### PR TITLE
perf(catalog): batch price resolution in products afterList hook

### DIFF
--- a/packages/core/src/modules/catalog/api/products/route.ts
+++ b/packages/core/src/modules/catalog/api/products/route.ts
@@ -628,9 +628,13 @@ async function decorateProductsAfterList(
       "catalogPricingService",
     );
 
+    const pricingEntries: Array<{ rows: PriceRow[]; context: PricingContext } | null> = [];
     for (const item of items) {
       const id = typeof item.id === "string" ? item.id : null;
-      if (!id) continue;
+      if (!id) {
+        pricingEntries.push(null);
+        continue;
+      }
       const offerEntries = offersByProduct.get(id) ?? [];
       item.offers = offerEntries;
       const channelIds = Array.from(
@@ -668,10 +672,25 @@ async function decorateProductsAfterList(
         pricingContext.channelId || channelIds.length !== 1
           ? pricingContext
           : { ...pricingContext, channelId: channelIds[0] };
-      const best = await pricingService.resolvePrice(priceCandidates, {
-        ...channelScopedContext,
-        quantity: normalizedQuantityForPricing,
+      pricingEntries.push({
+        rows: priceCandidates,
+        context: { ...channelScopedContext, quantity: normalizedQuantityForPricing },
       });
+    }
+
+    const resolveInputs: Array<{ rows: PriceRow[]; context: PricingContext }> = [];
+    const resolveIndices: number[] = [];
+    for (let i = 0; i < pricingEntries.length; i++) {
+      if (pricingEntries[i] !== null) {
+        resolveInputs.push(pricingEntries[i]!);
+        resolveIndices.push(i);
+      }
+    }
+    const priceResults = await pricingService.resolvePriceMany(resolveInputs);
+
+    for (let i = 0; i < resolveIndices.length; i++) {
+      const item = items[resolveIndices[i]];
+      const best = priceResults[i];
       if (best) {
         item.pricing = {
           kind: resolvePriceKindCode(best),

--- a/packages/core/src/modules/catalog/lib/pricing.ts
+++ b/packages/core/src/modules/catalog/lib/pricing.ts
@@ -180,3 +180,12 @@ export async function resolveCatalogPrice(
 
   return resolved ?? null
 }
+
+export async function resolveCatalogPriceBatch(
+  entries: Array<{ rows: PriceRow[]; context: PricingContext }>,
+  options?: { eventBus?: EventBus | null }
+): Promise<Array<PriceRow | null>> {
+  return Promise.all(
+    entries.map(({ rows, context }) => resolveCatalogPrice(rows, context, options))
+  )
+}

--- a/packages/core/src/modules/catalog/services/__tests__/catalogPricingService.test.ts
+++ b/packages/core/src/modules/catalog/services/__tests__/catalogPricingService.test.ts
@@ -1,8 +1,9 @@
 import { DefaultCatalogPricingService } from '../catalogPricingService'
-import { resolveCatalogPrice, type PriceRow, type PricingContext } from '../../lib/pricing'
+import { resolveCatalogPrice, resolveCatalogPriceBatch, type PriceRow, type PricingContext } from '../../lib/pricing'
 
 jest.mock('../../lib/pricing', () => ({
   resolveCatalogPrice: jest.fn(),
+  resolveCatalogPriceBatch: jest.fn(),
 }))
 
 describe('DefaultCatalogPricingService', () => {
@@ -17,5 +18,21 @@ describe('DefaultCatalogPricingService', () => {
 
     expect(resolveCatalogPrice).toHaveBeenCalledWith(rows, context, { eventBus })
     expect(result).toEqual({ id: 'best-price' })
+  })
+
+  it('delegates batch resolution to the shared batch pricing helper', async () => {
+    const entries = [
+      { rows: [] as PriceRow[], context: { quantity: 1, date: new Date() } as PricingContext },
+      { rows: [] as PriceRow[], context: { quantity: 2, date: new Date() } as PricingContext },
+    ]
+    const eventBus = { emitEvent: jest.fn() }
+    const expected = [{ id: 'price-1' }, null]
+    ;(resolveCatalogPriceBatch as jest.Mock).mockResolvedValue(expected)
+
+    const service = new DefaultCatalogPricingService(eventBus as any)
+    const result = await service.resolvePriceMany(entries)
+
+    expect(resolveCatalogPriceBatch).toHaveBeenCalledWith(entries, { eventBus })
+    expect(result).toEqual(expected)
   })
 })

--- a/packages/core/src/modules/catalog/services/catalogPricingService.ts
+++ b/packages/core/src/modules/catalog/services/catalogPricingService.ts
@@ -1,12 +1,14 @@
 import type { EventBus } from '@open-mercato/events'
 import {
   resolveCatalogPrice,
+  resolveCatalogPriceBatch,
   type PriceRow,
   type PricingContext,
 } from '../lib/pricing'
 
 export interface CatalogPricingService {
   resolvePrice(rows: PriceRow[], context: PricingContext): Promise<PriceRow | null>
+  resolvePriceMany(entries: Array<{ rows: PriceRow[]; context: PricingContext }>): Promise<Array<PriceRow | null>>
 }
 
 export class DefaultCatalogPricingService implements CatalogPricingService {
@@ -14,6 +16,10 @@ export class DefaultCatalogPricingService implements CatalogPricingService {
 
   async resolvePrice(rows: PriceRow[], context: PricingContext): Promise<PriceRow | null> {
     return resolveCatalogPrice(rows, context, { eventBus: this.eventBus })
+  }
+
+  async resolvePriceMany(entries: Array<{ rows: PriceRow[]; context: PricingContext }>): Promise<Array<PriceRow | null>> {
+    return resolveCatalogPriceBatch(entries, { eventBus: this.eventBus })
   }
 }
 


### PR DESCRIPTION
## Summary

- Replaces serial per-row `await pricingService.resolvePrice()` in `decorateProductsAfterList` with a concurrent batch call via a new `resolvePriceMany` API
- Adds `resolveCatalogPriceBatch` to `lib/pricing.ts` using `Promise.all` over the existing per-row resolver (preserving per-row event semantics and resolver priority)
- Extends `CatalogPricingService` interface and `DefaultCatalogPricingService` with `resolvePriceMany` — additive, backward-compatible change

## Motivation

Closes #2352. The `after_list_hook` phase cost was N × per-resolve (≈8.5 ms/product on demo data). On a real catalog with `pageSize=50–100` this adds hundreds of ms of serial latency before the response serializes.

## Files changed

- `packages/core/src/modules/catalog/lib/pricing.ts` — `resolveCatalogPriceBatch`
- `packages/core/src/modules/catalog/services/catalogPricingService.ts` — `resolvePriceMany` interface + impl
- `packages/core/src/modules/catalog/api/products/route.ts` — two-pass refactor of `decorateProductsAfterList`
- `packages/core/src/modules/catalog/services/__tests__/catalogPricingService.test.ts` — test for `resolvePriceMany`

## Notes

`resolveCatalogPriceBatch` uses unbounded `Promise.all`. The default resolver path (`selectBestPrice`) is pure in-memory so there is no DB stress for the default case. Third-party resolver authors should be aware that per-row prices now resolve concurrently rather than sequentially; if a custom resolver hits the DB, connection-pool pressure may increase on large pages.

## Test plan

- [ ] `packages/core` unit tests pass (`catalogPricingService.test.ts` — 2/2)
- [ ] `GET /api/catalog/products` response is byte-identical to pre-patch (pricing output unchanged)
- [ ] `after_list_hook` phase time is approximately constant across page sizes on a seeded catalog of ≥50 products