### PR TITLE
feat(resources): declare ACL feature dependencies (#2182)

### DIFF
--- a/packages/core/src/modules/resources/__tests__/acl.test.ts
+++ b/packages/core/src/modules/resources/__tests__/acl.test.ts
@@ -1,0 +1,51 @@
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as resourcesFeatures } from '../acl'
+
+const resourcesDescriptors: FeatureDescriptor[] = resourcesFeatures
+
+const resourcesOwnIds = resourcesDescriptors.map((feature) => feature.id)
+
+describe('resources acl dependency declarations', () => {
+  it('declares dependsOn only against features registered in the catalog', () => {
+    const granted = resourcesOwnIds
+    const diagnostics = resolveAclDependencyDiagnostics(granted, resourcesDescriptors)
+    const ownUnknown = diagnostics.unknownReferences.filter((ref) =>
+      ref.feature.startsWith('resources.'),
+    )
+    expect(ownUnknown).toEqual([])
+  })
+
+  it('resolves cleanly with no missing deps when every feature and its deps are granted', () => {
+    const granted = resourcesOwnIds
+    const diagnostics = resolveAclDependencyDiagnostics(granted, resourcesDescriptors)
+    const ownMissing = diagnostics.missingDependencies.filter((dep) =>
+      dep.feature.startsWith('resources.'),
+    )
+    expect(ownMissing).toEqual([])
+  })
+
+  it('flags resources.view as a missing dep of manage_resources when only manage is granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(
+      ['resources.manage_resources'],
+      resourcesDescriptors,
+    )
+    expect(diagnostics.unknownReferences).toEqual([])
+    const manage = diagnostics.missingDependencies.find(
+      (dep) => dep.feature === 'resources.manage_resources',
+    )
+    expect(manage?.missing).toEqual(['resources.view'])
+  })
+
+  it('keeps every internal resources dependency target within the resources feature set', () => {
+    const resourcesIds = new Set(resourcesOwnIds)
+    const internalDeps = resourcesDescriptors.flatMap((feature) =>
+      (feature.dependsOn ?? []).filter((dep) => dep.startsWith('resources.')),
+    )
+    for (const dep of internalDeps) {
+      expect(resourcesIds.has(dep)).toBe(true)
+    }
+  })
+})

--- a/packages/core/src/modules/resources/acl.ts
+++ b/packages/core/src/modules/resources/acl.ts
@@ -1,6 +1,11 @@
 export const features = [
   { id: 'resources.view', title: 'View resources', module: 'resources' },
-  { id: 'resources.manage_resources', title: 'Manage resources', module: 'resources' },
+  {
+    id: 'resources.manage_resources',
+    title: 'Manage resources',
+    module: 'resources',
+    dependsOn: ['resources.view'],
+  },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2182

Per-module follow-up to PR #2141 (ACL dependency bundles) and the umbrella spec [`.ai/specs/2026-05-27-acl-dependency-bundles.md`](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md) §6.43.

## Problem
- The `resources` module's `acl.ts` did not declare `dependsOn`, so the `AclEditor` could not warn operators when `resources.manage_resources` is granted without its `resources.view` prerequisite.

## Root Cause
- Infrastructure for ACL dependency bundles shipped in #2141 with `customers` as the reference; every other module still needed its `acl.ts` updated.

## What Changed
- `packages/core/src/modules/resources/acl.ts`: `resources.manage_resources` now declares `dependsOn: ['resources.view']`, matching spec §6.43.
- `packages/core/src/modules/resources/__tests__/acl.test.ts`: unit tests asserting the declarations resolve cleanly against the catalog (no `unknownReferences` for resources' own ids) and that `resources.view` is reported as a missing dependency when only `manage_resources` is granted.

## Why no setup.ts change
- The spec table for `resources` has no `*`-marked deps, so **no new view-grained features** were introduced. `setup.ts` `defaultRoleFeatures` (`admin: ['resources.*']`) already covers both features, so no `sync-role-acls` run is required for existing tenants.

## Tests
- Added `packages/core/src/modules/resources/__tests__/acl.test.ts` (4 cases). Full resources suite: 9/9 pass.
- Note: `yarn workspace @open-mercato/core typecheck` fails on a pre-existing, change-unrelated `tsconfig.json` `ignoreDeprecations: "6.0"` error caused by the installed TypeScript version; it reproduces on `origin/develop` and is independent of this two-file change.

## Backward Compatibility
- Additive only — `dependsOn` is an optional field on the feature descriptor contract. No feature ids removed or renamed, no API/event/DI/route changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)