### PR TITLE
feat: 2492 progress integration coverage

### DIFF
--- a/packages/core/src/modules/progress/__integration__/TC-PROG-003.spec.ts
+++ b/packages/core/src/modules/progress/__integration__/TC-PROG-003.spec.ts
@@ -1,0 +1,196 @@
+import { test, expect } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  cancelProgressJob,
+  createProgressJob,
+  listProgressJobs,
+  uniqueJobName,
+  uniqueJobType,
+} from './helpers/progress'
+
+/**
+ * TC-PROG-003: List progress jobs with pagination and filtering.
+ * Covers GET /api/progress/jobs query surface: pagination, status filter
+ * (single + comma-separated union), jobType filter, name search, createdAt
+ * sorting, and the list item shape.
+ *
+ * Note on reachable statuses: the public API can only put a job into `pending`
+ * (POST) or `cancelled` (DELETE on a cancellable pending job). `running` /
+ * `completed` / `failed` are only reachable from workers via the service, so
+ * this spec exercises the filter surface with `pending` and `cancelled`.
+ * Every query is scoped by a per-run unique jobType so the assertions stay
+ * deterministic regardless of any other jobs already present in the tenant.
+ */
+test.describe('TC-PROG-003: List progress jobs with pagination and filtering', () => {
+  test('paginates a scoped set of jobs', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const jobType = uniqueJobType('qa-prog-003-page')
+    const created: string[] = []
+    try {
+      for (let index = 0; index < 5; index += 1) {
+        created.push(await createProgressJob(request, token, { jobType, name: uniqueJobName('QA Page') }))
+      }
+
+      const firstPage = await listProgressJobs(request, token, { jobType, page: 1, pageSize: 2 })
+      expect(firstPage.total).toBe(5)
+      expect(firstPage.page).toBe(1)
+      expect(firstPage.pageSize).toBe(2)
+      expect(firstPage.totalPages).toBe(3)
+      expect(firstPage.items).toHaveLength(2)
+
+      const lastPage = await listProgressJobs(request, token, { jobType, page: 3, pageSize: 2 })
+      expect(lastPage.items).toHaveLength(1)
+
+      // The three pages partition the five jobs with no overlap.
+      const secondPage = await listProgressJobs(request, token, { jobType, page: 2, pageSize: 2 })
+      const pagedIds = [...firstPage.items, ...secondPage.items, ...lastPage.items].map((job) => job.id)
+      expect(new Set(pagedIds).size).toBe(5)
+      expect(new Set(pagedIds)).toEqual(new Set(created))
+    } finally {
+      for (const id of created) await cancelProgressJob(request, token, id)
+    }
+  })
+
+  test('filters by single status and by a comma-separated union', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const jobType = uniqueJobType('qa-prog-003-status')
+    const created: string[] = []
+    try {
+      for (let index = 0; index < 4; index += 1) {
+        created.push(await createProgressJob(request, token, { jobType, name: uniqueJobName('QA Status') }))
+      }
+      // Cancel two so the set spans both reachable statuses.
+      const cancelled = [created[0], created[1]]
+      for (const id of cancelled) await cancelProgressJob(request, token, id)
+      const stillPending = [created[2], created[3]]
+
+      const pendingOnly = await listProgressJobs(request, token, { jobType, status: 'pending', pageSize: 100 })
+      expect(pendingOnly.items.every((job) => job.status === 'pending')).toBe(true)
+      expect(new Set(pendingOnly.items.map((job) => job.id))).toEqual(new Set(stillPending))
+
+      const cancelledOnly = await listProgressJobs(request, token, { jobType, status: 'cancelled', pageSize: 100 })
+      expect(cancelledOnly.items.every((job) => job.status === 'cancelled')).toBe(true)
+      expect(new Set(cancelledOnly.items.map((job) => job.id))).toEqual(new Set(cancelled))
+
+      const union = await listProgressJobs(request, token, { jobType, status: 'pending,cancelled', pageSize: 100 })
+      expect(new Set(union.items.map((job) => job.id))).toEqual(new Set(created))
+
+      // No status param defaults to active-only (pending|running), so cancelled jobs drop out.
+      const defaultView = await listProgressJobs(request, token, { jobType, pageSize: 100 })
+      expect(new Set(defaultView.items.map((job) => job.id))).toEqual(new Set(stillPending))
+    } finally {
+      for (const id of created) await cancelProgressJob(request, token, id)
+    }
+  })
+
+  test('filters by jobType', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const jobTypeA = uniqueJobType('qa-prog-003-typea')
+    const jobTypeB = uniqueJobType('qa-prog-003-typeb')
+    const created: string[] = []
+    try {
+      const aIds = [
+        await createProgressJob(request, token, { jobType: jobTypeA, name: uniqueJobName('QA TypeA') }),
+        await createProgressJob(request, token, { jobType: jobTypeA, name: uniqueJobName('QA TypeA') }),
+      ]
+      const bId = await createProgressJob(request, token, { jobType: jobTypeB, name: uniqueJobName('QA TypeB') })
+      created.push(...aIds, bId)
+
+      const onlyB = await listProgressJobs(request, token, { jobType: jobTypeB, pageSize: 100 })
+      expect(onlyB.items.every((job) => job.jobType === jobTypeB)).toBe(true)
+      expect(onlyB.items.map((job) => job.id)).toContain(bId)
+
+      const onlyA = await listProgressJobs(request, token, { jobType: jobTypeA, pageSize: 100 })
+      expect(onlyA.items.every((job) => job.jobType === jobTypeA)).toBe(true)
+      expect(onlyA.items.map((job) => job.id)).not.toContain(bId)
+    } finally {
+      for (const id of created) await cancelProgressJob(request, token, id)
+    }
+  })
+
+  test('searches by name case-insensitively', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const jobType = uniqueJobType('qa-prog-003-search')
+    const nameToken = `QA003Search${Date.now()}`
+    const created: string[] = []
+    try {
+      created.push(await createProgressJob(request, token, { jobType, name: `${nameToken} Alpha` }))
+      created.push(await createProgressJob(request, token, { jobType, name: `${nameToken} Bravo` }))
+
+      const exact = await listProgressJobs(request, token, { search: nameToken, pageSize: 100 })
+      const exactIds = new Set(exact.items.map((job) => job.id))
+      for (const id of created) expect(exactIds.has(id)).toBe(true)
+
+      // ILIKE search is case-insensitive: lowercased token still matches.
+      const lowered = await listProgressJobs(request, token, { search: nameToken.toLowerCase(), pageSize: 100 })
+      const loweredIds = new Set(lowered.items.map((job) => job.id))
+      for (const id of created) expect(loweredIds.has(id)).toBe(true)
+    } finally {
+      for (const id of created) await cancelProgressJob(request, token, id)
+    }
+  })
+
+  test('sorts by createdAt ascending and descending', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const jobType = uniqueJobType('qa-prog-003-sort')
+    const created: string[] = []
+    try {
+      for (let index = 0; index < 3; index += 1) {
+        created.push(await createProgressJob(request, token, { jobType, name: uniqueJobName('QA Sort') }))
+      }
+
+      const ascending = await listProgressJobs(request, token, {
+        jobType,
+        sortField: 'createdAt',
+        sortDir: 'asc',
+        pageSize: 100,
+      })
+      const ascTimes = ascending.items.map((job) => new Date(job.createdAt ?? 0).getTime())
+      for (let index = 1; index < ascTimes.length; index += 1) {
+        expect(ascTimes[index]).toBeGreaterThanOrEqual(ascTimes[index - 1])
+      }
+
+      const descending = await listProgressJobs(request, token, {
+        jobType,
+        sortField: 'createdAt',
+        sortDir: 'desc',
+        pageSize: 100,
+      })
+      const descTimes = descending.items.map((job) => new Date(job.createdAt ?? 0).getTime())
+      for (let index = 1; index < descTimes.length; index += 1) {
+        expect(descTimes[index]).toBeLessThanOrEqual(descTimes[index - 1])
+      }
+
+      expect(new Set(ascending.items.map((job) => job.id))).toEqual(new Set(created))
+    } finally {
+      for (const id of created) await cancelProgressJob(request, token, id)
+    }
+  })
+
+  test('returns the documented job fields', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const jobType = uniqueJobType('qa-prog-003-shape')
+    let jobId: string | null = null
+    try {
+      jobId = await createProgressJob(request, token, { jobType, name: uniqueJobName('QA Shape'), totalCount: 50 })
+
+      const result = await listProgressJobs(request, token, { jobType, pageSize: 100 })
+      const job = result.items.find((item) => item.id === jobId)
+      expect(job, 'created job should be present in the list').toBeTruthy()
+      if (!job) return
+
+      expect(typeof job.id).toBe('string')
+      expect(job.jobType).toBe(jobType)
+      expect(typeof job.name).toBe('string')
+      expect(job.status).toBe('pending')
+      expect(typeof job.progressPercent).toBe('number')
+      expect(typeof job.processedCount).toBe('number')
+      expect(job.totalCount).toBe(50)
+      expect(typeof job.cancellable).toBe('boolean')
+      expect(typeof job.createdAt).toBe('string')
+      expect(typeof job.tenantId).toBe('string')
+    } finally {
+      await cancelProgressJob(request, token, jobId)
+    }
+  })
+})

--- a/packages/core/src/modules/progress/__integration__/TC-PROG-004.spec.ts
+++ b/packages/core/src/modules/progress/__integration__/TC-PROG-004.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  PROGRESS_ACTIVE_PATH,
+  PROGRESS_JOBS_PATH,
+  cancelProgressJob,
+  createProgressJob,
+  createProgressUserWithFeatures,
+  deleteProgressUser,
+  progressJobPath,
+  type RestrictedProgressUser,
+} from './helpers/progress'
+
+/**
+ * TC-PROG-004: Read-access RBAC contract for the progress GET endpoints.
+ *
+ * The issue proposed that a missing `progress.view` feature blocks list/detail
+ * access. That does NOT match the implementation: `GET /api/progress/jobs`,
+ * `/api/progress/active`, and `/api/progress/jobs/:id` declare `requireAuth`
+ * only (no `requireFeatures`) — reads are gated by authentication, not by a
+ * feature. The write endpoints ARE feature-gated; that is covered by
+ * TC-PROG-005/006/007. This spec locks in the real read contract so a future
+ * change to read gating is a deliberate, visible decision.
+ */
+async function getUnauthenticated(request: APIRequestContext, path: string) {
+  return request.fetch(path, { method: 'GET', headers: { 'Content-Type': 'application/json' } })
+}
+
+test.describe('TC-PROG-004: Progress reads are auth-gated, not feature-gated', () => {
+  test('rejects unauthenticated reads with 401', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let jobId: string | null = null
+    try {
+      jobId = await createProgressJob(request, token)
+
+      expect((await getUnauthenticated(request, PROGRESS_JOBS_PATH)).status()).toBe(401)
+      expect((await getUnauthenticated(request, PROGRESS_ACTIVE_PATH)).status()).toBe(401)
+      expect((await getUnauthenticated(request, progressJobPath(jobId))).status()).toBe(401)
+    } finally {
+      await cancelProgressJob(request, token, jobId)
+    }
+  })
+
+  test('allows an authenticated user without progress features to read list, active, and detail', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    let restricted: RestrictedProgressUser | null = null
+    let jobId: string | null = null
+    try {
+      jobId = await createProgressJob(request, adminToken)
+      restricted = await createProgressUserWithFeatures(request, adminToken, [], 'reader')
+
+      const listRes = await apiRequest(request, 'GET', PROGRESS_JOBS_PATH, { token: restricted.token })
+      expect(listRes.status(), 'list is readable without progress features').toBe(200)
+
+      const activeRes = await apiRequest(request, 'GET', PROGRESS_ACTIVE_PATH, { token: restricted.token })
+      expect(activeRes.status(), 'active is readable without progress features').toBe(200)
+
+      const detailRes = await apiRequest(request, 'GET', progressJobPath(jobId), { token: restricted.token })
+      expect(detailRes.status(), 'detail is readable without progress features').toBe(200)
+    } finally {
+      await cancelProgressJob(request, adminToken, jobId)
+      await deleteProgressUser(request, adminToken, restricted)
+    }
+  })
+})

--- a/packages/core/src/modules/progress/__integration__/TC-PROG-005.spec.ts
+++ b/packages/core/src/modules/progress/__integration__/TC-PROG-005.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  PROGRESS_FEATURES,
+  PROGRESS_JOBS_PATH,
+  cancelProgressJob,
+  createProgressJob,
+  createProgressUserWithFeatures,
+  deleteProgressUser,
+  listProgressJobs,
+  uniqueJobType,
+  type RestrictedProgressUser,
+} from './helpers/progress'
+
+/**
+ * TC-PROG-005: `progress.create` gates job creation.
+ * A user with `progress.view` but not `progress.create` is denied POST (403),
+ * no job is persisted, and an admin (progress.*) can still create.
+ */
+test.describe('TC-PROG-005: progress.create gates job creation', () => {
+  test('denies POST without progress.create and creates nothing', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    let restricted: RestrictedProgressUser | null = null
+    let adminJobId: string | null = null
+    const deniedJobType = uniqueJobType('qa-prog-005-denied')
+    try {
+      restricted = await createProgressUserWithFeatures(request, adminToken, [PROGRESS_FEATURES.view], 'no-create')
+
+      const deniedRes = await apiRequest(request, 'POST', PROGRESS_JOBS_PATH, {
+        token: restricted.token,
+        data: { jobType: deniedJobType, name: 'should not be created', cancellable: true },
+      })
+      expect(deniedRes.status(), 'POST without progress.create is forbidden').toBe(403)
+      const deniedBody = await readJsonSafe<{ requiredFeatures?: string[] }>(deniedRes)
+      expect(deniedBody?.requiredFeatures ?? []).toContain(PROGRESS_FEATURES.create)
+
+      // Nothing was persisted for the denied attempt.
+      const persisted = await listProgressJobs(request, adminToken, { jobType: deniedJobType, status: 'pending,cancelled', pageSize: 100 })
+      expect(persisted.items).toHaveLength(0)
+
+      // Admin retains create access.
+      adminJobId = await createProgressJob(request, adminToken, { jobType: uniqueJobType('qa-prog-005-allowed') })
+      expect(adminJobId).toBeTruthy()
+    } finally {
+      await cancelProgressJob(request, adminToken, adminJobId)
+      await deleteProgressUser(request, adminToken, restricted)
+    }
+  })
+})

--- a/packages/core/src/modules/progress/__integration__/TC-PROG-006.spec.ts
+++ b/packages/core/src/modules/progress/__integration__/TC-PROG-006.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  PROGRESS_FEATURES,
+  cancelProgressJob,
+  createProgressJob,
+  createProgressUserWithFeatures,
+  deleteProgressUser,
+  progressJobPath,
+  type RestrictedProgressUser,
+} from './helpers/progress'
+
+/**
+ * TC-PROG-006: `progress.update` gates progress updates.
+ * A user with `progress.view` but not `progress.update` is denied PUT (403),
+ * the job is left untouched, and an admin can still update.
+ */
+test.describe('TC-PROG-006: progress.update gates progress updates', () => {
+  test('denies PUT without progress.update and leaves the job unchanged', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    let restricted: RestrictedProgressUser | null = null
+    let jobId: string | null = null
+    try {
+      jobId = await createProgressJob(request, adminToken, { totalCount: 10 })
+      restricted = await createProgressUserWithFeatures(request, adminToken, [PROGRESS_FEATURES.view], 'no-update')
+
+      const deniedRes = await apiRequest(request, 'PUT', progressJobPath(jobId), {
+        token: restricted.token,
+        data: { processedCount: 5, totalCount: 10 },
+      })
+      expect(deniedRes.status(), 'PUT without progress.update is forbidden').toBe(403)
+      const deniedBody = await readJsonSafe<{ requiredFeatures?: string[] }>(deniedRes)
+      expect(deniedBody?.requiredFeatures ?? []).toContain(PROGRESS_FEATURES.update)
+
+      // The job was not advanced by the forbidden request.
+      const afterDenied = await apiRequest(request, 'GET', progressJobPath(jobId), { token: adminToken })
+      const afterDeniedBody = await readJsonSafe<{ processedCount?: number; progressPercent?: number }>(afterDenied)
+      expect(afterDeniedBody?.processedCount).toBe(0)
+      expect(afterDeniedBody?.progressPercent).toBe(0)
+
+      // Admin retains update access.
+      const allowedRes = await apiRequest(request, 'PUT', progressJobPath(jobId), {
+        token: adminToken,
+        data: { processedCount: 5, totalCount: 10 },
+      })
+      expect(allowedRes.status()).toBe(200)
+      const allowedBody = await readJsonSafe<{ ok?: boolean; progressPercent?: number }>(allowedRes)
+      expect(allowedBody?.ok).toBe(true)
+      expect(allowedBody?.progressPercent).toBe(50)
+    } finally {
+      await cancelProgressJob(request, adminToken, jobId)
+      await deleteProgressUser(request, adminToken, restricted)
+    }
+  })
+})

--- a/packages/core/src/modules/progress/__integration__/TC-PROG-007.spec.ts
+++ b/packages/core/src/modules/progress/__integration__/TC-PROG-007.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  PROGRESS_FEATURES,
+  cancelProgressJob,
+  createProgressJob,
+  createProgressUserWithFeatures,
+  deleteProgressUser,
+  progressJobPath,
+  type RestrictedProgressUser,
+} from './helpers/progress'
+
+/**
+ * TC-PROG-007: `progress.cancel` gates job cancellation.
+ * A user with `progress.view` but not `progress.cancel` is denied DELETE (403),
+ * the job stays pending, and an admin can still cancel (status -> cancelled).
+ */
+test.describe('TC-PROG-007: progress.cancel gates job cancellation', () => {
+  test('denies DELETE without progress.cancel and leaves the job cancellable', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    let restricted: RestrictedProgressUser | null = null
+    let jobId: string | null = null
+    try {
+      jobId = await createProgressJob(request, adminToken, { cancellable: true })
+      restricted = await createProgressUserWithFeatures(request, adminToken, [PROGRESS_FEATURES.view], 'no-cancel')
+
+      const deniedRes = await apiRequest(request, 'DELETE', progressJobPath(jobId), { token: restricted.token })
+      expect(deniedRes.status(), 'DELETE without progress.cancel is forbidden').toBe(403)
+      const deniedBody = await readJsonSafe<{ requiredFeatures?: string[] }>(deniedRes)
+      expect(deniedBody?.requiredFeatures ?? []).toContain(PROGRESS_FEATURES.cancel)
+
+      // The job was not cancelled by the forbidden request.
+      const afterDenied = await apiRequest(request, 'GET', progressJobPath(jobId), { token: adminToken })
+      const afterDeniedBody = await readJsonSafe<{ status?: string }>(afterDenied)
+      expect(afterDeniedBody?.status).toBe('pending')
+
+      // Admin retains cancel access; a pending cancellable job cancels immediately.
+      const allowedRes = await apiRequest(request, 'DELETE', progressJobPath(jobId), { token: adminToken })
+      expect(allowedRes.status()).toBe(200)
+      const allowedBody = await readJsonSafe<{ ok?: boolean }>(allowedRes)
+      expect(allowedBody?.ok).toBe(true)
+
+      const afterCancel = await apiRequest(request, 'GET', progressJobPath(jobId), { token: adminToken })
+      const afterCancelBody = await readJsonSafe<{ status?: string }>(afterCancel)
+      expect(afterCancelBody?.status).toBe('cancelled')
+    } finally {
+      await cancelProgressJob(request, adminToken, jobId)
+      await deleteProgressUser(request, adminToken, restricted)
+    }
+  })
+})

--- a/packages/core/src/modules/progress/__integration__/TC-PROG-008.spec.ts
+++ b/packages/core/src/modules/progress/__integration__/TC-PROG-008.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { PROGRESS_JOBS_PATH, cancelProgressJob, uniqueJobName, uniqueJobType } from './helpers/progress'
+
+type CreateError = { error?: string; details?: { fieldErrors?: Record<string, string[]> } }
+
+/**
+ * TC-PROG-008: Invalid create requests return 400 with field-level details,
+ * unknown fields are stripped (still 201), and valid requests create a job.
+ */
+test.describe('TC-PROG-008: progress job creation input validation', () => {
+  test('rejects invalid payloads and accepts valid ones', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const createdIds: string[] = []
+    try {
+      const post = (data: unknown) => apiRequest(request, 'POST', PROGRESS_JOBS_PATH, { token, data })
+
+      // Missing jobType -> 400 with a flattened field error.
+      const missingType = await post({ name: uniqueJobName('QA Missing Type') })
+      expect(missingType.status()).toBe(400)
+      const missingTypeBody = await readJsonSafe<CreateError>(missingType)
+      expect(missingTypeBody?.error).toBe('Invalid input')
+      expect(missingTypeBody?.details?.fieldErrors?.jobType?.length ?? 0).toBeGreaterThan(0)
+
+      // jobType longer than 100 chars -> 400.
+      const longType = await post({ jobType: 'a'.repeat(101), name: uniqueJobName('QA Long Type') })
+      expect(longType.status()).toBe(400)
+      expect((await readJsonSafe<CreateError>(longType))?.details?.fieldErrors?.jobType?.length ?? 0).toBeGreaterThan(0)
+
+      // Missing name -> 400.
+      const missingName = await post({ jobType: uniqueJobType('qa-prog-008') })
+      expect(missingName.status()).toBe(400)
+      expect((await readJsonSafe<CreateError>(missingName))?.details?.fieldErrors?.name?.length ?? 0).toBeGreaterThan(0)
+
+      // Negative totalCount -> 400 (schema requires a positive integer).
+      const negativeTotal = await post({
+        jobType: uniqueJobType('qa-prog-008'),
+        name: uniqueJobName('QA Negative Total'),
+        totalCount: -5,
+      })
+      expect(negativeTotal.status()).toBe(400)
+      expect((await readJsonSafe<CreateError>(negativeTotal))?.details?.fieldErrors?.totalCount?.length ?? 0).toBeGreaterThan(0)
+
+      // Valid payload with an unknown field -> 201, unknown field ignored.
+      const extraField = await post({
+        jobType: uniqueJobType('qa-prog-008'),
+        name: uniqueJobName('QA Extra Field'),
+        cancellable: true,
+        bogusUnknownField: 'ignored',
+      })
+      expect(extraField.status()).toBe(201)
+      const extraId = (await readJsonSafe<{ id?: string }>(extraField))?.id
+      expect(typeof extraId).toBe('string')
+      if (extraId) createdIds.push(extraId)
+
+      // Plain valid payload -> 201.
+      const valid = await post({
+        jobType: uniqueJobType('qa-prog-008'),
+        name: uniqueJobName('QA Valid'),
+        cancellable: true,
+      })
+      expect(valid.status()).toBe(201)
+      const validId = (await readJsonSafe<{ id?: string }>(valid))?.id
+      expect(typeof validId).toBe('string')
+      if (validId) createdIds.push(validId)
+    } finally {
+      for (const id of createdIds) await cancelProgressJob(request, token, id)
+    }
+  })
+})

--- a/packages/core/src/modules/progress/__integration__/TC-PROG-009.spec.ts
+++ b/packages/core/src/modules/progress/__integration__/TC-PROG-009.spec.ts
@@ -1,0 +1,38 @@
+import { randomUUID } from 'node:crypto'
+import { test, expect } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { progressJobPath } from './helpers/progress'
+
+/**
+ * TC-PROG-009: Accessing a nonexistent job returns clean client errors, never
+ * a 500 with a leaked stack.
+ *   - GET    -> 404 { error: 'Not found' }
+ *   - PUT    -> 404 { error: 'Not found' }            (service not-found is mapped, not surfaced as 500)
+ *   - DELETE -> 400 { error: 'Cannot cancel this job' } (cancel guard rejects unknown jobs)
+ */
+test.describe('TC-PROG-009: nonexistent progress job returns clean not-found errors', () => {
+  test('GET / PUT / DELETE on an unknown job id are 4xx with no stack leak', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const missingId = randomUUID()
+    const path = progressJobPath(missingId)
+
+    const getRes = await apiRequest(request, 'GET', path, { token })
+    expect(getRes.status()).toBe(404)
+    const getBody = await readJsonSafe<{ error?: string; stack?: unknown }>(getRes)
+    expect(getBody?.error).toBe('Not found')
+    expect(getBody).not.toHaveProperty('stack')
+
+    const putRes = await apiRequest(request, 'PUT', path, { token, data: { processedCount: 1 } })
+    expect(putRes.status(), 'PUT on a missing job must not 500').toBe(404)
+    const putBody = await readJsonSafe<{ error?: string; stack?: unknown }>(putRes)
+    expect(putBody?.error).toBe('Not found')
+    expect(putBody).not.toHaveProperty('stack')
+
+    const deleteRes = await apiRequest(request, 'DELETE', path, { token })
+    expect(deleteRes.status()).toBe(400)
+    const deleteBody = await readJsonSafe<{ error?: string; stack?: unknown }>(deleteRes)
+    expect(deleteBody?.error).toBe('Cannot cancel this job')
+    expect(deleteBody).not.toHaveProperty('stack')
+  })
+})

--- a/packages/core/src/modules/progress/__integration__/helpers/progress.ts
+++ b/packages/core/src/modules/progress/__integration__/helpers/progress.ts
@@ -1,0 +1,176 @@
+import { expect, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { expectId, getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+
+export const PROGRESS_JOBS_PATH = '/api/progress/jobs'
+export const PROGRESS_ACTIVE_PATH = '/api/progress/active'
+export const progressJobPath = (id: string): string => `${PROGRESS_JOBS_PATH}/${id}`
+
+/** Feature ids declared in the progress module's `acl.ts`. */
+export const PROGRESS_FEATURES = {
+  view: 'progress.view',
+  create: 'progress.create',
+  update: 'progress.update',
+  cancel: 'progress.cancel',
+} as const
+
+/** Shape returned by `GET /api/progress/jobs` list items (`api/jobs/route.ts` → `toRow`). */
+export type ProgressJobListItem = {
+  id: string
+  jobType: string
+  name: string
+  description: string | null
+  status: string
+  progressPercent: number
+  processedCount: number
+  totalCount: number | null
+  etaSeconds: number | null
+  cancellable: boolean
+  startedAt: string | null
+  finishedAt: string | null
+  errorMessage: string | null
+  createdAt: string | null
+  tenantId: string
+  organizationId: string | null
+}
+
+export type ProgressListResponse = {
+  items: ProgressJobListItem[]
+  total: number
+  page: number
+  pageSize: number
+  totalPages: number
+}
+
+export type CreateProgressJobOverrides = {
+  jobType?: string
+  name?: string
+  description?: string
+  totalCount?: number
+  cancellable?: boolean
+  meta?: Record<string, unknown>
+}
+
+let sequence = 0
+
+/** Unique-enough job type so a run's fixtures never collide with prior runs or other tests. */
+export function uniqueJobType(prefix: string): string {
+  sequence += 1
+  return `${prefix}-${Date.now()}-${sequence}`
+}
+
+/** Unique-enough job name token usable for search assertions. */
+export function uniqueJobName(prefix: string): string {
+  sequence += 1
+  return `${prefix} ${Date.now()}-${sequence}`
+}
+
+/** Create a progress job via the API and return its id. Defaults to cancellable so teardown can cancel it. */
+export async function createProgressJob(
+  request: APIRequestContext,
+  token: string,
+  overrides: CreateProgressJobOverrides = {},
+): Promise<string> {
+  const data: Record<string, unknown> = {
+    jobType: overrides.jobType ?? uniqueJobType('qa-progress'),
+    name: overrides.name ?? uniqueJobName('QA Progress Job'),
+    cancellable: overrides.cancellable ?? true,
+  }
+  if (overrides.description !== undefined) data.description = overrides.description
+  if (overrides.totalCount !== undefined) data.totalCount = overrides.totalCount
+  if (overrides.meta !== undefined) data.meta = overrides.meta
+
+  const response = await apiRequest(request, 'POST', PROGRESS_JOBS_PATH, { token, data })
+  const body = await readJsonSafe<{ id?: string }>(response)
+  expect(response.status(), 'POST /api/progress/jobs should return 201').toBe(201)
+  return expectId(body?.id, 'Job creation response should include id')
+}
+
+/** List progress jobs with arbitrary query params; asserts 200 and returns the parsed body. */
+export async function listProgressJobs(
+  request: APIRequestContext,
+  token: string,
+  query: Record<string, string | number | undefined> = {},
+): Promise<ProgressListResponse> {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined) params.set(key, String(value))
+  }
+  const queryString = params.toString()
+  const path = queryString ? `${PROGRESS_JOBS_PATH}?${queryString}` : PROGRESS_JOBS_PATH
+
+  const response = await apiRequest(request, 'GET', path, { token })
+  expect(response.status(), `GET ${path} should return 200`).toBe(200)
+  const body = await readJsonSafe<ProgressListResponse>(response)
+  expect(body, 'progress list response should be JSON').not.toBeNull()
+  return body as ProgressListResponse
+}
+
+/** Best-effort cancellation used in teardown. Swallows errors so it never masks the real assertion. */
+export async function cancelProgressJob(
+  request: APIRequestContext,
+  token: string | null,
+  id: string | null,
+): Promise<void> {
+  if (!token || !id) return
+  await apiRequest(request, 'DELETE', progressJobPath(id), { token }).catch(() => undefined)
+}
+
+export type RestrictedProgressUser = {
+  token: string
+  userId: string
+  roleId: string
+  email: string
+}
+
+// Password policy requires upper + lower + digit + special; the seeded "secret" is too weak for the users API.
+const RESTRICTED_USER_PASSWORD = 'QaProgress1!'
+
+/**
+ * Provision a fresh user whose single custom role grants exactly `features`, then log in as them.
+ * Org/tenant are taken from the admin caller so the user lands in the same scope as the fixtures.
+ */
+export async function createProgressUserWithFeatures(
+  request: APIRequestContext,
+  adminToken: string,
+  features: string[],
+  labelPrefix: string,
+): Promise<RestrictedProgressUser> {
+  const { organizationId } = getTokenContext(adminToken)
+  sequence += 1
+  const suffix = `${Date.now()}-${sequence}`
+  const slug = labelPrefix.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+
+  const roleId = await createRoleFixture(request, adminToken, { name: `qa-progress ${labelPrefix} ${suffix}` })
+  await setRoleAclFeatures(request, adminToken, { roleId, features })
+
+  const email = `qa-progress-${slug}-${suffix}@qa.example.com`
+  const userId = await createUserFixture(request, adminToken, {
+    email,
+    password: RESTRICTED_USER_PASSWORD,
+    organizationId,
+    roles: [roleId],
+    name: `QA Progress ${labelPrefix} ${suffix}`,
+  })
+
+  const token = await getAuthToken(request, email, RESTRICTED_USER_PASSWORD)
+  return { token, userId, roleId, email }
+}
+
+/** Tear down a user created by {@link createProgressUserWithFeatures}; user first, then its role. */
+export async function deleteProgressUser(
+  request: APIRequestContext,
+  adminToken: string | null,
+  user: { userId?: string | null; roleId?: string | null } | null,
+): Promise<void> {
+  if (!adminToken || !user) return
+  await deleteUserIfExists(request, adminToken, user.userId ?? null)
+  await deleteRoleIfExists(request, adminToken, user.roleId ?? null)
+}

--- a/packages/core/src/modules/progress/api/jobs/[id]/route.ts
+++ b/packages/core/src/modules/progress/api/jobs/[id]/route.ts
@@ -73,6 +73,12 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
   }
 
   const container = await createRequestContainer()
+  const em = container.resolve('em') as EntityManager
+  const existing = await em.findOne(ProgressJob, { id: params.id, tenantId: auth.tenantId })
+  if (!existing) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
   const progressService = container.resolve('progressService') as ProgressService
 
   const job = await progressService.updateProgress(params.id, parsed.data, {
@@ -122,6 +128,7 @@ export const openApi = {
     responses: {
       200: { description: 'Progress updated' },
       400: { description: 'Invalid input' },
+      404: { description: 'Job not found' },
     },
   },
   DELETE: {


### PR DESCRIPTION
## Summary

Expands integration-test coverage for the `progress` module (issue #2492) and fixes a
latent defect surfaced while grounding the scenarios against the live API: `PUT
/api/progress/jobs/:id` on a nonexistent job returned **HTTP 500** (the handler called
`updateProgress` → `em.findOneOrFail` with no error handling) instead of a clean
not-found. It now returns **404 `{ error: 'Not found' }`**, mirroring the GET handler in
the same route file.

Adds executable Playwright specs TC-PROG-003..009 covering the list query surface,
RBAC enforcement, input validation, and not-found error paths — all asserted against the
module's actual route/validator/guard behavior (verified empirically, not assumed).

## Changes

- fix(progress): `PUT /api/progress/jobs/:id` returns a tenant-scoped 404 on a missing
  job instead of 500 (`api/jobs/[id]/route.ts`); document 404 in the PUT openApi responses.
- test(progress): add `__integration__/TC-PROG-003.spec.ts` — list pagination, status
  filter (single + comma-separated union), jobType filter, case-insensitive name search,
  createdAt sorting, and list-item shape.
- test(progress): add TC-PROG-005/006/007 — `progress.create`/`update`/`cancel` gates
  return 403 for a role lacking the feature, leave state untouched, and admin still succeeds.
- test(progress): add TC-PROG-004 — read endpoints are auth-gated only (401 unauth; an
  authed user with no progress features can still read). Note: the issue's proposed
  `progress.view`-gates-reads premise does not match the implementation; the GET routes
  declare `requireAuth` only, so this documents the real contract rather than adding a gate.
- test(progress): add TC-PROG-008 (input validation: 400 + field errors; unknown field
  stripped → 201) and TC-PROG-009 (GET 404 / PUT 404 / DELETE 400, no stack leak).
- test(progress): add `__integration__/helpers/progress.ts` (job + restricted-user fixtures).

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test-coverage addition + a small not-found fix on an existing module; issue #2492 is the source of record.

## Testing

Run against an isolated, seeded dev server (`yarn dev:app --database-name=… ` + `yarn initialize`, `BASE_URL=…`):

- `yarn typecheck` — ✅ 21/21 packages
- `yarn test` — ✅ 634 suites / 5274 unit tests, no regressions
- `yarn build:packages` — ✅ 21/21
- `yarn build:app` — ✅
- `yarn generate` — ✅ no generated drift
- `yarn i18n:check-sync` — ✅ all locales in sync
- `npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/progress/__integration__` — ✅ 15/15 (13 new + pre-existing TC-001/002)
- Note: `yarn lint` fails with a pre-existing ESLint 10.4.1 engine crash (`scopeManager.addGlobals is not a function`) in `@open-mercato/app`, unrelated to this change (all changed files are in `packages/core`).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (Updated PUT openApi to document 404; no locale/generator changes required.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Per current convention specs live module-local in `packages/core/src/modules/progress/__integration__/`; `.ai/qa/tests/` holds config only.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec required for test-coverage + minor fix.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2492