### PR TITLE
fix(scheduler): jobs undo is a silent no-op — use extractUndoPayload (#2504)

### DIFF
--- a/packages/scheduler/src/modules/scheduler/__integration__/TC-UNDO-001-scheduler-jobs.spec.ts
+++ b/packages/scheduler/src/modules/scheduler/__integration__/TC-UNDO-001-scheduler-jobs.spec.ts
@@ -1,0 +1,174 @@
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+
+/**
+ * TC-UNDO-001: scheduler.jobs undo round-trip (regression for issue #2504).
+ *
+ * Before the fix, every scheduler.jobs undo handler read `logEntry.payload`
+ * (always undefined — the command bus persists the undo snapshot under
+ * `commandPayload`), so undo returned `{ ok: true }` while silently changing
+ * nothing. This spec exercises the real HTTP path end-to-end:
+ *   - CREATE -> undo  => job is soft-deleted (no longer listed)
+ *   - UPDATE -> undo  => renamed field is restored to its prior value
+ *   - DELETE -> undo  => soft-deleted job is re-materialized
+ *
+ * Endpoints covered:
+ *   - POST   /api/scheduler/jobs                       (create)
+ *   - GET    /api/scheduler/jobs?id=                   (read)
+ *   - PUT    /api/scheduler/jobs                       (update)
+ *   - DELETE /api/scheduler/jobs                       (delete, cleanup)
+ *   - POST   /api/audit_logs/audit-logs/actions/undo   (undo)
+ */
+
+type ScheduleRow = {
+  id: string
+  name: string
+  description: string | null
+  scheduleValue: string
+}
+
+// The undo endpoint only honors the *latest* undoable log for a resource, and
+// `latestUndoableForResource` orders by `created_at` alone. Audit `created_at` is
+// millisecond-precision (`new Date()` at log time), so a create + a follow-up
+// mutation issued within the same millisecond tie and the lookup may resolve to
+// the wrong log. A short settle guarantees the operation under undo is strictly
+// the most recent, keeping the round-trip deterministic.
+async function settleAuditClock(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 50))
+}
+
+function readUndoToken(res: APIResponse): string {
+  const header = res.headers()['x-om-operation'] ?? ''
+  const enc = header.startsWith('omop:') ? header.slice(5) : ''
+  expect(enc, 'x-om-operation header should carry an omop: payload').not.toBe('')
+  const payload = JSON.parse(decodeURIComponent(enc)) as { undoToken?: string }
+  expect(typeof payload.undoToken, 'undoToken present in operation payload').toBe('string')
+  return payload.undoToken as string
+}
+
+async function getById(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<ScheduleRow | undefined> {
+  const res = await apiRequest(request, 'GET', `/api/scheduler/jobs?id=${encodeURIComponent(id)}`, { token })
+  expect(res.status()).toBe(200)
+  const body = (await res.json()) as { items?: ScheduleRow[] }
+  return (body.items ?? [])[0]
+}
+
+async function createJob(request: APIRequestContext, token: string, name: string): Promise<{ id: string; res: APIResponse }> {
+  const res = await apiRequest(request, 'POST', '/api/scheduler/jobs', {
+    token,
+    data: {
+      name,
+      description: 'TC-UNDO-001 probe',
+      scopeType: 'tenant',
+      scheduleType: 'cron',
+      scheduleValue: '0 0 * * *',
+      timezone: 'UTC',
+      targetType: 'queue',
+      targetQueue: 'default',
+      isEnabled: true,
+      sourceType: 'user',
+    },
+  })
+  expect(res.status(), 'create returns 201').toBe(201)
+  const id = ((await res.json()) as { id: string }).id
+  expect(id, 'create returns an id').toBeTruthy()
+  return { id, res }
+}
+
+async function undo(request: APIRequestContext, token: string, undoToken: string): Promise<void> {
+  const res = await apiRequest(request, 'POST', '/api/audit_logs/audit-logs/actions/undo', {
+    token,
+    data: { undoToken },
+  })
+  const raw = await res.text()
+  expect(res.status(), `undo returns 200 (body: ${raw})`).toBe(200)
+  const body = JSON.parse(raw) as { ok?: boolean }
+  expect(body.ok, 'undo body is { ok: true }').toBe(true)
+}
+
+async function cleanup(request: APIRequestContext, token: string | null, id: string | null): Promise<void> {
+  if (!token || !id) return
+  try {
+    await apiRequest(request, 'DELETE', '/api/scheduler/jobs', { token, data: { id } })
+  } catch {
+    /* ignore */
+  }
+}
+
+test.describe('TC-UNDO-001: scheduler.jobs undo actually restores state (#2504)', () => {
+  test('UPDATE -> undo restores the prior name', async ({ request }) => {
+    let token: string | null = null
+    let id: string | null = null
+    try {
+      token = await getAuthToken(request, 'admin')
+      const originalName = `TC-UNDO-001 Update ${Date.now()}`
+      ;({ id } = await createJob(request, token, originalName))
+      await settleAuditClock()
+
+      const updateRes = await apiRequest(request, 'PUT', '/api/scheduler/jobs', {
+        token,
+        data: { id, name: `${originalName} RENAMED` },
+      })
+      expect(updateRes.status(), 'update returns 200').toBe(200)
+      expect((await getById(request, token, id))?.name).toBe(`${originalName} RENAMED`)
+
+      await undo(request, token, readUndoToken(updateRes))
+
+      const restored = await getById(request, token, id)
+      expect(restored, 'job still exists after update-undo').toBeTruthy()
+      expect(restored!.name, 'name restored to original by undo').toBe(originalName)
+    } finally {
+      await cleanup(request, token, id)
+    }
+  })
+
+  test('DELETE -> undo re-lists the soft-deleted job', async ({ request }) => {
+    let token: string | null = null
+    let id: string | null = null
+    try {
+      token = await getAuthToken(request, 'admin')
+      const name = `TC-UNDO-001 Delete ${Date.now()}`
+      ;({ id } = await createJob(request, token, name))
+      await settleAuditClock()
+
+      const deleteRes = await apiRequest(request, 'DELETE', '/api/scheduler/jobs', {
+        token,
+        data: { id },
+      })
+      expect(deleteRes.status(), 'delete returns 200').toBe(200)
+      expect(await getById(request, token, id), 'job is gone after delete').toBeFalsy()
+
+      await undo(request, token, readUndoToken(deleteRes))
+
+      const restored = await getById(request, token, id)
+      expect(restored, 'job re-materialized by delete-undo').toBeTruthy()
+      expect(restored!.name).toBe(name)
+    } finally {
+      await cleanup(request, token, id)
+    }
+  })
+
+  test('CREATE -> undo removes the created job', async ({ request }) => {
+    let token: string | null = null
+    let id: string | null = null
+    try {
+      token = await getAuthToken(request, 'admin')
+      const name = `TC-UNDO-001 Create ${Date.now()}`
+      const created = await createJob(request, token, name)
+      id = created.id
+
+      expect(await getById(request, token, id), 'job exists after create').toBeTruthy()
+
+      await undo(request, token, readUndoToken(created.res))
+
+      expect(await getById(request, token, id), 'job removed by create-undo').toBeFalsy()
+      id = null // already undone; nothing to clean up
+    } finally {
+      await cleanup(request, token, id)
+    }
+  })
+})

--- a/packages/scheduler/src/modules/scheduler/commands/__tests__/jobs.undo.test.ts
+++ b/packages/scheduler/src/modules/scheduler/commands/__tests__/jobs.undo.test.ts
@@ -1,0 +1,181 @@
+export {}
+
+// Regression coverage for issue #2504: scheduler.jobs undo handlers were silent
+// no-ops because they read `logEntry.payload` (always undefined) instead of the
+// persisted `commandPayload`. These tests construct the logEntry exactly as the
+// command bus persists it (redo-wrapped `commandPayload`, no top-level `payload`)
+// and assert undo actually restores state.
+
+const registerCommand = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/commands', () => ({
+  registerCommand,
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn().mockResolvedValue({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+function loadCommands() {
+  let create: any
+  let update: any
+  let del: any
+  jest.isolateModules(() => {
+    require('../jobs')
+    create = registerCommand.mock.calls.find(([cmd]) => cmd.id === 'scheduler.jobs.create')?.[0]
+    update = registerCommand.mock.calls.find(([cmd]) => cmd.id === 'scheduler.jobs.update')?.[0]
+    del = registerCommand.mock.calls.find(([cmd]) => cmd.id === 'scheduler.jobs.delete')?.[0]
+  })
+  return { create, update, del }
+}
+
+function makeEm(schedule: Record<string, unknown> | null) {
+  const removeFlush = jest.fn().mockResolvedValue(undefined)
+  const created: Record<string, unknown>[] = []
+  const em: any = {
+    fork: jest.fn().mockReturnThis(),
+    findOne: jest.fn().mockResolvedValue(schedule),
+    persist: jest.fn(),
+    remove: jest.fn().mockReturnValue({ flush: removeFlush }),
+    flush: jest.fn().mockResolvedValue(undefined),
+    create: jest.fn((_entity: unknown, data: Record<string, unknown>) => {
+      created.push(data)
+      return data
+    }),
+    __created: created,
+    __removeFlush: removeFlush,
+  }
+  return em
+}
+
+function makeCtx(em: any) {
+  return {
+    auth: { isSuperAdmin: true, tenantId: null },
+    container: { resolve: jest.fn(() => em) },
+  } as any
+}
+
+// Mirrors command-bus.persistLog: metadata.payload becomes the redo-wrapped
+// `commandPayload`; there is no top-level `payload` on the stored row.
+function persistedLogEntry(snapshots: { before?: unknown; after?: unknown }) {
+  return {
+    commandPayload: { __redoInput: { id: 'job-1' }, undo: { ...snapshots } },
+    snapshotBefore: snapshots.before,
+    snapshotAfter: snapshots.after,
+  }
+}
+
+function baseSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'job-1',
+    name: 'Nightly report',
+    description: 'original description',
+    scopeType: 'tenant',
+    organizationId: null,
+    tenantId: 'tenant-a',
+    scheduleType: 'cron',
+    scheduleValue: '0 0 * * *',
+    timezone: 'UTC',
+    targetType: 'queue',
+    targetQueue: 'default',
+    targetCommand: null,
+    targetPayload: null,
+    requireFeature: null,
+    isEnabled: true,
+    sourceType: 'user',
+    sourceModule: null,
+    nextRunAt: null,
+    lastRunAt: null,
+    ...overrides,
+  }
+}
+
+describe('scheduler.jobs undo restores state (issue #2504)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.resetModules()
+  })
+
+  it('update undo restores the prior field values from commandPayload', async () => {
+    const { update } = loadCommands()
+    expect(update).toBeDefined()
+
+    const before = baseSnapshot({ name: 'Nightly report' })
+    const after = baseSnapshot({ name: 'Nightly report RENAMED' })
+    // The live row currently holds the post-update ("after") state.
+    const liveRow: Record<string, unknown> = { ...after }
+    const em = makeEm(liveRow)
+
+    await update.undo({ logEntry: persistedLogEntry({ before, after }), ctx: makeCtx(em) })
+
+    expect(em.flush).toHaveBeenCalled()
+    expect(liveRow.name).toBe('Nightly report')
+  })
+
+  it('update undo coerces JSON-serialized Date fields back to Date instances', async () => {
+    const { update } = loadCommands()
+    // Snapshots persisted in the action log are JSON, so Date fields arrive as
+    // ISO strings. They MUST be coerced to Date before assignment, otherwise
+    // MikroORM throws on the typed Date column (the real failure behind #2504).
+    const before = baseSnapshot({ nextRunAt: '2026-06-05T00:00:00.000Z', lastRunAt: '2026-06-04T00:00:00.000Z' })
+    const liveRow: Record<string, unknown> = { ...baseSnapshot() }
+    const em = makeEm(liveRow)
+
+    await update.undo({ logEntry: persistedLogEntry({ before }), ctx: makeCtx(em) })
+
+    expect(liveRow.nextRunAt).toBeInstanceOf(Date)
+    expect(liveRow.lastRunAt).toBeInstanceOf(Date)
+    expect((liveRow.nextRunAt as Date).toISOString()).toBe('2026-06-05T00:00:00.000Z')
+  })
+
+  it('update undo is a no-op when no snapshot is recoverable', async () => {
+    const { update } = loadCommands()
+    const em = makeEm({ id: 'job-1', name: 'whatever' })
+    // No commandPayload and no snapshots -> nothing to restore.
+    await update.undo({ logEntry: { commandPayload: null }, ctx: makeCtx(em) })
+    expect(em.findOne).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('create undo removes the created row using the after snapshot', async () => {
+    const { create } = loadCommands()
+    const after = baseSnapshot()
+    const liveRow = { ...after }
+    const em = makeEm(liveRow)
+
+    await create.undo({ logEntry: persistedLogEntry({ after }), ctx: makeCtx(em) })
+
+    expect(em.remove).toHaveBeenCalledWith(liveRow)
+    expect(em.__removeFlush).toHaveBeenCalled()
+  })
+
+  it('delete undo restores a soft-deleted row by clearing deletedAt', async () => {
+    const { del } = loadCommands()
+    const before = baseSnapshot()
+    const liveRow: Record<string, unknown> = { ...before, deletedAt: new Date() }
+    const em = makeEm(liveRow)
+
+    await del.undo({ logEntry: persistedLogEntry({ before }), ctx: makeCtx(em) })
+
+    expect(liveRow.deletedAt).toBeNull()
+    expect(em.flush).toHaveBeenCalled()
+    expect(em.create).not.toHaveBeenCalled()
+  })
+
+  it('delete undo re-materializes a hard-removed row from the snapshot', async () => {
+    const { del } = loadCommands()
+    const before = baseSnapshot({ name: 'Hard removed job', nextRunAt: '2026-06-05T00:00:00.000Z' })
+    // findOne returns null -> the row no longer exists and must be re-created.
+    const em = makeEm(null)
+
+    await del.undo({ logEntry: persistedLogEntry({ before }), ctx: makeCtx(em) })
+
+    expect(em.create).toHaveBeenCalled()
+    expect(em.__created[0]).toMatchObject({ id: 'job-1', name: 'Hard removed job', deletedAt: null })
+    // Re-materialization also coerces JSON date strings to Date instances.
+    expect(em.__created[0].nextRunAt).toBeInstanceOf(Date)
+    expect(em.flush).toHaveBeenCalled()
+  })
+})

--- a/packages/scheduler/src/modules/scheduler/commands/jobs.ts
+++ b/packages/scheduler/src/modules/scheduler/commands/jobs.ts
@@ -1,5 +1,6 @@
 import { registerCommand } from '@open-mercato/shared/lib/commands'
 import type { CommandHandler, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import { extractUndoPayload, type UndoPayload } from '@open-mercato/shared/lib/commands/undo'
 import { ensureOrganizationScope } from '@open-mercato/shared/lib/commands/scope'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { EntityManager } from '@mikro-orm/core'
@@ -68,6 +69,48 @@ async function loadScheduleSnapshot(
     nextRunAt: schedule.nextRunAt ?? null,
     lastRunAt: schedule.lastRunAt ?? null,
   }
+}
+
+/**
+ * Snapshots are persisted as JSON (in the action log's command payload), so Date
+ * fields come back as ISO strings on undo. Coerce them to Date before writing
+ * them onto the entity, otherwise MikroORM throws while flushing a Date column.
+ */
+function toDate(value: Date | string | null | undefined): Date | null {
+  if (!value) return null
+  return value instanceof Date ? value : new Date(value)
+}
+
+/**
+ * Re-create a ScheduledJob entity from a snapshot, preserving its original id.
+ * Used by delete-undo when the row was hard-removed rather than soft-deleted.
+ */
+function materializeScheduleFromSnapshot(em: EntityManager, snapshot: ScheduleSnapshot): ScheduledJob {
+  const now = new Date()
+  return em.create(ScheduledJob, {
+    id: snapshot.id,
+    name: snapshot.name,
+    description: snapshot.description,
+    scopeType: snapshot.scopeType,
+    organizationId: snapshot.organizationId,
+    tenantId: snapshot.tenantId,
+    scheduleType: snapshot.scheduleType,
+    scheduleValue: snapshot.scheduleValue,
+    timezone: snapshot.timezone,
+    targetType: snapshot.targetType,
+    targetQueue: snapshot.targetQueue,
+    targetCommand: snapshot.targetCommand,
+    targetPayload: snapshot.targetPayload,
+    requireFeature: snapshot.requireFeature,
+    isEnabled: snapshot.isEnabled,
+    sourceType: snapshot.sourceType,
+    sourceModule: snapshot.sourceModule,
+    nextRunAt: toDate(snapshot.nextRunAt),
+    lastRunAt: toDate(snapshot.lastRunAt),
+    deletedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  })
 }
 
 /**
@@ -197,8 +240,7 @@ const createScheduleCommand: CommandHandler<ScheduleCreateInput, { id: string }>
   },
 
   async undo({ logEntry, ctx }) {
-    const undoPayload = logEntry.payload as { undo?: { after?: ScheduleSnapshot } }
-    const after = undoPayload?.undo?.after
+    const after = extractUndoPayload<UndoPayload<ScheduleSnapshot>>(logEntry)?.after
     if (!after) return
 
     const em = ctx.container.resolve<EntityManager>('em').fork()
@@ -307,8 +349,7 @@ const updateScheduleCommand: CommandHandler<ScheduleUpdateInput, { ok: boolean }
   },
 
   async undo({ logEntry, ctx }) {
-    const undoPayload = logEntry.payload as { undo?: { before?: ScheduleSnapshot; after?: ScheduleSnapshot } }
-    const before = undoPayload?.undo?.before
+    const before = extractUndoPayload<UndoPayload<ScheduleSnapshot>>(logEntry)?.before
     if (!before) return
 
     const em = ctx.container.resolve<EntityManager>('em').fork()
@@ -332,8 +373,8 @@ const updateScheduleCommand: CommandHandler<ScheduleUpdateInput, { ok: boolean }
       schedule.isEnabled = before.isEnabled
       schedule.sourceType = before.sourceType
       schedule.sourceModule = before.sourceModule
-      schedule.nextRunAt = before.nextRunAt
-      schedule.lastRunAt = before.lastRunAt
+      schedule.nextRunAt = toDate(before.nextRunAt)
+      schedule.lastRunAt = toDate(before.lastRunAt)
       schedule.updatedAt = new Date()
 
       await em.flush()
@@ -392,20 +433,22 @@ const deleteScheduleCommand: CommandHandler<{ id: string }, { ok: boolean }> = {
   },
 
   async undo({ logEntry, ctx }) {
-    const undoPayload = logEntry.payload as { undo?: { before?: ScheduleSnapshot } }
-    const before = undoPayload?.undo?.before
+    const before = extractUndoPayload<UndoPayload<ScheduleSnapshot>>(logEntry)?.before
     if (!before) return
 
     const em = ctx.container.resolve<EntityManager>('em').fork()
-    const schedule = await em.findOne(ScheduledJob, { id: before.id })
+    const existing = await em.findOne(ScheduledJob, { id: before.id })
 
-    if (schedule) {
-      // Restore by clearing deletedAt
+    // Soft-deleted rows are restored by clearing `deletedAt`. A hard-removed row
+    // (no surviving record) is re-materialized from the snapshot so undo is
+    // robust to either deletion strategy — mirroring the sales reference undo.
+    const schedule = existing ?? materializeScheduleFromSnapshot(em, before)
+    if (existing) {
       schedule.deletedAt = null
       schedule.updatedAt = new Date()
-      await em.flush()
-      await syncBullMQAfterUndo(ctx, schedule)
     }
+    await em.flush()
+    await syncBullMQAfterUndo(ctx, schedule)
   },
 }
 

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -121,6 +121,15 @@ import { hasFeature, hasAllFeatures } from '@open-mercato/shared/security/featur
 - Use `parseIdsParam()` and `mergeIdFilter()` from `@open-mercato/shared/lib/crud/ids` for factory-level `ids` query support.
 - Keep `ids` format as comma-separated UUIDs (`?ids=uuid1,uuid2`) and intersect with existing `id` filters.
 
+### Command Undo Pattern — read the snapshot via `extractUndoPayload`
+
+A command's `buildLog()` returns `payload: { undo: { before, after } }`, but the command bus persists that under `commandPayload` (column `command_payload`, wrapped in a redo envelope) — **the stored `ActionLog` row has no top-level `payload`**. Reading `logEntry.payload` inside an `undo()` handler is therefore always `undefined`, which makes undo a silent no-op (issue #2504).
+
+MUST rules:
+- Inside `undo()`, read the snapshot **only** through `extractUndoPayload<UndoPayload<TSnapshot>>(logEntry)` from `@open-mercato/shared/lib/commands/undo`. It unwraps `commandPayload` (and the redo envelope) and falls back to `snapshotBefore`/`snapshotAfter`.
+- NEVER access `logEntry.payload` in an undo handler. The `logEntry` parameter is typed as `CommandUndoLogEntry`, which intentionally omits `payload` so this footgun is a compile-time error.
+- Delete-undo should be robust to either deletion strategy: clear `deletedAt` when the row survives (soft delete), otherwise re-create the entity from the snapshot (mirror `packages/core/src/modules/sales/commands/configuration.ts`).
+
 ### Module-Level Overrides (`@open-mercato/shared/modules/overrides`)
 
 Downstream apps replace or disable any contract a module presents through a single `entry.overrides` field on a `ModuleEntry`. The umbrella spec is `.ai/specs/2026-05-04-modules-ts-unified-overrides.md`; phases 1-18 are wired.

--- a/packages/shared/src/lib/commands/types.ts
+++ b/packages/shared/src/lib/commands/types.ts
@@ -54,6 +54,38 @@ export type CommandExecuteResult<TResult> = {
   logEntry: any | null
 }
 
+/**
+ * Shape of the persisted action log handed to a command's `undo()` handler.
+ *
+ * IMPORTANT: there is intentionally **no `payload` field**. `buildLog()` returns
+ * a `payload` in its metadata, but the command bus persists that under
+ * `commandPayload` (column `command_payload`, wrapped in a redo envelope) — the
+ * stored row never has a top-level `payload`. Reading `logEntry.payload` in an
+ * undo handler is therefore always `undefined` and silently no-ops the undo
+ * (issue #2504). Always read the undo snapshot through
+ * `extractUndoPayload(logEntry)` from `@open-mercato/shared/lib/commands/undo`,
+ * which unwraps `commandPayload`/snapshots correctly. Omitting `payload` here
+ * makes the footgun a compile-time error instead of a runtime silent failure.
+ */
+export type CommandUndoLogEntry = {
+  id?: string
+  commandId?: string
+  commandPayload?: unknown | null
+  snapshotBefore?: unknown | null
+  snapshotAfter?: unknown | null
+  resourceKind?: string | null
+  resourceId?: string | null
+  undoToken?: string | null
+  actionLabel?: string | null
+  tenantId?: string | null
+  organizationId?: string | null
+  actorUserId?: string | null
+  changesJson?: Record<string, unknown> | null
+  contextJson?: Record<string, unknown> | null
+  createdAt?: Date | string
+  updatedAt?: Date | string
+}
+
 export type CommandLogBuilderArgs<TInput, TResult> = {
   input: TInput
   result: TResult
@@ -71,7 +103,7 @@ export interface CommandHandler<TInput = unknown, TResult = unknown> {
   execute(input: TInput, ctx: CommandRuntimeContext): Promise<TResult> | TResult
   buildLog?(args: CommandLogBuilderArgs<TInput, TResult>): Promise<CommandLogMetadata | null | undefined> | CommandLogMetadata | null | undefined
   captureAfter?(input: TInput, result: TResult, ctx: CommandRuntimeContext): Promise<unknown> | unknown
-  undo?(params: { input: TInput; ctx: CommandRuntimeContext; logEntry: any }): Promise<void> | void
+  undo?(params: { input: TInput; ctx: CommandRuntimeContext; logEntry: CommandUndoLogEntry }): Promise<void> | void
 }
 
 export type CommandExecutionOptions<TInput> = {


### PR DESCRIPTION
Fixes #2504

## Problem
All `scheduler.jobs` undo handlers were silent no-ops: `update`/`delete`/`create` undo returned `{ ok: true }` but restored nothing. Found during TC-UNDO-001 (#2468).

## Root Cause
The handlers read the snapshot from `logEntry.payload`, but the persisted `ActionLog` has no `payload` field — the command bus stores undo data under `commandPayload` (redo-wrapped). So `logEntry.payload` was always `undefined` and each handler bailed at `if (!before) return` while still reporting success. Every working module uses the shared `extractUndoPayload(logEntry)` helper; the scheduler hand-rolled `logEntry.payload` and bypassed it.

## What Changed
- **`packages/scheduler/.../commands/jobs.ts`** — all three undo handlers now read the snapshot via `extractUndoPayload<UndoPayload<ScheduleSnapshot>>(logEntry)` (mirrors `sales/commands/configuration.ts`).
- **Date coercion** — snapshots round-trip through JSON, so `nextRunAt`/`lastRunAt` come back as ISO strings. The restore path (never exercised before this fix) now coerces them to `Date`, otherwise MikroORM throws on the typed `Date` columns.
- **Robust delete-undo** — re-materializes the row from the snapshot when no soft-deleted row survives (hard-remove safety), aligning with the sales reference.
- **Broader systemic fix (prevent recurrence):** `CommandHandler.undo`'s `logEntry` is now typed as `CommandUndoLogEntry` (in `packages/shared/src/lib/commands/types.ts`), which intentionally omits `payload` — so reading `logEntry.payload` in any undo handler is now a **compile-time error**. Documented the pattern in `packages/shared/AGENTS.md`.

## Tests
- **Unit** (`jobs.undo.test.ts`): update-restore, create-remove, delete soft-restore, delete hard re-materialize, no-op when no snapshot, and JSON Date-string coercion. 6 tests.
- **Integration** (`TC-UNDO-001-scheduler-jobs.spec.ts`): real create/update/delete → undo HTTP round-trip via the audit-logs undo endpoint. **Verified green in the ephemeral Playwright environment** (3/3).
- Full monorepo `yarn typecheck` passes — the `logEntry` type tightening broke no existing handler (footgun was isolated to scheduler).

## Backward Compatibility
- No API response fields, event IDs, ACL features, DI names, or import paths removed.
- `CommandUndoLogEntry` is additive; `logEntry.payload` was never a valid field on the persisted row, so removing it from the type surfaces a latent bug rather than breaking a real contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)