### PR TITLE
feat: 2490 currencies integration coverage

### DIFF
--- a/packages/core/src/helpers/integration/currenciesFixtures.ts
+++ b/packages/core/src/helpers/integration/currenciesFixtures.ts
@@ -18,6 +18,65 @@ export async function createCurrencyFixture(
   return body.id as string;
 }
 
+// Codes seeded by the currencies module (seedExampleCurrencies). Generated test
+// codes avoid these so fixtures never collide with seeded rows.
+const SEEDED_CURRENCY_CODES = new Set([
+  'USD', 'EUR', 'JPY', 'GBP', 'CHF', 'CAD', 'AUD', 'CNY', 'CNH', 'PLN',
+]);
+// Reserved across the worker so two fixtures never draw the same code in one run.
+const reservedCurrencyCodes = new Set<string>();
+
+/** Draws an ISO-style three-letter code unused by seeds or earlier fixtures. */
+export function generateUniqueCurrencyCode(): string {
+  const letter = () => String.fromCharCode(65 + Math.floor(Math.random() * 26));
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const code = `${letter()}${letter()}${letter()}`;
+    if (!SEEDED_CURRENCY_CODES.has(code) && !reservedCurrencyCodes.has(code)) {
+      reservedCurrencyCodes.add(code);
+      return code;
+    }
+  }
+  throw new Error('[internal] exhausted unique currency code space');
+}
+
+/**
+ * Creates a currency with a generated unique code and returns its id and code.
+ *
+ * Currency DELETE is a soft delete, but the (organization, tenant, code) unique
+ * constraint still counts soft-deleted rows — re-using a code an earlier test
+ * soft-deleted makes the create fail. Drawing from the full three-letter space
+ * (minus seeds) and retrying with a fresh code on an accidental collision keeps
+ * fixture setup deterministic across runs that share a database.
+ */
+export async function createRandomCurrencyFixture(
+  request: APIRequestContext,
+  token: string,
+  input: { name: string; symbol?: string; isActive?: boolean },
+): Promise<{ id: string; code: string }> {
+  const { organizationId, tenantId } = getTokenContext(token);
+  let lastStatus = 0;
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const code = generateUniqueCurrencyCode();
+    const data: Record<string, unknown> = {
+      organizationId,
+      tenantId,
+      code,
+      name: input.name,
+      symbol: input.symbol ?? null,
+    };
+    if (typeof input.isActive === 'boolean') data.isActive = input.isActive;
+    const response = await apiRequest(request, 'POST', '/api/currencies/currencies', { token, data });
+    if (response.status() === 201) {
+      const body = (await response.json()) as { id?: string };
+      if (typeof body.id === 'string' && body.id.length > 0) {
+        return { id: body.id, code };
+      }
+    }
+    lastStatus = response.status();
+  }
+  throw new Error(`[internal] failed to create currency fixture after retries (last status ${lastStatus})`);
+}
+
 export async function createFetchConfigFixture(
   request: APIRequestContext,
   token: string,

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-005.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-005.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures';
+import {
+  createRandomCurrencyFixture,
+  generateUniqueCurrencyCode,
+  deleteCurrenciesEntityIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures';
+import { deleteUserAclInDb } from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures';
+import { getTokenContext } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+/**
+ * TC-CUR-005: RBAC — `currencies.manage` gates currency mutations.
+ * Source: issue #2490 (currencies integration coverage).
+ *
+ * A user that holds only `currencies.view` may LIST currencies (200) but is
+ * forbidden (403) from POST/PUT/DELETE on /api/currencies/currencies, which the
+ * route guards with `currencies.manage`.
+ *
+ * The currencies module seeds features only for `admin` (`currencies.*`), so the
+ * seeded `employee` account has no currencies access at all. This spec therefore
+ * provisions a dedicated view-only user instead of relying on a seeded role.
+ */
+test.describe('TC-CUR-005: currencies.manage RBAC gate', () => {
+  test('view-only user lists currencies but cannot create, update, or delete', async ({ request }) => {
+    test.slow();
+    const stamp = Date.now();
+    const password = 'Secret123!';
+    const viewerEmail = `tc-cur-005-viewer-${stamp}@example.com`;
+
+    let adminToken: string | null = null;
+    let viewerToken: string | null = null;
+    let roleId: string | null = null;
+    let viewerUserId: string | null = null;
+    let currencyId: string | null = null;
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      const { organizationId, tenantId } = getTokenContext(adminToken);
+
+      currencyId = (await createRandomCurrencyFixture(request, adminToken, { name: 'QA TC-CUR-005 Currency' })).id;
+
+      roleId = await createRoleFixture(request, adminToken, { name: `TC-CUR-005 Viewer ${stamp}` });
+      viewerUserId = await createUserFixture(request, adminToken, {
+        email: viewerEmail,
+        password,
+        organizationId,
+        roles: [roleId],
+      });
+      await setUserAclVisibility(request, adminToken, {
+        userId: viewerUserId,
+        features: ['currencies.view'],
+        organizations: null,
+      });
+      viewerToken = await getAuthToken(request, viewerEmail, password);
+
+      const createAttempt = await apiRequest(request, 'POST', '/api/currencies/currencies', {
+        token: viewerToken,
+        data: { organizationId, tenantId, code: generateUniqueCurrencyCode(), name: 'Should not be created' },
+      });
+      expect(createAttempt.status(), 'POST without currencies.manage must return 403').toBe(403);
+
+      const updateAttempt = await apiRequest(request, 'PUT', '/api/currencies/currencies', {
+        token: viewerToken,
+        data: { id: currencyId, symbol: 'ZZ' },
+      });
+      expect(updateAttempt.status(), 'PUT without currencies.manage must return 403').toBe(403);
+
+      const deleteAttempt = await apiRequest(
+        request,
+        'DELETE',
+        `/api/currencies/currencies?id=${encodeURIComponent(currencyId)}`,
+        { token: viewerToken },
+      );
+      expect(deleteAttempt.status(), 'DELETE without currencies.manage must return 403').toBe(403);
+
+      const listResponse = await apiRequest(request, 'GET', '/api/currencies/currencies?pageSize=1', {
+        token: viewerToken,
+      });
+      expect(listResponse.status(), 'GET with currencies.view must return 200').toBe(200);
+    } finally {
+      await deleteCurrenciesEntityIfExists(request, adminToken, '/api/currencies/currencies', currencyId);
+      await deleteUserIfExists(request, adminToken, viewerUserId);
+      await deleteUserAclInDb(viewerUserId ?? '').catch(() => undefined);
+      await deleteRoleIfExists(request, adminToken, roleId);
+    }
+  });
+});

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-006.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-006.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures';
+import {
+  createRandomCurrencyFixture,
+  deleteCurrenciesEntityIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures';
+import { deleteUserAclInDb } from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+/**
+ * TC-CUR-006: RBAC — `currencies.rates.manage` gates exchange-rate mutations.
+ * Source: issue #2490 (currencies integration coverage).
+ *
+ * A user that holds `currencies.rates.view` (and `currencies.view`, its
+ * dependency) may LIST exchange rates (200) but is forbidden (403) from
+ * POST/PUT/DELETE on /api/currencies/exchange-rates, which the route guards with
+ * `currencies.rates.manage`.
+ */
+test.describe('TC-CUR-006: currencies.rates.manage RBAC gate', () => {
+  test('rates-view user lists exchange rates but cannot create, update, or delete', async ({ request }) => {
+    test.slow();
+    const stamp = Date.now();
+    const password = 'Secret123!';
+    const viewerEmail = `tc-cur-006-viewer-${stamp}@example.com`;
+
+    let adminToken: string | null = null;
+    let viewerToken: string | null = null;
+    let roleId: string | null = null;
+    let viewerUserId: string | null = null;
+    let rateId: string | null = null;
+    let fromCurrencyId: string | null = null;
+    let toCurrencyId: string | null = null;
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      const { organizationId, tenantId } = getTokenContext(adminToken);
+
+      const fromCurrency = await createRandomCurrencyFixture(request, adminToken, { name: 'QA TC-CUR-006 From' });
+      const toCurrency = await createRandomCurrencyFixture(request, adminToken, { name: 'QA TC-CUR-006 To' });
+      fromCurrencyId = fromCurrency.id;
+      toCurrencyId = toCurrency.id;
+
+      const rateCreate = await apiRequest(request, 'POST', '/api/currencies/exchange-rates', {
+        token: adminToken,
+        data: {
+          organizationId,
+          tenantId,
+          fromCurrencyCode: fromCurrency.code,
+          toCurrencyCode: toCurrency.code,
+          rate: '1.25',
+          date: new Date().toISOString(),
+          source: 'QA-Manual',
+        },
+      });
+      expect(rateCreate.status(), 'admin should create the exchange-rate fixture (201)').toBe(201);
+      rateId = (await readJsonSafe<{ id?: string }>(rateCreate))?.id ?? null;
+
+      roleId = await createRoleFixture(request, adminToken, { name: `TC-CUR-006 Viewer ${stamp}` });
+      viewerUserId = await createUserFixture(request, adminToken, {
+        email: viewerEmail,
+        password,
+        organizationId,
+        roles: [roleId],
+      });
+      await setUserAclVisibility(request, adminToken, {
+        userId: viewerUserId,
+        features: ['currencies.view', 'currencies.rates.view'],
+        organizations: null,
+      });
+      viewerToken = await getAuthToken(request, viewerEmail, password);
+
+      const createAttempt = await apiRequest(request, 'POST', '/api/currencies/exchange-rates', {
+        token: viewerToken,
+        data: {
+          organizationId,
+          tenantId,
+          fromCurrencyCode: fromCurrency.code,
+          toCurrencyCode: toCurrency.code,
+          rate: '1.5',
+          date: new Date().toISOString(),
+          source: 'QA-Manual',
+        },
+      });
+      expect(createAttempt.status(), 'POST without currencies.rates.manage must return 403').toBe(403);
+
+      const updateAttempt = await apiRequest(request, 'PUT', '/api/currencies/exchange-rates', {
+        token: viewerToken,
+        data: { id: rateId, rate: '1.75' },
+      });
+      expect(updateAttempt.status(), 'PUT without currencies.rates.manage must return 403').toBe(403);
+
+      const deleteAttempt = await apiRequest(
+        request,
+        'DELETE',
+        `/api/currencies/exchange-rates?id=${encodeURIComponent(rateId ?? '')}`,
+        { token: viewerToken },
+      );
+      expect(deleteAttempt.status(), 'DELETE without currencies.rates.manage must return 403').toBe(403);
+
+      const listResponse = await apiRequest(request, 'GET', '/api/currencies/exchange-rates?pageSize=1', {
+        token: viewerToken,
+      });
+      expect(listResponse.status(), 'GET with currencies.rates.view must return 200').toBe(200);
+    } finally {
+      await deleteCurrenciesEntityIfExists(request, adminToken, '/api/currencies/exchange-rates', rateId);
+      await deleteCurrenciesEntityIfExists(request, adminToken, '/api/currencies/currencies', fromCurrencyId);
+      await deleteCurrenciesEntityIfExists(request, adminToken, '/api/currencies/currencies', toCurrencyId);
+      await deleteUserIfExists(request, adminToken, viewerUserId);
+      await deleteUserAclInDb(viewerUserId ?? '').catch(() => undefined);
+      await deleteRoleIfExists(request, adminToken, roleId);
+    }
+  });
+});

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-007.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-007.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  createRandomCurrencyFixture,
+  deleteCurrenciesEntityIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+/**
+ * TC-CUR-007: Exchange-rate validation — self-reference and invalid rate values
+ * are rejected with 400.
+ * Source: issue #2490 (currencies integration coverage).
+ *
+ * The create command parses `exchangeRateCreateSchema`, which enforces:
+ *   - from/to currency codes must differ (`.refine`)
+ *   - rate matches /^\d+(\.\d{1,8})?$/ (rejects negatives, non-numeric, > 8 decimals)
+ *   - parseFloat(rate) > 0 (rejects zero)
+ * A Zod failure surfaces through `makeCrudRoute` as HTTP 400.
+ */
+test.describe('TC-CUR-007: exchange-rate validation boundaries', () => {
+  test('rejects self-reference and invalid rate values, accepts a valid rate', async ({ request }) => {
+    let token: string | null = null;
+    let fromCurrencyId: string | null = null;
+    let toCurrencyId: string | null = null;
+    let validRateId: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+      const { organizationId, tenantId } = getTokenContext(token);
+
+      const fromCurrency = await createRandomCurrencyFixture(request, token, { name: 'QA TC-CUR-007 From' });
+      const toCurrency = await createRandomCurrencyFixture(request, token, { name: 'QA TC-CUR-007 To' });
+      fromCurrencyId = fromCurrency.id;
+      toCurrencyId = toCurrency.id;
+
+      const baseRatePayload = {
+        organizationId,
+        tenantId,
+        date: new Date().toISOString(),
+        source: 'QA-Manual',
+      };
+
+      const postRate = (data: Record<string, unknown>) =>
+        apiRequest(request, 'POST', '/api/currencies/exchange-rates', { token: token!, data });
+
+      const selfReference = await postRate({ ...baseRatePayload, fromCurrencyCode: fromCurrency.code, toCurrencyCode: fromCurrency.code, rate: '1.5' });
+      expect(selfReference.status(), 'self-referencing rate (from === to) must be 400').toBe(400);
+
+      const negative = await postRate({ ...baseRatePayload, fromCurrencyCode: fromCurrency.code, toCurrencyCode: toCurrency.code, rate: '-1.50' });
+      expect(negative.status(), 'negative rate must be 400').toBe(400);
+
+      const zero = await postRate({ ...baseRatePayload, fromCurrencyCode: fromCurrency.code, toCurrencyCode: toCurrency.code, rate: '0' });
+      expect(zero.status(), 'zero rate must be 400').toBe(400);
+
+      const nonNumeric = await postRate({ ...baseRatePayload, fromCurrencyCode: fromCurrency.code, toCurrencyCode: toCurrency.code, rate: 'abc' });
+      expect(nonNumeric.status(), 'non-numeric rate must be 400').toBe(400);
+
+      const tooPrecise = await postRate({ ...baseRatePayload, fromCurrencyCode: fromCurrency.code, toCurrencyCode: toCurrency.code, rate: '1.123456789' });
+      expect(tooPrecise.status(), 'rate exceeding 8 decimal places must be 400').toBe(400);
+
+      const valid = await postRate({ ...baseRatePayload, fromCurrencyCode: fromCurrency.code, toCurrencyCode: toCurrency.code, rate: '1.5' });
+      expect(valid.status(), 'valid distinct-currency positive rate must be 201').toBe(201);
+      validRateId = (await readJsonSafe<{ id?: string }>(valid))?.id ?? null;
+      expect(validRateId, 'valid rate response should contain an id').toBeTruthy();
+    } finally {
+      await deleteCurrenciesEntityIfExists(request, token, '/api/currencies/exchange-rates', validRateId);
+      await deleteCurrenciesEntityIfExists(request, token, '/api/currencies/currencies', fromCurrencyId);
+      await deleteCurrenciesEntityIfExists(request, token, '/api/currencies/currencies', toCurrencyId);
+    }
+  });
+});

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-008.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-008.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  createFetchConfigFixture,
+  deleteCurrenciesEntityIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures';
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+/**
+ * TC-CUR-008: Fetch-rates endpoint — POST /api/currencies/fetch-rates returns the
+ * provider result envelope and records the side effect on the matching config.
+ * Source: issue #2490 (currencies integration coverage).
+ *
+ * Only the NBP and Raiffeisen providers are registered in DI; `Custom` is a valid
+ * config provider but has no fetcher. Posting `providers: ['Custom']` therefore
+ * runs no network call and returns 200 with `{ totalFetched: 0, byProvider: {},
+ * errors: ['Unknown provider: Custom'] }`, while the fetch-rates route still
+ * stamps `lastSyncAt`/`lastSyncCount` on the existing `Custom` config — the
+ * deterministic side effect this test asserts.
+ */
+type FetchConfig = {
+  id?: string;
+  provider?: string;
+  lastSyncAt?: string | null;
+  lastSyncStatus?: string | null;
+  lastSyncCount?: number | null;
+};
+
+async function findCustomConfig(
+  request: APIRequestContext,
+  token: string,
+): Promise<FetchConfig | null> {
+  const response = await apiRequest(request, 'GET', '/api/currencies/fetch-configs', { token });
+  const body = await readJsonSafe<{ configs?: FetchConfig[] }>(response);
+  return (body?.configs ?? []).find((config) => config.provider === 'Custom') ?? null;
+}
+
+test.describe('TC-CUR-008: fetch-rates endpoint', () => {
+  test('triggers provider sync and updates the Custom config sync metadata', async ({ request }) => {
+    let token: string | null = null;
+    let configId: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+
+      // Defensive pre-clean: the (org, tenant, provider) uniqueness constraint
+      // means a leftover Custom config (e.g. from a crashed run or a retry) would
+      // make the fixture create fail with 409/400.
+      const existingCustom = await findCustomConfig(request, token);
+      if (existingCustom?.id) {
+        await deleteCurrenciesEntityIfExists(request, token, '/api/currencies/fetch-configs', existingCustom.id);
+      }
+
+      configId = await createFetchConfigFixture(request, token, { provider: 'Custom', isEnabled: false });
+
+      const fetchResponse = await apiRequest(request, 'POST', '/api/currencies/fetch-rates', {
+        token,
+        data: { providers: ['Custom'] },
+      });
+      expect(fetchResponse.status(), 'POST /api/currencies/fetch-rates should return 200').toBe(200);
+
+      const result = await readJsonSafe<{
+        totalFetched?: number;
+        byProvider?: Record<string, unknown>;
+        errors?: unknown[];
+      }>(fetchResponse);
+      expect(typeof result?.totalFetched, 'response should include numeric totalFetched').toBe('number');
+      expect(result?.byProvider && typeof result.byProvider === 'object', 'response should include a byProvider map').toBeTruthy();
+      expect(Array.isArray(result?.errors), 'response should include an errors array').toBeTruthy();
+      expect(result?.totalFetched, 'no rates are fetched for the unregistered Custom provider').toBe(0);
+      expect(
+        (result?.errors ?? []).some((entry) => typeof entry === 'string' && entry.includes('Custom')),
+        'errors should report the unregistered Custom provider',
+      ).toBeTruthy();
+
+      const updatedConfig = await findCustomConfig(request, token);
+      expect(updatedConfig?.id, 'Custom config should still exist after fetch').toBe(configId);
+      expect(updatedConfig?.lastSyncAt, 'fetch-rates should stamp lastSyncAt on the Custom config').toBeTruthy();
+      expect(updatedConfig?.lastSyncCount, 'lastSyncCount should reflect zero fetched rates').toBe(0);
+    } finally {
+      await deleteCurrenciesEntityIfExists(request, token, '/api/currencies/fetch-configs', configId);
+    }
+  });
+});

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-009.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-009.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  createRandomCurrencyFixture,
+  deleteCurrenciesEntityIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures';
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+/**
+ * TC-CUR-009: Currency options endpoint — search, limit, and inactive handling.
+ * Source: issue #2490 (currencies integration coverage).
+ *
+ * GET /api/currencies/currencies/options returns `{ items: [{ value, label }] }`
+ * where `value` is the currency code and `label` is `"<code> - <name>"`. It
+ * supports `q`/`query`/`search` (code or name, ilike), `limit` (default 50,
+ * max 100), and `includeInactive` (defaults to active-only). Fixture currencies
+ * share a unique name stamp so name searches resolve to exactly this test's data
+ * (the org also carries seeded currencies).
+ */
+type OptionItem = { value: string; label: string };
+
+async function fetchOptions(
+  request: APIRequestContext,
+  token: string,
+  query: string,
+): Promise<OptionItem[]> {
+  const response = await apiRequest(request, 'GET', `/api/currencies/currencies/options${query}`, { token });
+  expect(response.status(), `GET options${query} should return 200`).toBe(200);
+  const body = await readJsonSafe<{ items?: OptionItem[] }>(response);
+  return body?.items ?? [];
+}
+
+test.describe('TC-CUR-009: currency options endpoint', () => {
+  test('filters options by search term and limit and honors includeInactive', async ({ request }) => {
+    test.slow();
+    const stamp = Date.now();
+    const nameToken = `qatc009-${stamp}`;
+
+    let token: string | null = null;
+    const createdIds: string[] = [];
+    const activeCodes: string[] = [];
+    let inactiveCode: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+
+      for (let index = 0; index < 5; index += 1) {
+        const currency = await createRandomCurrencyFixture(request, token, { name: `${nameToken} active ${index}` });
+        activeCodes.push(currency.code);
+        createdIds.push(currency.id);
+      }
+
+      const inactiveCurrency = await createRandomCurrencyFixture(request, token, { name: `${nameToken} inactive`, isActive: false });
+      inactiveCode = inactiveCurrency.code;
+      createdIds.push(inactiveCurrency.id);
+
+      const byName = await fetchOptions(request, token, `?search=${encodeURIComponent(nameToken)}`);
+      const byNameValues = byName.map((item) => item.value);
+      for (const code of activeCodes) {
+        expect(byNameValues, `options (name search) should include active code ${code}`).toContain(code);
+      }
+      expect(byNameValues, 'inactive currency must be excluded by default').not.toContain(inactiveCode);
+      expect(
+        byName.every((item) => typeof item.value === 'string' && typeof item.label === 'string' && item.label.includes(' - ')),
+        'each option should expose value and "<code> - <name>" label',
+      ).toBeTruthy();
+
+      const byCode = await fetchOptions(request, token, `?q=${encodeURIComponent(activeCodes[0])}`);
+      expect(byCode.map((item) => item.value), 'options (code search) should include the searched code').toContain(activeCodes[0]);
+
+      const limited = await fetchOptions(request, token, `?search=${encodeURIComponent(nameToken)}&limit=2`);
+      expect(limited.length, 'limit=2 should cap the result count').toBeLessThanOrEqual(2);
+
+      const withInactive = await fetchOptions(request, token, `?search=${encodeURIComponent(nameToken)}&includeInactive=true`);
+      const withInactiveValues = withInactive.map((item) => item.value);
+      expect(withInactiveValues, 'includeInactive=true should include the inactive currency').toContain(inactiveCode);
+      for (const code of activeCodes) {
+        expect(withInactiveValues, `includeInactive=true should still include active code ${code}`).toContain(code);
+      }
+    } finally {
+      for (const id of createdIds) {
+        await deleteCurrenciesEntityIfExists(request, token, '/api/currencies/currencies', id);
+      }
+    }
+  });
+});

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-010.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-010.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures';
+import {
+  createRandomCurrencyFixture,
+  deleteCurrenciesEntityIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures';
+import {
+  createOrganizationInDb,
+  deleteOrganizationInDb,
+  deleteUserAclInDb,
+} from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+/**
+ * TC-CUR-010: Organization-scope isolation for currencies.
+ * Source: issue #2490 (currencies integration coverage).
+ *
+ * The currencies list route scopes by BOTH tenant and organization
+ * (`filter.tenantId = auth.tenantId; if (auth.orgId) filter.organizationId =
+ * auth.orgId`). This exercises the organization dimension — the part testable via
+ * API/DB fixtures without provisioning a second tenant: a currency created in
+ * org B is invisible to a user scoped to org A and vice versa, and a cross-org id
+ * lookup returns no rows.
+ *
+ * ENVIRONMENT: mixes API fixtures (hit the app) with a DB-level org fixture (raw
+ * `pg` against `DATABASE_URL`, because the directory create command denies
+ * non-super-admin actors). It MUST run under a coherent app+DB stack (the
+ * standard `yarn test:integration` / `yarn test:integration:ephemeral` harness)
+ * where the app server and the fixtures share one database.
+ */
+async function listCurrencyIds(
+  request: APIRequestContext,
+  token: string,
+  query: string,
+): Promise<{ status: number; items: Array<{ id: string; organizationId: string }> }> {
+  const response = await apiRequest(request, 'GET', `/api/currencies/currencies${query}`, { token });
+  const body = await readJsonSafe<{ items?: Array<{ id: string; organizationId: string }> }>(response);
+  return { status: response.status(), items: body?.items ?? [] };
+}
+
+test.describe('TC-CUR-010: cross-organization currency isolation', () => {
+  test('a currency in org B is invisible to an org A user and vice versa', async ({ request }) => {
+    test.slow();
+    const stamp = Date.now();
+    const password = 'Secret123!';
+    const orgBUserEmail = `tc-cur-010-orgb-${stamp}@example.com`;
+
+    let adminToken: string | null = null;
+    let orgBToken: string | null = null;
+    let orgBId: string | null = null;
+    let roleId: string | null = null;
+    let orgBUserId: string | null = null;
+    let currencyOrgAId: string | null = null;
+    let currencyOrgBId: string | null = null;
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      const { tenantId } = getTokenScope(adminToken);
+      expect(tenantId, 'admin token should carry a tenant id').toBeTruthy();
+
+      // Org B is a fresh, unseeded organization in the admin tenant.
+      orgBId = await createOrganizationInDb({ name: `TC-CUR-010 Org B ${stamp}`, tenantId });
+
+      // A user whose home org is org B, granted currencies access scoped to org B.
+      roleId = await createRoleFixture(request, adminToken, { name: `TC-CUR-010 Org B ${stamp}` });
+      orgBUserId = await createUserFixture(request, adminToken, {
+        email: orgBUserEmail,
+        password,
+        organizationId: orgBId,
+        roles: [roleId],
+      });
+      await setUserAclVisibility(request, adminToken, {
+        userId: orgBUserId,
+        features: ['currencies.view', 'currencies.manage'],
+        organizations: [orgBId],
+      });
+      orgBToken = await getAuthToken(request, orgBUserEmail, password);
+      expect(getTokenScope(orgBToken).organizationId, 'org B user token should be scoped to org B').toBe(orgBId);
+
+      currencyOrgAId = (await createRandomCurrencyFixture(request, adminToken, { name: 'QA TC-CUR-010 Org A' })).id;
+      currencyOrgBId = (await createRandomCurrencyFixture(request, orgBToken, { name: 'QA TC-CUR-010 Org B' })).id;
+
+      // Each scope sees only its own currency by id.
+      const adminSeesOwn = await listCurrencyIds(request, adminToken, `?id=${encodeURIComponent(currencyOrgAId)}`);
+      expect(adminSeesOwn.status, 'admin GET own currency should be 200').toBe(200);
+      expect(adminSeesOwn.items.map((item) => item.id), 'admin should see its own org A currency').toContain(currencyOrgAId);
+
+      const adminCannotSeeOrgB = await listCurrencyIds(request, adminToken, `?id=${encodeURIComponent(currencyOrgBId)}`);
+      expect(adminCannotSeeOrgB.items, 'admin (org A) must not see the org B currency').toHaveLength(0);
+
+      const orgBSeesOwn = await listCurrencyIds(request, orgBToken, `?id=${encodeURIComponent(currencyOrgBId)}`);
+      expect(orgBSeesOwn.status, 'org B GET own currency should be 200').toBe(200);
+      expect(orgBSeesOwn.items.map((item) => item.id), 'org B user should see its own currency').toContain(currencyOrgBId);
+
+      const orgBCannotSeeOrgA = await listCurrencyIds(request, orgBToken, `?id=${encodeURIComponent(currencyOrgAId)}`);
+      expect(orgBCannotSeeOrgA.items, 'org B user must not see the org A currency by id').toHaveLength(0);
+
+      // The org B user's full list never leaks another org's rows.
+      const orgBList = await listCurrencyIds(request, orgBToken, '?pageSize=100');
+      expect(orgBList.status, 'org B list should be 200').toBe(200);
+      expect(orgBList.items.length, 'org B list should contain its own currency').toBeGreaterThan(0);
+      expect(
+        orgBList.items.every((item) => item.organizationId === orgBId),
+        'org B list must only contain org B currencies',
+      ).toBeTruthy();
+    } finally {
+      await deleteCurrenciesEntityIfExists(request, orgBToken, '/api/currencies/currencies', currencyOrgBId);
+      await deleteCurrenciesEntityIfExists(request, adminToken, '/api/currencies/currencies', currencyOrgAId);
+      await deleteUserIfExists(request, adminToken, orgBUserId);
+      await deleteUserAclInDb(orgBUserId ?? '').catch(() => undefined);
+      await deleteRoleIfExists(request, adminToken, roleId);
+      await deleteOrganizationInDb(orgBId).catch(() => undefined);
+    }
+  });
+});

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-011.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-011.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  createRandomCurrencyFixture,
+  deleteCurrenciesEntityIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures';
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+/**
+ * TC-CUR-011: Currency active flag and soft delete.
+ * Source: issue #2490 (currencies integration coverage).
+ *
+ * Verified against the route's actual behavior (the list applies no implicit
+ * `isActive` filter — only `deletedAt: null`):
+ *   - `?isActive=true` hides an inactive currency; `?isActive=false` reveals it.
+ *   - the default (unfiltered) list still includes inactive currencies; only the
+ *     explicit active filter excludes them.
+ *   - DELETE soft-deletes (sets `deletedAt`), after which the row is absent from
+ *     every list view, including the inactive filter.
+ * All lookups are scoped by `?id=` so seeded/other-test currencies can't interfere.
+ */
+async function listById(
+  request: APIRequestContext,
+  token: string,
+  currencyId: string,
+  extra = '',
+): Promise<Array<{ id: string; isActive: boolean }>> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `/api/currencies/currencies?id=${encodeURIComponent(currencyId)}${extra}`,
+    { token },
+  );
+  expect(response.status(), `GET ?id=${currencyId}${extra} should return 200`).toBe(200);
+  const body = await readJsonSafe<{ items?: Array<{ id: string; isActive: boolean }> }>(response);
+  return body?.items ?? [];
+}
+
+test.describe('TC-CUR-011: currency active flag and soft delete', () => {
+  test('isActive filtering and DELETE soft-delete behave as the route defines', async ({ request }) => {
+    let token: string | null = null;
+    let currencyId: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+      currencyId = (await createRandomCurrencyFixture(request, token, { name: 'QA TC-CUR-011 Currency' })).id;
+
+      const initial = await listById(request, token, currencyId);
+      expect(initial.map((item) => item.id), 'new currency appears in the default list').toContain(currencyId);
+      expect(initial[0]?.isActive, 'new currency defaults to active').toBe(true);
+
+      const deactivate = await apiRequest(request, 'PUT', '/api/currencies/currencies', {
+        token,
+        data: { id: currencyId, isActive: false },
+      });
+      expect(deactivate.status(), 'PUT isActive=false should return 200').toBe(200);
+
+      const activeFiltered = await listById(request, token, currencyId, '&isActive=true');
+      expect(activeFiltered, 'isActive=true filter hides the deactivated currency').toHaveLength(0);
+
+      const inactiveFiltered = await listById(request, token, currencyId, '&isActive=false');
+      expect(inactiveFiltered.map((item) => item.id), 'isActive=false filter reveals the deactivated currency').toContain(currencyId);
+
+      const defaultAfterDeactivate = await listById(request, token, currencyId);
+      expect(
+        defaultAfterDeactivate.map((item) => item.id),
+        'default list still includes inactive currencies (only deletedAt excludes)',
+      ).toContain(currencyId);
+
+      const deleteResponse = await apiRequest(
+        request,
+        'DELETE',
+        `/api/currencies/currencies?id=${encodeURIComponent(currencyId)}`,
+        { token },
+      );
+      expect(deleteResponse.status(), 'DELETE should return 200').toBe(200);
+
+      const inactiveAfterDelete = await listById(request, token, currencyId, '&isActive=false');
+      expect(inactiveAfterDelete, 'soft-deleted currency is gone from the inactive filter').toHaveLength(0);
+
+      const defaultAfterDelete = await listById(request, token, currencyId);
+      expect(defaultAfterDelete, 'soft-deleted currency is gone from the default list').toHaveLength(0);
+      currencyId = null;
+    } finally {
+      await deleteCurrenciesEntityIfExists(request, token, '/api/currencies/currencies', currencyId);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds integration-test coverage for the `currencies` module (issue #2490): RBAC enforcement, exchange-rate validation boundaries, the fetch-rates and currency-options endpoints, cross-organization scoping, and soft-delete / active-flag behavior. Specs assert the module's **actual** API behavior — several auto-generated scenario assumptions did not match the implementation and were corrected (see Changes).

## Changes

- Add 7 Playwright integration specs under `packages/core/src/modules/currencies/__integration__/`:
  - **TC-CUR-005** — RBAC: `currencies.manage` gates currency POST/PUT/DELETE (view-only user → 403; GET → 200).
  - **TC-CUR-006** — RBAC: `currencies.rates.manage` gates exchange-rate mutations.
  - **TC-CUR-007** — Exchange-rate validation: self-reference, negative, zero, non-numeric, and >8-decimal rates → 400; valid → 201.
  - **TC-CUR-008** — `POST /api/currencies/fetch-rates` returns `{ totalFetched, byProvider, errors }` and stamps `lastSyncAt`/`lastSyncCount` on the matching fetch config.
  - **TC-CUR-009** — Currency options endpoint: code/name search, `limit`, and `includeInactive`.
  - **TC-CUR-010** — Cross-organization isolation: a currency in org B is invisible to an org-A user and vice versa.
  - **TC-CUR-011** — `isActive` filtering and soft-delete behavior.
- Add `createRandomCurrencyFixture` + `generateUniqueCurrencyCode` to `packages/core/src/helpers/integration/currenciesFixtures.ts` — collision-resistant currency fixtures (currency DELETE is a soft delete, but the `(org,tenant,code)` unique index counts soft-deleted rows, so re-using a code returns 500; the helper draws from the full 3-letter space minus seeded codes, reserves per worker, and retries on conflict). Additive — existing `createCurrencyFixture` is unchanged.
- Tests assert actual behavior, correcting the issue's auto-generated guesses: the default list shows inactive currencies (only `deletedAt` hides); `Custom` is an unregistered provider; the seeded `employee` role has no currencies features; the issue's literal currency codes are all seeded.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:** n/a — test-only coverage addition tracked by issue #2490.

## Testing

- Playwright integration specs against a seeded local `dev:app` on an isolated DB (`BASE_URL=http://127.0.0.1:3017`):
  - The 7 new specs: **7 passed, run 3× consecutively, 0 flaky.**
  - Full currencies suite (existing + new): 15 passed; the only failure is the pre-existing UI test **TC-CUR-004** ("Set Base Currency from UI"), which also fails in isolation under `dev:app` (its backend DataTable depends on query-index/search workers not spawned in this lean env) — unrelated to this change.
- `yarn typecheck` — 21/21 tasks successful.
- `yarn i18n:check-sync` — all 4 locales in sync.
- `yarn lint` — pre-existing tooling failure in `@open-mercato/app#lint` (`react/no-direct-mutation-state` fails to load under ESLint v9), reproduced on a clean tree with these changes stashed; not introduced here (this change adds only `packages/core` test files).
- `yarn test` (jest) — not applicable: no jest unit test imports the changed integration helper; the new specs are Playwright (excluded from jest); no product code changed.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- none required; i18n in sync -->
- [x] I added or adjusted tests that cover the change. <!-- the change is the tests -->
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- specs live in the module __integration__/ folder per .ai/qa/AGENTS.md; .ai/qa/tests holds only the shared Playwright config -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — test-only -->

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI (backend/API integration tests)
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2490