### PR TITLE
fix(api-docs): use shared base URL resolver for docs routes

### DIFF
--- a/apps/mercato/src/app/api/docs/markdown/route.ts
+++ b/apps/mercato/src/app/api/docs/markdown/route.ts
@@ -1,22 +1,14 @@
 import { modules } from '@/.mercato/generated/modules.generated'
+import { resolveApiDocsBaseUrl } from '@open-mercato/core/modules/api_docs/lib/resources'
 import { buildOpenApiDocument, generateMarkdownFromOpenApi, sanitizeOpenApiDocument } from '@open-mercato/shared/lib/openapi'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { APP_VERSION } from '@open-mercato/shared/lib/version'
 
 export const dynamic = 'force-dynamic'
 
-function resolveBaseUrl() {
-  return (
-    process.env.NEXT_PUBLIC_API_BASE_URL ||
-    process.env.NEXT_PUBLIC_APP_URL ||
-    process.env.APP_URL ||
-    'http://localhost:3000'
-  )
-}
-
 export async function GET() {
   const { t } = await resolveTranslations()
-  const baseUrl = resolveBaseUrl()
+  const baseUrl = resolveApiDocsBaseUrl()
   const rawDoc = buildOpenApiDocument(modules, {
     title: t('api.docs.title', 'Open Mercato API'),
     version: APP_VERSION,

--- a/apps/mercato/src/app/api/docs/openapi/route.ts
+++ b/apps/mercato/src/app/api/docs/openapi/route.ts
@@ -1,23 +1,15 @@
 import { NextResponse } from 'next/server'
 import { modules } from '@/.mercato/generated/modules.generated'
+import { resolveApiDocsBaseUrl } from '@open-mercato/core/modules/api_docs/lib/resources'
 import { buildOpenApiDocument, sanitizeOpenApiDocument } from '@open-mercato/shared/lib/openapi'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { APP_VERSION } from '@open-mercato/shared/lib/version'
 
 export const dynamic = 'force-dynamic'
 
-function resolveBaseUrl() {
-  return (
-    process.env.NEXT_PUBLIC_API_BASE_URL ||
-    process.env.NEXT_PUBLIC_APP_URL ||
-    process.env.APP_URL ||
-    'http://localhost:3000'
-  )
-}
-
 export async function GET() {
   const { t } = await resolveTranslations()
-  const baseUrl = resolveBaseUrl()
+  const baseUrl = resolveApiDocsBaseUrl()
   const rawDoc = buildOpenApiDocument(modules, {
     title: t('api.docs.title', 'Open Mercato API'),
     version: APP_VERSION,

--- a/packages/core/src/modules/api_docs/lib/__tests__/resources.test.ts
+++ b/packages/core/src/modules/api_docs/lib/__tests__/resources.test.ts
@@ -1,0 +1,41 @@
+import { resolveApiDocsBaseUrl } from '../resources'
+
+describe('resolveApiDocsBaseUrl', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    delete process.env.NEXT_PUBLIC_API_BASE_URL
+    delete process.env.NEXT_PUBLIC_APP_URL
+    delete process.env.APP_URL
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('derives the API base URL from APP_URL by appending /api', () => {
+    process.env.APP_URL = 'http://localhost:3000'
+
+    expect(resolveApiDocsBaseUrl()).toBe('http://localhost:3000/api')
+  })
+
+  it('preserves an explicit API base URL override', () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://localhost:3000/api'
+    process.env.APP_URL = 'http://localhost:3000'
+
+    expect(resolveApiDocsBaseUrl()).toBe('http://localhost:3000/api')
+  })
+
+  it('appends /api to a nested public app URL', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://example.com/admin'
+
+    expect(resolveApiDocsBaseUrl()).toBe('https://example.com/admin/api')
+  })
+
+  it('does not duplicate /api when the app URL already includes it', () => {
+    process.env.APP_URL = 'https://example.com/api'
+
+    expect(resolveApiDocsBaseUrl()).toBe('https://example.com/api')
+  })
+})

--- a/packages/create-app/template/src/app/api/docs/markdown/route.ts
+++ b/packages/create-app/template/src/app/api/docs/markdown/route.ts
@@ -1,22 +1,14 @@
 import { modules } from '@/.mercato/generated/modules.generated'
+import { resolveApiDocsBaseUrl } from '@open-mercato/core/modules/api_docs/lib/resources'
 import { buildOpenApiDocument, generateMarkdownFromOpenApi, sanitizeOpenApiDocument } from '@open-mercato/shared/lib/openapi'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { APP_VERSION } from '@open-mercato/shared/lib/version'
 
 export const dynamic = 'force-dynamic'
 
-function resolveBaseUrl() {
-  return (
-    process.env.NEXT_PUBLIC_API_BASE_URL ||
-    process.env.NEXT_PUBLIC_APP_URL ||
-    process.env.APP_URL ||
-    'http://localhost:3000'
-  )
-}
-
 export async function GET() {
   const { t } = await resolveTranslations()
-  const baseUrl = resolveBaseUrl()
+  const baseUrl = resolveApiDocsBaseUrl()
   const rawDoc = buildOpenApiDocument(modules, {
     title: t('api.docs.title', 'Open Mercato API'),
     version: APP_VERSION,

--- a/packages/create-app/template/src/app/api/docs/openapi/route.ts
+++ b/packages/create-app/template/src/app/api/docs/openapi/route.ts
@@ -1,23 +1,15 @@
 import { NextResponse } from 'next/server'
 import { modules } from '@/.mercato/generated/modules.generated'
+import { resolveApiDocsBaseUrl } from '@open-mercato/core/modules/api_docs/lib/resources'
 import { buildOpenApiDocument, sanitizeOpenApiDocument } from '@open-mercato/shared/lib/openapi'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { APP_VERSION } from '@open-mercato/shared/lib/version'
 
 export const dynamic = 'force-dynamic'
 
-function resolveBaseUrl() {
-  return (
-    process.env.NEXT_PUBLIC_API_BASE_URL ||
-    process.env.NEXT_PUBLIC_APP_URL ||
-    process.env.APP_URL ||
-    'http://localhost:3000'
-  )
-}
-
 export async function GET() {
   const { t } = await resolveTranslations()
-  const baseUrl = resolveBaseUrl()
+  const baseUrl = resolveApiDocsBaseUrl()
   const rawDoc = buildOpenApiDocument(modules, {
     title: t('api.docs.title', 'Open Mercato API'),
     version: APP_VERSION,


### PR DESCRIPTION
Fixes #2089 

## Summary

Fix the OpenAPI docs default API base URL so the interactive API tester works out of the box, without requiring `NEXT_PUBLIC_API_BASE_URL` override.

## Changes

- Reuse `resolveApiDocsBaseUrl()` in the app OpenAPI JSON and Markdown routes.
- Apply the same fix to the create-app template routes.
- Add regression coverage for deriving `http://localhost:3000/api` from `APP_URL=http://localhost:3000`.

## Verification

Passed:

- yarn workspace @open-mercato/core test src/modules/api_docs/lib/__tests__/resources.test.ts --runInBand
- yarn typecheck
- yarn workspace @open-mercato/core build
- yarn workspace @open-mercato/app build