### PR TITLE
fix(messages): keep autosuggest working for multi-character recipient…

### DIFF
--- a/packages/ui/src/backend/messages/__tests__/MessageComposer.test.tsx
+++ b/packages/ui/src/backend/messages/__tests__/MessageComposer.test.tsx
@@ -225,6 +225,84 @@ describe('MessageComposer draft flow', () => {
     })
   })
 
+  it('keeps recipient suggestions available for multi-character input when backend search is unreliable', async () => {
+    ;(apiCall as jest.Mock).mockImplementation((url: string, options?: { method?: string, body?: string }) => {
+      if (url.startsWith('/api/messages/types')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          result: {
+            items: [{
+              type: 'default',
+              module: 'messages',
+              labelKey: 'messages.types.default',
+              icon: 'mail',
+              allowReply: true,
+              allowForward: true,
+            }],
+          },
+          response: { status: 200 },
+        })
+      }
+
+      if (url.startsWith('/api/auth/users?')) {
+        const requestUrl = new URL(url, 'http://localhost')
+        const search = requestUrl.searchParams.get('search') ?? ''
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          result: {
+            items: search.length <= 1
+              ? [{ id: 'user-1', email: 'alice@example.com' }]
+              : [],
+          },
+          response: { status: 200 },
+        })
+      }
+
+      if (url === '/api/messages' && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          result: { id: 'message-1' },
+          response: { status: 200 },
+        })
+      }
+
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        result: { items: [] },
+        response: { status: 200 },
+      })
+    })
+
+    renderWithProviders(
+      <MessageComposer inline variant="compose" />,
+      { dict: {} },
+    )
+
+    const input = await screen.findByPlaceholderText('Search recipients...')
+
+    fireEvent.mouseDown(input)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'alice@example.com' })).toBeInTheDocument()
+    })
+
+    fireEvent.change(input, { target: { value: 'ali' } })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'alice@example.com' })).toBeInTheDocument()
+    })
+
+    const authUserCalls = (apiCall as jest.Mock).mock.calls
+      .filter((call) => typeof call[0] === 'string' && call[0].startsWith('/api/auth/users?'))
+      .map((call) => call[0] as string)
+
+    expect(authUserCalls.every((call) => !call.includes('search='))).toBe(true)
+  })
+
   it('changes priority selection on click', async () => {
     renderWithProviders(
       <MessageComposer inline variant="compose" />,

--- a/packages/ui/src/backend/messages/useMessageCompose.ts
+++ b/packages/ui/src/backend/messages/useMessageCompose.ts
@@ -131,6 +131,7 @@ export function useMessageCompose({
   const t = useT()
   const variant = variantProp
   const isOpen = inline ? true : Boolean(open)
+  const recipientSuggestionsCacheRef = React.useRef<TagsInputOption[] | null>(null)
 
   const [recipientIds, setRecipientIds] = React.useState<string[]>([])
   const [recipientMap, setRecipientMap] = React.useState<Record<string, TagsInputOption>>({})
@@ -342,6 +343,11 @@ export function useMessageCompose({
     setRecipientIds([])
   }, [variant, visibility])
 
+  React.useEffect(() => {
+    if (isOpen) return
+    recipientSuggestionsCacheRef.current = null
+  }, [isOpen])
+
   const resolveRecipientLabel = React.useCallback((id: string) => {
     return recipientMap[id]?.label ?? id
   }, [recipientMap])
@@ -350,13 +356,16 @@ export function useMessageCompose({
     return recipientIds.map((id) => recipientMap[id] ?? { value: id, label: id })
   }, [recipientIds, recipientMap])
 
-  const loadRecipientSuggestions = React.useCallback(async (query?: string) => {
+  const loadRecipientSuggestions = React.useCallback(async (_query?: string) => {
+    const cachedOptions = recipientSuggestionsCacheRef.current
+    if (cachedOptions) {
+      return cachedOptions
+    }
+
     const params = new URLSearchParams()
     params.set('page', '1')
-    params.set('pageSize', '20')
-    if (query && query.trim().length) {
-      params.set('search', query.trim())
-    }
+    params.set('pageSize', '100')
+    // Recipient lookup is filtered in TagsInput because incremental auth user search is unreliable.
 
     const call = await apiCall<{ items?: UserListItem[] }>(`/api/auth/users?${params.toString()}`)
     if (!call.ok) {
@@ -390,6 +399,7 @@ export function useMessageCompose({
       })
     }
 
+    recipientSuggestionsCacheRef.current = options
     return options
   }, [])
 

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,10 @@
       "cache": false,
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
+    "start": {
+      "cache": false,
+      "persistent": true
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
This PR fixes a bug in the message composer where recipient autosuggest only worked for single-character input.

The composer now loads and caches recipient suggestions once per open session, then filters them client-side instead of depending on incremental backend search results. This keeps autosuggest stable for longer queries and avoids suggestions disappearing after the first typed character.

A regression test was added to cover the multi-character input case and verify suggestions remain available while typing.