### PR TITLE
feat: adding HMR mode to packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ yarn install
 cp apps/mercato/.env.example apps/mercato/.env # EDIT this file to set up your specific files
 #At minimum, set `DATABASE_URL`, `JWT_SECRET`, and `REDIS_URL` (or `EVENTS_REDIS_URL`) before bootstrapping.
 
-yarn build:packages
 yarn generate
 yarn initialize # or yarn reinstall
 yarn dev

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,8 +16,8 @@
     "@docusaurus/theme-mermaid": "^3.9.1",
     "@easyops-cn/docusaurus-search-local": "^0.44.0",
     "@mdx-js/react": "^3.0.0",
-    "clsx": "^2.1.0",
     "@mermaid-js/layout-elk": "^0.1.1",
+    "clsx": "^2.1.0",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "turbo run dev --filter=@open-mercato/app",
+    "dev": "yarn build:packages && yarn watch:packages & sleep 3 && yarn dev:app",
+    "dev:app": "turbo run dev --filter=@open-mercato/app",
+    "watch:packages": "turbo run watch --filter='./packages/*' --parallel",
     "build:app": "turbo run build --filter=@open-mercato/app",
     "build:packages": "turbo run build --filter='./packages/*'",
     "lint": "turbo run lint",

--- a/packages/ai-assistant/package.json
+++ b/packages/ai-assistant/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "node build.mjs",
+    "watch": "node watch.mjs",
     "mcp:dev": "mercato ai_assistant mcp:dev",
     "mcp:serve-http": "mercato ai_assistant mcp:serve-http"
   },

--- a/packages/ai-assistant/watch.mjs
+++ b/packages/ai-assistant/watch.mjs
@@ -1,0 +1,6 @@
+import { watch } from '../../scripts/watch.mjs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+watch(__dirname)

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "node build.mjs",
+    "watch": "node watch.mjs",
     "test": "jest --config jest.config.cjs",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/cache/watch.mjs
+++ b/packages/cache/watch.mjs
@@ -1,0 +1,6 @@
+import { watch } from '../../scripts/watch.mjs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+watch(__dirname)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
   },
   "scripts": {
     "build": "node build.mjs",
+    "watch": "node watch.mjs",
     "test": "jest --config jest.config.cjs",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/cli/watch.mjs
+++ b/packages/cli/watch.mjs
@@ -1,0 +1,6 @@
+import { watch } from '../../scripts/watch.mjs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+watch(__dirname)

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "node build.mjs",
+    "watch": "node watch.mjs",
     "test": "jest --config jest.config.cjs",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/content/watch.mjs
+++ b/packages/content/watch.mjs
@@ -1,0 +1,6 @@
+import { watch } from '../../scripts/watch.mjs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+watch(__dirname)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "node build.mjs",
+    "watch": "node watch.mjs",
     "test": "jest --config jest.config.cjs",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/core/watch.mjs
+++ b/packages/core/watch.mjs
@@ -1,0 +1,6 @@
+import { watch } from '../../scripts/watch.mjs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+watch(__dirname)

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "node build.mjs",
+    "watch": "node watch.mjs",
     "test": "jest --config jest.config.cjs",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/events/watch.mjs
+++ b/packages/events/watch.mjs
@@ -1,0 +1,6 @@
+import { watch } from '../../scripts/watch.mjs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+watch(__dirname)

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "node build.mjs",
+    "watch": "node watch.mjs",
     "test": "jest --config jest.config.cjs",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/onboarding/watch.mjs
+++ b/packages/onboarding/watch.mjs
@@ -1,0 +1,6 @@
+import { watch } from '../../scripts/watch.mjs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+watch(__dirname)

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "node build.mjs",
+    "watch": "node watch.mjs",
     "test": "jest --config jest.config.cjs",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/queue/watch.mjs
+++ b/packages/queue/watch.mjs
@@ -1,0 +1,6 @@
+import { watch } from '../../scripts/watch.mjs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+watch(__dirname)

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -110,6 +110,7 @@
   },
   "scripts": {
     "build": "node build.mjs",
+    "watch": "node watch.mjs",
     "test": "jest --config jest.config.cjs",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/search/watch.mjs
+++ b/packages/search/watch.mjs
@@ -1,0 +1,6 @@
+import { watch } from '../../scripts/watch.mjs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+watch(__dirname)

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "node build.mjs",
+    "watch": "node watch.mjs",
     "test": "jest --config jest.config.cjs",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+// test comment Tue Jan 20 20:05:42 CET 2026

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,0 @@
-// test comment Tue Jan 20 20:05:42 CET 2026

--- a/packages/shared/watch.mjs
+++ b/packages/shared/watch.mjs
@@ -1,0 +1,6 @@
+import { watch } from '../../scripts/watch.mjs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+watch(__dirname)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "node build.mjs",
+    "watch": "node watch.mjs",
     "test": "jest --config jest.config.cjs",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/ui/watch.mjs
+++ b/packages/ui/watch.mjs
@@ -1,0 +1,6 @@
+import { watch } from '../../scripts/watch.mjs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+watch(__dirname)

--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -1,0 +1,109 @@
+import * as esbuild from 'esbuild'
+import { glob } from 'glob'
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { dirname, join, relative, basename } from 'node:path'
+
+/**
+ * Creates the add-js-extension plugin for a given package directory
+ * This plugin adds .js extensions to relative imports after compilation
+ */
+function createAddJsExtensionPlugin(packageDir) {
+  return {
+    name: 'add-js-extension',
+    setup(build) {
+      build.onEnd(async (result) => {
+        if (result.errors.length > 0) return
+        const outputFiles = await glob(join(packageDir, 'dist/**/*.js'))
+        for (const file of outputFiles) {
+          const fileDir = dirname(file)
+          let content = readFileSync(file, 'utf-8')
+          // Add .js to relative imports that don't have an extension
+          content = content.replace(
+            /from\s+["'](\.[^"']+)["']/g,
+            (match, path) => {
+              if (path.endsWith('.js') || path.endsWith('.json')) return match
+              // Check if it's a directory with index.js
+              const resolvedPath = join(fileDir, path)
+              if (existsSync(resolvedPath) && existsSync(join(resolvedPath, 'index.js'))) {
+                return `from "${path}/index.js"`
+              }
+              return `from "${path}.js"`
+            }
+          )
+          content = content.replace(
+            /import\s*\(\s*["'](\.[^"']+)["']\s*\)/g,
+            (match, path) => {
+              if (path.endsWith('.js') || path.endsWith('.json')) return match
+              // Check if it's a directory with index.js
+              const resolvedPath = join(fileDir, path)
+              if (existsSync(resolvedPath) && existsSync(join(resolvedPath, 'index.js'))) {
+                return `import("${path}/index.js")`
+              }
+              return `import("${path}.js")`
+            }
+          )
+          // Handle side-effect imports: import "./path" (no from clause)
+          content = content.replace(
+            /import\s+["'](\.[^"']+)["'];/g,
+            (match, path) => {
+              if (path.endsWith('.js') || path.endsWith('.json')) return match
+              // Check if it's a directory with index.js
+              const resolvedPath = join(fileDir, path)
+              if (existsSync(resolvedPath) && existsSync(join(resolvedPath, 'index.js'))) {
+                return `import "${path}/index.js";`
+              }
+              return `import "${path}.js";`
+            }
+          )
+          writeFileSync(file, content)
+        }
+      })
+    }
+  }
+}
+
+/**
+ * Start watching a package for changes and incrementally rebuild
+ * @param {string} packageDir - Absolute path to the package directory
+ */
+export async function watch(packageDir) {
+  const packageName = basename(packageDir)
+
+  const entryPoints = await glob(join(packageDir, 'src/**/*.{ts,tsx}'), {
+    ignore: ['**/__tests__/**', '**/*.test.ts', '**/*.test.tsx']
+  })
+
+  if (entryPoints.length === 0) {
+    console.log(`[watch] ${packageName}: no source files found, skipping`)
+    return
+  }
+
+  const ctx = await esbuild.context({
+    entryPoints,
+    outdir: join(packageDir, 'dist'),
+    outbase: join(packageDir, 'src'),
+    format: 'esm',
+    platform: 'node',
+    target: 'node18',
+    sourcemap: true,
+    jsx: 'automatic',
+    plugins: [createAddJsExtensionPlugin(packageDir)],
+    logLevel: 'warning',
+  })
+
+  // Skip initial build - assume build:packages already ran
+  // This avoids race conditions where the app starts before watch completes
+  console.log(`[watch] ${packageName}: watching for changes...`)
+
+  await ctx.watch()
+
+  // Handle graceful shutdown
+  const cleanup = async () => {
+    console.log(`\n[watch] ${packageName}: stopping...`)
+    await ctx.dispose()
+    process.exit(0)
+  }
+
+  process.on('SIGINT', cleanup)
+  process.on('SIGTERM', cleanup)
+}

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,10 @@
       "cache": false,
       "persistent": true
     },
+    "watch": {
+      "cache": false,
+      "persistent": true
+    },
     "mcp:dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
This pull request introduces a standardized watch script across all core packages to streamline local development. It adds a `watch` command to each package, enabling automatic rebuilding on file changes, and updates the root and documentation app scripts to leverage these new capabilities for a smoother developer experience.

**Monorepo Development Workflow Improvements:**

* Added a `watch` script to the `package.json` of all core packages (`ai-assistant`, `cache`, `cli`, `content`, `core`, `events`, `onboarding`, `queue`, `search`), allowing each package to rebuild automatically when files change. [[1]](diffhunk://#diff-99007a52a65c5b1e71003d56a8868daff5c8a6f49e701f604aef458b2f9cf9b2R9) [[2]](diffhunk://#diff-d232cbfa8f24cc2cfe7b700df716789ae83147c39b58541db55c5270a9e3c1aaR9) [[3]](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758R51) [[4]](diffhunk://#diff-44b6e5be6a31389ab82b7da55e0988b5279bc4e6e34c195c4403474ae803ca00R9) [[5]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7R9) [[6]](diffhunk://#diff-ed3f848f52f3731096830f219636ce29a381000844391a69de7338dfe83fcadbR9) [[7]](diffhunk://#diff-5f1c2a8b332605e1dfa70be0e3ecbfee04be4664b29356c09cbb11e4d5d21442R9) [[8]](diffhunk://#diff-afd977fa68e553057ec11394344e0f07c9ab54c92aec3fce31fc14f0020c4dcbR10) [[9]](diffhunk://#diff-a8d004b220907f6de1d22d818ca06350516584cd248956e8bdd5f169aefd342fR113)
* Added a shared `watch.mjs` implementation to each package, which delegates to the central watch script in `scripts/watch.mjs` for consistency and maintainability.

**Root and App Script Enhancements:**

* Updated the root `package.json` scripts: the `dev` command now builds and watches all packages before starting the app, and a new `watch:packages` script runs watch in parallel for all packages.

**Dependency Management:**

* Minor reordering of the `clsx` dependency in `apps/docs/package.json` to maintain package.json formatting standards.