### PR TITLE
perf(customers): parallelize search-token sources in CRM search (#2231)

### DIFF
--- a/packages/core/src/modules/customers/api/__tests__/utils.test.ts
+++ b/packages/core/src/modules/customers/api/__tests__/utils.test.ts
@@ -1,7 +1,74 @@
-import { withScopedPayload } from '../utils'
+import { withScopedPayload, findMatchingEntityIdsBySearchTokensAcrossSources } from '../utils'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 
 const translate = (key: string, fallback?: string) => fallback ?? key
+
+type FakeDbOptions = {
+  customFieldDefs?: Array<Record<string, unknown>>
+  searchTokenRowsByEntity?: Record<string, Array<{ entity_id: string }>>
+  mapRowsByTable?: Record<string, Array<Record<string, unknown>>>
+  onSearchTokenExecute?: () => Promise<void> | void
+}
+
+function createFakeDb(options: FakeDbOptions) {
+  const {
+    customFieldDefs = [],
+    searchTokenRowsByEntity = {},
+    mapRowsByTable = {},
+    onSearchTokenExecute,
+  } = options
+
+  const makeBuilder = () => {
+    const state: { table: string | null; conditions: Record<string, unknown> } = {
+      table: null,
+      conditions: {},
+    }
+    const builder: Record<string, unknown> = {
+      selectFrom(table: string) {
+        state.table = table
+        return builder
+      },
+      select() {
+        return builder
+      },
+      where(column: unknown, _op?: unknown, value?: unknown) {
+        if (typeof column === 'string') state.conditions[column] = value
+        return builder
+      },
+      groupBy() {
+        return builder
+      },
+      having() {
+        return builder
+      },
+      async execute() {
+        if (state.table === 'custom_field_defs') return customFieldDefs
+        if (state.table === 'search_tokens') {
+          if (onSearchTokenExecute) await onSearchTokenExecute()
+          const entityType = state.conditions['entity_type']
+          return typeof entityType === 'string' ? searchTokenRowsByEntity[entityType] ?? [] : []
+        }
+        return mapRowsByTable[state.table ?? ''] ?? []
+      },
+    }
+    return builder
+  }
+
+  return {
+    selectFrom(table: string) {
+      return makeBuilder().selectFrom(table)
+    },
+  }
+}
+
+function createCtxWithDb(db: unknown) {
+  const em = { getKysely: () => db }
+  return {
+    auth: { tenantId: 'tenant-1' },
+    selectedOrganizationId: 'org-1',
+    container: { resolve: (key: string) => (key === 'em' ? em : undefined) },
+  } as any
+}
 
 describe('customers api utils - withScopedPayload', () => {
   it('throws when tenant context cannot be resolved', () => {
@@ -57,5 +124,85 @@ describe('customers api utils - withScopedPayload', () => {
       tenantId: 'tenant-1',
     })
     expect(scoped).not.toHaveProperty('organizationId')
+  })
+})
+
+describe('customers api utils - findMatchingEntityIdsBySearchTokensAcrossSources', () => {
+  it('returns null for a blank query', async () => {
+    const ctx = createCtxWithDb(createFakeDb({}))
+    const result = await findMatchingEntityIdsBySearchTokensAcrossSources({
+      ctx,
+      sources: [{ entityType: 'customers:person', fields: ['name'] }],
+      query: '   ',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('unions matched ids across sources and applies id mapping', async () => {
+    const db = createFakeDb({
+      searchTokenRowsByEntity: {
+        'customers:person': [{ entity_id: 'person-1' }, { entity_id: 'person-2' }],
+        'customers:address': [{ entity_id: 'address-9' }],
+      },
+      mapRowsByTable: {
+        customer_addresses: [{ person_id: 'person-2' }, { person_id: 'person-3' }],
+      },
+    })
+    const ctx = createCtxWithDb(db)
+
+    const result = await findMatchingEntityIdsBySearchTokensAcrossSources({
+      ctx,
+      query: 'ada',
+      sources: [
+        { entityType: 'customers:person', fields: ['name'] },
+        {
+          entityType: 'customers:address',
+          fields: ['city'],
+          mapToEntityIds: { table: 'customer_addresses', targetColumn: 'person_id' },
+        },
+      ],
+    })
+
+    expect(result).not.toBeNull()
+    expect(new Set(result as string[])).toEqual(new Set(['person-1', 'person-2', 'person-3']))
+  })
+
+  it('resolves token sources concurrently rather than sequentially', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    const onSearchTokenExecute = () =>
+      new Promise<void>((resolve) => {
+        inFlight += 1
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        setTimeout(() => {
+          inFlight -= 1
+          resolve()
+        }, 0)
+      })
+
+    const db = createFakeDb({
+      searchTokenRowsByEntity: {
+        'customers:person': [{ entity_id: 'person-1' }],
+        'customers:address': [{ entity_id: 'address-1' }],
+      },
+      mapRowsByTable: { customer_addresses: [{ person_id: 'person-9' }] },
+      onSearchTokenExecute,
+    })
+    const ctx = createCtxWithDb(db)
+
+    await findMatchingEntityIdsBySearchTokensAcrossSources({
+      ctx,
+      query: 'ada',
+      sources: [
+        { entityType: 'customers:person', fields: ['name'] },
+        {
+          entityType: 'customers:address',
+          fields: ['city'],
+          mapToEntityIds: { table: 'customer_addresses', targetColumn: 'person_id' },
+        },
+      ],
+    })
+
+    expect(maxInFlight).toBe(2)
   })
 })

--- a/packages/core/src/modules/customers/api/utils.ts
+++ b/packages/core/src/modules/customers/api/utils.ts
@@ -191,18 +191,24 @@ export async function findMatchingEntityIdsBySearchTokensAcrossSources({
   if (!trimmed) return null
 
   const enrichedSources = await enrichSearchSourcesWithCustomFieldTokens(ctx, sources)
+  const perSource = await Promise.all(
+    enrichedSources.map(async (source) => {
+      const rawIds = await findSearchTokenEntityIds({
+        ctx,
+        entityType: source.entityType,
+        fields: source.fields,
+        query: trimmed,
+      })
+      if (rawIds === null) return null
+      return source.mapToEntityIds
+        ? await mapScopedEntityIds({ ctx, ids: rawIds, config: source.mapToEntityIds })
+        : rawIds
+    }),
+  )
+
   const matchedIds = new Set<string>()
-  for (const source of enrichedSources) {
-    const rawIds = await findSearchTokenEntityIds({
-      ctx,
-      entityType: source.entityType,
-      fields: source.fields,
-      query: trimmed,
-    })
-    if (rawIds === null) return null
-    const entityIds = source.mapToEntityIds
-      ? await mapScopedEntityIds({ ctx, ids: rawIds, config: source.mapToEntityIds })
-      : rawIds
+  for (const entityIds of perSource) {
+    if (entityIds === null) return null
     entityIds.forEach((id) => matchedIds.add(id))
   }
 


### PR DESCRIPTION
Fixes #2231

## Problem
CRM list search (`customers/people`, `companies`, `deals`) resolved search-token matches by looping over token **sources sequentially**, issuing one (or two, with id-mapping) DB query per source before the main list query even ran. People search has 2 sources → 2–4 sequential round-trips per keystroke, on the search-as-you-type critical path.

## Root Cause
`findMatchingEntityIdsBySearchTokensAcrossSources` in `packages/core/src/modules/customers/api/utils.ts` awaited each source's token query (and its optional id-mapping query) inside a `for` loop, so every source blocked the next even though sources are independent and their matched ids are simply unioned.

## What Changed
- Resolve sources concurrently via `Promise.all`: each source runs its `findSearchTokenEntityIds` token query plus optional `mapScopedEntityIds` mapping independently, then the per-source id lists are unioned into `matchedIds`.
- `enrichSearchSourcesWithCustomFieldTokens` remains the single up-front await.
- The `return null` short-circuit (fall back to ILIKE) is preserved — any source resolving to `null` after the await yields `null`.
- Matched-id set is identical; latency now scales with the slowest source instead of the sum.

## Tests
- `packages/core/src/modules/customers/api/__tests__/utils.test.ts`:
  - unions matched ids across multiple sources and applies scoped id-mapping
  - asserts sources resolve **concurrently** (max in-flight token queries == source count) — verified to fail against the old sequential implementation
  - preserves the blank-query `null` short-circuit
- Ran the full `packages/core/src/modules/customers/api` suite: 28 suites / 128 tests green (people/companies/deals route tests stay green).
- `yarn build:packages`, `yarn generate`, core typecheck (root tsc) all clean.

## Backward Compatibility
- No contract surface changes. Function signature, return type, tenant/org scoping, and matched-id semantics are unchanged.