### PR TITLE
fix(workflows): Definition form persists Category/Tags/Icon (metadata.*) (#2503)

### DIFF
--- a/packages/core/src/modules/workflows/__integration__/TC-WF-014.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-014.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
+import {
+  buildWorkflowPayload,
+  parseWorkflowToFormValues,
+  defaultFormValues,
+  type WorkflowDefinitionFormValues,
+} from '../components/formConfig'
+
+// Regression for issue #2503: the Workflow Definition CrudForm declares its
+// Category/Tags/Icon fields with dot-path ids (`metadata.category`, `.tags`,
+// `.icon`). CrudForm only collapses dot-paths for injected/custom fields, so
+// these base fields are carried as flat keys. Previously the form helpers wrote
+// them into a nested `metadata` object the inputs never read, so the values
+// silently failed to load and edits were stripped before reaching the API.
+//
+// This test exercises the real form-mapping helpers against the live API to
+// prove the full round trip: form values -> POST -> GET -> hydrated form values
+// (load) and edited form values -> PUT -> GET (save).
+
+type WorkflowDefinitionRecord = {
+  id: string
+  workflowId: string
+  workflowName: string
+  version: number
+  definition: Record<string, unknown>
+  metadata?: { tags?: string[]; category?: string; icon?: string } | null
+}
+
+function buildFormValues(timestamp: number): WorkflowDefinitionFormValues {
+  return {
+    ...defaultFormValues,
+    workflowId: `qa-wf-metadata-${timestamp}`,
+    workflowName: `QA Metadata Workflow ${timestamp}`,
+    description: 'Workflow used to validate metadata.* persistence (issue #2503)',
+    version: 1,
+    'metadata.category': 'Sales',
+    'metadata.tags': ['sales', 'orders', 'invoicing'],
+    'metadata.icon': 'shopping-cart',
+    steps: [
+      { stepId: 'start', stepName: 'Start', stepType: 'START' },
+      { stepId: 'end', stepName: 'End', stepType: 'END' },
+    ],
+    transitions: [
+      {
+        transitionId: 'start_to_end',
+        fromStepId: 'start',
+        toStepId: 'end',
+        trigger: 'auto',
+        priority: 10,
+      },
+    ],
+  }
+}
+
+async function deleteWorkflowDefinitionIfExists(
+  request: APIRequestContext,
+  token: string | null,
+  id: string | null,
+) {
+  if (!token || !id) return
+  try {
+    await apiRequest(request, 'DELETE', `/api/workflows/definitions/${id}`, { token })
+  } catch {
+    return
+  }
+}
+
+async function fetchDefinition(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<WorkflowDefinitionRecord> {
+  const response = await apiRequest(request, 'GET', `/api/workflows/definitions/${id}`, { token })
+  const body = await readJsonSafe<{ data?: WorkflowDefinitionRecord; error?: string }>(response)
+  expect(response.status(), `Fetch definition failed: ${JSON.stringify(body)}`).toBe(200)
+  expect(body?.data).toBeTruthy()
+  return body!.data!
+}
+
+test.describe('TC-WF-014: Workflow Definition metadata.* load/save round trip (#2503)', () => {
+  test('persists and hydrates Category/Tags/Icon through the form helpers', async ({ request }) => {
+    const timestamp = Date.now()
+    const formValues = buildFormValues(timestamp)
+
+    let token: string | null = null
+    let definitionId: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+
+      // --- Create: form values -> payload -> POST ---
+      const createPayload = buildWorkflowPayload(formValues)
+      // The helper must collapse the flat dot-path keys into nested metadata.
+      expect(createPayload.metadata).toEqual({
+        tags: ['sales', 'orders', 'invoicing'],
+        category: 'Sales',
+        icon: 'shopping-cart',
+      })
+
+      const createResponse = await apiRequest(request, 'POST', '/api/workflows/definitions', {
+        token,
+        data: createPayload,
+      })
+      const createBody = await readJsonSafe<{ data?: WorkflowDefinitionRecord; error?: string }>(createResponse)
+      expect(
+        createResponse.status(),
+        `Definition creation failed: ${JSON.stringify(createBody)}`,
+      ).toBe(201)
+      definitionId = createBody?.data?.id ?? null
+      expect(definitionId).toBeTruthy()
+      // Save side on create must reach the server intact.
+      expect(createBody?.data?.metadata).toEqual({
+        tags: ['sales', 'orders', 'invoicing'],
+        category: 'Sales',
+        icon: 'shopping-cart',
+      })
+
+      // --- Load: GET -> parseWorkflowToFormValues must hydrate the flat keys ---
+      const created = await fetchDefinition(request, token, definitionId!)
+      const hydrated = parseWorkflowToFormValues(created)
+      expect(hydrated['metadata.category']).toBe('Sales')
+      expect(hydrated['metadata.tags']).toEqual(['sales', 'orders', 'invoicing'])
+      expect(hydrated['metadata.icon']).toBe('shopping-cart')
+
+      // --- Edit: change category via the flat key the input writes, then PUT ---
+      const editedValues: WorkflowDefinitionFormValues = {
+        ...hydrated,
+        workflowName: `${formValues.workflowName} (edited)`,
+        'metadata.category': 'qa-category-2503',
+      }
+      const updatePayload = buildWorkflowPayload(editedValues)
+      const updateResponse = await apiRequest(
+        request,
+        'PUT',
+        `/api/workflows/definitions/${definitionId}`,
+        { token, data: updatePayload },
+      )
+      const updateBody = await readJsonSafe<{ data?: WorkflowDefinitionRecord; error?: string }>(updateResponse)
+      expect(
+        updateResponse.status(),
+        `Definition update failed: ${JSON.stringify(updateBody)}`,
+      ).toBe(200)
+
+      // --- Verify save: GET -> edited category persisted, tags/icon preserved ---
+      const updated = await fetchDefinition(request, token, definitionId!)
+      expect(updated.workflowName).toBe(`${formValues.workflowName} (edited)`)
+      expect(updated.metadata?.category).toBe('qa-category-2503')
+      expect(updated.metadata?.tags).toEqual(['sales', 'orders', 'invoicing'])
+      expect(updated.metadata?.icon).toBe('shopping-cart')
+
+      // Re-hydrating the updated record must show the edited value (load again).
+      const rehydrated = parseWorkflowToFormValues(updated)
+      expect(rehydrated['metadata.category']).toBe('qa-category-2503')
+    } finally {
+      await deleteWorkflowDefinitionIfExists(request, token, definitionId)
+    }
+  })
+})

--- a/packages/core/src/modules/workflows/components/__tests__/formConfig.test.ts
+++ b/packages/core/src/modules/workflows/components/__tests__/formConfig.test.ts
@@ -85,4 +85,95 @@ describe('workflow definition formConfig', () => {
       expect(payload.definition).not.toHaveProperty('triggers')
     })
   })
+
+  // Regression for issue #2503: the Category/Tags/Icon fields are declared with
+  // dot-path ids (`metadata.category`, `.tags`, `.icon`). CrudForm reads/writes
+  // those as flat keys, so parse must hydrate the flat keys and build must
+  // collapse them back into the nested metadata object the API expects.
+  describe('metadata.* dot-path round trip (#2503)', () => {
+    test('parseWorkflowToFormValues hydrates flat metadata keys from nested metadata', () => {
+      const values = parseWorkflowToFormValues({
+        workflowId: 'wf',
+        workflowName: 'Workflow',
+        version: 1,
+        enabled: true,
+        metadata: { category: 'Sales', tags: ['sales', 'orders'], icon: 'shopping-cart' },
+        definition: { steps: [], transitions: [] },
+      })
+      expect(values['metadata.category']).toBe('Sales')
+      expect(values['metadata.tags']).toEqual(['sales', 'orders'])
+      expect(values['metadata.icon']).toBe('shopping-cart')
+    })
+
+    test('parseWorkflowToFormValues defaults flat metadata keys when metadata is absent', () => {
+      const values = parseWorkflowToFormValues({
+        workflowId: 'wf',
+        workflowName: 'Workflow',
+        version: 1,
+        enabled: true,
+        definition: { steps: [], transitions: [] },
+      })
+      expect(values['metadata.category']).toBe('')
+      expect(values['metadata.tags']).toEqual([])
+      expect(values['metadata.icon']).toBe('')
+    })
+
+    test('buildWorkflowPayload collapses flat metadata keys into nested metadata', () => {
+      const values: WorkflowDefinitionFormValues = {
+        ...defaultFormValues,
+        workflowId: 'wf',
+        workflowName: 'Workflow',
+        'metadata.category': 'qa-category-2503',
+        'metadata.tags': ['sales', 'orders'],
+        'metadata.icon': 'shopping-cart',
+      }
+
+      const payload = buildWorkflowPayload(values)
+
+      expect(payload.metadata).toEqual({
+        tags: ['sales', 'orders'],
+        category: 'qa-category-2503',
+        icon: 'shopping-cart',
+      })
+    })
+
+    test('buildWorkflowPayload drops blank category/icon but keeps tags array', () => {
+      const values: WorkflowDefinitionFormValues = {
+        ...defaultFormValues,
+        workflowId: 'wf',
+        workflowName: 'Workflow',
+        'metadata.category': '   ',
+        'metadata.tags': [],
+        'metadata.icon': '',
+      }
+
+      const payload = buildWorkflowPayload(values)
+
+      expect(payload.metadata).toEqual({ tags: [] })
+    })
+
+    test('edited category persists through a parse -> edit -> build round trip', () => {
+      const hydrated = parseWorkflowToFormValues({
+        workflowId: 'wf',
+        workflowName: 'Workflow',
+        version: 1,
+        enabled: true,
+        metadata: { category: 'Sales', tags: ['sales'], icon: 'shopping-cart' },
+        definition: { steps: [], transitions: [] },
+      })
+
+      const edited: WorkflowDefinitionFormValues = {
+        ...hydrated,
+        'metadata.category': 'qa-category-2503',
+      }
+
+      const payload = buildWorkflowPayload(edited)
+
+      expect(payload.metadata).toEqual({
+        tags: ['sales'],
+        category: 'qa-category-2503',
+        icon: 'shopping-cart',
+      })
+    })
+  })
 })

--- a/packages/core/src/modules/workflows/components/formConfig.tsx
+++ b/packages/core/src/modules/workflows/components/formConfig.tsx
@@ -17,11 +17,14 @@ export type WorkflowDefinitionFormValues = {
   enabled: boolean
   effectiveFrom?: string | null
   effectiveTo?: string | null
-  metadata?: {
-    tags?: string[]
-    category?: string
-    icon?: string
-  } | null
+  // Metadata fields are declared on the form with dot-path ids
+  // (`metadata.category`, `metadata.tags`, `metadata.icon`). CrudForm only
+  // collapses dot-paths for injected/custom fields, so declared base fields are
+  // carried as flat keys end-to-end; buildWorkflowPayload reassembles them into
+  // the nested metadata object the API expects. See issue #2503.
+  'metadata.category'?: string
+  'metadata.tags'?: string[]
+  'metadata.icon'?: string
   steps: any[]
   transitions: any[]
   triggers: WorkflowDefinitionTrigger[]
@@ -47,11 +50,11 @@ export const workflowDefinitionFormSchema = z.object({
   enabled: z.boolean(),
   effectiveFrom: z.string().optional().nullable(),
   effectiveTo: z.string().optional().nullable(),
-  metadata: z.object({
-    tags: z.array(z.string()).optional(),
-    category: z.string().max(50).optional(),
-    icon: z.string().max(50).optional(),
-  }).optional().nullable(),
+  // Flat dot-path keys mirror the field ids so CrudForm's non-strict
+  // schema.safeParse keeps them instead of stripping them before onSubmit.
+  'metadata.category': z.string().max(50).optional(),
+  'metadata.tags': z.array(z.string()).optional(),
+  'metadata.icon': z.string().max(50).optional(),
   steps: z.array(z.any()),
   transitions: z.array(z.any()),
   triggers: z.array(z.any()).default([]),
@@ -68,11 +71,9 @@ export const defaultFormValues: WorkflowDefinitionFormValues = {
   enabled: true,
   effectiveFrom: null,
   effectiveTo: null,
-  metadata: {
-    tags: [],
-    category: '',
-    icon: '',
-  },
+  'metadata.category': '',
+  'metadata.tags': [],
+  'metadata.icon': '',
   steps: [],
   transitions: [],
   triggers: [],
@@ -234,6 +235,7 @@ import { toDateInputValue } from '@open-mercato/shared/lib/date/format'
  * Parse workflow definition to form values
  */
 export function parseWorkflowToFormValues(workflow: any): WorkflowDefinitionFormValues {
+  const metadata = workflow.metadata || {}
   return {
     workflowId: workflow.workflowId || '',
     workflowName: workflow.workflowName || '',
@@ -242,7 +244,10 @@ export function parseWorkflowToFormValues(workflow: any): WorkflowDefinitionForm
     enabled: workflow.enabled ?? true,
     effectiveFrom: toDateInputValue(workflow.effectiveFrom),
     effectiveTo: toDateInputValue(workflow.effectiveTo),
-    metadata: workflow.metadata || { tags: [], category: '', icon: '' },
+    // Hydrate the flat dot-path keys the CrudForm inputs actually read.
+    'metadata.category': metadata.category || '',
+    'metadata.tags': Array.isArray(metadata.tags) ? metadata.tags : [],
+    'metadata.icon': metadata.icon || '',
     steps: workflow.definition?.steps || [],
     transitions: workflow.definition?.transitions || [],
     triggers: workflow.definition?.triggers || [],
@@ -254,6 +259,16 @@ export function parseWorkflowToFormValues(workflow: any): WorkflowDefinitionForm
  */
 export function buildWorkflowPayload(values: WorkflowDefinitionFormValues) {
   const triggers = values.triggers ?? []
+  // Collapse the flat dot-path keys back into the nested metadata object the API
+  // expects. Empty category/icon are dropped so they don't persist as blanks.
+  const category = (values['metadata.category'] || '').trim()
+  const icon = (values['metadata.icon'] || '').trim()
+  const tags = Array.isArray(values['metadata.tags']) ? values['metadata.tags'] : []
+  const metadata = {
+    tags,
+    ...(category ? { category } : {}),
+    ...(icon ? { icon } : {}),
+  }
   return {
     workflowId: values.workflowId,
     workflowName: values.workflowName,
@@ -262,7 +277,7 @@ export function buildWorkflowPayload(values: WorkflowDefinitionFormValues) {
     enabled: values.enabled,
     effectiveFrom: values.effectiveFrom || null,
     effectiveTo: values.effectiveTo || null,
-    metadata: values.metadata || null,
+    metadata,
     definition: {
       steps: values.steps,
       transitions: values.transitions,


### PR DESCRIPTION
Fixes #2503

## Problem
The Workflow Definition edit/create form (`/backend/definitions/{id}`) silently dropped its **Category**, **Tags**, and **Icon** fields:
- **Load broken** — opening an existing definition showed Category/Tags/Icon blank even when `metadata.{category,tags,icon}` was populated.
- **Save broken** — editing those fields was a net no-op; the edits never reached the API.

## Root Cause
These fields are declared with **dot-path ids** (`metadata.category`, `metadata.tags`, `metadata.icon`). `CrudForm` only collapses dot-paths for *injected/custom* fields — for ordinary declared base fields it reads/writes the literal flat key (`values["metadata.category"]`). The module's form helpers instead stored the values under a **nested** `metadata` object the inputs never read, and the non-strict `schema.safeParse` stripped the unknown flat keys before `onSubmit`. So the inputs hydrated empty and edits were discarded (no corruption — the untouched nested metadata was passed through unchanged).

## What Changed
Module-local fix in `packages/core/src/modules/workflows/components/formConfig.tsx`:
- `parseWorkflowToFormValues` now hydrates the **flat dot-path keys** the inputs actually read.
- `buildWorkflowPayload` collapses those flat keys back into the nested `metadata` object the API expects (blank category/icon dropped; tags kept as an array).
- `workflowDefinitionFormSchema` declares the flat keys so `safeParse` keeps them instead of stripping them.

No server, API, or contract changes — the GET serializer and PUT/POST handlers already handled `metadata` correctly.

## Tests
- **Unit** (`components/__tests__/formConfig.test.ts`): 6 new regressions — load hydration, save collapse, blank-field handling, and a full parse → edit → build round trip.
- **Integration** (`__integration__/TC-WF-014.spec.ts`): exercises the **real** form helpers against the live API (create → load → edit → save round trip), asserting Category/Tags/Icon persist and re-hydrate.
- Verified in a booted app: the full workflows integration suite (incl. browser-DOM UI tests TC-WF-010/011) passes **44/44**, with TC-WF-014 green.
- `yarn typecheck` green; workflows unit suite 510/510.

## Backward Compatibility
No contract surface changes. The `WorkflowDefinitionFormValues` form-values type is module-internal; the API payload shape (`metadata: { tags, category, icon }`) is unchanged.