### PR TITLE
test(ui): fix CodeQL incomplete-URL-sanitization false positive in command-menu test

### DIFF
--- a/.ai/runs/2026-06-02-codeql-url-sanitization-command-menu-test.md
+++ b/.ai/runs/2026-06-02-codeql-url-sanitization-command-menu-test.md
@@ -72,3 +72,7 @@ Clear CodeQL alert #126 without changing test behavior or any product code.
 >   `core/src/generated-shims/entities.ids.generated.ts` (`#generated/*` missing
 >   because `yarn generate` has not run in this fresh worktree). No errors in the
 >   changed file.
+
+## Changelog
+
+- Opened as PR #2427 against `develop`. Status: complete.

--- a/.ai/runs/2026-06-02-codeql-url-sanitization-command-menu-test.md
+++ b/.ai/runs/2026-06-02-codeql-url-sanitization-command-menu-test.md
@@ -1,0 +1,64 @@
+# Fix CodeQL `js/incomplete-url-substring-sanitization` alert in command-menu test
+
+## Overview
+
+GitHub Advanced Security (CodeQL) raised one open code-scanning alert against the
+`develop` → `main` release PR [#2425](https://github.com/open-mercato/open-mercato/pull/2425):
+
+- **Alert #126** — `js/incomplete-url-substring-sanitization` (security-severity: high, classified `test`)
+  - File: `packages/ui/src/primitives/__tests__/command-menu.test.tsx:156`
+  - Message: *"'Monday.com' can be anywhere in the URL, and arbitrary hosts may come before or after it."*
+
+### Root cause
+
+The test locates a `CommandMenuItem` by its visible label:
+
+```ts
+const monday = Array.from(items).find((el) => el.textContent?.includes('Monday.com')) as HTMLElement
+```
+
+CodeQL's `js/incomplete-url-substring-sanitization` heuristic flags any `.includes()`
+of a host-like literal (`Monday.com` contains a `.com` TLD) as an incomplete URL host
+check that can be bypassed. Here the string is **not** a URL and the check is **not**
+security-sensitive — it is a DOM-text match in a unit test that finds the menu item
+whose label is `Monday.com`. This is a false positive driven purely by the literal
+shape.
+
+### Fix
+
+Match the item's label by exact (trimmed) equality instead of substring containment.
+This preserves the test's intent (find the item labeled exactly `Monday.com`), is
+actually more precise, and is not a substring/URL check, so the CodeQL heuristic no
+longer fires.
+
+## Goal
+
+Clear CodeQL alert #126 without changing test behavior or any product code.
+
+## Scope
+
+- `packages/ui/src/primitives/__tests__/command-menu.test.tsx` — single predicate change.
+
+## Non-goals
+
+- No changes to `CommandMenu` primitive or any product code.
+- No suppression/dismissal of the alert via config; fix the flagged pattern at source.
+- No changes to other tests or fixtures.
+
+## External References
+
+- None (`--skill-url` not provided).
+
+## Risks
+
+- Minimal. The exact-match predicate could fail if the rendered label carried extra
+  whitespace; `.trim()` guards against that. Verified by re-running the UI test suite.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Remediate alert #126
+
+- [ ] 1.1 Replace substring `.includes('Monday.com')` with exact trimmed label match
+- [ ] 1.2 Run UI package tests + typecheck to confirm green

--- a/.ai/runs/2026-06-02-codeql-url-sanitization-command-menu-test.md
+++ b/.ai/runs/2026-06-02-codeql-url-sanitization-command-menu-test.md
@@ -60,5 +60,15 @@ Clear CodeQL alert #126 without changing test behavior or any product code.
 
 ### Phase 1: Remediate alert #126
 
-- [ ] 1.1 Replace substring `.includes('Monday.com')` with exact trimmed label match
-- [ ] 1.2 Run UI package tests + typecheck to confirm green
+- [x] 1.1 Replace substring `.includes('Monday.com')` with exact trimmed label match — 4218d8e63
+- [x] 1.2 Run UI package tests + typecheck to confirm green — 4218d8e63
+
+> Validation notes:
+> - `NODE_ENV=test yarn workspace @open-mercato/ui test -- command-menu` → **12 passed, 12 total**.
+>   (The janitor shell defaults `NODE_ENV=production`, which makes React load its
+>   production bundle without `act`; every render test in the package fails until
+>   `NODE_ENV=test` is set — pre-existing and unrelated to this change.)
+> - UI typecheck reports only two pre-existing errors in
+>   `core/src/generated-shims/entities.ids.generated.ts` (`#generated/*` missing
+>   because `yarn generate` has not run in this fresh worktree). No errors in the
+>   changed file.

--- a/packages/ui/src/primitives/__tests__/command-menu.test.tsx
+++ b/packages/ui/src/primitives/__tests__/command-menu.test.tsx
@@ -153,7 +153,7 @@ describe('CommandMenu', () => {
     const onSelectMonday = jest.fn()
     render(<ExampleMenu onSelectMonday={onSelectMonday} />)
     const items = document.querySelectorAll('[data-slot="command-menu-item"]') as NodeListOf<HTMLElement>
-    const monday = Array.from(items).find((el) => el.textContent?.includes('Monday.com')) as HTMLElement
+    const monday = Array.from(items).find((el) => el.textContent?.trim() === 'Monday.com') as HTMLElement
     expect(monday).toBeTruthy()
     fireEvent.click(monday)
     expect(onSelectMonday).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-02-codeql-url-sanitization-command-menu-test.md
Status: complete

## Goal
- Clear the open GitHub Advanced Security (CodeQL) alert on release PR #2425: `js/incomplete-url-substring-sanitization` (#126, high), flagged in the `command-menu` unit test.

## What Changed
- `packages/ui/src/primitives/__tests__/command-menu.test.tsx`: locate the `Monday.com` command-menu item by **exact trimmed label** (`textContent?.trim() === 'Monday.com'`) instead of substring containment (`textContent?.includes('Monday.com')`).

### Why this clears the alert
CodeQL's `js/incomplete-url-substring-sanitization` heuristic treats any `.includes()` of a host-shaped literal (`Monday.com` ends in a `.com` TLD) as an incomplete URL host check that an attacker could bypass. In this test the string is a **DOM label**, not a URL, and the match drives no security decision — it just finds the menu item to click. Switching to exact-label equality removes the substring/URL pattern entirely while making the lookup more precise. No product code is touched.

## Tests
- `NODE_ENV=test yarn workspace @open-mercato/ui test -- command-menu` → **12 passed, 12 total** (includes the `fires onSelect when an item is clicked` test that owns the changed line).
- No new test needed: the change is inside the existing test and preserves its behavior.

## Backward Compatibility
- No contract surface changes. Test-only edit; no API, types, event IDs, exports, DB schema, or DI names affected.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-02-codeql-url-sanitization-command-menu-test.md#progress).
