### PR TITLE
fix(events): remove SSE abort listeners on cleanup (#1422)

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/portal/events/__tests__/stream.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/events/__tests__/stream.test.ts
@@ -1,0 +1,64 @@
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuth', () => ({
+  getCustomerAuthFromRequest: jest.fn(async () => ({
+    tenantId: 't1',
+    orgId: 'o1',
+    sub: 'c1',
+  })),
+}))
+
+import { GET } from '@open-mercato/core/modules/customer_accounts/api/portal/events/stream'
+
+function makeTrackedRequest() {
+  const controller = new AbortController()
+  const req = new Request('http://localhost/api/portal/events/stream', { signal: controller.signal })
+  const addSpy = jest.spyOn(req.signal, 'addEventListener')
+  const removeSpy = jest.spyOn(req.signal, 'removeEventListener')
+  return { req, controller, addSpy, removeSpy }
+}
+
+describe('Portal SSE event stream — abort listener hygiene', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('registers the abort listener with { once: true }', async () => {
+    const { req, addSpy } = makeTrackedRequest()
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+
+    const abortCalls = addSpy.mock.calls.filter((call) => call[0] === 'abort')
+    expect(abortCalls).toHaveLength(1)
+    expect(abortCalls[0][2]).toMatchObject({ once: true })
+
+    try { await (res.body as ReadableStream).cancel() } catch {}
+  })
+
+  it('detaches the abort listener when the stream is cancelled', async () => {
+    const { req, addSpy, removeSpy } = makeTrackedRequest()
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+
+    const attachedListener = addSpy.mock.calls.find((call) => call[0] === 'abort')![1]
+
+    await (res.body as ReadableStream).cancel()
+
+    const abortRemove = removeSpy.mock.calls.find((call) => call[0] === 'abort' && call[1] === attachedListener)
+    expect(abortRemove).toBeDefined()
+  })
+
+  it('detaches the abort listener when the request aborts', async () => {
+    const { req, controller, addSpy, removeSpy } = makeTrackedRequest()
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+
+    const attachedListener = addSpy.mock.calls.find((call) => call[0] === 'abort')![1]
+
+    controller.abort()
+    await new Promise((resolve) => setImmediate(resolve))
+
+    const abortRemove = removeSpy.mock.calls.find((call) => call[0] === 'abort' && call[1] === attachedListener)
+    expect(abortRemove).toBeDefined()
+
+    try { await (res.body as ReadableStream).cancel() } catch {}
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/portal/events/stream.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/events/stream.ts
@@ -135,6 +135,7 @@ export async function GET(req: Request): Promise<Response> {
   const encoder = new TextEncoder()
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null
   let connection: PortalSseConnection | null = null
+  const onAbort = () => cleanup()
 
   const stream = new ReadableStream({
     start(controller) {
@@ -173,9 +174,12 @@ export async function GET(req: Request): Promise<Response> {
       portalConnections.delete(connection)
       connection = null
     }
+    // Detach from the request signal so reconnect churn does not accumulate
+    // listeners and closures on long-lived AbortSignals.
+    req.signal.removeEventListener('abort', onAbort)
   }
 
-  req.signal.addEventListener('abort', cleanup)
+  req.signal.addEventListener('abort', onAbort, { once: true })
 
   return new Response(stream, {
     status: 200,

--- a/packages/events/src/modules/events/api/stream/__tests__/route.test.ts
+++ b/packages/events/src/modules/events/api/stream/__tests__/route.test.ts
@@ -1,0 +1,93 @@
+jest.mock('@open-mercato/shared/lib/api/context', () => ({
+  resolveRequestContext: jest.fn(async () => ({
+    ctx: {
+      auth: { tenantId: 't1', sub: 'u1', orgId: 'o1', roles: ['admin'] },
+      selectedOrganizationId: 'o1',
+    },
+    container: {},
+  })),
+}))
+
+jest.mock('../../../../../bus', () => ({
+  registerGlobalEventTap: jest.fn(),
+  registerCrossProcessEventListener: jest.fn(),
+}))
+
+import { GET } from '@open-mercato/events/modules/events/api/stream/route'
+
+// req.signal is a linked/derived signal in Node, so we spy AFTER the
+// Request is constructed to intercept the handler's real calls.
+function makeTrackedRequest() {
+  const controller = new AbortController()
+  const req = new Request('http://localhost/api/events/stream', { signal: controller.signal })
+  const addSpy = jest.spyOn(req.signal, 'addEventListener')
+  const removeSpy = jest.spyOn(req.signal, 'removeEventListener')
+  return { req, controller, addSpy, removeSpy }
+}
+
+describe('SSE event stream — abort listener hygiene', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('registers the abort listener with { once: true }', async () => {
+    const { req, addSpy } = makeTrackedRequest()
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+
+    const abortCalls = addSpy.mock.calls.filter((call) => call[0] === 'abort')
+    expect(abortCalls).toHaveLength(1)
+    expect(abortCalls[0][2]).toMatchObject({ once: true })
+
+    try { await (res.body as ReadableStream).cancel() } catch {}
+  })
+
+  it('detaches the abort listener when the stream is cancelled', async () => {
+    const { req, addSpy, removeSpy } = makeTrackedRequest()
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+
+    const abortAdd = addSpy.mock.calls.find((call) => call[0] === 'abort')
+    const attachedListener = abortAdd![1]
+
+    await (res.body as ReadableStream).cancel()
+
+    const abortRemove = removeSpy.mock.calls.find((call) => call[0] === 'abort' && call[1] === attachedListener)
+    expect(abortRemove).toBeDefined()
+  })
+
+  it('detaches the abort listener when the request aborts', async () => {
+    const { req, controller, addSpy, removeSpy } = makeTrackedRequest()
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+
+    const attachedListener = addSpy.mock.calls.find((call) => call[0] === 'abort')![1]
+
+    controller.abort()
+    await new Promise((resolve) => setImmediate(resolve))
+
+    const abortRemove = removeSpy.mock.calls.find((call) => call[0] === 'abort' && call[1] === attachedListener)
+    expect(abortRemove).toBeDefined()
+
+    try { await (res.body as ReadableStream).cancel() } catch {}
+  })
+
+  it('does not retain listeners across many reconnects', async () => {
+    for (let i = 0; i < 20; i += 1) {
+      const { req, controller, addSpy, removeSpy } = makeTrackedRequest()
+      const res = await GET(req)
+      expect(res.status).toBe(200)
+
+      const attachedListener = addSpy.mock.calls.find((call) => call[0] === 'abort')![1]
+
+      controller.abort()
+      await new Promise((resolve) => setImmediate(resolve))
+
+      const abortRemove = removeSpy.mock.calls.find((call) => call[0] === 'abort' && call[1] === attachedListener)
+      expect(abortRemove).toBeDefined()
+
+      try { await (res.body as ReadableStream).cancel() } catch {}
+      jest.restoreAllMocks()
+    }
+  })
+})

--- a/packages/events/src/modules/events/api/stream/route.ts
+++ b/packages/events/src/modules/events/api/stream/route.ts
@@ -209,6 +209,7 @@ export async function GET(req: Request): Promise<Response> {
   const encoder = new TextEncoder()
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null
   let connection: SseConnection | null = null
+  const onAbort = () => cleanup()
 
   const stream = new ReadableStream({
     start(controller) {
@@ -249,10 +250,12 @@ export async function GET(req: Request): Promise<Response> {
       connections.delete(connection)
       connection = null
     }
+    // Detach from the request signal so reconnect churn does not accumulate
+    // listeners and closures on long-lived AbortSignals.
+    req.signal.removeEventListener('abort', onAbort)
   }
 
-  // Clean up when client disconnects
-  req.signal.addEventListener('abort', cleanup)
+  req.signal.addEventListener('abort', onAbort, { once: true })
 
   return new Response(stream, {
     status: 200,


### PR DESCRIPTION
Fixes #1422

## Problem

`packages/events/src/modules/events/api/stream/route.ts` and
`packages/core/src/modules/customer_accounts/api/portal/events/stream.ts`
attached an `abort` listener to `req.signal` but never removed it.
Under SSE reconnect churn every closed stream left an abort listener
plus closures and timer references attached to the request graph until
GC eventually collected it, increasing memory pressure.

## Root Cause

The listener had no `{ once: true }` option and was never torn down
from the `cancel()` path either, so long-lived AbortSignals retained
the closures indefinitely.

## What Changed

- Register the abort listener with `{ once: true }`.
- Explicitly detach it from the request signal inside `cleanup()` so
  the stream-cancel path also releases the closure.
- Applied identically in both the DOM Event Bridge (`/api/events/stream`)
  and the Portal Event Bridge (`/api/portal/events/stream`).

## Tests

- `packages/events/src/modules/events/api/stream/__tests__/route.test.ts`
  - registers the abort listener with `{ once: true }`
  - detaches the listener when the stream is cancelled
  - detaches the listener when the request aborts
  - does not retain listeners across many reconnects (20 iterations)
- `packages/core/src/modules/customer_accounts/api/portal/events/__tests__/stream.test.ts`
  - mirrors the three core listener-hygiene checks for the portal bridge

All tests fail against the previous implementation (the stream-cancel
path never calls `removeEventListener`) and pass with the fix.

## Backward Compatibility

No contract surface changes. SSE response shape, auth, and audience
filtering are untouched.