### PR TITLE
security(sales,auth): fix race conditions in payments, quotes, shipments, and password reset (#1414)

### DIFF
--- a/packages/core/src/modules/auth/services/__tests__/authService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/authService.test.ts
@@ -2,6 +2,13 @@ import { AuthService } from '@open-mercato/core/modules/auth/services/authServic
 import { Session } from '@open-mercato/core/modules/auth/data/entities'
 import { hashAuthToken } from '@open-mercato/core/modules/auth/lib/tokenHash'
 
+const mockFindOneWithDecryption = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...args),
+  findWithDecryption: jest.fn().mockResolvedValue([]),
+}))
+
 function makeEm() {
   const calls: any[] = []
   const em: any = {
@@ -9,8 +16,13 @@ function makeEm() {
     create: jest.fn((_cls: any, data: any) => ({ ...data, id: 'generated-id' })),
     findOne: jest.fn(async () => null),
     nativeDelete: jest.fn(async () => 1),
+    nativeUpdate: jest.fn(async () => 1),
+    flush: jest.fn(async () => undefined),
     find: jest.fn(async () => []),
   }
+  mockFindOneWithDecryption.mockImplementation(async (passedEm: any, _cls: any, filter: any) => {
+    return passedEm.findOne?.(_cls, filter)
+  })
   return { em, calls }
 }
 
@@ -151,5 +163,70 @@ describe('AuthService', () => {
     })
     const svc = new AuthService(em)
     await expect(svc.findActiveSessionById('session-1')).resolves.toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // Regression: password reset token replay prevention (issue #1414)
+  // -------------------------------------------------------------------------
+
+  it('confirmPasswordReset uses atomic nativeUpdate to prevent concurrent token replay', async () => {
+    const { em } = makeEm()
+    const resetRow = {
+      id: 'reset-1',
+      token: hashAuthToken('raw-token-value'),
+      expiresAt: new Date(Date.now() + 60000),
+      usedAt: null,
+      user: { id: 'u1' },
+    }
+    em.findOne.mockResolvedValueOnce(resetRow)
+    em.nativeUpdate.mockResolvedValueOnce(1)
+    mockFindOneWithDecryption.mockResolvedValueOnce({ id: 'u1', passwordHash: 'old-hash', deletedAt: null })
+
+    const svc = new AuthService(em)
+    const result = await svc.confirmPasswordReset('raw-token-value', 'NewSecurePass1!')
+
+    expect(result).not.toBeNull()
+    expect(em.nativeUpdate).toHaveBeenCalledTimes(1)
+    const [_entity, filter, update] = em.nativeUpdate.mock.calls[0]
+    expect(filter).toMatchObject({ id: 'reset-1', usedAt: null })
+    expect(update).toMatchObject({ usedAt: expect.any(Date) })
+  })
+
+  it('confirmPasswordReset returns null when nativeUpdate affects 0 rows (token already consumed)', async () => {
+    const { em } = makeEm()
+    const resetRow = {
+      id: 'reset-1',
+      token: hashAuthToken('raw-token-value'),
+      expiresAt: new Date(Date.now() + 60000),
+      usedAt: null,
+      user: { id: 'u1' },
+    }
+    em.findOne.mockResolvedValueOnce(resetRow)
+    em.nativeUpdate.mockResolvedValueOnce(0)
+
+    const svc = new AuthService(em)
+    const result = await svc.confirmPasswordReset('raw-token-value', 'NewSecurePass1!')
+
+    expect(result).toBeNull()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('confirmPasswordReset does not set usedAt via ORM — only via nativeUpdate', async () => {
+    const { em } = makeEm()
+    const resetRow = {
+      id: 'reset-1',
+      token: hashAuthToken('raw-token-value'),
+      expiresAt: new Date(Date.now() + 60000),
+      usedAt: null,
+      user: { id: 'u1' },
+    }
+    em.findOne.mockResolvedValueOnce(resetRow)
+    em.nativeUpdate.mockResolvedValueOnce(1)
+    mockFindOneWithDecryption.mockResolvedValueOnce({ id: 'u1', passwordHash: 'old-hash', deletedAt: null })
+
+    const svc = new AuthService(em)
+    await svc.confirmPasswordReset('raw-token-value', 'NewSecurePass1!')
+
+    expect(resetRow.usedAt).toBeNull()
   })
 })

--- a/packages/core/src/modules/auth/services/authService.ts
+++ b/packages/core/src/modules/auth/services/authService.ts
@@ -132,10 +132,18 @@ export class AuthService {
       row = await this.em.findOne(PasswordReset, { token })
     }
     if (!row || (row.usedAt && row.usedAt <= now) || row.expiresAt <= now) return null
+
+    // Atomic compare-and-set: only mark used if still unused — prevents token replay under concurrency
+    const affected = await this.em.nativeUpdate(
+      PasswordReset,
+      { id: row.id, usedAt: null },
+      { usedAt: now },
+    )
+    if (affected === 0) return null
+
     const user = await findOneWithDecryption(this.em, User, { id: row.user.id, deletedAt: null })
     if (!user) return null
     user.passwordHash = await hash(newPassword, 10)
-    row.usedAt = new Date()
     await this.em.flush()
     await this.deleteAllUserSessions(String(user.id))
     return user

--- a/packages/core/src/modules/sales/api/__tests__/quotes.acceptance.test.ts
+++ b/packages/core/src/modules/sales/api/__tests__/quotes.acceptance.test.ts
@@ -10,12 +10,13 @@ import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
 
 const mockCommandBus = { execute: jest.fn() }
 const mockRateLimiterService = { trustProxyDepth: 1, consume: jest.fn() }
-const mockEm = {
+const mockEm: Record<string, jest.Mock> = {
   fork: jest.fn(),
   findOne: jest.fn(),
   find: jest.fn(),
   persist: jest.fn(),
   flush: jest.fn(),
+  transactional: jest.fn().mockImplementation(async (callback: (trx: any) => Promise<unknown>) => callback(mockEm)),
 }
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
@@ -535,5 +536,60 @@ describe('quote editing invalidates sent token', () => {
     expect(quote.acceptanceToken).toBeNull()
     expect(quote.sentAt).toBeNull()
     expect(quote.status).toBe('draft')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Regression: quote double-acceptance prevention — no non-transactional fallback (issue #1414)
+// ---------------------------------------------------------------------------
+
+describe('accept - always uses em.transactional (no fallback)', () => {
+  const ACCEPTANCE_TOKEN = '00000000-0000-4000-8000-0000000014a0'
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    mockEm.fork.mockReturnValue(mockEm)
+    mockRateLimiterService.consume.mockResolvedValue({ allowed: true, remainingPoints: 9, msBeforeNext: 0 })
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    const { getCachedRateLimiterService } = await import('@open-mercato/core/bootstrap')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue(null)
+    ;(getCachedRateLimiterService as jest.Mock).mockReturnValue(mockRateLimiterService)
+  })
+
+  test('accept calls em.transactional unconditionally — no non-transactional fallback path', async () => {
+    const quote = {
+      id: '99999999-9999-4999-8999-999999999999',
+      tenantId: '00000000-0000-4000-8000-000000000000',
+      organizationId: '11111111-1111-4111-8111-111111111111',
+      quoteNumber: 'SQ-TX-1',
+      status: 'sent',
+      statusEntryId: null,
+      validUntil: new Date(Date.now() + 60_000),
+      updatedAt: new Date(),
+    }
+
+    let transactionalUsed = false
+    mockEm.transactional = jest.fn(async (callback: (trx: any) => Promise<unknown>) => {
+      transactionalUsed = true
+      return callback(mockEm)
+    }) as any
+
+    mockEm.findOne.mockImplementation(async (cls: any) => {
+      if (cls === SalesQuote) return quote
+      if (cls === Dictionary) return { id: 'dict-1' }
+      if (cls === DictionaryEntry) return { id: 'entry-confirmed' }
+      if (cls === SalesOrder) return { id: 'order-tx-1', orderNumber: 'SO-TX-1', deletedAt: null }
+      return null
+    })
+    mockCommandBus.execute.mockResolvedValue({ result: { orderId: 'order-tx-1' } })
+
+    const res = await acceptQuote(makeAcceptRequest({ token: ACCEPTANCE_TOKEN }))
+    expect(res.status).toBe(200)
+    expect(transactionalUsed).toBe(true)
+    expect(mockEm.findOne).not.toHaveBeenCalledWith(
+      SalesQuote,
+      expect.anything(),
+      expect.not.objectContaining({ lockMode: LockMode.PESSIMISTIC_WRITE })
+    )
   })
 })

--- a/packages/core/src/modules/sales/api/quotes/accept/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/accept/route.ts
@@ -64,14 +64,10 @@ export async function POST(req: Request) {
     const container = await createRequestContainer()
     const em = (container.resolve('em') as EntityManager).fork()
 
-    const transactionalEm = em as EntityManager & {
-      transactional?: <TResult>(callback: (trx: EntityManager) => Promise<TResult>) => Promise<TResult>
-    }
-
     const hashedToken = hashAuthToken(token)
     const tenantScope = auth?.tenantId ? { tenantId: auth.tenantId } : undefined
 
-    const acceptQuote = async (trx: EntityManager) => {
+    const quote = await em.transactional(async (trx) => {
       const findQuoteByToken = (acceptanceToken: string) =>
         findOneWithDecryption(
           trx,
@@ -111,11 +107,7 @@ export async function POST(req: Request) {
       await trx.flush()
 
       return quote
-    }
-
-    const quote = typeof transactionalEm.transactional === 'function'
-      ? await transactionalEm.transactional((trx) => acceptQuote(trx))
-      : await acceptQuote(em)
+    })
 
     const commandBus = container.resolve('commandBus') as CommandBus
     const ctx: CommandRuntimeContext = {

--- a/packages/core/src/modules/sales/commands/__tests__/payments.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/payments.test.ts
@@ -69,6 +69,10 @@ function buildMockEm(overrides: Record<string, unknown> = {}) {
     remove: jest.fn(),
     flush: jest.fn().mockResolvedValue(undefined),
     getReference: jest.fn().mockImplementation((_entity: unknown, id: unknown) => ({ id })),
+    transactional: jest.fn().mockImplementation(async (callback: (tx: any) => Promise<any>) => {
+      const self = buildMockEm(overrides)
+      return callback(self)
+    }),
     ...overrides,
   }
 }
@@ -413,5 +417,71 @@ describe('createPaymentCommand.undo — tenant-scoped SalesOrder lookup', () => 
       tenantId: TEST_TENANT_ID,
       organizationId: TEST_ORG_ID,
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Regression: payment balance corruption — transaction wrapping (issue #1414)
+// ---------------------------------------------------------------------------
+
+describe('createPaymentCommand.execute — transaction wrapping for race condition prevention', () => {
+  beforeEach(() => {
+    ;(findOneWithDecryption as jest.Mock).mockClear()
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValue(null)
+    ;(findWithDecryption as jest.Mock).mockClear()
+    ;(findWithDecryption as jest.Mock).mockResolvedValue([])
+  })
+
+  it('wraps order lookup and payment creation in em.transactional()', async () => {
+    const execute = commandRegistry.get('sales.payments.create')?.execute
+    expect(execute).toBeInstanceOf(Function)
+
+    let transactionalCalled = false
+    const mockOrder = {
+      id: TEST_ORDER_ID,
+      tenantId: TEST_TENANT_ID,
+      organizationId: TEST_ORG_ID,
+      deletedAt: null,
+      currencyCode: 'USD',
+      paymentMethodId: null,
+      paymentMethodCode: null,
+      orderNumber: 'ORD-001',
+      grandTotalGrossAmount: '100',
+      paidTotalAmount: '0',
+      refundedTotalAmount: '0',
+      outstandingAmount: '100',
+    }
+
+    const innerEm = buildMockEm({
+      transactional: jest.fn().mockImplementation(async (callback: (tx: any) => Promise<any>) => {
+        transactionalCalled = true
+        const txEm = buildMockEm()
+        ;(findOneWithDecryption as jest.Mock).mockResolvedValueOnce(mockOrder)
+        return callback(txEm)
+      }),
+    })
+
+    const container = {
+      resolve: jest.fn().mockImplementation((name: string) => {
+        if (name === 'em') return { fork: jest.fn().mockReturnValue(innerEm) }
+        if (name === 'dataEngine') return {}
+        return {}
+      }),
+    }
+    const ctx = {
+      container,
+      auth: { tenantId: TEST_TENANT_ID, orgId: TEST_ORG_ID },
+      selectedOrganizationId: TEST_ORG_ID,
+      organizationIds: [TEST_ORG_ID],
+      request: {} as Request,
+      organizationScope: null,
+    }
+
+    await execute?.(
+      { orderId: TEST_ORDER_ID, tenantId: TEST_TENANT_ID, organizationId: TEST_ORG_ID, amount: 50, currencyCode: 'USD' },
+      ctx as any,
+    )
+
+    expect(transactionalCalled).toBe(true)
   })
 })

--- a/packages/core/src/modules/sales/commands/__tests__/shipments.race-conditions.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/shipments.race-conditions.test.ts
@@ -1,0 +1,211 @@
+/** @jest-environment node */
+
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { LockMode } from '@mikro-orm/core'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn().mockResolvedValue(null),
+  findWithDecryption: jest.fn().mockResolvedValue([]),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn().mockResolvedValue({}),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => ({
+  emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@open-mercato/core/modules/entities/lib/helpers', () => ({
+  setRecordCustomFields: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../../lib/dictionaries', () => ({
+  resolveDictionaryEntryValue: jest.fn().mockResolvedValue(null),
+}))
+
+jest.mock('../../lib/shipments/snapshots', () => ({
+  coerceShipmentQuantity: (v: unknown) => (typeof v === 'number' ? v : Number(v) || 0),
+  readShipmentItemsSnapshot: jest.fn().mockReturnValue([]),
+  refreshShipmentItemsSnapshot: jest.fn().mockResolvedValue(undefined),
+  buildShipmentItemSnapshots: jest.fn().mockReturnValue([]),
+}))
+
+const TEST_TENANT_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+const TEST_ORG_ID = 'bbbbbbbb-bbbb-4bbb-abbb-bbbbbbbbbbbb'
+const TEST_ORDER_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const TEST_LINE_ID = 'dddddddd-dddd-4ddd-9ddd-dddddddddddd'
+
+function buildMockTx() {
+  return {
+    findOne: jest.fn().mockResolvedValue(null),
+    find: jest.fn().mockResolvedValue([]),
+    create: jest.fn().mockImplementation((_entity: unknown, data: Record<string, unknown>) => ({
+      ...data,
+      id: data.id ?? 'new-shipment-id',
+    })),
+    persist: jest.fn(),
+    remove: jest.fn(),
+    flush: jest.fn().mockResolvedValue(undefined),
+    getReference: jest.fn().mockImplementation((_entity: unknown, id: unknown) => ({ id })),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Regression: shipment over-fulfillment — order lines locked during validation (issue #1414)
+// ---------------------------------------------------------------------------
+
+describe('createShipmentCommand — order line locking for race condition prevention', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../shipments')
+  })
+
+  beforeEach(() => {
+    ;(findOneWithDecryption as jest.Mock).mockClear()
+    ;(findWithDecryption as jest.Mock).mockClear()
+  })
+
+  it('validateShipmentItems acquires PESSIMISTIC_WRITE lock on order lines', async () => {
+    const execute = commandRegistry.get('sales.shipments.create')?.execute
+    expect(execute).toBeInstanceOf(Function)
+
+    const mockOrder = {
+      id: TEST_ORDER_ID,
+      tenantId: TEST_TENANT_ID,
+      organizationId: TEST_ORG_ID,
+      deletedAt: null,
+    }
+
+    const mockLine = {
+      id: TEST_LINE_ID,
+      quantity: '100',
+      fulfilledQuantity: '0',
+    }
+
+    const tx = buildMockTx()
+    // loadOrder uses raw em.findOne — need to return the order
+    tx.findOne.mockResolvedValue(mockOrder)
+    const em = {
+      ...buildMockTx(),
+      transactional: jest.fn().mockImplementation(async (callback: (trx: any) => Promise<any>) => {
+        ;(findWithDecryption as jest.Mock)
+          .mockResolvedValueOnce([mockLine]) // order lines query (with lock)
+          .mockResolvedValueOnce([]) // loadShippedTotals: shipments
+          .mockResolvedValueOnce([]) // recomputeFulfilledQuantities: shipments
+          .mockResolvedValueOnce([]) // recomputeFulfilledQuantities: shipment items
+          .mockResolvedValueOnce([mockLine]) // recomputeFulfilledQuantities: order lines (with lock)
+        return callback(tx)
+      }),
+    }
+
+    const container = {
+      resolve: jest.fn().mockImplementation((name: string) => {
+        if (name === 'em') return { fork: jest.fn().mockReturnValue(em) }
+        if (name === 'dataEngine') return {}
+        return {}
+      }),
+    }
+    const ctx = {
+      container,
+      auth: { tenantId: TEST_TENANT_ID, orgId: TEST_ORG_ID },
+      selectedOrganizationId: TEST_ORG_ID,
+      organizationIds: [TEST_ORG_ID],
+      request: {} as Request,
+      organizationScope: null,
+    }
+
+    await execute?.(
+      {
+        orderId: TEST_ORDER_ID,
+        tenantId: TEST_TENANT_ID,
+        organizationId: TEST_ORG_ID,
+        items: [{ orderLineId: TEST_LINE_ID, quantity: 10 }],
+      },
+      ctx as any,
+    )
+
+    // Verify findWithDecryption was called with PESSIMISTIC_WRITE lock for order lines
+    const orderLinesCall = (findWithDecryption as jest.Mock).mock.calls.find(
+      (args: unknown[]) => {
+        const opts = args[3] as Record<string, unknown> | undefined
+        return opts?.lockMode === LockMode.PESSIMISTIC_WRITE
+      }
+    )
+    expect(orderLinesCall).toBeDefined()
+  })
+
+  it('recomputeFulfilledQuantities uses findWithDecryption instead of raw em.find', async () => {
+    const execute = commandRegistry.get('sales.shipments.create')?.execute
+    expect(execute).toBeInstanceOf(Function)
+
+    const mockOrder = {
+      id: TEST_ORDER_ID,
+      tenantId: TEST_TENANT_ID,
+      organizationId: TEST_ORG_ID,
+      deletedAt: null,
+    }
+
+    const mockLine = {
+      id: TEST_LINE_ID,
+      quantity: '50',
+      fulfilledQuantity: '0',
+    }
+
+    const tx = buildMockTx()
+    tx.findOne.mockResolvedValue(mockOrder)
+    const em = {
+      ...buildMockTx(),
+      transactional: jest.fn().mockImplementation(async (callback: (trx: any) => Promise<any>) => {
+        ;(findWithDecryption as jest.Mock)
+          .mockResolvedValueOnce([mockLine]) // order lines query
+          .mockResolvedValueOnce([]) // loadShippedTotals: shipments
+          .mockResolvedValueOnce([]) // recomputeFulfilledQuantities: shipments
+          .mockResolvedValueOnce([]) // recomputeFulfilledQuantities: shipment items
+          .mockResolvedValueOnce([mockLine]) // recomputeFulfilledQuantities: order lines
+        return callback(tx)
+      }),
+    }
+
+    const container = {
+      resolve: jest.fn().mockImplementation((name: string) => {
+        if (name === 'em') return { fork: jest.fn().mockReturnValue(em) }
+        if (name === 'dataEngine') return {}
+        return {}
+      }),
+    }
+    const ctx = {
+      container,
+      auth: { tenantId: TEST_TENANT_ID, orgId: TEST_ORG_ID },
+      selectedOrganizationId: TEST_ORG_ID,
+      organizationIds: [TEST_ORG_ID],
+      request: {} as Request,
+      organizationScope: null,
+    }
+
+    await execute?.(
+      {
+        orderId: TEST_ORDER_ID,
+        tenantId: TEST_TENANT_ID,
+        organizationId: TEST_ORG_ID,
+        items: [{ orderLineId: TEST_LINE_ID, quantity: 5 }],
+      },
+      ctx as any,
+    )
+
+    // No raw em.find should have been called on the transaction EM
+    expect(tx.find).not.toHaveBeenCalled()
+    // findWithDecryption should have been used for all queries
+    expect((findWithDecryption as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/packages/core/src/modules/sales/commands/payments.ts
+++ b/packages/core/src/modules/sales/commands/payments.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 
 import { registerCommand, type CommandHandler } from '@open-mercato/shared/lib/commands'
+import { LockMode } from '@mikro-orm/core'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
@@ -244,10 +245,15 @@ export async function restorePaymentSnapshot(em: EntityManager, snapshot: Paymen
 
 async function recomputeOrderPaymentTotals(
   em: EntityManager,
-  order: SalesOrder
+  order: SalesOrder,
+  options?: { lock?: boolean }
 ): Promise<{ paidTotalAmount: number; refundedTotalAmount: number; outstandingAmount: number }> {
   const orderId = order.id
   const scope = { organizationId: order.organizationId, tenantId: order.tenantId }
+
+  if (options?.lock) {
+    await em.findOne(SalesOrder, { id: orderId }, { lockMode: LockMode.PESSIMISTIC_WRITE })
+  }
 
   const allocations = await findWithDecryption(
     em,
@@ -326,128 +332,133 @@ const createPaymentCommand: CommandHandler<
     if (!input.orderId) {
       throw new CrudHttpError(400, { error: translate('sales.payments.order_required', 'Order is required for payments.') })
     }
-    const order = assertFound(
-      await findOneWithDecryption(em, SalesOrder, { id: input.orderId }, {}, { tenantId: input.tenantId, organizationId: input.organizationId }),
-      'sales.payments.order_not_found'
-    )
-    ensureSameScope(order, input.organizationId, input.tenantId)
-    if (order.deletedAt) {
-      throw new CrudHttpError(404, { error: 'sales.payments.order_not_found' })
-    }
-    if (
-      order.currencyCode &&
-      input.currencyCode &&
-      order.currencyCode.toUpperCase() !== input.currencyCode.toUpperCase()
-    ) {
-      throw new CrudHttpError(400, {
-        error: translate('sales.payments.currency_mismatch', 'Payment currency must match the order currency.'),
-      })
-    }
-    let paymentMethod = null
-    if (input.paymentMethodId) {
-      const method = assertFound(
-        await findOneWithDecryption(em, SalesPaymentMethod, { id: input.paymentMethodId }, {}, { tenantId: input.tenantId, organizationId: input.organizationId }),
-        'sales.payments.method_not_found'
+
+    const { payment, order, totals, orderPaymentMethodIdBefore, orderPaymentMethodCodeBefore } = await em.transactional(async (tx) => {
+      const order = assertFound(
+        await findOneWithDecryption(tx, SalesOrder, { id: input.orderId }, { lockMode: LockMode.PESSIMISTIC_WRITE }, { tenantId: input.tenantId, organizationId: input.organizationId }),
+        'sales.payments.order_not_found'
       )
-      ensureSameScope(method, input.organizationId, input.tenantId)
-      paymentMethod = method
-    }
-    const orderPaymentMethodIdBefore = order.paymentMethodId ?? null
-    const orderPaymentMethodCodeBefore = order.paymentMethodCode ?? null
-    if (paymentMethod && !order.paymentMethodId) {
-      order.paymentMethodId = paymentMethod.id
-      order.paymentMethodCode = paymentMethod.code ?? null
-      order.updatedAt = new Date()
-      em.persist(order)
-    }
-    if (input.documentStatusEntryId !== undefined) {
-      const orderStatus = await resolveDictionaryEntryValue(em, input.documentStatusEntryId ?? null)
-      if (input.documentStatusEntryId && !orderStatus) {
+      ensureSameScope(order, input.organizationId, input.tenantId)
+      if (order.deletedAt) {
+        throw new CrudHttpError(404, { error: 'sales.payments.order_not_found' })
+      }
+      if (
+        order.currencyCode &&
+        input.currencyCode &&
+        order.currencyCode.toUpperCase() !== input.currencyCode.toUpperCase()
+      ) {
         throw new CrudHttpError(400, {
-          error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.'),
+          error: translate('sales.payments.currency_mismatch', 'Payment currency must match the order currency.'),
         })
       }
-      order.statusEntryId = input.documentStatusEntryId ?? null
-      order.status = orderStatus
-      order.updatedAt = new Date()
-      em.persist(order)
-    }
-    if (input.lineStatusEntryId !== undefined) {
-      const lineStatus = await resolveDictionaryEntryValue(em, input.lineStatusEntryId ?? null)
-      if (input.lineStatusEntryId && !lineStatus) {
-        throw new CrudHttpError(400, {
-          error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.'),
+      let paymentMethod = null
+      if (input.paymentMethodId) {
+        const method = assertFound(
+          await findOneWithDecryption(tx, SalesPaymentMethod, { id: input.paymentMethodId }, {}, { tenantId: input.tenantId, organizationId: input.organizationId }),
+          'sales.payments.method_not_found'
+        )
+        ensureSameScope(method, input.organizationId, input.tenantId)
+        paymentMethod = method
+      }
+      const orderPaymentMethodIdBefore = order.paymentMethodId ?? null
+      const orderPaymentMethodCodeBefore = order.paymentMethodCode ?? null
+      if (paymentMethod && !order.paymentMethodId) {
+        order.paymentMethodId = paymentMethod.id
+        order.paymentMethodCode = paymentMethod.code ?? null
+        order.updatedAt = new Date()
+        tx.persist(order)
+      }
+      if (input.documentStatusEntryId !== undefined) {
+        const orderStatus = await resolveDictionaryEntryValue(tx, input.documentStatusEntryId ?? null)
+        if (input.documentStatusEntryId && !orderStatus) {
+          throw new CrudHttpError(400, {
+            error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.'),
+          })
+        }
+        order.statusEntryId = input.documentStatusEntryId ?? null
+        order.status = orderStatus
+        order.updatedAt = new Date()
+        tx.persist(order)
+      }
+      if (input.lineStatusEntryId !== undefined) {
+        const lineStatus = await resolveDictionaryEntryValue(tx, input.lineStatusEntryId ?? null)
+        if (input.lineStatusEntryId && !lineStatus) {
+          throw new CrudHttpError(400, {
+            error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.'),
+          })
+        }
+        const orderLines = await findWithDecryption(tx, SalesOrderLine, { order }, {}, { tenantId: input.tenantId, organizationId: input.organizationId })
+        orderLines.forEach((line) => {
+          line.statusEntryId = input.lineStatusEntryId ?? null
+          line.status = lineStatus
+          line.updatedAt = new Date()
+        })
+        orderLines.forEach((line) => tx.persist(line))
+      }
+      const status = await resolveDictionaryEntryValue(tx, input.statusEntryId ?? null)
+      const payment = tx.create(SalesPayment, {
+        organizationId: input.organizationId,
+        tenantId: input.tenantId,
+        order,
+        paymentMethod,
+        paymentReference: input.paymentReference ?? null,
+        statusEntryId: input.statusEntryId ?? null,
+        status,
+        amount: toNumericString(input.amount) ?? '0',
+        currencyCode: input.currencyCode,
+        capturedAmount: toNumericString(input.capturedAmount) ?? '0',
+        refundedAmount: toNumericString(input.refundedAmount) ?? '0',
+        receivedAt: input.receivedAt ?? null,
+        capturedAt: input.capturedAt ?? null,
+        metadata: input.metadata ? cloneJson(input.metadata) : null,
+        customFieldSetId: input.customFieldSetId ?? null,
+      })
+      const allocationInputs = Array.isArray(input.allocations) ? input.allocations : []
+      const allocations = allocationInputs.length
+        ? allocationInputs
+        : [
+            {
+              orderId: input.orderId,
+              invoiceId: null,
+              amount: input.amount,
+              currencyCode: input.currencyCode,
+              metadata: null,
+            },
+          ]
+      allocations.forEach((allocation) => {
+        const orderRef = allocation.orderId ? tx.getReference(SalesOrder, allocation.orderId) : order
+        const invoiceRef = allocation.invoiceId ? tx.getReference(SalesInvoice, allocation.invoiceId) : null
+        const entity = tx.create(SalesPaymentAllocation, {
+          payment,
+          order: orderRef,
+          invoice: invoiceRef,
+          organizationId: input.organizationId,
+          tenantId: input.tenantId,
+          amount: toNumericString(allocation.amount) ?? '0',
+          currencyCode: allocation.currencyCode,
+          metadata: allocation.metadata ? cloneJson(allocation.metadata) : null,
+        })
+        tx.persist(entity)
+      })
+      tx.persist(payment)
+      if (input.customFields !== undefined) {
+        if (!payment.id) {
+          await tx.flush()
+        }
+        await setRecordCustomFields(tx, {
+          entityId: E.sales.sales_payment,
+          recordId: payment.id,
+          organizationId: input.organizationId,
+          tenantId: input.tenantId,
+          values: normalizeCustomFieldsInput(input.customFields),
         })
       }
-      const orderLines = await findWithDecryption(em, SalesOrderLine, { order }, {}, { tenantId: input.tenantId, organizationId: input.organizationId })
-      orderLines.forEach((line) => {
-        line.statusEntryId = input.lineStatusEntryId ?? null
-        line.status = lineStatus
-        line.updatedAt = new Date()
-      })
-      orderLines.forEach((line) => em.persist(line))
-    }
-    const status = await resolveDictionaryEntryValue(em, input.statusEntryId ?? null)
-    const payment = em.create(SalesPayment, {
-      organizationId: input.organizationId,
-      tenantId: input.tenantId,
-      order,
-      paymentMethod,
-      paymentReference: input.paymentReference ?? null,
-      statusEntryId: input.statusEntryId ?? null,
-      status,
-      amount: toNumericString(input.amount) ?? '0',
-      currencyCode: input.currencyCode,
-      capturedAmount: toNumericString(input.capturedAmount) ?? '0',
-      refundedAmount: toNumericString(input.refundedAmount) ?? '0',
-      receivedAt: input.receivedAt ?? null,
-      capturedAt: input.capturedAt ?? null,
-      metadata: input.metadata ? cloneJson(input.metadata) : null,
-      customFieldSetId: input.customFieldSetId ?? null,
+      await tx.flush()
+      const totals = await recomputeOrderPaymentTotals(tx, order)
+      await tx.flush()
+      return { payment, order, totals, orderPaymentMethodIdBefore, orderPaymentMethodCodeBefore }
     })
-    const allocationInputs = Array.isArray(input.allocations) ? input.allocations : []
-    const allocations = allocationInputs.length
-      ? allocationInputs
-      : [
-          {
-            orderId: input.orderId,
-            invoiceId: null,
-            amount: input.amount,
-            currencyCode: input.currencyCode,
-            metadata: null,
-          },
-        ]
-    allocations.forEach((allocation) => {
-      const orderRef = allocation.orderId ? em.getReference(SalesOrder, allocation.orderId) : order
-      const invoiceRef = allocation.invoiceId ? em.getReference(SalesInvoice, allocation.invoiceId) : null
-      const entity = em.create(SalesPaymentAllocation, {
-        payment,
-        order: orderRef,
-        invoice: invoiceRef,
-        organizationId: input.organizationId,
-        tenantId: input.tenantId,
-        amount: toNumericString(allocation.amount) ?? '0',
-        currencyCode: allocation.currencyCode,
-        metadata: allocation.metadata ? cloneJson(allocation.metadata) : null,
-      })
-      em.persist(entity)
-    })
-    em.persist(payment)
-    if (input.customFields !== undefined) {
-      if (!payment.id) {
-        await em.flush()
-      }
-      await setRecordCustomFields(em, {
-        entityId: E.sales.sales_payment,
-        recordId: payment.id,
-        organizationId: input.organizationId,
-        tenantId: input.tenantId,
-        values: normalizeCustomFieldsInput(input.customFields),
-      })
-    }
-    await em.flush()
-    const totals = await recomputeOrderPaymentTotals(em, order)
-    await em.flush()
+
     await invalidateOrderCache(ctx.container, order, ctx.auth?.tenantId ?? null)
 
     const dataEngine = ctx.container.resolve('dataEngine') as DataEngine
@@ -549,16 +560,18 @@ const createPaymentCommand: CommandHandler<
         )
       )
       for (const id of orderIds) {
-        const order = await findOneWithDecryption(em, SalesOrder, { id }, {}, { tenantId: after.tenantId, organizationId: after.organizationId })
-        if (!order) continue
-        if (id === after.orderId && 'orderPaymentMethodIdBefore' in (payload ?? {})) {
-          order.paymentMethodId = payload.orderPaymentMethodIdBefore ?? null
-          order.paymentMethodCode = payload.orderPaymentMethodCodeBefore ?? null
-          order.updatedAt = new Date()
-          await em.flush()
-        }
-        await recomputeOrderPaymentTotals(em, order)
-        await em.flush()
+        await em.transactional(async (tx) => {
+          const order = await findOneWithDecryption(tx, SalesOrder, { id }, { lockMode: LockMode.PESSIMISTIC_WRITE }, { tenantId: after.tenantId, organizationId: after.organizationId })
+          if (!order) return
+          if (id === after.orderId && 'orderPaymentMethodIdBefore' in (payload ?? {})) {
+            order.paymentMethodId = payload.orderPaymentMethodIdBefore ?? null
+            order.paymentMethodCode = payload.orderPaymentMethodCodeBefore ?? null
+            order.updatedAt = new Date()
+            await tx.flush()
+          }
+          await recomputeOrderPaymentTotals(tx, order)
+          await tx.flush()
+        })
       }
     }
   },
@@ -734,20 +747,30 @@ const updatePaymentCommand: CommandHandler<
       await em.flush()
     }
 
-    const nextOrder =
-      (payment.order as SalesOrder | null) ??
-      (typeof payment.order === 'string'
-        ? await findOneWithDecryption(em, SalesOrder, { id: payment.order }, {}, { tenantId: resolvedTenantId, organizationId: resolvedOrganizationId })
-        : null)
+    const nextOrderId =
+      (payment.order as SalesOrder | null)?.id ??
+      (typeof payment.order === 'string' ? payment.order : null)
     let totals: { paidTotalAmount: number; refundedTotalAmount: number; outstandingAmount: number } | undefined
-    if (nextOrder) {
-      totals = await recomputeOrderPaymentTotals(em, nextOrder)
-      await em.flush()
-      await invalidateOrderCache(ctx.container, nextOrder, ctx.auth?.tenantId ?? null)
+    if (nextOrderId) {
+      totals = await em.transactional(async (tx) => {
+        const lockedOrder = await tx.findOne(SalesOrder, { id: nextOrderId }, { lockMode: LockMode.PESSIMISTIC_WRITE })
+        if (!lockedOrder) return undefined
+        const result = await recomputeOrderPaymentTotals(tx, lockedOrder)
+        await tx.flush()
+        return result
+      })
+      if (totals) {
+        const nextOrder = await em.findOne(SalesOrder, { id: nextOrderId })
+        if (nextOrder) await invalidateOrderCache(ctx.container, nextOrder, ctx.auth?.tenantId ?? null)
+      }
     }
-    if (previousOrder && (!nextOrder || previousOrder.id !== nextOrder.id)) {
-      await recomputeOrderPaymentTotals(em, previousOrder)
-      await em.flush()
+    if (previousOrder && (!nextOrderId || previousOrder.id !== nextOrderId)) {
+      await em.transactional(async (tx) => {
+        const lockedOrder = await tx.findOne(SalesOrder, { id: previousOrder.id }, { lockMode: LockMode.PESSIMISTIC_WRITE })
+        if (!lockedOrder) return
+        await recomputeOrderPaymentTotals(tx, lockedOrder)
+        await tx.flush()
+      })
       await invalidateOrderCache(ctx.container, previousOrder, ctx.auth?.tenantId ?? null)
     }
 
@@ -797,11 +820,12 @@ const updatePaymentCommand: CommandHandler<
     await restorePaymentSnapshot(em, before)
     await em.flush()
     if (before.orderId) {
-      const order = await findOneWithDecryption(em, SalesOrder, { id: before.orderId }, {}, { tenantId: before.tenantId, organizationId: before.organizationId })
-      if (order) {
-        await recomputeOrderPaymentTotals(em, order)
-        await em.flush()
-      }
+      await em.transactional(async (tx) => {
+        const order = await findOneWithDecryption(tx, SalesOrder, { id: before.orderId! }, { lockMode: LockMode.PESSIMISTIC_WRITE }, { tenantId: before.tenantId, organizationId: before.organizationId })
+        if (!order) return
+        await recomputeOrderPaymentTotals(tx, order)
+        await tx.flush()
+      })
     }
   },
 }
@@ -863,14 +887,18 @@ const deletePaymentCommand: CommandHandler<
     )
     const primaryOrderId = order && typeof order === 'object' ? order.id : null
     for (const orderId of orderIds) {
-      const target = typeof order === 'object' && order.id === orderId ? order : await findOneWithDecryption(em, SalesOrder, { id: orderId }, {}, { tenantId: payment.tenantId, organizationId: payment.organizationId })
-      if (!target) continue
-      const recomputed = await recomputeOrderPaymentTotals(em, target)
-      if (!totals || (primaryOrderId && orderId === primaryOrderId)) {
+      const recomputed = await em.transactional(async (tx) => {
+        const lockedOrder = await tx.findOne(SalesOrder, { id: orderId }, { lockMode: LockMode.PESSIMISTIC_WRITE })
+        if (!lockedOrder) return undefined
+        const result = await recomputeOrderPaymentTotals(tx, lockedOrder)
+        await tx.flush()
+        return result
+      })
+      if (recomputed && (!totals || (primaryOrderId && orderId === primaryOrderId))) {
         totals = recomputed
       }
-      await em.flush()
-      await invalidateOrderCache(ctx.container, target, ctx.auth?.tenantId ?? null)
+      const target = await em.findOne(SalesOrder, { id: orderId })
+      if (target) await invalidateOrderCache(ctx.container, target, ctx.auth?.tenantId ?? null)
     }
     const dataEngine = ctx.container.resolve('dataEngine') as DataEngine
     await emitCrudSideEffects({
@@ -927,11 +955,12 @@ const deletePaymentCommand: CommandHandler<
     await restorePaymentSnapshot(em, before)
     await em.flush()
     if (before.orderId) {
-      const order = await findOneWithDecryption(em, SalesOrder, { id: before.orderId }, {}, { tenantId: before.tenantId, organizationId: before.organizationId })
-      if (order) {
-        await recomputeOrderPaymentTotals(em, order)
-        await em.flush()
-      }
+      await em.transactional(async (tx) => {
+        const order = await findOneWithDecryption(tx, SalesOrder, { id: before.orderId! }, { lockMode: LockMode.PESSIMISTIC_WRITE }, { tenantId: before.tenantId, organizationId: before.organizationId })
+        if (!order) return
+        await recomputeOrderPaymentTotals(tx, order)
+        await tx.flush()
+      })
     }
   },
 }

--- a/packages/core/src/modules/sales/commands/shipments.ts
+++ b/packages/core/src/modules/sales/commands/shipments.ts
@@ -34,7 +34,7 @@ import { resolveDictionaryEntryValue } from '../lib/dictionaries'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import { emitCrudSideEffects } from '@open-mercato/shared/lib/commands/helpers'
 import type { CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
-import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 const shipmentCrudEvents: CrudEventsConfig = {
   module: 'sales',
@@ -298,17 +298,19 @@ export async function restoreShipmentSnapshot(em: EntityManager, snapshot: Shipm
 }
 
 async function deleteShipmentWithItems(em: EntityManager, shipment: SalesShipment): Promise<void> {
-  const items = await em.find(SalesShipmentItem, { shipment })
+  const scope = { tenantId: shipment.tenantId, organizationId: shipment.organizationId }
+  const items = await findWithDecryption(em, SalesShipmentItem, { shipment }, {}, scope)
   items.forEach((item) => em.remove(item))
   em.remove(shipment)
   await em.flush()
 }
 
 async function recomputeFulfilledQuantities(em: EntityManager, order: SalesOrder): Promise<void> {
-  const shipments = await em.find(SalesShipment, { order, deletedAt: null })
+  const scope = { tenantId: order.tenantId, organizationId: order.organizationId }
+  const shipments = await findWithDecryption(em, SalesShipment, { order, deletedAt: null }, {}, scope)
   const shipmentIds = shipments.map((entry) => entry.id)
   const shipmentItems = shipmentIds.length
-    ? await em.find(SalesShipmentItem, { shipment: { $in: shipmentIds } })
+    ? await findWithDecryption(em, SalesShipmentItem, { shipment: { $in: shipmentIds } }, {}, scope)
     : []
   const totals = shipmentItems.reduce<Map<string, number>>((acc, item) => {
     const lineId =
@@ -320,7 +322,7 @@ async function recomputeFulfilledQuantities(em: EntityManager, order: SalesOrder
     acc.set(lineId, next)
     return acc
   }, new Map())
-  const lines = await em.find(SalesOrderLine, { order })
+  const lines = await findWithDecryption(em, SalesOrderLine, { order }, { lockMode: LockMode.PESSIMISTIC_WRITE }, scope)
   lines.forEach((line) => {
     const shipped = totals.get(line.id) ?? 0
     line.fulfilledQuantity = shipped.toString()
@@ -338,12 +340,13 @@ async function loadShippedTotals(
   order: SalesOrder,
   excludeShipmentId?: string | null
 ): Promise<Map<string, number>> {
-  const shipments = await em.find(SalesShipment, { order, deletedAt: null })
+  const scope = { tenantId: order.tenantId, organizationId: order.organizationId }
+  const shipments = await findWithDecryption(em, SalesShipment, { order, deletedAt: null }, {}, scope)
   const shipmentIds = shipments
     .map((entry) => entry.id)
     .filter((id) => !excludeShipmentId || id !== excludeShipmentId)
   if (!shipmentIds.length) return new Map()
-  const items = await em.find(SalesShipmentItem, { shipment: { $in: shipmentIds } })
+  const items = await findWithDecryption(em, SalesShipmentItem, { shipment: { $in: shipmentIds } }, {}, scope)
   return items.reduce<Map<string, number>>((acc, item) => {
     const lineId =
       typeof item.orderLine === 'string'
@@ -371,10 +374,13 @@ async function validateShipmentItems(params: {
   if (!items || !items.length) {
     throw new CrudHttpError(400, { error: translate('sales.shipments.items_required', 'Add at least one line to ship.') })
   }
-  const orderLines = await em.find(
+  const scope = { tenantId: order.tenantId, organizationId: order.organizationId }
+  const orderLines = await findWithDecryption(
+    em,
     SalesOrderLine,
     { order },
-    lockOrderLines ? { lockMode: LockMode.PESSIMISTIC_WRITE } : undefined
+    lockOrderLines ? { lockMode: LockMode.PESSIMISTIC_WRITE } : undefined,
+    scope,
   )
   const lineMap = new Map(orderLines.map((line) => [line.id, line]))
   const shippedTotals = await loadShippedTotals(em, order, excludeShipmentId)


### PR DESCRIPTION
Fixes #1414

## Problem
Four critical race conditions in financial/security-sensitive operations allow data corruption under concurrent requests:
1. **Payment balance corruption** — concurrent payment creates/updates on the same order can corrupt `paidAmount`
2. **Quote double-acceptance** — concurrent accept requests can convert the same quote twice
3. **Shipment over-fulfillment** — concurrent shipment creates can exceed order line quantities
4. **Password reset token replay** — concurrent token usage can reset a password multiple times

## Root Cause
All four share a common pattern: load-check-write without database-level concurrency control. Application-level checks pass for both concurrent requests before either commits, allowing both to succeed.

## What Changed

### Payments (`commands/payments.ts`)
- Wrapped order lookup + payment creation in `em.transactional()` with `PESSIMISTIC_WRITE` lock on the order row
- Applied same transactional locking to update, delete commands and all undo handlers
- `recomputeOrderPaymentTotals` now accepts optional `lock` parameter

### Quotes (`api/quotes/accept/route.ts`)
- Removed the non-transactional fallback path (`typeof transactionalEm.transactional === 'function'` check)
- Quote acceptance now always runs inside `em.transactional()` with `PESSIMISTIC_WRITE` lock

### Shipments (`commands/shipments.ts`)
- Replaced all raw `em.find` calls with `findWithDecryption` (per AGENTS.md encryption rules)
- Added `PESSIMISTIC_WRITE` lock on order lines in `validateShipmentItems` and `recomputeFulfilledQuantities`

### Password Reset (`auth/services/authService.ts`)
- Replaced ORM-based `row.usedAt = new Date()` + `em.flush()` with atomic `nativeUpdate` using `WHERE usedAt IS NULL`
- Returns null (token already consumed) when `affected === 0` — classic compare-and-set pattern

## Tests
- **Auth**: 3 new tests — atomic nativeUpdate usage, zero-rows-affected handling, no ORM usedAt assignment
- **Payments**: 1 new test — verifies `em.transactional()` wrapping of order lock + payment creation
- **Quotes**: 1 new test — verifies `em.transactional` is called unconditionally (no fallback path)
- **Shipments**: 2 new tests (new file) — verifies `PESSIMISTIC_WRITE` lock on order lines, verifies `findWithDecryption` used instead of raw `em.find`
- All 45 targeted tests pass; full core suite 2761/2762 (1 pre-existing unrelated failure in `InlineEditors.test.tsx`)
- Typecheck passes with no errors

## Backward Compatibility
- No contract surface changes
- No API response field changes
- No event ID or widget spot changes
- Internal implementation changes only (locking strategy, query helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)