### PR TITLE
fix(sales): enforce integer return quantity and fix float precision in remaining qty (#1540)

### DIFF
--- a/packages/core/src/modules/sales/components/documents/ReturnDialog.tsx
+++ b/packages/core/src/modules/sales/components/documents/ReturnDialog.tsx
@@ -10,6 +10,7 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
+import { computeAvailableReturnQuantity } from '@open-mercato/core/modules/sales/lib/returnQuantity'
 
 export type ReturnOrderLine = {
   id: string
@@ -48,7 +49,7 @@ export function ReturnDialog({ open, orderId, lines, onClose, onSaved }: ReturnD
   const availableLines = React.useMemo(() => {
     return lines
       .map((line) => {
-        const available = Math.max(0, line.quantity - line.returnedQuantity)
+        const available = computeAvailableReturnQuantity(line)
         return { ...line, available }
       })
       .filter((line) => line.available > 0)
@@ -64,17 +65,27 @@ export function ReturnDialog({ open, orderId, lines, onClose, onSaved }: ReturnD
   const submit = React.useCallback(async () => {
     if (saving) return
     let hasInvalidQuantity = false
+    let hasNonInteger = false
     const linesForRequest: Array<{ orderLineId: string; quantity: string }> = []
     availableLines.forEach((line) => {
       const raw = quantities[line.id]
       const qty = normalizeNumber(raw)
       if (!Number.isFinite(qty) || qty <= 0) return
-      if (qty - 1e-6 > line.available) {
+      if (!Number.isInteger(qty)) {
+        hasNonInteger = true
+        return
+      }
+      if (qty > line.available) {
         hasInvalidQuantity = true
         return
       }
       linesForRequest.push({ orderLineId: line.id, quantity: qty.toString() })
     })
+
+    if (hasNonInteger) {
+      flash(t('sales.returns.errors.quantityNotInteger', 'Return quantity must be a whole number.'), 'error')
+      return
+    }
 
     if (hasInvalidQuantity) {
       flash(t('sales.returns.errors.quantityExceeded', 'Cannot return more than available quantity.'), 'error')
@@ -164,10 +175,17 @@ export function ReturnDialog({ open, orderId, lines, onClose, onSaved }: ReturnD
                           </Label>
                           <Input
                             id={`return-qty-${line.id}`}
-                            inputMode="decimal"
+                            type="number"
+                            inputMode="numeric"
+                            min={1}
+                            max={line.available}
+                            step={1}
                             placeholder="0"
                             value={value}
-                            onChange={(e) => setQuantities((prev) => ({ ...prev, [line.id]: e.target.value }))}
+                            onChange={(e) => {
+                              const next = e.target.value.replace(/[^0-9]/g, '')
+                              setQuantities((prev) => ({ ...prev, [line.id]: next }))
+                            }}
                           />
                         </div>
                       </div>

--- a/packages/core/src/modules/sales/data/__tests__/validators.quantity.test.ts
+++ b/packages/core/src/modules/sales/data/__tests__/validators.quantity.test.ts
@@ -4,6 +4,7 @@ import {
   shipmentCreateSchema,
   invoiceCreateSchema,
   creditMemoCreateSchema,
+  returnCreateSchema,
 } from '../validators'
 
 const MAX_QUANTITY = 999_999_999
@@ -167,6 +168,81 @@ describe('creditMemoCreateSchema — lines quantity validation', () => {
     const result = creditMemoCreateSchema.safeParse({
       ...base,
       lines: [{ quantity: MAX_QUANTITY + 1, currencyCode: 'USD' }],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) expectQuantityError(result)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// returnCreateSchema — integer-only quantity (issue #1540)
+// ---------------------------------------------------------------------------
+
+describe('returnCreateSchema — quantity validation', () => {
+  const base = {
+    ...SCOPE,
+    orderId: UUID,
+  }
+
+  it('accepts integer quantity', () => {
+    const result = returnCreateSchema.safeParse({
+      ...base,
+      lines: [{ orderLineId: UUID, quantity: 1 }],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('coerces integer-string quantity', () => {
+    const result = returnCreateSchema.safeParse({
+      ...base,
+      lines: [{ orderLineId: UUID, quantity: '3' }],
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.lines[0].quantity).toBe(3)
+    }
+  })
+
+  it('rejects fractional quantity (0.9)', () => {
+    const result = returnCreateSchema.safeParse({
+      ...base,
+      lines: [{ orderLineId: UUID, quantity: 0.9 }],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain('Return quantity must be a whole number.')
+    }
+  })
+
+  it('rejects fractional quantity passed as string', () => {
+    const result = returnCreateSchema.safeParse({
+      ...base,
+      lines: [{ orderLineId: UUID, quantity: '0.9' }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects zero quantity', () => {
+    const result = returnCreateSchema.safeParse({
+      ...base,
+      lines: [{ orderLineId: UUID, quantity: 0 }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects negative quantity', () => {
+    const result = returnCreateSchema.safeParse({
+      ...base,
+      lines: [{ orderLineId: UUID, quantity: -1 }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects quantity = MAX_QUANTITY + 1', () => {
+    const result = returnCreateSchema.safeParse({
+      ...base,
+      lines: [{ orderLineId: UUID, quantity: MAX_QUANTITY + 1 }],
     })
     expect(result.success).toBe(false)
     if (!result.success) expectQuantityError(result)

--- a/packages/core/src/modules/sales/data/validators.ts
+++ b/packages/core/src/modules/sales/data/validators.ts
@@ -618,6 +618,12 @@ export const shipmentUpdateSchema = z
   })
   .merge(shipmentCreateSchema.partial())
 
+const returnLineQuantitySchema = z.coerce
+  .number()
+  .int('Return quantity must be a whole number.')
+  .min(1, 'Return quantity must be at least 1.')
+  .max(MAX_QUANTITY, 'Quantity is too large.')
+
 export const returnCreateSchema = scoped.extend({
   orderId: uuid(),
   reason: z.string().trim().max(4000).optional(),
@@ -627,7 +633,7 @@ export const returnCreateSchema = scoped.extend({
     .array(
       z.object({
         orderLineId: uuid(),
-        quantity: decimal({ min: 0 }),
+        quantity: returnLineQuantitySchema,
       })
     )
     .min(1),

--- a/packages/core/src/modules/sales/i18n/de.json
+++ b/packages/core/src/modules/sales/i18n/de.json
@@ -1272,6 +1272,7 @@
   "sales.returns.errors.linesRequired": "Wähle mindestens eine Position zur Rückgabe aus.",
   "sales.returns.errors.load": "Rückgaben konnten nicht geladen werden.",
   "sales.returns.errors.quantityExceeded": "Es kann nicht mehr als die verfügbare Menge zurückgegeben werden.",
+  "sales.returns.errors.quantityNotInteger": "Die Rückgabemenge muss eine ganze Zahl sein.",
   "sales.returns.lineMissing": "Bestellposition nicht gefunden.",
   "sales.returns.linesRequired": "Wähle mindestens eine Position zur Rückgabe aus.",
   "sales.returns.loading": "Rückgaben werden geladen...",

--- a/packages/core/src/modules/sales/i18n/en.json
+++ b/packages/core/src/modules/sales/i18n/en.json
@@ -1272,6 +1272,7 @@
   "sales.returns.errors.linesRequired": "Select at least one line to return.",
   "sales.returns.errors.load": "Failed to load returns.",
   "sales.returns.errors.quantityExceeded": "Cannot return more than available quantity.",
+  "sales.returns.errors.quantityNotInteger": "Return quantity must be a whole number.",
   "sales.returns.lineMissing": "Order line not found.",
   "sales.returns.linesRequired": "Select at least one line to return.",
   "sales.returns.loading": "Loading returns...",

--- a/packages/core/src/modules/sales/i18n/es.json
+++ b/packages/core/src/modules/sales/i18n/es.json
@@ -1272,6 +1272,7 @@
   "sales.returns.errors.linesRequired": "Selecciona al menos una línea para devolver.",
   "sales.returns.errors.load": "No se pudieron cargar las devoluciones.",
   "sales.returns.errors.quantityExceeded": "No se puede devolver más que la cantidad disponible.",
+  "sales.returns.errors.quantityNotInteger": "La cantidad de devolución debe ser un número entero.",
   "sales.returns.lineMissing": "No se encontró la línea del pedido.",
   "sales.returns.linesRequired": "Selecciona al menos una línea para devolver.",
   "sales.returns.loading": "Cargando devoluciones...",

--- a/packages/core/src/modules/sales/i18n/pl.json
+++ b/packages/core/src/modules/sales/i18n/pl.json
@@ -1272,6 +1272,7 @@
   "sales.returns.errors.linesRequired": "Wybierz co najmniej jedną pozycję do zwrotu.",
   "sales.returns.errors.load": "Nie udało się załadować zwrotów.",
   "sales.returns.errors.quantityExceeded": "Nie można zwrócić więcej niż dostępna ilość.",
+  "sales.returns.errors.quantityNotInteger": "Ilość zwrotu musi być liczbą całkowitą.",
   "sales.returns.lineMissing": "Nie znaleziono pozycji zamówienia.",
   "sales.returns.linesRequired": "Wybierz co najmniej jedną pozycję do zwrotu.",
   "sales.returns.loading": "Ładowanie zwrotów...",

--- a/packages/core/src/modules/sales/lib/__tests__/returnQuantity.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/returnQuantity.test.ts
@@ -1,0 +1,28 @@
+import { computeAvailableReturnQuantity } from '../returnQuantity'
+
+describe('computeAvailableReturnQuantity (issue #1540)', () => {
+  it('returns 0 when nothing remains', () => {
+    expect(computeAvailableReturnQuantity({ quantity: 1, returnedQuantity: 1 })).toBe(0)
+  })
+
+  it('returns floor of difference for clean integers', () => {
+    expect(computeAvailableReturnQuantity({ quantity: 5, returnedQuantity: 2 })).toBe(3)
+  })
+
+  it('avoids float precision artifacts (1 - 0.9 must not show 0.0999...)', () => {
+    expect(computeAvailableReturnQuantity({ quantity: 1, returnedQuantity: 0.9 })).toBe(0)
+  })
+
+  it('floors legacy fractional returnedQuantity to a whole-number remainder', () => {
+    expect(computeAvailableReturnQuantity({ quantity: 5, returnedQuantity: 0.9 })).toBe(4)
+  })
+
+  it('returns 0 when result would be negative', () => {
+    expect(computeAvailableReturnQuantity({ quantity: 1, returnedQuantity: 5 })).toBe(0)
+  })
+
+  it('returns 0 for non-finite inputs', () => {
+    expect(computeAvailableReturnQuantity({ quantity: Number.NaN, returnedQuantity: 0 })).toBe(0)
+    expect(computeAvailableReturnQuantity({ quantity: 1, returnedQuantity: Number.POSITIVE_INFINITY })).toBe(0)
+  })
+})

--- a/packages/core/src/modules/sales/lib/returnQuantity.ts
+++ b/packages/core/src/modules/sales/lib/returnQuantity.ts
@@ -1,0 +1,10 @@
+export type ReturnAvailableInput = {
+  quantity: number
+  returnedQuantity: number
+}
+
+export function computeAvailableReturnQuantity(line: ReturnAvailableInput): number {
+  const raw = line.quantity - line.returnedQuantity
+  if (!Number.isFinite(raw) || raw <= 0) return 0
+  return Math.max(0, Math.floor(raw + 1e-6))
+}


### PR DESCRIPTION
Fixes #1540

## Problem
Returns module accepted fractional quantities like `0.9` against an order line, causing two visible defects:
- The "available" quantity displayed as `0.09999999999999998` due to raw float subtraction (`line.quantity - line.returnedQuantity`).
- No domain validation enforced whole-unit returns even though returns are conceptually discrete.

## Root Cause
1. `returnCreateSchema.lines[].quantity` was declared with the generic `decimal({ min: 0 })` helper, which only coerces to a `number` and accepts any non-negative real value.
2. `ReturnDialog` rendered the quantity input with `inputMode="decimal"` and computed `available = line.quantity - line.returnedQuantity` — both contributing to and exposing IEEE-754 precision artifacts.
3. The frontend tolerance (`qty - 1e-6 > available`) only masked overflow checks; it did not prevent the bad display nor reject fractional input.

## What Changed
- **Validator**: introduced `returnLineQuantitySchema` (positive integer, max `MAX_QUANTITY`) and applied it to `returnCreateSchema`. The API now rejects fractional `quantity` values with a clear message.
- **UI**: switched the quantity field in `ReturnDialog` to `type="number" step="1" min="1" max={available}`, stripped non-digit input, and added a client-side guard that flashes `sales.returns.errors.quantityNotInteger` if a non-integer slips in.
- **Display**: extracted `computeAvailableReturnQuantity` (in `packages/core/src/modules/sales/lib/returnQuantity.ts`) which floors the remainder with a 1e-6 epsilon. This gives a clean whole-number "Available" value even for legacy rows that previously stored fractional `returned_quantity` (e.g. `5 − 0.9` now displays as `4`, not `4.0999...`).
- **i18n**: added `sales.returns.errors.quantityNotInteger` across `en`, `pl`, `es`, `de`.

## Tests
- New unit tests in `validators.quantity.test.ts` covering `returnCreateSchema` (accepts integer & integer-string, rejects fractional number, fractional string, zero, negative, and over-max).
- New unit tests in `lib/__tests__/returnQuantity.test.ts` covering the available-quantity helper, including the exact floating-point case from the bug report (`{ quantity: 1, returnedQuantity: 0.9 }` → `0`).
- Full sales workspace suite: `yarn workspace @open-mercato/core jest --testPathPatterns "src/modules/sales/"` → **188/188 passing**.

## Validation
- `yarn typecheck` — pass
- `yarn i18n:check-sync` — pass (4 locales in sync)
- `yarn workspace @open-mercato/core jest --testPathPatterns "validators.quantity|returnQuantity"` — 27/27 pass
- `yarn workspace @open-mercato/core jest --testPathPatterns "src/modules/sales/"` — 188/188 pass
- `yarn build:packages` — pass
- `yarn build:app` — fails on an unrelated pre-existing infrastructure issue (`/_global-error/page` static export hits `Cannot read properties of null (reading 'useContext')` regardless of these changes; `develop` CI is currently red on the same workflow at SHA `89a7f2b`). None of the touched files are involved in that path.
- `yarn i18n:check-usage` — only pre-existing advisory output (no new unused keys introduced here).

## Backward Compatibility
- API: `POST /api/sales/returns` previously accepted decimal `quantity` values that produced incorrect downstream data. Validation is now narrowed to positive integers — this is a deliberate corrective change tied to the bug fix; the prior behaviour was not a supported contract. The reject path returns the standard zod error envelope.
- Database: no schema change. The `numeric(18,4)` columns continue to work; new returns simply store integer-valued strings (e.g. `"1.0000"`).
- Existing data: legacy fractional `returned_quantity` rows render correctly thanks to the new helper; no migration needed.