### PR TITLE
fix(data): cascade customer delete to portal users, sales docs, and custom fields (#1418)

### DIFF
--- a/packages/core/src/modules/customer_accounts/__tests__/unlinkOnCustomerDelete.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/unlinkOnCustomerDelete.test.ts
@@ -1,0 +1,89 @@
+import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
+import unlinkOnPersonDelete, { metadata as personMeta } from '@open-mercato/core/modules/customer_accounts/subscribers/unlinkOnPersonDelete'
+import unlinkOnCompanyDelete, { metadata as companyMeta } from '@open-mercato/core/modules/customer_accounts/subscribers/unlinkOnCompanyDelete'
+
+type NativeUpdateCall = { entity: unknown; where: Record<string, unknown>; data: Record<string, unknown> }
+
+function makeEm() {
+  const calls: NativeUpdateCall[] = []
+  const em = {
+    nativeUpdate: async (entity: unknown, where: Record<string, unknown>, data: Record<string, unknown>) => {
+      calls.push({ entity, where, data })
+      return 1
+    },
+  }
+  return { em, calls }
+}
+
+function makeCtx(em: unknown) {
+  return { resolve: <T = unknown>(name: string): T => (name === 'em' ? (em as T) : (undefined as unknown as T)) }
+}
+
+describe('customer_accounts unlink subscribers on CRM delete', () => {
+  test('person subscriber wires to customers.person.deleted', () => {
+    expect(personMeta.event).toBe('customers.person.deleted')
+    expect(personMeta.persistent).toBe(true)
+    expect(personMeta.id).toBe('customer_accounts:unlink-on-person-delete')
+  })
+
+  test('company subscriber wires to customers.company.deleted', () => {
+    expect(companyMeta.event).toBe('customers.company.deleted')
+    expect(companyMeta.persistent).toBe(true)
+    expect(companyMeta.id).toBe('customer_accounts:unlink-on-company-delete')
+  })
+
+  test('person delete nullifies personEntityId on matching customer users scoped by tenant', async () => {
+    const { em, calls } = makeEm()
+    const entityId = '00000000-0000-0000-0000-000000000001'
+    const tenantId = '00000000-0000-0000-0000-000000000002'
+    await unlinkOnPersonDelete({ entityId, id: 'some-profile-id', tenantId }, makeCtx(em))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].entity).toBe(CustomerUser)
+    expect(calls[0].where).toEqual({ personEntityId: entityId, tenantId })
+    expect(calls[0].data.personEntityId).toBeNull()
+    expect(calls[0].data.updatedAt).toBeInstanceOf(Date)
+  })
+
+  test('person delete falls back to payload.id when entityId is missing (backward compatibility)', async () => {
+    const { em, calls } = makeEm()
+    const legacyId = '00000000-0000-0000-0000-000000000003'
+    await unlinkOnPersonDelete({ id: legacyId, tenantId: 'tenant-1' }, makeCtx(em))
+    expect(calls[0].where).toEqual({ personEntityId: legacyId, tenantId: 'tenant-1' })
+  })
+
+  test('person delete is a no-op when entityId or tenantId is missing', async () => {
+    const { em, calls } = makeEm()
+    await unlinkOnPersonDelete({ tenantId: 'tenant-1' }, makeCtx(em))
+    await unlinkOnPersonDelete({ entityId: 'id-1' }, makeCtx(em))
+    await unlinkOnPersonDelete(null, makeCtx(em))
+    expect(calls).toHaveLength(0)
+  })
+
+  test('company delete nullifies customerEntityId on matching customer users', async () => {
+    const { em, calls } = makeEm()
+    const entityId = '00000000-0000-0000-0000-000000000010'
+    const tenantId = '00000000-0000-0000-0000-000000000020'
+    await unlinkOnCompanyDelete({ entityId, id: 'company-profile-id', tenantId }, makeCtx(em))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].entity).toBe(CustomerUser)
+    expect(calls[0].where).toEqual({ customerEntityId: entityId, tenantId })
+    expect(calls[0].data.customerEntityId).toBeNull()
+    expect(calls[0].data.updatedAt).toBeInstanceOf(Date)
+  })
+
+  test('swallows errors so a failing unlink does not break the event bus', async () => {
+    const errorEm = {
+      nativeUpdate: async () => {
+        throw new Error('db down')
+      },
+    }
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    await expect(
+      unlinkOnPersonDelete({ entityId: 'id', tenantId: 't' }, makeCtx(errorEm)),
+    ).resolves.toBeUndefined()
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/subscribers/unlinkOnCompanyDelete.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/unlinkOnCompanyDelete.ts
@@ -1,0 +1,30 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
+
+export const metadata = {
+  event: 'customers.company.deleted',
+  persistent: true,
+  id: 'customer_accounts:unlink-on-company-delete',
+}
+
+export default async function handle(
+  payload: unknown,
+  ctx: { resolve: <T = unknown>(name: string) => T; eventName?: string },
+): Promise<void> {
+  const data = payload as Record<string, unknown>
+  const entityId = (data?.entityId as string | undefined) ?? (data?.id as string | undefined)
+  const tenantId = data?.tenantId as string | undefined
+  if (!entityId || !tenantId) return
+
+  const em = ctx.resolve<EntityManager>('em')
+
+  try {
+    await em.nativeUpdate(
+      CustomerUser,
+      { customerEntityId: entityId, tenantId },
+      { customerEntityId: null, updatedAt: new Date() },
+    )
+  } catch (err) {
+    console.error('[customer_accounts:unlink-on-company-delete] Failed to clear customerEntityId on customer users:', err)
+  }
+}

--- a/packages/core/src/modules/customer_accounts/subscribers/unlinkOnPersonDelete.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/unlinkOnPersonDelete.ts
@@ -1,0 +1,30 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
+
+export const metadata = {
+  event: 'customers.person.deleted',
+  persistent: true,
+  id: 'customer_accounts:unlink-on-person-delete',
+}
+
+export default async function handle(
+  payload: unknown,
+  ctx: { resolve: <T = unknown>(name: string) => T; eventName?: string },
+): Promise<void> {
+  const data = payload as Record<string, unknown>
+  const entityId = (data?.entityId as string | undefined) ?? (data?.id as string | undefined)
+  const tenantId = data?.tenantId as string | undefined
+  if (!entityId || !tenantId) return
+
+  const em = ctx.resolve<EntityManager>('em')
+
+  try {
+    await em.nativeUpdate(
+      CustomerUser,
+      { personEntityId: entityId, tenantId },
+      { personEntityId: null, updatedAt: new Date() },
+    )
+  } catch (err) {
+    console.error('[customer_accounts:unlink-on-person-delete] Failed to clear personEntityId on customer users:', err)
+  }
+}

--- a/packages/core/src/modules/customers/commands/companies.ts
+++ b/packages/core/src/modules/customers/commands/companies.ts
@@ -50,6 +50,8 @@ import {
 import type { CrudIndexerConfig, CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
 import { E } from '#generated/entities.ids.generated'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { CUSTOMER_ENTITY_ID } from '../lib/customFieldRouting'
+import { CustomFieldValue } from '@open-mercato/core/modules/entities/data/entities'
 
 const COMPANY_ENTITY_ID = 'customers:customer_company_profile'
 const INTERACTION_ENTITY_ID = 'customers:customer_interaction'
@@ -58,12 +60,13 @@ const companyCrudIndexer: CrudIndexerConfig<CustomerEntity> = {
   entityType: E.customers.customer_company_profile,
 }
 
-const companyCrudEvents: CrudEventsConfig = {
+const companyCrudEvents: CrudEventsConfig<CustomerEntity> = {
   module: 'customers',
   entity: 'company',
   persistent: true,
   buildPayload: (ctx) => ({
     id: ctx.identifiers.id,
+    entityId: ctx.entity?.id ?? ctx.identifiers.id,
     organizationId: ctx.identifiers.organizationId,
     tenantId: ctx.identifiers.tenantId,
   }),
@@ -794,6 +797,10 @@ const deleteCompanyCommand: CommandHandler<{ body?: Record<string, unknown>; que
       await em.nativeDelete(CustomerAddress, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
       await em.nativeDelete(CustomerComment, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
       await em.nativeDelete(CustomerTagAssignment, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
+      if (profile) {
+        await em.nativeDelete(CustomFieldValue, { entityId: COMPANY_ENTITY_ID, recordId: profile.id })
+      }
+      await em.nativeDelete(CustomFieldValue, { entityId: CUSTOMER_ENTITY_ID, recordId: record.id })
       em.remove(record)
       await em.flush()
 

--- a/packages/core/src/modules/customers/commands/people.ts
+++ b/packages/core/src/modules/customers/commands/people.ts
@@ -24,6 +24,7 @@ import {
   CustomerTagAssignment,
 } from '../data/entities'
 import { resolvePersonCustomFieldRouting, CUSTOMER_ENTITY_ID, PERSON_ENTITY_ID } from '../lib/customFieldRouting'
+import { CustomFieldValue } from '@open-mercato/core/modules/entities/data/entities'
 import {
   personCreateSchema,
   personUpdateSchema,
@@ -181,12 +182,13 @@ const personCrudIndexer: CrudIndexerConfig<CustomerEntity> = {
   entityType: E.customers.customer_person_profile,
 }
 
-const personCrudEvents: CrudEventsConfig = {
+const personCrudEvents: CrudEventsConfig<CustomerEntity> = {
   module: 'customers',
   entity: 'person',
   persistent: true,
   buildPayload: (ctx) => ({
     id: ctx.identifiers.id,
+    entityId: ctx.entity?.id ?? ctx.identifiers.id,
     organizationId: ctx.identifiers.organizationId,
     tenantId: ctx.identifiers.tenantId,
   }),
@@ -958,6 +960,10 @@ const deletePersonCommand: CommandHandler<{ body?: Record<string, unknown>; quer
       await em.nativeDelete(CustomerTodoLink, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
       await em.nativeDelete(CustomerTagAssignment, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
       await em.nativeDelete(CustomerDealPersonLink, { person: record })
+      if (profile) {
+        await em.nativeDelete(CustomFieldValue, { entityId: PERSON_ENTITY_ID, recordId: profile.id })
+      }
+      await em.nativeDelete(CustomFieldValue, { entityId: CUSTOMER_ENTITY_ID, recordId: record.id })
       em.remove(record)
       await em.flush()
 

--- a/packages/core/src/modules/sales/subscribers/__tests__/reconcileOnCrmDelete.test.ts
+++ b/packages/core/src/modules/sales/subscribers/__tests__/reconcileOnCrmDelete.test.ts
@@ -1,0 +1,130 @@
+import { SalesOrder, SalesQuote } from '@open-mercato/core/modules/sales/data/entities'
+import reconcileOnCustomerDelete, { metadata as personMeta } from '@open-mercato/core/modules/sales/subscribers/reconcileOnCustomerDelete'
+import reconcileOnCompanyDelete, { metadata as companyMeta } from '@open-mercato/core/modules/sales/subscribers/reconcileOnCompanyDelete'
+import reconcileOnAddressDelete, { metadata as addressMeta } from '@open-mercato/core/modules/sales/subscribers/reconcileOnAddressDelete'
+
+type NativeUpdateCall = { entity: unknown; where: Record<string, unknown>; data: Record<string, unknown> }
+
+function makeEm() {
+  const calls: NativeUpdateCall[] = []
+  const em = {
+    nativeUpdate: async (entity: unknown, where: Record<string, unknown>, data: Record<string, unknown>) => {
+      calls.push({ entity, where, data })
+      return 1
+    },
+  }
+  return { em, calls }
+}
+
+function makeCtx(em: unknown) {
+  return { resolve: <T = unknown>(name: string): T => (name === 'em' ? (em as T) : (undefined as unknown as T)) }
+}
+
+describe('sales reconcile subscribers on CRM delete', () => {
+  test('person subscriber is persistent and wires to customers.person.deleted', () => {
+    expect(personMeta.event).toBe('customers.person.deleted')
+    expect(personMeta.persistent).toBe(true)
+    expect(personMeta.id).toBe('sales:reconcile-on-person-delete')
+  })
+
+  test('company subscriber is persistent and wires to customers.company.deleted', () => {
+    expect(companyMeta.event).toBe('customers.company.deleted')
+    expect(companyMeta.persistent).toBe(true)
+    expect(companyMeta.id).toBe('sales:reconcile-on-company-delete')
+  })
+
+  test('address subscriber is persistent and wires to customers.address.deleted', () => {
+    expect(addressMeta.event).toBe('customers.address.deleted')
+    expect(addressMeta.persistent).toBe(true)
+    expect(addressMeta.id).toBe('sales:reconcile-on-address-delete')
+  })
+
+  test('person delete nulls customerEntityId on orders and quotes, scoped by tenant', async () => {
+    const { em, calls } = makeEm()
+    const entityId = '00000000-0000-0000-0000-000000000001'
+    const tenantId = '00000000-0000-0000-0000-000000000002'
+    await reconcileOnCustomerDelete({ entityId, id: 'some-profile-id', tenantId }, makeCtx(em))
+
+    expect(calls).toHaveLength(2)
+    const orderCall = calls.find((c) => c.entity === SalesOrder)
+    const quoteCall = calls.find((c) => c.entity === SalesQuote)
+    expect(orderCall?.where).toEqual({ customerEntityId: entityId, tenantId })
+    expect(orderCall?.data).toEqual({ customerEntityId: null })
+    expect(quoteCall?.where).toEqual({ customerEntityId: entityId, tenantId })
+    expect(quoteCall?.data).toEqual({ customerEntityId: null })
+  })
+
+  test('person delete falls back to payload.id when entityId is missing', async () => {
+    const { em, calls } = makeEm()
+    const legacyId = '00000000-0000-0000-0000-000000000003'
+    await reconcileOnCustomerDelete({ id: legacyId, tenantId: 'tenant-1' }, makeCtx(em))
+    expect(calls.every((c) => c.where.customerEntityId === legacyId)).toBe(true)
+  })
+
+  test('person delete is a no-op when entityId or tenantId missing', async () => {
+    const { em, calls } = makeEm()
+    await reconcileOnCustomerDelete({ tenantId: 't' }, makeCtx(em))
+    await reconcileOnCustomerDelete({ entityId: 'e' }, makeCtx(em))
+    await reconcileOnCustomerDelete(null, makeCtx(em))
+    expect(calls).toHaveLength(0)
+  })
+
+  test('company delete nulls customerEntityId on orders and quotes', async () => {
+    const { em, calls } = makeEm()
+    await reconcileOnCompanyDelete({ entityId: 'company-1', tenantId: 'tenant-1' }, makeCtx(em))
+    expect(calls.map((c) => c.entity).sort((a: any, b: any) => String(a.name).localeCompare(String(b.name)))).toEqual(
+      [SalesOrder, SalesQuote].sort((a: any, b: any) => String(a.name).localeCompare(String(b.name))),
+    )
+  })
+
+  test('address delete nulls both billing and shipping references on orders and quotes', async () => {
+    const { em, calls } = makeEm()
+    const addressId = '00000000-0000-0000-0000-000000000100'
+    const tenantId = '00000000-0000-0000-0000-000000000200'
+    await reconcileOnAddressDelete({ id: addressId, tenantId }, makeCtx(em))
+
+    expect(calls).toHaveLength(4)
+    const billingOrder = calls.find(
+      (c) => c.entity === SalesOrder && 'billingAddressId' in (c.where as any),
+    )
+    const shippingOrder = calls.find(
+      (c) => c.entity === SalesOrder && 'shippingAddressId' in (c.where as any),
+    )
+    const billingQuote = calls.find(
+      (c) => c.entity === SalesQuote && 'billingAddressId' in (c.where as any),
+    )
+    const shippingQuote = calls.find(
+      (c) => c.entity === SalesQuote && 'shippingAddressId' in (c.where as any),
+    )
+
+    expect(billingOrder?.where).toEqual({ billingAddressId: addressId, tenantId })
+    expect(billingOrder?.data).toEqual({ billingAddressId: null })
+    expect(shippingOrder?.where).toEqual({ shippingAddressId: addressId, tenantId })
+    expect(shippingOrder?.data).toEqual({ shippingAddressId: null })
+    expect(billingQuote?.where).toEqual({ billingAddressId: addressId, tenantId })
+    expect(billingQuote?.data).toEqual({ billingAddressId: null })
+    expect(shippingQuote?.where).toEqual({ shippingAddressId: addressId, tenantId })
+    expect(shippingQuote?.data).toEqual({ shippingAddressId: null })
+  })
+
+  test('address delete is a no-op when id or tenantId missing', async () => {
+    const { em, calls } = makeEm()
+    await reconcileOnAddressDelete({ tenantId: 't' }, makeCtx(em))
+    await reconcileOnAddressDelete({ id: 'a' }, makeCtx(em))
+    expect(calls).toHaveLength(0)
+  })
+
+  test('swallows errors so a failing reconcile does not break the event bus', async () => {
+    const errorEm = {
+      nativeUpdate: async () => {
+        throw new Error('db down')
+      },
+    }
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    await expect(
+      reconcileOnAddressDelete({ id: 'addr-1', tenantId: 't' }, makeCtx(errorEm)),
+    ).resolves.toBeUndefined()
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+})

--- a/packages/core/src/modules/sales/subscribers/reconcileOnAddressDelete.ts
+++ b/packages/core/src/modules/sales/subscribers/reconcileOnAddressDelete.ts
@@ -1,0 +1,47 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { SalesOrder, SalesQuote } from '@open-mercato/core/modules/sales/data/entities'
+
+export const metadata = {
+  event: 'customers.address.deleted',
+  persistent: true,
+  id: 'sales:reconcile-on-address-delete',
+}
+
+export default async function handle(
+  payload: unknown,
+  ctx: { resolve: <T = unknown>(name: string) => T; eventName?: string },
+): Promise<void> {
+  const data = payload as Record<string, unknown>
+  const addressId = data?.id as string | undefined
+  const tenantId = data?.tenantId as string | undefined
+  if (!addressId || !tenantId) return
+
+  const em = ctx.resolve<EntityManager>('em')
+
+  try {
+    await Promise.all([
+      em.nativeUpdate(
+        SalesOrder,
+        { billingAddressId: addressId, tenantId },
+        { billingAddressId: null },
+      ),
+      em.nativeUpdate(
+        SalesOrder,
+        { shippingAddressId: addressId, tenantId },
+        { shippingAddressId: null },
+      ),
+      em.nativeUpdate(
+        SalesQuote,
+        { billingAddressId: addressId, tenantId },
+        { billingAddressId: null },
+      ),
+      em.nativeUpdate(
+        SalesQuote,
+        { shippingAddressId: addressId, tenantId },
+        { shippingAddressId: null },
+      ),
+    ])
+  } catch (err) {
+    console.error('[sales:reconcile-on-address-delete] Failed to null address references on sales documents:', err)
+  }
+}

--- a/packages/core/src/modules/sales/subscribers/reconcileOnCompanyDelete.ts
+++ b/packages/core/src/modules/sales/subscribers/reconcileOnCompanyDelete.ts
@@ -1,0 +1,37 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { SalesOrder, SalesQuote } from '@open-mercato/core/modules/sales/data/entities'
+
+export const metadata = {
+  event: 'customers.company.deleted',
+  persistent: true,
+  id: 'sales:reconcile-on-company-delete',
+}
+
+export default async function handle(
+  payload: unknown,
+  ctx: { resolve: <T = unknown>(name: string) => T; eventName?: string },
+): Promise<void> {
+  const data = payload as Record<string, unknown>
+  const entityId = (data?.entityId as string | undefined) ?? (data?.id as string | undefined)
+  const tenantId = data?.tenantId as string | undefined
+  if (!entityId || !tenantId) return
+
+  const em = ctx.resolve<EntityManager>('em')
+
+  try {
+    await Promise.all([
+      em.nativeUpdate(
+        SalesOrder,
+        { customerEntityId: entityId, tenantId },
+        { customerEntityId: null },
+      ),
+      em.nativeUpdate(
+        SalesQuote,
+        { customerEntityId: entityId, tenantId },
+        { customerEntityId: null },
+      ),
+    ])
+  } catch (err) {
+    console.error('[sales:reconcile-on-company-delete] Failed to null customerEntityId on sales documents:', err)
+  }
+}

--- a/packages/core/src/modules/sales/subscribers/reconcileOnCustomerDelete.ts
+++ b/packages/core/src/modules/sales/subscribers/reconcileOnCustomerDelete.ts
@@ -1,0 +1,37 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { SalesOrder, SalesQuote } from '@open-mercato/core/modules/sales/data/entities'
+
+export const metadata = {
+  event: 'customers.person.deleted',
+  persistent: true,
+  id: 'sales:reconcile-on-person-delete',
+}
+
+export default async function handle(
+  payload: unknown,
+  ctx: { resolve: <T = unknown>(name: string) => T; eventName?: string },
+): Promise<void> {
+  const data = payload as Record<string, unknown>
+  const entityId = (data?.entityId as string | undefined) ?? (data?.id as string | undefined)
+  const tenantId = data?.tenantId as string | undefined
+  if (!entityId || !tenantId) return
+
+  const em = ctx.resolve<EntityManager>('em')
+
+  try {
+    await Promise.all([
+      em.nativeUpdate(
+        SalesOrder,
+        { customerEntityId: entityId, tenantId },
+        { customerEntityId: null },
+      ),
+      em.nativeUpdate(
+        SalesQuote,
+        { customerEntityId: entityId, tenantId },
+        { customerEntityId: null },
+      ),
+    ])
+  } catch (err) {
+    console.error('[sales:reconcile-on-person-delete] Failed to null customerEntityId on sales documents:', err)
+  }
+}


### PR DESCRIPTION
Fixes #1418

## Problem
Customer deletes left dangling UUID references in multiple modules:

- **Portal users**: `customer_users.person_entity_id` and `customer_entity_id` were not cleared when the linked CRM person/company was deleted, so portal accounts kept pointing at ghost records.
- **Sales documents**: `SalesOrder`/`SalesQuote.customer_entity_id`, `billing_address_id`, and `shipping_address_id` were raw UUIDs with no reconciliation on CRM/address delete.
- **Custom fields**: `CustomFieldValue` rows keyed off the deleted person/company profile stayed behind, producing orphaned EAV data.

## Root Cause
The modules are deliberately decoupled (no ORM relations between `customer_accounts`, `sales`, and `customers`), but the event-driven cleanup path was missing. `customers.person.deleted` / `customers.company.deleted` / `customers.address.deleted` were emitted, but nothing listened on them from `customer_accounts` or `sales`. Custom field rows were never deleted by the customer delete command.

## What Changed
- **Payload extension (additive, BC-safe)**: `customers.person.deleted` and `customers.company.deleted` now include an explicit `entityId: CustomerEntity.id`. Existing `id` field is preserved (`profile?.id ?? entity.id` as before). Subscribers prefer `entityId` and fall back to `id`.
- **New subscribers in `customer_accounts`** — null out dangling portal-user references, scoped by tenant:
  - `customer_accounts:unlink-on-person-delete` → `CustomerUser.personEntityId`
  - `customer_accounts:unlink-on-company-delete` → `CustomerUser.customerEntityId`
- **New subscribers in `sales`** — null out dangling sales-document references, scoped by tenant:
  - `sales:reconcile-on-person-delete` → `SalesOrder.customerEntityId`, `SalesQuote.customerEntityId`
  - `sales:reconcile-on-company-delete` → same as above
  - `sales:reconcile-on-address-delete` → `SalesOrder.billingAddressId` + `shippingAddressId`, `SalesQuote.billingAddressId` + `shippingAddressId`
- **Custom field cleanup in commands** — `deletePersonCommand` and `deleteCompanyCommand` now delete `CustomFieldValue` rows for both the `CustomerEntity` record and the detail profile before removing the entity.
- All subscribers are persistent and fail closed (log + swallow) so a reconcile failure cannot break the event bus.

## Tests
Added two subscriber unit-test files (17 cases total):
- `packages/core/src/modules/customer_accounts/__tests__/unlinkOnCustomerDelete.test.ts` — person/company metadata, happy-path update, `entityId`-vs-`id` fallback, no-op on missing fields, error swallowing (7 cases)
- `packages/core/src/modules/sales/subscribers/__tests__/reconcileOnCrmDelete.test.ts` — person/company/address reconciliation including 4 parallel updates for billing + shipping on orders and quotes, no-ops, error swallowing (10 cases)

## Checks Run
- `yarn generate` ✅
- `yarn typecheck` ✅ (18/18 packages)
- `yarn test` ✅ (new suites 17/17 pass; only pre-existing failure on clean `develop` was `sync-akeneo/catalog-importer` — unrelated dist-path resolution issue)
- `yarn i18n:check-sync` ✅
- `yarn i18n:check-usage` ✅ (advisory only; no new keys)
- `yarn build:app` ⚠️ pre-existing failure on clean `develop` (`/_global-error` and `/_not-found` pages fail to prerender with `Cannot read properties of null (reading 'useContext')`). Verified against a fresh `origin/develop` worktree — not caused by this PR.

## Backward Compatibility
- **Event payload**: `customers.person.deleted` / `customers.company.deleted` gain an additive `entityId` field; no existing fields removed or renamed.
- **No contract-surface breaks**: no API route changes, no DI key renames, no DB-schema/migration changes, no removed imports, no new required features in `acl.ts`.
- New subscribers use unique IDs (`customer_accounts:unlink-on-*`, `sales:reconcile-on-*`); no collisions with existing subscriber IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)