### PR TITLE
feat: 2487 payment gateways integration coverage

### DIFF
--- a/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-014.spec.ts
+++ b/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-014.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import { getTokenScope } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+
+/**
+ * TC-PGWY-014: RBAC feature gates — 403 when missing required payment_gateways features
+ *
+ * Every payment_gateways API route declares `requireFeatures` in its metadata and the
+ * central API dispatcher (apps/mercato/src/app/api/[...slug]/route.ts) enforces them via
+ * `rbacService.userHasAllFeatures`, returning 403 before the handler runs. This proves the
+ * gates are wired per-feature, not all-or-nothing:
+ *   - /sessions, /cancel                 → payment_gateways.manage
+ *   - /capture                           → payment_gateways.capture
+ *   - /refund                            → payment_gateways.refund
+ *   - /transactions, /status, /providers → payment_gateways.view
+ *
+ * A user holding only `manage` is rejected from view/capture/refund routes, and a user
+ * holding only `view` is rejected from manage/capture/refund routes — while each is still
+ * allowed on the route its single feature covers.
+ */
+const PASSWORD = 'Qa!2026Pgwy'
+const unique = () => `${Date.now()}-${Math.floor(Math.random() * 1_000_000_000)}`
+
+test.describe('TC-PGWY-014: RBAC feature gates (403)', () => {
+  test('enforces per-feature access across payment_gateways routes', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const superToken = await getAuthToken(request, 'superadmin')
+    const { organizationId, tenantId } = getTokenScope(adminToken)
+    expect(organizationId, 'admin token must carry a concrete organization').toBeTruthy()
+    expect(tenantId, 'admin token must carry a concrete tenant').toBeTruthy()
+
+    let manageRoleId: string | null = null
+    let viewRoleId: string | null = null
+    let manageUserId: string | null = null
+    let viewUserId: string | null = null
+
+    try {
+      manageRoleId = await createRoleFixture(request, superToken, { name: `qa-pgwy-manage-${unique()}`, tenantId })
+      await setRoleAclFeatures(request, superToken, { roleId: manageRoleId, features: ['payment_gateways.manage'] })
+      const manageEmail = `qa-pgwy-manage-${unique()}@acme.com`
+      manageUserId = await createUserFixture(request, superToken, {
+        email: manageEmail,
+        password: PASSWORD,
+        organizationId,
+        roles: [manageRoleId],
+        name: 'QA PGWY Manage Only',
+      })
+      const manageToken = await getAuthToken(request, manageEmail, PASSWORD)
+
+      viewRoleId = await createRoleFixture(request, superToken, { name: `qa-pgwy-view-${unique()}`, tenantId })
+      await setRoleAclFeatures(request, superToken, { roleId: viewRoleId, features: ['payment_gateways.view'] })
+      const viewEmail = `qa-pgwy-view-${unique()}@acme.com`
+      viewUserId = await createUserFixture(request, superToken, {
+        email: viewEmail,
+        password: PASSWORD,
+        organizationId,
+        roles: [viewRoleId],
+        name: 'QA PGWY View Only',
+      })
+      const viewToken = await getAuthToken(request, viewEmail, PASSWORD)
+
+      const createSessionAsManage = await apiRequest(request, 'POST', '/api/payment_gateways/sessions', {
+        token: manageToken,
+        data: { providerKey: 'mock', amount: 10, currencyCode: 'USD', captureMethod: 'manual' },
+      })
+      expect(createSessionAsManage.status(), 'manage feature permits session creation').toBe(201)
+
+      const listAsManage = await apiRequest(request, 'GET', '/api/payment_gateways/transactions', { token: manageToken })
+      expect(listAsManage.status(), 'view feature required for transactions list').toBe(403)
+
+      const statusAsManage = await apiRequest(request, 'GET', `/api/payment_gateways/status?transactionId=${randomUUID()}`, { token: manageToken })
+      expect(statusAsManage.status(), 'view feature required for status').toBe(403)
+
+      const captureAsManage = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
+        token: manageToken,
+        data: { transactionId: randomUUID() },
+      })
+      expect(captureAsManage.status(), 'capture feature required for capture').toBe(403)
+
+      const refundAsManage = await apiRequest(request, 'POST', '/api/payment_gateways/refund', {
+        token: manageToken,
+        data: { transactionId: randomUUID() },
+      })
+      expect(refundAsManage.status(), 'refund feature required for refund').toBe(403)
+
+      const listAsView = await apiRequest(request, 'GET', '/api/payment_gateways/transactions', { token: viewToken })
+      expect(listAsView.status(), 'view feature permits transactions list').toBe(200)
+
+      const createSessionAsView = await apiRequest(request, 'POST', '/api/payment_gateways/sessions', {
+        token: viewToken,
+        data: { providerKey: 'mock', amount: 10, currencyCode: 'USD', captureMethod: 'manual' },
+      })
+      expect(createSessionAsView.status(), 'manage feature required for session creation').toBe(403)
+
+      const cancelAsView = await apiRequest(request, 'POST', '/api/payment_gateways/cancel', {
+        token: viewToken,
+        data: { transactionId: randomUUID() },
+      })
+      expect(cancelAsView.status(), 'manage feature required for cancel').toBe(403)
+
+      const captureAsView = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
+        token: viewToken,
+        data: { transactionId: randomUUID() },
+      })
+      expect(captureAsView.status(), 'capture feature required for capture').toBe(403)
+
+      const refundAsView = await apiRequest(request, 'POST', '/api/payment_gateways/refund', {
+        token: viewToken,
+        data: { transactionId: randomUUID() },
+      })
+      expect(refundAsView.status(), 'refund feature required for refund').toBe(403)
+    } finally {
+      await deleteUserIfExists(request, superToken, manageUserId)
+      await deleteUserIfExists(request, superToken, viewUserId)
+      await deleteRoleIfExists(request, superToken, manageRoleId)
+      await deleteRoleIfExists(request, superToken, viewRoleId)
+    }
+  })
+})

--- a/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-015.spec.ts
+++ b/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-015.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { createPaymentSession } from './helpers/fixtures'
+
+/**
+ * TC-PGWY-015: Query parameter validation on GET /transactions
+ *
+ * `listTransactionsQuerySchema` validates page/pageSize/status before any DB query.
+ * Invalid query parameters are rejected with 400 `{ error: 'Invalid query', details }`
+ * where `details` is the flattened zod error. Valid filters return a 200 paged result.
+ */
+type ListResponse = {
+  items: Array<{ id: string; providerKey: string; unifiedStatus: string }>
+  total: number
+  page: number
+  pageSize: number
+  totalPages: number
+}
+
+type ValidationError = {
+  error: string
+  details?: { fieldErrors?: Record<string, string[]> }
+}
+
+test.describe('TC-PGWY-015: Transactions list query validation', () => {
+  test('rejects invalid page/pageSize/status with 400', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const pageZero = await apiRequest(request, 'GET', '/api/payment_gateways/transactions?page=0', { token })
+    expect(pageZero.status(), 'page=0 is below the minimum').toBe(400)
+    const pageZeroBody = await readJsonSafe<ValidationError>(pageZero)
+    expect(pageZeroBody?.details?.fieldErrors?.page, 'page field error present').toBeTruthy()
+
+    const pageNonNumeric = await apiRequest(request, 'GET', '/api/payment_gateways/transactions?page=abc', { token })
+    expect(pageNonNumeric.status(), 'page=abc is non-numeric').toBe(400)
+
+    const pageSizeZero = await apiRequest(request, 'GET', '/api/payment_gateways/transactions?pageSize=0', { token })
+    expect(pageSizeZero.status(), 'pageSize=0 is below the minimum').toBe(400)
+
+    const pageSizeTooLarge = await apiRequest(request, 'GET', '/api/payment_gateways/transactions?pageSize=101', { token })
+    expect(pageSizeTooLarge.status(), 'pageSize=101 exceeds the maximum of 100').toBe(400)
+
+    const invalidStatus = await apiRequest(request, 'GET', '/api/payment_gateways/transactions?status=invalid_status', { token })
+    expect(invalidStatus.status(), 'status must be a known unified status').toBe(400)
+    const invalidStatusBody = await readJsonSafe<ValidationError>(invalidStatus)
+    expect(invalidStatusBody?.details?.fieldErrors?.status, 'status field error present').toBeTruthy()
+  })
+
+  test('accepts valid pagination and provider filters with 200', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    await createPaymentSession(request, token, {
+      providerKey: 'mock',
+      amount: 21.5,
+      currencyCode: 'USD',
+      captureMethod: 'manual',
+    })
+
+    const paged = await apiRequest(request, 'GET', '/api/payment_gateways/transactions?page=1&pageSize=20&status=authorized', { token })
+    expect(paged.status(), 'valid page/pageSize/status query is accepted').toBe(200)
+    const pagedBody = await readJsonSafe<ListResponse>(paged)
+    expect(Array.isArray(pagedBody?.items), 'response carries an items array').toBe(true)
+    expect(pagedBody?.page, 'echoes requested page').toBe(1)
+    expect(pagedBody?.pageSize, 'echoes requested pageSize').toBe(20)
+    expect((pagedBody?.items.length ?? 0), 'authorized filter returns at least the created row').toBeGreaterThan(0)
+    for (const item of pagedBody?.items ?? []) {
+      expect(item.unifiedStatus, 'status filter returns only authorized rows').toBe('authorized')
+    }
+
+    const filtered = await apiRequest(request, 'GET', '/api/payment_gateways/transactions?providerKey=mock', { token })
+    expect(filtered.status(), 'valid providerKey filter is accepted').toBe(200)
+    const filteredBody = await readJsonSafe<ListResponse>(filtered)
+    expect((filteredBody?.items.length ?? 0), 'provider filter returns at least the created row').toBeGreaterThan(0)
+    for (const item of filteredBody?.items ?? []) {
+      expect(item.providerKey, 'provider filter returns only mock rows').toBe('mock')
+    }
+  })
+})

--- a/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-016.spec.ts
+++ b/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-016.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  createOrganizationFixture,
+  createRoleFixture,
+  createUserFixture,
+  deleteOrganizationIfExists,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { createPaymentSession } from './helpers/fixtures'
+
+/**
+ * TC-PGWY-016: Cross-organization isolation on detail and mutation routes
+ *
+ * Two users in two organizations BOTH hold full payment_gateways features, so RBAC does
+ * not deny them. Isolation is enforced at the data layer: every transaction lookup is
+ * scoped by `organizationId` + `tenantId` (gateway-service `findTransactionOrThrow` /
+ * `findTransaction`, and the transactions/[id] route's `findOneWithDecryption`). A user
+ * from organization B therefore can never read or mutate organization A's transaction:
+ *   - GET /transactions/[id] and GET /status → 404 (scoped lookup returns null)
+ *   - POST /capture | /refund | /cancel      → 502 (service throws 'Transaction not found',
+ *                                                    which the route maps to a gateway error)
+ * The owning user is unaffected and can still read and capture their own transaction.
+ */
+const PASSWORD = 'Qa!2026Pgwy'
+const PAYMENT_FEATURES = [
+  'payment_gateways.view',
+  'payment_gateways.manage',
+  'payment_gateways.capture',
+  'payment_gateways.refund',
+]
+const unique = () => `${Date.now()}-${Math.floor(Math.random() * 1_000_000_000)}`
+
+test.describe('TC-PGWY-016: Cross-organization isolation', () => {
+  test('denies a different-org user read/mutation access to a transaction', async ({ request }) => {
+    const superToken = await getAuthToken(request, 'superadmin')
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenScope(adminToken)
+    expect(tenantId, 'admin token must carry a concrete tenant').toBeTruthy()
+
+    let org1Id: string | null = null
+    let org2Id: string | null = null
+    let roleId: string | null = null
+    let userAId: string | null = null
+    let userBId: string | null = null
+
+    try {
+      org1Id = await createOrganizationFixture(request, superToken, { name: `QA PGWY Org A ${unique()}`, tenantId })
+      org2Id = await createOrganizationFixture(request, superToken, { name: `QA PGWY Org B ${unique()}`, tenantId })
+
+      roleId = await createRoleFixture(request, superToken, { name: `qa-pgwy-full-${unique()}`, tenantId })
+      await setRoleAclFeatures(request, superToken, { roleId, features: PAYMENT_FEATURES })
+
+      const userAEmail = `qa-pgwy-a-${unique()}@acme.com`
+      userAId = await createUserFixture(request, superToken, {
+        email: userAEmail,
+        password: PASSWORD,
+        organizationId: org1Id,
+        roles: [roleId],
+        name: 'QA PGWY User A',
+      })
+      const userBEmail = `qa-pgwy-b-${unique()}@acme.com`
+      userBId = await createUserFixture(request, superToken, {
+        email: userBEmail,
+        password: PASSWORD,
+        organizationId: org2Id,
+        roles: [roleId],
+        name: 'QA PGWY User B',
+      })
+
+      const tokenA = await getAuthToken(request, userAEmail, PASSWORD)
+      const tokenB = await getAuthToken(request, userBEmail, PASSWORD)
+
+      const session = await createPaymentSession(request, tokenA, {
+        providerKey: 'mock',
+        amount: 64.0,
+        currencyCode: 'USD',
+        captureMethod: 'manual',
+      })
+      expect(session.transactionId, 'org A user creates a transaction').toBeTruthy()
+
+      const detailAsB = await apiRequest(request, 'GET', `/api/payment_gateways/transactions/${session.transactionId}`, { token: tokenB })
+      expect(detailAsB.status(), 'cross-org transaction detail is not found').toBe(404)
+
+      const statusAsB = await apiRequest(request, 'GET', `/api/payment_gateways/status?transactionId=${session.transactionId}`, { token: tokenB })
+      expect(statusAsB.status(), 'cross-org status is not found').toBe(404)
+      const statusAsBBody = await readJsonSafe<{ error?: string }>(statusAsB)
+      expect(statusAsBBody?.error, 'status reports transaction not found').toMatch(/not found/i)
+
+      const captureAsB = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
+        token: tokenB,
+        data: { transactionId: session.transactionId },
+      })
+      expect(captureAsB.status(), 'cross-org capture cannot resolve the transaction').toBe(502)
+      const captureAsBBody = await readJsonSafe<{ error?: string }>(captureAsB)
+      expect(captureAsBBody?.error, 'capture reports transaction not found').toMatch(/not found/i)
+
+      const refundAsB = await apiRequest(request, 'POST', '/api/payment_gateways/refund', {
+        token: tokenB,
+        data: { transactionId: session.transactionId },
+      })
+      expect(refundAsB.status(), 'cross-org refund cannot resolve the transaction').toBe(502)
+
+      const cancelAsB = await apiRequest(request, 'POST', '/api/payment_gateways/cancel', {
+        token: tokenB,
+        data: { transactionId: session.transactionId },
+      })
+      expect(cancelAsB.status(), 'cross-org cancel cannot resolve the transaction').toBe(502)
+
+      const listAsB = await apiRequest(request, 'GET', '/api/payment_gateways/transactions', { token: tokenB })
+      expect(listAsB.status(), 'org B can list its own (empty) transactions').toBe(200)
+      const listAsBBody = await readJsonSafe<{ items: Array<{ id: string }> }>(listAsB)
+      expect((listAsBBody?.items ?? []).some((item) => item.id === session.transactionId), 'org B never sees org A rows').toBe(false)
+
+      const detailAsA = await apiRequest(request, 'GET', `/api/payment_gateways/transactions/${session.transactionId}`, { token: tokenA })
+      expect(detailAsA.status(), 'owner can read its own transaction').toBe(200)
+
+      const captureAsA = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
+        token: tokenA,
+        data: { transactionId: session.transactionId },
+      })
+      expect(captureAsA.status(), 'owner can capture its own transaction').toBe(200)
+    } finally {
+      await deleteUserIfExists(request, superToken, userAId)
+      await deleteUserIfExists(request, superToken, userBId)
+      await deleteRoleIfExists(request, superToken, roleId)
+      await deleteOrganizationIfExists(request, superToken, org1Id)
+      await deleteOrganizationIfExists(request, superToken, org2Id)
+    }
+  })
+})

--- a/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-017.spec.ts
+++ b/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-017.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { createPaymentSession } from './helpers/fixtures'
+
+/**
+ * TC-PGWY-017: Payload validation on the mutation routes
+ *
+ * /capture, /refund, /cancel and /sessions validate their JSON body with zod before any
+ * service call and reject malformed payloads with 422 `{ error: 'Invalid payload', details }`.
+ * Covers positive amounts, required transactionId, UUID format, reason length, currency
+ * length and required providerKey. A fully valid session + capture confirm the happy path.
+ */
+type ValidationError = {
+  error: string
+  details?: { fieldErrors?: Record<string, string[]> }
+}
+
+test.describe('TC-PGWY-017: Mutation payload validation', () => {
+  test('rejects invalid capture/refund payloads with 422', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const validId = randomUUID()
+
+    const negativeAmount = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
+      token,
+      data: { transactionId: validId, amount: -10 },
+    })
+    expect(negativeAmount.status(), 'capture amount must be positive').toBe(422)
+    const negativeAmountBody = await readJsonSafe<ValidationError>(negativeAmount)
+    expect(negativeAmountBody?.details?.fieldErrors?.amount, 'amount field error present').toBeTruthy()
+
+    const zeroAmount = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
+      token,
+      data: { transactionId: validId, amount: 0 },
+    })
+    expect(zeroAmount.status(), 'capture amount of zero is not positive').toBe(422)
+
+    const nonNumericAmount = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
+      token,
+      data: { transactionId: validId, amount: 'abc' },
+    })
+    expect(nonNumericAmount.status(), 'capture amount must be numeric').toBe(422)
+
+    const missingTransactionId = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
+      token,
+      data: { amount: 10 },
+    })
+    expect(missingTransactionId.status(), 'capture requires transactionId').toBe(422)
+    const missingTransactionIdBody = await readJsonSafe<ValidationError>(missingTransactionId)
+    expect(missingTransactionIdBody?.details?.fieldErrors?.transactionId, 'transactionId field error present').toBeTruthy()
+
+    const malformedTransactionId = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
+      token,
+      data: { transactionId: 'not-a-uuid', amount: 10 },
+    })
+    expect(malformedTransactionId.status(), 'capture transactionId must be a UUID').toBe(422)
+
+    const refundNegative = await apiRequest(request, 'POST', '/api/payment_gateways/refund', {
+      token,
+      data: { transactionId: validId, amount: -5 },
+    })
+    expect(refundNegative.status(), 'refund amount must be positive').toBe(422)
+
+    const refundLongReason = await apiRequest(request, 'POST', '/api/payment_gateways/refund', {
+      token,
+      data: { transactionId: validId, amount: 5, reason: 'x'.repeat(201) },
+    })
+    expect(refundLongReason.status(), 'refund reason must be 200 chars or fewer').toBe(422)
+  })
+
+  test('rejects invalid session payloads with 422', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const negativeAmount = await apiRequest(request, 'POST', '/api/payment_gateways/sessions', {
+      token,
+      data: { providerKey: 'mock', amount: -1, currencyCode: 'USD' },
+    })
+    expect(negativeAmount.status(), 'session amount must be positive').toBe(422)
+
+    const shortCurrency = await apiRequest(request, 'POST', '/api/payment_gateways/sessions', {
+      token,
+      data: { providerKey: 'mock', amount: 10, currencyCode: 'US' },
+    })
+    expect(shortCurrency.status(), 'currencyCode must be 3 characters').toBe(422)
+
+    const longCurrency = await apiRequest(request, 'POST', '/api/payment_gateways/sessions', {
+      token,
+      data: { providerKey: 'mock', amount: 10, currencyCode: 'USDA' },
+    })
+    expect(longCurrency.status(), 'currencyCode must be 3 characters').toBe(422)
+
+    const missingProvider = await apiRequest(request, 'POST', '/api/payment_gateways/sessions', {
+      token,
+      data: { amount: 10, currencyCode: 'USD' },
+    })
+    expect(missingProvider.status(), 'session requires providerKey').toBe(422)
+
+    const emptyProvider = await apiRequest(request, 'POST', '/api/payment_gateways/sessions', {
+      token,
+      data: { providerKey: '', amount: 10, currencyCode: 'USD' },
+    })
+    expect(emptyProvider.status(), 'providerKey must be non-empty').toBe(422)
+  })
+
+  test('accepts valid session and capture payloads', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const session = await createPaymentSession(request, token, {
+      providerKey: 'mock',
+      amount: 30.0,
+      currencyCode: 'USD',
+      captureMethod: 'manual',
+    })
+    expect(session.status, 'a valid session payload authorizes').toBe('authorized')
+
+    const capture = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
+      token,
+      data: { transactionId: session.transactionId, amount: 30.0 },
+    })
+    expect(capture.status(), 'a valid capture payload succeeds').toBe(200)
+  })
+})

--- a/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-018.spec.ts
+++ b/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-018.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+
+/**
+ * TC-PGWY-018: Non-existent resource lookups return 404
+ *
+ * Well-formed but non-existent identifiers must produce clean not-found responses, never
+ * leak another scope's data and never crash:
+ *   - GET /transactions/[uuid] for an unknown id     → 404 'Transaction not found'
+ *   - GET /status?transactionId=[uuid] for unknown id → 404 'Transaction not found'
+ *   - GET /providers/[key] for an unknown provider    → 404 'Provider descriptor not found'
+ *   - GET /providers/[blank] (whitespace-only key)    → 400 'Provider key is required'
+ */
+test.describe('TC-PGWY-018: Non-existent resource lookups', () => {
+  test('returns 404 for unknown transaction and provider identifiers', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const unknownTransactionId = randomUUID()
+
+    const detail = await apiRequest(request, 'GET', `/api/payment_gateways/transactions/${unknownTransactionId}`, { token })
+    expect(detail.status(), 'unknown transaction detail is not found').toBe(404)
+    const detailBody = await readJsonSafe<{ error?: string }>(detail)
+    expect(detailBody?.error, 'detail reports transaction not found').toMatch(/not found/i)
+
+    const status = await apiRequest(request, 'GET', `/api/payment_gateways/status?transactionId=${unknownTransactionId}`, { token })
+    expect(status.status(), 'unknown transaction status is not found').toBe(404)
+    const statusBody = await readJsonSafe<{ error?: string }>(status)
+    expect(statusBody?.error, 'status reports transaction not found').toMatch(/not found/i)
+
+    const provider = await apiRequest(request, 'GET', '/api/payment_gateways/providers/definitely-not-a-real-provider', { token })
+    expect(provider.status(), 'unknown provider descriptor is not found').toBe(404)
+    const providerBody = await readJsonSafe<{ error?: string }>(provider)
+    expect(providerBody?.error, 'provider reports descriptor not found').toMatch(/not found/i)
+
+    const blankProvider = await apiRequest(request, 'GET', '/api/payment_gateways/providers/%20', { token })
+    expect(blankProvider.status(), 'blank provider key is rejected').toBe(400)
+  })
+})

--- a/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-019.spec.ts
+++ b/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-019.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { createPaymentSession } from './helpers/fixtures'
+
+/**
+ * TC-PGWY-019: Required and well-formed transactionId on GET /status
+ *
+ * The status route guards its single query parameter:
+ *   - missing transactionId            → 400 'transactionId is required'
+ *   - empty transactionId              → 400 'transactionId is required'
+ *   - malformed (non-UUID) transactionId → 400 (validated as a UUID before any DB lookup)
+ *   - well-formed but unknown id        → 404 'Transaction not found'
+ *   - well-formed and existing id       → 200 with the transaction status
+ *
+ * The malformed-UUID case is the regression guard for a hardening fix: previously the raw
+ * string reached a Postgres `uuid` comparison and surfaced as an unhandled 500. It is now
+ * validated up front and returns a clean 400.
+ */
+test.describe('TC-PGWY-019: Status transactionId validation', () => {
+  test('requires a well-formed transactionId before lookup', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const missing = await apiRequest(request, 'GET', '/api/payment_gateways/status', { token })
+    expect(missing.status(), 'missing transactionId is rejected').toBe(400)
+    const missingBody = await readJsonSafe<{ error?: string }>(missing)
+    expect(missingBody?.error, 'reports transactionId is required').toBe('transactionId is required')
+
+    const empty = await apiRequest(request, 'GET', '/api/payment_gateways/status?transactionId=', { token })
+    expect(empty.status(), 'empty transactionId is rejected').toBe(400)
+
+    const malformed = await apiRequest(request, 'GET', '/api/payment_gateways/status?transactionId=not-a-uuid', { token })
+    expect(malformed.status(), 'malformed transactionId is rejected before DB lookup').toBe(400)
+
+    const unknown = await apiRequest(request, 'GET', `/api/payment_gateways/status?transactionId=${randomUUID()}`, { token })
+    expect(unknown.status(), 'well-formed but unknown transactionId is not found').toBe(404)
+  })
+
+  test('returns the status for an existing transactionId', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const session = await createPaymentSession(request, token, {
+      providerKey: 'mock',
+      amount: 18.25,
+      currencyCode: 'USD',
+      captureMethod: 'manual',
+    })
+
+    const status = await apiRequest(request, 'GET', `/api/payment_gateways/status?transactionId=${session.transactionId}`, { token })
+    expect(status.status(), 'existing transactionId resolves').toBe(200)
+    const statusBody = await readJsonSafe<{ transactionId?: string; status?: string }>(status)
+    expect(statusBody?.transactionId, 'status echoes the transaction id').toBe(session.transactionId)
+    expect(statusBody?.status, 'status carries a unified status').toBe('authorized')
+  })
+})

--- a/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-020.spec.ts
+++ b/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-020.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  createOrganizationFixture,
+  createRoleFixture,
+  createUserFixture,
+  deleteOrganizationIfExists,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { createPaymentSession } from './helpers/fixtures'
+
+/**
+ * TC-PGWY-020: Transaction list pagination boundaries
+ *
+ * Verifies offset/limit math and empty-result handling in an isolated organization that
+ * holds exactly 25 transactions (so totals are deterministic), plus a second, freshly
+ * created organization with zero transactions:
+ *   - page=1&pageSize=5  → 5 items, total=25, totalPages=5
+ *   - page=5&pageSize=5  → final 5 items
+ *   - page=6&pageSize=5  → 0 items, total/totalPages unchanged
+ *   - page=1&pageSize=100 → all 25 items, totalPages=1
+ *   - zero-transaction org → items=[], total=0, totalPages=1
+ */
+const PASSWORD = 'Qa!2026Pgwy'
+const TRANSACTION_COUNT = 25
+const PAYMENT_FEATURES = [
+  'payment_gateways.view',
+  'payment_gateways.manage',
+  'payment_gateways.capture',
+  'payment_gateways.refund',
+]
+const unique = () => `${Date.now()}-${Math.floor(Math.random() * 1_000_000_000)}`
+
+type ListResponse = {
+  items: Array<{ id: string }>
+  total: number
+  page: number
+  pageSize: number
+  totalPages: number
+}
+
+async function listTransactionsPaged(
+  request: APIRequestContext,
+  token: string,
+  page: number,
+  pageSize: number,
+): Promise<ListResponse | null> {
+  const response = await apiRequest(request, 'GET', `/api/payment_gateways/transactions?page=${page}&pageSize=${pageSize}`, { token })
+  expect(response.status(), `list page=${page} pageSize=${pageSize} succeeds`).toBe(200)
+  return readJsonSafe<ListResponse>(response)
+}
+
+test.describe('TC-PGWY-020: Transaction list pagination boundaries', () => {
+  let superToken: string
+  let filledOrgId: string | null = null
+  let emptyOrgId: string | null = null
+  let roleId: string | null = null
+  let filledUserId: string | null = null
+  let emptyUserId: string | null = null
+  let filledUserToken: string
+  let emptyUserToken: string
+
+  test.beforeAll(async ({ request }) => {
+    superToken = await getAuthToken(request, 'superadmin')
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenScope(adminToken)
+    expect(tenantId, 'admin token must carry a concrete tenant').toBeTruthy()
+
+    filledOrgId = await createOrganizationFixture(request, superToken, { name: `QA PGWY Page Full ${unique()}`, tenantId })
+    emptyOrgId = await createOrganizationFixture(request, superToken, { name: `QA PGWY Page Empty ${unique()}`, tenantId })
+
+    roleId = await createRoleFixture(request, superToken, { name: `qa-pgwy-page-${unique()}`, tenantId })
+    await setRoleAclFeatures(request, superToken, { roleId, features: PAYMENT_FEATURES })
+
+    const filledEmail = `qa-pgwy-page-full-${unique()}@acme.com`
+    filledUserId = await createUserFixture(request, superToken, {
+      email: filledEmail,
+      password: PASSWORD,
+      organizationId: filledOrgId,
+      roles: [roleId],
+      name: 'QA PGWY Page Full',
+    })
+    const emptyEmail = `qa-pgwy-page-empty-${unique()}@acme.com`
+    emptyUserId = await createUserFixture(request, superToken, {
+      email: emptyEmail,
+      password: PASSWORD,
+      organizationId: emptyOrgId,
+      roles: [roleId],
+      name: 'QA PGWY Page Empty',
+    })
+
+    filledUserToken = await getAuthToken(request, filledEmail, PASSWORD)
+    emptyUserToken = await getAuthToken(request, emptyEmail, PASSWORD)
+
+    // Warm the session route, then create the remaining transactions concurrently.
+    await createPaymentSession(request, filledUserToken, { providerKey: 'mock', amount: 10, currencyCode: 'USD', captureMethod: 'manual' })
+    await Promise.all(
+      Array.from({ length: TRANSACTION_COUNT - 1 }, () =>
+        createPaymentSession(request, filledUserToken, { providerKey: 'mock', amount: 10, currencyCode: 'USD', captureMethod: 'manual' }),
+      ),
+    )
+  })
+
+  test.afterAll(async ({ request }) => {
+    await deleteUserIfExists(request, superToken, filledUserId)
+    await deleteUserIfExists(request, superToken, emptyUserId)
+    await deleteRoleIfExists(request, superToken, roleId)
+    await deleteOrganizationIfExists(request, superToken, filledOrgId)
+    await deleteOrganizationIfExists(request, superToken, emptyOrgId)
+  })
+
+  test('returns the first full page with a correct total', async ({ request }) => {
+    const body = await listTransactionsPaged(request, filledUserToken, 1, 5)
+    expect(body?.items.length, 'first page holds pageSize items').toBe(5)
+    expect(body?.total, 'total reflects every transaction in the org').toBe(TRANSACTION_COUNT)
+    expect(body?.totalPages, '25 items at pageSize 5 spans 5 pages').toBe(5)
+  })
+
+  test('returns the final page', async ({ request }) => {
+    const body = await listTransactionsPaged(request, filledUserToken, 5, 5)
+    expect(body?.items.length, 'last page holds the remaining items').toBe(5)
+    expect(body?.total, 'total is stable across pages').toBe(TRANSACTION_COUNT)
+  })
+
+  test('returns no items beyond the last page', async ({ request }) => {
+    const body = await listTransactionsPaged(request, filledUserToken, 6, 5)
+    expect(body?.items.length, 'a page past the end is empty').toBe(0)
+    expect(body?.total, 'total still reflects every transaction').toBe(TRANSACTION_COUNT)
+    expect(body?.totalPages, 'totalPages is unchanged past the end').toBe(5)
+  })
+
+  test('returns all items on a single large page', async ({ request }) => {
+    const body = await listTransactionsPaged(request, filledUserToken, 1, 100)
+    expect(body?.items.length, 'a 100-row page holds all 25 items').toBe(TRANSACTION_COUNT)
+    expect(body?.totalPages, 'all items fit on one page').toBe(1)
+  })
+
+  test('returns an empty result for an org with no transactions', async ({ request }) => {
+    const body = await listTransactionsPaged(request, emptyUserToken, 1, 20)
+    expect(body?.items.length, 'a zero-transaction org returns no items').toBe(0)
+    expect(body?.total, 'total is zero').toBe(0)
+    expect(body?.totalPages, 'totalPages floors at 1').toBe(1)
+  })
+})

--- a/packages/core/src/modules/payment_gateways/api/status/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/status/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getStatusSchema } from '../../data/validators'
 import type { PaymentGatewayService } from '../../lib/gateway-service'
 import { paymentGatewaysTag } from '../openapi'
 
@@ -19,6 +20,10 @@ export async function GET(req: Request) {
   const transactionId = url.searchParams.get('transactionId')
   if (!transactionId) {
     return NextResponse.json({ error: 'transactionId is required' }, { status: 400 })
+  }
+  const parsedTransactionId = getStatusSchema.safeParse({ transactionId })
+  if (!parsedTransactionId.success) {
+    return NextResponse.json({ error: 'Invalid transactionId', details: parsedTransactionId.error.flatten() }, { status: 400 })
   }
 
   const container = await createRequestContainer()
@@ -62,6 +67,7 @@ export const openApi = {
       tags: [paymentGatewaysTag],
       responses: [
         { status: 200, description: 'Transaction status' },
+        { status: 400, description: 'Missing or malformed transactionId' },
         { status: 404, description: 'Transaction not found' },
       ],
     },


### PR DESCRIPTION
## Summary

Fills the high-value integration-test gaps for the `payment_gateways` module called out in #2487 (RBAC enforcement, query/payload validation, cross-organization isolation, not-found lookups, and pagination boundaries). While writing the coverage, the status route was found to crash with an unhandled 500 on a malformed `transactionId`; this PR hardens it to a clean 400 using the module's existing (previously unused) `getStatusSchema`.

## Changes

- Add 7 module-local Playwright integration specs, `__integration__/TC-PGWY-014..020.spec.ts`:
  - **014** RBAC: per-feature 403 gates (`sessions`/`cancel`→`manage`, `capture`→`capture`, `refund`→`refund`, `transactions`/`status`/`providers`→`view`) with manage-only and view-only users, plus positive baselines.
  - **015** `GET /transactions` query validation (invalid page/pageSize/status → 400; valid filters → 200).
  - **016** Cross-organization isolation — two full-feature users in two orgs: cross-org reads → 404, mutations → 502; owner unaffected.
  - **017** Mutation payload validation (`capture`/`refund`/`cancel`/`sessions`) → 422.
  - **018** Non-existent transaction/provider lookups → 404; blank provider key → 400.
  - **019** `GET /status` `transactionId` validation (missing/empty/malformed → 400, unknown → 404, existing → 200).
  - **020** Transaction list pagination boundaries (isolated 25-transaction org + zero-transaction org).
- Fix `api/status/route.ts`: validate `transactionId` as a UUID before the DB lookup (returns 400 instead of an unhandled 500 that leaked a raw Postgres error); document the 400 in `openApi`.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — scenarios are defined directly in issue #2487; per `.ai/qa/AGENTS.md`, scenario markdown is optional and executable specs live module-local in `__integration__/`.

## Testing

Verified docker-free against `yarn dev:app` on an isolated DB (`yarn initialize` for seed) with `BASE_URL`:
- `BASE_URL=http://localhost:3033 npx playwright test --config .ai/qa/tests/playwright.config.ts <TC-PGWY-014..020>` → **15/15 passed** (re-run 3× for stability; config is `workers:1`, `retries:1`).
- `yarn build:packages` → 21/21 · `yarn generate` → clean · `yarn i18n:check-sync` → in sync · `yarn typecheck` → 21/21 · `yarn workspace @open-mercato/core test payment_gateways` → 6/6 · `yarn build:app` → success.
- Manually confirmed the fix at the HTTP layer: `GET /status?transactionId=not-a-uuid` 500 → 400; missing/empty `transactionId` still 400 `"transactionId is required"`.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- submitter to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- updated route openApi; no locale/generator changes needed (i18n:check-sync passes) -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- added in the module `__integration__/` dir per `.ai/qa/AGENTS.md`; `.ai/qa/tests/` holds only the shared Playwright config -->
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A: test coverage + minor hardening, no spec -->

### Design System Compliance
- [x] No hardcoded status colors — N/A — backend API + integration tests, no UI
- [x] No arbitrary text sizes — N/A — no UI
- [x] Empty state handled for list/data pages — N/A — no UI
- [x] Loading state handled for async pages — N/A — no UI
- [x] `aria-label` on all icon-only buttons — N/A — no UI
- [x] Uses existing DS components — N/A — no UI

## Linked issues

Fixes #2487