### PR TITLE
docs: in-process dev watcher/workers + parallelism flags

### DIFF
--- a/apps/docs/docs/installation/setup.mdx
+++ b/apps/docs/docs/installation/setup.mdx
@@ -258,6 +258,41 @@ To hide the coding-tools menu from the splash:
 OM_ENABLE_CODING_FLOW_FROM_SPLASH=false yarn dev
 ```
 
+### In-process watcher and workers (memory optimization)
+
+To keep idle memory low, `yarn dev` now runs two things **in-process** inside the `mercato server dev` runtime instead of as separate long-running Node processes:
+
+- **Structural regeneration watcher** — the watcher that re-runs `mercato generate` when module files change is hosted by the dev server itself. Collapsing this dedicated sidecar saves ~190 MB of resident memory.
+- **Queue workers** — background queue workers are auto-spawned inside the dev process so jobs (indexing, bulk operations, notifications) are processed without a second runtime.
+
+This is the right default for most local development. If you need **higher throughput** — for example a heavy import/reindex, or to profile worker behavior in isolation — opt back into separate parallel processes with these flags.
+
+Run the generate watcher as a standalone sidecar process again:
+
+```bash
+OM_DEV_GENERATE_WATCH_MODE=legacy yarn dev
+```
+
+Stop the dev runtime from hosting workers, then run dedicated worker processes alongside it (each process runs its own event loop, so several in parallel scale throughput):
+
+```bash
+# In the dev runtime: do not auto-spawn in-process workers
+AUTO_SPAWN_WORKERS=false yarn dev
+
+# In separate terminals: dedicated worker processes, tuned per queue
+yarn mercato <module> worker <queue-name> --concurrency=5
+```
+
+Tune `--concurrency` per the queue guidelines (I/O-bound 5–10, CPU-bound 1–2, DB-heavy 3–5; never exceed 20). For production-grade parallelism across machines, set `QUEUE_STRATEGY=async` to use the Redis-backed BullMQ strategy.
+
+To poll for jobs lazily instead of holding eager in-process workers (lower idle cost, slightly higher pickup latency):
+
+```bash
+OM_AUTO_SPAWN_WORKERS_LAZY=true yarn dev
+# optional: tune the poll interval (ms, default 1000)
+OM_AUTO_SPAWN_WORKERS_LAZY_POLL_MS=500 yarn dev
+```
+
 ## Docker Management
 
 **Stop services:**


### PR DESCRIPTION
## Summary
- Documents that `yarn dev` now hosts the **structural regeneration watcher** and **queue workers** in-process (memory optimization; ~190 MB saved by collapsing the generate-watch sidecar).
- Highlights the flags to opt back into separate **parallel** processes for higher throughput:
  - `OM_DEV_GENERATE_WATCH_MODE=legacy` — standalone generate-watch sidecar
  - `AUTO_SPAWN_WORKERS=false` + dedicated `yarn mercato <module> worker <queue> --concurrency=N` processes
  - `QUEUE_STRATEGY=async` for Redis/BullMQ parallelism
  - `OM_AUTO_SPAWN_WORKERS_LAZY=true` (+ `OM_AUTO_SPAWN_WORKERS_LAZY_POLL_MS`) for lazy spawn
- Added under the existing "Native dev runtime" section in `installation/setup.mdx`.

## Test plan
- [ ] Docs build passes in CI.
- [ ] Flags verified against source: `in-process-generate-watcher-mode.ts`, `auto-spawn-workers.ts`, queue worker contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)