### PR TITLE
feat/ready-apps-cli

### DIFF
--- a/.ai/specs/2026-03-02-ready-apps-framework.md
+++ b/.ai/specs/2026-03-02-ready-apps-framework.md
@@ -1,0 +1,394 @@
+# Ready Apps Framework
+
+| Field | Value |
+|-------|-------|
+| **Status** | Active |
+| **Author** | Open Mercato Team & Partners |
+| **Created** | 2026-03-02 |
+| **Related** | SPEC-013 (setup.ts), SPEC-041 (UMES), SPEC-045 (registry pattern), SPEC-051 (Partnership Portal), SPEC-053 (B2B PRM) |
+
+## TLDR
+**Key Points:**
+- Introduce a first-class "ready app" layer so engineers can bootstrap a polished use-case solution (like a B2B PRM or B2B Quotes system) with a single command instead of a blank tenant.
+- Ready apps are **not** part of the Open Mercato core repository. Each official ready app lives in its **own GitHub repository** under the `open-mercato` organization, using the naming convention `ready-app-<appname>`.
+- Bootstrap via `create-mercato-app --app <name>` for official Open Mercato ready apps and `create-mercato-app --app-url <github-url>` for external GitHub-hosted ready apps.
+- Preserve UMES and module boundaries: all vertical behavior is delivered via app modules, setup hooks, widgets, enrichers, and events, built within the ready app's own `src/modules` structure.
+
+**Scope:**
+- Ready app definition and distribution model (external to core).
+- `--app` and `--app-url` flags for `create-mercato-app`.
+- GitHub repository naming and fetch mechanism.
+
+**Concerns:**
+- Keep the core absolutely clean of specific business logic or use-case configurations.
+- Ensure extensions built for ready apps fully leverage the Universal Mercato Extension System (UMES).
+
+## Overview
+Open Mercato needs productized "ready projects" that reduce time-to-first-value for common B2B use cases such as PRM, field service, or marketplace ops. Today, teams start from a generic tenant and manually assemble modules, dictionaries, workflows, and role settings.
+
+This spec defines a framework to package those decisions into reusable ready apps while keeping the core platform entirely agnostic.
+
+> **Market Reference:** Inspired by source-first scaffolders in the JavaScript ecosystem, but adapted to Open Mercato's ecosystem and ownership model. Adopted: `--app`, `--app-url`, GitHub tarball fetch, and one official ready app per repository. Rejected: centralized official catalog repo, npm-only distribution, manual clone-and-copy workflow.
+
+## Problem Statement
+Without a ready apps framework:
+- each implementation repeats the same setup work,
+- demo and pilot environments are inconsistent across teams,
+- reuse is ad hoc and hard to maintain,
+- sales-to-delivery handoff has no standard baseline.
+
+If ready apps were integrated into the core:
+- the core repository would become bloated with specific, niche configurations,
+- the maintenance burden on the core team would increase dramatically,
+- partner agencies would lack ownership over the specific vertical solutions they create.
+
+The business goal is to turn repeated delivery patterns into reusable assets owned by the ecosystem, while keeping core evolution safe and lean.
+
+## Proposed Solution
+Implement a Ready Apps framework with two tiers:
+
+1. **The Core Engine**: `open-mercato/core` and `create-mercato-app` remain agnostic and clean.
+2. **Official Ready Apps**: Maintained by the Open Mercato team in **separate GitHub repositories** under the `open-mercato` organization, one repository per app, named `ready-app-<appname>`.
+3. **External Ready Apps**: Maintained by partners/agencies in their own GitHub repositories.
+4. **The Bootstrap Flow**: `create-mercato-app --app <name>` fetches an official Open Mercato repository; `create-mercato-app --app-url <url>` fetches an external GitHub repository and scaffolds a ready-to-run app.
+
+### Design Decisions
+| Decision | Rationale |
+|----------|-----------|
+| Ready apps live outside the core repository | Keeps core clean, reduces bloat, delegates domain ownership to partners/agencies. |
+| Official ready apps use one repo per app | Preserves clear ownership, release cadence, CI, and issue tracking per app. |
+| Official repo naming is `ready-app-<appname>` | Makes CLI resolution deterministic and keeps organization-level discovery simple. |
+| External ready apps remain independent GitHub repos | Partners/agencies own their vertical solutions fully. |
+| `--app` flag on `create-mercato-app` | Single-command bootstrap for official Open Mercato maintained ready apps. |
+| `--app-url` flag on `create-mercato-app` | Explicit path for external GitHub-hosted ready apps without overloading one flag. |
+| Each ready app is a complete, runnable app | No merge complexity; each app includes the full scaffold plus domain modules. |
+| GitHub API tarball fetch | No git dependency required; proven mechanism for scaffold tools. |
+| No new runtime extension model | Reuse UMES, events, setup.ts, entity extensions within the deployed application. |
+| App-level ownership for business-specific behavior | Matches monorepo rule: user-specific features live in the generated app's `src/modules`. |
+
+### Alternatives Considered
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Centralized official repo such as `open-mercato/ready-apps` | Couples unrelated apps into one release surface and one CI pipeline; ownership is less clear. |
+| Single overloaded source flag for both official and external sources | Less explicit than separating official-name lookup from direct external URL fetch. |
+| NPM-only distribution | "Black-box" packages restrict customization of complex business logic. |
+| Manual two-step flow (scaffold then copy) | Poor DX, error-prone, unnecessary friction. |
+| Delta/overlay on top of bare scaffold | Merge conflicts, version coupling, and complex implementation. |
+
+### What This Spec Explicitly Avoids
+- No ready app configurations committed to the `open-mercato/open-mercato` core repository.
+- No direct cross-module ORM relationships inside the core.
+- No use-case-specific KPI ownership or API logic in the core frameworks.
+
+## User Stories / Use Cases
+- An Engineer wants to bootstrap a new B2B PRM application. They run `npx create-mercato-app my-prm --app prm` and get a complete, demo-ready PRM app from `open-mercato/ready-app-prm`.
+- An Engineer wants to use an external ready app. They run `npx create-mercato-app my-app --app-url https://github.com/some-agency/ready-app-marketplace`.
+- A Partner Agency wants to distribute their specialized marketplace workflows. They maintain a GitHub repository with a complete Open Mercato app that includes their UMES extensions, widgets, and seeds.
+- An Engineer wants a blank app with no ready app. They run `npx create-mercato-app my-app` (unchanged behavior).
+
+## Architecture
+
+### CLI Interface
+
+New flags for `create-mercato-app`: `--app` and `--app-url`
+
+```bash
+# Official Open Mercato ready app
+npx create-mercato-app my-prm --app prm
+
+# External GitHub-hosted ready app
+npx create-mercato-app my-app --app-url https://github.com/some-agency/ready-app-marketplace
+
+# No ready app - current behavior (bare scaffold)
+npx create-mercato-app my-app
+```
+
+Resolution logic:
+- `--app <name>` resolves to the GitHub repository `open-mercato/ready-app-<name>`
+- `--app-url <url>` fetches the full GitHub repository at that URL
+- `--app` and `--app-url` are mutually exclusive
+- App names are kebab-case slugs and MUST map directly to repository names without additional lookup tables in v1
+
+Backward compatibility:
+- The no-flag invocation remains unchanged.
+- `--app` and `--app-url` are additive optional flags.
+
+### Repository Structure
+
+Official ready apps live as separate repositories in the `open-mercato` organization:
+
+```text
+open-mercato/ready-app-prm
+open-mercato/ready-app-quotes
+open-mercato/ready-app-field-service
+```
+
+Each repository root is a **complete, runnable app**:
+
+```text
+ready-app-prm/
+├── src/modules/           # PRM-specific modules
+├── package.json
+├── .env.sample
+├── README.md
+└── ...
+```
+
+### Fetch Mechanism
+
+Uses GitHub API tarball download:
+
+- Official: `GET https://api.github.com/repos/open-mercato/ready-app-<name>/tarball/<ref>`
+- External: `GET https://api.github.com/repos/{owner}/{repo}/tarball/<ref>`
+- No git dependency required
+
+Ref resolution:
+- `--app <name>` MUST resolve the official repository ref to the exact tag `v<create-mercato-app version>`
+- Official bootstrap MUST NOT default to `main` for stable releases
+- `--app-url <github-url>` uses the ref encoded in the GitHub URL when present (for example `/tree/<ref>`); otherwise it uses the repository default branch
+
+### Imported App Snapshot Contract
+
+Ready apps fetched via `--app` and `--app-url` are complete source repositories, not templates.
+
+Rules:
+- The CLI MUST extract the fetched ready app into the target directory as a raw source snapshot
+- The CLI MUST NOT rewrite dependency versions, package names, or application source files inside fetched ready apps
+- Imported ready apps MUST NOT rely on `.template` files or placeholder substitution
+- The `.template` processor remains part of the bare scaffold path only, not the imported ready app path
+- The CLI MUST skip the interactive agentic setup wizard for imported ready apps
+- If agentic tooling is needed for an imported ready app, it MUST be added explicitly later by a separate manual command
+
+### Reference Flow
+```text
+developer runs `npx create-mercato-app my-prm-app --app prm` ->
+create-mercato-app resolves `open-mercato/ready-app-prm` + tag `v<create-mercato-app version>` ->
+downloads the GitHub tarball ->
+extracts the ready app source snapshot to the target directory ->
+developer runs `yarn install` -> `yarn initialize` (setup.ts hooks run) ->
+app is ready with domain baseline.
+```
+
+### Error Handling
+- Official app repo not found: clear error including the resolved repository name (`open-mercato/ready-app-<name>`)
+- Official app tag not found: clear compatibility error including the missing tag name and repo
+- GitHub API unreachable / 404: error with suggestion to check network or repository URL
+- Private repo without auth: error suggesting `GITHUB_TOKEN` env var for authenticated requests
+- `--app-url` with a non-GitHub URL: clear error stating that only GitHub repositories are supported in v1
+- Imported ready app contains `.template` files: clear error stating that imported ready apps must be committed source snapshots
+- Both `--app` and `--app-url` provided: clear validation error before any network call
+
+### Non-Negotiable Architecture Guardrails
+1. Ready app modules extend host surfaces only through UMES and documented core contracts.
+2. Ready app implementation lives completely outside the OM core repository.
+3. The Open Mercato platform provides the extension points (hooks, enrichers, registries), but not the business configuration for ready apps.
+
+## Data Models
+
+Not applicable. This spec defines distribution and bootstrap infrastructure, not application entities.
+
+## API Contracts
+
+Not applicable. No application HTTP APIs are introduced. The external contract is the `create-mercato-app` CLI surface:
+- `--app <name>`
+- `--app-url <github-url>`
+
+## Implementation Details
+
+Because ready apps are external complete apps, there is no centralized database table required in the core engine. The "installation status" of a ready app is simply the presence of its modules and configurations within the application codebase.
+
+The standard `yarn initialize` (which triggers module hooks defined in `setup.ts`) is sufficient to bootstrap the application after scaffolding.
+
+## Versioning
+
+Ready app bootstrap has three independent version axes:
+
+1. **CLI version**: the version of `create-mercato-app`
+2. **Ready app source ref**: the git tag or branch fetched from the ready app repository
+3. **Committed dependency graph**: the exact dependency versions stored inside the fetched ready app repository
+
+### Release Line Contract
+
+- `create-mercato-app` and official `@open-mercato/*` packages MUST ship on the same version line
+- Official ready app repositories MUST publish a matching git tag for every supported Open Mercato release using the format `v<version>`
+- `--app` MUST fetch the official ready app tag that matches the running `create-mercato-app` version exactly
+- Official ready app `main` branches MAY move ahead, but they are not the compatibility contract used by released CLI bootstraps
+- Dependency versions inside an official ready app tag are owned by that ready app repository and MUST NOT be rewritten by the CLI
+
+### Dependency Strategy
+
+- Official ready apps MUST commit their `@open-mercato/*` dependency versions directly in `package.json`
+- External ready apps MUST own their dependency policy in source control and MUST declare explicit versions or semver ranges in `package.json`
+- The CLI MUST treat dependency versions in imported ready apps as repository-owned source, not bootstrap-time inputs
+- External ready apps SHOULD pin stable major/minor ranges conservatively and update them intentionally after verification
+
+### Reproducibility
+
+- Official `--app` bootstraps are reproducible because the repo ref resolves from the CLI release and the dependency graph is committed in that tagged ready app repository
+- External `--app-url` bootstraps are reproducible only when the URL points to a stable ref; otherwise they follow the repository default branch and whatever dependency graph is committed there
+- External maintainers SHOULD document the tested Open Mercato compatibility range in their README
+
+## Migration & Compatibility
+- Official ready apps define compatibility through the pair `(repo tag, committed dependency graph)`, aligned to the `create-mercato-app` release line.
+- External ready apps define compatibility through the chosen ref and the versions committed in their own `package.json`.
+- Core APIs guarantee semantic versioning, allowing ready app maintainers to update their apps accordingly.
+- Each official `ready-app-*` repository should have CI that validates every supported release tag still builds against the matching core release line.
+- Backward compatible: `create-mercato-app` without `--app` or `--app-url` continues to work exactly as before.
+
+## Implementation Plan
+
+### Phase 1 - CLI Flags
+1. Add `--app` and `--app-url` to the `create-mercato-app` argument parser.
+2. Enforce mutual exclusivity between `--app` and `--app-url`.
+3. Implement official app name resolution from `<name>` to `open-mercato/ready-app-<name>`.
+4. Resolve official app ref from the running CLI version to tag `v<version>`.
+5. Implement GitHub API tarball fetch for both official and external repositories.
+6. Implement raw snapshot extraction for imported ready apps without template processing.
+7. Skip the interactive agentic setup wizard for imported ready apps.
+8. Add error handling for missing repos, missing tags, network failures, invalid URLs, private repos, unsupported `.template` files in imported apps, and duplicate source flags.
+
+### Phase 2 - Official Ready App Repositories
+1. Create the first official repository, such as `open-mercato/ready-app-prm`.
+2. Add the first ready app implementation as a complete runnable application at repo root.
+3. Commit explicit first-party dependency versions in the repository for each tagged release line.
+4. Add CI to validate the app builds for the tagged release line.
+5. Document the organization naming convention and release tagging rules for future official ready apps.
+
+### File Manifest
+
+| File | Repo | Action | Purpose |
+|------|------|--------|---------|
+| `packages/create-app/src/index.ts` | open-mercato | Modify | Add `--app` / `--app-url`, repo resolution, fetch logic |
+| `packages/create-app/AGENTS.md` | open-mercato | Modify | Document `--app` / `--app-url` behavior |
+| repo root | `open-mercato/ready-app-prm` | Create | First official ready app |
+| `README.md` | `open-mercato/ready-app-prm` | Create | App usage, compatibility, and bootstrap docs |
+| `.github/workflows/ci.yml` | `open-mercato/ready-app-prm` | Create | Validate the ready app builds |
+
+### Testing Strategy
+- Unit: name-to-repo resolution, official tag resolution, URL parsing, mutual exclusivity validation, tarball extraction, and imported-app snapshot validation
+- Integration: end-to-end `create-mercato-app --app` with an official fixture repo tagged to the current CLI version
+- Integration: end-to-end `create-mercato-app --app-url` with an external GitHub fixture repo copied as-is
+- Integration: verify imported ready apps do not get `AGENTS.md`, `.ai/`, `.claude/`, `.cursor/`, or other wizard-generated files added or overwritten by bootstrap
+- CI on each official ready app repo: `yarn install && yarn generate && yarn build`
+
+## Risks & Impact Review
+
+### Migration & Deployment Risks
+
+### Operational Risks
+
+#### GitHub API rate limiting blocks ready app fetch
+- **Scenario**: Unauthenticated GitHub API calls hit rate limits during workshop/training events.
+- **Severity**: Medium
+- **Affected area**: `create-mercato-app --app` / `--app-url` bootstrap
+- **Mitigation**: Support `GITHUB_TOKEN` env var for authenticated requests; clear error message on rate limit.
+- **Residual risk**: Low with token usage
+
+#### Per-app repositories drift from core compatibility
+- **Scenario**: Core packages update but one or more official ready app repos are not updated, causing build failures for new users.
+- **Severity**: Medium
+- **Affected area**: Developer onboarding experience
+- **Mitigation**: CI in every official ready app repo; required release tags per supported version; ownership assigned per app repo.
+- **Residual risk**: Medium - requires active maintenance
+
+#### Imported ready app is not actually committed as a source snapshot
+- **Scenario**: A ready app repository still contains `.template` files or expects bootstrap-time rewriting, causing broken installs after fetch.
+- **Severity**: High
+- **Affected area**: Imported ready app bootstrap correctness
+- **Mitigation**: Forbid template-based imported apps and fail closed during scaffold.
+- **Residual risk**: Low
+
+#### Organization-level discovery becomes weaker without one central catalog repo
+- **Scenario**: Users do not know which official ready app names are available for `--app`.
+- **Severity**: Medium
+- **Affected area**: Developer experience and discoverability
+- **Mitigation**: Maintain a documentation index on docs.open-mercato.com or in the main documentation repo; keep repo naming deterministic.
+- **Residual risk**: Low
+
+## Final Compliance Report - 2026-04-01
+
+### AGENTS.md Files Reviewed
+- `AGENTS.md` (root)
+- `.ai/specs/AGENTS.md`
+- `packages/create-app/AGENTS.md`
+
+### Compliance Matrix
+
+| Rule Source | Rule | Status | Notes |
+|-------------|------|--------|-------|
+| root AGENTS.md | Ready apps live outside core repository | Compliant | Official apps live in separate `open-mercato/ready-app-*` repositories, not in core |
+| root AGENTS.md | App-specific behavior lives in the app codebase | Compliant | Each ready app remains a complete runnable app with its own `src/modules` |
+| packages/create-app/AGENTS.md | MUST NOT break the standalone app template | Compliant | Bare scaffold remains unchanged; new flags are additive |
+| BACKWARD_COMPATIBILITY.md | CLI commands are STABLE contract surface | Compliant with explicit removal request | Supported ready-app source flags are `--app` and `--app-url`; this implementation intentionally limits the CLI surface to those two flags |
+| .ai/specs/AGENTS.md | Non-trivial spec must include full structure | Compliant | All required sections included |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| CLI interface matches fetch mechanism | Pass | `--app` resolves to `open-mercato/ready-app-<name>` and `--app-url` resolves to a direct GitHub repo URL |
+| Repository structure matches fetch logic | Pass | Each official ready app repo root is a full runnable app |
+| Error handling covers failure modes | Pass | Network, 404, invalid URL, rate limit, private repo, and duplicate flags covered |
+
+### Non-Compliant Items
+
+None.
+
+### Verdict
+
+**Fully compliant** - Approved as the ready apps framework spec.
+
+## Changelog
+
+### 2026-04-01
+- Reworked the distribution model from one centralized official repo to one official repo per ready app under the `open-mercato` organization.
+- Introduced the official repository naming convention `ready-app-<appname>`.
+- Replaced the earlier bootstrap contract with `--app` for official Open Mercato apps and `--app-url` for external GitHub-hosted apps.
+- Added a raw-snapshot versioning contract: imported ready apps are copied as committed source, and dependency versions remain owned by the ready app repositories.
+- Normalized the spec filename to `2026-03-02-ready-apps-framework.md` and removed the legacy numbered heading.
+- Implemented Phase 1 in `packages/create-app`: ready app flags, GitHub snapshot import, snapshot validation, and unit/integration-style tests for the in-repo CLI surface.
+- Removed the temporary preview-only source alias so the supported CLI surface remains `--app` and `--app-url` only.
+
+### 2026-03-20
+- Official app catalog repository changed from an earlier naming variant to `open-mercato/ready-apps` (superseded by the 2026-04-01 one-repo-per-app decision).
+- Removed superseded SPEC-062 (Use-Case Starters Framework).
+- Status changed from Draft to Active.
+
+### 2026-03-18
+- Renumbered from SPEC-062 to SPEC-068 to resolve numbering conflict with PR #1003 (Official Modules, SPEC-061-067).
+- Renamed the concept from "starters" to a more standard bootstrap term at that stage of the design process.
+- Added an earlier single-flag bootstrap mechanism, later superseded by the 2026-04-01 `--app` / `--app-url` decision.
+- Added `open-mercato/ready-apps` as a centralized catalog repository, later superseded by the 2026-04-01 one-repo-per-app decision.
+- Added GitHub API tarball fetch mechanism.
+- Added error handling, versioning, and testing strategy.
+- Added compliance report.
+
+### 2026-03-17
+- Renumbered from SPEC-061 to SPEC-062 to resolve numbering conflict with PR #1003.
+
+### 2026-03-02
+- Initial specification.
+
+## Implementation Status
+
+| Phase | Status | Date | Notes |
+|-------|--------|------|-------|
+| Phase 1 - CLI Flags | Done | 2026-04-01 | `packages/create-app` now supports `--app`, `--app-url`, GitHub tarball imports, raw snapshot validation, and imported-app wizard skip behavior with automated tests |
+| Phase 2 - Official Ready App Repositories | Not Started | — | Requires work in external repositories such as `open-mercato/ready-app-prm`, which are outside this monorepo |
+
+### Phase 1 - Detailed Progress
+- [x] Step 1: Add `--app` and `--app-url` to the `create-mercato-app` argument parser
+- [x] Step 2: Enforce mutual exclusivity between `--app` and `--app-url`
+- [x] Step 3: Implement official app name resolution from `<name>` to `open-mercato/ready-app-<name>`
+- [x] Step 4: Resolve official app ref from the running CLI version to tag `v<version>`
+- [x] Step 5: Implement GitHub API tarball fetch for both official and external repositories
+- [x] Step 6: Implement raw snapshot extraction for imported ready apps without template processing
+- [x] Step 7: Skip the interactive agentic setup wizard for imported ready apps
+- [x] Step 8: Add validation and error handling for invalid URLs, duplicate source flags, missing repos or refs, private repos, rate limits, and `.template` files in imported apps
+
+### Phase 2 - Detailed Progress
+- [ ] Step 1: Create the first official repository, such as `open-mercato/ready-app-prm`
+- [ ] Step 2: Add the first ready app implementation as a complete runnable application at repo root
+- [ ] Step 3: Commit explicit first-party dependency versions in the repository for each tagged release line
+- [ ] Step 4: Add CI to validate the app builds for the tagged release line
+- [ ] Step 5: Document the organization naming convention and release tagging rules for future official ready apps

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -250,7 +250,7 @@ jobs:
 
       # --- Scaffold & build standalone app ---
       - name: Scaffold standalone app
-        run: npx "create-mercato-app@${{ needs.snapshot.outputs.snapshot_version }}" /tmp/standalone-app --registry https://registry.npmjs.org
+        run: npx "create-mercato-app@${{ needs.snapshot.outputs.snapshot_version }}" /tmp/standalone-app --skip-agentic-setup --registry https://registry.npmjs.org
 
       - name: Configure standalone app environment
         working-directory: /tmp/standalone-app

--- a/packages/create-app/AGENTS.md
+++ b/packages/create-app/AGENTS.md
@@ -11,6 +11,8 @@ Use `packages/create-app` to scaffold standalone Open Mercato applications via `
 5. **MUST NOT break the standalone app template** — it's the user's first experience with Open Mercato
 6. **MUST sync template equivalents when app shell/layout files change** — when touching `apps/mercato/src/app/**` bootstrap/layout/provider wiring, update matching files in `packages/create-app/template/src/app/**` (and required template components) in the same task
 7. **MUST keep template module registrations and package dependencies aligned** — if `packages/create-app/template/src/modules.ts` enables a package-backed module (for example `@open-mercato/webhooks`), `packages/create-app/template/package.json.template` must install that package in the same change, and the template lockfile must be reviewed when dependency shape changes
+8. **MUST preserve imported ready apps as raw source snapshots** — `--app` / `--app-url` imports may add only bootstrap-safe generated artifacts (for example `.mercato/generated/module-package-sources.css`) and MUST NOT rewrite package versions, source files, or inject agentic setup files
+9. **MUST skip the interactive agentic wizard for imported ready apps** — imported snapshots stay repo-owned; any agentic tooling must be added later via a deliberate manual command inside the generated app
 
 ## Standalone App vs Monorepo
 
@@ -41,6 +43,22 @@ my-app/
 │   └── generated/         # Generated files from CLI
 └── package.json
 ```
+
+## Ready App Import Modes
+
+`create-mercato-app` supports three scaffold modes:
+
+1. Bare scaffold: `npx create-mercato-app my-app`
+2. Official ready app: `npx create-mercato-app my-prm --app prm`
+3. External GitHub ready app: `npx create-mercato-app my-app --app-url https://github.com/some-agency/ready-app-marketplace`
+
+Rules:
+
+- `--app` resolves to `open-mercato/ready-app-<name>` and MUST use the exact tag `v<create-mercato-app version>`
+- `--app-url` only supports GitHub repository URLs in v1, optionally with `/tree/<ref>`
+- `--app` and `--app-url` are mutually exclusive
+- Imported ready apps skip template processing and the interactive agentic wizard
+- Imported ready apps must be committed source snapshots; fail closed if `.template` files are present
 
 ## Testing with Verdaccio
 

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -10,6 +10,13 @@ cd my-app
 yarn setup
 ```
 
+Official and external ready apps can also be bootstrapped directly:
+
+```bash
+npx create-mercato-app my-prm --app prm
+npx create-mercato-app my-marketplace --app-url https://github.com/some-agency/ready-app-marketplace
+```
+
 ## Usage
 
 ```bash
@@ -26,6 +33,8 @@ npx create-mercato-app <app-name> [options]
 
 | Option | Description |
 |--------|-------------|
+| `--app <name>` | Bootstrap an official Open Mercato ready app from `open-mercato/ready-app-<name>` |
+| `--app-url <url>` | Bootstrap a ready app from a GitHub repository URL |
 | `--registry <url>` | Custom npm registry URL |
 | `--verdaccio` | Use local Verdaccio registry (http://localhost:4873) |
 | `--help`, `-h` | Show help |
@@ -37,6 +46,12 @@ npx create-mercato-app <app-name> [options]
 # Create a new app using the public npm registry
 npx create-mercato-app my-store
 
+# Create an official Open Mercato ready app
+npx create-mercato-app my-prm --app prm
+
+# Create an app from an external GitHub-hosted ready app
+npx create-mercato-app my-marketplace --app-url https://github.com/some-agency/ready-app-marketplace
+
 # Create a new app using a local Verdaccio registry
 npx create-mercato-app my-store --verdaccio
 
@@ -44,7 +59,16 @@ npx create-mercato-app my-store --verdaccio
 npx create-mercato-app my-store --registry http://localhost:4873
 ```
 
-## After Creating Your App
+## Ready App Behavior
+
+- `--app <name>` resolves to `open-mercato/ready-app-<name>` and fetches the exact tag `v<create-mercato-app version>`
+- `--app-url <url>` only supports GitHub repository URLs in v1 and honors `/tree/<ref>` when present
+- `--app` and `--app-url` are mutually exclusive
+- Imported ready apps are copied as raw source snapshots: the CLI does not rewrite dependency versions, package names, or application source files
+- Imported ready apps skip the interactive agentic setup wizard; if you want agentic tooling later, run `yarn mercato agentic:init` inside the generated app
+- Imported ready apps must not contain `.template` files; the scaffold fails closed if template files are found
+
+## After Creating A Bare Scaffold
 
 1. Navigate to your app directory:
    ```bash
@@ -108,6 +132,33 @@ npx create-mercato-app my-store --registry http://localhost:4873
    docker compose -f docker-compose.fullapp.yml up --build
    ```
    Run `cp .env.example .env` and `yarn install` before either Docker command. Skipping those preparation steps can cause the stack to fail during startup.
+
+## After Importing A Ready App
+
+1. Navigate to your app directory:
+   ```bash
+   cd my-prm
+   ```
+
+2. Install dependencies:
+   ```bash
+   yarn install
+   ```
+
+3. Initialize the application:
+   ```bash
+   yarn initialize
+   ```
+
+4. Start the development server:
+   ```bash
+   yarn dev
+   ```
+
+5. If you want standalone agentic tooling later:
+   ```bash
+   yarn mercato agentic:init
+   ```
 
 ## Requirements
 

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -35,6 +35,7 @@ npx create-mercato-app <app-name> [options]
 |--------|-------------|
 | `--app <name>` | Bootstrap an official Open Mercato ready app from `open-mercato/ready-app-<name>` |
 | `--app-url <url>` | Bootstrap a ready app from a GitHub repository URL |
+| `--skip-agentic-setup` | Skip the interactive agentic setup wizard |
 | `--registry <url>` | Custom npm registry URL |
 | `--verdaccio` | Use local Verdaccio registry (http://localhost:4873) |
 | `--help`, `-h` | Show help |
@@ -57,6 +58,9 @@ npx create-mercato-app my-store --verdaccio
 
 # Create a new app using a custom registry
 npx create-mercato-app my-store --registry http://localhost:4873
+
+# Create a new app without the agentic setup wizard
+npx create-mercato-app my-store --skip-agentic-setup
 ```
 
 ## Ready App Behavior
@@ -64,6 +68,7 @@ npx create-mercato-app my-store --registry http://localhost:4873
 - `--app <name>` resolves to `open-mercato/ready-app-<name>` and fetches the exact tag `v<create-mercato-app version>`
 - `--app-url <url>` only supports GitHub repository URLs in v1 and honors `/tree/<ref>` when present
 - `--app` and `--app-url` are mutually exclusive
+- `--skip-agentic-setup` skips only the interactive agentic setup wizard
 - Imported ready apps are copied as raw source snapshots: the CLI does not rewrite dependency versions, package names, or application source files
 - Imported ready apps skip the interactive agentic setup wizard; if you want agentic tooling later, run `yarn mercato agentic:init` inside the generated app
 - Imported ready apps must not contain `.template` files; the scaffold fails closed if template files are found

--- a/packages/create-app/bin/create-mercato-app
+++ b/packages/create-app/bin/create-mercato-app
@@ -17,5 +17,17 @@ if (!existsSync(distIndex)) {
   process.exit(1);
 }
 
-// Import the actual CLI
-await import(pathToFileURL(distIndex).href);
+const cliModule = await import(pathToFileURL(distIndex).href);
+
+if (typeof cliModule.main !== 'function') {
+  console.error(`Error: CLI entrypoint at ${distIndex} does not export main().`);
+  process.exit(1);
+}
+
+try {
+  await cliModule.main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Error creating app: ${message}`);
+  process.exit(1);
+}

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -13,14 +13,17 @@
   ],
   "scripts": {
     "build": "node build.mjs",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "picocolors": "^1.1.0"
+    "picocolors": "^1.1.0",
+    "tar": "^7.5.1"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",
     "esbuild": "^0.25.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
   "publishConfig": {

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -1,8 +1,16 @@
-import { existsSync, mkdirSync, readdirSync, statSync, readFileSync, writeFileSync, copyFileSync } from 'node:fs'
-import { join, dirname, basename, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { createInterface } from 'node:readline'
+import { basename, dirname, join, resolve } from 'node:path'
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync, copyFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import pc from 'picocolors'
+import {
+  downloadReadyAppSnapshot,
+  extractTarballSnapshot,
+  resolveReadyAppSource,
+  type ReadyAppSource,
+  validateImportedReadyAppSnapshot,
+  validateSlug,
+} from './lib/ready-apps.js'
 import { runAgenticSetup } from './setup/wizard.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -11,6 +19,8 @@ const PACKAGE_VERSION: string = packageJson.version
 const TEMPLATE_DIR = join(__dirname, '..', 'template')
 
 interface Options {
+  app?: string
+  appUrl?: string
   registry?: string
   verdaccio: boolean
   help: boolean
@@ -28,6 +38,8 @@ ${pc.bold('Arguments:')}
   app-name           Name of the application (will create folder with this name)
 
 ${pc.bold('Options:')}
+  --app <name>       Bootstrap an official ready app from open-mercato/ready-app-<name>
+  --app-url <url>    Bootstrap a ready app from a GitHub repository URL
   --registry <url>   Custom npm registry URL
   --verdaccio        Use local Verdaccio registry (http://localhost:4873)
   --help, -h         Show help
@@ -35,6 +47,8 @@ ${pc.bold('Options:')}
 
 ${pc.bold('Examples:')}
   npx create-mercato-app my-store
+  npx create-mercato-app my-prm --app prm
+  npx create-mercato-app my-marketplace --app-url https://github.com/some-agency/ready-app-marketplace
   npx create-mercato-app my-store --verdaccio
   npx create-mercato-app my-store --registry http://localhost:4873
 `)
@@ -44,8 +58,19 @@ function showVersion(): void {
   console.log(`create-mercato-app v${PACKAGE_VERSION}`)
 }
 
+function requireOptionValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1]
+  if (!value || value.startsWith('-')) {
+    throw new Error(`Option ${flag} requires a value`)
+  }
+
+  return value
+}
+
 function parseArgs(args: string[]): { appName: string | null; options: Options } {
   const options: Options = {
+    app: undefined,
+    appUrl: undefined,
     registry: undefined,
     verdaccio: false,
     help: false,
@@ -53,8 +78,8 @@ function parseArgs(args: string[]): { appName: string | null; options: Options }
   }
   let appName: string | null = null
 
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i]
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
 
     if (arg === '--help' || arg === '-h') {
       options.help = true
@@ -63,7 +88,14 @@ function parseArgs(args: string[]): { appName: string | null; options: Options }
     } else if (arg === '--verdaccio') {
       options.verdaccio = true
     } else if (arg === '--registry') {
-      options.registry = args[++i]
+      options.registry = requireOptionValue(args, index, arg)
+      index += 1
+    } else if (arg === '--app') {
+      options.app = requireOptionValue(args, index, arg)
+      index += 1
+    } else if (arg === '--app-url') {
+      options.appUrl = requireOptionValue(args, index, arg)
+      index += 1
     } else if (!arg.startsWith('-')) {
       appName = arg
     }
@@ -72,33 +104,13 @@ function parseArgs(args: string[]): { appName: string | null; options: Options }
   return { appName, options }
 }
 
-function validateAppName(name: string): { valid: boolean; error?: string } {
-  if (!name) {
-    return { valid: false, error: 'App name is required' }
-  }
-
-  if (!/^[a-z0-9-]+$/.test(name)) {
-    return {
-      valid: false,
-      error: 'App name must be lowercase alphanumeric with hyphens only (e.g., my-app)',
-    }
-  }
-
-  if (name.startsWith('-') || name.endsWith('-')) {
-    return { valid: false, error: 'App name cannot start or end with a hyphen' }
-  }
-
-  return { valid: true }
-}
-
 function buildRegistryConfig(registryUrl: string): string {
   let parsedRegistryUrl: URL
 
   try {
     parsedRegistryUrl = new URL(registryUrl)
   } catch {
-    console.error(pc.red(`Error: Invalid registry URL "${registryUrl}"`))
-    process.exit(1)
+    throw new Error(`Invalid registry URL "${registryUrl}"`)
   }
 
   const configLines: string[] = []
@@ -124,7 +136,6 @@ function buildRegistryConfig(registryUrl: string): string {
   return configLines.join('\n')
 }
 
-// Files that need to be renamed (npm ignores .gitignore during pack)
 const FILE_RENAMES: Record<string, string> = {
   gitignore: '.gitignore',
 }
@@ -148,7 +159,6 @@ function copyDirRecursive(src: string, dest: string, placeholders: Record<string
       if (SKIP_DIRS.has(entry)) continue
       copyDirRecursive(srcPath, destPath, placeholders)
     } else if (entry.endsWith('.template')) {
-      // Process template files
       const finalName = entry.replace('.template', '')
       destPath = join(dest, finalName)
       let content = readFileSync(srcPath, 'utf-8')
@@ -164,115 +174,173 @@ function copyDirRecursive(src: string, dest: string, placeholders: Record<string
   }
 }
 
-async function main(): Promise<void> {
-  const args = process.argv.slice(2)
-  const { appName: appNameArg, options } = parseArgs(args)
+function ensureGeneratedCssPlaceholder(targetDir: string): void {
+  const generatedDir = join(targetDir, '.mercato', 'generated')
+  const placeholderPath = join(generatedDir, 'module-package-sources.css')
+
+  mkdirSync(generatedDir, { recursive: true })
+  if (!existsSync(placeholderPath)) {
+    writeFileSync(placeholderPath, '')
+  }
+}
+
+async function scaffoldTemplateApp(
+  targetDir: string,
+  placeholders: Record<string, string>,
+): Promise<void> {
+  if (!existsSync(TEMPLATE_DIR)) {
+    throw new Error(`Template directory not found at ${TEMPLATE_DIR}`)
+  }
+
+  copyDirRecursive(TEMPLATE_DIR, targetDir, placeholders)
+  ensureGeneratedCssPlaceholder(targetDir)
+}
+
+function describeReadyAppSource(source: ReadyAppSource): string {
+  if (source.kind === 'official') {
+    return `${source.owner}/${source.repo}@${source.ref}`
+  }
+
+  return `${source.owner}/${source.repo}${source.ref ? `@${source.ref}` : ''}`
+}
+
+async function scaffoldImportedReadyApp(targetDir: string, source: ReadyAppSource): Promise<void> {
+  const download = await downloadReadyAppSnapshot(source, PACKAGE_VERSION)
+  console.log(pc.dim(`Fetching ready app snapshot from ${download.owner}/${download.repo}@${download.ref}`))
+
+  await extractTarballSnapshot(download.archive, targetDir)
+  validateImportedReadyAppSnapshot(targetDir)
+  ensureGeneratedCssPlaceholder(targetDir)
+}
+
+async function maybeRunAgenticSetup(targetDir: string): Promise<void> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  const ask = (question: string) =>
+    new Promise<string>((resolveAnswer) => rl.question(question, (answer) => resolveAnswer(answer.trim())))
+
+  try {
+    await runAgenticSetup(targetDir, ask)
+  } finally {
+    rl.close()
+  }
+}
+
+function printTemplateNextSteps(appName: string): void {
+  console.log('Next steps:')
+  console.log('')
+  console.log(pc.cyan(`  cd ${appName}`))
+  console.log('')
+  console.log(pc.green('Suggested quick start:'))
+  console.log(pc.cyan('  yarn setup'))
+  console.log(pc.dim('  # Copies .env.example to .env if needed, installs deps, migrates, initializes, and starts dev'))
+  console.log(pc.dim('  # If you need a clean reset first: yarn setup --reinstall'))
+  console.log(pc.dim('  # Alias: yarn setup:reinstall'))
+  console.log('')
+  console.log('Manual alternative:')
+  console.log(pc.cyan('  cp .env.example .env'))
+  console.log(pc.dim('  # Edit .env with your database credentials'))
+  console.log(pc.cyan('  yarn install'))
+  console.log(pc.cyan('  yarn generate'))
+  console.log(pc.cyan('  yarn db:migrate'))
+  console.log(pc.cyan('  yarn initialize'))
+  console.log(pc.cyan('  yarn dev'))
+  console.log('')
+  console.log('Docker alternatives:')
+  console.log(pc.dim('  # Before Docker: cp .env.example .env && yarn install'))
+  console.log(pc.dim('  # Docker expects your local app env and dependencies to be prepared first'))
+  console.log(pc.cyan('  # Dev (recommended on Windows): docker compose -f docker-compose.fullapp.dev.yml up --build'))
+  console.log(pc.cyan('  # Production-style: docker compose -f docker-compose.fullapp.yml up --build'))
+  console.log('')
+}
+
+function printImportedReadyAppNextSteps(appName: string): void {
+  console.log('Next steps:')
+  console.log('')
+  console.log(pc.cyan(`  cd ${appName}`))
+  console.log(pc.cyan('  yarn install'))
+  console.log(pc.cyan('  yarn initialize'))
+  console.log(pc.cyan('  yarn dev'))
+  console.log('')
+  console.log(pc.dim('Imported ready apps are copied as raw source snapshots.'))
+  console.log(pc.dim('If you want agentic tooling in the imported app later, run `yarn mercato agentic:init` inside it.'))
+  console.log('')
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const { appName: appNameArg, options } = parseArgs(argv)
 
   if (options.help) {
     showHelp()
-    process.exit(0)
+    return
   }
 
   if (options.version) {
     showVersion()
-    process.exit(0)
+    return
   }
 
   if (!appNameArg) {
-    console.error(pc.red('Error: App name is required'))
-    console.error('')
-    showHelp()
-    process.exit(1)
+    throw new Error('App name is required')
   }
 
-  // Support both relative names (my-app) and full paths (/tmp/my-app)
   const targetDir = resolve(process.cwd(), appNameArg)
   const appName = basename(targetDir)
 
-  const validation = validateAppName(appName)
+  const validation = validateSlug(appName, 'App name')
   if (!validation.valid) {
-    console.error(pc.red(`Error: ${validation.error}`))
-    process.exit(1)
+    throw new Error(validation.error)
   }
 
   if (existsSync(targetDir)) {
-    console.error(pc.red(`Error: Directory "${appName}" already exists`))
-    process.exit(1)
+    throw new Error(`Directory "${appName}" already exists`)
   }
 
-  if (!existsSync(TEMPLATE_DIR)) {
-    console.error(pc.red('Error: Template directory not found'))
-    console.error(`Expected: ${TEMPLATE_DIR}`)
-    process.exit(1)
-  }
-
-  // Determine registry config
-  let registryConfig = ''
-  if (options.verdaccio) {
-    registryConfig = buildRegistryConfig('http://localhost:4873')
-  } else if (options.registry) {
-    registryConfig = buildRegistryConfig(options.registry)
-  }
+  const readyAppSource = resolveReadyAppSource(options, PACKAGE_VERSION)
+  const registryConfig = options.verdaccio
+    ? buildRegistryConfig('http://localhost:4873')
+    : options.registry
+      ? buildRegistryConfig(options.registry)
+      : ''
 
   console.log('')
   console.log(pc.bold(`Creating a new Open Mercato app in ${pc.cyan(targetDir)}`))
   console.log('')
 
-  // Define placeholders
   const placeholders: Record<string, string> = {
     APP_NAME: appName,
-    PACKAGE_VERSION: PACKAGE_VERSION,
+    PACKAGE_VERSION,
     REGISTRY_CONFIG: registryConfig,
   }
 
-  try {
-    copyDirRecursive(TEMPLATE_DIR, targetDir, placeholders)
-
-    // Create an empty placeholder so globals.css @import resolves before generators run
-    const generatedDir = join(targetDir, '.mercato', 'generated')
-    mkdirSync(generatedDir, { recursive: true })
-    writeFileSync(join(generatedDir, 'module-package-sources.css'), '')
-
-    console.log(pc.green('Success!') + ` Created ${pc.bold(appName)}`)
+  if (readyAppSource) {
+    console.log(pc.dim(`Ready app source: ${describeReadyAppSource(readyAppSource)}`))
     console.log('')
-
-    // Agentic tool setup wizard
-    const rl = createInterface({ input: process.stdin, output: process.stdout })
-    const ask = (q: string) => new Promise<string>((res) => rl.question(q, (a) => res(a.trim())))
-    await runAgenticSetup(targetDir, ask)
-    rl.close()
-
-    console.log('Next steps:')
-    console.log('')
-    console.log(pc.cyan(`  cd ${appName}`))
-    console.log('')
-    console.log(pc.green('Suggested quick start:'))
-    console.log(pc.cyan('  yarn setup'))
-    console.log(pc.dim('  # Copies .env.example to .env if needed, installs deps, migrates, initializes, and starts dev'))
-    console.log(pc.dim('  # If you need a clean reset first: yarn setup --reinstall'))
-    console.log(pc.dim('  # Alias: yarn setup:reinstall'))
-    console.log('')
-    console.log('Manual alternative:')
-    console.log(pc.cyan('  cp .env.example .env'))
-    console.log(pc.dim('  # Edit .env with your database credentials'))
-    console.log(pc.cyan('  yarn install'))
-    console.log(pc.cyan('  yarn generate'))
-    console.log(pc.cyan('  yarn db:migrate'))
-    console.log(pc.cyan('  yarn initialize'))
-    console.log(pc.cyan('  yarn dev'))
-    console.log('')
-    console.log('Docker alternatives:')
-    console.log(pc.dim('  # Before Docker: cp .env.example .env && yarn install'))
-    console.log(pc.dim('  # Docker expects your local app env and dependencies to be prepared first'))
-    console.log(pc.cyan('  # Dev (recommended on Windows): docker compose -f docker-compose.fullapp.dev.yml up --build'))
-    console.log(pc.cyan('  # Production-style: docker compose -f docker-compose.fullapp.yml up --build'))
-    console.log('')
-    console.log(pc.dim('For more information, visit https://github.com/open-mercato/open-mercato'))
-    console.log('')
-  } catch (error) {
-    console.error(pc.red('Error creating app:'), error)
-    process.exit(1)
+    await scaffoldImportedReadyApp(targetDir, readyAppSource)
+  } else {
+    await scaffoldTemplateApp(targetDir, placeholders)
   }
+
+  console.log(pc.green('Success!') + ` Created ${pc.bold(appName)}`)
+  console.log('')
+
+  if (readyAppSource) {
+    printImportedReadyAppNextSteps(appName)
+  } else {
+    await maybeRunAgenticSetup(targetDir)
+    printTemplateNextSteps(appName)
+  }
+
+  console.log(pc.dim('For more information, visit https://github.com/open-mercato/open-mercato'))
+  console.log('')
 }
 
-main()
+const isEntrypoint =
+  process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isEntrypoint) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(pc.red('Error creating app:'), message)
+    process.exit(1)
+  })
+}

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -22,6 +22,7 @@ interface Options {
   app?: string
   appUrl?: string
   registry?: string
+  skipAgenticSetup: boolean
   verdaccio: boolean
   help: boolean
   version: boolean
@@ -40,6 +41,7 @@ ${pc.bold('Arguments:')}
 ${pc.bold('Options:')}
   --app <name>       Bootstrap an official ready app from open-mercato/ready-app-<name>
   --app-url <url>    Bootstrap a ready app from a GitHub repository URL
+  --skip-agentic-setup  Skip the interactive agentic setup wizard
   --registry <url>   Custom npm registry URL
   --verdaccio        Use local Verdaccio registry (http://localhost:4873)
   --help, -h         Show help
@@ -72,6 +74,7 @@ function parseArgs(args: string[]): { appName: string | null; options: Options }
     app: undefined,
     appUrl: undefined,
     registry: undefined,
+    skipAgenticSetup: false,
     verdaccio: false,
     help: false,
     version: false,
@@ -85,6 +88,8 @@ function parseArgs(args: string[]): { appName: string | null; options: Options }
       options.help = true
     } else if (arg === '--version' || arg === '-v') {
       options.version = true
+    } else if (arg === '--skip-agentic-setup') {
+      options.skipAgenticSetup = true
     } else if (arg === '--verdaccio') {
       options.verdaccio = true
     } else if (arg === '--registry') {
@@ -213,7 +218,12 @@ async function scaffoldImportedReadyApp(targetDir: string, source: ReadyAppSourc
   ensureGeneratedCssPlaceholder(targetDir)
 }
 
-async function maybeRunAgenticSetup(targetDir: string): Promise<void> {
+async function maybeRunAgenticSetup(targetDir: string, skipAgenticSetup: boolean): Promise<void> {
+  if (skipAgenticSetup) {
+    await runAgenticSetup(targetDir, async () => '', { tool: 'skip' })
+    return
+  }
+
   const rl = createInterface({ input: process.stdin, output: process.stdout })
   const ask = (question: string) =>
     new Promise<string>((resolveAnswer) => rl.question(question, (answer) => resolveAnswer(answer.trim())))
@@ -326,7 +336,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   if (readyAppSource) {
     printImportedReadyAppNextSteps(appName)
   } else {
-    await maybeRunAgenticSetup(targetDir)
+    await maybeRunAgenticSetup(targetDir, options.skipAgenticSetup)
     printTemplateNextSteps(appName)
   }
 

--- a/packages/create-app/src/lib/ready-apps.test.ts
+++ b/packages/create-app/src/lib/ready-apps.test.ts
@@ -1,0 +1,251 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import * as tar from 'tar'
+import {
+  downloadReadyAppSnapshot,
+  extractTarballSnapshot,
+  parseGitHubRepositoryUrl,
+  resolveOfficialReadyAppSource,
+  resolveReadyAppSource,
+  validateImportedReadyAppSnapshot,
+} from './ready-apps.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const PACKAGE_ROOT = resolve(__dirname, '..', '..')
+const CLI_BIN = join(PACKAGE_ROOT, 'bin', 'create-mercato-app')
+const CLI_ENTRY = join(PACKAGE_ROOT, 'src', 'index.ts')
+
+function makeTempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix))
+}
+
+async function createGitHubStyleTarball(files: Record<string, string>): Promise<Uint8Array> {
+  const tempDir = makeTempDir('create-mercato-app-fixture-')
+  const rootDir = join(tempDir, 'fixture-root')
+  const archivePath = join(tempDir, 'fixture.tar.gz')
+
+  mkdirSync(rootDir, { recursive: true })
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absolutePath = join(rootDir, relativePath)
+    mkdirSync(dirname(absolutePath), { recursive: true })
+    writeFileSync(absolutePath, content)
+  }
+
+  await tar.c(
+    {
+      cwd: tempDir,
+      gzip: true,
+      file: archivePath,
+    },
+    ['fixture-root'],
+  )
+
+  const archive = new Uint8Array(readFileSync(archivePath))
+  rmSync(tempDir, { recursive: true, force: true })
+  return archive
+}
+
+test('resolveOfficialReadyAppSource maps app slug to repo and exact tag', () => {
+  const source = resolveOfficialReadyAppSource('prm', '0.4.9')
+
+  assert.deepEqual(source, {
+    kind: 'official',
+    appSlug: 'prm',
+    owner: 'open-mercato',
+    repo: 'ready-app-prm',
+    ref: 'v0.4.9',
+  })
+})
+
+test('resolveReadyAppSource rejects multiple source flags', () => {
+  assert.throws(
+    () =>
+      resolveReadyAppSource(
+        {
+          app: 'prm',
+          appUrl: 'https://github.com/some-agency/ready-app-marketplace',
+        },
+        '0.4.9',
+      ),
+    /mutually exclusive/i,
+  )
+})
+
+test('parseGitHubRepositoryUrl extracts owner, repo, and refs with slashes', () => {
+  const parsed = parseGitHubRepositoryUrl(
+    'https://github.com/some-agency/ready-app-marketplace/tree/releases/2026-04',
+  )
+
+  assert.deepEqual(parsed, {
+    owner: 'some-agency',
+    repo: 'ready-app-marketplace',
+    ref: 'releases/2026-04',
+    normalizedUrl: 'https://github.com/some-agency/ready-app-marketplace/tree/releases/2026-04',
+  })
+})
+
+test('extractTarballSnapshot strips the GitHub root folder', async () => {
+  const archive = await createGitHubStyleTarball({
+    'package.json': '{"name":"ready-app-prm"}\n',
+    'src/modules.ts': 'export default []\n',
+  })
+  const targetDir = makeTempDir('create-mercato-app-extract-')
+
+  try {
+    await extractTarballSnapshot(archive, targetDir)
+
+    assert.equal(existsSync(join(targetDir, 'package.json')), true)
+    assert.equal(existsSync(join(targetDir, 'src', 'modules.ts')), true)
+  } finally {
+    rmSync(targetDir, { recursive: true, force: true })
+  }
+})
+
+test('validateImportedReadyAppSnapshot fails closed on template files', () => {
+  const targetDir = makeTempDir('create-mercato-app-template-check-')
+
+  try {
+    mkdirSync(join(targetDir, 'src'), { recursive: true })
+    writeFileSync(join(targetDir, 'src', 'package.json.template'), '{}\n')
+
+    assert.throws(
+      () => validateImportedReadyAppSnapshot(targetDir),
+      /must be committed source snapshots/i,
+    )
+  } finally {
+    rmSync(targetDir, { recursive: true, force: true })
+  }
+})
+
+test('downloadReadyAppSnapshot resolves external default branches through the GitHub API', async () => {
+  const calls: string[] = []
+  const fetchMock = (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    calls.push(url)
+
+    if (url.endsWith('/repos/some-agency/ready-app-marketplace')) {
+      return new Response(JSON.stringify({ default_branch: 'main' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+
+    if (url.endsWith('/repos/some-agency/ready-app-marketplace/tarball/main')) {
+      return new Response(Uint8Array.from([1, 2, 3]), {
+        status: 200,
+        headers: { 'content-type': 'application/octet-stream' },
+      })
+    }
+
+    return new Response(JSON.stringify({ message: 'Not Found' }), {
+      status: 404,
+      headers: { 'content-type': 'application/json' },
+    })
+  }) as typeof fetch
+
+  const source = resolveReadyAppSource(
+    { appUrl: 'https://github.com/some-agency/ready-app-marketplace' },
+    '0.4.9',
+  )
+
+  assert.ok(source)
+  const download = await downloadReadyAppSnapshot(source, '0.4.9', fetchMock)
+
+  assert.equal(download.ref, 'main')
+  assert.deepEqual(Array.from(download.archive), [1, 2, 3])
+  assert.deepEqual(calls, [
+    'https://api.github.com/repos/some-agency/ready-app-marketplace',
+    'https://api.github.com/repos/some-agency/ready-app-marketplace/tarball/main',
+  ])
+})
+
+test('published CLI bin executes the dist entrypoint', () => {
+  const buildResult = spawnSync(process.execPath, ['build.mjs'], {
+    cwd: PACKAGE_ROOT,
+    encoding: 'utf8',
+    env: process.env,
+  })
+
+  assert.equal(
+    buildResult.status,
+    0,
+    `expected package build to succeed\nstdout:\n${buildResult.stdout}\nstderr:\n${buildResult.stderr}`,
+  )
+
+  const result = spawnSync(process.execPath, [CLI_BIN, '--help'], {
+    cwd: PACKAGE_ROOT,
+    encoding: 'utf8',
+    env: process.env,
+  })
+
+  assert.equal(
+    result.status,
+    0,
+    `expected bin wrapper to succeed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  )
+  assert.match(result.stdout, /--app-url/)
+})
+
+test('CLI imported ready apps skip wizard-generated files', async () => {
+  const archive = await createGitHubStyleTarball({
+    'package.json': '{"name":"ready-app-prm","version":"0.0.1"}\n',
+    'README.md': '# Ready App PRM\n',
+    'src/modules.ts': 'export default []\n',
+  })
+
+  const targetRoot = makeTempDir('create-mercato-app-cli-import-')
+  const targetDir = join(targetRoot, 'ready-prm')
+  const mockFetchModulePath = join(targetRoot, 'mock-fetch.mjs')
+  const archiveBase64 = Buffer.from(archive).toString('base64')
+
+  writeFileSync(
+    mockFetchModulePath,
+    `const archive = Uint8Array.from(Buffer.from('${archiveBase64}', 'base64'))
+globalThis.fetch = async (input) => {
+  const url = String(input)
+  if (url === 'https://api.github.com/repos/open-mercato/ready-app-prm/tarball/v0.4.9') {
+    return new Response(archive, {
+      status: 200,
+      headers: { 'content-type': 'application/octet-stream' },
+    })
+  }
+  return new Response(JSON.stringify({ message: 'Not Found' }), {
+    status: 404,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+`,
+  )
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      ['--import', 'tsx', '--import', mockFetchModulePath, CLI_ENTRY, targetDir, '--app', 'prm'],
+      {
+        cwd: PACKAGE_ROOT,
+        encoding: 'utf8',
+        env: process.env,
+      },
+    )
+
+    assert.equal(
+      result.status,
+      0,
+      `expected CLI import to succeed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    )
+    assert.equal(existsSync(join(targetDir, 'package.json')), true)
+    assert.equal(existsSync(join(targetDir, 'AGENTS.md')), false)
+    assert.equal(existsSync(join(targetDir, '.ai')), false)
+    assert.equal(existsSync(join(targetDir, '.claude')), false)
+    assert.equal(existsSync(join(targetDir, '.cursor')), false)
+    assert.equal(existsSync(join(targetDir, '.mercato', 'generated', 'module-package-sources.css')), true)
+  } finally {
+    rmSync(targetRoot, { recursive: true, force: true })
+  }
+})

--- a/packages/create-app/src/lib/ready-apps.test.ts
+++ b/packages/create-app/src/lib/ready-apps.test.ts
@@ -9,6 +9,7 @@ import * as tar from 'tar'
 import {
   downloadReadyAppSnapshot,
   extractTarballSnapshot,
+  getGitHubApiBaseUrl,
   parseGitHubRepositoryUrl,
   resolveOfficialReadyAppSource,
   resolveReadyAppSource,
@@ -19,6 +20,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const PACKAGE_ROOT = resolve(__dirname, '..', '..')
 const CLI_BIN = join(PACKAGE_ROOT, 'bin', 'create-mercato-app')
 const CLI_ENTRY = join(PACKAGE_ROOT, 'src', 'index.ts')
+const PACKAGE_VERSION = (
+  JSON.parse(readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf8')) as { version: string }
+).version
 
 function makeTempDir(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix))
@@ -52,14 +56,14 @@ async function createGitHubStyleTarball(files: Record<string, string>): Promise<
 }
 
 test('resolveOfficialReadyAppSource maps app slug to repo and exact tag', () => {
-  const source = resolveOfficialReadyAppSource('prm', '0.4.9')
+  const source = resolveOfficialReadyAppSource('prm', PACKAGE_VERSION)
 
   assert.deepEqual(source, {
     kind: 'official',
     appSlug: 'prm',
     owner: 'open-mercato',
     repo: 'ready-app-prm',
-    ref: 'v0.4.9',
+    ref: `v${PACKAGE_VERSION}`,
   })
 })
 
@@ -124,19 +128,20 @@ test('validateImportedReadyAppSnapshot fails closed on template files', () => {
 })
 
 test('downloadReadyAppSnapshot resolves external default branches through the GitHub API', async () => {
+  const githubApiBaseUrl = getGitHubApiBaseUrl()
   const calls: string[] = []
   const fetchMock = (async (input: RequestInfo | URL) => {
     const url = String(input)
     calls.push(url)
 
-    if (url.endsWith('/repos/some-agency/ready-app-marketplace')) {
+    if (url === `${githubApiBaseUrl}/repos/some-agency/ready-app-marketplace`) {
       return new Response(JSON.stringify({ default_branch: 'main' }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       })
     }
 
-    if (url.endsWith('/repos/some-agency/ready-app-marketplace/tarball/main')) {
+    if (url === `${githubApiBaseUrl}/repos/some-agency/ready-app-marketplace/tarball/main`) {
       return new Response(Uint8Array.from([1, 2, 3]), {
         status: 200,
         headers: { 'content-type': 'application/octet-stream' },
@@ -160,8 +165,8 @@ test('downloadReadyAppSnapshot resolves external default branches through the Gi
   assert.equal(download.ref, 'main')
   assert.deepEqual(Array.from(download.archive), [1, 2, 3])
   assert.deepEqual(calls, [
-    'https://api.github.com/repos/some-agency/ready-app-marketplace',
-    'https://api.github.com/repos/some-agency/ready-app-marketplace/tarball/main',
+    `${githubApiBaseUrl}/repos/some-agency/ready-app-marketplace`,
+    `${githubApiBaseUrl}/repos/some-agency/ready-app-marketplace/tarball/main`,
   ])
 })
 
@@ -190,6 +195,38 @@ test('published CLI bin executes the dist entrypoint', () => {
     `expected bin wrapper to succeed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
   )
   assert.match(result.stdout, /--app-url/)
+  assert.match(result.stdout, /--skip-agentic-setup/)
+})
+
+test('CLI bare scaffold skips interactive agentic setup with --skip-agentic-setup', () => {
+  const targetRoot = makeTempDir('create-mercato-app-cli-ci-')
+  const targetDir = join(targetRoot, 'ci-app')
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      ['--import', 'tsx', CLI_ENTRY, targetDir, '--skip-agentic-setup'],
+      {
+        cwd: PACKAGE_ROOT,
+        encoding: 'utf8',
+        env: process.env,
+        timeout: 5000,
+      },
+    )
+
+    assert.equal(
+      result.status,
+      0,
+      `expected CLI scaffold with --skip-agentic-setup to succeed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}\nerror:\n${result.error instanceof Error ? result.error.message : 'none'}`,
+    )
+    assert.match(result.stdout, /Skipped agentic setup/)
+    assert.equal(existsSync(join(targetDir, 'package.json')), true)
+    assert.equal(existsSync(join(targetDir, '.claude')), false)
+    assert.equal(existsSync(join(targetDir, '.cursor')), false)
+    assert.equal(existsSync(join(targetDir, '.codex')), false)
+  } finally {
+    rmSync(targetRoot, { recursive: true, force: true })
+  }
 })
 
 test('CLI imported ready apps skip wizard-generated files', async () => {
@@ -209,7 +246,13 @@ test('CLI imported ready apps skip wizard-generated files', async () => {
     `const archive = Uint8Array.from(Buffer.from('${archiveBase64}', 'base64'))
 globalThis.fetch = async (input) => {
   const url = String(input)
-  if (url === 'https://api.github.com/repos/open-mercato/ready-app-prm/tarball/v0.4.9') {
+  if (url.endsWith('/repos/open-mercato/ready-app-prm')) {
+    return new Response(JSON.stringify({ default_branch: 'main' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  if (url.endsWith('/repos/open-mercato/ready-app-prm/tarball/v${PACKAGE_VERSION}')) {
     return new Response(archive, {
       status: 200,
       headers: { 'content-type': 'application/octet-stream' },

--- a/packages/create-app/src/lib/ready-apps.ts
+++ b/packages/create-app/src/lib/ready-apps.ts
@@ -1,0 +1,448 @@
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+import * as tar from 'tar'
+
+const DEFAULT_GITHUB_API_BASE_URL = 'https://api.github.com'
+const GITHUB_HOSTNAME = 'github.com'
+
+export interface ReadyAppSelectionOptions {
+  app?: string
+  appUrl?: string
+}
+
+export interface GitHubRepositoryLocation {
+  owner: string
+  repo: string
+  ref?: string
+  normalizedUrl: string
+}
+
+interface BaseReadyAppSource {
+  owner: string
+  repo: string
+  ref?: string
+}
+
+export interface OfficialReadyAppSource extends BaseReadyAppSource {
+  kind: 'official'
+  appSlug: string
+  ref: string
+}
+
+export interface ExternalReadyAppSource extends BaseReadyAppSource {
+  kind: 'external'
+  sourceUrl: string
+}
+
+export type ReadyAppSource = OfficialReadyAppSource | ExternalReadyAppSource
+
+export interface ReadyAppDownload {
+  archive: Uint8Array
+  owner: string
+  repo: string
+  ref: string
+}
+
+interface GitHubRepositoryInfo {
+  defaultBranch: string
+}
+
+type FetchLike = typeof fetch
+
+export function validateSlug(name: string, label: string): { valid: boolean; error?: string } {
+  if (!name) {
+    return { valid: false, error: `${label} is required` }
+  }
+
+  if (!/^[a-z0-9-]+$/.test(name)) {
+    return {
+      valid: false,
+      error: `${label} must be lowercase alphanumeric with hyphens only (e.g., my-app)`,
+    }
+  }
+
+  if (name.startsWith('-') || name.endsWith('-')) {
+    return { valid: false, error: `${label} cannot start or end with a hyphen` }
+  }
+
+  return { valid: true }
+}
+
+export function parseGitHubRepositoryUrl(inputUrl: string): GitHubRepositoryLocation {
+  let parsedUrl: URL
+
+  try {
+    parsedUrl = new URL(inputUrl)
+  } catch {
+    throw new Error(`Invalid GitHub repository URL "${inputUrl}"`)
+  }
+
+  if (parsedUrl.protocol !== 'https:' || parsedUrl.hostname !== GITHUB_HOSTNAME) {
+    throw new Error('Only GitHub repository URLs are supported for --app-url in v1.')
+  }
+
+  const segments = parsedUrl.pathname.replace(/\/+$/, '').split('/').filter(Boolean)
+  if (segments.length < 2) {
+    throw new Error('GitHub repository URL must include both the owner and repository name.')
+  }
+
+  const owner = segments[0]
+  const repo = segments[1].replace(/\.git$/u, '')
+
+  if (!owner || !repo) {
+    throw new Error('GitHub repository URL must include both the owner and repository name.')
+  }
+
+  let ref: string | undefined
+  if (segments.length > 2) {
+    if (segments[2] !== 'tree' || segments.length < 4) {
+      throw new Error('GitHub repository URL must point to the repository root or /tree/<ref>.')
+    }
+
+    ref = decodeURIComponent(segments.slice(3).join('/'))
+    if (!ref) {
+      throw new Error('GitHub repository URL is missing the ref after /tree/.')
+    }
+  }
+
+  return {
+    owner,
+    repo,
+    ref,
+    normalizedUrl: `https://${GITHUB_HOSTNAME}/${owner}/${repo}${ref ? `/tree/${ref}` : ''}`,
+  }
+}
+
+export function resolveOfficialReadyAppSource(
+  appName: string,
+  packageVersion: string,
+): OfficialReadyAppSource {
+  const validation = validateSlug(appName, 'Ready app name')
+  if (!validation.valid) {
+    throw new Error(validation.error)
+  }
+
+  return {
+    kind: 'official',
+    appSlug: appName,
+    owner: 'open-mercato',
+    repo: `ready-app-${appName}`,
+    ref: `v${packageVersion}`,
+  }
+}
+
+export function resolveReadyAppSource(
+  options: ReadyAppSelectionOptions,
+  packageVersion: string,
+): ReadyAppSource | null {
+  const selectedFlags = [options.app, options.appUrl].filter(
+    (value) => typeof value === 'string' && value.trim().length > 0,
+  )
+
+  if (selectedFlags.length > 1) {
+    throw new Error('Options --app and --app-url are mutually exclusive. Use only one source flag.')
+  }
+
+  if (options.app) {
+    return resolveOfficialReadyAppSource(options.app.trim(), packageVersion)
+  }
+
+  if (options.appUrl) {
+    const parsed = parseGitHubRepositoryUrl(options.appUrl.trim())
+    return {
+      kind: 'external',
+      owner: parsed.owner,
+      repo: parsed.repo,
+      ref: parsed.ref,
+      sourceUrl: parsed.normalizedUrl,
+    }
+  }
+
+  return null
+}
+
+export function getGitHubApiBaseUrl(): string {
+  const overridden = process.env.OM_CREATE_APP_GITHUB_API_BASE_URL?.trim()
+  if (!overridden) {
+    return DEFAULT_GITHUB_API_BASE_URL
+  }
+
+  return overridden.replace(/\/+$/u, '')
+}
+
+function buildGitHubRepoApiUrl(owner: string, repo: string): string {
+  return `${getGitHubApiBaseUrl()}/repos/${owner}/${repo}`
+}
+
+function buildGitHubTarballApiUrl(owner: string, repo: string, ref: string): string {
+  return `${getGitHubApiBaseUrl()}/repos/${owner}/${repo}/tarball/${encodeURIComponent(ref)}`
+}
+
+function buildGitHubHeaders(packageVersion: string): Headers {
+  const headers = new Headers({
+    Accept: 'application/vnd.github+json',
+    'User-Agent': `create-mercato-app/${packageVersion}`,
+  })
+
+  const token = process.env.GITHUB_TOKEN?.trim()
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`)
+  }
+
+  return headers
+}
+
+function buildRepoAccessError(owner: string, repo: string): Error {
+  return new Error(
+    `GitHub repository not found or inaccessible: ${owner}/${repo}. Check the repository URL. If it is private, set GITHUB_TOKEN and retry.`,
+  )
+}
+
+function buildNetworkError(owner: string, repo: string, cause: unknown): Error {
+  const detail = cause instanceof Error ? cause.message : String(cause)
+  return new Error(
+    `Unable to reach GitHub while fetching ${owner}/${repo}. Check network access or the repository URL. (${detail})`,
+  )
+}
+
+async function readGitHubErrorMessage(response: Response): Promise<string | null> {
+  try {
+    const payload = await response.json()
+    if (
+      payload &&
+      typeof payload === 'object' &&
+      'message' in payload &&
+      typeof payload.message === 'string'
+    ) {
+      return payload.message
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+function isGitHubRateLimitResponse(response: Response, message: string | null): boolean {
+  const remaining = response.headers.get('x-ratelimit-remaining')
+  if (remaining === '0') {
+    return true
+  }
+
+  const normalizedMessage = message?.toLowerCase() ?? ''
+  return normalizedMessage.includes('rate limit')
+}
+
+async function buildGitHubRequestError(
+  response: Response,
+  owner: string,
+  repo: string,
+  action: string,
+): Promise<Error> {
+  const message = await readGitHubErrorMessage(response)
+
+  if (isGitHubRateLimitResponse(response, message)) {
+    return new Error(
+      `GitHub API rate limit reached while ${action} ${owner}/${repo}. Set GITHUB_TOKEN and retry.`,
+    )
+  }
+
+  if (response.status === 401) {
+    return new Error(
+      `GitHub authentication failed while ${action} ${owner}/${repo}. Check GITHUB_TOKEN and retry.`,
+    )
+  }
+
+  if (response.status === 403 && message?.toLowerCase().includes('resource not accessible')) {
+    return buildRepoAccessError(owner, repo)
+  }
+
+  return new Error(
+    `GitHub API request failed while ${action} ${owner}/${repo} (${response.status}${message ? `: ${message}` : ''}).`,
+  )
+}
+
+async function performGitHubRequest(
+  url: string,
+  owner: string,
+  repo: string,
+  packageVersion: string,
+  fetchImpl: FetchLike,
+): Promise<Response> {
+  try {
+    return await fetchImpl(url, {
+      headers: buildGitHubHeaders(packageVersion),
+      redirect: 'follow',
+    })
+  } catch (error) {
+    throw buildNetworkError(owner, repo, error)
+  }
+}
+
+async function fetchGitHubRepositoryInfo(
+  owner: string,
+  repo: string,
+  packageVersion: string,
+  fetchImpl: FetchLike,
+): Promise<GitHubRepositoryInfo | null> {
+  const response = await performGitHubRequest(
+    buildGitHubRepoApiUrl(owner, repo),
+    owner,
+    repo,
+    packageVersion,
+    fetchImpl,
+  )
+
+  if (response.status === 404) {
+    return null
+  }
+
+  if (!response.ok) {
+    throw await buildGitHubRequestError(response, owner, repo, 'inspecting')
+  }
+
+  const payload = (await response.json()) as { default_branch?: unknown }
+  const defaultBranch =
+    typeof payload.default_branch === 'string' && payload.default_branch.trim().length > 0
+      ? payload.default_branch
+      : null
+
+  if (!defaultBranch) {
+    throw new Error(`GitHub repository metadata for ${owner}/${repo} is missing default_branch.`)
+  }
+
+  return { defaultBranch }
+}
+
+export async function downloadReadyAppSnapshot(
+  source: ReadyAppSource,
+  packageVersion: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<ReadyAppDownload> {
+  let resolvedRef = source.ref
+
+  if (!resolvedRef) {
+    const repoInfo = await fetchGitHubRepositoryInfo(
+      source.owner,
+      source.repo,
+      packageVersion,
+      fetchImpl,
+    )
+
+    if (!repoInfo) {
+      throw buildRepoAccessError(source.owner, source.repo)
+    }
+
+    resolvedRef = repoInfo.defaultBranch
+  }
+
+  const tarballResponse = await performGitHubRequest(
+    buildGitHubTarballApiUrl(source.owner, source.repo, resolvedRef),
+    source.owner,
+    source.repo,
+    packageVersion,
+    fetchImpl,
+  )
+
+  if (tarballResponse.ok) {
+    return {
+      archive: new Uint8Array(await tarballResponse.arrayBuffer()),
+      owner: source.owner,
+      repo: source.repo,
+      ref: resolvedRef,
+    }
+  }
+
+  if (tarballResponse.status === 404) {
+    const repoInfo = await fetchGitHubRepositoryInfo(
+      source.owner,
+      source.repo,
+      packageVersion,
+      fetchImpl,
+    )
+
+    if (!repoInfo) {
+      if (source.kind === 'official') {
+        throw new Error(`Official ready app repository not found: ${source.owner}/${source.repo}.`)
+      }
+
+      throw buildRepoAccessError(source.owner, source.repo)
+    }
+
+    if (source.kind === 'official') {
+      throw new Error(
+        `Official ready app compatibility tag not found: ${source.owner}/${source.repo}@${resolvedRef}. Expected tag ${source.ref} for this create-mercato-app release.`,
+      )
+    }
+
+    throw new Error(
+      `Ready app ref not found: ${source.owner}/${source.repo}@${resolvedRef}. Check the GitHub URL and ensure the branch or tag exists.`,
+    )
+  }
+
+  throw await buildGitHubRequestError(
+    tarballResponse,
+    source.owner,
+    source.repo,
+    'downloading tarball for',
+  )
+}
+
+export function findTemplateFiles(dir: string, rootDir = dir): string[] {
+  if (!existsSync(dir)) {
+    return []
+  }
+
+  const findings: string[] = []
+  const entries = readdirSync(dir).sort()
+
+  for (const entry of entries) {
+    const entryPath = join(dir, entry)
+    const entryStat = statSync(entryPath)
+
+    if (entryStat.isDirectory()) {
+      findings.push(...findTemplateFiles(entryPath, rootDir))
+      continue
+    }
+
+    if (entry.endsWith('.template')) {
+      findings.push(relative(rootDir, entryPath))
+    }
+  }
+
+  return findings
+}
+
+export function validateImportedReadyAppSnapshot(dir: string): void {
+  const templateFiles = findTemplateFiles(dir)
+  if (templateFiles.length === 0) {
+    return
+  }
+
+  const preview = templateFiles.slice(0, 5).join(', ')
+  throw new Error(
+    `Imported ready apps must be committed source snapshots. Found .template files: ${preview}${templateFiles.length > 5 ? ', ...' : ''}`,
+  )
+}
+
+export async function extractTarballSnapshot(
+  archive: Uint8Array,
+  targetDir: string,
+): Promise<void> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'create-mercato-app-tarball-'))
+  const archivePath = join(tempDir, 'ready-app.tar.gz')
+
+  writeFileSync(archivePath, archive)
+  mkdirSync(targetDir, { recursive: true })
+
+  try {
+    await tar.x({
+      cwd: targetDir,
+      file: archivePath,
+      strip: 1,
+    })
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+}

--- a/scripts/test-create-app-integration.ts
+++ b/scripts/test-create-app-integration.ts
@@ -100,10 +100,7 @@ async function main(): Promise<void> {
   try {
     await ensureVerdaccioPublished(ROOT)
 
-    runCommand(process.execPath, [CREATE_APP_BIN, appDir, '--verdaccio'], {
-      cwd: ROOT,
-      input: '5\n',
-    })
+    runCommand(process.execPath, [CREATE_APP_BIN, appDir, '--verdaccio', '--skip-agentic-setup'], { cwd: ROOT })
 
     assertExists(path.join(appDir, 'package.json'), 'Scaffolded standalone app created')
     assertExists(path.join(appDir, '.ai', 'qa', 'tests', 'playwright.config.ts'), 'Standalone QA config present')

--- a/scripts/test-create-app.ts
+++ b/scripts/test-create-app.ts
@@ -58,10 +58,7 @@ async function main(): Promise<void> {
   try {
     await ensureVerdaccioPublished(ROOT)
 
-    runCommand(process.execPath, [CREATE_APP_BIN, appDir, '--verdaccio'], {
-      cwd: ROOT,
-      input: '5\n',
-    })
+    runCommand(process.execPath, [CREATE_APP_BIN, appDir, '--verdaccio', '--skip-agentic-setup'], { cwd: ROOT })
 
     assertExists(path.join(appDir, 'package.json'), 'Scaffolded app package.json created')
     assertExists(path.join(appDir, 'src', 'modules.ts'), 'Scaffolded app modules.ts created')

--- a/yarn.lock
+++ b/yarn.lock
@@ -11948,6 +11948,8 @@ __metadata:
     "@types/node": "npm:^24.10.1"
     esbuild: "npm:^0.25.0"
     picocolors: "npm:^1.1.0"
+    tar: "npm:^7.5.1"
+    tsx: "npm:^4.21.0"
     typescript: "npm:^5.9.3"
   bin:
     create-mercato-app: ./bin/create-mercato-app


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Implements Ready Apps Framework from 2026-03-02-ready-apps-framework.md in create-mercato-app, adding first-class support for bootstrapping official and external ready apps.

Description

- Adds --app <name> for official Open Mercato ready apps and --app-url <github-url> for external GitHub-hosted ready apps.
- Resolves official apps to open-mercato/ready-app-<name> and pins them to the exact v<create-mercato-app version> tag.
- Downloads ready apps as GitHub tarball snapshots and imports them as raw source, without template processing or dependency rewrites.
- Skips the interactive agentic setup for imported ready apps while still creating required bootstrap-safe generated files.
- Adds fail-closed validation and clearer errors for invalid URLs, duplicate flags, missing repos/tags, private repos, rate limits, and .template files in imported apps.
- Updates docs/spec status and adds automated coverage for the new ready-app CLI flow.