### PR TITLE
fix: add combined build script with correct workflow order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Prepare generated modules
         run: yarn generate
 
+      - name: Rebuild packages with generated files
+        run: yarn build:packages
+
       - name: Checking types
         run: yarn typecheck
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev": "yarn build:packages && yarn watch:packages & sleep 3 && yarn dev:app",
     "dev:app": "turbo run dev --filter=@open-mercato/app",
     "watch:packages": "turbo run watch --filter='./packages/*' --parallel",
+    "build": "yarn build:packages && yarn generate && yarn build:packages && yarn build:app",
     "build:app": "turbo run build --filter=@open-mercato/app",
     "build:packages": "turbo run build --filter='./packages/*'",
     "lint": "turbo run lint",


### PR DESCRIPTION
## Summary
- Adds a `yarn build` script that ensures the correct build order after a clean install

## Problem
After `yarn clean`, running `yarn build:app` fails because:
1. Packages need to be built first for `yarn generate` to work
2. `yarn generate` creates files in `packages/core/generated/`
3. Packages need to be rebuilt to compile generated files to `dist/generated/`
4. Only then can the app be built

## Solution
Adds a combined `build` script:
```
"build": "yarn build:packages && yarn generate && yarn build:packages && yarn build:app"
```

## Test plan
- [x] `yarn clean && yarn install && yarn build` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)