### PR TITLE
fix(directory): push tenants list pagination to DB; close findAndCount fetch-all-then-slice audit (#2136)

### DIFF
--- a/.ai/runs/2026-05-27-crud-sql-query-optimizations/findings-2136-findandcount-audit.md
+++ b/.ai/runs/2026-05-27-crud-sql-query-optimizations/findings-2136-findandcount-audit.md
@@ -1,0 +1,31 @@
+# Findings — Issue #2136: audit `em.findAndCount` / `em.find` fetch-all-then-slice callers
+
+**Issue:** [#2136](https://github.com/open-mercato/open-mercato/issues/2136) (quick-win H)
+**Pattern audited:** a list route fetches the full result set via `em.find(...)` / `em.findAndCount(Entity, filter, { orderBy })` **without** `limit`/`offset`, then slices in JS with `array.slice(start, start + pageSize)`.
+**Reference fix (proven, trivial case):** `currencies/api/currencies/route.ts` + `exchange-rates/route.ts` (PR #2139 / commit `4a8bb2b0b`).
+
+Each candidate gets an independent decision:
+- **PUSH** — slice is pure paging over a single DB-filtered, DB-ordered result set → push `limit`/`offset` to the query and drop the JS slice.
+- **STRUCTURAL** — the slice runs over data that was merged, deduplicated, hierarchy-ordered, JS-searched on decrypted fields, or otherwise transformed in JS after the fetch. Pagination cannot be pushed to one query without changing the page contents or the `total`. Keep the JS slice.
+
+## Verdicts
+
+| # | Route (file:line of slice) | Verdict | Why |
+|---|---|---|---|
+| 1 | `catalog/api/categories/route.ts:228` | STRUCTURAL | `computeHierarchyForCategories(...)` builds the tree from the full set, then status/search filtering runs in JS before the slice. Tree ordering requires all rows. |
+| 2 | `customers/api/activities/route.ts:183` | STRUCTURAL | Items are a union of two sources (legacy `CustomerInteraction` + canonical `CustomerActivity`), merged, deduped and re-sorted in JS before paging. (Called out as structural in the issue body.) |
+| 3 | `customers/api/labels/route.ts:124` | STRUCTURAL | Fetched via `findWithDecryption`; the `?ids=` narrowing and `?search=` match run in JS against the **decrypted** `label` value, so they cannot be expressed as SQL. `total` derives from the JS-filtered length. |
+| 4 | `staff/api/team-members/assignable/route.ts:217` | STRUCTURAL | Members are hydrated (user/team), search-filtered, then **deduplicated by `userId`** in JS. Dedup changes `total`, so paging must follow it. (`customers/api/assignable-staff` is a 308 redirect to this canonical route.) |
+| 5 | `customers/api/deals/[id]/people/route.ts:138` | STRUCTURAL | JS `sortItems(...)` (label-asc/label-desc/recent) + JS search run on mapped, enriched items before the slice. |
+| 6 | `customers/api/deals/[id]/companies/route.ts:159` | STRUCTURAL | Same as #5, plus profile enrichment merged in JS. |
+| 7 | `customers/api/companies/[id]/people/route.ts:197` | STRUCTURAL | Same as #5/#6 (name-asc/name-desc/recent sort + search + profile enrichment in JS). |
+| 8 | `customers/api/people/[id]/companies/enriched/route.ts:376` | STRUCTURAL | Seven related-entity batch fetches are merged and enriched (active deals, CLV, last-contact), then JS search + computed-field sort before the slice. |
+| 9 | `directory/api/tenants/route.ts` | **PUSH (conditional)** | `name`/`isActive`/`orderBy` are already DB-expressible. Only custom-field filters are matched in JS (CF values live in a separate store). **Fixed:** push `findAndCount` `limit`/`offset` when no CF filter is active (the common case); keep fetch-all only when a CF filter must be matched in memory. |
+| 10 | `directory/api/organizations/route.ts:378, 477` | STRUCTURAL | Both slices run over a per-tenant (and, for super-admin, cross-tenant) hierarchy flattened in JS, then status/search/ids filtering. Hierarchy ordering requires the full set. |
+
+Already handled by PR #2217 (server-side sorting via query engine): `customers/api/people/route.ts`, `customers/api/companies/route.ts`. Not re-touched here.
+
+## Outcome
+
+- **1 concrete pushdown** implemented: `directory/api/tenants/route.ts` now pushes pagination to the database via `em.findAndCount(..., { limit, offset })` whenever no JS-side custom-field filter is active, avoiding a full-table scan on every tenants list request. The fetch-all path is preserved (and documented inline at the branch) for the CF-filter case. Regression coverage: `directory/api/tenants/__tests__/list-pagination.test.ts`.
+- **9 sites confirmed STRUCTURAL** and intentionally left as JS slices for the reasons above. No further pushdowns are safe without changing wire behavior, so the audit is closed.

--- a/packages/core/src/modules/directory/api/tenants/__tests__/list-pagination.test.ts
+++ b/packages/core/src/modules/directory/api/tenants/__tests__/list-pagination.test.ts
@@ -1,0 +1,108 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+
+const em = {
+  find: jest.fn(),
+  findAndCount: jest.fn(),
+} as { find: jest.Mock; findAndCount: jest.Mock }
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: 'user-1', tenantId })),
+}))
+
+const loadCustomFieldValues = jest.fn(async () => ({}))
+const buildCustomFieldFiltersFromQuery = jest.fn(async () => ({}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: (...args: unknown[]) => loadCustomFieldValues(...(args as [])),
+  buildCustomFieldFiltersFromQuery: (...args: unknown[]) => buildCustomFieldFiltersFromQuery(...(args as [])),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/factory', () => ({
+  makeCrudRoute: () => ({ GET: jest.fn(), POST: jest.fn(), PUT: jest.fn(), DELETE: jest.fn() }),
+  logCrudAccess: jest.fn(async () => {}),
+}))
+
+import { GET } from '../route'
+
+const makeTenant = (i: number, extra: Record<string, unknown> = {}) => ({
+  id: `00000000-0000-4000-8000-${i.toString().padStart(12, '0')}`,
+  name: `Tenant ${i}`,
+  isActive: true,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+  ...extra,
+})
+
+describe('GET /api/directory/tenants pagination', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    loadCustomFieldValues.mockResolvedValue({})
+    buildCustomFieldFiltersFromQuery.mockResolvedValue({})
+  })
+
+  it('pushes limit and offset to findAndCount when no custom-field filter is active', async () => {
+    em.findAndCount.mockResolvedValue([[makeTenant(1)], 137])
+    const res = await GET(new Request('http://localhost/api/directory/tenants?page=3&pageSize=25'))
+
+    expect(em.find).not.toHaveBeenCalled()
+    expect(em.findAndCount).toHaveBeenCalledTimes(1)
+    const [, , options] = em.findAndCount.mock.calls[0]
+    expect(options).toEqual(
+      expect.objectContaining({ orderBy: { name: 'ASC' }, limit: 25, offset: 50 }),
+    )
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: unknown[]; total: number; page: number; pageSize: number; totalPages: number }
+    expect(body.items).toHaveLength(1)
+    expect(body.total).toBe(137)
+    expect(body.page).toBe(3)
+    expect(body.pageSize).toBe(25)
+    expect(body.totalPages).toBe(Math.ceil(137 / 25))
+  })
+
+  it('respects sortField + sortDir on the pushed-down query', async () => {
+    em.findAndCount.mockResolvedValue([[], 0])
+    await GET(new Request('http://localhost/api/directory/tenants?page=1&pageSize=50&sortField=name&sortDir=desc'))
+    const options = em.findAndCount.mock.calls[0][2]
+    expect(options.orderBy).toEqual({ name: 'DESC' })
+    expect(options.limit).toBe(50)
+    expect(options.offset).toBe(0)
+  })
+
+  it('falls back to fetch-all + JS slice when a custom-field filter must be matched in memory', async () => {
+    // Custom-field values live in a separate store and are matched in JS, so the
+    // full set must be loaded before filtering — pagination cannot be pushed down.
+    buildCustomFieldFiltersFromQuery.mockResolvedValue({ 'cf:tier': { $in: ['gold'] } })
+    const gold1 = makeTenant(1)
+    const gold2 = makeTenant(2)
+    const silver = makeTenant(3)
+    em.find.mockResolvedValue([gold1, gold2, silver])
+    loadCustomFieldValues.mockResolvedValue({
+      [gold1.id]: { cf_tier: 'gold' },
+      [gold2.id]: { cf_tier: 'gold' },
+      [silver.id]: { cf_tier: 'silver' },
+    })
+
+    const res = await GET(new Request('http://localhost/api/directory/tenants?page=1&pageSize=50&cf_tier=gold'))
+
+    expect(em.findAndCount).not.toHaveBeenCalled()
+    expect(em.find).toHaveBeenCalledTimes(1)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: { id: string }[]; total: number }
+    expect(body.total).toBe(2)
+    expect(body.items.map((it) => it.id)).toEqual([gold1.id, gold2.id])
+  })
+})

--- a/packages/core/src/modules/directory/api/tenants/route.ts
+++ b/packages/core/src/modules/directory/api/tenants/route.ts
@@ -136,27 +136,6 @@ export async function GET(req: Request) {
     orderBy.name = 'ASC'
   }
 
-  const all = await em.find(Tenant, where, { orderBy })
-  const recordIds = all.map((tenant) => String(tenant.id))
-
-  const tenantIdByRecord: Record<string, string | null> = {}
-  const organizationIdByRecord: Record<string, string | null> = {}
-  for (const rid of recordIds) {
-    tenantIdByRecord[rid] = null
-    organizationIdByRecord[rid] = null
-  }
-
-  const cfValues = recordIds.length
-    ? await loadCustomFieldValues({
-        em,
-        entityId: E.directory.tenant,
-        recordIds,
-        tenantIdByRecord,
-        organizationIdByRecord,
-        tenantFallbacks: auth.tenantId ? [auth.tenantId] : [],
-      })
-    : {}
-
   const rawQuery = Array.from(url.searchParams.keys()).reduce<Record<string, unknown>>((acc, key) => {
     const values = url.searchParams.getAll(key)
     if (!values.length) return acc
@@ -175,29 +154,64 @@ export async function GET(req: Request) {
     return [normalizedKey, condition] as const
   })
 
-  const filtered = cfFilterEntries.length
-    ? all.filter((tenant) => {
-        const rid = String(tenant.id)
-        const payload = cfValues[rid] ?? {}
-        return cfFilterEntries.every(([key, expected]) => {
-          const value = payload[`cf_${key}`]
-          if (expected && typeof expected === 'object' && !Array.isArray(expected)) {
-            const maybeIn = (expected as { $in?: unknown[] }).$in
-            if (Array.isArray(maybeIn)) {
-              if (value === undefined || value === null) return false
-              if (Array.isArray(value)) return value.some((val) => maybeIn.includes(val))
-              return maybeIn.includes(value)
-            }
-          }
-          return matchesValue(value, expected)
-        })
-      })
-    : all
+  const loadCfValues = (tenants: Tenant[]): Promise<Record<string, Record<string, unknown>>> => {
+    const recordIds = tenants.map((tenant) => String(tenant.id))
+    if (!recordIds.length) return Promise.resolve({})
+    const tenantIdByRecord: Record<string, string | null> = {}
+    const organizationIdByRecord: Record<string, string | null> = {}
+    for (const rid of recordIds) {
+      tenantIdByRecord[rid] = null
+      organizationIdByRecord[rid] = null
+    }
+    return loadCustomFieldValues({
+      em,
+      entityId: E.directory.tenant,
+      recordIds,
+      tenantIdByRecord,
+      organizationIdByRecord,
+      tenantFallbacks: auth.tenantId ? [auth.tenantId] : [],
+    })
+  }
 
-  const total = filtered.length
   const start = (page - 1) * pageSize
-  const paged = filtered.slice(start, start + pageSize)
-  const items = paged.map((tenant) => {
+
+  let pageTenants: Tenant[]
+  let total: number
+  let cfValues: Record<string, Record<string, unknown>>
+
+  if (cfFilterEntries.length) {
+    // Custom-field filters are matched in JS against separately-loaded values,
+    // so the full result set must be fetched before filtering and paging.
+    const all = await em.find(Tenant, where, { orderBy })
+    cfValues = await loadCfValues(all)
+    const filtered = all.filter((tenant) => {
+      const rid = String(tenant.id)
+      const payload = cfValues[rid] ?? {}
+      return cfFilterEntries.every(([key, expected]) => {
+        const value = payload[`cf_${key}`]
+        if (expected && typeof expected === 'object' && !Array.isArray(expected)) {
+          const maybeIn = (expected as { $in?: unknown[] }).$in
+          if (Array.isArray(maybeIn)) {
+            if (value === undefined || value === null) return false
+            if (Array.isArray(value)) return value.some((val) => maybeIn.includes(val))
+            return maybeIn.includes(value)
+          }
+        }
+        return matchesValue(value, expected)
+      })
+    })
+    total = filtered.length
+    pageTenants = filtered.slice(start, start + pageSize)
+  } else {
+    // No JS-side filtering applies, so pagination is pushed to the database
+    // instead of fetching the whole table and slicing in memory.
+    const [rows, count] = await em.findAndCount(Tenant, where, { orderBy, limit: pageSize, offset: start })
+    total = count
+    pageTenants = rows
+    cfValues = await loadCfValues(rows)
+  }
+
+  const items = pageTenants.map((tenant) => {
     const rid = String(tenant.id)
     const cf = cfValues[rid] ?? {}
     return toRow(tenant, cf)


### PR DESCRIPTION
Fixes #2136

## Problem

Issue #2136 (quick-win **H** from the CRUD SQL optimization run) asked to audit every `em.findAndCount` / `em.find` *fetch-all-then-slice* caller across `packages/core` and, per route, either push pagination to the database (the pattern proven for currencies/exchange-rates in #2139) or document why the JS slice is structurally required.

## Root Cause

Several list routes call `em.find(Entity, where, { orderBy })` / `em.findAndCount(...)` **without** `limit`/`offset` and then `array.slice(start, start + pageSize)` in JS, loading the whole table per request. Most of them, however, transform the data in JS *before* paging (hierarchy builds, multi-source merges, search on decrypted fields, dedup, enrichment), so pagination genuinely cannot be pushed to one query without changing the page contents or `total`.

## What Changed

- **`directory/api/tenants/route.ts` — concrete pushdown.** `name`, `isActive`, and the sort are already DB-expressible; only custom-field filters are matched in JS against separately-loaded values. When **no** CF filter is active (the common case) the route now uses `em.findAndCount(Tenant, where, { orderBy, limit: pageSize, offset })` and loads custom-field values only for the returned page. When a CF filter must be matched in memory, the original fetch-all + JS-slice path is preserved (and documented inline at the branch). Response shape, `total` semantics, and ordering are unchanged.
- **Audit findings doc** — `.ai/runs/2026-05-27-crud-sql-query-optimizations/findings-2136-findandcount-audit.md` records the per-route verdict for all ten candidate sites.

### Audit verdicts (9 STRUCTURAL, 1 PUSH)

| Route | Verdict | Why |
|---|---|---|
| `catalog/.../categories` | STRUCTURAL | hierarchy tree built from full set, then JS filter |
| `customers/.../activities` | STRUCTURAL | union of legacy + canonical sources, merged/deduped/sorted in JS |
| `customers/.../labels` | STRUCTURAL | `ids` + `search` matched in JS on **decrypted** label |
| `staff/.../team-members/assignable` | STRUCTURAL | dedup by `userId` after hydration changes `total` |
| `customers/.../deals/[id]/people` | STRUCTURAL | JS `sortItems` + search on enriched items |
| `customers/.../deals/[id]/companies` | STRUCTURAL | JS sort/search + profile enrichment |
| `customers/.../companies/[id]/people` | STRUCTURAL | JS sort/search + profile enrichment |
| `customers/.../people/[id]/companies/enriched` | STRUCTURAL | 7 batch fetches merged + computed-field sort |
| `directory/.../organizations` (×2) | STRUCTURAL | per-/cross-tenant hierarchy flattened in JS |
| **`directory/.../tenants`** | **PUSH** | only CF filter is JS-side → push when absent |

`customers/api/{people,companies}/route.ts` were already moved to query-engine pagination by #2217 and are not re-touched.

## Tests

- New `directory/api/tenants/__tests__/list-pagination.test.ts`:
  - pushes `limit`/`offset` to `findAndCount` (and respects `sortField`/`sortDir`) when no CF filter is active, never calling `em.find`;
  - falls back to fetch-all + JS slice (no `findAndCount`) when a CF filter must be matched in memory, with `total`/page derived from the JS-filtered set.
- `yarn workspace @open-mercato/core test src/modules/directory` — all non-`.tsx` suites pass (38 incl. the 3 new). Two pre-existing `.tsx` component suites (`TenantSelect`, `OrganizationSelect`) fail with `React.act is not a function` from a local react-dom/testing-library version skew — unrelated to this change and present on `develop`.
- `yarn build:packages`, `yarn generate`, and `tsc --noEmit` (core, TS 6.0.3) all pass.

## Backward Compatibility

- No contract-surface changes. Response keys, `total` semantics, and ordering for `GET /api/directory/tenants` are identical; the pushdown is bit-equivalent to the previous fetch-all+slice for the no-CF-filter case, and the CF-filter path is unchanged.