### PR TITLE
test(customers): stabilize flaky TC-CRM-028 example-customer-sync poll

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-028.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-028.spec.ts
@@ -731,7 +731,17 @@ test.describe('TC-CRM-028: Example customer sync', () => {
       expect(mapping.syncStatus).toBe('synced');
       expect(mapping.exampleHref).toContain(todoId);
 
-      const todo = await waitForExampleTodo(request, adminToken, todoId, (item) => item.cf_severity === 'high');
+      const todo = await waitForExampleTodo(
+        request,
+        adminToken,
+        todoId,
+        (item) =>
+          item.cf_severity === 'high' &&
+          item.cf_description === 'Follow up with procurement' &&
+          item.cf_priority === 3 &&
+          item.is_done === false &&
+          (item.title?.includes('CRM027 lifecycle') ?? false),
+      );
       expect(todo.title).toContain('CRM027 lifecycle');
       expect(todo.is_done).toBe(false);
       expect(todo.cf_priority).toBe(3);


### PR DESCRIPTION
## What

Stabilizes the one flaky integration test surfaced by running **2 full ephemeral integration rounds on `develop`** (`yarn test:integration:ephemeral`, CI-faithful `workers: 1`).

Test-only change in `packages/core/.../customers/__integration__/TC-CRM-028.spec.ts` — **no product code is touched**.

## Two-round results (ephemeral, fresh DB per round)

| Round | Passed | Skipped | Flaky | Failed |
|-------|--------|---------|-------|--------|
| 1 | 851 | 38 | **1** (`TC-CRM-028`) | 0 |
| 2 | 851 | 39 | 0 | 0 |

- The **only** instability across both rounds was `TC-CRM-028 › syncs canonical customer task lifecycle to example todos and exposes mappings` — flaky in round 1 (failed first attempt, passed on retry), clean in round 2.
- The skip delta (38→39, `TC-DS-001`) is **by design**: that test self-skips via `test.skip()` when no runnable `data_sync` provider is registered. Not a flake — no change needed.

## Root cause of the `TC-CRM-028` flake

The test drains the outbound sync queue, then polls `waitForExampleTodo()` gating **only** on `cf_severity === 'high'`, but immediately asserts `cf_description`, `cf_priority`, `is_done` and `title` as well. Reads go through the cached `/api/example/todos` list endpoint (`ENABLE_CRUD_API_CACHE`), so the synced custom fields can become visible at slightly different times. The poll could resolve once `severity` had propagated but **before** `description`, yielding `cf_description === null` on the first attempt (round 1's failure: `Expected "Follow up with procurement", Received null`).

## Fix

Gate the poll on **every** field the test subsequently asserts, so it only resolves once the todo is fully synced:

```ts
const todo = await waitForExampleTodo(
  request, adminToken, todoId,
  (item) =>
    item.cf_severity === 'high' &&
    item.cf_description === 'Follow up with procurement' &&
    item.cf_priority === 3 &&
    item.is_done === false &&
    (item.title?.includes('CRM027 lifecycle') ?? false),
);
```

Strictly stricter wait, same 15s budget — converts the mid-poll race into a proper wait without changing any assertion semantics.

| Failing test | Evidence | Diagnosis | Owner | Action |
|--------------|----------|-----------|-------|--------|
| `TC-CRM-028 :: syncs canonical customer task lifecycle…` | round-1 stdout + `error-context.md` (`cf_description` = null at attempt 1) | Poll gate narrower than the assertions; cached list read exposes synced custom fields at slightly different times | Agent/QA (test) | Gate poll on all asserted fields (this PR) |

## Validation

- Re-ran the full `TC-CRM-028` spec through the ephemeral runner with the fix: **9 passed, 1 skipped, 0 failed, 0 flaky** (lifecycle case green, incl. the delete-sync removal step).
- `yarn typecheck` — ✅ 19/19 workspaces.

> Note: root `yarn lint` (`@open-mercato/app eslint .`) currently crashes with a pre-existing `eslint-plugin-react` ↔ ESLint 10.4.1 incompatibility (`contextOrFilename.getFilename is not a function`) on the generated `next-env.d.ts`. This is unrelated to this `.ts` test change and reproduces on a clean `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)