### PR TITLE
fix(customers): personCompanyLinks undo handlers lose writes under tenant encryption (#2507)

### DIFF
--- a/packages/core/src/modules/customers/commands/__tests__/personCompanyLinks.undo.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/personCompanyLinks.undo.test.ts
@@ -1,0 +1,313 @@
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+// Simulates the tenant-encryption afterFind/onLoad behavior (issue #2507):
+// every find re-baselines the change tracking of the entities it returns
+// (subscriber.syncOriginalEntityData with syncOriginal: true), so scalar
+// mutations made BEFORE a query that re-selects the same managed entity are
+// silently dropped at flush time. The fake EM below mirrors MikroORM's
+// snapshot-diff flush so the undo handlers are exercised against the same
+// semantics that made `customers.personCompanyLinks.create` undo a no-op.
+const mockFindWithDecryption = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...(args as [])),
+  findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...(args as [])),
+}))
+
+import '@open-mercato/core/modules/customers/commands'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import type { CommandHandler, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import {
+  CustomerEntity,
+  CustomerPersonCompanyLink,
+  CustomerPersonProfile,
+} from '../../data/entities'
+
+const ORG_ID = 'org-pcl-1'
+const TENANT_ID = 'tenant-pcl-1'
+const PERSON_ID = 'person-pcl-1'
+const COMPANY_A_ID = 'company-pcl-a'
+const COMPANY_B_ID = 'company-pcl-b'
+const LINK_A_ID = 'link-pcl-a'
+const LINK_B_ID = 'link-pcl-b'
+
+type LinkRow = { isPrimary: boolean; deletedAt: Date | null }
+type ProfileRow = { companyId: string | null }
+
+type Fixtures = {
+  person: CustomerEntity
+  companyA: CustomerEntity
+  companyB: CustomerEntity
+  profile: CustomerPersonProfile
+  links: CustomerPersonCompanyLink[]
+  linkRows: Map<string, LinkRow>
+  profileRow: ProfileRow
+  em: any
+}
+
+function makeCustomerEntity(id: string, kind: 'person' | 'company', displayName: string): CustomerEntity {
+  return {
+    id,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    kind,
+    displayName,
+    deletedAt: null,
+  } as unknown as CustomerEntity
+}
+
+function makeLink(id: string, person: CustomerEntity, company: CustomerEntity, state: LinkRow): CustomerPersonCompanyLink {
+  return {
+    id,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    person,
+    company,
+    isPrimary: state.isPrimary,
+    deletedAt: state.deletedAt,
+    createdAt: new Date('2026-06-01T00:00:00Z'),
+    updatedAt: new Date('2026-06-01T00:00:00Z'),
+  } as unknown as CustomerPersonCompanyLink
+}
+
+function makeFixtures(linkStates: Array<{ id: string; companyId: string } & LinkRow>, profileCompanyId: string | null): Fixtures {
+  const person = makeCustomerEntity(PERSON_ID, 'person', 'Jane Doe')
+  const companyA = makeCustomerEntity(COMPANY_A_ID, 'company', 'Acme A')
+  const companyB = makeCustomerEntity(COMPANY_B_ID, 'company', 'Acme B')
+  const companies = new Map([[COMPANY_A_ID, companyA], [COMPANY_B_ID, companyB]])
+
+  const linkRows = new Map<string, LinkRow>()
+  const links = linkStates.map((state) => {
+    linkRows.set(state.id, { isPrimary: state.isPrimary, deletedAt: state.deletedAt })
+    return makeLink(state.id, person, companies.get(state.companyId)!, state)
+  })
+
+  const profileRow: ProfileRow = { companyId: profileCompanyId }
+  const profile = {
+    id: 'profile-pcl-1',
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    entity: person,
+    company: profileCompanyId ? companies.get(profileCompanyId) ?? null : null,
+  } as unknown as CustomerPersonProfile
+
+  const linkSnapshots = new Map<string, LinkRow>()
+  let profileSnapshot: ProfileRow = { companyId: profileCompanyId }
+
+  const snapshotLink = (link: CustomerPersonCompanyLink) => {
+    linkSnapshots.set(link.id, {
+      isPrimary: Boolean(link.isPrimary),
+      deletedAt: link.deletedAt ?? null,
+    })
+  }
+  const snapshotProfile = () => {
+    const company = profile.company
+    profileSnapshot = { companyId: company && typeof company !== 'string' ? company.id : null }
+  }
+
+  links.forEach(snapshotLink)
+  snapshotProfile()
+
+  const rebaseline = (entity: unknown) => {
+    if (entity === profile) {
+      snapshotProfile()
+      return
+    }
+    const link = links.find((candidate) => candidate === entity)
+    if (link) snapshotLink(link)
+  }
+
+  mockFindOneWithDecryption.mockImplementation(async (...args: unknown[]) => {
+    const [, ctor, rawWhere] = args as [unknown, unknown, Record<string, unknown>]
+    if (ctor === CustomerPersonCompanyLink) {
+      const found = links.find((link) => link.id === rawWhere.id) ?? null
+      if (found) rebaseline(found)
+      return found
+    }
+    if (ctor === CustomerEntity) {
+      if (rawWhere.kind === 'person') return rawWhere.id === person.id ? person : null
+      if (rawWhere.kind === 'company') {
+        const company = companies.get(String(rawWhere.id)) ?? null
+        return company
+      }
+      return null
+    }
+    if (ctor === CustomerPersonProfile) {
+      rebaseline(profile)
+      return profile
+    }
+    return null
+  })
+
+  mockFindWithDecryption.mockImplementation(async (...args: unknown[]) => {
+    const [, ctor] = args as [unknown, unknown]
+    if (ctor !== CustomerPersonCompanyLink) return []
+    const active = links.filter((link) => linkRows.get(link.id)?.deletedAt == null)
+    active.sort((left, right) => Number(linkRows.get(right.id)?.isPrimary) - Number(linkRows.get(left.id)?.isPrimary))
+    active.forEach(rebaseline)
+    return active
+  })
+
+  const em: any = {
+    fork: jest.fn(),
+    persist: jest.fn(),
+    isInTransaction: jest.fn(() => false),
+    begin: jest.fn(async () => undefined),
+    commit: jest.fn(async () => undefined),
+    rollback: jest.fn(async () => undefined),
+    nativeUpdate: jest.fn(async (ctor: unknown, where: Record<string, unknown>, data: Record<string, unknown>) => {
+      if (ctor !== CustomerPersonCompanyLink) return 0
+      let affected = 0
+      for (const link of links) {
+        const row = linkRows.get(link.id)!
+        if (where.person && where.person !== link.person) continue
+        if ('isPrimary' in where && row.isPrimary !== where.isPrimary) continue
+        if ('isPrimary' in data) {
+          row.isPrimary = Boolean(data.isPrimary)
+          affected += 1
+        }
+      }
+      return affected
+    }),
+    flush: jest.fn(async () => {
+      for (const link of links) {
+        const snapshot = linkSnapshots.get(link.id)!
+        const row = linkRows.get(link.id)!
+        const currentDeletedAt = link.deletedAt ?? null
+        if (Boolean(link.isPrimary) !== snapshot.isPrimary) row.isPrimary = Boolean(link.isPrimary)
+        if (currentDeletedAt !== snapshot.deletedAt) row.deletedAt = currentDeletedAt
+        snapshotLink(link)
+      }
+      const company = profile.company
+      const currentCompanyId = company && typeof company !== 'string' ? company.id : null
+      if (currentCompanyId !== profileSnapshot.companyId) profileRow.companyId = currentCompanyId
+      snapshotProfile()
+    }),
+  }
+  em.fork.mockReturnValue(em)
+
+  return { person, companyA, companyB, profile, links, linkRows, profileRow, em }
+}
+
+function makeCtx(em: any): CommandRuntimeContext {
+  const dataEngine: any = {
+    markOrmEntityChange: jest.fn(),
+    flushOrmEntityChanges: jest.fn(async () => {}),
+    emitOrmEntityEvent: jest.fn(async () => {}),
+  }
+  return {
+    container: {
+      resolve: (token: string): any => {
+        if (token === 'em') return em
+        if (token === 'dataEngine') return dataEngine
+        throw new Error(`Unexpected DI token: ${token}`)
+      },
+    } as any,
+    auth: { sub: 'user-1', tenantId: TENANT_ID, orgId: ORG_ID } as any,
+    selectedOrganizationId: ORG_ID,
+    organizationScope: null,
+    organizationIds: null,
+    request: undefined as any,
+  }
+}
+
+function makeLinkSnapshot(linkId: string, companyId: string, isPrimary: boolean) {
+  return {
+    id: linkId,
+    personEntityId: PERSON_ID,
+    companyEntityId: companyId,
+    isPrimary,
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    deletedAt: null,
+  }
+}
+
+describe('customers.personCompanyLinks undo — encryption re-baseline regression (#2507)', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('create undo soft-deletes the link even when re-selecting it re-baselines change tracking', async () => {
+    const fixtures = makeFixtures(
+      [{ id: LINK_A_ID, companyId: COMPANY_A_ID, isPrimary: true, deletedAt: null }],
+      COMPANY_A_ID,
+    )
+    const handler = commandRegistry.get('customers.personCompanyLinks.create') as CommandHandler
+    expect(handler?.undo).toBeDefined()
+
+    await handler.undo!({
+      logEntry: { payload: { undo: { after: makeLinkSnapshot(LINK_A_ID, COMPANY_A_ID, true) } } },
+      ctx: makeCtx(fixtures.em),
+    } as any)
+
+    const row = fixtures.linkRows.get(LINK_A_ID)!
+    expect(row.deletedAt).not.toBeNull()
+    expect(row.isPrimary).toBe(false)
+    expect(fixtures.profileRow.companyId).toBeNull()
+  })
+
+  it('create undo promotes the remaining link to primary and persists the soft delete', async () => {
+    const fixtures = makeFixtures(
+      [
+        { id: LINK_A_ID, companyId: COMPANY_A_ID, isPrimary: true, deletedAt: null },
+        { id: LINK_B_ID, companyId: COMPANY_B_ID, isPrimary: false, deletedAt: null },
+      ],
+      COMPANY_A_ID,
+    )
+    const handler = commandRegistry.get('customers.personCompanyLinks.create') as CommandHandler
+
+    await handler.undo!({
+      logEntry: { payload: { undo: { after: makeLinkSnapshot(LINK_A_ID, COMPANY_A_ID, true) } } },
+      ctx: makeCtx(fixtures.em),
+    } as any)
+
+    const removedRow = fixtures.linkRows.get(LINK_A_ID)!
+    expect(removedRow.deletedAt).not.toBeNull()
+    expect(removedRow.isPrimary).toBe(false)
+    expect(fixtures.linkRows.get(LINK_B_ID)!.isPrimary).toBe(true)
+    expect(fixtures.profileRow.companyId).toBe(COMPANY_B_ID)
+  })
+
+  it('update undo restores the primary flag and the legacy profile company', async () => {
+    const fixtures = makeFixtures(
+      [{ id: LINK_A_ID, companyId: COMPANY_A_ID, isPrimary: false, deletedAt: null }],
+      null,
+    )
+    const handler = commandRegistry.get('customers.personCompanyLinks.update') as CommandHandler
+    expect(handler?.undo).toBeDefined()
+
+    await handler.undo!({
+      logEntry: { payload: { undo: { before: makeLinkSnapshot(LINK_A_ID, COMPANY_A_ID, true) } } },
+      ctx: makeCtx(fixtures.em),
+    } as any)
+
+    const row = fixtures.linkRows.get(LINK_A_ID)!
+    expect(row.isPrimary).toBe(true)
+    expect(row.deletedAt).toBeNull()
+    expect(fixtures.profileRow.companyId).toBe(COMPANY_A_ID)
+  })
+
+  it('delete undo restores the soft-deleted link and its primary flag', async () => {
+    const deletedAt = new Date('2026-06-02T00:00:00Z')
+    const fixtures = makeFixtures(
+      [{ id: LINK_A_ID, companyId: COMPANY_A_ID, isPrimary: false, deletedAt }],
+      null,
+    )
+    const handler = commandRegistry.get('customers.personCompanyLinks.delete') as CommandHandler
+    expect(handler?.undo).toBeDefined()
+
+    await handler.undo!({
+      logEntry: { payload: { undo: { before: makeLinkSnapshot(LINK_A_ID, COMPANY_A_ID, true) } } },
+      ctx: makeCtx(fixtures.em),
+    } as any)
+
+    const row = fixtures.linkRows.get(LINK_A_ID)!
+    expect(row.deletedAt).toBeNull()
+    expect(row.isPrimary).toBe(true)
+    expect(fixtures.profileRow.companyId).toBe(COMPANY_A_ID)
+  })
+})

--- a/packages/core/src/modules/customers/commands/personCompanyLinks.ts
+++ b/packages/core/src/modules/customers/commands/personCompanyLinks.ts
@@ -294,33 +294,38 @@ const createPersonCompanyLinkCommand: CommandHandler<PersonCompanyLinkCreateInpu
     )
     if (!link) return
 
+    let person: CustomerEntity | null = null
+    let profile: CustomerPersonProfile | null = null
+    let remainingLinks: CustomerPersonCompanyLink[] = []
+
     await withAtomicFlush(em, [
       async () => {
-        link.isPrimary = false
-        link.deletedAt = new Date()
-        const person = await findOneWithDecryption(
+        person = await findOneWithDecryption(
           em,
           CustomerEntity,
           { id: after.personEntityId, kind: 'person', tenantId: after.tenantId, organizationId: after.organizationId, deletedAt: null },
           undefined,
           { tenantId: after.tenantId, organizationId: after.organizationId },
         )
-        if (person) {
-          const profile = await findOneWithDecryption(
-            em,
-            CustomerPersonProfile,
-            { entity: person },
-            { populate: ['company'] },
-            { tenantId: person.tenantId, organizationId: person.organizationId },
-          )
-          if (profile) {
-            const remainingLinks = await loadPersonCompanyLinks(em, person)
-            if (after.isPrimary) {
-              await promoteFallbackPrimaryLink(em, person, profile, remainingLinks, after.companyEntityId)
-            } else if (profile.company && typeof profile.company !== 'string' && profile.company.id === after.companyEntityId) {
-              profile.company = null
-            }
-          }
+        if (!person) return
+        profile = await findOneWithDecryption(
+          em,
+          CustomerPersonProfile,
+          { entity: person },
+          { populate: ['company'] },
+          { tenantId: person.tenantId, organizationId: person.organizationId },
+        )
+        if (!profile) return
+        remainingLinks = (await loadPersonCompanyLinks(em, person)).filter((entry) => entry.id !== link.id)
+      },
+      async () => {
+        link.isPrimary = false
+        link.deletedAt = new Date()
+        if (!person || !profile) return
+        if (after.isPrimary) {
+          await promoteFallbackPrimaryLink(em, person, profile, remainingLinks, after.companyEntityId)
+        } else if (profile.company && typeof profile.company !== 'string' && profile.company.id === after.companyEntityId) {
+          profile.company = null
         }
       },
     ], { transaction: true })
@@ -453,39 +458,44 @@ const updatePersonCompanyLinkCommand: CommandHandler<PersonCompanyLinkUpdateInpu
     )
     if (!link) return
 
+    let person: CustomerEntity | null = null
+    let profile: CustomerPersonProfile | null = null
+    let company: CustomerEntity | null = null
+
     await withAtomicFlush(em, [
       async () => {
-        const person = await findOneWithDecryption(
+        person = await findOneWithDecryption(
           em,
           CustomerEntity,
           { id: before.personEntityId, kind: 'person', tenantId: before.tenantId, organizationId: before.organizationId, deletedAt: null },
           undefined,
           { tenantId: before.tenantId, organizationId: before.organizationId },
         )
-        if (person) {
-          const profile = await findOneWithDecryption(
-            em,
-            CustomerPersonProfile,
-            { entity: person },
-            { populate: ['company'] },
-            { tenantId: person.tenantId, organizationId: person.organizationId },
-          )
-          if (profile) {
-            if (before.isPrimary) {
-              await clearPrimaryFlagsForPerson(em, person)
-              link.isPrimary = true
-              const company = await findOneWithDecryption(
-                em,
-                CustomerEntity,
-                { id: before.companyEntityId, kind: 'company', tenantId: before.tenantId, organizationId: before.organizationId, deletedAt: null },
-                undefined,
-                { tenantId: before.tenantId, organizationId: before.organizationId },
-              )
-              if (company) profile.company = company
-            } else {
-              link.isPrimary = false
-            }
-          }
+        if (!person) return
+        profile = await findOneWithDecryption(
+          em,
+          CustomerPersonProfile,
+          { entity: person },
+          { populate: ['company'] },
+          { tenantId: person.tenantId, organizationId: person.organizationId },
+        )
+        if (!profile || !before.isPrimary) return
+        company = await findOneWithDecryption(
+          em,
+          CustomerEntity,
+          { id: before.companyEntityId, kind: 'company', tenantId: before.tenantId, organizationId: before.organizationId, deletedAt: null },
+          undefined,
+          { tenantId: before.tenantId, organizationId: before.organizationId },
+        )
+      },
+      async () => {
+        if (!person || !profile) return
+        if (before.isPrimary) {
+          await clearPrimaryFlagsForPerson(em, person)
+          link.isPrimary = true
+          if (company) profile.company = company
+        } else {
+          link.isPrimary = false
         }
       },
     ], { transaction: true })
@@ -610,38 +620,43 @@ const deletePersonCompanyLinkCommand: CommandHandler<PersonCompanyLinkDeleteInpu
     )
     if (!link) return
 
+    let person: CustomerEntity | null = null
+    let profile: CustomerPersonProfile | null = null
+    let company: CustomerEntity | null = null
+
     await withAtomicFlush(em, [
       async () => {
-        link.deletedAt = null
-        link.isPrimary = before.isPrimary
-
-        const person = await findOneWithDecryption(
+        person = await findOneWithDecryption(
           em,
           CustomerEntity,
           { id: before.personEntityId, kind: 'person', tenantId: before.tenantId, organizationId: before.organizationId, deletedAt: null },
           undefined,
           { tenantId: before.tenantId, organizationId: before.organizationId },
         )
+        if (!person || !before.isPrimary) return
+        profile = await findOneWithDecryption(
+          em,
+          CustomerPersonProfile,
+          { entity: person },
+          { populate: ['company'] },
+          { tenantId: person.tenantId, organizationId: person.organizationId },
+        )
+        if (!profile) return
+        company = await findOneWithDecryption(
+          em,
+          CustomerEntity,
+          { id: before.companyEntityId, kind: 'company', tenantId: before.tenantId, organizationId: before.organizationId, deletedAt: null },
+          undefined,
+          { tenantId: before.tenantId, organizationId: before.organizationId },
+        )
+      },
+      async () => {
+        link.deletedAt = null
+        link.isPrimary = before.isPrimary
         if (person && before.isPrimary) {
           await clearPrimaryFlagsForPerson(em, person)
           link.isPrimary = true
-          const profile = await findOneWithDecryption(
-            em,
-            CustomerPersonProfile,
-            { entity: person },
-            { populate: ['company'] },
-            { tenantId: person.tenantId, organizationId: person.organizationId },
-          )
-          if (profile) {
-            const company = await findOneWithDecryption(
-              em,
-              CustomerEntity,
-              { id: before.companyEntityId, kind: 'company', tenantId: before.tenantId, organizationId: before.organizationId, deletedAt: null },
-              undefined,
-              { tenantId: before.tenantId, organizationId: before.organizationId },
-            )
-            if (company) profile.company = company
-          }
+          if (profile && company) profile.company = company
         }
       },
     ], { transaction: true })


### PR DESCRIPTION
Fixes #2507

## Problem
`customers.personCompanyLinks.create` undo was a silent no-op: after create→undo the person↔company link still existed (undo returned ok but the junction row was never soft-deleted). Found during TC-UNDO-001 (#2468).

## Root Cause
The create undo handler mutated the link first (`isPrimary = false`, `deletedAt = new Date()`) and then ran `findOneWithDecryption`/`loadPersonCompanyLinks` on the same `EntityManager`. `loadPersonCompanyLinks` re-selects the not-yet-flushed link row (SQL still sees `deleted_at IS NULL`), the identity map returns the same mutated instance, and the tenant-encryption `afterFind` deep-decrypt re-baselines its change tracking (`syncOriginalEntityData` → `__originalEntityData` = current in-memory state, `__touched = false`). The final `em.flush()` then sees no changeset and emits no UPDATE — the soft delete is silently dropped.

This is the same mechanism class as #2498, but the correct fix here is **handler-local**: `withAtomicFlush` guarantees atomicity only, so the documented SPEC-018 safe ordering (all queries before any scalar mutation) must hold inside the handler. The `delete` command's `execute` path already follows it. This PR intentionally does **not** touch the encryption subscriber — the systemic re-baseline fix stays with #2498 (in progress) and is complementary.

Per the issue's verification ask: `update`/`delete` undo are **not broken today** (they never re-select the mutated link after mutating it), but they used the same unsafe mutate-then-query ordering and were one `populate` away from the same bug — they are reordered to the safe pattern as well.

## What Changed
- `packages/core/src/modules/customers/commands/personCompanyLinks.ts` — all three undo handlers (`create`, `update`, `delete`) now run every query (person, profile, company, link list) in a first `withAtomicFlush` phase and apply scalar mutations in a second phase. Pure reordering: every branch (person missing, non-primary link, fallback-primary promotion) produces the same end state as before. Tenant/org scoping on every query is unchanged; side-effect emission stays outside `withAtomicFlush`.
- `packages/core/src/modules/customers/commands/__tests__/personCompanyLinks.undo.test.ts` — new regression suite with a fake EM that simulates MikroORM snapshot-diff flushing plus the encryption re-baseline-on-find semantics. The two create-undo tests fail on the previous ordering (reproducing the exact QA evidence: link survives with `isPrimary: true`) and pass with the fix; update/delete undo tests pin their restore behavior.

## Tests
- New: `personCompanyLinks.undo.test.ts` (4 tests — red on old code, green on fix)
- `yarn workspace @open-mercato/core test --testPathPatterns customers` → 139 suites / 770 tests pass
- Full gate: `yarn generate` ✅ · `yarn build:packages` ✅ · `yarn typecheck` ✅ · `yarn i18n:check-sync` ✅ · `yarn build:app` ✅
- `yarn test` → only pre-existing failures unrelated to this change: `@open-mercato/cli` `dev-env-reload.test.ts` (fs-watch timing, fails identically on pristine develop in this environment) ; `yarn i18n:check-usage` reports 10 pre-existing missing keys in `sso`/`ai_assistant`/`api_keys` (this PR adds no strings)

## Backward Compatibility
- No contract surface changes: command IDs, event emissions (`customers.person_company_link.*`), undo payload shapes, API routes, DB schema, DI keys, and ACL features are all unchanged.

## Security impact
- No change to authentication, authorization, or encryption semantics. All queries keep their existing tenant/organization scoping and continue to go through `findOneWithDecryption`/`findWithDecryption`. The fix only reorders reads before writes inside the undo transactions so writes are not lost.

Refs #2468 #2498

🤖 Generated with [Claude Code](https://claude.com/claude-code)
