### PR TITLE
feat(sync_excel): declare ACL feature dependencies (#2183)

### DIFF
--- a/packages/core/src/modules/sync_excel/__tests__/acl-dependencies.test.ts
+++ b/packages/core/src/modules/sync_excel/__tests__/acl-dependencies.test.ts
@@ -1,0 +1,48 @@
+/** @jest-environment node */
+
+import { describe, it, expect } from '@jest/globals'
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
+import { features as syncExcelFeatures } from '../acl'
+
+const descriptors: FeatureDescriptor[] = syncExcelFeatures as FeatureDescriptor[]
+const ownIds = descriptors.map((feature) => feature.id)
+
+describe('sync_excel acl dependency declarations', () => {
+  it('declares dependsOn only against features registered in the module catalog', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(ownIds, descriptors)
+    const ownUnknown = diagnostics.unknownReferences.filter((ref) =>
+      ref.feature.startsWith('sync_excel.'),
+    )
+    expect(ownUnknown).toEqual([])
+  })
+
+  it('resolves cleanly with no missing deps when every feature is granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(ownIds, descriptors)
+    const ownMissing = diagnostics.missingDependencies.filter((dep) =>
+      dep.feature.startsWith('sync_excel.'),
+    )
+    expect(ownMissing).toEqual([])
+  })
+
+  it('flags sync_excel.view as missing when only sync_excel.run is granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(['sync_excel.run'], descriptors)
+    const runEntry = diagnostics.missingDependencies.find(
+      (dep) => dep.feature === 'sync_excel.run',
+    )
+    expect(runEntry?.missing).toEqual(['sync_excel.view'])
+  })
+
+  it('keeps every internal dependency target within the sync_excel feature set', () => {
+    const ids = new Set(ownIds)
+    const internalDeps = descriptors.flatMap((feature) =>
+      (feature.dependsOn ?? []).filter((dep) => dep.startsWith('sync_excel.')),
+    )
+    for (const dep of internalDeps) {
+      expect(ids.has(dep)).toBe(true)
+    }
+    expect(internalDeps).toContain('sync_excel.view')
+  })
+})

--- a/packages/core/src/modules/sync_excel/acl.ts
+++ b/packages/core/src/modules/sync_excel/acl.ts
@@ -1,6 +1,11 @@
 export const features = [
   { id: 'sync_excel.view', title: 'View sync_excel uploads and previews', module: 'sync_excel' },
-  { id: 'sync_excel.run', title: 'Upload CSV files and prepare imports', module: 'sync_excel' },
+  {
+    id: 'sync_excel.run',
+    title: 'Upload CSV files and prepare imports',
+    module: 'sync_excel',
+    dependsOn: ['sync_excel.view'],
+  },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2183

## Problem
Per-module follow-up to PR #2141 (`feat(auth): ACL dependency bundles`). The infrastructure (resolver, API forwarding, `AclEditor` warning UX) shipped with `customers` as the reference module; every other module still needs `dependsOn` declared in its `acl.ts`. This PR covers `sync_excel` per spec [`.ai/specs/2026-05-27-acl-dependency-bundles.md` §6.44](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md#644-sync_excel).

## Root Cause
`sync_excel.run` (upload/import) was grantable without `sync_excel.view` (preview), so the operator got no warning about an incoherent grant. The upload/import routes require `sync_excel.run` while the preview route requires `sync_excel.view` — running an import without preview access is not a usable state.

## What Changed
- `packages/core/src/modules/sync_excel/acl.ts`: `sync_excel.run` now declares `dependsOn: ['sync_excel.view']` (matches the spec §6.44 table exactly).
- No new view-grained features were required (the spec table has no `*` markers), so `setup.ts` `defaultRoleFeatures` is unchanged.

## Tests
- New `packages/core/src/modules/sync_excel/__tests__/acl-dependencies.test.ts` (mirrors the catalog/sales pattern):
  - no `unknownReferences` for `sync_excel.*` ids when resolved against the module catalog
  - no `missingDependencies` when every feature is granted
  - granting only `sync_excel.run` surfaces `sync_excel.view` as the missing dependency
  - every internal dependency target stays within the `sync_excel` feature set
- `yarn workspace @open-mercato/core test -- acl-dependencies` → 9 passed (sync_excel + sales suites).

## Backward Compatibility
- No contract surface changes. `dependsOn` is an additive, optional field on the existing feature descriptors; no feature IDs were added, removed, or renamed.

## Notes
- Repo-wide `yarn typecheck` currently fails only on a pre-existing toolchain mismatch (`tsconfig.json` `ignoreDeprecations: "6.0"` vs the resolved TypeScript 5.9.3, error TS5103) that exists on `develop` and is unrelated to this change. The new test type-compiles cleanly under ts-jest.