### PR TITLE
fix: code review fixes for v0.4.10 pre-release

### DIFF
--- a/apps/mercato/src/modules/example/__integration__/TC-UMES-003.spec.ts
+++ b/apps/mercato/src/modules/example/__integration__/TC-UMES-003.spec.ts
@@ -663,7 +663,11 @@ test.describe('TC-UMES-003: Events & DOM Bridge', () => {
       await page.goto('/backend/umes-handlers', { waitUntil: 'commit' })
       await page.waitForLoadState('domcontentloaded')
 
-      await page.getByTestId('phase-d-person-id').fill(personId)
+      const personIdInput = page.getByTestId('phase-d-person-id')
+      await personIdInput.click()
+      await personIdInput.fill('')
+      await personIdInput.pressSequentially(personId)
+      await expect(personIdInput).toHaveValue(personId)
       await page.getByTestId('phase-d-probe-title').fill('')
       await page.getByTestId('phase-d-run-probe').click()
 

--- a/docker-compose.fullapp.yml
+++ b/docker-compose.fullapp.yml
@@ -25,45 +25,11 @@ services:
       - /bin/sh
       - -lc
       - |
-        run_init_or_migrate() {
-          MARKER_FILE="$$1"
-          INIT_COMMAND="$$2"
-          MIGRATE_COMMAND="$$3"
-          ALREADY_INITIALIZED_PATTERN='Initialization aborted: found [0-9][0-9]* existing user\(s\) in the database\.'
-
-          if [ ! -f "$${MARKER_FILE}" ]; then
-            echo "First run: full initialization..."
-            LOG_FILE="$$(mktemp)"
-            if sh -lc "$${INIT_COMMAND}" >"$${LOG_FILE}" 2>&1; then
-              cat "$${LOG_FILE}"
-              rm -f "$${LOG_FILE}"
-              mkdir -p "$$(dirname "$${MARKER_FILE}")"
-              touch "$${MARKER_FILE}"
-            else
-              STATUS=$$?
-              cat "$${LOG_FILE}"
-              if grep -Eq "$${ALREADY_INITIALIZED_PATTERN}" "$${LOG_FILE}"; then
-                rm -f "$${LOG_FILE}"
-                echo "Initialization reported existing users; treating database as already initialized."
-                echo "Running migrations..."
-                sh -lc "$${MIGRATE_COMMAND}"
-                mkdir -p "$$(dirname "$${MARKER_FILE}")"
-                touch "$${MARKER_FILE}"
-              else
-                rm -f "$${LOG_FILE}"
-                return "$${STATUS}"
-              fi
-            fi
-          else
-            echo "Subsequent run: migrations only..."
-            sh -lc "$${MIGRATE_COMMAND}"
-          fi
-        }
-        if [ -f /app/docker/scripts/init-or-migrate.sh ]; then
-          INIT_COMMAND='yarn mercato init' sh /app/docker/scripts/init-or-migrate.sh
-        else
-          run_init_or_migrate /tmp/init-marker/.seeded 'yarn mercato init' 'yarn db:migrate'
+        if [ ! -f /app/docker/scripts/init-or-migrate.sh ]; then
+          echo "ERROR: init-or-migrate.sh not found. Please rebuild the container: docker compose build --no-cache app"
+          exit 1
         fi
+        INIT_COMMAND='yarn mercato init' sh /app/docker/scripts/init-or-migrate.sh
         yarn start
     volumes:
       - init_marker:/tmp/init-marker

--- a/packages/core/src/modules/messages/i18n/de.json
+++ b/packages/core/src/modules/messages/i18n/de.json
@@ -34,6 +34,7 @@
   "messages.composer.attachmentPicker.title": "Dateien anhängen",
   "messages.composer.attachmentPicker.upload": "Dateien hochladen",
   "messages.composer.confirm.incompatibleObjects": "Beim Ändern des Nachrichtentyps werden {count} inkompatible angehängte Objekte entfernt. Fortfahren?",
+  "messages.composer.dialogDescription": "Nachricht verfassen und senden.",
   "messages.composer.hints.actionExpiry": "Aktionen für diesen Typ verfallen nach {hours} Stunden.",
   "messages.composer.maxObjectsWarning": "Empfohlene Grenze von 25 angehängten Objekten erreicht.",
   "messages.composer.noAttachments": "Noch keine Dateien angehängt.",

--- a/packages/core/src/modules/messages/i18n/en.json
+++ b/packages/core/src/modules/messages/i18n/en.json
@@ -34,6 +34,7 @@
   "messages.composer.attachmentPicker.title": "Attach files",
   "messages.composer.attachmentPicker.upload": "Upload files",
   "messages.composer.confirm.incompatibleObjects": "Changing message type will remove {count} incompatible attached objects. Continue?",
+  "messages.composer.dialogDescription": "Compose and send a message.",
   "messages.composer.hints.actionExpiry": "Actions for this type expire after {hours} hours.",
   "messages.composer.maxObjectsWarning": "You reached the recommended limit of 25 attached objects.",
   "messages.composer.noAttachments": "No files attached yet.",

--- a/packages/core/src/modules/messages/i18n/es.json
+++ b/packages/core/src/modules/messages/i18n/es.json
@@ -34,6 +34,7 @@
   "messages.composer.attachmentPicker.title": "Adjuntar archivos",
   "messages.composer.attachmentPicker.upload": "Subir archivos",
   "messages.composer.confirm.incompatibleObjects": "Cambiar el tipo de mensaje eliminará {count} objetos adjuntos incompatibles. ¿Continuar?",
+  "messages.composer.dialogDescription": "Redactar y enviar un mensaje.",
   "messages.composer.hints.actionExpiry": "Las acciones de este tipo vencen tras {hours} horas.",
   "messages.composer.maxObjectsWarning": "Has alcanzado el límite recomendado de 25 objetos adjuntos.",
   "messages.composer.noAttachments": "Aún no hay archivos adjuntos.",

--- a/packages/core/src/modules/messages/i18n/pl.json
+++ b/packages/core/src/modules/messages/i18n/pl.json
@@ -34,6 +34,7 @@
   "messages.composer.attachmentPicker.title": "Dołącz pliki",
   "messages.composer.attachmentPicker.upload": "Prześlij pliki",
   "messages.composer.confirm.incompatibleObjects": "Zmiana typu wiadomości usunie {count} niezgodnych dołączonych obiektów. Kontynuować?",
+  "messages.composer.dialogDescription": "Utwórz i wyślij wiadomość.",
   "messages.composer.hints.actionExpiry": "Akcje dla tego typu wygasają po {hours} godzinach.",
   "messages.composer.maxObjectsWarning": "Osiągnięto zalecany limit 25 dołączonych obiektów.",
   "messages.composer.noAttachments": "Nie dołączono jeszcze plików.",

--- a/packages/create-app/template/docker-compose.fullapp.yml
+++ b/packages/create-app/template/docker-compose.fullapp.yml
@@ -15,45 +15,11 @@ services:
       - /bin/sh
       - -lc
       - |
-        run_init_or_migrate() {
-          MARKER_FILE="$$1"
-          INIT_COMMAND="$$2"
-          MIGRATE_COMMAND="$$3"
-          ALREADY_INITIALIZED_PATTERN='Initialization aborted: found [0-9][0-9]* existing user\(s\) in the database\.'
-
-          if [ ! -f "$${MARKER_FILE}" ]; then
-            echo "First run: full initialization..."
-            LOG_FILE="$$(mktemp)"
-            if sh -lc "$${INIT_COMMAND}" >"$${LOG_FILE}" 2>&1; then
-              cat "$${LOG_FILE}"
-              rm -f "$${LOG_FILE}"
-              mkdir -p "$$(dirname "$${MARKER_FILE}")"
-              touch "$${MARKER_FILE}"
-            else
-              STATUS=$$?
-              cat "$${LOG_FILE}"
-              if grep -Eq "$${ALREADY_INITIALIZED_PATTERN}" "$${LOG_FILE}"; then
-                rm -f "$${LOG_FILE}"
-                echo "Initialization reported existing users; treating database as already initialized."
-                echo "Running migrations..."
-                sh -lc "$${MIGRATE_COMMAND}"
-                mkdir -p "$$(dirname "$${MARKER_FILE}")"
-                touch "$${MARKER_FILE}"
-              else
-                rm -f "$${LOG_FILE}"
-                return "$${STATUS}"
-              fi
-            fi
-          else
-            echo "Subsequent run: migrations only..."
-            sh -lc "$${MIGRATE_COMMAND}"
-          fi
-        }
-        if [ -f /app/docker/scripts/init-or-migrate.sh ]; then
-          sh /app/docker/scripts/init-or-migrate.sh
-        else
-          run_init_or_migrate /tmp/init-marker/.seeded 'yarn initialize' 'yarn db:migrate'
+        if [ ! -f /app/docker/scripts/init-or-migrate.sh ]; then
+          echo "ERROR: init-or-migrate.sh not found. Please rebuild the container: docker compose build --no-cache app"
+          exit 1
         fi
+        sh /app/docker/scripts/init-or-migrate.sh
         yarn start
     working_dir: /app
     volumes:


### PR DESCRIPTION
## Summary
- **Remove duplicated init-or-migrate inline shell** from both `docker-compose.fullapp.yml` files — the canonical `docker/scripts/init-or-migrate.sh` is now the single source of truth, with a clear rebuild error message if the script is missing from a stale container image
- **Add missing i18n key** `messages.composer.dialogDescription` to all 4 locales (en, pl, es, de)
- **Fix integration test robustness** in TC-UMES-003: use `click → fill('') → pressSequentially → assertValue` pattern for the person ID input (synced app ↔ template)

## Test plan
- [x] `yarn i18n:check-sync` passes
- [x] `yarn i18n:check-usage` reports 0 missing keys
- [x] `yarn template:sync` passes
- [x] All CI gates pass (build, typecheck, test, build:app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)