### PR TITLE
feat: 2489 shipping carriers integration coverage

### DIFF
--- a/apps/mercato/src/modules/example/lib/mock-shipping-adapter.ts
+++ b/apps/mercato/src/modules/example/lib/mock-shipping-adapter.ts
@@ -9,6 +9,8 @@ import type {
   TrackingResult,
   ShippingWebhookEvent,
   UnifiedShipmentStatus,
+  DropOffPoint,
+  SearchDropOffPointsInput,
 } from '@open-mercato/core/modules/shipping_carriers/lib/adapter'
 
 /**
@@ -209,5 +211,36 @@ export const mockShippingAdapter: ShippingAdapter = {
       cancelled: 'cancelled',
     }
     return map[carrierStatus] ?? 'unknown'
+  },
+
+  async searchDropOffPoints(input: SearchDropOffPointsInput): Promise<DropOffPoint[]> {
+    const postalCode = typeof input.postCode === 'string' && input.postCode.trim().length > 0
+      ? input.postCode.trim()
+      : '10001'
+    const pointType = typeof input.type === 'string' && input.type.trim().length > 0
+      ? input.type.trim()
+      : 'locker'
+    return [
+      {
+        id: 'MOCK-POP-001',
+        name: 'Mock Locker - Main Street',
+        type: pointType,
+        city: 'New York',
+        postalCode,
+        street: '100 Main Street',
+        latitude: 40.7128,
+        longitude: -74.006,
+      },
+      {
+        id: 'MOCK-POP-002',
+        name: 'Mock Pickup Point - Market Square',
+        type: pointType,
+        city: 'New York',
+        postalCode,
+        street: '250 Market Square',
+        latitude: 40.7138,
+        longitude: -74.001,
+      },
+    ]
   },
 }

--- a/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-009.spec.ts
+++ b/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-009.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import { deleteUserAclInDb } from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { createShipment } from './helpers/fixtures'
+
+/**
+ * TC-SHIP-009: RBAC enforcement — `shipping_carriers.view` is required to read.
+ *
+ * The read endpoints (`/tracking`, `/points`) declare
+ * `requireFeatures: ['shipping_carriers.view']`. A logged-in user whose
+ * effective features do NOT include it must receive 403 Forbidden (not 401, not
+ * 502) — the feature gate runs in the catch-all API route before the handler,
+ * so no adapter is ever invoked.
+ *
+ * ENVIRONMENT: mixes API fixtures (hit the app) with a DB-level ACL cleanup
+ * (raw `pg` against `DATABASE_URL`). Run under a coherent app+DB stack (the
+ * `yarn test:integration` / `yarn test:integration:ephemeral` harness).
+ */
+test.describe('TC-SHIP-009: RBAC — view feature required for tracking and points', () => {
+  test('denies tracking and points for a user without shipping_carriers.view (403)', async ({ request }) => {
+    const stamp = Date.now()
+    const password = 'Secret123!'
+    const userEmail = `tc-ship-009-${stamp}@example.com`
+
+    let adminToken: string | null = null
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      adminToken = await getAuthToken(request, 'admin')
+      const { organizationId, tenantId } = getTokenScope(adminToken)
+      expect(organizationId, 'admin token should carry an organization id').toBeTruthy()
+      expect(tenantId, 'admin token should carry a tenant id').toBeTruthy()
+
+      roleId = await createRoleFixture(request, adminToken, { name: `TC-SHIP-009 No-View Role ${stamp}` })
+      userId = await createUserFixture(request, adminToken, {
+        email: userEmail,
+        password,
+        organizationId,
+        roles: [roleId],
+      })
+      // No shipping features at all; org visibility unrestricted so only the
+      // feature gate can deny. Set via the ACL API so the RBAC cache is invalidated.
+      await setUserAclVisibility(request, adminToken, {
+        userId,
+        features: [],
+        organizations: null,
+      })
+
+      const userToken = await getAuthToken(request, userEmail, password)
+
+      const trackingResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/shipping-carriers/tracking?providerKey=mock_carrier&shipmentId=${crypto.randomUUID()}`,
+        { token: userToken },
+      )
+      expect(trackingResponse.status(), 'tracking must be forbidden without shipping_carriers.view').toBe(403)
+      const trackingBody = await readJsonSafe<{ error?: string; requiredFeatures?: string[] }>(trackingResponse)
+      expect(
+        trackingBody?.requiredFeatures,
+        'forbidden response should name the missing feature',
+      ).toContain('shipping_carriers.view')
+
+      const pointsResponse = await apiRequest(
+        request,
+        'GET',
+        '/api/shipping-carriers/points?providerKey=mock_carrier&query=locker',
+        { token: userToken },
+      )
+      expect(pointsResponse.status(), 'points must be forbidden without shipping_carriers.view').toBe(403)
+    } finally {
+      await deleteUserAclInDb(userId ?? '').catch(() => undefined)
+      await deleteUserIfExists(request, adminToken, userId)
+      await deleteRoleIfExists(request, adminToken, roleId)
+    }
+  })
+
+  test('allows tracking and points for a privileged user (positive control, 200)', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+
+    const shipment = await createShipment(request, adminToken, { providerKey: 'mock_carrier' })
+
+    const trackingResponse = await apiRequest(
+      request,
+      'GET',
+      `/api/shipping-carriers/tracking?providerKey=mock_carrier&shipmentId=${shipment.shipmentId}`,
+      { token: adminToken },
+    )
+    expect(trackingResponse.status(), 'admin (has view) can read tracking').toBe(200)
+
+    const pointsResponse = await apiRequest(
+      request,
+      'GET',
+      '/api/shipping-carriers/points?providerKey=mock_carrier&query=locker&postCode=10001',
+      { token: adminToken },
+    )
+    expect(pointsResponse.status(), 'admin (has view) can search drop-off points').toBe(200)
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-010.spec.ts
+++ b/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-010.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import { deleteUserAclInDb } from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { defaultOrigin, defaultDestination, defaultPackage } from './helpers/fixtures'
+
+/**
+ * TC-SHIP-010: RBAC enforcement — `shipping_carriers.manage` is required to mutate.
+ *
+ * The write endpoints (`/rates`, `/shipments`, `/cancel`) declare
+ * `requireFeatures: ['shipping_carriers.manage']`. A user granted only
+ * `shipping_carriers.view` must receive 403 Forbidden on all three (no backend
+ * mutation occurs — the feature gate runs before the handler), while still being
+ * able to reach a `view`-gated endpoint. That positive control isolates the
+ * denial to the missing `manage` feature rather than a broken token.
+ *
+ * ENVIRONMENT: mixes API fixtures with a DB-level ACL cleanup (raw `pg` against
+ * `DATABASE_URL`). Run under a coherent app+DB stack (the
+ * `yarn test:integration` / `yarn test:integration:ephemeral` harness).
+ */
+test.describe('TC-SHIP-010: RBAC — manage feature required for rates, shipments, cancel', () => {
+  test('denies rates, shipments and cancel for a view-only user; still allows a view endpoint', async ({ request }) => {
+    const stamp = Date.now()
+    const password = 'Secret123!'
+    const userEmail = `tc-ship-010-${stamp}@example.com`
+
+    let adminToken: string | null = null
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      adminToken = await getAuthToken(request, 'admin')
+      const { organizationId, tenantId } = getTokenScope(adminToken)
+      expect(organizationId, 'admin token should carry an organization id').toBeTruthy()
+      expect(tenantId, 'admin token should carry a tenant id').toBeTruthy()
+
+      roleId = await createRoleFixture(request, adminToken, { name: `TC-SHIP-010 View-Only Role ${stamp}` })
+      userId = await createUserFixture(request, adminToken, {
+        email: userEmail,
+        password,
+        organizationId,
+        roles: [roleId],
+      })
+      // View but not manage; org visibility unrestricted so only the manage gate
+      // can deny the write endpoints.
+      await setUserAclVisibility(request, adminToken, {
+        userId,
+        features: ['shipping_carriers.view'],
+        organizations: null,
+      })
+
+      const userToken = await getAuthToken(request, userEmail, password)
+
+      // Positive control: the view feature lets the same user reach a view endpoint.
+      const pointsResponse = await apiRequest(
+        request,
+        'GET',
+        '/api/shipping-carriers/points?providerKey=mock_carrier&query=locker',
+        { token: userToken },
+      )
+      expect(pointsResponse.status(), 'view-only user can reach a view-gated endpoint').toBe(200)
+
+      const ratesResponse = await apiRequest(request, 'POST', '/api/shipping-carriers/rates', {
+        token: userToken,
+        data: {
+          providerKey: 'mock_carrier',
+          origin: defaultOrigin(),
+          destination: defaultDestination(),
+          packages: [defaultPackage()],
+        },
+      })
+      expect(ratesResponse.status(), 'rates must be forbidden without shipping_carriers.manage').toBe(403)
+      const ratesBody = await readJsonSafe<{ requiredFeatures?: string[] }>(ratesResponse)
+      expect(
+        ratesBody?.requiredFeatures,
+        'forbidden response should name the missing feature',
+      ).toContain('shipping_carriers.manage')
+
+      const shipmentsResponse = await apiRequest(request, 'POST', '/api/shipping-carriers/shipments', {
+        token: userToken,
+        data: {
+          providerKey: 'mock_carrier',
+          orderId: crypto.randomUUID(),
+          origin: defaultOrigin(),
+          destination: defaultDestination(),
+          packages: [defaultPackage()],
+          serviceCode: 'standard',
+        },
+      })
+      expect(shipmentsResponse.status(), 'shipments must be forbidden without shipping_carriers.manage').toBe(403)
+
+      const cancelResponse = await apiRequest(request, 'POST', '/api/shipping-carriers/cancel', {
+        token: userToken,
+        data: {
+          providerKey: 'mock_carrier',
+          shipmentId: crypto.randomUUID(),
+        },
+      })
+      expect(cancelResponse.status(), 'cancel must be forbidden without shipping_carriers.manage').toBe(403)
+    } finally {
+      await deleteUserAclInDb(userId ?? '').catch(() => undefined)
+      await deleteUserIfExists(request, adminToken, userId)
+      await deleteRoleIfExists(request, adminToken, roleId)
+    }
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-011.spec.ts
+++ b/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-011.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { defaultOrigin, defaultDestination, defaultPackage } from './helpers/fixtures'
+
+/**
+ * TC-SHIP-011: Input validation — malformed addresses and packages are rejected
+ * with 422 before any adapter is invoked.
+ *
+ * The rates and shipment routes validate the body with a Zod schema and return
+ * `{ error: 'Invalid payload', details: <flattened> }` with status 422 on
+ * failure. Uses an admin token (has `shipping_carriers.manage`) so requests
+ * clear the feature gate and actually reach validation.
+ */
+type ValidationBody = {
+  error?: string
+  details?: { fieldErrors?: Record<string, string[] | undefined> }
+}
+
+test.describe('TC-SHIP-011: Validation rejects invalid address/package payloads (422)', () => {
+  test('rejects rates payloads with a missing country code or empty city', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const missingCountry = await apiRequest(request, 'POST', '/api/shipping-carriers/rates', {
+      token,
+      data: {
+        providerKey: 'mock_carrier',
+        // origin.countryCode omitted — addressSchema requires it (min 2 chars).
+        origin: { postalCode: '10001', city: 'New York', line1: '123 Sender St' },
+        destination: defaultDestination(),
+        packages: [defaultPackage()],
+      },
+    })
+    expect(missingCountry.status(), 'missing origin.countryCode must be 422').toBe(422)
+    const missingCountryBody = await readJsonSafe<ValidationBody>(missingCountry)
+    expect(missingCountryBody?.error).toBe('Invalid payload')
+    expect(missingCountryBody?.details?.fieldErrors?.origin, 'origin should carry a field error').toBeTruthy()
+
+    const emptyCity = await apiRequest(request, 'POST', '/api/shipping-carriers/rates', {
+      token,
+      data: {
+        providerKey: 'mock_carrier',
+        origin: defaultOrigin(),
+        destination: { ...defaultDestination(), city: '' },
+        packages: [defaultPackage()],
+      },
+    })
+    expect(emptyCity.status(), 'empty destination.city must be 422').toBe(422)
+    const emptyCityBody = await readJsonSafe<ValidationBody>(emptyCity)
+    expect(emptyCityBody?.error).toBe('Invalid payload')
+    expect(emptyCityBody?.details?.fieldErrors?.destination, 'destination should carry a field error').toBeTruthy()
+  })
+
+  test('rejects shipment payloads with empty packages or a non-positive weight', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const emptyPackages = await apiRequest(request, 'POST', '/api/shipping-carriers/shipments', {
+      token,
+      data: {
+        providerKey: 'mock_carrier',
+        orderId: crypto.randomUUID(),
+        origin: defaultOrigin(),
+        destination: defaultDestination(),
+        packages: [],
+        serviceCode: 'standard',
+      },
+    })
+    expect(emptyPackages.status(), 'empty packages array must be 422').toBe(422)
+    const emptyPackagesBody = await readJsonSafe<ValidationBody>(emptyPackages)
+    expect(emptyPackagesBody?.error).toBe('Invalid payload')
+    expect(emptyPackagesBody?.details?.fieldErrors?.packages, 'packages should carry a field error').toBeTruthy()
+
+    const zeroWeight = await apiRequest(request, 'POST', '/api/shipping-carriers/shipments', {
+      token,
+      data: {
+        providerKey: 'mock_carrier',
+        orderId: crypto.randomUUID(),
+        origin: defaultOrigin(),
+        destination: defaultDestination(),
+        packages: [{ ...defaultPackage(), weightKg: 0 }],
+        serviceCode: 'standard',
+      },
+    })
+    expect(zeroWeight.status(), 'non-positive package weight must be 422').toBe(422)
+    const zeroWeightBody = await readJsonSafe<ValidationBody>(zeroWeight)
+    expect(zeroWeightBody?.error).toBe('Invalid payload')
+    expect(zeroWeightBody?.details?.fieldErrors?.packages, 'packages should carry a field error').toBeTruthy()
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-012.spec.ts
+++ b/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-012.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { createShipment } from './helpers/fixtures'
+import {
+  setCarrierShipmentStatusInDb,
+  getCarrierShipmentRowFromDb,
+  deleteCarrierShipmentInDb,
+} from './helpers/db'
+
+/**
+ * TC-SHIP-012: Status transition boundary — a shipment cannot be cancelled once
+ * it is `in_transit` or in a terminal status (`delivered`).
+ *
+ * `cancelShipment` rejects the transition (`ShipmentCancelNotAllowedError`) which
+ * the route maps to 422 with a message naming the current status. The non-
+ * cancellable states are only reachable via async carrier events, so the
+ * fixture sets `carrier_shipments.unified_status` directly to keep the test
+ * deterministic, then asserts the status is NOT mutated by the rejected cancel.
+ *
+ * ENVIRONMENT: mixes API fixtures with DB-level fixtures (raw `pg` against
+ * `DATABASE_URL`). Run under a coherent app+DB stack (the `yarn test:integration`
+ * / `yarn test:integration:ephemeral` harness) where the app and fixtures share
+ * the same database — otherwise the DB writes are invisible to the app.
+ */
+test.describe('TC-SHIP-012: Cancel is rejected from in_transit and terminal statuses (422)', () => {
+  test('returns 422 and leaves the status unchanged when cancelling in_transit or delivered shipments', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    let inTransitId: string | null = null
+    let deliveredId: string | null = null
+
+    try {
+      const inTransit = await createShipment(request, token, { providerKey: 'mock_carrier' })
+      inTransitId = inTransit.shipmentId
+      await setCarrierShipmentStatusInDb(inTransitId, 'in_transit')
+
+      const cancelInTransit = await apiRequest(request, 'POST', '/api/shipping-carriers/cancel', {
+        token,
+        data: { providerKey: 'mock_carrier', shipmentId: inTransitId },
+      })
+      expect(cancelInTransit.status(), 'cancelling an in_transit shipment must be 422').toBe(422)
+      const inTransitBody = await readJsonSafe<{ error?: string }>(cancelInTransit)
+      expect(inTransitBody?.error, 'error should name the current status').toContain('in_transit')
+
+      const inTransitRow = await getCarrierShipmentRowFromDb(inTransitId)
+      expect(inTransitRow?.unifiedStatus, 'in_transit shipment must not be mutated by a rejected cancel').toBe('in_transit')
+
+      const delivered = await createShipment(request, token, { providerKey: 'mock_carrier' })
+      deliveredId = delivered.shipmentId
+      await setCarrierShipmentStatusInDb(deliveredId, 'delivered')
+
+      const cancelDelivered = await apiRequest(request, 'POST', '/api/shipping-carriers/cancel', {
+        token,
+        data: { providerKey: 'mock_carrier', shipmentId: deliveredId },
+      })
+      expect(cancelDelivered.status(), 'cancelling a delivered shipment must be 422').toBe(422)
+      const deliveredBody = await readJsonSafe<{ error?: string }>(cancelDelivered)
+      expect(deliveredBody?.error, 'error should name the current status').toContain('delivered')
+
+      const deliveredRow = await getCarrierShipmentRowFromDb(deliveredId)
+      expect(deliveredRow?.unifiedStatus, 'delivered shipment must not be mutated by a rejected cancel').toBe('delivered')
+    } finally {
+      await deleteCarrierShipmentInDb(inTransitId).catch(() => undefined)
+      await deleteCarrierShipmentInDb(deliveredId).catch(() => undefined)
+    }
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-013.spec.ts
+++ b/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-013.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+
+/**
+ * TC-SHIP-013: Drop-off points search (happy path).
+ *
+ * GET /api/shipping-carriers/points returns `{ points: DropOffPoint[] }` for a
+ * provider whose adapter implements `searchDropOffPoints`. The mock_carrier
+ * adapter implements it, so the endpoint returns 200 with an array of points,
+ * each carrying a stable identifier and location fields.
+ */
+type DropOffPoint = {
+  id?: string
+  name?: string
+  type?: string
+  city?: string
+  postalCode?: string
+  street?: string
+}
+
+test.describe('TC-SHIP-013: Drop-off points search returns 200 with a points array', () => {
+  test('should return a points array for the mock_carrier provider', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const response = await apiRequest(
+      request,
+      'GET',
+      '/api/shipping-carriers/points?providerKey=mock_carrier&query=locker&postCode=10001',
+      { token },
+    )
+    expect(response.status(), 'points search should return 200').toBe(200)
+
+    const body = await readJsonSafe<{ points?: DropOffPoint[]; error?: string }>(response)
+    expect(body?.error, 'happy-path points search should not carry an error').toBeFalsy()
+    expect(Array.isArray(body?.points), 'response.points should be an array').toBe(true)
+    expect((body?.points ?? []).length, 'mock_carrier should return at least one point').toBeGreaterThan(0)
+
+    const firstPoint = (body?.points ?? [])[0]
+    expect(firstPoint?.id, 'each point should carry an identifier').toBeTruthy()
+    expect(firstPoint?.name, 'each point should carry a name').toBeTruthy()
+    expect(firstPoint?.city, 'each point should carry a city').toBeTruthy()
+    expect(firstPoint?.postalCode, 'each point should carry a postal code').toBeTruthy()
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-014.spec.ts
+++ b/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-014.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { createShipment } from './helpers/fixtures'
+
+/**
+ * TC-SHIP-014: Tracking query validation — at least one of `shipmentId` or
+ * `trackingNumber` is required.
+ *
+ * The tracking query schema has a `.refine()` requiring one identifier; omitting
+ * both returns 422 `{ error: 'Invalid query', details: <flattened> }` with the
+ * refine message under `shipmentId`. A query carrying a valid (real) shipment id
+ * returns 200 — the positive control proving the query is otherwise well-formed.
+ */
+test.describe('TC-SHIP-014: Tracking requires shipmentId or trackingNumber (422)', () => {
+  test('returns 422 when both shipmentId and trackingNumber are omitted', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const response = await apiRequest(
+      request,
+      'GET',
+      '/api/shipping-carriers/tracking?providerKey=mock_carrier',
+      { token },
+    )
+    expect(response.status(), 'omitting both identifiers must be 422').toBe(422)
+
+    const body = await readJsonSafe<{
+      error?: string
+      details?: { fieldErrors?: Record<string, string[] | undefined> }
+    }>(response)
+    expect(body?.error).toBe('Invalid query')
+    expect(
+      (body?.details?.fieldErrors?.shipmentId ?? []).join(' '),
+      'error should explain that one identifier is required',
+    ).toContain('shipmentId or trackingNumber is required')
+  })
+
+  test('returns 200 for a query carrying a valid shipment id (positive control)', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const shipment = await createShipment(request, token, { providerKey: 'mock_carrier' })
+
+    const response = await apiRequest(
+      request,
+      'GET',
+      `/api/shipping-carriers/tracking?providerKey=mock_carrier&shipmentId=${shipment.shipmentId}`,
+      { token },
+    )
+    expect(response.status(), 'a valid shipmentId query should return 200').toBe(200)
+    const body = await readJsonSafe<{ trackingNumber?: string }>(response)
+    expect(body?.trackingNumber, 'tracking should resolve the created shipment').toBe(shipment.trackingNumber)
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-015.spec.ts
+++ b/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-015.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { defaultOrigin, defaultDestination, defaultPackage } from './helpers/fixtures'
+import { getCarrierShipmentRowFromDb, deleteCarrierShipmentInDb } from './helpers/db'
+
+/**
+ * TC-SHIP-015: Shipment creation persists to the database and is retrievable.
+ *
+ * Existing happy-path tests assert the create response shape only. This locks in
+ * persistence: the created shipment is retrievable by both `shipmentId` and
+ * `trackingNumber`, and the persisted row carries the expected tracking number,
+ * status, label URL, and tenant/organization scope.
+ *
+ * ENVIRONMENT: mixes API fixtures with DB-level assertions (raw `pg` against
+ * `DATABASE_URL`). Run under a coherent app+DB stack (the `yarn test:integration`
+ * / `yarn test:integration:ephemeral` harness) where the app and fixtures share
+ * the same database.
+ */
+test.describe('TC-SHIP-015: Shipment persists and is retrievable', () => {
+  test('persists a created shipment and resolves it by shipmentId and trackingNumber', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const { organizationId, tenantId } = getTokenScope(token)
+    expect(organizationId, 'admin token should carry an organization id').toBeTruthy()
+    expect(tenantId, 'admin token should carry a tenant id').toBeTruthy()
+
+    let shipmentId: string | null = null
+
+    try {
+      const createResponse = await apiRequest(request, 'POST', '/api/shipping-carriers/shipments', {
+        token,
+        data: {
+          providerKey: 'mock_carrier',
+          orderId: crypto.randomUUID(),
+          origin: defaultOrigin(),
+          destination: defaultDestination(),
+          packages: [defaultPackage()],
+          serviceCode: 'standard',
+          labelFormat: 'pdf',
+        },
+      })
+      expect(createResponse.status(), 'shipment creation should return 201').toBe(201)
+      const created = await readJsonSafe<{
+        shipmentId?: string
+        trackingNumber?: string
+        status?: string
+        labelUrl?: string
+      }>(createResponse)
+      shipmentId = created?.shipmentId ?? null
+      expect(shipmentId, 'create response should include a shipment id').toBeTruthy()
+      expect(created?.trackingNumber, 'create response should include a tracking number').toBeTruthy()
+      expect(created?.status).toBe('label_created')
+
+      // Retrievable by shipmentId (this path reads the persisted DB row).
+      const byId = await apiRequest(
+        request,
+        'GET',
+        `/api/shipping-carriers/tracking?providerKey=mock_carrier&shipmentId=${shipmentId}`,
+        { token },
+      )
+      expect(byId.status(), 'tracking by shipmentId should return 200').toBe(200)
+      const byIdBody = await readJsonSafe<{ trackingNumber?: string }>(byId)
+      expect(byIdBody?.trackingNumber, 'tracking by id should resolve the created shipment').toBe(created?.trackingNumber)
+
+      // Also resolvable by trackingNumber (carrier lookup; the persisted-row
+      // assertion below is the authoritative DB-persistence proof).
+      const byTracking = await apiRequest(
+        request,
+        'GET',
+        `/api/shipping-carriers/tracking?providerKey=mock_carrier&trackingNumber=${encodeURIComponent(created!.trackingNumber!)}`,
+        { token },
+      )
+      expect(byTracking.status(), 'tracking by trackingNumber should return 200').toBe(200)
+      const byTrackingBody = await readJsonSafe<{ trackingNumber?: string }>(byTracking)
+      expect(byTrackingBody?.trackingNumber, 'tracking by number should resolve the created shipment').toBe(created?.trackingNumber)
+
+      // Persistence detail: the row carries the expected fields and tenant scope.
+      const row = await getCarrierShipmentRowFromDb(shipmentId as string)
+      expect(row, 'shipment row should be persisted').not.toBeNull()
+      expect(row?.trackingNumber).toBe(created?.trackingNumber)
+      expect(row?.unifiedStatus).toBe('label_created')
+      expect(row?.labelUrl, 'label URL should be persisted').toBe(created?.labelUrl)
+      expect(row?.organizationId).toBe(organizationId)
+      expect(row?.tenantId).toBe(tenantId)
+    } finally {
+      await deleteCarrierShipmentInDb(shipmentId).catch(() => undefined)
+    }
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/__integration__/helpers/db.ts
+++ b/packages/core/src/modules/shipping_carriers/__integration__/helpers/db.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { Client } from 'pg'
+
+/**
+ * Direct-Postgres fixtures for shipping_carriers integration specs.
+ *
+ * Some shipment states (e.g. `in_transit`, `delivered`) are only reachable
+ * through asynchronous carrier webhooks/pollers, which are non-deterministic in
+ * a test. These helpers set/read `carrier_shipments` rows directly so status
+ * transition boundaries and persistence can be asserted deterministically — the
+ * same `pg`-based approach already used by the shared `dbFixtures` helpers.
+ *
+ * They talk to `DATABASE_URL`, so the spec MUST run under a coherent app+DB
+ * stack (the `yarn test:integration` / `yarn test:integration:ephemeral`
+ * harness) where the app server and these fixtures share the same database.
+ */
+
+function resolveAppRoot(): string {
+  const fromEnv = process.env.OM_TEST_APP_ROOT?.trim()
+  return fromEnv ? path.resolve(fromEnv) : path.resolve(process.cwd(), 'apps/mercato')
+}
+
+function readEnvValue(key: string): string | undefined {
+  if (process.env[key]) return process.env[key]
+  const candidatePaths = [
+    path.resolve(resolveAppRoot(), '.env'),
+    path.resolve(process.cwd(), 'apps/mercato/.env'),
+    path.resolve(process.cwd(), '.env'),
+  ]
+  for (const envPath of candidatePaths) {
+    try {
+      const content = readFileSync(envPath, 'utf-8')
+      const match = content.match(new RegExp(`^${key}=(.+)$`, 'm'))
+      if (match?.[1]) return match[1].trim()
+    } catch {
+      continue
+    }
+  }
+  return undefined
+}
+
+function resolveDatabaseUrl(): string {
+  const url = readEnvValue('DATABASE_URL')
+  if (!url) throw new Error('[internal] DATABASE_URL is not configured for shipping_carriers DB fixtures')
+  return url
+}
+
+async function withClient<T>(run: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client({ connectionString: resolveDatabaseUrl() })
+  await client.connect()
+  try {
+    return await run(client)
+  } finally {
+    await client.end()
+  }
+}
+
+export type CarrierShipmentRow = {
+  unifiedStatus: string
+  trackingNumber: string
+  labelUrl: string | null
+  organizationId: string
+  tenantId: string
+}
+
+/** Forces a shipment's `unified_status` to a specific value (e.g. `in_transit`). */
+export async function setCarrierShipmentStatusInDb(shipmentId: string, status: string): Promise<void> {
+  await withClient(async (client) => {
+    await client.query(
+      'update carrier_shipments set unified_status = $2, updated_at = now() where id = $1',
+      [shipmentId, status],
+    )
+  })
+}
+
+/** Reads the persisted shipment row, or `null` when it does not exist. */
+export async function getCarrierShipmentRowFromDb(shipmentId: string): Promise<CarrierShipmentRow | null> {
+  return withClient(async (client) => {
+    const result = await client.query<{
+      unified_status: string
+      tracking_number: string
+      label_url: string | null
+      organization_id: string
+      tenant_id: string
+    }>(
+      `select unified_status, tracking_number, label_url, organization_id, tenant_id
+         from carrier_shipments
+        where id = $1
+        limit 1`,
+      [shipmentId],
+    )
+    const row = result.rows[0]
+    if (!row) return null
+    return {
+      unifiedStatus: row.unified_status,
+      trackingNumber: row.tracking_number,
+      labelUrl: row.label_url,
+      organizationId: row.organization_id,
+      tenantId: row.tenant_id,
+    }
+  })
+}
+
+/** Hard-deletes a shipment row (best-effort test cleanup). */
+export async function deleteCarrierShipmentInDb(shipmentId: string | null): Promise<void> {
+  if (!shipmentId) return
+  await withClient(async (client) => {
+    await client.query('delete from carrier_shipments where id = $1', [shipmentId])
+  })
+}

--- a/packages/core/src/modules/shipping_carriers/api/cancel/route.ts
+++ b/packages/core/src/modules/shipping_carriers/api/cancel/route.ts
@@ -3,7 +3,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import type { ShippingCarrierService } from '../../lib/shipping-service'
-import { ShipmentCancelNotAllowedError } from '../../lib/status-sync'
+import { isShipmentCancelNotAllowedError } from '../../lib/status-sync'
 import { cancelShipmentSchema } from '../../data/validators'
 import { shippingCarriersTag } from '../openapi'
 
@@ -32,7 +32,7 @@ export async function POST(req: Request) {
     })
     return NextResponse.json(result)
   } catch (error: unknown) {
-    if (error instanceof ShipmentCancelNotAllowedError) {
+    if (isShipmentCancelNotAllowedError(error)) {
       return NextResponse.json({ error: error.message }, { status: 422 })
     }
     const message = error instanceof Error ? error.message : 'Failed to cancel shipment'

--- a/packages/core/src/modules/shipping_carriers/lib/status-sync.ts
+++ b/packages/core/src/modules/shipping_carriers/lib/status-sync.ts
@@ -2,11 +2,30 @@ import type { UnifiedShipmentStatus } from './adapter'
 import type { CarrierShipment } from '../data/entities'
 import type { ShippingEventId } from '../events'
 
+// Use Symbol.for so the marker survives module duplication across bundle
+// boundaries — production builds can split this class into separate chunks,
+// which breaks `instanceof` (see isCrudHttpError in
+// @open-mercato/shared/lib/crud/errors for the same pattern).
+const SHIPMENT_CANCEL_NOT_ALLOWED_MARKER = Symbol.for('@open-mercato/shipping_carriers/ShipmentCancelNotAllowedError')
+
 export class ShipmentCancelNotAllowedError extends Error {
+  readonly [SHIPMENT_CANCEL_NOT_ALLOWED_MARKER] = true
+
   constructor(status: string) {
     super(`Shipment cannot be cancelled in its current status: ${status}`)
     this.name = 'ShipmentCancelNotAllowedError'
   }
+}
+
+/**
+ * Type-safe check that works across module/bundle boundaries. Prefer this over
+ * `instanceof ShipmentCancelNotAllowedError` in route handlers, where the thrown
+ * error may originate from a different bundle than the one performing the check.
+ */
+export function isShipmentCancelNotAllowedError(error: unknown): error is ShipmentCancelNotAllowedError {
+  return !!error
+    && typeof error === 'object'
+    && (error as Record<symbol, unknown>)[SHIPMENT_CANCEL_NOT_ALLOWED_MARKER] === true
 }
 
 const VALID_SHIPPING_TRANSITIONS: Record<string, UnifiedShipmentStatus[]> = {

--- a/packages/create-app/template/src/modules/example/lib/mock-shipping-adapter.ts
+++ b/packages/create-app/template/src/modules/example/lib/mock-shipping-adapter.ts
@@ -9,6 +9,8 @@ import type {
   TrackingResult,
   ShippingWebhookEvent,
   UnifiedShipmentStatus,
+  DropOffPoint,
+  SearchDropOffPointsInput,
 } from '@open-mercato/core/modules/shipping_carriers/lib/adapter'
 
 /**
@@ -209,5 +211,36 @@ export const mockShippingAdapter: ShippingAdapter = {
       cancelled: 'cancelled',
     }
     return map[carrierStatus] ?? 'unknown'
+  },
+
+  async searchDropOffPoints(input: SearchDropOffPointsInput): Promise<DropOffPoint[]> {
+    const postalCode = typeof input.postCode === 'string' && input.postCode.trim().length > 0
+      ? input.postCode.trim()
+      : '10001'
+    const pointType = typeof input.type === 'string' && input.type.trim().length > 0
+      ? input.type.trim()
+      : 'locker'
+    return [
+      {
+        id: 'MOCK-POP-001',
+        name: 'Mock Locker - Main Street',
+        type: pointType,
+        city: 'New York',
+        postalCode,
+        street: '100 Main Street',
+        latitude: 40.7128,
+        longitude: -74.006,
+      },
+      {
+        id: 'MOCK-POP-002',
+        name: 'Mock Pickup Point - Market Square',
+        type: pointType,
+        city: 'New York',
+        postalCode,
+        street: '250 Market Square',
+        latitude: 40.7138,
+        longitude: -74.001,
+      },
+    ]
   },
 }


### PR DESCRIPTION
## Summary

Adds the seven integration-test scenarios requested in #2489 for the `shipping_carriers`
module (TC-SHIP-009 … TC-SHIP-015): RBAC enforcement, input validation, status-transition
boundaries, drop-off-point search, tracking-query validation, and shipment persistence.

Implementing TC-SHIP-012 surfaced a real production bug: cancelling a non-cancellable
shipment returned **502 instead of the documented 422**. The cancel route relied on
`error instanceof ShipmentCancelNotAllowedError`, which is unreliable in production builds
where the class is duplicated across bundle chunks (the same defect the repo already fixed
for `CrudHttpError` via `isCrudHttpError`). Fixed with a `Symbol.for` marker + tagged guard.

## Changes

- Add `__integration__/TC-SHIP-009…015.spec.ts` covering: `shipping_carriers.view`/`.manage`
  RBAC (403), rates/shipment validation (422), cancel-from-`in_transit`/`delivered` (422),
  drop-off points (200), tracking-query validation (422), and shipment persistence/retrieval.
- Add `__integration__/helpers/db.ts` — `pg`-based fixtures to set/read/delete `carrier_shipments`
  rows (the non-cancellable states are only reachable via async carrier events, so the fixture
  sets `unified_status` directly to stay deterministic; mirrors the existing `dbFixtures` pattern).
- Fix `shipping_carriers/lib/status-sync.ts` + `api/cancel/route.ts`: add a `Symbol.for` marker
  and `isShipmentCancelNotAllowedError` guard, and use the guard instead of `instanceof` so the
  route returns the documented 422 in production builds.
- Add `searchDropOffPoints` to the example `mock_carrier` adapter (app + create-app template,
  kept identical) so the points endpoint has a happy path to exercise.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
.ai/specs/implemented/SPEC-045c-payment-shipping-hubs.md — no spec change needed: this adds the
issue's integration coverage and aligns the cancel route with its already-documented 422 response.

## Testing

- `yarn typecheck` — pass (exit 0)
- `yarn lint` — pass (exit 0)
- `yarn i18n:check-sync` — pass (all 4 locales in sync)
- `yarn test` — pass (22/22 turbo tasks; core 634 suites / 5274 tests)
- `yarn test:integration:ephemeral shipping_carriers` — **31/31 passed** (production build), including
  all 7 new specs; TC-SHIP-012 confirmed 502→422 after the fix; TC-SHIP-001…008 unchanged and green.
- `yarn template:sync` — only pre-existing, unrelated drift; the mock-adapter copies stay in parity.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — i18n:check-sync green.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (7 specs added under the module's `__integration__/`.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no behavior change beyond the documented 422 contract.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, backend/API + test code, no UI.
- [x] No arbitrary text sizes — N/A, no UI.
- [x] Empty state handled for list/data pages — N/A, no UI.
- [x] Loading state handled for async pages — N/A, no UI.
- [x] `aria-label` on all icon-only buttons — N/A, no UI.
- [x] Uses existing DS components — N/A, no UI.

## Linked issues

Fixes #2489