### PR TITLE
fix(sync-excel): match external custom field labels

### DIFF
--- a/packages/core/src/modules/sync_excel/lib/__tests__/parser.test.ts
+++ b/packages/core/src/modules/sync_excel/lib/__tests__/parser.test.ts
@@ -24,4 +24,36 @@ describe('sync_excel parser', () => {
       ['ACME', 'Line one; still same field'],
     ])
   })
+
+  it('preserves all source headers from Zoho-style lead exports', () => {
+    const buffer = Buffer.from(
+      [
+        'Record Id,Lead Name,Company,Created Time,Service needed,Lead Source,Lead Status,Annual Revenue,Referred by,Industry',
+        'zcrm_1,Wojciech Skrzypiec,Wojciech Skrzypiec,2020-04-10 20:12:31,,Facebook,Lost Lead,,,Health Care',
+      ].join('\n'),
+      'utf-8',
+    )
+
+    const preview = parseCsvPreview(buffer, { maxRows: 5 })
+
+    expect(preview.headers).toEqual([
+      'Record Id',
+      'Lead Name',
+      'Company',
+      'Created Time',
+      'Service needed',
+      'Lead Source',
+      'Lead Status',
+      'Annual Revenue',
+      'Referred by',
+      'Industry',
+    ])
+    expect(preview.headers).toHaveLength(10)
+    expect(preview.totalRows).toBe(1)
+    expect(preview.sampleRows[0]).toMatchObject({
+      'Record Id': 'zcrm_1',
+      Company: 'Wojciech Skrzypiec',
+      Industry: 'Health Care',
+    })
+  })
 })

--- a/packages/core/src/modules/sync_excel/widgets/injection/upload-config/__tests__/target-options.test.ts
+++ b/packages/core/src/modules/sync_excel/widgets/injection/upload-config/__tests__/target-options.test.ts
@@ -116,6 +116,109 @@ describe('sync_excel target options helpers', () => {
     expect(nextSuggestedMapping.unmappedColumns).toEqual([])
   })
 
+  it('matches Zoho lead headers to external custom fields with cleaned labels', () => {
+    const nextSuggestedMapping = buildPeopleSuggestedMapping(
+      [
+        'Record Id',
+        'Lead Name',
+        'Company',
+        'Created Time',
+        'Service needed',
+        'Lead Source',
+        'Lead Status',
+        'Annual Revenue',
+        'Referred by',
+        'Industry',
+      ],
+      {
+        entityType: 'customers.person',
+        matchStrategy: 'externalId',
+        matchField: 'person.externalId',
+        fields: [
+          {
+            externalField: 'Record Id',
+            localField: 'person.externalId',
+            mappingKind: 'external_id',
+            dedupeRole: 'primary',
+          },
+          {
+            externalField: 'Lead Name',
+            localField: 'person.displayName',
+            mappingKind: 'core',
+          },
+          {
+            externalField: 'Lead Source',
+            localField: 'person.source',
+            mappingKind: 'core',
+          },
+          {
+            externalField: 'Lead Status',
+            localField: 'person.status',
+            mappingKind: 'core',
+          },
+        ],
+        unmappedColumns: [
+          'Company',
+          'Created Time',
+          'Service needed',
+          'Annual Revenue',
+          'Referred by',
+          'Industry',
+        ],
+      },
+      [
+        {
+          entityId: 'customers:customer_person_profile',
+          key: 'company_external',
+          kind: 'text',
+          label: 'Company (external)',
+        },
+        {
+          entityId: 'customers:customer_person_profile',
+          key: 'industry_external',
+          kind: 'dictionary',
+          label: 'Industry (external)',
+        },
+        {
+          entityId: 'customers:customer_person_profile',
+          key: 'service_needed',
+          kind: 'dictionary',
+          label: 'Service needed',
+        },
+        {
+          entityId: 'customers:customer_person_profile',
+          key: 'annual_revenue',
+          kind: 'currency',
+          label: 'Annual revenue (external)',
+        },
+      ],
+    )
+
+    expect(nextSuggestedMapping.fields).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        externalField: 'Company',
+        localField: 'cf:company_external',
+        mappingKind: 'custom_field',
+      }),
+      expect.objectContaining({
+        externalField: 'Industry',
+        localField: 'cf:industry_external',
+        mappingKind: 'custom_field',
+      }),
+      expect.objectContaining({
+        externalField: 'Service needed',
+        localField: 'cf:service_needed',
+        mappingKind: 'custom_field',
+      }),
+      expect.objectContaining({
+        externalField: 'Annual Revenue',
+        localField: 'cf:annual_revenue',
+        mappingKind: 'custom_field',
+      }),
+    ]))
+    expect(nextSuggestedMapping.unmappedColumns).toEqual(['Created Time', 'Referred by'])
+  })
+
   it('does not duplicate address target suggestions when the user already mapped a field manually', () => {
     const nextSuggestedMapping = buildPeopleSuggestedMapping(
       ['Address Line 1', 'Postal Code'],

--- a/packages/core/src/modules/sync_excel/widgets/injection/upload-config/target-options.ts
+++ b/packages/core/src/modules/sync_excel/widgets/injection/upload-config/target-options.ts
@@ -202,6 +202,45 @@ function normalizeMatchToken(value: string): string {
     .trim()
 }
 
+const TRAILING_IMPORT_QUALIFIERS = new Set(['external', 'imported', 'crm'])
+
+function addNormalizedMatchToken(tokens: Set<string>, value: string): void {
+  const normalized = normalizeMatchToken(value)
+  if (normalized.length > 0) {
+    tokens.add(normalized)
+  }
+}
+
+function stripParentheticalText(value: string): string {
+  return value.replace(/\s*\([^)]*\)\s*/g, ' ')
+}
+
+function stripTrailingImportQualifier(value: string): string {
+  const parts = normalizeMatchToken(value).split(' ').filter((part) => part.length > 0)
+  while (parts.length > 1 && TRAILING_IMPORT_QUALIFIERS.has(parts[parts.length - 1])) {
+    parts.pop()
+  }
+  return parts.join(' ')
+}
+
+function buildCustomFieldMatchTokens(def: CustomFieldDefDto, fallback: string): string[] {
+  const tokens = new Set<string>()
+  const candidates = [
+    def.key,
+    fallback,
+    stripParentheticalText(fallback),
+    stripTrailingImportQualifier(def.key),
+    stripTrailingImportQualifier(fallback),
+    stripTrailingImportQualifier(stripParentheticalText(fallback)),
+  ]
+
+  for (const candidate of candidates) {
+    addNormalizedMatchToken(tokens, candidate)
+  }
+
+  return Array.from(tokens)
+}
+
 function titleizeKey(key: string): string {
   return key
     .split('_')
@@ -248,16 +287,12 @@ function buildCustomFieldOption(def: CustomFieldDefDto): MappingTargetOption {
   const fallback = typeof def.label === 'string' && def.label.trim().length > 0
     ? def.label.trim()
     : titleizeKey(def.key)
-  const normalizedTokens = Array.from(new Set([
-    normalizeMatchToken(def.key),
-    normalizeMatchToken(fallback),
-  ].filter((value) => value.length > 0)))
 
   return {
     value: `cf:${def.key}`,
     fallback,
     mappingKind: 'custom_field',
-    matchTokens: normalizedTokens,
+    matchTokens: buildCustomFieldMatchTokens(def, fallback),
   }
 }
 


### PR DESCRIPTION
## Summary

Improve CSV import mapping suggestions for custom fields whose labels or keys include import qualifiers. Headers such as `Company` and `Industry` now match custom fields labeled `Company (external)` and `Industry (external)` without changing CSV parsing or import execution behavior.

## Changes

- Generate additional normalized match tokens for sync_excel custom fields:
  - remove parenthetical label text, e.g. `Company (external)` -> `company`
  - remove safe trailing import qualifiers from normalized keys/labels: `external`, `imported`, `crm`
  - preserve existing key/label tokens and target-field deduplication
- Add regression coverage for Zoho-style lead headers mapping to external custom fields.
- Add parser regression coverage proving a Zoho-style 10-column CSV preserves all 10 headers.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/2026-03-29-sync-excel-customers-import-foundation.md`

This is a narrow bug fix within the existing CSV import foundation. The existing spec already covers preserving unmapped columns and custom-field mapping support; no architecture/spec contract change is required.

## Testing

- [x] `corepack yarn install --immutable`
- [x] `corepack yarn exec jest src/modules/sync_excel/widgets/injection/upload-config/__tests__/target-options.test.ts src/modules/sync_excel/lib/__tests__/parser.test.ts --runInBand --config packages/core/jest.config.cjs`
- [x] `git diff --check origin/upstream-baseline..HEAD -- packages/core/src/modules/sync_excel/widgets/injection/upload-config/target-options.ts packages/core/src/modules/sync_excel/widgets/injection/upload-config/__tests__/target-options.test.ts packages/core/src/modules/sync_excel/lib/__tests__/parser.test.ts`

Additional fork validation before opening this upstream draft:

- Deployed the same scoped fix to `crm.they.dev`.
- Uploaded `Leads_2026_05_25.csv` through the sync_excel import UI.
- Confirmed upload preview shows 10 source columns.
- Confirmed `Company -> Company (external)` and `Industry -> Industry (external)`.
- Did not start the final import.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A: no docs/locales/generator changes required.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). Focused unit regressions cover the pure matching/parser behavior; no API/schema/navigation contract changes are introduced.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). Existing spec applies; no changelog entry required for this narrow bug fix.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

Design-system checklist is N/A in practice because this PR changes matching logic and tests only, not UI components.

## Linked issues

N/A
