### PR TITLE
test(attachments): add integration tests for cross-tenant access (TC-ATTACH-XSS-001-005)

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,8 +169,8 @@
     "typescript": "^6.0.3"
   },
   "resolutions": {
-    "tmp": "0.2.7",
     "@xmldom/xmldom": "0.8.13",
+    "tmp": "0.2.6",
     "@hono/node-server": "1.19.14",
     "hono": "4.12.14",
     "pg": "8.21.0",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
   },
   "resolutions": {
     "@xmldom/xmldom": "0.8.13",
-    "tmp": "0.2.6",
+    "tmp": "0.2.7",
     "@hono/node-server": "1.19.14",
     "hono": "4.12.14",
     "pg": "8.21.0",

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-001.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-001.spec.ts
@@ -2,14 +2,13 @@ import { test } from "@playwright/test";
 
 test.describe("TC-ATTACH-XSS-001: Partial-null org — same-tenant cross-org access to private attachment", () => {
   test("should return 404 when a user in tenant T1 / org B reads an attachment seeded in tenant T1 with organization_id = NULL", async () => {
-    // Requires seeding an attachment with organization_id = NULL via the standard API, which is not
-    // supported in the current integration environment - there is no fixture or API parameter
-    // that produces a tenant-scoped but org-null attachment row.
+    // Requires seeding an attachment with organization_id = NULL via the standard API.
+    // There is no fixture or API parameter that produces a tenant-scoped but org-null
+    // attachment row in the current integration environment.
     // The isSameScope() partial-null path is covered at the unit level in:
-    //   - packages/core/src/modules/auth/lib/__tests__/ (PR #2107)
-    // and the query-layer defence-in-depth for this case is covered in:
-    //   packages/core/src/modules/attachments/api/__tests__/file.route.test.ts (PR #2124)
-    test.skip(
+    //   - packages/core/src/modules/attachments/lib/__tests__/access.test.ts
+    //     ("checkAttachmentAccess — partial-null scope fail-closed", lines 74-132)
+    test.fixme(
       true,
       "Requires a fixture that seeds an attachment with organization_id = NULL; not available in the standard integration environment",
     );

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-001.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-001.spec.ts
@@ -1,7 +1,7 @@
-import { test } from "@playwright/test";
+import { test } from '@playwright/test'
 
-test.describe("TC-ATTACH-XSS-001: Partial-null org — same-tenant cross-org access to private attachment", () => {
-  test("should return 404 when a user in tenant T1 / org B reads an attachment seeded in tenant T1 with organization_id = NULL", async () => {
+test.describe('TC-ATTACH-XSS-001: Partial-null org — same-tenant cross-org access to private attachment', () => {
+  test('should return 404 when a user in tenant T1 / org B reads an attachment seeded in tenant T1 with organization_id = NULL', async () => {
     // Requires seeding an attachment with organization_id = NULL via the standard API.
     // There is no fixture or API parameter that produces a tenant-scoped but org-null
     // attachment row in the current integration environment.
@@ -10,7 +10,7 @@ test.describe("TC-ATTACH-XSS-001: Partial-null org — same-tenant cross-org acc
     //     ("checkAttachmentAccess — partial-null scope fail-closed", lines 74-132)
     test.fixme(
       true,
-      "Requires a fixture that seeds an attachment with organization_id = NULL; not available in the standard integration environment",
-    );
-  });
-});
+      'Requires a fixture that seeds an attachment with organization_id = NULL; not available in the standard integration environment',
+    )
+  })
+})

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-001.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-001.spec.ts
@@ -1,0 +1,17 @@
+import { test } from "@playwright/test";
+
+test.describe("TC-ATTACH-XSS-001: Partial-null org — same-tenant cross-org access to private attachment", () => {
+  test("should return 404 when a user in tenant T1 / org B reads an attachment seeded in tenant T1 with organization_id = NULL", async () => {
+    // Requires seeding an attachment with organization_id = NULL via the standard API, which is not
+    // supported in the current integration environment - there is no fixture or API parameter
+    // that produces a tenant-scoped but org-null attachment row.
+    // The isSameScope() partial-null path is covered at the unit level in:
+    //   - packages/core/src/modules/auth/lib/__tests__/ (PR #2107)
+    // and the query-layer defence-in-depth for this case is covered in:
+    //   packages/core/src/modules/attachments/api/__tests__/file.route.test.ts (PR #2124)
+    test.skip(
+      true,
+      "Requires a fixture that seeds an attachment with organization_id = NULL; not available in the standard integration environment",
+    );
+  });
+});

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-002.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-002.spec.ts
@@ -1,14 +1,14 @@
-import { test } from "@playwright/test";
+import { test } from '@playwright/test'
 
-test.describe("TC-ATTACH-XSS-002: Cross-tenant access to private attachment via file route", () => {
-  test("should return 404 when an authenticated user from tenant T2 reads a private attachment from tenant T1", async () => {
+test.describe('TC-ATTACH-XSS-002: Cross-tenant access to private attachment via file route', () => {
+  test('should return 404 when an authenticated user from tenant T2 reads a private attachment from tenant T1', async () => {
     // Requires two isolated tenants in the integration environment.
     // The equivalent behaviour is verified at the unit level in:
     //   - packages/core/src/modules/attachments/api/__tests__/file.route.test.ts
     //     (asserts em.findOne receives tenantId filter and checkAttachmentAccess is never called)
     test.fixme(
       true,
-      "Requires multi-tenant integration environment; not available in the standard integration environment",
-    );
-  });
-});
+      'Requires multi-tenant integration environment; not available in the standard integration environment',
+    )
+  })
+})

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-002.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-002.spec.ts
@@ -1,0 +1,13 @@
+import { test } from "@playwright/test";
+
+test.describe("TC-ATTACH-XSS-002: Cross-tenant access to private attachment via file route", () => {
+  test("should return 404 when an authenticated user from another tenant reads a private attachment", async () => {
+    // Cross-tenant scenarios require isolated tenants in the integration environment.
+    // The equivalent behaviour is verified at the unit level in:
+    //   - packages/core/src/modules/attachments/api/__tests__/file.route.test.ts
+    test.skip(
+      true,
+      "Requires multi-tenant integration environment; covered by file.route.test.ts unit tests",
+    );
+  });
+});

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-002.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-002.spec.ts
@@ -61,7 +61,7 @@ test.describe('TC-ATTACH-XSS-002: Cross-tenant access to private attachment via 
         email: t2UserEmail,
         password: 'Valid1!Pass',
         organizationId: t2OrgId,
-        roles: ['employee'],
+        roles: [],
       })
 
       // Admin (T1) uploads a private attachment — stored with tenantId = T1.

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-002.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-002.spec.ts
@@ -1,13 +1,14 @@
 import { test } from "@playwright/test";
 
 test.describe("TC-ATTACH-XSS-002: Cross-tenant access to private attachment via file route", () => {
-  test("should return 404 when an authenticated user from another tenant reads a private attachment", async () => {
-    // Cross-tenant scenarios require isolated tenants in the integration environment.
+  test("should return 404 when an authenticated user from tenant T2 reads a private attachment from tenant T1", async () => {
+    // Requires two isolated tenants in the integration environment.
     // The equivalent behaviour is verified at the unit level in:
     //   - packages/core/src/modules/attachments/api/__tests__/file.route.test.ts
-    test.skip(
+    //     (asserts em.findOne receives tenantId filter and checkAttachmentAccess is never called)
+    test.fixme(
       true,
-      "Requires multi-tenant integration environment; covered by file.route.test.ts unit tests",
+      "Requires multi-tenant integration environment; not available in the standard integration environment",
     );
   });
 });

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-002.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-002.spec.ts
@@ -1,14 +1,95 @@
-import { test } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  deleteGeneralEntityIfExists,
+  expectId,
+  readJsonSafe,
+} from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import {
+  createUserFixture,
+  deleteUserIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import {
+  deleteAttachmentIfExists,
+  uploadAttachmentFixture,
+} from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
+
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
 
 test.describe('TC-ATTACH-XSS-002: Cross-tenant access to private attachment via file route', () => {
-  test('should return 404 when an authenticated user from tenant T2 reads a private attachment from tenant T1', async () => {
-    // Requires two isolated tenants in the integration environment.
-    // The equivalent behaviour is verified at the unit level in:
-    //   - packages/core/src/modules/attachments/api/__tests__/file.route.test.ts
-    //     (asserts em.findOne receives tenantId filter and checkAttachmentAccess is never called)
-    test.fixme(
-      true,
-      'Requires multi-tenant integration environment; not available in the standard integration environment',
-    )
+  test('should return 404 when an authenticated user from tenant T2 reads a private attachment from tenant T1', async ({
+    request,
+  }) => {
+    const superadminToken = await getAuthToken(request, 'superadmin')
+    const adminToken = await getAuthToken(request, 'admin')
+
+    const stamp = Date.now()
+    const t2UserEmail = `qa-xss-002-t2-${stamp}@test.invalid`
+    const recordId = `qa-xss-002-${stamp}`
+
+    let t2TenantId: string | null = null
+    let t2OrgId: string | null = null
+    let t2UserId: string | null = null
+    let attachmentId: string | null = null
+
+    try {
+      // Create a second tenant T2 — POST /api/directory/tenants is available in the
+      // integration environment (pattern established by TC-AUTH-041).
+      const tenantRes = await apiRequest(request, 'POST', '/api/directory/tenants', {
+        token: superadminToken,
+        data: { name: `qa-xss-002-tenant-${stamp}` },
+      })
+      expect(tenantRes.status()).toBe(201)
+      t2TenantId = expectId(
+        (await readJsonSafe<{ id?: string }>(tenantRes))?.id,
+        'tenant create should return id',
+      )
+
+      // Create an org in T2 — tenantId in the body routes the org to T2.
+      const orgRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+        token: superadminToken,
+        data: { tenantId: t2TenantId, name: `qa-xss-002-org-${stamp}` },
+      })
+      expect(orgRes.status()).toBe(201)
+      t2OrgId = expectId(
+        (await readJsonSafe<{ id?: string }>(orgRes))?.id,
+        'org create should return id',
+      )
+
+      // Create a user in T2 — their JWT will carry T2's tenantId.
+      t2UserId = await createUserFixture(request, superadminToken, {
+        email: t2UserEmail,
+        password: 'Valid1!Pass',
+        organizationId: t2OrgId,
+        roles: ['employee'],
+      })
+
+      // Admin (T1) uploads a private attachment — stored with tenantId = T1.
+      const uploaded = await uploadAttachmentFixture(request, adminToken, {
+        entityId: 'attachments:library',
+        recordId,
+        fileName: 'xss-002.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('cross-tenant isolation test', 'utf8'),
+      })
+      attachmentId = uploaded.id
+
+      // T2 user's JWT carries T2's tenantId. The file route adds
+      // tenantId = T2 to em.findOne, so the T1 attachment row is never returned → 404.
+      const t2UserToken = await getAuthToken(request, t2UserEmail, 'Valid1!Pass')
+      const response = await request.fetch(
+        `${BASE_URL}/api/attachments/file/${encodeURIComponent(attachmentId)}`,
+        {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${t2UserToken}` },
+        },
+      )
+      expect(response.status()).toBe(404)
+    } finally {
+      await deleteAttachmentIfExists(request, superadminToken, attachmentId)
+      await deleteUserIfExists(request, superadminToken, t2UserId)
+      await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/organizations', t2OrgId)
+      await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/tenants', t2TenantId)
+    }
   })
 })

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-003.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-003.spec.ts
@@ -1,45 +1,45 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from '@playwright/test'
 import {
   apiRequest,
   getAuthToken,
-} from "@open-mercato/core/modules/core/__integration__/helpers/api";
+} from '@open-mercato/core/modules/core/__integration__/helpers/api'
 import {
   expectId,
   getTokenScope,
   readJsonSafe,
-} from "@open-mercato/core/modules/core/__integration__/helpers/generalFixtures";
+} from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
 import {
   createUserFixture,
   deleteUserIfExists,
-} from "@open-mercato/core/modules/core/__integration__/helpers/authFixtures";
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
 import {
   deleteAttachmentIfExists,
   uploadAttachmentFixture,
-} from "@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures";
+} from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
 
-const BASE_URL = process.env.BASE_URL?.trim() || "http://localhost:3000";
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
 
-test.describe("TC-ATTACH-XSS-003: Cross-org access to private attachment within the same tenant", () => {
-  test("should return 404 when an authenticated user from org B reads a private attachment uploaded by org A in the same tenant", async ({
+test.describe('TC-ATTACH-XSS-003: Cross-org access to private attachment within the same tenant', () => {
+  test('should return 404 when an authenticated user from org B reads a private attachment uploaded by org A in the same tenant', async ({
     request,
   }) => {
-    const superadminToken = await getAuthToken(request, "superadmin");
-    const adminToken = await getAuthToken(request, "admin");
-    const { tenantId: adminTenantId } = getTokenScope(adminToken);
+    const superadminToken = await getAuthToken(request, 'superadmin')
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId: adminTenantId } = getTokenScope(adminToken)
 
-    const crossOrgUserEmail = `qa-xss-003-${Date.now()}@test.invalid`;
-    const recordId = `qa-xss-003-${Date.now()}`;
+    const crossOrgUserEmail = `qa-xss-003-${Date.now()}@test.invalid`
+    const recordId = `qa-xss-003-${Date.now()}`
 
-    let crossOrgId: string | null = null;
-    let crossOrgUserId: string | null = null;
-    let attachmentId: string | null = null;
+    let crossOrgId: string | null = null
+    let crossOrgUserId: string | null = null
+    let attachmentId: string | null = null
 
     try {
       // Create a second org in the same tenant as admin
       const orgResponse = await apiRequest(
         request,
-        "POST",
-        "/api/directory/organizations",
+        'POST',
+        '/api/directory/organizations',
         {
           token: superadminToken,
           data: {
@@ -47,28 +47,28 @@ test.describe("TC-ATTACH-XSS-003: Cross-org access to private attachment within 
             name: `qa-xss-003-org-${Date.now()}`,
           },
         },
-      );
-      expect(orgResponse.status()).toBe(201);
-      const orgBody = await readJsonSafe<{ id?: string }>(orgResponse);
-      crossOrgId = expectId(orgBody?.id, "org create should return id");
+      )
+      expect(orgResponse.status()).toBe(201)
+      const orgBody = await readJsonSafe<{ id?: string }>(orgResponse)
+      crossOrgId = expectId(orgBody?.id, 'org create should return id')
 
       // Create a user in the second org
       crossOrgUserId = await createUserFixture(request, superadminToken, {
         email: crossOrgUserEmail,
-        password: "Valid1!Pass",
+        password: 'Valid1!Pass',
         organizationId: crossOrgId,
-        roles: ["employee"],
-      });
+        roles: ['employee'],
+      })
 
       // Admin (org A) uploads a private attachment
       const uploaded = await uploadAttachmentFixture(request, adminToken, {
-        entityId: "attachments:library",
+        entityId: 'attachments:library',
         recordId,
-        fileName: "xss-003.txt",
-        mimeType: "text/plain",
-        buffer: Buffer.from("cross-org isolation test", "utf8"),
-      });
-      attachmentId = uploaded.id;
+        fileName: 'xss-003.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('cross-org isolation test', 'utf8'),
+      })
+      attachmentId = uploaded.id
 
       // Cross-org user (org B, same tenant) tries to access the attachment.
       // Returns 404 via query-layer scoping added in #2124 —
@@ -76,27 +76,27 @@ test.describe("TC-ATTACH-XSS-003: Cross-org access to private attachment within 
       const crossOrgUserToken = await getAuthToken(
         request,
         crossOrgUserEmail,
-        "Valid1!Pass",
-      );
+        'Valid1!Pass',
+      )
       const response = await request.fetch(
         `${BASE_URL}/api/attachments/file/${encodeURIComponent(attachmentId)}`,
         {
-          method: "GET",
+          method: 'GET',
           headers: { Authorization: `Bearer ${crossOrgUserToken}` },
         },
-      );
-      expect(response.status()).toBe(404);
+      )
+      expect(response.status()).toBe(404)
     } finally {
-      await deleteAttachmentIfExists(request, adminToken, attachmentId);
-      await deleteUserIfExists(request, superadminToken, crossOrgUserId);
+      await deleteAttachmentIfExists(request, adminToken, attachmentId)
+      await deleteUserIfExists(request, superadminToken, crossOrgUserId)
       if (crossOrgId) {
         await apiRequest(
           request,
-          "DELETE",
+          'DELETE',
           `/api/directory/organizations?id=${encodeURIComponent(crossOrgId)}`,
           { token: superadminToken },
-        ).catch(() => undefined);
+        ).catch(() => undefined)
       }
     }
-  });
-});
+  })
+})

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-003.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-003.spec.ts
@@ -1,13 +1,102 @@
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import {
+  apiRequest,
+  getAuthToken,
+} from "@open-mercato/core/modules/core/__integration__/helpers/api";
+import {
+  expectId,
+  getTokenScope,
+  readJsonSafe,
+} from "@open-mercato/core/modules/core/__integration__/helpers/generalFixtures";
+import {
+  createUserFixture,
+  deleteUserIfExists,
+} from "@open-mercato/core/modules/core/__integration__/helpers/authFixtures";
+import {
+  deleteAttachmentIfExists,
+  uploadAttachmentFixture,
+} from "@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures";
+
+const BASE_URL = process.env.BASE_URL?.trim() || "http://localhost:3000";
 
 test.describe("TC-ATTACH-XSS-003: Cross-org access to private attachment within the same tenant", () => {
-  test("should return 404 when an authenticated user from a different org reads a private attachment", async () => {
-    // Cross-organisation scenarios require multiple orgs within one tenant in the integration environment.
-    // The equivalent behaviour is verified at the unit level in:
-    //   - packages/core/src/modules/attachments/api/__tests__/file.route.test.ts
-    test.skip(
-      true,
-      "Requires multi-org integration environment; covered by file.route.test.ts unit tests",
-    );
+  test("should return 404 when an authenticated user from org B reads a private attachment uploaded by org A in the same tenant", async ({
+    request,
+  }) => {
+    const superadminToken = await getAuthToken(request, "superadmin");
+    const adminToken = await getAuthToken(request, "admin");
+    const { tenantId: adminTenantId } = getTokenScope(adminToken);
+
+    const crossOrgUserEmail = `qa-xss-003-${Date.now()}@test.invalid`;
+    const recordId = `qa-xss-003-${Date.now()}`;
+
+    let crossOrgId: string | null = null;
+    let crossOrgUserId: string | null = null;
+    let attachmentId: string | null = null;
+
+    try {
+      // Create a second org in the same tenant as admin
+      const orgResponse = await apiRequest(
+        request,
+        "POST",
+        "/api/directory/organizations",
+        {
+          token: superadminToken,
+          data: {
+            tenantId: adminTenantId,
+            name: `qa-xss-003-org-${Date.now()}`,
+          },
+        },
+      );
+      expect(orgResponse.status()).toBe(201);
+      const orgBody = await readJsonSafe<{ id?: string }>(orgResponse);
+      crossOrgId = expectId(orgBody?.id, "org create should return id");
+
+      // Create a user in the second org
+      crossOrgUserId = await createUserFixture(request, superadminToken, {
+        email: crossOrgUserEmail,
+        password: "Valid1!Pass",
+        organizationId: crossOrgId,
+        roles: ["employee"],
+      });
+
+      // Admin (org A) uploads a private attachment
+      const uploaded = await uploadAttachmentFixture(request, adminToken, {
+        entityId: "attachments:library",
+        recordId,
+        fileName: "xss-003.txt",
+        mimeType: "text/plain",
+        buffer: Buffer.from("cross-org isolation test", "utf8"),
+      });
+      attachmentId = uploaded.id;
+
+      // Cross-org user (org B, same tenant) tries to access the attachment.
+      // Returns 404 via query-layer scoping added in #2124 —
+      // em.findOne filters by organizationId so the row is never returned.
+      const crossOrgUserToken = await getAuthToken(
+        request,
+        crossOrgUserEmail,
+        "Valid1!Pass",
+      );
+      const response = await request.fetch(
+        `${BASE_URL}/api/attachments/file/${encodeURIComponent(attachmentId)}`,
+        {
+          method: "GET",
+          headers: { Authorization: `Bearer ${crossOrgUserToken}` },
+        },
+      );
+      expect(response.status()).toBe(404);
+    } finally {
+      await deleteAttachmentIfExists(request, adminToken, attachmentId);
+      await deleteUserIfExists(request, superadminToken, crossOrgUserId);
+      if (crossOrgId) {
+        await apiRequest(
+          request,
+          "DELETE",
+          `/api/directory/organizations?id=${encodeURIComponent(crossOrgId)}`,
+          { token: superadminToken },
+        ).catch(() => undefined);
+      }
+    }
   });
 });

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-003.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-003.spec.ts
@@ -1,0 +1,13 @@
+import { test } from "@playwright/test";
+
+test.describe("TC-ATTACH-XSS-003: Cross-org access to private attachment within the same tenant", () => {
+  test("should return 404 when an authenticated user from a different org reads a private attachment", async () => {
+    // Cross-organisation scenarios require multiple orgs within one tenant in the integration environment.
+    // The equivalent behaviour is verified at the unit level in:
+    //   - packages/core/src/modules/attachments/api/__tests__/file.route.test.ts
+    test.skip(
+      true,
+      "Requires multi-org integration environment; covered by file.route.test.ts unit tests",
+    );
+  });
+});

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-004.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-004.spec.ts
@@ -1,5 +1,11 @@
 import { expect, test } from '@playwright/test'
-import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  expectId,
+  getTokenScope,
+  readJsonSafe,
+} from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { createUserFixture, deleteUserIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
 import {
   deleteAttachmentIfExists,
   uploadAttachmentFixture,
@@ -8,32 +14,76 @@ import {
 const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
 
 test.describe('TC-ATTACH-XSS-004: Super-admin access to any private attachment', () => {
-  test('should return 200 when a super-admin reads a private attachment from any tenant', async ({ request }) => {
+  test('should return 200 and serve the correct file when a super-admin reads an attachment that is blocked for cross-org users', async ({ request }) => {
+    const superadminToken = await getAuthToken(request, 'superadmin')
     const adminToken = await getAuthToken(request, 'admin')
-    const superAdminToken = await getAuthToken(request, 'superadmin')
+    const { tenantId: adminTenantId } = getTokenScope(adminToken)
+
+    const crossOrgUserEmail = `qa-xss-004-${Date.now()}@test.invalid`
     const recordId = `qa-xss-004-${Date.now()}`
+    const fileContent = 'super-admin bypass test'
+
+    let crossOrgId: string | null = null
+    let crossOrgUserId: string | null = null
     let attachmentId: string | null = null
 
     try {
+      // Create a second org so we can prove the org filter is active for regular users
+      // but bypassed for super-admin via isSuperAdminAuth() in the route.
+      const orgResponse = await apiRequest(request, 'POST', '/api/directory/organizations', {
+        token: superadminToken,
+        data: { tenantId: adminTenantId, name: `qa-xss-004-org-${Date.now()}` },
+      })
+      expect(orgResponse.status()).toBe(201)
+      const orgBody = await readJsonSafe<{ id?: string }>(orgResponse)
+      crossOrgId = expectId(orgBody?.id, 'org create should return id')
+
+      crossOrgUserId = await createUserFixture(request, superadminToken, {
+        email: crossOrgUserEmail,
+        password: 'Valid1!Pass',
+        organizationId: crossOrgId,
+        roles: ['employee'],
+      })
+
+      // Admin (org A) uploads a private attachment
       const uploaded = await uploadAttachmentFixture(request, adminToken, {
         entityId: 'attachments:library',
         recordId,
         fileName: 'xss-004.txt',
         mimeType: 'text/plain',
-        buffer: Buffer.from('super-admin bypass test', 'utf8'),
+        buffer: Buffer.from(fileContent, 'utf8'),
       })
       attachmentId = uploaded.id
 
-      const response = await request.fetch(
+      // Cross-org user (org B) is blocked — confirms the org filter is active
+      const crossOrgUserToken = await getAuthToken(request, crossOrgUserEmail, 'Valid1!Pass')
+      const blockedResponse = await request.fetch(
         `${BASE_URL}/api/attachments/file/${encodeURIComponent(attachmentId)}`,
-        {
-          method: 'GET',
-          headers: { Authorization: `Bearer ${superAdminToken}` },
-        },
+        { method: 'GET', headers: { Authorization: `Bearer ${crossOrgUserToken}` } },
       )
-      expect(response.status()).toBe(200)
+      expect(blockedResponse.status()).toBe(404)
+
+      // Super-admin bypasses the org filter: isSuperAdminAuth() returns true so the
+      // route skips adding tenantId/organizationId to em.findOne (route.ts lines 42-45).
+      const superadminResponse = await request.fetch(
+        `${BASE_URL}/api/attachments/file/${encodeURIComponent(attachmentId)}`,
+        { method: 'GET', headers: { Authorization: `Bearer ${superadminToken}` } },
+      )
+      expect(superadminResponse.status()).toBe(200)
+      expect(superadminResponse.headers()['content-type']).toContain('application/octet-stream')
+      const body = await superadminResponse.text()
+      expect(body).toBe(fileContent)
     } finally {
       await deleteAttachmentIfExists(request, adminToken, attachmentId)
+      await deleteUserIfExists(request, superadminToken, crossOrgUserId)
+      if (crossOrgId) {
+        await apiRequest(
+          request,
+          'DELETE',
+          `/api/directory/organizations?id=${encodeURIComponent(crossOrgId)}`,
+          { token: superadminToken },
+        ).catch(() => undefined)
+      }
     }
   })
 })

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-004.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-004.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  deleteAttachmentIfExists,
+  uploadAttachmentFixture,
+} from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
+
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
+
+test.describe('TC-ATTACH-XSS-004: Super-admin access to any private attachment', () => {
+  test('should return 200 when a super-admin reads a private attachment from any tenant', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const superAdminToken = await getAuthToken(request, 'superadmin')
+    const recordId = `qa-xss-004-${Date.now()}`
+    let attachmentId: string | null = null
+
+    try {
+      const uploaded = await uploadAttachmentFixture(request, adminToken, {
+        entityId: 'attachments:library',
+        recordId,
+        fileName: 'xss-004.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('super-admin bypass test', 'utf8'),
+      })
+      attachmentId = uploaded.id
+
+      const response = await request.fetch(
+        `${BASE_URL}/api/attachments/file/${encodeURIComponent(attachmentId)}`,
+        {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${superAdminToken}` },
+        },
+      )
+      expect(response.status()).toBe(200)
+    } finally {
+      await deleteAttachmentIfExists(request, adminToken, attachmentId)
+    }
+  })
+})

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-004.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-004.spec.ts
@@ -3,6 +3,7 @@ import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__inte
 import {
   deleteGeneralEntityIfExists,
   expectId,
+  getTokenScope,
   readJsonSafe,
 } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
 import {
@@ -17,26 +18,50 @@ import {
 const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
 
 test.describe('TC-ATTACH-XSS-004: Super-admin access to any private attachment', () => {
-  test('should return 200 when a super-admin reads a private attachment uploaded in a different tenant', async ({
+  test('should return 200 for super-admin while cross-org and cross-tenant users are blocked', async ({
     request,
   }) => {
     const superadminToken = await getAuthToken(request, 'superadmin')
     const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId: adminTenantId } = getTokenScope(adminToken)
 
     const stamp = Date.now()
-    const t2AdminEmail = `qa-xss-004-t2-${stamp}@test.invalid`
+    const crossOrgUserEmail = `qa-xss-004-org-${stamp}@test.invalid`
+    const t2UserEmail = `qa-xss-004-t2-${stamp}@test.invalid`
     const recordId = `qa-xss-004-${stamp}`
-    const fileContent = 'super-admin cross-tenant bypass test'
+    const fileContent = 'super-admin bypass test'
 
+    let crossOrgId: string | null = null
+    let crossOrgUserId: string | null = null
     let t2TenantId: string | null = null
     let t2OrgId: string | null = null
-    let t2AdminId: string | null = null
+    let t2UserId: string | null = null
     let attachmentId: string | null = null
 
     try {
-      // Create tenant T2 so the attachment is owned by a different tenant than the
-      // global super-admin's own tenant. This proves the bypass operates at the tenant
-      // boundary, not just the org boundary.
+      // Create a second org in T1 so we can prove the org filter is active.
+      const orgRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+        token: superadminToken,
+        data: { tenantId: adminTenantId, name: `qa-xss-004-org-${stamp}` },
+      })
+      expect(orgRes.status()).toBe(201)
+      crossOrgId = expectId(
+        (await readJsonSafe<{ id?: string }>(orgRes))?.id,
+        'org create should return id',
+      )
+
+      // T1/orgB employee — used to prove the org filter blocks within the same tenant.
+      // Roles are assignable here because T1 is the primary seeded tenant.
+      crossOrgUserId = await createUserFixture(request, superadminToken, {
+        email: crossOrgUserEmail,
+        password: 'Valid1!Pass',
+        organizationId: crossOrgId,
+        roles: ['employee'],
+      })
+
+      // Create T2 tenant and a user inside it to prove the tenant filter is also active.
+      // T2 user is created without roles because freshly created tenants do not have
+      // roles seeded — an authenticated JWT with T2's tenantId is all we need here.
       const tenantRes = await apiRequest(request, 'POST', '/api/directory/tenants', {
         token: superadminToken,
         data: { name: `qa-xss-004-tenant-${stamp}` },
@@ -47,27 +72,25 @@ test.describe('TC-ATTACH-XSS-004: Super-admin access to any private attachment',
         'tenant create should return id',
       )
 
-      const orgRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      const t2OrgRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
         token: superadminToken,
-        data: { tenantId: t2TenantId, name: `qa-xss-004-org-${stamp}` },
+        data: { tenantId: t2TenantId, name: `qa-xss-004-t2-org-${stamp}` },
       })
-      expect(orgRes.status()).toBe(201)
+      expect(t2OrgRes.status()).toBe(201)
       t2OrgId = expectId(
-        (await readJsonSafe<{ id?: string }>(orgRes))?.id,
-        'org create should return id',
+        (await readJsonSafe<{ id?: string }>(t2OrgRes))?.id,
+        't2 org create should return id',
       )
 
-      // Create a T2 admin to upload the attachment — their JWT carries T2's tenantId,
-      // so the resulting attachment row is stored with tenantId = T2.
-      t2AdminId = await createUserFixture(request, superadminToken, {
-        email: t2AdminEmail,
+      t2UserId = await createUserFixture(request, superadminToken, {
+        email: t2UserEmail,
         password: 'Valid1!Pass',
         organizationId: t2OrgId,
-        roles: ['admin'],
+        roles: [],
       })
 
-      const t2AdminToken = await getAuthToken(request, t2AdminEmail, 'Valid1!Pass')
-      const uploaded = await uploadAttachmentFixture(request, t2AdminToken, {
+      // Admin (T1/orgA) uploads a private attachment — stored with tenantId = T1, orgId = orgA.
+      const uploaded = await uploadAttachmentFixture(request, adminToken, {
         entityId: 'attachments:library',
         recordId,
         fileName: 'xss-004.txt',
@@ -76,16 +99,28 @@ test.describe('TC-ATTACH-XSS-004: Super-admin access to any private attachment',
       })
       attachmentId = uploaded.id
 
-      // T1 admin (different tenant) is blocked — confirms the tenant filter is active.
-      // em.findOne({ id, tenantId: T1 }) returns null because the attachment is in T2.
-      const blockedResponse = await request.fetch(
+      // T1/orgB user is blocked — confirms the organizationId filter is active.
+      const crossOrgUserToken = await getAuthToken(request, crossOrgUserEmail, 'Valid1!Pass')
+      const crossOrgResponse = await request.fetch(
         `${BASE_URL}/api/attachments/file/${encodeURIComponent(attachmentId)}`,
-        { method: 'GET', headers: { Authorization: `Bearer ${adminToken}` } },
+        { method: 'GET', headers: { Authorization: `Bearer ${crossOrgUserToken}` } },
       )
-      expect(blockedResponse.status()).toBe(404)
+      expect(crossOrgResponse.status()).toBe(404)
 
-      // Global super-admin bypasses via isSuperAdminAuth() — em.findOne receives no
-      // tenantId/organizationId constraint, so the T2 row is found and served.
+      // T2 user is blocked — confirms the tenantId filter is active.
+      const t2UserToken = await getAuthToken(request, t2UserEmail, 'Valid1!Pass')
+      const crossTenantResponse = await request.fetch(
+        `${BASE_URL}/api/attachments/file/${encodeURIComponent(attachmentId)}`,
+        { method: 'GET', headers: { Authorization: `Bearer ${t2UserToken}` } },
+      )
+      expect(crossTenantResponse.status()).toBe(404)
+
+      // Super-admin bypasses both filters via isSuperAdminAuth() — em.findOne receives
+      // no tenantId/organizationId constraint. The org-level bypass is directly guarded
+      // above; the tenant-level bypass is covered at the unit level in
+      // packages/core/src/modules/attachments/lib/__tests__/access.test.ts because
+      // freshly created T2 tenants lack seeded roles, preventing uploads scoped to T2
+      // in the integration environment.
       const superadminResponse = await request.fetch(
         `${BASE_URL}/api/attachments/file/${encodeURIComponent(attachmentId)}`,
         { method: 'GET', headers: { Authorization: `Bearer ${superadminToken}` } },
@@ -96,7 +131,16 @@ test.describe('TC-ATTACH-XSS-004: Super-admin access to any private attachment',
       expect(body).toBe(fileContent)
     } finally {
       await deleteAttachmentIfExists(request, superadminToken, attachmentId)
-      await deleteUserIfExists(request, superadminToken, t2AdminId)
+      await deleteUserIfExists(request, superadminToken, crossOrgUserId)
+      await deleteUserIfExists(request, superadminToken, t2UserId)
+      if (crossOrgId) {
+        await apiRequest(
+          request,
+          'DELETE',
+          `/api/directory/organizations?id=${encodeURIComponent(crossOrgId)}`,
+          { token: superadminToken },
+        ).catch(() => undefined)
+      }
       await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/organizations', t2OrgId)
       await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/tenants', t2TenantId)
     }

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-004.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-004.spec.ts
@@ -1,11 +1,14 @@
 import { expect, test } from '@playwright/test'
 import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
 import {
+  deleteGeneralEntityIfExists,
   expectId,
-  getTokenScope,
   readJsonSafe,
 } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
-import { createUserFixture, deleteUserIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import {
+  createUserFixture,
+  deleteUserIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
 import {
   deleteAttachmentIfExists,
   uploadAttachmentFixture,
@@ -14,39 +17,57 @@ import {
 const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
 
 test.describe('TC-ATTACH-XSS-004: Super-admin access to any private attachment', () => {
-  test('should return 200 and serve the correct file when a super-admin reads an attachment that is blocked for cross-org users', async ({ request }) => {
+  test('should return 200 when a super-admin reads a private attachment uploaded in a different tenant', async ({
+    request,
+  }) => {
     const superadminToken = await getAuthToken(request, 'superadmin')
     const adminToken = await getAuthToken(request, 'admin')
-    const { tenantId: adminTenantId } = getTokenScope(adminToken)
 
-    const crossOrgUserEmail = `qa-xss-004-${Date.now()}@test.invalid`
-    const recordId = `qa-xss-004-${Date.now()}`
-    const fileContent = 'super-admin bypass test'
+    const stamp = Date.now()
+    const t2AdminEmail = `qa-xss-004-t2-${stamp}@test.invalid`
+    const recordId = `qa-xss-004-${stamp}`
+    const fileContent = 'super-admin cross-tenant bypass test'
 
-    let crossOrgId: string | null = null
-    let crossOrgUserId: string | null = null
+    let t2TenantId: string | null = null
+    let t2OrgId: string | null = null
+    let t2AdminId: string | null = null
     let attachmentId: string | null = null
 
     try {
-      // Create a second org so we can prove the org filter is active for regular users
-      // but bypassed for super-admin via isSuperAdminAuth() in the route.
-      const orgResponse = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      // Create tenant T2 so the attachment is owned by a different tenant than the
+      // global super-admin's own tenant. This proves the bypass operates at the tenant
+      // boundary, not just the org boundary.
+      const tenantRes = await apiRequest(request, 'POST', '/api/directory/tenants', {
         token: superadminToken,
-        data: { tenantId: adminTenantId, name: `qa-xss-004-org-${Date.now()}` },
+        data: { name: `qa-xss-004-tenant-${stamp}` },
       })
-      expect(orgResponse.status()).toBe(201)
-      const orgBody = await readJsonSafe<{ id?: string }>(orgResponse)
-      crossOrgId = expectId(orgBody?.id, 'org create should return id')
+      expect(tenantRes.status()).toBe(201)
+      t2TenantId = expectId(
+        (await readJsonSafe<{ id?: string }>(tenantRes))?.id,
+        'tenant create should return id',
+      )
 
-      crossOrgUserId = await createUserFixture(request, superadminToken, {
-        email: crossOrgUserEmail,
+      const orgRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+        token: superadminToken,
+        data: { tenantId: t2TenantId, name: `qa-xss-004-org-${stamp}` },
+      })
+      expect(orgRes.status()).toBe(201)
+      t2OrgId = expectId(
+        (await readJsonSafe<{ id?: string }>(orgRes))?.id,
+        'org create should return id',
+      )
+
+      // Create a T2 admin to upload the attachment — their JWT carries T2's tenantId,
+      // so the resulting attachment row is stored with tenantId = T2.
+      t2AdminId = await createUserFixture(request, superadminToken, {
+        email: t2AdminEmail,
         password: 'Valid1!Pass',
-        organizationId: crossOrgId,
-        roles: ['employee'],
+        organizationId: t2OrgId,
+        roles: ['admin'],
       })
 
-      // Admin (org A) uploads a private attachment
-      const uploaded = await uploadAttachmentFixture(request, adminToken, {
+      const t2AdminToken = await getAuthToken(request, t2AdminEmail, 'Valid1!Pass')
+      const uploaded = await uploadAttachmentFixture(request, t2AdminToken, {
         entityId: 'attachments:library',
         recordId,
         fileName: 'xss-004.txt',
@@ -55,16 +76,16 @@ test.describe('TC-ATTACH-XSS-004: Super-admin access to any private attachment',
       })
       attachmentId = uploaded.id
 
-      // Cross-org user (org B) is blocked — confirms the org filter is active
-      const crossOrgUserToken = await getAuthToken(request, crossOrgUserEmail, 'Valid1!Pass')
+      // T1 admin (different tenant) is blocked — confirms the tenant filter is active.
+      // em.findOne({ id, tenantId: T1 }) returns null because the attachment is in T2.
       const blockedResponse = await request.fetch(
         `${BASE_URL}/api/attachments/file/${encodeURIComponent(attachmentId)}`,
-        { method: 'GET', headers: { Authorization: `Bearer ${crossOrgUserToken}` } },
+        { method: 'GET', headers: { Authorization: `Bearer ${adminToken}` } },
       )
       expect(blockedResponse.status()).toBe(404)
 
-      // Super-admin bypasses the org filter: isSuperAdminAuth() returns true so the
-      // route skips adding tenantId/organizationId to em.findOne (route.ts lines 42-45).
+      // Global super-admin bypasses via isSuperAdminAuth() — em.findOne receives no
+      // tenantId/organizationId constraint, so the T2 row is found and served.
       const superadminResponse = await request.fetch(
         `${BASE_URL}/api/attachments/file/${encodeURIComponent(attachmentId)}`,
         { method: 'GET', headers: { Authorization: `Bearer ${superadminToken}` } },
@@ -74,16 +95,10 @@ test.describe('TC-ATTACH-XSS-004: Super-admin access to any private attachment',
       const body = await superadminResponse.text()
       expect(body).toBe(fileContent)
     } finally {
-      await deleteAttachmentIfExists(request, adminToken, attachmentId)
-      await deleteUserIfExists(request, superadminToken, crossOrgUserId)
-      if (crossOrgId) {
-        await apiRequest(
-          request,
-          'DELETE',
-          `/api/directory/organizations?id=${encodeURIComponent(crossOrgId)}`,
-          { token: superadminToken },
-        ).catch(() => undefined)
-      }
+      await deleteAttachmentIfExists(request, superadminToken, attachmentId)
+      await deleteUserIfExists(request, superadminToken, t2AdminId)
+      await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/organizations', t2OrgId)
+      await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/tenants', t2TenantId)
     }
   })
 })

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-005.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-005.spec.ts
@@ -1,13 +1,11 @@
-import { test } from "@playwright/test";
+import { test } from '@playwright/test'
 
-test.describe("TC-ATTACH-XSS-005: Cross-tenant access to private attachment via image route", () => {
-  test("should return 404 when an authenticated user from another tenant reads a private attachment via the image route", async () => {
-    // Cross-tenant scenarios require isolated tenants in the integration environment.
+test.describe('TC-ATTACH-XSS-005: Cross-tenant access to private attachment via image route', () => {
+  test('should return 404 when an authenticated user from tenant T2 reads a private attachment from tenant T1 via the image route', async () => {
+    // Requires two isolated tenants in the integration environment.
     // The equivalent behaviour is verified at the unit level in:
     //   - packages/core/src/modules/attachments/api/__tests__/image.route.test.ts
-    test.skip(
-      true,
-      "Requires multi-tenant integration environment; covered by image.route.test.ts unit tests",
-    );
-  });
-});
+    //     (asserts em.findOne receives tenantId filter and checkAttachmentAccess is never called)
+    test.fixme(true, 'Requires multi-tenant integration environment; not available in the standard integration environment')
+  })
+})

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-005.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-005.spec.ts
@@ -1,0 +1,13 @@
+import { test } from "@playwright/test";
+
+test.describe("TC-ATTACH-XSS-005: Cross-tenant access to private attachment via image route", () => {
+  test("should return 404 when an authenticated user from another tenant reads a private attachment via the image route", async () => {
+    // Cross-tenant scenarios require isolated tenants in the integration environment.
+    // The equivalent behaviour is verified at the unit level in:
+    //   - packages/core/src/modules/attachments/api/__tests__/image.route.test.ts
+    test.skip(
+      true,
+      "Requires multi-tenant integration environment; covered by image.route.test.ts unit tests",
+    );
+  });
+});

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-005.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-005.spec.ts
@@ -58,7 +58,7 @@ test.describe('TC-ATTACH-XSS-005: Cross-tenant access to private attachment via 
         email: t2UserEmail,
         password: 'Valid1!Pass',
         organizationId: t2OrgId,
-        roles: ['employee'],
+        roles: [],
       })
 
       // Admin (T1) uploads a private attachment — stored with tenantId = T1.

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-005.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-005.spec.ts
@@ -1,11 +1,93 @@
-import { test } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  deleteGeneralEntityIfExists,
+  expectId,
+  readJsonSafe,
+} from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import {
+  createUserFixture,
+  deleteUserIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import {
+  deleteAttachmentIfExists,
+  uploadAttachmentFixture,
+} from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
+
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
 
 test.describe('TC-ATTACH-XSS-005: Cross-tenant access to private attachment via image route', () => {
-  test('should return 404 when an authenticated user from tenant T2 reads a private attachment from tenant T1 via the image route', async () => {
-    // Requires two isolated tenants in the integration environment.
-    // The equivalent behaviour is verified at the unit level in:
-    //   - packages/core/src/modules/attachments/api/__tests__/image.route.test.ts
-    //     (asserts em.findOne receives tenantId filter and checkAttachmentAccess is never called)
-    test.fixme(true, 'Requires multi-tenant integration environment; not available in the standard integration environment')
+  test('should return 404 when an authenticated user from tenant T2 reads a private attachment from tenant T1 via the image route', async ({
+    request,
+  }) => {
+    const superadminToken = await getAuthToken(request, 'superadmin')
+    const adminToken = await getAuthToken(request, 'admin')
+
+    const stamp = Date.now()
+    const t2UserEmail = `qa-xss-005-t2-${stamp}@test.invalid`
+    const recordId = `qa-xss-005-${stamp}`
+
+    let t2TenantId: string | null = null
+    let t2OrgId: string | null = null
+    let t2UserId: string | null = null
+    let attachmentId: string | null = null
+
+    try {
+      // Create T2 tenant and user — same fixture pattern as TC-ATTACH-XSS-002.
+      const tenantRes = await apiRequest(request, 'POST', '/api/directory/tenants', {
+        token: superadminToken,
+        data: { name: `qa-xss-005-tenant-${stamp}` },
+      })
+      expect(tenantRes.status()).toBe(201)
+      t2TenantId = expectId(
+        (await readJsonSafe<{ id?: string }>(tenantRes))?.id,
+        'tenant create should return id',
+      )
+
+      const orgRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+        token: superadminToken,
+        data: { tenantId: t2TenantId, name: `qa-xss-005-org-${stamp}` },
+      })
+      expect(orgRes.status()).toBe(201)
+      t2OrgId = expectId(
+        (await readJsonSafe<{ id?: string }>(orgRes))?.id,
+        'org create should return id',
+      )
+
+      t2UserId = await createUserFixture(request, superadminToken, {
+        email: t2UserEmail,
+        password: 'Valid1!Pass',
+        organizationId: t2OrgId,
+        roles: ['employee'],
+      })
+
+      // Admin (T1) uploads a private attachment — stored with tenantId = T1.
+      // The image route applies the same em.findOne tenantId filter as the file route
+      // (image route.ts lines 56-60), so the 404 is reached before any MIME-type check.
+      const uploaded = await uploadAttachmentFixture(request, adminToken, {
+        entityId: 'attachments:library',
+        recordId,
+        fileName: 'xss-005.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('cross-tenant image-route isolation test', 'utf8'),
+      })
+      attachmentId = uploaded.id
+
+      // T2 user's JWT carries T2's tenantId → em.findOne({ id, tenantId: T2 }) → null → 404.
+      const t2UserToken = await getAuthToken(request, t2UserEmail, 'Valid1!Pass')
+      const response = await request.fetch(
+        `${BASE_URL}/api/attachments/image/${encodeURIComponent(attachmentId)}`,
+        {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${t2UserToken}` },
+        },
+      )
+      expect(response.status()).toBe(404)
+    } finally {
+      await deleteAttachmentIfExists(request, superadminToken, attachmentId)
+      await deleteUserIfExists(request, superadminToken, t2UserId)
+      await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/organizations', t2OrgId)
+      await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/tenants', t2TenantId)
+    }
   })
 })

--- a/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-006.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATTACH-XSS-006.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  expectId,
+  getTokenScope,
+  readJsonSafe,
+} from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import {
+  createUserFixture,
+  deleteUserIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import {
+  deleteAttachmentIfExists,
+  uploadAttachmentFixture,
+} from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
+
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
+
+test.describe('TC-ATTACH-XSS-006: Cross-org access to private attachment via image route within the same tenant', () => {
+  test('should return 404 when an authenticated user from org B reads a private attachment uploaded by org A via the image route', async ({
+    request,
+  }) => {
+    const superadminToken = await getAuthToken(request, 'superadmin')
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId: adminTenantId } = getTokenScope(adminToken)
+
+    const crossOrgUserEmail = `qa-xss-006-${Date.now()}@test.invalid`
+    const recordId = `qa-xss-006-${Date.now()}`
+
+    let crossOrgId: string | null = null
+    let crossOrgUserId: string | null = null
+    let attachmentId: string | null = null
+
+    try {
+      // Create a second org in the same tenant — same fixture pattern as TC-ATTACH-XSS-003.
+      const orgResponse = await apiRequest(request, 'POST', '/api/directory/organizations', {
+        token: superadminToken,
+        data: { tenantId: adminTenantId, name: `qa-xss-006-org-${Date.now()}` },
+      })
+      expect(orgResponse.status()).toBe(201)
+      crossOrgId = expectId(
+        (await readJsonSafe<{ id?: string }>(orgResponse))?.id,
+        'org create should return id',
+      )
+
+      crossOrgUserId = await createUserFixture(request, superadminToken, {
+        email: crossOrgUserEmail,
+        password: 'Valid1!Pass',
+        organizationId: crossOrgId,
+        roles: ['employee'],
+      })
+
+      // Admin (org A) uploads a private attachment.
+      const uploaded = await uploadAttachmentFixture(request, adminToken, {
+        entityId: 'attachments:library',
+        recordId,
+        fileName: 'xss-006.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('cross-org image-route isolation test', 'utf8'),
+      })
+      attachmentId = uploaded.id
+
+      // Cross-org user (org B, same tenant) tries the image route.
+      // em.findOne({ id, organizationId: orgB }) → null → 404,
+      // reached before any MIME-type check.
+      const crossOrgUserToken = await getAuthToken(request, crossOrgUserEmail, 'Valid1!Pass')
+      const response = await request.fetch(
+        `${BASE_URL}/api/attachments/image/${encodeURIComponent(attachmentId)}`,
+        {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${crossOrgUserToken}` },
+        },
+      )
+      expect(response.status()).toBe(404)
+    } finally {
+      await deleteAttachmentIfExists(request, adminToken, attachmentId)
+      await deleteUserIfExists(request, superadminToken, crossOrgUserId)
+      if (crossOrgId) {
+        await apiRequest(
+          request,
+          'DELETE',
+          `/api/directory/organizations?id=${encodeURIComponent(crossOrgId)}`,
+          { token: superadminToken },
+        ).catch(() => undefined)
+      }
+    }
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -25520,10 +25520,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:0.2.6":
-  version: 0.2.6
-  resolution: "tmp@npm:0.2.6"
-  checksum: 10/4ba072821d65f6ec0ae680dd49261bcc66c96a5a463c80ca040747256238aaad68ad5db7aa8367dd1554d22aa77c2988bdb1c5556ecfc4df105f5b73206b7d9b
+"tmp@npm:0.2.7":
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 10/0a3bc90beb0c6275273c3475fb57e466eaab1c9c4a101d029ff62b18146ce136e7f75d09de34863d9f2c2a492751402508f9e028bc98eb34a1416195d4b15619
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -25520,10 +25520,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:0.2.7":
-  version: 0.2.7
-  resolution: "tmp@npm:0.2.7"
-  checksum: 10/0a3bc90beb0c6275273c3475fb57e466eaab1c9c4a101d029ff62b18146ce136e7f75d09de34863d9f2c2a492751402508f9e028bc98eb34a1416195d4b15619
+"tmp@npm:0.2.6":
+  version: 0.2.6
+  resolution: "tmp@npm:0.2.6"
+  checksum: 10/4ba072821d65f6ec0ae680dd49261bcc66c96a5a463c80ca040747256238aaad68ad5db7aa8367dd1554d22aa77c2988bdb1c5556ecfc4df105f5b73206b7d9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds integration test stubs for issue #2110 — cross-tenant attachment read attempts via the file and image delivery routes.

`TC-ATTACH-XSS-004` — super-admin bypass — is fully implemented. The remaining four cases are skipped with clear reasons because they require multi-tenant or partial-null fixture infrastructure that is not available in the standard integration environment.

## Changes

- Add `TC-ATTACH-XSS-001.spec.ts` — partial-null org scenario  
  Skipped, requires org-null fixture.

- Add `TC-ATTACH-XSS-002.spec.ts` — cross-tenant file route  
  Skipped, requires multi-tenant env.

- Add `TC-ATTACH-XSS-003.spec.ts` — cross-org file route  
  Skipped, requires multi-org env.

- Add `TC-ATTACH-XSS-004.spec.ts` — super-admin access to any private attachment  
  Active, expects `200`.

- Add `TC-ATTACH-XSS-005.spec.ts` — cross-tenant image route  
  Skipped, requires multi-tenant env.

## Specification

- [x] N/A — minor change, no spec needed.

## Testing

- `TC-ATTACH-XSS-004` runs and passes under:

  ```bash
  yarn test:integration
  ```

- `TC-ATTACH-XSS-001`, `TC-ATTACH-XSS-002`, `TC-ATTACH-XSS-003`, and `TC-ATTACH-XSS-005` appear as skipped with clear reasons in the test report.

- Skipped cross-tenant cases are covered at the unit level by `file.route.test.ts` and `image.route.test.ts`, added in #2124. These tests assert that:
  - `em.findOne` receives the correct tenant/org filter,
  - `checkAttachmentAccess` is never reached for cross-tenant queries.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement — see `docs/cla.md`.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `packages/core/src/modules/attachments/__integration__/`.

## Design System Compliance

- [x] N/A — test-only change, no UI components.

## Linked issues

Closes #2110