### PR TITLE
Fix CRM customer list server-side sorting

### DIFF
--- a/packages/core/src/modules/customers/api/companies/route.ts
+++ b/packages/core/src/modules/customers/api/companies/route.ts
@@ -114,6 +114,12 @@ const crud = makeCrudRoute({
     ],
     sortFieldMap: {
       name: 'display_name',
+      email: 'primary_email',
+      primaryEmail: 'primary_email',
+      status: 'status',
+      lifecycleStage: 'lifecycle_stage',
+      source: 'source',
+      nextInteractionAt: 'next_interaction_at',
       createdAt: 'created_at',
       updatedAt: 'updated_at',
     },

--- a/packages/core/src/modules/customers/api/deals/__tests__/route.filters.test.ts
+++ b/packages/core/src/modules/customers/api/deals/__tests__/route.filters.test.ts
@@ -1,6 +1,32 @@
 /** @jest-environment node */
 
 import { buildDealListFilters, dealListQuerySchema } from '../route'
+import type { CrudCtx } from '@open-mercato/shared/lib/crud/factory'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+
+function createDealFilterContext(rows: Array<{ id: string }>, url = 'https://example.test/api/customers/deals'): {
+  ctx: CrudCtx
+  execute: jest.Mock
+} {
+  const execute = jest.fn(async () => rows)
+  const em = {
+    getConnection: () => ({ execute }),
+  }
+  const ctx = {
+    auth: { tenantId, orgId: organizationId },
+    request: new Request(url),
+    container: {
+      resolve: (key: string) => {
+        if (key !== 'em') throw new Error(`Unexpected container key: ${key}`)
+        return em
+      },
+    },
+  } as unknown as CrudCtx
+
+  return { ctx, execute }
+}
 
 describe('customers deals list filters', () => {
   it('parses explicit false booleans without applying stuck or overdue filters', async () => {
@@ -91,5 +117,66 @@ describe('customers deals list filters', () => {
     const parsed = dealListQuerySchema.parse({ isStuck: 'true' })
     const filters = await buildDealListFilters(parsed)
     expect(filters.id).toBeUndefined()
+  })
+
+  it('narrows canonical personId/companyId filters before pagination', async () => {
+    const personA = '33333333-3333-4333-8333-333333333333'
+    const personB = '44444444-4444-4444-8444-444444444444'
+    const companyA = '55555555-5555-4555-8555-555555555555'
+    const dealA = '66666666-6666-4666-8666-666666666666'
+    const dealB = '77777777-7777-4777-8777-777777777777'
+    const { ctx, execute } = createDealFilterContext([{ id: dealA }, { id: dealB }])
+    const parsed = dealListQuerySchema.parse({
+      personId: `${personA},${personB}`,
+      companyId: [companyA],
+    })
+
+    const filters = await buildDealListFilters(parsed, ctx)
+
+    expect(filters.id).toEqual({ $in: [dealA, dealB] })
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(execute.mock.calls[0]?.[0]).toContain('FROM customer_deals')
+    expect(execute.mock.calls[0]?.[0]).toContain('customer_deal_people')
+    expect(execute.mock.calls[0]?.[0]).toContain('customer_deal_companies')
+    expect(execute.mock.calls[0]?.[1]).toEqual([
+      organizationId,
+      tenantId,
+      personA,
+      personB,
+      companyA,
+    ])
+  })
+
+  it('keeps legacy personEntityId/companyEntityId aliases as pre-pagination filters', async () => {
+    const personA = '33333333-3333-4333-8333-333333333333'
+    const personB = '44444444-4444-4444-8444-444444444444'
+    const companyA = '55555555-5555-4555-8555-555555555555'
+    const dealA = '66666666-6666-4666-8666-666666666666'
+    const url =
+      `https://example.test/api/customers/deals?personEntityId=${personA}` +
+      `&personEntityId=${personB}&companyEntityId=${companyA}`
+    const { ctx, execute } = createDealFilterContext([{ id: dealA }], url)
+    const parsed = dealListQuerySchema.parse({})
+
+    const filters = await buildDealListFilters(parsed, ctx)
+
+    expect(filters.id).toEqual({ $in: [dealA] })
+    expect(execute.mock.calls[0]?.[1]).toEqual([
+      organizationId,
+      tenantId,
+      personA,
+      personB,
+      companyA,
+    ])
+  })
+
+  it('collapses person/company association filters to no-match before pagination', async () => {
+    const personA = '33333333-3333-4333-8333-333333333333'
+    const { ctx } = createDealFilterContext([])
+    const parsed = dealListQuerySchema.parse({ personId: personA })
+
+    const filters = await buildDealListFilters(parsed, ctx)
+
+    expect(filters.id).toEqual({ $eq: '00000000-0000-0000-0000-000000000000' })
   })
 })

--- a/packages/core/src/modules/customers/api/people/route.ts
+++ b/packages/core/src/modules/customers/api/people/route.ts
@@ -108,6 +108,12 @@ const crud = makeCrudRoute({
     ],
     sortFieldMap: {
       name: 'display_name',
+      email: 'primary_email',
+      primaryEmail: 'primary_email',
+      status: 'status',
+      lifecycleStage: 'lifecycle_stage',
+      source: 'source',
+      nextInteractionAt: 'next_interaction_at',
       createdAt: 'created_at',
       updatedAt: 'updated_at',
     },

--- a/packages/core/src/modules/customers/backend/customers/__tests__/listSorting.test.ts
+++ b/packages/core/src/modules/customers/backend/customers/__tests__/listSorting.test.ts
@@ -28,7 +28,7 @@ describe('customer list sorting', () => {
       { id: 'name', desc: false },
     ])
 
-    expect(params.get('sort')).toBe('cf:created_at_external')
-    expect(params.get('order')).toBe('desc')
+    expect(params.get('sortField')).toBe('cf:created_at_external')
+    expect(params.get('sortDir')).toBe('desc')
   })
 })

--- a/packages/core/src/modules/customers/backend/customers/__tests__/listSorting.test.ts
+++ b/packages/core/src/modules/customers/backend/customers/__tests__/listSorting.test.ts
@@ -1,0 +1,34 @@
+import { appendCustomerListSortParams, resolveCustomerListSortField } from '../listSorting'
+
+describe('customer list sorting', () => {
+  it('maps supported table columns to API sort fields', () => {
+    expect(resolveCustomerListSortField('name')).toBe('name')
+    expect(resolveCustomerListSortField('email')).toBe('primaryEmail')
+    expect(resolveCustomerListSortField('status')).toBe('status')
+    expect(resolveCustomerListSortField('lifecycleStage')).toBe('lifecycleStage')
+    expect(resolveCustomerListSortField('source')).toBe('source')
+    expect(resolveCustomerListSortField('nextInteractionAt')).toBe('nextInteractionAt')
+  })
+
+  it('normalizes custom field column ids to query-engine selectors', () => {
+    expect(resolveCustomerListSortField('cf_created_at_external')).toBe('cf:created_at_external')
+    expect(resolveCustomerListSortField('cf:created_at_external')).toBe('cf:created_at_external')
+  })
+
+  it('ignores unsupported table columns', () => {
+    expect(resolveCustomerListSortField('description')).toBeNull()
+    expect(resolveCustomerListSortField('unknown')).toBeNull()
+  })
+
+  it('appends only the first supported active sort', () => {
+    const params = new URLSearchParams()
+
+    appendCustomerListSortParams(params, [
+      { id: 'cf_created_at_external', desc: true },
+      { id: 'name', desc: false },
+    ])
+
+    expect(params.get('sort')).toBe('cf:created_at_external')
+    expect(params.get('order')).toBe('desc')
+  })
+})

--- a/packages/core/src/modules/customers/backend/customers/companies/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/companies/page.tsx
@@ -819,6 +819,7 @@ export default function CustomersCompaniesPage() {
       .map<ColumnDef<CompanyRow>>((def) => ({
         accessorKey: `cf_${def.key}`,
         header: def.label || def.key,
+        enableSorting: true,
         meta: {
           columnChooserGroup: def.group?.title ?? 'Custom Fields',
           filterGroup: def.group?.title ?? 'Custom Fields',

--- a/packages/core/src/modules/customers/backend/customers/companies/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/companies/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { DataTable, type DataTableExportFormat, withDataTableNamespaces } from '@open-mercato/ui/backend/DataTable'
-import type { ColumnDef } from '@tanstack/react-table'
+import type { ColumnDef, SortingState } from '@tanstack/react-table'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { RowActions } from '@open-mercato/ui/backend/RowActions'
 import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
@@ -53,6 +53,7 @@ import {
   mapAssignableStaffToFilterOptions,
 } from '../../../components/detail/assignableStaff'
 import { CollectionPreviewCell, normalizeCollectionLabels } from '../../../components/list/CollectionPreviewCell'
+import { appendCustomerListSortParams } from '../listSorting'
 
 type DictionaryOptionWithTone = AdvancedFilterOption & FilterOption
 
@@ -191,7 +192,7 @@ export default function CustomersCompaniesPage() {
   const [rows, setRows] = React.useState<CompanyRow[]>([])
   const [page, setPage] = React.useState(1)
   const [pageSize, setPageSize] = React.useState(20)
-  const [sorting, setSorting] = React.useState<import('@tanstack/react-table').SortingState>([])
+  const [sorting, setSorting] = React.useState<SortingState>([])
   const [total, setTotal] = React.useState(0)
   const [totalPages, setTotalPages] = React.useState(1)
   const [search, setSearch] = React.useState('')
@@ -244,6 +245,10 @@ export default function CustomersCompaniesPage() {
   const router = useRouter()
   const handlePageSizeChange = React.useCallback((newSize: number) => {
     setPageSize(newSize)
+    setPage(1)
+  }, [])
+  const handleSortingChange = React.useCallback((nextSorting: SortingState) => {
+    setSorting(nextSorting)
     setPage(1)
   }, [])
 
@@ -350,10 +355,7 @@ export default function CustomersCompaniesPage() {
     const params = new URLSearchParams()
     params.set('page', String(page))
     params.set('pageSize', String(pageSize))
-    if (sorting.length > 0) {
-      params.set('sort', sorting[0].id)
-      params.set('order', sorting[0].desc ? 'desc' : 'asc')
-    }
+    appendCustomerListSortParams(params, sorting)
     if (search.trim()) params.set('search', search.trim())
     const advancedParams = serializeTree(advancedFilterState)
     for (const [key, val] of Object.entries(advancedParams)) {
@@ -374,10 +376,7 @@ export default function CustomersCompaniesPage() {
     const params = new URLSearchParams()
     if (search.trim().length) params.set('search', search.trim())
     if (page > 1) params.set('page', String(page))
-    if (sorting.length > 0) {
-      params.set('sort', sorting[0].id)
-      params.set('order', sorting[0].desc ? 'desc' : 'asc')
-    }
+    appendCustomerListSortParams(params, sorting)
     const advancedParams = serializeTree(advancedFilterState)
     for (const [key, val] of Object.entries(advancedParams)) {
       params.set(key, val)
@@ -887,8 +886,9 @@ export default function CustomersCompaniesPage() {
           onRowClick={(row) => router.push(`/backend/customers/companies-v2/${row.id}`)}
           perspective={{ tableId: 'customers.companies.list' }}
           sortable
+          manualSorting
           sorting={sorting}
-          onSortingChange={setSorting}
+          onSortingChange={handleSortingChange}
           bulkActions={[
             {
               id: 'delete',

--- a/packages/core/src/modules/customers/backend/customers/listSorting.ts
+++ b/packages/core/src/modules/customers/backend/customers/listSorting.ts
@@ -1,0 +1,27 @@
+import type { SortingState } from '@tanstack/react-table'
+
+const CUSTOMER_LIST_SORT_FIELDS: Record<string, string> = {
+  name: 'name',
+  email: 'primaryEmail',
+  status: 'status',
+  lifecycleStage: 'lifecycleStage',
+  source: 'source',
+  nextInteractionAt: 'nextInteractionAt',
+}
+
+export function resolveCustomerListSortField(columnId: string): string | null {
+  const normalized = columnId.trim()
+  if (!normalized) return null
+  if (normalized.startsWith('cf:')) return normalized
+  if (normalized.startsWith('cf_')) return `cf:${normalized.slice(3)}`
+  return CUSTOMER_LIST_SORT_FIELDS[normalized] ?? null
+}
+
+export function appendCustomerListSortParams(params: URLSearchParams, sorting: SortingState): void {
+  const activeSort = sorting[0]
+  if (!activeSort) return
+  const sortField = resolveCustomerListSortField(activeSort.id)
+  if (!sortField) return
+  params.set('sort', sortField)
+  params.set('order', activeSort.desc ? 'desc' : 'asc')
+}

--- a/packages/core/src/modules/customers/backend/customers/listSorting.ts
+++ b/packages/core/src/modules/customers/backend/customers/listSorting.ts
@@ -22,6 +22,6 @@ export function appendCustomerListSortParams(params: URLSearchParams, sorting: S
   if (!activeSort) return
   const sortField = resolveCustomerListSortField(activeSort.id)
   if (!sortField) return
-  params.set('sort', sortField)
-  params.set('order', activeSort.desc ? 'desc' : 'asc')
+  params.set('sortField', sortField)
+  params.set('sortDir', activeSort.desc ? 'desc' : 'asc')
 }

--- a/packages/core/src/modules/customers/backend/customers/people/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people/page.tsx
@@ -846,6 +846,7 @@ export default function CustomersPeoplePage() {
       .map<ColumnDef<PersonRow>>((def) => ({
         accessorKey: `cf_${def.key}`,
         header: def.label || def.key,
+        enableSorting: true,
         meta: {
           columnChooserGroup: def.group?.title ?? 'Custom Fields',
           filterGroup: def.group?.title ?? 'Custom Fields',

--- a/packages/core/src/modules/customers/backend/customers/people/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { DataTable, type DataTableExportFormat, withDataTableNamespaces } from '@open-mercato/ui/backend/DataTable'
-import type { ColumnDef } from '@tanstack/react-table'
+import type { ColumnDef, SortingState } from '@tanstack/react-table'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { RowActions } from '@open-mercato/ui/backend/RowActions'
 import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
@@ -53,6 +53,7 @@ import {
   mapAssignableStaffToFilterOptions,
 } from '../../../components/detail/assignableStaff'
 import { CollectionPreviewCell, normalizeCollectionLabels } from '../../../components/list/CollectionPreviewCell'
+import { appendCustomerListSortParams } from '../listSorting'
 
 type DictionaryOptionWithTone = AdvancedFilterOption & FilterOption
 
@@ -199,7 +200,7 @@ export default function CustomersPeoplePage() {
   const [rows, setRows] = React.useState<PersonRow[]>([])
   const [page, setPage] = React.useState(1)
   const [pageSize, setPageSize] = React.useState(20)
-  const [sorting, setSorting] = React.useState<import('@tanstack/react-table').SortingState>([])
+  const [sorting, setSorting] = React.useState<SortingState>([])
   const [total, setTotal] = React.useState(0)
   const [totalPages, setTotalPages] = React.useState(1)
   const [search, setSearch] = React.useState('')
@@ -254,6 +255,10 @@ export default function CustomersPeoplePage() {
   const router = useRouter()
   const handlePageSizeChange = React.useCallback((newSize: number) => {
     setPageSize(newSize)
+    setPage(1)
+  }, [])
+  const handleSortingChange = React.useCallback((nextSorting: SortingState) => {
+    setSorting(nextSorting)
     setPage(1)
   }, [])
 
@@ -361,10 +366,7 @@ export default function CustomersPeoplePage() {
     const params = new URLSearchParams()
     params.set('page', String(page))
     params.set('pageSize', String(pageSize))
-    if (sorting.length > 0) {
-      params.set('sort', sorting[0].id)
-      params.set('order', sorting[0].desc ? 'desc' : 'asc')
-    }
+    appendCustomerListSortParams(params, sorting)
     if (search.trim()) params.set('search', search.trim())
     const advancedParams = serializeTree(advancedFilterState)
     for (const [key, val] of Object.entries(advancedParams)) {
@@ -386,10 +388,7 @@ export default function CustomersPeoplePage() {
     const params = new URLSearchParams()
     if (search.trim().length) params.set('search', search.trim())
     if (page > 1) params.set('page', String(page))
-    if (sorting.length > 0) {
-      params.set('sort', sorting[0].id)
-      params.set('order', sorting[0].desc ? 'desc' : 'asc')
-    }
+    appendCustomerListSortParams(params, sorting)
     const advancedParams = serializeTree(advancedFilterState)
     for (const [key, val] of Object.entries(advancedParams)) {
       params.set(key, val)
@@ -914,8 +913,9 @@ export default function CustomersPeoplePage() {
           perspective={{ tableId: 'customers.people.list' }}
           onRowClick={(row) => router.push(`/backend/customers/people-v2/${row.id}`)}
           sortable
+          manualSorting
           sorting={sorting}
-          onSortingChange={setSorting}
+          onSortingChange={handleSortingChange}
           bulkActions={[
             {
               id: 'delete',

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -1,3 +1,7 @@
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: async (_tenantId: string | null, fn: () => Promise<unknown>) => fn(),
+}), { virtual: true })
+
 import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
 import { registerApiInterceptors } from '@open-mercato/shared/lib/crud/interceptor-registry'
 import { z } from 'zod'
@@ -247,6 +251,16 @@ describe('CRUD Factory', () => {
     expect(queryArgs?.filters).toEqual({
       id: { $in: [idA, idB] },
     })
+  })
+
+  it('GET normalizes custom field sort selectors for the query engine path', async () => {
+    await route.GET(new Request('http://x/api/example/todos?page=1&pageSize=10&sortField=cf_priority&sortDir=desc'))
+
+    expect(queryEngine.query).toHaveBeenCalled()
+    const queryArgs = queryEngine.query.mock.calls.at(-1)?.[1]
+    expect(queryArgs?.sort).toEqual([
+      { field: 'cf:priority', dir: 'desc' },
+    ])
   })
 
   it('GET intersects ids with existing buildFilters id constraint', async () => {

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -76,6 +76,11 @@ function resolveSortParams(queryParams: Record<string, unknown>) {
   const sortDir = normalizedDir === 'desc' ? SortDir.Desc : SortDir.Asc
   return { sortField, sortDir }
 }
+
+function normalizeSortFieldSelector(sortField: string): string {
+  if (sortField.startsWith('cf_')) return `cf:${sortField.slice(3)}`
+  return sortField
+}
 /**
  * Translates column-name filter keys to MikroORM property names so the ORM
  * fallback path can apply buildFilters correctly.  Without this, filters like
@@ -1482,7 +1487,8 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
         const qe = (ctx.container.resolve('queryEngine') as QueryEngine)
         profiler.mark('query_engine_resolved')
         const { sortField: sortFieldRaw, sortDir: sortDirRaw } = resolveSortParams(queryParams as Record<string, unknown>)
-        const sortField = (opts.list.sortFieldMap && opts.list.sortFieldMap[sortFieldRaw]) || sortFieldRaw
+        const mappedSortField = (opts.list.sortFieldMap && opts.list.sortFieldMap[sortFieldRaw]) || sortFieldRaw
+        const sortField = typeof mappedSortField === 'string' ? normalizeSortFieldSelector(mappedSortField) : mappedSortField
         const sort: Sort[] = [{ field: sortField as any, dir: sortDirRaw } as any]
         const page: Page = exportRequested
           ? { page: 1, pageSize: exportPageSize }

--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -216,6 +216,7 @@ export type DataTableProps<T> = {
   actions?: React.ReactNode
   refreshButton?: DataTableRefreshButton
   sortable?: boolean
+  manualSorting?: boolean
   sorting?: SortingState
   onSortingChange?: (s: SortingState) => void
   pagination?: PaginationProps
@@ -941,6 +942,7 @@ export function DataTable<T>({
   actions,
   refreshButton,
   sortable,
+  manualSorting,
   sorting: sortingProp,
   onSortingChange,
   pagination,
@@ -1424,11 +1426,13 @@ export function DataTable<T>({
   const hasInjectedBulkActions = injectedBulkActions.length > 0 || hasPropBulkActions
   const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({})
   const selectionScopeKeyRef = React.useRef<string | undefined>(selectionScopeKey)
+  const enableClientSorting = sortable && !manualSorting
   const table = useReactTable<T>({
     data: clientFilteredData,
     columns: mergedColumns,
     getCoreRowModel: getCoreRowModel(),
-    ...(sortable ? { getSortedRowModel: getSortedRowModel() } : {}),
+    ...(enableClientSorting ? { getSortedRowModel: getSortedRowModel() } : {}),
+    manualSorting: manualSorting === true,
     getRowId: resolveDataTableRowId,
     state: { sorting, columnVisibility, columnOrder, rowSelection },
     enableRowSelection: hasInjectedBulkActions,

--- a/packages/ui/src/backend/__tests__/DataTable.render.test.tsx
+++ b/packages/ui/src/backend/__tests__/DataTable.render.test.tsx
@@ -1,13 +1,19 @@
+/** @jest-environment jsdom */
 import * as React from 'react'
 import { renderToString } from 'react-dom/server'
 import { DataTable } from '../DataTable'
 import type { ColumnDef } from '@tanstack/react-table'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+import { fireEvent, render, screen } from '@testing-library/react'
 
 // Mock next/navigation for SSR compatibility of client components
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+}))
+
+jest.mock('../injection/useInjectionDataWidgets', () => ({
+  useInjectionDataWidgets: () => ({ widgets: [], isLoading: false }),
 }))
 
 type Row = { id: string; name: string }
@@ -77,6 +83,47 @@ describe('DataTable SSR render', () => {
       )
       expect(html).toContain('whitespace-nowrap')
       expect(html).toContain('per page')
+    } finally {
+      queryClient.clear()
+    }
+  })
+
+  it('keeps provided row order in manual sorting mode and reports sorting changes', () => {
+    const columns: ColumnDef<Row>[] = [
+      { accessorKey: 'name', header: 'Name' },
+    ]
+    const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+    const onSortingChange = jest.fn()
+    try {
+      const { container } = render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider locale="en" dict={{}}>
+            <DataTable
+              columns={columns}
+              data={[
+                { id: '2', name: 'Zed' },
+                { id: '1', name: 'Ada' },
+              ]}
+              sortable
+              manualSorting
+              sorting={[]}
+              onSortingChange={onSortingChange}
+            />
+          </I18nProvider>
+        </QueryClientProvider>,
+      )
+
+      const beforeText = container.textContent ?? ''
+      expect(beforeText.indexOf('Zed')).toBeGreaterThanOrEqual(0)
+      expect(beforeText.indexOf('Zed')).toBeLessThan(beforeText.indexOf('Ada'))
+
+      fireEvent.click(screen.getByRole('button', { name: /name/i }))
+
+      expect(onSortingChange).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ id: 'name' })]),
+      )
+      const afterText = container.textContent ?? ''
+      expect(afterText.indexOf('Zed')).toBeLessThan(afterText.indexOf('Ada'))
     } finally {
       queryClient.clear()
     }


### PR DESCRIPTION
## Summary

- Move CRM people/companies list sorting to server-driven query params so header clicks sort the full result set, not only the currently loaded page.
- Add support for sorting CRM custom-field columns by mapping `cf_<key>` UI column ids to `cf:<key>` API sort fields.
- Add regression coverage for deal association filters so `personId`/`personEntityId` and `companyId`/`companyEntityId` continue narrowing deal ids before pagination.

## Related issue

Should close #1717.

The current `develop` branch already contains the pre-pagination deal association filtering path. This PR adds a focused regression test for the exact contract described in #1717 so it does not regress while also fixing the adjacent CRM-list server-side query behavior.

## Notes

- `DataTable` gets an additive `manualSorting?: boolean` prop. Existing tables keep client-side sorting unless they opt in.
- People and companies backend pages now control sorting state, reset to page 1 on sort change, and send `sortField`/`sortDir` to their APIs.
- Custom field sort params are normalized defensively in the CRUD route factory, accepting both `cf_created_at_external` and `cf:created_at_external` forms.

## Testing

- `corepack yarn build:packages`
- `corepack yarn workspace @open-mercato/core test src/modules/customers/api/deals/__tests__/route.filters.test.ts --runInBand`
- `corepack yarn workspace @open-mercato/core test src/modules/customers/backend/customers/__tests__/listSorting.test.ts --runInBand`
- `corepack yarn workspace @open-mercato/ui test src/backend/__tests__/DataTable.render.test.tsx --runInBand`
- `corepack yarn workspace @open-mercato/shared test src/lib/crud/__tests__/crud-factory.test.ts --runInBand`

## Preview validation

Read-only browser validation on `https://preview-customer-list-server-sorting-0207e2.om.they.dev`:

- Logged in with the demo admin account and opened `/backend/customers/people`.
- Clicking the standard `Nazwa` header issued a server/RSC navigation with `sortField=name&sortDir=asc` instead of sorting only the current in-memory page.
- The custom-field column `Sort Date E2E` was visible in the people table; triggering its header issued `/backend/customers/people?sortField=cf%3Asort_date_e2e&sortDir=asc`.
- The rendered table showed the custom date values in ascending order (`2026-01-01`, `2026-01-02`, `2026-01-03`, ...), and direct API reads confirmed `sortField=cf:sort_date_e2e` is accepted by the backend.
