### PR TITLE
fix(entities): persist metadata changes for system entities on save (#2411)

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/entities.api.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/entities.api.test.ts
@@ -1,0 +1,85 @@
+/** @jest-environment node */
+import { GET } from '../entities'
+
+const mockEm = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  persist: jest.fn(),
+  flush: jest.fn(async () => undefined),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (key: string) => {
+      if (key === 'em') return mockEm
+      return null
+    },
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: async () => ({
+    sub: 'user-1',
+    tenantId: 'tenant-1',
+    orgId: 'org-1',
+    isSuperAdmin: false,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/entityIds', () => ({
+  getEntityIds: () => ({
+    customers: { customer_person: 'customers:customer_person' },
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/entities/system-entities', () => ({
+  isSystemEntitySelectable: (id: string) => id === 'customers:customer_person',
+}))
+
+describe('GET /api/entities/entities — overlay merge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // second em.find (for field definitions) returns empty
+    mockEm.find.mockResolvedValue([])
+  })
+
+  it('preserves source: code for a generated entity that has a CustomEntity overlay', async () => {
+    // First em.find returns a CustomEntity overlay for the code-sourced entity
+    mockEm.find.mockResolvedValueOnce([
+      {
+        entityId: 'customers:customer_person',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        label: 'Custom Label',
+        description: 'Overridden description',
+        defaultEditor: 'markdown',
+        showInSidebar: false,
+        isActive: true,
+      },
+    ])
+
+    const response = await GET(new Request('http://x/api/entities/entities'))
+    expect(response.status).toBe(200)
+
+    const json = await response.json()
+    const item = json.items.find((i: { entityId: string }) => i.entityId === 'customers:customer_person')
+    expect(item).toBeDefined()
+    expect(item.source).toBe('code')
+    expect(item.label).toBe('Custom Label')
+    expect(item.description).toBe('Overridden description')
+    expect(item.defaultEditor).toBe('markdown')
+  })
+
+  it('reports source: code for a generated entity with no overlay', async () => {
+    mockEm.find.mockResolvedValueOnce([])
+
+    const response = await GET(new Request('http://x/api/entities/entities'))
+    expect(response.status).toBe(200)
+
+    const json = await response.json()
+    const item = json.items.find((i: { entityId: string }) => i.entityId === 'customers:customer_person')
+    expect(item).toBeDefined()
+    expect(item.source).toBe('code')
+  })
+})

--- a/packages/core/src/modules/entities/api/entities.ts
+++ b/packages/core/src/modules/entities/api/entities.ts
@@ -63,7 +63,10 @@ export async function GET(req: Request) {
 
   const byId = new Map<string, any>()
   for (const g of generated) byId.set(g.entityId, g)
-  for (const cu of custom) byId.set(cu.entityId, { ...byId.get(cu.entityId), ...cu })
+  for (const cu of custom) {
+    const existing = byId.get(cu.entityId)
+    byId.set(cu.entityId, { ...existing, ...cu, source: existing?.source ?? cu.source })
+  }
 
   // Count field definitions scoped to current tenant/org (same scoping as custom entities)
   const defsWhere: any = { isActive: true }

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
@@ -473,20 +473,13 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
       flash('Please fix validation errors in field definitions', 'error')
       throw createCrudFormError('Please fix validation errors in field definitions')
     }
-    if (entitySource === 'custom') {
-      const partial = upsertCustomEntitySchema
-        .pick({ label: true, description: true, labelField: true as any, defaultEditor: true as any })
-        .extend({ showInSidebar: z.boolean().optional() }) as unknown as z.ZodTypeAny
-      const normalized = {
-        ...(vals as any),
-        defaultEditor: (vals as any)?.defaultEditor || undefined,
-      }
-      const parsed = partial.safeParse(normalized)
-      if (!parsed.success) throw createCrudFormError('Validation failed')
+    {
+      const entityPayload = buildEntityMetadataPayload(entitySource, vals)
+      if (!entityPayload) throw createCrudFormError('Validation failed')
       const callEntity = await apiCall('/api/entities/entities', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ entityId, ...(parsed.data as any) }),
+        body: JSON.stringify({ entityId, ...entityPayload }),
       })
       if (!callEntity.ok) {
         await raiseCrudError(callEntity.response, 'Failed to save entity')
@@ -602,4 +595,22 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
       </Dialog>
     </Page>
   )
+}
+
+export function buildEntityMetadataPayload(
+  entitySource: 'code' | 'custom',
+  vals: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const partial = entitySource === 'custom'
+    ? upsertCustomEntitySchema
+        .pick({ label: true, description: true, labelField: true as any, defaultEditor: true as any })
+        .extend({ showInSidebar: z.boolean().optional() }) as unknown as z.ZodTypeAny
+    : upsertCustomEntitySchema
+        .pick({ label: true, description: true, defaultEditor: true as any }) as unknown as z.ZodTypeAny
+  const normalized = {
+    ...vals,
+    defaultEditor: typeof vals.defaultEditor === 'string' && vals.defaultEditor ? vals.defaultEditor : undefined,
+  }
+  const parsed = partial.safeParse(normalized)
+  return parsed.success ? (parsed.data as Record<string, unknown>) : null
 }

--- a/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts
+++ b/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts
@@ -1,0 +1,79 @@
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
+  CrudForm: () => null,
+}))
+
+import { buildEntityMetadataPayload } from '../[entityId]/page'
+
+describe('buildEntityMetadataPayload', () => {
+  describe('code-sourced (system) entities', () => {
+    it('returns a payload with label, description, and defaultEditor', () => {
+      const result = buildEntityMetadataPayload('code', {
+        label: 'My Entity',
+        description: 'Some description',
+        defaultEditor: 'markdown',
+      })
+      expect(result).not.toBeNull()
+      expect(result).toMatchObject({
+        label: 'My Entity',
+        description: 'Some description',
+        defaultEditor: 'markdown',
+      })
+    })
+
+    it('returns a payload even when only label is provided', () => {
+      const result = buildEntityMetadataPayload('code', { label: 'System Entity' })
+      expect(result).not.toBeNull()
+      expect(result?.label).toBe('System Entity')
+    })
+
+    it('does not include showInSidebar in the payload', () => {
+      const result = buildEntityMetadataPayload('code', {
+        label: 'My Entity',
+        showInSidebar: true,
+      })
+      expect(result).not.toBeNull()
+      expect(result).not.toHaveProperty('showInSidebar')
+    })
+
+    it('normalizes empty string defaultEditor to undefined', () => {
+      const result = buildEntityMetadataPayload('code', {
+        label: 'My Entity',
+        defaultEditor: '',
+      })
+      expect(result).not.toBeNull()
+      expect(result?.defaultEditor).toBeUndefined()
+    })
+  })
+
+  describe('custom entities', () => {
+    it('returns a payload with showInSidebar', () => {
+      const result = buildEntityMetadataPayload('custom', {
+        label: 'Custom Entity',
+        description: 'Custom description',
+        showInSidebar: true,
+      })
+      expect(result).not.toBeNull()
+      expect(result).toMatchObject({
+        label: 'Custom Entity',
+        description: 'Custom description',
+        showInSidebar: true,
+      })
+    })
+
+    it('returns a valid payload when showInSidebar is not provided', () => {
+      const result = buildEntityMetadataPayload('custom', { label: 'Custom Entity' })
+      expect(result).not.toBeNull()
+      expect(result?.label).toBe('Custom Entity')
+    })
+  })
+
+  it('returns null when label is missing', () => {
+    const result = buildEntityMetadataPayload('code', { description: 'No label here' })
+    expect(result).toBeNull()
+  })
+
+  it('returns null when label is empty', () => {
+    const result = buildEntityMetadataPayload('custom', { label: '' })
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #2411

## Problem
- Editing a System Entity (Data Designer → System Entities) showed a success notification ("Definitions saved") but the changes to label, description, and defaultEditor were not persisted.

## Root Cause
Two bugs, both fixed in this PR:

1. **Client-side skip:** In \`handleCrudFormSubmit\` the API call to save entity metadata (\`POST /api/entities/entities\`) was guarded by \`if (entitySource === 'custom')\`. System entities have \`entitySource === 'code'\`, so the call was never made.

2. **GET overlay-merge flips source:** Once the first fix caused a \`CustomEntity\` overlay row to be created for a code-sourced entity, the \`GET /api/entities/entities\` merge loop was spreading the overlay last — overwriting \`source: 'code'\` with \`source: 'custom'\`. This made the entity disappear from the System Entities list and gain a Delete button (identified in code review of the first commit).

## What Changed
- Removed the \`if (entitySource === 'custom')\` guard; entity metadata is now always persisted for both code-sourced and custom entities
- System entities do not include \`showInSidebar\` in the payload (consistent with the form not displaying it)
- Extracted \`buildEntityMetadataPayload(entitySource, vals)\` for testability
- Fixed GET overlay merge to pin \`source\` to the generated entity's value when an overlay exists: \`{ ...existing, ...cu, source: existing?.source ?? cu.source }\`

## Tests
- \`edit-entity-submit.test.ts\` — 8 unit tests for \`buildEntityMetadataPayload\`
- \`entities.api.test.ts\` — 2 unit tests for the GET overlay merge (regression for the source-flip bug)
- All 4616 core tests pass; all 19 typecheck tasks pass

## Backward Compatibility
- No contract surface changes (API route, public types, event IDs, ACL features, DB schema are all unchanged)
- The new \`buildEntityMetadataPayload\` export is additive only