### PR TITLE
fix(integrations): fail closed when credentials DEK is unavailable

### DIFF
--- a/.ai/specs/2026-03-23-inbound-webhook-handlers.md
+++ b/.ai/specs/2026-03-23-inbound-webhook-handlers.md
@@ -936,7 +936,7 @@ The existing `WebhookEndpointAdapter` interface from SPEC-057 Phase 3 is superse
 | Handler causes infinite event loop (handler emits event → triggers outbound webhook → external system sends webhook back) | High | Built-in loop detection: tag emitted events with `_inboundIngestionId`, skip outbound dispatch for tagged events. Rate limiting provides secondary protection |
 | Large payload DoS | Medium | Request body size limit (1MB default, configurable per source) |
 | Source verifier is slow/hangs | Medium | Verification timeout (5s default); async dispatch means receiver returns quickly |
-| Credential DEK unavailable (KMS outage) | Medium | Fallback key chain: KMS → `TENANT_DATA_ENCRYPTION_FALLBACK_KEY` → `AUTH_SECRET`. Webhook verification fails gracefully with 500 if no key available |
+| Credential DEK unavailable (KMS outage) | Medium | Fallback key chain: KMS -> dedicated `TENANT_DATA_ENCRYPTION_FALLBACK_KEY`; auth/session secrets are not data-encryption fallbacks. Webhook verification fails gracefully with 500 if no key available |
 | Env-to-encrypted migration fails (inbox_ops) | Medium | Migration is idempotent — retries on next tenant setup. Env vars remain readable as fallback during transition. CLI command for manual re-run |
 | Inbox_ops old URL removal breaks external Resend config | High | Old URL kept as redirect for ≥1 minor version. Resend dashboard config updated in docs. Admin notification when old URL is hit |
 | Handler results JSON grows unbounded | Low | Cap `handlerResults` array to 50 entries per ingestion. Truncate error messages to 1KB |

--- a/.ai/specs/2026-05-29-integrations-credentials-encryption-fail-closed.md
+++ b/.ai/specs/2026-05-29-integrations-credentials-encryption-fail-closed.md
@@ -1,0 +1,89 @@
+# Integrations Credentials Encryption Fail-Closed
+
+## TLDR
+
+Fix issue #2251 by removing the integrations credentials service's local DEK derivation fallback. Integration credentials must be encrypted only with a DEK returned by the shared KMS path. If no DEK is available, credentials reads for encrypted rows and all credential writes fail closed instead of falling back to auth secrets, dev defaults, or public constants.
+
+## Problem Statement
+
+Integration credentials contain third-party API keys, OAuth client secrets, webhook secrets, and passwords. The previous implementation could derive a DEK inside `packages/core/src/modules/integrations/lib/credentials-service.ts` from `AUTH_SECRET`, `NEXTAUTH_SECRET`, a dev default, or the public production constant `om-emergency-fallback-rotate-me` using a single SHA-256 hash. A database dump plus a reused or known secret could decrypt stored credentials offline.
+
+The shared KMS fallback also accepted `AUTH_SECRET` and `NEXTAUTH_SECRET` as tenant-data encryption fallback inputs. That made the integrations fix incomplete unless the shared KMS candidate list was narrowed to data-encryption-specific secrets.
+
+## Proposed Solution
+
+- Remove all local fallback secret resolution and SHA-256 DEK derivation from the integrations credentials service.
+- Use only `createKmsService().getTenantDek()` or `createTenantDek()` for credential encryption/decryption.
+- Throw a typed `CredentialsEncryptionUnavailableError` when no DEK is available.
+- Return HTTP 503 from the credentials API for that typed error.
+- Remove `AUTH_SECRET` and `NEXTAUTH_SECRET` from shared KMS derived-key candidates.
+- Keep derived KMS available through dedicated data-encryption secrets: `TENANT_DATA_ENCRYPTION_FALLBACK_KEY`, then legacy `TENANT_DATA_ENCRYPTION_KEY`.
+- Require `ALLOW_DERIVED_KMS_FALLBACK=true` before using the built-in dev default derived key.
+
+## Architecture
+
+`integrationCredentialsService.save()` resolves the DEK before touching the database. If KMS cannot provide or create a tenant DEK, the method throws and leaves storage untouched. When a row exists, `getRaw()` decrypts the blob only after KMS returns a DEK. Empty/missing credential rows still return `null` without requiring KMS.
+
+The encrypted blob format remains unchanged:
+
+- JSON credentials are encrypted with AES-GCM.
+- The encrypted payload stays under `__om_encrypted_credentials_blob_v1`.
+- Existing rows remain readable when the same KMS/fallback DEK is configured.
+
+## API Contracts
+
+No route path, method, request body, or successful response shape changes.
+
+New failure behavior:
+
+- `GET /api/integrations/:id/credentials` returns `503` when an existing encrypted credential row cannot be decrypted because no credential DEK is available.
+- `PUT /api/integrations/:id/credentials` returns `503` when credentials cannot be encrypted because no credential DEK is available.
+
+The response body is intentionally generic:
+
+```json
+{ "error": "Integration credentials encryption is unavailable" }
+```
+
+## Migration & Backward Compatibility
+
+This intentionally changes insecure fallback behavior. Deployments that relied on `AUTH_SECRET`, `NEXTAUTH_SECRET`, or the hardcoded integrations fallback must configure Vault KMS or a dedicated `TENANT_DATA_ENCRYPTION_FALLBACK_KEY`.
+
+Existing credentials encrypted with the old integrations-local SHA-256 fallback are not silently migrated by this patch because the old fallback included insecure auth/public constants. Operators should restore the previous secret in an isolated migration/rotation workflow and re-save credentials under Vault or a dedicated fallback key.
+
+The public credentials service type and API routes remain stable. The new typed error is additive.
+
+## Verification Plan
+
+- Unit test the integrations credentials service:
+  - encrypts only with a KMS DEK,
+  - fails before storage writes when no DEK exists,
+  - does not require KMS for missing rows,
+  - fails when encrypted rows exist but no DEK exists.
+- Unit test shared KMS:
+  - auth secrets alone do not create derived tenant keys,
+  - dev default derived keys require `ALLOW_DERIVED_KMS_FALLBACK=true`,
+  - explicit fallback secret still works when Vault times out.
+- Run targeted Jest suites for `integrations` and `shared` encryption.
+- Run TypeScript checks for `packages/core` and `packages/shared`.
+
+## Risks & Impact Review
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| Deployments using auth secrets as data-encryption fallback can no longer decrypt credential rows. | High | Fail closed and document dedicated fallback requirement. This is the intended security boundary. |
+| Local dev environments without Vault/fallback cannot save integration credentials. | Medium | Set `TENANT_DATA_ENCRYPTION_FALLBACK_KEY` or explicitly opt into the dev default with `ALLOW_DERIVED_KMS_FALLBACK=true`. |
+| Existing old-fallback ciphertext cannot be read after the insecure path is removed. | Medium | Require explicit operator-controlled rotation instead of automatic reuse of insecure constants. |
+
+## Final Compliance Report
+
+- No API route URLs or methods changed.
+- No database schema changes.
+- No DI service names changed.
+- No integration registry contracts changed.
+- Sensitive data remains encrypted through AES-GCM and tenant DEKs.
+- The insecure local AES/KMS fallback is removed from integrations credentials.
+
+## Changelog
+
+- 2026-05-29 - Initial security hardening spec for issue #2251.

--- a/apps/docs/docs/architecture/data-encryption.mdx
+++ b/apps/docs/docs/architecture/data-encryption.mdx
@@ -30,7 +30,7 @@ This document outlines the data-encryption architecture so module owners can wir
 - **Auth adjustments** – `users` table gains `email_hash` (indexed) so login can query by hash even when `email` is encrypted.
 - **Tenant bootstrap** – tenant creation flow generates and stores a DEK via `kmsService.createTenantDek` with the `tenant_key_<tenantId>` prefix.
 - **Observability** – warning rows (or audit logs) emitted when KMS is unavailable; set `TENANT_DATA_ENCRYPTION_DEBUG=yes` to log map evaluation plus Vault KMS reads/writes.
-- **Fallback path** – if Vault is unhealthy, the runtime uses a derived-key KMS when a fallback secret is provided (`TENANT_DATA_ENCRYPTION_FALLBACK_KEY` → `TENANT_DATA_ENCRYPTION_KEY` → `AUTH_SECRET/NEXTAUTH_SECRET`, dev default last); without any secret in production it becomes a noop KMS (ciphertext left plaintext).
+- **Fallback path** – if Vault is unhealthy, the runtime uses a derived-key KMS only when a dedicated data-encryption fallback secret is provided (`TENANT_DATA_ENCRYPTION_FALLBACK_KEY`, then legacy `TENANT_DATA_ENCRYPTION_KEY`). `AUTH_SECRET` and `NEXTAUTH_SECRET` are never used for tenant data encryption. The dev default fallback is available only with `ALLOW_DERIVED_KMS_FALLBACK=true`; otherwise missing KMS configuration becomes a noop KMS.
 
 ## Environment variables
 
@@ -38,7 +38,7 @@ This document outlines the data-encryption architecture so module owners can wir
 - `TENANT_DATA_ENCRYPTION_DEBUG` – `yes` to surface map evaluation decisions, Vault cache hits/misses, and fallback selection in logs.
 - `VAULT_ADDR`, `VAULT_TOKEN` – required for the HashiCorp Vault KMS provider.
 - `VAULT_KV_PATH` – KV v2 mount for tenant keys; defaults to `secret/data`.
-- Fallback secrets (used when Vault is down or missing): `TENANT_DATA_ENCRYPTION_FALLBACK_KEY`, then `TENANT_DATA_ENCRYPTION_KEY`, then `AUTH_SECRET`/`NEXTAUTH_SECRET` in dev; production without any secret falls back to the noop KMS.
+- Fallback secrets (used when Vault is down or missing): `TENANT_DATA_ENCRYPTION_FALLBACK_KEY`, then legacy `TENANT_DATA_ENCRYPTION_KEY`. Auth/session secrets are intentionally excluded. The built-in dev fallback requires `ALLOW_DERIVED_KMS_FALLBACK=true`; production without a dedicated fallback secret falls back to the noop KMS.
 
 ## Data flow
 
@@ -98,7 +98,7 @@ flowchart TD
 - **DEK generation** – 32 random bytes, base64-encoded; stored under `tenant_key_<tenantId>` in Vault.
 - **Rotation** – future addition: new version stored under suffix `tenant_key_<tenantId>_v2` with dual-read, single-write strategy; current design keeps a single active DEK per tenant.
 - **Caching** – DEKs cached with TTL (e.g., 15 minutes) and proactive refresh on expiry; invalidated if KMS returns a new version.
-- **Derived-key fallback** – when running without Vault, the derived KMS hashes the chosen secret to a root key (SHA-256) and produces per-tenant DEKs via `HMAC-SHA256(root, tenantId)`, encoded base64. The key stays stable for a tenant while the secret is unchanged.
+- **Derived-key fallback** – when running without Vault and with a dedicated fallback secret, the derived KMS hashes the chosen secret to a root key and produces per-tenant DEKs with PBKDF2-SHA512 using the tenant id as salt, encoded base64. The key stays stable for a tenant while the secret is unchanged.
 
 ## Integration points to implement
 

--- a/apps/docs/docs/user-guide/encryption.mdx
+++ b/apps/docs/docs/user-guide/encryption.mdx
@@ -11,7 +11,7 @@ Use tenant data encryption to protect sensitive columns with per-tenant DEKs, ke
 - `TENANT_DATA_ENCRYPTION_DEBUG` – `yes` to log map evaluation, Vault calls, cache hits, and fallback selection.
 - `VAULT_ADDR`, `VAULT_TOKEN` – required for HashiCorp Vault KMS. Example: `https://vault.example.com`.
 - `VAULT_KV_PATH` – KV v2 mount for tenant keys (default `secret/data`).
-- Fallback (dev / when Vault is down): set `TENANT_DATA_ENCRYPTION_FALLBACK_KEY` (preferred) or `TENANT_DATA_ENCRYPTION_KEY`. If none are set, `AUTH_SECRET`/`NEXTAUTH_SECRET` is used in dev; production falls back to noop KMS.
+- Fallback (dev / when Vault is down): set `TENANT_DATA_ENCRYPTION_FALLBACK_KEY` (preferred) or legacy `TENANT_DATA_ENCRYPTION_KEY`. `AUTH_SECRET` and `NEXTAUTH_SECRET` are not used for data encryption. The built-in dev fallback is disabled unless `ALLOW_DERIVED_KMS_FALLBACK=true`; production without a dedicated fallback secret falls back to noop KMS.
 
 Note: changing encryption maps or toggling the **Encrypted** flag on a custom field only applies to data written after the change; previously stored values stay as they were unless you re-save or migrate them.
 
@@ -130,7 +130,7 @@ The `--confirm <tenantUuid>` flag is a required safety gate — it must exactly 
 
 - Turn on `TENANT_DATA_ENCRYPTION_DEBUG=yes` to see KMS cache hits/misses, Vault calls, and which fields were encrypted.
 - Debug logs also call out Vault health and the selected KMS path (Vault vs derived vs noop) so you can verify `VAULT_ADDR`, `VAULT_TOKEN`, and `VAULT_KV_PATH` without exposing the token value.
-- If Vault is unreachable, the runtime logs a warning and falls back to the derived-key KMS when a fallback secret is present; otherwise it becomes a noop KMS (data stays plaintext).
+- If Vault is unreachable, the runtime logs a warning and falls back to the derived-key KMS when a dedicated fallback secret is present; otherwise it becomes a noop KMS (data stays plaintext). Integration credentials fail closed instead of saving under a noop or auth-derived key.
 - Use **Configuration → System status** to confirm the active values of the encryption env vars in the running instance.
 
 ## Running without Vault

--- a/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
@@ -5,7 +5,10 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getIntegration } from '@open-mercato/shared/modules/integrations/types'
 import { emitIntegrationsEvent } from '../../../events'
 import { saveCredentialsSchema } from '../../../data/validators'
-import type { CredentialsService } from '../../../lib/credentials-service'
+import {
+  isCredentialsEncryptionUnavailableError,
+  type CredentialsService,
+} from '../../../lib/credentials-service'
 import {
   resolveUserFeatures,
   runIntegrationMutationGuardAfterSuccess,
@@ -53,7 +56,15 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
   const credentialsService = container.resolve('integrationCredentialsService') as CredentialsService
   const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
 
-  const values = await credentialsService.resolve(integration.id, scope)
+  let values: Record<string, unknown> | null
+  try {
+    values = await credentialsService.resolve(integration.id, scope)
+  } catch (error) {
+    if (isCredentialsEncryptionUnavailableError(error)) {
+      return NextResponse.json({ error: 'Integration credentials encryption is unavailable' }, { status: 503 })
+    }
+    throw error
+  }
 
   return NextResponse.json({
     integrationId: integration.id,
@@ -118,7 +129,14 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
   const credentialsService = container.resolve('integrationCredentialsService') as CredentialsService
   const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
 
-  await credentialsService.save(integration.id, payloadData.credentials, scope)
+  try {
+    await credentialsService.save(integration.id, payloadData.credentials, scope)
+  } catch (error) {
+    if (isCredentialsEncryptionUnavailableError(error)) {
+      return NextResponse.json({ error: 'Integration credentials encryption is unavailable' }, { status: 503 })
+    }
+    throw error
+  }
 
   await emitIntegrationsEvent('integrations.credentials.updated', {
     integrationId: integration.id,

--- a/packages/core/src/modules/integrations/lib/__tests__/credentials-service.test.ts
+++ b/packages/core/src/modules/integrations/lib/__tests__/credentials-service.test.ts
@@ -1,0 +1,117 @@
+/** @jest-environment node */
+
+import { decryptWithAesGcm, encryptWithAesGcm, generateDek } from '@open-mercato/shared/lib/encryption/aes'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { createKmsService } from '@open-mercato/shared/lib/encryption/kms'
+import { EncryptionMap } from '../../../entities/data/entities'
+import { IntegrationCredentials } from '../../data/entities'
+import {
+  createCredentialsService,
+  CredentialsEncryptionUnavailableError,
+} from '../credentials-service'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/kms', () => ({
+  createKmsService: jest.fn(),
+}))
+
+const mockFindOneWithDecryption = findOneWithDecryption as jest.MockedFunction<typeof findOneWithDecryption>
+const mockCreateKmsService = createKmsService as jest.MockedFunction<typeof createKmsService>
+
+const scope = { organizationId: 'org-1', tenantId: 'tenant-1' }
+const encryptedBlobKey = '__om_encrypted_credentials_blob_v1'
+
+function mockKms(dek: string | null) {
+  mockCreateKmsService.mockReturnValue({
+    isHealthy: () => Boolean(dek),
+    getTenantDek: jest.fn(async (tenantId: string) => dek ? { tenantId, key: dek, fetchedAt: Date.now() } : null),
+    createTenantDek: jest.fn(async (tenantId: string) => dek ? { tenantId, key: dek, fetchedAt: Date.now() } : null),
+  })
+}
+
+function createMockEntityManager() {
+  const persisted: unknown[] = []
+  const em = {
+    create: jest.fn((_Entity: unknown, data: Record<string, unknown>) => ({ ...data })),
+    persist: jest.fn((entity: unknown) => {
+      persisted.push(entity)
+      return em
+    }),
+    flush: jest.fn(async () => undefined),
+  }
+  return { em, persisted }
+}
+
+describe('integration credentials service encryption', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('encrypts credentials only with a DEK resolved from KMS', async () => {
+    const dek = generateDek()
+    mockKms(dek)
+    mockFindOneWithDecryption.mockImplementation(async (_em, entity) => {
+      if (entity === EncryptionMap) return null
+      if (entity === IntegrationCredentials) return null
+      return null
+    })
+    const { em, persisted } = createMockEntityManager()
+    const service = createCredentialsService(em as never)
+
+    await service.save('gateway_test', { apiKey: 'sk_test_secret' }, scope)
+
+    const credentialsRow = persisted.find((row) =>
+      typeof row === 'object'
+      && row !== null
+      && (row as { integrationId?: unknown }).integrationId === 'gateway_test'
+    ) as { credentials?: Record<string, unknown> } | undefined
+
+    expect(credentialsRow?.credentials).toEqual({
+      [encryptedBlobKey]: expect.any(String),
+    })
+    const decrypted = decryptWithAesGcm(String(credentialsRow?.credentials?.[encryptedBlobKey]), dek)
+    expect(JSON.parse(String(decrypted))).toEqual({ apiKey: 'sk_test_secret' })
+  })
+
+  it('fails closed before touching storage when no credential DEK is available', async () => {
+    mockKms(null)
+    const { em, persisted } = createMockEntityManager()
+    const service = createCredentialsService(em as never)
+
+    await expect(service.save('gateway_test', { apiKey: 'sk_test_secret' }, scope))
+      .rejects
+      .toBeInstanceOf(CredentialsEncryptionUnavailableError)
+
+    expect(mockFindOneWithDecryption).not.toHaveBeenCalled()
+    expect(persisted).toEqual([])
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('does not require KMS when no credentials row exists', async () => {
+    mockFindOneWithDecryption.mockResolvedValue(null)
+    const { em } = createMockEntityManager()
+    const service = createCredentialsService(em as never)
+
+    await expect(service.getRaw('gateway_test', scope)).resolves.toBeNull()
+
+    expect(mockCreateKmsService).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when encrypted credentials exist but no DEK is available', async () => {
+    const dek = generateDek()
+    const encrypted = encryptWithAesGcm(JSON.stringify({ apiKey: 'sk_test_secret' }), dek).value
+    mockKms(null)
+    mockFindOneWithDecryption.mockResolvedValue({
+      credentials: { [encryptedBlobKey]: encrypted },
+    } as never)
+    const { em } = createMockEntityManager()
+    const service = createCredentialsService(em as never)
+
+    await expect(service.getRaw('gateway_test', scope))
+      .rejects
+      .toBeInstanceOf(CredentialsEncryptionUnavailableError)
+  })
+})

--- a/packages/core/src/modules/integrations/lib/credentials-service.ts
+++ b/packages/core/src/modules/integrations/lib/credentials-service.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { decryptWithAesGcm, encryptWithAesGcm } from '@open-mercato/shared/lib/encryption/aes'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -14,7 +13,19 @@ import { EncryptionMap } from '../../entities/data/entities'
 import { IntegrationCredentials } from '../data/entities'
 
 const ENCRYPTED_CREDENTIALS_BLOB_KEY = '__om_encrypted_credentials_blob_v1'
-const DERIVED_KEY_CONTEXT = 'integrations.credentials'
+const CREDENTIALS_ENCRYPTION_UNAVAILABLE_MESSAGE =
+  'Integration credentials encryption key is unavailable. Configure Vault KMS or TENANT_DATA_ENCRYPTION_FALLBACK_KEY.'
+
+export class CredentialsEncryptionUnavailableError extends Error {
+  constructor() {
+    super(CREDENTIALS_ENCRYPTION_UNAVAILABLE_MESSAGE)
+    this.name = 'CredentialsEncryptionUnavailableError'
+  }
+}
+
+export function isCredentialsEncryptionUnavailableError(error: unknown): error is CredentialsEncryptionUnavailableError {
+  return error instanceof CredentialsEncryptionUnavailableError
+}
 
 function isRecordValue(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
@@ -26,35 +37,6 @@ function normalizeCredentialsRecord(value: unknown): Record<string, unknown> {
 
   const parsed = parseDecryptedFieldValue(value)
   return isRecordValue(parsed) ? parsed : {}
-}
-
-function resolveFallbackEncryptionSecret(): string {
-  const candidates = [
-    process.env.TENANT_DATA_ENCRYPTION_FALLBACK_KEY,
-    process.env.TENANT_DATA_ENCRYPTION_KEY,
-    process.env.AUTH_SECRET,
-    process.env.NEXTAUTH_SECRET,
-  ]
-
-  for (const value of candidates) {
-    const normalized = value?.trim()
-    if (normalized) return normalized
-  }
-
-  if (process.env.NODE_ENV !== 'production') return 'om-dev-tenant-encryption'
-
-  console.warn(
-    '[integrations.credentials] No encryption secret configured; using emergency fallback secret. Configure TENANT_DATA_ENCRYPTION_FALLBACK_KEY immediately.',
-  )
-  return 'om-emergency-fallback-rotate-me'
-}
-
-function deriveDekFromSecret(secret: string, tenantId: string): string {
-  return crypto
-    .createHash('sha256')
-    .update(`${DERIVED_KEY_CONTEXT}:${tenantId}:${secret}`)
-    .digest()
-    .toString('base64')
 }
 
 export function createCredentialsService(em: EntityManager) {
@@ -100,7 +82,7 @@ export function createCredentialsService(em: EntityManager) {
     const created = await kms.createTenantDek(scope.tenantId)
     if (created?.key) return created.key
 
-    return deriveDekFromSecret(resolveFallbackEncryptionSecret(), scope.tenantId)
+    throw new CredentialsEncryptionUnavailableError()
   }
 
   async function encryptCredentialsBlob(
@@ -162,8 +144,8 @@ export function createCredentialsService(em: EntityManager) {
     },
 
     async save(integrationId: string, credentials: Record<string, unknown>, scope: IntegrationScope): Promise<void> {
-      await ensureCredentialsEncryptionMap(scope)
       const encryptedCredentials = await encryptCredentialsBlob(credentials, scope)
+      await ensureCredentialsEncryptionMap(scope)
 
       const row = await findOneWithDecryption(
         em,

--- a/packages/shared/src/lib/encryption/__tests__/kms.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/kms.test.ts
@@ -49,4 +49,42 @@ describe('kms timeout handling', () => {
     expect(dek?.key).toBeTruthy()
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
+
+  it('does not derive tenant keys from auth secrets', async () => {
+    process.env.NODE_ENV = 'production'
+    process.env.TENANT_DATA_ENCRYPTION = 'yes'
+    process.env.AUTH_SECRET = 'auth-secret-that-must-not-encrypt-tenant-data'
+    process.env.NEXTAUTH_SECRET = 'nextauth-secret-that-must-not-encrypt-tenant-data'
+    delete process.env.TENANT_DATA_ENCRYPTION_FALLBACK_KEY
+    delete process.env.TENANT_DATA_ENCRYPTION_KEY
+    delete process.env.VAULT_ADDR
+    delete process.env.VAULT_TOKEN
+
+    const service = createKmsService()
+    const dek = await service.createTenantDek('tenant-auth-only')
+
+    expect(service.isHealthy()).toBe(false)
+    expect(dek).toBeNull()
+  })
+
+  it('requires an explicit opt-in before using the dev default derived key', async () => {
+    process.env.NODE_ENV = 'test'
+    process.env.TENANT_DATA_ENCRYPTION = 'yes'
+    delete process.env.TENANT_DATA_ENCRYPTION_FALLBACK_KEY
+    delete process.env.TENANT_DATA_ENCRYPTION_KEY
+    delete process.env.AUTH_SECRET
+    delete process.env.NEXTAUTH_SECRET
+    delete process.env.VAULT_ADDR
+    delete process.env.VAULT_TOKEN
+
+    const serviceWithoutOptIn = createKmsService()
+    await expect(serviceWithoutOptIn.createTenantDek('tenant-dev')).resolves.toBeNull()
+
+    process.env.ALLOW_DERIVED_KMS_FALLBACK = 'true'
+    const serviceWithOptIn = createKmsService()
+    const dek = await serviceWithOptIn.createTenantDek('tenant-dev')
+
+    expect(typeof dek?.key).toBe('string')
+    expect(dek?.key).toBeTruthy()
+  })
 })

--- a/packages/shared/src/lib/encryption/kms.ts
+++ b/packages/shared/src/lib/encryption/kms.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto'
 import { generateDek, hashForLookup } from './aes'
 import { isEncryptionDebugEnabled, isTenantDataEncryptionEnabled } from './toggles'
+import { parseBooleanToken } from '../boolean'
 import { fetchWithTimeout, resolveTimeoutMs } from '../http/fetchWithTimeout'
 
 const DEFAULT_VAULT_REQUEST_TIMEOUT_MS = 1_000
@@ -100,14 +101,15 @@ function resolveDerivedKeySecret(): DerivedSecret | null {
   const candidates: Array<{ value: string | null; envName: string }> = [
     { value: process.env.TENANT_DATA_ENCRYPTION_FALLBACK_KEY ?? null, envName: 'TENANT_DATA_ENCRYPTION_FALLBACK_KEY' },
     { value: process.env.TENANT_DATA_ENCRYPTION_KEY ?? null, envName: 'TENANT_DATA_ENCRYPTION_KEY' },
-    { value: process.env.AUTH_SECRET ?? null, envName: 'AUTH_SECRET' },
-    { value: process.env.NEXTAUTH_SECRET ?? null, envName: 'NEXTAUTH_SECRET' },
   ]
   for (const raw of candidates) {
     const normalized = normalizeEnv(raw.value ?? undefined)
     if (normalized) return { secret: normalized, source: 'explicit', envName: raw.envName }
   }
-  if (process.env.NODE_ENV !== 'production') {
+  if (
+    process.env.NODE_ENV !== 'production'
+    && parseBooleanToken(process.env.ALLOW_DERIVED_KMS_FALLBACK) === true
+  ) {
     return { secret: 'om-dev-tenant-encryption', source: 'dev-default', envName: 'DEV_DEFAULT' }
   }
   return null


### PR DESCRIPTION
## Summary
- remove integrations credentials local DEK derivation from auth secrets/dev/public fallback constants
- make encrypted credential reads and all credential writes fail closed when KMS cannot provide a DEK
- stop shared KMS from using AUTH_SECRET/NEXTAUTH_SECRET as data-encryption fallback inputs
- document the migration path and add regression coverage

## Tests
- yarn workspace @open-mercato/core exec jest --config jest.config.cjs src/modules/integrations/lib/__tests__/credentials-service.test.ts
- yarn workspace @open-mercato/core exec jest --config jest.config.cjs src/modules/integrations
- yarn workspace @open-mercato/shared test -- src/lib/encryption/__tests__/kms.test.ts
- yarn exec tsc -p packages/shared/tsconfig.json --noEmit
- yarn exec tsc -p packages/core/tsconfig.json --noEmit

Closes #2251