### PR TITLE
perf(directory): consolidate org-scope resolution into a single organizations query (#2228)

### DIFF
--- a/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
+++ b/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
@@ -235,6 +235,68 @@ describe('resolveOrganizationScope', () => {
       expect(result.selectedId).toBeNull()
     })
   })
+
+  // Regression for issue #2228: scope resolution previously issued one
+  // `organizations` SELECT per collectWithDescendants call (accessible set,
+  // fallback set, selected set) — up to 3-4 sequential round-trips per request.
+  // It must now consolidate every descendant expansion into a single query.
+  describe('single-query consolidation (issue #2228)', () => {
+    it('issues exactly one organizations query when a selected org is inside a restricted ACL', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({
+        isSuperAdmin: false,
+        features: ['some.feature'],
+        organizations: ['org-a', 'org-b'],
+      })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false, orgId: 'org-home' }),
+        selectedId: 'org-b',
+      })
+      expect((em.find as jest.Mock)).toHaveBeenCalledTimes(1)
+      expect(result.selectedId).toBe('org-b')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-b', 'org-b-child']))
+      expect(result.allowedIds).toEqual(expect.arrayContaining(['org-a', 'org-b', 'org-b-child']))
+    })
+
+    it('issues exactly one organizations query when falling back from a disallowed selection', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({
+        isSuperAdmin: false,
+        features: ['some.feature'],
+        organizations: ['org-a'],
+      })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false, orgId: 'org-home' }),
+        selectedId: 'org-b',
+      })
+      expect((em.find as jest.Mock)).toHaveBeenCalledTimes(1)
+      expect(result.selectedId).not.toBe('org-b')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-a']))
+    })
+
+    it('batches accessible, selected, and fallback ids into one $in query', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({
+        isSuperAdmin: false,
+        features: ['some.feature'],
+        organizations: ['org-a', 'org-b'],
+      })
+      await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false, orgId: 'org-home' }),
+        selectedId: 'org-b',
+      })
+      expect((em.find as jest.Mock)).toHaveBeenCalledTimes(1)
+      const [, filter] = (em.find as jest.Mock).mock.calls[0]
+      expect(filter).toMatchObject({ tenant: 'tenant-1', deletedAt: null })
+      expect(filter.id.$in).toEqual(expect.arrayContaining(['org-a', 'org-b', 'org-home']))
+    })
+  })
 })
 
 describe('resolveOrganizationScopeForRequest', () => {

--- a/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
+++ b/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
@@ -256,8 +256,8 @@ describe('resolveOrganizationScope', () => {
       })
       expect((em.find as jest.Mock)).toHaveBeenCalledTimes(1)
       expect(result.selectedId).toBe('org-b')
-      expect(result.filterIds).toEqual(expect.arrayContaining(['org-b', 'org-b-child']))
-      expect(result.allowedIds).toEqual(expect.arrayContaining(['org-a', 'org-b', 'org-b-child']))
+      expect([...(result.filterIds ?? [])].sort()).toEqual(['org-b', 'org-b-child'])
+      expect([...(result.allowedIds ?? [])].sort()).toEqual(['org-a', 'org-b', 'org-b-child'])
     })
 
     it('issues exactly one organizations query when falling back from a disallowed selection', async () => {

--- a/packages/core/src/modules/directory/utils/organizationScope.ts
+++ b/packages/core/src/modules/directory/utils/organizationScope.ts
@@ -147,7 +147,7 @@ function normalizeOrganizationIds(ids: string[]): string[] {
 // returned an empty set for it).
 type OrgDescendantMap = Map<string, string[]>
 
-// Phase 2228 — single round-trip for org-scope resolution. Instead of issuing
+// Issue #2228 — single round-trip for org-scope resolution. Instead of issuing
 // one `organizations` SELECT per `collectWithDescendants` call (up to 3-4
 // sequential queries per request: accessible set, fallback set, selected set),
 // gather every candidate id up front and fetch their descendant expansions in

--- a/packages/core/src/modules/directory/utils/organizationScope.ts
+++ b/packages/core/src/modules/directory/utils/organizationScope.ts
@@ -131,29 +131,56 @@ export function getSelectedTenantFromRequest(
   return parseSelectedTenantCookie(header)
 }
 
-async function collectWithDescendants(em: EntityManager, tenantId: string, ids: string[]): Promise<Set<string>> {
-  if (!ids.length) return new Set()
-  const unique = Array.from(new Set(
+function normalizeOrganizationIds(ids: string[]): string[] {
+  return Array.from(new Set(
     ids.map((value) => normalizeOrganizationId(value)).filter((value): value is string => {
       if (!value) return false
       if (isAllOrganizationsSelection(value)) return false
       return true
     })
   ))
-  if (!unique.length) return new Set()
+}
+
+// Map each organization id to itself plus its persisted descendant ids. Only
+// orgs that exist for the tenant and are not soft-deleted are included, so an
+// unknown/inaccessible id simply has no entry (matching the per-id query that
+// returned an empty set for it).
+type OrgDescendantMap = Map<string, string[]>
+
+// Phase 2228 — single round-trip for org-scope resolution. Instead of issuing
+// one `organizations` SELECT per `collectWithDescendants` call (up to 3-4
+// sequential queries per request: accessible set, fallback set, selected set),
+// gather every candidate id up front and fetch their descendant expansions in
+// one `em.find(Organization, { id: $in })`. Expansion then happens in-memory.
+async function loadOrgDescendantMap(em: EntityManager, tenantId: string, ids: string[]): Promise<OrgDescendantMap> {
+  const unique = normalizeOrganizationIds(ids)
+  if (!unique.length) return new Map()
   const filter: FilterQuery<Organization> = {
     tenant: tenantId,
     id: { $in: unique },
     deletedAt: null,
   }
   const orgs = await em.find(Organization, filter)
-  const set = new Set<string>()
+  const map: OrgDescendantMap = new Map()
   for (const org of orgs) {
     const id = String(org.id)
-    set.add(id)
+    const expansion = [id]
     if (Array.isArray(org.descendantIds)) {
-      for (const desc of org.descendantIds) set.add(String(desc))
+      for (const desc of org.descendantIds) expansion.push(String(desc))
     }
+    map.set(id, expansion)
+  }
+  return map
+}
+
+function expandWithDescendants(map: OrgDescendantMap, ids: string[]): Set<string> {
+  const set = new Set<string>()
+  for (const value of ids) {
+    const id = normalizeOrganizationId(value)
+    if (!id || isAllOrganizationsSelection(id)) continue
+    const expansion = map.get(id)
+    if (!expansion) continue
+    for (const entry of expansion) set.add(entry)
   }
   return set
 }
@@ -214,14 +241,18 @@ export async function resolveOrganizationScope({
 
   const accountOrgId = actorTenantId && actorTenantId === tenantId ? normalizeOrganizationId(auth.orgId) : null
   const fallbackOrgId = accountOrgId ?? null
-  let fallbackSet: Set<string> | null = null
-  const loadFallbackSet = async (): Promise<Set<string> | null> => {
-    if (!fallbackOrgId) return null
-    if (!fallbackSet) {
-      fallbackSet = await collectWithDescendants(em, tenantId, [fallbackOrgId])
-    }
-    return fallbackSet
-  }
+
+  // Every id that could be expanded below — accessible set, fallback (account)
+  // org, and the requested selection — is known up front, so fetch them all in
+  // a single `organizations` query and expand from the in-memory map.
+  const candidateIds = [
+    ...(accessibleList ?? []),
+    ...(fallbackOrgId ? [fallbackOrgId] : []),
+    ...(normalizedSelectedId ? [normalizedSelectedId] : []),
+  ]
+  const orgDescendants = await loadOrgDescendantMap(em, tenantId, candidateIds)
+  const loadFallbackSet = (): Set<string> | null =>
+    fallbackOrgId ? expandWithDescendants(orgDescendants, [fallbackOrgId]) : null
 
   let allowedSet: Set<string> | null = null
   if (accessibleList === null) {
@@ -229,11 +260,11 @@ export async function resolveOrganizationScope({
   } else if (accessibleList.length === 0) {
     allowedSet = new Set()
   } else {
-    allowedSet = await collectWithDescendants(em, tenantId, accessibleList)
+    allowedSet = expandWithDescendants(orgDescendants, accessibleList)
   }
 
   if (allowedSet && allowedSet.size === 0 && fallbackOrgId) {
-    const computed = await loadFallbackSet()
+    const computed = loadFallbackSet()
     if (computed && computed.size > 0) {
       allowedSet = computed
     }
@@ -256,17 +287,17 @@ export async function resolveOrganizationScope({
 
   let filterSet: Set<string> | null = null
   if (effectiveSelected) {
-    filterSet = await collectWithDescendants(em, tenantId, [effectiveSelected])
+    filterSet = expandWithDescendants(orgDescendants, [effectiveSelected])
   } else if (allowedSet !== null) {
     filterSet = allowedSet
   } else if (widenToAllOrgs) {
     filterSet = null
   } else if (auth.orgId) {
-    filterSet = await loadFallbackSet()
+    filterSet = loadFallbackSet()
   }
 
   if ((!filterSet || filterSet.size === 0) && fallbackOrgId && !widenToAllOrgs) {
-    const computed = await loadFallbackSet()
+    const computed = loadFallbackSet()
     if (computed && computed.size > 0) {
       filterSet = computed
       if (!effectiveSelected) {


### PR DESCRIPTION
Fixes #2228

## Problem
Organization-scope resolution runs on **every** authenticated CRUD list/detail request (via `makeCrudRoute` `withCtx`). `resolveOrganizationScope` issued **up to 3-4 sequential `organizations` SELECTs** per request — one per `collectWithDescendants` call (accessible set, fallback/account org, selected org). On a networked production DB these sequential lookups add real latency to every request.

## Root Cause
`packages/core/src/modules/directory/utils/organizationScope.ts` called `collectWithDescendants(em, tenantId, ids)` separately for the accessible ACL set, the fallback (account) org, and the selected org. Each call ran its own `em.find(Organization, { id: $in })`, even though all the candidate ids are known before any query runs.

## What Changed
- Gather every candidate org id up front (`accessibleList` + `fallbackOrgId` + `normalizedSelectedId`) and fetch their descendant expansions in a **single** `em.find(Organization, { id: $in })` via the new `loadOrgDescendantMap` helper.
- Expand each set (accessible / fallback / selected) **in-memory** from that map via `expandWithDescendants`; `loadFallbackSet` is now synchronous.
- Behavior is unchanged: the batched candidate set is the union of the ids the sequential calls would have queried, and per-id descendant expansion is identical (an unknown/inaccessible id simply has no map entry, matching the old empty-set result).

A list request now issues **at most one** `organizations` query for scope, satisfying the issue's acceptance criterion.

Out of scope (deliberately, as higher-risk follow-ups): shipping the scope cache enabled by default (`ORG_SCOPE_DEFAULT_TTL_MS`), and deduping the double resolution across `withCtx` and `resolveFeatureCheckContext`.

## Tests
- Existing `organizationScope.test.ts` suite stays green (incl. the superadmin tenant-override single-`$in` assertion).
- Added regression tests: `em.find` is called **exactly once** for multi-org scenarios (restricted ACL + selected org inside the ACL; restricted ACL + fallback from a disallowed selection), and accessible + selected + fallback ids are batched into a single `$in` query.
- `yarn workspace @open-mercato/core test organizationScope` → 30 passed; `yarn workspace @open-mercato/core typecheck` clean; `yarn build:packages` green.

## Backward Compatibility
No contract surface changes. The internal `collectWithDescendants` helper was replaced with `loadOrgDescendantMap`/`expandWithDescendants` (both module-private); all exported signatures (`resolveOrganizationScope`, `resolveOrganizationScopeForRequest`, `resolveFeatureCheckContext`) and the `OrganizationScope` shape are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
