### PR TITLE
feat: 2486 communication channels api coverage

### DIFF
--- a/packages/core/src/helpers/integration/communicationChannelsFixtures.ts
+++ b/packages/core/src/helpers/integration/communicationChannelsFixtures.ts
@@ -64,6 +64,11 @@ export async function seedConnectedChannel(
  *
  * Returns the created link + message ids (the message id is the platform
  * `messages.message` id, usable as `messageThreadId` to thread a follow-up).
+ *
+ * Pass `createThreadMapping: true` to also seed a `ChannelThreadMapping` for the
+ * thread — required before exercising the reaction (`/messages/[id]/reactions`)
+ * and thread-assign (`/threads/[id]/assign`) routes, which resolve the owning
+ * channel through that mapping.
  */
 export async function seedInboundMessage(
   request: APIRequestContext,
@@ -80,6 +85,7 @@ export async function seedInboundMessage(
     references?: string[];
     messageThreadId?: string;
     providerKey?: string;
+    createThreadMapping?: boolean;
   },
 ): Promise<{ channelLinkId: string; messageId: string; conversationId: string }> {
   const response = await apiRequest(request, 'POST', TEST_SEED_PATH, {

--- a/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-001.spec.ts
+++ b/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-001.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  deleteChannelIfExists,
+  isChannelSeedingAvailable,
+  seedConnectedChannel,
+} from '@open-mercato/core/helpers/integration/communicationChannelsFixtures'
+
+/**
+ * TC-CHANNEL-API-001 — GET /channels/[id] returns metadata without credentials.
+ * Source: https://github.com/open-mercato/open-mercato/issues/2486
+ *
+ * Positive-path coverage for the channel-detail route: a seeded, connected
+ * channel is retrievable by id, the payload echoes its public metadata, and the
+ * route never embeds raw credentials (only a vault `credentialsRef`).
+ *
+ * Driven via the env-gated test-seed fixture (`OM_ENABLE_TEST_CHANNEL_SEEDING`);
+ * skips when the gate is off.
+ */
+test.describe('TC-CHANNEL-API-001: GET channel detail returns metadata, no credentials', () => {
+  test('returns the seeded channel and never leaks credentials', async ({ request }) => {
+    let token: string | null = null
+    let channelId: string | null = null
+    try {
+      token = await getAuthToken(request, 'admin')
+      const seedingAvailable = await isChannelSeedingAvailable(request, token)
+      test.skip(
+        !seedingAvailable,
+        'OM_ENABLE_TEST_CHANNEL_SEEDING is not enabled in this environment; cannot seed a connected channel.',
+      )
+
+      channelId = await seedConnectedChannel(request, token, {
+        displayName: `TC-CHANNEL-API-001 ${Date.now()}`,
+      })
+
+      const response = await apiRequest(
+        request,
+        'GET',
+        `/api/communication_channels/channels/${channelId}`,
+        { token },
+      )
+      expect(response.status(), 'GET channel detail should return 200').toBe(200)
+
+      const body = await readJsonSafe<Record<string, unknown>>(response)
+      expect(body?.id, 'response id must match the seeded channel').toBe(channelId)
+      expect(body?.providerKey, 'seeded channel uses the test-seed stub provider').toBe('__test_seed__')
+
+      // The detail route exposes only a credentials *reference*, never secrets.
+      expect(body, 'detail must not embed a raw credentials object').not.toHaveProperty('credentials')
+      expect(body, 'detail must not embed a password').not.toHaveProperty('password')
+      expect(body, 'detail must not embed a secret').not.toHaveProperty('secret')
+    } finally {
+      await deleteChannelIfExists(request, token, channelId)
+    }
+  })
+
+  test('rejects an unauthenticated request with 401', async ({ request }) => {
+    const unknownId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    const response = await request.fetch(`/api/communication_channels/channels/${unknownId}`, {
+      method: 'GET',
+    })
+    expect(response.status()).toBe(401)
+  })
+})

--- a/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-002.spec.ts
+++ b/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-002.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import {
+  deleteChannelIfExists,
+  isChannelSeedingAvailable,
+  seedConnectedChannel,
+} from '@open-mercato/core/helpers/integration/communicationChannelsFixtures'
+
+/**
+ * TC-CHANNEL-API-002 — POST set-primary marks exactly one channel primary.
+ * Source: https://github.com/open-mercato/open-mercato/issues/2486
+ *
+ * "Primary" is a per-user invariant (a partial unique index on user_id), so the
+ * test runs against a DEDICATED user with two seeded channels. This isolates the
+ * "only one primary" assertion from the shared admin and from parallel specs:
+ * `GET /me/channels` then lists exactly the two channels under test.
+ *
+ * Driven via the env-gated test-seed fixture (`OM_ENABLE_TEST_CHANNEL_SEEDING`);
+ * skips when the gate is off.
+ */
+async function listPrimaryChannelIds(request: APIRequestContext, token: string): Promise<string[]> {
+  const response = await apiRequest(request, 'GET', '/api/communication_channels/me/channels', { token })
+  expect(response.status(), 'GET /me/channels should return 200').toBe(200)
+  const body = await readJsonSafe<{ items?: Array<{ id: string; isPrimary: boolean }> }>(response)
+  return (body?.items ?? []).filter((item) => item.isPrimary).map((item) => item.id)
+}
+
+test.describe('TC-CHANNEL-API-002: set-primary keeps a single primary per user', () => {
+  test('set-primary moves the primary flag and supersedes the previous one', async ({ request }) => {
+    test.slow()
+    const stamp = Date.now()
+    let adminToken: string | null = null
+    let userToken: string | null = null
+    let userId: string | null = null
+    let roleId: string | null = null
+    let channelA: string | null = null
+    let channelB: string | null = null
+    try {
+      adminToken = await getAuthToken(request, 'admin')
+      const seedingAvailable = await isChannelSeedingAvailable(request, adminToken)
+      test.skip(
+        !seedingAvailable,
+        'OM_ENABLE_TEST_CHANNEL_SEEDING is not enabled in this environment; cannot seed connected channels.',
+      )
+
+      const scope = getTokenScope(adminToken)
+      const roleName = `qa_channel_api_002_${stamp}`
+      roleId = await createRoleFixture(request, adminToken, { name: roleName, tenantId: scope.tenantId })
+      await setRoleAclFeatures(request, adminToken, {
+        roleId,
+        features: ['communication_channels.connect_user_channel'],
+      })
+
+      const userEmail = `qa-channel-api-002-${stamp}@acme.com`
+      const userPassword = 'Valid1!Pass'
+      userId = await createUserFixture(request, adminToken, {
+        email: userEmail,
+        password: userPassword,
+        organizationId: scope.organizationId,
+        roles: [roleName],
+        name: 'QA Channel API 002 User',
+      })
+      userToken = await getAuthToken(request, userEmail, userPassword)
+
+      channelA = await seedConnectedChannel(request, userToken, { displayName: `API-002 A ${stamp}` })
+      channelB = await seedConnectedChannel(request, userToken, { displayName: `API-002 B ${stamp}` })
+
+      // Set channel A primary.
+      const setA = await apiRequest(
+        request,
+        'POST',
+        `/api/communication_channels/channels/${channelA}/set-primary`,
+        { token: userToken },
+      )
+      expect(setA.status(), 'set-primary A should return 200').toBe(200)
+      const setABody = await readJsonSafe<{ isPrimary?: boolean }>(setA)
+      expect(setABody?.isPrimary, 'channel A is now primary').toBe(true)
+      expect(await listPrimaryChannelIds(request, userToken), 'exactly A is primary after setting A').toEqual([
+        channelA,
+      ])
+
+      // Set channel B primary — supersedes A.
+      const setB = await apiRequest(
+        request,
+        'POST',
+        `/api/communication_channels/channels/${channelB}/set-primary`,
+        { token: userToken },
+      )
+      expect(setB.status(), 'set-primary B should return 200').toBe(200)
+      const setBBody = await readJsonSafe<{ isPrimary?: boolean; previousPrimaryChannelId?: string | null }>(setB)
+      expect(setBBody?.isPrimary, 'channel B is now primary').toBe(true)
+      expect(setBBody?.previousPrimaryChannelId, 'B supersedes A as the previous primary').toBe(channelA)
+      expect(await listPrimaryChannelIds(request, userToken), 'exactly B is primary after setting B').toEqual([
+        channelB,
+      ])
+    } finally {
+      await deleteChannelIfExists(request, userToken, channelA)
+      await deleteChannelIfExists(request, userToken, channelB)
+      await deleteUserIfExists(request, adminToken, userId)
+      await deleteRoleIfExists(request, adminToken, roleId)
+    }
+  })
+})

--- a/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-003.spec.ts
+++ b/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-003.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  deleteChannelIfExists,
+  isChannelSeedingAvailable,
+  seedConnectedChannel,
+  seedInboundMessage,
+} from '@open-mercato/core/helpers/integration/communicationChannelsFixtures'
+
+/**
+ * TC-CHANNEL-API-003 — GET /channels/[id]/health returns delivery metrics.
+ * Source: https://github.com/open-mercato/open-mercato/issues/2486
+ *
+ * Health aggregates `message_channel_links` for the channel over the trailing
+ * 24h window. We seed one inbound message (lands as a 'delivered' link), then
+ * assert the snapshot is scoped to the channel and reports numeric counts.
+ *
+ * Driven via the env-gated test-seed fixture (`OM_ENABLE_TEST_CHANNEL_SEEDING`);
+ * skips when the gate is off.
+ */
+test.describe('TC-CHANNEL-API-003: channel health metrics', () => {
+  test('reports numeric delivery counts and includes a seeded message', async ({ request }) => {
+    test.slow()
+    let token: string | null = null
+    let channelId: string | null = null
+    try {
+      token = await getAuthToken(request, 'admin')
+      const seedingAvailable = await isChannelSeedingAvailable(request, token)
+      test.skip(
+        !seedingAvailable,
+        'OM_ENABLE_TEST_CHANNEL_SEEDING is not enabled in this environment; cannot seed a channel/message.',
+      )
+
+      const stamp = Date.now()
+      channelId = await seedConnectedChannel(request, token, {
+        displayName: `TC-CHANNEL-API-003 ${stamp}`,
+        externalIdentifier: `api-003-${stamp}@test-seed.local`,
+      })
+      await seedInboundMessage(request, token, {
+        channelId,
+        from: `sender-${stamp}@example.com`,
+        to: [`api-003-${stamp}@test-seed.local`],
+        subject: `Health seed ${stamp}`,
+        bodyText: 'seed message for the health window',
+      })
+
+      const response = await apiRequest(
+        request,
+        'GET',
+        `/api/communication_channels/channels/${channelId}/health`,
+        { token },
+      )
+      expect(response.status(), 'GET health should return 200').toBe(200)
+
+      const body = await readJsonSafe<{
+        channelId?: string
+        counts?: Record<string, number>
+        totalsLast24h?: number
+      }>(response)
+      expect(body?.channelId, 'health is scoped to the requested channel').toBe(channelId)
+
+      const counts = body?.counts ?? {}
+      expect(typeof counts.sent, 'counts.sent is numeric').toBe('number')
+      expect(typeof counts.failed, 'counts.failed is numeric').toBe('number')
+      expect(counts.sent, 'counts.sent >= 0').toBeGreaterThanOrEqual(0)
+      expect(counts.failed, 'counts.failed >= 0').toBeGreaterThanOrEqual(0)
+      // The seeded inbound link lands inside the trailing-24h window.
+      expect(body?.totalsLast24h ?? 0, 'the seeded message is counted in the 24h window').toBeGreaterThanOrEqual(1)
+    } finally {
+      await deleteChannelIfExists(request, token, channelId)
+    }
+  })
+})

--- a/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-004.spec.ts
+++ b/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-004.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  deleteChannelIfExists,
+  isChannelSeedingAvailable,
+  seedConnectedChannel,
+} from '@open-mercato/core/helpers/integration/communicationChannelsFixtures'
+
+/**
+ * TC-CHANNEL-API-004 — POST /channels/[id]/poll-now enqueues a poll.
+ * Source: https://github.com/open-mercato/open-mercato/issues/2486
+ *
+ * A connected channel accepts a manual poll: the route enqueues a poll-channel
+ * job and returns 202 Accepted. `lastPolledAt` is updated asynchronously by the
+ * worker (not in the response), so we assert the queued acknowledgement instead.
+ *
+ * Driven via the env-gated test-seed fixture (`OM_ENABLE_TEST_CHANNEL_SEEDING`);
+ * skips when the gate is off.
+ */
+test.describe('TC-CHANNEL-API-004: poll-now enqueues a poll', () => {
+  test('accepts a manual poll for a connected channel (202)', async ({ request }) => {
+    let token: string | null = null
+    let channelId: string | null = null
+    try {
+      token = await getAuthToken(request, 'admin')
+      const seedingAvailable = await isChannelSeedingAvailable(request, token)
+      test.skip(
+        !seedingAvailable,
+        'OM_ENABLE_TEST_CHANNEL_SEEDING is not enabled in this environment; cannot seed a connected channel.',
+      )
+
+      channelId = await seedConnectedChannel(request, token, {
+        displayName: `TC-CHANNEL-API-004 ${Date.now()}`,
+      })
+
+      const response = await apiRequest(
+        request,
+        'POST',
+        `/api/communication_channels/channels/${channelId}/poll-now`,
+        { token },
+      )
+      expect(response.status(), 'poll-now should enqueue and return 202').toBe(202)
+
+      const body = await readJsonSafe<{ ok?: boolean; queued?: boolean; channelId?: string }>(response)
+      expect(body?.ok, 'poll-now acknowledges the request').toBe(true)
+      expect(body?.queued, 'a poll job is queued').toBe(true)
+      expect(body?.channelId, 'poll-now echoes the channel id').toBe(channelId)
+    } finally {
+      await deleteChannelIfExists(request, token, channelId)
+    }
+  })
+})

--- a/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-005.spec.ts
+++ b/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-005.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  deleteChannelIfExists,
+  isChannelSeedingAvailable,
+  seedConnectedChannel,
+  seedInboundMessage,
+} from '@open-mercato/core/helpers/integration/communicationChannelsFixtures'
+
+/**
+ * TC-CHANNEL-API-005 — add and remove a reaction on a channel-linked message.
+ * Source: https://github.com/open-mercato/open-mercato/issues/2486
+ *
+ * Reacting resolves the owning channel through the thread mapping, so the inbound
+ * message is seeded with `createThreadMapping: true`. The channel owner (the
+ * seeding caller) adds a reaction (201) and removes it by id (204).
+ *
+ * Driven via the env-gated test-seed fixture (`OM_ENABLE_TEST_CHANNEL_SEEDING`);
+ * skips when the gate is off.
+ */
+test.describe('TC-CHANNEL-API-005: add/remove a reaction', () => {
+  test('POST creates a reaction and DELETE removes it', async ({ request }) => {
+    test.slow()
+    let token: string | null = null
+    let channelId: string | null = null
+    try {
+      token = await getAuthToken(request, 'admin')
+      const seedingAvailable = await isChannelSeedingAvailable(request, token)
+      test.skip(
+        !seedingAvailable,
+        'OM_ENABLE_TEST_CHANNEL_SEEDING is not enabled in this environment; cannot seed a channel-linked message.',
+      )
+
+      const stamp = Date.now()
+      channelId = await seedConnectedChannel(request, token, {
+        displayName: `TC-CHANNEL-API-005 ${stamp}`,
+        externalIdentifier: `api-005-${stamp}@test-seed.local`,
+      })
+      const seeded = await seedInboundMessage(request, token, {
+        channelId,
+        from: `sender-${stamp}@example.com`,
+        to: [`api-005-${stamp}@test-seed.local`],
+        subject: `Reaction seed ${stamp}`,
+        bodyText: 'react to me',
+        createThreadMapping: true,
+      })
+
+      // Add a reaction.
+      const addResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/communication_channels/messages/${seeded.messageId}/reactions`,
+        { token, data: { emoji: '👍' } },
+      )
+      expect(addResponse.status(), 'adding a reaction should return 201').toBe(201)
+      const addBody = await readJsonSafe<{ id?: string; emoji?: string; messageId?: string }>(addResponse)
+      const reactionId = expectId(addBody?.id, 'reaction response should include the new reaction id')
+      expect(addBody?.emoji, 'reaction echoes the emoji').toBe('👍')
+      expect(addBody?.messageId, 'reaction is bound to the seeded message').toBe(seeded.messageId)
+
+      // Remove it by id.
+      const deleteResponse = await apiRequest(
+        request,
+        'DELETE',
+        `/api/communication_channels/messages/${seeded.messageId}/reactions/${reactionId}`,
+        { token },
+      )
+      expect(deleteResponse.status(), 'removing a reaction should return 204').toBe(204)
+    } finally {
+      await deleteChannelIfExists(request, token, channelId)
+    }
+  })
+})

--- a/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-006.spec.ts
+++ b/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-006.spec.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  deleteChannelIfExists,
+  isChannelSeedingAvailable,
+  seedConnectedChannel,
+  seedInboundMessage,
+} from '@open-mercato/core/helpers/integration/communicationChannelsFixtures'
+
+/**
+ * TC-CHANNEL-API-006 — PUT /threads/[threadId]/assign reassigns a conversation.
+ * Source: https://github.com/open-mercato/open-mercato/issues/2486
+ *
+ * Assignment resolves the conversation through the thread mapping, so the inbound
+ * message is seeded with an explicit `messageThreadId` and `createThreadMapping:
+ * true`. Assigning the thread to a live tenant user updates the owner and echoes
+ * the previous (none) and next assignee.
+ *
+ * Driven via the env-gated test-seed fixture (`OM_ENABLE_TEST_CHANNEL_SEEDING`);
+ * skips when the gate is off.
+ */
+test.describe('TC-CHANNEL-API-006: assign a channel-linked thread', () => {
+  test('assigns a seeded thread to a tenant user', async ({ request }) => {
+    test.slow()
+    let token: string | null = null
+    let channelId: string | null = null
+    try {
+      token = await getAuthToken(request, 'admin')
+      const seedingAvailable = await isChannelSeedingAvailable(request, token)
+      test.skip(
+        !seedingAvailable,
+        'OM_ENABLE_TEST_CHANNEL_SEEDING is not enabled in this environment; cannot seed a channel-linked thread.',
+      )
+
+      const scope = getTokenScope(token)
+      const stamp = Date.now()
+      const threadId = randomUUID()
+      channelId = await seedConnectedChannel(request, token, {
+        displayName: `TC-CHANNEL-API-006 ${stamp}`,
+        externalIdentifier: `api-006-${stamp}@test-seed.local`,
+      })
+      await seedInboundMessage(request, token, {
+        channelId,
+        from: `sender-${stamp}@example.com`,
+        to: [`api-006-${stamp}@test-seed.local`],
+        subject: `Assign seed ${stamp}`,
+        bodyText: 'assign me',
+        messageThreadId: threadId,
+        createThreadMapping: true,
+      })
+
+      const response = await apiRequest(
+        request,
+        'PUT',
+        `/api/communication_channels/threads/${threadId}/assign`,
+        { token, data: { assignedUserId: scope.userId } },
+      )
+      expect(response.status(), 'assign should return 200').toBe(200)
+
+      const body = await readJsonSafe<{
+        threadId?: string
+        assignedUserId?: string | null
+        previousAssignedUserId?: string | null
+      }>(response)
+      expect(body?.threadId, 'assign echoes the thread id').toBe(threadId)
+      expect(body?.assignedUserId, 'the conversation is now owned by the target user').toBe(scope.userId)
+      expect(body?.previousAssignedUserId ?? null, 'the seeded thread had no prior owner').toBeNull()
+    } finally {
+      await deleteChannelIfExists(request, token, channelId)
+    }
+  })
+})

--- a/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-007.spec.ts
+++ b/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-API-007.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  deleteChannelIfExists,
+  isChannelSeedingAvailable,
+  seedConnectedChannel,
+} from '@open-mercato/core/helpers/integration/communicationChannelsFixtures'
+
+/**
+ * TC-CHANNEL-API-007 — DELETE /channels/[id] soft-deletes the channel.
+ * Source: https://github.com/open-mercato/open-mercato/issues/2486
+ *
+ * Deleting a seeded channel returns 204, and the soft-deleted row is no longer
+ * retrievable: a subsequent GET returns 404.
+ *
+ * Driven via the env-gated test-seed fixture (`OM_ENABLE_TEST_CHANNEL_SEEDING`);
+ * skips when the gate is off.
+ */
+test.describe('TC-CHANNEL-API-007: DELETE soft-deletes a channel', () => {
+  test('DELETE returns 204 and a subsequent GET returns 404', async ({ request }) => {
+    let token: string | null = null
+    let channelId: string | null = null
+    let deleted = false
+    try {
+      token = await getAuthToken(request, 'admin')
+      const seedingAvailable = await isChannelSeedingAvailable(request, token)
+      test.skip(
+        !seedingAvailable,
+        'OM_ENABLE_TEST_CHANNEL_SEEDING is not enabled in this environment; cannot seed a connected channel.',
+      )
+
+      channelId = await seedConnectedChannel(request, token, {
+        displayName: `TC-CHANNEL-API-007 ${Date.now()}`,
+      })
+
+      const deleteResponse = await apiRequest(
+        request,
+        'DELETE',
+        `/api/communication_channels/channels/${channelId}`,
+        { token },
+      )
+      expect(deleteResponse.status(), 'DELETE should return 204').toBe(204)
+      deleted = true
+
+      const getResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/communication_channels/channels/${channelId}`,
+        { token },
+      )
+      expect(getResponse.status(), 'a soft-deleted channel is no longer retrievable (404)').toBe(404)
+    } finally {
+      // Already deleted in the happy path; deleteChannelIfExists is best-effort.
+      if (!deleted) await deleteChannelIfExists(request, token, channelId)
+    }
+  })
+})

--- a/packages/core/src/modules/communication_channels/api/post/test-seed/route.ts
+++ b/packages/core/src/modules/communication_channels/api/post/test-seed/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
-import { ExternalConversation, MessageChannelLink } from '../../../data/entities'
+import { ChannelThreadMapping, ExternalConversation, MessageChannelLink } from '../../../data/entities'
 import {
   COMMUNICATION_CHANNELS_CONNECT_CREDENTIAL_CHANNEL_COMMAND_ID,
   type ConnectCredentialChannelInput,
@@ -79,6 +79,14 @@ const emitInboundSchema = z.object({
    * hub-thread inheritance join can resolve a Person from a sibling message.
    */
   messageThreadId: z.string().uuid().optional(),
+  /**
+   * Test-only: also create a `ChannelThreadMapping` for the seeded thread. The
+   * reaction (`/messages/[id]/reactions`) and thread-assign
+   * (`/threads/[id]/assign`) routes resolve the owning channel through this
+   * mapping and return 409/404 without it. Opt-in so the existing CRM-link
+   * seeds (which don't need a mapping) keep their current mapping-free shape.
+   */
+  createThreadMapping: z.boolean().optional(),
 })
 
 const bodySchema = z.discriminatedUnion('action', [connectChannelSchema, emitInboundSchema])
@@ -225,6 +233,25 @@ export async function POST(req: Request): Promise<Response> {
   })
   em.persist(link)
   await em.flush()
+
+  // Optionally mirror `ingest-inbound-message`: a real inbound message always
+  // lands a ChannelThreadMapping that the reaction + thread-assign routes use to
+  // resolve the owning channel. Seeded inbound messages skip it by default; opt
+  // in for tests that exercise those routes. Keyed by `messageThreadId ?? messageId`
+  // to match how those commands resolve the mapping (`message.threadId ?? message.id`).
+  if (body.createThreadMapping) {
+    const mapping = em.create(ChannelThreadMapping, {
+      externalConversationId: conversation.id,
+      messageThreadId: body.messageThreadId ?? messageId,
+      channelId: body.channelId,
+      providerKey,
+      externalThreadRef: conversation.externalConversationId,
+      tenantId,
+      organizationId,
+    })
+    em.persist(mapping)
+    await em.flush()
+  }
 
   // Emit the hub event through the real event bus so the persistent customers
   // link-channel-message-received subscriber is enqueued to the `events` queue.

--- a/packages/core/src/modules/communication_channels/commands/set-primary-channel.ts
+++ b/packages/core/src/modules/communication_channels/commands/set-primary-channel.ts
@@ -86,12 +86,12 @@ const setPrimaryChannelCommand: CommandHandler<
     // `is_primary=false` and `is_primary=true` updates is unsafe: MikroORM
     // does not guarantee SET-false statements execute before SET-true.
     //
-    // Fix (review R2-H1 / F2, 2026-05-26): two phases inside one transaction.
-    // `withAtomicFlush` runs each phase and flushes between them (the platform
-    // helper for exactly this multi-phase mutation — see packages/core/AGENTS.md
-    // "Entity Update Safety"). Phase 1 clears + flushes so Postgres observes
-    // `is_primary=false` before Phase 2's UPDATE runs; the transaction wraps both
-    // for all-or-nothing semantics.
+    // `withAtomicFlush` issues ONE flush at the END of all phases (it does NOT
+    // flush between them — see packages/shared/src/lib/commands/flush.ts), so a
+    // managed-entity two-phase still lands the SET-false and SET-true updates in
+    // that single unordered flush and races (23505). Phase 1 therefore flushes
+    // the clear EXPLICITLY so Postgres observes `is_primary=false` before Phase
+    // 2's SET-true UPDATE runs; the transaction wraps both for all-or-nothing.
     const previousPrimaries = await findWithDecryption(
       em,
       CommunicationChannel,
@@ -114,11 +114,14 @@ const setPrimaryChannelCommand: CommandHandler<
     await withAtomicFlush(
       em,
       [
-        () => {
+        async () => {
           for (const prev of previousPrimaries as CommunicationChannel[]) {
             previousPrimaryChannelId = prev.id
             prev.isPrimary = false
           }
+          // Flush the clear before Phase 2 sets the new primary, so Postgres
+          // never sees two `is_primary` rows for this user at once (see above).
+          await em.flush()
         },
         () => {
           channel.isPrimary = true


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Fills the integration-test coverage gap for the `communication_channels` module requested in #2486 — seven positive-path API scenarios (TC-CHANNEL-API-001…007: GET channel detail, set-primary, health, poll-now, reaction add/remove, thread assign, soft-delete). Implementing the set-primary scenario surfaced a real product bug: superseding an existing primary channel returned HTTP 500 (`UniqueConstraintViolationException` on `communication_channels_one_primary_per_user_uq`). That bug is fixed here so the contract the issue asks us to test actually holds.

## Changes

- **Add 7 Playwright API integration specs** under `communication_channels/__integration__/TC-CHANNEL-API-001…007.spec.ts`, driving the env-gated test-seed fixtures and asserting exact contracts (status codes, credential masking, one-primary-per-user, health counts, 202 enqueue, 201/204 reactions, 200 assign, 204→404 soft-delete).
- **Fix `set-primary-channel` supersede 500**: `withAtomicFlush` issues a single end-flush (not one between phases), so the two-phase "clear old primary / set new primary" raced the partial unique index. Phase 1 now flushes the clear explicitly before Phase 2 sets the new primary, inside the same transaction. Also corrected the misleading code comment about `withAtomicFlush`.
- **Test-seed `emit-inbound`**: add an opt-in `createThreadMapping` flag that also seeds the `ChannelThreadMapping` (mirroring real inbound ingestion). Required for the reaction/assign routes, which resolve the owning channel through that mapping. Strictly opt-in — existing `TC-CRM-EMAIL-002..005` consumers are unaffected. The endpoint remains test-only and fail-closed 404 in production.
- **Integration helper**: add `createThreadMapping?: boolean` to `seedInboundMessage`.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test coverage plus a contained bug fix on an existing, spec'd module (email-integration). No spec change required.


## Testing

List the tests or commands you ran to validate the change.

- `BASE_URL=<live app> npx playwright test --config .ai/qa/tests/playwright.config.ts -g "TC-CHANNEL-API" --workers=1` → **8 passed** (app booted with `OM_ENABLE_TEST_CHANNEL_SEEDING=true` on an isolated DB).
- set-primary supersede repro: **500 before** the fix, **200 after** (verified with curl + `psql` on `is_primary` state).
- `yarn turbo run typecheck --filter=@open-mercato/core` → pass.
- `yarn workspace @open-mercato/core test communication_channels` → **535 passed**, 54 suites.
- `yarn build:app` → pass.
- `yarn i18n:check-sync` → in sync.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).  <!-- author to confirm on submit -->
- [x] I updated documentation, locales, or generators if the change requires it.  <!-- none required: no user-facing strings, no new auto-discovered module files -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).  <!-- specs live in the module's __integration__/ per .ai/qa/AGENTS.md; .ai/qa/tests is config-only -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).  <!-- N/A — no spec change needed -->

### Design System Compliance
- [x] No hardcoded status colors — N/A, backend/test-only change, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2486