### PR TITLE
fix(business_rules): cache rule discovery

### DIFF
--- a/packages/core/src/modules/business_rules/api/__tests__/execute.route.test.ts
+++ b/packages/core/src/modules/business_rules/api/__tests__/execute.route.test.ts
@@ -1,12 +1,12 @@
 /** @jest-environment node */
 
 import { describe, test, expect, beforeEach, jest } from '@jest/globals'
-import { createAuthMock, createMockContainer, createMockEntityManager } from './test-helpers'
-import { invalidateBusinessRuleDiscoveryCache } from '../../lib/rule-engine'
+import { createAuthMock, createMockCache, createMockContainer, createMockEntityManager } from './test-helpers'
 
 const mockGetAuthFromRequest = createAuthMock()
 const mockEm = createMockEntityManager()
-const mockContainer = createMockContainer(mockEm)
+const mockCache = createMockCache()
+const mockContainer = createMockContainer(mockEm, mockCache)
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(async () => mockContainer),
@@ -31,7 +31,7 @@ describe('Business Rules API - Execute Endpoint', () => {
   const validOrgId = '223e4567-e89b-12d3-a456-426614174000'
 
   beforeEach(() => {
-    invalidateBusinessRuleDiscoveryCache()
+    mockCache.clearAll()
     jest.clearAllMocks()
     mockGetAuthFromRequest.mockResolvedValue({
       sub: 'user-1',

--- a/packages/core/src/modules/business_rules/api/__tests__/execute.route.test.ts
+++ b/packages/core/src/modules/business_rules/api/__tests__/execute.route.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, test, expect, beforeEach, jest } from '@jest/globals'
 import { createAuthMock, createMockContainer, createMockEntityManager } from './test-helpers'
+import { invalidateBusinessRuleDiscoveryCache } from '../../lib/rule-engine'
 
 const mockGetAuthFromRequest = createAuthMock()
 const mockEm = createMockEntityManager()
@@ -30,6 +31,7 @@ describe('Business Rules API - Execute Endpoint', () => {
   const validOrgId = '223e4567-e89b-12d3-a456-426614174000'
 
   beforeEach(() => {
+    invalidateBusinessRuleDiscoveryCache()
     jest.clearAllMocks()
     mockGetAuthFromRequest.mockResolvedValue({
       sub: 'user-1',

--- a/packages/core/src/modules/business_rules/api/__tests__/rules.route.test.ts
+++ b/packages/core/src/modules/business_rules/api/__tests__/rules.route.test.ts
@@ -1,12 +1,13 @@
 /** @jest-environment node */
 
 import { describe, test, expect, beforeEach, jest } from '@jest/globals'
-import { createAuthMock, createMockContainer, createMockEntityManager } from './test-helpers'
+import { createAuthMock, createMockCache, createMockContainer, createMockEntityManager } from './test-helpers'
 import * as ruleEngine from '../../lib/rule-engine'
 
 const mockGetAuthFromRequest = createAuthMock()
 const mockEm = createMockEntityManager()
-const mockContainer = createMockContainer(mockEm)
+const mockCache = createMockCache()
+const mockContainer = createMockContainer(mockEm, mockCache)
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(async () => mockContainer),
@@ -58,7 +59,7 @@ describe('Business Rules API - /api/business_rules/rules', () => {
   const validOrgId = '223e4567-e89b-12d3-a456-426614174000'
 
   beforeEach(() => {
-    ruleEngine.invalidateBusinessRuleDiscoveryCache()
+    mockCache.clearAll()
     jest.clearAllMocks()
     mockGetAuthFromRequest.mockResolvedValue({
       sub: 'user-1',
@@ -75,7 +76,7 @@ describe('Business Rules API - /api/business_rules/rules', () => {
       eventType: 'created',
       tenantId: validTenantId,
       organizationId: validOrgId,
-    })
+    }, { cache: mockCache })
     expect(mockEm.find).toHaveBeenCalledTimes(1)
   }
 
@@ -86,7 +87,7 @@ describe('Business Rules API - /api/business_rules/rules', () => {
       eventType: 'created',
       tenantId: validTenantId,
       organizationId: validOrgId,
-    })
+    }, { cache: mockCache })
     expect(mockEm.find).toHaveBeenCalledTimes(2)
   }
 

--- a/packages/core/src/modules/business_rules/api/__tests__/rules.route.test.ts
+++ b/packages/core/src/modules/business_rules/api/__tests__/rules.route.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, test, expect, beforeEach, jest } from '@jest/globals'
 import { createAuthMock, createMockContainer, createMockEntityManager } from './test-helpers'
+import * as ruleEngine from '../../lib/rule-engine'
 
 const mockGetAuthFromRequest = createAuthMock()
 const mockEm = createMockEntityManager()
@@ -57,6 +58,7 @@ describe('Business Rules API - /api/business_rules/rules', () => {
   const validOrgId = '223e4567-e89b-12d3-a456-426614174000'
 
   beforeEach(() => {
+    ruleEngine.invalidateBusinessRuleDiscoveryCache()
     jest.clearAllMocks()
     mockGetAuthFromRequest.mockResolvedValue({
       sub: 'user-1',
@@ -65,6 +67,28 @@ describe('Business Rules API - /api/business_rules/rules', () => {
       orgId: validOrgId,
     })
   })
+
+  async function primeRuleDiscoveryCache() {
+    mockEm.find.mockResolvedValueOnce([])
+    await ruleEngine.findApplicableRules(mockEm as any, {
+      entityType: 'WorkOrder',
+      eventType: 'created',
+      tenantId: validTenantId,
+      organizationId: validOrgId,
+    })
+    expect(mockEm.find).toHaveBeenCalledTimes(1)
+  }
+
+  async function expectRuleDiscoveryCacheInvalidated() {
+    mockEm.find.mockResolvedValueOnce([])
+    await ruleEngine.findApplicableRules(mockEm as any, {
+      entityType: 'WorkOrder',
+      eventType: 'created',
+      tenantId: validTenantId,
+      organizationId: validOrgId,
+    })
+    expect(mockEm.find).toHaveBeenCalledTimes(2)
+  }
 
   describe('Metadata', () => {
     test('should have correct RBAC requirements', () => {
@@ -306,6 +330,34 @@ describe('Business Rules API - /api/business_rules/rules', () => {
       )
     })
 
+    test('should invalidate rule discovery cache after successful create', async () => {
+      await primeRuleDiscoveryCache()
+
+      const newRule = {
+        ruleId: 'RULE-CACHE-CREATE',
+        ruleName: 'Cache Create Rule',
+        ruleType: 'ACTION',
+        entityType: 'WorkOrder',
+      }
+
+      mockEm.create.mockReturnValue({
+        id: '623e4567-e89b-12d3-a456-426614174008',
+        ...newRule,
+        tenantId: validTenantId,
+        organizationId: validOrgId,
+      })
+      mockEm.flush.mockResolvedValue(undefined)
+
+      const request = new Request('http://localhost:3000/api/business_rules/rules', {
+        method: 'POST',
+        body: JSON.stringify(newRule),
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(201)
+      await expectRuleDiscoveryCacheInvalidated()
+    })
+
     test('should return 500 with sanitized JSON error when flush fails', async () => {
       const newRule = {
         ruleId: 'RULE-DB-FAIL',
@@ -489,6 +541,37 @@ describe('Business Rules API - /api/business_rules/rules', () => {
       expect(existingRule.enabled).toBe(false)
       expect(mockEm.flush).toHaveBeenCalled()
     })
+
+    test('should invalidate rule discovery cache after successful update', async () => {
+      await primeRuleDiscoveryCache()
+
+      const existingRule = {
+        id: '123e4567-e89b-12d3-a456-426614174001',
+        ruleId: 'RULE-001',
+        ruleName: 'Original Name',
+        ruleType: 'GUARD',
+        entityType: 'WorkOrder',
+        tenantId: validTenantId,
+        organizationId: validOrgId,
+        deletedAt: null,
+      }
+
+      mockEm.findOne.mockResolvedValue(existingRule)
+      mockEm.assign.mockImplementation((target: any, data: any) => Object.assign(target, data))
+      mockEm.flush.mockResolvedValue(undefined)
+
+      const request = new Request('http://localhost:3000/api/business_rules/rules', {
+        method: 'PUT',
+        body: JSON.stringify({
+          id: '123e4567-e89b-12d3-a456-426614174001',
+          ruleName: 'Updated Name',
+        }),
+      })
+      const response = await PUT(request)
+
+      expect(response.status).toBe(200)
+      await expectRuleDiscoveryCacheInvalidated()
+    })
   })
 
   describe('DELETE - Delete rule', () => {
@@ -527,6 +610,29 @@ describe('Business Rules API - /api/business_rules/rules', () => {
       expect(body.ok).toBe(true)
       expect(existingRule.deletedAt).toBeInstanceOf(Date)
       expect(mockEm.flush).toHaveBeenCalled()
+    })
+
+    test('should invalidate rule discovery cache after successful delete', async () => {
+      await primeRuleDiscoveryCache()
+
+      const existingRule = {
+        id: '123e4567-e89b-12d3-a456-426614174001',
+        ruleId: 'RULE-001',
+        tenantId: validTenantId,
+        organizationId: validOrgId,
+        deletedAt: null,
+      }
+
+      mockEm.findOne.mockResolvedValue(existingRule)
+      mockEm.flush.mockResolvedValue(undefined)
+
+      const request = new Request('http://localhost:3000/api/business_rules/rules?id=rule-1', {
+        method: 'DELETE',
+      })
+      const response = await DELETE(request)
+
+      expect(response.status).toBe(200)
+      await expectRuleDiscoveryCacheInvalidated()
     })
 
     test('should return 404 if rule not found', async () => {

--- a/packages/core/src/modules/business_rules/api/__tests__/test-helpers.ts
+++ b/packages/core/src/modules/business_rules/api/__tests__/test-helpers.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals'
 import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
 
-type AsyncMock<T = unknown> = jest.MockedFunction<(...args: any[]) => Promise<T>>
+type AsyncMock<T = unknown, Args extends any[] = any[]> = jest.MockedFunction<(...args: Args) => Promise<T>>
 type SyncMock<T = unknown, Args extends any[] = any[]> = jest.MockedFunction<(...args: Args) => T>
 
 export type MockEntityManager = {
@@ -13,6 +13,13 @@ export type MockEntityManager = {
   remove: SyncMock<any>
   flush: AsyncMock<void>
   assign: SyncMock<any, [any, any]>
+}
+
+export type MockCache = {
+  get: AsyncMock<any>
+  set: AsyncMock<void, [string, unknown, { ttl?: number; tags?: string[] }?]>
+  deleteByTags: AsyncMock<number, [string[]]>
+  clearAll: () => void
 }
 
 export function createAuthMock(defaultValue?: AuthContext): AsyncMock<AuthContext> {
@@ -37,8 +44,34 @@ export function createMockEntityManager(overrides: Partial<MockEntityManager> = 
   return { ...base, ...overrides }
 }
 
-export function createMockContainer(em: MockEntityManager) {
+export function createMockCache(): MockCache {
+  const entries = new Map<string, { value: unknown; tags: string[] }>()
+
   return {
-    resolve: jest.fn((token: string) => (token === 'em' ? em : undefined)),
+    get: jest.fn(async (key: string) => entries.get(key)?.value ?? null) as AsyncMock<any>,
+    set: jest.fn(async (key: string, value: unknown, options?: { ttl?: number; tags?: string[] }) => {
+      entries.set(key, { value, tags: options?.tags ?? [] })
+    }) as AsyncMock<void, [string, unknown, { ttl?: number; tags?: string[] }?]>,
+    deleteByTags: jest.fn(async (tags: string[]) => {
+      let deleted = 0
+      for (const [key, entry] of entries.entries()) {
+        if (entry.tags.some((tag) => tags.includes(tag))) {
+          entries.delete(key)
+          deleted++
+        }
+      }
+      return deleted
+    }) as AsyncMock<number, [string[]]>,
+    clearAll: () => entries.clear(),
+  }
+}
+
+export function createMockContainer(em: MockEntityManager, cache?: MockCache) {
+  return {
+    resolve: jest.fn((token: string) => {
+      if (token === 'em') return em
+      if (token === 'cache') return cache
+      return undefined
+    }),
   }
 }

--- a/packages/core/src/modules/business_rules/api/execute/route.ts
+++ b/packages/core/src/modules/business_rules/api/execute/route.ts
@@ -47,6 +47,7 @@ export async function POST(req: Request) {
 
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
+  const cache = ruleEngine.resolveBusinessRuleDiscoveryCache(container.resolve.bind(container))
   let eventBus: EventBus | null = null
   try {
     eventBus = container.resolve('eventBus') as EventBus
@@ -92,7 +93,7 @@ export async function POST(req: Request) {
   }
 
   try {
-    const result = await ruleEngine.executeRules(em, context, { eventBus })
+    const result = await ruleEngine.executeRules(em, context, { eventBus, cache })
 
     const response = {
       allowed: result.allowed,

--- a/packages/core/src/modules/business_rules/api/rules/route.ts
+++ b/packages/core/src/modules/business_rules/api/rules/route.ts
@@ -15,7 +15,10 @@ import {
   businessRuleFilterSchema,
   ruleTypeSchema,
 } from '../../data/validators'
-import { invalidateBusinessRuleDiscoveryCache } from '../../lib/rule-engine'
+import {
+  invalidateBusinessRuleDiscoveryCache,
+  resolveBusinessRuleDiscoveryCache,
+} from '../../lib/rule-engine'
 
 const querySchema = z.looseObject({
   id: z.uuid().optional(),
@@ -181,6 +184,7 @@ export async function POST(req: Request) {
 
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
+  const cache = resolveBusinessRuleDiscoveryCache(container.resolve.bind(container))
 
   let body: any
   try {
@@ -213,7 +217,7 @@ export async function POST(req: Request) {
 
   try {
     await em.persist(rule).flush()
-    invalidateBusinessRuleDiscoveryCache(rule.tenantId, rule.organizationId)
+    await invalidateBusinessRuleDiscoveryCache(cache, rule.tenantId, rule.organizationId)
   } catch (error) {
     console.error('[business_rules.rules] Failed to persist new rule:', error)
     return NextResponse.json(
@@ -233,6 +237,7 @@ export async function PUT(req: Request) {
 
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
+  const cache = resolveBusinessRuleDiscoveryCache(container.resolve.bind(container))
 
   let body: any
   try {
@@ -276,7 +281,7 @@ export async function PUT(req: Request) {
 
   try {
     await em.persist(rule).flush()
-    invalidateBusinessRuleDiscoveryCache(rule.tenantId, rule.organizationId)
+    await invalidateBusinessRuleDiscoveryCache(cache, rule.tenantId, rule.organizationId)
   } catch (error) {
     console.error('[business_rules.rules] Failed to persist rule update:', error)
     return NextResponse.json(
@@ -303,6 +308,7 @@ export async function DELETE(req: Request) {
 
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
+  const cache = resolveBusinessRuleDiscoveryCache(container.resolve.bind(container))
 
   const rule = await em.findOne(BusinessRule, {
     id,
@@ -317,7 +323,7 @@ export async function DELETE(req: Request) {
 
   rule.deletedAt = new Date()
   await em.persist(rule).flush()
-  invalidateBusinessRuleDiscoveryCache(rule.tenantId, rule.organizationId)
+  await invalidateBusinessRuleDiscoveryCache(cache, rule.tenantId, rule.organizationId)
 
   return NextResponse.json({ ok: true })
 }

--- a/packages/core/src/modules/business_rules/api/rules/route.ts
+++ b/packages/core/src/modules/business_rules/api/rules/route.ts
@@ -15,6 +15,7 @@ import {
   businessRuleFilterSchema,
   ruleTypeSchema,
 } from '../../data/validators'
+import { invalidateBusinessRuleDiscoveryCache } from '../../lib/rule-engine'
 
 const querySchema = z.looseObject({
   id: z.uuid().optional(),
@@ -212,6 +213,7 @@ export async function POST(req: Request) {
 
   try {
     await em.persist(rule).flush()
+    invalidateBusinessRuleDiscoveryCache(rule.tenantId, rule.organizationId)
   } catch (error) {
     console.error('[business_rules.rules] Failed to persist new rule:', error)
     return NextResponse.json(
@@ -274,6 +276,7 @@ export async function PUT(req: Request) {
 
   try {
     await em.persist(rule).flush()
+    invalidateBusinessRuleDiscoveryCache(rule.tenantId, rule.organizationId)
   } catch (error) {
     console.error('[business_rules.rules] Failed to persist rule update:', error)
     return NextResponse.json(
@@ -314,6 +317,7 @@ export async function DELETE(req: Request) {
 
   rule.deletedAt = new Date()
   await em.persist(rule).flush()
+  invalidateBusinessRuleDiscoveryCache(rule.tenantId, rule.organizationId)
 
   return NextResponse.json({ ok: true })
 }

--- a/packages/core/src/modules/business_rules/cli.ts
+++ b/packages/core/src/modules/business_rules/cli.ts
@@ -2,6 +2,7 @@ import type { ModuleCli } from '@open-mercato/shared/modules/registry'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { BusinessRule } from './data/entities'
+import { invalidateBusinessRuleDiscoveryCache } from './lib/rule-engine'
 import * as fs from 'fs'
 import * as path from 'path'
 
@@ -70,6 +71,7 @@ const seedGuardRules: ModuleCli = {
         })
 
         await em.persist(rule).flush()
+        invalidateBusinessRuleDiscoveryCache(tenantId, organizationId)
         console.log(`  ✓ Seeded guard rule: ${rule.ruleName}`)
         seededCount++
       }

--- a/packages/core/src/modules/business_rules/cli.ts
+++ b/packages/core/src/modules/business_rules/cli.ts
@@ -2,7 +2,10 @@ import type { ModuleCli } from '@open-mercato/shared/modules/registry'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { BusinessRule } from './data/entities'
-import { invalidateBusinessRuleDiscoveryCache } from './lib/rule-engine'
+import {
+  invalidateBusinessRuleDiscoveryCache,
+  resolveBusinessRuleDiscoveryCache,
+} from './lib/rule-engine'
 import * as fs from 'fs'
 import * as path from 'path'
 
@@ -40,6 +43,7 @@ const seedGuardRules: ModuleCli = {
     try {
       const { resolve } = await createRequestContainer()
       const em = resolve<EntityManager>('em')
+      const cache = resolveBusinessRuleDiscoveryCache(resolve)
 
       // Read guard rules from workflows examples
       const rulesPath = path.join(__dirname, '../workflows/examples', 'guard-rules-example.json')
@@ -71,7 +75,7 @@ const seedGuardRules: ModuleCli = {
         })
 
         await em.persist(rule).flush()
-        invalidateBusinessRuleDiscoveryCache(tenantId, organizationId)
+        await invalidateBusinessRuleDiscoveryCache(cache, tenantId, organizationId)
         console.log(`  ✓ Seeded guard rule: ${rule.ruleName}`)
         seededCount++
       }

--- a/packages/core/src/modules/business_rules/lib/__tests__/rule-engine.test.ts
+++ b/packages/core/src/modules/business_rules/lib/__tests__/rule-engine.test.ts
@@ -43,6 +43,8 @@ describe('Rule Engine (Unit Tests)', () => {
   }
 
   beforeEach(() => {
+    ruleEngine.invalidateBusinessRuleDiscoveryCache()
+
     // Create mock EntityManager
     mockEm = {
       find: jest.fn(),
@@ -132,6 +134,58 @@ describe('Rule Engine (Unit Tests)', () => {
       })
 
       expect(rules).toHaveLength(0)
+    })
+
+    test('should cache empty discovery results for repeated wildcard subscriber events', async () => {
+      mockEm.find.mockResolvedValue([])
+
+      const options = {
+        entityType: 'WorkOrder',
+        eventType: 'created',
+        tenantId: testTenantId,
+        organizationId: testOrgId,
+      }
+
+      await ruleEngine.findApplicableRules(mockEm, options)
+      await ruleEngine.findApplicableRules(mockEm, options)
+
+      expect(mockEm.find).toHaveBeenCalledTimes(1)
+    })
+
+    test('should keep discovery cache scoped by entity and event type', async () => {
+      mockEm.find.mockResolvedValue([])
+
+      await ruleEngine.findApplicableRules(mockEm, {
+        entityType: 'WorkOrder',
+        eventType: 'created',
+        tenantId: testTenantId,
+        organizationId: testOrgId,
+      })
+      await ruleEngine.findApplicableRules(mockEm, {
+        entityType: 'WorkOrder',
+        eventType: 'updated',
+        tenantId: testTenantId,
+        organizationId: testOrgId,
+      })
+
+      expect(mockEm.find).toHaveBeenCalledTimes(2)
+    })
+
+    test('should invalidate cached discovery results for a tenant organization', async () => {
+      mockEm.find.mockResolvedValue([])
+
+      const options = {
+        entityType: 'WorkOrder',
+        eventType: 'created',
+        tenantId: testTenantId,
+        organizationId: testOrgId,
+      }
+
+      await ruleEngine.findApplicableRules(mockEm, options)
+      ruleEngine.invalidateBusinessRuleDiscoveryCache(testTenantId, testOrgId)
+      await ruleEngine.findApplicableRules(mockEm, options)
+
+      expect(mockEm.find).toHaveBeenCalledTimes(2)
     })
 
     test('should sort rules by priority descending', async () => {

--- a/packages/core/src/modules/business_rules/lib/__tests__/rule-engine.test.ts
+++ b/packages/core/src/modules/business_rules/lib/__tests__/rule-engine.test.ts
@@ -11,8 +11,29 @@ import type { BusinessRule } from '../../data/entities'
 jest.mock('../rule-evaluator')
 jest.mock('../action-executor')
 
+function createMockRuleDiscoveryCache() {
+  const entries = new Map<string, { value: unknown; tags: string[] }>()
+  return {
+    get: jest.fn(async (key: string) => entries.get(key)?.value ?? null),
+    set: jest.fn(async (key: string, value: unknown, options?: { tags?: string[] }) => {
+      entries.set(key, { value, tags: options?.tags ?? [] })
+    }),
+    deleteByTags: jest.fn(async (tags: string[]) => {
+      let deleted = 0
+      for (const [key, entry] of entries.entries()) {
+        if (entry.tags.some((tag) => tags.includes(tag))) {
+          entries.delete(key)
+          deleted++
+        }
+      }
+      return deleted
+    }),
+  }
+}
+
 describe('Rule Engine (Unit Tests)', () => {
   let mockEm: jest.Mocked<EntityManager>
+  let mockCache: ReturnType<typeof createMockRuleDiscoveryCache>
 
   const testTenantId = '00000000-0000-4000-8000-000000000001'
   const testOrgId = '00000000-0000-4000-8000-000000000002'
@@ -43,7 +64,7 @@ describe('Rule Engine (Unit Tests)', () => {
   }
 
   beforeEach(() => {
-    ruleEngine.invalidateBusinessRuleDiscoveryCache()
+    mockCache = createMockRuleDiscoveryCache()
 
     // Create mock EntityManager
     mockEm = {
@@ -146,10 +167,52 @@ describe('Rule Engine (Unit Tests)', () => {
         organizationId: testOrgId,
       }
 
-      await ruleEngine.findApplicableRules(mockEm, options)
-      await ruleEngine.findApplicableRules(mockEm, options)
+      await ruleEngine.findApplicableRules(mockEm, options, { cache: mockCache })
+      await ruleEngine.findApplicableRules(mockEm, options, { cache: mockCache })
 
       expect(mockEm.find).toHaveBeenCalledTimes(1)
+    })
+
+    test('should cache rule identifiers and refetch rules with the current entity manager', async () => {
+      const originalRule: Partial<BusinessRule> = {
+        id: 'rule-1',
+        ruleId: 'TEST-001',
+        ruleName: 'Cached Rule',
+        ruleType: 'GUARD',
+        priority: 100,
+        entityType: 'WorkOrder',
+        enabled: true,
+        tenantId: testTenantId,
+        organizationId: testOrgId,
+      }
+      const refetchedRule: Partial<BusinessRule> = {
+        ...originalRule,
+        ruleName: 'Refetched Rule',
+      }
+      const options = {
+        entityType: 'WorkOrder',
+        eventType: 'created',
+        tenantId: testTenantId,
+        organizationId: testOrgId,
+      }
+
+      mockEm.find
+        .mockResolvedValueOnce([originalRule as BusinessRule])
+        .mockResolvedValueOnce([refetchedRule as BusinessRule])
+
+      await ruleEngine.findApplicableRules(mockEm, options, { cache: mockCache })
+      const rules = await ruleEngine.findApplicableRules(mockEm, options, { cache: mockCache })
+
+      expect(rules).toHaveLength(1)
+      expect(rules[0].ruleName).toBe('Refetched Rule')
+      expect(mockEm.find).toHaveBeenCalledTimes(2)
+      expect(mockCache.set).toHaveBeenCalledWith(
+        expect.any(String),
+        { ruleIds: ['rule-1'] },
+        expect.objectContaining({
+          tags: expect.arrayContaining(['business_rules:discovery']),
+        }),
+      )
     })
 
     test('should keep discovery cache scoped by entity and event type', async () => {
@@ -160,13 +223,13 @@ describe('Rule Engine (Unit Tests)', () => {
         eventType: 'created',
         tenantId: testTenantId,
         organizationId: testOrgId,
-      })
+      }, { cache: mockCache })
       await ruleEngine.findApplicableRules(mockEm, {
         entityType: 'WorkOrder',
         eventType: 'updated',
         tenantId: testTenantId,
         organizationId: testOrgId,
-      })
+      }, { cache: mockCache })
 
       expect(mockEm.find).toHaveBeenCalledTimes(2)
     })
@@ -181,9 +244,9 @@ describe('Rule Engine (Unit Tests)', () => {
         organizationId: testOrgId,
       }
 
-      await ruleEngine.findApplicableRules(mockEm, options)
-      ruleEngine.invalidateBusinessRuleDiscoveryCache(testTenantId, testOrgId)
-      await ruleEngine.findApplicableRules(mockEm, options)
+      await ruleEngine.findApplicableRules(mockEm, options, { cache: mockCache })
+      await ruleEngine.invalidateBusinessRuleDiscoveryCache(mockCache, testTenantId, testOrgId)
+      await ruleEngine.findApplicableRules(mockEm, options, { cache: mockCache })
 
       expect(mockEm.find).toHaveBeenCalledTimes(2)
     })

--- a/packages/core/src/modules/business_rules/lib/rule-engine.ts
+++ b/packages/core/src/modules/business_rules/lib/rule-engine.ts
@@ -1,4 +1,5 @@
 import type { EntityManager } from '@mikro-orm/core'
+import { runWithCacheTenant, type CacheStrategy } from '@open-mercato/cache'
 import type { EventBus } from '@open-mercato/events'
 import { BusinessRule, RuleExecutionLog, type RuleType } from '../data/entities'
 import * as ruleEvaluator from './rule-evaluator'
@@ -88,20 +89,13 @@ export interface RuleDiscoveryOptions {
 }
 
 type CachedRuleDiscovery = {
-  rules: BusinessRule[]
-  cachedAt: number
+  ruleIds: string[]
 }
 
-const GLOBAL_RULE_DISCOVERY_CACHE_KEY = '__openMercatoBusinessRuleDiscoveryCache__'
+export type RuleDiscoveryCache = Pick<CacheStrategy, 'get' | 'set' | 'deleteByTags'>
 
-function getRuleDiscoveryCache(): Map<string, CachedRuleDiscovery> {
-  const existing = (globalThis as any)[GLOBAL_RULE_DISCOVERY_CACHE_KEY] as
-    | Map<string, CachedRuleDiscovery>
-    | undefined
-  if (existing) return existing
-  const created = new Map<string, CachedRuleDiscovery>()
-  ;(globalThis as any)[GLOBAL_RULE_DISCOVERY_CACHE_KEY] = created
-  return created
+export type RuleDiscoveryCacheOptions = {
+  cache?: RuleDiscoveryCache | null
 }
 
 function normalizeCachePart(value: string | null | undefined): string {
@@ -118,30 +112,114 @@ function getRuleDiscoveryCacheKey(options: RuleDiscoveryOptions): string {
   ].join(':')
 }
 
-export function invalidateBusinessRuleDiscoveryCache(tenantId?: string | null, organizationId?: string | null): void {
-  const cache = getRuleDiscoveryCache()
+function isCachedRuleDiscovery(value: unknown): value is CachedRuleDiscovery {
+  if (!value || typeof value !== 'object') return false
+  const ruleIds = (value as CachedRuleDiscovery).ruleIds
+  return Array.isArray(ruleIds) && ruleIds.every((entry) => typeof entry === 'string')
+}
+
+export function isRuleDiscoveryCache(value: unknown): value is RuleDiscoveryCache {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<RuleDiscoveryCache>
+  return (
+    typeof candidate.get === 'function'
+    && typeof candidate.set === 'function'
+    && typeof candidate.deleteByTags === 'function'
+  )
+}
+
+export function resolveBusinessRuleDiscoveryCache(resolve: (token: string) => unknown): RuleDiscoveryCache | null {
+  try {
+    const cache = resolve('cache')
+    return isRuleDiscoveryCache(cache) ? cache : null
+  } catch {
+    return null
+  }
+}
+
+function getRuleDiscoveryCacheTags(options: Pick<RuleDiscoveryOptions, 'organizationId'>): string[] {
+  return [
+    'business_rules:discovery',
+    `business_rules:discovery:organization:${options.organizationId}`,
+  ]
+}
+
+async function getCachedRuleDiscovery(
+  cache: RuleDiscoveryCache | null | undefined,
+  options: RuleDiscoveryOptions,
+): Promise<CachedRuleDiscovery | null> {
+  if (!cache) return null
+
+  let value: unknown
+  try {
+    value = await runWithCacheTenant(options.tenantId, () =>
+      cache.get(getRuleDiscoveryCacheKey(options))
+    )
+  } catch (error) {
+    console.warn('[business_rules] Failed to read rule discovery cache:', error)
+    return null
+  }
+
+  return isCachedRuleDiscovery(value) ? value : null
+}
+
+async function cacheRuleDiscovery(
+  cache: RuleDiscoveryCache | null | undefined,
+  options: RuleDiscoveryOptions,
+  rules: BusinessRule[],
+): Promise<void> {
+  if (!cache) return
+
+  const ruleIds = rules
+    .map((rule) => rule.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+
+  if (ruleIds.length !== rules.length) return
+
+  try {
+    await runWithCacheTenant(options.tenantId, () =>
+      cache.set(
+        getRuleDiscoveryCacheKey(options),
+        { ruleIds },
+        {
+          ttl: RULE_DISCOVERY_CACHE_TTL,
+          tags: getRuleDiscoveryCacheTags(options),
+        },
+      )
+    )
+  } catch (error) {
+    console.warn('[business_rules] Failed to write rule discovery cache:', error)
+  }
+}
+
+export async function invalidateBusinessRuleDiscoveryCache(
+  cache: RuleDiscoveryCache | null | undefined,
+  tenantId?: string | null,
+  organizationId?: string | null,
+): Promise<void> {
+  if (!cache) return
+
   const normalizedTenantId = tenantId?.trim()
   const normalizedOrganizationId = organizationId?.trim()
 
   if (!normalizedTenantId) {
-    cache.clear()
     return
   }
 
-  const tenantPrefix = `${normalizeCachePart(normalizedTenantId)}:`
-  const orgPrefix = normalizedOrganizationId
-    ? `${tenantPrefix}${normalizeCachePart(normalizedOrganizationId)}:`
-    : null
+  const tags = normalizedOrganizationId
+    ? [`business_rules:discovery:organization:${normalizedOrganizationId}`]
+    : ['business_rules:discovery']
 
-  for (const key of cache.keys()) {
-    if (orgPrefix ? key.startsWith(orgPrefix) : key.startsWith(tenantPrefix)) {
-      cache.delete(key)
-    }
+  try {
+    await runWithCacheTenant(normalizedTenantId, () => cache.deleteByTags(tags))
+  } catch (error) {
+    console.warn('[business_rules] Failed to invalidate rule discovery cache:', error)
   }
 }
 
 export type RuleEngineExecutionOptions = {
   eventBus?: Pick<EventBus, 'emitEvent'> | null
+  cache?: RuleDiscoveryCache | null
 }
 
 type RuleExecutionFailedPayload = {
@@ -267,7 +345,7 @@ export async function executeRules(
       eventType: context.eventType,
       tenantId: context.tenantId,
       organizationId: context.organizationId,
-    })
+    }, { cache: options.cache })
 
     // Check rule count limit
     if (rules.length > MAX_RULES_PER_EXECUTION) {
@@ -522,44 +600,53 @@ export async function executeSingleRule(
  */
 export async function findApplicableRules(
   em: EntityManager,
-  options: RuleDiscoveryOptions
+  options: RuleDiscoveryOptions,
+  cacheOptions: RuleDiscoveryCacheOptions = {},
 ): Promise<BusinessRule[]> {
   // Validate input
   ruleDiscoveryOptionsSchema.parse(options)
 
   const { entityType, eventType, tenantId, organizationId, ruleType } = options
-  const cacheKey = getRuleDiscoveryCacheKey(options)
-  const cache = getRuleDiscoveryCache()
-  const cached = cache.get(cacheKey)
+  const baseWhere: Record<string, unknown> = {
+    entityType,
+    tenantId,
+    organizationId,
+    enabled: true,
+    deletedAt: null,
+  }
+
+  if (eventType) {
+    baseWhere.eventType = eventType
+  }
+
+  if (ruleType) {
+    baseWhere.ruleType = ruleType
+  }
+
+  const cached = await getCachedRuleDiscovery(cacheOptions.cache, options)
   let rules: BusinessRule[]
 
-  if (cached && Date.now() - cached.cachedAt < RULE_DISCOVERY_CACHE_TTL) {
-    rules = cached.rules
+  if (cached) {
+    if (cached.ruleIds.length === 0) {
+      rules = []
+    } else {
+      const cachedRules = await em.find(BusinessRule, {
+        ...baseWhere,
+        id: { $in: cached.ruleIds },
+      }, {
+        orderBy: { priority: 'DESC', ruleId: 'ASC' },
+      } as any)
+      const byId = new Map(cachedRules.map((rule) => [rule.id, rule]))
+      rules = cached.ruleIds
+        .map((id) => byId.get(id))
+        .filter((rule): rule is BusinessRule => Boolean(rule))
+    }
   } else {
-    const where: Partial<BusinessRule> = {
-      entityType,
-      tenantId,
-      organizationId,
-      enabled: true,
-      deletedAt: null,
-    }
-
-    if (eventType) {
-      where.eventType = eventType
-    }
-
-    if (ruleType) {
-      where.ruleType = ruleType
-    }
-
-    rules = await em.find(BusinessRule, where, {
+    rules = await em.find(BusinessRule, baseWhere as Partial<BusinessRule>, {
       orderBy: { priority: 'DESC', ruleId: 'ASC' },
     })
 
-    cache.set(cacheKey, {
-      rules,
-      cachedAt: Date.now(),
-    })
+    await cacheRuleDiscovery(cacheOptions.cache, options, rules)
   }
 
   // Filter by effective date range

--- a/packages/core/src/modules/business_rules/lib/rule-engine.ts
+++ b/packages/core/src/modules/business_rules/lib/rule-engine.ts
@@ -22,6 +22,7 @@ const EXECUTION_RESULT_FAILURE = 'FAILURE'
 const MAX_RULES_PER_EXECUTION = 100
 const MAX_SINGLE_RULE_TIMEOUT_MS = 30000  // 30 seconds
 const MAX_TOTAL_EXECUTION_TIMEOUT_MS = 60000  // 60 seconds
+const RULE_DISCOVERY_CACHE_TTL = 5 * 60 * 1000
 
 /**
  * Rule execution context
@@ -84,6 +85,59 @@ export interface RuleDiscoveryOptions {
   tenantId: string
   organizationId: string
   ruleType?: RuleType
+}
+
+type CachedRuleDiscovery = {
+  rules: BusinessRule[]
+  cachedAt: number
+}
+
+const GLOBAL_RULE_DISCOVERY_CACHE_KEY = '__openMercatoBusinessRuleDiscoveryCache__'
+
+function getRuleDiscoveryCache(): Map<string, CachedRuleDiscovery> {
+  const existing = (globalThis as any)[GLOBAL_RULE_DISCOVERY_CACHE_KEY] as
+    | Map<string, CachedRuleDiscovery>
+    | undefined
+  if (existing) return existing
+  const created = new Map<string, CachedRuleDiscovery>()
+  ;(globalThis as any)[GLOBAL_RULE_DISCOVERY_CACHE_KEY] = created
+  return created
+}
+
+function normalizeCachePart(value: string | null | undefined): string {
+  return encodeURIComponent(value?.trim() || '*')
+}
+
+function getRuleDiscoveryCacheKey(options: RuleDiscoveryOptions): string {
+  return [
+    normalizeCachePart(options.tenantId),
+    normalizeCachePart(options.organizationId),
+    normalizeCachePart(options.entityType),
+    normalizeCachePart(options.eventType),
+    normalizeCachePart(options.ruleType),
+  ].join(':')
+}
+
+export function invalidateBusinessRuleDiscoveryCache(tenantId?: string | null, organizationId?: string | null): void {
+  const cache = getRuleDiscoveryCache()
+  const normalizedTenantId = tenantId?.trim()
+  const normalizedOrganizationId = organizationId?.trim()
+
+  if (!normalizedTenantId) {
+    cache.clear()
+    return
+  }
+
+  const tenantPrefix = `${normalizeCachePart(normalizedTenantId)}:`
+  const orgPrefix = normalizedOrganizationId
+    ? `${tenantPrefix}${normalizeCachePart(normalizedOrganizationId)}:`
+    : null
+
+  for (const key of cache.keys()) {
+    if (orgPrefix ? key.startsWith(orgPrefix) : key.startsWith(tenantPrefix)) {
+      cache.delete(key)
+    }
+  }
 }
 
 export type RuleEngineExecutionOptions = {
@@ -474,26 +528,39 @@ export async function findApplicableRules(
   ruleDiscoveryOptionsSchema.parse(options)
 
   const { entityType, eventType, tenantId, organizationId, ruleType } = options
+  const cacheKey = getRuleDiscoveryCacheKey(options)
+  const cache = getRuleDiscoveryCache()
+  const cached = cache.get(cacheKey)
+  let rules: BusinessRule[]
 
-  const where: Partial<BusinessRule> = {
-    entityType,
-    tenantId,
-    organizationId,
-    enabled: true,
-    deletedAt: null,
+  if (cached && Date.now() - cached.cachedAt < RULE_DISCOVERY_CACHE_TTL) {
+    rules = cached.rules
+  } else {
+    const where: Partial<BusinessRule> = {
+      entityType,
+      tenantId,
+      organizationId,
+      enabled: true,
+      deletedAt: null,
+    }
+
+    if (eventType) {
+      where.eventType = eventType
+    }
+
+    if (ruleType) {
+      where.ruleType = ruleType
+    }
+
+    rules = await em.find(BusinessRule, where, {
+      orderBy: { priority: 'DESC', ruleId: 'ASC' },
+    })
+
+    cache.set(cacheKey, {
+      rules,
+      cachedAt: Date.now(),
+    })
   }
-
-  if (eventType) {
-    where.eventType = eventType
-  }
-
-  if (ruleType) {
-    where.ruleType = ruleType
-  }
-
-  const rules = await em.find(BusinessRule, where, {
-    orderBy: { priority: 'DESC', ruleId: 'ASC' },
-  })
 
   // Filter by effective date range
   const now = new Date()

--- a/packages/core/src/modules/business_rules/subscribers/__tests__/crud-rule-trigger.test.ts
+++ b/packages/core/src/modules/business_rules/subscribers/__tests__/crud-rule-trigger.test.ts
@@ -7,10 +7,12 @@ jest.mock('../../lib/rule-engine', () => ({
     totalExecutionTime: 0,
     errors: [],
   })),
+  resolveBusinessRuleDiscoveryCache: jest.fn(() => null),
 }))
 
-import { executeRules } from '../../lib/rule-engine'
+import { executeRules, resolveBusinessRuleDiscoveryCache } from '../../lib/rule-engine'
 const executeRulesMock = executeRules as jest.MockedFunction<typeof executeRules>
+const resolveBusinessRuleDiscoveryCacheMock = resolveBusinessRuleDiscoveryCache as jest.MockedFunction<typeof resolveBusinessRuleDiscoveryCache>
 
 describe('business_rules crud-rule-trigger subscriber', () => {
   const mockEm = {} as any
@@ -53,7 +55,8 @@ describe('business_rules crud-rule-trigger subscriber', () => {
       data: { id: 'person-1' },
       tenantId: 't1',
       organizationId: 'o1',
-    })
+    }, { cache: null })
+    expect(resolveBusinessRuleDiscoveryCacheMock).toHaveBeenCalled()
   })
 
   it('does not trust payload tenant scope over subscriber context scope', async () => {
@@ -65,7 +68,7 @@ describe('business_rules crud-rule-trigger subscriber', () => {
       data: { tenantId: 'spoofed-tenant', organizationId: 'spoofed-org', id: 'person-1' },
       tenantId: 'trusted-tenant',
       organizationId: 'trusted-org',
-    }))
+    }), { cache: null })
   })
 
   it('skips excluded internal events', async () => {

--- a/packages/core/src/modules/business_rules/subscribers/crud-rule-trigger.ts
+++ b/packages/core/src/modules/business_rules/subscribers/crud-rule-trigger.ts
@@ -11,7 +11,7 @@
  */
 
 import type { EntityManager } from '@mikro-orm/core'
-import { executeRules } from '../lib/rule-engine'
+import { executeRules, resolveBusinessRuleDiscoveryCache } from '../lib/rule-engine'
 
 export const metadata = {
   event: '*',
@@ -64,6 +64,7 @@ export default async function handle(
   if (!tenantId || !organizationId) return
 
   const em = ctx.resolve<EntityManager>('em')
+  const cache = resolveBusinessRuleDiscoveryCache(ctx.resolve)
 
   try {
     await executeRules(em, {
@@ -72,7 +73,7 @@ export default async function handle(
       data,
       tenantId,
       organizationId,
-    })
+    }, { cache })
   } catch (error) {
     console.error(`[business_rules] Rule execution failed for event ${eventName}:`, error)
   }

--- a/packages/core/src/modules/workflows/cli.ts
+++ b/packages/core/src/modules/workflows/cli.ts
@@ -4,6 +4,10 @@ import { getRedisUrl, getRedisUrlOrThrow } from '@open-mercato/shared/lib/redis/
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { WorkflowDefinition } from './data/entities'
 import { BusinessRule, type RuleType } from '@open-mercato/core/modules/business_rules/data/entities'
+import {
+  invalidateBusinessRuleDiscoveryCache,
+  resolveBusinessRuleDiscoveryCache,
+} from '@open-mercato/core/modules/business_rules/lib/rule-engine'
 import * as fs from 'fs'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
@@ -69,6 +73,7 @@ const seedDemoWithRules: ModuleCli = {
     try {
       const { resolve } = await createRequestContainer()
       const em = resolve<EntityManager>('em')
+      const cache = resolveBusinessRuleDiscoveryCache(resolve)
 
       // Import BusinessRule entity
       const { BusinessRule } = await import('../business_rules/data/entities')
@@ -100,6 +105,7 @@ const seedDemoWithRules: ModuleCli = {
         })
 
         await em.persist(rule).flush()
+        await invalidateBusinessRuleDiscoveryCache(cache, tenantId, organizationId)
         console.log(`  ✓ Seeded guard rule: ${rule.ruleName}`)
         seededCount++
       }
@@ -211,6 +217,7 @@ const seedOrderApproval: ModuleCli = {
     try {
       const { resolve } = await createRequestContainer()
       const em = resolve<EntityManager>('em')
+      const cache = resolveBusinessRuleDiscoveryCache(resolve)
 
       // 1. Seed order approval guard rules first
       const guardRulesPath = path.join(__dirname, 'examples', 'order-approval-guard-rules.json')
@@ -252,6 +259,7 @@ const seedOrderApproval: ModuleCli = {
 
       if (rulesSeeded > 0) {
         await em.flush()
+        await invalidateBusinessRuleDiscoveryCache(cache, tenantId, organizationId)
       }
 
       console.log(`✅ Seeded order approval guard rules`)

--- a/packages/core/src/modules/workflows/lib/seeds.ts
+++ b/packages/core/src/modules/workflows/lib/seeds.ts
@@ -4,6 +4,10 @@ import * as path from 'path'
 import { fileURLToPath } from 'node:url'
 import { WorkflowDefinition, type WorkflowDefinitionData } from '../data/entities'
 import { BusinessRule, type RuleType } from '@open-mercato/core/modules/business_rules/data/entities'
+import {
+  invalidateBusinessRuleDiscoveryCache,
+  type RuleDiscoveryCache,
+} from '@open-mercato/core/modules/business_rules/lib/rule-engine'
 
 const __esmDirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -130,6 +134,7 @@ async function seedGuardRules(
   em: EntityManager,
   scope: WorkflowSeedScope,
   fileName: string,
+  cache?: RuleDiscoveryCache | null,
 ): Promise<{ seeded: number; skipped: number; updated: number }> {
   const seeds = readExampleJson<GuardRuleSeed[]>(fileName)
   if (!Array.isArray(seeds)) {
@@ -185,16 +190,21 @@ async function seedGuardRules(
   }
   if (seeded > 0 || updated > 0) {
     await em.flush()
+    await invalidateBusinessRuleDiscoveryCache(cache, scope.tenantId, scope.organizationId)
   }
   return { seeded, skipped, updated }
 }
 
-export async function seedExampleWorkflows(em: EntityManager, scope: WorkflowSeedScope): Promise<void> {
+export async function seedExampleWorkflows(
+  em: EntityManager,
+  scope: WorkflowSeedScope,
+  options: { cache?: RuleDiscoveryCache | null } = {},
+): Promise<void> {
   // workflows.checkout-demo and workflows.simple-approval are now code-defined
   // (see packages/core/src/modules/workflows/workflows.ts). Seeding DB rows for
   // them would shadow the code definitions in the merge layer, so they are no
   // longer seeded here. Existing tenants are migrated via Migration20260428102318.
-  await seedGuardRules(em, scope, 'guard-rules-example.json')
+  await seedGuardRules(em, scope, 'guard-rules-example.json', options.cache)
   await seedWorkflowDefinition(em, scope, 'sales-pipeline-definition.json')
-  await seedGuardRules(em, scope, 'order-approval-guard-rules.json')
+  await seedGuardRules(em, scope, 'order-approval-guard-rules.json', options.cache)
 }

--- a/packages/core/src/modules/workflows/setup.ts
+++ b/packages/core/src/modules/workflows/setup.ts
@@ -1,10 +1,12 @@
 import type { ModuleSetupConfig } from '@open-mercato/shared/modules/setup'
+import { resolveBusinessRuleDiscoveryCache } from '@open-mercato/core/modules/business_rules/lib/rule-engine'
 import { seedExampleWorkflows } from './lib/seeds'
 
 export const setup: ModuleSetupConfig = {
   seedDefaults: async (ctx) => {
     const scope = { tenantId: ctx.tenantId, organizationId: ctx.organizationId }
-    await seedExampleWorkflows(ctx.em, scope)
+    const cache = resolveBusinessRuleDiscoveryCache(ctx.container.resolve.bind(ctx.container))
+    await seedExampleWorkflows(ctx.em, scope, { cache })
   },
 
   defaultRoleFeatures: {


### PR DESCRIPTION
## Summary
- cache business rule discovery by tenant, organization, entity, event, and rule type with a short TTL
- make no-rule tenants avoid repeated BusinessRule SELECTs on wildcard domain events after the first lookup
- invalidate rule discovery cache when rules are created, updated, deleted, or seeded by CLI
- add regression coverage for empty-result caching and cache invalidation from rules API mutations

Fixes #2255

## Tests
- yarn workspace @open-mercato/core exec jest --config jest.config.cjs src/modules/business_rules
- yarn exec tsc -p packages/core/tsconfig.json --noEmit