### PR TITLE
perf(sales): fold shipment status DictionaryEntry fetch into afterList Promise.all (#2131)

### DIFF
--- a/packages/core/src/modules/sales/api/__tests__/shipments.afterList.test.ts
+++ b/packages/core/src/modules/sales/api/__tests__/shipments.afterList.test.ts
@@ -1,0 +1,95 @@
+/** @jest-environment node */
+import type { CrudCtx } from '@open-mercato/shared/lib/crud/factory'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((em: any, entityName: any, where: any, options: any) =>
+    em.find(entityName, where, options)
+  ),
+}))
+
+import { enrichShipmentListResponse } from '@open-mercato/core/modules/sales/api/shipments/route'
+
+type FakeEntityData = Record<string, Record<string, unknown>[]>
+
+function makeCtx(data: FakeEntityData, calls: string[]): CrudCtx {
+  const em = {
+    find: (entity: { name: string }) => {
+      calls.push(entity.name)
+      return Promise.resolve(data[entity.name] ?? [])
+    },
+  }
+  return {
+    container: { resolve: (token: string) => (token === 'em' ? em : null) },
+    auth: { tenantId: 'ten-1', orgId: 'org-1' },
+  } as unknown as CrudCtx
+}
+
+describe('enrichShipmentListResponse', () => {
+  it('enriches status from DictionaryEntry fetched in the parallel batch (before the dependent order-line fetch)', async () => {
+    const calls: string[] = []
+    const ctx = makeCtx(
+      {
+        SalesShipmentItem: [
+          { id: 'si-1', shipment: 'shp-1', orderLine: 'ol-1', quantity: 2, metadata: { foo: 'bar' } },
+        ],
+        SalesShippingMethod: [{ id: 'sm-1', code: 'STD', name: 'Standard' }],
+        DictionaryEntry: [{ id: 'st-1', value: 'shipped', label: 'Shipped' }],
+        SalesOrderLine: [{ id: 'ol-1', lineNumber: 3, name: 'Widget', catalogSnapshot: null }],
+      },
+      calls,
+    )
+    const payload: { items: Record<string, unknown>[] } = {
+      items: [{ id: 'shp-1', status_entry_id: 'st-1', shipping_method_id: 'sm-1', status: null }],
+    }
+
+    await enrichShipmentListResponse(payload, ctx)
+
+    const item = payload.items[0]
+    expect(item.status).toBe('shipped')
+    expect(item.status_label).toBe('Shipped')
+    expect(item.shipping_method_code).toBe('STD')
+    expect(item.shipping_method_name).toBe('Standard')
+    expect(item.items).toEqual([
+      {
+        id: 'si-1',
+        orderLineId: 'ol-1',
+        orderLineName: 'Widget',
+        orderLineNumber: 3,
+        quantity: 2,
+        metadata: { foo: 'bar' },
+      },
+    ])
+
+    // Regression for #2131: the DictionaryEntry lookup must run in the same
+    // Promise.all batch as the shipment-item/shipping-method fetches, i.e. it
+    // is invoked before the order-line fetch that depends on the batch result.
+    // The previous sequential code fetched DictionaryEntry after the order
+    // lines, which this assertion catches.
+    const dictionaryAt = calls.indexOf('DictionaryEntry')
+    const orderLineAt = calls.indexOf('SalesOrderLine')
+    expect(dictionaryAt).toBeGreaterThanOrEqual(0)
+    expect(orderLineAt).toBeGreaterThanOrEqual(0)
+    expect(dictionaryAt).toBeLessThan(orderLineAt)
+  })
+
+  it('skips the DictionaryEntry fetch when no status_entry_id is present', async () => {
+    const calls: string[] = []
+    const ctx = makeCtx(
+      {
+        SalesShipmentItem: [{ id: 'si-1', shipment: 'shp-1', orderLine: 'ol-1', quantity: 1, metadata: null }],
+        SalesShippingMethod: [],
+        SalesOrderLine: [{ id: 'ol-1', lineNumber: 1, name: 'Widget', catalogSnapshot: null }],
+      },
+      calls,
+    )
+    const payload: { items: Record<string, unknown>[] } = {
+      items: [{ id: 'shp-1', shipping_method_id: null, status: 'pending' }],
+    }
+
+    await enrichShipmentListResponse(payload, ctx)
+
+    expect(calls).not.toContain('DictionaryEntry')
+    expect(payload.items[0].status).toBe('pending')
+    expect(payload.items[0].status_label).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/sales/api/shipments/route.ts
+++ b/packages/core/src/modules/sales/api/shipments/route.ts
@@ -72,7 +72,11 @@ export async function enrichShipmentListResponse(
     }
   })
   const shipmentIds = items
-    .map((item: unknown) => (item && typeof item === 'object' ? (item as Record<string, unknown>).id : null))
+    .map((item: unknown) => {
+      if (!item || typeof item !== 'object') return null
+      const raw = (item as Record<string, unknown>).id
+      return typeof raw === 'string' ? raw : null
+    })
     .filter((value: string | null): value is string => typeof value === 'string')
   if (!shipmentIds.length) return
   const em = ctx.container.resolve('em') as EntityManager

--- a/packages/core/src/modules/sales/api/shipments/route.ts
+++ b/packages/core/src/modules/sales/api/shipments/route.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
+import { makeCrudRoute, type CrudCtx } from '@open-mercato/shared/lib/crud/factory'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { splitCustomFieldPayload } from '@open-mercato/shared/lib/crud/custom-fields'
@@ -51,6 +51,157 @@ const toNumber = (value: unknown): number => {
     if (!Number.isNaN(parsed)) return parsed
   }
   return 0
+}
+
+export async function enrichShipmentListResponse(
+  payload: { items?: unknown[] },
+  ctx: CrudCtx,
+): Promise<void> {
+  const items = Array.isArray(payload.items) ? payload.items : []
+  if (!items.length) return
+  const snapshotMap = new Map<string, ReturnType<typeof readShipmentItemsSnapshot>>()
+  items.forEach((item: unknown) => {
+    if (!item || typeof item !== 'object') return
+    const id = (item as Record<string, unknown>).id
+    if (typeof id !== 'string') return
+    const snapshot = readShipmentItemsSnapshot(
+      (item as any).items_snapshot ?? (item as any).itemsSnapshot ?? null
+    )
+    if (snapshot.length) {
+      snapshotMap.set(id, snapshot)
+    }
+  })
+  const shipmentIds = items
+    .map((item: unknown) => (item && typeof item === 'object' ? (item as Record<string, unknown>).id : null))
+    .filter((value: string | null): value is string => typeof value === 'string')
+  if (!shipmentIds.length) return
+  const em = ctx.container.resolve('em') as EntityManager
+  const statusIds: string[] = Array.from(
+    new Set(
+      items
+        .map((item: unknown) => {
+          if (!item || typeof item !== 'object') return null
+          const raw = (item as Record<string, unknown>).status_entry_id
+          return typeof raw === 'string' ? raw : null
+        })
+        .filter((value: string | null): value is string => typeof value === 'string' && value.length > 0)
+    )
+  )
+  const [shipmentItems, shippingMethods, statusEntries] = await Promise.all([
+    findWithDecryption(
+      em,
+      SalesShipmentItem,
+      { shipment: { $in: shipmentIds } },
+      { populate: ['orderLine'] },
+      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+    ),
+    (async () => {
+      const ids: string[] = Array.from(
+        new Set(
+          items
+            .map((item: unknown) => {
+              if (!item || typeof item !== 'object') return null
+              const raw = (item as Record<string, unknown>).shipping_method_id
+              return typeof raw === 'string' ? raw : null
+            })
+            .filter((value: string | null): value is string => typeof value === 'string' && value.length > 0)
+        )
+      )
+      if (!ids.length) return []
+      return em.find(SalesShippingMethod, { id: { $in: ids } })
+    })(),
+    statusIds.length ? em.find(DictionaryEntry, { id: { $in: statusIds } }) : [],
+  ])
+  const orderLineIds = Array.from(
+    new Set(
+      shipmentItems
+        .map((entry) =>
+          typeof entry.orderLine === 'string'
+            ? entry.orderLine
+            : entry.orderLine?.id ?? (entry as any).orderLineId ?? null
+        )
+        .filter((value): value is string => typeof value === 'string')
+    )
+  )
+  const orderLines = orderLineIds.length
+    ? await em.find(SalesOrderLine, { id: { $in: orderLineIds } })
+    : []
+  const lineMap = new Map(
+    orderLines.map((line) => [
+      line.id,
+      {
+        lineNumber: line.lineNumber ?? null,
+        name:
+          line.name ??
+          (typeof line.catalogSnapshot === 'object' && line.catalogSnapshot
+            ? ((line.catalogSnapshot as any).name as string | undefined) ?? null
+            : null),
+      },
+    ])
+  )
+  const grouped = shipmentItems.reduce<Map<string, Array<Record<string, unknown>>>>((acc, entry) => {
+    const shipmentId =
+      typeof entry.shipment === 'string'
+        ? entry.shipment
+        : entry.shipment?.id ?? (entry as any).shipment_id ?? null
+    const lineId =
+      typeof entry.orderLine === 'string'
+        ? entry.orderLine
+        : entry.orderLine?.id ?? (entry as any).order_line_id ?? null
+    if (!shipmentId || !lineId) return acc
+    const line = lineMap.get(lineId)
+    const list = acc.get(shipmentId) ?? []
+    list.push({
+      id: entry.id,
+      orderLineId: lineId,
+      orderLineName: line?.name ?? null,
+      orderLineNumber: line?.lineNumber ?? null,
+      quantity: toNumber(entry.quantity),
+      metadata: entry.metadata ?? null,
+    })
+    acc.set(shipmentId, list)
+    return acc
+  }, new Map())
+  const shippingMap = new Map(
+    shippingMethods.map((method) => [
+      method.id,
+      {
+        code: method.code ?? null,
+        name: method.name ?? method.code ?? null,
+      },
+    ])
+  )
+  const statusMap = new Map<string, { value: string | null; label: string | null }>()
+  statusEntries.forEach((entry) =>
+    statusMap.set(entry.id, {
+      value: entry.value ?? null,
+      label: entry.label ?? entry.value ?? null,
+    })
+  )
+  items.forEach((item: unknown) => {
+    if (!item || typeof item !== 'object') return
+    const id = (item as Record<string, unknown>).id
+    if (typeof id !== 'string') return
+    const snapshot = snapshotMap.get(id)
+    if (snapshot?.length) {
+      ;(item as Record<string, unknown>).items_snapshot = snapshot
+    }
+    ;(item as Record<string, unknown>).items = snapshot?.length ? snapshot : grouped.get(id) ?? []
+    const shippingId = (item as Record<string, unknown>).shipping_method_id
+    if (typeof shippingId === 'string' && shippingMap.has(shippingId)) {
+      const method = shippingMap.get(shippingId)
+      ;(item as Record<string, unknown>).shipping_method_code = method?.code ?? null
+      ;(item as Record<string, unknown>).shipping_method_name = method?.name ?? null
+    }
+    const statusId = (item as Record<string, unknown>).status_entry_id
+    if (typeof statusId === 'string' && statusMap.has(statusId)) {
+      const status = statusMap.get(statusId)
+      if (!(item as Record<string, unknown>).status) {
+        ;(item as Record<string, unknown>).status = status?.value ?? null
+      }
+      ;(item as Record<string, unknown>).status_label = status?.label ?? status?.value ?? null
+    }
+  })
 }
 
 const crud = makeCrudRoute({
@@ -153,155 +304,7 @@ const crud = makeCrudRoute({
     },
   },
   hooks: {
-    afterList: async (payload, ctx) => {
-      const items = Array.isArray(payload.items) ? payload.items : []
-      if (!items.length) return
-      const snapshotMap = new Map<string, ReturnType<typeof readShipmentItemsSnapshot>>()
-      items.forEach((item: unknown) => {
-        if (!item || typeof item !== 'object') return
-        const id = (item as Record<string, unknown>).id
-        if (typeof id !== 'string') return
-        const snapshot = readShipmentItemsSnapshot(
-          (item as any).items_snapshot ?? (item as any).itemsSnapshot ?? null
-        )
-        if (snapshot.length) {
-          snapshotMap.set(id, snapshot)
-        }
-      })
-      const shipmentIds = items
-        .map((item: unknown) => (item && typeof item === 'object' ? (item as Record<string, unknown>).id : null))
-        .filter((value: string | null): value is string => typeof value === 'string')
-      if (!shipmentIds.length) return
-      const em = ctx.container.resolve('em') as EntityManager
-      const [shipmentItems, shippingMethods] = await Promise.all([
-        findWithDecryption(
-          em,
-          SalesShipmentItem,
-          { shipment: { $in: shipmentIds } },
-          { populate: ['orderLine'] },
-          { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
-        ),
-        (async () => {
-          const ids: string[] = Array.from(
-            new Set(
-              items
-                .map((item: unknown) => {
-                  if (!item || typeof item !== 'object') return null
-                  const raw = (item as Record<string, unknown>).shipping_method_id
-                  return typeof raw === 'string' ? raw : null
-                })
-                .filter((value: string | null): value is string => typeof value === 'string' && value.length > 0)
-            )
-          )
-          if (!ids.length) return []
-          return em.find(SalesShippingMethod, { id: { $in: ids } })
-        })(),
-      ])
-      const orderLineIds = Array.from(
-        new Set(
-          shipmentItems
-            .map((entry) =>
-              typeof entry.orderLine === 'string'
-                ? entry.orderLine
-                : entry.orderLine?.id ?? (entry as any).orderLineId ?? null
-            )
-            .filter((value): value is string => typeof value === 'string')
-        )
-      )
-      const orderLines = orderLineIds.length
-        ? await em.find(SalesOrderLine, { id: { $in: orderLineIds } })
-        : []
-      const lineMap = new Map(
-        orderLines.map((line) => [
-          line.id,
-          {
-            lineNumber: line.lineNumber ?? null,
-            name:
-              line.name ??
-              (typeof line.catalogSnapshot === 'object' && line.catalogSnapshot
-                ? ((line.catalogSnapshot as any).name as string | undefined) ?? null
-                : null),
-          },
-        ])
-      )
-      const grouped = shipmentItems.reduce<Map<string, Array<Record<string, unknown>>>>((acc, entry) => {
-        const shipmentId =
-          typeof entry.shipment === 'string'
-            ? entry.shipment
-            : entry.shipment?.id ?? (entry as any).shipment_id ?? null
-        const lineId =
-          typeof entry.orderLine === 'string'
-            ? entry.orderLine
-            : entry.orderLine?.id ?? (entry as any).order_line_id ?? null
-        if (!shipmentId || !lineId) return acc
-        const line = lineMap.get(lineId)
-        const list = acc.get(shipmentId) ?? []
-        list.push({
-          id: entry.id,
-          orderLineId: lineId,
-          orderLineName: line?.name ?? null,
-          orderLineNumber: line?.lineNumber ?? null,
-          quantity: toNumber(entry.quantity),
-          metadata: entry.metadata ?? null,
-        })
-        acc.set(shipmentId, list)
-        return acc
-      }, new Map())
-      const shippingMap = new Map(
-        shippingMethods.map((method) => [
-          method.id,
-          {
-            code: method.code ?? null,
-            name: method.name ?? method.code ?? null,
-          },
-        ])
-      )
-      const statusIds: string[] = Array.from(
-        new Set(
-          items
-            .map((item: unknown) => {
-              if (!item || typeof item !== 'object') return null
-              const raw = (item as Record<string, unknown>).status_entry_id
-              return typeof raw === 'string' ? raw : null
-            })
-            .filter((value: string | null): value is string => typeof value === 'string' && value.length > 0)
-        )
-      )
-      const statusMap = new Map<string, { value: string | null; label: string | null }>()
-      if (statusIds.length) {
-        const entries = await em.find(DictionaryEntry, { id: { $in: statusIds } })
-        entries.forEach((entry) =>
-          statusMap.set(entry.id, {
-            value: entry.value ?? null,
-            label: entry.label ?? entry.value ?? null,
-          })
-        )
-      }
-      items.forEach((item: unknown) => {
-        if (!item || typeof item !== 'object') return
-        const id = (item as Record<string, unknown>).id
-        if (typeof id !== 'string') return
-        const snapshot = snapshotMap.get(id)
-        if (snapshot?.length) {
-          ;(item as Record<string, unknown>).items_snapshot = snapshot
-        }
-        ;(item as Record<string, unknown>).items = snapshot?.length ? snapshot : grouped.get(id) ?? []
-        const shippingId = (item as Record<string, unknown>).shipping_method_id
-        if (typeof shippingId === 'string' && shippingMap.has(shippingId)) {
-          const method = shippingMap.get(shippingId)
-          ;(item as Record<string, unknown>).shipping_method_code = method?.code ?? null
-          ;(item as Record<string, unknown>).shipping_method_name = method?.name ?? null
-        }
-        const statusId = (item as Record<string, unknown>).status_entry_id
-        if (typeof statusId === 'string' && statusMap.has(statusId)) {
-          const status = statusMap.get(statusId)
-          if (!(item as Record<string, unknown>).status) {
-            ;(item as Record<string, unknown>).status = status?.value ?? null
-          }
-          ;(item as Record<string, unknown>).status_label = status?.label ?? status?.value ?? null
-        }
-      })
-    },
+    afterList: (payload, ctx) => enrichShipmentListResponse(payload, ctx),
   },
 })
 


### PR DESCRIPTION
Fixes #2131

## Problem
In the shipments list `afterList` hook (`packages/core/src/modules/sales/api/shipments/route.ts`), the `DictionaryEntry` status lookup ran sequentially after the order-line fetch, even though it only depends on the input list `items` (available at the start of the hook). This cost one extra DB round-trip per shipments list page.

## Root Cause
`statusIds` were extracted and the `DictionaryEntry` query was awaited *after* the existing `Promise.all([shipmentItems, shippingMethods])` and after the dependent `SalesOrderLine` fetch, instead of being batched into the initial parallel fetch.

## What Changed
- Hoisted the `statusIds` extraction above the `Promise.all` (it only reads `items`).
- Folded the `DictionaryEntry` lookup in as a third parallel entry of the same `Promise.all`, removing the later sequential `await`.
- Extracted the hook body into an exported `enrichShipmentListResponse(payload, ctx)` so the behavior and the parallelism are directly unit-testable. The `afterList` hook now delegates to it.

Result keys (`status`, `status_label`, `shipping_method_*`, `items`), ordering, and decryption are unchanged — pure parallelization, 100% BC.

## Tests
- New `packages/core/src/modules/sales/api/__tests__/shipments.afterList.test.ts`:
  - Asserts status enrichment from `DictionaryEntry` still works and that the dictionary fetch is invoked **before** the dependent order-line fetch (i.e. in the parallel batch). This assertion fails on the old sequential code (verified by temporarily reverting) and passes on the fix.
  - Asserts the `DictionaryEntry` query is skipped when no `status_entry_id` is present.
- `yarn workspace @open-mercato/core typecheck` passes.
- 5 pre-existing sales suites fail in a fresh worktree for environmental reasons (jsdom component tests + `quotes.acceptance` setup) — confirmed identical failures with this change reverted, so unrelated.

## Backward Compatibility
- No contract surface changes. Response shape, event IDs, ACL, DI, import paths, and DB schema are untouched.
- New `enrichShipmentListResponse` export is purely additive.
- Encrypted `SalesShipmentItem` still goes through `findWithDecryption` with tenant/org scope; the relocated `DictionaryEntry`/`SalesShippingMethod` lookups remain plain `em.find` (non-encrypted lookup entities), matching prior behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)