### PR TITLE
fix(workflows): replace time-bomb date literals in validators test (closes #2384)

### DIFF
--- a/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
+++ b/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
@@ -23,6 +23,8 @@ import {
   type CreateUserTaskInput,
 } from '../validators'
 
+const futureIsoDatetime = (offsetMs = 60_000) => new Date(Date.now() + offsetMs).toISOString()
+
 describe('Workflows Validators', () => {
   describe('workflowStepTypeSchema', () => {
     test('should accept valid step types', () => {
@@ -204,7 +206,7 @@ describe('Workflows Validators', () => {
 
       test('accepts ISO datetime as "until"', () => {
         expect(() =>
-          workflowStepSchema.parse({ ...baseTimerStep, config: { until: '2026-06-01T12:00:00.000Z' } })
+          workflowStepSchema.parse({ ...baseTimerStep, config: { until: futureIsoDatetime() } })
         ).not.toThrow()
       })
 
@@ -242,7 +244,7 @@ describe('Workflows Validators', () => {
         expect(() =>
           workflowStepSchema.parse({
             ...baseTimerStep,
-            config: { duration: 'PT5M', until: '2026-06-01T12:00:00.000Z' },
+            config: { duration: 'PT5M', until: futureIsoDatetime() },
           })
         ).toThrow(/not both/i)
       })
@@ -407,7 +409,7 @@ describe('Workflows Validators', () => {
         expect(() =>
           activityDefinitionSchema.parse({
             ...baseWait,
-            config: { duration: 'PT5M', until: '2026-06-01T12:00:00.000Z' },
+            config: { duration: 'PT5M', until: futureIsoDatetime() },
           })
         ).toThrow(/not both/i)
       })


### PR DESCRIPTION
## Goal
- Fix the time-bomb unit test in `packages/core/src/modules/workflows/data/__tests__/validators.test.ts` that fails CI on `develop` and every open PR after `2026-06-01T12:00Z`, and fix all sibling occurrences of the same hardcoded-future-date pattern in the file.

## Root cause
The `WAIT_FOR_TIMER` / `WAIT` `"until"` test cases hardcoded `2026-06-01T12:00:00.000Z` as a "future" datetime. `workflowStepSchema` / `activityDefinitionSchema` require `until` to be in the future (`isFutureIsoDateString`). Once the timestamp elapsed, `accepts ISO datetime as "until"` started throwing `ZodError: "until" must be a future datetime`, permanently failing the `test` job and blocking the merge queue. Introduced by #1991.

## What Changed
- Added a `futureIsoDatetime(offsetMs = 60_000)` test helper that derives a fresh future timestamp at runtime.
- Replaced all three once-future hardcoded literals with the helper:
  - `WAIT_FOR_TIMER › accepts ISO datetime as "until"` (the actively-failing case).
  - `WAIT_FOR_TIMER › rejects both duration and until`.
  - `WAIT activity › rejects both duration and until`.
- Left the two intentionally-past `2020-01-01T00:00:00.000Z` literals unchanged — they assert the past-datetime rejection path and are stable by design.

## Tests
- `yarn workspace @open-mercato/core test src/modules/workflows/data/__tests__/validators.test.ts` → **68 passed**.
- `yarn turbo run typecheck --filter=@open-mercato/core` → passes (after `yarn build:packages && yarn generate` to materialize the generated entity-id shim in the fresh worktree).

## Backward Compatibility
- No contract surface changes. Test-only change; validator behavior is unchanged.

## Rollback
- Revert this single commit; no migrations, no runtime code touched.