### PR TITLE
fix(sales): resolve 500 errors on shipment ops + integer quantities (carries #1543)

### DIFF
--- a/packages/core/src/modules/sales/commands/__tests__/shipments.undo-transactions.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/shipments.undo-transactions.test.ts
@@ -1,0 +1,157 @@
+/** @jest-environment node */
+
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn().mockResolvedValue(null),
+  findWithDecryption: jest.fn().mockResolvedValue([]),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn().mockResolvedValue({}),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => ({
+  emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@open-mercato/core/modules/entities/lib/helpers', () => ({
+  setRecordCustomFields: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../../lib/dictionaries', () => ({
+  resolveDictionaryEntryValue: jest.fn().mockResolvedValue(null),
+}))
+
+jest.mock('../../lib/shipments/snapshots', () => ({
+  coerceShipmentQuantity: (v: unknown) => (typeof v === 'number' ? v : Number(v) || 0),
+  readShipmentItemsSnapshot: jest.fn().mockReturnValue([]),
+  refreshShipmentItemsSnapshot: jest.fn().mockResolvedValue(undefined),
+  buildShipmentItemSnapshots: jest.fn().mockReturnValue([]),
+}))
+
+const TEST_TENANT_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+const TEST_ORG_ID = 'bbbbbbbb-bbbb-4bbb-abbb-bbbbbbbbbbbb'
+const TEST_ORDER_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const TEST_SHIPMENT_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+
+function buildMockTx() {
+  return {
+    findOne: jest.fn().mockResolvedValue(null),
+    find: jest.fn().mockResolvedValue([]),
+    create: jest.fn(),
+    persist: jest.fn(),
+    remove: jest.fn(),
+    flush: jest.fn().mockResolvedValue(undefined),
+    getReference: jest.fn(),
+  }
+}
+
+function buildEnvelope(snapshotPayload: Record<string, unknown>) {
+  const tx = buildMockTx()
+  const transactional = jest.fn().mockImplementation(async (callback: (trx: any) => Promise<any>) => {
+    return callback(tx)
+  })
+  const em = { ...buildMockTx(), transactional }
+  const container = {
+    resolve: jest.fn().mockImplementation((name: string) => {
+      if (name === 'em') return { fork: jest.fn().mockReturnValue(em) }
+      if (name === 'dataEngine') return {}
+      return {}
+    }),
+  }
+  const ctx = {
+    container,
+    auth: { tenantId: TEST_TENANT_ID, orgId: TEST_ORG_ID },
+    selectedOrganizationId: TEST_ORG_ID,
+    organizationIds: [TEST_ORG_ID],
+    request: {} as Request,
+    organizationScope: null,
+  }
+  const logEntry = { payload: { undo: snapshotPayload } } as any
+  return { tx, em, transactional, container, ctx, logEntry }
+}
+
+// ---------------------------------------------------------------------------
+// Regression: shipment undo handlers must wrap recomputeFulfilledQuantities in
+// a transaction because it issues PESSIMISTIC_WRITE locks. Without an active
+// transaction the driver throws and the request 500s. (issue #1541)
+// ---------------------------------------------------------------------------
+
+describe('shipment undo handlers — transactional wrapping', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../shipments')
+  })
+
+  beforeEach(() => {
+    ;(findOneWithDecryption as jest.Mock).mockReset().mockResolvedValue(null)
+  })
+
+  it('createShipmentCommand.undo runs inside em.transactional', async () => {
+    const undo = commandRegistry.get('sales.shipments.create')?.undo
+    expect(undo).toBeInstanceOf(Function)
+
+    const envelope = buildEnvelope({
+      after: {
+        id: TEST_SHIPMENT_ID,
+        orderId: TEST_ORDER_ID,
+        organizationId: TEST_ORG_ID,
+        tenantId: TEST_TENANT_ID,
+        items: [],
+      },
+    })
+
+    await undo?.({ logEntry: envelope.logEntry, ctx: envelope.ctx as any } as any)
+
+    expect(envelope.transactional).toHaveBeenCalledTimes(1)
+  })
+
+  it('updateShipmentCommand.undo runs inside em.transactional', async () => {
+    const undo = commandRegistry.get('sales.shipments.update')?.undo
+    expect(undo).toBeInstanceOf(Function)
+
+    const envelope = buildEnvelope({
+      before: {
+        id: TEST_SHIPMENT_ID,
+        orderId: TEST_ORDER_ID,
+        organizationId: TEST_ORG_ID,
+        tenantId: TEST_TENANT_ID,
+        items: [],
+      },
+    })
+
+    await undo?.({ logEntry: envelope.logEntry, ctx: envelope.ctx as any } as any)
+
+    expect(envelope.transactional).toHaveBeenCalledTimes(1)
+  })
+
+  it('deleteShipmentCommand.undo runs inside em.transactional', async () => {
+    const undo = commandRegistry.get('sales.shipments.delete')?.undo
+    expect(undo).toBeInstanceOf(Function)
+
+    const envelope = buildEnvelope({
+      before: {
+        id: TEST_SHIPMENT_ID,
+        orderId: TEST_ORDER_ID,
+        organizationId: TEST_ORG_ID,
+        tenantId: TEST_TENANT_ID,
+        items: [],
+      },
+    })
+
+    await undo?.({ logEntry: envelope.logEntry, ctx: envelope.ctx as any } as any)
+
+    expect(envelope.transactional).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/sales/commands/shipments.ts
+++ b/packages/core/src/modules/sales/commands/shipments.ts
@@ -611,141 +611,145 @@ const updateShipmentCommand: CommandHandler<ShipmentUpdateInput, { shipmentId: s
     ensureTenantScope(ctx, input.tenantId)
     ensureOrganizationScope(ctx, input.organizationId)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const shipment = await findOneWithDecryption(
-      em,
-      SalesShipment,
-      { id: input.id },
-      { populate: ['order'] },
-      { tenantId: input.tenantId, organizationId: input.organizationId },
-    )
     const { translate } = await resolveTranslations()
-    if (!shipment || !shipment.order) {
-      throw new CrudHttpError(404, { error: 'sales.shipments.not_found' })
-    }
-    ensureSameScope(shipment, input.organizationId, input.tenantId)
-    const order = shipment.order as SalesOrder
-    if (input.orderId && input.orderId !== order.id) {
-      throw new CrudHttpError(400, { error: 'sales.shipments.invalid_order' })
-    }
-    const validatedItems = input.items
-      ? await validateShipmentItems({
-          em,
-          order,
-          items: input.items,
-          excludeShipmentId: shipment.id,
-        })
-      : null
-    const normalizedItems = validatedItems?.items ?? null
-    const lineMap = validatedItems?.lineMap ?? new Map<string, SalesOrderLine>()
-    if (input.shipmentNumber !== undefined) shipment.shipmentNumber = input.shipmentNumber ?? null
-    if (input.shippingMethodId !== undefined) shipment.shippingMethodId = input.shippingMethodId ?? null
-    if (input.statusEntryId !== undefined) {
-      shipment.statusEntryId = input.statusEntryId ?? null
-      shipment.status = await resolveDictionaryEntryValue(em, input.statusEntryId ?? null)
-    }
-    if (input.carrierName !== undefined) shipment.carrierName = input.carrierName ?? null
-    if (input.trackingNumbers !== undefined) shipment.trackingNumbers = parseTrackingNumbers(input.trackingNumbers)
-    if (input.shippedAt !== undefined) shipment.shippedAt = input.shippedAt ?? null
-    if (input.deliveredAt !== undefined) shipment.deliveredAt = input.deliveredAt ?? null
-    if (input.weightValue !== undefined) shipment.weightValue = input.weightValue !== null ? input.weightValue.toString() : null
-    if (input.weightUnit !== undefined) shipment.weightUnit = input.weightUnit ?? null
-    if (input.declaredValueNet !== undefined) {
-      shipment.declaredValueNet = input.declaredValueNet !== null ? input.declaredValueNet.toString() : null
-    }
-    if (input.declaredValueGross !== undefined) {
-      shipment.declaredValueGross = input.declaredValueGross !== null ? input.declaredValueGross.toString() : null
-    }
-    if (input.currencyCode !== undefined) shipment.currencyCode = input.currencyCode ?? null
-    if (input.notes !== undefined) shipment.notesText = input.notes ?? null
-    if (input.metadata !== undefined || input.shipmentAddressSnapshot !== undefined) {
-      shipment.metadata = mergeAddressSnapshot(
-        input.metadata ? cloneJson(input.metadata) : shipment.metadata ?? null,
-        input.shipmentAddressSnapshot
+
+    const shipment = await em.transactional(async (tx) => {
+      const shipmentEntity = await findOneWithDecryption(
+        tx,
+        SalesShipment,
+        { id: input.id },
+        { populate: ['order'] },
+        { tenantId: input.tenantId, organizationId: input.organizationId },
       )
-    }
-    shipment.updatedAt = new Date()
+      if (!shipmentEntity || !shipmentEntity.order) {
+        throw new CrudHttpError(404, { error: 'sales.shipments.not_found' })
+      }
+      ensureSameScope(shipmentEntity, input.organizationId, input.tenantId)
+      const order = shipmentEntity.order as SalesOrder
+      if (input.orderId && input.orderId !== order.id) {
+        throw new CrudHttpError(400, { error: 'sales.shipments.invalid_order' })
+      }
+      const validatedItems = input.items
+        ? await validateShipmentItems({
+            em: tx,
+            order,
+            items: input.items,
+            excludeShipmentId: shipmentEntity.id,
+          })
+        : null
+      const normalizedItems = validatedItems?.items ?? null
+      const lineMap = validatedItems?.lineMap ?? new Map<string, SalesOrderLine>()
+      if (input.shipmentNumber !== undefined) shipmentEntity.shipmentNumber = input.shipmentNumber ?? null
+      if (input.shippingMethodId !== undefined) shipmentEntity.shippingMethodId = input.shippingMethodId ?? null
+      if (input.statusEntryId !== undefined) {
+        shipmentEntity.statusEntryId = input.statusEntryId ?? null
+        shipmentEntity.status = await resolveDictionaryEntryValue(tx, input.statusEntryId ?? null)
+      }
+      if (input.carrierName !== undefined) shipmentEntity.carrierName = input.carrierName ?? null
+      if (input.trackingNumbers !== undefined) shipmentEntity.trackingNumbers = parseTrackingNumbers(input.trackingNumbers)
+      if (input.shippedAt !== undefined) shipmentEntity.shippedAt = input.shippedAt ?? null
+      if (input.deliveredAt !== undefined) shipmentEntity.deliveredAt = input.deliveredAt ?? null
+      if (input.weightValue !== undefined) shipmentEntity.weightValue = input.weightValue !== null ? input.weightValue.toString() : null
+      if (input.weightUnit !== undefined) shipmentEntity.weightUnit = input.weightUnit ?? null
+      if (input.declaredValueNet !== undefined) {
+        shipmentEntity.declaredValueNet = input.declaredValueNet !== null ? input.declaredValueNet.toString() : null
+      }
+      if (input.declaredValueGross !== undefined) {
+        shipmentEntity.declaredValueGross = input.declaredValueGross !== null ? input.declaredValueGross.toString() : null
+      }
+      if (input.currencyCode !== undefined) shipmentEntity.currencyCode = input.currencyCode ?? null
+      if (input.notes !== undefined) shipmentEntity.notesText = input.notes ?? null
+      if (input.metadata !== undefined || input.shipmentAddressSnapshot !== undefined) {
+        shipmentEntity.metadata = mergeAddressSnapshot(
+          input.metadata ? cloneJson(input.metadata) : shipmentEntity.metadata ?? null,
+          input.shipmentAddressSnapshot
+        )
+      }
+      shipmentEntity.updatedAt = new Date()
 
-    const shouldLoadItems = Boolean(normalizedItems || input.lineStatusEntryId !== undefined)
-    const existingItems = shouldLoadItems ? await em.find(SalesShipmentItem, { shipment }) : []
-    const newItems: SalesShipmentItem[] = []
-    if (normalizedItems) {
-      existingItems.forEach((item) => em.remove(item))
-      normalizedItems.forEach((item) => {
-        const lineRef = em.getReference(SalesOrderLine, item.orderLineId)
-        const shipmentItem = em.create(SalesShipmentItem, {
-          id: randomUUID(),
-          shipment,
-          orderLine: lineRef,
-          organizationId: shipment.organizationId,
-          tenantId: shipment.tenantId,
-          quantity: item.quantity.toString(),
-          metadata: item.metadata ? cloneJson(item.metadata) : null,
+      const shouldLoadItems = Boolean(normalizedItems || input.lineStatusEntryId !== undefined)
+      const existingItems = shouldLoadItems ? await findWithDecryption(tx, SalesShipmentItem, { shipment: shipmentEntity }, {}, { tenantId: shipmentEntity.tenantId, organizationId: shipmentEntity.organizationId }) : []
+      const newItems: SalesShipmentItem[] = []
+      if (normalizedItems) {
+        existingItems.forEach((item) => tx.remove(item))
+        normalizedItems.forEach((item) => {
+          const lineRef = tx.getReference(SalesOrderLine, item.orderLineId)
+          const shipmentItem = tx.create(SalesShipmentItem, {
+            id: randomUUID(),
+            shipment: shipmentEntity,
+            orderLine: lineRef,
+            organizationId: shipmentEntity.organizationId,
+            tenantId: shipmentEntity.tenantId,
+            quantity: item.quantity.toString(),
+            metadata: item.metadata ? cloneJson(item.metadata) : null,
+          })
+          newItems.push(shipmentItem)
+          tx.persist(shipmentItem)
         })
-        newItems.push(shipmentItem)
-        em.persist(shipmentItem)
-      })
-    }
+      }
 
-    if (input.customFields !== undefined) {
-      await setRecordCustomFields(em, {
-        entityId: E.sales.sales_shipment,
-        recordId: shipment.id,
-        organizationId: shipment.organizationId,
-        tenantId: shipment.tenantId,
-        values: normalizeCustomFieldsInput(input.customFields),
-      })
-    }
-    if (input.documentStatusEntryId !== undefined) {
-      const orderStatus = await resolveDictionaryEntryValue(em, input.documentStatusEntryId ?? null)
-      if (input.documentStatusEntryId && !orderStatus) {
-        throw new CrudHttpError(400, { error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.') })
+      if (input.customFields !== undefined) {
+        await setRecordCustomFields(tx, {
+          entityId: E.sales.sales_shipment,
+          recordId: shipmentEntity.id,
+          organizationId: shipmentEntity.organizationId,
+          tenantId: shipmentEntity.tenantId,
+          values: normalizeCustomFieldsInput(input.customFields),
+        })
       }
-      order.statusEntryId = input.documentStatusEntryId ?? null
-      order.status = orderStatus
-      order.updatedAt = new Date()
-    }
-    if (input.lineStatusEntryId !== undefined) {
-      const lineStatus = await resolveDictionaryEntryValue(em, input.lineStatusEntryId ?? null)
-      if (input.lineStatusEntryId && !lineStatus) {
-        throw new CrudHttpError(400, { error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.') })
-      }
-      const targetLineIds = normalizedItems
-        ? Array.from(new Set(normalizedItems.map((item) => item.orderLineId)))
-        : Array.from(
-            new Set(
-              existingItems
-                .map((item) =>
-                  typeof item.orderLine === 'string'
-                    ? item.orderLine
-                    : (item.orderLine as SalesOrderLine | null)?.id ?? null
-                )
-                .filter((id): id is string => Boolean(id))
-            )
-          )
-      if (targetLineIds.length) {
-        const missing = targetLineIds.filter((id) => !lineMap.has(id))
-        if (missing.length) {
-          const fetched = await em.find(SalesOrderLine, { id: { $in: missing } })
-          fetched.forEach((line) => lineMap.set(line.id, line))
+      if (input.documentStatusEntryId !== undefined) {
+        const orderStatus = await resolveDictionaryEntryValue(tx, input.documentStatusEntryId ?? null)
+        if (input.documentStatusEntryId && !orderStatus) {
+          throw new CrudHttpError(400, { error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.') })
         }
-        targetLineIds.forEach((lineId) => {
-          const line = lineMap.get(lineId)
-          if (!line) return
-          line.statusEntryId = input.lineStatusEntryId ?? null
-          line.status = lineStatus
-          line.updatedAt = new Date()
-        })
+        order.statusEntryId = input.documentStatusEntryId ?? null
+        order.status = orderStatus
+        order.updatedAt = new Date()
       }
-    }
+      if (input.lineStatusEntryId !== undefined) {
+        const lineStatus = await resolveDictionaryEntryValue(tx, input.lineStatusEntryId ?? null)
+        if (input.lineStatusEntryId && !lineStatus) {
+          throw new CrudHttpError(400, { error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.') })
+        }
+        const targetLineIds = normalizedItems
+          ? Array.from(new Set(normalizedItems.map((item) => item.orderLineId)))
+          : Array.from(
+              new Set(
+                existingItems
+                  .map((item) =>
+                    typeof item.orderLine === 'string'
+                      ? item.orderLine
+                      : (item.orderLine as SalesOrderLine | null)?.id ?? null
+                  )
+                  .filter((id): id is string => Boolean(id))
+              )
+            )
+        if (targetLineIds.length) {
+          const missing = targetLineIds.filter((id) => !lineMap.has(id))
+          if (missing.length) {
+            const fetched = await tx.find(SalesOrderLine, { id: { $in: missing } })
+            fetched.forEach((line) => lineMap.set(line.id, line))
+          }
+          targetLineIds.forEach((lineId) => {
+            const line = lineMap.get(lineId)
+            if (!line) return
+            line.statusEntryId = input.lineStatusEntryId ?? null
+            line.status = lineStatus
+            line.updatedAt = new Date()
+          })
+        }
+      }
 
-    const itemsForSnapshot =
-      normalizedItems || shouldLoadItems
-        ? (normalizedItems ? newItems : existingItems)
-        : await em.find(SalesShipmentItem, { shipment })
-    await refreshShipmentItemsSnapshot(em, shipment, { items: itemsForSnapshot, lineMap })
-    await em.flush()
-    await recomputeFulfilledQuantities(em, order)
-    await em.flush()
+      const itemsForSnapshot =
+        normalizedItems || shouldLoadItems
+          ? (normalizedItems ? newItems : existingItems)
+          : await findWithDecryption(tx, SalesShipmentItem, { shipment: shipmentEntity }, {}, { tenantId: shipmentEntity.tenantId, organizationId: shipmentEntity.organizationId })
+      await refreshShipmentItemsSnapshot(tx, shipmentEntity, { items: itemsForSnapshot, lineMap })
+      await tx.flush()
+      await recomputeFulfilledQuantities(tx, order)
+      await tx.flush()
+      return shipmentEntity
+    })
 
     const dataEngine = ctx.container.resolve('dataEngine') as DataEngine
     await emitCrudSideEffects({
@@ -863,36 +867,44 @@ const deleteShipmentCommand: CommandHandler<
       throw error
     }
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const shipment = await findOneWithDecryption(
-      em,
-      SalesShipment,
-      { id: payload.id },
-      { populate: ['order'] },
-      { tenantId: payload.tenantId, organizationId: payload.organizationId },
-    )
-    if (!shipment || !shipment.order) {
-      throw new CrudHttpError(404, { error: translate('sales.shipments.not_found', 'Shipment not found') })
-    }
-    try {
-      ensureSameScope(shipment, payload.organizationId, payload.tenantId)
-    } catch (error) {
-      logShipmentDeleteScopeRejection(ctx, 'Shipment scope mismatch against payload', {
-        shipmentId: payload.id,
-        shipmentOrganizationId: shipment.organizationId,
-        shipmentTenantId: shipment.tenantId,
-        payloadOrganizationId: payload.organizationId,
-        payloadTenantId: payload.tenantId,
-      })
-      throw error
-    }
-    const order = shipment.order as SalesOrder
-    if (order.id !== payload.orderId) {
-      throw new CrudHttpError(400, { error: translate('sales.shipments.invalid_order', 'Shipment does not belong to this order') })
-    }
-    const shipmentItems = await em.find(SalesShipmentItem, { shipment })
-    await deleteShipmentWithItems(em, shipment)
-    await recomputeFulfilledQuantities(em, order)
-    await em.flush()
+
+    const { shipment, shipmentItems } = await em.transactional(async (tx) => {
+      const shipmentEntity = await findOneWithDecryption(
+        tx,
+        SalesShipment,
+        { id: payload.id },
+        { populate: ['order'] },
+        { tenantId: payload.tenantId, organizationId: payload.organizationId },
+      )
+      if (!shipmentEntity || !shipmentEntity.order) {
+        throw new CrudHttpError(404, { error: translate('sales.shipments.not_found', 'Shipment not found') })
+      }
+      try {
+        ensureSameScope(shipmentEntity, payload.organizationId, payload.tenantId)
+      } catch (error) {
+        logShipmentDeleteScopeRejection(ctx, 'Shipment scope mismatch against payload', {
+          shipmentId: payload.id,
+          shipmentOrganizationId: shipmentEntity.organizationId,
+          shipmentTenantId: shipmentEntity.tenantId,
+          payloadOrganizationId: payload.organizationId,
+          payloadTenantId: payload.tenantId,
+        })
+        throw error
+      }
+      const order = shipmentEntity.order as SalesOrder
+      if (order.id !== payload.orderId) {
+        throw new CrudHttpError(400, { error: translate('sales.shipments.invalid_order', 'Shipment does not belong to this order') })
+      }
+      const scope = { tenantId: shipmentEntity.tenantId, organizationId: shipmentEntity.organizationId }
+      const items = await findWithDecryption(tx, SalesShipmentItem, { shipment: shipmentEntity }, {}, scope)
+      items.forEach((item) => tx.remove(item))
+      tx.remove(shipmentEntity)
+      await tx.flush()
+      await recomputeFulfilledQuantities(tx, order)
+      await tx.flush()
+      return { shipment: shipmentEntity, shipmentItems: items }
+    })
+
     const dataEngine = ctx.container.resolve('dataEngine') as DataEngine
     await emitCrudSideEffects({
       dataEngine,

--- a/packages/core/src/modules/sales/commands/shipments.ts
+++ b/packages/core/src/modules/sales/commands/shipments.ts
@@ -574,22 +574,22 @@ const createShipmentCommand: CommandHandler<ShipmentCreateInput, { shipmentId: s
     const after = payload?.after
     if (!after) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const existing = await findOneWithDecryption(
-      em,
-      SalesShipment,
-      { id: after.id },
-      { populate: ['order'] },
-      { tenantId: after.tenantId, organizationId: after.organizationId },
-    )
-    if (existing) {
+    await em.transactional(async (tx) => {
+      const existing = await findOneWithDecryption(
+        tx,
+        SalesShipment,
+        { id: after.id },
+        { populate: ['order'] },
+        { tenantId: after.tenantId, organizationId: after.organizationId },
+      )
+      if (!existing) return
       const order = existing.order as SalesOrder | null
-      await deleteShipmentWithItems(em, existing)
+      await deleteShipmentWithItems(tx, existing)
       if (order) {
-        await recomputeFulfilledQuantities(em, order)
-        await em.flush()
+        await recomputeFulfilledQuantities(tx, order)
+        await tx.flush()
       }
-      return
-    }
+    })
   },
 }
 
@@ -795,13 +795,15 @@ const updateShipmentCommand: CommandHandler<ShipmentUpdateInput, { shipmentId: s
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    await restoreShipmentSnapshot(em, before)
-    const order = await em.findOne(SalesOrder, { id: before.orderId })
-    await em.flush()
-    if (order) {
-      await recomputeFulfilledQuantities(em, order)
-      await em.flush()
-    }
+    await em.transactional(async (tx) => {
+      await restoreShipmentSnapshot(tx, before)
+      const order = await tx.findOne(SalesOrder, { id: before.orderId })
+      await tx.flush()
+      if (order) {
+        await recomputeFulfilledQuantities(tx, order)
+        await tx.flush()
+      }
+    })
   },
 }
 
@@ -942,13 +944,15 @@ const deleteShipmentCommand: CommandHandler<
     const snapshot = payload?.before ?? null
     if (!snapshot) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    await restoreShipmentSnapshot(em, snapshot)
-    const order = await em.findOne(SalesOrder, { id: snapshot.orderId })
-    await em.flush()
-    if (order) {
-      await recomputeFulfilledQuantities(em, order)
-      await em.flush()
-    }
+    await em.transactional(async (tx) => {
+      await restoreShipmentSnapshot(tx, snapshot)
+      const order = await tx.findOne(SalesOrder, { id: snapshot.orderId })
+      await tx.flush()
+      if (order) {
+        await recomputeFulfilledQuantities(tx, order)
+        await tx.flush()
+      }
+    })
   },
   buildLog: async ({ snapshots }) => {
     const before = snapshots.before as ShipmentSnapshot | undefined

--- a/packages/core/src/modules/sales/components/documents/ShipmentDialog.tsx
+++ b/packages/core/src/modules/sales/components/documents/ShipmentDialog.tsx
@@ -1195,7 +1195,7 @@ export function ShipmentDialog({
                 <div className="space-y-1">
                   <Input
                     type="number"
-                    step="0.01"
+                    step="1"
                     min="0"
                     value={valueString}
                     disabled={disabled}

--- a/packages/core/src/modules/sales/data/__tests__/validators.quantity.test.ts
+++ b/packages/core/src/modules/sales/data/__tests__/validators.quantity.test.ts
@@ -113,6 +113,62 @@ describe('shipmentCreateSchema — items quantity validation', () => {
     expect(result.success).toBe(false)
     if (!result.success) expectQuantityError(result)
   })
+
+  it('accepts integer quantity = 1', () => {
+    const result = shipmentCreateSchema.safeParse({
+      ...base,
+      items: [{ orderLineId: UUID, quantity: 1 }],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts integer quantity = 0', () => {
+    const result = shipmentCreateSchema.safeParse({
+      ...base,
+      items: [{ orderLineId: UUID, quantity: 0 }],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts integer quantity = 100', () => {
+    const result = shipmentCreateSchema.safeParse({
+      ...base,
+      items: [{ orderLineId: UUID, quantity: 100 }],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects fractional quantity = 0.7', () => {
+    const result = shipmentCreateSchema.safeParse({
+      ...base,
+      items: [{ orderLineId: UUID, quantity: 0.7 }],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain('Quantity must be a whole number.')
+    }
+  })
+
+  it('rejects fractional quantity = 1.5', () => {
+    const result = shipmentCreateSchema.safeParse({
+      ...base,
+      items: [{ orderLineId: UUID, quantity: 1.5 }],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain('Quantity must be a whole number.')
+    }
+  })
+
+  it('rejects negative quantity', () => {
+    const result = shipmentCreateSchema.safeParse({
+      ...base,
+      items: [{ orderLineId: UUID, quantity: -1 }],
+    })
+    expect(result.success).toBe(false)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/modules/sales/data/validators.ts
+++ b/packages/core/src/modules/sales/data/validators.ts
@@ -605,7 +605,7 @@ export const shipmentCreateSchema = scoped.extend({
     .array(
       z.object({
         orderLineId: uuid(),
-        quantity: decimal({ min: 0, max: MAX_QUANTITY, message: 'Quantity is too large.' }),
+        quantity: decimal({ min: 0, max: MAX_QUANTITY, message: 'Quantity is too large.' }).int('Quantity must be a whole number.'),
         metadata,
       })
     )


### PR DESCRIPTION
Supersedes #1543

Credit: original implementation by @muhammadusman586. This follow-up PR carries that work forward with the requested fixes from the auto-review so it can merge without waiting on the fork branch.

## Included work

### From #1543 (original)
- Wraps `createShipmentCommand.execute`, `updateShipmentCommand.execute`, and `deleteShipmentCommand.execute` in `em.transactional()` so `recomputeFulfilledQuantities` can acquire its `LockMode.PESSIMISTIC_WRITE` lock on order lines (fixes the 500 errors reported in #1541)
- Adds `.int('Quantity must be a whole number.')` to `shipmentCreateSchema.items[].quantity` (and inherited by `shipmentUpdateSchema`) so fractional shipment quantities are rejected
- Changes the `<Input step>` for shipment item quantity from `0.01` to `1` in `ShipmentDialog.tsx`
- Adds 6 new validator unit tests for integer/fractional quantity rejection

### Added during auto-review
- Wraps the three `undo` handlers (`createShipmentCommand.undo`, `updateShipmentCommand.undo`, `deleteShipmentCommand.undo`) in `em.transactional()` — they share the same root-cause bug (PESSIMISTIC_WRITE outside a transaction) and would re-trigger the 500 error when a user undoes a shipment audit-log entry
- Adds `shipments.undo-transactions.test.ts` (3 tests) locking in that the three undo handlers always run inside `em.transactional()`

## Validation

- ✅ `yarn typecheck` (18/18 packages)
- ✅ `yarn lint` (0 errors)
- ✅ `yarn jest --testPathPatterns='sales'` — 184/184 pass (including the 3 new undo-transaction tests and 6 new validator tests)

## Linked issues

Fixes #1541

🤖 Generated with [Claude Code](https://claude.com/claude-code)