### PR TITLE
fix(shared): make route matching case-insensitive for static segments (#1559)

### DIFF
--- a/packages/shared/src/modules/__tests__/registry.test.ts
+++ b/packages/shared/src/modules/__tests__/registry.test.ts
@@ -9,6 +9,7 @@ import {
   findFrontendMatch,
   findBackendMatch,
   findApi,
+  matchRoutePattern,
 } from '../registry'
 
 describe('CLI Modules Registry', () => {
@@ -188,6 +189,62 @@ describe('CLI Modules Registry', () => {
 
       const result = findFrontendMatch(modules, '/settings')
       expect(result).toBeUndefined()
+    })
+
+    it('should match static segments case-insensitively (issue #1559)', () => {
+      const modules: Module[] = [
+        {
+          id: 'auth',
+          frontendRoutes: [
+            {
+              pattern: '/login',
+              Component: () => null,
+            },
+          ],
+        },
+      ]
+
+      expect(findFrontendMatch(modules, '/lOgin')).toBeDefined()
+      expect(findFrontendMatch(modules, '/LOGIN')).toBeDefined()
+      expect(findFrontendMatch(modules, '/Login')).toBeDefined()
+    })
+
+    it('should preserve dynamic param case', () => {
+      const modules: Module[] = [
+        {
+          id: 'test',
+          frontendRoutes: [
+            {
+              pattern: '/users/[id]',
+              Component: () => null,
+            },
+          ],
+        },
+      ]
+
+      const result = findFrontendMatch(modules, '/Users/JohnSmith')
+      expect(result).toBeDefined()
+      expect(result?.params).toEqual({ id: 'JohnSmith' })
+    })
+  })
+
+  describe('matchRoutePattern', () => {
+    it('matches multi-segment static patterns case-insensitively', () => {
+      expect(matchRoutePattern('/backend/customers/people', '/Backend/Customers/PEOPLE')).toEqual({})
+    })
+
+    it('matches mixed static + dynamic patterns and preserves dynamic case', () => {
+      expect(matchRoutePattern('/users/[id]/edit', '/USERS/AbC123/Edit')).toEqual({ id: 'AbC123' })
+    })
+
+    it('preserves catch-all segment case', () => {
+      expect(matchRoutePattern('/docs/[...slug]', '/Docs/API/Getting-Started')).toEqual({
+        slug: ['API', 'Getting-Started'],
+      })
+    })
+
+    it('returns undefined when static segments do not match even case-insensitively', () => {
+      expect(matchRoutePattern('/login', '/sign-in')).toBeUndefined()
     })
   })
 

--- a/packages/shared/src/modules/registry.ts
+++ b/packages/shared/src/modules/registry.ts
@@ -256,7 +256,7 @@ export function matchRoutePattern(pattern: string, pathname: string): RouteMatch
       if (i >= uSegs.length) return undefined
       params[mDyn[1]] = uSegs[i]
     } else {
-      if (i >= uSegs.length || uSegs[i] !== seg) return undefined
+      if (i >= uSegs.length || uSegs[i].toLowerCase() !== seg.toLowerCase()) return undefined
     }
   }
   if (i !== uSegs.length) return undefined


### PR DESCRIPTION
Fixes #1559

## Problem
Visiting `/lOgin` (or any path with uppercase letters in a static segment such as `/Backend/Customers/People`) returned a 404 because the dispatcher matched route patterns with strict case-sensitive segment equality.

## Root Cause
`matchRoutePattern` in `packages/shared/src/modules/registry.ts` is the single matcher used by `findRouteManifestMatch`, `findFrontendMatch`, `findBackendMatch`, and `findApiRouteManifestMatch`. Its static-segment branch compared `uSegs[i] !== seg` directly, so any letter-case mismatch produced no match and the catch-all `[...slug]` page returned `notFound()`.

## What Changed
- `matchRoutePattern` now compares static segments using `.toLowerCase()` on both sides.
- Dynamic segments (`[id]`) and catch-all segments (`[...slug]` / `[[...slug]]`) still capture the original (case-preserving) URL substring, so values like usernames, slugs, and UUIDs are unaffected.
- The change is purely additive in behavior: paths that matched before still match; paths that previously 404'd because of casing now resolve to their canonical route.

## Tests
- Added regression coverage in `packages/shared/src/modules/__tests__/registry.test.ts`:
  - `/lOgin`, `/LOGIN`, `/Login` resolve to the `/login` frontend route (issue #1559).
  - `/Users/JohnSmith` resolves to `/users/[id]` and the captured `id` keeps its original case.
  - `matchRoutePattern` direct cases for multi-segment static patterns, mixed static + dynamic patterns, catch-all patterns, and a negative case.
- Reran `yarn typecheck`, `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, and the full `yarn test` suite. The only failures encountered (`packages/ui CustomDataSection` cases and `apps/mercato /_global-error` prerender) reproduce on `origin/develop` without this change and are unrelated to route matching.

## Backward Compatibility
- Function signature and exports unchanged.
- No contract surface from `BACKWARD_COMPATIBILITY.md` is affected (route URLs are stable; this widens what the matcher accepts, never narrows).
- No DB schema, event ID, ACL, widget spot, DI service, or API URL changes.