### PR TITLE
fix(security): revalidate portal user state from DB on every request (#1426)

### DIFF
--- a/packages/core/src/modules/customer_accounts/__tests__/customerAuth.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/customerAuth.test.ts
@@ -6,6 +6,7 @@ import {
 
 const findActiveSessionById = jest.fn()
 const findOneWithDecryption = jest.fn()
+const loadAcl = jest.fn()
 const mockEm = {}
 const containerResolve = jest.fn()
 const createRequestContainer = jest.fn(async () => ({
@@ -59,10 +60,19 @@ describe('getCustomerAuthFromRequest — session revocation', () => {
       if (name === 'customerSessionService') {
         return { findActiveSessionById }
       }
+      if (name === 'customerRbacService') {
+        return { loadAcl }
+      }
       if (name === 'em') return mockEm
       return null
     })
-    findOneWithDecryption.mockResolvedValue({ id: userId, sessionsRevokedAt: null })
+    findOneWithDecryption.mockResolvedValue({
+      id: userId,
+      sessionsRevokedAt: null,
+      deletedAt: null,
+      isActive: true,
+    })
+    loadAcl.mockResolvedValue({ isPortalAdmin: false, features: ['customer_portal.view'] })
     findActiveSessionById.mockResolvedValue({
       id: sessionId,
       deletedAt: null,
@@ -134,5 +144,65 @@ describe('getCustomerAuthFromRequest — session revocation', () => {
     })
 
     await expect(getCustomerAuthFromRequest(req)).resolves.toBeNull()
+  })
+
+  it('rejects tokens for soft-deleted users', async () => {
+    findOneWithDecryption.mockResolvedValueOnce({
+      id: userId,
+      sessionsRevokedAt: null,
+      deletedAt: new Date(),
+      isActive: true,
+    })
+    const token = signAudienceJwt(CUSTOMER_AUDIENCE, buildCustomerPayload())
+    const req = new Request('http://localhost/api/customer/me', {
+      headers: { cookie: buildCustomerCookieHeader(token) },
+    })
+
+    await expect(getCustomerAuthFromRequest(req)).resolves.toBeNull()
+  })
+
+  it('rejects tokens for deactivated users', async () => {
+    findOneWithDecryption.mockResolvedValueOnce({
+      id: userId,
+      sessionsRevokedAt: null,
+      deletedAt: null,
+      isActive: false,
+    })
+    const token = signAudienceJwt(CUSTOMER_AUDIENCE, buildCustomerPayload())
+    const req = new Request('http://localhost/api/customer/me', {
+      headers: { cookie: buildCustomerCookieHeader(token) },
+    })
+
+    await expect(getCustomerAuthFromRequest(req)).resolves.toBeNull()
+  })
+
+  it('resolves features from DB instead of trusting JWT claims', async () => {
+    loadAcl.mockResolvedValueOnce({ isPortalAdmin: false, features: ['portal.orders.view'] })
+    const token = signAudienceJwt(CUSTOMER_AUDIENCE, buildCustomerPayload({
+      resolvedFeatures: ['portal.admin.all', 'portal.users.manage'],
+    }))
+    const req = new Request('http://localhost/api/customer/me', {
+      headers: { cookie: buildCustomerCookieHeader(token) },
+    })
+
+    const result = await getCustomerAuthFromRequest(req)
+
+    expect(result).not.toBeNull()
+    expect(result!.resolvedFeatures).toEqual(['portal.orders.view'])
+    expect(result!.resolvedFeatures).not.toContain('portal.admin.all')
+    expect(result!.resolvedFeatures).not.toContain('portal.users.manage')
+  })
+
+  it('grants wildcard features for portal admins', async () => {
+    loadAcl.mockResolvedValueOnce({ isPortalAdmin: true, features: ['portal.orders.view'] })
+    const token = signAudienceJwt(CUSTOMER_AUDIENCE, buildCustomerPayload())
+    const req = new Request('http://localhost/api/customer/me', {
+      headers: { cookie: buildCustomerCookieHeader(token) },
+    })
+
+    const result = await getCustomerAuthFromRequest(req)
+
+    expect(result).not.toBeNull()
+    expect(result!.resolvedFeatures).toEqual(['*'])
   })
 })

--- a/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server'
 import { verifyAudienceJwt, verifyJwt } from '@open-mercato/shared/lib/auth/jwt'
 import type { CustomerRbacService } from '@open-mercato/core/modules/customer_accounts/services/customerRbacService'
-import { hasAllFeatures } from '@open-mercato/shared/lib/auth/featureMatch'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { CUSTOMER_JWT_AUDIENCE } from '@open-mercato/core/modules/customer_accounts/services/customerSessionService'
 
@@ -47,17 +46,38 @@ export function readCookieFromHeader(header: string | null | undefined, name: st
   return undefined
 }
 
-async function isSessionRevoked(sub: string, iat: unknown): Promise<boolean> {
+type UserValidationResult =
+  | { valid: false }
+  | { valid: true; resolvedFeatures: string[] }
+
+async function validateUserState(
+  sub: string,
+  tenantId: string,
+  orgId: string,
+  iat: unknown,
+): Promise<UserValidationResult> {
   const [{ createRequestContainer }, { CustomerUser }] = await Promise.all([
     import('@open-mercato/shared/lib/di/container'),
     import('@open-mercato/core/modules/customer_accounts/data/entities'),
   ])
   const container = await createRequestContainer()
   const em = container.resolve('em') as import('@mikro-orm/postgresql').EntityManager
-  const user = await findOneWithDecryption(em, CustomerUser, { id: sub }, { fields: ['sessionsRevokedAt'] })
-  if (!user) return true
-  if (!user.sessionsRevokedAt || typeof iat !== 'number') return false
-  return iat * 1000 < user.sessionsRevokedAt.getTime()
+  const user = await findOneWithDecryption(em, CustomerUser, { id: sub }, {
+    fields: ['sessionsRevokedAt', 'deletedAt', 'isActive'],
+  })
+  if (!user) return { valid: false }
+  if (user.deletedAt) return { valid: false }
+  if (!user.isActive) return { valid: false }
+  if (user.sessionsRevokedAt && typeof iat === 'number' && iat * 1000 < user.sessionsRevokedAt.getTime()) {
+    return { valid: false }
+  }
+
+  const { CustomerRbacService } = await import(
+    '@open-mercato/core/modules/customer_accounts/services/customerRbacService'
+  )
+  const rbac = container.resolve('customerRbacService') as InstanceType<typeof CustomerRbacService>
+  const acl = await rbac.loadAcl(sub, { tenantId, organizationId: orgId })
+  return { valid: true, resolvedFeatures: acl.isPortalAdmin ? ['*'] : acl.features }
 }
 
 export async function getCustomerAuthFromRequest(req: Request): Promise<CustomerAuthContext | null> {
@@ -95,11 +115,13 @@ export async function getCustomerAuthFromRequest(req: Request): Promise<Customer
     const stillActive = sid ? await assertSessionStillActive(sid) : true
     if (!stillActive) return null
 
-    try {
-      if (await isSessionRevoked(String(payload.sub), payload.iat)) return null
-    } catch {
-      return null
-    }
+    const userState = await validateUserState(
+      String(payload.sub),
+      String(payload.tenantId),
+      String(payload.orgId),
+      payload.iat,
+    )
+    if (!userState.valid) return null
 
     return {
       sub: String(payload.sub),
@@ -111,7 +133,7 @@ export async function getCustomerAuthFromRequest(req: Request): Promise<Customer
       displayName: String(payload.displayName || ''),
       customerEntityId: payload.customerEntityId ? String(payload.customerEntityId) : null,
       personEntityId: payload.personEntityId ? String(payload.personEntityId) : null,
-      resolvedFeatures: Array.isArray(payload.resolvedFeatures) ? payload.resolvedFeatures as string[] : [],
+      resolvedFeatures: userState.resolvedFeatures,
     }
   } catch {
     // Invalid or expired JWT — treat as unauthenticated

--- a/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
@@ -46,11 +46,11 @@ export function readCookieFromHeader(header: string | null | undefined, name: st
   return undefined
 }
 
-type UserValidationResult =
+export type UserValidationResult =
   | { valid: false }
   | { valid: true; resolvedFeatures: string[] }
 
-async function validateUserState(
+export async function validateUserState(
   sub: string,
   tenantId: string,
   orgId: string,

--- a/packages/core/src/modules/customer_accounts/lib/customerAuthServer.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerAuthServer.ts
@@ -7,6 +7,7 @@
 
 import { cookies } from 'next/headers'
 import { verifyAudienceJwt } from '@open-mercato/shared/lib/auth/jwt'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { CUSTOMER_JWT_AUDIENCE } from '@open-mercato/core/modules/customer_accounts/services/customerSessionService'
 import type { CustomerAuthContext } from './customerAuth'
 
@@ -25,6 +26,40 @@ async function assertSessionStillActive(sessionId: string): Promise<boolean> {
   } catch {
     return false
   }
+}
+
+type UserValidationResult =
+  | { valid: false }
+  | { valid: true; resolvedFeatures: string[] }
+
+async function validateUserState(
+  sub: string,
+  tenantId: string,
+  orgId: string,
+  iat: unknown,
+): Promise<UserValidationResult> {
+  const [{ createRequestContainer }, { CustomerUser }] = await Promise.all([
+    import('@open-mercato/shared/lib/di/container'),
+    import('@open-mercato/core/modules/customer_accounts/data/entities'),
+  ])
+  const container = await createRequestContainer()
+  const em = container.resolve('em') as import('@mikro-orm/postgresql').EntityManager
+  const user = await findOneWithDecryption(em, CustomerUser, { id: sub }, {
+    fields: ['sessionsRevokedAt', 'deletedAt', 'isActive'],
+  })
+  if (!user) return { valid: false }
+  if (user.deletedAt) return { valid: false }
+  if (!user.isActive) return { valid: false }
+  if (user.sessionsRevokedAt && typeof iat === 'number' && iat * 1000 < user.sessionsRevokedAt.getTime()) {
+    return { valid: false }
+  }
+
+  const { CustomerRbacService } = await import(
+    '@open-mercato/core/modules/customer_accounts/services/customerRbacService'
+  )
+  const rbac = container.resolve('customerRbacService') as InstanceType<typeof CustomerRbacService>
+  const acl = await rbac.loadAcl(sub, { tenantId, organizationId: orgId })
+  return { valid: true, resolvedFeatures: acl.isPortalAdmin ? ['*'] : acl.features }
 }
 
 /**
@@ -56,6 +91,14 @@ export async function getCustomerAuthFromCookies(): Promise<CustomerAuthContext 
     const stillActive = await assertSessionStillActive(sid)
     if (!stillActive) return null
 
+    const userState = await validateUserState(
+      String(payload.sub),
+      String(payload.tenantId),
+      String(payload.orgId),
+      payload.iat,
+    )
+    if (!userState.valid) return null
+
     return {
       sub: String(payload.sub),
       sid,
@@ -66,7 +109,7 @@ export async function getCustomerAuthFromCookies(): Promise<CustomerAuthContext 
       displayName: String(payload.displayName || ''),
       customerEntityId: payload.customerEntityId ? String(payload.customerEntityId) : null,
       personEntityId: payload.personEntityId ? String(payload.personEntityId) : null,
-      resolvedFeatures: Array.isArray(payload.resolvedFeatures) ? payload.resolvedFeatures as string[] : [],
+      resolvedFeatures: userState.resolvedFeatures,
     }
   } catch {
     // Invalid or expired JWT — treat as unauthenticated

--- a/packages/core/src/modules/customer_accounts/lib/customerAuthServer.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerAuthServer.ts
@@ -7,8 +7,8 @@
 
 import { cookies } from 'next/headers'
 import { verifyAudienceJwt } from '@open-mercato/shared/lib/auth/jwt'
-import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { CUSTOMER_JWT_AUDIENCE } from '@open-mercato/core/modules/customer_accounts/services/customerSessionService'
+import { validateUserState } from './customerAuth'
 import type { CustomerAuthContext } from './customerAuth'
 
 export type { CustomerAuthContext }
@@ -26,40 +26,6 @@ async function assertSessionStillActive(sessionId: string): Promise<boolean> {
   } catch {
     return false
   }
-}
-
-type UserValidationResult =
-  | { valid: false }
-  | { valid: true; resolvedFeatures: string[] }
-
-async function validateUserState(
-  sub: string,
-  tenantId: string,
-  orgId: string,
-  iat: unknown,
-): Promise<UserValidationResult> {
-  const [{ createRequestContainer }, { CustomerUser }] = await Promise.all([
-    import('@open-mercato/shared/lib/di/container'),
-    import('@open-mercato/core/modules/customer_accounts/data/entities'),
-  ])
-  const container = await createRequestContainer()
-  const em = container.resolve('em') as import('@mikro-orm/postgresql').EntityManager
-  const user = await findOneWithDecryption(em, CustomerUser, { id: sub }, {
-    fields: ['sessionsRevokedAt', 'deletedAt', 'isActive'],
-  })
-  if (!user) return { valid: false }
-  if (user.deletedAt) return { valid: false }
-  if (!user.isActive) return { valid: false }
-  if (user.sessionsRevokedAt && typeof iat === 'number' && iat * 1000 < user.sessionsRevokedAt.getTime()) {
-    return { valid: false }
-  }
-
-  const { CustomerRbacService } = await import(
-    '@open-mercato/core/modules/customer_accounts/services/customerRbacService'
-  )
-  const rbac = container.resolve('customerRbacService') as InstanceType<typeof CustomerRbacService>
-  const acl = await rbac.loadAcl(sub, { tenantId, organizationId: orgId })
-  return { valid: true, resolvedFeatures: acl.isPortalAdmin ? ['*'] : acl.features }
 }
 
 /**


### PR DESCRIPTION
Fixes #1426

## Problem
- Portal auth (`getCustomerAuthFromRequest` and `getCustomerAuthFromCookies`) trusted JWT claims for `resolvedFeatures` and did not check whether the user had been deleted (`deletedAt`) or deactivated (`isActive: false`) after token issuance
- A deleted/deactivated user could retain portal access with stale privileges until the 8-hour JWT expired

## Root Cause
- `isSessionRevoked()` only checked `sessionsRevokedAt` on the `CustomerUser` record — it did not verify `deletedAt` or `isActive`
- `resolvedFeatures` were read directly from JWT claims instead of being re-resolved from the database

## What Changed
- Replaced `isSessionRevoked()` with `validateUserState()` that checks `deletedAt`, `isActive`, and `sessionsRevokedAt`
- Re-resolves RBAC features from DB via `CustomerRbacService.loadAcl` on every request instead of trusting JWT-embedded claims
- Applied the same fix to both `customerAuth.ts` (API routes) and `customerAuthServer.ts` (server components)

## Tests
- Added unit test: rejects tokens for soft-deleted users
- Added unit test: rejects tokens for deactivated users
- Added unit test: resolves features from DB instead of trusting JWT claims
- Added unit test: grants wildcard features for portal admins
- All 9 customer auth tests pass

## Backward Compatibility
- No contract surface changes — `CustomerAuthContext` type unchanged
- Function signatures unchanged for all exported helpers
- Behavioral change is strictly security-hardening: stale JWT claims are no longer trusted

🤖 Generated with [Claude Code](https://claude.com/claude-code)