### PR TITLE
feat(sso): declare ACL feature dependencies (#2174)

### DIFF
--- a/packages/enterprise/src/modules/sso/__tests__/acl.test.ts
+++ b/packages/enterprise/src/modules/sso/__tests__/acl.test.ts
@@ -1,0 +1,67 @@
+/** @jest-environment node */
+
+import { describe, it, expect } from '@jest/globals'
+import { hasFeature } from '@open-mercato/shared/security/features'
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as ssoFeatures } from '../acl'
+import { setup } from '../setup'
+
+// The sso dependency table (spec §6.35) only references sibling sso features,
+// so the resolved catalog is the module's own feature set.
+const ssoDescriptors: FeatureDescriptor[] = ssoFeatures
+const ssoOwnIds = ssoDescriptors.map((feature) => feature.id)
+
+describe('sso acl dependency declarations', () => {
+  it('declares dependsOn only against features registered in the catalog', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(ssoOwnIds, ssoDescriptors)
+    const ownUnknown = diagnostics.unknownReferences.filter((ref) =>
+      ref.feature.startsWith('sso.'),
+    )
+    expect(ownUnknown).toEqual([])
+  })
+
+  it('resolves cleanly with no missing deps when every feature is granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(ssoOwnIds, ssoDescriptors)
+    const ownMissing = diagnostics.missingDependencies.filter((dep) =>
+      dep.feature.startsWith('sso.'),
+    )
+    expect(ownMissing).toEqual([])
+  })
+
+  it('surfaces the missing read dependency when only sso.config.manage is granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(['sso.config.manage'], ssoDescriptors)
+    const manageEntry = diagnostics.missingDependencies.find(
+      (dep) => dep.feature === 'sso.config.manage',
+    )
+    expect(manageEntry?.missing).toEqual(['sso.config.view'])
+  })
+
+  it('surfaces the management dependency when only sso.scim.manage is granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(['sso.scim.manage'], ssoDescriptors)
+    const scimEntry = diagnostics.missingDependencies.find(
+      (dep) => dep.feature === 'sso.scim.manage',
+    )
+    expect(scimEntry?.missing).toEqual(['sso.config.manage'])
+  })
+
+  it('keeps every dependency target within the sso feature set', () => {
+    const ssoIds = new Set(ssoOwnIds)
+    const deps = ssoDescriptors.flatMap((feature) => feature.dependsOn ?? [])
+    for (const dep of deps) {
+      expect(ssoIds.has(dep)).toBe(true)
+    }
+  })
+
+  it('default role grants cover every declared sso feature', () => {
+    const superadminFeatures = (setup.defaultRoleFeatures?.superadmin ?? []) as string[]
+    const adminFeatures = (setup.defaultRoleFeatures?.admin ?? []) as string[]
+
+    for (const id of ssoOwnIds) {
+      expect(hasFeature(superadminFeatures, id)).toBe(true)
+      expect(hasFeature(adminFeatures, id)).toBe(true)
+    }
+  })
+})

--- a/packages/enterprise/src/modules/sso/acl.ts
+++ b/packages/enterprise/src/modules/sso/acl.ts
@@ -1,7 +1,17 @@
 export const features = [
   { id: 'sso.config.view', title: 'View SSO configuration', module: 'sso' },
-  { id: 'sso.config.manage', title: 'Manage SSO configuration', module: 'sso' },
-  { id: 'sso.scim.manage', title: 'Manage SCIM provisioning tokens', module: 'sso' },
+  {
+    id: 'sso.config.manage',
+    title: 'Manage SSO configuration',
+    module: 'sso',
+    dependsOn: ['sso.config.view'],
+  },
+  {
+    id: 'sso.scim.manage',
+    title: 'Manage SCIM provisioning tokens',
+    module: 'sso',
+    dependsOn: ['sso.config.manage'],
+  },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2174

## Problem
The SSO enterprise module's `acl.ts` had not been updated with the `dependsOn` declarations introduced by PR #2141 (ACL dependency bundles). Without them, `AclEditor` cannot warn operators when a granted SSO feature's prerequisites are missing.

## Root Cause
SSO was a follow-up module to the ACL dependency bundles infrastructure; only `customers` shipped as the reference. Every other module needs its own `dependsOn` table applied from the spec.

## What Changed
- `packages/enterprise/src/modules/sso/acl.ts` — added `dependsOn` per spec [§6.35](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md#635-enterprisesso):
  - `sso.config.manage` → `['sso.config.view']`
  - `sso.scim.manage` → `['sso.config.manage']`
- The dependency table is fully internal (`sso.*` only) with no `*`-marked deps, so **no new view-grained features** are introduced.

## Setup / Role ACLs
- No `setup.ts` change: `defaultRoleFeatures.admin` already grants all three features and `superadmin` keeps the `sso.*` wildcard.
- No `yarn mercato auth sync-role-acls` needed — there are no new features for existing tenants to pick up.

## Tests
- New `packages/enterprise/src/modules/sso/__tests__/acl.test.ts` (6 tests):
  - declarations resolve with no `unknownReferences` for `sso.*`
  - clean resolution (no `missingDependencies`) when every feature is granted
  - granting only `sso.config.manage` / only `sso.scim.manage` surfaces the missing prerequisite
  - every `dependsOn` target stays within the SSO feature set
  - default role grants cover every declared feature
- Verified the two prerequisite-surfacing tests fail against the pre-fix flat `acl.ts`.
- `yarn workspace @open-mercato/enterprise typecheck` passes; `yarn build:packages` + `yarn generate` succeed.

## Backward Compatibility
- Purely additive metadata (`dependsOn`) on existing feature descriptors. No feature IDs renamed/removed, no API response, event, widget, DI, or import-path changes. No contract surface broken.

## Spec
Umbrella spec: `.ai/specs/2026-05-27-acl-dependency-bundles.md` (§6.35).