### PR TITLE
fix(queue): add retry and backoff for failed jobs in all queue strategies (#1416)

### DIFF
--- a/packages/events/src/modules/events/workers/__tests__/events.worker.test.ts
+++ b/packages/events/src/modules/events/workers/__tests__/events.worker.test.ts
@@ -289,7 +289,7 @@ describe('Events Worker', () => {
       expect(called).toBe(true)
     })
 
-    it('should isolate errors - continue processing other subscribers when one fails', async () => {
+    it('should run all subscribers even when one fails, then throw to trigger retry', async () => {
       const subscriber1Calls: unknown[] = []
       const subscriber2Calls: unknown[] = []
 
@@ -326,13 +326,17 @@ describe('Events Worker', () => {
       const job = createMockJob('test.event', { data: 'test' })
       const ctx = createMockContext()
 
-      // Should not throw - partial failures are logged but don't fail the job
-      await expect(handle(job, ctx)).resolves.toBeUndefined()
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
-      // Both subscribers should have been called
+      await expect(handle(job, ctx)).rejects.toThrow(
+        '1/2 subscriber(s) failed for event "test.event": a:failing-subscriber'
+      )
+
       expect(subscriber1Calls.length).toBe(1)
       expect(subscriber2Calls.length).toBe(1)
       expect(subscriber2Calls[0]).toEqual({ data: 'test' })
+
+      errorSpy.mockRestore()
     })
 
     it('should throw when all subscribers fail', async () => {
@@ -368,8 +372,13 @@ describe('Events Worker', () => {
       const job = createMockJob('test.event', { data: 'test' })
       const ctx = createMockContext()
 
-      // Should throw when all subscribers fail
-      await expect(handle(job, ctx)).rejects.toThrow('All 2 subscriber(s) failed for event "test.event"')
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      await expect(handle(job, ctx)).rejects.toThrow(
+        '2/2 subscriber(s) failed for event "test.event": a:failing-subscriber, b:failing-subscriber'
+      )
+
+      errorSpy.mockRestore()
     })
   })
 })

--- a/packages/events/src/modules/events/workers/events.worker.ts
+++ b/packages/events/src/modules/events/workers/events.worker.ts
@@ -95,13 +95,10 @@ export default async function handle(
     }
   }
 
-  // If all subscribers failed, throw to trigger retry
-  if (errors.length === subscribers.length) {
-    throw new Error(`All ${errors.length} subscriber(s) failed for event "${event}"`)
-  }
-
-  // Log partial failures but don't fail the job
   if (errors.length > 0) {
-    console.warn(`[events] ${errors.length}/${subscribers.length} subscriber(s) failed for event "${event}"`)
+    const failedIds = errors.map((e) => e.subscriberId).join(', ')
+    throw new Error(
+      `${errors.length}/${subscribers.length} subscriber(s) failed for event "${event}": ${failedIds}`
+    )
   }
 }

--- a/packages/queue/src/__tests__/async.strategy.test.ts
+++ b/packages/queue/src/__tests__/async.strategy.test.ts
@@ -93,6 +93,25 @@ describe('Queue - async strategy', () => {
     })
   })
 
+  it('enqueues jobs with retry attempts and exponential backoff', async () => {
+    const queue = createQueue<{ value: number }>('test-queue', 'async')
+
+    await queue.enqueue({ value: 42 })
+
+    expect(queueAdd).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ payload: { value: 42 } }),
+      expect.objectContaining({
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 1000 },
+        removeOnComplete: true,
+        removeOnFail: 1000,
+      }),
+    )
+
+    await queue.close()
+  })
+
   it('keeps structured Redis options when host-based config is used', async () => {
     const queue = createQueue<{ value: number }>('test-queue', 'async', {
       connection: {

--- a/packages/queue/src/__tests__/local.strategy.test.ts
+++ b/packages/queue/src/__tests__/local.strategy.test.ts
@@ -205,6 +205,92 @@ describe('Queue - local strategy', () => {
     await queue.close()
   })
 
+  test('failed jobs are retained in queue for retry', async () => {
+    const queue = createQueue<{ shouldFail: boolean }>('test-queue', 'local')
+    const queuePath = path.join('.mercato', 'queue', 'test-queue', 'queue.json')
+
+    await queue.enqueue({ shouldFail: true })
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    await queue.process((job) => {
+      if (job.payload.shouldFail) throw new Error('transient')
+    }, { limit: 10 })
+
+    const remaining = readJson(queuePath)
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].attemptCount).toBe(1)
+    expect(remaining[0].availableAt).toBeDefined()
+
+    errorSpy.mockRestore()
+    await queue.close()
+  })
+
+  test('failed jobs are removed after max attempts', async () => {
+    const queue = createQueue<{ value: number }>('test-queue', 'local')
+    const queuePath = path.join('.mercato', 'queue', 'test-queue', 'queue.json')
+
+    await queue.enqueue({ value: 1 })
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Manually set attemptCount to simulate prior failures
+    const jobs = readJson(queuePath)
+    jobs[0].attemptCount = 2
+    jobs[0].availableAt = undefined
+    fs.writeFileSync(queuePath, JSON.stringify(jobs, null, 2), 'utf8')
+
+    await queue.process(() => { throw new Error('permanent') }, { limit: 10 })
+
+    const remaining = readJson(queuePath)
+    expect(remaining).toHaveLength(0)
+
+    errorSpy.mockRestore()
+    await queue.close()
+  })
+
+  test('retry jobs include exponential backoff delay', async () => {
+    const queue = createQueue<{ value: number }>('test-queue', 'local')
+    const queuePath = path.join('.mercato', 'queue', 'test-queue', 'queue.json')
+
+    await queue.enqueue({ value: 1 })
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const beforeProcess = Date.now()
+
+    await queue.process(() => { throw new Error('fail') }, { limit: 10 })
+
+    const remaining = readJson(queuePath)
+    expect(remaining).toHaveLength(1)
+    const availableAt = new Date(remaining[0].availableAt).getTime()
+    expect(availableAt).toBeGreaterThanOrEqual(beforeProcess + 1000)
+
+    errorSpy.mockRestore()
+    await queue.close()
+  })
+
+  test('attempt number is passed correctly in job context', async () => {
+    const queue = createQueue<{ value: number }>('test-queue', 'local')
+    const queuePath = path.join('.mercato', 'queue', 'test-queue', 'queue.json')
+    const attempts: number[] = []
+
+    await queue.enqueue({ value: 1 })
+
+    // Set attemptCount to 1 to simulate a retry
+    const jobs = readJson(queuePath)
+    jobs[0].attemptCount = 1
+    jobs[0].availableAt = undefined
+    fs.writeFileSync(queuePath, JSON.stringify(jobs, null, 2), 'utf8')
+
+    await queue.process((_job, ctx) => {
+      attempts.push(ctx.attemptNumber)
+    }, { limit: 10 })
+
+    expect(attempts).toEqual([2])
+
+    await queue.close()
+  })
+
   test('job context contains correct information', async () => {
     const queue = createQueue<{ value: number }>('context-test', 'local')
     let capturedContext: any = null

--- a/packages/queue/src/strategies/async.ts
+++ b/packages/queue/src/strategies/async.ts
@@ -17,7 +17,13 @@ interface BullQueueInterface<T> {
   add: (
     name: string,
     data: T,
-    opts?: { removeOnComplete?: boolean; removeOnFail?: number; delay?: number },
+    opts?: {
+      removeOnComplete?: boolean
+      removeOnFail?: number
+      delay?: number
+      attempts?: number
+      backoff?: { type: string; delay: number }
+    },
   ) => Promise<{ id?: string }>
   obliterate: (opts?: { force?: boolean }) => Promise<void>
   close: () => Promise<void>
@@ -128,7 +134,9 @@ export function createAsyncQueue<T = unknown>(
     const job = await queue.add(jobData.id, jobData, {
       delay: options?.delayMs && options.delayMs > 0 ? options.delayMs : undefined,
       removeOnComplete: true,
-      removeOnFail: 1000, // Keep last 1000 failed jobs
+      removeOnFail: 1000,
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 1000 },
     })
 
     return job.id ?? jobData.id

--- a/packages/queue/src/strategies/local.ts
+++ b/packages/queue/src/strategies/local.ts
@@ -11,11 +11,14 @@ type LocalState = {
 
 type StoredJob<T> = QueuedJob<T> & {
   availableAt?: string
+  attemptCount?: number
 }
 
 /** Default polling interval in milliseconds */
 const DEFAULT_POLL_INTERVAL = 1000
 const DEFAULT_LOCAL_QUEUE_BASE_DIR = '.mercato/queue'
+const DEFAULT_MAX_ATTEMPTS = 3
+const RETRY_BACKOFF_BASE_MS = 1000
 
 /**
  * Creates a file-based local queue.
@@ -176,17 +179,10 @@ export function createLocalQueue<T = unknown>(
     const state = readState()
     const jobs = readQueue()
 
-    // Find jobs that haven't been processed yet
-    const lastProcessedIndex = state.lastProcessedId
-      ? jobs.findIndex((j) => j.id === state.lastProcessedId)
-      : -1
-
-    const pendingJobs = jobs
-      .slice(lastProcessedIndex + 1)
-      .filter((job) => {
-        if (!job.availableAt) return true
-        return new Date(job.availableAt).getTime() <= Date.now()
-      })
+    const pendingJobs = jobs.filter((job) => {
+      if (!job.availableAt) return true
+      return new Date(job.availableAt).getTime() <= Date.now()
+    })
     const jobsToProcess = options?.limit
       ? pendingJobs.slice(0, options.limit)
       : pendingJobs
@@ -194,39 +190,53 @@ export function createLocalQueue<T = unknown>(
     let processed = 0
     let failed = 0
     let lastJobId: string | undefined
-    const jobIdsToRemove = new Set<string>()
+    const completedJobIds = new Set<string>()
+    const deadJobIds = new Set<string>()
+    const retryUpdates = new Map<string, StoredJob<T>>()
 
     for (const job of jobsToProcess) {
+      const attemptNumber = (job.attemptCount ?? 0) + 1
       try {
         await Promise.resolve(
           handler(job, {
             jobId: job.id,
-            attemptNumber: 1,
+            attemptNumber,
             queueName: name,
           })
         )
         processed++
         lastJobId = job.id
-        jobIdsToRemove.add(job.id)
+        completedJobIds.add(job.id)
         console.log(`[queue:${name}] Job ${job.id} completed`)
       } catch (error) {
-        console.error(`[queue:${name}] Job ${job.id} failed:`, error)
+        console.error(`[queue:${name}] Job ${job.id} failed (attempt ${attemptNumber}/${DEFAULT_MAX_ATTEMPTS}):`, error)
         failed++
         lastJobId = job.id
-        jobIdsToRemove.add(job.id) // Remove failed jobs too (matching async strategy)
+        if (attemptNumber >= DEFAULT_MAX_ATTEMPTS) {
+          console.error(`[queue:${name}] Job ${job.id} exhausted all ${DEFAULT_MAX_ATTEMPTS} attempts, moving to dead letter`)
+          deadJobIds.add(job.id)
+        } else {
+          const backoffMs = RETRY_BACKOFF_BASE_MS * Math.pow(2, attemptNumber - 1)
+          retryUpdates.set(job.id, {
+            ...job,
+            attemptCount: attemptNumber,
+            availableAt: new Date(Date.now() + backoffMs).toISOString(),
+          })
+        }
       }
     }
 
-    // Remove processed jobs from queue (matching async removeOnComplete behavior)
-    if (jobIdsToRemove.size > 0) {
-      const updatedJobs = jobs.filter((j) => !jobIdsToRemove.has(j.id))
+    const hasChanges = completedJobIds.size > 0 || deadJobIds.size > 0 || retryUpdates.size > 0
+    if (hasChanges) {
+      const updatedJobs = jobs
+        .filter((j) => !completedJobIds.has(j.id) && !deadJobIds.has(j.id))
+        .map((j) => retryUpdates.get(j.id) ?? j)
       writeQueue(updatedJobs)
 
-      // Update state with running counts
       const newState: LocalState = {
         lastProcessedId: lastJobId,
         completedCount: (state.completedCount ?? 0) + processed,
-        failedCount: (state.failedCount ?? 0) + failed,
+        failedCount: (state.failedCount ?? 0) + deadJobIds.size,
       }
       writeState(newState)
     }


### PR DESCRIPTION
Fixes #1416

## Problem
Event worker and queue strategies silently lose failed jobs. Specifically:
- Event worker only throws when ALL subscribers fail — partial failures are silently swallowed
- Local queue removes failed jobs immediately with no retry mechanism
- BullMQ enqueues jobs without retry attempts or backoff configuration

## Root Cause
Three independent gaps in error handling across the queue/events infrastructure:
1. Event worker treated partial subscriber failures as acceptable, logging but not retrying
2. Local queue added failed job IDs to the removal set alongside completed jobs
3. BullMQ `queue.add()` called without `attempts` or `backoff` options

## What Changed
- **Event worker** (`events.worker.ts`): Now throws on ANY subscriber failure (not just when all fail), triggering job retry. Safe because subscribers are required to be idempotent per AGENTS.md.
- **BullMQ async queue** (`async.ts`): Added `attempts: 3` with exponential backoff (`delay: 1000ms`) to all enqueued jobs.
- **Local queue** (`local.ts`): Failed jobs are retained in queue with `attemptCount` tracking and exponential backoff (`availableAt`). Jobs are only removed after exhausting 3 attempts (dead letter). Removed the `lastProcessedId`-based skip logic since completed jobs are already removed from the queue file.

## Tests
- 4 new local queue tests: retry retention, max attempts exhaustion, exponential backoff delay, attempt number in context
- 1 new async queue test: verifies retry options are passed to BullMQ
- Updated event worker tests: partial failure now throws (was silently swallowed), all-fail error message updated
- All 39 affected tests pass; only pre-existing `sync-akeneo` failure (missing generated file) remains

## Backward Compatibility
- No contract surface changes (no public API, event ID, widget spot ID, or import path changes)
- `StoredJob` type gains optional `attemptCount` field — additive only
- Event worker now fails-fast on partial subscriber errors — this is a behavior change but aligns with the documented idempotency requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)