### PR TITLE
fix(auth): scope role selector to selected tenant in user create/edit (#1538)

### DIFF
--- a/packages/core/src/modules/auth/backend/users/[id]/edit/page.tsx
+++ b/packages/core/src/modules/auth/backend/users/[id]/edit/page.tsx
@@ -118,6 +118,7 @@ export default function EditUserPage({ params }: { params?: { id?: string } }) {
   const [aclData, setAclData] = React.useState<AclData>({ isSuperAdmin: false, features: [], organizations: null })
   const [customFieldValues, setCustomFieldValues] = React.useState<Record<string, unknown>>({})
   const [actorIsSuperAdmin, setActorIsSuperAdmin] = React.useState(false)
+  const [actorResolved, setActorResolved] = React.useState(false)
   const widgetEditorRef = React.useRef<WidgetVisibilityEditorHandle | null>(null)
   const [resendingInvite, setResendingInvite] = React.useState(false)
 
@@ -174,6 +175,7 @@ export default function EditUserPage({ params }: { params?: { id?: string } }) {
         const item = Array.isArray(result?.items) ? result?.items?.[0] : undefined
         if (!cancelled) {
           setActorIsSuperAdmin(Boolean(result?.isSuperAdmin))
+          setActorResolved(true)
           if (!item) {
             setError(tRef.current('auth.users.form.errors.notFound', 'User not found'))
             setCustomFieldValues({})
@@ -212,6 +214,7 @@ export default function EditUserPage({ params }: { params?: { id?: string } }) {
         console.error('Failed to load user:', err)
         if (!cancelled) setError(tRef.current('auth.users.form.errors.load', 'Failed to load user data'))
         if (!cancelled) setCustomFieldValues({})
+        if (!cancelled) setActorResolved(true)
       }
       if (!cancelled) setLoading(false)
       try {
@@ -242,13 +245,17 @@ export default function EditUserPage({ params }: { params?: { id?: string } }) {
     return [{ id: selectedTenantId, name, isActive: true }]
   }, [initialUser, selectedTenantId])
 
+  // Block role loading until we know whether the actor is a super admin. Without this guard the
+  // initial (non-super-admin) branch fires before the flag resolves and the server returns roles
+  // from other tenants because the real caller is a super admin without tenantId scoping.
   const loadRoleOptions = React.useCallback(async (query?: string): Promise<CrudFieldOption[]> => {
+    if (!actorResolved) return []
     if (actorIsSuperAdmin) {
       if (!selectedTenantId) return []
       return fetchRoleOptions(query, { tenantId: selectedTenantId })
     }
     return fetchRoleOptions(query)
-  }, [actorIsSuperAdmin, selectedTenantId])
+  }, [actorIsSuperAdmin, actorResolved, selectedTenantId])
 
   const userHasPassword = initialUser?.hasPassword !== false
   const fields: CrudField[] = React.useMemo(() => {

--- a/packages/core/src/modules/auth/backend/users/create/page.tsx
+++ b/packages/core/src/modules/auth/backend/users/create/page.tsx
@@ -85,6 +85,7 @@ export default function CreateUserPage() {
   const [selectedWidgets, setSelectedWidgets] = React.useState<string[]>([])
   const [selectedTenantId, setSelectedTenantId] = React.useState<string | null>(null)
   const [actorIsSuperAdmin, setActorIsSuperAdmin] = React.useState(false)
+  const [actorResolved, setActorResolved] = React.useState(false)
   const [sendInviteEmail, setSendInviteEmail] = React.useState(false)
   const passwordPolicy = React.useMemo(() => getPasswordPolicy(), [])
   const passwordRequirements = React.useMemo(
@@ -147,6 +148,8 @@ export default function CreateUserPage() {
         if (!cancelled && ok) setActorIsSuperAdmin(Boolean(result?.isSuperAdmin))
       } catch (err) {
         console.error('Failed to resolve actor super admin flag', err)
+      } finally {
+        if (!cancelled) setActorResolved(true)
       }
     }
     loadActor()
@@ -157,13 +160,17 @@ export default function CreateUserPage() {
     setSelectedWidgets((prev) => (prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]))
   }, [])
 
+  // Block role loading until we know whether the actor is a super admin. Without this guard the
+  // initial (non-super-admin) branch fires before the flag resolves and the server returns roles
+  // from other tenants because the real caller is a super admin without tenantId scoping.
   const loadRoleOptions = React.useCallback(async (query?: string): Promise<CrudFieldOption[]> => {
+    if (!actorResolved) return []
     if (actorIsSuperAdmin) {
       if (!selectedTenantId) return []
       return fetchRoleOptions(query, { tenantId: selectedTenantId })
     }
     return fetchRoleOptions(query)
-  }, [actorIsSuperAdmin, selectedTenantId])
+  }, [actorIsSuperAdmin, actorResolved, selectedTenantId])
 
   const fields: CrudField[] = React.useMemo(() => {
     const items: CrudField[] = [

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -2286,6 +2286,12 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     }
   }
 
+  // Tracks the last loader function observed per field id so we can invalidate cached
+  // options when callers rebuild loaders that capture different state (e.g. a tenant id).
+  const dynamicOptionLoadersRef = React.useRef<
+    Map<string, ((query?: string) => Promise<CrudFieldOption[]>) | undefined>
+  >(new Map())
+
   // Stable key prevents infinite re-render loop (see #814) — do not depend on allFields directly.
   React.useEffect(() => {
     let cancelled = false
@@ -2297,6 +2303,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
         )
         .map(async (f) => {
           try {
+            dynamicOptionLoadersRef.current.set(f.id, f.loadOptions)
             const opts = await f.loadOptions()
             if (!cancelled) setDynamicOptions((prev) => ({ ...prev, [f.id]: opts }))
           } catch {
@@ -2316,7 +2323,16 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     const builtin = field as CrudBuiltinField
     const loader = builtin.loadOptions
     if (typeof loader === 'function') {
-      if (query === undefined && Array.isArray(dynamicOptions[field.id])) return dynamicOptions[field.id]
+      const previousLoader = dynamicOptionLoadersRef.current.get(field.id)
+      const loaderChanged = previousLoader !== loader
+      dynamicOptionLoadersRef.current.set(field.id, loader)
+      if (
+        query === undefined &&
+        !loaderChanged &&
+        Array.isArray(dynamicOptions[field.id])
+      ) {
+        return dynamicOptions[field.id]
+      }
       try {
         const fetched = await loader(query)
         if (query === undefined) {

--- a/packages/ui/src/backend/__tests__/CrudForm.render.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.render.test.tsx
@@ -102,6 +102,35 @@ describe('CrudForm initialValues', () => {
     expect(loader.mock.calls.length).toBeLessThanOrEqual(callsAfterMount + 1)
   })
 
+  it('re-invokes loadOptions and refreshes cached options when the loader identity changes (#1538)', async () => {
+    const firstLoader = jest.fn().mockResolvedValue([{ label: 'Alpha', value: 'alpha' }])
+    const secondLoader = jest.fn().mockResolvedValue([{ label: 'Beta', value: 'beta' }])
+    const makeFields = (loader: (q?: string) => Promise<{ label: string; value: string }[]>): CrudField[] => [
+      { id: 'pick', label: 'Pick', type: 'combobox', loadOptions: loader },
+    ]
+
+    const { rerender, container } = renderWithProviders(
+      <CrudForm title="Form" fields={makeFields(firstLoader)} onSubmit={() => {}} />
+    )
+    await act(() => Promise.resolve())
+    expect(firstLoader).toHaveBeenCalled()
+    expect(secondLoader).not.toHaveBeenCalled()
+
+    await act(async () => {
+      rerender(
+        <CrudForm title="Form" fields={makeFields(secondLoader)} onSubmit={() => {}} />
+      )
+    })
+    await act(() => Promise.resolve())
+
+    // The new loader MUST run because it captures different parent state
+    // (e.g. tenant scope). Reusing cached options from the old loader would
+    // leak cross-scope values such as roles from another tenant.
+    expect(secondLoader).toHaveBeenCalled()
+    const fieldNode = container.querySelector('[data-crud-field-id="pick"]')
+    expect(fieldNode).not.toBeNull()
+  })
+
   it('does not reset fields on initialValues reference churn', async () => {
     const { container, rerender } = renderWithProviders(
       <CrudForm title="Form" fields={fields} initialValues={{ name: 'Alice' }} onSubmit={() => {}} />


### PR DESCRIPTION
Fixes #1538

## Problem
Super admin creates a brand-new tenant + organization, then opens `/backend/users/create`. The role selector lists roles from other tenants; picking one fails with `Role(s) not found` because roles are strictly tenant-scoped.

## Root Cause
Two independent layers combined to leak cross-tenant roles:

1. **`CrudForm` option cache did not react to `loadOptions` identity changes.** Results were keyed only by field id, so when the parent rebuilt a `loadOptions` closure that captured a new `selectedTenantId`, the form kept returning the cached, cross-tenant option list.
2. **Role loading fired before the actor-is-super-admin flag resolved** in `auth/backend/users/create/page.tsx` and `auth/backend/users/[id]/edit/page.tsx`. During that initial window the non-super branch ran `fetchRoleOptions(query)` without `tenantId`. The server, seeing the real super-admin caller, legitimately returned roles across tenants (the same endpoint powers `/backend/roles`), which the UI then cached.

## What Changed
- `packages/ui/src/backend/CrudForm.tsx`: track the last observed loader reference per field id in a ref, and bypass the option cache when the loader reference changes. This forces a fresh fetch whenever a parent rebuilds a `loadOptions` closure that captures different state.
- `packages/core/src/modules/auth/backend/users/create/page.tsx`: add `actorResolved` state, flip it in the `loadActor` `finally` block, and gate `loadRoleOptions` on it so the role endpoint is never queried until we know whether the actor is a super admin.
- `packages/core/src/modules/auth/backend/users/[id]/edit/page.tsx`: apply the same `actorResolved` gate (flipped on both success and error branches of the user fetch) so editing has the same invariant.

## Tests
- `packages/ui/src/backend/__tests__/CrudForm.render.test.tsx`: new `#1538` regression test that re-renders a `CrudForm` with a different `loadOptions` reference and asserts the new loader is invoked. Verified it fails on `develop` (loader call count 0) and passes after the fix.
- Ran `yarn typecheck` (20 packages green), `yarn i18n:check-sync`, and the focused `auth` + `ui/backend` test suites. Four pre-existing jsdom-env failures (`FlashMessages`, `useNotifications.strategy`, `useProgress.strategy`, `CustomDataSection`) also fail on `develop` and are unrelated to this change.
- No `em.find(` / `em.findOne(` in the changed files — the fix is UI-only.

## Backward Compatibility
- No contract surface changes. `CrudForm` keeps its public API; the cache behavior change strictly improves correctness (stale cross-scope options are now refreshed when the loader closure changes).
- No API route, event, entity, or ACL change.

## Test plan
- [ ] Sign in as super admin, create a new tenant + organization.
- [ ] Open `/backend/users/create`: role selector should be empty until a tenant is chosen; once chosen, only that tenant's roles appear.
- [ ] Pick a role from the new tenant and submit: user creation succeeds (no `Role(s) not found`).
- [ ] Switching tenants in the same form updates the role selector to the new tenant's roles.
- [ ] `/backend/users/<id>/edit`: role selector lists only the user's tenant roles; editing still works for non-super-admin actors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)