### PR TITLE
fix(auth): add tenant feature checks for scheduler

### DIFF
--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -220,6 +220,81 @@ describe('RbacService', () => {
     })
   })
 
+  describe('tenantHasFeature', () => {
+    it('returns false without a tenant id', async () => {
+      const ok = await service.tenantHasFeature(null, 'data_sync.run')
+
+      expect(ok).toBe(false)
+      expect(em.find).not.toHaveBeenCalled()
+    })
+
+    it('matches role ACL grants with wildcard semantics for scheduler feature checks', async () => {
+      const roleAcls: Array<Partial<RoleAcl>> = [
+        { tenantId: 'tenant-1', isSuperAdmin: false, featuresJson: ['data_sync.*'], organizationsJson: null },
+      ]
+
+      em.find.mockImplementation(async (entity: any, where: any) => {
+        if (entity === RoleAcl && where?.tenantId === 'tenant-1') return roleAcls
+        return []
+      })
+
+      const ok = await service.tenantHasFeature('tenant-1', 'data_sync.run', { organizationId: 'org-1' })
+
+      expect(ok).toBe(true)
+      expect(em.find).toHaveBeenCalledWith(RoleAcl, { tenantId: 'tenant-1', deletedAt: null }, {})
+    })
+
+    it('returns true when an in-scope role ACL is marked super admin', async () => {
+      const roleAcls: Array<Partial<RoleAcl>> = [
+        { tenantId: 'tenant-1', isSuperAdmin: true, featuresJson: [], organizationsJson: ['org-1'] },
+      ]
+
+      em.find.mockImplementation(async (entity: any, where: any) => {
+        if (entity === RoleAcl && where?.tenantId === 'tenant-1') return roleAcls
+        return []
+      })
+
+      const ok = await service.tenantHasFeature('tenant-1', 'data_sync.run', { organizationId: 'org-1' })
+
+      expect(ok).toBe(true)
+    })
+
+    it('honors organization restrictions on role ACLs', async () => {
+      const roleAcls: Array<Partial<RoleAcl>> = [
+        { tenantId: 'tenant-1', isSuperAdmin: false, featuresJson: ['data_sync.*'], organizationsJson: ['org-1'] },
+      ]
+
+      em.find.mockImplementation(async (entity: any, where: any) => {
+        if (entity === RoleAcl && where?.tenantId === 'tenant-1') return roleAcls
+        return []
+      })
+
+      const ok = await service.tenantHasFeature('tenant-1', 'data_sync.run', { organizationId: 'org-2' })
+
+      expect(ok).toBe(false)
+    })
+
+    it('drops grants from disabled modules before evaluating tenant features', async () => {
+      jest
+        .spyOn(enabledModulesRegistry, 'filterGrantsByEnabledModules')
+        .mockImplementation((granted) => granted.filter((feature) => !feature.startsWith('data_sync.')))
+
+      const roleAcls: Array<Partial<RoleAcl>> = [
+        { tenantId: 'tenant-1', isSuperAdmin: false, featuresJson: ['data_sync.*'], organizationsJson: null },
+      ]
+
+      em.find.mockImplementation(async (entity: any, where: any) => {
+        if (entity === RoleAcl && where?.tenantId === 'tenant-1') return roleAcls
+        return []
+      })
+
+      const ok = await service.tenantHasFeature('tenant-1', 'data_sync.run')
+
+      expect(ok).toBe(false)
+      expect(enabledModulesRegistry.filterGrantsByEnabledModules).toHaveBeenCalledWith(['data_sync.*'])
+    })
+  })
+
   describe('userHasAllFeatures', () => {
     it('returns true when no required features', async () => {
       const ok = await service.userHasAllFeatures('any', [], { tenantId: null, organizationId: null })

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -70,6 +70,13 @@ export class RbacService {
     return sharedHasAllFeatures(required, granted)
   }
 
+  private roleAclAllowsOrganization(acl: RoleAcl, organizationId: string | null | undefined): boolean {
+    if (!organizationId) return true
+    const organizations = Array.isArray(acl.organizationsJson) ? acl.organizationsJson : null
+    if (!organizations || !organizations.length || organizations.includes('__all__')) return true
+    return organizations.includes(organizationId)
+  }
+
   private getCacheKey(userId: string, scope: { tenantId: string | null; organizationId: string | null }): string {
     return `rbac:${userId}:${scope.tenantId || 'null'}:${scope.organizationId || 'null'}`
   }
@@ -370,6 +377,37 @@ export class RbacService {
   ): Promise<string[]> {
     const acl = await this.loadAcl(userId, scope)
     return Array.isArray(acl.features) ? acl.features : []
+  }
+
+  /**
+   * Checks whether any tenant role grants a feature.
+   *
+   * This supports non-user runtimes such as scheduler workers that execute with
+   * tenant scope but without an authenticated user.
+   */
+  async tenantHasFeature(
+    tenantId: string | null | undefined,
+    feature: string,
+    opts?: { organizationId?: string | null },
+  ): Promise<boolean> {
+    if (!tenantId || !feature) return false
+
+    const enabledIds = getEnabledModuleIds()
+    if (enabledIds.length && !enabledIds.includes(getOwningModuleId(feature))) return false
+
+    const em = this.em.fork()
+    const roleAcls = await em.find(RoleAcl, { tenantId, deletedAt: null } as any, {})
+    const list = Array.isArray(roleAcls) ? roleAcls : []
+    const organizationId = opts?.organizationId ?? null
+
+    for (const acl of list) {
+      if (!this.roleAclAllowsOrganization(acl, organizationId)) continue
+      if (acl.isSuperAdmin) return true
+      const grants = Array.isArray(acl.featuresJson) ? acl.featuresJson : []
+      if (this.hasAllFeatures([feature], filterGrantsByEnabledModules(grants))) return true
+    }
+
+    return false
   }
 
   /**

--- a/packages/scheduler/src/modules/scheduler/workers/execute-schedule.worker.ts
+++ b/packages/scheduler/src/modules/scheduler/workers/execute-schedule.worker.ts
@@ -24,6 +24,13 @@ export type ExecuteSchedulePayload = {
 }
 
 type HandlerContext = { resolve: <T = unknown>(name: string) => T }
+type RbacServiceLike = {
+  tenantHasFeature(
+    tenantId: string | null | undefined,
+    feature: string,
+    opts?: { organizationId?: string | null },
+  ): Promise<boolean>
+}
 
 /**
  * Worker that executes scheduled jobs.
@@ -67,7 +74,7 @@ export default async function executeScheduleWorker(
   const { scheduleId } = payload
 
   const em = ctx.resolve<EntityManager>('em')
-  const rbacService = ctx.resolve<{ tenantHasFeature(tenantId: string | null | undefined, feature: string): Promise<boolean> }>('rbacService')
+  const rbacService = ctx.resolve<RbacServiceLike>('rbacService')
 
   // Load fresh schedule from database
   const schedule = await em.findOne(ScheduledJob, { 
@@ -129,9 +136,10 @@ export default async function executeScheduleWorker(
 
   // Check feature flag if required
   if (schedule.requireFeature) {
-      const hasFeature = await rbacService.tenantHasFeature(
+    const hasFeature = await rbacService.tenantHasFeature(
       schedule.tenantId,
-      schedule.requireFeature
+      schedule.requireFeature,
+      { organizationId: schedule.organizationId },
     )
     
     if (!hasFeature) {


### PR DESCRIPTION
## Summary

Fixes scheduler feature-gated jobs being skipped because `@open-mercato/scheduler` calls `rbacService.tenantHasFeature(...)`, but `RbacService` did not implement that method.

This specifically unblocks `data_sync` recurring schedules, which register scheduled jobs with `requireFeature: 'data_sync.run'`.

## Changes

- Added `RbacService.tenantHasFeature(...)` for tenant/org-scoped scheduler checks.
- Reused existing wildcard-aware and module-aware RBAC semantics.
- Passed `organizationId` from the BullMQ scheduler worker, matching the local scheduler path.
- Added unit coverage for tenant-level feature checks.

## Verification

- `yarn workspace @open-mercato/core test src/modules/auth/services/__tests__/rbacService.test.ts --runInBand`
- `yarn workspace @open-mercato/scheduler test src/modules/scheduler/services/__tests__/localSchedulerService.test.ts --runInBand`
- `yarn workspace @open-mercato/scheduler build`
- `yarn workspace @open-mercato/core build`

Fixes [#2085](https://github.com/open-mercato/open-mercato/issues/2085)