### PR TITLE
fix(events): dispatch event subscribers in parallel (#1405)

### DIFF
--- a/packages/events/src/modules/events/workers/__tests__/events.worker.test.ts
+++ b/packages/events/src/modules/events/workers/__tests__/events.worker.test.ts
@@ -339,6 +339,52 @@ describe('Events Worker', () => {
       errorSpy.mockRestore()
     })
 
+    it('should dispatch subscribers in parallel, not sequentially', async () => {
+      const executionLog: Array<{ id: string; phase: 'start' | 'end'; time: number }> = []
+
+      const createDelayedHandler = (id: string, delayMs: number) => async () => {
+        executionLog.push({ id, phase: 'start', time: Date.now() })
+        await new Promise((resolve) => setTimeout(resolve, delayMs))
+        executionLog.push({ id, phase: 'end', time: Date.now() })
+      }
+
+      const mockModules: Module[] = [
+        {
+          id: 'module-a',
+          subscribers: [
+            { id: 'a:slow', event: 'test.parallel', handler: createDelayedHandler('a:slow', 100) },
+          ],
+        },
+        {
+          id: 'module-b',
+          subscribers: [
+            { id: 'b:slow', event: 'test.parallel', handler: createDelayedHandler('b:slow', 100) },
+          ],
+        },
+        {
+          id: 'module-c',
+          subscribers: [
+            { id: 'c:slow', event: 'test.parallel', handler: createDelayedHandler('c:slow', 100) },
+          ],
+        },
+      ]
+
+      registerCliModules(mockModules)
+
+      const job = createMockJob('test.parallel', {})
+      const ctx = createMockContext()
+
+      const startTime = Date.now()
+      await handle(job, ctx)
+      const totalTime = Date.now() - startTime
+
+      expect(executionLog.filter((e) => e.phase === 'start')).toHaveLength(3)
+      expect(executionLog.filter((e) => e.phase === 'end')).toHaveLength(3)
+
+      // Sequential would take ~300ms; parallel should complete in ~100-150ms
+      expect(totalTime).toBeLessThan(250)
+    })
+
     it('should throw when all subscribers fail', async () => {
       const mockModules: Module[] = [
         {

--- a/packages/events/src/modules/events/workers/events.worker.ts
+++ b/packages/events/src/modules/events/workers/events.worker.ts
@@ -79,19 +79,23 @@ export default async function handle(
 
   if (!subscribers || subscribers.length === 0) return
 
-  const errors: Array<{ subscriberId: string; error: unknown }> = []
+  const handlerCtx = {
+    resolve: ctx.resolve,
+    tenantId: options?.tenantId ?? null,
+    organizationId: options?.organizationId ?? null,
+  }
 
-  for (const sub of subscribers) {
-    try {
-      await sub.handler(payload, {
-        resolve: ctx.resolve,
-        tenantId: options?.tenantId ?? null,
-        organizationId: options?.organizationId ?? null,
-      })
-    } catch (error) {
-      // Log error but continue processing other subscribers
-      console.error(`[events] Subscriber "${sub.id}" failed for event "${event}":`, error)
-      errors.push({ subscriberId: sub.id, error })
+  const results = await Promise.allSettled(
+    subscribers.map((sub) => Promise.resolve(sub.handler(payload, handlerCtx)))
+  )
+
+  const errors: Array<{ subscriberId: string; error: unknown }> = []
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]
+    if (result.status === 'rejected') {
+      const sub = subscribers[i]
+      console.error(`[events] Subscriber "${sub.id}" failed for event "${event}":`, result.reason)
+      errors.push({ subscriberId: sub.id, error: result.reason })
     }
   }
 


### PR DESCRIPTION
Fixes #1405

## Problem
- Event worker dispatched subscribers sequentially via `for...of await`
- One slow subscriber (e.g., external API call) blocked all subsequent handlers
- Total execution time = sum of all handler durations

## Root Cause
- `events.worker.ts` used a sequential `for (const sub of subscribers) { await sub.handler(...) }` loop instead of concurrent dispatch

## What Changed
- Replaced sequential `for...of` loop with `Promise.allSettled(subscribers.map(...))` for parallel execution
- Preserved per-subscriber error isolation — failures in one subscriber don't affect others
- Built handler context once before dispatch instead of per-subscriber (minor allocation saving)
- Wrapped `sub.handler()` in `Promise.resolve()` to safely handle synchronous handlers

## Tests
- Added regression test proving parallel execution: 3 subscribers each taking 100ms complete in ~100ms (not ~300ms)
- All 14 existing worker tests continue to pass
- All 26 events package tests pass
- Full typecheck passes

## Backward Compatibility
- No contract surface changes
- Error message format unchanged
- Worker metadata (queue name, concurrency) unchanged
- Subscriber handler signature unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)