### PR TITLE
fix(api-docs): protect docs export routes (#2270)

### DIFF
--- a/apps/mercato/src/app/api/docs/__tests__/routes.test.ts
+++ b/apps/mercato/src/app/api/docs/__tests__/routes.test.ts
@@ -1,0 +1,93 @@
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+
+const getAuthFromRequestMock = jest.fn()
+const userHasAllFeaturesMock = jest.fn<
+  ReturnType<RbacService['userHasAllFeatures']>,
+  Parameters<RbacService['userHasAllFeatures']>
+>()
+
+jest.mock('@/.mercato/generated/modules.generated', () => ({
+  modules: [],
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => getAuthFromRequestMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (key: string) => {
+      if (key === 'rbacService') return { userHasAllFeatures: userHasAllFeaturesMock }
+      return null
+    },
+  }),
+}))
+
+jest.mock('@open-mercato/core/modules/api_docs/lib/resources', () => ({
+  resolveApiDocsBaseUrl: () => 'https://example.test',
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/openapi', () => ({
+  buildOpenApiDocument: jest.fn(() => ({ openapi: '3.1.0' })),
+  sanitizeOpenApiDocument: jest.fn((doc) => doc),
+  generateMarkdownFromOpenApi: jest.fn(() => '# API Docs'),
+}))
+
+import { GET as getOpenApi } from '@/app/api/docs/openapi/route'
+import { GET as getMarkdown } from '@/app/api/docs/markdown/route'
+
+describe('API docs routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    userHasAllFeaturesMock.mockResolvedValue(true)
+  })
+
+  it('returns 401 for anonymous OpenAPI requests', async () => {
+    getAuthFromRequestMock.mockResolvedValueOnce(null)
+
+    const response = await getOpenApi(new Request('https://example.test/api/docs/openapi'))
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ ok: false, error: 'Authentication required' })
+  })
+
+  it('returns 403 when authenticated user lacks api_docs.view', async () => {
+    getAuthFromRequestMock.mockResolvedValueOnce({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      isSuperAdmin: false,
+    })
+    userHasAllFeaturesMock.mockResolvedValueOnce(false)
+
+    const response = await getOpenApi(new Request('https://example.test/api/docs/openapi'))
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ ok: false, error: 'Insufficient permissions' })
+  })
+
+  it('returns markdown for authorized users', async () => {
+    getAuthFromRequestMock.mockResolvedValueOnce({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      isSuperAdmin: false,
+    })
+
+    const response = await getMarkdown(new Request('https://example.test/api/docs/markdown'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('text/markdown; charset=utf-8')
+    await expect(response.text()).resolves.toBe('# API Docs')
+    expect(userHasAllFeaturesMock).toHaveBeenCalledWith('user-1', ['api_docs.view'], {
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+  })
+})

--- a/apps/mercato/src/app/api/docs/markdown/route.ts
+++ b/apps/mercato/src/app/api/docs/markdown/route.ts
@@ -1,4 +1,8 @@
+import { NextResponse } from 'next/server'
 import { modules } from '@/.mercato/generated/modules.generated'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { resolveApiDocsBaseUrl } from '@open-mercato/core/modules/api_docs/lib/resources'
 import { buildOpenApiDocument, generateMarkdownFromOpenApi, sanitizeOpenApiDocument } from '@open-mercato/shared/lib/openapi'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
@@ -6,7 +10,24 @@ import { APP_VERSION } from '@open-mercato/shared/lib/version'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET() {
+export async function GET(req: Request) {
+  const auth = await getAuthFromRequest(req)
+  if (!auth) {
+    return NextResponse.json({ ok: false, error: 'Authentication required' }, { status: 401 })
+  }
+
+  const container = await createRequestContainer()
+  const rbacService = container.resolve('rbacService') as RbacService
+  const hasAccess =
+    auth.isSuperAdmin === true ||
+    await rbacService.userHasAllFeatures(auth.sub, ['api_docs.view'], {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+    })
+  if (!hasAccess) {
+    return NextResponse.json({ ok: false, error: 'Insufficient permissions' }, { status: 403 })
+  }
+
   const { t } = await resolveTranslations()
   const baseUrl = resolveApiDocsBaseUrl()
   const rawDoc = buildOpenApiDocument(modules, {

--- a/apps/mercato/src/app/api/docs/openapi/route.ts
+++ b/apps/mercato/src/app/api/docs/openapi/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server'
 import { modules } from '@/.mercato/generated/modules.generated'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { resolveApiDocsBaseUrl } from '@open-mercato/core/modules/api_docs/lib/resources'
 import { buildOpenApiDocument, sanitizeOpenApiDocument } from '@open-mercato/shared/lib/openapi'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
@@ -7,7 +10,24 @@ import { APP_VERSION } from '@open-mercato/shared/lib/version'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET() {
+export async function GET(req: Request) {
+  const auth = await getAuthFromRequest(req)
+  if (!auth) {
+    return NextResponse.json({ ok: false, error: 'Authentication required' }, { status: 401 })
+  }
+
+  const container = await createRequestContainer()
+  const rbacService = container.resolve('rbacService') as RbacService
+  const hasAccess =
+    auth.isSuperAdmin === true ||
+    await rbacService.userHasAllFeatures(auth.sub, ['api_docs.view'], {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+    })
+  if (!hasAccess) {
+    return NextResponse.json({ ok: false, error: 'Insufficient permissions' }, { status: 403 })
+  }
+
   const { t } = await resolveTranslations()
   const baseUrl = resolveApiDocsBaseUrl()
   const rawDoc = buildOpenApiDocument(modules, {

--- a/packages/core/src/modules/api_docs/acl.ts
+++ b/packages/core/src/modules/api_docs/acl.ts
@@ -1,3 +1,3 @@
-export const features: string[] = []
+export const features: string[] = ['api_docs.view']
 
 export default features

--- a/packages/core/src/modules/api_docs/backend/docs/page.meta.ts
+++ b/packages/core/src/modules/api_docs/backend/docs/page.meta.ts
@@ -11,6 +11,7 @@ const bookIcon = React.createElement(
 
 export const metadata = {
   requireAuth: true,
+  requireFeatures: ['api_docs.view'],
   pageTitle: 'API documentation',
   pageTitleKey: 'api_docs.nav.title',
   pageGroup: 'Developers',

--- a/packages/core/src/modules/api_docs/setup.ts
+++ b/packages/core/src/modules/api_docs/setup.ts
@@ -1,0 +1,10 @@
+import type { ModuleSetupConfig } from '@open-mercato/shared/modules/setup'
+
+export const setup: ModuleSetupConfig = {
+  defaultRoleFeatures: {
+    superadmin: ['api_docs.*'],
+    admin: ['api_docs.view'],
+  },
+}
+
+export default setup

--- a/packages/create-app/template/src/app/api/docs/markdown/route.ts
+++ b/packages/create-app/template/src/app/api/docs/markdown/route.ts
@@ -1,4 +1,8 @@
+import { NextResponse } from 'next/server'
 import { modules } from '@/.mercato/generated/modules.generated'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { resolveApiDocsBaseUrl } from '@open-mercato/core/modules/api_docs/lib/resources'
 import { buildOpenApiDocument, generateMarkdownFromOpenApi, sanitizeOpenApiDocument } from '@open-mercato/shared/lib/openapi'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
@@ -6,7 +10,24 @@ import { APP_VERSION } from '@open-mercato/shared/lib/version'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET() {
+export async function GET(req: Request) {
+  const auth = await getAuthFromRequest(req)
+  if (!auth) {
+    return NextResponse.json({ ok: false, error: 'Authentication required' }, { status: 401 })
+  }
+
+  const container = await createRequestContainer()
+  const rbacService = container.resolve('rbacService') as RbacService
+  const hasAccess =
+    auth.isSuperAdmin === true ||
+    await rbacService.userHasAllFeatures(auth.sub, ['api_docs.view'], {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+    })
+  if (!hasAccess) {
+    return NextResponse.json({ ok: false, error: 'Insufficient permissions' }, { status: 403 })
+  }
+
   const { t } = await resolveTranslations()
   const baseUrl = resolveApiDocsBaseUrl()
   const rawDoc = buildOpenApiDocument(modules, {

--- a/packages/create-app/template/src/app/api/docs/openapi/route.ts
+++ b/packages/create-app/template/src/app/api/docs/openapi/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server'
 import { modules } from '@/.mercato/generated/modules.generated'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { resolveApiDocsBaseUrl } from '@open-mercato/core/modules/api_docs/lib/resources'
 import { buildOpenApiDocument, sanitizeOpenApiDocument } from '@open-mercato/shared/lib/openapi'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
@@ -7,7 +10,24 @@ import { APP_VERSION } from '@open-mercato/shared/lib/version'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET() {
+export async function GET(req: Request) {
+  const auth = await getAuthFromRequest(req)
+  if (!auth) {
+    return NextResponse.json({ ok: false, error: 'Authentication required' }, { status: 401 })
+  }
+
+  const container = await createRequestContainer()
+  const rbacService = container.resolve('rbacService') as RbacService
+  const hasAccess =
+    auth.isSuperAdmin === true ||
+    await rbacService.userHasAllFeatures(auth.sub, ['api_docs.view'], {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+    })
+  if (!hasAccess) {
+    return NextResponse.json({ ok: false, error: 'Insufficient permissions' }, { status: 403 })
+  }
+
   const { t } = await resolveTranslations()
   const baseUrl = resolveApiDocsBaseUrl()
   const rawDoc = buildOpenApiDocument(modules, {


### PR DESCRIPTION
## Summary
- require authenticated staff access with the api_docs.view feature for both API docs export routes
- declare and seed the new api_docs.view ACL feature and require it on the backend docs page
- sync the standalone template routes and add focused regression tests for the app routes

## Testing
- yarn jest --config "apps/mercato/jest.config.cjs" "apps/mercato/src/app/api/docs/__tests__/routes.test.ts"

## Notes
- `yarn generate` is currently blocked by a pre-existing runtime import error in generated module discovery: `@mikro-orm/core` does not provide `Entity` to `packages/core/dist/modules/entities/data/entities.js`
- app-wide `tsc -p apps/mercato/tsconfig.json --noEmit` is currently blocked by pre-existing generated-module and unrelated type errors in this checkout

Fixes #2270