### PR TITLE
docs: organize AGENTS.md agent instructions

### DIFF
--- a/.ai/qa/AGENTS.md
+++ b/.ai/qa/AGENTS.md
@@ -304,7 +304,7 @@ export const integrationMeta = {
 }
 ```
 
-### MUST Rules for Executable Tests
+### Always / Never for Executable Tests
 
 - Use Playwright locators: `getByRole`, `getByLabel`, `getByText`, `getByPlaceholder` — avoid CSS selectors
 - If a matching scenario exists, reference it in a comment (e.g., `Source: .ai/qa/scenarios/TC-AUTH-001-*.md`)

--- a/.ai/qa/AGENTS.md
+++ b/.ai/qa/AGENTS.md
@@ -1,5 +1,34 @@
 # QA Integration Testing Instructions
 
+## Always
+
+- Prefer executable Playwright TypeScript tests in module `__integration__` folders.
+- Reuse shared helpers from `@open-mercato/core/helpers/integration/*`.
+- Keep integration tests independent, data-independent, deterministic, and safe across retries.
+- Create required fixtures per test and clean up created data in `finally`/teardown.
+- Check `.ai/qa/ephemeral-env.json` before starting a new manual exploration environment.
+
+## Ask First
+
+- Ask before applying migrations or resetting a developer's local database.
+- Ask before adding tests that require live external services or secrets instead of using metadata gates.
+- Ask before placing executable specs outside the preferred module `__integration__` locations.
+
+## Never
+
+- Never put executable `.spec.ts` files under `.ai/qa/tests`; that directory is for shared Playwright config.
+- Never rely on seeded/demo data being present.
+- Never leave broken tests; fix them or use `test.skip()` with a clear reason.
+- Never use loose `testIgnore` globs that can match parent workspace paths.
+
+## Validation Commands
+
+```bash
+yarn test:integration
+yarn test:integration:ephemeral
+npx playwright test --config .ai/qa/tests/playwright.config.ts --list
+```
+
 ## Quick Start
 
 ```bash
@@ -304,7 +333,7 @@ export const integrationMeta = {
 }
 ```
 
-### Always / Never for Executable Tests
+### Executable Test Rules
 
 - Use Playwright locators: `getByRole`, `getByLabel`, `getByText`, `getByPlaceholder` — avoid CSS selectors
 - If a matching scenario exists, reference it in a comment (e.g., `Source: .ai/qa/scenarios/TC-AUTH-001-*.md`)

--- a/.ai/specs/AGENTS.md
+++ b/.ai/specs/AGENTS.md
@@ -61,7 +61,7 @@ Examples:
 - Update changelog with exact date and concise summary.
 - Re-run review checklist and final compliance gate before approval.
 
-## MUST Rules (Condensed)
+## Always (Condensed)
 
 - Every non-trivial spec includes: TLDR, Overview, Problem Statement, Proposed Solution, Architecture, Data Models, API Contracts, Risks & Impact Review, Final Compliance Report, Changelog.
 - Risks must document concrete failure scenarios, severity, affected area, mitigation, and residual risk.

--- a/.ai/specs/AGENTS.md
+++ b/.ai/specs/AGENTS.md
@@ -2,6 +2,31 @@
 
 Check `.ai/specs/` and `.ai/specs/enterprise/` before modifying any module. Create or update specs when the change is non-trivial.
 
+## Always
+
+- Check both OSS and enterprise spec directories before modifying a module.
+- Create a new spec for a new module, significant feature, or architecture change touching multiple files.
+- Update an existing spec when changing APIs, data models, workflows, permissions, or cross-module behavior.
+- Keep specs implementation-accurate and update the changelog after implementation.
+- Use the root Task Router to identify all related guides for review.
+
+## Ask First
+
+- Ask before moving a spec to `implemented/` if deployment/completion evidence is incomplete.
+- Ask before renaming legacy spec files or changing the spec directory taxonomy.
+
+## Never
+
+- Never introduce new `SPEC-*` or `SPEC-ENT-*` filename prefixes.
+- Never leave stale endpoints, entities, or assumptions in an updated spec.
+- Never put enterprise-only scope in the OSS specs directory.
+
+## Validation Commands
+
+```bash
+find .ai/specs .ai/specs/enterprise -maxdepth 2 -name '*.md' -print
+```
+
 ## Spec Separation
 
 - `.ai/specs/` contains Open Source edition specifications.
@@ -61,7 +86,7 @@ Examples:
 - Update changelog with exact date and concise summary.
 - Re-run review checklist and final compliance gate before approval.
 
-## Always (Condensed)
+## Spec Content Checklist
 
 - Every non-trivial spec includes: TLDR, Overview, Problem Statement, Proposed Solution, Architecture, Data Models, API Contracts, Risks & Impact Review, Final Compliance Report, Changelog.
 - Risks must document concrete failure scenarios, severity, affected area, mitigation, and residual risk.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,47 @@
 
 Leverage the module system and follow strict naming and coding conventions to keep the system consistent and safe to extend.
 
-## Before Writing Code
+## Always
 
-1. Check the Task Router below — a single task may match multiple rows; read **all** relevant guides.
-2. Check `.ai/specs/` and `.ai/specs/enterprise/` for existing specs on the module you're modifying
-3. Enter plan mode for non-trivial tasks (3+ steps or architectural decisions)
-4. Identify the reference module (customers) if building CRUD features
+- Check the Task Router below before research or coding; a single task may match multiple rows, and all relevant guides apply.
+- Check `.ai/specs/` and `.ai/specs/enterprise/` for existing specs before modifying a module.
+- Enter plan mode for non-trivial tasks with 3+ steps or architectural decisions.
+- Identify the reference module (`customers`) when building CRUD features.
+- Preserve behavior unless the user or a spec explicitly asks for a behavior change.
+- Keep changes minimal, focused, and integrated through real call sites.
+- Use the closest package/module `AGENTS.md` for local architecture, imports, and validation commands.
+- Follow `BACKWARD_COMPATIBILITY.md` before touching any contract surface.
+- Run `yarn generate` after adding or modifying module files that rely on auto-discovery.
+
+## Ask First
+
+- Ask before reducing scope, changing architecture, changing public contracts, adding production dependencies, or touching multiple modules in a way not covered by an existing spec.
+- Ask before changing branch/PR automation, pipeline labels, QA flow, release behavior, or external official-module submodule pointers.
+- Ask before applying database migrations locally with `yarn db:migrate`; normal PRs should include migration files and snapshots.
+- Ask before introducing provider-specific preconfiguration outside the provider package.
+
+## Never
+
+- Never expose cross-tenant data or skip tenant/organization scoping.
+- Never edit generated files by hand.
+- Never add code directly under `apps/mercato/src/` except committed, typed `*.generated.ts` registries described below.
+- Never create direct ORM relationships between modules.
+- Never bypass mutation guards, command side effects, encryption helpers, RBAC wildcard matching, or shared UI data-call helpers.
+- Never hard-code user-facing strings or design-system status colors.
+- Never commit credentials, raw tokens, private keys, local-only ops files, or fork-only infrastructure notes into upstream-friendly branches.
+
+## Validation Commands
+
+Choose the smallest relevant set for the change:
+
+```bash
+yarn generate
+yarn build:packages
+yarn typecheck
+yarn lint
+yarn test
+yarn build:app
+```
 
 ## Task Router — Where to Find Detailed Guidance
 
@@ -227,7 +262,7 @@ All paths use `src/modules/<module>/` as shorthand. See `packages/core/AGENTS.md
 | `widgets/components.ts` | `componentOverrides` | Component replacement/wrapper/props override definitions |
 | `data/enrichers.ts` | `enrichers` | Response enrichers for data federation |
 
-### Always
+### Module Rules
 
 - API routes MUST export `openApi` for documentation generation
 - CRUD routes: use `makeCrudRoute` with `indexer: { entityType }` for query index coverage
@@ -273,13 +308,18 @@ Third-party module developers depend on stable platform APIs. Any change to a **
 
 **Deprecation protocol** (summary): (1) never remove in one release, (2) add `@deprecated` JSDoc, (3) provide a bridge (re-export/alias/dual-emit) for ≥1 minor version, (4) document in RELEASE_NOTES.md, (5) reference a spec with "Migration & Backward Compatibility" section.
 
-## Always / Ask First / Never
+## Boundary Labels for Agent Rules
 
-Use `Always`, `Ask First`, and `Never` headings when adding or reorganizing agent rules:
+Use `Always`, `Ask First`, `Never`, and `Validation Commands` headings when adding or reorganizing agent rules:
 
 - `Always` — required defaults and commands agents should apply without asking.
 - `Ask First` — decisions that need maintainer input before changing behavior, scope, dependencies, branch/deploy flow, or contract surfaces.
 - `Never` — prohibited actions and unsafe shortcuts.
+- `Validation Commands` — short, real commands agents can run to prove the relevant path.
+
+## Architecture, Data, UI, and Code Rules
+
+These are critical project-wide rules. The top-level `Always`, `Ask First`, and `Never` sections summarize their boundaries; this section keeps the detailed requirements.
 
 ### Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,7 @@ All paths use `src/modules/<module>/` as shorthand. See `packages/core/AGENTS.md
 | `widgets/components.ts` | `componentOverrides` | Component replacement/wrapper/props override definitions |
 | `data/enrichers.ts` | `enrichers` | Response enrichers for data federation |
 
-### Key Rules
+### Always
 
 - API routes MUST export `openApi` for documentation generation
 - CRUD routes: use `makeCrudRoute` with `indexer: { entityType }` for query index coverage
@@ -273,7 +273,13 @@ Third-party module developers depend on stable platform APIs. Any change to a **
 
 **Deprecation protocol** (summary): (1) never remove in one release, (2) add `@deprecated` JSDoc, (3) provide a bridge (re-export/alias/dual-emit) for ≥1 minor version, (4) document in RELEASE_NOTES.md, (5) reference a spec with "Migration & Backward Compatibility" section.
 
-## Critical Rules
+## Always / Ask First / Never
+
+Use `Always`, `Ask First`, and `Never` headings when adding or reorganizing agent rules:
+
+- `Always` — required defaults and commands agents should apply without asking.
+- `Ask First` — decisions that need maintainer input before changing behavior, scope, dependencies, branch/deploy flow, or contract surfaces.
+- `Never` — prohibited actions and unsafe shortcuts.
 
 ### Architecture
 

--- a/docker/opencode/AGENTS.md
+++ b/docker/opencode/AGENTS.md
@@ -2,22 +2,38 @@
 
 You are an AI assistant for the **Open Mercato** business platform with full API access through MCP tools.
 
-## Rules
+## Always
 
 1. **READ = GET only.** find/list/show/search/get → only GET. NEVER call PUT/POST/DELETE for a read query.
 2. **PUT path = collection path.** id goes in the BODY, not the URL. Example: `PUT /api/customers/companies` with `{ id: '...', name: 'New' }`. There are NO `/{id}` path segments.
-3. **Confirm before ANY write.** Before POST/PUT/DELETE: present your plan in business language, STOP, wait for "yes".
-4. **Max 4 tool calls per message.** Hard limit is 10.
-5. **NEVER call findEndpoints/describeEndpoint for COMMON PATHS** — use them directly.
-6. **NEVER repeat a search** from earlier in the conversation — reuse previous results.
-7. **NEVER make N+1 calls** (1 per record). Fetch a list and reason about results.
-8. **When you already have data**, use it — do NOT re-fetch to "enrich".
-9. **Do NOT write JS filters/regex** to match records. Fetch with api.request() and use YOUR knowledge.
-10. **"search" query param is fulltext only** — won't match nationalities, categories, or subjective criteria. For those, fetch all and reason.
-11. **NEVER set computed/total fields** — the server calculates them.
-12. **For creates with children** (e.g. quote + lines): include children INLINE using the nestedCollections field name.
-13. **For unknown fields, OMIT them** — the API uses defaults for optional fields.
-14. **Session token:** Every conversation includes a session token. Include it as `_sessionToken` in EVERY tool call.
+3. **Max 4 tool calls per message.** Hard limit is 10.
+4. **When you already have data**, use it.
+5. **"search" query param is fulltext only** — won't match nationalities, categories, or subjective criteria. For those, fetch all and reason.
+6. **For creates with children** (e.g. quote + lines): include children INLINE using the nestedCollections field name.
+7. **For unknown fields, OMIT them** — the API uses defaults for optional fields.
+8. **Session token:** Every conversation includes a session token. Include it as `_sessionToken` in EVERY tool call.
+
+## Ask First
+
+- Confirm before ANY write. Before POST/PUT/DELETE: present your plan in business language, STOP, wait for "yes".
+
+## Never
+
+- Never call PUT/POST/DELETE for a read query.
+- Never call `findEndpoints`/`describeEndpoint` for COMMON PATHS — use them directly.
+- Never repeat a search from earlier in the conversation — reuse previous results.
+- Never make N+1 calls (1 per record). Fetch a list and reason about results.
+- Never re-fetch data just to "enrich".
+- Never write JS filters/regex to match records. Fetch with `api.request()` and use YOUR knowledge.
+- Never set computed/total fields — the server calculates them.
+
+## Validation Commands
+
+Use this smoke check when changing this assistant prompt:
+
+```bash
+rg -n 'Confirm before|_sessionToken|search.*fulltext|Common API Paths' docker/opencode/AGENTS.md
+```
 
 ---
 

--- a/packages/ai-assistant/AGENTS.md
+++ b/packages/ai-assistant/AGENTS.md
@@ -2,6 +2,36 @@
 
 > **IMPORTANT**: Update this file with every major change to this module. When implementing new features, modifying architecture, or changing key interfaces, update the relevant sections to keep guidance accurate for future agents.
 
+## Always
+
+- Treat the public AI assistant docs linked below as the source of truth when they disagree with this file.
+- Use `registerMcpTool`/`defineAiTool` with Zod schemas, `moduleId`, `requiredFeatures`, and serializable handler results.
+- Run `yarn generate` after adding or changing agents, tools, API discovery metadata, or tool packs.
+- Route model selection through `createModelFactory(container)` instead of ad hoc provider clients.
+- Route mutation-capable AI tools through the mutation approval path before execution.
+
+## Ask First
+
+- Use `AskUserQuestion` before any AI operation that creates, updates, or deletes data.
+- Ask before changing OpenCode Docker configuration, MCP authentication, provider/model resolution precedence, or session-token semantics.
+- Ask before widening tool allowlists, relaxing mutation policies, or exposing new data surfaces to an agent.
+
+## Never
+
+- Never leave `requiredFeatures` empty for tools that access tenant data.
+- Never bypass endpoint-level RBAC in Code Mode or MCP tool execution.
+- Never call the OpenCode HTTP API directly from chat flows; use the module handlers.
+- Never log credentials, session tokens, API keys, prompt secrets, or raw tenant data.
+- Never cache MCP server instances across requests or skip per-tool ACL checks.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn workspace @open-mercato/ai-assistant test
+yarn workspace @open-mercato/ai-assistant build
+```
+
 ## Where to look first
 
 Before editing this module — and especially before writing or reviewing a new agent — read the public framework docs. They are the source of truth and stay in sync with this AGENTS.md by review:
@@ -599,7 +629,7 @@ when the registry has no configured provider and `code: 'api_key_missing'`
 when the picked provider returns an empty key — every current call site
 already relies on the throw bubbling up, do not swallow it.
 
-## MANDATORY: Use AskUserQuestion for Confirmations
+## Ask First: Use AskUserQuestion for Confirmations
 
 > **This is the MOST IMPORTANT rule. NEVER skip this.**
 

--- a/packages/cache/AGENTS.md
+++ b/packages/cache/AGENTS.md
@@ -14,9 +14,25 @@ Use `@open-mercato/cache` for all caching needs. MUST NOT use raw Redis, SQLite,
 
 1. **MUST resolve via DI** — always use `container.resolve('cacheService')`, never instantiate cache directly
 2. **MUST scope to tenant** — include `tenantId` in cache keys or use `runWithCacheTenant()` for automatic scoping
-3. **MUST NOT use raw Redis/SQLite clients** — all cache access goes through the cache service abstraction
-4. **MUST use tag-based invalidation** for CRUD side effects — tag entries so related data can be invalidated together
-5. **MUST NOT cache sensitive data** (passwords, tokens, PII) without encryption
+3. **MUST use tag-based invalidation** for CRUD side effects — tag entries so related data can be invalidated together
+
+## Ask First
+
+- Ask before adding a new cache backend, changing default strategy selection, or caching data whose sensitivity is unclear.
+- Ask before changing invalidation semantics that could affect multiple modules or tenants.
+
+## Never
+
+- Never instantiate cache clients directly; all cache access goes through the cache service abstraction.
+- Never use raw Redis or SQLite clients from module code.
+- Never cache sensitive data (passwords, tokens, PII) without encryption.
+
+## Validation Commands
+
+```bash
+yarn workspace @open-mercato/cache test
+yarn workspace @open-mercato/cache build
+```
 
 ## Tag-Based Invalidation
 

--- a/packages/cache/AGENTS.md
+++ b/packages/cache/AGENTS.md
@@ -10,7 +10,7 @@ Use `@open-mercato/cache` for all caching needs. MUST NOT use raw Redis, SQLite,
 | SQLite | Use for single-server production deployments | `CACHE_STRATEGY=sqlite` |
 | Redis | Use for multi-server production with shared cache | `CACHE_STRATEGY=redis` |
 
-## MUST Rules
+## Always
 
 1. **MUST resolve via DI** — always use `container.resolve('cacheService')`, never instantiate cache directly
 2. **MUST scope to tenant** — include `tenantId` in cache keys or use `runWithCacheTenant()` for automatic scoping

--- a/packages/checkout/AGENTS.md
+++ b/packages/checkout/AGENTS.md
@@ -10,6 +10,25 @@ Use `packages/checkout/src/modules/checkout/` for all checkout module work.
 4. MUST keep pay-page replacement handles and UMES spot IDs stable once released.
 5. MUST follow the pay-links Phase A spec and its companion wireframes before changing checkout UI or API behavior.
 
+## Ask First
+
+- Ask before changing checkout payment state transitions, public pay-page API contracts, password verification, or allowed-origin behavior.
+- Ask before adding a gateway-specific shortcut outside the provider or integration boundary.
+
+## Never
+
+- Never trust submitted amount, status, or consent state from the client.
+- Never expose gateway credentials, gateway settings, password hashes, or prior-customer data from public routes.
+- Never make checkout transaction status updates non-idempotent.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn workspace @open-mercato/checkout test
+yarn workspace @open-mercato/checkout build
+```
+
 ## Reference Files
 
 - Spec: `.ai/specs/implemented/2026-03-19-checkout-pay-links.md`

--- a/packages/checkout/AGENTS.md
+++ b/packages/checkout/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use `packages/checkout/src/modules/checkout/` for all checkout module work.
 
-## MUST Rules
+## Always
 
 1. MUST keep checkout isolated from core business modules; use DI, events, and UMES surfaces instead of direct module internals.
 2. MUST treat public pay-page security as server-authoritative. Never trust submitted amount, status, or consent state from the client.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -2,6 +2,33 @@
 
 `@open-mercato/cli` provides CLI tooling, module generators, and database migration commands.
 
+## Always
+
+1. Keep generator output deterministic and derived from module source files.
+2. Run `yarn generate` after changing generator discovery or output.
+3. Keep `.snapshot-open-mercato.json` in sync with intended module entity changes.
+4. Keep standalone app generator contracts aligned across `packages/create-app`, template package scripts, and CLI testing paths.
+
+## Ask First
+
+- Ask before changing generated file locations, auto-discovery conventions, migration ordering, or CLI command contracts.
+- Ask before applying migrations locally with `yarn db:migrate`; PRs normally include migration files and snapshots, not local DB state.
+
+## Never
+
+- Never commit unrelated generated migrations caused by stale snapshots in other modules.
+- Never make generator post-steps fail generation when optional cache tooling is unavailable.
+- Never use runtime imports in `generators.ts` plugin files.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn db:generate
+yarn workspace @open-mercato/cli test
+yarn workspace @open-mercato/cli build
+```
+
 ## Structure
 
 ```

--- a/packages/content/AGENTS.md
+++ b/packages/content/AGENTS.md
@@ -8,6 +8,23 @@ Use `@open-mercato/content` for static content pages (privacy policies, terms, l
 2. **MUST use `useT()` for all user-facing text** — never hard-code strings in content components
 3. **MUST follow the module extensibility contract** from `packages/core/AGENTS.md`
 
+## Ask First
+
+- Ask before adding behavior that turns a static content page into a dynamic workflow.
+- Ask before changing public legal, privacy, or terms copy unless the task explicitly includes that text.
+
+## Never
+
+- Never hard-code user-facing strings in content components.
+- Never create custom layout primitives when existing `@open-mercato/ui` components fit.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn workspace @open-mercato/content build
+```
+
 ## Adding a New Content Page
 
 1. Create a new page file in `packages/content/src/modules/content/frontend/<page-name>/page.tsx`

--- a/packages/content/AGENTS.md
+++ b/packages/content/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use `@open-mercato/content` for static content pages (privacy policies, terms, legal pages).
 
-## MUST Rules
+## Always
 
 1. **MUST keep content components stateless** — no business logic, no API calls from content pages
 2. **MUST use `useT()` for all user-facing text** — never hard-code strings in content components

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -593,7 +593,7 @@ const crud = makeCrudRoute({
 })
 ```
 
-### Key Rules
+### Always
 
 - MUST implement `enrichMany()` for batch endpoints (prevents N+1 queries)
 - MUST namespace enriched fields with `_moduleName` prefix (e.g. `_example.todoCount`)

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -2,6 +2,42 @@
 
 `@open-mercato/core` contains all core business modules (auth, catalog, customers, sales, etc.). This guide covers the full extensibility contract and module development patterns.
 
+## Always
+
+- Preserve auto-discovery contracts for module files, API routes, pages, subscribers, workers, widgets, and generated registries.
+- Export `openApi` from every API route file.
+- Use `makeCrudRoute` with `indexer: { entityType }` for CRUD routes that should participate in query indexing.
+- Wire custom write routes through the mutation guard contract.
+- Use declarative feature guards and add new `acl.ts` features to `setup.ts` `defaultRoleFeatures`.
+- Use `findWithDecryption` / `findOneWithDecryption` for encrypted entities.
+- Implement domain writes through commands so audit, undo, cache, events, and indexing stay consistent.
+- Run `yarn generate` after changing module files discovered by the generator.
+
+## Ask First
+
+- Ask before changing any contract surface from `BACKWARD_COMPATIBILITY.md`: auto-discovery, public types, import paths, event IDs, widget spot IDs, API URLs, DB schema, DI names, ACL features, notification IDs, CLI commands, or generated file contracts.
+- Ask before moving versioned generated files or changing where generated registries live.
+- Ask before applying migrations with `yarn db:migrate`; normal PRs should include migration files and snapshots.
+
+## Never
+
+- Never create direct ORM relationships between modules; use foreign key IDs and fetch separately.
+- Never expose cross-tenant data or omit tenant/organization scoping.
+- Never hand-edit generated files.
+- Never import generated app bootstrap files from packages.
+- Never run raw `em.find` / `em.findOne` between scalar mutations and `em.flush()` on the same `EntityManager` without `withAtomicFlush`.
+- Never hand-roll AES/KMS encryption or bypass `TenantDataEncryptionService`.
+- Never compare raw feature arrays with exact string checks when wildcard grants apply.
+
+## Validation Commands
+
+```bash
+yarn db:generate
+yarn generate
+yarn workspace @open-mercato/core build
+yarn workspace @open-mercato/core test
+```
+
 ## Core Modules
 
 | Module | Path | Description |
@@ -593,7 +629,7 @@ const crud = makeCrudRoute({
 })
 ```
 
-### Always
+### Response Enricher Rules
 
 - MUST implement `enrichMany()` for batch endpoints (prevents N+1 queries)
 - MUST namespace enriched fields with `_moduleName` prefix (e.g. `_example.todoCount`)

--- a/packages/core/src/modules/auth/AGENTS.md
+++ b/packages/core/src/modules/auth/AGENTS.md
@@ -2,6 +2,33 @@
 
 The auth module handles authentication, authorization, users, roles, and RBAC.
 
+## Always
+
+1. Hash passwords with `bcryptjs` using cost >= 10.
+2. Use `findWithDecryption` / `findOneWithDecryption` for user queries.
+3. Prefer `requireFeatures` in page/API metadata for access control.
+4. Declare every module feature in `acl.ts` and seed role grants through `setup.ts`.
+5. Use wildcard-aware helpers such as `matchFeature`, `hasFeature`, and `hasAllFeatures` when inspecting raw granted features.
+
+## Ask First
+
+- Ask before changing session token format, RBAC semantics, wildcard matching, super-admin behavior, or tenant provisioning outputs.
+- Ask before changing login/reset/invitation error messages because auth messages can leak account existence.
+
+## Never
+
+- Never log credentials, password reset tokens, session tokens, or decrypted user secrets.
+- Never reveal whether an email exists through auth error messages.
+- Never check raw ACL arrays with `includes(...)`, `Set.has(...)`, or ad hoc wildcard logic.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn workspace @open-mercato/core build
+yarn workspace @open-mercato/core test
+```
+
 ## Data Model
 
 - **Users** — system users with credentials, profile, preferences

--- a/packages/core/src/modules/catalog/AGENTS.md
+++ b/packages/core/src/modules/catalog/AGENTS.md
@@ -4,11 +4,30 @@ Use the catalog module for products, categories, pricing, variants, and offers.
 
 ## Always
 
-1. **MUST NOT reimplement pricing logic** — use `selectBestPrice` and the resolver pipeline from `lib/pricing.ts`
+1. **MUST use `selectBestPrice` and the resolver pipeline from `lib/pricing.ts`** for pricing logic.
 2. **MUST use the DI token `catalogPricingService`** when resolving prices — ensures overrides take effect
 3. **MUST register custom pricing resolvers** with explicit priority (`registerCatalogPricingResolver(resolver, { priority })`)
 4. **MUST declare widget injections** in `widgets/injection/` and map via `injection-table.ts`
 5. **MUST follow the standard event pattern** in `events.ts` for all CRUD and lifecycle events
+
+## Ask First
+
+- Ask before changing price-layer precedence, resolver priority semantics, event IDs, or released widget spot IDs.
+- Ask before deleting or changing option schemas that existing variants may reference.
+
+## Never
+
+- Never reimplement catalog pricing inline.
+- Never delete option schemas while variants reference them.
+- Never bypass `prepareMutation` for catalog AI tools that mutate products, prices, or media.
+
+## Validation Commands
+
+```bash
+yarn db:generate
+yarn generate
+yarn workspace @open-mercato/core build
+```
 
 ## When You Need Pricing Logic
 

--- a/packages/core/src/modules/catalog/AGENTS.md
+++ b/packages/core/src/modules/catalog/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use the catalog module for products, categories, pricing, variants, and offers.
 
-## MUST Rules
+## Always
 
 1. **MUST NOT reimplement pricing logic** — use `selectBestPrice` and the resolver pipeline from `lib/pricing.ts`
 2. **MUST use the DI token `catalogPricingService`** when resolving prices — ensures overrides take effect

--- a/packages/core/src/modules/currencies/AGENTS.md
+++ b/packages/core/src/modules/currencies/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use the currencies module for multi-currency support, exchange rates, and currency conversion.
 
-## MUST Rules
+## Always
 
 1. **MUST store currency amounts with 4 decimal precision** — never truncate to 2 decimals internally
 2. **MUST use date-based exchange rates** — always resolve rates for the transaction date, not "current" rate

--- a/packages/core/src/modules/currencies/AGENTS.md
+++ b/packages/core/src/modules/currencies/AGENTS.md
@@ -8,7 +8,26 @@ Use the currencies module for multi-currency support, exchange rates, and curren
 2. **MUST use date-based exchange rates** — always resolve rates for the transaction date, not "current" rate
 3. **MUST record both transaction currency and base currency amounts** — dual recording is mandatory for reporting
 4. **MUST calculate realized gains/losses** on payment: `(payment rate - invoice rate) × foreign amount`
-5. **MUST NOT hard-delete exchange rate records** — rates are historical reference data
+5. **MUST keep financial postings atomic** — full transaction rollback on error
+
+## Ask First
+
+- Ask before changing precision, exchange-rate lookup semantics, realized gain/loss formulas, or financial reporting fields.
+- Ask before changing historical exchange-rate retention behavior.
+
+## Never
+
+- Never truncate internal currency amounts to 2 decimals.
+- Never hard-delete exchange rate records — rates are historical reference data.
+- Never delete posted transactions or audit-trail entries.
+
+## Validation Commands
+
+```bash
+yarn db:generate
+yarn generate
+yarn workspace @open-mercato/core build
+```
 
 ## Key Files
 

--- a/packages/core/src/modules/customer_accounts/AGENTS.md
+++ b/packages/core/src/modules/customer_accounts/AGENTS.md
@@ -2,7 +2,7 @@
 
 Customer-facing identity and portal authentication with a two-tier RBAC model. This module manages customer user accounts, sessions, roles, invitations, and the authentication flow for the customer portal. It is separate from the internal `auth` module, which handles staff authentication.
 
-## MUST Rules
+## Always
 
 1. **MUST hash passwords with `bcryptjs` (cost >= 10)** — never store plaintext passwords
 2. **MUST return minimal error messages on auth endpoints** — never reveal whether an email exists (use generic "Invalid email or password")

--- a/packages/core/src/modules/customer_accounts/AGENTS.md
+++ b/packages/core/src/modules/customer_accounts/AGENTS.md
@@ -10,11 +10,31 @@ Customer-facing identity and portal authentication with a two-tier RBAC model. T
 4. **MUST validate all inputs with zod** — schemas live in `data/validators.ts`
 5. **MUST export `openApi`** from every API route file
 6. **MUST scope all queries by `tenantId`** and filter `deletedAt: null` for soft-deleted records
-7. **MUST NOT expose cross-tenant data** — session validation checks tenant match
-8. **MUST use `hashForLookup` for email-based lookups** — emails are stored with a deterministic hash for indexed queries
-9. **MUST use `hashToken` for storing session/verification/reset tokens** — raw tokens are never persisted
-10. **MUST emit events via `emitCustomerAccountsEvent`** for all state changes (login, signup, lock, password reset)
-11. **MUST NOT import staff auth services** — customer auth is a fully separate identity system
+7. **MUST use `hashForLookup` for email-based lookups** — emails are stored with a deterministic hash for indexed queries
+8. **MUST use `hashToken` for storing session/verification/reset tokens** — raw tokens are never persisted
+9. **MUST emit events via `emitCustomerAccountsEvent`** for all state changes (login, signup, lock, password reset)
+
+## Ask First
+
+- Ask before changing cookie names, token TTLs, JWT claim shape, rate limits, lockout thresholds, or portal RBAC semantics.
+- Ask before moving customer portal navigation into a different staff IA group.
+- Ask before changing CRM auto-linking behavior.
+
+## Never
+
+- Never store plaintext passwords or raw tokens.
+- Never reveal whether an email exists.
+- Never expose cross-tenant data — session validation checks tenant match.
+- Never import staff auth services; customer auth is a fully separate identity system.
+- Never use exact `includes(...)` checks for portal wildcard ACL matching.
+
+## Validation Commands
+
+```bash
+yarn db:generate
+yarn generate
+yarn workspace @open-mercato/core build
+```
 
 ## Data Model
 

--- a/packages/core/src/modules/customers/AGENTS.md
+++ b/packages/core/src/modules/customers/AGENTS.md
@@ -2,7 +2,7 @@
 
 **This is the reference CRUD module.** When building new modules, copy patterns from here first.
 
-## MUST Rules
+## Always
 
 1. **MUST use this module as the template** for new CRUD modules — copy file structure and patterns
 2. **MUST include all standard module files** — use the list below as a checklist

--- a/packages/core/src/modules/customers/AGENTS.md
+++ b/packages/core/src/modules/customers/AGENTS.md
@@ -11,6 +11,25 @@
 5. **MUST capture custom field snapshots** in command `before`/`after` payloads for undo support
 6. **MUST use `useGuardedMutation` for non-`CrudForm` backend writes** (`POST`/`PUT`/`PATCH`/`DELETE`) and pass `retryLastMutation` in injection context
 
+## Ask First
+
+- Ask before changing this module's reference patterns, standard module-file checklist, or AI mutation policies.
+- Ask before changing customer data model relationships that downstream modules may copy.
+
+## Never
+
+- Never bypass custom field normalization in CRUD create/update/read responses.
+- Never omit undo snapshots for custom field mutations.
+- Never write backend `POST`/`PUT`/`PATCH`/`DELETE` actions outside `CrudForm` without `useGuardedMutation`.
+
+## Validation Commands
+
+```bash
+yarn db:generate
+yarn generate
+yarn workspace @open-mercato/core build
+```
+
 ## Key Reference Files — Copy From Here
 
 | When you need | Copy from |

--- a/packages/core/src/modules/data_sync/AGENTS.md
+++ b/packages/core/src/modules/data_sync/AGENTS.md
@@ -6,6 +6,36 @@ The `data_sync` module provides a streaming data synchronization hub for import/
 
 ---
 
+## Always
+
+- **Always scope by organizationId + tenantId** — every entity query
+- **Use the queue system** — never run syncs inline in API handlers
+- **New sync providers MUST support provider-owned env preconfiguration** when fresh installs need credentials or default mappings/locales/channels from deployment env
+- **Persist cursor after each batch** — enables resume on failure
+- **Log item-level errors** — don't stop the sync for individual item failures
+- **Check for overlap** before starting a new run (same integration + entityType + direction)
+- **API routes must export `openApi`** for documentation generation
+
+## Ask First
+
+- Ask before changing adapter contracts, run lifecycle states, cursor semantics, queue names, or overlap detection.
+- Ask before adding provider-specific logic to this generic module.
+- Ask before changing progress delivery or cancellation behavior.
+
+## Never
+
+- Never import from provider adapter modules — `data_sync` is generic.
+- Never run syncs inline in API handlers.
+- Never add frontend polling loops for sync progress beyond initial hydration or reconnect recovery.
+- Never special-case provider credentials, mappings, or state in `data_sync`.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn workspace @open-mercato/core build
+```
+
 ## Module Structure
 
 ```
@@ -152,14 +182,3 @@ Data sync providers can leverage the **Unified Module Extension System (UMES)** 
 - Use helpers from `@open-mercato/core/modules/core/__integration__/helpers/*`
 - Tests must create prerequisites via API and clean up in `finally`
 - Avoid hard dependency on late-phase modules; keep tests scoped to implemented contracts
-
-## Always
-
-- **Always scope by organizationId + tenantId** — every entity query
-- **Never import from provider adapter modules** — data_sync is generic
-- **Use the queue system** — never run syncs inline in API handlers
-- **New sync providers MUST support provider-owned env preconfiguration** when fresh installs need credentials or default mappings/locales/channels from deployment env
-- **Persist cursor after each batch** — enables resume on failure
-- **Log item-level errors** — don't stop the sync for individual item failures
-- **Check for overlap** before starting a new run (same integration + entityType + direction)
-- **API routes must export `openApi`** for documentation generation

--- a/packages/core/src/modules/data_sync/AGENTS.md
+++ b/packages/core/src/modules/data_sync/AGENTS.md
@@ -153,7 +153,7 @@ Data sync providers can leverage the **Unified Module Extension System (UMES)** 
 - Tests must create prerequisites via API and clean up in `finally`
 - Avoid hard dependency on late-phase modules; keep tests scoped to implemented contracts
 
-## MUST Rules
+## Always
 
 - **Always scope by organizationId + tenantId** — every entity query
 - **Never import from provider adapter modules** — data_sync is generic

--- a/packages/core/src/modules/integrations/AGENTS.md
+++ b/packages/core/src/modules/integrations/AGENTS.md
@@ -6,6 +6,37 @@ The `integrations` module is the foundation layer for all external connectors (p
 
 ---
 
+## Always
+
+- **Always scope by organizationId + tenantId** — every entity query and service call
+- **Use `findWithDecryption`/`findOneWithDecryption`** for credential reads
+- **New providers MUST support provider-owned env preconfiguration** when credentials/settings are deployment-managed; implement it in the provider package, not in core
+- **Health check services** must be registered in DI by the provider module, not by integrations
+- **API routes must export `openApi`** for documentation generation
+- **All user-facing strings** via i18n keys in `i18n/en.json`
+- **Keep ACL default export shape** consistent: `export const features = [...]; export default features`
+- **Registry/type contracts** live in `@open-mercato/shared/modules/integrations/types`
+
+## Ask First
+
+- Ask before changing credential resolution order, registry type contracts, canonical API routes, or compatibility surfaces.
+- Ask before moving provider-specific logic into this module.
+- Ask before changing health-check timeouts, log retention semantics, or credential redaction behavior.
+
+## Never
+
+- Never import from provider modules — integrations module is generic; providers import from integrations, not vice versa.
+- Never log credential values — log service strips secret fields from payload.
+- Never special-case provider env presets, credentials, mappings, or enabled state in core.
+- Never remove legacy `integrations.detail:tabs` fallback without a compatibility plan.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn workspace @open-mercato/core build
+```
+
 ## Module Structure
 
 ```
@@ -192,16 +223,3 @@ The integrations module itself uses UMES to inject external ID displays on any e
 - Module-local integration tests go under `__integration__/`
 - Use helpers from `@open-mercato/core/modules/core/__integration__/helpers/*`
 - Tests must create prerequisites via API and clean up in `finally`
-
-## Always
-
-- **Never import from provider modules** — integrations module is generic; providers import from integrations, not vice versa
-- **Always scope by organizationId + tenantId** — every entity query and service call
-- **Use `findWithDecryption`/`findOneWithDecryption`** for credential reads
-- **New providers MUST support provider-owned env preconfiguration** when credentials/settings are deployment-managed; implement it in the provider package, not in core
-- **Never log credential values** — log service strips secret fields from payload
-- **Health check services** must be registered in DI by the provider module, not by integrations
-- **API routes must export `openApi`** for documentation generation
-- **All user-facing strings** via i18n keys in `i18n/en.json`
-- **Keep ACL default export shape** consistent: `export const features = [...]; export default features`
-- **Registry/type contracts** live in `@open-mercato/shared/modules/integrations/types`

--- a/packages/core/src/modules/integrations/AGENTS.md
+++ b/packages/core/src/modules/integrations/AGENTS.md
@@ -193,7 +193,7 @@ The integrations module itself uses UMES to inject external ID displays on any e
 - Use helpers from `@open-mercato/core/modules/core/__integration__/helpers/*`
 - Tests must create prerequisites via API and clean up in `finally`
 
-## MUST Rules
+## Always
 
 - **Never import from provider modules** — integrations module is generic; providers import from integrations, not vice versa
 - **Always scope by organizationId + tenantId** — every entity query and service call

--- a/packages/core/src/modules/progress/AGENTS.md
+++ b/packages/core/src/modules/progress/AGENTS.md
@@ -11,7 +11,25 @@ Use the progress module for every user-visible bulk operation and every long-run
 5. **MUST use queue workers for durable work** — use `@open-mercato/queue`; do not implement custom queues, timers, or page polling loops.
 6. **MUST run mutations through commands** — workers must use `commandBus.execute(...)` for domain writes so audit, undo, cache, events, and index invalidation stay intact.
 7. **MUST use client-local progress only for browser-bound loops** — local `client:*` progress events are best-effort and must not represent work that should survive navigation.
-8. **MUST NOT build per-module progress bars for global operations** — use `ProgressTopBar` and shared progress hooks.
+
+## Ask First
+
+- Ask before adding a new progress mode, changing job terminal states, or changing cancellation semantics.
+- Ask before creating a module-specific progress UI for work that could use the shared top bar.
+
+## Never
+
+- Never leave running jobs without heartbeat/progress updates.
+- Never implement custom queues, timers, or page polling loops for durable work.
+- Never represent durable server work with client-local `client:*` progress events.
+- Never build per-module progress bars for global operations — use `ProgressTopBar` and shared progress hooks.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn workspace @open-mercato/core build
+```
 
 ## Choosing Progress Mode
 

--- a/packages/core/src/modules/progress/AGENTS.md
+++ b/packages/core/src/modules/progress/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use the progress module for every user-visible bulk operation and every long-running operation. Keep `ProgressTopBar` the single shared progress surface.
 
-## MUST Rules
+## Always
 
 1. **MUST create `ProgressJob` for durable work** — imports, exports, bulk mutations, reindexing, external sync, and queued work must persist progress server-side.
 2. **MUST return `progressJobId` to the UI** — DataTable bulk actions and start-operation APIs must expose the job id so the top bar can track it.

--- a/packages/core/src/modules/sales/AGENTS.md
+++ b/packages/core/src/modules/sales/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use the sales module for orders, quotes, invoices, shipments, and payments. This module has the most complex business logic in the system.
 
-## MUST Rules
+## Always
 
 1. **MUST NOT reimplement document math inline** — use `salesCalculationService` from DI
 2. **MUST follow document flow**: Quote → Order → Invoice — no skipping steps

--- a/packages/core/src/modules/sales/AGENTS.md
+++ b/packages/core/src/modules/sales/AGENTS.md
@@ -4,11 +4,30 @@ Use the sales module for orders, quotes, invoices, shipments, and payments. This
 
 ## Always
 
-1. **MUST NOT reimplement document math inline** — use `salesCalculationService` from DI
+1. **MUST use `salesCalculationService` from DI** for document math.
 2. **MUST follow document flow**: Quote → Order → Invoice — no skipping steps
-3. **MUST NOT modify configuration entities directly** (statuses, methods, channels) — use the admin UI or setup hooks
-4. **MUST use `selectBestPrice`** from catalog pricing helpers — never inline price calculations
-5. **MUST scope all documents to a channel** — channel selection affects pricing, numbering, and visibility
+3. **MUST use `selectBestPrice`** from catalog pricing helpers.
+4. **MUST scope all documents to a channel** — channel selection affects pricing, numbering, and visibility
+
+## Ask First
+
+- Ask before changing the Quote → Order → Invoice flow, workflow states, numbering rules, or channel scoping behavior.
+- Ask before changing configuration entity semantics for statuses, methods, channels, price kinds, adjustment kinds, or document numbers.
+
+## Never
+
+- Never reimplement document math inline.
+- Never skip configured document workflow states.
+- Never modify configuration entities directly; use the admin UI or setup hooks.
+- Never inline price calculations.
+
+## Validation Commands
+
+```bash
+yarn db:generate
+yarn generate
+yarn workspace @open-mercato/core build
+```
 
 ## Document Flow
 

--- a/packages/core/src/modules/workflows/AGENTS.md
+++ b/packages/core/src/modules/workflows/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use the workflows module for business process automation: defining step-based workflows, executing instances, handling user tasks, processing async activities, and triggering workflows from domain events.
 
-## MUST Rules
+## Always
 
 1. **MUST resolve services via DI** — use `container.resolve('workflowExecutor')`, never import and call lib functions directly
 2. **MUST NOT skip the execution loop** — always use `workflowExecutor.startWorkflow()` to create and run instances; never insert `WorkflowInstance` rows directly

--- a/packages/core/src/modules/workflows/AGENTS.md
+++ b/packages/core/src/modules/workflows/AGENTS.md
@@ -5,15 +5,37 @@ Use the workflows module for business process automation: defining step-based wo
 ## Always
 
 1. **MUST resolve services via DI** — use `container.resolve('workflowExecutor')`, never import and call lib functions directly
-2. **MUST NOT skip the execution loop** — always use `workflowExecutor.startWorkflow()` to create and run instances; never insert `WorkflowInstance` rows directly
+2. **MUST use `workflowExecutor.startWorkflow()`** to create and run instances.
 3. **MUST follow the step state machine** — steps transition `PENDING → ACTIVE → COMPLETED|FAILED|SKIPPED|CANCELLED`; never set status out of order
 4. **MUST follow the instance state machine** — instances transition `RUNNING → COMPLETED|FAILED|CANCELLED`; intermediate states include `PAUSED`, `WAITING_FOR_ACTIVITIES`, `COMPENSATING`
 5. **MUST keep activity handlers idempotent** — check state before mutating; activities may be retried on failure
 6. **MUST use event sourcing** — log all workflow events via `eventLogger.logWorkflowEvent()`; never mutate instance state without a corresponding event
 7. **MUST use variable interpolation** for dynamic activity config — use `{{context.*}}`, `{{workflow.*}}`, `{{env.*}}`, `{{now}}`; never hardcode values
-8. **MUST NOT couple other modules to workflow internals** — use event triggers and signals for cross-module integration; widget injection for UI
+8. **MUST use event triggers, signals, and widget injection** for cross-module integration.
 9. **MUST declare new events in `events.ts`** with `as const` — undeclared events trigger TypeScript errors and runtime warnings
 10. **MUST scope all queries by `organization_id`** — workflow data is tenant-scoped; never expose cross-tenant instances or tasks
+
+## Ask First
+
+- Ask before changing workflow, step, or activity state machines.
+- Ask before changing SSRF guard behavior, private URL allowances, compensation semantics, or trigger storm controls.
+- Ask before coupling another module directly to workflow internals.
+
+## Never
+
+- Never import and call workflow lib functions directly instead of resolving DI services.
+- Never skip the execution loop or insert `WorkflowInstance` rows directly.
+- Never mutate instance state without a corresponding workflow event.
+- Never expose cross-tenant workflow instances or tasks.
+- Never leave `OM_WORKFLOWS_ALLOW_PRIVATE_URLS` enabled in production.
+
+## Validation Commands
+
+```bash
+yarn db:generate
+yarn generate
+yarn workspace @open-mercato/core build
+```
 
 ## Execution Architecture
 

--- a/packages/create-app/AGENTS.md
+++ b/packages/create-app/AGENTS.md
@@ -8,12 +8,32 @@ Use `packages/create-app` to scaffold standalone Open Mercato applications via `
 2. **MUST keep `@types/*` in `dependencies`** (not `devDependencies`) — standalone apps need type declarations at runtime
 3. **MUST follow build order** — `yarn build:packages` → `yarn generate` → `yarn build:packages`
 4. **MUST build before publishing** — generators scan `node_modules/@open-mercato/*/dist/modules/` for `.js` files
-5. **MUST NOT break the standalone app template** — it's the user's first experience with Open Mercato
-6. **MUST sync template equivalents when app shell/layout files change** — when touching `apps/mercato/src/app/**` bootstrap/layout/provider wiring, update matching files in `packages/create-app/template/src/app/**` (and required template components) in the same task
-7. **MUST keep template module registrations and package dependencies aligned** — if `packages/create-app/template/src/modules.ts` enables a package-backed module (for example `@open-mercato/webhooks`), `packages/create-app/template/package.json.template` must install that package in the same change, and the template lockfile must be reviewed when dependency shape changes
-8. **MUST preserve imported ready apps as raw source snapshots** — `--app` / `--app-url` imports may add only bootstrap-safe generated artifacts (for example `.mercato/generated/module-package-sources.css`) and MUST NOT rewrite package versions, source files, or inject agentic setup files
-9. **MUST skip the interactive agentic wizard for imported ready apps** — imported snapshots stay repo-owned; any agentic tooling must be added later via a deliberate manual command inside the generated app
-10. **MUST keep standalone agent guidance aligned with generator behavior** — if `yarn generate` gains post-steps such as structural cache purging, update `packages/create-app/template/AGENTS.md` and `packages/create-app/agentic/shared/AGENTS.md.template` in the same task
+5. **MUST sync template equivalents when app shell/layout files change** — when touching `apps/mercato/src/app/**` bootstrap/layout/provider wiring, update matching files in `packages/create-app/template/src/app/**` (and required template components) in the same task
+6. **MUST keep template module registrations and package dependencies aligned** — if `packages/create-app/template/src/modules.ts` enables a package-backed module (for example `@open-mercato/webhooks`), `packages/create-app/template/package.json.template` must install that package in the same change, and the template lockfile must be reviewed when dependency shape changes
+7. **MUST preserve imported ready apps as raw source snapshots** — `--app` / `--app-url` imports may add only bootstrap-safe generated artifacts (for example `.mercato/generated/module-package-sources.css`)
+8. **MUST keep standalone agent guidance aligned with generator behavior** — if `yarn generate` gains post-steps such as structural cache purging, update `packages/create-app/template/AGENTS.md` and `packages/create-app/agentic/shared/AGENTS.md.template` in the same task
+
+## Ask First
+
+- Ask before changing scaffold modes, ready-app import behavior, agentic setup generation, or template package dependency shape.
+- Ask before publishing canary or registry changes if the task did not explicitly request a release test.
+
+## Never
+
+- Never break the standalone app template — it's the user's first experience with Open Mercato.
+- Never rewrite package versions, source files, or inject agentic setup files into imported ready apps.
+- Never run the interactive agentic wizard for imported ready apps; any agentic tooling must be added later via a deliberate manual command inside the generated app.
+- Never leave app-shell changes unsynced between monorepo and template equivalents.
+
+## Validation Commands
+
+```bash
+yarn build:packages
+yarn generate
+yarn build:packages
+yarn test:create-app
+yarn test:create-app:integration
+```
 
 ## Standalone App vs Monorepo
 

--- a/packages/create-app/AGENTS.md
+++ b/packages/create-app/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use `packages/create-app` to scaffold standalone Open Mercato applications via `npx create-mercato-app my-app`.
 
-## MUST Rules
+## Always
 
 1. **MUST test both environments** — verify changes work in monorepo (`yarn dev` / `yarn dev:verbose` when relevant) AND standalone app (via Verdaccio)
 2. **MUST keep `@types/*` in `dependencies`** (not `devDependencies`) — standalone apps need type declarations at runtime

--- a/packages/create-app/template/AGENTS.md
+++ b/packages/create-app/template/AGENTS.md
@@ -2,6 +2,40 @@
 
 This is a **standalone application** that consumes Open Mercato packages from the npm registry. Unlike the monorepo development environment, packages here are pre-compiled and installed as dependencies.
 
+## Always
+
+- Treat this app as a package consumer: inspect `node_modules/@open-mercato/*/dist/` when framework behavior is unclear.
+- Put custom modules in `src/modules/<module>/` and add them to `src/modules.ts` with `from: '@app'`.
+- Run `yarn generate` after changing modules, overrides, pages, widgets, AI agents, AI tools, or structural navigation.
+- Declare API route `metadata` per HTTP method, including explicit unauthenticated public routes.
+- Keep generated files under `.mercato/generated/` as generated output only.
+
+## Ask First
+
+- Ask before applying migrations, resetting local databases, or changing `.env` database targets.
+- Ask before using manual SQL instead of the generated migration path.
+- Ask before adding a new framework primitive when a canonical mechanism is not listed below.
+- Ask before enabling live external services, secrets, or provider credentials in tests.
+
+## Never
+
+- Never use raw `fetch`, raw `<form>`, ad hoc crypto, ad hoc Redis, custom queues, or manual cross-module ORM joins when a framework primitive exists.
+- Never use `requireRoles`; use feature-based RBAC and grant features in module setup.
+- Never store sensitive data as plaintext "for now" or hand-roll encryption.
+- Never hardcode user-facing strings or Tailwind status colors in UI changes.
+- Never edit already-shipped historical migrations; add a new corrective migration.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn typecheck
+yarn lint
+yarn test
+yarn build
+yarn test:integration:ephemeral
+```
+
 ## Package Source Files
 
 To explore or understand the Open Mercato framework code:

--- a/packages/enterprise/AGENTS.md
+++ b/packages/enterprise/AGENTS.md
@@ -2,12 +2,32 @@
 
 Use this package for commercial Open Mercato features.
 
-## Scope
+## Always
 
 - Place enterprise-only modules in `packages/enterprise/src/modules/<module>/`.
 - Keep integrations compatible with existing `@open-mercato/core` conventions.
-- Do not duplicate open source modules unless explicitly creating an enterprise overlay.
 - Keep any published `@types/*` packages required by exported enterprise sources in `dependencies`, not `devDependencies`, so standalone apps can typecheck installed packages.
+
+## Ask First
+
+- Ask before changing enterprise licensing boundaries, moving OSS code into enterprise-only modules, or exposing enterprise APIs as public contracts.
+- Ask before duplicating an open source module as an enterprise overlay.
+
+## Never
+
+- Never duplicate open source modules unless explicitly creating an enterprise overlay.
+- Never put commercial-only behavior into an OSS package as part of enterprise work.
+
+## Validation Commands
+
+```bash
+yarn workspace @open-mercato/enterprise build
+```
+
+## Scope
+
+- Enterprise-only modules live in `packages/enterprise/src/modules/<module>/`.
+- Enterprise overlays must remain explicit and easy to distinguish from OSS modules.
 
 ## Current Focus
 

--- a/packages/events/AGENTS.md
+++ b/packages/events/AGENTS.md
@@ -6,10 +6,28 @@ Use `@open-mercato/events` for all event-driven communication between modules. M
 
 1. **MUST declare events in the emitting module's `events.ts`** — use `createModuleEvents()` with `as const` for type safety
 2. **MUST run `yarn generate`** after creating or modifying `events.ts` files
-3. **MUST NOT emit undeclared events** — undeclared events trigger TypeScript errors and runtime warnings
-4. **MUST export `metadata`** from every subscriber with `{ event, persistent?, id? }`
-5. **MUST keep subscribers focused** — one side effect per subscriber file
-6. **MUST make persistent subscribers idempotent** — they may be retried on failure
+3. **MUST export `metadata`** from every subscriber with `{ event, persistent?, id? }`
+4. **MUST keep subscribers focused** — one side effect per subscriber file
+5. **MUST make persistent subscribers idempotent** — they may be retried on failure
+
+## Ask First
+
+- Ask before renaming event IDs, changing persistent delivery semantics, or altering SSE audience filtering.
+- Ask before increasing SSE payload size limits or heartbeat/deduplication behavior.
+
+## Never
+
+- Never use direct module-to-module function calls for side effects.
+- Never emit undeclared events — undeclared events trigger TypeScript errors and runtime warnings.
+- Never rely on payload-provided tenant or organization scope when trusted scope is available.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn workspace @open-mercato/events test
+yarn workspace @open-mercato/events build
+```
 
 ## Event Declaration
 
@@ -136,7 +154,7 @@ useAppEvent('mymod.entity.created', (event) => {
 }, [])
 ```
 
-### Always
+### Browser Delivery Rules
 
 - Events are server-filtered by audience before SSE send:
   - Tenant: `tenantId` must match

--- a/packages/events/AGENTS.md
+++ b/packages/events/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use `@open-mercato/events` for all event-driven communication between modules. MUST NOT use direct module-to-module function calls for side effects.
 
-## MUST Rules
+## Always
 
 1. **MUST declare events in the emitting module's `events.ts`** — use `createModuleEvents()` with `as const` for type safety
 2. **MUST run `yarn generate`** after creating or modifying `events.ts` files
@@ -136,7 +136,7 @@ useAppEvent('mymod.entity.created', (event) => {
 }, [])
 ```
 
-### Key Rules
+### Always
 
 - Events are server-filtered by audience before SSE send:
   - Tenant: `tenantId` must match

--- a/packages/onboarding/AGENTS.md
+++ b/packages/onboarding/AGENTS.md
@@ -6,8 +6,26 @@ Use `@open-mercato/onboarding` for setup wizards and guided flows during new ten
 
 1. **MUST keep wizard steps idempotent** — re-running a step MUST NOT create duplicate data
 2. **MUST persist state per tenant/organization** — use the ORM entities in `data/`
-3. **MUST NOT hard-code user-facing strings** — all wizard copy lives in `i18n/<locale>.json`
-4. **MUST use shared email utilities** from `@open-mercato/shared/lib/email` for welcome/invitation emails
+3. **MUST use shared email utilities** from `@open-mercato/shared/lib/email` for welcome/invitation emails
+4. Keep all wizard copy in `i18n/<locale>.json`.
+
+## Ask First
+
+- Ask before changing tenant-creation ordering, default seeded data, or welcome/invitation email semantics.
+- Ask before adding a wizard step that depends on external credentials or paid services.
+
+## Never
+
+- Never hard-code user-facing wizard or email strings.
+- Never make a step accessible before its predecessor is complete.
+- Never create duplicate tenant data when a step is retried.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn workspace @open-mercato/onboarding build
+```
 
 ## Rules for Wizard Steps
 

--- a/packages/onboarding/AGENTS.md
+++ b/packages/onboarding/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use `@open-mercato/onboarding` for setup wizards and guided flows during new tenant provisioning.
 
-## MUST Rules
+## Always
 
 1. **MUST keep wizard steps idempotent** — re-running a step MUST NOT create duplicate data
 2. **MUST persist state per tenant/organization** — use the ORM entities in `data/`

--- a/packages/queue/AGENTS.md
+++ b/packages/queue/AGENTS.md
@@ -13,8 +13,26 @@ Use `@open-mercato/queue` for all background job processing. MUST NOT implement 
 
 1. **MUST make workers idempotent** — jobs may be retried on failure; duplicate execution MUST NOT corrupt data
 2. **MUST export `metadata`** with `{ queue, id?, concurrency? }` from every worker file
-3. **MUST NOT exceed concurrency 20** — keep concurrency appropriate for the task type
-4. **MUST test with both strategies** — verify workers process correctly with `local` and `async`
+3. **MUST test with both strategies** — verify workers process correctly with `local` and `async`
+
+## Ask First
+
+- Ask before changing queue strategy defaults, retry semantics, or worker concurrency limits.
+- Ask before adding a polling loop or long-running process outside the queue worker contract.
+
+## Never
+
+- Never implement custom job queues or polling loops.
+- Never exceed worker concurrency 20.
+- Never make a worker depend on single-run semantics.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn workspace @open-mercato/queue test
+yarn workspace @open-mercato/queue build
+```
 
 ## Concurrency Guidelines
 

--- a/packages/queue/AGENTS.md
+++ b/packages/queue/AGENTS.md
@@ -9,7 +9,7 @@ Use `@open-mercato/queue` for all background job processing. MUST NOT implement 
 | Local | Use for development — jobs process from `.mercato/queue/` (or `QUEUE_BASE_DIR`) | `QUEUE_STRATEGY=local` |
 | BullMQ | Use for production — Redis-backed with retries and concurrency | `QUEUE_STRATEGY=async` |
 
-## MUST Rules
+## Always
 
 1. **MUST make workers idempotent** — jobs may be retried on failure; duplicate execution MUST NOT corrupt data
 2. **MUST export `metadata`** with `{ queue, id?, concurrency? }` from every worker file

--- a/packages/search/AGENTS.md
+++ b/packages/search/AGENTS.md
@@ -2,16 +2,33 @@
 
 When working on search functionality, use this guide. It covers indexing, querying, and configuring search across all entity types.
 
-## Always / Never
+## Always
 
 1. **MUST** create a `search.ts` file for every module with searchable entities.
 2. **MUST** define `fieldPolicy.excluded` for any sensitive fields (passwords, tokens, SSNs, bank accounts) -- never allow them into any index.
 3. **MUST** define `formatResult` for every entity that uses the tokens strategy -- without it, users see raw UUIDs instead of names.
 4. **MUST** include `checksumSource` in every `buildSource` return value so the indexer can detect changes and skip redundant re-embedding.
 5. **MUST** use the `entityId` format `module:entity_name` and ensure it matches the entity registry exactly.
-6. **MUST NOT** call raw `fetch` against the search API -- use `apiCall`/`apiCallOrThrow` from `@open-mercato/ui/backend/utils/apiCall`.
-7. **MUST NOT** include encrypted or sensitive fields in `buildSource` text output -- they end up in plain text in vector stores.
-8. **MUST NOT** skip `fieldPolicy.hashOnly` for PII fields (email, phone, tax_id) that need exact-match filtering but not fuzzy search.
+6. **MUST** use `fieldPolicy.hashOnly` for PII fields (email, phone, tax_id) that need exact-match filtering but not fuzzy search.
+
+## Ask First
+
+- Ask before changing search strategy defaults, entity IDs, queue behavior, or vector provider assumptions.
+- Ask before indexing a field whose sensitivity is unclear.
+
+## Never
+
+- Never call raw `fetch` against the search API; use `apiCall`/`apiCallOrThrow` from `@open-mercato/ui/backend/utils/apiCall`.
+- Never include encrypted or sensitive fields in `buildSource` text output; they end up in plain text in vector stores.
+- Never skip `fieldPolicy.hashOnly` for PII fields (email, phone, tax_id) that need exact-match filtering but not fuzzy search.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn workspace @open-mercato/search test
+yarn workspace @open-mercato/search build
+```
 
 ## Search Strategies -- When to Use Each
 

--- a/packages/search/AGENTS.md
+++ b/packages/search/AGENTS.md
@@ -2,7 +2,7 @@
 
 When working on search functionality, use this guide. It covers indexing, querying, and configuring search across all entity types.
 
-## MUST / MUST NOT Rules
+## Always / Never
 
 1. **MUST** create a `search.ts` file for every module with searchable entities.
 2. **MUST** define `fieldPolicy.excluded` for any sensitive fields (passwords, tokens, SSNs, bank accounts) -- never allow them into any index.

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use `@open-mercato/shared` for cross-cutting utilities, types, DSL helpers, and infrastructure. MUST NOT import from `@open-mercato/core` or any domain package — shared has zero domain dependencies.
 
-## MUST Rules
+## Always
 
 1. **MUST NOT add domain-specific logic** — this package is infrastructure only
 2. **MUST use precise types** — no `any`, use zod schemas + `z.infer`

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -4,11 +4,29 @@ Use `@open-mercato/shared` for cross-cutting utilities, types, DSL helpers, and 
 
 ## Always
 
-1. **MUST NOT add domain-specific logic** — this package is infrastructure only
-2. **MUST use precise types** — no `any`, use zod schemas + `z.infer`
-3. **MUST check for existing utilities** before adding new helpers — avoid duplication
-4. **MUST export narrow interfaces** (e.g., `QueryEngine`) — never pass `any`/`unknown`
-5. **MUST centralize reusable types and constants here** to prevent drift across packages
+1. **MUST use precise types** — no `any`, use zod schemas + `z.infer`
+2. **MUST check for existing utilities** before adding new helpers — avoid duplication
+3. **MUST export narrow interfaces** (e.g., `QueryEngine`) — never pass `any`/`unknown`
+4. **MUST centralize reusable types and constants here** to prevent drift across packages
+
+## Ask First
+
+- Ask before adding a domain-specific helper, new override domain, or shared public type that becomes a cross-package contract.
+- Ask before changing import paths documented in this file.
+
+## Never
+
+- Never add domain-specific logic; this package is infrastructure only.
+- Never import from `@open-mercato/core` or any domain package; shared has zero domain dependencies.
+- Never gate raw feature arrays with `includes(...)`, `Set.has(...)`, or ad hoc wildcard matching.
+- Never use `any` for exported shared interfaces.
+
+## Validation Commands
+
+```bash
+yarn workspace @open-mercato/shared test
+yarn workspace @open-mercato/shared build
+```
 
 ## Library Directory (`src/lib/`)
 

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -154,7 +154,7 @@ import { Avatar, AvatarStack } from '@open-mercato/ui/primitives/avatar'
 // renders: JK · OZ · AN · +1
 ```
 
-### MUST rules
+### Usage Rules
 
 - NEVER render `<div className="rounded-full bg-muted ...">` for avatars — use `Avatar`
 - `size="sm"` uses `text-[9px]` — DS exception for tiny initials (same as notification badge count)
@@ -192,7 +192,7 @@ import { Kbd, KbdShortcut } from '@open-mercato/ui/primitives/kbd'
 </span>
 ```
 
-### MUST rules
+### Usage Rules
 
 - NEVER use raw `<span>` or `<code>` to display keyboard keys — use `Kbd`
 - Platform-specific keys (`⌘` vs `Ctrl`): detect with `navigator.platform` or use `Ctrl/⌘` text when cross-platform
@@ -255,7 +255,7 @@ const leadTagMap: TagMap<'customer' | 'hot' | 'inactive' | 'renewal'> = {
 <Tag variant={leadTagMap[tag.type]} dot>{tag.label}</Tag>
 ```
 
-### MUST rules
+### Usage Rules
 
 - NEVER hardcode colors on `Tag` — use variants only
 - Use `dot` for tags that represent a status-like category (Customer, Hot); omit for purely descriptive labels

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -4,6 +4,41 @@ UI usage patterns based on customers, sales, and staff modules. Use these defaul
 
 > **DS reference:** [`.ai/ds-rules.md`](../../.ai/ds-rules.md) — color tokens, typography, spacing, decision trees. **Component reference (variants/sizes/props/examples/MUST rules):** [`.ai/ui-components.md`](../../.ai/ui-components.md).
 
+## Always
+
+- Use existing UI primitives and backend components before creating new ones.
+- Use `CrudForm` for create/edit flows and dialog forms unless the task explicitly needs a custom host.
+- Use `DataTable` as the default list view, including portal list pages.
+- Use `apiCall`/`apiCallOrThrow` for backend and portal data calls.
+- Use `useGuardedMutation` for every write that cannot use `CrudForm`.
+- Use i18n keys and `useT()` for user-facing copy.
+- Keep UMES spot IDs, replacement handles, field/group IDs, and portal page metadata stable.
+- Follow `.ai/ds-rules.md` and `.ai/ui-components.md` for tokens, primitives, and component contracts.
+
+## Ask First
+
+- Ask before changing primitive APIs, DataTable/CrudForm contracts, portal shell behavior, frozen portal spots, or replacement handles.
+- Ask before creating a new primitive or backend component when an existing component might fit.
+- Ask before changing default interaction patterns for dialogs, bulk actions, row clicks, or portal navigation.
+
+## Never
+
+- Never use raw `<button>`, raw checkbox inputs, or raw `<Link>` styled as a button.
+- Never use raw `fetch` in UI data flows where `apiCall` is available.
+- Never hard-code user-facing strings.
+- Never use `window.confirm`; use the shared confirmation dialog.
+- Never add custom per-page progress bars for DataTable bulk work.
+- Never omit `page.meta.ts` for guarded portal pages.
+- Never gate wildcard feature arrays with `includes(...)` or `Set.has(...)`.
+
+## Validation Commands
+
+```bash
+yarn workspace @open-mercato/ui test
+yarn workspace @open-mercato/ui build
+yarn i18n:check
+```
+
 ## Reference Modules
 
 - Customers: `packages/core/src/modules/customers/backend/customers/people/create/page.tsx`, `…/people/page.tsx`, `…/components/detail/TaskForm.tsx`
@@ -45,7 +80,7 @@ When you need… use this. Details (variants, sizes, props, MUST rules) live in 
 | Breadcrumb navigation (DS-aligned, slash/arrow/dot divider, ARIA correct) | `Breadcrumb` (with `BreadcrumbList` / `BreadcrumbItem` / `BreadcrumbLink` / `BreadcrumbPage` / `BreadcrumbStatic` / `BreadcrumbSeparator` / `BreadcrumbEllipsis`) | `@open-mercato/ui/primitives/breadcrumb` |
 | Wrap a `<Link>` as button | `Button asChild` / `IconButton asChild` | — |
 
-## Critical MUST rules (top of mind)
+## Critical Primitive Rules
 
 1. **NEVER use raw `<button>` or `<input type="checkbox">`** — always use the primitives. Native checkboxes get `accent-color: var(--accent-indigo)` as a safety net for legacy code, but new code MUST use `Checkbox`.
 2. **Always pass `type="button"` explicitly** on non-submit `Button`/`IconButton` — HTML defaults to `submit`.

--- a/packages/ui/src/backend/AGENTS.md
+++ b/packages/ui/src/backend/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use `@open-mercato/ui/backend` for all admin/backend page components. See `packages/ui/AGENTS.md` for full UI patterns.
 
-## MUST Rules
+## Always
 
 1. **MUST set stable `id` values on `RowActions` items** — use `edit`, `open`, `delete`, etc. DataTable resolves default row-click behavior from these ids
 2. **MUST use `apiCall`/`apiCallOrThrow`** from `@open-mercato/ui/backend/utils/apiCall` — never use raw `fetch`

--- a/packages/ui/src/backend/AGENTS.md
+++ b/packages/ui/src/backend/AGENTS.md
@@ -7,10 +7,29 @@ Use `@open-mercato/ui/backend` for all admin/backend page components. See `packa
 1. **MUST set stable `id` values on `RowActions` items** — use `edit`, `open`, `delete`, etc. DataTable resolves default row-click behavior from these ids
 2. **MUST use `apiCall`/`apiCallOrThrow`** from `@open-mercato/ui/backend/utils/apiCall` — never use raw `fetch`
 3. **MUST use `LoadingMessage`/`ErrorMessage`** from `@open-mercato/ui/backend/detail` for loading and error states
-4. **MUST NOT hard-code user-facing strings** — use `useT()` for all labels and messages
+4. **MUST use `useT()`** for all labels and messages
 5. **MUST use `useGuardedMutation` when not using `CrudForm`** — wrap every write operation (`POST`/`PUT`/`PATCH`/`DELETE`) in `runMutation({ operation, context, mutationPayload })` so global mutation injections (record locks, conflict UI, future guards) run consistently
-6. **MUST use `Button` or `IconButton`** for every interactive button — never use raw `<button>` elements. Use `IconButton` for icon-only buttons, `Button` for everything else. Always pass `type="button"` explicitly on non-submit buttons. See `packages/ui/AGENTS.md` → Button and IconButton Usage for full patterns and variant reference.
-7. **MUST treat missing records as a dedicated page-level state** — distinguish `notFound` from generic `error`, return early, and render a shared `ErrorMessage`-based state with a clear recovery action (for example, back to the owning list page). Do not render `CrudForm`, detail sections, tabs, or record actions when the record is missing.
+6. **MUST use `Button` or `IconButton`** for every interactive button. Use `IconButton` for icon-only buttons, `Button` for everything else. Always pass `type="button"` explicitly on non-submit buttons. See `packages/ui/AGENTS.md` → Button and IconButton Usage for full patterns and variant reference.
+7. **MUST treat missing records as a dedicated page-level state** — distinguish `notFound` from generic `error`, return early, and render a shared `ErrorMessage`-based state with a clear recovery action (for example, back to the owning list page).
+
+## Ask First
+
+- Ask before changing DataTable row-click defaults, UMES host surface IDs, CrudForm event behavior, or replacement handles.
+- Ask before introducing backend-page write flows that do not fit `CrudForm` or `useGuardedMutation`.
+
+## Never
+
+- Never use raw `fetch` from backend UI components.
+- Never hard-code user-facing strings.
+- Never use raw `<button>` elements.
+- Never render `CrudForm`, detail sections, tabs, or record actions when the record is missing.
+
+## Validation Commands
+
+```bash
+yarn workspace @open-mercato/ui test
+yarn workspace @open-mercato/ui build
+```
 
 ## DataTable Row-Click Behavior
 

--- a/packages/webhooks/AGENTS.md
+++ b/packages/webhooks/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use `@open-mercato/webhooks` for Standard Webhooks delivery, inbound verification, and webhook marketplace/admin flows.
 
-## MUST Rules
+## Always
 
 1. **MUST use the shared webhook primitives** — import signing, verification, and secret helpers from `@open-mercato/shared/lib/webhooks`
 2. **MUST enqueue outbound deliveries** — never send webhook HTTP requests directly from subscribers or API routes unless the endpoint is the explicit synchronous test route

--- a/packages/webhooks/AGENTS.md
+++ b/packages/webhooks/AGENTS.md
@@ -13,6 +13,27 @@ Use `@open-mercato/webhooks` for Standard Webhooks delivery, inbound verificatio
 7. **MUST wire backend UI writes through shared CRUD helpers or guarded mutations** — do not add ad hoc fetch logic for create, update, retry, rotate, or test actions
 8. **MUST treat inbound adapters as provider-owned** — register `WebhookEndpointAdapter` in the provider module; do not hardcode provider behavior in the webhooks package
 
+## Ask First
+
+- Ask before changing webhook signing, verification, canonical route contracts, or compatibility aliases.
+- Ask before moving provider-specific inbound behavior into the shared webhooks package.
+- Ask before changing retry, deduplication, or delivery lifecycle event semantics.
+
+## Never
+
+- Never send webhook HTTP requests directly from subscribers or API routes unless the endpoint is the explicit synchronous test route.
+- Never read encrypted webhook secrets with raw ORM helpers.
+- Never add ad hoc backend `fetch` logic for create, update, retry, rotate, or test actions.
+- Never hardcode provider-specific inbound behavior in this package.
+
+## Validation Commands
+
+```bash
+yarn generate
+yarn workspace @open-mercato/webhooks test
+yarn workspace @open-mercato/webhooks build
+```
+
 ## When You Need Outbound Webhooks
 
 1. Declare or reuse the source event in the emitting module's `events.ts`


### PR DESCRIPTION
## Summary

Reorganizes project-owned `AGENTS.md` files into a consistent agent-boundary structure:

- `Always`
- `Ask First`
- `Never`
- `Validation Commands`

This is a documentation-only change. It does not change runtime behavior, APIs, generators, package exports, database schema, UI, or deployment configuration.

## Track

- [x] `contrib/*` – intended to stay upstream-candidate friendly
- [ ] `fork/*` – intentionally fork-only
- [ ] `sync/*` – branch used only for sync or extraction work

## Changes

- Added top-level `Always`, `Ask First`, `Never`, and `Validation Commands` sections to all 31 project-owned `AGENTS.md` files.
- Preserved detailed local guidance, examples, file maps, contracts, and workflow sections instead of replacing them with summaries.
- Moved prohibitions such as `MUST NOT` rules into `Never` sections while keeping their original force.
- Kept high-risk operational details intact, including:
  - OpenCode's fulltext-only `search` caveat.
  - OpenCode's hard 4 tool-call / 10 hard-limit rule.
  - Backend UI `runMutation({ operation, context, mutationPayload })` guidance.
  - Ready-app bootstrap-safe generated artifact exception.
  - AI Assistant `AskUserQuestion` confirmation boundary.
- Removed stale `npm run modules:prepare` guidance in favor of the existing `yarn generate` workflow.
- Added package/module-local validation commands using existing package scripts.

## Semantic review

I performed two semantic review passes against `upstream/develop`, plus a per-file side-by-side audit for every changed `AGENTS.md`:

1. Reviewed removed and moved lines with `git diff --unified=0 upstream/develop -- ':(glob)**/AGENTS.md'`.
2. Reviewed high-risk word diffs for files where instruction weakening is most likely: OpenCode, create-app, backend UI, workflows, sales, specs, search, shared, events, and customer accounts.
3. Compared all 31 changed `AGENTS.md` files side-by-side against their `upstream/develop` versions and recorded moved/rewritten/removed instructions in a local audit report.
4. Rechecked all project-owned `AGENTS.md` files for exact top-level boundary headings.
5. Rechecked stale-command drift and legacy/mixed rule headings.
6. Fixed a P3-only UI heading consistency issue (`### MUST rules` -> `### Usage Rules`) without changing rule text.

Result: no known P0/P1/P2 semantic regressions remain.

## Testing

Passed:

- `rg --files -g 'AGENTS.md' --hidden | grep -v '^node_modules/' | sort`
- Verified all 31 project-owned `AGENTS.md` files contain exact top-level `Always`, `Ask First`, `Never`, and `Validation Commands` headings.
- `find . -name AGENTS.md -not -path './.git/*' -not -path './node_modules/*' -print0 | xargs -0 grep -n "npm run modules:prepare" || true` returned no matches.
- Legacy/mixed heading search returned no matches for `MUST Rules`, `Critical MUST`, `Always / Never`, `Always / Ask First / Never`, or `MANDATORY:` headings.
- `git diff --check upstream/develop...HEAD -- ':(glob)**/AGENTS.md'`
- `corepack yarn generate`
- `corepack yarn build:packages`
- `corepack yarn typecheck`

Not green locally:

- `yarn generate` without Corepack fails because the active global Yarn is 1.22 while this repo requires Yarn 4.12.0 via `packageManager`; `corepack yarn generate` passed.
- `corepack yarn lint` fails before linting project changes in `@open-mercato/app` while linting `apps/mercato/next.config.ts` with ESLint/plugin tooling error: `TypeError: Error while loading rule 'react/no-direct-mutation-state': contextOrFilename.getFilename is not a function`.

Integration tests were not added because this is a documentation-only instruction update and does not touch runtime code, UI flows, API contracts, persistence, generators, or auto-discovery behavior.

## Specification

**Does a spec exist for this feature/module?**

- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (documentation-only agent-instruction cleanup)

**Spec file path:**

N/A.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Upstreamability

- [x] This branch was created from a fresh `develop`.
- [x] This change is isolated from fork-only history, or this PR is explicitly fork-only.
- [x] This change still makes sense without this fork's deployment, branding, or local business rules.
- [x] I preferred a module, extension point, or provider package over a fork-only core patch.
- [x] I checked `BACKWARD_COMPATIBILITY.md` for any touched contract surface.
- [x] I ran the relevant local quality gates for this documentation-only change, with the local lint tooling blocker documented above.

## Linked issues

N/A.

