### PR TITLE
feat(entities): declare ACL feature dependencies (#2178)

### DIFF
--- a/packages/core/src/modules/entities/__tests__/acl-dependencies.test.ts
+++ b/packages/core/src/modules/entities/__tests__/acl-dependencies.test.ts
@@ -1,0 +1,47 @@
+/** @jest-environment node */
+
+import { describe, test, expect } from '@jest/globals'
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as entitiesFeatures } from '../acl'
+
+// The entities dependency table (spec §6.39) is self-contained: every declared
+// dependency points at another entities feature, so the module's own catalog is
+// sufficient to validate the declarations.
+const catalog = entitiesFeatures as FeatureDescriptor[]
+const entitiesFeatureIds = catalog.map((f) => f.id)
+
+describe('entities ACL dependency declarations', () => {
+  test('every entities dependency resolves to a known feature (no unknown references)', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(entitiesFeatureIds, catalog)
+    const entitiesUnknown = diagnostics.unknownReferences.filter((entry) =>
+      entry.feature.startsWith('entities.'),
+    )
+    expect(entitiesUnknown).toEqual([])
+  })
+
+  test('manage features depend on their matching view feature', () => {
+    const definitionsManage = catalog.find((f) => f.id === 'entities.definitions.manage')
+    const recordsManage = catalog.find((f) => f.id === 'entities.records.manage')
+    expect(definitionsManage?.dependsOn).toContain('entities.definitions.view')
+    expect(recordsManage?.dependsOn).toContain('entities.records.view')
+  })
+
+  test('view features declare no dependencies', () => {
+    const definitionsView = catalog.find((f) => f.id === 'entities.definitions.view')
+    const recordsView = catalog.find((f) => f.id === 'entities.records.view')
+    expect(definitionsView?.dependsOn ?? []).toEqual([])
+    expect(recordsView?.dependsOn ?? []).toEqual([])
+  })
+
+  test('granting a manage feature alone surfaces its missing read dependency', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(['entities.definitions.manage'], catalog)
+    const entry = diagnostics.missingDependencies.find(
+      (item) => item.feature === 'entities.definitions.manage',
+    )
+    expect(entry).toBeDefined()
+    expect([...(entry?.missing ?? [])]).toEqual(['entities.definitions.view'])
+  })
+})

--- a/packages/core/src/modules/entities/acl.ts
+++ b/packages/core/src/modules/entities/acl.ts
@@ -1,8 +1,18 @@
 export const features = [
   { id: 'entities.definitions.view', title: 'View custom field definitions', module: 'entities' },
-  { id: 'entities.definitions.manage', title: 'Manage custom field definitions', module: 'entities' },
+  {
+    id: 'entities.definitions.manage',
+    title: 'Manage custom field definitions',
+    module: 'entities',
+    dependsOn: ['entities.definitions.view'],
+  },
   { id: 'entities.records.view', title: 'View records', module: 'entities' },
-  { id: 'entities.records.manage', title: 'Manage records', module: 'entities' },
+  {
+    id: 'entities.records.manage',
+    title: 'Manage records',
+    module: 'entities',
+    dependsOn: ['entities.records.view'],
+  },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2178

## Problem
- The `entities` module's `acl.ts` did not declare `dependsOn` for its features, so granting a manage feature without the matching view feature produced no diagnostic (the warning UX shipped in PR #2141 had nothing to report for this module).

## Root Cause
- Per the umbrella spec [`.ai/specs/2026-05-27-acl-dependency-bundles.md`](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md) §6.39, every module's feature descriptors must declare their real dependencies. `entities` was still on the pre-#2141 flat list.

## What Changed
- `packages/core/src/modules/entities/acl.ts`: added `dependsOn` arrays per spec §6.39:
  - `entities.definitions.manage` → `entities.definitions.view`
  - `entities.records.manage` → `entities.records.view`
- The §6.39 table is self-contained: no cross-module dependencies and no new view-grained features, so `setup.ts` needs no changes — `admin` already carries the `entities.*` wildcard, which covers the unchanged view features. No `yarn mercato auth sync-role-acls` run is required because no new feature ids were introduced.

## Tests
- New `packages/core/src/modules/entities/__tests__/acl-dependencies.test.ts` (4 cases): asserts the declarations resolve with no `unknownReferences` for `entities.*`, that each manage feature depends on its matching view feature, that view features declare no dependencies, and that granting a manage feature alone surfaces its missing read dependency.
- Verified red-without-fix (2/4 fail on the pre-change `acl.ts`), green-with-fix (4/4). Full entities suite: 29/29 pass.

## Backward Compatibility
- Additive only. `dependsOn` is an optional field on existing feature descriptors; no feature ids added, removed, or renamed. No API/event/DI/schema contract surface touched.

Refs umbrella spec §6.39 and reference module `customers` (PR #2141).