### PR TITLE
fix(tests): repair clock-dependent time-bomb test failing on main

### DIFF
--- a/.ai/runs/2026-06-01-time-bomb-test-scanner.md
+++ b/.ai/runs/2026-06-01-time-bomb-test-scanner.md
@@ -1,0 +1,109 @@
+# Execution Plan — Time-bomb test scanner + fixes
+
+**Slug:** time-bomb-test-scanner
+**Branch:** fix/time-bomb-test-scanner
+**Date:** 2026-06-01
+**Closes:** #2384
+
+## Goal
+
+Add a dependency-free scanner that detects "time-bomb" tests (hardcoded absolute
+date literals whose pass/fail depends on the wall clock), and fix every genuine
+time-bomb currently in the suite — starting with #2384.
+
+## Background
+
+Issue #2384: `packages/core/src/modules/workflows/data/__tests__/validators.test.ts`
+hardcoded `until: '2026-06-01T12:00:00.000Z'` and asserted `.not.toThrow()`. The
+validator requires `until` to be in the future, so once that timestamp elapsed the
+test fails permanently and reddens CI on every PR. A "time-bomb" is any hardcoded
+absolute date literal whose assertion outcome flips with the system clock.
+
+## Scope
+
+- New tool: `scripts/time-bomb-scanner.mjs` + npm scripts + allowlist file.
+- Fix the genuine bombs: #2384 (3 lines) + near-future HIGH literals + far-future HIGH literals.
+
+## Non-goals
+
+- Do NOT touch past-date fixtures (createdAt/scheduledAt/expiresAt set in the past) — they stay past, not clock-dependent.
+- Do NOT touch format/parse round-trip tests (`expect(fmt(x)).toBe('YYYY-MM-DD')`) — both sides hardcoded, not clock-dependent.
+- No CI pipeline wiring in this PR (can follow up); the npm script + `--fail` mode are provided for opt-in use.
+
+## Risks
+
+- Heuristic false positives/negatives — mitigated by an assertion-context classifier and an allowlist.
+- Converting fixture dates to clock-relative could change snapshot/formatted output in UI tests — fix per case and re-run the affected jest file.
+- Far-future fixtures (2099 lock expiry) may be semantically "must be far ahead of now" — convert to `Date.now() + N years` to preserve intent rather than blindly allowlisting.
+
+## Implementation Plan
+
+### Phase 1: Scanner tool
+
+- 1.1 Add `scripts/time-bomb-scanner.mjs` (walk test files, extract ISO literals, classify vs now, severity buckets, allowlist, CLI flags, exit codes).
+- 1.2 Tune heuristic: HIGH only when literal sits in future-validity context (`not.toThrow`/`isFuture`/`until`/`future`/`deadline`/`expires`); downgrade equality/format assertions; add a separate `slow` bucket for far-future (> ~5y) literals.
+- 1.3 Add `.ai/time-bomb-allowlist.json` (empty entries + `$comment`).
+- 1.4 Wire `check:time-bombs` and `check:time-bombs:fail` npm scripts in root `package.json`.
+
+### Phase 2: Fix #2384 (workflows)
+
+- 2.1 Replace the 3 future `until: '2026-06-01T12:00:00.000Z'` literals in `workflows/data/__tests__/validators.test.ts` with `new Date(Date.now() + 60_000).toISOString()`; keep the intentional `2020-01-01` past literals. Run the jest file.
+
+### Phase 3: Fix near-future HIGH literals
+
+- 3.1 business_rules formHelpers.test.ts + validators.test.ts (effectiveTo future dates).
+- 3.2 customers TC-CRM-026 / TC-CRM-027 (future scheduledAt), validators.test.ts (153), deals route.filters.test.ts (88), ScheduleActivityDialog.test.tsx (22).
+- 3.3 planner TC-PLAN-003 (106,107).
+- Run the affected jest files after each sub-step.
+
+### Phase 4: Fix far-future HIGH literals
+
+- 4.1 currencies exchangeRateService.test.ts (575 `futureDate`).
+- 4.2 messages token route.test.ts (65).
+- 4.3 enterprise record_locks recordLockService.test.ts (2099 lock-expiry fixtures) — convert to `Date.now() + N years` or allowlist with justification.
+- Run the affected jest files.
+
+### Phase 5: Verify + gate
+
+- 5.1 Re-run `yarn check:time-bombs` — confirm clean (or only allowlisted/non-actionable).
+- 5.2 Full validation gate (typecheck/test/build) + code-review + BC self-review.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Scanner tool
+
+- [x] 1.1 Add time-bomb-scanner.mjs — fc41e8201
+- [x] 1.2 Tune heuristic (context-aware HIGH + far-future bucket) — fc41e8201
+- [x] 1.3 Add allowlist file — fc41e8201
+- [x] 1.4 Wire npm scripts — fc41e8201
+
+### Phase 2: Fix #2384 (workflows)
+
+- [x] 2.1 Replace future `until` literals with clock-relative — f526a1059
+
+### Phase 3: Fix near-future HIGH literals
+
+- [x] 3.1 business_rules (reviewed non-clock-dependent → allowlisted) — 89c046ee4
+- [x] 3.2 customers — 89c046ee4
+- [x] 3.3 planner — 89c046ee4
+
+### Phase 4: Fix far-future HIGH literals
+
+- [x] 4.1 currencies — 526700ce5
+- [x] 4.2 messages — 526700ce5
+- [x] 4.3 enterprise record_locks — 526700ce5
+
+### Phase 5: Verify + gate
+
+- [x] 5.1 Re-run scanner clean (0 high / 0 medium)
+- [x] 5.2 Gate: build:packages/generate/i18n/typecheck/build:app ✓, changed tests ✓; pre-existing unrelated cli fs-watch flake noted; code-review + BC clean
+
+## Changelog
+
+- Opened PR open-mercato/open-mercato#2393 (fork: adeptofvoltron:fix/time-bomb-test-scanner). Gate green except a pre-existing unrelated cli fs-watch flake. Upstream labels/reviews not permitted from fork.
+
+### Phase 6: CI integration
+
+- [x] 6.1 Wire `check:time-bombs:fail` into the ci.yml `test` job — 2e1d8a1ab

--- a/.ai/time-bomb-allowlist.json
+++ b/.ai/time-bomb-allowlist.json
@@ -1,0 +1,21 @@
+{
+  "$comment": "Intentional absolute date literals in tests that the time-bomb scanner (scripts/time-bomb-scanner.mjs) should ignore. Each entry is either a 'relpath:line' location, a 'relpath' (whole file), or a raw literal value — optionally wrapped as { \"match\": \"...\", \"reason\": \"...\" }. Prefer a clock-relative value (new Date(Date.now() + N)) over allowlisting whenever the assertion depends on the literal being past/future. Entries below are reviewed format/round-trip or relative-comparison tests that do NOT compare the literal to the current time, so they can never become time-bombs.",
+  "entries": [
+    {
+      "match": "packages/core/src/modules/business_rules/components/utils/__tests__/formHelpers.test.ts:84",
+      "reason": "parseRuleToFormValues format round-trip: datetime literal asserted verbatim as its YYYY-MM-DD form; no comparison to now."
+    },
+    {
+      "match": "packages/core/src/modules/business_rules/components/utils/__tests__/formHelpers.test.ts:124",
+      "reason": "Date pass-through test: YYYY-MM-DD literal echoed verbatim in the assertion; no comparison to now."
+    },
+    {
+      "match": "packages/core/src/modules/business_rules/components/utils/__tests__/formHelpers.test.ts:168",
+      "reason": "buildRulePayload pass-through test: date literal echoed verbatim in the assertion; no comparison to now."
+    },
+    {
+      "match": "packages/core/src/modules/business_rules/data/__tests__/validators.test.ts:213",
+      "reason": "createBusinessRuleSchema compares effectiveTo relative to effectiveFrom (both literals), never to now; stays valid regardless of the clock."
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,9 @@ jobs:
         run: yarn i18n:check-usage
         continue-on-error: true
 
+      - name: Check for time-bomb test literals
+        run: yarn check:time-bombs:fail
+
       - name: Checking types
         # On PRs: scope to packages/app that changed since the base branch.
         # On pushes to protected branches: full typecheck, no filter.

--- a/package.json
+++ b/package.json
@@ -99,7 +99,9 @@
     "test:integration:ephemeral:start:verbose": "cross-env ENABLE_CRUD_API_CACHE=true yarn mercato test:ephemeral --verbose",
     "prepare": "husky",
     "check:client-boundaries": "node scripts/check-client-boundaries.mjs",
-    "check:client-boundaries:fail": "node scripts/check-client-boundaries.mjs --fail"
+    "check:client-boundaries:fail": "node scripts/check-client-boundaries.mjs --fail",
+    "check:time-bombs": "node scripts/time-bomb-scanner.mjs",
+    "check:time-bombs:fail": "node scripts/time-bomb-scanner.mjs --fail"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.65",

--- a/packages/core/src/modules/currencies/services/__tests__/exchangeRateService.test.ts
+++ b/packages/core/src/modules/currencies/services/__tests__/exchangeRateService.test.ts
@@ -572,7 +572,7 @@ describe('ExchangeRateService', () => {
     })
 
     it('throws error for dates far in the future', async () => {
-      const futureDate = new Date('2050-12-31T00:00:00Z')
+      const futureDate = new Date(Date.now() + 25 * 365 * 24 * 60 * 60 * 1000)
 
       await expect(
         service.getRate({

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-026.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-026.spec.ts
@@ -104,7 +104,7 @@ test.describe('TC-CRM-026: Canonical Interactions API', () => {
 
       const createRes = await apiRequest(request, 'POST', '/api/customers/interactions', {
         token,
-        data: { entityId: companyId, interactionType: 'meeting', title: 'CRM-026 cancel test', scheduledAt: '2026-07-01T14:00:00Z' },
+        data: { entityId: companyId, interactionType: 'meeting', title: 'CRM-026 cancel test', scheduledAt: new Date(Date.now() + 30 * 86_400_000).toISOString() },
       });
       expect(createRes.status()).toBe(201);
       const created = await readJsonSafe<JsonRecord>(createRes);
@@ -194,11 +194,11 @@ test.describe('TC-CRM-026: Canonical Interactions API', () => {
       const [callRes, meetingRes] = await Promise.all([
         apiRequest(request, 'POST', '/api/customers/interactions', {
           token,
-          data: { entityId: companyId, interactionType: 'call', title: 'CRM-026 filter call', scheduledAt: '2026-08-01T10:00:00Z' },
+          data: { entityId: companyId, interactionType: 'call', title: 'CRM-026 filter call', scheduledAt: new Date(Date.now() + 30 * 86_400_000).toISOString() },
         }),
         apiRequest(request, 'POST', '/api/customers/interactions', {
           token,
-          data: { entityId: companyId, interactionType: 'meeting', title: 'CRM-026 filter meeting', scheduledAt: '2026-09-01T14:00:00Z' },
+          data: { entityId: companyId, interactionType: 'meeting', title: 'CRM-026 filter meeting', scheduledAt: new Date(Date.now() + 60 * 86_400_000).toISOString() },
         }),
       ]);
       expect(callRes.status()).toBe(201);

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-027.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-027.spec.ts
@@ -135,7 +135,7 @@ test.describe('TC-CRM-027: Person Detail & Interaction ACL', () => {
       // Create one as admin so we can test update/delete denial
       const adminCreateRes = await apiRequest(request, 'POST', '/api/customers/interactions', {
         token: adminToken,
-        data: { entityId: companyId, interactionType: 'call', title: 'Admin created', scheduledAt: '2026-09-01T10:00:00Z' },
+        data: { entityId: companyId, interactionType: 'call', title: 'Admin created', scheduledAt: new Date(Date.now() + 90 * 86_400_000).toISOString() },
       });
       const adminCreated = await readJsonSafe<JsonRecord>(adminCreateRes);
       interactionId = typeof adminCreated?.id === 'string' ? adminCreated.id : null;

--- a/packages/core/src/modules/customers/__tests__/validators.test.ts
+++ b/packages/core/src/modules/customers/__tests__/validators.test.ts
@@ -150,7 +150,7 @@ describe('interactionUpdateSchema scheduledAt derivation', () => {
   it('derives scheduledAt on update when only date+time supplied', () => {
     const result = interactionUpdateSchema.safeParse({
       ...baseUpdate,
-      date: '2026-07-20',
+      date: new Date(Date.now() + 30 * 86_400_000).toISOString().slice(0, 10),
       time: '08:15',
     })
     expect(result.success).toBe(true)

--- a/packages/core/src/modules/customers/api/deals/__tests__/route.filters.test.ts
+++ b/packages/core/src/modules/customers/api/deals/__tests__/route.filters.test.ts
@@ -59,7 +59,7 @@ describe('customers deals list filters', () => {
   it('applies date range filter when expectedCloseAtFrom/To are provided', async () => {
     const parsed = dealListQuerySchema.parse({
       expectedCloseAtFrom: '2026-01-01',
-      expectedCloseAtTo: '2026-12-31',
+      expectedCloseAtTo: new Date(Date.now() + 180 * 86_400_000).toISOString().slice(0, 10),
     })
     const filters = await buildDealListFilters(parsed)
     expect(filters.expected_close_at).toMatchObject({

--- a/packages/core/src/modules/customers/components/detail/__tests__/ScheduleActivityDialog.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ScheduleActivityDialog.test.tsx
@@ -19,7 +19,7 @@ function createScheduleState(overrides: Record<string, unknown> = {}) {
     setActivityType: jest.fn(),
     title: 'Quarterly review',
     setTitle: jest.fn(),
-    date: '2026-08-03',
+    date: new Date(Date.now() + 60 * 86_400_000).toISOString().slice(0, 10),
     setDate: jest.fn(),
     startTime: '13:45',
     setStartTime: jest.fn(),

--- a/packages/core/src/modules/messages/api/token/[token]/__tests__/route.test.ts
+++ b/packages/core/src/modules/messages/api/token/[token]/__tests__/route.test.ts
@@ -62,7 +62,7 @@ describe('messages /api/messages/token/[token]', () => {
       token: 'ok',
       messageId: 'message-1',
       recipientUserId: 'user-1',
-      expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+      expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
       useCount: 0,
     }
   }

--- a/packages/core/src/modules/planner/__integration__/TC-PLAN-003.spec.ts
+++ b/packages/core/src/modules/planner/__integration__/TC-PLAN-003.spec.ts
@@ -102,9 +102,9 @@ test.describe('TC-PLAN-003: Weekly & Date-specific availability replace APIs', (
         displayName: `QA DateSpec ${stamp}`,
       })
 
-      // Set date-specific availability for two dates
-      const targetDate1 = '2026-06-15'
-      const targetDate2 = '2026-06-16'
+      // Set date-specific availability for two dates (relative to now so the test never expires)
+      const targetDate1 = new Date(Date.now() + 30 * 86_400_000).toISOString().slice(0, 10)
+      const targetDate2 = new Date(Date.now() + 31 * 86_400_000).toISOString().slice(0, 10)
 
       const dateSpecResponse = await apiRequest(
         request,

--- a/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
+++ b/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
@@ -184,6 +184,8 @@ describe('Workflows Validators', () => {
         stepType: 'WAIT_FOR_TIMER' as const,
       }
 
+      const futureDatetime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+
       test('accepts ISO 8601 duration', () => {
         expect(() =>
           workflowStepSchema.parse({ ...baseTimerStep, config: { duration: 'PT5M' } })
@@ -204,7 +206,7 @@ describe('Workflows Validators', () => {
 
       test('accepts ISO datetime as "until"', () => {
         expect(() =>
-          workflowStepSchema.parse({ ...baseTimerStep, config: { until: '2026-06-01T12:00:00.000Z' } })
+          workflowStepSchema.parse({ ...baseTimerStep, config: { until: futureDatetime } })
         ).not.toThrow()
       })
 
@@ -242,7 +244,7 @@ describe('Workflows Validators', () => {
         expect(() =>
           workflowStepSchema.parse({
             ...baseTimerStep,
-            config: { duration: 'PT5M', until: '2026-06-01T12:00:00.000Z' },
+            config: { duration: 'PT5M', until: futureDatetime },
           })
         ).toThrow(/not both/i)
       })
@@ -379,6 +381,8 @@ describe('Workflows Validators', () => {
         activityType: 'WAIT' as const,
       }
 
+      const futureDatetime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+
       test('accepts ISO 8601 duration', () => {
         expect(() =>
           activityDefinitionSchema.parse({ ...baseWait, config: { duration: 'PT5M' } })
@@ -407,7 +411,7 @@ describe('Workflows Validators', () => {
         expect(() =>
           activityDefinitionSchema.parse({
             ...baseWait,
-            config: { duration: 'PT5M', until: '2026-06-01T12:00:00.000Z' },
+            config: { duration: 'PT5M', until: futureDatetime },
           })
         ).toThrow(/not both/i)
       })

--- a/packages/enterprise/src/modules/record_locks/__tests__/recordLockService.test.ts
+++ b/packages/enterprise/src/modules/record_locks/__tests__/recordLockService.test.ts
@@ -711,7 +711,7 @@ describe('RecordLockService.emitIncomingChangesNotificationAfterMutation', () =>
         lockedByUserId: '40000000-0000-4000-8000-000000000001',
         lockedAt: new Date('2026-02-17T10:00:00.000Z'),
         baseActionLogId: '50000000-0000-4000-8000-000000000001',
-        expiresAt: new Date('2099-02-17T10:05:00.000Z'),
+        expiresAt: new Date(Date.now() + 86_400_000),
       }),
     ])
     serviceAny.findLatestActionLog = jest.fn().mockResolvedValue({
@@ -757,7 +757,7 @@ describe('RecordLockService.emitIncomingChangesNotificationAfterMutation', () =>
         lockedByUserId: '40000000-0000-4000-8000-000000000001',
         lockedAt: new Date('2026-02-17T10:00:00.000Z'),
         baseActionLogId: '50000000-0000-4000-8000-000000000001',
-        expiresAt: new Date('2099-02-17T10:05:00.000Z'),
+        expiresAt: new Date(Date.now() + 86_400_000),
       }),
     ])
     serviceAny.findLatestActionLog = jest.fn().mockResolvedValue({
@@ -804,7 +804,7 @@ describe('RecordLockService.emitIncomingChangesNotificationAfterMutation', () =>
         lockedByUserId: '40000000-0000-4000-8000-000000000001',
         lockedAt: new Date('2026-02-17T10:00:00.000Z'),
         baseActionLogId: '50000000-0000-4000-8000-000000000001',
-        expiresAt: new Date('2099-02-17T10:05:00.000Z'),
+        expiresAt: new Date(Date.now() + 86_400_000),
       }),
     ])
     serviceAny.findLatestActionLog = jest.fn().mockResolvedValue({
@@ -843,7 +843,7 @@ describe('RecordLockService.emitIncomingChangesNotificationAfterMutation', () =>
     em.find.mockResolvedValue([
       buildLock({
         lockedByUserId: '40000000-0000-4000-8000-000000000001',
-        expiresAt: new Date('2099-02-17T10:05:00.000Z'),
+        expiresAt: new Date(Date.now() + 86_400_000),
       }),
     ])
     serviceAny.findLatestActionLog = jest.fn().mockResolvedValue(null)
@@ -879,7 +879,7 @@ describe('RecordLockService.emitIncomingChangesNotificationAfterMutation', () =>
         buildLock({
           lockedByUserId: '40000000-0000-4000-8000-000000000001',
           organizationId: '70000000-0000-4000-8000-000000000099',
-          expiresAt: new Date('2099-02-17T10:05:00.000Z'),
+          expiresAt: new Date(Date.now() + 86_400_000),
         }),
       ])
 
@@ -934,7 +934,7 @@ describe('RecordLockService.emitIncomingChangesNotificationAfterMutation', () =>
         buildLock({
           lockedByUserId: '40000000-0000-4000-8000-000000000001',
           organizationId: '70000000-0000-4000-8000-000000000001',
-          expiresAt: new Date('2099-02-17T10:05:00.000Z'),
+          expiresAt: new Date(Date.now() + 86_400_000),
         }),
       ])
 
@@ -991,7 +991,7 @@ describe('RecordLockService.emitIncomingChangesNotificationAfterMutation', () =>
           status: 'released',
           lockedByUserId: '40000000-0000-4000-8000-000000000001',
           updatedAt: new Date('2026-02-17T10:04:30.000Z'),
-          expiresAt: new Date('2099-02-17T10:04:00.000Z'),
+          expiresAt: new Date(Date.now() + 86_400_000),
         }),
       ])
 
@@ -1048,7 +1048,7 @@ describe('RecordLockService.emitIncomingChangesNotificationAfterMutation', () =>
         status: 'force_released',
         lockedByUserId: '40000000-0000-4000-8000-000000000001',
         updatedAt: new Date('2026-02-17T10:04:30.000Z'),
-        expiresAt: new Date('2099-02-17T10:04:00.000Z'),
+        expiresAt: new Date(Date.now() + 86_400_000),
       }),
     ])
     serviceAny.findLatestActionLog = jest.fn().mockResolvedValue({

--- a/scripts/time-bomb-scanner.mjs
+++ b/scripts/time-bomb-scanner.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+// Time-bomb test scanner.
+//
+// A "time-bomb" test is one that hardcodes an absolute date/datetime literal
+// whose pass/fail outcome depends on the wall clock at run time. The classic
+// failure mode (see issue #2384) is a literal that was "just over the horizon"
+// when authored and asserted as valid/future — it silently flips to failing
+// once that timestamp elapses, turning CI red on unrelated PRs.
+//
+// This scanner walks test files, extracts absolute date literals, and uses the
+// surrounding lines (±2) to judge whether the assertion is clock-dependent:
+//
+//   HIGH   — future literal asserted as future-valid (will flip when it elapses),
+//            or a future-validity assertion whose literal has already elapsed
+//            (likely failing right now).
+//   MEDIUM — near-future fixture literal (becomes past soon), or a far-future
+//            (> 5y) "slow" time-bomb, or an ambiguous past-in-validity-context.
+//   LOW    — literal echoed in an equality/format assertion (both sides
+//            hardcoded → not clock-dependent), or a plain past fixture.
+//
+// Intentional "rejects past datetime" tests (a past literal asserted to throw)
+// are recognised and NOT flagged. The safe, time-independent patterns
+// (`Date.now()`, `new Date()`, `new Date(Date.now() + 60_000)`) contain no
+// literal and are naturally ignored.
+//
+// Usage:
+//   node scripts/time-bomb-scanner.mjs [--json] [--all] [--fail]
+//        [--fail-on=high|medium] [--now=<ISO>] [path ...]
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const rawArgs = process.argv.slice(2)
+const flags = new Set(rawArgs.filter((a) => a.startsWith('--')))
+const positional = rawArgs.filter((a) => !a.startsWith('--'))
+
+const json = flags.has('--json')
+const includeLow = flags.has('--all')
+const shouldFail = flags.has('--fail')
+
+function flagValue(name, fallback) {
+  const hit = rawArgs.find((a) => a.startsWith(`${name}=`))
+  return hit ? hit.split('=').slice(1).join('=') : fallback
+}
+
+const failOn = flagValue('--fail-on', 'high').toLowerCase()
+const nowArg = flagValue('--now', null)
+const now = nowArg ? new Date(nowArg).getTime() : Date.now()
+if (Number.isNaN(now)) {
+  console.error(`Invalid --now value: ${nowArg}`)
+  process.exit(2)
+}
+
+const allowlistPath = path.join(root, '.ai/time-bomb-allowlist.json')
+
+const YEAR_MS = 365 * 24 * 60 * 60 * 1000
+const FAR_FUTURE_YEARS = 5
+const CONTEXT_RADIUS = 2 // lines of context examined on each side of a literal
+const SEVERITY_ORDER = { high: 3, medium: 2, low: 1 }
+const IGNORE_DIRS = new Set(['node_modules', '.next', '.mercato', 'dist', 'coverage', 'generated', '.git'])
+const TEST_FILE_RE = /(?:\.(?:test|spec)\.[mc]?[jt]sx?$)|(?:[\\/]__tests__[\\/])/
+const SENTINEL_YEAR = 9000 // years >= this are treated as never-expiring sentinels (e.g. 9999-12-31)
+
+// Quoted ISO-8601 date or datetime literal, e.g. '2026-06-01T12:00:00.000Z' or "2025-01-01".
+const ISO_LITERAL_RE =
+  /(['"`])(\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:?\d{2})?)?)\1/g
+
+// Context markers.
+const VALIDITY_RE = /\buntil\b|isFuture|\bfuture\b|must be a future|toBeGreaterThan|isAfter\b/i
+const REJECT_RE = /\.toThrow|toThrow\(/
+const ACCEPT_RE = /not\.toThrow/
+const ECHO_RE = /\.(?:toBe|toEqual|toStrictEqual|toContain)\(|toHaveValue\(|toHaveBeenCalledWith\(/
+
+function loadAllowlist() {
+  if (!existsSync(allowlistPath)) return { locations: new Set(), literals: new Set() }
+  try {
+    const parsed = JSON.parse(readFileSync(allowlistPath, 'utf8'))
+    const entries = Array.isArray(parsed) ? parsed : parsed.entries ?? []
+    const locations = new Set()
+    const literals = new Set()
+    for (const entry of entries) {
+      const value = typeof entry === 'string' ? entry : entry?.match
+      if (!value) continue
+      if (/:\d+$/.test(value) || value.includes('/')) locations.add(value)
+      else literals.add(value)
+    }
+    return { locations, literals }
+  } catch (err) {
+    console.error(`Failed to parse ${rel(allowlistPath)}: ${err.message}`)
+    return { locations: new Set(), literals: new Set() }
+  }
+}
+
+function normalize(file) {
+  return file.split(path.sep).join('/')
+}
+
+function rel(file) {
+  return normalize(path.relative(root, file))
+}
+
+function walk(dir, out = []) {
+  if (!existsSync(dir)) return out
+  let entries
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return out
+  }
+  for (const entry of entries) {
+    if (IGNORE_DIRS.has(entry)) continue
+    const full = path.join(dir, entry)
+    let st
+    try {
+      st = statSync(full)
+    } catch {
+      continue
+    }
+    if (st.isDirectory()) walk(full, out)
+    else if (TEST_FILE_RE.test(normalize(full))) out.push(full)
+  }
+  return out
+}
+
+function classify(timestamp, line, context) {
+  const year = new Date(timestamp).getUTCFullYear()
+  if (year >= SENTINEL_YEAR) return null // never-expiring sentinel
+
+  const future = timestamp > now
+  const yearsOut = (timestamp - now) / YEAR_MS
+  const isValidity = VALIDITY_RE.test(context)
+  const expectsReject = REJECT_RE.test(context)
+  const expectsAccept = ACCEPT_RE.test(context)
+  const isEcho = ECHO_RE.test(line)
+
+  if (isValidity) {
+    if (future) {
+      if (yearsOut > FAR_FUTURE_YEARS) {
+        return { severity: 'medium', reason: 'far-future validity literal — slow time-bomb' }
+      }
+      return { severity: 'high', reason: 'future literal in a future-validity assertion — flips when it elapses' }
+    }
+    // past literal in a future-validity context
+    if (expectsReject && !expectsAccept) {
+      return null // intentional "rejects past datetime" test — correct by design
+    }
+    if (expectsAccept) {
+      return {
+        severity: 'high',
+        reason: 'future-validity assertion whose literal has already elapsed — likely failing now',
+      }
+    }
+    return { severity: 'medium', reason: 'past literal in a future-validity context — review for clock dependence' }
+  }
+
+  if (isEcho) {
+    return { severity: 'low', reason: 'literal echoed in an equality/format assertion — not clock-dependent' }
+  }
+
+  if (future) {
+    if (yearsOut > FAR_FUTURE_YEARS) {
+      return { severity: 'medium', reason: 'far-future fixture literal — slow time-bomb' }
+    }
+    return {
+      severity: 'medium',
+      reason: 'near-future fixture literal — becomes past soon; verify no future-dependent assertion relies on it',
+    }
+  }
+  return { severity: 'low', reason: 'past date fixture — usually stable' }
+}
+
+function scanFile(file) {
+  const text = readFileSync(file, 'utf8')
+  const lines = text.split(/\r?\n/)
+  const findings = []
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const context = lines.slice(Math.max(0, i - CONTEXT_RADIUS), i + CONTEXT_RADIUS + 1).join('\n')
+    ISO_LITERAL_RE.lastIndex = 0
+    let match
+    while ((match = ISO_LITERAL_RE.exec(line)) !== null) {
+      const literal = match[2]
+      const timestamp = new Date(literal).getTime()
+      if (Number.isNaN(timestamp)) continue
+      const verdict = classify(timestamp, line, context)
+      if (!verdict) continue
+      findings.push({
+        file: rel(file),
+        line: i + 1,
+        literal,
+        iso: new Date(timestamp).toISOString(),
+        severity: verdict.severity,
+        reason: verdict.reason,
+        snippet: line.trim().slice(0, 160),
+      })
+    }
+  }
+  return findings
+}
+
+const allowlist = loadAllowlist()
+
+function isAllowlisted(finding) {
+  if (allowlist.literals.has(finding.literal)) return true
+  if (allowlist.locations.has(`${finding.file}:${finding.line}`)) return true
+  if (allowlist.locations.has(finding.file)) return true
+  return false
+}
+
+const searchRoots = positional.length
+  ? positional.map((p) => path.resolve(root, p))
+  : [path.join(root, 'packages'), path.join(root, 'apps'), path.join(root, 'external')]
+
+const files = searchRoots.flatMap((target) => {
+  if (!existsSync(target)) return []
+  return statSync(target).isDirectory() ? walk(target) : [target]
+})
+
+let findings = files
+  .flatMap(scanFile)
+  .filter((f) => !isAllowlisted(f))
+  .filter((f) => includeLow || f.severity !== 'low')
+
+findings.sort(
+  (a, b) =>
+    SEVERITY_ORDER[b.severity] - SEVERITY_ORDER[a.severity] ||
+    a.file.localeCompare(b.file) ||
+    a.line - b.line
+)
+
+const counts = findings.reduce(
+  (acc, f) => ((acc[f.severity] = (acc[f.severity] ?? 0) + 1), acc),
+  { high: 0, medium: 0, low: 0 }
+)
+
+if (json) {
+  console.log(
+    JSON.stringify(
+      { now: new Date(now).toISOString(), scannedFiles: files.length, counts, findings },
+      null,
+      2
+    )
+  )
+} else {
+  printReport()
+}
+
+function severityLabel(severity) {
+  return { high: 'HIGH  ', medium: 'MEDIUM', low: 'LOW   ' }[severity]
+}
+
+function printReport() {
+  console.log(`Time-bomb test scan`)
+  console.log(`  reference now : ${new Date(now).toISOString()}`)
+  console.log(`  test files    : ${files.length}`)
+  console.log(
+    `  findings      : ${findings.length} (high: ${counts.high}, medium: ${counts.medium}, low: ${counts.low}${
+      includeLow ? '' : ' — low hidden, pass --all to show'
+    })`
+  )
+  console.log('')
+
+  if (findings.length === 0) {
+    console.log('  No actionable time-bomb literals detected. ✅')
+    return
+  }
+
+  for (const f of findings) {
+    console.log(`  [${severityLabel(f.severity)}] ${f.file}:${f.line}`)
+    console.log(`            literal "${f.literal}" → ${f.iso}`)
+    console.log(`            ${f.reason}`)
+    console.log(`            ${f.snippet}`)
+    console.log('')
+  }
+
+  console.log('  Fix: replace the literal with a clock-relative value computed at run time, e.g.')
+  console.log("       const future = new Date(Date.now() + 60_000).toISOString()")
+  console.log(`  Intentional literals can be allowlisted in ${rel(allowlistPath)}.`)
+}
+
+if (shouldFail) {
+  const threshold = SEVERITY_ORDER[failOn] ?? SEVERITY_ORDER.high
+  const breaching = findings.filter((f) => SEVERITY_ORDER[f.severity] >= threshold)
+  if (breaching.length > 0) process.exit(1)
+}


### PR DESCRIPTION
## Why

`main`'s unit suite is red because of a **time-bomb test** — a test with a hardcoded future date that has now elapsed.

`packages/core/src/modules/workflows/data/__tests__/validators.test.ts` asserted that a WAIT-timer step accepts `until: '2026-06-01T12:00:00.000Z'`. The validator (`validators.ts`) requires `until` to be a *future* datetime. As of 2026-06-03 that literal is in the past, so the validator correctly throws `"until" must be a future datetime` and the `.not.toThrow()` assertion fails.

Reproduced on `main`: `Tests: 1 failed, 67 passed`. After this PR: `68 passed`.

## What

Cherry-picks the two already-reviewed develop commits that fix this and prevent recurrence:

- **`7090ca7a6`** — compute the timer `until` datetime dynamically (`now + 24h`) so the assertion can never expire. This is the actual fix for the failing test.
- **`86677441c` (#2393)** — add `scripts/time-bomb-scanner.mjs`, the `check:time-bombs` / `check:time-bombs:fail` npm scripts, an allowlist, and a CI gate that fails a build on **HIGH** findings (a future-validity literal that has already elapsed). Also converts other near/far-future literals to clock-relative values.

> Note: this includes a CI pipeline addition (`.github/workflows/ci.yml` runs `check:time-bombs:fail`). The gate fails only on HIGH findings, so the existing MEDIUM/LOW fixture literals on `main` do not block it.

## Verification

- `node scripts/time-bomb-scanner.mjs --fail` → `findings: 0` (exit 0) ✅
- `jest src/modules/workflows/data/__tests__/validators.test.ts` → `68 passed` ✅

These commits already live on `develop`; this PR forward-ports the fix to the lagging `main` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)