### PR TITLE
fix(ui): open DatePicker on the selected value's month

### DIFF
--- a/packages/ui/src/primitives/__tests__/date-picker.test.tsx
+++ b/packages/ui/src/primitives/__tests__/date-picker.test.tsx
@@ -177,6 +177,18 @@ describe('DatePicker primitive', () => {
       expect(dayCellButton.className).not.toMatch(/focus-visible:ring-2/)
     }
   })
+
+  it('opens on the month of the selected value, not the current month (regression)', async () => {
+    // A value far from any plausible "today" so the assertion stays deterministic.
+    // react-day-picker v10 derives the initial month from `month`/`defaultMonth`
+    // (falling back to today) and ignores `selected`, so DatePicker must pass
+    // `defaultMonth` or the selected day is never rendered.
+    renderWithI18n(<DatePicker value={new Date(2020, 0, 15)} onChange={() => {}} footer="none" />)
+    await openPopover()
+    const selectedCell = document.querySelector('td[data-selected="true"]')
+    expect(selectedCell).not.toBeNull()
+    expect((selectedCell as HTMLElement).className).toMatch(/!bg-primary/)
+  })
 })
 
 describe('DatePicker backwards-compat shims', () => {

--- a/packages/ui/src/primitives/date-picker.tsx
+++ b/packages/ui/src/primitives/date-picker.tsx
@@ -230,6 +230,7 @@ export function DatePicker({
         <Calendar
           mode="single"
           selected={selectedDate ?? undefined}
+          defaultMonth={selectedDate ?? undefined}
           onSelect={handleDaySelect}
           locale={locale}
           disabled={disabledMatcher}


### PR DESCRIPTION
## Summary
Fixes a pre-existing `develop` test failure (`date-picker.test.tsx` → "selected day cell paints primary fill") and the underlying UX bug behind it.

**Root cause:** the react-day-picker v9→v10 dependabot bump changed how the initial month is chosen. In v10, `getInitialMonth` uses `month || defaultMonth || today` and **no longer falls back to the `selected` date** (v9 did). `DatePicker` passed `selected` but never `defaultMonth`, so opening a picker whose value is in a different month than today showed **today's** month and the selected day was never rendered.

That also made the "selected day cell" regression test **time-dependent**: it hard-codes `May 9 2026`, so it only passed when the machine clock was in May 2026 — it currently fails on `develop` because today is outside that month.

## What changed
- `packages/ui/src/primitives/date-picker.tsx`: pass `defaultMonth={selectedDate ?? undefined}` to `Calendar` so the popover opens on the month of the current value.
- `packages/ui/src/primitives/__tests__/date-picker.test.tsx`: added a clock-independent regression test (value in `2020`) asserting the picker opens on the selected value's month (`td[data-selected="true"]` present). The pre-existing regression test is now deterministic too.

## Tests
- `npx jest src/primitives/__tests__/date-picker.test.tsx` (in `packages/ui`) — **21/21 pass** (was 20 with 1 failing).
- `yarn workspace @open-mercato/ui typecheck` — clean (after `yarn build:packages && yarn generate`).

## Manual verification
Open any backend form with a `DatePicker` whose stored value is in a past/future month (e.g. a date in 2020). Click the trigger: the calendar now opens on that month with the day highlighted, instead of opening on the current month.

## Backward compatibility
- Additive only: one extra prop on the internal `Calendar` call. No public API/contract change. `defaultMonth` only sets the *initial* visible month — users can still navigate freely.

## Rollback
Revert this commit — two files, no migrations.
