### PR TITLE
feat: 2493 sync excel integration coverage

### DIFF
--- a/packages/core/src/modules/sync_excel/__integration__/TC-SX-002.spec.ts
+++ b/packages/core/src/modules/sync_excel/__integration__/TC-SX-002.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  ENTITY_TYPE,
+  SAMPLE_CSV,
+  csvFilePart,
+  readJson,
+  uploadMultipart,
+} from './helpers/syncExcel'
+
+/**
+ * TC-SX-002: Upload endpoint rejects non-CSV file types and MIME types.
+ *
+ * Source: GitHub issue #2493 (sync_excel coverage expansion).
+ *
+ * The upload route (`packages/core/src/modules/sync_excel/api/upload/route.ts`)
+ * accepts a file when it is CSV *by MIME type* OR *by `.csv` extension*
+ * (`!isCsvByMime && !isCsvByName` => reject). The original issue assumed an
+ * AND rule (reject a `.csv` name with a non-CSV MIME); this spec asserts the
+ * real OR semantics:
+ *   - a file that is neither CSV-by-name nor CSV-by-MIME => 422
+ *   - a `.csv`-named file with a non-CSV MIME => accepted (200)
+ *   - a CSV-MIME file with a non-`.csv` name => accepted (200)
+ */
+test.describe('TC-SX-002: sync_excel upload rejects non-CSV files', () => {
+  test('rejects files that are neither CSV by name nor by MIME type', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const nonCsvCases = [
+      { name: 'data.json', mimeType: 'application/json', content: '{"lead":"Ada"}' },
+      { name: 'data.txt', mimeType: 'text/plain', content: 'Record Id,Lead Name\nsx-1,Ada\n' },
+      { name: 'report.pdf', mimeType: 'application/pdf', content: '%PDF-1.4 not really a pdf' },
+    ]
+
+    for (const file of nonCsvCases) {
+      const response = await uploadMultipart(request, token, {
+        entityType: ENTITY_TYPE,
+        file: csvFilePart(file),
+      })
+
+      expect(response.status(), `${file.name} (${file.mimeType}) must be rejected`).toBe(422)
+      const body = await readJson(response)
+      expect(String(body.error)).toContain('Only CSV uploads are supported')
+    }
+  })
+
+  test('accepts CSV detected by extension or MIME even when the other signal is off', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    // `.csv` extension but a non-CSV MIME — accepted (extension is sufficient).
+    const byExtension = await uploadMultipart(request, token, {
+      entityType: ENTITY_TYPE,
+      file: csvFilePart({ name: 'leads.csv', mimeType: 'application/json', content: SAMPLE_CSV }),
+    })
+    expect(byExtension.status()).toBe(200)
+    expect(String((await readJson(byExtension)).entityType)).toBe(ENTITY_TYPE)
+
+    // CSV MIME but a non-`.csv` name — accepted (MIME is sufficient).
+    const byMime = await uploadMultipart(request, token, {
+      entityType: ENTITY_TYPE,
+      file: csvFilePart({ name: 'leads.dat', mimeType: 'text/csv', content: SAMPLE_CSV }),
+    })
+    expect(byMime.status()).toBe(200)
+    expect(String((await readJson(byMime)).entityType)).toBe(ENTITY_TYPE)
+  })
+})

--- a/packages/core/src/modules/sync_excel/__integration__/TC-SX-003.spec.ts
+++ b/packages/core/src/modules/sync_excel/__integration__/TC-SX-003.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { ENTITY_TYPE, csvFilePart, readJson, uploadMultipart } from './helpers/syncExcel'
+
+/**
+ * TC-SX-003: Upload endpoint enforces the maximum upload size (413).
+ *
+ * Source: GitHub issue #2493 (sync_excel coverage expansion).
+ *
+ * The upload route rejects oversized uploads in two places
+ * (`packages/core/src/modules/sync_excel/api/upload/route.ts`):
+ *   - a `Content-Length` guard with a 1MB multipart overhead allowance, and
+ *   - a per-file `file.size` guard against the resolved max upload bytes.
+ * The default attachment max is 25MB (`resolveDefaultAttachmentMaxUploadBytes`,
+ * overridable via `OM_ATTACHMENT_MAX_UPLOAD_MB`). A buffer comfortably above
+ * 26MB trips at least one of the two guards regardless of whether the client
+ * sends a `Content-Length` header. In practice Playwright sends a Content-Length
+ * for a buffered multipart body, so the Content-Length guard is the branch
+ * exercised here; either way the response is 413 with the same message.
+ *
+ * The exact-boundary "size == max => 200" case is intentionally omitted: it
+ * would require uploading, parsing, encrypting and persisting a ~25MB
+ * attachment for which the module exposes no delete endpoint, and risks the
+ * 20s spec timeout. The high-value security boundary is the rejection path.
+ */
+test.describe('TC-SX-003: sync_excel upload size limit', () => {
+  test('rejects uploads larger than the maximum upload size with 413', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    // 27MB > the 25MB file-size limit and > the 26MB content-length limit.
+    const oversized = Buffer.alloc(27 * 1024 * 1024, 0x61)
+    const response = await uploadMultipart(request, token, {
+      entityType: ENTITY_TYPE,
+      file: csvFilePart({ name: 'oversized.csv', mimeType: 'text/csv', content: oversized }),
+    })
+
+    expect(response.status()).toBe(413)
+    const body = await readJson(response)
+    expect(String(body.error)).toContain('exceeds the maximum upload size')
+  })
+
+  test('accepts a small CSV well under the limit', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const response = await uploadMultipart(request, token, {
+      entityType: ENTITY_TYPE,
+      file: csvFilePart({ name: 'small.csv', content: 'Record Id,Lead Name\nsx-small,Within Limit\n' }),
+    })
+
+    expect(response.status()).toBe(200)
+    expect(String((await readJson(response)).entityType)).toBe(ENTITY_TYPE)
+  })
+})

--- a/packages/core/src/modules/sync_excel/__integration__/TC-SX-004.spec.ts
+++ b/packages/core/src/modules/sync_excel/__integration__/TC-SX-004.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { ENTITY_TYPE, csvFilePart, readJson, uploadMultipart } from './helpers/syncExcel'
+
+/**
+ * TC-SX-004: Upload endpoint validates the multipart payload fields.
+ *
+ * Source: GitHub issue #2493 (sync_excel coverage expansion).
+ *
+ * Upload route validation order
+ * (`packages/core/src/modules/sync_excel/api/upload/route.ts`):
+ *   - `entityType` is parsed first and defaults to `customers.person`;
+ *     an unknown value fails the enum => 422 'Invalid upload payload.'
+ *   - the `file` part must be an actual File => otherwise 400
+ *     'Select a CSV file to upload.'
+ */
+test.describe('TC-SX-004: sync_excel upload field validation', () => {
+  test('returns 400 when the file part is missing', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const response = await uploadMultipart(request, token, { entityType: ENTITY_TYPE })
+
+    expect(response.status()).toBe(400)
+    expect(String((await readJson(response)).error)).toContain('Select a CSV file to upload')
+  })
+
+  test('returns 400 when the file field is a non-file value', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const response = await uploadMultipart(request, token, { entityType: ENTITY_TYPE, file: '' })
+
+    expect(response.status()).toBe(400)
+    expect(String((await readJson(response)).error)).toContain('Select a CSV file to upload')
+  })
+
+  test('defaults entityType to customers.person when omitted', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const response = await uploadMultipart(request, token, {
+      file: csvFilePart({ name: 'defaulted.csv', content: 'Record Id,Lead Name\nsx-default,Default Entity\n' }),
+    })
+
+    expect(response.status()).toBe(200)
+    expect(String((await readJson(response)).entityType)).toBe(ENTITY_TYPE)
+  })
+
+  test('returns 422 for an unsupported entityType value', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const response = await uploadMultipart(request, token, {
+      entityType: 'customers.company',
+      file: csvFilePart({ name: 'invalid-entity.csv' }),
+    })
+
+    expect(response.status()).toBe(422)
+    expect(String((await readJson(response)).error)).toContain('Invalid upload payload')
+  })
+})

--- a/packages/core/src/modules/sync_excel/__integration__/TC-SX-005.spec.ts
+++ b/packages/core/src/modules/sync_excel/__integration__/TC-SX-005.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { ENTITY_TYPE, previewUpload, readJson, uploadSampleCsv } from './helpers/syncExcel'
+
+/**
+ * TC-SX-005: Preview endpoint not-found and organization scoping.
+ *
+ * Source: GitHub issue #2493 (sync_excel coverage expansion).
+ *
+ * The preview route looks up the upload scoped by `organizationId` + `tenantId`
+ * (`packages/core/src/modules/sync_excel/api/preview/route.ts`). A well-formed
+ * but unknown id returns 404 (the original issue claimed 200 here — that is the
+ * found case, not the missing case). Selecting "All organizations" (`__all__`)
+ * is rejected before the lookup with 422, which exercises the org-scoping guard
+ * without depending on a second seeded organization.
+ */
+test.describe('TC-SX-005: sync_excel preview not-found and scoping', () => {
+  let token: string
+  let uploadId: string
+
+  test.beforeAll(async ({ request }) => {
+    token = await getAuthToken(request, 'admin')
+    const upload = await uploadSampleCsv(request, token, 'sx-preview')
+    uploadId = String(upload.uploadId)
+  })
+
+  test('returns 404 for a well-formed but non-existent uploadId', async ({ request }) => {
+    const response = await previewUpload(request, token, {
+      uploadId: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+      entityType: ENTITY_TYPE,
+    })
+
+    expect(response.status()).toBe(404)
+    expect(String((await readJson(response)).error)).toContain('Upload preview not found')
+  })
+
+  test('returns 200 for an existing upload within the active organization', async ({ request }) => {
+    const response = await previewUpload(request, token, { uploadId, entityType: ENTITY_TYPE })
+
+    expect(response.status()).toBe(200)
+    const body = await readJson(response)
+    expect(String(body.uploadId)).toBe(uploadId)
+    expect(String(body.entityType)).toBe(ENTITY_TYPE)
+  })
+
+  test('rejects "All organizations" scope with 422 before the lookup', async ({ request }) => {
+    const response = await previewUpload(request, token, { uploadId, entityType: ENTITY_TYPE }, '__all__')
+
+    expect(response.status()).toBe(422)
+    expect(String((await readJson(response)).error)).toContain('Select a concrete organization')
+  })
+})

--- a/packages/core/src/modules/sync_excel/__integration__/TC-SX-006.spec.ts
+++ b/packages/core/src/modules/sync_excel/__integration__/TC-SX-006.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { ENTITY_TYPE, previewUpload, readJson, uploadSampleCsv } from './helpers/syncExcel'
+
+/**
+ * TC-SX-006: Preview endpoint query-parameter validation.
+ *
+ * Source: GitHub issue #2493 (sync_excel coverage expansion).
+ *
+ * `syncExcelPreviewQuerySchema` requires `uploadId` to be a UUID and makes
+ * `entityType` an optional enum. A malformed uploadId or an out-of-enum
+ * entityType fails query validation => 422 'Invalid query', before any lookup.
+ * Omitting `entityType` is valid (the route falls back to the upload's stored
+ * entityType). The optional-entityType case uses a real upload so it exercises
+ * the success path rather than a not-found lookup.
+ */
+test.describe('TC-SX-006: sync_excel preview query validation', () => {
+  let token: string
+  let uploadId: string
+
+  test.beforeAll(async ({ request }) => {
+    token = await getAuthToken(request, 'admin')
+    const upload = await uploadSampleCsv(request, token, 'sx-query')
+    uploadId = String(upload.uploadId)
+  })
+
+  test('returns 422 for a malformed uploadId', async ({ request }) => {
+    const response = await previewUpload(request, token, { uploadId: 'not-a-uuid', entityType: ENTITY_TYPE })
+
+    expect(response.status()).toBe(422)
+    expect(String((await readJson(response)).error)).toContain('Invalid query')
+  })
+
+  test('returns 422 for an unsupported entityType', async ({ request }) => {
+    const response = await previewUpload(request, token, { uploadId, entityType: 'invalid.type' })
+
+    expect(response.status()).toBe(422)
+    expect(String((await readJson(response)).error)).toContain('Invalid query')
+  })
+
+  test('accepts a request without entityType (optional, falls back to the upload)', async ({ request }) => {
+    const response = await previewUpload(request, token, { uploadId })
+
+    expect(response.status()).toBe(200)
+    expect(String((await readJson(response)).entityType)).toBe(ENTITY_TYPE)
+  })
+})

--- a/packages/core/src/modules/sync_excel/__integration__/TC-SX-007.spec.ts
+++ b/packages/core/src/modules/sync_excel/__integration__/TC-SX-007.spec.ts
@@ -1,0 +1,89 @@
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { config as loadEnv } from 'dotenv'
+import { Client } from 'pg'
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  ENTITY_TYPE,
+  INTEGRATION_ID,
+  buildValidMapping,
+  decodeTokenScope,
+  readJson,
+  startImport,
+  uploadSampleCsv,
+} from './helpers/syncExcel'
+
+// Match TC-SX-001: when not running under the integration runner (which injects
+// DATABASE_URL), load it from apps/mercato/.env so a manual single-spec run works.
+if (!process.env.OM_TEST_APP_ROOT?.trim()) {
+  loadEnv({ path: path.resolve(process.cwd(), 'apps/mercato', '.env') })
+}
+
+/**
+ * TC-SX-007: Import endpoint detects concurrent import conflicts (409).
+ *
+ * Source: GitHub issue #2493 (sync_excel coverage expansion).
+ *
+ * The import route calls `findRunningOverlap('sync_excel', 'customers.person',
+ * 'import', scope)` and returns 409 'A sync_excel import is already in progress
+ * for this entity type.' when a run in `pending`/`running` state exists for that
+ * scope. The 409 is returned before the route persists the mapping or starts a
+ * run (overlap check precedes the write transaction).
+ *
+ * Determinism: the integration runner enables `AUTO_SPAWN_WORKERS`, so a real
+ * import started via the API would be picked up and completed by the
+ * data-sync-import worker, turning the conflict into a timing race. Instead this
+ * test seeds an in-progress `sync_runs` row directly with NO queue job — the
+ * worker never touches it, so it stays in-progress until the test removes it.
+ * This mirrors TC-SX-001's pg-based run lifecycle handling and requires
+ * `DATABASE_URL` (provided by the integration runner).
+ *
+ * Scope note: the complementary "conflict clears after the run finishes" path is
+ * intentionally not asserted here — proving it requires a real worker-processed
+ * import, which is nondeterministic and mutates shared mapping/customer state.
+ */
+test.describe('TC-SX-007: sync_excel import concurrency conflict', () => {
+  test('returns 409 when an import for the same entity type is already in progress', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const scope = decodeTokenScope(token)
+
+    const connectionString = process.env.DATABASE_URL
+    if (!connectionString) {
+      throw new Error('DATABASE_URL is required for TC-SX-007 to seed an in-progress sync run')
+    }
+    const dbClient = new Client({ connectionString })
+    await dbClient.connect()
+
+    // A valid upload is required for the import to reach the overlap check.
+    const upload = await uploadSampleCsv(request, token, 'sx-concurrency')
+    const overlapRunId = randomUUID()
+
+    try {
+      await dbClient.query(
+        `insert into sync_runs (id, integration_id, entity_type, direction, status, organization_id, tenant_id, created_at, updated_at)
+         values ($1, $2, $3, 'import', 'running', $4, $5, now(), now())`,
+        [overlapRunId, INTEGRATION_ID, ENTITY_TYPE, scope.orgId, scope.tenantId],
+      )
+
+      const conflict = await startImport(request, token, {
+        uploadId: String(upload.uploadId),
+        entityType: ENTITY_TYPE,
+        mapping: buildValidMapping(),
+      })
+
+      expect(conflict.status()).toBe(409)
+      expect(String((await readJson(conflict)).error)).toContain('already in progress')
+    } finally {
+      await dbClient
+        .query(
+          `update sync_runs set status = 'cancelled', updated_at = now()
+           where integration_id = $1 and entity_type = $2 and direction = 'import'
+             and status in ('pending', 'running') and organization_id = $3 and tenant_id = $4 and deleted_at is null`,
+          [INTEGRATION_ID, ENTITY_TYPE, scope.orgId, scope.tenantId],
+        )
+        .catch(() => undefined)
+      await dbClient.end().catch(() => undefined)
+    }
+  })
+})

--- a/packages/core/src/modules/sync_excel/__integration__/TC-SX-008.spec.ts
+++ b/packages/core/src/modules/sync_excel/__integration__/TC-SX-008.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  ENTITY_TYPE,
+  buildValidMapping,
+  readJson,
+  startImport,
+  type JsonRecord,
+} from './helpers/syncExcel'
+
+/**
+ * TC-SX-008: Import endpoint validates the payload and mapping schema.
+ *
+ * Source: GitHub issue #2493 (sync_excel coverage expansion).
+ *
+ * `syncExcelImportRequestSchema` enforces a UUID `uploadId`, an enum
+ * `entityType`, a structurally valid `mapping`, and a bounded `batchSize`.
+ * Any violation returns 422 'Invalid import payload.' before scope resolution
+ * or any lookup. A structurally valid payload that references a missing upload
+ * passes schema validation and returns 404.
+ *
+ * Note: `syncExcelEntityTypes` currently has a single member
+ * (`customers.person`), so the route's explicit "Upload entity type does not
+ * match" / "Mapping entity type does not match" 422 branches are unreachable
+ * through the public API — Zod constrains both `entityType` and
+ * `mapping.entityType` to the same enum value before those checks run. This
+ * spec therefore asserts the reachable schema-level rejection (an out-of-enum
+ * `mapping.entityType` fails validation) rather than the dead comparison.
+ */
+const VALID_UUID = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+
+test.describe('TC-SX-008: sync_excel import payload validation', () => {
+  test('rejects malformed import payloads with 422', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const invalidPayloads: Array<{ label: string; payload: JsonRecord }> = [
+      { label: 'missing uploadId', payload: { entityType: ENTITY_TYPE, mapping: buildValidMapping() } },
+      { label: 'malformed uploadId', payload: { uploadId: 'not-a-uuid', entityType: ENTITY_TYPE, mapping: buildValidMapping() } },
+      { label: 'unsupported entityType', payload: { uploadId: VALID_UUID, entityType: 'customers.company', mapping: buildValidMapping() } },
+      { label: 'missing mapping', payload: { uploadId: VALID_UUID, entityType: ENTITY_TYPE } },
+      {
+        label: 'mapping missing matchStrategy',
+        payload: {
+          uploadId: VALID_UUID,
+          entityType: ENTITY_TYPE,
+          mapping: { entityType: ENTITY_TYPE, fields: [], unmappedColumns: [] },
+        },
+      },
+      {
+        label: 'mapping entityType out of enum',
+        payload: {
+          uploadId: VALID_UUID,
+          entityType: ENTITY_TYPE,
+          mapping: { ...buildValidMapping(), entityType: 'customers.company' },
+        },
+      },
+      {
+        label: 'batchSize below minimum',
+        payload: { uploadId: VALID_UUID, entityType: ENTITY_TYPE, mapping: buildValidMapping(), batchSize: 0 },
+      },
+    ]
+
+    for (const { label, payload } of invalidPayloads) {
+      const response = await startImport(request, token, payload)
+      expect(response.status(), `${label} must be rejected with 422`).toBe(422)
+      expect(String((await readJson(response)).error)).toContain('Invalid import payload')
+    }
+  })
+
+  test('returns 404 for a schema-valid payload referencing a non-existent upload', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const response = await startImport(request, token, {
+      uploadId: VALID_UUID,
+      entityType: ENTITY_TYPE,
+      mapping: buildValidMapping(),
+    })
+
+    expect(response.status()).toBe(404)
+    expect(String((await readJson(response)).error)).toContain('Upload preview not found')
+  })
+})

--- a/packages/core/src/modules/sync_excel/__integration__/helpers/syncExcel.ts
+++ b/packages/core/src/modules/sync_excel/__integration__/helpers/syncExcel.ts
@@ -1,0 +1,116 @@
+import { expect, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/crmFixtures'
+
+export type JsonRecord = Record<string, unknown>
+
+export const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
+export const ENTITY_TYPE = 'customers.person'
+export const INTEGRATION_ID = 'sync_excel'
+
+export const SAMPLE_CSV = 'Record Id,Lead Name,Email\nsx-fixture,Sample Lead,sample@example.com\n'
+
+type MultipartFilePart = { name: string; mimeType: string; buffer: Buffer }
+type MultipartValue = string | MultipartFilePart
+export type MultipartPayload = Record<string, MultipartValue>
+
+export async function readJson(response: APIResponse): Promise<JsonRecord> {
+  return ((await readJsonSafe<JsonRecord>(response)) ?? {}) as JsonRecord
+}
+
+export function uniqueSuffix(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`
+}
+
+export function decodeTokenScope(token: string): { tenantId: string; orgId: string } {
+  const [, payload] = token.split('.')
+  if (!payload) throw new Error('Auth token is missing a JWT payload')
+  const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as JsonRecord
+  const tenantId = typeof claims.tenantId === 'string' ? claims.tenantId : ''
+  const orgId = typeof claims.orgId === 'string' ? claims.orgId : ''
+  if (!tenantId || !orgId) throw new Error('Auth token is missing tenantId/orgId claims')
+  return { tenantId, orgId }
+}
+
+export function syncExcelHeaders(token: string, selectedOrgId?: string): Record<string, string> {
+  const scope = decodeTokenScope(token)
+  return {
+    Authorization: `Bearer ${token}`,
+    Cookie: `om_selected_tenant=${scope.tenantId}; om_selected_org=${selectedOrgId ?? scope.orgId}`,
+  }
+}
+
+export function csvFilePart(input?: { name?: string; mimeType?: string; content?: string | Buffer }): MultipartFilePart {
+  const content = input?.content ?? SAMPLE_CSV
+  return {
+    name: input?.name ?? 'leads.csv',
+    mimeType: input?.mimeType ?? 'text/csv',
+    buffer: Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf8'),
+  }
+}
+
+export function buildValidMapping(): JsonRecord {
+  return {
+    entityType: ENTITY_TYPE,
+    matchStrategy: 'externalId',
+    matchField: 'person.externalId',
+    fields: [],
+    unmappedColumns: [],
+  }
+}
+
+export async function uploadMultipart(
+  request: APIRequestContext,
+  token: string,
+  multipart: MultipartPayload,
+  selectedOrgId?: string,
+): Promise<APIResponse> {
+  return request.fetch(`${BASE_URL}/api/sync_excel/upload`, {
+    method: 'POST',
+    headers: syncExcelHeaders(token, selectedOrgId),
+    multipart,
+  })
+}
+
+export async function uploadSampleCsv(
+  request: APIRequestContext,
+  token: string,
+  fileNamePrefix = 'sx',
+): Promise<JsonRecord> {
+  const response = await uploadMultipart(request, token, {
+    entityType: ENTITY_TYPE,
+    file: csvFilePart({ name: `${fileNamePrefix}-${uniqueSuffix()}.csv`, content: SAMPLE_CSV }),
+  })
+  expect(response.status()).toBe(200)
+  return readJson(response)
+}
+
+export async function previewUpload(
+  request: APIRequestContext,
+  token: string,
+  query: { uploadId?: string; entityType?: string },
+  selectedOrgId?: string,
+): Promise<APIResponse> {
+  const params = new URLSearchParams()
+  if (query.uploadId !== undefined) params.set('uploadId', query.uploadId)
+  if (query.entityType !== undefined) params.set('entityType', query.entityType)
+  const suffix = params.toString()
+  return request.get(`${BASE_URL}/api/sync_excel/preview${suffix ? `?${suffix}` : ''}`, {
+    headers: syncExcelHeaders(token, selectedOrgId),
+  })
+}
+
+export async function startImport(
+  request: APIRequestContext,
+  token: string,
+  data: JsonRecord,
+  selectedOrgId?: string,
+): Promise<APIResponse> {
+  return request.fetch(`${BASE_URL}/api/sync_excel/import`, {
+    method: 'POST',
+    headers: {
+      ...syncExcelHeaders(token, selectedOrgId),
+      'Content-Type': 'application/json',
+    },
+    data,
+  })
+}


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Expands integration-test coverage for the `sync_excel` module (issue #2493) with seven new Playwright API specs (TC-SX-002 – TC-SX-008): upload file-type/MIME rejection, upload size limits, multipart field validation, preview not-found/org-scoping and query validation, import concurrency conflict (409), and import payload/mapping validation. Tests only — no product code changes.

## Changes

- `sync_excel/__integration__/TC-SX-002.spec.ts` — upload rejects non-CSV files (json/txt/pdf → 422); asserts the route's real `name`-OR-`MIME` accept rule (a `.csv` name with a non-CSV MIME, and a CSV MIME with a non-`.csv` name, are accepted).
- `sync_excel/__integration__/TC-SX-003.spec.ts` — upload over the max size → 413; small CSV → 200.
- `sync_excel/__integration__/TC-SX-004.spec.ts` — missing/empty file → 400; omitted entityType defaults to `customers.person`; unknown entityType → 422.
- `sync_excel/__integration__/TC-SX-005.spec.ts` — preview of a non-existent id → 404; existing id → 200; "All organizations" scope → 422.
- `sync_excel/__integration__/TC-SX-006.spec.ts` — preview query validation: malformed uploadId → 422, unknown entityType → 422, omitted entityType → 200.
- `sync_excel/__integration__/TC-SX-007.spec.ts` — import concurrency conflict → 409, via a deterministically seeded in-progress `sync_runs` row (no queue job, so the eager worker cannot race it).
- `sync_excel/__integration__/TC-SX-008.spec.ts` — import payload/mapping schema validation → 422; schema-valid-but-missing upload → 404.
- `sync_excel/__integration__/helpers/syncExcel.ts` — shared API helpers (scoped headers, multipart upload, preview, import, valid mapping).

Note: corrected three inaccuracies in the auto-generated issue against actual route behavior — a `.csv`-named file with a non-CSV MIME is accepted (not 422); preview of a well-formed nonexistent id returns 404 (not 200); the import "entity-type mismatch" 422 branch is unreachable because the entity-type enum has a single member, so TC-SX-008 asserts the reachable schema-level 422 instead.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — additive integration tests for existing, stable `sync_excel` API surfaces (no behavior change); scenarios are driven by issue #2493.

## Testing

- `yarn typecheck --filter=@open-mercato/core` → pass (new `__integration__` specs + helper are in the core `tsc --noEmit` include set).
- `yarn test:integration:ephemeral --filter "sync_excel" --no-reuse-env` → 19 passed (TC-SX-001 + the 7 new specs) in a fresh ephemeral env.
- `yarn test:integration:ephemeral --filter "TC-SX-00[2-8]" --no-reuse-env` → 17 passed (the 7 new specs).
- `yarn test --filter=@open-mercato/core` → 5273 passed; all `sync_excel` unit suites pass. One pre-existing, unrelated failure in `communication_channels/lib/__tests__/thread-token.test.ts` (async-teardown leak) is not touched by this change and is not run alongside these specs (jest does not execute `__integration__/*.spec.ts`).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — tests only.)
- [x] I added or adjusted tests that cover the change. (The change is entirely tests.)
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Added 7 specs in the module's `__integration__/` folder — the canonical location per `.ai/qa/AGENTS.md`; `.ai/qa/tests/` holds Playwright config only.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec needed.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, backend API tests, no UI.
- [x] No arbitrary text sizes — N/A, no UI.
- [x] Empty state handled for list/data pages — N/A, no UI.
- [x] Loading state handled for async pages — N/A, no UI.
- [x] `aria-label` on all icon-only buttons — N/A, no UI.
- [x] Uses existing DS components — N/A, no UI.

## Linked issues

Fixes #2493.