### PR TITLE
fix(audit_logs): make tenant-level org undo reachable via public undo API (#2398)

### DIFF
--- a/packages/core/src/modules/audit_logs/api/__tests__/undo.route.test.ts
+++ b/packages/core/src/modules/audit_logs/api/__tests__/undo.route.test.ts
@@ -100,4 +100,56 @@ describe('POST /api/audit_logs/audit-logs/actions/undo', () => {
       selectedOrganizationId: 'org-1',
     }))
   })
+
+  // Regression for issue #2398 — org create/update/delete/reparent log rows are
+  // tenant-level (organization_id = NULL). A super-admin resolves to a concrete
+  // home org, so the old code re-looked-up the latest undoable action with that
+  // home org and never matched the null-org row, returning 400. The lookup must
+  // be scoped to the target row's own organization instead of the caller's.
+  it('undoes a tenant-level org action when the caller resolves to a different home org', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    const { resolveFeatureCheckContext } = await import('@open-mercato/core/modules/directory/utils/organizationScope')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'admin-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-home',
+      isSuperAdmin: true,
+    })
+    // Super-admin browsing the global directory resolves to their home org.
+    ;(resolveFeatureCheckContext as jest.Mock).mockResolvedValue({
+      organizationId: 'org-home',
+      scope: { allowedIds: null },
+    })
+    // Super-admin has audit_logs.undo_tenant via the wildcard grant.
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+
+    const target = {
+      id: 'log-org-1',
+      actorUserId: 'admin-1',
+      tenantId: 'tenant-1',
+      organizationId: null,
+      resourceKind: 'directory.organization',
+      resourceId: 'new-org-1',
+      executionState: 'done',
+    }
+    mockLogs.findByUndoToken.mockResolvedValue(target)
+    // Mirror the DB filter: the row is only returned when the lookup is NOT
+    // over-scoped to a concrete org it does not belong to.
+    mockLogs.latestUndoableForResource.mockImplementation(
+      async ({ organizationId }: { organizationId: string | null }) =>
+        organizationId == null ? target : null,
+    )
+    mockLogs.latestUndoableForActor.mockImplementation(
+      async (_actorUserId: string, { organizationId }: { organizationId: string | null }) =>
+        organizationId == null ? target : null,
+    )
+
+    const res = await POST(makeRequest({ undoToken: 'token-org-1' }))
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ ok: true, logId: 'log-org-1' })
+    expect(mockLogs.latestUndoableForResource).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: null, resourceId: 'new-org-1' }),
+    )
+    expect(mockCommandBus.undo).toHaveBeenCalledWith('token-org-1', expect.anything())
+  })
 })

--- a/packages/core/src/modules/audit_logs/api/audit-logs/actions/undo/route.ts
+++ b/packages/core/src/modules/audit_logs/api/audit-logs/actions/undo/route.ts
@@ -74,12 +74,19 @@ export async function POST(req: Request) {
   }
 
   const lookupActorId = canUndoTenant ? (target.actorUserId ?? auth.sub) : auth.sub
+  // Scope the latest-undoable re-lookup to the target row's own organization, not
+  // the caller's currently-resolved org. The actor/tenant/org guards above already
+  // authorized the caller for this row; reusing the caller's scope here breaks undo
+  // for tenant-level rows (organization create/update/delete/reparent log with a
+  // null organization_id) whenever the caller resolves to a concrete home org, so
+  // the lookup never matches and returns "Undo token not available" (issue #2398).
+  const lookupOrgId = target.organizationId ?? null
   let latest = null
   if (target.resourceKind || target.resourceId) {
     latest = await logs.latestUndoableForResource({
       actorUserId: lookupActorId,
       tenantId: auth.tenantId ?? null,
-      organizationId: scopedOrgId,
+      organizationId: lookupOrgId,
       resourceKind: target.resourceKind ?? undefined,
       resourceId: target.resourceId ?? undefined,
     })
@@ -87,7 +94,7 @@ export async function POST(req: Request) {
   if (!latest) {
     latest = await logs.latestUndoableForActor(lookupActorId, {
       tenantId: auth.tenantId ?? null,
-      organizationId: scopedOrgId,
+      organizationId: lookupOrgId,
     })
   }
   if (!latest || latest.id !== target.id) {

--- a/packages/core/src/modules/directory/__integration__/TC-DIR-ATOMIC-VERIFY.spec.ts
+++ b/packages/core/src/modules/directory/__integration__/TC-DIR-ATOMIC-VERIFY.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type APIRequestContext } from '@playwright/test';
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test';
 import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
 import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
 
@@ -25,18 +25,17 @@ import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integr
  *   3. Delete reparents children to the deleted node's parent (root) atomically
  *      and the deleted node disappears from the manage view.
  *
- * NOTE on org undo (intentionally skipped, with a verified reason):
- *   directory.organizations create/delete return an `x-om-operation` undo token,
- *   but the public undo route (/api/audit_logs/audit-logs/actions/undo) cannot
- *   reach those action logs for the only actor permitted to create organizations
- *   (super-admin). Org commands require super-admin, and the undo route's
- *   latest-undoable lookup is scoped to the caller's selected/auth organization,
- *   which never equals the directory-org log's recorded organization. Probing the
- *   live API confirmed both create-undo and delete-undo return HTTP 400
- *   "Undo token not available", and the org log does not surface in the
- *   audit-logs actions feed under any reachable org scope. This is a routing/
- *   scoping limitation of the undo endpoint for tenant-level org operations, not
- *   an atomic-write defect, so the undo subcase is skipped rather than asserted.
+ * NOTE on org undo (issue #2398 — now reachable):
+ *   directory.organizations create/delete return an `x-om-operation` undo token.
+ *   Org action logs are tenant-level (organization_id = NULL) because orgs are not
+ *   nested under another org. Previously the public undo route
+ *   (/api/audit_logs/audit-logs/actions/undo) re-scoped its latest-undoable lookup
+ *   to the caller's resolved organization, so a super-admin (the only role allowed
+ *   to manage organizations) resolving to a concrete home org never matched the
+ *   null-org row and got HTTP 400 "Undo token not available". The route now scopes
+ *   the lookup to the target row's own organization, so a super-admin can undo a
+ *   recent org create/update/delete/reparent. The undo subcase below exercises the
+ *   create-undo round-trip end to end.
  */
 
 type ManageOrg = {
@@ -67,6 +66,24 @@ async function createOrg(
   const body = await readJsonSafe<{ id?: string }>(res);
   expect(typeof body?.id, 'create returns an id').toBe('string');
   return body!.id as string;
+}
+
+function readUndoToken(res: APIResponse): string {
+  const enc = (res.headers()['x-om-operation'] ?? '').slice(5);
+  expect(enc, 'x-om-operation header carries an omop: payload').not.toBe('');
+  const payload = JSON.parse(decodeURIComponent(enc)) as { undoToken?: string };
+  expect(typeof payload.undoToken, 'undoToken present in operation payload').toBe('string');
+  return payload.undoToken as string;
+}
+
+async function undoAction(request: APIRequestContext, token: string, undoToken: string): Promise<void> {
+  const res = await apiRequest(request, 'POST', '/api/audit_logs/audit-logs/actions/undo', {
+    token,
+    data: { undoToken },
+  });
+  expect(res.status(), 'undo returns 200').toBe(200);
+  const body = await readJsonSafe<{ ok?: boolean }>(res);
+  expect(body?.ok, 'undo body is { ok: true }').toBe(true);
 }
 
 async function loadManageById(
@@ -281,12 +298,45 @@ test.describe('TC-DIR-ATOMIC-VERIFY: directory organizations atomic refactor (PR
     }
   });
 
-  // Org create/delete undo is not exercisable through the public undo API for the
-  // super-admin actor (the only role allowed to manage organizations). See the
-  // file-level NOTE: the undo route's org-scoped latest-undoable lookup never
-  // matches the directory-org action log, returning HTTP 400 "Undo token not
-  // available". Verified live with curl against create- and delete-issued tokens.
-  test.skip('org create/delete undo via public undo API (unreachable for super-admin org scope)', () => {
-    // Intentionally skipped — documented routing/scoping limitation, not a data defect.
+  // Issue #2398: org create undo via the public undo API is now reachable for the
+  // super-admin actor. The create-issued undo token round-trips through the public
+  // undo route and removes the freshly created org from the manage view.
+  test('org create undo via public undo API removes the created org (issue #2398)', async ({ request }) => {
+    let token: string | null = null;
+    let orgId: string | null = null;
+    let undone = false;
+    const stamp = Date.now();
+
+    try {
+      token = await getAuthToken(request, 'superadmin');
+      const { tenantId } = getTokenContext(token);
+      expect(tenantId, 'superadmin token carries a tenant id').toBeTruthy();
+
+      const slug = `tc-dir-undo-${stamp}`;
+      const createRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+        token,
+        data: { tenantId, name: `TC-DIR Undo ${stamp}`, slug, isActive: true },
+      });
+      expect(createRes.status(), 'create organization returns 201').toBe(201);
+      const createBody = await readJsonSafe<{ id?: string }>(createRes);
+      expect(typeof createBody?.id, 'create returns an id').toBe('string');
+      orgId = createBody!.id as string;
+      const undoToken = readUndoToken(createRes);
+
+      // Sanity: the org is present before the undo.
+      const before = await loadManageById(request, token, tenantId!, orgId);
+      expect(before, 'created organization present before undo').toBeTruthy();
+
+      // Undo the create through the public undo API (was HTTP 400 before #2398).
+      await undoAction(request, token, undoToken);
+      undone = true;
+
+      // Undo of a create removes the org from the manage view.
+      const after = await loadManageById(request, token, tenantId!, orgId);
+      expect(after, 'organization removed from manage view after undo').toBeUndefined();
+    } finally {
+      // If the undo did not run (e.g. earlier failure), clean up the org directly.
+      if (!undone) await deleteOrgIfExists(request, token, orgId);
+    }
   });
 });


### PR DESCRIPTION
Fixes #2398

## Problem
A super-admin cannot undo a recent organization create/update/delete/reparent via the public undo API (`POST /api/audit_logs/audit-logs/actions/undo`) — it returns `400 {"error":"Undo token not available"}`. The forward org transactions are fully consistent; only the undo affordance was unreachable.

## Root Cause
Organization action-log rows are **tenant-level** (`organization_id = NULL`) because organizations are not nested under another org. The undo route fetched the target row by token and validated the caller's actor/tenant/org permissions, but then **re-scoped the "latest undoable" lookup (`latestUndoableForResource` / `latestUndoableForActor`) to the caller's resolved organization**. A super-admin (the only role allowed to manage organizations) resolves to a concrete home org when browsing the global directory, so the lookup filtered by that home org and never matched the `NULL`-org row → 400.

This mirrors the same class of bug fixed for `auth.users.*` in #1978, but for orgs there is no containing org to anchor to, so the fix belongs on the read side.

## What Changed
- `packages/core/.../actions/undo/route.ts`: scope the latest-undoable re-lookup to the **target row's own organization** (`target.organizationId ?? null`) instead of the caller's resolved org. The actor/tenant/org guards above the lookup already authorize the caller for the row, so isolation is preserved while tenant-level (`NULL`-org) rows become reachable. For normal org-scoped rows the value is identical to the previous `scopedOrgId` (the guard already proved they match), so there is no behavior change there.

## Tests
- **Unit (new):** `undo.route.test.ts` — super-admin whose resolved home org differs from a `NULL`-org `directory.organization` row now undoes successfully; asserts the lookup is called with `organizationId: null`. Verified red→green (returns 400 before the fix, 200 after).
- **Integration:** converted the previously-skipped `TC-DIR-ATOMIC-VERIFY` org-undo subcase into a live create-undo round-trip (create org → undo via public API → assert it disappears from the manage view) and updated the file-level NOTE.
- Full `@open-mercato/core` suite green (4609 tests); `typecheck` green.

## Backward Compatibility
No contract surface changes. No API response fields removed, no event IDs / DI names / ACL features / route paths altered. The change only widens which undo tokens resolve successfully (additive capability); cross-tenant and cross-org isolation for non-tenant-capable callers is unchanged (the existing guards and the `actorUserId` lookup filter still apply).

## Security impact
Touches authorization-adjacent logic (undo scoping). The fix does **not** relax the permission guards: actor-match-or-`undo_tenant`, tenant-match, and org-match (lines 65–74) are unchanged. It only stops the post-authorization re-lookup from over-constraining to the caller's transient org scope, scoping it to the row the caller was already authorized for. Net effect: super-admins can undo tenant-level org operations; no new cross-tenant or cross-org capability for other roles.

## QA note
Backoffice behavior change (super-admin org undo). Worth a manual exercise: as super-admin, create an organization, then undo it from the actions/undo affordance — it should now succeed and remove the org.
