### PR TITLE
perf(test): cap yarn test memory fan-out below the yarn dev budget (#2402)

### DIFF
--- a/apps/mercato/jest.config.cjs
+++ b/apps/mercato/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/jest.config.base.cjs
+++ b/jest.config.base.cjs
@@ -1,0 +1,23 @@
+/** @type {import('jest').Config} */
+// Shared jest base config — governs the test-suite memory fan-out (issue #2402).
+//
+// `turbo run test` launches one jest "main" per package, and each main forks
+// worker processes. Left uncapped, every package would default to
+// `os.cpus().length - 1` workers, so the worst-case worker count is
+// (packages × cores) — structurally unbounded and easily above the `yarn dev`
+// RSS budget on smaller machines.
+//
+// This base pins the two per-package multipliers so peak RSS stays bounded:
+//   peak ≈ (turboConcurrency × maxWorkers) × perWorkerHeapCap + mainOverhead
+// Turbo concurrency and the per-worker V8 heap cap are pinned in the root
+// `test` script; the worker count and recycling threshold are pinned here.
+//
+// Every package's jest.config.cjs spreads this first, then overrides specifics.
+module.exports = {
+  // Cap workers per package so the turbo fan-out stays small
+  // (turbo concurrency × maxWorkers heavy workers at peak).
+  maxWorkers: 2,
+  // Recycle a worker once its heap bloats past this, instead of letting it
+  // grow toward V8's default ceiling for the whole run.
+  workerIdleMemoryLimit: '512MB',
+}

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,7 +1,9 @@
 /** @type {import('jest').Config} */
+const base = require('./jest.config.base.cjs')
 const isGitHubActions = process.env.GITHUB_ACTIONS === 'true'
 
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:packages": "turbo run build --filter='./packages/*'",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
-    "test": "turbo run test",
+    "test": "cross-env NODE_OPTIONS=--max-old-space-size=768 turbo run test --concurrency=4",
     "start": "turbo run start --filter=@open-mercato/app",
     "generate": "turbo run generate --filter=@open-mercato/app",
     "reinstall": "turbo run reinstall --filter=@open-mercato/app",

--- a/packages/ai-assistant/jest.config.cjs
+++ b/packages/ai-assistant/jest.config.cjs
@@ -1,9 +1,11 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',
-  maxWorkers: 4,
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   moduleNameMapper: {
     '^@open-mercato/ai-assistant/(.*)$': '<rootDir>/src/$1',

--- a/packages/cache/jest.config.cjs
+++ b/packages/cache/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/packages/checkout/jest.config.cjs
+++ b/packages/checkout/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/packages/cli/jest.config.cjs
+++ b/packages/cli/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/packages/content/jest.config.cjs
+++ b/packages/content/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/packages/core/jest.config.cjs
+++ b/packages/core/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   testTimeout: 30000,
   watchman: false,

--- a/packages/enterprise/jest.config.cjs
+++ b/packages/enterprise/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/packages/events/jest.config.cjs
+++ b/packages/events/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/packages/gateway-stripe/jest.config.cjs
+++ b/packages/gateway-stripe/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/packages/onboarding/jest.config.cjs
+++ b/packages/onboarding/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   preset: 'ts-jest',
   testEnvironment: 'node',
   watchman: false,

--- a/packages/queue/jest.config.cjs
+++ b/packages/queue/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/packages/scheduler/jest.config.cjs
+++ b/packages/scheduler/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   roots: ['<rootDir>/src'],

--- a/packages/search/jest.config.cjs
+++ b/packages/search/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/packages/shared/jest.config.cjs
+++ b/packages/shared/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/packages/storage-s3/jest.config.cjs
+++ b/packages/storage-s3/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   preset: 'ts-jest',
   testEnvironment: 'node',
   watchman: false,

--- a/packages/sync-akeneo/jest.config.cjs
+++ b/packages/sync-akeneo/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/packages/ui/jest.config.cjs
+++ b/packages/ui/jest.config.cjs
@@ -1,10 +1,12 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'jsdom',
   testTimeout: 30000,
   watchman: false,
   rootDir: '.',
-  maxWorkers: 4,
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   moduleNameMapper: {
     '^@open-mercato/ui/(.*)$': '<rootDir>/src/$1',

--- a/packages/webhooks/jest.config.cjs
+++ b/packages/webhooks/jest.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('jest').Config} */
+const base = require('../../jest.config.base.cjs')
+
 module.exports = {
+  ...base,
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',

--- a/scripts/__tests__/jest-memory-fanout.test.mjs
+++ b/scripts/__tests__/jest-memory-fanout.test.mjs
@@ -1,0 +1,79 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+// Regression guard for issue #2402: `yarn test` peak memory fan-out must stay
+// bounded below the `yarn dev` budget. The bound is enforced by three pinned
+// factors — turbo test concurrency, per-package jest `maxWorkers`, and a V8
+// old-space cap on the test path. These tests fail if any factor is removed.
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const require = createRequire(import.meta.url)
+
+const MAX_WORKERS_BOUND = 2
+
+function findJestConfigs() {
+  const roots = [path.join(REPO_ROOT, 'packages'), path.join(REPO_ROOT, 'apps')]
+  const found = []
+  for (const root of roots) {
+    if (!fs.existsSync(root)) continue
+    for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      const cfg = path.join(root, entry.name, 'jest.config.cjs')
+      if (fs.existsSync(cfg)) found.push(cfg)
+    }
+  }
+  return found
+}
+
+test('a shared jest base config exists with bounded worker memory knobs', () => {
+  const basePath = path.join(REPO_ROOT, 'jest.config.base.cjs')
+  assert.ok(fs.existsSync(basePath), 'jest.config.base.cjs must exist at repo root')
+  const base = require(basePath)
+  assert.ok(
+    typeof base.maxWorkers === 'number' && base.maxWorkers <= MAX_WORKERS_BOUND,
+    `base maxWorkers must be a number <= ${MAX_WORKERS_BOUND}, got ${base.maxWorkers}`,
+  )
+  assert.ok(
+    typeof base.workerIdleMemoryLimit === 'string' && base.workerIdleMemoryLimit.length > 0,
+    'base must set workerIdleMemoryLimit so bloated workers are recycled',
+  )
+})
+
+test('every package jest config inherits the bounded worker caps', () => {
+  const configs = findJestConfigs()
+  assert.ok(configs.length >= 18, `expected the full set of package jest configs, found ${configs.length}`)
+  for (const cfg of configs) {
+    const resolved = require(cfg)
+    const rel = path.relative(REPO_ROOT, cfg)
+    assert.ok(
+      typeof resolved.maxWorkers === 'number' && resolved.maxWorkers <= MAX_WORKERS_BOUND,
+      `${rel}: maxWorkers must be <= ${MAX_WORKERS_BOUND}, got ${resolved.maxWorkers}`,
+    )
+    assert.ok(
+      typeof resolved.workerIdleMemoryLimit === 'string' && resolved.workerIdleMemoryLimit.length > 0,
+      `${rel}: must inherit workerIdleMemoryLimit from the shared base`,
+    )
+  }
+})
+
+test('the root test script caps turbo concurrency and the V8 heap', () => {
+  const pkg = require(path.join(REPO_ROOT, 'package.json'))
+  const script = pkg.scripts.test
+  assert.ok(script, 'root package.json must define a test script')
+  assert.match(
+    script,
+    /--concurrency=\d+/,
+    'root test script must cap turbo test concurrency (e.g. --concurrency=4)',
+  )
+  const concurrency = Number(script.match(/--concurrency=(\d+)/)[1])
+  assert.ok(concurrency <= 8, `turbo test concurrency must stay small, got ${concurrency}`)
+  assert.match(
+    script,
+    /--max-old-space-size=\d+/,
+    'root test script must pin a V8 old-space cap on the test path',
+  )
+})


### PR DESCRIPTION
Fixes #2402

## Problem
`yarn test` (`turbo run test`) had no bound on its total process fan-out, so peak RSS could exceed — and OOM past — the `yarn dev` budget on smaller machines.

## Root Cause
Two uncapped multipliers stacked:
1. Turbo ran every package's `test` task in parallel (global `concurrency: 32` ≥ 19 jest packages ⇒ all 19 jest mains at once).
2. 17 of 19 jest packages had no `maxWorkers`, defaulting to `os.cpus().length - 1` (13 on a 14-core box). No V8 heap cap and no worker recycling either.

Worst case ≈ `17×13 + 2×4 + 19 mains ≈ ~248` Node processes — structurally unbounded and higher than `yarn dev`.

## What Changed
- **New shared base config `jest.config.base.cjs`** — `maxWorkers: 2`, `workerIdleMemoryLimit: '512MB'`. Spread (`...base`) into all 19 package jest configs + the root config. Dropped the ad-hoc `maxWorkers: 4` from `ui`/`ai-assistant` in favor of the shared bound.
- **Capped turbo test concurrency** — root `test` script now runs `turbo run test --concurrency=4` instead of inheriting the global `32`.
- **Pinned the V8 heap** — root `test` script sets `NODE_OPTIONS=--max-old-space-size=768` (via the already-present `cross-env`), matching the dev-mode V8 strategy from `.ai/specs/2026-05-27-dev-mode-memory-quick-wins.md`.

Result: at most `4 × 2 = 8` heavy workers at peak (down from ~221), comfortably under the 3–4 GB `yarn dev` budget and the ≤2.5 GB target.

## Tests
- New `scripts/__tests__/jest-memory-fanout.test.mjs` (3 tests) guards all three factors: base config exists with bounded knobs, every package config inherits `maxWorkers ≤ 2` + `workerIdleMemoryLimit`, and the root `test` script caps turbo concurrency + the V8 heap. Fails before the fix, passes after. Runs under `yarn test:scripts` (CI-covered).
- `yarn test:scripts` — 177/177 pass.
- `yarn build:packages`, `yarn generate` — clean.
- Sample package suites with the new config: `cache` (41/41), `events` (32/32), `queue` (51/51) — clean.

### Known pre-existing failure (out of scope)
`packages/shared` test `CRUD Factory › POST is blocked by interceptor before hook` fails on pristine `origin/develop` as well — reproduced in full isolation, and this PR touches **no** `packages/shared/src/**` (config-only). Not caused by this change; left for a separate fix.

## Backward Compatibility
No contract surface changes. Jest configs are test infrastructure (not one of the 13 contract-surface categories); the new base config is additive and the `test` script change is internal.