### PR TITLE
fix(customers): bound memory on legacy todos/activities reads (#1397)

### DIFF
--- a/packages/core/src/modules/customers/api/activities/__tests__/merged-pagination.test.ts
+++ b/packages/core/src/modules/customers/api/activities/__tests__/merged-pagination.test.ts
@@ -1,0 +1,124 @@
+/** @jest-environment node */
+
+import { CustomerActivity, CustomerInteraction } from '../../../data/entities'
+import { GET } from '../route'
+
+const ORG_ID = '123e4567-e89b-41d3-a456-426614174000'
+const TENANT_ID = '123e4567-e89b-41d3-a456-426614174010'
+
+const mockCommandBus = { execute: jest.fn() }
+const mockEm = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  findAndCount: jest.fn(),
+  count: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'commandBus') return mockCommandBus
+    if (name === 'em') return mockEm
+    if (name === 'queryEngine') return { query: jest.fn() }
+    throw new Error(`Unknown dependency: ${name}`)
+  }),
+}
+
+const mockContext = {
+  auth: { sub: 'user-1', tenantId: TENANT_ID, orgId: ORG_ID },
+  em: mockEm,
+  organizationIds: [ORG_ID],
+  selectedOrganizationId: ORG_ID,
+  container: mockContainer,
+  commandContext: {
+    container: mockContainer,
+    auth: { sub: 'user-1', tenantId: TENANT_ID, orgId: ORG_ID },
+    organizationScope: null,
+    selectedOrganizationId: ORG_ID,
+    organizationIds: [ORG_ID],
+    request: undefined,
+  },
+}
+
+jest.mock('../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn(),
+}))
+
+jest.mock('../../../lib/interactionRequestContext', () => ({
+  resolveCustomersRequestContext: jest.fn(async () => mockContext),
+}))
+
+jest.mock('../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async () => []),
+  loadCustomerSummaries: jest.fn(async () => new Map()),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+jest.mock('../../../lib/interactionCompatibility', () => ({
+  mapInteractionRecordToActivitySummary: jest.fn(),
+  CUSTOMER_INTERACTION_ACTIVITY_ADAPTER_SOURCE: 'adapter:activity',
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(async () => []),
+}))
+
+describe('activities merged GET pagination', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    const { resolveCustomerInteractionFeatureFlags } = jest.requireMock(
+      '../../../lib/interactionFeatureFlags',
+    )
+    resolveCustomerInteractionFeatureFlags.mockResolvedValue({
+      unified: false,
+      legacyAdapters: true,
+      externalSync: false,
+    })
+
+    mockEm.findAndCount.mockImplementation(async () => [[], 0])
+    mockEm.find.mockImplementation(async () => [])
+    mockEm.count.mockImplementation(async () => 0)
+  })
+
+  it('uses bounded DB-side paginated fetches for both sources in non-unified mode', async () => {
+    await GET(new Request('http://localhost/api/customers/activities?page=2&pageSize=50'))
+
+    const legacyCall = mockEm.findAndCount.mock.calls.find(
+      (args) => args[0] === CustomerActivity,
+    )
+    const canonicalCall = mockEm.findAndCount.mock.calls.find(
+      (args) => args[0] === CustomerInteraction,
+    )
+
+    expect(legacyCall).toBeDefined()
+    expect(canonicalCall).toBeDefined()
+
+    const legacyOptions = legacyCall![2] as Record<string, unknown>
+    const canonicalOptions = canonicalCall![2] as Record<string, unknown>
+
+    expect(typeof legacyOptions.limit).toBe('number')
+    expect(legacyOptions.limit as number).toBeGreaterThan(0)
+    expect(legacyOptions.limit as number).toBeLessThanOrEqual(2000)
+    expect(legacyOptions.offset).toBe(0)
+
+    expect(typeof canonicalOptions.limit).toBe('number')
+    expect(canonicalOptions.limit as number).toBeGreaterThan(0)
+    expect(canonicalOptions.limit as number).toBeLessThanOrEqual(2000)
+    expect(canonicalOptions.offset).toBe(0)
+  })
+
+  it('does not fall back to unbounded em.find for either source', async () => {
+    await GET(new Request('http://localhost/api/customers/activities?page=1&pageSize=50'))
+
+    for (const call of mockEm.find.mock.calls) {
+      const entity = call[0]
+      expect(entity).not.toBe(CustomerActivity)
+      expect(entity).not.toBe(CustomerInteraction)
+    }
+  })
+})

--- a/packages/core/src/modules/customers/api/activities/route.ts
+++ b/packages/core/src/modules/customers/api/activities/route.ts
@@ -68,6 +68,12 @@ const ADAPTER_HEADERS = {
   Link: '</api/customers/interactions>; rel="successor-version"',
 }
 
+// Caps the per-source fetch window used by the deprecated merged (legacy +
+// canonical bridge) read path. Keeps memory bounded on tenants with large
+// activity history; deep-pagination beyond this window is not supported here —
+// use /api/customers/interactions instead.
+const MERGED_ACTIVITY_FETCH_CAP = 2000
+
 type ActivityItem = {
   id: string
   activityType: string
@@ -461,23 +467,36 @@ export async function GET(request: Request): Promise<Response> {
           organizationIds,
           query,
         )
-      : await Promise.all([
-        listLegacyActivities(em, auth.tenantId, organizationIds, query, { paginate: false }, selectedOrganizationId),
-        listCanonicalActivities(
-          em,
-          container,
-          auth,
-          selectedOrganizationId,
-          auth.tenantId,
-          organizationIds,
-          query,
-          {
-            includeDeleted: true,
-            paginate: false,
-            source: CUSTOMER_INTERACTION_ACTIVITY_ADAPTER_SOURCE,
-          },
-        ),
-      ]).then(([legacy, canonical]) => {
+      : await (async () => {
+        const windowSize = Math.min(
+          MERGED_ACTIVITY_FETCH_CAP,
+          Math.max(query.pageSize, query.page * query.pageSize + query.pageSize),
+        )
+        const windowedQuery = { ...query, page: 1, pageSize: windowSize }
+        const [legacy, canonical] = await Promise.all([
+          listLegacyActivities(
+            em,
+            auth.tenantId,
+            organizationIds,
+            windowedQuery,
+            { paginate: true },
+            selectedOrganizationId,
+          ),
+          listCanonicalActivities(
+            em,
+            container,
+            auth,
+            selectedOrganizationId,
+            auth.tenantId,
+            organizationIds,
+            windowedQuery,
+            {
+              includeDeleted: true,
+              paginate: true,
+              source: CUSTOMER_INTERACTION_ACTIVITY_ADAPTER_SOURCE,
+            },
+          ),
+        ])
         const merged = sortActivityItems(
           [
             ...legacy.items.filter((item) => !canonical.bridgeIds.has(item.id)),
@@ -491,7 +510,7 @@ export async function GET(request: Request): Promise<Response> {
           items: paged.items,
           total: paged.total,
         }
-      })
+      })()
 
     return withAdapterHeaders(
       NextResponse.json({

--- a/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/route.ts
+++ b/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/route.ts
@@ -61,6 +61,7 @@ export async function GET(req: Request) {
       sub: 'customers.dashboard.todos',
     }
     const flags = await resolveCustomerInteractionFeatureFlags(container, tenantId)
+    const mergedWindow = Math.min(limit * 4, 50)
     const rows = flags.unified
       ? (await listCanonicalTodoRows(
           em,
@@ -68,6 +69,7 @@ export async function GET(req: Request) {
           auth,
           organizationIds?.[0] ?? null,
           organizationIds ?? null,
+          { pagination: { page: 1, pageSize: limit } },
         )).items
       : await Promise.all([
           listLegacyTodoRows(
@@ -76,6 +78,7 @@ export async function GET(req: Request) {
             tenantId,
             organizationIds ?? null,
             undefined,
+            { limit: mergedWindow },
           ),
           listCanonicalTodoRows(
             em,
@@ -86,6 +89,7 @@ export async function GET(req: Request) {
             {
               includeDeleted: true,
               source: CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE,
+              limit: mergedWindow,
             },
           ),
         ]).then(([legacyRows, canonicalRows]) =>

--- a/packages/core/src/modules/customers/api/interactions/tasks/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/tasks/route.ts
@@ -30,6 +30,11 @@ export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.interactions.view'] },
 }
 
+// Per-source fetch cap used when the legacy adapter must merge legacy and
+// canonical-bridge rows without DB-side union. Bounds memory on tenants with
+// large task history.
+const MERGED_TASK_FETCH_CAP = 2000
+
 export async function GET(request: Request): Promise<Response> {
   const { translate } = await resolveTranslations()
   try {
@@ -41,34 +46,57 @@ export async function GET(request: Request): Promise<Response> {
     const search = normalizeTodoSearch(query.search)
     const queryEngine = container.resolve('queryEngine') as QueryEngine
 
-    const mergedRows = flags.unified
-      ? (await listCanonicalTodoRows(
-          em,
-          container,
-          auth,
-          selectedOrganizationId,
-          organizationIds,
-          { entityId: query.entityId },
-        )).items
-      : await Promise.all([
-          listLegacyTodoRows(em, queryEngine, auth.tenantId, organizationIds, query.entityId),
-          listCanonicalTodoRows(
-            em,
-            container,
-            auth,
-            selectedOrganizationId,
-            organizationIds,
-            {
-              entityId: query.entityId,
-              includeDeleted: true,
-              source: CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE,
-            },
-          ),
-        ]).then(([legacyRows, canonicalRows]) => [
-          ...legacyRows.filter((row) => !canonicalRows.bridgeIds.has(row.todoId)),
-          ...canonicalRows.items,
-        ])
+    if (flags.unified) {
+      const canonical = await listCanonicalTodoRows(
+        em,
+        container,
+        auth,
+        selectedOrganizationId,
+        organizationIds,
+        {
+          entityId: query.entityId,
+          pagination: exportAll ? null : { page: query.page, pageSize: query.pageSize },
+          searchText: search,
+        },
+      )
+      const total = canonical.total
+      return NextResponse.json({
+        items: canonical.items,
+        total,
+        page: exportAll ? 1 : query.page,
+        pageSize: exportAll ? canonical.items.length : query.pageSize,
+        totalPages: exportAll ? 1 : Math.max(1, Math.ceil(total / query.pageSize)),
+      })
+    }
 
+    const legacyWindow = exportAll
+      ? null
+      : Math.min(
+          MERGED_TASK_FETCH_CAP,
+          Math.max(query.pageSize, query.page * query.pageSize + query.pageSize),
+        )
+    const [legacyRows, canonicalRows] = await Promise.all([
+      listLegacyTodoRows(em, queryEngine, auth.tenantId, organizationIds, query.entityId, {
+        limit: legacyWindow,
+      }),
+      listCanonicalTodoRows(
+        em,
+        container,
+        auth,
+        selectedOrganizationId,
+        organizationIds,
+        {
+          entityId: query.entityId,
+          includeDeleted: true,
+          source: CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE,
+          limit: legacyWindow,
+        },
+      ),
+    ])
+    const mergedRows = [
+      ...legacyRows.filter((row) => !canonicalRows.bridgeIds.has(row.todoId)),
+      ...canonicalRows.items,
+    ]
     const filteredRows = filterTodoRows(sortTodoRows(mergedRows), search)
     const paged = paginateTodoRows(filteredRows, query.page, query.pageSize, exportAll)
 

--- a/packages/core/src/modules/customers/api/todos/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/todos/__tests__/route.test.ts
@@ -160,6 +160,7 @@ describe('customers todos adapter route', () => {
     listCanonicalTodoRows.mockResolvedValue({
       items: [canonicalRow],
       bridgeIds: new Set([TODO_ID]),
+      total: 1,
     })
 
     const { hydrateCanonicalInteractions, loadCustomerSummaries } =
@@ -358,6 +359,68 @@ describe('customers todos adapter route', () => {
         input: { id: TODO_ID },
       }),
     )
+  })
+
+  it('pushes pagination and search to the DB layer in unified mode', async () => {
+    const { resolveCustomerInteractionFeatureFlags } = jest.requireMock('../../../lib/interactionFeatureFlags')
+    resolveCustomerInteractionFeatureFlags.mockResolvedValue({
+      unified: true,
+      legacyAdapters: true,
+      externalSync: false,
+    })
+
+    const { listCanonicalTodoRows, listLegacyTodoRows } = jest.requireMock('../../../lib/todoCompatibility')
+    listCanonicalTodoRows.mockResolvedValue({
+      items: [],
+      bridgeIds: new Set(),
+      total: 317,
+    })
+
+    const res = await GET(
+      new Request(
+        `http://localhost/api/customers/todos?entityId=${ENTITY_ID}&page=4&pageSize=25&search=  Invoice  `,
+      ),
+    )
+    expect(res.status).toBe(200)
+
+    expect(listCanonicalTodoRows).toHaveBeenCalledTimes(1)
+    expect(listLegacyTodoRows).not.toHaveBeenCalled()
+    const call = listCanonicalTodoRows.mock.calls[0]
+    const options = call[5]
+    expect(options).toEqual(
+      expect.objectContaining({
+        entityId: ENTITY_ID,
+        pagination: { page: 4, pageSize: 25 },
+        searchText: 'invoice',
+      }),
+    )
+
+    const body = await res.json()
+    expect(body.total).toBe(317)
+    expect(body.page).toBe(4)
+    expect(body.pageSize).toBe(25)
+    expect(body.totalPages).toBe(Math.ceil(317 / 25))
+  })
+
+  it('bounds per-source windows in merged non-unified mode', async () => {
+    const { listCanonicalTodoRows, listLegacyTodoRows } = jest.requireMock('../../../lib/todoCompatibility')
+
+    await GET(
+      new Request(`http://localhost/api/customers/todos?entityId=${ENTITY_ID}&page=2&pageSize=50`),
+    )
+
+    expect(listLegacyTodoRows).toHaveBeenCalledTimes(1)
+    expect(listCanonicalTodoRows).toHaveBeenCalledTimes(1)
+
+    const legacyArgs = listLegacyTodoRows.mock.calls[0]
+    expect(legacyArgs[5]).toEqual(expect.objectContaining({ limit: expect.any(Number) }))
+    expect(legacyArgs[5].limit).toBeLessThanOrEqual(2000)
+    expect(legacyArgs[5].limit).toBeGreaterThan(0)
+
+    const canonicalArgs = listCanonicalTodoRows.mock.calls[0]
+    expect(canonicalArgs[5]).toEqual(expect.objectContaining({ limit: expect.any(Number) }))
+    expect(canonicalArgs[5].limit).toBeLessThanOrEqual(2000)
+    expect(canonicalArgs[5].limit).toBeGreaterThan(0)
   })
 
   it('returns 410 when legacy adapters are disabled', async () => {

--- a/packages/core/src/modules/customers/api/todos/route.ts
+++ b/packages/core/src/modules/customers/api/todos/route.ts
@@ -78,6 +78,12 @@ const DEPRECATION_HEADERS = {
   Link: '</api/customers/interactions>; rel="successor-version"',
 }
 
+// Caps the per-source fetch window used by the deprecated merged (legacy +
+// canonical bridge) read path. Keeps memory bounded on tenants with large
+// todo history; deep-pagination beyond this window is not supported here —
+// use /api/customers/interactions instead.
+const MERGED_TODO_FETCH_CAP = 2000
+
 function resolveGuardUserId(auth: {
   sub?: string | null
   userId?: string | null
@@ -232,34 +238,56 @@ export async function GET(request: Request): Promise<Response> {
     const exportAll = parseBooleanToken(query.all) === true
     const search = normalizeTodoSearch(query.search)
 
-    const mergedRows = flags.unified
-      ? (await listCanonicalTodoRows(
-          em,
-          container,
-          auth,
-          selectedOrganizationId,
-          organizationIds,
-          { entityId: query.entityId },
-        )).items
-      : await Promise.all([
-        listLegacyTodoRows(em, queryEngine, auth.tenantId, organizationIds, query.entityId),
-        listCanonicalTodoRows(
-          em,
-          container,
-          auth,
-          selectedOrganizationId,
-          organizationIds,
-          {
-            entityId: query.entityId,
-            includeDeleted: true,
-            source: CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE,
-          },
-        ),
-      ]).then(([legacyRows, canonicalRows]) => [
-        ...legacyRows.filter((row) => !canonicalRows.bridgeIds.has(row.todoId)),
-        ...canonicalRows.items,
-      ])
+    if (flags.unified) {
+      const canonical = await listCanonicalTodoRows(
+        em,
+        container,
+        auth,
+        selectedOrganizationId,
+        organizationIds,
+        {
+          entityId: query.entityId,
+          pagination: exportAll ? null : { page: query.page, pageSize: query.pageSize },
+          searchText: search,
+        },
+      )
+      const total = canonical.total
+      return withAdapterHeaders(
+        NextResponse.json({
+          items: canonical.items,
+          total,
+          page: exportAll ? 1 : query.page,
+          pageSize: exportAll ? canonical.items.length : query.pageSize,
+          totalPages: exportAll ? 1 : Math.max(1, Math.ceil(total / query.pageSize)),
+        }),
+      )
+    }
 
+    const legacyWindow = exportAll
+      ? null
+      : Math.min(MERGED_TODO_FETCH_CAP, Math.max(query.pageSize, query.page * query.pageSize + query.pageSize))
+    const [legacyRows, canonicalRows] = await Promise.all([
+      listLegacyTodoRows(em, queryEngine, auth.tenantId, organizationIds, query.entityId, {
+        limit: legacyWindow,
+      }),
+      listCanonicalTodoRows(
+        em,
+        container,
+        auth,
+        selectedOrganizationId,
+        organizationIds,
+        {
+          entityId: query.entityId,
+          includeDeleted: true,
+          source: CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE,
+          limit: legacyWindow,
+        },
+      ),
+    ])
+    const mergedRows = [
+      ...legacyRows.filter((row) => !canonicalRows.bridgeIds.has(row.todoId)),
+      ...canonicalRows.items,
+    ]
     const filteredRows = filterTodoRows(sortTodoRows(mergedRows), search)
     const paged = paginateTodoRows(filteredRows, query.page, query.pageSize, exportAll)
 

--- a/packages/core/src/modules/customers/lib/__tests__/todoCompatibility.pagination.test.ts
+++ b/packages/core/src/modules/customers/lib/__tests__/todoCompatibility.pagination.test.ts
@@ -1,0 +1,155 @@
+/** @jest-environment node */
+
+import { CustomerInteraction, CustomerTodoLink } from '../../data/entities'
+import { listCanonicalTodoRows, listLegacyTodoRows } from '../todoCompatibility'
+
+jest.mock('../interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async ({ interactions }) =>
+    interactions.map((row: { id: string }) => ({
+      id: row.id,
+      interactionType: 'task',
+      title: 'Hydrated',
+      status: 'planned',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      entityId: null,
+      _integrations: null,
+      customValues: null,
+    })),
+  ),
+  loadCustomerSummaries: jest.fn(async () => new Map()),
+}))
+
+const TENANT = '00000000-0000-0000-0000-000000000001'
+const ORG = '00000000-0000-0000-0000-000000000002'
+
+describe('listCanonicalTodoRows pagination', () => {
+  it('pushes pagination to the DB via findAndCount when options.pagination is provided', async () => {
+    const findAndCount = jest.fn(async () => [
+      [{ id: 'i1', deletedAt: null, organizationId: ORG, tenantId: TENANT }],
+      42,
+    ])
+    const find = jest.fn(async () => [])
+    const em = { findAndCount, find } as any
+    const container = { resolve: jest.fn() }
+
+    const result = await listCanonicalTodoRows(
+      em,
+      container,
+      { tenantId: TENANT, orgId: ORG },
+      ORG,
+      [ORG],
+      { pagination: { page: 3, pageSize: 25 } },
+    )
+
+    expect(findAndCount).toHaveBeenCalledTimes(1)
+    expect(find).not.toHaveBeenCalled()
+    const [, , findOptions] = findAndCount.mock.calls[0]
+    expect(findOptions).toEqual(
+      expect.objectContaining({
+        offset: 50,
+        limit: 25,
+        orderBy: { createdAt: 'desc' },
+      }),
+    )
+    expect(result.total).toBe(42)
+    expect(result.items).toHaveLength(1)
+    expect(result.bridgeIds.has('i1')).toBe(true)
+  })
+
+  it('pushes search text to the DB as $ilike on title and body', async () => {
+    const findAndCount = jest.fn(async () => [[], 0])
+    const em = { findAndCount, find: jest.fn() } as any
+    const container = { resolve: jest.fn() }
+
+    await listCanonicalTodoRows(
+      em,
+      container,
+      { tenantId: TENANT, orgId: ORG },
+      ORG,
+      [ORG],
+      { pagination: { page: 1, pageSize: 50 }, searchText: 'Invoice' },
+    )
+
+    const [entity, where] = findAndCount.mock.calls[0]
+    expect(entity).toBe(CustomerInteraction)
+    expect(where).toEqual(
+      expect.objectContaining({
+        tenantId: TENANT,
+        interactionType: 'task',
+        $or: [
+          { title: { $ilike: '%Invoice%' } },
+          { body: { $ilike: '%Invoice%' } },
+        ],
+      }),
+    )
+  })
+
+  it('falls back to unpaginated em.find when no pagination is requested', async () => {
+    const find = jest.fn(async () => [])
+    const em = { find, findAndCount: jest.fn() } as any
+    const container = { resolve: jest.fn() }
+
+    const result = await listCanonicalTodoRows(
+      em,
+      container,
+      { tenantId: TENANT, orgId: ORG },
+      ORG,
+      [ORG],
+    )
+
+    expect(find).toHaveBeenCalledTimes(1)
+    const [, , findOptions] = find.mock.calls[0]
+    expect(findOptions).toEqual({ orderBy: { createdAt: 'desc' } })
+    expect(result.total).toBe(0)
+  })
+
+  it('honors options.limit without pagination for bounded merged reads', async () => {
+    const find = jest.fn(async () => [])
+    const em = { find, findAndCount: jest.fn() } as any
+    const container = { resolve: jest.fn() }
+
+    await listCanonicalTodoRows(
+      em,
+      container,
+      { tenantId: TENANT, orgId: ORG },
+      ORG,
+      [ORG],
+      { limit: 250 },
+    )
+
+    const [, , findOptions] = find.mock.calls[0]
+    expect(findOptions).toEqual(
+      expect.objectContaining({ limit: 250, orderBy: { createdAt: 'desc' } }),
+    )
+  })
+})
+
+describe('listLegacyTodoRows pagination', () => {
+  it('passes limit to em.find when options.limit is provided', async () => {
+    const find = jest.fn(async () => [])
+    const em = { find } as any
+    const queryEngine = { query: jest.fn() } as any
+
+    await listLegacyTodoRows(em, queryEngine, TENANT, [ORG], undefined, { limit: 500 })
+
+    const [entity, , findOptions] = find.mock.calls[0]
+    expect(entity).toBe(CustomerTodoLink)
+    expect(findOptions).toEqual(
+      expect.objectContaining({ limit: 500, orderBy: { createdAt: 'desc' } }),
+    )
+  })
+
+  it('does not include limit when options.limit is not provided', async () => {
+    const find = jest.fn(async () => [])
+    const em = { find } as any
+    const queryEngine = { query: jest.fn() } as any
+
+    await listLegacyTodoRows(em, queryEngine, TENANT, [ORG], undefined)
+
+    const [, , findOptions] = find.mock.calls[0]
+    expect(findOptions.limit).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/customers/lib/todoCompatibility.ts
+++ b/packages/core/src/modules/customers/lib/todoCompatibility.ts
@@ -70,7 +70,10 @@ type CustomersContainerLike = {
 export type CanonicalTodoListResult = {
   items: CustomerTodoRow[]
   bridgeIds: Set<string>
+  total: number
 }
+
+export type ListTodosPagination = { page: number; pageSize: number }
 
 function resolveLegacyTodoSource(source: string | null | undefined): string {
   return typeof source === 'string' && source.trim().length > 0
@@ -359,6 +362,7 @@ export async function listLegacyTodoRows(
   tenantId: string,
   organizationIds: string[] | null,
   entityId: string | undefined,
+  options?: { limit?: number | null },
 ): Promise<CustomerTodoRow[]> {
   const where: Record<string, unknown> = { tenantId }
   if (organizationIds && organizationIds.length > 0) {
@@ -368,10 +372,15 @@ export async function listLegacyTodoRows(
     where.entity = entityId
   }
 
-  const links = await em.find(CustomerTodoLink, where, {
+  const findOptions: Record<string, unknown> = {
     populate: ['entity'],
     orderBy: { createdAt: 'desc' },
-  })
+  }
+  if (typeof options?.limit === 'number' && Number.isFinite(options.limit) && options.limit > 0) {
+    findOptions.limit = options.limit
+  }
+
+  const links = await em.find(CustomerTodoLink, where, findOptions as any)
   const details = await resolveLegacyTodoDetails(
     queryEngine,
     links,
@@ -398,6 +407,9 @@ export async function listCanonicalTodoRows(
     entityId?: string
     includeDeleted?: boolean
     source?: string | string[] | null
+    pagination?: ListTodosPagination | null
+    searchText?: string | null
+    limit?: number | null
   },
 ): Promise<CanonicalTodoListResult> {
   const where: Record<string, unknown> = {
@@ -416,10 +428,41 @@ export async function listCanonicalTodoRows(
   if (options?.source) {
     where.source = Array.isArray(options.source) ? { $in: options.source } : options.source
   }
+  const trimmedSearch =
+    typeof options?.searchText === 'string' ? options.searchText.trim() : ''
+  if (trimmedSearch.length > 0) {
+    const pattern = `%${trimmedSearch}%`
+    where.$or = [
+      { title: { $ilike: pattern } },
+      { body: { $ilike: pattern } },
+    ]
+  }
 
-  const interactions = await em.find(CustomerInteraction, where, {
+  const findOptions: Record<string, unknown> = {
     orderBy: { createdAt: 'desc' },
-  })
+  }
+  const pagination = options?.pagination ?? null
+  if (pagination) {
+    findOptions.offset = Math.max(0, (pagination.page - 1) * pagination.pageSize)
+    findOptions.limit = pagination.pageSize
+  } else if (
+    typeof options?.limit === 'number' &&
+    Number.isFinite(options.limit) &&
+    options.limit > 0
+  ) {
+    findOptions.limit = options.limit
+  }
+
+  let interactions: CustomerInteraction[]
+  let total: number
+  if (pagination) {
+    const [rows, count] = await em.findAndCount(CustomerInteraction, where, findOptions as any)
+    interactions = rows
+    total = count
+  } else {
+    interactions = await em.find(CustomerInteraction, where, findOptions as any)
+    total = interactions.filter((interaction) => !interaction.deletedAt).length
+  }
   const activeInteractions = interactions.filter((interaction) => !interaction.deletedAt)
   const groups = new Map<string, CustomerInteraction[]>()
 
@@ -480,6 +523,7 @@ export async function listCanonicalTodoRows(
       .map((interaction) => rowByInteractionId.get(interaction.id) ?? null)
       .filter((row): row is CustomerTodoRow => !!row),
     bridgeIds: new Set(interactions.map((interaction) => interaction.id)),
+    total,
   }
 }
 


### PR DESCRIPTION
Fixes #1397

## Problem
The deprecated customers adapter routes `/api/customers/todos` and `/api/customers/activities` load entire tenant datasets into memory, hydrate each row, then filter/sort/paginate in JavaScript. On tenants with large task/activity history this degrades tail latency and risks OOM.

## Root Cause
- Todos route called `listLegacyTodoRows` / `listCanonicalTodoRows` without limits, then `filterTodoRows` + `paginateTodoRows` in-memory.
- Activities route invoked `listLegacyActivities` / `listCanonicalActivities` with `paginate: false`, so each helper ran unbounded `em.find` calls against `CustomerActivity` / `CustomerInteraction`.
- Search matching for canonical tasks was done after hydration, not as SQL `$ilike` — so even the unified path scanned entire tables.

## What Changed
- `listCanonicalTodoRows` now accepts `pagination`, `searchText`, and `limit`. With `pagination`, it calls `em.findAndCount` (authoritative `total`) and pushes `title`/`body` `$ilike` into SQL via `where.$or`. Without pagination, `limit` still caps the read.
- `listLegacyTodoRows` accepts `{ limit }` and passes it through to `em.find`.
- Todos adapter route branches explicitly on `flags.unified`:
  - **Unified:** pagination + search pushed to DB; canonical `total` returned as-is.
  - **Merged:** bounded per-source window of `min(2000, max(pageSize, page*pageSize + pageSize))`; both sources paginated at DB, then merged, deduped via `bridgeIds`, filtered, and sliced for the requested page.
- Activities adapter merged path flips `paginate: false` -> `paginate: true` with the same bounded-window computation, so both `CustomerActivity` and `CustomerInteraction` reads go through `em.findAndCount(..., { offset, limit })`.
- Canonical tasks read endpoint (`/api/customers/interactions/tasks`) mirrors the todos fix.
- Customer-todos dashboard widget passes `pagination: { page: 1, pageSize: limit }` on the unified path and caps the merged window at `min(limit * 4, 50)`.
- Exports (`?all=true`) still bypass the cap; the cap only applies when paginating.

Per-source cap is intentionally conservative (2000): deep-paginating beyond it against the merged adapter is not supported — consumers are directed to `/api/customers/interactions` via the existing `Deprecation` / `Sunset` / `Link` headers.

## Tests
- Added `packages/core/src/modules/customers/lib/__tests__/todoCompatibility.pagination.test.ts`:
  - `findAndCount` invoked with `offset`/`limit`/`orderBy` when pagination is passed.
  - `$ilike` pushed to DB on `title`/`body` when `searchText` is set.
  - `em.find` fallback (not `findAndCount`) when no pagination is requested.
  - `options.limit` propagates to both canonical and legacy `em.find` calls.
- Added `packages/core/src/modules/customers/api/activities/__tests__/merged-pagination.test.ts`:
  - Merged non-unified GET drives bounded `findAndCount` on both `CustomerActivity` and `CustomerInteraction` (limit in (0, 2000], offset 0).
  - No fallback to unbounded `em.find` on either entity.
- Extended `packages/core/src/modules/customers/api/todos/__tests__/route.test.ts` with two new cases covering unified pagination + search pushdown and merged per-source windowing.

Targeted subset: `yarn workspace @open-mercato/core test --testPathPatterns "customers/(lib/__tests__/todoCompatibility|api/todos/__tests__/|api/activities/__tests__/|api/interactions/tasks/|api/dashboard/widgets/customer-todos/__tests__/)"` -> 6 suites, 24 tests passed.
Full gate: `yarn generate`, `yarn typecheck` (all packages), `yarn i18n:check-sync` clean. `yarn test` has 2 pre-existing unrelated failures in `packages/ui` (`CustomDataSection`) and `packages/core` (`InlineEditors`), verified to reproduce on `develop` without this change.

## Backward Compatibility
- Helper signatures extended with new **optional** `options` fields (`limit`, `pagination`, `searchText`). All pre-existing callers compile unchanged.
- `CanonicalTodoListResult` gains a `total: number` field (additive).
- API route contracts unchanged: same query params, same response shape. `Deprecation`/`Sunset`/`Link` headers unchanged.
- No new `em.find` / `em.findOne` calls introduced (verified via diff); the encryption rule posture is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)