### PR TITLE
fix(planner): stabilize availability schedule switching (#2307)

### DIFF
--- a/packages/core/src/modules/planner/__tests__/availabilityRulesEditorState.test.ts
+++ b/packages/core/src/modules/planner/__tests__/availabilityRulesEditorState.test.ts
@@ -1,0 +1,11 @@
+import { resolveRuleSetSelectValue } from '../components/availabilityRulesEditorState'
+
+describe('availabilityRulesEditorState', () => {
+  it('returns undefined when the selected ruleset is not loaded', () => {
+    expect(resolveRuleSetSelectValue([{ id: 'schedule-1' }], 'schedule-2')).toBeUndefined()
+  })
+
+  it('returns the selected ruleset id when it exists in the options', () => {
+    expect(resolveRuleSetSelectValue([{ id: 'schedule-1' }, { id: 'schedule-2' }], 'schedule-2')).toBe('schedule-2')
+  })
+})

--- a/packages/core/src/modules/planner/components/AvailabilityRulesEditor.tsx
+++ b/packages/core/src/modules/planner/components/AvailabilityRulesEditor.tsx
@@ -30,6 +30,7 @@ import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 import { parseAvailabilityRuleWindow } from '@open-mercato/core/modules/planner/lib/availabilitySchedule'
 import { CrudForm, type CrudField } from '@open-mercato/ui/backend/CrudForm'
 import { Calendar, Clock, List, PencilLine, Plus, Trash2 } from 'lucide-react'
+import { resolveRuleSetSelectValue } from './availabilityRulesEditorState'
 
 type AvailabilityRepeat = 'once' | 'daily' | 'weekly'
 type AvailabilitySubjectType = 'member' | 'resource' | 'ruleset'
@@ -398,6 +399,7 @@ export function AvailabilityRulesEditor({
   const [createRuleSetOpen, setCreateRuleSetOpen] = React.useState(false)
   const [isWeeklyAutoSaving, setIsWeeklyAutoSaving] = React.useState(false)
   const [customOverridesEnabled, setCustomOverridesEnabled] = React.useState(false)
+  const [selectedRulesetId, setSelectedRulesetId] = React.useState<string | null>(rulesetId ?? null)
   const autoSaveTimerRef = React.useRef<number | null>(null)
   const lastSavedWeeklyKeyRef = React.useRef<string | null>(null)
   const weeklySaveStateRef = React.useRef({ inFlight: false, queued: false })
@@ -409,7 +411,12 @@ export function AvailabilityRulesEditor({
   >(null)
   const timezoneOptions = React.useMemo(() => getTimezoneOptions(), [])
 
-  const usingRuleSet = Boolean(rulesetId) && availabilityRules.length === 0 && !customOverridesEnabled
+  React.useEffect(() => {
+    setSelectedRulesetId(rulesetId ?? null)
+  }, [rulesetId])
+
+  const effectiveRulesetId = selectedRulesetId
+  const usingRuleSet = Boolean(effectiveRulesetId) && availabilityRules.length === 0 && !customOverridesEnabled
   const activeRules = usingRuleSet ? rulesetRules : availabilityRules
   const scheduleRules = React.useMemo(() => {
     const dateBlockers = new Set<string>()
@@ -547,7 +554,7 @@ export function AvailabilityRulesEditor({
   }, [labelPrefix, subjectId, subjectType, t])
 
   const refreshRuleSetRules = React.useCallback(async () => {
-    if (!rulesetId) {
+    if (!effectiveRulesetId) {
       setRulesetRules([])
       return
     }
@@ -556,7 +563,7 @@ export function AvailabilityRulesEditor({
         page: '1',
         pageSize: '100',
         subjectType: 'ruleset',
-        subjectIds: rulesetId,
+        subjectIds: effectiveRulesetId,
       })
       const call = await apiCall<{ items?: AvailabilityRule[] }>(`/api/planner/availability?${params.toString()}`)
       const items = Array.isArray(call.result?.items) ? call.result.items : []
@@ -564,7 +571,7 @@ export function AvailabilityRulesEditor({
     } catch {
       setRulesetRules([])
     }
-  }, [rulesetId])
+  }, [effectiveRulesetId])
 
   const refreshRuleSets = React.useCallback(async () => {
     if (!onRulesetChange) return
@@ -653,10 +660,10 @@ export function AvailabilityRulesEditor({
 
   React.useEffect(() => {
     if (timezoneDirty) return
-    if (!usingRuleSet || !rulesetId) return
-    const ruleset = ruleSets.find((entry) => entry.id === rulesetId)
+    if (!usingRuleSet || !effectiveRulesetId) return
+    const ruleset = ruleSets.find((entry) => entry.id === effectiveRulesetId)
     if (ruleset?.timezone) setTimezone(ruleset.timezone)
-  }, [rulesetId, ruleSets, timezoneDirty, usingRuleSet])
+  }, [effectiveRulesetId, ruleSets, timezoneDirty, usingRuleSet])
 
   React.useEffect(() => {
     if (availabilityRules.length > 0) {
@@ -665,10 +672,10 @@ export function AvailabilityRulesEditor({
   }, [availabilityRules.length])
 
   React.useEffect(() => {
-    if (!rulesetId) {
+    if (!effectiveRulesetId) {
       setCustomOverridesEnabled(false)
     }
-  }, [rulesetId])
+  }, [effectiveRulesetId])
 
   const refreshBookedEvents = React.useCallback(async () => {
     if (!loadBookedEvents) return
@@ -764,7 +771,7 @@ export function AvailabilityRulesEditor({
   const saveWeeklyHours = React.useCallback(async (options?: { silentSuccess?: boolean; skipRefresh?: boolean }) => {
     if (isReadOnly) return
     const subjectForRules: AvailabilitySubjectType = usingRuleSet ? 'ruleset' : subjectType
-    const subjectIdForRules = usingRuleSet ? (rulesetId ?? '') : subjectId
+    const subjectIdForRules = usingRuleSet ? (effectiveRulesetId ?? '') : subjectId
     if (!subjectIdForRules) return
     if (weeklyHasErrors) return
 
@@ -802,7 +809,7 @@ export function AvailabilityRulesEditor({
     listLabels.saveWeeklySuccess,
     refreshAvailability,
     refreshRuleSetRules,
-    rulesetId,
+    effectiveRulesetId,
     subjectId,
     subjectType,
     timezone,
@@ -856,7 +863,7 @@ export function AvailabilityRulesEditor({
     if (isReadOnly) return
     if (timezoneSaveInFlightRef.current) return
     const trimmedTimezone = nextTimezone.trim() || 'UTC'
-    const rulesetTimezoneId = subjectType === 'ruleset' ? subjectId : rulesetId
+    const rulesetTimezoneId = subjectType === 'ruleset' ? subjectId : effectiveRulesetId
     const rulesToUpdate = activeRules.filter((rule) => rule.timezone !== trimmedTimezone)
     if (!rulesToUpdate.length && !rulesetTimezoneId) {
       setTimezoneDirty(false)
@@ -895,7 +902,7 @@ export function AvailabilityRulesEditor({
     listLabels.timezoneSaveError,
     refreshAvailability,
     refreshRuleSetRules,
-    rulesetId,
+    effectiveRulesetId,
     subjectId,
     subjectType,
     isReadOnly,
@@ -927,7 +934,7 @@ export function AvailabilityRulesEditor({
 
   const handleCustomize = React.useCallback(async () => {
     if (isReadOnly) return
-    if (!rulesetId) return
+    if (!effectiveRulesetId) return
     try {
       const creations = rulesetRules.map((rule) => createCrud('planner/availability', {
         subjectType,
@@ -945,11 +952,11 @@ export function AvailabilityRulesEditor({
       const message = error instanceof Error ? error.message : listLabels.saveWeeklyError
       flash(message, 'error')
     }
-  }, [listLabels.saveWeeklyError, refreshAvailability, rulesetId, rulesetRules, subjectId, subjectType, isReadOnly])
+  }, [effectiveRulesetId, listLabels.saveWeeklyError, refreshAvailability, rulesetRules, subjectId, subjectType, isReadOnly])
 
   const handleResetToRuleSet = React.useCallback(async () => {
     if (isReadOnly) return
-    if (!rulesetId) return
+    if (!effectiveRulesetId) return
     try {
       await Promise.all(
         availabilityRules.map((rule) => deleteCrud('planner/availability', rule.id, { errorMessage: listLabels.saveWeeklyError })),
@@ -960,12 +967,12 @@ export function AvailabilityRulesEditor({
       const message = error instanceof Error ? error.message : listLabels.saveWeeklyError
       flash(message, 'error')
     }
-  }, [availabilityRules, listLabels.saveWeeklyError, refreshAvailability, rulesetId, isReadOnly])
+  }, [availabilityRules, effectiveRulesetId, listLabels.saveWeeklyError, refreshAvailability, isReadOnly])
 
   const handleRuleSetChange = React.useCallback(async (nextId: string | null) => {
     if (isReadOnly) return
     if (!onRulesetChange) return
-    if (availabilityRules.length > 0 && nextId !== rulesetId) {
+    if (availabilityRules.length > 0 && nextId !== effectiveRulesetId) {
       const confirmed = await confirm({
         title: listLabels.ruleSetConfirm,
         variant: 'default',
@@ -975,17 +982,23 @@ export function AvailabilityRulesEditor({
         availabilityRules.map((rule) => deleteCrud('planner/availability', rule.id, { errorMessage: listLabels.saveWeeklyError })),
       )
     }
+    setSelectedRulesetId(nextId)
     setCustomOverridesEnabled(false)
-    await onRulesetChange(nextId)
-    await refreshAvailability()
+    try {
+      await onRulesetChange(nextId)
+      await refreshAvailability()
+    } catch (error) {
+      setSelectedRulesetId(effectiveRulesetId)
+      throw error
+    }
   }, [
     availabilityRules,
     confirm,
+    effectiveRulesetId,
     listLabels.ruleSetConfirm,
     listLabels.saveWeeklyError,
     onRulesetChange,
     refreshAvailability,
-    rulesetId,
     isReadOnly,
   ])
 
@@ -1058,6 +1071,7 @@ export function AvailabilityRulesEditor({
     }
     await refreshRuleSets()
     if (onRulesetChange) {
+      setSelectedRulesetId(id)
       await onRulesetChange(id)
       await refreshAvailability()
     }
@@ -1155,7 +1169,7 @@ export function AvailabilityRulesEditor({
     if (isReadOnly) return
     if (editorUnavailable && !canManageUnavailability) return
     const subjectForRules: AvailabilitySubjectType = usingRuleSet ? 'ruleset' : subjectType
-    const subjectIdForRules = usingRuleSet ? (rulesetId ?? '') : subjectId
+    const subjectIdForRules = usingRuleSet ? (effectiveRulesetId ?? '') : subjectId
     if (!subjectIdForRules) return
     if (!editorUnavailable && editorWindowErrors.some(Boolean)) return
     const validWindows = editorWindows
@@ -1235,7 +1249,7 @@ export function AvailabilityRulesEditor({
     refreshAvailability,
     refreshRuleSetRules,
     reasonEntriesById,
-    rulesetId,
+    effectiveRulesetId,
     subjectId,
     subjectType,
     timezone,
@@ -1316,7 +1330,7 @@ export function AvailabilityRulesEditor({
                 <span className="text-xs text-muted-foreground">{listLabels.ruleSetLoading}</span>
               ) : (
                 <Select
-                  value={rulesetId || undefined}
+                  value={resolveRuleSetSelectValue(ruleSets, effectiveRulesetId)}
                   onValueChange={(value) => {
                     void handleRuleSetChange(value ? value : null)
                   }}
@@ -1338,12 +1352,12 @@ export function AvailabilityRulesEditor({
                 <Plus className="size-4 mr-2" aria-hidden />
                 {listLabels.ruleSetCreateLabel}
               </Button>
-              {rulesetId && usingRuleSet ? (
+              {effectiveRulesetId && usingRuleSet ? (
                 <Button type="button" variant="outline" size="sm" onClick={handleCustomize} disabled={isReadOnly}>
                   {listLabels.ruleSetCustomize}
                 </Button>
               ) : null}
-              {rulesetId && !usingRuleSet ? (
+              {effectiveRulesetId && !usingRuleSet ? (
                 <Button type="button" variant="ghost" size="sm" onClick={handleResetToRuleSet} disabled={isReadOnly}>
                   {listLabels.ruleSetReset}
                 </Button>

--- a/packages/core/src/modules/planner/components/availabilityRulesEditorState.ts
+++ b/packages/core/src/modules/planner/components/availabilityRulesEditorState.ts
@@ -1,0 +1,11 @@
+export type AvailabilityRuleSetOption = {
+  id: string
+}
+
+export function resolveRuleSetSelectValue(
+  ruleSets: AvailabilityRuleSetOption[],
+  selectedRulesetId: string | null | undefined,
+): string | undefined {
+  if (!selectedRulesetId) return undefined
+  return ruleSets.some((ruleSet) => ruleSet.id === selectedRulesetId) ? selectedRulesetId : undefined
+}


### PR DESCRIPTION
## Summary
- keep a local effective ruleset selection in `AvailabilityRulesEditor` so schedule switching stays stable while the parent async update is in flight
- reset derived ruleset state immediately when the selected schedule changes and fall back safely when the selected ruleset is not in the loaded options
- add focused helper coverage for the ruleset select value guard

## Testing
- yarn jest --config "packages/core/jest.config.cjs" "packages/core/src/modules/planner/__tests__/availabilityRulesEditorState.test.ts"

Fixes #2307