### PR TITLE
test: stabilize release integration flakes (sales shard-12 timeouts + deal-create hydration race)

### DIFF
--- a/packages/core/src/modules/sales/__integration__/TC-SALES-002.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-002.spec.ts
@@ -8,6 +8,10 @@ import { addCustomLine, createSalesDocument } from '@open-mercato/core/modules/c
  */
 test.describe('TC-SALES-002: Quote To Order Conversion', () => {
   test('should convert quote into order from actions menu', async ({ page }) => {
+    // Heavy multi-hop UI flow (login + createSalesDocument + line) routinely
+    // exceeds Playwright's 20s default on a loaded ephemeral shard; opt into the
+    // sanctioned per-test budget (see TC-SALES-005). Global bump is disallowed.
+    test.slow();
     await login(page, 'admin');
     await createSalesDocument(page, { kind: 'quote' });
     await addCustomLine(page, {

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-003.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-003.spec.ts
@@ -8,6 +8,10 @@ import { createSalesDocument } from '@open-mercato/core/modules/core/__integrati
  */
 test.describe('TC-SALES-003: Order Creation', () => {
   test('should create a sales order from UI create form', async ({ page }) => {
+    // Heavy multi-hop UI flow (login + createSalesDocument) routinely exceeds
+    // Playwright's 20s default on a loaded ephemeral shard; opt into the
+    // sanctioned per-test budget (see TC-SALES-005). Global bump is disallowed.
+    test.slow();
     await login(page, 'admin');
     const orderId = await createSalesDocument(page, { kind: 'order' });
 

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-004.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-004.spec.ts
@@ -8,6 +8,11 @@ import { addCustomLine, createSalesDocument, updateLineQuantity } from '@open-me
  */
 test.describe('TC-SALES-004: Order Line Management', () => {
   test('should create and update order line in UI', async ({ page }) => {
+    // Heavy multi-hop UI flow (login + createSalesDocument + line update)
+    // routinely exceeds Playwright's 20s default on a loaded ephemeral shard;
+    // opt into the sanctioned per-test budget (see TC-SALES-005). Global bump
+    // is disallowed.
+    test.slow();
     const lineName = `QA TC-SALES-004 ${Date.now()}`;
 
     await login(page, 'admin');

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-006.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-006.spec.ts
@@ -8,6 +8,10 @@ import { addCustomLine, createSalesDocument } from '@open-mercato/core/modules/c
  */
 test.describe('TC-SALES-006: Order Tax Calculation', () => {
   test('should display tax-aware net/gross amounts on order line in UI', async ({ page }) => {
+    // Heavy multi-hop UI flow (login + createSalesDocument + line) routinely
+    // exceeds Playwright's 20s default on a loaded ephemeral shard; opt into the
+    // sanctioned per-test budget (see TC-SALES-005). Global bump is disallowed.
+    test.slow();
     const lineName = `QA TC-SALES-006 ${Date.now()}`;
 
     await login(page, 'admin');

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-007.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-007.spec.ts
@@ -8,6 +8,11 @@ import { addCustomLine, addShipment, createSalesDocument } from '@open-mercato/c
  */
 test.describe('TC-SALES-007: Shipment Recording', () => {
   test('should create shipment from order UI', async ({ page }) => {
+    // Heavy multi-hop UI flow (login + createSalesDocument + line + shipment)
+    // routinely exceeds Playwright's 20s default on a loaded ephemeral shard;
+    // opt into the sanctioned per-test budget (see TC-SALES-005). Global bump
+    // is disallowed.
+    test.slow();
     await login(page, 'admin');
     await createSalesDocument(page, { kind: 'order' });
     await addCustomLine(page, {

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-010.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-010.spec.ts
@@ -8,6 +8,11 @@ import { addCustomLine, addPayment, createSalesDocument } from '@open-mercato/co
  */
 test.describe('TC-SALES-010: Payment Recording', () => {
   test('should record payment from order payments UI', async ({ page }) => {
+    // Heavy multi-hop UI flow (login + createSalesDocument + line + payment)
+    // routinely exceeds Playwright's 20s default on a loaded ephemeral shard;
+    // opt into the sanctioned per-test budget (see TC-SALES-005). Global bump
+    // is disallowed.
+    test.slow();
     const amount = 42.37;
     await login(page, 'admin');
     await createSalesDocument(page, { kind: 'order' });

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-011.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-011.spec.ts
@@ -8,6 +8,11 @@ import { addCustomLine, createSalesDocument } from '@open-mercato/core/modules/c
  */
 test.describe('TC-SALES-011: Payment Allocation', () => {
   test('should expose allocation controls in payment UI when available', async ({ page }) => {
+    // Heavy multi-hop UI flow (login + createSalesDocument + line + allocation)
+    // routinely exceeds Playwright's 20s default on a loaded ephemeral shard;
+    // opt into the sanctioned per-test budget (see TC-SALES-005). Global bump
+    // is disallowed.
+    test.slow();
     await login(page, 'admin');
     await createSalesDocument(page, { kind: 'order' });
     await addCustomLine(page, { name: `QA TC-SALES-011 ${Date.now()}`, quantity: 1, unitPriceGross: 60 });


### PR DESCRIPTION
## Summary
Stabilizes the two integration failures blocking release PR #2193 (develop→main, v0.6.3). Both are **test-only**; no product code changes.

### 1. `ephemeral-integration (12/15)` — `TC-SALES-007/010/011` (20s timeouts)
Heavy multi-hop sales UI flows (login + `createSalesDocument` + `addCustomLine` + shipment/payment/allocation), each helper waiting up to `TEST_WAIT_TIMEOUT_MS=10s`, blew Playwright's 20s default under loaded shard-12. Sibling heavy specs (001/005/017/019/020) already opt into `test.slow()`; seven (002/003/004/006/007/010/011) were missing it. **Fix:** apply the sanctioned per-test `test.slow()` opt-in consistently.

### 2. Standalone job — `TC-CRM-071` (create-deal redesign, deterministic timeout)
From the run-26574881201 trace + screenshots: the test filled the deal **title** before the redesigned form finished hydrating its lazily-loaded client registries (PR #2129), so React reset the controlled title input on hydration → "Title is required" blocked submit → the form never POSTed (`waitForResponse` waited 52s, zero `POST /api/customers/deals` in the network log) → 60s timeout. The timed-out test couldn't run its `finally` cleanup (context closed), **orphaning the tenant-wide required custom-field definition**, which then blocked the retry's submit too (cascade — confirmed by two differently-stamped required fields in the retry screenshot). Regressed once client registries became lazy (#2129); passed before because hydration was eager. **Fix:** gate the test on the "Create deal" submit button being enabled (only true after custom fields load = after hydration) before typing any field, so every fill sticks and the test POSTs + cleans up reliably.

## Why these are flakes, not regressions in product behavior
`git diff c97dbde79..70f30e284` (last green #2193 run → failing) shows **no sales-UI changes** and no deal-create form logic changes — only catalog #2196, dev tooling, AI-chat isolation, and a dashboard reload. The deal-create issue is a pre-hydration test-timing race widened by #2129's lazy loading, not a product logic change.

## Test plan
- [ ] `ephemeral-integration (12/15)` passes (was red on #2193).
- [ ] `Standalone App Integration Tests` passes `TC-CRM-071`.
- [ ] No other shard regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)