### PR TITLE
test(qa): stabilize flaky integration tests TC-MSG-009 and TC-AUTH-009

### DIFF
--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-009.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-009.spec.ts
@@ -29,13 +29,24 @@ test.describe('TC-AUTH-009: User Creation Validation Errors', () => {
 
     await page.getByRole('button', { name: 'Create' }).first().click();
 
-    // Submitting an invalid payload is blocked client-side: CrudForm keeps the
-    // user on the create route and surfaces the validation error by moving focus
-    // to the first invalid required field (organization). There is no top-level
-    // error alert on this form, so asserting on role="alert" is unreliable — it
-    // resolves to the Next.js route announcer and any transient info banners
-    // rather than a validation error, which flakes under strict mode in CI.
+    // Submitting without an organization is blocked by validation: the form
+    // stays on the create page and the required Organization <select> is flagged
+    // invalid and focused. Assert on the native validity state + focus rather
+    // than role="alert": the page can carry unrelated alert-role nodes (the
+    // Next.js route announcer and reactive notification banners), which makes a
+    // bare getByRole('alert') ambiguous and flaky across runs. The custom inline
+    // error text does not render deterministically because native constraint
+    // validation short-circuits the submit before the JS error state is shown.
     await expect(page).toHaveURL(/\/backend\/users\/create/);
-    await expect(page.locator('#organizationId')).toBeFocused();
+    const organizationSelect = page.locator('#organizationId');
+    await expect(organizationSelect).toBeFocused();
+    const validity = await organizationSelect.evaluate(
+      (element: HTMLSelectElement) => ({
+        valid: element.validity.valid,
+        valueMissing: element.validity.valueMissing,
+        value: element.value,
+      }),
+    );
+    expect(validity).toEqual({ valid: false, valueMissing: true, value: '' });
   });
 });

--- a/packages/core/src/modules/messages/__integration__/TC-MSG-009.spec.ts
+++ b/packages/core/src/modules/messages/__integration__/TC-MSG-009.spec.ts
@@ -72,8 +72,11 @@ async function openReplyFromHeader(page: Page): Promise<void> {
 test.describe('TC-MSG-009: Message Detail Inline Reply And Forward Composer', () => {
   test('should compose inline below conversation, switch modes, close with escape, and submit forward/reply', async ({ page, request }) => {
     // Multiple safeFill chains plus waitForResponse on submit; under CI shard 9
-    // parallel load each chain may consume ~10–80s of the default 20s budget.
-    test.setTimeout(180_000);
+    // parallel load each chain may consume well over the default 20s budget.
+    // test.slow() triples the per-test timeout (matches the repo idiom for heavy
+    // E2E); the inline-reply submit below uses a bounded waitForResponse so a
+    // load-induced hiccup fails fast instead of hanging the whole budget.
+    test.slow();
 
     let rootMessageId: string | null = null;
     let threadReplyMessageId: string | null = null;
@@ -162,30 +165,41 @@ test.describe('TC-MSG-009: Message Detail Inline Reply And Forward Composer', ()
       await expect(inlineReplyInput).toBeEnabled();
       await safeFill(page, inlineReplyInput, inlineReplyBody);
 
-      const inlineReplyResponsePromise = page.waitForResponse((response) => {
-        if (response.request().method() !== 'POST') return false;
-        let pathname = '';
-        try {
-          pathname = new URL(response.url()).pathname;
-        } catch {
-          return false;
-        }
-        if (!/^\/api\/messages\/[^/]+\/reply$/i.test(pathname)) return false;
-        const requestBody = response.request().postData() ?? '';
-        return requestBody.includes(inlineReplyBody);
-      });
+      // Match the inline reply POST by endpoint with a bounded timeout, then
+      // assert the request body separately. The previous predicate also required
+      // the POST body to include inlineReplyBody inline; under heavy parallel
+      // load, when React was slow to commit the controlled textarea value the
+      // submit fired a non-matching POST (or validation blocked it entirely), so
+      // the unbounded waitForResponse hung for the whole 180s test budget rather
+      // than failing fast. Endpoint-only matching plus an explicit 30s timeout
+      // turns that into a quick, loud failure that the global retry recovers,
+      // and the post-hoc body assertion still proves the typed reply was sent.
+      const inlineReplyResponsePromise = page.waitForResponse(
+        (response) => {
+          if (response.request().method() !== 'POST') return false;
+          let pathname = '';
+          try {
+            pathname = new URL(response.url()).pathname;
+          } catch {
+            return false;
+          }
+          return /^\/api\/messages\/[^/]+\/reply$/i.test(pathname);
+        },
+        { timeout: 30_000 },
+      );
+      // Re-assert the textarea still holds the body before submitting. CI shard 9
+      // traces show the inline composer occasionally drops controlled state
+      // between fill and click; asserting here makes that failure mode loud
+      // (assertion error) instead of a silent empty-body POST.
+      await expect(inlineReplyInput).toHaveValue(inlineReplyBody);
       // Click the composer submit button instead of pressing Ctrl+Enter — the
       // SwitchableMarkdownInput textarea (text mode) has no keyboard submit
       // handler, so Ctrl+Enter just inserts a newline. The composer header
       // renders a "Reply" submit button via FormHeader; .last() picks it
       // (the dropdown menu item is gone after openReplyFromHeader).
-      // Re-assert the textarea still holds the body. CI shard 9 trace shows
-      // the inline composer occasionally drops controlled state between fill
-      // and click — refilling here makes the failure mode loud (assertion
-      // error pointing at the resync) instead of a silent empty-body POST.
-      await expect(inlineReplyInput).toHaveValue(inlineReplyBody);
       await page.getByRole('button', { name: /^Reply$/i }).last().click();
       const inlineReplyResponse = await inlineReplyResponsePromise;
+      expect(inlineReplyResponse.request().postData() ?? '').toContain(inlineReplyBody);
 
       expect(inlineReplyResponse.ok()).toBeTruthy();
       const inlineReplyPayload = (await inlineReplyResponse.json()) as { id?: unknown };


### PR DESCRIPTION
## Summary

Ran **two full rounds** of the integration suite against `develop` using the ephemeral runner, classified failures, and stabilized the test-side issues. A **third confirmation round** after the fixes was fully green.

| Round | Result |
|-------|--------|
| 1 (fresh ephemeral) | 851 passed, 38 skipped, **1 failed** → `TC-AUTH-009` |
| 2 (fresh ephemeral) | 850 passed, 39 skipped, **1 flaky** → `TC-MSG-009` (passed on retry) |
| 3 (confirmation, both fixes) | **852 passed, 38 skipped, 0 failed, 0 flaky** ✅ |

Both issues were **test brittleness**, not product regressions.

## `TC-MSG-009` — Message detail inline reply/forward composer (flaky)

**Root cause.** The inline-reply submit pre-registered `page.waitForResponse` with a predicate that required the POST body to *include the typed reply text*. Under heavy 16-worker parallel load, when React was slow to commit the controlled textarea value the submit fired a non-matching POST (or native validation blocked it). Because the wait was unbounded, it then hung for the **entire `test.setTimeout(180_000)` budget (~3 minutes)** before failing — turning a transient timing hiccup into a hard, expensive failure.

**Fix.**
- Match the reply POST **by endpoint** with an explicit **30s timeout**, then assert the request body **separately** (`postData().toContain(body)`). A missed/slow submit now fails fast and loud — and the global `retries: 1` recovers it — instead of hanging the whole budget. The body assertion still proves the typed reply was actually sent.
- Replace the `test.setTimeout(180_000)` band-aid with the idiomatic **`test.slow()`** (60s). The test legitimately needs more than the 20s global budget under full-suite load (observed 21–22s happy-path runs at 6 workers), so `test.slow()` is the right ceiling — and 128 specs in this repo already use `test.slow()` / `test.setTimeout`.

## `TC-AUTH-009` — User-create validation (hardening)

`develop` had already removed this test's brittle `getByRole('alert')` assertion (it resolved to the Next.js route announcer and reactive notification banners → strict-mode violation; this is what failed in round 1 on the older base). This change **strengthens** the remaining check: rather than relying only on the focus side-effect, it asserts the required Organization `<select>` reports the **native constraint-validation failure** (`valid: false, valueMissing: true`) — the deterministic reason the submit is blocked.

## Verification

Ephemeral runner; local Chromium via the `ubuntu24.04` fallback build (`PLAYWRIGHT_HOST_PLATFORM_OVERRIDE`).

- `TC-MSG-009`: **8/8** green at 6 workers (including the 21–22s runs that exceed the bare 20s budget); 6/6 in isolation.
- `TC-AUTH-009`: **3/3** green (`--repeat-each`); green in full-suite rounds 2 and 3.

## Scope

Test-only change — two `.spec.ts` files, no product/runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
