### PR TITLE
fix(catalog): tier pricing tie-break selects higher minQuantity

### DIFF
--- a/packages/core/src/modules/catalog/AGENTS.md
+++ b/packages/core/src/modules/catalog/AGENTS.md
@@ -26,6 +26,16 @@ registerCatalogPricingResolver(myResolver, { priority: 10 })
 
 The default pipeline emits `catalog.pricing.resolve.before|after` events.
 
+### Price selection order
+
+When multiple price rows match the same context, `selectBestPrice` resolves ties in this order:
+
+1. **Score** (descending) — `custom` > `promotion` > `tier` > `regular`, plus additional points for variant, offer, channel, user, group, and customer scoping. See `scorePrice` for the full rubric.
+2. **`startsAt`** (descending) — when scores tie, the row with the more recent `startsAt` wins.
+3. **`minQuantity`** — direction depends on whether the tied rows share the same resolved kind:
+    - **Same kind** (e.g. tier vs tier): **descending** — the row with the larger `minQuantity` wins. This implements the standard volume-discount semantic: for `qty=50` with tiers `minQty=10` ($9) and `minQty=50` ($8), the `minQty=50` row applies (issue #1706).
+    - **Different kinds** (e.g. promotion vs tier): **ascending** — the row with the smaller `minQuantity` wins. The `+1 for minQuantity > 1` bonus in `scorePrice` can pull a lower-base kind up to the same total as a higher-base kind (e.g. tier `minQty=3` = 3+1 vs promotion `minQty=1` = 4). Ascending across kinds preserves the kind precedence in those collisions.
+
 ## Data Model Constraints
 
 - **Products** — core entities with media and descriptions. MUST have at least a name

--- a/packages/core/src/modules/catalog/lib/__tests__/pricing.test.ts
+++ b/packages/core/src/modules/catalog/lib/__tests__/pricing.test.ts
@@ -56,6 +56,12 @@ describe('catalog pricing helpers', () => {
   })
 
   it('selects the highest scoring price with deterministic tie breakers', () => {
+    // `base` has score 2 (regular kind, no scoping). Both variant rows share kind, variant,
+    // and channel scoping so they tie at score 17 — verifying that scorePrice wins first
+    // and `startsAt` (descending) breaks the remaining tie. `older-variant` keeps the
+    // default `minQuantity` from `baseRow` so it passes `matchesContext` at `ctx.quantity=1`
+    // and actually reaches the comparator (prior to this it carried `minQuantity: 5` and
+    // was filtered out before the sort ran, leaving the tie-break code unexercised).
     const rows: PriceRow[] = [
       baseRow({ id: 'base', minQuantity: 1, kind: 'regular' }),
       baseRow({
@@ -73,7 +79,6 @@ describe('catalog pricing helpers', () => {
         priceKind: { id: 'pk-promo', code: 'promotion', isPromotion: true } as any,
         channelId: 'channel-1',
         startsAt: new Date('2024-01-01T00:00:00Z'),
-        minQuantity: 5,
       }),
     ]
 
@@ -146,5 +151,61 @@ describe('catalog pricing helpers', () => {
 
     expect(emitEvent).toHaveBeenCalledTimes(2)
     expect(result).toBe(overridden)
+  })
+
+  it('breaks tier-pricing ties by selecting the higher minQuantity (volume discount semantic)', () => {
+    // Mirrors the repro from issue #1706:
+    // qty=3 with tiers minQty=2 ($9) and minQty=3 ($8) must resolve to the minQty=3 tier.
+    const tierKind = { id: 'pk-tier', code: 'tier', isPromotion: false } as any
+    const tierLow = baseRow({
+      id: 'tier-low',
+      kind: 'tier',
+      minQuantity: 2,
+      priceKind: tierKind,
+      unitPriceNet: '9.00',
+      unitPriceGross: '11.07',
+    })
+    const tierHigh = baseRow({
+      id: 'tier-high',
+      kind: 'tier',
+      minQuantity: 3,
+      priceKind: tierKind,
+      unitPriceNet: '8.00',
+      unitPriceGross: '9.84',
+    })
+
+    const result = selectBestPrice([tierLow, tierHigh], { ...ctx, quantity: 3 })
+
+    expect(result?.id).toBe('tier-high')
+  })
+
+  it('keeps promotion over tier when scorePrice ties them across kinds', () => {
+    // Regression guard for the #1706 fix: scorePrice gives `promotion` base=4 and `tier`
+    // base=3 + 1 (bonus for minQuantity > 1). A promotion row with minQuantity=1 and a
+    // tier row with minQuantity>=2 both end up at score=4 with no other scoping. Tie-break
+    // on minQuantity must keep promotion (lower minQuantity) winning across kinds — the
+    // descending direction introduced for #1706 only applies within the same kind.
+    const promoKind = { id: 'pk-promo', code: 'promotion', isPromotion: true } as any
+    const tierKind = { id: 'pk-tier', code: 'tier', isPromotion: false } as any
+    const promo = baseRow({
+      id: 'promo',
+      kind: 'promotion',
+      minQuantity: 1,
+      priceKind: promoKind,
+      unitPriceNet: '7.00',
+      unitPriceGross: '8.61',
+    })
+    const tier = baseRow({
+      id: 'tier',
+      kind: 'tier',
+      minQuantity: 3,
+      priceKind: tierKind,
+      unitPriceNet: '8.00',
+      unitPriceGross: '9.84',
+    })
+
+    const result = selectBestPrice([promo, tier], { ...ctx, quantity: 5 })
+
+    expect(result?.id).toBe('promo')
   })
 })

--- a/packages/core/src/modules/catalog/lib/pricing.ts
+++ b/packages/core/src/modules/catalog/lib/pricing.ts
@@ -95,6 +95,14 @@ export function selectBestPrice(rows: PriceRow[], ctx: PricingContext): PriceRow
     const startA = a.startsAt ? a.startsAt.getTime() : 0
     const startB = b.startsAt ? b.startsAt.getTime() : 0
     if (startA !== startB) return startB - startA
+    // minQuantity tie-break is direction-dependent on the resolved kind.
+    // Within the same kind we pick the more specific tier (higher minQuantity wins — issue #1706).
+    // Across kinds we keep the pre-#1706 ascending order so a row whose kind has a higher
+    // scoreBase still wins when scorePrice's "+1 for minQuantity > 1" bonus produces a
+    // cross-kind collision (e.g. promotion[minQty=1]=4 vs tier[minQty=3]=4).
+    if (resolvePriceKindCode(a) === resolvePriceKindCode(b)) {
+      return (b.minQuantity ?? 1) - (a.minQuantity ?? 1)
+    }
     return (a.minQuantity ?? 1) - (b.minQuantity ?? 1)
   })
   return candidates[0]


### PR DESCRIPTION
Fixes #1706.

## Summary

`selectBestPrice` previously broke ties on `minQuantity` ascending, so when two tier-priced rows both matched the pricing context the lower `minQuantity` (smaller-volume) tier won — contradicting the standard volume-discount semantic. This PR resolves the `minQuantity` tie-break direction based on whether the tied rows share the same resolved kind.

- **Same kind** (e.g. tier vs tier): **descending** — the more specific tier wins. For the issue body repro (`qty=3`, tiers `minQty=2` $9 and `minQty=3` $8), `selectBestPrice` now resolves to the `minQty=3` row.
- **Different kinds** (e.g. promotion vs tier): **ascending** — preserves kind precedence when `scorePrice`'s `+1 for minQuantity > 1` bonus pulls a lower-base kind up to the same total as a higher-base kind (e.g. `tier[minQty>=2]=3+1` collides with `promotion[minQty=1]=4`).

## Why not the unconditional comparator flip

The issue body suggested two possible fixes: flip the comparator, or weight the score by `minQuantity`. An unconditional flip introduces a cross-kind regression — `promotion[minQty=1]` (score 4) tied with `tier[minQty=3]` (score 3+1) would resolve to the `tier` row, when the `promotion` row should win. The same collision shape exists for `promotion[minQty>1]=5` vs `custom[minQty=1]=5`. Limiting the descending direction to same-kind ties fixes both without changing `scorePrice`.

## Changes

- `packages/core/src/modules/catalog/lib/pricing.ts` — comparator in `selectBestPrice` resolves the `minQuantity` tie-break direction based on the resolved kind of both rows.
- `packages/core/src/modules/catalog/lib/__tests__/pricing.test.ts`
  - New unit test for the within-kind case (issue body repro: `qty=3`, tiers `minQty=2`/`3` → `minQty=3` wins).
  - New unit test for the cross-kind collision case (`promotion[minQty=1]` vs `tier[minQty=3]`, `qty=5` → `promotion` wins).
  - Reworked the existing `selects the highest scoring price with deterministic tie breakers` test so it actually reaches the comparator. The higher-scoring row previously carried `minQuantity=5` and was filtered out by `matchesContext` at `ctx.quantity=1`, leaving the tie-break code unexercised.
- `packages/core/src/modules/catalog/AGENTS.md` — documents the resulting tie-break order (`score` → `startsAt` → `minQuantity`, direction-dependent on kind), closing the doc gap flagged in the issue body.

## CI gate (local)

- ✅ `yarn typecheck` — 19/19 packages pass
- ✅ Catalog Jest suite — 45/45 suites, 550/550 tests pass (8 pricing tests including the two new ones)
- ✅ `yarn build:app` — pass

Closes #1706
