### PR TITLE
chore(deps): bump follow-redirects from 1.15.11 to 1.16.0 (develop)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15205,12 +15205,12 @@ __metadata:
   linkType: hard
 
 "follow-redirects@npm:^1.0.0":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10/07372fd74b98c78cf4d417d68d41fdaa0be4dcacafffb9e67b1e3cf090bc4771515e65020651528faab238f10f9b9c0d9707d6c1574a6c0387c5de1042cde9ba
+  checksum: 10/3fbe3d80b3b544c22705d837aa5d4a0d07a740d913534a2620b0a004c610af4148e3b58723536dd099aaa1c9d3a155964bde9665d6e5cb331460809a1fc572fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Carries forward #1535 onto the `develop` branch so security-relevant dependency bumps land there instead of `main`.

Credit to @dependabot for the original bump. Original PR #1535 will be closed in favor of this one.

## Summary
- Bumps transitive dependency `follow-redirects` from 1.15.11 to 1.16.0 (yarn.lock only).
- Targets `develop` per team policy — direct dependency fixes are not committed to `main`.

## Test plan
- [ ] CI passes on `develop` branch.