### PR TITLE
security(attachments): fail closed when attachment scope columns are null

### DIFF
--- a/packages/core/src/modules/attachments/lib/__tests__/access.test.ts
+++ b/packages/core/src/modules/attachments/lib/__tests__/access.test.ts
@@ -70,3 +70,63 @@ describe('checkAttachmentAccess — cross-tenant public partition fix', () => {
     expect(checkAttachmentAccess(superAuth, attachment(), partition(true)).ok).toBe(true)
   })
 })
+
+describe('checkAttachmentAccess — partial-null scope fail-closed', () => {
+  it('blocks cross-org auth when attachment has tenantId set but organizationId null (private)', () => {
+    const result = checkAttachmentAccess(
+      auth({ tenantId: 'tenant-1', orgId: 'org-2' }),
+      attachment({ tenantId: 'tenant-1', organizationId: null }),
+      partition(false),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(403)
+  })
+
+  it('blocks cross-tenant auth when attachment has organizationId set but tenantId null (private)', () => {
+    const result = checkAttachmentAccess(
+      auth({ tenantId: 'other-tenant', orgId: 'org-1' }),
+      attachment({ tenantId: null, organizationId: 'org-1' }),
+      partition(false),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(403)
+  })
+
+  it('blocks cross-org auth when attachment has tenantId set but organizationId null (public)', () => {
+    const result = checkAttachmentAccess(
+      auth({ tenantId: 'tenant-1', orgId: 'org-2' }),
+      attachment({ tenantId: 'tenant-1', organizationId: null }),
+      partition(true),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(403)
+  })
+
+  it('blocks any authenticated principal from a scoped attachment whose other column is null', () => {
+    const result = checkAttachmentAccess(
+      auth({ tenantId: 'tenant-1', orgId: 'org-1' }),
+      attachment({ tenantId: null, organizationId: 'org-2' }),
+      partition(false),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(403)
+  })
+
+  it('preserves access for fully-unscoped (global) attachments to authenticated principals', () => {
+    const result = checkAttachmentAccess(
+      auth({ tenantId: 'tenant-1', orgId: 'org-1' }),
+      attachment({ tenantId: null, organizationId: null }),
+      partition(false),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('still allows same-scope auth when both attachment columns are set and match', () => {
+    const result = checkAttachmentAccess(
+      auth({ tenantId: 'tenant-1', orgId: 'org-1' }),
+      attachment({ tenantId: 'tenant-1', organizationId: 'org-1' }),
+      partition(false),
+    )
+    expect(result.ok).toBe(true)
+  })
+})

--- a/packages/core/src/modules/attachments/lib/access.ts
+++ b/packages/core/src/modules/attachments/lib/access.ts
@@ -10,9 +10,21 @@ export function isSuperAdminAuth(auth: AuthContext | null | undefined): boolean 
 
 function isSameScope(auth: AuthContext | null | undefined, attachment: Attachment): boolean {
   if (!auth) return false
-  const sameTenant = attachment.tenantId ? attachment.tenantId === auth.tenantId : true
-  const sameOrg = attachment.organizationId ? attachment.organizationId === auth.orgId : true
-  return sameTenant && sameOrg
+  const attachmentTenant = attachment.tenantId ?? null
+  const attachmentOrg = attachment.organizationId ?? null
+  // Preserve the legacy "global attachment" semantics: a row with both scope
+  // columns null is treated as accessible to any authenticated principal.
+  // The unauthenticated branch in checkAttachmentAccess already gates this on
+  // partition.isPublic.
+  if (attachmentTenant === null && attachmentOrg === null) {
+    return true
+  }
+  // Fail-closed on partial-null scope. Previously a missing tenant_id or
+  // organization_id was treated as "matches any auth value", which allowed
+  // cross-tenant / cross-org access on private partitions when an attachment
+  // ended up with one scope column unset. Mirrors the fail-closed pattern
+  // from #2012 (mergeIdFilter).
+  return attachmentTenant === auth.tenantId && attachmentOrg === auth.orgId
 }
 
 export function checkAttachmentAccess(


### PR DESCRIPTION
## Summary

`isSameScope()` in `packages/core/src/modules/attachments/lib/access.ts` previously defaulted `sameTenant` and `sameOrg` to `true` whenever `attachment.tenantId` or `attachment.organizationId` were null:

```ts
const sameTenant = attachment.tenantId ? attachment.tenantId === auth.tenantId : true
const sameOrg = attachment.organizationId ? attachment.organizationId === auth.orgId : true
```

The public `image/[id]` and `file/[id]` routes look up attachments by id only (\`em.findOne(Attachment, { id })\`) and delegate scoping entirely to \`checkAttachmentAccess\`. With the above shape, an attachment whose scope was partially null — e.g. \`tenant_id='A', organization_id=null\` — became readable by any authenticated principal regardless of their tenant or organization, on both public *and* private partitions.

Both scope columns on \`Attachment\` are declared \`nullable: true\` (\`packages/core/src/modules/attachments/data/entities.ts:58-62\`), so this fail-open path is reachable in practice for any attachment row that happens to be missing one of the scope columns (legacy data, system uploads, migration artifacts, etc.).

This fixes the check to fail closed on partial-null scope while preserving the legacy \"global attachment\" path (both columns null → accessible to any authenticated principal, with the unauthenticated branch already gating that on \`partition.isPublic\`). The pattern mirrors #2012 / #1736 (\`mergeIdFilter\`).

## What changed

- \`packages/core/src/modules/attachments/lib/access.ts\` — \`isSameScope\` requires strict equality on both \`tenant_id\` and \`organization_id\` when either is set. A fully-unscoped attachment (both null) keeps its existing \"global\" behaviour.
- \`packages/core/src/modules/attachments/lib/__tests__/access.test.ts\` — 6 new cases covering the previously fail-open paths (private + public partitions, partial-null on either column) plus regression coverage for fully-unscoped + fully-scoped attachments. All 14 cases pass.

## Backward compatibility

100% BC for the documented contract surface:
- Fully-scoped attachments where both columns match auth — unchanged (allowed).
- Fully-scoped attachments where either column mismatches auth — unchanged (denied).
- Fully-unscoped attachments (both null) accessed by any authenticated principal — unchanged (allowed; preserves \"global attachment\" semantics).
- Public-partition reads without auth — unchanged (gate is \`partition.isPublic\`, not \`isSameScope\`).
- Super-admin reads — unchanged (checked separately at \`checkAttachmentAccess:36\`).

The behaviour that changes is the fail-open path itself: an authenticated principal can no longer read an attachment whose scope columns are only partially set. That is the bug being fixed; it was not a documented contract.

## Test plan

- [x] \`yarn workspace @open-mercato/core test --testPathPatterns \"attachments/lib/__tests__/access\"\` — 14/14 pass (8 existing + 6 new).
- [x] \`yarn workspace @open-mercato/core test --testPathPatterns \"attachments/lib\"\` — 84/84 pass (full lib regression).
- [ ] Reviewer to confirm production data is largely fully-scoped — the migration impact of this fix scales with how many rows in \`attachments\` have a null \`tenant_id\` or \`organization_id\` while the other column is set; such rows transition from \"any authenticated principal can read\" to \"only fully-matching scope can read\" (correct behaviour, but worth a sanity check).

## Related

- #2012 / #1736 — \`mergeIdFilter\` fail-closed (same pattern).
- #1366 — \`fix(attachments): enforce tenant scope on public-partition file access\` (earlier hardening that this fix extends to private partitions and partial-null rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)