### PR TITLE
feat(ai_assistant): declare ACL feature dependencies (#2169)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/__tests__/acl-dependencies.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/__tests__/acl-dependencies.test.ts
@@ -1,0 +1,64 @@
+/** @jest-environment node */
+
+import { describe, test, expect } from '@jest/globals'
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as aiAssistantFeatures } from '../acl'
+import { setup } from '../setup'
+
+const descriptors: FeatureDescriptor[] = aiAssistantFeatures as FeatureDescriptor[]
+const aiAssistantIds = descriptors.map((feature) => feature.id)
+
+describe('ai_assistant ACL dependency declarations', () => {
+  test('declares dependsOn only against features registered in the catalog (no unknown references)', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(aiAssistantIds, descriptors)
+    const ownUnknown = diagnostics.unknownReferences.filter((ref) =>
+      ref.feature.startsWith('ai_assistant.'),
+    )
+    expect(ownUnknown).toEqual([])
+  })
+
+  test('resolves cleanly with no missing deps when every feature is granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(aiAssistantIds, descriptors)
+    const ownMissing = diagnostics.missingDependencies.filter((dep) =>
+      dep.feature.startsWith('ai_assistant.'),
+    )
+    expect(ownMissing).toEqual([])
+  })
+
+  test('every internal dependency target stays within the ai_assistant feature set', () => {
+    const knownIds = new Set(aiAssistantIds)
+    const deps = descriptors.flatMap((feature) => feature.dependsOn ?? [])
+    for (const dep of deps) {
+      expect(knownIds.has(dep)).toBe(true)
+    }
+  })
+
+  test('manage features depend on their view-grained counterpart', () => {
+    const settingsManage = descriptors.find((f) => f.id === 'ai_assistant.settings.manage')
+    const mcpServersManage = descriptors.find((f) => f.id === 'ai_assistant.mcp_servers.manage')
+    expect(settingsManage?.dependsOn).toContain('ai_assistant.view')
+    expect(mcpServersManage?.dependsOn).toContain('ai_assistant.mcp_servers.view')
+  })
+
+  test('conversations.share depends on ai_assistant.view, not conversations.manage', () => {
+    // setup.ts grants employees `conversations.share` without `conversations.manage`,
+    // so the share dependency must resolve against the view feature only — otherwise
+    // the employee default would surface a missing-dependency warning at edit time.
+    const share = descriptors.find((f) => f.id === 'ai_assistant.conversations.share')
+    expect(share?.dependsOn).toEqual(['ai_assistant.view'])
+  })
+
+  test('default role grants resolve without missing dependencies', () => {
+    const adminFeatures = (setup.defaultRoleFeatures?.admin ?? []) as string[]
+    const employeeFeatures = (setup.defaultRoleFeatures?.employee ?? []) as string[]
+
+    const adminDiagnostics = resolveAclDependencyDiagnostics(adminFeatures, descriptors)
+    expect(adminDiagnostics.missingDependencies).toEqual([])
+
+    const employeeDiagnostics = resolveAclDependencyDiagnostics(employeeFeatures, descriptors)
+    expect(employeeDiagnostics.missingDependencies).toEqual([])
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/acl.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/acl.ts
@@ -1,12 +1,47 @@
 export const features = [
   { id: 'ai_assistant.view', title: 'View AI Assistant Settings', module: 'ai_assistant' },
-  { id: 'ai_assistant.settings.manage', title: 'Manage AI Assistant Settings', module: 'ai_assistant' },
-  { id: 'ai_assistant.conversations.manage', title: 'Manage AI Assistant Conversations', module: 'ai_assistant' },
-  { id: 'ai_assistant.conversations.share', title: 'Share AI Assistant Conversations', module: 'ai_assistant' },
-  { id: 'ai_assistant.mcp.serve', title: 'Start MCP Server', module: 'ai_assistant' },
-  { id: 'ai_assistant.tools.list', title: 'List MCP Tools', module: 'ai_assistant' },
-  { id: 'ai_assistant.mcp_servers.view', title: 'View MCP Server Configurations', module: 'ai_assistant' },
-  { id: 'ai_assistant.mcp_servers.manage', title: 'Manage MCP Server Configurations', module: 'ai_assistant' },
+  {
+    id: 'ai_assistant.settings.manage',
+    title: 'Manage AI Assistant Settings',
+    module: 'ai_assistant',
+    dependsOn: ['ai_assistant.view'],
+  },
+  {
+    id: 'ai_assistant.conversations.manage',
+    title: 'Manage AI Assistant Conversations',
+    module: 'ai_assistant',
+    dependsOn: ['ai_assistant.view'],
+  },
+  {
+    id: 'ai_assistant.conversations.share',
+    title: 'Share AI Assistant Conversations',
+    module: 'ai_assistant',
+    dependsOn: ['ai_assistant.view'],
+  },
+  {
+    id: 'ai_assistant.mcp.serve',
+    title: 'Start MCP Server',
+    module: 'ai_assistant',
+    dependsOn: ['ai_assistant.view'],
+  },
+  {
+    id: 'ai_assistant.tools.list',
+    title: 'List MCP Tools',
+    module: 'ai_assistant',
+    dependsOn: ['ai_assistant.view'],
+  },
+  {
+    id: 'ai_assistant.mcp_servers.view',
+    title: 'View MCP Server Configurations',
+    module: 'ai_assistant',
+    dependsOn: ['ai_assistant.view'],
+  },
+  {
+    id: 'ai_assistant.mcp_servers.manage',
+    title: 'Manage MCP Server Configurations',
+    module: 'ai_assistant',
+    dependsOn: ['ai_assistant.mcp_servers.view'],
+  },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2169

## Problem
Per-module follow-up to PR #2141 (`feat(auth): ACL dependency bundles`). The infrastructure shipped with `customers` as the reference; `ai_assistant` still needed `dependsOn` declarations so the AclEditor can warn when a granted feature's prerequisites are missing.

## Root Cause
`ai_assistant/acl.ts` declared a flat feature list with no `dependsOn` edges, so the dependency resolver produced no diagnostics for this module.

## What Changed
- `packages/ai-assistant/src/modules/ai_assistant/acl.ts` — added `dependsOn` per spec [`.ai/specs/2026-05-27-acl-dependency-bundles.md` §6.29](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md#629-ai_assistant):
  - `settings.manage`, `conversations.manage`, `mcp.serve`, `tools.list`, `mcp_servers.view` → `ai_assistant.view`
  - `mcp_servers.manage` → `ai_assistant.mcp_servers.view`
- **Spec refinement:** `ai_assistant.conversations.share` is absent from the spec table. It depends on `ai_assistant.view` **only** — `setup.ts` grants the `employee` role `conversations.share` without `conversations.manage`, so a `manage` dependency would generate a false missing-dependency warning for the default employee grant.

## Tests
- New `__tests__/acl-dependencies.test.ts` (6 cases): no `unknownReferences`/`missingDependencies` for this module's own features, internal dep targets stay within the feature set, manage→view edges, `conversations.share`→view edge, and admin + employee default grants resolve without missing dependencies.
- Full module suite: 1176 passed / 81 suites.

## Backward Compatibility
- No contract surface changes. Feature IDs are unchanged; `dependsOn` is an additive optional descriptor field.
- No new view-grained features (spec table has no `*` markers for this module), so `setup.ts` `defaultRoleFeatures` is unchanged and no `yarn mercato auth sync-role-acls` is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)