### PR TITLE
docs(qa): Timesheets (#2456) and Undo/Redo (#2468) manual QA scenarios

### DIFF
--- a/.ai/qa/scenarios/TC-STAFF-TS-001-timesheets-manual-qa.md
+++ b/.ai/qa/scenarios/TC-STAFF-TS-001-timesheets-manual-qa.md
@@ -1,0 +1,150 @@
+# TC-STAFF-TS-001 — Timesheets manual QA (timer, entries, projects, reporting)
+
+> **Type:** QA verification ticket (single ticket, many browser scenarios)
+> **Tracks:** [open-mercato/open-mercato#2456](https://github.com/open-mercato/open-mercato/issues/2456) — *bug: run manual tests for the Timesheets* (fixes landed via #2309).
+> **Module:** `packages/core/src/modules/staff/` (timesheets area)
+> **Goal:** Manually verify the Timesheets feature in the browser — with special focus on the two reported defects: **(a) start/stop timer "sometimes does not work"**, and **(b) the ongoing/running timer "loses the task description"**. Then cover the full surface (manual entries, segments, projects, membership, reporting, ACL).
+>
+> <!-- INTEGRATION-TEST CANDIDATE (NEXT STAGE):
+>   Every scenario below is a candidate for a Playwright integration test under
+>   `packages/core/src/modules/staff/__integration__/...timesheets*.spec.ts`.
+>   The "Expected" column is the assertion contract. Timer/description scenarios (T-*)
+>   and concurrency scenarios (C-*) are the highest-value automation targets because
+>   they map directly to #2456. DO NOT write the tests now — this ticket is the manual
+>   QA pass first. Automation is the next step once the browser pass confirms behavior
+>   and surfaces the real repro for the "sometimes" failures.
+> -->
+
+---
+
+## 0. Test environment & accounts
+
+- **Boot the branch app** (NOT the :3000 standalone): build → generate → build:packages → `next dev -p 3100`. Login `admin@acme.com` / `secret`.
+- Needs **two accounts** to exercise ownership/ACL:
+  - **Admin** (`staff.*`) — manage all projects/entries, assign members.
+  - **Employee** (`staff.timesheets.view`, `.manage_own`, `.projects.view`) — own entries only, no project management.
+- The acting user must be **linked to a staff member** (`staff.timesheets.errors.noStaffMember` appears otherwise) — verify this prerequisite first.
+- Use **two browsers/tabs** (or one normal + one incognito) for concurrency and cross-surface scenarios.
+
+**Key surfaces under test**
+| Surface | Route / location |
+|---|---|
+| My Timesheets (timer + grid + list) | `/backend/staff/timesheets` |
+| Projects portfolio | `/backend/staff/timesheets/projects` |
+| Project details (members) | `/backend/staff/timesheets/projects/{id}` |
+| Create / edit project | `/backend/staff/timesheets/projects/create`, `.../{id}/edit` |
+| Sidebar running-timer indicator | injected in left sidebar (all backend pages) |
+| Dashboard widget — Time Reporting (quick timer) | Dashboard |
+| Dashboard widget — Hours by Project | Dashboard |
+
+**Reference fields (assertion targets):** `StaffTimeEntry`(date, durationMinutes, startedAt, endedAt, **notes**, timeProjectId, source, deletedAt), `StaffTimeEntrySegment`(startedAt, endedAt, segmentType work/break), `StaffTimeProject`(name, code[unique/org], status, color, …), `StaffTimeProjectMember`(staffMemberId, role, status active/inactive, showInGrid, assignedStart/End).
+
+---
+
+## 1. PRIORITY P0 — Timer start/stop reliability (#2456a)
+
+A "running" entry = `startedAt` set, `endedAt` null, with an open work segment. Start = POST create entry → POST `…/{id}/timer-start`. Stop = POST `…/{id}/timer-stop` (closes segment, recomputes `durationMinutes` from work segments).
+
+| ID | Scenario (browser steps) | Expected |
+|---|---|---|
+| T1 | On My Timesheets, pick a project, click **Start**. | Timer begins; elapsed counter ticks `H:MM:SS`; Start → **Stop** (red). One running entry exists. |
+| T2 | Click **Stop**. | Timer stops; entry shows computed duration; counter resets; Start re-enabled. |
+| T3 | **Start with no project selected.** | Either blocked with a clear validation message OR starts per design — verify it is intentional and consistent, not a silent no-op. |
+| T4 | **Double-click Start** rapidly. | Exactly **one** running entry/segment created; no duplicate; no error toast left dangling. (Pessimistic lock returns 409 on the loser.) |
+| T5 | **Double-click Stop** rapidly. | One stop applied; second is a clean no-op/409 ("no active segment"); duration not double-counted. |
+| T6 | Start, then **immediately Stop** (sub-second). | Stop succeeds; very small/zero duration; no orphan open segment. |
+| T7 | Start timer, **reload the page** (F5) while running. | After reload the timer still shows **running** with correct elapsed and the **same project** (state reloaded from API, not lost). |
+| T8 | Start on project A, then try to **Start again** (same or different project) without stopping. | Cannot run two timers; UI prevents/guards a second start, or surfaces a clear message. Verify no two `started_at`/`endedAt=null` entries exist. |
+| T9 | Start, wait **5+ minutes**, observe sidebar indicator + grid. | Elapsed keeps advancing accurately on both the bar and the sidebar indicator (30s poll); no drift/reset. |
+| T10 | Start timer in **tab A**, open My Timesheets in **tab B**. | Tab B reflects the running timer (on load/poll); stopping in one tab is reflected in the other after refresh/poll. |
+| T11 | **Stop with the network throttled/offline** (DevTools), then restore. | Stop either succeeds on retry or shows a clear error AND the timer remains running on the server (no silent loss). Re-verify state after reload. |
+| T12 | Start a timer, **navigate to another module** and back to `/backend/staff/timesheets`. | Timer still running, elapsed correct; no duplicate entry created on return. |
+
+---
+
+## 2. PRIORITY P0 — Ongoing timer keeps the task description (#2456b)
+
+The description is the `notes` field captured at start. Suspected loss points: sidebar indicator does not carry notes; page reload/navigation may not restore typed text; stop clears the field even on failure. Verify each path.
+
+| ID | Scenario | Expected |
+|---|---|---|
+| D1 | Type a long description (e.g. 200 chars), pick project, **Start**. | Running timer shows the **full description** (read-only/locked while running). |
+| D2 | While running, **navigate away** (e.g. to Projects) then **back** to My Timesheets. | Description is **still shown** on the running timer — not blank. |
+| D3 | While running, **reload the page** (F5). | Description **reloads from the entry** and is visible — not lost. |
+| D4 | While running, hover/open the **sidebar timer indicator**, then return to the page. | Description is preserved on the timesheet timer (indicator may show project only, but returning must not wipe the description). |
+| D5 | Start with description → **Stop** successfully. | Entry persists with the description in the saved row (List view → entry's notes). Description visible in history. |
+| D6 | Start with description → **Stop fails** (throttle/offline). | Typed description is **not silently discarded**; user can recover/retry; server still has the notes on the running entry. |
+| D7 | Start with **empty** description; while running, edit the entry's notes inline in **List view**. | Notes save (PUT) and show on the running entry/row consistently. |
+| D8 | Description with special chars / emoji / newlines / 2000-char max. | Saved and redisplayed intact; >2000 chars rejected per validator (max 2000). |
+| D9 | Open the **Dashboard Time Reporting widget**, enter notes, start there, then open My Timesheets. | The same running timer + its description are consistent across the widget and the page (single source of truth). |
+
+---
+
+## 3. PRIORITY P1 — Sidebar indicator & dashboard widgets
+
+| ID | Scenario | Expected |
+|---|---|---|
+| S1 | No timer running. | Sidebar indicator is **hidden**. |
+| S2 | Start a timer. | Sidebar shows pulsing dot + **project name** + live elapsed; clicking it navigates to `/backend/staff/timesheets`. |
+| S3 | Stop the timer. | Sidebar indicator disappears within one poll cycle (≤30s) / immediately on the acting page. |
+| S4 | Indicator after full navigation across modules. | Persists (sessionStorage-backed) without flashing away; elapsed stays correct. |
+| S5 | **Hours by Project** widget, default range "this month". | Shows hours grouped by project, total correct for the signed-in user; changing the date-range preset updates totals. |
+| S6 | **Time Reporting** widget remembers last project. | Re-selecting is pre-filled with `lastProjectId`; start/stop here behaves identically to the page timer (re-run T1–T2, D9). |
+
+---
+
+## 4. PRIORITY P1 — Manual time entries (no timer) & segments
+
+| ID | Scenario | Expected |
+|---|---|---|
+| M1 | Add a manual entry: date, project, duration, notes via **Add row**. | Saves; appears in grid + list; duration shown. |
+| M2 | Edit an entry (change date/duration/project/notes). | Persists; updated values reflected. |
+| M3 | Delete an entry (with confirmation). | Soft-deleted; removed from grid/list; totals update. |
+| M4 | Duration validation: enter `0`, `1440`, `1441`, negative, non-numeric. | 0–1440 accepted; out-of-range/invalid rejected with message. |
+| M5 | **Bulk save** several rows at once (create + edit mix). | All persist (limit 200); new rows created, owned existing rows updated; project validated per row. |
+| M6 | Weekly vs Monthly view toggle; Timesheet vs List view toggle; calendar date navigation. | Each view shows correct entries for the selected period; daily/weekly totals correct. |
+| M7 | Work/break **segments**: a timer entry should sum only **work** segments into duration. | `durationMinutes` = sum of work segments; break time excluded. |
+| M8 | Entry on a project the user is **not assigned to**. | Blocked / `notAssigned` error — cannot log to unassigned project. |
+
+---
+
+## 5. PRIORITY P1 — Projects & membership (admin)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| P1 | Create project: name, **code**, status, color, type, start date, cost center, description. | Saves; appears in portfolio. |
+| P2 | Create a second project with a **duplicate code**. | Rejected (409 / `projectCodeDuplicate`). |
+| P3 | Edit project fields. | Persist; reflected in cards/table + details. |
+| P4 | Delete project (soft-delete). | Removed from active lists; existing time entries are **not** cascade-deleted (orphan rows remain). |
+| P5 | Portfolio views: cards ↔ table toggle; status saved-views (Active/All/Mine/On Hold/Completed); search by name/code; filters; export; columns chooser. | Each filters/sorts correctly; KPI strip totals (counts, hours week/month, team active) consistent. |
+| P6 | Project details → **assign member** (employee, role, start/end date). | Member added with `active` status. |
+| P7 | Toggle member **active ↔ inactive**; **unassign** member. | Inactive/unassigned members can no longer log time to the project; existing entries remain. |
+| P8 | Employee **My Projects**: only assigned/active projects appear; toggle **show in grid** per project. | Grid reflects only checked projects; toggle is per-user. |
+
+---
+
+## 6. PRIORITY P2 — ACL / ownership / scoping
+
+| ID | Scenario | Expected |
+|---|---|---|
+| A1 | Employee tries to open Create/Edit Project. | Blocked (no `projects.manage`); page guarded. |
+| A2 | Employee edits/deletes **another user's** entry. | Forbidden (`notOwner`); only `manage_all` bypasses. |
+| A3 | Admin with `manage_all` edits an employee's entry. | Allowed. |
+| A4 | User with no staff-member link opens Timesheets. | Clear `noStaffMember` message, no crash. |
+| A5 | Tenant/org isolation: timer, entries, projects, KPIs scoped to current org. | No cross-tenant/org data visible; switching org changes the data set. |
+
+---
+
+## 7. Defect-hunting checklist (map results back to #2456)
+
+When any T*/D*/C* scenario fails, capture the **exact repro** (clicks, timing, network state), a screenshot/video, the failing API call + status (DevTools Network), and the entry's DB state (`started_at`, `ended_at`, `notes`, segments). Specifically confirm or rule out:
+- Start "doesn't work" = double-click 409 / two-running-timers / slow-network state mismatch / page-return race (T4, T8, T11, T12).
+- Description "lost" = sidebar indicator drops notes / navigation-back wipes field / reload doesn't rehydrate / stop clears on error (D2, D3, D4, D6).
+
+---
+
+## 8. Reporting & next stage
+
+For each row record: pass/fail, environment, repro steps, screenshot, and (for failures) the network/DB evidence above. File failures as `bug` against #2456 with `priority-high` for any timer start/stop or description-loss defect (P0).
+
+**Next stage (automation):** convert the confirmed P0 timer/description scenarios (Sections 1–2) and concurrency cases first into Playwright integration tests under `packages/core/src/modules/staff/__integration__/`, then the remaining surface. See the INTEGRATION-TEST CANDIDATE comment at the top — do not build the tests until this manual pass confirms the repros.

--- a/.ai/qa/scenarios/TC-UNDO-001-undo-redo-all-commands.md
+++ b/.ai/qa/scenarios/TC-UNDO-001-undo-redo-all-commands.md
@@ -1,0 +1,230 @@
+# TC-UNDO-001 — Undo/Redo correctness across all undoable commands
+
+> **Type:** QA verification ticket (single ticket, many scenarios)
+> **Area:** Audit logs / Command bus / Undo–Redo
+> **Goal:** Confirm that **undo always works** for every command that declares undo support — the entity is returned to its exact pre-command state (all fields, soft-delete flags, relations, custom fields) — and that **redo** re-applies it. Confirm that commands **without** undo support correctly expose no undo affordance.
+>
+> <!-- INTEGRATION-TEST CANDIDATE (NEXT STAGE):
+>   Every scenario row below is a candidate for an automated per-module integration test
+>   (`packages/<pkg>/src/modules/<module>/__integration__/...undo.spec.ts`).
+>   The "Fields to verify saved/undone" column is the assertion contract for those tests:
+>   snapshot the entity before the command, run the command, run undo, assert deep-equality
+>   on the listed fields (incl. deleted_at, related collections, custom fields). Redo asserts
+>   the post-command state is reproduced. Do NOT write the tests as part of this ticket — this
+>   ticket is manual QA first; automation is the next stage once the human pass confirms the
+>   field contracts below are accurate per command.
+> -->
+
+---
+
+## 1. How undo works (mechanism QA must understand)
+
+All domain writes run through the **Command bus** (`packages/shared/src/lib/commands/command-bus.ts`). Each undoable command:
+
+1. `prepare()` captures a **before** snapshot, `captureAfter()` captures an **after** snapshot.
+2. `buildLog()` writes an `ActionLog` row (`action_logs` table) holding `command_id`, `command_payload` (incl. the undo payload), `snapshot_before`, `snapshot_after`, `changes_json`, and a unique **`undo_token`**.
+3. `undo()` replays the inverse mutation from the stored snapshot and then `markUndone()` sets `execution_state = 'undone'` and **clears `undo_token`** (so the same action can't be undone twice). A mirror trace log is written with reversed snapshots — that mirror is what **redo** undoes.
+
+**Surfaces that trigger undo:**
+- **Undo banner / toast** after a mutation — client store keeps the last operations for **60 s** (`LAST_OPERATION_TTL_MS`), auto-dismiss default **10 s** (`NEXT_PUBLIC_OM_UNDO_BANNER_TIMEOUT_MS`), stack limit 20.
+- **Version History panel** (`packages/ui/src/backend/version-history/VersionHistoryPanel.tsx`) — per-entry **Undo** / **Redo** buttons.
+- **API:** `POST /api/audit_logs/audit-logs/actions/undo` `{ undoToken }`; `POST /api/audit_logs/audit-logs/actions/redo` `{ logId }`; list via `GET /api/audit_logs/audit-logs/actions?undoableOnly=true`.
+
+**Permissions / scope (verify these gates too):**
+- `audit_logs.undo_self` (default for `employee`) — undo your **own** actions; `audit_logs.undo_tenant` (admin) — undo anyone's in tenant.
+- `audit_logs.redo_self` / `audit_logs.redo_tenant` mirror the above for redo; `audit_logs.view_self` / `view_tenant` gate history visibility.
+- **Latest-only rule:** only the **most recent** undoable action for a resource (or actor) can be undone — undoing an older action while a newer one exists returns `400 Undo token not available`.
+- **Tenant/org isolation:** undo across a different tenant or organization is rejected.
+
+---
+
+## 2. Invariants to assert on EVERY scenario below
+
+For each command, run: **create state → execute command → UNDO → (then) REDO**. Verify:
+
+| # | Invariant |
+|---|-----------|
+| I1 | After undo, the entity matches its **pre-command** state on **all** listed fields (incl. `updated_at` behavior, `is_active`, `deleted_at`). |
+| I2 | Soft-deleted records are **restored** (`deleted_at = null`) on undoing a delete; created records are **soft-deleted/removed** on undoing a create. |
+| I3 | **Related collections** (addresses, tags/assignments, comments, activities, todos, interactions, line items) are restored to their exact prior set — no orphans, no duplicates. |
+| I4 | **Custom field values** are restored exactly (added cf removed, removed cf re-added, changed cf reverted). |
+| I5 | The action's `undo_token` is consumed after undo (cannot undo twice); the entry shows as **undone** in Version History and offers **Redo**. |
+| I6 | **Redo** re-applies the command, reproducing the post-command state; entity, relations, and custom fields match the after-snapshot. |
+| I7 | List views, detail views, **search index**, and any cached counts reflect the restored/redone state (undo emits the same CRUD side effects as the original mutation). |
+| I8 | Lists/search are tenant- and org-scoped after undo/redo (no cross-tenant leakage). |
+| I9 | Undo affordance is **absent** for non-undoable commands (Section 4). |
+
+**Generic field contract by command kind** (applies unless a row notes specifics):
+- **create → undo** = remove the record (soft delete / hard remove per entity); redo re-creates it.
+- **update → undo** = restore the **complete before snapshot** of all scalar fields + relations + custom fields.
+- **delete → undo** = re-materialize the record from the before snapshot (all scalars, `deleted_at=null`, relations, custom fields).
+- **assign/unassign / link/unlink** = toggle the junction row's `deleted_at`.
+
+---
+
+## 3. Undoable commands — scenarios & field contracts
+
+> Legend: ✅ = undo supported. Snapshot = "complete before snapshot of all scalar fields + custom fields" unless noted. Run each as Create/Update/Delete triple where applicable.
+
+### 3.1 customers (reference module — richest relations)
+| Command | Entity | Fields to verify saved/undone |
+|---|---|---|
+| `customers.people.create/update/delete` | Person | entity scalars (name, email, phone, status…), profile, **addresses**, **comments**, **activities**, **todos**, **interactions**, **tagIds**, **company links**, custom fields, `deleted_at` |
+| `customers.companies.create/update/delete` | Company | displayName, description + company profile, tags, custom fields, `deleted_at` |
+| `customers.deals.create/update/delete` | Deal | full deal snapshot (title, value, stage/pipeline, owner…), custom fields, `deleted_at` |
+| `customers.addresses.create/update/delete` | Address | all address fields, `deleted_at` |
+| `customers.comments.create/update/delete` | Comment | body, author, links, `deleted_at` |
+| `customers.activities.create/update/delete` | Activity | type, payload, timestamps, `deleted_at` |
+| `customers.interactions.create/update/delete` | Interaction | snapshot, `deleted_at` |
+| `customers.interactions.complete` | Interaction | **status + completedAt** restored to prior values |
+| `customers.interactions.cancel` | Interaction | **status + cancelledAt** restored to prior values |
+| `customers.personCompanyLinks.create/update/delete` | PersonCompanyLink | role/relationship fields, `deleted_at` |
+| `customers.tags.create/update/delete` | Tag | name, color, `deleted_at` |
+| `customers.tags.assign / unassign` | TagAssignment | junction `deleted_at` toggled |
+| `customers.labels.create` / `labels.assign` / `labels.unassign` | Label / LabelAssignment | label fields / junction `deleted_at` |
+| `customers.todos.create` / `todos.unlink` | Todo / TodoLink | todo + link snapshot / link `deleted_at` |
+| `customers.dictionaryEntries.create/update/delete` | DictionaryEntry | label, value, order, `deleted_at` |
+| `customers.dictionaryKindSettings.upsert` | DictionaryKindSettings | before snapshot, or **deleted if newly created** |
+| `customers.entityRoles.create/update/delete` | EntityRole | role fields, `deleted_at` |
+
+### 3.2 auth
+| Command | Entity | Fields |
+|---|---|---|
+| `auth.users.create/update/delete` | User | email, firstName, lastName, phone, status, isActive, **roles**, custom fields, `deleted_at` |
+| `auth.roles.create/update/delete` | Role | name, description, **features**, isSystem, `deleted_at` |
+
+### 3.3 catalog
+| Command | Entity | Fields |
+|---|---|---|
+| `catalog.products.create/update/delete` | Product | full product snapshot, custom fields, `deleted_at` |
+| `catalog.variants.create/update/delete` | Variant | variant snapshot, `deleted_at` |
+| `catalog.categories.create/update/delete` | Category | name, slug, description, **parentId, rootId, treePath, depth, ancestorIds, childIds, descendantIds**, isActive, custom fields, `deleted_at` |
+| `catalog.offers.create/update/delete` | Offer | offer snapshot, `deleted_at` |
+| `catalog.prices.create/update/delete` | Price | amount, currency, kind, `deleted_at` |
+| `catalog.priceKinds.create/update/delete` | PriceKind | snapshot, `deleted_at` |
+| `catalog.optionSchemas.create/update/delete` | OptionSchema | snapshot, `deleted_at` |
+| `catalog.productUnitConversions.create/update/delete` | ProductUnitConversion | snapshot, `deleted_at` |
+
+### 3.4 sales
+| Command | Entity | Fields |
+|---|---|---|
+| `sales.channels.create/update/delete` | Channel | snapshot, `deleted_at` |
+| `sales.shipping-methods.create/update/delete` | ShippingMethod | snapshot, `deleted_at` |
+| `sales.payment-methods.create/update/delete` | PaymentMethod | snapshot, `deleted_at` |
+| `sales.delivery-windows.create/update/delete` | DeliveryWindow | snapshot, `deleted_at` |
+| `sales.tax-rates.create/update/delete` | TaxRate | snapshot, `deleted_at` |
+| `sales.notes.create/update/delete` | Note | snapshot, `deleted_at` |
+| `sales.payments.create/update/delete` | Payment | full payment snapshot, `deleted_at` |
+| `sales.shipments.create/update/delete` | Shipment | full shipment snapshot, `deleted_at` |
+| `sales.document-addresses.create/update/delete` | DocumentAddress | address fields, `deleted_at` |
+| `sales.tags.create/update/delete` | Tag | name, color, `deleted_at` |
+
+### 3.5 staff
+| Command | Entity | Fields |
+|---|---|---|
+| `staff.team-members.create/update/delete` | TeamMember | full snapshot, custom fields, `deleted_at` |
+| `staff.team-members.tags.assign / unassign` | TagAssignment | junction `deleted_at` |
+| `staff.teams.create/update/delete` | Team | snapshot, `deleted_at` |
+| `staff.team-roles.create/update/delete` | TeamRole | snapshot, `deleted_at` |
+| `staff.team-member-activities.create/update/delete` | Activity | snapshot, `deleted_at` |
+| `staff.team-member-addresses.create/update/delete` | Address | snapshot, `deleted_at` |
+| `staff.team-member-comments.create/update/delete` | Comment | snapshot, `deleted_at` |
+| `staff.team-member-job-histories.create/update/delete` | JobHistory | snapshot, `deleted_at` |
+| `staff.leave-requests.create/update/delete` | LeaveRequest | full snapshot, `deleted_at` |
+| `staff.leave-requests.accept` | LeaveRequest | **status + approvalDate** restored |
+| `staff.leave-requests.reject` | LeaveRequest | **status + rejectionDate** restored |
+| `staff.timesheets.time_entries.create/update/delete` | TimeEntry | snapshot, `deleted_at` |
+| `staff.timesheets.time_projects.create/update/delete` | TimeProject | snapshot, `deleted_at` |
+| `staff.timesheets.time_project_members.assign / unassign` | ProjectMember | junction `deleted_at` |
+
+### 3.6 resources
+| Command | Entity | Fields |
+|---|---|---|
+| `resources.resources.create/update/delete` | Resource | snapshot, `deleted_at` |
+| `resources.resource-types.create/update/delete` | ResourceType | snapshot, `deleted_at` |
+| `resources.resource-activities.create/update/delete` | Activity | snapshot, `deleted_at` |
+| `resources.resource-comments.create/update/delete` | Comment | snapshot, `deleted_at` |
+| `resources.resourceTags.create/update/delete` | Tag | snapshot, `deleted_at` |
+| `resources.resourceTags.assign / unassign` | TagAssignment | junction `deleted_at` |
+
+### 3.7 planner
+| Command | Entity | Fields |
+|---|---|---|
+| `planner.availability.create/update/delete` | Availability | snapshot, `deleted_at` |
+| `planner.availability.weekly.replace` | AvailabilityWeekly | **complete weekly schedule** restored |
+| `planner.availability.date-specific.replace` | AvailabilityDateSpecific | **complete date-specific slot set** restored |
+| `planner.availability-rule-sets.create/update/delete` | AvailabilityRuleSet | snapshot, `deleted_at` |
+
+### 3.8 currencies
+| Command | Entity | Fields |
+|---|---|---|
+| `currencies.currencies.create/update/delete` | Currency | code, symbol, precision, isActive, `deleted_at` |
+| `currencies.exchange_rates.create/update/delete` | ExchangeRate | rate, pair, effectiveAt, `deleted_at` |
+
+### 3.9 directory
+| Command | Entity | Fields |
+|---|---|---|
+| `directory.organizations.create/update/delete` | Organization | snapshot incl. **reparent** fields, `deleted_at` (note: org rows log with null `organization_id` — verify undo still works for tenant-level rows, ref issue #2398) |
+
+### 3.10 feature_toggles
+| Command | Entity | Fields |
+|---|---|---|
+| `feature_toggles.global.create/update/delete` | FeatureToggle | key, state, description, `deleted_at` |
+
+### 3.11 scheduler
+| Command | Entity | Fields |
+|---|---|---|
+| `scheduler.jobs.create/update/delete` | Job | cron/schedule, payload, enabled, `deleted_at` |
+
+### 3.12 checkout
+| Command | Entity | Fields |
+|---|---|---|
+| `checkout.template.create/update/delete` | Template | snapshot, `deleted_at` |
+| `checkout.link.create/update/delete` | Link | snapshot, `deleted_at` |
+
+---
+
+## 4. Commands WITHOUT undo — verify NO undo affordance (negative scenarios)
+
+These intentionally do **not** support undo. Verify no Undo button/banner appears and the API rejects an undo attempt. Do **not** raise bugs for missing undo here.
+
+- **customers:** `pipelines.*`, `pipeline-stages.*` (incl. `reorder`), `settings.save*`, `interaction.recompute_next`
+- **dictionaries:** `entries.reorder`, `entries.set_default`
+- **directory:** `tenants.create/update/delete`
+- **feature_toggles:** `overrides.changeState`
+- **sales:** `returns.create`, `settings.save`
+- **translations:** `translation.save`, `translation.delete`
+- **messages:** all (`compose`, `update_draft`, `reply`, `forward`, `delete_for_actor`, recipients `mark_read/mark_unread/archive/unarchive`, conversation `archive/delete/mark_unread_for_actor`, attachments `link/unlink`, `confirmations.confirm`, `actions.execute/record_terminal`, `tokens.consume`)
+- **communication_channels:** all (connect/disconnect/delete channel, deliver/ingest message, reactions, reassign, set-primary, push register/renew/unregister, queue-import-history)
+- **checkout:** `transaction.create`, `transaction.updateStatus`
+- **currencies:** `fetch-configs`
+- **scheduler:** `test.echo`
+- **enterprise/security:** all (changePassword, enforcement-policy CRUD, sudo-config CRUD, regenerateRecoveryCodes, removeMfaMethod, resetUserMfa)
+- **enterprise/record_locks:** `conflict.accept_incoming`, `conflict.accept_mine`
+
+---
+
+## 5. Cross-cutting scenarios (run once each)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| X1 | Undo from the **banner/toast** within 60 s | Restores entity; banner dismisses |
+| X2 | Undo from **Version History** panel | Entry flips to "undone"; Redo offered |
+| X3 | **Redo** an undone action | Re-applies command; matches after-snapshot |
+| X4 | **Latest-only:** create A then B on same resource, try to undo A | `400 Undo token not available` |
+| X5 | **Double-undo:** undo same token twice | Second attempt rejected (token consumed) |
+| X6 | **Permission:** user without `undo_self` | No undo affordance; API 400/403 |
+| X7 | **Cross-actor:** non-admin undoes another user's action | Rejected unless `undo_tenant` |
+| X8 | **Tenant/org isolation:** undo token from another tenant/org | Rejected |
+| X9 | **Bulk operation undo** (DataTable bulk delete) | All affected rows restored via bulk undo tokens |
+| X10 | **Custom-field heavy entity** (e.g. Person/Product with cf) create→edit cf→undo | cf values revert exactly |
+| X11 | **Relations** (Person with addresses+tags+todos) delete→undo | All related rows restored, none duplicated |
+| X12 | **Search/index consistency** after undo | List + global search reflect restored state |
+
+---
+
+## 6. Reporting
+
+For each row, record: entity before / after command / after undo / after redo (key fields), pass/fail per invariant (I1–I9), and any field that did **not** restore. File failures as `bug` + `priority-high` (data-integrity).
+
+**Next stage (automation):** convert confirmed rows into per-module integration tests asserting the field contracts above — see the INTEGRATION-TEST CANDIDATE comment at the top.


### PR DESCRIPTION
## Summary

Adds two QA scenario specs under `.ai/qa/scenarios/` — manual browser test plans that double as the assertion contract for future integration tests. Docs-only; no code changes.

### `TC-STAFF-TS-001` — Timesheets manual QA — relates to #2456
Browser scenarios for the staff timesheets feature, front-loading the two defects reported in #2456:
- **P0 timer start/stop reliability** (#2456a) — double-click, reload-while-running, two-timers-at-once, slow/offline network, cross-tab, navigate-back races.
- **P0 ongoing-timer description loss** (#2456b) — sidebar indicator dropping notes, navigation-back, reload rehydration, stop-clears-on-error.
- Plus full surface: manual entries + work/break segments, projects + membership, dashboard widgets/reporting, ACL/ownership/tenant scoping.

### `TC-UNDO-001` — Undo/Redo across all commands — relates to #2468
Verifies undo returns each entity to its exact pre-command state across ~214 undoable commands (all scalars, `deleted_at`, relations, custom fields), redo re-applies, and non-undoable commands expose no undo. Includes per-command field contracts and cross-cutting cases (latest-only, double-undo, permissions, tenant isolation, bulk undo).

## Next stage
Both specs explicitly mark integration-test automation as a **follow-up** (Playwright under each module's `__integration__/`). This PR is the manual QA plan only — tests come after the human pass confirms the repros/field contracts.

## Test plan
- [x] Docs-only (markdown). No build/test impact.

Relates to #2456, #2468

🤖 Generated with [Claude Code](https://claude.com/claude-code)