### PR TITLE
fix(customers): validate deal pipeline stage assignments

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-023.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-023.spec.ts
@@ -118,10 +118,9 @@ test.describe('TC-CRM-023: Deal Pipeline Stage Assignment', () => {
     }
   });
 
-  test('should allow deal creation with mismatched pipelineId and pipelineStageId (no server-side validation)', async ({ request }) => {
+  test('should reject deal creation with mismatched pipelineId and pipelineStageId', async ({ request }) => {
     let pipeline1Id: string | null = null;
     let pipeline2Id: string | null = null;
-    let dealId: string | null = null;
     try {
       const ts = `${Date.now()}`;
       const { pipelineId: pid1 } = await createPipelineWithStage(request, token, `${ts}A`);
@@ -137,10 +136,48 @@ test.describe('TC-CRM-023: Deal Pipeline Stage Assignment', () => {
           pipelineStageId: stageFromPipeline2,
         },
       });
-      expect(dealRes.ok(), `deal creation should succeed: ${dealRes.status()}`).toBeTruthy();
-      const body = await dealRes.json() as Record<string, unknown>;
-      dealId = body.id as string;
-      expect(typeof dealId).toBe('string');
+      expect(dealRes.status()).toBe(400);
+    } finally {
+      if (pipeline1Id) {
+        await apiRequest(request, 'DELETE', '/api/customers/pipelines', { token, data: { id: pipeline1Id } }).catch(() => {});
+      }
+      if (pipeline2Id) {
+        await apiRequest(request, 'DELETE', '/api/customers/pipelines', { token, data: { id: pipeline2Id } }).catch(() => {});
+      }
+    }
+  });
+
+  test('should reject deal update with mismatched pipelineId and pipelineStageId', async ({ request }) => {
+    let pipeline1Id: string | null = null;
+    let pipeline2Id: string | null = null;
+    let dealId: string | null = null;
+    try {
+      const ts = `${Date.now()}`;
+      const { pipelineId: pid1, stageId: stageFromPipeline1 } = await createPipelineWithStage(request, token, `${ts}A`);
+      pipeline1Id = pid1;
+      const { pipelineId: pid2, stageId: stageFromPipeline2 } = await createPipelineWithStage(request, token, `${ts}B`);
+      pipeline2Id = pid2;
+
+      const dealRes = await apiRequest(request, 'POST', '/api/customers/deals', {
+        token,
+        data: {
+          title: `TC-CRM-023 Update Mismatch ${ts}`,
+          pipelineId: pipeline1Id,
+          pipelineStageId: stageFromPipeline1,
+        },
+      });
+      const dealBody = await dealRes.json() as Record<string, unknown>;
+      dealId = dealBody.id as string;
+
+      const updateRes = await apiRequest(request, 'PUT', '/api/customers/deals', {
+        token,
+        data: {
+          id: dealId,
+          pipelineId: pipeline1Id,
+          pipelineStageId: stageFromPipeline2,
+        },
+      });
+      expect(updateRes.status()).toBe(400);
     } finally {
       if (dealId) {
         await apiRequest(request, 'DELETE', '/api/customers/deals', { token, data: { id: dealId } }).catch(() => {});

--- a/packages/core/src/modules/customers/commands/deals.ts
+++ b/packages/core/src/modules/customers/commands/deals.ts
@@ -110,6 +110,34 @@ async function resolvePipelineStageValue(
   return entry?.value ?? stage.label
 }
 
+function resolvePipelineAssignment(input: {
+  pipelineId?: string | null
+  pipelineStageId?: string | null
+  stageSnapshot: PipelineStageSnapshot | null
+}): { pipelineId: string | null; pipelineStageId: string | null } {
+  const requestedPipelineId = input.pipelineId ?? null
+  const requestedPipelineStageId = input.pipelineStageId ?? null
+
+  if (requestedPipelineStageId && !input.stageSnapshot) {
+    throw new CrudHttpError(400, { error: 'Pipeline stage not found' })
+  }
+
+  if (
+    requestedPipelineId &&
+    input.stageSnapshot &&
+    input.stageSnapshot.pipelineId !== requestedPipelineId
+  ) {
+    throw new CrudHttpError(400, {
+      error: 'Pipeline stage does not belong to the selected pipeline',
+    })
+  }
+
+  return {
+    pipelineId: requestedPipelineId ?? input.stageSnapshot?.pipelineId ?? null,
+    pipelineStageId: requestedPipelineStageId,
+  }
+}
+
 async function upsertDealStageTransition(
   em: EntityManager,
   input: {
@@ -369,12 +397,21 @@ const createDealCommand: CommandHandler<DealCreateInput, { dealId: string }> = {
     const normalizedTransitionAuthorUserId = normalizeAuthorUserId(null, ctx.auth)
     let deal!: CustomerDeal
     let stageSnapshot: PipelineStageSnapshot | null = null
+    let pipelineAssignment: { pipelineId: string | null; pipelineStageId: string | null } = {
+      pipelineId: null,
+      pipelineStageId: null,
+    }
     let resolvedPipelineStageLabel: string | null = null
     await withAtomicFlush(em, [
       async () => {
         stageSnapshot = parsed.pipelineStageId
           ? await loadPipelineStageSnapshot(em, parsed.pipelineStageId, parsed.tenantId, parsed.organizationId)
           : null
+        pipelineAssignment = resolvePipelineAssignment({
+          pipelineId: parsed.pipelineId,
+          pipelineStageId: parsed.pipelineStageId,
+          stageSnapshot,
+        })
         resolvedPipelineStageLabel = stageSnapshot
           ? (await ensureDictionaryEntry(em, {
             tenantId: parsed.tenantId,
@@ -392,8 +429,8 @@ const createDealCommand: CommandHandler<DealCreateInput, { dealId: string }> = {
           description: parsed.description ?? null,
           status: parsed.status ?? 'open',
           pipelineStage: resolvedPipelineStageLabel,
-          pipelineId: parsed.pipelineId ?? null,
-          pipelineStageId: parsed.pipelineStageId ?? null,
+          pipelineId: pipelineAssignment.pipelineId,
+          pipelineStageId: pipelineAssignment.pipelineStageId,
           valueAmount: toNumericString(parsed.valueAmount),
           valueCurrency: parsed.valueCurrency ?? null,
           probability: parsed.probability ?? null,
@@ -509,14 +546,34 @@ const updateDealCommand: CommandHandler<DealUpdateInput, { dealId: string }> = {
     const normalizedTransitionAuthorUserId = normalizeAuthorUserId(null, ctx.auth)
 
     let nextStageSnapshot: PipelineStageSnapshot | null = null
+    let nextPipelineAssignment: { pipelineId: string | null; pipelineStageId: string | null } = {
+      pipelineId: record.pipelineId ?? null,
+      pipelineStageId: record.pipelineStageId ?? null,
+    }
     let nextPipelineStageLabel: string | null = null
     let resolvedCurrentPipelineStageLabel: string | null = null
 
     await withAtomicFlush(em, [
       async () => {
-        nextStageSnapshot = parsed.pipelineStageId
-          ? await loadPipelineStageSnapshot(em, parsed.pipelineStageId, record.tenantId, record.organizationId)
+        const pipelineAssignmentChanged =
+          parsed.pipelineId !== undefined || parsed.pipelineStageId !== undefined
+        const requestedPipelineStageId =
+          parsed.pipelineStageId !== undefined
+            ? parsed.pipelineStageId ?? null
+            : record.pipelineStageId ?? null
+        const requestedPipelineId =
+          parsed.pipelineId !== undefined ? parsed.pipelineId ?? null : record.pipelineId ?? null
+
+        nextStageSnapshot = requestedPipelineStageId && (pipelineAssignmentChanged || !record.pipelineStage)
+          ? await loadPipelineStageSnapshot(em, requestedPipelineStageId, record.tenantId, record.organizationId)
           : null
+        if (pipelineAssignmentChanged) {
+          nextPipelineAssignment = resolvePipelineAssignment({
+            pipelineId: requestedPipelineId,
+            pipelineStageId: requestedPipelineStageId,
+            stageSnapshot: nextStageSnapshot,
+          })
+        }
         nextPipelineStageLabel = nextStageSnapshot
           ? (await ensureDictionaryEntry(em, {
             tenantId: record.tenantId,
@@ -535,8 +592,10 @@ const updateDealCommand: CommandHandler<DealUpdateInput, { dealId: string }> = {
         if (parsed.description !== undefined) record.description = parsed.description ?? null
         if (parsed.status !== undefined) record.status = parsed.status ?? record.status
         if (parsed.pipelineStage !== undefined) record.pipelineStage = parsed.pipelineStage ?? null
-        if (parsed.pipelineId !== undefined) record.pipelineId = parsed.pipelineId ?? null
-        if (parsed.pipelineStageId !== undefined) record.pipelineStageId = parsed.pipelineStageId ?? null
+        if (parsed.pipelineId !== undefined || (parsed.pipelineStageId !== undefined && nextStageSnapshot)) {
+          record.pipelineId = nextPipelineAssignment.pipelineId
+        }
+        if (parsed.pipelineStageId !== undefined) record.pipelineStageId = nextPipelineAssignment.pipelineStageId
 
         if (nextPipelineStageLabel && (parsed.pipelineStageId !== undefined || !record.pipelineStage)) {
           record.pipelineStage = nextPipelineStageLabel

--- a/packages/core/src/modules/customers/components/detail/DealForm.tsx
+++ b/packages/core/src/modules/customers/components/detail/DealForm.tsx
@@ -805,11 +805,12 @@ export function DealForm({
       label: t('customers.people.detail.deals.fields.pipeline', 'Pipeline'),
       type: 'custom',
       layout: 'half',
-      component: ({ value, setValue }) => (
+      component: ({ value, setValue, setFormValue }) => (
         <Select
           value={typeof value === 'string' && value ? value : undefined}
           onValueChange={(next) => {
             setValue(next ?? '')
+            setFormValue?.('pipelineStageId', '')
             loadStagesForPipeline(next ?? '').catch(() => {})
           }}
           disabled={disabled}

--- a/packages/core/src/modules/customers/components/detail/DealsSection.tsx
+++ b/packages/core/src/modules/customers/components/detail/DealsSection.tsx
@@ -226,6 +226,14 @@ function normalizeDeal(deal: Partial<DealSummary> & { id: string; title?: string
     status: typeof deal.status === 'string' ? deal.status : deal.status ?? null,
     pipelineStage:
       typeof deal.pipelineStage === 'string' ? deal.pipelineStage : deal.pipelineStage ?? null,
+    pipelineId:
+      typeof deal.pipelineId === 'string' && deal.pipelineId.trim().length
+        ? deal.pipelineId.trim()
+        : deal.pipelineId ?? null,
+    pipelineStageId:
+      typeof deal.pipelineStageId === 'string' && deal.pipelineStageId.trim().length
+        ? deal.pipelineStageId.trim()
+        : deal.pipelineStageId ?? null,
     valueAmount: toNumber(deal.valueAmount ?? null),
     valueCurrency:
       typeof deal.valueCurrency === 'string' && deal.valueCurrency.trim().length
@@ -413,6 +421,18 @@ export function DealsSection({
             : typeof record.pipeline_stage === 'string' && record.pipeline_stage.trim().length
               ? record.pipeline_stage.trim()
               : null
+        const pipelineId =
+          typeof record.pipelineId === 'string' && record.pipelineId.trim().length
+            ? record.pipelineId.trim()
+            : typeof record.pipeline_id === 'string' && record.pipeline_id.trim().length
+              ? record.pipeline_id.trim()
+              : null
+        const pipelineStageId =
+          typeof record.pipelineStageId === 'string' && record.pipelineStageId.trim().length
+            ? record.pipelineStageId.trim()
+            : typeof record.pipeline_stage_id === 'string' && record.pipeline_stage_id.trim().length
+              ? record.pipeline_stage_id.trim()
+              : null
         const valueAmount = toNumber(record.valueAmount ?? record.value_amount)
         const valueCurrencyRaw = record.valueCurrency ?? record.value_currency ?? null
         const valueCurrency =
@@ -494,6 +514,8 @@ export function DealsSection({
           title,
           status,
           pipelineStage,
+          pipelineId,
+          pipelineStageId,
           valueAmount,
           valueCurrency,
           probability,
@@ -727,6 +749,8 @@ export function DealsSection({
           title: base.title,
           status: base.status ?? undefined,
           pipelineStage: base.pipelineStage ?? undefined,
+          pipelineId: base.pipelineId ?? undefined,
+          pipelineStageId: base.pipelineStageId ?? undefined,
           valueAmount: typeof base.valueAmount === 'number' ? base.valueAmount : undefined,
           valueCurrency: base.valueCurrency ?? undefined,
           probability: typeof base.probability === 'number' ? base.probability : undefined,
@@ -761,6 +785,8 @@ export function DealsSection({
             title: base.title,
             status: base.status ?? null,
             pipelineStage: base.pipelineStage ?? null,
+            pipelineId: base.pipelineId ?? null,
+            pipelineStageId: base.pipelineStageId ?? null,
             valueAmount: base.valueAmount ?? null,
             valueCurrency: base.valueCurrency ?? null,
             probability: base.probability ?? null,


### PR DESCRIPTION
## Summary

Preserve deal pipeline assignments when creating deals from the customer detail Deals section, and reject inconsistent `pipelineId` + `pipelineStageId` payloads in the customers deal commands.

This keeps the deal kanban/API contract consistent: a deal cannot be saved with a stage from a different pipeline, and selecting a stage without an explicit pipeline infers the stage's pipeline.

## Changes

- Preserve `pipelineId` and `pipelineStageId` while normalizing and creating deals in `DealsSection`.
- Clear the selected stage when the pipeline select changes in `DealForm`.
- Validate deal create/update pipeline assignments server-side and return `400` for missing/out-of-scope or mismatched stages.
- Extend `TC-CRM-023` coverage to assert mismatched create/update payloads are rejected.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor bug fix, no spec needed)

**Spec file path:**
N/A

## Testing

- [x] `corepack yarn workspace @open-mercato/core build`
- [x] `corepack yarn build:packages`
- [x] `corepack yarn test:integration:ephemeral packages/core/src/modules/customers/__integration__/TC-CRM-023.spec.ts` — 5 passed

Integration coverage lives in the existing customers module integration spec `TC-CRM-023`, which directly exercises the public deal API paths touched by this bug fix.

Note: `corepack yarn workspace @open-mercato/core typecheck` currently stops before checking source files on this baseline with `tsconfig.json(7,27): error TS5103: Invalid value for '--ignoreDeprecations'`.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

N/A
