### PR TITLE
docs(issue-template): add Page URL field to bug report

### DIFF
--- a/.ai/runs/2026-06-01-bug-report-page-url-field.md
+++ b/.ai/runs/2026-06-01-bug-report-page-url-field.md
@@ -32,4 +32,4 @@ Add a dedicated field to `.github/ISSUE_TEMPLATE/bug_report.md` where reporters 
 
 ### Phase 1: Add the page-URL field
 
-- [ ] 1.1 Add a "Page URL" section to bug_report.md
+- [x] 1.1 Add a "Page URL" section to bug_report.md — e66d4fc2d

--- a/.ai/runs/2026-06-01-bug-report-page-url-field.md
+++ b/.ai/runs/2026-06-01-bug-report-page-url-field.md
@@ -1,0 +1,35 @@
+# Execution Plan: Add page-URL field to bug report template
+
+## Goal
+
+Add a dedicated field to `.github/ISSUE_TEMPLATE/bug_report.md` where reporters can paste the link to the subpage on which the bug occurs.
+
+## Scope
+
+- Edit only `.github/ISSUE_TEMPLATE/bug_report.md`.
+- Add a clear "Page URL" / "Affected page link" section so reporters supply the URL of the page where the bug appears.
+
+## Non-goals
+
+- No changes to other issue/PR templates.
+- No changes to issue automation, labels, or workflows.
+- No restructuring of the existing template sections beyond adding the new field.
+
+## Implementation Plan
+
+### Phase 1: Add the page-URL field
+
+- Insert a new section capturing the link to the affected subpage, placed where reporters naturally provide environment/reproduction context.
+- Keep wording bilingual-friendly and consistent with the existing English template tone.
+
+## Risks
+
+- Trivial docs change; the only risk is malformed frontmatter. Mitigated by re-reading the diff and validating YAML frontmatter remains intact.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Add the page-URL field
+
+- [ ] 1.1 Add a "Page URL" section to bug_report.md

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,10 @@ assignees: ""
 
 Provide a clear description of the bug.
 
+## Page URL
+
+Paste the link to the subpage where the bug occurs (e.g. `/backend/customers`).
+
 ## Steps to reproduce
 
 1. …


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-01-bug-report-page-url-field.md
Status: complete

## Goal
- Add a dedicated field to the bug report issue template for the link to the subpage where the bug occurs.

## What Changed
- Added a `## Page URL` section to `.github/ISSUE_TEMPLATE/bug_report.md` prompting reporters to paste the link to the affected subpage, with an example path.

## Tests
- Docs-only change (GitHub issue template). No unit tests applicable.
- Manual re-read of the diff; YAML frontmatter left intact.

## Backward Compatibility
- No contract surface changes. Issue templates are not a platform contract surface.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-01-bug-report-page-url-field.md#progress).
