### PR TITLE
fix(queue): replace synchronous file I/O with async fs.promises (#1401)

### DIFF
--- a/packages/queue/src/__tests__/local.strategy.test.ts
+++ b/packages/queue/src/__tests__/local.strategy.test.ts
@@ -309,4 +309,84 @@ describe('Queue - local strategy', () => {
 
     await queue.close()
   })
+
+  // Regression: queue operations MUST use async fs.promises.* so they do not
+  // block the Node.js event loop. See GitHub issue #1401.
+  test('queue operations do not call synchronous fs APIs on queue files', async () => {
+    const queueDir = path.join('.mercato', 'queue', 'sync-free')
+    const touchesQueue = (args: unknown[]) =>
+      args.some((arg) => typeof arg === 'string' && arg.includes(queueDir))
+
+    const syncCalls: string[] = []
+    const mkdirSpy = jest.spyOn(fs, 'mkdirSync').mockImplementation((...args: any[]) => {
+      if (touchesQueue(args)) syncCalls.push(`mkdirSync(${args[0]})`)
+      return undefined as any
+    })
+    const readSpy = jest.spyOn(fs, 'readFileSync').mockImplementation((...args: any[]) => {
+      if (touchesQueue(args)) syncCalls.push(`readFileSync(${args[0]})`)
+      return '' as any
+    })
+    const writeSpy = jest.spyOn(fs, 'writeFileSync').mockImplementation((...args: any[]) => {
+      if (touchesQueue(args)) syncCalls.push(`writeFileSync(${args[0]})`)
+      return undefined as any
+    })
+
+    try {
+      const queue = createQueue<{ value: number }>('sync-free', 'local')
+
+      await queue.enqueue({ value: 1 })
+      await queue.enqueue({ value: 2 })
+      await queue.getJobCounts()
+      await queue.process((_job) => {}, { limit: 10 })
+      await queue.clear()
+      await queue.close()
+
+      expect(syncCalls).toEqual([])
+    } finally {
+      mkdirSpy.mockRestore()
+      readSpy.mockRestore()
+      writeSpy.mockRestore()
+    }
+  })
+
+  // Regression: serialize enqueue calls so async fs writes cannot clobber
+  // each other. Before the async conversion this was trivially safe because
+  // sync I/O executed atomically. With async fs a mutex is required.
+  test('concurrent enqueues do not lose jobs', async () => {
+    const queue = createQueue<{ value: number }>('concurrent-queue', 'local')
+    const queuePath = path.join('.mercato', 'queue', 'concurrent-queue', 'queue.json')
+
+    const enqueueCount = 50
+    await Promise.all(
+      Array.from({ length: enqueueCount }, (_, idx) => queue.enqueue({ value: idx })),
+    )
+
+    const stored = readJson(queuePath)
+    expect(stored).toHaveLength(enqueueCount)
+    const storedValues = stored.map((job: any) => job.payload.value).sort((a: number, b: number) => a - b)
+    expect(storedValues).toEqual(Array.from({ length: enqueueCount }, (_, idx) => idx))
+
+    await queue.close()
+  })
+
+  // Regression: jobs enqueued while a batch is running must survive the
+  // subsequent write that removes completed jobs. The pre-fix snapshot-only
+  // write would clobber them.
+  test('jobs enqueued during batch handler are preserved on final write', async () => {
+    const queue = createQueue<{ value: number; latecomer?: boolean }>('race-queue', 'local')
+    const queuePath = path.join('.mercato', 'queue', 'race-queue', 'queue.json')
+
+    await queue.enqueue({ value: 1 })
+
+    await queue.process(async () => {
+      // Mid-handler, enqueue a second job. It should survive the final write.
+      await queue.enqueue({ value: 2, latecomer: true })
+    }, { limit: 10 })
+
+    const remaining = readJson(queuePath)
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].payload).toEqual({ value: 2, latecomer: true })
+
+    await queue.close()
+  })
 })

--- a/packages/queue/src/strategies/local.ts
+++ b/packages/queue/src/strategies/local.ts
@@ -20,6 +20,8 @@ const DEFAULT_LOCAL_QUEUE_BASE_DIR = '.mercato/queue'
 const DEFAULT_MAX_ATTEMPTS = 3
 const RETRY_BACKOFF_BASE_MS = 1000
 
+const fsp = fs.promises
+
 /**
  * Creates a file-based local queue.
  *
@@ -31,6 +33,11 @@ const RETRY_BACKOFF_BASE_MS = 1000
  * - Jobs are processed sequentially (concurrency option is for logging/compatibility only)
  * - Not suitable for production or multi-process environments
  * - No retry mechanism for failed jobs
+ *
+ * All file I/O is asynchronous (`fs.promises.*`) so queue operations do not
+ * block the Node.js event loop. A per-queue promise chain serializes
+ * read-modify-write sequences to preserve the atomicity guarantees the
+ * previous synchronous implementation relied on.
  *
  * @template T - The payload type for jobs
  * @param name - Queue name (used for directory naming)
@@ -56,14 +63,25 @@ export function createLocalQueue<T = unknown>(
   let isProcessing = false
   let activeHandler: JobHandler<T> | null = null
 
+  // Per-queue mutex. Serializes read-modify-write segments so async fs calls
+  // cannot interleave and clobber each other's writes.
+  let fileOpChain: Promise<unknown> = Promise.resolve()
+  function withFileLock<R>(fn: () => Promise<R>): Promise<R> {
+    const run = fileOpChain.then(() => fn(), () => fn())
+    fileOpChain = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
+  }
+
   // -------------------------------------------------------------------------
   // File Operations
   // -------------------------------------------------------------------------
 
-  function ensureDir(): void {
-    // Use atomic operations to handle race conditions
+  async function ensureDir(): Promise<void> {
     try {
-      fs.mkdirSync(queueDir, { recursive: true })
+      await fsp.mkdir(queueDir, { recursive: true })
     } catch (e: unknown) {
       const error = e as NodeJS.ErrnoException
       if (error.code !== 'EEXIST') throw error
@@ -71,7 +89,7 @@ export function createLocalQueue<T = unknown>(
 
     // Initialize queue file with exclusive create flag
     try {
-      fs.writeFileSync(queueFile, '[]', { encoding: 'utf8', flag: 'wx' })
+      await fsp.writeFile(queueFile, '[]', { encoding: 'utf8', flag: 'wx' })
     } catch (e: unknown) {
       const error = e as NodeJS.ErrnoException
       if (error.code !== 'EEXIST') throw error
@@ -79,26 +97,26 @@ export function createLocalQueue<T = unknown>(
 
     // Initialize state file with exclusive create flag
     try {
-      fs.writeFileSync(stateFile, '{}', { encoding: 'utf8', flag: 'wx' })
+      await fsp.writeFile(stateFile, '{}', { encoding: 'utf8', flag: 'wx' })
     } catch (e: unknown) {
       const error = e as NodeJS.ErrnoException
       if (error.code !== 'EEXIST') throw error
     }
   }
 
-  function backupCorruptedQueueFile(content: string): string {
+  async function backupCorruptedQueueFile(content: string): Promise<string> {
     const backupFile = path.join(queueDir, `queue.corrupted.${Date.now()}.json`)
-    fs.writeFileSync(backupFile, content, 'utf8')
-    fs.writeFileSync(queueFile, '[]', 'utf8')
+    await fsp.writeFile(backupFile, content, 'utf8')
+    await fsp.writeFile(queueFile, '[]', 'utf8')
     return backupFile
   }
 
-  function readQueue(): StoredJob<T>[] {
-    ensureDir()
+  async function readQueue(): Promise<StoredJob<T>[]> {
+    await ensureDir()
     let content: string
 
     try {
-      content = fs.readFileSync(queueFile, 'utf8')
+      content = await fsp.readFile(queueFile, 'utf8')
     } catch (error: unknown) {
       const readError = error as NodeJS.ErrnoException
       if (readError.code === 'ENOENT') {
@@ -119,30 +137,30 @@ export function createLocalQueue<T = unknown>(
     } catch (error: unknown) {
       const parseError = error as Error
       console.error(`[queue:${name}] Failed to read queue file:`, parseError.message)
-      const backupFile = backupCorruptedQueueFile(content)
+      const backupFile = await backupCorruptedQueueFile(content)
       console.error(`[queue:${name}] Backed up corrupted queue file to ${backupFile} and recreated queue.json`)
       return []
     }
   }
 
-  function writeQueue(jobs: StoredJob<T>[]): void {
-    ensureDir()
-    fs.writeFileSync(queueFile, JSON.stringify(jobs, null, 2), 'utf8')
+  async function writeQueue(jobs: StoredJob<T>[]): Promise<void> {
+    await ensureDir()
+    await fsp.writeFile(queueFile, JSON.stringify(jobs, null, 2), 'utf8')
   }
 
-  function readState(): LocalState {
-    ensureDir()
+  async function readState(): Promise<LocalState> {
+    await ensureDir()
     try {
-      const content = fs.readFileSync(stateFile, 'utf8')
+      const content = await fsp.readFile(stateFile, 'utf8')
       return JSON.parse(content) as LocalState
     } catch {
       return {}
     }
   }
 
-  function writeState(state: LocalState): void {
-    ensureDir()
-    fs.writeFileSync(stateFile, JSON.stringify(state, null, 2), 'utf8')
+  async function writeState(state: LocalState): Promise<void> {
+    await ensureDir()
+    await fsp.writeFile(stateFile, JSON.stringify(state, null, 2), 'utf8')
   }
 
   function generateId(): string {
@@ -154,7 +172,6 @@ export function createLocalQueue<T = unknown>(
   // -------------------------------------------------------------------------
 
   async function enqueue(data: T, options?: EnqueueOptions): Promise<string> {
-    const jobs = readQueue()
     const availableAt = options?.delayMs && options.delayMs > 0
       ? new Date(Date.now() + options.delayMs).toISOString()
       : undefined
@@ -164,8 +181,11 @@ export function createLocalQueue<T = unknown>(
       createdAt: new Date().toISOString(),
       ...(availableAt ? { availableAt } : {}),
     }
-    jobs.push(job)
-    writeQueue(jobs)
+    await withFileLock(async () => {
+      const jobs = await readQueue()
+      jobs.push(job)
+      await writeQueue(jobs)
+    })
     return job.id
   }
 
@@ -176,8 +196,11 @@ export function createLocalQueue<T = unknown>(
     handler: JobHandler<T>,
     options?: ProcessOptions
   ): Promise<ProcessResult> {
-    const state = readState()
-    const jobs = readQueue()
+    const { state, jobs } = await withFileLock(async () => {
+      const stateRead = await readState()
+      const jobsRead = await readQueue()
+      return { state: stateRead, jobs: jobsRead }
+    })
 
     const pendingJobs = jobs.filter((job) => {
       if (!job.availableAt) return true
@@ -228,17 +251,21 @@ export function createLocalQueue<T = unknown>(
 
     const hasChanges = completedJobIds.size > 0 || deadJobIds.size > 0 || retryUpdates.size > 0
     if (hasChanges) {
-      const updatedJobs = jobs
-        .filter((j) => !completedJobIds.has(j.id) && !deadJobIds.has(j.id))
-        .map((j) => retryUpdates.get(j.id) ?? j)
-      writeQueue(updatedJobs)
+      await withFileLock(async () => {
+        // Re-read so jobs enqueued during handler execution are preserved.
+        const currentJobs = await readQueue()
+        const updatedJobs = currentJobs
+          .filter((j) => !completedJobIds.has(j.id) && !deadJobIds.has(j.id))
+          .map((j) => retryUpdates.get(j.id) ?? j)
+        await writeQueue(updatedJobs)
 
-      const newState: LocalState = {
-        lastProcessedId: lastJobId,
-        completedCount: (state.completedCount ?? 0) + processed,
-        failedCount: (state.failedCount ?? 0) + deadJobIds.size,
-      }
-      writeState(newState)
+        const newState: LocalState = {
+          lastProcessedId: lastJobId,
+          completedCount: (state.completedCount ?? 0) + processed,
+          failedCount: (state.failedCount ?? 0) + deadJobIds.size,
+        }
+        await writeState(newState)
+      })
     }
 
     return { processed, failed, lastJobId }
@@ -290,16 +317,18 @@ export function createLocalQueue<T = unknown>(
   }
 
   async function clear(): Promise<{ removed: number }> {
-    const jobs = readQueue()
-    const removed = jobs.length
-    writeQueue([])
-    // Reset state but preserve counts for historical tracking
-    const state = readState()
-    writeState({
-      completedCount: state.completedCount,
-      failedCount: state.failedCount,
+    return withFileLock(async () => {
+      const jobs = await readQueue()
+      const removed = jobs.length
+      await writeQueue([])
+      // Reset state but preserve counts for historical tracking
+      const state = await readState()
+      await writeState({
+        completedCount: state.completedCount,
+        failedCount: state.failedCount,
+      })
+      return { removed }
     })
-    return { removed }
   }
 
   async function close(): Promise<void> {
@@ -329,15 +358,17 @@ export function createLocalQueue<T = unknown>(
     completed: number
     failed: number
   }> {
-    const state = readState()
-    const jobs = readQueue()
+    return withFileLock(async () => {
+      const state = await readState()
+      const jobs = await readQueue()
 
-    return {
-      waiting: jobs.length, // All jobs in queue are waiting (processed ones are removed)
-      active: 0, // Local strategy doesn't track active jobs
-      completed: state.completedCount ?? 0,
-      failed: state.failedCount ?? 0,
-    }
+      return {
+        waiting: jobs.length, // All jobs in queue are waiting (processed ones are removed)
+        active: 0, // Local strategy doesn't track active jobs
+        completed: state.completedCount ?? 0,
+        failed: state.failedCount ?? 0,
+      }
+    })
   }
 
   return {


### PR DESCRIPTION
Fixes #1401

## Problem

`packages/queue/src/strategies/local.ts` used synchronous `fs.mkdirSync`, `fs.readFileSync`, and `fs.writeFileSync` calls on the main thread for every enqueue, dequeue, state read, state write, and polling tick. Under load this blocks the Node.js event loop — starving request handlers, other queue workers, and HTTP responses until the sync disk I/O completes. The queue file is fully rewritten on every mutation, so the blocking window grows with queue size.

## Root Cause

All file operations inside `createLocalQueue` went through the sync fs API. There was no way to yield the event loop between a read and a write.

## What Changed

- `packages/queue/src/strategies/local.ts`
  - Replaced every `fs.*Sync` call in `ensureDir`, `readQueue`, `writeQueue`, `readState`, `writeState`, and `backupCorruptedQueueFile` with `fs.promises.*`. All helpers are now async.
  - Added a per-queue promise-chain mutex (`withFileLock`) so concurrent enqueues and the batch read/write phases cannot interleave and clobber each other now that the I/O no longer executes atomically on a single thread.
  - `processBatch` now re-reads the queue immediately before the final write (inside the mutex) so jobs enqueued during handler execution are preserved instead of being silently overwritten by the pre-handler snapshot. This removes a latent lost-write race that the previous sync implementation also shipped with.
- `packages/queue/src/__tests__/local.strategy.test.ts`
  - New regression test: spies on `fs.mkdirSync` / `fs.readFileSync` / `fs.writeFileSync` and asserts none are called against the queue directory during any public queue operation.
  - New regression test: 50 concurrent `enqueue` calls all land on disk (serialization works).
  - New regression test: a job enqueued from inside the batch handler is preserved on the subsequent write.

Public API (`enqueue`, `process`, `clear`, `close`, `getJobCounts`) and on-disk file formats are unchanged.

## Tests

- `yarn workspace @open-mercato/queue test` — 43/43 tests pass (14 pre-existing + 3 new regression tests).
- `yarn typecheck` — repo-wide clean.
- `yarn build:packages` — clean.
- `yarn test` — queue, scheduler, webhooks, sync-akeneo, checkout, etc. all pass. Two pre-existing failures unrelated to this change: `@open-mercato/ui CustomDataSection` (also fails on `origin/develop`) and `@open-mercato/app build` Next.js `_global-error` prerender (app shell issue, nothing touched by this diff).

## Backward Compatibility

- No contract surface changes. Queue strategy interface, file layout, env vars (`QUEUE_BASE_DIR`, `QUEUE_STRATEGY`), and worker metadata are untouched.
- The re-read-before-write behavior change is a strict correctness improvement: jobs that the old code silently dropped are now retained. No existing caller relied on the drop.