### PR TITLE
feat(currencies): declare ACL feature dependencies (#2179)

### DIFF
--- a/packages/core/src/modules/currencies/__tests__/acl-dependencies.test.ts
+++ b/packages/core/src/modules/currencies/__tests__/acl-dependencies.test.ts
@@ -1,0 +1,60 @@
+/** @jest-environment node */
+
+import { describe, test, expect } from '@jest/globals'
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as currenciesFeatures } from '../acl'
+
+// All currencies dependencies are intra-module (spec §6.40), so the resolver
+// catalog is just the module's own feature set.
+const currenciesCatalog: FeatureDescriptor[] = currenciesFeatures as FeatureDescriptor[]
+const currenciesFeatureIds = currenciesCatalog.map((feature) => feature.id)
+
+describe('currencies ACL dependency declarations', () => {
+  test('every dependency resolves to a currencies feature (no unknown references)', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(currenciesFeatureIds, currenciesCatalog)
+    const ownUnknown = diagnostics.unknownReferences.filter((entry) =>
+      entry.feature.startsWith('currencies.'),
+    )
+    expect(ownUnknown).toEqual([])
+  })
+
+  test('resolves cleanly with no missing deps when every feature is granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(currenciesFeatureIds, currenciesCatalog)
+    const ownMissing = diagnostics.missingDependencies.filter((entry) =>
+      entry.feature.startsWith('currencies.'),
+    )
+    expect(ownMissing).toEqual([])
+  })
+
+  test('declares the dependency table from spec §6.40', () => {
+    const dependsOnById = new Map(
+      currenciesCatalog.map((feature) => [feature.id, [...(feature.dependsOn ?? [])].sort()]),
+    )
+    expect(dependsOnById.get('currencies.view')).toEqual([])
+    expect(dependsOnById.get('currencies.manage')).toEqual(['currencies.view'])
+    expect(dependsOnById.get('currencies.rates.view')).toEqual(['currencies.view'])
+    expect(dependsOnById.get('currencies.rates.manage')).toEqual(['currencies.rates.view'])
+    expect(dependsOnById.get('currencies.fetch.view')).toEqual(['currencies.view'])
+    expect(dependsOnById.get('currencies.fetch.manage')).toEqual(['currencies.fetch.view'])
+  })
+
+  test('granting only a manage feature surfaces its read dependency as missing', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(['currencies.rates.manage'], currenciesCatalog)
+    expect(diagnostics.unknownReferences).toEqual([])
+    const ratesManage = diagnostics.missingDependencies.find(
+      (entry) => entry.feature === 'currencies.rates.manage',
+    )
+    expect(ratesManage?.missing).toEqual(['currencies.rates.view'])
+  })
+
+  test('keeps every dependency target within the currencies feature set', () => {
+    const ids = new Set(currenciesFeatureIds)
+    const deps = currenciesCatalog.flatMap((feature) => feature.dependsOn ?? [])
+    for (const dep of deps) {
+      expect(ids.has(dep)).toBe(true)
+    }
+  })
+})

--- a/packages/core/src/modules/currencies/acl.ts
+++ b/packages/core/src/modules/currencies/acl.ts
@@ -8,26 +8,31 @@ export const features = [
     id: 'currencies.manage',
     title: 'Manage currencies',
     module: 'currencies',
+    dependsOn: ['currencies.view'],
   },
   {
     id: 'currencies.rates.view',
     title: 'View exchange rates',
     module: 'currencies',
+    dependsOn: ['currencies.view'],
   },
   {
     id: 'currencies.rates.manage',
     title: 'Manage exchange rates',
     module: 'currencies',
+    dependsOn: ['currencies.rates.view'],
   },
   {
     id: 'currencies.fetch.view',
     title: 'View currency fetch configuration',
     module: 'currencies',
+    dependsOn: ['currencies.view'],
   },
   {
     id: 'currencies.fetch.manage',
     title: 'Manage currency fetch configuration',
     module: 'currencies',
+    dependsOn: ['currencies.fetch.view'],
   },
 ]
 


### PR DESCRIPTION
Fixes #2179

## Problem
- The `currencies` module's `acl.ts` did not declare the `dependsOn` dependency metadata introduced by PR #2141 (ACL dependency bundles). This is the per-module follow-up tracked by #2179.

## Root Cause
- PR #2141 shipped the resolver/API/UI infrastructure and used `customers` as the reference module. Every other module still needs its `acl.ts` updated; `currencies` had not been done.

## What Changed
- Added `dependsOn` to the currencies feature descriptors per spec §6.40 of `.ai/specs/2026-05-27-acl-dependency-bundles.md`:
  - `currencies.manage` → `currencies.view`
  - `currencies.rates.view` → `currencies.view`
  - `currencies.rates.manage` → `currencies.rates.view`
  - `currencies.fetch.view` → `currencies.view`
  - `currencies.fetch.manage` → `currencies.fetch.view`
- No new view-grained features were required (the spec table has no `*` markers), and `setup.ts` already grants `currencies.*` to `admin`, so `defaultRoleFeatures` is unchanged. No `yarn mercato auth sync-role-acls` run is needed because no new feature ids were introduced.

## Tests
- Added `packages/core/src/modules/currencies/__tests__/acl-dependencies.test.ts` (5 tests) asserting:
  - every declared dependency resolves to a registered currencies feature (no `unknownReferences`),
  - the fully-granted set has no `missingDependencies`,
  - the declared table matches spec §6.40,
  - granting a `manage` feature alone surfaces its read dependency as missing,
  - every dependency target stays within the currencies feature set.
- Verified the test fails before the `acl.ts` change and passes after (5/5 passing).
- Cross-module ACL tests that include currencies features (catalog, sales) still pass.

## Backward Compatibility
- Additive only — `dependsOn` is an optional field added to existing feature descriptors. No feature ids, ACL features, or other contract surfaces were removed or renamed.

## Notes on validation environment
- `yarn typecheck` and `yarn lint` could not be run to completion in this environment due to pre-existing toolchain version mismatches unrelated to this change (TypeScript `--ignoreDeprecations "6.0"` rejected by the resolved compiler; `eslint@10` incompatible with the configured `eslint-plugin-react`). These fail identically on `develop`. The change is data-only and was type-checked/executed via the Jest run.

Spec: `.ai/specs/2026-05-27-acl-dependency-bundles.md` §6.40