### PR TITLE
fix(workflows): use dynamic future datetime in timer validator tests

### DIFF
--- a/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
+++ b/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
@@ -184,6 +184,8 @@ describe('Workflows Validators', () => {
         stepType: 'WAIT_FOR_TIMER' as const,
       }
 
+      const futureDatetime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+
       test('accepts ISO 8601 duration', () => {
         expect(() =>
           workflowStepSchema.parse({ ...baseTimerStep, config: { duration: 'PT5M' } })
@@ -204,7 +206,7 @@ describe('Workflows Validators', () => {
 
       test('accepts ISO datetime as "until"', () => {
         expect(() =>
-          workflowStepSchema.parse({ ...baseTimerStep, config: { until: '2026-06-01T12:00:00.000Z' } })
+          workflowStepSchema.parse({ ...baseTimerStep, config: { until: futureDatetime } })
         ).not.toThrow()
       })
 
@@ -242,7 +244,7 @@ describe('Workflows Validators', () => {
         expect(() =>
           workflowStepSchema.parse({
             ...baseTimerStep,
-            config: { duration: 'PT5M', until: '2026-06-01T12:00:00.000Z' },
+            config: { duration: 'PT5M', until: futureDatetime },
           })
         ).toThrow(/not both/i)
       })
@@ -379,6 +381,8 @@ describe('Workflows Validators', () => {
         activityType: 'WAIT' as const,
       }
 
+      const futureDatetime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+
       test('accepts ISO 8601 duration', () => {
         expect(() =>
           activityDefinitionSchema.parse({ ...baseWait, config: { duration: 'PT5M' } })
@@ -407,7 +411,7 @@ describe('Workflows Validators', () => {
         expect(() =>
           activityDefinitionSchema.parse({
             ...baseWait,
-            config: { duration: 'PT5M', until: '2026-06-01T12:00:00.000Z' },
+            config: { duration: 'PT5M', until: futureDatetime },
           })
         ).toThrow(/not both/i)
       })


### PR DESCRIPTION
## Problem

The `test` job on `develop` is failing ([run 26758152458](https://github.com/open-mercato/open-mercato/actions/runs/26758152458)). `@open-mercato/core#test` reports **1 failed, 4502 passed**:

```
FAIL src/modules/workflows/data/__tests__/validators.test.ts
  ● WAIT_FOR_TIMER step config › accepts ISO datetime as "until"
    expect(received).not.toThrow()
    ZodError: "until" must be a future datetime
```

## Root cause

The `WAIT_FOR_TIMER` `until` tests hardcoded `'2026-06-01T12:00:00.000Z'` as a "future" datetime. That is a **time-bomb test**: the timestamp became the past on 2026-06-01, so the schema's future-datetime guard (correctly) rejected it and the suite started failing.

## Fix

Compute the datetime dynamically (`now + 24h`) in both affected describe blocks (`workflowStepSchema` and `activityDefinitionSchema`) so the positive assertions can never expire. The negative/past-datetime tests keep their fixed past literals.

## Verification

```
$ yarn jest src/modules/workflows/data/__tests__/validators.test.ts
Test Suites: 1 passed, 1 total
Tests:       68 passed, 68 total
```

Test-only, non-customer-facing → `skip-qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)