### PR TITLE
fix(customers): allow optional pipeline stage appearance

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-022.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-022.spec.ts
@@ -29,13 +29,52 @@ test.describe('TC-CRM-022: Pipeline Stage CRUD and Reorder', () => {
     let pipelineId: string | null = null;
     try {
       pipelineId = await createTestPipeline(request, token);
+      const label = `Prospecting ${Date.now()}`;
       const res = await apiRequest(request, 'POST', '/api/customers/pipeline-stages', {
         token,
-        data: { pipelineId, label: 'Prospecting' },
+        data: { pipelineId, label },
       });
       expect(res.ok(), `POST stage failed: ${res.status()}`).toBeTruthy();
       const body = await res.json() as Record<string, unknown>;
       expect(typeof body.id).toBe('string');
+
+      const listRes = await apiRequest(request, 'GET', `/api/customers/pipeline-stages?pipelineId=${encodeURIComponent(pipelineId)}`, { token });
+      expect(listRes.ok(), `GET stages failed: ${listRes.status()}`).toBeTruthy();
+      const listBody = await listRes.json() as Record<string, unknown>;
+      const items = listBody.items as Array<Record<string, unknown>>;
+      const created = items.find((stage) => stage.id === body.id);
+      expect(created?.label).toBe(label);
+      expect(created?.color).toBeNull();
+      expect(created?.icon).toBeNull();
+    } finally {
+      if (pipelineId) await deletePipeline(request, token, pipelineId);
+    }
+  });
+
+  test('should clear optional stage appearance with null values', async ({ request }) => {
+    let pipelineId: string | null = null;
+    try {
+      pipelineId = await createTestPipeline(request, token);
+      const createRes = await apiRequest(request, 'POST', '/api/customers/pipeline-stages', {
+        token,
+        data: { pipelineId, label: 'Styled Stage', color: '#2563eb', icon: 'lucide:star' },
+      });
+      expect(createRes.ok(), `POST styled stage failed: ${createRes.status()}`).toBeTruthy();
+      const stageId = ((await createRes.json()) as Record<string, unknown>).id as string;
+
+      const updateRes = await apiRequest(request, 'PUT', '/api/customers/pipeline-stages', {
+        token,
+        data: { id: stageId, color: null, icon: null },
+      });
+      expect(updateRes.ok(), `PUT clear stage appearance failed: ${updateRes.status()}`).toBeTruthy();
+
+      const listRes = await apiRequest(request, 'GET', `/api/customers/pipeline-stages?pipelineId=${encodeURIComponent(pipelineId)}`, { token });
+      expect(listRes.ok(), `GET stages failed: ${listRes.status()}`).toBeTruthy();
+      const listBody = await listRes.json() as Record<string, unknown>;
+      const items = listBody.items as Array<Record<string, unknown>>;
+      const updated = items.find((stage) => stage.id === stageId);
+      expect(updated?.color).toBeNull();
+      expect(updated?.icon).toBeNull();
     } finally {
       if (pipelineId) await deletePipeline(request, token, pipelineId);
     }

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { login } from '@open-mercato/core/helpers/integration/auth';
+import { getAuthToken, apiRequest } from '@open-mercato/core/helpers/integration/api';
+
+/**
+ * TC-CRM-072: Pipeline Stage Optional Appearance UI
+ */
+test.describe('TC-CRM-072: Pipeline Stage Optional Appearance UI', () => {
+  test('should create a pipeline stage without color or icon from settings', async ({ page, request }) => {
+    const token = await getAuthToken(request);
+    const timestamp = Date.now();
+    const pipelineName = `QA optional appearance ${timestamp}`;
+    const stageName = `QA stage no appearance ${timestamp}`;
+    let pipelineId: string | null = null;
+
+    try {
+      await login(page, 'admin');
+      await page.goto('/backend/config/customers/pipeline-stages');
+
+      await page.getByRole('button', { name: /add pipeline/i }).click();
+      const pipelineDialog = page.getByRole('dialog', { name: /create pipeline/i });
+      await expect(pipelineDialog).toBeVisible();
+      await pipelineDialog.getByRole('textbox', { name: /pipeline name/i }).fill(pipelineName);
+      await pipelineDialog.getByRole('button', { name: /^save$/i }).click();
+
+      await expect(page.getByText(pipelineName, { exact: false })).toBeVisible();
+      const pipelinesRes = await apiRequest(request, 'GET', '/api/customers/pipelines', { token });
+      expect(pipelinesRes.ok(), `GET pipelines failed: ${pipelinesRes.status()}`).toBeTruthy();
+      const pipelinesBody = await pipelinesRes.json() as Record<string, unknown>;
+      const pipelines = pipelinesBody.items as Array<Record<string, unknown>>;
+      const pipeline = pipelines.find((item) => item.name === pipelineName);
+      expect(pipeline?.id, 'Created pipeline should be visible through API').toBeTruthy();
+      pipelineId = pipeline?.id as string;
+
+      await page.getByRole('button', { name: /add stage/i }).click();
+      const stageDialog = page.getByRole('dialog', { name: /create stage/i });
+      await expect(stageDialog).toBeVisible();
+      await stageDialog.getByRole('textbox', { name: /stage name/i }).fill(stageName);
+      await stageDialog.getByRole('button', { name: /^save$/i }).click();
+
+      await expect(page.getByText(stageName, { exact: true })).toBeVisible();
+
+      const stagesRes = await apiRequest(
+        request,
+        'GET',
+        `/api/customers/pipeline-stages?pipelineId=${encodeURIComponent(pipelineId)}`,
+        { token },
+      );
+      expect(stagesRes.ok(), `GET stages failed: ${stagesRes.status()}`).toBeTruthy();
+      const stagesBody = await stagesRes.json() as Record<string, unknown>;
+      const stages = stagesBody.items as Array<Record<string, unknown>>;
+      const stage = stages.find((item) => item.label === stageName);
+      expect(stage?.color).toBeNull();
+      expect(stage?.icon).toBeNull();
+    } finally {
+      if (pipelineId) {
+        await apiRequest(request, 'DELETE', '/api/customers/pipelines', { token, data: { id: pipelineId } }).catch(() => {});
+      }
+    }
+  });
+});

--- a/packages/core/src/modules/customers/backend/config/customers/pipeline-stages/page.tsx
+++ b/packages/core/src/modules/customers/backend/config/customers/pipeline-stages/page.tsx
@@ -209,9 +209,13 @@ export default function PipelineStagesPage() {
     setSaving(true)
     try {
       if (stageDialog?.mode === 'create') {
+        const appearancePayload = {
+          ...(stageColor !== null ? { color: stageColor } : {}),
+          ...(stageIcon !== null ? { icon: stageIcon } : {}),
+        }
         const result = await apiCall('/api/customers/pipeline-stages', {
           method: 'POST',
-          body: JSON.stringify({ pipelineId: selectedPipelineId, label: stageName.trim(), color: stageColor, icon: stageIcon }),
+          body: JSON.stringify({ pipelineId: selectedPipelineId, label: stageName.trim(), ...appearancePayload }),
           headers: { 'Content-Type': 'application/json' },
         })
         if (!result.ok) {

--- a/packages/core/src/modules/customers/data/validators.ts
+++ b/packages/core/src/modules/customers/data/validators.ts
@@ -580,16 +580,16 @@ export const pipelineStageCreateSchema = scopedSchema.extend({
   pipelineId: uuid(),
   label: z.string().trim().min(1).max(200),
   order: z.number().int().min(0).optional(),
-  color: z.string().trim().max(20).optional(),
-  icon: z.string().trim().max(100).optional(),
+  color: z.string().trim().max(20).nullish(),
+  icon: z.string().trim().max(100).nullish(),
 })
 
 export const pipelineStageUpdateSchema = z.object({
   id: uuid(),
   label: z.string().trim().min(1).max(200).optional(),
   order: z.number().int().min(0).optional(),
-  color: z.string().trim().max(20).optional(),
-  icon: z.string().trim().max(100).optional(),
+  color: z.string().trim().max(20).nullish(),
+  icon: z.string().trim().max(100).nullish(),
 })
 
 export const pipelineStageDeleteSchema = z.object({


### PR DESCRIPTION
## Summary

- Allows customer pipeline stage `color` and `icon` to be omitted or sent as `null` in create/update payloads.
- Keeps create-stage UI from sending empty appearance fields while preserving edit-stage clearing via `null`.
- Adds API and UI integration coverage for stages without appearance.

## Backward compatibility

- No route, schema field, DB, ACL, event, or widget spot removals.
- Request handling is additive: existing string appearance values still work, and `null` is now accepted for clearing optional appearance.
- Response shape remains unchanged: stages without appearance return `color: null` and `icon: null`.

## Integration coverage

- `TC-CRM-022` now verifies creating a stage with only `pipelineId` + `label` and clearing appearance with `null`.
- `TC-CRM-072` covers the settings UI flow for creating a stage without selecting color/icon.

## Testing

- `corepack yarn install --immutable`
- `corepack yarn build:packages`
- `corepack yarn generate`
- `corepack yarn build:packages`
- `BASE_URL=http://127.0.0.1:5001 corepack yarn exec playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/customers/__integration__/TC-CRM-022.spec.ts packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts --retries=0` — 8 passed
- `corepack yarn typecheck`

## Notes

`yarn generate` completed successfully but printed an esbuild service deadlock stack while exiting; the subsequent `build:packages`, targeted integration tests, and `typecheck` all passed.
