### PR TITLE
fix: resolve #generated/* imports to relative paths in core build

### DIFF
--- a/packages/core/build.mjs
+++ b/packages/core/build.mjs
@@ -16,16 +16,58 @@ const generatedEntryPoints = await glob(join(__dirname, 'generated/**/*.{ts,tsx}
 
 const entryPoints = srcEntryPoints
 
-// Plugin to add .js extension to relative imports
+// Plugin to add .js extension to relative imports and resolve #generated/* imports
 const addJsExtension = {
   name: 'add-js-extension',
   setup(build) {
     build.onEnd(async (result) => {
       if (result.errors.length > 0) return
       const outputFiles = await glob(join(__dirname, 'dist/**/*.js'))
+      const distDir = join(__dirname, 'dist')
       for (const file of outputFiles) {
         const fileDir = dirname(file)
         let content = readFileSync(file, 'utf-8')
+
+        // Helper to resolve #generated/* paths
+        const resolveGeneratedPath = (importPath) => {
+          if (importPath === 'entity-fields-registry') {
+            // Special case: entity-fields-registry is in generated-shims
+            return join(distDir, 'generated-shims', 'entity-fields-registry.js')
+          } else if (importPath.startsWith('entities/')) {
+            // Entity imports: #generated/entities/<name> → dist/generated/entities/<name>/index.js
+            return join(distDir, 'generated', importPath, 'index.js')
+          } else {
+            // Other generated files: #generated/<name> → dist/generated/<name>.js
+            return join(distDir, 'generated', importPath + '.js')
+          }
+        }
+
+        // Resolve #generated/* static imports to relative paths
+        content = content.replace(
+          /from\s+["']#generated\/([^"']+)["']/g,
+          (match, importPath) => {
+            const targetPath = resolveGeneratedPath(importPath)
+            let relativePath = relative(fileDir, targetPath)
+            if (!relativePath.startsWith('.')) {
+              relativePath = './' + relativePath
+            }
+            return `from "${relativePath}"`
+          }
+        )
+
+        // Resolve #generated/* dynamic imports to relative paths
+        content = content.replace(
+          /import\s*\(\s*["']#generated\/([^"']+)["']\s*\)/g,
+          (match, importPath) => {
+            const targetPath = resolveGeneratedPath(importPath)
+            let relativePath = relative(fileDir, targetPath)
+            if (!relativePath.startsWith('.')) {
+              relativePath = './' + relativePath
+            }
+            return `import("${relativePath}")`
+          }
+        )
+
         // Add .js to relative imports that don't have an extension
         content = content.replace(
           /from\s+["'](\.[^"']+)["']/g,


### PR DESCRIPTION
## Summary
- Fixes Next.js build failure after package publishing changes (#400)
- Resolves `#generated/*` subpath imports to relative paths during esbuild compilation
- Handles both static (`from "#generated/..."`) and dynamic (`import("#generated/...")`) imports

## Problem
The package publishing commit changed `packages/core/package.json` imports field to point to compiled `./dist/generated/*.js` files. However, esbuild wasn't resolving these Node.js subpath imports during build, leaving unresolved `#generated/*` imports in the compiled JS files that Next.js/Turbopack couldn't handle.

## Solution
Updated `packages/core/build.mjs` to resolve `#generated/*` imports to proper relative paths:
- `#generated/entities.ids.generated` → `../../generated/entities.ids.generated.js`
- `#generated/entities/<name>` → `../../generated/entities/<name>/index.js`
- `#generated/entity-fields-registry` → `../../generated-shims/entity-fields-registry.js`

## Test plan
- [x] Verified `npm run build` in `packages/core` succeeds
- [x] Verified no `#generated` imports remain in `packages/core/dist/**/*.js`
- [x] Verified `npm run build` in `apps/mercato` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)