### PR TITLE
feat(storage_s3): declare ACL feature dependencies (#2176)

### DIFF
--- a/packages/storage-s3/src/modules/storage_s3/__tests__/acl-dependencies.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/acl-dependencies.test.ts
@@ -1,0 +1,34 @@
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as storageS3Features } from '../acl'
+
+const catalog: FeatureDescriptor[] = storageS3Features
+const ownIds = new Set(catalog.map((feature) => feature.id))
+
+describe('storage_s3 acl dependency declarations', () => {
+  it('declares dependsOn only against features registered in the catalog', () => {
+    const granted = catalog.map((feature) => feature.id)
+    const diagnostics = resolveAclDependencyDiagnostics(granted, catalog)
+    const ownUnknown = diagnostics.unknownReferences.filter((ref) => ownIds.has(ref.feature))
+    expect(ownUnknown).toEqual([])
+  })
+
+  it('resolves cleanly with no missing deps when every feature is granted', () => {
+    const granted = catalog.map((feature) => feature.id)
+    const diagnostics = resolveAclDependencyDiagnostics(granted, catalog)
+    const ownMissing = diagnostics.missingDependencies.filter((dep) => ownIds.has(dep.feature))
+    expect(ownMissing).toEqual([])
+    expect(diagnostics.unknownReferences).toEqual([])
+  })
+
+  it('keeps every internal dependency target within the module feature set', () => {
+    const internalDeps = catalog.flatMap((feature) =>
+      (feature.dependsOn ?? []).filter((dep) => ownIds.has(dep) || dep.startsWith('storage_providers.')),
+    )
+    for (const dep of internalDeps) {
+      expect(ownIds.has(dep)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
Fixes #2176

## Problem
Per-module follow-up to PR #2141 (ACL dependency bundles). Every module's `acl.ts` needs `dependsOn` declarations per the umbrella spec, plus a regression test proving the declarations resolve cleanly against the catalog.

## Root Cause
N/A — this is the per-module rollout for `storage_s3`.

## What Changed
- Per spec [`.ai/specs/2026-05-27-acl-dependency-bundles.md` §6.37](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md#637-storage_s3), `storage_s3` exposes a single feature `storage_providers.manage` with **no** dependencies (table marks it `—`).
- No real dependency exists, so `acl.ts` needs no `dependsOn` arrays.
- No `*`-marked deps in the spec table, so there are no new view-grained features to add and `setup.ts` `defaultRoleFeatures` is unchanged.
- Added a regression test asserting the module's `acl.ts` declarations resolve cleanly against its own catalog via `resolveAclDependencyDiagnostics` (no `unknownReferences` / `missingDependencies` for `storage_s3`-owned feature ids).

## Tests
- New `packages/storage-s3/src/modules/storage_s3/__tests__/acl-dependencies.test.ts` (3 cases).
- `yarn workspace @open-mercato/storage-s3 test` → 57 passed (54 existing + 3 new).
- `yarn workspace @open-mercato/storage-s3 typecheck` → clean.

## Backward Compatibility
- No contract surface changes. Test-only addition; no ACL ids, setup grants, or public types modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
