### PR TITLE
fix: Change the base image to debian for opencode

### DIFF
--- a/docker/opencode/Dockerfile
+++ b/docker/opencode/Dockerfile
@@ -1,7 +1,8 @@
-FROM alpine:3.20
-
-# Install dependencies (Alpine uses apk, not affected by Debian mirror issues)
-RUN apk add --no-cache curl ca-certificates bash shadow
+FROM debian:bookworm-slim
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates bash passwd \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install OpenCode and move to system path
 RUN curl -fsSL https://opencode.ai/install | bash && \


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The previous implementation of alpine did not work it failed with the following error:  
```
Error loading shared library libstdc++.so.6: No such file or directory (needed by /usr/local/bin/opencode)
Error loading shared library libgcc_s.so.1: No such file or directory (needed by /usr/local/bin/opencode)
Error relocating /usr/local/bin/opencode: _ZSt20__throw_length_errorPKc: symbol not found
Error relocating /usr/local/bin/opencode: __cxa_thread_atexit: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt9terminatev: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt15get_new_handlerv: symbol not found
Error relocating /usr/local/bin/opencode: _ZNSt18condition_variable4waitERSt11unique_lockISt5mutexE: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt13set_terminatePFvvE: symbol not found
Error relocating /usr/local/bin/opencode: _ZNSt18condition_variableC1Ev: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_: symbol not found
Error relocating /usr/local/bin/opencode: __cxa_guard_acquire: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt25__throw_bad_function_callv: symbol not found
Error relocating /usr/local/bin/opencode: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE15_M_replace_coldEPcmPKcmm: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt17__throw_bad_allocv: symbol not found
Error relocating /usr/local/bin/opencode: _ZNSt8__detail15_List_node_base9_M_unhookEv: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt20__throw_system_errori: symbol not found
Error relocating /usr/local/bin/opencode: __cxa_pure_virtual: symbol not found
Error relocating /usr/local/bin/opencode: __cxa_guard_release: symbol not found
Error relocating /usr/local/bin/opencode: _ZNSt18condition_variable10notify_allEv: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt28__throw_bad_array_new_lengthv: symbol not found
Error relocating /usr/local/bin/opencode: __cxa_demangle: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt21__glibcxx_assert_failPKciS0_S0_: symbol not found
Error relocating /usr/local/bin/opencode: _ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm: symbol not found
Error relocating /usr/local/bin/opencode: _ZNSt19_Sp_make_shared_tag5_S_eqERKSt9type_info: symbol not found
Error relocating /usr/local/bin/opencode: _ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc: symbol not found
Error relocating /usr/local/bin/opencode: _ZNSt18condition_variable10notify_oneEv: symbol not found
Error relocating /usr/local/bin/opencode: __dynamic_cast: symbol not found
Error relocating /usr/local/bin/opencode: _ZNSt18condition_variableD1Ev: symbol not found
Error relocating /usr/local/bin/opencode: _ZNSt8__detail15_List_node_base7_M_hookEPS0_: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt24__throw_out_of_range_fmtPKcz: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt11_Hash_bytesPKvmm: symbol not found
Error relocating /usr/local/bin/opencode: __once_proxy: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt19__throw_logic_errorPKc: symbol not found
Error relocating /usr/local/bin/opencode: __fixdfti: symbol not found
Error relocating /usr/local/bin/opencode: __modti3: symbol not found
Error relocating /usr/local/bin/opencode: __umodti3: symbol not found
Error relocating /usr/local/bin/opencode: _Unwind_Resume: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt15__once_callable: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt11__once_call: symbol not found
Error relocating /usr/local/bin/opencode: _Unwind_GetIP: symbol not found
Error relocating /usr/local/bin/opencode: _Unwind_GetTextRelBase: symbol not found
Error relocating /usr/local/bin/opencode: _Unwind_GetDataRelBase: symbol not found
Error relocating /usr/local/bin/opencode: _Unwind_Backtrace: symbol not found
Error relocating /usr/local/bin/opencode: _Unwind_GetLanguageSpecificData: symbol not found
Error relocating /usr/local/bin/opencode: _Unwind_GetIPInfo: symbol not found
Error relocating /usr/local/bin/opencode: _Unwind_GetRegionStart: symbol not found
Error relocating /usr/local/bin/opencode: _Unwind_SetGR: symbol not found
Error relocating /usr/local/bin/opencode: _Unwind_SetIP: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt4cerr: symbol not found
Error relocating /usr/local/bin/opencode: _ZTVN10__cxxabiv120__si_class_type_infoE: symbol not found
Error relocating /usr/local/bin/opencode: _ZTVN10__cxxabiv117__class_type_infoE: symbol not found
Error relocating /usr/local/bin/opencode: _ZTVN10__cxxabiv121__vmi_class_type_infoE: symbol not found
```

## Changes

- Change to debian and adjust the dockerfile to it

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

Now opencode says that it listens on the port:
```
INFO  2026-01-27T09:43:23 +6ms service=models.dev file={} refreshing

INFO  2026-01-27T09:43:23 +118ms service=default version=1.1.36 args=["serve","--hostname","0.0.0.0","--print-logs","--log-level","DEBUG"] opencode

Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.

INFO  2026-01-27T09:43:23 +1ms service=config path=/home/opencode/.config/opencode/config.json loading

INFO  2026-01-27T09:43:23 +2ms service=config path=/home/opencode/.config/opencode/opencode.json loading

INFO  2026-01-27T09:43:23 +0ms service=config path=/home/opencode/.config/opencode/opencode.jsonc loading

opencode server listening on [http://0.0.0.0:4096⁠](http://0.0.0.0:4096/)
```

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
