### PR TITLE
security(customers): scope comment/activity deal enrichment to tenant+org (#2117)

### DIFF
--- a/packages/core/src/modules/customers/api/activities/__tests__/deal-enrichment-scope.test.ts
+++ b/packages/core/src/modules/customers/api/activities/__tests__/deal-enrichment-scope.test.ts
@@ -1,0 +1,130 @@
+/** @jest-environment node */
+
+/**
+ * Regression test for #2117 (audit finding C-03): the legacy activities deal
+ * enrichment (decorateActivityItems) must hard-fail (400) when tenant/org scope
+ * is missing instead of falling through to an unscoped em.find that could
+ * decrypt foreign-tenant deal titles. The deal lookup must also scope its WHERE
+ * clause by tenant + org.
+ */
+
+const mockFindWithDecryption = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+}))
+
+jest.mock('../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn(),
+}))
+
+jest.mock('../../../lib/interactionRequestContext', () => ({
+  resolveCustomersRequestContext: jest.fn(),
+}))
+
+jest.mock('../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(),
+  loadCustomerSummaries: jest.fn(),
+}))
+
+jest.mock('../../../lib/interactionCompatibility', () => ({
+  mapInteractionRecordToActivitySummary: jest.fn(),
+  CUSTOMER_INTERACTION_ACTIVITY_ADAPTER_SOURCE: 'adapter:activity',
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+import { decorateActivityItems } from '../route'
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CustomerDeal } from '../../../data/entities'
+
+const DEAL_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+function makeItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'activity-1',
+    activityType: 'call',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    dealId: DEAL_ID,
+    authorUserId: null,
+    ...overrides,
+  } as Parameters<typeof decorateActivityItems>[1][number]
+}
+
+describe('activities decorateActivityItems deal scope (#2117)', () => {
+  beforeEach(() => {
+    mockFindWithDecryption.mockReset()
+  })
+
+  it('throws 400 when scope is missing and a deal needs enrichment', async () => {
+    const em = { find: jest.fn() }
+    let caught: unknown
+    try {
+      await decorateActivityItems(em as never, [makeItem()], undefined)
+    } catch (err) {
+      caught = err
+    }
+
+    expect(isCrudHttpError(caught)).toBe(true)
+    expect((caught as { status: number }).status).toBe(400)
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(em.find).not.toHaveBeenCalled()
+  })
+
+  it('throws 400 when scope is missing its organization', async () => {
+    const em = { find: jest.fn() }
+    let caught: unknown
+    try {
+      await decorateActivityItems(em as never, [makeItem()], {
+        tenantId: 'tenant-1',
+      } as { tenantId: string; organizationId: string })
+    } catch (err) {
+      caught = err
+    }
+
+    expect(isCrudHttpError(caught)).toBe(true)
+    expect((caught as { status: number }).status).toBe(400)
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(em.find).not.toHaveBeenCalled()
+  })
+
+  it('scopes the deal lookup by tenant and organization in the WHERE clause', async () => {
+    mockFindWithDecryption.mockResolvedValue([{ id: DEAL_ID, title: 'Acme expansion' }])
+    const em = { find: jest.fn().mockResolvedValue([]) }
+
+    const result = await decorateActivityItems(em as never, [makeItem()], {
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+
+    expect(mockFindWithDecryption).toHaveBeenCalledWith(
+      em,
+      CustomerDeal,
+      expect.objectContaining({
+        id: { $in: [DEAL_ID] },
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+      }),
+      undefined,
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+    expect(result[0].dealTitle).toBe('Acme expansion')
+  })
+
+  it('does not require scope when no item references a deal', async () => {
+    const em = { find: jest.fn().mockResolvedValue([]) }
+
+    const result = await decorateActivityItems(
+      em as never,
+      [makeItem({ dealId: null })],
+      undefined,
+    )
+
+    expect(result).toHaveLength(1)
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/activities/route.ts
+++ b/packages/core/src/modules/customers/api/activities/route.ts
@@ -185,7 +185,7 @@ function paginateActivityItems(
   }
 }
 
-async function decorateActivityItems(
+export async function decorateActivityItems(
   em: EntityManager,
   items: ActivityItem[],
   decryptionScope?: { tenantId: string; organizationId: string },
@@ -207,12 +207,23 @@ async function decorateActivityItems(
     ),
   )
 
+  if (dealIds.length > 0 && (!decryptionScope?.tenantId || !decryptionScope?.organizationId)) {
+    const { translate } = await resolveTranslations()
+    throw new CrudHttpError(400, {
+      error: translate('customers.errors.tenant_required', 'Tenant context is required'),
+    })
+  }
+
   const [users, deals] = await Promise.all([
     authorIds.length > 0 ? em.find(User, { id: { $in: authorIds } }) : Promise.resolve([]),
-    dealIds.length > 0
-      ? decryptionScope
-        ? findWithDecryption(em, CustomerDeal, { id: { $in: dealIds } }, undefined, decryptionScope)
-        : em.find(CustomerDeal, { id: { $in: dealIds } })
+    dealIds.length > 0 && decryptionScope
+      ? findWithDecryption(
+          em,
+          CustomerDeal,
+          { id: { $in: dealIds }, tenantId: decryptionScope.tenantId, organizationId: decryptionScope.organizationId },
+          undefined,
+          decryptionScope,
+        )
       : Promise.resolve([]),
   ])
 

--- a/packages/core/src/modules/customers/api/comments/__tests__/missing-scope.test.ts
+++ b/packages/core/src/modules/customers/api/comments/__tests__/missing-scope.test.ts
@@ -1,0 +1,136 @@
+/** @jest-environment node */
+
+/**
+ * Regression test for #2117 (audit finding C-03): the comments afterList deal
+ * enrichment must hard-fail (400) when tenant/org context is missing instead of
+ * falling through to an unscoped em.find that could decrypt foreign-tenant deal
+ * titles. The deal lookup must also scope its WHERE clause by tenant + org.
+ */
+
+const mockFindWithDecryption = jest.fn()
+let capturedCrudOptions: Record<string, any> | null = null
+
+jest.mock('@open-mercato/shared/lib/crud/factory', () => ({
+  makeCrudRoute: jest.fn((opts: Record<string, any>) => {
+    capturedCrudOptions = opts
+    return { GET: jest.fn(), POST: jest.fn(), PUT: jest.fn(), DELETE: jest.fn() }
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+
+const DEAL_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+type AfterListCtx = {
+  auth: { tenantId: string | null; orgId: string | null }
+  selectedOrganizationId: string | null
+  container: { resolve: (token: string) => unknown }
+}
+
+async function runAfterList(
+  payload: { items: unknown[] },
+  ctx: AfterListCtx,
+): Promise<unknown> {
+  let caught: unknown
+  try {
+    await capturedCrudOptions?.hooks?.afterList?.(payload, ctx)
+  } catch (err) {
+    caught = err
+  }
+  return caught
+}
+
+describe('customers comments afterList deal enrichment scope (#2117)', () => {
+  beforeAll(async () => {
+    await import('../route')
+  })
+
+  beforeEach(() => {
+    mockFindWithDecryption.mockReset()
+  })
+
+  it('throws 400 when tenant context is missing and deals need enrichment', async () => {
+    const em = { find: jest.fn() }
+    const ctx: AfterListCtx = {
+      auth: { tenantId: null, orgId: null },
+      selectedOrganizationId: null,
+      container: { resolve: (token) => (token === 'em' ? em : null) },
+    }
+    const caught = await runAfterList({ items: [{ id: 'c1', deal_id: DEAL_ID }] }, ctx)
+
+    expect(isCrudHttpError(caught)).toBe(true)
+    expect((caught as { status: number }).status).toBe(400)
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(em.find).not.toHaveBeenCalled()
+  })
+
+  it('throws 400 when organization context is missing even with a tenant', async () => {
+    const em = { find: jest.fn() }
+    const ctx: AfterListCtx = {
+      auth: { tenantId: 'tenant-1', orgId: null },
+      selectedOrganizationId: null,
+      container: { resolve: (token) => (token === 'em' ? em : null) },
+    }
+    const caught = await runAfterList({ items: [{ id: 'c1', deal_id: DEAL_ID }] }, ctx)
+
+    expect(isCrudHttpError(caught)).toBe(true)
+    expect((caught as { status: number }).status).toBe(400)
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(em.find).not.toHaveBeenCalled()
+  })
+
+  it('scopes the deal lookup by tenant and organization in the WHERE clause', async () => {
+    mockFindWithDecryption.mockResolvedValue([{ id: DEAL_ID, title: 'Acme expansion' }])
+    const em = { find: jest.fn() }
+    const ctx: AfterListCtx = {
+      auth: { tenantId: 'tenant-1', orgId: 'org-1' },
+      selectedOrganizationId: 'org-1',
+      container: { resolve: (token) => (token === 'em' ? em : null) },
+    }
+    const payload = { items: [{ id: 'c1', deal_id: DEAL_ID }] as Record<string, unknown>[] }
+
+    const caught = await runAfterList(payload, ctx)
+
+    expect(caught).toBeUndefined()
+    expect(em.find).not.toHaveBeenCalled()
+    expect(mockFindWithDecryption).toHaveBeenCalledWith(
+      em,
+      expect.anything(),
+      expect.objectContaining({
+        id: { $in: [DEAL_ID] },
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+      }),
+      undefined,
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+    expect(payload.items[0]).toMatchObject({
+      deal_title: 'Acme expansion',
+      dealTitle: 'Acme expansion',
+    })
+  })
+
+  it('does not require scope when no item references a deal', async () => {
+    const em = { find: jest.fn() }
+    const ctx: AfterListCtx = {
+      auth: { tenantId: null, orgId: null },
+      selectedOrganizationId: null,
+      container: { resolve: (token) => (token === 'em' ? em : null) },
+    }
+    const caught = await runAfterList({ items: [{ id: 'c1' }] }, ctx)
+
+    expect(caught).toBeUndefined()
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(em.find).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/comments/route.ts
+++ b/packages/core/src/modules/customers/api/comments/route.ts
@@ -139,13 +139,23 @@ const crud = makeCrudRoute({
         ),
       )
       if (!dealIds.length) return
+      const tenantId = ctx.auth?.tenantId ?? null
+      const organizationId = ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null
+      if (!tenantId || !organizationId) {
+        const { translate } = await resolveTranslations()
+        throw new CrudHttpError(400, {
+          error: translate('customers.errors.tenant_required', 'Tenant context is required'),
+        })
+      }
       try {
         const em = (ctx.container.resolve('em') as EntityManager)
-        const tenantId = ctx.auth?.tenantId ?? null
-        const organizationId = ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null
-        const deals = tenantId && organizationId
-          ? await findWithDecryption(em, CustomerDeal, { id: { $in: dealIds } }, undefined, { tenantId, organizationId })
-          : await em.find(CustomerDeal, { id: { $in: dealIds } })
+        const deals = await findWithDecryption(
+          em,
+          CustomerDeal,
+          { id: { $in: dealIds }, tenantId, organizationId },
+          undefined,
+          { tenantId, organizationId },
+        )
         const map = new Map<string, string>()
         deals.forEach((deal: CustomerDeal) => {
           if (deal.id) map.set(deal.id, deal.title ?? '')


### PR DESCRIPTION
Fixes #2117

## Problem
`customers/api/comments/route.ts` (afterList deal-title enrichment) and `customers/api/activities/route.ts` (`decorateActivityItems`, the legacy adapter) fell back to an **unscoped** `em.find(CustomerDeal, { id: { $in: dealIds } })` whenever `tenantId`/`organizationId` context was absent. That fallback ran with a null decryption scope, so deal titles (encrypted PII) could be decrypted and returned for any deal whose UUID appeared in the page payload — a leak that surfaces if a buggy or malicious upstream (interceptor, custom field, response enricher) injects foreign-tenant deal UUIDs. Audit finding **C-03** (`.ai/runs/2026-05-27-crm-sales-catalog-audit/FINDINGS.md`).

## Root Cause
The enrichment used `tenantId && organizationId ? findWithDecryption(...) : em.find(...)`. The `else` branch had neither tenant nor org filter, and `findWithDecryption` only uses the scope for decryption keys — it does **not** add a WHERE filter — so even the "scoped" branch queried by id alone.

## What Changed
- **comments/route.ts**: the afterList hook now computes scope before the (best-effort) try block and throws `CrudHttpError(400, customers.errors.tenant_required)` when tenant **or** org is missing, instead of falling through. The deal lookup always goes through `findWithDecryption` with the tenant/org **added to the WHERE clause** (`{ id: { $in }, tenantId, organizationId }`). The thrown `CrudHttpError` propagates through the CRUD factory's `handleError` → HTTP 400.
- **activities/route.ts**: `decorateActivityItems` hard-fails the same way when deals need enrichment but scope is missing/incomplete, and scopes the deal WHERE by tenant + org. The GET handler's existing `isCrudHttpError` catch turns it into a 400. The helper is now exported for unit testing (additive).

## Tests
- `api/comments/__tests__/missing-scope.test.ts` (4 cases): 400 on missing tenant, 400 on missing org, scoped WHERE (`id $in` + tenant + org) on the happy path, and no-scope-required when no item references a deal.
- `api/activities/__tests__/deal-enrichment-scope.test.ts` (4 cases): 400 on missing scope, 400 on partial scope, scoped WHERE, and no-scope-required without deals.
- Verified the new activities tests **fail on the pre-fix code** (the old query lacked tenant/org and did not throw) and pass after — genuine regression coverage.
- Validation: `@open-mercato/core` customers `api/` suite 130/130 pass; new suites 8/8; `yarn turbo run typecheck --filter=@open-mercato/core` clean; `yarn i18n:check-sync` in sync; `yarn i18n:check-usage` advisory-only. The `customers.errors.tenant_required` key already exists in all 4 locales (en/pl/es/de). The repo-wide `.tsx` component failures are the known sandbox `React.act is not a function` testing-library mismatch — unrelated.

## Scope notes
- The fix is deliberately limited to the `CustomerDeal` enrichment named in C-03. The pre-existing `em.find(User, …)` in `decorateActivityItems` (author name/email lookup) is unchanged — it was not part of this finding and changing its decryption behavior on a deprecated route is out of scope.
- **Behavior change (intended, per the issue acceptance):** when tenant/org context is genuinely absent (e.g. super-admin with no org selected), these enrichment paths now return 400 rather than unscoped data. Normal authenticated users (org present via `selectedOrganizationId ?? auth.orgId`) are unaffected.

## Backward Compatibility
No contract surface changes: no API response fields removed, no event/widget/ACL/DI/import-path/DB-schema changes. The only new export (`decorateActivityItems`) is additive.