### PR TITLE
feat(example): declare ACL feature dependencies (#2184)

### DIFF
--- a/apps/mercato/src/modules/example/__tests__/acl-dependencies.test.ts
+++ b/apps/mercato/src/modules/example/__tests__/acl-dependencies.test.ts
@@ -1,0 +1,71 @@
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as exampleFeatures } from '../acl'
+import { features as syncFeatures } from '../../example_customers_sync/acl'
+import { features as customersFeatures } from '@open-mercato/core/modules/customers/acl'
+
+const exampleDescriptors: FeatureDescriptor[] = exampleFeatures
+const syncDescriptors: FeatureDescriptor[] = syncFeatures
+
+// The example template modules exercise the dependency convention end-to-end so
+// create-app templates ship with declared deps. `example_customers_sync` references
+// the cross-module `customers.people.view`, so the resolved catalog must include the
+// customers features for that reference to resolve to a registered id.
+const resolvedCatalog: FeatureDescriptor[] = [
+  ...exampleDescriptors,
+  ...syncDescriptors,
+  ...customersFeatures,
+]
+
+const exampleOwnIds = exampleDescriptors.map((feature) => feature.id)
+const syncOwnIds = syncDescriptors.map((feature) => feature.id)
+
+describe('example template acl dependency declarations', () => {
+  it('declares dependsOn only against features registered in the resolved catalog', () => {
+    const granted = resolvedCatalog.map((feature) => feature.id)
+    const diagnostics = resolveAclDependencyDiagnostics(granted, resolvedCatalog)
+    const ownUnknown = diagnostics.unknownReferences.filter(
+      (ref) => ref.feature.startsWith('example.') || ref.feature.startsWith('example_customers_sync.'),
+    )
+    expect(ownUnknown).toEqual([])
+  })
+
+  it('resolves cleanly with no missing deps when every feature and its deps are granted', () => {
+    const granted = resolvedCatalog.map((feature) => feature.id)
+    const diagnostics = resolveAclDependencyDiagnostics(granted, resolvedCatalog)
+    const ownMissing = diagnostics.missingDependencies.filter(
+      (dep) => dep.feature.startsWith('example.') || dep.feature.startsWith('example_customers_sync.'),
+    )
+    expect(ownMissing).toEqual([])
+  })
+
+  it('flags missing example deps (not unknown) when a dependent is granted without its owner', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(['example.todos.manage'], resolvedCatalog)
+    expect(diagnostics.unknownReferences).toEqual([])
+    const manage = diagnostics.missingDependencies.find(
+      (dep) => dep.feature === 'example.todos.manage',
+    )
+    expect(manage?.missing).toEqual(['example.todos.view'])
+  })
+
+  it('flags the cross-module sync dep as missing (not unknown) when only sync features are granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(syncOwnIds, resolvedCatalog)
+    expect(diagnostics.unknownReferences).toEqual([])
+    const view = diagnostics.missingDependencies.find(
+      (dep) => dep.feature === 'example_customers_sync.view',
+    )
+    expect(view?.missing).toEqual(['customers.people.view'])
+  })
+
+  it('keeps every internal example dependency target within the example feature set', () => {
+    const exampleIds = new Set(exampleOwnIds)
+    const internalDeps = exampleDescriptors.flatMap((feature) =>
+      (feature.dependsOn ?? []).filter((dep) => dep.startsWith('example.')),
+    )
+    for (const dep of internalDeps) {
+      expect(exampleIds.has(dep)).toBe(true)
+    }
+  })
+})

--- a/apps/mercato/src/modules/example/acl.ts
+++ b/apps/mercato/src/modules/example/acl.ts
@@ -2,11 +2,36 @@ export const features = [
   { id: 'example.backend', title: 'Access example backend', module: 'example' },
   { id: 'example.view', title: 'View example enrichments', module: 'example' },
   { id: 'example.todos.view', title: 'View todos', module: 'example' },
-  { id: 'example.todos.manage', title: 'Manage todos', module: 'example' },
-  { id: 'example.widgets.injection', title: 'Use injection widgets', module: 'example' },
-  { id: 'example.widgets.todo', title: 'Use dashboard todo widget', module: 'example' },
-  { id: 'example.widgets.welcome', title: 'Use dashboard welcome widget', module: 'example' },
-  { id: 'example.widgets.notes', title: 'Use dashboard notes widget', module: 'example' },
+  {
+    id: 'example.todos.manage',
+    title: 'Manage todos',
+    module: 'example',
+    dependsOn: ['example.todos.view'],
+  },
+  {
+    id: 'example.widgets.injection',
+    title: 'Use injection widgets',
+    module: 'example',
+    dependsOn: ['example.view'],
+  },
+  {
+    id: 'example.widgets.todo',
+    title: 'Use dashboard todo widget',
+    module: 'example',
+    dependsOn: ['example.todos.view'],
+  },
+  {
+    id: 'example.widgets.welcome',
+    title: 'Use dashboard welcome widget',
+    module: 'example',
+    dependsOn: ['example.view'],
+  },
+  {
+    id: 'example.widgets.notes',
+    title: 'Use dashboard notes widget',
+    module: 'example',
+    dependsOn: ['example.view'],
+  },
 ]
 
 export default features

--- a/apps/mercato/src/modules/example_customers_sync/acl.ts
+++ b/apps/mercato/src/modules/example_customers_sync/acl.ts
@@ -1,6 +1,16 @@
 export const features = [
-  { id: 'example_customers_sync.view', title: 'View Example customer sync diagnostics', module: 'example_customers_sync' },
-  { id: 'example_customers_sync.manage', title: 'Manage Example customer sync', module: 'example_customers_sync' },
+  {
+    id: 'example_customers_sync.view',
+    title: 'View Example customer sync diagnostics',
+    module: 'example_customers_sync',
+    dependsOn: ['customers.people.view'],
+  },
+  {
+    id: 'example_customers_sync.manage',
+    title: 'Manage Example customer sync',
+    module: 'example_customers_sync',
+    dependsOn: ['example_customers_sync.view'],
+  },
 ]
 
 export default features

--- a/packages/create-app/template/src/modules/example/acl.ts
+++ b/packages/create-app/template/src/modules/example/acl.ts
@@ -2,11 +2,36 @@ export const features = [
   { id: 'example.backend', title: 'Access example backend', module: 'example' },
   { id: 'example.view', title: 'View example enrichments', module: 'example' },
   { id: 'example.todos.view', title: 'View todos', module: 'example' },
-  { id: 'example.todos.manage', title: 'Manage todos', module: 'example' },
-  { id: 'example.widgets.injection', title: 'Use injection widgets', module: 'example' },
-  { id: 'example.widgets.todo', title: 'Use dashboard todo widget', module: 'example' },
-  { id: 'example.widgets.welcome', title: 'Use dashboard welcome widget', module: 'example' },
-  { id: 'example.widgets.notes', title: 'Use dashboard notes widget', module: 'example' },
+  {
+    id: 'example.todos.manage',
+    title: 'Manage todos',
+    module: 'example',
+    dependsOn: ['example.todos.view'],
+  },
+  {
+    id: 'example.widgets.injection',
+    title: 'Use injection widgets',
+    module: 'example',
+    dependsOn: ['example.view'],
+  },
+  {
+    id: 'example.widgets.todo',
+    title: 'Use dashboard todo widget',
+    module: 'example',
+    dependsOn: ['example.todos.view'],
+  },
+  {
+    id: 'example.widgets.welcome',
+    title: 'Use dashboard welcome widget',
+    module: 'example',
+    dependsOn: ['example.view'],
+  },
+  {
+    id: 'example.widgets.notes',
+    title: 'Use dashboard notes widget',
+    module: 'example',
+    dependsOn: ['example.view'],
+  },
 ]
 
 export default features

--- a/packages/create-app/template/src/modules/example_customers_sync/acl.ts
+++ b/packages/create-app/template/src/modules/example_customers_sync/acl.ts
@@ -1,6 +1,16 @@
 export const features = [
-  { id: 'example_customers_sync.view', title: 'View Example customer sync diagnostics', module: 'example_customers_sync' },
-  { id: 'example_customers_sync.manage', title: 'Manage Example customer sync', module: 'example_customers_sync' },
+  {
+    id: 'example_customers_sync.view',
+    title: 'View Example customer sync diagnostics',
+    module: 'example_customers_sync',
+    dependsOn: ['customers.people.view'],
+  },
+  {
+    id: 'example_customers_sync.manage',
+    title: 'Manage Example customer sync',
+    module: 'example_customers_sync',
+    dependsOn: ['example_customers_sync.view'],
+  },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2184

## Problem
Per-module follow-up to PR #2141 (`feat(auth): ACL dependency bundles`). The infra shipped with `customers` as the reference module; the example/template modules still needed `dependsOn` declared on their feature descriptors.

## Root Cause
The four example template `acl.ts` files (`apps/mercato` + `packages/create-app/template`, for both `example` and `example_customers_sync`) declared features as a flat list with no `dependsOn`, so the AclEditor dependency-warning UX had nothing to resolve for these modules and the templates didn't exercise the convention end-to-end.

## What Changed
Declared `dependsOn` per spec §6.45 (`.ai/specs/2026-05-27-acl-dependency-bundles.md`), verified against the actual page/widget wiring:

- `example`:
  - `example.todos.manage` → `example.todos.view`
  - `example.widgets.injection` → `example.view`
  - `example.widgets.todo` → `example.todos.view`
  - `example.widgets.welcome` → `example.view`
  - `example.widgets.notes` → `example.view`
  - (`example.backend`, `example.view`, `example.todos.view` have no deps)
- `example_customers_sync`:
  - `example_customers_sync.view` → `customers.people.view` (cross-module)
  - `example_customers_sync.manage` → `example_customers_sync.view`

Applied identically to `apps/mercato/src/modules/{example,example_customers_sync}/acl.ts` and `packages/create-app/template/src/modules/{example,example_customers_sync}/acl.ts` — treated as one coordinated change because create-app templates ship via Verdaccio.

No new view-grained features were required (the spec table has no `*` markers), so `setup.ts` `defaultRoleFeatures` and `yarn mercato auth sync-role-acls` are unaffected.

## Tests
- New `apps/mercato/src/modules/example/__tests__/acl-dependencies.test.ts` (5 cases) asserting:
  - the template modules' declarations resolve with no `unknownReferences` against the resolved catalog (incl. `customers`),
  - everything resolves cleanly with no missing deps when all features are granted,
  - granting a dependent without its owner reports it as `missing` (not `unknown`) for both an internal (`example.todos.manage`) and the cross-module (`example_customers_sync.view` → `customers.people.view`) case,
  - every internal `example.*` dependency target stays within the `example` feature set.
- `yarn jest` (apps/mercato config): new suite passes (5/5).
- `yarn tsc --noEmit`: clean for `apps/mercato` and `packages/create-app`.
- `yarn build:packages` + `yarn generate`: succeed; no committed-file churn.

Pre-existing, unrelated env-dependent failures (`mock-gateway-adapter` / `mock-shipping-adapter` tests requiring `MOCK_GATEWAY_WEBHOOK_SECRET`) are not touched by this change.

## Backward Compatibility
STABLE / ADDITIVE-ONLY — only adds optional `dependsOn` metadata to existing feature descriptors. No feature IDs, response fields, event IDs, or other contract surfaces changed.

Spec: `.ai/specs/2026-05-27-acl-dependency-bundles.md` §6.45

🤖 Generated with [Claude Code](https://claude.com/claude-code)