### PR TITLE
fix(data-engine): validate event names against module registry (#1421)

### DIFF
--- a/packages/shared/src/lib/data/__tests__/engine.event-validation.test.ts
+++ b/packages/shared/src/lib/data/__tests__/engine.event-validation.test.ts
@@ -1,0 +1,109 @@
+import type { AwilixContainer } from 'awilix'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { DefaultDataEngine, __resetUndeclaredEventWarningsForTests } from '../engine'
+import { createModuleEvents } from '../../../modules/events'
+
+const testEvents = [
+  { id: 'issue1421_test.widget.created', label: 'Widget Created', entity: 'widget', category: 'crud' as const },
+  { id: 'issue1421_test.widget.updated', label: 'Widget Updated', entity: 'widget', category: 'crud' as const },
+  { id: 'issue1421_test.widget.deleted', label: 'Widget Deleted', entity: 'widget', category: 'crud' as const },
+] as const
+
+// Register the declared events with the shared registry used by DataEngine.
+createModuleEvents({ moduleId: 'issue1421_test', events: testEvents })
+
+type EmittedEvent = { name: string; payload: unknown; options?: unknown }
+
+function makeFixture() {
+  const emitted: EmittedEvent[] = []
+  const bus = {
+    emitEvent: jest.fn(async (name: string, payload: unknown, options?: unknown) => {
+      emitted.push({ name, payload, options })
+    }),
+  }
+  const container = {
+    resolve: (name: string) => (name === 'eventBus' ? bus : undefined),
+  } as unknown as AwilixContainer
+  const em = {} as unknown as EntityManager
+  const engine = new DefaultDataEngine(em, container)
+  return { engine, bus, emitted }
+}
+
+describe('DataEngine event contract validation (issue #1421)', () => {
+  const identifiers = {
+    id: 'rec-1',
+    organizationId: 'org-1',
+    tenantId: 'tenant-1',
+  }
+
+  beforeEach(() => {
+    __resetUndeclaredEventWarningsForTests()
+  })
+
+  it('emits declared events without warning', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const { engine, emitted } = makeFixture()
+
+      await engine.emitOrmEntityEvent({
+        action: 'created',
+        entity: { id: identifiers.id },
+        identifiers,
+        events: { module: 'issue1421_test', entity: 'widget' },
+      })
+
+      expect(emitted).toEqual([
+        expect.objectContaining({ name: 'issue1421_test.widget.created' }),
+      ])
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('warns when emitting an event that is not registered', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const { engine, emitted } = makeFixture()
+
+      await engine.emitOrmEntityEvent({
+        action: 'created',
+        entity: { id: identifiers.id },
+        identifiers,
+        events: { module: 'issue1421_unregistered', entity: 'ghost' },
+      })
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const warningMessage = warnSpy.mock.calls[0]?.[0] ?? ''
+      expect(warningMessage).toContain('issue1421_unregistered.ghost.created')
+      expect(warningMessage).toContain('events.ts')
+
+      // Emission is still attempted (non-strict), matching the factory's default behavior
+      expect(emitted).toEqual([
+        expect.objectContaining({ name: 'issue1421_unregistered.ghost.created' }),
+      ])
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('deduplicates repeated warnings for the same undeclared event', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const { engine } = makeFixture()
+
+      for (let i = 0; i < 3; i++) {
+        await engine.emitOrmEntityEvent({
+          action: 'updated',
+          entity: { id: identifiers.id },
+          identifiers,
+          events: { module: 'issue1421_unregistered', entity: 'ghost' },
+        })
+      }
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+})

--- a/packages/shared/src/lib/data/engine.ts
+++ b/packages/shared/src/lib/data/engine.ts
@@ -14,6 +14,24 @@ import type {
 import { CrudHttpError } from '../crud/errors'
 import { normalizeCustomFieldValues } from '../custom-fields/normalize'
 import { parseBooleanToken } from '../boolean'
+import { isEventDeclared } from '../../modules/events'
+
+const undeclaredEventWarned = new Set<string>()
+
+function warnIfUndeclaredEvent(eventName: string, context: string): void {
+  if (isEventDeclared(eventName)) return
+  if (undeclaredEventWarned.has(eventName)) return
+  undeclaredEventWarned.add(eventName)
+  console.warn(
+    `[data-engine] ${context} is emitting undeclared event "${eventName}". ` +
+    `Declare it in the owning module's events.ts (createModuleEvents) so the event registry stays authoritative.`,
+  )
+}
+
+/** Internal: clear the undeclared-event warning cache. Exposed for tests. */
+export function __resetUndeclaredEventWarningsForTests(): void {
+  undeclaredEventWarned.clear()
+}
 
 const COVERAGE_REFRESH_INTERVAL_MS = 5 * 60 * 1000
 const coverageRefreshTracker = new Map<string, number>()
@@ -154,8 +172,10 @@ export class DefaultDataEngine implements DataEngine {
       if (bus) {
         const [mod, ent] = (entityId || '').split(':')
         if (mod && ent) {
+          const eventName = `${mod}.${ent}.updated`
+          warnIfUndeclaredEvent(eventName, 'setCustomFields')
           try {
-            await bus.emitEvent(`${mod}.${ent}.updated`, { id: recordId, organizationId, tenantId }, { persistent: true })
+            await bus.emitEvent(eventName, { id: recordId, organizationId, tenantId }, { persistent: true })
           } catch {
             // non-blocking
           }
@@ -463,6 +483,7 @@ export class DefaultDataEngine implements DataEngine {
 
     if (events) {
       const eventName = `${events.module}.${events.entity}.${action}`
+      warnIfUndeclaredEvent(eventName, 'emitOrmEntityEvent')
       const payload = events.buildPayload
         ? events.buildPayload(ctx)
         : {


### PR DESCRIPTION
Fixes #1421

## Problem
`events.ts` declarations created with `createModuleEvents(...)` were effectively documentation-only. `DataEngine.emitOrmEntityEvent` (and the notify path inside `setCustomFields`) built event names via string concatenation and pushed them straight onto the event bus, bypassing `isEventDeclared` and the rest of the central registry. Typos, renames or stale declarations in any module's `events.ts` would not be caught.

## Root Cause
`packages/shared/src/lib/data/engine.ts` emitted `${events.module}.${events.entity}.${action}` (CRUD path) and `${module}.${entity}.updated` (custom fields notify path) directly on `eventBus.emitEvent`, without ever consulting the global event registry that `createModuleEvents` populates.

## What Changed
- `DataEngine` now calls a local `warnIfUndeclaredEvent(...)` helper before the two concatenated emissions. The helper uses `isEventDeclared` from `@open-mercato/shared/modules/events` and logs a one-time `console.warn` per undeclared event id, instructing the owner to declare it in the module's `events.ts`.
- Emission itself is unchanged (non-strict, matching the factory default) so existing subscribers continue to receive events. The warning is additive; no known emission stops firing.
- An internal `__resetUndeclaredEventWarningsForTests` helper is exported so tests can clear the dedupe cache between cases.

## Tests
- New `packages/shared/src/lib/data/__tests__/engine.event-validation.test.ts` with three cases:
  - emits declared events without warning
  - warns when emitting an event that is not registered (and still emits, non-strict)
  - deduplicates repeated warnings for the same undeclared event id
- `yarn jest` in `@open-mercato/shared` passes (619/619 tests, including the new file).
- `yarn typecheck` passes for all 18 packages.
- `yarn i18n:check-sync` passes; `yarn i18n:check-usage` is advisory only.
- `yarn test` and `yarn build:app` surfaced the same `#generated/entities.ids.generated` resolution failure (in `@open-mercato/sync-akeneo` tests and the Next.js app build) that already reproduces on a clean `origin/develop` checkout; unrelated to this fix.

## Backward Compatibility
- No contract surface changes. No event ids, import paths, API responses, DI names, ACLs or DB schemas changed.
- New console warning is purely observability and can be silenced by declaring the event in the owning module's `events.ts`, which is the documented pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)