### PR TITLE
fix(customers): stop dealAnalyzer loop after update_deal_stage tool call (#2054)

### DIFF
--- a/packages/core/src/modules/customers/__tests__/ai-agents.test.ts
+++ b/packages/core/src/modules/customers/__tests__/ai-agents.test.ts
@@ -405,14 +405,14 @@ describe('customers.deal_analyzer demo agents', () => {
     expect(dealAnalyzer.allowRuntimeOverride).toBe(true)
   })
 
-  it('declares loop budget without stopping immediately on the mutation tool call', () => {
+  it('declares loop budget and stops immediately after the mutation tool call', () => {
     const loop = dealAnalyzer.loop
     expect(loop).toBeDefined()
     expect(loop?.maxSteps).toBe(12)
     expect(loop?.budget?.maxToolCalls).toBe(12)
     expect(loop?.budget?.maxWallClockMs).toBe(60_000)
     expect(loop?.allowRuntimeOverride).toBe(true)
-    expect(loop?.stopWhen).toBeUndefined()
+    expect(loop?.stopWhen).toContainEqual({ kind: 'hasToolCall', toolName: 'customers.update_deal_stage' })
   })
 
   it('whitelists the analyze + update-stage tools and not others', () => {

--- a/packages/core/src/modules/customers/ai-agents.ts
+++ b/packages/core/src/modules/customers/ai-agents.ts
@@ -490,6 +490,7 @@ const dealAnalyzer: AiAgentDefinition = {
     prepareStep: buildDealAnalyzerPrepareStep() as AiAgentDefinition['loop'] extends undefined
       ? never
       : NonNullable<AiAgentDefinition['loop']>['prepareStep'],
+    stopWhen: [{ kind: 'hasToolCall', toolName: 'customers.update_deal_stage' }],
     budget: {
       maxToolCalls: 12,
       maxWallClockMs: 60_000,


### PR DESCRIPTION
Fixes #2054

## Problem
The `dealAnalyzer` agentic loop did not stop after calling the `customers.update_deal_stage` mutation tool. As a result, the loop continued consuming steps and tokens until the 60-second wall-clock budget was exhausted, and could call the mutation tool more than once per turn.

## Root Cause
The `loop` block of the `dealAnalyzer` agent definition in `ai-agents.ts` was missing a `stopWhen` condition. The `AiAgentLoopStopCondition` type already supported `{ kind: 'hasToolCall'; toolName: string }`, but this condition was simply not wired up to the agent config.

## What Changed
- Added `stopWhen: [{ kind: 'hasToolCall', toolName: 'customers.update_deal_stage' }]` to the `loop` block of the `dealAnalyzer` agent in `packages/core/src/modules/customers/ai-agents.ts`
- The `dealAnalyzerToolLoop` sibling agent inherits this condition automatically via the spread (`...dealAnalyzer`), so no additional change was needed there
- Updated the corresponding test in `ai-agents.test.ts` to assert that `loop?.stopWhen` contains the new condition

## Tests
- Updated test: renamed from "declares loop budget without stopping immediately on the mutation tool call" to "declares loop budget and stops immediately after the mutation tool call"; flipped assertion from `expect(loop?.stopWhen).toBeUndefined()` to `expect(loop?.stopWhen).toContainEqual({ kind: 'hasToolCall', toolName: 'customers.update_deal_stage' })`
- All 31 tests in `ai-agents.test.ts` pass
- All 157 tests in the `customers/__tests__` suite pass
- TypeScript typecheck (`tsc --noEmit`) is clean

## Backward Compatibility
No contract changes — `stopWhen` is an additive field on the agent loop config and does not alter any API response shape, event ID, widget spot ID, ACL ID, or import path.

🤖 Generated by autofix.