### PR TITLE
feat(query_index): declare ACL feature dependencies (#2181)

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/acl.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/acl.test.ts
@@ -1,0 +1,54 @@
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as queryIndexFeatures } from '../acl'
+
+const queryIndexDescriptors: FeatureDescriptor[] = queryIndexFeatures
+const queryIndexOwnIds = queryIndexDescriptors.map((feature) => feature.id)
+
+describe('query_index acl dependency declarations', () => {
+  it('declares dependsOn only against features registered in the catalog', () => {
+    const granted = queryIndexDescriptors.map((feature) => feature.id)
+    const diagnostics = resolveAclDependencyDiagnostics(granted, queryIndexDescriptors)
+    const ownUnknown = diagnostics.unknownReferences.filter((ref) =>
+      ref.feature.startsWith('query_index.'),
+    )
+    expect(ownUnknown).toEqual([])
+  })
+
+  it('resolves cleanly with no missing deps when every feature and its deps are granted', () => {
+    const granted = queryIndexDescriptors.map((feature) => feature.id)
+    const diagnostics = resolveAclDependencyDiagnostics(granted, queryIndexDescriptors)
+    const ownMissing = diagnostics.missingDependencies.filter((dep) =>
+      dep.feature.startsWith('query_index.'),
+    )
+    expect(ownMissing).toEqual([])
+  })
+
+  it('flags reindex and purge as missing their view dep when only those are granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(
+      ['query_index.reindex', 'query_index.purge'],
+      queryIndexDescriptors,
+    )
+    expect(diagnostics.unknownReferences).toEqual([])
+    const reindex = diagnostics.missingDependencies.find(
+      (dep) => dep.feature === 'query_index.reindex',
+    )
+    const purge = diagnostics.missingDependencies.find(
+      (dep) => dep.feature === 'query_index.purge',
+    )
+    expect(reindex?.missing).toEqual(['query_index.status.view'])
+    expect(purge?.missing).toEqual(['query_index.status.view'])
+  })
+
+  it('keeps every internal query_index dependency target within the feature set', () => {
+    const ids = new Set(queryIndexOwnIds)
+    const internalDeps = queryIndexDescriptors.flatMap((feature) =>
+      (feature.dependsOn ?? []).filter((dep) => dep.startsWith('query_index.')),
+    )
+    for (const dep of internalDeps) {
+      expect(ids.has(dep)).toBe(true)
+    }
+  })
+})

--- a/packages/core/src/modules/query_index/acl.ts
+++ b/packages/core/src/modules/query_index/acl.ts
@@ -1,7 +1,17 @@
 export const features = [
   { id: 'query_index.status.view', title: 'View index status', module: 'query_index' },
-  { id: 'query_index.reindex', title: 'Trigger reindex', module: 'query_index' },
-  { id: 'query_index.purge', title: 'Purge index', module: 'query_index' },
+  {
+    id: 'query_index.reindex',
+    title: 'Trigger reindex',
+    module: 'query_index',
+    dependsOn: ['query_index.status.view'],
+  },
+  {
+    id: 'query_index.purge',
+    title: 'Purge index',
+    module: 'query_index',
+    dependsOn: ['query_index.status.view'],
+  },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2181

## Problem
- Per-module follow-up to PR #2141 (`feat(auth): ACL dependency bundles`). The `query_index` module's `acl.ts` features did not declare `dependsOn`, so the `AclEditor` could not warn operators when a granted feature's prerequisite was missing.

## Root Cause
- PR #2141 shipped the infrastructure (resolver, API forwarding, UI panel) using `customers` as the reference module. Every other module still needs its `acl.ts` annotated with the dependency table from the umbrella spec.

## What Changed
- `packages/core/src/modules/query_index/acl.ts`: added `dependsOn: ['query_index.status.view']` to `query_index.reindex` and `query_index.purge`, per [spec §6.42](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md#642-query_index). `query_index.status.view` has no dependencies.
- No new view-grained features were required (the spec table has no `*` markers), so `setup.ts` `defaultRoleFeatures` is unchanged and no `yarn mercato auth sync-role-acls` run is needed.

## Tests
- Added `packages/core/src/modules/query_index/__tests__/acl.test.ts` (4 cases): declarations resolve with no `unknownReferences` for the module's own ids, resolve with no missing deps when all features are granted, correctly flag `query_index.status.view` as missing for `reindex`/`purge` when only those are granted, and keep every internal dependency target within the feature set. 4/4 pass.

## Backward Compatibility
- `dependsOn` is an additive optional field on the feature descriptor. No feature IDs were changed or removed and no other contract surface was touched.