### PR TITLE
fix(ui): LookupSelect search input no longer clears typed text (#2389)

### DIFF
--- a/packages/ui/src/backend/inputs/LookupSelect.tsx
+++ b/packages/ui/src/backend/inputs/LookupSelect.tsx
@@ -85,11 +85,16 @@ export function LookupSelect({
   const [fetchKey, setFetchKey] = React.useState(0)
   const fetchItemsRef = React.useRef(fetchItems ?? fetchOptions)
   const setQueryRef = React.useRef(setQuery)
+  const onReadyRef = React.useRef(onReady)
   const optionsWasArrayRef = React.useRef(Array.isArray(options))
 
   React.useEffect(() => {
     fetchItemsRef.current = fetchItems ?? fetchOptions
   }, [fetchItems, fetchOptions])
+
+  React.useEffect(() => {
+    onReadyRef.current = onReady
+  }, [onReady])
 
   React.useEffect(() => {
     if (Array.isArray(options)) {
@@ -103,8 +108,8 @@ export function LookupSelect({
 
   React.useEffect(() => {
     setQueryRef.current = setQuery
-    if (onReady) onReady({ setQuery })
-  }, [onReady, setQuery])
+    if (onReadyRef.current) onReadyRef.current({ setQuery })
+  }, [setQuery])
 
   const shouldSearch =
     defaultOpen || query.trim().length >= minQuery || Boolean(value && (options?.length ?? 0) > 0)

--- a/packages/ui/src/backend/inputs/__tests__/LookupSelect.test.tsx
+++ b/packages/ui/src/backend/inputs/__tests__/LookupSelect.test.tsx
@@ -1,0 +1,88 @@
+/** @jest-environment jsdom */
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback: string) => fallback,
+}))
+
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { LookupSelect } from '../LookupSelect'
+
+function getInput(container: HTMLElement): HTMLInputElement {
+  const el = container.querySelector('input')
+  if (!el) throw new Error('input not found')
+  return el as HTMLInputElement
+}
+
+// Mirrors the inline editors in the sales document detail page: a parent that
+// re-renders (e.g. when a fetch toggles a loading flag) passes a brand-new
+// `onReady` callback each render, and that callback force-prefills the search
+// box. Regression for issue #2389 — typed text must survive parent re-renders.
+function PrefillHarness({ prefill = '' }: { prefill?: string }) {
+  const [, force] = React.useState(0)
+  return (
+    <div>
+      <LookupSelect
+        value={null}
+        onChange={() => {}}
+        fetchItems={async () => []}
+        onReady={({ setQuery }) => {
+          setQuery(prefill)
+        }}
+      />
+      <button type="button" data-testid="rerender" onClick={() => force((n) => n + 1)}>
+        rerender
+      </button>
+    </div>
+  )
+}
+
+describe('LookupSelect onReady stability', () => {
+  it('keeps the typed query after a parent re-render replaces onReady (issue #2389)', () => {
+    const { container } = render(<PrefillHarness prefill="" />)
+    const input = getInput(container)
+
+    fireEvent.change(input, { target: { value: 'Me' } })
+    expect(input.value).toBe('Me')
+
+    // Force a parent re-render — this hands LookupSelect a new onReady identity.
+    fireEvent.click(screen.getByTestId('rerender'))
+
+    expect(input.value).toBe('Me')
+  })
+
+  it('invokes onReady once on mount and not again on subsequent re-renders', () => {
+    const onReady = jest.fn()
+    function Harness() {
+      const [, force] = React.useState(0)
+      return (
+        <div>
+          {/* fresh inline callback every render — identity changes each time */}
+          <LookupSelect
+            value={null}
+            onChange={() => {}}
+            fetchItems={async () => []}
+            onReady={(controls) => onReady(controls)}
+          />
+          <button type="button" data-testid="rerender" onClick={() => force((n) => n + 1)}>
+            rerender
+          </button>
+        </div>
+      )
+    }
+
+    render(<Harness />)
+    expect(onReady).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByTestId('rerender'))
+    fireEvent.click(screen.getByTestId('rerender'))
+
+    expect(onReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('still prefills the search box once via onReady on mount', () => {
+    const { container } = render(<PrefillHarness prefill="Mercato Fashion Online" />)
+    const input = getInput(container)
+    expect(input.value).toBe('Mercato Fashion Online')
+  })
+})


### PR DESCRIPTION
Fixes #2389

## Problem
When editing a sales document that was created **without** a Sales Channel, the Sales Channel field could not be searched: after typing two characters the input cleared immediately, so no channel could be found or selected.

## Root Cause
`LookupSelect` (`packages/ui/src/backend/inputs/LookupSelect.tsx`) re-invoked its `onReady` callback on **every render** — the `onReady` effect listed `onReady` in its dependency array, and every consumer passes a brand-new inline callback each render.

The sales document detail page inline editors (`ChannelInlineEditor`, `MethodInlineEditor`) use `onReady` to *prefill* the search box with the currently-selected value. Typing ≥2 characters triggers a fetch that toggles a `loading` flag → parent re-render → `LookupSelect` sees a new `onReady` identity → re-runs the prefill → overwrites the user's typed text. For a document with no channel the prefill value is an empty string, so the typed characters were wiped entirely and the field became unsearchable. (The customer field worked because its `onReady` only stores the setter and never re-prefills.)

## What Changed
- `LookupSelect` now holds `onReady` in a ref and invokes it **once** when the control is ready (the `setQuery` setter is referentially stable). Re-renders no longer re-run consumer prefill logic, so typed input is preserved.
- This also fixes the identical defect in the shipping/payment **method** inline editors, which share the same primitive.
- No prop or type-signature changes; on-mount prefill behavior is preserved (verified by test).

## Tests
- New `packages/ui/src/backend/inputs/__tests__/LookupSelect.test.tsx`:
  - typed query survives a parent re-render that hands `LookupSelect` a new `onReady` identity (the issue #2389 regression — fails before the fix, passes after)
  - `onReady` is invoked exactly once across re-renders
  - the search box is still prefilled once via `onReady` on mount
- Full UI suite: 1387 tests pass (7 unrelated AiChat suites fail to *load* in this sandbox due to a missing generated `@open-mercato/ai-assistant` module — pre-existing env quirk, not touched by this change).
- `yarn workspace @open-mercato/ui typecheck` passes.

## Backward Compatibility
No contract surface changes. `onReady`'s type signature is unchanged. Firing it once when ready is the intended semantics; the previous repeated invocation was the bug. All in-repo consumers only use `onReady` to register the `setQuery` control and are unaffected (or fixed) by the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)