### PR TITLE
fix(storage-s3): harden S3 upload validation and download headers

### DIFF
--- a/.ai/specs/implemented/SPEC-045i-storage-hub.md
+++ b/.ai/specs/implemented/SPEC-045i-storage-hub.md
@@ -357,12 +357,13 @@ The S3 integration can be used **independently** of the attachments module. This
 # Upload a file directly to S3
 POST /api/storage-providers/s3/upload
   Content-Type: multipart/form-data
-  Body: { file: File, key?: string, bucket?: string, contentType?: string }
-  Response: { key, bucket, url, size }
+  Body: { file: File, key?: string, contentType?: string }
+  Response: { key, bucket, size, contentType? }
+  Errors: 400 (missing file, blocked content type, S3 not configured), 403 (key not tenant-scoped), 413 (size/quota)
 
 # Download a file from S3
-GET /api/storage-providers/s3/download?key=exports/report-2026.csv&bucket=my-bucket
-  Response: File stream
+GET /api/storage-providers/s3/download?key=uploads/org_{orgId}/tenant_{tenantId}/report.csv&download=1
+  Response: File stream with security headers (see §10.1.1)
 
 # Generate a pre-signed URL for direct browser upload/download
 POST /api/storage-providers/s3/signed-url
@@ -371,7 +372,7 @@ POST /api/storage-providers/s3/signed-url
 
 # Delete a file from S3
 DELETE /api/storage-providers/s3/delete
-  Body: { key: string, bucket?: string }
+  Body: { key: string }
   Response: 204
 
 # List files by prefix
@@ -379,7 +380,40 @@ GET /api/storage-providers/s3/list?prefix=exports/&maxKeys=100
   Response: { files: [{ key, size, lastModified }], truncated, nextContinuationToken }
 ```
 
-All routes require `storage_providers.manage` feature and use the configured S3 integration credentials.
+All routes require `storage_providers.manage` feature and use the configured S3 integration credentials. Optional `key` overrides must be scoped to `org_{orgId}/tenant_{tenantId}` path segments.
+
+### 10.1.1 Upload & download security baseline
+
+Standalone S3 routes reuse the attachments module security helpers — do not duplicate validation logic in the provider package.
+
+**Shared helpers (core `attachments` module):**
+
+| Helper | Path | Used on |
+|--------|------|---------|
+| `hasDangerousExecutableExtension`, `detectAttachmentMimeType`, `isActiveContentAttachment`, `sanitizeUploadedFileName` | `attachments/lib/security.ts` | upload |
+| `isMultipartRequestWithinUploadLimit`, `resolveAttachmentMaxBytes`, `willExceedAttachmentTenantQuota` | `attachments/lib/upload-limits.ts` | upload |
+| `readTenantAttachmentUsageBytes` | `attachments/lib/tenant-usage.ts` | upload (quota) |
+| `canRenderInlineAttachment`, `buildAttachmentContentDisposition` | `attachments/lib/security.ts` | download |
+
+**Upload (`POST /api/storage-providers/s3/upload`) — before `putObject`:**
+
+1. Reject dangerous executable extensions (`hasDangerousExecutableExtension`).
+2. Enforce global upload size (`resolveAttachmentMaxBytes`, `OM_ATTACHMENT_MAX_UPLOAD_MB` / legacy alias) and multipart `Content-Length` preflight (`isMultipartRequestWithinUploadLimit`).
+3. Enforce tenant attachment storage quota (`readTenantAttachmentUsageBytes` + `willExceedAttachmentTenantQuota`; same env keys as attachments: `OM_ATTACHMENT_TENANT_QUOTA_MB`).
+4. Derive trusted MIME via `detectAttachmentMimeType(buffer, fileName)` — the multipart `contentType` field is **not** trusted for storage metadata.
+5. Reject active content (`isActiveContentAttachment`) — blocks HTML, SVG, XML, and sniffed equivalents.
+
+**Download (`GET /api/storage-providers/s3/download`) — application-origin proxy:**
+
+1. Derive effective MIME from buffer + key basename + stored S3 `Content-Type` (`detectAttachmentMimeType`).
+2. Set `X-Content-Type-Options: nosniff` and `Content-Security-Policy: default-src 'none'; sandbox` on every response.
+3. Default to `Content-Disposition: attachment`; render inline only when `canRenderInlineAttachment(mimeType)` (safe image types).
+4. Support `?download=1` to force attachment disposition even for inline-allowed types.
+
+**Known limitations / follow-up:**
+
+- `POST /api/storage-providers/s3/signed-url` with `operation: 'upload'` can still write arbitrary bytes directly to S3; XSS via the **app download proxy** is mitigated by §10.1.1 download headers, but presigned download URLs served from S3 retain object metadata.
+- Tenant quota on standalone upload counts **attachment table usage** only, not total S3 prefix size outside the attachments module.
 
 ### 10.2 StorageService (DI: `storageService`)
 
@@ -668,7 +702,9 @@ The S3 integration appears in the Integration Marketplace under the **Storage** 
 | Create partition with S3 config | `POST /api/attachments/partitions` | Create partition with `storageDriver: 's3'` and `configJson` |
 | Update partition storage driver | `PUT /api/attachments/partitions` | Change `storageDriver` on existing partition |
 | Standalone S3 upload | `POST /api/storage-providers/s3/upload` | Upload file directly to S3 without attachments module |
+| Standalone S3 upload security (unit) | `packages/storage-s3/.../upload.route.test.ts` | Rejects active content, executables, oversize, quota exhaustion |
 | Standalone S3 download | `GET /api/storage-providers/s3/download` | Download file from S3 by key |
+| Standalone S3 download security (unit) | `packages/storage-s3/.../download.route.test.ts` | Verifies nosniff/CSP/attachment headers; inline only for safe images |
 | Standalone S3 signed URL | `POST /api/storage-providers/s3/signed-url` | Get pre-signed URL for direct browser upload/download |
 | Legacy compat | `GET /api/attachments/file/{id}` | Existing `legacyPublic` driver attachments still accessible |
 | Library delete | `DELETE /api/attachments/library/{id}` | Delete via library endpoint using driver |
@@ -737,3 +773,4 @@ The `S3StorageDriver` class lives in `@open-mercato/storage-s3` (at `src/modules
 | 2026-03-10 | Claude | Initial draft — merged from SPEC-045e storage section and SPEC-058 (PR #875) |
 | 2026-03-11 | Claude | Removed database storage driver (PostgreSQL bytea); kept local (BC default) + S3 only. Added standalone S3 usage API and documentation (§10) for direct file operations without attachments module. |
 | 2026-04-28 | Claude | Post-CR fixes: moved S3StorageDriver + AWS SDK out of core into storage-s3; renamed s3Driver.ts → s3-driver.ts (kebab-case); added StorageDriverFactory.registerDriver() for external driver registration; gated storage_s3 behind OM_ENABLE_STORAGE_S3 env var; moved LocalStack behind docker compose profiles:storage-s3; added tenant-key scoping to standalone S3 API endpoints; fixed storage-service.ts to use driver.listObjects(); reverted accidental data/cache.db bump; added §16 Migration & Backward Compatibility section. |
+| 2026-05-29 | — | Security: standalone S3 upload/download aligned with attachments baseline (§10.1.1) — MIME sniffing, active-content block, size/quota limits, download nosniff/CSP/Content-Disposition; extracted `readTenantAttachmentUsageBytes` to `attachments/lib/tenant-usage.ts`; unit tests in `@open-mercato/storage-s3` (issue #2269). |

--- a/packages/core/src/modules/attachments/api/route.ts
+++ b/packages/core/src/modules/attachments/api/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from 'next/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { z } from 'zod'
-import { sql } from 'kysely'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { buildAttachmentFileUrl, buildAttachmentImageUrl, slugifyAttachmentFileName } from '../lib/imageUrls'
 import { ensureDefaultPartitions, resolveDefaultPartitionCode, sanitizePartitionCode } from '../lib/partitions'
@@ -39,6 +38,7 @@ import {
   resolveAttachmentMaxBytes,
   willExceedAttachmentTenantQuota,
 } from '../lib/upload-limits'
+import { readTenantAttachmentUsageBytes } from '../lib/tenant-usage'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 export const metadata = {
@@ -495,26 +495,6 @@ export async function POST(req: Request) {
       customFields: Object.keys(customFieldValues).length ? customFieldValues : undefined,
     },
   })
-}
-
-async function readTenantAttachmentUsageBytes(em: EntityManager, tenantId: string): Promise<number> {
-  try {
-    const db = em.getKysely<any>() as any
-    const row = await db
-      .selectFrom('attachments')
-      .select(sql<string>`sum(file_size)`.as('total_size'))
-      .where('tenant_id', '=', tenantId)
-      .executeTakeFirst() as { total_size: string | number | null } | undefined
-    const total = row?.total_size
-    if (typeof total === 'number') return Number.isFinite(total) ? total : 0
-    if (typeof total === 'string') {
-      const parsed = Number(total)
-      return Number.isFinite(parsed) ? parsed : 0
-    }
-    return 0
-  } catch {
-    return 0
-  }
 }
 
 export async function DELETE(req: Request) {

--- a/packages/core/src/modules/attachments/lib/tenant-usage.ts
+++ b/packages/core/src/modules/attachments/lib/tenant-usage.ts
@@ -1,0 +1,22 @@
+import { sql } from 'kysely'
+import type { EntityManager } from '@mikro-orm/postgresql'
+
+export async function readTenantAttachmentUsageBytes(em: EntityManager, tenantId: string): Promise<number> {
+  try {
+    const db = em.getKysely<any>() as any
+    const row = await db
+      .selectFrom('attachments')
+      .select(sql<string>`sum(file_size)`.as('total_size'))
+      .where('tenant_id', '=', tenantId)
+      .executeTakeFirst() as { total_size: string | number | null } | undefined
+    const total = row?.total_size
+    if (typeof total === 'number') return Number.isFinite(total) ? total : 0
+    if (typeof total === 'string') {
+      const parsed = Number(total)
+      return Number.isFinite(parsed) ? parsed : 0
+    }
+    return 0
+  } catch {
+    return 0
+  }
+}

--- a/packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/__tests__/download.route.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/__tests__/download.route.test.ts
@@ -1,0 +1,107 @@
+/** @jest-environment node */
+
+const mockRead = jest.fn()
+
+jest.mock('../../../../../lib/s3-driver', () => ({
+  S3StorageDriver: jest.fn().mockImplementation(() => ({
+    read: mockRead,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    tenantId: 'tenant-1',
+    orgId: 'org-1',
+    roles: ['admin'],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (key: string) => {
+      if (key === 'integrationCredentialsService') {
+        return {
+          resolve: jest.fn(async () => ({
+            bucket: 'test-bucket',
+            accessKeyId: 'AKID',
+            secretAccessKey: 'SECRET',
+          })),
+        }
+      }
+      return null
+    },
+  })),
+}))
+
+type DownloadRoute = typeof import('../download')
+
+const scopedKey = 'uploads/org_org-1/tenant_tenant-1/20260101_photo.png'
+
+describe('S3 download route', () => {
+  let GET: DownloadRoute['GET']
+
+  beforeAll(async () => {
+    GET = (await import('../download')).GET
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('serves safe images inline with protective headers', async () => {
+    const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00])
+    mockRead.mockResolvedValueOnce({ buffer: pngHeader, contentType: 'text/html' })
+
+    const response = await GET(
+      new Request(`http://localhost/api/storage-providers/s3/download?key=${encodeURIComponent(scopedKey)}`),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('image/png')
+    expect(response.headers.get('Content-Disposition')).toContain('inline')
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+    expect(response.headers.get('Content-Security-Policy')).toBe("default-src 'none'; sandbox")
+  })
+
+  it('forces attachment disposition for active content', async () => {
+    mockRead.mockResolvedValueOnce({
+      buffer: Buffer.from('<html><script>alert(1)</script></html>', 'utf8'),
+      contentType: 'text/html',
+    })
+    const htmlKey = 'uploads/org_org-1/tenant_tenant-1/page.html'
+
+    const response = await GET(
+      new Request(`http://localhost/api/storage-providers/s3/download?key=${encodeURIComponent(htmlKey)}`),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/octet-stream')
+    expect(response.headers.get('Content-Disposition')).toContain('attachment')
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+    expect(response.headers.get('Content-Security-Policy')).toBe("default-src 'none'; sandbox")
+  })
+
+  it('forces attachment when download=1 is set even for safe images', async () => {
+    const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00])
+    mockRead.mockResolvedValueOnce({ buffer: pngHeader, contentType: 'image/png' })
+
+    const response = await GET(
+      new Request(`http://localhost/api/storage-providers/s3/download?key=${encodeURIComponent(scopedKey)}&download=1`),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/octet-stream')
+    expect(response.headers.get('Content-Disposition')).toContain('attachment')
+  })
+
+  it('rejects keys outside tenant scope', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/storage-providers/s3/download?key=exports/other-tenant/file.txt'),
+    )
+
+    expect(response.status).toBe(403)
+    expect(mockRead).not.toHaveBeenCalled()
+  })
+})
+
+export {}

--- a/packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/download.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/download.ts
@@ -1,8 +1,14 @@
+import path from 'path'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import {
+  buildAttachmentContentDisposition,
+  canRenderInlineAttachment,
+  detectAttachmentMimeType,
+} from '@open-mercato/core/modules/attachments/lib/security'
 import { S3StorageDriver } from '../../../../lib/s3-driver'
 
 export const metadata = {
@@ -31,7 +37,8 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const key = new URL(req.url).searchParams.get('key')
+  const url = new URL(req.url)
+  const key = url.searchParams.get('key')
   if (!key) {
     return NextResponse.json({ error: 'key query param is required' }, { status: 400 })
   }
@@ -46,20 +53,34 @@ export async function GET(req: Request) {
   }
 
   let buffer: Buffer
-  let contentType: string | undefined
+  let storedContentType: string | undefined
   try {
     const result = await driver.read('', key)
     buffer = result.buffer
-    contentType = result.contentType
+    storedContentType = result.contentType
   } catch {
     return NextResponse.json({ error: 'File not found' }, { status: 404 })
   }
 
+  const fileName = path.basename(key)
+  const effectiveMimeType = detectAttachmentMimeType(buffer, fileName, storedContentType)
+  const forceDownload = url.searchParams.get('download') === '1'
+  const renderInline = !forceDownload && canRenderInlineAttachment(effectiveMimeType)
+
   return new NextResponse(new Uint8Array(buffer), {
     status: 200,
     headers: {
-      'Content-Type': contentType ?? 'application/octet-stream',
+      'Cache-Control': 'private, max-age=60',
+      'Content-Security-Policy': "default-src 'none'; sandbox",
+      'Content-Type': renderInline
+        ? effectiveMimeType || 'application/octet-stream'
+        : 'application/octet-stream',
+      'Content-Disposition': buildAttachmentContentDisposition(
+        fileName,
+        renderInline ? 'inline' : 'attachment',
+      ),
       'Content-Length': String(buffer.length),
+      'X-Content-Type-Options': 'nosniff',
     },
   })
 }
@@ -73,7 +94,10 @@ export const openApi: OpenApiRouteDoc = {
     GET: {
       summary: 'Download a file from S3 by key',
       description: 'Streams the file content for the given S3 key. Requires storage_providers.manage feature.',
-      query: z.object({ key: z.string().describe('S3 object key') }),
+      query: z.object({
+        key: z.string().describe('S3 object key'),
+        download: z.string().optional().describe('Set to 1 to force attachment download'),
+      }),
       responses: [{ status: 200, description: 'File content stream', schema: z.any() }],
       errors: [
         { status: 400, description: 'Missing key or S3 not configured', schema: z.object({ error: z.string() }) },

--- a/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/__tests__/upload.route.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/__tests__/upload.route.test.ts
@@ -1,0 +1,154 @@
+/** @jest-environment node */
+
+const mockPutObject = jest.fn().mockResolvedValue(undefined)
+const mockGetBucket = jest.fn().mockReturnValue('test-bucket')
+const mockReadTenantAttachmentUsageBytes = jest.fn(async () => 0)
+
+jest.mock('../../../../../lib/s3-driver', () => ({
+  S3StorageDriver: jest.fn().mockImplementation(() => ({
+    putObject: mockPutObject,
+    getBucket: mockGetBucket,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    tenantId: 'tenant-1',
+    orgId: 'org-1',
+    roles: ['admin'],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    t: (_key: string, fallback: string) => fallback,
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/attachments/lib/tenant-usage', () => ({
+  readTenantAttachmentUsageBytes: () => mockReadTenantAttachmentUsageBytes(),
+}))
+
+const mockEm = {}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (key: string) => {
+      if (key === 'em') return mockEm
+      if (key === 'integrationCredentialsService') {
+        return {
+          resolve: jest.fn(async () => ({
+            bucket: 'test-bucket',
+            accessKeyId: 'AKID',
+            secretAccessKey: 'SECRET',
+          })),
+        }
+      }
+      return null
+    },
+  })),
+}))
+
+type UploadRoute = typeof import('../upload')
+
+function buildMultipartRequest(file: File, extra: Record<string, string> = {}) {
+  const form = new FormData()
+  form.set('file', file)
+  for (const [key, value] of Object.entries(extra)) {
+    form.set(key, value)
+  }
+  return new Request('http://localhost/api/storage-providers/s3/upload', {
+    method: 'POST',
+    body: form,
+  })
+}
+
+function scopedKey(fileName: string) {
+  return `uploads/org_org-1/tenant_tenant-1/${fileName}`
+}
+
+describe('S3 upload route', () => {
+  let POST: UploadRoute['POST']
+
+  beforeAll(async () => {
+    POST = (await import('../upload')).POST
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockReadTenantAttachmentUsageBytes.mockResolvedValue(0)
+    process.env.OM_ATTACHMENT_MAX_UPLOAD_MB = '25'
+    process.env.OM_ATTACHMENT_TENANT_QUOTA_MB = '512'
+  })
+
+  afterEach(() => {
+    delete process.env.OM_ATTACHMENT_MAX_UPLOAD_MB
+    delete process.env.OM_ATTACHMENT_TENANT_QUOTA_MB
+  })
+
+  it('uploads a safe file with trusted MIME type', async () => {
+    const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00])
+    const file = new File([pngHeader], 'photo.png', { type: 'text/html' })
+    const response = await POST(buildMultipartRequest(file))
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.key).toContain('org_org-1/tenant_tenant-1/')
+    expect(body.contentType).toBe('image/png')
+    expect(mockPutObject).toHaveBeenCalledWith(
+      expect.stringContaining('photo.png'),
+      expect.any(Buffer),
+      'image/png',
+    )
+  })
+
+  it('rejects active content uploads', async () => {
+    const file = new File(['<html><script>alert(1)</script></html>'], 'page.html', { type: 'text/plain' })
+    const response = await POST(buildMultipartRequest(file, { key: scopedKey('page.html') }))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Active content uploads are not allowed.' })
+    expect(mockPutObject).not.toHaveBeenCalled()
+  })
+
+  it('rejects dangerous executable extensions', async () => {
+    const file = new File(['echo bad'], 'script.ps1', { type: 'application/octet-stream' })
+    const response = await POST(buildMultipartRequest(file, { key: scopedKey('script.ps1') }))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Executable file types are not allowed as attachments.' })
+    expect(mockPutObject).not.toHaveBeenCalled()
+  })
+
+  it('rejects files above the global upload limit', async () => {
+    process.env.OM_ATTACHMENT_MAX_UPLOAD_MB = '1'
+    const file = new File([Buffer.alloc(2 * 1024 * 1024)], 'large.bin', { type: 'application/octet-stream' })
+    const response = await POST(buildMultipartRequest(file, { key: scopedKey('large.bin') }))
+
+    expect(response.status).toBe(413)
+    expect(await response.json()).toEqual({ error: 'Attachment exceeds the maximum upload size.' })
+    expect(mockPutObject).not.toHaveBeenCalled()
+  })
+
+  it('rejects uploads that exceed the tenant attachment quota', async () => {
+    process.env.OM_ATTACHMENT_TENANT_QUOTA_MB = '1'
+    mockReadTenantAttachmentUsageBytes.mockResolvedValueOnce(1_048_576)
+    const file = new File(['small payload'], 'note.txt', { type: 'text/plain' })
+    const response = await POST(buildMultipartRequest(file, { key: scopedKey('note.txt') }))
+
+    expect(response.status).toBe(413)
+    expect(await response.json()).toEqual({ error: 'Attachment storage quota exceeded for this tenant.' })
+    expect(mockPutObject).not.toHaveBeenCalled()
+  })
+
+  it('rejects key overrides outside tenant scope', async () => {
+    const file = new File(['hello'], 'note.txt', { type: 'text/plain' })
+    const response = await POST(buildMultipartRequest(file, { key: 'exports/other-tenant/note.txt' }))
+
+    expect(response.status).toBe(403)
+    expect(mockPutObject).not.toHaveBeenCalled()
+  })
+})
+
+export {}

--- a/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
@@ -3,6 +3,20 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import {
+  detectAttachmentMimeType,
+  hasDangerousExecutableExtension,
+  isActiveContentAttachment,
+  sanitizeUploadedFileName,
+} from '@open-mercato/core/modules/attachments/lib/security'
+import {
+  isMultipartRequestWithinUploadLimit,
+  resolveAttachmentMaxBytes,
+  willExceedAttachmentTenantQuota,
+} from '@open-mercato/core/modules/attachments/lib/upload-limits'
+import { readTenantAttachmentUsageBytes } from '@open-mercato/core/modules/attachments/lib/tenant-usage'
 import { S3StorageDriver } from '../../../../lib/s3-driver'
 import { randomUUID } from 'crypto'
 
@@ -17,10 +31,6 @@ const responseSchema = z.object({
   size: z.number().int(),
   contentType: z.string().optional(),
 })
-
-function sanitizeFileName(name: string): string {
-  return name.replace(/[^a-zA-Z0-9._-]/g, '_') || 'upload'
-}
 
 function isKeyScoped(key: string, orgId: string, tenantId: string): boolean {
   const parts = key.split('/')
@@ -46,9 +56,16 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const { t } = await resolveTranslations()
+
   const contentType = req.headers.get('content-type') ?? ''
   if (!contentType.includes('multipart/form-data')) {
     return NextResponse.json({ error: 'Expected multipart/form-data' }, { status: 400 })
+  }
+  if (!isMultipartRequestWithinUploadLimit(req.headers.get('content-length'))) {
+    return NextResponse.json({
+      error: t('attachments.errors.maxUploadSize', 'Attachment exceeds the maximum upload size.'),
+    }, { status: 413 })
   }
 
   const form = await req.formData()
@@ -58,7 +75,6 @@ export async function POST(req: Request) {
   }
 
   const keyOverride = form.get('key') ? String(form.get('key')) : null
-  const contentTypeHeader = form.get('contentType') ? String(form.get('contentType')) : file.type || undefined
 
   if (keyOverride !== null && !isKeyScoped(keyOverride, auth.orgId, auth.tenantId)) {
     return NextResponse.json(
@@ -67,24 +83,53 @@ export async function POST(req: Request) {
     )
   }
 
+  if (hasDangerousExecutableExtension(file.name)) {
+    return NextResponse.json({
+      error: t('attachments.errors.dangerousExecutable', 'Executable file types are not allowed as attachments.'),
+    }, { status: 400 })
+  }
+
+  const effectiveMaxBytes = resolveAttachmentMaxBytes()
+  if (file.size > effectiveMaxBytes) {
+    return NextResponse.json({
+      error: t('attachments.errors.maxUploadSize', 'Attachment exceeds the maximum upload size.'),
+    }, { status: 413 })
+  }
+
+  const { resolve } = await createRequestContainer()
+  const em = resolve('em') as EntityManager
+  const tenantUsageBytes = await readTenantAttachmentUsageBytes(em, auth.tenantId)
+  if (willExceedAttachmentTenantQuota(tenantUsageBytes, file.size)) {
+    return NextResponse.json({
+      error: t('attachments.errors.quotaExceeded', 'Attachment storage quota exceeded for this tenant.'),
+    }, { status: 413 })
+  }
+
   const driver = await resolveDriver(auth.tenantId, auth.orgId)
   if (!driver) {
     return NextResponse.json({ error: 'S3 integration is not configured.' }, { status: 400 })
   }
 
   const buffer = Buffer.from(await file.arrayBuffer())
-  const safeName = sanitizeFileName(file.name)
+  const safeName = sanitizeUploadedFileName(file.name)
+  const trustedContentType = detectAttachmentMimeType(buffer, safeName, file.type)
+  if (isActiveContentAttachment(buffer, safeName, trustedContentType)) {
+    return NextResponse.json({
+      error: t('attachments.errors.activeContentBlocked', 'Active content uploads are not allowed.'),
+    }, { status: 400 })
+  }
+
   const key =
     keyOverride ??
     `uploads/org_${auth.orgId}/tenant_${auth.tenantId}/${Date.now()}_${randomUUID().slice(0, 8)}_${safeName}`
 
-  await driver.putObject(key, buffer, contentTypeHeader)
+  await driver.putObject(key, buffer, trustedContentType)
 
   return NextResponse.json({
     key,
     bucket: driver.getBucket(),
     size: buffer.length,
-    contentType: contentTypeHeader,
+    contentType: trustedContentType,
   })
 }
 
@@ -102,14 +147,15 @@ export const openApi: OpenApiRouteDoc = {
         schema: z.object({
           file: z.any().describe('File to upload'),
           key: z.string().optional().describe('Optional S3 key override (must be scoped to org/tenant)'),
-          contentType: z.string().optional().describe('Optional content-type override'),
+          contentType: z.string().optional().describe('Ignored for trust; MIME is derived from file content and name'),
         }),
       },
       responses: [{ status: 200, description: 'Upload result', schema: responseSchema }],
       errors: [
-        { status: 400, description: 'Missing file or S3 not configured', schema: z.object({ error: z.string() }) },
+        { status: 400, description: 'Missing file, blocked content type, or S3 not configured', schema: z.object({ error: z.string() }) },
         { status: 401, description: 'Unauthorized', schema: z.object({ error: z.string() }) },
         { status: 403, description: 'Key override not scoped to this tenant', schema: z.object({ error: z.string() }) },
+        { status: 413, description: 'File exceeds size or tenant quota limits', schema: z.object({ error: z.string() }) },
       ],
     },
   },


### PR DESCRIPTION

## Summary

Standalone S3 upload/download routes (gated by `storage_providers.manage`) accepted attacker-controlled `contentType`, skipped attachment security checks, and served files inline without protective headers — enabling stored XSS in the application origin and storage exhaustion.

This PR aligns standalone S3 routes with the attachments security baseline: upload validation (MIME sniffing, dangerous extensions, active content, size limits, tenant quota) and download hardening (`nosniff`, CSP sandbox, safe `Content-Disposition`).

Fixes [open-mercato/open-mercato#2269](https://github.com/open-mercato/open-mercato/issues/2269).

## Changes

- **upload.ts** — reuse `attachments/lib/security` and `upload-limits`; reject dangerous/active content; derive trusted MIME via `detectAttachmentMimeType`; enforce size and tenant quota before `putObject`
- **download.ts** — add `X-Content-Type-Options: nosniff`, `Content-Security-Policy: default-src 'none'; sandbox`, and `Content-Disposition: attachment` by default; inline only for `canRenderInlineAttachment`; support `?download=1`
- **tenant-usage.ts** — extract `readTenantAttachmentUsageBytes` for shared quota lookup
- **attachments/api/route.ts** — import quota helper from `tenant-usage.ts`
- **Unit tests** — `upload.route.test.ts` and `download.route.test.ts` in `@open-mercato/storage-s3`
- **Spec** — update `SPEC-045i-storage-hub.md` (§10.1, §10.1.1, §14, changelog)

## Specification

**Does a spec exist for this feature/module?**

- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:** `.ai/specs/implemented/SPEC-045i-storage-hub.md` (§10.1.1 Upload & download security baseline)

## Testing

- `yarn workspace @open-mercato/storage-s3 test`
- `yarn workspace @open-mercato/core test -- packages/core/src/modules/attachments/lib/__tests__/upload-limits.test.ts`
- `yarn generate`
- `yarn typecheck`

Integration tests not added: security behavior covered by new unit tests; existing `TC-ATT-006` still covers standalone S3 happy path. Presigned upload bypass (`signed-url`) documented as known limitation in spec §10.1.1 (out of scope for #2269).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance

Backend-only change — no UI touched. Design System checklist items are not applicable.

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #2269