### PR TITLE
perf(dashboards): add batch widget-data endpoint to collapse per-widget container/RBAC/scope rebuild (#2273)

### DIFF
--- a/packages/core/src/modules/dashboards/api/widgets/data/batch/route.ts
+++ b/packages/core/src/modules/dashboards/api/widgets/data/batch/route.ts
@@ -1,0 +1,168 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { CacheStrategy } from '@open-mercato/cache'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import {
+  createWidgetDataService,
+  type WidgetDataRequest,
+  WidgetDataValidationError,
+} from '../../../../services/widgetDataService'
+import { runWidgetDataBatch } from '../../../../lib/widgetDataBatch'
+import type { AnalyticsRegistry } from '../../../../services/analyticsRegistry'
+import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { dashboardsTag, dashboardsErrorSchema } from '../../../openapi'
+import { widgetDataRequestSchema, widgetDataResponseSchema } from '../schema'
+
+export const metadata = {
+  POST: { requireAuth: true, requireFeatures: ['analytics.view'] },
+}
+
+const MAX_BATCH_SIZE = 50
+
+const widgetDataBatchRequestSchema = z.object({
+  requests: z
+    .array(
+      z.object({
+        id: z.string().min(1),
+        request: widgetDataRequestSchema,
+      }),
+    )
+    .min(1)
+    .max(MAX_BATCH_SIZE),
+})
+
+const widgetDataBatchResponseSchema = z.object({
+  results: z.array(
+    z.discriminatedUnion('ok', [
+      z.object({
+        id: z.string(),
+        ok: z.literal(true),
+        data: widgetDataResponseSchema,
+      }),
+      z.object({
+        id: z.string(),
+        ok: z.literal(false),
+        error: z.string(),
+      }),
+    ]),
+  ),
+})
+
+export async function POST(req: Request) {
+  const auth = await getAuthFromRequest(req)
+  if (!auth) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parsed = widgetDataBatchRequestSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid request payload', issues: parsed.error.issues },
+      { status: 400 },
+    )
+  }
+
+  const tenantId = auth.tenantId ?? null
+  if (!tenantId) {
+    return NextResponse.json({ error: 'Tenant context is required' }, { status: 400 })
+  }
+
+  // Build the per-request DI/RBAC/org-scope stack exactly once for the whole
+  // batch instead of once per widget (see issue #2273).
+  const container = await createRequestContainer()
+  const analyticsRegistry = container.resolve<AnalyticsRegistry>('analyticsRegistry')
+
+  const em = (container.resolve('em') as EntityManager).fork({
+    clear: true,
+    freshEventManager: true,
+    useContext: true,
+  })
+
+  const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
+
+  const organizationIds = (() => {
+    if (scope?.selectedId) return [scope.selectedId]
+    if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+    if (scope?.allowedIds === null) return undefined
+    if (auth.orgId) return [auth.orgId]
+    return undefined
+  })()
+
+  const cache = container.resolve<CacheStrategy>('cache')
+  const service = createWidgetDataService(em, { tenantId, organizationIds }, analyticsRegistry, cache)
+
+  const rbacService = container.resolve<{
+    userHasAllFeatures: (
+      userId: string,
+      features: string[],
+      scope: { tenantId: string; organizationId?: string | null },
+    ) => Promise<boolean>
+  }>('rbacService')
+
+  try {
+    const results = await runWidgetDataBatch(parsed.data.requests as Array<{ id: string; request: WidgetDataRequest }>, {
+      getRequiredFeatures: (entityType) => analyticsRegistry.getRequiredFeatures(entityType),
+      checkFeatures: (features) => {
+        if (features.length === 0) return Promise.resolve(true)
+        return rbacService.userHasAllFeatures(auth.sub, features, {
+          tenantId,
+          organizationId: auth.orgId,
+        })
+      },
+      fetchOne: (request) => service.fetchWidgetData(request),
+      describeError: (error) =>
+        error instanceof WidgetDataValidationError
+          ? error.message
+          : 'An error occurred while processing your request',
+    })
+    return NextResponse.json({ results })
+  } catch (err) {
+    console.error('[widgets/data/batch] Error:', err)
+    return NextResponse.json(
+      { error: 'An error occurred while processing your request' },
+      { status: 500 },
+    )
+  }
+}
+
+const widgetDataBatchPostDoc: OpenApiMethodDoc = {
+  summary: 'Fetch aggregated data for multiple dashboard widgets in one request',
+  description:
+    'Resolves a batch of widget data requests with a single authentication, RBAC, organization-scope, and database-context setup. Each request is keyed by an opaque widget id and resolved independently, so a failure in one widget does not fail the batch.',
+  tags: [dashboardsTag],
+  requestBody: {
+    contentType: 'application/json',
+    schema: widgetDataBatchRequestSchema,
+    description: 'A list of id-keyed widget data requests to resolve together.',
+  },
+  responses: [
+    {
+      status: 200,
+      description: 'Per-widget aggregation results keyed by request id.',
+      schema: widgetDataBatchResponseSchema,
+    },
+  ],
+  errors: [
+    { status: 400, description: 'Invalid request payload', schema: dashboardsErrorSchema },
+    { status: 401, description: 'Authentication required', schema: dashboardsErrorSchema },
+    { status: 500, description: 'Internal server error', schema: dashboardsErrorSchema },
+  ],
+}
+
+export const openApi: OpenApiRouteDoc = {
+  tag: dashboardsTag,
+  summary: 'Batch widget data aggregation endpoint',
+  methods: {
+    POST: widgetDataBatchPostDoc,
+  },
+}

--- a/packages/core/src/modules/dashboards/api/widgets/data/route.ts
+++ b/packages/core/src/modules/dashboards/api/widgets/data/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server'
-import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { CacheStrategy } from '@open-mercato/cache'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
@@ -13,99 +12,11 @@ import {
 import type { AnalyticsRegistry } from '../../../services/analyticsRegistry'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { dashboardsTag, dashboardsErrorSchema } from '../../openapi'
+import { widgetDataRequestSchema, widgetDataResponseSchema } from './schema'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['analytics.view'] },
 }
-
-const aggregateFunctionSchema = z.enum(['count', 'sum', 'avg', 'min', 'max'])
-const dateGranularitySchema = z.enum(['day', 'week', 'month', 'quarter', 'year'])
-const dateRangePresetSchema = z.enum([
-  'today',
-  'yesterday',
-  'this_week',
-  'last_week',
-  'this_month',
-  'last_month',
-  'this_quarter',
-  'last_quarter',
-  'this_year',
-  'last_year',
-  'last_7_days',
-  'last_30_days',
-  'last_90_days',
-])
-
-const filterOperatorSchema = z.enum([
-  'eq',
-  'neq',
-  'gt',
-  'gte',
-  'lt',
-  'lte',
-  'in',
-  'not_in',
-  'is_null',
-  'is_not_null',
-])
-
-const widgetDataRequestSchema = z.object({
-  entityType: z.string().min(1),
-  metric: z.object({
-    field: z.string().min(1),
-    aggregate: aggregateFunctionSchema,
-  }),
-  groupBy: z
-    .object({
-      field: z.string().min(1),
-      granularity: dateGranularitySchema.optional(),
-      limit: z.number().int().min(1).max(100).optional(),
-      resolveLabels: z.boolean().optional(),
-    })
-    .optional(),
-  filters: z
-    .array(
-      z.object({
-        field: z.string().min(1),
-        operator: filterOperatorSchema,
-        value: z.unknown().optional(),
-      }),
-    )
-    .optional(),
-  dateRange: z
-    .object({
-      field: z.string().min(1),
-      preset: dateRangePresetSchema,
-    })
-    .optional(),
-  comparison: z
-    .object({
-      type: z.enum(['previous_period', 'previous_year']),
-    })
-    .optional(),
-})
-
-const widgetDataItemSchema = z.object({
-  groupKey: z.unknown(),
-  groupLabel: z.string().optional(),
-  value: z.number().nullable(),
-})
-
-const widgetDataResponseSchema = z.object({
-  value: z.number().nullable(),
-  data: z.array(widgetDataItemSchema),
-  comparison: z
-    .object({
-      value: z.number().nullable(),
-      change: z.number(),
-      direction: z.enum(['up', 'down', 'unchanged']),
-    })
-    .optional(),
-  metadata: z.object({
-    fetchedAt: z.string(),
-    recordCount: z.number(),
-  }),
-})
 
 export async function POST(req: Request) {
   const auth = await getAuthFromRequest(req)

--- a/packages/core/src/modules/dashboards/api/widgets/data/schema.ts
+++ b/packages/core/src/modules/dashboards/api/widgets/data/schema.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod'
+
+export const aggregateFunctionSchema = z.enum(['count', 'sum', 'avg', 'min', 'max'])
+export const dateGranularitySchema = z.enum(['day', 'week', 'month', 'quarter', 'year'])
+export const dateRangePresetSchema = z.enum([
+  'today',
+  'yesterday',
+  'this_week',
+  'last_week',
+  'this_month',
+  'last_month',
+  'this_quarter',
+  'last_quarter',
+  'this_year',
+  'last_year',
+  'last_7_days',
+  'last_30_days',
+  'last_90_days',
+])
+
+export const filterOperatorSchema = z.enum([
+  'eq',
+  'neq',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'in',
+  'not_in',
+  'is_null',
+  'is_not_null',
+])
+
+export const widgetDataRequestSchema = z.object({
+  entityType: z.string().min(1),
+  metric: z.object({
+    field: z.string().min(1),
+    aggregate: aggregateFunctionSchema,
+  }),
+  groupBy: z
+    .object({
+      field: z.string().min(1),
+      granularity: dateGranularitySchema.optional(),
+      limit: z.number().int().min(1).max(100).optional(),
+      resolveLabels: z.boolean().optional(),
+    })
+    .optional(),
+  filters: z
+    .array(
+      z.object({
+        field: z.string().min(1),
+        operator: filterOperatorSchema,
+        value: z.unknown().optional(),
+      }),
+    )
+    .optional(),
+  dateRange: z
+    .object({
+      field: z.string().min(1),
+      preset: dateRangePresetSchema,
+    })
+    .optional(),
+  comparison: z
+    .object({
+      type: z.enum(['previous_period', 'previous_year']),
+    })
+    .optional(),
+})
+
+export const widgetDataItemSchema = z.object({
+  groupKey: z.unknown(),
+  groupLabel: z.string().optional(),
+  value: z.number().nullable(),
+})
+
+export const widgetDataResponseSchema = z.object({
+  value: z.number().nullable(),
+  data: z.array(widgetDataItemSchema),
+  comparison: z
+    .object({
+      value: z.number().nullable(),
+      change: z.number(),
+      direction: z.enum(['up', 'down', 'unchanged']),
+    })
+    .optional(),
+  metadata: z.object({
+    fetchedAt: z.string(),
+    recordCount: z.number(),
+  }),
+})

--- a/packages/core/src/modules/dashboards/lib/__tests__/widgetDataBatch.test.ts
+++ b/packages/core/src/modules/dashboards/lib/__tests__/widgetDataBatch.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @jest-environment node
+ */
+import {
+  resolveEntityFeatureAccess,
+  runWidgetDataBatch,
+  type WidgetDataBatchEntry,
+} from '../widgetDataBatch'
+import type { WidgetDataRequest, WidgetDataResponse } from '../../services/widgetDataService'
+import { WidgetDataValidationError } from '../../services/widgetDataService'
+
+function makeRequest(entityType: string): WidgetDataRequest {
+  return { entityType, metric: { field: 'id', aggregate: 'count' } }
+}
+
+function makeEntry(id: string, entityType: string): WidgetDataBatchEntry {
+  return { id, request: makeRequest(entityType) }
+}
+
+const response: WidgetDataResponse = {
+  value: 1,
+  data: [],
+  metadata: { fetchedAt: '2026-05-31T00:00:00.000Z', recordCount: 1 },
+}
+
+describe('resolveEntityFeatureAccess', () => {
+  test('resolves RBAC for the union of required features in a single check', async () => {
+    const checkFeatures = jest.fn().mockResolvedValue(true)
+    const getRequiredFeatures = (entityType: string) =>
+      entityType === 'sales:orders' ? ['sales.view'] : ['customers.view']
+
+    const access = await resolveEntityFeatureAccess(
+      ['sales:orders', 'customers:entities', 'sales:orders'],
+      getRequiredFeatures,
+      checkFeatures,
+    )
+
+    expect(checkFeatures).toHaveBeenCalledTimes(1)
+    expect([...checkFeatures.mock.calls[0][0]].sort()).toEqual(['customers.view', 'sales.view'])
+    expect(access.get('sales:orders')).toBe(true)
+    expect(access.get('customers:entities')).toBe(true)
+  })
+
+  test('entity types without required features are allowed without an RBAC call', async () => {
+    const checkFeatures = jest.fn().mockResolvedValue(true)
+    const access = await resolveEntityFeatureAccess(
+      ['public:metric'],
+      () => null,
+      checkFeatures,
+    )
+    expect(checkFeatures).not.toHaveBeenCalled()
+    expect(access.get('public:metric')).toBe(true)
+  })
+
+  test('union denial falls back to per-entity-type checks', async () => {
+    const checkFeatures = jest
+      .fn()
+      // union check fails
+      .mockResolvedValueOnce(false)
+      // per-type: sales allowed, customers denied
+      .mockImplementation(async (features: string[]) => features.includes('sales.view'))
+
+    const access = await resolveEntityFeatureAccess(
+      ['sales:orders', 'customers:entities'],
+      (entityType) => (entityType === 'sales:orders' ? ['sales.view'] : ['customers.view']),
+      checkFeatures,
+    )
+
+    expect(access.get('sales:orders')).toBe(true)
+    expect(access.get('customers:entities')).toBe(false)
+    // 1 union check + 2 per-type checks
+    expect(checkFeatures).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('runWidgetDataBatch', () => {
+  test('checks RBAC once for the whole batch and fetches each widget', async () => {
+    const checkFeatures = jest.fn().mockResolvedValue(true)
+    const fetchOne = jest.fn().mockResolvedValue(response)
+
+    const entries = [
+      makeEntry('a', 'sales:orders'),
+      makeEntry('b', 'sales:orders'),
+      makeEntry('c', 'customers:entities'),
+    ]
+
+    const results = await runWidgetDataBatch(entries, {
+      getRequiredFeatures: () => ['analytics.view'],
+      checkFeatures,
+      fetchOne,
+      describeError: () => 'error',
+    })
+
+    expect(checkFeatures).toHaveBeenCalledTimes(1)
+    expect(fetchOne).toHaveBeenCalledTimes(3)
+    expect(results).toEqual([
+      { id: 'a', ok: true, data: response },
+      { id: 'b', ok: true, data: response },
+      { id: 'c', ok: true, data: response },
+    ])
+  })
+
+  test('isolates per-widget failures without failing the batch', async () => {
+    const fetchOne = jest.fn(async (request: WidgetDataRequest) => {
+      if (request.entityType === 'bad:type') {
+        throw new WidgetDataValidationError('Invalid entity type: bad:type')
+      }
+      return response
+    })
+
+    const results = await runWidgetDataBatch(
+      [makeEntry('ok', 'sales:orders'), makeEntry('bad', 'bad:type')],
+      {
+        getRequiredFeatures: () => null,
+        checkFeatures: jest.fn().mockResolvedValue(true),
+        fetchOne,
+        describeError: (error) =>
+          error instanceof WidgetDataValidationError ? error.message : 'unexpected',
+      },
+    )
+
+    expect(results).toEqual([
+      { id: 'ok', ok: true, data: response },
+      { id: 'bad', ok: false, error: 'Invalid entity type: bad:type' },
+    ])
+  })
+
+  test('denies forbidden entity types and never fetches them', async () => {
+    const fetchOne = jest.fn().mockResolvedValue(response)
+    const checkFeatures = jest
+      .fn()
+      .mockResolvedValueOnce(false) // union fails
+      .mockImplementation(async (features: string[]) => features.includes('sales.view'))
+
+    const results = await runWidgetDataBatch(
+      [makeEntry('ok', 'sales:orders'), makeEntry('nope', 'secret:entities')],
+      {
+        getRequiredFeatures: (entityType) =>
+          entityType === 'sales:orders' ? ['sales.view'] : ['secret.view'],
+        checkFeatures,
+        fetchOne,
+        describeError: () => 'error',
+      },
+    )
+
+    expect(results).toEqual([
+      { id: 'ok', ok: true, data: response },
+      { id: 'nope', ok: false, error: 'Forbidden' },
+    ])
+    expect(fetchOne).toHaveBeenCalledTimes(1)
+    expect(fetchOne).toHaveBeenCalledWith(makeRequest('sales:orders'))
+  })
+})

--- a/packages/core/src/modules/dashboards/lib/widgetDataBatch.ts
+++ b/packages/core/src/modules/dashboards/lib/widgetDataBatch.ts
@@ -1,0 +1,89 @@
+import type { WidgetDataRequest, WidgetDataResponse } from '../services/widgetDataService'
+
+export type WidgetDataBatchEntry = {
+  id: string
+  request: WidgetDataRequest
+}
+
+export type WidgetDataBatchResult =
+  | { id: string; ok: true; data: WidgetDataResponse }
+  | { id: string; ok: false; error: string }
+
+export type WidgetDataBatchDeps = {
+  getRequiredFeatures: (entityType: string) => string[] | null
+  checkFeatures: (features: string[]) => Promise<boolean>
+  fetchOne: (request: WidgetDataRequest) => Promise<WidgetDataResponse>
+  describeError: (error: unknown) => string
+}
+
+/**
+ * Resolves per-entity-type feature access for a batch of widget requests while
+ * collapsing the common case to a single RBAC resolution. The happy path checks
+ * the union of all required features once; only when the union check fails do we
+ * fall back to per-entity-type checks so a single privileged entity type does
+ * not reject widgets the caller is allowed to see.
+ */
+export async function resolveEntityFeatureAccess(
+  entityTypes: string[],
+  getRequiredFeatures: (entityType: string) => string[] | null,
+  checkFeatures: (features: string[]) => Promise<boolean>,
+): Promise<Map<string, boolean>> {
+  const access = new Map<string, boolean>()
+  const featuresByEntity = new Map<string, string[]>()
+  const unionFeatures = new Set<string>()
+
+  for (const entityType of new Set(entityTypes)) {
+    const features = getRequiredFeatures(entityType) ?? []
+    featuresByEntity.set(entityType, features)
+    if (features.length === 0) {
+      access.set(entityType, true)
+    } else {
+      for (const feature of features) unionFeatures.add(feature)
+    }
+  }
+
+  const gated = [...featuresByEntity.entries()].filter(([, features]) => features.length > 0)
+  if (gated.length === 0) return access
+
+  if (await checkFeatures([...unionFeatures])) {
+    for (const [entityType] of gated) access.set(entityType, true)
+    return access
+  }
+
+  for (const [entityType, features] of gated) {
+    access.set(entityType, await checkFeatures(features))
+  }
+  return access
+}
+
+/**
+ * Runs a batch of widget-data requests against shared request-scoped
+ * dependencies (a single container, RBAC resolution, org-scope, and EM fork).
+ * Feature access is resolved once up front; each request is then executed
+ * concurrently with per-widget error isolation so one bad request never fails
+ * the whole batch.
+ */
+export async function runWidgetDataBatch(
+  entries: WidgetDataBatchEntry[],
+  deps: WidgetDataBatchDeps,
+): Promise<WidgetDataBatchResult[]> {
+  const access = await resolveEntityFeatureAccess(
+    entries.map((entry) => entry.request.entityType),
+    deps.getRequiredFeatures,
+    deps.checkFeatures,
+  )
+
+  return Promise.all(
+    entries.map(async (entry): Promise<WidgetDataBatchResult> => {
+      if (access.get(entry.request.entityType) === false) {
+        return { id: entry.id, ok: false, error: 'Forbidden' }
+      }
+      try {
+        const data = await deps.fetchOne(entry.request)
+        return { id: entry.id, ok: true, data }
+      } catch (error) {
+        return { id: entry.id, ok: false, error: deps.describeError(error) }
+      }
+    }),
+  )
+}

--- a/packages/core/src/modules/dashboards/widgets/dashboard/aov-kpi/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/aov-kpi/widget.client.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import type { DashboardWidgetComponentProps } from '@open-mercato/shared/modules/dashboard/widgets'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useWidgetData, type WidgetDataFetcher } from '@open-mercato/ui/backend/dashboard/widgetData'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { KpiCard, type KpiTrend } from '@open-mercato/ui/backend/charts'
 import {
@@ -15,7 +15,7 @@ import { DEFAULT_SETTINGS, hydrateSettings, type AovKpiSettings } from './config
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
 import { formatCurrencyWithDecimals } from '../../../lib/formatters'
 
-async function fetchAovData(settings: AovKpiSettings): Promise<WidgetDataResponse> {
+async function fetchAovData(settings: AovKpiSettings, fetchWidgetData: WidgetDataFetcher): Promise<WidgetDataResponse> {
   const body = {
     entityType: 'sales:orders',
     metric: {
@@ -29,18 +29,7 @@ async function fetchAovData(settings: AovKpiSettings): Promise<WidgetDataRespons
     comparison: settings.showComparison ? { type: 'previous_period' } : undefined,
   }
 
-  const call = await apiCall<WidgetDataResponse>('/api/dashboards/widgets/data', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-
-  if (!call.ok) {
-    const errorMsg = (call.result as Record<string, unknown>)?.error
-    throw new Error(typeof errorMsg === 'string' ? errorMsg : 'Failed to fetch AOV data')
-  }
-
-  return call.result as WidgetDataResponse
+  return fetchWidgetData<WidgetDataResponse>(body)
 }
 
 const AovKpiWidget: React.FC<DashboardWidgetComponentProps<AovKpiSettings>> = ({
@@ -57,12 +46,13 @@ const AovKpiWidget: React.FC<DashboardWidgetComponentProps<AovKpiSettings>> = ({
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
 
+  const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
     onRefreshStateChange?.(true)
     setLoading(true)
     setError(null)
     try {
-      const data = await fetchAovData(hydrated)
+      const data = await fetchAovData(hydrated, fetchWidgetData)
       setValue(data.value)
       if (data.comparison) {
         setTrend({
@@ -79,7 +69,7 @@ const AovKpiWidget: React.FC<DashboardWidgetComponentProps<AovKpiSettings>> = ({
       setLoading(false)
       onRefreshStateChange?.(false)
     }
-  }, [hydrated, onRefreshStateChange, t])
+  }, [hydrated, fetchWidgetData, onRefreshStateChange, t])
 
   React.useEffect(() => {
     refresh().catch(() => {})

--- a/packages/core/src/modules/dashboards/widgets/dashboard/new-customers-kpi/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/new-customers-kpi/widget.client.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import type { DashboardWidgetComponentProps } from '@open-mercato/shared/modules/dashboard/widgets'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useWidgetData, type WidgetDataFetcher } from '@open-mercato/ui/backend/dashboard/widgetData'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { KpiCard, type KpiTrend } from '@open-mercato/ui/backend/charts'
 import {
@@ -14,7 +14,7 @@ import {
 import { DEFAULT_SETTINGS, hydrateSettings, type NewCustomersKpiSettings } from './config'
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
 
-async function fetchNewCustomersData(settings: NewCustomersKpiSettings): Promise<WidgetDataResponse> {
+async function fetchNewCustomersData(settings: NewCustomersKpiSettings, fetchWidgetData: WidgetDataFetcher): Promise<WidgetDataResponse> {
   const body = {
     entityType: 'customers:entities',
     metric: {
@@ -28,18 +28,7 @@ async function fetchNewCustomersData(settings: NewCustomersKpiSettings): Promise
     comparison: settings.showComparison ? { type: 'previous_period' } : undefined,
   }
 
-  const call = await apiCall<WidgetDataResponse>('/api/dashboards/widgets/data', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-
-  if (!call.ok) {
-    const errorMsg = (call.result as Record<string, unknown>)?.error
-    throw new Error(typeof errorMsg === 'string' ? errorMsg : 'Failed to fetch new customers data')
-  }
-
-  return call.result as WidgetDataResponse
+  return fetchWidgetData<WidgetDataResponse>(body)
 }
 
 const NewCustomersKpiWidget: React.FC<DashboardWidgetComponentProps<NewCustomersKpiSettings>> = ({
@@ -56,12 +45,13 @@ const NewCustomersKpiWidget: React.FC<DashboardWidgetComponentProps<NewCustomers
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
 
+  const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
     onRefreshStateChange?.(true)
     setLoading(true)
     setError(null)
     try {
-      const data = await fetchNewCustomersData(hydrated)
+      const data = await fetchNewCustomersData(hydrated, fetchWidgetData)
       setValue(data.value)
       if (data.comparison) {
         setTrend({
@@ -78,7 +68,7 @@ const NewCustomersKpiWidget: React.FC<DashboardWidgetComponentProps<NewCustomers
       setLoading(false)
       onRefreshStateChange?.(false)
     }
-  }, [hydrated, onRefreshStateChange, t])
+  }, [hydrated, fetchWidgetData, onRefreshStateChange, t])
 
   React.useEffect(() => {
     refresh().catch(() => {})

--- a/packages/core/src/modules/dashboards/widgets/dashboard/orders-by-status/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/orders-by-status/widget.client.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import type { DashboardWidgetComponentProps } from '@open-mercato/shared/modules/dashboard/widgets'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useWidgetData, type WidgetDataFetcher } from '@open-mercato/ui/backend/dashboard/widgetData'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { PieChart, type PieChartDataItem } from '@open-mercato/ui/backend/charts'
 import {
@@ -20,7 +20,7 @@ import {
 import { DEFAULT_SETTINGS, hydrateSettings, type OrdersByStatusSettings } from './config'
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
 
-async function fetchOrdersByStatusData(settings: OrdersByStatusSettings): Promise<WidgetDataResponse> {
+async function fetchOrdersByStatusData(settings: OrdersByStatusSettings, fetchWidgetData: WidgetDataFetcher): Promise<WidgetDataResponse> {
   const body = {
     entityType: 'sales:orders',
     metric: {
@@ -36,18 +36,7 @@ async function fetchOrdersByStatusData(settings: OrdersByStatusSettings): Promis
     },
   }
 
-  const call = await apiCall<WidgetDataResponse>('/api/dashboards/widgets/data', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-
-  if (!call.ok) {
-    const errorMsg = (call.result as Record<string, unknown>)?.error
-    throw new Error(typeof errorMsg === 'string' ? errorMsg : 'Failed to fetch orders by status data')
-  }
-
-  return call.result as WidgetDataResponse
+  return fetchWidgetData<WidgetDataResponse>(body)
 }
 
 const ORDER_STATUS_KEYS: Record<string, string> = {
@@ -82,12 +71,13 @@ const OrdersByStatusWidget: React.FC<DashboardWidgetComponentProps<OrdersByStatu
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
 
+  const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
     onRefreshStateChange?.(true)
     setLoading(true)
     setError(null)
     try {
-      const result = await fetchOrdersByStatusData(hydrated)
+      const result = await fetchOrdersByStatusData(hydrated, fetchWidgetData)
       const chartData = result.data.map((item) => ({
         name: formatStatusLabel(item.groupKey as string | null, t),
         value: item.value ?? 0,
@@ -100,7 +90,7 @@ const OrdersByStatusWidget: React.FC<DashboardWidgetComponentProps<OrdersByStatu
       setLoading(false)
       onRefreshStateChange?.(false)
     }
-  }, [hydrated, onRefreshStateChange, t])
+  }, [hydrated, fetchWidgetData, onRefreshStateChange, t])
 
   React.useEffect(() => {
     refresh().catch(() => {})

--- a/packages/core/src/modules/dashboards/widgets/dashboard/orders-kpi/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/orders-kpi/widget.client.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import type { DashboardWidgetComponentProps } from '@open-mercato/shared/modules/dashboard/widgets'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useWidgetData, type WidgetDataFetcher } from '@open-mercato/ui/backend/dashboard/widgetData'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { KpiCard, type KpiTrend } from '@open-mercato/ui/backend/charts'
 import {
@@ -14,7 +14,7 @@ import {
 import { DEFAULT_SETTINGS, hydrateSettings, type OrdersKpiSettings } from './config'
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
 
-async function fetchOrdersData(settings: OrdersKpiSettings): Promise<WidgetDataResponse> {
+async function fetchOrdersData(settings: OrdersKpiSettings, fetchWidgetData: WidgetDataFetcher): Promise<WidgetDataResponse> {
   const body = {
     entityType: 'sales:orders',
     metric: {
@@ -28,18 +28,7 @@ async function fetchOrdersData(settings: OrdersKpiSettings): Promise<WidgetDataR
     comparison: settings.showComparison ? { type: 'previous_period' } : undefined,
   }
 
-  const call = await apiCall<WidgetDataResponse>('/api/dashboards/widgets/data', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-
-  if (!call.ok) {
-    const errorMsg = (call.result as Record<string, unknown>)?.error
-    throw new Error(typeof errorMsg === 'string' ? errorMsg : 'Failed to fetch orders data')
-  }
-
-  return call.result as WidgetDataResponse
+  return fetchWidgetData<WidgetDataResponse>(body)
 }
 
 const OrdersKpiWidget: React.FC<DashboardWidgetComponentProps<OrdersKpiSettings>> = ({
@@ -56,12 +45,13 @@ const OrdersKpiWidget: React.FC<DashboardWidgetComponentProps<OrdersKpiSettings>
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
 
+  const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
     onRefreshStateChange?.(true)
     setLoading(true)
     setError(null)
     try {
-      const data = await fetchOrdersData(hydrated)
+      const data = await fetchOrdersData(hydrated, fetchWidgetData)
       setValue(data.value)
       if (data.comparison) {
         setTrend({
@@ -78,7 +68,7 @@ const OrdersKpiWidget: React.FC<DashboardWidgetComponentProps<OrdersKpiSettings>
       setLoading(false)
       onRefreshStateChange?.(false)
     }
-  }, [hydrated, onRefreshStateChange, t])
+  }, [hydrated, fetchWidgetData, onRefreshStateChange, t])
 
   React.useEffect(() => {
     refresh().catch(() => {})

--- a/packages/core/src/modules/dashboards/widgets/dashboard/pipeline-summary/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/pipeline-summary/widget.client.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import type { DashboardWidgetComponentProps } from '@open-mercato/shared/modules/dashboard/widgets'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useWidgetData, type WidgetDataFetcher } from '@open-mercato/ui/backend/dashboard/widgetData'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { BarChart, type BarChartDataItem } from '@open-mercato/ui/backend/charts'
 import {
@@ -14,7 +14,7 @@ import { DEFAULT_SETTINGS, hydrateSettings, type PipelineSummarySettings } from 
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
 import { formatCurrencyCompact } from '../../../lib/formatters'
 
-async function fetchPipelineData(settings: PipelineSummarySettings): Promise<WidgetDataResponse> {
+async function fetchPipelineData(settings: PipelineSummarySettings, fetchWidgetData: WidgetDataFetcher): Promise<WidgetDataResponse> {
   const body = {
     entityType: 'customers:deals',
     metric: {
@@ -31,18 +31,7 @@ async function fetchPipelineData(settings: PipelineSummarySettings): Promise<Wid
     },
   }
 
-  const call = await apiCall<WidgetDataResponse>('/api/dashboards/widgets/data', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-
-  if (!call.ok) {
-    const errorMsg = (call.result as Record<string, unknown>)?.error
-    throw new Error(typeof errorMsg === 'string' ? errorMsg : 'Failed to fetch pipeline data')
-  }
-
-  return call.result as WidgetDataResponse
+  return fetchWidgetData<WidgetDataResponse>(body)
 }
 
 function formatStageLabel(stage: unknown, t: (key: string, fallback: string) => string): string {
@@ -69,12 +58,13 @@ const PipelineSummaryWidget: React.FC<DashboardWidgetComponentProps<PipelineSumm
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
 
+  const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
     onRefreshStateChange?.(true)
     setLoading(true)
     setError(null)
     try {
-      const result = await fetchPipelineData(hydrated)
+      const result = await fetchPipelineData(hydrated, fetchWidgetData)
       const chartData = result.data
         .filter((item) => item.groupKey != null && item.groupKey !== '' && String(item.groupKey) !== '0')
         .map((item) => ({
@@ -89,7 +79,7 @@ const PipelineSummaryWidget: React.FC<DashboardWidgetComponentProps<PipelineSumm
       setLoading(false)
       onRefreshStateChange?.(false)
     }
-  }, [hydrated, onRefreshStateChange, t])
+  }, [hydrated, fetchWidgetData, onRefreshStateChange, t])
 
   React.useEffect(() => {
     refresh().catch(() => {})

--- a/packages/core/src/modules/dashboards/widgets/dashboard/revenue-kpi/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/revenue-kpi/widget.client.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import type { DashboardWidgetComponentProps } from '@open-mercato/shared/modules/dashboard/widgets'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useWidgetData, type WidgetDataFetcher } from '@open-mercato/ui/backend/dashboard/widgetData'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { KpiCard, type KpiTrend } from '@open-mercato/ui/backend/charts'
 import {
@@ -15,7 +15,7 @@ import { DEFAULT_SETTINGS, hydrateSettings, type RevenueKpiSettings } from './co
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
 import { formatCurrency } from '../../../lib/formatters'
 
-async function fetchRevenueData(settings: RevenueKpiSettings): Promise<WidgetDataResponse> {
+async function fetchRevenueData(settings: RevenueKpiSettings, fetchWidgetData: WidgetDataFetcher): Promise<WidgetDataResponse> {
   const body = {
     entityType: 'sales:orders',
     metric: {
@@ -29,18 +29,7 @@ async function fetchRevenueData(settings: RevenueKpiSettings): Promise<WidgetDat
     comparison: settings.showComparison ? { type: 'previous_period' } : undefined,
   }
 
-  const call = await apiCall<WidgetDataResponse>('/api/dashboards/widgets/data', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-
-  if (!call.ok) {
-    const errorMsg = (call.result as Record<string, unknown>)?.error
-    throw new Error(typeof errorMsg === 'string' ? errorMsg : 'Failed to fetch revenue data')
-  }
-
-  return call.result as WidgetDataResponse
+  return fetchWidgetData<WidgetDataResponse>(body)
 }
 
 const RevenueKpiWidget: React.FC<DashboardWidgetComponentProps<RevenueKpiSettings>> = ({
@@ -57,12 +46,13 @@ const RevenueKpiWidget: React.FC<DashboardWidgetComponentProps<RevenueKpiSetting
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
 
+  const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
     onRefreshStateChange?.(true)
     setLoading(true)
     setError(null)
     try {
-      const data = await fetchRevenueData(hydrated)
+      const data = await fetchRevenueData(hydrated, fetchWidgetData)
       setValue(data.value)
       if (data.comparison) {
         setTrend({
@@ -79,7 +69,7 @@ const RevenueKpiWidget: React.FC<DashboardWidgetComponentProps<RevenueKpiSetting
       setLoading(false)
       onRefreshStateChange?.(false)
     }
-  }, [hydrated, onRefreshStateChange, t])
+  }, [hydrated, fetchWidgetData, onRefreshStateChange, t])
 
   React.useEffect(() => {
     refresh().catch(() => {})

--- a/packages/core/src/modules/dashboards/widgets/dashboard/revenue-trend/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/revenue-trend/widget.client.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import type { DashboardWidgetComponentProps } from '@open-mercato/shared/modules/dashboard/widgets'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useWidgetData, type WidgetDataFetcher } from '@open-mercato/ui/backend/dashboard/widgetData'
 import { useT, useLocale } from '@open-mercato/shared/lib/i18n/context'
 import { LineChart, type LineChartDataItem } from '@open-mercato/ui/backend/charts'
 import {
@@ -22,7 +22,7 @@ import { DEFAULT_SETTINGS, hydrateSettings, type RevenueTrendSettings } from './
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
 import { formatCurrencyCompact } from '../../../lib/formatters'
 
-async function fetchRevenueTrendData(settings: RevenueTrendSettings): Promise<WidgetDataResponse> {
+async function fetchRevenueTrendData(settings: RevenueTrendSettings, fetchWidgetData: WidgetDataFetcher): Promise<WidgetDataResponse> {
   const body = {
     entityType: 'sales:orders',
     metric: {
@@ -39,18 +39,7 @@ async function fetchRevenueTrendData(settings: RevenueTrendSettings): Promise<Wi
     },
   }
 
-  const call = await apiCall<WidgetDataResponse>('/api/dashboards/widgets/data', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-
-  if (!call.ok) {
-    const errorMsg = (call.result as Record<string, unknown>)?.error
-    throw new Error(typeof errorMsg === 'string' ? errorMsg : 'Failed to fetch revenue trend data')
-  }
-
-  return call.result as WidgetDataResponse
+  return fetchWidgetData<WidgetDataResponse>(body)
 }
 
 function formatDate(dateStr: string | null, granularity: DateGranularity, locale?: string): string {
@@ -125,12 +114,13 @@ const RevenueTrendWidget: React.FC<DashboardWidgetComponentProps<RevenueTrendSet
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
 
+  const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
     onRefreshStateChange?.(true)
     setLoading(true)
     setError(null)
     try {
-      const result = await fetchRevenueTrendData(hydrated)
+      const result = await fetchRevenueTrendData(hydrated, fetchWidgetData)
       const sortedData = [...result.data].sort((a, b) => {
         const aTime = new Date(a.groupKey as string || 0).getTime()
         const bTime = new Date(b.groupKey as string || 0).getTime()
@@ -148,7 +138,7 @@ const RevenueTrendWidget: React.FC<DashboardWidgetComponentProps<RevenueTrendSet
       setLoading(false)
       onRefreshStateChange?.(false)
     }
-  }, [hydrated, locale, onRefreshStateChange, t])
+  }, [hydrated, fetchWidgetData, locale, onRefreshStateChange, t])
 
   React.useEffect(() => {
     refresh().catch(() => {})

--- a/packages/core/src/modules/dashboards/widgets/dashboard/sales-by-region/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/sales-by-region/widget.client.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import type { DashboardWidgetComponentProps } from '@open-mercato/shared/modules/dashboard/widgets'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useWidgetData, type WidgetDataFetcher } from '@open-mercato/ui/backend/dashboard/widgetData'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { BarChart, type BarChartDataItem } from '@open-mercato/ui/backend/charts'
 import { DateRangeSelect, type DateRangePreset } from '@open-mercato/ui/backend/date-range'
@@ -11,7 +11,7 @@ import { DEFAULT_SETTINGS, hydrateSettings, type SalesByRegionSettings } from '.
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
 import { formatCurrencyCompact } from '../../../lib/formatters'
 
-async function fetchSalesByRegionData(settings: SalesByRegionSettings): Promise<WidgetDataResponse> {
+async function fetchSalesByRegionData(settings: SalesByRegionSettings, fetchWidgetData: WidgetDataFetcher): Promise<WidgetDataResponse> {
   const body = {
     entityType: 'sales:orders',
     metric: {
@@ -28,18 +28,7 @@ async function fetchSalesByRegionData(settings: SalesByRegionSettings): Promise<
     },
   }
 
-  const call = await apiCall<WidgetDataResponse>('/api/dashboards/widgets/data', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-
-  if (!call.ok) {
-    const errorMsg = (call.result as Record<string, unknown>)?.error
-    throw new Error(typeof errorMsg === 'string' ? errorMsg : 'Failed to fetch sales by region data')
-  }
-
-  return call.result as WidgetDataResponse
+  return fetchWidgetData<WidgetDataResponse>(body)
 }
 
 const SalesByRegionWidget: React.FC<DashboardWidgetComponentProps<SalesByRegionSettings>> = ({
@@ -55,12 +44,13 @@ const SalesByRegionWidget: React.FC<DashboardWidgetComponentProps<SalesByRegionS
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
 
+  const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
     onRefreshStateChange?.(true)
     setLoading(true)
     setError(null)
     try {
-      const result = await fetchSalesByRegionData(hydrated)
+      const result = await fetchSalesByRegionData(hydrated, fetchWidgetData)
       const chartData = result.data.map((item) => ({
         region: String(item.groupKey || t('dashboards.analytics.labels.unknown', 'Unknown')),
         Revenue: item.value ?? 0,
@@ -73,7 +63,7 @@ const SalesByRegionWidget: React.FC<DashboardWidgetComponentProps<SalesByRegionS
       setLoading(false)
       onRefreshStateChange?.(false)
     }
-  }, [hydrated, onRefreshStateChange, t])
+  }, [hydrated, fetchWidgetData, onRefreshStateChange, t])
 
   React.useEffect(() => {
     refresh().catch(() => {})

--- a/packages/core/src/modules/dashboards/widgets/dashboard/top-customers/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/top-customers/widget.client.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import type { DashboardWidgetComponentProps } from '@open-mercato/shared/modules/dashboard/widgets'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useWidgetData, type WidgetDataFetcher } from '@open-mercato/ui/backend/dashboard/widgetData'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { TopNTable, type TopNTableColumn } from '@open-mercato/ui/backend/charts'
 import { DateRangeSelect, type DateRangePreset } from '@open-mercato/ui/backend/date-range'
@@ -17,7 +17,7 @@ type CustomerRow = {
   revenue: number
 }
 
-async function fetchTopCustomersData(settings: TopCustomersSettings): Promise<WidgetDataResponse> {
+async function fetchTopCustomersData(settings: TopCustomersSettings, fetchWidgetData: WidgetDataFetcher): Promise<WidgetDataResponse> {
   const body = {
     entityType: 'sales:orders',
     metric: {
@@ -35,18 +35,7 @@ async function fetchTopCustomersData(settings: TopCustomersSettings): Promise<Wi
     },
   }
 
-  const call = await apiCall<WidgetDataResponse>('/api/dashboards/widgets/data', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-
-  if (!call.ok) {
-    const errorMsg = (call.result as Record<string, unknown>)?.error
-    throw new Error(typeof errorMsg === 'string' ? errorMsg : 'Failed to fetch top customers data')
-  }
-
-  return call.result as WidgetDataResponse
+  return fetchWidgetData<WidgetDataResponse>(body)
 }
 
 function formatCustomerName(name: string | null, unknownLabel: string): string {
@@ -90,12 +79,13 @@ const TopCustomersWidget: React.FC<DashboardWidgetComponentProps<TopCustomersSet
     [t, unknownLabel],
   )
 
+  const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
     onRefreshStateChange?.(true)
     setLoading(true)
     setError(null)
     try {
-      const result = await fetchTopCustomersData(hydrated)
+      const result = await fetchTopCustomersData(hydrated, fetchWidgetData)
       const tableData: CustomerRow[] = result.data.map((item, index) => ({
         rank: index + 1,
         customerId: item.groupLabel || String(item.groupKey || t('dashboards.analytics.labels.unknown', 'Unknown')),
@@ -109,7 +99,7 @@ const TopCustomersWidget: React.FC<DashboardWidgetComponentProps<TopCustomersSet
       setLoading(false)
       onRefreshStateChange?.(false)
     }
-  }, [hydrated, onRefreshStateChange, t])
+  }, [hydrated, fetchWidgetData, onRefreshStateChange, t])
 
   React.useEffect(() => {
     refresh().catch(() => {})

--- a/packages/core/src/modules/dashboards/widgets/dashboard/top-products/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/top-products/widget.client.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import type { DashboardWidgetComponentProps } from '@open-mercato/shared/modules/dashboard/widgets'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useWidgetData, type WidgetDataFetcher } from '@open-mercato/ui/backend/dashboard/widgetData'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { BarChart, type BarChartDataItem } from '@open-mercato/ui/backend/charts'
 import { DateRangeSelect, InlineDateRangeSelect, type DateRangePreset } from '@open-mercato/ui/backend/date-range'
@@ -18,7 +18,7 @@ import { DEFAULT_SETTINGS, hydrateSettings, type TopProductsSettings } from './c
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
 import { formatCurrencyCompact } from '../../../lib/formatters'
 
-async function fetchTopProductsData(settings: TopProductsSettings): Promise<WidgetDataResponse> {
+async function fetchTopProductsData(settings: TopProductsSettings, fetchWidgetData: WidgetDataFetcher): Promise<WidgetDataResponse> {
   const body = {
     entityType: 'sales:order_lines',
     metric: {
@@ -36,18 +36,7 @@ async function fetchTopProductsData(settings: TopProductsSettings): Promise<Widg
     },
   }
 
-  const call = await apiCall<WidgetDataResponse>('/api/dashboards/widgets/data', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-
-  if (!call.ok) {
-    const errorMsg = (call.result as Record<string, unknown>)?.error
-    throw new Error(typeof errorMsg === 'string' ? errorMsg : 'Failed to fetch top products data')
-  }
-
-  return call.result as WidgetDataResponse
+  return fetchWidgetData<WidgetDataResponse>(body)
 }
 
 function truncateLabel(
@@ -82,6 +71,7 @@ const TopProductsWidget: React.FC<DashboardWidgetComponentProps<TopProductsSetti
   const [error, setError] = React.useState<string | null>(null)
   const fetchingRef = React.useRef(false)
 
+  const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
     if (fetchingRef.current) return
     fetchingRef.current = true
@@ -89,7 +79,7 @@ const TopProductsWidget: React.FC<DashboardWidgetComponentProps<TopProductsSetti
     setLoading(true)
     setError(null)
     try {
-      const result = await fetchTopProductsData(hydrated)
+      const result = await fetchTopProductsData(hydrated, fetchWidgetData)
       const chartData = result.data.map((item, index) => ({
         name: truncateLabel(item.groupLabel ?? item.groupKey ?? `Product ${index + 1}`, t),
         Revenue: item.value ?? 0,
@@ -103,7 +93,7 @@ const TopProductsWidget: React.FC<DashboardWidgetComponentProps<TopProductsSetti
       onRefreshStateChange?.(false)
       fetchingRef.current = false
     }
-  }, [hydrated, onRefreshStateChange, t])
+  }, [hydrated, fetchWidgetData, onRefreshStateChange, t])
 
   React.useEffect(() => {
     refresh().catch(() => {})

--- a/packages/ui/src/backend/dashboard/DashboardScreen.tsx
+++ b/packages/ui/src/backend/dashboard/DashboardScreen.tsx
@@ -14,6 +14,7 @@ import { GripVertical, Info, Plus, RefreshCw, Settings2, Trash2, X, Loader2 } fr
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { InjectionSpot } from '../injection/InjectionSpot'
+import { WidgetDataBatchProvider } from './widgetData'
 
 type DashboardWidgetSize = 'sm' | 'md' | 'lg'
 
@@ -429,6 +430,7 @@ export function DashboardScreen() {
         </div>
       )}
 
+      <WidgetDataBatchProvider>
       <div className={cn(
         'grid gap-3 sm:gap-4 md:gap-6',
         'grid-cols-1',
@@ -493,6 +495,7 @@ export function DashboardScreen() {
           )
         })}
       </div>
+      </WidgetDataBatchProvider>
 
       {layout.length === 0 && (
         <div className="rounded-lg border border-dashed bg-muted/30 p-10 text-center text-sm text-muted-foreground">

--- a/packages/ui/src/backend/dashboard/__tests__/widgetDataBatcher.test.ts
+++ b/packages/ui/src/backend/dashboard/__tests__/widgetDataBatcher.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment node
+ */
+import {
+  createWidgetDataBatcher,
+  type WidgetDataBatchRequestEntry,
+  type WidgetDataBatchResultEntry,
+} from '../widgetDataBatcher'
+
+describe('createWidgetDataBatcher', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('coalesces requests fired within the window into a single send', async () => {
+    const send = jest.fn(async (entries: WidgetDataBatchRequestEntry[]) =>
+      entries.map((entry): WidgetDataBatchResultEntry => ({ id: entry.id, ok: true, data: entry.request })),
+    )
+    const batcher = createWidgetDataBatcher({ send, windowMs: 16 })
+
+    const p1 = batcher.fetch<{ widget: number }>({ widget: 1 })
+    const p2 = batcher.fetch<{ widget: number }>({ widget: 2 })
+    const p3 = batcher.fetch<{ widget: number }>({ widget: 3 })
+
+    expect(send).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(16)
+
+    await expect(p1).resolves.toEqual({ widget: 1 })
+    await expect(p2).resolves.toEqual({ widget: 2 })
+    await expect(p3).resolves.toEqual({ widget: 3 })
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send.mock.calls[0][0]).toHaveLength(3)
+  })
+
+  test('rejects only the failing widget and resolves the rest', async () => {
+    const send = jest.fn(async (entries: WidgetDataBatchRequestEntry[]) =>
+      entries.map((entry, index): WidgetDataBatchResultEntry =>
+        index === 1
+          ? { id: entry.id, ok: false, error: 'boom' }
+          : { id: entry.id, ok: true, data: entry.request },
+      ),
+    )
+    const batcher = createWidgetDataBatcher({ send, windowMs: 16 })
+
+    const ok = batcher.fetch({ widget: 'a' })
+    const bad = batcher.fetch({ widget: 'b' })
+    jest.advanceTimersByTime(16)
+
+    await expect(ok).resolves.toEqual({ widget: 'a' })
+    await expect(bad).rejects.toThrow('boom')
+  })
+
+  test('rejects a caller whose id is missing from the response', async () => {
+    const send = jest.fn(async () => [] as WidgetDataBatchResultEntry[])
+    const batcher = createWidgetDataBatcher({ send, windowMs: 16 })
+
+    const p = batcher.fetch({ widget: 1 })
+    jest.advanceTimersByTime(16)
+
+    await expect(p).rejects.toThrow('No result returned for widget')
+  })
+
+  test('rejects all callers when the batch send fails', async () => {
+    const send = jest.fn(async () => {
+      throw new Error('network down')
+    })
+    const batcher = createWidgetDataBatcher({ send, windowMs: 16 })
+
+    const p1 = batcher.fetch({ widget: 1 })
+    const p2 = batcher.fetch({ widget: 2 })
+    jest.advanceTimersByTime(16)
+
+    await expect(p1).rejects.toThrow('network down')
+    await expect(p2).rejects.toThrow('network down')
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  test('splits queues larger than maxBatchSize into multiple sends', async () => {
+    const send = jest.fn(async (entries: WidgetDataBatchRequestEntry[]) =>
+      entries.map((entry): WidgetDataBatchResultEntry => ({ id: entry.id, ok: true, data: entry.request })),
+    )
+    const batcher = createWidgetDataBatcher({ send, windowMs: 16, maxBatchSize: 2 })
+
+    const promises = [1, 2, 3, 4, 5].map((widget) => batcher.fetch({ widget }))
+    jest.advanceTimersByTime(16)
+
+    await Promise.all(promises)
+    expect(send).toHaveBeenCalledTimes(3)
+    expect(send.mock.calls[0][0]).toHaveLength(2)
+    expect(send.mock.calls[1][0]).toHaveLength(2)
+    expect(send.mock.calls[2][0]).toHaveLength(1)
+  })
+})

--- a/packages/ui/src/backend/dashboard/index.ts
+++ b/packages/ui/src/backend/dashboard/index.ts
@@ -1,1 +1,2 @@
 export { DashboardScreen } from './DashboardScreen'
+export { WidgetDataBatchProvider, useWidgetData, type WidgetDataFetcher } from './widgetData'

--- a/packages/ui/src/backend/dashboard/widgetData.tsx
+++ b/packages/ui/src/backend/dashboard/widgetData.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import * as React from 'react'
+import { apiCall } from '../utils/apiCall'
+import {
+  createWidgetDataBatcher,
+  type WidgetDataBatchResultEntry,
+  type WidgetDataBatchSender,
+} from './widgetDataBatcher'
+
+const SINGLE_ENDPOINT = '/api/dashboards/widgets/data'
+const BATCH_ENDPOINT = '/api/dashboards/widgets/data/batch'
+
+
+export type WidgetDataFetcher = <TResponse>(request: unknown) => Promise<TResponse>
+
+function readError(result: unknown, fallback: string): string {
+  const errorMsg = (result as Record<string, unknown> | null)?.error
+  return typeof errorMsg === 'string' ? errorMsg : fallback
+}
+
+/**
+ * Fallback used when a widget renders outside a {@link WidgetDataBatchProvider}
+ * (e.g. a standalone preview). Issues a single un-batched request so widgets
+ * keep working without the dashboard host.
+ */
+const singleWidgetDataFetch: WidgetDataFetcher = async (request) => {
+  const call = await apiCall(SINGLE_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  })
+  if (!call.ok) {
+    throw new Error(readError(call.result, 'Failed to fetch widget data'))
+  }
+  return call.result as never
+}
+
+const WidgetDataContext = React.createContext<WidgetDataFetcher>(singleWidgetDataFetch)
+
+const batchSender: WidgetDataBatchSender = async (entries) => {
+  const call = await apiCall<{ results?: WidgetDataBatchResultEntry[] }>(BATCH_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ requests: entries }),
+  })
+  if (!call.ok || !call.result || !Array.isArray(call.result.results)) {
+    throw new Error(readError(call.result, 'Failed to fetch widget data'))
+  }
+  return call.result.results
+}
+
+export type WidgetDataBatchProviderProps = {
+  children: React.ReactNode
+  windowMs?: number
+  maxBatchSize?: number
+}
+
+/**
+ * Provides a batched widget-data fetcher to descendant dashboard widgets.
+ * Requests fired within a short window collapse into one POST to the batch
+ * endpoint, so a first dashboard render issues a single authenticated request
+ * instead of one per widget (see #2273).
+ */
+export function WidgetDataBatchProvider({
+  children,
+  windowMs,
+  maxBatchSize,
+}: WidgetDataBatchProviderProps): React.ReactElement {
+  const batcher = React.useMemo(
+    () => createWidgetDataBatcher({ send: batchSender, windowMs, maxBatchSize }),
+    [windowMs, maxBatchSize],
+  )
+  const fetcher = React.useCallback<WidgetDataFetcher>(
+    (request) => batcher.fetch(request),
+    [batcher],
+  )
+  return <WidgetDataContext.Provider value={fetcher}>{children}</WidgetDataContext.Provider>
+}
+
+/** Returns the active widget-data fetcher (batched when inside a provider). */
+export function useWidgetData(): WidgetDataFetcher {
+  return React.useContext(WidgetDataContext)
+}

--- a/packages/ui/src/backend/dashboard/widgetDataBatcher.ts
+++ b/packages/ui/src/backend/dashboard/widgetDataBatcher.ts
@@ -1,0 +1,100 @@
+export type WidgetDataBatchRequestEntry = { id: string; request: unknown }
+
+export type WidgetDataBatchResultEntry =
+  | { id: string; ok: true; data: unknown }
+  | { id: string; ok: false; error: string }
+
+export type WidgetDataBatchSender = (
+  entries: WidgetDataBatchRequestEntry[],
+) => Promise<WidgetDataBatchResultEntry[]>
+
+export type WidgetDataBatcherOptions = {
+  send: WidgetDataBatchSender
+  /** Coalescing window in ms. Widget requests fired within the window share one HTTP call. */
+  windowMs?: number
+  /** Upper bound on requests per HTTP call; larger queues are split into multiple sends. */
+  maxBatchSize?: number
+}
+
+export type WidgetDataBatcher = {
+  fetch: <TResponse>(request: unknown) => Promise<TResponse>
+}
+
+type PendingCall = {
+  id: string
+  request: unknown
+  resolve: (value: unknown) => void
+  reject: (error: unknown) => void
+}
+
+const DEFAULT_WINDOW_MS = 16
+const DEFAULT_MAX_BATCH_SIZE = 50
+
+/**
+ * Coalesces independent widget-data requests fired within a short window into a
+ * single batch call. Each call resolves with its own slice of the batch result,
+ * so callers stay decoupled from one another while collapsing N HTTP requests
+ * (and N server-side container/RBAC/org-scope rebuilds) into one (see #2273).
+ */
+export function createWidgetDataBatcher(options: WidgetDataBatcherOptions): WidgetDataBatcher {
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS
+  const maxBatchSize = options.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE
+
+  let queue: PendingCall[] = []
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let counter = 0
+
+  const flush = () => {
+    timer = null
+    const pending = queue
+    queue = []
+    if (pending.length === 0) return
+
+    for (let start = 0; start < pending.length; start += maxBatchSize) {
+      const chunk = pending.slice(start, start + maxBatchSize)
+      void dispatchChunk(chunk)
+    }
+  }
+
+  const dispatchChunk = async (chunk: PendingCall[]) => {
+    try {
+      const results = await options.send(chunk.map((call) => ({ id: call.id, request: call.request })))
+      const byId = new Map<string, WidgetDataBatchResultEntry>()
+      for (const result of results) byId.set(result.id, result)
+
+      for (const call of chunk) {
+        const result = byId.get(call.id)
+        if (!result) {
+          call.reject(new Error('No result returned for widget'))
+        } else if (result.ok) {
+          call.resolve(result.data)
+        } else {
+          call.reject(new Error(result.error))
+        }
+      }
+    } catch (error) {
+      for (const call of chunk) call.reject(error)
+    }
+  }
+
+  const scheduleFlush = () => {
+    if (timer != null) return
+    timer = setTimeout(flush, windowMs)
+  }
+
+  return {
+    fetch<TResponse>(request: unknown): Promise<TResponse> {
+      counter += 1
+      const id = `w${counter}`
+      return new Promise<TResponse>((resolve, reject) => {
+        queue.push({
+          id,
+          request,
+          resolve: (value) => resolve(value as TResponse),
+          reject,
+        })
+        scheduleFlush()
+      })
+    },
+  }
+}


### PR DESCRIPTION
Fixes #2273

## Problem
A first analytics dashboard render fans out one HTTP request per widget (~10) to `POST /api/dashboards/widgets/data`. Each call independently rebuilds the entire per-request stack — `createRequestContainer()`, `rbacService.userHasAllFeatures()`, `resolveOrganizationScopeForRequest()` (a directory org-scope SELECT), and an `em.fork` — *before* its small aggregation SQL. The 120s `WidgetDataService` cache only helps repeat loads; it never collapses the N concurrent first-paint requests.

## Root Cause
There was no way to resolve multiple widgets in one request, so the DI/RBAC/org-scope/EM setup ran N times per dashboard render.

## What Changed
**Backend**
- New `POST /api/dashboards/widgets/data/batch` accepting `{ requests: [{ id, request }] }`. It builds the container, EM fork, and organization scope **once**, then resolves all widgets. Returns `{ results: [{ id, ok, data } | { id, ok, error }] }` with per-widget error isolation (one bad request never fails the batch).
- `lib/widgetDataBatch.ts` — `runWidgetDataBatch` + `resolveEntityFeatureAccess`. RBAC is resolved against the **union** of all required features in a single check; only if the union is denied does it fall back to per-entity-type checks (so one privileged entity type can't reject widgets the caller may see). Forbidden entity types are never fetched.
- Extracted the shared request/response Zod schemas into `api/widgets/data/schema.ts` (used by both the single and batch routes). The existing single endpoint's contract is unchanged.

**Client**
- `packages/ui/src/backend/dashboard/widgetDataBatcher.ts` — framework-agnostic batcher that coalesces requests fired within a short window into one `send`, distributing results per caller.
- `widgetData.tsx` — `WidgetDataBatchProvider` + `useWidgetData()` hook (POSTs to the batch endpoint). Falls back to a single un-batched request when no provider is mounted.
- `DashboardScreen` mounts the provider around the widget grid; all 10 analytics widgets now fetch through `useWidgetData()`, so a first render issues a single authenticated request instead of N.

## Tests
- `packages/core/.../lib/__tests__/widgetDataBatch.test.ts` (6) — union RBAC resolved in one check; per-widget error isolation; forbidden entity types denied and never fetched; union-denial fallback.
- `packages/ui/.../__tests__/widgetDataBatcher.test.ts` (5) — N calls coalesce into one send; per-widget rejection isolation; missing-result + send-failure handling; max-batch-size chunking.
- `yarn build:packages`, `yarn generate` (batch route discovered at `/dashboards/widgets/data/batch`), `yarn typecheck` (all 19 packages green), full `dashboards` suite (79) green.

> Note: the pre-existing `DashboardScreen.test.tsx` suite fails locally with `React.act is not a function` — reproduced on the clean `origin/develop` baseline with the same `--mode=skip-build` install, so it is an environment artifact unrelated to this change.

## Backward Compatibility
- Additive: new route + new UI exports. The existing `/api/dashboards/widgets/data` request/response contract is unchanged (schemas were only relocated). No API fields, event IDs, ACL IDs, DI names, or import paths removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)