### PR TITLE
fix(search): scope results to allowed organizations

### DIFF
--- a/packages/search/src/__tests__/service.test.ts
+++ b/packages/search/src/__tests__/service.test.ts
@@ -232,6 +232,50 @@ describe('SearchService', () => {
       expect(results[0].source).toBe('fallback')
     })
 
+    it('should drop cross-organization results for scoped multi-org searches', async () => {
+      const strategy = createMockStrategy({
+        id: 'test',
+        search: jest.fn().mockResolvedValue([
+          createMockResult({ recordId: 'rec-a', organizationId: 'org-A' }),
+          createMockResult({ recordId: 'rec-b', organizationId: 'org-B' }),
+          createMockResult({ recordId: 'rec-c', organizationId: 'org-C' }),
+          createMockResult({ recordId: 'rec-unknown', organizationId: undefined }),
+        ]),
+      })
+      const service = new SearchService({
+        strategies: [strategy],
+        defaultStrategies: ['test'],
+      })
+
+      const results = await service.search('test', {
+        tenantId: 'tenant-123',
+        organizationIds: ['org-A', 'org-B'],
+      })
+
+      expect(results.map((result) => result.recordId)).toEqual(['rec-a', 'rec-b'])
+    })
+
+    it('should fail closed for an empty organization allowlist', async () => {
+      const strategy = createMockStrategy({
+        id: 'test',
+        search: jest.fn().mockResolvedValue([
+          createMockResult({ recordId: 'rec-a', organizationId: 'org-A' }),
+        ]),
+      })
+      const service = new SearchService({
+        strategies: [strategy],
+        defaultStrategies: ['test'],
+      })
+
+      const results = await service.search('test', {
+        tenantId: 'tenant-123',
+        organizationIds: [],
+      })
+
+      expect(results).toEqual([])
+      expect(strategy.search).not.toHaveBeenCalled()
+    })
+
     it('should enrich results when navigation metadata is missing even if presenter title exists', async () => {
       const strategy = createMockStrategy({
         id: 'test',

--- a/packages/search/src/fulltext/drivers/meilisearch/index.ts
+++ b/packages/search/src/fulltext/drivers/meilisearch/index.ts
@@ -66,8 +66,21 @@ export function createMeilisearchDriver(
   function buildFilters(options: FullTextSearchQuery): string[] {
     const filters: string[] = []
 
-    if (options.organizationId) {
-      filters.push(`_organizationId = "${escapeFilterValue(options.organizationId)}"`)
+    const organizationId = typeof options.organizationId === 'string' ? options.organizationId.trim() : ''
+    if (organizationId) {
+      filters.push(`_organizationId = "${escapeFilterValue(organizationId)}"`)
+    } else if (Array.isArray(options.organizationIds)) {
+      const organizationIds = Array.from(new Set(
+        options.organizationIds
+          .map((value) => (typeof value === 'string' ? value.trim() : ''))
+          .filter((value) => value.length > 0),
+      ))
+      if (organizationIds.length === 0) {
+        filters.push('_organizationId = "__open_mercato_no_matching_organization__"')
+      } else {
+        const orgFilter = organizationIds.map((id) => `"${escapeFilterValue(id)}"`).join(', ')
+        filters.push(`_organizationId IN [${orgFilter}]`)
+      }
     }
 
     if (options.entityTypes?.length) {
@@ -216,6 +229,7 @@ export function createMeilisearchDriver(
           recordId: hit._id as string,
           entityId: hit._entityId as EntityId,
           score: (hit._rankingScore as number) ?? 0.5,
+          organizationId: hit._organizationId as string | null | undefined,
           presenter: hit._presenter as FullTextSearchHit['presenter'],
           url: hit._url as string | undefined,
           links: hit._links as FullTextSearchHit['links'],

--- a/packages/search/src/fulltext/types.ts
+++ b/packages/search/src/fulltext/types.ts
@@ -39,6 +39,7 @@ export type FullTextSearchDocument = {
 export type FullTextSearchQuery = {
   tenantId: string
   organizationId?: string | null
+  organizationIds?: string[] | null
   entityTypes?: EntityId[]
   limit?: number
   offset?: number
@@ -52,6 +53,7 @@ export type FullTextSearchHit = {
   recordId: string
   entityId: EntityId
   score: number
+  organizationId?: string | null
   presenter?: SearchResultPresenter
   url?: string
   links?: SearchResultLink[]

--- a/packages/search/src/lib/merger.ts
+++ b/packages/search/src/lib/merger.ts
@@ -65,15 +65,22 @@ export function mergeAndRankResults(
             presenter: result.presenter,
             url: existing.result.url ?? result.url,
             links: existing.result.links ?? result.links,
+            organizationId: existing.result.organizationId ?? result.organizationId,
           }
           existing.bestContribution = Math.max(existing.bestContribution, rrfScore)
         } else if (hasExistingPresenter && hasNewPresenter && rrfScore > existing.bestContribution) {
           // Both have presenter, keep the one with better RRF contribution (not raw score)
-          existing.result = { ...result }
+          existing.result = {
+            ...result,
+            organizationId: result.organizationId ?? existing.result.organizationId,
+          }
           existing.bestContribution = rrfScore
         } else if (!hasExistingPresenter && !hasNewPresenter && rrfScore > existing.bestContribution) {
           // Neither has presenter, keep result with better RRF contribution
-          existing.result = { ...result }
+          existing.result = {
+            ...result,
+            organizationId: result.organizationId ?? existing.result.organizationId,
+          }
           existing.bestContribution = rrfScore
         }
         // If existing has presenter and new doesn't, keep existing (do nothing)

--- a/packages/search/src/modules/search/api/__tests__/org-scoping.routes.test.ts
+++ b/packages/search/src/modules/search/api/__tests__/org-scoping.routes.test.ts
@@ -71,12 +71,13 @@ describe('Search API organizationId scoping', () => {
 
     const passedOptions = (searchService.search as jest.Mock).mock.calls[0][1] as Record<string, unknown>
     expect(passedOptions.organizationId).toEqual('org-A')
+    expect(passedOptions.organizationIds).toEqual(['org-A'])
 
     const body = await res.json()
     expect(Array.isArray(body.results)).toBe(true)
   })
 
-  test('/api/search/search/global uses resolved org scope (all orgs, non-superadmin)', async () => {
+  test('/api/search/search/global uses full allowed org scope when no single org is selected', async () => {
     mockGetAuthFromRequest.mockResolvedValue({ tenantId: 't1', orgId: 'org-A', sub: 'user-1', isSuperAdmin: false })
 
     const searchService = {
@@ -99,6 +100,33 @@ describe('Search API organizationId scoping', () => {
 
     const passedOptions = (searchService.search as jest.Mock).mock.calls[0][1] as Record<string, unknown>
     expect(passedOptions.organizationId).toBeUndefined()
+    expect(passedOptions.organizationIds).toEqual(['org-A', 'org-B'])
+  })
+
+  test('/api/search/search uses full allowed org scope when restricted user has no selected org', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({ tenantId: 't1', orgId: 'org-A', sub: 'user-1', isSuperAdmin: false })
+
+    const searchService = {
+      search: jest.fn().mockResolvedValue([]),
+    }
+    const container = {
+      resolve: jest.fn((name: string) => (name === 'searchService' ? searchService : undefined)),
+      dispose: jest.fn(),
+    }
+    mockCreateRequestContainer.mockResolvedValue(container)
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: null,
+      filterIds: ['org-A', 'org-B'],
+      allowedIds: ['org-A', 'org-B'],
+      tenantId: 't1',
+    } satisfies MockOrganizationScope)
+
+    const req = new Request('http://localhost/api/search/search?q=test')
+    await hybridSearchGet(req)
+
+    const passedOptions = (searchService.search as jest.Mock).mock.calls[0][1] as Record<string, unknown>
+    expect(passedOptions.organizationId).toBeUndefined()
+    expect(passedOptions.organizationIds).toEqual(['org-A', 'org-B'])
   })
 
   test('/api/search/index list respects resolved org scope and does not default to org NULL', async () => {

--- a/packages/search/src/modules/search/api/search/global/route.ts
+++ b/packages/search/src/modules/search/api/search/global/route.ts
@@ -3,6 +3,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import type { SearchService } from '@open-mercato/search'
 import type { EmbeddingService } from '../../../../../vector'
 import { resolveEmbeddingConfig } from '../../../lib/embedding-config'
@@ -93,11 +94,13 @@ export async function GET(req: Request) {
       })
     }
 
+    const scopeFilter = resolveOrganizationScopeFilter(scope, auth)
     const organizationId =
       typeof scope.selectedId === 'string' && scope.selectedId.trim().length > 0 ? scope.selectedId.trim() : undefined
     const searchOptions = {
       tenantId: auth.tenantId,
       organizationId,
+      organizationIds: scopeFilter.organizationIds,
       limit,
       strategies,
       entityTypes,

--- a/packages/search/src/modules/search/api/search/route.ts
+++ b/packages/search/src/modules/search/api/search/route.ts
@@ -3,6 +3,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import type { SearchService } from '@open-mercato/search'
 import type { SearchStrategyId } from '@open-mercato/shared/modules/search'
 import type { EmbeddingService } from '../../../../vector'
@@ -90,11 +91,13 @@ export async function GET(req: Request) {
       })
     }
 
+    const scopeFilter = resolveOrganizationScopeFilter(scope, auth)
     const organizationId =
       typeof scope.selectedId === 'string' && scope.selectedId.trim().length > 0 ? scope.selectedId.trim() : undefined
     const searchOptions = {
       tenantId: auth.tenantId,
       organizationId,
+      organizationIds: scopeFilter.organizationIds,
       limit,
       strategies,
       entityTypes,

--- a/packages/search/src/service.ts
+++ b/packages/search/src/service.ts
@@ -26,6 +26,31 @@ const DEFAULT_MERGE_CONFIG: ResultMergeConfig = {
  */
 const STRATEGY_AVAILABILITY_CACHE_TTL_MS = 2_000
 
+function normalizeOrganizationFilter(options: SearchOptions): string[] | null {
+  const single = typeof options.organizationId === 'string' ? options.organizationId.trim() : ''
+  if (single) return [single]
+  if (!Array.isArray(options.organizationIds)) return null
+
+  const values = Array.from(new Set(
+    options.organizationIds
+      .map((value) => (typeof value === 'string' ? value.trim() : ''))
+      .filter((value) => value.length > 0),
+  ))
+  return values
+}
+
+function filterResultsByOrganizationScope(results: SearchResult[], options: SearchOptions): SearchResult[] {
+  const organizationIds = normalizeOrganizationFilter(options)
+  if (!organizationIds) return results
+  if (organizationIds.length === 0) return []
+
+  const allowed = new Set(organizationIds)
+  return results.filter((result) => {
+    const organizationId = typeof result.organizationId === 'string' ? result.organizationId.trim() : ''
+    return organizationId.length > 0 && allowed.has(organizationId)
+  })
+}
+
 /**
  * SearchService orchestrates multiple search strategies, executing searches in parallel
  * and merging results using the RRF algorithm.
@@ -87,6 +112,11 @@ export class SearchService {
    * @returns Merged and ranked search results
    */
   async search(query: string, options: SearchOptions): Promise<SearchResult[]> {
+    const organizationIds = normalizeOrganizationFilter(options)
+    if (organizationIds && organizationIds.length === 0) {
+      return []
+    }
+
     const strategyIds = options.strategies ?? this.defaultStrategies
     const activeStrategies = await this.getAvailableStrategies(strategyIds)
 
@@ -126,9 +156,10 @@ export class SearchService {
 
     // Merge and rank results
     const merged = mergeAndRankResults(allResults, this.mergeConfig)
+    const scoped = filterResultsByOrganizationScope(merged, options)
 
     // Enrich results missing presenter or navigation metadata
-    return this.enrichResultsWithPresenter(merged, options.tenantId, options.organizationId)
+    return this.enrichResultsWithPresenter(scoped, options.tenantId, options.organizationId)
   }
 
   /**

--- a/packages/search/src/strategies/fulltext.strategy.ts
+++ b/packages/search/src/strategies/fulltext.strategy.ts
@@ -34,9 +34,17 @@ export class FullTextSearchStrategy implements SearchStrategy {
   }
 
   async search(query: string, options: SearchOptions): Promise<SearchResult[]> {
+    if (Array.isArray(options.organizationIds)) {
+      const organizationIds = options.organizationIds
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter((value) => value.length > 0)
+      if (!options.organizationId && organizationIds.length === 0) return []
+    }
+
     const hits = await this.driver.search(query, {
       tenantId: options.tenantId,
       organizationId: options.organizationId,
+      organizationIds: options.organizationIds,
       entityTypes: options.entityTypes,
       limit: options.limit,
       offset: options.offset,
@@ -133,6 +141,7 @@ export class FullTextSearchStrategy implements SearchStrategy {
       recordId: hit.recordId,
       score: hit.score,
       source: this.id,
+      organizationId: hit.organizationId ?? null,
       presenter: hit.presenter,
       url: hit.url,
       links: hit.links,

--- a/packages/search/src/strategies/token.strategy.ts
+++ b/packages/search/src/strategies/token.strategy.ts
@@ -18,6 +18,17 @@ export type TokenStrategyConfig = {
   defaultLimit?: number
 }
 
+function normalizeOrganizationIds(options: SearchOptions): string[] | null {
+  const single = typeof options.organizationId === 'string' ? options.organizationId.trim() : ''
+  if (single) return [single]
+  if (!Array.isArray(options.organizationIds)) return null
+  return Array.from(new Set(
+    options.organizationIds
+      .map((value) => (typeof value === 'string' ? value.trim() : ''))
+      .filter((value) => value.length > 0),
+  ))
+}
+
 /**
  * TokenSearchStrategy provides hash-based search using the existing search_tokens table.
  * This strategy is always available and serves as a fallback when other strategies fail.
@@ -50,6 +61,9 @@ export class TokenSearchStrategy implements SearchStrategy {
   }
 
   async search(query: string, options: SearchOptions): Promise<SearchResult[]> {
+    const organizationIds = normalizeOrganizationIds(options)
+    if (organizationIds && organizationIds.length === 0) return []
+
     // Dynamically import tokenization to avoid circular dependencies
     const { tokenizeText } = await import('@open-mercato/shared/lib/search/tokenize')
     const { resolveSearchConfig } = await import('@open-mercato/shared/lib/search/config')
@@ -68,24 +82,30 @@ export class TokenSearchStrategy implements SearchStrategy {
       .select([
         'entity_type' as any,
         'entity_id' as any,
+        'organization_id' as any,
         sql<string>`count(*)`.as('match_count'),
       ])
       .where('token_hash' as any, 'in', hashes)
       .where('tenant_id' as any, '=', options.tenantId)
-      .groupBy(['entity_type' as any, 'entity_id' as any])
+      .groupBy(['entity_type' as any, 'entity_id' as any, 'organization_id' as any])
       .having(sql<SqlBool>`count(distinct token_hash) >= ${minMatches}`)
       .orderBy(sql`count(distinct token_hash) desc`)
       .limit(limit)
 
-    if (options.organizationId) {
-      queryBuilder = queryBuilder.where('organization_id' as any, '=', options.organizationId)
+    if (organizationIds) {
+      queryBuilder = queryBuilder.where('organization_id' as any, 'in', organizationIds)
     }
 
     if (options.entityTypes?.length) {
       queryBuilder = queryBuilder.where('entity_type' as any, 'in', options.entityTypes)
     }
 
-    const rows = await queryBuilder.execute() as Array<{ entity_type: string; entity_id: string; match_count: string | number }>
+    const rows = await queryBuilder.execute() as Array<{
+      entity_type: string
+      entity_id: string
+      organization_id: string | null
+      match_count: string | number
+    }>
 
     return rows.map((row) => {
       const matchCount = typeof row.match_count === 'string'
@@ -99,6 +119,7 @@ export class TokenSearchStrategy implements SearchStrategy {
         recordId: row.entity_id,
         score,
         source: this.id,
+        organizationId: row.organization_id ?? null,
       }
     })
   }

--- a/packages/search/src/strategies/vector.strategy.ts
+++ b/packages/search/src/strategies/vector.strategy.ts
@@ -26,6 +26,17 @@ export type VectorStrategyConfig = {
   defaultLimit?: number
 }
 
+function normalizeOrganizationIds(options: SearchOptions): string[] | null {
+  const single = typeof options.organizationId === 'string' ? options.organizationId.trim() : ''
+  if (single) return [single]
+  if (!Array.isArray(options.organizationIds)) return null
+  return Array.from(new Set(
+    options.organizationIds
+      .map((value) => (typeof value === 'string' ? value.trim() : ''))
+      .filter((value) => value.length > 0),
+  ))
+}
+
 /**
  * VectorSearchStrategy provides semantic search using embeddings.
  * It wraps the existing vector module infrastructure.
@@ -62,6 +73,9 @@ export class VectorSearchStrategy implements SearchStrategy {
   }
 
   async search(query: string, options: SearchOptions): Promise<SearchResult[]> {
+    const organizationIds = normalizeOrganizationIds(options)
+    if (organizationIds && organizationIds.length === 0) return []
+
     await this.ensureReady()
     const embedding = await this.embeddingService.createEmbedding(query)
 
@@ -71,15 +85,18 @@ export class VectorSearchStrategy implements SearchStrategy {
     const filter: {
       tenantId: string
       organizationId?: string | null
+      organizationIds?: string[] | null
       entityIds?: EntityId[]
     } = {
       tenantId: options.tenantId,
       entityIds: options.entityTypes as EntityId[],
     }
 
-    // Only add organizationId filter if it's a real org ID
-    if (options.organizationId) {
-      filter.organizationId = options.organizationId
+    if (organizationIds) {
+      filter.organizationIds = organizationIds
+      if (organizationIds.length === 1) {
+        filter.organizationId = organizationIds[0]
+      }
     }
 
     const results = await this.vectorDriver.query({
@@ -93,6 +110,7 @@ export class VectorSearchStrategy implements SearchStrategy {
       recordId: hit.recordId,
       score: hit.score,
       source: this.id,
+      organizationId: hit.organizationId ?? null,
       presenter: hit.presenter ?? undefined,
       url: hit.primaryLinkHref ?? hit.url ?? undefined,
       links: hit.links?.map((link) => ({

--- a/packages/search/src/vector/drivers/pgvector/index.ts
+++ b/packages/search/src/vector/drivers/pgvector/index.ts
@@ -318,11 +318,23 @@ export function createPgVectorDriver(opts: PgVectorDriverOptions = {}): VectorDr
       typeof filter.organizationId === 'string' && filter.organizationId.trim().length > 0
         ? filter.organizationId.trim()
         : null
+    const normalizedOrganizationIds = normalizedOrganizationId
+      ? [normalizedOrganizationId]
+      : Array.isArray(filter.organizationIds)
+        ? Array.from(new Set(
+            filter.organizationIds
+              .map((value) => (typeof value === 'string' ? value.trim() : ''))
+              .filter((value) => value.length > 0),
+          ))
+        : null
+    if (normalizedOrganizationIds && normalizedOrganizationIds.length === 0) {
+      return []
+    }
     const params: any[] = [
       vectorLiteral,
       DRIVER_ID,
       filter.tenantId,
-      normalizedOrganizationId,
+      normalizedOrganizationIds,
       Array.isArray(filter.entityIds) && filter.entityIds.length ? filter.entityIds : null,
       input.limit ?? 20,
     ]
@@ -365,7 +377,7 @@ export function createPgVectorDriver(opts: PgVectorDriverOptions = {}): VectorDr
         FROM ${tableIdent}
         WHERE driver_id = $2
           AND tenant_id = $3::uuid
-          AND ($4::uuid IS NULL OR organization_id = $4::uuid)
+          AND ($4::uuid[] IS NULL OR organization_id = ANY($4::uuid[]))
           AND (
             $5::text[] IS NULL OR entity_id = ANY($5::text[])
           )

--- a/packages/search/src/vector/types.ts
+++ b/packages/search/src/vector/types.ts
@@ -50,6 +50,7 @@ export type VectorDriverQuery = {
   filter?: {
     entityIds?: EntityId[]
     organizationId?: string | null
+    organizationIds?: string[] | null
     tenantId: string
   }
 }

--- a/packages/shared/src/modules/search.ts
+++ b/packages/shared/src/modules/search.ts
@@ -52,6 +52,8 @@ export type SearchResult = {
   links?: SearchResultLink[]
   /** Extra metadata from the strategy */
   metadata?: Record<string, unknown>
+  /** Organization scope of the result, when known by the strategy. */
+  organizationId?: string | null
 }
 
 // =============================================================================
@@ -70,6 +72,15 @@ export type SearchOptions = {
    * - `undefined` or `null` means no organization filter (tenant-wide).
    */
   organizationId?: string | null
+  /**
+   * Optional organization allowlist.
+   * - Non-empty array restricts results to one of those organizations.
+   * - Empty array means no organizations are visible and should return no results.
+   * - `undefined` or `null` means no organization filter (tenant-wide).
+   *
+   * `organizationId` takes precedence when both are provided.
+   */
+  organizationIds?: string[] | null
   /** Filter to specific entity types */
   entityTypes?: EntityId[]
   /** Use only specific strategies (defaults to all available) */


### PR DESCRIPTION
## Summary
- pass the full resolved organization allowlist from standard and global search routes
- add organizationIds support to search options and fulltext/token/vector strategies
- add a fail-closed SearchService backstop that drops results outside the requested organization scope
- preserve organizationId during result merging and add regression tests for restricted multi-org search

Fixes #2268

## Tests
- yarn workspace @open-mercato/search test
- yarn exec tsc -p packages/search/tsconfig.json --noEmit
- yarn exec tsc -p packages/shared/tsconfig.json --noEmit