### PR TITLE
fix: acl for admin and employee roles for translations module granted

### DIFF
--- a/packages/core/src/modules/auth/__tests__/cli-setup-acl.test.ts
+++ b/packages/core/src/modules/auth/__tests__/cli-setup-acl.test.ts
@@ -28,6 +28,7 @@ const testModules: Module[] = [
   { id: 'planner', setup: { defaultRoleFeatures: { admin: ['planner.*'], employee: ['planner.view'] } } },
   { id: 'resources', setup: { defaultRoleFeatures: { admin: ['resources.*'] } } },
   { id: 'staff', setup: { defaultRoleFeatures: { admin: ['staff.*', 'staff.leave_requests.manage'], employee: ['staff.leave_requests.send', 'staff.my_availability.view', 'staff.my_availability.manage', 'staff.my_leave_requests.view', 'staff.my_leave_requests.send'] } } },
+  { id: 'translations', setup: { defaultRoleFeatures: { admin: ['translations.*'], employee: ['translations.view', 'translations.manage'] } } },
   { id: 'example', setup: { defaultRoleFeatures: { admin: ['example.*'], employee: ['example.*', 'example.widgets.*'] } } },
 ]
 registerModules(testModules)
@@ -118,6 +119,7 @@ describe('auth CLI setup seeds ACLs', () => {
       'api_keys.*',
       'perspectives.use',
       'perspectives.role_defaults',
+      'translations.*',
     ]))
     expect(adminAcl?.featuresJson).not.toContain('directory.organizations.*')
 
@@ -139,6 +141,8 @@ describe('auth CLI setup seeds ACLs', () => {
       'dashboards.configure',
       'audit_logs.undo_self',
       'perspectives.use',
+      'translations.view',
+      'translations.manage',
     ]))
   })
 })

--- a/packages/core/src/modules/translations/setup.ts
+++ b/packages/core/src/modules/translations/setup.ts
@@ -3,7 +3,7 @@ import type { ModuleSetupConfig } from '@open-mercato/shared/modules/setup'
 export const setup: ModuleSetupConfig = {
   defaultRoleFeatures: {
     admin: ['translations.*'],
-    employee: ['translations.view'],
+    employee: ['translations.view', 'translations.manage'],
   },
 }
 


### PR DESCRIPTION
This pull request updates the default role-based access control (RBAC) features for the `translations` module, expanding the permissions granted to the `employee` role. Employees now have both `translations.view` and `translations.manage` permissions, allowing them to edit and delete translations (but not manage locales). The changes are reflected in module setup, test seeds, and integration tests to ensure correct authorization behavior.

**RBAC and Permissions Updates:**

* Updated `translations` module setup to grant `employee` both `translations.view` and `translations.manage` permissions by default, instead of just `translations.view`. (`packages/core/src/modules/translations/setup.ts`, [[1]](diffhunk://#diff-5c89b9c1c3af9bc3810ea05900f0336edad5b164cdf0b10284057a92f3963017R31) [[2]](diffhunk://#diff-f6307c48da50460575d962fd411d69403a1d647d0463608ff8638a58e4b4ec8eL6-R6)
* Adjusted ACL seed data and tests to reflect the expanded `employee` permissions for translations, ensuring that both admin and employee roles have the correct features. (`packages/core/src/modules/auth/__tests__/cli-setup-acl.test.ts`, [[1]](diffhunk://#diff-5c89b9c1c3af9bc3810ea05900f0336edad5b164cdf0b10284057a92f3963017R31) [[2]](diffhunk://#diff-5c89b9c1c3af9bc3810ea05900f0336edad5b164cdf0b10284057a92f3963017R122) [[3]](diffhunk://#diff-5c89b9c1c3af9bc3810ea05900f0336edad5b164cdf0b10284057a92f3963017R144-R145)

**Integration Test Enhancements:**

* Updated integration tests for the `translations` module to verify that employees can now PUT (edit) and DELETE translations, not just view them. Test descriptions and expectations were changed to match the new permissions. (`packages/core/src/modules/translations/__integration__/TC-TRANS-008.spec.ts`, [[1]](diffhunk://#diff-3ee1cb959b73a50c6a494ce05b47eb106b996ad4800c7687b1265553f15e04b4L11-R16) [[2]](diffhunk://#diff-3ee1cb959b73a50c6a494ce05b47eb106b996ad4800c7687b1265553f15e04b4L25-R25) [[3]](diffhunk://#diff-3ee1cb959b73a50c6a494ce05b47eb106b996ad4800c7687b1265553f15e04b4L118-R118) [[4]](diffhunk://#diff-3ee1cb959b73a50c6a494ce05b47eb106b996ad4800c7687b1265553f15e04b4L154-R154) [[5]](diffhunk://#diff-3ee1cb959b73a50c6a494ce05b47eb106b996ad4800c7687b1265553f15e04b4L166-R176) [[6]](diffhunk://#diff-3ee1cb959b73a50c6a494ce05b47eb106b996ad4800c7687b1265553f15e04b4L191-R193)