### PR TITLE
fix(auth): parallelize per-request session/user/role/ACL resolution (#2221)

### DIFF
--- a/packages/core/src/modules/auth/lib/__tests__/sessionIntegrity.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/sessionIntegrity.test.ts
@@ -244,6 +244,87 @@ describe('isAuthContextValid', () => {
     expect(findOneWithDecryption).not.toHaveBeenCalled()
   })
 
+  it('issues the session and user lookups concurrently', async () => {
+    const callOrder: string[] = []
+    let releaseSession: (() => void) | undefined
+    const sessionGate = new Promise<void>((resolve) => {
+      releaseSession = resolve
+    })
+    findOneWithDecryption.mockImplementation(async (...args: unknown[]) => {
+      const entity = args[1]
+      if (entity === Session) {
+        callOrder.push('session')
+        await sessionGate
+        return validSession
+      }
+      if (entity === User) {
+        callOrder.push('user')
+        return { id: userId, tenantId, organizationId }
+      }
+      return null
+    })
+
+    const pending = resolveCanonicalStaffAuthContext(em, {
+      sub: userId,
+      sid: sessionId,
+      tenantId,
+      orgId: organizationId,
+      roles: [],
+    })
+
+    // Both lookups are issued before the (still pending) session lookup resolves.
+    expect(callOrder).toEqual(['session', 'user'])
+
+    releaseSession?.()
+    await expect(pending).resolves.toMatchObject({ sub: userId })
+  })
+
+  it('issues the role-link and user-acl lookups concurrently', async () => {
+    const callOrder: string[] = []
+    let releaseLinks: ((value: unknown[]) => void) | undefined
+    const linksGate = new Promise<unknown[]>((resolve) => {
+      releaseLinks = resolve
+    })
+    findOneWithDecryption.mockImplementation(async (...args: unknown[]) => {
+      const entity = args[1]
+      if (entity === Session) return validSession
+      if (entity === User) return { id: userId, tenantId, organizationId }
+      if (entity === UserAcl) {
+        callOrder.push('userAcl')
+        return null
+      }
+      if (entity === RoleAcl) {
+        callOrder.push('roleAcl')
+        return null
+      }
+      return null
+    })
+    findWithDecryption.mockImplementation(async () => {
+      callOrder.push('links')
+      return linksGate
+    })
+
+    const pending = resolveCanonicalStaffAuthContext(em, {
+      sub: userId,
+      sid: sessionId,
+      tenantId,
+      orgId: organizationId,
+      roles: [],
+    })
+
+    await new Promise((resolve) => setImmediate(resolve))
+
+    // The user-acl lookup runs alongside the (still pending) role-link lookup, and
+    // the role-acl lookup is deferred until the role links resolve.
+    expect(callOrder).toContain('userAcl')
+    expect(callOrder).not.toContain('roleAcl')
+
+    releaseLinks?.([{ role: { id: adminRoleId, name: 'admin' } }])
+    await pending
+
+    expect(callOrder).toContain('roleAcl')
+  })
+
   it('skips user integrity lookup for api key auth', async () => {
     await expect(
       isAuthContextValid(em, {

--- a/packages/core/src/modules/auth/lib/sessionIntegrity.ts
+++ b/packages/core/src/modules/auth/lib/sessionIntegrity.ts
@@ -64,19 +64,28 @@ export async function resolveCanonicalStaffAuthContext(
       return null
     }
   }
-  if (sessionId !== null) {
-    const session = await findOneWithDecryption(em, Session, { id: sessionId, deletedAt: null })
-    if (!session) return null
-    if (session.expiresAt.getTime() < Date.now()) return null
-  }
-
-  const user = await findOneWithDecryption(
+  // The session-revocation check and the user load are independent (neither reads
+  // the other's result), so they run concurrently to collapse two sequential DB
+  // round-trips into one. The `em` here is a fresh request-scoped EntityManager
+  // (resolved per request, never inside an explicit transaction), so concurrent
+  // reads on it are safe.
+  const sessionPromise = sessionId !== null
+    ? findOneWithDecryption(em, Session, { id: sessionId, deletedAt: null })
+    : Promise.resolve(null)
+  const userPromise = findOneWithDecryption(
     em,
     User,
     { id: subjectId, deletedAt: null },
     undefined,
     { tenantId: actorTenantId, organizationId: actorOrganizationId },
   )
+  const [session, user] = await Promise.all([sessionPromise, userPromise])
+
+  if (sessionId !== null) {
+    if (!session) return null
+    if (session.expiresAt.getTime() < Date.now()) return null
+  }
+
   if (!user) return null
 
   const currentTenantId = normalizeScopeId(user.tenantId ?? null)
@@ -90,8 +99,12 @@ export async function resolveCanonicalStaffAuthContext(
     return null
   }
 
-  const links = currentTenantId
-    ? await findWithDecryption(
+  // Role links and the per-user super-admin flag are likewise independent, so they
+  // run concurrently. The role-level super-admin lookup depends on the resolved
+  // role ids, so it stays sequential after the links resolve (and is skipped
+  // entirely when the per-user flag already grants super-admin).
+  const linksPromise = currentTenantId
+    ? findWithDecryption(
         em,
         UserRole,
         {
@@ -102,7 +115,11 @@ export async function resolveCanonicalStaffAuthContext(
         { populate: ['role'] },
         { tenantId: currentTenantId, organizationId: currentOrganizationId },
       )
-    : []
+    : Promise.resolve([] as UserRole[])
+  const userAclSuperAdminPromise = currentTenantId
+    ? userAclGrantsSuperAdmin(em, user.id, currentTenantId, currentOrganizationId)
+    : Promise.resolve(false)
+  const [links, userAclSuperAdmin] = await Promise.all([linksPromise, userAclSuperAdminPromise])
 
   const linkedRoles = links
     .map((link) => link.role)
@@ -113,7 +130,7 @@ export async function resolveCanonicalStaffAuthContext(
     .filter((name): name is string => typeof name === 'string' && name.trim().length > 0)
 
   const isSuperAdmin = currentTenantId
-    ? await hasSuperAdminFlag(em, user.id, linkedRoles, currentTenantId, currentOrganizationId)
+    ? userAclSuperAdmin || (await roleAclGrantsSuperAdmin(em, linkedRoles, currentTenantId, currentOrganizationId))
     : false
 
   return {
@@ -126,10 +143,9 @@ export async function resolveCanonicalStaffAuthContext(
   }
 }
 
-async function hasSuperAdminFlag(
+async function userAclGrantsSuperAdmin(
   em: EntityManager,
   userId: string,
-  linkedRoles: Role[],
   tenantId: string,
   organizationId: string | null,
 ): Promise<boolean> {
@@ -145,10 +161,15 @@ async function hasSuperAdminFlag(
     undefined,
     { tenantId, organizationId },
   )
-  if (userAcl && (userAcl as { isSuperAdmin?: boolean }).isSuperAdmin === true) {
-    return true
-  }
+  return !!(userAcl && (userAcl as { isSuperAdmin?: boolean }).isSuperAdmin === true)
+}
 
+async function roleAclGrantsSuperAdmin(
+  em: EntityManager,
+  linkedRoles: Role[],
+  tenantId: string,
+  organizationId: string | null,
+): Promise<boolean> {
   const roleIds = Array.from(
     new Set(
       linkedRoles


### PR DESCRIPTION
Fixes #2221

## Problem
Per-request authentication resolution is the single largest fixed cost on authenticated API requests across `catalog`, `sales`, and `customers` (~30 ms/req on a local DB, more on a networked DB). `resolveCanonicalStaffAuthContext()` ran **4–5 sequential decrypted DB round-trips on every request**: session → user → user-roles (+populate) → user-ACL / role-ACL super-admin checks.

## Root Cause
The lookups were awaited one after another even though several of them are independent of each other, so their latencies stacked linearly.

## What Changed
`packages/core/src/modules/auth/lib/sessionIntegrity.ts` — collapse the independent lookups into two concurrent phases:

1. **Phase 1** (`Promise.all`): session-revocation check + user load. Neither reads the other's result.
2. **Phase 2** (`Promise.all`): role-link load + per-user super-admin flag (`UserAcl`). These are independent.

The role-level super-admin lookup (`RoleAcl`) stays **sequential** after the role links resolve (it needs the resolved role ids) and is **skipped entirely** when the per-user flag already grants super-admin — preserving the exact `UserAcl`-then-`RoleAcl` precedence of the original `hasSuperAdminFlag`. That helper is split into two focused helpers (`userAclGrantsSuperAdmin` / `roleAclGrantsSuperAdmin`) so the per-user check can run in parallel with the role-link load.

For a normal non-super-admin user this reduces ~4–5 sequential round-trips to ~3 phases (and 2 for a super-admin granted via `UserAcl`).

### Safety
- All security semantics are preserved exactly: session existence/expiry/revocation, tenant/org binding match, and super-admin precedence. The only behavioral nuance is that the user load now also runs when the session is invalid (previously short-circuited) — benign, since both paths return `null`, and it only adds one query in the rare revoked/expired-session case.
- The request `EntityManager` is resolved per request via `createRequestContainer()` and is never inside an explicit transaction, so concurrent reads on it are safe. No `em.fork()` is introduced and the request EM is reused (per issue item #3 intent for this path).
- Still uses `findOneWithDecryption` / `findWithDecryption` with identical scopes — no raw `em.find` / `em.findOne`.

## Tests
- `packages/core/src/modules/auth/lib/__tests__/sessionIntegrity.test.ts` — 2 new regression tests proving the lookups are now issued concurrently (session issued while user is in-flight; `UserAcl` issued while role-links are in-flight, with `RoleAcl` deferred until links resolve). All 13 existing semantic tests still pass (15/15 total); full `auth/lib` suite green (66/66).
- Core typecheck clean (0 errors after `yarn generate`).

## Deferred (out of scope, intentionally not in this PR)
The issue proposed two further optimizations that change behavior and need maintainer sign-off:
- **Short-TTL session/user cache keyed by `sid`** — changes revocation/expiry detection semantics (delays revocation by the TTL) and needs cross-module invalidation wiring (logout / session revoke / password change). This is "Ask First" territory per the auth AGENTS.md, so it is left for a follow-up.
- **Removing `em.fork()` calls in `rbacService`** — those forks are deliberately defensive against inheriting aborted transactions from callers; `loadAcl` is already cached 5 min so it is not on the hot per-request path.

## Backward Compatibility
- No contract surface changes. `resolveCanonicalStaffAuthContext` / `isAuthContextValid` exports and signatures are unchanged; only a private helper was refactored.