### PR TITLE
fix(staff): add optimistic locking to job history (#2306)

### DIFF
--- a/packages/core/src/modules/staff/api/job-histories.ts
+++ b/packages/core/src/modules/staff/api/job-histories.ts
@@ -12,6 +12,11 @@ import { E } from '#generated/entities.ids.generated'
 
 const rawBodySchema = z.object({}).passthrough()
 
+const optimisticDeleteSchema = z.object({
+  id: z.string().uuid(),
+  updatedAt: z.string().datetime().optional(),
+})
+
 const listSchema = z
   .object({
     page: z.coerce.number().min(1).default(1),
@@ -94,7 +99,13 @@ const crud = makeCrudRoute({
       mapInput: async ({ parsed, ctx }) => {
         const { translate } = await resolveTranslations()
         const id = resolveCrudRecordId(parsed, ctx, translate)
-        return { id }
+        return {
+          id,
+          updatedAt:
+            typeof (parsed as Record<string, unknown>).updatedAt === 'string'
+              ? (parsed as Record<string, unknown>).updatedAt
+              : undefined,
+        }
       },
       response: () => ({ ok: true }),
     },
@@ -137,7 +148,7 @@ export const openApi = createStaffCrudOpenApi({
     description: 'Updates a team member job history entry.',
   },
   del: {
-    schema: z.object({ id: z.string().uuid() }),
+    schema: optimisticDeleteSchema,
     responseSchema: defaultOkResponseSchema,
     description: 'Deletes a team member job history entry.',
   },

--- a/packages/core/src/modules/staff/api/job-histories.ts
+++ b/packages/core/src/modules/staff/api/job-histories.ts
@@ -4,6 +4,7 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveCrudRecordId, parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import { StaffTeamMemberJobHistory } from '../data/entities'
 import {
+  optimisticUpdatedAtSchema,
   staffTeamMemberJobHistoryCreateSchema,
   staffTeamMemberJobHistoryUpdateSchema,
 } from '../data/validators'
@@ -14,7 +15,7 @@ const rawBodySchema = z.object({}).passthrough()
 
 const optimisticDeleteSchema = z.object({
   id: z.string().uuid(),
-  updatedAt: z.string().datetime().optional(),
+  updatedAt: optimisticUpdatedAtSchema.optional(),
 })
 
 const listSchema = z

--- a/packages/core/src/modules/staff/api/job-histories.ts
+++ b/packages/core/src/modules/staff/api/job-histories.ts
@@ -100,12 +100,10 @@ const crud = makeCrudRoute({
       mapInput: async ({ parsed, ctx }) => {
         const { translate } = await resolveTranslations()
         const id = resolveCrudRecordId(parsed, ctx, translate)
+        const parsedBody = (parsed as { body?: Record<string, unknown> })?.body
         return {
           id,
-          updatedAt:
-            typeof (parsed as Record<string, unknown>).updatedAt === 'string'
-              ? (parsed as Record<string, unknown>).updatedAt
-              : undefined,
+          updatedAt: typeof parsedBody?.updatedAt === 'string' ? parsedBody.updatedAt : undefined,
         }
       },
       response: () => ({ ok: true }),

--- a/packages/core/src/modules/staff/commands/__tests__/job-histories.optimistic-locking.test.ts
+++ b/packages/core/src/modules/staff/commands/__tests__/job-histories.optimistic-locking.test.ts
@@ -1,6 +1,16 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { AwilixContainer } from 'awilix'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { staffTeamMemberJobHistoryUpdateSchema } from '../../data/validators'
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/commands/helpers')
+  return {
+    ...actual,
+    emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+    emitCrudUndoSideEffects: jest.fn().mockResolvedValue(undefined),
+  }
+})
 
 jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
   resolveTranslations: jest.fn().mockResolvedValue({
@@ -46,6 +56,47 @@ function createCtx(em: Pick<EntityManager, 'findOne' | 'fork'>) {
 describe('staff job history optimistic locking', () => {
   const jobHistoryId = '123e4567-e89b-41d3-a456-426614174000'
 
+  it('accepts non-Z updatedAt values from the list API', () => {
+    expect(() =>
+      staffTeamMemberJobHistoryUpdateSchema.parse({
+        id: jobHistoryId,
+        updatedAt: '2026-05-30T10:00:00+00:00',
+      }),
+    ).not.toThrow()
+  })
+
+  it('does not treat equivalent updatedAt instants as a conflict', async () => {
+    const { update } = await loadCommands()
+    const record = {
+      id: jobHistoryId,
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      updatedAt: new Date('2026-05-30T10:00:00.000Z'),
+      member: { id: 'member-1', tenantId: 'tenant-1', organizationId: 'org-1' },
+      name: 'Engineer',
+      companyName: null,
+      description: null,
+      startDate: new Date('2026-05-01T00:00:00.000Z'),
+      endDate: null,
+    }
+    const em = {
+      fork: jest.fn().mockReturnThis(),
+      findOne: jest.fn().mockResolvedValue(record),
+      flush: jest.fn().mockResolvedValue(undefined),
+    }
+
+    await expect(
+      update.execute(
+        {
+          id: jobHistoryId,
+          name: 'Senior Engineer',
+          updatedAt: '2026-05-30T10:00:00+00:00',
+        },
+        createCtx(em),
+      ),
+    ).resolves.toEqual({ jobHistoryId })
+  })
+
   it('returns 409 when updating a stale job history entry', async () => {
     const { update } = await loadCommands()
     const record = {
@@ -54,17 +105,24 @@ describe('staff job history optimistic locking', () => {
       organizationId: 'org-1',
       updatedAt: new Date('2026-05-30T10:00:00.000Z'),
       name: 'Engineer',
+      member: { id: 'member-1' },
+      companyName: null,
+      description: null,
+      startDate: new Date('2026-05-01T00:00:00.000Z'),
+      endDate: null,
     }
     const em = {
       fork: jest.fn().mockReturnThis(),
       findOne: jest.fn().mockResolvedValue(record),
     }
 
-    await expect(update.execute({
-      id: jobHistoryId,
-      name: 'Senior Engineer',
-      updatedAt: '2026-05-30T09:00:00.000Z',
-    }, createCtx(em))).rejects.toMatchObject<Partial<CrudHttpError>>({
+    await expect(
+      update.execute({
+        id: jobHistoryId,
+        name: 'Senior Engineer',
+        updatedAt: '2026-05-30T09:00:00+00:00',
+      }, createCtx(em)),
+    ).rejects.toMatchObject<Partial<CrudHttpError>>({
       status: 409,
       body: { error: 'This record was modified by someone else. Refresh and try again.' },
     })
@@ -77,10 +135,12 @@ describe('staff job history optimistic locking', () => {
       findOne: jest.fn().mockResolvedValue(null),
     }
 
-    await expect(del.execute({
-      id: jobHistoryId,
-      updatedAt: '2026-05-30T09:00:00.000Z',
-    }, createCtx(em))).rejects.toMatchObject<Partial<CrudHttpError>>({
+    await expect(
+      del.execute({
+        id: jobHistoryId,
+        updatedAt: '2026-05-30T09:00:00.000Z',
+      }, createCtx(em)),
+    ).rejects.toMatchObject<Partial<CrudHttpError>>({
       status: 409,
       body: { error: 'This record was modified by someone else. Refresh and try again.' },
     })

--- a/packages/core/src/modules/staff/commands/__tests__/job-histories.optimistic-locking.test.ts
+++ b/packages/core/src/modules/staff/commands/__tests__/job-histories.optimistic-locking.test.ts
@@ -145,4 +145,63 @@ describe('staff job history optimistic locking', () => {
       body: { error: 'This record was modified by someone else. Refresh and try again.' },
     })
   })
+
+  it('returns 409 when deleting a job history entry with a stale updatedAt', async () => {
+    const { del } = await loadCommands()
+    const record = {
+      id: jobHistoryId,
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      updatedAt: new Date('2026-05-30T10:00:00.000Z'),
+      member: { id: 'member-1' },
+      name: 'Engineer',
+      companyName: null,
+      description: null,
+      startDate: new Date('2026-05-01T00:00:00.000Z'),
+      endDate: null,
+    }
+    const em = {
+      fork: jest.fn().mockReturnThis(),
+      findOne: jest.fn().mockResolvedValue(record),
+    }
+
+    await expect(
+      del.execute({
+        id: jobHistoryId,
+        updatedAt: '2026-05-30T09:00:00.000Z',
+      }, createCtx(em)),
+    ).rejects.toMatchObject<Partial<CrudHttpError>>({
+      status: 409,
+      body: { error: 'This record was modified by someone else. Refresh and try again.' },
+    })
+  })
+
+  it('succeeds when deleting a job history entry with a matching updatedAt', async () => {
+    const { del } = await loadCommands()
+    const record = {
+      id: jobHistoryId,
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      updatedAt: new Date('2026-05-30T10:00:00.000Z'),
+      member: { id: 'member-1' },
+      name: 'Engineer',
+      companyName: null,
+      description: null,
+      startDate: new Date('2026-05-01T00:00:00.000Z'),
+      endDate: null,
+    }
+    const em = {
+      fork: jest.fn().mockReturnThis(),
+      findOne: jest.fn().mockResolvedValue(record),
+      remove: jest.fn().mockReturnThis(),
+      flush: jest.fn().mockResolvedValue(undefined),
+    }
+
+    await expect(
+      del.execute({
+        id: jobHistoryId,
+        updatedAt: '2026-05-30T10:00:00+00:00',
+      }, createCtx(em)),
+    ).resolves.toEqual({ jobHistoryId })
+  })
 })

--- a/packages/core/src/modules/staff/commands/__tests__/job-histories.optimistic-locking.test.ts
+++ b/packages/core/src/modules/staff/commands/__tests__/job-histories.optimistic-locking.test.ts
@@ -1,0 +1,88 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { AwilixContainer } from 'awilix'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn().mockResolvedValue({
+    translate: (_key: string, fallback: string) => fallback,
+  }),
+}))
+
+type RegisteredCommand = {
+  execute: (input: unknown, ctx: unknown) => Promise<unknown>
+}
+
+async function loadCommands() {
+  jest.resetModules()
+  const { commandRegistry } = await import('@open-mercato/shared/lib/commands')
+  commandRegistry.clear()
+  await import('../job-histories')
+  return {
+    update: commandRegistry.get('staff.team-member-job-histories.update') as RegisteredCommand,
+    del: commandRegistry.get('staff.team-member-job-histories.delete') as RegisteredCommand,
+  }
+}
+
+function createCtx(em: Pick<EntityManager, 'findOne' | 'fork'>) {
+  return {
+    auth: {
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+    },
+    container: {
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        if (name === 'dataEngine') return null
+        return null
+      },
+    } as unknown as AwilixContainer,
+    selectedOrganizationId: null,
+    organizationScope: null,
+    organizationIds: null,
+  }
+}
+
+describe('staff job history optimistic locking', () => {
+  const jobHistoryId = '123e4567-e89b-41d3-a456-426614174000'
+
+  it('returns 409 when updating a stale job history entry', async () => {
+    const { update } = await loadCommands()
+    const record = {
+      id: jobHistoryId,
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      updatedAt: new Date('2026-05-30T10:00:00.000Z'),
+      name: 'Engineer',
+    }
+    const em = {
+      fork: jest.fn().mockReturnThis(),
+      findOne: jest.fn().mockResolvedValue(record),
+    }
+
+    await expect(update.execute({
+      id: jobHistoryId,
+      name: 'Senior Engineer',
+      updatedAt: '2026-05-30T09:00:00.000Z',
+    }, createCtx(em))).rejects.toMatchObject<Partial<CrudHttpError>>({
+      status: 409,
+      body: { error: 'This record was modified by someone else. Refresh and try again.' },
+    })
+  })
+
+  it('returns 409 when deleting a stale job history entry that was already removed', async () => {
+    const { del } = await loadCommands()
+    const em = {
+      fork: jest.fn().mockReturnThis(),
+      findOne: jest.fn().mockResolvedValue(null),
+    }
+
+    await expect(del.execute({
+      id: jobHistoryId,
+      updatedAt: '2026-05-30T09:00:00.000Z',
+    }, createCtx(em))).rejects.toMatchObject<Partial<CrudHttpError>>({
+      status: 409,
+      body: { error: 'This record was modified by someone else. Refresh and try again.' },
+    })
+  })
+})

--- a/packages/core/src/modules/staff/commands/job-histories.ts
+++ b/packages/core/src/modules/staff/commands/job-histories.ts
@@ -36,6 +36,7 @@ type JobHistorySnapshot = {
   description: string | null
   startDate: string
   endDate: string | null
+  updatedAt: string
 }
 
 type JobHistoryUndoPayload = {
@@ -56,7 +57,23 @@ async function loadJobHistorySnapshot(em: EntityManager, id: string): Promise<Jo
     description: record.description ?? null,
     startDate: record.startDate.toISOString(),
     endDate: record.endDate ? record.endDate.toISOString() : null,
+    updatedAt: record.updatedAt.toISOString(),
   }
+}
+
+async function buildOptimisticLockError(): Promise<CrudHttpError> {
+  const { translate } = await resolveTranslations()
+  return new CrudHttpError(409, {
+    error: translate(
+      'staff.teamMembers.detail.jobHistory.conflict',
+      'This record was modified by someone else. Refresh and try again.',
+    ),
+  })
+}
+
+function hasUpdatedAtConflict(record: StaffTeamMemberJobHistory, expectedUpdatedAt?: string): boolean {
+  if (!expectedUpdatedAt) return false
+  return record.updatedAt.toISOString() !== expectedUpdatedAt
 }
 
 const createJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryCreateInput, { jobHistoryId: string }> = {
@@ -149,9 +166,13 @@ const updateJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryUpdateInp
     const parsed = staffTeamMemberJobHistoryUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const record = await em.findOne(StaffTeamMemberJobHistory, { id: parsed.id })
-    if (!record) throw new CrudHttpError(404, { error: 'Job history entry not found' })
+    if (!record) {
+      if (parsed.updatedAt) throw await buildOptimisticLockError()
+      throw new CrudHttpError(404, { error: 'Job history entry not found' })
+    }
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)
+    if (hasUpdatedAtConflict(record, parsed.updatedAt)) throw await buildOptimisticLockError()
 
     if (parsed.entityId !== undefined) {
       const member = await requireTeamMember(em, parsed.entityId, 'Team member not found')
@@ -268,7 +289,7 @@ const updateJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryUpdateInp
   },
 }
 
-const deleteJobHistoryCommand: CommandHandler<{ body?: Record<string, unknown>; query?: Record<string, unknown> }, { jobHistoryId: string }> =
+const deleteJobHistoryCommand: CommandHandler<{ id?: string; updatedAt?: string; body?: Record<string, unknown>; query?: Record<string, unknown> }, { jobHistoryId: string }> =
   {
     id: 'staff.team-member-job-histories.delete',
     async prepare(input, ctx) {
@@ -279,11 +300,16 @@ const deleteJobHistoryCommand: CommandHandler<{ body?: Record<string, unknown>; 
     },
     async execute(input, ctx) {
       const id = requireId(input, 'Job history id required')
+      const expectedUpdatedAt = typeof input.updatedAt === 'string' ? input.updatedAt : undefined
       const em = (ctx.container.resolve('em') as EntityManager).fork()
       const record = await em.findOne(StaffTeamMemberJobHistory, { id })
-      if (!record) throw new CrudHttpError(404, { error: 'Job history entry not found' })
+      if (!record) {
+        if (expectedUpdatedAt) throw await buildOptimisticLockError()
+        throw new CrudHttpError(404, { error: 'Job history entry not found' })
+      }
       ensureTenantScope(ctx, record.tenantId)
       ensureOrganizationScope(ctx, record.organizationId)
+      if (hasUpdatedAtConflict(record, expectedUpdatedAt)) throw await buildOptimisticLockError()
       em.remove(record)
       await em.flush()
 

--- a/packages/core/src/modules/staff/commands/job-histories.ts
+++ b/packages/core/src/modules/staff/commands/job-histories.ts
@@ -73,7 +73,9 @@ async function buildOptimisticLockError(): Promise<CrudHttpError> {
 
 function hasUpdatedAtConflict(record: StaffTeamMemberJobHistory, expectedUpdatedAt?: string): boolean {
   if (!expectedUpdatedAt) return false
-  return record.updatedAt.toISOString() !== expectedUpdatedAt
+  const expectedTime = new Date(expectedUpdatedAt).getTime()
+  if (Number.isNaN(expectedTime)) return false
+  return record.updatedAt.getTime() !== expectedTime
 }
 
 const createJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryCreateInput, { jobHistoryId: string }> = {

--- a/packages/core/src/modules/staff/components/detail/JobHistorySection.tsx
+++ b/packages/core/src/modules/staff/components/detail/JobHistorySection.tsx
@@ -19,7 +19,7 @@ type JobHistoryRecord = {
   description: string | null
   startDate: string | null
   endDate: string | null
-  updatedAt: string | null
+  updatedAt: string | undefined
 }
 
 type JobHistoryResponse = {
@@ -139,7 +139,13 @@ export function JobHistorySection({ memberId }: { memberId: string | null }) {
     if (!memberId) return
     const payload = buildJobHistoryPayload(values)
     if (dialogMode === 'edit' && activeRecord) {
-      await updateCrud('staff/job-histories', { id: activeRecord.id, updatedAt: activeRecord.updatedAt, ...payload }, { errorMessage: labels.errorSave })
+      try {
+        await updateCrud('staff/job-histories', { id: activeRecord.id, updatedAt: activeRecord.updatedAt, ...payload }, { errorMessage: labels.errorSave })
+      } catch (error) {
+        const message = error instanceof Error && error.message.trim().length > 0 ? error.message : labels.conflict
+        flash(message, 'error')
+        return
+      }
       flash(labels.updated, 'success')
     } else {
       await createCrud('staff/job-histories', { entityId: memberId, ...payload }, { errorMessage: labels.errorSave })
@@ -147,7 +153,7 @@ export function JobHistorySection({ memberId }: { memberId: string | null }) {
     }
     closeDialog()
     setReloadToken((prev) => prev + 1)
-  }, [activeRecord, closeDialog, dialogMode, labels.errorSave, labels.saved, labels.updated, memberId])
+  }, [activeRecord, closeDialog, dialogMode, labels.conflict, labels.errorSave, labels.saved, labels.updated, memberId])
 
   const handleDelete = React.useCallback(async (record: JobHistoryRecord) => {
     const confirmed = await confirmDialog({
@@ -305,7 +311,7 @@ function normalizeJobHistoryItems(items?: Record<string, unknown>[]): JobHistory
           ? record.updated_at
           : typeof record.updatedAt === 'string'
             ? record.updatedAt
-            : null,
+            : undefined,
       }
     })
     .filter((value): value is JobHistoryRecord => value !== null)

--- a/packages/core/src/modules/staff/components/detail/JobHistorySection.tsx
+++ b/packages/core/src/modules/staff/components/detail/JobHistorySection.tsx
@@ -19,6 +19,7 @@ type JobHistoryRecord = {
   description: string | null
   startDate: string | null
   endDate: string | null
+  updatedAt: string | null
 }
 
 type JobHistoryResponse = {
@@ -54,6 +55,7 @@ export function JobHistorySection({ memberId }: { memberId: string | null }) {
     errorLoad: t('staff.teamMembers.detail.jobHistory.errorLoad', 'Failed to load job history.'),
     errorSave: t('staff.teamMembers.detail.jobHistory.errorSave', 'Failed to save job history.'),
     errorDelete: t('staff.teamMembers.detail.jobHistory.errorDelete', 'Failed to delete job history.'),
+    conflict: t('staff.teamMembers.detail.jobHistory.conflict', 'This record was modified by someone else. Refresh and try again.'),
     loading: t('staff.teamMembers.detail.jobHistory.loading', 'Loading job history...'),
     saved: t('staff.teamMembers.detail.jobHistory.saved', 'Job history saved.'),
     updated: t('staff.teamMembers.detail.jobHistory.updated', 'Job history updated.'),
@@ -137,7 +139,7 @@ export function JobHistorySection({ memberId }: { memberId: string | null }) {
     if (!memberId) return
     const payload = buildJobHistoryPayload(values)
     if (dialogMode === 'edit' && activeRecord) {
-      await updateCrud('staff/job-histories', { id: activeRecord.id, ...payload }, { errorMessage: labels.errorSave })
+      await updateCrud('staff/job-histories', { id: activeRecord.id, updatedAt: activeRecord.updatedAt, ...payload }, { errorMessage: labels.errorSave })
       flash(labels.updated, 'success')
     } else {
       await createCrud('staff/job-histories', { entityId: memberId, ...payload }, { errorMessage: labels.errorSave })
@@ -153,10 +155,19 @@ export function JobHistorySection({ memberId }: { memberId: string | null }) {
       variant: 'destructive',
     })
     if (!confirmed) return
-    await deleteCrud('staff/job-histories', { id: record.id, errorMessage: labels.errorDelete })
-    flash(labels.deleted, 'success')
-    setReloadToken((prev) => prev + 1)
-  }, [labels.deleteConfirm, labels.deleted, labels.errorDelete, confirmDialog])
+    try {
+      await deleteCrud('staff/job-histories', {
+        id: record.id,
+        body: { id: record.id, updatedAt: record.updatedAt },
+        errorMessage: labels.errorDelete,
+      })
+      flash(labels.deleted, 'success')
+      setReloadToken((prev) => prev + 1)
+    } catch (error) {
+      const message = error instanceof Error && error.message.trim().length > 0 ? error.message : labels.conflict
+      flash(message, 'error')
+    }
+  }, [labels.conflict, labels.deleteConfirm, labels.deleted, labels.errorDelete, confirmDialog])
 
   const dialogTitle = dialogMode === 'edit' ? labels.edit : labels.add
 
@@ -289,6 +300,11 @@ function normalizeJobHistoryItems(items?: Record<string, unknown>[]): JobHistory
           ? record.end_date
           : typeof record.endDate === 'string'
             ? record.endDate
+            : null,
+        updatedAt: typeof record.updated_at === 'string'
+          ? record.updated_at
+          : typeof record.updatedAt === 'string'
+            ? record.updatedAt
             : null,
       }
     })

--- a/packages/core/src/modules/staff/data/validators.ts
+++ b/packages/core/src/modules/staff/data/validators.ts
@@ -113,6 +113,7 @@ export const staffTeamMemberJobHistoryCreateSchema = z.object({
 export const staffTeamMemberJobHistoryUpdateSchema = z
   .object({
     id: z.string().uuid(),
+    updatedAt: z.string().datetime().optional(),
   })
   .merge(staffTeamMemberJobHistoryCreateSchema.partial())
 

--- a/packages/core/src/modules/staff/data/validators.ts
+++ b/packages/core/src/modules/staff/data/validators.ts
@@ -2,6 +2,11 @@ import { z } from 'zod'
 
 const tagsSchema = z.array(z.string().min(1)).optional().default([])
 
+export const optimisticUpdatedAtSchema = z.string().refine(
+  (value) => !Number.isNaN(new Date(value).getTime()),
+  { message: 'Invalid datetime' },
+)
+
 const scopedCreateFields = {
   tenantId: z.string().uuid(),
   organizationId: z.string().uuid(),
@@ -113,7 +118,7 @@ export const staffTeamMemberJobHistoryCreateSchema = z.object({
 export const staffTeamMemberJobHistoryUpdateSchema = z
   .object({
     id: z.string().uuid(),
-    updatedAt: z.string().datetime().optional(),
+    updatedAt: optimisticUpdatedAtSchema.optional(),
   })
   .merge(staffTeamMemberJobHistoryCreateSchema.partial())
 


### PR DESCRIPTION
## Summary
- carry job history `updatedAt` through the staff UI update and delete flows
- enforce optimistic-lock conflicts in the job history command handlers for stale updates and stale deletes
- preserve `updatedAt` in the delete route contract and add focused command-level regression coverage

## Testing
- yarn jest --config "packages/core/jest.config.cjs" "packages/core/src/modules/staff/commands/__tests__/job-histories.optimistic-locking.test.ts"

## Notes
- `./node_modules/typescript/bin/tsc -p "packages/core/tsconfig.json" --noEmit` is still blocked by unrelated pre-existing generated-entity/type errors elsewhere in this checkout

Fixes #2306