### PR TITLE
fix(auth): use forwarded headers for redirect URLs behind reverse proxies

### DIFF
--- a/packages/core/src/modules/auth/api/reset.ts
+++ b/packages/core/src/modules/auth/api/reset.ts
@@ -13,6 +13,7 @@ import { z } from 'zod'
 import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
 import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/config'
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
+import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 
 const resetRateLimitConfig = readEndpointRateLimitConfig('RESET', {
   points: 3, duration: 60, blockDuration: 60, keyPrefix: 'reset',
@@ -41,8 +42,7 @@ export async function POST(req: Request) {
   const resReq = await auth.requestPasswordReset(parsed.data.email)
   if (!resReq) return NextResponse.json({ ok: true })
   const { user, token } = resReq
-  const url = new URL(req.url)
-  const base = process.env.APP_URL || `${url.protocol}//${url.host}`
+  const base = getAppBaseUrl(req)
   const resetUrl = `${base}/reset/${token}`
 
   const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/auth/api/session/refresh.ts
+++ b/packages/core/src/modules/auth/api/session/refresh.ts
@@ -7,6 +7,7 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { refreshSessionRequestSchema } from '@open-mercato/core/modules/auth/data/validators'
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
 import { buildRequestOriginUrl } from '@open-mercato/core/modules/auth/lib/requestRedirect'
+import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/config'
 import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
 import { z } from 'zod'
@@ -56,7 +57,7 @@ function clearStaffAuthCookies(response: NextResponse) {
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const baseUrl = process.env.APP_URL || `${url.protocol}//${url.host}`
+  const baseUrl = getAppBaseUrl(req)
   const redirectTo = sanitizeRedirect(url.searchParams.get('redirect'), baseUrl)
   const token = parseCookie(req, 'session_token')
   if (!token) {

--- a/packages/core/src/modules/auth/lib/requestRedirect.ts
+++ b/packages/core/src/modules/auth/lib/requestRedirect.ts
@@ -1,6 +1,5 @@
+import { resolveRequestOrigin } from '@open-mercato/shared/lib/url'
+
 export function buildRequestOriginUrl(req: Request, path: string): string {
-  const url = new URL(req.url)
-  const proto = req.headers.get('x-forwarded-proto') || url.protocol.replace(':', '')
-  const host = req.headers.get('x-forwarded-host') || req.headers.get('host') || url.host
-  return new URL(path, `${proto}://${host}`).toString()
+  return new URL(path, resolveRequestOrigin(req)).toString()
 }

--- a/packages/core/src/modules/auth/lib/requestRedirect.ts
+++ b/packages/core/src/modules/auth/lib/requestRedirect.ts
@@ -1,4 +1,6 @@
 export function buildRequestOriginUrl(req: Request, path: string): string {
   const url = new URL(req.url)
-  return new URL(path, `${url.protocol}//${url.host}`).toString()
+  const proto = req.headers.get('x-forwarded-proto') || url.protocol.replace(':', '')
+  const host = req.headers.get('x-forwarded-host') || req.headers.get('host') || url.host
+  return new URL(path, `${proto}://${host}`).toString()
 }

--- a/packages/core/src/modules/customer_accounts/api/signup.ts
+++ b/packages/core/src/modules/customer_accounts/api/signup.ts
@@ -18,6 +18,7 @@ import {
   customerSignupIpRateLimitConfig,
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
 import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
+import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 
 export const metadata: { path?: string } = {}
 
@@ -26,8 +27,7 @@ type OrganizationLookupRow = {
 }
 
 function resolveBaseUrl(req: Request): string {
-  const url = new URL(req.url)
-  return process.env.APP_URL || `${url.protocol}//${url.host}`
+  return getAppBaseUrl(req)
 }
 
 function resolvePortalLoginUrl(baseUrl: string, organizationSlug?: string | null): string {

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 import { OnboardingService } from '@open-mercato/onboarding/modules/onboarding/lib/service'
 import { sendWorkspaceReadyEmail } from '@open-mercato/onboarding/modules/onboarding/lib/ready-email'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -25,7 +26,7 @@ export async function GET(req: Request) {
     return NextResponse.json({ ok: false, error: 'Invalid tenant id.' }, { status: 400 })
   }
 
-  const baseUrl = process.env.APP_URL || `${url.protocol}//${url.host}`
+  const baseUrl = getAppBaseUrl(req)
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
   const service = new OnboardingService(em)

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { SearchIndexer } from '@open-mercato/search'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 import { onboardingVerifySchema } from '@open-mercato/onboarding/modules/onboarding/data/validators'
 import { OnboardingService } from '@open-mercato/onboarding/modules/onboarding/lib/service'
 import { sendWorkspaceReadyEmail } from '@open-mercato/onboarding/modules/onboarding/lib/ready-email'
@@ -288,7 +289,7 @@ async function runDeferredProvisioning(args: {
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const baseUrl = process.env.APP_URL || `${url.protocol}//${url.host}`
+  const baseUrl = getAppBaseUrl(req)
   const token = url.searchParams.get('token') ?? ''
   const parsed = onboardingVerifySchema.safeParse({ token })
   if (!parsed.success) {

--- a/packages/onboarding/src/modules/onboarding/api/post/onboarding.ts
+++ b/packages/onboarding/src/modules/onboarding/api/post/onboarding.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 import { loadDictionary } from '@open-mercato/shared/lib/i18n/server'
 import { defaultLocale, locales, type Locale } from '@open-mercato/shared/lib/i18n/config'
 import { createFallbackTranslator } from '@open-mercato/shared/lib/i18n/translate'
@@ -124,8 +125,7 @@ export async function POST(req: Request) {
       throw err
     }
 
-    const url = new URL(req.url)
-    const baseUrl = process.env.APP_URL || `${url.protocol}//${url.host}`
+    const baseUrl = getAppBaseUrl(req)
     const verifyUrl = `${baseUrl}/api/onboarding/onboarding/verify?token=${token}`
 
     const firstName = request.firstName || parsed.data.firstName

--- a/packages/shared/src/lib/__tests__/url.test.ts
+++ b/packages/shared/src/lib/__tests__/url.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { resolveRequestOrigin, getAppBaseUrl, toAbsoluteUrl } from '../url'
 
 function createRequest(url: string, headers: Record<string, string> = {}): Request {

--- a/packages/shared/src/lib/__tests__/url.test.ts
+++ b/packages/shared/src/lib/__tests__/url.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { resolveRequestOrigin, getAppBaseUrl, toAbsoluteUrl } from '../url'
+
+function createRequest(url: string, headers: Record<string, string> = {}): Request {
+  return new Request(url, { headers })
+}
+
+describe('resolveRequestOrigin', () => {
+  it('returns origin from request URL when no forwarded headers', () => {
+    const req = createRequest('http://localhost:3000/api/test')
+    expect(resolveRequestOrigin(req)).toBe('http://localhost:3000')
+  })
+
+  it('uses x-forwarded-proto when present', () => {
+    const req = createRequest('http://internal:3000/api/test', {
+      'x-forwarded-proto': 'https',
+    })
+    expect(resolveRequestOrigin(req)).toBe('https://internal:3000')
+  })
+
+  it('uses x-forwarded-host when present', () => {
+    const req = createRequest('http://internal:3000/api/test', {
+      'x-forwarded-host': 'app.example.com',
+    })
+    expect(resolveRequestOrigin(req)).toBe('http://app.example.com')
+  })
+
+  it('uses both forwarded headers when present', () => {
+    const req = createRequest('http://internal:3000/api/test', {
+      'x-forwarded-proto': 'https',
+      'x-forwarded-host': 'app.example.com',
+    })
+    expect(resolveRequestOrigin(req)).toBe('https://app.example.com')
+  })
+
+  it('falls back to host header when x-forwarded-host is absent', () => {
+    const req = createRequest('http://internal:3000/api/test', {
+      host: 'proxy.example.com',
+    })
+    expect(resolveRequestOrigin(req)).toBe('http://proxy.example.com')
+  })
+})
+
+describe('getAppBaseUrl', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+    delete process.env.APP_URL
+  })
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_APP_URL = originalEnv.NEXT_PUBLIC_APP_URL
+    process.env.APP_URL = originalEnv.APP_URL
+  })
+
+  it('prefers NEXT_PUBLIC_APP_URL over everything', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://next-public.example.com'
+    process.env.APP_URL = 'https://app-url.example.com'
+    const req = createRequest('http://internal:3000/api/test', {
+      'x-forwarded-proto': 'https',
+      'x-forwarded-host': 'forwarded.example.com',
+    })
+    expect(getAppBaseUrl(req)).toBe('https://next-public.example.com')
+  })
+
+  it('prefers APP_URL over forwarded headers', () => {
+    process.env.APP_URL = 'https://app-url.example.com'
+    const req = createRequest('http://internal:3000/api/test', {
+      'x-forwarded-host': 'forwarded.example.com',
+    })
+    expect(getAppBaseUrl(req)).toBe('https://app-url.example.com')
+  })
+
+  it('falls back to forwarded headers when no env vars set', () => {
+    const req = createRequest('http://internal:3000/api/test', {
+      'x-forwarded-proto': 'https',
+      'x-forwarded-host': 'app.example.com',
+    })
+    expect(getAppBaseUrl(req)).toBe('https://app.example.com')
+  })
+
+  it('falls back to request URL when nothing else available', () => {
+    const req = createRequest('http://localhost:3000/api/test')
+    expect(getAppBaseUrl(req)).toBe('http://localhost:3000')
+  })
+})
+
+describe('toAbsoluteUrl', () => {
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+    delete process.env.APP_URL
+  })
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+    delete process.env.APP_URL
+  })
+
+  it('resolves a path against the app base URL', () => {
+    const req = createRequest('http://localhost:3000/api/test', {
+      'x-forwarded-proto': 'https',
+      'x-forwarded-host': 'app.example.com',
+    })
+    expect(toAbsoluteUrl(req, '/reset/token123')).toBe('https://app.example.com/reset/token123')
+  })
+})

--- a/packages/shared/src/lib/url.ts
+++ b/packages/shared/src/lib/url.ts
@@ -1,9 +1,15 @@
-export function getAppBaseUrl(req: Request): string {
+function resolveRequestOrigin(req: Request): string {
   const url = new URL(req.url)
+  const proto = req.headers.get('x-forwarded-proto') || url.protocol.replace(':', '')
+  const host = req.headers.get('x-forwarded-host') || req.headers.get('host') || url.host
+  return `${proto}://${host}`
+}
+
+export function getAppBaseUrl(req: Request): string {
   return (
     process.env.NEXT_PUBLIC_APP_URL ||
     process.env.APP_URL ||
-    `${url.protocol}//${url.host}`
+    resolveRequestOrigin(req)
   )
 }
 

--- a/packages/shared/src/lib/url.ts
+++ b/packages/shared/src/lib/url.ts
@@ -1,4 +1,4 @@
-function resolveRequestOrigin(req: Request): string {
+export function resolveRequestOrigin(req: Request): string {
   const url = new URL(req.url)
   const proto = req.headers.get('x-forwarded-proto') || url.protocol.replace(':', '')
   const host = req.headers.get('x-forwarded-host') || req.headers.get('host') || url.host


### PR DESCRIPTION
Supersedes #1515

Credit: original implementation by @jtomaszewski. This follow-up PR carries that work forward with the requested fixes so it can merge without waiting on the original branch.

## Included work
- Original changes from #1515: centralize reverse-proxy-aware URL resolution using `x-forwarded-proto` and `x-forwarded-host` headers
- Follow-up fixes applied during re-review:
  - Export `resolveRequestOrigin` from `@open-mercato/shared/lib/url` and reuse in `buildRequestOriginUrl` to eliminate code duplication
  - Add comprehensive unit tests for `resolveRequestOrigin`, `getAppBaseUrl`, and `toAbsoluteUrl` covering env var precedence and header fallback scenarios

## Summary
Behind reverse proxies (Cloud Run, nginx), `req.url` resolves to the container's internal address instead of the external URL. This PR uses `X-Forwarded-Host` and `X-Forwarded-Proto` headers when available, with env vars (`NEXT_PUBLIC_APP_URL` / `APP_URL`) taking precedence.

## Test plan
- [x] Unit tests for `resolveRequestOrigin` (10 tests, all passing)
- [x] Typecheck clean for shared and onboarding packages
- [ ] Manual: verify password reset email links behind a reverse proxy
- [ ] Manual: verify session refresh redirects behind a reverse proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)