### PR TITLE
feat: 2488 attachments integration coverage

### DIFF
--- a/packages/core/src/modules/attachments/__integration__/TC-ATT-008.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATT-008.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  getTokenContext,
+  readJsonSafe,
+} from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import {
+  createUserFixture,
+  deleteUserIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import {
+  deleteAttachmentIfExists,
+  uploadAttachmentFixture,
+} from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
+
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
+
+/**
+ * TC-ATT-008: RBAC — 401 on missing auth and 403 on missing feature gates
+ * Source: GitHub issue #2488 (attachments integration coverage)
+ * Surfaces: /api/attachments (view/manage), /api/attachments/library (view),
+ *           /api/attachments/library/{id} (view/manage)
+ *
+ * The catch-all API guard returns 401 when authentication is required and absent,
+ * and 403 ({ error: 'Forbidden', requiredFeatures }) for an authenticated caller
+ * lacking the declared features. The gate runs before the route handler, so query
+ * validity is irrelevant for the negative cases.
+ */
+test.describe('TC-ATT-008: Attachment RBAC and feature gates', () => {
+  test('should enforce 401 without auth and 403 without attachments features', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { organizationId } = getTokenContext(adminToken)
+    const stamp = Date.now()
+    const recordId = `qa-rbac-008-${stamp}`
+    const recordQuery = `entityId=${encodeURIComponent('attachments:library')}&recordId=${encodeURIComponent(recordId)}`
+    const unprivilegedEmail = `qa-att-008-noaccess-${stamp}@test.invalid`
+
+    let attachmentId: string | null = null
+    let unprivilegedUserId: string | null = null
+
+    try {
+      // An authenticated principal with no roles → no attachments.* features.
+      unprivilegedUserId = await createUserFixture(request, adminToken, {
+        email: unprivilegedEmail,
+        password: 'Valid1!Pass',
+        organizationId,
+        roles: [],
+      })
+      const unprivilegedToken = await getAuthToken(request, unprivilegedEmail, 'Valid1!Pass')
+
+      // Seed an attachment as admin so the detail-route checks have a real target.
+      const uploaded = await uploadAttachmentFixture(request, adminToken, {
+        entityId: 'attachments:library',
+        recordId,
+        fileName: 'rbac-008.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('rbac gate fixture', 'utf8'),
+      })
+      attachmentId = uploaded.id
+      const detailPath = `/api/attachments/library/${encodeURIComponent(attachmentId)}`
+
+      // GET /api/attachments without any token → 401.
+      const recordListNoAuth = await request.fetch(`${BASE_URL}/api/attachments?${recordQuery}`, {
+        method: 'GET',
+      })
+      expect(recordListNoAuth.status(), 'GET /api/attachments without auth should be 401').toBe(401)
+
+      // GET /api/attachments with an unprivileged user (lacks attachments.view) → 403.
+      const recordListForbidden = await apiRequest(request, 'GET', `/api/attachments?${recordQuery}`, {
+        token: unprivilegedToken,
+      })
+      expect(recordListForbidden.status(), 'GET /api/attachments without attachments.view should be 403').toBe(403)
+
+      // GET /api/attachments/library without any token → 401.
+      const libraryNoAuth = await request.fetch(`${BASE_URL}/api/attachments/library`, { method: 'GET' })
+      expect(libraryNoAuth.status(), 'GET /api/attachments/library without auth should be 401').toBe(401)
+
+      // GET /api/attachments/library with unprivileged user (lacks attachments.view) → 403.
+      const libraryForbidden = await apiRequest(request, 'GET', '/api/attachments/library', {
+        token: unprivilegedToken,
+      })
+      expect(libraryForbidden.status(), 'GET /api/attachments/library without attachments.view should be 403').toBe(403)
+
+      // GET /api/attachments/library/{id} with unprivileged user (lacks attachments.view) → 403.
+      const detailForbidden = await apiRequest(request, 'GET', detailPath, { token: unprivilegedToken })
+      expect(detailForbidden.status(), 'GET detail without attachments.view should be 403').toBe(403)
+
+      // PATCH /api/attachments/library/{id} with unprivileged user (lacks attachments.manage) → 403.
+      const patchForbidden = await apiRequest(request, 'PATCH', detailPath, {
+        token: unprivilegedToken,
+        data: { tags: ['blocked'] },
+      })
+      expect(patchForbidden.status(), 'PATCH detail without attachments.manage should be 403').toBe(403)
+
+      // DELETE /api/attachments/library/{id} with unprivileged user (lacks attachments.manage) → 403.
+      const deleteForbidden = await apiRequest(request, 'DELETE', detailPath, { token: unprivilegedToken })
+      expect(deleteForbidden.status(), 'DELETE detail without attachments.manage should be 403').toBe(403)
+
+      // Admin with the features can read the same record → 200 (positive control).
+      const detailOk = await apiRequest(request, 'GET', detailPath, { token: adminToken })
+      expect(detailOk.status(), 'admin GET detail should be 200').toBe(200)
+      const detailBody = await readJsonSafe<{ item?: { id?: string } }>(detailOk)
+      expect(detailBody?.item?.id).toBe(attachmentId)
+    } finally {
+      await deleteAttachmentIfExists(request, adminToken, attachmentId)
+      await deleteUserIfExists(request, adminToken, unprivilegedUserId)
+    }
+  })
+})

--- a/packages/core/src/modules/attachments/__integration__/TC-ATT-009.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATT-009.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { deleteAttachmentIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
+
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
+
+/**
+ * TC-ATT-009: Upload validation — dangerous executable extensions are rejected
+ * Source: GitHub issue #2488 (attachments integration coverage)
+ * Surface: /api/attachments (POST)
+ *
+ * `hasDangerousExecutableExtension` rejects executable extensions (exe, bat, …)
+ * case-insensitively with HTTP 400 and a structured error message. Ordinary
+ * document/image types upload successfully.
+ *
+ * Assertions check the 400 status (the locale-independent contract) plus a
+ * non-empty error body — the rejection message is localized via `t(...)`, so
+ * matching specific English copy would be brittle across locales.
+ */
+
+// Minimal 10x10 red PNG (valid binary fixture), mirrors TC-ATT-005.
+function makeMinimalPng(): Buffer {
+  const base64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='
+  return Buffer.from(base64, 'base64')
+}
+
+async function uploadFile(
+  request: APIRequestContext,
+  token: string,
+  recordId: string,
+  file: { name: string; mimeType: string; buffer: Buffer },
+): Promise<APIResponse> {
+  return request.fetch(`${BASE_URL}/api/attachments`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    multipart: {
+      entityId: 'attachments:library',
+      recordId,
+      file,
+    },
+  })
+}
+
+test.describe('TC-ATT-009: Attachment upload validation (dangerous extensions)', () => {
+  test('should reject executable uploads with 400 and allow legitimate types', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    const recordId = `qa-validation-009-${stamp}`
+    const createdIds: string[] = []
+
+    try {
+      // .exe → 400, message mentions "Executable".
+      const exeResponse = await uploadFile(request, token, recordId, {
+        name: 'payload.exe',
+        mimeType: 'application/octet-stream',
+        buffer: Buffer.from('MZ executable stub', 'utf8'),
+      })
+      expect(exeResponse.status(), '.exe upload should be 400').toBe(400)
+      const exeBody = await readJsonSafe<{ error?: string }>(exeResponse)
+      expect(
+        typeof exeBody?.error === 'string' && exeBody.error.length > 0,
+        '.exe rejection should include an error message',
+      ).toBe(true)
+
+      // .bat → 400.
+      const batResponse = await uploadFile(request, token, recordId, {
+        name: 'script.bat',
+        mimeType: 'application/octet-stream',
+        buffer: Buffer.from('@echo off', 'utf8'),
+      })
+      expect(batResponse.status(), '.bat upload should be 400').toBe(400)
+      const batBody = await readJsonSafe<{ error?: string }>(batResponse)
+      expect(
+        typeof batBody?.error === 'string' && batBody.error.length > 0,
+        '.bat rejection should include an error message',
+      ).toBe(true)
+
+      // Uppercase .EXE → 400 (extension matching is case-insensitive).
+      const upperExeResponse = await uploadFile(request, token, recordId, {
+        name: 'PAYLOAD.EXE',
+        mimeType: 'application/octet-stream',
+        buffer: Buffer.from('MZ executable stub', 'utf8'),
+      })
+      expect(upperExeResponse.status(), '.EXE upload should be 400').toBe(400)
+
+      // .txt → 200 (sanity).
+      const txtResponse = await uploadFile(request, token, recordId, {
+        name: 'notes.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('plain text body', 'utf8'),
+      })
+      expect(txtResponse.status(), '.txt upload should be 200').toBe(200)
+      const txtBody = await readJsonSafe<{ item?: { id?: string } }>(txtResponse)
+      if (txtBody?.item?.id) createdIds.push(txtBody.item.id)
+
+      // Legitimate image → 200.
+      const pngResponse = await uploadFile(request, token, recordId, {
+        name: 'picture.png',
+        mimeType: 'image/png',
+        buffer: makeMinimalPng(),
+      })
+      expect(pngResponse.status(), '.png upload should be 200').toBe(200)
+      const pngBody = await readJsonSafe<{ item?: { id?: string } }>(pngResponse)
+      if (pngBody?.item?.id) createdIds.push(pngBody.item.id)
+
+      // Legitimate document → 200.
+      const pdfResponse = await uploadFile(request, token, recordId, {
+        name: 'document.pdf',
+        mimeType: 'application/pdf',
+        buffer: Buffer.from('%PDF-1.4 minimal document', 'utf8'),
+      })
+      expect(pdfResponse.status(), '.pdf upload should be 200').toBe(200)
+      const pdfBody = await readJsonSafe<{ item?: { id?: string } }>(pdfResponse)
+      if (pdfBody?.item?.id) createdIds.push(pdfBody.item.id)
+    } finally {
+      for (const id of createdIds) {
+        await deleteAttachmentIfExists(request, token, id)
+      }
+    }
+  })
+})

--- a/packages/core/src/modules/attachments/__integration__/TC-ATT-010.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATT-010.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import {
+  deleteAttachmentIfExists,
+  uploadAttachmentFixture,
+} from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
+
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
+
+/**
+ * TC-ATT-010: Image route — dimension validation and unsupported media types
+ * Source: GitHub issue #2488 (attachments integration coverage)
+ * Surface: /api/attachments/image/{id} (GET)
+ *
+ * The route rejects non-image attachments with 400 "Unsupported media type" and
+ * out-of-range width/height (zod min 1, max 4000) with 400 "Invalid size parameters".
+ * A valid in-range request returns 200 with binary image content.
+ */
+
+// A 32x32 solid PNG re-encoded by sharp/libvips. The image route resizes with
+// sharp's `failOn: 'error'`, which rejects PNGs whose pixel data trips libspng's
+// strict decoder. A sharp-encoded buffer decodes cleanly through that path.
+function makeRenderablePng(): Buffer {
+  const base64 =
+    'iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAKklEQVR42mO4o6FBU8QwasGoBaMWjFowasGoBaMWjFowasGoBaMWDBULAIahsD0l4r5QAAAAAElFTkSuQmCC'
+  return Buffer.from(base64, 'base64')
+}
+
+test.describe('TC-ATT-010: Attachment image route validation', () => {
+  test('should reject non-images and out-of-range dimensions, and serve valid sizes', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    let textAttachmentId: string | null = null
+    let imageAttachmentId: string | null = null
+
+    const fetchImage = (id: string, query = '') =>
+      request.fetch(`${BASE_URL}/api/attachments/image/${encodeURIComponent(id)}${query}`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+
+    try {
+      // A text attachment is not renderable as an image → 400 "Unsupported media type".
+      const textUpload = await uploadAttachmentFixture(request, token, {
+        entityId: 'attachments:library',
+        recordId: `qa-image-010-text-${stamp}`,
+        fileName: 'not-an-image.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('definitely not an image', 'utf8'),
+      })
+      textAttachmentId = textUpload.id
+
+      const unsupported = await fetchImage(textAttachmentId)
+      expect(unsupported.status(), 'image route on text file should be 400').toBe(400)
+      const unsupportedBody = await readJsonSafe<{ error?: string }>(unsupported)
+      expect(unsupportedBody?.error ?? '').toContain('Unsupported media type')
+
+      // A real PNG is renderable.
+      const imageUpload = await uploadAttachmentFixture(request, token, {
+        entityId: 'attachments:library',
+        recordId: `qa-image-010-png-${stamp}`,
+        fileName: 'red-pixel.png',
+        mimeType: 'image/png',
+        buffer: makeRenderablePng(),
+      })
+      imageAttachmentId = imageUpload.id
+
+      // width above the 4000 ceiling → 400.
+      const tooWide = await fetchImage(imageAttachmentId, '?width=5000')
+      expect(tooWide.status(), 'width=5000 should be 400').toBe(400)
+
+      // height above the 4000 ceiling → 400.
+      const tooTall = await fetchImage(imageAttachmentId, '?height=5000')
+      expect(tooTall.status(), 'height=5000 should be 400').toBe(400)
+
+      // zero width → 400.
+      const zeroWidth = await fetchImage(imageAttachmentId, '?width=0')
+      expect(zeroWidth.status(), 'width=0 should be 400').toBe(400)
+
+      // negative width → 400.
+      const negativeWidth = await fetchImage(imageAttachmentId, '?width=-1')
+      expect(negativeWidth.status(), 'width=-1 should be 400').toBe(400)
+
+      // valid in-range dimensions → 200 with image content.
+      const validResize = await fetchImage(imageAttachmentId, '?width=100&height=100')
+      expect(validResize.status(), 'width=100&height=100 should be 200').toBe(200)
+      expect(validResize.headers()['content-type'] ?? '').toMatch(/^image\//)
+      const imageBytes = await validResize.body()
+      expect(imageBytes.length, 'resized image should have a non-empty body').toBeGreaterThan(0)
+    } finally {
+      await deleteAttachmentIfExists(request, token, textAttachmentId)
+      await deleteAttachmentIfExists(request, token, imageAttachmentId)
+    }
+  })
+})

--- a/packages/core/src/modules/attachments/__integration__/TC-ATT-011.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATT-011.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import {
+  deleteAttachmentIfExists,
+  uploadAttachmentFixture,
+} from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
+
+/**
+ * TC-ATT-011: Library search, tag filter, sorting and pagination
+ * Source: GitHub issue #2488 (attachments integration coverage)
+ * Surface: /api/attachments/library (GET)
+ *
+ * The library lists every attachment in the caller's tenant/org, so this test
+ * isolates its fixtures with a unique fileName prefix and unique tags. Within that
+ * isolated set it asserts fileName ILIKE search, tag containment filtering,
+ * fileName/createdAt sorting, and page/pageSize pagination.
+ */
+
+type LibraryItem = { id: string; fileName: string }
+type LibraryResponse = {
+  items?: LibraryItem[]
+  total?: number
+  page?: number
+  pageSize?: number
+  totalPages?: number
+}
+
+async function libraryQuery(
+  request: APIRequestContext,
+  token: string,
+  query: string,
+): Promise<LibraryResponse> {
+  const response = await apiRequest(request, 'GET', `/api/attachments/library?${query}`, { token })
+  expect(response.status(), `GET /api/attachments/library?${query} should be 200`).toBe(200)
+  return (await readJsonSafe<LibraryResponse>(response)) ?? {}
+}
+
+test.describe('TC-ATT-011: Attachment library search, filter, sort, pagination', () => {
+  test('should search by name, filter by tag, sort, and paginate within an isolated set', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    const prefix = `att011-${stamp}-`
+    const tagMonthly = `att011-monthly-${stamp}`
+    const tagFinancial = `att011-financial-${stamp}`
+    const recordId = `qa-library-011-${stamp}`
+
+    let janId: string | null = null
+    let febId: string | null = null
+    let marchId: string | null = null
+
+    // Restrict response items to this test's own fixtures, preserving server order.
+    const ownOrder = (items: LibraryItem[] | undefined, own: Set<string>): string[] =>
+      (items ?? []).map((item) => item.id).filter((id) => own.has(id))
+
+    try {
+      // Uploaded sequentially so createdAt is strictly increasing: jan < feb < march.
+      const jan = await uploadAttachmentFixture(request, token, {
+        entityId: 'attachments:library',
+        recordId,
+        fileName: `${prefix}report-jan.txt`,
+        mimeType: 'text/plain',
+        buffer: Buffer.from('january report', 'utf8'),
+        tags: [tagMonthly],
+      })
+      janId = jan.id
+      const feb = await uploadAttachmentFixture(request, token, {
+        entityId: 'attachments:library',
+        recordId,
+        fileName: `${prefix}report-feb.txt`,
+        mimeType: 'text/plain',
+        buffer: Buffer.from('february report', 'utf8'),
+        tags: [tagMonthly],
+      })
+      febId = feb.id
+      const march = await uploadAttachmentFixture(request, token, {
+        entityId: 'attachments:library',
+        recordId,
+        fileName: `${prefix}invoice-march.txt`,
+        mimeType: 'text/plain',
+        buffer: Buffer.from('march invoice', 'utf8'),
+        tags: [tagFinancial],
+      })
+      marchId = march.id
+
+      const ownIds = new Set<string>([janId, febId, marchId])
+
+      // 1) Search by fileName (ILIKE) — "report" prefix matches the two reports only.
+      const reportSearch = await libraryQuery(request, token, `search=${encodeURIComponent(`${prefix}report`)}`)
+      const reportIds = new Set(ownOrder(reportSearch.items, ownIds))
+      expect(reportIds.has(janId)).toBe(true)
+      expect(reportIds.has(febId)).toBe(true)
+      expect(reportIds.has(marchId)).toBe(false)
+
+      // 2) Search isolates the invoice file only.
+      const invoiceSearch = await libraryQuery(request, token, `search=${encodeURIComponent(`${prefix}invoice`)}`)
+      const invoiceIds = new Set(ownOrder(invoiceSearch.items, ownIds))
+      expect(invoiceIds.has(marchId)).toBe(true)
+      expect(invoiceIds.has(janId)).toBe(false)
+      expect(invoiceIds.has(febId)).toBe(false)
+
+      // 3) Tag filter — monthly tag returns the two reports.
+      const monthly = await libraryQuery(request, token, `tags=${encodeURIComponent(tagMonthly)}`)
+      const monthlyIds = new Set(ownOrder(monthly.items, ownIds))
+      expect(monthlyIds.has(janId)).toBe(true)
+      expect(monthlyIds.has(febId)).toBe(true)
+      expect(monthlyIds.has(marchId)).toBe(false)
+
+      // 4) Tag filter — financial tag returns the invoice only.
+      const financial = await libraryQuery(request, token, `tags=${encodeURIComponent(tagFinancial)}`)
+      const financialIds = new Set(ownOrder(financial.items, ownIds))
+      expect(financialIds.has(marchId)).toBe(true)
+      expect(financialIds.has(janId)).toBe(false)
+      expect(financialIds.has(febId)).toBe(false)
+
+      // 5) Sort by fileName ascending → invoice-march, report-feb, report-jan.
+      const byNameAsc = await libraryQuery(
+        request,
+        token,
+        `search=${encodeURIComponent(prefix)}&sortField=fileName&sortDir=asc`,
+      )
+      expect(ownOrder(byNameAsc.items, ownIds)).toEqual([marchId, febId, janId])
+
+      // 6) Sort by createdAt descending → newest first (march, feb, jan).
+      const byCreatedDesc = await libraryQuery(
+        request,
+        token,
+        `search=${encodeURIComponent(prefix)}&sortField=createdAt&sortDir=desc`,
+      )
+      expect(ownOrder(byCreatedDesc.items, ownIds)).toEqual([marchId, febId, janId])
+
+      // 7) Pagination over the isolated set (alphabetical), pageSize 2.
+      const page1 = await libraryQuery(
+        request,
+        token,
+        `search=${encodeURIComponent(prefix)}&sortField=fileName&sortDir=asc&page=1&pageSize=2`,
+      )
+      expect(page1.total).toBe(3)
+      expect(page1.totalPages).toBe(2)
+      expect(ownOrder(page1.items, ownIds)).toEqual([marchId, febId])
+
+      const page2 = await libraryQuery(
+        request,
+        token,
+        `search=${encodeURIComponent(prefix)}&sortField=fileName&sortDir=asc&page=2&pageSize=2`,
+      )
+      expect(ownOrder(page2.items, ownIds)).toEqual([janId])
+    } finally {
+      await deleteAttachmentIfExists(request, token, janId)
+      await deleteAttachmentIfExists(request, token, febId)
+      await deleteAttachmentIfExists(request, token, marchId)
+    }
+  })
+})

--- a/packages/core/src/modules/attachments/__integration__/TC-ATT-012.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATT-012.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { deleteAttachmentPartitionIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
+
+/**
+ * TC-ATT-012: Partition uniqueness — duplicate code rejected with 409
+ * Source: GitHub issue #2488 (attachments integration coverage)
+ * Surface: /api/attachments/partitions (POST, GET)
+ *
+ * Partition mutations are locked when DEMO_MODE/self-service onboarding is active
+ * (the common case), in which POST returns 403. When unlocked, creating a duplicate
+ * code returns 409 while a distinct code still succeeds.
+ */
+test.describe('TC-ATT-012: Attachment partition uniqueness', () => {
+  test('should reject duplicate partition codes with 409 when partitions are unlocked', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    const code = `qa_unique_012_${stamp}`
+    const otherCode = `qa_unique_012b_${stamp}`
+
+    let partitionId: string | null = null
+    let otherPartitionId: string | null = null
+
+    try {
+      const createResponse = await apiRequest(request, 'POST', '/api/attachments/partitions', {
+        token,
+        data: { code, title: 'QA Unique 012' },
+      })
+
+      // Environment-locked deployments manage partitions via env and return 403.
+      if (createResponse.status() === 403) {
+        test.skip(true, 'Attachment partitions are environment-locked (DEMO_MODE/onboarding); skipping uniqueness checks.')
+      }
+
+      expect(createResponse.status(), 'first partition create should be 201').toBe(201)
+      const createBody = await readJsonSafe<{ item?: { id?: string; code?: string } }>(createResponse)
+      partitionId = createBody?.item?.id ?? null
+      expect(createBody?.item?.code).toBe(code)
+
+      // Duplicate code → 409 with a uniqueness message.
+      const duplicateResponse = await apiRequest(request, 'POST', '/api/attachments/partitions', {
+        token,
+        data: { code, title: 'QA Unique 012 Duplicate' },
+      })
+      expect(duplicateResponse.status(), 'duplicate code should be 409').toBe(409)
+      const duplicateBody = await readJsonSafe<{ error?: string }>(duplicateResponse)
+      expect(duplicateBody?.error ?? '').toMatch(/already exists/i)
+
+      // A distinct code still succeeds (no interference).
+      const otherResponse = await apiRequest(request, 'POST', '/api/attachments/partitions', {
+        token,
+        data: { code: otherCode, title: 'QA Unique 012 Other' },
+      })
+      expect(otherResponse.status(), 'distinct code create should be 201').toBe(201)
+      const otherBody = await readJsonSafe<{ item?: { id?: string } }>(otherResponse)
+      otherPartitionId = otherBody?.item?.id ?? null
+
+      // Listing includes both new partitions.
+      const listResponse = await apiRequest(request, 'GET', '/api/attachments/partitions', { token })
+      expect(listResponse.status()).toBe(200)
+      const listBody = await readJsonSafe<{ items?: Array<{ code?: string }> }>(listResponse)
+      const codes = new Set((listBody?.items ?? []).map((entry) => entry.code))
+      expect(codes.has(code)).toBe(true)
+      expect(codes.has(otherCode)).toBe(true)
+    } finally {
+      await deleteAttachmentPartitionIfExists(request, token, partitionId)
+      await deleteAttachmentPartitionIfExists(request, token, otherPartitionId)
+    }
+  })
+})

--- a/packages/core/src/modules/attachments/__integration__/TC-ATT-013.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATT-013.spec.ts
@@ -1,0 +1,118 @@
+import { randomUUID } from 'crypto'
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import {
+  deleteAttachmentIfExists,
+  uploadAttachmentFixture,
+} from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
+
+/**
+ * TC-ATT-013: Transfer API — payload and matching validation
+ * Source: GitHub issue #2488 (attachments integration coverage)
+ * Surface: /api/attachments/transfer (POST)
+ *
+ * Empty attachmentIds or a missing toRecordId fail schema validation (400). A valid
+ * UUID that matches no record, or a mismatched entityId, yields 404. A valid transfer
+ * moves recordId and rewrites the matching assignment to the new record.
+ */
+test.describe('TC-ATT-013: Attachment transfer validation', () => {
+  test('should validate payloads, matching, and perform a real transfer', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    const entityId = 'example:todo'
+    const fromRecordId = `att013-from-${stamp}`
+    const toRecordId = `att013-to-${stamp}`
+
+    let attachmentId: string | null = null
+
+    try {
+      const uploaded = await uploadAttachmentFixture(request, token, {
+        entityId,
+        recordId: fromRecordId,
+        fileName: 'transfer-013.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('transfer fixture', 'utf8'),
+      })
+      attachmentId = uploaded.id
+
+      // Empty attachmentIds → 400 (schema requires at least one).
+      const emptyResponse = await apiRequest(request, 'POST', '/api/attachments/transfer', {
+        token,
+        data: { entityId, attachmentIds: [], toRecordId },
+      })
+      expect(emptyResponse.status(), 'empty attachmentIds should be 400').toBe(400)
+
+      // Missing toRecordId → 400 (schema requires it).
+      const missingTargetResponse = await apiRequest(request, 'POST', '/api/attachments/transfer', {
+        token,
+        data: { entityId, attachmentIds: [attachmentId] },
+      })
+      expect(missingTargetResponse.status(), 'missing toRecordId should be 400').toBe(400)
+
+      // Valid UUID that matches no attachment → 404.
+      const missingRecordResponse = await apiRequest(request, 'POST', '/api/attachments/transfer', {
+        token,
+        data: { entityId, attachmentIds: [randomUUID()], toRecordId },
+      })
+      expect(missingRecordResponse.status(), 'non-existent attachmentId should be 404').toBe(404)
+
+      // Mismatched entityId (attachment belongs to example:todo) → 404.
+      const mismatchedResponse = await apiRequest(request, 'POST', '/api/attachments/transfer', {
+        token,
+        data: { entityId: 'example:note', attachmentIds: [attachmentId], toRecordId },
+      })
+      expect(mismatchedResponse.status(), 'mismatched entityId should be 404').toBe(404)
+
+      // Valid transfer → 200 { ok: true, updated: 1 }.
+      const transferResponse = await apiRequest(request, 'POST', '/api/attachments/transfer', {
+        token,
+        data: { entityId, attachmentIds: [attachmentId], toRecordId },
+      })
+      expect(transferResponse.status(), 'valid transfer should be 200').toBe(200)
+      const transferBody = await readJsonSafe<{ ok?: boolean; updated?: number }>(transferResponse)
+      expect(transferBody?.ok).toBe(true)
+      expect(transferBody?.updated).toBe(1)
+
+      // The attachment now lives under the target record and not the source record.
+      const atTarget = await apiRequest(
+        request,
+        'GET',
+        `/api/attachments?entityId=${encodeURIComponent(entityId)}&recordId=${encodeURIComponent(toRecordId)}`,
+        { token },
+      )
+      expect(atTarget.status()).toBe(200)
+      const atTargetBody = await readJsonSafe<{ items?: Array<{ id: string }> }>(atTarget)
+      expect(atTargetBody?.items?.some((item) => item.id === attachmentId)).toBe(true)
+
+      const atSource = await apiRequest(
+        request,
+        'GET',
+        `/api/attachments?entityId=${encodeURIComponent(entityId)}&recordId=${encodeURIComponent(fromRecordId)}`,
+        { token },
+      )
+      expect(atSource.status()).toBe(200)
+      const atSourceBody = await readJsonSafe<{ items?: Array<{ id: string }> }>(atSource)
+      expect(atSourceBody?.items?.some((item) => item.id === attachmentId)).toBe(false)
+
+      // The auto-created assignment was rewritten to the new record id.
+      const detail = await apiRequest(
+        request,
+        'GET',
+        `/api/attachments/library/${encodeURIComponent(attachmentId)}`,
+        { token },
+      )
+      expect(detail.status()).toBe(200)
+      const detailBody = await readJsonSafe<{
+        item?: { assignments?: Array<{ type: string; id: string }> }
+      }>(detail)
+      expect(
+        detailBody?.item?.assignments?.some(
+          (assignment) => assignment.type === entityId && assignment.id === toRecordId,
+        ),
+      ).toBe(true)
+    } finally {
+      await deleteAttachmentIfExists(request, token, attachmentId)
+    }
+  })
+})

--- a/packages/core/src/modules/attachments/__integration__/TC-ATT-014.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATT-014.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  deleteAttachmentIfExists,
+  uploadAttachmentFixture,
+} from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
+
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
+
+/**
+ * TC-ATT-014: File route — public vs private cache headers, inline disposition, access model
+ * Source: GitHub issue #2488 (attachments integration coverage)
+ * Surface: /api/attachments/file/{id} (GET)
+ *
+ * The file route stamps `Cache-Control: public, max-age=86400` for public-partition
+ * files and `private, max-age=60` for private ones, always sets a sandboxed CSP and
+ * nosniff, and serves viewable images inline. A file lands in the public `productsMedia`
+ * partition by uploading with the catalog product entityId (default routing); explicit
+ * public-partition overrides are rejected by the upload route.
+ *
+ * Note on unauthenticated access: the upload API always tenant-scopes attachment rows,
+ * and the access model returns 401 for any scoped row read without auth — even on a
+ * public partition (only legacy null-scope rows are publicly readable). So this test
+ * asserts the real behavior (401), not an unauthenticated 200.
+ */
+test.describe('TC-ATT-014: Attachment file route headers and access', () => {
+  test('should set public/private cache headers, inline images, and gate unauthenticated reads', async ({
+    request,
+  }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+
+    let privateTextId: string | null = null
+    let privateImageId: string | null = null
+    let publicImageId: string | null = null
+
+    const fetchFile = (id: string, withAuth: boolean) =>
+      request.fetch(`${BASE_URL}/api/attachments/file/${encodeURIComponent(id)}`, {
+        method: 'GET',
+        headers: withAuth ? { Authorization: `Bearer ${token}` } : undefined,
+      })
+
+    try {
+      // Private text file (default privateAttachments partition).
+      const privateText = await uploadAttachmentFixture(request, token, {
+        entityId: 'attachments:library',
+        recordId: `qa-file-014-private-${stamp}`,
+        fileName: 'private-014.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('private file body', 'utf8'),
+      })
+      privateTextId = privateText.id
+
+      const privateResponse = await fetchFile(privateTextId, true)
+      expect(privateResponse.status(), 'authenticated private file read should be 200').toBe(200)
+      expect(privateResponse.headers()['cache-control']).toBe('private, max-age=60')
+      expect(privateResponse.headers()['content-security-policy'] ?? '').toContain('sandbox')
+      expect(privateResponse.headers()['x-content-type-options']).toBe('nosniff')
+
+      // Private image is served inline with its image content type.
+      const privateImage = await uploadAttachmentFixture(request, token, {
+        entityId: 'attachments:library',
+        recordId: `qa-file-014-image-${stamp}`,
+        fileName: 'inline-014.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from(
+          'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==',
+          'base64',
+        ),
+      })
+      privateImageId = privateImage.id
+
+      const imageResponse = await fetchFile(privateImageId, true)
+      expect(imageResponse.status()).toBe(200)
+      expect(imageResponse.headers()['content-type']).toBe('image/png')
+      expect(imageResponse.headers()['content-disposition'] ?? '').toContain('inline')
+      expect(imageResponse.headers()['cache-control']).toBe('private, max-age=60')
+
+      // Public file: the catalog product entityId routes uploads to the public
+      // `productsMedia` partition without an explicit (rejected) override.
+      const publicImage = await uploadAttachmentFixture(request, token, {
+        entityId: 'catalog:catalog_product',
+        recordId: `qa-file-014-public-${stamp}`,
+        fileName: 'public-014.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from(
+          'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==',
+          'base64',
+        ),
+      })
+      publicImageId = publicImage.id
+      expect(publicImage.partitionCode, 'catalog product upload should route to productsMedia').toBe('productsMedia')
+
+      const publicResponse = await fetchFile(publicImageId, true)
+      expect(publicResponse.status(), 'authenticated public file read should be 200').toBe(200)
+      expect(publicResponse.headers()['cache-control']).toBe('public, max-age=86400')
+      expect(publicResponse.headers()['content-security-policy'] ?? '').toContain('sandbox')
+
+      // Unauthenticated reads of tenant-scoped rows are gated with 401 on both partitions.
+      const privateNoAuth = await fetchFile(privateTextId, false)
+      expect(privateNoAuth.status(), 'unauthenticated private read should be 401').toBe(401)
+
+      const publicNoAuth = await fetchFile(publicImageId, false)
+      expect(publicNoAuth.status(), 'unauthenticated public read of a scoped row should be 401').toBe(401)
+    } finally {
+      await deleteAttachmentIfExists(request, token, privateTextId)
+      await deleteAttachmentIfExists(request, token, privateImageId)
+      await deleteAttachmentIfExists(request, token, publicImageId)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Adds the 7 high-value integration-test scenarios requested in #2488 to close the
`attachments` module coverage gaps (RBAC/feature gates, upload validation, image-route
validation, library search/filter/sort/pagination, partition uniqueness, transfer
validation, and file-route headers/access). Test-only change — no product code modified.

## Changes

- Add `TC-ATT-008` — RBAC: 401 unauthenticated and 403 without `attachments.view`/`.manage` across `/api/attachments`, `/api/attachments/library`, `/api/attachments/library/{id}` (+ admin positive control)
- Add `TC-ATT-009` — upload validation: dangerous executable extensions (`.exe/.bat/.EXE`) rejected with 400; `.txt/.png/.pdf` accepted
- Add `TC-ATT-010` — image route: non-image → 400 "Unsupported media type"; width/height `0/-1/5000` → 400; valid `100×100` → 200 with image content
- Add `TC-ATT-011` — library: fileName ILIKE search, tag containment filter, fileName/createdAt sort, page/pageSize pagination (fixtures isolated by a unique prefix + unique tags)
- Add `TC-ATT-012` — partition uniqueness: duplicate code → 409; distinct code → 201 (skips gracefully when partitions are environment-locked)
- Add `TC-ATT-013` — transfer: empty `attachmentIds`/missing `toRecordId` → 400; bad/mismatched id → 404; valid transfer → `{ ok, updated: 1 }` with record + assignment rewritten
- Add `TC-ATT-014` — file route: public (`max-age=86400`) vs private (`max-age=60`) `Cache-Control`, inline disposition for images, CSP + `nosniff`, and unauthenticated reads of tenant-scoped rows → 401

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — coverage-gap issue #2488; scenarios are specified in the issue itself.

## Testing

- `yarn test:integration:ephemeral --filter "attachments/__integration__/TC-ATT-0"` → **10 passed** (TC-ATT-008→014 plus existing TC-ATT-001–003; S3 004–007 skip without LocalStack)
- `BASE_URL=… npx playwright test … TC-ATT-009.spec.ts TC-ATT-010.spec.ts --retries=0` → **2 passed** (final code)
- `npx tsc -p packages/core/tsconfig.json --noEmit` → **exit 0** (`__integration__` specs are in scope)
- Each spec creates its fixtures via API and cleans them up in `finally`; no reliance on seeded/demo data.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). _(author to confirm on submit)_
- [x] I updated documentation, locales, or generators if the change requires it. _(none required — test-only)_
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). _(placed in the module's preferred `packages/core/src/modules/attachments/__integration__/` location per `.ai/qa/AGENTS.md`; `.ai/qa/tests/` is config-only)_
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). _(N/A — coverage-gap issue, no spec)_

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled — N/A, no UI
- [x] Loading state handled — N/A, no UI
- [x] `aria-label` on icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2488