### PR TITLE
fix(ui): avoid false unsaved prompt on clean person detail

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-074.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-074.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  createPersonFixture,
+  deleteEntityIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
+
+/**
+ * TC-CRM-074: Person detail clean navigation guard
+ *
+ * Opening a person detail page must not mark the form dirty by normalizing
+ * empty API values during initialization. Leaving the untouched page should
+ * navigate normally without a native beforeunload prompt or app alertdialog.
+ */
+test.describe('TC-CRM-074: Person detail clean navigation guard', () => {
+  test('leaves an untouched person detail page without an unsaved-changes prompt', async ({ page, request }) => {
+    test.slow();
+
+    let token: string | null = null;
+    let personId: string | null = null;
+    let nativeDialogOpened = false;
+    const displayName = `QA TC-CRM-074 Person ${Date.now()}`;
+
+    page.on('dialog', async (dialog) => {
+      nativeDialogOpened = true;
+      await dialog.dismiss().catch(() => {});
+    });
+
+    try {
+      token = await getAuthToken(request);
+      personId = await createPersonFixture(request, token, {
+        firstName: 'QA',
+        lastName: 'Guard',
+        displayName,
+      });
+
+      await login(page, 'admin');
+      await page.goto(`/backend/customers/people-v2/${personId}`, { waitUntil: 'domcontentloaded' });
+      await expect(page.getByText(displayName, { exact: true }).first()).toBeVisible({ timeout: 15_000 });
+      await page.waitForTimeout(750);
+
+      await page.evaluate(() => {
+        const link = document.createElement('a');
+        link.href = '/backend/customers/people';
+        link.textContent = 'Leave person detail';
+        link.setAttribute('data-testid', 'person-detail-clean-leave-link');
+        document.body.appendChild(link);
+      });
+
+      await page.getByTestId('person-detail-clean-leave-link').click();
+
+      await expect(page.getByRole('alertdialog')).toHaveCount(0);
+      expect(nativeDialogOpened).toBe(false);
+      await expect(page).toHaveURL(/\/backend\/customers\/people(?:\?.*)?$/);
+      await expect(page.getByRole('button', { name: /Refresh/i })).toBeVisible({ timeout: 15_000 });
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/people', personId);
+    }
+  });
+});

--- a/packages/enterprise/src/modules/record_locks/__tests__/recordLockWidgetHeaders.test.ts
+++ b/packages/enterprise/src/modules/record_locks/__tests__/recordLockWidgetHeaders.test.ts
@@ -45,7 +45,8 @@ describe('record lock widget resolution headers', () => {
       pendingResolutionArmed: false,
     })
 
-    const result = await widget.eventHandlers.onBeforeSave({}, { formId } as any)
+    const context: Parameters<NonNullable<typeof widget.eventHandlers.onBeforeSave>>[1] = { formId }
+    const result = await widget.eventHandlers.onBeforeSave({}, context)
     expect(result.ok).toBe(false)
     expect(mockedValidateBeforeSave).not.toHaveBeenCalled()
   })
@@ -123,5 +124,44 @@ describe('record lock widget resolution headers', () => {
     if (result.ok) throw new Error('Expected blocked save result')
     expect(result.message).toContain('deleted')
     expect(mockedValidateBeforeSave).not.toHaveBeenCalled()
+  })
+
+  test('allows save with an acquired lock when no conflict or deletion is pending', async () => {
+    setRecordLockFormState(formId, {
+      formId,
+      resourceKind: 'customers.person',
+      resourceId: 'b0000000-0000-4000-8000-000000000001',
+      acquired: true,
+      lock: {
+        id: 'c0000000-0000-4000-8000-000000000001',
+        resourceKind: 'customers.person',
+        resourceId: 'b0000000-0000-4000-8000-000000000001',
+        token: 'lock-token',
+        strategy: 'optimistic',
+        status: 'active',
+        lockedByUserId: 'user-1',
+        baseActionLogId: null,
+        lockedAt: '2026-06-03T10:00:00.000Z',
+        lastHeartbeatAt: '2026-06-03T10:00:00.000Z',
+        expiresAt: '2026-06-03T10:05:00.000Z',
+      },
+      latestActionLogId: 'log-1',
+      conflict: null,
+      pendingResolution: 'normal',
+      pendingResolutionArmed: false,
+      recordDeleted: false,
+    })
+
+    const result = await widget.eventHandlers.onBeforeSave({}, { formId } as any)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('Expected successful result')
+    expect(result.requestHeaders).toMatchObject({
+      'x-om-record-lock-kind': 'customers.person',
+      'x-om-record-lock-resource-id': 'b0000000-0000-4000-8000-000000000001',
+      'x-om-record-lock-token': 'lock-token',
+      'x-om-record-lock-base-log-id': 'log-1',
+    })
+    expect(mockedValidateBeforeSave).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -451,6 +451,32 @@ function serializeIssuePath(path: ReadonlyArray<string | number | symbol>): stri
   return segments.length > 0 ? segments.join('.') : null
 }
 
+function normalizeDirtySnapshotValue(value: unknown): unknown {
+  if (value === undefined || value === null || value === '') return undefined
+  if (Array.isArray(value)) {
+    const normalized = value
+      .map((entry) => normalizeDirtySnapshotValue(entry))
+      .filter((entry) => entry !== undefined)
+    return normalized.length ? normalized : undefined
+  }
+  if (typeof value !== 'object') return value
+
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) return value
+
+  const normalized: Record<string, unknown> = {}
+  const record = value as Record<string, unknown>
+  for (const key of Object.keys(record).sort()) {
+    const nextValue = normalizeDirtySnapshotValue(record[key])
+    if (nextValue !== undefined) normalized[key] = nextValue
+  }
+  return Object.keys(normalized).length ? normalized : undefined
+}
+
+function createDirtySnapshot(source: Record<string, unknown>): string {
+  return JSON.stringify(normalizeDirtySnapshotValue(source) ?? {})
+}
+
 const FIELDSET_ICON_COMPONENTS: Record<string, React.ComponentType<{ className?: string }>> = {
   layers: Layers,
   tag: Tag,
@@ -750,7 +776,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
       setHasUnsavedChanges(false)
       return
     }
-    const currentSnapshot = JSON.stringify(values)
+    const currentSnapshot = createDirtySnapshot(values as Record<string, unknown>)
     const dirty = currentSnapshot !== snapshot
     isDirtyRef.current = dirty
     setHasUnsavedChanges(dirty)
@@ -797,7 +823,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
 
   const clearDirtyState = React.useCallback((snapshotSource?: Record<string, unknown>) => {
     const source = snapshotSource ?? (valuesRef.current as Record<string, unknown>)
-    dirtyBaselineSnapshotRef.current = JSON.stringify(source)
+    dirtyBaselineSnapshotRef.current = createDirtySnapshot(source)
     isDirtyRef.current = false
     setHasUnsavedChanges(false)
   }, [])
@@ -842,7 +868,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
       if (!target) return
       if (shouldBypassUnsavedChangesGuardRef.current?.(target)) return
       const baselineSnapshot = dirtyBaselineSnapshotRef.current
-      if (baselineSnapshot && JSON.stringify(valuesRef.current) === baselineSnapshot) {
+      if (baselineSnapshot && createDirtySnapshot(valuesRef.current as Record<string, unknown>) === baselineSnapshot) {
         isDirtyRef.current = false
         setHasUnsavedChanges(false)
         return
@@ -874,7 +900,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
           return original(data, unused, url)
         }
         const baselineSnapshot = dirtyBaselineSnapshotRef.current
-        if (baselineSnapshot && JSON.stringify(valuesRef.current) === baselineSnapshot) {
+        if (baselineSnapshot && createDirtySnapshot(valuesRef.current as Record<string, unknown>) === baselineSnapshot) {
           isDirtyRef.current = false
           setHasUnsavedChanges(false)
           return original(data, unused, url)
@@ -2177,7 +2203,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
       return mergedValues
     })
     if (mergedValues) {
-      dirtyBaselineSnapshotRef.current = JSON.stringify(mergedValues)
+      dirtyBaselineSnapshotRef.current = createDirtySnapshot(mergedValues as Record<string, unknown>)
     }
     if (!extendedInjectionEventsEnabled || !mergedValues) return
     let cancelled = false
@@ -2190,7 +2216,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
         )
         const transformed = result.data
         if (cancelled || !transformed) return
-        dirtyBaselineSnapshotRef.current = JSON.stringify(transformed as Record<string, unknown>)
+        dirtyBaselineSnapshotRef.current = createDirtySnapshot(transformed as Record<string, unknown>)
         setValues(transformed as CrudFormValues<TValues>)
       } catch (err) {
         console.error('[CrudForm] Error in transformDisplayData:', err)
@@ -2259,7 +2285,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
 
     // Update the dirty baseline so the form doesn't appear dirty from defaults
     if (mergedValues) {
-      dirtyBaselineSnapshotRef.current = JSON.stringify(mergedValues)
+      dirtyBaselineSnapshotRef.current = createDirtySnapshot(mergedValues as Record<string, unknown>)
     }
   }, [isLoading, initialValuesHasId, cfDefinitions, customEntity])
 

--- a/packages/ui/src/backend/__tests__/CrudForm.unsavedNavigation.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.unsavedNavigation.test.tsx
@@ -3,6 +3,9 @@ jest.setTimeout(15000)
 
 const pushMock = jest.fn()
 const confirmDialogMock = jest.fn()
+const triggerEventMock = jest.fn()
+let mockInjectionSpotDataChange: (() => unknown) | null = null
+let mockInjectionSpotDataChangeCalled = false
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock }),
@@ -19,9 +22,17 @@ jest.mock('../confirm-dialog', () => ({
 }))
 jest.mock('../injection/InjectionSpot', () => ({
   __esModule: true,
-  InjectionSpot: () => null,
+  InjectionSpot: ({ onDataChange }: { onDataChange?: (next: unknown) => void }) => {
+    const React = require('react') as typeof import('react')
+    React.useEffect(() => {
+      if (!mockInjectionSpotDataChange || mockInjectionSpotDataChangeCalled) return
+      mockInjectionSpotDataChangeCalled = true
+      onDataChange?.(mockInjectionSpotDataChange())
+    }, [onDataChange])
+    return null
+  },
   useInjectionWidgets: () => ({ widgets: [], loading: false, error: null }),
-  useInjectionSpotEvents: () => ({ triggerEvent: jest.fn() }),
+  useInjectionSpotEvents: () => ({ triggerEvent: triggerEventMock }),
 }))
 jest.mock('../injection/useInjectionDataWidgets', () => ({
   __esModule: true,
@@ -40,6 +51,10 @@ describe('CrudForm unsaved navigation guard', () => {
     pushMock.mockReset()
     confirmDialogMock.mockReset()
     confirmDialogMock.mockResolvedValue(true)
+    triggerEventMock.mockReset()
+    triggerEventMock.mockImplementation(async (_event: string, data: Record<string, unknown>) => ({ ok: true, data }))
+    mockInjectionSpotDataChange = null
+    mockInjectionSpotDataChangeCalled = false
     window.history.replaceState({}, '', '/current')
   })
 
@@ -264,5 +279,39 @@ describe('CrudForm unsaved navigation guard', () => {
     expect(event.defaultPrevented).toBe(false)
 
     anchor.remove()
+  })
+
+  it('does not prompt when initialization normalizes empty values without user edits', async () => {
+    mockInjectionSpotDataChange = () => ({ name: undefined, tags: [], meta: { note: null } })
+
+    renderWithProviders(
+      <CrudForm
+        title="Form"
+        fields={fields}
+        initialValues={{ name: '', tags: [], meta: { note: '' } }}
+        injectionSpotId="customers.person"
+        onSubmit={() => {}}
+      />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+          'ui.forms.confirmUnsavedChanges': 'You have unsaved changes. Are you sure you want to leave?',
+        },
+      },
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      window.history.pushState({}, '', '/backend/customers/people')
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(confirmDialogMock).not.toHaveBeenCalled()
+    expect(window.location.pathname).toBe('/backend/customers/people')
   })
 })


### PR DESCRIPTION
## Summary

Fixes a false unsaved-changes prompt that can appear after opening a person/detail form and leaving without user edits. The form dirty snapshot now normalizes equivalent empty values (`undefined`, `null`, empty string, empty arrays/objects) before comparing baseline and current values, so initialization-time value normalization does not count as a user edit. Real non-empty changes still mark the form dirty and keep the existing navigation guard behavior.

## Changes

- Normalize `CrudForm` dirty-state snapshots before comparing baseline/current values.
- Add a `CrudForm` regression test for initialization-time empty value normalization through injection data.
- Add record-lock coverage showing an acquired lock without conflict/deletion does not block save headers.
- Add Playwright coverage for leaving an untouched person detail page without native or app unsaved-changes prompts.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- `corepack yarn workspace @open-mercato/ui test --runTestsByPath src/backend/__tests__/CrudForm.unsavedNavigation.test.tsx`
- `corepack yarn workspace @open-mercato/enterprise test --runTestsByPath src/modules/record_locks/__tests__/recordLockWidgetHeaders.test.ts`
- `corepack yarn build:packages`
- `corepack yarn generate` (completed with OpenAPI static fallback after local `isolated-vm` native build was unavailable for Node 25)
- `corepack yarn build:packages`
- `corepack yarn typecheck`
- `corepack yarn test:integration:ephemeral packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Reported from THEY CRM issue THOM-11.