### PR TITLE
fix(shared): memoize TenantEncryptionSubscriber per service (#2235)

### DIFF
--- a/packages/shared/src/lib/encryption/__tests__/subscriber.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/subscriber.test.ts
@@ -1,0 +1,79 @@
+import {
+  TenantEncryptionSubscriber,
+  decryptEntitiesWithFallbackScope,
+} from '../subscriber'
+import type { TenantDataEncryptionService } from '../tenantDataEncryptionService'
+
+describe('decryptEntitiesWithFallbackScope subscriber memoization (issue #2235)', () => {
+  const originalToggle = process.env.TENANT_DATA_ENCRYPTION
+
+  beforeEach(() => {
+    delete process.env.TENANT_DATA_ENCRYPTION
+  })
+
+  afterEach(() => {
+    if (originalToggle === undefined) delete process.env.TENANT_DATA_ENCRYPTION
+    else process.env.TENANT_DATA_ENCRYPTION = originalToggle
+    jest.restoreAllMocks()
+  })
+
+  function makeService(): TenantDataEncryptionService {
+    return { isEnabled: () => true } as unknown as TenantDataEncryptionService
+  }
+
+  function makeEm() {
+    return {} as { getMetadata?: () => unknown; getComparator?: () => unknown }
+  }
+
+  it('reuses a single subscriber instance across calls with the same service', async () => {
+    const seen: TenantEncryptionSubscriber[] = []
+    jest
+      .spyOn(TenantEncryptionSubscriber.prototype, 'decryptEntityGraph')
+      .mockImplementation(async function (this: TenantEncryptionSubscriber) {
+        seen.push(this)
+      })
+
+    const service = makeService()
+    const em = makeEm()
+
+    await decryptEntitiesWithFallbackScope({ id: 'a' }, { em, encryptionService: service })
+    await decryptEntitiesWithFallbackScope({ id: 'b' }, { em, encryptionService: service })
+    await decryptEntitiesWithFallbackScope([{ id: 'c' }, { id: 'd' }], { em, encryptionService: service })
+
+    expect(seen).toHaveLength(4)
+    const first = seen[0]
+    expect(seen.every((subscriber) => subscriber === first)).toBe(true)
+  })
+
+  it('uses a distinct subscriber per service instance', async () => {
+    const seen: TenantEncryptionSubscriber[] = []
+    jest
+      .spyOn(TenantEncryptionSubscriber.prototype, 'decryptEntityGraph')
+      .mockImplementation(async function (this: TenantEncryptionSubscriber) {
+        seen.push(this)
+      })
+
+    const em = makeEm()
+    const serviceA = makeService()
+    const serviceB = makeService()
+
+    await decryptEntitiesWithFallbackScope({ id: 'a' }, { em, encryptionService: serviceA })
+    await decryptEntitiesWithFallbackScope({ id: 'b' }, { em, encryptionService: serviceB })
+    await decryptEntitiesWithFallbackScope({ id: 'c' }, { em, encryptionService: serviceA })
+
+    expect(seen).toHaveLength(3)
+    expect(seen[0]).toBe(seen[2])
+    expect(seen[0]).not.toBe(seen[1])
+  })
+
+  it('skips decryption entirely when the service is disabled', async () => {
+    const spy = jest
+      .spyOn(TenantEncryptionSubscriber.prototype, 'decryptEntityGraph')
+      .mockImplementation(async () => {})
+
+    const disabled = { isEnabled: () => false } as unknown as TenantDataEncryptionService
+    await decryptEntitiesWithFallbackScope({ id: 'a' }, { em: makeEm(), encryptionService: disabled })
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/shared/src/lib/encryption/subscriber.ts
+++ b/packages/shared/src/lib/encryption/subscriber.ts
@@ -38,6 +38,16 @@ function debug(event: string, payload: Record<string, unknown>) {
 
 const registeredEventManagers = new WeakSet<object>()
 
+const subscribersByService = new WeakMap<TenantDataEncryptionService, TenantEncryptionSubscriber>()
+
+function getSubscriberForService(service: TenantDataEncryptionService): TenantEncryptionSubscriber {
+  const existing = subscribersByService.get(service)
+  if (existing) return existing
+  const subscriber = new TenantEncryptionSubscriber(service)
+  subscribersByService.set(service, subscriber)
+  return subscriber
+}
+
 const toSnakeCase = (value: string): string =>
   value.replace(/([A-Z])/g, '_$1').replace(/__/g, '_').toLowerCase()
 
@@ -397,7 +407,7 @@ export async function decryptEntitiesWithFallbackScope(
   if (!list.length) return
   const service = encryptionService ?? resolveTenantEncryptionService(em as any)
   if (!service || !service.isEnabled()) return
-  const subscriber = new TenantEncryptionSubscriber(service)
+  const subscriber = getSubscriberForService(service)
   const fallback: Scope | undefined =
     tenantId || organizationId
       ? {


### PR DESCRIPTION
Fixes #2235

## Problem
- When tenant data encryption is enabled, `decryptEntitiesWithFallbackScope` allocated a brand-new `TenantEncryptionSubscriber` on every call. Because `findWithDecryption`/`findOneWithDecryption` invoke it 10+ times per authenticated request, this produced many short-lived subscriber allocations per request.

## Root Cause
- `packages/shared/src/lib/encryption/subscriber.ts` constructed `new TenantEncryptionSubscriber(service)` inside `decryptEntitiesWithFallbackScope`. The subscriber is stateless with respect to the records it decrypts — its only state is a `readonly service` reference, and `decryptEntityGraph` takes the entity + scope as arguments — so a fresh instance per call is pure churn.

## What Changed
- Added a module-level `WeakMap<TenantDataEncryptionService, TenantEncryptionSubscriber>` and a `getSubscriberForService(service)` helper that memoizes one subscriber per service instance.
- `decryptEntitiesWithFallbackScope` now reuses the memoized subscriber instead of allocating a new one each call. Decrypted output is unchanged; the disabled-encryption early-out is untouched.

## Tests
- New `packages/shared/src/lib/encryption/__tests__/subscriber.test.ts`:
  - reuses a single subscriber instance across calls with the same service (the regression — fails before the fix),
  - uses a distinct subscriber per service instance,
  - skips decryption entirely when the service is disabled.
- Verified the regression test fails before the fix and passes after.
- `yarn workspace @open-mercato/shared test` — encryption suites green; the only failures are pre-existing and unrelated (`@open-mercato/cache` module resolution under skip-build install, and a crud-factory interceptor test that does not import this code).
- `tsc --noEmit` for `@open-mercato/shared` passes.

## Backward Compatibility
- No contract surface changes. Public exports and signatures (`decryptEntitiesWithFallbackScope`, `TenantEncryptionSubscriber`) are unchanged; the WeakMap and helper are internal.