### PR TITLE
feat(onboarding): declare ACL feature dependencies (#2171)

### DIFF
--- a/packages/onboarding/src/__tests__/acl.test.ts
+++ b/packages/onboarding/src/__tests__/acl.test.ts
@@ -1,3 +1,7 @@
+import {
+  resolveAclDependencyDiagnostics,
+  type FeatureDescriptor,
+} from '@open-mercato/shared/security/aclDependencies'
 import { features } from '../modules/onboarding/acl'
 
 describe('onboarding ACL features', () => {
@@ -48,5 +52,50 @@ describe('onboarding ACL features', () => {
   it('is the default export', async () => {
     const mod = await import('../modules/onboarding/acl')
     expect(mod.default).toBe(features)
+  })
+})
+
+describe('onboarding acl dependency declarations', () => {
+  const descriptors: FeatureDescriptor[] = features
+  const ownIds = descriptors.map((feature) => feature.id)
+
+  it('declares dependsOn only against features registered in the catalog', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(ownIds, descriptors)
+    const ownUnknown = diagnostics.unknownReferences.filter((ref) =>
+      ref.feature.startsWith('onboarding.'),
+    )
+    expect(ownUnknown).toEqual([])
+  })
+
+  it('resolves cleanly with no missing deps when every feature is granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(ownIds, descriptors)
+    const ownMissing = diagnostics.missingDependencies.filter((dep) =>
+      dep.feature.startsWith('onboarding.'),
+    )
+    expect(ownMissing).toEqual([])
+  })
+
+  it('keeps every dependency target within the onboarding feature set', () => {
+    const ids = new Set(ownIds)
+    const deps = descriptors.flatMap((feature) => feature.dependsOn ?? [])
+    for (const dep of deps) {
+      expect(ids.has(dep)).toBe(true)
+    }
+  })
+
+  it('flags submit and verify as missing onboarding.access when access is not granted', () => {
+    const diagnostics = resolveAclDependencyDiagnostics(
+      ['onboarding.submit', 'onboarding.verify'],
+      descriptors,
+    )
+    expect(diagnostics.unknownReferences).toEqual([])
+    const submitMissing = diagnostics.missingDependencies.find(
+      (dep) => dep.feature === 'onboarding.submit',
+    )
+    const verifyMissing = diagnostics.missingDependencies.find(
+      (dep) => dep.feature === 'onboarding.verify',
+    )
+    expect(submitMissing?.missing).toEqual(['onboarding.access'])
+    expect(verifyMissing?.missing).toEqual(['onboarding.access'])
   })
 })

--- a/packages/onboarding/src/modules/onboarding/acl.ts
+++ b/packages/onboarding/src/modules/onboarding/acl.ts
@@ -1,7 +1,17 @@
 export const features = [
   { id: 'onboarding.access', title: 'Access onboarding flow', module: 'onboarding' },
-  { id: 'onboarding.submit', title: 'Submit onboarding request', module: 'onboarding' },
-  { id: 'onboarding.verify', title: 'Verify onboarding request', module: 'onboarding' },
+  {
+    id: 'onboarding.submit',
+    title: 'Submit onboarding request',
+    module: 'onboarding',
+    dependsOn: ['onboarding.access'],
+  },
+  {
+    id: 'onboarding.verify',
+    title: 'Verify onboarding request',
+    module: 'onboarding',
+    dependsOn: ['onboarding.access'],
+  },
 ]
 
 export default features


### PR DESCRIPTION
Fixes #2171

## Problem
Per-module follow-up to PR #2141 (`feat(auth): ACL dependency bundles`). That PR shipped the resolver/API/UI infrastructure and used `customers` as the reference module; every other module still needs `dependsOn` declared on its `acl.ts` features. This PR covers the `onboarding` module per spec [§6.32](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-27-acl-dependency-bundles.md#632-onboarding).

## Root Cause
`onboarding/acl.ts` declared three flat features with no dependency metadata, so the AclEditor warning UX could not detect that `onboarding.submit` / `onboarding.verify` are only meaningful when `onboarding.access` is also granted.

## What Changed
- `packages/onboarding/src/modules/onboarding/acl.ts` — added `dependsOn: ['onboarding.access']` to both `onboarding.submit` and `onboarding.verify`, matching the spec table exactly. `onboarding.access` has no dependencies.
- No new view-grained features were needed (the spec table declares no `*` deps), so `setup.ts` `defaultRoleFeatures` is unchanged (the module has no `setup.ts`).

## Tests
- `packages/onboarding/src/__tests__/acl.test.ts` — added a `dependency declarations` suite that:
  - asserts no `unknownReferences` for onboarding ids when resolving against the module catalog,
  - asserts no `missingDependencies` when every feature is granted,
  - asserts every dependency target stays within the onboarding feature set,
  - asserts `submit`/`verify` are flagged as missing `onboarding.access` when access is not granted.
- `yarn workspace @open-mercato/onboarding test -- acl.test` → 12/12 passing.
- `yarn workspace @open-mercato/onboarding run typecheck` → clean (exit 0).

## Backward Compatibility
- Purely additive: an optional `dependsOn` field on existing feature descriptors. No feature ids, titles, modules, import paths, event IDs, or API response fields removed or changed. Warnings are advisory and non-blocking per spec §4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
