### PR TITLE
feat(customers): SPEC-028 Phase 1 — pipelines data layer

### DIFF
--- a/packages/core/src/modules/customers/data/entities.ts
+++ b/packages/core/src/modules/customers/data/entities.ts
@@ -278,6 +278,12 @@ export class CustomerDeal {
   @Property({ name: 'pipeline_stage', type: 'text', nullable: true })
   pipelineStage?: string | null
 
+  @Property({ name: 'pipeline_id', type: 'uuid', nullable: true })
+  pipelineId?: string | null
+
+  @Property({ name: 'pipeline_stage_id', type: 'uuid', nullable: true })
+  pipelineStageId?: string | null
+
   @Property({ name: 'value_amount', type: 'numeric', precision: 14, scale: 2, nullable: true })
   valueAmount?: string | null
 
@@ -676,4 +682,62 @@ export class CustomerTodoLink {
 
   @ManyToOne(() => CustomerEntity, { fieldName: 'entity_id' })
   entity!: CustomerEntity
+}
+
+@Entity({ tableName: 'customer_pipelines' })
+@Index({ name: 'customer_pipelines_org_tenant_idx', properties: ['organizationId', 'tenantId'] })
+export class CustomerPipeline {
+  [OptionalProps]?: 'isDefault' | 'createdAt' | 'updatedAt'
+
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
+  id!: string
+
+  @Property({ name: 'organization_id', type: 'uuid' })
+  organizationId!: string
+
+  @Property({ name: 'tenant_id', type: 'uuid' })
+  tenantId!: string
+
+  @Property({ type: 'text' })
+  name!: string
+
+  @Property({ name: 'is_default', type: 'boolean', default: false })
+  isDefault: boolean = false
+
+  @Property({ name: 'created_at', type: Date, onCreate: () => new Date() })
+  createdAt: Date = new Date()
+
+  @Property({ name: 'updated_at', type: Date, onUpdate: () => new Date() })
+  updatedAt: Date = new Date()
+}
+
+@Entity({ tableName: 'customer_pipeline_stages' })
+@Index({ name: 'customer_pipeline_stages_org_tenant_idx', properties: ['organizationId', 'tenantId'] })
+@Index({ name: 'customer_pipeline_stages_pipeline_position_idx', properties: ['pipelineId', 'position'] })
+export class CustomerPipelineStage {
+  [OptionalProps]?: 'position' | 'createdAt' | 'updatedAt'
+
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
+  id!: string
+
+  @Property({ name: 'organization_id', type: 'uuid' })
+  organizationId!: string
+
+  @Property({ name: 'tenant_id', type: 'uuid' })
+  tenantId!: string
+
+  @Property({ name: 'pipeline_id', type: 'uuid' })
+  pipelineId!: string
+
+  @Property({ type: 'text' })
+  name!: string
+
+  @Property({ type: 'int', default: 0 })
+  position: number = 0
+
+  @Property({ name: 'created_at', type: Date, onCreate: () => new Date() })
+  createdAt: Date = new Date()
+
+  @Property({ name: 'updated_at', type: Date, onUpdate: () => new Date() })
+  updatedAt: Date = new Date()
 }

--- a/packages/core/src/modules/customers/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/customers/migrations/.snapshot-open-mercato.json
@@ -71,6 +71,24 @@
           "nullable": true,
           "mappedType": "text"
         },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "uuid"
+        },
+        "pipeline_stage_id": {
+          "name": "pipeline_stage_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "uuid"
+        },
         "value_amount": {
           "name": "value_amount",
           "type": "numeric(14,2)",
@@ -707,7 +725,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_deals",
-          "createForeignKeyConstraint": true,
           "updateRule": "cascade"
         },
         "customer_deal_people_person_entity_id_foreign": {
@@ -720,7 +737,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_entities",
-          "createForeignKeyConstraint": true,
           "updateRule": "cascade"
         }
       },
@@ -824,7 +840,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_deals",
-          "createForeignKeyConstraint": true,
           "updateRule": "cascade"
         },
         "customer_deal_companies_company_entity_id_foreign": {
@@ -837,7 +852,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_entities",
-          "createForeignKeyConstraint": true,
           "updateRule": "cascade"
         }
       },
@@ -1024,7 +1038,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_entities",
-          "createForeignKeyConstraint": true,
           "updateRule": "cascade"
         }
       },
@@ -1192,7 +1205,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_entities",
-          "createForeignKeyConstraint": true,
           "updateRule": "cascade"
         },
         "customer_comments_deal_id_foreign": {
@@ -1205,7 +1217,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_deals",
-          "createForeignKeyConstraint": true,
           "deleteRule": "set null",
           "updateRule": "cascade"
         }
@@ -1435,7 +1446,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_entities",
-          "createForeignKeyConstraint": true,
           "updateRule": "cascade"
         }
       },
@@ -1633,7 +1643,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_entities",
-          "createForeignKeyConstraint": true,
           "updateRule": "cascade"
         },
         "customer_activities_deal_id_foreign": {
@@ -1646,7 +1655,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_deals",
-          "createForeignKeyConstraint": true,
           "deleteRule": "set null",
           "updateRule": "cascade"
         }
@@ -1859,7 +1867,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_entities",
-          "createForeignKeyConstraint": true,
           "updateRule": "cascade"
         },
         "customer_people_company_entity_id_foreign": {
@@ -1872,11 +1879,228 @@
             "id"
           ],
           "referencedTableName": "public.customer_entities",
-          "createForeignKeyConstraint": true,
           "deleteRule": "set null",
           "updateRule": "cascade"
         }
       },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "gen_random_uuid()",
+          "mappedType": "uuid"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "mappedType": "datetime"
+        }
+      },
+      "name": "customer_pipelines",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "customer_pipelines_org_tenant_idx",
+          "columnNames": [
+            "organization_id",
+            "tenant_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "customer_pipelines_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "gen_random_uuid()",
+          "mappedType": "uuid"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "position": {
+          "name": "position",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "0",
+          "mappedType": "integer"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "mappedType": "datetime"
+        }
+      },
+      "name": "customer_pipeline_stages",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "customer_pipeline_stages_pipeline_position_idx",
+          "columnNames": [
+            "pipeline_id",
+            "position"
+          ],
+          "composite": true,
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "customer_pipeline_stages_org_tenant_idx",
+          "columnNames": [
+            "organization_id",
+            "tenant_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "customer_pipeline_stages_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
       "nativeEnums": {}
     },
     {
@@ -2203,7 +2427,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_tags",
-          "createForeignKeyConstraint": true,
           "updateRule": "cascade"
         },
         "customer_tag_assignments_entity_id_foreign": {
@@ -2216,7 +2439,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_entities",
-          "createForeignKeyConstraint": true,
           "updateRule": "cascade"
         }
       },
@@ -2359,7 +2581,6 @@
             "id"
           ],
           "referencedTableName": "public.customer_entities",
-          "createForeignKeyConstraint": true,
           "updateRule": "cascade"
         }
       },

--- a/packages/core/src/modules/customers/migrations/Migration20260218191730.ts
+++ b/packages/core/src/modules/customers/migrations/Migration20260218191730.ts
@@ -1,0 +1,78 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260218191730 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table "customer_pipelines" ("id" uuid not null default gen_random_uuid(), "organization_id" uuid not null, "tenant_id" uuid not null, "name" text not null, "is_default" boolean not null default false, "created_at" timestamptz not null, "updated_at" timestamptz not null, constraint "customer_pipelines_pkey" primary key ("id"));`);
+    this.addSql(`create index "customer_pipelines_org_tenant_idx" on "customer_pipelines" ("organization_id", "tenant_id");`);
+
+    this.addSql(`create table "customer_pipeline_stages" ("id" uuid not null default gen_random_uuid(), "organization_id" uuid not null, "tenant_id" uuid not null, "pipeline_id" uuid not null, "name" text not null, "position" int not null default 0, "created_at" timestamptz not null, "updated_at" timestamptz not null, constraint "customer_pipeline_stages_pkey" primary key ("id"));`);
+    this.addSql(`create index "customer_pipeline_stages_pipeline_position_idx" on "customer_pipeline_stages" ("pipeline_id", "position");`);
+    this.addSql(`create index "customer_pipeline_stages_org_tenant_idx" on "customer_pipeline_stages" ("organization_id", "tenant_id");`);
+
+    this.addSql(`alter table "customer_deals" add column "pipeline_id" uuid null, add column "pipeline_stage_id" uuid null;`);
+
+    // Data migration: backfill existing deals from legacy pipeline_stage (text) → pipeline_id + pipeline_stage_id
+    this.addSql(`
+      DO $$
+      DECLARE
+        r             RECORD;
+        v_pipeline_id UUID;
+        v_stage_id    UUID;
+        v_pos         INT;
+        stage_values  TEXT[] := ARRAY[
+          'opportunity','marketing_qualified_lead','sales_qualified_lead',
+          'offering','negotiations','win','loose','stalled'
+        ];
+        stage_labels  TEXT[] := ARRAY[
+          'Opportunity','Marketing Qualified Lead','Sales Qualified Lead',
+          'Offering','Negotiations','Win','Loose','Stalled'
+        ];
+      BEGIN
+        FOR r IN (
+          SELECT DISTINCT organization_id, tenant_id FROM customer_deals
+          WHERE pipeline_stage IS NOT NULL AND pipeline_stage <> '' AND pipeline_id IS NULL
+        ) LOOP
+          SELECT id INTO v_pipeline_id FROM customer_pipelines
+          WHERE organization_id = r.organization_id AND tenant_id = r.tenant_id AND is_default = true LIMIT 1;
+
+          IF v_pipeline_id IS NULL THEN
+            INSERT INTO customer_pipelines (id, organization_id, tenant_id, name, is_default, created_at, updated_at)
+            VALUES (gen_random_uuid(), r.organization_id, r.tenant_id, 'Default Pipeline', true, now(), now())
+            RETURNING id INTO v_pipeline_id;
+          END IF;
+
+          IF NOT EXISTS (SELECT 1 FROM customer_pipeline_stages WHERE pipeline_id = v_pipeline_id) THEN
+            FOR v_pos IN 1..array_length(stage_labels, 1) LOOP
+              INSERT INTO customer_pipeline_stages (id, organization_id, tenant_id, pipeline_id, name, position, created_at, updated_at)
+              VALUES (gen_random_uuid(), r.organization_id, r.tenant_id, v_pipeline_id, stage_labels[v_pos], v_pos - 1, now(), now());
+            END LOOP;
+          END IF;
+
+          FOR v_pos IN 1..array_length(stage_values, 1) LOOP
+            SELECT id INTO v_stage_id FROM customer_pipeline_stages
+            WHERE pipeline_id = v_pipeline_id AND name = stage_labels[v_pos] LIMIT 1;
+            IF v_stage_id IS NOT NULL THEN
+              UPDATE customer_deals
+              SET pipeline_id = v_pipeline_id, pipeline_stage_id = v_stage_id
+              WHERE organization_id = r.organization_id AND tenant_id = r.tenant_id
+                AND pipeline_id IS NULL
+                AND pipeline_stage IN (stage_values[v_pos], stage_labels[v_pos]);
+            END IF;
+          END LOOP;
+
+          -- deals with unknown stage value: assign to pipeline, stage stays NULL
+          UPDATE customer_deals SET pipeline_id = v_pipeline_id
+          WHERE organization_id = r.organization_id AND tenant_id = r.tenant_id AND pipeline_id IS NULL;
+        END LOOP;
+      END $$;
+    `);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "customer_deals" drop column "pipeline_id", drop column "pipeline_stage_id";`);
+    this.addSql(`drop table if exists "customer_pipeline_stages";`);
+    this.addSql(`drop table if exists "customer_pipelines";`);
+  }
+
+}

--- a/packages/core/src/modules/customers/setup.ts
+++ b/packages/core/src/modules/customers/setup.ts
@@ -1,11 +1,12 @@
 import type { ModuleSetupConfig } from '@open-mercato/shared/modules/setup'
-import { seedCustomerDictionaries, seedCurrencyDictionary, seedCustomerExamples } from './cli'
+import { seedCustomerDictionaries, seedCurrencyDictionary, seedCustomerExamples, seedDefaultPipeline } from './cli'
 
 export const setup: ModuleSetupConfig = {
   seedDefaults: async (ctx) => {
     const scope = { tenantId: ctx.tenantId, organizationId: ctx.organizationId }
     await seedCustomerDictionaries(ctx.em, scope)
     await seedCurrencyDictionary(ctx.em, scope)
+    await seedDefaultPipeline(ctx.em, scope)
   },
 
   seedExamples: async (ctx) => {

--- a/turbo.json
+++ b/turbo.json
@@ -43,6 +43,18 @@
     "initialize": {
       "cache": false,
       "outputs": []
+    },
+    "db:generate": {
+      "cache": false,
+      "outputs": []
+    },
+    "db:migrate": {
+      "cache": false,
+      "outputs": []
+    },
+    "db:greenfield": {
+      "cache": false,
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Summary

Implements Phase 1 (data layer only) of SPEC-028: Multiple Sales Pipelines.

This PR introduces first-class `CustomerPipeline` and `CustomerPipelineStage` entities and links them to `CustomerDeal`. The existing `pipeline_stage` free-text field is preserved for backward compatibility, and a migration safely backfills the new relational references.

The goal of this phase is to establish a clean and extensible data model that future phases (commands, API, UI) can build on, while maintaining full compatibility with existing data.

This PR intentionally limits scope to the data layer only to keep review focused and safe.

---

## Changes

**Entities**

- Add `CustomerPipeline` entity
- Add `CustomerPipelineStage` entity
- Add nullable `pipelineId` and `pipelineStageId` to `CustomerDeal`
- Preserve legacy `pipelineStage` text field (deprecated, not removed)

**Migration**

- Create `customer_pipelines` table
- Create `customer_pipeline_stages` table
- Alter `customer_deals` to add relational columns
- Backfill existing deals from legacy `pipeline_stage`
- Implement safe rollback in `down()` method

**Initialization / Seeding**

- Add `seedDefaultPipeline()` function
- Creates default pipeline with 8 default stages
- Idempotent and safe to run multiple times
- Integrated into existing initialization flow

**Infrastructure**

- Add missing `db:generate`, `db:migrate`, and `db:greenfield` tasks to `turbo.json`

---

## Specification

**Does a spec exist for this feature/module?**

- [x] Yes

**Spec file path:**

.ai/specs/SPEC-028-2026-02-16-multiple-sales-pipelines.md

---

## Testing

Commands executed successfully:

```bash
yarn build:packages
yarn db:migrate
yarn initialize
```

Manual verification:

- `customer_pipelines`: 1 row, `is_default = true`
- `customer_pipeline_stages`: 8 rows, `position` 0–7 (Opportunity → Stalled)
- `customer_deals` with legacy `pipeline_stage`: `pipeline_id` + `pipeline_stage_id` populated
- Re-running `yarn initialize`: no duplicate pipelines created (idempotency confirmed)
---

## Design scope

This PR includes only the data layer.

Out of scope (planned for next phases):

- commands
- API endpoints
- UI integration
- business logic changes

This separation is intentional to keep the PR focused and reviewable.

---

## Feedback requested

This is my first contribution in this area of the codebase, and I want to ensure the approach aligns with Open Mercato’s architectural and domain patterns.

I intentionally limited this PR to Phase 1 so that the data model, migration strategy, and seeding approach can be reviewed and validated before proceeding further.

I would greatly appreciate feedback on:

- entity design and relationships
- migration structure and backfill approach
- seeding and initialization integration
- naming conventions and module structure

If anything should be structured differently, I’m happy to adjust the implementation before moving on to Phase 2.

My goal is to contribute this feature in a way that aligns with the project’s conventions and long-term direction.

---

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if required.
- [ ] I added or adjusted tests if required. <!-- Integration tests deferred to Phase 2 per SPEC-028 phasing -->
- [x] Spec exists and is referenced.

---

## Linked issues

Part of #561 — SPEC-028 Multiple Sales Pipelines

Phase 1: Data layer (this PR)  
Phase 2: Commands and API (planned next, pending feedback)  
Phase 3: UI integration (planned after Phase 2)