### PR TITLE
perf(core): batch N+1 lookups in rate ingestion, field defs, role perspectives (#1399)

### DIFF
--- a/packages/core/src/modules/currencies/services/__tests__/rateFetchingService.batching.test.ts
+++ b/packages/core/src/modules/currencies/services/__tests__/rateFetchingService.batching.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals'
+import { ExchangeRate } from '../../data/entities'
+import { RateFetchingService } from '../rateFetchingService'
+import {
+  createMockEntityManager,
+  createMockProvider,
+  createTestCurrency,
+  createTestRate,
+  createTestExchangeRate,
+  TEST_SCOPE,
+  TEST_DATE,
+} from './rateFetchingService.setup'
+
+const isExchangeRateCall = (call: unknown[]) => {
+  const entity = call[0] as any
+  return entity === ExchangeRate || entity?.name === 'ExchangeRate'
+}
+
+describe('RateFetchingService - batched persistence (issue #1399)', () => {
+  let service: RateFetchingService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('prefetches existing rates with a single query instead of one lookup per rate', async () => {
+    const currencies = [
+      createTestCurrency({ code: 'USD' }),
+      createTestCurrency({ code: 'EUR' }),
+      createTestCurrency({ code: 'GBP' }),
+      createTestCurrency({ code: 'PLN' }),
+    ]
+    const { em } = createMockEntityManager({ currencies })
+    service = new RateFetchingService(em)
+
+    const rates = [
+      createTestRate({ fromCurrencyCode: 'USD', toCurrencyCode: 'EUR', source: 'BULK' }),
+      createTestRate({ fromCurrencyCode: 'USD', toCurrencyCode: 'GBP', source: 'BULK' }),
+      createTestRate({ fromCurrencyCode: 'EUR', toCurrencyCode: 'PLN', source: 'BULK' }),
+      createTestRate({ fromCurrencyCode: 'GBP', toCurrencyCode: 'PLN', source: 'BULK' }),
+    ]
+    service.registerProvider(createMockProvider({ source: 'BULK', rates }))
+
+    const result = await service.fetchRatesForDate(TEST_DATE, TEST_SCOPE)
+
+    expect(result.totalFetched).toBe(4)
+    // No per-rate point lookups.
+    const findOneExchangeCalls = (em.findOne as jest.Mock).mock.calls.filter(isExchangeRateCall)
+    expect(findOneExchangeCalls).toHaveLength(0)
+    // Exactly one prefetch query for the whole batch.
+    const findExchangeCalls = (em.find as jest.Mock).mock.calls.filter(isExchangeRateCall)
+    expect(findExchangeCalls).toHaveLength(1)
+    expect(findExchangeCalls[0][1]).toMatchObject({
+      organizationId: TEST_SCOPE.organizationId,
+      tenantId: TEST_SCOPE.tenantId,
+      fromCurrencyCode: { $in: expect.arrayContaining(['USD', 'EUR', 'GBP']) },
+      toCurrencyCode: { $in: expect.arrayContaining(['EUR', 'GBP', 'PLN']) },
+      source: { $in: ['BULK'] },
+    })
+    // A single flush for the whole batch.
+    expect(em.flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates prefetched matches and inserts the rest in one batch', async () => {
+    const currencies = [
+      createTestCurrency({ code: 'USD' }),
+      createTestCurrency({ code: 'EUR' }),
+      createTestCurrency({ code: 'GBP' }),
+    ]
+    const existingRates = [
+      createTestExchangeRate({
+        fromCurrencyCode: 'USD',
+        toCurrencyCode: 'EUR',
+        rate: '0.80',
+        date: TEST_DATE,
+        source: 'BULK',
+      }),
+    ]
+    const { em, persisted } = createMockEntityManager({ currencies, existingRates })
+    service = new RateFetchingService(em)
+
+    const rates = [
+      // Matches the existing row -> update in memory.
+      createTestRate({ fromCurrencyCode: 'USD', toCurrencyCode: 'EUR', rate: '0.95', date: TEST_DATE, source: 'BULK' }),
+      // New row -> insert.
+      createTestRate({ fromCurrencyCode: 'USD', toCurrencyCode: 'GBP', rate: '0.78', date: TEST_DATE, source: 'BULK' }),
+    ]
+    service.registerProvider(createMockProvider({ source: 'BULK', rates }))
+
+    const result = await service.fetchRatesForDate(TEST_DATE, TEST_SCOPE)
+
+    expect(result.totalFetched).toBe(2)
+    // The existing entity was mutated, not duplicated.
+    expect(existingRates[0].rate).toBe('0.95')
+    // create() only called for the genuinely new pair.
+    const createdPairs = (em.create as jest.Mock).mock.calls
+      .filter(isExchangeRateCall)
+      .map((call) => `${(call[1] as any).fromCurrencyCode}->${(call[1] as any).toCurrencyCode}`)
+    expect(createdPairs).toEqual(['USD->GBP'])
+    expect(persisted).toHaveLength(2)
+    expect(em.flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the database entirely when there are no valid rates', async () => {
+    const currencies = [createTestCurrency({ code: 'USD' })]
+    const { em } = createMockEntityManager({ currencies })
+    service = new RateFetchingService(em)
+
+    // USD->EUR is filtered out because EUR is not an active currency.
+    service.registerProvider(
+      createMockProvider({ source: 'BULK', rates: [createTestRate({ fromCurrencyCode: 'USD', toCurrencyCode: 'EUR' })] })
+    )
+
+    const result = await service.fetchRatesForDate(TEST_DATE, TEST_SCOPE)
+
+    expect(result.totalFetched).toBe(0)
+    // No transaction, no prefetch, no flush when nothing is storable.
+    expect(em.transactional).not.toHaveBeenCalled()
+    const findExchangeCalls = (em.find as jest.Mock).mock.calls.filter(isExchangeRateCall)
+    expect(findExchangeCalls).toHaveLength(0)
+  })
+})

--- a/packages/core/src/modules/currencies/services/__tests__/rateFetchingService.errors.test.ts
+++ b/packages/core/src/modules/currencies/services/__tests__/rateFetchingService.errors.test.ts
@@ -193,26 +193,25 @@ describe('RateFetchingService - Error Handling', () => {
 
     it('stores rates with correct scope information', async () => {
       // Setup
+      const customScope = { tenantId: 'tenant-abc', organizationId: 'org-xyz' }
       const currencies = [
-        createTestCurrency({ code: 'USD' }),
-        createTestCurrency({ code: 'EUR' }),
+        createTestCurrency({ code: 'USD', tenantId: customScope.tenantId, organizationId: customScope.organizationId }),
+        createTestCurrency({ code: 'EUR', tenantId: customScope.tenantId, organizationId: customScope.organizationId }),
       ]
-      
+
       const { em } = createMockEntityManager({ currencies })
       service = new RateFetchingService(em)
-      
+
       const provider = createMockProvider({
         source: 'TEST',
         rates: [createTestRate({ fromCurrencyCode: 'USD', toCurrencyCode: 'EUR' })],
       })
-      
+
       service.registerProvider(provider)
-      
-      const customScope = { tenantId: 'tenant-abc', organizationId: 'org-xyz' }
-      
+
       // Execute
       await service.fetchRatesForDate(TEST_DATE, customScope)
-      
+
       // Assert - verify transactional was called (rates stored with scope)
       expect(em.transactional).toHaveBeenCalled()
     })

--- a/packages/core/src/modules/currencies/services/__tests__/rateFetchingService.setup.ts
+++ b/packages/core/src/modules/currencies/services/__tests__/rateFetchingService.setup.ts
@@ -17,6 +17,31 @@ export interface MockProviderConfig {
 }
 
 /**
+ * Match a field value against a scalar equality filter or a `{ $in: [...] }` operator.
+ * `undefined` filters match everything (no constraint).
+ */
+function matchesFilter(value: unknown, filter: unknown): boolean {
+  if (filter === undefined) return true
+  if (filter && typeof filter === 'object' && '$in' in (filter as Record<string, unknown>)) {
+    const candidates = (filter as { $in: unknown[] }).$in
+    return Array.isArray(candidates) && candidates.includes(value)
+  }
+  return value === filter
+}
+
+/**
+ * Date-aware variant of `matchesFilter` comparing by epoch milliseconds.
+ */
+function matchesDateFilter(value: Date, filter: unknown): boolean {
+  if (filter === undefined) return true
+  if (filter && typeof filter === 'object' && '$in' in (filter as Record<string, unknown>)) {
+    const candidates = (filter as { $in: Date[] }).$in
+    return Array.isArray(candidates) && candidates.some((candidate) => candidate.getTime() === value.getTime())
+  }
+  return filter instanceof Date && value.getTime() === filter.getTime()
+}
+
+/**
  * Create a mock EntityManager for testing
  */
 export function createMockEntityManager(config: MockEntityManagerConfig = {}) {
@@ -41,13 +66,14 @@ export function createMockEntityManager(config: MockEntityManagerConfig = {}) {
       // Return exchange rates for ExchangeRate entity queries
       if (entityClass === ExchangeRate || entityClass.name === 'ExchangeRate') {
         const rates = config.existingRates || []
-        // Apply filters if specified
+        // Apply filters if specified (scalar equality or `{ $in: [...] }`)
         return rates.filter(r => {
-          if (filter.organizationId && r.organizationId !== filter.organizationId) return false
-          if (filter.tenantId && r.tenantId !== filter.tenantId) return false
-          if (filter.fromCurrencyCode && r.fromCurrencyCode !== filter.fromCurrencyCode) return false
-          if (filter.toCurrencyCode && r.toCurrencyCode !== filter.toCurrencyCode) return false
-          if (filter.date && r.date.getTime() !== filter.date.getTime()) return false
+          if (!matchesFilter(r.organizationId, filter.organizationId)) return false
+          if (!matchesFilter(r.tenantId, filter.tenantId)) return false
+          if (!matchesFilter(r.fromCurrencyCode, filter.fromCurrencyCode)) return false
+          if (!matchesFilter(r.toCurrencyCode, filter.toCurrencyCode)) return false
+          if (!matchesDateFilter(r.date, filter.date)) return false
+          if (!matchesFilter(r.source, filter.source)) return false
           if (filter.isActive !== undefined && r.isActive !== filter.isActive) return false
           if (filter.deletedAt !== undefined && filter.deletedAt === null && r.deletedAt !== null) return false
           return true
@@ -89,9 +115,9 @@ export function createMockEntityManager(config: MockEntityManagerConfig = {}) {
       if (config.shouldFailTransaction) {
         throw new Error('Transaction failed')
       }
-      // Create a separate mock EM for the transaction with same config
-      const txEm = createMockEntityManager(config).em
-      return callback(txEm)
+      // Reuse the same mock EM inside the transaction so queries/writes issued during
+      // the transactional block are observable on the outer spies.
+      return callback(mockEm)
     }),
   }
   

--- a/packages/core/src/modules/currencies/services/rateFetchingService.ts
+++ b/packages/core/src/modules/currencies/services/rateFetchingService.ts
@@ -13,6 +13,13 @@ export interface FetchOptions {
   forceUpdate?: boolean
 }
 
+const exchangeRateKey = (
+  fromCurrencyCode: string,
+  toCurrencyCode: string,
+  date: Date,
+  source: string
+): string => `${fromCurrencyCode}|${toCurrencyCode}|${date.getTime()}|${source}`
+
 export class RateFetchingService {
   private providers: Map<string, RateProvider>
 
@@ -103,25 +110,47 @@ export class RateFetchingService {
     rates: RateProviderResult[],
     scope: { tenantId: string; organizationId: string }
   ): Promise<number> {
+    if (rates.length === 0) return 0
+
     let stored = 0
 
     await this.em.transactional(async (em) => {
+      // Prefetch every existing rate that could match this batch in a single query,
+      // then index by composite key so the per-rate loop never hits the database.
+      const fromCurrencyCodes = Array.from(new Set(rates.map((rate) => rate.fromCurrencyCode)))
+      const toCurrencyCodes = Array.from(new Set(rates.map((rate) => rate.toCurrencyCode)))
+      const sources = Array.from(new Set(rates.map((rate) => rate.source)))
+      const dates = Array.from(new Set(rates.map((rate) => rate.date.getTime()))).map(
+        (time) => new Date(time)
+      )
+
+      const existingRates = await em.find(ExchangeRate, {
+        organizationId: scope.organizationId,
+        tenantId: scope.tenantId,
+        fromCurrencyCode: { $in: fromCurrencyCodes },
+        toCurrencyCode: { $in: toCurrencyCodes },
+        date: { $in: dates },
+        source: { $in: sources },
+      })
+
+      const existingByKey = new Map<string, ExchangeRate>()
+      for (const existing of existingRates) {
+        existingByKey.set(
+          exchangeRateKey(existing.fromCurrencyCode, existing.toCurrencyCode, existing.date, existing.source),
+          existing
+        )
+      }
+
+      const now = new Date()
       for (const rate of rates) {
-        // Check if rate already exists
-        const existing = await em.findOne(ExchangeRate, {
-          organizationId: scope.organizationId,
-          tenantId: scope.tenantId,
-          fromCurrencyCode: rate.fromCurrencyCode,
-          toCurrencyCode: rate.toCurrencyCode,
-          date: rate.date,
-          source: rate.source,
-        })
+        const key = exchangeRateKey(rate.fromCurrencyCode, rate.toCurrencyCode, rate.date, rate.source)
+        const existing = existingByKey.get(key)
 
         if (existing) {
           // Update existing rate
           existing.rate = rate.rate
           existing.type = rate.type ?? null
-          existing.updatedAt = new Date()
+          existing.updatedAt = now
           em.persist(existing)
         } else {
           // Create new rate
@@ -135,15 +164,17 @@ export class RateFetchingService {
             source: rate.source,
             type: rate.type ?? null,
             isActive: true,
-            createdAt: new Date(),
-            updatedAt: new Date(),
+            createdAt: now,
+            updatedAt: now,
           })
           em.persist(newRate)
+          // Track so duplicate keys within the same batch update in memory instead of double-inserting.
+          existingByKey.set(key, newRate)
         }
 
         stored++
       }
-      
+
       // Flush all changes at once
       await em.flush()
     })

--- a/packages/core/src/modules/entities/api/__tests__/definitions.batch.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/definitions.batch.test.ts
@@ -1,0 +1,111 @@
+/** @jest-environment node */
+import { POST } from '../definitions.batch'
+
+const invalidateDefinitionsCacheMock = jest.fn()
+
+type Where = Record<string, unknown>
+
+const mockEm = {
+  begin: jest.fn(async () => {}),
+  commit: jest.fn(async () => {}),
+  rollback: jest.fn(async () => {}),
+  find: jest.fn(async (_entity: unknown, _where: Where) => [] as unknown[]),
+  findOne: jest.fn(async () => null),
+  create: jest.fn((_entity: unknown, data: Where) => ({ ...data })),
+  persist: jest.fn(),
+  flush: jest.fn(async () => {}),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (key: string) => {
+      if (key === 'em') return mockEm
+      if (key === 'cache') throw new Error('no cache')
+      return null
+    },
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: async () => ({
+    sub: 'user-1',
+    tenantId: 'tenant-1',
+    orgId: 'org-1',
+    roles: ['admin'],
+  }),
+}))
+
+jest.mock('@open-mercato/core/modules/entities/data/entities', () => ({
+  CustomFieldDef: 'CustomFieldDef',
+  CustomFieldEntityConfig: 'CustomFieldEntityConfig',
+}))
+
+jest.mock('../definitions.cache', () => ({
+  invalidateDefinitionsCache: (...args: unknown[]) => invalidateDefinitionsCacheMock(...args),
+}))
+
+const makeRequest = (body: unknown) =>
+  new Request('http://x/api/entities/definitions/batch', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+
+describe('entities/definitions.batch POST (issue #1399)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm.find.mockResolvedValue([] as unknown[])
+  })
+
+  it('prefetches existing definitions in one query instead of a lookup per definition', async () => {
+    const body = {
+      entityId: 'test:entity',
+      definitions: [
+        { key: 'alpha', kind: 'text' },
+        { key: 'beta', kind: 'integer' },
+        { key: 'gamma', kind: 'boolean' },
+      ],
+    }
+
+    const response = await POST(makeRequest(body))
+
+    expect(response.status).toBe(200)
+    // Single prefetch keyed by the full set of keys, scoped to tenant/org/entity.
+    const defFinds = mockEm.find.mock.calls.filter((call) => call[0] === 'CustomFieldDef')
+    expect(defFinds).toHaveLength(1)
+    expect(defFinds[0][1]).toMatchObject({
+      entityId: 'test:entity',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      key: { $in: ['alpha', 'beta', 'gamma'] },
+    })
+    // No per-definition point lookups.
+    expect(mockEm.findOne).not.toHaveBeenCalled()
+    // All three created (none existed) and flushed once in the transaction.
+    expect(mockEm.create).toHaveBeenCalledTimes(3)
+    expect(mockEm.flush).toHaveBeenCalledTimes(1)
+    expect(mockEm.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates a prefetched definition in place rather than re-querying it', async () => {
+    const existing = { entityId: 'test:entity', key: 'alpha', kind: 'text', configJson: {}, isActive: true }
+    mockEm.find.mockResolvedValueOnce([existing] as unknown[])
+
+    const body = {
+      entityId: 'test:entity',
+      definitions: [
+        { key: 'alpha', kind: 'integer' },
+        { key: 'beta', kind: 'text' },
+      ],
+    }
+
+    const response = await POST(makeRequest(body))
+
+    expect(response.status).toBe(200)
+    expect(mockEm.findOne).not.toHaveBeenCalled()
+    // Existing 'alpha' mutated in memory; only 'beta' is newly created.
+    expect(existing.kind).toBe('integer')
+    expect(mockEm.create).toHaveBeenCalledTimes(1)
+    expect(mockEm.create.mock.calls[0][1]).toMatchObject({ key: 'beta' })
+    expect(mockEm.flush).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/entities/api/definitions.batch.ts
+++ b/packages/core/src/modules/entities/api/definitions.batch.ts
@@ -65,6 +65,20 @@ export async function POST(req: Request) {
 
   await em.begin()
   try {
+    // Prefetch every existing definition for this entity in a single query, then index
+    // by key so the per-definition loop resolves create/update without round trips.
+    const defByKey = new Map<string, any>()
+    const keys = definitions.map((d) => d.key)
+    if (keys.length > 0) {
+      const existingDefs = await em.find(CustomFieldDef, {
+        entityId,
+        key: { $in: keys },
+        organizationId: auth.orgId ?? null,
+        tenantId: auth.tenantId ?? null,
+      })
+      for (const existing of existingDefs) defByKey.set(existing.key, existing)
+    }
+
     for (const [idx, d] of definitions.entries()) {
       const where: any = {
         entityId,
@@ -72,8 +86,11 @@ export async function POST(req: Request) {
         organizationId: auth.orgId ?? null,
         tenantId: auth.tenantId ?? null,
       }
-      let def = await em.findOne(CustomFieldDef, where)
-      if (!def) def = em.create(CustomFieldDef, { ...where, createdAt: new Date() })
+      let def = defByKey.get(d.key)
+      if (!def) {
+        def = em.create(CustomFieldDef, { ...where, createdAt: new Date() })
+        defByKey.set(d.key, def)
+      }
       def.kind = d.kind
 
       const inCfg = (d as any).configJson ?? {}

--- a/packages/core/src/modules/entities/lib/__tests__/field-definitions.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/field-definitions.test.ts
@@ -1,0 +1,78 @@
+import { ensureCustomFieldDefinitions } from '../field-definitions'
+
+type Where = Record<string, unknown>
+
+function createMockEm(existing: Array<Record<string, unknown>> = []) {
+  const persisted: Array<Record<string, unknown>> = []
+  return {
+    find: jest.fn(async (_entity: unknown, _where: Where) => existing),
+    findOne: jest.fn(async () => null),
+    create: jest.fn((_entity: unknown, data: Where) => ({ ...data })),
+    persist: jest.fn((entity: Record<string, unknown>) => {
+      persisted.push(entity)
+    }),
+    flush: jest.fn(async () => {}),
+    persisted,
+  }
+}
+
+const scope = { organizationId: 'org-1', tenantId: 'tenant-1' }
+
+describe('ensureCustomFieldDefinitions (issue #1399)', () => {
+  it('prefetches existing definitions once and flushes a single time for the whole batch', async () => {
+    const em = createMockEm()
+    const sets = [
+      { entity: 'a:one', fields: [{ key: 'foo', kind: 'text' as const }, { key: 'bar', kind: 'integer' as const }] },
+      { entity: 'b:two', fields: [{ key: 'baz', kind: 'boolean' as const }] },
+    ]
+
+    const result = await ensureCustomFieldDefinitions(em as any, sets, scope)
+
+    expect(result).toEqual({ created: 3, updated: 0, unchanged: 0 })
+    // One prefetch query covering every entity/key in the batch.
+    expect(em.find).toHaveBeenCalledTimes(1)
+    expect(em.find.mock.calls[0][1]).toMatchObject({
+      entityId: { $in: ['a:one', 'b:two'] },
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      key: { $in: ['foo', 'bar', 'baz'] },
+    })
+    // No per-field point lookups, single flush for the batch.
+    expect(em.findOne).not.toHaveBeenCalled()
+    expect(em.flush).toHaveBeenCalledTimes(1)
+    expect(em.persisted).toHaveLength(3)
+  })
+
+  it('updates prefetched matches in memory without per-field lookups', async () => {
+    const existing = [
+      { entityId: 'a:one', key: 'foo', kind: 'text', configJson: { label: 'Old' }, isActive: true, deletedAt: null },
+    ]
+    const em = createMockEm(existing)
+    const sets = [
+      { entity: 'a:one', fields: [
+        { key: 'foo', kind: 'integer' as const, label: 'New' },
+        { key: 'bar', kind: 'text' as const },
+      ] },
+    ]
+
+    const result = await ensureCustomFieldDefinitions(em as any, sets, scope)
+
+    expect(result).toEqual({ created: 1, updated: 1, unchanged: 0 })
+    expect(existing[0].kind).toBe('integer')
+    expect(em.findOne).not.toHaveBeenCalled()
+    expect(em.flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not query or flush on a dry run', async () => {
+    const em = createMockEm()
+    const sets = [{ entity: 'a:one', fields: [{ key: 'foo', kind: 'text' as const }] }]
+
+    const result = await ensureCustomFieldDefinitions(em as any, sets, { ...scope, dryRun: true })
+
+    expect(result).toEqual({ created: 1, updated: 0, unchanged: 0 })
+    // Prefetch still runs (read-only) but nothing is persisted or flushed.
+    expect(em.findOne).not.toHaveBeenCalled()
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/entities/lib/field-definitions.ts
+++ b/packages/core/src/modules/entities/lib/field-definitions.ts
@@ -73,15 +73,28 @@ export async function ensureCustomFieldDefinitions(
   let updated = 0
   let unchanged = 0
 
+  // Prefetch every existing definition the batch could touch in a single query,
+  // then index by composite key so the nested loop never issues per-field lookups.
+  const entityIds = Array.from(new Set(sets.map((set) => set.entity)))
+  const fieldKeys = Array.from(new Set(sets.flatMap((set) => set.fields.map((field) => field.key))))
+  const existingByKey = new Map<string, CustomFieldDef>()
+  if (entityIds.length > 0 && fieldKeys.length > 0) {
+    const existingDefs = await em.find(CustomFieldDef, {
+      entityId: { $in: entityIds },
+      organizationId: scope.organizationId,
+      tenantId: scope.tenantId,
+      key: { $in: fieldKeys },
+    })
+    for (const def of existingDefs) {
+      existingByKey.set(`${def.entityId}|${def.key}`, def)
+    }
+  }
+
+  let dirty = false
+
   for (const set of sets) {
     for (const field of set.fields) {
-      const where = {
-        entityId: set.entity,
-        organizationId: scope.organizationId,
-        tenantId: scope.tenantId,
-        key: field.key,
-      }
-      const existing = await em.findOne(CustomFieldDef, where)
+      const existing = existingByKey.get(`${set.entity}|${field.key}`) ?? null
       const configJson: Record<string, unknown> = {}
 
       for (const key of CONFIG_PASSTHROUGH_KEYS) {
@@ -91,19 +104,21 @@ export async function ensureCustomFieldDefinitions(
 
       if (!existing) {
         if (!scope.dryRun) {
-          await em.persist(
-            em.create(CustomFieldDef, {
-              entityId: set.entity,
-              organizationId: scope.organizationId,
-              tenantId: scope.tenantId,
-              key: field.key,
-              kind: field.kind,
-              configJson,
-              isActive: true,
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            })
-          ).flush()
+          const createdDef = em.create(CustomFieldDef, {
+            entityId: set.entity,
+            organizationId: scope.organizationId,
+            tenantId: scope.tenantId,
+            key: field.key,
+            kind: field.kind,
+            configJson,
+            isActive: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          })
+          em.persist(createdDef)
+          // Track so duplicate (entity, key) pairs within the batch update in memory instead of double-inserting.
+          existingByKey.set(`${set.entity}|${field.key}`, createdDef)
+          dirty = true
         }
         created++
         continue
@@ -127,10 +142,16 @@ export async function ensureCustomFieldDefinitions(
         existing.isActive = true
         existing.updatedAt = new Date()
         if (existing.deletedAt) existing.deletedAt = null
-        await em.flush()
+        em.persist(existing)
+        dirty = true
       }
       updated++
     }
+  }
+
+  if (dirty) {
+    // Single flush for the whole batch instead of one round trip per field.
+    await em.flush()
   }
 
   return { created, updated, unchanged }

--- a/packages/core/src/modules/perspectives/services/__tests__/perspectiveService.batching.test.ts
+++ b/packages/core/src/modules/perspectives/services/__tests__/perspectiveService.batching.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals'
+import { saveRolePerspectives } from '../perspectiveService'
+
+type Where = Record<string, unknown>
+
+function createMockEm(existing: Array<Record<string, unknown>> = []) {
+  return {
+    find: jest.fn(async (_entity: unknown, _where: Where) => existing),
+    findOne: jest.fn(async () => null),
+    create: jest.fn((_entity: unknown, data: Where) => ({ ...data, id: `id-${(data as any).roleId}` })),
+    persist: jest.fn(),
+    flush: jest.fn(async () => {}),
+    nativeUpdate: jest.fn(async () => 0),
+  }
+}
+
+const baseOptions = {
+  tableId: 'orders',
+  tenantId: 'tenant-1',
+  organizationId: 'org-1',
+}
+
+const settings = { columns: undefined, sort: undefined, filters: undefined } as any
+
+describe('saveRolePerspectives (issue #1399)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('prefetches all role perspectives in one query instead of one lookup per role', async () => {
+    const em = createMockEm()
+    const roleIds = ['11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', '33333333-3333-3333-3333-333333333333']
+
+    const result = await saveRolePerspectives(em as any, null, {
+      ...baseOptions,
+      input: { roleIds, name: 'Shared', settings, setDefault: false },
+    })
+
+    expect(result).toHaveLength(3)
+    // Single prefetch keyed by all role ids.
+    expect(em.find).toHaveBeenCalledTimes(1)
+    expect(em.find.mock.calls[0][1]).toMatchObject({
+      roleId: { $in: roleIds },
+      tableId: 'orders',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      name: 'Shared',
+      deletedAt: null,
+    })
+    // No per-role point lookups, single flush for the batch.
+    expect(em.findOne).not.toHaveBeenCalled()
+    expect(em.flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates prefetched records in memory and creates only missing ones', async () => {
+    const roleA = '11111111-1111-1111-1111-111111111111'
+    const roleB = '22222222-2222-2222-2222-222222222222'
+    const existing = [
+      { id: 'existing-a', roleId: roleA, tableId: 'orders', name: 'Shared', settingsJson: {}, isDefault: false, tenantId: 'tenant-1', organizationId: 'org-1', createdAt: new Date('2024-01-01'), updatedAt: new Date('2024-01-01') },
+    ]
+    const em = createMockEm(existing)
+
+    const result = await saveRolePerspectives(em as any, null, {
+      ...baseOptions,
+      input: { roleIds: [roleA, roleB], name: 'Shared', settings, setDefault: false },
+    })
+
+    expect(result).toHaveLength(2)
+    expect(em.findOne).not.toHaveBeenCalled()
+    // Only the missing role (B) is created.
+    expect(em.create).toHaveBeenCalledTimes(1)
+    expect(em.create.mock.calls[0][1]).toMatchObject({ roleId: roleB })
+    expect(em.flush).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/perspectives/services/perspectiveService.ts
+++ b/packages/core/src/modules/perspectives/services/perspectiveService.ts
@@ -339,15 +339,23 @@ export async function saveRolePerspectives(
 
   const results: ResolvedRolePerspective[] = []
 
-  for (const roleId of input.roleIds) {
-    let record = await em.findOne(RolePerspective, {
-      roleId,
+  // Prefetch every matching role perspective in a single query, then index by role id
+  // so the loop resolves create/update without a lookup per role.
+  const recordByRole = new Map<string, RolePerspective>()
+  if (input.roleIds.length) {
+    const existingRecords = await em.find(RolePerspective, {
+      roleId: { $in: input.roleIds },
       tableId,
       tenantId,
       organizationId,
       name: input.name,
       deletedAt: null,
     })
+    for (const existing of existingRecords) recordByRole.set(existing.roleId, existing)
+  }
+
+  for (const roleId of input.roleIds) {
+    let record = recordByRole.get(roleId) ?? null
     if (!record) {
       record = em.create(RolePerspective, {
         roleId,
@@ -361,6 +369,7 @@ export async function saveRolePerspectives(
         updatedAt: now,
       })
       em.persist(record)
+      recordByRole.set(roleId, record)
     } else {
       record.settingsJson = input.settings
       record.updatedAt = now


### PR DESCRIPTION
Fixes #1399

## Problem
Several write-heavy core paths issued a `em.findOne` per row inside a loop (plus, in places, a flush per row), turning bulk operations into O(n) round trips:

- **Exchange-rate ingestion** — `RateFetchingService.storeRates` did a point lookup per rate (up to 500 lookups before any write).
- **Field-definition upserts** — `ensureCustomFieldDefinitions` and the `definitions.batch` route did a row-by-row `findOne` (and, in the lib, a flush per created field).
- **Role-perspective save** — `saveRolePerspectives` did one lookup per `roleId`.

## Root Cause
Each loop resolved the create-vs-update decision with an individual scoped `findOne`, instead of prefetching the candidate set once and indexing it in memory.

## What Changed
All four sites now follow the same pattern (as suggested in the issue):
1. Prefetch every candidate row in **one** tenant/organization-scoped query using `$in`.
2. Index results by composite key in a `Map`.
3. Apply create/update in memory.
4. A **single** `em.flush()` at the end.

Details:
- `currencies/services/rateFetchingService.ts` — batch prefetch by `(from, to, date, source)`; early-return on empty batches; within-batch duplicate keys update in memory instead of double-inserting.
- `entities/lib/field-definitions.ts` — prefetch by `(entityId, key)`; one flush for the whole batch instead of one per created field; dry-run still performs no writes.
- `entities/api/definitions.batch.ts` — prefetch all defs for the entity by `key`; keeps the existing `begin/commit` transaction and single flush.
- `perspectives/services/perspectiveService.ts` — prefetch all role rows by `roleId $in`.

Every prefetch runs **before** any mutation, so no query is interleaved between scalar mutations and `flush()` (no `withAtomicFlush` needed, and it is strictly safer than the previous interleaved `findOne`+`flush` pattern).

### Deliberately out of scope: payment commands
The issue also flagged `sales/commands/payments.ts`. Those `for (const id of orderIds)` loops run **per-order pessimistic-lock transactions** over a tiny N (a payment's order plus its allocation orders — usually 1), and `recomputeOrderPaymentTotals` is inherently per-order. The narrow per-order lock scope is a deliberate concurrency design in the most correctness-critical module; batching it would change lock contention/semantics for negligible real-world gain. Left unchanged.

## Tests
- `currencies/.../rateFetchingService.batching.test.ts` — asserts a single prefetch query, **zero** per-rate `findOne`, one flush, correct update/insert split, and DB-skip on empty batches.
- `entities/api/__tests__/definitions.batch.test.ts` — asserts one prefetch by `key $in`, no `findOne`, in-place update of prefetched rows.
- `entities/lib/__tests__/field-definitions.test.ts` — asserts single prefetch + single flush, in-memory updates, and no writes on dry run.
- `perspectives/.../perspectiveService.batching.test.ts` — asserts one prefetch by `roleId $in`, no `findOne`, create-only-for-missing.
- Updated the shared currencies test mock to understand `$in`/date filters and to surface transaction-internal calls; fixed one existing test whose scope mismatched its fixtures.
- All targeted + existing unit suites for the changed modules pass (49 + currencies/entities/perspectives suites). `tsc` (TS 6.0.3) is clean for the changed files.

## Backward Compatibility
- No contract-surface changes: no API routes, public types, signatures, event IDs, DB schema, DI keys, or ACL features changed. The batch route response stays `{ ok: true }`.
- Tenant/organization scoping preserved on every prefetch — no cross-tenant exposure.
- The touched entities (`ExchangeRate`, `CustomFieldDef`, `RolePerspective`) are not encryption-scoped (no encryption maps; original code used raw `em.find`/`findOne`), so the raw prefetch is consistent and correct.