### PR TITLE
fix: Dockerfile template in create-mercato-app fails to build

### DIFF
--- a/packages/create-app/template/Dockerfile
+++ b/packages/create-app/template/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:24-alpine AS builder
 
-ENV NODE_ENV=production \
-    NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 WORKDIR /app
 
@@ -12,7 +11,8 @@ COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install
 
 COPY . .
-RUN yarn build
+RUN yarn generate
+RUN NODE_ENV=production yarn build
 
 FROM node:24-alpine AS dev
 
@@ -51,7 +51,7 @@ RUN corepack enable
 COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install --production=true
 
-COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/.mercato/next ./.mercato/next
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/src ./src
 COPY --from=builder /app/types ./types


### PR DESCRIPTION
## Summary

The Dockerfile generated by `npx create-mercato-app` has three bugs that cause `docker-compose -f docker-compose.fullapp.yml up --build` to fail. This PR fixes all three:

- **Remove `NODE_ENV=production` from builder stage ENV** — it caused `yarn install` to skip devDependencies, breaking transitive deps needed at build time (e.g. `language-subtag-registry`)
- **Add `RUN yarn generate` before `yarn build`** — the `.mercato/generated/` directory must exist for Next.js imports to resolve
- **Fix COPY path from `.next` to `.mercato/next`** — `next.config.ts` sets `distDir: '.mercato/next'`, so the build output is not at `.next`

## Test plan

- [ ] Run `npx create-mercato-app test-app` (via Verdaccio)
- [ ] Run `docker-compose -f docker-compose.fullapp.yml up --build` in the generated app
- [ ] Confirm the build completes without `Module not found` errors
- [ ] Confirm the container starts and serves the app


🤖 Generated with [Claude Code](https://claude.com/claude-code)