### PR TITLE
feat(checkout): declare ACL feature dependencies (#2170)

### DIFF
--- a/packages/checkout/src/modules/checkout/__tests__/acl-dependencies.test.ts
+++ b/packages/checkout/src/modules/checkout/__tests__/acl-dependencies.test.ts
@@ -1,0 +1,61 @@
+/** @jest-environment node */
+
+import { describe, test, expect } from '@jest/globals'
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as checkoutFeatures } from '../acl'
+import { features as salesFeatures } from '@open-mercato/core/modules/sales/acl'
+import { features as customersFeatures } from '@open-mercato/core/modules/customers/acl'
+
+// The checkout dependency table (spec §6.30) references features from the
+// sales and customers modules, so the catalog the resolver checks against must
+// include them or those cross-module ids would surface as unknown references.
+const combinedCatalog: FeatureDescriptor[] = [
+  ...(checkoutFeatures as FeatureDescriptor[]),
+  ...(salesFeatures as FeatureDescriptor[]),
+  ...(customersFeatures as FeatureDescriptor[]),
+]
+
+const checkoutFeatureIds = (checkoutFeatures as FeatureDescriptor[]).map((feature) => feature.id)
+
+describe('checkout ACL dependency declarations', () => {
+  test('every checkout dependency resolves to a known feature (no unknown references)', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(
+      combinedCatalog.map((feature) => feature.id),
+      combinedCatalog,
+    )
+    const checkoutUnknown = diagnostics.unknownReferences.filter((entry) =>
+      entry.feature.startsWith('checkout.'),
+    )
+    expect(checkoutUnknown).toEqual([])
+  })
+
+  test('write features depend on checkout.view', () => {
+    const byId = new Map(
+      (checkoutFeatures as FeatureDescriptor[]).map((feature) => [feature.id, feature]),
+    )
+    for (const id of ['checkout.create', 'checkout.edit', 'checkout.delete', 'checkout.viewPii', 'checkout.export']) {
+      expect(byId.get(id)?.dependsOn).toContain('checkout.view')
+    }
+  })
+
+  test('granting checkout.create alone surfaces the cross-module read dependencies', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(['checkout.create'], combinedCatalog)
+    const createEntry = diagnostics.missingDependencies.find(
+      (entry) => entry.feature === 'checkout.create',
+    )
+    expect(createEntry).toBeDefined()
+    expect([...(createEntry?.missing ?? [])].sort()).toEqual(
+      ['checkout.view', 'customers.people.view', 'sales.orders.view'].sort(),
+    )
+  })
+
+  test('checkout.viewPii depends on the customers people read feature', () => {
+    const viewPii = (checkoutFeatures as FeatureDescriptor[]).find(
+      (feature) => feature.id === 'checkout.viewPii',
+    )
+    expect(viewPii?.dependsOn).toContain('customers.people.view')
+  })
+})

--- a/packages/checkout/src/modules/checkout/acl.ts
+++ b/packages/checkout/src/modules/checkout/acl.ts
@@ -1,10 +1,35 @@
 export const features = [
   { id: 'checkout.view', title: 'View checkout links and transactions', module: 'checkout' },
-  { id: 'checkout.create', title: 'Create checkout links and templates', module: 'checkout' },
-  { id: 'checkout.edit', title: 'Edit checkout links and templates', module: 'checkout' },
-  { id: 'checkout.delete', title: 'Delete checkout links and templates', module: 'checkout' },
-  { id: 'checkout.viewPii', title: 'View checkout customer PII', module: 'checkout' },
-  { id: 'checkout.export', title: 'Export checkout transactions', module: 'checkout' },
+  {
+    id: 'checkout.create',
+    title: 'Create checkout links and templates',
+    module: 'checkout',
+    dependsOn: ['checkout.view', 'sales.orders.view', 'customers.people.view'],
+  },
+  {
+    id: 'checkout.edit',
+    title: 'Edit checkout links and templates',
+    module: 'checkout',
+    dependsOn: ['checkout.view'],
+  },
+  {
+    id: 'checkout.delete',
+    title: 'Delete checkout links and templates',
+    module: 'checkout',
+    dependsOn: ['checkout.view'],
+  },
+  {
+    id: 'checkout.viewPii',
+    title: 'View checkout customer PII',
+    module: 'checkout',
+    dependsOn: ['checkout.view', 'customers.people.view'],
+  },
+  {
+    id: 'checkout.export',
+    title: 'Export checkout transactions',
+    module: 'checkout',
+    dependsOn: ['checkout.view'],
+  },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2170

## Problem
The `checkout` module's `acl.ts` shipped a flat feature list with no `dependsOn` declarations. It was a per-module follow-up to PR #2141 (ACL dependency bundles), which introduced the optional `dependsOn?: string[]` field and the `AclEditor` warning UX. Without declarations, granting a checkout feature in isolation gives operators no hint about the sibling reads it needs.

## Root Cause
`packages/checkout/src/modules/checkout/acl.ts` had not yet been updated with the dependency table from the umbrella spec ([`.ai/specs/2026-05-27-acl-dependency-bundles.md`](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md) §6.30).

## What Changed
- Added `dependsOn` arrays to the checkout feature descriptors per spec §6.30:
  - `checkout.create` → `checkout.view`, `sales.orders.view`, `customers.people.view`
  - `checkout.edit` / `checkout.delete` / `checkout.export` → `checkout.view`
  - `checkout.viewPii` → `checkout.view`, `customers.people.view`
- No new view-grained features were introduced (the §6.30 table has no `*` markers for checkout), so `setup.ts` `defaultRoleFeatures` is unchanged.

## Tests
- New unit test `packages/checkout/src/modules/checkout/__tests__/acl-dependencies.test.ts`:
  - asserts no `unknownReferences` for checkout ids against the combined checkout/sales/customers catalog
  - asserts every write feature depends on `checkout.view`
  - asserts granting `checkout.create` alone surfaces its missing cross-module reads (`customers.people.view`, `sales.orders.view`)
  - asserts `checkout.viewPii` depends on `customers.people.view`
- `yarn workspace @open-mercato/checkout test …/acl-dependencies.test.ts` → 4 passed
- `yarn workspace @open-mercato/checkout typecheck` → clean

## Backward Compatibility
- Additive only: `dependsOn` is an optional field added to existing descriptors. No feature IDs were removed, renamed, or had their `module`/`title` changed. No contract surface broken; warnings-only per spec §4.6.

## Follow-up (operational)
- No new role grants are required, so `yarn mercato auth sync-role-acls` is not strictly needed for this change; run it on deploy only if reconciling the broader ACL dependency rollout.

Spec: [`.ai/specs/2026-05-27-acl-dependency-bundles.md` §6.30](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md#630-checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)