### PR TITLE
fix: onboarding vector reindex hangs

### DIFF
--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -241,6 +241,9 @@ OPENAI_API_KEY=your_openai_api_key_here
 # Models: nomic-embed-text (768 dim), mxbai-embed-large (1024 dim), all-minilm (384 dim)
 # Default: http://localhost:11434 (no /api suffix needed)
 # OLLAMA_BASE_URL=http://localhost:11434
+# Optional request cap for all embedding providers. Prevents stalled vector jobs
+# from blocking onboarding or workers forever.
+# VECTOR_EMBEDDING_TIMEOUT_MS=15000
 
 # ============================================================================
 # OCR (Optical Character Recognition) Configuration

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -243,7 +243,7 @@ OPENAI_API_KEY=your_openai_api_key_here
 # OLLAMA_BASE_URL=http://localhost:11434
 # Optional request cap for all embedding providers. Prevents stalled vector jobs
 # from blocking onboarding or workers forever.
-# VECTOR_EMBEDDING_TIMEOUT_MS=15000
+# VECTOR_EMBEDDING_TIMEOUT_MS=3000
 
 # ============================================================================
 # OCR (Optical Character Recognition) Configuration

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
+import type { SearchIndexer } from '@open-mercato/search'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { onboardingVerifySchema } from '@open-mercato/onboarding/modules/onboarding/data/validators'
 import { OnboardingService } from '@open-mercato/onboarding/modules/onboarding/lib/service'
@@ -14,7 +15,6 @@ import { refreshCoverageSnapshot } from '@open-mercato/core/modules/query_index/
 import { flattenSystemEntityIds } from '@open-mercato/shared/lib/entities/system-entities'
 import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import { getModules } from '@open-mercato/shared/lib/modules/registry'
-import type { VectorIndexService } from '@open-mercato/search/vector'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 
 export const metadata = {
@@ -50,6 +50,38 @@ function redirectToLogin(baseUrl: string, tenantId: string | null) {
     })
   }
   return response
+}
+
+const VECTOR_REINDEX_ENQUEUE_TIMEOUT_MS = 5_000
+
+function createTimeoutPromise(label: string, timeoutMs: number): Promise<never> {
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs)
+  })
+}
+
+async function enqueueVectorReindex(args: {
+  container: { resolve: <T = unknown>(name: string) => T }
+  tenantId: string
+  organizationId: string | null
+}) {
+  let searchIndexer: SearchIndexer | null = null
+  try {
+    searchIndexer = args.container.resolve<SearchIndexer>('searchIndexer')
+  } catch {
+    searchIndexer = null
+  }
+  if (!searchIndexer) return
+
+  await Promise.race([
+    searchIndexer.reindexAllToVector({
+      tenantId: args.tenantId,
+      organizationId: args.organizationId,
+      purgeFirst: true,
+      useQueue: true,
+    }),
+    createTimeoutPromise('vector reindex enqueue', VECTOR_REINDEX_ENQUEUE_TIMEOUT_MS),
+  ])
 }
 
 export async function GET(req: Request) {
@@ -164,12 +196,6 @@ export async function GET(req: Request) {
       }
     }
     if (tenantId) {
-      let vectorService: VectorIndexService | null = null
-      try {
-        vectorService = container.resolve<VectorIndexService>('vectorIndexService')
-      } catch {
-        vectorService = null
-      }
       const coverageRefreshKeys = new Set<string>()
       try {
         const allEntities = getEntityIds()
@@ -198,14 +224,6 @@ export async function GET(req: Request) {
         console.error('[onboarding.verify] failed to rebuild query indexes', { tenantId, error })
       }
 
-      if (vectorService) {
-        try {
-          await vectorService.reindexAll({ tenantId, organizationId, purgeFirst: true })
-        } catch (error) {
-          console.error('[onboarding.verify] failed to rebuild vector indexes', { tenantId, organizationId, error })
-        }
-      }
-
       if (coverageRefreshKeys.size) {
         for (const entry of coverageRefreshKeys) {
           const [entityType, tenantKey, orgKey] = entry.split('|')
@@ -230,6 +248,18 @@ export async function GET(req: Request) {
           }
         }
       }
+
+      void enqueueVectorReindex({
+        container,
+        tenantId,
+        organizationId,
+      }).catch((error) => {
+        console.warn('[onboarding.verify] vector reindex enqueue did not complete promptly', {
+          tenantId,
+          organizationId,
+          reason: error instanceof Error ? error.message : String(error),
+        })
+      })
     }
 
     await service.markCompleted(request, { tenantId, organizationId, userId: resolvedUserId })

--- a/packages/search/src/__tests__/embedding.test.ts
+++ b/packages/search/src/__tests__/embedding.test.ts
@@ -1,0 +1,57 @@
+jest.mock('ai', () => ({
+  embed: jest.fn(),
+}))
+
+import { embed } from 'ai'
+import { EmbeddingService } from '../vector/services/embedding'
+
+const mockedEmbed = jest.mocked(embed)
+
+describe('EmbeddingService', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('times out stalled embedding requests', async () => {
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
+    process.env.VECTOR_EMBEDDING_TIMEOUT_MS = '5'
+    mockedEmbed.mockImplementation(() => new Promise(() => undefined))
+
+    const service = new EmbeddingService({
+      config: {
+        providerId: 'ollama',
+        model: 'nomic-embed-text',
+        dimension: 768,
+        updatedAt: new Date().toISOString(),
+      },
+    })
+
+    await expect(service.createEmbedding('test input')).rejects.toThrow(
+      '[vector.embedding] Ollama (Local) request timed out after 5ms. Check OLLAMA_BASE_URL.',
+    )
+  })
+
+  it('returns embeddings when provider responds before the timeout', async () => {
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
+    process.env.VECTOR_EMBEDDING_TIMEOUT_MS = '100'
+    mockedEmbed.mockResolvedValue({ embedding: [0.25, 0.5, 0.75] } as Awaited<ReturnType<typeof embed>>)
+
+    const service = new EmbeddingService({
+      config: {
+        providerId: 'ollama',
+        model: 'nomic-embed-text',
+        dimension: 768,
+        updatedAt: new Date().toISOString(),
+      },
+    })
+
+    await expect(service.createEmbedding('test input')).resolves.toEqual([0.25, 0.5, 0.75])
+  })
+})

--- a/packages/search/src/vector/services/embedding.ts
+++ b/packages/search/src/vector/services/embedding.ts
@@ -30,6 +30,25 @@ type ProviderClient = ReturnType<typeof createOpenAI>
   | ReturnType<typeof createAmazonBedrock>
   | OllamaClient
 
+const DEFAULT_EMBEDDING_TIMEOUT_MS = 15_000
+
+function resolveEmbeddingTimeoutMs(): number {
+  const rawValue = process.env.VECTOR_EMBEDDING_TIMEOUT_MS
+  if (!rawValue) return DEFAULT_EMBEDDING_TIMEOUT_MS
+  const parsed = Number.parseInt(rawValue, 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_EMBEDDING_TIMEOUT_MS
+  }
+  return parsed
+}
+
+function timeoutError(providerId: EmbeddingProviderId, timeoutMs: number): Error {
+  const providerInfo = EMBEDDING_PROVIDERS[providerId]
+  return new Error(
+    `${providerInfo.name} request timed out after ${timeoutMs}ms. Check ${providerInfo.envKeyRequired}.`,
+  )
+}
+
 export class EmbeddingService {
   private config: EmbeddingProviderConfig
   private clientCache: Map<EmbeddingProviderId, ProviderClient> = new Map()
@@ -213,13 +232,19 @@ export class EmbeddingService {
 
     const model = this.getEmbeddingModel() as EmbeddingModel
     const providerOptions = this.getProviderOptions()
+    const timeoutMs = resolveEmbeddingTimeoutMs()
 
     try {
-      const result = await embed({
-        model,
-        value: merged,
-        ...(providerOptions && { providerOptions }),
-      })
+      const result = await Promise.race([
+        embed({
+          model,
+          value: merged,
+          ...(providerOptions && { providerOptions }),
+        }),
+        new Promise<never>((_, reject) => {
+          setTimeout(() => reject(timeoutError(this.config.providerId, timeoutMs)), timeoutMs)
+        }),
+      ])
       const emb = Array.isArray(result.embedding)
         ? result.embedding
         : Array.from(result.embedding as ArrayLike<number>)
@@ -254,9 +279,13 @@ export class EmbeddingService {
           guidance = `${providerInfo.name} account is disabled. Contact support or provide a different key.`
           break
         default:
-          guidance = rawMessage.includes('https://')
+          guidance = rawMessage.startsWith('[vector.embedding] ')
+            ? rawMessage.slice('[vector.embedding] '.length)
+            : rawMessage.includes('https://')
             ? rawMessage
-            : `${rawMessage}. Check ${providerInfo.envKeyRequired}.`
+            : rawMessage.includes(providerInfo.envKeyRequired)
+              ? rawMessage
+              : `${rawMessage}. Check ${providerInfo.envKeyRequired}.`
       }
       const wrapped = new Error(`[vector.embedding] ${guidance}`) as Error & { status?: number; code?: string; cause?: unknown }
       if (typeof status === 'number' && Number.isFinite(status)) {

--- a/packages/search/src/vector/services/embedding.ts
+++ b/packages/search/src/vector/services/embedding.ts
@@ -30,7 +30,7 @@ type ProviderClient = ReturnType<typeof createOpenAI>
   | ReturnType<typeof createAmazonBedrock>
   | OllamaClient
 
-const DEFAULT_EMBEDDING_TIMEOUT_MS = 15_000
+const DEFAULT_EMBEDDING_TIMEOUT_MS = 3_000
 
 function resolveEmbeddingTimeoutMs(): number {
   const rawValue = process.env.VECTOR_EMBEDDING_TIMEOUT_MS


### PR DESCRIPTION
## Summary
- stop onboarding verification from waiting on direct vector reindex completion
- enqueue vector reindex through the queue path with a short enqueue timeout
- add a hard embedding request timeout so stalled providers fail fast instead of hanging workers

## Verification
- yarn build
- yarn test
- yarn --cwd packages/search test --runInBand embedding.test.ts
- yarn --cwd packages/search test --runInBand workers.test.ts