### PR TITLE
feat(ui): auto-hide completed progress operations after configurable timeout (#2206)

### DIFF
--- a/packages/ui/src/backend/AppShell.tsx
+++ b/packages/ui/src/backend/AppShell.tsx
@@ -111,6 +111,11 @@ export type AppShellProps = {
   profileSectionTitle?: string
   profilePathPrefixes?: string[]
   mobileSidebarSlot?: React.ReactNode
+  /**
+   * How long (ms) to keep successfully completed progress operations visible
+   * before auto-hiding. Pass `false` or `0` to disable. Defaults to 10 000 ms.
+   */
+  progressCompletedAutoHideMs?: number | false
 }
 
 type Breadcrumb = Array<{ label: string; href?: string }>
@@ -417,7 +422,7 @@ export function AppShell(props: AppShellProps) {
   )
 }
 
-function AppShellBody({ productName, logo, email, canManageUpgradeActions = false, groups, rightHeaderSlot, children, sidebarCollapsedDefault = false, currentTitle, breadcrumb, version, settingsSectionTitle, settingsPathPrefixes = [], settingsSections, profileSections, profileSectionTitle, profilePathPrefixes = [], mobileSidebarSlot }: AppShellProps) {
+function AppShellBody({ productName, logo, email, canManageUpgradeActions = false, groups, rightHeaderSlot, children, sidebarCollapsedDefault = false, currentTitle, breadcrumb, version, settingsSectionTitle, settingsPathPrefixes = [], settingsSections, profileSections, profileSectionTitle, profilePathPrefixes = [], mobileSidebarSlot, progressCompletedAutoHideMs }: AppShellProps) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const t = useT()
@@ -1337,7 +1342,7 @@ function AppShellBody({ productName, logo, email, canManageUpgradeActions = fals
             )}
           </div>
         </header>
-        <ProgressTopBar t={t} className="sticky top-0 z-sticky" />
+        <ProgressTopBar t={t} className="sticky top-0 z-sticky" completedAutoHideMs={progressCompletedAutoHideMs} />
         <main className="flex-1 p-4 lg:p-6 mx-auto w-full max-w-screen-2xl">
           <InjectionSpot spotId={BACKEND_LAYOUT_TOP_INJECTION_SPOT_ID} context={injectionContext} />
           <FlashMessages />

--- a/packages/ui/src/backend/__tests__/useAutoHideCompletedJobs.test.tsx
+++ b/packages/ui/src/backend/__tests__/useAutoHideCompletedJobs.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { useAutoHideCompletedJobs } from '../progress/useAutoHideCompletedJobs'
+import type { ProgressJobDto } from '../progress/useProgressPoll'
+
+function makeJob(overrides: Partial<ProgressJobDto> = {}): ProgressJobDto {
+  return {
+    id: 'job-1',
+    jobType: 'bulk-delete',
+    name: 'Delete selected',
+    status: 'completed',
+    progressPercent: 100,
+    processedCount: 5,
+    cancellable: false,
+    finishedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('useAutoHideCompletedJobs', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('hides a completed job after the timeout elapses', () => {
+    const jobs = [makeJob({ id: 'j1', finishedAt: new Date().toISOString() })]
+    const { result } = renderHook(() => useAutoHideCompletedJobs(jobs, 10_000))
+
+    expect(result.current).toHaveLength(1)
+
+    act(() => { jest.advanceTimersByTime(10_000) })
+
+    expect(result.current).toHaveLength(0)
+  })
+
+  it('keeps failed jobs visible after the timeout', () => {
+    const jobs = [
+      makeJob({ id: 'j-ok', status: 'completed', finishedAt: new Date().toISOString() }),
+      makeJob({ id: 'j-fail', status: 'failed', finishedAt: new Date().toISOString() }),
+    ]
+    const { result } = renderHook(() => useAutoHideCompletedJobs(jobs, 10_000))
+
+    act(() => { jest.advanceTimersByTime(10_000) })
+
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].id).toBe('j-fail')
+  })
+
+  it('keeps cancelled jobs visible after the timeout', () => {
+    const jobs = [
+      makeJob({ id: 'j-cancel', status: 'cancelled', finishedAt: new Date().toISOString() }),
+    ]
+    const { result } = renderHook(() => useAutoHideCompletedJobs(jobs, 10_000))
+
+    act(() => { jest.advanceTimersByTime(10_000) })
+
+    expect(result.current).toHaveLength(1)
+  })
+
+  it('hides each job based on its own finishedAt (no false-positive cascade)', () => {
+    const now = Date.now()
+    const jobs = [
+      makeJob({ id: 'j-early', finishedAt: new Date(now - 8_000).toISOString() }), // finished 8s ago
+      makeJob({ id: 'j-late', finishedAt: new Date(now).toISOString() }),           // just finished
+    ]
+    const { result } = renderHook(() => useAutoHideCompletedJobs(jobs, 10_000))
+
+    // After 2s more, the early job (8s+2s=10s) should expire
+    act(() => { jest.advanceTimersByTime(2_000) })
+    expect(result.current.map((j) => j.id)).toEqual(['j-late'])
+
+    // After another 8s, the late job expires too
+    act(() => { jest.advanceTimersByTime(8_000) })
+    expect(result.current).toHaveLength(0)
+  })
+
+  it('immediately hides completed jobs whose finishedAt is already past the timeout', () => {
+    const pastFinishedAt = new Date(Date.now() - 15_000).toISOString() // finished 15s ago
+    const jobs = [makeJob({ id: 'j-old', finishedAt: pastFinishedAt })]
+    const { result } = renderHook(() => useAutoHideCompletedJobs(jobs, 10_000))
+
+    // No timer needed — should already be filtered out
+    expect(result.current).toHaveLength(0)
+  })
+
+  it('does not hide when timeoutMs is false', () => {
+    const jobs = [makeJob({ id: 'j1' })]
+    const { result } = renderHook(() => useAutoHideCompletedJobs(jobs, false))
+
+    act(() => { jest.advanceTimersByTime(60_000) })
+
+    expect(result.current).toHaveLength(1)
+  })
+
+  it('does not hide when timeoutMs is 0', () => {
+    const jobs = [makeJob({ id: 'j1' })]
+    const { result } = renderHook(() => useAutoHideCompletedJobs(jobs, 0))
+
+    act(() => { jest.advanceTimersByTime(60_000) })
+
+    expect(result.current).toHaveLength(1)
+  })
+
+  it('respects a custom timeout', () => {
+    const jobs = [makeJob({ id: 'j1', finishedAt: new Date().toISOString() })]
+    const { result } = renderHook(() => useAutoHideCompletedJobs(jobs, 3_000))
+
+    act(() => { jest.advanceTimersByTime(2_999) })
+    expect(result.current).toHaveLength(1)
+
+    act(() => { jest.advanceTimersByTime(1) })
+    expect(result.current).toHaveLength(0)
+  })
+
+  it('does not re-schedule a timer when jobs list updates with the same completed job', () => {
+    const job = makeJob({ id: 'j1', finishedAt: new Date().toISOString() })
+    const { result, rerender } = renderHook(
+      ({ jobs }: { jobs: ProgressJobDto[] }) => useAutoHideCompletedJobs(jobs, 10_000),
+      { initialProps: { jobs: [job] } },
+    )
+
+    act(() => { jest.advanceTimersByTime(5_000) })
+    // Simulate poll refresh — same job still in list
+    rerender({ jobs: [job] })
+
+    // Timer should expire at original 10s mark, not reset to 15s
+    act(() => { jest.advanceTimersByTime(5_000) })
+    expect(result.current).toHaveLength(0)
+  })
+
+  it('clears timers on unmount without errors', () => {
+    const jobs = [makeJob({ id: 'j1', finishedAt: new Date().toISOString() })]
+    const { unmount } = renderHook(() => useAutoHideCompletedJobs(jobs, 10_000))
+
+    expect(() => {
+      unmount()
+      jest.advanceTimersByTime(15_000)
+    }).not.toThrow()
+  })
+
+  it('treats a malformed finishedAt as "just finished" — does not error and hides after full timeout', () => {
+    const jobs = [makeJob({ id: 'j-bad', finishedAt: 'not-a-date' })]
+    const { result } = renderHook(() => useAutoHideCompletedJobs(jobs, 10_000))
+
+    // Should be visible initially (malformed → treated as now)
+    expect(result.current).toHaveLength(1)
+
+    act(() => { jest.advanceTimersByTime(10_000) })
+
+    expect(result.current).toHaveLength(0)
+  })
+
+  it('stays hidden when list cycles through empty — does not restart timer', () => {
+    const job = makeJob({ id: 'j1', finishedAt: new Date().toISOString() })
+    const { result, rerender } = renderHook(
+      ({ jobs }: { jobs: ProgressJobDto[] }) => useAutoHideCompletedJobs(jobs, 10_000),
+      { initialProps: { jobs: [job] } },
+    )
+
+    // Advance past the timeout so job expires
+    act(() => { jest.advanceTimersByTime(10_000) })
+    expect(result.current).toHaveLength(0)
+
+    // List goes empty then comes back with the same job
+    rerender({ jobs: [] })
+    rerender({ jobs: [job] })
+
+    // Job should stay hidden — scheduledRef prevents re-scheduling
+    expect(result.current).toHaveLength(0)
+  })
+})

--- a/packages/ui/src/backend/progress/ProgressTopBar.tsx
+++ b/packages/ui/src/backend/progress/ProgressTopBar.tsx
@@ -5,6 +5,7 @@ import { Button } from '../../primitives/button'
 import { Progress } from '../../primitives/progress'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { useProgress } from './useProgress'
+import { useAutoHideCompletedJobs } from './useAutoHideCompletedJobs'
 import type { ProgressJobDto } from './useProgressPoll'
 import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
 import { apiCall } from '../utils/apiCall'
@@ -12,10 +13,17 @@ import { apiCall } from '../utils/apiCall'
 export type ProgressTopBarProps = {
   className?: string
   t: TranslateFn
+  /**
+   * How long (ms) to keep successfully completed jobs visible before auto-hiding.
+   * Set to `false` or `0` to disable auto-hide. Defaults to 10 000 ms.
+   * Failed and cancelled jobs are never auto-hidden.
+   */
+  completedAutoHideMs?: number | false
 }
 
-export function ProgressTopBar({ className, t }: ProgressTopBarProps) {
+export function ProgressTopBar({ className, t, completedAutoHideMs }: ProgressTopBarProps) {
   const { activeJobs, recentlyCompleted, refresh } = useProgress()
+  const visibleCompleted = useAutoHideCompletedJobs(recentlyCompleted, completedAutoHideMs)
   const [expanded, setExpanded] = React.useState(false)
 
   React.useEffect(() => {
@@ -28,7 +36,7 @@ export function ProgressTopBar({ className, t }: ProgressTopBarProps) {
   }, [expanded])
 
   const hasActiveJobs = activeJobs.length > 0
-  const hasRecentJobs = recentlyCompleted.length > 0
+  const hasRecentJobs = visibleCompleted.length > 0
 
   if (!hasActiveJobs && !hasRecentJobs) return null
 
@@ -60,7 +68,7 @@ export function ProgressTopBar({ className, t }: ProgressTopBarProps) {
             <>
               <CheckCircle className="h-4 w-4 text-status-success-icon" />
               <span className="text-muted-foreground">
-                {t('progress.recentlyCompleted', '{count} operations completed', { count: recentlyCompleted.length })}
+                {t('progress.recentlyCompleted', '{count} operations completed', { count: visibleCompleted.length })}
               </span>
             </>
           )}
@@ -77,7 +85,7 @@ export function ProgressTopBar({ className, t }: ProgressTopBarProps) {
           {activeJobs.map((job) => (
             <ProgressJobCard key={job.id} job={job} t={t} onCancel={refresh} />
           ))}
-          {recentlyCompleted.map((job) => (
+          {visibleCompleted.map((job) => (
             <ProgressJobCard key={job.id} job={job} t={t} />
           ))}
         </div>

--- a/packages/ui/src/backend/progress/useAutoHideCompletedJobs.ts
+++ b/packages/ui/src/backend/progress/useAutoHideCompletedJobs.ts
@@ -1,0 +1,100 @@
+"use client"
+import * as React from 'react'
+import type { ProgressJobDto } from './useProgressPoll'
+
+/** Default auto-hide delay for successfully completed progress jobs (ms). */
+export const DEFAULT_AUTO_HIDE_MS = 10_000
+
+function safeParseMs(isoString: string | null | undefined): number | null {
+  if (!isoString) return null
+  const ms = new Date(isoString).getTime()
+  return isNaN(ms) ? null : ms
+}
+
+/**
+ * Hides successfully completed progress jobs after a configurable timeout.
+ *
+ * Uses `finishedAt` so a job that finished 8s ago with a 10s timeout
+ * disappears in 2s instead of a full new 10s window — works correctly
+ * after panel collapse/expand or page focus restore.
+ *
+ * Pass `timeoutMs={false}` or `timeoutMs={0}` to disable auto-hide.
+ * Failed and cancelled jobs are never hidden automatically.
+ *
+ * Each completed job ID is scheduled at most once. If the same job ID
+ * reappears in the list after its timer has already fired (which should
+ * not occur in normal server behaviour), it remains hidden.
+ */
+export function useAutoHideCompletedJobs(
+  completed: ProgressJobDto[],
+  timeoutMs: number | false = DEFAULT_AUTO_HIDE_MS,
+): ProgressJobDto[] {
+  const [expiredIds, setExpiredIds] = React.useState<ReadonlySet<string>>(new Set())
+  // Tracks IDs for which a hide-timer has been scheduled to prevent double-scheduling
+  // on poll/SSE refresh cycles. IDs remain here after the timer fires so a reappearing
+  // job (should not happen) stays hidden rather than restarting the countdown.
+  const scheduledRef = React.useRef<Set<string>>(new Set())
+  const timersRef = React.useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  // Clear all pending timers on unmount
+  React.useEffect(() => {
+    return () => {
+      for (const t of timersRef.current.values()) clearTimeout(t)
+      timersRef.current.clear()
+      scheduledRef.current.clear()
+    }
+  }, [])
+
+  React.useEffect(() => {
+    if (timeoutMs === false || timeoutMs <= 0) return
+
+    const now = Date.now()
+    const timeout = timeoutMs as number
+
+    for (const job of completed) {
+      if (job.status !== 'completed') continue
+      if (scheduledRef.current.has(job.id)) continue
+
+      scheduledRef.current.add(job.id)
+
+      const finishedAt = safeParseMs(job.finishedAt) ?? now
+      const elapsed = now - finishedAt
+      const remaining = Math.max(0, timeout - elapsed)
+
+      if (remaining === 0) {
+        // Already past the timeout window (e.g. page reload with stale job)
+        setExpiredIds((prev) => {
+          const next = new Set(prev)
+          next.add(job.id)
+          return next
+        })
+        continue
+      }
+
+      const t = setTimeout(() => {
+        setExpiredIds((prev) => {
+          const next = new Set(prev)
+          next.add(job.id)
+          return next
+        })
+        timersRef.current.delete(job.id)
+      }, remaining)
+      timersRef.current.set(job.id, t)
+    }
+  }, [completed, timeoutMs])
+
+  if (timeoutMs === false || timeoutMs <= 0) return completed
+
+  const timeout = timeoutMs as number
+  const now = Date.now()
+
+  return completed.filter((job) => {
+    if (job.status !== 'completed') return true
+    if (expiredIds.has(job.id)) return false
+    // Safety: hide jobs whose finishedAt is already past the window
+    // (handles panel remount or page reload without relying solely on expiredIds)
+    const finishedAt = safeParseMs(job.finishedAt)
+    if (finishedAt !== null && now - finishedAt >= timeout) return false
+    return true
+  })
+}


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

# Summary

Completed progress operations accumulate in the top-bar panel indefinitely, making it difficult to identify active or failed jobs. This PR introduces client-side auto-hide behavior for successfully completed jobs: they are automatically removed approximately 10 seconds after completion (based on `finishedAt`), while failed and cancelled jobs remain visible. The timeout can be configured or disabled per application.

# Changes

* **`useAutoHideCompletedJobs.ts`**

  * Added a new hook that schedules per-job hide timers based on `finishedAt`
  * Jobs already past the timeout threshold are hidden immediately on mount (supports page reloads)
  * Guards against malformed ISO timestamps
  * Exports `DEFAULT_AUTO_HIDE_MS`

* **`ProgressTopBar.tsx`**

  * Integrated the hook through `visibleCompleted`
  * Header counts and rendered job lists now only include visible completed jobs
  * Added optional prop: `completedAutoHideMs?: number | false`

* **`AppShell.tsx`**

  * Added `progressCompletedAutoHideMs` to `AppShellProps`
  * Allows applications to customize or disable completed-job auto-hide behavior

* **`useAutoHideCompletedJobs.test.tsx`**

  * Added 11 focused tests covering:

    * Successful job auto-hide
    * Failed and cancelled job retention
    * Independent timing per job
    * Expired jobs on initial mount
    * Disabled mode (`false` / `0`)
    * Custom timeout values
    * No timer re-scheduling during polling refreshes
    * Malformed `finishedAt` handling
    * Empty-list lifecycle
    * Cleanup on unmount

# Specification

**Does a spec exist for this feature/module?**

* [ ] Yes
* [ ] No (created a new spec)
* [x] N/A (minor change, no spec needed)

# Testing

```bash
yarn workspace @open-mercato/ui test --runTestsByPath src/backend/__tests__/useAutoHideCompletedJobs.test.tsx

yarn workspace @open-mercato/ui build
```

**Manual verification**

1. Trigger a bulk delete operation.
2. Confirm completed jobs appear as green success cards.
3. Verify completed jobs disappear individually after approximately 10 seconds based on their own `finishedAt` timestamp.
4. Verify failed operations remain visible indefinitely.

# Checklist

* [x] This pull request targets `develop`.
* [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
* [x] I updated documentation, locales, or generators if the change requires it.
* [x] I added or adjusted tests that cover the change.
* [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).

**Integration test rationale**

Pure client-side UI timer hook — no API surface, no server-side state changes, and no cross-component workflow requiring integration coverage.

# Design System Compliance

* [x] No hardcoded status colors
* [x] No arbitrary text sizes
* [x] No new DS primitives introduced
* [x] No regressions to loading/error states

# Linked Issues

Closes #2206 