### PR TITLE
fix: harden wildcard audit permission checks

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -76,6 +76,8 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 
 **Rule**: Any feature-gated helper outside the core RBAC service must use the shared wildcard-aware matcher (`hasFeature` / `hasAllFeatures`) instead of ad hoc exact-match checks such as `features.includes(...)`, `set.has(...)`, or `every(...includes(...))`.
 
+**Additional rule**: Do not assume every `granted` feature array is normalized to exact requested ids. Some flows return exact feature-check responses, while others pass through stored wildcard ACLs or resolved feature snapshots. Runtime helpers must treat all granted-feature arrays as wildcard-capable input.
+
 **Applies to**: Navigation builders, injected menu filtering, notification dispatchers, mutation guards, command interceptors, and similar client/server ACL-driven registries.
 
 ## Always propagate structured conflict payload from `onBeforeSave` blockers

--- a/packages/ui/src/backend/__tests__/useAuditPermissions.test.tsx
+++ b/packages/ui/src/backend/__tests__/useAuditPermissions.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useAuditPermissions } from '../version-history/useAuditPermissions'
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+}))
+
+function Probe() {
+  const permissions = useAuditPermissions(true)
+
+  return (
+    <div>
+      <div data-testid="loading">{permissions.isLoading ? 'yes' : 'no'}</div>
+      <div data-testid="view-tenant">{permissions.canViewTenant ? 'yes' : 'no'}</div>
+      <div data-testid="undo-tenant">{permissions.canUndoTenant ? 'yes' : 'no'}</div>
+      <div data-testid="redo-tenant">{permissions.canRedoTenant ? 'yes' : 'no'}</div>
+    </div>
+  )
+}
+
+describe('useAuditPermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('accepts wildcard grants returned by the feature check', async () => {
+    ;(apiCall as jest.Mock).mockResolvedValue({
+      ok: true,
+      result: {
+        granted: ['audit_logs.*'],
+        userId: 'user-1',
+      },
+    })
+
+    render(<Probe />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('no')
+    })
+
+    expect(screen.getByTestId('view-tenant').textContent).toBe('yes')
+    expect(screen.getByTestId('undo-tenant').textContent).toBe('yes')
+    expect(screen.getByTestId('redo-tenant').textContent).toBe('yes')
+  })
+})

--- a/packages/ui/src/backend/version-history/useAuditPermissions.ts
+++ b/packages/ui/src/backend/version-history/useAuditPermissions.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from 'react'
+import { hasAllFeatures } from '@open-mercato/shared/lib/auth/featureMatch'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 
 const AUDIT_FEATURES = [
@@ -52,14 +53,14 @@ export function useAuditPermissions(enabled: boolean): AuditPermissions {
           body: JSON.stringify({ features: AUDIT_FEATURES }),
         })
         if (cancelled) return
-        const granted = new Set(res.result?.granted ?? [])
+        const granted = res.result?.granted ?? []
         setPermissions({
           currentUserId: res.result?.userId ?? null,
-          canViewTenant: granted.has('audit_logs.view_tenant'),
-          canUndoSelf: granted.has('audit_logs.undo_self'),
-          canUndoTenant: granted.has('audit_logs.undo_tenant'),
-          canRedoSelf: granted.has('audit_logs.redo_self'),
-          canRedoTenant: granted.has('audit_logs.redo_tenant'),
+          canViewTenant: hasAllFeatures(['audit_logs.view_tenant'], granted),
+          canUndoSelf: hasAllFeatures(['audit_logs.undo_self'], granted),
+          canUndoTenant: hasAllFeatures(['audit_logs.undo_tenant'], granted),
+          canRedoSelf: hasAllFeatures(['audit_logs.redo_self'], granted),
+          canRedoTenant: hasAllFeatures(['audit_logs.redo_tenant'], granted),
           isLoading: false,
         })
       } catch {


### PR DESCRIPTION
## Summary
- harden `useAuditPermissions` to evaluate granted ACLs with the shared wildcard-aware matcher instead of exact `Set.has(...)`
- add a UI regression test covering wildcard grants returned to the audit permission hook
- extend `.ai/lessons.md` with the rule that runtime helpers must treat granted feature arrays as wildcard-capable input

## Verification
- `npx jest packages/ui/src/backend/__tests__/nav-utils.test.ts packages/core/src/modules/auth/api/__tests__/admin-nav.test.ts packages/ui/src/backend/__tests__/useAuditPermissions.test.tsx --runInBand`

## Notes
- Browser/integration rerun was blocked locally because the reusable ephemeral QA app was down and Docker was not running, so a fresh ephemeral environment could not be started in this session.
- The existing wildcard navigation/browser regression remains in `packages/core/src/modules/auth/__integration__/TC-AUTH-022.spec.ts`.