### PR TITLE
test(catalog): integration coverage for tier-pricing tie-break (follow-up to #2454)

### DIFF
--- a/packages/core/src/modules/catalog/AGENTS.md
+++ b/packages/core/src/modules/catalog/AGENTS.md
@@ -26,6 +26,16 @@ registerCatalogPricingResolver(myResolver, { priority: 10 })
 
 The default pipeline emits `catalog.pricing.resolve.before|after` events.
 
+### Price selection order
+
+When multiple price rows match the same context, `selectBestPrice` resolves ties in this order:
+
+1. **Score** (descending) — `custom` > `promotion` > `tier` > `regular`, plus additional points for variant, offer, channel, user, group, and customer scoping. See `scorePrice` for the full rubric.
+2. **`startsAt`** (descending) — when scores tie, the row with the more recent `startsAt` wins.
+3. **`minQuantity`** — direction depends on whether the tied rows share the same resolved kind:
+    - **Same kind** (e.g. tier vs tier): **descending** — the row with the larger `minQuantity` wins. This implements the standard volume-discount semantic: for `qty=50` with tiers `minQty=10` ($9) and `minQty=50` ($8), the `minQty=50` row applies (issue #1706).
+    - **Different kinds** (e.g. promotion vs tier): **ascending** — the row with the smaller `minQuantity` wins. The `+1 for minQuantity > 1` bonus in `scorePrice` can pull a lower-base kind up to the same total as a higher-base kind (e.g. tier `minQty=3` = 3+1 vs promotion `minQty=1` = 4). Ascending across kinds preserves the kind precedence in those collisions.
+
 ## Data Model Constraints
 
 - **Products** — core entities with media and descriptions. MUST have at least a name

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-026.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-026.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createProductFixture,
+  deleteCatalogProductIfExists,
+} from '@open-mercato/core/helpers/integration/catalogFixtures'
+
+/**
+ * TC-CAT-026: tier-pricing tie-break selects the more specific tier (#1706 / PR #2454).
+ *
+ * When two same-kind tier prices both match the pricing context, the resolver
+ * (`selectBestPrice` via `GET /api/catalog/products?quantity=N`) must pick the
+ * tier with the higher `minQuantity` — the standard volume-discount semantic.
+ * Issue body repro: qty 3, tiers minQty 2 ($9) and minQty 3 ($8) → minQty 3 ($8) wins.
+ */
+
+async function ensureTierPriceKind(
+  request: APIRequestContext,
+  token: string,
+): Promise<{ id: string; currencyCode: string }> {
+  const stamp = Date.now()
+  const response = await apiRequest(request, 'POST', '/api/catalog/price-kinds', {
+    token,
+    data: {
+      title: `Tier tie-break kind ${stamp}`,
+      code: `tier_tiebreak_${stamp}`,
+      displayMode: 'including-tax',
+      currencyCode: 'USD',
+    },
+  })
+  expect(response.ok(), `Failed to create price kind fixture: ${response.status()}`).toBeTruthy()
+  const body = (await response.json()) as { id?: string; result?: { id?: string } }
+  const id = typeof body.id === 'string' ? body.id : body.result?.id
+  expect(typeof id === 'string' && (id as string).length > 0, 'Price kind id missing').toBeTruthy()
+  return { id: id as string, currencyCode: 'USD' }
+}
+
+async function createTierPrice(
+  request: APIRequestContext,
+  token: string,
+  input: { productId: string; priceKindId: string; currencyCode: string; minQuantity: number; amount: number },
+): Promise<void> {
+  const response = await apiRequest(request, 'POST', '/api/catalog/prices', {
+    token,
+    data: {
+      productId: input.productId,
+      priceKindId: input.priceKindId,
+      currencyCode: input.currencyCode,
+      minQuantity: input.minQuantity,
+      unitPriceNet: input.amount,
+      unitPriceGross: input.amount,
+    },
+  })
+  expect(response.ok(), `Failed to create tier price (minQty ${input.minQuantity}): ${response.status()}`).toBeTruthy()
+}
+
+async function resolvePricingAtQuantity(
+  request: APIRequestContext,
+  token: string,
+  productId: string,
+  quantity: number,
+): Promise<{ minQuantity: number; gross: number } | null> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `/api/catalog/products?id=${encodeURIComponent(productId)}&quantity=${quantity}&page=1&pageSize=1`,
+    { token },
+  )
+  expect(response.ok(), `Failed to resolve product pricing: ${response.status()}`).toBeTruthy()
+  const body = (await response.json()) as { items?: Array<Record<string, unknown>> }
+  const row = Array.isArray(body.items) ? body.items[0] : null
+  const pricing = row && typeof row.pricing === 'object' ? (row.pricing as Record<string, unknown>) : null
+  if (!pricing) return null
+  return {
+    minQuantity: Number(pricing.min_quantity),
+    gross: Number(pricing.unit_price_gross),
+  }
+}
+
+test.describe('TC-CAT-026 tier pricing tie-break', () => {
+  test('same-kind tier tie-break selects the higher minQuantity at the matching quantity (#1706)', async ({ request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    let productId: string | null = null
+    const stamp = Date.now()
+
+    try {
+      const priceKind = await ensureTierPriceKind(request, token)
+      productId = await createProductFixture(request, token, {
+        title: `Tier tie-break product ${stamp}`,
+        sku: `TIER-TB-${stamp}`,
+      })
+
+      // Two same-kind tiers; the higher-volume tier is cheaper per unit.
+      await createTierPrice(request, token, {
+        productId,
+        priceKindId: priceKind.id,
+        currencyCode: priceKind.currencyCode,
+        minQuantity: 2,
+        amount: 9,
+      })
+      await createTierPrice(request, token, {
+        productId,
+        priceKindId: priceKind.id,
+        currencyCode: priceKind.currencyCode,
+        minQuantity: 3,
+        amount: 8,
+      })
+
+      // At qty 3 both tiers match; the more specific (minQty 3, $8) must win.
+      const atThree = await resolvePricingAtQuantity(request, token, productId!, 3)
+      expect(atThree, 'Expected resolved pricing at quantity 3').not.toBeNull()
+      expect(atThree!.minQuantity).toBe(3)
+      expect(atThree!.gross).toBeCloseTo(8, 4)
+
+      // At qty 2 only the minQty 2 tier matches, so it resolves to $9.
+      const atTwo = await resolvePricingAtQuantity(request, token, productId!, 2)
+      expect(atTwo, 'Expected resolved pricing at quantity 2').not.toBeNull()
+      expect(atTwo!.minQuantity).toBe(2)
+      expect(atTwo!.gross).toBeCloseTo(9, 4)
+    } finally {
+      await deleteCatalogProductIfExists(request, token, productId)
+    }
+  })
+})

--- a/packages/core/src/modules/catalog/lib/__tests__/pricing.test.ts
+++ b/packages/core/src/modules/catalog/lib/__tests__/pricing.test.ts
@@ -56,6 +56,12 @@ describe('catalog pricing helpers', () => {
   })
 
   it('selects the highest scoring price with deterministic tie breakers', () => {
+    // `base` has score 2 (regular kind, no scoping). Both variant rows share kind, variant,
+    // and channel scoping so they tie at score 17 — verifying that scorePrice wins first
+    // and `startsAt` (descending) breaks the remaining tie. `older-variant` keeps the
+    // default `minQuantity` from `baseRow` so it passes `matchesContext` at `ctx.quantity=1`
+    // and actually reaches the comparator (prior to this it carried `minQuantity: 5` and
+    // was filtered out before the sort ran, leaving the tie-break code unexercised).
     const rows: PriceRow[] = [
       baseRow({ id: 'base', minQuantity: 1, kind: 'regular' }),
       baseRow({
@@ -73,7 +79,6 @@ describe('catalog pricing helpers', () => {
         priceKind: { id: 'pk-promo', code: 'promotion', isPromotion: true } as any,
         channelId: 'channel-1',
         startsAt: new Date('2024-01-01T00:00:00Z'),
-        minQuantity: 5,
       }),
     ]
 
@@ -146,5 +151,61 @@ describe('catalog pricing helpers', () => {
 
     expect(emitEvent).toHaveBeenCalledTimes(2)
     expect(result).toBe(overridden)
+  })
+
+  it('breaks tier-pricing ties by selecting the higher minQuantity (volume discount semantic)', () => {
+    // Mirrors the repro from issue #1706:
+    // qty=3 with tiers minQty=2 ($9) and minQty=3 ($8) must resolve to the minQty=3 tier.
+    const tierKind = { id: 'pk-tier', code: 'tier', isPromotion: false } as any
+    const tierLow = baseRow({
+      id: 'tier-low',
+      kind: 'tier',
+      minQuantity: 2,
+      priceKind: tierKind,
+      unitPriceNet: '9.00',
+      unitPriceGross: '11.07',
+    })
+    const tierHigh = baseRow({
+      id: 'tier-high',
+      kind: 'tier',
+      minQuantity: 3,
+      priceKind: tierKind,
+      unitPriceNet: '8.00',
+      unitPriceGross: '9.84',
+    })
+
+    const result = selectBestPrice([tierLow, tierHigh], { ...ctx, quantity: 3 })
+
+    expect(result?.id).toBe('tier-high')
+  })
+
+  it('keeps promotion over tier when scorePrice ties them across kinds', () => {
+    // Regression guard for the #1706 fix: scorePrice gives `promotion` base=4 and `tier`
+    // base=3 + 1 (bonus for minQuantity > 1). A promotion row with minQuantity=1 and a
+    // tier row with minQuantity>=2 both end up at score=4 with no other scoping. Tie-break
+    // on minQuantity must keep promotion (lower minQuantity) winning across kinds — the
+    // descending direction introduced for #1706 only applies within the same kind.
+    const promoKind = { id: 'pk-promo', code: 'promotion', isPromotion: true } as any
+    const tierKind = { id: 'pk-tier', code: 'tier', isPromotion: false } as any
+    const promo = baseRow({
+      id: 'promo',
+      kind: 'promotion',
+      minQuantity: 1,
+      priceKind: promoKind,
+      unitPriceNet: '7.00',
+      unitPriceGross: '8.61',
+    })
+    const tier = baseRow({
+      id: 'tier',
+      kind: 'tier',
+      minQuantity: 3,
+      priceKind: tierKind,
+      unitPriceNet: '8.00',
+      unitPriceGross: '9.84',
+    })
+
+    const result = selectBestPrice([promo, tier], { ...ctx, quantity: 5 })
+
+    expect(result?.id).toBe('promo')
   })
 })

--- a/packages/core/src/modules/catalog/lib/pricing.ts
+++ b/packages/core/src/modules/catalog/lib/pricing.ts
@@ -95,6 +95,14 @@ export function selectBestPrice(rows: PriceRow[], ctx: PricingContext): PriceRow
     const startA = a.startsAt ? a.startsAt.getTime() : 0
     const startB = b.startsAt ? b.startsAt.getTime() : 0
     if (startA !== startB) return startB - startA
+    // minQuantity tie-break is direction-dependent on the resolved kind.
+    // Within the same kind we pick the more specific tier (higher minQuantity wins — issue #1706).
+    // Across kinds we keep the pre-#1706 ascending order so a row whose kind has a higher
+    // scoreBase still wins when scorePrice's "+1 for minQuantity > 1" bonus produces a
+    // cross-kind collision (e.g. promotion[minQty=1]=4 vs tier[minQty=3]=4).
+    if (resolvePriceKindCode(a) === resolvePriceKindCode(b)) {
+      return (b.minQuantity ?? 1) - (a.minQuantity ?? 1)
+    }
     return (a.minQuantity ?? 1) - (b.minQuantity ?? 1)
   })
   return candidates[0]


### PR DESCRIPTION
Follow-up to #2454 (fix by @jakubmatwiejew-wq) — adds the integration test that PR was missing.

## What
New integration spec `TC-CAT-026` exercising the catalog tier-pricing tie-break through the **real HTTP resolver path** (`GET /api/catalog/products?quantity=N` → `resolvePrice` → `selectBestPrice`):

- Two **same-kind** tiers on one product: `minQty 2 → $9`, `minQty 3 → $8`.
- At **qty 3** both tiers match → the more specific tier (`minQty 3`, `$8`) must win (issue #1706 repro).
- At **qty 2** only the `minQty 2` tier matches → resolves to `$9`.

## Verification
Booted both branches locally against the same DB:
- **With #2454** → qty 3 resolves `min_quantity=3, unit_price_gross=8` ✅ (test passes)
- **Without #2454** (develop resolver) → qty 3 resolves `min_quantity=2, unit_price_gross=9` ❌ (test fails)

So this is a genuine regression guard for the tie-break direction.

## Stacking
This branch is based on #2454's head so CI is green (the test needs the fix). It includes #2454's `selectBestPrice` commit plus this test commit. Merge order options:
- Merge #2454 first, then rebase this onto `develop` so the diff reduces to the test only; **or**
- Merge this directly (it carries both the fix and the test).

Credit for the `selectBestPrice` fix belongs to @jakubmatwiejew-wq (#2454).

🤖 Generated with [Claude Code](https://claude.com/claude-code)