### PR TITLE
fix(docker): add NODE_OPTIONS heap cap to production fullapp stack (#2371)

### DIFF
--- a/apps/docs/docs/installation/vps.mdx
+++ b/apps/docs/docs/installation/vps.mdx
@@ -62,6 +62,7 @@ JWT_SECRET=your-strong-jwt-secret
 # Application
 APP_URL=https://your-domain.com
 NODE_ENV=production
+# NODE_OPTIONS=--max-old-space-size=3072  # default; raise for larger hosts — see Troubleshooting
 
 # Cache
 CACHE_REDIS_URL=redis://redis:6379
@@ -213,6 +214,28 @@ grep DATABASE_URL apps/mercato/.env
 ```bash
 docker system df            # check usage
 docker system prune -a      # clean unused resources (does not touch named volumes)
+```
+
+**App container keeps restarting (OOM killed):**
+
+Check the effective V8 heap limit inside the running container:
+
+```bash
+docker compose -f docker-compose.fullapp.yml exec app node \
+  -e "const s=require('v8').getHeapStatistics(); \
+      console.log(Math.round(s.heap_size_limit/1024/1024)+' MB heap limit')"
+```
+
+If the value is below 1 GB, raise `NODE_OPTIONS` in `apps/mercato/.env` then restart:
+
+| Host RAM | `NODE_OPTIONS` value |
+|----------|---------------------|
+| 4 GB | `--max-old-space-size=3072` *(default)* |
+| 8 GB | `--max-old-space-size=5120` |
+| 16 GB+ | `--max-old-space-size=8192` |
+
+```bash
+docker compose -f docker-compose.fullapp.yml up -d
 ```
 
 **Full reset (deletes all data):**

--- a/docker-compose.fullapp.yml
+++ b/docker-compose.fullapp.yml
@@ -58,6 +58,7 @@ services:
       TENANT_DATA_ENCRYPTION_DEBUG: ${TENANT_DATA_ENCRYPTION_DEBUG:-false}
       TENANT_DATA_ENCRYPTION_FALLBACK_KEY: ${TENANT_DATA_ENCRYPTION_FALLBACK_KEY:-dev-tenant-encryption-fallback-key-32chars}
       NODE_ENV: development
+      NODE_OPTIONS: ${NODE_OPTIONS:---max-old-space-size=3072}
       DEPLOY_ENV: ${DEPLOY_ENV:-local}
       PORT: ${CONTAINER_PORT:-3000}
       DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@mercato-postgres-${DEPLOY_ENV:-local}:5432/${POSTGRES_DB:-open-mercato}

--- a/docker-compose.fullapp.yml
+++ b/docker-compose.fullapp.yml
@@ -58,6 +58,8 @@ services:
       TENANT_DATA_ENCRYPTION_DEBUG: ${TENANT_DATA_ENCRYPTION_DEBUG:-false}
       TENANT_DATA_ENCRYPTION_FALLBACK_KEY: ${TENANT_DATA_ENCRYPTION_FALLBACK_KEY:-dev-tenant-encryption-fallback-key-32chars}
       NODE_ENV: development
+      # Prevents V8 from growing toward total host RAM before GC kicks in.
+      # Override in .env to tune for your host: --max-old-space-size=6144 suits 16 GB+ servers.
       NODE_OPTIONS: ${NODE_OPTIONS:---max-old-space-size=3072}
       DEPLOY_ENV: ${DEPLOY_ENV:-local}
       PORT: ${CONTAINER_PORT:-3000}

--- a/packages/create-app/template/docker-compose.fullapp.yml
+++ b/packages/create-app/template/docker-compose.fullapp.yml
@@ -32,6 +32,8 @@ services:
       TENANT_DATA_ENCRYPTION_DEBUG: ${TENANT_DATA_ENCRYPTION_DEBUG:-false}
       TENANT_DATA_ENCRYPTION_FALLBACK_KEY: ${TENANT_DATA_ENCRYPTION_FALLBACK_KEY:-dev-tenant-encryption-fallback-key-32chars}
       NODE_ENV: development
+      # Prevents V8 from growing toward total host RAM before GC kicks in.
+      # Override in .env to tune for your host: --max-old-space-size=6144 suits 16 GB+ servers.
       NODE_OPTIONS: ${NODE_OPTIONS:---max-old-space-size=3072}
       DEPLOY_ENV: ${DEPLOY_ENV:-local}
       PORT: ${CONTAINER_PORT:-3000}

--- a/packages/create-app/template/docker-compose.fullapp.yml
+++ b/packages/create-app/template/docker-compose.fullapp.yml
@@ -32,6 +32,7 @@ services:
       TENANT_DATA_ENCRYPTION_DEBUG: ${TENANT_DATA_ENCRYPTION_DEBUG:-false}
       TENANT_DATA_ENCRYPTION_FALLBACK_KEY: ${TENANT_DATA_ENCRYPTION_FALLBACK_KEY:-dev-tenant-encryption-fallback-key-32chars}
       NODE_ENV: development
+      NODE_OPTIONS: ${NODE_OPTIONS:---max-old-space-size=3072}
       DEPLOY_ENV: ${DEPLOY_ENV:-local}
       PORT: ${CONTAINER_PORT:-3000}
       DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-open-mercato}

--- a/scripts/__tests__/prod-compose-node-options.test.mjs
+++ b/scripts/__tests__/prod-compose-node-options.test.mjs
@@ -15,18 +15,18 @@ function extractDefaultHeapMb(relPath) {
 
 test('docker-compose.fullapp.yml NODE_OPTIONS default heap cap is at least 1024 MB', () => {
   const mb = extractDefaultHeapMb('docker-compose.fullapp.yml')
-  assert.ok(mb !== null, 'NODE_OPTIONS not found in docker-compose.fullapp.yml — add NODE_OPTIONS: ${NODE_OPTIONS:---max-old-space-size=3072} to the app service environment')
+  assert.notStrictEqual(mb, null, 'NODE_OPTIONS default not found in docker-compose.fullapp.yml')
   assert.ok(
     mb >= MIN_HEAP_MB,
-    `Default heap cap is ${mb} MB — below the ${MIN_HEAP_MB} MB minimum needed for normal app operation; raise the default in docker-compose.fullapp.yml`
+    `Default heap cap is ${mb} MB — below the ${MIN_HEAP_MB} MB minimum needed for normal app operation`
   )
 })
 
 test('create-app template docker-compose.fullapp.yml NODE_OPTIONS default heap cap is at least 1024 MB', () => {
   const mb = extractDefaultHeapMb('packages/create-app/template/docker-compose.fullapp.yml')
-  assert.ok(mb !== null, 'NODE_OPTIONS not found in template docker-compose.fullapp.yml')
+  assert.notStrictEqual(mb, null, 'NODE_OPTIONS default not found in template docker-compose.fullapp.yml')
   assert.ok(
     mb >= MIN_HEAP_MB,
-    `Template default heap cap is ${mb} MB — below the ${MIN_HEAP_MB} MB minimum; update packages/create-app/template/docker-compose.fullapp.yml`
+    `Template default heap cap is ${mb} MB — below the ${MIN_HEAP_MB} MB minimum`
   )
 })

--- a/scripts/__tests__/prod-compose-node-options.test.mjs
+++ b/scripts/__tests__/prod-compose-node-options.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const MIN_HEAP_MB = 1024
+
+function extractDefaultHeapMb(relPath) {
+  const content = fs.readFileSync(path.resolve(ROOT, relPath), 'utf8')
+  const match = content.match(/NODE_OPTIONS:---max-old-space-size=(\d+)/)
+  return match ? parseInt(match[1], 10) : null
+}
+
+test('docker-compose.fullapp.yml NODE_OPTIONS default heap cap is at least 1024 MB', () => {
+  const mb = extractDefaultHeapMb('docker-compose.fullapp.yml')
+  assert.ok(mb !== null, 'NODE_OPTIONS not found in docker-compose.fullapp.yml — add NODE_OPTIONS: ${NODE_OPTIONS:---max-old-space-size=3072} to the app service environment')
+  assert.ok(
+    mb >= MIN_HEAP_MB,
+    `Default heap cap is ${mb} MB — below the ${MIN_HEAP_MB} MB minimum needed for normal app operation; raise the default in docker-compose.fullapp.yml`
+  )
+})
+
+test('create-app template docker-compose.fullapp.yml NODE_OPTIONS default heap cap is at least 1024 MB', () => {
+  const mb = extractDefaultHeapMb('packages/create-app/template/docker-compose.fullapp.yml')
+  assert.ok(mb !== null, 'NODE_OPTIONS not found in template docker-compose.fullapp.yml')
+  assert.ok(
+    mb >= MIN_HEAP_MB,
+    `Template default heap cap is ${mb} MB — below the ${MIN_HEAP_MB} MB minimum; update packages/create-app/template/docker-compose.fullapp.yml`
+  )
+})


### PR DESCRIPTION
## Summary

`docker-compose.fullapp.yml` (production stack) was missing the `NODE_OPTIONS`
heap cap that `docker-compose.fullapp.dev.yml` already carries since #2375.
Without a cap, V8 defers GC until RSS approaches total host RAM, leading to
periodic OOM restarts on memory-constrained production hosts.

This adds `NODE_OPTIONS: ${NODE_OPTIONS:---max-old-space-size=3072}` to the
app service environment, matching the existing dev-stack entry exactly.
The shell-default syntax means any platform-level override (Railway config var,
K8s secret, `.env`) wins automatically — no file edits required.

## Changes

- `docker-compose.fullapp.yml`: add `NODE_OPTIONS` between `NODE_ENV` and `DEPLOY_ENV` (1 line)
- `packages/create-app/template/docker-compose.fullapp.yml`: same for template parity (1 line)

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

## Testing

```bash
# YAML syntax valid
docker compose -f docker-compose.fullapp.yml config --quiet  # OK (warnings are unset API keys only)

# Override check: platform-level NODE_OPTIONS wins
NODE_OPTIONS=--max-old-space-size=6144 docker compose -f docker-compose.fullapp.yml config \
  | grep NODE_OPTIONS  # → --max-old-space-size=6144

# Script test suite (includes PR #2402 jest-memory-fanout guard)
yarn test:scripts  # 177 pass, 0 fail
```

CI note: `docker-build` job builds the `Dockerfile` image only — it does not run
`docker compose up`, so this compose change has no CI breakage risk.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change. *(N/A — compose config change; validated via `docker compose config` and override check)*
- [ ] I added or updated integration tests in `.ai/qa/tests/`. *(N/A — manual QA scenarios TC-DOCKER-007 covers the production Docker stack)*
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry. *(N/A — 1-line infra change, no contract surface)*

### Design System Compliance
N/A — infrastructure change, no UI touched.

## Linked issues

Fixes #2371