### PR TITLE
feat(catalog): declare ACL feature dependencies (#2143)

### DIFF
--- a/packages/core/src/modules/catalog/__tests__/acl.test.ts
+++ b/packages/core/src/modules/catalog/__tests__/acl.test.ts
@@ -1,0 +1,59 @@
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as catalogFeatures } from '../acl'
+import { features as currenciesFeatures } from '../../currencies/acl'
+import { features as dictionariesFeatures } from '../../dictionaries/acl'
+
+const catalogDescriptors: FeatureDescriptor[] = catalogFeatures
+
+// The catalog dependency declarations reference cross-module view features
+// (`currencies.view`, `dictionaries.view`). The resolved catalog must therefore
+// include those modules' features so the references resolve to registered ids.
+const resolvedCatalog: FeatureDescriptor[] = [
+  ...catalogDescriptors,
+  ...currenciesFeatures,
+  ...dictionariesFeatures,
+]
+
+const catalogOwnIds = catalogDescriptors.map((feature) => feature.id)
+
+describe('catalog acl dependency declarations', () => {
+  it('declares dependsOn only against features registered in the resolved catalog', () => {
+    const granted = resolvedCatalog.map((feature) => feature.id)
+    const diagnostics = resolveAclDependencyDiagnostics(granted, resolvedCatalog)
+    const ownUnknown = diagnostics.unknownReferences.filter((ref) =>
+      ref.feature.startsWith('catalog.'),
+    )
+    expect(ownUnknown).toEqual([])
+  })
+
+  it('resolves cleanly with no missing deps when every feature and its deps are granted', () => {
+    const granted = resolvedCatalog.map((feature) => feature.id)
+    const diagnostics = resolveAclDependencyDiagnostics(granted, resolvedCatalog)
+    const ownMissing = diagnostics.missingDependencies.filter((dep) =>
+      dep.feature.startsWith('catalog.'),
+    )
+    expect(ownMissing).toEqual([])
+  })
+
+  it('flags cross-module deps as missing (not unknown) when only catalog features are granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(catalogOwnIds, resolvedCatalog)
+    expect(diagnostics.unknownReferences).toEqual([])
+    const productsView = diagnostics.missingDependencies.find(
+      (dep) => dep.feature === 'catalog.products.view',
+    )
+    expect(productsView?.missing).toEqual(['currencies.view', 'dictionaries.view'])
+  })
+
+  it('keeps every internal catalog dependency target within the catalog feature set', () => {
+    const catalogIds = new Set(catalogOwnIds)
+    const internalDeps = catalogDescriptors.flatMap((feature) =>
+      (feature.dependsOn ?? []).filter((dep) => dep.startsWith('catalog.')),
+    )
+    for (const dep of internalDeps) {
+      expect(catalogIds.has(dep)).toBe(true)
+    }
+  })
+})

--- a/packages/core/src/modules/catalog/acl.ts
+++ b/packages/core/src/modules/catalog/acl.ts
@@ -1,10 +1,35 @@
 export const features = [
-  { id: 'catalog.products.view', title: 'View catalog products', module: 'catalog' },
-  { id: 'catalog.products.manage', title: 'Manage catalog products', module: 'catalog' },
+  {
+    id: 'catalog.products.view',
+    title: 'View catalog products',
+    module: 'catalog',
+    dependsOn: ['currencies.view', 'dictionaries.view'],
+  },
+  {
+    id: 'catalog.products.manage',
+    title: 'Manage catalog products',
+    module: 'catalog',
+    dependsOn: ['catalog.products.view'],
+  },
   { id: 'catalog.categories.view', title: 'View catalog categories', module: 'catalog' },
-  { id: 'catalog.categories.manage', title: 'Manage catalog categories', module: 'catalog' },
-  { id: 'catalog.variants.manage', title: 'Manage catalog variants', module: 'catalog' },
-  { id: 'catalog.pricing.manage', title: 'Manage catalog pricing', module: 'catalog' },
+  {
+    id: 'catalog.categories.manage',
+    title: 'Manage catalog categories',
+    module: 'catalog',
+    dependsOn: ['catalog.categories.view'],
+  },
+  {
+    id: 'catalog.variants.manage',
+    title: 'Manage catalog variants',
+    module: 'catalog',
+    dependsOn: ['catalog.products.view'],
+  },
+  {
+    id: 'catalog.pricing.manage',
+    title: 'Manage catalog pricing',
+    module: 'catalog',
+    dependsOn: ['catalog.products.view', 'currencies.view'],
+  },
   { id: 'catalog.settings.manage', title: 'Manage catalog settings', module: 'catalog' },
 ]
 


### PR DESCRIPTION
Fixes #2143

> **Stacked on #2141.** The ACL-dependency infrastructure (`dependsOn` field, `resolveAclDependencyDiagnostics`, the spec) lives only on PR #2141 (`feat/acl-dependency-bundles`), which is still open. This PR therefore **targets the `feat/acl-dependency-bundles` branch**, not `develop`. Merge order: **#2141 first**, then this PR (GitHub will auto-retarget to `develop` when #2141 merges).

## Problem
PR #2141 shipped the ACL dependency-bundle infrastructure and enacted only the `customers` reference module. Every other module's `acl.ts` still needs `dependsOn` declared. This is the per-module follow-up for **`catalog`** (spec §6.3).

## What Changed
- `packages/core/src/modules/catalog/acl.ts` — added `dependsOn` arrays per the spec §6.3 proposed-default table:
  | Feature | dependsOn |
  |---------|-----------|
  | `catalog.products.view` | `currencies.view`, `dictionaries.view` |
  | `catalog.products.manage` | `catalog.products.view` |
  | `catalog.categories.manage` | `catalog.categories.view` |
  | `catalog.variants.manage` | `catalog.products.view` |
  | `catalog.pricing.manage` | `catalog.products.view`, `currencies.view` |
  | `catalog.categories.view`, `catalog.settings.manage` | — (root) |
- `packages/core/src/modules/catalog/__tests__/acl.test.ts` — new unit test.

## Notes / refinements
- §6.3 marks **no** dependencies with `*`, so there are **no new view-grained features** to introduce. `setup.ts` `defaultRoleFeatures` is unchanged, and there are no new grants to sync with `yarn mercato auth sync-role-acls`.
- The table is enacted as-proposed; the cross-module targets (`currencies.view`, `dictionaries.view`) are real, registered features. Granting them to default catalog roles is intentionally **out of scope** (cross-module change) — the resolver surfaces a *warning* only, per spec §4.6.

## Tests
- New `catalog/acl.test.ts` (4 cases): own declarations resolve with no `unknownReferences`; clean resolution when all deps granted; cross-module deps reported as *missing* (not *unknown*) when only catalog features are granted; every internal catalog dep target stays within the catalog feature set. **All pass.**
- Regression: shared `aclDependencies.test.ts` (19) and auth `features.test.ts` (6) still green.
- `yarn turbo run typecheck --filter=@open-mercato/core` passes (after `yarn build:packages` + `yarn generate`).

## Backward Compatibility
- ACL features are an additive-only contract surface. Only `dependsOn` metadata was added — no feature id removed, renamed, or introduced. No API/event/widget/DI/import changes. Fully BC-safe.