### PR TITLE
perf(crud): push pagination + parallelize decryption fetches for two CRUD SQL quick wins

### DIFF
--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/HANDOFF.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/HANDOFF.md
@@ -1,10 +1,10 @@
 # Handoff — 2026-05-27-crud-sql-query-optimizations
 
-**Last updated:** 2026-05-27T15:40:00Z
+**Last updated:** 2026-05-27T15:50:00Z
 **Branch:** feat/crud-sql-query-optimizations
-**PR:** not yet opened
-**Current phase/step:** Phase 4 Step 4.1 (final gate + PR open)
-**Last commit:** e4b809875 — perf(customers): fetch CustomerEntity and CustomerPersonProfile concurrently in people afterList
+**PR:** https://github.com/open-mercato/open-mercato/pull/2139 (Status: complete)
+**Current phase/step:** run complete — every Tasks-table row is `done`
+**Last commit:** 0c6e6fcc8 — docs(runs): record final gate checks for crud-sql-query-optimizations (Step 4.1)
 
 ## What just happened
 

--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/HANDOFF.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/HANDOFF.md
@@ -1,23 +1,25 @@
 # Handoff — 2026-05-27-crud-sql-query-optimizations
 
-**Last updated:** 2026-05-27T15:30:00Z
+**Last updated:** 2026-05-27T15:40:00Z
 **Branch:** feat/crud-sql-query-optimizations
 **PR:** not yet opened
-**Current phase/step:** Phase 1 Step 1.1 (seeding run folder)
-**Last commit:** _none yet_
+**Current phase/step:** Phase 4 Step 4.1 (final gate + PR open)
+**Last commit:** e4b809875 — perf(customers): fetch CustomerEntity and CustomerPersonProfile concurrently in people afterList
 
 ## What just happened
 
-- Run scoped and planned. Two implementation steps (Step 2.1, Step 2.2) chosen as the two BC quick wins to land in this PR.
-- Remaining catalogued wins (C through J) will be filed as GitHub issues in Step 3.1.
+- Step 1.1 (seed) and Steps 2.1 + 2.2 (both quick wins) landed cleanly.
+- Step 3.1 filed 8 follow-up GitHub issues (#2131–#2138) covering findings C through J.
+- Step 4.1 — about to open the PR + run the final gate.
 
 ## Next concrete action
 
-- Commit `PLAN.md`, `HANDOFF.md`, `NOTIFY.md` (this Step 1.1) and push.
+- Commit this PLAN/HANDOFF/NOTIFY update for Step 3.1, push, then open the PR.
+- Run targeted validation, then full gate (constrained by janitor sandbox having no `node_modules` — CI will run the full gate).
 
 ## Blockers / open questions
 
-- None.
+- Janitor sandbox cannot run `yarn` commands (no `node_modules`). All validation will land via the PR's CI run rather than locally. Document this explicitly in `final-gate-checks.md` and in the PR summary.
 
 ## Environment caveats
 

--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/HANDOFF.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/HANDOFF.md
@@ -1,0 +1,31 @@
+# Handoff — 2026-05-27-crud-sql-query-optimizations
+
+**Last updated:** 2026-05-27T15:30:00Z
+**Branch:** feat/crud-sql-query-optimizations
+**PR:** not yet opened
+**Current phase/step:** Phase 1 Step 1.1 (seeding run folder)
+**Last commit:** _none yet_
+
+## What just happened
+
+- Run scoped and planned. Two implementation steps (Step 2.1, Step 2.2) chosen as the two BC quick wins to land in this PR.
+- Remaining catalogued wins (C through J) will be filed as GitHub issues in Step 3.1.
+
+## Next concrete action
+
+- Commit `PLAN.md`, `HANDOFF.md`, `NOTIFY.md` (this Step 1.1) and push.
+
+## Blockers / open questions
+
+- None.
+
+## Environment caveats
+
+- Dev runtime runnable: unknown — not started this session. Step 2.1 + 2.2 are server-side and validated by unit tests; no Playwright pass needed.
+- Playwright / browser checks: skipped — pure server-side perf, no UI change.
+- Database/migration state: clean. No migrations in this run.
+
+## Worktree
+
+- Path: `/home/pkarw/Projects/github-janitor/.janitor/repos/open-mercato__open-mercato/worktrees/4b738f14-839e-4c9a-ba40-784c4314f0c0`
+- Created this run: no — reused the existing linked janitor worktree (`GIT_DIR != GIT_COMMON_DIR`).

--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/NOTIFY.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/NOTIFY.md
@@ -37,3 +37,17 @@
 - #2137 (I — customers activities decorator parallelize)
 - #2138 (J — auth roles ACL parallelize)
 - All filed with `refactor` label. PR cross-link will be added once PR is opened.
+
+## 2026-05-27T15:48:00Z — Step 4.1 complete — PR #2139 opened
+
+- PR: https://github.com/open-mercato/open-mercato/pull/2139
+- Title: `perf(crud): push pagination + parallelize decryption fetches for two CRUD SQL quick wins`
+- Labels applied: `review`, `refactor`, `skip-qa` — each with a rationale comment per AGENTS.md.
+- Three-signal in-progress lock claimed (assignee `pkarw`, `in-progress` label, claim comment).
+- Cross-linked PR #2139 to each of #2131–#2138 via issue comments.
+- Comprehensive summary comment posted with full Verification phases / How to verify / Risk analysis sections.
+- `auto-review-pr` autofix pass substituted with manual self-review (janitor sandbox lacks `node_modules`); precedent: #2102 and #2130. CI on the PR runs the full gate.
+
+## 2026-05-27T15:50:00Z — run complete
+
+- Lock release follows immediately after this NOTIFY/HANDOFF commit lands.

--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/NOTIFY.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/NOTIFY.md
@@ -1,0 +1,15 @@
+# Notify — 2026-05-27-crud-sql-query-optimizations
+
+> Append-only log. Every entry is UTC-timestamped. Never rewrite prior entries.
+
+## 2026-05-27T15:30:00Z — run started
+
+- Brief: analyze CRUD API SQL queries across modules; implement first two BC quick wins; file GitHub issues for the rest.
+- External skill URLs: none.
+- Module scope: customers (CRM), sales, catalog, staff, resources, workflows, plus other modules with CRUD routes (currencies, auth, directory).
+- Plan classification: **Spec-implementation run** — multi-phase work spanning analysis, two implementation Steps, and issue creation.
+- Branch: `feat/crud-sql-query-optimizations` off `origin/develop` (latest at `da89d7530`).
+- Two implementation steps chosen:
+  - Step 2.1 — push DB-level pagination to currencies + exchange-rates list routes (highest-impact bug-grade fix; clear OOM/perf risk on large tables).
+  - Step 2.2 — parallelize entity + profile decryption fetch in customers people `afterList` (highest-traffic CRM list endpoint).
+- Other catalogued wins (C–J in PLAN.md) deferred to GitHub issues per user request.

--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/NOTIFY.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/NOTIFY.md
@@ -13,3 +13,27 @@
   - Step 2.1 — push DB-level pagination to currencies + exchange-rates list routes (highest-impact bug-grade fix; clear OOM/perf risk on large tables).
   - Step 2.2 — parallelize entity + profile decryption fetch in customers people `afterList` (highest-traffic CRM list endpoint).
 - Other catalogued wins (C–J in PLAN.md) deferred to GitHub issues per user request.
+
+## 2026-05-27T15:30:30Z — Step 2.1 landed
+
+- Pushed `4a8bb2b0b`: `perf(currencies): push pagination to DB on currencies + exchange-rates list`.
+- Janitor harness wrote an intermediate periodic-autosave commit (`741af1b01`) before the manual commit could land; resolved by `git reset --soft d51129921` to fold the changes into a single clean Step 2.1 commit. No content lost.
+- Tests added under both `currencies/__tests__/list-pagination.test.ts` and `exchange-rates/__tests__/list-pagination.test.ts`. Cannot run locally — janitor sandbox has no `node_modules`. CI will verify.
+
+## 2026-05-27T15:35:00Z — Step 2.2 landed
+
+- Pushed `e4b809875`: `perf(customers): fetch CustomerEntity and CustomerPersonProfile concurrently in people afterList`.
+- Added a deferred-promise concurrency test to `customers/api/people/__tests__/route.test.ts` that proves both fetches initiate before either resolves.
+- No autosave conflict this time.
+
+## 2026-05-27T15:38:00Z — Step 3.1 GitHub issues filed
+
+- #2131 (C — sales shipments DictionaryEntry parallelize)
+- #2132 (D — QueryEngine gate cf:* joins)
+- #2133 (E — thread CF def index through QueryEngine)
+- #2134 (F — sales shipments orderLines batching; depends on #2131)
+- #2135 (G — makeCrudRoute cache-tag loop flatten)
+- #2136 (H — audit em.findAndCount callers)
+- #2137 (I — customers activities decorator parallelize)
+- #2138 (J — auth roles ACL parallelize)
+- All filed with `refactor` label. PR cross-link will be added once PR is opened.

--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
@@ -12,7 +12,7 @@
 | Phase | Step | Title | Status | Commit |
 |-------|------|-------|--------|--------|
 | 1 | 1.1 | Seed run folder (PLAN, HANDOFF, NOTIFY) | done | ac97a27c0 |
-| 2 | 2.1 | Push DB-level pagination to currencies + exchange-rates list routes | todo | — |
+| 2 | 2.1 | Push DB-level pagination to currencies + exchange-rates list routes | done | pending |
 | 2 | 2.2 | Parallelize entity + profile decryption fetch in customers people afterList | todo | — |
 | 3 | 3.1 | File GitHub issues for the remaining catalogued quick wins | todo | — |
 | 4 | 4.1 | Final gate + PR summary | todo | — |

--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
@@ -12,7 +12,7 @@
 | Phase | Step | Title | Status | Commit |
 |-------|------|-------|--------|--------|
 | 1 | 1.1 | Seed run folder (PLAN, HANDOFF, NOTIFY) | done | ac97a27c0 |
-| 2 | 2.1 | Push DB-level pagination to currencies + exchange-rates list routes | done | pending |
+| 2 | 2.1 | Push DB-level pagination to currencies + exchange-rates list routes | done | 4a8bb2b0b |
 | 2 | 2.2 | Parallelize entity + profile decryption fetch in customers people afterList | todo | — |
 | 3 | 3.1 | File GitHub issues for the remaining catalogued quick wins | todo | — |
 | 4 | 4.1 | Final gate + PR summary | todo | — |

--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
@@ -15,7 +15,7 @@
 | 2 | 2.1 | Push DB-level pagination to currencies + exchange-rates list routes | done | 4a8bb2b0b |
 | 2 | 2.2 | Parallelize entity + profile decryption fetch in customers people afterList | done | e4b809875 |
 | 3 | 3.1 | File GitHub issues for the remaining catalogued quick wins | done | pending |
-| 4 | 4.1 | Final gate + PR summary | todo | — |
+| 4 | 4.1 | Final gate + PR summary | done | pending |
 
 ## GitHub Issues filed (Step 3.1)
 

--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
@@ -13,7 +13,7 @@
 |-------|------|-------|--------|--------|
 | 1 | 1.1 | Seed run folder (PLAN, HANDOFF, NOTIFY) | done | ac97a27c0 |
 | 2 | 2.1 | Push DB-level pagination to currencies + exchange-rates list routes | done | 4a8bb2b0b |
-| 2 | 2.2 | Parallelize entity + profile decryption fetch in customers people afterList | todo | — |
+| 2 | 2.2 | Parallelize entity + profile decryption fetch in customers people afterList | done | pending |
 | 3 | 3.1 | File GitHub issues for the remaining catalogued quick wins | todo | — |
 | 4 | 4.1 | Final gate + PR summary | todo | — |
 

--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
@@ -13,9 +13,22 @@
 |-------|------|-------|--------|--------|
 | 1 | 1.1 | Seed run folder (PLAN, HANDOFF, NOTIFY) | done | ac97a27c0 |
 | 2 | 2.1 | Push DB-level pagination to currencies + exchange-rates list routes | done | 4a8bb2b0b |
-| 2 | 2.2 | Parallelize entity + profile decryption fetch in customers people afterList | done | pending |
-| 3 | 3.1 | File GitHub issues for the remaining catalogued quick wins | todo | — |
+| 2 | 2.2 | Parallelize entity + profile decryption fetch in customers people afterList | done | e4b809875 |
+| 3 | 3.1 | File GitHub issues for the remaining catalogued quick wins | done | pending |
 | 4 | 4.1 | Final gate + PR summary | todo | — |
+
+## GitHub Issues filed (Step 3.1)
+
+| Finding | Issue | URL |
+|---------|-------|-----|
+| C — sales shipments DictionaryEntry parallelize | #2131 | https://github.com/open-mercato/open-mercato/issues/2131 |
+| D — QueryEngine gate cf:* joins | #2132 | https://github.com/open-mercato/open-mercato/issues/2132 |
+| E — thread CF def index through QueryEngine | #2133 | https://github.com/open-mercato/open-mercato/issues/2133 |
+| F — sales shipments orderLines batching | #2134 | https://github.com/open-mercato/open-mercato/issues/2134 |
+| G — makeCrudRoute cache-tag loop flatten | #2135 | https://github.com/open-mercato/open-mercato/issues/2135 |
+| H — audit em.findAndCount callers | #2136 | https://github.com/open-mercato/open-mercato/issues/2136 |
+| I — customers activities decorator parallelize | #2137 | https://github.com/open-mercato/open-mercato/issues/2137 |
+| J — auth roles ACL parallelize | #2138 | https://github.com/open-mercato/open-mercato/issues/2138 |
 
 ## Goal
 

--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
@@ -1,0 +1,181 @@
+# PLAN — CRUD API SQL Query Quick Wins (100% BC)
+
+**Run slug:** `2026-05-27-crud-sql-query-optimizations`
+**Branch:** `feat/crud-sql-query-optimizations`
+**Base:** `develop`
+**Brief:** Analyze SQL queries used by CRUD APIs across modules (CRM/customers, sales, catalog, staff, resource, workflows, others). Catalogue backward-compatible quick wins. Implement the top two. File GitHub issues for the rest.
+
+## Tasks
+
+> Authoritative status table. `Status` is one of `todo` or `done`. On landing a Step, flip `Status` to `done` and fill the `Commit` column with the short SHA. The first row whose `Status` is not `done` is the resume point for `auto-continue-pr`. Step ids are immutable once a Step has a commit.
+
+| Phase | Step | Title | Status | Commit |
+|-------|------|-------|--------|--------|
+| 1 | 1.1 | Seed run folder (PLAN, HANDOFF, NOTIFY) | done | ac97a27c0 |
+| 2 | 2.1 | Push DB-level pagination to currencies + exchange-rates list routes | todo | — |
+| 2 | 2.2 | Parallelize entity + profile decryption fetch in customers people afterList | todo | — |
+| 3 | 3.1 | File GitHub issues for the remaining catalogued quick wins | todo | — |
+| 4 | 4.1 | Final gate + PR summary | todo | — |
+
+## Goal
+
+Land two concrete, 100%-backward-compatible CRUD SQL optimizations and capture the rest as tracked GitHub issues so the team can pick them up incrementally.
+
+## Scope
+
+- Modify only the two route files that ship Step 2.1 and the one route file that ships Step 2.2.
+- Add unit tests covering the new pagination behavior and the parallel-fetch behavior.
+- File GitHub issues for every other catalogued optimization with concrete file:line citations and BC notes.
+- Touch nothing else.
+
+## Non-goals
+
+- No public API contract change. Response shape stays identical.
+- No DB schema change. No new migrations, no new indexes (those go in follow-up issues if warranted).
+- No refactors to `makeCrudRoute`, `QueryEngine`, or any shared CRUD plumbing in this PR (those are issue candidates, not in-scope changes).
+- No DS / UI changes — this PR is server-side only.
+
+## Risks
+
+- **Pagination behavior change risk**: switching from "fetch all, slice in JS" to "LIMIT/OFFSET in SQL" changes the row set under unstable sort orders. Mitigation: both routes already define stable `orderBy` (`date DESC` for exchange-rates, `code ASC` for currencies) before the slice, and we keep the same `orderBy`. We also preserve the `findAndCount` shape so `total` is unchanged.
+- **Promise.all error propagation**: in `afterList` for people, switching two awaits to `Promise.all` changes failure semantics slightly (first-failure-aborts vs. sequential-stops-at-first). Mitigation: both calls already throw on failure; the user-visible behavior is unchanged.
+- No mutation safety risk — all changes are read-path only, so `withAtomicFlush` rules do not apply.
+
+## External References
+
+None. No `--skill-url` arguments were supplied. All guidance taken from in-repo AGENTS.md files (root, `packages/core`, `packages/core/src/modules/customers`, `packages/core/src/modules/sales`) and from `BACKWARD_COMPATIBILITY.md` implicitly via the BC self-review step.
+
+## Findings catalogue
+
+Findings labelled "implemented" land in this PR (Steps 2.1 and 2.2). Everything else gets a GitHub issue in Step 3.1.
+
+### A. (IMPLEMENTED — Step 2.1) Currencies + Exchange-rates list: fetch-all-then-slice anti-pattern
+
+- **Files**:
+  - `packages/core/src/modules/currencies/api/currencies/route.ts:175-177`
+  - `packages/core/src/modules/currencies/api/exchange-rates/route.ts:172-174`
+- **Problem**: `em.findAndCount(Entity, where, { orderBy })` is called without `limit`/`offset`, then `paged = all.slice(start, start + pageSize)` slices in JS. With thousands of rows this loads the entire table per request.
+- **Why this is the strongest win**: trivial single-line edit, two routes, identical pattern, no semantic change (same `orderBy`, same `findAndCount` total, same response shape). Wire-format unchanged.
+- **Fix**: push `limit: pageSize, offset: (page - 1) * pageSize` into the `findAndCount` options. Keep the JS structures so we still compute `totalPages`.
+- **BC**: 100% — same `orderBy`, same response keys, same `total` semantics. Behavior is bit-identical when `total <= pageSize`.
+
+### B. (IMPLEMENTED — Step 2.2) Customers people `afterList`: sequential decryption fetches
+
+- **File**: `packages/core/src/modules/customers/api/people/route.ts:429-459`
+- **Problem**: Two `findWithDecryption` calls run sequentially — `CustomerEntity` (line 429) and `CustomerPersonProfile` (line 453). Both depend only on the page item ids that are already known when `afterList` starts; they are independent of each other.
+- **Fix**: wrap both calls in `Promise.all([...])`. Saves one DB round-trip per list page across the highest-traffic CRM endpoint.
+- **BC**: 100% — same queries, same scope, same decryption. Only the await ordering changes.
+
+### C. (ISSUE) Sales shipments `afterList`: DictionaryEntry fetch sequential after Promise.all
+
+- **File**: `packages/core/src/modules/sales/api/shipments/route.ts:272`
+- **Problem**: First `Promise.all([shipmentItems, shippingMethods])` runs in parallel. Then `em.find(SalesOrderLine, ...)` (line 211) depends on the result. But the subsequent `em.find(DictionaryEntry, ...)` (line 272) depends ONLY on `items` (the input page), not on the first round-trip — so it could join the first `Promise.all` and save one round-trip.
+- **Fix**: extract `statusIds` synchronously from `items` before the first `Promise.all` and add a third independent fetch to that `Promise.all`.
+
+### D. (ISSUE) QueryEngine custom-field joins built even when no cf field is requested
+
+- **File**: `packages/shared/src/lib/query/engine.ts:254-256`
+- **Problem**: `buildFilterableCustomFieldJoins(opts.customFieldSources)` is appended to the joins list unconditionally. If the caller did not request any `cf:*` field, did not filter on any `cf:*`, and did not pass `includeCustomFields: true`, the extra LEFT JOINs are dead weight on every query.
+- **Fix**: gate the join construction on `hasCfRequest = includeCustomFields || fields.some(f => f.startsWith('cf:')) || filters.some(f => f.field.startsWith('cf:'))`.
+- **BC**: result rows identical (LEFT JOIN of dead aggregates yields no extra rows); only the SQL plan changes.
+
+### E. (ISSUE) Custom field definitions loaded twice on every decorated list
+
+- **Files**:
+  - `packages/shared/src/lib/query/engine.ts:517-592` (QueryEngine loads `custom_field_defs` for the entity)
+  - `packages/shared/src/lib/crud/factory.ts:891-916` (factory calls `loadCustomFieldDefinitionIndex()` again for `decorateItemsWithCustomFields`)
+- **Problem**: Same `custom_field_defs` rows are fetched twice per request.
+- **Fix**: have the QueryEngine expose the resolved definitions in its result (additive, optional field), and let the factory reuse them instead of reloading. Internal-only contract addition; no public type change.
+
+### F. (ISSUE) Sales shipments orderLines fetch could batch with another lookup
+
+- **File**: `packages/core/src/modules/sales/api/shipments/route.ts:211-213`
+- **Problem**: `em.find(SalesOrderLine, { id: { $in: orderLineIds } })` runs alone after the first Promise.all. If `statusIds` extraction is moved earlier (see C), the `orderLines` and `DictionaryEntry` fetches could also be `Promise.all`'d.
+- **Fix**: after the first Promise.all returns, run a second small Promise.all combining orderLines and any other deferred-but-independent lookups.
+
+### G. (ISSUE) Cache tag computation in `makeCrudRoute` loops can be flattened
+
+- **File**: `packages/shared/src/lib/crud/factory.ts:1280-1293`
+- **Problem**: Collection-tag loop runs inside the record-id loop on multi-org/multi-alias resources, recomputing the same tags repeatedly. They are then deduped via a `Set`, so correctness is fine, but we allocate N×M intermediate tags.
+- **Fix**: precompute collection tags once before the record-id loop.
+- **Impact**: micro — but trivially safe and free.
+
+### H. (ISSUE) Audit `em.findAndCount` callers for additional fetch-all-then-slice bugs
+
+- **Pattern**: `em.findAndCount(Entity, filter, { orderBy })` followed by JS slicing.
+- **Candidates** (from grep over `packages/core/src/modules`):
+  - `catalog/api/categories/route.ts:226-228` — categories hierarchy; needs careful inspection because the tree build may require the full set
+  - `customers/api/activities/route.ts:181-183` — activities are unioned from multiple sources before paging; structurally requires JS slice but worth confirming
+  - `customers/api/labels/route.ts:122-124` — labels list
+  - `customers/api/assignable-staff/route.ts:208-210` — assignable staff list
+  - `customers/api/deals/[id]/people/route.ts:136-138` — relational list
+  - `customers/api/deals/[id]/companies/route.ts:157-159` — relational list
+  - `customers/api/companies/[id]/people/route.ts:195-197` — relational list
+  - `customers/api/people/[id]/companies/enriched/route.ts:374-376` — enriched relational list
+  - `directory/api/tenants/route.ts:197-199` — tenants list
+  - `directory/api/organizations/route.ts:376-378, 475-477` — organizations list
+- **Fix**: per route, decide whether the JS slice is structurally required (multi-source merge/dedup) or just legacy. Push to DB where possible.
+
+### I. (ISSUE) Customers activities decorator: two batched but un-parallelized lookups
+
+- **File**: `packages/core/src/modules/customers/api/activities/route.ts:210-217` and `~360`
+- **Problem**: After fetching activities, the decorator runs `em.find(User)` and `em.find(CustomerDeal)` (and a third `CustomerInteraction` lookup elsewhere). Each is batched via `$in`, but they are sequential.
+- **Fix**: `Promise.all` the three lookups.
+
+### J. (ISSUE) Auth roles ACL: two sequential `em.findOne` on Role + RoleAcl
+
+- **File**: `packages/core/src/modules/auth/api/roles/acl/route.ts:67-96` (GET), `137-174` (PUT)
+- **Problem**: ACL fetch and mutate paths run two sequential `findOne` calls. They could be a single join or a Promise.all.
+- **Fix**: prefer Promise.all (lower risk than touching ORM relations). Impact is small — ACL changes are rare — but free latency win.
+
+## Implementation Plan
+
+### Phase 1 — Run setup
+
+#### Step 1.1 — Seed run folder
+
+- Create `.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md`, `HANDOFF.md`, `NOTIFY.md`.
+- Commit + push.
+
+### Phase 2 — Implement the two quick wins
+
+#### Step 2.1 — Currencies + exchange-rates: push pagination to DB
+
+- Edit `packages/core/src/modules/currencies/api/currencies/route.ts`: include `limit: pageSize, offset: (page - 1) * pageSize` in the `em.findAndCount` options. Remove the JS `.slice` since `findAndCount` now returns the page.
+- Edit `packages/core/src/modules/currencies/api/exchange-rates/route.ts`: same change.
+- Add unit tests under each module's `__tests__/` (or extend if existing): assert that `findAndCount` is called with `limit`/`offset` matching the requested page, that the returned `items` reflect the DB page directly, and that `total` and `totalPages` remain consistent.
+- Single commit. Push.
+
+#### Step 2.2 — Customers people afterList: parallelize entity + profile fetch
+
+- Edit `packages/core/src/modules/customers/api/people/route.ts`: replace the sequential `await findWithDecryption(...CustomerEntity...)` + `await findWithDecryption(...CustomerPersonProfile...)` with a single `Promise.all([...])` returning `[entities, profiles]`. Keep all filter clauses, scope, and post-processing identical.
+- Add a unit test in `packages/core/src/modules/customers/__tests__/` (if missing, create) verifying that both `findWithDecryption` calls are invoked concurrently (e.g., assert the slower mock resolves before sequential awaits would allow) and that the final mapped output matches the existing baseline.
+- Single commit. Push.
+
+### Phase 3 — File issues for the remainder
+
+#### Step 3.1 — Open GitHub issues C, D, E, F, G, H, I, J
+
+- Use `gh issue create` (or `gh api graphql`) to file one issue per remaining catalogued win. Each issue must include: problem statement, file/line citation, proposed BC-safe fix, BC assessment, and suggested labels (`refactor`, `performance`, and a relevant category if applicable).
+- Track the created issue URLs back into `NOTIFY.md` and append a `## GitHub Issues` section at the bottom of this PLAN.md with the issue numbers and URLs (separate commit, fine; not a Step requirement but the table row covers it as one commit).
+
+### Phase 4 — Final gate + PR
+
+#### Step 4.1 — Final gate + PR summary
+
+- Run focused validation (typecheck + targeted tests for currencies and customers modules; full gate per the workflow). Document in `final-gate-checks.md`.
+- Open the PR against `develop`. Apply labels per AGENTS.md (`review` + `refactor` + `performance` if exists, `skip-qa` because this is server-side perf with no customer-facing UI change). Claim with the three-signal lock.
+- Run `auto-review-pr` in autofix mode.
+- Post the comprehensive summary comment.
+
+## Verification strategy
+
+- **Currencies + exchange-rates**: existing integration tests under `.ai/qa/tests/api/currencies` (if present) verify pagination round-trips; add a unit test that asserts `findAndCount` was called with `limit`/`offset` for a non-first page.
+- **People afterList**: existing customers integration tests under `.ai/qa/tests/admin/customers` exercise the people list endpoint and will catch any regression in the returned shape.
+- **Issue PRs**: out of scope for this run; only filing the issues.
+
+## Out-of-scope reminders
+
+- No changes to `engine.ts` or `factory.ts` in this PR — they all become Step-3 issues.
+- No DS, UI, or response-shape changes.
+- No new database migrations.

--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/final-gate-checks.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/final-gate-checks.md
@@ -1,0 +1,98 @@
+# Final gate checks — 2026-05-27-crud-sql-query-optimizations
+
+**Date:** 2026-05-27T15:42:00Z
+**Branch:** feat/crud-sql-query-optimizations
+**Range:** `develop..HEAD` — commits 4a8bb2b0b (Step 2.1) and e4b809875 (Step 2.2). Step 3.1 commit f1b2d6b98 is docs-only.
+
+## Sandbox constraint (must read before interpreting this file)
+
+This run executed inside a janitor sandbox that does **not** have
+`node_modules` installed (`yarn install` was not run on the worktree).
+Running `yarn typecheck`, `yarn test`, `yarn build:packages`, `yarn lint`,
+or `yarn build:app` is therefore impossible in this environment. The same
+caveat applies to `yarn test:integration` and `yarn test:create-app:integration`.
+
+The full validation gate will run on the PR's CI. That is the source of
+truth for whether the change passes. This file documents which checks
+**should** run and what we already verified manually.
+
+## What was verified manually
+
+- **Reading the diffs end-to-end** for both Step 2.1 and Step 2.2. The
+  changes are tightly scoped — three production files plus two new test
+  files and one extension to an existing test file.
+- **TypeScript surface review**: variable renames (`all`/`paged` →
+  `rows`) and the `offset` local in Step 2.1 are scoped to the GET
+  handlers; `total` and the response shape stay identical. In Step 2.2
+  the `entities` and `profiles` consts retain their original types via
+  the `Promise.all` tuple destructuring.
+- **Query-shape review**: Step 2.1's `findAndCount` now receives
+  `{ orderBy, limit, offset }` instead of `{ orderBy }` — the orderBy
+  payload is unchanged and `findAndCount` is documented to accept
+  `limit`/`offset` in MikroORM v7. Step 2.2's two `findWithDecryption`
+  calls retain identical filter clauses, decryption scope, and
+  `populate` settings.
+- **No mutation paths touched**, so `withAtomicFlush` rules and command
+  side-effect contracts are unaffected.
+
+## Validation matrix (what CI will run)
+
+| Gate command | Expected | Status |
+|--------------|----------|--------|
+| `yarn typecheck` | passes | **deferred to CI** |
+| `yarn test` (scoped: currencies + customers) | passes including new unit tests | **deferred to CI** |
+| `yarn lint` | passes | **deferred to CI** |
+| `yarn build:packages` | passes | **deferred to CI** |
+| `yarn build:app` | passes | **deferred to CI** |
+| `yarn i18n:check-sync` | passes (no strings changed) | **deferred to CI** — no locale files modified, expected no-op |
+| `yarn i18n:check-usage` | passes (no strings changed) | **deferred to CI** — same |
+| `yarn test:integration` | passes for currencies + customers people | **deferred to CI** |
+| `yarn test:create-app:integration` | passes (no packaging touched) | **deferred to CI** — only `packages/core` modules touched, no `packages/create-app`/template changes |
+| `ds-guardian` | clean (no UI touched) | **n/a** — server-side only |
+
+## BC self-review (per `BACKWARD_COMPATIBILITY.md`)
+
+- **Step 2.1**: API request/response shapes for
+  `GET /api/currencies/currencies` and `GET /api/currencies/exchange-rates`
+  are identical (`items`, `total`, `page`, `pageSize`, `totalPages`).
+  Query parameters (`page`, `pageSize`, `sortField`, `sortDir`, filters)
+  are unchanged. SQL ordering is unchanged (same `orderBy`). When
+  `pageSize >= total`, the new code returns the same rows as the old
+  code (LIMIT/OFFSET is a no-op). No contract surface (auto-discovery
+  paths, types, signatures, import paths, event IDs, widget spot IDs,
+  API routes, DB schema, DI keys, ACL features, notification IDs, CLI
+  commands, generated files) is affected.
+- **Step 2.2**: Same input ids, same output map keys, same decryption
+  semantics. The two `findWithDecryption` calls produce the same
+  result sets they did before. Only the await ordering is changed.
+  No contract surface touched.
+- **Verdict**: 100% backward compatible. No deprecation protocol
+  required.
+
+## Code-review self-check (per `.ai/skills/code-review/SKILL.md`)
+
+- Both changes are minimal and focused.
+- Both add unit tests for the new behavior.
+- No `any` introduced.
+- No DS / Tailwind tokens involved.
+- No hardcoded user-facing strings touched.
+- No `em.findOne`/`em.find` introduced where `findWithDecryption`/`findOneWithDecryption` would be required (currencies and exchange-rates entities do not carry encrypted fields per `packages/core/src/modules/currencies/encryption.ts` review — same as the existing pattern in those files).
+- No mutation guards bypassed (no write paths touched).
+- No tenant/org scoping weakened (filter clauses preserved verbatim).
+- No `--no-verify` / hook skipping.
+
+## DS-guardian residual findings
+
+None. No UI files touched in this run.
+
+## Notes
+
+- Step 3.1 (filing 8 follow-up issues) is the documented mechanism for
+  carrying forward the remaining catalogued wins. The user-facing
+  instruction was "implement first two, create github issues for the
+  rest" and that's exactly what landed.
+- The janitor harness periodically auto-commits in-progress edits. One
+  such autosave (`741af1b01`) momentarily fragmented Step 2.1's history
+  before it was folded back into the clean Step 2.1 commit via a
+  `git reset --soft`. The final pushed history shows the intended one
+  commit per Step shape.

--- a/packages/core/src/modules/currencies/api/currencies/__tests__/list-pagination.test.ts
+++ b/packages/core/src/modules/currencies/api/currencies/__tests__/list-pagination.test.ts
@@ -1,0 +1,99 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+
+const em = {
+  findAndCount: jest.fn(),
+} as { findAndCount: jest.Mock }
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    sub: 'user-1',
+    tenantId,
+    orgId,
+  })),
+}))
+
+import { GET } from '../route'
+
+const makeRow = (i: number) => ({
+  id: `00000000-0000-4000-8000-${i.toString().padStart(12, '0')}`,
+  organizationId: orgId,
+  tenantId,
+  code: `C${i.toString().padStart(2, '0')}`,
+  name: `Currency ${i}`,
+  symbol: null,
+  decimalPlaces: 2,
+  thousandsSeparator: null,
+  decimalSeparator: null,
+  isBase: false,
+  isActive: true,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+})
+
+describe('GET /api/currencies/currencies pagination', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('pushes limit and offset to findAndCount instead of slicing in memory', async () => {
+    em.findAndCount.mockResolvedValue([[makeRow(1)], 137])
+    const res = await GET(
+      new Request('http://localhost/api/currencies/currencies?page=3&pageSize=25'),
+    )
+    expect(em.findAndCount).toHaveBeenCalledTimes(1)
+    const [entity, where, options] = em.findAndCount.mock.calls[0]
+    expect(entity).toBeDefined()
+    expect(where).toEqual(
+      expect.objectContaining({ tenantId, organizationId: orgId, deletedAt: null }),
+    )
+    expect(options).toEqual(
+      expect.objectContaining({
+        orderBy: { code: 'ASC' },
+        limit: 25,
+        offset: 50,
+      }),
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: unknown[]; total: number; page: number; pageSize: number; totalPages: number }
+    expect(body.items).toHaveLength(1)
+    expect(body.total).toBe(137)
+    expect(body.page).toBe(3)
+    expect(body.pageSize).toBe(25)
+    expect(body.totalPages).toBe(Math.ceil(137 / 25))
+  })
+
+  it('respects sortField + sortDir when passed', async () => {
+    em.findAndCount.mockResolvedValue([[], 0])
+    await GET(
+      new Request('http://localhost/api/currencies/currencies?page=1&pageSize=50&sortField=name&sortDir=desc'),
+    )
+    const options = em.findAndCount.mock.calls[0][2]
+    expect(options.orderBy).toEqual({ name: 'DESC' })
+    expect(options.limit).toBe(50)
+    expect(options.offset).toBe(0)
+  })
+
+  it('returns the rows that findAndCount produced without applying any JS slice', async () => {
+    const rows = [makeRow(1), makeRow(2), makeRow(3)]
+    em.findAndCount.mockResolvedValue([rows, 3])
+    const res = await GET(
+      new Request('http://localhost/api/currencies/currencies?page=1&pageSize=50'),
+    )
+    const body = (await res.json()) as { items: { id: string }[] }
+    expect(body.items.map((it) => it.id)).toEqual(rows.map((r) => r.id))
+  })
+})

--- a/packages/core/src/modules/currencies/api/currencies/route.ts
+++ b/packages/core/src/modules/currencies/api/currencies/route.ts
@@ -172,10 +172,9 @@ export async function GET(req: Request) {
     orderBy.code = 'ASC'
   }
 
-  const [all, total] = await em.findAndCount(Currency, filter, { orderBy })
-  const start = (page - 1) * pageSize
-  const paged = all.slice(start, start + pageSize)
-  const items = paged.map(toRow)
+  const offset = (page - 1) * pageSize
+  const [rows, total] = await em.findAndCount(Currency, filter, { orderBy, limit: pageSize, offset })
+  const items = rows.map(toRow)
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
 
   return NextResponse.json({ items, total, page, pageSize, totalPages })

--- a/packages/core/src/modules/currencies/api/exchange-rates/__tests__/list-pagination.test.ts
+++ b/packages/core/src/modules/currencies/api/exchange-rates/__tests__/list-pagination.test.ts
@@ -1,0 +1,97 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+
+const em = {
+  findAndCount: jest.fn(),
+} as { findAndCount: jest.Mock }
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    sub: 'user-1',
+    tenantId,
+    orgId,
+  })),
+}))
+
+import { GET } from '../route'
+
+const makeRate = (i: number) => ({
+  id: `00000000-0000-4000-8000-${i.toString().padStart(12, '0')}`,
+  organizationId: orgId,
+  tenantId,
+  fromCurrencyCode: 'USD',
+  toCurrencyCode: 'EUR',
+  rate: (1 + i / 100).toFixed(6),
+  date: new Date(`2026-01-${(i % 28 + 1).toString().padStart(2, '0')}T00:00:00.000Z`),
+  source: 'TEST',
+  type: null,
+  isActive: true,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+})
+
+describe('GET /api/currencies/exchange-rates pagination', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('pushes limit and offset to findAndCount instead of slicing in memory', async () => {
+    em.findAndCount.mockResolvedValue([[makeRate(1)], 5_000])
+    const res = await GET(
+      new Request('http://localhost/api/currencies/exchange-rates?page=10&pageSize=20'),
+    )
+    expect(em.findAndCount).toHaveBeenCalledTimes(1)
+    const [entity, where, options] = em.findAndCount.mock.calls[0]
+    expect(entity).toBeDefined()
+    expect(where).toEqual(
+      expect.objectContaining({ tenantId, organizationId: orgId, deletedAt: null }),
+    )
+    expect(options).toEqual(
+      expect.objectContaining({
+        orderBy: { date: 'DESC' },
+        limit: 20,
+        offset: 180,
+      }),
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: unknown[]; total: number; page: number; pageSize: number; totalPages: number }
+    expect(body.total).toBe(5_000)
+    expect(body.page).toBe(10)
+    expect(body.pageSize).toBe(20)
+    expect(body.totalPages).toBe(250)
+  })
+
+  it('respects sortField when passed', async () => {
+    em.findAndCount.mockResolvedValue([[], 0])
+    await GET(
+      new Request('http://localhost/api/currencies/exchange-rates?page=1&pageSize=50&sortField=fromCurrencyCode&sortDir=asc'),
+    )
+    const options = em.findAndCount.mock.calls[0][2]
+    expect(options.orderBy).toEqual({ fromCurrencyCode: 'ASC' })
+    expect(options.limit).toBe(50)
+    expect(options.offset).toBe(0)
+  })
+
+  it('returns the rows that findAndCount produced without applying any JS slice', async () => {
+    const rates = [makeRate(1), makeRate(2)]
+    em.findAndCount.mockResolvedValue([rates, 2])
+    const res = await GET(
+      new Request('http://localhost/api/currencies/exchange-rates?page=1&pageSize=50'),
+    )
+    const body = (await res.json()) as { items: { id: string }[] }
+    expect(body.items.map((it) => it.id)).toEqual(rates.map((r) => r.id))
+  })
+})

--- a/packages/core/src/modules/currencies/api/exchange-rates/route.ts
+++ b/packages/core/src/modules/currencies/api/exchange-rates/route.ts
@@ -169,10 +169,9 @@ export async function GET(req: Request) {
     orderBy.date = 'DESC'
   }
 
-  const [all, total] = await em.findAndCount(ExchangeRate, where, { orderBy })
-  const start = (page - 1) * pageSize
-  const paged = all.slice(start, start + pageSize)
-  const items = paged.map(toRow)
+  const offset = (page - 1) * pageSize
+  const [rows, total] = await em.findAndCount(ExchangeRate, where, { orderBy, limit: pageSize, offset })
+  const items = rows.map(toRow)
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
 
   return NextResponse.json({ items, total, page, pageSize, totalPages })

--- a/packages/core/src/modules/customers/api/people/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/people/__tests__/route.test.ts
@@ -129,4 +129,37 @@ describe('customers people route afterList hook', () => {
       company_entity_id: 'company-1',
     })
   })
+
+  it('fetches customer entities and person profiles concurrently in afterList', async () => {
+    let resolveEntities: ((value: unknown[]) => void) | null = null
+    let resolveProfiles: ((value: unknown[]) => void) | null = null
+    const entitiesPromise = new Promise<unknown[]>((resolve) => {
+      resolveEntities = resolve
+    })
+    const profilesPromise = new Promise<unknown[]>((resolve) => {
+      resolveProfiles = resolve
+    })
+    mockFindWithDecryption
+      .mockReturnValueOnce(entitiesPromise)
+      .mockReturnValueOnce(profilesPromise)
+
+    const payload = {
+      items: [{ id: 'person-1' }],
+    }
+    const em = {}
+    const ctx = {
+      auth: { tenantId: 'tenant-1', orgId: 'org-1' },
+      selectedOrganizationId: 'org-1',
+      container: { resolve: (token: string) => (token === 'em' ? em : null) },
+    }
+
+    const hookPromise = capturedCrudOptions?.hooks?.afterList?.(payload, ctx)
+    // Both findWithDecryption calls should have been initiated synchronously
+    // before either resolves — that's the proof of concurrent fetching.
+    expect(mockFindWithDecryption).toHaveBeenCalledTimes(2)
+
+    resolveProfiles?.([])
+    resolveEntities?.([])
+    await hookPromise
+  })
 })

--- a/packages/core/src/modules/customers/api/people/route.ts
+++ b/packages/core/src/modules/customers/api/people/route.ts
@@ -426,37 +426,39 @@ const crud = makeCrudRoute({
         tenantId: ctx.auth?.tenantId ?? null,
         organizationId: ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null,
       }
-      const entities = await findWithDecryption(
-        em,
-        CustomerEntity,
-        {
-          id: { $in: ids },
-          deletedAt: null,
-          kind: 'person',
-        } as FilterQuery<CustomerEntity>,
-        undefined,
-        decryptionScope,
-      )
-      const entitiesById = new Map<string, CustomerEntity>()
-      for (const entity of entities) {
-        entitiesById.set(entity.id, entity)
-      }
-
-      const where: Record<string, unknown> = {
+      const profileWhere: Record<string, unknown> = {
         entity: { $in: ids },
         tenantId: ctx.auth?.tenantId ?? null,
       }
       if (ctx.selectedOrganizationId) {
-        where.organizationId = ctx.selectedOrganizationId
+        profileWhere.organizationId = ctx.selectedOrganizationId
       }
 
-      const profiles = await findWithDecryption(
-        em,
-        CustomerPersonProfile,
-        where as FilterQuery<CustomerPersonProfile>,
-        { populate: ['entity', 'company'] },
-        decryptionScope,
-      )
+      const [entities, profiles] = await Promise.all([
+        findWithDecryption(
+          em,
+          CustomerEntity,
+          {
+            id: { $in: ids },
+            deletedAt: null,
+            kind: 'person',
+          } as FilterQuery<CustomerEntity>,
+          undefined,
+          decryptionScope,
+        ),
+        findWithDecryption(
+          em,
+          CustomerPersonProfile,
+          profileWhere as FilterQuery<CustomerPersonProfile>,
+          { populate: ['entity', 'company'] },
+          decryptionScope,
+        ),
+      ])
+
+      const entitiesById = new Map<string, CustomerEntity>()
+      for (const entity of entities) {
+        entitiesById.set(entity.id, entity)
+      }
 
       const profilesByEntityId = new Map<string, CustomerPersonProfile>()
       for (const profile of profiles) {


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md
Tracking run folder: .ai/runs/2026-05-27-crud-sql-query-optimizations/
Status: complete

## Goal

Analyze SQL queries used by CRUD APIs across modules (CRM/customers, sales, catalog, staff, resource, workflows, plus others). Land the top two 100%-backward-compatible quick wins. File GitHub issues for the rest so the team can pick them up incrementally.

## What Changed

- **Step 2.1 — `perf(currencies)`** at `4a8bb2b0b`: `GET /api/currencies/currencies` and `GET /api/currencies/exchange-rates` were calling `em.findAndCount(Entity, where, { orderBy })` without `limit`/`offset` and then slicing the result array in JavaScript. On tables with thousands of rows that loaded the entire table into memory on every list request. Push `limit: pageSize` and `offset: (page - 1) * pageSize` into the `findAndCount` options. Behavior is bit-identical when `total <= pageSize`; on larger tables the request now scales correctly. Unit tests added for both routes.
- **Step 2.2 — `perf(customers)`** at `e4b809875`: the `afterList` hook on the customers people list was awaiting `findWithDecryption(CustomerEntity, ...)` then `findWithDecryption(CustomerPersonProfile, ...)` sequentially. The two queries are independent — both keyed off the same set of page ids — so the second always waited for the first round-trip needlessly. Wrap both in `Promise.all([...])`. Filter clauses, decryption scope, populate options, and downstream Map-building are unchanged — only await ordering changes. A new test gates each fetch behind a deferred promise to prove they initiate concurrently.
- **Step 3.1 — issues filed** at `f1b2d6b98`: 8 follow-up issues for the remaining catalogued quick wins (C–J in the plan).

## External References

None. No `--skill-url` arguments were supplied. All guidance taken from in-repo AGENTS.md files.

## Follow-up issues filed for the rest

| Finding | Issue |
|---------|-------|
| C — sales shipments DictionaryEntry parallelize | #2131 |
| D — QueryEngine gate `cf:*` joins | #2132 |
| E — thread CF def index through QueryEngine | #2133 |
| F — sales shipments orderLines batching | #2134 |
| G — makeCrudRoute cache-tag loop flatten | #2135 |
| H — audit `em.findAndCount` callers | #2136 |
| I — customers activities decorator parallelize | #2137 |
| J — auth roles ACL parallelize | #2138 |

## Tests

- `packages/core/src/modules/currencies/api/currencies/__tests__/list-pagination.test.ts` — 3 cases asserting `limit`/`offset`/`orderBy` reach `findAndCount` correctly across default sort, custom sort, and direct row return.
- `packages/core/src/modules/currencies/api/exchange-rates/__tests__/list-pagination.test.ts` — 3 cases mirroring the same coverage for exchange rates (including a 5000-row scenario where the JS slice would have been catastrophic).
- `packages/core/src/modules/customers/api/people/__tests__/route.test.ts` — extended with a deferred-promise concurrency test that asserts both `findWithDecryption` calls are initiated before either resolves.

## Backward Compatibility

Both changes are 100% backward compatible.

- Step 2.1 keeps `items`, `total`, `page`, `pageSize`, `totalPages` semantics identical. `orderBy` is unchanged. Same query parameters, same response shape. No contract surface (auto-discovery, types, signatures, import paths, event IDs, widget spot IDs, API routes, DB schema, DI keys, ACL features, notification IDs, CLI commands, generated files) is affected.
- Step 2.2 keeps the same filter clauses, decryption scope, populate options, and Map-building. Only the await ordering changes. No contract surface touched.

## Sandbox caveat

This PR was authored inside the janitor sandbox, which does not install `node_modules`. The full validation gate (`yarn typecheck`, `yarn test`, `yarn lint`, `yarn build:packages`, `yarn build:app`, `yarn i18n:check-*`, `yarn test:integration`, `yarn test:create-app:integration`) is therefore deferred to this PR's CI. The diff has been read end-to-end, manually code-reviewed, and BC-self-reviewed; results are recorded in `.ai/runs/2026-05-27-crud-sql-query-optimizations/final-gate-checks.md`. Same caveat as #2102 / #2130.

## Progress

See the [Tasks table in the plan](.ai/runs/2026-05-27-crud-sql-query-optimizations/PLAN.md#tasks) — all rows are `done`.

## Handoff & Notifications

- Live handoff: `.ai/runs/2026-05-27-crud-sql-query-optimizations/HANDOFF.md`
- Notifications log: `.ai/runs/2026-05-27-crud-sql-query-optimizations/NOTIFY.md`