### PR TITLE
feat(ui): adopt RecordNotFoundState across throw-on-load edit pages (Phase 4, #2101)

### DIFF
--- a/apps/mercato/src/modules/example/backend/todos/[id]/edit/page.tsx
+++ b/apps/mercato/src/modules/example/backend/todos/[id]/edit/page.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { useRouter } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { CrudForm, type CrudField, type CrudFormGroup } from '@open-mercato/ui/backend/CrudForm'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { fetchCrudList, updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { pushWithFlash } from '@open-mercato/ui/backend/utils/flash'
 import { SendObjectMessageDialog } from '@open-mercato/ui/backend/messages'
@@ -25,6 +26,7 @@ export default function EditTodoPage({ params }: { params?: { id?: string } }) {
   const [initial, setInitial] = React.useState<TodoFormValues | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [err, setErr] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   // Memoize fields to avoid recreating arrays/objects each render (prevents focus loss)
   const baseFields = React.useMemo<CrudField[]>(() => [
     {
@@ -76,10 +78,14 @@ export default function EditTodoPage({ params }: { params?: { id?: string } }) {
       if (!id) return
       setLoading(true)
       setErr(null)
+      setIsNotFound(false)
       try {
         const data = await fetchCrudList<TodoItem>('example/todos', { id: String(id), pageSize: 1 })
         const item = data?.items?.[0]
-        if (!item) throw new Error(t('example.todos.form.error.notFound'))
+        if (!item) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         // Map to form initial values
         const extended = item as TodoItem & Record<string, unknown>
         const cfInit = extractCustomFieldEntries(extended) as Partial<TodoCustomFieldValues>
@@ -92,8 +98,12 @@ export default function EditTodoPage({ params }: { params?: { id?: string } }) {
         if (!cancelled) setInitial(init)
       } catch (error: unknown) {
         if (!cancelled) {
-          const message = error instanceof Error && error.message ? error.message : t('example.todos.form.error.load')
-          setErr(message)
+          if ((error as { status?: number }).status === 404) {
+            setIsNotFound(true)
+          } else {
+            const message = error instanceof Error && error.message ? error.message : t('example.todos.form.error.load')
+            setErr(message)
+          }
         }
       } finally {
         if (!cancelled) setLoading(false)
@@ -111,11 +121,25 @@ export default function EditTodoPage({ params }: { params?: { id?: string } }) {
 
   if (!id) return null
 
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('example.todos.form.error.notFound')}
+            backHref="/backend/todos"
+            backLabel={t('example.todos.form.actions.backToList', 'Back to todos')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
   return (
     <Page>
       <PageBody>
         {err ? (
-          <div className="text-red-600">{err}</div>
+          <ErrorMessage label={err} />
         ) : (
           <CrudForm<TodoFormValues>
             title={t('example.todos.form.edit.title')}

--- a/packages/core/src/modules/catalog/backend/catalog/categories/[id]/edit/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/categories/[id]/edit/page.tsx
@@ -7,6 +7,7 @@ import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customFieldValues'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { extractCustomFieldEntries } from '@open-mercato/shared/lib/crud/custom-fields-client'
 import { E } from '#generated/entities.ids.generated'
@@ -81,6 +82,7 @@ export default function EditCatalogCategoryPage({ params }: { params?: { id?: st
   const [pathLabel, setPathLabel] = React.useState<string>('')
   const [loading, setLoading] = React.useState<boolean>(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState<boolean>(false)
 
   React.useEffect(() => {
     if (!categoryId) return
@@ -88,13 +90,23 @@ export default function EditCatalogCategoryPage({ params }: { params?: { id?: st
     async function load() {
       setLoading(true)
       setError(null)
+      setIsNotFound(false)
       try {
-        const { ok, result } = await apiCall<CategoryResponse>(
+        const { ok, status, result } = await apiCall<CategoryResponse>(
           `/api/catalog/categories?view=manage&ids=${encodeURIComponent(categoryId)}&status=all&page=1&pageSize=1`,
         )
-        if (!ok) throw new Error(t('catalog.categories.form.errors.load', 'Failed to load category'))
+        if (!ok) {
+          if (status === 404) {
+            if (!cancelled) setIsNotFound(true)
+            return
+          }
+          throw new Error(t('catalog.categories.form.errors.load', 'Failed to load category'))
+        }
         const record = Array.isArray(result?.items) ? result.items?.[0] : null
-        if (!record) throw new Error(t('catalog.categories.form.errors.notFound', 'Category not found'))
+        if (!record) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         if (cancelled) return
         const customValues = extractCustomFieldEntries(record as Record<string, unknown>)
         setInitialValues({
@@ -191,14 +203,33 @@ export default function EditCatalogCategoryPage({ params }: { params?: { id?: st
     )
   }
 
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('catalog.categories.form.errors.notFound', 'Category not found')}
+            backHref="/backend/catalog/categories"
+            backLabel={t('catalog.categories.form.actions.backToList', 'Back to categories')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
+  if (error && !loading) {
+    return (
+      <Page>
+        <PageBody>
+          <ErrorMessage label={error} />
+        </PageBody>
+      </Page>
+    )
+  }
+
   return (
     <Page>
       <PageBody>
-        {error ? (
-          <div className="mb-4 rounded border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            {error}
-          </div>
-        ) : null}
         <CrudForm<CategoryFormValues>
           title={t('catalog.categories.form.editTitle', 'Edit category')}
           backHref="/backend/catalog/categories"

--- a/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/[variantId]/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/[variantId]/page.tsx
@@ -9,7 +9,7 @@ import { createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors
 import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customFieldValues'
 import { apiCall, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
-import { ErrorMessage } from '@open-mercato/ui/backend/detail'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { extractCustomFieldEntries } from '@open-mercato/shared/lib/crud/custom-fields-client'
 import { E } from '#generated/entities.ids.generated'
@@ -95,6 +95,7 @@ export default function EditVariantPage({ params }: { params?: { productId?: str
   const [existingPriceIds, setExistingPriceIds] = React.useState<Record<string, string>>({})
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [currentProductId, setCurrentProductId] = React.useState<string | null>(productId)
   const [productTitle, setProductTitle] = React.useState<string>('')
   const [productTaxRateId, setProductTaxRateId] = React.useState<string | null>(null)
@@ -162,13 +163,23 @@ export default function EditVariantPage({ params }: { params?: { productId?: str
     async function load() {
       setLoading(true)
       setError(null)
+      setIsNotFound(false)
       try {
         const variantRes = await apiCall<VariantResponse>(
           `/api/catalog/variants?id=${encodeURIComponent(variantId!)}&page=1&pageSize=1`,
         )
-        if (!variantRes.ok) throw new Error(t('catalog.variants.form.errors.load', 'Failed to load variant.'))
+        if (!variantRes.ok) {
+          if (variantRes.status === 404) {
+            if (!cancelled) setIsNotFound(true)
+            return
+          }
+          throw new Error(t('catalog.variants.form.errors.load', 'Failed to load variant.'))
+        }
         const record = Array.isArray(variantRes.result?.items) ? variantRes.result?.items?.[0] : undefined
-        if (!record) throw new Error(t('catalog.variants.form.errors.notFound', 'Variant not found.'))
+        if (!record) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         const resolvedProductId =
           typeof record.product_id === 'string'
             ? record.product_id
@@ -418,12 +429,33 @@ export default function EditVariantPage({ params }: { params?: { productId?: str
     : t('catalog.variants.form.editTitle', 'Edit variant')
   const productVariantsHref = `/backend/catalog/products/${currentProductId}#variants`
 
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('catalog.variants.form.errors.notFound', 'Variant not found.')}
+            backHref={productVariantsHref}
+            backLabel={t('catalog.variants.form.actions.backToProduct', 'Back to product variants')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
+  if (error && !loading) {
+    return (
+      <Page>
+        <PageBody>
+          <ErrorMessage label={error} />
+        </PageBody>
+      </Page>
+    )
+  }
+
   return (
     <Page>
       <PageBody>
-        {error ? (
-          <ErrorMessage label={error} className="mb-4" />
-        ) : null}
         <CrudForm<VariantFormValues>
           title={formTitle}
           backHref={productVariantsHref}

--- a/packages/core/src/modules/directory/backend/directory/organizations/[id]/edit/page.tsx
+++ b/packages/core/src/modules/directory/backend/directory/organizations/[id]/edit/page.tsx
@@ -16,6 +16,7 @@ import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { deleteCrud, updateCrud } from '@open-mercato/ui/backend/utils/crud'
 import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customFieldValues'
 import { createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 
 type TreeResponse = {
   items: OrganizationTreeNode[]
@@ -48,6 +49,7 @@ export default function EditOrganizationPage({ params }: { params?: { id?: strin
   const [tenantId, setTenantId] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [parentTree, setParentTree] = React.useState<OrganizationTreeNode[]>([])
   const [childSummary, setChildSummary] = React.useState<OrganizationTreeOption[]>([])
   const [originalChildIds, setOriginalChildIds] = React.useState<string[]>([])
@@ -107,13 +109,23 @@ export default function EditOrganizationPage({ params }: { params?: { id?: strin
     async function load() {
       setLoading(true)
       setError(null)
+      setIsNotFound(false)
       try {
-        const { ok, result } = await apiCall<OrganizationResponse>(
+        const { ok, status, result } = await apiCall<OrganizationResponse>(
           `/api/directory/organizations?view=manage&ids=${currentOrgId}&status=all&includeInactive=true&page=1&pageSize=1`,
         )
-        if (!ok) throw new Error(t('directory.organizations.form.errors.load', 'Failed to load organization'))
+        if (!ok) {
+          if (status === 404) {
+            if (!cancelled) setIsNotFound(true)
+            return
+          }
+          throw new Error(t('directory.organizations.form.errors.load', 'Failed to load organization'))
+        }
         const record = Array.isArray(result?.items) ? result.items?.[0] : undefined
-        if (!record) throw new Error(t('directory.organizations.form.errors.notFound', 'Organization not found'))
+        if (!record) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         const resolvedTenantId = record.tenantId || null
         setTenantId(resolvedTenantId)
         const baseTree = await loadParentTree(resolvedTenantId, record.descendantIds ?? [])
@@ -263,11 +275,25 @@ export default function EditOrganizationPage({ params }: { params?: { id?: strin
     )
   }
 
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('directory.organizations.form.errors.notFound', 'Organization not found')}
+            backHref="/backend/directory/organizations"
+            backLabel={t('directory.organizations.form.actions.backToList', 'Back to organizations')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
   if (error && !loading && !initialValues) {
     return (
       <Page>
         <PageBody>
-          <div className="rounded border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">{error}</div>
+          <ErrorMessage label={error} />
         </PageBody>
       </Page>
     )

--- a/packages/core/src/modules/directory/backend/directory/tenants/[id]/edit/page.tsx
+++ b/packages/core/src/modules/directory/backend/directory/tenants/[id]/edit/page.tsx
@@ -7,6 +7,7 @@ import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customF
 import { updateCrud } from '@open-mercato/ui/backend/utils/crud'
 import { raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { readApiResultOrThrow, apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { extractCustomFieldEntries } from '@open-mercato/shared/lib/crud/custom-fields-client'
 
@@ -21,6 +22,7 @@ export default function EditTenantPage({ params }: { params?: { id?: string } })
   const [initial, setInitial] = React.useState<TenantFormValues | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const t = useT()
   const fields = React.useMemo<CrudField[]>(() => [
     { id: 'name', label: t('directory.tenants.form.fields.name', 'Name'), type: 'text', required: true },
@@ -37,6 +39,7 @@ export default function EditTenantPage({ params }: { params?: { id?: string } })
       if (!tenantId) return
       setLoading(true)
       setError(null)
+      setIsNotFound(false)
       try {
         const data = await readApiResultOrThrow<{ items?: Record<string, unknown>[] }>(
           `/api/directory/tenants?id=${encodeURIComponent(tenantId)}`,
@@ -45,7 +48,10 @@ export default function EditTenantPage({ params }: { params?: { id?: string } })
         )
         const rows = Array.isArray(data?.items) ? data.items : []
         const row = rows[0]
-        if (!row) throw new Error(t('directory.tenants.form.errors.notFound', 'Tenant not found'))
+        if (!row) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         const cfValues = extractCustomFieldEntries(row as Record<string, unknown>)
         const values: TenantFormValues = {
           id: String(row.id),
@@ -56,8 +62,12 @@ export default function EditTenantPage({ params }: { params?: { id?: string } })
         if (!cancelled) setInitial(values)
       } catch (err) {
         if (!cancelled) {
-          const message = err instanceof Error ? err.message : t('directory.tenants.form.errors.load', 'Failed to load tenant')
-          setError(message)
+          if ((err as { status?: number }).status === 404) {
+            setIsNotFound(true)
+          } else {
+            const message = err instanceof Error ? err.message : t('directory.tenants.form.errors.load', 'Failed to load tenant')
+            setError(message)
+          }
         }
       } finally {
         if (!cancelled) setLoading(false)
@@ -69,13 +79,25 @@ export default function EditTenantPage({ params }: { params?: { id?: string } })
 
   if (!tenantId) return null
 
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('directory.tenants.form.errors.notFound', 'Tenant not found')}
+            backHref="/backend/directory/tenants"
+            backLabel={t('directory.tenants.form.actions.backToList', 'Back to tenants')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
   if (error && !loading && !initial) {
     return (
       <Page>
         <PageBody>
-          <div className="rounded border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-            {error}
-          </div>
+          <ErrorMessage label={error} />
         </PageBody>
       </Page>
     )

--- a/packages/core/src/modules/planner/backend/planner/availability-rulesets/[id]/page.tsx
+++ b/packages/core/src/modules/planner/backend/planner/availability-rulesets/[id]/page.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { useRouter } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { Button } from '@open-mercato/ui/primitives/button'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
@@ -40,6 +41,8 @@ export default function PlannerAvailabilityRuleSetDetailPage({ params }: { param
   const translate = useT()
   const router = useRouter()
   const [initialValues, setInitialValues] = React.useState<AvailabilityRuleSetFormValues | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [activeTab, setActiveTab] = React.useState<'details' | 'availability'>('details')
 
   React.useEffect(() => {
@@ -47,6 +50,10 @@ export default function PlannerAvailabilityRuleSetDetailPage({ params }: { param
     const rulesetIdValue = rulesetId
     let cancelled = false
     async function loadRuleSet() {
+      if (!cancelled) {
+        setError(null)
+        setIsNotFound(false)
+      }
       try {
         const params = new URLSearchParams({ page: '1', pageSize: '1', ids: rulesetIdValue })
         const payload = await readApiResultOrThrow<RuleSetResponse>(
@@ -55,7 +62,10 @@ export default function PlannerAvailabilityRuleSetDetailPage({ params }: { param
           { errorMessage: translate('planner.availabilityRuleSets.form.errors.load', 'Failed to load schedule.') },
         )
         const record = Array.isArray(payload.items) ? payload.items[0] : null
-        if (!record) throw new Error(translate('planner.availabilityRuleSets.form.errors.notFound', 'Schedule not found.'))
+        if (!record) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         const customFields = extractCustomFieldEntries(record)
         if (!cancelled) {
           setInitialValues({
@@ -66,9 +76,15 @@ export default function PlannerAvailabilityRuleSetDetailPage({ params }: { param
             ...customFields,
           })
         }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : translate('planner.availabilityRuleSets.form.errors.load', 'Failed to load schedule.')
-        flash(message, 'error')
+      } catch (err) {
+        if (!cancelled) {
+          if ((err as { status?: number }).status === 404) {
+            setIsNotFound(true)
+          } else {
+            const message = err instanceof Error ? err.message : translate('planner.availabilityRuleSets.form.errors.load', 'Failed to load schedule.')
+            setError(message)
+          }
+        }
       }
     }
     loadRuleSet()
@@ -149,6 +165,30 @@ export default function PlannerAvailabilityRuleSetDetailPage({ params }: { param
   ]), [translate])
 
   const resolvedInitialValues = initialValues ?? {}
+
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={translate('planner.availabilityRuleSets.form.errors.notFound', 'Schedule not found.')}
+            backHref="/backend/planner/availability-rulesets"
+            backLabel={translate('planner.availabilityRuleSets.actions.backToList', 'Back to schedules')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
+  if (error && !initialValues) {
+    return (
+      <Page>
+        <PageBody>
+          <ErrorMessage label={error} />
+        </PageBody>
+      </Page>
+    )
+  }
 
   return (
     <Page>

--- a/packages/core/src/modules/sales/backend/sales/channels/[channelId]/edit/page.tsx
+++ b/packages/core/src/modules/sales/backend/sales/channels/[channelId]/edit/page.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { CrudForm } from '@open-mercato/ui/backend/CrudForm'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customFieldValues'
 import { updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
@@ -28,6 +29,7 @@ export default function EditChannelPage({ params }: { params?: { channelId?: str
   const [initialValues, setInitialValues] = React.useState<ChannelFormValues | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [activeTab, setActiveTab] = React.useState<'settings' | 'offers'>('settings')
 
   React.useEffect(() => {
@@ -45,6 +47,7 @@ export default function EditChannelPage({ params }: { params?: { channelId?: str
     async function loadChannel() {
       setLoading(true)
       setError(null)
+      setIsNotFound(false)
       try {
         const payload = await readApiResultOrThrow<ChannelApiResponse>(
           `/api/sales/channels?id=${encodeURIComponent(channelId)}&pageSize=1`,
@@ -53,14 +56,21 @@ export default function EditChannelPage({ params }: { params?: { channelId?: str
         )
         const item = Array.isArray(payload.items) ? payload.items[0] : null
         if (!item) {
-          throw new Error(t('sales.channels.form.errors.notFound', 'Channel not found.'))
+          if (!cancelled) setIsNotFound(true)
+          return
         }
         if (!cancelled) {
           setInitialValues(mapChannelToFormValues(item))
         }
       } catch (err) {
         console.error('sales.channels.load', err)
-        if (!cancelled) setError(t('sales.channels.form.errors.load', 'Failed to load channel.'))
+        if (!cancelled) {
+          if ((err as { status?: number }).status === 404) {
+            setIsNotFound(true)
+          } else {
+            setError(t('sales.channels.form.errors.load', 'Failed to load channel.'))
+          }
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }
@@ -116,14 +126,33 @@ export default function EditChannelPage({ params }: { params?: { channelId?: str
     </div>
   ), [tabButton, t])
 
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('sales.channels.form.errors.notFound', 'Channel not found.')}
+            backHref="/backend/sales/channels"
+            backLabel={t('sales.channels.actions.backToList', 'Back to channels')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
+  if (error && !loading && !initialValues) {
+    return (
+      <Page>
+        <PageBody>
+          <ErrorMessage label={error} />
+        </PageBody>
+      </Page>
+    )
+  }
+
   return (
     <Page>
       <PageBody>
-        {error ? (
-          <div className="mb-4 rounded border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-            {error}
-          </div>
-        ) : null}
         {activeTab === 'settings' ? (
           <CrudForm<ChannelFormValues>
             title={t('sales.channels.form.editTitle', 'Edit channel')}

--- a/packages/core/src/modules/staff/backend/staff/leave-requests/[id]/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/leave-requests/[id]/page.tsx
@@ -6,7 +6,7 @@ import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { Badge } from '@open-mercato/ui/primitives/badge'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Textarea } from '@open-mercato/ui/primitives/textarea'
-import { LoadingMessage, ErrorMessage } from '@open-mercato/ui/backend/detail'
+import { LoadingMessage, ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { SendObjectMessageDialog } from '@open-mercato/ui/backend/messages'
 import { apiCallOrThrow, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { updateCrud } from '@open-mercato/ui/backend/utils/crud'
@@ -21,12 +21,13 @@ export default function StaffLeaveRequestDetailPage({ params }: { params?: { id?
   const router = useRouter()
   const [isLoading, setIsLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [record, setRecord] = React.useState<NormalizedLeaveRequest | null>(null)
   const [decisionComment, setDecisionComment] = React.useState('')
 
   React.useEffect(() => {
     if (!id) {
-      setError(t('staff.leaveRequests.errors.notFound', 'Leave request not found.'))
+      setIsNotFound(true)
       setIsLoading(false)
       return
     }
@@ -35,6 +36,7 @@ export default function StaffLeaveRequestDetailPage({ params }: { params?: { id?
     async function load() {
       setIsLoading(true)
       setError(null)
+      setIsNotFound(false)
       try {
         const params = new URLSearchParams({ page: '1', pageSize: '1', ids: requestId })
         const payload = await readApiResultOrThrow<LeaveRequestsResponse>(
@@ -43,7 +45,13 @@ export default function StaffLeaveRequestDetailPage({ params }: { params?: { id?
           { errorMessage: t('staff.leaveRequests.errors.load', 'Failed to load leave request.') },
         )
         const entry = Array.isArray(payload.items) ? payload.items[0] : null
-        if (!entry) throw new Error(t('staff.leaveRequests.errors.notFound', 'Leave request not found.'))
+        if (!entry) {
+          if (!cancelled) {
+            setIsNotFound(true)
+            setRecord(null)
+          }
+          return
+        }
         if (!cancelled) {
           const normalized = normalizeLeaveRequest(entry)
           setRecord(normalized)
@@ -51,9 +59,14 @@ export default function StaffLeaveRequestDetailPage({ params }: { params?: { id?
         }
       } catch (err) {
         if (!cancelled) {
-          const message = err instanceof Error ? err.message : t('staff.leaveRequests.errors.load', 'Failed to load leave request.')
-          setError(message)
-          setRecord(null)
+          if ((err as { status?: number }).status === 404) {
+            setIsNotFound(true)
+            setRecord(null)
+          } else {
+            const message = err instanceof Error ? err.message : t('staff.leaveRequests.errors.load', 'Failed to load leave request.')
+            setError(message)
+            setRecord(null)
+          }
         }
       } finally {
         if (!cancelled) setIsLoading(false)
@@ -110,6 +123,20 @@ const handleSubmit = React.useCallback(async (values: LeaveRequestFormValues) =>
       <Page>
         <PageBody>
           <LoadingMessage label={t('staff.leaveRequests.form.loading', 'Loading leave request...')} />
+        </PageBody>
+      </Page>
+    )
+  }
+
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('staff.leaveRequests.errors.notFound', 'Leave request not found.')}
+            backHref="/backend/staff/leave-requests"
+            backLabel={t('staff.leaveRequests.actions.backToList', 'Back to leave requests')}
+          />
         </PageBody>
       </Page>
     )

--- a/packages/core/src/modules/staff/backend/staff/my-leave-requests/[id]/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/my-leave-requests/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { Badge } from '@open-mercato/ui/primitives/badge'
 import { Button } from '@open-mercato/ui/primitives/button'
-import { LoadingMessage, ErrorMessage } from '@open-mercato/ui/backend/detail'
+import { LoadingMessage, ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { SendObjectMessageDialog } from '@open-mercato/ui/backend/messages'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { updateCrud } from '@open-mercato/ui/backend/utils/crud'
@@ -20,11 +20,12 @@ export default function StaffMyLeaveRequestDetailPage({ params }: { params?: { i
   const router = useRouter()
   const [isLoading, setIsLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [record, setRecord] = React.useState<NormalizedLeaveRequest | null>(null)
 
   React.useEffect(() => {
     if (!id) {
-      setError(t('staff.leaveRequests.errors.notFound', 'Leave request not found.'))
+      setIsNotFound(true)
       setIsLoading(false)
       return
     }
@@ -33,6 +34,7 @@ export default function StaffMyLeaveRequestDetailPage({ params }: { params?: { i
     async function load() {
       setIsLoading(true)
       setError(null)
+      setIsNotFound(false)
       try {
         const params = new URLSearchParams({ page: '1', pageSize: '1', ids: requestId })
         const payload = await readApiResultOrThrow<LeaveRequestsResponse>(
@@ -41,15 +43,26 @@ export default function StaffMyLeaveRequestDetailPage({ params }: { params?: { i
           { errorMessage: t('staff.leaveRequests.errors.load', 'Failed to load leave request.') },
         )
         const entry = Array.isArray(payload.items) ? payload.items[0] : null
-        if (!entry) throw new Error(t('staff.leaveRequests.errors.notFound', 'Leave request not found.'))
+        if (!entry) {
+          if (!cancelled) {
+            setIsNotFound(true)
+            setRecord(null)
+          }
+          return
+        }
         if (!cancelled) {
           setRecord(normalizeLeaveRequest(entry))
         }
       } catch (err) {
         if (!cancelled) {
-          const message = err instanceof Error ? err.message : t('staff.leaveRequests.errors.load', 'Failed to load leave request.')
-          setError(message)
-          setRecord(null)
+          if ((err as { status?: number }).status === 404) {
+            setIsNotFound(true)
+            setRecord(null)
+          } else {
+            const message = err instanceof Error ? err.message : t('staff.leaveRequests.errors.load', 'Failed to load leave request.')
+            setError(message)
+            setRecord(null)
+          }
         }
       } finally {
         if (!cancelled) setIsLoading(false)
@@ -88,6 +101,20 @@ const handleSubmit = React.useCallback(async (values: LeaveRequestFormValues) =>
       <Page>
         <PageBody>
           <LoadingMessage label={t('staff.leaveRequests.form.loading', 'Loading leave request...')} />
+        </PageBody>
+      </Page>
+    )
+  }
+
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('staff.leaveRequests.errors.notFound', 'Leave request not found.')}
+            backHref="/backend/staff/my-leave-requests"
+            backLabel={t('staff.leaveRequests.actions.backToMyList', 'Back to my leave requests')}
+          />
         </PageBody>
       </Page>
     )

--- a/packages/core/src/modules/staff/backend/staff/team-members/[id]/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/team-members/[id]/page.tsx
@@ -17,6 +17,7 @@ import { TeamMemberForm, buildTeamMemberPayload, type TeamMemberFormValues } fro
 import { NotesSection } from '@open-mercato/ui/backend/detail'
 import { ActivitiesSection, type SectionAction } from '@open-mercato/ui/backend/detail'
 import { AddressesSection as SharedAddressesSection } from '@open-mercato/ui/backend/detail'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { renderDictionaryColor, renderDictionaryIcon, ICON_SUGGESTIONS } from '@open-mercato/core/modules/dictionaries/components/dictionaryAppearance'
 import { createStaffNotesAdapter } from '@open-mercato/core/modules/staff/components/detail/notesAdapter'
 import { createStaffActivitiesAdapter } from '@open-mercato/core/modules/staff/components/detail/activitiesAdapter'
@@ -70,6 +71,8 @@ export default function StaffTeamMemberDetailPage({ params }: { params?: { id?: 
   const searchParams = useSearchParams()
   const [initialValues, setInitialValues] = React.useState<TeamMemberFormValues | null>(null)
   const [memberRecord, setMemberRecord] = React.useState<TeamMemberRecord | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [availabilityRuleSetId, setAvailabilityRuleSetId] = React.useState<string | null>(null)
   const [activePanel, setActivePanel] = React.useState<'details' | 'availability' | 'jobHistory'>('details')
   const [activeTab, setActiveTab] = React.useState<'notes' | 'activities' | 'addresses'>('notes')
@@ -194,6 +197,10 @@ export default function StaffTeamMemberDetailPage({ params }: { params?: { id?: 
     const memberIdValue = memberId
     let cancelled = false
     async function loadMember() {
+      if (!cancelled) {
+        setError(null)
+        setIsNotFound(false)
+      }
       try {
         const params = new URLSearchParams({ page: '1', pageSize: '1', ids: memberIdValue })
         const payload = await readApiResultOrThrow<TeamMemberResponse>(
@@ -202,7 +209,10 @@ export default function StaffTeamMemberDetailPage({ params }: { params?: { id?: 
           { errorMessage: t('staff.teamMembers.form.errors.load', 'Failed to load team member.') },
         )
         const record = Array.isArray(payload.items) ? payload.items[0] : null
-        if (!record) throw new Error(t('staff.teamMembers.form.errors.notFound', 'Team member not found.'))
+        if (!record) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         const customFields = extractCustomFieldEntries(record)
         if (!cancelled) {
           const resolvedTeamId = record.teamId ?? record.team_id ?? null
@@ -227,9 +237,15 @@ export default function StaffTeamMemberDetailPage({ params }: { params?: { id?: 
                 : null,
           )
         }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : t('staff.teamMembers.form.errors.load', 'Failed to load team member.')
-        flash(message, 'error')
+      } catch (err) {
+        if (!cancelled) {
+          if ((err as { status?: number }).status === 404) {
+            setIsNotFound(true)
+          } else {
+            const message = err instanceof Error ? err.message : t('staff.teamMembers.form.errors.load', 'Failed to load team member.')
+            setError(message)
+          }
+        }
       }
     }
     void loadMember()
@@ -303,6 +319,30 @@ export default function StaffTeamMemberDetailPage({ params }: { params?: { id?: 
     ? memberRecord?.roleNames
     : [t('staff.teamMembers.detail.roles.unassigned', 'No roles assigned')]
   const userEmail = memberRecord?.user?.email ?? null
+
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('staff.teamMembers.form.errors.notFound', 'Team member not found.')}
+            backHref="/backend/staff/team-members"
+            backLabel={t('staff.teamMembers.actions.backToList', 'Back to team members')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
+  if (error && !initialValues) {
+    return (
+      <Page>
+        <PageBody>
+          <ErrorMessage label={error} />
+        </PageBody>
+      </Page>
+    )
+  }
 
   return (
     <Page>

--- a/packages/core/src/modules/staff/backend/staff/team-roles/[id]/edit/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/team-roles/[id]/edit/page.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { useRouter } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { readApiResultOrThrow, apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
@@ -38,6 +39,8 @@ export default function StaffTeamRoleEditPage({ params }: { params?: { id?: stri
   const router = useRouter()
   const scopeVersion = useOrganizationScopeVersion()
   const [initialValues, setInitialValues] = React.useState<TeamRoleFormValues | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [teams, setTeams] = React.useState<TeamRoleOption[]>([])
 
   React.useEffect(() => {
@@ -45,6 +48,10 @@ export default function StaffTeamRoleEditPage({ params }: { params?: { id?: stri
     const roleIdValue = roleId
     let cancelled = false
     async function loadRole() {
+      if (!cancelled) {
+        setError(null)
+        setIsNotFound(false)
+      }
       try {
         const params = new URLSearchParams({ page: '1', pageSize: '1', ids: roleIdValue })
         const payload = await readApiResultOrThrow<TeamRoleResponse>(
@@ -53,7 +60,10 @@ export default function StaffTeamRoleEditPage({ params }: { params?: { id?: stri
           { errorMessage: t('staff.teamRoles.errors.load', 'Failed to load team role.') },
         )
         const record = Array.isArray(payload.items) ? payload.items[0] : null
-        if (!record) throw new Error(t('staff.teamRoles.errors.notFound', 'Team role not found.'))
+        if (!record) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         const customFields = extractCustomFieldEntries(record)
         const appearanceIcon = typeof record.appearanceIcon === 'string'
           ? record.appearanceIcon
@@ -79,9 +89,15 @@ export default function StaffTeamRoleEditPage({ params }: { params?: { id?: stri
             ...customFields,
           })
         }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : t('staff.teamRoles.errors.load', 'Failed to load team role.')
-        flash(message, 'error')
+      } catch (err) {
+        if (!cancelled) {
+          if ((err as { status?: number }).status === 404) {
+            setIsNotFound(true)
+          } else {
+            const message = err instanceof Error ? err.message : t('staff.teamRoles.errors.load', 'Failed to load team role.')
+            setError(message)
+          }
+        }
       }
     }
     loadRole()
@@ -130,6 +146,30 @@ export default function StaffTeamRoleEditPage({ params }: { params?: { id?: stri
     flash(t('staff.teamRoles.messages.deleted', 'Team role deleted.'), 'success')
     router.push('/backend/staff/team-roles')
   }, [roleId, router, t])
+
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('staff.teamRoles.errors.notFound', 'Team role not found.')}
+            backHref="/backend/staff/team-roles"
+            backLabel={t('staff.teamRoles.actions.backToList', 'Back to team roles')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
+  if (error && !initialValues) {
+    return (
+      <Page>
+        <PageBody>
+          <ErrorMessage label={error} />
+        </PageBody>
+      </Page>
+    )
+  }
 
   return (
     <Page>

--- a/packages/core/src/modules/staff/backend/staff/teams/[id]/edit/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/teams/[id]/edit/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import type { ColumnDef, SortingState } from '@tanstack/react-table'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { DataTable, withDataTableNamespaces } from '@open-mercato/ui/backend/DataTable'
@@ -59,6 +60,8 @@ export default function StaffTeamEditPage({ params }: { params?: { id?: string }
   const searchParams = useSearchParams()
   const scopeVersion = useOrganizationScopeVersion()
   const [initialValues, setInitialValues] = React.useState<TeamFormValues | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [activeTab, setActiveTab] = React.useState<'details' | 'members'>('details')
   const [memberRows, setMemberRows] = React.useState<TeamMemberRow[]>([])
   const [memberPage, setMemberPage] = React.useState(1)
@@ -168,6 +171,10 @@ export default function StaffTeamEditPage({ params }: { params?: { id?: string }
     const teamIdValue = teamId
     let cancelled = false
     async function loadTeam() {
+      if (!cancelled) {
+        setError(null)
+        setIsNotFound(false)
+      }
       try {
         const params = new URLSearchParams({ page: '1', pageSize: '1', ids: teamIdValue })
         const payload = await readApiResultOrThrow<TeamResponse>(
@@ -176,7 +183,10 @@ export default function StaffTeamEditPage({ params }: { params?: { id?: string }
           { errorMessage: t('staff.teams.errors.load', 'Failed to load team.') },
         )
         const record = Array.isArray(payload.items) ? payload.items[0] : null
-        if (!record) throw new Error(t('staff.teams.errors.notFound', 'Team not found.'))
+        if (!record) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         const customFields = extractCustomFieldEntries(record)
         const isActive = typeof record.isActive === 'boolean'
           ? record.isActive
@@ -192,9 +202,15 @@ export default function StaffTeamEditPage({ params }: { params?: { id?: string }
             ...customFields,
           })
         }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : t('staff.teams.errors.load', 'Failed to load team.')
-        flash(message, 'error')
+      } catch (err) {
+        if (!cancelled) {
+          if ((err as { status?: number }).status === 404) {
+            setIsNotFound(true)
+          } else {
+            const message = err instanceof Error ? err.message : t('staff.teams.errors.load', 'Failed to load team.')
+            setError(message)
+          }
+        }
       }
     }
     loadTeam()
@@ -287,6 +303,30 @@ export default function StaffTeamEditPage({ params }: { params?: { id?: string }
     })
     router.push('/backend/staff/teams')
   }, [teamId, router, t])
+
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('staff.teams.errors.notFound', 'Team not found.')}
+            backHref="/backend/staff/teams"
+            backLabel={t('staff.teams.actions.backToList', 'Back to teams')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
+  if (error && !initialValues) {
+    return (
+      <Page>
+        <PageBody>
+          <ErrorMessage label={error} />
+        </PageBody>
+      </Page>
+    )
+  }
 
   return (
     <Page>

--- a/packages/core/src/modules/workflows/backend/definitions/[id]/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/[id]/page.tsx
@@ -8,6 +8,7 @@ import { CrudForm } from '@open-mercato/ui/backend/CrudForm'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Alert, AlertDescription } from '@open-mercato/ui/primitives/alert'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { apiFetch } from '@open-mercato/ui/backend/utils/api'
 import { readJsonSafe } from '@open-mercato/ui/backend/utils/serverErrors'
 import { formatWorkflowValidationError } from '../../../lib/format-validation-error'
@@ -49,13 +50,21 @@ export default function EditWorkflowDefinitionPage() {
     queryFn: async () => {
       const response = await apiFetch(`/api/workflows/definitions/${definitionId}`)
       if (!response.ok) {
-        throw new Error(t('workflows.errors.fetchFailed'))
+        const err = new Error(t('workflows.errors.fetchFailed')) as Error & { status?: number }
+        err.status = response.status
+        throw err
       }
       const result = await response.json()
       return result.data
     },
     enabled: !!definitionId,
+    retry: (failureCount, err) => {
+      if ((err as { status?: number }).status === 404) return false
+      return failureCount < 2
+    },
   })
+
+  const isNotFound = (error as { status?: number } | null)?.status === 404
 
   const initialValues = React.useMemo(() => {
     if (definition) {
@@ -209,12 +218,26 @@ export default function EditWorkflowDefinitionPage() {
     )
   }
 
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('workflows.errors.notFound', t('workflows.errors.loadFailed'))}
+            backHref="/backend/definitions"
+            backLabel={t('workflows.backToList')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
   if (error || !definition) {
     return (
       <Page>
         <PageBody>
-          <div className="flex h-[50vh] flex-col items-center justify-center gap-2 text-muted-foreground">
-            <p>{t('workflows.errors.loadFailed')}</p>
+          <ErrorMessage label={t('workflows.errors.loadFailed')} />
+          <div className="mt-4 flex justify-center">
             <Button asChild variant="outline">
               <a href="/backend/definitions">{t('workflows.backToList')}</a>
             </Button>

--- a/packages/create-app/template/src/modules/example/backend/todos/[id]/edit/page.tsx
+++ b/packages/create-app/template/src/modules/example/backend/todos/[id]/edit/page.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { useRouter } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { CrudForm, type CrudField, type CrudFormGroup } from '@open-mercato/ui/backend/CrudForm'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { fetchCrudList, updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { pushWithFlash } from '@open-mercato/ui/backend/utils/flash'
 import { SendObjectMessageDialog } from '@open-mercato/ui/backend/messages'
@@ -25,6 +26,7 @@ export default function EditTodoPage({ params }: { params?: { id?: string } }) {
   const [initial, setInitial] = React.useState<TodoFormValues | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [err, setErr] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   // Memoize fields to avoid recreating arrays/objects each render (prevents focus loss)
   const baseFields = React.useMemo<CrudField[]>(() => [
     {
@@ -76,10 +78,14 @@ export default function EditTodoPage({ params }: { params?: { id?: string } }) {
       if (!id) return
       setLoading(true)
       setErr(null)
+      setIsNotFound(false)
       try {
         const data = await fetchCrudList<TodoItem>('example/todos', { id: String(id), pageSize: 1 })
         const item = data?.items?.[0]
-        if (!item) throw new Error(t('example.todos.form.error.notFound'))
+        if (!item) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         // Map to form initial values
         const extended = item as TodoItem & Record<string, unknown>
         const cfInit = extractCustomFieldEntries(extended) as Partial<TodoCustomFieldValues>
@@ -92,8 +98,12 @@ export default function EditTodoPage({ params }: { params?: { id?: string } }) {
         if (!cancelled) setInitial(init)
       } catch (error: unknown) {
         if (!cancelled) {
-          const message = error instanceof Error && error.message ? error.message : t('example.todos.form.error.load')
-          setErr(message)
+          if ((error as { status?: number }).status === 404) {
+            setIsNotFound(true)
+          } else {
+            const message = error instanceof Error && error.message ? error.message : t('example.todos.form.error.load')
+            setErr(message)
+          }
         }
       } finally {
         if (!cancelled) setLoading(false)
@@ -111,11 +121,25 @@ export default function EditTodoPage({ params }: { params?: { id?: string } }) {
 
   if (!id) return null
 
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('example.todos.form.error.notFound')}
+            backHref="/backend/todos"
+            backLabel={t('example.todos.form.actions.backToList', 'Back to todos')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
   return (
     <Page>
       <PageBody>
         {err ? (
-          <div className="text-red-600">{err}</div>
+          <ErrorMessage label={err} />
         ) : (
           <CrudForm<TodoFormValues>
             title={t('example.todos.form.edit.title')}


### PR DESCRIPTION
## Summary

Rolls out `RecordNotFoundState` to all backend edit/detail `[id]` pages that previously handled missing records by `throw new Error('not_found')` (or equivalent) inside their loaders (Phase 4 of #2101).

Each affected page now tracks `isNotFound` as a dedicated boolean, separate from generic `error`. Empty load results and 404 responses set `isNotFound`; transport and parse failures set `error`. Missing records render the shared `RecordNotFoundState` with a working back-to-list action; load failures still surface via `ErrorMessage`.

## Changes

* **`catalog/categories/[id]/edit`** — `!record` and 404 → `setIsNotFound(true)`
* **`catalog/products/[productId]/variants/[variantId]`** — `!record` and 404 → `setIsNotFound(true)`
* **`directory/tenants/[id]/edit`** — `!row` and 404 from `readApiResultOrThrow` → `setIsNotFound(true)`
* **`directory/organizations/[id]/edit`** — `!record` and 404 → `setIsNotFound(true)`
* **`staff/teams/[id]/edit`** — `!record` and 404 → `setIsNotFound(true)`; surface load errors via `ErrorMessage` instead of `flash`
* **`staff/team-roles/[id]/edit`** — `!record` and 404 → `setIsNotFound(true)`; surface load errors via `ErrorMessage` instead of `flash`
* **`staff/team-members/[id]`** — `!record` and 404 → `setIsNotFound(true)`; surface load errors via `ErrorMessage` instead of `flash`
* **`staff/leave-requests/[id]`** — `!entry` and 404 → `setIsNotFound(true)`
* **`staff/my-leave-requests/[id]`** — `!entry` and 404 → `setIsNotFound(true)`
* **`planner/availability-rulesets/[id]`** — `!record` and 404 → `setIsNotFound(true)`; surface load errors via `ErrorMessage` instead of `flash`
* **`workflows/definitions/[id]`** — propagate `response.status` from react-query error and short-circuit on 404 → `RecordNotFoundState`
* **`sales/channels/[channelId]/edit`** — `!item` and 404 → `setIsNotFound(true)`
* **`example/todos/[id]/edit`** (mercato app + create-app template) — `!item` and 404 → `setIsNotFound(true)`; load errors use `ErrorMessage`

## Specification

**Does a spec exist for this feature/module?**

- [x] Yes

**Spec file path:**

```text
.ai/specs/2026-03-23-unified-record-not-found-ui-state.md
````

## Testing

```bash
yarn workspace @open-mercato/core build       # ✅ built successfully
yarn workspace @open-mercato/scheduler build  # ✅ built successfully
yarn workspace @open-mercato/webhooks build   # ✅ built successfully
yarn workspace @open-mercato/enterprise build # ✅ built successfully
```

Manual smoke test:

* Verified that navigating to an edit page with a non-existent ID renders `RecordNotFoundState` with a working back link.
* Tested locally on `/backend/catalog/categories/non-existent-uuid/edit`.

## Checklist

* [x] This pull request targets `develop`.
* [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
* [ ] I updated documentation, locales, or generators if the change requires it.
* [ ] I added or adjusted tests that cover the change.
* [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).

  * Integration tests for `RecordNotFoundState` are scoped to Phase 5 of #2101 per the issue plan.
* [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

  * Spec exists; changelog entry will be added when Phase 5 closes out the spec.

## Design System Compliance

* No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens.
* No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`.
* Empty state handled for list/data pages (`<EmptyState>` or `DataTable emptyState` prop).
* Loading state handled for async pages.
* `aria-label` on all icon-only buttons (`<IconButton>`).
* Uses existing DS components (`Alert`, `StatusBadge`, `FormField`) — no custom replacements.

## Linked Issues

Part of #2101.

* Phase 1 — merged
* Phase 2 — merged
* Phase 3 — merged
* Phase 4 — this PR
* Phase 5 — pending