### PR TITLE
Add dedicated develop-branch release workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,8 +1,6 @@
 name: Canary Release
 
 on:
-  push:
-    branches: [develop]
   pull_request:
     branches: [main, develop]
 
@@ -14,8 +12,8 @@ jobs:
   canary:
     name: Publish Canary
     runs-on: ubuntu-latest
-    # Only run on push to develop, or PRs from the same repo (not forks)
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    # Only run for PRs from the same repo (not forks)
+    if: github.event.pull_request.head.repo.full_name == github.repository
     env:
       YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,42 @@
+name: Develop Release
+
+on:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+jobs:
+  develop:
+    name: Publish Develop
+    runs-on: ubuntu-latest
+    env:
+      YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Configure npm authentication
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          echo "access=public" >> .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Release develop
+        run: ./scripts/release-develop.sh

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "registry:setup-user": "./scripts/registry/setup-user.sh",
     "registry:publish": "./scripts/registry/publish.sh",
     "release:canary": "./scripts/release-canary.sh",
+    "release:develop": "./scripts/release-develop.sh",
     "release:patch": "./scripts/release-patch.sh",
     "release:minor": "./scripts/release-minor.sh",
     "release:major": "./scripts/release-major.sh",

--- a/scripts/release-develop.sh
+++ b/scripts/release-develop.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Develop release: version with commit hash, build, and publish
+set -euo pipefail
+
+COMMIT_HASH=$(git rev-parse --short=10 HEAD)
+
+# Get base version from shared package, bump patch, add develop suffix
+BASE_VERSION=$(jq -r '.version' packages/shared/package.json | sed -E 's/-.*$//')
+IFS='.' read -r major minor patch <<< "$BASE_VERSION"
+DEVELOP_VERSION="${major}.${minor}.$((patch + 1))-develop-${COMMIT_HASH}"
+
+echo "==> Setting version to ${DEVELOP_VERSION}..."
+yarn workspaces foreach -A --no-private version "$DEVELOP_VERSION"
+echo "==> Version set successfully"
+
+echo "==> Building packages..."
+yarn build:packages
+echo "==> Build completed"
+
+echo "==> Generating..."
+yarn generate
+echo "==> Generate completed"
+
+echo "==> Rebuilding packages with generated files..."
+yarn build:packages
+echo "==> Rebuild completed"
+
+echo "==> Publishing packages..."
+yarn workspaces foreach -Av --topological --no-private npm publish --access public
+echo "==> Publish completed"
+
+echo "==> Done!"


### PR DESCRIPTION
## Summary

- Add new `develop.yml` workflow that triggers on push to `develop` and publishes packages with a `-develop-{hash}` version suffix
- Remove push-to-develop trigger from `canary.yml`, keeping it PR-only
- Add `release:develop` script to `package.json`

## Test plan

- [ ] Verify `develop.yml` triggers only on push to `develop`
- [ ] Verify `canary.yml` triggers only on PRs to `main`/`develop`
- [ ] Verify `release-develop.sh` produces versions with `-develop-{hash}` suffix
- [ ] Verify `yarn release:develop` runs the new script

🤖 Generated with [Claude Code](https://claude.com/claude-code)