### PR TITLE
test(customers): un-skip TC-CRM-071 + fix create-deal hydration race

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-071-create-deal-redesign.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-071-create-deal-redesign.spec.ts
@@ -60,9 +60,7 @@ async function deleteCustomFieldDefinition(
  * (deal + fixtures) is cleaned up in the finally block. No reliance on seeded/demo data.
  */
 test.describe('TC-CRM-071: Create deal (UX redesign)', () => {
-  test.skip('creates a deal with linked person and company from the redesigned create page', async ({ page, request }) => {
-    // Standalone create-app integration runs time out after the redesign while ephemeral tests pass.
-    // Keep this skipped until the standalone-specific regression is fixed.
+  test('creates a deal with linked person and company from the redesigned create page', async ({ page, request }) => {
     test.slow();
 
     const stamp = Date.now();
@@ -98,6 +96,17 @@ test.describe('TC-CRM-071: Create deal (UX redesign)', () => {
       // section card uses "Create deal" as its title (rendered via DealSectionCard, not an <h1>).
       // Wait for the section card title plus the required field before interacting.
       await expect(page.getByRole('link', { name: /Back to deals/i })).toBeVisible({ timeout: 15_000 });
+
+      // CRITICAL — wait for the form to be fully hydrated before typing. Deal title lives in client
+      // state and the "Create deal" submit button stays disabled until the async custom-field load
+      // resolves (`submitDisabled = !customFieldsLoaded`). Client registries hydrate lazily, so filling
+      // inputs before hydration completes lets React reset the controlled values when it attaches —
+      // the title silently clears and submit is then blocked by "Title is required" (the form never
+      // POSTs, the test times out, and its required custom-field definition is orphaned tenant-wide,
+      // which cascades into the retry). Gating on the enabled submit button guarantees hydration +
+      // custom fields are ready, so every subsequent fill sticks.
+      const submitButton = page.getByRole('button', { name: 'Create deal', exact: true }).first();
+      await expect(submitButton).toBeEnabled({ timeout: 30_000 });
 
       // DealFormField associates each <Label> with its control via useId/htmlFor, so the required
       // title field exposes the accessible label "Deal title" (plus a "*" required marker) — target it


### PR DESCRIPTION
## Summary
Re-enables `TC-CRM-071` (create-deal redesign), which develop currently **skips** as a release stopgap ("standalone create-app integration runs time out after the redesign while ephemeral tests pass"), and fixes the underlying race so it passes reliably.

Extracted from the merged PR #2202 (which carried only the sales-shard fix after being squash-merged early).

## Root cause (from the run-26574881201 trace + failure screenshots)
- The test filled the deal **title** before the redesigned form finished hydrating its lazily-loaded client registries (PR #2129). React reset the controlled title input on hydration → "Title is required" blocked submit → the form never POSTed (`waitForResponse` waited 52s, **zero** `POST /api/customers/deals` in the network log) → 60s timeout.
- The timed-out test couldn't run its `finally` cleanup (context closed), **orphaning the tenant-wide required custom-field definition**, which then blocked the retry's submit too (cascade — confirmed by two differently-stamped required fields in the retry screenshot).
- Load-dependent: the standalone job (full suite, single serial server) hydrates slower so the race fires; ephemeral shards pass. Regressed once client registries became lazy (#2129); passed before because hydration was eager.

## Fix
Gate the test on the "Create deal" submit button being **enabled** — which only happens after custom fields load (i.e. after hydration, since `submitDisabled = !customFieldsLoaded`) — before typing any field. Every fill then sticks, the form POSTs, the test passes, and its cleanup runs (breaking the orphan cascade). Test-only; no product change.

## Test plan
- [ ] **Standalone App Integration Tests** runs and passes the now-un-skipped `TC-CRM-071` (the authoritative check — it's the job that was timing out).
- [ ] Ephemeral shards stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)