### PR TITLE
feat:2494 translations integration coverage

### DIFF
--- a/packages/core/src/modules/translations/__integration__/TC-TRANS-012.spec.ts
+++ b/packages/core/src/modules/translations/__integration__/TC-TRANS-012.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { createProductFixture, deleteCatalogProductIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/catalogFixtures'
+import { deleteTranslationIfExists } from './helpers/translationFixtures'
+
+const ENTITY_TYPE = 'catalog:catalog_product'
+
+/**
+ * TC-TRANS-012: GET returns 404 for translations without previous save
+ * Surfaces: GET /api/translations/:entityType/:entityId
+ *
+ * Probes the not-found path for a valid entity that never had translations
+ * saved. Complements TC-TRANS-002 (which asserts only the 404 status) by also
+ * asserting the error-body contract is { error: 'Not found' }.
+ */
+test.describe('TC-TRANS-012: GET 404 for entity without translations', () => {
+  test('returns 404 with a "Not found" error body when no translation exists', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const saToken = await getAuthToken(request, 'superadmin')
+    const productTitle = `QA TC-TRANS-012 ${Date.now()}`
+    const sku = `QA-TRANS-012-${Date.now()}`
+    let productId: string | null = null
+
+    try {
+      productId = await createProductFixture(request, adminToken, { title: productTitle, sku })
+
+      const response = await apiRequest(request, 'GET', `/api/translations/${ENTITY_TYPE}/${productId}`, { token: saToken })
+      expect(response.status()).toBe(404)
+      const body = (await response.json()) as { error?: string }
+      expect(body.error).toBe('Not found')
+    } finally {
+      await deleteTranslationIfExists(request, saToken, ENTITY_TYPE, productId)
+      await deleteCatalogProductIfExists(request, adminToken, productId)
+    }
+  })
+})

--- a/packages/core/src/modules/translations/__integration__/TC-TRANS-013.spec.ts
+++ b/packages/core/src/modules/translations/__integration__/TC-TRANS-013.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { ISO_639_1 } from '@open-mercato/shared/lib/i18n/iso639'
+import { getLocales, setLocales } from './helpers/translationFixtures'
+
+/**
+ * TC-TRANS-013: Locales max-50 boundary validation
+ * Surfaces: PUT /api/translations/locales
+ *
+ * The supported-locales body schema accepts at most 50 ISO 639-1 codes. Verify
+ * the boundary on both sides: 50 distinct valid codes succeed (200), 51 are
+ * rejected (400). Locale codes are drawn from the canonical ISO_639_1 table so
+ * they are guaranteed valid and distinct.
+ */
+const allCodes = ISO_639_1.map((entry) => entry.code)
+const fiftyValidLocales = allCodes.slice(0, 50)
+const fiftyOneValidLocales = allCodes.slice(0, 51)
+
+test.describe('TC-TRANS-013: locales max-50 boundary', () => {
+  test('accepts exactly 50 locales and rejects 51', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const originalLocales = await getLocales(request, adminToken)
+
+    try {
+      expect(fiftyValidLocales).toHaveLength(50)
+      expect(fiftyOneValidLocales).toHaveLength(51)
+
+      const okResponse = await apiRequest(request, 'PUT', '/api/translations/locales', {
+        token: adminToken,
+        data: { locales: fiftyValidLocales },
+      })
+      expect(okResponse.status()).toBe(200)
+      const okBody = (await okResponse.json()) as { locales: string[] }
+      expect(okBody.locales).toHaveLength(50)
+      expect([...okBody.locales].sort()).toEqual([...fiftyValidLocales].sort())
+
+      const tooManyResponse = await apiRequest(request, 'PUT', '/api/translations/locales', {
+        token: adminToken,
+        data: { locales: fiftyOneValidLocales },
+      })
+      expect(tooManyResponse.status()).toBe(400)
+    } finally {
+      await setLocales(request, adminToken, originalLocales).catch(() => {})
+    }
+  })
+})

--- a/packages/core/src/modules/translations/__integration__/TC-TRANS-014.spec.ts
+++ b/packages/core/src/modules/translations/__integration__/TC-TRANS-014.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { createProductFixture, deleteCatalogProductIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/catalogFixtures'
+import { deleteTranslationIfExists } from './helpers/translationFixtures'
+
+const ENTITY_TYPE = 'catalog:catalog_product'
+
+type TranslationsBody = { translations: Record<string, Record<string, string | null>> }
+
+/**
+ * TC-TRANS-014: Translation body with null field values
+ * Surfaces: PUT + GET /api/translations/:entityType/:entityId
+ *
+ * The validator allows null field values (z.union([z.string(), z.null()])).
+ * A saved null must round-trip: the key is present with a null value, not
+ * silently omitted, on both the PUT response and a fresh GET.
+ */
+test.describe('TC-TRANS-014: null field values persist', () => {
+  test('persists a null field value and returns it (not omitted)', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const saToken = await getAuthToken(request, 'superadmin')
+    const productTitle = `QA TC-TRANS-014 ${Date.now()}`
+    const sku = `QA-TRANS-014-${Date.now()}`
+    let productId: string | null = null
+
+    try {
+      productId = await createProductFixture(request, adminToken, { title: productTitle, sku })
+
+      const putResponse = await apiRequest(request, 'PUT', `/api/translations/${ENTITY_TYPE}/${productId}`, {
+        token: saToken,
+        data: { de: { title: null } },
+      })
+      expect(putResponse.status()).toBe(200)
+      const putBody = (await putResponse.json()) as TranslationsBody
+      expect(putBody.translations.de).toHaveProperty('title', null)
+
+      const getResponse = await apiRequest(request, 'GET', `/api/translations/${ENTITY_TYPE}/${productId}`, { token: saToken })
+      expect(getResponse.status()).toBe(200)
+      const getBody = (await getResponse.json()) as TranslationsBody
+      expect(getBody.translations.de).toHaveProperty('title')
+      expect(getBody.translations.de.title).toBeNull()
+    } finally {
+      await deleteTranslationIfExists(request, saToken, ENTITY_TYPE, productId)
+      await deleteCatalogProductIfExists(request, adminToken, productId)
+    }
+  })
+})

--- a/packages/core/src/modules/translations/__integration__/TC-TRANS-015.spec.ts
+++ b/packages/core/src/modules/translations/__integration__/TC-TRANS-015.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { createProductFixture, deleteCatalogProductIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/catalogFixtures'
+import { deleteTranslationIfExists } from './helpers/translationFixtures'
+
+const ENTITY_TYPE = 'catalog:catalog_product'
+
+/**
+ * TC-TRANS-015: Malformed JSON body returns 400
+ * Surfaces: PUT /api/translations/:entityType/:entityId
+ *
+ * A syntactically invalid JSON request body must be rejected with 400 and must
+ * not persist anything (a subsequent GET stays 404). The malformed bytes are
+ * sent as a Buffer so Playwright transmits them verbatim — passing a raw string
+ * with an application/json content type would be re-serialized into a valid JSON
+ * string literal, which never exercises the server's body-parse failure path.
+ */
+test.describe('TC-TRANS-015: malformed JSON body rejected with 400', () => {
+  test('rejects a malformed JSON body with 400 and persists nothing', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const saToken = await getAuthToken(request, 'superadmin')
+    const productTitle = `QA TC-TRANS-015 ${Date.now()}`
+    const sku = `QA-TRANS-015-${Date.now()}`
+    let productId: string | null = null
+
+    try {
+      productId = await createProductFixture(request, adminToken, { title: productTitle, sku })
+
+      const malformedBody = Buffer.from('{"de": {"title": "Broken",}}', 'utf-8')
+      const response = await apiRequest(request, 'PUT', `/api/translations/${ENTITY_TYPE}/${productId}`, {
+        token: saToken,
+        data: malformedBody,
+      })
+      expect(response.status()).toBe(400)
+      const body = (await response.json()) as { error?: string; details?: unknown }
+      expect(body.error || body.details).toBeTruthy()
+
+      // The rejected write must not have created a partial record.
+      const getResponse = await apiRequest(request, 'GET', `/api/translations/${ENTITY_TYPE}/${productId}`, { token: saToken })
+      expect(getResponse.status()).toBe(404)
+    } finally {
+      await deleteTranslationIfExists(request, saToken, ENTITY_TYPE, productId)
+      await deleteCatalogProductIfExists(request, adminToken, productId)
+    }
+  })
+})

--- a/packages/core/src/modules/translations/__integration__/TC-TRANS-016.spec.ts
+++ b/packages/core/src/modules/translations/__integration__/TC-TRANS-016.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { createProductFixture, deleteCatalogProductIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/catalogFixtures'
+import { deleteTranslationIfExists } from './helpers/translationFixtures'
+
+const ENTITY_TYPE = 'catalog:catalog_product'
+
+/**
+ * TC-TRANS-016: DELETE returns 204 for non-existent translation (idempotent)
+ * Surfaces: DELETE /api/translations/:entityType/:entityId
+ *
+ * DELETE is idempotent: it returns 204 even when no translation row ever
+ * existed, and a repeated DELETE also returns 204. The no-op delete must not
+ * create any side-effect row (a follow-up GET stays 404).
+ */
+test.describe('TC-TRANS-016: DELETE is idempotent (204)', () => {
+  test('returns 204 for a never-saved translation and on repeat, creating no row', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const saToken = await getAuthToken(request, 'superadmin')
+    const productTitle = `QA TC-TRANS-016 ${Date.now()}`
+    const sku = `QA-TRANS-016-${Date.now()}`
+    let productId: string | null = null
+
+    try {
+      productId = await createProductFixture(request, adminToken, { title: productTitle, sku })
+
+      const firstDelete = await apiRequest(request, 'DELETE', `/api/translations/${ENTITY_TYPE}/${productId}`, { token: saToken })
+      expect(firstDelete.status()).toBe(204)
+
+      const secondDelete = await apiRequest(request, 'DELETE', `/api/translations/${ENTITY_TYPE}/${productId}`, { token: saToken })
+      expect(secondDelete.status()).toBe(204)
+
+      const getResponse = await apiRequest(request, 'GET', `/api/translations/${ENTITY_TYPE}/${productId}`, { token: saToken })
+      expect(getResponse.status()).toBe(404)
+    } finally {
+      await deleteTranslationIfExists(request, saToken, ENTITY_TYPE, productId)
+      await deleteCatalogProductIfExists(request, adminToken, productId)
+    }
+  })
+})

--- a/packages/core/src/modules/translations/__integration__/TC-TRANS-017.spec.ts
+++ b/packages/core/src/modules/translations/__integration__/TC-TRANS-017.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { createProductFixture, deleteCatalogProductIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/catalogFixtures'
+import { deleteTranslationIfExists } from './helpers/translationFixtures'
+
+const ENTITY_TYPE = 'catalog:catalog_product'
+
+/**
+ * TC-TRANS-017: Field key with empty string is rejected (min length 1)
+ * Surfaces: PUT /api/translations/:entityType/:entityId
+ *
+ * Field keys must be 1..100 chars. An empty-string field key must be rejected
+ * with 400 and persist nothing (a follow-up GET stays 404).
+ */
+test.describe('TC-TRANS-017: empty field key rejected', () => {
+  test('rejects an empty field key with 400 and persists nothing', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const saToken = await getAuthToken(request, 'superadmin')
+    const productTitle = `QA TC-TRANS-017 ${Date.now()}`
+    const sku = `QA-TRANS-017-${Date.now()}`
+    let productId: string | null = null
+
+    try {
+      productId = await createProductFixture(request, adminToken, { title: productTitle, sku })
+
+      const response = await apiRequest(request, 'PUT', `/api/translations/${ENTITY_TYPE}/${productId}`, {
+        token: saToken,
+        data: { de: { '': 'value' } },
+      })
+      expect(response.status()).toBe(400)
+
+      const getResponse = await apiRequest(request, 'GET', `/api/translations/${ENTITY_TYPE}/${productId}`, { token: saToken })
+      expect(getResponse.status()).toBe(404)
+    } finally {
+      await deleteTranslationIfExists(request, saToken, ENTITY_TYPE, productId)
+      await deleteCatalogProductIfExists(request, adminToken, productId)
+    }
+  })
+})

--- a/packages/core/src/modules/translations/__integration__/TC-TRANS-018.spec.ts
+++ b/packages/core/src/modules/translations/__integration__/TC-TRANS-018.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { getTokenScope } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+
+/**
+ * TC-TRANS-018: 403 Forbidden when missing translations.view (GET locales)
+ * Surfaces: GET /api/translations/locales
+ *
+ * The locales read is guarded by translations.view. A principal that lacks the
+ * feature must receive 403. Uses a dedicated, freshly-created role (granted no
+ * features) and user so the test is fully isolated and safe under parallel
+ * workers — it never mutates the shared employee/admin roles other specs rely on.
+ */
+test.describe('TC-TRANS-018: GET locales denied without translations.view', () => {
+  test('returns 403 for a user whose role lacks translations.view', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const scope = getTokenScope(adminToken)
+    const stamp = Date.now()
+    const roleName = `qa_trans_018_noview_${stamp}`
+    const userEmail = `qa-trans-018-${stamp}@acme.com`
+    const userPassword = 'Valid1!Pass'
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      roleId = await createRoleFixture(request, adminToken, { name: roleName, tenantId: scope.tenantId })
+
+      // Grant no features at all, so translations.view is absent for this role.
+      const aclResponse = await apiRequest(request, 'PUT', '/api/auth/roles/acl', {
+        token: adminToken,
+        data: { roleId, features: [] },
+      })
+      expect(aclResponse.ok()).toBeTruthy()
+
+      userId = await createUserFixture(request, adminToken, {
+        email: userEmail,
+        password: userPassword,
+        organizationId: scope.organizationId,
+        roles: [roleName],
+        name: 'QA TC-TRANS-018 User',
+      })
+
+      const userToken = await getAuthToken(request, userEmail, userPassword)
+      const response = await apiRequest(request, 'GET', '/api/translations/locales', { token: userToken })
+      expect(response.status()).toBe(403)
+    } finally {
+      await deleteUserIfExists(request, adminToken, userId)
+      await deleteRoleIfExists(request, adminToken, roleId)
+    }
+  })
+})

--- a/packages/core/src/modules/translations/api/[entityType]/[entityId]/route.ts
+++ b/packages/core/src/modules/translations/api/[entityType]/[entityId]/route.ts
@@ -69,7 +69,15 @@ export async function PUT(req: Request, ctx: { params?: { entityType?: string; e
       entityId: ctx.params?.entityId,
     })
 
-    const rawBody = await req.json().catch(() => ({}))
+    const rawText = await req.text()
+    let rawBody: unknown = {}
+    if (rawText.trim().length > 0) {
+      try {
+        rawBody = JSON.parse(rawText)
+      } catch {
+        return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+      }
+    }
     const translations = translationBodySchema.parse(rawBody)
 
     const commandBus = context.container.resolve('commandBus') as CommandBus


### PR DESCRIPTION
## Summary

Fills the integration-test coverage gaps for the `translations` module requested in #2494 (TC-TRANS-012..018), and fixes a P0 defect that TC-TRANS-015 surfaced: `PUT /api/translations/:entityType/:entityId` silently swallowed a malformed JSON body into `{}`, persisting an empty translations row and returning **200** instead of **400**. The handler now rejects a non-empty unparseable body with 400 while preserving the existing empty/absent-body behavior.

## Changes

- fix(translations): `PUT /api/translations/:entityType/:entityId` reads the raw body, returns `400 { error: 'Invalid JSON body' }` for a non-empty unparseable payload, and keeps the prior empty-body → `{}` → 200 path (backward-compatible).
- test(translations): add 7 self-contained integration specs in `__integration__/`:
  - TC-TRANS-012 `[P0]` — GET returns 404 with `{ error: 'Not found' }` for an entity that never had translations.
  - TC-TRANS-013 `[P1]` — `PUT /locales` accepts exactly 50 ISO-639-1 codes (200), rejects 51 (400).
  - TC-TRANS-014 `[P1]` — a `null` field value round-trips (key present, value null, not omitted).
  - TC-TRANS-015 `[P0]` — malformed JSON body → 400, nothing persisted (GET stays 404).
  - TC-TRANS-016 `[P1]` — DELETE is idempotent (204 for never-saved, 204 on repeat, no side-effect row).
  - TC-TRANS-017 `[P1]` — empty-string field key → 400, nothing persisted.
  - TC-TRANS-018 `[P1]` — GET `/locales` → 403 for a principal lacking `translations.view` (isolated dedicated role+user).

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — additive integration coverage plus a minimal error-contract bugfix. The translations module's behavior spec (system-wide entity translations) exists and needs no update for this change; the coverage-gap analysis in #2494 is the source of record.

## Testing

- `npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/translations/__integration__/ --retries=1` → **43 passed** (existing 11 specs incl. UI flows + the 7 new ones), against an ephemeral env (`yarn test:integration:ephemeral:start`).
- Red→green proof: TC-TRANS-015 fails (`Received 200, Expected 400`) on the unfixed handler, passes after the fix.
- `turbo run typecheck --filter=@open-mercato/core --force` → PASS.
- `turbo run test --filter=@open-mercato/core --force` → 634 suites / 5279 tests passed.
- `yarn i18n:check-sync` → all locales in sync.
- `build:packages` + `next build` (app) → green via the ephemeral rebuild.
- `curl` ground-truth: malformed body → `400 {"error":"Invalid JSON body"}`; `{}` → `200`.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — no new i18n keys, docs, or generated registries affected; `i18n:check-sync` passes.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Placed module-local in `packages/core/src/modules/translations/__integration__/` per the current QA convention in `.ai/qa/AGENTS.md`.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec change.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, backend API + tests, no UI.
- [x] No arbitrary text sizes — N/A, no UI.
- [x] Empty state handled for list/data pages — N/A, no UI.
- [x] Loading state handled for async pages — N/A, no UI.
- [x] `aria-label` on all icon-only buttons — N/A, no UI.
- [x] Uses existing DS components — N/A, no UI.

## Linked issues

Fixes #2494