### PR TITLE
fix(storage-s3): validate uploads and harden downloads (#2269)

### DIFF
--- a/apps/mercato/src/__tests__/storage-s3-routes.test.ts
+++ b/apps/mercato/src/__tests__/storage-s3-routes.test.ts
@@ -1,0 +1,121 @@
+const getAuthFromRequestMock = jest.fn()
+const credentialsResolveMock = jest.fn()
+
+const putObjectMock = jest.fn()
+const getBucketMock = jest.fn(() => 'test-bucket')
+const listObjectsMock = jest.fn()
+const readMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => getAuthFromRequestMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (key: string) => {
+      if (key === 'integrationCredentialsService') {
+        return { resolve: credentialsResolveMock }
+      }
+      return null
+    },
+  }),
+}))
+
+jest.mock('../../../../packages/storage-s3/src/modules/storage_s3/lib/s3-driver', () => ({
+  S3StorageDriver: jest.fn().mockImplementation(() => ({
+    putObject: putObjectMock,
+    getBucket: getBucketMock,
+    listObjects: listObjectsMock,
+    read: readMock,
+  })),
+}))
+
+import { GET as download } from '../../../../packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/download'
+import { POST as upload } from '../../../../packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload'
+
+describe('storage_s3 upload/download routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getAuthFromRequestMock.mockResolvedValue({ tenantId: 'tenant-1', orgId: 'org-1' })
+    credentialsResolveMock.mockResolvedValue({ bucket: 'bucket' })
+    listObjectsMock.mockResolvedValue({ files: [], truncated: false, nextContinuationToken: undefined })
+    putObjectMock.mockResolvedValue(undefined)
+    readMock.mockResolvedValue({ buffer: Buffer.from('body'), contentType: 'image/png' })
+  })
+
+  it('rejects active content uploads even when client contentType looks safe', async () => {
+    const form = new FormData()
+    form.append('file', new File(['<html><body>x</body></html>'], 'payload.html', { type: 'text/plain' }))
+    form.append('contentType', 'image/png')
+
+    const response = await upload(new Request('http://test/api/storage-providers/s3/upload', {
+      method: 'POST',
+      body: form,
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Active content uploads are not allowed.' })
+    expect(putObjectMock).not.toHaveBeenCalled()
+  })
+
+  it('uses trusted detected MIME instead of attacker-supplied contentType', async () => {
+    const pngBuffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    const form = new FormData()
+    form.append('file', new File([pngBuffer], 'proof.png', { type: 'text/plain' }))
+    form.append('contentType', 'text/html')
+
+    const response = await upload(new Request('http://test/api/storage-providers/s3/upload', {
+      method: 'POST',
+      body: form,
+    }))
+
+    expect(response.status).toBe(200)
+    expect(putObjectMock).toHaveBeenCalledWith(expect.any(String), expect.any(Buffer), 'image/png')
+    await expect(response.json()).resolves.toEqual(expect.objectContaining({
+      bucket: 'test-bucket',
+      contentType: 'image/png',
+      size: pngBuffer.length,
+    }))
+  })
+
+  it('rejects uploads that exceed tenant quota', async () => {
+    listObjectsMock.mockResolvedValueOnce({
+      files: [{ key: 'uploads/org_org-1/tenant_tenant-1/existing.bin', size: 536_870_912, lastModified: new Date() }],
+      truncated: false,
+      nextContinuationToken: undefined,
+    })
+    const form = new FormData()
+    form.append('file', new File(['a'], 'tiny.txt', { type: 'text/plain' }))
+
+    const response = await upload(new Request('http://test/api/storage-providers/s3/upload', {
+      method: 'POST',
+      body: form,
+    }))
+
+    expect(response.status).toBe(413)
+    await expect(response.json()).resolves.toEqual({ error: 'Attachment storage quota exceeded for this tenant.' })
+    expect(putObjectMock).not.toHaveBeenCalled()
+  })
+
+  it('forces attachment download headers for unsafe inline content', async () => {
+    readMock.mockResolvedValueOnce({ buffer: Buffer.from('<svg/>'), contentType: 'image/svg+xml' })
+
+    const response = await download(new Request('http://test/api/storage-providers/s3/download?key=uploads/org_org-1/tenant_tenant-1/file.svg'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('application/octet-stream')
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+    expect(response.headers.get('content-security-policy')).toContain('sandbox')
+    expect(response.headers.get('content-disposition')).toContain('attachment;')
+  })
+
+  it('allows inline rendering only for safe image MIME types', async () => {
+    readMock.mockResolvedValueOnce({ buffer: Buffer.from([0x89, 0x50, 0x4e, 0x47]), contentType: 'image/png' })
+
+    const response = await download(new Request('http://test/api/storage-providers/s3/download?key=uploads/org_org-1/tenant_tenant-1/file.png'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('image/png')
+    expect(response.headers.get('content-disposition')).toContain('inline;')
+  })
+})

--- a/packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/download.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/download.ts
@@ -3,6 +3,11 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import {
+  buildAttachmentContentDisposition,
+  canRenderInlineAttachment,
+  sanitizeUploadedFileName,
+} from '@open-mercato/core/modules/attachments/lib/security'
 import { S3StorageDriver } from '../../../../lib/s3-driver'
 
 export const metadata = {
@@ -55,11 +60,18 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'File not found' }, { status: 404 })
   }
 
+  const fileName = sanitizeUploadedFileName(key.split('/').pop() || 'download')
+  const renderInline = canRenderInlineAttachment(contentType)
+  const responseContentType = renderInline ? (contentType ?? 'application/octet-stream') : 'application/octet-stream'
+
   return new NextResponse(new Uint8Array(buffer), {
     status: 200,
     headers: {
-      'Content-Type': contentType ?? 'application/octet-stream',
+      'Content-Security-Policy': "default-src 'none'; sandbox",
+      'Content-Disposition': buildAttachmentContentDisposition(fileName, renderInline ? 'inline' : 'attachment'),
       'Content-Length': String(buffer.length),
+      'Content-Type': responseContentType,
+      'X-Content-Type-Options': 'nosniff',
     },
   })
 }

--- a/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
@@ -3,6 +3,16 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import {
+  detectAttachmentMimeType,
+  hasDangerousExecutableExtension,
+  isActiveContentAttachment,
+} from '@open-mercato/core/modules/attachments/lib/security'
+import {
+  isMultipartRequestWithinUploadLimit,
+  resolveAttachmentMaxBytes,
+  willExceedAttachmentTenantQuota,
+} from '@open-mercato/core/modules/attachments/lib/upload-limits'
 import { S3StorageDriver } from '../../../../lib/s3-driver'
 import { randomUUID } from 'crypto'
 
@@ -40,10 +50,35 @@ async function resolveDriver(
   return new S3StorageDriver(creds)
 }
 
+async function readTenantStorageUsageBytes(
+  driver: S3StorageDriver,
+  tenantId: string,
+  orgId: string,
+): Promise<number> {
+  let totalBytes = 0
+  let continuationToken: string | undefined
+
+  do {
+    const page = await driver.listObjects('', 1000, continuationToken)
+    for (const file of page.files) {
+      if (isKeyScoped(file.key, orgId, tenantId)) {
+        totalBytes += file.size
+      }
+    }
+    continuationToken = page.truncated ? page.nextContinuationToken : undefined
+  } while (continuationToken)
+
+  return totalBytes
+}
+
 export async function POST(req: Request) {
   const auth = await getAuthFromRequest(req)
   if (!auth?.tenantId || !auth.orgId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (!isMultipartRequestWithinUploadLimit(req.headers.get('content-length'))) {
+    return NextResponse.json({ error: 'Attachment exceeds the maximum upload size.' }, { status: 413 })
   }
 
   const contentType = req.headers.get('content-type') ?? ''
@@ -58,13 +93,21 @@ export async function POST(req: Request) {
   }
 
   const keyOverride = form.get('key') ? String(form.get('key')) : null
-  const contentTypeHeader = form.get('contentType') ? String(form.get('contentType')) : file.type || undefined
 
   if (keyOverride !== null && !isKeyScoped(keyOverride, auth.orgId, auth.tenantId)) {
     return NextResponse.json(
       { error: 'Access denied: key override is not scoped to this tenant.' },
       { status: 403 },
     )
+  }
+
+  if (hasDangerousExecutableExtension(file.name)) {
+    return NextResponse.json({ error: 'Executable file types are not allowed as attachments.' }, { status: 400 })
+  }
+
+  const effectiveMaxBytes = resolveAttachmentMaxBytes()
+  if (file.size > effectiveMaxBytes) {
+    return NextResponse.json({ error: 'Attachment exceeds the maximum upload size.' }, { status: 413 })
   }
 
   const driver = await resolveDriver(auth.tenantId, auth.orgId)
@@ -74,17 +117,27 @@ export async function POST(req: Request) {
 
   const buffer = Buffer.from(await file.arrayBuffer())
   const safeName = sanitizeFileName(file.name)
+  const trustedMimeType = detectAttachmentMimeType(buffer, safeName, file.type || null)
+  if (isActiveContentAttachment(buffer, safeName, trustedMimeType)) {
+    return NextResponse.json({ error: 'Active content uploads are not allowed.' }, { status: 400 })
+  }
+
+  const tenantUsageBytes = await readTenantStorageUsageBytes(driver, auth.tenantId, auth.orgId)
+  if (willExceedAttachmentTenantQuota(tenantUsageBytes, buffer.length)) {
+    return NextResponse.json({ error: 'Attachment storage quota exceeded for this tenant.' }, { status: 413 })
+  }
+
   const key =
     keyOverride ??
     `uploads/org_${auth.orgId}/tenant_${auth.tenantId}/${Date.now()}_${randomUUID().slice(0, 8)}_${safeName}`
 
-  await driver.putObject(key, buffer, contentTypeHeader)
+  await driver.putObject(key, buffer, trustedMimeType)
 
   return NextResponse.json({
     key,
     bucket: driver.getBucket(),
     size: buffer.length,
-    contentType: contentTypeHeader,
+    contentType: trustedMimeType,
   })
 }
 
@@ -102,14 +155,15 @@ export const openApi: OpenApiRouteDoc = {
         schema: z.object({
           file: z.any().describe('File to upload'),
           key: z.string().optional().describe('Optional S3 key override (must be scoped to org/tenant)'),
-          contentType: z.string().optional().describe('Optional content-type override'),
+          contentType: z.string().optional().describe('Optional client-provided content-type hint; the server derives the trusted MIME type.'),
         }),
       },
       responses: [{ status: 200, description: 'Upload result', schema: responseSchema }],
       errors: [
-        { status: 400, description: 'Missing file or S3 not configured', schema: z.object({ error: z.string() }) },
+        { status: 400, description: 'Missing file, blocked file type, or S3 not configured', schema: z.object({ error: z.string() }) },
         { status: 401, description: 'Unauthorized', schema: z.object({ error: z.string() }) },
         { status: 403, description: 'Key override not scoped to this tenant', schema: z.object({ error: z.string() }) },
+        { status: 413, description: 'Upload too large or tenant storage quota exceeded', schema: z.object({ error: z.string() }) },
       ],
     },
   },


### PR DESCRIPTION
## Summary
- reject dangerous, active-content, oversized, and quota-exceeding direct S3 uploads
- ignore attacker-supplied MIME overrides and derive a trusted MIME type server-side
- harden S3 downloads with nosniff, sandbox CSP, and attachment-by-default headers
- add focused regression tests for the upload and download routes

## Testing
- yarn jest --config "apps/mercato/jest.config.cjs" "apps/mercato/src/__tests__/storage-s3-routes.test.ts"
- ./node_modules/typescript/bin/tsc -p "packages/storage-s3/tsconfig.json" --noEmit

Fixes #2269