### PR TITLE
fix(dev): template parity follow-ups for consolidated package watcher (#2102 follow-up)

### DIFF
--- a/.ai/runs/2026-05-27-dev-watch-template-followups.md
+++ b/.ai/runs/2026-05-27-dev-watch-template-followups.md
@@ -1,0 +1,116 @@
+# Dev-watch template follow-ups (post-#2102)
+
+## Overview
+
+PR #2102 (`feat(dev): consolidate workspace package watchers`) merged into
+`develop` at 2026-05-27T13:56:41Z. After that merge, two follow-up commits
+were pushed to the source branch `fix/dev-mode-package-watch-consolidation`
+to close low-priority code-review findings and patch a template gap that
+the consolidation work exposed. A first attempt to ship them as PR #2126
+was opened with an empty body and immediately closed at 14:43:39Z — the
+branch had drifted from `develop` and the PR carried 10 commits instead
+of the 2 new ones.
+
+This run cleanly cherry-picks just the two follow-up commits onto a fresh
+`fix/dev-watch-template-followups` branch off the latest `develop` and
+opens a focused PR.
+
+### Source commits to carry forward
+
+- `f5157953511bd5b939800cd9f3451e7cce7a89aa` — `fix(dev): address low-priority code-review findings (template parity + env-var docs)`
+- `f7e29e416acd70e222c25fd074872f6f66a5263b` — `fix(dev): include dev-shutdown-utils.mjs in template-sync mapping`
+
+Both commits land cleanly because the upstream files have not changed
+since #2102 merged.
+
+## Goal
+
+Re-land the two post-merge follow-up commits from
+`fix/dev-mode-package-watch-consolidation` as a clean, scoped PR against
+`develop`, with no unrelated drift in the diff.
+
+## Scope
+
+- Cherry-pick `f5157953` and `f7e29e41` only.
+- No new functionality, no refactors, no rebuilds of the consolidation
+  itself (that already shipped via #2102).
+- Files touched (per the cherry-pick set):
+  - `apps/docs/docs/appendix/troubleshooting.mdx`
+  - `packages/create-app/template/scripts/dev.mjs`
+  - `packages/create-app/template/scripts/dev-orchestration-log-policy.mjs`
+  - `packages/create-app/template/scripts/dev-shutdown-utils.mjs` (added)
+  - `scripts/template-sync.ts`
+  - `scripts/watch-packages.mjs`
+
+## Non-goals
+
+- Re-implementing or modifying the consolidated watcher behavior.
+- Pulling in any other commits from the now-stale source branch.
+- Rebasing the source branch on develop (the source branch will remain
+  archived; the new branch supersedes it).
+
+## Implementation Plan
+
+### Phase 1: Carry the two follow-up commits
+
+1.1 Branch `fix/dev-watch-template-followups` off the latest `develop`
+    in the linked janitor worktree.
+1.2 Cherry-pick `f5157953511bd5b939800cd9f3451e7cce7a89aa` (template
+    parity + env-var docs).
+1.3 Cherry-pick `f7e29e416acd70e222c25fd074872f6f66a5263b` (include
+    `dev-shutdown-utils.mjs` in `template-sync` mapping and ship the
+    template copy).
+
+### Phase 2: Validation
+
+2.1 Confirm cherry-picks have empty conflict markers and the diff
+    matches the two upstream commits.
+2.2 Verify `yarn template:sync` would pass (re-run logic: the template
+    copies of `dev.mjs` and `dev-orchestration-log-policy.mjs` now
+    match root; `dev-shutdown-utils.mjs` exists at template; mapping
+    in `scripts/template-sync.ts` is registered).
+2.3 Run any cheap targeted checks the sandbox allows (this worktree
+    has no installed deps; full gate is deferred to CI — same caveat
+    documented in the original `.ai/runs/2026-05-27-dev-mode-package-watch-consolidation/HANDOFF.md`).
+
+### Phase 3: Ship
+
+3.1 Push branch and open PR against `develop`.
+3.2 Apply `review` pipeline label and `skip-qa` (docs + scripts +
+    template-sync; not customer-facing).
+3.3 Post the comprehensive `auto-create-pr` summary comment.
+
+## Risks
+
+- **Most likely regression**: template parity may drift again if the
+  root `scripts/dev.mjs` or `scripts/dev-orchestration-log-policy.mjs`
+  is changed after this PR but before merge. Mitigation: `yarn template:sync`
+  is part of CI and will fail loudly.
+- **Second-order effect**: documentation tweak in `troubleshooting.mdx`
+  changes the env-var contract description for `OM_WATCH_PACKAGES_MODE`
+  vs `OM_PACKAGE_WATCH_MODE`. Both vars already exist in code; this is
+  documentation only.
+- **BC impact**: none. No frozen / stable contract surface touched.
+- **Tenant/isolation risks**: N/A (dev-mode build tooling only).
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Carry the two follow-up commits
+
+- [ ] 1.1 Branch off latest develop
+- [ ] 1.2 Cherry-pick template-parity + env-var-docs commit
+- [ ] 1.3 Cherry-pick dev-shutdown-utils template-sync commit
+
+### Phase 2: Validation
+
+- [ ] 2.1 Diff parity vs upstream commits
+- [ ] 2.2 Template-sync mapping verification
+- [ ] 2.3 Targeted checks available in sandbox
+
+### Phase 3: Ship
+
+- [ ] 3.1 Push branch + open PR
+- [ ] 3.2 Apply labels with explanatory comments
+- [ ] 3.3 Post comprehensive summary comment

--- a/.ai/runs/2026-05-27-dev-watch-template-followups.md
+++ b/.ai/runs/2026-05-27-dev-watch-template-followups.md
@@ -99,15 +99,15 @@ Re-land the two post-merge follow-up commits from
 
 ### Phase 1: Carry the two follow-up commits
 
-- [ ] 1.1 Branch off latest develop
-- [ ] 1.2 Cherry-pick template-parity + env-var-docs commit
-- [ ] 1.3 Cherry-pick dev-shutdown-utils template-sync commit
+- [x] 1.1 Branch off latest develop — aa9fd46df
+- [x] 1.2 Cherry-pick template-parity + env-var-docs commit — d61698b6b
+- [x] 1.3 Cherry-pick dev-shutdown-utils template-sync commit — af3b6d71c
 
 ### Phase 2: Validation
 
-- [ ] 2.1 Diff parity vs upstream commits
-- [ ] 2.2 Template-sync mapping verification
-- [ ] 2.3 Targeted checks available in sandbox
+- [x] 2.1 Diff parity vs upstream commits — verified byte-identical for both cherry-picks
+- [x] 2.2 Template-sync mapping verification — `dev-shutdown-utils.mjs` registered in `scripts/template-sync.ts:80-82`; root/template diffs empty for all three files
+- [x] 2.3 Targeted checks available in sandbox — janitor worktree has no installed deps (same caveat as `2026-05-27-dev-mode-package-watch-consolidation`); full gate deferred to CI
 
 ### Phase 3: Ship
 

--- a/.ai/runs/2026-05-27-dev-watch-template-followups.md
+++ b/.ai/runs/2026-05-27-dev-watch-template-followups.md
@@ -111,6 +111,6 @@ Re-land the two post-merge follow-up commits from
 
 ### Phase 3: Ship
 
-- [ ] 3.1 Push branch + open PR
-- [ ] 3.2 Apply labels with explanatory comments
-- [ ] 3.3 Post comprehensive summary comment
+- [x] 3.1 Push branch + open PR — PR #2130
+- [x] 3.2 Apply labels with explanatory comments — review + skip-qa + documentation
+- [x] 3.3 Post comprehensive summary comment

--- a/apps/docs/docs/appendix/troubleshooting.mdx
+++ b/apps/docs/docs/appendix/troubleshooting.mdx
@@ -63,10 +63,15 @@ In lazy mode the runtime starts lightweight supervisors. The worker supervisor w
 
 For production deployments, prefer `AUTO_SPAWN_WORKERS=false` plus separately managed worker processes — lazy mode targets memory-sensitive dev and small unified deployments.
 
-The monorepo package watcher also defaults to low-memory one-shot rebuilds. It watches package source files without keeping a persistent esbuild graph for every package after the initial build. To restore the previous faster-but-heavier incremental watcher for a session, run:
+The monorepo package watcher also defaults to low-memory one-shot rebuilds. Two near-identical env vars tune different layers of that path, so it pays to keep them straight:
+
+- `OM_WATCH_PACKAGES_MODE` (dispatch-level) picks which watcher implementation `yarn dev` runs. Default is the consolidated single-process watcher (`scripts/watch-packages.mjs`). Set `OM_WATCH_PACKAGES_MODE=legacy` to fall back to the Turbo per-package fan-out (`yarn watch:packages:legacy`) when debugging the new path or pinning the old behavior.
+- `OM_PACKAGE_WATCH_MODE` (per-package mode, only meaningful under the legacy Turbo fan-out) chooses between the low-memory one-shot mode (default) and the older `persistent` esbuild-context mode that keeps the incremental graph in memory for faster rebuilds at the cost of ~1 GB of idle RSS.
+
+To restore the previous faster-but-heavier incremental watcher for a session, combine both:
 
 ```bash
-OM_PACKAGE_WATCH_MODE=persistent yarn dev
+OM_WATCH_PACKAGES_MODE=legacy OM_PACKAGE_WATCH_MODE=persistent yarn dev
 ```
 
 ## PostgreSQL auth errors on local setup

--- a/packages/create-app/template/scripts/dev-orchestration-log-policy.mjs
+++ b/packages/create-app/template/scripts/dev-orchestration-log-policy.mjs
@@ -66,6 +66,17 @@ export function isIgnorableTurboShutdownLine(line) {
     || /^command (interrupted|cancelled|canceled)/i.test(plain)
 }
 
+export function isIgnorableConsolidatedWatchLine(line) {
+  if (typeof line !== 'string') return false
+  const plain = normalize(line)
+  if (!plain.startsWith('[watch]')) return false
+  return /^\[watch\] consolidated watcher: /.test(plain)
+    || /^\[watch\] [^:]+: rebuilding\.\.\.$/.test(plain)
+    || /^\[watch\] [^:]+: rebuild complete$/.test(plain)
+    || /^\[watch\] [^:]+: no source files found, skipping rebuild$/.test(plain)
+    || /^\[watch\] no workspace packages with a `watch` script /.test(plain)
+}
+
 const FAILURE_NOISE_PREDICATES = [
   isIgnorableBoxDrawingLine,
   isIgnorableEnvInjectionLine,
@@ -89,6 +100,7 @@ const TURBO_NOISE_PREDICATES = [
   isIgnorableTurboCacheCancellationLine,
   isIgnorableTurboShutdownLine,
   isIgnorableBoxDrawingLine,
+  isIgnorableConsolidatedWatchLine,
 ]
 
 export function isIgnorableTurboLine(line) {

--- a/packages/create-app/template/scripts/dev-shutdown-utils.mjs
+++ b/packages/create-app/template/scripts/dev-shutdown-utils.mjs
@@ -1,0 +1,41 @@
+import spawn from 'cross-spawn'
+
+// Windows does not propagate signals from a parent process down to grandchildren
+// the way POSIX does: child.kill('SIGTERM'/'SIGKILL') only terminates the direct
+// child, leaving any further descendants (next dev, mercato generate watch, etc.)
+// alive and still holding ports. taskkill with /T (tree) /F (force) is the
+// platform-blessed way to terminate the whole descendant tree. On POSIX we keep
+// child.kill so the existing graceful-then-forced two-phase shutdown is preserved.
+export function killProcessTree(child, signal, options = {}) {
+  if (!child) return false
+
+  const platform = options.platform ?? process.platform
+  const spawnImpl = options.spawn ?? spawn
+
+  if (platform === 'win32') {
+    const pid = child.pid
+    if (typeof pid !== 'number' || Number.isNaN(pid) || pid <= 0) {
+      return false
+    }
+    try {
+      const killer = spawnImpl('taskkill', ['/pid', String(pid), '/T', '/F'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      })
+      if (killer && typeof killer.on === 'function') {
+        killer.on('error', () => { /* best-effort: taskkill may not exist on stripped images */ })
+      }
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  if (child.killed) return false
+  try {
+    child.kill(signal)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/create-app/template/scripts/dev.mjs
+++ b/packages/create-app/template/scripts/dev.mjs
@@ -23,6 +23,7 @@ import {
   stripAnsi,
 } from './dev-splash-helpers.mjs'
 import { purgeAppBuildCaches } from './dev-cache-purge.mjs'
+import { killProcessTree } from './dev-shutdown-utils.mjs'
 import { resolveSpawnCommand } from './dev-spawn-utils.mjs'
 import { createDevSplashCodingFlow } from './dev-splash-coding-flow.mjs'
 import { createDevSplashGitRepoFlow } from './dev-splash-git-repo-flow.mjs'
@@ -1023,13 +1024,13 @@ function shutdown(exitCode = 0) {
   }
 
   for (const child of alive) {
-    child.kill('SIGTERM')
+    killProcessTree(child, 'SIGTERM')
   }
 
   setTimeout(() => {
     for (const child of children) {
       if (!child.killed) {
-        child.kill('SIGKILL')
+        killProcessTree(child, 'SIGKILL')
       }
     }
     closeDevLogSession()
@@ -1492,10 +1493,21 @@ async function runPassthroughStage(label, commandArgs, options = {}) {
   console.log(`✅ ${formatProgressLine(label, stageCurrent, stageTotal, resolveProgressPercent(stageCurrent, stageTotal))} in ${formatDuration(Date.now() - startedAt)}`)
 }
 
+function resolveWatchPackagesScript() {
+  // `OM_WATCH_PACKAGES_MODE=legacy` falls back to the Turbo per-package
+  // fan-out for developers who need the old behavior (debugging, or pairing
+  // with `OM_PACKAGE_WATCH_MODE=persistent` for hot rebuilds at the cost of
+  // ~1 GB more idle RSS). Default is the consolidated single-process watcher.
+  const raw = String(process.env.OM_WATCH_PACKAGES_MODE ?? '').trim().toLowerCase()
+  return raw === 'legacy' ? 'watch:packages:legacy' : 'watch:packages'
+}
+
 function startPackageWatch() {
+  const watchScript = resolveWatchPackagesScript()
+
   if (classic) {
-    const child = spawnCommand(yarnCommand, ['watch:packages'], {
-      label: 'watch:packages',
+    const child = spawnCommand(yarnCommand, [watchScript], {
+      label: watchScript,
       logFile: getDevRunnerLog(),
       mirrorOutput: true,
     })
@@ -1529,16 +1541,7 @@ function startPackageWatch() {
     activity: 'Workspace package watch started',
   })
 
-  const child = spawnCommand(yarnCommand, [
-    'turbo',
-    'run',
-    'watch',
-    '--filter=./packages/*',
-    '--concurrency=32',
-    '--output-logs=errors-only',
-    '--log-order=grouped',
-    '--log-prefix=none',
-  ], {
+  const child = spawnCommand(yarnCommand, [watchScript], {
     label: 'Watching workspace packages',
     logFile: getDevRunnerLog(),
     mirrorOutput: verbose,

--- a/scripts/template-sync.ts
+++ b/scripts/template-sync.ts
@@ -77,6 +77,11 @@ const EXPLICIT_TEMPLATE_FILE_MAPPINGS = [
     rel: 'scripts/dev-orchestration-log-policy.mjs',
   },
   {
+    sourceFile: path.join(ROOT, 'scripts', 'dev-shutdown-utils.mjs'),
+    templateFile: path.join(ROOT, 'packages', 'create-app', 'template', 'scripts', 'dev-shutdown-utils.mjs'),
+    rel: 'scripts/dev-shutdown-utils.mjs',
+  },
+  {
     sourceFile: path.join(ROOT, 'scripts', 'dev-database-url.mjs'),
     templateFile: path.join(ROOT, 'packages', 'create-app', 'template', 'scripts', 'dev-database-url.mjs'),
     rel: 'scripts/dev-database-url.mjs',

--- a/scripts/watch-packages.mjs
+++ b/scripts/watch-packages.mjs
@@ -17,6 +17,12 @@
 //
 // Escape hatch: set `OM_WATCH_PACKAGES_MODE=legacy` to fall back to the
 // previous Turbo-based per-package watcher path (see `package.json`).
+//
+// Note: this var is distinct from `OM_PACKAGE_WATCH_MODE` (see
+// `scripts/watch.mjs`), which only takes effect under the legacy path and
+// toggles per-package `low-memory` vs `persistent` modes. The consolidated
+// watcher always runs in the low-memory equivalent. See
+// `apps/docs/docs/appendix/troubleshooting.mdx` for the public reference.
 
 import * as esbuild from 'esbuild'
 import { glob } from 'glob'


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-05-27-dev-watch-template-followups.md
Status: complete

## Goal

Re-land the two post-merge follow-up commits from
`fix/dev-mode-package-watch-consolidation` (the source branch behind
#2102) as a clean, scoped PR against `develop`. The original follow-up
attempt at #2126 was closed because the branch had drifted and carried
10 commits instead of the 2 new ones; this PR cherry-picks only the
two unmerged commits onto a fresh branch off the latest `develop`.

## What Changed

This PR carries two upstream commits forward unchanged:

1. **`fix(dev): address low-priority code-review findings (template parity + env-var docs)`** — original `f5157953`
   - Re-syncs `packages/create-app/template/scripts/dev.mjs` and
     `packages/create-app/template/scripts/dev-orchestration-log-policy.mjs`
     to mirror their root counterparts (the consolidated-watcher dispatch
     and the noise-filter predicate). Closes L1 from the post-#2102
     code review.
   - Expands `apps/docs/docs/appendix/troubleshooting.mdx` to document
     `OM_WATCH_PACKAGES_MODE` (dispatch-level) and `OM_PACKAGE_WATCH_MODE`
     (per-package, legacy path only) side by side, and cross-links both
     env vars from `scripts/watch-packages.mjs`. Closes L2.
2. **`fix(dev): include dev-shutdown-utils.mjs in template-sync mapping`** — original `f7e29e41`
   - Adds `packages/create-app/template/scripts/dev-shutdown-utils.mjs`
     (a copy of the root helper from PR #2022) and registers the
     mapping in `scripts/template-sync.ts` so the standalone-template
     `dev.mjs` can resolve its `./dev-shutdown-utils.mjs` import.

No behavior change in the consolidated watcher itself — that already
shipped via #2102. This PR is documentation + standalone-template
parity only.

## Tests

- No code-level behavior changes; existing `scripts/__tests__/*.mjs`
  cases from #2102 continue to cover the watcher and the noise-filter
  predicate.
- Template parity verified manually: `diff` of the three synced files
  (`dev.mjs`, `dev-orchestration-log-policy.mjs`, `dev-shutdown-utils.mjs`)
  vs their root counterparts is empty.
- `scripts/template-sync.ts` registration for `dev-shutdown-utils.mjs`
  inspected at lines 80-82.
- Full `yarn template:sync` / `yarn build:packages` / `yarn typecheck` /
  `yarn test` / `yarn build:app` deferred to CI — janitor worktree has
  no installed deps (same caveat as #2102).

## Backward Compatibility

No contract surface from `BACKWARD_COMPATIBILITY.md` is touched. The
two new commits change:

- A docs page (`apps/docs/docs/appendix/troubleshooting.mdx`) — additive.
- Two standalone-template files (`packages/create-app/template/scripts/*`) — additive parity
  with root that already shipped.
- A new template file (`dev-shutdown-utils.mjs`) — additive.
- The `scripts/template-sync.ts` mapping — additive entry.
- A code comment in `scripts/watch-packages.mjs` — no runtime effect.

Both `OM_WATCH_PACKAGES_MODE=legacy` and `OM_PACKAGE_WATCH_MODE=persistent`
escape hatches continue to work exactly as #2102 documented them.

## Progress

See [Progress section in the plan](.ai/runs/2026-05-27-dev-watch-template-followups.md#progress).

## Why a new PR (not a rebase of the source branch)

The original branch `fix/dev-mode-package-watch-consolidation` was not
rebased after #2102's squash-merge. Its first attempt (#2126) carried
all 10 commits — including the 8 that #2102 already merged — and was
closed without merging. Cherry-picking onto a fresh branch off `develop`
keeps the diff focused on just the two unmerged commits.