### PR TITLE
test(ui): add RecordNotFoundState integration coverage (Phase 5, #2101)

### DIFF
--- a/.ai/specs/2026-03-23-unified-record-not-found-ui-state.md
+++ b/.ai/specs/2026-03-23-unified-record-not-found-ui-state.md
@@ -246,7 +246,8 @@ Existing pages can adopt the new component incrementally.
 ## Changelog
 
 - 2026-03-23: Initial draft for unified backend record-not-found page handling.
-- 2026-06-03: Phase 5 — Integration coverage added under `packages/core/src/modules/{customers,sales}/__integration__/TC-UX-{006,007,008}-*.spec.ts`:
+- 2026-06-03: Phase 5 — Integration coverage added under `packages/core/src/modules/{customers,sales}/__integration__/TC-UX-{006,007,008,009}-*.spec.ts` (one `test.describe` per file per `.ai/qa/AGENTS.md`):
   - TC-UX-006: random UUID on `/backend/customers/people/[id]` renders `RecordNotFoundState` with "Back to people" recovery action; CrudForm submit control absent.
-  - TC-UX-007: stale id on `/backend/sales/documents/[id]` (list API returning empty `items`) renders the shared not-found state with kind-aware back link (`?kind=order` → orders list; default → quotes list).
-  - TC-UX-008: clicking the back-to-list action on a Phase-1 page (`/backend/customers/companies/[id]`) actually navigates to the owning list page. Closeout (`git mv` to `.ai/specs/implemented/`) deferred until Phases 1–5 land on `develop`.
+  - TC-UX-007: stale id on `/backend/sales/documents/[id]` (list API returning empty `items`) renders the shared not-found state with the default "Back to quotes" back link.
+  - TC-UX-008: clicking the back-to-list action on a Phase-1 page (`/backend/customers/companies/[id]`) actually navigates to the owning list page.
+  - TC-UX-009: stale id on `/backend/sales/documents/[id]?kind=order` renders the shared not-found state with the kind-aware "Back to orders" back link. Closeout (`git mv` to `.ai/specs/implemented/`) deferred until Phases 1–5 land on `develop`.

--- a/.ai/specs/2026-03-23-unified-record-not-found-ui-state.md
+++ b/.ai/specs/2026-03-23-unified-record-not-found-ui-state.md
@@ -246,3 +246,7 @@ Existing pages can adopt the new component incrementally.
 ## Changelog
 
 - 2026-03-23: Initial draft for unified backend record-not-found page handling.
+- 2026-06-03: Phase 5 — Integration coverage added under `packages/core/src/modules/{customers,sales}/__integration__/TC-UX-{006,007,008}-*.spec.ts`:
+  - TC-UX-006: random UUID on `/backend/customers/people/[id]` renders `RecordNotFoundState` with "Back to people" recovery action; CrudForm submit control absent.
+  - TC-UX-007: stale id on `/backend/sales/documents/[id]` (list API returning empty `items`) renders the shared not-found state with kind-aware back link (`?kind=order` → orders list; default → quotes list).
+  - TC-UX-008: clicking the back-to-list action on a Phase-1 page (`/backend/customers/companies/[id]`) actually navigates to the owning list page. Closeout (`git mv` to `.ai/specs/implemented/`) deferred until Phases 1–5 land on `develop`.

--- a/packages/core/src/modules/customers/__integration__/TC-UX-006-record-not-found-people.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-UX-006-record-not-found-people.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test'
+import { login } from '@open-mercato/core/helpers/integration/auth'
+
+/**
+ * TC-UX-006: RecordNotFoundState renders for a missing person detail
+ * Source: .ai/specs/2026-03-23-unified-record-not-found-ui-state.md (Phase 5 — Integration Coverage)
+ *
+ * Verifies:
+ * - Navigating to `/backend/customers/people/<random-uuid>` renders the shared
+ *   `RecordNotFoundState` instead of the detail form.
+ * - The "Back to people" recovery action is visible.
+ * - No CrudForm submit control is rendered on the not-found page.
+ */
+test.describe('TC-UX-006: RecordNotFoundState — people detail with non-existent UUID', () => {
+  test('renders shared not-found state and back-to-list action', async ({ page }) => {
+    await login(page, 'admin')
+
+    const missingId = crypto.randomUUID()
+    await page.goto(`/backend/customers/people/${missingId}`, { waitUntil: 'commit' })
+
+    const notFoundLabel = page.getByText('Person not found', { exact: false })
+    await expect(notFoundLabel).toBeVisible({ timeout: 15_000 })
+
+    const backLink = page.getByRole('link', { name: /back to people/i })
+    await expect(backLink).toBeVisible()
+    await expect(backLink).toHaveAttribute('href', '/backend/customers/people')
+
+    await expect(page.getByRole('button', { name: /^save$/i })).toHaveCount(0)
+  })
+})

--- a/packages/core/src/modules/customers/__integration__/TC-UX-008-record-not-found-back-nav.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-UX-008-record-not-found-back-nav.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test'
+import { login } from '@open-mercato/core/helpers/integration/auth'
+
+/**
+ * TC-UX-008: RecordNotFoundState back-to-list action navigates to the owning list page
+ * Source: .ai/specs/2026-03-23-unified-record-not-found-ui-state.md (Phase 5 — Integration Coverage)
+ *
+ * Uses the Phase-1 representative page `/backend/customers/companies/[id]`
+ * (introduced in PR #2014) to confirm the recovery action actually navigates,
+ * not just renders a link with the right href.
+ */
+test.describe('TC-UX-008: RecordNotFoundState — back-to-list navigation on Phase-1 page', () => {
+  test('clicking back-to-list navigates to the companies list', async ({ page }) => {
+    await login(page, 'admin')
+
+    const missingId = crypto.randomUUID()
+    await page.goto(`/backend/customers/companies/${missingId}`, { waitUntil: 'commit' })
+
+    const notFoundLabel = page.getByText('Company not found', { exact: false })
+    await expect(notFoundLabel).toBeVisible({ timeout: 15_000 })
+
+    const backLink = page.getByRole('link', { name: /back to companies/i })
+    await expect(backLink).toBeVisible()
+
+    await backLink.click()
+    await page.waitForURL('**/backend/customers/companies', { timeout: 15_000 })
+    expect(new URL(page.url()).pathname).toBe('/backend/customers/companies')
+  })
+})

--- a/packages/core/src/modules/sales/__integration__/TC-UX-007-record-not-found-documents.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-UX-007-record-not-found-documents.spec.ts
@@ -2,16 +2,16 @@ import { expect, test } from '@playwright/test'
 import { login } from '@open-mercato/core/helpers/integration/auth'
 
 /**
- * TC-UX-007: RecordNotFoundState renders for a missing sales document detail
+ * TC-UX-007: RecordNotFoundState renders for a missing sales document detail (default kind → quotes)
  * Source: .ai/specs/2026-03-23-unified-record-not-found-ui-state.md (Phase 5 — Integration Coverage)
  *
  * The sales documents detail page is backed by a list API that returns an
  * empty `items` array when the requested id does not exist (not an HTTP 404).
- * This test exercises that branch: a stale/random id should render the shared
- * `RecordNotFoundState` instead of the detail form.
+ * This test exercises that branch with no `kind` query parameter, so the
+ * back-to-list action should point at the quotes list.
  */
-test.describe('TC-UX-007: RecordNotFoundState — sales document detail with stale id', () => {
-  test('renders shared not-found state and back-to-list action for an unknown document', async ({ page }) => {
+test.describe('TC-UX-007: RecordNotFoundState — sales document detail with stale id (default kind)', () => {
+  test('renders shared not-found state and back-to-quotes action for an unknown document', async ({ page }) => {
     await login(page, 'admin')
 
     const staleId = crypto.randomUUID()
@@ -23,19 +23,5 @@ test.describe('TC-UX-007: RecordNotFoundState — sales document detail with sta
     const backLink = page.getByRole('link', { name: /back to quotes/i })
     await expect(backLink).toBeVisible()
     await expect(backLink).toHaveAttribute('href', '/backend/sales/quotes')
-  })
-
-  test('renders order-scoped back link when kind=order is supplied', async ({ page }) => {
-    await login(page, 'admin')
-
-    const staleId = crypto.randomUUID()
-    await page.goto(`/backend/sales/documents/${staleId}?kind=order`, { waitUntil: 'commit' })
-
-    const notFoundLabel = page.getByText('Document not found', { exact: false })
-    await expect(notFoundLabel).toBeVisible({ timeout: 15_000 })
-
-    const backLink = page.getByRole('link', { name: /back to orders/i })
-    await expect(backLink).toBeVisible()
-    await expect(backLink).toHaveAttribute('href', '/backend/sales/orders')
   })
 })

--- a/packages/core/src/modules/sales/__integration__/TC-UX-007-record-not-found-documents.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-UX-007-record-not-found-documents.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test'
+import { login } from '@open-mercato/core/helpers/integration/auth'
+
+/**
+ * TC-UX-007: RecordNotFoundState renders for a missing sales document detail
+ * Source: .ai/specs/2026-03-23-unified-record-not-found-ui-state.md (Phase 5 — Integration Coverage)
+ *
+ * The sales documents detail page is backed by a list API that returns an
+ * empty `items` array when the requested id does not exist (not an HTTP 404).
+ * This test exercises that branch: a stale/random id should render the shared
+ * `RecordNotFoundState` instead of the detail form.
+ */
+test.describe('TC-UX-007: RecordNotFoundState — sales document detail with stale id', () => {
+  test('renders shared not-found state and back-to-list action for an unknown document', async ({ page }) => {
+    await login(page, 'admin')
+
+    const staleId = crypto.randomUUID()
+    await page.goto(`/backend/sales/documents/${staleId}`, { waitUntil: 'commit' })
+
+    const notFoundLabel = page.getByText('Document not found', { exact: false })
+    await expect(notFoundLabel).toBeVisible({ timeout: 15_000 })
+
+    const backLink = page.getByRole('link', { name: /back to quotes/i })
+    await expect(backLink).toBeVisible()
+    await expect(backLink).toHaveAttribute('href', '/backend/sales/quotes')
+  })
+
+  test('renders order-scoped back link when kind=order is supplied', async ({ page }) => {
+    await login(page, 'admin')
+
+    const staleId = crypto.randomUUID()
+    await page.goto(`/backend/sales/documents/${staleId}?kind=order`, { waitUntil: 'commit' })
+
+    const notFoundLabel = page.getByText('Document not found', { exact: false })
+    await expect(notFoundLabel).toBeVisible({ timeout: 15_000 })
+
+    const backLink = page.getByRole('link', { name: /back to orders/i })
+    await expect(backLink).toBeVisible()
+    await expect(backLink).toHaveAttribute('href', '/backend/sales/orders')
+  })
+})

--- a/packages/core/src/modules/sales/__integration__/TC-UX-009-record-not-found-document-orders.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-UX-009-record-not-found-document-orders.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test'
+import { login } from '@open-mercato/core/helpers/integration/auth'
+
+/**
+ * TC-UX-009: RecordNotFoundState renders order-scoped back link when kind=order is supplied
+ * Source: .ai/specs/2026-03-23-unified-record-not-found-ui-state.md (Phase 5 — Integration Coverage)
+ *
+ * Sibling of TC-UX-007: verifies that the sales documents detail page renders
+ * the shared `RecordNotFoundState` with an orders-scoped recovery action when
+ * the `?kind=order` query parameter is supplied. The page chooses the back
+ * link target based on `searchParams.get('kind')`, so this case proves the
+ * kind-aware branch independently from the default (quotes) case.
+ */
+test.describe('TC-UX-009: RecordNotFoundState — sales document detail with stale id (kind=order)', () => {
+  test('renders shared not-found state and back-to-orders action when kind=order is supplied', async ({ page }) => {
+    await login(page, 'admin')
+
+    const staleId = crypto.randomUUID()
+    await page.goto(`/backend/sales/documents/${staleId}?kind=order`, { waitUntil: 'commit' })
+
+    const notFoundLabel = page.getByText('Document not found', { exact: false })
+    await expect(notFoundLabel).toBeVisible({ timeout: 15_000 })
+
+    const backLink = page.getByRole('link', { name: /back to orders/i })
+    await expect(backLink).toBeVisible()
+    await expect(backLink).toHaveAttribute('href', '/backend/sales/orders')
+  })
+})


### PR DESCRIPTION
## Summary

Closes the Phase 5 plan from #2101 by adding the integration coverage required by the spec's "Integration Coverage" section. Two pages cover the two missing-record detection paths; one page covers the back-to-list recovery action on a Phase-1 page.

## Changes

* **`TC-UX-006`** (`packages/core/src/modules/customers/__integration__/`) — random UUID on `/backend/customers/people/[id]` renders `RecordNotFoundState` with the "Back to people" recovery link; CrudForm submit control is absent.
* **`TC-UX-007`** (`packages/core/src/modules/sales/__integration__/`) — stale id on `/backend/sales/documents/[id]` (list API returning empty `items`) renders the shared not-found state with a kind-aware back link:

  * default → "Back to quotes" → `/backend/sales/quotes`
  * `?kind=order` → "Back to orders" → `/backend/sales/orders`
* **`TC-UX-008`** (`packages/core/src/modules/customers/__integration__/`) — clicking the back-to-list action on the Phase-1 page `/backend/customers/companies/[id]` actually navigates to `/backend/customers/companies` (not just renders the link).
* **Spec changelog** — appended a 2026-06-03 Phase 5 entry to `.ai/specs/2026-03-23-unified-record-not-found-ui-state.md` listing the three TC-UX cases. Moving the spec to `.ai/specs/implemented/` is intentionally deferred to a maintainer follow-up once Phase 5 lands on `develop`, per `.ai/specs/AGENTS.md` — "Ask before moving a spec to `implemented/` if deployment/completion evidence is incomplete".

## Specification

**Does a spec exist for this feature/module?**

* [x] Yes

**Spec file path:** `.ai/specs/2026-03-23-unified-record-not-found-ui-state.md`

## Testing

```bash id="ft8r4h"
npx playwright test --config .ai/qa/tests/playwright.config.ts \
  packages/core/src/modules/customers/__integration__/TC-UX-006 \
  packages/core/src/modules/customers/__integration__/TC-UX-008 \
  packages/core/src/modules/sales/__integration__/TC-UX-007 --list

# → 4 tests in 3 files discovered
```

The full suite is intended to run in CI via `yarn test:integration`.

## Checklist

* [x] This pull request targets `develop`.
* [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
* [ ] I updated documentation, locales, or generators if the change requires it.

  * No new i18n keys introduced; tests assert against existing locale strings (verified present in `en`, `pl`, `de`, `es` for all asserted keys).
* [ ] I added or adjusted tests that cover the change.

  * This PR is the test addition; there is no production code change to cover beyond it.
* [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).

  * Tests live in the module `__integration__/` folders per `.ai/qa/AGENTS.md` (executable specs are forbidden under `.ai/qa/tests/`).
* [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

  * Phase 5 entry appended to the changelog. Moving the file to `.ai/specs/implemented/` is intentionally deferred to a maintainer follow-up after merge.

## Design System Compliance

* No hardcoded status colors — use semantic tokens
* No arbitrary text sizes — use typography scale or text-overline
* Empty state handled for list/data pages
* Loading state handled for async pages
* aria-label on all icon-only buttons
* Uses existing DS components — no custom replacements

## Linked Issues

Closes #2101.

* Phase 1 — merged (#2014)
* Phase 2 — merged
* Phase 3 — merged
* Phase 4 — ready to merge (#2435)
* Phase 5 — this PR
