### PR TITLE
fix(cli): handle OpenAPI generator paths correctly on Windows

### DIFF
--- a/packages/cli/src/lib/generators/__tests__/openapi.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/openapi.test.ts
@@ -1,0 +1,22 @@
+describe('resolveOpenApiGeneratorProjectRoot', () => {
+  it('resolves the monorepo root from a POSIX module URL', async () => {
+    const { resolveOpenApiGeneratorProjectRoot } = await import('../openapi-paths')
+
+    expect(
+      resolveOpenApiGeneratorProjectRoot(
+        'file:///Users/test/open-mercato/packages/cli/src/lib/generators/openapi.ts'
+      )
+    ).toBe('/Users/test/open-mercato')
+  })
+
+  it('resolves the monorepo root from a Windows module URL', async () => {
+    const { resolveOpenApiGeneratorProjectRoot } = await import('../openapi-paths')
+
+    expect(
+      resolveOpenApiGeneratorProjectRoot(
+        'file:///C:/open-mercato/packages/cli/src/lib/generators/openapi.ts',
+        { windows: true }
+      )
+    ).toBe('C:\\open-mercato')
+  })
+})

--- a/packages/cli/src/lib/generators/openapi-paths.ts
+++ b/packages/cli/src/lib/generators/openapi-paths.ts
@@ -1,0 +1,16 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export function resolveOpenApiGeneratorProjectRoot(
+  moduleUrl: string,
+  options?: { windows?: boolean }
+): string {
+  const pathModule = options?.windows === undefined
+    ? path
+    : options.windows ? path.win32 : path.posix
+  const modulePath = options?.windows === undefined
+    ? fileURLToPath(moduleUrl)
+    : fileURLToPath(moduleUrl, { windows: options.windows })
+
+  return pathModule.resolve(pathModule.dirname(modulePath), '../../../../..')
+}

--- a/packages/cli/src/lib/generators/openapi.ts
+++ b/packages/cli/src/lib/generators/openapi.ts
@@ -9,6 +9,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import type { PackageResolver } from '../resolver'
+import { resolveOpenApiGeneratorProjectRoot } from './openapi-paths'
 import {
   calculateChecksum,
   readChecksumRecord,
@@ -537,10 +538,7 @@ export async function generateOpenApi(options: GenerateOpenApiOptions): Promise<
   }
 
   // Determine project root (cli package is at packages/cli/src/lib/generators/)
-  const projectRoot = path.resolve(
-    path.dirname(new URL(import.meta.url).pathname),
-    '../../../../..'
-  )
+  const projectRoot = resolveOpenApiGeneratorProjectRoot(import.meta.url)
 
   // Try esbuild bundle approach first — produces full requestBody/response schemas
   let doc: Record<string, any> | null = await generateOpenApiViaBundle(routes, projectRoot, quiet)


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Provide a concise description of the problem and the proposed solution.

## Changes

- bullet the key code or documentation updates

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
