### PR TITLE
security(catalog): scope decorateOffersWithDetails reads by tenant/org (#2120)

### DIFF
--- a/packages/core/src/modules/catalog/api/__tests__/offers.route.test.ts
+++ b/packages/core/src/modules/catalog/api/__tests__/offers.route.test.ts
@@ -107,7 +107,13 @@ describe('catalog offers route helpers', () => {
         return []
       }),
     }
-    const ctx = { query: { channelId: 'channel-1' }, container: { resolve: jest.fn().mockReturnValue(em) } } as any
+    const ctx = {
+      query: { channelId: 'channel-1' },
+      auth: { tenantId: 'tenant-1', orgId: 'org-1' },
+      selectedOrganizationId: 'org-1',
+      organizationIds: null,
+      container: { resolve: jest.fn().mockReturnValue(em) },
+    } as any
 
     await decorateOffersWithDetails(items, ctx)
 
@@ -151,11 +157,52 @@ describe('catalog offers route helpers', () => {
     expect(items[1].prices).toHaveLength(1)
     expect(items[1].productDefaultPrices).toEqual([])
     expect(items[1].productChannelPrice).toBeNull()
-    expect(em.find).toHaveBeenCalledWith(CatalogProduct, expect.any(Object), expect.any(Object))
+    expect(em.find).toHaveBeenCalledWith(
+      CatalogProduct,
+      expect.objectContaining({ id: { $in: ['prod-1', 'prod-2'] }, tenantId: 'tenant-1', organizationId: 'org-1' }),
+      expect.any(Object),
+    )
     expect(em.find).toHaveBeenCalledWith(
       CatalogProductPrice,
-      expect.objectContaining({ offer: { $in: ['offer-1', 'offer-2'] } }),
+      expect.objectContaining({ offer: { $in: ['offer-1', 'offer-2'] }, tenantId: 'tenant-1', organizationId: 'org-1' }),
       expect.objectContaining({ populate: ['priceKind'] }),
     )
+  })
+
+  it('scopes every catalog read by tenant and organization', async () => {
+    const items: any[] = [{ id: 'offer-1', productId: 'prod-1', channelId: 'channel-1' }]
+    const em = { find: jest.fn(async () => []) }
+    const ctx = {
+      query: { channelId: 'channel-1' },
+      auth: { tenantId: 'tenant-9', orgId: 'org-fallback' },
+      selectedOrganizationId: null,
+      organizationIds: ['org-a', 'org-b'],
+      container: { resolve: jest.fn().mockReturnValue(em) },
+    } as any
+
+    await decorateOffersWithDetails(items, ctx)
+
+    expect(em.find).toHaveBeenCalled()
+    for (const call of em.find.mock.calls) {
+      const where = call[1] as Record<string, unknown>
+      expect(where.tenantId).toBe('tenant-9')
+      // Multi-org scope (organizationIds set, no selected org) → $in over the allowed set.
+      expect(where.organizationId).toEqual({ $in: ['org-a', 'org-b'] })
+    }
+  })
+
+  it('hard-fails when tenant scope is missing instead of issuing unscoped reads', async () => {
+    const items: any[] = [{ id: 'offer-1', productId: 'prod-1' }]
+    const em = { find: jest.fn(async () => []) }
+    const ctx = {
+      query: {},
+      auth: { orgId: 'org-1' },
+      selectedOrganizationId: 'org-1',
+      organizationIds: null,
+      container: { resolve: jest.fn().mockReturnValue(em) },
+    } as any
+
+    await expect(decorateOffersWithDetails(items, ctx)).rejects.toMatchObject({ status: 403 })
+    expect(em.find).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/catalog/api/offers/route.ts
+++ b/packages/core/src/modules/catalog/api/offers/route.ts
@@ -94,11 +94,25 @@ export async function decorateOffersWithDetails(
     .filter((value): value is string => !!value)
   if (!offerIds.length && !productIds.length) return
   const em = ctx.container.resolve('em') as EntityManager
+  const scopeTenantId = ctx.auth?.tenantId ?? null
+  if (!scopeTenantId) {
+    throw new CrudHttpError(403, '[internal] Missing tenant scope for offer decoration')
+  }
+  const scopeOrgIds =
+    Array.isArray(ctx.organizationIds) && ctx.organizationIds.length
+      ? Array.from(new Set(ctx.organizationIds))
+      : (ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null)
+        ? [(ctx.selectedOrganizationId ?? ctx.auth?.orgId) as string]
+        : []
+  const scopeWhere: Record<string, unknown> = { tenantId: scopeTenantId }
+  if (scopeOrgIds.length === 1) scopeWhere.organizationId = scopeOrgIds[0]
+  else if (scopeOrgIds.length > 1) scopeWhere.organizationId = { $in: scopeOrgIds }
+  const scope = { tenantId: scopeTenantId, organizationId: scopeOrgIds.length === 1 ? scopeOrgIds[0] : null }
   const [products, prices, defaultVariants] = await Promise.all([
     productIds.length
       ? em.find(
           CatalogProduct,
-          { id: { $in: productIds } },
+          { id: { $in: productIds }, ...scopeWhere },
           {
             fields: ['id', 'title', 'description', 'defaultMediaId', 'defaultMediaUrl', 'sku'],
           },
@@ -108,15 +122,15 @@ export async function decorateOffersWithDetails(
       ? findWithDecryption(
           em,
           CatalogProductPrice,
-          { offer: { $in: offerIds } },
+          { offer: { $in: offerIds }, ...scopeWhere },
           { populate: ['priceKind'] },
-          { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+          scope,
         )
       : [],
     productIds.length
       ? em.find(
           CatalogProductVariant,
-          { product: { $in: productIds }, isDefault: true },
+          { product: { $in: productIds }, isDefault: true, ...scopeWhere },
           { fields: ['id', 'product'] },
         )
       : [],
@@ -227,6 +241,7 @@ export async function decorateOffersWithDetails(
         CatalogProductPrice,
         {
           offer: null,
+          ...scopeWhere,
           $and: [
             { $or: fallbackTargets },
             channelFilterValues.includes(null)
@@ -240,7 +255,7 @@ export async function decorateOffersWithDetails(
           ],
         },
         { populate: ['priceKind'] },
-        { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+        scope,
       )
     : []
   fallbackEntries.forEach((entry) => {


### PR DESCRIPTION
Fixes #2120

## Problem
`decorateOffersWithDetails` in `packages/core/src/modules/catalog/api/offers/route.ts` (the offers list `afterList` hook) read `CatalogProduct`, `CatalogProductVariant`, and `CatalogProductPrice` (including the fallback channel-price query) filtering only by `id` / `offer` / `product`. No `tenantId` / `organizationId` appeared in the SQL `WHERE` clause — the tenant guard lived only in the `findWithDecryption` decryption-scope argument, which picks the decryption key but does **not** filter rows.

## Root Cause
The decoration looks up products/variants/prices by IDs derived from the response items. If a malicious request can plant arbitrary `productId` / `offerId` values into those items (crafted custom-field payload, interceptor reshaping), the unscoped reads disclose foreign-tenant titles, SKUs, default media URLs, and fallback price entries. Even absent injection, the reads bypassed any per-org defense-in-depth filter.

## What Changed
- All four reads (`CatalogProduct`, offer-price `findWithDecryption`, `CatalogProductVariant`, fallback-price `findWithDecryption`) now intersect their `WHERE` with `tenantId` and `organizationId`.
- Scope mirrors the list query itself: `tenantId = ctx.auth.tenantId`; org from `ctx.organizationIds` (multi-org → `$in`) else `ctx.selectedOrganizationId ?? ctx.auth.orgId`. When no concrete org scope exists (tenant-wide admin view) the tenant filter still applies, matching the list's own behavior so multi-org views don't break.
- The decorator hard-fails with `403` when tenant scope is missing instead of issuing unscoped reads.
- The decryption-scope arg passes the single resolved org (or `null` for multi-org, letting per-entity fallback decryption pick the right key).

## Tests
- Updated the existing `decorateOffersWithDetails` test to assert each read now carries `tenantId` + `organizationId` in the `WHERE`.
- Added a regression test proving every catalog read is scoped (multi-org `$in` case).
- Added a regression test proving a missing-tenant context hard-fails (403) and issues **no** reads.
- `yarn workspace @open-mercato/core test --testPathPattern "catalog/api"` → 16/16 green; `yarn typecheck` → 19/19 packages.

## Backward Compatibility
- No contract surface changes: `decorateOffersWithDetails` signature unchanged, API response shape unchanged, no event/ACL/DI/import/DB-schema changes. The 403 guard only triggers on a missing tenant context, which cannot occur on this `requireAuth` route.