### PR TITLE
fix(staff): serialize timesheets timer/segment writes with a locking transaction (#2416)

### DIFF
--- a/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/segments/[segmentId]/route.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/segments/[segmentId]/route.ts
@@ -6,7 +6,9 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { EntityManager } from '@mikro-orm/postgresql'
+import { LockMode } from '@mikro-orm/core'
 import { StaffTimeEntry, StaffTimeEntrySegment } from '../../../../../../data/entities'
 import { staffTimeEntrySegmentUpdateSchema } from '../../../../../../data/validators'
 import { getStaffMemberByUserId } from '../../../../../../lib/staffMemberResolver'
@@ -110,17 +112,54 @@ export async function PATCH(req: Request) {
     )
   }
 
-  if (parsed.data.startedAt !== undefined) {
-    segment.startedAt = parsed.data.startedAt
-  }
-  if (parsed.data.endedAt !== undefined) {
-    segment.endedAt = parsed.data.endedAt ?? null
-  }
-  if (parsed.data.segmentType !== undefined) {
-    segment.segmentType = parsed.data.segmentType
-  }
+  // Apply the segment edit inside a single transaction with a PESSIMISTIC_WRITE
+  // lock on the parent time entry row, re-loading the segment under the lock so
+  // concurrent segment edits / timer-stop recomputes on the same entry serialize
+  // instead of racing on a shared in-memory snapshot (issue #2416).
+  let updatedSegment: StaffTimeEntrySegment
+  try {
+    updatedSegment = await em.transactional(async (trx) => {
+      const lockedEntry = await findOneWithDecryption(
+        trx,
+        StaffTimeEntry,
+        { id: ids.entryId, tenantId, organizationId, deletedAt: null },
+        { lockMode: LockMode.PESSIMISTIC_WRITE },
+        scopeCtx,
+      )
+      if (!lockedEntry) {
+        throw new CrudHttpError(404, { error: 'Time entry not found' })
+      }
 
-  await em.flush()
+      const lockedSegment = await findOneWithDecryption(
+        trx,
+        StaffTimeEntrySegment,
+        { id: ids.segmentId, timeEntryId: ids.entryId, tenantId, organizationId, deletedAt: null },
+        {},
+        scopeCtx,
+      )
+      if (!lockedSegment) {
+        throw new CrudHttpError(404, { error: 'Segment not found' })
+      }
+
+      if (parsed.data.startedAt !== undefined) {
+        lockedSegment.startedAt = parsed.data.startedAt
+      }
+      if (parsed.data.endedAt !== undefined) {
+        lockedSegment.endedAt = parsed.data.endedAt ?? null
+      }
+      if (parsed.data.segmentType !== undefined) {
+        lockedSegment.segmentType = parsed.data.segmentType
+      }
+
+      await trx.flush()
+      return lockedSegment
+    })
+  } catch (err) {
+    if (isCrudHttpError(err)) {
+      return NextResponse.json(err.body, { status: err.status })
+    }
+    throw err
+  }
 
   if (guardResult.afterSuccessCallbacks.length) {
     await runStaffMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
@@ -128,7 +167,7 @@ export async function PATCH(req: Request) {
       organizationId,
       userId: auth.sub ?? '',
       resourceKind: 'staff.timesheets.time_entry_segment',
-      resourceId: segment.id,
+      resourceId: updatedSegment.id,
       operation: 'update',
       requestMethod: req.method,
       requestHeaders: req.headers,
@@ -138,13 +177,13 @@ export async function PATCH(req: Request) {
   return NextResponse.json({
     ok: true,
     item: {
-      id: segment.id,
-      timeEntryId: segment.timeEntryId,
-      startedAt: segment.startedAt,
-      endedAt: segment.endedAt,
-      segmentType: segment.segmentType,
-      createdAt: segment.createdAt,
-      updatedAt: segment.updatedAt,
+      id: updatedSegment.id,
+      timeEntryId: updatedSegment.timeEntryId,
+      startedAt: updatedSegment.startedAt,
+      endedAt: updatedSegment.endedAt,
+      segmentType: updatedSegment.segmentType,
+      createdAt: updatedSegment.createdAt,
+      updatedAt: updatedSegment.updatedAt,
     },
   })
 }

--- a/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/segments/route.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/segments/route.ts
@@ -9,6 +9,7 @@ import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import type { EntityManager } from '@mikro-orm/postgresql'
+import { LockMode } from '@mikro-orm/core'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { StaffTimeEntry, StaffTimeEntrySegment } from '../../../../../data/entities'
 import { staffTimeEntrySegmentCreateSchema } from '../../../../../data/validators'
@@ -109,17 +110,35 @@ export async function POST(req: Request) {
       )
     }
 
-    const segmentData = {
-      tenantId: input.tenantId,
-      organizationId: input.organizationId,
-      timeEntryId: input.timeEntryId,
-      startedAt: input.startedAt,
-      endedAt: input.endedAt ?? null,
-      segmentType: input.segmentType,
-    }
-    const segment = em.create(StaffTimeEntrySegment, segmentData as never)
+    // Create the segment inside a single transaction with a PESSIMISTIC_WRITE
+    // lock on the parent time entry row, so segment writes serialize against
+    // concurrent timer-stop / segment mutations that recompute the entry from a
+    // shared snapshot (issue #2416).
+    const segment = await em.transactional(async (trx) => {
+      const lockedEntry = await findOneWithDecryption(
+        trx,
+        StaffTimeEntry,
+        { id: entryId, tenantId, organizationId, deletedAt: null },
+        { lockMode: LockMode.PESSIMISTIC_WRITE },
+        scopeCtx,
+      )
+      if (!lockedEntry) {
+        throw new CrudHttpError(404, { error: translate('staff.timesheets.errors.entryNotFound', 'Time entry not found.') })
+      }
 
-    await em.flush()
+      const segmentData = {
+        tenantId: input.tenantId,
+        organizationId: input.organizationId,
+        timeEntryId: input.timeEntryId,
+        startedAt: input.startedAt,
+        endedAt: input.endedAt ?? null,
+        segmentType: input.segmentType,
+      }
+      const created = trx.create(StaffTimeEntrySegment, segmentData as never)
+
+      await trx.flush()
+      return created
+    })
 
     if (guardResult.afterSuccessCallbacks.length) {
       await runStaffMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {

--- a/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/timer-start/route.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/timer-start/route.ts
@@ -7,6 +7,7 @@ import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { EntityManager } from '@mikro-orm/postgresql'
+import { LockMode } from '@mikro-orm/core'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { StaffTimeEntry, StaffTimeEntrySegment } from '../../../../../data/entities'
 import { getStaffMemberByUserId } from '../../../../../lib/staffMemberResolver'
@@ -98,20 +99,43 @@ export async function POST(req: Request) {
       )
     }
 
-    const now = new Date()
-    entry.startedAt = now
-    entry.source = 'timer'
+    // Start the timer inside a single transaction with a PESSIMISTIC_WRITE lock
+    // on the time entry row, re-checking startedAt under the lock so two
+    // concurrent timer-start calls on the same entry cannot both create an
+    // initial work segment (issue #2416).
+    const now = await em.transactional(async (trx) => {
+      const lockedEntry = await findOneWithDecryption(
+        trx,
+        StaffTimeEntry,
+        { id: entryId, tenantId, organizationId, deletedAt: null },
+        { lockMode: LockMode.PESSIMISTIC_WRITE },
+        scopeCtx,
+      )
+      if (!lockedEntry) {
+        throw new CrudHttpError(404, { error: translate('staff.timesheets.errors.entryNotFound', 'Time entry not found.') })
+      }
+      if (lockedEntry.startedAt) {
+        throw new CrudHttpError(409, {
+          error: translate('staff.timesheets.errors.timerAlreadyStarted', 'Timer is already started for this entry.'),
+        })
+      }
 
-    const segmentData = {
-      tenantId,
-      organizationId,
-      timeEntryId: entry.id,
-      startedAt: now,
-      segmentType: 'work' as const,
-    }
-    em.create(StaffTimeEntrySegment, segmentData as never)
+      const startedAt = new Date()
+      lockedEntry.startedAt = startedAt
+      lockedEntry.source = 'timer'
 
-    await em.flush()
+      const segmentData = {
+        tenantId,
+        organizationId,
+        timeEntryId: lockedEntry.id,
+        startedAt,
+        segmentType: 'work' as const,
+      }
+      trx.create(StaffTimeEntrySegment, segmentData as never)
+
+      await trx.flush()
+      return startedAt
+    })
 
     void emitStaffEvent('staff.timesheets.time_entry.timer_started', {
       id: entry.id,

--- a/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/timer-stop/route.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/timer-stop/route.ts
@@ -7,6 +7,7 @@ import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { EntityManager } from '@mikro-orm/postgresql'
+import { LockMode } from '@mikro-orm/core'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { StaffTimeEntry, StaffTimeEntrySegment } from '../../../../../data/entities'
 import { getStaffMemberByUserId } from '../../../../../lib/staffMemberResolver'
@@ -70,22 +71,6 @@ export async function POST(req: Request) {
       throw new CrudHttpError(403, { error: translate('staff.timesheets.errors.notOwner', 'You can only manage your own time entries.') })
     }
 
-    const segments = await findWithDecryption(
-      em,
-      StaffTimeEntrySegment,
-      { timeEntryId: entry.id, tenantId, organizationId, deletedAt: null },
-      {},
-      scopeCtx,
-    )
-
-    const activeSegment = segments.find((segment) => !segment.endedAt)
-    if (!activeSegment) {
-      return NextResponse.json(
-        { error: translate('staff.timesheets.errors.noActiveSegment', 'No active timer segment found for this entry.') },
-        { status: 409 },
-      )
-    }
-
     const guardResult = await runStaffMutationGuards(
       container,
       {
@@ -107,29 +92,62 @@ export async function POST(req: Request) {
       )
     }
 
-    const now = new Date()
-    activeSegment.endedAt = now
-    entry.endedAt = now
-
-    const allSegments = segments.map((segment) => {
-      if (segment.id === activeSegment.id) {
-        return { ...segment, endedAt: now }
+    // Recompute and persist the timer state inside a single transaction with a
+    // PESSIMISTIC_WRITE lock on the time entry row, so concurrent timer-stop /
+    // segment writes on the same entry serialize instead of racing on a shared
+    // in-memory snapshot (issue #2416).
+    const { now, durationMinutes } = await em.transactional(async (trx) => {
+      const lockedEntry = await findOneWithDecryption(
+        trx,
+        StaffTimeEntry,
+        { id: entryId, tenantId, organizationId, deletedAt: null },
+        { lockMode: LockMode.PESSIMISTIC_WRITE },
+        scopeCtx,
+      )
+      if (!lockedEntry) {
+        throw new CrudHttpError(404, { error: translate('staff.timesheets.errors.entryNotFound', 'Time entry not found.') })
       }
-      return segment
+
+      const segments = await findWithDecryption(
+        trx,
+        StaffTimeEntrySegment,
+        { timeEntryId: lockedEntry.id, tenantId, organizationId, deletedAt: null },
+        {},
+        scopeCtx,
+      )
+
+      const activeSegment = segments.find((segment) => !segment.endedAt)
+      if (!activeSegment) {
+        throw new CrudHttpError(409, {
+          error: translate('staff.timesheets.errors.noActiveSegment', 'No active timer segment found for this entry.'),
+        })
+      }
+
+      const stoppedAt = new Date()
+      activeSegment.endedAt = stoppedAt
+      lockedEntry.endedAt = stoppedAt
+
+      const allSegments = segments.map((segment) => {
+        if (segment.id === activeSegment.id) {
+          return { ...segment, endedAt: stoppedAt }
+        }
+        return segment
+      })
+
+      const totalWorkMinutes = allSegments
+        .filter((segment) => segment.segmentType === 'work' && segment.startedAt && segment.endedAt)
+        .reduce((sum, segment) => {
+          const startMs = new Date(segment.startedAt).getTime()
+          const endMs = new Date(segment.endedAt!).getTime()
+          return sum + (endMs - startMs)
+        }, 0)
+
+      const computedMinutes = Math.round(totalWorkMinutes / 60000)
+      lockedEntry.durationMinutes = computedMinutes
+
+      await trx.flush()
+      return { now: stoppedAt, durationMinutes: computedMinutes }
     })
-
-    const totalWorkMinutes = allSegments
-      .filter((segment) => segment.segmentType === 'work' && segment.startedAt && segment.endedAt)
-      .reduce((sum, segment) => {
-        const startMs = new Date(segment.startedAt).getTime()
-        const endMs = new Date(segment.endedAt!).getTime()
-        return sum + (endMs - startMs)
-      }, 0)
-
-    const durationMinutes = Math.round(totalWorkMinutes / 60000)
-    entry.durationMinutes = durationMinutes
-
-    await em.flush()
 
     void emitStaffEvent('staff.timesheets.time_entry.timer_stopped', {
       id: entry.id,

--- a/packages/core/src/modules/staff/api/timesheets/time-entries/__tests__/timer-segment-atomic-write.test.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/__tests__/timer-segment-atomic-write.test.ts
@@ -1,0 +1,311 @@
+/** @jest-environment node */
+// Regression coverage for issue #2416: the timer/segment write endpoints must
+// perform their read-modify-write inside a single transaction with a
+// PESSIMISTIC_WRITE lock on the StaffTimeEntry row so concurrent requests on the
+// same entry serialize instead of racing on a shared in-memory snapshot.
+import { LockMode } from '@mikro-orm/core'
+import { StaffTimeEntry, StaffTimeEntrySegment } from '@open-mercato/core/modules/staff/data/entities'
+
+const mockFindOneWithDecryption = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockGetStaffMemberByUserId = jest.fn()
+const mockRunStaffMutationGuards = jest.fn()
+const mockRunStaffMutationGuardAfterSuccess = jest.fn()
+const mockEmitStaffEvent = jest.fn()
+const mockParseScopedCommandInput = jest.fn()
+
+const findOneOptions: Array<Record<string, unknown>> = []
+let transactionalCalls = 0
+let lastTrxFlushCount = 0
+
+const mockEm: Record<string, jest.Mock> = {
+  fork: jest.fn(),
+  create: jest.fn((_cls: unknown, data: Record<string, unknown>) => ({
+    id: 'segment-created',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...data,
+  })),
+  flush: jest.fn(async () => {
+    lastTrxFlushCount += 1
+  }),
+  transactional: jest.fn(async (callback: (trx: unknown) => Promise<unknown>) => {
+    transactionalCalls += 1
+    return callback(mockEm)
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (token: string) => {
+      if (token === 'em') return mockEm
+      return null
+    },
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    sub: 'user-1',
+    tenantId: 'tenant-1',
+    orgId: 'org-1',
+    roles: ['admin'],
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({
+    tenantId: 'tenant-1',
+    selectedId: 'org-1',
+    filterIds: ['org-1'],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+}))
+
+jest.mock('@open-mercato/core/modules/staff/lib/staffMemberResolver', () => ({
+  getStaffMemberByUserId: jest.fn((...args: unknown[]) => mockGetStaffMemberByUserId(...args)),
+}))
+
+jest.mock('@open-mercato/core/modules/staff/api/guards', () => ({
+  resolveUserFeatures: jest.fn(() => ['staff.timesheets.manage_own']),
+  runStaffMutationGuards: jest.fn((...args: unknown[]) => mockRunStaffMutationGuards(...args)),
+  runStaffMutationGuardAfterSuccess: jest.fn((...args: unknown[]) =>
+    mockRunStaffMutationGuardAfterSuccess(...args),
+  ),
+}))
+
+jest.mock('@open-mercato/core/modules/staff/events', () => ({
+  emitStaffEvent: jest.fn((...args: unknown[]) => mockEmitStaffEvent(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/api/scoped', () => ({
+  parseScopedCommandInput: jest.fn((...args: unknown[]) => mockParseScopedCommandInput(...args)),
+}))
+
+const ENTRY_ID = '11111111-1111-4111-8111-111111111111'
+const SEGMENT_ID = '22222222-2222-4222-8222-222222222222'
+const STAFF_MEMBER_ID = '33333333-3333-4333-8333-333333333333'
+
+function makeEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ENTRY_ID,
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    staffMemberId: STAFF_MEMBER_ID,
+    startedAt: null,
+    endedAt: null,
+    durationMinutes: 0,
+    source: 'manual',
+    ...overrides,
+  }
+}
+
+function lockOptionWasUsed() {
+  return findOneOptions.some((opt) => opt && opt.lockMode === LockMode.PESSIMISTIC_WRITE)
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  findOneOptions.length = 0
+  transactionalCalls = 0
+  lastTrxFlushCount = 0
+  mockEm.fork.mockReturnValue(mockEm)
+  mockGetStaffMemberByUserId.mockResolvedValue({ id: STAFF_MEMBER_ID })
+  mockRunStaffMutationGuards.mockResolvedValue({ ok: true, afterSuccessCallbacks: [] })
+  mockRunStaffMutationGuardAfterSuccess.mockResolvedValue(undefined)
+  mockEmitStaffEvent.mockResolvedValue(undefined)
+  mockFindOneWithDecryption.mockImplementation(async (_em, _cls, _where, opts) => {
+    if (opts) findOneOptions.push(opts)
+    return null
+  })
+  mockFindWithDecryption.mockResolvedValue([])
+})
+
+describe('timer-start atomic write (#2416)', () => {
+  function request() {
+    return new Request(`http://localhost/api/staff/timesheets/time-entries/${ENTRY_ID}/timer-start`, {
+      method: 'POST',
+    })
+  }
+
+  test('starts the timer inside a locking transaction', async () => {
+    mockFindOneWithDecryption.mockImplementation(async (_em, _cls, _where, opts) => {
+      if (opts) findOneOptions.push(opts)
+      return makeEntry()
+    })
+
+    const { POST } = await import('../[id]/timer-start/route')
+    const res = await POST(request())
+
+    expect(res.status).toBe(200)
+    expect(transactionalCalls).toBe(1)
+    expect(lockOptionWasUsed()).toBe(true)
+    expect(mockEm.create).toHaveBeenCalledWith(StaffTimeEntrySegment, expect.objectContaining({
+      timeEntryId: ENTRY_ID,
+      segmentType: 'work',
+    }))
+    expect(lastTrxFlushCount).toBe(1)
+  })
+
+  test('rejects a concurrent start when the lock observes startedAt already set', async () => {
+    let call = 0
+    mockFindOneWithDecryption.mockImplementation(async (_em, _cls, _where, opts) => {
+      if (opts) findOneOptions.push(opts)
+      call += 1
+      // First (unlocked) load races through; the locked re-read sees startedAt set.
+      return call === 1 ? makeEntry() : makeEntry({ startedAt: new Date('2026-01-01T00:00:00.000Z') })
+    })
+
+    const { POST } = await import('../[id]/timer-start/route')
+    const res = await POST(request())
+
+    expect(res.status).toBe(409)
+    expect(lockOptionWasUsed()).toBe(true)
+    expect(mockEm.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('timer-stop atomic write (#2416)', () => {
+  function request() {
+    return new Request(`http://localhost/api/staff/timesheets/time-entries/${ENTRY_ID}/timer-stop`, {
+      method: 'POST',
+    })
+  }
+
+  test('stops the timer and recomputes duration inside a locking transaction', async () => {
+    mockFindOneWithDecryption.mockImplementation(async (_em, _cls, _where, opts) => {
+      if (opts) findOneOptions.push(opts)
+      return makeEntry({ startedAt: new Date('2026-01-01T08:00:00.000Z') })
+    })
+    mockFindWithDecryption.mockResolvedValue([
+      {
+        id: SEGMENT_ID,
+        segmentType: 'work',
+        startedAt: new Date('2026-01-01T08:00:00.000Z'),
+        endedAt: null,
+      },
+    ])
+
+    const { POST } = await import('../[id]/timer-stop/route')
+    const res = await POST(request())
+    const body = (await res.json()) as Record<string, unknown>
+
+    expect(res.status).toBe(200)
+    expect(typeof body.durationMinutes).toBe('number')
+    expect(transactionalCalls).toBe(1)
+    expect(lockOptionWasUsed()).toBe(true)
+    expect(lastTrxFlushCount).toBe(1)
+  })
+
+  test('returns 409 when no active segment is found under the lock', async () => {
+    mockFindOneWithDecryption.mockImplementation(async (_em, _cls, _where, opts) => {
+      if (opts) findOneOptions.push(opts)
+      return makeEntry({ startedAt: new Date('2026-01-01T08:00:00.000Z') })
+    })
+    mockFindWithDecryption.mockResolvedValue([
+      {
+        id: SEGMENT_ID,
+        segmentType: 'work',
+        startedAt: new Date('2026-01-01T08:00:00.000Z'),
+        endedAt: new Date('2026-01-01T09:00:00.000Z'),
+      },
+    ])
+
+    const { POST } = await import('../[id]/timer-stop/route')
+    const res = await POST(request())
+
+    expect(res.status).toBe(409)
+    expect(lockOptionWasUsed()).toBe(true)
+    expect(lastTrxFlushCount).toBe(0)
+  })
+})
+
+describe('segment create atomic write (#2416)', () => {
+  function request() {
+    return new Request(`http://localhost/api/staff/timesheets/time-entries/${ENTRY_ID}/segments`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ startedAt: '2026-01-01T08:00:00.000Z', segmentType: 'work' }),
+    })
+  }
+
+  test('creates the segment inside a transaction that locks the parent entry', async () => {
+    mockFindOneWithDecryption.mockImplementation(async (_em, _cls, _where, opts) => {
+      if (opts) findOneOptions.push(opts)
+      return makeEntry()
+    })
+    mockParseScopedCommandInput.mockReturnValue({
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      timeEntryId: ENTRY_ID,
+      startedAt: new Date('2026-01-01T08:00:00.000Z'),
+      endedAt: null,
+      segmentType: 'work',
+    })
+
+    const { POST } = await import('../[id]/segments/route')
+    const res = await POST(request())
+
+    expect(res.status).toBe(201)
+    expect(transactionalCalls).toBe(1)
+    expect(lockOptionWasUsed()).toBe(true)
+    expect(mockEm.create).toHaveBeenCalledWith(StaffTimeEntrySegment, expect.objectContaining({
+      timeEntryId: ENTRY_ID,
+    }))
+    expect(lastTrxFlushCount).toBe(1)
+  })
+})
+
+describe('segment edit atomic write (#2416)', () => {
+  function request() {
+    return new Request(
+      `http://localhost/api/staff/timesheets/time-entries/${ENTRY_ID}/segments/${SEGMENT_ID}`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ segmentType: 'break' }),
+      },
+    )
+  }
+
+  test('updates the segment inside a transaction that locks the parent entry', async () => {
+    mockFindOneWithDecryption.mockImplementation(async (_em, cls, _where, opts) => {
+      if (opts) findOneOptions.push(opts)
+      if (cls === StaffTimeEntry) return makeEntry()
+      if (cls === StaffTimeEntrySegment) {
+        return {
+          id: SEGMENT_ID,
+          timeEntryId: ENTRY_ID,
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+          startedAt: new Date('2026-01-01T08:00:00.000Z'),
+          endedAt: null,
+          segmentType: 'work',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        }
+      }
+      return null
+    })
+
+    const { PATCH } = await import('../[id]/segments/[segmentId]/route')
+    const res = await PATCH(request())
+    const body = (await res.json()) as Record<string, unknown>
+
+    expect(res.status).toBe(200)
+    expect((body.item as Record<string, unknown>).segmentType).toBe('break')
+    expect(transactionalCalls).toBe(1)
+    expect(lockOptionWasUsed()).toBe(true)
+    expect(lastTrxFlushCount).toBe(1)
+  })
+})


### PR DESCRIPTION
Fixes #2416

## Problem
The timesheets timer/segment write endpoints performed an **unlocked read-modify-write** on `StaffTimeEntry` / `StaffTimeEntrySegment`: they loaded the entry + segments, recomputed `durationMinutes` in memory, then called a bare `em.flush()` with **no `em.transactional()` wrapper and no pessimistic lock**. Two genuinely concurrent requests on the same entry could interleave read and write, yielding lost/duplicated updates and inconsistent computed durations. This diverged from the sibling `bulk/route.ts` and from this release's atomic-write hardening (#2335–#2343).

Affected routes:
- `timesheets/time-entries/[id]/timer-start/route.ts`
- `timesheets/time-entries/[id]/timer-stop/route.ts`
- `timesheets/time-entries/[id]/segments/route.ts`
- `timesheets/time-entries/[id]/segments/[segmentId]/route.ts`

## Root Cause
The recompute-and-flush ran directly on a forked `EntityManager` with no transaction boundary and no row lock, so the read snapshot and the write were not serialized across concurrent requests.

## What Changed
- Each route now performs its read-modify-write inside `em.transactional(async (trx) => { ... })`, re-loading the `StaffTimeEntry` through `trx` with `LockMode.PESSIMISTIC_WRITE`, mirroring `sales/api/quotes/accept/route.ts`.
- State-dependent guards now run **under the lock**:
  - `timer-start`: re-checks `startedAt` under the lock → a concurrent second start cannot also create an initial work segment (returns `409`).
  - `timer-stop`: re-reads segments and the active-segment `409` guard under the lock, then recomputes `durationMinutes` and flushes atomically.
  - segment create/edit: lock the parent entry so segment writes serialize against concurrent timer recomputes.
- Auth/ownership checks and mutation guards remain outside the lock (no behavior change); only the authoritative read-modify-write moved inside the transaction. The segment-edit `PATCH` route gained a localized `CrudHttpError` → response mapping for the transactional block.

## Tests
- New `time-entries/__tests__/timer-segment-atomic-write.test.ts` (6 cases) asserting each route runs inside a locking transaction (`em.transactional` invoked, `LockMode.PESSIMISTIC_WRITE` used, flush via `trx`), plus the second concurrent `timer-start`/`timer-stop` is rejected under the lock.
- `yarn workspace @open-mercato/core test src/modules/staff` → 67 passed.
- `yarn typecheck --filter=@open-mercato/core` → passes.
- `yarn build:packages` + `yarn generate` → clean.

## Backward Compatibility
- No contract surface changes: same routes, methods, request/response shapes, status codes, event IDs, and ACL features. No DB schema change.