### PR TITLE
fix(ui): open DatePicker on selected value's month (cherry-pick #2330 to main)

### DIFF
--- a/packages/ui/src/primitives/__tests__/date-picker.test.tsx
+++ b/packages/ui/src/primitives/__tests__/date-picker.test.tsx
@@ -177,6 +177,18 @@ describe('DatePicker primitive', () => {
       expect(dayCellButton.className).not.toMatch(/focus-visible:ring-2/)
     }
   })
+
+  it('opens on the month of the selected value, not the current month (regression)', async () => {
+    // A value far from any plausible "today" so the assertion stays deterministic.
+    // react-day-picker v10 derives the initial month from `month`/`defaultMonth`
+    // (falling back to today) and ignores `selected`, so DatePicker must pass
+    // `defaultMonth` or the selected day is never rendered.
+    renderWithI18n(<DatePicker value={new Date(2020, 0, 15)} onChange={() => {}} footer="none" />)
+    await openPopover()
+    const selectedCell = document.querySelector('td[data-selected="true"]')
+    expect(selectedCell).not.toBeNull()
+    expect((selectedCell as HTMLElement).className).toMatch(/!bg-primary/)
+  })
 })
 
 describe('DatePicker backwards-compat shims', () => {

--- a/packages/ui/src/primitives/date-picker.tsx
+++ b/packages/ui/src/primitives/date-picker.tsx
@@ -230,6 +230,7 @@ export function DatePicker({
         <Calendar
           mode="single"
           selected={selectedDate ?? undefined}
+          defaultMonth={selectedDate ?? undefined}
           onSelect={handleDaySelect}
           locale={locale}
           disabled={disabledMatcher}


### PR DESCRIPTION
## Why

`main` CI is red: the only failing test is
`DatePicker primitive › selected day cell paints primary fill and forces button transparent (regression)` (`packages/ui/src/primitives/__tests__/date-picker.test.tsx`).

### Root cause — date-dependent test, not a code regression in the failing commit

react-day-picker **v10** (dependabot-bumped) derives the initial calendar month from `month`/`defaultMonth`, falling back to **today** — it no longer falls back to `selected` like v9 did. On `main`, `DatePicker` passes `selected` but **not** `defaultMonth`, so the popover opens on the current month.

The regression test renders a picker with value **May 9, 2026** and asserts the selected `td.!bg-primary` cell is painted:
- v0.6.3 CI ran **2026-05-28** → "today" was May → May 9 on-grid → ✅
- First `main` CI after the month rolled over ran **2026-06-03** → calendar opened on June → May 9 off-grid → `expect(selectedCells.length).toBeGreaterThan(0)` got `0` → ❌

The docs-only commit #2431 that the run is attributed to didn't break anything — it was just the first push to `main` after the calendar month flipped.

## Fix

Cherry-pick of #2330 (`2f078a2b6`, already on `develop`): pass `defaultMonth={selectedDate}` so the calendar opens on the selected value's month regardless of "today", plus a clock-independent regression test. +13 lines, 2 files.

## Notes

- After cherry-pick, the two touched files are **byte-identical to `develop`**, so a future `main`↔`develop` merge does **not** conflict on them (verified with a trial merge: clean, rc=0). No develop-side change is needed.
- `yarn workspace @open-mercato/ui test date-picker` → **21 passed, 21 total** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)