### PR TITLE
feat(agent-skills): Create structure for agent skills in open mercato

### DIFF
--- a/.ai/skills/README.md
+++ b/.ai/skills/README.md
@@ -1,0 +1,475 @@
+# Agent Skills
+
+Skills extend AI agents with task-specific capabilities. This guide covers both **Claude Code** and **Codex** - note that they use different skill formats and locations.
+
+This repository contains example skills for both tools in a unified structure.
+
+---
+
+## Repository Structure
+
+```
+.ai/skills/
+├── README.md                           # This documentation
+├── claude/                             # Claude Code skills (flat .md files)
+│   └── backend-ui-design.md
+└── codex/                              # Codex skills (folder-based)
+    ├── references/                     # Shared references across skills
+    └── backend-ui-design/
+        ├── SKILL.md                    # Main skill file
+        └── references/
+            └── ui-components.md        # Skill-specific references
+```
+
+---
+
+## Quick Comparison
+
+| Aspect | Claude Code | Codex |
+|--------|-------------|-------|
+| **Skill location** | `.claude/skills/` | `.codex/skills/` |
+| **Skill format** | `skill-name.md` | `skill-name/SKILL.md` |
+| **Invoke syntax** | `/skill-name` | `$skill-name` |
+| **List skills** | `/skills` | `/skills` |
+| **Specification** | Claude-specific | [Agent Skills Standard](https://github.com/openai/agent-skills) |
+
+---
+
+## Installation
+
+### For Claude Code
+
+Option 1: Symlink the claude skills folder:
+
+```bash
+mkdir -p .claude
+ln -s ../.ai/skills/claude .claude/skills
+```
+
+Option 2: Configure custom directory in `.claude/settings.json`:
+
+```json
+{
+  "skills": {
+    "directory": ".ai/skills/claude"
+  }
+}
+```
+
+### For Codex
+
+Symlink the codex skills folder:
+
+```bash
+ln -s .ai/skills/codex .codex/skills
+```
+
+Or copy individual skills to your `.codex/skills/` directory.
+
+### Verify Installation
+
+**Claude Code:**
+```bash
+claude
+> /skills
+# Should list backend-ui-design
+```
+
+**Codex:**
+```bash
+codex
+> /skills
+# Should list backend-ui-design
+```
+
+---
+
+## Claude Code Skills
+
+### Directory Structure
+
+Skills are single markdown files with YAML frontmatter:
+
+```
+.ai/skills/claude/              # or .claude/skills/
+├── backend-ui-design.md
+├── api-design.md
+└── [skill-name].md
+```
+
+### Skill File Format
+
+```markdown
+---
+name: skill-name
+description: When to use this skill. Helps Claude select it automatically.
+---
+
+Instructions for Claude to follow when this skill is active.
+
+## Section 1
+...
+```
+
+### Using Skills in Claude Code
+
+| Action | Command |
+|--------|---------|
+| Invoke skill | `/skill-name` |
+| List skills | `/skills` |
+| Get help | `/help skills` |
+
+**Example:**
+```bash
+claude
+> /backend-ui-design
+> Create a customer list page with filtering
+```
+
+---
+
+## Codex Skills
+
+Codex uses the [Agent Skills Standard](https://github.com/openai/agent-skills). Skills are folders containing a `SKILL.md` file plus optional scripts and resources.
+
+### Skill Structure
+
+```
+.ai/skills/codex/               # or .codex/skills/
+└── my-skill/
+    ├── SKILL.md                # Required: instructions + metadata
+    ├── scripts/                # Optional: executable code
+    ├── references/             # Optional: documentation
+    └── assets/                 # Optional: templates, resources
+```
+
+### SKILL.md Format
+
+```markdown
+---
+name: skill-name
+description: Description that helps Codex select the skill
+metadata:
+  short-description: Optional user-facing description
+---
+
+Skill instructions for the Codex agent to follow when using this skill.
+
+## Section 1
+...
+```
+
+### Skill Locations (Precedence Order)
+
+Codex loads skills from multiple locations. Higher precedence overrides lower when names collide:
+
+| Precedence | Scope | Location | Use Case |
+|------------|-------|----------|----------|
+| 1 (highest) | REPO | `$CWD/.codex/skills` | Skills for current working directory |
+| 2 | REPO | `$CWD/../.codex/skills` | Parent folder skills (monorepo modules) |
+| 3 | REPO | `$REPO_ROOT/.codex/skills` | Repository-wide skills |
+| 4 | USER | `~/.codex/skills` | Personal skills across all repos |
+| 5 | ADMIN | `/etc/codex/skills` | System-wide admin skills |
+| 6 (lowest) | SYSTEM | Bundled with Codex | Built-in skills (`$skill-creator`, etc.) |
+
+**Example for monorepo:**
+```
+my-monorepo/
+├── .codex/skills/              # Repo-wide skills (precedence 3)
+│   └── repo-conventions/
+│       └── SKILL.md
+├── apps/
+│   └── backend/
+│       └── .codex/skills/      # Module-specific skills (precedence 1)
+│           └── backend-api/
+│               └── SKILL.md
+└── packages/
+```
+
+### Progressive Disclosure
+
+Codex uses **progressive disclosure** to manage context efficiently:
+
+1. At startup, Codex loads only the `name` and `description` of each skill
+2. Full instructions are loaded only when a skill is invoked
+3. This keeps context small until capabilities are needed
+
+### Invoking Skills in Codex
+
+#### Explicit Invocation
+
+You directly request a skill:
+
+```
+# Using slash command
+/skills
+→ Select from list
+
+# Mentioning a skill with $
+$backend-ui-design create a customer list page
+
+# Or describe which skill to use
+Please use the backend-ui-design skill to create a customer list page
+```
+
+**Note:** Codex web and iOS don't support explicit invocation yet, but can use skills checked into repos.
+
+#### Implicit Invocation
+
+Codex automatically selects skills when your task matches a skill's description:
+
+```
+# If backend-ui-design skill has description mentioning "admin pages", "CRUD", etc.
+Create an admin page for managing products
+→ Codex may automatically invoke backend-ui-design
+```
+
+### Installing Community Skills
+
+Use the built-in `$skill-installer` to download skills:
+
+```bash
+# Install from curated skills
+$skill-installer install the linear skill from the .experimental folder
+
+# Install planning skill
+$skill-installer install the create-plan skill from the .experimental folder
+
+# Install from other repositories
+$skill-installer install skill-name from github.com/user/repo
+```
+
+After installing, restart Codex to pick up new skills.
+
+### Built-in Skills
+
+| Skill | Description |
+|-------|-------------|
+| `$skill-creator` | Create new skills interactively |
+| `$skill-installer` | Install community skills |
+| `$create-plan` | Research and plan features (experimental, install first) |
+
+### Creating Skills in Codex
+
+**Option 1: Use skill-creator**
+```
+$skill-creator
+
+I want to create a skill for designing backend admin pages...
+```
+
+**Option 2: Manual creation**
+```bash
+mkdir -p .ai/skills/codex/my-skill/references
+touch .ai/skills/codex/my-skill/SKILL.md
+```
+
+### Disabling Skills
+
+In `~/.codex/config.toml` (experimental):
+
+```toml
+[[skills.config]]
+path = "/path/to/skill"
+enabled = false
+```
+
+Restart Codex after changes.
+
+---
+
+## Converting Between Formats
+
+### Claude Code → Codex
+
+Convert a Claude Code skill to Codex format:
+
+**Before (Claude Code):** `.ai/skills/claude/backend-ui-design.md`
+```markdown
+---
+name: backend-ui-design
+description: Design backend interfaces...
+---
+
+Instructions...
+```
+
+**After (Codex):** `.ai/skills/codex/backend-ui-design/SKILL.md`
+```markdown
+---
+name: backend-ui-design
+description: Design backend interfaces...
+metadata:
+  short-description: Backend UI design skill
+---
+
+Instructions...
+```
+
+### Codex → Claude Code
+
+Convert a Codex skill to Claude Code format:
+
+1. Copy `SKILL.md` content to `.ai/skills/claude/skill-name.md`
+2. Remove `metadata` section from frontmatter (optional in Claude Code)
+3. Inline any referenced files from `references/` folder
+
+---
+
+## Project Setup for Both Tools
+
+This repository uses a unified structure in `.ai/skills/` with symlinks to tool-specific locations:
+
+```
+your-repo/
+├── .ai/
+│   └── skills/                      # Unified skill repository
+│       ├── README.md
+│       ├── claude/                  # Claude Code format skills
+│       │   └── backend-ui-design.md
+│       └── codex/                   # Codex format skills
+│           └── backend-ui-design/
+│               ├── SKILL.md
+│               └── references/
+│                   └── ui-components.md
+├── .claude/
+│   └── skills -> ../.ai/skills/claude    # Symlink for Claude Code
+└── .codex/
+    └── skills -> ../.ai/skills/codex     # Symlink for Codex
+```
+
+**Setup commands:**
+```bash
+# Create symlinks for both tools
+mkdir -p .claude .codex
+ln -s ../.ai/skills/claude .claude/skills
+ln -s ../.ai/skills/codex .codex/skills
+```
+
+This approach:
+- Keeps all skills in one location (`.ai/skills/`)
+- Maintains tool-specific formats in subdirectories
+- Uses symlinks so each tool finds skills in its expected location
+- Makes it easy to version control and share skills
+
+---
+
+## Best Practices
+
+### Writing Effective Descriptions
+
+The `description` field drives automatic skill selection. Include:
+
+- **Trigger words**: "when building", "when creating", "when designing"
+- **Domain terms**: "admin pages", "API endpoints", "CRUD interfaces"
+- **Outcomes**: "ensures consistency", "follows conventions"
+
+**Good:**
+```yaml
+description: Design and implement backend/backoffice interfaces using @open-mercato/ui. Use when building admin pages, CRUD interfaces, data tables, forms, or detail pages.
+```
+
+**Weak:**
+```yaml
+description: Helps with UI stuff.
+```
+
+### Structuring Instructions
+
+```markdown
+## Principles
+High-level guidelines and philosophy
+
+## Components / Patterns
+Specific implementations and code examples
+
+## Checklist
+Verification steps before completing work
+
+## Anti-Patterns
+What to explicitly avoid
+```
+
+### Skill Size Guidelines
+
+| Size | Lines | Use Case |
+|------|-------|----------|
+| Small | < 100 | Simple conventions |
+| Medium | 100-300 | Component libraries, API patterns |
+| Large | 300-500 | Complex workflows |
+
+If exceeding 500 lines, consider splitting into multiple skills or using `references/` folder (Codex).
+
+---
+
+## Skills vs Global Instructions
+
+| File | Purpose | Scope | When Active |
+|------|---------|-------|-------------|
+| `CLAUDE.md` | Project instructions | Global | Always (Claude Code) |
+| `AGENTS.md` | Agent conventions | Global | Always |
+| `codex.md` | Project instructions | Global | Always (Codex) |
+| Skills | Task-specific guidance | Per-task | On demand |
+
+**Use skills when:**
+- Instructions are task-specific
+- You want explicit invocation control
+- Guidance is substantial (>50 lines)
+
+---
+
+## Available Skills
+
+| Skill | Description | Claude Code | Codex |
+|-------|-------------|-------------|-------|
+| `backend-ui-design` | Backend/admin UI using @open-mercato/ui | `/backend-ui-design` | `$backend-ui-design` |
+
+---
+
+## Troubleshooting
+
+### Skill Not Found
+
+| Tool | Solution |
+|------|----------|
+| **Claude Code** | Check symlink exists: `ls -la .claude/skills` |
+| **Codex** | Check symlink exists: `ls -la .codex/skills` |
+| **Both** | Verify skill file has valid YAML frontmatter |
+
+### Symlink Issues
+
+```bash
+# Verify symlinks are correct
+ls -la .claude/skills
+ls -la .codex/skills
+
+# Recreate if broken
+rm .claude/skills .codex/skills
+ln -s ../.ai/skills/claude .claude/skills
+ln -s ../.ai/skills/codex .codex/skills
+```
+
+### Skill Not Auto-Selected
+
+- Improve `description` with more specific trigger words
+- Add domain-specific terminology
+- Ensure description matches common task phrasings
+
+### Codex Not Loading Updated Skill
+
+- Restart Codex after adding/modifying skills
+- Check `SKILL.md` has valid YAML frontmatter
+- Verify folder is in a valid skill location
+
+---
+
+## References
+
+### Claude Code
+- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
+- [Extend Claude Code With Skills](https://code.claude.com/docs/en/skills)
+
+### Codex
+- [Codex Skills Documentation](https://openai.com/codex/skills)
+- [Agent Skills Specification](https://github.com/openai/agent-skills)
+- [Create Custom Skills Guide](https://openai.com/codex/skills/create)

--- a/.ai/skills/claude/backend-ui-design.md
+++ b/.ai/skills/claude/backend-ui-design.md
@@ -1,0 +1,248 @@
+---
+name: backend-ui-design
+description: Design and implement consistent, production-grade backend/backoffice interfaces using the @open-mercato/ui component library. Use this skill when building admin pages, CRUD interfaces, data tables, forms, detail pages, or any backoffice UI components. Ensures visual consistency and UX patterns across all application modules.
+---
+
+This skill guides creation of consistent, production-grade backend/backoffice interfaces using the established @open-mercato/ui component library. All implementations must leverage existing components to maintain visual and behavioral consistency across modules.
+
+## Design Principles
+
+Backend UI prioritizes **usability, consistency, and productivity** over creative expression:
+
+1. **Consistency First**: Every page should feel like part of the same application. Use established patterns.
+2. **Component Reuse**: Never create custom implementations when a shared component exists.
+3. **Data Density**: Admin users need information-rich interfaces. Optimize for scanning and quick actions.
+4. **Keyboard Navigation**: Support Cmd/Ctrl+Enter for primary actions, Escape to cancel, and standard shortcuts.
+5. **Clear Hierarchy**: Page → Section → Content. Use PageHeader, PageBody, and consistent spacing.
+
+## Required Component Library
+
+ALWAYS import from `@open-mercato/ui`. Reference the component documentation at `.ai/specs/SPEC-001-2026-01-21-ui-reusable-components.md`.
+
+### Core Layout Pattern
+
+```tsx
+import { Page, PageHeader, PageBody } from '@open-mercato/ui/backend/Page'
+import { AppShell } from '@open-mercato/ui/backend/AppShell'
+
+// Every backend page follows this structure
+<Page>
+  <PageHeader>
+    {/* Title, actions, breadcrumbs */}
+  </PageHeader>
+  <PageBody>
+    {/* Main content */}
+  </PageBody>
+</Page>
+```
+
+### Data Display (Lists)
+
+Use `DataTable` for ALL tabular data. Never implement custom tables.
+
+```tsx
+import { DataTable } from '@open-mercato/ui/backend/DataTable'
+import type { FilterDef } from '@open-mercato/ui/backend/FilterBar'
+import { RowActions } from '@open-mercato/ui/backend/RowActions'
+import { TruncatedCell } from '@open-mercato/ui/backend/TruncatedCell'
+import { BooleanIcon, EnumBadge } from '@open-mercato/ui/backend/ValueIcons'
+```
+
+Column configuration patterns:
+- Text columns: Use `TruncatedCell` with `meta.maxWidth` for long content
+- Boolean columns: Use `BooleanIcon`
+- Status/enum columns: Use `EnumBadge` with severity presets
+- Actions column: Use `RowActions` for context menus
+
+### Forms
+
+Use `CrudForm` for ALL forms. Never build forms from scratch.
+
+```tsx
+import { CrudForm, type CrudField, type CrudFormGroup } from '@open-mercato/ui/backend/CrudForm'
+import { JsonBuilder } from '@open-mercato/ui/backend/JsonBuilder'
+```
+
+Form field types available:
+- `text`, `textarea`, `number`, `email`, `password`
+- `select`, `multiselect`, `combobox`
+- `checkbox`, `switch`
+- `date`, `datetime`
+- `custom` (for JsonBuilder, TagsInput, etc.)
+
+### Dialogs
+
+```tsx
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@open-mercato/ui/primitives/dialog'
+import { CrudForm } from '@open-mercato/ui/backend/CrudForm'
+
+// Dialog forms MUST use embedded={true}
+<Dialog open={isOpen} onOpenChange={onClose}>
+  <DialogContent className="sm:max-w-2xl [&_.grid]:!grid-cols-1">
+    <DialogHeader>
+      <DialogTitle>Edit Item</DialogTitle>
+    </DialogHeader>
+    <CrudForm
+      fields={fields}
+      groups={groups}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      embedded={true}
+      submitLabel="Save"
+    />
+  </DialogContent>
+</Dialog>
+```
+
+### Detail Pages
+
+```tsx
+import {
+  DetailFieldsSection,
+  LoadingMessage,
+  ErrorMessage,
+  TabEmptyState
+} from '@open-mercato/ui/backend/detail'
+import { NotesSection } from '@open-mercato/ui/backend/detail/NotesSection'
+import { TagsSection } from '@open-mercato/ui/backend/detail/TagsSection'
+import { CustomDataSection } from '@open-mercato/ui/backend/detail/CustomDataSection'
+```
+
+### Notifications
+
+```tsx
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
+
+// Success
+flash('Record saved successfully', 'success')
+
+// Error
+flash('Failed to save record', 'error')
+
+// Warning/Info
+flash('This action cannot be undone', 'warning')
+flash('Processing in background', 'info')
+```
+
+NEVER use `alert()`, `console.log()`, or custom toast implementations.
+
+### Loading & Error States
+
+```tsx
+import { Spinner } from '@open-mercato/ui/primitives/spinner'
+import { DataLoader } from '@open-mercato/ui/primitives/DataLoader'
+import { ErrorNotice } from '@open-mercato/ui/primitives/ErrorNotice'
+import { EmptyState } from '@open-mercato/ui/backend/EmptyState'
+import { LoadingMessage, ErrorMessage } from '@open-mercato/ui/backend/detail'
+```
+
+### Primitives (use sparingly, prefer backend components)
+
+```tsx
+import { Button } from '@open-mercato/ui/primitives/button'
+import { Input } from '@open-mercato/ui/primitives/input'
+import { Label } from '@open-mercato/ui/primitives/label'
+import { Badge } from '@open-mercato/ui/primitives/badge'
+import { Alert, AlertTitle, AlertDescription } from '@open-mercato/ui/primitives/alert'
+import { Separator } from '@open-mercato/ui/primitives/separator'
+import { Switch } from '@open-mercato/ui/primitives/switch'
+import { SimpleTooltip } from '@open-mercato/ui/primitives/tooltip'
+```
+
+## Implementation Checklist
+
+Before writing any backend UI code, verify:
+
+- [ ] Using `CrudForm` for forms (not custom form implementations)
+- [ ] Using `DataTable` for lists (not custom tables)
+- [ ] Using `flash()` for notifications (not alert/toast)
+- [ ] Dialog forms have `embedded={true}`
+- [ ] Keyboard shortcuts: Cmd/Ctrl+Enter (submit), Escape (cancel)
+- [ ] Loading states use `LoadingMessage` or `DataLoader`
+- [ ] Error states use `ErrorMessage` or `ErrorNotice`
+- [ ] Empty states use `EmptyState`
+- [ ] Column truncation configured with `meta.truncate` and `meta.maxWidth`
+- [ ] Boolean values use `BooleanIcon`
+- [ ] Status/enum values use `EnumBadge`
+- [ ] Row actions use `RowActions` component
+
+## Visual Guidelines
+
+### Spacing
+- Use consistent padding: `p-4` for cards, `p-6` for page sections
+- Use `gap-4` or `gap-6` for flex/grid layouts
+- Maintain vertical rhythm with `space-y-4` or `space-y-6`
+
+### Colors
+- Use semantic colors from the theme (don't hardcode hex values)
+- Destructive actions: `variant="destructive"` on buttons
+- Status badges: Use `useSeverityPreset()` for consistent coloring
+
+### Typography
+- Page titles: Handled by `PageHeader`
+- Section titles: `text-lg font-semibold`
+- Labels: Handled by form components
+- Body text: Default sizing, avoid custom font sizes
+
+### Layout Patterns
+- List pages: FilterBar + DataTable + Pagination
+- Detail pages: Header + Tabs or Sections + Related data
+- Create/Edit: Full-page CrudForm or Dialog with embedded CrudForm
+- Settings: Grouped sections with inline editing
+
+## Anti-Patterns to Avoid
+
+1. **Custom form implementations** - Always use CrudForm
+2. **Manual table markup** - Always use DataTable
+3. **Custom toast/notification** - Always use flash()
+4. **Inline styles** - Use Tailwind classes
+5. **Hardcoded colors** - Use theme variables
+6. **Missing loading states** - Every async operation needs feedback
+7. **Missing error handling** - Every failure needs user-friendly messaging
+8. **Missing keyboard shortcuts** - All dialogs need Cmd+Enter and Escape
+9. **Custom truncation logic** - Use TruncatedCell with meta.maxWidth
+10. **Direct fetch() calls** - Use apiCall/apiCallOrThrow from utils
+
+## API Integration Pattern
+
+```tsx
+import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { createCrud, updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
+import { mapCrudServerErrorToFormErrors, createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors'
+
+// For CRUD operations
+const handleCreate = async (values: FormValues) => {
+  const result = await createCrud<ResponseType>('module/resource', values)
+  if (result.ok) {
+    flash('Created successfully', 'success')
+    router.push(`/backend/module/${result.result.id}`)
+  }
+  return result
+}
+
+// For custom endpoints
+const result = await apiCall<ResponseType>('/api/custom-endpoint', {
+  method: 'POST',
+  body: JSON.stringify(data)
+})
+```
+
+## Custom Fields Integration
+
+When building CRUD interfaces that support custom fields:
+
+```tsx
+import { useCustomFieldDefinitions } from '@open-mercato/ui/backend/utils/customFieldDefs'
+import { buildCustomFieldFormFields } from '@open-mercato/ui/backend/utils/customFieldForms'
+import { buildCustomFieldColumns } from '@open-mercato/ui/backend/utils/customFieldColumns'
+import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customFieldValues'
+```
+
+## When to Create New Components
+
+Only create new components when:
+1. No existing component serves the use case
+2. The pattern will be reused across 3+ modules
+3. Approved for addition to `@open-mercato/ui`
+
+If creating something new, it should eventually be added to the shared library, not kept in a single module.

--- a/.ai/skills/codex/backend-ui-design/SKILL.md
+++ b/.ai/skills/codex/backend-ui-design/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: backend-ui-design
+description: Design and implement consistent, production-grade backend/backoffice interfaces using the @open-mercato/ui component library. Use this skill when building admin pages, CRUD interfaces, data tables, forms, detail pages, or any backoffice UI components. Ensures visual consistency and UX patterns across all application modules.
+metadata:
+  short-description: Backend UI design using @open-mercato/ui
+  author: Open Mercato
+  version: 1.0.0
+  tags:
+    - ui
+    - backend
+    - admin
+    - crud
+    - forms
+    - tables
+---
+
+This skill guides creation of consistent, production-grade backend/backoffice interfaces using the established @open-mercato/ui component library. All implementations must leverage existing components to maintain visual and behavioral consistency across modules.
+
+For complete component documentation, see `references/ui-components.md`.
+
+## Design Principles
+
+Backend UI prioritizes **usability, consistency, and productivity** over creative expression:
+
+1. **Consistency First**: Every page should feel like part of the same application. Use established patterns.
+2. **Component Reuse**: Never create custom implementations when a shared component exists.
+3. **Data Density**: Admin users need information-rich interfaces. Optimize for scanning and quick actions.
+4. **Keyboard Navigation**: Support Cmd/Ctrl+Enter for primary actions, Escape to cancel, and standard shortcuts.
+5. **Clear Hierarchy**: Page → Section → Content. Use PageHeader, PageBody, and consistent spacing.
+
+## Required Component Library
+
+ALWAYS import from `@open-mercato/ui`. Reference the component documentation at `.ai/specs/SPEC-001-2026-01-21-ui-reusable-components.md`.
+
+### Core Layout Pattern
+
+```tsx
+import { Page, PageHeader, PageBody } from '@open-mercato/ui/backend/Page'
+import { AppShell } from '@open-mercato/ui/backend/AppShell'
+
+// Every backend page follows this structure
+<Page>
+  <PageHeader>
+    {/* Title, actions, breadcrumbs */}
+  </PageHeader>
+  <PageBody>
+    {/* Main content */}
+  </PageBody>
+</Page>
+```
+
+### Data Display (Lists)
+
+Use `DataTable` for ALL tabular data. Never implement custom tables.
+
+```tsx
+import { DataTable } from '@open-mercato/ui/backend/DataTable'
+import type { FilterDef } from '@open-mercato/ui/backend/FilterBar'
+import { RowActions } from '@open-mercato/ui/backend/RowActions'
+import { TruncatedCell } from '@open-mercato/ui/backend/TruncatedCell'
+import { BooleanIcon, EnumBadge } from '@open-mercato/ui/backend/ValueIcons'
+```
+
+Column configuration patterns:
+- Text columns: Use `TruncatedCell` with `meta.maxWidth` for long content
+- Boolean columns: Use `BooleanIcon`
+- Status/enum columns: Use `EnumBadge` with severity presets
+- Actions column: Use `RowActions` for context menus
+
+### Forms
+
+Use `CrudForm` for ALL forms. Never build forms from scratch.
+
+```tsx
+import { CrudForm, type CrudField, type CrudFormGroup } from '@open-mercato/ui/backend/CrudForm'
+import { JsonBuilder } from '@open-mercato/ui/backend/JsonBuilder'
+```
+
+Form field types available:
+- `text`, `textarea`, `number`, `email`, `password`
+- `select`, `multiselect`, `combobox`
+- `checkbox`, `switch`
+- `date`, `datetime`
+- `custom` (for JsonBuilder, TagsInput, etc.)
+
+### Dialogs
+
+```tsx
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@open-mercato/ui/primitives/dialog'
+import { CrudForm } from '@open-mercato/ui/backend/CrudForm'
+
+// Dialog forms MUST use embedded={true}
+<Dialog open={isOpen} onOpenChange={onClose}>
+  <DialogContent className="sm:max-w-2xl [&_.grid]:!grid-cols-1">
+    <DialogHeader>
+      <DialogTitle>Edit Item</DialogTitle>
+    </DialogHeader>
+    <CrudForm
+      fields={fields}
+      groups={groups}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      embedded={true}
+      submitLabel="Save"
+    />
+  </DialogContent>
+</Dialog>
+```
+
+### Detail Pages
+
+```tsx
+import {
+  DetailFieldsSection,
+  LoadingMessage,
+  ErrorMessage,
+  TabEmptyState
+} from '@open-mercato/ui/backend/detail'
+import { NotesSection } from '@open-mercato/ui/backend/detail/NotesSection'
+import { TagsSection } from '@open-mercato/ui/backend/detail/TagsSection'
+import { CustomDataSection } from '@open-mercato/ui/backend/detail/CustomDataSection'
+```
+
+### Notifications
+
+```tsx
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
+
+// Success
+flash('Record saved successfully', 'success')
+
+// Error
+flash('Failed to save record', 'error')
+
+// Warning/Info
+flash('This action cannot be undone', 'warning')
+flash('Processing in background', 'info')
+```
+
+NEVER use `alert()`, `console.log()`, or custom toast implementations.
+
+### Loading & Error States
+
+```tsx
+import { Spinner } from '@open-mercato/ui/primitives/spinner'
+import { DataLoader } from '@open-mercato/ui/primitives/DataLoader'
+import { ErrorNotice } from '@open-mercato/ui/primitives/ErrorNotice'
+import { EmptyState } from '@open-mercato/ui/backend/EmptyState'
+import { LoadingMessage, ErrorMessage } from '@open-mercato/ui/backend/detail'
+```
+
+### Primitives (use sparingly, prefer backend components)
+
+```tsx
+import { Button } from '@open-mercato/ui/primitives/button'
+import { Input } from '@open-mercato/ui/primitives/input'
+import { Label } from '@open-mercato/ui/primitives/label'
+import { Badge } from '@open-mercato/ui/primitives/badge'
+import { Alert, AlertTitle, AlertDescription } from '@open-mercato/ui/primitives/alert'
+import { Separator } from '@open-mercato/ui/primitives/separator'
+import { Switch } from '@open-mercato/ui/primitives/switch'
+import { SimpleTooltip } from '@open-mercato/ui/primitives/tooltip'
+```
+
+## Implementation Checklist
+
+Before writing any backend UI code, verify:
+
+- [ ] Using `CrudForm` for forms (not custom form implementations)
+- [ ] Using `DataTable` for lists (not custom tables)
+- [ ] Using `flash()` for notifications (not alert/toast)
+- [ ] Dialog forms have `embedded={true}`
+- [ ] Keyboard shortcuts: Cmd/Ctrl+Enter (submit), Escape (cancel)
+- [ ] Loading states use `LoadingMessage` or `DataLoader`
+- [ ] Error states use `ErrorMessage` or `ErrorNotice`
+- [ ] Empty states use `EmptyState`
+- [ ] Column truncation configured with `meta.truncate` and `meta.maxWidth`
+- [ ] Boolean values use `BooleanIcon`
+- [ ] Status/enum values use `EnumBadge`
+- [ ] Row actions use `RowActions` component
+
+## Visual Guidelines
+
+### Spacing
+- Use consistent padding: `p-4` for cards, `p-6` for page sections
+- Use `gap-4` or `gap-6` for flex/grid layouts
+- Maintain vertical rhythm with `space-y-4` or `space-y-6`
+
+### Colors
+- Use semantic colors from the theme (don't hardcode hex values)
+- Destructive actions: `variant="destructive"` on buttons
+- Status badges: Use `useSeverityPreset()` for consistent coloring
+
+### Typography
+- Page titles: Handled by `PageHeader`
+- Section titles: `text-lg font-semibold`
+- Labels: Handled by form components
+- Body text: Default sizing, avoid custom font sizes
+
+### Layout Patterns
+- List pages: FilterBar + DataTable + Pagination
+- Detail pages: Header + Tabs or Sections + Related data
+- Create/Edit: Full-page CrudForm or Dialog with embedded CrudForm
+- Settings: Grouped sections with inline editing
+
+## Anti-Patterns to Avoid
+
+1. **Custom form implementations** - Always use CrudForm
+2. **Manual table markup** - Always use DataTable
+3. **Custom toast/notification** - Always use flash()
+4. **Inline styles** - Use Tailwind classes
+5. **Hardcoded colors** - Use theme variables
+6. **Missing loading states** - Every async operation needs feedback
+7. **Missing error handling** - Every failure needs user-friendly messaging
+8. **Missing keyboard shortcuts** - All dialogs need Cmd+Enter and Escape
+9. **Custom truncation logic** - Use TruncatedCell with meta.maxWidth
+10. **Direct fetch() calls** - Use apiCall/apiCallOrThrow from utils
+
+## API Integration Pattern
+
+```tsx
+import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { createCrud, updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
+import { mapCrudServerErrorToFormErrors, createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors'
+
+// For CRUD operations
+const handleCreate = async (values: FormValues) => {
+  const result = await createCrud<ResponseType>('module/resource', values)
+  if (result.ok) {
+    flash('Created successfully', 'success')
+    router.push(`/backend/module/${result.result.id}`)
+  }
+  return result
+}
+
+// For custom endpoints
+const result = await apiCall<ResponseType>('/api/custom-endpoint', {
+  method: 'POST',
+  body: JSON.stringify(data)
+})
+```
+
+## Custom Fields Integration
+
+When building CRUD interfaces that support custom fields:
+
+```tsx
+import { useCustomFieldDefinitions } from '@open-mercato/ui/backend/utils/customFieldDefs'
+import { buildCustomFieldFormFields } from '@open-mercato/ui/backend/utils/customFieldForms'
+import { buildCustomFieldColumns } from '@open-mercato/ui/backend/utils/customFieldColumns'
+import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customFieldValues'
+```
+
+## When to Create New Components
+
+Only create new components when:
+1. No existing component serves the use case
+2. The pattern will be reused across 3+ modules
+3. Approved for addition to `@open-mercato/ui`
+
+If creating something new, it should eventually be added to the shared library, not kept in a single module.

--- a/.ai/skills/codex/backend-ui-design/references/ui-components.md
+++ b/.ai/skills/codex/backend-ui-design/references/ui-components.md
@@ -1,0 +1,228 @@
+# UI Components Reference
+
+Complete reference of all available UI components in `@open-mercato/ui`.
+
+## Package Structure
+
+```
+@open-mercato/ui/
+├── primitives/          # Base UI components (shadcn-style)
+├── backend/             # Full-featured admin components
+├── frontend/            # Public-facing components
+└── theme/               # Theme and provider setup
+```
+
+## PRIMITIVES (`@open-mercato/ui/primitives/*`)
+
+| Component | Import Path | Purpose |
+|-----------|-------------|---------|
+| **Button** | `@open-mercato/ui/primitives/button` | Core button with variants (default, outline, ghost, destructive) |
+| **Input** | `@open-mercato/ui/primitives/input` | Text input field |
+| **Label** | `@open-mercato/ui/primitives/label` | Form label component |
+| **Textarea** | `@open-mercato/ui/primitives/textarea` | Multi-line text input |
+| **Dialog** | `@open-mercato/ui/primitives/dialog` | Modal dialog (Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter) |
+| **Tooltip** | `@open-mercato/ui/primitives/tooltip` | Hover tooltip + `SimpleTooltip` utility component |
+| **Table** | `@open-mercato/ui/primitives/table` | Table structure (Table, TableHeader, TableBody, TableRow, TableHead, TableCell) |
+| **Alert** | `@open-mercato/ui/primitives/alert` | Alert boxes (Alert, AlertTitle, AlertDescription) with variants |
+| **Badge** | `@open-mercato/ui/primitives/badge` | Small badge/tag labels with variants |
+| **Separator** | `@open-mercato/ui/primitives/separator` | Visual divider line |
+| **Switch** | `@open-mercato/ui/primitives/switch` | Toggle switch control |
+| **Spinner** | `@open-mercato/ui/primitives/spinner` | Loading spinner animation |
+| **ErrorNotice** | `@open-mercato/ui/primitives/ErrorNotice` | Error message display with icon |
+| **DataLoader** | `@open-mercato/ui/primitives/DataLoader` | Loading state wrapper with spinner and optional skeleton |
+
+## BACKEND COMPONENTS (`@open-mercato/ui/backend/*`)
+
+### Core Layout & Navigation
+
+| Component | Import Path | Purpose | Key Props |
+|-----------|-------------|---------|-----------|
+| **AppShell** | `@open-mercato/ui/backend/AppShell` | Main application shell with sidebar, header, breadcrumbs | `navigation`, `user`, `children` |
+| **Page, PageHeader, PageBody** | `@open-mercato/ui/backend/Page` | Page layout containers | - |
+| **UserMenu** | `@open-mercato/ui/backend/UserMenu` | User profile dropdown with logout | `user`, `onLogout` |
+| **FlashMessages, flash** | `@open-mercato/ui/backend/FlashMessages` | Toast notifications. Use `flash(message, type)` programmatically | Type: 'success' \| 'error' \| 'warning' \| 'info' |
+
+### Data Display & Tables
+
+| Component | Import Path | Purpose | Key Props |
+|-----------|-------------|---------|-----------|
+| **DataTable** | `@open-mercato/ui/backend/DataTable` | Feature-rich table with sorting, filtering, pagination, export, perspectives | `columns`, `data`, `filters`, `pagination`, `perspective`, `onRowClick` |
+| **TruncatedCell** | `@open-mercato/ui/backend/TruncatedCell` | Table cell with text truncation and tooltip | `value`, `maxWidth` |
+| **EmptyState** | `@open-mercato/ui/backend/EmptyState` | Empty state placeholder | `title`, `description`, `action`, `icon` |
+| **RowActions** | `@open-mercato/ui/backend/RowActions` | Context menu for row actions | `items: {label, href?, onSelect?, destructive?}[]` |
+| **FilterBar** | `@open-mercato/ui/backend/FilterBar` | Search and filter UI bar | `filters`, `values`, `onApply`, `onClear` |
+| **ValueIcons** | `@open-mercato/ui/backend/ValueIcons` | `BooleanIcon`, `EnumBadge`, `useSeverityPreset()` | - |
+
+### Forms
+
+| Component | Import Path | Purpose | Key Props |
+|-----------|-------------|---------|-----------|
+| **CrudForm** | `@open-mercato/ui/backend/CrudForm` | Complete CRUD form with field registry, groups, custom fields, validation | `fields`, `groups`, `initialValues`, `onSubmit`, `schema`, `embedded`, `extraActions` |
+| **JsonBuilder** | `@open-mercato/ui/backend/JsonBuilder` | Interactive JSON editor with "Raw JSON" and "Builder" tabs | `value`, `onChange`, `disabled` |
+| **JsonDisplay** | `@open-mercato/ui/backend/JsonDisplay` | Read-only JSON viewer with expand/collapse | `data`, `title`, `maxInitialDepth`, `showCopy` |
+
+### Input Components (`@open-mercato/ui/backend/inputs/*`)
+
+| Component | Import Path | Purpose | Key Props |
+|-----------|-------------|---------|-----------|
+| **TagsInput** | `@open-mercato/ui/backend/inputs/TagsInput` | Multi-tag input with suggestions | `value`, `onChange`, `placeholder`, `suggestions` |
+| **ComboboxInput** | `@open-mercato/ui/backend/inputs/ComboboxInput` | Searchable dropdown (single value) | `value`, `onChange`, `options`, `placeholder` |
+| **PhoneNumberField** | `@open-mercato/ui/backend/inputs/PhoneNumberField` | Phone input with formatting | `value`, `onChange`, `checkDuplicate` |
+| **LookupSelect** | `@open-mercato/ui/backend/inputs/LookupSelect` | Async lookup/search select | `value`, `onChange`, `onSearch`, `renderItem` |
+| **SwitchableMarkdownInput** | `@open-mercato/ui/backend/inputs/SwitchableMarkdownInput` | Text/markdown toggle input | `value`, `onChange`, `placeholder` |
+
+### Detail Page Components (`@open-mercato/ui/backend/detail/*`)
+
+| Component | Import Path | Purpose | Key Props |
+|-----------|-------------|---------|-----------|
+| **DetailFieldsSection** | `@open-mercato/ui/backend/detail/DetailFieldsSection` | Entity field display with inline editing | `fields`, `entity`, `onUpdate` |
+| **InlineTextEditor** | `@open-mercato/ui/backend/detail/InlineEditors` | Click-to-edit text field | `value`, `onSave`, `label` |
+| **InlineMultilineEditor** | `@open-mercato/ui/backend/detail/InlineEditors` | Click-to-edit textarea | `value`, `onSave`, `label` |
+| **InlineSelectEditor** | `@open-mercato/ui/backend/detail/InlineEditors` | Click-to-edit select | `value`, `onSave`, `options`, `label` |
+| **NotesSection** | `@open-mercato/ui/backend/detail/NotesSection` | Notes/comments section with markdown | `notes`, `onAdd`, `onUpdate`, `onDelete` |
+| **TagsSection** | `@open-mercato/ui/backend/detail/TagsSection` | Tag management section | `tags`, `onAdd`, `onRemove`, `suggestions` |
+| **CustomDataSection** | `@open-mercato/ui/backend/detail/CustomDataSection` | Custom fields display | `data`, `fieldDefinitions` |
+| **LoadingMessage** | `@open-mercato/ui/backend/detail` | Loading state with spinner | `message` |
+| **ErrorMessage** | `@open-mercato/ui/backend/detail` | Error alert with action | `title`, `description`, `action` |
+| **TabEmptyState** | `@open-mercato/ui/backend/detail` | Empty state for tabs | `message`, `action` |
+
+## BACKEND UTILITIES (`@open-mercato/ui/backend/utils/*`)
+
+| Utility | Import Path | Purpose | Key Exports |
+|---------|-------------|---------|-------------|
+| **apiCall** | `@open-mercato/ui/backend/utils/apiCall` | HTTP client with auth | `apiCall`, `apiCallOrThrow`, `readApiResultOrThrow` |
+| **api** | `@open-mercato/ui/backend/utils/api` | Low-level API utils | `apiFetch` |
+| **crud** | `@open-mercato/ui/backend/utils/crud` | CRUD operation helpers | `createCrud`, `updateCrud`, `deleteCrud` |
+| **serverErrors** | `@open-mercato/ui/backend/utils/serverErrors` | Error mapping | `mapCrudServerErrorToFormErrors`, `createCrudFormError`, `raiseCrudError` |
+| **customFieldValues** | `@open-mercato/ui/backend/utils/customFieldValues` | Custom field value helpers | `collectCustomFieldValues`, `normalizeCustomFieldSubmitValue` |
+| **customFieldDefs** | `@open-mercato/ui/backend/utils/customFieldDefs` | Field definition fetching | `useCustomFieldDefinitions` |
+| **customFieldForms** | `@open-mercato/ui/backend/utils/customFieldForms` | Form field generation | `buildCustomFieldFormFields` |
+| **customFieldColumns** | `@open-mercato/ui/backend/utils/customFieldColumns` | Column builders | `buildCustomFieldColumns` |
+| **customFieldFilters** | `@open-mercato/ui/backend/utils/customFieldFilters` | Filter definitions | `useCustomFieldFilters` |
+
+## Common Usage Patterns
+
+### Flash Messages
+```tsx
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
+
+flash('Record saved successfully', 'success')
+flash('Failed to save record', 'error')
+// Types: 'success' | 'error' | 'warning' | 'info'
+```
+
+### DataTable with Filters
+```tsx
+import { DataTable } from '@open-mercato/ui/backend/DataTable'
+import type { FilterDef, FilterValues } from '@open-mercato/ui/backend/FilterBar'
+
+const filters: FilterDef[] = [
+  { id: 'search', type: 'text', label: 'Search', placeholder: 'Search...' },
+  { id: 'status', type: 'select', label: 'Status', options: [...] },
+]
+
+<DataTable
+  title="Items"
+  columns={columns}
+  data={data}
+  filters={filters}
+  filterValues={filterValues}
+  onFiltersApply={handleFiltersApply}
+  onFiltersClear={handleFiltersClear}
+  pagination={{ page, pageSize, total, totalPages, onPageChange }}
+  onRowClick={(row) => router.push(`/items/${row.id}`)}
+/>
+```
+
+### CrudForm
+```tsx
+import { CrudForm, type CrudField, type CrudFormGroup } from '@open-mercato/ui/backend/CrudForm'
+
+const fields: CrudField[] = [
+  { id: 'name', label: 'Name', type: 'text', required: true },
+  { id: 'description', label: 'Description', type: 'textarea' },
+  { id: 'status', label: 'Status', type: 'select', options: [...] },
+  { id: 'config', label: 'Config', type: 'custom', component: (props) => <JsonBuilder {...props} /> },
+]
+
+const groups: CrudFormGroup[] = [
+  { id: 'basic', title: 'Basic Info', column: 1, fields: ['name', 'description'] },
+  { id: 'settings', title: 'Settings', column: 1, fields: ['status', 'config'] },
+]
+
+<CrudForm
+  title="Create Item"
+  fields={fields}
+  groups={groups}
+  initialValues={{}}
+  onSubmit={handleSubmit}
+  submitLabel="Save"
+  embedded={true}  // For use inside dialogs
+  extraActions={<Button onClick={handleDelete}>Delete</Button>}
+/>
+```
+
+### Dialog with Form
+```tsx
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@open-mercato/ui/primitives/dialog'
+import { CrudForm } from '@open-mercato/ui/backend/CrudForm'
+
+<Dialog open={isOpen} onOpenChange={onClose}>
+  <DialogContent className="sm:max-w-2xl [&_.grid]:!grid-cols-1">
+    <DialogHeader>
+      <DialogTitle>Edit Item</DialogTitle>
+    </DialogHeader>
+    <CrudForm
+      fields={fields}
+      groups={groups}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      embedded={true}
+      submitLabel="Save"
+    />
+  </DialogContent>
+</Dialog>
+```
+
+### Detail Page with Inline Editing
+```tsx
+import { DetailFieldsSection, LoadingMessage, ErrorMessage } from '@open-mercato/ui/backend/detail'
+
+if (isLoading) return <LoadingMessage message="Loading..." />
+if (error) return <ErrorMessage title="Error" description={error.message} />
+
+<DetailFieldsSection
+  fields={[
+    { id: 'name', label: 'Name', type: 'text' },
+    { id: 'status', label: 'Status', type: 'select', options: [...] },
+  ]}
+  entity={entity}
+  onUpdate={handleUpdate}
+/>
+```
+
+### API Calls
+```tsx
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { createCrud, updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
+
+// Generic API call
+const result = await apiCall<ResponseType>('/api/endpoint', { method: 'POST', body: JSON.stringify(data) })
+if (result.ok) {
+  // result.result contains the parsed JSON response
+}
+
+// CRUD operations
+const created = await createCrud<ItemType>('module/items', payload)
+const updated = await updateCrud<ItemType>('module/items', id, payload)
+const deleted = await deleteCrud('module/items', id)
+```
+
+## Important Notes
+
+1. **Always use `flash()` for notifications** - Don't use `alert()` or custom toast implementations
+2. **Use `CrudForm` for forms** - Provides consistent validation, field rendering, and keyboard shortcuts
+3. **Use `DataTable` for lists** - Includes filtering, sorting, pagination, export, and perspectives
+4. **Use `JsonBuilder` for JSON editing** - Provides both raw JSON and visual builder modes
+5. **Dialog forms need `embedded={true}`** - And add `[&_.grid]:!grid-cols-1` to DialogContent for single-column layout
+6. **Support Cmd/Ctrl+Enter and Escape** - All dialogs should support these keyboard shortcuts


### PR DESCRIPTION
  Added Agent Skills Framework                                                                                                                                                          
                                                                                                                                                                                        
  Introduces a unified skills directory (.ai/skills/) containing reusable AI agent skills for both Claude Code and Codex.                                                               
                                                                                                                                                                                        
  Added Files                                                                                                                                                                           
                                                                                                                                                                                        
  .ai/skills/                                                                                                                                                                           
  ├── README.md                           # Comprehensive documentation                                                                                                                 
  ├── claude/                                                                                                                                                                           
  │   └── backend-ui-design.md            # Claude Code format                                                                                                                          
  └── codex/                                                                                                                                                                            
      └── backend-ui-design/                                                                                                                                                            
          ├── SKILL.md                    # Codex format                                                                                                                                
          └── references/                                                                                                                                                               
              └── ui-components.md        # Component reference                                                                                                                         
                                                                                                                                                                                        
  What's Included                                                                                                                                                                       
                                                                                                                                                                                        
  - backend-ui-design skill: Guides consistent backend/admin UI development using @open-mercato/ui components (CrudForm, DataTable, flash(), etc.)                                      
  - README documentation: Installation instructions, usage guides, format comparison, and best practices for both tools                                                                 
                                                                                                                                                                                        
  Installation                                                                                                                                                                          
                                                                                                                                                                                        
  # Claude Code                                                                                                                                                                         
  ln -s ../.ai/skills/claude .claude/skills                                                                                                                                             
                                                                                                                                                                                        
  # Codex                                                                                                                                                                               
  ln -s ../.ai/skills/codex .codex/skills                                                                                                                                               
                                                                                                                                                                                        
  Usage                                                                                                                                                                                 
                                                                                                                                                                                        
  - Claude Code: /backend-ui-design                                                                                                                                                     
  - Codex: $backend-ui-design   

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

