### PR TITLE
fix: expand scheduler coverage

### DIFF
--- a/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-002.spec.ts
+++ b/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-002.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  SCHEDULER_JOBS_PATH,
+  createScheduleJob,
+  deleteScheduleJob,
+  getScheduleJobById,
+  uniqueScheduleName,
+} from './helpers/scheduler'
+
+/**
+ * TC-SCHED-002: PUT /api/scheduler/jobs updates schedule fields correctly
+ *
+ * Note: scheduleUpdateSchema requires `scheduleType` whenever `scheduleValue`
+ * changes, so the update payload sends both (the issue's draft omitted the
+ * type — the route rejects that with 400). This asserts the real contract.
+ */
+test.describe('TC-SCHED-002: PUT /api/scheduler/jobs updates schedule fields', () => {
+  test('updates name and scheduleValue while preserving identity and scope', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let scheduleId: string | null = null
+
+    try {
+      scheduleId = await createScheduleJob(request, token, {
+        name: uniqueScheduleName('Sched Update'),
+        scheduleType: 'interval',
+        scheduleValue: '15m',
+      })
+
+      const original = await getScheduleJobById(request, token, scheduleId)
+      expect(original).not.toBeNull()
+      expect(original!.scheduleValue).toBe('15m')
+
+      const updateResponse = await apiRequest(request, 'PUT', SCHEDULER_JOBS_PATH, {
+        token,
+        data: { id: scheduleId, name: 'Updated-Test-1', scheduleType: 'interval', scheduleValue: '30m' },
+      })
+      expect(updateResponse.status()).toBe(200)
+      const updateBody = await readJsonSafe<{ ok?: boolean }>(updateResponse)
+      expect(updateBody?.ok).toBe(true)
+
+      const updated = await getScheduleJobById(request, token, scheduleId)
+      expect(updated).not.toBeNull()
+      // Mutated fields persisted
+      expect(updated!.name).toBe('Updated-Test-1')
+      expect(updated!.scheduleValue).toBe('30m')
+      // Identity and scope unchanged
+      expect(updated!.id).toBe(scheduleId)
+      expect(updated!.tenantId).toBe(original!.tenantId)
+      expect(updated!.organizationId).toBe(original!.organizationId)
+      expect(updated!.targetQueue).toBe(original!.targetQueue)
+      // updatedAt advances past the original creation timestamp
+      if (original!.createdAt && updated!.updatedAt) {
+        expect(new Date(updated!.updatedAt).getTime()).toBeGreaterThanOrEqual(
+          new Date(original!.createdAt).getTime(),
+        )
+      }
+    } finally {
+      await deleteScheduleJob(request, token, scheduleId)
+    }
+  })
+})

--- a/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-003.spec.ts
+++ b/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-003.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { SCHEDULER_JOBS_PATH, createScheduleJob, deleteScheduleJob, getScheduleJobById } from './helpers/scheduler'
+
+/**
+ * TC-SCHED-003: DELETE /api/scheduler/jobs soft-deletes a schedule and
+ * prevents re-listing. The list endpoint keeps returning 200 (not 404) with
+ * the soft-deleted record filtered out by the `deletedAt` soft-delete field.
+ */
+test.describe('TC-SCHED-003: DELETE /api/scheduler/jobs soft-deletes a schedule', () => {
+  test('removes the schedule from listings and returns 200 (not 404) afterwards', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let scheduleId: string | null = null
+    let deleted = false
+
+    try {
+      scheduleId = await createScheduleJob(request, token)
+
+      const present = await getScheduleJobById(request, token, scheduleId)
+      expect(present).not.toBeNull()
+
+      const deleteResponse = await apiRequest(request, 'DELETE', SCHEDULER_JOBS_PATH, {
+        token,
+        data: { id: scheduleId },
+      })
+      expect(deleteResponse.status()).toBe(200)
+      const deleteBody = await readJsonSafe<{ ok?: boolean }>(deleteResponse)
+      expect(deleteBody?.ok).toBe(true)
+      deleted = true
+
+      // Soft delete: list still returns 200 with an (empty) items array, never 404.
+      const afterResponse = await apiRequest(
+        request,
+        'GET',
+        `${SCHEDULER_JOBS_PATH}?id=${encodeURIComponent(scheduleId)}`,
+        { token },
+      )
+      expect(afterResponse.status()).toBe(200)
+      const afterBody = await readJsonSafe<{ items?: Array<{ id: string }> }>(afterResponse)
+      expect(Array.isArray(afterBody?.items)).toBe(true)
+      expect((afterBody?.items ?? []).some((item) => item.id === scheduleId)).toBe(false)
+      expect((afterBody?.items ?? []).length).toBe(0)
+    } finally {
+      if (!deleted) await deleteScheduleJob(request, token, scheduleId)
+    }
+  })
+})

--- a/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-004.spec.ts
+++ b/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-004.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { SCHEDULER_EXECUTION_QUEUE, SCHEDULER_TARGETS_PATH } from './helpers/scheduler'
+
+type TargetOption = { value: string; label: string }
+type TargetsResponse = { queues?: TargetOption[]; commands?: TargetOption[] }
+
+function expectSortedByValue(options: TargetOption[], label: string) {
+  const values = options.map((option) => option.value)
+  expect(values, `${label} should be sorted alphabetically by value`).toEqual(
+    [...values].sort((a, b) => a.localeCompare(b)),
+  )
+}
+
+function expectOptionShape(options: TargetOption[], label: string) {
+  for (const option of options) {
+    expect(typeof option.value, `${label} option value should be a string`).toBe('string')
+    expect(typeof option.label, `${label} option label should be a string`).toBe('string')
+  }
+}
+
+/**
+ * TC-SCHED-004: GET /api/scheduler/targets returns available queue names
+ * (from module workers) and registered command IDs (from the command
+ * registry), both sorted alphabetically by value. Read-only, no fixtures.
+ */
+test.describe('TC-SCHED-004: GET /api/scheduler/targets lists queues and commands', () => {
+  test('returns sorted queues (incl. scheduler-execution) and a non-empty command list', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const response = await apiRequest(request, 'GET', SCHEDULER_TARGETS_PATH, { token })
+    expect(response.status()).toBe(200)
+
+    const body = await readJsonSafe<TargetsResponse>(response)
+    const queues = body?.queues ?? []
+    const commands = body?.commands ?? []
+
+    // Queues: non-empty, well-shaped, sorted, and include the known scheduler queue.
+    expect(Array.isArray(body?.queues)).toBe(true)
+    expect(queues.length).toBeGreaterThan(0)
+    expectOptionShape(queues, 'queues')
+    expect(queues.map((queue) => queue.value)).toContain(SCHEDULER_EXECUTION_QUEUE)
+    expectSortedByValue(queues, 'queues')
+
+    // Commands: non-empty, well-shaped, and sorted.
+    expect(Array.isArray(body?.commands)).toBe(true)
+    expect(commands.length).toBeGreaterThan(0)
+    expectOptionShape(commands, 'commands')
+    expectSortedByValue(commands, 'commands')
+  })
+})

--- a/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-005.spec.ts
+++ b/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-005.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  SCHEDULER_TRIGGER_PATH,
+  createScheduleJob,
+  deleteScheduleJob,
+  uniqueScheduleName,
+} from './helpers/scheduler'
+
+const isAsyncQueueStrategy = (process.env.QUEUE_STRATEGY || 'local') === 'async'
+
+/**
+ * TC-SCHED-005: POST /api/scheduler/trigger manually enqueues a schedule for
+ * execution. Manual triggers require the async (BullMQ) queue strategy, so the
+ * assertion branches on QUEUE_STRATEGY exactly like TC-SCHED-001: async returns
+ * 200 + jobId, local returns 400 with an "async required" message.
+ */
+test.describe('TC-SCHED-005: POST /api/scheduler/trigger manual execution', () => {
+  test('enqueues an execution job (async) or rejects with async-required (local)', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let scheduleId: string | null = null
+
+    try {
+      scheduleId = await createScheduleJob(request, token, {
+        name: uniqueScheduleName('Trigger-Test'),
+        scheduleType: 'interval',
+        scheduleValue: '1h',
+      })
+
+      const response = await apiRequest(request, 'POST', SCHEDULER_TRIGGER_PATH, {
+        token,
+        data: { id: scheduleId },
+      })
+
+      if (isAsyncQueueStrategy) {
+        expect(response.status()).toBe(200)
+        const body = await readJsonSafe<{ ok?: boolean; jobId?: string; message?: string }>(response)
+        expect(body?.ok).toBe(true)
+        expect(typeof body?.jobId === 'string' && (body?.jobId?.length ?? 0) > 0).toBe(true)
+        expect(body?.message ?? '').toMatch(/queued|triggered/i)
+      } else {
+        expect(response.status()).toBe(400)
+        const body = await readJsonSafe<{ error?: string; message?: string }>(response)
+        expect(`${body?.error ?? ''} ${body?.message ?? ''}`).toMatch(/async/i)
+      }
+    } finally {
+      await deleteScheduleJob(request, token, scheduleId)
+    }
+  })
+})

--- a/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-006.spec.ts
+++ b/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-006.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { SCHEDULER_JOBS_PATH, createScheduleJob, deleteScheduleJob, getScheduleJobById } from './helpers/scheduler'
+
+type ForbiddenBody = { error?: string; requiredFeatures?: string[] }
+
+/**
+ * TC-SCHED-006: PUT and DELETE on /api/scheduler/jobs are gated by
+ * `scheduler.jobs.manage`. A user holding only `scheduler.jobs.view` can read
+ * schedules but is denied with 403 on both mutating verbs, and a failed attempt
+ * leaves the schedule untouched.
+ */
+test.describe('TC-SCHED-006: scheduler.jobs.manage gate on PUT/DELETE', () => {
+  test('view-only user gets 403 on PUT and DELETE; schedule stays intact', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { organizationId } = getTokenContext(adminToken)
+    expect(organizationId.length, 'admin token should carry an organization id').toBeGreaterThan(0)
+
+    const stamp = `${Date.now()}`
+    let roleId: string | null = null
+    let userId: string | null = null
+    let scheduleId: string | null = null
+
+    try {
+      // A role that can view schedules but not manage them.
+      roleId = await createRoleFixture(request, adminToken, { name: `sched-view-only-${stamp}` })
+      await setRoleAclFeatures(request, adminToken, { roleId, features: ['scheduler.jobs.view'] })
+
+      const email = `sched-view-only-${stamp}@example.com`
+      // Password must satisfy the default policy (min length + digit + uppercase + special).
+      const password = 'Sched-View-1!'
+      userId = await createUserFixture(request, adminToken, {
+        email,
+        password,
+        organizationId,
+        roles: [roleId],
+        name: 'Scheduler View Only',
+      })
+      const viewToken = await getAuthToken(request, email, password)
+
+      scheduleId = await createScheduleJob(request, adminToken)
+
+      // Sanity: the view-only user authenticates and CAN list (has the view feature),
+      // so the 403s below are specifically about the missing manage feature.
+      const listResponse = await apiRequest(request, 'GET', SCHEDULER_JOBS_PATH, { token: viewToken })
+      expect(listResponse.status()).toBe(200)
+
+      // PUT denied
+      const putResponse = await apiRequest(request, 'PUT', SCHEDULER_JOBS_PATH, {
+        token: viewToken,
+        data: { id: scheduleId, name: 'Should-Not-Apply' },
+      })
+      expect(putResponse.status()).toBe(403)
+      const putBody = await readJsonSafe<ForbiddenBody>(putResponse)
+      expect(putBody?.requiredFeatures ?? []).toContain('scheduler.jobs.manage')
+
+      // DELETE denied
+      const deleteResponse = await apiRequest(request, 'DELETE', SCHEDULER_JOBS_PATH, {
+        token: viewToken,
+        data: { id: scheduleId },
+      })
+      expect(deleteResponse.status()).toBe(403)
+      const deleteBody = await readJsonSafe<ForbiddenBody>(deleteResponse)
+      expect(deleteBody?.requiredFeatures ?? []).toContain('scheduler.jobs.manage')
+
+      // The schedule is unchanged and still present (admin can read it).
+      const after = await getScheduleJobById(request, adminToken, scheduleId)
+      expect(after).not.toBeNull()
+      expect(after!.name).not.toBe('Should-Not-Apply')
+    } finally {
+      await deleteScheduleJob(request, adminToken, scheduleId)
+      await deleteUserIfExists(request, adminToken, userId)
+      await deleteRoleIfExists(request, adminToken, roleId)
+    }
+  })
+})

--- a/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-007.spec.ts
+++ b/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-007.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { SCHEDULER_EXECUTION_QUEUE, SCHEDULER_JOBS_PATH, uniqueScheduleName } from './helpers/scheduler'
+
+type ValidationError = { error?: string; details?: Array<{ path?: Array<string | number> }> }
+
+/**
+ * TC-SCHED-007: POST /api/scheduler/jobs rejects invalid cron and interval
+ * `scheduleValue`s with 400 and an error scoped to the `scheduleValue` path.
+ *
+ * Interval format is `<number><unit>` with unit in s|m|h|d, so the inputs below
+ * are genuinely malformed (the issue's "99h"/"0m" drafts are actually valid).
+ * All cases are rejected at validation, so no records are created and no
+ * teardown is required.
+ */
+const invalidCases = [
+  { label: 'cron: not a cron expression', scheduleType: 'cron' as const, scheduleValue: 'not-a-cron' },
+  { label: 'cron: too few fields', scheduleType: 'cron' as const, scheduleValue: '* * *' },
+  { label: 'interval: unsupported unit', scheduleType: 'interval' as const, scheduleValue: '15x' },
+  { label: 'interval: missing unit', scheduleType: 'interval' as const, scheduleValue: '99' },
+]
+
+test.describe('TC-SCHED-007: POST /api/scheduler/jobs validates schedule value format', () => {
+  for (const testCase of invalidCases) {
+    test(`rejects ${testCase.label} with 400 on scheduleValue`, async ({ request }) => {
+      const token = await getAuthToken(request, 'admin')
+
+      const response = await apiRequest(request, 'POST', SCHEDULER_JOBS_PATH, {
+        token,
+        data: {
+          name: uniqueScheduleName('Invalid Schedule Value'),
+          scopeType: 'organization',
+          scheduleType: testCase.scheduleType,
+          scheduleValue: testCase.scheduleValue,
+          timezone: 'UTC',
+          targetType: 'queue',
+          targetQueue: SCHEDULER_EXECUTION_QUEUE,
+          isEnabled: true,
+          sourceType: 'user',
+        },
+      })
+
+      expect(response.status(), `${testCase.label} should be rejected with 400`).toBe(400)
+      const body = await readJsonSafe<ValidationError>(response)
+      const issuePaths = (body?.details ?? []).map((issue) => (issue.path ?? []).join('.'))
+      expect(issuePaths, `${testCase.label} error should target scheduleValue`).toContain('scheduleValue')
+    })
+  }
+})

--- a/packages/scheduler/src/modules/scheduler/__integration__/helpers/scheduler.ts
+++ b/packages/scheduler/src/modules/scheduler/__integration__/helpers/scheduler.ts
@@ -1,0 +1,110 @@
+import { expect, type APIRequestContext } from '@playwright/test'
+import { apiRequest } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+export const SCHEDULER_JOBS_PATH = '/api/scheduler/jobs'
+export const SCHEDULER_TARGETS_PATH = '/api/scheduler/targets'
+export const SCHEDULER_TRIGGER_PATH = '/api/scheduler/trigger'
+
+/** Queue registered by the scheduler module's execute-schedule worker. */
+export const SCHEDULER_EXECUTION_QUEUE = 'scheduler-execution'
+
+export type SchedulerJob = {
+  id: string
+  name: string
+  description: string | null
+  scopeType: 'system' | 'organization' | 'tenant'
+  organizationId: string | null
+  tenantId: string | null
+  scheduleType: 'cron' | 'interval'
+  scheduleValue: string
+  timezone: string
+  targetType: 'queue' | 'command'
+  targetQueue: string | null
+  targetCommand: string | null
+  isEnabled: boolean
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+export type CreateScheduleOverrides = {
+  name?: string
+  description?: string | null
+  scopeType?: 'system' | 'organization' | 'tenant'
+  scheduleType?: 'cron' | 'interval'
+  scheduleValue?: string
+  timezone?: string
+  targetType?: 'queue' | 'command'
+  targetQueue?: string
+  targetCommand?: string
+  targetPayload?: Record<string, unknown>
+  isEnabled?: boolean
+  sourceType?: 'user' | 'module'
+}
+
+let sequence = 0
+
+/** Stable-ish unique label so concurrent fixtures never collide on name. */
+export function uniqueScheduleName(prefix: string): string {
+  sequence += 1
+  return `${prefix} ${Date.now()}-${sequence}`
+}
+
+/**
+ * Create an organization-scoped queue-target schedule via the API and return its id.
+ * Org/tenant are derived server-side from the caller's auth context, so the caller
+ * only needs an admin (or otherwise scheduler.jobs.manage) token.
+ */
+export async function createScheduleJob(
+  request: APIRequestContext,
+  token: string,
+  overrides: CreateScheduleOverrides = {},
+): Promise<string> {
+  const targetType = overrides.targetType ?? 'queue'
+  const data: Record<string, unknown> = {
+    name: overrides.name ?? uniqueScheduleName('Integration Scheduler'),
+    description: overrides.description ?? 'Created by scheduler integration tests',
+    scopeType: overrides.scopeType ?? 'organization',
+    scheduleType: overrides.scheduleType ?? 'interval',
+    scheduleValue: overrides.scheduleValue ?? '15m',
+    timezone: overrides.timezone ?? 'UTC',
+    targetType,
+    targetPayload: overrides.targetPayload ?? { source: 'integration-test' },
+    isEnabled: overrides.isEnabled ?? true,
+    sourceType: overrides.sourceType ?? 'user',
+  }
+  if (targetType === 'command') {
+    data.targetCommand = overrides.targetCommand
+  } else {
+    data.targetQueue = overrides.targetQueue ?? SCHEDULER_EXECUTION_QUEUE
+  }
+
+  const response = await apiRequest(request, 'POST', SCHEDULER_JOBS_PATH, { token, data })
+  const body = await readJsonSafe<{ id?: string }>(response)
+  expect(response.status(), 'POST /api/scheduler/jobs should return 201').toBe(201)
+  const id = body?.id
+  expect(typeof id === 'string' && /^[0-9a-f-]{36}$/i.test(id), 'create response should include a UUID id').toBe(true)
+  return String(id)
+}
+
+/** Fetch a single schedule by id from the list endpoint; null when absent (e.g. soft-deleted). */
+export async function getScheduleJobById(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<SchedulerJob | null> {
+  const response = await apiRequest(request, 'GET', `${SCHEDULER_JOBS_PATH}?id=${encodeURIComponent(id)}`, { token })
+  expect(response.status(), 'GET /api/scheduler/jobs?id should return 200').toBe(200)
+  const body = await readJsonSafe<{ items?: SchedulerJob[] }>(response)
+  return (body?.items ?? []).find((item) => item.id === id) ?? null
+}
+
+/** Best-effort cleanup; swallows errors so teardown never masks the real assertion. */
+export async function deleteScheduleJob(
+  request: APIRequestContext,
+  token: string,
+  id: string | null,
+): Promise<void> {
+  if (!id) return
+  await apiRequest(request, 'DELETE', SCHEDULER_JOBS_PATH, { token, data: { id } }).catch(() => null)
+}


### PR DESCRIPTION
## Summary

Expands integration-test coverage for the `scheduler` module per #2496, adding the high-value, low-effort API scenarios that were previously untested: PUT/DELETE CRUD, target discovery, manual trigger, RBAC gating, and schedule-value validation. **Test-only change — no product code is modified.**

While implementing, three of the issue's auto-generated draft assertions were corrected to match the real contract (verified against source): PUT must send `scheduleType` when `scheduleValue` changes; and the issue's "invalid" interval samples `99h` (99 hours) and `0m` are actually valid, so genuinely-malformed values are used instead.

## Changes

- `TC-SCHED-002` — PUT updates `name`/`scheduleValue`, preserves id/tenant/org/queue, advances `updatedAt`
- `TC-SCHED-003` — DELETE soft-deletes; a subsequent `?id=` GET returns `200` with empty `items` (not `404`)
- `TC-SCHED-004` — GET `/api/scheduler/targets` returns alphabetically-sorted queues (incl. `scheduler-execution`) and a non-empty command list
- `TC-SCHED-005` — POST `/api/scheduler/trigger` returns `200` + `jobId` (async strategy) or `400` "async required" (local strategy)
- `TC-SCHED-006` — a view-only user (`scheduler.jobs.view` only) gets `403` on PUT/DELETE with `requiredFeatures: ['scheduler.jobs.manage']`, and the schedule is left untouched
- `TC-SCHED-007` — POST rejects invalid cron/interval values with `400` scoped to the `scheduleValue` path (4 cases)
- `__integration__/helpers/scheduler.ts` — shared create/get/delete fixture helpers for the specs above
- No product code changed.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test-coverage only, no behavior change. (The module's existing `.ai/specs/2026-05-13-lazy-auto-spawn-scheduler.md` is unaffected.)

## Testing

- `yarn test:integration:ephemeral --filter TC-SCHED` → **11 passed** (the 9 new test cases + the 2 pre-existing TC-SCHED-001, confirming no regression), run against a freshly seeded ephemeral app + DB.
- `npx tsc --noEmit -p packages/scheduler/tsconfig.json` → **clean** (the scheduler tsconfig includes `__integration__`, so the new specs are type-checked).
- Fresh-context adversarial review of the diff → **approved, 0 blockers**.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. _(N/A — test-only; no docs/locale/generator surface touched.)_
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). _(Added module-local specs under `packages/scheduler/src/modules/scheduler/__integration__/` — the current convention per `.ai/qa/AGENTS.md`; `.ai/qa/tests/` holds only the shared Playwright config.)_
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). _(N/A — no behavior change, no spec update required.)_

### Design System Compliance
_N/A — backend/API test-only change; no UI/frontend code touched._
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #2496