### PR TITLE
fix(customer_accounts): filter portal SSE recipients

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/admin/users/[id].ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users/[id].ts
@@ -190,6 +190,7 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
 
   void emitCustomerAccountsEvent('customer_accounts.user.updated', {
     id: user.id,
+    recipientUserId: user.id,
     email: user.email,
     tenantId: auth.tenantId,
     organizationId: auth.orgId,

--- a/packages/core/src/modules/customer_accounts/api/admin/users/[id]/__tests__/reset-password.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users/[id]/__tests__/reset-password.route.test.ts
@@ -94,6 +94,15 @@ describe('admin /api/customer_accounts/admin/users/[id]/reset-password — atomi
     expect(emittedIds).toContain('customer_accounts.password.reset')
     expect(emittedIds).toContain('customer_accounts.password.changed')
 
+    const resetCall = mockEmit.mock.calls.find((c: unknown[]) => c[0] === 'customer_accounts.password.reset')
+    expect(resetCall?.[1]).toMatchObject({
+      id: userId,
+      recipientUserId: userId,
+      tenantId,
+      organizationId: orgId,
+      resetBy: adminId,
+    })
+
     const changedCall = mockEmit.mock.calls.find((c: unknown[]) => c[0] === 'customer_accounts.password.changed')
     expect(changedCall).toBeDefined()
     const payload = changedCall![1] as Record<string, unknown>

--- a/packages/core/src/modules/customer_accounts/api/admin/users/[id]/reset-password.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users/[id]/reset-password.ts
@@ -52,6 +52,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
 
   void emitCustomerAccountsEvent('customer_accounts.password.reset', {
     id: user.id,
+    recipientUserId: user.id,
     email: user.email,
     tenantId: auth.tenantId,
     organizationId: auth.orgId,

--- a/packages/core/src/modules/customer_accounts/api/admin/users/[id]/send-reset-link.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users/[id]/send-reset-link.ts
@@ -36,6 +36,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
 
   void emitCustomerAccountsEvent('customer_accounts.password.reset', {
     id: user.id,
+    recipientUserId: user.id,
     email: user.email,
     tenantId: auth.tenantId,
     organizationId: auth.orgId,

--- a/packages/core/src/modules/customer_accounts/api/admin/users/[id]/verify-email.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users/[id]/verify-email.ts
@@ -41,6 +41,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
 
   void emitCustomerAccountsEvent('customer_accounts.email.verified', {
     id: user.id,
+    recipientUserId: user.id,
     email: user.email,
     tenantId: auth.tenantId,
     organizationId: auth.orgId,

--- a/packages/core/src/modules/customer_accounts/api/email/verify.ts
+++ b/packages/core/src/modules/customer_accounts/api/email/verify.ts
@@ -35,6 +35,7 @@ export async function POST(req: Request) {
 
   void emitCustomerAccountsEvent('customer_accounts.email.verified', {
     userId: result.userId,
+    recipientUserId: result.userId,
     tenantId: result.tenantId,
   }).catch(() => undefined)
 

--- a/packages/core/src/modules/customer_accounts/api/portal/events/__tests__/stream.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/events/__tests__/stream.test.ts
@@ -1,12 +1,29 @@
+const mockGetCustomerAuthFromRequest = jest.fn(async () => ({
+  tenantId: 't1',
+  orgId: 'o1',
+  sub: 'c1',
+}))
+
+const mockIsPortalBroadcastEvent = jest.fn((eventName: string) => eventName === 'customer_accounts.user.updated')
+const mockRegisterGlobalEventTap = jest.fn()
+const mockRegisterCrossProcessEventListener = jest.fn()
+
 jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuth', () => ({
-  getCustomerAuthFromRequest: jest.fn(async () => ({
-    tenantId: 't1',
-    orgId: 'o1',
-    sub: 'c1',
-  })),
+  getCustomerAuthFromRequest: (...args: unknown[]) => mockGetCustomerAuthFromRequest(...args),
+}))
+
+jest.mock('@open-mercato/shared/modules/events', () => ({
+  isPortalBroadcastEvent: (...args: [string]) => mockIsPortalBroadcastEvent(...args),
+}))
+
+jest.mock('@open-mercato/events/bus', () => ({
+  registerGlobalEventTap: (...args: unknown[]) => mockRegisterGlobalEventTap(...args),
+  registerCrossProcessEventListener: (...args: unknown[]) => mockRegisterCrossProcessEventListener(...args),
 }))
 
 import { GET } from '@open-mercato/core/modules/customer_accounts/api/portal/events/stream'
+
+type StreamReader = ReadableStreamDefaultReader<Uint8Array>
 
 function makeTrackedRequest() {
   const controller = new AbortController()
@@ -16,7 +33,130 @@ function makeTrackedRequest() {
   return { req, controller, addSpy, removeSpy }
 }
 
+async function waitForPortalTap(): Promise<(eventName: string, payload: Record<string, unknown>) => Promise<void>> {
+  for (let i = 0; i < 5; i += 1) {
+    const callback = mockRegisterGlobalEventTap.mock.calls[0]?.[0]
+    if (typeof callback === 'function') {
+      return callback as (eventName: string, payload: Record<string, unknown>) => Promise<void>
+    }
+    await new Promise((resolve) => setImmediate(resolve))
+  }
+  throw new Error('Portal event tap was not registered')
+}
+
+async function readSsePayload(reader: StreamReader): Promise<Record<string, unknown>> {
+  const result = await reader.read()
+  return parseSseReadResult(result)
+}
+
+function parseSseReadResult(result: ReadableStreamReadResult<Uint8Array>): Record<string, unknown> {
+  if (result.done || !result.value) throw new Error('Expected SSE payload')
+  const text = new TextDecoder().decode(result.value)
+  const json = text.replace(/^data:\s*/, '').trim()
+  return JSON.parse(json) as Record<string, unknown>
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms = 25): Promise<{ status: 'resolved'; value: T } | { status: 'timeout' }> {
+  return Promise.race([
+    promise.then((value) => ({ status: 'resolved' as const, value })),
+    new Promise<{ status: 'timeout' }>((resolve) => setTimeout(() => resolve({ status: 'timeout' }), ms)),
+  ])
+}
+
+describe('Portal SSE event stream — audience filtering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetCustomerAuthFromRequest.mockResolvedValue({
+      tenantId: 't1',
+      orgId: 'o1',
+      sub: 'c1',
+    })
+    mockIsPortalBroadcastEvent.mockImplementation((eventName: string) => eventName === 'customer_accounts.user.updated')
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('filters portalBroadcast events by recipient customer user before sending', async () => {
+    mockGetCustomerAuthFromRequest
+      .mockResolvedValueOnce({ tenantId: 't1', orgId: 'o1', sub: 'c1' })
+      .mockResolvedValueOnce({ tenantId: 't1', orgId: 'o1', sub: 'c2' })
+
+    const first = await GET(makeTrackedRequest().req)
+    const second = await GET(makeTrackedRequest().req)
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+
+    const firstReader = first.body!.getReader()
+    const secondReader = second.body!.getReader()
+
+    try {
+      const broadcast = await waitForPortalTap()
+
+      const secondReadForFirstEvent = secondReader.read()
+      await broadcast('customer_accounts.user.updated', {
+        tenantId: 't1',
+        organizationId: 'o1',
+        recipientUserId: 'c1',
+        email: 'customer-one@example.com',
+      })
+
+      const firstPayload = await readSsePayload(firstReader)
+      expect(firstPayload).toMatchObject({
+        id: 'customer_accounts.user.updated',
+        payload: {
+          recipientUserId: 'c1',
+          email: 'customer-one@example.com',
+        },
+      })
+      expect(await withTimeout(secondReadForFirstEvent)).toEqual({ status: 'timeout' })
+
+      const firstReadForSecondEvent = firstReader.read()
+      await broadcast('customer_accounts.user.updated', {
+        tenantId: 't1',
+        organizationId: 'o1',
+        recipientUserIds: ['c2'],
+        email: 'customer-two@example.com',
+      })
+
+      const secondArrayPayload = parseSseReadResult(await secondReadForFirstEvent)
+      expect(secondArrayPayload).toMatchObject({
+        id: 'customer_accounts.user.updated',
+        payload: {
+          recipientUserIds: ['c2'],
+          email: 'customer-two@example.com',
+        },
+      })
+      expect(await withTimeout(firstReadForSecondEvent)).toEqual({ status: 'timeout' })
+
+      const secondReadForOrgEvent = secondReader.read()
+      await broadcast('customer_accounts.user.updated', {
+        tenantId: 't1',
+        organizationId: 'o1',
+        id: 'org-wide',
+      })
+
+      const firstOrgPayload = parseSseReadResult(await firstReadForSecondEvent)
+      const secondOrgPayload = parseSseReadResult(await secondReadForOrgEvent)
+      expect(firstOrgPayload).toMatchObject({ payload: { id: 'org-wide' } })
+      expect(secondOrgPayload).toMatchObject({ payload: { id: 'org-wide' } })
+    } finally {
+      await firstReader.cancel().catch(() => undefined)
+      await secondReader.cancel().catch(() => undefined)
+    }
+  })
+})
+
 describe('Portal SSE event stream — abort listener hygiene', () => {
+  beforeEach(() => {
+    mockGetCustomerAuthFromRequest.mockResolvedValue({
+      tenantId: 't1',
+      orgId: 'o1',
+      sub: 'c1',
+    })
+  })
+
   afterEach(() => {
     jest.restoreAllMocks()
   })

--- a/packages/core/src/modules/customer_accounts/api/portal/events/stream.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/events/stream.ts
@@ -31,6 +31,7 @@ type PortalSseConnection = {
 function normalizeAudience(data: Record<string, unknown>): {
   tenantId: string | null
   organizationScopes: string[]
+  recipientUserScopes: string[]
 } {
   const tenantId = typeof data.tenantId === 'string' ? data.tenantId : null
   const organizationScopes = new Set<string>()
@@ -44,7 +45,24 @@ function normalizeAudience(data: Record<string, unknown>): {
       }
     }
   }
-  return { tenantId, organizationScopes: Array.from(organizationScopes) }
+
+  const recipientUserScopes = new Set<string>()
+  if (typeof data.recipientUserId === 'string' && data.recipientUserId.trim().length > 0) {
+    recipientUserScopes.add(data.recipientUserId.trim())
+  }
+  if (Array.isArray(data.recipientUserIds)) {
+    for (const userId of data.recipientUserIds) {
+      if (typeof userId === 'string' && userId.trim().length > 0) {
+        recipientUserScopes.add(userId.trim())
+      }
+    }
+  }
+
+  return {
+    tenantId,
+    organizationScopes: Array.from(organizationScopes),
+    recipientUserScopes: Array.from(recipientUserScopes),
+  }
 }
 
 function matchesAudience(conn: PortalSseConnection, audience: ReturnType<typeof normalizeAudience>): boolean {
@@ -52,6 +70,9 @@ function matchesAudience(conn: PortalSseConnection, audience: ReturnType<typeof 
   if (conn.tenantId !== audience.tenantId) return false
   if (audience.organizationScopes.length > 0) {
     if (!audience.organizationScopes.includes(conn.organizationId)) return false
+  }
+  if (audience.recipientUserScopes.length > 0 && !audience.recipientUserScopes.includes(conn.customerUserId)) {
+    return false
   }
   return true
 }
@@ -194,7 +215,7 @@ export async function GET(req: Request): Promise<Response> {
 
 const methodDoc: OpenApiMethodDoc = {
   summary: 'Subscribe to portal events via SSE (Portal Event Bridge)',
-  description: 'Long-lived SSE connection that receives server-side events marked with portalBroadcast: true. Events are filtered by the customer\'s tenant and organization.',
+  description: 'Long-lived SSE connection that receives server-side events marked with portalBroadcast: true. Events are filtered by the customer\'s tenant, organization, and recipient user audience.',
   tags: ['Customer Portal'],
   responses: [
     {


### PR DESCRIPTION
## Summary
- filter portal SSE broadcasts by recipientUserId/recipientUserIds before sending
- add recipientUserId to customer-specific portal broadcast events carrying user PII
- add regression coverage for cross-customer SSE delivery

Fixes #2272

## Tests
- yarn workspace @open-mercato/core exec jest --config jest.config.cjs --runTestsByPath src/modules/customer_accounts/api/portal/events/__tests__/stream.test.ts 'src/modules/customer_accounts/api/admin/users/[id]/__tests__/reset-password.route.test.ts'
- yarn exec tsc -p packages/core/tsconfig.json --noEmit