### PR TITLE
fix(api_keys): gate role loader on actor-resolution (#1556)

### DIFF
--- a/packages/core/src/modules/api_keys/backend/api-keys/create/__tests__/CreateApiKeyPage.test.tsx
+++ b/packages/core/src/modules/api_keys/backend/api-keys/create/__tests__/CreateApiKeyPage.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { act, render, waitFor } from '@testing-library/react'
+import CreateApiKeyPage from '../page'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { fetchRoleOptions } from '@open-mercato/core/modules/auth/backend/users/roleOptions'
+
+const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+const mockPush = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: any) => <div>{children}</div>,
+  PageBody: ({ children }: any) => <div>{children}</div>,
+}))
+
+type CapturedField = { id: string; loadOptions?: (query?: string) => Promise<unknown> }
+let capturedFields: CapturedField[] = []
+
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
+  CrudForm: (props: any) => {
+    capturedFields = Array.isArray(props.fields) ? props.fields : []
+    return <div data-testid="crud-form-mock" />
+  },
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  createCrud: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/serverErrors', () => ({
+  createCrudFormError: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children }: any) => <button>{children}</button>,
+}))
+
+jest.mock('@open-mercato/core/modules/directory/components/OrganizationSelect', () => ({
+  OrganizationSelect: () => null,
+}))
+
+jest.mock('@open-mercato/core/modules/auth/backend/users/roleOptions', () => ({
+  fetchRoleOptions: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeDetail: () => ({ tenantId: null, organizationId: null }),
+  useOrganizationScopeVersion: () => 0,
+}))
+
+function findLoadRoleOptions(): ((query?: string) => Promise<unknown>) | undefined {
+  const rolesField = capturedFields.find((field) => field.id === 'roles')
+  return rolesField?.loadOptions
+}
+
+describe('CreateApiKeyPage — role selector tenant scoping (#1556)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    capturedFields = []
+  })
+
+  it('returns empty options and skips fetchRoleOptions until actor-resolution completes', async () => {
+    let resolveActor: (value: any) => void = () => {}
+    const actorResolution = new Promise<any>((resolve) => {
+      resolveActor = resolve
+    })
+    ;(apiCall as jest.Mock).mockImplementation(() => actorResolution)
+    ;(fetchRoleOptions as jest.Mock).mockResolvedValue([
+      { value: 'role-a', label: 'Role A' },
+    ])
+
+    render(<CreateApiKeyPage />)
+
+    await waitFor(() => expect(capturedFields.length).toBeGreaterThan(0))
+
+    const loadRoleOptions = findLoadRoleOptions()
+    expect(typeof loadRoleOptions).toBe('function')
+
+    // Before the actor-resolution promise settles, the loader MUST return []
+    // and MUST NOT invoke fetchRoleOptions — otherwise an unscoped query could
+    // leak roles from other tenants when the real caller is a super admin.
+    const earlyResult = await loadRoleOptions!()
+    expect(earlyResult).toEqual([])
+    expect(fetchRoleOptions).not.toHaveBeenCalled()
+
+    // Resolve the actor as a non-super admin. Once the resolution finishes,
+    // the loader is allowed to hit the roles endpoint (without tenantId for
+    // non-super-admin callers, matching server-side scoping rules).
+    await act(async () => {
+      resolveActor({ ok: true, result: { tenantId: 'tenant-1', isSuperAdmin: false } })
+      await actorResolution
+    })
+
+    await waitFor(() => {
+      const latest = findLoadRoleOptions()
+      expect(latest).not.toBe(loadRoleOptions)
+    })
+
+    const resolvedLoader = findLoadRoleOptions()!
+    await resolvedLoader()
+    expect(fetchRoleOptions).toHaveBeenCalledTimes(1)
+    expect(fetchRoleOptions).toHaveBeenCalledWith(undefined)
+  })
+
+  it('still blocks the initial call when actor resolution fails (error branch sets actorResolved)', async () => {
+    let rejectActor: (reason: unknown) => void = () => {}
+    const actorResolution = new Promise<any>((_resolve, reject) => {
+      rejectActor = reject
+    })
+    ;(apiCall as jest.Mock).mockImplementation(() => actorResolution)
+    ;(fetchRoleOptions as jest.Mock).mockResolvedValue([])
+
+    render(<CreateApiKeyPage />)
+
+    await waitFor(() => expect(capturedFields.length).toBeGreaterThan(0))
+
+    const earlyLoader = findLoadRoleOptions()!
+    expect(await earlyLoader()).toEqual([])
+    expect(fetchRoleOptions).not.toHaveBeenCalled()
+
+    await act(async () => {
+      rejectActor(new Error('boom'))
+      await actorResolution.catch(() => {})
+    })
+
+    // After the finally-block flips actorResolved, a fresh loader closure
+    // must be produced and the fallback branch is allowed to run.
+    await waitFor(() => {
+      const latest = findLoadRoleOptions()
+      expect(latest).not.toBe(earlyLoader)
+    })
+
+    const recoveredLoader = findLoadRoleOptions()!
+    await recoveredLoader()
+    expect(fetchRoleOptions).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/api_keys/backend/api-keys/create/page.tsx
+++ b/packages/core/src/modules/api_keys/backend/api-keys/create/page.tsx
@@ -24,6 +24,7 @@ type FormValues = {
 export default function CreateApiKeyPage() {
   const [createdSecret, setCreatedSecret] = React.useState<{ secret: string; keyPrefix: string } | null>(null)
   const [actorIsSuperAdmin, setActorIsSuperAdmin] = React.useState(false)
+  const [actorResolved, setActorResolved] = React.useState(false)
   const [selectedTenantId, setSelectedTenantId] = React.useState<string | null>(null)
   const router = useRouter()
   const scopeDetail = useOrganizationScopeDetail()
@@ -47,6 +48,8 @@ export default function CreateApiKeyPage() {
         setActorIsSuperAdmin(Boolean(result?.isSuperAdmin))
       } catch {
         if (!cancelled) setActorIsSuperAdmin(false)
+      } finally {
+        if (!cancelled) setActorResolved(true)
       }
     }
     loadInitialScope()
@@ -63,14 +66,18 @@ export default function CreateApiKeyPage() {
     })
   }, [scopeDetail.tenantId, scopeVersion])
 
+  // Block role loading until we know whether the actor is a super admin. Without this guard the
+  // initial (non-super-admin) branch fires before the flag resolves and the server returns roles
+  // from other tenants because the real caller is a super admin without tenantId scoping.
   const loadRoleOptions = React.useCallback(async (query?: string) => {
+    if (!actorResolved) return []
     if (actorIsSuperAdmin) {
       const tenant = typeof selectedTenantId === 'string' && selectedTenantId.trim().length > 0 ? selectedTenantId.trim() : null
       if (!tenant) return []
       return fetchRoleOptions(query, { tenantId: tenant })
     }
     return fetchRoleOptions(query)
-  }, [actorIsSuperAdmin, selectedTenantId])
+  }, [actorIsSuperAdmin, actorResolved, selectedTenantId])
 
   const fields = React.useMemo<CrudField[]>(() => [
     { id: 'name', label: t('api_keys.form.name'), type: 'text', required: true },


### PR DESCRIPTION
Fixes #1556

## Problem
`/backend/api-keys/create` leaks cross-tenant roles in the role tag selector for a super-admin caller during the window between initial render and actor-resolution completion. Same pattern as #1538 (fixed on the users pages by PR #1554).

## Root Cause
`actorIsSuperAdmin` holds its initial `false` default until `/api/directory/organization-switcher` resolves. During that window the non-super branch of `loadRoleOptions` runs `fetchRoleOptions(query)` **without** a `tenantId`. The `/api/auth/roles` endpoint, seeing the real caller is a super admin, legitimately returns roles across tenants — which then surface briefly in the selector.

The universal `CrudForm` cache fix shipped in PR #1554 already shortens the staleness window when the loader closure changes, but it does not prevent the *first* unscoped fetch from being issued to the server.

## What Changed
- `packages/core/src/modules/api_keys/backend/api-keys/create/page.tsx`: add `actorResolved` state, flip it in the `finally` block of the actor-resolution `useEffect` (both success and error branches), and gate `loadRoleOptions` on it so the roles endpoint is never queried until we know whether the actor is a super admin.

## Tests
- New `packages/core/src/modules/api_keys/backend/api-keys/create/__tests__/CreateApiKeyPage.test.tsx` with two regression cases:
  - `loadRoleOptions` returns `[]` and does **not** invoke `fetchRoleOptions` until the actor-resolution promise settles.
  - The error branch of actor-resolution still flips `actorResolved` via `finally`, so the loader recovers instead of blocking forever.
- Verified both tests fail on `develop` (loader invoked unscoped) and pass after the fix.
- `yarn typecheck` — green (20 packages).
- `yarn i18n:check-sync` — green.
- `yarn workspace @open-mercato/core jest` — only pre-existing `customers/.../InlineEditors.test.tsx` fails (also fails on clean `develop`; unrelated).

## Backward Compatibility
- No contract surface changes. UI-only scope fix; server responses are already behaving correctly given the scoping of the caller.
- No API route, event, entity, ACL, or DI change. No removed exports.

## Test plan
- [ ] Sign in as super admin; create a new tenant + organization and switch into it.
- [ ] Open `/backend/api-keys/create` — the role tag selector shows no options until the actor-resolution completes.
- [ ] Once resolved, the selector shows only the selected tenant's roles.
- [ ] Submitting creates the API key with the selected tenant's role(s) without `Role(s) not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)