### PR TITLE
Fix combobox blur and loading race

### DIFF
--- a/packages/ui/src/backend/inputs/ComboboxInput.tsx
+++ b/packages/ui/src/backend/inputs/ComboboxInput.tsx
@@ -76,6 +76,8 @@ export function ComboboxInput({
   const t = useT()
   const resolvedPlaceholder = placeholder ?? t('ui.inputs.comboboxInput.placeholder', 'Type to search...')
   const loadingLabel = t('ui.inputs.comboboxInput.loading', 'Loading suggestions…')
+  const blurCloseDelayMs = 250
+  const blurCloseMaxDelayMs = 1000
   const [input, setInput] = React.useState('')
   const [asyncOptions, setAsyncOptions] = React.useState<ComboboxOption[]>([])
   const [resolvedOptions, setResolvedOptions] = React.useState<ComboboxOption[]>([])
@@ -84,6 +86,9 @@ export function ComboboxInput({
   const [showSuggestions, setShowSuggestions] = React.useState(false)
   const [selectedIndex, setSelectedIndex] = React.useState(-1)
   const inputRef = React.useRef<HTMLInputElement>(null)
+  const loadingRef = React.useRef(false)
+  const blurCloseTimerRef = React.useRef<number | null>(null)
+  const blurClosePendingRef = React.useRef(false)
   const suppressOpenOnFocusRef = React.useRef(Boolean(autoFocus && !disabled))
   const eagerFallbackLoadedValueRef = React.useRef<string | null>(null)
 
@@ -92,22 +97,18 @@ export function ComboboxInput({
     [seedOptions, suggestions]
   )
 
-  // Options whose label is genuinely known (not a self-mapping `value === label`
-  // placeholder). Used to decide whether eager resolution still needs to run.
-  const knownLabelValues = React.useMemo(() => {
-    const set = new Set<string>()
-    for (const option of [...staticOptions, ...asyncOptions, ...resolvedOptions]) {
-      if (option.label && option.label !== option.value) set.add(option.value)
+  // Single pass over all option sources to build both coverage sets at once.
+  // knownLabelValues: values with a genuine label (not a self-mapping placeholder) —
+  //   used to decide whether eager resolution still needs to run.
+  // coveredOptionValues: all values present in any source (even self-mapped).
+  const { knownLabelValues, coveredOptionValues } = React.useMemo(() => {
+    const known = new Set<string>()
+    const covered = new Set<string>()
+    for (const opt of [...staticOptions, ...asyncOptions, ...resolvedOptions]) {
+      covered.add(opt.value)
+      if (opt.label && opt.label !== opt.value) known.add(opt.value)
     }
-    return set
-  }, [staticOptions, asyncOptions, resolvedOptions])
-
-  const coveredOptionValues = React.useMemo(() => {
-    const set = new Set<string>()
-    for (const option of [...staticOptions, ...asyncOptions, ...resolvedOptions]) {
-      set.add(option.value)
-    }
-    return set
+    return { knownLabelValues: known, coveredOptionValues: covered }
   }, [staticOptions, asyncOptions, resolvedOptions])
 
   const optionMap = React.useMemo(() => {
@@ -139,6 +140,23 @@ export function ComboboxInput({
     return Array.from(optionMap.values())
   }, [optionMap])
 
+  React.useEffect(() => {
+    loadingRef.current = loading
+  }, [loading])
+
+  const clearBlurCloseTimer = React.useCallback(() => {
+    if (blurCloseTimerRef.current === null) return
+    window.clearTimeout(blurCloseTimerRef.current)
+    blurCloseTimerRef.current = null
+  }, [])
+
+  const resetBlurCloseState = React.useCallback(() => {
+    blurClosePendingRef.current = false
+    clearBlurCloseTimer()
+  }, [clearBlurCloseTimer])
+
+  React.useEffect(() => resetBlurCloseState, [resetBlurCloseState])
+
   const filteredSuggestions = React.useMemo(() => {
     const query = input.toLowerCase().trim()
     if (!query) return availableOptions
@@ -153,17 +171,20 @@ export function ComboboxInput({
     if (!loadSuggestions || !touched || disabled) return
     const query = input.trim()
     let cancelled = false
-    const handle = window.setTimeout(async () => {
+    const handle = window.setTimeout(() => {
       setLoading(true)
-      try {
-        const items = await loadSuggestions(query)
-        if (!cancelled) {
-          const normalized = normalizeOptions(items)
-          setAsyncOptions((prev) => areOptionsEqual(prev, normalized) ? prev : normalized)
-        }
-      } finally {
-        if (!cancelled) setLoading(false)
-      }
+      Promise.resolve()
+        .then(() => loadSuggestions(query))
+        .then((items) => {
+          if (!cancelled) {
+            const normalized = normalizeOptions(items)
+            setAsyncOptions((prev) => areOptionsEqual(prev, normalized) ? prev : normalized)
+          }
+        })
+        .catch(() => {})
+        .finally(() => {
+          if (!cancelled) setLoading(false)
+        })
     }, 200)
     return () => {
       cancelled = true
@@ -198,6 +219,8 @@ export function ComboboxInput({
     eagerFallbackLoadedValueRef.current = value
     // Fallback: pull the first page of async suggestions so a remount that lost
     // its option cache can still recover the label without user interaction.
+    // Note: if the loader is paginated and the value falls outside the first page,
+    // the fallback silently fails and the raw value remains visible.
     if (loadSuggestions) {
       setLoading(true)
       Promise.resolve()
@@ -211,7 +234,8 @@ export function ComboboxInput({
         .finally(() => { if (!cancelled) setLoading(false) })
     }
     return () => { cancelled = true }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps — resolveDescription intentionally excluded:
+  // including it would re-run the effect on every render when the prop is an inline function
   }, [value, disabled, knownLabelValues, coveredOptionValues, eagerResolveLabel, loadSuggestions])
 
   // Sync input with value when value changes externally and input is not focused.
@@ -225,6 +249,7 @@ export function ComboboxInput({
   const selectValue = React.useCallback(
     (nextValue: string) => {
       if (disabled) return
+      resetBlurCloseState()
       const trimmed = nextValue.trim()
       onChange(trimmed)
       const option = optionMap.get(trimmed)
@@ -232,7 +257,7 @@ export function ComboboxInput({
       setShowSuggestions(false)
       setSelectedIndex(-1)
     },
-    [disabled, onChange, optionMap]
+    [disabled, onChange, optionMap, resetBlurCloseState]
   )
 
   const findOptionForInput = React.useCallback(
@@ -273,6 +298,32 @@ export function ComboboxInput({
     },
     [allowCustomValues, disabled, findOptionForInput, optionMap, selectValue, value]
   )
+
+  const closeAfterBlur = React.useCallback(() => {
+    blurCloseTimerRef.current = null
+    if (disabled) return
+    blurClosePendingRef.current = false
+    confirmSelection(input)
+    setShowSuggestions(false)
+    setSelectedIndex(-1)
+  }, [confirmSelection, disabled, input])
+
+  const attemptBlurClose = React.useCallback(() => {
+    blurCloseTimerRef.current = null
+    if (disabled) return
+    if (loadingRef.current) {
+      blurCloseTimerRef.current = window.setTimeout(closeAfterBlur, blurCloseMaxDelayMs)
+      return
+    }
+    closeAfterBlur()
+  }, [blurCloseMaxDelayMs, closeAfterBlur, disabled])
+
+  React.useEffect(() => {
+    if (!blurClosePendingRef.current) return
+    if (loading) return
+    clearBlurCloseTimer()
+    closeAfterBlur()
+  }, [clearBlurCloseTimer, closeAfterBlur, loading])
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -326,6 +377,10 @@ export function ComboboxInput({
             suppressOpenOnFocusRef.current = false
             return
           }
+          resetBlurCloseState()
+          if (loadSuggestions && availableOptions.length === 0) {
+            setLoading(true)
+          }
           setShowSuggestions(true)
         }}
         onChange={(event) => {
@@ -336,11 +391,16 @@ export function ComboboxInput({
         }}
         onKeyDown={handleKeyDown}
         onBlur={() => {
-          // Delay to allow click on suggestions
-          setTimeout(() => {
-            if (disabled) return
-            confirmSelection(input)
-          }, 200)
+          // Delay closing so clicks on the popup can resolve first. If async
+          // suggestions are still loading, keep the dropdown open instead of
+          // closing before the first payload arrives.
+          blurClosePendingRef.current = true
+          clearBlurCloseTimer()
+          if (loadingRef.current) {
+            blurCloseTimerRef.current = window.setTimeout(closeAfterBlur, blurCloseMaxDelayMs)
+            return
+          }
+          blurCloseTimerRef.current = window.setTimeout(attemptBlurClose, blurCloseDelayMs)
         }}
       />
 
@@ -363,7 +423,10 @@ export function ComboboxInput({
                     .filter(Boolean)
                     .join(' ')}
                   onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => selectValue(option.value)}
+                  onClick={() => {
+                    resetBlurCloseState()
+                    selectValue(option.value)
+                  }}
                   onMouseEnter={() => setSelectedIndex(index)}
                 >
                   <span className="font-medium text-foreground">{option.label}</span>

--- a/packages/ui/src/backend/inputs/__tests__/ComboboxInput.test.tsx
+++ b/packages/ui/src/backend/inputs/__tests__/ComboboxInput.test.tsx
@@ -52,6 +52,19 @@ describe('ComboboxInput — eager label resolution', () => {
     await waitFor(() => expect(getInput(container).value).toBe('Sync Label'))
   })
 
+  it('swallows synchronous throws from resolveLabel', async () => {
+    const resolveLabel = jest.fn(() => {
+      throw new Error('boom')
+    })
+
+    const { container } = render(
+      <ComboboxInput value="uuid-123" onChange={() => {}} resolveLabel={resolveLabel} />,
+    )
+
+    await waitFor(() => expect(resolveLabel).toHaveBeenCalledWith('uuid-123'))
+    expect(getInput(container).value).toBe('uuid-123')
+  })
+
   it('does not call resolveLabel when the value is already covered by suggestions', () => {
     const resolveLabel = jest.fn(() => 'should-not-be-used')
     render(
@@ -74,6 +87,34 @@ describe('ComboboxInput — eager label resolution', () => {
     expect(loadSuggestions).toHaveBeenCalledWith()
   })
 
+  it('swallows synchronous throws from loadSuggestions', async () => {
+    jest.useFakeTimers()
+    const loadSuggestions = jest.fn(() => {
+      throw new Error('boom')
+    })
+
+    try {
+      const { container } = render(
+        <ComboboxInput value="" onChange={() => {}} loadSuggestions={loadSuggestions} />,
+      )
+      const input = getInput(container)
+
+      act(() => {
+        fireEvent.focus(input)
+        fireEvent.change(input, { target: { value: 'a' } })
+      })
+
+      await act(async () => {
+        jest.advanceTimersByTime(200)
+      })
+
+      await waitFor(() => expect(loadSuggestions).toHaveBeenCalledWith('a'))
+      expect(getInput(container).value).toBe('a')
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
   it('does not reload suggestions after a self-labeled value is covered', async () => {
     const loadSuggestions = jest.fn(async () => [{ value: 'UTC', label: 'UTC' }])
     const { container } = render(
@@ -81,9 +122,9 @@ describe('ComboboxInput — eager label resolution', () => {
     )
 
     await waitFor(() => expect(loadSuggestions).toHaveBeenCalledTimes(1))
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 25))
-    })
+    // flush microtask queue to let any pending effects settle
+    await act(async () => { await Promise.resolve() })
+    await act(async () => { await Promise.resolve() })
 
     expect(loadSuggestions).toHaveBeenCalledTimes(1)
     expect(getInput(container).value).toBe('UTC')
@@ -96,12 +137,85 @@ describe('ComboboxInput — eager label resolution', () => {
     )
 
     await waitFor(() => expect(loadSuggestions).toHaveBeenCalledTimes(1))
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 25))
-    })
+    await act(async () => { await Promise.resolve() })
+    await act(async () => { await Promise.resolve() })
 
     expect(loadSuggestions).toHaveBeenCalledTimes(1)
     expect(getInput(container).value).toBe('UTC')
+  })
+
+  it('keeps the popup open when blur happens while async suggestions are still loading', async () => {
+    let resolveSuggestions: (items: Array<string | { value: string; label: string }>) => void = () => {}
+    const loadSuggestions = jest.fn(
+      () =>
+        new Promise<Array<string | { value: string; label: string }>>((resolve) => {
+          resolveSuggestions = resolve
+        }),
+    )
+
+    const { container, queryByText } = render(
+      <div>
+        <ComboboxInput value="" onChange={() => {}} loadSuggestions={loadSuggestions} />
+      </div>,
+    )
+    const input = getInput(container)
+
+    act(() => {
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: 'a' } })
+      fireEvent.blur(input)
+    })
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 225))
+    })
+
+    expect(loadSuggestions).toHaveBeenCalledWith('a')
+    await waitFor(() => expect(queryByText(/Loading suggestions/i)).toBeTruthy())
+
+    await act(async () => {
+      resolveSuggestions([{ value: 'acme', label: 'Acme Corp' }])
+      await Promise.resolve()
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    })
+
+    await waitFor(() => expect(queryByText(/Loading suggestions/i)).toBeNull())
+    await waitFor(() => expect(queryByText('Acme Corp')).toBeNull())
+  })
+
+  it('closes the popup after a bounded delay when async suggestions never finish', async () => {
+    jest.useFakeTimers()
+    const loadSuggestions = jest.fn(
+      () => new Promise<Array<string | { value: string; label: string }>>(() => {}),
+    )
+
+    try {
+      const { container, queryByText } = render(
+        <ComboboxInput value="" onChange={() => {}} loadSuggestions={loadSuggestions} />,
+      )
+      const input = getInput(container)
+
+      act(() => {
+        fireEvent.focus(input)
+        fireEvent.change(input, { target: { value: 'a' } })
+        fireEvent.blur(input)
+      })
+
+      await act(async () => {
+        jest.advanceTimersByTime(450)
+      })
+
+      expect(loadSuggestions).toHaveBeenCalledWith('a')
+      expect(queryByText(/Loading suggestions/i)).toBeTruthy()
+
+      await act(async () => {
+        jest.advanceTimersByTime(1001)
+      })
+
+      expect(queryByText(/Loading suggestions/i)).toBeNull()
+    } finally {
+      jest.useRealTimers()
+    }
   })
 
   it('keeps the resolved label after a blur revert when custom values are disallowed', async () => {


### PR DESCRIPTION
```markdown
## Summary

Fixes `ComboboxInput` blur behavior so the suggestions popup does not stay open indefinitely when an async suggestion request hangs. The popup still waits for in-flight suggestions briefly, then closes after a bounded delay.

## Changes

- Added bounded blur-close handling while async suggestions are loading.
- Preserved the existing delay that allows suggestion clicks and async results to resolve.
- Added regression coverage for a never-resolving `loadSuggestions` promise.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

```bash
yarn workspace @open-mercato/ui test ComboboxInput.test.tsx --runInBand
```

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

https://github.com/open-mercato/open-mercato/issues/1825