### PR TITLE
fix(api_keys): add transactional mock to keys.route unit test

### DIFF
--- a/packages/core/src/modules/api_keys/api/__tests__/keys.route.test.ts
+++ b/packages/core/src/modules/api_keys/api/__tests__/keys.route.test.ts
@@ -12,6 +12,7 @@ interface MockEntityManager {
   findOne: jest.Mock<Promise<unknown>, [unknown, Record<string, unknown>?]>
   find: jest.Mock<Promise<unknown[]>, [unknown, Record<string, unknown>?]>
   fork: jest.Mock<MockEntityManager, []>
+  transactional: jest.Mock<Promise<unknown>, [(em: MockEntityManager) => Promise<unknown>]>
 }
 
 interface MockDataEngine {
@@ -42,6 +43,9 @@ const mockEm: MockEntityManager = {
   findOne: jest.fn<Promise<unknown>, [unknown, Record<string, unknown>?]>(),
   find: jest.fn<Promise<unknown[]>, [unknown, Record<string, unknown>?]>(),
   fork: jest.fn<MockEntityManager, []>(),
+  transactional: jest.fn<Promise<unknown>, [(em: MockEntityManager) => Promise<unknown>]>(
+    async (cb) => cb(mockEm),
+  ),
 }
 const mockDataEngine: MockDataEngine = {
   __queue: queue,


### PR DESCRIPTION
## Problem
- `src/modules/api_keys/api/__tests__/keys.route.test.ts` was failing with status 500 instead of 201

## Root Cause
Commit 51c4036 (#2335/#2376) wrapped the `makeCrudRoute` direct-ORM write path in `em.transactional(async () => { ... })` to make entity + custom-field writes atomic. The `MockEntityManager` in this test did not include a `transactional` method, so calling it threw `TypeError: em.transactional is not a function`, which the CRUD factory's catch block turned into a 500 response.

## What Changed
- Added `transactional` to the `MockEntityManager` interface
- Added `transactional: jest.fn(async (cb) => cb(mockEm))` to the mock instance — executes the callback immediately (no real transaction), which is the correct behaviour for a unit test

## Tests
- All 5 tests in `keys.route.test.ts` now pass (were: 1 failed, 4 passed)
- No other files changed

## Backward Compatibility
- Test-only change — no production code touched