### PR TITLE
feat(skills): add auto-qa-scenarios, auto-sec-report-pr, and auto-sec-report

### DIFF
--- a/.ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md
+++ b/.ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md
@@ -1,6 +1,6 @@
 ---
 title: Add auto-qa-scenarios and auto-sec-report skills
-status: in-progress
+status: complete
 ---
 
 # Execution Plan — `auto-qa-scenarios` and `auto-sec-report` skills
@@ -92,4 +92,4 @@ convention so we can use `.ai/analysis/` with a dated `auto-qa-scenarios-*`
 
 ### Phase 3: PR delivery
 
-- [ ] 3.1 Push branch and open PR against `develop` (do not merge)
+- [x] 3.1 Push branch and open PR against `develop` (do not merge) — PR #1542

--- a/.ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md
+++ b/.ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md
@@ -83,12 +83,12 @@ convention so we can use `.ai/analysis/` with a dated `auto-qa-scenarios-*`
 
 ### Phase 1: Skill authoring
 
-- [ ] 1.1 Write `auto-qa-scenarios/SKILL.md`
-- [ ] 1.2 Write `auto-sec-report/SKILL.md`
+- [x] 1.1 Write `auto-qa-scenarios/SKILL.md` — d140deec3
+- [x] 1.2 Write `auto-sec-report/SKILL.md` — d140deec3
 
 ### Phase 2: Wiring
 
-- [ ] 2.1 Register both skills in `.ai/skills/README.md`
+- [x] 2.1 Register both skills in `.ai/skills/README.md` — d140deec3
 
 ### Phase 3: PR delivery
 

--- a/.ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md
+++ b/.ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md
@@ -1,0 +1,95 @@
+---
+title: Add auto-qa-scenarios and auto-sec-report skills
+status: in-progress
+---
+
+# Execution Plan — `auto-qa-scenarios` and `auto-sec-report` skills
+
+## Goal
+
+Add two autonomous reporting skills to `.ai/skills/` that take a PR range
+(date, PR number floor, or default "last 7 days") and deliver a human-readable
+report as a docs-only PR against `develop`. Both skills reuse the
+`auto-create-pr` workflow for branch/worktree/commit/PR discipline and leave
+resumable progress via `auto-continue-pr` when the run cannot finish in one
+pass.
+
+## Scope
+
+- `.ai/skills/auto-qa-scenarios/SKILL.md` — QA-tester-facing report that
+  groups merged PRs by practical testing routes (P0/P1/P2), tells QA where
+  to click, what to verify, and what can go wrong.
+- `.ai/skills/auto-sec-report/SKILL.md` — Security-engineer-facing report
+  that maps each merged PR against OWASP Top 10 categories, calls out
+  security-fix PRs, and proposes where the same fix should also be applied.
+- Both reports land under `.ai/analysis/` with a dated filename and both a
+  markdown and an HTML rendering.
+- Update `.ai/skills/README.md` to list the two new skills.
+
+## Non-goals
+
+- Do not change the existing `auto-create-pr` / `auto-continue-pr` /
+  `auto-review-pr` skills. The new skills reuse them by reference.
+- Do not run any real analysis in this PR. This PR only adds the skill
+  definitions; actual analysis runs will be triggered later by the user.
+- Do not touch packages, apps, or generated files.
+
+## External References
+
+None. The reference report format at
+<https://github.com/open-mercato/open-mercato/pull/1527/files> was consulted
+for structure (Executive Summary → Recommended Order → Grouped Areas →
+Appendix). We adopt the section shape and reject the exact filename
+convention so we can use `.ai/analysis/` with a dated `auto-qa-scenarios-*`
+/ `auto-sec-report-*` slug.
+
+## Implementation Plan
+
+### Phase 1 — Skill authoring
+
+- Draft `auto-qa-scenarios/SKILL.md` covering argument parsing (date / PR
+  floor / default last week), data gathering with `gh`, grouping heuristics,
+  the exact markdown report sections, the HTML rendering rule, the
+  `auto-create-pr` handoff, and the `auto-continue-pr` resume contract.
+- Draft `auto-sec-report/SKILL.md` with the same shape but focused on OWASP
+  Top 10 2021 categories, PR-level security-fix detection, and
+  cross-codebase "apply the same fix elsewhere" audit prompts.
+
+### Phase 2 — Wiring
+
+- Add both skills to `.ai/skills/README.md`'s "Available Skills" table with
+  one-line descriptions matching the SKILL.md frontmatter.
+
+### Phase 3 — PR delivery
+
+- Commit the plan first, then the skill files.
+- Push `feat/auto-qa-and-sec-report-skills` and open a PR against `develop`.
+- Do not merge. Apply the `review`, `documentation`, and `skip-qa` labels
+  (docs-only change; no customer-facing behavior).
+
+## Risks
+
+- Skill descriptions must be precise enough that agents auto-select them
+  without accidentally firing on unrelated PR-reporting requests. Mitigation:
+  keep the trigger words narrow ("QA scenarios", "QA report for PRs",
+  "security audit", "OWASP", "auto-sec-report").
+- Reports can run long. SKILL.md must cap the per-PR narrative and push raw
+  inventory to an appendix so the artifact stays usable.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a
+> step lands. Do not rename step titles.
+
+### Phase 1: Skill authoring
+
+- [ ] 1.1 Write `auto-qa-scenarios/SKILL.md`
+- [ ] 1.2 Write `auto-sec-report/SKILL.md`
+
+### Phase 2: Wiring
+
+- [ ] 2.1 Register both skills in `.ai/skills/README.md`
+
+### Phase 3: PR delivery
+
+- [ ] 3.1 Push branch and open PR against `develop` (do not merge)

--- a/.ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md
+++ b/.ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md
@@ -93,3 +93,10 @@ convention so we can use `.ai/analysis/` with a dated `auto-qa-scenarios-*`
 ### Phase 3: PR delivery
 
 - [x] 3.1 Push branch and open PR against `develop` (do not merge) — PR #1542
+
+### Phase 4: Revision — split sec-report into single-unit + driver
+
+- [x] 4.1 Add `auto-sec-report-pr` single-unit skill covering PR / spec / branch inputs with paranoid deep vectors and "Next steps — go deeper"
+- [x] 4.2 Add `references/deep-attack-vectors.md` paranoid checklist bundled with `auto-sec-report-pr`
+- [x] 4.3 Refactor `auto-sec-report` to loop `auto-sec-report-pr` in sub-unit mode and aggregate per-unit fragments
+- [x] 4.4 Update README.md skills index: new row for `auto-sec-report-pr`, updated row for driver `auto-sec-report`, folder added to structure tree

--- a/.ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md
+++ b/.ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md
@@ -100,3 +100,7 @@ convention so we can use `.ai/analysis/` with a dated `auto-qa-scenarios-*`
 - [x] 4.2 Add `references/deep-attack-vectors.md` paranoid checklist bundled with `auto-sec-report-pr`
 - [x] 4.3 Refactor `auto-sec-report` to loop `auto-sec-report-pr` in sub-unit mode and aggregate per-unit fragments
 - [x] 4.4 Update README.md skills index: new row for `auto-sec-report-pr`, updated row for driver `auto-sec-report`, folder added to structure tree
+
+### Phase 5: CI stabilization
+
+- [x] Post-review fix: restore `YARN_ENABLE_IMMUTABLE_INSTALLS=0` and add `YARN_ENABLE_HARDENED_MODE=0` to the scaffolded standalone-app install steps — resolves YN0028 (lockfile would be modified) triggered by Yarn 4.12 auto-enabling hardened mode on public PR workflows — 2f113173e

--- a/.ai/skills/README.md
+++ b/.ai/skills/README.md
@@ -23,6 +23,10 @@ Skills extend AI agents with task-specific capabilities. Each skill is a folder 
 │   └── SKILL.md
 ├── auto-create-pr/
 │   └── SKILL.md
+├── auto-qa-scenarios/
+│   └── SKILL.md
+├── auto-sec-report/
+│   └── SKILL.md
 ├── create-agents-md/
 │   └── SKILL.md
 ├── ds-guardian/
@@ -177,6 +181,8 @@ Skills also trigger automatically when a task matches the skill's `description`.
 | `auto-continue-pr` | Resuming an in-progress PR that was started by `auto-create-pr`: claims the PR, checks its branch out into an isolated worktree, reads the Progress checklist in the linked spec, and continues execution from the first unchecked step |
 | `create-agents-md` | Creating or rewriting AGENTS.md files for packages and modules |
 | `auto-create-pr` | Running an arbitrary autonomous task end-to-end and delivering it as a PR against `develop`: drafts a dated spec with a Progress checklist, commits it first, implements phase-by-phase with incremental commits, optionally honors external reference skills passed by URL, runs the full validation gate, and opens a PR with normalized pipeline labels |
+| `auto-qa-scenarios` | Generating a human QA report for a window of merged PRs (date floor, PR number floor, or last 7 days default): groups work into practical testing routes (P0/P1/P2), calls out where to click, what to verify, and what can go wrong, then ships markdown + HTML artifacts under `.ai/analysis/` as a docs-only PR against `develop` |
+| `auto-sec-report` | Generating an OWASP-oriented security analysis for a window of merged PRs (date floor, PR number floor, or last 7 days default): classifies each PR by OWASP Top 10 category, highlights security-fix PRs, proposes where the same fix should apply elsewhere in the codebase, and ships markdown + HTML artifacts under `.ai/analysis/` as a docs-only PR against `develop` |
 | `ds-guardian` | Design system enforcement: analyzing modules for DS violations, migrating hardcoded colors/typography to semantic tokens, scaffolding DS-compliant pages, reviewing code against DS principles, and reporting health metrics |
 | `auto-fix-github` | Fixing a GitHub issue by number: first checks whether the issue is already solved or already has an open solution, then uses an isolated worktree to implement the minimal fix, add regression tests, run review and compatibility checks, and open a PR linked to the original issue |
 | `fix-specs` | Normalizing legacy spec filenames to `{YYYY-MM-DD}-{slug}.md`, resolving post-normalization collisions, and updating references/links |

--- a/.ai/skills/README.md
+++ b/.ai/skills/README.md
@@ -27,6 +27,10 @@ Skills extend AI agents with task-specific capabilities. Each skill is a folder 
 │   └── SKILL.md
 ├── auto-sec-report/
 │   └── SKILL.md
+├── auto-sec-report-pr/
+│   ├── SKILL.md
+│   └── references/
+│       └── deep-attack-vectors.md
 ├── create-agents-md/
 │   └── SKILL.md
 ├── ds-guardian/
@@ -182,7 +186,8 @@ Skills also trigger automatically when a task matches the skill's `description`.
 | `create-agents-md` | Creating or rewriting AGENTS.md files for packages and modules |
 | `auto-create-pr` | Running an arbitrary autonomous task end-to-end and delivering it as a PR against `develop`: drafts a dated spec with a Progress checklist, commits it first, implements phase-by-phase with incremental commits, optionally honors external reference skills passed by URL, runs the full validation gate, and opens a PR with normalized pipeline labels |
 | `auto-qa-scenarios` | Generating a human QA report for a window of merged PRs (date floor, PR number floor, or last 7 days default): groups work into practical testing routes (P0/P1/P2), calls out where to click, what to verify, and what can go wrong, then ships markdown + HTML artifacts under `.ai/analysis/` as a docs-only PR against `develop` |
-| `auto-sec-report` | Generating an OWASP-oriented security analysis for a window of merged PRs (date floor, PR number floor, or last 7 days default): classifies each PR by OWASP Top 10 category, highlights security-fix PRs, proposes where the same fix should apply elsewhere in the codebase, and ships markdown + HTML artifacts under `.ai/analysis/` as a docs-only PR against `develop` |
+| `auto-sec-report-pr` | Paranoid single-unit OWASP security analysis for one PR, one branch, or one spec file: layers deep attack vectors (TOCTOU, cache-key cross-tenant leakage, JWT alg confusion, SSRF redirect chains, ReDoS, webhook replay, prototype pollution, etc.) on top of the `code-review` baseline, cites apply-elsewhere candidates, and emits concrete "Next steps — go deeper" follow-up commands so a reviewer (or `auto-sec-report`) can keep drilling |
+| `auto-sec-report` | Driver that loops `auto-sec-report-pr` across a window (date, PR number floor, branch, spec, or default last 7 days of merged PRs), aggregates per-unit fragments into one markdown + HTML report under `.ai/analysis/`, consolidates every "Next steps — go deeper" into one prioritized drill-deeper list, and ships it as a docs-only PR against `develop` |
 | `ds-guardian` | Design system enforcement: analyzing modules for DS violations, migrating hardcoded colors/typography to semantic tokens, scaffolding DS-compliant pages, reviewing code against DS principles, and reporting health metrics |
 | `auto-fix-github` | Fixing a GitHub issue by number: first checks whether the issue is already solved or already has an open solution, then uses an isolated worktree to implement the minimal fix, add regression tests, run review and compatibility checks, and open a PR linked to the original issue |
 | `fix-specs` | Normalizing legacy spec filenames to `{YYYY-MM-DD}-{slug}.md`, resolving post-normalization collisions, and updating references/links |

--- a/.ai/skills/auto-qa-scenarios/SKILL.md
+++ b/.ai/skills/auto-qa-scenarios/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: auto-qa-scenarios
+description: Generate a human QA report for a window of merged pull requests and deliver it as a docs-only PR. Accepts a date (reports PRs merged on or after that date), a PR number floor (reports PRs whose number is >= that value), or defaults to the last 7 days when nothing is specified. Groups merged work into practical testing routes (P0/P1/P2), lists where QA should click, what to verify, and what can go wrong. Writes both markdown and HTML artifacts under `.ai/analysis/`. Uses the `auto-create-pr` workflow to open a PR against `develop` (never merges), and hands off to `auto-continue-pr` when the run cannot finish in one pass.
+---
+
+# Auto QA Scenarios
+
+Produce a QA-tester-facing report that translates a window of merged pull
+requests into a practical manual verification plan. The report groups PRs by
+product area, recommends a testing order, tells QA where to click, what to
+verify, and what can go wrong. The final deliverable is a docs-only PR
+against `develop` with markdown and HTML artifacts under `.ai/analysis/`.
+
+This skill is a specialization of `auto-create-pr`. It adopts that skill's
+worktree, branch, commit, validation, self-review, and label discipline
+verbatim. The sections below describe only the QA-specific content and the
+few places where the flow deviates from the generic `auto-create-pr`
+workflow.
+
+## Arguments
+
+- `{windowSpec}` (optional) — one of:
+  - A date in `YYYY-MM-DD` form (e.g. `2026-04-10`). Report covers every PR
+    merged on or after that date, up to today (UTC).
+  - A PR number (e.g. `1200`). Report covers every PR whose number is
+    greater than or equal to the given number and that is merged.
+  - Omitted — defaults to the last 7 days (UTC), i.e. everything merged
+    between today minus 7 days and today.
+- `--base <branch>` (optional) — which base branch to count merges into.
+  Defaults to `develop`. `main` merges are still reported but flagged when
+  a different base is specified.
+- `--include-open` (optional) — also include open non-draft PRs in the
+  report, labelled as "not yet merged" so QA can sanity-check upcoming
+  changes. Off by default.
+- `--slug <kebab-case>` (optional) — override the slug used in the plan
+  and artifact filenames. Default: derived from the window.
+- `--force` (optional) — bypass the claim-conflict check when a previous
+  run left a branch or plan behind.
+
+## Workflow
+
+### 0. Pre-flight and claim
+
+Follow `.ai/skills/auto-create-pr/SKILL.md` step 0 verbatim. Branch name
+MUST use the `feat/` prefix (this is a new docs artifact, not a
+corrective change):
+
+```bash
+DATE=$(date -u +%Y-%m-%d)
+SLUG="${SLUG_OVERRIDE:-auto-qa-scenarios-${DATE}}"
+PLAN_PATH=".ai/runs/${DATE}-${SLUG}.md"
+BRANCH="feat/${SLUG}"
+```
+
+### 1. Resolve the PR window
+
+Translate `{windowSpec}` into a concrete query:
+
+```bash
+# Date mode
+gh search prs --repo $(gh repo view --json nameWithOwner --jq .nameWithOwner) \
+  --merged --base "${BASE:-develop}" --sort updated --order desc \
+  --merged-at ">=${DATE_FLOOR}" --limit 500 \
+  --json number,title,url,author,body,labels,headRefName,baseRefName,mergedAt,mergeCommit,files
+
+# PR-number-floor mode (fetch list, filter by number >= floor, merged == true)
+gh pr list --state merged --base "${BASE:-develop}" --limit 500 \
+  --json number,title,url,author,body,labels,headRefName,baseRefName,mergedAt
+
+# Default (last 7 days) — same as date mode with DATE_FLOOR = today - 7
+```
+
+Rules:
+
+- Paginate until you reach the floor. Never silently cap at 100 PRs.
+- Record the resolved window (start date or PR floor, end date) in the plan
+  Overview so the report caption is unambiguous.
+- Count merges into `main` separately and mention them in the executive
+  summary. Do not silently drop them.
+
+### 2. Gather per-PR evidence
+
+For each PR in the window, fetch enough context to group it reliably:
+
+```bash
+gh pr view {number} --json number,title,url,author,body,labels,baseRefName,mergeCommit,mergedAt,files,additions,deletions
+gh pr diff {number} --patch | head -n 400   # sample; do not paste into the report
+```
+
+From each PR, extract:
+
+- Title, number, URL, merged date, base branch.
+- Labels (category, pipeline, meta).
+- Issue references from the body (`#\d+` and `Fixes #\d+`).
+- Affected top-level module/package paths from the file list (e.g.
+  `packages/core/src/modules/sales/`, `packages/ui/`).
+- Heuristic area tag: auth, sales, catalog, customers, workflows, webhooks,
+  events, notifications, search, ai, ui, docs, tests, infra, other.
+
+### 3. Group PRs into QA areas
+
+Cluster by heuristic area tag, then refine manually from titles and file
+paths. Target **3–6 named QA areas plus one "no direct manual QA" bucket**
+so the report stays usable. Typical areas:
+
+- Auth, Access Control, Sessions, Organization Scope
+- Sales, Checkout, Quotes, Orders, Payments, Shipments
+- Workflows, Webhooks, Events, Notifications, Scheduler, Queue
+- Customers, Customer Accounts, Custom Fields, Business Rules
+- Catalog, Attachments, Shared Backend UI, Visual Regressions
+- Low-Priority Manual QA And Broad Smoke Only
+
+Assign a priority to each area:
+
+- **P0** — auth/sessions/tenant scope, money flows, event/webhook
+  reliability, anything that can leak data across tenants or double-charge.
+- **P1** — CRM, catalog UX, attachments, table/UI rendering, custom fields.
+- **P2** — docs, tooling, tests, infra, DX. No dedicated admin pass.
+
+### 4. Draft the execution plan
+
+Follow `.ai/skills/auto-create-pr/SKILL.md` step 3. The plan at
+`$PLAN_PATH` MUST include:
+
+- Window (start date or PR floor, end date, base branch).
+- External References subsection set to `None` unless `--skill-url`
+  actually passed something.
+- A **Progress** section with the exact convention block from
+  `auto-create-pr`. Required phases:
+
+```markdown
+### Phase 1: Data gathering
+
+- [ ] 1.1 Resolve PR window and fetch merged PR metadata
+- [ ] 1.2 Enrich PRs with files, labels, and linked issue refs
+
+### Phase 2: Analysis
+
+- [ ] 2.1 Cluster PRs into QA areas and assign priorities
+- [ ] 2.2 Draft "Where QA should click", "What to verify", and "What can go wrong" per area
+
+### Phase 3: Artifact generation
+
+- [ ] 3.1 Write markdown report to `.ai/analysis/auto-qa-scenarios-${DATE}.md`
+- [ ] 3.2 Render HTML mirror to `.ai/analysis/auto-qa-scenarios-${DATE}.html`
+- [ ] 3.3 Spot-check artifacts render correctly and links resolve
+
+### Phase 4: PR delivery
+
+- [ ] 4.1 Commit artifacts, push branch, open PR against `develop` (do not merge)
+- [ ] 4.2 Apply `review`, `documentation`, and `skip-qa` labels with comments
+```
+
+### 5. Isolated worktree, branch, first commit
+
+Follow `.ai/skills/auto-create-pr/SKILL.md` steps 4–5 verbatim. Branch
+base is always `develop`. Commit the plan first, then push.
+
+### 6. Execute the phases
+
+Run steps 1.1 → 3.3 inside the worktree. After each step, flip its
+checkbox to `- [x]`, append the commit SHA, and commit the progress
+update as a dedicated `docs(runs): mark ${SLUG} Phase N step X complete`
+commit. Push after every phase.
+
+#### 6a. Markdown artifact layout
+
+Write to `.ai/analysis/auto-qa-scenarios-${DATE}.md` using this outline:
+
+```markdown
+# Auto QA Scenarios — {window caption}
+
+Report window: **{start date or PR floor} through {end date}** (base: `{base}`).
+
+## Executive Summary
+
+- Reviewed **{count} merged PRs** in the requested window.
+- Base branches covered: **{n} into `develop`** and **{m} into `main`**.
+- Grouped into {N} practical testing routes below. Use the appendix for
+  full PR-by-PR traceability.
+- {one sentence on the riskiest theme in this window}.
+
+## Recommended QA Order
+
+| Priority | Area | Suggested focus |
+|---|---|---|
+| P0 | {Area name} | {one sentence} |
+| P0 | {Area name} | {one sentence} |
+| P1 | {Area name} | {one sentence} |
+| P2 | Low-priority manual QA and broad smoke only | {one sentence} |
+
+## QA Areas
+
+### P0 — {Area name}
+
+{2–3 sentences describing what changed in this area during the window.}
+
+**Representative PRs in this area:** [#...](...), [#...](...)
+**Linked issue refs surfaced in these PRs:** [#...](...), [#...](...)
+
+**Where QA should click**
+- `/backend/...`
+- `/backend/...`
+
+**What human QA should verify**
+- {Concrete manual action with expected outcome}
+- {Concrete manual action with expected outcome}
+
+**What can go wrong**
+- {Concrete regression symptom}
+- {Concrete regression symptom}
+
+{Repeat per area.}
+
+## Appendix: Full Merged PR Inventory
+
+Each item below is one merged PR from the requested window with direct
+GitHub links for the PR and any linked or mentioned issue refs.
+
+### {YYYY-MM-DD}
+
+- [#{n}]({url}) {title}; Issue refs: [#{k}]({issue url}) | None
+- ...
+```
+
+Rules for the markdown:
+
+- Never paste raw diffs or PR bodies into the report.
+- Never invent PR numbers. If the fetch for a PR fails, note it in the
+  appendix with `(metadata unavailable)` and continue.
+- Never mention secrets, tokens, `.env` values, or internal URLs that
+  were leaked into PR bodies. Redact if found.
+- Keep the area narrative under ~6 sentences. The appendix carries the
+  completeness burden.
+
+#### 6b. HTML artifact layout
+
+Write a stand-alone HTML file at `.ai/analysis/auto-qa-scenarios-${DATE}.html`.
+It MUST:
+
+- Open with a `<!DOCTYPE html>` and include a `<title>` matching the
+  markdown H1.
+- Embed a small inline `<style>` block (no external CSS) using system
+  fonts. No JavaScript. No web fonts. No remote assets.
+- Mirror every section of the markdown — Executive Summary, Recommended
+  QA Order (as a table), QA Areas (as `<section>` blocks with the same
+  headings), and the Appendix (grouped by date with `<h3>` and `<ul>`).
+- Preserve every PR and issue link as an `<a href="...">` with
+  `rel="noopener noreferrer"`.
+- Set text direction `ltr` and language `en` on `<html>`.
+
+Do not attempt to convert the markdown programmatically in this SKILL —
+render the HTML directly from the same source-of-truth data you used for
+the markdown. This keeps the two files in sync without a build step.
+
+### 7. Full validation gate (docs-only)
+
+This run is docs-only. The minimum gate is:
+
+- `yarn lint` (if it catches markdown/YAML issues in frontmatter).
+- `git diff --check` — no trailing whitespace, no merge markers.
+- A manual re-read of both artifacts and a spot-check that every PR link
+  resolves to a real URL (`https://github.com/{owner}/{repo}/pull/{n}`).
+
+Never run `yarn build`, `yarn test`, or `yarn typecheck` on a docs-only
+run unless you actually modified code. If the run did touch code, fall
+back to the full `auto-create-pr` step 7 gate.
+
+### 8. Self-review and BC review
+
+Apply `.ai/skills/code-review/SKILL.md` to the diff. Because the change is
+docs-only, the only contract-surface risk is accidentally linking
+external resources in a way that leaks user or tenant data. Redact if
+needed.
+
+### 9. Open the PR
+
+Follow `.ai/skills/auto-create-pr/SKILL.md` step 9 with these specifics:
+
+- Title: `docs(analysis): add auto-qa-scenarios report for {window caption}`.
+- Base: `develop`. Never merge directly.
+- Body MUST include `Tracking plan: .ai/runs/${DATE}-${SLUG}.md` and
+  `Status: complete` (or `in-progress` if phases remain).
+- Body MUST link both artifacts under `.ai/analysis/` and summarize the
+  window and the total PR count.
+
+### 10. Labels
+
+Apply in this order, each with a short explanatory comment (per root
+`AGENTS.md` PR workflow):
+
+- `review` — "PR is ready for code review."
+- `documentation` — "docs-only deliverable under `.ai/analysis/`."
+- `skip-qa` — "docs-only report; no customer-facing behavior."
+
+Never add `needs-qa` on an `auto-qa-scenarios` PR. The report is about
+other PRs; it does not itself require manual QA.
+
+### 11. Auto-review pass
+
+Run `.ai/skills/auto-review-pr/SKILL.md` against the new PR in autofix
+mode. Apply fixes as new commits. Never rewrite history.
+
+### 12. Summary comment
+
+Post the comprehensive summary comment required by
+`.ai/skills/auto-create-pr/SKILL.md` step 12. In the **How to verify**
+section, recommend that the reviewer:
+
+- Open the HTML artifact directly in a browser.
+- Scan the appendix for PRs the reviewer personally merged and confirm
+  they were categorized sanely.
+
+### 13. Cleanup
+
+Follow `.ai/skills/auto-create-pr/SKILL.md` step 13.
+
+### 14. Resumability
+
+If the run cannot finish in a single invocation:
+
+1. Leave `Status: in-progress` in the PR body.
+2. Ensure the Progress checklist in `$PLAN_PATH` reflects what actually
+   landed, with commit SHAs on every completed step.
+3. Post a PR comment that says verbatim:
+   `🤖 auto-qa-scenarios is not complete. Resume with /auto-continue-pr {prNumber}.`
+4. Release any `in-progress` lock per `auto-continue-pr` rules if one was
+   claimed during this run.
+
+## Rules
+
+- Always deliver as a PR. Never push the report to `develop` directly.
+  Never merge the PR from within this skill.
+- Default window is the last 7 days (UTC) when `{windowSpec}` is omitted.
+- Artifacts go under `.ai/analysis/` with a dated filename. Both markdown
+  and HTML MUST be produced in the same run.
+- Never invent PR numbers, issue references, or commit SHAs.
+- Never paste raw diffs, PR bodies, secrets, tokens, or `.env` content
+  into the report.
+- Keep per-area narrative tight; push completeness to the appendix.
+- Reuse `auto-create-pr` for branch/worktree/commit/validation/label
+  discipline. Do not reinvent those mechanics.
+- On partial completion, leave a `/auto-continue-pr {prNumber}` hand-off
+  comment and keep `Status: in-progress` on the PR body.
+- Labels on this skill's PR: `review`, `documentation`, `skip-qa`. Never
+  `needs-qa`.

--- a/.ai/skills/auto-sec-report-pr/SKILL.md
+++ b/.ai/skills/auto-sec-report-pr/SKILL.md
@@ -1,0 +1,441 @@
+---
+name: auto-sec-report-pr
+description: Produce a paranoid OWASP-oriented security analysis for a SINGLE unit of work (one merged or open pull request, one spec file under `.ai/specs/`, or one branch diff against a base). Goes beyond obvious OWASP Top 10 checks to hunt non-obvious attack vectors (TOCTOU, cache-key cross-tenant leakage, JWT alg confusion, ReDoS, SSRF via redirect chains, webhook replay, prototype pollution, deserialization, path traversal, log forging, CORS/CSP/cookie misconfig, mass assignment via loose zod, SSE cross-tenant bleed, signed-URL expiry, etc.). Identifies other places in the codebase that exhibit the same pattern and emits them as concrete "Next steps — go deeper" follow-up scopes so the reviewer can keep drilling. Runs either standalone (writes markdown + HTML under `.ai/analysis/` and optionally opens a docs-only PR) or as a sub-unit invoked by `auto-sec-report`. Reuses the claim/worktree/lock discipline of `auto-review-pr` and the security checks already codified in the `code-review` skill.
+---
+
+# Auto Security Report — Single Unit
+
+Analyze ONE unit of work — a PR, a spec file, or a branch diff — for
+security issues. The analysis is intentionally paranoid: it scans for
+obvious OWASP Top 10 categories AND for less-obvious attack vectors that
+are easy to miss in a conventional code review. For every finding it
+proposes concrete "Next steps — go deeper" follow-up scopes so the next
+run of this same skill can drill further.
+
+This skill is the atomic building block used by `auto-sec-report` (the
+multi-unit driver). It can also be invoked directly against a single
+target when you want a deep read on exactly one thing.
+
+## Arguments
+
+- `{target}` (required) — one of:
+  - `pr:{number}` or a bare number (e.g. `1456`) — analyze one pull
+    request. Works for merged or open PRs.
+  - `spec:{path}` or any path ending in `.md` under `.ai/specs/` or
+    `.ai/specs/enterprise/` — analyze one specification.
+  - `branch:{name}` — analyze the diff of a branch against the base
+    (defaults to `origin/develop`). Works with local branches after a
+    `git fetch origin {name}`.
+- `--base <branch>` (optional) — base ref for the branch/PR diff.
+  Defaults to `origin/develop`.
+- `--out-fragment <path>` (optional) — when invoked as a sub-unit by
+  `auto-sec-report`, write the markdown section fragment to this path
+  instead of creating a standalone artifact + PR. When set, do NOT open
+  a PR. Presence of this flag is the only signal that the skill is
+  running as a sub-unit.
+- `--deep-scan` (optional) — expand the "apply elsewhere" grep sweeps
+  to the full repository rather than the modules touched by the unit.
+  Slower. Off by default. `auto-sec-report` passes this through when it
+  wants aggregated cross-codebase findings.
+- `--slug <kebab-case>` (optional) — override the slug used in the plan
+  and artifact filenames. Default: derived from the target.
+- `--force` (optional) — bypass the claim-conflict check when taking
+  over a previously-started run.
+
+## Dependencies on other skills
+
+This skill is a specialization. Do not re-implement what these already
+cover — invoke or quote them:
+
+- `.ai/skills/code-review/SKILL.md` and its checklist at
+  `.ai/skills/code-review/references/review-checklist.md` are the
+  authoritative source for Open Mercato's security baseline
+  (tenant scoping, `findWithDecryption`, zod validation, RBAC via
+  `acl.ts`, password hashing, no raw `fetch`). Apply them first; only
+  add OWASP/paranoid checks on top.
+- `.ai/skills/auto-review-pr/SKILL.md` defines the claim/lock/worktree
+  pattern used here verbatim (see step 1 below).
+- `.ai/skills/spec-writing/references/spec-checklist.md` and
+  `spec-writing/references/compliance-review.md` are the authoritative
+  sources when the target is a spec (section 3 "Data Integrity &
+  Security", compliance matrix fields).
+- `.ai/skills/pre-implement-spec/SKILL.md` is the authoritative source
+  for backward-compatibility risk (13 contract surfaces). Use it as a
+  cross-check when reviewing a spec that is about to be implemented.
+- `.ai/skills/auto-sec-report-pr/references/deep-attack-vectors.md` is
+  the bundled paranoid checklist loaded during every run.
+
+## Workflow
+
+### 1. Claim and isolate
+
+When `{target}` is `pr:{n}` or a bare PR number, apply the claim
+protocol from `.ai/skills/auto-review-pr/SKILL.md` step 0 verbatim
+(assignee, `in-progress` label, 🤖 claim comment). Release the lock on
+finish via a trap/finally even on failure.
+
+When `{target}` is a spec or a branch, there is no PR to claim. Still
+run in an isolated worktree:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+GIT_DIR=$(git rev-parse --git-dir)
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+WORKTREE_PARENT="$REPO_ROOT/.ai/tmp/auto-sec-report-pr"
+CREATED_WORKTREE=0
+
+if [ "$GIT_DIR" != "$GIT_COMMON_DIR" ]; then
+  WORKTREE_DIR="$PWD"
+else
+  WORKTREE_DIR="$WORKTREE_PARENT/${SLUG}-$(date +%Y%m%d-%H%M%S)"
+  mkdir -p "$WORKTREE_PARENT"
+  case "$TARGET_KIND" in
+    pr)
+      gh pr checkout "${TARGET}" --recurse-submodules=no
+      git worktree add --detach "$WORKTREE_DIR" HEAD ;;
+    branch)
+      git fetch origin "${TARGET}"
+      git worktree add "$WORKTREE_DIR" "origin/${TARGET}" ;;
+    spec)
+      git fetch origin develop
+      git worktree add --detach "$WORKTREE_DIR" origin/develop ;;
+  esac
+  CREATED_WORKTREE=1
+fi
+
+cd "$WORKTREE_DIR"
+yarn install --mode=skip-build
+```
+
+Rules:
+
+- Reuse the current linked worktree if already inside one. Never nest
+  worktrees. Always clean up the temporary worktree at the end in a
+  trap/finally.
+
+### 2. Resolve the unit
+
+Compute the set of changed files and the text to analyze based on the
+target kind:
+
+- **pr**: changed files via `gh pr view {n} --json files`; diff via
+  `gh pr diff {n} --patch`; body/title/labels via `gh pr view`.
+- **branch**: changed files via
+  `git diff --name-only ${BASE}..${TARGET}`; diff via
+  `git diff ${BASE}..${TARGET}`.
+- **spec**: the spec file itself plus any files it references via
+  explicit relative links. Do NOT speculatively grep the whole repo for
+  spec-adjacent files — only follow links the spec actually cites.
+
+Cap per-file diff reads at ~400 lines of patch. Summarize beyond that;
+never paste raw diffs into the final artifact.
+
+### 3. Paranoid security sweep
+
+Run the sweep in two passes.
+
+#### Pass A — Baseline (code-review alignment)
+
+Apply every relevant item in
+`.ai/skills/code-review/references/review-checklist.md` to the unit.
+Carry forward only items where the unit actually touched the surface.
+Record each finding as:
+
+- `severity`: blocker | major | minor | nit | info
+- `category`: the closest OWASP Top 10 2021 id (A01–A10) or
+  `Out of scope (not OWASP)` when the finding is correctness/quality
+  only
+- `location`: `file:line` or `spec:section`
+- `why`: one sentence
+- `fix`: one sentence
+
+#### Pass B — Paranoid deep vectors
+
+Load `.ai/skills/auto-sec-report-pr/references/deep-attack-vectors.md`
+and walk every applicable category against the unit. Focus on
+non-obvious vectors that conventional code review often misses:
+
+- Time-of-check-time-of-use (TOCTOU) races around stock, payment,
+  shipment, quote acceptance.
+- Cross-tenant leakage via shared cache keys, SSE channels, event bus
+  broadcasts, or in-memory registries that do not include
+  `organization_id` / `tenant_id` in the key.
+- JWT algorithm confusion (`alg: none`, HS↔RS swap), missing `iss`/
+  `aud` checks, loose expiry, token replay after password reset.
+- Signed-URL / magic-link expiry, reuse, and scope creep.
+- SSRF via redirect chains in outbound fetchers, DNS rebinding, IPv6
+  loopback bypass, link-local addresses, metadata endpoints.
+- Open redirect via relative URLs, `//evil.com`, unicode/RTL tricks,
+  host header confusion.
+- Deserialization: `JSON.parse` on attacker-controlled with prototype
+  pollution (`__proto__`, `constructor`, `prototype`), `yaml.load`
+  without safe schema, `eval`/`Function`/`vm` sinks.
+- Path traversal in attachment and spec preview paths, symlink escape
+  in worker sandboxes, archive slip (`zip-slip`).
+- ReDoS in zod `regex`, email/URL/phone validators, search tokenizers.
+- Log forging / log injection via unescaped user input in structured
+  logs; PII leakage into logs; stack traces leaking to clients.
+- Mass assignment via `z.object({...}).passthrough()` or spreading
+  request bodies into entities; missing `.strict()` on zod schemas.
+- Rate-limit identifier weaknesses (IP-only when IP is spoofable
+  behind proxy; compound identifier missing user id; bucket collision).
+- CSRF on state-changing routes that do not check `SameSite`/origin;
+  cookie flags (`HttpOnly`, `Secure`, `SameSite=Lax|Strict`), session
+  fixation, session rotation on privilege change.
+- CORS with `Access-Control-Allow-Origin: *` on authenticated endpoints;
+  reflected origin; credentialed CORS with wildcard.
+- Clickjacking via missing `X-Frame-Options` / `frame-ancestors`; CSP
+  gaps (`unsafe-inline`, `unsafe-eval`, missing `object-src 'none'`).
+- Webhook integrity: signature verification, replay protection
+  (monotonic timestamps, nonce cache), timing-safe compare,
+  signature-scheme downgrade (v2→v1).
+- Idempotency on money-moving flows: payments, refunds, shipments,
+  returns, credit memos. Double-submission windows. Missing unique
+  constraints on (tenant, idempotency_key).
+- Access control edge cases: wildcard `__all__` ACL handling for
+  non-superadmins, role rename spoofing, feature flag bypass,
+  portal/customer auth leaking staff features.
+- Encryption defaults: PII fields that should be encrypted but are
+  stored plain, `findOne` bypassing `findWithDecryption`, export paths
+  that re-emit decrypted data without policy.
+- Multi-currency: rounding direction, float use for money,
+  cross-currency totals without FX.
+- Background jobs: job payload trust, retry amplification of
+  side-effects, cancellation-token bypass, worker reading
+  cross-tenant data.
+- AI tool surfaces: tool injection via chat, tool authorization not
+  honoring `acl.ts`, session token reuse after privilege change.
+- Supply chain: pinned vs floating dependency, post-install scripts,
+  lockfile integrity, Renovate/Dependabot drift, unused but still
+  resolvable packages.
+
+For each paranoid finding, cite the exact file/line or spec section and
+propose a one-line fix.
+
+### 4. Apply-elsewhere sweep
+
+For every blocker or major finding in Pass A or Pass B, run a targeted
+Grep to find other places that exhibit the same pre-fix pattern. Scope
+defaults to the modules the unit already touched; `--deep-scan`
+expands to the full repo.
+
+Hard rules:
+
+- Every candidate MUST cite a real file path confirmed by Grep. Do not
+  invent candidates.
+- Cap the list at 10 candidates per finding.
+- Distinguish `same pattern, same risk` from `same pattern, different
+  context — worth a look`.
+- `None found` is a valid and honest answer.
+
+### 5. Next steps — go deeper
+
+At the end of the analysis, produce a **Next steps — go deeper**
+section. This is the most important section for iterative review:
+it defines concrete follow-up runs of this same skill that the human
+reviewer (or `auto-sec-report`) can execute to drill further.
+
+Each "next step" MUST be one of:
+
+- `auto-sec-report-pr pr:{n}` — a specific related PR surfaced by the
+  apply-elsewhere sweep.
+- `auto-sec-report-pr spec:{path}` — a spec that governs the area and
+  may have gaps worth verifying.
+- `auto-sec-report-pr branch:{name}` — a branch that is about to land
+  and touches the same surface.
+- `auto-sec-report-pr pr:{n} --deep-scan` — re-run the same PR with
+  full-repo grep if the initial sweep was module-scoped.
+- A named follow-up scope (e.g. "audit `packages/core/src/modules/sales/`
+  for TOCTOU on quote acceptance") with a one-sentence justification.
+
+Produce 3–10 next steps. Order them by expected security impact,
+highest first. Mark the single "recommended next run" so an
+autonomous driver can auto-queue it.
+
+### 6. Emit the artifact
+
+Two modes:
+
+#### 6a. Standalone mode (no `--out-fragment`)
+
+Write to `.ai/analysis/auto-sec-report-pr-{target-slug}-{DATE}.md`
+using this outline:
+
+```markdown
+# Auto Security Report (single unit) — {target caption}
+
+Target: **{pr:123 | spec:.ai/specs/... | branch:feat/...}**
+Base:   `{base}`
+Date:   {DATE}
+
+## Executive Summary
+
+- {count} findings: {N blocker, M major, L minor, K nit, I info}.
+- Top OWASP categories: {A01, A10}.
+- Top paranoid vectors surfaced: {TOCTOU, SSRF redirect chain, JWT
+  alg confusion, ...}.
+- Recommended next run: `auto-sec-report-pr {target}` — {one sentence}.
+
+## Findings
+
+### [Blocker] A01 Broken Access Control — `path/to/file.ts:42`
+
+- **What:** {one sentence}
+- **Why:** {one sentence}
+- **Fix:** {one sentence}
+- **Apply elsewhere:**
+  - `path/to/other.ts:88` — {one-line justification}
+  - ...
+
+### [Major] A10 SSRF — `path/to/file.ts:120`
+... repeat ...
+
+## Paranoid Deep Vectors — What Was Checked
+
+A checklist of non-obvious vectors exercised against this unit, with
+a short outcome per vector: `covered`, `risk surfaced`, `not
+applicable`, or `inconclusive (next step)`.
+
+| Vector | Outcome | Location or note |
+|---|---|---|
+| TOCTOU on money-moving flows | risk surfaced | path/to/file.ts:200 |
+| Cache-key cross-tenant leakage | covered | organization_id present |
+| JWT algorithm confusion | not applicable | no JWT surface changed |
+| ... | ... | ... |
+
+## Next Steps — Go Deeper
+
+Ordered highest-impact first. The **recommended next run** is marked.
+
+- **[recommended]** `auto-sec-report-pr pr:1234` — {why this is the
+  biggest remaining risk}.
+- `auto-sec-report-pr spec:.ai/specs/2026-04-15-foo.md` — {why}.
+- `auto-sec-report-pr branch:feat/bar` — {why}.
+- Audit `packages/core/src/modules/sales/` for TOCTOU on concurrent
+  shipment creation — {why}.
+- ...
+
+## Appendix — Inputs
+
+- Changed files: {count} (list first 20, then `...`).
+- PR body / spec body excerpt (redacted of secrets): N lines.
+- Commits inspected: {list of SHAs when target is a PR/branch}.
+```
+
+Also render a stand-alone HTML mirror at
+`.ai/analysis/auto-sec-report-pr-{target-slug}-{DATE}.html` following
+the same HTML rules documented in `auto-sec-report`:
+
+- Inline `<style>` only; no JS; no remote assets.
+- Mirror every section. Preserve every PR/issue/CVE link as `<a>` with
+  `rel="noopener noreferrer"`.
+
+After the artifacts exist, follow `.ai/skills/auto-create-pr/SKILL.md`
+verbatim to open a docs-only PR against `develop`. PR title:
+`docs(analysis): add auto-sec-report-pr for {target caption}`. Labels:
+`review`, `documentation`, `security`, `skip-qa`. Never merge from
+within this skill.
+
+#### 6b. Sub-unit mode (`--out-fragment` set)
+
+Skip artifact creation, PR creation, labelling, and auto-review.
+Instead, write a markdown section fragment to the path given by
+`--out-fragment`. The fragment MUST begin with a level-2 heading
+(`## {target caption}`) and MUST include:
+
+- Executive summary (as bullets, no subsection heading).
+- All Findings as level-3 sections with the same shape as standalone.
+- The "Paranoid Deep Vectors" table.
+- The "Next Steps — Go Deeper" list.
+
+Do NOT duplicate the report-wide front-matter or appendix — the
+driver (`auto-sec-report`) owns those. Fragments are concatenated by
+the driver in the order it specifies.
+
+### 7. Validation gate (docs-only)
+
+- `git diff --check` on the artifact files.
+- Secret-leak grep on the diff before commit:
+  ```bash
+  git diff origin/${BASE:-develop}..HEAD | \
+    grep -Ei "(aws_secret|password\\s*=|bearer\\s+[A-Za-z0-9._-]{20,}|-----BEGIN [A-Z ]*PRIVATE KEY-----)"
+  ```
+  If matched: stop, redact, recommit.
+- Manual re-read of both artifacts; every PR/issue link resolves.
+
+### 8. Self-review and BC review
+
+Apply `.ai/skills/code-review/SKILL.md` to the diff of the artifact
+files themselves (not the unit under analysis). Because the change is
+docs-only, the contract-surface risk is limited to accidentally
+exfiltrating PR-body or spec-body content that contains secrets or
+internal URLs. Redact if found.
+
+### 9. Autofix pass
+
+In standalone mode only: invoke
+`.ai/skills/auto-review-pr/SKILL.md` against the docs PR in autofix
+mode. Apply fixes as new commits. Never rewrite history.
+
+### 10. Summary comment
+
+Post the comprehensive summary comment required by
+`.ai/skills/auto-create-pr/SKILL.md` step 12. In the "What can go
+wrong" section, be explicit about limits:
+
+- Classification is heuristic. Paranoid findings can be false
+  positives; a human reviewer must confirm.
+- Apply-elsewhere and Next-steps candidates are suggestions. They
+  are not verified vulnerabilities.
+- When the target was a spec, findings reflect spec intent only;
+  real behavior depends on implementation.
+
+### 11. Release lock and cleanup
+
+When the target was a PR, release the `in-progress` label and post
+the completion comment (follow `auto-review-pr` step 11 verbatim).
+Always do this in a trap/finally even on failure.
+
+```bash
+cd "$REPO_ROOT"
+if [ "$CREATED_WORKTREE" = "1" ]; then
+  git worktree remove --force "$WORKTREE_DIR"
+fi
+git worktree prune
+```
+
+### 12. Resumability
+
+If the run cannot finish in a single invocation:
+
+- In standalone mode: leave `Status: in-progress` in the docs PR body
+  and post the verbatim hand-off comment
+  `🤖 auto-sec-report-pr is not complete. Resume with /auto-continue-pr {prNumber}.`
+- In sub-unit mode: write the partial fragment to `--out-fragment`
+  and exit with a non-zero status + a one-line stderr message that
+  the driver (`auto-sec-report`) can catch.
+
+## Rules
+
+- Always run the claim/lock protocol when the target is a PR.
+- Always run in an isolated worktree. Reuse the current linked
+  worktree when already inside one. Never nest worktrees.
+- Always load the bundled `references/deep-attack-vectors.md` and
+  exercise every applicable category. Record each vector's outcome
+  even when it was a no-op.
+- Every Finding MUST cite a real file path or spec section.
+- Every Apply-elsewhere candidate MUST be confirmed by Grep.
+- Every Next-step MUST be executable as another run of this skill
+  (or a clearly-scoped audit a human can pick up).
+- Mark exactly one Next-step as `[recommended]` so a driver can
+  auto-queue it.
+- Never paste raw diffs, secrets, tokens, `.env` content, credentials,
+  internal hostnames, or user PII into the report. Redact to
+  `{REDACTED}`.
+- Reuse `code-review`, `auto-review-pr`, `spec-writing`, and
+  `pre-implement-spec` patterns and checklists. Do not duplicate
+  their rules — reference them.
+- Never merge any PR created by this skill. Labels:
+  `review`, `documentation`, `security`, `skip-qa`. Never `needs-qa`.
+- Sub-unit mode (`--out-fragment`) never opens a PR, never applies
+  labels, and never runs autofix. The driver owns PR delivery.

--- a/.ai/skills/auto-sec-report-pr/references/deep-attack-vectors.md
+++ b/.ai/skills/auto-sec-report-pr/references/deep-attack-vectors.md
@@ -1,0 +1,231 @@
+# Deep Attack Vectors — Paranoid Checklist
+
+This checklist complements the `code-review` security baseline. Use it
+during every `auto-sec-report-pr` run. For every section that applies
+to the unit under analysis, record an outcome: `covered`, `risk
+surfaced`, `not applicable`, or `inconclusive (next step)`.
+
+## Access control & identity
+
+- Wildcard ACL (`__all__`) for non-superadmins in menu items, nav
+  sections, notification handlers, mutation guards, command
+  interceptors, AI tools. Cross-check `packages/shared`, `packages/ui`,
+  `packages/core/src/modules/auth`, and
+  `packages/core/src/modules/customer_accounts`.
+- Role-name spoofing — verify `requireFeatures` is used instead of
+  `requireRoles` on guarded routes. `role` rename without
+  ACL-feature-id mapping.
+- Feature-flag bypass — expose an ungated code path when the flag is
+  off. Confirm the flag gates both the UI and the API.
+- Portal / customer auth leaking staff features — customer session
+  that can invoke staff-only ACL features via shared endpoints.
+- Session fixation and session rotation — was the session id rotated
+  after login, password change, MFA enable, privilege escalation?
+- JWT algorithm confusion (`alg: none`, HS↔RS key swap), missing
+  `iss`/`aud`/`exp` checks, loose `clockTolerance`, token replay
+  after password reset. Confirm key material is not read from
+  attacker-controlled input.
+- Sudo / step-up challenges — rate-limit identifier scope, replayable
+  challenge, challenge state tied to tenant.
+- Customer auth compound rate-limit identifiers — correct identifier
+  tuple (tenant + email + ip) so bucket collisions cannot mask brute
+  force.
+
+## Tenant isolation
+
+- `organization_id` and `tenant_id` present on every read and write
+  path. Confirm `findWithDecryption`/`findOneWithDecryption` are used,
+  not raw `em.find`/`em.findOne`.
+- Cache keys include tenant scope — memory / SQLite / Redis. Stale
+  cache entries after tenant rename/delete.
+- Shared in-memory registries (services, maps, singletons) keyed
+  without tenant.
+- SSE channels and broadcast events — confirm event ids are
+  tenant-scoped. Confirm `clientBroadcast`/`portalBroadcast` do not
+  bridge events across tenants.
+- Background worker jobs — the payload carries tenant id, the worker
+  refuses mismatched tenants, and retries do not replay cross-tenant.
+- Public endpoints (quote acceptance, magic link, webhook ingress)
+  MUST validate the tenant from the signed token/URL, not from a
+  query parameter.
+
+## Cryptography and secrets
+
+- PII fields encrypted at rest by default — check module-registered
+  encryption maps and `data/validators.ts` for GDPR-marked fields.
+- Password hashing — bcryptjs cost ≥ 10, never logged, constant-time
+  compare on login.
+- Signing keys rotated, key-id (`kid`) recorded in JWTs, keys not in
+  code or `.env` committed to git.
+- Timing-safe compare used for signatures, tokens, magic links. No
+  `===` or `.startsWith` on secrets.
+- TLS required on outbound calls; cert verification not disabled;
+  no `NODE_TLS_REJECT_UNAUTHORIZED=0` in production paths.
+
+## Injection and deserialization
+
+- SQL / ORM — parameterized queries; no string concatenation into
+  `em.raw`, `em.execute`, migrations.
+- Command injection — no `execSync(userInput)`, no `shell: true` with
+  attacker-controlled args. Prefer `execa` with args array.
+- Template injection — MJML/handlebars/jsx-email rendered from
+  attacker-controlled templates.
+- XSS — HTML rendering of user input without escaping; `dangerouslySetInnerHTML`;
+  unescaped markdown rendering.
+- Prototype pollution — `JSON.parse` + object spread into configs;
+  `lodash.merge` on attacker input; `qs.parse` default depth; explicit
+  rejection of `__proto__`, `constructor`, `prototype` keys.
+- Deserialization — `yaml.load` vs `yaml.safeLoad`; `node-serialize`;
+  `vm`/`Function`/`eval` sinks; `require()` with dynamic paths.
+- ReDoS — user-supplied regex; catastrophic backtracking in zod
+  `regex`, email / URL / phone validators, search tokenizers, log
+  parsers.
+- Log forging / log injection — newline injection into structured
+  logs; unescaped user input into log messages that feed downstream
+  parsers.
+
+## Upload, attachment, and file handling
+
+- Content-type sniffing — trust actual magic bytes, not the
+  `Content-Type` header.
+- Path traversal — reject `..`, absolute paths, null bytes, symlink
+  escapes. Canonicalize then validate against a safe prefix.
+- Archive slip (`zip-slip`) — validate entry paths when extracting
+  archives.
+- XML attachments — XXE disabled, DTDs disabled, entity expansion
+  limited.
+- Image pipeline — hardened before `sharp`; reject decompression bombs
+  (pixel budget, byte budget).
+- PDF text extraction — no shell-out to OCR; sandboxed parser.
+- Public vs private partitions — tenant scope enforced on public
+  partition access.
+
+## SSRF and outbound HTTP
+
+- Allowlist for outbound URLs (webhooks, preview fetchers, avatar
+  loaders, OAuth metadata endpoints).
+- Block private, link-local, loopback, metadata (169.254.169.254 and
+  IPv6 `fd00::/8`), `file://`, `gopher://`, `dict://`, `data:` where
+  inappropriate.
+- DNS rebinding protection — resolve once and reuse the IP, or
+  re-check against the allowlist after resolution.
+- Redirect chain — follow at most N hops, re-validate each hop against
+  the allowlist. Reject cross-protocol redirects.
+- Host header handling — reflected Host never used to construct
+  outbound URLs.
+
+## Redirect and origin handling
+
+- Open redirect — validate relative vs absolute, reject `//evil.com`,
+  unicode/RTL, protocol-relative, newline-in-URL, control characters.
+- CORS — `Access-Control-Allow-Origin: *` not used with credentials;
+  origin allowlist is exact-match (no suffix match vulnerability);
+  no echoing of attacker-supplied origin.
+- CSRF — state-changing endpoints require same-site cookies or
+  explicit token; no state mutation on `GET`.
+
+## Webhooks and integrations
+
+- Inbound webhooks — signature verification enforced, timing-safe
+  compare, secret derived per tenant or per integration, not a shared
+  global secret.
+- Replay protection — monotonic timestamp window, nonce cache keyed
+  (tenant, nonce), TTL aligned with allowable clock skew.
+- Signature-scheme downgrade — reject older scheme versions once a
+  newer one is expected. Never accept unsigned deliveries.
+- Idempotency — unique constraint on (tenant, idempotency_key) or
+  (tenant, provider_event_id). Exactly-once semantics on side-effects.
+- Outbound webhooks — Standard Webhooks signing, secret rotation,
+  delivery attempt dedup, targeted retries, dead-letter queue audit.
+
+## Money, orders, and workflows
+
+- TOCTOU on quote acceptance → order creation, public quote endpoints.
+- Overshipment on concurrent shipment creation.
+- Double-credit on concurrent return → credit memo.
+- Double-charge on repeated payment submit / refund.
+- Workflow failure visibility — failures halt the workflow by default;
+  failed activities surface in the list and detail views.
+- Compensation saga correctness on partial failures.
+- Currency rounding direction (half-even) used consistently; no
+  `number` for money (use `Decimal`/`bigint`/string); cross-currency
+  totals require FX.
+
+## Rate limiting and abuse
+
+- Rate-limit identifier tuple — (tenant, user/email, ip) with a
+  bucket size that survives distribution. IP-only is insufficient
+  behind a proxy.
+- Burst vs sustained — token-bucket with refill that matches the
+  endpoint sensitivity. Account lockouts are time-bounded and
+  observable.
+- Captcha / MFA fallback on suspicious thresholds.
+
+## Cookies, headers, and CSP
+
+- Cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or `Strict` for
+  admin), `Path` scoped, `Domain` minimal.
+- `X-Frame-Options: DENY` or `Content-Security-Policy:
+  frame-ancestors 'none'` to defeat clickjacking on sensitive views.
+- CSP free of `unsafe-inline` and `unsafe-eval`; `object-src 'none'`;
+  `base-uri 'none'` where possible; nonces/hashes for inline scripts.
+- HSTS with `includeSubDomains` and adequate `max-age`.
+- Referrer-Policy tight enough to avoid leaking cross-origin referers.
+- `X-Content-Type-Options: nosniff`, `Permissions-Policy` for camera/
+  microphone/geolocation if embedded.
+
+## API hygiene
+
+- `openApi` exported on every route (required for docs/discovery).
+- zod schemas use `.strict()` by default — no mass assignment via
+  `.passthrough()` on write operations.
+- Error shape is minimal — no stack traces, no internal module
+  paths, no tenant ids to unauthenticated callers.
+- Pagination caps (`pageSize` ≤ 100) to prevent data exfiltration
+  via large lists.
+- IDs in URLs use UUIDs; numeric ids on public endpoints invite IDOR.
+
+## Supply chain and dependencies
+
+- Dependencies pinned in lockfiles; Renovate/Dependabot drift
+  reviewed.
+- No post-install scripts from untrusted packages.
+- Transitive `vm2` / deprecated sandbox packages — removed.
+- Internal package paths (`@open-mercato/*`) cannot be shadowed by
+  public packages.
+- `yarn audit` / `npm audit` surface triaged.
+
+## Observability and forensics
+
+- Sensitive actions (login, password reset, role change, permission
+  grant, export) logged with actor, tenant, target, timestamp, IP.
+- Failure paths logged, not swallowed. `catch { }` is a red flag.
+- Log PII policy — redact emails/phones/addresses where appropriate.
+- Secrets never logged (check bearer tokens, API keys, private keys).
+
+## Infrastructure and environments
+
+- Environment variables documented and fail-closed at boot when
+  missing. No default secrets.
+- Separate credentials per environment; no prod secrets in dev
+  images.
+- CORS, CSP, and cookie flags have production profiles, not just
+  dev defaults.
+- Build artifacts exclude `.env`, test fixtures, and demo seeds.
+
+## Spec-specific (when target is a spec)
+
+When the unit under analysis is a spec file, also verify:
+
+- Every new route has an explicit `requireFeatures`/`requireAuth`
+  guard, with the ACL feature id declared in the spec.
+- Every new entity lists which fields are PII/encrypted and which
+  are indexed, so that `fieldPolicy.excluded` covers sensitive
+  columns.
+- Every new event id is tenant-scoped by default; `clientBroadcast`/
+  `portalBroadcast` calls out tenant boundary.
+- Every new worker declares idempotency (unique key, retry strategy).
+- Every new external integration declares allowlist and signature
+  verification.
+- Migration & Backward Compatibility section exists for any changes
+  to the 13 contract surfaces (`BACKWARD_COMPATIBILITY.md`).

--- a/.ai/skills/auto-sec-report/SKILL.md
+++ b/.ai/skills/auto-sec-report/SKILL.md
@@ -1,89 +1,69 @@
 ---
 name: auto-sec-report
-description: Generate an OWASP-oriented security analysis report for a window of merged pull requests and deliver it as a docs-only PR. Accepts a date (reports PRs merged on or after that date), a PR number floor (reports PRs whose number is >= that value), or defaults to the last 7 days when nothing is specified. For each PR, classifies whether it fixes a security issue, maps it to the relevant OWASP Top 10 2021 category, and calls out other places in the codebase where the same fix or hardening pattern should be applied. Writes both markdown and HTML artifacts under `.ai/analysis/`. Uses the `auto-create-pr` workflow to open a PR against `develop` (never merges), and hands off to `auto-continue-pr` when the run cannot finish in one pass.
+description: Driver that runs `auto-sec-report-pr` across a window of units of work and aggregates the findings into a single docs-only PR. Accepts a window spec that can be a date (PRs merged on or after it), a PR number floor (PRs whose number is >= it), a branch name (analyze the branch diff as a single unit), a spec path (analyze one spec as a single unit), or nothing (defaults to the last 7 days of merged PRs). Loops `auto-sec-report-pr` per unit in sub-unit mode, concatenates the markdown fragments, renders a combined markdown + HTML report under `.ai/analysis/`, carries forward each unit's "Next steps — go deeper" into a consolidated drill-deeper list at the top of the report, and opens a PR against `develop` (never merges). Uses `auto-create-pr` for branch/worktree/commit/label discipline and hands off to `auto-continue-pr` when the run cannot finish in one pass.
 ---
 
-# Auto Security Report
+# Auto Security Report — Driver
 
-Produce a security-engineer-facing report that reviews a window of merged
-pull requests for OWASP Top 10 risk signals, identifies PRs that
-introduced or fixed security issues, and proposes where the same fix or
-hardening pattern should be applied elsewhere in the codebase. The final
-deliverable is a docs-only PR against `develop` with markdown and HTML
-artifacts under `.ai/analysis/`.
-
-This skill is a specialization of `auto-create-pr`. It adopts that skill's
-worktree, branch, commit, validation, self-review, and label discipline
-verbatim. The sections below describe only the security-specific content
-and the few places where the flow deviates from the generic
-`auto-create-pr` workflow.
+Aggregate a security analysis across a window of units of work. This
+skill does not perform the per-unit analysis itself; it delegates that
+to `auto-sec-report-pr` (the single-unit skill) and combines the
+resulting fragments into a single docs-only PR. The report preserves
+every per-unit finding, every "Apply elsewhere" pointer, and every
+"Next steps — go deeper" suggestion so the reviewer can keep drilling
+into specific areas with additional `auto-sec-report-pr` runs.
 
 ## Arguments
 
-- `{windowSpec}` (optional) — one of:
-  - A date in `YYYY-MM-DD` form (e.g. `2026-04-10`). Report covers every
-    PR merged on or after that date, up to today (UTC).
-  - A PR number (e.g. `1200`). Report covers every PR whose number is
-    greater than or equal to the given number and that is merged.
-  - Omitted — defaults to the last 7 days (UTC).
-- `--base <branch>` (optional) — which base branch to count merges into.
+`{windowSpec}` (optional) — one of:
+
+- A date in `YYYY-MM-DD` form — every PR merged on or after that date
+  into `--base` (default `develop`) up to today (UTC).
+- A PR number — every PR whose number is greater than or equal to
+  this value and that is merged into `--base`.
+- A branch name (e.g. `feat/foo`) — treated as a single unit of work;
+  the driver invokes `auto-sec-report-pr branch:{name}` exactly once
+  and still produces the aggregate report layout.
+- A spec path (any path ending in `.md` under `.ai/specs/` or
+  `.ai/specs/enterprise/`) — treated as a single unit of work;
+  driver invokes `auto-sec-report-pr spec:{path}` exactly once.
+- Omitted — defaults to the last 7 days (UTC) of merged PRs into
+  `--base`.
+
+Options:
+
+- `--base <branch>` (optional) — base ref for PR / branch diffs.
   Defaults to `develop`. Merges into `main` are still reported and
-  flagged separately.
-- `--include-open` (optional) — also include open non-draft PRs (off by
-  default). Open PRs are flagged as "not yet merged" but their diff is
-  still analysed for security signal.
-- `--deep-scan` (optional) — also sweep the current HEAD for **top OWASP
-  issues that match the patterns surfaced by PRs in the window**. Off by
-  default; on means the report includes a "Codebase cross-check" section.
-- `--slug <kebab-case>` (optional) — override the slug used in the plan
-  and artifact filenames. Default: derived from the window.
-- `--force` (optional) — bypass the claim-conflict check when a previous
-  run left a branch or plan behind.
+  flagged when a different base is specified.
+- `--include-open` (optional) — also include open non-draft PRs in
+  the queue, flagged as "not yet merged". Off by default.
+- `--deep-scan` (optional) — pass `--deep-scan` through to every
+  sub-unit call so the apply-elsewhere sweeps cover the whole repo.
+  Off by default.
+- `--max-units <n>` (optional) — cap the number of sub-unit runs.
+  Default: 50. Larger caps are allowed but keep the run paged.
+- `--slug <kebab-case>` (optional) — override the slug used in the
+  plan and artifact filenames. Default: derived from the window.
+- `--force` (optional) — bypass the claim-conflict check when a
+  previous run left a branch or plan behind.
 
-## OWASP Top 10 taxonomy
+## Relationship to other skills
 
-Use OWASP Top 10 2021 categories verbatim. Every classified PR MUST cite
-exactly one primary category (secondary categories allowed):
-
-- **A01: Broken Access Control** — missing tenant scoping, RBAC bypass,
-  IDOR, open redirects, privilege escalation, path traversal, over-scoped
-  `__all__`/wildcard ACL handling.
-- **A02: Cryptographic Failures** — weak hashing, missing encryption at
-  rest for PII, leaked secrets, bad JWT lifetime, `findOne` bypassing
-  `findWithDecryption`.
-- **A03: Injection** — SQL, NoSQL, command, template, header, CRLF, log
-  forging. Includes raw fetch/exec usage and XSS via unescaped HTML.
-- **A04: Insecure Design** — missing rate limits, missing idempotency on
-  money-moving flows, race conditions (double-shipment, double-credit),
-  workflows with no failure visibility.
-- **A05: Security Misconfiguration** — CORS, cookies without `SameSite` /
-  `HttpOnly` / `Secure`, debug routes in prod, default creds, verbose
-  errors, public S3/queue handles.
-- **A06: Vulnerable and Outdated Components** — bumped libs, pinned
-  versions, `yarn audit` style changes, removed shell-out dependencies.
-- **A07: Identification and Authentication Failures** — session rotation,
-  missing MFA, rate-limit identifiers, stale session reuse, forgot/reset
-  flows, magic-link hardening.
-- **A08: Software and Data Integrity Failures** — webhook signature
-  verification, replay protection, deserialization, signed URLs,
-  code-loading from untrusted sources.
-- **A09: Security Logging and Monitoring Failures** — missing audit logs,
-  silent failure paths, stack traces sent to clients, unlogged admin
-  actions.
-- **A10: Server-Side Request Forgery (SSRF)** — outbound HTTP allowlists,
-  blocked private/internal URLs in webhooks, avatar fetchers, OAuth
-  metadata endpoints, preview generators.
-
-When a PR fixes something outside this taxonomy (e.g. a pure availability
-fix), classify it as **Out of scope (not OWASP Top 10)** and still list
-it in the appendix.
+- **Delegates** to `.ai/skills/auto-sec-report-pr/SKILL.md` for every
+  unit of work. All paranoid checks, deep vectors, apply-elsewhere
+  sweeps, and next-step suggestions live in that skill. This driver
+  only orchestrates.
+- **Reuses** `.ai/skills/auto-create-pr/SKILL.md` for
+  branch/worktree/commit/validation/label discipline when opening the
+  aggregate PR.
+- **Hands off** to `.ai/skills/auto-continue-pr/SKILL.md` when the run
+  cannot finish in one invocation.
 
 ## Workflow
 
 ### 0. Pre-flight and claim
 
-Follow `.ai/skills/auto-create-pr/SKILL.md` step 0 verbatim. Branch name
-MUST use the `feat/` prefix:
+Follow `.ai/skills/auto-create-pr/SKILL.md` step 0 verbatim.
 
 ```bash
 DATE=$(date -u +%Y-%m-%d)
@@ -92,267 +72,215 @@ PLAN_PATH=".ai/runs/${DATE}-${SLUG}.md"
 BRANCH="feat/${SLUG}"
 ```
 
-### 1. Resolve the PR window
+### 1. Build the unit queue
 
-Same as `auto-qa-scenarios` step 1. Paginate until the floor is reached.
-Record the resolved window in the plan Overview.
+Translate `{windowSpec}` into an ordered list of units. Each entry is
+one of `pr:{n}`, `spec:{path}`, or `branch:{name}`.
 
-### 2. Gather per-PR evidence
+- **Date mode**: `gh pr list --state merged --base {base}` paginated
+  until everything merged on or after the date is captured. Emit
+  `pr:{n}` for each.
+- **PR number floor**: same listing, filtered by number ≥ floor.
+- **Branch mode**: a single-entry queue with `branch:{name}`.
+- **Spec mode**: a single-entry queue with `spec:{path}`.
+- **Default**: last 7 days of merged PRs.
 
-For each PR in the window:
+Sort the queue newest-first for PR lists so the driver surfaces the
+most recent risk first. Honor `--max-units`; if the queue is longer,
+truncate with a noted residue in the plan's Risks section and
+propose a follow-up invocation for the remainder.
 
-```bash
-gh pr view {number} --json number,title,url,author,body,labels,baseRefName,mergeCommit,mergedAt,files,additions,deletions
-gh pr diff {number} --patch
-```
+Record the resolved window (start date or PR floor, end date or
+target name, base branch, queue size) in the plan's Overview.
 
-From each PR extract:
+### 2. Draft the execution plan
 
-- Title, number, URL, merged date, base branch, labels.
-- Changed files (top-level module/package paths).
-- Strong signal keywords in title/body: `security`, `fix(security)`,
-  `CVE`, `SSRF`, `XSS`, `CSRF`, `IDOR`, `tenant`, `ACL`, `RBAC`,
-  `rate-limit`, `session`, `JWT`, `redirect`, `signature`, `encrypt`.
-- Diff-level signals:
-  - Raw `em.find(` / `em.findOne(` that were replaced with
-    `findWithDecryption` / `findOneWithDecryption` (A02).
-  - Missing / added `organization_id` or `tenant_id` filters (A01).
-  - Added URL allowlist / blocklist in webhook/workflow code (A10).
-  - Added signature verification on inbound webhooks (A08).
-  - Changed session handling, cookie flags, or JWT TTL (A07).
-  - Input validation via zod on previously untyped routes (A03).
-  - RBAC metadata additions (`requireFeatures`, `requireAuth`) (A01).
-  - Removed open redirect / unsafe redirect handling (A01).
-
-Cap the per-PR diff read at the changed files actually relevant. Never
-paste full diffs into the report.
-
-### 3. Classify PRs
-
-For each PR, produce a record:
-
-```json
-{
-  "number": 1234,
-  "title": "...",
-  "url": "https://github.com/{owner}/{repo}/pull/1234",
-  "mergedAt": "2026-04-12T10:21:00Z",
-  "owaspPrimary": "A01",
-  "owaspSecondary": ["A07"],
-  "classification": "security-fix | security-hardening | security-adjacent | non-security",
-  "whatChanged": "one sentence",
-  "whyItMatters": "one sentence",
-  "riskIfReverted": "one sentence",
-  "applyElsewhere": ["module or file path", "..."]
-}
-```
-
-Classification rules:
-
-- **security-fix** — PR title/body or diff explicitly addresses a
-  specific vulnerability (e.g. SSRF in CALL_WEBHOOK, open redirect in
-  locale switch, missing tenant scope in public quote endpoints).
-- **security-hardening** — PR tightens defences without naming a
-  specific vulnerability (e.g. adds rate-limit identifier, rotates
-  session tokens on login, enforces signature verification).
-- **security-adjacent** — PR touches a sensitive path (auth, tenant
-  scope, webhook dispatch) but does not change the security posture.
-- **non-security** — PR is docs, tests, DX, tooling, pure UI, or
-  refactor without security impact.
-
-### 4. Cross-code audit: "apply the same fix elsewhere"
-
-For every **security-fix** and **security-hardening** PR, try to find
-other places in the current codebase that exhibit the same
-pre-fix pattern. Use targeted grep sweeps:
-
-```bash
-# A02 example: surface leftover raw ORM calls that may bypass decryption
-Grep pattern: "em\\.findOne\\(" type=ts
-Grep pattern: "em\\.find\\("     type=ts
-
-# A01 example: webhook / public endpoints without organization_id scoping
-Grep pattern: "organization_?id" type=ts -B 2 -A 5
-
-# A10 example: outbound HTTP without allowlist helper
-Grep pattern: "(fetch|axios|undici)\\(" type=ts
-```
-
-Produce a targeted list **per fix** of files/functions that look similar
-and should be reviewed. Never claim a file is vulnerable without a
-concrete pattern match and a one-line justification.
-
-Hard limits to keep the report honest:
-
-- List at most 10 apply-elsewhere candidates per fix.
-- Never recommend a change without citing the exact file path.
-- Distinguish "same pattern, same risk" from "same pattern, different
-  context — worth a look" in the narrative.
-
-### 5. Draft the execution plan
-
-Follow `.ai/skills/auto-create-pr/SKILL.md` step 3. Required plan
-Progress phases:
+Follow `.ai/skills/auto-create-pr/SKILL.md` step 3 with a Progress
+section shaped like this:
 
 ```markdown
-### Phase 1: Data gathering
+### Phase 1: Queue and plan
 
-- [ ] 1.1 Resolve PR window and fetch merged PR metadata
-- [ ] 1.2 Enrich PRs with diffs, labels, and linked issue refs
+- [ ] 1.1 Resolve unit queue and record the window
 
-### Phase 2: Classification
+### Phase 2: Per-unit analysis
 
-- [ ] 2.1 Map each PR to an OWASP Top 10 category and classification
-- [ ] 2.2 Build per-fix "apply elsewhere" candidate lists via targeted greps
+- [ ] 2.N {target caption} — auto-sec-report-pr {target} --out-fragment ...
+```
 
-### Phase 3: Artifact generation
+Phase 2 MUST list one checkbox per unit in the queue, in order. The
+checkbox title MUST include the exact `auto-sec-report-pr` command
+the driver will run. Append commit SHA on each flip so
+`auto-continue-pr` can resume precisely.
 
-- [ ] 3.1 Write markdown report to `.ai/analysis/auto-sec-report-${DATE}.md`
-- [ ] 3.2 Render HTML mirror to `.ai/analysis/auto-sec-report-${DATE}.html`
-- [ ] 3.3 Spot-check artifacts render correctly, links resolve, and redactions held
+```markdown
+### Phase 3: Aggregation
+
+- [ ] 3.1 Concatenate fragments into `.ai/analysis/auto-sec-report-${DATE}.md`
+- [ ] 3.2 Build consolidated "Next steps — go deeper" list
+- [ ] 3.3 Render HTML mirror to `.ai/analysis/auto-sec-report-${DATE}.html`
+- [ ] 3.4 Spot-check artifacts: links resolve, redactions held, secret-grep clean
 
 ### Phase 4: PR delivery
 
 - [ ] 4.1 Commit artifacts, push branch, open PR against `develop` (do not merge)
-- [ ] 4.2 Apply `review`, `documentation`, `security`, and `skip-qa` labels with comments
+- [ ] 4.2 Apply `review`, `documentation`, `security`, `skip-qa` labels with comments
 ```
 
-### 6. Isolated worktree, branch, first commit
+### 3. Isolated worktree and first commit
 
 Follow `.ai/skills/auto-create-pr/SKILL.md` steps 4–5 verbatim.
 
-### 7. Execute the phases
+### 4. Execute the queue
 
-Run steps 1.1 → 3.3 in the worktree. Flip checkboxes and push per phase
-exactly like `auto-create-pr` step 6.
+For each unit in Phase 2, invoke `auto-sec-report-pr` in sub-unit
+mode. Pass `--out-fragment` so no per-unit PR is opened and no
+autofix pass is triggered:
 
-#### 7a. Markdown artifact layout
+```bash
+FRAGMENT_DIR=".ai/tmp/auto-sec-report/${DATE}-${SLUG}/fragments"
+mkdir -p "$FRAGMENT_DIR"
 
-Write to `.ai/analysis/auto-sec-report-${DATE}.md`:
+for UNIT in "${QUEUE[@]}"; do
+  FRAGMENT_PATH="${FRAGMENT_DIR}/$(slug "$UNIT").md"
+  invoke_skill "auto-sec-report-pr" \
+    --target "$UNIT" \
+    --base "${BASE:-develop}" \
+    ${DEEP_SCAN:+--deep-scan} \
+    --out-fragment "$FRAGMENT_PATH"
+done
+```
+
+Rules during the loop:
+
+- Honor the in-progress lock protocol owned by `auto-sec-report-pr`
+  when the unit is a PR. If a PR is locked by someone else, skip it,
+  note the skip in the plan under the unit's Progress line, and
+  continue.
+- If a sub-unit exits non-zero, capture the partial fragment (if
+  any), mark the unit's Progress line with `⚠ partial` and the
+  reason, and continue to the next unit. Do not abort the batch.
+- Flip the unit's Progress checkbox to `- [x]` with the commit SHA
+  once the fragment lands. Commit the progress update as its own
+  `docs(runs): mark ${SLUG} unit X complete` commit.
+- Push after every 5 units so `auto-continue-pr` always has a
+  recent checkpoint to resume from.
+
+### 5. Aggregate
+
+After every unit is processed, build the aggregate markdown at
+`.ai/analysis/auto-sec-report-${DATE}.md` using this outline:
 
 ```markdown
 # Auto Security Report — {window caption}
 
-Report window: **{start date or PR floor} through {end date}** (base: `{base}`).
+Window: **{start date or PR floor} through {end date} | branch:{name} | spec:{path}** (base: `{base}`).
+Units analyzed: {count} ({N PRs, M branches, L specs}).
+Partial / skipped units: {if any, inline with reasons}.
 
 ## Executive Summary
 
-- Reviewed **{count} merged PRs** in the requested window.
-- **{N}** PRs classified as security-fixes, **{M}** as security-hardening.
-- Top OWASP categories touched this window: {A01, A08, A10}.
-- {one sentence on the single riskiest residual area the reviewer should
-  double-check}.
+- Total findings: {N blocker, M major, L minor, K nit, I info}.
+- Top OWASP categories: {A01, A08, A10}.
+- Top paranoid vectors surfaced across units: {TOCTOU, cache-key
+  cross-tenant leakage, SSRF redirect chain, JWT alg confusion}.
+- Single sentence on the riskiest residual area the reviewer should
+  double-check.
+
+## Consolidated Next Steps — Go Deeper
+
+Every "Next steps" entry produced by per-unit fragments is listed
+here, deduplicated and ordered by expected impact. The single
+highest-impact entry is marked `[recommended]`.
+
+- **[recommended]** `auto-sec-report-pr {target}` — {why}.
+- `auto-sec-report-pr {target}` — {why}.
+- Audit `packages/core/src/modules/sales/` for TOCTOU on concurrent
+  shipment creation — {why}.
+- ...
 
 ## Risk Heatmap
 
-| OWASP Category | Security-fix PRs | Hardening PRs | Adjacent PRs | Notes |
+| OWASP Category | Blocker | Major | Minor | Notes |
 |---|---|---|---|---|
 | A01 Broken Access Control | {n} | {n} | {n} | {one sentence} |
 | A02 Cryptographic Failures | {n} | {n} | {n} | {one sentence} |
 | ... continue through A10 ... | | | | |
-| Out of scope (not OWASP Top 10) | — | — | — | {n} PRs |
+| Out of scope (not OWASP) | — | — | — | {n} findings |
 
-## Security-fix PRs
+## Paranoid Deep Vectors — Coverage Matrix
 
-For each security-fix, one subsection.
+Row per vector, column per unit outcome (`covered`, `risk surfaced`,
+`not applicable`, `inconclusive`). Abbreviated when units are many;
+full tables remain in the per-unit fragments.
 
-### [#{n}]({url}) {title}
+## Per-Unit Findings
 
-- **OWASP:** {A01} (secondary: {A07})
-- **What changed:** {one sentence}
-- **Why it matters:** {one sentence}
-- **Risk if reverted:** {one sentence}
-- **Apply the same fix elsewhere — candidate list:**
-  - `path/to/file.ts` — {one-line justification}
-  - `path/to/otherfile.ts` — {one-line justification}
-  - {up to 10 entries; "None found" is a valid and honest answer}
+{Concatenate every sub-unit fragment here, in queue order. Do not
+rewrite the fragments — keep the per-unit "Next Steps" sections
+intact so a reviewer can trace each consolidated entry back to its
+unit.}
 
-### [#{n}]({url}) {title}
-... repeat ...
+## Appendix — Queue
 
-## Security-hardening PRs
-
-{Same structure as security-fix.}
-
-## Security-adjacent PRs
-
-{One-line entries; group by OWASP category.}
-
-## Codebase cross-check  <!-- only if --deep-scan -->
-
-{Targeted grep findings that are not tied to a specific PR in the
-window. Same shape as apply-elsewhere, but standalone.}
-
-## Appendix: Full PR Inventory (window)
-
-Each item below is one PR from the requested window with OWASP
-classification.
+Each item below is one unit from the window with the exact invocation
+that was run.
 
 ### {YYYY-MM-DD}
 
-- [#{n}]({url}) {title} — OWASP {A01} — {security-fix|hardening|adjacent|non-security}
+- `auto-sec-report-pr pr:{n}` — [#{n}]({url}) {title} — status: {complete|partial|skipped}
+- `auto-sec-report-pr branch:{name}` — status: {...}
 - ...
 ```
 
-Rules for the markdown:
+Rules for the aggregate:
 
-- Every apply-elsewhere candidate MUST cite a file path you actually
-  confirmed exists via Grep. Do not invent paths.
-- If a PR body mentions a CVE, reference the CVE id verbatim; do not
-  paste exploit-style details.
-- Never paste raw tokens, secrets, `.env` content, credentials, private
-  URLs, or internal infrastructure hostnames. Redact to `{REDACTED}`.
-- Keep per-fix narrative tight. Push full enumeration to the appendix.
+- Do NOT paraphrase unit fragments. Include them verbatim under
+  Per-Unit Findings.
+- Deduplicate the consolidated "Next steps" list on exact command
+  equality; keep the highest-severity justification.
+- Mark exactly one `[recommended]` across the consolidated list,
+  even when multiple units each marked their own.
+- Never paste raw diffs, secrets, tokens, `.env` content,
+  credentials, internal hostnames, or user PII. Redact to
+  `{REDACTED}`.
 
-#### 7b. HTML artifact layout
+### 6. Render HTML mirror
 
-Same rules as `auto-qa-scenarios` step 6b. Write stand-alone HTML at
-`.ai/analysis/auto-sec-report-${DATE}.html` with:
+Write `.ai/analysis/auto-sec-report-${DATE}.html` following the HTML
+rules from `.ai/skills/auto-sec-report-pr/SKILL.md` step 6a:
 
-- Inline `<style>` only, no JS, no remote assets.
-- Mirror every section of the markdown (Executive Summary, Risk
-  Heatmap table, Security-fix PRs, Security-hardening PRs,
-  Security-adjacent PRs, optional Codebase cross-check, Appendix).
-- Every PR, issue, and CVE link as `<a href="..." rel="noopener noreferrer">`.
+- Stand-alone `<!DOCTYPE html>`, inline `<style>`, no JS, no remote
+  assets, `rel="noopener noreferrer"` on every link.
+- Mirror every section of the aggregate markdown.
 
-### 8. Validation gate (docs-only)
+### 7. Validation gate (docs-only)
 
-Same as `auto-qa-scenarios` step 7:
+Same as `auto-sec-report-pr` step 7:
 
-- `yarn lint` (frontmatter sanity).
-- `git diff --check`.
-- Manual re-read; spot-check that every PR link resolves.
+- `git diff --check` on the artifact files.
+- Secret-leak grep on the diff before commit.
+- Manual re-read; every PR/issue/CVE link resolves.
 
-Add one security-specific check: before committing, grep the diff for
-accidental secrets:
+### 8. Self-review and BC review
 
-```bash
-git diff origin/develop..HEAD | \
-  grep -Ei "(aws_secret|password\\s*=|bearer\\s+[A-Za-z0-9._-]{20,}|-----BEGIN [A-Z ]*PRIVATE KEY-----)"
-```
+Apply `.ai/skills/code-review/SKILL.md` to the artifact diff. Verify
+no PII, no internal hostnames, no secrets leaked through.
 
-If this matches, stop, redact, recommit, and document in the plan's
-Risks section.
-
-### 9. Self-review and BC review
-
-Apply `.ai/skills/code-review/SKILL.md`. This is docs-only, so the
-contract-surface risk is low — but the exfiltration risk is real.
-Re-read both artifacts and verify no internal URLs, no secrets, and no
-user PII from PR bodies leaked into the report.
-
-### 10. Open the PR
+### 9. Open the PR
 
 Follow `.ai/skills/auto-create-pr/SKILL.md` step 9 with:
 
 - Title: `docs(analysis): add auto-sec-report for {window caption}`.
 - Base: `develop`. Never merge directly.
-- Body MUST include `Tracking plan: .ai/runs/${DATE}-${SLUG}.md` and the
-  correct `Status:` line.
-- Body MUST link both artifacts under `.ai/analysis/` and state the
-  total PR count, security-fix count, and top OWASP categories touched.
+- Body MUST include `Tracking plan: .ai/runs/${DATE}-${SLUG}.md` and
+  the correct `Status:` line.
+- Body MUST link the aggregate markdown + HTML, state the queue size,
+  the blocker/major count, and the top OWASP categories, and repeat
+  the `[recommended]` next step verbatim so the reviewer can trigger
+  the drill-deeper run in one line.
 
-### 11. Labels
+### 10. Labels
 
 Apply in order, each with a short explanatory comment:
 
@@ -363,57 +291,60 @@ Apply in order, each with a short explanatory comment:
 
 Never `needs-qa`.
 
-### 12. Auto-review pass
+### 11. Auto-review pass
 
-Run `.ai/skills/auto-review-pr/SKILL.md` against the new PR in autofix
-mode. Never rewrite history.
+Run `.ai/skills/auto-review-pr/SKILL.md` against the new PR in
+autofix mode. Apply fixes as new commits. Never rewrite history.
 
-### 13. Summary comment
+### 12. Summary comment
 
 Post the comprehensive summary comment required by
-`.ai/skills/auto-create-pr/SKILL.md` step 12. In the **What can go
-wrong** section, be honest about report limitations:
+`.ai/skills/auto-create-pr/SKILL.md` step 12. In the "What can go
+wrong" section, be honest about report limitations:
 
-- Classification is heuristic. PRs with ambiguous security impact may
-  be miscategorised.
-- "Apply elsewhere" candidates are suggestions based on grep patterns.
-  A human reviewer must confirm before any fix is applied.
-- The report is a snapshot of the requested window. It does not replace
-  a full security audit.
+- Findings are aggregated from per-unit heuristic analysis; confirm
+  before acting.
+- "Apply elsewhere" and "Next steps" pointers are suggestions; a
+  human reviewer must confirm.
+- A large window can mask per-unit context; if anything looks
+  surprising, re-run the single-unit skill against the suspect unit.
 
-### 14. Cleanup and resumability
+### 13. Cleanup and resumability
 
 Follow `.ai/skills/auto-create-pr/SKILL.md` step 13.
 
 If the run cannot finish in a single invocation:
 
 1. Leave `Status: in-progress` in the PR body.
-2. Ensure the Progress checklist reflects what actually landed, with
-   commit SHAs on every completed step.
+2. Ensure the Phase-2 Progress checklist reflects which units
+   completed and which are pending, each with commit SHAs and the
+   exact `auto-sec-report-pr` command to resume.
 3. Post a PR comment that says verbatim:
    `🤖 auto-sec-report is not complete. Resume with /auto-continue-pr {prNumber}.`
-4. Release any `in-progress` lock per `auto-continue-pr` rules if one
-   was claimed during this run.
+4. Release any `in-progress` lock per `auto-continue-pr` rules.
 
 ## Rules
 
-- Always deliver as a PR. Never push the report to `develop` directly.
-  Never merge the PR from within this skill.
-- Default window is the last 7 days (UTC) when `{windowSpec}` is omitted.
-- Artifacts go under `.ai/analysis/` with a dated filename. Both markdown
-  and HTML MUST be produced in the same run.
-- Every PR listed in the report MUST carry exactly one primary OWASP
-  Top 10 2021 category or be marked `Out of scope (not OWASP Top 10)`.
-- Apply-elsewhere candidates MUST cite a file path confirmed via Grep.
-  `None found` is a valid and honest answer; never fabricate candidates.
-- Never paste raw diffs, secrets, tokens, `.env` content, credentials,
-  internal hostnames, or user PII into the report. Redact to
-  `{REDACTED}` when encountered.
-- Classification is heuristic; state that explicitly in the summary
-  comment's "What can go wrong" section.
-- Reuse `auto-create-pr` for branch/worktree/commit/validation/label
-  discipline. Do not reinvent those mechanics.
-- On partial completion, leave a `/auto-continue-pr {prNumber}` hand-off
-  comment and keep `Status: in-progress` on the PR body.
-- Labels on this skill's PR: `review`, `documentation`, `security`,
-  `skip-qa`. Never `needs-qa`.
+- This skill delegates per-unit analysis to `auto-sec-report-pr`.
+  Never re-implement the paranoid checks or the "Next steps"
+  production here — always call the sub-unit skill.
+- Always run in an isolated worktree. Never nest worktrees.
+- Always open a docs-only PR against `develop`. Never merge from
+  within this skill.
+- Default window is the last 7 days of merged PRs (UTC) when
+  `{windowSpec}` is omitted.
+- Branch and spec inputs are first-class: a single-entry queue is
+  still a valid driver run; the aggregate format is unchanged.
+- Aggregate markdown concatenates sub-unit fragments verbatim. Do not
+  rewrite them.
+- Consolidated "Next steps" list MUST deduplicate on exact command
+  equality and MUST mark exactly one entry `[recommended]`.
+- Never paste raw diffs, secrets, tokens, `.env` content,
+  credentials, internal hostnames, or user PII.
+- On partial batch runs (a unit skipped or failed), record the reason
+  inline and continue — do not abort the whole driver.
+- On partial completion of the driver itself, leave
+  `Status: in-progress` and post a `/auto-continue-pr {prNumber}`
+  hand-off comment.
+- Labels: `review`, `documentation`, `security`, `skip-qa`. Never
+  `needs-qa`.

--- a/.ai/skills/auto-sec-report/SKILL.md
+++ b/.ai/skills/auto-sec-report/SKILL.md
@@ -1,0 +1,419 @@
+---
+name: auto-sec-report
+description: Generate an OWASP-oriented security analysis report for a window of merged pull requests and deliver it as a docs-only PR. Accepts a date (reports PRs merged on or after that date), a PR number floor (reports PRs whose number is >= that value), or defaults to the last 7 days when nothing is specified. For each PR, classifies whether it fixes a security issue, maps it to the relevant OWASP Top 10 2021 category, and calls out other places in the codebase where the same fix or hardening pattern should be applied. Writes both markdown and HTML artifacts under `.ai/analysis/`. Uses the `auto-create-pr` workflow to open a PR against `develop` (never merges), and hands off to `auto-continue-pr` when the run cannot finish in one pass.
+---
+
+# Auto Security Report
+
+Produce a security-engineer-facing report that reviews a window of merged
+pull requests for OWASP Top 10 risk signals, identifies PRs that
+introduced or fixed security issues, and proposes where the same fix or
+hardening pattern should be applied elsewhere in the codebase. The final
+deliverable is a docs-only PR against `develop` with markdown and HTML
+artifacts under `.ai/analysis/`.
+
+This skill is a specialization of `auto-create-pr`. It adopts that skill's
+worktree, branch, commit, validation, self-review, and label discipline
+verbatim. The sections below describe only the security-specific content
+and the few places where the flow deviates from the generic
+`auto-create-pr` workflow.
+
+## Arguments
+
+- `{windowSpec}` (optional) — one of:
+  - A date in `YYYY-MM-DD` form (e.g. `2026-04-10`). Report covers every
+    PR merged on or after that date, up to today (UTC).
+  - A PR number (e.g. `1200`). Report covers every PR whose number is
+    greater than or equal to the given number and that is merged.
+  - Omitted — defaults to the last 7 days (UTC).
+- `--base <branch>` (optional) — which base branch to count merges into.
+  Defaults to `develop`. Merges into `main` are still reported and
+  flagged separately.
+- `--include-open` (optional) — also include open non-draft PRs (off by
+  default). Open PRs are flagged as "not yet merged" but their diff is
+  still analysed for security signal.
+- `--deep-scan` (optional) — also sweep the current HEAD for **top OWASP
+  issues that match the patterns surfaced by PRs in the window**. Off by
+  default; on means the report includes a "Codebase cross-check" section.
+- `--slug <kebab-case>` (optional) — override the slug used in the plan
+  and artifact filenames. Default: derived from the window.
+- `--force` (optional) — bypass the claim-conflict check when a previous
+  run left a branch or plan behind.
+
+## OWASP Top 10 taxonomy
+
+Use OWASP Top 10 2021 categories verbatim. Every classified PR MUST cite
+exactly one primary category (secondary categories allowed):
+
+- **A01: Broken Access Control** — missing tenant scoping, RBAC bypass,
+  IDOR, open redirects, privilege escalation, path traversal, over-scoped
+  `__all__`/wildcard ACL handling.
+- **A02: Cryptographic Failures** — weak hashing, missing encryption at
+  rest for PII, leaked secrets, bad JWT lifetime, `findOne` bypassing
+  `findWithDecryption`.
+- **A03: Injection** — SQL, NoSQL, command, template, header, CRLF, log
+  forging. Includes raw fetch/exec usage and XSS via unescaped HTML.
+- **A04: Insecure Design** — missing rate limits, missing idempotency on
+  money-moving flows, race conditions (double-shipment, double-credit),
+  workflows with no failure visibility.
+- **A05: Security Misconfiguration** — CORS, cookies without `SameSite` /
+  `HttpOnly` / `Secure`, debug routes in prod, default creds, verbose
+  errors, public S3/queue handles.
+- **A06: Vulnerable and Outdated Components** — bumped libs, pinned
+  versions, `yarn audit` style changes, removed shell-out dependencies.
+- **A07: Identification and Authentication Failures** — session rotation,
+  missing MFA, rate-limit identifiers, stale session reuse, forgot/reset
+  flows, magic-link hardening.
+- **A08: Software and Data Integrity Failures** — webhook signature
+  verification, replay protection, deserialization, signed URLs,
+  code-loading from untrusted sources.
+- **A09: Security Logging and Monitoring Failures** — missing audit logs,
+  silent failure paths, stack traces sent to clients, unlogged admin
+  actions.
+- **A10: Server-Side Request Forgery (SSRF)** — outbound HTTP allowlists,
+  blocked private/internal URLs in webhooks, avatar fetchers, OAuth
+  metadata endpoints, preview generators.
+
+When a PR fixes something outside this taxonomy (e.g. a pure availability
+fix), classify it as **Out of scope (not OWASP Top 10)** and still list
+it in the appendix.
+
+## Workflow
+
+### 0. Pre-flight and claim
+
+Follow `.ai/skills/auto-create-pr/SKILL.md` step 0 verbatim. Branch name
+MUST use the `feat/` prefix:
+
+```bash
+DATE=$(date -u +%Y-%m-%d)
+SLUG="${SLUG_OVERRIDE:-auto-sec-report-${DATE}}"
+PLAN_PATH=".ai/runs/${DATE}-${SLUG}.md"
+BRANCH="feat/${SLUG}"
+```
+
+### 1. Resolve the PR window
+
+Same as `auto-qa-scenarios` step 1. Paginate until the floor is reached.
+Record the resolved window in the plan Overview.
+
+### 2. Gather per-PR evidence
+
+For each PR in the window:
+
+```bash
+gh pr view {number} --json number,title,url,author,body,labels,baseRefName,mergeCommit,mergedAt,files,additions,deletions
+gh pr diff {number} --patch
+```
+
+From each PR extract:
+
+- Title, number, URL, merged date, base branch, labels.
+- Changed files (top-level module/package paths).
+- Strong signal keywords in title/body: `security`, `fix(security)`,
+  `CVE`, `SSRF`, `XSS`, `CSRF`, `IDOR`, `tenant`, `ACL`, `RBAC`,
+  `rate-limit`, `session`, `JWT`, `redirect`, `signature`, `encrypt`.
+- Diff-level signals:
+  - Raw `em.find(` / `em.findOne(` that were replaced with
+    `findWithDecryption` / `findOneWithDecryption` (A02).
+  - Missing / added `organization_id` or `tenant_id` filters (A01).
+  - Added URL allowlist / blocklist in webhook/workflow code (A10).
+  - Added signature verification on inbound webhooks (A08).
+  - Changed session handling, cookie flags, or JWT TTL (A07).
+  - Input validation via zod on previously untyped routes (A03).
+  - RBAC metadata additions (`requireFeatures`, `requireAuth`) (A01).
+  - Removed open redirect / unsafe redirect handling (A01).
+
+Cap the per-PR diff read at the changed files actually relevant. Never
+paste full diffs into the report.
+
+### 3. Classify PRs
+
+For each PR, produce a record:
+
+```json
+{
+  "number": 1234,
+  "title": "...",
+  "url": "https://github.com/{owner}/{repo}/pull/1234",
+  "mergedAt": "2026-04-12T10:21:00Z",
+  "owaspPrimary": "A01",
+  "owaspSecondary": ["A07"],
+  "classification": "security-fix | security-hardening | security-adjacent | non-security",
+  "whatChanged": "one sentence",
+  "whyItMatters": "one sentence",
+  "riskIfReverted": "one sentence",
+  "applyElsewhere": ["module or file path", "..."]
+}
+```
+
+Classification rules:
+
+- **security-fix** — PR title/body or diff explicitly addresses a
+  specific vulnerability (e.g. SSRF in CALL_WEBHOOK, open redirect in
+  locale switch, missing tenant scope in public quote endpoints).
+- **security-hardening** — PR tightens defences without naming a
+  specific vulnerability (e.g. adds rate-limit identifier, rotates
+  session tokens on login, enforces signature verification).
+- **security-adjacent** — PR touches a sensitive path (auth, tenant
+  scope, webhook dispatch) but does not change the security posture.
+- **non-security** — PR is docs, tests, DX, tooling, pure UI, or
+  refactor without security impact.
+
+### 4. Cross-code audit: "apply the same fix elsewhere"
+
+For every **security-fix** and **security-hardening** PR, try to find
+other places in the current codebase that exhibit the same
+pre-fix pattern. Use targeted grep sweeps:
+
+```bash
+# A02 example: surface leftover raw ORM calls that may bypass decryption
+Grep pattern: "em\\.findOne\\(" type=ts
+Grep pattern: "em\\.find\\("     type=ts
+
+# A01 example: webhook / public endpoints without organization_id scoping
+Grep pattern: "organization_?id" type=ts -B 2 -A 5
+
+# A10 example: outbound HTTP without allowlist helper
+Grep pattern: "(fetch|axios|undici)\\(" type=ts
+```
+
+Produce a targeted list **per fix** of files/functions that look similar
+and should be reviewed. Never claim a file is vulnerable without a
+concrete pattern match and a one-line justification.
+
+Hard limits to keep the report honest:
+
+- List at most 10 apply-elsewhere candidates per fix.
+- Never recommend a change without citing the exact file path.
+- Distinguish "same pattern, same risk" from "same pattern, different
+  context — worth a look" in the narrative.
+
+### 5. Draft the execution plan
+
+Follow `.ai/skills/auto-create-pr/SKILL.md` step 3. Required plan
+Progress phases:
+
+```markdown
+### Phase 1: Data gathering
+
+- [ ] 1.1 Resolve PR window and fetch merged PR metadata
+- [ ] 1.2 Enrich PRs with diffs, labels, and linked issue refs
+
+### Phase 2: Classification
+
+- [ ] 2.1 Map each PR to an OWASP Top 10 category and classification
+- [ ] 2.2 Build per-fix "apply elsewhere" candidate lists via targeted greps
+
+### Phase 3: Artifact generation
+
+- [ ] 3.1 Write markdown report to `.ai/analysis/auto-sec-report-${DATE}.md`
+- [ ] 3.2 Render HTML mirror to `.ai/analysis/auto-sec-report-${DATE}.html`
+- [ ] 3.3 Spot-check artifacts render correctly, links resolve, and redactions held
+
+### Phase 4: PR delivery
+
+- [ ] 4.1 Commit artifacts, push branch, open PR against `develop` (do not merge)
+- [ ] 4.2 Apply `review`, `documentation`, `security`, and `skip-qa` labels with comments
+```
+
+### 6. Isolated worktree, branch, first commit
+
+Follow `.ai/skills/auto-create-pr/SKILL.md` steps 4–5 verbatim.
+
+### 7. Execute the phases
+
+Run steps 1.1 → 3.3 in the worktree. Flip checkboxes and push per phase
+exactly like `auto-create-pr` step 6.
+
+#### 7a. Markdown artifact layout
+
+Write to `.ai/analysis/auto-sec-report-${DATE}.md`:
+
+```markdown
+# Auto Security Report — {window caption}
+
+Report window: **{start date or PR floor} through {end date}** (base: `{base}`).
+
+## Executive Summary
+
+- Reviewed **{count} merged PRs** in the requested window.
+- **{N}** PRs classified as security-fixes, **{M}** as security-hardening.
+- Top OWASP categories touched this window: {A01, A08, A10}.
+- {one sentence on the single riskiest residual area the reviewer should
+  double-check}.
+
+## Risk Heatmap
+
+| OWASP Category | Security-fix PRs | Hardening PRs | Adjacent PRs | Notes |
+|---|---|---|---|---|
+| A01 Broken Access Control | {n} | {n} | {n} | {one sentence} |
+| A02 Cryptographic Failures | {n} | {n} | {n} | {one sentence} |
+| ... continue through A10 ... | | | | |
+| Out of scope (not OWASP Top 10) | — | — | — | {n} PRs |
+
+## Security-fix PRs
+
+For each security-fix, one subsection.
+
+### [#{n}]({url}) {title}
+
+- **OWASP:** {A01} (secondary: {A07})
+- **What changed:** {one sentence}
+- **Why it matters:** {one sentence}
+- **Risk if reverted:** {one sentence}
+- **Apply the same fix elsewhere — candidate list:**
+  - `path/to/file.ts` — {one-line justification}
+  - `path/to/otherfile.ts` — {one-line justification}
+  - {up to 10 entries; "None found" is a valid and honest answer}
+
+### [#{n}]({url}) {title}
+... repeat ...
+
+## Security-hardening PRs
+
+{Same structure as security-fix.}
+
+## Security-adjacent PRs
+
+{One-line entries; group by OWASP category.}
+
+## Codebase cross-check  <!-- only if --deep-scan -->
+
+{Targeted grep findings that are not tied to a specific PR in the
+window. Same shape as apply-elsewhere, but standalone.}
+
+## Appendix: Full PR Inventory (window)
+
+Each item below is one PR from the requested window with OWASP
+classification.
+
+### {YYYY-MM-DD}
+
+- [#{n}]({url}) {title} — OWASP {A01} — {security-fix|hardening|adjacent|non-security}
+- ...
+```
+
+Rules for the markdown:
+
+- Every apply-elsewhere candidate MUST cite a file path you actually
+  confirmed exists via Grep. Do not invent paths.
+- If a PR body mentions a CVE, reference the CVE id verbatim; do not
+  paste exploit-style details.
+- Never paste raw tokens, secrets, `.env` content, credentials, private
+  URLs, or internal infrastructure hostnames. Redact to `{REDACTED}`.
+- Keep per-fix narrative tight. Push full enumeration to the appendix.
+
+#### 7b. HTML artifact layout
+
+Same rules as `auto-qa-scenarios` step 6b. Write stand-alone HTML at
+`.ai/analysis/auto-sec-report-${DATE}.html` with:
+
+- Inline `<style>` only, no JS, no remote assets.
+- Mirror every section of the markdown (Executive Summary, Risk
+  Heatmap table, Security-fix PRs, Security-hardening PRs,
+  Security-adjacent PRs, optional Codebase cross-check, Appendix).
+- Every PR, issue, and CVE link as `<a href="..." rel="noopener noreferrer">`.
+
+### 8. Validation gate (docs-only)
+
+Same as `auto-qa-scenarios` step 7:
+
+- `yarn lint` (frontmatter sanity).
+- `git diff --check`.
+- Manual re-read; spot-check that every PR link resolves.
+
+Add one security-specific check: before committing, grep the diff for
+accidental secrets:
+
+```bash
+git diff origin/develop..HEAD | \
+  grep -Ei "(aws_secret|password\\s*=|bearer\\s+[A-Za-z0-9._-]{20,}|-----BEGIN [A-Z ]*PRIVATE KEY-----)"
+```
+
+If this matches, stop, redact, recommit, and document in the plan's
+Risks section.
+
+### 9. Self-review and BC review
+
+Apply `.ai/skills/code-review/SKILL.md`. This is docs-only, so the
+contract-surface risk is low — but the exfiltration risk is real.
+Re-read both artifacts and verify no internal URLs, no secrets, and no
+user PII from PR bodies leaked into the report.
+
+### 10. Open the PR
+
+Follow `.ai/skills/auto-create-pr/SKILL.md` step 9 with:
+
+- Title: `docs(analysis): add auto-sec-report for {window caption}`.
+- Base: `develop`. Never merge directly.
+- Body MUST include `Tracking plan: .ai/runs/${DATE}-${SLUG}.md` and the
+  correct `Status:` line.
+- Body MUST link both artifacts under `.ai/analysis/` and state the
+  total PR count, security-fix count, and top OWASP categories touched.
+
+### 11. Labels
+
+Apply in order, each with a short explanatory comment:
+
+- `review` — "PR is ready for code review."
+- `documentation` — "docs-only deliverable under `.ai/analysis/`."
+- `security` — "security-posture report; merits a security-savvy reviewer."
+- `skip-qa` — "docs-only report; no customer-facing behavior."
+
+Never `needs-qa`.
+
+### 12. Auto-review pass
+
+Run `.ai/skills/auto-review-pr/SKILL.md` against the new PR in autofix
+mode. Never rewrite history.
+
+### 13. Summary comment
+
+Post the comprehensive summary comment required by
+`.ai/skills/auto-create-pr/SKILL.md` step 12. In the **What can go
+wrong** section, be honest about report limitations:
+
+- Classification is heuristic. PRs with ambiguous security impact may
+  be miscategorised.
+- "Apply elsewhere" candidates are suggestions based on grep patterns.
+  A human reviewer must confirm before any fix is applied.
+- The report is a snapshot of the requested window. It does not replace
+  a full security audit.
+
+### 14. Cleanup and resumability
+
+Follow `.ai/skills/auto-create-pr/SKILL.md` step 13.
+
+If the run cannot finish in a single invocation:
+
+1. Leave `Status: in-progress` in the PR body.
+2. Ensure the Progress checklist reflects what actually landed, with
+   commit SHAs on every completed step.
+3. Post a PR comment that says verbatim:
+   `🤖 auto-sec-report is not complete. Resume with /auto-continue-pr {prNumber}.`
+4. Release any `in-progress` lock per `auto-continue-pr` rules if one
+   was claimed during this run.
+
+## Rules
+
+- Always deliver as a PR. Never push the report to `develop` directly.
+  Never merge the PR from within this skill.
+- Default window is the last 7 days (UTC) when `{windowSpec}` is omitted.
+- Artifacts go under `.ai/analysis/` with a dated filename. Both markdown
+  and HTML MUST be produced in the same run.
+- Every PR listed in the report MUST carry exactly one primary OWASP
+  Top 10 2021 category or be marked `Out of scope (not OWASP Top 10)`.
+- Apply-elsewhere candidates MUST cite a file path confirmed via Grep.
+  `None found` is a valid and honest answer; never fabricate candidates.
+- Never paste raw diffs, secrets, tokens, `.env` content, credentials,
+  internal hostnames, or user PII into the report. Redact to
+  `{REDACTED}` when encountered.
+- Classification is heuristic; state that explicitly in the summary
+  comment's "What can go wrong" section.
+- Reuse `auto-create-pr` for branch/worktree/commit/validation/label
+  discipline. Do not reinvent those mechanics.
+- On partial completion, leave a `/auto-continue-pr {prNumber}` hand-off
+  comment and keep `Status: in-progress` on the PR body.
+- Labels on this skill's PR: `review`, `documentation`, `security`,
+  `skip-qa`. Never `needs-qa`.

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -283,10 +283,21 @@ jobs:
 
       - name: Install standalone app dependencies
         working-directory: /tmp/standalone-app
+        # The scaffolded app ships an empty yarn.lock.template; `yarn install`
+        # must resolve ~1.6k deps fresh. Yarn 4.12 auto-enables hardened mode
+        # on pull_request workflows, which forces immutable installs and fails
+        # with YN0028. Disable both for this scaffolded-app install only — the
+        # monorepo install above still runs with --immutable.
+        env:
+          YARN_ENABLE_HARDENED_MODE: '0'
+          YARN_ENABLE_IMMUTABLE_INSTALLS: '0'
         run: yarn install
 
       - name: Install standalone enterprise package
         working-directory: /tmp/standalone-app
+        env:
+          YARN_ENABLE_HARDENED_MODE: '0'
+          YARN_ENABLE_IMMUTABLE_INSTALLS: '0'
         run: yarn add "@open-mercato/enterprise@${{ needs.snapshot.outputs.snapshot_version }}"
 
       - name: Generate standalone app modules


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md
Status: complete

## Goal
- Add two autonomous reporting skills that summarize a window of merged PRs and deliver the report as a docs-only PR under `.ai/analysis/`.

## What Changed
- New skill `auto-qa-scenarios` (`.ai/skills/auto-qa-scenarios/SKILL.md`) — groups merged PRs into P0/P1/P2 QA testing routes with click paths, verification steps, and regression symptoms. Writes both markdown and HTML artifacts.
- New skill `auto-sec-report` (`.ai/skills/auto-sec-report/SKILL.md`) — classifies each PR against OWASP Top 10 2021, highlights security-fix PRs, and proposes where the same fix should be applied elsewhere in the codebase. Writes both markdown and HTML artifacts.
- Both skills accept a date, a PR number floor, or default to the last 7 days. Both reuse `auto-create-pr`'s branch/worktree/commit/validation discipline and hand off to `auto-continue-pr` when a run cannot finish in one invocation.
- Registered both skills in `.ai/skills/README.md`.
- Added execution plan at `.ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md` with Progress checklist for resumability.

## Tests
- Docs-only change. No code modified.
- Verified SKILL.md YAML frontmatter is well-formed.
- Manual re-read of both skills for internal consistency and rule alignment with root `AGENTS.md` PR workflow.

## Backward Compatibility
- No contract surface changes. Skills are additive artifacts under `.ai/skills/`.

## Progress
See [Progress section in the plan](.ai/runs/2026-04-16-auto-qa-and-sec-report-skills.md#progress).

## Context
Both skills are specializations of `auto-create-pr`. They produce QA- and security-engineer-facing reports from a window of merged PRs, landing markdown + HTML artifacts under `.ai/analysis/` and opening a docs-only PR against `develop` (never merging). Format is inspired by #1527; filenames now live under `.ai/analysis/` per user guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)