### PR TITLE
Fix encrypted field sorting in query engines

### DIFF
--- a/packages/core/src/modules/core/__integration__/integration/TC-INT-002.spec.ts
+++ b/packages/core/src/modules/core/__integration__/integration/TC-INT-002.spec.ts
@@ -56,7 +56,7 @@ test.describe('TC-INT-002: Customer to Deal to Quote to Order Flow', () => {
         const opt = typeof label === 'string'
           ? page.getByRole('option', { name: label, exact })
           : page.getByRole('option', { name: label });
-        await expect(opt.first()).toBeVisible({ timeout: 10_000 });
+        await expect(opt.first()).toBeVisible({ timeout: 30_000 });
         await opt.first().click();
       }
       await selectByFieldId('companyEntityId', companyName)
@@ -109,7 +109,9 @@ test.describe('TC-INT-002: Customer to Deal to Quote to Order Flow', () => {
       await expect(page).toHaveURL(/\/backend\/customers\/deals$/i, { timeout: 30_000 });
 
       await page.getByPlaceholder(/Search by title/i).fill(dealTitle);
-      await page.locator('tr').filter({ hasText: dealTitle }).first().click();
+      const dealRow = page.locator('tr').filter({ has: page.getByText(dealTitle, { exact: true }) }).first();
+      await expect(dealRow).toBeVisible({ timeout: 30_000 });
+      await dealRow.getByText(dealTitle, { exact: true }).click();
       await expect(page).toHaveURL(/\/backend\/customers\/deals\/[0-9a-f-]{36}$/i);
       dealId = page.url().match(/\/backend\/customers\/deals\/([0-9a-f-]{36})$/i)?.[1] ?? null;
 

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -1,4 +1,5 @@
 import { HybridQueryEngine } from '../../query_index/lib/engine'
+import { SortDir } from '@open-mercato/shared/lib/query/types'
 
 type KyselyMockConfig = {
   baseTable: string
@@ -438,6 +439,71 @@ describe('HybridQueryEngine', () => {
     expect(result.items).toEqual([
       expect.objectContaining({ id: 'user-1', name: 'Alice Owner' }),
     ])
+  })
+
+  test('sorts encrypted base fields after decryption before pagination', async () => {
+    const db = createFakeKysely({
+      baseTable: 'customer_entities',
+      hasIndexAny: true,
+      baseCount: 5,
+      indexCount: 5,
+      columns: [
+        { table_name: 'customer_entities', column_name: 'id' },
+        { table_name: 'customer_entities', column_name: 'tenant_id' },
+        { table_name: 'customer_entities', column_name: 'organization_id' },
+        { table_name: 'customer_entities', column_name: 'deleted_at' },
+        { table_name: 'customer_entities', column_name: 'display_name' },
+      ],
+      rows: {
+        customer_entities: [
+          { id: '3', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-c' },
+          { id: '1', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-a' },
+          { id: '5', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-e' },
+          { id: '2', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-b' },
+          { id: '4', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-d' },
+        ],
+      },
+    })
+    const namesById: Record<string, string> = {
+      '1': 'Alice',
+      '2': 'Bob',
+      '3': 'Charlie',
+      '4': 'Dave',
+      '5': 'Eve',
+    }
+    const em = buildEm(db)
+    const fallback = { query: jest.fn() }
+    const emitEvent = jest.fn().mockResolvedValue(undefined)
+    const engine = new HybridQueryEngine(
+      em,
+      fallback as any,
+      () => ({ emitEvent }),
+      undefined,
+      () => ({
+        isEnabled: () => true,
+        getEncryptedFieldNames: async () => ['display_name'],
+        decryptEntityPayload: async (_entityId, payload) => ({
+          display_name: namesById[String(payload.id)],
+        }),
+      }),
+    )
+
+    const result = await engine.query('customers:customer_entity', {
+      fields: ['id', 'display_name'],
+      organizationId: 'org1',
+      tenantId: 't1',
+      sort: [{ field: 'display_name', dir: SortDir.Asc }],
+      page: { page: 2, pageSize: 2 },
+    })
+
+    expect(fallback.query).not.toHaveBeenCalled()
+    expect(result.items.map((item: any) => item.display_name)).toEqual(['Charlie', 'Dave'])
+    const dataRead = db._chains
+      .filter((chain: ChainLog) => chain.table === 'customer_entities')
+      .at(-1)
+    expect(dataRead?.orderBys).toEqual([])
+    expect(dataRead?.limit).toBeNull()
+    expect(dataRead?.offset).toBeNull()
   })
 
   test('joins entity index aliases for customFieldSources', async () => {

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -1,4 +1,4 @@
-import type { QueryEngine, QueryOptions, QueryResult, FilterOp, Filter, QueryCustomFieldSource, PartialIndexWarning, QueryExtensionsConfig } from '@open-mercato/shared/lib/query/types'
+import type { QueryEngine, QueryOptions, QueryResult, FilterOp, Filter, QueryCustomFieldSource, PartialIndexWarning, QueryExtensionsConfig, Sort } from '@open-mercato/shared/lib/query/types'
 import { SortDir } from '@open-mercato/shared/lib/query/types'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { EntityManager } from '@mikro-orm/postgresql'
@@ -21,6 +21,7 @@ import {
 import { resolveSearchConfig, type SearchConfig } from '@open-mercato/shared/lib/search/config'
 import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
 import { runBeforeQueryPipeline, runAfterQueryPipeline, type QueryExtensionContext } from '@open-mercato/shared/lib/query/query-extension-runner'
+import { resolveEncryptedSortFields, sortRowsInMemory } from '@open-mercato/shared/lib/query/encrypted-sort'
 
 function buildFilterableCustomFieldJoins(
   sources: QueryCustomFieldSource[] | undefined,
@@ -90,6 +91,7 @@ type SearchRuntime = {
 
 type EncryptionResolver = () => {
   decryptEntityPayload?: (entityId: EntityId, payload: Record<string, unknown>, tenantId?: string | null, organizationId?: string | null) => Promise<Record<string, unknown>>
+  getEncryptedFieldNames?: (entityId: EntityId, tenantId?: string | null, organizationId?: string | null) => Promise<readonly string[]>
   isEnabled?: () => boolean
 } | null
 
@@ -504,6 +506,28 @@ export class HybridQueryEngine implements QueryEngine {
         if (field === 'organization_id' && columns.has('id')) return 'id'
         return null
       }
+      const fallbackOrgId =
+        opts.organizationId
+        ?? (Array.isArray(opts.organizationIds) && opts.organizationIds.length === 1 ? opts.organizationIds[0] : null)
+      const encSvc = this.getEncryptionService()
+      const resolvedSorts: Sort[] = []
+      for (const sort of opts.sort || []) {
+        const field = String(sort.field)
+        if (field.startsWith('cf:')) {
+          resolvedSorts.push({ ...sort, field })
+        } else {
+          const baseField = resolveBaseColumn(field)
+          if (baseField) resolvedSorts.push({ ...sort, field: baseField })
+        }
+      }
+      const encryptedSortFields = await resolveEncryptedSortFields(
+        encSvc,
+        entity,
+        resolvedSorts.filter((sort) => !sort.field.startsWith('cf:')).map((sort) => sort.field),
+        opts.tenantId ?? null,
+        fallbackOrgId,
+      )
+      const requiresPlaintextSort = encryptedSortFields.size > 0
 
       // ────────────────────────────────────────────────────────────────
       // Build a reusable "applyQueryShape" function that applies every
@@ -735,6 +759,9 @@ export class HybridQueryEngine implements QueryEngine {
 
       // Selection (for data query)
       const selectFieldSet = new Set<string>((opts.fields && opts.fields.length) ? opts.fields.map(String) : Array.from(columns.keys()))
+      if (requiresPlaintextSort) {
+        for (const field of encryptedSortFields) selectFieldSet.add(field)
+      }
       if (opts.includeCustomFields === true) {
         const entityIds = Array.from(new Set(indexSources.map((src) => String(src.entityId))))
         try {
@@ -767,7 +794,8 @@ export class HybridQueryEngine implements QueryEngine {
 
       const applySort = (q: AnyBuilder): AnyBuilder => {
         let next = q
-        for (const s of opts.sort || []) {
+        if (requiresPlaintextSort) return next
+        for (const s of resolvedSorts) {
           const fieldName = String(s.field)
           if (fieldName.startsWith('cf:')) {
             const textExpr = this.buildCfTextExprSql(fieldName, indexSources)
@@ -845,7 +873,9 @@ export class HybridQueryEngine implements QueryEngine {
       let dataBuilder = await applyQueryShape(dataRoot)
       dataBuilder = applySelection(dataBuilder)
       dataBuilder = applySort(dataBuilder)
-      dataBuilder = dataBuilder.limit(pageSize).offset((page - 1) * pageSize)
+      if (!requiresPlaintextSort) {
+        dataBuilder = dataBuilder.limit(pageSize).offset((page - 1) * pageSize)
+      }
 
       if (debugEnabled && sqlDebugEnabled) {
         const compiled = dataBuilder.compile()
@@ -859,15 +889,11 @@ export class HybridQueryEngine implements QueryEngine {
       if (debugEnabled) this.debug('query:complete', { entity, total, items: Array.isArray(itemsRaw) ? itemsRaw.length : 0 })
 
       let items = itemsRaw as any[]
-      const encSvc = this.getEncryptionService()
       const dekKeyCache = new Map<string | null, string | null>()
       if (encSvc?.decryptEntityPayload) {
         const decrypt = encSvc.decryptEntityPayload.bind(encSvc) as (
           entityId: EntityId, payload: Record<string, unknown>, tenantId: string | null, organizationId: string | null,
         ) => Promise<Record<string, unknown>>
-        const fallbackOrgId =
-          opts.organizationId
-          ?? (Array.isArray(opts.organizationIds) && opts.organizationIds.length === 1 ? opts.organizationIds[0] : null)
         items = await Promise.all(
           items.map(async (item) => {
             try {
@@ -899,6 +925,10 @@ export class HybridQueryEngine implements QueryEngine {
             } catch { return item }
           }),
         )
+      }
+      if (requiresPlaintextSort) {
+        items = sortRowsInMemory(items as Record<string, unknown>[], resolvedSorts)
+          .slice((page - 1) * pageSize, page * pageSize)
       }
 
       const typedItems = items as unknown as T[]

--- a/packages/shared/src/lib/encryption/__tests__/tenantDataEncryptionService.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/tenantDataEncryptionService.test.ts
@@ -128,3 +128,24 @@ describe('TenantDataEncryptionService.decryptFields (issue #1734)', () => {
     expect(out.description).toBe('null')
   })
 })
+
+describe('TenantDataEncryptionService.getEncryptedFieldNames', () => {
+  it('returns active encryption-map field names for query planning', async () => {
+    const service = new TenantDataEncryptionService({} as never)
+    jest.spyOn(service, 'isEnabled').mockReturnValue(true)
+    ;(service as unknown as {
+      getMap: () => Promise<{ fields: Array<{ field?: unknown }> }>
+    }).getMap = jest.fn(async () => ({
+      fields: [
+        { field: 'display_name' },
+        { field: 'primary_email' },
+        { field: '' },
+        { field: null },
+      ],
+    }))
+
+    await expect(
+      service.getEncryptedFieldNames('customers:customer_entity', 't1', 'org1'),
+    ).resolves.toEqual(['display_name', 'primary_email'])
+  })
+})

--- a/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
+++ b/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
@@ -236,6 +236,19 @@ export class TenantDataEncryptionService {
     }
   }
 
+  async getEncryptedFieldNames(
+    entityId: string,
+    tenantId: string | null | undefined,
+    organizationId?: string | null
+  ): Promise<string[]> {
+    if (!this.isEnabled()) return []
+    const map = await this.getMap({ entityId, tenantId: tenantId ?? null, organizationId: organizationId ?? null })
+    if (!map || !map.fields?.length) return []
+    return map.fields
+      .map((rule) => rule.field)
+      .filter((field): field is string => typeof field === 'string' && field.trim().length > 0)
+  }
+
   private encryptFields(
     obj: Record<string, unknown>,
     fields: EncryptedFieldRule[],

--- a/packages/shared/src/lib/query/__tests__/engine.test.ts
+++ b/packages/shared/src/lib/query/__tests__/engine.test.ts
@@ -516,4 +516,90 @@ describe('BasicQueryEngine (Kysely)', () => {
       : false
     expect(hasInFilter).toBe(true)
   })
+
+  test('sorts encrypted base fields after decryption before pagination', async () => {
+    const fakeDb = createFakeKysely({
+      customer_entities: [
+        { id: '3', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-c' },
+        { id: '1', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-a' },
+        { id: '5', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-e' },
+        { id: '2', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-b' },
+        { id: '4', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-d' },
+      ],
+      'information_schema.columns': [
+        { table_name: 'customer_entities', column_name: 'id' },
+        { table_name: 'customer_entities', column_name: 'tenant_id' },
+        { table_name: 'customer_entities', column_name: 'organization_id' },
+        { table_name: 'customer_entities', column_name: 'deleted_at' },
+        { table_name: 'customer_entities', column_name: 'display_name' },
+      ],
+    })
+    const namesById: Record<string, string> = {
+      '1': 'Alice',
+      '2': 'Bob',
+      '3': 'Charlie',
+      '4': 'Dave',
+      '5': 'Eve',
+    }
+    const engine = new BasicQueryEngine(
+      {} as any,
+      () => fakeDb as any,
+      () => ({
+        isEnabled: () => true,
+        getEncryptedFieldNames: async () => ['display_name'],
+        decryptEntityPayload: async (_entityId, payload) => ({
+          display_name: namesById[String(payload.id)],
+        }),
+      }),
+    )
+
+    const result = await engine.query('customers:customer_entity', {
+      tenantId: 't1',
+      organizationId: 'org1',
+      fields: ['id', 'display_name'],
+      sort: [{ field: 'display_name', dir: SortDir.Asc }],
+      page: { page: 2, pageSize: 2 },
+    })
+
+    expect(result.items.map((item: any) => item.display_name)).toEqual(['Charlie', 'Dave'])
+    const baseCall = fakeDb._calls.find((call: any) => call._ops.table === 'customer_entities')
+    expect(baseCall._ops.orderBys).toEqual([])
+    expect(baseCall._ops.limits).toBe(0)
+  })
+
+  test('keeps SQL ordering and pagination for unencrypted base fields', async () => {
+    const fakeDb = createFakeKysely({
+      customer_entities: [
+        { id: '1', tenant_id: 't1', organization_id: 'org1', display_name: 'Alice' },
+      ],
+      'information_schema.columns': [
+        { table_name: 'customer_entities', column_name: 'id' },
+        { table_name: 'customer_entities', column_name: 'tenant_id' },
+        { table_name: 'customer_entities', column_name: 'organization_id' },
+        { table_name: 'customer_entities', column_name: 'deleted_at' },
+        { table_name: 'customer_entities', column_name: 'display_name' },
+      ],
+    })
+    const engine = new BasicQueryEngine(
+      {} as any,
+      () => fakeDb as any,
+      () => ({
+        isEnabled: () => true,
+        getEncryptedFieldNames: async () => [],
+      }),
+    )
+
+    await engine.query('customers:customer_entity', {
+      tenantId: 't1',
+      organizationId: 'org1',
+      fields: ['id', 'display_name'],
+      sort: [{ field: 'display_name', dir: SortDir.Asc }],
+      page: { page: 2, pageSize: 10 },
+    })
+
+    const baseCall = fakeDb._calls.find((call: any) => call._ops.table === 'customer_entities')
+    expect(baseCall._ops.orderBys).toEqual([['customer_entities.display_name', 'asc']])
+    expect(baseCall._ops.limits).toBe(10)
+    expect(baseCall._ops.offsets).toBe(10)
+  })
 })

--- a/packages/shared/src/lib/query/encrypted-sort.ts
+++ b/packages/shared/src/lib/query/encrypted-sort.ts
@@ -1,0 +1,86 @@
+import type { EntityId } from '@open-mercato/shared/modules/entities'
+import { SortDir, type Sort } from './types'
+
+export type QueryEncryptionService = {
+  getEncryptedFieldNames?: (
+    entityId: EntityId,
+    tenantId?: string | null,
+    organizationId?: string | null,
+  ) => Promise<readonly string[]>
+  isEnabled?: () => boolean
+}
+
+const toSnakeCase = (value: string): string =>
+  value.replace(/([A-Z])/g, '_$1').replace(/__/g, '_').toLowerCase()
+
+const toCamelCase = (value: string): string =>
+  value.replace(/_([a-z])/g, (_, c) => c.toUpperCase())
+
+export function fieldNameCandidates(field: string): string[] {
+  const raw = String(field || '').trim()
+  if (!raw) return []
+  const candidates = [raw, toSnakeCase(raw), toCamelCase(raw)]
+  if (raw.startsWith('cf:')) candidates.push(raw.replace(/[^a-zA-Z0-9_]/g, '_'))
+  return Array.from(new Set(candidates))
+}
+
+export async function resolveEncryptedSortFields(
+  service: QueryEncryptionService | null | undefined,
+  entity: EntityId,
+  sortFields: readonly string[],
+  tenantId?: string | null,
+  organizationId?: string | null,
+): Promise<Set<string>> {
+  if (!service?.getEncryptedFieldNames) return new Set()
+  if (service.isEnabled && !service.isEnabled()) return new Set()
+  const encrypted = await service.getEncryptedFieldNames(entity, tenantId ?? null, organizationId ?? null)
+  const encryptedCandidates = new Set<string>()
+  for (const field of encrypted) {
+    for (const candidate of fieldNameCandidates(field)) encryptedCandidates.add(candidate)
+  }
+  const result = new Set<string>()
+  for (const field of sortFields) {
+    if (field.startsWith('cf:')) continue
+    const matches = fieldNameCandidates(field).some((candidate) => encryptedCandidates.has(candidate))
+    if (matches) result.add(field)
+  }
+  return result
+}
+
+function readField(row: Record<string, unknown>, field: string): unknown {
+  for (const candidate of fieldNameCandidates(field)) {
+    if (Object.prototype.hasOwnProperty.call(row, candidate)) return row[candidate]
+  }
+  return undefined
+}
+
+function compareValues(left: unknown, right: unknown): number {
+  const leftMissing = left === null || left === undefined
+  const rightMissing = right === null || right === undefined
+  if (leftMissing && rightMissing) return 0
+  if (leftMissing) return 1
+  if (rightMissing) return -1
+  if (left instanceof Date && right instanceof Date) return left.getTime() - right.getTime()
+  if (typeof left === 'number' && typeof right === 'number') return left - right
+  if (typeof left === 'boolean' && typeof right === 'boolean') return Number(left) - Number(right)
+  return String(left).localeCompare(String(right), undefined, {
+    sensitivity: 'base',
+    numeric: true,
+  })
+}
+
+export function sortRowsInMemory<T extends Record<string, unknown>>(
+  rows: readonly T[],
+  sorts: readonly Sort[],
+): T[] {
+  return [...rows].sort((left, right) => {
+    for (const sort of sorts) {
+      const direction = sort.dir === SortDir.Desc ? -1 : 1
+      const compared = compareValues(readField(left, sort.field), readField(right, sort.field))
+      if (compared !== 0) return compared * direction
+    }
+    const leftId = readField(left, 'id')
+    const rightId = readField(right, 'id')
+    return compareValues(leftId, rightId)
+  })
+}

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -1,4 +1,4 @@
-import type { QueryEngine, QueryOptions, QueryResult, QueryCustomFieldSource, QueryExtensionsConfig } from './types'
+import type { QueryEngine, QueryOptions, QueryResult, QueryCustomFieldSource, QueryExtensionsConfig, Sort } from './types'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { type Kysely, sql, type RawBuilder } from 'kysely'
@@ -14,6 +14,7 @@ import {
 import { resolveSearchConfig } from '../search/config'
 import { tokenizeText } from '../search/tokenize'
 import { runBeforeQueryPipeline, runAfterQueryPipeline, type QueryExtensionContext } from './query-extension-runner'
+import { resolveEncryptedSortFields, sortRowsInMemory } from './encrypted-sort'
 
 type AnyDb = Kysely<any>
 type AnyBuilder = any
@@ -22,6 +23,7 @@ const entityTableCache = new Map<string, string>()
 
 type EncryptionResolver = () => {
   decryptEntityPayload?: (entityId: EntityId, payload: Record<string, unknown>, tenantId?: string | null, organizationId?: string | null) => Promise<Record<string, unknown>>
+  getEncryptedFieldNames?: (entityId: EntityId, tenantId?: string | null, organizationId?: string | null) => Promise<readonly string[]>
   isEnabled?: () => boolean
 } | null
 
@@ -475,9 +477,35 @@ export class BasicQueryEngine implements QueryEngine {
       applyJoinFilterOp,
       columnExists: (tbl, column) => this.columnExists(tbl, column),
     })
+
+    const fallbackOrgId =
+      opts.organizationId
+      ?? (Array.isArray(opts.organizationIds) && opts.organizationIds.length === 1 ? opts.organizationIds[0] : null)
+    const encryptionService = this.getEncryptionService()
+    const resolvedSorts: Sort[] = []
+    for (const s of opts.sort || []) {
+      if (s.field.startsWith('cf:')) {
+        resolvedSorts.push(s)
+      } else {
+        const column = await this.resolveBaseColumn(table, s.field)
+        if (column) resolvedSorts.push({ ...s, field: column })
+      }
+    }
+    const encryptedSortFields = await resolveEncryptedSortFields(
+      encryptionService,
+      entity,
+      resolvedSorts.filter((sort) => !sort.field.startsWith('cf:')).map((sort) => sort.field),
+      opts.tenantId ?? null,
+      fallbackOrgId,
+    )
+    const requiresPlaintextSort = encryptedSortFields.size > 0
+
     // Selection (base columns only here; cf:* handled later)
     if (opts.fields && opts.fields.length) {
-      const cols = opts.fields.filter((f) => !f.startsWith('cf:'))
+      const cols = new Set(opts.fields.filter((f) => !f.startsWith('cf:')))
+      if (requiresPlaintextSort) {
+        for (const field of encryptedSortFields) cols.add(field)
+      }
       for (const c of cols) {
         // Qualify and alias to base names to avoid ambiguity
         q = q.select(sql.ref(qualify(c)).as(c))
@@ -714,7 +742,7 @@ export class BasicQueryEngine implements QueryEngine {
     }
 
     // Sorting: base fields and cf:* (use aggregated alias for cf)
-    for (const s of opts.sort || []) {
+    for (const s of resolvedSorts) {
       if (s.field.startsWith('cf:')) {
         const key = s.field.slice(3)
         const alias = sanitize(`cf:${key}`)
@@ -726,11 +754,9 @@ export class BasicQueryEngine implements QueryEngine {
             cfSelectedAliases.push(alias)
           }
         }
-        q = q.orderBy(alias, (s.dir ?? 'asc') as any)
+        if (!requiresPlaintextSort) q = q.orderBy(alias, (s.dir ?? 'asc') as any)
       } else {
-        const column = await this.resolveBaseColumn(table, s.field)
-        if (!column) continue
-        q = q.orderBy(qualify(column), (s.dir ?? 'asc') as any)
+        if (!requiresPlaintextSort) q = q.orderBy(qualify(s.field), (s.dir ?? 'asc') as any)
       }
     }
 
@@ -747,7 +773,10 @@ export class BasicQueryEngine implements QueryEngine {
       : q.clearSelect().clearOrderBy().select(sql<string>`count(distinct ${sql.ref(`${table}.id`)})`.as('count'))
     const countRow = await countBuilder.executeTakeFirst() as { count: unknown } | undefined
     const total = Number((countRow as any)?.count ?? 0)
-    const items = await q.limit(pageSize).offset((page - 1) * pageSize).execute() as any[]
+    const dataQuery = requiresPlaintextSort
+      ? q
+      : q.limit(pageSize).offset((page - 1) * pageSize)
+    const items = await dataQuery.execute() as any[]
 
     if (cfJsonAliases.size > 0) {
       for (const row of items) {
@@ -771,7 +800,7 @@ export class BasicQueryEngine implements QueryEngine {
       }
     }
 
-    const svc = this.getEncryptionService()
+    const svc = encryptionService
     const decryptPayload =
       svc?.decryptEntityPayload?.bind(svc) as
         | ((
@@ -783,9 +812,6 @@ export class BasicQueryEngine implements QueryEngine {
         | null
     let decryptedItems = items
     if (decryptPayload) {
-      const fallbackOrgId =
-        opts.organizationId
-        ?? (Array.isArray(opts.organizationIds) && opts.organizationIds.length === 1 ? opts.organizationIds[0] : null)
       decryptedItems = await Promise.all(
         (items as any[]).map(async (item) => {
           try {
@@ -804,7 +830,12 @@ export class BasicQueryEngine implements QueryEngine {
       )
     }
 
-    let queryResult: QueryResult<T> = { items: decryptedItems, page, pageSize, total }
+    const pagedItems = requiresPlaintextSort
+      ? sortRowsInMemory(decryptedItems as Record<string, unknown>[], resolvedSorts)
+          .slice((page - 1) * pageSize, page * pageSize)
+      : decryptedItems
+
+    let queryResult: QueryResult<T> = { items: pagedItems, page, pageSize, total }
 
     // --- UMES query extension: after-query pipeline ---
     if (ext && extensionCtx) {


### PR DESCRIPTION
## Summary

Fixes a follow-up issue from #2217: CRM customer lists now send sorting to the backend, but encrypted base fields like `display_name` and `primary_email` were still sorted by ciphertext before decryption.

## Changes

- Add an additive encryption-map API, `getEncryptedFieldNames`, so query engines can identify encrypted base-field sort requests.
- Make `BasicQueryEngine` and `HybridQueryEngine` fetch matching rows, decrypt them, sort by plaintext, and paginate in memory only when the active sort touches an encrypted base field.
- Keep the existing SQL/index ordering path for non-encrypted sorts.
- Add regression coverage for encrypted plaintext sorting, global pagination after plaintext sort, and unchanged SQL ordering for non-encrypted fields.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor bugfix/regression, no spec needed)

**Spec file path:**
N/A

## Testing

- [x] `yarn workspace @open-mercato/shared test src/lib/encryption/__tests__/tenantDataEncryptionService.test.ts src/lib/query/__tests__/engine.test.ts --runInBand`
- [x] `yarn workspace @open-mercato/core test src/modules/query_index/__tests__/hybrid-engine.test.ts --runInBand`
- [x] `yarn tsc --noEmit --ignoreDeprecations 6.0 -p packages/shared/tsconfig.json`
- [x] `yarn workspace @open-mercato/shared build`
- [x] `yarn workspace @open-mercato/core build`
- [x] `yarn build:packages`
- [x] `yarn generate`
- [x] `yarn build:packages`
- [x] `yarn check:dep-versions`
- [x] `yarn i18n:check-sync`
- [x] `yarn i18n:check-usage` (advisory unused-key output only)
- [x] `yarn typecheck`
- [x] `yarn build:app`
- [x] `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' BASE_URL=https://preview-customer-list-encrypted-field-sortin-44bade.om.they.dev yarn test:integration packages/core/src/modules/core/__integration__/integration/TC-INT-002.spec.ts`

Local `yarn test` did not complete on my machine because `@open-mercato/ai-assistant` crashed a Jest worker with `SIGSEGV` in `src/modules/ai_assistant/lib/__tests__/sandbox.test.ts`. The PR CI `test` job passed in GitHub Actions.

PR CI note: the first run had one unrelated Playwright shard failure in `TC-INT-002: Customer to Deal to Quote to Order Flow`. The retry screenshot showed the created deal row was present, but the test clicked the whole table row and did not navigate reliably. I added a focused test stabilization commit that waits for the matching row and clicks the deal title text instead. The updated TC-INT-002 spec passes against the branch preview. A new PR CI run is now in progress.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Integration coverage note

No new Playwright spec was added because this is a query-engine regression covered by focused unit tests in both query engine implementations. The existing end-to-end `TC-INT-002` flow was stabilized after it blocked the first CI run.

Preview validation completed on `https://preview-customer-list-encrypted-field-sortin-44bade.om.they.dev` using agent-browser, read-only:

- People list `Name` sort: before sorting the first page was not alphabetical; after clicking `Name`, order became `Arjun Patel`, `Daniel Cho`, `Lena Ortiz`, `Mia Johnson`, `Naomi Harris`, `Taylor Brooks`; second click reversed the order.
- People API confirmed `sortField=name&sortDir=asc` and `sortField=name&sortDir=desc` return plaintext-sorted `display_name` values.
- Companies list `Name` sort returned `Brightside Solar`, `Copperleaf Design Co.`, `Harborview Analytics`.
- Companies API confirmed `sortField=name&sortDir=asc` returns plaintext-sorted `display_name` values.

## Linked issues

Follow-up to #2217.
