### PR TITLE
fix: 2495 ai assistant integration tests

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-ACTIONS-PENDING-004-confirm-cancel-mutations.spec.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-ACTIONS-PENDING-004-confirm-cancel-mutations.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect, request as playwrightRequest } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+import { deleteUserAclInDb } from '@open-mercato/core/helpers/integration/dbFixtures';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  seedPendingActionInDb,
+  deletePendingActionInDb,
+  type SeedPendingActionInput,
+} from './helpers/aiAssistantFixtures';
+
+/**
+ * TC-AI-ACTIONS-PENDING-004 — Pending action confirm/cancel (mutation-approval gate).
+ * Source: GitHub issue #2495.
+ *
+ * Surfaces under test:
+ *   - /api/ai_assistant/ai/actions/{id}            (GET)
+ *   - /api/ai_assistant/ai/actions/{id}/confirm     (POST)
+ *   - /api/ai_assistant/ai/actions/{id}/cancel       (POST)
+ *
+ * Contract notes verified against the route handlers:
+ *   - there is NO public route to CREATE a pending action (it is born only from
+ *     the internal `prepareMutation` path), so rows are seeded directly via SQL.
+ *   - GET strips `normalizedInput`, `createdByUserId`, `idempotencyKey`,
+ *     `tenantId`, `organizationId` from the client serialization.
+ *   - confirm/cancel are idempotent at the route layer; an already-terminal row
+ *     short-circuits (200) rather than throwing.
+ *   - cancelling an expired row -> 409 `expired`; confirming a cancelled row ->
+ *     409 `invalid_status`; unknown id -> 404 `pending_action_not_found`.
+ *   - all three require `ai_assistant.view`.
+ *
+ * The confirm HAPPY path is exercised via the terminal short-circuit (a seeded
+ * `confirmed` row) so the test stays deterministic and provider-free — driving a
+ * real `pending -> confirmed` transition would execute a live tool mutation that
+ * depends on the agent/tool registry and an LLM-proposed payload.
+ */
+
+const ACTIONS = '/api/ai_assistant/ai/actions';
+
+interface SerializedPendingAction {
+  id: string;
+  agentId: string;
+  toolName: string;
+  status: string;
+  createdAt: string;
+  expiresAt: string;
+  executionResult: unknown;
+  normalizedInput?: unknown;
+  createdByUserId?: unknown;
+  idempotencyKey?: unknown;
+  tenantId?: unknown;
+  organizationId?: unknown;
+}
+
+test.describe('TC-AI-ACTIONS-PENDING-004: Pending action confirm/cancel', () => {
+  test('GET serialization, cancel + confirm idempotency, and state-machine guards', async ({ request }) => {
+    test.slow();
+    const adminToken = await getAuthToken(request, 'admin');
+    const { tenantId, organizationId, userId: adminId } = getTokenScope(adminToken);
+    const seededIds: string[] = [];
+    const seed = async (overrides: Partial<SeedPendingActionInput>) => {
+      const row = await seedPendingActionInDb({
+        tenantId,
+        organizationId: organizationId || null,
+        createdByUserId: adminId,
+        ...overrides,
+      });
+      seededIds.push(row.id);
+      return row;
+    };
+
+    try {
+      // GET returns the client serialization with privileged fields stripped.
+      const pending = await seed({ status: 'pending' });
+      const getRes = await apiRequest(request, 'GET', `${ACTIONS}/${pending.id}`, { token: adminToken });
+      expect(getRes.status()).toBe(200);
+      const body = await readJsonSafe<SerializedPendingAction>(getRes);
+      expect(body?.id).toBe(pending.id);
+      expect(body?.status).toBe('pending');
+      expect(typeof body?.agentId).toBe('string');
+      expect(typeof body?.expiresAt).toBe('string');
+      expect(body?.normalizedInput, 'normalizedInput is stripped').toBeUndefined();
+      expect(body?.createdByUserId, 'createdByUserId is stripped').toBeUndefined();
+      expect(body?.idempotencyKey, 'idempotencyKey is stripped').toBeUndefined();
+      expect(body?.tenantId, 'tenantId is stripped').toBeUndefined();
+      expect(body?.organizationId, 'organizationId is stripped').toBeUndefined();
+
+      // Cancel happy path + idempotency.
+      const cancelable = await seed({ status: 'pending' });
+      const cancel = await apiRequest(request, 'POST', `${ACTIONS}/${cancelable.id}/cancel`, {
+        token: adminToken,
+        data: { reason: 'user_rejected' },
+      });
+      expect(cancel.status()).toBe(200);
+      const cancelBody = await readJsonSafe<{ ok: boolean; pendingAction: SerializedPendingAction }>(cancel);
+      expect(cancelBody?.ok).toBe(true);
+      expect(cancelBody?.pendingAction.status).toBe('cancelled');
+
+      const cancelAgain = await apiRequest(request, 'POST', `${ACTIONS}/${cancelable.id}/cancel`, {
+        token: adminToken,
+        data: {},
+      });
+      expect(cancelAgain.status(), 'cancel is idempotent').toBe(200);
+      expect((await readJsonSafe<{ pendingAction: SerializedPendingAction }>(cancelAgain))?.pendingAction.status).toBe(
+        'cancelled',
+      );
+
+      // Confirm happy path via the terminal short-circuit (seeded confirmed row).
+      const confirmed = await seed({ status: 'confirmed', executionResult: { recordId: 'seeded-record' } });
+      const confirm = await apiRequest(request, 'POST', `${ACTIONS}/${confirmed.id}/confirm`, {
+        token: adminToken,
+        data: {},
+      });
+      expect(confirm.status()).toBe(200);
+      const confirmBody = await readJsonSafe<{ ok: boolean; pendingAction: SerializedPendingAction; mutationResult: unknown }>(
+        confirm,
+      );
+      expect(confirmBody?.ok).toBe(true);
+      expect(confirmBody?.pendingAction.status).toBe('confirmed');
+      expect(confirmBody?.mutationResult).toEqual({ recordId: 'seeded-record' });
+
+      // Confirming a cancelled row -> 409 invalid_status.
+      const cancelledRow = await seed({ status: 'cancelled' });
+      const confirmCancelled = await apiRequest(request, 'POST', `${ACTIONS}/${cancelledRow.id}/confirm`, {
+        token: adminToken,
+        data: {},
+      });
+      expect(confirmCancelled.status()).toBe(409);
+      expect((await readJsonSafe<{ code?: string }>(confirmCancelled))?.code).toBe('invalid_status');
+
+      // Cancelling an expired row -> 409 expired.
+      const expiredRow = await seed({ status: 'pending', expiresInMinutes: -10 });
+      const cancelExpired = await apiRequest(request, 'POST', `${ACTIONS}/${expiredRow.id}/cancel`, {
+        token: adminToken,
+        data: {},
+      });
+      expect(cancelExpired.status()).toBe(409);
+      expect((await readJsonSafe<{ code?: string }>(cancelExpired))?.code).toBe('expired');
+
+      // Unknown id -> 404; over-long id -> 400 validation_error.
+      const notFound = await apiRequest(request, 'GET', `${ACTIONS}/${randomUUID()}`, { token: adminToken });
+      expect(notFound.status()).toBe(404);
+      expect((await readJsonSafe<{ code?: string }>(notFound))?.code).toBe('pending_action_not_found');
+
+      const tooLong = await apiRequest(request, 'GET', `${ACTIONS}/${'a'.repeat(200)}`, { token: adminToken });
+      expect(tooLong.status()).toBe(400);
+      expect((await readJsonSafe<{ code?: string }>(tooLong))?.code).toBe('validation_error');
+    } finally {
+      for (const id of seededIds) {
+        await deletePendingActionInDb(id).catch(() => undefined);
+      }
+    }
+  });
+
+  test('auth gates: unauthenticated 401 and missing ai_assistant.view 403', async ({ request, baseURL }) => {
+    test.slow();
+    const adminToken = await getAuthToken(request, 'admin');
+    const { tenantId, organizationId, userId: adminId } = getTokenScope(adminToken);
+    const stamp = randomUUID().slice(0, 8);
+    const password = 'Secret123!';
+
+    let seededId: string | null = null;
+    let roleId: string | null = null;
+    let userId: string | null = null;
+    try {
+      const row = await seedPendingActionInDb({
+        tenantId,
+        organizationId: organizationId || null,
+        createdByUserId: adminId,
+        status: 'pending',
+      });
+      seededId = row.id;
+
+      // Unauthenticated GET -> 401 (fresh context, no session cookie).
+      const anon = await playwrightRequest.newContext({ baseURL });
+      try {
+        const res = await anon.fetch(`${ACTIONS}/${seededId}`, { method: 'GET' });
+        expect(res.status()).toBe(401);
+      } finally {
+        await anon.dispose();
+      }
+
+      // Authenticated user lacking ai_assistant.view -> 403.
+      roleId = await createRoleFixture(request, adminToken, { name: `IT Pending Role ${stamp}` });
+      userId = await createUserFixture(request, adminToken, {
+        email: `it-pending-${stamp}@example.com`,
+        password,
+        organizationId,
+        roles: [roleId],
+      });
+      await setUserAclVisibility(request, adminToken, { userId, features: [], organizations: null });
+      const viewlessToken = await getAuthToken(request, `it-pending-${stamp}@example.com`, password);
+      const denied = await apiRequest(request, 'GET', `${ACTIONS}/${seededId}`, { token: viewlessToken });
+      expect(denied.status(), 'caller without ai_assistant.view is 403').toBe(403);
+    } finally {
+      await deletePendingActionInDb(seededId).catch(() => undefined);
+      await deleteUserAclInDb(userId ?? '').catch(() => undefined);
+      await deleteUserIfExists(request, adminToken, userId);
+      await deleteRoleIfExists(request, adminToken, roleId);
+    }
+  });
+});

--- a/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-AGENT-OVERRIDES-005-prompt-mutation-loop.spec.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-AGENT-OVERRIDES-005-prompt-mutation-loop.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect, request as playwrightRequest } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { deleteAgentOverridesInDb } from './helpers/aiAssistantFixtures';
+
+/**
+ * TC-AI-AGENT-OVERRIDES-005 — Per-agent runtime overrides (prompt / mutation-policy / loop).
+ * Source: GitHub issue #2495.
+ *
+ * Surfaces under test:
+ *   - /api/ai_assistant/ai/agents/{agentId}/prompt-override     (GET, POST)
+ *   - /api/ai_assistant/ai/agents/{agentId}/mutation-policy      (GET, POST, DELETE)
+ *   - /api/ai_assistant/ai/agents/{agentId}/loop-override         (GET, PUT, DELETE)
+ *
+ * Contract notes verified against the route handlers (the issue's guesses were wrong):
+ *   - prompt-override + mutation-policy use POST (NOT PUT); loop-override uses PUT.
+ *   - prompt-override has no DELETE route (versioned) -> swept via SQL in teardown.
+ *   - mutation-policy escalation beyond the agent's declared ceiling -> 400
+ *     `escalation_not_allowed` (NOT `policy_escalation_not_allowed`); an invalid
+ *     policy value -> 400 `validation_error` (NOT `invalid_mutation_policy`).
+ *   - a malformed agentId -> 400 `validation_error`; an unknown one -> 404 `agent_unknown`.
+ *   - writes require `ai_assistant.settings.manage`.
+ *
+ * The agent id is discovered dynamically from GET /ai/agents — never hard-coded.
+ */
+
+const AGENTS = '/api/ai_assistant/ai/agents';
+
+interface AgentSummary {
+  id: string;
+  mutationPolicy: string;
+}
+
+const POLICY_RANK: Record<string, number> = {
+  'read-only': 0,
+  'destructive-confirm-required': 1,
+  'confirm-required': 2,
+};
+
+test.describe('TC-AI-AGENT-OVERRIDES-005: Per-agent runtime overrides', () => {
+  test('prompt + mutation-policy + loop override CRUD, validation, escalation, RBAC', async ({
+    request,
+    baseURL,
+  }) => {
+    test.slow();
+    const adminToken = await getAuthToken(request, 'admin');
+    const { tenantId } = getTokenScope(adminToken);
+
+    const agentsRes = await apiRequest(request, 'GET', AGENTS, { token: adminToken });
+    expect(agentsRes.status()).toBe(200);
+    const agentsBody = await readJsonSafe<{ agents: AgentSummary[] }>(agentsRes);
+    expect(Array.isArray(agentsBody?.agents) && (agentsBody?.agents.length ?? 0) > 0, 'at least one agent is registered').toBe(
+      true,
+    );
+    // Intentionally targets the first registered agent (whichever modules are
+    // enabled). Policy assertions are computed relative to that agent's declared
+    // ceiling (`codeDeclared`) so the test is correct for any agent.
+    const agentId = agentsBody!.agents[0].id;
+
+    const promptOverride = `${AGENTS}/${encodeURIComponent(agentId)}/prompt-override`;
+    const mutationPolicy = `${AGENTS}/${encodeURIComponent(agentId)}/mutation-policy`;
+    const loopOverride = `${AGENTS}/${encodeURIComponent(agentId)}/loop-override`;
+
+    try {
+      // --- prompt-override (GET + POST; reserved-key validation) ---
+      const savePrompt = await apiRequest(request, 'POST', promptOverride, {
+        token: adminToken,
+        data: { sections: { tone: 'Be concise and helpful.' } },
+      });
+      expect(savePrompt.status(), 'POST prompt-override returns 200').toBe(200);
+      const savedPrompt = await readJsonSafe<{ ok: boolean; version: number }>(savePrompt);
+      expect(savedPrompt?.ok).toBe(true);
+      expect(typeof savedPrompt?.version).toBe('number');
+
+      const getPrompt = await apiRequest(request, 'GET', promptOverride, { token: adminToken });
+      expect(getPrompt.status()).toBe(200);
+      const promptBody = await readJsonSafe<{ override: { sections: Record<string, string> } | null }>(getPrompt);
+      expect(promptBody?.override?.sections?.tone).toBe('Be concise and helpful.');
+
+      const reserved = await apiRequest(request, 'POST', promptOverride, {
+        token: adminToken,
+        data: { sections: { mutationPolicy: 'confirm-required' } },
+      });
+      expect(reserved.status()).toBe(400);
+      expect((await readJsonSafe<{ code?: string }>(reserved))?.code).toBe('reserved_key');
+
+      // --- mutation-policy (GET + POST + DELETE; escalation + invalid value) ---
+      const getPolicy = await apiRequest(request, 'GET', mutationPolicy, { token: adminToken });
+      expect(getPolicy.status()).toBe(200);
+      const policyBody = await readJsonSafe<{ codeDeclared: string }>(getPolicy);
+      const codeDeclared = policyBody?.codeDeclared ?? 'read-only';
+
+      // 'read-only' is the most restrictive policy, so saving it is never an escalation.
+      const savePolicy = await apiRequest(request, 'POST', mutationPolicy, {
+        token: adminToken,
+        data: { mutationPolicy: 'read-only' },
+      });
+      expect(savePolicy.status(), 'saving a non-escalating policy returns 200').toBe(200);
+
+      const getPolicyAfter = await apiRequest(request, 'GET', mutationPolicy, { token: adminToken });
+      expect((await readJsonSafe<{ override: { mutationPolicy: string } | null }>(getPolicyAfter))?.override?.mutationPolicy).toBe(
+        'read-only',
+      );
+
+      const invalidPolicy = await apiRequest(request, 'POST', mutationPolicy, {
+        token: adminToken,
+        data: { mutationPolicy: 'not-a-valid-policy' },
+      });
+      expect(invalidPolicy.status()).toBe(400);
+      expect((await readJsonSafe<{ code?: string }>(invalidPolicy))?.code).toBe('validation_error');
+
+      // Escalation (widening the agent's declared ceiling) is rejected. Only
+      // assert when 'confirm-required' is strictly less restrictive than declared.
+      if ((POLICY_RANK[codeDeclared] ?? 0) < POLICY_RANK['confirm-required']) {
+        const escalation = await apiRequest(request, 'POST', mutationPolicy, {
+          token: adminToken,
+          data: { mutationPolicy: 'confirm-required' },
+        });
+        expect(escalation.status()).toBe(400);
+        expect((await readJsonSafe<{ code?: string }>(escalation))?.code).toBe('escalation_not_allowed');
+      }
+
+      const deletePolicy = await apiRequest(request, 'DELETE', mutationPolicy, { token: adminToken });
+      expect(deletePolicy.status()).toBe(200);
+      const getPolicyCleared = await apiRequest(request, 'GET', mutationPolicy, { token: adminToken });
+      expect((await readJsonSafe<{ override: unknown }>(getPolicyCleared))?.override, 'override cleared (null, not 404)').toBeNull();
+
+      // --- loop-override (GET + PUT + DELETE) ---
+      const putLoop = await apiRequest(request, 'PUT', loopOverride, {
+        token: adminToken,
+        data: { loopMaxSteps: 5 },
+      });
+      expect(putLoop.status(), 'PUT loop-override returns 200').toBe(200);
+
+      const getLoop = await apiRequest(request, 'GET', loopOverride, { token: adminToken });
+      expect(getLoop.status()).toBe(200);
+      expect((await readJsonSafe<{ override: { loopMaxSteps: number } | null }>(getLoop))?.override?.loopMaxSteps).toBe(5);
+
+      const deleteLoop = await apiRequest(request, 'DELETE', loopOverride, { token: adminToken });
+      expect(deleteLoop.status()).toBe(200);
+      const getLoopCleared = await apiRequest(request, 'GET', loopOverride, { token: adminToken });
+      expect((await readJsonSafe<{ override: unknown }>(getLoopCleared))?.override).toBeNull();
+
+      // --- agent-id validation ---
+      const malformed = await apiRequest(request, 'GET', `${AGENTS}/BadAgentId/prompt-override`, { token: adminToken });
+      expect(malformed.status()).toBe(400);
+      expect((await readJsonSafe<{ code?: string }>(malformed))?.code).toBe('validation_error');
+
+      const unknown = await apiRequest(request, 'GET', `${AGENTS}/does.not_exist/prompt-override`, { token: adminToken });
+      expect(unknown.status()).toBe(404);
+      expect((await readJsonSafe<{ code?: string }>(unknown))?.code).toBe('agent_unknown');
+
+      // --- RBAC: employee lacks settings.manage; unauthenticated is rejected ---
+      const employeeToken = await getAuthToken(request, 'employee');
+      const denied = await apiRequest(request, 'POST', promptOverride, {
+        token: employeeToken,
+        data: { sections: { tone: 'nope' } },
+      });
+      expect(denied.status(), 'employee lacks settings.manage -> 403').toBe(403);
+
+      const anon = await playwrightRequest.newContext({ baseURL });
+      try {
+        const res = await anon.fetch(promptOverride, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          data: JSON.stringify({ sections: { tone: 'nope' } }),
+        });
+        expect(res.status(), 'unauthenticated POST is 401').toBe(401);
+      } finally {
+        await anon.dispose();
+      }
+    } finally {
+      await deleteAgentOverridesInDb({ tenantId, agentId }).catch(() => undefined);
+    }
+  });
+});

--- a/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-CONVERSATIONS-001-create-list-delete.spec.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-CONVERSATIONS-001-create-list-delete.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect, request as playwrightRequest } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+import {
+  createOrganizationInDb,
+  deleteOrganizationInDb,
+  deleteUserAclInDb,
+} from '@open-mercato/core/helpers/integration/dbFixtures';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { deleteConversationCascadeInDb } from './helpers/aiAssistantFixtures';
+
+/**
+ * TC-AI-CONVERSATIONS-001 — Conversation CRUD lifecycle (create, list, patch, delete).
+ * Source: GitHub issue #2495.
+ *
+ * Surfaces under test:
+ *   - /api/ai_assistant/ai/conversations            (POST, GET)
+ *   - /api/ai_assistant/ai/conversations/{id}        (PATCH, DELETE)
+ *
+ * Contract notes verified against the route handlers (not the issue's guesses):
+ *   - create body field is `agentId` (required); response is a single serialized
+ *     conversation with `conversationId/agentId/title/status/visibility/isOwner`.
+ *   - re-creating the same `conversationId` is idempotent -> 200 (vs 201 first time).
+ *   - DELETE is a SOFT delete returning 200 `{ ok: true }` (NOT 204).
+ *   - item routes are scoped by tenant+organization+ownership; a caller in a
+ *     different organization sees the row as absent -> 404 `conversation_not_found`
+ *     (NOT 403).
+ */
+
+const CONVERSATIONS = '/api/ai_assistant/ai/conversations';
+
+interface SerializedConversation {
+  conversationId: string;
+  agentId: string;
+  title: string | null;
+  status: string;
+  visibility: string;
+  isOwner: boolean | null;
+  participantCount: number;
+}
+
+test.describe('TC-AI-CONVERSATIONS-001: Conversation CRUD lifecycle + org scoping', () => {
+  test('create (idempotent) -> list -> patch -> soft-delete hides from list', async ({ request }) => {
+    test.slow();
+    const adminToken = await getAuthToken(request, 'admin');
+    const { tenantId } = getTokenScope(adminToken);
+    const agentId = `it_conv.agent_${randomUUID().slice(0, 8)}`;
+    const conversationId = `it-conv-${randomUUID()}`;
+
+    try {
+      const createRes = await apiRequest(request, 'POST', CONVERSATIONS, {
+        token: adminToken,
+        data: { agentId, conversationId, title: 'Original title' },
+      });
+      expect(createRes.status(), 'create returns 201').toBe(201);
+      const created = await readJsonSafe<SerializedConversation>(createRes);
+      expect(created?.conversationId).toBe(conversationId);
+      expect(created?.agentId).toBe(agentId);
+      expect(created?.title).toBe('Original title');
+      expect(created?.status).toBe('open');
+      expect(created?.visibility).toBe('private');
+      // `isOwner` is only enriched on the item GET (which passes callerUserId);
+      // on the create/list responses it is intentionally null.
+      expect(created?.isOwner).toBeNull();
+
+      const recreate = await apiRequest(request, 'POST', CONVERSATIONS, {
+        token: adminToken,
+        data: { agentId, conversationId, title: 'Original title' },
+      });
+      expect(recreate.status(), 're-create with same id is idempotent (200)').toBe(200);
+
+      // Item GET enriches ownership: the creator is the owner.
+      const getItem = await apiRequest(
+        request,
+        'GET',
+        `${CONVERSATIONS}/${encodeURIComponent(conversationId)}`,
+        { token: adminToken },
+      );
+      expect(getItem.status()).toBe(200);
+      const item = await readJsonSafe<{ conversation: SerializedConversation }>(getItem);
+      expect(item?.conversation.conversationId).toBe(conversationId);
+      expect(item?.conversation.isOwner).toBe(true);
+
+      const listRes = await apiRequest(
+        request,
+        'GET',
+        `${CONVERSATIONS}?agent=${encodeURIComponent(agentId)}`,
+        { token: adminToken },
+      );
+      expect(listRes.status()).toBe(200);
+      const list = await readJsonSafe<{ items: SerializedConversation[]; nextCursor: string | null }>(listRes);
+      expect(Array.isArray(list?.items)).toBe(true);
+      expect(list?.items.some((c) => c.conversationId === conversationId)).toBe(true);
+
+      const patchRes = await apiRequest(
+        request,
+        'PATCH',
+        `${CONVERSATIONS}/${encodeURIComponent(conversationId)}`,
+        { token: adminToken, data: { title: 'Renamed title', status: 'closed' } },
+      );
+      expect(patchRes.status()).toBe(200);
+      const patched = await readJsonSafe<SerializedConversation>(patchRes);
+      expect(patched?.title).toBe('Renamed title');
+      expect(patched?.status).toBe('closed');
+
+      const delRes = await apiRequest(
+        request,
+        'DELETE',
+        `${CONVERSATIONS}/${encodeURIComponent(conversationId)}`,
+        { token: adminToken },
+      );
+      expect(delRes.status(), 'delete returns 200 (soft delete)').toBe(200);
+      expect((await readJsonSafe<{ ok: boolean }>(delRes))?.ok).toBe(true);
+
+      const listAfter = await apiRequest(
+        request,
+        'GET',
+        `${CONVERSATIONS}?agent=${encodeURIComponent(agentId)}`,
+        { token: adminToken },
+      );
+      expect(listAfter.status()).toBe(200);
+      const listAfterBody = await readJsonSafe<{ items: SerializedConversation[] }>(listAfter);
+      expect(listAfterBody?.items.some((c) => c.conversationId === conversationId)).toBe(false);
+    } finally {
+      await deleteConversationCascadeInDb({ tenantId, conversationId }).catch(() => undefined);
+    }
+  });
+
+  test('validation + auth gates: missing agentId -> 400, unauthenticated -> 401', async ({ request, baseURL }) => {
+    const adminToken = await getAuthToken(request, 'admin');
+
+    const badCreate = await apiRequest(request, 'POST', CONVERSATIONS, {
+      token: adminToken,
+      data: { title: 'no agent id' },
+    });
+    expect(badCreate.status()).toBe(400);
+    expect((await readJsonSafe<{ code?: string }>(badCreate))?.code).toBe('validation_error');
+
+    const anon = await playwrightRequest.newContext({ baseURL });
+    try {
+      const res = await anon.fetch(CONVERSATIONS, { method: 'GET' });
+      expect(res.status(), 'unauthenticated list is 401').toBe(401);
+    } finally {
+      await anon.dispose();
+    }
+  });
+
+  test('cross-org caller cannot GET/PATCH/DELETE another org conversation (404)', async ({ request }) => {
+    test.slow();
+    const adminToken = await getAuthToken(request, 'admin');
+    const { tenantId } = getTokenScope(adminToken);
+    const stamp = randomUUID().slice(0, 8);
+    const password = 'Secret123!';
+    const agentId = `it_conv.xorg_${stamp}`;
+    const conversationId = `it-conv-xorg-${randomUUID()}`;
+
+    let orgBId: string | null = null;
+    let roleId: string | null = null;
+    let userId: string | null = null;
+    try {
+      orgBId = await createOrganizationInDb({ name: `IT Conv OrgB ${stamp}`, tenantId });
+      roleId = await createRoleFixture(request, adminToken, { name: `IT Conv Role ${stamp}` });
+      userId = await createUserFixture(request, adminToken, {
+        email: `it-conv-${stamp}@example.com`,
+        password,
+        organizationId: orgBId,
+        roles: [roleId],
+      });
+      await setUserAclVisibility(request, adminToken, {
+        userId,
+        features: ['ai_assistant.view', 'ai_assistant.conversations.share'],
+        organizations: [orgBId],
+      });
+      const otherToken = await getAuthToken(request, `it-conv-${stamp}@example.com`, password);
+      expect(getTokenScope(otherToken).organizationId, 'fixture user is homed in org B').toBe(orgBId);
+
+      const createRes = await apiRequest(request, 'POST', CONVERSATIONS, {
+        token: adminToken,
+        data: { agentId, conversationId, title: 'Org A private' },
+      });
+      expect(createRes.status()).toBe(201);
+
+      const getRes = await apiRequest(
+        request,
+        'GET',
+        `${CONVERSATIONS}/${encodeURIComponent(conversationId)}`,
+        { token: otherToken },
+      );
+      expect(getRes.status(), 'cross-org GET is 404 (not 403)').toBe(404);
+      expect((await readJsonSafe<{ code?: string }>(getRes))?.code).toBe('conversation_not_found');
+
+      const patchRes = await apiRequest(
+        request,
+        'PATCH',
+        `${CONVERSATIONS}/${encodeURIComponent(conversationId)}`,
+        { token: otherToken, data: { title: 'hijack' } },
+      );
+      expect(patchRes.status(), 'cross-org PATCH is 404').toBe(404);
+
+      const delRes = await apiRequest(
+        request,
+        'DELETE',
+        `${CONVERSATIONS}/${encodeURIComponent(conversationId)}`,
+        { token: otherToken },
+      );
+      expect(delRes.status(), 'cross-org DELETE is 404').toBe(404);
+    } finally {
+      await deleteConversationCascadeInDb({ tenantId, conversationId }).catch(() => undefined);
+      await deleteUserAclInDb(userId ?? '').catch(() => undefined);
+      await deleteUserIfExists(request, adminToken, userId);
+      await deleteRoleIfExists(request, adminToken, roleId);
+      await deleteOrganizationInDb(orgBId).catch(() => undefined);
+    }
+  });
+});

--- a/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-PARTICIPANTS-002-add-remove-participants.spec.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-PARTICIPANTS-002-add-remove-participants.spec.ts
@@ -1,0 +1,184 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+import {
+  createOrganizationInDb,
+  deleteOrganizationInDb,
+  deleteUserAclInDb,
+} from '@open-mercato/core/helpers/integration/dbFixtures';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { deleteConversationCascadeInDb } from './helpers/aiAssistantFixtures';
+
+/**
+ * TC-AI-PARTICIPANTS-002 — Conversation participants (add / list / remove).
+ * Source: GitHub issue #2495.
+ *
+ * Surfaces under test:
+ *   - /api/ai_assistant/ai/conversations/{id}/participants            (POST, GET)
+ *   - /api/ai_assistant/ai/conversations/{id}/participants/{userId}    (DELETE)
+ *
+ * Contract notes verified against the route handlers:
+ *   - add requires `ai_assistant.conversations.share`; only the owner may add.
+ *   - the only wire role is `viewer` (the owner row is implicit).
+ *   - add returns 201 `{ participant: { userId, role, lastReadAt, addedAt } }`.
+ *   - removing a participant returns 204; removing the OWNER is 403; a missing
+ *     participant is 404 `participant_not_found`.
+ *   - self-add is 400 `self_share_not_allowed`; a duplicate is 409
+ *     `duplicate_participant`; a target in another org is 400 `user_not_found`.
+ */
+
+const CONVERSATIONS = '/api/ai_assistant/ai/conversations';
+
+interface ParticipantRow {
+  userId: string;
+  role: string;
+  lastReadAt: string | null;
+  addedAt: string;
+}
+
+test.describe('TC-AI-PARTICIPANTS-002: Conversation participants', () => {
+  test('add -> list -> remove lifecycle plus owner/duplicate/self/cross-org/RBAC guards', async ({ request }) => {
+    test.slow();
+    const adminToken = await getAuthToken(request, 'admin');
+    const { tenantId, organizationId: orgAId, userId: ownerId } = getTokenScope(adminToken);
+    const stamp = randomUUID().slice(0, 8);
+    const password = 'Secret123!';
+    const agentId = `it_part.agent_${stamp}`;
+    const conversationId = `it-part-${randomUUID()}`;
+
+    let roleId: string | null = null;
+    let memberId: string | null = null;
+    let foreignOrgId: string | null = null;
+    let foreignUserId: string | null = null;
+    try {
+      roleId = await createRoleFixture(request, adminToken, { name: `IT Part Role ${stamp}` });
+      // Member lives in the SAME org as the owner and carries only view -> valid
+      // share target AND a deterministic "lacks conversations.share" caller.
+      memberId = await createUserFixture(request, adminToken, {
+        email: `it-part-member-${stamp}@example.com`,
+        password,
+        organizationId: orgAId,
+        roles: [roleId],
+      });
+      await setUserAclVisibility(request, adminToken, {
+        userId: memberId,
+        features: ['ai_assistant.view'],
+        organizations: [orgAId],
+      });
+      // Foreign user lives in another org -> cannot be shared into this conversation.
+      foreignOrgId = await createOrganizationInDb({ name: `IT Part OrgB ${stamp}`, tenantId });
+      foreignUserId = await createUserFixture(request, adminToken, {
+        email: `it-part-foreign-${stamp}@example.com`,
+        password,
+        organizationId: foreignOrgId,
+        roles: [roleId],
+      });
+
+      const createRes = await apiRequest(request, 'POST', CONVERSATIONS, {
+        token: adminToken,
+        data: { agentId, conversationId, title: 'Shareable conversation' },
+      });
+      expect(createRes.status()).toBe(201);
+
+      const participantsPath = `${CONVERSATIONS}/${encodeURIComponent(conversationId)}/participants`;
+
+      // Add member -> 201 viewer
+      const addRes = await apiRequest(request, 'POST', participantsPath, {
+        token: adminToken,
+        data: { userId: memberId },
+      });
+      expect(addRes.status(), 'add participant returns 201').toBe(201);
+      const added = await readJsonSafe<{ participant: ParticipantRow }>(addRes);
+      expect(added?.participant.userId).toBe(memberId);
+      expect(added?.participant.role).toBe('viewer');
+
+      // List -> owner + member
+      const listRes = await apiRequest(request, 'GET', participantsPath, { token: adminToken });
+      expect(listRes.status()).toBe(200);
+      const list = await readJsonSafe<{ ownerUserId: string; participants: ParticipantRow[] }>(listRes);
+      expect(list?.ownerUserId).toBe(ownerId);
+      expect(list?.participants.some((p) => p.userId === ownerId && p.role === 'owner')).toBe(true);
+      expect(list?.participants.some((p) => p.userId === memberId && p.role === 'viewer')).toBe(true);
+
+      // Self-add -> 400 self_share_not_allowed
+      const selfAdd = await apiRequest(request, 'POST', participantsPath, {
+        token: adminToken,
+        data: { userId: ownerId },
+      });
+      expect(selfAdd.status()).toBe(400);
+      expect((await readJsonSafe<{ code?: string }>(selfAdd))?.code).toBe('self_share_not_allowed');
+
+      // Duplicate -> 409 duplicate_participant
+      const dup = await apiRequest(request, 'POST', participantsPath, {
+        token: adminToken,
+        data: { userId: memberId },
+      });
+      expect(dup.status()).toBe(409);
+      expect((await readJsonSafe<{ code?: string }>(dup))?.code).toBe('duplicate_participant');
+
+      // Foreign-org target -> 400 user_not_found
+      const foreign = await apiRequest(request, 'POST', participantsPath, {
+        token: adminToken,
+        data: { userId: foreignUserId },
+      });
+      expect(foreign.status()).toBe(400);
+      expect((await readJsonSafe<{ code?: string }>(foreign))?.code).toBe('user_not_found');
+
+      // Caller lacking conversations.share -> 403 (feature gate fires first)
+      const memberToken = await getAuthToken(request, `it-part-member-${stamp}@example.com`, password);
+      const denied = await apiRequest(request, 'POST', participantsPath, {
+        token: memberToken,
+        data: { userId: randomUUID() },
+      });
+      expect(denied.status(), 'caller without conversations.share is 403').toBe(403);
+
+      // Remove the OWNER -> 403
+      const removeOwner = await apiRequest(
+        request,
+        'DELETE',
+        `${participantsPath}/${encodeURIComponent(ownerId)}`,
+        { token: adminToken },
+      );
+      expect(removeOwner.status(), 'cannot revoke the owner').toBe(403);
+
+      // Remove the member -> 204
+      const removeMember = await apiRequest(
+        request,
+        'DELETE',
+        `${participantsPath}/${encodeURIComponent(memberId)}`,
+        { token: adminToken },
+      );
+      expect(removeMember.status(), 'revoke participant returns 204').toBe(204);
+
+      // List -> member gone
+      const listAfter = await apiRequest(request, 'GET', participantsPath, { token: adminToken });
+      expect(listAfter.status()).toBe(200);
+      const after = await readJsonSafe<{ participants: ParticipantRow[] }>(listAfter);
+      expect(after?.participants.some((p) => p.userId === memberId)).toBe(false);
+
+      // Remove again -> 404 participant_not_found
+      const removeAgain = await apiRequest(
+        request,
+        'DELETE',
+        `${participantsPath}/${encodeURIComponent(memberId)}`,
+        { token: adminToken },
+      );
+      expect(removeAgain.status()).toBe(404);
+      expect((await readJsonSafe<{ code?: string }>(removeAgain))?.code).toBe('participant_not_found');
+    } finally {
+      await deleteConversationCascadeInDb({ tenantId, conversationId }).catch(() => undefined);
+      await deleteUserAclInDb(memberId ?? '').catch(() => undefined);
+      await deleteUserIfExists(request, adminToken, memberId);
+      await deleteUserIfExists(request, adminToken, foreignUserId);
+      await deleteRoleIfExists(request, adminToken, roleId);
+      await deleteOrganizationInDb(foreignOrgId).catch(() => undefined);
+    }
+  });
+});

--- a/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-SESSION-KEY-006-create-session-token.spec.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-SESSION-KEY-006-create-session-token.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, request as playwrightRequest } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+import { deleteUserAclInDb } from '@open-mercato/core/helpers/integration/dbFixtures';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+/**
+ * TC-AI-SESSION-KEY-006 — Session key generation.
+ * Source: GitHub issue #2495.
+ *
+ * Surface under test:
+ *   - /api/ai_assistant/session-key   (POST)
+ *
+ * Contract notes verified against the route handler (the issue's guesses were wrong):
+ *   - the response body is EXACTLY `{ sessionToken, expiresAt }` — it does NOT
+ *     include userId / tenantId / organizationId.
+ *   - token format is `sess_` + 32 lowercase hex chars; TTL is 120 minutes.
+ *   - requires `ai_assistant.view`; unauthenticated -> 401; missing feature -> 403.
+ *
+ * NOTE: the returned `sess_...` token is consumed only as the MCP `_sessionToken`
+ * tool-call argument — it is NOT accepted by the Next.js HTTP auth resolver as a
+ * Bearer/header, so the issue's "use the token to call /tools" step is invalid
+ * and intentionally omitted here.
+ */
+
+const SESSION_KEY = '/api/ai_assistant/session-key';
+const SESSION_TOKEN_RE = /^sess_[0-9a-f]{32}$/;
+const TTL_MINUTES = 120;
+
+test.describe('TC-AI-SESSION-KEY-006: Session key generation', () => {
+  test('POST mints a unique sess_ token with a ~120 minute TTL', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin');
+
+    const first = await apiRequest(request, 'POST', SESSION_KEY, { token: adminToken, data: {} });
+    expect(first.status(), 'session-key POST returns 200').toBe(200);
+    const body = await readJsonSafe<{ sessionToken: string; expiresAt: string }>(first);
+    expect(body?.sessionToken).toMatch(SESSION_TOKEN_RE);
+
+    const now = Date.now();
+    const expiresAt = Date.parse(body!.expiresAt);
+    expect(Number.isNaN(expiresAt)).toBe(false);
+    // Allow generous slop for clock + request latency around the 120-minute TTL.
+    expect(expiresAt).toBeGreaterThan(now + (TTL_MINUTES - 5) * 60 * 1000);
+    expect(expiresAt).toBeLessThan(now + (TTL_MINUTES + 5) * 60 * 1000);
+
+    const second = await apiRequest(request, 'POST', SESSION_KEY, { token: adminToken, data: {} });
+    expect(second.status()).toBe(200);
+    const secondBody = await readJsonSafe<{ sessionToken: string }>(second);
+    expect(secondBody?.sessionToken).toMatch(SESSION_TOKEN_RE);
+    expect(secondBody?.sessionToken, 'each call mints a distinct token').not.toBe(body?.sessionToken);
+  });
+
+  test('auth gates: unauthenticated 401 and missing ai_assistant.view 403', async ({ request, baseURL }) => {
+    test.slow();
+    const adminToken = await getAuthToken(request, 'admin');
+    const { organizationId } = getTokenScope(adminToken);
+    const stamp = randomUUID().slice(0, 8);
+    const password = 'Secret123!';
+
+    const anon = await playwrightRequest.newContext({ baseURL });
+    try {
+      const res = await anon.fetch(SESSION_KEY, { method: 'POST', data: '{}' });
+      expect(res.status(), 'unauthenticated POST is 401').toBe(401);
+    } finally {
+      await anon.dispose();
+    }
+
+    let roleId: string | null = null;
+    let userId: string | null = null;
+    try {
+      roleId = await createRoleFixture(request, adminToken, { name: `IT Session Role ${stamp}` });
+      userId = await createUserFixture(request, adminToken, {
+        email: `it-session-${stamp}@example.com`,
+        password,
+        organizationId,
+        roles: [roleId],
+      });
+      await setUserAclVisibility(request, adminToken, { userId, features: [], organizations: null });
+      const viewlessToken = await getAuthToken(request, `it-session-${stamp}@example.com`, password);
+      const denied = await apiRequest(request, 'POST', SESSION_KEY, { token: viewlessToken, data: {} });
+      expect(denied.status(), 'caller without ai_assistant.view is 403').toBe(403);
+    } finally {
+      await deleteUserAclInDb(userId ?? '').catch(() => undefined);
+      await deleteUserIfExists(request, adminToken, userId);
+      await deleteRoleIfExists(request, adminToken, roleId);
+    }
+  });
+});

--- a/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-SETTINGS-ALLOWLIST-003-put-delete-allowlist.spec.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-SETTINGS-ALLOWLIST-003-put-delete-allowlist.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect, request as playwrightRequest } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { deleteTenantAllowlistInDb } from './helpers/aiAssistantFixtures';
+
+/**
+ * TC-AI-SETTINGS-ALLOWLIST-003 — Tenant model allowlist (PUT/DELETE) + settings reflection.
+ * Source: GitHub issue #2495.
+ *
+ * Surfaces under test:
+ *   - /api/ai_assistant/settings/allowlist   (PUT, DELETE)
+ *   - /api/ai_assistant/settings             (GET — reflects the snapshot)
+ *
+ * Contract notes verified against the route handlers:
+ *   - PUT body fields are `allowedProviders` / `allowedModelsByProvider`
+ *     (NOT `providers` / `models`); success is 200 returning the saved snapshot.
+ *   - DELETE returns 200 `{ cleared: boolean }` and is idempotent
+ *     (`cleared: false` when no active row exists).
+ *   - GET /settings exposes `tenantAllowlist` (null when unset) + `effectiveAllowlist`.
+ *   - PUT/DELETE require `ai_assistant.settings.manage`.
+ *
+ * Out of scope (documented): the `provider_not_in_env_allowlist` 400 branch only
+ * fires when the APP process has `OM_AI_AVAILABLE_PROVIDERS` set to exclude the
+ * provider. The deterministic harness does not control the app's env, so that
+ * branch is covered by the module's unit tests; here we assert the env-agnostic
+ * Zod validation (wrong type -> 400 validation_error) instead.
+ */
+
+const ALLOWLIST = '/api/ai_assistant/settings/allowlist';
+const SETTINGS = '/api/ai_assistant/settings';
+
+interface TenantAllowlistSnapshot {
+  allowedProviders: string[] | null;
+  allowedModelsByProvider: Record<string, string[]>;
+}
+
+test.describe('TC-AI-SETTINGS-ALLOWLIST-003: Tenant model allowlist', () => {
+  test('PUT persists, GET reflects, DELETE clears + is idempotent', async ({ request }) => {
+    test.slow();
+    const adminToken = await getAuthToken(request, 'admin');
+    const { tenantId } = getTokenScope(adminToken);
+    try {
+      // Start from a known-clean state.
+      const reset = await apiRequest(request, 'DELETE', ALLOWLIST, { token: adminToken });
+      expect(reset.status()).toBe(200);
+
+      const settingsBefore = await apiRequest(request, 'GET', SETTINGS, { token: adminToken });
+      expect(settingsBefore.status()).toBe(200);
+      const before = await readJsonSafe<{ tenantAllowlist: TenantAllowlistSnapshot | null; effectiveAllowlist: unknown }>(
+        settingsBefore,
+      );
+      expect(before?.tenantAllowlist).toBeNull();
+      expect(before?.effectiveAllowlist).toBeTruthy();
+
+      const put = await apiRequest(request, 'PUT', ALLOWLIST, {
+        token: adminToken,
+        data: { allowedProviders: ['openai'], allowedModelsByProvider: { openai: ['gpt-5-mini'] } },
+      });
+      expect(put.status(), 'PUT allowlist returns 200').toBe(200);
+      const saved = await readJsonSafe<TenantAllowlistSnapshot>(put);
+      expect(saved?.allowedProviders).toContain('openai');
+      expect(saved?.allowedModelsByProvider?.openai).toContain('gpt-5-mini');
+
+      const settingsAfter = await apiRequest(request, 'GET', SETTINGS, { token: adminToken });
+      expect(settingsAfter.status()).toBe(200);
+      const after = await readJsonSafe<{ tenantAllowlist: TenantAllowlistSnapshot | null }>(settingsAfter);
+      expect(after?.tenantAllowlist?.allowedProviders).toContain('openai');
+
+      const del = await apiRequest(request, 'DELETE', ALLOWLIST, { token: adminToken });
+      expect(del.status()).toBe(200);
+      expect((await readJsonSafe<{ cleared: boolean }>(del))?.cleared).toBe(true);
+
+      const settingsCleared = await apiRequest(request, 'GET', SETTINGS, { token: adminToken });
+      const cleared = await readJsonSafe<{ tenantAllowlist: TenantAllowlistSnapshot | null }>(settingsCleared);
+      expect(cleared?.tenantAllowlist).toBeNull();
+
+      const delAgain = await apiRequest(request, 'DELETE', ALLOWLIST, { token: adminToken });
+      expect(delAgain.status()).toBe(200);
+      expect((await readJsonSafe<{ cleared: boolean }>(delAgain))?.cleared, 'DELETE is idempotent').toBe(false);
+    } finally {
+      await deleteTenantAllowlistInDb(tenantId).catch(() => undefined);
+    }
+  });
+
+  test('validation + RBAC gates: bad body 400, employee 403, unauthenticated 401', async ({ request, baseURL }) => {
+    const adminToken = await getAuthToken(request, 'admin');
+
+    const badType = await apiRequest(request, 'PUT', ALLOWLIST, {
+      token: adminToken,
+      data: { allowedProviders: 123 },
+    });
+    expect(badType.status()).toBe(400);
+    expect((await readJsonSafe<{ code?: string }>(badType))?.code).toBe('validation_error');
+
+    // Employee carries ai_assistant.view but NOT ai_assistant.settings.manage.
+    const employeeToken = await getAuthToken(request, 'employee');
+    const denied = await apiRequest(request, 'PUT', ALLOWLIST, {
+      token: employeeToken,
+      data: { allowedProviders: ['openai'] },
+    });
+    expect(denied.status(), 'employee lacks settings.manage -> 403').toBe(403);
+
+    const anon = await playwrightRequest.newContext({ baseURL });
+    try {
+      const res = await anon.fetch(ALLOWLIST, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify({ allowedProviders: ['openai'] }),
+      });
+      expect(res.status(), 'unauthenticated PUT is 401').toBe(401);
+    } finally {
+      await anon.dispose();
+    }
+  });
+});

--- a/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-TOOLS-EXECUTE-007-direct-tool-execution.spec.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/__integration__/TC-AI-TOOLS-EXECUTE-007-direct-tool-execution.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect, request as playwrightRequest } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+/**
+ * TC-AI-TOOLS-EXECUTE-007 — Direct tool execution + tool listing.
+ * Source: GitHub issue #2495.
+ *
+ * Surfaces under test:
+ *   - /api/ai_assistant/tools          (GET)
+ *   - /api/ai_assistant/tools/execute   (POST)
+ *
+ * Contract notes verified against the route handlers (the issue's guesses were wrong):
+ *   - execute body fields are `toolName` + `args` (NOT `name` / `input`);
+ *     success is 200 `{ success: true, result }`.
+ *   - a missing `toolName` -> 400 `{ error: 'toolName is required' }`.
+ *   - an unknown tool -> 400 `{ success: false, error: 'Tool "<n>" not found' }`
+ *     (NOT a typed `code`; the errorCode only selects 400 vs 403 internally).
+ *   - both routes require `ai_assistant.view`; the per-tool `requiredFeatures` are
+ *     enforced separately inside the executor.
+ */
+
+const TOOLS = '/api/ai_assistant/tools';
+const EXECUTE = '/api/ai_assistant/tools/execute';
+
+interface ToolSummary {
+  name: string;
+  description: string;
+  inputSchema: { required?: unknown } & Record<string, unknown>;
+  module: string;
+}
+
+test.describe('TC-AI-TOOLS-EXECUTE-007: Direct tool execution', () => {
+  test('list tools, validate + reject unknown tools, and exercise a no-arg tool', async ({ request }) => {
+    test.slow();
+    const adminToken = await getAuthToken(request, 'admin');
+
+    const listRes = await apiRequest(request, 'GET', TOOLS, { token: adminToken });
+    expect(listRes.status()).toBe(200);
+    const list = await readJsonSafe<{ tools: ToolSummary[] }>(listRes);
+    expect(Array.isArray(list?.tools)).toBe(true);
+    expect((list?.tools.length ?? 0) > 0, 'at least one tool is visible to admin').toBe(true);
+    const sample = list!.tools[0];
+    expect(typeof sample.name).toBe('string');
+    expect(typeof sample.inputSchema).toBe('object');
+
+    // Missing toolName -> 400 with the route-level message.
+    const missing = await apiRequest(request, 'POST', EXECUTE, { token: adminToken, data: {} });
+    expect(missing.status()).toBe(400);
+    expect((await readJsonSafe<{ error?: string }>(missing))?.error).toBe('toolName is required');
+
+    // Unknown tool -> 400 { success: false, error: '... not found' }.
+    const unknown = await apiRequest(request, 'POST', EXECUTE, {
+      token: adminToken,
+      data: { toolName: 'does.not_exist_tool', args: {} },
+    });
+    expect(unknown.status()).toBe(400);
+    const unknownBody = await readJsonSafe<{ success?: boolean; error?: string }>(unknown);
+    expect(unknownBody?.success).toBe(false);
+    expect(unknownBody?.error ?? '').toContain('not found');
+
+    // Best-effort happy path: a tool whose input schema has no required fields can
+    // be invoked with empty args. The execute route runs the handler and returns
+    // 200 `{ success }`; assert the envelope only when such a tool is available.
+    const noArgTool = list!.tools.find((tool) => {
+      const required = tool.inputSchema?.required;
+      return !Array.isArray(required) || required.length === 0;
+    });
+    if (noArgTool) {
+      const exec = await apiRequest(request, 'POST', EXECUTE, {
+        token: adminToken,
+        data: { toolName: noArgTool.name, args: {} },
+      });
+      // A 200 from the execute route always carries `success: true` (only a
+      // thrown handler yields 400 `{ success: false }`), so assert the real
+      // value rather than mere presence. A no-arg tool that rejects empty input
+      // legitimately returns 400, which this guard intentionally tolerates.
+      if (exec.status() === 200) {
+        expect((await readJsonSafe<{ success?: boolean }>(exec))?.success).toBe(true);
+      }
+    }
+  });
+
+  test('unauthenticated execute is rejected with 401', async ({ baseURL }) => {
+    const anon = await playwrightRequest.newContext({ baseURL });
+    try {
+      const res = await anon.fetch(EXECUTE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify({ toolName: 'does.not_exist_tool', args: {} }),
+      });
+      expect(res.status()).toBe(401);
+    } finally {
+      await anon.dispose();
+    }
+  });
+});

--- a/packages/ai-assistant/src/modules/ai_assistant/__integration__/helpers/aiAssistantFixtures.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/__integration__/helpers/aiAssistantFixtures.ts
@@ -1,0 +1,198 @@
+import { readFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { Client } from 'pg';
+
+/**
+ * Direct-Postgres fixtures for AI Assistant integration specs.
+ *
+ * Mirrors the sanctioned pattern in
+ * `@open-mercato/core/helpers/integration/dbFixtures` (raw SQL against
+ * `DATABASE_URL`) for the surfaces that have NO public create route:
+ *  - `ai_pending_actions`: a pending mutation approval is only ever born from
+ *    the internal `prepareMutation` path during a real LLM agent turn. Seeding
+ *    the row directly keeps confirm/cancel/GET coverage deterministic and
+ *    provider-free.
+ *  - prompt overrides: the `prompt-override` route exposes no DELETE, so
+ *    versioned rows must be swept via SQL after a test.
+ *
+ * The app server and this helper MUST share one `DATABASE_URL`, so specs using
+ * these helpers only run under the coherent app+DB harness
+ * (`yarn test:integration` / `:ephemeral`), never against an arbitrary dev
+ * server whose `DATABASE_URL` differs from `apps/mercato/.env`.
+ */
+
+function resolveAppRoot(): string {
+  const fromEnv = process.env.OM_TEST_APP_ROOT?.trim();
+  return fromEnv ? path.resolve(fromEnv) : path.resolve(process.cwd(), 'apps/mercato');
+}
+
+function readEnvValue(key: string): string | undefined {
+  if (process.env[key]) return process.env[key];
+  const candidatePaths = [
+    path.resolve(resolveAppRoot(), '.env'),
+    path.resolve(process.cwd(), 'apps/mercato/.env'),
+    path.resolve(process.cwd(), '.env'),
+  ];
+  for (const envPath of candidatePaths) {
+    try {
+      const content = readFileSync(envPath, 'utf-8');
+      const match = content.match(new RegExp(`^${key}=(.+)$`, 'm'));
+      if (match?.[1]) return match[1].trim();
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+function resolveDatabaseUrl(): string {
+  const url = readEnvValue('DATABASE_URL');
+  if (!url) throw new Error('[internal] DATABASE_URL is not configured for AI Assistant integration DB fixtures');
+  return url;
+}
+
+async function withClient<T>(run: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client({ connectionString: resolveDatabaseUrl() });
+  await client.connect();
+  try {
+    return await run(client);
+  } finally {
+    await client.end();
+  }
+}
+
+export type SeededPendingActionStatus =
+  | 'pending'
+  | 'confirmed'
+  | 'cancelled'
+  | 'expired'
+  | 'executing'
+  | 'failed';
+
+export interface SeedPendingActionInput {
+  tenantId: string;
+  organizationId?: string | null;
+  createdByUserId: string;
+  status?: SeededPendingActionStatus;
+  agentId?: string;
+  toolName?: string;
+  /** Minutes from now until expiry. Negative => the row is already expired. */
+  expiresInMinutes?: number;
+  normalizedInput?: Record<string, unknown>;
+  executionResult?: Record<string, unknown> | null;
+  idempotencyKey?: string;
+}
+
+export interface SeededPendingAction {
+  id: string;
+  idempotencyKey: string;
+}
+
+/**
+ * Inserts an `ai_pending_actions` row directly. Returns the new id so the test
+ * can act on it and clean it up. Defaults produce an actionable `pending` row
+ * with a future TTL; override `status`/`expiresInMinutes`/`executionResult` to
+ * cover the idempotency short-circuit and 409 error branches.
+ */
+export async function seedPendingActionInDb(input: SeedPendingActionInput): Promise<SeededPendingAction> {
+  const idempotencyKey = input.idempotencyKey ?? `it-pending-${randomUUID()}`;
+  const status = input.status ?? 'pending';
+  const expiresInMinutes = input.expiresInMinutes ?? 60;
+  const normalizedInput = JSON.stringify(input.normalizedInput ?? {});
+  const executionResult =
+    input.executionResult === undefined || input.executionResult === null
+      ? null
+      : JSON.stringify(input.executionResult);
+  return withClient(async (client) => {
+    const result = await client.query<{ id: string }>(
+      `insert into ai_pending_actions
+         (id, tenant_id, organization_id, agent_id, tool_name, normalized_input,
+          field_diff, attachment_ids, idempotency_key, created_by_user_id, status,
+          queue_mode, execution_result, created_at, expires_at)
+       values
+         (gen_random_uuid(), $1, $2, $3, $4, $5::jsonb,
+          '[]'::jsonb, '[]'::jsonb, $6, $7, $8,
+          'inline', $9::jsonb, now(), now() + make_interval(mins => $10::int))
+       returning id`,
+      [
+        input.tenantId,
+        input.organizationId ?? null,
+        input.agentId ?? 'it_agent.pending_fixture',
+        input.toolName ?? 'it_tool.noop',
+        normalizedInput,
+        idempotencyKey,
+        input.createdByUserId,
+        status,
+        executionResult,
+        expiresInMinutes,
+      ],
+    );
+    return { id: result.rows[0].id, idempotencyKey };
+  });
+}
+
+/** Hard-deletes a seeded pending action row (best-effort test cleanup). */
+export async function deletePendingActionInDb(id: string | null): Promise<void> {
+  if (!id) return;
+  await withClient(async (client) => {
+    await client.query('delete from ai_pending_actions where id = $1', [id]);
+  });
+}
+
+/**
+ * Sweeps every per-agent override row for a tenant across the three override
+ * tables. Required for `prompt-override` cleanup (no DELETE route) and used as a
+ * belt-and-braces teardown for mutation-policy / loop overrides.
+ */
+export async function deleteAgentOverridesInDb(input: { tenantId: string; agentId: string }): Promise<void> {
+  if (!input.tenantId || !input.agentId) return;
+  await withClient(async (client) => {
+    await client.query('delete from ai_agent_prompt_overrides where tenant_id = $1 and agent_id = $2', [
+      input.tenantId,
+      input.agentId,
+    ]);
+    await client.query('delete from ai_agent_mutation_policy_overrides where tenant_id = $1 and agent_id = $2', [
+      input.tenantId,
+      input.agentId,
+    ]);
+    await client.query('delete from ai_agent_runtime_overrides where tenant_id = $1 and agent_id = $2', [
+      input.tenantId,
+      input.agentId,
+    ]);
+  });
+}
+
+/** Hard-deletes any tenant model-allowlist rows (best-effort cleanup). */
+export async function deleteTenantAllowlistInDb(tenantId: string | null): Promise<void> {
+  if (!tenantId) return;
+  await withClient(async (client) => {
+    await client.query('delete from ai_tenant_model_allowlists where tenant_id = $1', [tenantId]);
+  });
+}
+
+/**
+ * Hard-deletes a conversation and its participant + message rows by the
+ * client-facing `conversation_id`. The DELETE route only soft-deletes, so this
+ * gives specs a true teardown for the rows they created.
+ */
+export async function deleteConversationCascadeInDb(input: {
+  tenantId: string;
+  conversationId: string;
+}): Promise<void> {
+  if (!input.tenantId || !input.conversationId) return;
+  await withClient(async (client) => {
+    await client.query('delete from ai_chat_messages where tenant_id = $1 and conversation_id = $2', [
+      input.tenantId,
+      input.conversationId,
+    ]);
+    await client.query(
+      'delete from ai_chat_conversation_participants where tenant_id = $1 and conversation_id = $2',
+      [input.tenantId, input.conversationId],
+    );
+    await client.query('delete from ai_chat_conversations where tenant_id = $1 and conversation_id = $2', [
+      input.tenantId,
+      input.conversationId,
+    ]);
+  });
+}


### PR DESCRIPTION
## Summary

Expands integration-test coverage for the `ai_assistant` module (#2495) with 7 executable
Playwright specs plus a module-local DB-fixtures helper, exercising the previously-untested
mutation-approval, conversation-management, and provider/agent-control surfaces against the
**real** route contracts. Each spec is self-contained (fixtures via API/SQL, cleanup in
`finally`) and idempotent across retries. No product code changes.

Note: the scenarios in #2495 were auto-generated from a gap analysis and several of their
asserted contracts were inaccurate; the tests assert the actual handler behavior instead
(e.g. cross-org conversation access is 404 not 403; allowlist body is
`allowedProviders`/`allowedModelsByProvider`; prompt-override/mutation-policy use POST;
session-key returns only `{sessionToken, expiresAt}`).

## Changes

- Add `__integration__/helpers/aiAssistantFixtures.ts` — raw-`pg` fixtures (mirrors core
  `dbFixtures`) for surfaces with no public create route: seeds `ai_pending_actions`, sweeps
  prompt/mutation-policy/loop overrides, allowlist, and conversation cascades.
- Add `TC-AI-CONVERSATIONS-001` — conversation create (idempotent)/list/patch/soft-delete +
  cross-org 404 isolation. [P0]
- Add `TC-AI-PARTICIPANTS-002` — add/list/remove participants + owner/duplicate/self/
  cross-org/RBAC guards. [P0]
- Add `TC-AI-ACTIONS-PENDING-004` — pending-action GET serialization (field stripping),
  cancel/confirm idempotency, and 409 state-machine guards (invalid_status, expired). [P0]
- Add `TC-AI-SETTINGS-ALLOWLIST-003` — tenant allowlist PUT/GET/DELETE, idempotency, RBAC. [P1]
- Add `TC-AI-AGENT-OVERRIDES-005` — prompt/mutation-policy/loop override CRUD, policy
  escalation rejection, validation, RBAC (agent id discovered dynamically). [P1]
- Add `TC-AI-SESSION-KEY-006` — session-token format + 120-minute TTL + RBAC. [P1]
- Add `TC-AI-TOOLS-EXECUTE-007` — tool listing, validation, unknown-tool + unauthenticated
  rejection. [P2]

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test-only coverage for an existing module; scenarios are defined by issue #2495 and
the `integration-tests` skill (which supports generating specs directly from a description).

## Testing

All run against a locally booted, seeded app (`yarn dev:app --update-env` + `yarn initialize`):

- `BASE_URL=http://localhost:3045 npx playwright test --config .ai/qa/tests/playwright.config.ts <7 new specs> --retries=0` → **13 passed**; re-run → **13 passed** (idempotent).
- `yarn workspace @open-mercato/ai-assistant build` → built successfully (211 entry points).
- `yarn turbo run test --filter=@open-mercato/ai-assistant` → **81 suites / 1176 tests passed**.
- `yarn i18n:check-sync` → all translation files in sync.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — test-only; `i18n:check-sync` confirms locale parity.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Per current convention, executable specs live module-local in `__integration__/`; `.ai/qa/tests/` holds shared Playwright config only.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec required.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens (N/A — no UI)
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` (N/A — no UI)
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) (N/A — no UI)
- [x] Loading state handled for async pages (N/A — no UI)
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) (N/A — no UI)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements (N/A — no UI)

## Linked issues

Fixes #2495