### PR TITLE
feat(ui): adopt RecordNotFoundState in auth/catalog/resources/sales p…

### DIFF
--- a/packages/core/src/modules/auth/backend/users/[id]/edit/page.tsx
+++ b/packages/core/src/modules/auth/backend/users/[id]/edit/page.tsx
@@ -17,8 +17,8 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { extractCustomFieldEntries } from '@open-mercato/shared/lib/crud/custom-fields-client'
 import { formatPasswordRequirements, getPasswordPolicy } from '@open-mercato/shared/lib/auth/passwordPolicy'
 import { UserConsentsPanel } from '@open-mercato/core/modules/auth/components/UserConsentsPanel'
-import { normalizeDisplayNameInput } from '@open-mercato/core/modules/auth/lib/displayName'
 import { RecordNotFoundState, ErrorMessage } from '@open-mercato/ui/backend/detail'
+import { normalizeDisplayNameInput } from '@open-mercato/core/modules/auth/lib/displayName'
 
 type EditUserFormValues = {
   email: string

--- a/packages/core/src/modules/auth/backend/users/[id]/edit/page.tsx
+++ b/packages/core/src/modules/auth/backend/users/[id]/edit/page.tsx
@@ -18,6 +18,7 @@ import { extractCustomFieldEntries } from '@open-mercato/shared/lib/crud/custom-
 import { formatPasswordRequirements, getPasswordPolicy } from '@open-mercato/shared/lib/auth/passwordPolicy'
 import { UserConsentsPanel } from '@open-mercato/core/modules/auth/components/UserConsentsPanel'
 import { normalizeDisplayNameInput } from '@open-mercato/core/modules/auth/lib/displayName'
+import { RecordNotFoundState, ErrorMessage } from '@open-mercato/ui/backend/detail'
 
 type EditUserFormValues = {
   email: string
@@ -119,6 +120,7 @@ export default function EditUserPage({ params }: { params?: { id?: string } }) {
   const [selectedTenantId, setSelectedTenantId] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [canEditOrgs, setCanEditOrgs] = React.useState(false)
   const [aclData, setAclData] = React.useState<AclData>({ isSuperAdmin: false, features: [], organizations: null })
   const [customFieldValues, setCustomFieldValues] = React.useState<Record<string, unknown>>({})
@@ -171,6 +173,7 @@ export default function EditUserPage({ params }: { params?: { id?: string } }) {
     async function load() {
       setLoading(true)
       setError(null)
+      setIsNotFound(false)
       setCustomFieldValues({})
       try {
         const { ok, result } = await apiCall<UserListResponse>(
@@ -182,7 +185,7 @@ export default function EditUserPage({ params }: { params?: { id?: string } }) {
           setActorIsSuperAdmin(Boolean(result?.isSuperAdmin))
           setActorResolved(true)
           if (!item) {
-            setError(tRef.current('auth.users.form.errors.notFound', 'User not found'))
+            setIsNotFound(true)
             setCustomFieldValues({})
             setInitialUser(null)
             setSelectedTenantId(null)
@@ -404,14 +407,33 @@ export default function EditUserPage({ params }: { params?: { id?: string } }) {
     }
   }, [initialUser, customFieldValues, selectedTenantId])
 
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('auth.users.form.errors.notFound', 'User not found')}
+            backHref="/backend/users"
+            backLabel={t('auth.users.form.actions.backToList', 'Back to users')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
+  if (error && !loading) {
+    return (
+      <Page>
+        <PageBody>
+          <ErrorMessage label={error} />
+        </PageBody>
+      </Page>
+    )
+  }
+
   return (
     <Page>
       <PageBody>
-        {error && (
-          <div className="p-4 mb-4 bg-red-50 border border-red-200 rounded text-red-800">
-            {error}
-          </div>
-        )}
         <CrudForm<EditUserFormValues>
           title={t('auth.users.form.title.edit', 'Edit User')}
           backHref="/backend/users"

--- a/packages/core/src/modules/catalog/backend/catalog/products/[id]/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[id]/page.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { Page, PageBody } from "@open-mercato/ui/backend/Page";
-import { ErrorMessage } from "@open-mercato/ui/backend/detail";
+import { ErrorMessage, RecordNotFoundState } from "@open-mercato/ui/backend/detail";
 import {
   CrudForm,
   type CrudFormGroup,
@@ -327,6 +327,7 @@ export default function EditCatalogProductPage({
     React.useState<Partial<ProductFormValues> | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+  const [isNotFound, setIsNotFound] = React.useState(false);
   const offerSnapshotsRef = React.useRef<OfferSnapshot[]>([]);
   const initialConversionsRef = React.useRef<ProductUnitConversionDraft[]>([]);
   const [categorizeOptions, setCategorizeOptions] = React.useState<{
@@ -552,6 +553,7 @@ export default function EditCatalogProductPage({
     async function loadProduct() {
       setLoading(true);
       setError(null);
+      setIsNotFound(false);
       try {
         const productRes = await apiCall<ProductResponse>(
           `/api/catalog/products?id=${encodeURIComponent(productId!)}&page=1&pageSize=1&withDeleted=false`,
@@ -560,10 +562,10 @@ export default function EditCatalogProductPage({
         const record = Array.isArray(productRes.result?.items)
           ? productRes.result?.items?.[0]
           : undefined;
-        if (!record)
-          throw new Error(
-            t("catalog.products.edit.errors.notFound", "Product not found."),
-          );
+        if (!record) {
+          if (!cancelled) setIsNotFound(true);
+          return;
+        }
         const rawMetadata = isRecord(record.metadata)
           ? (record.metadata as Record<string, unknown>)
           : null;
@@ -1328,6 +1330,20 @@ export default function EditCatalogProductPage({
               "catalog.products.edit.errors.idMissing",
               "Product identifier is missing.",
             )}
+          />
+        </PageBody>
+      </Page>
+    );
+  }
+
+  if (isNotFound && !loading) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t("catalog.products.edit.errors.notFound", "Product not found.")}
+            backHref="/backend/catalog/products"
+            backLabel={t("catalog.products.edit.actions.backToList", "Back to products")}
           />
         </PageBody>
       </Page>

--- a/packages/core/src/modules/resources/backend/resources/resources/[id]/page.tsx
+++ b/packages/core/src/modules/resources/backend/resources/resources/[id]/page.tsx
@@ -10,7 +10,7 @@ import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customF
 import { createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
-import { ActivitiesSection, NotesSection, type SectionAction, type TagOption } from '@open-mercato/ui/backend/detail'
+import { ActivitiesSection, NotesSection, RecordNotFoundState, type SectionAction, type TagOption } from '@open-mercato/ui/backend/detail'
 import { VersionHistoryAction } from '@open-mercato/ui/backend/version-history'
 import { SendObjectMessageDialog } from '@open-mercato/ui/backend/messages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -83,6 +83,7 @@ export default function ResourcesResourceDetailPage({ params }: { params?: { id?
   const router = useRouter()
   const searchParams = useSearchParams()
   const [initialValues, setInitialValues] = React.useState<Record<string, unknown> | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [tags, setTags] = React.useState<TagOption[]>([])
   const [activeTab, setActiveTab] = React.useState<'details' | 'availability'>('details')
   const [activeDetailTab, setActiveDetailTab] = React.useState<'notes' | 'activities'>('notes')
@@ -411,6 +412,7 @@ export default function ResourcesResourceDetailPage({ params }: { params?: { id?
 
   React.useEffect(() => {
     if (!resourceId || !resourceTypesLoaded) return
+    setIsNotFound(false)
     let cancelled = false
     async function loadResource() {
       try {
@@ -421,7 +423,10 @@ export default function ResourcesResourceDetailPage({ params }: { params?: { id?
         const record = await readApiResultOrThrow<ResourceResponse>(`/api/resources/resources?${params.toString()}`)
         const resourceRaw = Array.isArray(record?.items) ? record.items[0] : null
         const resource = resourceRaw ? normalizeResourceRecord(resourceRaw) : null
-        if (!resource) throw new Error(t('resources.resources.form.errors.notFound', 'Resource not found.'))
+        if (!resource) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         if (!cancelled) {
           const customValues = extractCustomFieldEntries(resource)
           setTags(Array.isArray(resource.tags) ? resource.tags : [])
@@ -478,6 +483,20 @@ export default function ResourcesResourceDetailPage({ params }: { params?: { id?
     typeof initialValues?.name === 'string' && initialValues.name.trim().length > 0
       ? initialValues.name.trim()
       : t('resources.resources.detail.untitled', 'Unnamed resource')
+
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('resources.resources.form.errors.notFound', 'Resource not found.')}
+            backHref="/backend/resources/resources"
+            backLabel={t('resources.resources.detail.back', 'Back to resources')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
 
   return (
     <Page>

--- a/packages/core/src/modules/sales/backend/sales/documents/[id]/page.tsx
+++ b/packages/core/src/modules/sales/backend/sales/documents/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
   ErrorMessage,
   InlineTextEditor,
   LoadingMessage,
+  RecordNotFoundState,
   TabEmptyState,
   TagsSection,
   type TagOption,
@@ -1876,6 +1877,7 @@ export default function SalesDocumentDetailPage({
   const searchParams = useSearchParams()
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
   const [loading, setLoading] = React.useState(true)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [record, setRecord] = React.useState<DocumentRecord | null>(null)
   const [tags, setTags] = React.useState<TagOption[]>([])
   const [kind, setKind] = React.useState<'order' | 'quote'>('quote')
@@ -2483,6 +2485,7 @@ export default function SalesDocumentDetailPage({
     async function load() {
       setLoading(true)
       setError(null)
+      setIsNotFound(false)
       const requestedKind = searchParams.get('kind')
       const preferredKind = requestedKind === 'order' ? 'order' : requestedKind === 'quote' ? 'quote' : initialKind ?? null
       const kindsToTry: Array<'order' | 'quote'> = preferredKind
@@ -2505,7 +2508,11 @@ export default function SalesDocumentDetailPage({
       }
       if (!cancelled) {
         setLoading(false)
-        setError(lastError ?? loadErrorMessage)
+        if (lastError) {
+          setError(lastError)
+        } else {
+          setIsNotFound(true)
+        }
       }
     }
     load().catch((err) => {
@@ -4430,6 +4437,26 @@ export default function SalesDocumentDetailPage({
               className="min-w-[280px] justify-center border-0 bg-transparent text-base shadow-none"
             />
           </div>
+        </PageBody>
+      </Page>
+    )
+  }
+
+  if (isNotFound) {
+    const backHref = (searchParams.get('kind') === 'order' || initialKind === 'order')
+      ? '/backend/sales/orders'
+      : '/backend/sales/quotes'
+    const backLabel = (searchParams.get('kind') === 'order' || initialKind === 'order')
+      ? t('sales.documents.detail.backToOrders', 'Back to orders')
+      : t('sales.documents.detail.backToQuotes', 'Back to quotes')
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('sales.documents.detail.notFound', 'Document not found.')}
+            backHref={backHref}
+            backLabel={backLabel}
+          />
         </PageBody>
       </Page>
     )


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Adopts the shared `RecordNotFoundState` component (introduced in #2014) across the four representative pages listed in issue #2101 Phase 1.

Each page previously collapsed the not-found state into the generic error state; this PR separates them so `CrudForm` and detail sections no longer render when a record is missing.

## Changes

- `auth/users/[id]/edit`
  - `setIsNotFound(true)` replaces `setError('User not found')`
  - Removes hardcoded `bg-red-50/text-red-800` error div (DS violation)
  - Adds `ErrorMessage` early return for generic errors

- `catalog/products/[id]`
  - Converts `throw new Error('Product not found.')` inside loader to `setIsNotFound(true)`
  - Prevents not-found from being swallowed by the generic catch block

- `resources/resources/[id]`
  - Same pattern as catalog
  - Replaces throw with `setIsNotFound(true)` + early return

- `sales/documents/[id]`
  - When both order/quote fetch attempts return `null` without throwing, sets `isNotFound`
  - Prevents falling through to the generic error message

All four pages now follow the page-level contract from the spec:

```tsx
if (isNotFound) return <RecordNotFoundState ... />
if (error) return <ErrorMessage ... />

return <CrudFormOrDetailPage ... />
```

## Specification

**Does a spec exist for this feature/module?**

- [x] Yes

**Spec file path:**

`.ai/specs/2026-03-23-unified-record-not-found-ui-state.md`

## Testing

- `yarn typecheck` — clean
- `yarn lint` — clean
- Manually verified pattern matches reference implementation in:
  - `customers/companies/[id]/page.tsx` (landed in #2014)

## Checklist

- [x] This pull request targets `develop`
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`)
- [ ] I updated documentation, locales, or generators if the change requires it
- [ ] I added or adjusted tests that cover the change
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required)
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable)

### Design System Compliance

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [ ] Empty state handled for list/data pages — N/A
- [x] Loading state handled for async pages
- [ ] `aria-label` on all icon-only buttons — N/A
- [x] Uses existing DS components (`Alert`, `StatusBadge`, `FormField`) — no custom replacements

## Linked issues

Closes #2101 (partial — Phase 1 of 5)