### PR TITLE
test(core): stabilize TC-INT-004 — raise per-test timeout budget

### DIFF
--- a/packages/core/src/modules/core/__integration__/integration/TC-INT-004.spec.ts
+++ b/packages/core/src/modules/core/__integration__/integration/TC-INT-004.spec.ts
@@ -9,6 +9,7 @@ import { createUserViaUi } from '@open-mercato/core/modules/core/__integration__
  */
 test.describe('TC-INT-004: User to Role to Permission to Access Verification', () => {
   test('should apply restricted role and deny access to protected admin area', async ({ page, request }) => {
+    test.setTimeout(90_000);
     const stamp = Date.now();
     const roleName = `qa-int-004-role-${stamp}`;
     const email = `qa-int-004-${stamp}@acme.com`;
@@ -49,7 +50,7 @@ test.describe('TC-INT-004: User to Role to Permission to Access Verification', (
       await limitedPage.getByLabel('Email').fill(email);
       await limitedPage.getByLabel('Password', { exact: true }).fill(password);
       await limitedPage.getByLabel('Password', { exact: true }).press('Enter');
-      await limitedPage.waitForURL(/\/backend|\/login\?requireFeature=/, { timeout: 10_000 });
+      await limitedPage.waitForURL(/\/backend|\/login\?requireFeature=/, { timeout: 30_000 });
 
       if (/\/login\?requireFeature=/.test(limitedPage.url())) {
         await expect(limitedPage.getByText(/don't have access to this feature|permission/i).first()).toBeVisible();


### PR DESCRIPTION
## Summary

`TC-INT-004` (User → Role → Permission → Access Verification) is the integration test currently failing the `ephemeral-integration (7/15)` shard on **develop** (run `26631220573`, head `efaafadf7`). This stabilizes it.

## Root cause — timing/budget flake, **not** a regression

- The global Playwright per-test timeout is **20s** (`.ai/qa/tests/playwright.config.ts:61`, `workers: 1`, `retries: 1`).
- Every sibling in the TC-INT group already raises its budget: **TC-INT-001/003/005 → 60s**, **TC-INT-002 → 180s**. `TC-INT-004` was the **only one left on the 20s default**, yet it's the **heaviest UI flow** in the group:
  - admin login → create a role via the UI → create a user via the UI → open a **fresh browser context** → log in as the restricted user → assert the post-login redirect.
- Under shard-7 load the test exhausted its 20s budget at the post-login `waitForURL(/\/backend|\/login\?requireFeature=/)`, failing both the initial attempt **and** the retry. In the same run TC-INT-002 took 20.3s wall-clock — the whole shard was running hot.
- This is **not** caused by the recently-merged ACL dependency bundles (#2141/#2201/#2208/#2220):
  - shard 7 **passed** on #2141's own CI (run `26628806542`) with identical code,
  - the `TC-INT-004.spec.ts` file is unchanged,
  - the `/backend` dashboard requires only `requireAuth` (no features), so a featureless user renders it fine.

## Changes

- `test.setTimeout(90_000)` on TC-INT-004 — above the 60s siblings because this flow performs two UI-driven entity creations **plus** a second-context login.
- Post-login `waitForURL` timeout raised **10s → 30s** so the navigation has room to commit under load (matches TC-INT-002's 30s URL-wait convention).

Mirrors the previously-merged stabilization pattern in #2202 (`test.slow()`/budget for heavy UI flows). Test-only change; no production code touched.

## Testing

- Spec transpiles with no syntax errors; `test.setTimeout(N)` matches the verbatim sibling pattern.
- Integration suite is **CI-authoritative** (no local Postgres/Redis in this environment) — shard 7/15 is the gate to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)