### PR TITLE
fix(security): atomic token consumption to prevent race conditions

### DIFF
--- a/packages/core/src/modules/customer_accounts/__tests__/customerTokenService.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/customerTokenService.test.ts
@@ -1,0 +1,154 @@
+import { CustomerTokenService } from '../services/customerTokenService'
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/tokenGenerator', () => ({
+  generateSecureToken: () => 'raw-token',
+  hashToken: (t: string) => `hashed-${t}`,
+}))
+
+describe('CustomerTokenService – atomic token consumption', () => {
+  function createKnexChain(updateResult: number) {
+    const chain = {
+      where: jest.fn().mockReturnThis(),
+      whereNull: jest.fn().mockReturnThis(),
+      update: jest.fn().mockResolvedValue(updateResult),
+    }
+    return { chain, knexFn: jest.fn().mockReturnValue(chain) }
+  }
+
+  function createEm(overrides: {
+    findOneResult?: unknown
+    knexUpdateResult: number
+  }) {
+    const { chain, knexFn } = createKnexChain(overrides.knexUpdateResult)
+    const em = {
+      findOne: jest.fn().mockResolvedValue(overrides.findOneResult ?? null),
+      getKnex: jest.fn().mockReturnValue(knexFn),
+      flush: jest.fn(),
+    } as any
+    return { em, knexFn, chain }
+  }
+
+  describe('verifyEmailToken', () => {
+    const validRecord = {
+      id: 'ver-1',
+      token: 'hashed-abc',
+      purpose: 'email_verification',
+      usedAt: null,
+      expiresAt: new Date(Date.now() + 60000),
+      user: { id: 'user-1', tenantId: 'tenant-1' },
+    }
+
+    it('performs atomic UPDATE SET used_at WHERE used_at IS NULL', async () => {
+      const { em, knexFn, chain } = createEm({ findOneResult: validRecord, knexUpdateResult: 1 })
+      const service = new CustomerTokenService(em)
+
+      const result = await service.verifyEmailToken('abc', 'email_verification')
+
+      expect(knexFn).toHaveBeenCalledWith('customer_user_email_verifications')
+      expect(chain.where).toHaveBeenCalledWith('id', 'ver-1')
+      expect(chain.whereNull).toHaveBeenCalledWith('used_at')
+      expect(chain.where).toHaveBeenCalledWith('expires_at', '>', expect.any(Date))
+      expect(chain.update).toHaveBeenCalledWith({ used_at: expect.any(Date) })
+      expect(result).toEqual({ userId: 'user-1', tenantId: 'tenant-1' })
+    })
+
+    it('returns null when atomic UPDATE affects 0 rows (concurrent race)', async () => {
+      const { em } = createEm({ findOneResult: validRecord, knexUpdateResult: 0 })
+      const service = new CustomerTokenService(em)
+
+      const result = await service.verifyEmailToken('abc', 'email_verification')
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when token is already used (usedAt set)', async () => {
+      const usedRecord = { ...validRecord, usedAt: new Date() }
+      const { em } = createEm({ findOneResult: usedRecord, knexUpdateResult: 0 })
+      const service = new CustomerTokenService(em)
+
+      const result = await service.verifyEmailToken('abc', 'email_verification')
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when token is expired', async () => {
+      const expiredRecord = { ...validRecord, expiresAt: new Date(Date.now() - 60000) }
+      const { em } = createEm({ findOneResult: expiredRecord, knexUpdateResult: 0 })
+      const service = new CustomerTokenService(em)
+
+      const result = await service.verifyEmailToken('abc', 'email_verification')
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when token is not found', async () => {
+      const { em } = createEm({ findOneResult: null, knexUpdateResult: 0 })
+      const service = new CustomerTokenService(em)
+
+      const result = await service.verifyEmailToken('abc', 'email_verification')
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when tenant does not match', async () => {
+      const { em } = createEm({ findOneResult: validRecord, knexUpdateResult: 1 })
+      const service = new CustomerTokenService(em)
+
+      const result = await service.verifyEmailToken('abc', 'email_verification', 'other-tenant')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('verifyPasswordResetToken', () => {
+    const validRecord = {
+      id: 'rst-1',
+      token: 'hashed-xyz',
+      usedAt: null,
+      expiresAt: new Date(Date.now() + 60000),
+      user: { id: 'user-2', tenantId: 'tenant-2' },
+    }
+
+    it('performs atomic UPDATE SET used_at WHERE used_at IS NULL', async () => {
+      const { em, knexFn, chain } = createEm({ findOneResult: validRecord, knexUpdateResult: 1 })
+      const service = new CustomerTokenService(em)
+
+      const result = await service.verifyPasswordResetToken('xyz')
+
+      expect(knexFn).toHaveBeenCalledWith('customer_user_password_resets')
+      expect(chain.where).toHaveBeenCalledWith('id', 'rst-1')
+      expect(chain.whereNull).toHaveBeenCalledWith('used_at')
+      expect(chain.update).toHaveBeenCalledWith({ used_at: expect.any(Date) })
+      expect(result).toEqual({ userId: 'user-2', tenantId: 'tenant-2' })
+    })
+
+    it('returns null when atomic UPDATE affects 0 rows (concurrent race)', async () => {
+      const { em } = createEm({ findOneResult: validRecord, knexUpdateResult: 0 })
+      const service = new CustomerTokenService(em)
+
+      const result = await service.verifyPasswordResetToken('xyz')
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when token is already used', async () => {
+      const usedRecord = { ...validRecord, usedAt: new Date() }
+      const { em } = createEm({ findOneResult: usedRecord, knexUpdateResult: 0 })
+      const service = new CustomerTokenService(em)
+
+      const result = await service.verifyPasswordResetToken('xyz')
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when token is expired', async () => {
+      const expiredRecord = { ...validRecord, expiresAt: new Date(Date.now() - 60000) }
+      const { em } = createEm({ findOneResult: expiredRecord, knexUpdateResult: 0 })
+      const service = new CustomerTokenService(em)
+
+      const result = await service.verifyPasswordResetToken('xyz')
+
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/packages/core/src/modules/customer_accounts/services/customerTokenService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerTokenService.ts
@@ -70,8 +70,14 @@ export class CustomerTokenService {
     const user = record.user as CustomerUser
     if (tenantId && user?.tenantId !== tenantId) return null
 
-    record.usedAt = new Date()
-    await this.em.flush()
+    const knex = this.em.getKnex()
+    const consumed = await knex('customer_user_email_verifications')
+      .where('id', record.id)
+      .whereNull('used_at')
+      .where('expires_at', '>', new Date())
+      .update({ used_at: new Date() })
+    if (consumed === 0) return null
+
     const resolvedUserId = typeof user === 'string' ? user : user.id
     const resolvedTenantId = typeof user === 'string' ? '' : user.tenantId
     return { userId: resolvedUserId, tenantId: resolvedTenantId }
@@ -89,8 +95,14 @@ export class CustomerTokenService {
     const user = record.user as CustomerUser
     if (tenantId && user?.tenantId !== tenantId) return null
 
-    record.usedAt = new Date()
-    await this.em.flush()
+    const knex = this.em.getKnex()
+    const consumed = await knex('customer_user_password_resets')
+      .where('id', record.id)
+      .whereNull('used_at')
+      .where('expires_at', '>', new Date())
+      .update({ used_at: new Date() })
+    if (consumed === 0) return null
+
     const resolvedUserId = typeof user === 'string' ? user : user.id
     const resolvedTenantId = typeof user === 'string' ? '' : user.tenantId
     return { userId: resolvedUserId, tenantId: resolvedTenantId }

--- a/packages/core/src/modules/messages/commands/__tests__/tokens.test.ts
+++ b/packages/core/src/modules/messages/commands/__tests__/tokens.test.ts
@@ -19,7 +19,6 @@ jest.mock('../../events', () => ({
   emitMessagesEvent: jest.fn(async () => {}),
 }))
 
-// Import after mocks so registerCommand resolves to the mock above.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('../tokens')
 
@@ -29,6 +28,7 @@ if (!consumeCommand) {
 }
 
 type TokenRecord = {
+  id: string
   messageId: string
   recipientUserId: string
   token: string
@@ -37,7 +37,17 @@ type TokenRecord = {
   usedAt: Date | null
 }
 
-function buildCtx(tokenRecord: TokenRecord | null) {
+function createKnexChain(updateResult: number) {
+  const chain = {
+    where: jest.fn().mockReturnThis(),
+    update: jest.fn().mockResolvedValue(updateResult),
+  }
+  const knexFn = jest.fn().mockReturnValue(chain) as jest.Mock & { raw: jest.Mock }
+  knexFn.raw = jest.fn().mockReturnValue('use_count + 1')
+  return { chain, knexFn }
+}
+
+function buildCtx(tokenRecord: TokenRecord | null, knexUpdateResult = 1) {
   const message = {
     id: tokenRecord?.messageId ?? 'message-1',
     deletedAt: null,
@@ -48,23 +58,26 @@ function buildCtx(tokenRecord: TokenRecord | null) {
     status: 'unread' as 'unread' | 'read',
     readAt: null as Date | null,
   }
+  const { chain, knexFn } = createKnexChain(knexUpdateResult)
 
-  const em: Partial<EntityManager> & { findOne: jest.Mock; flush: jest.Mock } = {
+  const findOneResults: (unknown | null)[] = []
+  let findOneCallIndex = 0
+
+  const em: Partial<EntityManager> & { findOne: jest.Mock; flush: jest.Mock; getKnex: jest.Mock; clear: jest.Mock } = {
     findOne: jest.fn(async (cls: unknown, where: Record<string, unknown>) => {
       if (cls === MessageAccessToken) {
         if (!tokenRecord) return null
         if (where.token === tokenRecord.token) return tokenRecord
+        if (where.id === tokenRecord.id) return tokenRecord
         return null
       }
-      if (cls === Message) {
-        return message
-      }
-      if (cls === MessageRecipient) {
-        return recipient
-      }
+      if (cls === Message) return message
+      if (cls === MessageRecipient) return recipient
       return null
     }) as unknown as jest.Mock,
     flush: jest.fn(async () => {}),
+    getKnex: jest.fn().mockReturnValue(knexFn),
+    clear: jest.fn(),
   }
 
   const container = {
@@ -73,54 +86,130 @@ function buildCtx(tokenRecord: TokenRecord | null) {
       return { fork: () => em }
     },
   }
-  return { ctx: { container }, em, tokenRecord }
+  return { ctx: { container }, em, knexFn, chain }
 }
 
 describe('messages.tokens.consume command', () => {
   beforeEach(() => jest.clearAllMocks())
 
-  it('looks up the access token by HMAC hash of the raw request token', async () => {
-    const rawToken = 'raw-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-    const stored: TokenRecord = {
-      messageId: 'message-1',
-      recipientUserId: 'user-1',
-      token: hashAuthToken(rawToken),
-      expiresAt: new Date(Date.now() + 60_000),
-      useCount: 0,
-      usedAt: null,
-    }
-    const { ctx, em } = buildCtx(stored)
+  describe('hashed token lookup', () => {
+    it('looks up the access token by HMAC hash of the raw request token', async () => {
+      const rawToken = 'raw-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      const stored: TokenRecord = {
+        id: 'tok-1',
+        messageId: 'message-1',
+        recipientUserId: 'user-1',
+        token: hashAuthToken(rawToken),
+        expiresAt: new Date(Date.now() + 60_000),
+        useCount: 0,
+        usedAt: null,
+      }
+      const { ctx, em } = buildCtx(stored)
 
-    const result = await consumeCommand.execute({ token: rawToken }, ctx)
+      const result = await consumeCommand.execute({ token: rawToken }, ctx)
 
-    expect(result).toEqual({ messageId: 'message-1', recipientUserId: 'user-1' })
-    expect(em.findOne).toHaveBeenCalledWith(MessageAccessToken, { token: stored.token })
+      expect(result).toEqual({ messageId: 'message-1', recipientUserId: 'user-1' })
+      expect(em.findOne).toHaveBeenCalledWith(MessageAccessToken, { token: stored.token })
+    })
+
+    it('falls back to raw-token lookup for tokens written before hashing rollout', async () => {
+      const legacyRawToken = 'legacy-raw-token-3333333333333333333333333333333333333333333333333333'
+      const stored: TokenRecord = {
+        id: 'tok-1',
+        messageId: 'message-1',
+        recipientUserId: 'user-1',
+        token: legacyRawToken,
+        expiresAt: new Date(Date.now() + 60_000),
+        useCount: 0,
+        usedAt: null,
+      }
+      const { ctx, em } = buildCtx(stored)
+
+      const result = await consumeCommand.execute({ token: legacyRawToken }, ctx)
+
+      expect(result).toEqual({ messageId: 'message-1', recipientUserId: 'user-1' })
+      expect(em.findOne).toHaveBeenNthCalledWith(1, MessageAccessToken, { token: hashAuthToken(legacyRawToken) })
+      expect(em.findOne).toHaveBeenNthCalledWith(2, MessageAccessToken, { token: legacyRawToken })
+    })
+
+    it('throws when neither hashed nor raw lookup matches', async () => {
+      const { ctx } = buildCtx(null)
+
+      await expect(consumeCommand.execute({ token: 'unknown' }, ctx)).rejects.toThrow(
+        /Invalid or expired link/,
+      )
+    })
   })
 
-  it('falls back to raw-token lookup for tokens written before hashing rollout', async () => {
-    const legacyRawToken = 'legacy-raw-token-3333333333333333333333333333333333333333333333333333'
-    const stored: TokenRecord = {
-      messageId: 'message-1',
-      recipientUserId: 'user-1',
-      token: legacyRawToken,
-      expiresAt: new Date(Date.now() + 60_000),
-      useCount: 0,
-      usedAt: null,
-    }
-    const { ctx, em } = buildCtx(stored)
+  describe('atomic token consumption', () => {
+    it('performs an atomic conditional UPDATE instead of load-check-increment', async () => {
+      const stored: TokenRecord = {
+        id: 'tok-1',
+        messageId: 'msg-1',
+        recipientUserId: 'user-1',
+        token: hashAuthToken('valid-token'),
+        expiresAt: new Date(Date.now() + 60000),
+        useCount: 0,
+        usedAt: null,
+      }
+      const { ctx, knexFn, chain } = buildCtx(stored, 1)
 
-    const result = await consumeCommand.execute({ token: legacyRawToken }, ctx)
+      const result = await consumeCommand.execute({ token: 'valid-token' }, ctx)
 
-    expect(result).toEqual({ messageId: 'message-1', recipientUserId: 'user-1' })
-    expect(em.findOne).toHaveBeenNthCalledWith(1, MessageAccessToken, { token: hashAuthToken(legacyRawToken) })
-    expect(em.findOne).toHaveBeenNthCalledWith(2, MessageAccessToken, { token: legacyRawToken })
-  })
+      expect(knexFn).toHaveBeenCalledWith('message_access_tokens')
+      expect(chain.where).toHaveBeenCalledWith('id', 'tok-1')
+      expect(chain.where).toHaveBeenCalledWith('use_count', '<', 25)
+      expect(chain.where).toHaveBeenCalledWith('expires_at', '>', expect.any(Date))
+      expect(chain.update).toHaveBeenCalledWith({
+        use_count: 'use_count + 1',
+        used_at: expect.any(Date),
+      })
+      expect(result).toEqual({ messageId: 'msg-1', recipientUserId: 'user-1' })
+    })
 
-  it('throws when neither hashed nor raw lookup matches', async () => {
-    const { ctx } = buildCtx(null)
+    it('throws "This link has expired" when atomic UPDATE fails and token is expired', async () => {
+      const stored: TokenRecord = {
+        id: 'tok-1',
+        messageId: 'msg-1',
+        recipientUserId: 'user-1',
+        token: hashAuthToken('expired-token'),
+        expiresAt: new Date(Date.now() - 60000),
+        useCount: 0,
+        usedAt: null,
+      }
+      const { ctx } = buildCtx(stored, 0)
 
-    await expect(consumeCommand.execute({ token: 'unknown' }, ctx)).rejects.toThrow(
-      /Invalid or expired link/,
-    )
+      await expect(consumeCommand.execute({ token: 'expired-token' }, ctx)).rejects.toThrow('This link has expired')
+    })
+
+    it('throws "This link can no longer be used" when atomic UPDATE fails due to use count', async () => {
+      const stored: TokenRecord = {
+        id: 'tok-1',
+        messageId: 'msg-1',
+        recipientUserId: 'user-1',
+        token: hashAuthToken('maxed-token'),
+        expiresAt: new Date(Date.now() + 60000),
+        useCount: 25,
+        usedAt: null,
+      }
+      const { ctx } = buildCtx(stored, 0)
+
+      await expect(consumeCommand.execute({ token: 'maxed-token' }, ctx)).rejects.toThrow('This link can no longer be used')
+    })
+
+    it('rejects concurrent replay — second caller gets 0 affected rows', async () => {
+      const stored: TokenRecord = {
+        id: 'tok-1',
+        messageId: 'msg-1',
+        recipientUserId: 'user-1',
+        token: hashAuthToken('race-token'),
+        expiresAt: new Date(Date.now() + 60000),
+        useCount: 24,
+        usedAt: null,
+      }
+      const { ctx } = buildCtx(stored, 0)
+
+      await expect(consumeCommand.execute({ token: 'race-token' }, ctx)).rejects.toThrow('This link can no longer be used')
+    })
   })
 })

--- a/packages/core/src/modules/messages/commands/tokens.ts
+++ b/packages/core/src/modules/messages/commands/tokens.ts
@@ -4,14 +4,13 @@ import { registerCommand, type CommandHandler } from '@open-mercato/shared/lib/c
 import { Message, MessageAccessToken, MessageRecipient } from '../data/entities'
 import { emitMessagesEvent } from '../events'
 import { hashAuthToken } from '../../auth/lib/tokenHash'
+import { MAX_TOKEN_USE_COUNT, consumeMessageAccessToken } from '../lib/tokenConsumption'
 
-export const MAX_TOKEN_USE_COUNT = 25
+export { MAX_TOKEN_USE_COUNT }
 
 const consumeTokenSchema = z.object({
   token: z.string().min(1),
 })
-
-type ConsumeTokenInput = z.infer<typeof consumeTokenSchema>
 
 const consumeTokenCommand: CommandHandler<unknown, { messageId: string; recipientUserId: string }> = {
   id: 'messages.tokens.consume',
@@ -27,22 +26,9 @@ const consumeTokenCommand: CommandHandler<unknown, { messageId: string; recipien
       throw new Error('Invalid or expired link')
     }
 
-    const knex = em.getKnex()
-    const now = new Date()
-    const consumed = await knex('message_access_tokens')
-      .where('id', accessToken.id)
-      .where('use_count', '<', MAX_TOKEN_USE_COUNT)
-      .where('expires_at', '>', now)
-      .update({
-        use_count: knex.raw('use_count + 1'),
-        used_at: now,
-      })
-    if (consumed === 0) {
-      em.clear()
-      const fresh = await em.findOne(MessageAccessToken, { id: accessToken.id })
-      if (fresh && fresh.expiresAt < now) {
-        throw new Error('This link has expired')
-      }
+    const result = await consumeMessageAccessToken(em, accessToken.id)
+    if (!result.ok) {
+      if (result.reason === 'expired') throw new Error('This link has expired')
       throw new Error('This link can no longer be used')
     }
     em.clear()

--- a/packages/core/src/modules/messages/commands/tokens.ts
+++ b/packages/core/src/modules/messages/commands/tokens.ts
@@ -26,12 +26,26 @@ const consumeTokenCommand: CommandHandler<unknown, { messageId: string; recipien
     if (!accessToken) {
       throw new Error('Invalid or expired link')
     }
-    if (accessToken.expiresAt < new Date()) {
-      throw new Error('This link has expired')
-    }
-    if (accessToken.useCount >= MAX_TOKEN_USE_COUNT) {
+
+    const knex = em.getKnex()
+    const now = new Date()
+    const consumed = await knex('message_access_tokens')
+      .where('id', accessToken.id)
+      .where('use_count', '<', MAX_TOKEN_USE_COUNT)
+      .where('expires_at', '>', now)
+      .update({
+        use_count: knex.raw('use_count + 1'),
+        used_at: now,
+      })
+    if (consumed === 0) {
+      em.clear()
+      const fresh = await em.findOne(MessageAccessToken, { id: accessToken.id })
+      if (fresh && fresh.expiresAt < now) {
+        throw new Error('This link has expired')
+      }
       throw new Error('This link can no longer be used')
     }
+    em.clear()
 
     const message = await em.findOne(Message, {
       id: accessToken.messageId,
@@ -50,8 +64,6 @@ const consumeTokenCommand: CommandHandler<unknown, { messageId: string; recipien
       throw new Error('Invalid or expired link')
     }
 
-    accessToken.usedAt = new Date()
-    accessToken.useCount += 1
     let becameRead = false
     if (recipient.status === 'unread') {
       recipient.status = 'read'

--- a/packages/core/src/modules/messages/lib/__tests__/tokenConsumption.test.ts
+++ b/packages/core/src/modules/messages/lib/__tests__/tokenConsumption.test.ts
@@ -1,0 +1,79 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { MessageAccessToken } from '../../data/entities'
+import { MAX_TOKEN_USE_COUNT, consumeMessageAccessToken } from '../tokenConsumption'
+
+function createKnexChain(updateResult: number) {
+  const chain = {
+    where: jest.fn().mockReturnThis(),
+    update: jest.fn().mockResolvedValue(updateResult),
+  }
+  const knexFn = jest.fn().mockReturnValue(chain) as jest.Mock & { raw: jest.Mock }
+  knexFn.raw = jest.fn().mockReturnValue('use_count + 1')
+  return { chain, knexFn }
+}
+
+function buildEm(options: {
+  updateResult: number
+  fresh?: { id: string; expiresAt: Date } | null
+}): { em: EntityManager; chain: ReturnType<typeof createKnexChain>['chain']; knexFn: jest.Mock } {
+  const { chain, knexFn } = createKnexChain(options.updateResult)
+  const em = {
+    getKnex: jest.fn().mockReturnValue(knexFn),
+    clear: jest.fn(),
+    findOne: jest.fn(async (cls: unknown) => {
+      if (cls === MessageAccessToken) return options.fresh ?? null
+      return null
+    }),
+  } as unknown as EntityManager
+  return { em, chain, knexFn }
+}
+
+describe('consumeMessageAccessToken', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns ok when the atomic UPDATE affects one row', async () => {
+    const { em, chain, knexFn } = buildEm({ updateResult: 1 })
+
+    const result = await consumeMessageAccessToken(em, 'tok-1')
+
+    expect(result).toEqual({ ok: true })
+    expect(knexFn).toHaveBeenCalledWith('message_access_tokens')
+    expect(chain.where).toHaveBeenCalledWith('id', 'tok-1')
+    expect(chain.where).toHaveBeenCalledWith('use_count', '<', MAX_TOKEN_USE_COUNT)
+    expect(chain.where).toHaveBeenCalledWith('expires_at', '>', expect.any(Date))
+    expect(chain.update).toHaveBeenCalledWith({
+      use_count: 'use_count + 1',
+      used_at: expect.any(Date),
+    })
+  })
+
+  it('returns expired when the UPDATE affects zero rows and the token is past expiry', async () => {
+    const { em } = buildEm({
+      updateResult: 0,
+      fresh: { id: 'tok-1', expiresAt: new Date(Date.now() - 60_000) },
+    })
+
+    const result = await consumeMessageAccessToken(em, 'tok-1')
+
+    expect(result).toEqual({ ok: false, reason: 'expired' })
+  })
+
+  it('returns exhausted when the UPDATE affects zero rows but the token has not expired', async () => {
+    const { em } = buildEm({
+      updateResult: 0,
+      fresh: { id: 'tok-1', expiresAt: new Date(Date.now() + 60_000) },
+    })
+
+    const result = await consumeMessageAccessToken(em, 'tok-1')
+
+    expect(result).toEqual({ ok: false, reason: 'exhausted' })
+  })
+
+  it('returns not_found when the UPDATE affects zero rows and the token is gone', async () => {
+    const { em } = buildEm({ updateResult: 0, fresh: null })
+
+    const result = await consumeMessageAccessToken(em, 'tok-1')
+
+    expect(result).toEqual({ ok: false, reason: 'not_found' })
+  })
+})

--- a/packages/core/src/modules/messages/lib/tokenConsumption.ts
+++ b/packages/core/src/modules/messages/lib/tokenConsumption.ts
@@ -1,0 +1,33 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { MessageAccessToken } from '../data/entities'
+
+export const MAX_TOKEN_USE_COUNT = 25
+
+export type TokenConsumptionFailureReason = 'expired' | 'exhausted' | 'not_found'
+
+export type TokenConsumptionResult =
+  | { ok: true }
+  | { ok: false; reason: TokenConsumptionFailureReason }
+
+export async function consumeMessageAccessToken(
+  em: EntityManager,
+  tokenId: string,
+): Promise<TokenConsumptionResult> {
+  const knex = em.getKnex()
+  const now = new Date()
+  const consumed = await knex('message_access_tokens')
+    .where('id', tokenId)
+    .where('use_count', '<', MAX_TOKEN_USE_COUNT)
+    .where('expires_at', '>', now)
+    .update({
+      use_count: knex.raw('use_count + 1'),
+      used_at: now,
+    })
+  if (consumed > 0) return { ok: true }
+
+  em.clear()
+  const fresh = await em.findOne(MessageAccessToken, { id: tokenId })
+  if (!fresh) return { ok: false, reason: 'not_found' }
+  if (fresh.expiresAt < now) return { ok: false, reason: 'expired' }
+  return { ok: false, reason: 'exhausted' }
+}


### PR DESCRIPTION
Fixes #1423

## Problem

Single-use tokens use a load-check-increment-flush pattern without atomic guards, allowing concurrent requests to pass validation before either commits — enabling token replay under concurrency.

## Root Cause

- **Message access tokens** (`messages/commands/tokens.ts`): reads `useCount`, checks it in memory, increments, then flushes — no atomicity.
- **Customer portal tokens** (`customer_accounts/services/customerTokenService.ts`): email verification and password reset flows load `usedAt`, check it, set it, then flush — same race window.

## What Changed

- **Message access tokens**: replaced in-memory `useCount` check-and-increment with an atomic `UPDATE ... SET use_count = use_count + 1 WHERE use_count < 25 AND expires_at > now()`, verifying affected row count before proceeding. On failure, re-fetches to distinguish expired vs exhausted for the correct error message.
- **Customer portal tokens** (email verification + password reset): replaced ORM-level `usedAt` set-and-flush with an atomic `UPDATE ... SET used_at = now() WHERE used_at IS NULL AND expires_at > now()`, returning null on race loss.

## Tests

- `messages/commands/__tests__/tokens.test.ts` — 7 tests covering hashed lookup (from #1486), atomic UPDATE success, expiry detection, use-count exhaustion, and concurrent replay rejection.
- `customer_accounts/__tests__/customerTokenService.test.ts` — 10 tests covering atomic email verification and password reset token consumption, race conditions, expiry, and tenant isolation.

## Backward Compatibility

- No contract surface changes. The atomic UPDATE is an internal implementation detail — external API behavior and error messages remain identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)