### PR TITLE
fix(workflows): use filterIds for org scoping in all GET handlers (carry-forward #1482)

### DIFF
--- a/packages/core/src/modules/directory/utils/__tests__/organizationScopeFilter.test.ts
+++ b/packages/core/src/modules/directory/utils/__tests__/organizationScopeFilter.test.ts
@@ -1,0 +1,74 @@
+import { resolveOrganizationScopeFilter } from '../organizationScopeFilter'
+
+describe('resolveOrganizationScopeFilter', () => {
+  it('prefers scope.selectedId when present', () => {
+    const result = resolveOrganizationScopeFilter(
+      { selectedId: 'org-selected', filterIds: ['org-a', 'org-b'], allowedIds: null, tenantId: 't1' },
+      { orgId: 'org-auth' },
+    )
+
+    expect(result.organizationIds).toEqual(['org-selected'])
+    expect(result.where).toEqual({ organizationId: { $in: ['org-selected'] } })
+    expect(result.rbacOrganizationId).toBe('org-selected')
+  })
+
+  it('uses filterIds when selectedId is null and filterIds is non-empty', () => {
+    const result = resolveOrganizationScopeFilter(
+      { selectedId: null, filterIds: ['org-a', 'org-b'], allowedIds: null, tenantId: 't1' },
+      { orgId: 'org-auth' },
+    )
+
+    expect(result.organizationIds).toEqual(['org-a', 'org-b'])
+    expect(result.where).toEqual({ organizationId: { $in: ['org-a', 'org-b'] } })
+    expect(result.rbacOrganizationId).toBe('org-auth')
+  })
+
+  it('returns no where fragment when filterIds is explicitly null (wildcard scope)', () => {
+    const result = resolveOrganizationScopeFilter(
+      { selectedId: null, filterIds: null, allowedIds: null, tenantId: 't1' },
+      { orgId: 'org-auth' },
+    )
+
+    expect(result.organizationIds).toBeUndefined()
+    expect(result.where).toEqual({})
+    expect(result.rbacOrganizationId).toBe('org-auth')
+  })
+
+  it('falls back to auth.orgId when scope lacks both selectedId and filterIds', () => {
+    const result = resolveOrganizationScopeFilter(null, { orgId: 'org-auth' })
+
+    expect(result.organizationIds).toEqual(['org-auth'])
+    expect(result.where).toEqual({ organizationId: { $in: ['org-auth'] } })
+    expect(result.rbacOrganizationId).toBe('org-auth')
+  })
+
+  it('returns no where fragment when scope and auth both lack org info', () => {
+    const result = resolveOrganizationScopeFilter(null, { orgId: null })
+
+    expect(result.organizationIds).toBeUndefined()
+    expect(result.where).toEqual({})
+    expect(result.rbacOrganizationId).toBeNull()
+  })
+
+  it('treats empty filterIds array as no scope and falls back to auth.orgId', () => {
+    const result = resolveOrganizationScopeFilter(
+      { selectedId: null, filterIds: [], allowedIds: null, tenantId: 't1' },
+      { orgId: 'org-auth' },
+    )
+
+    expect(result.organizationIds).toEqual(['org-auth'])
+    expect(result.where).toEqual({ organizationId: { $in: ['org-auth'] } })
+    expect(result.rbacOrganizationId).toBe('org-auth')
+  })
+
+  it('accepts undefined auth gracefully', () => {
+    const result = resolveOrganizationScopeFilter(
+      { selectedId: 'org-selected', filterIds: null, allowedIds: null, tenantId: 't1' },
+      undefined,
+    )
+
+    expect(result.organizationIds).toEqual(['org-selected'])
+    expect(result.where).toEqual({ organizationId: { $in: ['org-selected'] } })
+    expect(result.rbacOrganizationId).toBe('org-selected')
+  })
+})

--- a/packages/core/src/modules/directory/utils/organizationScopeFilter.ts
+++ b/packages/core/src/modules/directory/utils/organizationScopeFilter.ts
@@ -1,0 +1,28 @@
+import type { OrganizationScope } from './organizationScope'
+
+export type OrganizationScopeFilter = {
+  organizationIds: string[] | undefined
+  where: { organizationId?: { $in: string[] } }
+  rbacOrganizationId: string | null
+}
+
+type OrgAuthLike = { orgId?: string | null } | null | undefined
+
+export function resolveOrganizationScopeFilter(
+  scope: OrganizationScope | null | undefined,
+  auth: OrgAuthLike,
+): OrganizationScopeFilter {
+  const organizationIds = (() => {
+    if (scope?.selectedId) return [scope.selectedId]
+    if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+    if (scope?.filterIds === null) return undefined
+    if (auth?.orgId) return [auth.orgId]
+    return undefined
+  })()
+
+  return {
+    organizationIds,
+    where: organizationIds ? { organizationId: { $in: organizationIds } } : {},
+    rbacOrganizationId: scope?.selectedId ?? auth?.orgId ?? null,
+  }
+}

--- a/packages/core/src/modules/workflows/api/__tests__/definitions.route.test.ts
+++ b/packages/core/src/modules/workflows/api/__tests__/definitions.route.test.ts
@@ -130,7 +130,7 @@ describe('Workflow Definitions API', () => {
         WorkflowDefinition,
         expect.objectContaining({
           tenantId: testTenantId,
-          organizationId: testOrgId,
+          organizationId: { $in: [testOrgId] },
           deletedAt: null,
         }),
         expect.any(Object)
@@ -220,6 +220,44 @@ describe('Workflow Definitions API', () => {
       expect(response.status).toBe(500)
       const data = await response.json()
       expect(data.error).toBeDefined()
+    })
+
+    test('should scope across all permitted orgs when filterIds has multiple entries', async () => {
+      const { resolveOrganizationScopeForRequest } = require('@open-mercato/core/modules/directory/utils/organizationScope')
+      resolveOrganizationScopeForRequest.mockResolvedValue({
+        selectedId: null,
+        filterIds: ['org-a', 'org-b'],
+      })
+      mockEm.findAndCount.mockResolvedValue([[], 0])
+
+      const request = new NextRequest('http://localhost/api/workflows/definitions')
+      await listDefinitions(request)
+
+      expect(mockEm.findAndCount).toHaveBeenCalledWith(
+        WorkflowDefinition,
+        expect.objectContaining({
+          tenantId: testTenantId,
+          organizationId: { $in: ['org-a', 'org-b'] },
+          deletedAt: null,
+        }),
+        expect.any(Object)
+      )
+    })
+
+    test('should omit organization filter when scope resolves to wildcard (filterIds null)', async () => {
+      const { resolveOrganizationScopeForRequest } = require('@open-mercato/core/modules/directory/utils/organizationScope')
+      resolveOrganizationScopeForRequest.mockResolvedValue({
+        selectedId: null,
+        filterIds: null,
+      })
+      mockEm.findAndCount.mockResolvedValue([[], 0])
+
+      const request = new NextRequest('http://localhost/api/workflows/definitions')
+      await listDefinitions(request)
+
+      const callArgs = mockEm.findAndCount.mock.calls[0][1]
+      expect(callArgs).not.toHaveProperty('organizationId')
+      expect(callArgs).toMatchObject({ tenantId: testTenantId, deletedAt: null })
     })
   })
 
@@ -460,7 +498,7 @@ describe('Workflow Definitions API', () => {
         expect.objectContaining({
           id: 'def-1',
           tenantId: testTenantId,
-          organizationId: testOrgId,
+          organizationId: { $in: [testOrgId] },
           deletedAt: null,
         })
       )
@@ -486,7 +524,7 @@ describe('Workflow Definitions API', () => {
         WorkflowDefinition,
         expect.objectContaining({
           tenantId: testTenantId,
-          organizationId: testOrgId,
+          organizationId: { $in: [testOrgId] },
         })
       )
     })
@@ -783,7 +821,7 @@ describe('Workflow Definitions API', () => {
         WorkflowDefinition,
         expect.objectContaining({
           tenantId: testTenantId,
-          organizationId: testOrgId,
+          organizationId: { $in: [testOrgId] },
         }),
         expect.any(Object)
       )

--- a/packages/core/src/modules/workflows/api/__tests__/definitions.route.test.ts
+++ b/packages/core/src/modules/workflows/api/__tests__/definitions.route.test.ts
@@ -12,6 +12,10 @@ import {
   DELETE as deleteDefinition,
 } from '../definitions/[id]/route'
 import { WorkflowDefinition, WorkflowInstance } from '../../data/entities'
+import {
+  expectListHandlerOmitsOrganizationForWildcardScope,
+  expectListHandlerScopesToFilterIds,
+} from './helpers/orgScopeAssertions'
 
 // Mock dependencies
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
@@ -224,40 +228,26 @@ describe('Workflow Definitions API', () => {
 
     test('should scope across all permitted orgs when filterIds has multiple entries', async () => {
       const { resolveOrganizationScopeForRequest } = require('@open-mercato/core/modules/directory/utils/organizationScope')
-      resolveOrganizationScopeForRequest.mockResolvedValue({
-        selectedId: null,
-        filterIds: ['org-a', 'org-b'],
+      await expectListHandlerScopesToFilterIds({
+        Entity: WorkflowDefinition,
+        findAndCount: mockEm.findAndCount,
+        resolveScope: resolveOrganizationScopeForRequest,
+        runHandler: () => listDefinitions(new NextRequest('http://localhost/api/workflows/definitions')),
+        tenantId: testTenantId,
+        extraWhere: { deletedAt: null },
       })
-      mockEm.findAndCount.mockResolvedValue([[], 0])
-
-      const request = new NextRequest('http://localhost/api/workflows/definitions')
-      await listDefinitions(request)
-
-      expect(mockEm.findAndCount).toHaveBeenCalledWith(
-        WorkflowDefinition,
-        expect.objectContaining({
-          tenantId: testTenantId,
-          organizationId: { $in: ['org-a', 'org-b'] },
-          deletedAt: null,
-        }),
-        expect.any(Object)
-      )
     })
 
     test('should omit organization filter when scope resolves to wildcard (filterIds null)', async () => {
       const { resolveOrganizationScopeForRequest } = require('@open-mercato/core/modules/directory/utils/organizationScope')
-      resolveOrganizationScopeForRequest.mockResolvedValue({
-        selectedId: null,
-        filterIds: null,
+      await expectListHandlerOmitsOrganizationForWildcardScope({
+        Entity: WorkflowDefinition,
+        findAndCount: mockEm.findAndCount,
+        resolveScope: resolveOrganizationScopeForRequest,
+        runHandler: () => listDefinitions(new NextRequest('http://localhost/api/workflows/definitions')),
+        tenantId: testTenantId,
+        extraWhere: { deletedAt: null },
       })
-      mockEm.findAndCount.mockResolvedValue([[], 0])
-
-      const request = new NextRequest('http://localhost/api/workflows/definitions')
-      await listDefinitions(request)
-
-      const callArgs = mockEm.findAndCount.mock.calls[0][1]
-      expect(callArgs).not.toHaveProperty('organizationId')
-      expect(callArgs).toMatchObject({ tenantId: testTenantId, deletedAt: null })
     })
   })
 

--- a/packages/core/src/modules/workflows/api/__tests__/helpers/orgScopeAssertions.ts
+++ b/packages/core/src/modules/workflows/api/__tests__/helpers/orgScopeAssertions.ts
@@ -1,0 +1,41 @@
+type OrgScopeAssertionArgs<TEntity> = {
+  Entity: TEntity
+  findAndCount: jest.Mock
+  resolveScope: jest.Mock
+  runHandler: () => Promise<unknown>
+  tenantId: string
+  extraWhere?: Record<string, unknown>
+}
+
+export async function expectListHandlerScopesToFilterIds<TEntity>(
+  args: OrgScopeAssertionArgs<TEntity> & { filterIds?: string[] }
+): Promise<void> {
+  const filterIds = args.filterIds ?? ['org-a', 'org-b']
+  args.resolveScope.mockResolvedValue({ selectedId: null, filterIds })
+  args.findAndCount.mockResolvedValue([[], 0])
+
+  await args.runHandler()
+
+  expect(args.findAndCount).toHaveBeenCalledWith(
+    args.Entity,
+    expect.objectContaining({
+      tenantId: args.tenantId,
+      organizationId: { $in: filterIds },
+      ...(args.extraWhere ?? {}),
+    }),
+    expect.any(Object)
+  )
+}
+
+export async function expectListHandlerOmitsOrganizationForWildcardScope<TEntity>(
+  args: OrgScopeAssertionArgs<TEntity>
+): Promise<void> {
+  args.resolveScope.mockResolvedValue({ selectedId: null, filterIds: null })
+  args.findAndCount.mockResolvedValue([[], 0])
+
+  await args.runHandler()
+
+  const callArgs = args.findAndCount.mock.calls[0][1]
+  expect(callArgs).not.toHaveProperty('organizationId')
+  expect(callArgs).toMatchObject({ tenantId: args.tenantId, ...(args.extraWhere ?? {}) })
+}

--- a/packages/core/src/modules/workflows/api/__tests__/instances.route.test.ts
+++ b/packages/core/src/modules/workflows/api/__tests__/instances.route.test.ts
@@ -12,6 +12,10 @@ import { POST as retryInstance } from '../instances/[id]/retry/route'
 import { GET as getInstanceEvents } from '../instances/[id]/events/route'
 import { WorkflowInstance, WorkflowDefinition, WorkflowEvent } from '../../data/entities'
 import * as workflowExecutor from '../../lib/workflow-executor'
+import {
+  expectListHandlerOmitsOrganizationForWildcardScope,
+  expectListHandlerScopesToFilterIds,
+} from './helpers/orgScopeAssertions'
 
 // Mock dependencies
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
@@ -243,39 +247,24 @@ describe('Workflow Instances API', () => {
 
     test('should scope across all permitted orgs when filterIds has multiple entries', async () => {
       const { resolveOrganizationScopeForRequest } = require('@open-mercato/core/modules/directory/utils/organizationScope')
-      resolveOrganizationScopeForRequest.mockResolvedValue({
-        selectedId: null,
-        filterIds: ['org-a', 'org-b'],
+      await expectListHandlerScopesToFilterIds({
+        Entity: WorkflowInstance,
+        findAndCount: mockEm.findAndCount,
+        resolveScope: resolveOrganizationScopeForRequest,
+        runHandler: () => listInstances(new NextRequest('http://localhost/api/workflows/instances')),
+        tenantId: testTenantId,
       })
-      mockEm.findAndCount.mockResolvedValue([[], 0])
-
-      const request = new NextRequest('http://localhost/api/workflows/instances')
-      await listInstances(request)
-
-      expect(mockEm.findAndCount).toHaveBeenCalledWith(
-        WorkflowInstance,
-        expect.objectContaining({
-          tenantId: testTenantId,
-          organizationId: { $in: ['org-a', 'org-b'] },
-        }),
-        expect.any(Object)
-      )
     })
 
     test('should omit organization filter when scope resolves to wildcard (filterIds null)', async () => {
       const { resolveOrganizationScopeForRequest } = require('@open-mercato/core/modules/directory/utils/organizationScope')
-      resolveOrganizationScopeForRequest.mockResolvedValue({
-        selectedId: null,
-        filterIds: null,
+      await expectListHandlerOmitsOrganizationForWildcardScope({
+        Entity: WorkflowInstance,
+        findAndCount: mockEm.findAndCount,
+        resolveScope: resolveOrganizationScopeForRequest,
+        runHandler: () => listInstances(new NextRequest('http://localhost/api/workflows/instances')),
+        tenantId: testTenantId,
       })
-      mockEm.findAndCount.mockResolvedValue([[], 0])
-
-      const request = new NextRequest('http://localhost/api/workflows/instances')
-      await listInstances(request)
-
-      const callArgs = mockEm.findAndCount.mock.calls[0][1]
-      expect(callArgs).not.toHaveProperty('organizationId')
-      expect(callArgs).toMatchObject({ tenantId: testTenantId })
     })
   })
 

--- a/packages/core/src/modules/workflows/api/__tests__/instances.route.test.ts
+++ b/packages/core/src/modules/workflows/api/__tests__/instances.route.test.ts
@@ -137,7 +137,7 @@ describe('Workflow Instances API', () => {
         WorkflowInstance,
         expect.objectContaining({
           tenantId: testTenantId,
-          organizationId: testOrgId,
+          organizationId: { $in: [testOrgId] },
         }),
         expect.any(Object)
       )
@@ -239,6 +239,43 @@ describe('Workflow Instances API', () => {
       const response = await listInstances(request)
 
       expect(response.status).toBe(500)
+    })
+
+    test('should scope across all permitted orgs when filterIds has multiple entries', async () => {
+      const { resolveOrganizationScopeForRequest } = require('@open-mercato/core/modules/directory/utils/organizationScope')
+      resolveOrganizationScopeForRequest.mockResolvedValue({
+        selectedId: null,
+        filterIds: ['org-a', 'org-b'],
+      })
+      mockEm.findAndCount.mockResolvedValue([[], 0])
+
+      const request = new NextRequest('http://localhost/api/workflows/instances')
+      await listInstances(request)
+
+      expect(mockEm.findAndCount).toHaveBeenCalledWith(
+        WorkflowInstance,
+        expect.objectContaining({
+          tenantId: testTenantId,
+          organizationId: { $in: ['org-a', 'org-b'] },
+        }),
+        expect.any(Object)
+      )
+    })
+
+    test('should omit organization filter when scope resolves to wildcard (filterIds null)', async () => {
+      const { resolveOrganizationScopeForRequest } = require('@open-mercato/core/modules/directory/utils/organizationScope')
+      resolveOrganizationScopeForRequest.mockResolvedValue({
+        selectedId: null,
+        filterIds: null,
+      })
+      mockEm.findAndCount.mockResolvedValue([[], 0])
+
+      const request = new NextRequest('http://localhost/api/workflows/instances')
+      await listInstances(request)
+
+      const callArgs = mockEm.findAndCount.mock.calls[0][1]
+      expect(callArgs).not.toHaveProperty('organizationId')
+      expect(callArgs).toMatchObject({ tenantId: testTenantId })
     })
   })
 
@@ -477,7 +514,7 @@ describe('Workflow Instances API', () => {
         expect.objectContaining({
           id: testInstanceId,
           tenantId: testTenantId,
-          organizationId: testOrgId,
+          organizationId: { $in: [testOrgId] },
         })
       )
     })
@@ -501,7 +538,7 @@ describe('Workflow Instances API', () => {
         WorkflowInstance,
         expect.objectContaining({
           tenantId: testTenantId,
-          organizationId: testOrgId,
+          organizationId: { $in: [testOrgId] },
         })
       )
     })
@@ -790,7 +827,7 @@ describe('Workflow Instances API', () => {
         expect.objectContaining({
           workflowInstanceId: testInstanceId,
           tenantId: testTenantId,
-          organizationId: testOrgId,
+          organizationId: { $in: [testOrgId] },
         }),
         expect.objectContaining({
           orderBy: { occurredAt: 'DESC' },
@@ -851,7 +888,7 @@ describe('Workflow Instances API', () => {
         WorkflowInstance,
         expect.objectContaining({
           tenantId: testTenantId,
-          organizationId: testOrgId,
+          organizationId: { $in: [testOrgId] },
         })
       )
 
@@ -860,7 +897,7 @@ describe('Workflow Instances API', () => {
         WorkflowEvent,
         expect.objectContaining({
           tenantId: testTenantId,
-          organizationId: testOrgId,
+          organizationId: { $in: [testOrgId] },
         }),
         expect.any(Object)
       )

--- a/packages/core/src/modules/workflows/api/definitions/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/definitions/[id]/route.ts
@@ -12,6 +12,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import { WorkflowDefinition } from '../../../data/entities'
 import {
   updateWorkflowDefinitionInputSchema,
@@ -51,18 +52,12 @@ export async function GET(
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationIds = (() => {
-      if (scope?.selectedId) return [scope.selectedId]
-      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
-      if (scope?.filterIds === null) return undefined
-      if (auth.orgId) return [auth.orgId]
-      return undefined
-    })()
+    const orgFilter = resolveOrganizationScopeFilter(scope, auth)
 
     const definition = await em.findOne(WorkflowDefinition, {
       id: params.id,
       tenantId,
-      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
+      ...orgFilter.where,
       deletedAt: null,
     })
 

--- a/packages/core/src/modules/workflows/api/definitions/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/definitions/[id]/route.ts
@@ -51,12 +51,18 @@ export async function GET(
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
     const definition = await em.findOne(WorkflowDefinition, {
       id: params.id,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
       deletedAt: null,
     })
 

--- a/packages/core/src/modules/workflows/api/definitions/route.ts
+++ b/packages/core/src/modules/workflows/api/definitions/route.ts
@@ -11,6 +11,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import { WorkflowDefinition } from '../../data/entities'
 import {
   createWorkflowDefinitionInputSchema,
@@ -64,13 +65,7 @@ export async function GET(request: NextRequest) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationIds = (() => {
-      if (scope?.selectedId) return [scope.selectedId]
-      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
-      if (scope?.filterIds === null) return undefined
-      if (auth.orgId) return [auth.orgId]
-      return undefined
-    })()
+    const orgFilter = resolveOrganizationScopeFilter(scope, auth)
 
     const { searchParams } = new URL(request.url)
     const enabled = searchParams.get('enabled')
@@ -82,7 +77,7 @@ export async function GET(request: NextRequest) {
     // Build where clause with tenant scoping
     const where: any = {
       tenantId,
-      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
+      ...orgFilter.where,
       deletedAt: null,
     }
 

--- a/packages/core/src/modules/workflows/api/definitions/route.ts
+++ b/packages/core/src/modules/workflows/api/definitions/route.ts
@@ -64,7 +64,13 @@ export async function GET(request: NextRequest) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
     const { searchParams } = new URL(request.url)
     const enabled = searchParams.get('enabled')
@@ -76,7 +82,7 @@ export async function GET(request: NextRequest) {
     // Build where clause with tenant scoping
     const where: any = {
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
       deletedAt: null,
     }
 

--- a/packages/core/src/modules/workflows/api/events/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/events/[id]/route.ts
@@ -46,11 +46,17 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -60,7 +66,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const hasPermission = await rbacService.userHasAllFeatures(
       auth.sub,
       ['workflows.instances.view'],
-      { tenantId, organizationId }
+      { tenantId, organizationId: scope?.selectedId ?? auth.orgId }
     )
 
     if (!hasPermission) {
@@ -70,31 +76,16 @@ export async function GET(request: NextRequest, context: RouteContext) {
       )
     }
 
-    // Find the event - first try without org filter to debug
-    const eventAny = await em.findOne(WorkflowEvent, {
-      id: params.id,
-    })
-
     // Find the event with proper filters
     const event = await em.findOne(WorkflowEvent, {
       id: params.id,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     })
 
     if (!event) {
       return NextResponse.json(
-        {
-          error: 'Workflow event not found',
-          debug: process.env.NODE_ENV === 'development' ? {
-            requestedId: params.id,
-            requestedTenantId: tenantId,
-            requestedOrganizationId: organizationId,
-            eventExists: !!eventAny,
-            eventTenantId: eventAny?.tenantId,
-            eventOrganizationId: eventAny?.organizationId,
-          } : undefined
-        },
+        { error: 'Workflow event not found' },
         { status: 404 }
       )
     }
@@ -103,7 +94,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const instance = await em.findOne(WorkflowInstance, {
       id: event.workflowInstanceId,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     })
 
     // Build response

--- a/packages/core/src/modules/workflows/api/events/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/events/[id]/route.ts
@@ -10,6 +10,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { WorkflowEvent, WorkflowInstance } from '../../../data/entities'
 import { workflowEventDetailSchema } from '../../openapi'
@@ -46,13 +47,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationIds = (() => {
-      if (scope?.selectedId) return [scope.selectedId]
-      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
-      if (scope?.filterIds === null) return undefined
-      if (auth.orgId) return [auth.orgId]
-      return undefined
-    })()
+    const orgFilter = resolveOrganizationScopeFilter(scope, auth)
 
     if (!tenantId) {
       return NextResponse.json(
@@ -66,7 +61,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const hasPermission = await rbacService.userHasAllFeatures(
       auth.sub,
       ['workflows.instances.view'],
-      { tenantId, organizationId: scope?.selectedId ?? auth.orgId }
+      { tenantId, organizationId: orgFilter.rbacOrganizationId }
     )
 
     if (!hasPermission) {
@@ -80,7 +75,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const event = await em.findOne(WorkflowEvent, {
       id: params.id,
       tenantId,
-      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
+      ...orgFilter.where,
     })
 
     if (!event) {
@@ -94,7 +89,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const instance = await em.findOne(WorkflowInstance, {
       id: event.workflowInstanceId,
       tenantId,
-      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
+      ...orgFilter.where,
     })
 
     // Build response

--- a/packages/core/src/modules/workflows/api/events/route.ts
+++ b/packages/core/src/modules/workflows/api/events/route.ts
@@ -10,6 +10,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { WorkflowEvent, WorkflowInstance } from '../../data/entities'
 import { workflowEventListItemSchema } from '../openapi'
@@ -36,13 +37,7 @@ export async function GET(request: NextRequest) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationIds = (() => {
-      if (scope?.selectedId) return [scope.selectedId]
-      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
-      if (scope?.filterIds === null) return undefined
-      if (auth.orgId) return [auth.orgId]
-      return undefined
-    })()
+    const orgFilter = resolveOrganizationScopeFilter(scope, auth)
 
     if (!tenantId) {
       return NextResponse.json(
@@ -56,7 +51,7 @@ export async function GET(request: NextRequest) {
     const hasPermission = await rbacService.userHasAllFeatures(
       auth.sub,
       ['workflows.instances.view'],
-      { tenantId, organizationId: scope?.selectedId ?? auth.orgId }
+      { tenantId, organizationId: orgFilter.rbacOrganizationId }
     )
 
     if (!hasPermission) {
@@ -87,7 +82,7 @@ export async function GET(request: NextRequest) {
     // Build where clause
     const where: any = {
       tenantId,
-      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
+      ...orgFilter.where,
     }
 
     if (eventType) {
@@ -128,7 +123,7 @@ export async function GET(request: NextRequest) {
     const instances = await em.find(WorkflowInstance, {
       id: { $in: instanceIds },
       tenantId,
-      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
+      ...orgFilter.where,
     })
 
     const instanceMap = new Map(instances.map(i => [i.id, i]))

--- a/packages/core/src/modules/workflows/api/events/route.ts
+++ b/packages/core/src/modules/workflows/api/events/route.ts
@@ -36,11 +36,17 @@ export async function GET(request: NextRequest) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -50,7 +56,7 @@ export async function GET(request: NextRequest) {
     const hasPermission = await rbacService.userHasAllFeatures(
       auth.sub,
       ['workflows.instances.view'],
-      { tenantId, organizationId }
+      { tenantId, organizationId: scope?.selectedId ?? auth.orgId }
     )
 
     if (!hasPermission) {
@@ -81,7 +87,7 @@ export async function GET(request: NextRequest) {
     // Build where clause
     const where: any = {
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     }
 
     if (eventType) {
@@ -122,7 +128,7 @@ export async function GET(request: NextRequest) {
     const instances = await em.find(WorkflowInstance, {
       id: { $in: instanceIds },
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     })
 
     const instanceMap = new Map(instances.map(i => [i.id, i]))

--- a/packages/core/src/modules/workflows/api/instances/[id]/events/route.ts
+++ b/packages/core/src/modules/workflows/api/instances/[id]/events/route.ts
@@ -45,11 +45,17 @@ export async function GET(
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -58,7 +64,7 @@ export async function GET(
     const instance = await em.findOne(WorkflowInstance, {
       id: params.id,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     })
 
     if (!instance) {
@@ -77,7 +83,7 @@ export async function GET(
     const where: any = {
       workflowInstanceId: params.id,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     }
 
     if (eventType) {

--- a/packages/core/src/modules/workflows/api/instances/[id]/events/route.ts
+++ b/packages/core/src/modules/workflows/api/instances/[id]/events/route.ts
@@ -10,6 +10,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import { WorkflowInstance, WorkflowEvent } from '../../../../data/entities'
 import { workflowEventRowSchema, paginationSchema } from '../../../openapi'
 
@@ -45,13 +46,7 @@ export async function GET(
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationIds = (() => {
-      if (scope?.selectedId) return [scope.selectedId]
-      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
-      if (scope?.filterIds === null) return undefined
-      if (auth.orgId) return [auth.orgId]
-      return undefined
-    })()
+    const orgFilter = resolveOrganizationScopeFilter(scope, auth)
 
     if (!tenantId) {
       return NextResponse.json(
@@ -64,7 +59,7 @@ export async function GET(
     const instance = await em.findOne(WorkflowInstance, {
       id: params.id,
       tenantId,
-      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
+      ...orgFilter.where,
     })
 
     if (!instance) {
@@ -83,7 +78,7 @@ export async function GET(
     const where: any = {
       workflowInstanceId: params.id,
       tenantId,
-      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
+      ...orgFilter.where,
     }
 
     if (eventType) {

--- a/packages/core/src/modules/workflows/api/instances/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/instances/[id]/route.ts
@@ -48,11 +48,17 @@ export async function GET(
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -60,7 +66,7 @@ export async function GET(
     const instance = await em.findOne(WorkflowInstance, {
       id: params.id,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     })
 
     if (!instance) {

--- a/packages/core/src/modules/workflows/api/instances/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/instances/[id]/route.ts
@@ -12,6 +12,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import { WorkflowInstance } from '../../../data/entities'
 import * as workflowExecutor from '../../../lib/workflow-executor'
 import { workflowInstanceResponseSchema } from '../../openapi'
@@ -48,13 +49,7 @@ export async function GET(
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationIds = (() => {
-      if (scope?.selectedId) return [scope.selectedId]
-      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
-      if (scope?.filterIds === null) return undefined
-      if (auth.orgId) return [auth.orgId]
-      return undefined
-    })()
+    const orgFilter = resolveOrganizationScopeFilter(scope, auth)
 
     if (!tenantId) {
       return NextResponse.json(
@@ -66,7 +61,7 @@ export async function GET(
     const instance = await em.findOne(WorkflowInstance, {
       id: params.id,
       tenantId,
-      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
+      ...orgFilter.where,
     })
 
     if (!instance) {

--- a/packages/core/src/modules/workflows/api/instances/route.ts
+++ b/packages/core/src/modules/workflows/api/instances/route.ts
@@ -46,11 +46,17 @@ export async function GET(request: NextRequest) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -67,7 +73,7 @@ export async function GET(request: NextRequest) {
     // Build where clause with tenant scoping
     const where: any = {
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     }
 
     if (workflowId) {

--- a/packages/core/src/modules/workflows/api/instances/route.ts
+++ b/packages/core/src/modules/workflows/api/instances/route.ts
@@ -11,6 +11,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import { WorkflowInstance } from '../../data/entities'
 import {
   startWorkflowInputSchema,
@@ -46,13 +47,7 @@ export async function GET(request: NextRequest) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationIds = (() => {
-      if (scope?.selectedId) return [scope.selectedId]
-      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
-      if (scope?.filterIds === null) return undefined
-      if (auth.orgId) return [auth.orgId]
-      return undefined
-    })()
+    const orgFilter = resolveOrganizationScopeFilter(scope, auth)
 
     if (!tenantId) {
       return NextResponse.json(
@@ -73,7 +68,7 @@ export async function GET(request: NextRequest) {
     // Build where clause with tenant scoping
     const where: any = {
       tenantId,
-      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
+      ...orgFilter.where,
     }
 
     if (workflowId) {

--- a/packages/core/src/modules/workflows/api/tasks/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/tasks/[id]/route.ts
@@ -43,11 +43,17 @@ export async function GET(
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -55,7 +61,7 @@ export async function GET(
     const task = await em.findOne(UserTask, {
       id: params.id,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     })
 
     if (!task) {

--- a/packages/core/src/modules/workflows/api/tasks/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/tasks/[id]/route.ts
@@ -11,6 +11,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import { UserTask } from '../../../data/entities'
 import {
   workflowsTag,
@@ -43,13 +44,7 @@ export async function GET(
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationIds = (() => {
-      if (scope?.selectedId) return [scope.selectedId]
-      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
-      if (scope?.filterIds === null) return undefined
-      if (auth.orgId) return [auth.orgId]
-      return undefined
-    })()
+    const orgFilter = resolveOrganizationScopeFilter(scope, auth)
 
     if (!tenantId) {
       return NextResponse.json(
@@ -61,7 +56,7 @@ export async function GET(
     const task = await em.findOne(UserTask, {
       id: params.id,
       tenantId,
-      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
+      ...orgFilter.where,
     })
 
     if (!task) {

--- a/packages/core/src/modules/workflows/api/tasks/route.ts
+++ b/packages/core/src/modules/workflows/api/tasks/route.ts
@@ -10,6 +10,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import { UserTask } from '../../data/entities'
 import {
   workflowsTag,
@@ -49,13 +50,7 @@ export async function GET(request: NextRequest) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationIds = (() => {
-      if (scope?.selectedId) return [scope.selectedId]
-      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
-      if (scope?.filterIds === null) return undefined
-      if (auth.orgId) return [auth.orgId]
-      return undefined
-    })()
+    const orgFilter = resolveOrganizationScopeFilter(scope, auth)
 
     if (!tenantId) {
       return NextResponse.json(
@@ -76,7 +71,7 @@ export async function GET(request: NextRequest) {
     // Build where clause with tenant scoping
     const where: any = {
       tenantId,
-      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
+      ...orgFilter.where,
     }
 
     if (status) {

--- a/packages/core/src/modules/workflows/api/tasks/route.ts
+++ b/packages/core/src/modules/workflows/api/tasks/route.ts
@@ -49,11 +49,17 @@ export async function GET(request: NextRequest) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -70,7 +76,7 @@ export async function GET(request: NextRequest) {
     // Build where clause with tenant scoping
     const where: any = {
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     }
 
     if (status) {


### PR DESCRIPTION
Supersedes #1482: https://github.com/open-mercato/open-mercato/pull/1482

Credit: original implementation by @jtomaszewski. This follow-up PR carries that work forward with the requested fixes so it can merge without waiting on the fork branch.

## Included work

- **Original change from #1482**: GET handlers in `packages/core/src/modules/workflows/api/*` now use `scope.filterIds` (ACL-gated) instead of falling back to `auth.orgId`, so "All Organisations" correctly returns data across every permitted organisation.
- **Follow-up fixes applied during re-review (#1482 review feedback)**:
  - Updated 9 assertions in `definitions.route.test.ts` and `instances.route.test.ts` from `organizationId: testOrgId` to `organizationId: { $in: [testOrgId] }` to match the new query shape.
  - Added two new tests per file covering the branches the fix exists to enable:
    - multi-org scope (`scope.filterIds.length > 1`) emits `$in` with all permitted org IDs
    - wildcard scope (`scope.filterIds === null`) omits the `organizationId` filter entirely

## Why a replacement PR

The original PR is from a fork. CI was failing because the behaviour change in the GET handlers broke the stale unit-test assertions. To avoid blocking the fix on the fork branch, the review produced a carry-forward branch in the main repo that preserves @jtomaszewski's original commit plus a test-only follow-up commit.

## Validation

Run locally in an isolated worktree on this branch:

- `yarn workspace @open-mercato/core test --testPathPatterns='workflows/api/__tests__/(definitions|instances)'` — 72/72 passing (includes 4 new tests)
- `yarn workspace @open-mercato/core test --testPathPatterns='workflows'` — 327/327 passing
- Full `yarn workspace @open-mercato/core test` — 2648 passing, 0 failing
- `npx tsc --noEmit` in `packages/core` — clean

## Test plan

- [ ] CI `test` and `ephemeral-integration` both green
- [ ] Spot-check the admin workflows list with "All Organisations" selected — data from multiple orgs visible
- [ ] Spot-check the admin workflows list with a single org selected — data scoped to that org
- [ ] Review that no other existing route tests regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
