### PR TITLE
fix(sales): preserve payment totals & derive tax from net/gross on document reads (#2455, #2457)

### DIFF
--- a/packages/core/src/modules/sales/__integration__/TC-SALES-030.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-030.spec.ts
@@ -447,4 +447,165 @@ test.describe('TC-SALES-030 sales read-model totals fidelity', () => {
       await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
     }
   })
+
+  test('rate-based and tax-kind order adjustments aggregate correctly', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let discountOrderId: string | null = null
+    let taxOrderId: string | null = null
+
+    try {
+      // Rate-based discount: 10% of a 100 net line.
+      const discountOrderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      discountOrderId = (await readJson(discountOrderResponse)).id as string
+      await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId: discountOrderId, currencyCode: 'USD', quantity: 1, name: 'Rate disc line', unitPriceNet: 100, unitPriceGross: 100 },
+      })
+      await apiRequest(request, 'POST', '/api/sales/order-adjustments', {
+        token,
+        data: { orderId: discountOrderId, scope: 'order', kind: 'discount', rate: 10, currencyCode: 'USD', label: 'Percent off' },
+      })
+      const discountOrder = await readSingleDocument(request, token, 'orders', discountOrderId!)
+      expect(num(discountOrder.discountTotalAmount)).toBe(10)
+      expect(num(discountOrder.grandTotalNetAmount)).toBe(90)
+
+      // Tax-kind adjustment: an explicit 7 tax on a 100 net line.
+      const taxOrderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      taxOrderId = (await readJson(taxOrderResponse)).id as string
+      await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId: taxOrderId, currencyCode: 'USD', quantity: 1, name: 'Tax adj line', unitPriceNet: 100, unitPriceGross: 100 },
+      })
+      await apiRequest(request, 'POST', '/api/sales/order-adjustments', {
+        token,
+        data: { orderId: taxOrderId, scope: 'order', kind: 'tax', amountNet: 7, amountGross: 7, currencyCode: 'USD', label: 'Eco tax' },
+      })
+      const taxOrder = await readSingleDocument(request, token, 'orders', taxOrderId!)
+      expect(num(taxOrder.taxTotalAmount)).toBe(7)
+      expect(num(taxOrder.grandTotalGrossAmount)).toBe(107)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', discountOrderId)
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', taxOrderId)
+    }
+  })
+
+  test('multiple payments sum into paid total', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let orderId: string | null = null
+    const paymentIds: string[] = []
+
+    try {
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      orderId = (await readJson(orderResponse)).id as string
+      await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId, currencyCode: 'USD', quantity: 1, name: 'Split-pay line', unitPriceNet: 100, unitPriceGross: 100 },
+      })
+      for (const amount of [30, 50]) {
+        const payResponse = await apiRequest(request, 'POST', '/api/sales/payments', {
+          token,
+          data: { orderId, amount, currencyCode: 'USD' },
+        })
+        expect(payResponse.status()).toBe(201)
+        paymentIds.push((await readJson(payResponse)).id as string)
+      }
+
+      const order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.paidTotalAmount)).toBe(80)
+      expect(num(order.outstandingAmount)).toBe(20)
+    } finally {
+      for (const id of paymentIds) {
+        await deleteSalesEntityIfExists(request, token, '/api/sales/payments', id)
+      }
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+
+  test('deleting an order adjustment recomputes document totals', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let orderId: string | null = null
+
+    try {
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      orderId = (await readJson(orderResponse)).id as string
+      await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId, currencyCode: 'USD', quantity: 1, name: 'Adj-del line', unitPriceNet: 100, unitPriceGross: 100 },
+      })
+      const adjResponse = await apiRequest(request, 'POST', '/api/sales/order-adjustments', {
+        token,
+        data: { orderId, scope: 'order', kind: 'surcharge', amountNet: 25, amountGross: 25, currencyCode: 'USD', label: 'Temp fee' },
+      })
+      expect(adjResponse.status()).toBe(201)
+      const adjustmentId = (await readJson(adjResponse)).id as string
+
+      let order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.grandTotalGrossAmount)).toBe(125)
+
+      const deleteResponse = await apiRequest(request, 'DELETE', '/api/sales/order-adjustments', {
+        token,
+        data: { id: adjustmentId, orderId },
+      })
+      expect(deleteResponse.status()).toBe(200)
+
+      order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.surchargeTotalAmount)).toBe(0)
+      expect(num(order.grandTotalGrossAmount)).toBe(100)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+
+  test('deleting an order line recomputes document totals', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let orderId: string | null = null
+
+    try {
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      orderId = (await readJson(orderResponse)).id as string
+      await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId, currencyCode: 'USD', quantity: 1, name: 'Keep', unitPriceNet: 100, unitPriceGross: 100 },
+      })
+      const removableResponse = await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId, currencyCode: 'USD', quantity: 1, name: 'Remove', unitPriceNet: 40, unitPriceGross: 40 },
+      })
+      const removableLineId = (await readJson(removableResponse)).id as string
+
+      let order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.subtotalNetAmount)).toBe(140)
+
+      const deleteResponse = await apiRequest(request, 'DELETE', '/api/sales/order-lines', {
+        token,
+        data: { id: removableLineId, orderId },
+      })
+      expect(deleteResponse.status()).toBe(200)
+
+      order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.subtotalNetAmount)).toBe(100)
+      expect(num(order.grandTotalGrossAmount)).toBe(100)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
 })

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-030.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-030.spec.ts
@@ -1,0 +1,450 @@
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { deleteSalesEntityIfExists } from '@open-mercato/core/helpers/integration/salesFixtures'
+
+/**
+ * TC-SALES-030: order/quote read-model totals fidelity.
+ *
+ * Regression coverage for two defects in the sales calculation pipeline that
+ * only surface on the read path (single-document detail read recomputes display
+ * totals through the calculation service, where the provider totals calculator
+ * rebuilds the document from lines+adjustments):
+ *
+ *  - #2455: after recording a payment, the order detail read returned the
+ *    pre-payment snapshot (paid 0 / outstanding = grand total) because the
+ *    rebuild reset the payment totals.
+ *  - #2457: a line whose gross already embeds tax (gross > net) but with no
+ *    explicit tax rate reported a document tax total of 0.
+ *
+ * Each `data:read` decimal field is serialized by the API as a fixed-scale
+ * string, so numeric assertions parse with Number().
+ */
+
+type JsonRecord = Record<string, unknown>
+
+async function readJson(response: APIResponse): Promise<JsonRecord> {
+  const raw = await response.text()
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw) as JsonRecord
+  } catch {
+    return {}
+  }
+}
+
+function num(value: unknown): number {
+  if (typeof value === 'number') return value
+  if (typeof value === 'string' && value.trim().length) return Number(value)
+  return Number.NaN
+}
+
+async function readSingleDocument(
+  request: APIRequestContext,
+  token: string,
+  resource: 'orders' | 'quotes',
+  id: string,
+): Promise<JsonRecord> {
+  const response = await apiRequest(request, 'GET', `/api/sales/${resource}?id=${encodeURIComponent(id)}`, { token })
+  expect(response.status(), `GET /api/sales/${resource}?id should be 200`).toBe(200)
+  const body = await readJson(response)
+  const items = Array.isArray(body.items) ? (body.items as JsonRecord[]) : []
+  return items[0] ?? {}
+}
+
+test.describe('TC-SALES-030 sales read-model totals fidelity', () => {
+  test('order detail reflects recorded payment in paid/outstanding (#2455)', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let orderId: string | null = null
+    let paymentId: string | null = null
+
+    try {
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      expect(orderResponse.status()).toBe(201)
+      orderId = (await readJson(orderResponse)).id as string
+      expect(orderId).toBeTruthy()
+
+      const lineResponse = await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: {
+          orderId,
+          currencyCode: 'USD',
+          quantity: 1,
+          name: 'PAY full line',
+          unitPriceNet: 1000,
+          unitPriceGross: 1000,
+        },
+      })
+      expect(lineResponse.status()).toBe(201)
+
+      const payResponse = await apiRequest(request, 'POST', '/api/sales/payments', {
+        token,
+        data: { orderId, amount: 1000, currencyCode: 'USD' },
+      })
+      expect(payResponse.status(), 'POST /api/sales/payments should be 201').toBe(201)
+      paymentId = (await readJson(payResponse)).id as string
+
+      const order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.grandTotalGrossAmount)).toBe(1000)
+      expect(num(order.paidTotalAmount)).toBe(1000)
+      expect(num(order.refundedTotalAmount)).toBe(0)
+      expect(num(order.outstandingAmount)).toBe(0)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/payments', paymentId)
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+
+  test('order detail reflects a partial payment (#2455)', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let orderId: string | null = null
+    let paymentId: string | null = null
+
+    try {
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      expect(orderResponse.status()).toBe(201)
+      orderId = (await readJson(orderResponse)).id as string
+
+      await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: {
+          orderId,
+          currencyCode: 'USD',
+          quantity: 1,
+          name: 'PAY partial line',
+          unitPriceNet: 200,
+          unitPriceGross: 200,
+        },
+      })
+
+      const payResponse = await apiRequest(request, 'POST', '/api/sales/payments', {
+        token,
+        data: { orderId, amount: 50, currencyCode: 'USD' },
+      })
+      expect(payResponse.status()).toBe(201)
+      paymentId = (await readJson(payResponse)).id as string
+
+      const order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.grandTotalGrossAmount)).toBe(200)
+      expect(num(order.paidTotalAmount)).toBe(50)
+      expect(num(order.outstandingAmount)).toBe(150)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/payments', paymentId)
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+
+  test('order detail tax total derives from net/gross delta when rate is absent (#2457)', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let orderId: string | null = null
+
+    try {
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      expect(orderResponse.status()).toBe(201)
+      orderId = (await readJson(orderResponse)).id as string
+
+      const lineResponse = await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: {
+          orderId,
+          currencyCode: 'USD',
+          quantity: 1,
+          name: 'Tax-class priced line',
+          unitPriceNet: 100,
+          unitPriceGross: 123,
+          totalNetAmount: 100,
+          totalGrossAmount: 123,
+        },
+      })
+      expect(lineResponse.status()).toBe(201)
+
+      const order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.subtotalNetAmount)).toBe(100)
+      expect(num(order.subtotalGrossAmount)).toBe(123)
+      expect(num(order.taxTotalAmount)).toBe(23)
+      expect(num(order.grandTotalGrossAmount)).toBe(123)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+
+  test('quote detail tax total derives from net/gross delta when rate is absent (#2457)', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let quoteId: string | null = null
+
+    try {
+      const quoteResponse = await apiRequest(request, 'POST', '/api/sales/quotes', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      expect(quoteResponse.status()).toBe(201)
+      quoteId = (await readJson(quoteResponse)).id as string
+
+      const lineResponse = await apiRequest(request, 'POST', '/api/sales/quote-lines', {
+        token,
+        data: {
+          quoteId,
+          currencyCode: 'USD',
+          quantity: 1,
+          name: 'Tax-class priced quote line',
+          unitPriceNet: 100,
+          unitPriceGross: 123,
+          totalNetAmount: 100,
+          totalGrossAmount: 123,
+        },
+      })
+      expect(lineResponse.status()).toBe(201)
+
+      const quote = await readSingleDocument(request, token, 'quotes', quoteId!)
+      expect(num(quote.subtotalNetAmount)).toBe(100)
+      expect(num(quote.subtotalGrossAmount)).toBe(123)
+      expect(num(quote.taxTotalAmount)).toBe(23)
+      expect(num(quote.grandTotalGrossAmount)).toBe(123)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/quotes', quoteId)
+    }
+  })
+
+  test('payment lifecycle (create/update/delete) keeps order totals consistent (#2455)', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let orderId: string | null = null
+    let paymentId: string | null = null
+
+    try {
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      orderId = (await readJson(orderResponse)).id as string
+      await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId, currencyCode: 'USD', quantity: 1, name: 'Lifecycle line', unitPriceNet: 100, unitPriceGross: 100 },
+      })
+
+      const payResponse = await apiRequest(request, 'POST', '/api/sales/payments', {
+        token,
+        data: { orderId, amount: 40, currencyCode: 'USD' },
+      })
+      expect(payResponse.status()).toBe(201)
+      paymentId = (await readJson(payResponse)).id as string
+      let order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.paidTotalAmount)).toBe(40)
+      expect(num(order.outstandingAmount)).toBe(60)
+
+      // Updating the amount must resync the auto-managed allocation so the
+      // recomputed paid total tracks the new amount.
+      const updateResponse = await apiRequest(request, 'PUT', '/api/sales/payments', {
+        token,
+        data: { id: paymentId!, amount: 75, currencyCode: 'USD' },
+      })
+      expect(updateResponse.status()).toBe(200)
+      order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.paidTotalAmount)).toBe(75)
+      expect(num(order.outstandingAmount)).toBe(25)
+
+      // Deleting the payment resets the order to fully outstanding.
+      const deleteResponse = await apiRequest(request, 'DELETE', '/api/sales/payments', {
+        token,
+        data: { id: paymentId! },
+      })
+      expect(deleteResponse.status()).toBe(200)
+      paymentId = null
+      order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.paidTotalAmount)).toBe(0)
+      expect(num(order.outstandingAmount)).toBe(100)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/payments', paymentId)
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+
+  test('refund increases outstanding (refundedTotalAmount) (#2455)', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let orderId: string | null = null
+    let paymentId: string | null = null
+
+    try {
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      orderId = (await readJson(orderResponse)).id as string
+      await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId, currencyCode: 'USD', quantity: 1, name: 'Refund line', unitPriceNet: 100, unitPriceGross: 100 },
+      })
+      const payResponse = await apiRequest(request, 'POST', '/api/sales/payments', {
+        token,
+        data: { orderId, amount: 100, currencyCode: 'USD' },
+      })
+      paymentId = (await readJson(payResponse)).id as string
+
+      const updateResponse = await apiRequest(request, 'PUT', '/api/sales/payments', {
+        token,
+        data: { id: paymentId!, amount: 100, refundedAmount: 30, currencyCode: 'USD' },
+      })
+      expect(updateResponse.status()).toBe(200)
+
+      const order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.paidTotalAmount)).toBe(100)
+      expect(num(order.refundedTotalAmount)).toBe(30)
+      expect(num(order.outstandingAmount)).toBe(30)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/payments', paymentId)
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+
+  test('paid total survives an adjustment-driven recompute (#2455)', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let orderId: string | null = null
+    let paymentId: string | null = null
+
+    try {
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      orderId = (await readJson(orderResponse)).id as string
+      await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId, currencyCode: 'USD', quantity: 1, name: 'Adj line', unitPriceNet: 100, unitPriceGross: 100 },
+      })
+      const payResponse = await apiRequest(request, 'POST', '/api/sales/payments', {
+        token,
+        data: { orderId, amount: 100, currencyCode: 'USD' },
+      })
+      paymentId = (await readJson(payResponse)).id as string
+
+      // Adding a surcharge after the payment changes the grand total; the
+      // payment totals must be preserved and outstanding recomputed against the
+      // new grand total (not reset to the pre-payment snapshot).
+      const adjResponse = await apiRequest(request, 'POST', '/api/sales/order-adjustments', {
+        token,
+        data: { orderId, scope: 'order', kind: 'surcharge', amountNet: 50, amountGross: 50, currencyCode: 'USD', label: 'Handling' },
+      })
+      expect(adjResponse.status()).toBe(201)
+
+      const order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.grandTotalGrossAmount)).toBe(150)
+      expect(num(order.surchargeTotalAmount)).toBe(50)
+      expect(num(order.paidTotalAmount)).toBe(100)
+      expect(num(order.outstandingAmount)).toBe(50)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/payments', paymentId)
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+
+  test('order-scoped adjustments aggregate into document totals', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let orderId: string | null = null
+
+    try {
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      orderId = (await readJson(orderResponse)).id as string
+      await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId, currencyCode: 'USD', quantity: 1, name: 'Base line', unitPriceNet: 100, unitPriceGross: 100 },
+      })
+
+      await apiRequest(request, 'POST', '/api/sales/order-adjustments', {
+        token,
+        data: { orderId, scope: 'order', kind: 'discount', amountNet: 10, amountGross: 10, currencyCode: 'USD', label: 'Promo' },
+      })
+      await apiRequest(request, 'POST', '/api/sales/order-adjustments', {
+        token,
+        data: { orderId, scope: 'order', kind: 'shipping', amountNet: 15, amountGross: 18, currencyCode: 'USD', label: 'Shipping' },
+      })
+
+      const order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.discountTotalAmount)).toBe(10)
+      expect(num(order.shippingNetAmount)).toBe(15)
+      // 100 base - 10 discount + 15 shipping net = 105 net; gross 100 - 10 + 18 = 108.
+      expect(num(order.grandTotalNetAmount)).toBe(105)
+      expect(num(order.grandTotalGrossAmount)).toBe(108)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+
+  test('multi-line order aggregates line totals', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let orderId: string | null = null
+
+    try {
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      orderId = (await readJson(orderResponse)).id as string
+      await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId, currencyCode: 'USD', quantity: 2, name: 'Line A', unitPriceNet: 50, unitPriceGross: 50 },
+      })
+      await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId, currencyCode: 'USD', quantity: 1, name: 'Line B', unitPriceNet: 30, unitPriceGross: 30 },
+      })
+
+      const order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.subtotalNetAmount)).toBe(130)
+      expect(num(order.grandTotalGrossAmount)).toBe(130)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+
+  test('return reduces order grand total', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let orderId: string | null = null
+
+    try {
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token,
+        data: { currencyCode: 'USD' },
+      })
+      orderId = (await readJson(orderResponse)).id as string
+      const lineResponse = await apiRequest(request, 'POST', '/api/sales/order-lines', {
+        token,
+        data: { orderId, currencyCode: 'USD', quantity: 2, name: 'Returnable', unitPriceNet: 100, unitPriceGross: 100 },
+      })
+      const orderLineId = (await readJson(lineResponse)).id as string
+
+      let order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.grandTotalGrossAmount)).toBe(200)
+
+      const returnResponse = await apiRequest(request, 'POST', '/api/sales/returns', {
+        token,
+        data: { orderId, reason: 'Damaged', lines: [{ orderLineId, quantity: 1 }] },
+      })
+      expect(returnResponse.status()).toBe(201)
+
+      order = await readSingleDocument(request, token, 'orders', orderId!)
+      expect(num(order.grandTotalGrossAmount)).toBe(100)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+})

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-ATOMIC-VERIFY.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-ATOMIC-VERIFY.spec.ts
@@ -448,18 +448,19 @@ test.describe('TC-SALES-ATOMIC-VERIFY: atomic-write backward-compat & data safet
       expect(payment.order_id).toBe(orderId)
       expect(payment.currency_code).toBe('USD')
 
-      // Order header totals stay non-negative and internally consistent on read.
+      // Order header totals reflect the recorded payment on read (#2455).
+      // The single-document read recomputes display totals through the sales
+      // calculation pipeline; the provider totals calculator must not reset the
+      // payment totals back to the pre-payment snapshot.
       const order = await readSingleDocument(request, token, 'orders', orderId!)
       const grand = num(order.grandTotalGrossAmount)
       const paid = num(order.paidTotalAmount)
       const refunded = num(order.refundedTotalAmount)
       const outstanding = num(order.outstandingAmount)
       expect(grand).toBe(100)
-      expect(paid).toBeGreaterThanOrEqual(0)
-      expect(refunded).toBeGreaterThanOrEqual(0)
-      expect(outstanding).toBeGreaterThanOrEqual(0)
-      // Outstanding never exceeds the grand total.
-      expect(outstanding).toBeLessThanOrEqual(grand)
+      expect(paid).toBe(75)
+      expect(refunded).toBe(0)
+      expect(outstanding).toBe(25)
     } finally {
       await deleteSalesEntityIfExists(request, token, '/api/sales/payments', paymentId)
       await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)

--- a/packages/core/src/modules/sales/commands/payments.ts
+++ b/packages/core/src/modules/sales/commands/payments.ts
@@ -757,6 +757,12 @@ const updatePaymentCommand: CommandHandler<
       }
       payment.updatedAt = new Date()
 
+      // Persist the payment scalar changes before any allocation query below.
+      // MikroORM discards pending scalar mutations when a find() runs on the
+      // same EntityManager before they are flushed, which would otherwise drop
+      // the updated amount/reference when allocations are (re)synced.
+      await tx.flush()
+
       if (input.allocations !== undefined) {
         const existingAllocations = await findWithDecryption(tx, SalesPaymentAllocation, { payment }, {}, { tenantId: payment.tenantId, organizationId: payment.organizationId })
         existingAllocations.forEach((allocation) => tx.remove(allocation))
@@ -815,6 +821,29 @@ const updatePaymentCommand: CommandHandler<
             metadata: allocation.metadata ? cloneJson(allocation.metadata) : null,
           })
           tx.persist(entity)
+        }
+      } else if (input.amount !== undefined || input.currencyCode !== undefined) {
+        // The caller changed the payment amount/currency without managing
+        // allocations explicitly. A simple payment carries a single
+        // auto-created allocation covering the full amount (see create); keep
+        // it in sync so recomputeOrderPaymentTotals — which sums allocations in
+        // preference to the payment amount — does not report a stale paid total
+        // after a payment edit (#2455).
+        const existingAllocations = await findWithDecryption(tx, SalesPaymentAllocation, { payment }, {}, { tenantId: payment.tenantId, organizationId: payment.organizationId })
+        const paymentOrderId =
+          (typeof payment.order === 'string' ? payment.order : payment.order?.id) ?? null
+        const isDefaultAllocation = (allocation: SalesPaymentAllocation): boolean => {
+          const allocationOrderId =
+            typeof allocation.order === 'string' ? allocation.order : allocation.order?.id ?? null
+          const allocationInvoiceId =
+            typeof allocation.invoice === 'string' ? allocation.invoice : allocation.invoice?.id ?? null
+          return allocationInvoiceId === null && allocationOrderId === paymentOrderId
+        }
+        if (existingAllocations.length === 1 && isDefaultAllocation(existingAllocations[0])) {
+          const [allocation] = existingAllocations
+          allocation.amount = toNumericString(toNumber(payment.amount)) ?? '0'
+          allocation.currencyCode = payment.currencyCode
+          tx.persist(allocation)
         }
       }
     })

--- a/packages/core/src/modules/sales/lib/__tests__/calculations.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/calculations.test.ts
@@ -1,5 +1,6 @@
 import {
   calculateDocumentTotals,
+  rebuildDocumentResult,
   registerSalesTotalsCalculator,
 } from '../calculations'
 import type { SalesAdjustmentDraft, SalesLineSnapshot } from '../types'
@@ -366,5 +367,136 @@ describe('calculateDocumentTotals', () => {
     // 100 - 20 (discount) + 5 (surcharge net) + 10 (shipping net) = 95 net.
     expect(positiveResult.totals.subtotalNetAmount).toBeCloseTo(95, 4)
     expect(positiveResult.totals.discountTotalAmount).toBeCloseTo(20, 4)
+  })
+
+  it('derives line tax from the net/gross delta when the rate is missing but gross embeds tax (issue #2457)', async () => {
+    const lines: SalesLineSnapshot[] = [
+      {
+        kind: 'product',
+        quantity: 1,
+        currencyCode: 'USD',
+        unitPriceNet: 100,
+        unitPriceGross: 123,
+        totalNetAmount: 100,
+        totalGrossAmount: 123,
+      },
+    ]
+
+    const result = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines,
+      adjustments: [],
+      context: { ...baseContext, metadata: {} },
+    })
+
+    expect(result.totals.subtotalNetAmount).toBeCloseTo(100, 4)
+    expect(result.totals.subtotalGrossAmount).toBeCloseTo(123, 4)
+    expect(result.totals.taxTotalAmount).toBeCloseTo(23, 4)
+    expect(result.totals.grandTotalGrossAmount).toBeCloseTo(123, 4)
+  })
+
+  it('does not invent tax when gross equals net (issue #2457 guard)', async () => {
+    const lines: SalesLineSnapshot[] = [
+      {
+        kind: 'product',
+        quantity: 1,
+        currencyCode: 'USD',
+        unitPriceNet: 100,
+        unitPriceGross: 100,
+        totalNetAmount: 100,
+        totalGrossAmount: 100,
+      },
+    ]
+
+    const result = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines,
+      adjustments: [],
+      context: { ...baseContext, metadata: {} },
+    })
+
+    expect(result.totals.taxTotalAmount).toBeCloseTo(0, 4)
+    expect(result.totals.grandTotalGrossAmount).toBeCloseTo(100, 4)
+  })
+
+  it('preserves payment totals when a totals calculator rebuilds the result (issue #2455)', async () => {
+    // Mirrors the provider totals calculator, which rebuilds the document from
+    // lines+adjustments via rebuildDocumentResult and would otherwise reset
+    // paid/refunded/outstanding to a pre-payment snapshot.
+    const unregister = registerSalesTotalsCalculator(({ documentKind, lines, current }) =>
+      rebuildDocumentResult({
+        documentKind,
+        currencyCode: current.currencyCode,
+        lines,
+        adjustments: current.adjustments,
+        metadata: current.metadata,
+      }),
+    )
+
+    try {
+      const result = await calculateDocumentTotals({
+        documentKind: 'order',
+        lines: [
+          {
+            kind: 'product',
+            quantity: 1,
+            currencyCode: 'USD',
+            unitPriceNet: 1000,
+            taxRate: 0,
+          },
+        ],
+        adjustments: [],
+        context: { ...baseContext, metadata: {} },
+        existingTotals: { paidTotalAmount: 1000, refundedTotalAmount: 0 },
+      })
+
+      expect(result.totals.grandTotalGrossAmount).toBeCloseTo(1000, 4)
+      expect(result.totals.paidTotalAmount).toBeCloseTo(1000, 4)
+      expect(result.totals.refundedTotalAmount).toBeCloseTo(0, 4)
+      expect(result.totals.outstandingAmount).toBeCloseTo(0, 4)
+    } finally {
+      unregister()
+    }
+  })
+
+  it('recomputes outstanding against the post-calculation grand total (issue #2455)', async () => {
+    // A totals calculator that adds a surcharge changes the grand total; the
+    // preserved payment totals must produce outstanding against the new total.
+    const unregister = registerSalesTotalsCalculator(({ documentKind, lines, current }) =>
+      rebuildDocumentResult({
+        documentKind,
+        currencyCode: current.currencyCode,
+        lines,
+        adjustments: [
+          ...current.adjustments,
+          { scope: 'order', kind: 'surcharge', amountNet: 100, amountGross: 100, currencyCode: 'USD' },
+        ],
+        metadata: current.metadata,
+      }),
+    )
+
+    try {
+      const result = await calculateDocumentTotals({
+        documentKind: 'order',
+        lines: [
+          {
+            kind: 'product',
+            quantity: 1,
+            currencyCode: 'USD',
+            unitPriceNet: 1000,
+            taxRate: 0,
+          },
+        ],
+        adjustments: [],
+        context: { ...baseContext, metadata: {} },
+        existingTotals: { paidTotalAmount: 1000, refundedTotalAmount: 0 },
+      })
+
+      expect(result.totals.grandTotalGrossAmount).toBeCloseTo(1100, 4)
+      expect(result.totals.paidTotalAmount).toBeCloseTo(1000, 4)
+      expect(result.totals.outstandingAmount).toBeCloseTo(100, 4)
+    } finally {
+      unregister()
+    }
   })
 })

--- a/packages/core/src/modules/sales/lib/calculations.ts
+++ b/packages/core/src/modules/sales/lib/calculations.ts
@@ -94,14 +94,23 @@ function buildBaseLineResult(line: SalesLineSnapshot): SalesLineCalculationResul
   const netSubtotalBeforeDiscount = toNumber(unitNet, 0) * quantity
   const discountTotal = Math.min(Math.max(discountPerUnit * quantity, 0), netSubtotalBeforeDiscount)
   const netSubtotal = Math.max(netSubtotalBeforeDiscount - discountTotal, 0)
-  const taxAmount =
-    line.taxAmount !== null && line.taxAmount !== undefined
-      ? toNumber(line.taxAmount, 0)
-      : round(netSubtotal * Math.max(taxRate, 0))
+  const explicitTaxAmount = line.taxAmount !== null && line.taxAmount !== undefined
+  let taxAmount = explicitTaxAmount
+    ? toNumber(line.taxAmount, 0)
+    : round(netSubtotal * Math.max(taxRate, 0))
   const grossSubtotal =
     line.totalGrossAmount !== null && line.totalGrossAmount !== undefined
       ? toNumber(line.totalGrossAmount, 0)
       : round(netSubtotal + taxAmount)
+  // When tax was not supplied explicitly and the rate-derived tax is zero but
+  // the gross total already embeds tax (gross > net) — e.g. a tax-class-priced
+  // line whose resolved rate was not persisted — derive the tax from the
+  // net/gross delta so the document-level tax total is not silently zeroed
+  // while per-line net/gross stay correct (#2457).
+  if (!explicitTaxAmount && taxAmount <= 0) {
+    const grossNetDelta = round(grossSubtotal - netSubtotal)
+    if (grossNetDelta > 0) taxAmount = grossNetDelta
+  }
 
   return {
     line,
@@ -354,6 +363,25 @@ class SalesCalculationRegistry {
           current = next
         },
       })
+    }
+
+    // Payment totals (paid/refunded) are authoritative inputs, not derived from
+    // lines or adjustments. Totals calculators rebuild the document result from
+    // lines+adjustments and would otherwise reset paid/refunded to 0 (and
+    // outstanding back to the full grand total), producing a stale paid/
+    // outstanding display after a payment. Re-apply the input totals last and
+    // recompute outstanding against the post-calculation grand total.
+    if (existingTotals) {
+      const paidTotalAmount = Math.max(toNumber(existingTotals.paidTotalAmount, 0), 0)
+      const refundedTotalAmount = Math.max(toNumber(existingTotals.refundedTotalAmount, 0), 0)
+      current.totals = {
+        ...current.totals,
+        paidTotalAmount,
+        refundedTotalAmount,
+        outstandingAmount: round(
+          Math.max(current.totals.grandTotalGrossAmount - paidTotalAmount + refundedTotalAmount, 0)
+        ),
+      }
     }
 
     return current


### PR DESCRIPTION
Fixes #2455
Fixes #2457

## Problem
- **#2455** — after recording a payment, the order **detail** read (`GET /api/sales/orders?id=…`) and the order-detail TOTALS panel showed the pre-payment snapshot (`paid 0` / `outstanding = grand total`), even though the DB row and the order **list** read were correct.
- **#2457** — setting a tax class per item priced Net/Gross correctly, but the document **Tax total** showed `0`.
- **Related** — updating a payment's amount did not move the order's paid total (it stayed at the old amount).

## Root Cause
- The single-document detail read recomputes display totals through the sales calculation pipeline. The provider totals calculator (`ensureProviderTotalsCalculator`) rebuilds the document via `rebuildDocumentResult`, which calls `buildBaseDocumentResult` **without** `existingTotals` — resetting `paid`/`refunded` to 0 and `outstanding` to the full grand total. Payment totals are authoritative *inputs*, not line-derived, so they must survive the rebuild. (#2455)
- `buildBaseLineResult` derived line tax as `net * rate`. A tax-class-priced line embeds tax in gross (`gross > net`) but may not carry a rate, so tax resolved to `0` and the gross−net delta was dropped from the document tax total. (#2457)
- The payment update command rebuilt allocations only when `allocations` was supplied; an amount-only edit left the auto-created default allocation stale, and `recomputeOrderPaymentTotals` prefers allocation sums. It also ran an allocation `find()` between the payment scalar mutation and flush, which MikroORM discards (the documented `withAtomicFlush` hazard), dropping the new amount.

## What Changed
- `lib/calculations.ts` → `calculateDocument`: re-apply `existingTotals` (paid/refunded) after all totals calculators run and recompute `outstanding` against the post-calculation grand total.
- `lib/calculations.ts` → `buildBaseLineResult`: when no explicit tax is given and the rate-derived tax is 0 but `gross > net`, derive the line tax from the net/gross delta.
- `commands/payments.ts` (update): flush payment scalar changes before any allocation query, and resync the single default allocation when the amount/currency changes without explicit allocations.

## Verification
- Reproduced both issues on a live build, then confirmed the fixes end-to-end in a **real browser**: order TOTALS now shows `Tax total $46.00`, `Paid $100.00`, `Outstanding $146.00` for a taxed + part-paid order. Quotes verified via API.

## Tests
- Unit regression tests in `lib/__tests__/calculations.test.ts` (verified failing before the fix, passing after).
- New integration spec `TC-SALES-030` — payment create/update/delete, refund, paid-survives-adjustment-recompute, tax net/gross delta (order **and** quote), order-scoped adjustments, multi-line, and returns. All 10 pass.
- Strengthened the previously-weak payment assertions in `TC-SALES-ATOMIC-VERIFY`.
- Full `@open-mercato/core` unit suite (5276 tests) + core typecheck pass.

## Backward Compatibility
- No contract-surface changes (no API fields, signatures, event IDs, DI keys, or ACL changes). Behavior change: when `existingTotals` is provided, payment totals now take precedence over any totals-calculator output (they are authoritative inputs); no shipped calculator sets payment totals in that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)