### PR TITLE
fix(sales,workflows): prevent premature state commits before side-effects complete (#1415)

### DIFF
--- a/packages/core/src/modules/sales/api/__tests__/quotes.acceptance.test.ts
+++ b/packages/core/src/modules/sales/api/__tests__/quotes.acceptance.test.ts
@@ -493,6 +493,147 @@ describe('accept - TOCTOU concurrency guard', () => {
   })
 })
 
+describe('accept - state rollback on conversion failure (fix: #1415)', () => {
+  const ACCEPTANCE_TOKEN = '00000000-0000-4000-8000-000000000003'
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    mockEm.fork.mockReturnValue(mockEm)
+    mockRateLimiterService.consume.mockResolvedValue({ allowed: true, remainingPoints: 9, msBeforeNext: 0 })
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    const { getCachedRateLimiterService } = await import('@open-mercato/core/bootstrap')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue(null)
+    ;(getCachedRateLimiterService as jest.Mock).mockReturnValue(mockRateLimiterService)
+  })
+
+  test('reverts quote status to sent when order conversion fails', async () => {
+    const quote = {
+      id: '99999999-9999-4999-8999-999999999999',
+      tenantId: '00000000-0000-4000-8000-000000000000',
+      organizationId: '11111111-1111-4111-8111-111111111111',
+      quoteNumber: 'SQ-REVERT-1',
+      status: 'sent',
+      statusEntryId: null,
+      validUntil: new Date(Date.now() + 60_000),
+      updatedAt: new Date(),
+    }
+
+    mockEm.transactional = jest.fn(async (callback: (trx: any) => Promise<unknown>) => {
+      return callback(mockEm)
+    }) as any
+
+    mockEm.findOne.mockImplementation(async (cls: any, where: any) => {
+      if (cls === SalesQuote) {
+        if (where?.acceptanceToken) return quote
+        if (where?.id === quote.id) return quote
+        return null
+      }
+      if (cls === Dictionary) return { id: 'dict-1' }
+      if (cls === DictionaryEntry) return { id: 'entry-confirmed' }
+      return null
+    })
+
+    mockCommandBus.execute.mockRejectedValue(new Error('Conversion failed'))
+
+    const res = await acceptQuote(makeAcceptRequest({ token: ACCEPTANCE_TOKEN }))
+    expect(res.status).toBe(400)
+    expect(quote.status).toBe('sent')
+  })
+})
+
+describe('send - no flush before email delivery (fix: #1415)', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    mockEm.fork.mockReturnValue(mockEm)
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    const { resolveOrganizationScopeForRequest } = await import('@open-mercato/core/modules/directory/utils/organizationScope')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: '00000000-0000-4000-8000-000000000000',
+      orgId: '11111111-1111-4111-8111-111111111111',
+      roles: ['admin'],
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: '11111111-1111-4111-8111-111111111111',
+      filterIds: ['11111111-1111-4111-8111-111111111111'],
+      allowedIds: ['11111111-1111-4111-8111-111111111111'],
+    })
+  })
+
+  test('does not persist quote state when email delivery fails', async () => {
+    const quote = {
+      id: '22222222-2222-4222-8222-222222222222',
+      tenantId: '00000000-0000-4000-8000-000000000000',
+      organizationId: '11111111-1111-4111-8111-111111111111',
+      quoteNumber: 'SQ-NOEMAIL-1',
+      currencyCode: 'USD',
+      grandTotalGrossAmount: '10',
+      status: 'draft',
+      statusEntryId: null,
+      customerSnapshot: { customer: { primaryEmail: 'test@example.com' } },
+      metadata: null,
+      updatedAt: new Date(),
+      validUntil: null,
+      sentAt: null,
+      acceptanceToken: null,
+    }
+
+    mockEm.findOne.mockImplementation(async (cls: any, where: any) => {
+      if (cls === SalesQuote) return where?.id === quote.id ? quote : null
+      if (cls === Dictionary) return { id: 'dict-1' }
+      if (cls === DictionaryEntry) return { id: 'entry-sent' }
+      return null
+    })
+
+    const { sendEmail } = await import('@open-mercato/shared/lib/email/send')
+    ;(sendEmail as jest.Mock).mockRejectedValueOnce(new Error('SMTP connection refused'))
+
+    const res = await sendQuote(makeRequest({ quoteId: quote.id, validForDays: 14 }))
+    expect(res.status).toBe(400)
+    expect(mockEm.flush).not.toHaveBeenCalled()
+  })
+
+  test('persists quote state only after email delivery succeeds', async () => {
+    const quote = {
+      id: '22222222-2222-4222-8222-222222222222',
+      tenantId: '00000000-0000-4000-8000-000000000000',
+      organizationId: '11111111-1111-4111-8111-111111111111',
+      quoteNumber: 'SQ-OK-1',
+      currencyCode: 'USD',
+      grandTotalGrossAmount: '10',
+      status: 'draft',
+      statusEntryId: null,
+      customerSnapshot: { customer: { primaryEmail: 'test@example.com' } },
+      metadata: null,
+      updatedAt: new Date(),
+      validUntil: null,
+      sentAt: null,
+      acceptanceToken: null,
+    }
+
+    mockEm.findOne.mockImplementation(async (cls: any, where: any) => {
+      if (cls === SalesQuote) return where?.id === quote.id ? quote : null
+      if (cls === Dictionary) return { id: 'dict-1' }
+      if (cls === DictionaryEntry) return { id: 'entry-sent' }
+      return null
+    })
+
+    const callOrder: string[] = []
+    mockEm.flush.mockImplementation(async () => {
+      callOrder.push('flush')
+    })
+
+    const { sendEmail } = await import('@open-mercato/shared/lib/email/send')
+    ;(sendEmail as jest.Mock).mockImplementation(async () => {
+      callOrder.push('sendEmail')
+    })
+
+    const res = await sendQuote(makeRequest({ quoteId: quote.id, validForDays: 14 }))
+    expect(res.status).toBe(200)
+    expect(callOrder.indexOf('sendEmail')).toBeLessThan(callOrder.indexOf('flush'))
+  })
+})
+
 describe('quote editing invalidates sent token', () => {
   test('updating a sent quote clears token and reverts status to draft', async () => {
     // Registers commands (including sales.quotes.update) into the global command registry.

--- a/packages/core/src/modules/sales/api/quotes/accept/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/accept/route.ts
@@ -127,10 +127,34 @@ export async function POST(req: Request) {
       request: req,
     }
 
-    const result = (await commandBus.execute('sales.quotes.convert_to_order', { input: { quoteId: quote.id }, ctx })) as ConvertToOrderResult | null
+    let result: ConvertToOrderResult | null
+    try {
+      result = (await commandBus.execute('sales.quotes.convert_to_order', { input: { quoteId: quote.id }, ctx })) as ConvertToOrderResult | null
+    } catch (conversionError) {
+      const freshEm = (container.resolve('em') as EntityManager).fork()
+      const staleQuote = await findOneWithDecryption(
+        freshEm,
+        SalesQuote,
+        { id: quote.id, deletedAt: null },
+        {},
+        tenantScope,
+      )
+      if (staleQuote) {
+        staleQuote.status = 'sent'
+        staleQuote.statusEntryId = await resolveStatusEntryIdByValue(freshEm, {
+          tenantId: staleQuote.tenantId,
+          organizationId: staleQuote.organizationId,
+          value: 'sent',
+        })
+        staleQuote.updatedAt = new Date()
+        freshEm.persist(staleQuote)
+        await freshEm.flush()
+      }
+      throw conversionError
+    }
     const orderId = result?.result?.orderId ?? result?.orderId ?? quote.id
 
-    const order = await em.findOne(SalesOrder, { id: orderId, deletedAt: null })
+    const order = await findOneWithDecryption(em, SalesOrder, { id: orderId, deletedAt: null }, {}, tenantScope)
     const orderNumber = order?.orderNumber ?? orderId
 
     // Admin notification should not block acceptance.

--- a/packages/core/src/modules/sales/api/quotes/send/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/send/route.ts
@@ -17,6 +17,7 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import crypto from 'node:crypto'
 import { withScopedPayload } from '../../utils'
 import { hashAuthToken } from '../../../../auth/lib/tokenHash'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { SalesQuote } from '../../../data/entities'
 import { quoteSendSchema } from '../../../data/validators'
 import { sendEmail } from '@open-mercato/shared/lib/email/send'
@@ -144,7 +145,8 @@ export async function POST(req: Request) {
     }
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const quote = await em.findOne(SalesQuote, { id: input.quoteId, deletedAt: null })
+    const tenantScope = ctx.auth?.tenantId ? { tenantId: ctx.auth.tenantId } : undefined
+    const quote = await findOneWithDecryption(em, SalesQuote, { id: input.quoteId, deletedAt: null }, {}, tenantScope)
     if (!quote) {
       throw new CrudHttpError(404, { error: translate('sales.documents.detail.error', 'Document not found or inaccessible.') })
     }
@@ -177,7 +179,6 @@ export async function POST(req: Request) {
     })
     quote.updatedAt = now
     em.persist(quote)
-    await em.flush()
 
     const appUrl = process.env.APP_URL || ''
     const url = appUrl ? `${appUrl.replace(/\/$/, '')}/quote/${rawAcceptanceToken}` : `/quote/${rawAcceptanceToken}`
@@ -206,6 +207,8 @@ export async function POST(req: Request) {
       subject: translate('sales.quotes.email.subject', 'Quote {quoteNumber}', { quoteNumber: quote.quoteNumber }),
       react: QuoteSentEmail({ url, copy }),
     })
+
+    await em.flush()
 
     if (guardResult.afterSuccessCallbacks.length) {
       await runGuardAfterSuccessCallbacks(guardResult.afterSuccessCallbacks, {

--- a/packages/core/src/modules/workflows/api/__tests__/instances.route.test.ts
+++ b/packages/core/src/modules/workflows/api/__tests__/instances.route.test.ts
@@ -750,6 +750,9 @@ describe('Workflow Instances API', () => {
         retryCount: 0,
         tenantId: testTenantId,
         organizationId: testOrgId,
+        errorMessage: 'Original error',
+        errorDetails: { step: 'payment' },
+        updatedAt: new Date(),
       }
 
       mockEm.findOne.mockResolvedValue(mockInstance)
@@ -762,6 +765,36 @@ describe('Workflow Instances API', () => {
       const response = await retryInstance(request, { params: Promise.resolve({ id: testInstanceId }) })
 
       expect(response.status).toBe(400)
+    })
+
+    test('should revert to FAILED status when execution throws (fix: #1415)', async () => {
+      const originalError = 'Payment gateway timeout'
+      const originalDetails = { step: 'payment', code: 'TIMEOUT' }
+      const mockInstance = {
+        id: testInstanceId,
+        status: 'FAILED',
+        retryCount: 1,
+        tenantId: testTenantId,
+        organizationId: testOrgId,
+        errorMessage: originalError,
+        errorDetails: originalDetails,
+        updatedAt: new Date(),
+      }
+
+      mockEm.findOne.mockResolvedValue(mockInstance);
+      (workflowExecutor.executeWorkflow as jest.Mock).mockRejectedValue(
+        new workflowExecutor.WorkflowExecutionError('Retry execution failed', 'EXECUTION_ERROR'),
+      )
+
+      const request = new NextRequest(`http://localhost/api/workflows/instances/${testInstanceId}/retry`, {
+        method: 'POST',
+      })
+      await retryInstance(request, { params: Promise.resolve({ id: testInstanceId }) })
+
+      expect(mockInstance.status).toBe('FAILED')
+      expect(mockInstance.errorMessage).toBe(originalError)
+      expect(mockInstance.errorDetails).toBe(originalDetails)
+      expect(mockEm.flush).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/packages/core/src/modules/workflows/api/instances/[id]/retry/route.ts
+++ b/packages/core/src/modules/workflows/api/instances/[id]/retry/route.ts
@@ -10,6 +10,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { WorkflowInstance } from '../../../../data/entities'
 import * as workflowExecutor from '../../../../lib/workflow-executor'
 import { workflowInstanceResponseSchema, workflowExecutionResultSchema } from '../../../openapi'
@@ -73,7 +74,7 @@ export async function POST(
       )
     }
 
-    const instance = await em.findOne(WorkflowInstance, {
+    const instance = await findOneWithDecryption(em, WorkflowInstance, {
       id: params.id,
       tenantId,
       organizationId,
@@ -96,7 +97,9 @@ export async function POST(
       )
     }
 
-    // Reset instance to RUNNING status and increment retry count
+    const previousErrorMessage = instance.errorMessage
+    const previousErrorDetails = instance.errorDetails
+
     instance.status = 'RUNNING'
     instance.retryCount = (instance.retryCount || 0) + 1
     instance.errorMessage = null
@@ -105,10 +108,18 @@ export async function POST(
 
     await em.flush()
 
-    // Execute workflow from current step
-    const result = await workflowExecutor.executeWorkflow(em, container, instance.id)
+    let result
+    try {
+      result = await workflowExecutor.executeWorkflow(em, container, instance.id)
+    } catch (executionError) {
+      instance.status = 'FAILED'
+      instance.errorMessage = previousErrorMessage
+      instance.errorDetails = previousErrorDetails
+      instance.updatedAt = new Date()
+      await em.flush()
+      throw executionError
+    }
 
-    // Reload instance to get final state
     await em.refresh(instance)
 
     return NextResponse.json({


### PR DESCRIPTION
Fixes #1415

## Problem
Three routes flush state transitions to the database **before** downstream operations complete, creating inconsistent state when those operations fail:
- **Quote accept**: status set to `confirmed` and flushed before order conversion runs
- **Quote send**: status set to `sent` and flushed before email delivery
- **Workflow retry**: status reset to `RUNNING` and flushed before `executeWorkflow()`

## Root Cause
Each route performs `em.flush()` (or commits a transaction) on the status change *before* the downstream side-effect (order conversion, email send, workflow execution). On failure, the already-committed state cannot be rolled back, leaving users with success indicators for operations that actually failed.

## What Changed
- **Quote accept** (`quotes/accept/route.ts`): Wrapped `commandBus.execute` in try/catch — on conversion failure, reverts the quote status from `confirmed` back to `sent` using a fresh EntityManager and re-throws
- **Quote send** (`quotes/send/route.ts`): Moved `em.flush()` to *after* `sendEmail()` succeeds — if SMTP fails, the in-memory status change is never persisted
- **Workflow retry** (`instances/[id]/retry/route.ts`): Saved previous error state before clearing; on `executeWorkflow` failure, restores `FAILED` status with original error message/details and re-flushes
- **Encryption compliance**: Replaced raw `em.findOne` with `findOneWithDecryption` in quote send and workflow retry routes (per AGENTS.md encryption contract)

## Tests
- `quotes.acceptance.test.ts`: Added 3 regression tests:
  - Quote accept reverts to `sent` when conversion fails
  - Quote send does not flush when email delivery fails
  - Quote send flushes only after email delivery succeeds (ordering assertion)
- `instances.route.test.ts`: Added 1 regression test:
  - Workflow retry reverts to `FAILED` with original error info when execution throws

All regression tests pass. Full validation suite run:
- `yarn build:packages` ✅
- `yarn generate` ✅
- `yarn typecheck` ✅ (18/18 packages)
- `yarn test` — core: 2758/2759 pass (1 pre-existing failure in unrelated `InlineEditors.test.tsx`)

## Backward Compatibility
- No contract surface changes — no new/removed API fields, event IDs, widget spots, or import paths
- Behavioral change is strictly error-path: success paths are unchanged
- Quote accept rollback uses a fresh EntityManager to avoid UoW conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)