### PR TITLE
feat: 2491 perspectives integration coverage

### DIFF
--- a/packages/core/src/modules/perspectives/__integration__/TC-PERSP-CLEAR-001.spec.ts
+++ b/packages/core/src/modules/perspectives/__integration__/TC-PERSP-CLEAR-001.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['perspectives'],
+};
+
+type RolePerspectiveDto = { roleId?: string };
+type SaveResponse = {
+  perspective?: { id?: string; updatedAt?: string | null };
+  rolePerspectives?: RolePerspectiveDto[];
+  clearedRoleIds?: string[];
+};
+type StateResponse = {
+  perspectives?: Array<{ id?: string; updatedAt?: string | null }>;
+  rolePerspectives?: RolePerspectiveDto[];
+};
+
+/**
+ * TC-PERSP-CLEAR-001 (#2491): POST clearRoleIds removes the listed role perspectives in the
+ * same transaction as a personal save, without deleting the personal perspective and without
+ * touching role perspectives that were not listed.
+ *
+ * Per-role state is observed through member users (GET only surfaces a caller's own roles):
+ * one member for role A (cleared) and one for role B (kept). The personal perspective is the
+ * admin's own, so it is read back directly from the admin GET.
+ */
+test.describe('TC-PERSP-CLEAR-001: clearRoleIds removes role perspectives without affecting personal', () => {
+  test('clears only the listed role and keeps the personal perspective and the other role', async ({ request }) => {
+    test.slow();
+    const stamp = Date.now();
+    const password = 'Secret123!';
+    const tableId = `qa-persp-clear-001-${stamp}`;
+    const perspectiveName = `Personal View ${stamp}`;
+    const emailA = `qa-persp-clear-001-a-${stamp}@example.com`;
+    const emailB = `qa-persp-clear-001-b-${stamp}@example.com`;
+
+    let adminToken: string | null = null;
+    let roleAId: string | null = null;
+    let roleBId: string | null = null;
+    let userAId: string | null = null;
+    let userBId: string | null = null;
+    let personalId: string | null = null;
+
+    const memberSeesRole = async (token: string, roleId: string): Promise<boolean> => {
+      const res = await apiRequest(request, 'GET', `/api/perspectives/${encodeURIComponent(tableId)}`, { token });
+      expect(res.status()).toBe(200);
+      const state = await readJsonSafe<StateResponse>(res);
+      return (state?.rolePerspectives ?? []).some((rp) => rp.roleId === roleId);
+    };
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      const { organizationId } = getTokenContext(adminToken);
+
+      const roleA = await createRoleFixture(request, adminToken, { name: `TC-PERSP-CLEAR-001 Role A ${stamp}` });
+      const roleB = await createRoleFixture(request, adminToken, { name: `TC-PERSP-CLEAR-001 Role B ${stamp}` });
+      roleAId = roleA;
+      roleBId = roleB;
+      userAId = await createUserFixture(request, adminToken, { email: emailA, password, organizationId, roles: [roleA] });
+      userBId = await createUserFixture(request, adminToken, { email: emailB, password, organizationId, roles: [roleB] });
+      await setUserAclVisibility(request, adminToken, { userId: userAId, features: ['perspectives.use'], organizations: [organizationId] });
+      await setUserAclVisibility(request, adminToken, { userId: userBId, features: ['perspectives.use'], organizations: [organizationId] });
+      const tokenA = await getAuthToken(request, emailA, password);
+      const tokenB = await getAuthToken(request, emailB, password);
+
+      // Seed personal + role perspectives for A and B in one request.
+      const seed = await apiRequest(request, 'POST', `/api/perspectives/${encodeURIComponent(tableId)}`, {
+        token: adminToken,
+        data: { name: perspectiveName, settings: { pageSize: 15 }, applyToRoles: [roleA, roleB] },
+      });
+      expect(seed.status(), 'seed personal + roles A,B').toBe(200);
+      const seedBody = await readJsonSafe<SaveResponse>(seed);
+      personalId = seedBody?.perspective?.id ?? null;
+      expect(typeof personalId, 'personal id present').toBe('string');
+      const seedUpdatedAt = seedBody?.perspective?.updatedAt ?? null;
+      expect(seedBody?.rolePerspectives ?? [], 'two role perspectives seeded').toHaveLength(2);
+
+      expect(await memberSeesRole(tokenA, roleA), 'role A member sees perspective before clear').toBe(true);
+      expect(await memberSeesRole(tokenB, roleB), 'role B member sees perspective before clear').toBe(true);
+
+      // Re-save personal (same name) and clear ONLY role A in the same request.
+      const cleared = await apiRequest(request, 'POST', `/api/perspectives/${encodeURIComponent(tableId)}`, {
+        token: adminToken,
+        data: { name: perspectiveName, settings: { pageSize: 18 }, clearRoleIds: [roleA] },
+      });
+      expect(cleared.status(), 'clearRoleIds POST').toBe(200);
+      const clearedBody = await readJsonSafe<SaveResponse>(cleared);
+      expect(clearedBody?.clearedRoleIds ?? [], 'response reports role A cleared').toEqual([roleA]);
+      expect(clearedBody?.perspective?.id, 'personal perspective is the same record').toBe(personalId);
+
+      // Personal perspective survives the clear and is updated in place.
+      const adminState = await apiRequest(request, 'GET', `/api/perspectives/${encodeURIComponent(tableId)}`, { token: adminToken });
+      expect(adminState.status()).toBe(200);
+      const personalState = await readJsonSafe<StateResponse>(adminState);
+      const personalMatches = (personalState?.perspectives ?? []).filter((perspective) => perspective.id === personalId);
+      expect(personalMatches, 'exactly one personal perspective remains').toHaveLength(1);
+      if (seedUpdatedAt && personalMatches[0].updatedAt) {
+        expect(
+          new Date(personalMatches[0].updatedAt).getTime(),
+          'personal updatedAt advanced after re-save',
+        ).toBeGreaterThanOrEqual(new Date(seedUpdatedAt).getTime());
+      }
+
+      // Role A cleared; role B untouched.
+      expect(await memberSeesRole(tokenA, roleA), 'role A member no longer sees perspective').toBe(false);
+      expect(await memberSeesRole(tokenB, roleB), 'role B member still sees perspective').toBe(true);
+    } finally {
+      if (adminToken && personalId) {
+        await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/${personalId}`, { token: adminToken }).catch(() => {});
+      }
+      if (adminToken && roleBId) {
+        await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/roles/${roleBId}`, { token: adminToken }).catch(() => {});
+      }
+      await deleteUserIfExists(request, adminToken, userAId);
+      await deleteUserIfExists(request, adminToken, userBId);
+      await deleteRoleIfExists(request, adminToken, roleAId);
+      await deleteRoleIfExists(request, adminToken, roleBId);
+    }
+  });
+});

--- a/packages/core/src/modules/perspectives/__integration__/TC-PERSP-CRUD-002.spec.ts
+++ b/packages/core/src/modules/perspectives/__integration__/TC-PERSP-CRUD-002.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['perspectives'],
+};
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type SaveResponse = { perspective?: { id?: string } };
+type StateResponse = { perspectives?: Array<{ id?: string; name?: string }> };
+
+/**
+ * TC-PERSP-CRUD-002 (#2491): DELETE /api/perspectives/[tableId]/[perspectiveId] removes
+ * exactly one personal perspective and is idempotent.
+ *
+ * deleteUserPerspective() soft-deletes the matching row and returns silently when no row
+ * matches, so the route always answers { success: true } / 200 — a repeat DELETE of the
+ * same id must NOT 404. Two perspectives are created in the same table so the test can
+ * prove that exactly the targeted record is removed and its sibling is untouched.
+ */
+test.describe('TC-PERSP-CRUD-002: delete personal perspective removes exactly one record', () => {
+  test('deletes one personal perspective, leaves siblings, and is idempotent', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = Date.now();
+    const tableId = `qa-persp-crud-002-${stamp}`;
+    const keepName = `QA Keep ${stamp}`;
+    const dropName = `QA Drop ${stamp}`;
+    let keepId: string | null = null;
+    let dropId: string | null = null;
+
+    const create = async (name: string): Promise<string> => {
+      const res = await apiRequest(request, 'POST', `/api/perspectives/${encodeURIComponent(tableId)}`, {
+        token,
+        data: { name, settings: { pageSize: 20 } },
+      });
+      expect(res.status(), `create ${name}`).toBe(200);
+      const body = await readJsonSafe<SaveResponse>(res);
+      const id = body?.perspective?.id;
+      expect(typeof id === 'string' && UUID_RE.test(id), 'create returns a UUID perspective id').toBe(true);
+      return id as string;
+    };
+
+    try {
+      keepId = await create(keepName);
+      dropId = await create(dropName);
+
+      // Both present before deletion.
+      const before = await apiRequest(request, 'GET', `/api/perspectives/${encodeURIComponent(tableId)}`, { token });
+      expect(before.status()).toBe(200);
+      const beforeState = await readJsonSafe<StateResponse>(before);
+      const beforeIds = (beforeState?.perspectives ?? []).map((perspective) => perspective.id);
+      expect(beforeIds).toContain(keepId);
+      expect(beforeIds).toContain(dropId);
+
+      // Delete exactly the drop perspective.
+      const del = await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/${dropId}`, { token });
+      expect(del.status(), 'DELETE returns 200').toBe(200);
+      expect(await readJsonSafe<{ success?: boolean }>(del)).toEqual({ success: true });
+
+      // Only the drop perspective is gone; the sibling survives (exactly one removed).
+      const after = await apiRequest(request, 'GET', `/api/perspectives/${encodeURIComponent(tableId)}`, { token });
+      expect(after.status()).toBe(200);
+      const afterState = await readJsonSafe<StateResponse>(after);
+      const afterIds = (afterState?.perspectives ?? []).map((perspective) => perspective.id);
+      expect(afterIds).toContain(keepId);
+      expect(afterIds).not.toContain(dropId);
+
+      // Idempotent: deleting the same id again still returns 200 (service no-ops on missing rows).
+      const delAgain = await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/${dropId}`, { token });
+      expect(delAgain.status(), 'idempotent DELETE returns 200 (not 404)').toBe(200);
+      expect(await readJsonSafe<{ success?: boolean }>(delAgain)).toEqual({ success: true });
+      dropId = null;
+    } finally {
+      if (keepId) {
+        await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/${keepId}`, { token }).catch(() => {});
+      }
+      if (dropId) {
+        await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/${dropId}`, { token }).catch(() => {});
+      }
+    }
+  });
+});

--- a/packages/core/src/modules/perspectives/__integration__/TC-PERSP-RBAC-001.spec.ts
+++ b/packages/core/src/modules/perspectives/__integration__/TC-PERSP-RBAC-001.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['perspectives'],
+};
+
+/**
+ * TC-PERSP-RBAC-001 (#2491): the perspectives.use feature guards every perspectives route.
+ *
+ * The GET/POST handlers on /api/perspectives/[tableId] declare
+ * `metadata.requireFeatures: ['perspectives.use']`, enforced centrally by the API
+ * dispatcher (apps/mercato/src/app/api/[...slug]/route.ts -> checkAuthorization): an
+ * authenticated user missing the feature is rejected with 403 before the handler runs.
+ * A featureless custom role + user proves the boundary holds.
+ */
+test.describe('TC-PERSP-RBAC-001: perspectives.use feature is required', () => {
+  test('denies perspectives access to a user without the perspectives.use feature', async ({ request }) => {
+    test.slow();
+    const stamp = Date.now();
+    const password = 'Secret123!';
+    const email = `qa-persp-rbac-001-${stamp}@example.com`;
+    const tableId = `qa-persp-rbac-001-${stamp}`;
+
+    let adminToken: string | null = null;
+    let roleId: string | null = null;
+    let userId: string | null = null;
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      const { organizationId } = getTokenContext(adminToken);
+
+      // Featureless role + user: no perspectives.use anywhere in the ACL chain.
+      roleId = await createRoleFixture(request, adminToken, { name: `TC-PERSP-RBAC-001 Role ${stamp}` });
+      userId = await createUserFixture(request, adminToken, {
+        email,
+        password,
+        organizationId,
+        roles: [roleId],
+      });
+      const userToken = await getAuthToken(request, email, password);
+
+      // The caller is authenticated (valid token) but lacks the feature, so the dispatcher
+      // feature gate rejects with 403 before the handler runs (401 only fires for missing auth).
+      const getRes = await apiRequest(request, 'GET', `/api/perspectives/${encodeURIComponent(tableId)}`, { token: userToken });
+      expect(getRes.status(), 'GET without perspectives.use is forbidden').toBe(403);
+      const getBody = await readJsonSafe<{ error?: unknown }>(getRes);
+      expect(typeof getBody?.error === 'string' && (getBody!.error as string).length > 0, 'GET response carries an error message').toBe(true);
+
+      const postRes = await apiRequest(request, 'POST', `/api/perspectives/${encodeURIComponent(tableId)}`, {
+        token: userToken,
+        data: { name: `Blocked ${stamp}`, settings: { pageSize: 10 } },
+      });
+      expect(postRes.status(), 'POST without perspectives.use is forbidden').toBe(403);
+      const postBody = await readJsonSafe<{ error?: unknown }>(postRes);
+      expect(typeof postBody?.error === 'string' && (postBody!.error as string).length > 0, 'POST response carries an error message').toBe(true);
+    } finally {
+      await deleteUserIfExists(request, adminToken, userId);
+      await deleteRoleIfExists(request, adminToken, roleId);
+    }
+  });
+});

--- a/packages/core/src/modules/perspectives/__integration__/TC-PERSP-RBAC-002.spec.ts
+++ b/packages/core/src/modules/perspectives/__integration__/TC-PERSP-RBAC-002.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['perspectives'],
+};
+
+/**
+ * TC-PERSP-RBAC-002 (#2491): perspectives.role_defaults guards the role operations inside
+ * POST /api/perspectives/[tableId].
+ *
+ * The handler checks `rbac.userHasAllFeatures(..., ['perspectives.role_defaults'])` whenever
+ * applyToRoles/clearRoleIds are present and returns 403 with
+ * `{ requiredFeatures: ['perspectives.role_defaults'] }` if the caller lacks it — while a
+ * personal-only save (no role ops) still succeeds with just perspectives.use. The fixture
+ * user is granted only perspectives.use (mirroring the seeded employee), so it can save its
+ * own perspective but cannot push defaults onto roles.
+ */
+test.describe('TC-PERSP-RBAC-002: perspectives.role_defaults gates role operations in POST', () => {
+  test('allows personal save but blocks applyToRoles for a user lacking perspectives.role_defaults', async ({ request }) => {
+    test.slow();
+    const stamp = Date.now();
+    const password = 'Secret123!';
+    const email = `qa-persp-rbac-002-${stamp}@example.com`;
+    const tableId = `qa-persp-rbac-002-${stamp}`;
+
+    let adminToken: string | null = null;
+    let employeeRoleId: string | null = null;
+    let targetRoleId: string | null = null;
+    let userId: string | null = null;
+    let personalId: string | null = null;
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      const { organizationId } = getTokenContext(adminToken);
+
+      employeeRoleId = await createRoleFixture(request, adminToken, { name: `TC-PERSP-RBAC-002 Employee ${stamp}` });
+      targetRoleId = await createRoleFixture(request, adminToken, { name: `TC-PERSP-RBAC-002 Target ${stamp}` });
+      userId = await createUserFixture(request, adminToken, {
+        email,
+        password,
+        organizationId,
+        roles: [employeeRoleId],
+      });
+      // Grant ONLY perspectives.use (use without role_defaults).
+      await setUserAclVisibility(request, adminToken, {
+        userId,
+        features: ['perspectives.use'],
+        organizations: [organizationId],
+      });
+      const userToken = await getAuthToken(request, email, password);
+
+      // applyToRoles requires perspectives.role_defaults -> 403 naming the missing feature.
+      const denied = await apiRequest(request, 'POST', `/api/perspectives/${encodeURIComponent(tableId)}`, {
+        token: userToken,
+        data: { name: `Role Attempt ${stamp}`, settings: { pageSize: 10 }, applyToRoles: [targetRoleId] },
+      });
+      expect(denied.status(), 'applyToRoles without role_defaults must be forbidden').toBe(403);
+      const deniedBody = await readJsonSafe<{ requiredFeatures?: unknown }>(denied);
+      expect(
+        Array.isArray(deniedBody?.requiredFeatures) && (deniedBody!.requiredFeatures as string[]).includes('perspectives.role_defaults'),
+        'forbidden response names perspectives.role_defaults',
+      ).toBe(true);
+
+      // Personal-only save still works with just perspectives.use.
+      const allowed = await apiRequest(request, 'POST', `/api/perspectives/${encodeURIComponent(tableId)}`, {
+        token: userToken,
+        data: { name: `Personal OK ${stamp}`, settings: { pageSize: 10 } },
+      });
+      expect(allowed.status(), 'personal-only save succeeds with perspectives.use').toBe(200);
+      const allowedBody = await readJsonSafe<{ perspective?: { id?: string }; rolePerspectives?: unknown[] }>(allowed);
+      personalId = allowedBody?.perspective?.id ?? null;
+      expect(typeof personalId, 'personal save returns an id').toBe('string');
+      expect(allowedBody?.rolePerspectives ?? [], 'no role perspectives created on personal-only save').toEqual([]);
+    } finally {
+      if (personalId) {
+        const userToken = await getAuthToken(request, email, password).catch(() => null);
+        if (userToken) {
+          await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/${personalId}`, { token: userToken }).catch(() => {});
+        }
+      }
+      await deleteUserIfExists(request, adminToken, userId);
+      await deleteRoleIfExists(request, adminToken, employeeRoleId);
+      await deleteRoleIfExists(request, adminToken, targetRoleId);
+    }
+  });
+});

--- a/packages/core/src/modules/perspectives/__integration__/TC-PERSP-ROLE-001.spec.ts
+++ b/packages/core/src/modules/perspectives/__integration__/TC-PERSP-ROLE-001.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { createRoleFixture, deleteRoleIfExists } from '@open-mercato/core/helpers/integration/authFixtures';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['perspectives'],
+};
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type RolePerspectiveDto = { id?: string; roleId?: string; name?: string; isDefault?: boolean; settings?: Record<string, unknown> };
+type SaveResponse = { perspective?: { id?: string }; rolePerspectives?: RolePerspectiveDto[] };
+type StateResponse = { roles?: Array<{ id?: string; name?: string }>; canApplyToRoles?: boolean };
+
+/**
+ * TC-PERSP-ROLE-001 (#2491): POST applyToRoles saves a role perspective for every targeted role.
+ *
+ * Verification is via the POST response, which is the authoritative record of what the save
+ * wrote: it returns one role perspective per applied role, each carrying the shared name and
+ * settings. The GET index only surfaces role perspectives for roles the CALLER is a member of
+ * (the handler loads role state with the caller's own assignedRoleIds), so an admin who is not
+ * a member of the freshly-created target roles cannot read their perspectives through GET by
+ * design — member-scoped GET reflection of a role perspective is covered by TC-PERSP-ROLE-002.
+ * Here GET is used only to confirm the roles are exposed as assignment targets.
+ */
+test.describe('TC-PERSP-ROLE-001: applyToRoles saves a role perspective per role', () => {
+  test('saves the same configuration to every applied role and lists the roles as targets', async ({ request }) => {
+    test.slow();
+    const token = await getAuthToken(request, 'admin');
+    const stamp = Date.now();
+    const tableId = `qa-persp-role-001-${stamp}`;
+    const perspectiveName = `Shared View ${stamp}`;
+    const settings = { pageSize: 33, columnOrder: ['col-x', 'col-y'], searchValue: `needle-${stamp}` };
+
+    let viewerRoleId: string | null = null;
+    let editorRoleId: string | null = null;
+    let personalId: string | null = null;
+
+    try {
+      const viewer = await createRoleFixture(request, token, { name: `TC-PERSP-ROLE-001 Viewer ${stamp}` });
+      const editor = await createRoleFixture(request, token, { name: `TC-PERSP-ROLE-001 Editor ${stamp}` });
+      viewerRoleId = viewer;
+      editorRoleId = editor;
+
+      const saveRes = await apiRequest(request, 'POST', `/api/perspectives/${encodeURIComponent(tableId)}`, {
+        token,
+        data: { name: perspectiveName, settings, applyToRoles: [viewer, editor], setRoleDefault: true },
+      });
+      expect(saveRes.status(), 'save with applyToRoles').toBe(200);
+      const body = await readJsonSafe<SaveResponse>(saveRes);
+
+      personalId = body?.perspective?.id ?? null;
+      expect(typeof personalId === 'string' && UUID_RE.test(personalId), 'personal perspective id is a UUID').toBe(true);
+
+      const rolePerspectives = body?.rolePerspectives ?? [];
+      expect(rolePerspectives, 'one role perspective per applied role').toHaveLength(2);
+      const byRole = new Map(rolePerspectives.map((rp): [string | undefined, RolePerspectiveDto] => [rp.roleId, rp]));
+      for (const roleId of [viewer, editor]) {
+        const rolePerspective = byRole.get(roleId);
+        expect(rolePerspective, `role perspective saved for role ${roleId}`).toBeTruthy();
+        expect(rolePerspective!.name).toBe(perspectiveName);
+        expect(rolePerspective!.isDefault, 'setRoleDefault=true marks the role perspective default').toBe(true);
+        expect(rolePerspective!.settings).toMatchObject(settings);
+      }
+
+      // A role_defaults-capable admin sees both roles as assignment targets.
+      const stateRes = await apiRequest(request, 'GET', `/api/perspectives/${encodeURIComponent(tableId)}`, { token });
+      expect(stateRes.status()).toBe(200);
+      const state = await readJsonSafe<StateResponse>(stateRes);
+      expect(state?.canApplyToRoles, 'admin can apply to roles').toBe(true);
+      const roleIds = (state?.roles ?? []).map((role) => role.id);
+      expect(roleIds).toContain(viewer);
+      expect(roleIds).toContain(editor);
+    } finally {
+      if (personalId) {
+        await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/${personalId}`, { token }).catch(() => {});
+      }
+      // Clear role perspectives before removing the roles (admin holds perspectives.role_defaults).
+      if (viewerRoleId) {
+        await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/roles/${viewerRoleId}`, { token }).catch(() => {});
+      }
+      if (editorRoleId) {
+        await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/roles/${editorRoleId}`, { token }).catch(() => {});
+      }
+      await deleteRoleIfExists(request, token, viewerRoleId);
+      await deleteRoleIfExists(request, token, editorRoleId);
+    }
+  });
+});

--- a/packages/core/src/modules/perspectives/__integration__/TC-PERSP-ROLE-002.spec.ts
+++ b/packages/core/src/modules/perspectives/__integration__/TC-PERSP-ROLE-002.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['perspectives'],
+};
+
+type RolePerspectiveDto = { id?: string; roleId?: string; roleName?: string | null; name?: string };
+type SaveResponse = { rolePerspectives?: RolePerspectiveDto[] };
+type StateResponse = {
+  rolePerspectives?: RolePerspectiveDto[];
+  roles?: Array<{ id?: string; hasPerspective?: boolean }>;
+};
+
+/**
+ * TC-PERSP-ROLE-002 (#2491): DELETE /api/perspectives/[tableId]/roles/[roleId] clears every
+ * role perspective for that role.
+ *
+ * The GET index only returns role perspectives for roles the caller belongs to, so the role's
+ * state is observed through a dedicated member user assigned to the target role (granted
+ * perspectives.use). The admin performs the role-default write and the role-scoped delete
+ * (which require perspectives.role_defaults).
+ */
+test.describe('TC-PERSP-ROLE-002: delete role perspectives for a role', () => {
+  test('removes the role perspective and reflects the cleared state to a role member', async ({ request }) => {
+    test.slow();
+    const stamp = Date.now();
+    const password = 'Secret123!';
+    const memberEmail = `qa-persp-role-002-${stamp}@example.com`;
+    const tableId = `qa-persp-role-002-${stamp}`;
+    const perspectiveName = `Role View ${stamp}`;
+
+    let adminToken: string | null = null;
+    let roleId: string | null = null;
+    let memberId: string | null = null;
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      const { organizationId } = getTokenContext(adminToken);
+
+      const role = await createRoleFixture(request, adminToken, { name: `TC-PERSP-ROLE-002 Role ${stamp}` });
+      roleId = role;
+      memberId = await createUserFixture(request, adminToken, {
+        email: memberEmail,
+        password,
+        organizationId,
+        roles: [role],
+      });
+      await setUserAclVisibility(request, adminToken, {
+        userId: memberId,
+        features: ['perspectives.use'],
+        organizations: [organizationId],
+      });
+      const memberToken = await getAuthToken(request, memberEmail, password);
+
+      // Admin assigns a role perspective to the role.
+      const saveRes = await apiRequest(request, 'POST', `/api/perspectives/${encodeURIComponent(tableId)}`, {
+        token: adminToken,
+        data: { name: perspectiveName, settings: { pageSize: 25 }, applyToRoles: [role] },
+      });
+      expect(saveRes.status(), 'admin save applyToRoles').toBe(200);
+      const saveBody = await readJsonSafe<SaveResponse>(saveRes);
+      expect(saveBody?.rolePerspectives ?? [], 'one role perspective created').toHaveLength(1);
+      expect(saveBody!.rolePerspectives![0].roleId).toBe(role);
+
+      // Member sees the role perspective before the delete.
+      const before = await apiRequest(request, 'GET', `/api/perspectives/${encodeURIComponent(tableId)}`, { token: memberToken });
+      expect(before.status()).toBe(200);
+      const beforeState = await readJsonSafe<StateResponse>(before);
+      const beforeRolePerspectives = (beforeState?.rolePerspectives ?? []).filter((rp) => rp.roleId === role);
+      expect(beforeRolePerspectives, 'member sees the role perspective before delete').toHaveLength(1);
+      expect(beforeRolePerspectives[0].name).toBe(perspectiveName);
+      expect(beforeRolePerspectives[0].roleName, 'roleName populated in GET').toBeTruthy();
+      expect((beforeState?.roles ?? []).find((entry) => entry.id === role)?.hasPerspective, 'roles[].hasPerspective true before delete').toBe(true);
+
+      // Admin clears all role perspectives for the role.
+      const del = await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/roles/${role}`, { token: adminToken });
+      expect(del.status(), 'DELETE role perspectives returns 200').toBe(200);
+      expect(await readJsonSafe<{ success?: boolean }>(del)).toEqual({ success: true });
+
+      // Member no longer sees it.
+      const after = await apiRequest(request, 'GET', `/api/perspectives/${encodeURIComponent(tableId)}`, { token: memberToken });
+      expect(after.status()).toBe(200);
+      const afterState = await readJsonSafe<StateResponse>(after);
+      const afterRolePerspectives = (afterState?.rolePerspectives ?? []).filter((rp) => rp.roleId === role);
+      expect(afterRolePerspectives, 'role perspective gone after delete').toHaveLength(0);
+      expect((afterState?.roles ?? []).find((entry) => entry.id === role)?.hasPerspective, 'roles[].hasPerspective false after delete').toBe(false);
+    } finally {
+      if (adminToken && roleId) {
+        await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/roles/${roleId}`, { token: adminToken }).catch(() => {});
+      }
+      await deleteUserIfExists(request, adminToken, memberId);
+      await deleteRoleIfExists(request, adminToken, roleId);
+    }
+  });
+});

--- a/packages/core/src/modules/perspectives/__integration__/TC-PERSP-UPDATE-001.spec.ts
+++ b/packages/core/src/modules/perspectives/__integration__/TC-PERSP-UPDATE-001.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['perspectives'],
+};
+
+type SaveResponse = {
+  perspective?: { id?: string; name?: string; createdAt?: string; updatedAt?: string | null; settings?: { pageSize?: number } };
+};
+type StateResponse = { perspectives?: Array<{ id?: string; name?: string; settings?: { pageSize?: number } }> };
+
+/**
+ * TC-PERSP-UPDATE-001 (#2491): POST with perspectiveId updates the existing record in place
+ * rather than creating a duplicate.
+ *
+ * saveUserPerspective() loads the row by id when perspectiveId is supplied and mutates it, so
+ * the returned id is stable, createdAt is preserved, updatedAt advances, and the GET index
+ * still lists exactly one record for that id.
+ */
+test.describe('TC-PERSP-UPDATE-001: perspectiveId updates the existing perspective', () => {
+  test('updates name and settings on the same record without creating a duplicate', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = Date.now();
+    const tableId = `qa-persp-update-001-${stamp}`;
+    let perspectiveId: string | null = null;
+
+    try {
+      const created = await apiRequest(request, 'POST', `/api/perspectives/${encodeURIComponent(tableId)}`, {
+        token,
+        data: { name: `Original ${stamp}`, settings: { pageSize: 10 } },
+      });
+      expect(created.status(), 'create perspective').toBe(200);
+      const createdBody = await readJsonSafe<SaveResponse>(created);
+      perspectiveId = createdBody?.perspective?.id ?? null;
+      expect(typeof perspectiveId, 'create returns id').toBe('string');
+      expect(createdBody?.perspective?.settings?.pageSize).toBe(10);
+      const createdAt = createdBody?.perspective?.createdAt ?? null;
+      const firstUpdatedAt = createdBody?.perspective?.updatedAt ?? null;
+
+      const updated = await apiRequest(request, 'POST', `/api/perspectives/${encodeURIComponent(tableId)}`, {
+        token,
+        data: { perspectiveId, name: `Updated ${stamp}`, settings: { pageSize: 20 } },
+      });
+      expect(updated.status(), 'update perspective by id').toBe(200);
+      const updatedBody = await readJsonSafe<SaveResponse>(updated);
+      expect(updatedBody?.perspective?.id, 'same record id (no new row)').toBe(perspectiveId);
+      expect(updatedBody?.perspective?.name).toBe(`Updated ${stamp}`);
+      expect(updatedBody?.perspective?.settings?.pageSize).toBe(20);
+      if (createdAt) {
+        expect(updatedBody?.perspective?.createdAt, 'createdAt unchanged').toBe(createdAt);
+      }
+      if (firstUpdatedAt && updatedBody?.perspective?.updatedAt) {
+        expect(
+          new Date(updatedBody.perspective.updatedAt).getTime(),
+          'updatedAt advanced after update',
+        ).toBeGreaterThanOrEqual(new Date(firstUpdatedAt).getTime());
+      }
+
+      // Exactly one record with that id and the updated content.
+      const state = await apiRequest(request, 'GET', `/api/perspectives/${encodeURIComponent(tableId)}`, { token });
+      expect(state.status()).toBe(200);
+      const stateBody = await readJsonSafe<StateResponse>(state);
+      const matches = (stateBody?.perspectives ?? []).filter((perspective) => perspective.id === perspectiveId);
+      expect(matches, 'exactly one record with the id').toHaveLength(1);
+      expect(matches[0].name).toBe(`Updated ${stamp}`);
+      expect(matches[0].settings?.pageSize).toBe(20);
+      // The update reused the row, so this freshly-stamped table holds exactly one perspective (no duplicate).
+      expect((stateBody?.perspectives ?? []).length, 'no duplicate row created for this table').toBe(1);
+    } finally {
+      if (perspectiveId) {
+        await apiRequest(request, 'DELETE', `/api/perspectives/${encodeURIComponent(tableId)}/${perspectiveId}`, { token }).catch(() => {});
+      }
+    }
+  });
+});


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Expands integration-test coverage for the `perspectives` module (saved views) per #2491,
adding the 7 high-value scenarios it enumerates: personal-perspective DELETE, RBAC on
`perspectives.use` and `perspectives.role_defaults`, role-perspective save via `applyToRoles`,
role-perspective DELETE, `clearRoleIds`, and in-place update via `perspectiveId`. No product
code changes — these specs validate existing, stable API behavior.

Two behaviors discovered while writing the tests shaped the design: (1) GET only surfaces role
perspectives for roles the *caller* is a member of, so role writes are asserted via the
authoritative POST response and GET reflection via member users; (2) the unique constraints are
non-partial, so the specs never re-create a soft-deleted name. The second is a latent product
bug (re-creating a deleted saved view by the same name 500s) tracked separately, out of scope here.

## Changes

- Add `TC-PERSP-CRUD-002` — DELETE personal perspective removes exactly one record; idempotent (200, not 404).
- Add `TC-PERSP-RBAC-001` — missing `perspectives.use` → GET/POST return 403.
- Add `TC-PERSP-RBAC-002` — missing `perspectives.role_defaults` → `applyToRoles` 403 with `requiredFeatures`; personal-only save still 200.
- Add `TC-PERSP-ROLE-001` — `applyToRoles` saves one role perspective per role (verified via POST response).
- Add `TC-PERSP-ROLE-002` — DELETE `/roles/[roleId]` clears the role perspective (verified via a role-member GET).
- Add `TC-PERSP-CLEAR-001` — `clearRoleIds` clears only the listed role; personal + other role untouched.
- Add `TC-PERSP-UPDATE-001` — `perspectiveId` updates the existing record in place (no duplicate).
- All under `packages/core/src/modules/perspectives/__integration__/`, using `@open-mercato/core/helpers/integration/*`, fixtures via API, cleaned up in `finally`.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test-coverage task; scenarios are enumerated directly in #2491.

## Testing

List the tests or commands you ran to validate the change.

- `OM_INTEGRATION_MODULES=perspectives BASE_URL=<ephemeral> npx playwright test --config .ai/qa/tests/playwright.config.ts` → **10 passed** (7 new + 2 existing perspectives specs), run twice for idempotency on the same DB.
- `yarn turbo run typecheck --filter=@open-mercato/core` → **0 errors** (`__integration__` specs are within core's tsconfig include).
- `yarn turbo run build --filter=@open-mercato/core` → **success**; full ephemeral prod build also succeeded with the specs present.
- `yarn i18n:check-sync` → **all locales in sync**.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — test-only.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Specs live in the module's `__integration__/` folder per current convention; `.ai/qa/tests/` holds the shared Playwright config only.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec needed.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens — N/A, no UI
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` — N/A, no UI
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) — N/A, no UI
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements — N/A, no UI

## Linked issues

Fixes #2491