### PR TITLE
feat(agentic): standalone app skills, navigation guide, and module-level guides

### DIFF
--- a/packages/core/src/modules/auth/agentic/standalone-guide.md
+++ b/packages/core/src/modules/auth/agentic/standalone-guide.md
@@ -1,0 +1,101 @@
+# Auth Module — Standalone App Guide
+
+The auth module handles staff authentication, authorization, users, roles, and RBAC. For customer portal authentication, see the `customer_accounts` module guide.
+
+## RBAC Implementation
+
+### Two-Layer Model
+
+1. **Role ACLs** — features assigned to roles (admin, employee, etc.)
+2. **User ACLs** — per-user overrides (additional features or restrictions)
+
+Effective permissions = Role features + User-specific features.
+
+### Declaring Features
+
+Every module MUST declare features in `acl.ts` and wire them in `setup.ts`:
+
+```typescript
+// src/modules/<your_module>/acl.ts
+export const features = [
+  'your_module.view',
+  'your_module.create',
+  'your_module.update',
+  'your_module.delete',
+]
+
+// src/modules/<your_module>/setup.ts
+import type { ModuleSetupConfig } from '@open-mercato/shared/modules/setup'
+
+export const setup: ModuleSetupConfig = {
+  defaultRoleFeatures: {
+    superadmin: ['your_module.*'],
+    admin: ['your_module.*'],
+    user: ['your_module.view'],
+  },
+}
+```
+
+### Feature Naming Convention
+
+Features follow the `<module>.<action>` pattern (e.g., `users.view`, `users.edit`).
+
+### Declarative Guards
+
+Prefer declarative guards in page and API metadata:
+
+```typescript
+export const metadata = {
+  requireAuth: true,
+  requireRoles: ['admin'],
+  requireFeatures: ['users.manage'],
+}
+```
+
+### Server-Side Checks
+
+```typescript
+const rbacService = container.resolve('rbacService')
+const hasAccess = await rbacService.userHasAllFeatures(
+  userId,
+  ['your_module.view'],
+  { tenantId, organizationId }
+)
+```
+
+### Wildcards
+
+Wildcards are first-class ACL grants: `module.*` and `*` satisfy matching concrete features. When your code inspects raw granted feature arrays (instead of calling `rbacService`), use the shared wildcard-aware matchers (`matchFeature`, `hasFeature`, `hasAllFeatures`) — never use `includes(...)`.
+
+### Special Flags
+
+- `isSuperAdmin` — bypasses all feature checks
+- Organization visibility list — restricts which organizations a user can access
+
+## Security Rules
+
+- Hash passwords with `bcryptjs` (cost >= 10)
+- Never log credentials
+- Return minimal auth error messages — never reveal whether an email exists
+- Use `findWithDecryption` / `findOneWithDecryption` for user queries
+
+## Authentication Flow
+
+1. User submits credentials via `POST /api/auth/session`
+2. Password verified with bcryptjs
+3. JWT session token issued
+4. Session attached to requests via middleware
+
+## Subscribing to Auth Events
+
+```typescript
+export const metadata = {
+  event: 'auth.user.created',
+  persistent: true,
+  id: 'your-module-user-created',
+}
+
+export default async function handler(payload, ctx) {
+  // React to new user registration
+}
+```

--- a/packages/core/src/modules/catalog/agentic/standalone-guide.md
+++ b/packages/core/src/modules/catalog/agentic/standalone-guide.md
@@ -1,0 +1,79 @@
+# Catalog Module — Standalone App Guide
+
+Use the catalog module for products, categories, pricing, variants, and offers.
+
+## Pricing System
+
+Never reimplement pricing logic. Use the catalog pricing service via DI:
+
+```typescript
+const pricingService = container.resolve('catalogPricingService')
+```
+
+- `selectBestPrice` — finds the best price for a given context (customer, channel, quantity)
+- `resolvePriceVariantId` — resolves variant-level prices
+- Register custom pricing resolvers with priority (higher = checked first):
+
+```typescript
+import { registerCatalogPricingResolver } from '@open-mercato/core/modules/catalog/lib/pricing'
+registerCatalogPricingResolver(myResolver, { priority: 10 })
+```
+
+Price layers compose in order: base price → channel override → customer-specific → promotional.
+
+The pipeline emits `catalog.pricing.resolve.before` and `catalog.pricing.resolve.after` events that your module can subscribe to.
+
+## Data Model
+
+| Entity | Purpose | Key Constraints |
+|--------|---------|----------------|
+| **Products** | Core items with media and descriptions | MUST have at least a name |
+| **Categories** | Hierarchical product grouping | No circular parent-child references |
+| **Variants** | Product variations (size, color) | MUST reference valid option schemas |
+| **Prices** | Multi-tier with channel scoping | Use `selectBestPrice` for resolution |
+| **Offers** | Time-limited promotions | MUST have valid date ranges |
+| **Option Schemas** | Variant option type definitions | Cannot delete while variants reference them |
+
+## Subscribing to Catalog Events
+
+React to product lifecycle events in your module:
+
+```typescript
+// src/modules/<your_module>/subscribers/product-updated.ts
+export const metadata = {
+  event: 'catalog.product.updated',
+  persistent: true,
+  id: 'your-module-product-updated',
+}
+
+export default async function handler(payload, ctx) {
+  // payload.resourceId = product ID
+}
+```
+
+Key events:
+- `catalog.product.created` / `updated` / `deleted`
+- `catalog.pricing.resolve.before` / `after` (excluded from workflow triggers)
+
+## Extending Catalog UI
+
+Use widget injection to add your module's UI into catalog pages:
+
+```typescript
+// src/modules/<your_module>/widgets/injection-table.ts
+export const widgetInjections = {
+  'crud-form:catalog.catalog_product:fields': {
+    widgetId: 'your-module-product-fields',
+    priority: 100,
+  },
+}
+```
+
+Common injection spots:
+- `crud-form:catalog.catalog_product:fields` — product edit form
+- `data-table:catalog.products:columns` — product list columns
+- `data-table:catalog.products:row-actions` — product row actions
+
+## Using Catalog in Sales
+
+When building sales-related features, use the catalog pricing service to resolve prices rather than reading price entities directly. This ensures channel scoping, customer-specific pricing, and promotional offers are applied correctly.

--- a/packages/core/src/modules/currencies/agentic/standalone-guide.md
+++ b/packages/core/src/modules/currencies/agentic/standalone-guide.md
@@ -1,0 +1,43 @@
+# Currencies Module — Standalone App Guide
+
+Use the currencies module for multi-currency support, exchange rates, and currency conversion.
+
+## Key Rules
+
+1. **Store amounts with 4 decimal precision** — never truncate to 2 decimals internally
+2. **Use date-based exchange rates** — always resolve rates for the transaction date, not the "current" rate
+3. **Record both currencies** — dual recording (transaction currency + base currency) is mandatory for reporting
+4. **Calculate realized gains/losses** on payment: `(payment rate - invoice rate) × foreign amount`
+5. **Never hard-delete exchange rates** — they are historical reference data
+
+## Multi-Currency Transaction Pattern
+
+When processing multi-currency transactions (e.g., sales invoice in EUR with USD base):
+
+1. Retrieve the exchange rate for the transaction date
+2. Generate the document in the transaction currency
+3. Calculate the base currency equivalent: `foreign amount × rate`
+4. Store both amounts on the document
+5. On payment: calculate realized gain/loss from rate difference
+6. Report in both transaction and base currencies
+
+## Data Model
+
+| Entity | Table | Purpose |
+|--------|-------|---------|
+| **Currency** | `currency` | Currency master data (code, name, symbol) |
+| **Exchange Rate** | `exchange_rate` | Daily exchange rates per currency pair |
+
+## Adding a New Currency
+
+1. Add the currency record via the admin UI or `seedDefaults` hook in your `setup.ts`
+2. Ensure exchange rates exist for the currency pair at required dates
+3. Verify all sales/pricing logic resolves the new currency correctly
+
+## Using Currencies in Your Module
+
+When your module deals with monetary amounts:
+- Store the currency code alongside the amount
+- Reference the currencies module for exchange rate lookups
+- Use the transaction date for rate resolution, not the current date
+- Store both foreign and base amounts for reporting

--- a/packages/core/src/modules/customer_accounts/agentic/standalone-guide.md
+++ b/packages/core/src/modules/customer_accounts/agentic/standalone-guide.md
@@ -1,0 +1,124 @@
+# Customer Accounts Module — Standalone App Guide
+
+Customer-facing identity and portal authentication. This module manages customer user accounts, sessions, roles, and the authentication flow for the customer portal. It is separate from the staff `auth` module.
+
+## Portal Authentication
+
+### Login Flow
+1. Customer submits credentials via `POST /api/login`
+2. Password verified with bcryptjs, lockout checked (5 attempts → 15 min lock)
+3. JWT issued with customer claims (`type: 'customer'`, features, CRM links)
+4. Two cookies set: `customer_auth_token` (JWT, 8h) + `customer_session_token` (raw, 30d)
+
+### Other Auth Methods
+- **Signup**: `POST /api/signup` — self-registration with email verification
+- **Magic Link**: `POST /api/magic-link/request` + `/verify` — passwordless login (15 min TTL)
+- **Password Reset**: `POST /api/password/reset-request` + `/reset-confirm` (60 min TTL)
+- **Invitation**: Admin invites user → `POST /api/invitations/accept` (72h TTL)
+
+## Customer RBAC
+
+### Two-Layer Model (mirrors staff RBAC)
+1. **Role ACLs** — features assigned to roles
+2. **User ACLs** — per-user overrides (takes precedence if present)
+
+### Default Roles (seeded on tenant creation)
+| Role | Features | Portal Admin |
+|------|----------|-------------|
+| Portal Admin | `portal.*` | Yes |
+| Buyer | Orders, quotes, catalog, account | No |
+| Viewer | Read-only orders, invoices, catalog | No |
+
+### Feature Convention
+Portal features use `portal.<area>.<action>` naming (e.g., `portal.orders.view`, `portal.catalog.view`).
+
+### Cross-Module Feature Merging
+Your module can declare `defaultCustomerRoleFeatures` in `setup.ts`. During tenant setup, these are merged into the corresponding customer role ACLs:
+
+```typescript
+// src/modules/<your_module>/setup.ts
+export const setup: ModuleSetupConfig = {
+  defaultCustomerRoleFeatures: {
+    portal_admin: ['portal.your_feature.*'],
+    buyer: ['portal.your_feature.view'],
+  },
+}
+```
+
+## Using Customer Auth in Your Module
+
+### Server Components (pages)
+```typescript
+import { getCustomerAuthFromCookies } from '@open-mercato/core/modules/customer_accounts/lib/customerAuthServer'
+
+const auth = await getCustomerAuthFromCookies()
+if (!auth) redirect('/login')
+```
+
+### API Routes
+```typescript
+import { requireCustomerAuth, requireCustomerFeature } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
+
+// In your API handler:
+const auth = requireCustomerAuth(request)  // throws 401 if not authenticated
+requireCustomerFeature(auth, ['portal.orders.view'])  // throws 403 if missing
+```
+
+### RBAC Service
+```typescript
+const rbacService = container.resolve('customerRbacService')
+const hasAccess = await rbacService.userHasAllFeatures(
+  userId, ['portal.orders.view'], { tenantId, organizationId }
+)
+```
+
+## Portal Page Guards
+
+Use declarative metadata for portal pages:
+
+```typescript
+export const metadata = {
+  requireCustomerAuth: true,
+  requireCustomerFeatures: ['portal.orders.view'],
+}
+```
+
+## Subscribing to Customer Events
+
+| Event | When |
+|-------|------|
+| `customer_accounts.user.created` | New customer signup |
+| `customer_accounts.user.updated` | Profile updated |
+| `customer_accounts.user.locked` | Account locked after failed logins |
+| `customer_accounts.login.success` | Successful login |
+| `customer_accounts.invitation.accepted` | Invitation accepted |
+
+```typescript
+export const metadata = {
+  event: 'customer_accounts.user.created',
+  persistent: true,
+  id: 'your-module-customer-signup',
+}
+
+export default async function handler(payload, ctx) {
+  // React to customer signup — e.g., create default preferences
+}
+```
+
+## CRM Auto-Linking
+
+When a customer signs up, the module automatically searches for a matching CRM person by email and links them (`personEntityId`). The reverse also works — creating a CRM person auto-links to an existing customer user.
+
+## Widget Injection Spots
+
+| Spot | Widget | Purpose |
+|------|--------|---------|
+| `crud-form:customers:customer_person_profile:fields` | Account status | Shows portal account status on CRM person detail |
+| `crud-form:customers:customer_company_profile:fields` | Company users | Shows portal users linked to a CRM company |
+
+## Security Notes
+
+- All public endpoints are rate-limited (per-email + per-IP)
+- Tokens stored as SHA-256 hashes — raw tokens never persisted
+- Emails use deterministic hash for lookups (`hashForLookup`)
+- Error messages never confirm whether an email is registered

--- a/packages/core/src/modules/customers/agentic/standalone-guide.md
+++ b/packages/core/src/modules/customers/agentic/standalone-guide.md
@@ -1,0 +1,138 @@
+# Customers Module — Reference CRUD Patterns
+
+This is the **reference CRUD module**. When building new modules in your standalone app, follow these patterns.
+
+## CRUD API Pattern
+
+Use `makeCrudRoute` with `indexer: { entityType }` for query index coverage:
+
+```typescript
+// src/modules/<your_module>/api/get/<entities>.ts
+import { makeCrudRoute } from '@open-mercato/shared/lib/crud/make-crud-route'
+import { YourEntity } from '../../entities/YourEntity'
+
+const handler = makeCrudRoute({
+  entity: YourEntity,
+  entityId: 'your_module.your_entity',
+  operations: ['list', 'detail'],
+  indexer: { entityType: 'your_module.your_entity' },
+})
+
+export default handler
+export const openApi = { summary: 'List and retrieve entities', tags: ['Your Module'] }
+```
+
+Key points:
+- Always set `indexer: { entityType }` — keeps custom entities indexed
+- Wire custom field helpers for create/update if your module supports custom fields
+- Export `openApi` on every API route file
+
+## Undoable Commands Pattern
+
+All write operations should use the Command pattern with undo support:
+
+```typescript
+import { registerCommand } from '@open-mercato/shared/lib/commands'
+import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
+
+registerCommand('your_module.entity.create', {
+  async execute(payload, ctx) {
+    // 1. Create entity
+    // 2. Capture snapshot for undo: extractUndoPayload(entity)
+    // 3. Side effects: emitCrudSideEffects({ indexer: { entityType, cacheAliases } })
+  },
+  async undo(payload, ctx) {
+    // 1. Restore from snapshot
+    // 2. Side effects: emitCrudUndoSideEffects({ indexer: { entityType, cacheAliases } })
+  },
+})
+```
+
+Key points:
+- Include `indexer: { entityType, cacheAliases }` in both `emitCrudSideEffects` and `emitCrudUndoSideEffects`
+- Capture custom field snapshots in `before`/`after` payloads (`snapshot.custom`)
+- Restore custom fields via `buildCustomFieldResetMap(before.custom, after.custom)` in undo
+
+## Custom Field Integration
+
+```typescript
+import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customFieldValues'
+```
+
+- Pass `{ transform }` to normalize values (e.g., `normalizeCustomFieldSubmitValue`)
+- Works for both `cf_` and `cf:` prefixed keys
+- Pass `entityIds` to form helpers so correct custom-field sets are loaded
+- If your module ships default custom fields, declare them in `ce.ts` via `entities[].fields`
+
+## Search Configuration
+
+Declare in `search.ts` with all three strategies:
+
+```typescript
+import type { SearchModuleConfig } from '@open-mercato/shared/modules/search'
+
+export const searchConfig: SearchModuleConfig = {
+  entities: {
+    'your_module.your_entity': {
+      fields: ['name', 'description'],  // Fulltext indexing
+      // fieldPolicy for sensitive field handling
+      // buildSource for vector embeddings
+      // formatResult for search result display
+    },
+  },
+}
+```
+
+Key points:
+- Use `fieldPolicy.excluded` for sensitive fields (passwords, tokens)
+- Use `fieldPolicy.hashOnly` for PII needing exact-match only (email, phone)
+- Always define `formatResult` for human-friendly search results
+
+## Backend Page Structure
+
+Follow this pattern for each page type:
+
+| Page | Pattern | Key Features |
+|------|---------|-------------|
+| **List** | `DataTable` | Filters, search, export, row actions, pagination |
+| **Create** | `CrudForm` mode=create | Fields, groups, custom fields, back link |
+| **Detail/Edit** | `CrudForm` mode=edit or tabbed layout | Entity data, related entities, activities |
+
+## Module Files Checklist
+
+When scaffolding a new CRUD module, ensure all these files are present:
+
+| File | Purpose |
+|------|---------|
+| `index.ts` | Module metadata |
+| `acl.ts` | Feature-based permissions |
+| `setup.ts` | Tenant init, default role features |
+| `di.ts` | Awilix DI registrations |
+| `events.ts` | Typed event declarations |
+| `data/entities.ts` | MikroORM entity classes |
+| `data/validators.ts` | Zod validation schemas |
+| `search.ts` | Search indexing configuration |
+| `ce.ts` | Custom entities / custom field sets |
+
+Optional:
+- `translations.ts` — translatable fields per entity
+- `notifications.ts` — notification type definitions
+- `cli.ts` — module CLI commands
+
+## Entity Update Safety
+
+When mutating entities across multiple phases that include queries:
+
+```typescript
+import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
+
+await withAtomicFlush(em, [
+  () => { record.name = 'New'; record.status = 'active' },
+  () => syncEntityTags(em, record, tags),
+], { transaction: true })
+
+// Side effects AFTER the atomic flush
+await emitCrudSideEffects({ ... })
+```
+
+Never run `em.find`/`em.findOne` between scalar mutations and `em.flush()` without `withAtomicFlush` — changes will be silently lost.

--- a/packages/core/src/modules/data_sync/agentic/standalone-guide.md
+++ b/packages/core/src/modules/data_sync/agentic/standalone-guide.md
@@ -1,0 +1,107 @@
+# Data Sync Module — Standalone App Guide
+
+The data sync module provides a streaming synchronization hub for import/export operations with external systems. Provider modules register `DataSyncAdapter` implementations.
+
+## Creating a Sync Adapter
+
+Implement the `DataSyncAdapter` interface in your provider module:
+
+```typescript
+import type { DataSyncAdapter } from '@open-mercato/core/modules/data_sync/lib/adapter'
+
+const myAdapter: DataSyncAdapter = {
+  providerKey: 'my_provider',
+  direction: 'import',  // 'import' | 'export' | 'bidirectional'
+  supportedEntities: ['catalog.product', 'customers.person'],
+
+  async *streamImport(entityType, cursor, config) {
+    // Yield ImportBatch objects with records
+    yield { records: [...], cursor: 'next-page-token' }
+  },
+
+  async validateConnection(credentials) {
+    // Verify external system is reachable
+    return { valid: true }
+  },
+
+  async getInitialCursor(entityType) {
+    return null  // Start from beginning
+  },
+}
+```
+
+Register in your module's `di.ts`:
+```typescript
+import { registerDataSyncAdapter } from '@open-mercato/core/modules/data_sync/lib/adapter-registry'
+registerDataSyncAdapter(myAdapter)
+```
+
+## Run Lifecycle
+
+```
+pending → running → completed | failed | cancelled
+```
+
+- **Cursor persistence**: After each batch, cursor is saved — enables resume on failure
+- **Progress**: Linked to `ProgressJob` for live progress display via `ProgressTopBar`
+- **Cancellation**: Via `progressService.isCancellationRequested()`
+- **Overlap protection**: Only one sync per integration + entityType + direction at a time
+
+## Key Services (DI)
+
+| Service | Purpose |
+|---------|---------|
+| `dataSyncRunService` | CRUD for sync runs, cursor management, overlap detection |
+| `dataSyncEngine` | Orchestrates streaming import/export with batch processing and progress |
+| `externalIdMappingService` | Maps local entity IDs to/from external system IDs |
+
+## Starting a Sync
+
+Via API:
+```
+POST /api/data_sync/run
+{ "integrationId": "my_provider", "entityType": "catalog.product", "direction": "import" }
+```
+
+Syncs run asynchronously via the queue system — never run inline in API handlers.
+
+## Queue Workers
+
+| Queue | Worker | Concurrency |
+|-------|--------|-------------|
+| `data-sync-import` | Import handler | 5 |
+| `data-sync-export` | Export handler | 5 |
+| `data-sync-scheduled` | Scheduled sync dispatch | 3 |
+
+## Events
+
+| Event | When |
+|-------|------|
+| `data_sync.run.started` | Sync begins processing |
+| `data_sync.run.completed` | Sync finishes successfully |
+| `data_sync.run.failed` | Sync fails |
+| `data_sync.run.cancelled` | Sync is cancelled |
+
+Subscribe to these events to trigger post-sync side effects in your module.
+
+## UMES Extension Points
+
+Sync providers can extend the platform UI:
+
+| Extension | Use Case |
+|-----------|----------|
+| **Widget Injection** | Sync status badges, mapping previews on entity pages |
+| **Event Subscribers** | React to sync lifecycle events |
+| **Entity Extensions** | Link sync metadata to core entities |
+| **Response Enrichers** | Attach external ID data to API responses |
+| **Notifications** | Alerts on sync completion/failure |
+| **DOM Event Bridge** | Real-time sync progress via SSE |
+| **Menu Injection** | Provider-specific sync dashboards in sidebar |
+
+## Key Rules
+
+- Always scope queries by `organizationId` + `tenantId`
+- Use the queue system — never run syncs inline
+- Persist cursor after each batch — enables resume on failure
+- Log item-level errors — don't stop the sync for individual failures
+- Check for overlap before starting a new run

--- a/packages/core/src/modules/integrations/agentic/standalone-guide.md
+++ b/packages/core/src/modules/integrations/agentic/standalone-guide.md
@@ -1,0 +1,113 @@
+# Integrations Module — Standalone App Guide
+
+The integrations module provides the foundation for all external connectors (payment gateways, shipping carriers, data sync providers, etc.). It offers three shared mechanisms: **Integration Registry**, **Credentials API**, and **Operation Logs**.
+
+## Creating an Integration Provider
+
+Create a new module in your app for each provider:
+
+1. Create `src/modules/<provider_id>/` with standard module files
+2. Add `integration.ts` at the module root exporting an `IntegrationDefinition`:
+
+```typescript
+import type { IntegrationDefinition } from '@open-mercato/shared/modules/integrations/types'
+
+export const integration: IntegrationDefinition = {
+  id: 'my_provider',
+  name: 'My Provider',
+  description: 'Integration with My Provider',
+  category: 'payment',
+  credentials: {
+    fields: [
+      { key: 'apiKey', label: 'API Key', type: 'password', required: true },
+      { key: 'environment', label: 'Environment', type: 'select', options: ['sandbox', 'production'] },
+    ],
+  },
+  healthCheck: { service: 'myProviderHealthCheck' },  // optional
+  apiVersions: ['v1', 'v2'],                          // optional
+}
+```
+
+3. Register the health check service in `di.ts` (if declared)
+4. Run `yarn generate` to auto-discover the integration
+
+## Key Services (DI)
+
+| Service | Purpose |
+|---------|---------|
+| `integrationCredentialsService` | Encrypted credential CRUD with bundle fallthrough |
+| `integrationStateService` | Enable/disable, API version, reauth, health state |
+| `integrationLogService` | Structured logging with scoped loggers |
+| `integrationHealthService` | Resolves and runs provider health checks |
+
+## Credential Resolution
+
+1. Direct credentials for the integration ID
+2. If `bundleId` is set, fallback to bundle's credentials
+3. Returns `null` if neither exists
+
+## Bundle Integrations
+
+For platform connectors with multiple integrations (e.g., an ERP with products + orders sync):
+
+```typescript
+export const bundle: IntegrationBundle = {
+  id: 'my_erp',
+  name: 'My ERP',
+  integrations: ['my_erp_products', 'my_erp_orders'],
+}
+```
+
+- Set `bundleId` on each child integration
+- Bundle credentials are shared via fallthrough
+
+## Events
+
+| Event | When |
+|-------|------|
+| `integrations.credentials.updated` | Credentials saved |
+| `integrations.state.updated` | Integration enabled/disabled |
+| `integrations.version.changed` | API version changed |
+| `integrations.log.created` | Log entry written |
+
+## Extending the Integration Detail Page
+
+Provider modules can add tabs, cards, or sections to the integration detail page:
+
+```typescript
+// integration.ts
+import { buildIntegrationDetailWidgetSpotId } from '@open-mercato/shared/modules/integrations/types'
+
+export const integration = {
+  id: 'my_provider',
+  detailPage: {
+    widgetSpotId: buildIntegrationDetailWidgetSpotId('my_provider'),
+  },
+} satisfies IntegrationDefinition
+```
+
+Register widgets for that spot in `widgets/injection-table.ts`. Use `placement.kind: 'tab'` for additional tabs, `'group'` for card panels, `'stack'` for inline sections.
+
+## UMES Extension Points
+
+Integration providers can leverage the full extension system:
+
+| Extension | Use Case |
+|-----------|----------|
+| **Widget Injection** | Inject status badges, config panels into other modules |
+| **Event Subscribers** | React to integration events for side-effects |
+| **Entity Extensions** | Link provider data to core entities (e.g., external IDs) |
+| **Response Enrichers** | Attach provider data to API responses |
+| **API Interceptors** | Intercept routes with before/after hooks |
+| **Notifications** | In-app alerts on integration events |
+| **DOM Event Bridge** | Real-time updates via SSE (`clientBroadcast: true`) |
+
+## Provider-Owned Env Preconfiguration
+
+If your provider needs credentials or settings after a fresh install:
+
+- Read env vars in a provider-local helper (e.g., `lib/preset.ts`)
+- Apply from your module's `setup.ts` for automatic tenant bootstrap
+- Expose a CLI command for rerunning the bootstrap
+- Use provider-prefixed env names (e.g., `OM_INTEGRATION_MYPROVIDER_*`)
+- Persist through normal integration services — never special-case in core

--- a/packages/core/src/modules/sales/agentic/standalone-guide.md
+++ b/packages/core/src/modules/sales/agentic/standalone-guide.md
@@ -1,0 +1,84 @@
+# Sales Module — Standalone App Guide
+
+Use the sales module for orders, quotes, invoices, shipments, and payments. This module has the most complex business logic in the system.
+
+## Document Flow
+
+```
+Quote → Order → Invoice
+         ↓
+    Shipments + Payments
+```
+
+- Quotes convert to orders — do not create orders without a source quote (unless configured)
+- Orders track shipments and payments independently
+- Each entity has its own status workflow — do not skip states
+- Returns create line-level adjustments and update `returned_quantity`
+
+## Pricing Calculations
+
+Always use the sales calculation service — never inline price math:
+
+```typescript
+const calcService = container.resolve('salesCalculationService')
+```
+
+- Dispatches `sales.line.calculate.*` and `sales.document.calculate.*` events
+- For catalog pricing: use `selectBestPrice` from the catalog module
+- Register custom line/totals calculators or override via DI
+
+## Channel Scoping
+
+All sales documents are scoped to channels. Channel selection affects:
+- Available pricing tiers
+- Document numbering sequences
+- Visibility in admin UI
+
+## Data Model
+
+### Core Entities
+| Entity | Purpose | Key Constraint |
+|--------|---------|---------------|
+| **Sales Orders** | Confirmed customer orders | MUST have a channel and at least one line |
+| **Sales Quotes** | Proposed orders | MUST track conversion status |
+| **Order/Quote Lines** | Individual items | MUST reference valid products |
+| **Adjustments** | Discounts/surcharges | MUST use registered `AdjustmentKind` |
+
+### Fulfillment
+| Entity | Purpose |
+|--------|---------|
+| **Shipments** | Delivery tracking with status workflow |
+| **Payments** | Payment recording with status workflow |
+| **Returns** | Order returns with line selection and automatic adjustments |
+
+### Configuration (do not modify directly)
+Channels, statuses, payment/shipping methods, price kinds, adjustment kinds, and document numbers — configure via admin UI or `setup.ts` hooks.
+
+## Subscribing to Sales Events
+
+```typescript
+// src/modules/<your_module>/subscribers/order-created.ts
+export const metadata = {
+  event: 'sales.order.created',
+  persistent: true,
+  id: 'your-module-order-created',
+}
+
+export default async function handler(payload, ctx) {
+  // React to new orders
+}
+```
+
+Key events: `sales.order.created` / `updated` / `deleted`, `sales.quote.created` / `updated`, `sales.payment.created`, `sales.shipment.created`
+
+## Extending Sales UI
+
+Common widget injection spots:
+- `crud-form:sales.sales_order:fields` — order detail form
+- `data-table:sales.orders:columns` — order list columns
+- `data-table:sales.orders:row-actions` — order row actions
+- `sales.document.detail.order:details` — order detail page sections
+
+## Frontend Pages
+
+- `frontend/quote/` — public-facing quote view for customer acceptance

--- a/packages/core/src/modules/workflows/agentic/standalone-guide.md
+++ b/packages/core/src/modules/workflows/agentic/standalone-guide.md
@@ -1,0 +1,152 @@
+# Workflows Module — Standalone App Guide
+
+Use the workflows module for business process automation: defining step-based workflows, executing instances, handling user tasks, and triggering workflows from domain events.
+
+## Using Workflows in Your App
+
+The workflow engine is provided by `@open-mercato/core`. Your standalone app can:
+
+1. **Create workflow definitions** via the visual editor at `/backend/workflows`
+2. **Trigger workflows** from domain events emitted by your modules
+3. **Subscribe to workflow events** for side effects in your modules
+4. **Inject UI widgets** into workflow pages or inject workflow widgets into your pages
+5. **Define user tasks** that require human approval or data entry
+
+## Starting Workflows Programmatically
+
+Resolve the workflow executor via DI — never import lib functions directly:
+
+```typescript
+// In your module's DI-aware context (API route, subscriber, worker)
+const executor = container.resolve('workflowExecutor')
+
+await executor.startWorkflow({
+  workflowId: 'order-approval',  // matches a WorkflowDefinition.workflowId
+  context: {
+    orderId: order.id,
+    orderTotal: order.totalGross,
+    customerName: order.customerName,
+  },
+  organizationId,
+  tenantId,
+})
+```
+
+## Event Triggers
+
+Configure automatic workflow starts from your module's domain events:
+
+1. Create a workflow definition with a `triggers[]` entry in the visual editor or via API
+2. The workflow engine's wildcard subscriber evaluates all non-internal events
+3. Use `filterConditions` to narrow which events match (e.g., only orders above a threshold)
+4. Use `contextMapping` to extract event payload fields into workflow context variables
+5. Use `debounceMs` and `maxConcurrentInstances` to prevent trigger storms
+
+Excluded event prefixes (never trigger workflows): `query_index`, `search`, `workflows`, `cache`, `queue`.
+
+## Subscribing to Workflow Events
+
+React to workflow lifecycle events in your module:
+
+```typescript
+// src/modules/<your_module>/subscribers/workflow-completed.ts
+export const metadata = {
+  event: 'workflows.instance.completed',
+  persistent: true,
+  id: 'your-module-workflow-completed',
+}
+
+export default async function handler(payload, ctx) {
+  // payload.resourceId = instance ID
+  // payload.workflowId = definition ID
+  // payload.context = workflow context variables
+}
+```
+
+Key workflow events your module can subscribe to:
+
+| Event | When it fires |
+|-------|--------------|
+| `workflows.instance.created` | New workflow instance started |
+| `workflows.instance.completed` | Workflow finished successfully |
+| `workflows.instance.failed` | Workflow failed |
+| `workflows.instance.cancelled` | Workflow was cancelled |
+| `workflows.task.created` | User task assigned |
+| `workflows.task.completed` | User task completed |
+| `workflows.step.completed` | Individual step finished |
+
+## Step Types
+
+| Step type | Use case |
+|-----------|----------|
+| `START` | Entry point — every definition has exactly one |
+| `END` | Terminal step — marks workflow as COMPLETED |
+| `USER_TASK` | Human approval or data entry — pauses until task completion |
+| `AUTOMATED` | Executes transition activities immediately and advances |
+| `SUB_WORKFLOW` | Invokes a nested workflow definition |
+| `WAIT_FOR_SIGNAL` | Pauses for an external signal (e.g., payment confirmed) |
+| `WAIT_FOR_TIMER` | Pauses for a configured duration |
+| `PARALLEL_FORK` / `PARALLEL_JOIN` | Splits/merges parallel execution paths |
+
+## Activity Types
+
+Activities execute on transitions between steps:
+
+| Activity type | Use case |
+|---------------|----------|
+| `SEND_EMAIL` | Send templated email |
+| `CALL_API` | Call an internal API endpoint |
+| `CALL_WEBHOOK` | Call an external HTTP endpoint |
+| `UPDATE_ENTITY` | Mutate an entity via the command bus |
+| `EMIT_EVENT` | Emit a domain event |
+| `EXECUTE_FUNCTION` | Run a registered custom function |
+| `WAIT` | Delay execution for a configured duration |
+
+Use `{{context.*}}`, `{{workflow.*}}`, `{{env.*}}`, `{{now}}` for variable interpolation in activity config — never hardcode values.
+
+## Sending Signals
+
+Resume a workflow waiting for an external signal:
+
+```typescript
+const executor = container.resolve('workflowExecutor')
+
+await executor.sendSignal({
+  instanceId: workflowInstanceId,
+  signalName: 'payment_confirmed',
+  payload: { transactionId: '...' },
+  organizationId,
+  tenantId,
+})
+```
+
+## Widget Injection
+
+Inject workflow-related UI into your module's pages, or inject your module's widgets into workflow pages:
+
+```typescript
+// src/modules/<your_module>/widgets/injection-table.ts
+export const widgetInjections = {
+  // Inject into workflow task detail page
+  'workflows.task.detail:after': {
+    widgetId: 'your-module-task-context',
+    priority: 50,
+  },
+}
+```
+
+## Compensation (Saga Pattern)
+
+When a workflow step fails, compensation activities execute in reverse order to undo previous steps. This follows the saga pattern:
+
+- **Sync activities** execute inline and advance immediately
+- **Async activities** enqueue to the `workflow-activities` queue; workflow pauses until completion
+- On failure, compensation runs in reverse — keep activity handlers **idempotent** (check state before mutating)
+
+## Key Rules
+
+- MUST resolve services via DI (`container.resolve('workflowExecutor')`) — never import lib functions directly
+- MUST use `workflowExecutor.startWorkflow()` to create instances — never insert rows directly
+- MUST keep activity handlers idempotent — they may be retried on failure
+- MUST scope all queries by `organization_id` — workflow data is tenant-scoped
+- MUST NOT couple your module to workflow internals — use event triggers and signals for integration

--- a/packages/create-app/agentic/shared/AGENTS.md.template
+++ b/packages/create-app/agentic/shared/AGENTS.md.template
@@ -63,6 +63,8 @@ step, you WILL produce incorrect imports and miss required patterns.
 | Debug / fix errors | `.ai/skills/troubleshooter/SKILL.md` |
 | Review code changes | `.ai/skills/code-review/SKILL.md` |
 | Write a spec | `.ai/skills/spec-writing/SKILL.md`, `.ai/specs/SPEC-000-template.md` |
+| Implement a spec (or selected phases) | `.ai/skills/implement-spec/SKILL.md` |
+| Create / run integration tests | `.ai/skills/integration-tests/SKILL.md` |
 
 ## Module Anatomy
 

--- a/packages/create-app/agentic/shared/AGENTS.md.template
+++ b/packages/create-app/agentic/shared/AGENTS.md.template
@@ -44,6 +44,7 @@ step, you WILL produce incorrect imports and miss required patterns.
 | Add/modify an entity, create migration | `.ai/guides/core.md` → Module Files, then `yarn mercato db generate` |
 | Add a REST API endpoint | `.ai/guides/core.md` → API Routes |
 | Add a backend page | `.ai/guides/ui.md` → CrudForm / DataTable |
+| Configure sidebar navigation, page groups, settings pages | `.ai/skills/module-scaffold/references/navigation-patterns.md` |
 | Add event subscribers or emit events | `.ai/guides/events.md` |
 | Add real-time browser updates (SSE) | `.ai/guides/events.md` → DOM Event Bridge |
 | Add search to a module | `.ai/guides/search.md` |
@@ -55,6 +56,22 @@ step, you WILL produce incorrect imports and miss required patterns.
 | Add permissions (RBAC) | `.ai/guides/core.md` → Access Control |
 | Add notifications | `.ai/guides/core.md` → Notifications |
 | Add custom fields | `.ai/guides/core.md` → Custom Fields |
+
+### Module-Specific Guides
+
+These guides ship automatically when the corresponding module is installed.
+
+| Task | Load |
+|---|---|
+| Build CRUD modules — reference patterns, commands, custom fields, search | `.ai/guides/core.customers.md` (if available) |
+| Use workflow automation, triggers, user tasks, signals | `.ai/guides/core.workflows.md` (if available) |
+| Use product catalog, pricing engine, variants, offers | `.ai/guides/core.catalog.md` (if available) |
+| Use sales orders, quotes, invoices, shipments, payments | `.ai/guides/core.sales.md` (if available) |
+| Use staff authentication, RBAC, roles, feature guards | `.ai/guides/core.auth.md` (if available) |
+| Use multi-currency, exchange rates, dual recording | `.ai/guides/core.currencies.md` (if available) |
+| Build integration providers, credentials, health checks | `.ai/guides/core.integrations.md` (if available) |
+| Build data sync adapters, import/export connectors | `.ai/guides/core.data_sync.md` (if available) |
+| Use customer portal auth, customer RBAC, portal pages | `.ai/guides/core.customer_accounts.md` (if available) |
 
 ### Quality & Process
 
@@ -120,6 +137,9 @@ Register in `src/modules.ts`: `{ id: '<id>', from: '@app' }`
 
 - Custom modules use `from: '@app'` in `src/modules.ts`
 - Sidebar icons MUST use `lucide-react` components — never inline SVG via `React.createElement`
+- `page.meta.ts` MUST include `pageGroup`, `pageGroupKey`, and `pageOrder` for sidebar grouping
+- Settings pages MUST use `pageContext: 'settings' as const` with `navHidden: true`
+- All related pages within a module MUST share the same `pageGroupKey`
 - DataTable MUST wire pagination props (`page`, `pageSize`, `totalCount`, `onPageChange`)
 
 ## Naming Conventions

--- a/packages/create-app/agentic/shared/ai/qa/playwright.config.ts
+++ b/packages/create-app/agentic/shared/ai/qa/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig } from '@playwright/test'
+import path from 'node:path'
+import { discoverIntegrationSpecFiles } from '@open-mercato/cli/lib/testing/integration-discovery'
+
+const captureScreenshots = process.env.PW_CAPTURE_SCREENSHOTS === '1'
+const isGitHubActions = process.env.GITHUB_ACTIONS === 'true'
+const projectRoot = path.resolve(__dirname, '..', '..')
+const qaTestResultsRoot = path.join(projectRoot, '.ai', 'qa', 'test-results')
+const normalizePath = (value: string) => value.split(path.sep).join('/')
+const STATIC_TEST_IGNORES = [
+  `${normalizePath(path.join(projectRoot, '.claude'))}/**`,
+  `${normalizePath(path.join(projectRoot, '.codex'))}/**`,
+  `${normalizePath(path.join(projectRoot, '.cursor'))}/**`,
+  `${normalizePath(path.join(projectRoot, 'node_modules'))}/**`,
+]
+const discoveredSpecs = discoverIntegrationSpecFiles(projectRoot, path.join(projectRoot, '.ai', 'qa', 'tests'))
+const discoveredSpecPaths = discoveredSpecs.map((entry) => entry.path)
+
+export default defineConfig({
+  testDir: projectRoot,
+  testMatch: discoveredSpecPaths.length > 0 ? discoveredSpecPaths : ['.ai/qa/tests/__no_tests__/*.spec.ts'],
+  testIgnore: [
+    ...STATIC_TEST_IGNORES,
+  ],
+  timeout: 20_000,
+  expect: {
+    timeout: 20_000,
+  },
+  retries: 1,
+  workers: 1,
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    headless: true,
+    screenshot: captureScreenshots ? 'on' : 'only-on-failure',
+    trace: 'on-first-retry',
+  },
+  reporter: isGitHubActions
+    ? [
+        ['github'],
+        ['list'],
+        ['json', { outputFile: path.join(qaTestResultsRoot, 'results.json') }],
+        ['html', { outputFolder: path.join(qaTestResultsRoot, 'html'), open: 'never' }],
+      ]
+    : [
+        ['list'],
+        ['json', { outputFile: path.join(qaTestResultsRoot, 'results.json') }],
+        ['html', { outputFolder: path.join(qaTestResultsRoot, 'html'), open: 'never' }],
+      ],
+  outputDir: path.join(qaTestResultsRoot, 'artifacts'),
+})

--- a/packages/create-app/agentic/shared/ai/skills/backend-ui-design/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/backend-ui-design/SKILL.md
@@ -218,3 +218,11 @@ import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customF
 - **Detail pages**: Header + Tabs/Sections + Related data
 - **Create/Edit**: Full-page CrudForm or Dialog with embedded CrudForm
 - **Settings**: Grouped sections with inline editing
+
+## Page Navigation Metadata
+
+Every backend page needs correct `page.meta.ts` for sidebar placement.
+See `.ai/skills/module-scaffold/references/navigation-patterns.md` for:
+- Complete field reference (`pageGroup`, `pageOrder`, `pageContext`, `navHidden`)
+- Settings page pattern (`pageContext: 'settings' as const` + `navHidden: true`)
+- Common anti-patterns (missing group, mismatched keys, broken icons)

--- a/packages/create-app/agentic/shared/ai/skills/code-review/references/review-checklist.md
+++ b/packages/create-app/agentic/shared/ai/skills/code-review/references/review-checklist.md
@@ -55,6 +55,9 @@
 - [ ] Empty states: `EmptyState`
 - [ ] `RowActions` items have stable `id` values
 - [ ] i18n: `useT()` client-side — no hardcoded strings
+- [ ] `page.meta.ts` includes `pageGroup` + `pageGroupKey` for sidebar placement
+- [ ] Settings pages have `pageContext: 'settings' as const` + `navHidden: true`
+- [ ] Sidebar icon uses `lucide-react` (not inline SVG)
 
 ## 7. Naming Conventions
 

--- a/packages/create-app/agentic/shared/ai/skills/implement-spec/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/implement-spec/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: implement-spec
+description: Implement a specification (or specific phases of a spec) using coordinated subagents. Handles multi-phase spec implementation with unit tests, integration tests, documentation, and code-review compliance. Use when the user says "implement spec", "implement the spec", "implement phases", "build from spec", or "code the spec". Tracks progress by updating the spec with implementation status.
+---
+
+# Implement Spec Skill
+
+Implements a specification (or selected phases) end-to-end using a team of coordinated subagents. Every code change MUST pass the code-review checklist before the phase is considered done.
+
+## Pre-Flight
+
+1. **Identify the spec**: Locate the target spec file in `.ai/specs/`.
+2. **Load context**: Read spec fully. Match affected tasks to the **Task → Context Map** in `AGENTS.md` and read all listed files (guides and skills).
+3. **Load code-review checklist**: Read `.ai/skills/code-review/references/review-checklist.md` — this is the acceptance gate for every phase.
+4. **Load lessons**: Read `.ai/lessons.md` for known pitfalls.
+5. **Scope phases**: If the user specifies phases (e.g. "phases c-e"), filter to only those. Otherwise implement all phases sequentially.
+
+## Implementation Workflow
+
+For **each phase** in the spec, execute these steps:
+
+### Step 1 — Plan the Phase
+
+Read the phase from the spec. For each step within the phase:
+- Identify files to create or modify (all paths under `src/modules/`)
+- Identify which guides and skills apply (use the Task → Context Map in `AGENTS.md`)
+- List required exports, conventions, and patterns from the relevant guides
+- Note any cross-module impacts (events, extensions, widgets, enrichers)
+
+Present a brief plan to the user before coding.
+
+### Step 2 — Implement
+
+Use subagents liberally to parallelize independent work:
+- **One subagent per independent file/component** when files don't depend on each other
+- **Sequential execution** when there are dependencies (e.g., entity before API route before backend page)
+
+For every piece of code, enforce these code-review rules inline:
+
+| Area | Rule |
+|------|------|
+| Types | No `any` — use zod + `z.infer` |
+| API routes | Export `openApi` and `metadata` with auth guards |
+| Entities | Standard columns, snake_case, UUID PKs, `organization_id` + `tenant_id` |
+| Security | `findWithDecryption`, tenant scoping, zod validation |
+| UI | `CrudForm`/`DataTable`, `apiCall`, `flash()`, `LoadingMessage`/`ErrorMessage` |
+| Events | `createModuleEvents()` with `as const`, subscribers export `metadata` |
+| i18n | `useT()` client, `resolveTranslations()` server, no hardcoded strings |
+| Imports | Package-level `@open-mercato/<pkg>/...` for framework imports |
+| Mutations | `useGuardedMutation` when not using CrudForm |
+| Keyboard | `Cmd/Ctrl+Enter` submit, `Escape` cancel on dialogs |
+| Naming | Modules plural snake_case, events `module.entity.past_tense`, features `module.action` |
+
+### Step 3 — Unit Tests
+
+For every new feature/function implemented in the phase:
+- Create unit tests colocated with the source (e.g., `*.test.ts` or `__tests__/`)
+- Test happy path + key edge cases
+- Test error paths for validation and authorization
+- Mock external dependencies (DI services, data engine)
+- Verify tests pass: `yarn test`
+
+### Step 4 — Integration Tests
+
+If the spec defines integration test scenarios (or the phase adds API endpoints / UI flows):
+- Follow the `integration-tests` skill workflow (`.ai/skills/integration-tests/SKILL.md`)
+- Place tests in `src/modules/<module>/__integration__/TC-{CATEGORY}-{XXX}.spec.ts`
+- Tests MUST be self-contained: create fixtures in setup, clean up in teardown
+- Tests MUST NOT rely on seeded/demo data
+- Run and verify: `npx playwright test --config .ai/qa/playwright.config.ts <path> --retries=0`
+
+If the spec does not explicitly list integration scenarios but the phase adds significant API or UI behavior, propose test scenarios to the user before writing them.
+
+### Step 5 — Documentation
+
+For each new feature:
+- Add/update locale files for new i18n keys
+- If new entities with user-facing text: create `translations.ts`
+- If new convention files: run `yarn generate`
+- Update relevant guides or `AGENTS.md` if the feature introduces new patterns developers should follow
+
+### Step 6 — Self-Review (Code-Review Gate)
+
+Before marking a phase complete, run a self-review against the checklist (`.ai/skills/code-review/references/review-checklist.md`):
+
+1. **Architecture & Module Independence** (section 1)
+2. **Security** (section 2)
+3. **Data Integrity & ORM** (section 3)
+4. **API Routes** (section 4) — if applicable
+5. **Events & Commands** (section 5) — if applicable
+6. **UI & Backend Pages** (section 6) — if applicable
+7. **Naming Conventions** (section 7)
+8. **Anti-Patterns** (section 8)
+
+Fix any violations before proceeding to the next phase.
+
+### Step 7 — Update Spec with Progress
+
+After completing each phase, update the spec file:
+- Add an `## Implementation Status` section at the bottom (or update it if it exists)
+- Use this format:
+
+```markdown
+## Implementation Status
+
+| Phase | Status | Date | Notes |
+|-------|--------|------|-------|
+| Phase A — Foundation | Done | 2026-02-20 | All steps implemented, tests passing |
+| Phase B — Menu Injection | Done | 2026-02-21 | 3/3 steps complete |
+| Phase C — Events Bridge | In Progress | 2026-02-22 | Step 1-2 done, step 3 pending |
+| Phase D — Enrichers | Not Started | — | — |
+```
+
+- For the current phase, mark individual steps:
+
+```markdown
+### Phase C — Detailed Progress
+- [x] Step 1: Create event definitions
+- [x] Step 2: Implement SSE bridge
+- [ ] Step 3: Add client-side hooks
+```
+
+### Step 8 — Verification
+
+After all targeted phases are complete:
+
+1. **Generate check**: `yarn generate` — must complete without errors
+2. **Type check**: `yarn typecheck` — must pass (if available)
+3. **Build check**: `yarn build` — must pass
+4. **Unit test check**: `yarn test` — must pass
+5. **Integration test check**: run any new integration tests — must pass
+6. **Migration check**: `yarn mercato db generate` — if any entities changed (verify generated migration is scoped correctly)
+
+Report results to the user. If any check fails, fix and re-verify.
+
+## Subagent Strategy
+
+| Task | Agent Type | When |
+|------|-----------|------|
+| Research existing patterns | Explore | Before implementing unfamiliar patterns |
+| Implement independent files | general-purpose | When files have no dependencies on each other |
+| Run tests | Bash | After each phase |
+| Self-review | general-purpose | After each phase, against checklist |
+| Integration tests | general-purpose | After phases with API/UI changes |
+
+**Concurrency rule**: Launch parallel subagents only for truly independent work. Sequential for dependent files.
+
+## Rules
+
+- MUST read the full spec before starting implementation
+- MUST read all guides and skills listed in the Task → Context Map before coding
+- MUST pass every applicable code-review checklist item before marking a phase done
+- MUST update the spec with implementation progress after each phase
+- MUST run `yarn build` after final phase to verify no build breaks
+- MUST create unit tests for all new behavioral code
+- MUST create or propose integration tests for phases with API endpoints or UI flows
+- MUST NOT skip the self-review step — it is the quality gate
+- MUST NOT introduce `any` types, hardcoded strings, raw `fetch`, or other anti-patterns
+- MUST keep subagents focused — one task per subagent, clear boundaries
+- MUST report blockers to the user immediately rather than working around them silently
+- MUST run `yarn generate` after creating or modifying module convention files
+- MUST run `yarn mercato db generate` after creating or modifying entities (and confirm migration with user before applying)

--- a/packages/create-app/agentic/shared/ai/skills/integration-tests/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/integration-tests/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: integration-tests
+description: Run and create QA integration tests (Playwright TypeScript), including executing the full suite, converting optional markdown scenarios, and generating new tests from specs or feature descriptions. Use when the user says "run integration tests", "test this feature", "create test for", "convert test case", "run QA tests", or "integration test".
+---
+
+# Integration Tests Skill
+
+This skill generates executable Playwright tests in module-local `__integration__` directories (for example `src/modules/sales/__integration__/TC-SALES-*.spec.ts`) by exploring the running application. It also covers running existing integration tests after feature/bug implementation and reporting failures with artifact-based diagnosis. It optionally produces a markdown scenario (`.ai/qa/scenarios/TC-*.md`) for documentation — the scenario is **not required**.
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Run all tests | `npx playwright test --config .ai/qa/playwright.config.ts` |
+| Run single test | `npx playwright test --config .ai/qa/playwright.config.ts <path>` |
+| Debug (fail-fast) | `npx playwright test --config .ai/qa/playwright.config.ts <path> --retries=0` |
+| View report | `npx playwright show-report .ai/qa/test-results/html` |
+| Test files location | `src/modules/<module>/__integration__/TC-XXX.spec.ts` |
+| Scenario sources (optional) | `.ai/qa/scenarios/TC-XXX-*.md` |
+
+## Runtime Policy
+
+Default QA runtime policy:
+- Keep global settings in `.ai/qa/playwright.config.ts`:
+  - `timeout: 20_000`
+  - `expect.timeout: 20_000`
+  - `retries: 1`
+- Do not add per-test timeout or retry overrides in `.spec.ts` files (`test.setTimeout`, `test.describe.configure({ retries })`, `test.retry`).
+
+Debug/development policy (fail fast while authoring/fixing tests):
+- Override retries at command level with `--retries=0`.
+- Do not edit global config just to debug a single test.
+
+## Workflow
+
+### Phase 1 — Identify What to Test
+
+Determine the feature scope from one of these sources (in priority order):
+
+1. **Spec file**: If a spec is referenced or was just implemented, read it from `.ai/specs/*.md`. Extract testable scenarios from the API Contracts, UI/UX, and Data Models sections.
+2. **User description**: If the user describes a feature ("test the company creation flow"), map it to the relevant module and pages.
+3. **Recent changes**: If triggered after implementation, use `git diff` or recent commits to identify changed endpoints, pages, and components.
+
+For each feature, identify:
+- Which **category** it belongs to (AUTH, CAT, CRM, SALES, ADMIN, INT, API-*)
+- Whether it's a **UI test** or **API test**
+- The **priority** (High for CRUD operations, Medium for settings/config, Low for edge cases)
+- The **prerequisite role** (superadmin, admin, or employee)
+
+### Phase 2 — Find the Next TC Number
+
+List existing test cases in the target category to determine the next sequential number:
+
+```bash
+ls .ai/qa/scenarios/TC-{CATEGORY}-*.md 2>/dev/null | sort | tail -1
+find src/modules -type f -name "TC-{CATEGORY}-*.spec.ts" 2>/dev/null | sort | tail -1
+```
+
+Use the highest number found across both directories, then increment. For example, if the last scenario is TC-CRM-011 but the last test is TC-CRM-013, use TC-CRM-014.
+
+### Phase 3 — Verify the Dev Server Is Running
+
+Before writing or running tests, ensure the app is running:
+
+1. Check if `yarn dev` is active (the app should be listening on `http://localhost:3000` or the `BASE_URL` configured in `.env`).
+2. If not running, tell the user to start it: `yarn dev`.
+3. Use the base URL from `.env` or default to `http://localhost:3000`.
+
+### Phase 4 — Explore the Feature via Playwright MCP
+
+Use the active base URL for MCP navigation, then discover the actual UI:
+
+1. Login with the appropriate role
+2. Navigate to the relevant page
+3. Take snapshots to identify exact element labels, button text, form fields
+4. Walk through the happy path to discover the actual flow
+5. Note any validation messages, success states, redirects
+
+For API tests, use cURL to discover:
+1. The exact endpoint path and method
+2. Required request headers and body shape
+3. The actual response structure
+4. Error responses for invalid inputs
+
+### Phase 5 — Write the Playwright Test
+
+Create the test in the module where the behavior lives:
+
+```
+src/modules/<module>/__integration__/TC-{CATEGORY}-{XXX}.spec.ts
+```
+
+Use the locators discovered in Phase 4 (not guessed). If a scenario was written, reference it in a comment.
+Do not hardcode entity IDs in routes, payloads, or assertions. Resolve entities dynamically at runtime by creating fixtures through API/UI steps or by selecting existing rows via stable UI text/role locators.
+
+**Helpers**: Import shared helpers from `@open-mercato/core/helpers/integration/*`:
+
+```typescript
+import { login } from '@open-mercato/core/helpers/integration/auth'
+import { getAuthToken, apiRequest } from '@open-mercato/core/helpers/integration/api'
+```
+
+| Helper Import | Main Exports | Typical Use |
+|------|-------|--------|
+| `@open-mercato/core/helpers/integration/auth` | `login`, `DEFAULT_CREDENTIALS` | UI authentication and role-based login |
+| `@open-mercato/core/helpers/integration/api` | `getAuthToken`, `apiRequest` | Authenticated API calls in integration tests |
+| `@open-mercato/core/helpers/integration/crmFixtures` | `createCompanyFixture`, `createPersonFixture`, `deleteEntityIfExists` | CRM fixture lifecycle |
+| `@open-mercato/core/helpers/integration/catalogFixtures` | `createProductFixture`, `deleteCatalogProductIfExists` | Catalog fixture lifecycle |
+| `@open-mercato/core/helpers/integration/salesFixtures` | `createSalesQuoteFixture`, `createSalesOrderFixture` | Sales fixture lifecycle |
+| `@open-mercato/core/helpers/integration/authFixtures` | `createRoleFixture`, `createUserFixture` | Role and user fixture lifecycle |
+| `@open-mercato/core/helpers/integration/generalFixtures` | `readJsonSafe`, `expectId` | General-purpose test utilities |
+
+**Metadata for conditional test enablement**:
+
+- Folder-level metadata (`__integration__/meta.ts`):
+
+```ts
+export const integrationMeta = {
+  description: 'Sales flows requiring currencies',
+  dependsOnModules: ['sales', 'currencies'],
+}
+```
+
+- Per-test metadata (sibling `.meta.ts` file):
+
+```ts
+export const integrationMeta = {
+  dependsOnModules: ['catalog'],
+}
+```
+
+If any required module is not enabled in the app, matching tests are skipped automatically.
+
+### Phase 6 — Optionally Write the Markdown Scenario
+
+If documentation is desired, create `.ai/qa/scenarios/TC-{CATEGORY}-{XXX}-{slug}.md` using this template:
+
+```markdown
+# Test Scenario [NUMBER]: [TITLE]
+
+## Test ID
+TC-{CATEGORY}-{XXX}
+
+## Category
+{Category Name}
+
+## Priority
+{High/Medium/Low}
+
+## Type
+{UI Test / API Test}
+
+## Description
+{What this test validates — derived from spec or feature description}
+
+## Prerequisites
+- User is logged in as {role}
+- {Other prerequisites from spec}
+
+## Test Steps
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | {Discovered action} | {Observed result} |
+| 2 | {Discovered action} | {Observed result} |
+
+## Expected Results
+- {Derived from spec's API Contracts or UI/UX section}
+
+## Edge Cases / Error Scenarios
+- {Derived from spec's Risks section or discovered during exploration}
+```
+
+Fill steps with **actual** actions and results observed during Phase 4, not hypothetical ones.
+
+This step is **optional** — skip it if the user only wants the executable test.
+
+### Phase 7 — Verify
+
+Run the new test to confirm it passes:
+
+```bash
+npx playwright test --config .ai/qa/playwright.config.ts <path-to-test-file>
+```
+
+When developing/debugging the test, run fail-fast with no retries:
+
+```bash
+npx playwright test --config .ai/qa/playwright.config.ts <path-to-test-file> --retries=0
+```
+
+If it fails, fix it. Do not leave broken tests.
+
+### Failure Analysis and User Reporting (Mandatory on Failures)
+
+After any failed test run (single test or suite), analyze failure artifacts before responding:
+
+1. Parse terminal output to capture the failing test names and first error stack/assertion.
+2. Inspect Playwright artifacts for each failed test from `test-results/`:
+   - `error-context.md`
+   - Screenshots (expected/actual/diff where available)
+   - Trace/video attachments if present
+3. Classify each failure into one primary reason:
+   - Product regression / real app bug
+   - Test issue (stale locator, brittle assertion, bad fixture/cleanup)
+   - Environment / data issue (service unavailable, auth/session drift)
+4. Decide ownership per failing test:
+   - `User/Product team` when behavior looks like a real regression
+   - `Agent/QA` when failure is test-code quality, selector drift, or fixture instability
+   - `Shared` when both product behavior and test assumptions need adjustment
+5. Respond with a table (required format) before any optional narrative:
+
+| Failing test | Evidence used | Reasoning (why it failed) | Suggested owner | Next action |
+|--------------|---------------|---------------------------|-----------------|-------------|
+| `<path>::<test name>` | `stdout + screenshot` | `Concise diagnosis` | `User/Product` / `Agent/QA` / `Shared` | `Fix recommendation` |
+
+Do not provide a generic "tests failed" summary without per-test reasoning.
+
+### Running-Only Mode (No New Test Authoring)
+
+If the user asks only to run integration tests (full suite/category/single file), skip authoring phases and execute the requested run directly.
+If the run fails, apply the failure-analysis section above.
+
+## Deriving Scenarios from a Spec
+
+When reading a spec, extract test scenarios from these sections:
+
+| Spec Section | Generates |
+|-------------|-----------|
+| API Contracts — each endpoint | One API test per endpoint (CRUD) |
+| UI/UX — each user flow | One UI test per flow |
+| Edge Cases / Error Scenarios | One test per significant error path |
+| Risks & Impact Review | Regression tests for documented failure modes |
+
+Typical spec produces 3-8 test cases. Prioritize:
+1. **High**: CRUD happy paths, authentication, authorization
+2. **Medium**: Validation errors, edge cases with business impact
+3. **Low**: Cosmetic, minor UX edge cases
+
+## Example
+
+Given a spec for an Inventory Management module, the skill would produce:
+
+- `src/modules/inventory/__integration__/TC-INV-001.spec.ts` — UI: create and list inventory items
+- `src/modules/inventory/__integration__/TC-INV-002.spec.ts` — API: CRUD operations on inventory items
+- `src/modules/inventory/__integration__/TC-INV-003.spec.ts` — UI: validation errors on create form
+- Optionally: matching `.ai/qa/scenarios/TC-INV-001-*.md` files for documentation
+
+## Default Credentials
+
+Created via `yarn initialize`:
+
+| Role | Email | Password |
+|------|-------|----------|
+| Superadmin | `superadmin@acme.com` | `secret` |
+| Admin | `admin@acme.com` | `secret` |
+| Employee | `employee@acme.com` | `secret` |
+
+Overridable via env: `OM_INIT_SUPERADMIN_EMAIL`, `OM_INIT_SUPERADMIN_PASSWORD`
+
+## Rules
+
+- MUST explore the running app before writing — never guess selectors or flows
+- MUST verify the dev server is running before executing tests
+- MUST NOT hardcode record IDs (UUIDs/PKs) in generated tests
+- MUST discover or create test entities at runtime, then navigate using discovered links/URLs
+- MUST NOT rely on seeded/demo data for prerequisites
+- MUST create required fixtures per test (prefer API fixture setup for stability)
+- MUST clean up any data created by the test in `finally`/teardown
+- MUST keep tests deterministic and isolated from run order or retries
+- MUST NOT add per-test timeout/retry overrides in `.spec.ts`; rely on global Playwright config (`timeout: 20s`, `expect.timeout: 20s`, `retries: 1`)
+- MUST create the `.spec.ts` — the markdown scenario is optional
+- MUST use actual locators from Playwright MCP snapshots (`getByRole`, `getByLabel`, `getByText`)
+- MUST verify the test passes before finishing
+- MUST analyze failed test artifacts (`stdout`, `error-context.md`, screenshots/report) before reporting failures
+- MUST report failures in a per-test table that includes reason, evidence, and suggested owner
+- MUST place new tests in module-local `__integration__` directories under `src/modules/`
+- MUST use `meta.ts` dependency metadata for module-gated folders and per-test `.meta.ts` for individual gating
+- When deriving from a spec, focus on the happy path first, then add edge cases as separate test cases
+- Each test file covers one scenario — create multiple files for multiple scenarios

--- a/packages/create-app/agentic/shared/ai/skills/module-scaffold/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/module-scaffold/SKILL.md
@@ -279,20 +279,27 @@ export const openApi = {
 
 Use `CrudForm` and `DataTable` from `@open-mercato/ui`. See the `backend-ui-design` skill for full component reference.
 
-### Page Metadata & Sidebar Icons
+### Page Metadata & Sidebar Navigation
 
 **File**: `src/modules/<module_id>/backend/page.meta.ts`
 
-Icons for the admin sidebar MUST use components from `lucide-react`. Never use inline `React.createElement('svg', ...)` — it is fragile in bundler contexts and can produce broken/wrong icons after `yarn generate`.
+Icons MUST use components from `lucide-react`. Never use inline `React.createElement('svg', ...)` — it breaks after `yarn generate`.
+
+For full field reference, settings pages, and anti-patterns, see [references/navigation-patterns.md](references/navigation-patterns.md).
 
 ```tsx
 import { Trophy } from 'lucide-react'
 
 export const metadata = {
-  title: '<Module Name>',
-  icon: <Trophy className="size-4" />,
   requireAuth: true,
-  features: ['<module_id>.view'],
+  requireFeatures: ['<module_id>.view'],
+  pageTitle: '<Module Name>',
+  pageTitleKey: '<module_id>.nav.title',
+  pageGroup: '<Module Name>',                 // Sidebar section name
+  pageGroupKey: '<module_id>.nav.group',      // i18n key — items with same key grouped together
+  pageOrder: 100,                             // Sort within group (lower = higher)
+  icon: <Trophy className="size-4" />,
+  breadcrumb: [{ label: '<Module Name>', labelKey: '<module_id>.nav.title' }],
 }
 ```
 
@@ -323,9 +330,13 @@ export default function <Module>ListPage() {
 }
 
 export const metadata = {
-  title: '<Module Name>',
   requireAuth: true,
-  features: ['<module_id>.view'],
+  requireFeatures: ['<module_id>.view'],
+  pageTitle: '<Module Name>',
+  pageTitleKey: '<module_id>.nav.title',
+  pageGroup: '<Module Name>',
+  pageGroupKey: '<module_id>.nav.group',
+  pageOrder: 100,
 }
 ```
 
@@ -357,9 +368,13 @@ export default function Create<Entity>Page() {
 }
 
 export const metadata = {
-  title: 'Create <Entity>',
   requireAuth: true,
-  features: ['<module_id>.create'],
+  requireFeatures: ['<module_id>.create'],
+  pageTitle: 'Create <Entity>',
+  pageTitleKey: '<module_id>.create.title',
+  pageGroup: '<Module Name>',
+  pageGroupKey: '<module_id>.nav.group',
+  navHidden: true,
 }
 ```
 
@@ -392,9 +407,12 @@ export default function Edit<Entity>Page({ params }: { params: { id: string } })
 }
 
 export const metadata = {
-  title: 'Edit <Entity>',
   requireAuth: true,
-  features: ['<module_id>.update'],
+  requireFeatures: ['<module_id>.update'],
+  pageTitle: 'Edit <Entity>',
+  pageTitleKey: '<module_id>.edit.title',
+  pageGroup: '<Module Name>',
+  pageGroupKey: '<module_id>.nav.group',
 }
 ```
 
@@ -606,6 +624,10 @@ yarn dev               # Start dev server
 - [ ] All API routes export `openApi`
 - [ ] Backend pages use `CrudForm` and `DataTable`
 - [ ] Sidebar icon uses `lucide-react` component (not inline SVG / `React.createElement`)
+- [ ] `page.meta.ts` includes `pageGroup` + `pageGroupKey` for sidebar grouping
+- [ ] `page.meta.ts` includes `pageOrder` for sort position
+- [ ] All related pages share the same `pageGroupKey`
+- [ ] Settings pages (if any) have `pageContext: 'settings' as const` and `navHidden: true`
 - [ ] ACL features declared and wired in `setup.ts`
 - [ ] Module registered in `src/modules.ts` with `from: '@app'`
 - [ ] `yarn generate` run after creating files
@@ -624,6 +646,8 @@ yarn dev               # Start dev server
 - **MUST** validate all inputs with zod schemas in `data/validators.ts`
 - **MUST** export `openApi` from every API route
 - **MUST** use `CrudForm` for forms and `DataTable` for tables
+- **MUST** include `pageGroup` and `pageGroupKey` on list/root backend pages for sidebar grouping
+- **MUST** use `as const` on `pageContext` values (e.g., `pageContext: 'settings' as const`)
 - **MUST** declare ACL features and wire them in `setup.ts` `defaultRoleFeatures`
 - **MUST** register module in `src/modules.ts` with `from: '@app'`
 - **MUST** run `yarn generate` after creating module files

--- a/packages/create-app/agentic/shared/ai/skills/module-scaffold/references/navigation-patterns.md
+++ b/packages/create-app/agentic/shared/ai/skills/module-scaffold/references/navigation-patterns.md
@@ -1,0 +1,97 @@
+# Navigation & Sidebar Patterns
+
+## page.meta.ts — Field Reference
+
+Every backend page needs a `page.meta.ts` file alongside its `page.tsx`. The metadata controls sidebar placement, access control, and display.
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `pageTitle` | string | — | Display title in sidebar and breadcrumb |
+| `pageTitleKey` | string | — | i18n key for title (preferred over `pageTitle`) |
+| `pageGroup` | string | — | **Sidebar section name** — items with same group appear together |
+| `pageGroupKey` | string | — | **i18n key for group** — used as the group identifier for matching |
+| `pageOrder` | number | 10000 | Sort position within group (lower = higher in sidebar) |
+| `icon` | ReactNode | — | Sidebar icon — MUST use `lucide-react` components |
+| `requireAuth` | boolean | false | Require authenticated user |
+| `requireFeatures` | string[] | — | Required ACL feature IDs (from `acl.ts`) |
+| `navHidden` | boolean | false | Hide from sidebar (page still accessible by URL) |
+| `pageContext` | `'main'` \| `'settings'` \| `'profile'` | `'main'` | Which navigation tier this page belongs to |
+| `breadcrumb` | `{ label, labelKey?, href? }[]` | — | Breadcrumb trail above page title |
+
+## Sidebar Group Configuration
+
+Items are grouped by `pageGroupKey` (falls back to `pageGroup` if no key). **All related pages in a module MUST share the same `pageGroupKey`** to appear in the same sidebar section.
+
+```typescript
+// page.meta.ts — List page (appears in sidebar)
+import { ShoppingCart } from 'lucide-react'
+
+export const metadata = {
+  requireAuth: true,
+  requireFeatures: ['order_items.view'],
+  pageTitle: 'Order Items',
+  pageTitleKey: 'order_items.nav.title',
+  pageGroup: 'Orders',                       // Display name for the sidebar section
+  pageGroupKey: 'order_items.nav.group',      // Matching key — all module pages use this
+  pageOrder: 100,                             // Position in the group
+  icon: <ShoppingCart className="size-4" />,
+  breadcrumb: [{ label: 'Order Items', labelKey: 'order_items.nav.title' }],
+}
+```
+
+**Group sorting**: Core module groups (Customers, Catalog, Sales) appear first in a hardcoded order. Custom module groups appear after, sorted by their lowest `pageOrder` value.
+
+## Settings Pages
+
+Settings pages appear in the Settings hub, not the main sidebar. They require two fields:
+
+```typescript
+// backend/config/page.meta.ts
+import { Settings } from 'lucide-react'
+
+export const metadata = {
+  requireAuth: true,
+  requireFeatures: ['order_items.settings.manage'],
+  pageTitle: 'Order Items Settings',
+  pageTitleKey: 'order_items.config.title',
+  pageGroup: 'Module Configs',
+  pageGroupKey: 'settings.sections.moduleConfigs',
+  pageOrder: 10,
+  icon: <Settings className="size-4" />,
+  pageContext: 'settings' as const,           // ← Places in Settings hub
+  navHidden: true,                            // ← MUST set — prevents duplicate in main sidebar
+}
+```
+
+**Standard settings section keys**: `settings.sections.system`, `settings.sections.auth`, `settings.sections.moduleConfigs`, `settings.sections.directory`.
+
+## Sub-Pages (Create / Edit / Detail)
+
+- **`[id]` pages**: Auto-excluded from sidebar (framework skips dynamic segments). Still need `pageGroupKey` for breadcrumb context.
+- **Create pages** (`new.tsx`): Set `navHidden: true` since they're accessed via the list page's create button.
+
+```typescript
+// backend/<entities>/new.meta.ts
+export const metadata = {
+  requireAuth: true,
+  requireFeatures: ['order_items.create'],
+  pageTitle: 'Create Order Item',
+  pageTitleKey: 'order_items.create.title',
+  pageGroup: 'Orders',
+  pageGroupKey: 'order_items.nav.group',      // ← Same key as list page
+  navHidden: true,                            // ← Not shown in sidebar
+}
+```
+
+## Anti-Patterns
+
+| Mistake | Symptom | Fix |
+|---------|---------|-----|
+| Missing `pageGroup` + `pageGroupKey` | Item creates orphan group or lands in "Uncategorized" | Add both fields matching your module's group |
+| Mismatched `pageGroupKey` across pages | Items from same module split into separate sidebar sections | Use identical `pageGroupKey` on all module pages |
+| Missing `icon` | Blank space in sidebar next to title | Add `lucide-react` icon component |
+| Inline SVG via `React.createElement` | Broken/wrong icon after `yarn generate` | Use `import { X } from 'lucide-react'` |
+| `pageContext: 'settings'` without `navHidden: true` | Page appears in both main sidebar AND settings hub | Always pair both fields |
+| Missing `as const` on `pageContext` | TypeScript error — type widened to `string` | Use `pageContext: 'settings' as const` |
+| Missing `pageOrder` | Unpredictable sort position (defaults to 10000) | Set explicit order value |
+| Missing `requireFeatures` | Page visible to users without permission | Add feature IDs from `acl.ts` |

--- a/packages/create-app/build.mjs
+++ b/packages/create-app/build.mjs
@@ -34,10 +34,22 @@ mkdirSync(guidesDestDir, { recursive: true })
 
 let guidesFound = 0
 for (const pkg of readdirSync(packagesDir)) {
+  // Package-level guide: packages/<pkg>/agentic/standalone-guide.md → <pkg>.md
   const guideSource = join(packagesDir, pkg, 'agentic', 'standalone-guide.md')
   if (existsSync(guideSource)) {
     cpSync(guideSource, join(guidesDestDir, `${pkg}.md`))
     guidesFound++
+  }
+
+  // Module-level guides: packages/<pkg>/src/modules/<mod>/agentic/standalone-guide.md → <pkg>.<mod>.md
+  const modulesDir = join(packagesDir, pkg, 'src', 'modules')
+  if (!existsSync(modulesDir)) continue
+  for (const mod of readdirSync(modulesDir)) {
+    const moduleGuideSource = join(modulesDir, mod, 'agentic', 'standalone-guide.md')
+    if (existsSync(moduleGuideSource)) {
+      cpSync(moduleGuideSource, join(guidesDestDir, `${pkg}.${mod}.md`))
+      guidesFound++
+    }
   }
 }
 if (guidesFound > 0) {

--- a/packages/create-app/src/setup/tools/shared.ts
+++ b/packages/create-app/src/setup/tools/shared.ts
@@ -105,6 +105,10 @@ export function generateShared(config: AgenticConfig): void {
     'ai/skills/module-scaffold/references/naming-conventions.md',
     join(targetDir, '.ai', 'skills', 'module-scaffold', 'references', 'naming-conventions.md'),
   )
+  copyFile(
+    'ai/skills/module-scaffold/references/navigation-patterns.md',
+    join(targetDir, '.ai', 'skills', 'module-scaffold', 'references', 'navigation-patterns.md'),
+  )
 
   // troubleshooter skill
   copyFile(

--- a/packages/create-app/src/setup/tools/shared.ts
+++ b/packages/create-app/src/setup/tools/shared.ts
@@ -132,6 +132,21 @@ export function generateShared(config: AgenticConfig): void {
     join(targetDir, '.ai', 'skills', 'data-model-design', 'references', 'mikro-orm-cheatsheet.md'),
   )
 
+  // implement-spec skill
+  copyFile(
+    'ai/skills/implement-spec/SKILL.md',
+    join(targetDir, '.ai', 'skills', 'implement-spec', 'SKILL.md'),
+  )
+
+  // integration-tests skill
+  copyFile(
+    'ai/skills/integration-tests/SKILL.md',
+    join(targetDir, '.ai', 'skills', 'integration-tests', 'SKILL.md'),
+  )
+
+  // .ai/qa/ — Playwright config for integration tests
+  copyFile('ai/qa/playwright.config.ts', join(targetDir, '.ai', 'qa', 'playwright.config.ts'))
+
   // Package guides — auto-discovered from sibling packages during build
   if (existsSync(GUIDES_DIR)) {
     const guidesDestDir = join(targetDir, '.ai', 'guides')


### PR DESCRIPTION
## Summary

- **Add implement-spec and integration-tests skills** for standalone app agentic development, adapted from core skills (removes backward compatibility concerns, extension mode decision, ephemeral environments; uses standalone-appropriate paths and commands)
- **Scaffold Playwright config** (`.ai/qa/playwright.config.ts`) for standalone apps using `@open-mercato/cli` test discovery with GitHub Actions reporter support
- **Add navigation-patterns.md reference** — complete `page.meta.ts` field reference, sidebar grouping, settings pages pattern, and 8 common anti-patterns with fixes
- **Fix incomplete page.meta.ts templates** in module-scaffold skill (add `pageGroup`, `pageGroupKey`, `pageOrder`, `breadcrumb`, `requireFeatures` to all page templates)
- **Extend `build.mjs`** to auto-discover module-level standalone guides at `packages/*/src/modules/*/agentic/standalone-guide.md` (output as `{pkg}.{mod}.md`)
- **Create 9 module-level standalone guides** for all core modules (customers, workflows, catalog, sales, auth, currencies, integrations, data_sync, customer_accounts) — focused on how standalone app developers *use* these modules, not modify internals

## Test plan

- [ ] Run `yarn build` in `packages/create-app` — verify `dist/agentic/guides/` contains all 16 guides (7 package-level + 9 module-level)
- [ ] Run `yarn test:create-app` — verify standalone app scaffold includes new skills and guides under `.ai/`
- [ ] Verify `AGENTS.md.template` renders correctly with new task router entries
- [ ] Verify `shared.ts` copies all new files (implement-spec, integration-tests, playwright.config.ts, navigation-patterns.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)