### PR TITLE
feat(docker-compose): Create a docker setup for postgres and redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # Example environment configuration
 # Copy this file to .env and adjust values for your environment.
 
+# PostgreSQL Configuration
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=open-mercato
+POSTGRES_PORT=5432
+
 # PostgreSQL connection string (required)
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/open-mercato
 
@@ -61,6 +67,9 @@ CACHE_STRATEGY=sqlite
 
 # Default TTL in milliseconds (optional)
 CACHE_TTL=300000
+
+# Redis Configuration
+#REDIS_PORT=6379
 
 # Redis configuration (for redis strategy)
 #CACHE_REDIS_URL=redis://localhost:6379

--- a/Dockerfile.postgres
+++ b/Dockerfile.postgres
@@ -1,0 +1,11 @@
+FROM postgres:15
+
+# Install pgvector extension
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    postgresql-15-pgvector && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy initialization script to enable vector extension
+COPY --chmod=755 docker/postgres-init.sh /docker-entrypoint-initdb.d/01-init-vector.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  postgres:
+    build:
+      context: .
+      dockerfile: Dockerfile.postgres
+    container_name: mercato-postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-open_mercato}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mercato-network
+
+  redis:
+    image: redis:7-alpine
+    container_name: mercato-redis
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mercato-network
+
+volumes:
+  postgres_data:
+    name: mercato-postgres-data
+  redis_data:
+    name: mercato-redis-data
+
+networks:
+  mercato-network:
+    name: mercato-network
+    driver: bridge

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,80 @@
+# Docker Setup for Open Mercato
+
+This directory contains Docker configuration for running Open Mercato with PostgreSQL (with pgvector) and Redis.
+
+## Quick Start
+
+```bash
+# Start all services
+docker compose up -d
+
+# Stop all services
+docker compose down
+
+# View logs
+docker compose logs -f
+
+# Restart services
+docker compose restart
+```
+
+## Services
+
+- **PostgreSQL 15** with pgvector extension (port 5432)
+- **Redis 7** for caching and event persistence (port 6379)
+
+## Database Initialization
+
+The `postgres-init.sh` script automatically:
+1. Creates the vector extension in the default database (`open_mercato`)
+2. Creates the vector extension in `template1` so all future databases inherit it automatically
+
+This means:
+- ✅ The `open_mercato` database has pgvector enabled
+- ✅ Any new database you create will automatically have pgvector enabled
+- ✅ No manual intervention needed after container restart
+
+If you're using an existing database volume (from before this setup), you may need to manually enable the extension:
+
+```bash
+docker exec mercato-postgres psql -U postgres -d open_mercato -c "CREATE EXTENSION IF NOT EXISTS vector;"
+```
+
+## Data Persistence
+
+Data is stored in named Docker volumes:
+- `mercato-postgres-data` - PostgreSQL data
+- `mercato-redis-data` - Redis data
+
+To completely reset and start fresh:
+
+```bash
+docker compose down -v  # This will DELETE all data
+docker compose up -d
+yarn mercato init
+```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust as needed:
+
+```bash
+cp .env.example .env
+```
+
+## Troubleshooting
+
+**Check if vector extension is installed:**
+```bash
+docker exec mercato-postgres psql -U postgres -c "SELECT * FROM pg_extension WHERE extname = 'vector';"
+```
+
+**Access PostgreSQL directly:**
+```bash
+docker exec -it mercato-postgres psql -U postgres
+```
+
+**Access Redis CLI:**
+```bash
+docker exec -it mercato-redis redis-cli
+```

--- a/docker/postgres-init.sh
+++ b/docker/postgres-init.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Enable pgvector extension in the default database
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE EXTENSION IF NOT EXISTS vector;
+EOSQL
+
+echo "pgvector extension enabled in database: $POSTGRES_DB"
+
+# Also enable in template1 so all new databases get it automatically
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "template1" <<-EOSQL
+    CREATE EXTENSION IF NOT EXISTS vector;
+EOSQL
+
+echo "pgvector extension enabled in template1 (all new databases will inherit it)"

--- a/docs/docs/installation/prerequisites.mdx
+++ b/docs/docs/installation/prerequisites.mdx
@@ -11,19 +11,18 @@ Before cloning the repository make sure the following tools are installed:
   corepack enable
   corepack prepare yarn@stable --activate
   ```
-- **PostgreSQL 14+** – the default database. A quick local instance can be started with Docker:
-  ```bash
-  docker run --name mercato-postgres -p 5432:5432 -e POSTGRES_PASSWORD=secret -d postgres:15
-  ```
-- **Redis (optional)** – only required when you want durable event queues; otherwise the file-backed driver works.
+- **Docker & Docker Compose** – required for running PostgreSQL with pgvector and Redis.
 - **OpenSSL** – handy for generating random secrets while configuring `.env`.
 
 Copy `.env.example` to `.env` and configure at least:
 
 ```bash
-DATABASE_URL=postgres://postgres:secret@localhost:5432/mercato
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/open-mercato
 JWT_SECRET=$(openssl rand -hex 32)
+REDIS_URL=redis://localhost:6379
 ```
+
+The pgvector extension is automatically installed in all databases, enabling vector search features out of the box.
 
 Need a refresher on what each environment toggle controls? Review the [System status variables](../framework/operations/system-status#managing-variables) directory for descriptions and defaults before you customize additional flags.
 

--- a/docs/docs/installation/setup.mdx
+++ b/docs/docs/installation/setup.mdx
@@ -10,16 +10,22 @@ Follow these steps after the [prerequisites](./prerequisites) are in place:
    git clone https://github.com/open-mercato/open-mercato.git
    cd open-mercato
    ```
-2. **Install workspace dependencies**
+2. **Start Docker services**
+   ```bash
+   docker compose up -d
+   ```
+   This starts PostgreSQL 15 with pgvector and Redis 7. The pgvector extension is automatically installed, enabling vector search features.
+
+3. **Install workspace dependencies**
    ```bash
    yarn install
    ```
-3. **Bootstrap everything with one command**
+4. **Bootstrap everything with one command**
    ```bash
    yarn mercato init
    ```
    This script prepares module registries, generates/applies migrations, seeds default roles, provisions an admin user, and loads demo CRM data (companies, people, deals, activities, todos). Add `--no-examples` if you prefer to skip the demo content while keeping core identities, `--stresstest` (optionally with `-n <count>`) to preload thousands of synthetic contacts, companies, deals, activities, and notes, or combine `--stresstest --lite` for high-volume contacts without the heavier extras when you need raw throughput.
-4. **Launch the app**
+5. **Launch the app**
    ```bash
    yarn dev
    ```
@@ -46,5 +52,29 @@ Follow these steps after the [prerequisites](./prerequisites) are in place:
 ![Open Mercato admin home](/screenshots/open-mercato-homepage.png)
 
 > 💡 Need a clean slate? Run `yarn mercato init --reinstall`. It wipes module migrations and **drops the database**, so only use it when you intentionally want to reset everything. Prefer `yarn mercato init --no-examples` if you just want an empty CRM without resetting the database.
+
+## Docker Management
+
+**Stop services:**
+```bash
+docker compose down
+```
+
+**View logs:**
+```bash
+docker compose logs -f
+```
+
+**Complete reset (deletes all data):**
+```bash
+docker compose down -v
+docker compose up -d
+yarn mercato init
+```
+
+**Verify pgvector installation:**
+```bash
+docker exec mercato-postgres psql -U postgres -d open-mercato -c "SELECT extname, extversion FROM pg_extension WHERE extname = 'vector';"
+```
 
 For advanced/manual flows (custom migration control, selective seeding, etc.) see the CLI reference in the repository README.


### PR DESCRIPTION
## Summary

This pull request contains Docker configuration for running Open Mercato with PostgreSQL (with pgvector) and Redis.

### Services

- **PostgreSQL 15** with pgvector extension (port 5432)
- **Redis 7** for caching and event persistence (port 6379)

### Database Initialization

The `postgres-init.sh` script automatically:
1. Creates the vector extension in the default database (`open_mercato`)
2. Creates the vector extension in `template1` so all future databases inherit it automatically

This means:
- ✅ The `open_mercato` database has pgvector enabled
- ✅ Any new database you create will automatically have pgvector enabled
- ✅ No manual intervention needed after container restart

## Changes

- docker-compose setup added
- installation documentation updated
- new environmental variable added

## Testing

`docker compose up -d`

All details regarding testing and using this docker setup will be in project documentation installation page or in:
`docker/README.md`

## Checklist

- [X] This pull request targets `develop`.
- [X] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [X] I updated documentation, locales, or generators if the change requires it.
- [X] I added or adjusted tests that cover the change.

## Linked issues

N/A
