### PR TITLE
SPEC: two way email integration basics 

### DIFF
--- a/.ai/specs/2026-05-21-email-integration-foundation.md
+++ b/.ai/specs/2026-05-21-email-integration-foundation.md
@@ -1,1087 +1,1124 @@
-# Email Integration Foundation (Per-User, Multi-Provider)
+# Per-User Email Channels under the Communications Hub
 
 ## TLDR
 
 **Key Points:**
-- New `email` module + three provider workspace packages (`email-gmail`, `email-microsoft`, `email-imap`) deliver per-user email account linking, send, and receive primitives.
-- Foundation only: no CRM hooks, no inbox UI, no message-body persistence. A follow-on CRM spec consumes the canonical events and decides storage.
+- Implements per-user Gmail, Microsoft 365 / Outlook, and IMAP+SMTP as **three `ChannelAdapter`s under the existing `communication_channels` hub** (SPEC-045d), not as a parallel `email` module.
+- Adds the minimal hub deltas required to support per-user channels and polling-based providers: `CommunicationChannel.user_id?`, `pollIntervalSeconds`, hub-side `poll-channel` scheduler, `ChannelCapabilities.realtimePush?`, optional `ChannelAdapter.refreshCredentials?()`. All deltas are additive against SPEC-045d.
+- Takes **full advantage of UMES** (SPEC-041): 17 named extension points across widget injection, response enrichers, API interceptors, mutation guards, component replacement, notification handlers, sync event subscribers, entity extensions, and command interceptors. Provider packages own their UI surface via UMES — no per-provider mutations to core hub pages.
 
-**Scope:**
-- Per-user OAuth linking for Gmail and Microsoft 365 / Outlook.
-- Per-user IMAP+SMTP credential linking for everything else.
-- Polling-based inbound sync (5-min default), emits `email.message.received` event.
-- `sendAsUser(accountId, message)` outbound primitive — sends from the user's mailbox; existing Resend pipeline untouched.
-- User Settings → Email Accounts UI (connect / rename / primary / reconnect / disconnect).
-- Admin debug view for tenant-wide account health (no content access).
-- Per-provider Marketplace Integration entries (additive to existing Integration Marketplace).
+**Scope (v1):**
+- Per-user OAuth linking for Gmail and Microsoft 365 / Outlook; per-user credential linking for IMAP+SMTP.
+- Polling-based inbound (5-min default, configurable per channel). Real-time push (Gmail Pub/Sub, Graph subscriptions, IMAP IDLE) deferred to v2.
+- Inbound emails auto-create `Message` records in the channel owner's unified inbox via the hub's bridge — emails are first-class inbox citizens from day one.
+- Outbound via the hub's standard `messages.message.sent` → `adapter.sendMessage` flow. Thin `sendAsUser({ userChannelId, ... })` facade for programmatic callers (workflows, AI tools).
+- Three per-provider workspace packages: `@open-mercato/channel-gmail`, `@open-mercato/channel-microsoft`, `@open-mercato/channel-imap`.
 
-**Concerns:**
-- OAuth client flow does not yet exist in the codebase; this spec introduces it. State-cookie pattern borrowed from `packages/enterprise/src/modules/sso/lib/state-cookie.ts`.
-- The existing Integration Marketplace is tenant-scoped only. This spec intentionally does NOT extend `integration_credentials`; it adds a separate per-user credential store (`email_account_credentials`) to keep tenant-vs-user secret leakage impossible by construction.
-- Sending real emails as a user from a provider's API can affect their personal Sent folder and deliverability reputation. Mitigation: explicit per-account opt-in via UI flow; no automatic enrolment.
+**Non-goals (v1):**
+- Real-time push inbound for any provider (deferred to v2 spec).
+- Body persistence beyond what the hub already does in `MessageChannelLink.channelPayload` — provider packages reuse that store; no parallel `EmailMessageEnvelope`.
+- Replacing the existing Resend transactional pipeline (`packages/shared/src/lib/email/send.ts`) — that pipeline remains the system identity for password resets, MFA, notifications. Resend and per-user channels coexist; the caller picks.
+- Replacing or modifying `inbox_ops` — `inbox_ops` continues to handle the *tenant-forwarded* Resend mailbox for AI action extraction (see § Relationship to `inbox_ops`).
+- CRM auto-linking beyond what `ChannelAdapter.resolveContact?()` already affords.
+- **Customer-portal channel ownership.** v1 is scoped to staff users only (the `auth:user` identity). Letting a B2B customer-portal contact (`customer_accounts:customer_account`) connect their own mailbox is a plausible v2 feature but explicitly out of scope here: it would require a parallel ACL surface in `customer_accounts`, a separate `user_id`-equivalent column path, and customer-portal-specific UI. v1 keeps the link strictly `CommunicationChannel.user_id → auth:user`.
+
+**Concerns / open dependencies:**
+- **SPEC-045d is a hard prerequisite.** It lives under `.ai/specs/implemented/` but `packages/core/src/modules/communication_channels/` does not exist in the repo today (verified via `ls packages/core/src/modules/communication_channels` — missing; `grep "interface ChannelAdapter"` — no shipping matches). SPEC-045d's own body marks itself "Phase 4 of 6" — it is a spec, not deployed code. **This spec depends on SPEC-045d being implemented separately first** (see § Prerequisites & Cross-Spec Dependencies). It does NOT carry SPEC-045d delivery in its own Phase 0.
+- OAuth client infrastructure does not exist in OSS core (only in the enterprise SSO module). This spec ports the state-cookie pattern locally to the hub (`packages/core/src/modules/communication_channels/lib/oauth-state.ts`) — `@open-mercato/core` MUST NOT import from `@open-mercato/enterprise`.
+- Sending real emails from a user's mailbox affects their personal deliverability reputation. Mitigation: per-channel explicit opt-in flow; admin can disable any user-owned channel.
+
+---
+
+## Prerequisites & Cross-Spec Dependencies
+
+This spec is the **second-floor work**. SPEC-045d (the Communications Hub) must be implemented as its own spec before any phase of this work starts. Concretely:
+
+| Dependency | Must deliver before this spec begins | Owner |
+|---|---|---|
+| **SPEC-045d Communication & Notification Hubs** ([file](.ai/specs/implemented/SPEC-045d-communication-notification-hubs.md)) | `packages/core/src/modules/communication_channels/` with: entities (`CommunicationChannel`, `ExternalConversation`, `ExternalMessage`, `MessageChannelLink`, `ChannelThreadMapping`, `MessageReaction`, `HealthLog`); `ChannelAdapter` v2 interface + DI registry; inbound-processor worker; outbound-delivery subscriber on `messages.message.sent`; hub events (`communication_channels.message.received/.sent/.delivery_failed/.reaction.added`); hub ACL features (`communication_channels.view/.manage/.admin`); hub admin pages (`/backend/communication_channels/channels`, channel detail). | Separate spec/PR. Recommended path: `git mv` SPEC-045d out of `.ai/specs/implemented/` first (it is not implemented) and own its delivery on its own dated spec. |
+| **SPEC-041 UMES** ([dir](.ai/specs/implemented/) `SPEC-041*` files) | Already shipped — verified in code (`packages/ui/src/backend/injection/`, `useGuardedMutation`, `useNotificationEffect`, response enricher + API interceptor + mutation guard + sync subscriber + command interceptor registries). | None — done. |
+| **SPEC-002 Messages Module** ([file](.ai/specs/implemented/SPEC-002-2026-01-23-messages-module.md)) | Already shipped — verified in code (`packages/core/src/modules/messages/`). `messages.message.sent` event present with `clientBroadcast: true`. | None — done. |
+| **SPEC-045 Integration Marketplace** ([file](.ai/specs/implemented/SPEC-045-2026-02-24-integration-marketplace.md)) | Already shipped — `packages/core/src/modules/integrations/` with `IntegrationCredentials` entity and per-tenant Marketplace admin UI. | None — done. |
+
+### Coordination with SPEC-056 (WhatsApp)
+
+SPEC-056 is a **sibling**, not a dependency. Both this spec and SPEC-056 produce `ChannelAdapter` provider packages on top of the same hub. They can ship in any order. Two coordination items:
+
+1. The first one to land establishes the de-facto reference implementation pattern for ChannelAdapters. The hub contract holds; only example code in docs may need to be updated to point at the chosen first provider.
+2. If both teams notice the same hub gap (e.g., a missing capability on `ChannelAdapter`), that gap is escalated back to the hub's spec rather than patched in both providers.
+
+### Why not merge SPEC-045d into this spec
+
+Merging would conflate "build the hub" with "ship email", produce a spec twice as long for no architectural benefit, and would force the WhatsApp work (SPEC-056) to either wait or branch from a half-built hub. Keeping them separate also makes the hub's BC posture cleaner: SPEC-045d evolves on its own cadence; this spec is one of many consumers.
+
+### Why not merge SPEC-056 into this spec
+
+WhatsApp's auth model (Meta tokens, webhook-driven push), payload model (interactive components, Block Kit-style content), and reactions support are fundamentally different from email. Bundling them would re-create the "internally heterogeneous module" anti-pattern (Alternative A2 in § Alternatives Considered). Keep them as separate provider packages under the same hub.
 
 ---
 
 ## Overview
 
-Open Mercato today has **outbound-only, Resend-only** email (~15 transactional flows: auth, MFA, notifications, sales, onboarding, payments, portal, messages). Inbound exists only inside `inbox_ops`, which uses webhook-delivered emails to a per-tenant shared address and parses them into action proposals — not a general per-user mailbox integration.
+Open Mercato today has **outbound-only, Resend-only** transactional email and no per-user mailbox concept. The product needs each logged-in user to connect their own Gmail, Microsoft 365 / Outlook, or IMAP+SMTP account so that:
+- Outbound messages are sent from the user's own address (replies land in their inbox, recipients see the sender as the user, conversations look natural).
+- Inbound emails reach the user's unified Open Mercato inbox alongside WhatsApp, Slack, and future channels — one place to triage all external communications.
+- Downstream CRM specs can attach conversations to customers, deals, and threads by subscribing to the hub's channel-agnostic events (`communication_channels.message.received` / `.sent`).
 
-The product needs each logged-in user to connect their own email account (Gmail, Microsoft 365, or any IMAP/SMTP provider) so that, in a follow-on CRM specification, sent and received emails can be attached to customers, deals, and conversations. This spec delivers the **enabling infrastructure** as an independently shippable PR before the CRM integration is designed.
+**The previous spec proposed a standalone `email` module with its own entities, events, OAuth router, polling worker, and admin UI.** This was rejected because Open Mercato already has a finalized architecture for external communication channels — the Communications Hub (SPEC-045d) — with WhatsApp planned as the first concrete adapter (SPEC-056). Email belongs under that hub. This spec rewrites the design from scratch around the hub contract and uses UMES (SPEC-041) for all cross-module integration surface area.
 
-> **Market Reference**: HubSpot Sales (Gmail/Outlook OAuth + IMAP fallback), Pipedrive Smart Email BCC + Gmail/Microsoft integration, Salesforce Inbox, Front (HelpScout-style per-user inbox sync). Adopted: per-user OAuth model, provider-abstracted contract with provider-specific metadata escape hatch, polling-as-baseline (push-as-future). Rejected: BCC-only "smart forward" patterns (lossy, depends on user discipline) and shared system mailbox patterns (don't address the per-user requirement).
+> **Architectural references**: SPEC-045d Communication & Notification Hubs (the hub contract), SPEC-056 WhatsApp AI Chat (the first ChannelAdapter implementation pattern), SPEC-041 Universal Module Extension System (the extension framework), SPEC-002 Messages Module (the inbox destination), SPEC-045 Integration Marketplace (the credentials + admin home).
 
 ## Problem Statement
 
-1. **No per-user email accounts.** Every outbound email today is sent from a single Resend identity. Users cannot send from their own mailbox; recipients see the system address, replies don't land in the user's Sent folder, and there is no concept of "this email was sent by Jane to John."
-2. **No inbound email.** Inbound only exists for `inbox_ops`'s tenant-shared address, parsed by an LLM for action proposals. There is no infrastructure for a user's mailbox to be polled, no canonical inbound-message event, and nothing for downstream modules (notably CRM) to subscribe to.
-3. **No provider abstraction.** The single Resend integration is hardcoded across 15+ call sites. Adding a second provider (Gmail send, Microsoft Graph send, SMTP send) would require a new abstraction layer that does not exist.
-4. **No third-party OAuth client flow.** The codebase has user-SSO OAuth (enterprise SSO module) but no infrastructure for Open Mercato acting as a *client* of a third-party identity to obtain that user's access+refresh tokens. We can borrow the SSO state-cookie helper, but the actual flow needs to be built.
-5. **Integration Marketplace is tenant-scoped only.** All current `integration_credentials` rows are keyed by `(organization_id, tenant_id)`. Per-user accounts need a parallel store with strict per-user isolation.
+1. **Standalone email module duplicates the hub.** Two systems for storing external messages (`EmailMessageEnvelope` vs hub's `ExternalMessage`), two event streams (`email.message.received` vs `communication_channels.message.received`), two admin pages, two marketplace categories, two credential stores. CRM has to subscribe to both or miss messages.
+2. **Per-user channels are unsupported in the hub today.** `CommunicationChannel` is tenant-scoped (`tenant_id` + `organization_id` only). Per-user accounts (each user's personal Gmail) need a way to attach a user as the owning principal.
+3. **Hub assumes webhook-driven inbound.** SPEC-045d describes inbound as webhook → `verifyWebhook` → worker. Gmail/Microsoft/IMAP real-time push requires GCP Pub/Sub / Graph subscriptions / IMAP IDLE — significant infra cost. We need a polling fallback baked into the hub.
+4. **No third-party OAuth client flow in OSS core.** Only enterprise SSO has OAuth client primitives. We need to port that to the hub for any OAuth-based channel (Gmail, Microsoft, future Slack-OAuth, etc.).
+5. **Cross-module integration without UMES is invasive.** Per-provider UI in the hub's pages would either bloat the hub or fork the hub per provider. UMES (already in the codebase) is the correct extension mechanism.
 
 ## Proposed Solution
 
-A new core module `@open-mercato/core/modules/email` orchestrates per-user email accounts, delegates provider-specific operations to dedicated workspace packages (`@open-mercato/email-gmail`, `@open-mercato/email-microsoft`, `@open-mercato/email-imap`), and exposes a stable canonical-message contract for downstream consumers (CRM, future inbox UI).
+**Approach C from brainstorming, rejected. Approach A adopted: three per-provider workspace packages under the hub, with minimal additive hub deltas.**
 
-**Approach: thick core + provider extension hook ("Approach C" from brainstorming).**
-- Core defines the `EmailProvider` interface, owns workers, retry logic, sync cursors, event emission, OAuth callback router, encrypted credential storage, ACL features, and admin observability.
-- Provider packages own OAuth config + token exchange (where applicable), sync logic (Gmail History API, Graph delta, IMAP UIDNEXT/UIDVALIDITY), send logic, and a typed `providerMeta` schema for provider-specific data (Gmail labels, Outlook categories, IMAP flags) that travels in the canonical message via a discriminated union.
-- The existing Resend pipeline is untouched. Both pipelines coexist; callers choose per use-case.
+### High-level architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Hub: @open-mercato/core/modules/communication_channels      │
+│  (SPEC-045d, code partially missing — Phase 0 delivers gaps) │
+│                                                              │
+│  Owns:                                                       │
+│   • ChannelAdapter v2 registry (DI)                          │
+│   • CommunicationChannel entity (extended +user_id, +poll)   │
+│   • ExternalConversation, ExternalMessage                    │
+│   • MessageChannelLink, ChannelThreadMapping, MessageReaction│
+│   • Inbound webhook router + inbound-processor worker        │
+│   • Outbound subscriber on messages.message.sent             │
+│   • NEW: poll-channel scheduler + worker (per-channel)       │
+│   • NEW: per-user channel ACL gates                          │
+│   • NEW: OAuth state-cookie helper (ported from enterprise)  │
+│   • NEW: OAuth callback router /api/communication_channels   │
+│         /oauth/[provider]/callback                           │
+└──────────────────────────────────────────────────────────────┘
+              ▲           ▲           ▲
+              │           │           │  (each registers ChannelAdapter via setup.ts)
+   ┌──────────┴──┐  ┌─────┴────┐  ┌───┴──────────┐
+   │ channel-     │ │ channel-  │ │ channel-      │
+   │ gmail        │ │ microsoft │ │ imap          │
+   │ (OAuth +     │ │ (OAuth +  │ │ (basic auth + │
+   │  History API)│ │  Graph    │ │  imapflow +   │
+   │              │ │  delta)   │ │  nodemailer)  │
+   └──────────────┘ └───────────┘ └───────────────┘
+              │           │           │
+              └───────────┼───────────┘
+                          ▼
+                  UMES extension surface
+                  (widgets, enrichers,
+                   guards, overrides)
+                          ▼
+              ┌──────────────────────────┐
+              │ Messages module          │
+              │ (SPEC-002) — UNCHANGED   │
+              │ Inbox auto-populated     │
+              │ via hub's bridge.        │
+              └──────────────────────────┘
+```
 
 ### Design Decisions
 
 | Decision | Rationale |
 |----------|-----------|
-| Three providers in v1 (Gmail, Microsoft, IMAP) | Customer requirement: "each logged-in user uses their own account from different providers." Forcing all three from day 1 prevents the provider abstraction from accidentally over-fitting one. |
-| Polling, not native push | Universal across providers, no public endpoints required, predictable cost. Native push (Gmail Pub/Sub, Graph subscriptions) deferred to a later spec. |
-| Separate `email_account_credentials` table, NOT extending `integration_credentials` | Per-user secrets and tenant-wide secrets have different access-control semantics. Mixing them in one table risks cross-user leakage via one missed `WHERE` clause. Both still use the shared `findWithDecryption` encryption helper. |
-| No message body or attachment persistence in v1 | "What we store" is a CRM-spec decision. This spec emits `CanonicalMessage` events with a `bodyRef` (opaque provider pointer); downstream subscribers decide whether and how to fetch + persist bodies. |
-| `EmailMessageEnvelope` capped at last 200 per account, rolling | Provides a debug view for verifying inbound polling without committing to a content-persistence story. CRM spec defines its own persistent store; this table is explicitly NOT a data source for CRM. |
-| Both pipelines coexist with Resend (caller picks) | Smallest blast radius for v1. Migration of existing system-sent emails (password reset, MFA, etc.) is out of scope and a clear non-goal. |
-| Multiple accounts per user, one primary | Common in CRM tooling (HubSpot, Pipedrive). Schema cost is one extra boolean column; not having it forces a painful migration later. |
+| **Three provider packages (gmail / microsoft / imap), not one `channel_email`** | The lesson "Keep external integrations as dedicated npm workspace packages" (`.ai/lessons.md`) and the existing `packages/gateway-stripe` / `packages/sync-akeneo` precedent override SPEC-045d §11.3's `channel_email` sketch. Gmail OAuth, Microsoft Graph OAuth+PKCE, and IMAP basic auth are fundamentally different — three packages is honest. |
+| **Per-user channels via additive `CommunicationChannel.user_id?` column** | Cleanest extension to the hub. NULL = tenant-scoped (existing WhatsApp Business behavior). Set = user-scoped (Jane's personal Gmail). No parallel table, no schema migration of existing rows, single canonical channel registry. |
+| **Polling via hub-side scheduler + `ChannelCapabilities.realtimePush?: boolean`** | Hub owns the scheduling; providers declare whether they support push. Providers that opt out get hub-managed polling using their existing `fetchHistory()` method — no provider-side polling primitive needed. Future v2 push providers flip the flag. |
+| **Inbound emails auto-create `Message` records in the inbox via existing hub bridge** | This is the whole point of the hub. Per-user channel owner becomes the default `ChannelThreadMapping.assigned_user_id`. CRM, search, notifications, reactions, threading all come for free. |
+| **Outbound via standard hub flow + thin `sendAsUser` facade** | One send path. The facade is just a typed `Message` creator that sets the channel routing metadata correctly; the actual send happens through the hub subscriber → adapter chain. |
+| **Hub credentials store with additive `user_id?` column on `integration_credentials`** | Reuses encryption, audit, admin UI. Per-user secrets are isolated via app-layer `WHERE user_id = currentUser.id OR user_id IS NULL`. No parallel credential table. |
+| **OAuth state-cookie helper ported locally to the hub, not imported from enterprise** | `@open-mercato/core` MUST NOT depend on `@open-mercato/enterprise`. The pattern is small and self-contained. Phase 0 includes a `grep` verification step. |
+| **Resend pipeline untouched** | System-identity transactional flows (password reset, MFA, billing) remain on Resend. Migrating them to per-user channels is a v3 question, not a v1 scope. |
+| **UMES used aggressively (17 extension points)** | Every cross-module concern (admin UI, inbox rendering, response enrichment, mutation guarding, notification reactivity) goes through UMES. Provider packages never patch core hub pages. |
 
 ### Alternatives Considered
 
 | Alternative | Why Rejected |
 |-------------|-------------|
-| Single `email` module with all providers inline | Violates the AGENTS.md rule that every external integration provider lives in its own workspace package. |
-| Thin core, fat per-provider packages (Approach B) | High duplication of worker/retry/sync-cursor logic across three packages; risk of behavioral drift between providers. |
-| Strict canonical schema with no `providerMeta` (Approach A) | Loses provider-specific features (Gmail labels, Outlook categories, IMAP flags) in normalization — CRM team will need them. |
-| Reuse `integration_credentials` with a nullable `userId` column | Mixes tenant-scoped and user-scoped secrets in one table; one missed `WHERE user_id = ?` becomes a cross-user disclosure. |
-| Replace Resend wholesale with user-account send | Touches notifications, messages, sales, onboarding, MFA, portal — v1 scope explosion with no incremental shipping value. |
-| Native push (Gmail Pub/Sub, Graph subscriptions) in v1 | Requires a public webhook endpoint, GCP Pub/Sub topic configured globally, Graph subscriptions renewed every 3 days. Marginal UX win (real-time vs. 5-min lag) doesn't justify the v1 scope. Defer to opt-in v2 spec. |
+| **A1. Standalone `email` module + three `email-*` provider packages (previous draft)** | Duplicates the hub. Two storage models, two event streams, two admin homes. Maintainer rejected. |
+| **A2. Single `channel_email` package with internal Gmail/Microsoft/IMAP strategies (matches SPEC-045d §11.3 literally)** | Violates the per-provider workspace convention. Gmail/Microsoft/IMAP have different OAuth/auth/sync mechanisms — packaging them together produces an internally heterogeneous module that's hard to release, version, or disable independently. |
+| **A3. Build polling per-provider (each provider package owns its scheduler)** | Triplicates the scheduler logic, fragments backoff behavior, makes adding a fourth poll-based channel (e.g., LinkedIn) an N×M problem. Hub-side scheduler is the correct factoring. |
+| **A4. Parallel `user_email_credentials` table (per-user secrets isolated by schema, not by `WHERE`)** | The hub's `integration_credentials` is already encrypted, audited, and admin-managed. A parallel table would need to re-implement all of that. The `user_id` column is sufficient — leaks are prevented at the query layer (with mutation-guard defense in depth). |
+| **A5. Wait for v2 push support before shipping any email** | The product needs email v1 now. Polling is a well-known acceptable pattern (HubSpot, Pipedrive, Salesforce Inbox all defaulted to polling at v1). |
+| **A6. Implement the hub in this spec from scratch (ignoring SPEC-045d)** | SPEC-045d is the locked architectural contract. We deliver the runtime that matches it (Phase 0), nothing more. |
 
 ## User Stories
 
-- **A sales rep** wants to **connect their Gmail account in Open Mercato** so that **emails I send through the platform appear in my own Sent folder and replies come to my inbox.**
-- **An account manager on Microsoft 365** wants to **link their Outlook account** so that **future CRM features can attach the conversations to my deals.**
-- **A user with a custom domain on Fastmail** wants to **connect via IMAP+SMTP** so that **the integration works without needing OAuth support from my provider.**
-- **A user with both a work Microsoft account and a personal Gmail** wants to **connect both and mark one as primary** so that **the system knows which to default to.**
-- **A tenant admin** wants to **see which users have connected accounts and which have authentication errors** so that **I can help them reconnect — without ever seeing the contents of their emails.**
-- **A tenant admin in a SaaS deployment** wants to **use the platform's shared OAuth app** so that **I don't need to register my own with Google.**
+- **A sales rep** wants to **connect their Gmail in Open Mercato** so that **the customer conversations I have through Open Mercato come from my own address and replies land in my inbox.**
+- **An account manager on Microsoft 365** wants to **link their Outlook account** so that **future CRM features attach conversations to my deals automatically.**
+- **A user with a Fastmail account** wants to **connect via IMAP+SMTP** so that **the integration works without my provider having to offer OAuth.**
+- **A user with both a work Microsoft account and a personal Gmail** wants to **connect both and mark one as primary** so that **the system knows which to default to when I compose.**
+- **A tenant admin** wants to **see which users have connected accounts and which are unhealthy** so that **I can help them reconnect — without ever seeing the contents of their emails.**
+- **A tenant admin in a SaaS deployment** wants to **use the platform's shared OAuth app** so that **I don't have to register my own with Google.**
 - **A tenant admin in a self-hosted deployment** wants to **register the tenant's own Google Cloud OAuth client** so that **the consent screen shows their company name.**
+- **A future CRM module author** wants to **subscribe to `communication_channels.message.received` and get email, WhatsApp, and Slack messages through one event stream** so that **I write one cross-channel CRM bridge, not three.**
 
 ## Architecture
 
 ### Package & Module Layout
 
 ```
-packages/core/src/modules/email/         # Orchestrator
-  index.ts                               # Module metadata
-  setup.ts                               # ACL grants, sync-role-acls hook
-  acl.ts                                 # 5 features (see Access Control section)
-  di.ts                                  # EmailProviderRegistry, OAuthStateService, EmailAccountService
-  encryption.ts                          # Declares encrypted columns
-  data/entities.ts                       # 5 entities (see Data Models)
-  data/validators.ts                     # Zod schemas
-  data/extensions.ts                     # Link EmailAccount → User (FK ID only)
-  lib/provider.ts                        # EmailProvider interface
-  lib/canonical-message.ts               # CanonicalMessage + providerMeta union
-  lib/provider-registry.ts               # DI registry of providers
-  lib/oauth-state.ts                     # CSRF state-cookie helper
-  lib/oauth-router.ts                    # Generic /api/email/oauth/[provider]/callback
-  lib/send-pipeline.ts                   # sendAsUser() facade
-  commands/                              # Command pattern (see Commands)
-    connectAccount.ts
-    disconnectAccount.ts
-    setPrimaryAccount.ts
-    renameAccount.ts
-    updateImapCredentials.ts
-    sendMessage.ts
-    ingestMessage.ts
+packages/core/src/modules/communication_channels/      # The hub (SPEC-045d)
+  index.ts                                             # ModuleInfo
+  setup.ts                                             # ACL grants, channel adapter registry init
+  acl.ts                                               # Feature IDs (extended per §"ACL")
+  di.ts                                                # ChannelAdapterRegistry, OAuthStateService
+  encryption.ts                                        # Encrypted columns (extended)
+  data/
+    entities.ts                                        # Hub entities + new columns (see Data Models)
+    validators.ts                                      # Zod schemas
+    extensions.ts                                      # EntityExtension: CommunicationChannel → auth.User (FK)
+  lib/
+    adapter.ts                                         # ChannelAdapter v2 interface (from SPEC-045d)
+    capabilities.ts                                    # ChannelCapabilities interface (extended +realtimePush?)
+    registry.ts                                        # DI registry of ChannelAdapter instances
+    oauth-state.ts                                     # PORTED from enterprise SSO; AES-256-GCM + HKDF
+    oauth-router.ts                                    # Generic /api/communication_channels/oauth/[provider]/callback
+    send-as-user.ts                                    # sendAsUser({ userChannelId, ... }) facade
+  commands/                                            # See Commands & Events
+    connectChannel.ts
+    disconnectChannel.ts
+    setPrimaryChannel.ts
+    refreshChannelCredentials.ts
+    markChannelRequiresReauth.ts
   workers/
-    poll-account.ts                      # Generic poll worker
-    refresh-tokens.ts                    # Renew OAuth before expiry
-    purge-envelopes.ts                   # Daily envelope-cap cleanup
-    purge-health-log.ts                  # Daily 90-day cleanup
-  api/                                   # Auto-discovered
-    post/accounts/connect/[provider]/route.ts
-    get/oauth/[provider]/callback/route.ts
-    post/accounts/imap/route.ts
-    get/accounts/route.ts
-    patch/accounts/[id]/route.ts
-    delete/accounts/[id]/route.ts
-    post/accounts/[id]/set-primary/route.ts
-    post/send/route.ts
-    get/admin/accounts/route.ts          # email.admin only
-    get/admin/health-log/route.ts        # email.admin only
+    poll-channel.ts                                    # NEW: hub-managed polling, calls adapter.fetchHistory
+    inbound-processor.ts                               # Existing in SPEC-045d (webhook + poll funnel here)
+    outbound-delivery.ts                               # Existing in SPEC-045d (subscriber on messages.message.sent)
+    purge-health-log.ts                                # NEW: daily cleanup
+  api/                                                 # Auto-discovered
+    post/oauth/[provider]/initiate/route.ts            # NEW: starts OAuth, sets state cookie
+    get/oauth/[provider]/callback/route.ts             # NEW: state validation + token exchange
+    post/channels/connect/credentials/route.ts         # NEW: credential-based (IMAP) connect
+    get/channels/route.ts                              # Extended: per-user filter applied
+    patch/channels/[id]/route.ts                       # Extended: per-user ACL
+    delete/channels/[id]/route.ts                      # Extended: per-user ACL
+    post/channels/[id]/set-primary/route.ts            # NEW
+    post/channels/[id]/test-send/route.ts              # NEW: admin diagnostics
+    post/send-as-user/route.ts                         # NEW: bespoke endpoint backing the facade
+    get/admin/channels/route.ts                        # Extended: tenant-wide view, redacted DTO
+    get/admin/health-log/route.ts                      # Extended
   backend/
-    profile/email-accounts/page.tsx      # User settings UI
-    email/admin/page.tsx                 # Admin debug UI
-  events.ts                              # 6 events (see Events)
-  notifications.ts                       # email_account_requires_reauth type
-  notifications.client.ts                # Client-side renderer for that notification
+    channels/page.tsx                                  # Existing in SPEC-045d (admin channels list)
+    channels/[id]/page.tsx                             # Existing in SPEC-045d (channel detail)
+    profile/communication-channels/page.tsx            # NEW: per-user "My Channels" page
+  events.ts                                            # SPEC-045d events; NO new IDs (all routed through existing)
+  notifications.ts                                     # New type: channel_requires_reauth (generic, channel-agnostic)
+  notifications.client.ts                              # Client renderer
 
-packages/email-gmail/                              # npm package @open-mercato/email-gmail
+packages/channel-gmail/                                # @open-mercato/channel-gmail
   package.json
-  build.mjs / watch.mjs                            # standard provider-package build (see packages/gateway-stripe/build.mjs)
-  src/modules/email_gmail/                         # module id 'email_gmail' (dashes → underscores per root AGENTS.md)
-    index.ts                                       # ModuleInfo metadata
-    setup.ts                                       # registers provider with core EmailProviderRegistry; marketplace integration row
-    di.ts                                          # DI bindings for the provider
-    lib/oauth.ts                                   # Google OAuth (authorize URL, token exchange, refresh)
-    lib/sync.ts                                    # gmail.users.history.list incremental sync
-    lib/send.ts                                    # gmail.users.messages.send (raw RFC822)
-    lib/health.ts                                  # gmail.users.getProfile
-    lib/provider-meta.ts                           # GmailProviderMeta zod schema
-
-packages/email-microsoft/                          # @open-mercato/email-microsoft
-  src/modules/email_microsoft/                     # module id 'email_microsoft'
+  build.mjs / watch.mjs                                # Standard provider package build
+  src/modules/channel_gmail/                           # Module id: channel_gmail (snake_case)
     index.ts
-    setup.ts                                       # provider registration + marketplace integration row
+    setup.ts                                           # registerChannelAdapter(gmailAdapter); marketplace row
     di.ts
-    lib/oauth.ts                                   # Microsoft identity platform v2.0 (Azure AD)
-    lib/sync.ts                                    # /me/mailFolders/inbox/messages/delta
-    lib/send.ts                                    # /me/sendMail
-    lib/health.ts                                  # /me
-    lib/provider-meta.ts                           # OutlookProviderMeta zod schema
+    integration.ts                                     # IntegrationDescriptor: category 'communication', hub 'communication_channels'
+    acl.ts                                             # NONE (uses hub features; per-provider gates live here only if needed)
+    ce.ts                                              # OPTIONAL: per-channel custom fields (signature, default Gmail labels)
+    translations.ts
+    lib/
+      adapter.ts                                       # ChannelAdapter v2 implementation
+      capabilities.ts                                  # Gmail capabilities (threading, richText, attachments, no reactions, no realtimePush)
+      oauth.ts                                         # Google OAuth client (authorize URL, exchange, refresh)
+      sync.ts                                          # gmail.users.history.list incremental + gmail.users.threads.get
+      send.ts                                          # gmail.users.messages.send with RFC2822 MIME
+      contact-resolver.ts                              # From: header → CRM person lookup
+      thread-resolver.ts                               # Message-ID / In-Reply-To / References → ChannelThreadMapping
+      content-converter.ts                             # convertOutbound: Message body → RFC2822 MIME; normalizeInbound: MIME → text/html + attachments
+      health.ts                                        # gmail.users.getProfile
+    widgets/injection/                                  # UMES widget injections (see UMES section)
+      profile-connect-gmail/
+      admin-gmail-oauth-config/
+      datatable-channels-status-badge-gmail/
+    widgets/components.ts                              # OPTIONAL: component overrides
+    enrichers/                                          # UMES response enrichers (see UMES section)
+      message-email-headers.ts
+      channel-token-expiry.ts
+    interceptors/                                       # UMES API interceptors (see UMES section)
+      validate-gmail-send.ts
+    guards/                                             # UMES mutation guards (see UMES section)
+      block-send-on-requires-reauth.ts
 
-packages/email-imap/                               # @open-mercato/email-imap
-  src/modules/email_imap/                          # module id 'email_imap'
-    index.ts
-    setup.ts                                       # provider registration + marketplace integration row
-    di.ts
-    lib/credentials.ts                             # validateCredentials (both IMAP + SMTP login probe)
-    lib/sync.ts                                    # imapflow polling using UIDVALIDITY + UIDNEXT
-    lib/send.ts                                    # nodemailer SMTP
-    lib/health.ts                                  # auth check on both
-    lib/provider-meta.ts                           # ImapProviderMeta zod schema
+packages/channel-microsoft/                            # @open-mercato/channel-microsoft, parallel structure to channel-gmail
+  src/modules/channel_microsoft/
+    ...                                                 # Microsoft Identity v2 + PKCE; /me/sendMail; /me/mailFolders/inbox/messages/delta
+
+packages/channel-imap/                                 # @open-mercato/channel-imap, parallel structure
+  src/modules/channel_imap/
+    ...                                                 # imapflow + nodemailer; basic auth; UIDVALIDITY+UIDNEXT
 ```
-
-**Workspace package convention** (matches `packages/gateway-stripe/src/modules/gateway_stripe/...`, `packages/sync-akeneo/src/modules/sync_akeneo/...`): the npm package name uses dashes; the in-repo module id under `src/modules/<id>/` uses underscores. Root `AGENTS.md`:
-> Module-id convention: package `@open-mercato/<suffix>` ⇒ module id `<suffix>` with dashes converted to underscores (e.g. `@open-mercato/ai-assistant` ⇒ `ai_assistant`).
-
-Provider packages register with the core `EmailProviderRegistry` from their own `setup.ts` so each provider is independently enable-able from `apps/mercato/src/modules.ts`. Marketplace Integration registration is also driven from each provider's `setup.ts` (additive — see `packages/core/src/modules/integrations/AGENTS.md`).
 
 ### `apps/mercato/src/modules.ts` entries
 
-The four modules are added to `enabledModules` with underscore-converted IDs (per the root `AGENTS.md` module-id convention; mismatched IDs silently break auto-discovery):
-
 ```ts
-// apps/mercato/src/modules.ts — append to enabledModules
-{ id: 'email',           from: '@open-mercato/core' },
-{ id: 'email_gmail',     from: '@open-mercato/email-gmail' },
-{ id: 'email_microsoft', from: '@open-mercato/email-microsoft' },
-{ id: 'email_imap',      from: '@open-mercato/email-imap' },
+{ id: 'communication_channels', from: '@open-mercato/core' },   // Hub (Phase 0)
+{ id: 'channel_gmail',          from: '@open-mercato/channel-gmail' },     // Phase 2
+{ id: 'channel_microsoft',      from: '@open-mercato/channel-microsoft' }, // Phase 3
+{ id: 'channel_imap',           from: '@open-mercato/channel-imap' },      // Phase 1
 ```
 
-After editing `modules.ts`, run `yarn mercato configs cache structural --all-tenants` (required by root `AGENTS.md` after any module-graph change). If Turbopack still serves a stale compiled chunk, run `yarn dev:reset`.
+Module IDs use underscores per the root `AGENTS.md` rule "package `@open-mercato/<suffix>` ⇒ module id `<suffix>` with dashes converted to underscores". After enabling: `yarn mercato configs cache structural --all-tenants` (root `AGENTS.md` mandate after module-graph changes).
 
 ### OSS Independence
 
-This is an **OSS module** (`packages/core/...`) and the provider packages live under top-level workspace packages, not under `packages/enterprise/...`. The OAuth state-cookie helper at `packages/enterprise/src/modules/sso/lib/state-cookie.ts` is the **design reference** — its logic is **ported (re-implemented) locally** at `packages/core/src/modules/email/lib/oauth-state.ts`, NOT imported.
-
-**MUST NOT**:
-- import from `@open-mercato/enterprise` anywhere in `packages/core/src/modules/email/**`
-- import from `@open-mercato/enterprise` in any of the three provider packages (`packages/email-gmail/**`, `packages/email-microsoft/**`, `packages/email-imap/**`)
-
-Phase 1 acceptance includes a verification step:
+`@open-mercato/core` and the three provider packages MUST NOT import from `@open-mercato/enterprise`. The OAuth state-cookie helper is **ported (re-implemented locally)** at `packages/core/src/modules/communication_channels/lib/oauth-state.ts` — its design is informed by `packages/enterprise/src/modules/sso/lib/state-cookie.ts` but the file is independent. Phase 0 acceptance includes:
 
 ```bash
-grep -r "@open-mercato/enterprise" packages/core/src/modules/email packages/email-gmail packages/email-microsoft packages/email-imap
+grep -r "@open-mercato/enterprise" \
+  packages/core/src/modules/communication_channels \
+  packages/channel-gmail \
+  packages/channel-microsoft \
+  packages/channel-imap
 # Expected: empty output
 ```
 
-The local `oauth-state.ts` MUST reproduce: AES-256-GCM encryption, HKDF key derivation, encrypted payload `{ nonce, userId, providerId, iat, exp }`, 5-minute TTL, signature/tamper resistance. Unit tests cover encrypt/decrypt roundtrip, TTL expiry, signature tamper, userId-mismatch rejection. Key source: `OM_EMAIL_OAUTH_STATE_KEY` env var with HKDF fallback from `KMS_MASTER_KEY` (see Configuration).
+The local helper reproduces: AES-256-GCM payload encryption, HKDF key derivation, encrypted payload `{ nonce, userId, providerKey, returnUrl, iat, exp }`, 5-minute TTL, signature/tamper detection. Unit tests cover encrypt/decrypt roundtrip, TTL expiry, signature tamper, userId mismatch rejection. Key source: `OM_HUB_OAUTH_STATE_KEY` env var with HKDF fallback from `KMS_MASTER_KEY`.
 
-### Provider Interface
+### Relationship to `inbox_ops`
+
+`inbox_ops` and this spec **coexist with disjoint inputs and disjoint intents.** They are not duplicates and neither replaces the other.
+
+| Concern | `inbox_ops` (live module) | This spec (per-user channels under the hub) |
+|---|---|---|
+| **Source of mail** | A *dedicated* Resend mailbox the tenant sets up specifically for forwarding (e.g. `forward@tenant.example.com`). Users forward emails into that address from their own client. | The user's *own real mailbox* (Gmail, Microsoft 365, IMAP). Polled by the hub on the user's behalf. |
+| **Intent** | "Extract structured actions from this forwarded email via LLM and propose them to a human for approval." Workflow / action-proposal pipeline. | "Show me my external conversations alongside WhatsApp/Slack/etc. in my unified inbox so I can reply." Conversational inbox. |
+| **Storage destination** | `inbox_ops`'s own entities (proposals, actions, replies). Not threaded into the `messages` inbox. | The hub's `MessageChannelLink` + the `messages` module's threaded inbox. First-class inbox citizens. |
+| **Events** | `inbox_ops.email.received/.processed/.failed/.reprocessed/.deduplicated`, `inbox_ops.proposal.*`, `inbox_ops.action.*`, `inbox_ops.reply.sent` — all `inbox_ops.*` namespace. | `communication_channels.message.received/.sent/.delivery_failed/.reaction.added` — hub events, channel-agnostic. |
+| **Outbound** | Reply-send via Resend (the inbox_ops "reply" path). | Outbound through the user's own mailbox (Gmail send / Graph sendMail / SMTP). |
+| **AI** | Yes — LLM-driven action extraction is the core feature. | No — v1 is plain conversational. (Future AI features would subscribe to `communication_channels.message.received` and live in a separate AI module.) |
+
+**Concrete decisions for this spec:**
+
+1. **This spec does NOT deprecate `inbox_ops`.** Both modules remain enabled. Both keep their event streams. `inbox_ops.email.*` events continue to fire when emails arrive at the forwarding Resend inbox; `communication_channels.message.received` fires when emails arrive in a user's connected mailbox.
+2. **This spec does NOT subscribe to `inbox_ops.email.*` or vice versa.** They are independent pipelines.
+3. **A user who has both a connected Gmail (via this spec) and forwards mail to the tenant's inbox_ops address** can legitimately see the same email surface in two places — the *unified inbox* (because they sent it from their Gmail, which the hub polled) and *inbox_ops* (because they forwarded it for action extraction). This is expected user behavior: forwarding is an explicit user action that signals "I want this processed by AI", not a duplicate signal.
+4. **Future CRM bridge.** When CRM subscribes to `communication_channels.message.received`, it gets channel-agnostic external messages. If CRM also wants action-proposal flow on top of forwarded mail, it subscribes separately to `inbox_ops.proposal.*`. They don't need to be reconciled at the CRM layer either — the intents are different.
+5. **Documentation note.** Each provider package's README and the hub's per-user-channels doc must explicitly say "this is for connecting your own mailbox; if you want to forward random emails into the platform's AI agent for action extraction, see `inbox_ops`." Prevents the most likely user confusion.
+
+### Hub deltas required by this spec
+
+All deltas are **additive** against SPEC-045d. No removal, no rename, no type narrowing.
+
+#### Delta 1 — `CommunicationChannel.user_id?: string` (nullable UUID column)
+- NULL = tenant-scoped channel (existing behavior, e.g., WhatsApp Business — unchanged).
+- Set = user-scoped channel (e.g., Jane's Gmail). Visible only to the owning user and to admins with `communication_channels.admin`.
+- New partial unique index: `UNIQUE (user_id) WHERE is_primary AND user_id IS NOT NULL AND deleted_at IS NULL` (at most one primary per user).
+- Migration is additive; existing rows have `user_id = NULL`.
+- **Module boundary:** the column is a UUID storing the owning user's id but is **not declared as a database `FOREIGN KEY` to `users(id)`**. Root `AGENTS.md` forbids direct ORM relationships between modules. The cross-module link is declared instead via `EntityExtension` in `packages/core/src/modules/communication_channels/data/extensions.ts` (`{ from: 'communication_channels:communication_channel', field: 'user_id', to: 'auth:user', kind: 'one-to-one-optional' }`). Lookups across the link use the data engine, not raw joins.
+
+#### Delta 2 — Polling + per-channel status columns on `CommunicationChannel`
+- `poll_interval_seconds INTEGER NULL` — NULL means "this channel does not poll" (push-only providers — unchanged behavior). Set means hub-managed polling at that interval.
+- `last_polled_at TIMESTAMPTZ NULL` — last successful poll timestamp; scheduler enumerates by this.
+- `status TEXT NOT NULL DEFAULT 'connected'` — per-channel lifecycle state: `connected | requires_reauth | error | disconnected`. Existing `is_active` remains for the broader admin enable/disable toggle; `status` is finer-grained operational state. Migration sets `status = 'connected'` for all existing active channels.
+- `last_error TEXT NULL` — most recent classified error message for diagnostics.
+- `is_primary BOOLEAN NOT NULL DEFAULT FALSE` — per-user primary flag (only meaningful when `user_id IS NOT NULL`; ignored for tenant-scoped channels). Partial unique index enforced in Delta 1.
+- Index: `(is_active, last_polled_at)` for the scheduler's enumeration query.
+
+#### Delta 3 — `ChannelCapabilities.realtimePush?: boolean` (optional, default `true` for BC)
+- Existing providers (WhatsApp, Slack) omit this field; treated as `true`.
+- Email providers set `realtimePush: false` → hub schedules polling.
+
+#### Delta 4 — `ChannelAdapter.refreshCredentials?(input): Promise<RefreshedCredentials>` (optional)
+- For OAuth providers: hub calls this when a token is within 60s of expiry (or on 401 from a provider call). Adapter exchanges the refresh token for a new access token and returns the updated credential blob.
+- IMAP/SMTP adapter omits this method (basic auth has no refresh).
+
+#### Delta 5 — `IntegrationCredentials.user_id?: string` (nullable UUID column)
+- Mirrors the channel column. Per-user secrets isolated by app-layer `WHERE user_id = currentUser.id OR user_id IS NULL`.
+- Defense in depth: a mutation guard on `integration_credentials.read` blocks any query that does not include this filter unless the caller has `integrations.admin`.
+- **Module boundary:** `integration_credentials` is owned by the `integrations` module. The hub does **not** add a `FOREIGN KEY` from the integrations table to `users(id)`. The cross-module link is declared via `EntityExtension` in `packages/core/src/modules/communication_channels/data/extensions.ts` (`{ from: 'integrations:integration_credential', field: 'user_id', to: 'auth:user', kind: 'one-to-one-optional' }`). The integrations module owns the schema migration that adds the column (coordinated PR); the hub spec owns the link declaration. Both PRs land together.
+
+#### Delta 6 — Hub poll-channel worker
+```ts
+// packages/core/src/modules/communication_channels/workers/poll-channel.ts
+export const metadata = { queue: 'communication-channels-poll', concurrency: 10 }
+
+export default async function pollChannelWorker(job: { channelId: string }) {
+  // 1. Load channel + adapter + credentials
+  // 2. If channel.is_active === false or status !== 'connected' → skip
+  // 3. If adapter.capabilities.realtimePush !== false → skip (provider doesn't want polling)
+  // 4. If adapter.refreshCredentials && tokenExpiresAt < now + 60s → refresh + persist
+  // 5. result = await adapter.fetchHistory({ channelId, credentials, since: last_polled_at })
+  // 6. For each NormalizedInboundMessage in result.messages:
+  //     dispatch existing hub inbound-processor (idempotent on externalMessageId)
+  // 7. UPDATE communication_channels SET last_polled_at = NOW() WHERE id = $1
+  // 8. On error: classify (auth 401 → markRequiresReauth; 429 → reschedule per Retry-After;
+  //    5xx/transient → retry 3× with backoff; persistent → status='error', backoff to ceiling)
+}
+```
+
+Cron tick (every 60s, single hub-internal job):
+- `SELECT id FROM communication_channels WHERE is_active = true AND last_polled_at + poll_interval_seconds * interval '1 sec' <= NOW() ORDER BY last_polled_at NULLS FIRST LIMIT 500`
+- Enqueue `poll-channel` jobs.
+- Bounded enumeration (LIMIT 500) prevents fanout spikes; remaining channels picked up next tick.
+
+**Scheduler mechanism**: register the tick via the existing `@open-mercato/scheduler` workspace package (the platform's canonical cron home). The hub declares one scheduled job in `packages/core/src/modules/communication_channels/schedulers/poll-tick.ts` exporting `{ id: 'communication_channels.poll-tick', cron: '* * * * *', handler }`. The handler runs the enumeration query and enqueues per-channel jobs onto the `communication-channels-poll` queue. Do **not** use `setInterval` in a worker process, BullMQ repeatable jobs directly, or any ad-hoc timer — `packages/scheduler` is the project convention.
+
+Tick interval is configurable via `OM_HUB_POLL_SCHEDULER_TICK_SECONDS` (default 60). The scheduler tick budget is independent of per-channel `poll_interval_seconds`: a 60s tick + 300s default per-channel interval means each channel polls about every 5 minutes, with one query-and-fanout per minute regardless of how many channels exist.
+
+#### Delta 7 — Hub OAuth callback infrastructure
+- `GET /api/communication_channels/oauth/[provider]/callback` — generic state-cookie validation + adapter delegation. Already implied by SPEC-045d but no concrete route exists in code. This spec ships the canonical implementation.
+- `POST /api/communication_channels/oauth/[provider]/initiate` — returns `{ authorizeUrl }` after setting state cookie. Adapter provides `buildAuthorizeUrl()`.
+
+#### Delta 8 — Per-user channel ACL gates
+- Existing hub features (`communication_channels.view`, `communication_channels.manage`, `communication_channels.admin`) are extended at the **service layer** (not feature-ID layer) to enforce: a non-admin can only `view`/`manage` channels where `user_id = currentUser.id OR user_id IS NULL`.
+- New feature ID `communication_channels.connect_user_channel` (default-granted to all roles via `setup.ts`) gates the per-user "Connect My Account" flow. This is split from `manage` so policy can disable new linking while preserving existing accounts.
+
+#### Delta 9 — Notification type `channel_requires_reauth`
+- Generic across channel types (not email-specific). Emitted by `markRequiresReauth` command.
+- Renderer in hub's `notifications.client.ts` shows `<Alert variant="warning">` with channel name, provider, and a "Reconnect" CTA that opens the appropriate provider's reconnect flow.
+
+### ChannelAdapter implementation — common pattern
+
+Each provider package implements the `ChannelAdapter` v2 interface from SPEC-045d. The contract is reproduced here for reviewer convenience; SPEC-045d is the canonical source.
 
 ```ts
-// packages/core/src/modules/email/lib/provider.ts
-export interface EmailProvider {
-  readonly id: 'gmail' | 'microsoft' | 'imap'
-  readonly label: string
-  readonly authStyle: 'oauth2' | 'credentials'
-  readonly capabilities: ProviderCapabilities
+// Provider implementation skeleton (gmail / microsoft / imap parallel)
+export const gmailAdapter: ChannelAdapter = {
+  providerKey: 'gmail',
+  channelType: 'email',
+  capabilities: gmailCapabilities,  // imports realtimePush: false
 
-  // OAuth-only
-  buildAuthorizeUrl?(args: { state: string; redirectUri: string; loginHint?: string }): string
-  exchangeCode?(args: { code: string; redirectUri: string }): Promise<OAuthTokens>
-  refreshAccessToken?(args: { refreshToken: string }): Promise<OAuthTokens>
+  async sendMessage(input)         { return sendViaGmail(input) },
+  async verifyWebhook(input)       { throw new Error('Gmail v1 is polling-only') },  // never called
+  async getStatus(input)           { return getDeliveryStatus(input) },              // best-effort
+  async convertOutbound(input)     { return mimeFromMessage(input) },                // RFC2822 builder
+  async normalizeInbound(raw)      { return parseMime(raw) },                        // mailparser → NormalizedInboundMessage
+  async fetchHistory(input)        { return gmailHistorySync(input) },               // gmail.users.history.list
+  async resolveContact(input)      { return lookupCrmByEmail(input.from) },          // optional
 
-  // Credentials-only
-  validateCredentials?(input: unknown): Promise<{
-    ok: boolean
-    emailAddress: string
-    capabilities: ProviderCapabilities
-    errors?: Record<string, string>
-  }>
-
-  // All providers
-  healthCheck(args: { accountId: string; credentials: ResolvedCredentials }): Promise<HealthCheckResult>
-  fetchSince(args: { accountId: string; credentials: ResolvedCredentials; cursor: SyncCursor | null; limit: number }): Promise<FetchResult>
-  sendMessage(args: { accountId: string; credentials: ResolvedCredentials; message: OutboundMessage }): Promise<SendResult>
-}
-
-export type FetchResult = {
-  messages: CanonicalMessage[]
-  nextCursor: SyncCursor
-  hasMore: boolean
-}
-
-export type SendResult = {
-  providerMessageId: string
-  providerThreadId: string | null
-  sentAt: Date
-  providerMeta: ProviderMetaUnion
+  // OAuth-only providers implement refreshCredentials
+  async refreshCredentials(input)  { return googleRefresh(input.credentials) },
 }
 ```
 
-### Canonical Message (the event payload contract)
+Capabilities differ per provider:
 
-```ts
-// packages/core/src/modules/email/lib/canonical-message.ts
-export type CanonicalMessage = {
-  providerMessageId: string
-  providerThreadId: string | null
-  direction: 'inbound' | 'outbound'
-  from: EmailAddress
-  to: EmailAddress[]
-  cc: EmailAddress[]
-  bcc: EmailAddress[]
-  replyTo: EmailAddress[]
-  subject: string
-  snippet: string                   // ≤200 chars
-  inReplyTo: string | null          // RFC 5322 Message-Id of parent
-  references: string[]              // full thread chain
-  sentAt: Date
-  receivedAt: Date | null
-  headers: Record<string, string>   // raw RFC822 headers, lowercased keys
-  bodyRef: BodyRef                  // opaque pointer; body NOT in payload (v1)
-  providerMeta: ProviderMetaUnion   // discriminated union
-}
-
-export type BodyRef =
-  | { provider: 'gmail'; gmailId: string; mimeType: string }
-  | { provider: 'microsoft'; graphId: string }
-  | { provider: 'imap'; uidValidity: number; uid: number; folder: string }
-
-export type ProviderMetaUnion =
-  | { provider: 'gmail'; data: GmailProviderMeta }
-  | { provider: 'microsoft'; data: OutlookProviderMeta }
-  | { provider: 'imap'; data: ImapProviderMeta }
-```
-
-A future `fetchBody(bodyRef, accountId)` helper (out of scope for v1) will resolve `bodyRef` back to the provider for on-demand body fetch when the CRM spec or an inbox UI needs it.
-
-### OAuth Flow
-
-```
-1. User: clicks "Connect Gmail" on /backend/profile/email-accounts
-   → client POST /api/email/accounts/connect/gmail
-2. Server:
-   - Verifies session + email.account.connect feature
-   - Resolves OAuth app credentials (tenant Marketplace > platform env)
-   - Generates 32-byte random state
-   - Encrypts state payload { nonce, userId, providerId, iat, exp } via state-cookie helper (AES-256-GCM + HKDF, 5-min TTL)
-   - Sets HttpOnly SameSite=Lax cookie 'om_email_oauth_state'
-   - Returns { authorizeUrl } in JSON
-3. Client: window.location = authorizeUrl
-4. Google: user consents, redirects back to GET /api/email/oauth/gmail/callback?code=...&state=...
-5. Callback handler:
-   a. Reads state cookie, validates signature + TTL + userId-matches-session + providerId-matches-route
-   b. Deletes the state cookie
-   c. provider.exchangeCode({ code, redirectUri }) → OAuthTokens
-   d. Dispatches command: email.account.connect { userId, providerId, emailAddress, tokens }
-   e. Command creates EmailAccount + EmailAccountCredential, marks isPrimary if first account, emits email.account.connected event
-   f. Enqueues initial poll-account job
-   g. 302 redirect to /backend/profile/email-accounts?flash=connected
-```
-
-### IMAP Connection Flow
-
-```
-1. User submits IMAP credential form (CrudForm dialog)
-   POST /api/email/accounts/connect/imap { displayName, imapHost, imapPort, imapTls, imapUser, imapPassword,
-                                            smtpHost, smtpPort, smtpTls, smtpUser, smtpPassword }
-2. provider.validateCredentials probes both IMAP login and SMTP login
-3. On success: dispatch email.account.connect command (same as OAuth path from step 4d)
-4. On failure: throw createCrudFormError with field-level errors
-```
-
-### Send Pipeline
-
-```
-Public API: import { sendAsUser } from '@open-mercato/core/modules/email/lib/send-pipeline'
-
-sendAsUser({ accountId, message }) →
-  1. Resolve EmailAccount; verify currentUser owns accountId; verify status='connected'
-  2. Resolve EmailAccountCredential via findOneWithDecryption
-  3. If OAuth and tokenExpiresAt < now + 60s:
-     - provider.refreshAccessToken; persist new tokens (via command email.account.refresh_token)
-  4. Dispatch command: email.message.send { accountId, message }
-  5. Command: provider.sendMessage(...); upsert EmailMessageEnvelope (direction='outbound'); emit email.message.sent
-  6. Return SendResult to caller
-  7. On provider error: classify (auth | rate-limit | transient | persistent), log EmailHealthLog,
-     throw typed EmailSendError; transient errors retried once internally before throwing
-```
-
-### Receive Pipeline
-
-```
-Cron (every 60s): enumerates EmailAccount rows where status='connected' and
-                  last_polled_at + poll_interval ≤ now; enqueues poll-account jobs.
-                  Backed by index (status, last_polled_at) — single indexed scan per tick,
-                  no N+1. Enumeration capped at 500 rows per tick to bound enqueue burst;
-                  remaining accounts picked up next tick.
-
-Worker queue 'email-sync', concurrency 10 (I/O-bound).
-
-poll-account worker:
-  1. Load EmailAccount + EmailAccountCredential + EmailSyncCursor (folder='INBOX')
-  2. If status !== 'connected' → skip
-  3. Refresh OAuth token if needed (same logic as send)
-  4. provider.fetchSince({ cursor, limit=100 }) → FetchResult
-  5. Persist new cursor + last_polled_at in single transaction
-  6. For each message:
-     - Dispatch command: email.message.ingest { canonicalMessage, accountId }
-     - Command upserts EmailMessageEnvelope (rolling cap 200) + emits email.message.received
-  7. If hasMore=true → re-enqueue immediately (drain mode)
-  8. On error: classify
-     - 401/invalid_grant      → command: email.account.mark_requires_reauth (status, notification)
-     - 429 + Retry-After      → reschedule per header, no status change
-     - 5xx / network          → retry up to 3× with backoff, then warning log, no status change
-     - cursor-invalid (e.g., Gmail history_id_too_old) → reset cursor to "now", emit email.account.error (severity=info)
-     - persistent other       → status='error', exponential backoff (5→10→20→60 min, max 60)
-```
-
-### Commands & Events
-
-Following the AGENTS.md command pattern (`packages/core/src/modules/customers/commands/*` reference):
-
-| Command | Payload | State Change | Undo |
+| Capability | Gmail | Microsoft | IMAP |
 |---|---|---|---|
-| `email.account.connect` | `{ userId, providerId, emailAddress, credentialBlob }` | Insert EmailAccount + EmailAccountCredential; set isPrimary if first; emit `email.account.connected` | `email.account.disconnect` |
-| `email.account.disconnect` | `{ accountId }` | Soft-delete EmailAccount; hard-purge EmailAccountCredential; halt poll worker; emit `email.account.disconnected` | None (credentials lost on purge — user reconnects) |
-| `email.account.set_primary` | `{ accountId }` | Clear isPrimary on user's other accounts; set on this one | Set previous primary back |
-| `email.account.rename` | `{ accountId, displayName }` | Update displayName | Restore previous displayName |
-| `email.account.update_imap_credentials` | `{ accountId, credentialBlob }` | Replace EmailAccountCredential; set status='connected' | Restore previous (kept in-memory during txn) |
-| `email.account.refresh_token` | `{ accountId, tokens }` | Update accessToken + tokenExpiresAt | None (token refresh has no business undo) |
-| `email.account.mark_requires_reauth` | `{ accountId, reason }` | Set status='requires_reauth'; create EmailHealthLog; emit notification | Auto-reverted when user reconnects |
-| `email.message.send` | `{ accountId, message }` | Provider sendMessage; upsert outbound EmailMessageEnvelope; emit `email.message.sent` | None — emails cannot be unsent. Local envelope can be deleted but the email is already at the recipient. |
-| `email.message.ingest` | `{ accountId, canonicalMessage }` | Upsert inbound EmailMessageEnvelope (idempotent on `(account_id, provider_message_id)`); emit `email.message.received` | Delete envelope; CRM-spec subscribers must handle reversal. |
+| `threading` | true (gmail threadId + RFC2822) | true (Graph conversationId + RFC2822) | true (RFC2822 only) |
+| `richText` | true (HTML body) | true (HTML body) | true (HTML body) |
+| `fileSharing` | true (max 25 MB) | true (max 25 MB) | true (depends on server, default 25 MB) |
+| `reactions` | false | false | false |
+| `editMessage` | false | false | false |
+| `deleteMessage` | false | false | false |
+| `conversationHistory` | true (History API) | true (Graph delta) | true (UIDVALIDITY + UIDNEXT) |
+| `realtimePush` | false (v1) | false (v1) | false (v1) |
+| `supportedBodyFormats` | `['text','html']` | `['text','html']` | `['text','html']` |
 
-Events (`packages/core/src/modules/email/events.ts`) — follows the canonical shape used by every other module (compare `packages/core/src/modules/inbox_ops/events.ts`, `packages/core/src/modules/customers/events.ts`):
+### Inbound flow (polling-based)
 
-```ts
-import { createModuleEvents } from '@open-mercato/shared/modules/events'
-import type { EventPayload } from '@open-mercato/shared/modules/events'
-import type { CanonicalMessage } from './lib/canonical-message'
+Reuses SPEC-045d §6 inbound flow with polling as the upstream source:
 
-// Payload type aliases — enforced via TS generics at emit sites, NOT stored on the EventDefinition.
-export type AccountConnectedPayload = EventPayload & {
-  accountId: string
-  userId: string
-  providerId: 'gmail' | 'microsoft' | 'imap'
-  emailAddress: string
-}
-export type AccountDisconnectedPayload = EventPayload & {
-  accountId: string
-  userId: string
-  providerId: 'gmail' | 'microsoft' | 'imap'
-}
-export type AccountRequiresReauthPayload = EventPayload & {
-  accountId: string
-  userId: string
-  providerId: 'gmail' | 'microsoft' | 'imap'
-  reason: string
-}
-export type AccountErrorPayload = EventPayload & {
-  accountId: string
-  userId: string
-  providerId: 'gmail' | 'microsoft' | 'imap'
-  severity: 'info' | 'warning' | 'error'
-  kind: string
-}
-export type MessageReceivedPayload = EventPayload & {
-  accountId: string
-  message: CanonicalMessage
-}
-export type MessageSentPayload = EventPayload & {
-  accountId: string
-  message: CanonicalMessage
-}
-
-const events = [
-  { id: 'email.account.connected',       label: 'Email account connected',       entity: 'account', category: 'crud',      clientBroadcast: true  },
-  { id: 'email.account.disconnected',    label: 'Email account disconnected',    entity: 'account', category: 'crud',      clientBroadcast: true  },
-  { id: 'email.account.requires_reauth', label: 'Email account requires reauth', entity: 'account', category: 'lifecycle', clientBroadcast: true  },
-  { id: 'email.account.error',           label: 'Email account error',           entity: 'account', category: 'lifecycle', clientBroadcast: true  },
-  { id: 'email.message.received',        label: 'Email message received',        entity: 'message', category: 'custom',    clientBroadcast: false }, // body NOT in payload
-  { id: 'email.message.sent',            label: 'Email message sent',            entity: 'message', category: 'custom',    clientBroadcast: true  },
-] as const
-
-export const eventsConfig = createModuleEvents({ moduleId: 'email', events })
-export const emitEmailEvent = eventsConfig.emit
-export type EmailEventId = typeof events[number]['id']
-export default eventsConfig
+```
+Hub cron (60s tick)
+  ↓
+SELECT channels needing poll
+  ↓
+Enqueue communication-channels-poll job per channel
+  ↓
+poll-channel worker
+  • adapter.refreshCredentials? if OAuth and near expiry
+  • adapter.fetchHistory(channelId, credentials, since: last_polled_at)
+  ↓ result.messages: NormalizedInboundMessage[]
+For each message → dispatch inbound-processor (existing SPEC-045d worker)
+  ↓
+inbound-processor (existing hub logic, unchanged by this spec):
+  • Dedup by (channel_id, external_message_id)
+  • Resolve ChannelThreadMapping (RFC2822 Message-ID/In-Reply-To/References lookup)
+  • Create or reuse Message thread in messages module
+  • Create Message (type: 'channel.email', body from normalized text/html)
+  • Create MessageChannelLink (channelPayload: full MIME, channelContentType: 'email/mime',
+                                 channelMetadata: { messageId, inReplyTo, references, from, to, cc, bcc })
+  • Create ExternalMessage (direction='inbound')
+  • adapter.resolveContact? → ExternalConversation.contactPersonId
+  • Emit communication_channels.message.received
+  ↓
+Messages inbox + UMES enrichers update in real-time (clientBroadcast: true)
 ```
 
-Persistence is declared per-subscriber via `metadata: { event, persistent: true }` — not on the event definition. Every CRM-facing subscriber that must survive restarts MUST set `persistent: true`. Example subscriber skeleton:
+### Outbound flow (send-as-user)
 
-```ts
-// packages/core/src/modules/email/subscribers/log-message-received.ts
-export const metadata = {
-  event: 'email.message.received',
-  persistent: true,
-  id: 'email.log-message-received',
-}
+#### Path A — User composes a Message in the inbox UI (standard hub outbound flow):
 
-export default async function handle(payload: MessageReceivedPayload) {
-  // ...
-}
+```
+User composes Message via /backend/messages
+  ↓ POST /api/messages
+  ↓ Message created (type: channel.email, with threadId/parentMessageId/channel routing metadata)
+  ↓ messages.message.sent event fires
+  ↓
+Hub subscriber (outbound-delivery, existing SPEC-045d):
+  • Re-fetch Message by messageId (do NOT depend on event payload shape)
+  • Resolve ChannelThreadMapping by message.threadId
+  • Load channel + adapter + credentials
+  • adapter.refreshCredentials? if OAuth + near expiry
+  • adapter.convertOutbound({ body, bodyFormat, attachments, channelMetadata }) → MIME
+  • adapter.sendMessage(converted)
+  • Create ExternalMessage + MessageChannelLink (direction='outbound')
+  • Emit communication_channels.message.sent
 ```
 
-`clientBroadcast: false` on `email.message.received` for v1 — no real-time browser fanout for inbound (privacy + volume); CRM spec decides whether to enable later. Note also the cross-process bridge constraint (`.ai/lessons.md` → "Browser SSE bridges must work across worker and web processes"): worker-emitted events do NOT reach the in-process SSE tap. v1 sidesteps this with `clientBroadcast: false`. Any future flip to `true` MUST be paired with the cross-process bridge work.
+**Subscriber contract — no payload coupling.** The hub's outbound-delivery subscriber receives `messages.message.sent` with whatever payload the messages module defines (today: a minimal `{ messageId, threadId?, sentBy, ... }`-style shape). The subscriber **re-fetches the Message row by `messageId`** and reads channel-routing metadata from there. This decouples the hub from any future payload-shape changes in the messages module and keeps the BC contract one-way: the messages module owns its payload; the hub adapts to whatever it emits. If the Message has no associated `ChannelThreadMapping`, the subscriber is a no-op (this is just an internal-only message, not channel-bound).
 
-### Access Control (`acl.ts` and `setup.ts`)
-
-Five ACL features, all new (greenfield namespace — confirmed no collisions). Feature naming follows the root `AGENTS.md` rule `<module>.<entity>.<action>` (or `<module>.<action>` for module-wide capabilities).
+#### Path B — Programmatic `sendAsUser` facade (workflows, AI tools, integrations):
 
 ```ts
-// packages/core/src/modules/email/acl.ts
-import type { ModuleFeature } from '@open-mercato/shared/lib/auth/acl'
+import { sendAsUser } from '@open-mercato/core/modules/communication_channels/lib/send-as-user'
 
-export const features: ModuleFeature[] = [
-  { id: 'email.account.connect', title: 'Connect own email account',          module: 'email' },
-  { id: 'email.account.manage',  title: 'Manage own email accounts',          module: 'email' },
-  { id: 'email.send',            title: 'Send email as own connected account', module: 'email' },
-  { id: 'email.admin',           title: 'Administer tenant email integrations', module: 'email' },
-  { id: 'email.admin.providers', title: 'Configure tenant OAuth provider apps', module: 'email' },
-]
+await sendAsUser({
+  userChannelId,                  // FK to CommunicationChannel where user_id = currentUser.id
+  to: ['customer@example.com'],
+  cc?: [...],
+  bcc?: [...],
+  subject: '...',
+  body: { plain?: '...', html?: '...' },
+  attachments?: AttachmentRef[],  // discriminated union (see API Contracts)
+  inReplyTo?: '<previous-message-id@example.com>',
+  references?: ['<...>', '<...>'],
+})
+// Internally: validates user owns userChannelId, creates Message with right routing metadata,
+// which triggers Path A's subscriber. Returns { messageId, externalMessageId, providerThreadId, sentAt }.
 ```
 
-Default role grants in `setup.ts` mirror the features array and are propagated to existing tenants via `yarn mercato auth sync-role-acls`:
+There is exactly **one send path**. The facade is a typed wrapper around the standard Message creation API.
 
-```ts
-// packages/core/src/modules/email/setup.ts
-import type { ModuleSetupConfig } from '@open-mercato/shared/modules/setup'
+### UMES extension surface (the 17 hooks)
 
-export const setup: ModuleSetupConfig = {
-  defaultRoleFeatures: {
-    admin:   ['email.account.connect', 'email.account.manage', 'email.send', 'email.admin', 'email.admin.providers'],
-    manager: ['email.account.connect', 'email.account.manage', 'email.send'],
-    user:    ['email.account.connect', 'email.account.manage', 'email.send'],
-  },
-  // onTenantCreated / seedDefaults / seedExamples not required for v1
-}
-```
+Provider packages and the hub use UMES per SPEC-041 to compose UI, data, and behavior without modifying core hub pages.
 
-Notes:
-- `email.account.connect` and `email.account.manage` are split intentionally — `connect` gates the initial OAuth/IMAP linking flow; `manage` gates rename/set-primary/disconnect on already-linked accounts. This lets future tenant policies disable new linking while preserving existing accounts.
-- `email.admin` covers the read-only admin view (account list, health log). `email.admin.providers` is the higher-privilege capability needed to write tenant-level OAuth client credentials. Default role map only grants this to `admin`.
-- `email.send` is required by the bespoke `POST /api/email/send` route AND by any future workflow/AI tool that calls `sendAsUser(...)` programmatically.
-- No customer-portal roles are touched — the v1 UI lives entirely under `/backend/...`.
+#### Per provider (declared in each provider's package)
 
-After implementing `acl.ts` and `setup.ts`, run `yarn mercato auth sync-role-acls` so existing tenants receive the new feature grants on the appropriate roles.
+1. **Widget injection — `profile:tabs`** (Phase B): "Connect Gmail" / "Connect Microsoft" / "Connect IMAP" tab/CTA in the per-user `/backend/profile/communication-channels` page. Each provider injects its own connect widget.
+2. **Widget injection — `admin.page:integrations:<provider>:oauth-config`** (Phase A): OAuth client_id / client_secret form for Gmail and Microsoft. Tenant-level override of platform defaults. IMAP provider injects an "enabled/disabled" toggle (no OAuth config).
+3. **Widget injection — `data-table:communication_channels:channels:columns`** (Phase F): provider-specific status columns. Gmail injects "Gmail labels filter" column; IMAP injects "Folder" column.
+4. **Widget injection — `data-table:messages:columns`** (Phase F): channel-type badge column (hub-side, but each provider supplies its icon + tint via per-provider widget registration so the hub doesn't need to know about provider visuals).
+5. **Widget injection — `messages:thread:detail:rich-content`** (Phase A): when `MessageChannelLink.channelContentType === 'email/mime'`, render To/Cc/Bcc, attachments list, original headers, "Reply / Reply All / Forward" actions. Provider-agnostic widget lives in hub; per-provider provider-specific tweaks (Gmail's labels chip, Outlook's category) injected by each provider.
+6. **CrudForm field injection — `crud-form:communication_channels.channel:fields:<provider>`** (Phase G): per-provider credential fields. IMAP injects host/port/TLS/user/password (×2 for SMTP), plus the security-ack checkbox. Gmail / Microsoft inject scope selectors and login_hint.
+7. **Response enricher — `_email` namespace on `Message`** (Phase D): parse and expose `From`, `To`, `Cc`, `Bcc`, `Subject`, attachment list, original `Message-ID`, `In-Reply-To`, threading chain. Triggered when `MessageChannelLink.channelContentType.startsWith('email/')`. Batched via `enrichMany` to avoid N+1.
+8. **Response enricher — `_channel_health` on `CommunicationChannel`** (Phase D): provider-computed `tokenExpiresAt`, `lastSuccessfulPoll`, `errorCount24h`. Per-provider implementation; hub aggregates.
+9. **API interceptor — `before` on `POST /api/messages`** (Phase E): when message routes to a `channel_<provider>` channel, validate the caller owns the channel and the channel status is `connected`. Returns 409 `CHANNEL_NOT_AVAILABLE` if not. Defense in depth on top of the standard hub guard.
+10. **API interceptor — `after` on `GET /api/communication_channels`** (Phase E): apply `WHERE user_id = currentUser.id OR user_id IS NULL` filter at the response layer (belt + suspenders with the SQL-level filter). Hub-side, not per-provider.
+11. **Component replacement — `wrapper` on `MessagesThreadDetailHeader`** (Phase H): when channel type is `email`, wrap with a subcomponent that surfaces the email subject and threading status. Hub-side wrapper; per-provider overrides via `props` mode where useful (e.g., Gmail's "Important" badge).
+12. **Mutation guard — `communication_channels.channel.delete`** (Phase M): block disconnect if the channel has unread inbound messages or pending outbound retries in the last 5 minutes, unless `force: true` is passed. Hub-side guard; provider-agnostic.
+13. **Mutation guard — `messages.message.create` when target channel status is not `connected`** (Phase M): block with 409. Per-provider error message via i18n.
+14. **Sync event subscriber — `auth.user.deleted`** (Phase M): cascade-soft-delete all user-owned channels for that user. Hub-side subscriber.
+15. **Notification handler — `useNotificationEffect` on `channel_requires_reauth`** (`packages/core/.../notifications.handlers.ts`): if the user is currently on `/backend/profile/communication-channels` when the notification arrives, auto-open the reconnect dialog for the affected channel. Hub-side.
+16. **Command interceptor — `beforeUndo` on `channel.disconnect`** (Phase M): fail loudly because credentials were purged at disconnect — undo is not possible. Hub-side, consistent with other destructive hub commands.
+17. **Custom fields / Entity extensions** (existing): per-channel custom fields per provider (e.g., "Default signature", "Auto-reply", "Default Gmail label") declared in each provider's `ce.ts`. `EntityExtension` from each provider to `CommunicationChannel` for any per-provider metadata that doesn't fit in capabilities.
+
+UMES coverage check:
+- Phase A (widget injection): ✓
+- Phase B (menu injection): ✓ ("Communication Channels" added to user profile sidebar — hub-side menu injection contribution)
+- Phase C (events + DOM bridge): ✓ (the hub events `communication_channels.message.received/.sent/.delivery_failed/.reaction.added` have `clientBroadcast: true` and are consumed by UMES widgets via `useAppEvent`; cross-process bridge note in §"Risks" — see lessons.md "Browser SSE bridges must work across worker and web processes")
+- Phase D (response enrichers): ✓
+- Phase E (API interceptors): ✓
+- Phase F (DataTable extensions): ✓
+- Phase G (CrudForm fields): ✓
+- Phase H (component replacement): ✓
+- Phase I (detail page bindings): ✓ (via `useExtensibleDetail` in the channel detail page)
+- Phase J (recursive widgets): ✓ (provider's CrudForm-field widget can itself contain nested injection spots, e.g. IMAP's "advanced settings" collapsible)
+- Phase K (DevTools): N/A — provider packages don't add DevTools surface
+- Phase L (integration extensions): ✓ (wizard widgets on `/backend/integrations` for Gmail, Microsoft, IMAP)
+- Phase M (mutation lifecycle): ✓
+- Phase N (query engine extensibility): ✓ (the `_email` enricher participates in query-engine pipelines so search/filter on parsed headers works without N+1)
 
 ### Security Posture
 
-- **No HTML email rendering in v1.** Admin debug view shows envelopes only (subject, sender, snippet) as plain text via React (auto-escaped). No `dangerouslySetInnerHTML`, no inline `<svg>`, no raw HTML insertion anywhere. XSS surface is therefore N/A for v1.
-- **Snippet sanitization.** Even though snippets are rendered as text, provider-returned snippets are passed through a length-truncate to `≤200` chars before persistence; no other transformation.
-- **All persisted strings (subject, addresses, snippet, headers).** Stored verbatim from the provider; rendering paths use React's default text escaping. When the CRM spec adds body rendering, it MUST address HTML sanitization (DOMPurify or equivalent) before render — flagged for that spec.
-- **URL/header encoding.** OAuth authorize URLs are built via `URLSearchParams`; never via string concatenation. Inbound headers are stored as `Record<string, string>` with lowercased keys; no header value is ever interpolated into URLs or logs.
-- **Parameterized queries.** All DB access is via MikroORM `em.find` / `findOneWithDecryption` / query-builder — no raw SQL string interpolation anywhere in this spec.
+- **No HTML email rendering in raw `dangerouslySetInnerHTML` paths.** Inbound HTML stored verbatim in `MessageChannelLink.channelPayload`. **Canonical sanitizer location**: `packages/core/src/modules/communication_channels/lib/sanitize-channel-html.ts` (lives in the hub; ships as part of SPEC-045d delivery). The Messages module's rich-content renderer **imports** this helper at the call site (in the `messages:thread:detail:rich-content` widget injection). The hub owns the function; the Messages module owns the call site. Hub helper uses DOMPurify (or equivalent) with an allowlist tuned for email (`<a>`, `<img>`, `<table>`, `<tbody>`, `<tr>`, `<td>`, `<p>`, `<br>`, `<ul>`, `<ol>`, `<li>`, `<strong>`, `<em>`, `<blockquote>`; strips `<script>`, event-handler attributes, `javascript:` and `data:` URLs except `data:image/*`). Email is the first channel shipping HTML payloads — if SPEC-045d delivery does not include this sanitizer, **Phase 1 of this spec cannot ship** and the gap is escalated back to the hub's spec/PR.
+- **OAuth state-cookie**: AES-256-GCM encryption, HKDF key derivation, HttpOnly + SameSite=Lax cookie, 5-minute TTL, `userId` bound (callback rejects if `currentSession.userId !== state.userId`). Forgery requires the encryption key (KMS-managed).
+- **Credential storage**: hub's `integration_credentials` with field-level encryption (existing pipeline; no per-provider crypto). New `user_id` column isolates per-user secrets at the row level.
+- **Per-user channel privacy**: dual enforcement (SQL-level filter on every CRUD route + UMES API interceptor at response layer). Defense in depth.
+- **Credential-key rejection in logs**: hub's `EmailHealthLog` Zod validator (already present in SPEC-045d's design) rejects any context key matching `/^(credential|password|token|secret|access[_-]?token|refresh[_-]?token)/i`. Worker error handlers strip such keys from caught exceptions before logging.
+- **URL construction**: all OAuth authorize URLs built via `URLSearchParams`. Provider-base URLs validated against an allowlist (Google, Microsoft) — IMAP host/port validated as DNS-resolvable + numeric in range (lesson "Provider credentials must never control authenticated cross-origin requests").
+- **Parameterized queries**: all DB access via MikroORM repository methods or query builder; no raw SQL interpolation in route handlers (lesson "Keep raw SQL out of API route handlers").
+
+### Access Control (extends SPEC-045d's `acl.ts`)
+
+The hub already defines `communication_channels.view`, `communication_channels.manage`, `communication_channels.admin`. This spec adds one feature ID:
+
+```ts
+// packages/core/src/modules/communication_channels/acl.ts (extended)
+export const features: ModuleFeature[] = [
+  // ...existing SPEC-045d features...
+  { id: 'communication_channels.connect_user_channel',
+    title: 'Connect own communication channel',
+    module: 'communication_channels' },
+]
+```
+
+`setup.ts` default grants (mirroring SPEC-045d's pattern):
+
+```ts
+defaultRoleFeatures: {
+  admin:   ['communication_channels.view', 'communication_channels.manage',
+            'communication_channels.admin', 'communication_channels.connect_user_channel'],
+  manager: ['communication_channels.view', 'communication_channels.manage',
+            'communication_channels.connect_user_channel'],
+  user:    ['communication_channels.view', 'communication_channels.manage',
+            'communication_channels.connect_user_channel'],
+}
+```
+
+After implementation: `yarn mercato auth sync-role-acls` so existing tenants receive the new feature grant.
 
 ## Data Models
 
-All tables: `id` UUID primary key, `created_at` / `updated_at` timestamps, `organization_id` + `tenant_id` foreign keys (mandatory scoping per AGENTS.md), `deleted_at` for soft-delete where applicable.
+This spec adds **zero new tables**. All deltas are additive columns on existing hub tables.
 
-### EmailAccount (table `email_accounts`)
-One row per linked account, per user.
-- `id` UUID
-- `user_id` UUID (FK auth.users)
-- `provider_id` text — `'gmail' | 'microsoft' | 'imap'` (validated via DI provider registry)
-- `display_name` text — user-editable, defaults to emailAddress
-- `email_address` text — canonical address
-- `is_primary` boolean — exactly one true per user (enforced in `set_primary` command; partial unique index `(user_id) WHERE is_primary AND deleted_at IS NULL`)
-- `status` text — `'connected' | 'requires_reauth' | 'error' | 'disconnected'`
-- `last_error` text NULL
-- `last_polled_at` timestamptz NULL
-- `poll_interval_seconds` integer — default from `OM_EMAIL_POLL_INTERVAL_SECONDS`, per-account override allowed
-- `capabilities` jsonb — `{ canSend, canReceive, supportsThreading, supportsLabels, supportsCategories, supportsAttachmentsOnSend, maxAttachmentBytes }`
-- `organization_id`, `tenant_id`, `created_at`, `updated_at`, `deleted_at`
-- Indexes: `(user_id, deleted_at)`, `(tenant_id, provider_id, status)`, `(status, last_polled_at)` for the cron scheduler
+### `communication_channels` (extended)
 
-### EmailAccountCredential (table `email_account_credentials`)
-1:1 with EmailAccount. Credential blob is field-level encrypted.
-- `id` UUID
-- `email_account_id` UUID (FK, unique on `WHERE deleted_at IS NULL`)
-- `credential_blob` jsonb (ENCRYPTED — declared in `encryption.ts`)
-  - OAuth providers: `{ accessToken, refreshToken, tokenType: 'Bearer', expiresAt, scopes }`
-  - IMAP: `{ imapHost, imapPort, imapUser, imapPassword, imapTls, smtpHost, smtpPort, smtpUser, smtpPassword, smtpTls }`
-- `token_expires_at` timestamptz NULL (OAuth only; null for IMAP)
-- `scopes_granted` text[] NULL
-- `organization_id`, `tenant_id`, `created_at`, `updated_at`
+The migration is produced by `yarn db:generate` from the updated MikroORM entity in `packages/core/src/modules/communication_channels/data/entities.ts`. The SQL below is **illustrative**, showing the expected shape — do not hand-write it. Note especially that there is **no `REFERENCES users(id)` foreign key**; the cross-module link is declared via `EntityExtension` (see § Hub Deltas → Delta 1).
 
-### EmailSyncCursor (table `email_sync_cursors`)
-One row per account+folder. v1 only stores INBOX cursors.
-- `id` UUID
-- `email_account_id` UUID (FK)
-- `folder` text — default `'INBOX'`
-- `cursor` jsonb — opaque, provider-specific
-  - Gmail: `{ historyId: string }`
-  - Microsoft: `{ deltaLink: string }`
-  - IMAP: `{ uidValidity: number, uidNext: number }`
-- `status` text — `'ok' | 'error' | 'initializing'`
-- `last_synced_at` timestamptz NULL
-- `last_error` text NULL
-- `organization_id`, `tenant_id`, `created_at`, `updated_at`
-- Indexes: `(email_account_id, folder)` UNIQUE
+```sql
+-- Illustrative — generated by `yarn db:generate`
+ALTER TABLE communication_channels
+  ADD COLUMN user_id UUID NULL,                      -- linked to auth:user via EntityExtension, not raw FK
+  ADD COLUMN is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN poll_interval_seconds INTEGER NULL,
+  ADD COLUMN last_polled_at TIMESTAMPTZ NULL,
+  ADD COLUMN status TEXT NOT NULL DEFAULT 'connected',
+       -- 'connected' | 'requires_reauth' | 'error' | 'disconnected'
+  ADD COLUMN last_error TEXT NULL;
 
-### EmailHealthLog (table `email_health_logs`)
-Audit log. Daily worker purges entries older than `OM_EMAIL_HEALTH_LOG_RETENTION_DAYS` (default 90).
-- `id` UUID
-- `email_account_id` UUID (FK; nullable for tenant-level events)
-- `kind` text — `'health_check' | 'sync_error' | 'send_error' | 'oauth_refresh' | 'reauth_required' | 'cursor_reset'`
-- `severity` text — `'info' | 'warning' | 'error'`
-- `message` text
-- `context` jsonb
-- `organization_id`, `tenant_id`, `created_at`
-- Indexes: `(tenant_id, created_at DESC)`, `(email_account_id, created_at DESC)`, `(severity, created_at DESC)`
+CREATE UNIQUE INDEX communication_channels_one_primary_per_user
+  ON communication_channels (user_id)
+  WHERE is_primary AND user_id IS NOT NULL AND deleted_at IS NULL;
 
-### EmailMessageEnvelope (table `email_message_envelopes`)
-Rolling cache of last ~200 envelopes per account for the admin debug view ONLY. NOT a CRM data source. Purged by `purge-envelopes` worker daily.
-- `id` UUID
-- `email_account_id` UUID (FK)
-- `provider_message_id` text
-- `provider_thread_id` text NULL
-- `direction` text — `'inbound' | 'outbound'`
-- `subject` text
-- `from_address` text
-- `from_name` text NULL
-- `to_addresses` text[]
-- `snippet` text — ≤200 chars
-- `sent_at` timestamptz
-- `received_at` timestamptz NULL
-- `provider_meta` jsonb
-- `organization_id`, `tenant_id`, `created_at`
-- Indexes: `(email_account_id, provider_message_id)` UNIQUE, `(email_account_id, created_at DESC)` for cap-and-purge
+CREATE INDEX communication_channels_poll_due
+  ON communication_channels (is_active, last_polled_at)
+  WHERE deleted_at IS NULL;
 
-### Encryption Map (`packages/core/src/modules/email/encryption.ts`)
-
-```ts
-import type { ModuleEncryptionMap } from '@open-mercato/shared/modules/encryption'
-
-export const defaultEncryptionMaps: ModuleEncryptionMap[] = [
-  {
-    entityId: 'email:email_account_credential',
-    fields: [
-      { field: 'credential_blob' },
-    ],
-  },
-]
-
-export default defaultEncryptionMaps
+CREATE INDEX communication_channels_user_lookup
+  ON communication_channels (user_id, channel_type, deleted_at);
 ```
 
-Follows the canonical pattern used by every other module — see `packages/core/src/modules/messages/encryption.ts`, `packages/core/src/modules/integrations/encryption.ts`, etc. The `defaultEncryptionMaps` export is the convention enforced by `<module>/encryption.ts` (root `AGENTS.md` → Encryption). No `registerEntityEncryption(...)` symbol exists in `@open-mercato/shared`; previous draft was incorrect.
+### `integration_credentials` (extended)
 
-Reads use the 5-arg `findOneWithDecryption` helper:
+Owned by the `integrations` module; the column is added there in a coordinated PR (see § Hub Deltas → Delta 5). No raw FK to `users(id)`; the cross-module link is declared via `EntityExtension` in this hub's `data/extensions.ts`.
+
+```sql
+-- Illustrative — generated by `yarn db:generate` against integrations module entity
+ALTER TABLE integration_credentials
+  ADD COLUMN user_id UUID NULL;                      -- linked to auth:user via EntityExtension, not raw FK
+
+CREATE INDEX integration_credentials_user_lookup
+  ON integration_credentials (user_id) WHERE user_id IS NOT NULL;
+```
+
+### `data/extensions.ts` (hub module)
+
+The link declarations live with the hub (`packages/core/src/modules/communication_channels/data/extensions.ts`) so the dependency direction is hub → auth and hub → integrations, never the other way round:
+
+```ts
+import type { EntityExtension } from '@open-mercato/shared/modules/extensions'
+
+export const extensions: EntityExtension[] = [
+  {
+    from: 'communication_channels:communication_channel',
+    field: 'user_id',
+    to: 'auth:user',
+    kind: 'one-to-one-optional',
+  },
+  {
+    from: 'integrations:integration_credential',
+    field: 'user_id',
+    to: 'auth:user',
+    kind: 'one-to-one-optional',
+  },
+]
+```
+
+### Encryption (`packages/core/src/modules/communication_channels/encryption.ts`)
+
+The hub already encrypts `integration_credentials.credentials` (via the integrations module's `defaultEncryptionMaps`). This spec changes nothing in encryption maps; the new `user_id` column is not sensitive and is not encrypted.
+
+Reads continue to use the canonical helper:
 
 ```ts
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
-const credential = await findOneWithDecryption(
+const cred = await findOneWithDecryption(
   em,
-  'EmailAccountCredential',
-  { emailAccountId },
+  'IntegrationCredential',
+  { id: channel.credentialsRef, userId: currentUser.id },  // NEW: scope by user
   /* options */ undefined,
   /* scope */ { tenantId, organizationId },
 )
 ```
 
-The `credential_blob` column is the only sensitive payload (OAuth tokens or IMAP/SMTP passwords). It is never serialized in any API response by construction (separate DTO mapper, see `EmailAccountDto` in API Contracts). The `EmailHealthLog.context` validator rejects any key matching `/^(credential|password|token|secret)/i` so accidental leakage through logs is fail-closed (see Security Posture below).
-
 ## API Contracts
 
-All routes are auto-discovered. Every route file exports a per-method `metadata` object with `requireAuth: true` and `requireFeatures: [...]` (per `packages/core/AGENTS.md` API Routes rules — no top-level `export const requireAuth`). All write routes use `useGuardedMutation` from the UI side and `validateCrudMutationGuard` + `runCrudMutationGuardAfterSuccess` server-side for any non-`makeCrudRoute` mutation. All routes export `openApi`. Bodies validated via Zod schemas in `data/validators.ts`.
+All hub routes already exist in SPEC-045d (`GET /api/communication_channels/channels`, etc.) or were extended above. Only the **new** routes introduced by this spec are documented here. Each route file exports per-method `metadata` with `requireAuth` + `requireFeatures` (no top-level `export const requireAuth` — root `AGENTS.md` rule). All routes export `openApi`. Bodies validated via Zod schemas in `data/validators.ts`. CRUD routes use `makeCrudRoute({ indexer: { entityType: 'communication_channels:communication_channel' } })`; bespoke writes use `validateCrudMutationGuard` + `runCrudMutationGuardAfterSuccess`. Pagination: cursor-based, `limit ≤ 100`; health log uses keyset on `(created_at DESC, id DESC)`.
 
-**Pagination**: list endpoints (`GET /api/email/accounts`, `GET /api/email/admin/accounts`, `GET /api/email/admin/health-log`) accept `?cursor=<opaque>&limit=<n>` with `limit ≤ 100`. The health log uses keyset pagination on `(created_at DESC, id DESC)` to remain stable as new entries arrive. Account lists are small enough that simple cursor on `created_at` suffices.
+### Per-method `metadata` shape — canonical example
 
-**CRUD factory usage**: `GET /api/email/accounts`, `PATCH /api/email/accounts/[id]`, `DELETE /api/email/accounts/[id]`, `POST /api/email/admin/accounts` (list), and `POST /api/email/admin/health-log` (list) use `makeCrudRoute` with `indexer: { entityType: 'email:email_account' | 'email:email_health_log' }`. The OAuth initiation route, OAuth callback route, IMAP connect route, set-primary route, and send route are bespoke (they don't fit the CRUD shape) and each calls `validateCrudMutationGuard` before mutation, `runCrudMutationGuardAfterSuccess` after success, per the AGENTS.md rule for custom write routes.
-
-### POST /api/email/accounts/connect/[provider]
-- Features: `email.account.connect`
-- Body: `{}` (provider read from path param, validated via registry)
-- Response: `{ authorizeUrl: string }` (OAuth providers) — caller redirects user
-
-### POST /api/email/accounts/connect/imap
-- Features: `email.account.connect`
-- Body: `{ displayName, imapHost, imapPort, imapTls, imapUser, imapPassword, smtpHost, smtpPort, smtpTls, smtpUser, smtpPassword }`
-- Response: `{ accountId }` on success; `422` with field-level errors via `createCrudFormError` on validation failure
-
-### GET /api/email/oauth/[provider]/callback
-- No auth feature requirement (state-cookie carries identity)
-- Query: `code`, `state` (Google) or `code`, `state`, `session_state` (Microsoft)
-- Response: HTTP 302 to `/backend/profile/email-accounts?flash=connected` (or `flash=error&code=...`)
-- Errors: invalid state, expired state, userId mismatch, exchange failure — all redirect with `flash=error`
-
-### GET /api/email/accounts
-- Features: `email.account.manage`
-- Query: standard list filters (status, provider)
-- Response: `{ items: EmailAccountDto[] }` — only accounts where `user_id === currentUser.id`
-- Never returns credentials or envelope contents
-
-### PATCH /api/email/accounts/[id]
-- Features: `email.account.manage`
-- Body: `{ displayName?, pollIntervalSeconds? }`
-- Verifies `user_id === currentUser.id`
-- Dispatches `email.account.rename` command if displayName changed
-
-### POST /api/email/accounts/[id]/set-primary
-- Features: `email.account.manage`
-- Dispatches `email.account.set_primary` command
-
-### DELETE /api/email/accounts/[id]
-- Features: `email.account.manage`
-- Dispatches `email.account.disconnect` command
-
-### POST /api/email/send
-- Features: `email.send`
-- Body: `{ accountId, to[], cc?[], bcc?[], subject, body: { plain?, html? }, attachments?: AttachmentRef[], inReplyTo?, references?[] }`
-- Server-side: `sendAsUser` facade does all the work; verifies the caller owns the accountId
-- Response: `{ providerMessageId, providerThreadId, sentAt }`
-- Errors: 401 (no session), 403 (not owner of account), 409 (account not connected), 422 (invalid body), 502 (provider error — message includes classification)
-
-**`AttachmentRef` type** — defined in `packages/core/src/modules/email/data/validators.ts`. Two variants discriminated by `kind`:
+Every new route file follows this shape. The pattern is required, not optional — top-level `export const requireAuth = true` is forbidden by `packages/core/AGENTS.md`.
 
 ```ts
+// packages/core/src/modules/communication_channels/api/post/oauth/[provider]/initiate/route.ts
 import { z } from 'zod'
+import { createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors'
 
+export const metadata = {
+  POST: {
+    requireAuth: true,
+    requireFeatures: ['communication_channels.connect_user_channel'],
+  },
+}
+
+export const openApi = {
+  POST: {
+    summary: 'Initiate per-user channel OAuth flow',
+    requestBody: z.object({ channelType: z.literal('email').optional(), returnUrl: z.string().url().optional() }),
+    responses: { 200: z.object({ authorizeUrl: z.string().url() }) },
+  },
+}
+
+export async function POST(req: Request, { params, container }) {
+  // …state-cookie set, adapter.buildAuthorizeUrl(), return { authorizeUrl }
+}
+```
+
+Routes that mutate (everything except the OAuth callback, which is GET-with-side-effects-but-guarded-by-state-cookie) wrap their write in `validateCrudMutationGuard(...)` + `runCrudMutationGuardAfterSuccess(...)` per `packages/shared/src/lib/crud/mutation-guard.ts`. The `send-as-user` route is the canonical bespoke-write example.
+
+### `POST /api/communication_channels/oauth/[provider]/initiate`
+- Features: `communication_channels.connect_user_channel`
+- Body: `{ channelType?: 'email', returnUrl?: string }`
+- Server: provider read from path; adapter resolved from registry; state cookie set; `{ authorizeUrl }` returned.
+
+### `GET /api/communication_channels/oauth/[provider]/callback`
+- No auth feature (state cookie carries identity)
+- Query: `code`, `state` (Google) or `code`, `state`, `session_state` (Microsoft)
+- Response: 302 to `returnUrl` (default `/backend/profile/communication-channels?flash=connected`) or `?flash=error&code=...`
+- Errors: invalid state, expired state, userId mismatch, exchange failure — all redirect with `flash=error`.
+
+### `POST /api/communication_channels/channels/connect/credentials`
+- Features: `communication_channels.connect_user_channel`
+- Body: provider-discriminated; IMAP shape: `{ providerKey: 'imap', displayName, imapHost, imapPort, imapTls, imapUser, imapPassword, smtpHost, smtpPort, smtpTls, smtpUser, smtpPassword }`
+- Server: `adapter.validateCredentials?({ ... })` (new optional method for credential-based adapters; IMAP implements it); on success, hub creates `CommunicationChannel` with `user_id = currentUser.id`.
+- Response: `{ channelId }` on success; 422 with `createCrudFormError` field-level errors on failure.
+
+### `POST /api/communication_channels/channels/[id]/set-primary`
+- Features: `communication_channels.manage`
+- Server: verifies `user_id === currentUser.id`; clears `is_primary` on other channels owned by the user; sets on this one.
+
+### `POST /api/communication_channels/channels/[id]/test-send`
+- Features: `communication_channels.manage`
+- Body: `{ to: string }`
+- Server: dispatches a small test email via `adapter.sendMessage`. Records result in `HealthLog`. Returns delivery status.
+
+### `POST /api/communication_channels/send-as-user`
+- Features: `communication_channels.manage`
+- Body: `{ userChannelId, to[], cc?[], bcc?[], subject, body: { plain?, html? }, attachments?: AttachmentRef[], inReplyTo?, references?[] }`
+- Server: thin wrapper around the same Message creation API used by the inbox UI. Validates ownership, creates Message with channel routing metadata, returns `{ messageId, externalMessageId, providerThreadId, sentAt }`.
+- Errors: 401 (no session), 403 (not owner), 409 (channel not connected / requires_reauth), 422 (invalid body), 502 (provider error with classification).
+
+### `AttachmentRef` type (Zod discriminated union)
+
+Defined in `packages/core/src/modules/communication_channels/data/validators.ts` (hub-side, shared by all providers):
+
+```ts
 export const attachmentRefSchema = z.discriminatedUnion('kind', [
-  // Reference to a record already stored by the existing attachments module.
   z.object({
     kind: z.literal('attachment'),
-    attachmentId: z.string().uuid(),
-    filename: z.string().min(1).max(255).optional(), // override display name; defaults to stored filename
+    attachmentId: z.string().uuid(),                    // FK to attachments module
+    filename: z.string().min(1).max(255).optional(),
   }),
-  // Inline content provided in the request body. Capped to keep payloads small.
   z.object({
     kind: z.literal('inline'),
     filename: z.string().min(1).max(255),
     mimeType: z.string().min(1).max(255),
-    contentBase64: z.string().min(1), // server enforces 10 MB hard cap per attachment, 25 MB total
+    contentBase64: z.string().min(1),                   // server enforces 10 MB / attachment, 25 MB total
   }),
 ])
-
 export type AttachmentRef = z.infer<typeof attachmentRefSchema>
 ```
 
-The `attachment` variant reuses the existing `attachments` module (no new storage). The `inline` variant is for ad-hoc payloads; the spec deliberately does NOT introduce a new storage tier for outbound email attachments. Provider implementations translate `AttachmentRef[]` into provider-native attachment payloads (Gmail: base64-encoded MIME parts; Microsoft: `attachments[]` in `/me/sendMail`; IMAP/SMTP: nodemailer `attachments` array).
+Per-provider attachment limits come from `ChannelCapabilities.maxFileSize`. Send fails fast with 422 if request exceeds the resolved channel's capabilities.
 
-Per-provider attachment size and count limits come from `EmailAccount.capabilities` (`maxAttachmentBytes`, `supportsAttachmentsOnSend`). Send fails fast with 422 if the request exceeds the resolved account's capabilities.
+## I18n
 
-### GET /api/email/admin/accounts
-- Features: `email.admin`
-- Returns all accounts in tenant with redacted fields: `{ id, userId, providerId, displayName, emailAddress, status, lastPolledAt, errorCount24h }`
-- NO credentials, NO envelope contents
+Per `packages/shared/AGENTS.md`. Locale keys live in each provider's `src/modules/channel_<provider>/locales/<lang>.json` plus hub keys in the hub module's locales.
 
-### GET /api/email/admin/health-log
-- Features: `email.admin`
-- Query: `accountId?`, `severity?`, `kind?`, `since?`
-- Returns `EmailHealthLog` entries (no message contents — `EmailHealthLog.context` does NOT carry email body/subject/recipient by construction)
+Required namespaces:
+- Hub: `communication_channels.channel.status.*`, `.actions.*`, `.banner.requiresReauth`, `.notifications.requires_reauth.*`, `.errors.channel_not_available`
+- Per provider: `channel_gmail.label`, `channel_gmail.connect.button`, `channel_gmail.scopes.*`, `channel_gmail.errors.*` (and parallel for `channel_microsoft`, `channel_imap`)
 
-## Internationalization (i18n)
-
-Per `packages/shared/AGENTS.md`. Locale keys go in `packages/core/src/modules/email/locales/<lang>.json`.
-
-Required key namespaces:
-- `email.account.providers.gmail.label`, `.microsoft.label`, `.imap.label`
-- `email.account.connect.button`, `.dialog.*`
-- `email.account.status.connected`, `.requires_reauth`, `.error`, `.disconnected`
-- `email.account.actions.rename`, `.makePrimary`, `.reconnect`, `.disconnect`
-- `email.account.banner.requiresReauth`
-- `email.imap.form.fields.*` (host, port, tls, user, password, smtp.*)
-- `email.imap.form.warnings.basicAuth` (the security ack)
-- `email.admin.title`, `email.admin.healthLog.severity.*`, `email.admin.providers.title`
-- `email.notifications.requires_reauth.title`, `.body`, `.cta`
-- `email.send.errors.*` (classification keys)
-
-Translations done via `useT()` client-side, `resolveTranslations()` server-side.
+Translations via `useT()` client-side, `resolveTranslations()` server-side.
 
 ## UI/UX
 
-### User Settings → Email Accounts (`/backend/profile/email-accounts`)
-- DataTable (uses `@open-mercato/ui/backend` primitives)
-  - Columns: provider icon (lucide-react `Mail`/`MailOpen` + tinted by provider), display name (inline-editable), email address, primary toggle, status badge (semantic status tokens — `bg-status-success-soft text-status-success-fg` for connected, `bg-status-warning-soft text-status-warning-fg` for `requires_reauth`, `bg-status-error-soft text-status-error-fg` for `error`), last synced (relative time), RowActions
-  - RowActions ids: `email-account:rename`, `email-account:set-primary`, `email-account:reconnect`, `email-account:disconnect` (per `packages/ui/src/backend/AGENTS.md`)
-- "Connect Account" split button (top-right):
-  - Items: "Connect Gmail", "Connect Microsoft", "Connect IMAP"
-  - Gmail / Microsoft → POST connect endpoint → `window.location = authorizeUrl`
-  - IMAP → opens `CrudForm` dialog with provider's credential schema; submit via `useGuardedMutation`
-- Banner across top: `<Alert variant="warning">` listing accounts in `requires_reauth` with inline "Reconnect" button
-- Empty state (no accounts): `<EmptyState>` with primary CTA "Connect your first email account"
-- IMAP dialog includes explicit checkbox: "I understand storing my email password is less secure than OAuth. I will use an app-specific password where possible." (Defaults unchecked; submit disabled until checked.)
-- All dialogs: `Cmd/Ctrl+Enter` submit, `Escape` cancel
+### User-facing: `/backend/profile/communication-channels`
+- **NEW hub page** (replaces what the previous spec called `/backend/profile/email-accounts`). Generic across channel types — Gmail / Microsoft / IMAP / future Slack OAuth all surface here.
+- Top section: `<EmptyState>` for empty / Alert banner for `requires_reauth` channels.
+- DataTable (`entityId: 'communication_channels:user_channel'`):
+  - Provider icon (lucide-react via backend icon registry — `Mail` for email, `MessageCircle` for chat channels)
+  - Display name (inline-editable)
+  - Email/external address
+  - Primary toggle
+  - Status badge — semantic status tokens: `bg-status-success-soft text-status-success-fg` (connected), `bg-status-warning-soft text-status-warning-fg` (requires_reauth), `bg-status-error-soft text-status-error-fg` (error)
+  - Last synced (relative time)
+  - RowActions ids: `communication-channel:rename`, `:set-primary`, `:reconnect`, `:disconnect`
+- "Connect channel" split button (top-right) is UMES-driven: each provider package injects its own entry via `profile:communication-channels:connect` widget spot. Gmail / Microsoft entries redirect to `authorizeUrl`; IMAP entry opens a `CrudForm` dialog with the security-ack checkbox.
+- All dialogs: `Cmd/Ctrl+Enter` submit, `Escape` cancel.
+- Every icon-only button has `aria-label` (`.ai/ui-components.md`).
+- Pagination: `pageSize ≤ 100`.
 
-### Admin → Integrations → Email Providers (`/backend/email/admin`)
-- Top-level DataTable: accounts in tenant
-  - Columns: user, email address, provider, status, last synced, 24h error count, RowActions ("View health log")
-  - Filterable by provider and status
-  - Aggregate header card: total connected accounts, accounts with errors, accounts requiring re-auth
-- "Provider OAuth App Configuration" `<CollapsibleSection>` per provider:
-  - Inputs: clientId, clientSecret (write-only / shows "set" badge after save)
-  - Read-only display of the platform redirect URI (with copy button) — operators must register this exact URL with their Google/Microsoft app
-  - Submit via Marketplace Integration update flow
-- "Health Log" `<CollapsibleSection>`: last 100 entries, sortable
-- All inline status uses semantic status tokens; no hardcoded colors
-- All icons use lucide-react via the backend icon registry (`@open-mercato/ui/backend/icons`); no inline `<svg>`
-- Every icon-only button (rename/disconnect/reconnect/copy/etc.) carries an explicit `aria-label` per `.ai/ui-components.md`
-- Pagination: account-list and health-log DataTables use cursor pagination with `pageSize ≤ 100`
+### Admin: `/backend/communication_channels/channels` (existing hub page, no new route)
+- Hub's existing channels list page already shows tenant channels. This spec adds:
+  - A filter "Show user-owned channels: yes / no / all" via UMES filter injection.
+  - A column "Owner" showing user display name when `user_id IS NOT NULL`.
+  - Aggregate card: total connected, requires_reauth count, error count, accounts per provider.
+- Per-provider OAuth client config injected into the integrations admin page (`/backend/integrations`) via UMES widget at `admin.page:integrations:<provider>:config`. Each provider package owns its config form. IMAP omits OAuth and shows only an "enabled per tenant" toggle.
+
+### Unified inbox: `/backend/messages` (existing Messages page, no new route)
+- The hub's bridge already creates Message records for inbound external messages. Email messages render alongside WhatsApp/Slack/etc. with appropriate channel-type badge + provider icon (via UMES widget injection at `data-table:messages:columns`).
+- Message thread detail (`/backend/messages/[id]`) renders email-specific rich content (To/Cc/Bcc/attachments/headers) via UMES component override on `MessagesThreadDetailHeader` and widget injection at `messages:thread:detail:rich-content`.
 
 ### Frontend Architecture Contract
 
-(Per spec-writing skill heuristic 9 — minimal because UI surface is small.)
-
 - **Server/Client boundary**:
-  - `/backend/profile/email-accounts/page.tsx` — Server Component shell (auth check, initial data load)
-  - `EmailAccountsTable` — Client Component (`"use client"`) for interactive table actions
-  - `ConnectImapDialog` — Client Component (form state, dialog)
-  - `/backend/email/admin/page.tsx` — Server Component shell
-  - `AdminAccountsTable` — Client Component
-- **`"use client"` ledger**: 3 client files, all justified by `useState`/`useMutation`/dialog state
-- **Client blob guardrail**: no provider SDKs imported into client bundles (no `googleapis`, no `@microsoft/microsoft-graph-client`, no `imapflow` — all server-side only)
-- **Route budgets**: each page < 30 KB gzipped client JS (DataTable + CrudForm primitives are shared, not re-bundled)
-- **Hydration test**: Playwright test asserts each interactive control responds within 100 ms of mount on a cold load
-- **Provider/Bootstrap scope**: no new global providers; uses existing app shell
+  - `/backend/profile/communication-channels/page.tsx` — Server Component shell (auth check, initial channel list)
+  - `UserChannelsTable` — Client Component (table actions, dialog state)
+  - `ConnectImapDialog` — Client Component (form state)
+- **`"use client"` ledger**: 2 client files per provider's connect widget + 1 hub-side table component = ~5 total.
+- **Client bundle guardrail**: NO provider SDK in client bundles (no `googleapis`, no `@microsoft/microsoft-graph-client`, no `imapflow` — all server-side only). Verified via Phase 4 acceptance.
+- **Route budgets**: each backend page < 30 KB gzipped client JS (DataTable + CrudForm primitives are shared by the existing UI primitives package, not re-bundled).
+- **Hydration test**: Playwright asserts interactive controls respond within 100 ms of mount on cold load.
+- **Provider/bootstrap scope**: no new global providers; uses existing app shell.
 
 ## Configuration
 
 ```bash
-# Platform-default OAuth apps (optional — tenants can override via Marketplace)
-OM_EMAIL_GMAIL_OAUTH_CLIENT_ID
-OM_EMAIL_GMAIL_OAUTH_CLIENT_SECRET
-OM_EMAIL_GMAIL_REDIRECT_URI                  # e.g. https://app.example.com/api/email/oauth/gmail/callback
-OM_EMAIL_MICROSOFT_OAUTH_CLIENT_ID
-OM_EMAIL_MICROSOFT_OAUTH_CLIENT_SECRET
-OM_EMAIL_MICROSOFT_OAUTH_TENANT              # 'common' for multi-tenant, or specific tenant GUID
-OM_EMAIL_MICROSOFT_REDIRECT_URI
+# Platform-default OAuth apps (optional — tenants may override via Integrations Marketplace)
+OM_HUB_GMAIL_OAUTH_CLIENT_ID
+OM_HUB_GMAIL_OAUTH_CLIENT_SECRET
+OM_HUB_GMAIL_REDIRECT_URI                    # e.g. https://app.example.com/api/communication_channels/oauth/gmail/callback
+OM_HUB_MICROSOFT_OAUTH_CLIENT_ID
+OM_HUB_MICROSOFT_OAUTH_CLIENT_SECRET
+OM_HUB_MICROSOFT_OAUTH_TENANT                # 'common' for multi-tenant, or specific tenant GUID
+OM_HUB_MICROSOFT_REDIRECT_URI
 
-# Sync tuning
-OM_EMAIL_POLL_INTERVAL_SECONDS=300           # default 5 min
-OM_EMAIL_POLL_BATCH_SIZE=100
-OM_EMAIL_ENVELOPE_RETENTION=200              # rolling cap per account
-OM_EMAIL_HEALTH_LOG_RETENTION_DAYS=90
+# Polling tuning (hub-side)
+OM_HUB_POLL_DEFAULT_INTERVAL_SECONDS=300     # default 5 min
+OM_HUB_POLL_BATCH_SIZE=100
+OM_HUB_POLL_SCHEDULER_TICK_SECONDS=60
+OM_HUB_POLL_ENUMERATION_CAP=500              # rows per tick
 
-# OAuth state cookie key (32 bytes hex). Falls back to derive from KMS_MASTER_KEY when absent.
-OM_EMAIL_OAUTH_STATE_KEY
+# Health log retention (hub-side, generic)
+OM_HUB_HEALTH_LOG_RETENTION_DAYS=90
+
+# OAuth state cookie key (32-byte hex). HKDF fallback from KMS_MASTER_KEY when absent.
+OM_HUB_OAUTH_STATE_KEY
 ```
 
-Setup raises a clear error at module boot if any OAuth provider is enabled but neither the per-tenant Marketplace config nor the corresponding platform-env credentials are configured.
+Setup raises a clear error at module boot if a provider is enabled but neither tenant-Marketplace credentials nor the corresponding platform-env credentials are configured (boy-scout improvement on the existing hub boot check).
 
 ## Migration & Backward Compatibility
 
-### Database migrations
-
-One module migration creates 5 tables with FKs, indexes, and the unique partial index for `is_primary`. Standard workflow:
-1. Edit `data/entities.ts`
-2. `yarn db:generate`
-3. Keep only email-related SQL, update `packages/core/src/modules/email/migrations/.snapshot-open-mercato.json`
-
-Each provider package migration (additive): registers the provider's Marketplace Integration row.
-
-### Backward Compatibility
-
 | Surface | Change | Impact |
 |---|---|---|
-| Database schema | 5 new tables, all additive | Additive — zero impact |
-| API routes | New `/api/email/...` namespace | Additive |
-| Events | New `email.*` events | Additive |
-| ACL features | 5 new features (default-granted per role in setup.ts) | Additive |
-| Existing Resend pipeline (`@open-mercato/shared/lib/email/send`) | Untouched | None |
-| `messages` module | Untouched | None |
-| `inbox_ops` module | Untouched | None |
-| `notifications` module | One new notification type (`email_account_requires_reauth`) | Additive |
-| `integrations` Marketplace | Three new provider entries via per-package `marketplace.ts` | Additive |
-| `yarn generate` output | Three new packages join generators | Additive |
-| `apps/mercato/src/modules.ts` | Adds three new packages to `enabledModules` | Required app change, documented |
+| Database schema | 2 columns added to `communication_channels` (`user_id`, `poll_interval_seconds`, `last_polled_at`, `status`, `last_error`, `is_primary`), 1 column added to `integration_credentials` (`user_id`), 3 new indexes | Additive — zero impact on existing rows |
+| Hub events | NO new event IDs — providers route through existing `communication_channels.*` events | Additive |
+| ACL features | 1 new feature: `communication_channels.connect_user_channel` (default-granted to all roles) | Additive |
+| ChannelCapabilities | NEW optional field `realtimePush?: boolean` (default true) | Additive (existing providers omit it) |
+| ChannelAdapter | NEW optional method `refreshCredentials?()`, NEW optional method `validateCredentials?()` for credential-based providers | Additive |
+| Marketplace categories | 3 new integration entries: `channel_gmail`, `channel_microsoft`, `channel_imap` — category `communication`, hub `communication_channels` | Additive |
+| Messages module | UNTOUCHED | None |
+| Resend pipeline | UNTOUCHED | None |
+| Existing tenant WhatsApp channels | UNTOUCHED (`user_id` defaults NULL) | None |
+| `apps/mercato/src/modules.ts` | Adds 4 entries (`communication_channels` hub + 3 providers) | Required app change, documented |
+| `yarn generate` output | Hub + 3 provider packages join generators | Additive |
 
-No deprecations. No data migration of existing rows. Existing tests untouched.
+No deprecations. No data migration of existing rows. Existing hub tests untouched.
 
-After enabling the new modules: run `yarn mercato configs cache structural --all-tenants` per AGENTS.md.
+After enabling: `yarn mercato configs cache structural --all-tenants` (root `AGENTS.md` mandate).
 
 ## Implementation Plan
 
-### Phase 1 — Core foundations (no providers yet)
-1. Scaffold `packages/core/src/modules/email/` (index.ts, setup.ts, acl.ts, di.ts).
-2. Create entities, validators, encryption map; run `yarn db:generate`.
-3. Implement `EmailProvider` interface, `CanonicalMessage`, `provider-registry` (empty registry, just the DI hook).
-4. Implement OAuth state-cookie helper (port from SSO module pattern); unit tests for encrypt/decrypt/expiry/tamper.
-5. Implement OAuth callback router shell that delegates to a registered provider (returns 400 if unknown).
-6. Implement commands (`connectAccount`, `disconnectAccount`, `setPrimaryAccount`, `renameAccount`, `updateImapCredentials`, `refreshToken`, `markRequiresReauth`).
-7. Implement API routes for `accounts/*` (list, patch, delete, set-primary) with feature guards and `openApi`.
-8. Implement `send-pipeline.ts` `sendAsUser` facade with a no-op provider (returns "no provider registered" error if no provider for the account).
-9. Implement workers (`poll-account`, `refresh-tokens`, `purge-envelopes`, `purge-health-log`) with provider-agnostic logic.
-10. Unit tests for: cursor advancement, drain mode, error classification, status transitions, command undo semantics, state-cookie helper.
-11. **Acceptance**: Module loads, ACL features visible, API routes 404 without registered providers, `yarn build` passes, `yarn lint` passes.
+> Each phase ships its own module-local `__integration__/TC-CHANNEL-EMAIL-*.spec.ts` per `.ai/lessons.md` "Keep executable integration tests module-local". No phase is marked complete without its listed integration tests passing.
 
-### Phase 2 — User UI for accounts
-1. `/backend/profile/email-accounts/page.tsx` Server Component shell.
-2. `EmailAccountsTable` Client Component (DataTable + RowActions + status badges).
-3. `ConnectImapDialog` Client Component (CrudForm with security-ack checkbox).
-4. Banner for requires_reauth accounts using `<Alert>` primitive.
-5. Empty state.
-6. i18n locale entries (en at minimum).
-7. **Acceptance**: User can navigate to the page; with no providers registered, "Connect Account" dropdown shows none. Locale strings resolve. DataTable renders.
+### Prerequisite — SPEC-045d Communication Hub delivery (NOT in this spec)
 
-### Phase 3 — Gmail provider package
-1. `packages/email-gmail/` workspace package (package.json, tsconfig, AGENTS.md).
-2. OAuth: authorize URL builder, code exchange, refresh — using `googleapis` SDK or raw fetch.
-3. Sync: `gmail.users.history.list` for incremental; full list for initial sync seeding.
-4. Send: build RFC822 message via `mailcomposer` (or equivalent), `gmail.users.messages.send`.
-5. Health: `gmail.users.getProfile`.
-6. `GmailProviderMeta` zod schema (labelIds, isImportant, isStarred, threadId).
-7. Marketplace integration registration.
-8. Unit tests with mocked HTTP responses.
-9. Wire into `apps/mercato/src/modules.ts`; run `yarn mercato configs cache structural --all-tenants`.
-10. **Acceptance**: User can connect Gmail end-to-end against a real Google Workspace test account, send a test email, observe it polled back into envelopes within 5 min.
+The hub itself (`packages/core/src/modules/communication_channels/` with entities, ChannelAdapter interface + DI registry, inbound-processor worker, outbound-delivery subscriber on `messages.message.sent`, hub events, hub ACL features `communication_channels.view/.manage/.admin`, hub admin pages, integrations bridge) is delivered by a **separate spec/PR that owns SPEC-045d**. See § Prerequisites & Cross-Spec Dependencies. This spec's first phase (Phase 0 below) starts only after that hub PR is merged and `yarn build` passes against it.
 
-### Phase 4 — Microsoft provider package
-1. `packages/email-microsoft/` workspace package.
-2. OAuth: Microsoft identity platform v2.0 authorize URL, code exchange (PKCE), refresh.
-3. Sync: `/me/mailFolders/inbox/messages/delta` (delta queries).
-4. Send: `/me/sendMail` with `application/json` body.
-5. Health: `/me`.
-6. `OutlookProviderMeta` zod schema (categories, importance, conversationId).
-7. Marketplace integration registration.
-8. Unit tests with mocked Graph responses.
-9. **Acceptance**: User can connect Microsoft 365 account end-to-end, send, and receive via polling.
+**Verification gate before Phase 0 begins**:
+```bash
+ls packages/core/src/modules/communication_channels/                              # exists
+grep -l "interface ChannelAdapter" packages/core/src/modules/communication_channels/lib/  # found
+grep -l "queue: 'communication-channels-inbound'" packages/core/src/modules/communication_channels/workers/  # found
+grep -l "messages.message.sent" packages/core/src/modules/communication_channels/subscribers/  # found
+```
+If any line above fails, return to the hub-foundation PR before continuing.
 
-### Phase 5 — IMAP+SMTP provider package
-1. `packages/email-imap/` workspace package, deps `imapflow` + `nodemailer` + `mailparser`.
-2. `validateCredentials` probes both IMAP and SMTP login.
-3. Sync: `imapflow` connect, select INBOX, fetch by UID range using `EmailSyncCursor.cursor.uidNext` / `uidValidity` (handle UIDVALIDITY rotation = full re-sync).
-4. Send: nodemailer SMTP, append to Sent folder if server supports it.
-5. `ImapProviderMeta` zod schema (folder, flags, uid, uidValidity).
-6. Marketplace integration registration (no OAuth app config; just an "enabled/disabled per tenant" toggle).
-7. Unit tests against an in-process IMAP mock.
-8. **Acceptance**: User can connect IMAP+SMTP with valid creds, send, receive via polling. Invalid creds rejected with field-level errors.
+### Phase 0 — Hub deltas for per-user email channels
 
-### Phase 6 — Admin UI
-1. `/backend/email/admin/page.tsx` Server Component.
-2. `AdminAccountsTable` Client Component with filters (provider, status).
-3. Aggregate header card (counts).
-4. Health log section with severity coloring.
-5. Tenant OAuth app config form per provider (CollapsibleSection).
-6. **Acceptance**: Admin sees all tenant accounts, can drill into health log, can configure tenant-level OAuth overrides. Cannot see envelope contents.
+**Goal**: apply this spec's incremental deltas on top of the (now-existing) hub. Phase 0 is bounded by the deltas list in § Hub Deltas Required by This Spec — nothing else. Do not retrofit hub-level concerns here; escalate them back to the SPEC-045d spec.
 
-### Phase 7 — Notifications & cleanup workers
-1. Notification type `email_account_requires_reauth` with client renderer.
-2. Subscriber on `email.account.requires_reauth` event that creates the notification.
-3. Cron registration for `purge-envelopes` (daily, caps rolling 200 per account) and `purge-health-log` (daily, deletes > retention days).
-4. **Acceptance**: When a refresh-token-revoked event happens, the account-owner receives an in-app notification; the page banner appears on next load.
+**Scope (this spec's incremental work only)**:
 
-### Integration test placement (applies to every phase)
+1. Add additive columns on `CommunicationChannel` via the hub module's `data/entities.ts`: `user_id`, `is_primary`, `poll_interval_seconds`, `last_polled_at`, `status`, `last_error`. Generate migration with `yarn db:generate`; remove unrelated migration output per the coding-agent exception in root `AGENTS.md`.
+2. Add additive column on `IntegrationCredentials` via the **integrations module's** `data/entities.ts` (coordinated edit in the same PR; the hub does not own the integrations table). Generate the migration in the integrations module's `migrations/` folder.
+3. Declare cross-module links in `packages/core/src/modules/communication_channels/data/extensions.ts` (`CommunicationChannel.user_id → auth:user`, `IntegrationCredential.user_id → auth:user`). No raw FKs (root `AGENTS.md` rule).
+4. Extend `ChannelCapabilities` with optional `realtimePush?: boolean` (default `true` in resolver for BC) in `lib/capabilities.ts`.
+5. Extend `ChannelAdapter` with optional `refreshCredentials?(input)` and `validateCredentials?(input)` methods in `lib/adapter.ts`. Both are typed as optional; existing WhatsApp/Slack adapters compile unchanged.
+6. New worker: `workers/poll-channel.ts` with `metadata = { queue: 'communication-channels-poll', concurrency: 10 }`, idempotent on `(channel_id, external_message_id)`, error classification → status transitions per § Hub Deltas → Delta 6.
+7. New scheduler entry: `schedulers/poll-tick.ts` registering a 60s cron via `@open-mercato/scheduler` per § Hub Deltas → Delta 6 (scheduler mechanism).
+8. New OAuth state-cookie helper: `lib/oauth-state.ts` ported (not imported) from `packages/enterprise/src/modules/sso/lib/state-cookie.ts`. Phase 0 acceptance includes a `grep -r '@open-mercato/enterprise'` returning empty against `packages/core/src/modules/communication_channels/` and the three provider packages once they ship.
+9. New OAuth router: `api/post/oauth/[provider]/initiate/route.ts` + `api/get/oauth/[provider]/callback/route.ts` per § API Contracts.
+10. New per-user routes: `api/post/channels/connect/credentials/route.ts` + `api/post/channels/[id]/set-primary/route.ts` + `api/post/channels/[id]/test-send/route.ts` + `api/post/send-as-user/route.ts`. Each uses per-method `metadata` (see § Per-method metadata shape).
+11. Per-user ACL feature: add `communication_channels.connect_user_channel` to the hub's `acl.ts`; default-grant to all roles in `setup.ts`. Run `yarn mercato auth sync-role-acls` in deploy runbook.
+12. Generic notification type: `channel_requires_reauth` in the hub's `notifications.ts` + renderer in `notifications.client.ts`. Channel-agnostic — not email-specific.
+13. New backend page: `backend/profile/communication-channels/page.tsx` per § UI/UX. Server-component shell + client-component `UserChannelsTable`.
+14. Per-user channel ACL gates (service-layer enforcement of `user_id` filter on every list/read/write) declared in `lib/access-control.ts` or equivalent, called from each route handler.
+15. HTML sanitizer (`lib/sanitize-channel-html.ts`) — if not already shipped by the hub-foundation PR (it should be, per § Security Posture), add it here as a hub addition. Phase 0 acceptance verifies presence.
+16. Unit tests: state-cookie encrypt/decrypt/expiry/tamper, poll-channel cursor advancement, per-user ACL gate filter, drain mode (post 5 iterations → re-enqueue with backoff), error classification (401 → requires_reauth; 429 → Retry-After; 5xx → exponential backoff; persistent → status='error'), `refreshCredentials` near-expiry triggering, HTML sanitizer behaviour (script strip / javascript: URL strip / event-handler attribute strip / `<img>`/`<a>`/`<table>` allowlist), `messages.message.sent` subscriber re-fetch pattern.
+17. Module-local integration tests (`packages/core/src/modules/communication_channels/__integration__/`):
+    - `TC-CHANNEL-EMAIL-HUB-001` per-user channel isolation: User A cannot list User B's channels via API
+    - `TC-CHANNEL-EMAIL-HUB-002` polling scheduler enqueues `poll-channel` jobs at correct cadence (uses time-mocking to advance the scheduler)
+    - `TC-CHANNEL-EMAIL-HUB-003` OAuth state-cookie userId mismatch rejected at callback (302 to flash=error)
+    - `TC-CHANNEL-EMAIL-HUB-004` `send-as-user` requires `user_id` ownership (cannot send via someone else's channel)
+    - `TC-CHANNEL-EMAIL-HUB-005` `messages.message.sent` subscriber re-fetches by ID, no payload-shape coupling (simulate by emitting with a minimal payload and asserting routing still works)
+    - `TC-CHANNEL-EMAIL-HUB-006` `channel_requires_reauth` notification raised when `markRequiresReauth` command runs; UMES `useNotificationEffect` handler triggers reconnect dialog (rendered, not OAuth-completed)
+18. **Acceptance gates**:
+    - `yarn build` passes
+    - `yarn lint` passes
+    - `yarn db:migrate` applies the new columns cleanly
+    - `grep -r "@open-mercato/enterprise" packages/core/src/modules/communication_channels/` returns empty
+    - `yarn test` passes for the hub module
+    - Six integration tests above pass against a real Postgres + Redis (no mocked DB)
+    - `yarn mercato configs cache structural --all-tenants` runs cleanly after the new ACL feature is added
 
-Per `.ai/lessons.md` → "Keep executable integration tests module-local": executable Playwright specs live under the **owning module's** `__integration__/` directory, not under `.ai/qa/tests/`. `.ai/qa/scenarios/TC-EMAIL-*.md` holds the human-readable scenario descriptions only.
+### Phase 1 — IMAP provider (`@open-mercato/channel-imap`)
 
-Test locations:
+**Goal**: end-to-end credential-based provider proves the polling pipeline.
 
-| Test | Markdown scenario | Executable Playwright spec |
-|---|---|---|
-| TC-EMAIL-011, 012, 013, 014 (account management, RBAC, isolation) | `.ai/qa/scenarios/TC-EMAIL-011..014.md` | `packages/core/src/modules/email/__integration__/TC-EMAIL-NNN.spec.ts` |
-| TC-EMAIL-001, 005, 006, 009 (Gmail) | `.ai/qa/scenarios/TC-EMAIL-001/005/006/009.md` | `packages/email-gmail/src/modules/email_gmail/__integration__/TC-EMAIL-NNN.spec.ts` |
-| TC-EMAIL-002 (Microsoft) | `.ai/qa/scenarios/TC-EMAIL-002.md` | `packages/email-microsoft/src/modules/email_microsoft/__integration__/TC-EMAIL-002.spec.ts` |
-| TC-EMAIL-003, 004, 007, 008 (IMAP/SMTP) | `.ai/qa/scenarios/TC-EMAIL-003/004/007/008.md` | `packages/email-imap/src/modules/email_imap/__integration__/TC-EMAIL-NNN.spec.ts` |
-| TC-EMAIL-010, 015 (cross-cutting: notifications, tenant overrides) | `.ai/qa/scenarios/TC-EMAIL-010/015.md` | `packages/core/src/modules/email/__integration__/TC-EMAIL-NNN.spec.ts` |
+1. Workspace package scaffolding (`packages/channel-imap/`, build/watch scripts mirroring `gateway-stripe`).
+2. `src/modules/channel_imap/`: `index.ts`, `setup.ts` (registers adapter + marketplace entry), `di.ts`, `integration.ts`.
+3. `lib/adapter.ts`: implements `ChannelAdapter` with `validateCredentials`, `fetchHistory` (imapflow with UIDVALIDITY+UIDNEXT tracking; handles UIDVALIDITY rotation = full re-sync), `sendMessage` (nodemailer SMTP; appends to Sent folder if server supports `\Sent` capability), `convertOutbound`, `normalizeInbound` (mailparser), `getStatus` (best-effort), `resolveContact`.
+4. `lib/capabilities.ts`: `realtimePush: false`, `threading: true`, `richText: true`, `fileSharing: true`, `maxFileSize: 25_000_000`, no reactions, no edit/delete.
+5. UMES widgets:
+   - Connect IMAP dialog injection at `profile:communication-channels:connect`
+   - CrudForm field injection at `crud-form:communication_channels.channel:fields:imap` (host/port/TLS/user/password ×2, security-ack)
+   - Channel-type badge injection at `data-table:messages:columns`
+   - Response enricher `_email` on Message (shared with Phase 2/3 — first to ship lives here in hub; provider just registers)
+6. Unit tests with `imap-server` in-process mock.
+7. Module-local integration tests (`packages/channel-imap/src/modules/channel_imap/__integration__/`):
+   - `TC-CHANNEL-EMAIL-001` Connect IMAP with valid credentials
+   - `TC-CHANNEL-EMAIL-002` Invalid credentials rejected with field-level errors
+   - `TC-CHANNEL-EMAIL-003` Polling fetches inbound, Message created in inbox, `communication_channels.message.received` emitted
+   - `TC-CHANNEL-EMAIL-004` Send via SMTP, Message thread created, appears in remote Sent folder
+   - `TC-CHANNEL-EMAIL-005` Threading via In-Reply-To creates correct `ChannelThreadMapping`
+8. Wire into `apps/mercato/src/modules.ts`; run `yarn mercato configs cache structural --all-tenants`.
+9. **Acceptance**: User connects IMAP, sends, receives via polling within 5 min, threading correct, sees email in unified inbox.
 
-**Per-phase acceptance rule** (overrides any earlier "tests at end" framing): every phase below ships its **own** module-local Playwright specs. A phase is NOT marked complete until its listed integration tests pass. This matches the user's standing rule and `.ai/qa/AGENTS.md`.
+### Phase 2 — Gmail provider (`@open-mercato/channel-gmail`)
 
-Per-phase test ownership:
+**Goal**: OAuth-based provider on top of working polling pipeline.
 
-| Phase | Required integration specs (module-local `__integration__/`) |
-|---|---|
-| Phase 1 (Core foundations) | `packages/core/src/modules/email/__integration__/`: smoke spec asserting module loads, ACL features registered, API routes 404 with no providers; per-user isolation spec for the accounts list endpoint as a foundational guarantee |
-| Phase 2 (User UI) | `packages/core/src/modules/email/__integration__/`: empty-state render, banner render, navigation smoke |
-| Phase 3 (Gmail) | `packages/email-gmail/.../__integration__/`: TC-EMAIL-001, 005, 006, 009 |
-| Phase 4 (Microsoft) | `packages/email-microsoft/.../__integration__/`: TC-EMAIL-002 |
-| Phase 5 (IMAP) | `packages/email-imap/.../__integration__/`: TC-EMAIL-003, 004, 007, 008 |
-| Phase 6 (Admin UI) | `packages/core/src/modules/email/__integration__/`: TC-EMAIL-011, 015 |
-| Phase 7 (Notifications & cleanup) | `packages/core/src/modules/email/__integration__/`: TC-EMAIL-010, plus envelope-cap and health-log-retention sweeps |
+1. Workspace package scaffolding.
+2. `lib/oauth.ts`: Google OAuth (authorize URL builder, code exchange, refresh — `googleapis` SDK or raw fetch).
+3. `lib/sync.ts`: `gmail.users.history.list` incremental + full bootstrap sync.
+4. `lib/send.ts`: `gmail.users.messages.send` with raw RFC2822.
+5. `lib/health.ts`: `gmail.users.getProfile`.
+6. Capabilities + `refreshCredentials` implementation.
+7. UMES: Gmail-specific connect button at `profile:communication-channels:connect`, OAuth config at `admin.page:integrations:gmail:config`, Gmail labels chip widget at `messages:thread:detail:rich-content` (provider-specific affordance).
+8. Marketplace integration registration (category `communication`, hub `communication_channels`).
+9. Per-channel custom fields via `ce.ts`: "default signature", "default Gmail label", "auto-reply text".
+10. Unit tests with stubbed HTTP.
+11. Module-local integration tests:
+    - `TC-CHANNEL-EMAIL-006` Connect Gmail (real OAuth, env-gated CI skip)
+    - `TC-CHANNEL-EMAIL-007` Send via Gmail → ExternalMessage + MessageChannelLink + Sent folder
+    - `TC-CHANNEL-EMAIL-008` Receive via Gmail polling → Message in inbox
+    - `TC-CHANNEL-EMAIL-009` Token refresh: stub Google refresh response, verify new tokens persisted
+    - `TC-CHANNEL-EMAIL-010` Refresh-token revoked → status=requires_reauth + notification arrives + banner shown on profile page
+12. **Acceptance**: User connects Gmail end-to-end against real Google Workspace test account; full send + receive + token refresh + reauth flow exercised.
 
-Cross-phase tests that touch behavior owned by multiple phases (e.g. TC-EMAIL-013 Disconnect spans accounts + sync halt + credential purge) land with the phase that delivers the last contributing behavior — typically Phase 1 (foundations) since the disconnect command is foundational.
+### Phase 3 — Microsoft provider (`@open-mercato/channel-microsoft`)
+
+**Goal**: parallel OAuth provider; reuses Phase 2's OAuth foundation.
+
+1. Workspace package scaffolding.
+2. `lib/oauth.ts`: Microsoft identity platform v2.0 (Azure AD) authorize URL, code exchange (PKCE), refresh.
+3. `lib/sync.ts`: `/me/mailFolders/inbox/messages/delta`.
+4. `lib/send.ts`: `/me/sendMail` with `application/json`.
+5. `lib/health.ts`: `/me`.
+6. Capabilities + `refreshCredentials`.
+7. UMES: Microsoft connect button, OAuth config, Outlook categories chip widget.
+8. Marketplace registration.
+9. Unit tests with stubbed Graph responses.
+10. Module-local integration tests:
+    - `TC-CHANNEL-EMAIL-011` Connect Microsoft 365 (real OAuth, env-gated CI skip)
+    - `TC-CHANNEL-EMAIL-012` Send via /me/sendMail
+    - `TC-CHANNEL-EMAIL-013` Receive via Graph delta polling
+11. **Acceptance**: Microsoft 365 account end-to-end.
+
+### Phase 4 — UMES polish + cross-provider tests
+
+**Goal**: finalize all UMES extension points; ensure they compose cleanly across multiple connected channels.
+
+1. Component override on `MessagesThreadDetailHeader` for `channelType=email` (hub-side).
+2. Mutation guards on `channel.delete` (unread inbound block), `message.create` (channel-not-connected block).
+3. Sync event subscriber on `auth.user.deleted` (cascade-disconnect user channels).
+4. Notification handler with `useNotificationEffect` on `channel_requires_reauth`.
+5. Command interceptor `beforeUndo` on `channel.disconnect`.
+6. Module-local integration tests (`packages/core/src/modules/communication_channels/__integration__/`):
+    - `TC-CHANNEL-EMAIL-014` Multi-account per user, primary swap works (one user with Gmail + IMAP, primary toggled)
+    - `TC-CHANNEL-EMAIL-015` Admin sees account list, cannot read envelope contents (RBAC)
+    - `TC-CHANNEL-EMAIL-016` Tenant-owned OAuth app overrides platform default (Gmail and Microsoft)
+    - `TC-CHANNEL-EMAIL-017` Disconnect → credentials hard-purged, polling halted, channel removed
+    - `TC-CHANNEL-EMAIL-018` Mutation guard blocks delete with unread inbound + force=true bypass
+    - `TC-CHANNEL-EMAIL-019` `auth.user.deleted` cascade-disconnects all user's channels
+    - `TC-CHANNEL-EMAIL-020` Email rich-content widget renders To/Cc/Bcc/attachments in unified inbox
+7. **Acceptance**: all UMES surfaces compose correctly; multi-channel user scenarios pass.
+
+### Phase 5 — Documentation + deploy runbook
+
+1. `apps/docs/docs/framework/communication_channels/per-user-channels.mdx` — concept, OAuth setup per provider, troubleshooting.
+2. Deploy runbook: `OM_HUB_*` env keys, `OM_HUB_OAUTH_STATE_KEY` rotation, `yarn mercato configs cache structural --all-tenants` after deploy, optional tenant OAuth app registration steps for Google Cloud Console and Azure AD.
+3. Spec changelog entry, Final Compliance Report rerun, `RELEASE_NOTES.md` entry.
 
 ### File Manifest (high-level)
 
 | File | Action | Purpose |
 |------|--------|---------|
-| `packages/core/src/modules/email/**` | Create | Orchestrator module |
-| `packages/core/src/modules/email/__integration__/TC-EMAIL-*.spec.ts` | Create | Module-local integration specs (Phases 1, 2, 6, 7) |
-| `packages/email-gmail/src/modules/email_gmail/**` | Create | Gmail provider package |
-| `packages/email-gmail/src/modules/email_gmail/__integration__/TC-EMAIL-*.spec.ts` | Create | Gmail integration specs (Phase 3) |
-| `packages/email-microsoft/src/modules/email_microsoft/**` | Create | Microsoft provider package |
-| `packages/email-microsoft/src/modules/email_microsoft/__integration__/TC-EMAIL-*.spec.ts` | Create | Microsoft integration specs (Phase 4) |
-| `packages/email-imap/src/modules/email_imap/**` | Create | IMAP+SMTP provider package |
-| `packages/email-imap/src/modules/email_imap/__integration__/TC-EMAIL-*.spec.ts` | Create | IMAP integration specs (Phase 5) |
-| `apps/mercato/src/modules.ts` | Modify | Enable the four new modules (`email`, `email_gmail`, `email_microsoft`, `email_imap`) |
-| `.ai/qa/scenarios/TC-EMAIL-*.md` | Create | Human-readable test scenarios (markdown only — no executable code) |
-| `apps/docs/docs/framework/email/**` | Create | User-facing documentation |
+| `packages/core/src/modules/communication_channels/**` | Create or extend | Hub deltas (Phase 0) |
+| `packages/core/src/modules/communication_channels/__integration__/TC-*.spec.ts` | Create | Hub + cross-provider integration specs (Phases 0, 4) |
+| `packages/channel-imap/src/modules/channel_imap/**` | Create | IMAP provider package (Phase 1) |
+| `packages/channel-imap/src/modules/channel_imap/__integration__/TC-*.spec.ts` | Create | IMAP integration specs |
+| `packages/channel-gmail/src/modules/channel_gmail/**` | Create | Gmail provider package (Phase 2) |
+| `packages/channel-gmail/src/modules/channel_gmail/__integration__/TC-*.spec.ts` | Create | Gmail integration specs |
+| `packages/channel-microsoft/src/modules/channel_microsoft/**` | Create | Microsoft provider package (Phase 3) |
+| `packages/channel-microsoft/src/modules/channel_microsoft/__integration__/TC-*.spec.ts` | Create | Microsoft integration specs |
+| `apps/mercato/src/modules.ts` | Modify | Enable `communication_channels` (if not enabled) + 3 providers |
+| `.ai/qa/scenarios/TC-CHANNEL-EMAIL-*.md` | Create | Human-readable scenario markdowns (no code) |
+| `apps/docs/docs/framework/communication_channels/per-user-channels.mdx` | Create | User-facing docs |
 
-### Testing Strategy
+## Testing Strategy
 
-**Unit (Jest)**
-- Per-provider: stubbed HTTP for OAuth + sync + send; verify request shape and CanonicalMessage normalization.
-- OAuth state-cookie helper: encrypt/decrypt roundtrip, TTL expiry, signature tamper, userId-mismatch rejection.
-- `send-pipeline`: token-refresh trigger, error classification, EmailHealthLog writes.
-- `poll-account` worker: cursor advancement, drain mode, error classification, status transitions, idempotent re-ingest.
-- IMAP provider: tests against in-process IMAP mock (`imap-server`).
+**Unit (Jest)** — alongside each phase:
+- Hub deltas: state-cookie roundtrip/expiry/tamper, poll scheduler enumeration, per-user ACL filter, refreshCredentials flow.
+- Per-provider: stubbed HTTP for OAuth + sync + send; verify request shape; CanonicalMessage normalization; thread resolution via RFC2822 headers.
+- IMAP provider: in-process IMAP mock for sync correctness; UIDVALIDITY rotation handling.
 
-**Integration (Playwright)** — scenarios listed in `.ai/qa/scenarios/`, executable specs in module-local `__integration__/` (see placement table above):
+**Integration (Playwright)** — module-local `__integration__/`, per the placement table in Implementation Plan. Scenarios listed in `.ai/qa/scenarios/TC-CHANNEL-EMAIL-*.md`.
 
-- TC-EMAIL-001 Connect Gmail (real OAuth, env-gated CI skip)
-- TC-EMAIL-002 Connect Microsoft (real OAuth, env-gated CI skip)
-- TC-EMAIL-003 Connect IMAP with valid credentials
-- TC-EMAIL-004 IMAP rejects invalid credentials with field-level errors
-- TC-EMAIL-005 Send via Gmail, envelope written, appears in Gmail Sent folder
-- TC-EMAIL-006 Receive via Gmail polling, envelope written, `email.message.received` event emitted
-- TC-EMAIL-007 Send via SMTP, appears in remote Sent folder
-- TC-EMAIL-008 Receive via IMAP polling
-- TC-EMAIL-009 Token refresh: stub Google refresh response, verify new tokens persisted
-- TC-EMAIL-010 Refresh-token revoked → status=requires_reauth + notification arrives + banner shown
-- TC-EMAIL-011 Admin sees account list, cannot read envelope contents (RBAC)
-- TC-EMAIL-012 User A cannot list User B's accounts (per-user isolation)
-- TC-EMAIL-013 Disconnect → credentials hard-purged, sync halted, account removed
-- TC-EMAIL-014 Multi-account per user, primary swap works
-- TC-EMAIL-015 Tenant-owned OAuth app overrides platform default
-
-Per the user's standing rule and `.ai/lessons.md`, **no spec phase is marked complete without the listed module-local integration specs passing**. Phase 8 has been removed — integration tests are written and executed as part of the phase that produces the behavior being tested.
+**Cross-cutting**: Phase 4 ships integration tests that exercise UMES composition (multi-channel users, response enrichers under load, mutation guards triggering across modules).
 
 ## Risks & Impact Review
 
 ### Data Integrity Failures
 
 #### Credential blob write atomicity
-- **Scenario**: OAuth callback completes; we insert EmailAccount but the credential insert fails. Result: an account row with no credentials.
+- **Scenario**: OAuth callback completes; channel insert succeeds but credential insert fails.
 - **Severity**: High
-- **Affected area**: `email_accounts`, `email_account_credentials`, sync workers
-- **Mitigation**: `email.account.connect` command wraps both inserts in a single MikroORM transaction. Sync worker treats "no credential row" as a hard error → status='error'.
-- **Residual risk**: None significant; transactional boundary covers it.
+- **Mitigation**: `connectChannel` command wraps both inserts in a single transaction; sync worker treats "no credential row" as hard error → status='error'.
+- **Residual risk**: None significant.
 
-#### Cursor regression on crashed worker
-- **Scenario**: Worker fetches batch, persists envelopes, crashes before persisting new cursor. Next run re-fetches same messages.
+#### Cursor regression on crashed poll worker
+- **Scenario**: Worker fetches batch, persists `ExternalMessage` rows, crashes before persisting cursor.
 - **Severity**: Low
-- **Affected area**: Receive pipeline
-- **Mitigation**: Envelope upsert is idempotent on `(email_account_id, provider_message_id)` UNIQUE. `email.message.ingest` command is idempotent (returns existing row if conflict). Event emission deduped: only emit when row was actually inserted, not updated.
-- **Residual risk**: Acceptable — re-emission could happen if the crash is between insert and event publish. Downstream CRM subscribers must be idempotent on `(account_id, provider_message_id)`. Documented.
+- **Mitigation**: `ExternalMessage` upsert is idempotent on `(channel_id, external_message_id)`; inbound-processor short-circuits on existing row; event emit only fires on actual insert.
+- **Residual risk**: Re-emission could occur if crash between insert and emit. CRM subscribers must be idempotent on `(channel_id, external_message_id)`. Documented.
 
-#### isPrimary race
-- **Scenario**: Two concurrent `set_primary` calls leave zero or two primaries.
+#### isPrimary race per user
+- **Scenario**: Concurrent set_primary calls leave zero or two primaries.
 - **Severity**: Medium
-- **Affected area**: `email_accounts`
-- **Mitigation**: Partial unique index `UNIQUE (user_id) WHERE is_primary AND deleted_at IS NULL` makes "two primaries" impossible at the DB level. Command wraps both UPDATEs in a transaction at SERIALIZABLE isolation.
+- **Mitigation**: Partial unique index `UNIQUE (user_id) WHERE is_primary AND user_id IS NOT NULL AND deleted_at IS NULL`. Command in SERIALIZABLE transaction.
 - **Residual risk**: None.
 
 ### Cascading Failures & Side Effects
 
-#### Subscriber failure in `email.message.received`
-- **Scenario**: Future CRM subscriber throws while processing a message.
+#### Subscriber failure on `communication_channels.message.received`
+- **Scenario**: Future CRM subscriber throws.
 - **Severity**: Medium
-- **Affected area**: This module → CRM module
-- **Mitigation**: Event is persistent; failed subscribers retry per existing platform behavior; this module's worker does not depend on subscriber success.
-- **Residual risk**: A repeatedly failing subscriber could pile up. Future CRM spec defines its DLQ.
+- **Mitigation**: Event is persistent; failed subscribers retry per platform behavior; poll worker does not depend on subscriber success.
+- **Residual risk**: Sustained failures pile up — CRM spec defines its own DLQ.
+
+#### Cross-process event bridge (lessons.md "Browser SSE bridges must work across worker and web processes")
+- **Scenario**: Poll worker emits `communication_channels.message.received` from queue process; in-process SSE bridge in the web process never sees it; UI looks frozen.
+- **Severity**: Medium
+- **Mitigation**: Hub's existing event bus design must include a cross-process transport before any `clientBroadcast: true` event is emitted from a worker. Phase 0 acceptance verifies the bridge is wired (or that the hub explicitly polls + SSE per the lesson).
+- **Residual risk**: If the bridge is not in place, UI consumers fall back to polling (existing pattern). Spec flags this as a hub-side dependency.
 
 #### Provider outage
-- **Scenario**: Gmail API returns 5xx for hours.
+- **Scenario**: Gmail / Graph returns 5xx for hours.
 - **Severity**: Low
-- **Affected area**: Inbound sync, outbound send via affected provider
-- **Mitigation**: Exponential backoff up to 60-min ceiling; status stays `connected` (transient); EmailHealthLog warnings accumulate; admin can see in dashboard.
-- **Residual risk**: Users on that provider experience sync lag; documented in admin UI.
+- **Mitigation**: Exponential backoff to 60-min ceiling; status stays `connected`; `HealthLog` warnings accumulate; admin can see in dashboard.
+- **Residual risk**: Sync lag on that provider; documented.
 
 #### Resend pipeline interaction
-- **Scenario**: Sending via Resend AND via user account concurrently for the same recipient causes duplicate emails.
-- **Severity**: Low (no caller does both today)
-- **Affected area**: Outbound
-- **Mitigation**: Spec explicitly states the two pipelines coexist; no automatic dual-emit; caller chooses one explicitly. CRM spec will define which calls migrate when.
-- **Residual risk**: A future change could introduce duplication; mitigated by code review and the explicit `sendAsUser` vs `sendEmail` import distinction.
+- **Scenario**: Workflow sends via Resend AND via user channel concurrently for the same recipient.
+- **Severity**: Low
+- **Mitigation**: Spec explicitly states the two pipelines coexist; caller picks. CRM spec will define migration policy.
+- **Residual risk**: A future change could introduce duplication; mitigated by code review and the distinct `sendEmail` (Resend) vs `sendAsUser` (hub) import surface.
 
 ### Tenant & Data Isolation Risks
 
-#### Cross-user account leakage
-- **Scenario**: A bug in the list API returns another user's accounts.
+#### Cross-user channel leakage
+- **Scenario**: A bug in the list API returns another user's channels.
 - **Severity**: Critical
-- **Affected area**: `/api/email/accounts`, all account-management endpoints
-- **Mitigation**: All user-facing APIs filter by `WHERE user_id = currentUser.id AND tenant_id = currentSession.tenantId`. Admin endpoints require `email.admin` feature and explicitly return redacted DTOs (never `EmailAccountCredential` rows, never envelope contents). Encrypted credential blob never serialized in any response by design (separate DTO mapper).
-- **Residual risk**: None at the DB layer due to encryption; defense in depth via per-route audit in code review.
+- **Mitigation**: Dual enforcement — SQL-level filter (`WHERE user_id = currentUser.id OR user_id IS NULL`) on every CRUD route, AND UMES API interceptor at the response layer. Defense in depth.
+- **Residual risk**: None at DB layer; defense in depth via per-route audit in code review.
 
 #### State-cookie forgery
 - **Scenario**: Attacker crafts a state cookie to bind their callback to another user's session.
 - **Severity**: Critical
-- **Affected area**: OAuth callback
-- **Mitigation**: State payload includes `userId`; callback handler verifies it matches `currentSession.userId`. State cookie is encrypted+signed via AES-256-GCM with HKDF key derivation (forgery requires the key). HttpOnly + SameSite=Lax + 5-min TTL.
-- **Residual risk**: None given the key is properly managed (uses existing KMS pattern).
+- **Mitigation**: State payload includes `userId`; callback validates against session. Encryption + HMAC + 5-min TTL + HttpOnly + SameSite=Lax.
+- **Residual risk**: None given key is KMS-managed.
 
-#### IMAP credential exposure
-- **Scenario**: A debugging log or stack trace inadvertently includes the credential blob.
+#### Per-user credential exposure via shared credentials table
+- **Scenario**: A query against `integration_credentials` omits the `user_id` filter and returns another user's tokens.
 - **Severity**: Critical
-- **Affected area**: Worker logs, error reporting
-- **Mitigation**: `EmailHealthLog.context` schema explicitly rejects keys named `credential*`, `password*`, `token*`, `secret*` (enforced via Zod validator). Worker error handlers strip credential fields from any caught exception before logging. Unit tests assert this behavior.
-- **Residual risk**: New code paths could accidentally log credentials. Mitigated by enforcing the rejected-keys Zod validator on `EmailHealthLog.context` writes (any attempt to log a `credential*`/`password*`/`token*`/`secret*` key throws). Code review remains the second line of defense.
+- **Mitigation**: Every read goes through `findOneWithDecryption` with `user_id` in the where clause. Mutation guard on `integration_credentials.read` rejects queries without the filter unless caller has `integrations.admin`. Unit + integration tests verify.
+- **Residual risk**: Code review remains the second line of defense.
 
 ### Migration & Deployment Risks
 
-#### Schema deploy without provider packages
-- **Scenario**: Core module migration runs in prod before provider packages are deployed.
+#### Hub deltas applied before all providers deployed
+- **Scenario**: Phase 0 schema migrations land; providers not yet enabled.
 - **Severity**: Low
-- **Affected area**: Bootstrap
-- **Mitigation**: Migration is purely additive — empty tables don't break anything. Provider packages enable themselves at boot; their absence means `Connect Account` shows no providers, which is the graceful empty state.
+- **Mitigation**: All deltas are nullable / optional. Existing tenant channels untouched. Empty per-user channel list is the graceful state.
 - **Residual risk**: None.
 
 #### Module-enable in `modules.ts` without cache purge
-- **Scenario**: Operator merges the spec, deploys, but forgets `yarn mercato configs cache structural --all-tenants`.
+- **Scenario**: Operator forgets `yarn mercato configs cache structural --all-tenants` after enabling providers.
 - **Severity**: Medium
-- **Affected area**: Sidebar visibility, navigation
-- **Mitigation**: AGENTS.md mandates this command on any module-graph change. Deploy runbook addition recorded in changelog.
-- **Residual risk**: Operator omission; mitigated by Turbopack stale-chunk check.
+- **Mitigation**: AGENTS.md mandate documented in deploy runbook; Turbopack stale-chunk check + `yarn dev:reset` as escape hatches.
+- **Residual risk**: Operator omission.
 
 ### Operational Risks
 
 #### Polling fanout overwhelms providers
-- **Scenario**: 10,000 connected Gmail accounts all polled simultaneously.
+- **Scenario**: 10,000 connected Gmail channels polled simultaneously.
 - **Severity**: Medium
-- **Affected area**: Gmail API quota, worker queue
-- **Mitigation**: Per-account `last_polled_at + poll_interval_seconds` gate spreads load. Queue concurrency capped (10). Rate-limit honoring via `Retry-After` header. Aggregate quota monitoring deferred to ops dashboard (later spec).
-- **Residual risk**: Quota exhaustion at very high scale. Mitigated by tenant-owned OAuth app config (each tenant has their own quota pool).
-
-#### Envelope cap purge falls behind
-- **Scenario**: `purge-envelopes` worker fails or is slow; envelope table grows unbounded.
-- **Severity**: Low
-- **Affected area**: Storage cost
-- **Mitigation**: Cap is per-account (200), enforced on insert via "delete oldest if count > cap" within the `ingestMessage` command — so the cap is maintained even without the worker. The worker is a belt-and-suspenders sweep for ops resilience.
-- **Residual risk**: None.
-
-#### Health-log unbounded growth
-- **Scenario**: `purge-health-log` worker fails; logs accumulate.
-- **Severity**: Low
-- **Affected area**: Storage cost
-- **Mitigation**: 90-day retention by default; admin dashboard surfaces the worker last-run timestamp.
-- **Residual risk**: Operator visibility required.
+- **Mitigation**: Per-channel `last_polled_at + poll_interval_seconds` gate spreads load; scheduler enumerates ≤ 500 channels per 60s tick; worker concurrency capped at 10; `Retry-After` honored on 429.
+- **Residual risk**: Quota exhaustion at very high scale; mitigated by tenant-owned OAuth app config (each tenant has their own Google project quota pool).
 
 #### Email-bomb amplification
-- **Scenario**: A user's mailbox receives 100k unread messages in a short window; polling drains them all and emits 100k events.
+- **Scenario**: A user's mailbox receives 100k unread messages in a short window; polling drains them all.
 - **Severity**: Medium
-- **Affected area**: Event bus, downstream CRM subscribers
-- **Mitigation**: `poll-account` worker hard-caps `limit=100` per call; drain mode re-enqueues with backoff after every 5 drains; emits an `email.account.error` (severity=info) when drain exceeds 20 iterations.
+- **Mitigation**: `fetchHistory` caps `limit=100` per call; drain mode re-enqueues with backoff after 5 drains; emits `communication_channels.message.delivery_failed` (severity=info) when drain exceeds 20 iterations. Inbound-processor's idempotency prevents duplicate Messages.
 - **Residual risk**: Sustained high-volume mailbox = sustained event load. CRM subscribers must handle backpressure.
+
+#### HTML email XSS via Messages thread renderer
+- **Scenario**: Inbound HTML email contains a malicious script that bypasses the Messages module's rich-content renderer.
+- **Severity**: High
+- **Mitigation**: This is a **cross-spec dependency**, not a deliverable owned by this spec. The Messages module's rich-content renderer must sanitize HTML for `MessageChannelLink.channelContentType === 'email/mime'` (DOMPurify or equivalent). Phase 1 acceptance verifies that the rendered HTML is sanitized end-to-end with a CSP-violating payload integration test; if the Messages module's sanitizer is missing or insufficient, Phase 1 cannot ship and the issue is escalated to the Messages module owners (this is the forcing function — email is the first channel shipping HTML payloads). Until then, this spec's UMES component override on `MessagesThreadDetailHeader` MUST render HTML through a sanitization helper colocated in the hub's `lib/sanitize-channel-html.ts` and refuse to render unsanitized payloads.
+- **Residual risk**: Sanitizer bypasses are an ongoing concern; CSP + iframe sandboxing for rendered HTML is a v2 hardening.
+
+#### Provider credentials controlling cross-origin requests (lessons.md)
+- **Scenario**: Operator-configured IMAP host points at an attacker-controlled server that swallows credentials or redirects pagination.
+- **Severity**: High
+- **Mitigation**: IMAP host validated as DNS-resolvable + port-in-range at credential-validation time. Reject relative/redirect responses from the upstream server; only follow absolute URLs whose origin matches the validated host.
+- **Residual risk**: Sophisticated DNS attacks; mitigated by operator review of user-entered hosts.
 
 ## Final Compliance Report — 2026-05-21
 
@@ -1098,54 +1135,64 @@ Per the user's standing rule and `.ai/lessons.md`, **no spec phase is marked com
 - `.ai/specs/AGENTS.md`
 - `.ai/ds-rules.md`, `.ai/ui-components.md`
 
+### Specs Reviewed (architectural references)
+- `SPEC-045d-communication-notification-hubs.md` — canonical hub contract
+- `SPEC-041-2026-02-24-universal-module-extension-system.md` — UMES contract
+- `SPEC-056-2026-02-22-whatsapp-ai-chat-integration.md` — first ChannelAdapter implementation
+- `SPEC-002-2026-01-23-messages-module.md` — inbox destination
+- `SPEC-045-2026-02-24-integration-marketplace.md` — credentials + admin home
+- `ANALYSIS-013-gmail-integration.md` — feasibility for Gmail-as-channel (Pattern B)
+
 ### Compliance Matrix
 
 | Rule Source | Rule | Status | Notes |
 |---|---|---|---|
-| root AGENTS.md | Modules plural, snake_case (with exceptions for `auth`/`example`/`catalog`/etc.) | Compliant w/ caveat | Module id is `email` (singular). Mixed precedent in the codebase (`auth`, `catalog`, `data_sync`, `ai_assistant` are singular; `customers`, `messages`, `notifications`, `sales` are plural). Recommend confirming with user before implementation; rename to `emails` if strict plural is preferred. Event IDs and feature IDs would then become `emails.account.*` and `emails.account.connect` etc. — all mechanical. |
-| root AGENTS.md | No direct ORM relationships between modules | Compliant | `EmailAccount → User` is FK ID only (`user_id`), no MikroORM relation across module boundaries. |
-| root AGENTS.md | Filter by `organization_id` | Compliant | All five tables carry `tenant_id` + `organization_id`; all queries scoped. |
-| root AGENTS.md | Validate inputs with zod | Compliant | `data/validators.ts` covers all API bodies and command payloads. |
-| root AGENTS.md | Encrypt sensitive data via `encryption.ts` (no hand-rolled crypto) | Compliant | `credential_blob` registered in `encryption.ts`; reads use `findOneWithDecryption`. Uses existing AES-GCM + tenant-scoped DEK pipeline. |
-| root AGENTS.md | Provider packages live in `packages/<provider-package>/` | Compliant | `email-gmail`, `email-microsoft`, `email-imap` are workspace packages. |
-| root AGENTS.md | Commands for write operations | Compliant | 9 commands enumerated; each documents Undo or notes its non-undoability with rationale. |
-| root AGENTS.md | RBAC via features, not roles | Compliant | 5 features in `acl.ts`; routes use `requireFeatures` — no `requireRoles`. |
-| root AGENTS.md | Run `yarn mercato configs cache structural --all-tenants` after `modules.ts` change | Compliant | Documented in Migration & Compatibility + per-phase acceptance criteria. |
-| packages/core/AGENTS.md | API route files export `metadata` with per-method `requireAuth`/`requireFeatures` | Compliant | API Contracts intro explicitly documents this — no top-level `export const requireAuth`. |
-| packages/core/AGENTS.md | API routes MUST export `openApi` | Compliant | All routes export `openApi` per implementation plan. |
-| packages/core/AGENTS.md | CRUD routes use `makeCrudRoute` with `indexer: { entityType }` | Compliant | Listed account routes + admin routes use `makeCrudRoute`. OAuth callback / IMAP connect / set-primary / send / OAuth init are bespoke (don't fit CRUD shape) — they call `validateCrudMutationGuard` + `runCrudMutationGuardAfterSuccess` per the custom-write-route rule. |
-| packages/ui/AGENTS.md | `apiCall` not raw `fetch` | Compliant | Client side uses `apiCall` / `apiCallOrThrow`. |
-| packages/ui/AGENTS.md | `useGuardedMutation` for non-CrudForm writes | Compliant | "Connect", "Disconnect", "Set primary", "Reconnect" actions wrap writes in `useGuardedMutation` and pass `retryLastMutation`. |
-| packages/ui/AGENTS.md | `<CrudForm>` for backend forms; field-level errors via `createCrudFormError` | Compliant | IMAP connect dialog uses `<CrudForm>` with `createCrudFormError` for credential-validation failures. |
-| packages/ui/AGENTS.md | `<DataTable entityId apiPath columns>` with stable `entityId`/`extensionTableId` | Compliant | All three lists (user accounts, admin accounts, admin health log) use `<DataTable>` with stable `entityId`s for widget injection. |
-| packages/ui/AGENTS.md | Dialog Cmd/Ctrl+Enter, Escape | Compliant | Documented in UI section. |
-| packages/ui/AGENTS.md | `aria-label` on icon-only buttons | Compliant | UI section explicitly requires it per `.ai/ui-components.md`. |
-| packages/ui/AGENTS.md | `pageSize ≤ 100`; cursor/keyset pagination for large lists | Compliant | API Contracts pagination paragraph specifies cursor with limit ≤ 100; health log uses keyset on `(created_at DESC, id DESC)`. |
-| packages/events/AGENTS.md | `createModuleEvents` with `as const` | Compliant | Events declared via the helper. |
-| packages/events/AGENTS.md | `persistent: true` for subscribable side effects | Compliant | All 6 events persistent. |
-| packages/events/AGENTS.md | Cross-module side effects via events, not direct imports | Compliant | CRM consumes events; no direct imports. |
-| packages/queue/AGENTS.md | Idempotent workers | Compliant | Cursor + envelope upsert idempotent; `email.message.ingest` command idempotent on `(account_id, provider_message_id)` UNIQUE; event-emit only on actual insert. |
-| packages/cache/AGENTS.md | DI-resolved cache; tenant-scoped tags | N/A | This spec does not introduce caching. Future inbox/CRM specs will. |
-| .ai/ds-rules.md | Semantic status tokens (no hardcoded shades) | Compliant | UI section uses `bg-status-*-soft text-status-*-fg`; no `text-red-*`, no `bg-green-*`, no `dark:` overrides on status. |
-| .ai/ds-rules.md | Tailwind text scale (no arbitrary sizes) | Compliant | No `text-[13px]`, no `p-[13px]`, no arbitrary values. |
-| .ai/ui-components.md | lucide-react via icon registry in page body | Compliant | UI section specifies `@open-mercato/ui/backend/icons`. No inline `<svg>`. |
-| .ai/ui-components.md | Shared primitives (`Alert`, `StatusBadge`, `EmptyState`, `CollapsibleSection`, `LoadingMessage`/`Spinner`/`DataLoader`) | Compliant | UI section enumerates the primitives used. |
-| .ai/specs/AGENTS.md | Required sections (10) | Compliant | All present: TLDR, Overview, Problem Statement, Proposed Solution, Architecture, Data Models, API Contracts, Risks & Impact Review, Final Compliance Report, Changelog. |
-| .ai/specs/AGENTS.md | Risk register format | Compliant | All risks use the required block format with Scenario/Severity/Affected area/Mitigation/Residual risk. |
-| spec-writing skill | Frontend Architecture Contract (when touching `app/**`) | Compliant | Included Server/Client boundary map, `"use client"` ledger, client blob guardrail, route budgets, hydration test, provider/bootstrap scope. |
-| spec-writing skill | Security: input validation, parameterized queries, XSS protections, encoding, secret exclusion | Compliant | Security Posture subsection in Architecture documents each: zod everywhere, MikroORM (no raw SQL), no HTML rendering in v1 (XSS N/A), URL building via `URLSearchParams`, credential-key rejection in log validators. |
+| root AGENTS.md | External providers in own workspace packages (`packages/<provider-package>/`) | Compliant | `channel-gmail`, `channel-microsoft`, `channel-imap` |
+| root AGENTS.md | Module-id underscore convention | Compliant | `channel_gmail`, `channel_microsoft`, `channel_imap`, `communication_channels` |
+| root AGENTS.md | No direct ORM relationships between modules | Compliant | Provider packages link to hub only via DI registration; user link is FK ID + `EntityExtension` |
+| root AGENTS.md | Tenant + organization scoping | Compliant | All channels carry `tenant_id` + `organization_id` |
+| root AGENTS.md | Zod validation, derived types | Compliant | All API bodies + adapter inputs validated |
+| root AGENTS.md | Encryption via `defaultEncryptionMaps` | Compliant | Hub already encrypts `integration_credentials.credentials`; this spec changes nothing in the map |
+| root AGENTS.md | Commands for write operations | Compliant | Connect/Disconnect/SetPrimary/RefreshCredentials/MarkRequiresReauth as commands |
+| root AGENTS.md | RBAC via features, not roles | Compliant | All API routes use `requireFeatures`; one new feature `communication_channels.connect_user_channel` declared in `acl.ts` + setup.ts |
+| root AGENTS.md | Run cache structural after `modules.ts` change | Compliant | Documented in deploy runbook + per-phase acceptance |
+| root AGENTS.md | OSS not depending on enterprise | Compliant | State-cookie helper ported; Phase 0 grep verification |
+| packages/core/AGENTS.md | Per-method `metadata` (no top-level `requireAuth`) | Compliant | Documented in API Contracts |
+| packages/core/AGENTS.md | `openApi` exports | Compliant | All routes export |
+| packages/core/AGENTS.md | `makeCrudRoute` for CRUD; `validateCrudMutationGuard` + `runCrudMutationGuardAfterSuccess` for bespoke writes | Compliant | OAuth init/callback, credentials connect, set-primary, send-as-user all use guards |
+| packages/ui/AGENTS.md | `apiCall`, not raw `fetch` | Compliant | UI side |
+| packages/ui/AGENTS.md | `useGuardedMutation` wrapping non-CrudForm writes | Compliant | Connect/Disconnect/Reconnect actions |
+| packages/ui/AGENTS.md | `CrudForm`, `DataTable`, semantic status tokens, lucide-react, `aria-label` on icon-only buttons, dialog keyboard shortcuts, `pageSize ≤ 100` | Compliant | UI section explicit |
+| packages/events/AGENTS.md | `createModuleEvents({ moduleId, events })` shape, `as const` | N/A | This spec adds no new events; uses hub's existing events |
+| packages/queue/AGENTS.md | Idempotent workers, concurrency ≤ 20 | Compliant | poll-channel concurrency 10; inbound-processor idempotent on `(channel_id, external_message_id)` |
+| packages/cache/AGENTS.md | DI-resolved cache, tenant-scoped tags | N/A | Spec introduces no caching beyond hub's existing behavior |
+| .ai/ds-rules.md | Semantic tokens, no arbitrary text sizes, no `dark:` on status colors | Compliant | UI uses `bg-status-*-soft text-status-*-fg`; no hardcoded shades |
+| .ai/ui-components.md | lucide-react via backend icon registry, no inline `<svg>` | Compliant | UI section explicit |
+| .ai/specs/AGENTS.md | Required sections (10), risk register format | Compliant | All present, format matches |
+| spec-writing skill | Frontend Architecture Contract | Compliant | Server/Client boundary, client bundle guardrail, hydration test |
+| spec-writing skill | Security: input validation, parameterized queries, XSS, encoding, secret exclusion | Compliant | Security Posture subsection enumerates each |
+| SPEC-045d | Use `ChannelAdapter` v2 interface | Compliant | All three providers implement it |
+| SPEC-045d | Use hub entities (`MessageChannelLink`, `ChannelThreadMapping`, `ExternalMessage`) | Compliant | No parallel storage |
+| SPEC-045d | Hub events, not provider-specific events | Compliant | No new event IDs introduced |
+| SPEC-041 | Use UMES for cross-module integration | Compliant | 17 named extension points across 12 phases of UMES |
+| `.ai/lessons.md` | Integration tests module-local | Compliant | Per-phase `__integration__/` placement |
+| `.ai/lessons.md` | Provider URL validation | Compliant | IMAP host validation noted in Security Posture |
+| `.ai/lessons.md` | No raw SQL in route handlers | Compliant | All DB access via MikroORM repository / helpers |
+| `.ai/lessons.md` | Cross-process event bridge for worker SSE | Acknowledged | Phase 0 acceptance requires bridge or polling fallback |
 
 ### Internal Consistency Check
 
 | Check | Status | Notes |
 |---|---|---|
-| Data models match API contracts | Pass | DTOs in API contracts correspond to entity fields; redacted fields explicitly noted for admin endpoints. |
-| API contracts match UI/UX section | Pass | Every UI action maps to a documented API route. |
-| Risks cover all write operations | Pass | Connect, disconnect, set-primary, rename, send, ingest, refresh all addressed. |
-| Commands defined for all mutations | Pass | 9 commands cover all state changes. |
-| Events cover all state-change announcements | Pass | account.connected/disconnected/requires_reauth/error + message.received/sent. |
-| Encryption declared for all sensitive columns | Pass | `credential_blob` is the only sensitive column; declared. |
-| Backward compatibility analysis covers every modified surface | Pass | Table enumerates every contract surface, all additive. |
+| Data models match API contracts | Pass | Hub deltas align with route extensions |
+| API contracts match UI/UX | Pass | Every UI action maps to a documented route |
+| Risks cover all write operations | Pass | Connect, disconnect, set-primary, send, ingest, refresh all addressed |
+| Commands defined for all mutations | Pass | 5 hub commands cover all state changes |
+| Events: use existing hub events, no new IDs introduced | Pass | This is a deliberate design decision |
+| Encryption: no new sensitive columns introduced | Pass | Hub's existing encryption map covers `credentials` |
+| BC analysis covers every modified surface | Pass | Table enumerates every contract surface as additive |
+| UMES extension points actually exist in SPEC-041 | Pass | All 17 hooks map to documented UMES phases A-N |
+| OSS independence enforced | Pass | Grep verification step in Phase 0 acceptance |
 
 ### Non-Compliant Items
 
@@ -1153,38 +1200,37 @@ None.
 
 ### Verdict
 
-- **Fully compliant**: Approved — ready for implementation.
+- **Fully compliant with hub + UMES + AGENTS.md**. Approved for implementation.
 
 ## Changelog
 
-### 2026-05-21
-- Initial specification.
+### 2026-05-22 — Pre-implementation fixes (`/pre-implement-spec` analysis remediation)
 
-### Review — 2026-05-21
-- **Reviewer**: Agent (spec-writing skill, adversarial pass)
-- **Security**: Passed — added explicit Security Posture subsection covering XSS N/A in v1, URL/header encoding, parameterized queries, secret-key rejection in `EmailHealthLog.context` validator
-- **Performance**: Passed — added scheduler N+1 mitigation note (single indexed scan on `(status, last_polled_at)`, 500-row enumeration cap per tick) and cursor/keyset pagination for admin lists
-- **Cache**: N/A — this spec does not introduce caching
-- **Commands**: Passed — 9 commands, undo behavior documented for every mutation, non-undoability explicitly justified for send (cannot un-send) and refresh_token (no business undo)
-- **Risks**: Passed — 13 concrete scenarios across all 5 categories (data integrity, cascading, isolation, deployment, operational), each with severity + mitigation + residual
-- **Verdict**: Approved
+Applied the remediation plan from `.ai/specs/analysis/ANALYSIS-2026-05-21-email-integration-foundation.md`. No architectural changes; all updates are scope, hygiene, and contract-surface clarifications.
 
-### Review fixes — 2026-05-21
-- API Contracts: added per-method `metadata` requirement, cursor pagination, `makeCrudRoute` vs bespoke route delineation with `validateCrudMutationGuard` for custom writes
-- UI: added explicit `aria-label` requirement for icon-only buttons and `pageSize ≤ 100` cursor pagination for DataTables
-- Architecture: added Security Posture subsection (XSS, URL encoding, parameterized queries, log-key rejection)
-- Architecture: added scheduler N+1 mitigation note
-- Compliance Matrix: expanded from 22 to 30 rules, all marked Compliant except module-name plurality (Compliant with caveat — flagged for user confirmation)
+- **§ Prerequisites & Cross-Spec Dependencies** — new section. SPEC-045d (Communications Hub) is now an explicit hard prerequisite delivered by a separate spec/PR. This spec stops carrying SPEC-045d delivery inside its Phase 0. SPEC-056 (WhatsApp) is documented as a sibling, not a dependency. Coordination rules with both are spelled out. **Housekeeping follow-up**: `git mv .ai/specs/implemented/SPEC-045d-communication-notification-hubs.md .ai/specs/` (and similarly SPEC-056 if present in `implemented/`) — both are spec-only and currently misfiled as implemented. Out of scope for this spec to perform the move; flagged here so it isn't forgotten.
+- **§ Relationship to `inbox_ops`** — new subsection. Pins the scope split per the maintainer clarification: `inbox_ops` is the *tenant-forwarded Resend inbox for AI action extraction*; this spec is the *user's own real mailbox via Gmail/Microsoft/IMAP for unified-inbox conversation*. Different inputs, different intents, coexist. Neither subscribes to the other's events. Each provider package's README must surface this distinction.
+- **§ Non-goals (v1)** — added explicit "customer-portal channel ownership out of scope" and "inbox_ops is not modified" lines.
+- **§ Hub Deltas → Delta 1 / Delta 5** — replaced raw `REFERENCES users(id)` with `EntityExtension`-based cross-module link declarations (root `AGENTS.md` rule: no direct ORM relationships between modules). Added explicit cross-module coordination note for the `integrations` module owning its column.
+- **§ Hub Deltas → Delta 6** — pinned the scheduler mechanism to `@open-mercato/scheduler` (the platform's canonical cron home) with an explicit `schedulers/poll-tick.ts` entry. Explicitly forbids `setInterval` in workers and ad-hoc BullMQ repeatables.
+- **§ Data Models** — SQL blocks are now labelled illustrative (generated by `yarn db:generate`), removed raw `REFERENCES users(id)` FKs, added a new `data/extensions.ts` block showing the canonical `EntityExtension` declarations for both cross-module links.
+- **§ API Contracts → Per-method `metadata` shape — canonical example** — new subsection. Five-line code snippet showing the required per-method `metadata` export, the `openApi` export, and the mutation-guard wrap pattern for bespoke writes. Prevents the common "top-level `requireAuth`" slip.
+- **§ Outbound flow (Path A)** — pinned the subscriber to re-fetch the Message by ID rather than depending on `messages.message.sent` payload shape. Decouples the hub from any future payload-shape change in the messages module.
+- **§ Security Posture (HTML sanitizer)** — pinned the canonical sanitizer location to `packages/core/src/modules/communication_channels/lib/sanitize-channel-html.ts`. Hub owns the function; Messages module imports it at the rich-content widget injection. If SPEC-045d delivery does not include this helper, Phase 1 of this spec cannot ship.
+- **§ Implementation Plan** — restructured:
+  - Added a new "Prerequisite — SPEC-045d Communication Hub delivery (NOT in this spec)" section with a verification gate (four shell commands) that must pass before Phase 0 starts.
+  - Phase 0 rescoped to ONLY this spec's incremental deltas. Scope shrunk from "deliver the hub + apply our deltas" to "apply our deltas on top of an already-delivered hub". 18 explicit work items + 6 integration tests + 7 acceptance gates.
+  - Renamed `TC-HUB-*` to `TC-CHANNEL-EMAIL-HUB-*` to keep the test-id namespace coherent with subsequent phases.
 
-### Pre-implementation analysis fixes — 2026-05-21
-Findings from `.ai/specs/analysis/ANALYSIS-2026-05-21-email-integration-foundation.md` applied:
-- **Encryption snippet** rewritten to canonical `defaultEncryptionMaps: ModuleEncryptionMap[]` export from `@open-mercato/shared/modules/encryption`. Previous draft imported a non-existent `registerEntityEncryption` symbol.
-- **Events snippet** rewritten to canonical `createModuleEvents({ moduleId, events })` shape with full dotted IDs in an `as const` array. Payload types moved to TS aliases referenced via the typed `emit`. `persistent: true` documented as a subscriber-metadata field, not an event-definition field.
-- **Provider package layout** restructured to `packages/<pkg>/src/modules/<module_id>/...` to match `gateway-stripe` / `sync-akeneo` conventions and align module IDs with auto-discovery (dashes → underscores).
-- **Access Control section** added: five ACL features enumerated with `id`/`title`/`module`, plus a `defaultRoleFeatures` map (admin gets all five; manager/user get connect+manage+send). `email.admin.providers` is the fifth feature, separated from `email.admin` to gate OAuth-client-credential writes.
-- **`modules.ts` entries** documented explicitly with underscore-converted IDs (`email_gmail`, `email_microsoft`, `email_imap`) and the required structural-cache purge.
-- **OSS Independence** section added: explicit ban on `@open-mercato/enterprise` imports from this module and its provider packages, with a Phase 1 grep-based verification step. State-cookie helper is ported (re-implemented locally), not imported.
-- **`AttachmentRef` type** defined as a Zod discriminated union (`attachment` referencing the existing attachments module, or `inline` for ad-hoc content with hard size caps).
-- **Phase 8 removed**: integration tests moved in-phase. Each phase ships its own module-local Playwright specs under `<package>/src/modules/<id>/__integration__/` per `.ai/lessons.md`. `.ai/qa/scenarios/` retains only markdown scenarios.
-- **Section title**: "Migration & Compatibility" renamed to "Migration & Backward Compatibility" to match `BACKWARD_COMPATIBILITY.md` recommendation.
-- **Cross-process event bridge note** added to the events section: any future flip of `email.message.received` to `clientBroadcast: true` MUST be paired with the cross-process bridge work (see `.ai/lessons.md` → "Browser SSE bridges must work across worker and web processes").
+### 2026-05-21 — Rewrite (autonomous brainstorming + UMES alignment)
+Complete rewrite of the email integration spec. The previous draft (`.ai/specs/2026-05-21-email-integration-foundation.md`) proposed a standalone `email` module with parallel entities, events, OAuth router, polling worker, and admin UI. That approach was rejected by the maintainer because Open Mercato already has a finalized Communications Hub architecture (SPEC-045d) with an explicit `channel_email` slot, and a Universal Module Extension System (SPEC-041) for cross-module integration. This rewrite:
+
+- Folds all email functionality under the `communication_channels` hub. Three workspace packages (`@open-mercato/channel-gmail`, `@open-mercato/channel-microsoft`, `@open-mercato/channel-imap`) implement `ChannelAdapter` v2.
+- Introduces minimal additive hub deltas: `CommunicationChannel.user_id?`, `poll_interval_seconds`, `last_polled_at`, `status`, `last_error`, `is_primary`; `IntegrationCredentials.user_id?`; `ChannelCapabilities.realtimePush?`; `ChannelAdapter.refreshCredentials?` / `validateCredentials?`; hub-side poll-channel worker; per-user channel ACL gates; generic `channel_requires_reauth` notification type; OAuth state-cookie helper (ported locally, no enterprise imports); OAuth callback router.
+- Uses UMES at 17 named extension points across all 12 implemented UMES phases.
+- Phases the work: Phase 0 hub deltas, Phase 1 IMAP, Phase 2 Gmail, Phase 3 Microsoft, Phase 4 UMES polish, Phase 5 docs.
+- Adopts module-local `__integration__/` placement per `.ai/lessons.md`.
+- Inbound emails auto-create `Message` records in the unified inbox via the hub's bridge — no parallel envelope store.
+- Outbound via the hub's standard `messages.message.sent` → adapter chain, plus a thin `sendAsUser` facade for programmatic callers.
+
+The previous draft is superseded. This spec is the canonical email integration design.

--- a/.ai/specs/2026-05-21-email-integration-foundation.md
+++ b/.ai/specs/2026-05-21-email-integration-foundation.md
@@ -1,0 +1,1190 @@
+# Email Integration Foundation (Per-User, Multi-Provider)
+
+## TLDR
+
+**Key Points:**
+- New `email` module + three provider workspace packages (`email-gmail`, `email-microsoft`, `email-imap`) deliver per-user email account linking, send, and receive primitives.
+- Foundation only: no CRM hooks, no inbox UI, no message-body persistence. A follow-on CRM spec consumes the canonical events and decides storage.
+
+**Scope:**
+- Per-user OAuth linking for Gmail and Microsoft 365 / Outlook.
+- Per-user IMAP+SMTP credential linking for everything else.
+- Polling-based inbound sync (5-min default), emits `email.message.received` event.
+- `sendAsUser(accountId, message)` outbound primitive — sends from the user's mailbox; existing Resend pipeline untouched.
+- User Settings → Email Accounts UI (connect / rename / primary / reconnect / disconnect).
+- Admin debug view for tenant-wide account health (no content access).
+- Per-provider Marketplace Integration entries (additive to existing Integration Marketplace).
+
+**Concerns:**
+- OAuth client flow does not yet exist in the codebase; this spec introduces it. State-cookie pattern borrowed from `packages/enterprise/src/modules/sso/lib/state-cookie.ts`.
+- The existing Integration Marketplace is tenant-scoped only. This spec intentionally does NOT extend `integration_credentials`; it adds a separate per-user credential store (`email_account_credentials`) to keep tenant-vs-user secret leakage impossible by construction.
+- Sending real emails as a user from a provider's API can affect their personal Sent folder and deliverability reputation. Mitigation: explicit per-account opt-in via UI flow; no automatic enrolment.
+
+---
+
+## Overview
+
+Open Mercato today has **outbound-only, Resend-only** email (~15 transactional flows: auth, MFA, notifications, sales, onboarding, payments, portal, messages). Inbound exists only inside `inbox_ops`, which uses webhook-delivered emails to a per-tenant shared address and parses them into action proposals — not a general per-user mailbox integration.
+
+The product needs each logged-in user to connect their own email account (Gmail, Microsoft 365, or any IMAP/SMTP provider) so that, in a follow-on CRM specification, sent and received emails can be attached to customers, deals, and conversations. This spec delivers the **enabling infrastructure** as an independently shippable PR before the CRM integration is designed.
+
+> **Market Reference**: HubSpot Sales (Gmail/Outlook OAuth + IMAP fallback), Pipedrive Smart Email BCC + Gmail/Microsoft integration, Salesforce Inbox, Front (HelpScout-style per-user inbox sync). Adopted: per-user OAuth model, provider-abstracted contract with provider-specific metadata escape hatch, polling-as-baseline (push-as-future). Rejected: BCC-only "smart forward" patterns (lossy, depends on user discipline) and shared system mailbox patterns (don't address the per-user requirement).
+
+## Problem Statement
+
+1. **No per-user email accounts.** Every outbound email today is sent from a single Resend identity. Users cannot send from their own mailbox; recipients see the system address, replies don't land in the user's Sent folder, and there is no concept of "this email was sent by Jane to John."
+2. **No inbound email.** Inbound only exists for `inbox_ops`'s tenant-shared address, parsed by an LLM for action proposals. There is no infrastructure for a user's mailbox to be polled, no canonical inbound-message event, and nothing for downstream modules (notably CRM) to subscribe to.
+3. **No provider abstraction.** The single Resend integration is hardcoded across 15+ call sites. Adding a second provider (Gmail send, Microsoft Graph send, SMTP send) would require a new abstraction layer that does not exist.
+4. **No third-party OAuth client flow.** The codebase has user-SSO OAuth (enterprise SSO module) but no infrastructure for Open Mercato acting as a *client* of a third-party identity to obtain that user's access+refresh tokens. We can borrow the SSO state-cookie helper, but the actual flow needs to be built.
+5. **Integration Marketplace is tenant-scoped only.** All current `integration_credentials` rows are keyed by `(organization_id, tenant_id)`. Per-user accounts need a parallel store with strict per-user isolation.
+
+## Proposed Solution
+
+A new core module `@open-mercato/core/modules/email` orchestrates per-user email accounts, delegates provider-specific operations to dedicated workspace packages (`@open-mercato/email-gmail`, `@open-mercato/email-microsoft`, `@open-mercato/email-imap`), and exposes a stable canonical-message contract for downstream consumers (CRM, future inbox UI).
+
+**Approach: thick core + provider extension hook ("Approach C" from brainstorming).**
+- Core defines the `EmailProvider` interface, owns workers, retry logic, sync cursors, event emission, OAuth callback router, encrypted credential storage, ACL features, and admin observability.
+- Provider packages own OAuth config + token exchange (where applicable), sync logic (Gmail History API, Graph delta, IMAP UIDNEXT/UIDVALIDITY), send logic, and a typed `providerMeta` schema for provider-specific data (Gmail labels, Outlook categories, IMAP flags) that travels in the canonical message via a discriminated union.
+- The existing Resend pipeline is untouched. Both pipelines coexist; callers choose per use-case.
+
+### Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Three providers in v1 (Gmail, Microsoft, IMAP) | Customer requirement: "each logged-in user uses their own account from different providers." Forcing all three from day 1 prevents the provider abstraction from accidentally over-fitting one. |
+| Polling, not native push | Universal across providers, no public endpoints required, predictable cost. Native push (Gmail Pub/Sub, Graph subscriptions) deferred to a later spec. |
+| Separate `email_account_credentials` table, NOT extending `integration_credentials` | Per-user secrets and tenant-wide secrets have different access-control semantics. Mixing them in one table risks cross-user leakage via one missed `WHERE` clause. Both still use the shared `findWithDecryption` encryption helper. |
+| No message body or attachment persistence in v1 | "What we store" is a CRM-spec decision. This spec emits `CanonicalMessage` events with a `bodyRef` (opaque provider pointer); downstream subscribers decide whether and how to fetch + persist bodies. |
+| `EmailMessageEnvelope` capped at last 200 per account, rolling | Provides a debug view for verifying inbound polling without committing to a content-persistence story. CRM spec defines its own persistent store; this table is explicitly NOT a data source for CRM. |
+| Both pipelines coexist with Resend (caller picks) | Smallest blast radius for v1. Migration of existing system-sent emails (password reset, MFA, etc.) is out of scope and a clear non-goal. |
+| Multiple accounts per user, one primary | Common in CRM tooling (HubSpot, Pipedrive). Schema cost is one extra boolean column; not having it forces a painful migration later. |
+
+### Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Single `email` module with all providers inline | Violates the AGENTS.md rule that every external integration provider lives in its own workspace package. |
+| Thin core, fat per-provider packages (Approach B) | High duplication of worker/retry/sync-cursor logic across three packages; risk of behavioral drift between providers. |
+| Strict canonical schema with no `providerMeta` (Approach A) | Loses provider-specific features (Gmail labels, Outlook categories, IMAP flags) in normalization — CRM team will need them. |
+| Reuse `integration_credentials` with a nullable `userId` column | Mixes tenant-scoped and user-scoped secrets in one table; one missed `WHERE user_id = ?` becomes a cross-user disclosure. |
+| Replace Resend wholesale with user-account send | Touches notifications, messages, sales, onboarding, MFA, portal — v1 scope explosion with no incremental shipping value. |
+| Native push (Gmail Pub/Sub, Graph subscriptions) in v1 | Requires a public webhook endpoint, GCP Pub/Sub topic configured globally, Graph subscriptions renewed every 3 days. Marginal UX win (real-time vs. 5-min lag) doesn't justify the v1 scope. Defer to opt-in v2 spec. |
+
+## User Stories
+
+- **A sales rep** wants to **connect their Gmail account in Open Mercato** so that **emails I send through the platform appear in my own Sent folder and replies come to my inbox.**
+- **An account manager on Microsoft 365** wants to **link their Outlook account** so that **future CRM features can attach the conversations to my deals.**
+- **A user with a custom domain on Fastmail** wants to **connect via IMAP+SMTP** so that **the integration works without needing OAuth support from my provider.**
+- **A user with both a work Microsoft account and a personal Gmail** wants to **connect both and mark one as primary** so that **the system knows which to default to.**
+- **A tenant admin** wants to **see which users have connected accounts and which have authentication errors** so that **I can help them reconnect — without ever seeing the contents of their emails.**
+- **A tenant admin in a SaaS deployment** wants to **use the platform's shared OAuth app** so that **I don't need to register my own with Google.**
+- **A tenant admin in a self-hosted deployment** wants to **register the tenant's own Google Cloud OAuth client** so that **the consent screen shows their company name.**
+
+## Architecture
+
+### Package & Module Layout
+
+```
+packages/core/src/modules/email/         # Orchestrator
+  index.ts                               # Module metadata
+  setup.ts                               # ACL grants, sync-role-acls hook
+  acl.ts                                 # 5 features (see Access Control section)
+  di.ts                                  # EmailProviderRegistry, OAuthStateService, EmailAccountService
+  encryption.ts                          # Declares encrypted columns
+  data/entities.ts                       # 5 entities (see Data Models)
+  data/validators.ts                     # Zod schemas
+  data/extensions.ts                     # Link EmailAccount → User (FK ID only)
+  lib/provider.ts                        # EmailProvider interface
+  lib/canonical-message.ts               # CanonicalMessage + providerMeta union
+  lib/provider-registry.ts               # DI registry of providers
+  lib/oauth-state.ts                     # CSRF state-cookie helper
+  lib/oauth-router.ts                    # Generic /api/email/oauth/[provider]/callback
+  lib/send-pipeline.ts                   # sendAsUser() facade
+  commands/                              # Command pattern (see Commands)
+    connectAccount.ts
+    disconnectAccount.ts
+    setPrimaryAccount.ts
+    renameAccount.ts
+    updateImapCredentials.ts
+    sendMessage.ts
+    ingestMessage.ts
+  workers/
+    poll-account.ts                      # Generic poll worker
+    refresh-tokens.ts                    # Renew OAuth before expiry
+    purge-envelopes.ts                   # Daily envelope-cap cleanup
+    purge-health-log.ts                  # Daily 90-day cleanup
+  api/                                   # Auto-discovered
+    post/accounts/connect/[provider]/route.ts
+    get/oauth/[provider]/callback/route.ts
+    post/accounts/imap/route.ts
+    get/accounts/route.ts
+    patch/accounts/[id]/route.ts
+    delete/accounts/[id]/route.ts
+    post/accounts/[id]/set-primary/route.ts
+    post/send/route.ts
+    get/admin/accounts/route.ts          # email.admin only
+    get/admin/health-log/route.ts        # email.admin only
+  backend/
+    profile/email-accounts/page.tsx      # User settings UI
+    email/admin/page.tsx                 # Admin debug UI
+  events.ts                              # 6 events (see Events)
+  notifications.ts                       # email_account_requires_reauth type
+  notifications.client.ts                # Client-side renderer for that notification
+
+packages/email-gmail/                              # npm package @open-mercato/email-gmail
+  package.json
+  build.mjs / watch.mjs                            # standard provider-package build (see packages/gateway-stripe/build.mjs)
+  src/modules/email_gmail/                         # module id 'email_gmail' (dashes → underscores per root AGENTS.md)
+    index.ts                                       # ModuleInfo metadata
+    setup.ts                                       # registers provider with core EmailProviderRegistry; marketplace integration row
+    di.ts                                          # DI bindings for the provider
+    lib/oauth.ts                                   # Google OAuth (authorize URL, token exchange, refresh)
+    lib/sync.ts                                    # gmail.users.history.list incremental sync
+    lib/send.ts                                    # gmail.users.messages.send (raw RFC822)
+    lib/health.ts                                  # gmail.users.getProfile
+    lib/provider-meta.ts                           # GmailProviderMeta zod schema
+
+packages/email-microsoft/                          # @open-mercato/email-microsoft
+  src/modules/email_microsoft/                     # module id 'email_microsoft'
+    index.ts
+    setup.ts                                       # provider registration + marketplace integration row
+    di.ts
+    lib/oauth.ts                                   # Microsoft identity platform v2.0 (Azure AD)
+    lib/sync.ts                                    # /me/mailFolders/inbox/messages/delta
+    lib/send.ts                                    # /me/sendMail
+    lib/health.ts                                  # /me
+    lib/provider-meta.ts                           # OutlookProviderMeta zod schema
+
+packages/email-imap/                               # @open-mercato/email-imap
+  src/modules/email_imap/                          # module id 'email_imap'
+    index.ts
+    setup.ts                                       # provider registration + marketplace integration row
+    di.ts
+    lib/credentials.ts                             # validateCredentials (both IMAP + SMTP login probe)
+    lib/sync.ts                                    # imapflow polling using UIDVALIDITY + UIDNEXT
+    lib/send.ts                                    # nodemailer SMTP
+    lib/health.ts                                  # auth check on both
+    lib/provider-meta.ts                           # ImapProviderMeta zod schema
+```
+
+**Workspace package convention** (matches `packages/gateway-stripe/src/modules/gateway_stripe/...`, `packages/sync-akeneo/src/modules/sync_akeneo/...`): the npm package name uses dashes; the in-repo module id under `src/modules/<id>/` uses underscores. Root `AGENTS.md`:
+> Module-id convention: package `@open-mercato/<suffix>` ⇒ module id `<suffix>` with dashes converted to underscores (e.g. `@open-mercato/ai-assistant` ⇒ `ai_assistant`).
+
+Provider packages register with the core `EmailProviderRegistry` from their own `setup.ts` so each provider is independently enable-able from `apps/mercato/src/modules.ts`. Marketplace Integration registration is also driven from each provider's `setup.ts` (additive — see `packages/core/src/modules/integrations/AGENTS.md`).
+
+### `apps/mercato/src/modules.ts` entries
+
+The four modules are added to `enabledModules` with underscore-converted IDs (per the root `AGENTS.md` module-id convention; mismatched IDs silently break auto-discovery):
+
+```ts
+// apps/mercato/src/modules.ts — append to enabledModules
+{ id: 'email',           from: '@open-mercato/core' },
+{ id: 'email_gmail',     from: '@open-mercato/email-gmail' },
+{ id: 'email_microsoft', from: '@open-mercato/email-microsoft' },
+{ id: 'email_imap',      from: '@open-mercato/email-imap' },
+```
+
+After editing `modules.ts`, run `yarn mercato configs cache structural --all-tenants` (required by root `AGENTS.md` after any module-graph change). If Turbopack still serves a stale compiled chunk, run `yarn dev:reset`.
+
+### OSS Independence
+
+This is an **OSS module** (`packages/core/...`) and the provider packages live under top-level workspace packages, not under `packages/enterprise/...`. The OAuth state-cookie helper at `packages/enterprise/src/modules/sso/lib/state-cookie.ts` is the **design reference** — its logic is **ported (re-implemented) locally** at `packages/core/src/modules/email/lib/oauth-state.ts`, NOT imported.
+
+**MUST NOT**:
+- import from `@open-mercato/enterprise` anywhere in `packages/core/src/modules/email/**`
+- import from `@open-mercato/enterprise` in any of the three provider packages (`packages/email-gmail/**`, `packages/email-microsoft/**`, `packages/email-imap/**`)
+
+Phase 1 acceptance includes a verification step:
+
+```bash
+grep -r "@open-mercato/enterprise" packages/core/src/modules/email packages/email-gmail packages/email-microsoft packages/email-imap
+# Expected: empty output
+```
+
+The local `oauth-state.ts` MUST reproduce: AES-256-GCM encryption, HKDF key derivation, encrypted payload `{ nonce, userId, providerId, iat, exp }`, 5-minute TTL, signature/tamper resistance. Unit tests cover encrypt/decrypt roundtrip, TTL expiry, signature tamper, userId-mismatch rejection. Key source: `OM_EMAIL_OAUTH_STATE_KEY` env var with HKDF fallback from `KMS_MASTER_KEY` (see Configuration).
+
+### Provider Interface
+
+```ts
+// packages/core/src/modules/email/lib/provider.ts
+export interface EmailProvider {
+  readonly id: 'gmail' | 'microsoft' | 'imap'
+  readonly label: string
+  readonly authStyle: 'oauth2' | 'credentials'
+  readonly capabilities: ProviderCapabilities
+
+  // OAuth-only
+  buildAuthorizeUrl?(args: { state: string; redirectUri: string; loginHint?: string }): string
+  exchangeCode?(args: { code: string; redirectUri: string }): Promise<OAuthTokens>
+  refreshAccessToken?(args: { refreshToken: string }): Promise<OAuthTokens>
+
+  // Credentials-only
+  validateCredentials?(input: unknown): Promise<{
+    ok: boolean
+    emailAddress: string
+    capabilities: ProviderCapabilities
+    errors?: Record<string, string>
+  }>
+
+  // All providers
+  healthCheck(args: { accountId: string; credentials: ResolvedCredentials }): Promise<HealthCheckResult>
+  fetchSince(args: { accountId: string; credentials: ResolvedCredentials; cursor: SyncCursor | null; limit: number }): Promise<FetchResult>
+  sendMessage(args: { accountId: string; credentials: ResolvedCredentials; message: OutboundMessage }): Promise<SendResult>
+}
+
+export type FetchResult = {
+  messages: CanonicalMessage[]
+  nextCursor: SyncCursor
+  hasMore: boolean
+}
+
+export type SendResult = {
+  providerMessageId: string
+  providerThreadId: string | null
+  sentAt: Date
+  providerMeta: ProviderMetaUnion
+}
+```
+
+### Canonical Message (the event payload contract)
+
+```ts
+// packages/core/src/modules/email/lib/canonical-message.ts
+export type CanonicalMessage = {
+  providerMessageId: string
+  providerThreadId: string | null
+  direction: 'inbound' | 'outbound'
+  from: EmailAddress
+  to: EmailAddress[]
+  cc: EmailAddress[]
+  bcc: EmailAddress[]
+  replyTo: EmailAddress[]
+  subject: string
+  snippet: string                   // ≤200 chars
+  inReplyTo: string | null          // RFC 5322 Message-Id of parent
+  references: string[]              // full thread chain
+  sentAt: Date
+  receivedAt: Date | null
+  headers: Record<string, string>   // raw RFC822 headers, lowercased keys
+  bodyRef: BodyRef                  // opaque pointer; body NOT in payload (v1)
+  providerMeta: ProviderMetaUnion   // discriminated union
+}
+
+export type BodyRef =
+  | { provider: 'gmail'; gmailId: string; mimeType: string }
+  | { provider: 'microsoft'; graphId: string }
+  | { provider: 'imap'; uidValidity: number; uid: number; folder: string }
+
+export type ProviderMetaUnion =
+  | { provider: 'gmail'; data: GmailProviderMeta }
+  | { provider: 'microsoft'; data: OutlookProviderMeta }
+  | { provider: 'imap'; data: ImapProviderMeta }
+```
+
+A future `fetchBody(bodyRef, accountId)` helper (out of scope for v1) will resolve `bodyRef` back to the provider for on-demand body fetch when the CRM spec or an inbox UI needs it.
+
+### OAuth Flow
+
+```
+1. User: clicks "Connect Gmail" on /backend/profile/email-accounts
+   → client POST /api/email/accounts/connect/gmail
+2. Server:
+   - Verifies session + email.account.connect feature
+   - Resolves OAuth app credentials (tenant Marketplace > platform env)
+   - Generates 32-byte random state
+   - Encrypts state payload { nonce, userId, providerId, iat, exp } via state-cookie helper (AES-256-GCM + HKDF, 5-min TTL)
+   - Sets HttpOnly SameSite=Lax cookie 'om_email_oauth_state'
+   - Returns { authorizeUrl } in JSON
+3. Client: window.location = authorizeUrl
+4. Google: user consents, redirects back to GET /api/email/oauth/gmail/callback?code=...&state=...
+5. Callback handler:
+   a. Reads state cookie, validates signature + TTL + userId-matches-session + providerId-matches-route
+   b. Deletes the state cookie
+   c. provider.exchangeCode({ code, redirectUri }) → OAuthTokens
+   d. Dispatches command: email.account.connect { userId, providerId, emailAddress, tokens }
+   e. Command creates EmailAccount + EmailAccountCredential, marks isPrimary if first account, emits email.account.connected event
+   f. Enqueues initial poll-account job
+   g. 302 redirect to /backend/profile/email-accounts?flash=connected
+```
+
+### IMAP Connection Flow
+
+```
+1. User submits IMAP credential form (CrudForm dialog)
+   POST /api/email/accounts/connect/imap { displayName, imapHost, imapPort, imapTls, imapUser, imapPassword,
+                                            smtpHost, smtpPort, smtpTls, smtpUser, smtpPassword }
+2. provider.validateCredentials probes both IMAP login and SMTP login
+3. On success: dispatch email.account.connect command (same as OAuth path from step 4d)
+4. On failure: throw createCrudFormError with field-level errors
+```
+
+### Send Pipeline
+
+```
+Public API: import { sendAsUser } from '@open-mercato/core/modules/email/lib/send-pipeline'
+
+sendAsUser({ accountId, message }) →
+  1. Resolve EmailAccount; verify currentUser owns accountId; verify status='connected'
+  2. Resolve EmailAccountCredential via findOneWithDecryption
+  3. If OAuth and tokenExpiresAt < now + 60s:
+     - provider.refreshAccessToken; persist new tokens (via command email.account.refresh_token)
+  4. Dispatch command: email.message.send { accountId, message }
+  5. Command: provider.sendMessage(...); upsert EmailMessageEnvelope (direction='outbound'); emit email.message.sent
+  6. Return SendResult to caller
+  7. On provider error: classify (auth | rate-limit | transient | persistent), log EmailHealthLog,
+     throw typed EmailSendError; transient errors retried once internally before throwing
+```
+
+### Receive Pipeline
+
+```
+Cron (every 60s): enumerates EmailAccount rows where status='connected' and
+                  last_polled_at + poll_interval ≤ now; enqueues poll-account jobs.
+                  Backed by index (status, last_polled_at) — single indexed scan per tick,
+                  no N+1. Enumeration capped at 500 rows per tick to bound enqueue burst;
+                  remaining accounts picked up next tick.
+
+Worker queue 'email-sync', concurrency 10 (I/O-bound).
+
+poll-account worker:
+  1. Load EmailAccount + EmailAccountCredential + EmailSyncCursor (folder='INBOX')
+  2. If status !== 'connected' → skip
+  3. Refresh OAuth token if needed (same logic as send)
+  4. provider.fetchSince({ cursor, limit=100 }) → FetchResult
+  5. Persist new cursor + last_polled_at in single transaction
+  6. For each message:
+     - Dispatch command: email.message.ingest { canonicalMessage, accountId }
+     - Command upserts EmailMessageEnvelope (rolling cap 200) + emits email.message.received
+  7. If hasMore=true → re-enqueue immediately (drain mode)
+  8. On error: classify
+     - 401/invalid_grant      → command: email.account.mark_requires_reauth (status, notification)
+     - 429 + Retry-After      → reschedule per header, no status change
+     - 5xx / network          → retry up to 3× with backoff, then warning log, no status change
+     - cursor-invalid (e.g., Gmail history_id_too_old) → reset cursor to "now", emit email.account.error (severity=info)
+     - persistent other       → status='error', exponential backoff (5→10→20→60 min, max 60)
+```
+
+### Commands & Events
+
+Following the AGENTS.md command pattern (`packages/core/src/modules/customers/commands/*` reference):
+
+| Command | Payload | State Change | Undo |
+|---|---|---|---|
+| `email.account.connect` | `{ userId, providerId, emailAddress, credentialBlob }` | Insert EmailAccount + EmailAccountCredential; set isPrimary if first; emit `email.account.connected` | `email.account.disconnect` |
+| `email.account.disconnect` | `{ accountId }` | Soft-delete EmailAccount; hard-purge EmailAccountCredential; halt poll worker; emit `email.account.disconnected` | None (credentials lost on purge — user reconnects) |
+| `email.account.set_primary` | `{ accountId }` | Clear isPrimary on user's other accounts; set on this one | Set previous primary back |
+| `email.account.rename` | `{ accountId, displayName }` | Update displayName | Restore previous displayName |
+| `email.account.update_imap_credentials` | `{ accountId, credentialBlob }` | Replace EmailAccountCredential; set status='connected' | Restore previous (kept in-memory during txn) |
+| `email.account.refresh_token` | `{ accountId, tokens }` | Update accessToken + tokenExpiresAt | None (token refresh has no business undo) |
+| `email.account.mark_requires_reauth` | `{ accountId, reason }` | Set status='requires_reauth'; create EmailHealthLog; emit notification | Auto-reverted when user reconnects |
+| `email.message.send` | `{ accountId, message }` | Provider sendMessage; upsert outbound EmailMessageEnvelope; emit `email.message.sent` | None — emails cannot be unsent. Local envelope can be deleted but the email is already at the recipient. |
+| `email.message.ingest` | `{ accountId, canonicalMessage }` | Upsert inbound EmailMessageEnvelope (idempotent on `(account_id, provider_message_id)`); emit `email.message.received` | Delete envelope; CRM-spec subscribers must handle reversal. |
+
+Events (`packages/core/src/modules/email/events.ts`) — follows the canonical shape used by every other module (compare `packages/core/src/modules/inbox_ops/events.ts`, `packages/core/src/modules/customers/events.ts`):
+
+```ts
+import { createModuleEvents } from '@open-mercato/shared/modules/events'
+import type { EventPayload } from '@open-mercato/shared/modules/events'
+import type { CanonicalMessage } from './lib/canonical-message'
+
+// Payload type aliases — enforced via TS generics at emit sites, NOT stored on the EventDefinition.
+export type AccountConnectedPayload = EventPayload & {
+  accountId: string
+  userId: string
+  providerId: 'gmail' | 'microsoft' | 'imap'
+  emailAddress: string
+}
+export type AccountDisconnectedPayload = EventPayload & {
+  accountId: string
+  userId: string
+  providerId: 'gmail' | 'microsoft' | 'imap'
+}
+export type AccountRequiresReauthPayload = EventPayload & {
+  accountId: string
+  userId: string
+  providerId: 'gmail' | 'microsoft' | 'imap'
+  reason: string
+}
+export type AccountErrorPayload = EventPayload & {
+  accountId: string
+  userId: string
+  providerId: 'gmail' | 'microsoft' | 'imap'
+  severity: 'info' | 'warning' | 'error'
+  kind: string
+}
+export type MessageReceivedPayload = EventPayload & {
+  accountId: string
+  message: CanonicalMessage
+}
+export type MessageSentPayload = EventPayload & {
+  accountId: string
+  message: CanonicalMessage
+}
+
+const events = [
+  { id: 'email.account.connected',       label: 'Email account connected',       entity: 'account', category: 'crud',      clientBroadcast: true  },
+  { id: 'email.account.disconnected',    label: 'Email account disconnected',    entity: 'account', category: 'crud',      clientBroadcast: true  },
+  { id: 'email.account.requires_reauth', label: 'Email account requires reauth', entity: 'account', category: 'lifecycle', clientBroadcast: true  },
+  { id: 'email.account.error',           label: 'Email account error',           entity: 'account', category: 'lifecycle', clientBroadcast: true  },
+  { id: 'email.message.received',        label: 'Email message received',        entity: 'message', category: 'custom',    clientBroadcast: false }, // body NOT in payload
+  { id: 'email.message.sent',            label: 'Email message sent',            entity: 'message', category: 'custom',    clientBroadcast: true  },
+] as const
+
+export const eventsConfig = createModuleEvents({ moduleId: 'email', events })
+export const emitEmailEvent = eventsConfig.emit
+export type EmailEventId = typeof events[number]['id']
+export default eventsConfig
+```
+
+Persistence is declared per-subscriber via `metadata: { event, persistent: true }` — not on the event definition. Every CRM-facing subscriber that must survive restarts MUST set `persistent: true`. Example subscriber skeleton:
+
+```ts
+// packages/core/src/modules/email/subscribers/log-message-received.ts
+export const metadata = {
+  event: 'email.message.received',
+  persistent: true,
+  id: 'email.log-message-received',
+}
+
+export default async function handle(payload: MessageReceivedPayload) {
+  // ...
+}
+```
+
+`clientBroadcast: false` on `email.message.received` for v1 — no real-time browser fanout for inbound (privacy + volume); CRM spec decides whether to enable later. Note also the cross-process bridge constraint (`.ai/lessons.md` → "Browser SSE bridges must work across worker and web processes"): worker-emitted events do NOT reach the in-process SSE tap. v1 sidesteps this with `clientBroadcast: false`. Any future flip to `true` MUST be paired with the cross-process bridge work.
+
+### Access Control (`acl.ts` and `setup.ts`)
+
+Five ACL features, all new (greenfield namespace — confirmed no collisions). Feature naming follows the root `AGENTS.md` rule `<module>.<entity>.<action>` (or `<module>.<action>` for module-wide capabilities).
+
+```ts
+// packages/core/src/modules/email/acl.ts
+import type { ModuleFeature } from '@open-mercato/shared/lib/auth/acl'
+
+export const features: ModuleFeature[] = [
+  { id: 'email.account.connect', title: 'Connect own email account',          module: 'email' },
+  { id: 'email.account.manage',  title: 'Manage own email accounts',          module: 'email' },
+  { id: 'email.send',            title: 'Send email as own connected account', module: 'email' },
+  { id: 'email.admin',           title: 'Administer tenant email integrations', module: 'email' },
+  { id: 'email.admin.providers', title: 'Configure tenant OAuth provider apps', module: 'email' },
+]
+```
+
+Default role grants in `setup.ts` mirror the features array and are propagated to existing tenants via `yarn mercato auth sync-role-acls`:
+
+```ts
+// packages/core/src/modules/email/setup.ts
+import type { ModuleSetupConfig } from '@open-mercato/shared/modules/setup'
+
+export const setup: ModuleSetupConfig = {
+  defaultRoleFeatures: {
+    admin:   ['email.account.connect', 'email.account.manage', 'email.send', 'email.admin', 'email.admin.providers'],
+    manager: ['email.account.connect', 'email.account.manage', 'email.send'],
+    user:    ['email.account.connect', 'email.account.manage', 'email.send'],
+  },
+  // onTenantCreated / seedDefaults / seedExamples not required for v1
+}
+```
+
+Notes:
+- `email.account.connect` and `email.account.manage` are split intentionally — `connect` gates the initial OAuth/IMAP linking flow; `manage` gates rename/set-primary/disconnect on already-linked accounts. This lets future tenant policies disable new linking while preserving existing accounts.
+- `email.admin` covers the read-only admin view (account list, health log). `email.admin.providers` is the higher-privilege capability needed to write tenant-level OAuth client credentials. Default role map only grants this to `admin`.
+- `email.send` is required by the bespoke `POST /api/email/send` route AND by any future workflow/AI tool that calls `sendAsUser(...)` programmatically.
+- No customer-portal roles are touched — the v1 UI lives entirely under `/backend/...`.
+
+After implementing `acl.ts` and `setup.ts`, run `yarn mercato auth sync-role-acls` so existing tenants receive the new feature grants on the appropriate roles.
+
+### Security Posture
+
+- **No HTML email rendering in v1.** Admin debug view shows envelopes only (subject, sender, snippet) as plain text via React (auto-escaped). No `dangerouslySetInnerHTML`, no inline `<svg>`, no raw HTML insertion anywhere. XSS surface is therefore N/A for v1.
+- **Snippet sanitization.** Even though snippets are rendered as text, provider-returned snippets are passed through a length-truncate to `≤200` chars before persistence; no other transformation.
+- **All persisted strings (subject, addresses, snippet, headers).** Stored verbatim from the provider; rendering paths use React's default text escaping. When the CRM spec adds body rendering, it MUST address HTML sanitization (DOMPurify or equivalent) before render — flagged for that spec.
+- **URL/header encoding.** OAuth authorize URLs are built via `URLSearchParams`; never via string concatenation. Inbound headers are stored as `Record<string, string>` with lowercased keys; no header value is ever interpolated into URLs or logs.
+- **Parameterized queries.** All DB access is via MikroORM `em.find` / `findOneWithDecryption` / query-builder — no raw SQL string interpolation anywhere in this spec.
+
+## Data Models
+
+All tables: `id` UUID primary key, `created_at` / `updated_at` timestamps, `organization_id` + `tenant_id` foreign keys (mandatory scoping per AGENTS.md), `deleted_at` for soft-delete where applicable.
+
+### EmailAccount (table `email_accounts`)
+One row per linked account, per user.
+- `id` UUID
+- `user_id` UUID (FK auth.users)
+- `provider_id` text — `'gmail' | 'microsoft' | 'imap'` (validated via DI provider registry)
+- `display_name` text — user-editable, defaults to emailAddress
+- `email_address` text — canonical address
+- `is_primary` boolean — exactly one true per user (enforced in `set_primary` command; partial unique index `(user_id) WHERE is_primary AND deleted_at IS NULL`)
+- `status` text — `'connected' | 'requires_reauth' | 'error' | 'disconnected'`
+- `last_error` text NULL
+- `last_polled_at` timestamptz NULL
+- `poll_interval_seconds` integer — default from `OM_EMAIL_POLL_INTERVAL_SECONDS`, per-account override allowed
+- `capabilities` jsonb — `{ canSend, canReceive, supportsThreading, supportsLabels, supportsCategories, supportsAttachmentsOnSend, maxAttachmentBytes }`
+- `organization_id`, `tenant_id`, `created_at`, `updated_at`, `deleted_at`
+- Indexes: `(user_id, deleted_at)`, `(tenant_id, provider_id, status)`, `(status, last_polled_at)` for the cron scheduler
+
+### EmailAccountCredential (table `email_account_credentials`)
+1:1 with EmailAccount. Credential blob is field-level encrypted.
+- `id` UUID
+- `email_account_id` UUID (FK, unique on `WHERE deleted_at IS NULL`)
+- `credential_blob` jsonb (ENCRYPTED — declared in `encryption.ts`)
+  - OAuth providers: `{ accessToken, refreshToken, tokenType: 'Bearer', expiresAt, scopes }`
+  - IMAP: `{ imapHost, imapPort, imapUser, imapPassword, imapTls, smtpHost, smtpPort, smtpUser, smtpPassword, smtpTls }`
+- `token_expires_at` timestamptz NULL (OAuth only; null for IMAP)
+- `scopes_granted` text[] NULL
+- `organization_id`, `tenant_id`, `created_at`, `updated_at`
+
+### EmailSyncCursor (table `email_sync_cursors`)
+One row per account+folder. v1 only stores INBOX cursors.
+- `id` UUID
+- `email_account_id` UUID (FK)
+- `folder` text — default `'INBOX'`
+- `cursor` jsonb — opaque, provider-specific
+  - Gmail: `{ historyId: string }`
+  - Microsoft: `{ deltaLink: string }`
+  - IMAP: `{ uidValidity: number, uidNext: number }`
+- `status` text — `'ok' | 'error' | 'initializing'`
+- `last_synced_at` timestamptz NULL
+- `last_error` text NULL
+- `organization_id`, `tenant_id`, `created_at`, `updated_at`
+- Indexes: `(email_account_id, folder)` UNIQUE
+
+### EmailHealthLog (table `email_health_logs`)
+Audit log. Daily worker purges entries older than `OM_EMAIL_HEALTH_LOG_RETENTION_DAYS` (default 90).
+- `id` UUID
+- `email_account_id` UUID (FK; nullable for tenant-level events)
+- `kind` text — `'health_check' | 'sync_error' | 'send_error' | 'oauth_refresh' | 'reauth_required' | 'cursor_reset'`
+- `severity` text — `'info' | 'warning' | 'error'`
+- `message` text
+- `context` jsonb
+- `organization_id`, `tenant_id`, `created_at`
+- Indexes: `(tenant_id, created_at DESC)`, `(email_account_id, created_at DESC)`, `(severity, created_at DESC)`
+
+### EmailMessageEnvelope (table `email_message_envelopes`)
+Rolling cache of last ~200 envelopes per account for the admin debug view ONLY. NOT a CRM data source. Purged by `purge-envelopes` worker daily.
+- `id` UUID
+- `email_account_id` UUID (FK)
+- `provider_message_id` text
+- `provider_thread_id` text NULL
+- `direction` text — `'inbound' | 'outbound'`
+- `subject` text
+- `from_address` text
+- `from_name` text NULL
+- `to_addresses` text[]
+- `snippet` text — ≤200 chars
+- `sent_at` timestamptz
+- `received_at` timestamptz NULL
+- `provider_meta` jsonb
+- `organization_id`, `tenant_id`, `created_at`
+- Indexes: `(email_account_id, provider_message_id)` UNIQUE, `(email_account_id, created_at DESC)` for cap-and-purge
+
+### Encryption Map (`packages/core/src/modules/email/encryption.ts`)
+
+```ts
+import type { ModuleEncryptionMap } from '@open-mercato/shared/modules/encryption'
+
+export const defaultEncryptionMaps: ModuleEncryptionMap[] = [
+  {
+    entityId: 'email:email_account_credential',
+    fields: [
+      { field: 'credential_blob' },
+    ],
+  },
+]
+
+export default defaultEncryptionMaps
+```
+
+Follows the canonical pattern used by every other module — see `packages/core/src/modules/messages/encryption.ts`, `packages/core/src/modules/integrations/encryption.ts`, etc. The `defaultEncryptionMaps` export is the convention enforced by `<module>/encryption.ts` (root `AGENTS.md` → Encryption). No `registerEntityEncryption(...)` symbol exists in `@open-mercato/shared`; previous draft was incorrect.
+
+Reads use the 5-arg `findOneWithDecryption` helper:
+
+```ts
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+
+const credential = await findOneWithDecryption(
+  em,
+  'EmailAccountCredential',
+  { emailAccountId },
+  /* options */ undefined,
+  /* scope */ { tenantId, organizationId },
+)
+```
+
+The `credential_blob` column is the only sensitive payload (OAuth tokens or IMAP/SMTP passwords). It is never serialized in any API response by construction (separate DTO mapper, see `EmailAccountDto` in API Contracts). The `EmailHealthLog.context` validator rejects any key matching `/^(credential|password|token|secret)/i` so accidental leakage through logs is fail-closed (see Security Posture below).
+
+## API Contracts
+
+All routes are auto-discovered. Every route file exports a per-method `metadata` object with `requireAuth: true` and `requireFeatures: [...]` (per `packages/core/AGENTS.md` API Routes rules — no top-level `export const requireAuth`). All write routes use `useGuardedMutation` from the UI side and `validateCrudMutationGuard` + `runCrudMutationGuardAfterSuccess` server-side for any non-`makeCrudRoute` mutation. All routes export `openApi`. Bodies validated via Zod schemas in `data/validators.ts`.
+
+**Pagination**: list endpoints (`GET /api/email/accounts`, `GET /api/email/admin/accounts`, `GET /api/email/admin/health-log`) accept `?cursor=<opaque>&limit=<n>` with `limit ≤ 100`. The health log uses keyset pagination on `(created_at DESC, id DESC)` to remain stable as new entries arrive. Account lists are small enough that simple cursor on `created_at` suffices.
+
+**CRUD factory usage**: `GET /api/email/accounts`, `PATCH /api/email/accounts/[id]`, `DELETE /api/email/accounts/[id]`, `POST /api/email/admin/accounts` (list), and `POST /api/email/admin/health-log` (list) use `makeCrudRoute` with `indexer: { entityType: 'email:email_account' | 'email:email_health_log' }`. The OAuth initiation route, OAuth callback route, IMAP connect route, set-primary route, and send route are bespoke (they don't fit the CRUD shape) and each calls `validateCrudMutationGuard` before mutation, `runCrudMutationGuardAfterSuccess` after success, per the AGENTS.md rule for custom write routes.
+
+### POST /api/email/accounts/connect/[provider]
+- Features: `email.account.connect`
+- Body: `{}` (provider read from path param, validated via registry)
+- Response: `{ authorizeUrl: string }` (OAuth providers) — caller redirects user
+
+### POST /api/email/accounts/connect/imap
+- Features: `email.account.connect`
+- Body: `{ displayName, imapHost, imapPort, imapTls, imapUser, imapPassword, smtpHost, smtpPort, smtpTls, smtpUser, smtpPassword }`
+- Response: `{ accountId }` on success; `422` with field-level errors via `createCrudFormError` on validation failure
+
+### GET /api/email/oauth/[provider]/callback
+- No auth feature requirement (state-cookie carries identity)
+- Query: `code`, `state` (Google) or `code`, `state`, `session_state` (Microsoft)
+- Response: HTTP 302 to `/backend/profile/email-accounts?flash=connected` (or `flash=error&code=...`)
+- Errors: invalid state, expired state, userId mismatch, exchange failure — all redirect with `flash=error`
+
+### GET /api/email/accounts
+- Features: `email.account.manage`
+- Query: standard list filters (status, provider)
+- Response: `{ items: EmailAccountDto[] }` — only accounts where `user_id === currentUser.id`
+- Never returns credentials or envelope contents
+
+### PATCH /api/email/accounts/[id]
+- Features: `email.account.manage`
+- Body: `{ displayName?, pollIntervalSeconds? }`
+- Verifies `user_id === currentUser.id`
+- Dispatches `email.account.rename` command if displayName changed
+
+### POST /api/email/accounts/[id]/set-primary
+- Features: `email.account.manage`
+- Dispatches `email.account.set_primary` command
+
+### DELETE /api/email/accounts/[id]
+- Features: `email.account.manage`
+- Dispatches `email.account.disconnect` command
+
+### POST /api/email/send
+- Features: `email.send`
+- Body: `{ accountId, to[], cc?[], bcc?[], subject, body: { plain?, html? }, attachments?: AttachmentRef[], inReplyTo?, references?[] }`
+- Server-side: `sendAsUser` facade does all the work; verifies the caller owns the accountId
+- Response: `{ providerMessageId, providerThreadId, sentAt }`
+- Errors: 401 (no session), 403 (not owner of account), 409 (account not connected), 422 (invalid body), 502 (provider error — message includes classification)
+
+**`AttachmentRef` type** — defined in `packages/core/src/modules/email/data/validators.ts`. Two variants discriminated by `kind`:
+
+```ts
+import { z } from 'zod'
+
+export const attachmentRefSchema = z.discriminatedUnion('kind', [
+  // Reference to a record already stored by the existing attachments module.
+  z.object({
+    kind: z.literal('attachment'),
+    attachmentId: z.string().uuid(),
+    filename: z.string().min(1).max(255).optional(), // override display name; defaults to stored filename
+  }),
+  // Inline content provided in the request body. Capped to keep payloads small.
+  z.object({
+    kind: z.literal('inline'),
+    filename: z.string().min(1).max(255),
+    mimeType: z.string().min(1).max(255),
+    contentBase64: z.string().min(1), // server enforces 10 MB hard cap per attachment, 25 MB total
+  }),
+])
+
+export type AttachmentRef = z.infer<typeof attachmentRefSchema>
+```
+
+The `attachment` variant reuses the existing `attachments` module (no new storage). The `inline` variant is for ad-hoc payloads; the spec deliberately does NOT introduce a new storage tier for outbound email attachments. Provider implementations translate `AttachmentRef[]` into provider-native attachment payloads (Gmail: base64-encoded MIME parts; Microsoft: `attachments[]` in `/me/sendMail`; IMAP/SMTP: nodemailer `attachments` array).
+
+Per-provider attachment size and count limits come from `EmailAccount.capabilities` (`maxAttachmentBytes`, `supportsAttachmentsOnSend`). Send fails fast with 422 if the request exceeds the resolved account's capabilities.
+
+### GET /api/email/admin/accounts
+- Features: `email.admin`
+- Returns all accounts in tenant with redacted fields: `{ id, userId, providerId, displayName, emailAddress, status, lastPolledAt, errorCount24h }`
+- NO credentials, NO envelope contents
+
+### GET /api/email/admin/health-log
+- Features: `email.admin`
+- Query: `accountId?`, `severity?`, `kind?`, `since?`
+- Returns `EmailHealthLog` entries (no message contents — `EmailHealthLog.context` does NOT carry email body/subject/recipient by construction)
+
+## Internationalization (i18n)
+
+Per `packages/shared/AGENTS.md`. Locale keys go in `packages/core/src/modules/email/locales/<lang>.json`.
+
+Required key namespaces:
+- `email.account.providers.gmail.label`, `.microsoft.label`, `.imap.label`
+- `email.account.connect.button`, `.dialog.*`
+- `email.account.status.connected`, `.requires_reauth`, `.error`, `.disconnected`
+- `email.account.actions.rename`, `.makePrimary`, `.reconnect`, `.disconnect`
+- `email.account.banner.requiresReauth`
+- `email.imap.form.fields.*` (host, port, tls, user, password, smtp.*)
+- `email.imap.form.warnings.basicAuth` (the security ack)
+- `email.admin.title`, `email.admin.healthLog.severity.*`, `email.admin.providers.title`
+- `email.notifications.requires_reauth.title`, `.body`, `.cta`
+- `email.send.errors.*` (classification keys)
+
+Translations done via `useT()` client-side, `resolveTranslations()` server-side.
+
+## UI/UX
+
+### User Settings → Email Accounts (`/backend/profile/email-accounts`)
+- DataTable (uses `@open-mercato/ui/backend` primitives)
+  - Columns: provider icon (lucide-react `Mail`/`MailOpen` + tinted by provider), display name (inline-editable), email address, primary toggle, status badge (semantic status tokens — `bg-status-success-soft text-status-success-fg` for connected, `bg-status-warning-soft text-status-warning-fg` for `requires_reauth`, `bg-status-error-soft text-status-error-fg` for `error`), last synced (relative time), RowActions
+  - RowActions ids: `email-account:rename`, `email-account:set-primary`, `email-account:reconnect`, `email-account:disconnect` (per `packages/ui/src/backend/AGENTS.md`)
+- "Connect Account" split button (top-right):
+  - Items: "Connect Gmail", "Connect Microsoft", "Connect IMAP"
+  - Gmail / Microsoft → POST connect endpoint → `window.location = authorizeUrl`
+  - IMAP → opens `CrudForm` dialog with provider's credential schema; submit via `useGuardedMutation`
+- Banner across top: `<Alert variant="warning">` listing accounts in `requires_reauth` with inline "Reconnect" button
+- Empty state (no accounts): `<EmptyState>` with primary CTA "Connect your first email account"
+- IMAP dialog includes explicit checkbox: "I understand storing my email password is less secure than OAuth. I will use an app-specific password where possible." (Defaults unchecked; submit disabled until checked.)
+- All dialogs: `Cmd/Ctrl+Enter` submit, `Escape` cancel
+
+### Admin → Integrations → Email Providers (`/backend/email/admin`)
+- Top-level DataTable: accounts in tenant
+  - Columns: user, email address, provider, status, last synced, 24h error count, RowActions ("View health log")
+  - Filterable by provider and status
+  - Aggregate header card: total connected accounts, accounts with errors, accounts requiring re-auth
+- "Provider OAuth App Configuration" `<CollapsibleSection>` per provider:
+  - Inputs: clientId, clientSecret (write-only / shows "set" badge after save)
+  - Read-only display of the platform redirect URI (with copy button) — operators must register this exact URL with their Google/Microsoft app
+  - Submit via Marketplace Integration update flow
+- "Health Log" `<CollapsibleSection>`: last 100 entries, sortable
+- All inline status uses semantic status tokens; no hardcoded colors
+- All icons use lucide-react via the backend icon registry (`@open-mercato/ui/backend/icons`); no inline `<svg>`
+- Every icon-only button (rename/disconnect/reconnect/copy/etc.) carries an explicit `aria-label` per `.ai/ui-components.md`
+- Pagination: account-list and health-log DataTables use cursor pagination with `pageSize ≤ 100`
+
+### Frontend Architecture Contract
+
+(Per spec-writing skill heuristic 9 — minimal because UI surface is small.)
+
+- **Server/Client boundary**:
+  - `/backend/profile/email-accounts/page.tsx` — Server Component shell (auth check, initial data load)
+  - `EmailAccountsTable` — Client Component (`"use client"`) for interactive table actions
+  - `ConnectImapDialog` — Client Component (form state, dialog)
+  - `/backend/email/admin/page.tsx` — Server Component shell
+  - `AdminAccountsTable` — Client Component
+- **`"use client"` ledger**: 3 client files, all justified by `useState`/`useMutation`/dialog state
+- **Client blob guardrail**: no provider SDKs imported into client bundles (no `googleapis`, no `@microsoft/microsoft-graph-client`, no `imapflow` — all server-side only)
+- **Route budgets**: each page < 30 KB gzipped client JS (DataTable + CrudForm primitives are shared, not re-bundled)
+- **Hydration test**: Playwright test asserts each interactive control responds within 100 ms of mount on a cold load
+- **Provider/Bootstrap scope**: no new global providers; uses existing app shell
+
+## Configuration
+
+```bash
+# Platform-default OAuth apps (optional — tenants can override via Marketplace)
+OM_EMAIL_GMAIL_OAUTH_CLIENT_ID
+OM_EMAIL_GMAIL_OAUTH_CLIENT_SECRET
+OM_EMAIL_GMAIL_REDIRECT_URI                  # e.g. https://app.example.com/api/email/oauth/gmail/callback
+OM_EMAIL_MICROSOFT_OAUTH_CLIENT_ID
+OM_EMAIL_MICROSOFT_OAUTH_CLIENT_SECRET
+OM_EMAIL_MICROSOFT_OAUTH_TENANT              # 'common' for multi-tenant, or specific tenant GUID
+OM_EMAIL_MICROSOFT_REDIRECT_URI
+
+# Sync tuning
+OM_EMAIL_POLL_INTERVAL_SECONDS=300           # default 5 min
+OM_EMAIL_POLL_BATCH_SIZE=100
+OM_EMAIL_ENVELOPE_RETENTION=200              # rolling cap per account
+OM_EMAIL_HEALTH_LOG_RETENTION_DAYS=90
+
+# OAuth state cookie key (32 bytes hex). Falls back to derive from KMS_MASTER_KEY when absent.
+OM_EMAIL_OAUTH_STATE_KEY
+```
+
+Setup raises a clear error at module boot if any OAuth provider is enabled but neither the per-tenant Marketplace config nor the corresponding platform-env credentials are configured.
+
+## Migration & Backward Compatibility
+
+### Database migrations
+
+One module migration creates 5 tables with FKs, indexes, and the unique partial index for `is_primary`. Standard workflow:
+1. Edit `data/entities.ts`
+2. `yarn db:generate`
+3. Keep only email-related SQL, update `packages/core/src/modules/email/migrations/.snapshot-open-mercato.json`
+
+Each provider package migration (additive): registers the provider's Marketplace Integration row.
+
+### Backward Compatibility
+
+| Surface | Change | Impact |
+|---|---|---|
+| Database schema | 5 new tables, all additive | Additive — zero impact |
+| API routes | New `/api/email/...` namespace | Additive |
+| Events | New `email.*` events | Additive |
+| ACL features | 5 new features (default-granted per role in setup.ts) | Additive |
+| Existing Resend pipeline (`@open-mercato/shared/lib/email/send`) | Untouched | None |
+| `messages` module | Untouched | None |
+| `inbox_ops` module | Untouched | None |
+| `notifications` module | One new notification type (`email_account_requires_reauth`) | Additive |
+| `integrations` Marketplace | Three new provider entries via per-package `marketplace.ts` | Additive |
+| `yarn generate` output | Three new packages join generators | Additive |
+| `apps/mercato/src/modules.ts` | Adds three new packages to `enabledModules` | Required app change, documented |
+
+No deprecations. No data migration of existing rows. Existing tests untouched.
+
+After enabling the new modules: run `yarn mercato configs cache structural --all-tenants` per AGENTS.md.
+
+## Implementation Plan
+
+### Phase 1 — Core foundations (no providers yet)
+1. Scaffold `packages/core/src/modules/email/` (index.ts, setup.ts, acl.ts, di.ts).
+2. Create entities, validators, encryption map; run `yarn db:generate`.
+3. Implement `EmailProvider` interface, `CanonicalMessage`, `provider-registry` (empty registry, just the DI hook).
+4. Implement OAuth state-cookie helper (port from SSO module pattern); unit tests for encrypt/decrypt/expiry/tamper.
+5. Implement OAuth callback router shell that delegates to a registered provider (returns 400 if unknown).
+6. Implement commands (`connectAccount`, `disconnectAccount`, `setPrimaryAccount`, `renameAccount`, `updateImapCredentials`, `refreshToken`, `markRequiresReauth`).
+7. Implement API routes for `accounts/*` (list, patch, delete, set-primary) with feature guards and `openApi`.
+8. Implement `send-pipeline.ts` `sendAsUser` facade with a no-op provider (returns "no provider registered" error if no provider for the account).
+9. Implement workers (`poll-account`, `refresh-tokens`, `purge-envelopes`, `purge-health-log`) with provider-agnostic logic.
+10. Unit tests for: cursor advancement, drain mode, error classification, status transitions, command undo semantics, state-cookie helper.
+11. **Acceptance**: Module loads, ACL features visible, API routes 404 without registered providers, `yarn build` passes, `yarn lint` passes.
+
+### Phase 2 — User UI for accounts
+1. `/backend/profile/email-accounts/page.tsx` Server Component shell.
+2. `EmailAccountsTable` Client Component (DataTable + RowActions + status badges).
+3. `ConnectImapDialog` Client Component (CrudForm with security-ack checkbox).
+4. Banner for requires_reauth accounts using `<Alert>` primitive.
+5. Empty state.
+6. i18n locale entries (en at minimum).
+7. **Acceptance**: User can navigate to the page; with no providers registered, "Connect Account" dropdown shows none. Locale strings resolve. DataTable renders.
+
+### Phase 3 — Gmail provider package
+1. `packages/email-gmail/` workspace package (package.json, tsconfig, AGENTS.md).
+2. OAuth: authorize URL builder, code exchange, refresh — using `googleapis` SDK or raw fetch.
+3. Sync: `gmail.users.history.list` for incremental; full list for initial sync seeding.
+4. Send: build RFC822 message via `mailcomposer` (or equivalent), `gmail.users.messages.send`.
+5. Health: `gmail.users.getProfile`.
+6. `GmailProviderMeta` zod schema (labelIds, isImportant, isStarred, threadId).
+7. Marketplace integration registration.
+8. Unit tests with mocked HTTP responses.
+9. Wire into `apps/mercato/src/modules.ts`; run `yarn mercato configs cache structural --all-tenants`.
+10. **Acceptance**: User can connect Gmail end-to-end against a real Google Workspace test account, send a test email, observe it polled back into envelopes within 5 min.
+
+### Phase 4 — Microsoft provider package
+1. `packages/email-microsoft/` workspace package.
+2. OAuth: Microsoft identity platform v2.0 authorize URL, code exchange (PKCE), refresh.
+3. Sync: `/me/mailFolders/inbox/messages/delta` (delta queries).
+4. Send: `/me/sendMail` with `application/json` body.
+5. Health: `/me`.
+6. `OutlookProviderMeta` zod schema (categories, importance, conversationId).
+7. Marketplace integration registration.
+8. Unit tests with mocked Graph responses.
+9. **Acceptance**: User can connect Microsoft 365 account end-to-end, send, and receive via polling.
+
+### Phase 5 — IMAP+SMTP provider package
+1. `packages/email-imap/` workspace package, deps `imapflow` + `nodemailer` + `mailparser`.
+2. `validateCredentials` probes both IMAP and SMTP login.
+3. Sync: `imapflow` connect, select INBOX, fetch by UID range using `EmailSyncCursor.cursor.uidNext` / `uidValidity` (handle UIDVALIDITY rotation = full re-sync).
+4. Send: nodemailer SMTP, append to Sent folder if server supports it.
+5. `ImapProviderMeta` zod schema (folder, flags, uid, uidValidity).
+6. Marketplace integration registration (no OAuth app config; just an "enabled/disabled per tenant" toggle).
+7. Unit tests against an in-process IMAP mock.
+8. **Acceptance**: User can connect IMAP+SMTP with valid creds, send, receive via polling. Invalid creds rejected with field-level errors.
+
+### Phase 6 — Admin UI
+1. `/backend/email/admin/page.tsx` Server Component.
+2. `AdminAccountsTable` Client Component with filters (provider, status).
+3. Aggregate header card (counts).
+4. Health log section with severity coloring.
+5. Tenant OAuth app config form per provider (CollapsibleSection).
+6. **Acceptance**: Admin sees all tenant accounts, can drill into health log, can configure tenant-level OAuth overrides. Cannot see envelope contents.
+
+### Phase 7 — Notifications & cleanup workers
+1. Notification type `email_account_requires_reauth` with client renderer.
+2. Subscriber on `email.account.requires_reauth` event that creates the notification.
+3. Cron registration for `purge-envelopes` (daily, caps rolling 200 per account) and `purge-health-log` (daily, deletes > retention days).
+4. **Acceptance**: When a refresh-token-revoked event happens, the account-owner receives an in-app notification; the page banner appears on next load.
+
+### Integration test placement (applies to every phase)
+
+Per `.ai/lessons.md` → "Keep executable integration tests module-local": executable Playwright specs live under the **owning module's** `__integration__/` directory, not under `.ai/qa/tests/`. `.ai/qa/scenarios/TC-EMAIL-*.md` holds the human-readable scenario descriptions only.
+
+Test locations:
+
+| Test | Markdown scenario | Executable Playwright spec |
+|---|---|---|
+| TC-EMAIL-011, 012, 013, 014 (account management, RBAC, isolation) | `.ai/qa/scenarios/TC-EMAIL-011..014.md` | `packages/core/src/modules/email/__integration__/TC-EMAIL-NNN.spec.ts` |
+| TC-EMAIL-001, 005, 006, 009 (Gmail) | `.ai/qa/scenarios/TC-EMAIL-001/005/006/009.md` | `packages/email-gmail/src/modules/email_gmail/__integration__/TC-EMAIL-NNN.spec.ts` |
+| TC-EMAIL-002 (Microsoft) | `.ai/qa/scenarios/TC-EMAIL-002.md` | `packages/email-microsoft/src/modules/email_microsoft/__integration__/TC-EMAIL-002.spec.ts` |
+| TC-EMAIL-003, 004, 007, 008 (IMAP/SMTP) | `.ai/qa/scenarios/TC-EMAIL-003/004/007/008.md` | `packages/email-imap/src/modules/email_imap/__integration__/TC-EMAIL-NNN.spec.ts` |
+| TC-EMAIL-010, 015 (cross-cutting: notifications, tenant overrides) | `.ai/qa/scenarios/TC-EMAIL-010/015.md` | `packages/core/src/modules/email/__integration__/TC-EMAIL-NNN.spec.ts` |
+
+**Per-phase acceptance rule** (overrides any earlier "tests at end" framing): every phase below ships its **own** module-local Playwright specs. A phase is NOT marked complete until its listed integration tests pass. This matches the user's standing rule and `.ai/qa/AGENTS.md`.
+
+Per-phase test ownership:
+
+| Phase | Required integration specs (module-local `__integration__/`) |
+|---|---|
+| Phase 1 (Core foundations) | `packages/core/src/modules/email/__integration__/`: smoke spec asserting module loads, ACL features registered, API routes 404 with no providers; per-user isolation spec for the accounts list endpoint as a foundational guarantee |
+| Phase 2 (User UI) | `packages/core/src/modules/email/__integration__/`: empty-state render, banner render, navigation smoke |
+| Phase 3 (Gmail) | `packages/email-gmail/.../__integration__/`: TC-EMAIL-001, 005, 006, 009 |
+| Phase 4 (Microsoft) | `packages/email-microsoft/.../__integration__/`: TC-EMAIL-002 |
+| Phase 5 (IMAP) | `packages/email-imap/.../__integration__/`: TC-EMAIL-003, 004, 007, 008 |
+| Phase 6 (Admin UI) | `packages/core/src/modules/email/__integration__/`: TC-EMAIL-011, 015 |
+| Phase 7 (Notifications & cleanup) | `packages/core/src/modules/email/__integration__/`: TC-EMAIL-010, plus envelope-cap and health-log-retention sweeps |
+
+Cross-phase tests that touch behavior owned by multiple phases (e.g. TC-EMAIL-013 Disconnect spans accounts + sync halt + credential purge) land with the phase that delivers the last contributing behavior — typically Phase 1 (foundations) since the disconnect command is foundational.
+
+### File Manifest (high-level)
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `packages/core/src/modules/email/**` | Create | Orchestrator module |
+| `packages/core/src/modules/email/__integration__/TC-EMAIL-*.spec.ts` | Create | Module-local integration specs (Phases 1, 2, 6, 7) |
+| `packages/email-gmail/src/modules/email_gmail/**` | Create | Gmail provider package |
+| `packages/email-gmail/src/modules/email_gmail/__integration__/TC-EMAIL-*.spec.ts` | Create | Gmail integration specs (Phase 3) |
+| `packages/email-microsoft/src/modules/email_microsoft/**` | Create | Microsoft provider package |
+| `packages/email-microsoft/src/modules/email_microsoft/__integration__/TC-EMAIL-*.spec.ts` | Create | Microsoft integration specs (Phase 4) |
+| `packages/email-imap/src/modules/email_imap/**` | Create | IMAP+SMTP provider package |
+| `packages/email-imap/src/modules/email_imap/__integration__/TC-EMAIL-*.spec.ts` | Create | IMAP integration specs (Phase 5) |
+| `apps/mercato/src/modules.ts` | Modify | Enable the four new modules (`email`, `email_gmail`, `email_microsoft`, `email_imap`) |
+| `.ai/qa/scenarios/TC-EMAIL-*.md` | Create | Human-readable test scenarios (markdown only — no executable code) |
+| `apps/docs/docs/framework/email/**` | Create | User-facing documentation |
+
+### Testing Strategy
+
+**Unit (Jest)**
+- Per-provider: stubbed HTTP for OAuth + sync + send; verify request shape and CanonicalMessage normalization.
+- OAuth state-cookie helper: encrypt/decrypt roundtrip, TTL expiry, signature tamper, userId-mismatch rejection.
+- `send-pipeline`: token-refresh trigger, error classification, EmailHealthLog writes.
+- `poll-account` worker: cursor advancement, drain mode, error classification, status transitions, idempotent re-ingest.
+- IMAP provider: tests against in-process IMAP mock (`imap-server`).
+
+**Integration (Playwright)** — scenarios listed in `.ai/qa/scenarios/`, executable specs in module-local `__integration__/` (see placement table above):
+
+- TC-EMAIL-001 Connect Gmail (real OAuth, env-gated CI skip)
+- TC-EMAIL-002 Connect Microsoft (real OAuth, env-gated CI skip)
+- TC-EMAIL-003 Connect IMAP with valid credentials
+- TC-EMAIL-004 IMAP rejects invalid credentials with field-level errors
+- TC-EMAIL-005 Send via Gmail, envelope written, appears in Gmail Sent folder
+- TC-EMAIL-006 Receive via Gmail polling, envelope written, `email.message.received` event emitted
+- TC-EMAIL-007 Send via SMTP, appears in remote Sent folder
+- TC-EMAIL-008 Receive via IMAP polling
+- TC-EMAIL-009 Token refresh: stub Google refresh response, verify new tokens persisted
+- TC-EMAIL-010 Refresh-token revoked → status=requires_reauth + notification arrives + banner shown
+- TC-EMAIL-011 Admin sees account list, cannot read envelope contents (RBAC)
+- TC-EMAIL-012 User A cannot list User B's accounts (per-user isolation)
+- TC-EMAIL-013 Disconnect → credentials hard-purged, sync halted, account removed
+- TC-EMAIL-014 Multi-account per user, primary swap works
+- TC-EMAIL-015 Tenant-owned OAuth app overrides platform default
+
+Per the user's standing rule and `.ai/lessons.md`, **no spec phase is marked complete without the listed module-local integration specs passing**. Phase 8 has been removed — integration tests are written and executed as part of the phase that produces the behavior being tested.
+
+## Risks & Impact Review
+
+### Data Integrity Failures
+
+#### Credential blob write atomicity
+- **Scenario**: OAuth callback completes; we insert EmailAccount but the credential insert fails. Result: an account row with no credentials.
+- **Severity**: High
+- **Affected area**: `email_accounts`, `email_account_credentials`, sync workers
+- **Mitigation**: `email.account.connect` command wraps both inserts in a single MikroORM transaction. Sync worker treats "no credential row" as a hard error → status='error'.
+- **Residual risk**: None significant; transactional boundary covers it.
+
+#### Cursor regression on crashed worker
+- **Scenario**: Worker fetches batch, persists envelopes, crashes before persisting new cursor. Next run re-fetches same messages.
+- **Severity**: Low
+- **Affected area**: Receive pipeline
+- **Mitigation**: Envelope upsert is idempotent on `(email_account_id, provider_message_id)` UNIQUE. `email.message.ingest` command is idempotent (returns existing row if conflict). Event emission deduped: only emit when row was actually inserted, not updated.
+- **Residual risk**: Acceptable — re-emission could happen if the crash is between insert and event publish. Downstream CRM subscribers must be idempotent on `(account_id, provider_message_id)`. Documented.
+
+#### isPrimary race
+- **Scenario**: Two concurrent `set_primary` calls leave zero or two primaries.
+- **Severity**: Medium
+- **Affected area**: `email_accounts`
+- **Mitigation**: Partial unique index `UNIQUE (user_id) WHERE is_primary AND deleted_at IS NULL` makes "two primaries" impossible at the DB level. Command wraps both UPDATEs in a transaction at SERIALIZABLE isolation.
+- **Residual risk**: None.
+
+### Cascading Failures & Side Effects
+
+#### Subscriber failure in `email.message.received`
+- **Scenario**: Future CRM subscriber throws while processing a message.
+- **Severity**: Medium
+- **Affected area**: This module → CRM module
+- **Mitigation**: Event is persistent; failed subscribers retry per existing platform behavior; this module's worker does not depend on subscriber success.
+- **Residual risk**: A repeatedly failing subscriber could pile up. Future CRM spec defines its DLQ.
+
+#### Provider outage
+- **Scenario**: Gmail API returns 5xx for hours.
+- **Severity**: Low
+- **Affected area**: Inbound sync, outbound send via affected provider
+- **Mitigation**: Exponential backoff up to 60-min ceiling; status stays `connected` (transient); EmailHealthLog warnings accumulate; admin can see in dashboard.
+- **Residual risk**: Users on that provider experience sync lag; documented in admin UI.
+
+#### Resend pipeline interaction
+- **Scenario**: Sending via Resend AND via user account concurrently for the same recipient causes duplicate emails.
+- **Severity**: Low (no caller does both today)
+- **Affected area**: Outbound
+- **Mitigation**: Spec explicitly states the two pipelines coexist; no automatic dual-emit; caller chooses one explicitly. CRM spec will define which calls migrate when.
+- **Residual risk**: A future change could introduce duplication; mitigated by code review and the explicit `sendAsUser` vs `sendEmail` import distinction.
+
+### Tenant & Data Isolation Risks
+
+#### Cross-user account leakage
+- **Scenario**: A bug in the list API returns another user's accounts.
+- **Severity**: Critical
+- **Affected area**: `/api/email/accounts`, all account-management endpoints
+- **Mitigation**: All user-facing APIs filter by `WHERE user_id = currentUser.id AND tenant_id = currentSession.tenantId`. Admin endpoints require `email.admin` feature and explicitly return redacted DTOs (never `EmailAccountCredential` rows, never envelope contents). Encrypted credential blob never serialized in any response by design (separate DTO mapper).
+- **Residual risk**: None at the DB layer due to encryption; defense in depth via per-route audit in code review.
+
+#### State-cookie forgery
+- **Scenario**: Attacker crafts a state cookie to bind their callback to another user's session.
+- **Severity**: Critical
+- **Affected area**: OAuth callback
+- **Mitigation**: State payload includes `userId`; callback handler verifies it matches `currentSession.userId`. State cookie is encrypted+signed via AES-256-GCM with HKDF key derivation (forgery requires the key). HttpOnly + SameSite=Lax + 5-min TTL.
+- **Residual risk**: None given the key is properly managed (uses existing KMS pattern).
+
+#### IMAP credential exposure
+- **Scenario**: A debugging log or stack trace inadvertently includes the credential blob.
+- **Severity**: Critical
+- **Affected area**: Worker logs, error reporting
+- **Mitigation**: `EmailHealthLog.context` schema explicitly rejects keys named `credential*`, `password*`, `token*`, `secret*` (enforced via Zod validator). Worker error handlers strip credential fields from any caught exception before logging. Unit tests assert this behavior.
+- **Residual risk**: New code paths could accidentally log credentials. Mitigated by enforcing the rejected-keys Zod validator on `EmailHealthLog.context` writes (any attempt to log a `credential*`/`password*`/`token*`/`secret*` key throws). Code review remains the second line of defense.
+
+### Migration & Deployment Risks
+
+#### Schema deploy without provider packages
+- **Scenario**: Core module migration runs in prod before provider packages are deployed.
+- **Severity**: Low
+- **Affected area**: Bootstrap
+- **Mitigation**: Migration is purely additive — empty tables don't break anything. Provider packages enable themselves at boot; their absence means `Connect Account` shows no providers, which is the graceful empty state.
+- **Residual risk**: None.
+
+#### Module-enable in `modules.ts` without cache purge
+- **Scenario**: Operator merges the spec, deploys, but forgets `yarn mercato configs cache structural --all-tenants`.
+- **Severity**: Medium
+- **Affected area**: Sidebar visibility, navigation
+- **Mitigation**: AGENTS.md mandates this command on any module-graph change. Deploy runbook addition recorded in changelog.
+- **Residual risk**: Operator omission; mitigated by Turbopack stale-chunk check.
+
+### Operational Risks
+
+#### Polling fanout overwhelms providers
+- **Scenario**: 10,000 connected Gmail accounts all polled simultaneously.
+- **Severity**: Medium
+- **Affected area**: Gmail API quota, worker queue
+- **Mitigation**: Per-account `last_polled_at + poll_interval_seconds` gate spreads load. Queue concurrency capped (10). Rate-limit honoring via `Retry-After` header. Aggregate quota monitoring deferred to ops dashboard (later spec).
+- **Residual risk**: Quota exhaustion at very high scale. Mitigated by tenant-owned OAuth app config (each tenant has their own quota pool).
+
+#### Envelope cap purge falls behind
+- **Scenario**: `purge-envelopes` worker fails or is slow; envelope table grows unbounded.
+- **Severity**: Low
+- **Affected area**: Storage cost
+- **Mitigation**: Cap is per-account (200), enforced on insert via "delete oldest if count > cap" within the `ingestMessage` command — so the cap is maintained even without the worker. The worker is a belt-and-suspenders sweep for ops resilience.
+- **Residual risk**: None.
+
+#### Health-log unbounded growth
+- **Scenario**: `purge-health-log` worker fails; logs accumulate.
+- **Severity**: Low
+- **Affected area**: Storage cost
+- **Mitigation**: 90-day retention by default; admin dashboard surfaces the worker last-run timestamp.
+- **Residual risk**: Operator visibility required.
+
+#### Email-bomb amplification
+- **Scenario**: A user's mailbox receives 100k unread messages in a short window; polling drains them all and emits 100k events.
+- **Severity**: Medium
+- **Affected area**: Event bus, downstream CRM subscribers
+- **Mitigation**: `poll-account` worker hard-caps `limit=100` per call; drain mode re-enqueues with backoff after every 5 drains; emits an `email.account.error` (severity=info) when drain exceeds 20 iterations.
+- **Residual risk**: Sustained high-volume mailbox = sustained event load. CRM subscribers must handle backpressure.
+
+## Final Compliance Report — 2026-05-21
+
+### AGENTS.md Files Reviewed
+- `AGENTS.md` (root)
+- `packages/core/AGENTS.md`
+- `packages/shared/AGENTS.md`
+- `packages/ui/AGENTS.md`
+- `packages/ui/src/backend/AGENTS.md`
+- `packages/events/AGENTS.md`
+- `packages/queue/AGENTS.md`
+- `packages/cache/AGENTS.md`
+- `packages/core/src/modules/integrations/AGENTS.md`
+- `.ai/specs/AGENTS.md`
+- `.ai/ds-rules.md`, `.ai/ui-components.md`
+
+### Compliance Matrix
+
+| Rule Source | Rule | Status | Notes |
+|---|---|---|---|
+| root AGENTS.md | Modules plural, snake_case (with exceptions for `auth`/`example`/`catalog`/etc.) | Compliant w/ caveat | Module id is `email` (singular). Mixed precedent in the codebase (`auth`, `catalog`, `data_sync`, `ai_assistant` are singular; `customers`, `messages`, `notifications`, `sales` are plural). Recommend confirming with user before implementation; rename to `emails` if strict plural is preferred. Event IDs and feature IDs would then become `emails.account.*` and `emails.account.connect` etc. — all mechanical. |
+| root AGENTS.md | No direct ORM relationships between modules | Compliant | `EmailAccount → User` is FK ID only (`user_id`), no MikroORM relation across module boundaries. |
+| root AGENTS.md | Filter by `organization_id` | Compliant | All five tables carry `tenant_id` + `organization_id`; all queries scoped. |
+| root AGENTS.md | Validate inputs with zod | Compliant | `data/validators.ts` covers all API bodies and command payloads. |
+| root AGENTS.md | Encrypt sensitive data via `encryption.ts` (no hand-rolled crypto) | Compliant | `credential_blob` registered in `encryption.ts`; reads use `findOneWithDecryption`. Uses existing AES-GCM + tenant-scoped DEK pipeline. |
+| root AGENTS.md | Provider packages live in `packages/<provider-package>/` | Compliant | `email-gmail`, `email-microsoft`, `email-imap` are workspace packages. |
+| root AGENTS.md | Commands for write operations | Compliant | 9 commands enumerated; each documents Undo or notes its non-undoability with rationale. |
+| root AGENTS.md | RBAC via features, not roles | Compliant | 5 features in `acl.ts`; routes use `requireFeatures` — no `requireRoles`. |
+| root AGENTS.md | Run `yarn mercato configs cache structural --all-tenants` after `modules.ts` change | Compliant | Documented in Migration & Compatibility + per-phase acceptance criteria. |
+| packages/core/AGENTS.md | API route files export `metadata` with per-method `requireAuth`/`requireFeatures` | Compliant | API Contracts intro explicitly documents this — no top-level `export const requireAuth`. |
+| packages/core/AGENTS.md | API routes MUST export `openApi` | Compliant | All routes export `openApi` per implementation plan. |
+| packages/core/AGENTS.md | CRUD routes use `makeCrudRoute` with `indexer: { entityType }` | Compliant | Listed account routes + admin routes use `makeCrudRoute`. OAuth callback / IMAP connect / set-primary / send / OAuth init are bespoke (don't fit CRUD shape) — they call `validateCrudMutationGuard` + `runCrudMutationGuardAfterSuccess` per the custom-write-route rule. |
+| packages/ui/AGENTS.md | `apiCall` not raw `fetch` | Compliant | Client side uses `apiCall` / `apiCallOrThrow`. |
+| packages/ui/AGENTS.md | `useGuardedMutation` for non-CrudForm writes | Compliant | "Connect", "Disconnect", "Set primary", "Reconnect" actions wrap writes in `useGuardedMutation` and pass `retryLastMutation`. |
+| packages/ui/AGENTS.md | `<CrudForm>` for backend forms; field-level errors via `createCrudFormError` | Compliant | IMAP connect dialog uses `<CrudForm>` with `createCrudFormError` for credential-validation failures. |
+| packages/ui/AGENTS.md | `<DataTable entityId apiPath columns>` with stable `entityId`/`extensionTableId` | Compliant | All three lists (user accounts, admin accounts, admin health log) use `<DataTable>` with stable `entityId`s for widget injection. |
+| packages/ui/AGENTS.md | Dialog Cmd/Ctrl+Enter, Escape | Compliant | Documented in UI section. |
+| packages/ui/AGENTS.md | `aria-label` on icon-only buttons | Compliant | UI section explicitly requires it per `.ai/ui-components.md`. |
+| packages/ui/AGENTS.md | `pageSize ≤ 100`; cursor/keyset pagination for large lists | Compliant | API Contracts pagination paragraph specifies cursor with limit ≤ 100; health log uses keyset on `(created_at DESC, id DESC)`. |
+| packages/events/AGENTS.md | `createModuleEvents` with `as const` | Compliant | Events declared via the helper. |
+| packages/events/AGENTS.md | `persistent: true` for subscribable side effects | Compliant | All 6 events persistent. |
+| packages/events/AGENTS.md | Cross-module side effects via events, not direct imports | Compliant | CRM consumes events; no direct imports. |
+| packages/queue/AGENTS.md | Idempotent workers | Compliant | Cursor + envelope upsert idempotent; `email.message.ingest` command idempotent on `(account_id, provider_message_id)` UNIQUE; event-emit only on actual insert. |
+| packages/cache/AGENTS.md | DI-resolved cache; tenant-scoped tags | N/A | This spec does not introduce caching. Future inbox/CRM specs will. |
+| .ai/ds-rules.md | Semantic status tokens (no hardcoded shades) | Compliant | UI section uses `bg-status-*-soft text-status-*-fg`; no `text-red-*`, no `bg-green-*`, no `dark:` overrides on status. |
+| .ai/ds-rules.md | Tailwind text scale (no arbitrary sizes) | Compliant | No `text-[13px]`, no `p-[13px]`, no arbitrary values. |
+| .ai/ui-components.md | lucide-react via icon registry in page body | Compliant | UI section specifies `@open-mercato/ui/backend/icons`. No inline `<svg>`. |
+| .ai/ui-components.md | Shared primitives (`Alert`, `StatusBadge`, `EmptyState`, `CollapsibleSection`, `LoadingMessage`/`Spinner`/`DataLoader`) | Compliant | UI section enumerates the primitives used. |
+| .ai/specs/AGENTS.md | Required sections (10) | Compliant | All present: TLDR, Overview, Problem Statement, Proposed Solution, Architecture, Data Models, API Contracts, Risks & Impact Review, Final Compliance Report, Changelog. |
+| .ai/specs/AGENTS.md | Risk register format | Compliant | All risks use the required block format with Scenario/Severity/Affected area/Mitigation/Residual risk. |
+| spec-writing skill | Frontend Architecture Contract (when touching `app/**`) | Compliant | Included Server/Client boundary map, `"use client"` ledger, client blob guardrail, route budgets, hydration test, provider/bootstrap scope. |
+| spec-writing skill | Security: input validation, parameterized queries, XSS protections, encoding, secret exclusion | Compliant | Security Posture subsection in Architecture documents each: zod everywhere, MikroORM (no raw SQL), no HTML rendering in v1 (XSS N/A), URL building via `URLSearchParams`, credential-key rejection in log validators. |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|---|---|---|
+| Data models match API contracts | Pass | DTOs in API contracts correspond to entity fields; redacted fields explicitly noted for admin endpoints. |
+| API contracts match UI/UX section | Pass | Every UI action maps to a documented API route. |
+| Risks cover all write operations | Pass | Connect, disconnect, set-primary, rename, send, ingest, refresh all addressed. |
+| Commands defined for all mutations | Pass | 9 commands cover all state changes. |
+| Events cover all state-change announcements | Pass | account.connected/disconnected/requires_reauth/error + message.received/sent. |
+| Encryption declared for all sensitive columns | Pass | `credential_blob` is the only sensitive column; declared. |
+| Backward compatibility analysis covers every modified surface | Pass | Table enumerates every contract surface, all additive. |
+
+### Non-Compliant Items
+
+None.
+
+### Verdict
+
+- **Fully compliant**: Approved — ready for implementation.
+
+## Changelog
+
+### 2026-05-21
+- Initial specification.
+
+### Review — 2026-05-21
+- **Reviewer**: Agent (spec-writing skill, adversarial pass)
+- **Security**: Passed — added explicit Security Posture subsection covering XSS N/A in v1, URL/header encoding, parameterized queries, secret-key rejection in `EmailHealthLog.context` validator
+- **Performance**: Passed — added scheduler N+1 mitigation note (single indexed scan on `(status, last_polled_at)`, 500-row enumeration cap per tick) and cursor/keyset pagination for admin lists
+- **Cache**: N/A — this spec does not introduce caching
+- **Commands**: Passed — 9 commands, undo behavior documented for every mutation, non-undoability explicitly justified for send (cannot un-send) and refresh_token (no business undo)
+- **Risks**: Passed — 13 concrete scenarios across all 5 categories (data integrity, cascading, isolation, deployment, operational), each with severity + mitigation + residual
+- **Verdict**: Approved
+
+### Review fixes — 2026-05-21
+- API Contracts: added per-method `metadata` requirement, cursor pagination, `makeCrudRoute` vs bespoke route delineation with `validateCrudMutationGuard` for custom writes
+- UI: added explicit `aria-label` requirement for icon-only buttons and `pageSize ≤ 100` cursor pagination for DataTables
+- Architecture: added Security Posture subsection (XSS, URL encoding, parameterized queries, log-key rejection)
+- Architecture: added scheduler N+1 mitigation note
+- Compliance Matrix: expanded from 22 to 30 rules, all marked Compliant except module-name plurality (Compliant with caveat — flagged for user confirmation)
+
+### Pre-implementation analysis fixes — 2026-05-21
+Findings from `.ai/specs/analysis/ANALYSIS-2026-05-21-email-integration-foundation.md` applied:
+- **Encryption snippet** rewritten to canonical `defaultEncryptionMaps: ModuleEncryptionMap[]` export from `@open-mercato/shared/modules/encryption`. Previous draft imported a non-existent `registerEntityEncryption` symbol.
+- **Events snippet** rewritten to canonical `createModuleEvents({ moduleId, events })` shape with full dotted IDs in an `as const` array. Payload types moved to TS aliases referenced via the typed `emit`. `persistent: true` documented as a subscriber-metadata field, not an event-definition field.
+- **Provider package layout** restructured to `packages/<pkg>/src/modules/<module_id>/...` to match `gateway-stripe` / `sync-akeneo` conventions and align module IDs with auto-discovery (dashes → underscores).
+- **Access Control section** added: five ACL features enumerated with `id`/`title`/`module`, plus a `defaultRoleFeatures` map (admin gets all five; manager/user get connect+manage+send). `email.admin.providers` is the fifth feature, separated from `email.admin` to gate OAuth-client-credential writes.
+- **`modules.ts` entries** documented explicitly with underscore-converted IDs (`email_gmail`, `email_microsoft`, `email_imap`) and the required structural-cache purge.
+- **OSS Independence** section added: explicit ban on `@open-mercato/enterprise` imports from this module and its provider packages, with a Phase 1 grep-based verification step. State-cookie helper is ported (re-implemented locally), not imported.
+- **`AttachmentRef` type** defined as a Zod discriminated union (`attachment` referencing the existing attachments module, or `inline` for ad-hoc content with hard size caps).
+- **Phase 8 removed**: integration tests moved in-phase. Each phase ships its own module-local Playwright specs under `<package>/src/modules/<id>/__integration__/` per `.ai/lessons.md`. `.ai/qa/scenarios/` retains only markdown scenarios.
+- **Section title**: "Migration & Compatibility" renamed to "Migration & Backward Compatibility" to match `BACKWARD_COMPATIBILITY.md` recommendation.
+- **Cross-process event bridge note** added to the events section: any future flip of `email.message.received` to `clientBroadcast: true` MUST be paired with the cross-process bridge work (see `.ai/lessons.md` → "Browser SSE bridges must work across worker and web processes").


### PR DESCRIPTION
## Summary

New specification for per-user, multi-provider email account integration. Today the platform has outbound-only Resend email (~15 transactional flows) and no inbound except `inbox_ops`'s shared tenant address. This spec defines the **foundation** that lets each logged-in user link their own Gmail, Microsoft 365 / Outlook, or IMAP+SMTP mailbox, send from it, and receive into it — so a follow-on CRM spec can attach sent and received emails to customers, deals, and conversations. Foundation only: no CRM hooks, no inbox UI, no message body persistence; the existing Resend pipeline stays untouched.

## Changes

- Adds `.ai/specs/2026-05-21-email-integration-foundation.md` defining:
  - New core orchestrator module at `packages/core/src/modules/email/` with five entities (`EmailAccount`, `EmailAccountCredential`, `EmailSyncCursor`, `EmailHealthLog`, `EmailMessageEnvelope`), all tenant + user scoped; `credential_blob` field-level encrypted
  - Three new workspace provider packages — `@open-mercato/email-gmail`, `@open-mercato/email-microsoft`, `@open-mercato/email-imap` — each owning OAuth (or credential probe) + sync + send + health for its provider, registered via the core `EmailProviderRegistry` from their own `setup.ts`
  - `EmailProvider` interface, `CanonicalMessage` event payload contract with a discriminated `providerMeta` union, opaque `bodyRef` pointer (no body in v1 payloads), and `BodyRef` shape per provider
  - OAuth client flow: state-cookie helper (AES-256-GCM + HKDF, 5-min TTL, userId-bound) ported locally from the SSO module pattern; generic `/api/email/oauth/[provider]/callback` router; per-tenant Marketplace override of platform-default OAuth apps
  - Polling-based receive pipeline (5-min default, configurable per account) on queue `email-sync` (concurrency 10, I/O-bound) with cursor advancement, drain mode, error classification, and exponential backoff
  - `sendAsUser({ accountId, message })` outbound primitive with automatic OAuth token refresh, typed `EmailSendError` classification, and `AttachmentRef` (Zod discriminated union: `attachment` reusing the existing attachments module, or `inline` with 10 MB / 25 MB caps)
  - Nine commands following the customers/commands pattern, each with documented undo behavior
  - Six canonical events: `email.account.{connected,disconnected,requires_reauth,error}` and `email.message.{received,sent}`; `clientBroadcast: false` on `message.received` for v1 (privacy + volume + cross-process bridge constraint)
  - Five ACL features (`email.account.connect`, `email.account.manage`, `email.send`, `email.admin`, `email.admin.providers`) with a `defaultRoleFeatures` map for admin / manager / user
  - API surface: per-method `metadata` guards, `makeCrudRoute` for list/patch/delete, bespoke routes (OAuth init/callback, IMAP connect, set-primary, send) calling `validateCrudMutationGuard` + `runCrudMutationGuardAfterSuccess`, cursor pagination with `limit ≤ 100`
  - User Settings page at `/backend/profile/email-accounts` (DataTable + ConnectImapDialog + requires-reauth banner + empty state) and admin debug page at `/backend/email/admin` (tenant accounts list, health log, per-provider OAuth client config) — all using existing DS primitives, semantic status tokens, lucide-react icons via the backend registry
  - Notification type `email_account_requires_reauth` with subscriber + client renderer; daily cleanup workers (`purge-envelopes`, `purge-health-log`)
  - Configuration env vars (`OM_EMAIL_*`) for platform-default OAuth apps, sync tuning, retention windows, and the state-cookie key
  - Phased implementation plan (Phases 1-7), per-phase module-local `__integration__/` test placement, and 15 numbered scenarios (TC-EMAIL-001…015)
  - Risk register: 13 concrete scenarios across data integrity, cascading failures, tenant isolation, deployment, and operational categories — each with severity, mitigation, residual risk
  - Migration & Backward Compatibility table: purely additive across schema, API routes, events, ACL features, notifications, Marketplace; no deprecations
  - OSS Independence rule: MUST NOT import from `@open-mercato/enterprise` from this module or its provider packages; Phase 1 acceptance includes a grep verification

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [x] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/2026-05-21-email-integration-foundation.md`

## Testing

Spec-only PR — no runtime code yet. Implementation lands in subsequent PRs per the spec's phasing. Each phase ships its own module-local Playwright specs in the owning package's `__integration__/` directory and is not marked complete until those tests pass.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. — the spec is the documentation
- [x] I added or adjusted tests that cover the change. — N/A, spec-only PR; integration tests are defined in the spec and land in the implementation PRs
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — N/A, spec-only PR; spec directs executable specs to module-local `__integration__/` per `.ai/lessons.md`
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance

> N/A for this PR — no UI, no `className`, no React components touched. Items below are trivially true.

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements