### PR TITLE
feat(gateway_stripe): declare ACL feature dependencies (#2175)

### DIFF
--- a/packages/gateway-stripe/src/modules/gateway_stripe/__tests__/acl-dependencies.test.ts
+++ b/packages/gateway-stripe/src/modules/gateway_stripe/__tests__/acl-dependencies.test.ts
@@ -1,0 +1,82 @@
+/** @jest-environment node */
+
+import { describe, test, expect } from '@jest/globals'
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as gatewayStripeFeatures } from '../acl'
+import { features as paymentGatewaysFeatures } from '@open-mercato/core/modules/payment_gateways/acl'
+
+// The gateway_stripe dependency table (spec §6.36) references features from the
+// payment_gateways module, so the catalog the resolver checks against must
+// include them.
+const combinedCatalog: FeatureDescriptor[] = [
+  ...(gatewayStripeFeatures as FeatureDescriptor[]),
+  ...(paymentGatewaysFeatures as FeatureDescriptor[]),
+]
+
+const gatewayStripeFeatureIds = (gatewayStripeFeatures as FeatureDescriptor[]).map((f) => f.id)
+
+describe('gateway_stripe ACL dependency declarations', () => {
+  test('every gateway_stripe dependency resolves to a known feature (no unknown references)', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(
+      combinedCatalog.map((f) => f.id),
+      combinedCatalog,
+    )
+    const gatewayStripeUnknown = diagnostics.unknownReferences.filter((entry) =>
+      entry.feature.startsWith('gateway_stripe.'),
+    )
+    expect(gatewayStripeUnknown).toEqual([])
+  })
+
+  test('view depends on the payment gateways read feature', () => {
+    const view = (gatewayStripeFeatures as FeatureDescriptor[]).find(
+      (f) => f.id === 'gateway_stripe.view',
+    )
+    expect(view?.dependsOn).toEqual(['payment_gateways.view'])
+  })
+
+  test('configure depends on the local view feature and the payment gateways manage feature', () => {
+    const configure = (gatewayStripeFeatures as FeatureDescriptor[]).find(
+      (f) => f.id === 'gateway_stripe.configure',
+    )
+    expect([...(configure?.dependsOn ?? [])].sort()).toEqual(
+      ['gateway_stripe.view', 'payment_gateways.manage'].sort(),
+    )
+  })
+
+  test('granting gateway_stripe.view alone surfaces the missing payment_gateways read dependency', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(['gateway_stripe.view'], combinedCatalog)
+    const viewEntry = diagnostics.missingDependencies.find(
+      (entry) => entry.feature === 'gateway_stripe.view',
+    )
+    expect(viewEntry).toBeDefined()
+    expect([...(viewEntry?.missing ?? [])]).toEqual(['payment_gateways.view'])
+  })
+
+  test('granting gateway_stripe.configure alone surfaces both declared dependencies', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(
+      ['gateway_stripe.configure'],
+      combinedCatalog,
+    )
+    const configureEntry = diagnostics.missingDependencies.find(
+      (entry) => entry.feature === 'gateway_stripe.configure',
+    )
+    expect(configureEntry).toBeDefined()
+    expect([...(configureEntry?.missing ?? [])].sort()).toEqual(
+      ['gateway_stripe.view', 'payment_gateways.manage'].sort(),
+    )
+  })
+
+  test('granting all referenced features clears gateway_stripe dependency warnings', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(
+      combinedCatalog.map((f) => f.id),
+      combinedCatalog,
+    )
+    const gatewayStripeMissing = diagnostics.missingDependencies.filter((entry) =>
+      entry.feature.startsWith('gateway_stripe.'),
+    )
+    expect(gatewayStripeMissing).toEqual([])
+  })
+})

--- a/packages/gateway-stripe/src/modules/gateway_stripe/acl.ts
+++ b/packages/gateway-stripe/src/modules/gateway_stripe/acl.ts
@@ -1,6 +1,16 @@
 export const features = [
-  { id: 'gateway_stripe.view', title: 'View Stripe gateway configuration', module: 'gateway_stripe' },
-  { id: 'gateway_stripe.configure', title: 'Configure Stripe gateway settings', module: 'gateway_stripe' },
+  {
+    id: 'gateway_stripe.view',
+    title: 'View Stripe gateway configuration',
+    module: 'gateway_stripe',
+    dependsOn: ['payment_gateways.view'],
+  },
+  {
+    id: 'gateway_stripe.configure',
+    title: 'Configure Stripe gateway settings',
+    module: 'gateway_stripe',
+    dependsOn: ['gateway_stripe.view', 'payment_gateways.manage'],
+  },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2175

## Problem
Per-module follow-up to PR #2141 (ACL dependency bundles). The `gateway_stripe` provider module's `acl.ts` did not declare `dependsOn` for its features, so the `AclEditor` could not warn operators when a granted Stripe feature's prerequisite payment-gateway features were missing.

## Root Cause
`gateway_stripe` features (`gateway_stripe.view`, `gateway_stripe.configure`) shipped without the `dependsOn` arrays that the dependency resolver introduced in #2141.

## What Changed
- `packages/gateway-stripe/src/modules/gateway_stripe/acl.ts`: declared dependencies per spec [§6.36](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md#636-gateway_stripe):
  - `gateway_stripe.view` → `payment_gateways.view`
  - `gateway_stripe.configure` → `gateway_stripe.view`, `payment_gateways.manage`
- No new view-grained features were introduced (the spec table has no `*` markers for this module), so `setup.ts` `defaultRoleFeatures` is unchanged and no `sync-role-acls` run is required.

## Tests
- Added `packages/gateway-stripe/src/modules/gateway_stripe/__tests__/acl-dependencies.test.ts` (6 cases): asserts the declarations resolve cleanly against the combined `gateway_stripe` + `payment_gateways` catalog (no `unknownReferences`), that each feature declares the expected deps, and that missing-dependency diagnostics fire when prerequisites are not granted.
- Verified the suite fails before the fix (4/6 fail) and passes after.
- `yarn workspace @open-mercato/gateway-stripe test` → 16 passed; `yarn workspace @open-mercato/gateway-stripe typecheck` → clean.

## Backward Compatibility
- Additive only: `dependsOn` added to existing feature descriptors. No feature IDs, API fields, event IDs, DI names, or CLI commands changed.

Spec: [`.ai/specs/2026-05-27-acl-dependency-bundles.md`](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)