### PR TITLE
docs: integrate PR #1222 analysis into unified AI tooling spec

### DIFF
--- a/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents-component-mockups.md
+++ b/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents-component-mockups.md
@@ -184,8 +184,121 @@ Behavior notes:
 - object-mode should never dump raw output into the normal transcript without formatting
 - copy actions matter because these results are likely to be reused elsewhere
 
+## 8. Mutation Preview Card (Phase 3)
+
+Rendered in-transcript when the runtime intercepts a mutation-capable tool call and creates a pending action. This is the primary approval surface for the interactive in-chat HIL flow described in the main spec (§9).
+
+```text
++--------------------------------------------------------------------------------------+
+| [!] Approval required                                   expires in 09:42            |
+|--------------------------------------------------------------------------------------|
+| Update deal DEAL-42 "Northwind Renewal Q3"                                          |
+| agent: customers.account_assistant       tool: customers.update_deal                 |
+|--------------------------------------------------------------------------------------|
+| Field diff                                                                           |
+|   stage        Negotiation  ->  Won                                                  |
+|   closeDate    null         ->  2026-04-18                                          |
+|   wonReason    null         ->  "Pricing accepted"                                   |
+|--------------------------------------------------------------------------------------|
+| Side effects                                                                         |
+| - deals.deal.updated event will fire                                                 |
+| - pipeline "Enterprise" totals will recompute                                        |
+| - attached QBR PDF will stay linked                                                  |
+|--------------------------------------------------------------------------------------|
+| [ Cancel (Esc) ]                                    [ Confirm (Cmd/Ctrl+Enter) ]    |
++--------------------------------------------------------------------------------------+
+```
+
+Behavior notes:
+- composer is soft-disabled while this card is pending, but the user can still scroll and re-read prior turns
+- the countdown ticks locally but the authoritative `expiresAt` is server-side; once the countdown hits zero, the buttons replace with an "Expired — ask again to retry" state
+- on `Confirm`, the card transitions into `confirmation-card` (see 10) while the server executes; on `Cancel`, the agent posts a short continuation and the composer re-enables
+- if the tab reloads mid-approval, `<AiChat>` calls `GET /api/ai/actions/:id` and re-renders the card in its current state
+
+## 9. Field Diff Card (Phase 3)
+
+Reusable component used both inside `mutation-preview-card` and — in the future Stacked Approval Queue (D17) — as a standalone row renderer.
+
+```text
++--------------------------------------------------------------+
+| Field diff                                                   |
+|--------------------------------------------------------------|
+| stage             Negotiation   ->   Won                     |
+| closeDate         (empty)       ->   2026-04-18              |
+| wonReason         (empty)       ->   "Pricing accepted"      |
+| attachments       2 linked      ->   2 linked (unchanged)    |
++--------------------------------------------------------------+
+```
+
+Behavior notes:
+- fields that do not change are either hidden or dimmed; never omit them silently if the agent referenced them in its plan
+- sensitive fields (tokens, secrets, encryption blobs) MUST be masked even in the diff — the server renders `***` for these, never the raw value
+- the diff is authoritative only at propose time; stale confirms are rejected server-side by the `recordVersion` check, so the UI does not need to re-diff live
+
+## 10. Confirmation Card (Phase 3)
+
+Transient state shown between `[Confirm]` click and the server's `mutation-result-card` response. Prevents double-submit and tells the user the system is doing the work.
+
+```text
++--------------------------------------------------------------+
+| [spinner] Executing: Update deal DEAL-42                     |
+| Re-checking permissions, scope, and freshness...             |
+|--------------------------------------------------------------|
+| [ Cancel is no longer available ]                            |
++--------------------------------------------------------------+
+```
+
+Behavior notes:
+- disabled buttons, not hidden ones — users need to understand the action is in-flight, not vanished
+- if the server responds with a `412` (stale version) or `422` (validation failed), this card transitions to an error variant explaining the failure and inviting the user to ask again rather than retry blindly
+
+## 11. Mutation Result Card (Phase 3)
+
+Terminal state rendered after successful execution. Replaces the `mutation-preview-card` in the transcript (the preview is not kept around — its job is done) and lets the agent continue the conversation naturally.
+
+```text
++--------------------------------------------------------------------------------------+
+| [✓] Saved: deal DEAL-42 "Northwind Renewal Q3"                                       |
+|--------------------------------------------------------------------------------------|
+| stage        Negotiation  ->  Won                                                    |
+| closeDate    null         ->  2026-04-18                                             |
+| wonReason    null         ->  "Pricing accepted"                                     |
+|--------------------------------------------------------------------------------------|
+| [ Open record ]                                                                      |
++--------------------------------------------------------------------------------------+
+```
+
+Behavior notes:
+- fires a DOM event bridge refresh so the underlying record page (if embedded) reflects the save without a manual reload
+- the agent immediately follows the card with a short natural-language confirmation ("Done — anything else?") so the transcript reads like a conversation, not a form submission log
+- on failure, a red variant of this card is rendered with a short error message and a "Try again" action that nudges the user to re-ask rather than blindly retry
+
+## 12. Future: Approval Queue Row (Phase 4+, D17)
+
+Design-only placeholder so consumers know the data contract is stable. Same `field-diff-card` renderer, different container. Not implemented in this spec.
+
+```text
++--------------------------------------------------------------------------------------+
+| Pending approvals (3)                                assigned to: sales-ops          |
+|--------------------------------------------------------------------------------------|
+| Agent                       Action                       Record        Expires   [ ] |
+|--------------------------------------------------------------------------------------|
+| customers.account_assistant Update deal (stage=Won)      DEAL-42       09:42    [ ] |
+| catalog.merchandising_asst  Update product pricing       PROD-910      14:05    [ ] |
+| sales.order_assistant       Issue partial refund $120    INV-2011      03:17    [ ] |
+|--------------------------------------------------------------------------------------|
+| [ Approve selected ]  [ Reject selected ]  [ Open in chat ]                          |
++--------------------------------------------------------------------------------------+
+```
+
+Behavior notes:
+- each row expands into a full `field-diff-card` inline; the component contract is reused exactly
+- bulk approve/reject fans out to the same single-action endpoints so every approval still runs the full server-side re-check
+- "Open in chat" re-hydrates the originating `<AiChat>` with the pending action so the user can drop back into the conversation
+
 ## Notes for Implementation
 
 - Reuse the same underlying runtime state across shell, debug drawer, and object result panel.
 - Keep the component contracts additive so modules can embed only the pieces they need.
 - Prefer simple composition over one giant "AI console" component.
+- The four Phase 3 cards are server-emitted only; client code never synthesizes them. The UI-part registry treats them as trusted markers but still re-fetches authoritative record state from the normal record endpoints before rendering anywhere outside the approval flow.

--- a/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents-component-mockups.md
+++ b/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents-component-mockups.md
@@ -1,0 +1,191 @@
+# Unified AI Tooling and Subagents - Component Mockups
+
+Companion to:
+- `.ai/specs/2026-04-11-unified-ai-tooling-and-subagents.md`
+- `.ai/specs/2026-04-11-unified-ai-tooling-and-subagents-screen-mockups.md`
+
+Purpose:
+- define the reusable building blocks for Phase 2 and Phase 3
+- keep component structure separate from the main spec narrative
+
+## 1. `AiChat` Shell
+
+```text
++--------------------------------------------------------------------------------------+
+| Header                                                                               |
+| [ agent badge ]  Title                           [ mode ] [ debug ] [ overflow menu ]|
++--------------------------------------------------------------------------------------+
+| Context strip                                                                        |
+| entity: catalog.product   record: prod_123   attachments: 2   tools: 5              |
++--------------------------------------------------------------------------------------+
+| Transcript                                                                           |
+|                                                                                      |
+| user bubble                                                                          |
+| assistant bubble                                                                     |
+| tool-call event card                                                                 |
+| ui-part card                                                                         |
+|                                                                                      |
++--------------------------------------------------------------------------------------+
+| Composer                                                                             |
+| [ textarea........................................................................ ] |
+| [ attach ] [ page context ] [ send ]                                                 |
++--------------------------------------------------------------------------------------+
+```
+
+Behavior notes:
+- header always makes the selected agent and mode obvious
+- context strip is compact but visible for debugging
+- transcript supports plain text, tool events, and UI parts in one stack
+
+## 2. Agent Picker
+
+```text
++--------------------------------------------------------------+
+| Select agent                                                 |
+|--------------------------------------------------------------|
+| Search [ customers........................................ ] |
+|--------------------------------------------------------------|
+| General                                                      |
+|  - Workspace assistant                 chat    tools: 7      |
+|                                                              |
+| Customers                                                    |
+|  - Account assistant                   chat    tools: 9      |
+|  - Deal copilot                        object  tools: 5      |
+|                                                              |
+| Catalog                                                      |
+|  - Merchandising assistant             chat    tools: 8      |
+|  - Pricing explainer                   object  tools: 4      |
++--------------------------------------------------------------+
+```
+
+Behavior notes:
+- grouped by module/domain
+- show execution mode and approximate tool breadth inline
+- surface only agents the current user can access
+
+## 3. Attachment Tray
+
+```text
++------------------------------------------------------------------+
+| Attachments                                                      |
+|------------------------------------------------------------------|
+| [ + Upload ]                                                     |
+|------------------------------------------------------------------|
+| 1. hero.jpg                           image/jpeg      ready       |
+|    source: bytes                      extracted: no               |
+|                                                                  |
+| 2. offer-spec.pdf                     application/pdf  ready      |
+|    source: signed-url                 extracted: yes              |
+|                                                                  |
+| 3. stock-export.xlsx                  metadata-only    fallback   |
+|    note: unsupported binary, model sees filename and type only   |
++------------------------------------------------------------------+
+```
+
+Behavior notes:
+- attachment processing state should be visible before send
+- the fallback mode must be explicit so users know what the model can actually consume
+
+## 4. Debug Drawer
+
+```text
++--------------------------------------------------------------------------------------+
+| Debug                                                                                |
+|--------------------------------------------------------------------------------------|
+| Request                                                                              |
+| - agentId: catalog.merchandising_assistant                                           |
+| - mode: chat                                                                         |
+| - pageContext: catalog.product / prod_123                                            |
+|                                                                                      |
+| Runtime                                                                              |
+| - prompt sections: ROLE, SCOPE, DATA, TOOLS, ATTACHMENTS, MUTATION POLICY           |
+| - resolved model: tenant default                                                     |
+|                                                                                      |
+| Events                                                                               |
+| 1. tool: catalog.get_product_detail                                                  |
+| 2. tool: attachments.read_attachment                                                 |
+| 3. ui-part: record-card                                                              |
++--------------------------------------------------------------------------------------+
+```
+
+Behavior notes:
+- split by request, runtime resolution, and events
+- avoid raw internal noise unless the user expands deeper details
+
+## 5. Prompt Override Editor
+
+```text
++--------------------------------------------------------------------------------------+
+| Prompt override                                                                      |
+|--------------------------------------------------------------------------------------|
+| Hard safety sections                                                                 |
+| [ROLE.................locked....................................................... ] |
+| [MUTATION POLICY......locked....................................................... ] |
+|                                                                                      |
+| Tenant additive sections                                                             |
+| [ Additional business rules........................................................ ] |
+| [ Additional tone/style guidance................................................... ] |
+| [ Domain glossary.................................................................. ] |
+|                                                                                      |
+| Preview                                                                              |
+| [ Show merged prompt ]  [ Diff from default ]                                        |
+|                                                                                      |
+| [ Save draft ] [ Publish ]                                                           |
++--------------------------------------------------------------------------------------+
+```
+
+Behavior notes:
+- the UI should make the locked vs editable boundary obvious
+- merged preview is necessary before publish
+
+## 6. Tool Pack Matrix
+
+```text
++------------------------------------------------------------------------------------------------+
+| Tool packs                                                                                     |
+|------------------------------------------------------------------------------------------------|
+| Pack                              | Included tools                       | Enabled | Writable   |
+|-----------------------------------|--------------------------------------|---------|-----------|
+| search.core                       | hybrid_search, get_record_context    |   [x]   |    no     |
+| attachments.core                  | list, read, transfer                 |   [x]   |   mixed   |
+| customers.account_read            | person, company, deal detail         |   [x]   |    no     |
+| customers.account_write           | update deal, tag assignment          |   [ ]   |   yes     |
+| catalog.merchandising_read        | product detail, media, offers        |   [x]   |    no     |
+| catalog.merchandising_write       | update product, update category      |   [ ]   |   yes     |
++------------------------------------------------------------------------------------------------+
+```
+
+Behavior notes:
+- this should help admins understand capability at a glance
+- writable packs should be visually distinct even if disabled
+
+## 7. Object Result Panel
+
+```text
++--------------------------------------------------------------------------------------+
+| Structured result                                                                     |
+|--------------------------------------------------------------------------------------|
+| schema: deal_brief_v1                                                                 |
+|                                                                                      |
+| {                                                                                    |
+|   "summary": "Renewal likely slips into next quarter",                               |
+|   "risks": ["pricing pushback", "missing stakeholder alignment"],                    |
+|   "nextActions": [                                                                   |
+|     "schedule procurement follow-up",                                                |
+|     "share revised commercial proposal"                                              |
+|   ]                                                                                  |
+| }                                                                                    |
+|                                                                                      |
+| [ Copy JSON ] [ Copy Markdown ] [ Re-run ]                                           |
++--------------------------------------------------------------------------------------+
+```
+
+Behavior notes:
+- object-mode should never dump raw output into the normal transcript without formatting
+- copy actions matter because these results are likely to be reused elsewhere
+
+## Notes for Implementation
+
+- Reuse the same underlying runtime state across shell, debug drawer, and object result panel.
+- Keep the component contracts additive so modules can embed only the pieces they need.
+- Prefer simple composition over one giant "AI console" component.

--- a/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents-screen-mockups.md
+++ b/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents-screen-mockups.md
@@ -174,8 +174,126 @@ Intent:
 +--------------------------------------------------------------------------------------------------+
 ```
 
+## 5. Mutation Approval in Transcript (Phase 3)
+Intent:
+- show how the in-chat HIL approval (main spec §9, D16) lives inside an existing embedded `<AiChat>` without opening a second screen
+- approval state transitions are visible in the same transcript the user was already reading
+
+```text
++--------------------------------------------------------------------------------------+
+| Customers account assistant                       [ debug ]  [ x ]                  |
++--------------------------------------------------------------------------------------+
+| user:                                                                                |
+|   Mark deal DEAL-42 as won and set close date to today.                              |
+|                                                                                      |
+| assistant:                                                                           |
+|   I'll update DEAL-42 to stage "Won" with a close date of 2026-04-18.                |
+|                                                                                      |
+| [mutation-preview-card]                                                              |
+| +----------------------------------------------------------------------------------+ |
+| | [!] Approval required                            expires in 09:42                | |
+| |----------------------------------------------------------------------------------| |
+| | Update deal DEAL-42 "Northwind Renewal Q3"                                      | |
+| | tool: customers.update_deal                                                     | |
+| |----------------------------------------------------------------------------------| |
+| | stage       Negotiation  ->  Won                                                | |
+| | closeDate   (empty)      ->  2026-04-18                                         | |
+| | wonReason   (empty)      ->  "Pricing accepted"                                 | |
+| |----------------------------------------------------------------------------------| |
+| | Side effects: deals.deal.updated event, pipeline totals recompute               | |
+| |----------------------------------------------------------------------------------| |
+| | [ Cancel (Esc) ]                         [ Confirm (Cmd/Ctrl+Enter) ]           | |
+| +----------------------------------------------------------------------------------+ |
+|                                                                                      |
+| [composer is soft-disabled while this action is pending]                             |
++--------------------------------------------------------------------------------------+
+```
+
+After confirm (one frame later):
+
+```text
+| [confirmation-card]                                                                  |
+| +----------------------------------------------------------------------------------+ |
+| | [spinner] Executing: Update deal DEAL-42                                         | |
+| | Re-checking permissions, scope, and freshness...                                 | |
+| +----------------------------------------------------------------------------------+ |
+```
+
+After success:
+
+```text
+| [mutation-result-card]                                                               |
+| +----------------------------------------------------------------------------------+ |
+| | [✓] Saved: deal DEAL-42 "Northwind Renewal Q3"                                   | |
+| | stage Negotiation -> Won | closeDate null -> 2026-04-18                          | |
+| | [ Open record ]                                                                  | |
+| +----------------------------------------------------------------------------------+ |
+|                                                                                      |
+| assistant:                                                                           |
+|   Done — DEAL-42 is now Won. Anything else?                                          |
+|                                                                                      |
+| [composer re-enabled]                                                                |
+```
+
+After cancel (alternative branch):
+
+```text
+| [mutation-cancelled note]                                                            |
+| "Cancelled at user request."                                                         |
+|                                                                                      |
+| assistant:                                                                           |
+|   Ok, leaving DEAL-42 as Negotiation. Want me to do something else with the deal?   |
+|                                                                                      |
+| [composer re-enabled]                                                                |
+```
+
+On expiry (alternative branch):
+
+```text
+| [mutation-preview-card — expired state]                                              |
+| +----------------------------------------------------------------------------------+ |
+| | [ ! ] Expired — ask again to retry                                              | |
+| +----------------------------------------------------------------------------------+ |
+|                                                                                      |
+| [composer re-enabled; original buttons gone]                                         |
+```
+
+## 6. Future: Approval Queue Page (Phase 4+, D17, design only)
+Intent:
+- keep the Phase 3 UI forward-compatible with a shared approval queue without building it in this spec
+- show the relationship between the in-chat preview and the batch queue: same data, different container
+
+```text
++--------------------------------------------------------------------------------------+
+| AI Approval Queue                                       assignee [ Me v ]           |
+| Pending actions waiting for confirm or cancel                                        |
++--------------------------------------------------------------------------------------+
+| Filters: agent [ all v ]   module [ all v ]   status [ pending v ]   search [.....] |
++--------------------------------------------------------------------------------------+
+| Agent                       Action                         Record     Expires   [ ] |
+|--------------------------------------------------------------------------------------|
+| [v] customers.account_asst  Update deal (stage=Won)        DEAL-42    09:42    [ ] |
+|     Proposed by @alice at 14:12 for tenant acme                                     |
+|     stage: Negotiation -> Won                                                        |
+|     closeDate: null -> 2026-04-18                                                    |
+|     [ Open in chat ]   [ Confirm ]   [ Cancel ]                                      |
+|--------------------------------------------------------------------------------------|
+| [>] catalog.merchandising_asst  Update pricing for PROD-910            14:05   [ ] |
+| [>] sales.order_assistant       Issue partial refund $120 on INV-2011  03:17   [ ] |
+|--------------------------------------------------------------------------------------|
+| [ Approve selected ]  [ Reject selected ]  [ Open in chat ]                          |
++--------------------------------------------------------------------------------------+
+```
+
+Design notes (not implemented in this spec):
+- the same `field-diff-card` component renders inside each row; no forked data contract
+- bulk approve/reject fans out to `POST /api/ai/actions/:id/confirm` one request at a time, preserving the per-action server-side re-check
+- "Open in chat" re-hydrates the originating `<AiChat>` so the user drops back into the conversation that proposed the action
+- queued pending actions fire `ai.action.confirmed` / `ai.action.cancelled` events that the originating agent's worker subscribes to in order to resume the next step of a multi-action workflow
+
 ## Notes for Implementation
 
 - The playground should prioritize transparency over polish.
 - The settings page should prioritize edit safety over density.
 - Embedded agent panels should stay secondary to the main business record, not replace the record UI.
+- Phase 3 mutation approval cards live inside the existing `<AiChat>` transcript — no separate approval screen is introduced in this spec; the Phase 4+ queue (§6 above) is explicitly design-only.

--- a/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents-screen-mockups.md
+++ b/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents-screen-mockups.md
@@ -1,0 +1,181 @@
+# Unified AI Tooling and Subagents - Screen Mockups
+
+Companion to:
+- `.ai/specs/2026-04-11-unified-ai-tooling-and-subagents.md`
+
+Purpose:
+- keep implementation-oriented ASCII screen mockups outside the main spec
+- give Phase 2 and Phase 3 work concrete UI targets without locking the final visual design too early
+
+## 1. Playground Page
+Route:
+- `/backend/config/ai-assistant/playground`
+
+Intent:
+- one place to test general, customers, and catalog agents
+- support both chat-mode and object-mode runs
+- make page context and attachment testing visible
+
+```text
++--------------------------------------------------------------------------------------------------+
+| AI Assistant Playground                                                                         |
+| Test agents, prompts, tools, files, and structured outputs                                      |
++--------------------------------------------------------------------------------------------------+
+| Agent          [ General workspace assistant                          v ]  Mode [ Chat v ]       |
+| Model override [ inherit tenant default............................ ]  Debug [x]  Dry run [ ]   |
+| Context source [ Manual v ]   Page ID [ backend/catalog/products ]   Entity [ catalog.product ] |
+| Record ID      [ prod_123......................................... ]   Prompt preset [ Default ] |
++--------------------------------------------------------------------------------------------------+
+| Allowed tools                                                                 | Attachments      |
+|--------------------------------------------------------------------------------|------------------|
+| [x] search.hybrid_search                                                      | + Upload file     |
+| [x] search.get_record_context                                                 | ---------------- |
+| [x] catalog.get_product_detail                                                | 1. hero.jpg      |
+| [x] catalog.list_product_media                                                |    image/jpeg    |
+| [ ] catalog.update_product                                                    | 2. spec.pdf      |
+| [ ] attachments.transfer_record_attachments                                   |    application/  |
+|                                                                                |    pdf           |
++--------------------------------------------------------------------------------------------------+
+| Transcript / Result                                                                              |
+|--------------------------------------------------------------------------------------------------|
+| user: "Summarize this product and tell me what the attached image suggests we should improve."   |
+|                                                                                                  |
+| assistant:                                                                                        |
+| - Product is active, configurable, and currently sold in EUR.                                    |
+| - Variant media is sparse compared to the description.                                           |
+| - The attached image suggests the hero crop should be tighter.                                   |
+|                                                                                                  |
+| [ record-card ] [ list-summary ] [ warning-note ]                                                |
+|                                                                                                  |
+| > If Mode = Object, this pane switches to formatted JSON / schema result preview.                |
++--------------------------------------------------------------------------------------------------+
+| Input                                                                                             |
+|--------------------------------------------------------------------------------------------------|
+| [ Ask something about the selected agent....................................................... ] |
+| [ Send ]  [ Run object mode ]  [ Clear ]                                                         |
++--------------------------------------------------------------------------------------------------+
+| Debug drawer                                                                                      |
+|--------------------------------------------------------------------------------------------------|
+| step 1: resolve agent -> catalog.merchandising_assistant                                         |
+| step 2: hydrate page context -> ok                                                                |
+| step 3: tool call -> catalog.get_product_detail(id=prod_123)                                     |
+| step 4: tool call -> attachments.read_attachment(id=att_456)                                     |
++--------------------------------------------------------------------------------------------------+
+```
+
+## 2. Agent Settings Page
+Route:
+- `/backend/config/ai-assistant/agents`
+
+Intent:
+- tenant admin can inspect agents, prompt overrides, tool packs, and attachment policy
+- hard safety rules remain server-owned; admin controls are additive
+
+```text
++--------------------------------------------------------------------------------------------------+
+| AI Agents Settings                                                                               |
+| Manage prompts, tools, and file policy per agent                                                 |
++--------------------------------------------------------------------------------------------------+
+| Sidebar                                                                 | Main panel             |
+|-------------------------------------------------------------------------|------------------------|
+| Agents                                                                  | Agent: customers.account|
+| - General workspace                                                     | assistant              |
+| - Customers                                                             |------------------------|
+|   - account assistant                                                   | Status: enabled        |
+|   - deal copilot                                                        | Execution: chat        |
+| - Catalog                                                               | Default model: tenant  |
+|   - merchandising assistant                                             | Features: customers.*  |
+|   - pricing explainer                                                   |                        |
+|-------------------------------------------------------------------------| Prompt sections        |
+| Filters                                                                 |------------------------|
+| [ Enabled only ]                                                        | [ROLE...............]  |
+| [ Show object agents ]                                                  | [SCOPE..............]  |
+| [ Search...................... ]                                        | [DATA...............]  |
+|                                                                         | [TOOLS..............]  |
+|                                                                         | [ATTACHMENTS........]  |
+|                                                                         | [MUTATION POLICY....]  |
+|                                                                         | [RESPONSE STYLE.....]  |
+|                                                                         |                        |
+|                                                                         | Tenant additive        |
+|                                                                         | override:              |
+|                                                                         | [....................] |
+|                                                                         | [....................] |
+|                                                                         |                        |
+|                                                                         | [ Save override ]      |
++--------------------------------------------------------------------------------------------------+
+| Tool packs                                                                                        |
+|--------------------------------------------------------------------------------------------------|
+| [x] search.hybrid_search   [x] customers.get_company_detail   [x] customers.get_person_detail    |
+| [x] customers.list_deals   [ ] customers.update_deal          [ ] attachments.transfer_*         |
++--------------------------------------------------------------------------------------------------+
+| Attachment policy                                                                                  |
+|--------------------------------------------------------------------------------------------------|
+| Images [ allow ]   PDFs [ allow ]   Generic files [ allow metadata-only ]   Max size [ 20 MB ]  |
+| OCR text [ prefer when available ]   Binary fallback [ mention unsupported files to model ]      |
++--------------------------------------------------------------------------------------------------+
+| Test snippets                                                                                      |
+|--------------------------------------------------------------------------------------------------|
+| 1. "Summarize the account and next steps."                                                        |
+| 2. "Compare this PDF to the CRM record."                                                          |
+| 3. "Prepare a structured brief for handoff."                                                      |
++--------------------------------------------------------------------------------------------------+
+```
+
+## 3. Embedded Detail Page Pattern
+Intent:
+- show how a module page embeds a focused agent without turning the page into a standalone chat app
+
+```text
++--------------------------------------------------------------------------------------------------+
+| Product Detail                                                                                   |
+| Organic Coffee Beans                                                                             |
++-----------------------------------------------+--------------------------------------------------+
+| Main detail form                               | Agent side panel                                 |
+|-----------------------------------------------|--------------------------------------------------|
+| Title            [ Organic Coffee Beans..... ] | Catalog merchandising assistant                  |
+| Subtitle         [ Premium roast............ ] |--------------------------------------------------|
+| Categories       [ Coffee, Organic......... ] | Context                                          |
+| Variants         [ 250g, 500g, 1kg......... ] | - page: backend/catalog/products                 |
+| Offers           [ 3 active................ ] | - entity: catalog.product                        |
+| Media gallery    [ image ][ image ][ pdf  ] | - record: prod_123                               |
+| Metadata         [ roast=medium............ ] |--------------------------------------------------|
+|                                               | Ask                                              |
+| [ Save ] [ Delete ]                           | [ How should we improve this listing?......... ] |
+|                                               | [ Attach file ] [ Send ]                         |
+|                                               |--------------------------------------------------|
+|                                               | assistant:                                       |
+|                                               | - The title is strong.                           |
+|                                               | - Variant naming is inconsistent.                |
+|                                               | - The image crop should focus on the package.    |
++--------------------------------------------------------------------------------------------------+
+```
+
+## 4. Customers Detail Embedded Pattern
+Intent:
+- show how the CRM assistants should fit next to the existing detail tabs
+
+```text
++--------------------------------------------------------------------------------------------------+
+| Company Detail: Northwind Trading                                                               |
++------------------------------------------------------+-------------------------------------------+
+| Tabs: Notes | Activities | Deals | People | Tasks    | Customers account assistant               |
+|------------------------------------------------------|-------------------------------------------|
+| Notes timeline                                        | Suggested actions                          |
+| - Meeting summary                                     | - Follow up on open deal in 3 days        |
+| - Pricing discussion                                  | - Ask for updated annual spend            |
+|                                                       |-------------------------------------------|
+| People                                                | Ask                                        |
+| - Jane Doe, Buyer                                     | [ Summarize this account and next step.. ] |
+| - John Roe, Finance                                   | [ Attach QBR PDF ] [ Send ]               |
+|                                                       |-------------------------------------------|
+| Deals                                                 | assistant:                                 |
+| - Renewal Q3                                          | - Account healthy but blocked on pricing.  |
+| - Upsell pilot                                        | - Jane is main commercial contact.         |
++--------------------------------------------------------------------------------------------------+
+```
+
+## Notes for Implementation
+
+- The playground should prioritize transparency over polish.
+- The settings page should prioritize edit safety over density.
+- Embedded agent panels should stay secondary to the main business record, not replace the record UI.

--- a/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents.md
+++ b/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents.md
@@ -5,6 +5,7 @@
 - Keep `ai-tools.ts`, `AiToolDefinition`, `McpToolDefinition`, `registerMcpTool()`, `ai-tools.generated.ts`, `/api/chat`, `/api/tools`, `mcp:serve`, and `mcp:serve-http` working unchanged.
 - Introduce a new additive module convention, `ai-agents.ts`, plus a reusable `<AiChat>` UI component, AI-SDK-first helper APIs, and a new authenticated dispatcher route, `POST /api/ai/chat?agent=<module>.<agent>`.
 - V1 ships focused, read-first sub-agents, standard auth, attachment-backed uploads, tagged client-rendered streamed UI parts, explicit coexistence with OpenCode Code Mode, and first-class support for Vercel AI SDK patterns such as `useChat`, direct transport, and structured-output agents built on `generateText(..., { output })`.
+- Formalizes a server-owned **pending-action** contract and an **in-chat human-in-the-loop (HIL) approval** flow so mutation-capable focused agents can be introduced later without inventing ad-hoc confirmation protocols per module.
 
 ## Overview
 Open Mercato already has three useful AI building blocks:
@@ -36,7 +37,7 @@ Current limitations:
 - The current MCP/runtime story is internally inconsistent: the generator still emits `ai-tools.generated.ts`, but current tool loading logic is Code Mode-centric. That mismatch must be resolved before adding more AI extension surfaces.
 - File handling is underspecified for AI workloads. The repo already has a mature attachments module, but the current spec does not define how attachment records become model-ready file parts, extracted text, or provider-safe binary payloads.
 - The spec does not yet define the baseline tool packs that a "general", "customers", or "catalog" agent should expose, which risks shipping chat shells without enough domain reach to match the UI.
-- Mutation safety for focused AI workflows is not formalized outside the existing OpenCode question flow.
+- Mutation safety for focused AI workflows is still prompt-level guidance, not a server-enforced contract. There is no shared primitive for "the model wants to write — ask the user first, re-check everything, then execute the real command", which means every module that ever wants write-capable agents would reinvent that flow (and likely reinvent it inconsistently).
 
 Non-goals for this spec:
 
@@ -237,6 +238,59 @@ Rules:
 - write tools should correspond to actual UI actions and command-backed operations already supported in the repo
 - the first module coverage target for this spec is `customers` and `catalog`
 
+### D16. Human-in-the-Loop Mutation Approval (Pending-Action Contract)
+Mutation safety must be a server-enforced protocol, not a prompt convention. Every write initiated by a focused agent flows through a pending-action contract with an explicit, auditable approval step.
+
+Rationale:
+
+- prompt-level "ask for confirmation first" is insufficient; the model can hallucinate acceptance, forget to ask, or be tricked by crafted transcript content
+- every module that ships write-capable agents needs the same primitive — pending actions, diff preview, confirm/cancel, server-side re-check — so it must live in the platform, not in modules
+- reuse of existing command/form paths must be guaranteed; there must not be an "AI-only" write path that bypasses the normal command validation, ACL, or event emission
+- the approval UI must live inside the existing `<AiChat>` transcript (no separate screen) so the user keeps their context and the agent can continue the conversation after the decision lands
+
+Rules:
+
+- no mutation tool is ever executed directly from the model's tool call
+- instead, mutation-capable tools resolve through a server-owned `prepareMutation` step that creates a pending-action record and returns an opaque `actionId`
+- the agent emits a `mutation-preview-card` UI part referencing the `actionId`; the transcript renders Confirm / Cancel controls inline
+- `POST /api/ai/actions/:id/confirm` and `POST /api/ai/actions/:id/cancel` are the only ways to move a pending action forward
+- on confirm, the server re-validates everything (user permissions, tenant/org scope, record existence, record version, action freshness, idempotency, tool-still-allowed) before executing through the normal command-backed write path
+- on execution, the server emits a `mutation-result-card` UI part and fires the normal CRUD/domain events so the rest of the UI (lists, detail pages, injected widgets) refreshes automatically through the DOM event bridge
+- every agent declares a `mutationPolicy` field: `'read-only'` (default), `'confirm-required'`, or `'destructive-confirm-required'` — runtime enforces the gate regardless of prompt content
+- pending actions are tenant-scoped, expire by default (TTL), and carry an idempotency key so a double-click or double-submit is safe
+- pending actions record enough context for auditing: who proposed (agent + user), what tool + input, what record, what diff, what side effects, when created, when confirmed or cancelled
+- this contract must be reusable by future **agent-to-agent** or **autonomous** execution flows — the record shape is the same whether a human confirms the action or a future approval queue does
+
+Current-phase implementation target:
+
+- inline, transcript-local approval (one agent turn blocks on one decision); the user stays in the chat and the agent resumes immediately after Confirm or Cancel
+
+Deferred to Phase 4+ (explicitly out of scope for this spec, design-only reference in the Future Scope section):
+
+- a persistent approval queue where pending actions accumulate across sessions and users (see D17)
+
+### D17. Stacked Approval Queue (Future-Phase Extension)
+Design-only placeholder so the current pending-action contract is forward-compatible with a shared approval-queue UI.
+
+Intent:
+
+- real autonomous or long-running agent workflows (batch catalog enrichment, mass deal-stage updates, imported-order reconciliation) will produce more pending actions than one user can approve inside a single chat turn
+- instead of blocking the transcript, the agent should be able to queue its pending actions into a **shared approval list**, return control to the user, and **resume automatically** once a decision lands
+- the platform already has the primitives (events, workers, user tasks in `workflows`) to build this; the pending-action contract from D16 is intentionally shaped so the same records can feed a queue UI without schema changes
+
+Rules (design-only, not implemented in this spec):
+
+- pending actions with `queueMode: 'stack'` are not rendered inline in the transcript; instead they are routed to an approval queue keyed by agent, module, tenant, and optional assignee role
+- the agent turn returns immediately with a `mutation-queued-card` UI part ("3 changes queued for approval") instead of blocking
+- when a queued action is confirmed or cancelled, the platform emits `ai.action.confirmed` / `ai.action.cancelled` events; the originating agent's worker subscribes and resumes the next step (continue the transcript, fire the next tool call, emit the next proposal)
+- same server-side re-checks on confirm as D16 — permissions, scope, freshness, idempotency — so a delayed approval cannot execute on stale context
+- a later spec defines the queue UI, assignee/role routing, SLA/expiry policy, bulk approve/reject, and the worker-resume contract
+
+Rationale for calling it out now:
+
+- D16 must stay compatible with D17; callers should never have to refactor pending actions when the queue ships
+- explicitly deferring keeps this spec shippable while telling future contributors "yes, we thought about it; no, we are not building it yet"
+
 ## Proposed Solution
 
 ### 1. Additive Tool Builder
@@ -281,6 +335,7 @@ type AiAgentDefinition = {
   requiredFeatures?: string[]
   uiParts?: string[]
   readOnly?: boolean
+  mutationPolicy?: 'read-only' | 'confirm-required' | 'destructive-confirm-required'
   maxSteps?: number
   output?: {
     schemaName: string
@@ -311,6 +366,8 @@ Rules:
 - `allowedTools` is an explicit whitelist
 - `readOnly` defaults to `true` in v1
 - if `readOnly` is `true`, tools marked `isMutation: true` are rejected at registration/runtime
+- `mutationPolicy` defaults to `'read-only'` and must remain `'read-only'` whenever `readOnly` is `true`; setting it to `'confirm-required'` or `'destructive-confirm-required'` opts the agent into the pending-action contract defined in D16 and is only honored once that contract ships (Phase 3)
+- runtime enforces the mutation gate regardless of prompt content: a `'confirm-required'` agent must always route mutations through `prepareMutation` + explicit user confirmation, even if the prompt is overridden by a tenant admin
 - focused agents may call other focused agents only in a later phase; v1 agents only call tools
 - `maxSteps` is optional; when set, limits the number of tool-call steps the runtime will execute per turn (passed to `streamText()`)
 - `output` is optional and only valid for `executionMode: 'object'`; it lets app teams run a focused agent through structured-output APIs without hand-writing the prompt and tool plumbing
@@ -377,9 +434,10 @@ V1 focused agents are read-first.
 
 Rules:
 
-- agent-bound chat may use only read-only tools in v1
+- agent-bound chat may use only read-only tools in v1 (Phase 1 / Phase 2)
 - mutation-capable tools remain available through the existing general assistant/MCP flows
-- mutation-capable focused agents are deferred to a later follow-up spec once confirmation semantics are unified
+- mutation-capable focused agents unlock in Phase 3 **only** through the pending-action contract defined in D16 and section 9 below; they must never execute a write without an explicit in-chat user confirmation step
+- the pending-action contract is designed, typed, and integration-tested in this spec so the Phase 3 rollout is additive and does not require another round of architectural debate
 
 ### 7. Tool Packs and Coverage
 V1 introduces explicit tool-pack guidance so agents are useful on day one.
@@ -449,7 +507,7 @@ Prefer aggregate read-model tools over raw CRUD lists when they exist. Reuse pag
 Images and PDFs may contain important business context. Summarize what is visible, mention uncertainty, and reference attached files explicitly when they influence the answer.
 
 [MUTATION POLICY]
-Never execute a write without an explicit user confirmation step. Summarize the intended change first.
+Never execute a write without an explicit user confirmation step. When you decide a write is appropriate, call the mutation tool normally — the runtime will turn it into a `mutation-preview-card` for the user to Confirm or Cancel. Do not claim a change has been saved until you receive a `mutation-result-card` with a success outcome.
 
 [RESPONSE STYLE]
 Be concise, business-facing, and action-oriented. Avoid raw IDs and internal implementation terms unless the user asks for them.
@@ -485,6 +543,104 @@ First settings page scope:
 - attachment policy controls by media type and size budget
 - sample context injection fields for testing prompts without changing production pages
 
+### 9. Mutation Approval Gate (Interactive In-Chat HIL)
+Introduces the server-owned pending-action contract from D16 as a first-class runtime layer. This is the "super cool" part of the chat — the user sees exactly what the agent wants to change, confirms in one click, and the agent picks up where it left off.
+
+#### 9.1 Flow (happy path)
+
+```text
+[user]           "Mark deal DEAL-42 as won and set close date to today."
+  |
+  v
+[agent turn 1]   model reasons, decides to call customers.update_deal
+  |              runtime intercepts: customers.update_deal.isMutation === true
+  |              and agent.mutationPolicy === 'confirm-required'
+  v
+[runtime]        calls prepareMutation(toolName, normalizedInput)
+  |                - validates ACL, tenant/org scope, record existence
+  |                - computes field diff against current record
+  |                - persists AiPendingAction (status=pending, ttl=10m)
+  |                - returns { actionId, preview, expiresAt }
+  v
+[transcript]     streams `mutation-preview-card` UI part with:
+  |                - title "Update deal DEAL-42"
+  |                - before/after table (stage: Negotiation -> Won, closeDate: null -> 2026-04-18)
+  |                - side-effects summary ("will emit deals.deal.updated, recompute pipeline totals")
+  |                - [Confirm] [Cancel] buttons wired to the two approval endpoints
+  |                - countdown badge (expires in 10:00)
+  v
+[user clicks Confirm]
+  |
+  v
+[POST /api/ai/actions/:id/confirm]
+  |                - re-checks permissions, scope, record existence, record version
+  |                - verifies action is still `pending` and not expired
+  |                - runs the normal command-backed update path
+  |                - flips pending action to `confirmed` with commit metadata
+  |                - fires deals.deal.updated (same as any UI-driven update)
+  v
+[runtime]        resumes the agent turn:
+  |                - streams `mutation-result-card` UI part (success + link to record)
+  |                - feeds a synthetic tool-result message to the model:
+  |                  "mutation confirmed and executed; record DEAL-42 is now stage=Won"
+  |                - lets the model continue the conversation naturally
+  v
+[agent turn 2]   model summarizes what happened and suggests next steps
+```
+
+#### 9.2 Flow (cancel)
+
+```text
+[user clicks Cancel]
+  |
+  v
+[POST /api/ai/actions/:id/cancel]
+  |                - flips pending action to `cancelled`
+  v
+[runtime]        resumes the agent turn:
+                   - streams a short `mutation-cancelled` note into the transcript
+                   - feeds a synthetic tool-result message to the model:
+                     "user cancelled the proposed mutation"
+                   - model continues the conversation (e.g. "ok, leaving DEAL-42 as Negotiation — anything else?")
+```
+
+#### 9.3 Flow (expiry)
+
+- pending actions carry a short TTL (default 10 minutes, configurable per agent)
+- an expired action is swept to `status=expired` by a cleanup worker; a subsequent confirm attempt returns `410 Gone`
+- the transcript `mutation-preview-card` shows an "Expired — ask again to retry" state once the countdown hits zero
+
+#### 9.4 Server-side re-check contract
+
+On every `POST /api/ai/actions/:id/confirm`, the runtime MUST re-validate:
+
+- the action is `status=pending` (not already confirmed, cancelled, expired, or executing)
+- the action has not expired
+- the confirming user's session is the same tenant/org as the proposing user (no cross-tenant confirm)
+- the confirming user has the same permissions required by the underlying tool and the agent's `requiredFeatures`
+- the target record still exists and is within the user's scope
+- if the tool declared a version/freshness requirement, the record's current version matches the captured version (or the diff is re-computed and presented again as a new pending action)
+- the agent's `mutationPolicy` still allows this tool (an admin could have demoted the agent to `read-only` between propose and confirm)
+- the tool is still in the agent's `allowedTools` whitelist
+
+Failures become specific error responses (see API contracts).
+
+#### 9.5 Why reuse the normal command path
+
+- command-backed operations already encode the canonical business rules, validation, encryption handling, and event emission for every module
+- an "AI-only" write would instantly drift from the UI's write path and become a second source of bugs
+- emitting the same CRUD/domain events means the rest of the UI (the record's own detail page, lists, injected widgets, DOM event bridge subscribers) refreshes with no extra plumbing
+
+#### 9.6 Attachment handling during mutations
+
+- if a pending action includes `attachmentIds`, those IDs are validated again on confirm against the same tenant/org scope
+- attachments are re-resolved at execution time (not snapshotted) so the final command receives the authoritative record references
+
+#### 9.7 Observability
+
+- every pending action is logged with `{ agentId, actionId, toolName, userId, tenantId, status, createdAt, resolvedAt, outcome }`
+- confirm and cancel events fire typed module events (`ai.action.confirmed`, `ai.action.cancelled`, `ai.action.expired`) so subscribers can audit, notify, or extend behavior without patching the runtime
+
 ## Architecture
 
 ### Runtime Layers
@@ -507,9 +663,18 @@ First settings page scope:
    - AI SDK adapter built from the same tool definitions
    - structured-output execution path for `executionMode: 'object'`
 
-5. HTTP/UI layer
+5. Mutation approval gate (Phase 3)
+   - `prepareMutation` resolver that wraps mutation-capable tool calls into pending actions
+   - pending-action store (`AiPendingAction` records) with TTL + idempotency key
+   - confirm/cancel endpoints that re-run full validation before invoking the normal command path
+   - event emission (`ai.action.confirmed`, `ai.action.cancelled`, `ai.action.expired`) and transcript resumption hook
+
+6. HTTP/UI layer
    - `POST /api/ai/chat?agent=...`
-   - `<AiChat>`
+   - `POST /api/ai/actions/:id/confirm` (Phase 3)
+   - `POST /api/ai/actions/:id/cancel` (Phase 3)
+   - `GET /api/ai/actions/:id` (Phase 3, for polling / reconnect)
+   - `<AiChat>` including the `mutation-preview-card`, `field-diff-card`, `confirmation-card`, and `mutation-result-card` UI parts
    - playground page
    - agent settings page
 
@@ -543,9 +708,11 @@ This is a prerequisite for the new focused-agent stack because agents depend on 
 
 ## Data Models
 
-V1 introduces no new database tables.
+V1 (Phase 1 / Phase 2) introduces no new database tables.
 
-Persistent sources reused in v1:
+Phase 3 adds one new table to back the pending-action contract (see `AiPendingAction` below); it is additive and follows the normal `yarn db:generate` migration flow. No existing tables are modified.
+
+Persistent sources reused from day one:
 
 - tenant AI settings from the current `ai_assistant` settings/config source
 - uploaded files from the attachments module
@@ -597,6 +764,71 @@ Rules:
 - images and PDFs should prefer `bytes` or short-lived `signed-url` sources depending on provider support
 - text-like files should include extracted `textContent`
 - unsupported binary files must still surface filename, media type, and size to the model/runtime
+
+### `AiPendingAction` (Phase 3)
+Persistent record backing the mutation approval gate (D16, section 9).
+
+```ts
+type AiPendingActionStatus =
+  | 'pending'
+  | 'confirmed'
+  | 'cancelled'
+  | 'expired'
+  | 'executing'
+  | 'failed'
+
+type AiPendingAction = {
+  id: string
+  agentId: string
+  toolName: string
+  conversationId: string | null
+  targetEntityType: string | null
+  targetRecordId: string | null
+  normalizedInput: Record<string, unknown>
+  fieldDiff: Array<{
+    field: string
+    before: unknown
+    after: unknown
+  }>
+  sideEffectsSummary: string | null
+  recordVersion: string | null
+  attachmentIds: string[]
+  idempotencyKey: string
+  createdByUserId: string
+  tenantId: string | null
+  organizationId: string | null
+  status: AiPendingActionStatus
+  createdAt: string
+  expiresAt: string
+  resolvedAt: string | null
+  resolvedByUserId: string | null
+  executionResult: {
+    recordId?: string
+    commandName?: string
+    error?: { code: string; message: string }
+  } | null
+  queueMode: 'inline' | 'stack'
+}
+```
+
+Rules:
+
+- `id` is a UUID used in the `POST /api/ai/actions/:id/{confirm,cancel}` endpoints and in the `mutation-preview-card` UI part props
+- `agentId` must match an enabled, allowed agent in the current tenant
+- `toolName` must be inside the agent's `allowedTools` whitelist and marked `isMutation: true`
+- `normalizedInput` is the same validated payload that would flow into the underlying command; it is stored so the confirm path can re-execute without a second tool-argument pass
+- `fieldDiff` is computed server-side from `normalizedInput` against the target record's current state; the card renders directly from this field so the UI does not re-derive the diff
+- `recordVersion` (when present) is used on confirm to detect stale proposals; if the record has moved on, confirm returns `409 Conflict` and the agent must propose again
+- `idempotencyKey` prevents double-submission; re-calling `prepareMutation` with the same key within the TTL returns the same `id`
+- `expiresAt` defaults to 10 minutes from `createdAt`; overridable per agent (`mutationApprovalTtlMs`)
+- `queueMode` defaults to `'inline'` in this spec; `'stack'` is reserved for the future Stacked Approval Queue (D17) and no runtime honors it yet
+- `executionResult` is populated only on `confirmed`, `executing`, or `failed` statuses and contains enough information for the `mutation-result-card` UI part without a second round trip
+
+Indexing guidance (deferred to implementation, not prescriptive):
+
+- `(tenantId, status, expiresAt)` for the cleanup sweep
+- `(createdByUserId, status)` for user-facing "pending approvals" badges
+- `(idempotencyKey)` unique per tenant for dedupe
 
 ## API Contracts
 
@@ -685,7 +917,90 @@ Rules:
 - `runAiAgentObject()` is the Vercel AI SDK-friendly entry point for structured-output agents
 - object helpers must use the same tool filtering, prompt composition, and attachment conversion path as chat helpers
 
-### 3. Existing Routes Preserved
+### 3. Pending Action Endpoints (Phase 3)
+Additive routes backing the mutation approval gate. All three are authenticated and tenant-scoped.
+
+#### 3.1 `GET /api/ai/actions/:id`
+
+Auth:
+
+- `requireAuth: true`
+- `requireFeatures: ['ai_assistant.view']`
+- additional runtime check: the caller's tenant/org must match the pending action
+
+Response:
+
+```ts
+type AiPendingActionResponse = {
+  id: string
+  agentId: string
+  toolName: string
+  status: AiPendingActionStatus
+  expiresAt: string
+  preview: {
+    title: string
+    targetEntityType: string | null
+    targetRecordId: string | null
+    fieldDiff: Array<{ field: string; before: unknown; after: unknown }>
+    sideEffectsSummary: string | null
+  }
+  executionResult: AiPendingAction['executionResult']
+}
+```
+
+Rules:
+
+- used for reconnect and polling so `<AiChat>` can resume after a page reload
+- no mutation is performed; a `404` response is returned for unknown or cross-tenant IDs to avoid enumeration
+
+#### 3.2 `POST /api/ai/actions/:id/confirm`
+
+Auth:
+
+- same as `GET`
+- additionally, the full re-check contract from section 9.4 runs before any execution
+
+Request body:
+
+```ts
+type AiConfirmActionRequest = {
+  clientIdempotencyKey?: string
+}
+```
+
+Response: the same `AiPendingActionResponse` shape with `status` transitioned to `confirmed` (or `executing` if the command is async). Streaming continuation of the agent turn lands on the open `/api/ai/chat` connection when one exists; disconnected clients can reconnect and read the status from `GET /api/ai/actions/:id`.
+
+Error model:
+
+- `401` unauthenticated
+- `403` missing feature, missing tool access, or cross-tenant access attempt
+- `404` unknown action id
+- `409` action is not `pending` (already confirmed, cancelled, or failed)
+- `410` action expired
+- `412` record version mismatch (stale proposal; agent must propose again)
+- `422` runtime validation failed (input no longer valid against current record)
+- `500` command execution failed (captured in `executionResult.error`)
+
+#### 3.3 `POST /api/ai/actions/:id/cancel`
+
+Auth:
+
+- same as confirm, minus the command execution step
+
+Response: the `AiPendingActionResponse` with `status=cancelled`.
+
+Error model:
+
+- `401`, `403`, `404` as above
+- `409` if action is not in a cancellable state
+
+#### 3.4 Rules shared by all three endpoints
+
+- all three MUST emit typed module events (`ai.action.confirmed`, `ai.action.cancelled`, `ai.action.expired`) so audit subscribers and the future approval-queue worker can react without patching the runtime
+- never include raw tokens or secrets in responses (e.g. database IDs of unrelated records, sensitive side-effect text)
+- error responses reuse the same minimal-detail model already used by `/api/ai/chat` so they are safe to surface in the transcript
+
+### 4. Existing Routes Preserved
 These remain supported and unchanged by this spec:
 
 - `POST /api/chat`
@@ -732,13 +1047,42 @@ UX rules:
 - `Escape` closes any open attachment/secondary dialog
 - use shared `Button` / `IconButton` primitives only
 
-Initial streamable UI parts for v1:
+Initial streamable UI parts for v1 (Phase 1 / Phase 2):
 
 - `record-card`
 - `list-summary`
 - `warning-note`
 
+Added in Phase 3 (Mutation Approval Gate — D16):
+
+- `mutation-preview-card` — top-level approval card; shows target record, tool, side-effects summary, expiry countdown, and `[Confirm]` / `[Cancel]` buttons wired to the approval endpoints
+- `field-diff-card` — renders the `fieldDiff` as a before/after table; used standalone or nested inside `mutation-preview-card`
+- `confirmation-card` — transient "executing…" state the runtime emits between `confirm` accepted and `mutation-result-card` returned; shown as a disabled card so the user cannot double-submit
+- `mutation-result-card` — terminal success / failure state with a link to the saved record and a one-line summary; subscribes to the relevant DOM event bridge channel so the underlying page also refreshes
+
 These are client-rendered components registered in the UI package.
+
+### Interactive In-Chat HIL — Transcript Pattern
+The mutation approval UX is part of `<AiChat>`, not a separate screen. Goals:
+
+- the user stays inside the conversation
+- the preview card is the single source of truth for "what will change"
+- the agent resumes without the user having to re-prompt
+
+Transcript rules:
+
+- when the runtime emits a `mutation-preview-card`, the composer is soft-disabled for that pending action but the user can still scroll and read prior turns
+- `[Confirm]` and `[Cancel]` are full-width primary/secondary buttons with keyboard shortcuts: `Cmd/Ctrl+Enter` confirms, `Escape` cancels; both shortcuts display as hints inside the card
+- `[Confirm]` shows a loading state until the server responds, then auto-replaces with a `confirmation-card`
+- on completion the `mutation-result-card` renders and the composer re-enables, the agent sends a short follow-up message ("Done — DEAL-42 is now Won. Anything else?") so the user sees confirmation both structurally (card) and naturally (chat)
+- if the page reloads mid-approval, `<AiChat>` reconnects by calling `GET /api/ai/actions/:id` for any pending actions referenced in its transcript and re-renders the card in its current state
+- on expiry, the card replaces `[Confirm]` / `[Cancel]` with a non-interactive "Expired — ask again to retry" state; the user types a new message to re-propose
+
+Why in-chat (and not a separate screen):
+
+- the approval is always about *what the user just asked the agent to do* — separating it loses context
+- the card is small enough to fit in any `<AiChat>` embed (side panel, playground, fullscreen) without layout changes
+- the agent can keep talking after the decision instead of the user having to navigate back
 
 ### Playground and Settings Pages
 Add two backend pages under AI Assistant configuration:
@@ -763,6 +1107,7 @@ Settings requirements:
 - model override display and edit surface
 - attachment policy summary
 - saved test snippets / reusable context blocks for admins
+- **mutation policy visibility** (Phase 3): display each agent's `mutationPolicy` (`read-only` / `confirm-required` / `destructive-confirm-required`) separately from prompt text; edits are feature-gated so a tenant admin cannot silently grant write access to a read-only agent
 
 ## Access Control
 
@@ -778,9 +1123,12 @@ Settings requirements:
 - agent runtime must intersect agent whitelist with tool ACL
 
 ### Mutation Policy
-- v1 focused agents are read-only by default
+- Phase 1 / Phase 2 focused agents are read-only by default
 - tools marked `isMutation: true` are blocked from read-only agents
-- mutation-capable focused agents require a follow-up spec defining shared confirmation semantics
+- Phase 3 introduces mutation-capable focused agents gated by the pending-action contract (D16, section 9)
+- the pending-action store is the only path through which a focused agent can execute a write; direct execution of a mutation tool from the model is refused at the runtime layer
+- the confirm endpoint re-runs permissions, scope, record existence, record version, TTL, and tool-whitelist checks independently of whatever was captured at propose time — a stale, demoted, or cross-tenant confirm cannot take effect
+- `mutationPolicy` on `AiAgentDefinition` is server-authoritative; a tenant prompt override cannot escalate an agent's mutation capability
 
 ## Risks & Impact Review
 
@@ -792,7 +1140,13 @@ Settings requirements:
 | Private attachment URLs are passed directly to providers and fail or leak | High | Security, attachment usability | Convert attachments to bytes, signed URLs, or extracted text in one runtime bridge | Low |
 | Provider/model drift across tenants | Medium | Runtime config | Reuse existing tenant settings and only allow `defaultModel` override in v1 | Low |
 | UI part registry grows into unstable mini-framework | Medium | UI maintainability | Ship a very small v1 registry with strict serializable props only | Low |
-| Pressure to allow write-capable focused agents too early | High | Data integrity, UX safety | Keep v1 focused agents read-only; follow-up spec for confirmation protocol | Medium |
+| Pressure to allow write-capable focused agents too early | High | Data integrity, UX safety | Keep Phase 1/2 agents read-only; gate Phase 3 writes behind the D16 pending-action contract with server-side re-check | Low |
+| Pending action is confirmed against a stale record version | High | Data integrity | Capture `recordVersion` at propose time; confirm endpoint rejects stale proposals with `412` and forces re-proposal | Low |
+| Pending action TTL too long; user confirms after business state moved on | Medium | UX, correctness | Default TTL of 10 minutes; configurable per agent with sane upper bound; cleanup worker sweeps to `expired` | Low |
+| Cross-tenant confirmation attempt on a leaked `actionId` | High | Security, privacy | Runtime re-checks tenant/org scope on confirm; unknown or cross-tenant IDs return `404` to prevent enumeration | Low |
+| Model bypasses approval by hand-crafting fake `mutation-result-card` UI parts | High | Data integrity | UI parts are server-emitted only; the client registry treats `mutation-preview-card` as a server-trusted marker; the actual state of record is always re-fetched from the real record endpoint, not the card props | Low |
+| Double-click or network retry executes the same mutation twice | Medium | Data integrity, UX | `idempotencyKey` on pending actions + `confirm` endpoint is idempotent when called with the same key on an already-confirmed action | Low |
+| Admin silently escalates a read-only agent to write via prompt override | High | Security, mutation safety | `mutationPolicy` is a server-authoritative field; prompt overrides cannot change it; settings UI gates mutation-policy edits with a distinct feature | Low |
 | `resolvePageContext` leaks cross-tenant data | High | Security, privacy | Resolver runs inside the same request-scoped context with tenant/org filters; validate resolver output does not include cross-tenant references | Low |
 | Routing metadata (`keywords`/`domain`) used for auto-selection prematurely | Medium | UX correctness | V1 ignores routing metadata at runtime; only emitted in generated registry for future use | Low |
 | Model factory env overrides bypass tenant settings silently | Medium | Runtime config, billing | Document env override precedence clearly; log which resolution path was used in debug mode | Low |
@@ -868,8 +1222,8 @@ Exit criteria:
 - tenant admins can adjust additive prompt overrides and inspect tool/attachment settings
 - at least one customers agent and one catalog agent run end-to-end on the new stack
 
-### Phase 3 - Production Hardening and Expansion
-Goal: prove the design on real production agents and harden the customization model.
+### Phase 3 - Production Hardening, Mutation Approval, and Expansion
+Goal: prove the design on real production agents, unlock write-capable focused agents behind the D16 pending-action contract, and harden the customization model.
 
 Scope:
 
@@ -877,8 +1231,9 @@ Scope:
 - shared model factory
 - prompt override persistence/versioning
 - page-context-driven embedding into existing backend surfaces
+- **mutation approval gate**: `AiPendingAction` store, `prepareMutation` runtime step, `/api/ai/actions/:id/{confirm,cancel}` endpoints, `mutation-preview-card` / `field-diff-card` / `confirmation-card` / `mutation-result-card` UI parts, agent `mutationPolicy` enforcement
 
-Candidate:
+Candidate agents:
 
 - `inbox_ops.proposal_assistant`
 - `sales.order_assistant`
@@ -890,7 +1245,13 @@ Deliverables:
 - one or more real `ai-agents.ts` files with `resolvePageContext` implementation
 - structured prompt templates and versioned tenant overrides
 - shared model factory utility extracted from `inbox_ops/lib/llmProvider.ts` into `@open-mercato/ai-assistant`, supporting `defaultModel` override and optional env-based per-agent override (`<MODULE>_AI_MODEL`)
-- integration coverage
+- `AiPendingAction` MikroORM entity, migration, and repository
+- `prepareMutation` runtime wrapper around mutation-capable tools
+- `/api/ai/actions/:id`, `/api/ai/actions/:id/confirm`, `/api/ai/actions/:id/cancel` routes with `openApi` and metadata-based auth
+- four new UI parts in `@open-mercato/ui/src/ai/parts/`
+- cleanup worker that sweeps expired pending actions
+- typed events: `ai.action.confirmed`, `ai.action.cancelled`, `ai.action.expired` (via `createModuleEvents`)
+- integration coverage including happy path, cancel, expiry, stale version, cross-tenant confirm, double-confirm idempotency
 
 Exit criteria:
 
@@ -898,18 +1259,33 @@ Exit criteria:
 - model selection is centralized
 - prompt overrides are safe, versioned, and test-covered
 - the playground and first module agents have been promoted into real production entry points where appropriate
+- at least one mutation-capable agent (candidate: `customers.account_assistant` for deal stage updates) is live behind the pending-action contract and cannot execute any write without a confirmed, unexpired, scope-valid pending action
 
 ### Phase 4 - Follow-up Scope
 Out of scope for this spec but expected follow-ups:
 
-- mutation-capable focused agents with shared confirmation protocol
+- **Stacked Approval Queue** (D17): persistent multi-action queue where agents enqueue pending actions with `queueMode: 'stack'`, return control to the user, and resume via `ai.action.confirmed` / `ai.action.cancelled` subscribers; includes queue UI, role-based assignment, bulk approve/reject, SLA/expiry policy, and the worker-resume contract
 - per-module MCP endpoints
-- agent-to-agent composition
+- agent-to-agent composition (chained LLM calls) beyond the approval-queue resumption hook
 - RSC `streamUI`
 - agent-suggestion feature consuming `keywords`, `domain`, and `dataCapabilities` metadata
 - context dependencies for auto-resolving tool whitelists from module affinities
 - execution budgets (`maxSteps`) recommended as mandatory for mutation-capable agents
 - versioned manifest contract (`manifestVersion`, `platformRange`) when external modules ship AI agents
+
+#### Phase 4 placeholder — Stacked Approval Queue (design only)
+
+Not built in this spec; captured here so the D16 contract stays compatible with it.
+
+Design sketch:
+
+- a later spec introduces a `GET /api/ai/actions?status=pending&assignee=me&agent=...` list endpoint and a backend `/backend/ai/approvals` page
+- the page renders pending actions grouped by agent or module; each row reuses the same `field-diff-card` / side-effects summary rendering as the in-chat card, so the data contract does not fork
+- bulk approve/reject wraps the same `POST /api/ai/actions/:id/confirm` endpoint; there is no batch-specific endpoint because every approval re-runs the full server-side re-check individually
+- the originating agent subscribes to `ai.action.confirmed` / `ai.action.cancelled` events (via the existing `subscribers/*.ts` convention) and resumes its turn: fetch the next LLM step, emit the next proposal, stream the next transcript update — or close out the conversation if nothing remains
+- assignment: pending actions gain an optional `assigneeRole` / `assigneeUserId` so finance, ops, or specific reviewers can own the queue without cross-cutting permission checks at confirm time
+- SLA / expiry: the TTL from D16 still applies, but the queue can surface "expires in X" as a soft warning and escalate via notifications
+- rationale: keeps every mutation fully re-checked at execution (no cached permissions), lets long-running or autonomous agents produce batches without blocking the chat UX, and reuses every piece of infrastructure built in Phase 3
 
 ## Implementation Plan
 
@@ -945,7 +1321,7 @@ The implementation plan below mirrors the delivery phases above. Each phase shou
 #### Workstream A - Shared UI
 1. Add `packages/ui/src/ai/AiChat.tsx`.
 2. Add upload adapter that reuses attachment APIs and returns `attachmentIds`.
-3. Add a minimal client-side UI-part registry.
+3. Add a minimal client-side UI-part registry with room for the Phase 3 approval cards (`mutation-preview-card`, `field-diff-card`, `confirmation-card`, `mutation-result-card`) so the registry API does not need to change when Phase 3 lands.
 
 #### Workstream B - Admin-facing screens
 1. Add backend playground page.
@@ -957,7 +1333,7 @@ The implementation plan below mirrors the delivery phases above. Each phase shou
 2. Ship first catalog agents with prompt templates.
 3. Add backend and portal examples using existing injection/replacement patterns.
 
-### Phase 3 - Production Hardening and Expansion
+### Phase 3 - Production Hardening, Mutation Approval, and Expansion
 #### Workstream A - Production agent runtime
 1. Extract shared model factory from `inbox_ops/lib/llmProvider.ts` into `@open-mercato/ai-assistant/lib/model-factory.ts`. Support `defaultModel` override and env-based per-agent override (`<MODULE>_AI_MODEL`).
 2. Implement production `ai-agents.ts` files with `resolvePageContext` callbacks that hydrate record-level context.
@@ -965,11 +1341,22 @@ The implementation plan below mirrors the delivery phases above. Each phase shou
 #### Workstream B - Prompt and settings hardening
 1. Add versioned prompt override persistence and safe additive merge rules.
 2. Add focused integration tests covering tenant prompt overrides and settings persistence.
+3. Surface `mutationPolicy` as a dedicated, feature-gated field in the settings UI (not part of the prompt editor).
 
-#### Workstream C - Production rollout
+#### Workstream C - Mutation approval gate (D16)
+1. Add `AiPendingAction` MikroORM entity and repository; run `yarn db:generate` for the migration.
+2. Add the `prepareMutation` runtime wrapper: when a model calls a tool that is `isMutation: true` inside an agent with `mutationPolicy !== 'read-only'`, execution is intercepted, a pending action is created, and a `mutation-preview-card` UI part is streamed into the transcript.
+3. Add `/api/ai/actions/:id` (GET), `/api/ai/actions/:id/confirm` (POST), `/api/ai/actions/:id/cancel` (POST) with `metadata` + `openApi`. Implement the full server-side re-check contract from section 9.4.
+4. Add the four new UI parts in `@open-mercato/ui/src/ai/parts/`: `mutation-preview-card`, `field-diff-card`, `confirmation-card`, `mutation-result-card`. Wire keyboard shortcuts (`Cmd/Ctrl+Enter` confirms, `Escape` cancels) and reconnect behavior through `GET /api/ai/actions/:id`.
+5. Add typed `ai.action.confirmed`, `ai.action.cancelled`, `ai.action.expired` events via `createModuleEvents`.
+6. Add a cleanup worker that sweeps expired pending actions (`status=pending` + `expiresAt < now`) to `expired` and fires the expiry event.
+7. Enable one end-to-end mutation-capable agent flow (candidate: `customers.account_assistant` for deal stage updates) using the normal command-backed update path.
+
+#### Workstream D - Production rollout
 1. Bind production agents to existing backend pages through normal injection/UI composition, passing `pageContext` from the page.
 2. Add focused integration tests covering page context resolution and model factory fallback chain.
-3. Add docs and operator rollout notes.
+3. Add integration tests for the pending-action contract: happy path, cancel, expiry, stale-version reject, cross-tenant confirm denial, idempotent double-confirm.
+4. Add docs and operator rollout notes.
 
 ## Integration Test Coverage
 
@@ -1016,6 +1403,21 @@ Required coverage for this spec:
 - agent with `maxSteps` stops after the declared number of tool-call steps
 - agent without `maxSteps` uses the runtime default
 
+### Mutation Approval Gate (Phase 3)
+- a mutation-capable tool call from an agent with `mutationPolicy: 'confirm-required'` does not execute directly; it creates a pending action and emits a `mutation-preview-card` UI part
+- calling `POST /api/ai/actions/:id/confirm` with a valid, pending, unexpired action runs the full server-side re-check and executes the command-backed write path exactly once
+- calling confirm twice with the same `clientIdempotencyKey` is a no-op on the second call (no double-write)
+- calling confirm on an expired action returns `410 Gone`
+- calling confirm on a record whose `recordVersion` has changed since propose time returns `412 Precondition Failed`
+- calling confirm as a user in a different tenant from the proposing user returns `404` (no enumeration)
+- calling cancel on a `pending` action transitions it to `cancelled` and streams the agent continuation
+- calling cancel on a `confirmed` action returns `409`
+- expired pending actions are swept by the cleanup worker and emit `ai.action.expired`
+- the underlying CRUD/domain event fires exactly once when a mutation lands (no duplicate events from the approval flow)
+- `mutationPolicy: 'read-only'` agents cannot create pending actions even if a mutation tool is in their `allowedTools` (runtime refuses at propose time)
+- a tenant prompt override cannot escalate `mutationPolicy`
+- page reload mid-approval: the client calls `GET /api/ai/actions/:id` and re-renders the card in its current state
+
 ### Backward Compatibility
 - existing `ai-tools.ts` modules still load
 - `ai-tools.generated.ts` output shape remains unchanged
@@ -1042,7 +1444,7 @@ This spec modifies public AI extension surfaces and therefore must remain additi
 
 ### Additive surfaces introduced
 - `ai-agents.ts`
-- `AiAgentDefinition` (with optional `executionMode`, `output`, `resolvePageContext`, `maxSteps`, `keywords`, `domain`, `dataCapabilities`)
+- `AiAgentDefinition` (with optional `executionMode`, `output`, `resolvePageContext`, `maxSteps`, `keywords`, `domain`, `dataCapabilities`, `mutationPolicy`)
 - `defineAiTool()`
 - `ai-agents.generated.ts`
 - `POST /api/ai/chat?agent=...`
@@ -1054,6 +1456,10 @@ This spec modifies public AI extension surfaces and therefore must remain additi
 - attachment bridge helpers for AI SDK file/text parts
 - playground and agent settings pages
 - shared model factory (`@open-mercato/ai-assistant/lib/model-factory.ts`, Phase 3)
+- `AiPendingAction` data model and table (Phase 3, additive migration)
+- `GET /api/ai/actions/:id`, `POST /api/ai/actions/:id/confirm`, `POST /api/ai/actions/:id/cancel` (Phase 3)
+- `mutation-preview-card`, `field-diff-card`, `confirmation-card`, `mutation-result-card` UI parts (Phase 3)
+- `ai.action.confirmed`, `ai.action.cancelled`, `ai.action.expired` typed events (Phase 3)
 
 ### Rules
 - no existing import path is removed or renamed
@@ -1071,6 +1477,7 @@ When implemented, release notes must call out:
 - new AI SDK helper adapters for chat and structured-output flows
 - new playground and agent settings pages
 - coexistence story with OpenCode and Command Palette
+- **mutation approval gate** (Phase 3): the new `AiPendingAction` contract, confirm/cancel endpoints, and the four new UI parts; call out clearly that focused agents still cannot execute writes without an explicit in-chat user approval
 
 ## Final Compliance Report
 
@@ -1086,6 +1493,24 @@ When implemented, release notes must call out:
 | Risks include failure scenarios and mitigations | Pass | Concrete table included |
 
 ## Changelog
+
+### 2026-04-18
+- Integrated @dominikpalatynski's review feedback into the spec as a first-class runtime layer rather than a prompt convention.
+- Added Decision **D16. Human-in-the-Loop Mutation Approval (Pending-Action Contract)** formalizing server-owned pending actions, in-chat approval, and the re-check contract on confirm.
+- Added Decision **D17. Stacked Approval Queue (Future-Phase Extension)** as design-only forward compatibility for a later approval-queue feature — no runtime work in this spec.
+- Added `mutationPolicy` field to `AiAgentDefinition` (`'read-only'` | `'confirm-required'` | `'destructive-confirm-required'`); read-only remains the default and tenant prompt overrides cannot escalate it.
+- Added Proposed Solution section **9. Mutation Approval Gate** with the full happy-path / cancel / expiry flow, the 9.4 server-side re-check contract, the "reuse normal command path" rule, and observability/event emission.
+- Added data model `AiPendingAction` (additive Phase 3 table) with status lifecycle, `fieldDiff`, `recordVersion`, `idempotencyKey`, TTL, and a reserved `queueMode: 'inline' | 'stack'` field so D17 can ship without schema churn.
+- Added API contracts for `GET /api/ai/actions/:id`, `POST /api/ai/actions/:id/confirm`, `POST /api/ai/actions/:id/cancel`, including the full error model (`401` / `403` / `404` / `409` / `410` / `412` / `422` / `500`).
+- Added four new server-emitted UI parts — `mutation-preview-card`, `field-diff-card`, `confirmation-card`, `mutation-result-card` — and an "Interactive In-Chat HIL — Transcript Pattern" UX section covering composer disabling, `Cmd/Ctrl+Enter` / `Escape` shortcuts, reconnect via `GET /api/ai/actions/:id`, and expiry states.
+- Added typed events `ai.action.confirmed`, `ai.action.cancelled`, `ai.action.expired` (Phase 3) as the integration point the future stacked approval queue (D17) will consume.
+- Updated Phase 3 to include a Workstream C dedicated to the Mutation Approval Gate (entity, `prepareMutation` wrapper, endpoints, UI parts, cleanup worker, typed events, one end-to-end mutation-capable agent).
+- Updated Phase 4 follow-up scope to point at the Stacked Approval Queue as the natural extension and added a design sketch covering queue listing, role-based assignment, bulk approve/reject, SLA, and worker-based agent resumption.
+- Added integration test coverage for the mutation approval gate: happy path, cancel, expiry, stale-version reject, cross-tenant confirm denial, idempotent double-confirm, event emission, and read-only-agent refusal at propose time.
+- Added risk entries for stale-record confirm, cross-tenant `actionId` leakage, UI-part spoofing, double-click idempotency, and silent `mutationPolicy` escalation via prompt overrides.
+- Updated BC summary: `AiAgentDefinition` now has optional `mutationPolicy`; new additive routes, table, events, and UI parts all ship additively in Phase 3.
+- Updated the `[MUTATION POLICY]` baseline prompt to acknowledge that the runtime (not the prompt) is authoritative, and to instruct the model not to claim writes succeeded until a `mutation-result-card` arrives.
+- Credit: approval-flow shape based on @dominikpalatynski's review of this PR.
 
 ### 2026-04-15
 - Integrated high-value ideas from PR #1222 analysis (`.ai/specs/2026-04-13-pr-1222-decentralized-ai-analysis.md`).

--- a/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents.md
+++ b/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents.md
@@ -745,6 +745,8 @@ Add two backend pages under AI Assistant configuration:
 
 - `/backend/config/ai-assistant/playground`
 - `/backend/config/ai-assistant/agents`
+- companion screen wireframes: `.ai/specs/2026-04-11-unified-ai-tooling-and-subagents-screen-mockups.md`
+- companion component wireframes: `.ai/specs/2026-04-11-unified-ai-tooling-and-subagents-component-mockups.md`
 
 Playground requirements:
 
@@ -799,8 +801,10 @@ Settings requirements:
 
 ## Phasing
 
-### Phase 0 - Alignment and Foundations
-Goal: align the current tool runtime with generator output and add additive contracts.
+This implementation should land in three delivery phases after the alignment prerequisite. The goal is to make the next execution round unambiguous: first make the runtime/tooling real, then ship the operator-facing UI, then harden and expand.
+
+### Phase 0 - Alignment Prerequisite
+Goal: remove current runtime mismatches and establish the additive contracts that every later phase depends on.
 
 Deliverables:
 
@@ -809,8 +813,21 @@ Deliverables:
 - add `AiAgentDefinition` and `ai-agents.ts` generator support
 - emit new `ai-agents.generated.ts`
 
-### Phase 1 - Tool Packs and AI SDK DX
-Goal: make the platform actually useful to Vercel AI SDK users and ship the baseline tool packs before polishing UI chrome.
+Exit criteria:
+
+- generated `ai-tools.ts` contributions are visible to the runtime again
+- generated `ai-agents.ts` contributions can be discovered without breaking BC
+- the attachment bridge contracts and prompt-composition primitives exist as implementation-ready types
+
+### Phase 1 - Runtime, Tools, and AI SDK DX
+Goal: make the platform actually usable to Vercel AI SDK users before building admin chrome.
+
+Scope:
+
+- one canonical agent runtime
+- one canonical attachment-to-model bridge
+- baseline general-purpose, customers, and catalog tool packs
+- AI SDK-native helper surface for chat and object agents
 
 Deliverables:
 
@@ -821,8 +838,21 @@ Deliverables:
 - add attachment-to-model conversion bridge
 - authenticate with standard route auth and AI SDK helper contexts
 
+Exit criteria:
+
+- a Vercel AI SDK consumer can use `createAiAgentTransport(...)`, `runAiAgentText(...)`, or `runAiAgentObject(...)` without custom glue
+- the runtime can accept images, PDFs, and generic files through `attachmentIds`
+- customers and catalog tool packs can reach the same read models and writes already exposed by the UI
+
 ### Phase 2 - Playground, Settings, and First Module Agents
-Goal: ship the admin-facing surfaces that make the system testable and configurable.
+Goal: ship the operator-facing surfaces that make the system testable, configurable, and demonstrable.
+
+Scope:
+
+- embeddable chat UI
+- backend playground page
+- backend agent settings page
+- first customers and catalog module agents using the new tool packs
 
 Deliverables:
 
@@ -832,8 +862,21 @@ Deliverables:
 - add settings page with prompt overrides, tool toggles, and attachment policy visibility
 - ship first customers and catalog module agents using the new tool packs
 
+Exit criteria:
+
+- an internal admin can test chat-mode and object-mode agents from the playground
+- tenant admins can adjust additive prompt overrides and inspect tool/attachment settings
+- at least one customers agent and one catalog agent run end-to-end on the new stack
+
 ### Phase 3 - Production Hardening and Expansion
 Goal: prove the design on real production agents and harden the customization model.
+
+Scope:
+
+- production-grade agents beyond the first customers/catalog examples
+- shared model factory
+- prompt override persistence/versioning
+- page-context-driven embedding into existing backend surfaces
 
 Candidate:
 
@@ -849,6 +892,13 @@ Deliverables:
 - shared model factory utility extracted from `inbox_ops/lib/llmProvider.ts` into `@open-mercato/ai-assistant`, supporting `defaultModel` override and optional env-based per-agent override (`<MODULE>_AI_MODEL`)
 - integration coverage
 
+Exit criteria:
+
+- production agents can be mounted into existing backend flows with `resolvePageContext`
+- model selection is centralized
+- prompt overrides are safe, versioned, and test-covered
+- the playground and first module agents have been promoted into real production entry points where appropriate
+
 ### Phase 4 - Follow-up Scope
 Out of scope for this spec but expected follow-ups:
 
@@ -863,7 +913,9 @@ Out of scope for this spec but expected follow-ups:
 
 ## Implementation Plan
 
-### Phase 0
+The implementation plan below mirrors the delivery phases above. Each phase should end in a reviewable, working slice rather than a partially wired framework.
+
+### Phase 0 - Alignment Prerequisite
 1. Add `AiAgentDefinition` type and export it from `@open-mercato/ai-assistant`.
 2. Add `defineAiTool()` helper that returns `AiToolDefinition`.
 3. Add generator extension for `ai-agents.ts` and emit `ai-agents.generated.ts`.
@@ -871,30 +923,53 @@ Out of scope for this spec but expected follow-ups:
 5. Add tests proving existing `ai-tools.ts` modules still register and execute.
 6. Add the attachment bridge contract types and prompt composition primitives.
 
-### Phase 1
+### Phase 1 - Runtime, Tools, and AI SDK DX
+#### Workstream A - Core runtime
 1. Add `agent-registry.ts` that loads `ai-agents.generated.ts`.
 2. Add runtime policy checks for `requiredFeatures`, `allowedTools`, `readOnly`, attachment access, and `executionMode`.
 3. Add `api/ai/chat/route.ts` with `metadata` and `openApi`.
-4. Add AI SDK helper adapters and transport helpers.
-5. Implement general-purpose tool packs plus customers/catalog tool packs that mirror existing UI read models and write operations.
-6. Add contract tests for unknown agent, forbidden agent, invalid attachment, allowed-tool filtering, and object-agent execution.
 
-### Phase 2
+#### Workstream B - AI SDK adapters
+1. Add AI SDK helper adapters and transport helpers.
+2. Add structured-output execution support for `executionMode: 'object'`.
+3. Add contract tests for chat-mode and object-mode parity.
+
+#### Workstream C - Files and tool packs
+1. Implement the attachment-to-model conversion bridge.
+2. Implement general-purpose tool packs.
+3. Implement customers tool packs that mirror person/company/deal detail views and write operations.
+4. Implement catalog tool packs that mirror product/category detail views and write operations.
+5. Add contract tests for unknown agent, forbidden agent, invalid attachment, allowed-tool filtering, and tool-pack coverage.
+
+### Phase 2 - Playground, Settings, and First Module Agents
+#### Workstream A - Shared UI
 1. Add `packages/ui/src/ai/AiChat.tsx`.
 2. Add upload adapter that reuses attachment APIs and returns `attachmentIds`.
 3. Add a minimal client-side UI-part registry.
-4. Add backend playground page and agent settings page.
-5. Add backend and portal examples using existing injection/replacement patterns.
-6. Add i18n strings and keyboard interaction coverage.
-7. Ship first customers and catalog module agents with prompt templates.
 
-### Phase 3
+#### Workstream B - Admin-facing screens
+1. Add backend playground page.
+2. Add backend agent settings page.
+3. Add i18n strings, keyboard interaction coverage, and debug support.
+
+#### Workstream C - First module agents
+1. Ship first customers agents with prompt templates.
+2. Ship first catalog agents with prompt templates.
+3. Add backend and portal examples using existing injection/replacement patterns.
+
+### Phase 3 - Production Hardening and Expansion
+#### Workstream A - Production agent runtime
 1. Extract shared model factory from `inbox_ops/lib/llmProvider.ts` into `@open-mercato/ai-assistant/lib/model-factory.ts`. Support `defaultModel` override and env-based per-agent override (`<MODULE>_AI_MODEL`).
 2. Implement production `ai-agents.ts` files with `resolvePageContext` callbacks that hydrate record-level context.
-3. Add versioned prompt override persistence and safe additive merge rules.
-4. Bind production agents to existing backend pages through normal injection/UI composition, passing `pageContext` from the page.
-5. Add focused integration tests covering page context resolution, model factory fallback chain, and tenant prompt overrides.
-6. Add docs.
+
+#### Workstream B - Prompt and settings hardening
+1. Add versioned prompt override persistence and safe additive merge rules.
+2. Add focused integration tests covering tenant prompt overrides and settings persistence.
+
+#### Workstream C - Production rollout
+1. Bind production agents to existing backend pages through normal injection/UI composition, passing `pageContext` from the page.
+2. Add focused integration tests covering page context resolution and model factory fallback chain.
+3. Add docs and operator rollout notes.
 
 ## Integration Test Coverage
 

--- a/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents.md
+++ b/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents.md
@@ -151,6 +151,27 @@ Rules:
 - sub-agents may be exposed through the generalized MCP registry later as additive tools
 - raw tools continue to flow through the existing generalized MCP surface
 
+### D11. Community-Sourced Future Enhancements
+Several ideas from the community-contributed decentralized AI specs (PR #1222) are worth adopting in later phases. The high-value ideas have been integrated directly into this spec as optional, additive fields on `AiAgentDefinition`:
+
+Adopted into the type definition (available from Phase 0, used progressively):
+
+- **Page context resolver** (`resolvePageContext`): modules hydrate rich record-level context instead of relying on pass-through `pageContext`. Used at runtime from Phase 3+.
+- **Routing metadata** (`keywords`, `domain`, `dataCapabilities`): emitted in the generated registry from Phase 0, consumed by a future agent-suggestion feature in Phase 4+.
+- **Execution budget** (`maxSteps`): turn-level step limit passed to `streamText()`. Available from Phase 1, recommended for mutation-capable agents in Phase 4+.
+
+Deferred to Phase 3 implementation (not in the type definition yet):
+
+- **Shared model factory**: consolidate provider/model resolution from `inbox_ops/lib/llmProvider.ts` into a reusable utility in `@open-mercato/ai-assistant` when the second agent is built. Support `defaultModel` override plus optional env-based per-agent override (`<MODULE>_AI_MODEL`).
+
+Tracked for Phase 4+ (design only, no implementation commitment):
+
+- **Structured prompt composition**: replace raw `systemPrompt` string with a prompt-builder that concatenates named sections (`[ROLE]`, `[AUTH CONTEXT]`, `[MODULE]`, `[GUIDELINES]`). Useful when prompt complexity grows with multi-agent orchestration and richer context injection.
+- **Context dependencies**: modules declare higher-level affinities (`contextDependencies: ['customers', 'catalog']`) that auto-resolve to tool whitelists. Convenience layer over explicit `allowedTools`.
+- **Versioned manifest contract**: add `manifestVersion` and `platformRange` to `AiAgentDefinition` when external modules ship AI agents. Follow existing module versioning patterns from SPEC-061/064/065.
+
+Credit: ideas extracted from @rchrzanwlc's research in PR #1222. Full analysis in `.ai/specs/2026-04-13-pr-1222-decentralized-ai-analysis.md`.
+
 ## Proposed Solution
 
 ### 1. Additive Tool Builder
@@ -194,6 +215,21 @@ type AiAgentDefinition = {
   requiredFeatures?: string[]
   uiParts?: string[]
   readOnly?: boolean
+  maxSteps?: number
+  resolvePageContext?: (ctx: {
+    entityType: string
+    recordId: string
+    container: AwilixContainer
+    tenantId: string | null
+    organizationId: string | null
+  }) => Promise<string | null>
+  keywords?: string[]
+  domain?: string
+  dataCapabilities?: {
+    entities?: string[]
+    operations?: Array<'read' | 'search' | 'aggregate'>
+    searchableFields?: string[]
+  }
 }
 ```
 
@@ -204,6 +240,9 @@ Rules:
 - `readOnly` defaults to `true` in v1
 - if `readOnly` is `true`, tools marked `isMutation: true` are rejected at registration/runtime
 - focused agents may call other focused agents only in a later phase; v1 agents only call tools
+- `maxSteps` is optional; when set, limits the number of tool-call steps the runtime will execute per turn (passed to `streamText()`)
+- `resolvePageContext` is optional; when present, the runtime calls it before composing the system prompt, injecting the returned string as additional context about the record the user is currently viewing — this replaces generic `pageContext` pass-through with module-owned hydration
+- `keywords`, `domain`, and `dataCapabilities` are optional routing metadata; v1 ignores them at runtime but they are emitted in the generated registry for future agent-suggestion features
 
 ### 3. Standard Agent Runtime
 Add an internal focused-agent runtime that:
@@ -211,8 +250,10 @@ Add an internal focused-agent runtime that:
 - resolves the agent definition from the generated registry
 - authenticates with standard Open Mercato auth
 - creates a request-scoped execution context
+- if the agent declares `resolvePageContext` and the request includes `pageContext` with `entityType` and `recordId`, calls the resolver and injects the result into the system prompt before the first model call
 - resolves whitelisted tools from the shared tool registry
 - adapts those tools to AI SDK tool execution using the same handler/ACL contract
+- enforces `maxSteps` when declared on the agent definition
 - streams text and tagged UI parts back to the client
 
 Important constraint:
@@ -366,7 +407,7 @@ Rules:
 
 - `messages` are required
 - `attachmentIds` must belong to the authenticated tenant/org scope
-- client may send `pageContext`, but server treats it as advisory context only
+- client may send `pageContext`; if the agent declares `resolvePageContext`, the runtime calls it to hydrate rich record-level context into the system prompt — otherwise `pageContext` is treated as advisory context only
 
 Response:
 
@@ -507,8 +548,9 @@ Candidate:
 
 Deliverables:
 
-- one real `ai-agents.ts`
+- one real `ai-agents.ts` with `resolvePageContext` implementation
 - one whitelisted read-only tool set
+- shared model factory utility extracted from `inbox_ops/lib/llmProvider.ts` into `@open-mercato/ai-assistant`, supporting `defaultModel` override and optional env-based per-agent override (`<MODULE>_AI_MODEL`)
 - integration coverage
 
 ### Phase 4 - Follow-up Scope

--- a/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents.md
+++ b/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents.md
@@ -506,6 +506,9 @@ These are client-rendered components registered in the UI package.
 | Provider/model drift across tenants | Medium | Runtime config | Reuse existing tenant settings and only allow `defaultModel` override in v1 | Low |
 | UI part registry grows into unstable mini-framework | Medium | UI maintainability | Ship a very small v1 registry with strict serializable props only | Low |
 | Pressure to allow write-capable focused agents too early | High | Data integrity, UX safety | Keep v1 focused agents read-only; follow-up spec for confirmation protocol | Medium |
+| `resolvePageContext` leaks cross-tenant data | High | Security, privacy | Resolver runs inside the same request-scoped context with tenant/org filters; validate resolver output does not include cross-tenant references | Low |
+| Routing metadata (`keywords`/`domain`) used for auto-selection prematurely | Medium | UX correctness | V1 ignores routing metadata at runtime; only emitted in generated registry for future use | Low |
+| Model factory env overrides bypass tenant settings silently | Medium | Runtime config, billing | Document env override precedence clearly; log which resolution path was used in debug mode | Low |
 
 ## Phasing
 
@@ -560,6 +563,11 @@ Out of scope for this spec but expected follow-ups:
 - per-module MCP endpoints
 - agent-to-agent composition
 - RSC `streamUI`
+- structured prompt composition with named sections (replace raw `systemPrompt` with a prompt builder)
+- agent-suggestion feature consuming `keywords`, `domain`, and `dataCapabilities` metadata
+- context dependencies for auto-resolving tool whitelists from module affinities
+- execution budgets (`maxSteps`) recommended as mandatory for mutation-capable agents
+- versioned manifest contract (`manifestVersion`, `platformRange`) when external modules ship AI agents
 
 ## Implementation Plan
 
@@ -585,9 +593,11 @@ Out of scope for this spec but expected follow-ups:
 5. Add i18n strings and keyboard interaction coverage.
 
 ### Phase 3
-1. Implement one production `ai-agents.ts`.
-2. Bind it to an existing backend page through normal injection/UI composition.
-3. Add focused integration tests and docs.
+1. Extract shared model factory from `inbox_ops/lib/llmProvider.ts` into `@open-mercato/ai-assistant/lib/model-factory.ts`. Support `defaultModel` override and env-based per-agent override (`<MODULE>_AI_MODEL`).
+2. Implement one production `ai-agents.ts` with a `resolvePageContext` callback that hydrates record-level context.
+3. Bind it to an existing backend page through normal injection/UI composition, passing `pageContext` from the page.
+4. Add focused integration tests covering page context resolution and model factory fallback chain.
+5. Add docs.
 
 ## Integration Test Coverage
 
@@ -609,6 +619,20 @@ Required coverage for this spec:
 - debug panel remains hidden unless enabled
 - keyboard shortcuts work
 - i18n keys resolve correctly
+
+### Page Context Resolution
+- agent with `resolvePageContext` receives hydrated context when `pageContext` includes `entityType` and `recordId`
+- agent without `resolvePageContext` treats `pageContext` as advisory only
+- `resolvePageContext` errors are caught and do not crash the chat request
+
+### Model Factory
+- model factory resolves per-agent env override when set
+- model factory falls back to `defaultModel` when no env override exists
+- model factory falls back to tenant settings when no `defaultModel` is declared
+
+### Execution Budget
+- agent with `maxSteps` stops after the declared number of tool-call steps
+- agent without `maxSteps` uses the runtime default
 
 ### Backward Compatibility
 - existing `ai-tools.ts` modules still load
@@ -635,11 +659,12 @@ This spec modifies public AI extension surfaces and therefore must remain additi
 
 ### Additive surfaces introduced
 - `ai-agents.ts`
-- `AiAgentDefinition`
+- `AiAgentDefinition` (with optional `resolvePageContext`, `maxSteps`, `keywords`, `domain`, `dataCapabilities`)
 - `defineAiTool()`
 - `ai-agents.generated.ts`
 - `POST /api/ai/chat?agent=...`
 - `<AiChat>`
+- shared model factory (`@open-mercato/ai-assistant/lib/model-factory.ts`, Phase 3)
 
 ### Rules
 - no existing import path is removed or renamed
@@ -670,6 +695,18 @@ When implemented, release notes must call out:
 | Risks include failure scenarios and mitigations | Pass | Concrete table included |
 
 ## Changelog
+
+### 2026-04-15
+- Integrated high-value ideas from PR #1222 analysis (`.ai/specs/2026-04-13-pr-1222-decentralized-ai-analysis.md`).
+- Added `resolvePageContext` callback to `AiAgentDefinition` for module-owned page context hydration (Phase 3).
+- Added `maxSteps` execution budget field to `AiAgentDefinition` (Phase 1+, recommended for Phase 4 mutation agents).
+- Added routing metadata fields (`keywords`, `domain`, `dataCapabilities`) to `AiAgentDefinition` for future agent-suggestion (Phase 4+).
+- Added shared model factory consolidation to Phase 3 deliverables.
+- Expanded Phase 4 follow-up scope with structured prompt composition, context dependencies, and versioned manifest contract.
+- Added Decision D11 documenting community-sourced enhancements and their adoption timeline.
+- Added integration test coverage for page context resolution, model factory, and execution budgets.
+- Added risk entries for `resolvePageContext` tenant isolation, routing metadata premature use, and model factory env overrides.
+- Credit: ideas sourced from @rchrzanwlc's research in PR #1222.
 
 ### 2026-04-11
 - Replaced the skeleton with an implementation-ready additive migration spec.

--- a/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents.md
+++ b/.ai/specs/2026-04-11-unified-ai-tooling-and-subagents.md
@@ -3,8 +3,8 @@
 ## TLDR
 - Add an additive AI runtime on top of the existing `@open-mercato/ai-assistant` package so modules can expose focused sub-agents and embeddable chat without breaking current MCP, OpenCode, or Command Palette behavior.
 - Keep `ai-tools.ts`, `AiToolDefinition`, `McpToolDefinition`, `registerMcpTool()`, `ai-tools.generated.ts`, `/api/chat`, `/api/tools`, `mcp:serve`, and `mcp:serve-http` working unchanged.
-- Introduce a new additive module convention, `ai-agents.ts`, plus a reusable `<AiChat>` UI component and a new authenticated dispatcher route, `POST /api/ai/chat?agent=<module>.<agent>`.
-- V1 ships focused, read-first sub-agents, standard auth, attachment-backed uploads, tagged client-rendered streamed UI parts, and explicit coexistence with OpenCode Code Mode.
+- Introduce a new additive module convention, `ai-agents.ts`, plus a reusable `<AiChat>` UI component, AI-SDK-first helper APIs, and a new authenticated dispatcher route, `POST /api/ai/chat?agent=<module>.<agent>`.
+- V1 ships focused, read-first sub-agents, standard auth, attachment-backed uploads, tagged client-rendered streamed UI parts, explicit coexistence with OpenCode Code Mode, and first-class support for Vercel AI SDK patterns such as `useChat`, direct transport, and structured-output agents built on `generateText(..., { output })`.
 
 ## Overview
 Open Mercato already has three useful AI building blocks:
@@ -19,6 +19,8 @@ What is missing is a productized path for focused, module-owned AI experiences:
 - an embeddable chat component that can be mounted on backend and portal pages
 - a standard authenticated HTTP endpoint for these focused chats
 - one canonical contract that keeps MCP, in-process AI SDK execution, and module tooling aligned
+- a Vercel AI SDK-friendly path for teams that want to treat an Open Mercato agent as a normal AI SDK primitive instead of a bespoke runtime
+- a first-class file bridge so images, PDFs, and other attachments can be passed to agents safely without leaking private URLs or forcing app teams to hand-roll conversion logic
 
 This specification adds those capabilities without replacing the current stack. OpenCode remains the general assistant. The new stack is for narrow, module-scoped AI features.
 
@@ -30,7 +32,10 @@ Current limitations:
 - Module-owned focused agents do not exist as first-class artifacts. A module can expose tools, but not a complete "orders assistant" or "inbox proposal assistant" with an owned prompt, media policy, and tool whitelist.
 - The current UI surface is centered on the Command Palette. There is no reusable `<AiChat>` component that a page can embed and bind to a specific agent.
 - The current `/api/chat` route is designed around OpenCode and its session/question protocol. It is not the right contract for module-specific agent endpoints.
+- The current public surface is not AI SDK-first. A Vercel AI SDK user should be able to wire Open Mercato agents into `useChat`, transport-based chat, or structured-output flows without reverse-engineering internal adapters.
 - The current MCP/runtime story is internally inconsistent: the generator still emits `ai-tools.generated.ts`, but current tool loading logic is Code Mode-centric. That mismatch must be resolved before adding more AI extension surfaces.
+- File handling is underspecified for AI workloads. The repo already has a mature attachments module, but the current spec does not define how attachment records become model-ready file parts, extracted text, or provider-safe binary payloads.
+- The spec does not yet define the baseline tool packs that a "general", "customers", or "catalog" agent should expose, which risks shipping chat shells without enough domain reach to match the UI.
 - Mutation safety for focused AI workflows is not formalized outside the existing OpenCode question flow.
 
 Non-goals for this spec:
@@ -40,6 +45,15 @@ Non-goals for this spec:
 - Introducing a new top-level package such as `@open-mercato/ai`.
 - Per-module MCP endpoints in v1.
 - RSC `streamUI` in v1.
+
+## Current-State Verification
+Repository inspection on `2026-04-15` confirms the following facts that this spec must design around:
+
+- `packages/ai-assistant/src/modules/ai_assistant/lib/tool-loader.ts` currently registers `context_whoami` plus Code Mode `search` and `execute`, but does not load generated module `ai-tools.ts` contributions. Phase 0 must fix this before any agent rollout.
+- `packages/ai-assistant/src/modules/ai_assistant/lib/mcp-tool-adapter.ts` already converts registered tools into AI SDK tools, which means the repo is structurally close to an AI SDK-first runtime.
+- The attachments module already exposes stable upload, list, transfer, file, image, and library endpoints under `/api/attachments*`, plus MIME validation, OCR/text extraction hooks, and attachment metadata. The new agent stack must reuse this contract instead of inventing a parallel upload system.
+- Customers detail UIs already aggregate the exact read models agents need to be useful: person detail includes notes, activities, deals, addresses, and tasks; company detail adds related people; deal detail includes associations plus notes and activities.
+- Catalog UIs already expose the surfaces that tool packs must mirror: products list/detail, categories list/edit, variants, offers, price kinds, product unit conversions, and product media/attachments.
 
 ## Decisions
 
@@ -56,8 +70,13 @@ Planned layout:
 
 - `packages/ai-assistant/src/modules/ai_assistant/lib/agent-registry.ts`
 - `packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts`
+- `packages/ai-assistant/src/modules/ai_assistant/lib/agent-tools.ts`
+- `packages/ai-assistant/src/modules/ai_assistant/lib/agent-transport.ts`
+- `packages/ai-assistant/src/modules/ai_assistant/lib/attachment-parts.ts`
 - `packages/ai-assistant/src/modules/ai_assistant/lib/ai-tool-definition.ts`
 - `packages/ai-assistant/src/modules/ai_assistant/api/ai/chat/route.ts`
+- `packages/ai-assistant/src/modules/ai_assistant/backend/config/ai-assistant/agents/page.tsx`
+- `packages/ai-assistant/src/modules/ai_assistant/backend/config/ai-assistant/playground/page.tsx`
 - `packages/ui/src/ai/AiChat.tsx`
 
 ### D2. Tool Source of Truth
@@ -166,11 +185,57 @@ Deferred to Phase 3 implementation (not in the type definition yet):
 
 Tracked for Phase 4+ (design only, no implementation commitment):
 
-- **Structured prompt composition**: replace raw `systemPrompt` string with a prompt-builder that concatenates named sections (`[ROLE]`, `[AUTH CONTEXT]`, `[MODULE]`, `[GUIDELINES]`). Useful when prompt complexity grows with multi-agent orchestration and richer context injection.
 - **Context dependencies**: modules declare higher-level affinities (`contextDependencies: ['customers', 'catalog']`) that auto-resolve to tool whitelists. Convenience layer over explicit `allowedTools`.
 - **Versioned manifest contract**: add `manifestVersion` and `platformRange` to `AiAgentDefinition` when external modules ship AI agents. Follow existing module versioning patterns from SPEC-061/064/065.
 
 Credit: ideas extracted from @rchrzanwlc's research in PR #1222. Full analysis in `.ai/specs/2026-04-13-pr-1222-decentralized-ai-analysis.md`.
+
+### D12. AI SDK-First Public Adapters
+The new runtime must feel native to Vercel AI SDK users. The HTTP route is necessary, but it is not sufficient.
+
+Rules:
+
+- expose a thin public helper for `useChat` transport creation so app code can bind `agentId`, custom body fields, and debug flags without hand-rolling URLs
+- expose a server-side helper that resolves an Open Mercato agent into AI SDK-compatible tools plus instructions/context for direct `generateText()` / `streamText()` usage
+- expose a structured-output helper so teams can run a focused Open Mercato agent as a normal object-producing call using AI SDK `output` instead of re-implementing the agent contract manually
+- the public helper surface must stay additive and optional; advanced teams may still call lower-level runtime APIs directly
+
+Design implication:
+
+- V1 supports two agent execution shapes:
+  - `chat` agents for multi-turn transcript-based flows
+  - `object` agents for single-turn or bounded structured-output workflows
+
+### D13. Attachment-to-Model Bridge
+Attachments stay stored as Open Mercato records, but the runtime must convert them into model-safe payloads before invocation.
+
+Rules:
+
+- clients send `attachmentIds`, never raw long-lived URLs
+- the runtime resolves each attachment record, validates tenant/org scope, and converts it into AI SDK-compatible file parts or text parts
+- never pass authenticated frontend URLs directly to providers; use short-lived signed URLs, inline bytes, or extracted text depending on provider capability and file type
+- images and PDFs are first-class inputs; text-like files (`txt`, `md`, `csv`, `json`) should also be converted into model-usable content
+- unsupported binary files still appear in agent context as metadata so the model can acknowledge them instead of silently ignoring them
+
+### D14. Prompt Contract and Override Model
+Prompt authoring should be structured from the start so the system is easy to reason about, test, and customize.
+
+Rules:
+
+- replace the flat mental model of one long `systemPrompt` string with a structured prompt composition contract, even if the stored value remains additive-compatible with `systemPrompt`
+- every agent prompt is composed from named sections: role, scope, available data/tools, attachment guidance, mutation policy, response style, and tenant/admin overrides
+- tenant admins may add additive prompt snippets and custom instructions through settings, but must not be able to disable hard safety sections
+- prompt overrides are versioned and attached to the agent id so they can be tested and audited independently
+
+### D15. Tool Coverage Must Follow Real UI Capability
+Agent tools should not be an arbitrary API wrapper set. They must let users reach the same business data and operations that the UI exposes.
+
+Rules:
+
+- every production agent must declare a tool pack that maps to real UI surfaces, not only raw CRUD endpoints
+- read tools should prefer aggregated detail/read-model outputs that mirror the UI tabs and panels users already understand
+- write tools should correspond to actual UI actions and command-backed operations already supported in the repo
+- the first module coverage target for this spec is `customers` and `catalog`
 
 ## Proposed Solution
 
@@ -208,6 +273,7 @@ type AiAgentDefinition = {
   moduleId: string
   label: string
   description: string
+  executionMode?: 'chat' | 'object'
   systemPrompt: string
   allowedTools: string[]
   defaultModel?: string
@@ -216,6 +282,11 @@ type AiAgentDefinition = {
   uiParts?: string[]
   readOnly?: boolean
   maxSteps?: number
+  output?: {
+    schemaName: string
+    schema: ZodTypeAny | StandardSchemaV1
+    mode?: 'generate' | 'stream'
+  }
   resolvePageContext?: (ctx: {
     entityType: string
     recordId: string
@@ -236,11 +307,13 @@ type AiAgentDefinition = {
 Rules:
 
 - `id` format: `<module>.<agent>`
+- `executionMode` defaults to `chat`
 - `allowedTools` is an explicit whitelist
 - `readOnly` defaults to `true` in v1
 - if `readOnly` is `true`, tools marked `isMutation: true` are rejected at registration/runtime
 - focused agents may call other focused agents only in a later phase; v1 agents only call tools
 - `maxSteps` is optional; when set, limits the number of tool-call steps the runtime will execute per turn (passed to `streamText()`)
+- `output` is optional and only valid for `executionMode: 'object'`; it lets app teams run a focused agent through structured-output APIs without hand-writing the prompt and tool plumbing
 - `resolvePageContext` is optional; when present, the runtime calls it before composing the system prompt, injecting the returned string as additional context about the record the user is currently viewing — this replaces generic `pageContext` pass-through with module-owned hydration
 - `keywords`, `domain`, and `dataCapabilities` are optional routing metadata; v1 ignores them at runtime but they are emitted in the generated registry for future agent-suggestion features
 
@@ -254,6 +327,8 @@ Add an internal focused-agent runtime that:
 - resolves whitelisted tools from the shared tool registry
 - adapts those tools to AI SDK tool execution using the same handler/ACL contract
 - enforces `maxSteps` when declared on the agent definition
+- resolves `executionMode: 'object'` agents into AI SDK structured-output calls instead of transcript-oriented chat loops
+- converts `attachmentIds` into validated model-ready file or text parts before invocation
 - streams text and tagged UI parts back to the client
 
 Important constraint:
@@ -261,7 +336,23 @@ Important constraint:
 - this is an internal runtime optimization, not a new public module-authoring contract
 - module authors still author MCP-compatible tools and declarative agent definitions
 
-### 4. Embeddable `<AiChat>`
+### 4. AI SDK-First Adapters
+Expose additive helpers so Open Mercato agents feel native in Vercel AI SDK codebases.
+
+Public helpers:
+
+- `createAiAgentTransport({ agentId, ... })` for `useChat`
+- `resolveAiAgentTools({ agentId, authContext, pageContext, attachmentIds })`
+- `runAiAgentText({ agentId, messages, ... })`
+- `runAiAgentObject({ agentId, input, ... })`
+
+Rules:
+
+- `runAiAgentObject()` uses AI SDK structured-output execution (`generateText` / `streamText` with `output`) instead of inventing a separate object-agent abstraction
+- helper inputs accept the same additive context used by the HTTP runtime: `pageContext`, `attachmentIds`, `debug`, and optional model override
+- transport helpers support request-level custom body fields so frontend pages can pass page context or agent settings without mutating the transcript
+
+### 5. Embeddable `<AiChat>`
 Add a reusable UI component for backend and portal pages.
 
 Supported bindings:
@@ -276,7 +367,12 @@ Supported media:
 - PDF attachments
 - generic file attachments already supported by the attachments module
 
-### 5. Safe V1 Scope
+Companion examples in scope:
+
+- a backend playground page where a user can pick the general assistant or a module agent and chat against it
+- a debug-friendly example that shows transcript events, tool calls, attachment previews, and structured output for object agents
+
+### 6. Safe V1 Scope
 V1 focused agents are read-first.
 
 Rules:
@@ -284,6 +380,110 @@ Rules:
 - agent-bound chat may use only read-only tools in v1
 - mutation-capable tools remain available through the existing general assistant/MCP flows
 - mutation-capable focused agents are deferred to a later follow-up spec once confirmation semantics are unified
+
+### 7. Tool Packs and Coverage
+V1 introduces explicit tool-pack guidance so agents are useful on day one.
+
+General-purpose tool packs to add:
+
+| Tool Pack | Purpose | Backing repo surface |
+|------|--------|-------|
+| `search.hybrid_search` | Global fulltext + vector + token search over enabled entities | `packages/search`, module `search.ts` configs |
+| `search.get_record_context` | Resolve presenter, links, and summary for a search hit | `packages/search` presenter/buildSource pipeline |
+| `attachments.list_record_attachments` | List files bound to a record | `/api/attachments` |
+| `attachments.read_attachment` | Fetch attachment metadata plus extracted text when available | `/api/attachments/library/[id]`, OCR/text extraction |
+| `attachments.transfer_record_attachments` | Move uploaded files from temp or draft records to saved records | `/api/attachments/transfer` |
+| `meta.describe_agent` | Return agent metadata, prompt sections, and tool pack summary | generated agent registry |
+| `meta.list_agents` | Enumerate general and module agents the current user can access | generated agent registry + RBAC |
+
+Customers tool coverage requirements:
+
+| Aggregate / Operation | Minimum tool coverage |
+|------|--------|
+| People list + detail | list/search people; get person detail with notes, activities, deals, addresses, tasks, tags, custom fields |
+| Companies list + detail | list/search companies; get company detail with notes, activities, deals, people, addresses, tasks, tags, custom fields |
+| Deals | list/search deals; get deal detail with notes, activities, people, companies; create/update/delete deal |
+| Activities and tasks | list/create/update activities; complete/cancel interaction; list/create/update customer tasks |
+| Addresses | list/create/update/delete addresses |
+| Tags | list/create tags; assign/unassign tags |
+| Settings data | pipelines, pipeline stages, dictionaries, address format settings |
+
+Catalog tool coverage requirements:
+
+| Aggregate / Operation | Minimum tool coverage |
+|------|--------|
+| Products list + detail | list/search products; get product detail with categories, variants, prices, offers, media, metadata, unit conversions |
+| Categories | list tree/manage categories; get category detail; create/update/archive category |
+| Variants | list/create/update/delete variants and surface option values/media |
+| Prices and price kinds | list/create/update/delete prices; list/create/update/delete price kinds |
+| Offers | list/create/update/delete offers |
+| Product media | list product media and manage attachment associations |
+| Product configuration | option schemas, tags, product unit conversions, bulk delete |
+
+### 8. Prompt Templates and Settings
+The first implementation should ship prompt templates, not ad hoc strings.
+
+Required prompt sections:
+
+- `ROLE`: what the agent is responsible for
+- `SCOPE`: module boundaries and current page context
+- `DATA`: which read models and entities the agent can access
+- `TOOLS`: allowed tool packs and when to use them
+- `ATTACHMENTS`: how to interpret images, PDFs, and files
+- `MUTATION POLICY`: confirmation and safety rules
+- `RESPONSE STYLE`: concise, business-facing output rules
+
+Baseline prompt blueprints to ship with the first implementation:
+
+```md
+[ROLE]
+You are the Open Mercato workspace assistant. Help the user find information, explain records, summarize files, and suggest next actions using only the tools and data currently available.
+
+[SCOPE]
+You may access only the current tenant and organization scope. Respect feature-based access control and do not invent records, actions, or permissions.
+
+[DATA]
+Prefer aggregate read-model tools over raw CRUD lists when they exist. Reuse page context and attachment content before asking for more data.
+
+[ATTACHMENTS]
+Images and PDFs may contain important business context. Summarize what is visible, mention uncertainty, and reference attached files explicitly when they influence the answer.
+
+[MUTATION POLICY]
+Never execute a write without an explicit user confirmation step. Summarize the intended change first.
+
+[RESPONSE STYLE]
+Be concise, business-facing, and action-oriented. Avoid raw IDs and internal implementation terms unless the user asks for them.
+```
+
+```md
+[ROLE]
+You are the customers workspace assistant. Help with people, companies, deals, activities, tasks, addresses, tags, pipelines, and CRM settings.
+
+[DATA]
+Prefer person/company/deal detail aggregate tools so the answer matches the CRM detail pages. Use timeline-style summaries when notes, activities, and tasks all matter.
+
+[MUTATION POLICY]
+When a user wants to change CRM data, explain exactly which record and fields will change before asking for confirmation.
+```
+
+```md
+[ROLE]
+You are the catalog merchandising assistant. Help with products, categories, variants, prices, offers, media, and product configuration.
+
+[DATA]
+Prefer product detail aggregate tools so the answer includes media, categories, variants, pricing, offers, and custom metadata in one coherent view.
+
+[ATTACHMENTS]
+Use attached images and PDFs as merchandising context. Mention when an answer depends on visual interpretation.
+```
+
+First settings page scope:
+
+- agent registry view with enabled/disabled status per agent
+- prompt override editor with additive tenant instructions
+- tool toggle / tool-pack visibility controls
+- attachment policy controls by media type and size budget
+- sample context injection fields for testing prompts without changing production pages
 
 ## Architecture
 
@@ -305,10 +505,13 @@ Rules:
    - MCP execution through existing MCP server/runtime
    - in-process execution through the existing `executeTool()` contract
    - AI SDK adapter built from the same tool definitions
+   - structured-output execution path for `executionMode: 'object'`
 
 5. HTTP/UI layer
    - `POST /api/ai/chat?agent=...`
    - `<AiChat>`
+   - playground page
+   - agent settings page
 
 ### Generator Changes
 
@@ -333,6 +536,8 @@ Before shipping the new runtime, Phase 0 must resolve the current mismatch betwe
 Required fix:
 
 - restore or replace module-tool loading so generated `ai-tools.ts` contributions are actually available to the runtime again
+- preserve the existing `mcp-tool-adapter.ts` path as the foundation for AI SDK-native tool resolution instead of replacing it with a second adapter stack
+- reuse existing attachments endpoints and storage records as the single source of truth for file uploads, previews, OCR, and transfer
 
 This is a prerequisite for the new focused-agent stack because agents depend on module-owned tool discovery.
 
@@ -374,6 +579,25 @@ type AiChatRequestContext = {
 }
 ```
 
+### `AiResolvedAttachmentPart`
+```ts
+type AiResolvedAttachmentPart = {
+  attachmentId: string
+  fileName: string
+  mediaType: string
+  source: 'bytes' | 'signed-url' | 'text' | 'metadata-only'
+  textContent?: string | null
+  url?: string | null
+  data?: Uint8Array | string | null
+}
+```
+
+Rules:
+
+- images and PDFs should prefer `bytes` or short-lived `signed-url` sources depending on provider support
+- text-like files should include extracted `textContent`
+- unsupported binary files must still surface filename, media type, and size to the model/runtime
+
 ## API Contracts
 
 ### 1. Focused Agent Chat
@@ -408,6 +632,7 @@ Rules:
 - `messages` are required
 - `attachmentIds` must belong to the authenticated tenant/org scope
 - client may send `pageContext`; if the agent declares `resolvePageContext`, the runtime calls it to hydrate rich record-level context into the system prompt — otherwise `pageContext` is treated as advisory context only
+- route requests must remain compatible with AI SDK chat transports by accepting request-level body fields without requiring transcript mutation
 
 Response:
 
@@ -424,7 +649,43 @@ Error model:
 - `409` agent/tool policy violation
 - `500` internal runtime failure
 
-### 2. Existing Routes Preserved
+### 2. AI SDK Helper Contracts
+These are additive public APIs, not HTTP endpoints:
+
+```ts
+type RunAiAgentTextInput = {
+  agentId: string
+  messages: UIMessage[]
+  attachmentIds?: string[]
+  pageContext?: {
+    pageId?: string
+    entityType?: string
+    recordId?: string
+  }
+  debug?: boolean
+}
+
+type RunAiAgentObjectInput<TSchema> = {
+  agentId: string
+  input: string | UIMessage[]
+  attachmentIds?: string[]
+  pageContext?: {
+    pageId?: string
+    entityType?: string
+    recordId?: string
+  }
+  output?: TSchema
+  debug?: boolean
+}
+```
+
+Rules:
+
+- `runAiAgentText()` maps to the same runtime policy as the HTTP chat route
+- `runAiAgentObject()` is the Vercel AI SDK-friendly entry point for structured-output agents
+- object helpers must use the same tool filtering, prompt composition, and attachment conversion path as chat helpers
+
+### 3. Existing Routes Preserved
 These remain supported and unchanged by this spec:
 
 - `POST /api/chat`
@@ -459,6 +720,7 @@ Behavior:
 - streamed text renders in the transcript
 - streamed UI parts render through a client-side registry
 - debug panel is opt-in and hidden by default
+- component should expose request-level `body`/context configuration so pages can pass `pageContext`, selected agent settings, or prompt-override ids the same way AI SDK transports pass custom body fields
 
 UX rules:
 
@@ -477,6 +739,28 @@ Initial streamable UI parts for v1:
 - `warning-note`
 
 These are client-rendered components registered in the UI package.
+
+### Playground and Settings Pages
+Add two backend pages under AI Assistant configuration:
+
+- `/backend/config/ai-assistant/playground`
+- `/backend/config/ai-assistant/agents`
+
+Playground requirements:
+
+- selectable agent picker including general agent, customers agents, and catalog agents
+- transcript mode and object-output mode
+- attachment upload and preview support
+- debug event stream and tool-call inspection
+- quick page-context injection form for testing `resolvePageContext`
+
+Settings requirements:
+
+- prompt override editor
+- tool-pack visibility toggles
+- model override display and edit surface
+- attachment policy summary
+- saved test snippets / reusable context blocks for admins
 
 ## Access Control
 
@@ -503,12 +787,15 @@ These are client-rendered components registered in the UI package.
 | Tool contract drift across MCP, in-process, and AI SDK adapters | High | AI runtime, security, behavior | One canonical builder, one `executeTool()` path, cross-surface contract tests | Medium |
 | Current `ai-tools.generated.ts` vs runtime-loading mismatch remains unresolved | High | Existing module tools, new focused agents | Fix current loading in Phase 0 before any new agent work | Low |
 | Tenant context leakage through attachment IDs | High | Security, privacy | Validate every attachment against tenant/org scope before model invocation | Low |
+| Private attachment URLs are passed directly to providers and fail or leak | High | Security, attachment usability | Convert attachments to bytes, signed URLs, or extracted text in one runtime bridge | Low |
 | Provider/model drift across tenants | Medium | Runtime config | Reuse existing tenant settings and only allow `defaultModel` override in v1 | Low |
 | UI part registry grows into unstable mini-framework | Medium | UI maintainability | Ship a very small v1 registry with strict serializable props only | Low |
 | Pressure to allow write-capable focused agents too early | High | Data integrity, UX safety | Keep v1 focused agents read-only; follow-up spec for confirmation protocol | Medium |
 | `resolvePageContext` leaks cross-tenant data | High | Security, privacy | Resolver runs inside the same request-scoped context with tenant/org filters; validate resolver output does not include cross-tenant references | Low |
 | Routing metadata (`keywords`/`domain`) used for auto-selection prematurely | Medium | UX correctness | V1 ignores routing metadata at runtime; only emitted in generated registry for future use | Low |
 | Model factory env overrides bypass tenant settings silently | Medium | Runtime config, billing | Document env override precedence clearly; log which resolution path was used in debug mode | Low |
+| Tenant prompt overrides can weaken safety instructions | High | Security, mutation safety | Keep hard safety sections server-owned and append tenant overrides after them | Low |
+| Tool coverage stops at CRUD and misses UI-level read models | Medium | UX usefulness | Require aggregate detail tools that mirror real tabs/panels for customers and catalog | Low |
 
 ## Phasing
 
@@ -522,37 +809,43 @@ Deliverables:
 - add `AiAgentDefinition` and `ai-agents.ts` generator support
 - emit new `ai-agents.generated.ts`
 
-### Phase 1 - Agent Runtime and Authenticated Dispatcher
-Goal: introduce the focused-agent runtime and HTTP entrypoint.
+### Phase 1 - Tool Packs and AI SDK DX
+Goal: make the platform actually useful to Vercel AI SDK users and ship the baseline tool packs before polishing UI chrome.
 
 Deliverables:
 
 - add agent registry/runtime
 - add `POST /api/ai/chat?agent=...`
-- authenticate with standard route auth
-- adapt whitelisted tools into AI SDK execution
+- add AI SDK helper adapters (`createAiAgentTransport`, `resolveAiAgentTools`, `runAiAgentText`, `runAiAgentObject`)
+- implement general-purpose tool packs plus the initial customers and catalog tool packs
+- add attachment-to-model conversion bridge
+- authenticate with standard route auth and AI SDK helper contexts
 
-### Phase 2 - Embeddable UI
-Goal: ship the reusable chat UI.
+### Phase 2 - Playground, Settings, and First Module Agents
+Goal: ship the admin-facing surfaces that make the system testable and configurable.
 
 Deliverables:
 
 - add `<AiChat>`
-- attachment-backed upload flow
 - tagged streamed UI parts
-- debug panel
+- add playground page with agent picker, chat mode, object mode, and debug panel
+- add settings page with prompt overrides, tool toggles, and attachment policy visibility
+- ship first customers and catalog module agents using the new tool packs
 
-### Phase 3 - First Production Agent
-Goal: prove the design on one real module-owned focused agent.
+### Phase 3 - Production Hardening and Expansion
+Goal: prove the design on real production agents and harden the customization model.
 
 Candidate:
 
-- `inbox_ops.proposal_assistant` or `sales.order_assistant`
+- `inbox_ops.proposal_assistant`
+- `sales.order_assistant`
+- `customers.account_assistant`
+- `catalog.merchandising_assistant`
 
 Deliverables:
 
-- one real `ai-agents.ts` with `resolvePageContext` implementation
-- one whitelisted read-only tool set
+- one or more real `ai-agents.ts` files with `resolvePageContext` implementation
+- structured prompt templates and versioned tenant overrides
 - shared model factory utility extracted from `inbox_ops/lib/llmProvider.ts` into `@open-mercato/ai-assistant`, supporting `defaultModel` override and optional env-based per-agent override (`<MODULE>_AI_MODEL`)
 - integration coverage
 
@@ -563,7 +856,6 @@ Out of scope for this spec but expected follow-ups:
 - per-module MCP endpoints
 - agent-to-agent composition
 - RSC `streamUI`
-- structured prompt composition with named sections (replace raw `systemPrompt` with a prompt builder)
 - agent-suggestion feature consuming `keywords`, `domain`, and `dataCapabilities` metadata
 - context dependencies for auto-resolving tool whitelists from module affinities
 - execution budgets (`maxSteps`) recommended as mandatory for mutation-capable agents
@@ -577,27 +869,32 @@ Out of scope for this spec but expected follow-ups:
 3. Add generator extension for `ai-agents.ts` and emit `ai-agents.generated.ts`.
 4. Restore loading of generated `ai-tools.generated.ts` contributions in the runtime.
 5. Add tests proving existing `ai-tools.ts` modules still register and execute.
+6. Add the attachment bridge contract types and prompt composition primitives.
 
 ### Phase 1
 1. Add `agent-registry.ts` that loads `ai-agents.generated.ts`.
-2. Add runtime policy checks for `requiredFeatures`, `allowedTools`, `readOnly`, and attachment access.
+2. Add runtime policy checks for `requiredFeatures`, `allowedTools`, `readOnly`, attachment access, and `executionMode`.
 3. Add `api/ai/chat/route.ts` with `metadata` and `openApi`.
-4. Reuse existing auth/context resolution for route and in-process execution.
-5. Add contract tests for unknown agent, forbidden agent, invalid attachment, and allowed-tool filtering.
+4. Add AI SDK helper adapters and transport helpers.
+5. Implement general-purpose tool packs plus customers/catalog tool packs that mirror existing UI read models and write operations.
+6. Add contract tests for unknown agent, forbidden agent, invalid attachment, allowed-tool filtering, and object-agent execution.
 
 ### Phase 2
 1. Add `packages/ui/src/ai/AiChat.tsx`.
 2. Add upload adapter that reuses attachment APIs and returns `attachmentIds`.
 3. Add a minimal client-side UI-part registry.
-4. Add backend and portal examples using existing injection/replacement patterns.
-5. Add i18n strings and keyboard interaction coverage.
+4. Add backend playground page and agent settings page.
+5. Add backend and portal examples using existing injection/replacement patterns.
+6. Add i18n strings and keyboard interaction coverage.
+7. Ship first customers and catalog module agents with prompt templates.
 
 ### Phase 3
 1. Extract shared model factory from `inbox_ops/lib/llmProvider.ts` into `@open-mercato/ai-assistant/lib/model-factory.ts`. Support `defaultModel` override and env-based per-agent override (`<MODULE>_AI_MODEL`).
-2. Implement one production `ai-agents.ts` with a `resolvePageContext` callback that hydrates record-level context.
-3. Bind it to an existing backend page through normal injection/UI composition, passing `pageContext` from the page.
-4. Add focused integration tests covering page context resolution and model factory fallback chain.
-5. Add docs.
+2. Implement production `ai-agents.ts` files with `resolvePageContext` callbacks that hydrate record-level context.
+3. Add versioned prompt override persistence and safe additive merge rules.
+4. Bind production agents to existing backend pages through normal injection/UI composition, passing `pageContext` from the page.
+5. Add focused integration tests covering page context resolution, model factory fallback chain, and tenant prompt overrides.
+6. Add docs.
 
 ## Integration Test Coverage
 
@@ -611,6 +908,8 @@ Required coverage for this spec:
 - attachment from another tenant/org is rejected
 - read-only agent cannot access a mutation-marked tool
 - tool whitelist is enforced even if the tool exists globally
+- object-mode agent can execute through the public helper with the same policy checks as chat-mode agents
+- custom request body fields propagate page context without altering the transcript
 
 ### UI
 - `<AiChat>` uploads files and sends `attachmentIds`
@@ -619,6 +918,14 @@ Required coverage for this spec:
 - debug panel remains hidden unless enabled
 - keyboard shortcuts work
 - i18n keys resolve correctly
+- playground page can switch between general, customers, and catalog agents
+- settings page persists additive prompt overrides without mutating hard safety sections
+
+### Tool Coverage
+- general search tool pack can reach fulltext, vector, and token-backed search results
+- customers tool pack can read the same aggregates shown on person, company, and deal pages
+- catalog tool pack can read the same aggregates shown on product and category pages
+- write tools map to the same command-backed operations already exposed by UI forms and actions
 
 ### Page Context Resolution
 - agent with `resolvePageContext` receives hydrated context when `pageContext` includes `entityType` and `recordId`
@@ -640,6 +947,7 @@ Required coverage for this spec:
 - `registerMcpTool()` still works
 - existing `/api/chat` and `/api/tools*` routes still function
 - existing `mcp:serve` and `mcp:serve-http` commands still function
+- current OpenCode Code Mode behavior remains available alongside the new agents
 
 ## Migration & Backward Compatibility
 
@@ -659,11 +967,17 @@ This spec modifies public AI extension surfaces and therefore must remain additi
 
 ### Additive surfaces introduced
 - `ai-agents.ts`
-- `AiAgentDefinition` (with optional `resolvePageContext`, `maxSteps`, `keywords`, `domain`, `dataCapabilities`)
+- `AiAgentDefinition` (with optional `executionMode`, `output`, `resolvePageContext`, `maxSteps`, `keywords`, `domain`, `dataCapabilities`)
 - `defineAiTool()`
 - `ai-agents.generated.ts`
 - `POST /api/ai/chat?agent=...`
 - `<AiChat>`
+- `createAiAgentTransport(...)`
+- `resolveAiAgentTools(...)`
+- `runAiAgentText(...)`
+- `runAiAgentObject(...)`
+- attachment bridge helpers for AI SDK file/text parts
+- playground and agent settings pages
 - shared model factory (`@open-mercato/ai-assistant/lib/model-factory.ts`, Phase 3)
 
 ### Rules
@@ -679,6 +993,8 @@ When implemented, release notes must call out:
 - new `ai-agents.ts` convention
 - new `defineAiTool()` helper
 - new `/api/ai/chat` route
+- new AI SDK helper adapters for chat and structured-output flows
+- new playground and agent settings pages
 - coexistence story with OpenCode and Command Palette
 
 ## Final Compliance Report
@@ -701,11 +1017,17 @@ When implemented, release notes must call out:
 - Added `resolvePageContext` callback to `AiAgentDefinition` for module-owned page context hydration (Phase 3).
 - Added `maxSteps` execution budget field to `AiAgentDefinition` (Phase 1+, recommended for Phase 4 mutation agents).
 - Added routing metadata fields (`keywords`, `domain`, `dataCapabilities`) to `AiAgentDefinition` for future agent-suggestion (Phase 4+).
+- Added AI SDK-first adapter requirements so Open Mercato agents can be used through chat transports and structured-output helper flows without custom glue code.
+- Added `executionMode` / `output` planning to make object-style agents first-class for Vercel AI SDK users.
+- Added explicit attachment-to-model conversion rules covering images, PDFs, text-like files, and unsupported binaries.
+- Added general-purpose tool packs plus customers/catalog coverage requirements derived from real UI and API surfaces in the repo.
+- Added playground and agent settings pages to the planned surface area.
+- Moved tool implementation to the next delivery phase and split the remainder into tooling, playground/settings, and production-hardening phases.
 - Added shared model factory consolidation to Phase 3 deliverables.
-- Expanded Phase 4 follow-up scope with structured prompt composition, context dependencies, and versioned manifest contract.
+- Expanded follow-up scope with context dependencies and versioned manifest contract.
 - Added Decision D11 documenting community-sourced enhancements and their adoption timeline.
-- Added integration test coverage for page context resolution, model factory, and execution budgets.
-- Added risk entries for `resolvePageContext` tenant isolation, routing metadata premature use, and model factory env overrides.
+- Added integration test coverage for AI SDK helper flows, playground/settings behavior, customers/catalog tool packs, page context resolution, model factory, and execution budgets.
+- Added risk entries for private attachment URL leakage, tenant prompt overrides, `resolvePageContext` tenant isolation, routing metadata premature use, and model factory env overrides.
 - Credit: ideas sourced from @rchrzanwlc's research in PR #1222.
 
 ### 2026-04-11

--- a/.ai/specs/2026-04-13-pr-1222-decentralized-ai-analysis.md
+++ b/.ai/specs/2026-04-13-pr-1222-decentralized-ai-analysis.md
@@ -1,0 +1,180 @@
+# Analysis: PR #1222 — Decentralized AI Assistant Ideas Worth Adopting
+
+**Date:** 2026-04-13
+**Status:** Analysis
+**Source:** [PR #1222](https://github.com/open-mercato/open-mercato/pull/1222) (closed — superseded by the official spec)
+**Official Spec:** [`2026-04-11-unified-ai-tooling-and-subagents.md`](./2026-04-11-unified-ai-tooling-and-subagents.md)
+
+## Context
+
+PR #1222 contributed two draft specs:
+
+1. **Decentralized AI Assistant** — replacing centralized OpenCode with module-driven AI using `ai-manifest.ts`, Vercel AI SDK chat, retrieval-based routing, and structured prompt composition.
+2. **Decentralized AI Capability Contract** — extending the above with a versioned public contract model, control-plane/execution-plane split, staged routing, and external-module ecosystem support.
+
+The official spec (`unified-ai-tooling-and-subagents`) takes a deliberately different, more conservative approach: additive `ai-agents.ts` convention, read-only focused sub-agents, explicit tool whitelists, and full preservation of existing MCP/OpenCode surfaces. Both approaches share the same goal — making AI capabilities module-driven — but differ significantly in scope, risk tolerance, and migration strategy.
+
+This document extracts the ideas from PR #1222 that are worth considering as future enhancements to the official spec, organized by value and feasibility.
+
+---
+
+## High-Value Ideas — Recommended for Future Phases
+
+### 1. AI Manifest Metadata for Routing Context
+
+**PR #1222 concept:** Each module declares an `AiManifest` with `domain`, `keywords`, `dataCapabilities` (entity names, operations, searchable fields, relationships), and `contextDependencies`.
+
+**Why it matters:** The official spec's sub-agents are explicitly addressed by `agentId`. There is no discovery mechanism — the caller must already know which agent to use. As the number of agents grows, a metadata layer that helps route ambiguous user queries to the right agent becomes valuable.
+
+**Recommended adoption path:**
+- Add optional `keywords`, `domain`, and `dataCapabilities` fields to `AiAgentDefinition` as non-breaking metadata.
+- Use this metadata in a future "agent suggestion" feature where the Command Palette or a general assistant can recommend which focused agent to invoke.
+- This is strictly additive and does not conflict with the official spec's explicit-agent-selection model.
+
+**Priority:** Phase 4+ (after the official spec's Phase 3 proves the basic agent model works)
+
+---
+
+### 2. Page Context Resolver
+
+**PR #1222 concept:** Modules declare a `pageContextResolver` function in their manifest that loads record-level context when a user is on a specific page (e.g., viewing Quote #Q-2024-0847). This injects a `[CURRENT RECORD]` section into the system prompt.
+
+**Why it matters:** The official spec already accepts `pageContext` in `AiChatRequest` but treats it as "advisory context only." PR #1222's approach makes the module responsible for hydrating that context into rich, structured data the agent can act on immediately — rather than requiring an extra tool call to look up what the user is viewing.
+
+**Recommended adoption path:**
+- Add an optional `resolvePageContext` callback to `AiAgentDefinition`:
+  ```typescript
+  resolvePageContext?: (ctx: {
+    entityType: string
+    recordId: string
+    container: AwilixContainer
+    tenantId: string | null
+    organizationId: string | null
+  }) => Promise<string | null>
+  ```
+- When present, the agent runtime calls it before composing the system prompt, injecting the result as additional context.
+- This is additive and does not change the existing `pageContext` pass-through.
+
+**Priority:** Phase 3 or 4 (natural fit when building the first production agent)
+
+---
+
+### 3. Structured Prompt Composition with Named Sections
+
+**PR #1222 concept:** Instead of a single `systemPrompt` string, the system prompt is composed from named sections (`[ROLE]`, `[AUTH CONTEXT]`, `[ACTIVE MODULES]`, `[MODULE: X]`, `[GUIDELINES]`), with each module contributing a fragment.
+
+**Why it matters:** The official spec gives each agent a single `systemPrompt` field, which is fine for v1. But as agents gain richer context (page context, cross-module data, operational guidelines), a structured template prevents prompt drift and makes debugging easier — you can inspect which section contributed what.
+
+**Recommended adoption path:**
+- Not needed for v1 (single-agent, single-prompt model works).
+- When adding multi-agent orchestration or richer context injection in Phase 4+, adopt a prompt-builder utility that concatenates named sections rather than raw string concatenation.
+- The specific section structure from PR #1222 (`[ROLE]`, `[AUTH CONTEXT]`, `[ACTIVE MODULES]`, `[GUIDELINES]`) is a reasonable starting point.
+
+**Priority:** Phase 4+ (when prompt complexity warrants it)
+
+---
+
+### 4. Provider/Model Abstraction Layer (`resolveAndCreateAiModel`)
+
+**PR #1222 concept:** A shared `model-factory.ts` with `resolveAndCreateAiModel()` that dynamically imports the correct `@ai-sdk/*` package based on provider selection, with a priority chain: per-module env -> global env -> legacy env -> tier default.
+
+**Why it matters:** The official spec defers to "existing tenant settings and provider resolution" (Decision D6). PR #1222's model factory is a clean, testable utility that consolidates provider logic in one place. The per-module model override (`SALES_AI_MODEL`, `INBOX_OPS_AI_MODEL`) is particularly useful for cost optimization — cheap models for classification, powerful models for complex workflows.
+
+**Recommended adoption path:**
+- Extract the model factory pattern from the existing `inbox_ops/lib/llmProvider.ts` into a shared utility inside `@open-mercato/ai-assistant`.
+- Support the `defaultModel` override that `AiAgentDefinition` already declares, plus an optional env-based override per agent/module.
+- This consolidation should happen when the second agent is built (Phase 3+), to avoid premature abstraction.
+
+**Priority:** Phase 3 (when multiple agents need different models)
+
+---
+
+## Medium-Value Ideas — Worth Tracking
+
+### 5. Context Dependencies Between Modules
+
+**PR #1222 concept:** Modules declare `contextDependencies` — other modules whose tools/context should be co-activated when this module is active. For example, Sales declares dependencies on Customers and Catalog.
+
+**Why it matters:** The official spec's `allowedTools` whitelist is explicit and safe but requires the agent author to enumerate every tool by name. Context dependencies express a higher-level intent ("this agent needs CRM data") that could auto-resolve to the correct tools.
+
+**Recommended adoption path:**
+- Not needed for v1 (explicit whitelists are correct for safety).
+- Track as a future convenience layer that could auto-expand `allowedTools` based on declared module affinities.
+- The companion spec's `hardDependencies` / `softAffinities` distinction is worth preserving if this is adopted.
+
+**Priority:** Phase 4+ (convenience, not correctness)
+
+---
+
+### 6. Versioned Manifest Contract for External Modules
+
+**PR #1222's companion spec concept:** Treat module AI declarations as a versioned public contract with `manifestVersion`, `moduleVersion`, `platformRange`, `testedCoreRange`, `source` (app/package/ejected), and conflict detection.
+
+**Why it matters:** The official spec is designed for monorepo-first development. As the external module ecosystem grows (official modules in separate repos, standalone apps), the AI contract surface will need the same versioning and compatibility guarantees that the rest of the module system has.
+
+**Recommended adoption path:**
+- Not needed until external modules ship AI agents.
+- When that happens, add `manifestVersion` and `platformRange` to `AiAgentDefinition` following the existing official-module versioning patterns from SPEC-061/064/065.
+- The companion spec's control-plane/execution-plane split is over-engineered for current needs but the compatibility validation concept is sound.
+
+**Priority:** When external module AI capabilities become real (post-Phase 4)
+
+---
+
+### 7. Execution Budgets and Deadlines
+
+**PR #1222's companion spec concept:** Explicit operational budgets per turn: `maxSteps`, `maxModules`, `maxParallelToolCalls`, `overallDeadlineMs`, `perToolDeadlineMs`.
+
+**Why it matters:** The official spec has `readOnly` and `maxCallsPerTurn` on individual tools but no turn-level budget. As agents become more capable (especially mutation-capable agents in Phase 4), turn-level budgets prevent runaway tool loops and bound latency.
+
+**Recommended adoption path:**
+- Add optional `maxSteps` to `AiAgentDefinition` (the official spec's runtime already passes `maxSteps` to `streamText()`).
+- Defer `overallDeadlineMs` and parallel-call limits until there's evidence of runaway behavior.
+
+**Priority:** Phase 4 (mutation-capable agents need tighter controls)
+
+---
+
+## Low-Value / Not Recommended
+
+### 8. Retrieval-Based Module Router (Keyword + Vector)
+
+PR #1222's keyword-scoring router and vector-based routing upgrade are interesting but solve a different problem than the official spec. The official spec deliberately uses explicit agent selection (`?agent=module.agent`) rather than automatic routing. This is the right call for v1 — automatic routing adds complexity, ambiguity, and a whole category of "wrong agent selected" bugs. Not recommended unless the product shifts toward a single unified chat that must auto-select agents.
+
+### 9. Removing OpenCode in Favor of Native Vercel AI SDK Chat
+
+PR #1222 proposes phasing out OpenCode entirely. The official spec explicitly preserves OpenCode and the Command Palette as the general-purpose assistant. This coexistence strategy is safer and more pragmatic. Not recommended.
+
+### 10. Staged Routing with Mid-Turn Re-Routing
+
+The companion spec's staged activation planning with mid-turn re-routing is architecturally interesting but adds significant complexity for marginal benefit. The official spec's explicit agent selection avoids this entire problem space. Not recommended for the foreseeable future.
+
+### 11. Full Control-Plane / Execution-Plane Split
+
+The companion spec proposes a two-layer architecture with a manifest catalog, compatibility validator, capability index, and conflict detector. This is enterprise-grade infrastructure that would be premature for the current stage. The official spec's simpler generated-registry approach is correct until the external module ecosystem actually materializes at scale.
+
+---
+
+## Summary Table
+
+| # | Idea | Value | Effort | Recommended Phase |
+|---|------|-------|--------|-------------------|
+| 1 | AI manifest metadata for routing/discovery | High | Low | Phase 4+ |
+| 2 | Page context resolver | High | Medium | Phase 3-4 |
+| 3 | Structured prompt composition | High | Low | Phase 4+ |
+| 4 | Shared model factory with per-agent overrides | High | Medium | Phase 3 |
+| 5 | Context dependencies between modules | Medium | Medium | Phase 4+ |
+| 6 | Versioned manifest contract | Medium | High | Post-Phase 4 |
+| 7 | Execution budgets and deadlines | Medium | Low | Phase 4 |
+| 8 | Retrieval-based module router | Low | High | Not recommended |
+| 9 | Remove OpenCode | Low | High | Not recommended |
+| 10 | Staged mid-turn re-routing | Low | High | Not recommended |
+| 11 | Control-plane / execution-plane split | Low | Very High | Not recommended |
+
+## Acknowledgment
+
+Credit to @rchrzanwlc for the thorough research and spec drafting in PR #1222. Several ideas — particularly the page context resolver, structured prompt composition, and model factory patterns — are strong contributions that will inform future phases of the official AI tooling spec.
+
+## Changelog
+
+- 2026-04-13: Initial analysis extracted from PR #1222 against the official unified AI tooling spec.


### PR DESCRIPTION
## Summary

- Includes the original analysis of PR #1222's decentralized AI ideas against the official unified AI tooling spec
- Applies the high-value suggestions directly to the official spec (`2026-04-11-unified-ai-tooling-and-subagents.md`)
- Extends the spec so the next implementation phase is explicitly Vercel AI SDK-friendly, attachment-safe, and grounded in the real customers/catalog surfaces already present in the repo
- Adds a clearer 3-phase delivery plan plus separate ASCII mockup companion docs for screens and reusable components

## Changes to the official spec

- Added AI SDK-first adapter planning so Open Mercato agents can be consumed through chat transports and structured-output helper flows, not only a bespoke runtime
- Added `executionMode` and `output` planning to support object-style agents for bounded structured-output use cases
- Added an attachment-to-model bridge that reuses the existing attachments module and supports images, PDFs, text-like files, and safe binary fallbacks
- Verified the repo state in the spec: current tool loading gap, existing AI SDK adapter, attachment APIs, and the customers/catalog UI aggregates the tools must match
- Defined baseline general-purpose tool packs, including hybrid search and attachment helpers
- Added explicit customers and catalog tool coverage requirements so agents can reach the same data and operations the UI exposes
- Added baseline prompt blueprints for the general assistant, customers agents, and catalog agents
- Reworked the implementation plan into a clearer 3-phase delivery model: runtime/tools first, then playground/settings and first module agents, then production hardening
- Added companion docs:
  - `2026-04-11-unified-ai-tooling-and-subagents-screen-mockups.md`
  - `2026-04-11-unified-ai-tooling-and-subagents-component-mockups.md`
- Added planned backend playground and agent settings pages for testing, prompt overrides, tool toggles, and attachment policy visibility

## Credit

Ideas originally sourced from @rchrzanwlc's research in PR #1222, then expanded here with repo verification, Vercel AI SDK DX requirements, and implementation-facing mockups.
