### PR TITLE
fix(ui): suppress initial focus flicker on focus-driven inputs

### DIFF
--- a/.ai/specs/2026-05-09-crudform-autofocus-flicker.md
+++ b/.ai/specs/2026-05-09-crudform-autofocus-flicker.md
@@ -1,0 +1,128 @@
+# CrudForm initial focus without open-state flicker
+
+**Status:** draft
+**Owner:** ui
+**Date:** 2026-05-09
+**Tracking issue:** [open-mercato/open-mercato#1820](https://github.com/open-mercato/open-mercato/issues/1820)
+
+## TLDR
+`CrudForm` still needs mount-time autofocus for ordinary forms, but hosts must be able to suppress that autofocus while async data is loading. When autofocus is enabled again, the first eligible field should gain focus without causing focus-driven controls such as comboboxes or tag pickers to flash their own suggestion UI.
+
+This spec covers:
+- a host-controlled `disableInitialFocus` flag on `CrudForm`
+- preserving mount autofocus once data is ready
+- guarding controls with their own open-on-focus behavior so the first programmatic focus does not briefly open and close their popup state
+
+## Overview
+The original bug report was not about removing autofocus altogether. The problem is narrower:
+
+1. the host sometimes renders `CrudForm` before its record data is ready
+2. `CrudForm` applies mount autofocus as soon as it can
+3. some inputs, especially `combobox` and similar suggestion-driven controls, open their UI on focus
+4. the initial programmatic focus therefore creates a flicker or flash during the loading transition
+
+The intended solution is to let the host delay initial focus until loading is finished, while still keeping the default focus behavior for normal forms.
+
+## Problem Statement
+`CrudForm` currently assumes that the first eligible field should be focused during mount. That behavior is correct for plain text inputs, but it is too eager for forms whose first interactive field is a control with its own focus/open lifecycle.
+
+Concrete failure mode:
+- host mounts the form with loading data
+- `CrudForm` focuses the first eligible field
+- a control like `ComboboxInput` reacts to focus by showing suggestions
+- the form then re-renders as data settles, and the control state changes again
+- the user sees a short flash or open/close flicker
+
+The fix must preserve:
+- autofocus for normal forms
+- autofocus after async data has loaded
+- autofocus after validation errors, when appropriate
+
+The fix must avoid:
+- forcing open-state controls to flash on first mount
+- requiring every host page to hand-roll focus management
+
+## Proposed Solution
+1. Add `disableInitialFocus?: boolean` to `CrudForm`.
+2. When `disableInitialFocus` is true, suppress mount-time autofocus entirely.
+3. When the host flips `disableInitialFocus` back to false after data has loaded, `CrudForm` may autofocus the first eligible field.
+4. Keep the first-focus behavior for normal inputs unchanged.
+5. Audit controls with their own open-on-focus behavior and suppress the initial programmatic open path only on the first mount focus.
+
+## Architecture
+### `CrudForm`
+- Add the `disableInitialFocus` prop to the public props type.
+- Use it in the mount autofocus effect and in the `autoFocus` flag passed to rendered fields.
+- Do not change validation-driven autofocus behavior unless the form is still in a loading-disabled state.
+- Preserve current behavior for non-loading pages that rely on autofocus today.
+
+### `ComboboxInput`
+- Keep autofocus on the input itself.
+- Suppress the first programmatic focus from immediately opening suggestions.
+- Allow subsequent user-driven focuses to open suggestions normally.
+
+### `TagsInput`
+- Suppress the first programmatic focus from triggering suggestion loading or suggestion display.
+- Allow later user-driven focus and typing to load suggestions normally.
+
+### Other UI core inputs
+- `DatePicker`, `DateTimePicker`, `TimePicker`, `LookupSelect`, `EventSelect`, `PhoneNumberField`, and `SwitchableMarkdownInput` do not currently open a popup purely because they received focus, so they are not expected to need the same suppression path.
+- If a future input introduces `focus -> open` behavior, it should adopt the same mount-suppression pattern instead of depending on host workarounds.
+
+## Data Models
+No data model changes.
+
+## API Contracts
+### `CrudForm`
+Add:
+```ts
+disableInitialFocus?: boolean
+```
+
+Semantics:
+- `false` or omitted: existing behavior, mount autofocus is allowed
+- `true`: mount autofocus is suppressed until the host turns the flag off
+
+### `ComboboxInput`
+Add an internal mount-focus suppression path, but keep the public API stable unless the final implementation needs an explicit prop for other host surfaces.
+
+### `TagsInput`
+Add `suppressInitialSuggestionsOnFocus?: boolean` for host surfaces that need the same one-shot suppression outside `CrudForm`.
+
+## Risks & Impact Review
+| Risk | Severity | Area | Mitigation | Residual risk |
+|---|---|---|---|---|
+| `disableInitialFocus` suppresses autofocus for forms that actually wanted immediate focus | Medium | UX | Default the flag to `false`; only set it during async loading flows | Low |
+| Suppressing initial focus only on comboboxes hides the bug but regresses keyboard discovery if over-applied | Medium | Accessibility / UX | Apply suppression only to the first programmatic focus, not to user-initiated focus | Low |
+| `TagsInput` may behave similarly but remain unhandled | Medium | UX consistency | Add one-shot suppression and cover with tests | Low |
+| Future open-on-focus controls reintroduce the same problem | Medium | Maintainability | Document the pattern in this spec and in `packages/ui/AGENTS.md` | Medium |
+| Validation autofocus accidentally becomes too conservative | High | Form usability | Keep validation autofocus separate from mount autofocus and cover both in tests | Low |
+
+## Test Plan
+### Unit / component tests
+- `CrudForm` autofocuses the first eligible field when `disableInitialFocus` is false.
+- `CrudForm` does not autofocus on mount when `disableInitialFocus` is true.
+- `CrudForm` still autofocuses again after the host flips `disableInitialFocus` off.
+- `ComboboxInput` does not open suggestions on the first programmatic focus.
+- `ComboboxInput` opens suggestions on a later user focus.
+- `TagsInput` does not fetch or display suggestions on the first programmatic focus.
+- `TagsInput` keeps normal suggestion loading for later user-driven focus and typing.
+
+### Manual verification
+- Load a record page with async data and confirm there is no visible suggestion flash while loading.
+- Confirm that once the data is ready, autofocus still lands on the first field.
+- Confirm plain text forms still autofocus immediately.
+
+## Final Compliance Report
+### AGENTS.md Files Reviewed
+- `AGENTS.md`
+- `packages/ui/AGENTS.md`
+- `packages/ui/src/backend/AGENTS.md`
+- `.ai/specs/AGENTS.md`
+
+### Verdict
+- Draft updated to reflect the host-controlled initial focus design and the control-level suppression needed to avoid suggestion flicker.
+
+## Changelog
+### 2026-05-09
+- Replaced the demo-only reproduction draft with the real implementation spec for host-controlled initial focus and open-on-focus suppression.

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -268,6 +268,12 @@ export type CrudFormProps<TValues extends Record<string, unknown>> = {
   schema?: z.ZodType<TValues>
   fields: CrudField[]
   initialValues?: Partial<TValues>
+  /**
+   * When true, suppresses the form's mount-time autofocus entirely.
+   * Hosts can keep this enabled while async record data is still loading, then
+   * flip it off once the initial values are ready to let the first field gain focus.
+   */
+  disableInitialFocus?: boolean
   submitLabel?: string
   submitIcon?: React.ComponentType<{ className?: string }>
   formId?: string
@@ -528,6 +534,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
   schema,
   fields,
   initialValues,
+  disableInitialFocus = false,
   submitLabel,
   submitIcon,
   formId: providedFormId,
@@ -1882,7 +1889,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
   React.useEffect(() => {
     if (typeof window === 'undefined' || typeof document === 'undefined') return
 
-    if (isLoading || isLoadingCustomFields || formReadOnly) {
+    if (disableInitialFocus || isLoading || isLoadingCustomFields || formReadOnly) {
       lastFocusedFieldRef.current = null
       return
     }
@@ -1929,7 +1936,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
         window.clearTimeout(frame as number)
       }
     }
-  }, [firstFieldId, formId, formReadOnly, isLoading, isLoadingCustomFields])
+  }, [disableInitialFocus, firstFieldId, formId, formReadOnly, isLoading, isLoadingCustomFields])
 
   React.useEffect(() => {
     if (typeof window === 'undefined' || typeof document === 'undefined') return
@@ -2669,7 +2676,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
               onBlurRequest={onBlurRequest}
               values={values}
               loadFieldOptions={loadFieldOptions}
-              autoFocus={!formReadOnly && Boolean(firstFieldId && f.id === firstFieldId)}
+                autoFocus={!disableInitialFocus && !formReadOnly && Boolean(firstFieldId && f.id === firstFieldId)}
               onSubmitRequest={requestSubmit}
               wrapperClassName={wrapperClassName}
               entityIdForField={primaryEntityId ?? undefined}
@@ -3230,7 +3237,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
                     onBlurRequest={onBlurRequest}
                     values={values}
                     loadFieldOptions={loadFieldOptions}
-                    autoFocus={!formReadOnly && Boolean(firstFieldId && f.id === firstFieldId)}
+                    autoFocus={!disableInitialFocus && !formReadOnly && Boolean(firstFieldId && f.id === firstFieldId)}
                     onSubmitRequest={requestSubmit}
                     wrapperClassName={wrapperClassName}
                     entityIdForField={primaryEntityId ?? undefined}
@@ -4047,6 +4054,7 @@ const FieldControl = React.memo(function FieldControlImpl({
           onChange={(next) => fieldSetValue(next)}
           placeholder={placeholder}
           autoFocus={autoFocusField}
+          suppressInitialSuggestionsOnFocus={autoFocusField}
           suggestions={options.map((opt) => ({ value: opt.value, label: opt.label }))}
           loadSuggestions={
             typeof builtin?.loadOptions === 'function'

--- a/packages/ui/src/backend/__tests__/CrudForm.render.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.render.test.tsx
@@ -26,7 +26,7 @@ jest.mock('../injection/useInjectionDataWidgets', () => ({
 
 import * as React from 'react'
 import { renderToString } from 'react-dom/server'
-import { act, fireEvent } from '@testing-library/react'
+import { act, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { CrudForm, type CrudField } from '../CrudForm'
 import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
@@ -171,5 +171,126 @@ describe('CrudForm initialValues', () => {
     expect(getByText('Locked overlay')).toBeInTheDocument()
     expect(queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
     expect(queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument()
+  })
+
+  it('autofocuses the first combobox without opening suggestions on mount', async () => {
+    jest.useFakeTimers()
+
+    const loadOptions = jest.fn().mockResolvedValue([{ label: 'Alpha', value: 'alpha' }])
+    const fields: CrudField[] = [
+      { id: 'primary_choice', label: 'Primary choice', type: 'combobox', loadOptions },
+      { id: 'secondary_title', label: 'Secondary title', type: 'text' },
+    ]
+
+    const { container, queryByRole } = renderWithProviders(
+      <CrudForm title="Form" fields={fields} onSubmit={() => {}} />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+        },
+      },
+    )
+
+    const comboboxInput = container.querySelector('[data-crud-field-id="primary_choice"] input[type="text"]') as HTMLInputElement | null
+    expect(comboboxInput).not.toBeNull()
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(comboboxInput)
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(250)
+      await Promise.resolve()
+    })
+
+    expect(queryByRole('button', { name: 'Alpha' })).toBeNull()
+    jest.useRealTimers()
+  })
+
+  it('autofocuses the first relation field on mount', async () => {
+    const loadOptions = jest.fn().mockResolvedValue([{ label: 'Alpha', value: 'alpha' }])
+    const fields: CrudField[] = [
+      { id: 'primary_choice', label: 'Primary choice', type: 'relation', loadOptions },
+      { id: 'secondary_title', label: 'Secondary title', type: 'text' },
+    ]
+
+    const { container } = renderWithProviders(
+      <CrudForm title="Form" fields={fields} onSubmit={() => {}} />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+        },
+      },
+    )
+
+    const relationInput = container.querySelector('[data-crud-field-id="primary_choice"] input[type="text"]') as HTMLInputElement | null
+    expect(relationInput).not.toBeNull()
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(relationInput)
+    })
+  })
+
+  it('respects disableInitialFocus', async () => {
+    const fields: CrudField[] = [
+      { id: 'title', label: 'Title', type: 'text' },
+      { id: 'summary', label: 'Summary', type: 'text' },
+    ]
+
+    const { container } = renderWithProviders(
+      <CrudForm title="Form" fields={fields} disableInitialFocus onSubmit={() => {}} />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+        },
+      },
+    )
+
+    const titleInput = container.querySelector('[data-crud-field-id="title"] input[type="text"]') as HTMLInputElement | null
+    expect(titleInput).not.toBeNull()
+
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(titleInput)
+    })
+  })
+
+  it('can autofocus the first combobox after initial loading is finished', async () => {
+    jest.useFakeTimers()
+
+    const loadOptions = jest.fn().mockResolvedValue([{ label: 'Alpha', value: 'alpha' }])
+    const fields: CrudField[] = [
+      { id: 'primary_choice', label: 'Primary choice', type: 'combobox', loadOptions },
+      { id: 'secondary_title', label: 'Secondary title', type: 'text' },
+    ]
+
+    const { container, rerender, queryByRole } = renderWithProviders(
+      <CrudForm title="Form" fields={fields} disableInitialFocus onSubmit={() => {}} />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+        },
+      },
+    )
+
+    const comboboxInput = container.querySelector('[data-crud-field-id="primary_choice"] input[type="text"]') as HTMLInputElement | null
+    expect(comboboxInput).not.toBeNull()
+    expect(document.activeElement).not.toBe(comboboxInput)
+
+    await act(async () => {
+      rerender(<CrudForm title="Form" fields={fields} onSubmit={() => {}} />)
+      jest.advanceTimersByTime(250)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(comboboxInput)
+    })
+
+    await waitFor(() => {
+      expect(queryByRole('button', { name: 'Alpha' })).toBeInTheDocument()
+    })
+
+    jest.useRealTimers()
   })
 })

--- a/packages/ui/src/backend/inputs/ComboboxInput.tsx
+++ b/packages/ui/src/backend/inputs/ComboboxInput.tsx
@@ -61,6 +61,7 @@ export function ComboboxInput({
   const [showSuggestions, setShowSuggestions] = React.useState(false)
   const [selectedIndex, setSelectedIndex] = React.useState(-1)
   const inputRef = React.useRef<HTMLInputElement>(null)
+  const suppressOpenOnFocusRef = React.useRef(Boolean(autoFocus && !disabled))
 
   const staticOptions = React.useMemo(() => normalizeOptions(suggestions), [suggestions])
 
@@ -223,6 +224,10 @@ export function ComboboxInput({
         disabled={disabled}
         onFocus={() => {
           setTouched(true)
+          if (suppressOpenOnFocusRef.current) {
+            suppressOpenOnFocusRef.current = false
+            return
+          }
           setShowSuggestions(true)
         }}
         onChange={(event) => {

--- a/packages/ui/src/backend/inputs/TagsInput.tsx
+++ b/packages/ui/src/backend/inputs/TagsInput.tsx
@@ -24,6 +24,7 @@ export type TagsInputProps = {
   disabled?: boolean
   allowCustomValues?: boolean
   showSuggestionsOnFocus?: boolean
+  suppressInitialSuggestionsOnFocus?: boolean
 }
 
 function normalizeOptions(input?: Array<string | TagsInputOption>): TagsInputOption[] {
@@ -59,6 +60,7 @@ export function TagsInput({
   disabled = false,
   allowCustomValues = true,
   showSuggestionsOnFocus = true,
+  suppressInitialSuggestionsOnFocus = false,
 }: TagsInputProps) {
   const t = useT()
   const [input, setInput] = React.useState('')
@@ -66,11 +68,16 @@ export function TagsInput({
   const [loading, setLoading] = React.useState(false)
   const [touched, setTouched] = React.useState(false)
   const suppressBlurCommitRef = React.useRef(false)
+  const suppressSuggestionsOnFocusRef = React.useRef(Boolean(autoFocus && suppressInitialSuggestionsOnFocus && !disabled))
   const valueRef = React.useRef(value)
 
   React.useEffect(() => {
     valueRef.current = value
   }, [value])
+
+  React.useEffect(() => {
+    suppressSuggestionsOnFocusRef.current = Boolean(autoFocus && suppressInitialSuggestionsOnFocus && !disabled)
+  }, [autoFocus, disabled, suppressInitialSuggestionsOnFocus])
 
   const staticOptions = React.useMemo(() => normalizeOptions(suggestions), [suggestions])
   const selectedOptionList = React.useMemo(
@@ -229,6 +236,10 @@ export function TagsInput({
           data-crud-focus-target=""
           disabled={disabled}
           onFocus={() => {
+            if (suppressSuggestionsOnFocusRef.current) {
+              suppressSuggestionsOnFocusRef.current = false
+              return
+            }
             if (showSuggestionsOnFocus) {
               setTouched(true)
             }

--- a/packages/ui/src/backend/inputs/__tests__/TagsInput.test.tsx
+++ b/packages/ui/src/backend/inputs/__tests__/TagsInput.test.tsx
@@ -1,3 +1,4 @@
+/** @jest-environment jsdom */
 import * as React from 'react'
 import { act, fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
@@ -72,6 +73,42 @@ describe('TagsInput', () => {
     })
 
     expect(screen.getByTestId('value')).toHaveTextContent('["first-tag","second-tag"]')
+
+    jest.useRealTimers()
+  })
+
+  it('skips loading suggestions on the first programmatic focus when suppressed', async () => {
+    jest.useFakeTimers()
+
+    const loadSuggestions = jest.fn().mockResolvedValue([
+      { value: 'catalog.product.deleted', label: 'Product Deleted' },
+    ])
+
+    function Harness() {
+      const [value, setValue] = React.useState<string[]>([])
+
+      return (
+        <TagsInput
+          value={value}
+          onChange={setValue}
+          autoFocus
+          suppressInitialSuggestionsOnFocus
+          loadSuggestions={loadSuggestions}
+        />
+      )
+    }
+
+    const { getByRole } = renderWithProviders(<Harness />)
+    const input = getByRole('textbox')
+
+    await act(async () => {
+      jest.advanceTimersByTime(300)
+      await Promise.resolve()
+    })
+
+    expect(loadSuggestions).not.toHaveBeenCalled()
+
+    expect(loadSuggestions).not.toHaveBeenCalled()
 
     jest.useRealTimers()
   })


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

`CrudForm` was auto-focusing the first field during mount even while async record data was still loading, which could cause focus-driven controls like `ComboboxInput` and `TagsInput` to flash their own suggestion UI.

This change adds a host-controlled `disableInitialFocus` flag so loading forms can defer autofocus until data is ready, while preserving normal autofocus behavior once loading finishes.

## Changes

- added `disableInitialFocus` to `CrudForm` for async loading flows
- suppressed the first programmatic open on `ComboboxInput` and `TagsInput`
- kept normal autofocus and user-driven suggestion opening intact
- added regression tests for `CrudForm` and `TagsInput`
- updated the spec for this bugfix in `.ai/specs/2026-05-09-crudform-autofocus-flicker.md`

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/2026-05-09-crudform-autofocus-flicker.md`

## Testing

- `yarn jest packages/ui/src/backend/inputs/__tests__/TagsInput.test.tsx packages/ui/src/backend/__tests__/CrudForm.render.test.tsx packages/ui/src/backend/__tests__/CrudForm.validation.test.tsx --runInBand`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #1820
