### PR TITLE
feat(directory): declare ACL feature dependencies (#2177)

### DIFF
--- a/packages/core/src/modules/directory/__tests__/acl.test.ts
+++ b/packages/core/src/modules/directory/__tests__/acl.test.ts
@@ -1,0 +1,48 @@
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as directoryFeatures } from '../acl'
+
+const directoryDescriptors: FeatureDescriptor[] = directoryFeatures
+
+const directoryOwnIds = directoryDescriptors.map((feature) => feature.id)
+
+describe('directory acl dependency declarations', () => {
+  it('declares dependsOn only against features registered in the catalog', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(directoryOwnIds, directoryDescriptors)
+    const ownUnknown = diagnostics.unknownReferences.filter((ref) =>
+      ref.feature.startsWith('directory.'),
+    )
+    expect(ownUnknown).toEqual([])
+  })
+
+  it('resolves cleanly with no missing deps when every feature is granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(directoryOwnIds, directoryDescriptors)
+    const ownMissing = diagnostics.missingDependencies.filter((dep) =>
+      dep.feature.startsWith('directory.'),
+    )
+    expect(ownMissing).toEqual([])
+  })
+
+  it('flags the matching view feature as missing when only a manage feature is granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(
+      ['directory.tenants.manage'],
+      directoryDescriptors,
+    )
+    const tenantsManage = diagnostics.missingDependencies.find(
+      (dep) => dep.feature === 'directory.tenants.manage',
+    )
+    expect(tenantsManage?.missing).toEqual(['directory.tenants.view'])
+  })
+
+  it('keeps every internal directory dependency target within the directory feature set', () => {
+    const directoryIds = new Set(directoryOwnIds)
+    const internalDeps = directoryDescriptors.flatMap((feature) =>
+      (feature.dependsOn ?? []).filter((dep) => dep.startsWith('directory.')),
+    )
+    for (const dep of internalDeps) {
+      expect(directoryIds.has(dep)).toBe(true)
+    }
+  })
+})

--- a/packages/core/src/modules/directory/acl.ts
+++ b/packages/core/src/modules/directory/acl.ts
@@ -1,8 +1,18 @@
 export const features = [
     { id: 'directory.tenants.view', title: 'View tenants', module: 'directory' },
-    { id: 'directory.tenants.manage', title: 'Manage tenants', module: 'directory' },
+    {
+        id: 'directory.tenants.manage',
+        title: 'Manage tenants',
+        module: 'directory',
+        dependsOn: ['directory.tenants.view'],
+    },
     { id: 'directory.organizations.view', title: 'View organizations', module: 'directory' },
-    { id: 'directory.organizations.manage', title: 'Manage organizations', module: 'directory' },
+    {
+        id: 'directory.organizations.manage',
+        title: 'Manage organizations',
+        module: 'directory',
+        dependsOn: ['directory.organizations.view'],
+    },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2177

## Problem
Per-module follow-up to PR #2141 (ACL dependency bundles). The infrastructure (resolver, API forwarding, `AclEditor` warning UX) shipped using `customers` as the reference module; every other module's `acl.ts` still needs `dependsOn` declarations. This PR covers the `directory` module.

## Root Cause
`directory/acl.ts` declared its features as a flat list with no `dependsOn`, so the editor could not warn when a granted `manage` feature was missing its matching `view` feature.

## What Changed
- `packages/core/src/modules/directory/acl.ts`: added `dependsOn` arrays per spec [§6.38](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md#638-directory):
  - `directory.tenants.manage` → `['directory.tenants.view']`
  - `directory.organizations.manage` → `['directory.organizations.view']`
- No new view-grained features were required (no `*` markers in the spec table), so `setup.ts` `defaultRoleFeatures` is unchanged and no `sync-role-acls` run is needed.

## Tests
- New `packages/core/src/modules/directory/__tests__/acl.test.ts` (4 cases):
  - no `unknownReferences` for the module's own ids,
  - no `missingDependencies` when every feature is granted,
  - the matching view feature is flagged missing when only `manage` is granted,
  - every internal dependency target stays within the directory feature set.
- `yarn workspace @open-mercato/core test -- src/modules/directory/__tests__/acl.test.ts` → 4 passed.
- Core typecheck (`tsc --noEmit`) passes after `yarn generate`.

## Backward Compatibility
- Additive only. No feature ids removed or renamed; `dependsOn` is an optional field on the existing feature descriptors. No contract surface broken.

Spec: [`.ai/specs/2026-05-27-acl-dependency-bundles.md`](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md) §6.38

🤖 Generated with [Claude Code](https://claude.com/claude-code)