### PR TITLE
feat(record_locks): declare ACL feature dependencies (#2173)

### DIFF
--- a/packages/enterprise/src/modules/record_locks/__tests__/acl-dependencies.test.ts
+++ b/packages/enterprise/src/modules/record_locks/__tests__/acl-dependencies.test.ts
@@ -1,0 +1,63 @@
+/** @jest-environment node */
+
+import { describe, test, expect } from '@jest/globals'
+import { hasFeature } from '@open-mercato/shared/security/features'
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as recordLocksFeatures } from '../acl'
+import { setup } from '../setup'
+
+// Every record_locks dependency references a feature inside the same module,
+// so the catalog the resolver checks against is just this module's own list.
+const catalog: FeatureDescriptor[] = recordLocksFeatures as FeatureDescriptor[]
+const featureById = (id: string) => catalog.find((f) => f.id === id)
+
+describe('record_locks ACL dependency declarations', () => {
+  test('every record_locks dependency resolves to a known feature (no unknown references)', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(
+      catalog.map((f) => f.id),
+      catalog,
+    )
+    const recordLocksUnknown = diagnostics.unknownReferences.filter((entry) =>
+      entry.feature.startsWith('record_locks.'),
+    )
+    expect(recordLocksUnknown).toEqual([])
+  })
+
+  test('manage / force_release / override_incoming depend on record_locks.view', () => {
+    expect(featureById('record_locks.manage')?.dependsOn).toEqual(['record_locks.view'])
+    expect(featureById('record_locks.force_release')?.dependsOn).toEqual(['record_locks.view'])
+    expect(featureById('record_locks.override_incoming')?.dependsOn).toEqual(['record_locks.view'])
+  })
+
+  test('record_locks.view is a root feature with no dependencies', () => {
+    expect(featureById('record_locks.view')?.dependsOn).toBeUndefined()
+  })
+
+  test('granting an action feature alone surfaces the missing view dependency', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(['record_locks.force_release'], catalog)
+    const entry = diagnostics.missingDependencies.find(
+      (item) => item.feature === 'record_locks.force_release',
+    )
+    expect(entry).toBeDefined()
+    expect([...(entry?.missing ?? [])]).toEqual(['record_locks.view'])
+  })
+
+  test('default role features satisfy every declared dependency', () => {
+    const adminFeatures = (setup.defaultRoleFeatures?.admin ?? []) as string[]
+    const employeeFeatures = (setup.defaultRoleFeatures?.employee ?? []) as string[]
+
+    // admin keeps the record_locks.* wildcard, which already covers view
+    expect(hasFeature(adminFeatures, 'record_locks.view')).toBe(true)
+    expect(hasFeature(adminFeatures, 'record_locks.manage')).toBe(true)
+
+    // employee only holds record_locks.view, so it never trips a dependency warning
+    const employeeDiagnostics = resolveAclDependencyDiagnostics(employeeFeatures, catalog)
+    const employeeMissing = employeeDiagnostics.missingDependencies.filter((entry) =>
+      entry.feature.startsWith('record_locks.'),
+    )
+    expect(employeeMissing).toEqual([])
+  })
+})

--- a/packages/enterprise/src/modules/record_locks/acl.ts
+++ b/packages/enterprise/src/modules/record_locks/acl.ts
@@ -1,8 +1,23 @@
 export const features = [
   { id: 'record_locks.view', title: 'View and use record locking', module: 'record_locks' },
-  { id: 'record_locks.manage', title: 'Manage record locking settings', module: 'record_locks' },
-  { id: 'record_locks.force_release', title: 'Force release locks owned by other users', module: 'record_locks' },
-  { id: 'record_locks.override_incoming', title: 'Override incoming conflict changes', module: 'record_locks' },
+  {
+    id: 'record_locks.manage',
+    title: 'Manage record locking settings',
+    module: 'record_locks',
+    dependsOn: ['record_locks.view'],
+  },
+  {
+    id: 'record_locks.force_release',
+    title: 'Force release locks owned by other users',
+    module: 'record_locks',
+    dependsOn: ['record_locks.view'],
+  },
+  {
+    id: 'record_locks.override_incoming',
+    title: 'Override incoming conflict changes',
+    module: 'record_locks',
+    dependsOn: ['record_locks.view'],
+  },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2173

## Problem
The `record_locks` enterprise module's `acl.ts` declared its four features without the `dependsOn` metadata introduced by PR #2141 (`feat(auth): ACL dependency bundles`). Operators granting an action feature (manage / force_release / override_incoming) got no warning that the underlying `record_locks.view` use-feature was missing.

## Root Cause
Per-module follow-up to #2141: only `customers` (the reference module) had `dependsOn` arrays. Every other module, including this enterprise overlay, still needed its table from [spec §6.34](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md#634-enterpriserecord_locks) enacted.

## What Changed
- `packages/enterprise/src/modules/record_locks/acl.ts`: added `dependsOn: ['record_locks.view']` to `record_locks.manage`, `record_locks.force_release`, and `record_locks.override_incoming`. `record_locks.view` stays a dependency-free root feature.

### Refinement vs the spec's proposed default
The spec proposed `force_release → manage`. I refined it to `force_release → view` (the spec explicitly invites module owners to correct the proposed defaults). Rationale from the actual route wiring:
- `api/force-release/route.ts` POST requires only `record_locks.force_release`.
- `api/acquire/route.ts` POST requires `record_locks.view` and checks `force_release` as an *elevated add-on* (`resolveCanForceRelease`), never `manage`.

So force-release is exercised entirely in the view/use plane and is independent of settings management. Declaring `manage` as its dependency would emit false-positive warnings for a legitimate grant such as "team lead can force-release locks but does not administer locking settings." `view` is the minimal correct dependency.

No new view-grained features were introduced, so `setup.ts` `defaultRoleFeatures` and `yarn mercato auth sync-role-acls` are unchanged (admin keeps `record_locks.*`; employee keeps `record_locks.view`, which satisfies every declared dependency).

## Tests
- New `packages/enterprise/src/modules/record_locks/__tests__/acl-dependencies.test.ts` (5 cases): no `unknownReferences` for the module's ids; each action feature depends on `record_locks.view`; `record_locks.view` is a root feature; granting an action alone surfaces the missing view dependency; default role grants (admin wildcard + employee allowlist) trip zero dependency warnings.
- 5/5 new pass; verified the dependency assertions are red without the `acl.ts` change.
- Full module suite green: 54/54 across 10 suites in `src/modules/record_locks`.

## Backward Compatibility
Additive only — new optional `dependsOn` metadata on existing feature descriptors. No feature ids removed or renamed, no API/event/DI/route changes. Warnings only (not blocking saves), per spec §4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)