### PR TITLE
Bug/auth user name field

### DIFF
--- a/packages/core/src/helpers/integration/authUi.ts
+++ b/packages/core/src/helpers/integration/authUi.ts
@@ -6,8 +6,17 @@ export async function createUserViaUi(page: Page, input: { email: string; passwo
   await page.goto('/backend/users/create');
   await expect(page.getByText('Create User')).toBeVisible();
 
-  await page.locator('[data-crud-field-id="email"] input').first().fill(input.email);
-  await page.locator('[data-crud-field-id="password"] input').first().fill(input.password);
+  const emailInput = page.locator('[data-crud-field-id="email"] input').first();
+  const nameInput = page.locator('[data-crud-field-id="name"] input').first();
+  const passwordInput = page.locator('[data-crud-field-id="password"] input').first();
+
+  await expect(emailInput).toBeVisible();
+  await emailInput.fill(input.email);
+  if (await nameInput.count()) {
+    await nameInput.fill('');
+  }
+  await expect(passwordInput).toBeVisible();
+  await passwordInput.fill(input.password);
 
   const orgSelect = page.locator('main').locator('select').first();
   await expect(orgSelect).toBeEnabled();

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-020.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-020.spec.ts
@@ -48,7 +48,7 @@ test.describe('TC-AUTH-020: Filter Users by Role', () => {
       // Select the role from suggestions inside the filter panel
       const suggestion = filterPanel.getByRole('button', { name: roleName });
       await expect(suggestion).toBeVisible();
-      await suggestion.click();
+      await suggestion.click({ force: true });
 
       // Apply the filter
       await filterPanel.getByRole('button', { name: /Apply/i }).first().click();

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-025.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-025.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test'
+import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth'
+
+/**
+ * TC-AUTH-025: Filter Users by Display Name
+ * Verifies that the live users list request includes the `name` filter.
+ */
+test.describe('TC-AUTH-025: Filter Users by Display Name', () => {
+  test('should include display name in the live users list request', async ({ page }) => {
+    const name = `qa-filter-name-${Date.now()}`
+
+    await login(page, 'admin')
+    await page.goto('/backend/users')
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible()
+
+    await page.getByRole('button', { name: /Filters/i }).click()
+    const filterPanel = page.locator('.fixed.inset-0')
+    await expect(filterPanel).toBeVisible()
+
+    const nameInput = filterPanel.getByPlaceholder(/filter by display name/i)
+    await expect(nameInput).toBeVisible()
+    await nameInput.fill(name)
+
+    const requestPromise = page.waitForRequest((request) => {
+      const url = new URL(request.url())
+      return url.pathname === '/api/auth/users' && url.searchParams.get('name') === name
+    })
+
+    await filterPanel.getByRole('button', { name: /Apply/i }).first().click()
+
+    const request = await requestPromise
+    expect(new URL(request.url()).searchParams.get('name')).toBe(name)
+  })
+})

--- a/packages/core/src/modules/translations/__integration__/TC-TRANS-005.spec.ts
+++ b/packages/core/src/modules/translations/__integration__/TC-TRANS-005.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Locator, type Page } from '@playwright/test'
 import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
 import { createProductFixture, deleteCatalogProductIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/catalogFixtures'
 import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth'
@@ -44,7 +44,7 @@ async function fillCombobox(
 }
 
 async function selectEntityForRecordPicker(
-  page: import('@playwright/test').Page,
+  page: Page,
   entityType: string,
 ) {
   const recordInput = page.getByPlaceholder('Search records...')
@@ -62,6 +62,28 @@ async function selectEntityForRecordPicker(
   }
 
   await expect(recordInput).toBeEnabled({ timeout: 10_000 })
+}
+
+async function waitForTranslationField(root: Locator, preferredPlaceholder?: string): Promise<Locator> {
+  const fieldLocator = root.locator('table').locator('input, textarea')
+  await expect.poll(async () => fieldLocator.count(), {
+    message: 'Expected at least one translation input to be available',
+    timeout: 45_000,
+  }).toBeGreaterThan(0)
+
+  const firstEditableField = fieldLocator.first()
+  await expect(firstEditableField).toBeVisible()
+  await expect(firstEditableField).toBeEnabled()
+
+  const normalizedPlaceholder = preferredPlaceholder?.trim()
+  if (!normalizedPlaceholder) return firstEditableField
+
+  const preferredField = root.getByPlaceholder(normalizedPlaceholder).first()
+  if (await preferredField.count()) {
+    if (await preferredField.isVisible()) return preferredField
+  }
+
+  return firstEditableField
 }
 
 /**
@@ -121,9 +143,11 @@ test.describe('TC-TRANS-005: Translation Manager Standalone', () => {
       await deTab.click()
       await expect(deTab).toHaveAttribute('data-state', 'active')
 
-      const titleInput = page.locator('table input').first()
-      await titleInput.fill('Deutscher Titel QA')
-      await expect(titleInput).toHaveValue('Deutscher Titel QA')
+      const titleInput = await waitForTranslationField(managerCard, 'Deutscher Titel QA')
+      await titleInput.click()
+      await page.keyboard.type('Deutscher Titel QA')
+      await expect.poll(async () => titleInput.inputValue()).toBe('Deutscher Titel QA')
+      await titleInput.press('Tab')
 
       const saveResponsePromise = page.waitForResponse((response) =>
         response.request().method() === 'PUT'
@@ -181,7 +205,8 @@ test.describe('TC-TRANS-005: Translation Manager Standalone', () => {
       await deTab.click()
       await expect(deTab).toHaveAttribute('data-state', 'active')
 
-      await expect(page.locator('table input').first()).toHaveValue('Persistenter Titel')
+      const titleInput = await waitForTranslationField(managerCard, 'Persistenter Titel')
+      await expect(titleInput).toHaveValue('Persistenter Titel')
     } finally {
       await deleteTranslationIfExists(request, saToken, ENTITY_TYPE, productId)
       await deleteCatalogProductIfExists(request, adminToken, productId)

--- a/packages/core/src/modules/translations/__integration__/TC-TRANS-009.spec.ts
+++ b/packages/core/src/modules/translations/__integration__/TC-TRANS-009.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Locator, type Page } from '@playwright/test'
 import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
 import { createProductFixture, deleteCatalogProductIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/catalogFixtures'
 import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth'
@@ -39,7 +39,7 @@ async function fillCombobox(
 }
 
 async function selectEntityForRecordPicker(
-  page: import('@playwright/test').Page,
+  page: Page,
   entityType: string,
 ) {
   const recordInput = page.getByPlaceholder('Search records...')
@@ -57,6 +57,28 @@ async function selectEntityForRecordPicker(
   }
 
   await expect(recordInput).toBeEnabled({ timeout: 10_000 })
+}
+
+async function waitForTranslationField(root: Locator, preferredPlaceholder?: string): Promise<Locator> {
+  const fieldLocator = root.locator('table').locator('input, textarea')
+  await expect.poll(async () => fieldLocator.count(), {
+    message: 'Expected at least one translation input to be available',
+    timeout: 45_000,
+  }).toBeGreaterThan(0)
+
+  const firstEditableField = fieldLocator.first()
+  await expect(firstEditableField).toBeVisible()
+  await expect(firstEditableField).toBeEnabled()
+
+  const normalizedPlaceholder = preferredPlaceholder?.trim()
+  if (!normalizedPlaceholder) return firstEditableField
+
+  const preferredField = root.getByPlaceholder(normalizedPlaceholder).first()
+  if (await preferredField.count()) {
+    if (await preferredField.isVisible()) return preferredField
+  }
+
+  return firstEditableField
 }
 
 /**
@@ -87,10 +109,18 @@ test.describe('TC-TRANS-009: Translation Command Undo', () => {
       })
       await managerCard.getByRole('button', { name: 'DE' }).click()
 
-      const titleInput = page.locator('table input').first()
-      await titleInput.fill('Deutscher Titel QA')
+      const titleInput = await waitForTranslationField(managerCard, 'Deutscher Titel QA')
+      await titleInput.click()
+      await page.keyboard.type('Deutscher Titel QA')
+      await expect.poll(async () => titleInput.inputValue()).toBe('Deutscher Titel QA')
 
+      const saveResponsePromise = page.waitForResponse((response) =>
+        response.request().method() === 'PUT'
+        && response.url().includes(`/api/translations/${encodeURIComponent(ENTITY_TYPE)}/${productId}`),
+      )
       await page.getByRole('button', { name: 'Save translations' }).click()
+      const saveResponse = await saveResponsePromise
+      expect(saveResponse.ok()).toBeTruthy()
       await expect(page.getByText('Translations saved').first()).toBeVisible()
 
       // Verify translation was created via API
@@ -144,12 +174,18 @@ test.describe('TC-TRANS-009: Translation Command Undo', () => {
       await managerCard.getByRole('button', { name: 'DE' }).click()
 
       // Verify the original translation is loaded
-      const titleInput = page.locator('table input').first()
+      const titleInput = await waitForTranslationField(managerCard, 'Original Titel')
       await expect(titleInput).toHaveValue('Original Titel')
 
       // Update the translation via UI
       await titleInput.fill('Aktualisierter Titel')
+      const saveResponsePromise = page.waitForResponse((response) =>
+        response.request().method() === 'PUT'
+        && response.url().includes(`/api/translations/${encodeURIComponent(ENTITY_TYPE)}/${productId}`),
+      )
       await page.getByRole('button', { name: 'Save translations' }).click()
+      const saveResponse = await saveResponsePromise
+      expect(saveResponse.ok()).toBeTruthy()
       await expect(page.getByText('Translations saved').first()).toBeVisible()
 
       // Click the Undo button


### PR DESCRIPTION
## Summary

Stabilize the translations integration coverage for the standalone translation manager and undo flow. The UI was flaky in CI because the translation input was matched too early and the save assertion could fire before the request completed.

## Changes

- Replaced brittle `table input` targeting with a stable helper that waits for the translation field to be present inside the translation manager card.
- Switched the translation entry flow to click + keyboard typing and wait for the input value to update before saving.
- Added explicit `waitForResponse` synchronization around translation saves before asserting the success flash.
- Kept the existing auth display-name changes intact; this commit only hardens the translation integration tests.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
- N/A

## Testing

- `npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/translations/__integration__/TC-TRANS-005.spec.ts packages/core/src/modules/translations/__integration__/TC-TRANS-009.spec.ts --workers 1`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

- N/A
