### PR TITLE
test(catalog): stabilize TC-AI-MERCHANDISING-008 selection-pill flake

### DIFF
--- a/packages/core/src/modules/catalog/__integration__/TC-AI-MERCHANDISING-008-products-sheet.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-AI-MERCHANDISING-008-products-sheet.spec.ts
@@ -113,10 +113,16 @@ test.describe('TC-AI-MERCHANDISING-008: catalog.merchandising_assistant sheet', 
     // Ensure the React click handler has bound — wait for the button to be enabled and any
     // pending DataTable/widget mount work to settle before exercising it.
     await expect(trigger).toBeEnabled({ timeout: 30_000 });
-    await trigger.click();
 
+    // Re-click (only while closed) until the sheet + composer mount — guards
+    // against a pre-hydration no-op click under heavy CI load.
     const sheet = page.locator('[data-ai-merchandising-sheet]');
-    await expect(sheet).toBeVisible();
+    const composer = page.locator('#ai-chat-composer');
+    await expect(async () => {
+      if (!(await sheet.isVisible())) await trigger.click();
+      await expect(sheet).toBeVisible({ timeout: 3_000 });
+      await expect(composer).toBeVisible({ timeout: 3_000 });
+    }).toPass({ timeout: 60_000, intervals: [500, 1_000, 2_000] });
 
     // Phase 2 ships with selectedCount = 0 (DataTable's internal rowSelection
     // is not yet exposed to the host page; see MerchandisingAssistantSheet


### PR DESCRIPTION
## Summary
- `TC-AI-MERCHANDISING-008 > selection pill reflects the current selected count when selection changes` failed twice on `ephemeral-integration (5/15)` of the release CI for develop (run [26567390468](https://github.com/open-mercato/open-mercato/actions/runs/26567390468/job/78266253366), surfaced on release PR #2193).
- Root cause: that test opened the merchandising sheet with a bare `await trigger.click()` + `await expect(sheet).toBeVisible()`. Under heavy CI load the trigger can be visible+enabled before React binds its `onClick`, so the single click is a no-op and the sheet `[data-ai-merchandising-sheet]` never mounts. The page itself loaded fine (nav + products list rendered in the failure trace).
- Fix: mirror the click-retry `toPass()` loop already proven in the two sibling tests in this same file (the ones landed in #2188) — re-click only while the sheet stays closed until both the sheet and `#ai-chat-composer` mount. This was the only remaining bare single-click in the catalog AI integration suite.

## Test plan
- [ ] `ephemeral-integration` shards green on this PR (CI).
- [ ] After merge into `develop`, release PR #2193 integration shards go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)