### PR TITLE
fix: 🔒 reliability: Search bulkIndex silently swallows strategy failures (#1424)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/lib/tool-search.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/tool-search.ts
@@ -204,7 +204,15 @@ export class ToolSearchService {
 
     // Bulk index using available strategies
     if (records.length > 0) {
-      await this.searchService.bulkIndex(records)
+      try {
+        await this.searchService.bulkIndex(records)
+      } catch (error) {
+        throw new Error(
+          `Failed to index ${records.length} tools: ${
+            error instanceof Error ? error.message : error
+          }`
+        )
+      }
     }
 
     // Update checksum

--- a/packages/search/src/__tests__/service.test.ts
+++ b/packages/search/src/__tests__/service.test.ts
@@ -306,6 +306,36 @@ describe('SearchService', () => {
       expect(strategy.bulkIndex).not.toHaveBeenCalled()
       expect(strategy.index).not.toHaveBeenCalled()
     })
+
+    it('should throw error when strategy bulkIndex fails', async () => {
+      const strategy = createMockStrategy({
+        id: 'failing-strategy',
+        bulkIndex: jest.fn().mockRejectedValue(new Error('Index strategy failed')),
+      })
+      const service = new SearchService({ strategies: [strategy] })
+      const records = [createMockRecord({ recordId: 'rec-1' })]
+
+      await expect(service.bulkIndex(records)).rejects.toThrow(
+        'Bulk indexing failed for 1 strategy(ies): failing-strategy (Index strategy failed)'
+      )
+    })
+
+    it('should throw error when multiple strategies fail', async () => {
+      const strategy1 = createMockStrategy({
+        id: 'failing1',
+        bulkIndex: jest.fn().mockRejectedValue(new Error('First failure')),
+      })
+      const strategy2 = createMockStrategy({
+        id: 'failing2',
+        bulkIndex: jest.fn().mockRejectedValue(new Error('Second failure')),
+      })
+      const service = new SearchService({ strategies: [strategy1, strategy2] })
+      const records = [createMockRecord({ recordId: 'rec-1' })]
+
+      await expect(service.bulkIndex(records)).rejects.toThrow(
+        'Bulk indexing failed for 2 strategy(ies): failing1 (First failure), failing2 (Second failure)'
+      )
+    })
   })
 
   describe('delete', () => {

--- a/packages/search/src/indexer/search-indexer.ts
+++ b/packages/search/src/indexer/search-indexer.ts
@@ -561,7 +561,15 @@ export class SearchIndexer {
     }
 
     if (indexableRecords.length > 0) {
-      await this.searchService.bulkIndex(indexableRecords)
+      try {
+        await this.searchService.bulkIndex(indexableRecords)
+      } catch (error) {
+        throw new Error(
+          `Failed to bulk index ${indexableRecords.length} records: ${
+            error instanceof Error ? error.message : error
+          }`
+        )
+      }
     }
   }
 

--- a/packages/search/src/service.ts
+++ b/packages/search/src/service.ts
@@ -234,17 +234,31 @@ export class SearchService {
       }),
     )
 
-    // Log any failures
+    // Collect failures and throw if any occurred
+    const failures: Array<{ strategyId: string; error: string }> = []
     for (let i = 0; i < results.length; i++) {
       const result = results[i]
       if (result.status === 'rejected') {
         const strategy = strategies[i]
+        const errorMessage = result.reason instanceof Error ? result.reason.message : result.reason
+        failures.push({
+          strategyId: strategy?.id || 'unknown',
+          error: errorMessage,
+        })
         searchError('SearchService', 'Strategy bulkIndex failed', {
           strategyId: strategy?.id,
           recordCount: records.length,
-          error: result.reason instanceof Error ? result.reason.message : result.reason,
+          error: errorMessage,
         })
       }
+    }
+
+    if (failures.length > 0) {
+      throw new Error(
+        `Bulk indexing failed for ${failures.length} strategy(ies): ${failures
+          .map((f) => `${f.strategyId} (${f.error})`)
+          .join(', ')}`
+      )
     }
   }
 


### PR DESCRIPTION
## Automated fix for #1424

Fixes #1424

> This PR was opened by [cezar](https://github.com/comerito/cezar) autofix. It is a **draft** — a human reviewer must verify correctness before it merges.

### Root cause
SearchService.bulkIndex silently swallows strategy failures instead of propagating them to callers

The bulkIndex method uses Promise.allSettled() at line 227-249 to execute indexing across multiple strategies. When strategies fail, the rejected promises are only logged via searchError() but never propagated to the caller. This causes partial indexing failures to be silently ignored, leading to inconsistent search indexes where some strategies succeed while others fail, with no upstream notification for retry logic.

### Approach
Changed bulkIndex() to throw descriptive errors when strategy failures occur instead of silently swallowing them. Updated all callers to handle the new exception behavior with proper try/catch blocks and descriptive error messages. Added comprehensive test coverage for both single and multiple strategy failure scenarios.

### Files changed
- `packages/search/src/service.ts`
- `packages/search/src/indexer/search-indexer.ts`
- `packages/ai-assistant/src/modules/ai_assistant/lib/tool-search.ts`
- `packages/search/src/__tests__/service.test.ts`

### Verification
Commands run by the fixer:
- `yarn test src/__tests__/service.test.ts`
- `yarn test --testNamePattern="bulkIndex" src/__tests__/service.test.ts`
- `npx turbo run typecheck --filter=@open-mercato/search`

### Review (automated)
**Verdict:** `pass`

Fix correctly addresses the root cause by converting silent failures to thrown exceptions. All direct callers are properly updated with try/catch handlers. Error messages are descriptive and preserve logging. The implementation is correct with proper null safety and array indexing.

Issues raised:
- **minor** `packages/search/src/__tests__/service.test.ts`:338: Missing test case for mixed scenario where one strategy succeeds and another fails. The code correctly throws, but this important edge case is not explicitly tested.

### Remaining concerns
_(none)_
