### PR TITLE
feat(progress): declare ACL feature dependencies (#2180)

### DIFF
--- a/packages/core/src/modules/progress/__tests__/acl.test.ts
+++ b/packages/core/src/modules/progress/__tests__/acl.test.ts
@@ -1,0 +1,49 @@
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as progressFeatures } from '../acl'
+
+const progressDescriptors: FeatureDescriptor[] = progressFeatures
+
+const progressOwnIds = progressDescriptors.map((feature) => feature.id)
+
+describe('progress acl dependency declarations', () => {
+  it('declares dependsOn only against features registered in the catalog', () => {
+    const granted = progressDescriptors.map((feature) => feature.id)
+    const diagnostics = resolveAclDependencyDiagnostics(granted, progressDescriptors)
+    const ownUnknown = diagnostics.unknownReferences.filter((ref) =>
+      ref.feature.startsWith('progress.'),
+    )
+    expect(ownUnknown).toEqual([])
+  })
+
+  it('resolves cleanly with no missing deps when every feature and its deps are granted', () => {
+    const granted = progressDescriptors.map((feature) => feature.id)
+    const diagnostics = resolveAclDependencyDiagnostics(granted, progressDescriptors)
+    const ownMissing = diagnostics.missingDependencies.filter((dep) =>
+      dep.feature.startsWith('progress.'),
+    )
+    expect(ownMissing).toEqual([])
+  })
+
+  it('flags the action features as missing progress.view when only they are granted', () => {
+    const granted = ['progress.create', 'progress.update', 'progress.cancel', 'progress.manage']
+    const diagnostics = resolveAclDependencyDiagnostics(granted, progressDescriptors)
+    expect(diagnostics.unknownReferences).toEqual([])
+    for (const id of granted) {
+      const missing = diagnostics.missingDependencies.find((dep) => dep.feature === id)
+      expect(missing?.missing).toEqual(['progress.view'])
+    }
+  })
+
+  it('keeps every internal progress dependency target within the progress feature set', () => {
+    const progressIds = new Set(progressOwnIds)
+    const internalDeps = progressDescriptors.flatMap((feature) =>
+      (feature.dependsOn ?? []).filter((dep) => dep.startsWith('progress.')),
+    )
+    for (const dep of internalDeps) {
+      expect(progressIds.has(dep)).toBe(true)
+    }
+  })
+})

--- a/packages/core/src/modules/progress/acl.ts
+++ b/packages/core/src/modules/progress/acl.ts
@@ -8,21 +8,25 @@ export const features = [
     id: 'progress.create',
     title: 'Create progress jobs',
     module: 'progress',
+    dependsOn: ['progress.view'],
   },
   {
     id: 'progress.update',
     title: 'Update progress jobs',
     module: 'progress',
+    dependsOn: ['progress.view'],
   },
   {
     id: 'progress.cancel',
     title: 'Cancel progress jobs',
     module: 'progress',
+    dependsOn: ['progress.view'],
   },
   {
     id: 'progress.manage',
     title: 'Manage all progress jobs',
     module: 'progress',
+    dependsOn: ['progress.view'],
   },
 ]
 


### PR DESCRIPTION
Fixes #2180

## Problem
The `progress` module's `acl.ts` did not declare feature dependencies (`dependsOn`), so the `AclEditor` warning UX introduced in PR #2141 (ACL dependency bundles) could not flag when a granted progress action feature was missing its prerequisite `progress.view` grant.

## Root Cause
PR #2141 shipped the infrastructure (resolver, API forwarding, UI panel) and enacted only the `customers` reference module. The `progress` module is a per-module follow-up listed in the umbrella spec.

## What Changed
- `packages/core/src/modules/progress/acl.ts` — added `dependsOn: ['progress.view']` to `progress.create`, `progress.update`, `progress.cancel`, and `progress.manage`, per spec §6.41. `progress.view` stays a root feature.
- No new view-grained features were required (spec §6.41 has no `*` markers), so `setup.ts` `defaultRoleFeatures` is unchanged (admin: `progress.*`, employee: `progress.view`) and no new ACL grants need syncing.

## Tests
- Added `packages/core/src/modules/progress/__tests__/acl.test.ts`, mirroring `catalog/__tests__/acl.test.ts`. It asserts:
  - no `unknownReferences` for the module's own ids,
  - clean resolution (no `missingDependencies`) when all features are granted,
  - the action features report `progress.view` as a missing dependency when it is not granted,
  - every internal dependency target stays within the progress feature set.

## Backward Compatibility
Additive only — `dependsOn` is an optional `FeatureDescriptor` field already consumed by the resolver. No contract surface removed.

## Spec
- `.ai/specs/2026-05-27-acl-dependency-bundles.md` §6.41 (progress)
