### PR TITLE
security(communication_channels): fix 4 high CodeQL alerts in email-mime + 0.6.5 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,38 @@
 
+# 0.6.5 (2026-06-03)
+
+## Highlights
+
+Open Mercato `0.6.5` opens the next cycle on top of `0.6.4`'s hardening work. The headline is the **IMAP + Google email integration foundation** — shared MIME assembly, inbound normalization, and threading-id plumbing that every email channel provider now builds on instead of copy-pasting. UI continues the `RecordNotFoundState` rollout into its fourth phase (throw-on-load edit pages) with integration coverage in phase five, and the dialog Esc/Cmd+Enter behavior is consolidated behind a single `useDialogKeyHandler` hook. Customers gains configurable, optional pipeline-stage handling, and the production Docker fullapp stack inherits the dev-mode `NODE_OPTIONS` heap cap. A CodeQL false-positive in the command-menu test is also cleared.
+
+## ✨ Features
+- ✨ IMAP + Google email integration foundations — shared MIME assembly, inbound parsing, and threading plumbing. (#2424) *(@haxiorz)*
+- ✨ Configurable dictionary entry sorting (carry-forward of #2429). (#2434) *(@pkarw)*
+- ✨ Adopt `RecordNotFoundState` across throw-on-load edit pages — Phase 4 (#2101). (#2435) *(@pkarw)*
+
+## 🐛 Fixes
+- 🐛 `LookupSelect` search input no longer clears typed text (#2389). (#2422) *(@pkarw)*
+- 🐛 Allow optional pipeline stage appearance (supersedes #2430). (#2433) *(@pkarw)*
+- 🐛 Validate deal pipeline stage assignments. (#2439) *(@pmadajthey)*
+- 🐛 Avoid a false unsaved-changes prompt on a clean person detail page. (#2437) *(@pmadajthey)*
+- 🐳 Add the `NODE_OPTIONS` heap cap to the production fullapp Docker stack (#2371). (#2438) *(@Kotmin)*
+
+## 🛠️ Improvements
+- 🛠️ Extract a `useDialogKeyHandler` hook for Esc/Cmd+Enter dialogs (#2366). (#2426) *(@Marynat)*
+
+## 🧪 Testing
+- 🧪 Add `RecordNotFoundState` integration coverage — Phase 5 (#2101). (#2436) *(@izqzmyli)*
+- 🧪 Clear a CodeQL incomplete-URL-sanitization false positive in the command-menu test. (#2427) *(@pkarw)*
+
+## 👥 Contributors
+
+- @haxiorz
+- @pkarw
+- @Marynat
+- @pmadajthey
+- @Kotmin
+- @izqzmyli
+
 # 0.6.4 (2026-06-02)
 
 ## Highlights

--- a/packages/core/src/modules/communication_channels/lib/__tests__/email-mime.test.ts
+++ b/packages/core/src/modules/communication_channels/lib/__tests__/email-mime.test.ts
@@ -4,6 +4,7 @@ import {
   encodeAddressHeaderWord,
   encodeCursor,
   encodeHeaderWord,
+  escapeQuotes,
   extractHeaders,
   generateMessageId,
   htmlToText,
@@ -97,6 +98,28 @@ describe('stripBrackets / parseReferences', () => {
 describe('htmlToText', () => {
   it('strips tags and decodes basic entities', () => {
     expect(htmlToText('<p>Hi <b>there</b></p>&amp;more')).toBe('Hi there\n\n&more')
+  })
+
+  it('does not double-unescape an entity-encoded entity', () => {
+    expect(htmlToText('<p>&amp;lt;b&amp;gt;</p>')).toBe('&lt;b&gt;')
+  })
+
+  it('strips script/style blocks whose close tag carries whitespace or attributes', () => {
+    expect(htmlToText('a<script>alert(1)</script >b')).toBe('a b')
+    expect(htmlToText('a<script>alert(1)</script foo="bar">b')).toBe('a b')
+    expect(htmlToText('a<STYLE>.x{}</STYLE>b')).toBe('a b')
+  })
+
+  it('removes a script tag reconstructed by a single sanitization pass', () => {
+    expect(htmlToText('<scr<script>ipt>alert(1)</scr</script>ipt>')).toBe('')
+  })
+})
+
+describe('escapeQuotes', () => {
+  it('escapes the backslash before the quote so the quote cannot be un-escaped', () => {
+    expect(escapeQuotes('a"b')).toBe('a\\"b')
+    expect(escapeQuotes('a\\"b')).toBe('a\\\\\\"b')
+    expect(escapeQuotes('a\\')).toBe('a\\\\')
   })
 })
 

--- a/packages/core/src/modules/communication_channels/lib/email-mime.ts
+++ b/packages/core/src/modules/communication_channels/lib/email-mime.ts
@@ -45,24 +45,41 @@ export function referencesFromMeta(value: unknown): string[] | undefined {
   return value.filter((entry): entry is string => typeof entry === 'string')
 }
 
+/**
+ * Strip every `<tag>…</tag>` block (and its contents) for a single tag name.
+ * Inbound HTML is untrusted, so the matcher must resist evasion: the close tag
+ * allows trailing attributes/whitespace (`</script >`, `</style foo>`), the `i`
+ * flag covers mixed case, and the replacement loops until the string is stable
+ * so a payload split across nested or reconstructed tags cannot survive a
+ * single pass (`<scr<script>ipt>` collapsing back into `<script>`).
+ */
+function stripTagBlocks(html: string, tag: string): string {
+  const blockPattern = new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}[^>]*>`, 'gi')
+  let previous: string
+  let current = html
+  do {
+    previous = current
+    current = current.replace(blockPattern, ' ')
+  } while (current !== previous)
+  return current
+}
+
 export function htmlToText(html: string): string {
-  return html
-    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
+  return stripTagBlocks(stripTagBlocks(html, 'style'), 'script')
     .replace(/<br\s*\/?>(?=\s*)/gi, '\n')
     .replace(/<\/p\s*>/gi, '\n\n')
     .replace(/<[^>]+>/g, '')
     .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
+    .replace(/&amp;/gi, '&')
     .replace(/\n{3,}/g, '\n\n')
     .trim()
 }
 
 export function escapeQuotes(value: string): string {
-  return value.replace(/"/g, '\\"')
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
 
 /**


### PR DESCRIPTION
## Why

PR #2425 (release v0.6.4) is blocked by **CodeQL** reporting 4 new **high-severity** alerts, all introduced by #2424 in `packages/core/src/modules/communication_channels/lib/email-mime.ts` (untrusted inbound-email handling):

| Alert | Rule | Location |
|---|---|---|
| #129 | `js/bad-tag-filter` | `</script>` regex misses `</script >` / `</script foo>` |
| #128 | `js/incomplete-multi-character-sanitization` | single-pass script/style strip can be re-introduced |
| #127 | `js/double-escaping` | `&amp;` decoded *before* other entities → `&amp;lt;` double-unescapes to `<` |
| #130 | `js/incomplete-sanitization` | `escapeQuotes` doesn't escape backslashes |

## What

- **`htmlToText`** — replace the two single-pass script/style regexes with `stripTagBlocks(html, tag)`, which:
  - matches close tags with trailing whitespace/attributes (`</script >`, `</style foo>`),
  - loops until the string is stable so a split/reconstructed tag (`<scr<script>ipt>`) cannot survive a pass.
  - Decode `&amp;` **last** so entity-encoded entities are not double-unescaped.
- **`escapeQuotes`** — escape the backslash first, then the quote, so a trailing `\` cannot un-escape the following quote in a quoted display name.
- Adds regression tests for each case (36 tests pass in the `email-mime` suite).

## Changelog

Also adds a **`0.6.5` CHANGELOG entry** for the 11 PRs merged into `develop` on 2026-06-03 (post-0.6.4), per the house emoji format.

## Validation

- `yarn jest` on `email-mime.test.ts` → 36 passed.
- Function signatures unchanged → Gmail/IMAP consumers unaffected.

Once merged into `develop` and the release branch is refreshed, CodeQL on #2425 should clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)