### PR TITLE
feat: implement dependency injection pattern for package publishability

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,2 +1,8 @@
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret'
 process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://user:pass@localhost:5432/mercato_test'
+
+// Note: Bootstrap is NOT called here because it imports modules.generated.ts
+// which eagerly loads all UI components with ESM dependencies that Jest cannot parse.
+// Tests that need bootstrap should:
+// 1. Call bootstrap() directly in their test file, OR
+// 2. Mock the specific registration functions they need

--- a/mercato-cli.ts
+++ b/mercato-cli.ts
@@ -2,7 +2,11 @@
 /**
  * CLI entry point at root level to ensure correct tsconfig resolution.
  */
+import { bootstrap } from './src/bootstrap'
 import { run } from './packages/cli/src/mercato'
+
+// Bootstrap all package registrations before running CLI
+bootstrap()
 
 async function main() {
   const code = await run(process.argv)

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -4,7 +4,24 @@
 
 import { createRequestContainer } from '@/lib/di/container'
 import { runWorker } from '@open-mercato/queue/worker'
-import generatedModules from '@/generated/modules.generated'
+import type { Module } from '@open-mercato/shared/modules/registry'
+
+// Registration pattern for publishable packages
+let _cliModules: Module[] | null = null
+
+export function registerCliModules(modules: Module[]) {
+  if (_cliModules !== null && process.env.NODE_ENV === 'development') {
+    console.debug('[Bootstrap] CLI modules re-registered (this may occur during HMR)')
+  }
+  _cliModules = modules
+}
+
+export function getCliModules(): Module[] {
+  if (!_cliModules) {
+    throw new Error('[Bootstrap] CLI modules not registered. Call registerCliModules() at bootstrap.')
+  }
+  return _cliModules
+}
 
 let envLoaded = false
 
@@ -375,8 +392,8 @@ export async function run(argv = process.argv) {
     rest = second !== undefined ? [second, ...remaining] : remaining
   }
   
-  // Load modules lazily, after init handling
-  const { modules } = await import('@/generated/modules.generated')
+  // Load modules from registered CLI modules
+  const modules = getCliModules()
   
   // Load optional app-level CLI commands lazily without static import resolution
   let appCli: any[] = []
@@ -410,7 +427,7 @@ export async function run(argv = process.argv) {
 
             // Load registered module subscribers
             const listeners = new Map<string, Set<any>>()
-            for (const mod of generatedModules) {
+            for (const mod of getCliModules()) {
               for (const sub of (mod as any).subscribers || []) {
                 if (!listeners.has(sub.event)) listeners.set(sub.event, new Set())
                 listeners.get(sub.event)!.add(sub.handler)

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -46,8 +46,8 @@ export async function bootstrap(container: AwilixContainer) {
   try {
     let loadedModules: any[] = []
     try {
-      const mod = await import('@/generated/modules.generated') as any
-      loadedModules = Array.isArray(mod?.modules) ? mod.modules : []
+      const { getModules } = await import('@open-mercato/shared/lib/i18n/server')
+      loadedModules = getModules()
     } catch {}
     const subs = loadedModules.flatMap((m) => m.subscribers || [])
     if (subs.length) (container.resolve as any)('eventBus').registerModuleSubscribers(subs)

--- a/packages/core/src/modules/api_docs/frontend/docs/api/page.tsx
+++ b/packages/core/src/modules/api_docs/frontend/docs/api/page.tsx
@@ -1,5 +1,5 @@
 import ApiDocsExplorer from './Explorer'
-import { modules } from '@/generated/modules.generated'
+import { getModules } from '@open-mercato/shared/lib/i18n/server'
 import { buildOpenApiDocument } from '@open-mercato/shared/lib/openapi'
 import { resolveApiDocsBaseUrl } from '@open-mercato/core/modules/api_docs/lib/resources'
 
@@ -51,6 +51,7 @@ function buildTagOrder(doc: any, operations: ExplorerOperation[]): string[] {
 
 export default async function ApiDocsViewerPage() {
   const baseUrl = resolveApiDocsBaseUrl()
+  const modules = getModules()
   const doc = buildOpenApiDocument(modules, {
     title: 'Open Mercato API',
     version: '1.0.0',

--- a/packages/core/src/modules/auth/api/admin/nav.ts
+++ b/packages/core/src/modules/auth/api/admin/nav.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { z } from 'zod'
-import { modules } from '@/generated/modules.generated'
+import { getModules } from '@open-mercato/shared/lib/i18n/server'
 import { getAuthFromRequest } from '@/lib/auth/server'
 import { createRequestContainer } from '@/lib/di/container'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
@@ -95,6 +95,7 @@ export async function GET(req: Request) {
   }
 
   const ctx = { auth: { roles: auth.roles || [], sub: auth.sub, tenantId: auth.tenantId, orgId: auth.orgId } }
+  const modules = getModules()
   for (const m of (modules as any[])) {
     const groupDefault = capitalize(m.id)
     for (const r of (m.backendRoutes || [])) {

--- a/packages/core/src/modules/auth/api/features.ts
+++ b/packages/core/src/modules/auth/api/features.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@/lib/auth/server'
-import { modules } from '@/generated/modules.generated'
+import { getModules } from '@open-mercato/shared/lib/i18n/server'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['auth.acl.manage'] },
@@ -11,6 +11,7 @@ export const metadata = {
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
   if (!auth) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const modules = getModules()
   const items = (modules || []).flatMap((m: any) =>
     (m.features || []).map((f: any) => ({ id: String(f.id), title: String(f.title || f.id), module: String(f.module || m.id) }))
   )
@@ -18,7 +19,7 @@ export async function GET(req: Request) {
   const byId = new Map<string, { id: string; title: string; module: string }>()
   for (const it of items) if (!byId.has(it.id)) byId.set(it.id, it)
   const list = Array.from(byId.values()).sort((a, b) => a.module.localeCompare(b.module) || a.id.localeCompare(b.id))
-  
+
   // Build module info map
   const moduleInfo = new Map<string, { id: string; title: string }>()
   for (const m of modules) {
@@ -26,7 +27,7 @@ export async function GET(req: Request) {
       moduleInfo.set(m.id, { id: m.id, title: (m.info as any)?.title || m.id })
     }
   }
-  
+
   return NextResponse.json({ items: list, modules: Array.from(moduleInfo.values()) })
 }
 

--- a/packages/core/src/modules/dashboards/lib/widgets.ts
+++ b/packages/core/src/modules/dashboards/lib/widgets.ts
@@ -1,5 +1,6 @@
 import type { Module, ModuleDashboardWidgetEntry } from '@open-mercato/shared/modules/registry'
 import type { DashboardWidgetMetadata, DashboardWidgetModule } from '@open-mercato/shared/modules/dashboard/widgets'
+import { getModules } from '@open-mercato/shared/lib/i18n/server'
 
 type LoadedWidgetModule = DashboardWidgetModule<any> & { metadata: DashboardWidgetMetadata }
 
@@ -17,8 +18,8 @@ export function invalidateWidgetCache() {
 }
 async function loadWidgetEntries(): Promise<WidgetEntry[]> {
   if (!widgetEntriesPromise) {
-    widgetEntriesPromise = import('@/generated/modules.generated').then((registry) => {
-      const list = (registry.modules ?? []) as Module[]
+    widgetEntriesPromise = Promise.resolve().then(() => {
+      const list = getModules() as Module[]
       return list.flatMap((mod) => {
         const entries = mod.dashboardWidgets ?? []
         return entries.map((entry) => ({

--- a/packages/core/src/modules/entities/__tests__/cli-rotate-encryption.test.ts
+++ b/packages/core/src/modules/entities/__tests__/cli-rotate-encryption.test.ts
@@ -2,6 +2,14 @@
 import { EncryptionMap } from '@open-mercato/core/modules/entities/data/entities'
 import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 import { decryptWithAesGcm } from '@open-mercato/shared/lib/encryption/aes'
+import { registerEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
+
+// Register mock entity IDs for the test
+registerEntityIds({
+  audit_logs: {
+    access_log: 'audit_logs:access_log',
+  },
+} as any)
 
 const execute = jest.fn()
 const find = jest.fn()

--- a/packages/core/src/modules/entities/api/entities.ts
+++ b/packages/core/src/modules/entities/api/entities.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@/lib/di/container'
 import { getAuthFromRequest } from '@/lib/auth/server'
 import { CustomEntity, CustomFieldDef } from '@open-mercato/core/modules/entities/data/entities'
-import { E as AllEntities } from '@/generated/entities.ids.generated'
+import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import { upsertCustomEntitySchema } from '@open-mercato/core/modules/entities/data/validators'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { isSystemEntitySelectable } from '@open-mercato/shared/lib/entities/system-entities'
@@ -22,6 +22,7 @@ export async function GET(req: Request) {
   const em = resolve('em') as any
 
   // Generated entities from code
+  const AllEntities = getEntityIds()
   const generated: { entityId: string; source: 'code'; label: string }[] = []
   for (const modId of Object.keys(AllEntities)) {
     const entities = (AllEntities as any)[modId] as Record<string, string>

--- a/packages/core/src/modules/entities/lib/install-from-ce.ts
+++ b/packages/core/src/modules/entities/lib/install-from-ce.ts
@@ -3,8 +3,8 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import type { CacheStrategy } from '@open-mercato/cache/types'
 import type { CustomFieldDefinition, CustomFieldSet, CustomEntitySpec } from '@open-mercato/shared/modules/entities'
 import { Tenant } from '@open-mercato/core/modules/directory/data/entities'
-import { modules } from '@/generated/modules.generated'
-import { E as GeneratedEntities } from '@/generated/entities.ids.generated'
+import { getModules } from '@open-mercato/shared/lib/i18n/server'
+import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import { ensureCustomFieldDefinitions } from './field-definitions'
 import { upsertCustomEntity, type UpsertCustomEntityResult } from './register'
 
@@ -73,6 +73,7 @@ function computeChecksum(payload: unknown): string {
 
 function systemEntityIds(): Set<string> {
   const ids = new Set<string>()
+  const GeneratedEntities = getEntityIds()
   for (const moduleEntities of Object.values(GeneratedEntities)) {
     for (const id of Object.values(moduleEntities as Record<string, string>)) {
       ids.add(id)
@@ -83,6 +84,7 @@ function systemEntityIds(): Set<string> {
 
 function buildAggregatedConfigs(): AggregatedEntityConfig[] {
   const map = new Map<string, AggregatedEntityConfig>()
+  const modules = getModules()
   for (const mod of modules) {
     const moduleId = mod.id
     const entitySpecs = ((mod as any).customEntities as CustomEntitySpec[] | undefined) ?? []

--- a/packages/core/src/modules/query_index/api/status.ts
+++ b/packages/core/src/modules/query_index/api/status.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createRequestContainer } from '@/lib/di/container'
 import { getAuthFromRequest } from '@/lib/auth/server'
-import { E as AllEntities } from '@/generated/entities.ids.generated'
+import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { readCoverageSnapshot, refreshCoverageSnapshot } from '../lib/coverage'
 import type { VectorIndexService } from '@open-mercato/vector'
@@ -61,7 +61,7 @@ export async function GET(req: Request) {
   const url = new URL(req.url)
   const forceRefresh = url.searchParams.has('refresh') && url.searchParams.get('refresh') !== '0'
 
-  const generatedIds = flattenSystemEntityIds(AllEntities as Record<string, Record<string, string>>)
+  const generatedIds = flattenSystemEntityIds(getEntityIds() as Record<string, Record<string, string>>)
   const generated = generatedIds.map((entityId) => ({ entityId, label: entityId }))
 
   const byId = new Map<string, { entityId: string; label: string }>()

--- a/packages/core/src/modules/query_index/cli.ts
+++ b/packages/core/src/modules/query_index/cli.ts
@@ -397,10 +397,8 @@ const rebuildAll: ModuleCli = {
     try {
       const knex = em.getConnection().getKnex()
 
-      const { E: All } = await import('@/generated/entities.ids.generated') as {
-        E: Record<string, Record<string, string>>
-      }
-      const entityIds = flattenSystemEntityIds(All)
+      const { getEntityIds } = await import('@open-mercato/shared/lib/encryption/entityIds')
+      const entityIds = flattenSystemEntityIds(getEntityIds() as Record<string, Record<string, string>>)
       if (!entityIds.length) {
         console.log('No entity definitions registered for query indexing.')
         return
@@ -645,10 +643,8 @@ const reindex: ModuleCli = {
         return
       }
 
-      const { E: All } = await import('@/generated/entities.ids.generated') as {
-        E: Record<string, Record<string, string>>
-      }
-      const entityIds = flattenSystemEntityIds(All)
+      const { getEntityIds } = await import('@open-mercato/shared/lib/encryption/entityIds')
+      const entityIds = flattenSystemEntityIds(getEntityIds() as Record<string, Record<string, string>>)
       if (!entityIds.length) {
         console.log('No entity definitions registered for query indexing.')
         return
@@ -859,10 +855,8 @@ const purge: ModuleCli = {
         return
       }
 
-      const { E: All } = await import('@/generated/entities.ids.generated') as {
-        E: Record<string, Record<string, string>>
-      }
-      const entityIds = flattenSystemEntityIds(All)
+      const { getEntityIds } = await import('@open-mercato/shared/lib/encryption/entityIds')
+      const entityIds = flattenSystemEntityIds(getEntityIds() as Record<string, Record<string, string>>)
       for (const id of entityIds) {
         await bus.emitEvent(
           'query_index.purge',

--- a/packages/core/src/modules/query_index/subscribers/coverage_warmup.ts
+++ b/packages/core/src/modules/query_index/subscribers/coverage_warmup.ts
@@ -1,4 +1,4 @@
-import { E as AllEntities } from '@/generated/entities.ids.generated'
+import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import type { EventBus } from '@open-mercato/events/types'
 import { flattenSystemEntityIds } from '@open-mercato/shared/lib/entities/system-entities'
 
@@ -15,9 +15,12 @@ function scopeKey(entityType: string, tenantId: string | null): string {
   return `${entityType}|${tenantId ?? '__null__'}`
 }
 
-const entityIds = flattenSystemEntityIds(AllEntities as Record<string, Record<string, string>>)
+function getEntityIdList(): string[] {
+  return flattenSystemEntityIds(getEntityIds() as Record<string, Record<string, string>>)
+}
 
 export default async function handle(payload: Payload, ctx: { resolve: <T = any>(name: string) => T }) {
+  const entityIds = getEntityIdList()
   if (!entityIds.length) return
   const tenantId = payload?.tenantId ?? null
   let eventBus: EventBus | null = null

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
@@ -18,6 +18,7 @@ import { reindexEntity } from '@open-mercato/core/modules/query_index/lib/reinde
 import { purgeIndexScope } from '@open-mercato/core/modules/query_index/lib/purge'
 import { refreshCoverageSnapshot } from '@open-mercato/core/modules/query_index/lib/coverage'
 import { flattenSystemEntityIds } from '@open-mercato/shared/lib/entities/system-entities'
+import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import type { VectorIndexService } from '@open-mercato/vector'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 
@@ -97,9 +98,7 @@ export async function GET(req: Request) {
       }
       const coverageRefreshKeys = new Set<string>()
       try {
-        const { E: allEntities } = await import('@/generated/entities.ids.generated') as {
-          E: Record<string, Record<string, string>>
-        }
+        const allEntities = getEntityIds()
         const entityIds = flattenSystemEntityIds(allEntities)
         for (const entityType of entityIds) {
           try {

--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -5,11 +5,28 @@ import { PostgreSqlDriver } from '@mikro-orm/postgresql'
 
 let ormInstance: MikroORM<PostgreSqlDriver> | null = null
 
+// Registration pattern for publishable packages
+let _entities: any[] | null = null
+
+export function registerOrmEntities(entities: any[]) {
+  if (_entities !== null && process.env.NODE_ENV === 'development') {
+    console.debug('[Bootstrap] ORM entities re-registered (this may occur during HMR)')
+  }
+  _entities = entities
+}
+
+export function getOrmEntities(): any[] {
+  if (!_entities) {
+    throw new Error('[Bootstrap] ORM entities not registered. Call registerOrmEntities() at bootstrap.')
+  }
+  return _entities
+}
+
 export async function getOrm() {
   if (ormInstance) {
     return ormInstance
   }
-  const { entities } = await import('@/generated/entities.generated')
+  const entities = getOrmEntities()
   const clientUrl = process.env.DATABASE_URL
   if (!clientUrl) throw new Error('DATABASE_URL is not set')
   

--- a/packages/shared/src/lib/query/__tests__/engine.test.ts
+++ b/packages/shared/src/lib/query/__tests__/engine.test.ts
@@ -1,12 +1,14 @@
 import { BasicQueryEngine } from '../engine'
 import { SortDir } from '../types'
+import { registerModules } from '../../i18n/server'
 
 // Mock modules with one entity extension
-jest.mock('@/generated/modules.generated', () => ({
-  modules: [
-    { id: 'auth', entityExtensions: [ { base: 'auth:user', extension: 'my_module:user_profile', join: { baseKey: 'id', extensionKey: 'user_id' } } ] },
-  ],
-}))
+const mockModules = [
+  { id: 'auth', entityExtensions: [ { base: 'auth:user', extension: 'my_module:user_profile', join: { baseKey: 'id', extensionKey: 'user_id' } } ] },
+]
+
+// Register modules for the registration-based pattern
+registerModules(mockModules as any)
 
 type FakeData = Record<string, any[]>
 

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -492,7 +492,8 @@ export class BasicQueryEngine implements QueryEngine {
 
     // Entity extensions joins (no selection yet; enables future filters/projections)
     if (opts.includeExtensions) {
-      const allMods = (await import('@/generated/modules.generated')).modules as any[]
+      const { getModules } = await import('@open-mercato/shared/lib/i18n/server')
+      const allMods = getModules() as any[]
       const allExts = allMods.flatMap((m) => (m as any).entityExtensions || [])
       const exts = allExts.filter((e: any) => e.base === entity)
       const chosen = Array.isArray(opts.includeExtensions)

--- a/packages/shared/src/lib/testing/bootstrap.ts
+++ b/packages/shared/src/lib/testing/bootstrap.ts
@@ -1,0 +1,124 @@
+/**
+ * Test Bootstrap Utility
+ *
+ * Provides a centralized way to bootstrap dependencies for tests.
+ * This utility allows tests to register only the dependencies they need
+ * without importing the full app bootstrap.
+ *
+ * Usage in tests:
+ *
+ * ```typescript
+ * import { bootstrapTest, resetTestBootstrap } from '@open-mercato/shared/lib/testing/bootstrap'
+ *
+ * beforeEach(() => {
+ *   resetTestBootstrap()
+ *   bootstrapTest({
+ *     modules: mockModules,
+ *     entityIds: mockEntityIds,
+ *   })
+ * })
+ * ```
+ *
+ * For tests that use jest.resetModules(), import dynamically:
+ *
+ * ```typescript
+ * beforeEach(async () => {
+ *   jest.resetModules()
+ *   const { registerModules } = await import('@open-mercato/shared/lib/i18n/server')
+ *   registerModules(mockModules as any)
+ * })
+ * ```
+ */
+
+import type { Module } from '../../modules/registry'
+
+export type EntityIds = Record<string, Record<string, string>>
+
+export interface TestBootstrapOptions {
+  /** Modules to register (for i18n, query engine, etc.) */
+  modules?: Module[]
+  /** Entity IDs to register (for encryption, indexing) */
+  entityIds?: EntityIds
+  /** ORM entities to register (rarely needed in unit tests) */
+  ormEntities?: any[]
+  /** DI registrars to register (rarely needed in unit tests) */
+  diRegistrars?: Array<(container: any) => void>
+}
+
+let _testBootstrapped = false
+
+/**
+ * Bootstrap dependencies for tests.
+ * Call this in beforeEach or beforeAll to set up required registrations.
+ */
+export function bootstrapTest(options: TestBootstrapOptions = {}): void {
+  const { modules, entityIds, ormEntities, diRegistrars } = options
+
+  if (modules !== undefined) {
+    // Import lazily to avoid circular dependencies
+    const { registerModules } = require('../../i18n/server')
+    registerModules(modules)
+  }
+
+  if (entityIds !== undefined) {
+    const { registerEntityIds } = require('../../encryption/entityIds')
+    registerEntityIds(entityIds)
+  }
+
+  if (ormEntities !== undefined) {
+    const { registerOrmEntities } = require('../../db/mikro')
+    registerOrmEntities(ormEntities)
+  }
+
+  if (diRegistrars !== undefined) {
+    const { registerDiRegistrars } = require('../../di/container')
+    registerDiRegistrars(diRegistrars)
+  }
+
+  _testBootstrapped = true
+}
+
+/**
+ * Reset the test bootstrap state.
+ * Call this in beforeEach when you need fresh state between tests.
+ *
+ * Note: This only resets the test bootstrap flag. To fully reset
+ * registration state, you may need to use jest.resetModules() and
+ * re-import the registration functions.
+ */
+export function resetTestBootstrap(): void {
+  _testBootstrapped = false
+}
+
+/**
+ * Check if test bootstrap has been called.
+ */
+export function isTestBootstrapped(): boolean {
+  return _testBootstrapped
+}
+
+/**
+ * Helper to create minimal mock modules for testing.
+ */
+export function createMockModules(overrides: Partial<Module>[] = []): Module[] {
+  return overrides.map((override, index) => ({
+    id: override.id || `test-module-${index}`,
+    ...override,
+  })) as Module[]
+}
+
+/**
+ * Helper to create minimal mock entity IDs for testing.
+ */
+export function createMockEntityIds(
+  entities: Record<string, string[]>
+): EntityIds {
+  const result: EntityIds = {}
+  for (const [module, entityNames] of Object.entries(entities)) {
+    result[module] = {}
+    for (const name of entityNames) {
+      result[module][name] = `${module}:${name}`
+    }
+  }
+  return result
+}

--- a/packages/shared/src/lib/testing/index.ts
+++ b/packages/shared/src/lib/testing/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Testing utilities for @open-mercato packages
+ */
+
+export {
+  bootstrapTest,
+  resetTestBootstrap,
+  isTestBootstrapped,
+  createMockModules,
+  createMockEntityIds,
+  type TestBootstrapOptions,
+  type EntityIds,
+} from './bootstrap'

--- a/scripts/generate-entity-ids.ts
+++ b/scripts/generate-entity-ids.ts
@@ -118,9 +118,6 @@ function writePerEntityFieldFiles(outRoot: string, fieldsByEntity: EntityFieldMa
     fs.mkdirSync(entDir, { recursive: true })
     const idx = fields.map((f) => `export const ${toVar(f)} = '${f}'`).join('\n') + '\n'
     fs.writeFileSync(path.join(entDir, 'index.ts'), idx)
-    for (const f of fields) {
-      fs.writeFileSync(path.join(entDir, `${f}.ts`), `export default '${f}'\n`)
-    }
   }
 }
 

--- a/src/__tests__/api-authorization.test.ts
+++ b/src/__tests__/api-authorization.test.ts
@@ -1,8 +1,16 @@
 import { NextRequest } from 'next/server'
-import { GET, POST, PUT, PATCH, DELETE } from '@/app/api/[...slug]/route'
 import { getAuthFromRequest } from '@/lib/auth/server'
 import type { Module, HttpMethod, ModuleApiRouteFile } from '@open-mercato/shared/modules/registry'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+
+// Mock bootstrap to prevent it from running during tests
+jest.mock('@/bootstrap', () => ({
+  bootstrap: jest.fn(),
+  isBootstrapped: jest.fn(() => true),
+}))
+
+// Import route handlers after bootstrap mock is set up
+import { GET, POST, PUT, PATCH, DELETE } from '@/app/api/[...slug]/route'
 
 // Mock the auth module
 jest.mock('@/lib/auth/server', () => ({
@@ -81,6 +89,10 @@ function getMockedModules(): Module[] {
 jest.mock('@/generated/modules.generated', () => ({
   modules: getMockedModules(),
 }))
+
+// Register modules for the registration-based pattern
+import { registerModules } from '@open-mercato/shared/lib/i18n/server'
+registerModules(getMockedModules() as any)
 
 const mockGetAuthFromRequest = getAuthFromRequest as jest.MockedFunction<typeof getAuthFromRequest>
 

--- a/src/app/api/[...slug]/route.ts
+++ b/src/app/api/[...slug]/route.ts
@@ -3,6 +3,10 @@ import { findApi, type HttpMethod } from '@open-mercato/shared/modules/registry'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { modules } from '@/generated/modules.generated'
 import { getAuthFromRequest } from '@/lib/auth/server'
+import { bootstrap } from '@/bootstrap'
+
+// Ensure all package registrations are initialized for API routes
+bootstrap()
 import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@/lib/di/container'
 import { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,13 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
+import { bootstrap } from '@/bootstrap'
 import { I18nProvider } from '@/lib/i18n/context'
+
+// Bootstrap all package registrations at module load time
+bootstrap()
 import { ThemeProvider, FrontendLayout, QueryProvider, AuthFooter } from '@open-mercato/ui'
+import { ClientBootstrapProvider } from '@/components/ClientBootstrap'
 import { GlobalNoticeBars } from '@/components/GlobalNoticeBars'
 import { detectLocale, loadDictionary, resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 
@@ -39,12 +44,14 @@ export default async function RootLayout({
     <html lang={locale}>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`} suppressHydrationWarning data-gramm="false">
         <I18nProvider locale={locale} dict={dict}>
-          <ThemeProvider>
-            <QueryProvider>
-              <FrontendLayout footer={<AuthFooter />}>{children}</FrontendLayout>
-              <GlobalNoticeBars demoModeEnabled={demoModeEnabled} />
-            </QueryProvider>
-          </ThemeProvider>
+          <ClientBootstrapProvider>
+            <ThemeProvider>
+              <QueryProvider>
+                <FrontendLayout footer={<AuthFooter />}>{children}</FrontendLayout>
+                <GlobalNoticeBars demoModeEnabled={demoModeEnabled} />
+              </QueryProvider>
+            </ThemeProvider>
+          </ClientBootstrapProvider>
         </I18nProvider>
       </body>
     </html>

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,0 +1,93 @@
+/**
+ * App-level bootstrap file
+ *
+ * This file imports all generated registries and calls the registration
+ * functions from each package. This must be called before any package
+ * code executes to ensure all dependencies are properly initialized.
+ *
+ * REGISTRATION ORDER MATTERS:
+ *
+ * 1. Foundation (ORM entities, DI registrars)
+ *    - registerOrmEntities: Required by database layer
+ *    - registerDiRegistrars: Required by dependency injection container
+ *
+ * 2. Modules registry (registerModules, registerCliModules)
+ *    - Required by: i18n translations, query engine, dashboards, CLI
+ *    - Both use the same modules array
+ *
+ * 3. Entity IDs (registerEntityIds)
+ *    - Required by: encryption layer, query indexing, entity link resolution
+ *
+ * 4. UI Widgets (registerDashboardWidgets, registerInjectionWidgets, etc.)
+ *    - Required by: dashboard rendering, widget injection system
+ *    - Can be registered after modules since they use module data
+ *
+ * 5. Optional packages (registerVectorConfigs)
+ *    - Vector search configuration
+ *    - Can be registered last as it's optional
+ */
+
+// Generated imports
+import { modules } from '@/generated/modules.generated'
+import { entities } from '@/generated/entities.generated'
+import { diRegistrars } from '@/generated/di.generated'
+import { E } from '@/generated/entities.ids.generated'
+import { dashboardWidgetEntries } from '@/generated/dashboard-widgets.generated'
+import { injectionWidgetEntries } from '@/generated/injection-widgets.generated'
+import { injectionTables } from '@/generated/injection-tables.generated'
+import { vectorModuleConfigs } from '@/generated/vector.generated'
+
+// Registration functions from packages/shared
+import { registerOrmEntities } from '@open-mercato/shared/lib/db/mikro'
+import { registerDiRegistrars } from '@open-mercato/shared/lib/di/container'
+import { registerModules } from '@open-mercato/shared/lib/i18n/server'
+import { registerEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
+
+// Registration functions from packages/ui
+import { registerDashboardWidgets } from '@open-mercato/ui/backend/dashboard/widgetRegistry'
+import { registerInjectionWidgets } from '@open-mercato/ui/backend/injection/widgetRegistry'
+
+// Registration functions from packages/core
+import {
+  registerCoreInjectionWidgets,
+  registerCoreInjectionTables,
+} from '@open-mercato/core/modules/widgets/lib/injection'
+
+// Registration functions from packages/vector
+import { registerVectorConfigs } from '@open-mercato/vector/modules/vector/di'
+
+// Registration functions from packages/cli
+import { registerCliModules } from '@open-mercato/cli/mercato'
+
+let _bootstrapped = false
+
+export function bootstrap() {
+  // In development, always re-run registrations to handle HMR
+  // (Module state may be reset when Turbopack reloads packages)
+  if (_bootstrapped && process.env.NODE_ENV !== 'development') return
+  _bootstrapped = true
+
+  // === 1. Foundation: ORM entities and DI registrars ===
+  registerOrmEntities(entities)
+  registerDiRegistrars(diRegistrars.filter((r): r is NonNullable<typeof r> => r != null))
+
+  // === 2. Modules registry (required by i18n, query engine, dashboards, CLI) ===
+  registerModules(modules)
+  registerCliModules(modules)
+
+  // === 3. Entity IDs (required by encryption, indexing, entity links) ===
+  registerEntityIds(E)
+
+  // === 4. UI Widgets ===
+  registerDashboardWidgets(dashboardWidgetEntries)
+  registerInjectionWidgets(injectionWidgetEntries)
+  registerCoreInjectionWidgets(injectionWidgetEntries)
+  registerCoreInjectionTables(injectionTables)
+
+  // === 5. Optional packages ===
+  registerVectorConfigs(vectorModuleConfigs)
+}
+
+export function isBootstrapped(): boolean {
+  return _bootstrapped
+}

--- a/src/components/ClientBootstrap.tsx
+++ b/src/components/ClientBootstrap.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import * as React from 'react'
+import { injectionWidgetEntries } from '@/generated/injection-widgets.generated'
+import { injectionTables } from '@/generated/injection-tables.generated'
+import { registerCoreInjectionWidgets, registerCoreInjectionTables } from '@open-mercato/core/modules/widgets/lib/injection'
+import { registerInjectionWidgets } from '@open-mercato/ui/backend/injection/widgetRegistry'
+import { dashboardWidgetEntries } from '@/generated/dashboard-widgets.generated'
+import { registerDashboardWidgets } from '@open-mercato/ui/backend/dashboard/widgetRegistry'
+
+let _clientBootstrapped = false
+
+function clientBootstrap() {
+  if (_clientBootstrapped) return
+  _clientBootstrapped = true
+
+  // Register injection widgets
+  registerInjectionWidgets(injectionWidgetEntries)
+  registerCoreInjectionWidgets(injectionWidgetEntries)
+  registerCoreInjectionTables(injectionTables)
+
+  // Register dashboard widgets
+  registerDashboardWidgets(dashboardWidgetEntries)
+}
+
+export function ClientBootstrapProvider({ children }: { children: React.ReactNode }) {
+  React.useEffect(() => {
+    clientBootstrap()
+  }, [])
+
+  // Also bootstrap synchronously on first render for SSR hydration
+  if (typeof window !== 'undefined' && !_clientBootstrapped) {
+    clientBootstrap()
+  }
+
+  return <>{children}</>
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,10 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
+// Note: Do NOT import bootstrap here - middleware runs in Edge runtime
+// which cannot use Node.js modules like MikroORM. Bootstrap is called
+// in layout.tsx which runs in Node.js runtime.
+
 export function middleware(req: NextRequest) {
   const requestHeaders = new Headers(req.headers)
   // Expose current URL path (no query) to server components via request headers


### PR DESCRIPTION
## Summary

  - Implement registration-based dependency injection pattern across all packages to remove `@/generated/` imports
  - Add server-side and client-side bootstrap to initialize package dependencies
  - Enable packages to be published independently without relying on app-level generated files

  ## Changes

  ### New Files
  - `src/bootstrap.ts` - Server-side bootstrap that registers all generated dependencies
  - `src/components/ClientBootstrap.tsx` - Client-side bootstrap provider for widget registrations

  ### Package Updates
  - **packages/shared**: Added registration functions for ORM entities, DI registrars, modules, and entity IDs
  - **packages/core**: Updated widget injection system with registration pattern and client-side graceful degradation
  - **packages/ui**: Added registration functions for dashboard and injection widgets
  - **packages/cli**: Added registration function for CLI modules
  - **packages/vector**: Added registration function for vector configs

  ### Key Features
  - HMR-safe: Bootstrap re-runs in development mode to handle Turbopack hot-reloading
  - Client-side support: Widget registries gracefully return empty arrays on client before registration
  - Type-safe: All registration functions maintain proper TypeScript types


ref: https://github.com/open-mercato/open-mercato/issues/242