### PR TITLE
perf(i18n): memoize dictionary per locale (#2224)

### DIFF
--- a/packages/shared/src/lib/i18n/__tests__/dictionary-cache.test.ts
+++ b/packages/shared/src/lib/i18n/__tests__/dictionary-cache.test.ts
@@ -1,0 +1,82 @@
+import {
+  loadDictionary,
+  registerModules,
+  registerAppDictionaryLoader,
+  invalidateDictionaryCache,
+} from '../server'
+import type { Locale } from '../config'
+
+describe('i18n dictionary memoization', () => {
+  beforeEach(() => {
+    registerModules([] as any)
+    registerAppDictionaryLoader(async () => ({}))
+    invalidateDictionaryCache()
+  })
+
+  it('builds the flattened dictionary once per locale and reuses it', async () => {
+    const loader = jest.fn(async (_locale: Locale) => ({ greeting: 'hello' }))
+    registerAppDictionaryLoader(loader)
+    registerModules([{ translations: { en: { module: { title: 'Module' } } } }] as any)
+
+    const first = await loadDictionary('en')
+    const second = await loadDictionary('en')
+
+    expect(first).toBe(second)
+    expect(loader).toHaveBeenCalledTimes(1)
+    expect(first).toEqual({ greeting: 'hello', 'module.title': 'Module' })
+  })
+
+  it('caches each locale independently', async () => {
+    const loader = jest.fn(async (locale: Locale) => ({ greeting: locale }))
+    registerAppDictionaryLoader(loader)
+    registerModules([] as any)
+
+    const en = await loadDictionary('en')
+    const pl = await loadDictionary('pl')
+    await loadDictionary('en')
+
+    expect(en).not.toBe(pl)
+    expect(en).toEqual({ greeting: 'en' })
+    expect(pl).toEqual({ greeting: 'pl' })
+    expect(loader).toHaveBeenCalledTimes(2)
+  })
+
+  it('rebuilds after modules are re-registered', async () => {
+    registerAppDictionaryLoader(async () => ({}))
+    registerModules([{ translations: { en: { a: 'one' } } }] as any)
+    const before = await loadDictionary('en')
+    expect(before).toEqual({ a: 'one' })
+
+    registerModules([{ translations: { en: { b: 'two' } } }] as any)
+    const after = await loadDictionary('en')
+
+    expect(after).not.toBe(before)
+    expect(after).toEqual({ b: 'two' })
+  })
+
+  it('rebuilds after the app dictionary loader is re-registered', async () => {
+    registerModules([] as any)
+    registerAppDictionaryLoader(async () => ({ greeting: 'old' }))
+    const before = await loadDictionary('en')
+    expect(before).toEqual({ greeting: 'old' })
+
+    registerAppDictionaryLoader(async () => ({ greeting: 'new' }))
+    const after = await loadDictionary('en')
+
+    expect(after).not.toBe(before)
+    expect(after).toEqual({ greeting: 'new' })
+  })
+
+  it('rebuilds after explicit cache invalidation', async () => {
+    const loader = jest.fn(async () => ({ greeting: 'hello' }))
+    registerAppDictionaryLoader(loader)
+    registerModules([] as any)
+
+    await loadDictionary('en')
+    expect(loader).toHaveBeenCalledTimes(1)
+
+    invalidateDictionaryCache()
+    await loadDictionary('en')
+    expect(loader).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/shared/src/lib/i18n/app-dictionaries.ts
+++ b/packages/shared/src/lib/i18n/app-dictionaries.ts
@@ -1,4 +1,5 @@
 import type { Locale } from './config'
+import { invalidateDictionaryCache } from './dictionary-cache'
 
 type DictionaryLoader = (locale: Locale) => Promise<Record<string, unknown>>
 
@@ -6,6 +7,7 @@ let _appDictionaryLoader: DictionaryLoader | null = null
 
 export function registerAppDictionaryLoader(loader: DictionaryLoader): void {
   _appDictionaryLoader = loader
+  invalidateDictionaryCache()
 }
 
 export async function loadAppDictionary(locale: Locale): Promise<Record<string, unknown>> {

--- a/packages/shared/src/lib/i18n/dictionary-cache.ts
+++ b/packages/shared/src/lib/i18n/dictionary-cache.ts
@@ -1,0 +1,35 @@
+import type { Locale } from './config'
+import type { Dict } from './context'
+
+// Process-level cache of flattened, module-merged translation dictionaries
+// keyed by locale. Locale dictionaries are immutable at runtime, so the
+// flatten+merge work in loadDictionary() only needs to run once per locale.
+//
+// Stored on globalThis for the same reason the module registry is: tsx/esbuild
+// can load this file as multiple module instances when mixing dynamic and
+// static imports, and the cache plus its invalidation must stay coherent across
+// those instances. See ../modules/registry.ts for the original workaround.
+const GLOBAL_KEY = '__openMercatoI18nDictionaryCache__'
+
+function getCache(): Map<Locale, Dict> {
+  const globalScope = globalThis as any
+  if (!globalScope[GLOBAL_KEY]) {
+    globalScope[GLOBAL_KEY] = new Map<Locale, Dict>()
+  }
+  return globalScope[GLOBAL_KEY]
+}
+
+export function getCachedDictionary(locale: Locale): Dict | undefined {
+  return getCache().get(locale)
+}
+
+export function setCachedDictionary(locale: Locale, dict: Dict): void {
+  getCache().set(locale, dict)
+}
+
+// Invalidate every cached locale dictionary. Called whenever the inputs to a
+// dictionary build change: module registration (module translations) and the
+// app dictionary loader registration (base translations).
+export function invalidateDictionaryCache(): void {
+  getCache().clear()
+}

--- a/packages/shared/src/lib/i18n/server.ts
+++ b/packages/shared/src/lib/i18n/server.ts
@@ -4,10 +4,12 @@ import { resolveLocaleFromAcceptLanguage } from './locale'
 import { createFallbackTranslator, createTranslator } from './translate'
 import { getModules } from '../modules/registry'
 import { loadAppDictionary } from './app-dictionaries'
+import { getCachedDictionary, setCachedDictionary } from './dictionary-cache'
 
 // Re-export for backwards compatibility
 export { registerModules, getModules } from '../modules/registry'
 export { registerAppDictionaryLoader } from './app-dictionaries'
+export { invalidateDictionaryCache } from './dictionary-cache'
 
 function flattenDictionary(source: unknown, prefix = ''): Dict {
   if (!source || typeof source !== 'object' || Array.isArray(source)) return {}
@@ -48,6 +50,11 @@ export async function detectLocale(): Promise<Locale> {
 }
 
 export async function loadDictionary(locale: Locale): Promise<Dict> {
+  // Locale dictionaries are immutable at runtime, so the flatten+merge below
+  // only needs to run once per locale. The cache is invalidated whenever
+  // modules or the app dictionary loader are (re)registered.
+  const cached = getCachedDictionary(locale)
+  if (cached) return cached
   // Load from registry instead of @/ import (works in standalone packages)
   const baseRaw = await loadAppDictionary(locale)
   const merged: Dict = { ...flattenDictionary(baseRaw) }
@@ -56,6 +63,7 @@ export async function loadDictionary(locale: Locale): Promise<Dict> {
     const dict = m.translations?.[locale]
     if (dict) Object.assign(merged, flattenDictionary(dict))
   }
+  setCachedDictionary(locale, merged)
   return merged
 }
 

--- a/packages/shared/src/lib/modules/registry.ts
+++ b/packages/shared/src/lib/modules/registry.ts
@@ -1,5 +1,6 @@
 import type { Module } from '@open-mercato/shared/modules/registry'
 import { applyModuleOverridesToModules } from '@open-mercato/shared/modules/overrides'
+import { invalidateDictionaryCache } from '../i18n/dictionary-cache'
 
 // Registration pattern for publishable packages.
 // Use globalThis to survive tsx/esbuild module duplication where the same
@@ -24,6 +25,7 @@ export function registerModules(modules: Module[]) {
     console.debug('[Bootstrap] Modules re-registered (this may occur during HMR)')
   }
   setGlobalModules(applyModuleOverridesToModules(modules))
+  invalidateDictionaryCache()
 }
 
 export function getModules(): Module[] {


### PR DESCRIPTION
Fixes #2224

## Problem
`resolveTranslations()` / `loadDictionary()` rebuilt and re-flattened the entire module-merged translation dictionary on **every** call, with no memoization. The `customers/people` route calls `resolveTranslations()` 3× per request, so the full O(modules × keys) merge+flatten ran repeatedly as pure wasted CPU.

## Root Cause
`loadDictionary(locale)` in `packages/shared/src/lib/i18n/server.ts` walked every registered module's translations and recursively flattened them on each invocation. Locale dictionaries are immutable at runtime, so this work only needs to happen once per locale.

## What Changed
- New `packages/shared/src/lib/i18n/dictionary-cache.ts`: a process-level `Map<Locale, Dict>` of flattened, module-merged dictionaries. Backed by `globalThis` to stay coherent across tsx/esbuild module duplication, mirroring the existing module-registry workaround.
- `loadDictionary()` now returns the cached dictionary when present and populates it on first build — O(1) after the first call per locale.
- Cache invalidation wired into the only two mutation points: `registerModules()` (module translations) and `registerAppDictionaryLoader()` (base translations). An `invalidateDictionaryCache()` helper is re-exported from `server.ts`.
- Verified all `loadDictionary()` / `resolveTranslations().dict` consumers are read-only, so sharing the cached object reference is safe.

No change needed in `customers/api/people/route.ts` — its 3 `resolveTranslations()` calls (L378/394/407) are now effectively free after the first.

## Tests
- New `packages/shared/src/lib/i18n/__tests__/dictionary-cache.test.ts` (5 cases): builds once per locale and reuses the reference, caches locales independently, rebuilds after `registerModules`, rebuilds after `registerAppDictionaryLoader`, and rebuilds after explicit invalidation.
- `yarn workspace @open-mercato/shared typecheck` ✓
- `yarn workspace @open-mercato/shared build` ✓
- Full shared Jest suite: 974 passing; the only failures are pre-existing and unrelated (`@open-mercato/cache` resolution + a `crud-factory` interceptor test that also fails on `develop`).

## Backward Compatibility
- Additive only. New module + one new additive export (`invalidateDictionaryCache`). No removed/changed exports, signatures, event IDs, or response fields. `loadDictionary` now returns a shared (read-only) cached object instead of a fresh one — confirmed no consumer mutates it.