### PR TITLE
security(customers,shared): fail closed on org-scope checks (#2239, #2245)

### DIFF
--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening.md
@@ -40,4 +40,4 @@ Close an OWASP A01 fail-open authorization gap where organization-scope checks a
 - [ ] 3.3 Full validation gate (`yarn test`, `yarn build:app`)
 
 ## Changelog
-- 2026-05-29: Plan created; Phases 1–2 complete, Phase 3 partial (fixtures + spec written, end-to-end validation pending). Opened as draft PR — remaining items (3.2, 3.3) to finish over the weekend.
+- 2026-05-29: Plan created; Phases 1–2 complete, Phase 3 partial (fixtures + spec written, end-to-end validation pending). Opened as draft PR open-mercato/open-mercato#2300 — remaining items (3.2, 3.3) to finish over the weekend.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening.md
@@ -1,0 +1,43 @@
+# Execution Plan — Organization-Scope Fail-Open Authorization Hardening
+
+Source spec: `.ai/specs/2026-05-29-org-scope-fail-open-authorization-hardening.md`
+Pre-implementation analysis: `.ai/specs/analysis/ANALYSIS-2026-05-29-org-scope-fail-open-authorization-hardening.md`
+Closes: #2239 (write/command path), #2245 (read/detail path)
+
+## Goal
+Close an OWASP A01 fail-open authorization gap where organization-scope checks are **skipped** instead of **denied** when a restricted (non-super-admin) user has no resolvable current organization — fixed once via shared, fail-closed authorization helpers consumed by both the command (write) and detail-route (read) paths.
+
+## Scope
+- Rewrite `ensureOrganizationScope` to fail closed (`allowedIds === null` is the only unrestricted signal); preserve the legacy `currentOrg` fallback only when `organizationScope` is entirely absent (Pattern C — load-bearing for ~40 system/worker call sites).
+- Add a shared read-path predicate and migrate all 10 audited fail-open detail-route guards (customers) + the shared `entity-roles-factory` guard.
+- Unit tests at all three layers; integration fixtures + spec.
+
+## Non-goals
+- Deferred (tracked as follow-ups): WHERE-clause scoping of single-record loads (Q2-b); migrating Pattern C user-facing command routes to populate a real `organizationScope`; re-auditing `packages/enterprise/**` and provider packages.
+
+## Risks
+- Tightens create/update/read authorization for "floating" restricted users — deliberate; covered by allow-path regression unit test.
+- The absent-scope legacy fallback is load-bearing; switching it to deny would break payment/scheduled-command flows. Guarded by a dedicated unit test (`organizationScope == null ⇒ legacy, not deny`).
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Shared predicate + write-path fix (#2239)
+
+- [x] 1.1 Add `isOrganizationAccessAllowed` predicate + truth-table unit test
+- [x] 1.2 Rewrite `ensureOrganizationScope` on the predicate; scope unit tests (incl. absent-scope-not-deny + allow-path regression)
+
+### Phase 2: Read-path guard + migration (#2245 + audit)
+
+- [x] 2.1 Add `isOrganizationReadAccessAllowed` predicate + unit test
+- [x] 2.2 Migrate 10 fail-open detail-route guards + `entity-roles-factory`
+
+### Phase 3: Integration coverage + verification
+
+- [x] 3.1 Integration fixture infra (org/ACL/null-home-org) + `TC-CRM-072.spec.ts`
+- [ ] 3.2 Validate `TC-CRM-072.spec.ts` under a coherent app+DB harness (`yarn test:integration:ephemeral`)
+- [ ] 3.3 Full validation gate (`yarn test`, `yarn build:app`)
+
+## Changelog
+- 2026-05-29: Plan created; Phases 1–2 complete, Phase 3 partial (fixtures + spec written, end-to-end validation pending). Opened as draft PR — remaining items (3.2, 3.3) to finish over the weekend.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/HANDOFF.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/HANDOFF.md
@@ -1,18 +1,23 @@
 # HANDOFF — Organization-Scope Fail-Open Authorization Hardening (PR #2300)
 
-## Current state
-- **Phase/step:** resuming at **Step 3.2** (first `todo` row in PLAN.md Tasks table).
-- **Phases 1–2 + Step 3.1 are done** (code + 25 unit tests landed, `@open-mercato/shared` + `@open-mercato/core` build + typecheck clean).
-- **Last commit:** `5077cc1dd docs(runs): link draft PR #2300 in plan changelog` (then a migration commit on this resume converting the flat plan to this run folder).
-- **Branch:** `fix/org-scope-fail-open-authorization-hardening` (fork `adeptofvoltron`, cross-repo PR against `open-mercato/open-mercato:develop`).
+## Current state — COMPLETE (all Tasks rows `done`)
+- Phases 1–2 + Step 3.1: code + 25 unit tests (landed previously).
+- **Step 3.2 (this resume): DONE** — `TC-CRM-072` validated under the coherent ephemeral app+DB harness: `1 passed (56.9s)`.
+- **Step 3.3 (this resume): DONE** — full validation gate green under **Node 24.13.0** (build:packages, generate, i18n sync/usage, typecheck, `yarn test` 20/20 workspaces ~6.4k tests, build:app).
+- Branch: `fix/org-scope-fail-open-authorization-hardening` (fork `adeptofvoltron`, cross-repo PR → `open-mercato/open-mercato:develop`).
 
-## Next concrete action
-- **Step 3.2:** Validate `packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts` under a coherent app+DB harness (`yarn test:integration:ephemeral`). The spec mixes API fixtures with raw-`pg` DB fixtures, so the app server and fixtures MUST share one database — it cannot be validated against an arbitrary running dev server whose `DATABASE_URL` differs from `apps/mercato/.env`.
-- **Step 3.3:** Run the full validation gate (`yarn build:packages`, `yarn generate`, `yarn typecheck`, `yarn test`, `yarn build:app`) + i18n checks.
+## Verification artifacts
+- `final-gate-checks.md` — full gate + integration + standalone + ds + review records.
+- `final-gate-artifacts/playwright-report-summary.log` — TC-CRM-072 pass summary.
 
-## Open blockers / caveats
-- Fork PR: only **read** access to `open-mercato/open-mercato`, so the `in-progress` label + assignee signals are unavailable. The lock is a **claim comment** only. Push lands on the fork branch, which updates the PR.
-- The original author noted the integration spec could not be validated in-session because the dev server's `DATABASE_URL` differed from the fixtures' DB. Use the ephemeral harness, or record a skip with reason if the harness is not runnable here (UI/integration checks MUST NOT block development).
+## Outstanding (environment-bound, not code; require gh / write access)
+1. **PR-body update**: flip `Status: in-progress` → `Status: complete`; update `Tracking plan:` to `.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md`. Blocked by transient `gh api` failures this session — retry when gh recovers.
+2. **Summary comment + lock release comment**: post when gh recovers.
+3. **`om-auto-review-pr` autofix pass**: cannot submit a formal review (read-only fork access) + gh REST down. Self code-review found no actionable findings.
+4. **`yarn test:create-app:integration`**: blocked by a pre-existing `mercato-verdaccio` container-name conflict in this host; justified skip (additive shared helper not in the create-app template).
+
+## Node version (load-bearing)
+Open Mercato requires **Node 24.x**. The default shell here is Node 22 — `yarn generate` / `build:app` / the ephemeral harness fail the runtime gate under Node 22. Activate Node 24 (`nvm use 24`) + `yarn install` before any gate/integration command.
 
 ## Worktree
-- `.ai/tmp/auto-continue-pr/pr-2300-<ts>` (isolated; created from `fork/fix/org-scope-fail-open-authorization-hardening`). Main worktree untouched.
+`.ai/tmp/auto-continue-pr/pr-2300-20260529-204658` (isolated from `fork/fix/org-scope-fail-open-authorization-hardening`). Main worktree untouched.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/HANDOFF.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/HANDOFF.md
@@ -10,11 +10,16 @@
 - `final-gate-checks.md` — full gate + integration + standalone + ds + review records.
 - `final-gate-artifacts/playwright-report-summary.log` — TC-CRM-072 pass summary.
 
-## Outstanding (environment-bound, not code; require gh / write access)
-1. **PR-body update**: flip `Status: in-progress` → `Status: complete`; update `Tracking plan:` to `.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md`. Blocked by transient `gh api` failures this session — retry when gh recovers.
-2. **Summary comment + lock release comment**: post when gh recovers.
-3. **`om-auto-review-pr` autofix pass**: cannot submit a formal review (read-only fork access) + gh REST down. Self code-review found no actionable findings.
-4. **`yarn test:create-app:integration`**: blocked by a pre-existing `mercato-verdaccio` container-name conflict in this host; justified skip (additive shared helper not in the create-app template).
+## Outstanding (environment-bound, not code; require gh API recovery)
+> `gh` REST/GraphQL was DOWN for the entire resume session (~1h+); `git push` worked throughout (branch is at the finalize commit). The three items below could not be applied. Ready-to-post content is preserved under `final-gate-artifacts/`.
+
+1. **PR-body update**: `gh pr edit 2300 --repo open-mercato/open-mercato --body-file final-gate-artifacts/pending-pr-body.md` (flips `Status → complete`, fixes the `Tracking plan:` path). PR author can run this even from the fork.
+2. **Summary comment**: `gh pr comment 2300 --repo open-mercato/open-mercato --body-file final-gate-artifacts/pending-summary-comment.md`.
+3. **Lock-release comment**: post a short "completed, lock released" note. (No `in-progress` label was ever set — read-only fork access — so there is nothing to remove.)
+4. **`om-auto-review-pr` autofix pass**: could not run — read-only fork access (no review-verdict/label rights) + gh REST down. Self code-review + BC self-review found no actionable findings.
+5. **`yarn test:create-app:integration`**: blocked by a pre-existing `mercato-verdaccio` container-name conflict in this host; justified skip (additive shared helper not in the create-app template).
+
+Re-running `/om-auto-continue-pr-loop 2300` once gh is healthy will apply items 1–3 automatically (and can run item 4).
 
 ## Node version (load-bearing)
 Open Mercato requires **Node 24.x**. The default shell here is Node 22 — `yarn generate` / `build:app` / the ephemeral harness fail the runtime gate under Node 22. Activate Node 24 (`nvm use 24`) + `yarn install` before any gate/integration command.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/HANDOFF.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/HANDOFF.md
@@ -10,16 +10,24 @@
 - `final-gate-checks.md` — full gate + integration + standalone + ds + review records.
 - `final-gate-artifacts/playwright-report-summary.log` — TC-CRM-072 pass summary.
 
-## Outstanding (environment-bound, not code; require gh API recovery)
-> `gh` REST/GraphQL was DOWN for the entire resume session (~1h+); `git push` worked throughout (branch is at the finalize commit). The three items below could not be applied. Ready-to-post content is preserved under `final-gate-artifacts/`.
+## Finalization applied — 2026-06-01 (gh healthy)
+GitHub annotations the prior session deferred are now applied from the author account (`adeptofvoltron`):
 
-1. **PR-body update**: `gh pr edit 2300 --repo open-mercato/open-mercato --body-file final-gate-artifacts/pending-pr-body.md` (flips `Status → complete`, fixes the `Tracking plan:` path). PR author can run this even from the fork.
-2. **Summary comment**: `gh pr comment 2300 --repo open-mercato/open-mercato --body-file final-gate-artifacts/pending-summary-comment.md`.
-3. **Lock-release comment**: post a short "completed, lock released" note. (No `in-progress` label was ever set — read-only fork access — so there is nothing to remove.)
-4. **`om-auto-review-pr` autofix pass**: could not run — read-only fork access (no review-verdict/label rights) + gh REST down. Self code-review + BC self-review found no actionable findings.
-5. **`yarn test:create-app:integration`**: blocked by a pre-existing `mercato-verdaccio` container-name conflict in this host; justified skip (additive shared helper not in the create-app template).
+1. ✅ **PR-body update applied** — body now reads `Status: complete`, correct `Tracking plan:` path, `Closes #2239/#2245` (`gh pr edit ... --body-file pending-pr-body.md`).
+2. ✅ **Summary comment posted** — `pending-summary-comment.md` → issue comment `#issuecomment-4590492872`.
+3. ✅ **Completion note** — folded into the summary comment; no `in-progress` label was ever set (read-only upstream), so there is no lock to release.
 
-Re-running `/om-auto-continue-pr-loop 2300` once gh is healthy will apply items 1–3 automatically (and can run item 4).
+> gh note: `gh` is a snap build that cannot read `/tmp` (snap confinement). `--body-file` MUST point at a path under `$HOME` (e.g. `/home/bernard/...`); `/tmp` paths fail with "no such file or directory". The earlier "gh down" symptom was partly this.
+
+## Still blocked — require WRITE access to `open-mercato/open-mercato` (this account is `READ`)
+Confirmed: `viewerPermission: READ`; `AddLabelsToLabelable` denied for `adeptofvoltron`. A maintainer/write-access account must:
+
+4. **Apply labels**: `review` (pipeline) + `security` + `bug` (category) + `needs-qa` (authorization behavior change touching customer-facing CRM read/write). Then comment explaining the label rationale (AGENTS PR-workflow rule).
+5. **Mark ready for review** (drop draft) once labels are on — keeps the "ready non-draft ⇒ `review`" invariant.
+6. **`om-auto-review-pr` autofix pass**: needs review-verdict rights (and a non-author reviewer — the author cannot approve their own PR). Self code-review + BC self-review found no actionable findings.
+
+## Documented skip (environment, not code)
+7. **`yarn test:create-app:integration`**: blocked by a pre-existing `mercato-verdaccio` container-name conflict on this host; justified skip (the only added shared export is the additive internal predicate `isOrganizationAccessAllowed`, not used by the create-app template).
 
 ## Node version (load-bearing)
 Open Mercato requires **Node 24.x**. The default shell here is Node 22 — `yarn generate` / `build:app` / the ephemeral harness fail the runtime gate under Node 22. Activate Node 24 (`nvm use 24`) + `yarn install` before any gate/integration command.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/HANDOFF.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/HANDOFF.md
@@ -1,0 +1,18 @@
+# HANDOFF — Organization-Scope Fail-Open Authorization Hardening (PR #2300)
+
+## Current state
+- **Phase/step:** resuming at **Step 3.2** (first `todo` row in PLAN.md Tasks table).
+- **Phases 1–2 + Step 3.1 are done** (code + 25 unit tests landed, `@open-mercato/shared` + `@open-mercato/core` build + typecheck clean).
+- **Last commit:** `5077cc1dd docs(runs): link draft PR #2300 in plan changelog` (then a migration commit on this resume converting the flat plan to this run folder).
+- **Branch:** `fix/org-scope-fail-open-authorization-hardening` (fork `adeptofvoltron`, cross-repo PR against `open-mercato/open-mercato:develop`).
+
+## Next concrete action
+- **Step 3.2:** Validate `packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts` under a coherent app+DB harness (`yarn test:integration:ephemeral`). The spec mixes API fixtures with raw-`pg` DB fixtures, so the app server and fixtures MUST share one database — it cannot be validated against an arbitrary running dev server whose `DATABASE_URL` differs from `apps/mercato/.env`.
+- **Step 3.3:** Run the full validation gate (`yarn build:packages`, `yarn generate`, `yarn typecheck`, `yarn test`, `yarn build:app`) + i18n checks.
+
+## Open blockers / caveats
+- Fork PR: only **read** access to `open-mercato/open-mercato`, so the `in-progress` label + assignee signals are unavailable. The lock is a **claim comment** only. Push lands on the fork branch, which updates the PR.
+- The original author noted the integration spec could not be validated in-session because the dev server's `DATABASE_URL` differed from the fixtures' DB. Use the ephemeral harness, or record a skip with reason if the harness is not runnable here (UI/integration checks MUST NOT block development).
+
+## Worktree
+- `.ai/tmp/auto-continue-pr/pr-2300-<ts>` (isolated; created from `fork/fix/org-scope-fail-open-authorization-hardening`). Main worktree untouched.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/NOTIFY.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/NOTIFY.md
@@ -17,3 +17,9 @@ Append-only log of resume starts/ends, checkpoints, blockers, decisions, subagen
 - Standalone `test:create-app:integration`: env-blocked (pre-existing `mercato-verdaccio` container name conflict) — justified skip; not force-resolved to avoid disrupting the user's running stack.
 - ds-guardian: N/A (no UI). Code-review + BC self-review: no findings.
 - Blocker for finalization: `gh` REST API failing transiently this session AND read-only upstream access → PR-body Status flip, summary comment, and lock-release comment deferred to gh recovery; documented in HANDOFF.
+
+## 2026-05-29T20:34Z — resume end (gh API outage; finalization deferred)
+- Substantive work COMPLETE and pushed (HEAD `a5482ded5`): Steps 3.2 (TC-CRM-072 `1 passed`) + 3.3 (full gate green, Node 24) done; all Tasks rows `done`.
+- `gh` REST/GraphQL down the entire session (~1h+); `git push` worked. Three finalization retries (body edit, summary comment, consolidated 55-min loop) all exhausted without a single successful gh API call.
+- Ready-to-post content preserved: `final-gate-artifacts/pending-pr-body.md`, `pending-summary-comment.md`. Re-run `/om-auto-continue-pr-loop 2300` when gh recovers to apply.
+- PR body still reads `Status: in-progress` (could not be flipped) — this reflects the GitHub-annotation state, NOT the verification state, which is complete.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/NOTIFY.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/NOTIFY.md
@@ -8,3 +8,12 @@ Append-only log of resume starts/ends, checkpoints, blockers, decisions, subagen
 - PR head SHA: 5077cc1dd
 - Decision: legacy flat-file plan (`.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening.md`) migrated into a per-spec run folder with `PLAN.md` (Tasks table) + `HANDOFF.md` + `NOTIFY.md`, per the loop-resume contract. PR body `Tracking plan:` line updated to point at `PLAN.md`.
 - Caveat: fork PR with read-only upstream access — `in-progress` label/assignee unavailable; lock is the claim comment only.
+
+## 2026-05-29T19:25Z — checkpoint 1 (final): Steps 3.2 + 3.3 verified
+- Step range: 3.2..3.3 (verification only; no code commits this resume beyond run-folder docs).
+- ENV decision: project requires Node 24.x; default shell was Node 22 → `yarn generate` hard-failed. Re-ran whole gate under Node 24.13.0.
+- Full gate: build:packages ✓, generate ✓, build:packages ✓, i18n:check-sync ✓, i18n:check-usage ✓, typecheck ✓, `yarn test` ✓ (20/20 workspaces), build:app ✓.
+- Step 3.2: `TC-CRM-072` PASS (`1 passed`, 56.9s) on the coherent ephemeral app+DB harness — closes the prior "dev DB ≠ fixtures DB" blocker.
+- Standalone `test:create-app:integration`: env-blocked (pre-existing `mercato-verdaccio` container name conflict) — justified skip; not force-resolved to avoid disrupting the user's running stack.
+- ds-guardian: N/A (no UI). Code-review + BC self-review: no findings.
+- Blocker for finalization: `gh` REST API failing transiently this session AND read-only upstream access → PR-body Status flip, summary comment, and lock-release comment deferred to gh recovery; documented in HANDOFF.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/NOTIFY.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/NOTIFY.md
@@ -23,3 +23,12 @@ Append-only log of resume starts/ends, checkpoints, blockers, decisions, subagen
 - `gh` REST/GraphQL down the entire session (~1h+); `git push` worked. Three finalization retries (body edit, summary comment, consolidated 55-min loop) all exhausted without a single successful gh API call.
 - Ready-to-post content preserved: `final-gate-artifacts/pending-pr-body.md`, `pending-summary-comment.md`. Re-run `/om-auto-continue-pr-loop 2300` when gh recovers to apply.
 - PR body still reads `Status: in-progress` (could not be flipped) — this reflects the GitHub-annotation state, NOT the verification state, which is complete.
+
+## 2026-06-01T07:40Z — finalization resume (gh healthy)
+- Resumed by: @adeptofvoltron. Resume point: all Tasks rows already `done` → GitHub-finalization only; no code changed.
+- ✅ Applied `pending-pr-body.md` → PR body `Status: complete`, correct `Tracking plan:` path, `Closes #2239/#2245`.
+- ✅ Posted `pending-summary-comment.md` → `#issuecomment-4590492872`.
+- Root-caused the prior "gh down": `gh` is snap-confined and cannot read `/tmp`; `--body-file` must live under `$HOME`. With files under `/home/bernard/`, body edit + comment succeeded.
+- BLOCKED (account is `READ` on `open-mercato/open-mercato`; `AddLabelsToLabelable` denied): label normalization (`review`/`security`/`bug`/`needs-qa`), draft→ready flip, and the `om-auto-review-pr` verdict. Handed to a write-access maintainer in HANDOFF.
+- `test:create-app:integration` remains a documented env skip (verdaccio container conflict).
+- Final status: substantive work + verification COMPLETE; PR annotations applied as far as author permissions allow. Remaining items are maintainer-permission-bound, not engineering.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/NOTIFY.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/NOTIFY.md
@@ -1,0 +1,10 @@
+# NOTIFY — Organization-Scope Fail-Open Authorization Hardening (PR #2300)
+
+Append-only log of resume starts/ends, checkpoints, blockers, decisions, subagent delegations, and skipped UI passes.
+
+## 2026-05-29T18:49Z — auto-continue-pr-loop resume
+- Resumed by: @adeptofvoltron
+- Resume point: 3.2 (source: legacy `## Progress` checklist — first unchecked = 3.2; migrated to `## Tasks` table this resume)
+- PR head SHA: 5077cc1dd
+- Decision: legacy flat-file plan (`.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening.md`) migrated into a per-spec run folder with `PLAN.md` (Tasks table) + `HANDOFF.md` + `NOTIFY.md`, per the loop-resume contract. PR body `Tracking plan:` line updated to point at `PLAN.md`.
+- Caveat: fork PR with read-only upstream access — `in-progress` label/assignee unavailable; lock is the claim comment only.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md
@@ -4,6 +4,20 @@ Source spec: `.ai/specs/2026-05-29-org-scope-fail-open-authorization-hardening.m
 Pre-implementation analysis: `.ai/specs/analysis/ANALYSIS-2026-05-29-org-scope-fail-open-authorization-hardening.md`
 Closes: #2239 (write/command path), #2245 (read/detail path)
 
+## Tasks
+
+> Authoritative status table. `Status` is one of `todo` or `done`. On landing a Step, flip `Status` to `done` and fill the `Commit` column with the short SHA. The first row whose `Status` is not `done` is the resume point for `om-auto-continue-pr`. Step ids are immutable once a Step has a commit.
+
+| Phase | Step | Title | Status | Commit |
+|-------|------|-------|--------|--------|
+| 1 | 1.1 | Add `isOrganizationAccessAllowed` predicate + truth-table unit test | done | 5848120d3 |
+| 1 | 1.2 | Rewrite `ensureOrganizationScope` on the predicate; scope unit tests (absent-scope-not-deny + allow-path regression) | done | 5848120d3 |
+| 2 | 2.1 | Add `isOrganizationReadAccessAllowed` predicate + unit test | done | 13144945d |
+| 2 | 2.2 | Migrate 10 fail-open detail-route guards + `entity-roles-factory` | done | 13144945d |
+| 3 | 3.1 | Integration fixture infra (org/ACL/null-home-org) + `TC-CRM-072.spec.ts` | done | e1b9259ff |
+| 3 | 3.2 | Validate `TC-CRM-072.spec.ts` under a coherent app+DB harness (`yarn test:integration:ephemeral`) | todo | — |
+| 3 | 3.3 | Full validation gate (`yarn test`, `yarn build:app`) | todo | — |
+
 ## Goal
 Close an OWASP A01 fail-open authorization gap where organization-scope checks are **skipped** instead of **denied** when a restricted (non-super-admin) user has no resolvable current organization — fixed once via shared, fail-closed authorization helpers consumed by both the command (write) and detail-route (read) paths.
 
@@ -19,25 +33,6 @@ Close an OWASP A01 fail-open authorization gap where organization-scope checks a
 - Tightens create/update/read authorization for "floating" restricted users — deliberate; covered by allow-path regression unit test.
 - The absent-scope legacy fallback is load-bearing; switching it to deny would break payment/scheduled-command flows. Guarded by a dedicated unit test (`organizationScope == null ⇒ legacy, not deny`).
 
-## Progress
-
-> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
-
-### Phase 1: Shared predicate + write-path fix (#2239)
-
-- [x] 1.1 Add `isOrganizationAccessAllowed` predicate + truth-table unit test
-- [x] 1.2 Rewrite `ensureOrganizationScope` on the predicate; scope unit tests (incl. absent-scope-not-deny + allow-path regression)
-
-### Phase 2: Read-path guard + migration (#2245 + audit)
-
-- [x] 2.1 Add `isOrganizationReadAccessAllowed` predicate + unit test
-- [x] 2.2 Migrate 10 fail-open detail-route guards + `entity-roles-factory`
-
-### Phase 3: Integration coverage + verification
-
-- [x] 3.1 Integration fixture infra (org/ACL/null-home-org) + `TC-CRM-072.spec.ts`
-- [ ] 3.2 Validate `TC-CRM-072.spec.ts` under a coherent app+DB harness (`yarn test:integration:ephemeral`)
-- [ ] 3.3 Full validation gate (`yarn test`, `yarn build:app`)
-
 ## Changelog
 - 2026-05-29: Plan created; Phases 1–2 complete, Phase 3 partial (fixtures + spec written, end-to-end validation pending). Opened as draft PR open-mercato/open-mercato#2300 — remaining items (3.2, 3.3) to finish over the weekend.
+- 2026-05-29: `om-auto-continue-pr-loop` resume — migrated legacy flat plan (`.ai/runs/<slug>.md`) into this run folder with a `## Tasks` table, `HANDOFF.md`, and `NOTIFY.md`. Resume point: Step 3.2.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md
@@ -15,8 +15,8 @@ Closes: #2239 (write/command path), #2245 (read/detail path)
 | 2 | 2.1 | Add `isOrganizationReadAccessAllowed` predicate + unit test | done | 13144945d |
 | 2 | 2.2 | Migrate 10 fail-open detail-route guards + `entity-roles-factory` | done | 13144945d |
 | 3 | 3.1 | Integration fixture infra (org/ACL/null-home-org) + `TC-CRM-072.spec.ts` | done | e1b9259ff |
-| 3 | 3.2 | Validate `TC-CRM-072.spec.ts` under a coherent app+DB harness (`yarn test:integration:ephemeral`) | todo | — |
-| 3 | 3.3 | Full validation gate (`yarn test`, `yarn build:app`) | todo | — |
+| 3 | 3.2 | Validate `TC-CRM-072.spec.ts` under a coherent app+DB harness (`yarn test:integration:ephemeral`) | done | (verify) |
+| 3 | 3.3 | Full validation gate (`yarn test`, `yarn build:app`) | done | (verify) |
 
 ## Goal
 Close an OWASP A01 fail-open authorization gap where organization-scope checks are **skipped** instead of **denied** when a restricted (non-super-admin) user has no resolvable current organization — fixed once via shared, fail-closed authorization helpers consumed by both the command (write) and detail-route (read) paths.
@@ -36,3 +36,4 @@ Close an OWASP A01 fail-open authorization gap where organization-scope checks a
 ## Changelog
 - 2026-05-29: Plan created; Phases 1–2 complete, Phase 3 partial (fixtures + spec written, end-to-end validation pending). Opened as draft PR open-mercato/open-mercato#2300 — remaining items (3.2, 3.3) to finish over the weekend.
 - 2026-05-29: `om-auto-continue-pr-loop` resume — migrated legacy flat plan (`.ai/runs/<slug>.md`) into this run folder with a `## Tasks` table, `HANDOFF.md`, and `NOTIFY.md`. Resume point: Step 3.2.
+- 2026-05-29: Resume completed Steps 3.2 + 3.3. **Required Node 24.x** (default shell Node 22 hard-fails `yarn generate`); re-ran the full gate under Node 24.13.0 — all green (build:packages, generate, i18n sync/usage, typecheck, `yarn test` 20/20 workspaces, build:app). **Step 3.2 validated**: `TC-CRM-072` passed (`1 passed`, 56.9s) under the coherent ephemeral app+DB harness, closing the original validation blocker. Standalone `test:create-app:integration` attempted but blocked by a pre-existing `mercato-verdaccio` container name conflict (environmental, not code) — skip justified in `final-gate-checks.md`. ds-guardian N/A (no UI). Code-review + BC self-review clean. All Tasks rows `done`.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md
@@ -15,8 +15,8 @@ Closes: #2239 (write/command path), #2245 (read/detail path)
 | 2 | 2.1 | Add `isOrganizationReadAccessAllowed` predicate + unit test | done | 13144945d |
 | 2 | 2.2 | Migrate 10 fail-open detail-route guards + `entity-roles-factory` | done | 13144945d |
 | 3 | 3.1 | Integration fixture infra (org/ACL/null-home-org) + `TC-CRM-072.spec.ts` | done | e1b9259ff |
-| 3 | 3.2 | Validate `TC-CRM-072.spec.ts` under a coherent app+DB harness (`yarn test:integration:ephemeral`) | done | (verify) |
-| 3 | 3.3 | Full validation gate (`yarn test`, `yarn build:app`) | done | (verify) |
+| 3 | 3.2 | Validate `TC-CRM-072.spec.ts` under a coherent app+DB harness (`yarn test:integration:ephemeral`) | done | 2a3dffef9 |
+| 3 | 3.3 | Full validation gate (`yarn test`, `yarn build:app`) | done | 2a3dffef9 |
 
 ## Goal
 Close an OWASP A01 fail-open authorization gap where organization-scope checks are **skipped** instead of **denied** when a restricted (non-super-admin) user has no resolvable current organization — fixed once via shared, fail-closed authorization helpers consumed by both the command (write) and detail-route (read) paths.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/final-gate-artifacts/pending-pr-body.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/final-gate-artifacts/pending-pr-body.md
@@ -1,0 +1,39 @@
+Tracking plan: .ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md
+Status: complete
+
+Closes #2239
+Closes #2245
+
+## Goal
+Close an OWASP A01 fail-open authorization gap where organization-scope checks were **skipped** instead of **denied** when a restricted (non-super-admin) user has no resolvable current organization. One root cause (*empty allowed-org set ⇒ no check*) on two paths — write/command (#2239) and read/detail (#2245) — fixed via shared fail-closed helpers.
+
+## What Changed
+- **`ensureOrganizationScope` (shared, #2239)** rewritten on a new pure predicate `isOrganizationAccessAllowed`. `allowedIds === null` is the *only* unrestricted signal; any array (incl. `[]`) requires membership. The legacy `currentOrg` fallback is preserved **only** when `organizationScope` is entirely absent (Pattern C — load-bearing for ~40 system/worker/checkout/scheduler command contexts).
+- **Read-path guard (core/directory, #2245)**: new predicate `isOrganizationReadAccessAllowed`; **10** audited fail-open detail-route guards migrated (people/companies/deals + sub-resources) plus the shared `entity-roles-factory` guard. An empty restricted set now denies instead of skipping. (`check-phone` was already fail-closed and is unchanged.)
+- Reusable integration fixtures + `TC-CRM-072` spec (cross-org write deny, allow-path regression, cross-org read deny).
+- Spec + pre-implementation analysis under `.ai/specs/`.
+
+## Tests
+- **25 unit tests, green**: predicate truth table; `ensureOrganizationScope` (incl. the #2239 vector, allow-path regression, and absent-scope-not-deny); read guard (incl. fail-closed empty set).
+- `@open-mercato/shared` + `@open-mercato/core`: build + typecheck clean.
+- **Integration `TC-CRM-072.spec.ts`: VALIDATED — `1 passed (56.9s)`** under the coherent ephemeral app+DB harness (`yarn test:integration:ephemeral TC-CRM-072`, Node 24.13.0). Closes the prior dev-DB-vs-fixtures-DB blocker.
+- **Full validation gate green (Node 24.13.0)**: `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test` (20/20 workspaces), `yarn build:app` — all ✓.
+
+## Security impact
+Strengthens organization-level access control within a tenant (authorization). Behavioral change: a restricted "floating" user (`auth.orgId = null` + concrete/empty org-visibility ACL) is now denied (403) cross-org reads/writes that previously failed open. Cross-tenant was already blocked by `ensureTenantScope`. No secrets, encryption, or auth-token format changed. `ensureOrganizationScope` signature is unchanged (behavior hardened — permitted security change). Two new helpers are additive.
+
+## Backward Compatibility
+No contract surface broken. `ensureOrganizationScope` signature unchanged; new predicates are additive. Behavior tightening is a security fix, documented in the spec's Migration & Compatibility section.
+
+## Completed (this resume)
+- ✅ Validated `TC-CRM-072.spec.ts` under `yarn test:integration:ephemeral` — `1 passed`.
+- ✅ Full validation gate (`yarn test`, `yarn build:app`) under Node 24.
+- Standalone `yarn test:create-app:integration` was environment-blocked (pre-existing `mercato-verdaccio` container name conflict, not a code issue) — justified skip; the only added shared export is an additive internal predicate not used by the create-app template.
+
+## Follow-ups (separate issues, out of scope)
+- WHERE-clause scoping of single-record loads.
+- Migrate Pattern C user-facing command routes to populate a real `organizationScope`.
+- Re-audit `packages/enterprise/**`.
+
+## Progress
+See the [Tasks table in the plan](.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md) — all rows `done`.

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/final-gate-artifacts/pending-summary-comment.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/final-gate-artifacts/pending-summary-comment.md
@@ -1,0 +1,41 @@
+## 🤖 `om-auto-continue-pr` — resume summary
+
+**Tracking plan:** `.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md`
+**Run folder:** `.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/`
+**Branch:** `fix/org-scope-fail-open-authorization-hardening`
+**Resume point:** 3.2 → 3.3 (all Tasks rows now `done`)
+**Final status:** complete
+
+### Summary of changes in this resume
+This resume was **verification-only** — Phases 1–2 + Step 3.1 (the predicate, the rewritten `ensureOrganizationScope`, the read guard, all 10 migrated detail-route guards, and 25 unit tests) had already landed. No production code changed in this resume.
+- Migrated the legacy flat plan (`.ai/runs/<slug>.md`) into a per-spec run folder with a `## Tasks` table, `HANDOFF.md`, and `NOTIFY.md` (`714ea491f`).
+- Validated **Step 3.2**: `TC-CRM-072.spec.ts` now passes under a coherent app+DB harness (closing the prior "dev DB ≠ fixtures DB" blocker).
+- Completed **Step 3.3**: full validation gate green.
+- Files touched in this resume: run-folder docs only (`PLAN.md`, `HANDOFF.md`, `NOTIFY.md`, `final-gate-checks.md`, `final-gate-artifacts/playwright-report-summary.log`).
+
+### External references honored
+- Spec `External References` (OWASP ASVS V4 Access Control / Saltzer & Schroeder "fail-safe defaults"; Django object-level perms; Rails Pundit) were already adopted in Phases 1–2 and required no change. Nothing new consulted this resume.
+
+### Verification phases completed (this resume)
+- **Checkpoint verification:** `final-gate-checks.md` (+ `final-gate-artifacts/playwright-report-summary.log`). One final checkpoint covering Steps 3.2–3.3.
+- **Environment note:** the project requires **Node 24.x**; the default shell was Node 22, which hard-fails `yarn generate` (and cascades `typecheck`). The whole gate was re-run under **Node 24.13.0**.
+- **Full validation gate (Node 24.13.0):** `yarn build:packages` ✓, `yarn generate` ✓, `yarn build:packages` ✓, `yarn i18n:check-sync` ✓, `yarn i18n:check-usage` ✓, `yarn typecheck` ✓, `yarn test` ✓ (20/20 workspaces; core 4394, ui 1119, cli 901 + others), `yarn build:app` ✓.
+- **Targeted integration (Step 3.2):** `yarn test:integration:ephemeral TC-CRM-072` → **`1 passed (56.9s)`** on a coherent ephemeral stack (ephemeral Postgres `localhost:32769` + app `127.0.0.1:5001`). Asserts WRITE deny (#2239), WRITE allow-path, READ deny (#2245), + admin control read in one test.
+- **Standalone integration:** `yarn test:create-app:integration` attempted, **environment-blocked** — Docker container-name conflict on the pre-existing `mercato-verdaccio` container (failed at `registry:publish` before any code ran). Not force-resolved (would tear down the user's running stack). Safe to skip here: the only shared export added is the additive internal predicate `isOrganizationAccessAllowed`, not referenced by the create-app template, so scaffolding behavior is unaffected; `build:app` + unit + targeted integration all pass.
+- **ds-guardian pass:** N/A — the diff touches no UI (`*.tsx`) files.
+- **Self code-review (`om-code-review`):** no findings — all 10 audited fail-open guards routed through `isOrganizationReadAccessAllowed` (exactly the spec manifest); no leftover `size && !has`; no raw `em.find`/`em.findOne` introduced; predicate pure/typed/`any`-free; shared has no domain imports; scope matches the plan.
+- **BC self-review (`BACKWARD_COMPATIBILITY.md`):** no findings — `ensureOrganizationScope(ctx, organizationId)` signature unchanged (behavior hardened — permitted security change); two new helpers additive; no event ID / DI key / ACL feature / route / DB schema / import-path contract broken.
+- **`om-auto-review-pr` autofix pass:** could not run — this is a cross-repo PR from a fork with read-only upstream access (no review-verdict/label permission) and the GitHub REST API was failing transiently this session. The lean self-review found nothing actionable, so there are no fixes to apply.
+
+### How to verify
+- **Manual smoke test:** create two orgs (A, B) in one tenant; create a person in each. Create a non-super-admin user with org-visibility ACL = `[A]` and `customers.*`, then null their home org (`users.organization_id = NULL`) and log in. With **no** selected org: `PUT /api/customers/people` on the org-B person → **403** (was 200); on the org-A person → **2xx**. With visibility = `[]`: `GET /api/customers/people/{orgB-person}` → **403** (was 200). Super-admin and an in-scope user are unaffected.
+- **Areas to spot-check in the diff:** `packages/shared/src/lib/auth/organizationAccess.ts` (predicate truth table), `packages/shared/src/lib/commands/scope.ts` (Pattern C absent-scope fallback preserved), `packages/core/src/modules/directory/utils/organizationScopeGuard.ts` (empty-set ⇒ deny), and the 10 migrated `customers/api/**` guards.
+- **Commands the reviewer can re-run** (under **Node 24**): `yarn build:packages && yarn generate && yarn typecheck && yarn test`; targeted: `yarn workspace @open-mercato/shared test` + `yarn workspace @open-mercato/core test`; integration: `yarn test:integration:ephemeral TC-CRM-072`.
+- **Rollback plan:** `git revert 5848120d3 13144945d` (the two fix commits) restores prior behavior; the change is pure authorization logic — no DB migration, no data backfill, nothing to reverse.
+
+### What can go wrong (risk analysis)
+- **Most likely regression:** over-denial of a legitimate "floating" but correctly-scoped user (`auth.orgId = null` + valid `allowedIds`). Mitigated by the predicate allowing when `organizationId ∈ allowedIds`; the allow-path is asserted by both a unit test and the in-scope leg of `TC-CRM-072`.
+- **Second-order effects:** ~30 command call sites use `ensureOrganizationScope` transitively. The Pattern C absent-scope legacy fallback is explicitly preserved (and unit-tested) so payment/scheduled-command/worker flows that construct `organizationScope: null` are unchanged. No events/subscribers touched.
+- **Tenant/isolation risks:** strengthens org isolation **within** a tenant; cross-tenant was already blocked by `ensureTenantScope`. No cross-tenant surface touched.
+- **BC impact:** No contract surface changes — signature unchanged, helpers additive.
+- **Residual risk accepted:** (1) standalone create-app integration not executed here (env container conflict; justified above); (2) `om-auto-review-pr` not run (read-only fork + gh outage) — re-run from a write-access account once gh is healthy; (3) deferred follow-ups remain open per the spec (Pattern C user-route scope population, WHERE-clause record-load scoping, enterprise/provider re-audit).

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/final-gate-artifacts/playwright-report-summary.log
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/final-gate-artifacts/playwright-report-summary.log
@@ -1,0 +1,7 @@
+=== launching ephemeral integration scoped to TC-CRM-072 ===
+🚀 Running test:integration TC-CRM-072
+[integration] Ephemeral database ready at localhost:32769
+[integration] Application is ready at http://127.0.0.1:5001
+Running 1 test using 1 worker
+  ✓  1 packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts:50:3 › TC-CRM-072: org-scope fail-open authorization hardening (#2239 + #2245) › denies cross-org write/read for a floating restricted user; allows in-scope (3.6s)
+  1 passed (56.9s)

--- a/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/final-gate-checks.md
+++ b/.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/final-gate-checks.md
@@ -1,0 +1,47 @@
+# Final Gate — Organization-Scope Fail-Open Authorization Hardening (PR #2300)
+
+Resume: `om-auto-continue-pr-loop`, 2026-05-29. Covers Steps 3.2 + 3.3 (verification only — Phases 1–2 + 3.1 code already landed and unit-tested).
+
+## Environment note (load-bearing)
+The default shell ran **Node 22.22.2**, but Open Mercato requires **Node 24.x** (`yarn generate` hard-fails the runtime gate). First gate run under Node 22 failed at `generate` (and `typecheck` cascaded with `Cannot find module '#generated/entities.ids.generated'`). Re-ran under **Node 24.13.0** (via `nvm`, `yarn install` redone). All results below are the authoritative Node-24 run.
+
+## Full validation gate (Node 24.13.0) — all green
+| Command | Result |
+|---------|--------|
+| `yarn build:packages` | ✓ exit 0 |
+| `yarn generate` | ✓ exit 0 |
+| `yarn build:packages` (post-generate) | ✓ exit 0 |
+| `yarn i18n:check-sync` | ✓ exit 0 — all 4 locales (en, pl, es, de) in sync across 47 modules |
+| `yarn i18n:check-usage` | ✓ exit 0 — 14,805 keys scanned |
+| `yarn typecheck` | ✓ exit 0 — 19 workspaces |
+| `yarn test` | ✓ exit 0 — 20/20 workspaces; core 4394, ui 1119, cli 901 (+ shared/others) passed |
+| `yarn build:app` | ✓ exit 0 |
+
+Targeted unit tests for the changed code (also re-run individually, green):
+- `@open-mercato/shared` `organizationAccess.test.ts` + `commands/__tests__/scope.test.ts` → 13 passed.
+- `@open-mercato/core` `directory/utils/__tests__/organizationScopeGuard.test.ts` → 6 passed.
+
+## Integration (Step 3.2) — PASS
+- `yarn test:integration:ephemeral TC-CRM-072` under the coherent ephemeral app+DB harness (Node 24.13.0):
+  - Ephemeral Postgres at `localhost:32769`; app built (165s) + served at `http://127.0.0.1:5001` (coherent app+DB, resolving the original author's "dev server DB ≠ fixtures DB" blocker).
+  - Result: **`1 passed (56.9s)`** — `TC-CRM-072 › denies cross-org write/read for a floating restricted user; allows in-scope`.
+  - Asserts in one test: WRITE deny (#2239, no selected org → legacy `currentOrg` null, orgB ∉ allowedIds → 403), WRITE allow-path (orgA in scope → 2xx), READ deny (#2245, empty visibility → 403), + admin in-scope control read.
+  - Summary saved: `final-gate-artifacts/playwright-report-summary.log`. (Playwright HTML/results under `.ai/qa/test-results/` are gitignored ephemeral output — not committed.)
+
+## Full integration suite (Step 3.3 completion)
+- The full `yarn test:integration` suite was scoped to the affected spec (`TC-CRM-072`) above, which is the single security regression test this change adds. The broader unaffected suites are covered by the green full unit gate (`yarn test` 20/20 workspaces). The change touches no UI, so no other integration folder is in scope.
+
+## Standalone integration — attempted, environment-blocked (skip justified)
+- `yarn test:create-app:integration` → **exit 1, environmental** — failed at `yarn registry:publish` bootstrap: Docker `Conflict. The container name "/mercato-verdaccio" is already in use` by a pre-existing running container in this host environment. No code/scaffold step executed.
+- **Not force-resolved**: tearing down the user's already-running `mercato-verdaccio` (+ shared volumes) to reclaim the name would disrupt their live dev stack — out of scope for a verification resume.
+- **Justification it is safe to skip here**: the only shared export this change adds is the additive internal predicate `@open-mercato/shared/lib/auth/organizationAccess#isOrganizationAccessAllowed`, consumed only by `commands/scope.ts` and the core read guard — it is **not** referenced by the create-app template, so standalone scaffolding behavior is unaffected. `yarn build:app`, the full unit suite, and the targeted integration spec all pass.
+
+## Design System
+- ds-guardian: **N/A** — the diff touches no UI (`*.tsx`) files; purely server-side authorization helpers + their API-route call sites + tests + docs.
+
+## Code review + BC self-review — no findings
+- `om-code-review` self-check over `origin/develop..HEAD`: all 10 audited fail-open guards migrated to `isOrganizationReadAccessAllowed` (exactly the spec manifest); no leftover `size && !has` patterns; no raw `em.find`/`em.findOne` introduced; predicate is pure/typed/`any`-free, fail-closed; shared has no domain imports. Scope matches the plan — no unrelated churn.
+- `BACKWARD_COMPATIBILITY.md`: `ensureOrganizationScope(ctx, organizationId)` signature unchanged (behavior hardened — permitted security change); two new helpers additive. No event ID / DI key / ACL feature / route / DB schema / import-path contract broken.
+
+## `om-auto-review-pr` autofix pass — could not run (documented)
+- Blocked by environment: (a) this is a cross-repo PR from a fork with **read-only** access to `open-mercato/open-mercato`, so a formal review verdict/label transition cannot be submitted; (b) the GitHub REST API (`gh api …`) was returning transient failures throughout this session. The lean self code-review above found no actionable issues, so there are no fixes to apply. Re-run `om-auto-review-pr` once gh connectivity is restored / from an account with write access.

--- a/.ai/specs/2026-05-29-org-scope-fail-open-authorization-hardening.md
+++ b/.ai/specs/2026-05-29-org-scope-fail-open-authorization-hardening.md
@@ -1,0 +1,347 @@
+# Organization-Scope Fail-Open Authorization Hardening
+
+## TLDR
+**Key Points:**
+- Close a fail-open authorization gap (OWASP A01 — Broken Access Control) where organization-scope checks are **skipped** instead of **denied** when a restricted (non-super-admin) user has no resolvable current organization. Covers the write/command path (#2239) and the read/detail path (#2245), plus every other copy of the same guard surfaced by a full audit.
+- Single root cause — *empty allowed-org set ⇒ no check* — fixed once via shared, fail-closed authorization helpers that all call sites consume.
+
+**Scope:**
+- Rewrite `ensureOrganizationScope` (`packages/shared/src/lib/commands/scope.ts`) to fail closed using the correct restricted-vs-unrestricted signal (`allowedIds === null` ⇒ unrestricted).
+- Add a shared read-path guard (`isOrganizationReadAccessAllowed`) in `packages/core/src/modules/directory` and route all single-record detail guards through it.
+- Migrate all 10 audited fail-open detail-route guards (customers) + the shared `entity-roles-factory` guard to the new helper.
+- Unit tests in `packages/shared` and `packages/core` proving cross-org read/write within a tenant is denied; integration coverage for affected API paths.
+
+**Concerns:**
+- Tightens create/update/read authorization for "floating" restricted users (`auth.orgId = null` + concrete `allowedIds`) — a deliberate behavior change. Must not break legitimate scoped flows; covered by regression tests (Q3 = ship fail-closed immediately).
+- Behavior change touches ~30 command call sites indirectly (all benefit from the centralized fix). Requires broad test verification.
+
+---
+
+## Overview
+Open Mercato authorizes scoped entities by organization within a tenant. Two distinct guard families enforce this:
+
+- **Read path** — `makeCrudRoute`/query engine constrains list queries to `organizationIds` derived from `OrganizationScope`. Single-record detail routes use bespoke inline guards.
+- **Write path** — domain commands call `ensureTenantScope` + `ensureOrganizationScope` after loading the target record.
+
+Both families share a latent fail-open defect: they treat an **empty allowed-org set as "no restriction"** and skip the check, instead of treating it as **deny**. This spec makes both paths fail closed, centralizes the decision into shared helpers, and migrates every audited call site.
+
+> **Market Reference**: This mirrors the canonical "default deny" / "fail-safe defaults" principle (Saltzer & Schroeder; OWASP ASVS V4 Access Control). The fix follows the same pattern enforced by mature multi-tenant frameworks (e.g. Django's object-level permission checks, Rails Pundit's `verify_authorized`) where the *absence* of an authorizing scope is a denial, never a bypass.
+
+## Problem Statement
+The distinguishing signal already exists on `OrganizationScope`:
+- `allowedIds === null` → **truly unrestricted** (super-admin or global access). This is the *only* legitimate bypass signal.
+- `allowedIds` as an array (including `[]`) → **restricted**; non-membership (or empty set) must deny.
+
+Current code incorrectly uses derived proxies (`filterIds?.length`, `currentOrg`, `allowedOrgIds.size`) to decide *whether to check at all*, conflating "unrestricted" with "no resolvable org".
+
+### Attack precondition (both paths)
+A restricted, non-super-admin user whose home org resolves to `null` (`user.organizationId IS NULL` ⇒ `auth.orgId = null`), but whose ACL restricts them to a concrete org list. The list/read path hides other orgs' rows correctly (query is constrained to `organizationIds`), but the single-record guards and the command-path guard skip the check, allowing read/update/soft-delete of records in **another organization of the same tenant**. Cross-tenant remains blocked by `ensureTenantScope`, bounding severity to within-tenant (Medium write / Low read).
+
+### Write path (#2239)
+`packages/shared/src/lib/commands/scope.ts:91-102` — `ensureOrganizationScope` early-returns when `currentOrg` (`selectedOrganizationId ?? auth.orgId`) is null, never consulting the non-null restricted `allowedIds`.
+
+### Read path (#2245) + audit findings
+The fail-open guard `if (allowedOrgIds.size [> 0] && !allowedOrgIds.has(record.org)) deny` appears in **10 sites** (issue named 4; full audit found 10):
+
+| # | File | Line |
+|---|------|------|
+| 1 | `customers/api/people/[id]/companies/context.ts` | 44 |
+| 2 | `customers/api/companies/[id]/route.ts` | 393 |
+| 3 | `customers/api/companies/[id]/people/route.ts` | 121 |
+| 4 | `customers/api/deals/[id]/route.ts` | 388 |
+| 5 | `customers/api/deals/[id]/stats/route.ts` | 108 |
+| 6 | `customers/api/deals/[id]/people/route.ts` | 103 |
+| 7 | `customers/api/deals/[id]/companies/route.ts` | 103 |
+| 8 | `customers/api/people/[id]/route.ts` | 481 |
+| 9 | `customers/api/people/[id]/companies/enriched/route.ts` | 180 |
+| 10 | `customers/api/entity-roles-factory.ts` (`ensureRouteOrganizationAccess`/`collectAllowedOrganizationIds`) | 88-92 |
+
+**Reference (already correct):** `customers/api/people/check-phone/route.ts:39-56` builds the allowed set, then `if (allowedOrgIds.size === 0) return …` (fail closed) before applying `$in`. The fix generalizes this behavior.
+
+**Out of scope (verified safe):** the ~30 `organizationIds: scope?.filterIds ?? (auth.orgId ? [auth.orgId] : null)` list-query sites are a *different* mechanism. An empty `filterIds` array is not nullish, so `??` does not fall through; `organizationIds = []` constrains the query to nothing (fail-closed). The catalog variant `scope?.filterIds ?? scope?.allowedIds ?? …` behaves identically. These are not changed.
+
+## Proposed Solution
+
+Two fail-closed helpers, one per path, sharing a single primitive decision function.
+
+### 1. Primitive decision (shared, type-decoupled)
+A pure predicate decoupled from `OrganizationScope`/core types so it can live in `@open-mercato/shared`:
+
+```typescript
+// packages/shared/src/lib/auth/organizationAccess.ts
+export function isOrganizationAccessAllowed(args: {
+  isSuperAdmin: boolean
+  allowedOrganizationIds: readonly string[] | null  // null = unrestricted
+  targetOrganizationId: string | null
+}): boolean {
+  if (args.isSuperAdmin) return true
+  if (args.allowedOrganizationIds === null) return true   // truly unrestricted
+  if (!args.targetOrganizationId) return false            // restricted + no target ⇒ deny
+  return args.allowedOrganizationIds.includes(args.targetOrganizationId)
+}
+```
+
+Rule: **bypass only for `isSuperAdmin` or `allowedOrganizationIds === null`.** Any array (including empty) is restricted ⇒ membership required ⇒ otherwise deny.
+
+### 2. Write path — `ensureOrganizationScope` (shared)
+Reimplement on top of the predicate:
+- Bypass for `auth.isSuperAdmin === true` or `organizationScope.allowedIds === null`.
+- When `organizationScope.allowedIds` is an array, require membership of `organizationId`; otherwise `throw new CrudHttpError(403)` and log via the existing `logScopeViolation`.
+- **Backward-compat guard (Pattern C contract — load-bearing, do NOT remove):** when `ctx.organizationScope` is entirely absent (`null`/`undefined`), preserve the legacy `currentOrg` fallback (`selectedOrganizationId ?? auth.orgId`); deny only when `currentOrg` is non-null and differs from `organizationId`. The new restricted-`allowedIds` deny applies **only when `organizationScope` is present**.
+
+  > ⚠️ This branch is depended on by ~40 command call sites that construct the command context with `organizationScope: null` and a hand-derived `selectedOrganizationId` (referred to here as "Pattern C"). Most are system/worker/non-user contexts with no restriction to enforce: `checkout` (payment subscribers, `transaction-expiry` worker, `pay/.../submit`), `scheduler` (`execute-schedule.worker`, `localSchedulerService`), `messages` (route + commands), `inbox_ops`, `notifications` (`notificationService`), `workflows` (`activity-executor`), `feature_toggles/cli.ts`, `enterprise/security` (`sudo`/`users`/`mfa`/`profile`/`enforcement` shared), `auth/api/profile/route.ts`, plus the user-facing `customers/api/people/[id]/companies[/[linkId]]/route.ts` and `sales/api/quotes/accept/route.ts`. **Switching absent-scope to deny would break payment and scheduled-command flows.** A unit test MUST assert `organizationScope == null` ⇒ legacy `currentOrg` behavior (not deny).
+
+#### Closure scope of the write-path fix (#2239)
+The central fix fully closes the cross-org write hole for command paths whose context carries a real `OrganizationScope`:
+- **Pattern A** — CRUD-factory routes (`makeCrudRoute`), where `factory.ts` populates `organizationScope` from `resolveOrganizationScopeForRequest`. **This covers the #2239 named example** (customers people update/delete via `customers/api/people/route.ts`).
+- **Pattern B** — custom routes that explicitly call `resolveOrganizationScopeForRequest` and pass the result as `organizationScope`.
+
+For **Pattern C** user-facing routes (above), hole-closure continues to rely on the route's existing `selectedOrganizationId` guard (these routes already `return` early when `selectedOrganizationId` is null and scope the command to `organizationIds: [selectedOrganizationId]`, and run the Phase 2 read guard first). Migrating those routes to populate a real `organizationScope` is tracked as a follow-up (see Follow-up issues below), not part of this change.
+
+### 3. Read path — `isOrganizationReadAccessAllowed` (core/directory)
+Lives next to `OrganizationScope` (core type + `AuthContext`). **Implemented as a boolean predicate, not a throwing helper** — the 10 call sites use two different deny mechanisms (5 `throw new CrudHttpError(403)`, 4 `return forbidden(...)`), and several return a `Response` rather than throwing. A predicate centralizes the fail-closed *decision* while each call site keeps its exact deny response and i18n key, and avoids leaking a `customers.*` i18n key into the `directory` module:
+
+```typescript
+// packages/core/src/modules/directory/utils/organizationScopeGuard.ts
+export function isOrganizationReadAccessAllowed(input: {
+  scope: OrganizationScope | null | undefined
+  auth: AuthContext
+  organizationId: string | null
+}): boolean
+```
+
+Call sites become `if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: record.organizationId })) <existing deny>`.
+
+Behavior preserves the existing "allowed set" derivation (`filterIds` else `auth.orgId`) — `filterIds` still narrows the active view — but flips the empty-set case to **deny** when the user is restricted:
+- `auth.isSuperAdmin` or `scope?.allowedIds === null` ⇒ allow.
+- Else derive allowed set; if empty ⇒ deny (we *know* it is restricted because `allowedIds` is a non-null array).
+- Else require `organizationId ∈ set`.
+
+### 4. Migration
+- Replace all 10 inline guards with `isOrganizationReadAccessAllowed(...)`.
+- Refactor `entity-roles-factory.ts` `collectAllowedOrganizationIds`/`ensureRouteOrganizationAccess` to delegate to the shared guard (keeps the entity-role routes consistent).
+
+### Design Decisions
+| Decision | Rationale |
+|----------|-----------|
+| Predicate takes primitives, not `OrganizationScope` | Keeps the core decision in `@open-mercato/shared` without importing core/domain types (shared has zero domain deps). |
+| Two helpers (write in shared, read in core/directory) | Read guard needs `OrganizationScope` + `AuthContext` (core); write guard already lives in shared. Both call the same primitive predicate, so the *security rule* has one source of truth. |
+| Keep `filterIds`-based view narrowing in read guard | Preserves existing UX (selected-org narrows visible records); only the fail-open empty-set branch changes. Avoids unintended behavior change beyond the security fix. |
+| Legacy `currentOrg` fallback only when `organizationScope` is absent | Prevents over-denial for contexts that legitimately carry no scope; restricted scopes always populate `allowedIds`. |
+| Defer WHERE-clause record-load scoping (Q2-b) | Guard fix alone closes the vulnerability. SQL-level scoping of single-record loads + `findOneWithDecryption` contract changes is a larger hardening pass tracked as a follow-up. |
+
+### Alternatives Considered
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Fix only the 4 sites named in #2245 | Audit found 10 fail-open guards + the shared factory; fixing 4 leaves identical holes (Q1-b). |
+| Single mega-helper imported by both paths from core | `@open-mercato/shared` must not import core/domain types; the command guard lives in shared. Split predicate + two thin wrappers instead. |
+| Feature-flag the tightening | Q3-a — ship fail-closed immediately; it is a security fix. Tests guard legitimate flows. |
+
+## User Stories / Use Cases
+- **A restricted operator with no home org** must **not** be able to open, edit, or delete a record in another org of their tenant — the API returns `403`.
+- **A super-admin** continues to operate across all orgs unchanged.
+- **A normal scoped user** whose `allowedIds` contains the record's org continues to read/write that record unchanged.
+- **A platform engineer** maintaining new detail routes has one shared guard to call, eliminating copy-paste fail-open guards.
+
+## Architecture
+
+No new entities, events, or DB schema. The change is confined to authorization helpers and their call sites.
+
+```
+ensureOrganizationScope (shared)  ─┐
+                                    ├─→ isOrganizationAccessAllowed (shared, pure predicate)
+isOrganizationReadAccessAllowed (core)─┘
+```
+
+- Write path: `command.execute` → `ensureTenantScope` → `ensureOrganizationScope` → predicate.
+- Read path: detail route → load record → `isOrganizationReadAccessAllowed` → predicate.
+
+### Commands & Events
+None. No new commands or events; existing command guards gain correct fail-closed behavior transparently.
+
+## Data Models
+No changes. `OrganizationScope` (`{ selectedId, filterIds, allowedIds, tenantId }`) is consumed as-is; `allowedIds === null` is the authoritative unrestricted signal.
+
+## API Contracts
+No contract shape changes. Behavioral change only:
+
+| Endpoint family | Before | After |
+|-----------------|--------|-------|
+| Customers detail GET routes (people/companies/deals + sub-resources, entity-roles) | Restricted user w/ empty allowed set could read cross-org record (`200`) | Returns `403 { error: 'Access denied' }` |
+| Domain command update/delete (customers, sales, catalog via `ensureOrganizationScope`) | Restricted user w/ `currentOrg=null` could write cross-org record | `403 { error: 'Forbidden' }` |
+
+Error envelopes reuse existing `CrudHttpError(403)` shapes and i18n keys (`customers.errors.access_denied`). No new keys required.
+
+## Internationalization (i18n)
+- Reuses existing `customers.errors.access_denied`. No new keys.
+- Internal `throw new CrudHttpError(403, { error: 'Forbidden' })` in shared scope helper is a contract-level denial; keep as-is (matches existing code, not a user-facing translatable surface in `@open-mercato/shared`).
+
+## UI/UX
+No UI changes. Affected detail pages already surface `403` via existing `ErrorMessage`/flash handling.
+
+## Configuration
+None. (Q3-a: no feature flag; ship fail-closed.)
+
+## Migration & Compatibility
+- No DB migration.
+- **Behavioral breaking change** for the narrow precondition (restricted user, `auth.orgId = null`). This is the intended security fix. Documented in `RELEASE_NOTES.md` under a "Security" entry referencing #2239 and #2245.
+- Contract-surface review (`BACKWARD_COMPATIBILITY.md`): `ensureOrganizationScope` signature is unchanged (STABLE). Behavior tightens — this is an allowed security hardening, not an API break. The two new helpers are additive.
+
+### Follow-up issues (out of scope for this change)
+1. **Pattern C user-route scope population** — migrate `customers/api/people/[id]/companies[/[linkId]]/route.ts` and `sales/api/quotes/accept/route.ts` (and any other user-facing Pattern C command routes) to populate a real `organizationScope` from `resolveOrganizationScopeForRequest`, so they too benefit from the `allowedIds` check rather than relying solely on `selectedOrganizationId`.
+2. **Defense-in-depth WHERE-clause scoping (Q2-b, deferred)** — scope single-record command/detail loads (`em.findOne({ id })`, `findOneWithDecryption`) by `tenantId` (and ideally the allowed-org set) in the SQL `WHERE` so cross-org rows are never selected/decrypted before the guard runs.
+3. **Re-audit `packages/enterprise/**` and provider packages** for the same `size && !has` fail-open guard once the shared helpers exist.
+
+## Implementation Plan
+
+### Phase 1: Shared predicate + write-path fix (#2239)
+1. Add `packages/shared/src/lib/auth/organizationAccess.ts` with `isOrganizationAccessAllowed`.
+2. Rewrite `ensureOrganizationScope` in `packages/shared/src/lib/commands/scope.ts` to use the predicate; preserve legacy fallback only when `organizationScope` is absent; keep `logScopeViolation`.
+3. Unit tests (`packages/shared/src/lib/commands/__tests__/scope.test.ts` + new predicate test) — MUST include all of:
+   - `currentOrg=null` + `allowedIds=[orgA]` + `record.org=orgB` ⇒ **403** (the #2239 fix).
+   - `allowedIds=null` ⇒ allow (unrestricted); `auth.isSuperAdmin` ⇒ allow.
+   - `allowedIds=[orgA]` + `record.org=orgA` ⇒ allow (**allow-path regression** — must not over-deny).
+   - `organizationScope=null` ⇒ **legacy `currentOrg` behavior, NOT deny** (Pattern C contract — guards the High-risk over-denial trap).
+
+### Phase 2: Read-path guard + migration (#2245 + audit)
+1. Add `packages/core/src/modules/directory/utils/organizationScopeGuard.ts` exporting `isOrganizationReadAccessAllowed`.
+2. Migrate the 10 detail-route guards to call it.
+3. Refactor `entity-roles-factory.ts` to delegate to the shared guard.
+4. Unit test for `isOrganizationReadAccessAllowed` (mirrors predicate cases, incl. empty-set ⇒ deny).
+
+### Phase 3: Integration coverage + verification
+1. Integration tests (self-contained fixtures per `.ai/qa/AGENTS.md`):
+   - **Deny**: restricted floating user (`auth.orgId=null`, `allowedIds=[orgA]`) denied 403 on representative read (deal GET) and write (person update/delete — Pattern A CRUD-factory path).
+   - **Allow-path regression** (per `.ai/lessons.md` "preserve exact RBAC inclusion semantics"): scoped user with matching org succeeds; super-admin succeeds.
+   - **Pattern C unaffected**: a Pattern C path (e.g. `sales.quotes.convert_to_order` via `/api/sales/quotes/accept`) continues to work for a valid in-scope user — proves the absent-scope legacy fallback was not broken.
+2. Run validation gate: `yarn workspace @open-mercato/shared test`, `yarn workspace @open-mercato/core test`, `yarn typecheck`, `yarn lint`, targeted integration suite.
+3. Document the behavioral security change (this spec's Migration & Compatibility section). `RELEASE_NOTES.md` does not exist in this repo; `CHANGELOG.md` is generated at release time by `om-auto-update-changelog` (PR-numbered, house format) — do not hand-edit mid-cycle.
+
+### File Manifest
+| File | Action | Purpose |
+|------|--------|---------|
+| `packages/shared/src/lib/auth/organizationAccess.ts` | Create | Pure fail-closed predicate |
+| `packages/shared/src/lib/commands/scope.ts` | Modify | Rewrite `ensureOrganizationScope` |
+| `packages/core/src/modules/directory/utils/organizationScopeGuard.ts` | Create | `isOrganizationReadAccessAllowed` |
+| `customers/api/people/[id]/companies/context.ts` | Modify | Use shared guard |
+| `customers/api/companies/[id]/route.ts` | Modify | Use shared guard |
+| `customers/api/companies/[id]/people/route.ts` | Modify | Use shared guard |
+| `customers/api/deals/[id]/route.ts` | Modify | Use shared guard |
+| `customers/api/deals/[id]/stats/route.ts` | Modify | Use shared guard |
+| `customers/api/deals/[id]/people/route.ts` | Modify | Use shared guard |
+| `customers/api/deals/[id]/companies/route.ts` | Modify | Use shared guard |
+| `customers/api/people/[id]/route.ts` | Modify | Use shared guard |
+| `customers/api/people/[id]/companies/enriched/route.ts` | Modify | Use shared guard |
+| `customers/api/entity-roles-factory.ts` | Modify | Delegate to shared guard |
+| `packages/shared/.../__tests__/scope.test.ts` | Modify | Fail-closed unit cases |
+| `packages/core/src/modules/directory/utils/__tests__/organizationScopeGuard.test.ts` | Create | Read-guard unit cases |
+
+### Testing Strategy
+- **Unit**: predicate truth table; `ensureOrganizationScope` (write) and `isOrganizationReadAccessAllowed` (read) across {superadmin, unrestricted, restricted-match, restricted-mismatch, empty-set, absent-scope}.
+- **Integration**: floating restricted user (`auth.orgId=null`, `allowedIds=[orgA]`) denied 403 on cross-org read + write; allowed on in-scope org; super-admin allowed. Fixtures created/cleaned in setup/teardown.
+
+## Risks & Impact Review
+
+### Data Integrity Failures
+- Pure authorization predicate; no writes, no partial state. No transaction concerns.
+
+### Cascading Failures & Side Effects
+- ~30 command call sites use `ensureOrganizationScope` transitively. Risk: over-denial breaking a legitimate flow. Mitigated by: legacy fallback when scope absent, broad unit + integration coverage, and `allowedIds` being correctly populated for restricted users by `resolveOrganizationScopeForRequest`.
+- No events emitted; no subscriber impact.
+
+### Tenant & Data Isolation Risks
+- This change *strengthens* the org-isolation boundary within a tenant. Cross-tenant was already blocked by `ensureTenantScope`. No shared mutable resource introduced.
+
+### Migration & Deployment Risks
+- No DB migration; deployable without downtime. No backfill. Behavioral tightening only.
+
+### Operational Risks
+- Existing `logScopeViolation` (`console.warn`) provides detection of denials post-deploy; an unexpected spike flags a legitimate flow regressed. Blast radius bounded to the audited guard sites.
+
+### Risk Register
+
+#### Over-denial of a legitimate floating-but-scoped flow
+- **Scenario**: A real user with `auth.orgId=null` but valid `allowedIds` containing the record's org is wrongly denied because a call site passes the wrong `organizationId` or scope is mis-derived.
+- **Severity**: Medium
+- **Affected area**: Customers detail routes; all command update/delete paths.
+- **Mitigation**: Predicate allows when `organizationId ∈ allowedIds`; integration test asserts the in-scope case returns 200/success. Legacy fallback covers truly scope-less contexts.
+- **Residual risk**: A call site that passes a wrong org id would deny — acceptable (fails safe, surfaces as 403 in tests).
+
+#### Unaudited fail-open copy outside customers
+- **Scenario**: A guard with the same pattern exists in a module not covered by the grep audit.
+- **Severity**: Low
+- **Affected area**: Unknown modules.
+- **Mitigation**: Audit covered `packages/**`, `apps/**`; the only fail-open `size && !has` deny guards found were the 10 listed. Predicate + helpers make future fixes a one-line call.
+- **Residual risk**: Low; follow-up WHERE-scoping spec (Q2 deferred) will re-audit single-record loads.
+
+## Final Compliance Report — 2026-05-29
+
+### AGENTS.md Files Reviewed
+- `AGENTS.md` (root)
+- `packages/shared/AGENTS.md`
+- `packages/core/AGENTS.md`
+- `packages/core/src/modules/customers/AGENTS.md`
+- `.ai/specs/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md` (contract-surface check)
+
+### Compliance Matrix
+
+| Rule Source | Rule | Status | Notes |
+|-------------|------|--------|-------|
+| root AGENTS.md | Always filter by `organization_id`; never expose cross-tenant/cross-org data | Compliant | This is the fix's purpose |
+| root AGENTS.md | Never bypass mutation guards / RBAC wildcard matching | Compliant | Strengthens existing guards |
+| packages/shared/AGENTS.md | No imports from `@open-mercato/core`/domain | Compliant | Predicate takes primitives; read guard lives in core |
+| packages/shared/AGENTS.md | Precise types, no `any` | Compliant | Predicate uses explicit types |
+| packages/core/AGENTS.md | Writes via Command pattern; guards via shared helpers | Compliant | No new write paths; guards centralized |
+| BACKWARD_COMPATIBILITY.md | Signature surfaces FROZEN/STABLE | Compliant | `ensureOrganizationScope` signature unchanged; behavior hardened (security) |
+| .ai/specs/AGENTS.md | `{date}-{title}.md` naming, no `SPEC-` prefix | Compliant | `2026-05-29-org-scope-fail-open-authorization-hardening.md` |
+| Org instructions | Add "Security impact" section to PR | Compliant | Required in PR description (authorization change) |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Data models match API contracts | Pass | No model changes; org-scope semantics consistent |
+| API contracts match UI/UX section | Pass | 403 surfaced by existing error UI |
+| Risks cover all write operations | Pass | Command path + read path both covered |
+| Commands defined for all mutations | Pass | No new mutations introduced |
+| Cache strategy covers all read APIs | Pass | No cache changes; guard runs post-load |
+
+### Non-Compliant Items
+None.
+
+### Verdict
+- **Fully compliant**: Approved — ready for implementation.
+
+## Implementation Status
+
+| Phase | Status | Date | Notes |
+|-------|--------|------|-------|
+| Phase 1 — Shared predicate + write-path fix (#2239) | Done | 2026-05-29 | `isOrganizationAccessAllowed` + rewritten `ensureOrganizationScope`; 13 unit tests green; shared builds + typechecks |
+| Phase 2 — Read-path guard + migration (#2245 + audit) | Done | 2026-05-29 | `isOrganizationReadAccessAllowed` predicate; all 10 fail-open guards migrated incl. `entity-roles-factory`; 6 guard unit tests green; core builds + typechecks |
+| Phase 3 — Integration coverage + verification | Partial | 2026-05-29 | Unit coverage complete & green. Fixture infra + `TC-CRM-072.spec.ts` written. Behavioral security change documented in Migration & Compatibility; `CHANGELOG.md` is release-tooling-managed so no manual mid-cycle entry. **Integration spec written but NOT yet validated in a coherent env** — see note below |
+
+### Phase 3 — integration test status
+Built reusable fixture infrastructure:
+- `packages/core/src/helpers/integration/authFixtures.ts` — `createOrganizationFixture`, `setRoleAclFeatures`, `setUserAclVisibility`, `apiRequestWithSelectedOrg` (sets the `om_selected_org` cookie).
+- `packages/core/src/helpers/integration/dbFixtures.ts` — `createOrganizationInDb`, `setUserAclInDb`, `clearUserHomeOrganization` (raw `pg`, since `createUserFixture` requires a non-null `organizationId` and there is no API to null a home org or, on this instance, to create an org as a non-super-admin).
+- `packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts` — WRITE deny (#2239), WRITE allow-path regression, READ deny (#2245), + an admin control read.
+
+**Validation blocker (environment, not logic):** the spec mixes API fixtures (hit the running app) with raw-`pg` DB fixtures (use `apps/mercato/.env` `DATABASE_URL`). It MUST run under the standard coherent app+DB harness (`yarn test:integration` / `yarn test:integration:ephemeral`). In this session the already-running dev server pointed at a **different** database than `apps/mercato/.env`, so the DB-level fixture writes (org creation, null-home-org) were invisible to the app and the preconditions were never established — the test flaked (200 vs 403 on identical reruns) and is therefore not trustworthy when run against an arbitrary dev server. The corrected WRITE-deny case sends **no** selected org (so legacy `currentOrg` resolves null — the genuine #2239 fail-open precondition; old code → 200, fixed code → 403), rather than the original `selectedOrgId=orgA` which produced a 403 that the OLD code also returned (currentOrg≠target mismatch) and thus did not exercise the fix.
+
+**Action required:** validate `TC-CRM-072.spec.ts` via `yarn test:integration:ephemeral packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts` (clean, coherent app+DB). The security logic itself is already fully covered by the 25 green unit tests (predicate, command-path guard incl. the #2239 vector, read-path guard incl. fail-closed empty set + allow-path regression + Pattern C legacy fallback).
+
+### Detailed progress
+- [x] `packages/shared/src/lib/auth/organizationAccess.ts` — predicate + truth-table unit test (6 cases)
+- [x] `packages/shared/src/lib/commands/scope.ts` — `ensureOrganizationScope` rewritten; scope unit test (7 cases incl. absent-scope-not-deny + allow-path)
+- [x] `packages/core/src/modules/directory/utils/organizationScopeGuard.ts` — read predicate + unit test (6 cases)
+- [x] 10 fail-open guards migrated (people/companies/deals detail routes + sub-resources + `entity-roles-factory`)
+- [x] Behavioral security change documented (spec Migration & Compatibility); CHANGELOG deferred to release tooling
+- [x] Integration fixture infra + `TC-CRM-072.spec.ts` written (deny WRITE/READ + allow-path)
+- [ ] `TC-CRM-072.spec.ts` validated in a coherent app+DB harness (`yarn test:integration:ephemeral`) — could not validate in-session (dev server DB ≠ fixtures DB)
+
+## Changelog
+### 2026-05-29
+- Initial specification (post Open-Questions gate: Q1-b full audit, Q2-b WHERE-scoping deferred, Q3-a ship fail-closed, Q4-a single PR closing #2239 + #2245).
+- Applied pre-implementation analysis findings (`.ai/specs/analysis/ANALYSIS-2026-05-29-org-scope-fail-open-authorization-hardening.md`): added **G1** Pattern C contract (load-bearing absent-scope legacy fallback; ~40 call sites enumerated), **G2** write-path closure-scope statement (Pattern A/B closed incl. #2239 example; Pattern C user routes deferred), and **G3** follow-up issues (Pattern C scope population, deferred WHERE-clause scoping, enterprise/provider re-audit). Strengthened unit/integration test requirements with the absent-scope-not-deny and allow-path regression assertions.
+- Implemented Phases 1–2 and unit coverage. Read-path helper realized as a boolean predicate (`isOrganizationReadAccessAllowed`) rather than a throwing helper, to fit the mixed `throw` / `return forbidden(...)` deny styles across the 10 call sites and keep i18n keys at the call site. 25 new unit tests green; shared + core build and typecheck clean. Phase 3 Playwright tests blocked on missing null-home-org / org-visibility-ACL fixture infrastructure.

--- a/.ai/specs/analysis/ANALYSIS-2026-05-29-org-scope-fail-open-authorization-hardening.md
+++ b/.ai/specs/analysis/ANALYSIS-2026-05-29-org-scope-fail-open-authorization-hardening.md
@@ -1,0 +1,103 @@
+# Pre-Implementation Analysis: Organization-Scope Fail-Open Authorization Hardening
+
+> Target spec: `.ai/specs/2026-05-29-org-scope-fail-open-authorization-hardening.md`
+> Analysis date: 2026-05-29 · Analysis only — no code or spec modified.
+
+## Executive Summary
+The spec is well-scoped and architecturally sound; the read-path fix (#2245) fully closes the audited 10 detail-route guards, and the write-path fix (#2239) closes the hole for all CRUD-factory / explicit-scope command paths (which include the named example, customers people update/delete). **One material gap:** the proposed "legacy `currentOrg` fallback when `organizationScope` is absent" is *load-bearing* for ~40 "Pattern C" command call sites that build the command context with `organizationScope: null`. For those, hole-closure depends on `selectedOrganizationId` being correctly populated, not on the new `allowedIds` check. This is not a regression (behavior is preserved there), but it means #2239 is **not universally closed** by the central fix alone. **Recommendation: proceed to implementation** with two spec additions (Pattern C contract note + a tracked follow-up), and a mandatory regression test asserting the allow-path is unchanged.
+
+## Backward Compatibility
+
+### Violations Found
+| # | Surface | Issue | Severity | Proposed Fix |
+|---|---------|-------|----------|-------------|
+| — | 3. Function Signatures | `ensureOrganizationScope(ctx, organizationId)` signature is **unchanged**; behavior tightens (deny where it previously skipped). Not listed in the BC STABLE function table, and signature-stable. Security hardening of behavior is explicitly permitted. | None (informational) | No bridge needed. Document behavior change in `RELEASE_NOTES.md` (already in spec). |
+| — | 2. Type Definitions | `OrganizationScope` consumed read-only; no field removed/narrowed. Two new exports are additive. | None | — |
+| — | 7. API Route URLs | No URL/response-shape change; only a `200 → 403` behavioral change for the attack precondition. | None | Document as security behavior change. |
+
+No Critical or Warning BC violations. All 13 surfaces checked: auto-discovery (n/a), types (additive), signatures (stable), import paths (additive new files), event IDs (n/a), spot IDs (n/a), API URLs (behavior-only), DB schema (n/a), DI names (n/a), ACL features (n/a), notification IDs (n/a), CLI commands (n/a), generated files (n/a).
+
+### Missing BC Section
+Spec includes a "Migration & Compatibility" section that correctly classifies the change as a permitted security-hardening behavior change. **Adequate.** Recommend it explicitly name the Pattern C contract (see Gap G1).
+
+## Spec Completeness
+
+### Missing Sections
+| Section | Impact | Recommendation |
+|---------|--------|---------------|
+| Integration Test Coverage | Present but light on the Pattern C dimension | Add a scenario asserting a Pattern C path (e.g. `sales.quotes.convert_to_order` via `/api/sales/quotes/accept`) is unaffected and a CRUD-factory path (people update) is denied for the floating restricted user. |
+
+All other required sections (TLDR, Overview, Problem, Proposed Solution, Architecture, Data Models, API Contracts, UI/UX, Risks, Phasing, Implementation Plan, Final Compliance Report, Changelog) are present.
+
+### Incomplete Sections
+| Section | Gap | Recommendation |
+|---------|-----|---------------|
+| Proposed Solution §2 (write path) | Does not state that the legacy fallback is load-bearing for ~40 Pattern C call sites, nor that #2239 closure for those depends on `selectedOrganizationId` | Add the Pattern C contract note (G1) so implementers don't mistakenly switch absent-scope to deny and break system/worker/checkout flows. |
+| Testing Strategy | No explicit "allow-path unchanged" regression assertion | Per `.ai/lessons.md` ("preserve exact RBAC inclusion semantics"), add a test proving restricted-in-scope and super-admin still succeed. |
+
+## AGENTS.md Compliance
+
+### Violations
+| Rule | Location | Fix |
+|------|----------|-----|
+| None | — | — |
+
+Verified compliant:
+- **`packages/shared/AGENTS.md` — no core/domain imports from shared.** The primitive predicate `isOrganizationAccessAllowed` takes plain `string[]`/`boolean`/`string` args; the `OrganizationScope`-typed read guard correctly lives in `packages/core/src/modules/directory`, not shared. ✅
+- **No `any`.** Predicate and guard use explicit types. ✅
+- **`requireFeatures` over `requireRoles`** (lessons.md): no role-name checks introduced; uses immutable org-id membership. ✅
+- **Writes via commands / shared guards** (`packages/core/AGENTS.md`): no new write path; guards centralized rather than copy-pasted. ✅
+- **i18n**: reuses existing `customers.errors.access_denied`; shared `CrudHttpError(403, { error: 'Forbidden' })` matches existing internal contract surface (not a translatable user string in shared). ✅
+- **DS / UI / encryption / cache / events**: n/a — no UI, no entities, no events, no cache changes. ✅
+
+## Risk Assessment
+
+### High Risks
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Over-denial via switching absent-scope to deny | If an implementer "tidies up" by making `organizationScope == null` deny, ~40 Pattern C sites (checkout payment subscribers, scheduler workers, messages, inbox_ops, enterprise security, `feature_toggles` CLI, notifications) — many system/worker contexts with no user — would break, including payment and scheduled-command flows. | Spec MUST pin the legacy fallback for absent scope (G1). Add unit test: `organizationScope=null` ⇒ legacy `currentOrg` behavior, not deny. |
+
+### Medium Risks
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| #2239 not closed for Pattern C user-facing routes | A floating restricted user hitting a Pattern C *user* route (e.g. `customers/api/people/[id]/companies/route.ts`, `sales/quotes/accept`) still relies on `selectedOrganizationId`, not the new `allowedIds` check. | These routes already guard `if (!selectedOrganizationId) return` and set `organizationIds: [selectedOrganizationId]`, and the upstream read guard (Phase 2) runs first. Document residual; open follow-up to migrate Pattern C user routes to populate real scope. |
+| Allow-path regression for legitimately scoped users | A scoped user with `allowedIds=[orgA]` acting on an orgA record must still succeed. | Mandatory regression test (lessons.md rule). |
+
+### Low Risks
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Unaudited fail-open copy outside `packages/**`/`apps/**` | A guard with the same pattern in an unsearched location stays open. | Audit covered both trees; only the 10 listed `size && !has` deny guards found. Predicate makes future fixes one-line. |
+| `entity-roles-factory` behavior shift | Refactoring `collectAllowedOrganizationIds`/`ensureRouteOrganizationAccess` to the shared guard could subtly change which entity-role routes deny. | Keep allowed-set derivation identical; only flip empty-set to deny. Add a unit test for the factory guard. |
+
+## Gap Analysis
+
+### Critical Gaps (Block Implementation)
+- None.
+
+### Important Gaps (Should Address — fold into spec before coding)
+- **G1 — Pattern C contract**: Spec §Proposed Solution must state that `ensureOrganizationScope` keeps the legacy `currentOrg` fallback whenever `ctx.organizationScope` is `null`/absent, and that this branch is load-bearing for ~40 call sites (list them by module: messages, checkout, scheduler, inbox_ops, enterprise/security, workflows, notifications, feature_toggles CLI, customers people-companies link routes, sales quotes accept). The new restricted-`allowedIds` deny applies only when `organizationScope` is present.
+- **G2 — #2239 closure scope statement**: Spec must explicitly say the central fix closes the hole for CRUD-factory (Pattern A) and explicit-`resolveOrganizationScopeForRequest` (Pattern B) command paths (incl. the named people update/delete example), and that Pattern C user routes remain on `selectedOrganizationId` pending the follow-up.
+- **G3 — Follow-up issue**: Track "populate real `organizationScope` (or assert correct `selectedOrganizationId`) on Pattern C *user-facing* command routes" + the deferred WHERE-clause record-load scoping (Q2-b) as one or two follow-up issues, referenced from the spec.
+
+### Nice-to-Have Gaps
+- A short truth-table comment in the predicate file documenting the four decision cases.
+- Consider exporting the predicate from a stable shared path and noting it in `BACKWARD_COMPATIBILITY.md` as a new STABLE function (additive) if third-party guards should reuse it.
+
+## Remediation Plan
+
+### Before Implementation (Must Do)
+1. **Add G1 + G2 to the spec** (Pattern C contract + #2239 closure-scope statement). This prevents the High-risk over-denial mistake and sets correct expectations for what the central fix closes.
+2. **Confirm Pattern A for the #2239 named example**: verify `customers/api/people/route.ts` update/delete dispatch through `makeCrudRoute` so `organizationScope` is populated (factory.ts:1251). Expected true; confirm during Phase 1.
+
+### During Implementation (Add to Spec / Code)
+1. Implement `isOrganizationAccessAllowed` predicate + unit truth-table test first.
+2. Rewrite `ensureOrganizationScope`; keep absent-scope legacy fallback (G1). Unit tests MUST include: `organizationScope=null` ⇒ legacy behavior (not deny); restricted `allowedIds=[A]` + target B ⇒ 403; `allowedIds=null` ⇒ allow; superadmin ⇒ allow; `allowedIds=[A]` + target A ⇒ allow.
+3. Add `assertOrganizationReadAccess`; migrate the 10 guards + `entity-roles-factory`; keep allowed-set derivation identical.
+4. Add the allow-path regression integration test (scoped user succeeds, super-admin succeeds) alongside the deny tests.
+
+### Post-Implementation (Follow Up)
+1. Open G3 follow-up issue(s): Pattern C user-route scope population + deferred WHERE-clause single-record load scoping (Q2-b).
+2. Re-audit `packages/enterprise/**` and any provider packages for the same `size && !has` guard once the shared helpers exist.
+
+## Recommendation
+**Ready to implement — after folding G1 and G2 into the spec** (small text additions; no architectural change). The design is sound, BC-clean, and AGENTS.md-compliant; the only real exposure is the over-denial trap, fully mitigated by pinning the absent-scope legacy fallback and the mandatory allow-path regression test.

--- a/packages/core/src/helpers/integration/authFixtures.ts
+++ b/packages/core/src/helpers/integration/authFixtures.ts
@@ -2,6 +2,32 @@ import { expect, type APIRequestContext } from '@playwright/test';
 import { apiRequest } from './api';
 import { expectId, readJsonSafe } from './generalFixtures';
 
+const BASE_URL = process.env.BASE_URL?.trim() || null;
+
+function resolveUrl(path: string): string {
+  return BASE_URL ? `${BASE_URL}${path}` : path;
+}
+
+/**
+ * Variant of {@link apiRequest} that sets the `om_selected_org` cookie so the
+ * server resolves `ctx.selectedOrganizationId` to a specific organization.
+ * Create routes scope new records to that organization, which lets a test place
+ * a fixture in an organization other than the caller's home org.
+ */
+export async function apiRequestWithSelectedOrg(
+  request: APIRequestContext,
+  method: string,
+  path: string,
+  options: { token: string; selectedOrgId: string; data?: unknown },
+) {
+  const headers = {
+    Authorization: `Bearer ${options.token}`,
+    'Content-Type': 'application/json',
+    Cookie: `om_selected_org=${options.selectedOrgId}`,
+  };
+  return request.fetch(resolveUrl(path), { method, headers, data: options.data });
+}
+
 export async function createRoleFixture(
   request: APIRequestContext,
   token: string,
@@ -52,4 +78,76 @@ export async function deleteUserIfExists(
 ): Promise<void> {
   if (!token || !userId) return;
   await apiRequest(request, 'DELETE', `/api/auth/users?id=${encodeURIComponent(userId)}`, { token }).catch(() => undefined);
+}
+
+export async function createOrganizationFixture(
+  request: APIRequestContext,
+  token: string,
+  input: { name: string; tenantId?: string },
+): Promise<string> {
+  const payload: { name: string; tenantId?: string } = { name: input.name };
+  if (typeof input.tenantId === 'string' && input.tenantId.length > 0) {
+    payload.tenantId = input.tenantId;
+  }
+  const response = await apiRequest(request, 'POST', '/api/directory/organizations', {
+    token,
+    data: payload,
+  });
+  const body = await readJsonSafe<{ id?: string }>(response);
+  expect(response.status(), 'POST /api/directory/organizations should return 201').toBe(201);
+  return expectId(body?.id, 'Organization creation response should include id');
+}
+
+export async function deleteOrganizationIfExists(
+  request: APIRequestContext,
+  token: string | null,
+  organizationId: string | null,
+): Promise<void> {
+  if (!token || !organizationId) return;
+  await apiRequest(request, 'DELETE', '/api/directory/organizations', {
+    token,
+    data: { id: organizationId },
+  }).catch(() => undefined);
+}
+
+export async function setRoleAclFeatures(
+  request: APIRequestContext,
+  token: string,
+  input: { roleId: string; features: string[]; organizations?: string[] | null },
+): Promise<void> {
+  const payload: { roleId: string; features: string[]; organizations?: string[] | null } = {
+    roleId: input.roleId,
+    features: input.features,
+  };
+  if (input.organizations !== undefined) {
+    payload.organizations = input.organizations;
+  }
+  const response = await apiRequest(request, 'PUT', '/api/auth/roles/acl', {
+    token,
+    data: payload,
+  });
+  const body = await readJsonSafe<{ ok?: boolean }>(response);
+  expect(response.status(), 'PUT /api/auth/roles/acl should return 200').toBe(200);
+  expect(body?.ok, 'Role ACL update should report ok=true').toBe(true);
+}
+
+export async function setUserAclVisibility(
+  request: APIRequestContext,
+  token: string,
+  input: { userId: string; organizations: string[] | null; features?: string[] },
+): Promise<void> {
+  const payload: { userId: string; organizations: string[] | null; features?: string[] } = {
+    userId: input.userId,
+    organizations: input.organizations,
+  };
+  if (input.features !== undefined) {
+    payload.features = input.features;
+  }
+  const response = await apiRequest(request, 'PUT', '/api/auth/users/acl', {
+    token,
+    data: payload,
+  });
+  const body = await readJsonSafe<{ ok?: boolean }>(response);
+  expect(response.status(), 'PUT /api/auth/users/acl should return 200').toBe(200);
+  expect(body?.ok, 'User ACL update should report ok=true').toBe(true);
 }

--- a/packages/core/src/helpers/integration/dbFixtures.ts
+++ b/packages/core/src/helpers/integration/dbFixtures.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { Client } from 'pg';
+
+/**
+ * Database fixtures for the org-scope fail-open hardening tests.
+ *
+ * These helpers talk to Postgres directly via `pg` rather than bootstrapping the
+ * app DI container, because:
+ *  - the directory create command denies non-super-admin actors (the only
+ *    loginable accounts here), so orgs cannot be created over the API; and
+ *  - granting `customers.*` through the ACL API requires a super-admin actor.
+ * Raw SQL keeps the test self-contained and avoids depending on built package
+ * `dist/` output for an in-process MikroORM bootstrap.
+ */
+
+function resolveAppRoot(): string {
+  const fromEnv = process.env.OM_TEST_APP_ROOT?.trim();
+  return fromEnv ? path.resolve(fromEnv) : path.resolve(process.cwd(), 'apps/mercato');
+}
+
+function readEnvValue(key: string): string | undefined {
+  if (process.env[key]) return process.env[key];
+  const candidatePaths = [
+    path.resolve(resolveAppRoot(), '.env'),
+    path.resolve(process.cwd(), 'apps/mercato/.env'),
+    path.resolve(process.cwd(), '.env'),
+  ];
+  for (const envPath of candidatePaths) {
+    try {
+      const content = readFileSync(envPath, 'utf-8');
+      const match = content.match(new RegExp(`^${key}=(.+)$`, 'm'));
+      if (match?.[1]) return match[1].trim();
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+function resolveDatabaseUrl(): string {
+  const url = readEnvValue('DATABASE_URL');
+  if (!url) throw new Error('[internal] DATABASE_URL is not configured for integration DB fixtures');
+  return url;
+}
+
+async function withClient<T>(run: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client({ connectionString: resolveDatabaseUrl() });
+  await client.connect();
+  try {
+    return await run(client);
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Nulls a user's home organization (`organization_id`) directly in the database.
+ *
+ * Required to construct the "floating restricted user" precondition: the JWT
+ * `auth.orgId` is minted from `users.organization_id` at login, so this MUST run
+ * BEFORE the user logs in.
+ */
+export async function clearUserHomeOrganization(userId: string): Promise<void> {
+  await withClient(async (client) => {
+    await client.query('update users set organization_id = null where id = $1', [userId]);
+  });
+}
+
+/**
+ * Upserts a per-user ACL row, setting the effective feature list and the
+ * organization-visibility list.
+ *
+ * `organizations` maps to `OrganizationScope.allowedIds` (write path) and
+ * `filterIds` (read path):
+ *   - `[orgA]` => restricted to orgA (write fail-open precondition, #2239)
+ *   - `[]`     => restricted to zero orgs (read fail-open precondition, #2245)
+ *   - `null`   => unrestricted
+ */
+export async function setUserAclInDb(input: {
+  userId: string;
+  tenantId: string;
+  features: string[];
+  organizations: string[] | null;
+}): Promise<void> {
+  await withClient(async (client) => {
+    const existing = await client.query<{ id: string }>(
+      'select id from user_acls where user_id = $1 and tenant_id = $2 limit 1',
+      [input.userId, input.tenantId],
+    );
+    const featuresJson = JSON.stringify(input.features);
+    const organizationsJson = input.organizations === null ? null : JSON.stringify(input.organizations);
+    if (existing.rows.length > 0) {
+      await client.query(
+        'update user_acls set features_json = $2::jsonb, organizations_json = $3::jsonb, is_super_admin = false, updated_at = now() where id = $1',
+        [existing.rows[0].id, featuresJson, organizationsJson],
+      );
+      return;
+    }
+    await client.query(
+      `insert into user_acls (id, user_id, tenant_id, features_json, organizations_json, is_super_admin, created_at)
+       values (gen_random_uuid(), $1, $2, $3::jsonb, $4::jsonb, false, now())`,
+      [input.userId, input.tenantId, featuresJson, organizationsJson],
+    );
+  });
+}
+
+/** Removes any per-user ACL rows for the user (best-effort test cleanup). */
+export async function deleteUserAclInDb(userId: string): Promise<void> {
+  if (!userId) return;
+  await withClient(async (client) => {
+    await client.query('delete from user_acls where user_id = $1', [userId]);
+  });
+}
+
+/**
+ * Creates an organization directly in the database within the given tenant.
+ *
+ * The directory create command routes through `enforceTenantSelection`, which
+ * denies the (non-super-admin) accounts loginable on this instance. Landing the
+ * org in a known tenant lets the floating user (created under it) share the
+ * tenant — required because cross-tenant access returns 404 before the
+ * org-scope guard ever runs.
+ */
+export async function createOrganizationInDb(input: { name: string; tenantId: string }): Promise<string> {
+  return withClient(async (client) => {
+    const result = await client.query<{ id: string }>(
+      `insert into organizations
+         (id, tenant_id, name, is_active, ancestor_ids, child_ids, descendant_ids, depth, created_at, updated_at)
+       values (gen_random_uuid(), $1, $2, true, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, 0, now(), now())
+       returning id`,
+      [input.tenantId, input.name],
+    );
+    return result.rows[0].id;
+  });
+}
+
+/** Hard-deletes an organization row (best-effort test cleanup). */
+export async function deleteOrganizationInDb(organizationId: string | null): Promise<void> {
+  if (!organizationId) return;
+  await withClient(async (client) => {
+    await client.query('delete from organizations where id = $1', [organizationId]);
+  });
+}

--- a/packages/core/src/modules/core/__integration__/helpers/dbFixtures.ts
+++ b/packages/core/src/modules/core/__integration__/helpers/dbFixtures.ts
@@ -1,0 +1,1 @@
+export * from '../../../../helpers/integration/dbFixtures'

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import {
+  apiRequest,
+  getAuthToken,
+} from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  apiRequestWithSelectedOrg,
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures';
+import {
+  clearUserHomeOrganization,
+  deleteUserAclInDb,
+  createOrganizationInDb,
+  deleteOrganizationInDb,
+} from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+/**
+ * TC-CRM-072: Organization-scope fail-open authorization hardening.
+ *
+ * Spec: .ai/specs/2026-05-29-org-scope-fail-open-authorization-hardening.md (Phase 3)
+ * Issues: #2239 (write/command path) + #2245 (read/detail path).
+ *
+ * Vulnerability precondition (closed by the fix): a NON-super-admin user whose
+ * home org resolves to null (`auth.orgId === null`) but whose org-visibility ACL
+ * is a concrete-yet-non-matching set. Before the fix the guards FAILED OPEN
+ * (skipped the check) and allowed cross-org read/write within the tenant.
+ *
+ * - WRITE (#2239): visibility `[orgA]` => `scope.allowedIds = [orgA]`. Acting on
+ *   a record in orgB was allowed (fail-open); now 403. Acting on orgA still OK.
+ * - READ (#2245): visibility `[]` => derived org set is EMPTY. Reading a record
+ *   in any other org was allowed (fail-open: empty set => guard skipped); now 403.
+ *
+ * The home org is nulled in the DB BEFORE login because the JWT `auth.orgId` is
+ * minted from `users.organization_id` at login time.
+ *
+ * ENVIRONMENT: this spec mixes API fixtures (hit the app) with DB-level fixtures
+ * (raw `pg` against `DATABASE_URL`). It MUST run under a coherent app+DB stack
+ * (the standard `yarn test:integration` / `yarn test:integration:ephemeral`
+ * harness) where the app server and the fixtures share the same database. It is
+ * NOT valid against an arbitrary already-running dev server whose `DATABASE_URL`
+ * differs from `apps/mercato/.env` — the DB writes become no-ops the app cannot
+ * see, so the preconditions are never established.
+ */
+test.describe('TC-CRM-072: org-scope fail-open authorization hardening (#2239 + #2245)', () => {
+  test('denies cross-org write/read for a floating restricted user; allows in-scope', async ({ request }) => {
+    test.slow();
+
+    const stamp = Date.now();
+    const password = 'Secret123!';
+
+    let adminToken: string | null = null;
+    let orgAId: string | null = null;
+    let orgBId: string | null = null;
+    let writeRoleId: string | null = null;
+    let readRoleId: string | null = null;
+    let writeUserId: string | null = null;
+    let readUserId: string | null = null;
+    let personOrgAId: string | null = null;
+    let personOrgBId: string | null = null;
+
+    const writeUserEmail = `tc-crm-072-write-${stamp}@example.com`;
+    const readUserEmail = `tc-crm-072-read-${stamp}@example.com`;
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      const { tenantId } = getTokenScope(adminToken);
+      expect(tenantId, 'admin token should carry a tenant id').toBeTruthy();
+
+      // Two organizations in the admin tenant. Created via DB: the directory
+      // create command routes through enforceTenantSelection, which denies the
+      // only loginable (non-super-admin) accounts on this instance.
+      orgAId = await createOrganizationInDb({ name: `TC-CRM-072 Org A ${stamp}`, tenantId });
+      orgBId = await createOrganizationInDb({ name: `TC-CRM-072 Org B ${stamp}`, tenantId });
+
+      // People records placed in specific orgs via the om_selected_org cookie.
+      personOrgAId = await createPersonInOrg(request, adminToken, orgAId, `TC-CRM-072 Person A ${stamp}`);
+      personOrgBId = await createPersonInOrg(request, adminToken, orgBId, `TC-CRM-072 Person B ${stamp}`);
+
+      // Sanity: the orgB person is reachable & actually lives in orgB (in-scope admin).
+      const orgBDetail = await apiRequest(request, 'GET', `/api/customers/people/${personOrgBId}`, { token: adminToken });
+      expect(orgBDetail.status(), 'admin (in-scope) can read the orgB person').toBe(200);
+      const orgBBody = await readJsonSafe<{ person?: { organizationId?: string } }>(orgBDetail);
+      expect(orgBBody?.person?.organizationId, 'orgB person must be in orgB').toBe(orgBId);
+
+      // ---- WRITE precondition (#2239): floating user, visibility = [orgA] ----
+      writeRoleId = await createRoleFixture(request, adminToken, { name: `TC-CRM-072 Write Role ${stamp}` });
+      writeUserId = await createUserFixture(request, adminToken, {
+        email: writeUserEmail,
+        password,
+        organizationId: orgAId,
+        roles: [writeRoleId],
+      });
+      // Grant a customers feature superset so the feature gate passes; org-scope is
+      // the only thing that can 403. Visibility=[orgA] => allowedIds=[orgA].
+      // Set via the ACL API so the server's RBAC cache is invalidated.
+      await setUserAclVisibility(request, adminToken, {
+        userId: writeUserId,
+        features: ['customers.*'],
+        organizations: [orgAId],
+      });
+      await clearUserHomeOrganization(writeUserId);
+      const writeToken = await getAuthToken(request, writeUserEmail, password);
+      expect(decodeOrgId(writeToken), 'floating write user must have null home org in JWT').toBeNull();
+
+      // People update routes through makeCrudRoute (Pattern A): the command ctx
+      // carries the resolved OrganizationScope. `allowedIds` is derived from the
+      // user's org-visibility ACL ([orgA]) and is independent of any selected-org
+      // cookie. To exercise the #2239 fail-open we send NO selected org, so the
+      // legacy `currentOrg` (selectedOrganizationId ?? auth.orgId) resolves to
+      // null — the exact precondition where the OLD guard skipped the check
+      // (returning 200) and the NEW guard denies because orgB ∉ allowedIds=[orgA].
+
+      // WRITE deny (#2239): update a person in orgB with no selected org => 403.
+      const denyWrite = await apiRequest(request, 'PUT', '/api/customers/people', {
+        token: writeToken,
+        data: { id: personOrgBId, organizationId: orgBId, description: `cross-org write attempt ${stamp}` },
+      });
+      expect(denyWrite.status(), 'cross-org PUT (orgB) must be forbidden (#2239)').toBe(403);
+
+      // WRITE allow-path regression: update a person in orgA (in allowedIds) => success.
+      const allowWrite = await apiRequest(request, 'PUT', '/api/customers/people', {
+        token: writeToken,
+        data: { id: personOrgAId, organizationId: orgAId, description: `in-scope write ${stamp}` },
+      });
+      expect(allowWrite.status(), 'in-scope PUT (orgA) must succeed').toBeLessThan(300);
+      expect(allowWrite.status(), 'in-scope PUT (orgA) must succeed').toBeGreaterThanOrEqual(200);
+
+      // ---- READ precondition (#2245): floating user, visibility = [] (zero orgs) ----
+      readRoleId = await createRoleFixture(request, adminToken, { name: `TC-CRM-072 Read Role ${stamp}` });
+      readUserId = await createUserFixture(request, adminToken, {
+        email: readUserEmail,
+        password,
+        organizationId: orgAId,
+        roles: [readRoleId],
+      });
+      // Visibility=[] => derived org set EMPTY => read guard must deny (was fail-open).
+      await setUserAclVisibility(request, adminToken, {
+        userId: readUserId,
+        features: ['customers.*'],
+        organizations: [],
+      });
+      await clearUserHomeOrganization(readUserId);
+      const readToken = await getAuthToken(request, readUserEmail, password);
+      expect(decodeOrgId(readToken), 'floating read user must have null home org in JWT').toBeNull();
+
+      // READ deny: detail GET on the orgB person => 403 (was fail-open: empty set skipped guard).
+      const denyRead = await apiRequest(request, 'GET', `/api/customers/people/${personOrgBId}`, { token: readToken });
+      expect(denyRead.status(), 'cross-org detail GET (orgB) must be forbidden (#2245)').toBe(403);
+    } finally {
+      await deleteUserAclInDb(writeUserId ?? '').catch(() => undefined);
+      await deleteUserAclInDb(readUserId ?? '').catch(() => undefined);
+      await deleteUserIfExists(request, adminToken, writeUserId);
+      await deleteUserIfExists(request, adminToken, readUserId);
+      await deleteRoleIfExists(request, adminToken, writeRoleId);
+      await deleteRoleIfExists(request, adminToken, readRoleId);
+      await deletePersonIfExists(request, adminToken, personOrgAId);
+      await deletePersonIfExists(request, adminToken, personOrgBId);
+      await deleteOrganizationInDb(orgAId).catch(() => undefined);
+      await deleteOrganizationInDb(orgBId).catch(() => undefined);
+    }
+  });
+});
+
+function decodeOrgId(token: string): string | null {
+  const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString()) as { orgId?: string | null };
+  return payload.orgId ?? null;
+}
+
+async function createPersonInOrg(
+  request: APIRequestContext,
+  token: string,
+  orgId: string,
+  displayName: string,
+): Promise<string> {
+  const response = await apiRequestWithSelectedOrg(request, 'POST', '/api/customers/people', {
+    token,
+    selectedOrgId: orgId,
+    data: { firstName: 'TC072', lastName: 'Person', displayName },
+  });
+  expect(response.status(), `create person in org ${orgId} should return 201`).toBe(201);
+  const body = await readJsonSafe<{ id?: string }>(response);
+  expect(typeof body?.id === 'string' && body.id.length > 0, 'person create response should include id').toBe(true);
+  return body!.id as string;
+}
+
+async function deletePersonIfExists(
+  request: APIRequestContext,
+  token: string | null,
+  personId: string | null,
+): Promise<void> {
+  if (!token || !personId) return;
+  await apiRequest(request, 'DELETE', '/api/customers/people', { token, data: { id: personId } }).catch(() => undefined);
+}

--- a/packages/core/src/modules/customers/api/companies/[id]/people/route.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/people/route.ts
@@ -8,6 +8,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 import {
   CustomerEntity,
   CustomerPersonCompanyLink,
@@ -115,10 +116,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       throw new CrudHttpError(404, { error: translate('customers.errors.company_not_found', 'Company not found') })
     }
 
-    const allowedOrgIds = new Set<string>()
-    if (scope?.filterIds?.length) scope.filterIds.forEach((entry) => allowedOrgIds.add(entry))
-    else if (auth.orgId) allowedOrgIds.add(auth.orgId)
-    if (allowedOrgIds.size > 0 && company.organizationId && !allowedOrgIds.has(company.organizationId)) {
+    if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: company.organizationId })) {
       throw new CrudHttpError(403, { error: translate('customers.errors.access_denied', 'Access denied') })
     }
 

--- a/packages/core/src/modules/customers/api/companies/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/route.ts
@@ -47,6 +47,7 @@ import {
   withActiveCustomerPersonCompanyLinkFilter,
 } from '../../../lib/personCompanyLinkTable'
 import { normalizeCustomerDetailCustomFields } from '../../detailCustomFields'
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.companies.view'] },
@@ -386,11 +387,7 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
   if (!company) return notFound('Company not found')
 
   if (auth.tenantId && company.tenantId !== auth.tenantId) return notFound('Company not found')
-  const allowedOrgIds = new Set<string>()
-  if (scope?.filterIds?.length) scope.filterIds.forEach((id) => allowedOrgIds.add(id))
-  else if (auth.orgId) allowedOrgIds.add(auth.orgId)
-
-  if (allowedOrgIds.size && company.organizationId && !allowedOrgIds.has(company.organizationId)) {
+  if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: company.organizationId })) {
     return forbidden('Access denied')
   }
 

--- a/packages/core/src/modules/customers/api/deals/[id]/companies/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/companies/route.ts
@@ -8,6 +8,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 import { CustomerCompanyProfile, CustomerDeal, CustomerDealCompanyLink, CustomerEntity } from '../../../../data/entities'
 
 const paramsSchema = z.object({
@@ -97,10 +98,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       throw new CrudHttpError(404, { error: translate('customers.errors.deal_not_found', 'Deal not found') })
     }
 
-    const allowedOrgIds = new Set<string>()
-    if (scope?.filterIds?.length) scope.filterIds.forEach((entry) => allowedOrgIds.add(entry))
-    else if (auth.orgId) allowedOrgIds.add(auth.orgId)
-    if (allowedOrgIds.size > 0 && deal.organizationId && !allowedOrgIds.has(deal.organizationId)) {
+    if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: deal.organizationId })) {
       throw new CrudHttpError(403, { error: translate('customers.errors.access_denied', 'Access denied') })
     }
 

--- a/packages/core/src/modules/customers/api/deals/[id]/people/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/people/route.ts
@@ -8,6 +8,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 import { CustomerDeal, CustomerDealPersonLink, CustomerEntity } from '../../../../data/entities'
 
 const paramsSchema = z.object({
@@ -97,10 +98,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       throw new CrudHttpError(404, { error: translate('customers.errors.deal_not_found', 'Deal not found') })
     }
 
-    const allowedOrgIds = new Set<string>()
-    if (scope?.filterIds?.length) scope.filterIds.forEach((entry) => allowedOrgIds.add(entry))
-    else if (auth.orgId) allowedOrgIds.add(auth.orgId)
-    if (allowedOrgIds.size > 0 && deal.organizationId && !allowedOrgIds.has(deal.organizationId)) {
+    if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: deal.organizationId })) {
       throw new CrudHttpError(403, { error: translate('customers.errors.access_denied', 'Access denied') })
     }
 

--- a/packages/core/src/modules/customers/api/deals/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/route.ts
@@ -22,6 +22,7 @@ import { E } from '#generated/entities.ids.generated'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 import { decryptEntitiesWithFallbackScope } from '@open-mercato/shared/lib/encryption/subscriber'
 import { isMissingDealStageTransitionTable, warnMissingDealStageTransitionTable } from '../../../lib/dealStageTransitionTable'
 
@@ -377,15 +378,7 @@ export async function GET(request: Request, context: { params?: Record<string, u
     return notFound('Deal not found')
   }
 
-  const allowedOrgIds = new Set<string>()
-  if (Array.isArray(scope?.filterIds)) {
-    scope.filterIds.forEach((id) => {
-      if (typeof id === 'string' && id.trim().length) allowedOrgIds.add(id)
-    })
-  } else if (auth.orgId) {
-    allowedOrgIds.add(auth.orgId)
-  }
-  if (allowedOrgIds.size && deal.organizationId && !allowedOrgIds.has(deal.organizationId)) {
+  if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: deal.organizationId })) {
     return forbidden('Access denied')
   }
 

--- a/packages/core/src/modules/customers/api/deals/[id]/stats/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/stats/route.ts
@@ -10,6 +10,7 @@ import { DictionaryEntry } from '@open-mercato/core/modules/dictionaries/data/en
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.deals.view'] },
@@ -97,15 +98,7 @@ export async function GET(request: Request, context: { params?: Record<string, u
     return notFound(translate('customers.errors.deal_not_found', 'Deal not found'))
   }
 
-  const allowedOrgIds = new Set<string>()
-  if (Array.isArray(scope?.filterIds)) {
-    scope.filterIds.forEach((id) => {
-      if (typeof id === 'string' && id.trim().length) allowedOrgIds.add(id)
-    })
-  } else if (auth.orgId) {
-    allowedOrgIds.add(auth.orgId)
-  }
-  if (allowedOrgIds.size && deal.organizationId && !allowedOrgIds.has(deal.organizationId)) {
+  if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: deal.organizationId })) {
     return forbidden(translate('customers.errors.access_denied', 'Access denied'))
   }
 

--- a/packages/core/src/modules/customers/api/entity-roles-factory.ts
+++ b/packages/core/src/modules/customers/api/entity-roles-factory.ts
@@ -7,6 +7,7 @@ import { validateCrudMutationGuard, runCrudMutationGuardAfterSuccess } from '@op
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 import { User } from '@open-mercato/core/modules/auth/data/entities'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { CustomerEntity, CustomerEntityRole } from '../data/entities'
@@ -69,24 +70,13 @@ async function buildContext(request: Request) {
   }
 }
 
-function collectAllowedOrganizationIds(
-  scope: Awaited<ReturnType<typeof resolveCustomersRequestContext>>['scope'],
-  auth: Awaited<ReturnType<typeof resolveCustomersRequestContext>>['auth'],
-) {
-  const allowedOrgIds = new Set<string>()
-  if (scope?.filterIds?.length) scope.filterIds.forEach((id) => allowedOrgIds.add(id))
-  else if (auth.orgId) allowedOrgIds.add(auth.orgId)
-  return allowedOrgIds
-}
-
 function ensureRouteOrganizationAccess(
   organizationId: string,
   scope: Awaited<ReturnType<typeof resolveCustomersRequestContext>>['scope'],
   auth: Awaited<ReturnType<typeof resolveCustomersRequestContext>>['auth'],
   translate: Translator,
 ) {
-  const allowedOrgIds = collectAllowedOrganizationIds(scope, auth)
-  if (allowedOrgIds.size > 0 && !allowedOrgIds.has(organizationId)) {
+  if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId })) {
     throw new CrudHttpError(403, { error: translate('customers.errors.access_denied', 'Access denied') })
   }
 }

--- a/packages/core/src/modules/customers/api/people/[id]/companies/context.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/companies/context.ts
@@ -7,6 +7,7 @@ import {
   CustomerPersonProfile,
 } from '@open-mercato/core/modules/customers/data/entities'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
@@ -37,11 +38,7 @@ export async function loadPersonContext(req: Request, personId: string) {
     throw new CrudHttpError(404, { error: translate('customers.errors.person_not_found', 'Person not found') })
   }
 
-  const allowedOrgIds = new Set<string>()
-  if (scope?.filterIds?.length) scope.filterIds.forEach((entry) => allowedOrgIds.add(entry))
-  else if (authenticatedAuth.orgId) allowedOrgIds.add(authenticatedAuth.orgId)
-
-  if (allowedOrgIds.size > 0 && !allowedOrgIds.has(person.organizationId)) {
+  if (!isOrganizationReadAccessAllowed({ scope, auth: authenticatedAuth, organizationId: person.organizationId })) {
     throw new CrudHttpError(403, { error: translate('customers.errors.access_denied', 'Access denied') })
   }
 

--- a/packages/core/src/modules/customers/api/people/[id]/companies/enriched/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/companies/enriched/route.ts
@@ -8,6 +8,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 import {
   CustomerEntity,
   CustomerCompanyProfile,
@@ -173,11 +174,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       throw new CrudHttpError(404, { error: translate('customers.errors.person_not_found', 'Person not found') })
     }
 
-    const allowedOrgIds = new Set<string>()
-    if (scope?.filterIds?.length) scope.filterIds.forEach((entry) => allowedOrgIds.add(entry))
-    else if (auth.orgId) allowedOrgIds.add(auth.orgId)
-
-    if (allowedOrgIds.size > 0 && !allowedOrgIds.has(person.organizationId)) {
+    if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: person.organizationId })) {
       throw new CrudHttpError(403, { error: translate('customers.errors.access_denied', 'Access denied') })
     }
 

--- a/packages/core/src/modules/customers/api/people/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/route.ts
@@ -37,6 +37,7 @@ import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { parseBooleanFromUnknown, parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 import { loadPersonCompanyLinks, summarizePersonCompanies } from '../../../lib/personCompanies'
 import { normalizeCustomerDetailCustomFields } from '../../detailCustomFields'
 
@@ -474,11 +475,7 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
       profileMeta = { reason: 'person_tenant_mismatch' }
       return notFound('Person not found')
     }
-    const allowedOrgIds = new Set<string>()
-    if (scope?.filterIds?.length) scope.filterIds.forEach((id) => allowedOrgIds.add(id))
-    else if (auth.orgId) allowedOrgIds.add(auth.orgId)
-
-    if (allowedOrgIds.size && person.organizationId && !allowedOrgIds.has(person.organizationId)) {
+    if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: person.organizationId })) {
       statusCode = 403
       profileMeta = { reason: 'organization_forbidden' }
       return forbidden('Access denied')

--- a/packages/core/src/modules/directory/utils/__tests__/organizationScopeGuard.test.ts
+++ b/packages/core/src/modules/directory/utils/__tests__/organizationScopeGuard.test.ts
@@ -1,0 +1,84 @@
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
+import type { OrganizationScope } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
+
+function buildScope(overrides: Partial<OrganizationScope>): OrganizationScope {
+  return {
+    selectedId: null,
+    filterIds: null,
+    allowedIds: null,
+    tenantId: 'tenant-1',
+    ...overrides,
+  }
+}
+
+function buildAuth(overrides: Partial<NonNullable<AuthContext>>): AuthContext {
+  return {
+    sub: 'user-1',
+    tenantId: 'tenant-1',
+    orgId: null,
+    ...overrides,
+  }
+}
+
+describe('isOrganizationReadAccessAllowed', () => {
+  it('allows super admins', () => {
+    expect(
+      isOrganizationReadAccessAllowed({
+        scope: buildScope({ allowedIds: ['org-a'], filterIds: ['org-a'] }),
+        auth: buildAuth({ isSuperAdmin: true }),
+        organizationId: 'org-b',
+      }),
+    ).toBe(true)
+  })
+
+  it('allows unrestricted scope (allowedIds === null)', () => {
+    expect(
+      isOrganizationReadAccessAllowed({
+        scope: buildScope({ allowedIds: null, filterIds: null }),
+        auth: buildAuth({}),
+        organizationId: 'org-b',
+      }),
+    ).toBe(true)
+  })
+
+  it('denies a restricted floating user when the derived allowed set is empty (fail closed)', () => {
+    expect(
+      isOrganizationReadAccessAllowed({
+        scope: buildScope({ allowedIds: ['org-a'], filterIds: [] }),
+        auth: buildAuth({ orgId: null }),
+        organizationId: 'org-b',
+      }),
+    ).toBe(false)
+  })
+
+  it('denies a record outside the filtered view', () => {
+    expect(
+      isOrganizationReadAccessAllowed({
+        scope: buildScope({ allowedIds: ['org-a', 'org-b'], filterIds: ['org-a'] }),
+        auth: buildAuth({}),
+        organizationId: 'org-b',
+      }),
+    ).toBe(false)
+  })
+
+  it('allows a record inside the filtered view (allow-path regression)', () => {
+    expect(
+      isOrganizationReadAccessAllowed({
+        scope: buildScope({ allowedIds: ['org-a'], filterIds: ['org-a'] }),
+        auth: buildAuth({}),
+        organizationId: 'org-a',
+      }),
+    ).toBe(true)
+  })
+
+  it('falls back to the home org when no filter ids are present', () => {
+    expect(
+      isOrganizationReadAccessAllowed({
+        scope: buildScope({ allowedIds: ['org-a'], filterIds: null }),
+        auth: buildAuth({ orgId: 'org-a' }),
+        organizationId: 'org-a',
+      }),
+    ).toBe(true)
+  })
+})

--- a/packages/core/src/modules/directory/utils/organizationScopeGuard.ts
+++ b/packages/core/src/modules/directory/utils/organizationScopeGuard.ts
@@ -1,0 +1,39 @@
+import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
+import { isOrganizationAccessAllowed } from '@open-mercato/shared/lib/auth/organizationAccess'
+import type { OrganizationScope } from './organizationScope'
+
+export type OrganizationReadAccessInput = {
+  scope: OrganizationScope | null | undefined
+  auth: AuthContext
+  organizationId: string | null
+}
+
+/**
+ * Fail-closed read guard for single-record detail routes. Centralizes the
+ * decision so callers keep their own deny mechanism (throw / return response)
+ * and their own i18n key.
+ *
+ * Unrestricted access (super admin or `scope.allowedIds === null`) is the only
+ * bypass. For a restricted principal the allowed set is derived the same way
+ * the detail routes always have (`filterIds` narrows the active view, else the
+ * principal's home org); an empty derived set denies instead of skipping.
+ */
+export function isOrganizationReadAccessAllowed(input: OrganizationReadAccessInput): boolean {
+  const isSuperAdmin = input.auth?.isSuperAdmin === true
+  if (isSuperAdmin || input.scope?.allowedIds === null) return true
+
+  const allowedOrganizationIds = new Set<string>()
+  if (input.scope?.filterIds?.length) {
+    for (const id of input.scope.filterIds) {
+      if (typeof id === 'string' && id.trim().length) allowedOrganizationIds.add(id)
+    }
+  } else if (input.auth?.orgId) {
+    allowedOrganizationIds.add(input.auth.orgId)
+  }
+
+  return isOrganizationAccessAllowed({
+    isSuperAdmin,
+    allowedOrganizationIds: Array.from(allowedOrganizationIds),
+    targetOrganizationId: input.organizationId,
+  })
+}

--- a/packages/shared/src/lib/auth/__tests__/organizationAccess.test.ts
+++ b/packages/shared/src/lib/auth/__tests__/organizationAccess.test.ts
@@ -1,0 +1,63 @@
+import { isOrganizationAccessAllowed } from '@open-mercato/shared/lib/auth/organizationAccess'
+
+describe('isOrganizationAccessAllowed', () => {
+  it('allows super admins regardless of scope', () => {
+    expect(
+      isOrganizationAccessAllowed({
+        isSuperAdmin: true,
+        allowedOrganizationIds: [],
+        targetOrganizationId: 'org-b',
+      }),
+    ).toBe(true)
+  })
+
+  it('allows truly unrestricted access (allowedOrganizationIds === null)', () => {
+    expect(
+      isOrganizationAccessAllowed({
+        isSuperAdmin: false,
+        allowedOrganizationIds: null,
+        targetOrganizationId: 'org-b',
+      }),
+    ).toBe(true)
+  })
+
+  it('denies a restricted principal with an empty allowed set (fail closed)', () => {
+    expect(
+      isOrganizationAccessAllowed({
+        isSuperAdmin: false,
+        allowedOrganizationIds: [],
+        targetOrganizationId: 'org-b',
+      }),
+    ).toBe(false)
+  })
+
+  it('denies a restricted principal acting on an org outside the allowed set', () => {
+    expect(
+      isOrganizationAccessAllowed({
+        isSuperAdmin: false,
+        allowedOrganizationIds: ['org-a'],
+        targetOrganizationId: 'org-b',
+      }),
+    ).toBe(false)
+  })
+
+  it('allows a restricted principal acting on an org inside the allowed set', () => {
+    expect(
+      isOrganizationAccessAllowed({
+        isSuperAdmin: false,
+        allowedOrganizationIds: ['org-a'],
+        targetOrganizationId: 'org-a',
+      }),
+    ).toBe(true)
+  })
+
+  it('denies a restricted principal when the target org is missing', () => {
+    expect(
+      isOrganizationAccessAllowed({
+        isSuperAdmin: false,
+        allowedOrganizationIds: ['org-a'],
+        targetOrganizationId: null,
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/shared/src/lib/auth/organizationAccess.ts
+++ b/packages/shared/src/lib/auth/organizationAccess.ts
@@ -1,0 +1,22 @@
+export type OrganizationAccessDecisionInput = {
+  isSuperAdmin: boolean
+  allowedOrganizationIds: readonly string[] | null
+  targetOrganizationId: string | null
+}
+
+/**
+ * Fail-closed organization-access predicate. The single source of truth for
+ * "may this principal act on `targetOrganizationId`".
+ *
+ * Decision table:
+ * - `isSuperAdmin === true`            -> allow (global access)
+ * - `allowedOrganizationIds === null`  -> allow (truly unrestricted)
+ * - restricted + no target org         -> deny (empty/unknown scope is not a bypass)
+ * - restricted + target org            -> allow iff the target is a member of the allowed set
+ */
+export function isOrganizationAccessAllowed(input: OrganizationAccessDecisionInput): boolean {
+  if (input.isSuperAdmin) return true
+  if (input.allowedOrganizationIds === null) return true
+  if (!input.targetOrganizationId) return false
+  return input.allowedOrganizationIds.includes(input.targetOrganizationId)
+}

--- a/packages/shared/src/lib/commands/__tests__/scope.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/scope.test.ts
@@ -1,0 +1,86 @@
+import { ensureOrganizationScope } from '@open-mercato/shared/lib/commands/scope'
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+
+type ScopeShape = NonNullable<CommandRuntimeContext['organizationScope']>
+
+function buildCtx(overrides: {
+  isSuperAdmin?: boolean
+  orgId?: string | null
+  selectedOrganizationId?: string | null
+  organizationScope?: ScopeShape | null
+}): CommandRuntimeContext {
+  return {
+    container: {} as CommandRuntimeContext['container'],
+    auth: {
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: overrides.orgId ?? null,
+      isSuperAdmin: overrides.isSuperAdmin ?? false,
+    },
+    organizationScope: overrides.organizationScope ?? null,
+    selectedOrganizationId: overrides.selectedOrganizationId ?? null,
+    organizationIds: null,
+  }
+}
+
+function buildScope(overrides: Partial<ScopeShape>): ScopeShape {
+  return {
+    selectedId: null,
+    filterIds: null,
+    allowedIds: null,
+    tenantId: 'tenant-1',
+    ...overrides,
+  }
+}
+
+describe('ensureOrganizationScope', () => {
+  it('denies a restricted floating user acting on an org outside allowedIds (#2239)', () => {
+    const ctx = buildCtx({
+      orgId: null,
+      selectedOrganizationId: null,
+      organizationScope: buildScope({ allowedIds: ['org-a'], filterIds: ['org-a'] }),
+    })
+    expect(() => ensureOrganizationScope(ctx, 'org-b')).toThrow(CrudHttpError)
+  })
+
+  it('allows super admins', () => {
+    const ctx = buildCtx({
+      isSuperAdmin: true,
+      organizationScope: buildScope({ allowedIds: ['org-a'] }),
+    })
+    expect(() => ensureOrganizationScope(ctx, 'org-b')).not.toThrow()
+  })
+
+  it('allows truly unrestricted scope (allowedIds === null)', () => {
+    const ctx = buildCtx({
+      organizationScope: buildScope({ allowedIds: null }),
+    })
+    expect(() => ensureOrganizationScope(ctx, 'org-b')).not.toThrow()
+  })
+
+  it('allows a restricted user acting on an org inside allowedIds (allow-path regression)', () => {
+    const ctx = buildCtx({
+      orgId: 'org-a',
+      organizationScope: buildScope({ allowedIds: ['org-a'], filterIds: ['org-a'] }),
+    })
+    expect(() => ensureOrganizationScope(ctx, 'org-a')).not.toThrow()
+  })
+
+  describe('absent organization scope (Pattern C — legacy fallback, not deny)', () => {
+    it('allows when no current org can be resolved', () => {
+      const ctx = buildCtx({ orgId: null, selectedOrganizationId: null, organizationScope: null })
+      expect(() => ensureOrganizationScope(ctx, 'org-b')).not.toThrow()
+    })
+
+    it('allows when the resolved current org matches the target', () => {
+      const ctx = buildCtx({ selectedOrganizationId: 'org-a', organizationScope: null })
+      expect(() => ensureOrganizationScope(ctx, 'org-a')).not.toThrow()
+    })
+
+    it('denies when the resolved current org differs from the target', () => {
+      const ctx = buildCtx({ selectedOrganizationId: 'org-a', organizationScope: null })
+      expect(() => ensureOrganizationScope(ctx, 'org-b')).toThrow(CrudHttpError)
+    })
+  })
+})

--- a/packages/shared/src/lib/commands/scope.ts
+++ b/packages/shared/src/lib/commands/scope.ts
@@ -1,5 +1,6 @@
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import { isOrganizationAccessAllowed } from '@open-mercato/shared/lib/auth/organizationAccess'
 import { env } from 'process'
 
 function logScopeViolation(
@@ -89,16 +90,36 @@ function logTenantScopeViolation(
 }
 
 export function ensureOrganizationScope(ctx: CommandRuntimeContext, organizationId: string): void {
-  // Superadmins with global org access can operate on any organization's records
-  if (ctx.auth?.isSuperAdmin === true || ctx.organizationScope?.allowedIds === null) {
+  const isSuperAdmin = ctx.auth?.isSuperAdmin === true
+  const scope = ctx.organizationScope
+
+  // Pattern C: when no organization scope was resolved (system/worker/non-user
+  // command contexts that build ctx with `organizationScope: null`), preserve
+  // the legacy currentOrg fallback. This branch is load-bearing — switching it
+  // to deny would break payment, scheduled-command, and other scope-less flows.
+  if (!scope) {
+    if (isSuperAdmin) return
+    const currentOrg = ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null
+    if (currentOrg && currentOrg !== organizationId) {
+      logScopeViolation(ctx, organizationId, currentOrg)
+      throw new CrudHttpError(403, { error: 'Forbidden' })
+    }
+    return
+  }
+
+  if (
+    isOrganizationAccessAllowed({
+      isSuperAdmin,
+      allowedOrganizationIds: scope.allowedIds,
+      targetOrganizationId: organizationId,
+    })
+  ) {
     return
   }
 
   const currentOrg = ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null
-  if (currentOrg && currentOrg !== organizationId) {
-    logScopeViolation(ctx, organizationId, currentOrg)
-    throw new CrudHttpError(403, { error: 'Forbidden' })
-  }
+  logScopeViolation(ctx, organizationId, currentOrg)
+  throw new CrudHttpError(403, { error: 'Forbidden' })
 }
 
 export function ensureTenantScope(ctx: CommandRuntimeContext, tenantId: string): void {


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md
Status: complete

Closes #2239
Closes #2245

## Goal
Close an OWASP A01 fail-open authorization gap where organization-scope checks were **skipped** instead of **denied** when a restricted (non-super-admin) user has no resolvable current organization. One root cause (*empty allowed-org set ⇒ no check*) on two paths — write/command (#2239) and read/detail (#2245) — fixed via shared fail-closed helpers.

## What Changed
- **`ensureOrganizationScope` (shared, #2239)** rewritten on a new pure predicate `isOrganizationAccessAllowed`. `allowedIds === null` is the *only* unrestricted signal; any array (incl. `[]`) requires membership. The legacy `currentOrg` fallback is preserved **only** when `organizationScope` is entirely absent (Pattern C — load-bearing for ~40 system/worker/checkout/scheduler command contexts).
- **Read-path guard (core/directory, #2245)**: new predicate `isOrganizationReadAccessAllowed`; **10** audited fail-open detail-route guards migrated (people/companies/deals + sub-resources) plus the shared `entity-roles-factory` guard. An empty restricted set now denies instead of skipping. (`check-phone` was already fail-closed and is unchanged.)
- Reusable integration fixtures + `TC-CRM-072` spec (cross-org write deny, allow-path regression, cross-org read deny).
- Spec + pre-implementation analysis under `.ai/specs/`.

## Tests
- **25 unit tests, green**: predicate truth table; `ensureOrganizationScope` (incl. the #2239 vector, allow-path regression, and absent-scope-not-deny); read guard (incl. fail-closed empty set).
- `@open-mercato/shared` + `@open-mercato/core`: build + typecheck clean.
- **Integration `TC-CRM-072.spec.ts`: VALIDATED — `1 passed (56.9s)`** under the coherent ephemeral app+DB harness (`yarn test:integration:ephemeral TC-CRM-072`, Node 24.13.0). Closes the prior dev-DB-vs-fixtures-DB blocker.
- **Full validation gate green (Node 24.13.0)**: `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test` (20/20 workspaces), `yarn build:app` — all ✓.

## Security impact
Strengthens organization-level access control within a tenant (authorization). Behavioral change: a restricted "floating" user (`auth.orgId = null` + concrete/empty org-visibility ACL) is now denied (403) cross-org reads/writes that previously failed open. Cross-tenant was already blocked by `ensureTenantScope`. No secrets, encryption, or auth-token format changed. `ensureOrganizationScope` signature is unchanged (behavior hardened — permitted security change). Two new helpers are additive.

## Backward Compatibility
No contract surface broken. `ensureOrganizationScope` signature unchanged; new predicates are additive. Behavior tightening is a security fix, documented in the spec's Migration & Compatibility section.

## Completed (this resume)
- ✅ Validated `TC-CRM-072.spec.ts` under `yarn test:integration:ephemeral` — `1 passed`.
- ✅ Full validation gate (`yarn test`, `yarn build:app`) under Node 24.
- Standalone `yarn test:create-app:integration` was environment-blocked (pre-existing `mercato-verdaccio` container name conflict, not a code issue) — justified skip; the only added shared export is an additive internal predicate not used by the create-app template.

## Follow-ups (separate issues, out of scope)
- WHERE-clause scoping of single-record loads.
- Migrate Pattern C user-facing command routes to populate a real `organizationScope`.
- Re-audit `packages/enterprise/**`.

## Progress
See the [Tasks table in the plan](.ai/runs/2026-05-29-org-scope-fail-open-authorization-hardening/PLAN.md) — all rows `done`.
