### PR TITLE
feat(security): declare ACL feature dependencies (#2172)

### DIFF
--- a/packages/enterprise/src/modules/security/__tests__/acl-dependencies.test.ts
+++ b/packages/enterprise/src/modules/security/__tests__/acl-dependencies.test.ts
@@ -1,0 +1,73 @@
+/** @jest-environment node */
+
+import { describe, test, expect } from '@jest/globals'
+import { hasFeature } from '@open-mercato/shared/security/features'
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as securityFeatures } from '../acl'
+import { setup } from '../setup'
+import { features as authFeatures } from '@open-mercato/core/modules/auth/acl'
+
+// The security dependency table (spec §6.33) references `auth.users.list` from
+// the auth module, so the catalog the resolver checks against must include it.
+const combinedCatalog: FeatureDescriptor[] = [
+  ...(securityFeatures as FeatureDescriptor[]),
+  ...(authFeatures as FeatureDescriptor[]),
+]
+
+describe('security ACL dependency declarations', () => {
+  test('every security dependency resolves to a known feature (no unknown references)', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(
+      combinedCatalog.map((feature) => feature.id),
+      combinedCatalog,
+    )
+    const securityUnknown = diagnostics.unknownReferences.filter((entry) =>
+      entry.feature.startsWith('security.'),
+    )
+    expect(securityUnknown).toEqual([])
+  })
+
+  test('granting security.admin.manage alone surfaces the missing read dependencies', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(['security.admin.manage'], combinedCatalog)
+    const adminEntry = diagnostics.missingDependencies.find(
+      (entry) => entry.feature === 'security.admin.manage',
+    )
+    expect(adminEntry).toBeDefined()
+    expect([...(adminEntry?.missing ?? [])].sort()).toEqual(
+      ['auth.users.list', 'security.profile.view'].sort(),
+    )
+  })
+
+  test('profile and sudo manage features depend on their view feature', () => {
+    const find = (id: string) =>
+      (securityFeatures as FeatureDescriptor[]).find((feature) => feature.id === id)
+
+    expect(find('security.profile.password')?.dependsOn).toContain('security.profile.view')
+    expect(find('security.profile.manage')?.dependsOn).toContain('security.profile.view')
+    expect(find('security.mfa.manage')?.dependsOn).toContain('security.profile.view')
+    expect(find('security.sudo.manage')?.dependsOn).toContain('security.sudo.view')
+  })
+
+  test('view-grained features declare no dependencies', () => {
+    const find = (id: string) =>
+      (securityFeatures as FeatureDescriptor[]).find((feature) => feature.id === id)
+
+    expect(find('security.profile.view')?.dependsOn).toBeUndefined()
+    expect(find('security.sudo.view')?.dependsOn).toBeUndefined()
+  })
+
+  test('default role features cover the security view dependencies', () => {
+    const adminFeatures = (setup.defaultRoleFeatures?.admin ?? []) as string[]
+    const employeeFeatures = (setup.defaultRoleFeatures?.employee ?? []) as string[]
+
+    // admin keeps the security.* wildcard, which already covers every view feature
+    expect(hasFeature(adminFeatures, 'security.profile.view')).toBe(true)
+    expect(hasFeature(adminFeatures, 'security.sudo.view')).toBe(true)
+
+    // employee is an explicit allowlist; it grants profile.view so the
+    // password/manage dependencies stay satisfied for the self-service page
+    expect(hasFeature(employeeFeatures, 'security.profile.view')).toBe(true)
+  })
+})

--- a/packages/enterprise/src/modules/security/acl.ts
+++ b/packages/enterprise/src/modules/security/acl.ts
@@ -1,11 +1,36 @@
 export const features = [
   { id: 'security.profile.view', title: 'View security profile', module: 'security' },
-  { id: 'security.profile.password', title: 'Change own password', module: 'security' },
-  { id: 'security.profile.manage', title: 'Manage security profile', module: 'security' },
-  { id: 'security.mfa.manage', title: 'Manage MFA settings', module: 'security' },
-  { id: 'security.admin.manage', title: 'Manage security policies', module: 'security' },
+  {
+    id: 'security.profile.password',
+    title: 'Change own password',
+    module: 'security',
+    dependsOn: ['security.profile.view'],
+  },
+  {
+    id: 'security.profile.manage',
+    title: 'Manage security profile',
+    module: 'security',
+    dependsOn: ['security.profile.view'],
+  },
+  {
+    id: 'security.mfa.manage',
+    title: 'Manage MFA settings',
+    module: 'security',
+    dependsOn: ['security.profile.view'],
+  },
+  {
+    id: 'security.admin.manage',
+    title: 'Manage security policies',
+    module: 'security',
+    dependsOn: ['security.profile.view', 'auth.users.list'],
+  },
   { id: 'security.sudo.view', title: 'View sudo protection', module: 'security' },
-  { id: 'security.sudo.manage', title: 'Manage sudo protection', module: 'security' },
+  {
+    id: 'security.sudo.manage',
+    title: 'Manage sudo protection',
+    module: 'security',
+    dependsOn: ['security.sudo.view'],
+  },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2172

## Problem
The enterprise `security` module's `acl.ts` had not yet been updated for the ACL dependency bundles shipped in PR #2141. Granting a manage/action feature without its prerequisite read feature produced no operator warning.

## Root Cause
`security/acl.ts` declared a flat feature list with no `dependsOn` arrays, so `resolveAclDependencyDiagnostics` reported no missing dependencies for the module.

## What Changed
- `packages/enterprise/src/modules/security/acl.ts` — declared `dependsOn` per spec [§6.33](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md#633-enterprisesecurity):
  - `security.profile.password`, `security.profile.manage`, `security.mfa.manage` → `security.profile.view`
  - `security.admin.manage` → `security.profile.view`, `auth.users.list`
  - `security.sudo.manage` → `security.sudo.view`
- No new view-grained features (the §6.33 table has no `*` deps), so `setup.ts` `defaultRoleFeatures` is unchanged — `admin` keeps `security.*` and the `employee` allowlist already grants `security.profile.view`. The cross-module `auth.users.list` dep is already granted to admin via the auth module. No `sync-role-acls` run is required.

## Tests
- New `packages/enterprise/src/modules/security/__tests__/acl-dependencies.test.ts` (5 tests):
  - every security `dependsOn` resolves cleanly against the security+auth catalog (no `unknownReferences`)
  - granting `security.admin.manage` alone surfaces its missing read deps (`auth.users.list`, `security.profile.view`)
  - manage/action features depend on their view feature; view features declare no deps
  - default role features cover the security view dependencies
- Verified red before the fix (2/5 fail), green after (5/5 pass).
- Pre-existing, unrelated env failures in the broader security suite (MFA/sudo command/route/component tests fail on `Cannot find module '@open-mercato/cache'` / React env skew) and `typecheck` (`#generated` shim + an unrelated `record_locks` page) are not touched by this change.

## Backward Compatibility
- No contract surface changes. `dependsOn` is the optional, additive field introduced by #2141; no feature IDs were added, removed, or renamed.