### PR TITLE
feat: optimistic-lock remaining custom non-CrudForm handlers (closes #2332)

### DIFF
--- a/packages/core/src/modules/catalog/backend/catalog/products/[id]/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[id]/page.tsx
@@ -1784,23 +1784,29 @@ function ProductOptionsSection({ values, setValue }: ProductFormGroupProps) {
 
   const handleDeleteSchema = React.useCallback(
     async (id: string) => {
+      const target = schemaTemplates.find((entry) => entry.id === id);
+      const lockVersion = target?.updatedAt ?? target?.updated_at ?? null;
       try {
-        await deleteCrud("catalog/option-schemas", id, {
-          errorMessage: t(
-            "catalog.products.edit.schemas.deleteError",
-            "Failed to delete schema.",
-          ),
-        });
+        await withScopedApiRequestHeaders(
+          buildOptimisticLockHeader(lockVersion),
+          () => deleteCrud("catalog/option-schemas", id, {
+            errorMessage: t(
+              "catalog.products.edit.schemas.deleteError",
+              "Failed to delete schema.",
+            ),
+          }),
+        );
         flash(
           t("catalog.products.edit.schemas.deleted", "Schema deleted."),
           "success",
         );
         void loadSchemas();
       } catch (err) {
+        if (surfaceRecordConflict(err, t)) { void loadSchemas(); return; }
         console.error("catalog.option-schemas.delete failed", err);
       }
     },
-    [loadSchemas, t],
+    [loadSchemas, schemaTemplates, t],
   );
 
   const handleSaveSchema = React.useCallback(
@@ -1832,8 +1838,25 @@ function ProductOptionsSection({ values, setValue }: ProductFormGroupProps) {
         isActive: true,
       };
       if (schemaToEdit?.id) payload.id = schemaToEdit.id;
-      if (schemaToEdit?.id) await updateCrud("catalog/option-schemas", payload);
-      else await createCrud("catalog/option-schemas", payload);
+      try {
+        if (schemaToEdit?.id) {
+          const lockVersion = schemaToEdit.updatedAt ?? schemaToEdit.updated_at ?? null;
+          await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(lockVersion),
+            () => updateCrud("catalog/option-schemas", payload),
+          );
+        } else {
+          await createCrud("catalog/option-schemas", payload);
+        }
+      } catch (err) {
+        if (surfaceRecordConflict(err, t)) {
+          setSaveSchemaOpen(false);
+          setSchemaToEdit(null);
+          void loadSchemas();
+          return;
+        }
+        throw err;
+      }
       flash(
         t("catalog.products.edit.schemas.saved", "Schema saved."),
         "success",

--- a/packages/core/src/modules/catalog/backend/catalog/products/optionSchemaClient.ts
+++ b/packages/core/src/modules/catalog/backend/catalog/products/optionSchemaClient.ts
@@ -20,6 +20,8 @@ export type OptionSchemaTemplateSummary = {
   name?: string | null
   description?: string | null
   schema?: OptionSchemaRecord | null
+  updatedAt?: string | null
+  updated_at?: string | null
 }
 
 type OptionSchemaTemplateListResponse = {

--- a/packages/core/src/modules/customers/backend/customers/deals/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/page.tsx
@@ -11,7 +11,9 @@ import type { AdvancedFilterTree } from '@open-mercato/shared/lib/query/advanced
 import { createEmptyTree, makeRuleTree, makeMultiRuleTree } from '@open-mercato/shared/lib/query/advanced-filter-tree'
 import { deserializeTree, deserializeAdvancedFilter, flatToTree, mapDictionaryColorToTone, serializeTree, type FilterFieldDef, type FilterOption as AdvancedFilterOption } from '@open-mercato/shared/lib/query/advanced-filter'
 import { useCurrentUserId } from '@open-mercato/ui/backend/utils/useCurrentUserId'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
+import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { buildCrudExportUrl, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { groupBulkDeleteFailures, runBulkDelete } from '@open-mercato/ui/backend/utils/bulkDelete'
 import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
@@ -447,14 +449,18 @@ export default function CustomersDealsPage() {
         variant: 'destructive',
       })
       if (!confirmed) return
+      const lockVersion = rows.find((row) => row.id === dealId)?.updatedAt ?? null
       setPendingDeleteId(dealId)
       try {
         await runSingleMutation({
           operation: async () => {
-            await deleteCrud('customers/deals', {
-              body: { id: dealId },
-              errorMessage: t('customers.deals.list.deleteError', 'Failed to delete deal.'),
-            })
+            await withScopedApiRequestHeaders(
+              buildOptimisticLockHeader(lockVersion),
+              () => deleteCrud('customers/deals', {
+                body: { id: dealId },
+                errorMessage: t('customers.deals.list.deleteError', 'Failed to delete deal.'),
+              }),
+            )
           },
           context: {
             formId: singleMutationContextId,
@@ -468,6 +474,12 @@ export default function CustomersDealsPage() {
         setTotal((prev) => Math.max(0, prev - 1))
         handleRefresh()
       } catch (err) {
+        // A stale delete surfaces the unified conflict bar (via the guarded
+        // mutation) — skip the generic error flash to avoid a double message (#2332).
+        if (surfaceRecordConflict(err, t)) {
+          handleRefresh()
+          return
+        }
         const message =
           err instanceof Error && err.message
             ? err.message
@@ -477,7 +489,7 @@ export default function CustomersDealsPage() {
         setPendingDeleteId(null)
       }
     },
-    [confirm, handleRefresh, pendingDeleteId, retrySingleMutation, runSingleMutation, singleMutationContextId, t],
+    [confirm, handleRefresh, pendingDeleteId, retrySingleMutation, rows, runSingleMutation, singleMutationContextId, t],
   )
 
   const handlePageSizeChange = React.useCallback((newSize: number) => {

--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx
@@ -41,7 +41,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@open-mercato/ui/primitives/select'
-import { apiCall, apiCallOrThrow, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { apiCall, apiCallOrThrow, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
+import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { useCurrentUserId } from '@open-mercato/ui/backend/utils/useCurrentUserId'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
@@ -1818,18 +1820,22 @@ export default function DealsKanbanPage(): React.ReactElement {
       })
       if (!confirmed) return
 
+      const lockVersion = deals.find((deal) => deal.id === dealId)?.updatedAt ?? null
       setPendingDealId(dealId)
       try {
         await runDealMutation({
           operation: async () => {
-            await deleteCrud('customers/deals', {
-              body: { id: dealId },
-              errorMessage: translateWithFallback(
-                t,
-                'customers.deals.kanban.menu.delete.error',
-                'Failed to delete deal.',
-              ),
-            })
+            await withScopedApiRequestHeaders(
+              buildOptimisticLockHeader(lockVersion),
+              () => deleteCrud('customers/deals', {
+                body: { id: dealId },
+                errorMessage: translateWithFallback(
+                  t,
+                  'customers.deals.kanban.menu.delete.error',
+                  'Failed to delete deal.',
+                ),
+              }),
+            )
           },
           context: {
             formId: dealMutationContextId,
@@ -1844,6 +1850,11 @@ export default function DealsKanbanPage(): React.ReactElement {
         )
         invalidateKanbanData()
       } catch (error) {
+        // A stale delete surfaces the unified conflict bar — skip the generic flash (#2332).
+        if (surfaceRecordConflict(error, t)) {
+          invalidateKanbanData()
+          return
+        }
         const message =
           error instanceof Error && error.message
             ? error.message
@@ -1857,7 +1868,7 @@ export default function DealsKanbanPage(): React.ReactElement {
         setPendingDealId(null)
       }
     },
-    [confirm, invalidateKanbanData, retryDealMutation, runDealMutation, t],
+    [confirm, deals, invalidateKanbanData, retryDealMutation, runDealMutation, t],
   )
 
   const bulkSelectionSummary = React.useMemo(() => {

--- a/packages/core/src/modules/sales/backend/sales/channels/offers/page.tsx
+++ b/packages/core/src/modules/sales/backend/sales/channels/offers/page.tsx
@@ -10,7 +10,9 @@ import { DataTable } from '@open-mercato/ui/backend/DataTable'
 import { BooleanIcon } from '@open-mercato/ui/backend/ValueIcons'
 import { RowActions } from '@open-mercato/ui/backend/RowActions'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
-import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
+import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -280,12 +282,16 @@ export default function SalesChannelOffersListPage() {
 
   const handleDelete = React.useCallback(async (row: OfferRow) => {
     try {
-      await deleteCrud('catalog/offers', row.id, {
-        errorMessage: t('sales.channels.offers.errors.delete', 'Failed to delete offer.'),
-      })
+      await withScopedApiRequestHeaders(
+        buildOptimisticLockHeader(row.updatedAt),
+        () => deleteCrud('catalog/offers', row.id, {
+          errorMessage: t('sales.channels.offers.errors.delete', 'Failed to delete offer.'),
+        }),
+      )
       flash(t('sales.channels.offers.messages.deleted', 'Offer deleted.'), 'success')
       handleRefresh()
     } catch (err) {
+      if (surfaceRecordConflict(err, t)) { handleRefresh(); return }
       console.error('sales.channels.offers.delete', err)
     }
   }, [handleRefresh, t])

--- a/packages/core/src/modules/sales/components/channels/ChannelOfferForm.tsx
+++ b/packages/core/src/modules/sales/components/channels/ChannelOfferForm.tsx
@@ -7,7 +7,9 @@ import { CrudForm, type CrudField, type CrudFormGroup, type CrudFormGroupCompone
 import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customFieldValues'
 import { createCrud, updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { createCrudFormError, type CrudServerFieldErrors } from '@open-mercato/ui/backend/utils/serverErrors'
-import { readApiResultOrThrow, apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { readApiResultOrThrow, apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
+import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Input } from '@open-mercato/ui/primitives/input'
@@ -41,6 +43,8 @@ type PriceOverrideDraft = {
   currencyCode?: string | null
   displayMode?: 'including-tax' | 'excluding-tax' | null
   amount?: string
+  /** The price row's version, for the per-price optimistic-lock header (#2332). */
+  updatedAt?: string | null
 }
 
 export type OfferFormValues = {
@@ -142,13 +146,15 @@ export function ChannelOfferForm({ channelId: lockedChannelId, offerId, mode }: 
   const variantMediaCache = React.useRef<Map<string, VariantThumbnailInfo>>(new Map())
   const [selectedChannelId, setSelectedChannelId] = React.useState<string | null>(lockedChannelId ?? null)
   const manualMediaSelections = React.useRef<Set<string>>(new Set())
-  const initialPriceIdsRef = React.useRef<Set<string>>(new Set())
+  // Map of the loaded price-override id → its `updatedAt`, so deletes during the
+  // offer save can send the price's own optimistic-lock version (#2332).
+  const initialPriceVersionsRef = React.useRef<Map<string, string | null>>(new Map())
   const [currentProductId, setCurrentProductId] = React.useState<string | null>(null)
   React.useEffect(() => {
     if (initialValues) {
-      initialPriceIdsRef.current = collectPriceIds(initialValues.priceOverrides)
+      initialPriceVersionsRef.current = collectPriceVersions(initialValues.priceOverrides)
     } else {
-      initialPriceIdsRef.current = new Set()
+      initialPriceVersionsRef.current = new Map()
     }
   }, [initialValues])
   const channelOffersHref = React.useMemo(
@@ -439,12 +445,16 @@ export function ChannelOfferForm({ channelId: lockedChannelId, offerId, mode }: 
     if (!priceId) return true
     if (mode !== 'edit') return true
     try {
-      await deleteCrud('catalog/prices', priceId, {
-        errorMessage: t('sales.channels.offers.errors.removePrice', 'Failed to remove price override.'),
-      })
-      initialPriceIdsRef.current.delete(priceId)
+      await withScopedApiRequestHeaders(
+        buildOptimisticLockHeader(draft.updatedAt),
+        () => deleteCrud('catalog/prices', priceId, {
+          errorMessage: t('sales.channels.offers.errors.removePrice', 'Failed to remove price override.'),
+        }),
+      )
+      initialPriceVersionsRef.current.delete(priceId)
       return true
     } catch (err) {
+      if (surfaceRecordConflict(err, t)) return false
       console.error('sales.channels.pricing.remove', err)
       flash(t('sales.channels.offers.errors.removePrice', 'Failed to remove price override.'), 'error')
       return false
@@ -595,10 +605,11 @@ export function ChannelOfferForm({ channelId: lockedChannelId, offerId, mode }: 
     }
     const submittedPriceIds = collectPriceIds(overrides)
     const deletedIdSet = new Set<string>()
-    initialPriceIdsRef.current.forEach((id) => {
+    initialPriceVersionsRef.current.forEach((_version, id) => {
       if (!submittedPriceIds.has(id)) deletedIdSet.add(id)
     })
     const deletedIds = Array.from(deletedIdSet)
+    const deletedVersions = new Map(deletedIds.map((id) => [id, initialPriceVersionsRef.current.get(id) ?? null]))
     let savedId = offerId ?? null
     try {
       if (mode === 'create') {
@@ -635,15 +646,16 @@ export function ChannelOfferForm({ channelId: lockedChannelId, offerId, mode }: 
       await syncPriceOverrides({
         overrides,
         deletedIds,
+        deletedVersions,
         offerId: savedId,
         channelId,
         productId,
       })
-      initialPriceIdsRef.current = submittedPriceIds
+      initialPriceVersionsRef.current = collectPriceVersions(overrides)
     }
     flash(t('sales.channels.offers.messages.saved', 'Offer saved.'), 'success')
     router.push(buildChannelOffersHref(channelId))
-  }, [attachmentCache, initialPriceIdsRef, lockedChannelId, mode, offerId, router, selectedChannelId, t])
+  }, [attachmentCache, lockedChannelId, mode, offerId, router, selectedChannelId, t])
 
   const handleDelete = React.useCallback(async () => {
     if (!offerId) return
@@ -749,6 +761,11 @@ function mapPriceRow(row: Record<string, unknown>): PriceOverrideDraft {
           : typeof row.unit_price_gross === 'string'
             ? row.unit_price_gross
             : '',
+    updatedAt: typeof row.updatedAt === 'string'
+      ? row.updatedAt
+      : typeof row.updated_at === 'string'
+        ? row.updated_at
+        : null,
   }
 }
 
@@ -758,6 +775,17 @@ function collectPriceIds(source: PriceOverrideDraft[] | null | undefined): Set<s
     .map((entry) => (typeof entry?.priceId === 'string' ? entry.priceId : null))
     .filter((id): id is string => Boolean(id))
   return new Set(ids)
+}
+
+function collectPriceVersions(source: PriceOverrideDraft[] | null | undefined): Map<string, string | null> {
+  const versions = new Map<string, string | null>()
+  if (!Array.isArray(source)) return versions
+  for (const entry of source) {
+    if (typeof entry?.priceId === 'string' && entry.priceId) {
+      versions.set(entry.priceId, typeof entry.updatedAt === 'string' ? entry.updatedAt : null)
+    }
+  }
+  return versions
 }
 
 function mergeCustomFieldValues(target: Record<string, unknown>, source: Record<string, unknown> | null | undefined) {
@@ -773,11 +801,12 @@ function buildChannelOffersHref(channelId?: string | null): string {
 async function syncPriceOverrides(params: {
   overrides: PriceOverrideDraft[]
   deletedIds: string[]
+  deletedVersions: Map<string, string | null>
   offerId: string
   channelId: string
   productId: string
 }) {
-  const { overrides, deletedIds, offerId, channelId, productId } = params
+  const { overrides, deletedIds, deletedVersions, offerId, channelId, productId } = params
   for (const draft of overrides) {
     if (!draft.priceKindId || !draft.amount) continue
     const amount = Number(draft.amount)
@@ -795,7 +824,14 @@ async function syncPriceOverrides(params: {
       payload.unitPriceNet = amount
     }
     if (draft.priceId) {
-      await updateCrud('catalog/prices', { id: draft.priceId, ...payload })
+      // Send the PRICE's own version, overriding the offer header the parent
+      // CrudForm submit scope put on the stack (otherwise the price guard would
+      // compare the offer's `updated_at` and 409 falsely). #2332.
+      const priceId = draft.priceId
+      await withScopedApiRequestHeaders(
+        buildOptimisticLockHeader(draft.updatedAt),
+        () => updateCrud('catalog/prices', { id: priceId, ...payload }),
+      )
     } else {
       await createCrud('catalog/prices', payload)
     }
@@ -806,7 +842,10 @@ async function syncPriceOverrides(params: {
   for (const id of uniqueDeletedIds) {
     if (!id) continue
     try {
-      await deleteCrud('catalog/prices', id)
+      await withScopedApiRequestHeaders(
+        buildOptimisticLockHeader(deletedVersions.get(id) ?? null),
+        () => deleteCrud('catalog/prices', id),
+      )
     } catch (err) {
       console.error('catalog.prices.delete', err)
     }

--- a/packages/core/src/modules/staff/backend/staff/teams/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/teams/page.tsx
@@ -10,7 +10,9 @@ import { RowActions } from '@open-mercato/ui/backend/RowActions'
 import { MarkdownPreview } from '@open-mercato/ui/backend/markdown/MarkdownContent'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { BooleanIcon } from '@open-mercato/ui/backend/ValueIcons'
-import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
+import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
@@ -207,14 +209,18 @@ export default function StaffTeamsPage() {
     })
     if (!confirmed) return
     try {
-      await deleteCrud('staff/teams', entry.id, { errorMessage: labels.errors.delete })
+      await withScopedApiRequestHeaders(
+        buildOptimisticLockHeader(entry.updatedAt),
+        () => deleteCrud('staff/teams', entry.id, { errorMessage: labels.errors.delete }),
+      )
       flash(labels.messages.deleted, 'success')
       handleRefresh()
     } catch (error) {
+      if (surfaceRecordConflict(error, t)) { handleRefresh(); return }
       console.error('staff.teams.delete', error)
       flash(labels.errors.delete, 'error')
     }
-  }, [confirm, handleRefresh, labels.actions.deleteConfirm, labels.actions.delete, labels.errors.delete, labels.errors.deleteAssigned, labels.messages.deleted])
+  }, [confirm, handleRefresh, labels.actions.deleteConfirm, labels.actions.delete, labels.errors.delete, labels.errors.deleteAssigned, labels.messages.deleted, t])
 
   return (
     <Page>


### PR DESCRIPTION
## Implements #2332 — optimistic locking for the remaining custom (non-CrudForm) handlers

**Stacked on #2276** (base = `feat/oss-locking-all-crudforms`). Re-target to `develop` once #2276 (and #2055) merge.

Re-auditing against #2276's CrudForm auto-derive showed most flagged sites were **already covered** (CrudForm detail pages auto-derive the header for both submit *and* delete; several list deletes were already wired). This PR closes the genuine gaps:

### Wired
- **staff** teams list-row delete → `row.updatedAt` + conflict bar.
- **sales** channel offers list-row delete → `row.updatedAt` + conflict bar.
- **catalog** product option-schema **update + delete** (dialog/list) → version from `schemaTemplates` / `schemaToEdit` (added `updatedAt` to `OptionSchemaTemplateSummary`).
- **customers** deals **single** delete (list + kanban) → version looked up from the loaded deals; conflict bar (bulk delete excluded).
- **sales `ChannelOfferForm`** price overrides — see the bug fix below.

### Bug fix (latent #2276 regression)
`ChannelOfferForm`'s offer save runs `syncPriceOverrides` **inside** the offer's CrudForm submit scope, so the **offer's** optimistic-lock header leaked onto the `catalog/prices` sub-mutations → a stale/`409` when saving an offer that has existing price overrides. Each price update/delete (and the immediate override-remove) now sends the **price's own** version, overriding the inherited offer header. This both fixes the false 409 and adds real per-price locking. (Verified the scoped-header stack: inner scope wins.)

### Excluded with rationale (tracked follow-up)
The catalog **product** save's offer-delete + unit-conversion sync run inside the product CrudForm submit (the same parent-header leak). A correct fix needs changes to a **shared** type (`ProductUnitConversionDraft`, also used by the product create page) plus version assumptions on embedded `product.offers`, in a ~3000-line file that can't be runtime-verified here. Deferred rather than risk breaking product saves. (Option-schemas + variant delete on that page **are** done.)

### Already covered (verified, no change)
resources (resource + resource-types detail & list, availability schedule), staff teams/team-roles/leave-request **detail** edit pages, staff team-roles list delete — all CrudForm-auto-derived or previously wired.

### Validation
`turbo typecheck` core + ui ✓ · shared optimistic-lock 80 ✓ · ui conflicts/optimisticLock/CrudForm 36 ✓ · core channels 3 ✓. Strictly additive (no header ⇒ unchanged behavior); no migrations.

Closes #2332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)