### PR TITLE
fix(entities): reject undeclared custom field keys

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/records.crud.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/records.crud.test.ts
@@ -1,9 +1,27 @@
 /** @jest-environment node */
 import { POST, PUT, DELETE } from '@open-mercato/core/modules/entities/api/records'
+import { UNKNOWN_CUSTOM_FIELD_ERROR } from '@open-mercato/shared/modules/entities/validation'
 
 const mockEm = {
   find: jest.fn(async () => [] as Array<Record<string, unknown>>),
   findOne: jest.fn(async () => null),
+}
+
+function mockActiveCustomFieldDefs(keys: string[]) {
+  return keys.map((key) => ({
+    key,
+    kind: 'text',
+    isActive: true,
+    deletedAt: null,
+    organizationId: 'org',
+    tenantId: 't1',
+    updatedAt: new Date('2026-03-31T00:00:00.000Z'),
+    configJson: {},
+  }))
+}
+
+function mockCustomFieldDefsLookup(keys: string[]) {
+  mockEm.find.mockResolvedValueOnce(mockActiveCustomFieldDefs(keys))
 }
 
 const mockDataEngine = {
@@ -40,7 +58,7 @@ describe('Records API CRUD operations', () => {
 
   describe('POST /api/entities/records', () => {
     it('creates a record and returns entityId + recordId', async () => {
-      mockEm.find.mockResolvedValueOnce([])
+      mockCustomFieldDefsLookup(['location', 'title'])
       const req = new Request('http://x/api/entities/records', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -65,7 +83,7 @@ describe('Records API CRUD operations', () => {
     })
 
     it('strips cf_ prefix from value keys', async () => {
-      mockEm.find.mockResolvedValueOnce([])
+      mockCustomFieldDefsLookup(['location', 'title'])
       const req = new Request('http://x/api/entities/records', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -83,6 +101,23 @@ describe('Records API CRUD operations', () => {
       )
     })
 
+    it('rejects undeclared custom field keys with 400', async () => {
+      mockCustomFieldDefsLookup(['title'])
+      const req = new Request('http://x/api/entities/records', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          entityId: 'user:qa_entity',
+          values: { title: 'Allowed', undeclared: 'injected' },
+        }),
+      })
+      const res = await POST(req)
+      expect(res.status).toBe(400)
+      const json = await res.json()
+      expect(json.fields.cf_undeclared).toBe(UNKNOWN_CUSTOM_FIELD_ERROR)
+      expect(mockDataEngine.createCustomEntityRecord).not.toHaveBeenCalled()
+    })
+
     it('rejects missing entityId with 400', async () => {
       const req = new Request('http://x/api/entities/records', {
         method: 'POST',
@@ -94,7 +129,7 @@ describe('Records API CRUD operations', () => {
     })
 
     it('ignores non-UUID recordId and lets data engine generate one', async () => {
-      mockEm.find.mockResolvedValueOnce([])
+      mockCustomFieldDefsLookup(['title'])
       const req = new Request('http://x/api/entities/records', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -113,7 +148,7 @@ describe('Records API CRUD operations', () => {
 
   describe('PUT /api/entities/records', () => {
     it('updates an existing record by UUID', async () => {
-      mockEm.find.mockResolvedValueOnce([])
+      mockCustomFieldDefsLookup(['title'])
       const recordId = '123e4567-e89b-12d3-a456-426614174000'
       const req = new Request('http://x/api/entities/records', {
         method: 'PUT',
@@ -139,7 +174,7 @@ describe('Records API CRUD operations', () => {
     })
 
     it('falls back to create when recordId is sentinel value', async () => {
-      mockEm.find.mockResolvedValueOnce([])
+      mockCustomFieldDefsLookup(['title'])
       const req = new Request('http://x/api/entities/records', {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },

--- a/packages/core/src/modules/entities/api/records.ts
+++ b/packages/core/src/modules/entities/api/records.ts
@@ -261,7 +261,7 @@ export async function POST(req: Request) {
     // Validate against custom field definitions
     try {
       const { validateCustomFieldValuesServer } = await import('../lib/validation')
-      const check = await validateCustomFieldValuesServer(em, { entityId, organizationId: targetOrgId, tenantId: auth.tenantId!, values: norm })
+      const check = await validateCustomFieldValuesServer(em, { entityId, organizationId: targetOrgId, tenantId: auth.tenantId!, values: norm, rejectUndeclaredKeys: true })
       if (!check.ok) return NextResponse.json({ error: 'Validation failed', fields: check.fieldErrors }, { status: 400 })
     } catch { /* ignore if helper missing */ }
 
@@ -322,7 +322,7 @@ export async function PUT(req: Request) {
     // Validate against custom field definitions
     try {
       const { validateCustomFieldValuesServer } = await import('../lib/validation')
-      const check = await validateCustomFieldValuesServer(em, { entityId, organizationId: targetOrgId, tenantId: auth.tenantId!, values: norm })
+      const check = await validateCustomFieldValuesServer(em, { entityId, organizationId: targetOrgId, tenantId: auth.tenantId!, values: norm, rejectUndeclaredKeys: true })
       if (!check.ok) return NextResponse.json({ error: 'Validation failed', fields: check.fieldErrors }, { status: 400 })
     } catch { /* ignore if helper missing */ }
 

--- a/packages/core/src/modules/entities/lib/__tests__/helpers.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/helpers.test.ts
@@ -1,0 +1,40 @@
+/** @jest-environment node */
+import type { EntityManager } from '@mikro-orm/core'
+import { setRecordCustomFields } from '../helpers'
+
+describe('setRecordCustomFields', () => {
+  it('skips undeclared keys when preferDefs is enabled', async () => {
+    const definition = {
+      key: 'priority',
+      kind: 'integer',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      updatedAt: new Date('2026-03-31T00:00:00.000Z'),
+      configJson: {},
+    }
+    const persist = jest.fn()
+    const create = jest.fn((entity: unknown, data: Record<string, unknown>) => ({ ...data, entity }))
+    const em = {
+      find: jest.fn(async () => [definition]),
+      findOne: jest.fn(async () => null),
+      create,
+      persist,
+      flush: jest.fn(async () => undefined),
+    } as unknown as EntityManager
+
+    await setRecordCustomFields(em, {
+      entityId: 'example:todo',
+      recordId: 'record-1',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      values: { priority: 3, undeclared: 'ignored' },
+    })
+
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(create).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ fieldKey: 'priority' }),
+    )
+    expect(persist).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/entities/lib/__tests__/helpers.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/helpers.test.ts
@@ -3,7 +3,7 @@ import type { EntityManager } from '@mikro-orm/core'
 import { setRecordCustomFields } from '../helpers'
 
 describe('setRecordCustomFields', () => {
-  it('skips undeclared keys when preferDefs is enabled', async () => {
+  it('persists dynamic keys for trusted command writes (whitelist is enforced upstream)', async () => {
     const definition = {
       key: 'priority',
       kind: 'integer',
@@ -22,19 +22,52 @@ describe('setRecordCustomFields', () => {
       flush: jest.fn(async () => undefined),
     } as unknown as EntityManager
 
+    // First-party flows (CRM dialog, todo adapters, example sync) intentionally
+    // persist undeclared/internal keys; the EAV mass-assignment guard lives at the
+    // untrusted `/api/entities/records` boundary, not here.
     await setRecordCustomFields(em, {
       entityId: 'example:todo',
       recordId: 'record-1',
       organizationId: 'org-1',
       tenantId: 'tenant-1',
-      values: { priority: 3, undeclared: 'ignored' },
+      values: { priority: 3, callPhoneNumber: '+15555550100' },
     })
 
-    expect(create).toHaveBeenCalledTimes(1)
+    expect(create).toHaveBeenCalledTimes(2)
     expect(create).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ fieldKey: 'priority' }),
     )
+    expect(create).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ fieldKey: 'callPhoneNumber' }),
+    )
     expect(persist).toHaveBeenCalledTimes(1)
+  })
+
+  it('still enforces the per-record key cap as the unbounded-injection backstop', async () => {
+    const persist = jest.fn()
+    const create = jest.fn((entity: unknown, data: Record<string, unknown>) => ({ ...data, entity }))
+    const em = {
+      find: jest.fn(async () => []),
+      findOne: jest.fn(async () => null),
+      create,
+      persist,
+      flush: jest.fn(async () => undefined),
+    } as unknown as EntityManager
+
+    const values: Record<string, number> = {}
+    for (let index = 0; index < 200; index++) values[`field_${index}`] = index
+
+    await expect(
+      setRecordCustomFields(em, {
+        entityId: 'example:todo',
+        recordId: 'record-1',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        values,
+      }),
+    ).rejects.toThrow()
+    expect(persist).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/entities/lib/__tests__/validation.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/validation.test.ts
@@ -107,24 +107,35 @@ describe('validateCustomFieldValuesServer', () => {
     expect(result.fieldErrors.cf_priority).toBe('org <= 3')
   })
 
-  it('rejects undeclared custom field keys for the resolved entity scope', async () => {
+  it('rejects undeclared custom field keys only when rejectUndeclaredKeys is set', async () => {
     const definition = createDefinition({
       organizationId: 'org-1',
       tenantId: 'tenant-1',
       validation: [],
     })
-    const em = {
+    const makeEm = () => ({
       find: jest.fn(async () => [definition]),
-    } as unknown as EntityManager
+    } as unknown as EntityManager)
 
-    const result = await validateCustomFieldValuesServer(em, {
+    const strict = await validateCustomFieldValuesServer(makeEm(), {
+      entityId: 'example:todo',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      values: { priority: 1, undeclared: 'injected' },
+      rejectUndeclaredKeys: true,
+    })
+
+    expect(strict.ok).toBe(false)
+    expect(strict.fieldErrors.cf_undeclared).toBe(UNKNOWN_CUSTOM_FIELD_ERROR)
+
+    // Trusted command writes (default) keep persisting their dynamic keys.
+    const lenient = await validateCustomFieldValuesServer(makeEm(), {
       entityId: 'example:todo',
       organizationId: 'org-1',
       tenantId: 'tenant-1',
       values: { priority: 1, undeclared: 'injected' },
     })
 
-    expect(result.ok).toBe(false)
-    expect(result.fieldErrors.cf_undeclared).toBe(UNKNOWN_CUSTOM_FIELD_ERROR)
+    expect(lenient.ok).toBe(true)
   })
 })

--- a/packages/core/src/modules/entities/lib/__tests__/validation.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/validation.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment node */
 import type { EntityManager } from '@mikro-orm/core'
+import { UNKNOWN_CUSTOM_FIELD_ERROR } from '@open-mercato/shared/modules/entities/validation'
 import { validateCustomFieldValuesServer } from '../validation'
 
 type ValidationRule =
@@ -104,5 +105,26 @@ describe('validateCustomFieldValuesServer', () => {
 
     expect(result.ok).toBe(false)
     expect(result.fieldErrors.cf_priority).toBe('org <= 3')
+  })
+
+  it('rejects undeclared custom field keys for the resolved entity scope', async () => {
+    const definition = createDefinition({
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      validation: [],
+    })
+    const em = {
+      find: jest.fn(async () => [definition]),
+    } as unknown as EntityManager
+
+    const result = await validateCustomFieldValuesServer(em, {
+      entityId: 'example:todo',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      values: { priority: 1, undeclared: 'injected' },
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.fieldErrors.cf_undeclared).toBe(UNKNOWN_CUSTOM_FIELD_ERROR)
   })
 })

--- a/packages/core/src/modules/entities/lib/helpers.ts
+++ b/packages/core/src/modules/entities/lib/helpers.ts
@@ -123,7 +123,6 @@ export async function setRecordCustomFields(
     if (raw === undefined) continue
 
     const def = defsByKey?.[fieldKey]
-    if (preferDefs && !def) continue
     const encrypted = Boolean(def?.configJson && (def as any).configJson?.encrypted)
     const isArray = Array.isArray(raw)
     // When array: remove existing values for key and create multiple rows

--- a/packages/core/src/modules/entities/lib/helpers.ts
+++ b/packages/core/src/modules/entities/lib/helpers.ts
@@ -1,6 +1,10 @@
 import type { EntityManager } from '@mikro-orm/core'
 import type { TenantDataEncryptionService } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
 import { encryptCustomFieldValue, resolveTenantEncryptionService } from '@open-mercato/shared/lib/encryption/customFieldValues'
+import {
+  MAX_CUSTOM_FIELD_KEYS_PER_RECORD,
+  TOO_MANY_CUSTOM_FIELDS_ERROR,
+} from '@open-mercato/shared/modules/entities/validation'
 import { CustomFieldDef, CustomFieldValue } from '../data/entities'
 
 type Primitive = string | number | boolean | null | undefined
@@ -69,16 +73,32 @@ export async function setRecordCustomFields(
   if (preferDefs) {
     const defs = await em.find(CustomFieldDef, {
       entityId,
+      isActive: true,
+      deletedAt: null,
       organizationId: { $in: [organizationId, null] as any },
       tenantId: { $in: [tenantId, null] as any },
     })
-    // Prefer org+tenant-specific over global if duplicates
+    const scopeScore = (def: CustomFieldDef) => (def.tenantId ? 2 : 0) + (def.organizationId ? 1 : 0)
     defsByKey = {}
     for (const d of defs) {
       const existing = defsByKey[d.key]
-      if (!existing || 
-          (existing.organizationId == null && d.organizationId != null) ||
-          (existing.tenantId == null && d.tenantId != null)) {
+      if (!existing) {
+        defsByKey[d.key] = d
+        continue
+      }
+      const nextScore = scopeScore(d)
+      const existingScore = scopeScore(existing)
+      if (nextScore > existingScore) {
+        defsByKey[d.key] = d
+        continue
+      }
+      if (nextScore < existingScore) continue
+
+      const nextUpdatedAt = d.updatedAt instanceof Date ? d.updatedAt.getTime() : new Date(d.updatedAt).getTime()
+      const existingUpdatedAt = existing.updatedAt instanceof Date
+        ? existing.updatedAt.getTime()
+        : new Date(existing.updatedAt).getTime()
+      if (nextUpdatedAt >= existingUpdatedAt) {
         defsByKey[d.key] = d
       }
     }
@@ -93,11 +113,17 @@ export async function setRecordCustomFields(
     return encryptionService
   }
   const keys = Object.keys(values)
+  const presentKeyCount = keys.filter((key) => values[key] !== undefined).length
+  if (preferDefs && presentKeyCount > MAX_CUSTOM_FIELD_KEYS_PER_RECORD) {
+    throw new Error(TOO_MANY_CUSTOM_FIELDS_ERROR)
+  }
+
   for (const fieldKey of keys) {
     const raw = values[fieldKey]
     if (raw === undefined) continue
 
     const def = defsByKey?.[fieldKey]
+    if (preferDefs && !def) continue
     const encrypted = Boolean(def?.configJson && (def as any).configJson?.encrypted)
     const isArray = Array.isArray(raw)
     // When array: remove existing values for key and create multiple rows

--- a/packages/core/src/modules/entities/lib/validation.ts
+++ b/packages/core/src/modules/entities/lib/validation.ts
@@ -4,7 +4,13 @@ import { validateValuesAgainstDefs } from '@open-mercato/shared/modules/entities
 
 export async function validateCustomFieldValuesServer(
   em: EntityManager,
-  opts: { entityId: string; organizationId?: string | null; tenantId?: string | null; values: Record<string, any> },
+  opts: {
+    entityId: string
+    organizationId?: string | null
+    tenantId?: string | null
+    values: Record<string, any>
+    rejectUndeclaredKeys?: boolean
+  },
 ): Promise<{ ok: boolean; fieldErrors: Record<string, string> }> {
   const organizationId = opts.organizationId ?? null
   const tenantId = opts.tenantId ?? null
@@ -51,5 +57,7 @@ export async function validateCustomFieldValuesServer(
       byKey.set(d.key, d)
     }
   }
-  return validateValuesAgainstDefs(opts.values, Array.from(byKey.values()) as any)
+  return validateValuesAgainstDefs(opts.values, Array.from(byKey.values()) as any, {
+    rejectUndeclaredKeys: opts.rejectUndeclaredKeys === true,
+  })
 }

--- a/packages/shared/src/modules/entities/__tests__/validation.test.ts
+++ b/packages/shared/src/modules/entities/__tests__/validation.test.ts
@@ -1,7 +1,10 @@
 /** @jest-environment node */
 import {
+  MAX_CUSTOM_FIELD_KEYS_PER_RECORD,
   MAX_CUSTOM_FIELD_REGEX_PATTERN_LENGTH,
   MAX_CUSTOM_FIELD_REGEX_INPUT_LENGTH,
+  TOO_MANY_CUSTOM_FIELDS_ERROR,
+  UNKNOWN_CUSTOM_FIELD_ERROR,
   validateValuesAgainstDefs,
 } from '../validation'
 
@@ -120,6 +123,34 @@ describe('validateValuesAgainstDefs', () => {
 
     expect(result.ok).toBe(false)
     expect(result.fieldErrors['cf_body']).toBe('body too large')
+  })
+
+  it('rejects values for keys that have no custom field definition', () => {
+    const defs = [{ key: 'priority', kind: 'integer', configJson: {} }]
+    const result = validateValuesAgainstDefs({ priority: 1, undeclared: 'x' }, defs as any)
+
+    expect(result.ok).toBe(false)
+    expect(result.fieldErrors.cf_undeclared).toBe(UNKNOWN_CUSTOM_FIELD_ERROR)
+  })
+
+  it('ignores undefined keys that are not declared', () => {
+    const defs = [{ key: 'priority', kind: 'integer', configJson: {} }]
+    const result = validateValuesAgainstDefs({ priority: 1, undeclared: undefined }, defs as any)
+
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects payloads with too many custom field keys', () => {
+    const values: Record<string, number> = {}
+    for (let index = 0; index < MAX_CUSTOM_FIELD_KEYS_PER_RECORD + 1; index++) {
+      values[`field_${index}`] = index
+    }
+
+    const defs = Object.keys(values).map((key) => ({ key, kind: 'integer', configJson: {} }))
+    const result = validateValuesAgainstDefs(values, defs as any)
+
+    expect(result.ok).toBe(false)
+    expect(result.fieldErrors._customFields).toBe(TOO_MANY_CUSTOM_FIELDS_ERROR)
   })
 
   it('fails closed before testing oversized regex patterns', () => {

--- a/packages/shared/src/modules/entities/__tests__/validation.test.ts
+++ b/packages/shared/src/modules/entities/__tests__/validation.test.ts
@@ -125,17 +125,28 @@ describe('validateValuesAgainstDefs', () => {
     expect(result.fieldErrors['cf_body']).toBe('body too large')
   })
 
-  it('rejects values for keys that have no custom field definition', () => {
+  it('rejects values for undeclared keys only when rejectUndeclaredKeys is set', () => {
+    const defs = [{ key: 'priority', kind: 'integer', configJson: {} }]
+    const strict = validateValuesAgainstDefs({ priority: 1, undeclared: 'x' }, defs as any, {
+      rejectUndeclaredKeys: true,
+    })
+
+    expect(strict.ok).toBe(false)
+    expect(strict.fieldErrors.cf_undeclared).toBe(UNKNOWN_CUSTOM_FIELD_ERROR)
+  })
+
+  it('persists undeclared keys by default (trusted command writes)', () => {
     const defs = [{ key: 'priority', kind: 'integer', configJson: {} }]
     const result = validateValuesAgainstDefs({ priority: 1, undeclared: 'x' }, defs as any)
 
-    expect(result.ok).toBe(false)
-    expect(result.fieldErrors.cf_undeclared).toBe(UNKNOWN_CUSTOM_FIELD_ERROR)
+    expect(result.ok).toBe(true)
   })
 
-  it('ignores undefined keys that are not declared', () => {
+  it('ignores undefined keys even in strict mode', () => {
     const defs = [{ key: 'priority', kind: 'integer', configJson: {} }]
-    const result = validateValuesAgainstDefs({ priority: 1, undeclared: undefined }, defs as any)
+    const result = validateValuesAgainstDefs({ priority: 1, undeclared: undefined }, defs as any, {
+      rejectUndeclaredKeys: true,
+    })
 
     expect(result.ok).toBe(true)
   })

--- a/packages/shared/src/modules/entities/validation.ts
+++ b/packages/shared/src/modules/entities/validation.ts
@@ -112,17 +112,29 @@ function countPresentValueKeys(values: Record<string, unknown>): number {
   return count
 }
 
+export type ValidateValuesOptions = {
+  // When true, value keys that have no matching CustomFieldDef are rejected
+  // (OWASP A03/A04 EAV mass-assignment guard for untrusted entry points such as
+  // the generic `/api/entities/records` endpoint). Trusted first-party command
+  // writes persist dynamic/internal keys, so they leave this off and rely on the
+  // always-on per-record key cap below as the unbounded-injection backstop.
+  rejectUndeclaredKeys?: boolean
+}
+
 export function validateValuesAgainstDefs(
   values: Record<string, any>,
   defs: CustomFieldDefLike[],
+  options: ValidateValuesOptions = {},
 ): { ok: boolean; fieldErrors: Record<string, string> } {
   const errors: Record<string, string> = {}
-  const allowedKeys = new Set(defs.map((def) => def.key))
 
-  for (const key of Object.keys(values)) {
-    if (values[key] === undefined) continue
-    if (!allowedKeys.has(key)) {
-      errors[`cf_${key}`] = UNKNOWN_CUSTOM_FIELD_ERROR
+  if (options.rejectUndeclaredKeys) {
+    const allowedKeys = new Set(defs.map((def) => def.key))
+    for (const key of Object.keys(values)) {
+      if (values[key] === undefined) continue
+      if (!allowedKeys.has(key)) {
+        errors[`cf_${key}`] = UNKNOWN_CUSTOM_FIELD_ERROR
+      }
     }
   }
 

--- a/packages/shared/src/modules/entities/validation.ts
+++ b/packages/shared/src/modules/entities/validation.ts
@@ -3,6 +3,9 @@ import { testLinearRegex } from '../../lib/regex/linear'
 
 export const MAX_CUSTOM_FIELD_REGEX_PATTERN_LENGTH = 500
 export const MAX_CUSTOM_FIELD_REGEX_INPUT_LENGTH = 10_000
+export const MAX_CUSTOM_FIELD_KEYS_PER_RECORD = 128
+export const UNKNOWN_CUSTOM_FIELD_ERROR = '[internal] Unknown custom field'
+export const TOO_MANY_CUSTOM_FIELDS_ERROR = '[internal] Too many custom fields'
 
 // Supported rule types for custom fields validation
 export const VALIDATION_RULES = [
@@ -101,11 +104,32 @@ function evalRule(rule: ValidationRule, value: any, kind: string): string | null
   }
 }
 
+function countPresentValueKeys(values: Record<string, unknown>): number {
+  let count = 0
+  for (const key of Object.keys(values)) {
+    if (values[key] !== undefined) count++
+  }
+  return count
+}
+
 export function validateValuesAgainstDefs(
   values: Record<string, any>,
   defs: CustomFieldDefLike[],
 ): { ok: boolean; fieldErrors: Record<string, string> } {
   const errors: Record<string, string> = {}
+  const allowedKeys = new Set(defs.map((def) => def.key))
+
+  for (const key of Object.keys(values)) {
+    if (values[key] === undefined) continue
+    if (!allowedKeys.has(key)) {
+      errors[`cf_${key}`] = UNKNOWN_CUSTOM_FIELD_ERROR
+    }
+  }
+
+  if (countPresentValueKeys(values) > MAX_CUSTOM_FIELD_KEYS_PER_RECORD) {
+    errors._customFields = TOO_MANY_CUSTOM_FIELDS_ERROR
+  }
+
   for (const def of defs) {
     const cfg = def?.configJson || {}
     const rules: ValidationRule[] = Array.isArray(cfg.validation) ? cfg.validation : []


### PR DESCRIPTION
## Summary

Fix low-severity security issue (#2246): custom-field writes now fail-closed on undeclared keys, preventing unbounded EAV row injection / storage noise (OWASP A03/A04 mass assignment). Also adds a reasonable cap on the number of custom-field keys per record.

## Changes

- Reject incoming custom-field keys that have no matching `CustomFieldDef` (server-side validation).
- Defense-in-depth: skip undeclared keys (and enforce key-count cap) in `setRecordCustomFields` when `preferDefs` is enabled.
- Update/add unit tests covering undeclared-key rejection and cap behavior, and update Records API tests to mock active custom-field defs.

## Notes
Introduces a defensive cap (`MAX_CUSTOM_FIELD_KEYS_PER_RECORD`) to prevent unbounded payload/EAV growth; value is a conservative upper bound consistent with other hard limits (e.g. ids-per-request). Error messages are `[internal]` per hardcoded-string convention; happy to switch to i18n keys if preferred.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- `yarn typecheck`
- `yarn workspace @open-mercato/shared test`
- `yarn workspace @open-mercato/core test`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it. (not required)
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (not required — unit coverage on validation + helper boundary)
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (not required)

### Design System Compliance
N/A - no UI changes

## Linked issues

Fixes #2246