### PR TITLE
feat: 2485 messages integration coverage

### DIFF
--- a/packages/core/src/helpers/integration/dbFixtures.ts
+++ b/packages/core/src/helpers/integration/dbFixtures.ts
@@ -44,7 +44,7 @@ function resolveDatabaseUrl(): string {
   return url;
 }
 
-async function withClient<T>(run: (client: Client) => Promise<T>): Promise<T> {
+export async function withClient<T>(run: (client: Client) => Promise<T>): Promise<T> {
   const client = new Client({ connectionString: resolveDatabaseUrl() });
   await client.connect();
   try {

--- a/packages/core/src/modules/messages/__integration__/TC-API-MSG-014.spec.ts
+++ b/packages/core/src/modules/messages/__integration__/TC-API-MSG-014.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { composeInternalMessage, deleteMessageIfExists } from './helpers';
+
+/**
+ * TC-API-MSG-014: Delete Message For Actor Removes Access
+ * Surface: packages/core/src/modules/messages/api/[id]/route.ts (DELETE)
+ *
+ * When the sender deletes a message, `messages.messages.delete_for_actor`
+ * soft-deletes the message itself (message.deletedAt), so both sender and
+ * recipient lose access (GET filters deletedAt: null). The response carries
+ * the operation metadata header. A missing message id returns 404.
+ */
+test.describe('TC-API-MSG-014: Delete Message For Actor Removes Access', () => {
+  test('should remove access for sender and recipient after sender delete', async ({ request }) => {
+    let messageId: string | null = null;
+    let adminToken: string | null = null;
+
+    try {
+      const fixture = await composeInternalMessage(request, {
+        subject: `QA TC-API-MSG-014 ${Date.now()}`,
+      });
+      messageId = fixture.messageId;
+      adminToken = fixture.senderToken;
+      const recipientToken = fixture.recipientToken;
+
+      // Recipient can read it before deletion (sanity check on access).
+      const preDeleteRecipient = await apiRequest(request, 'GET', `/api/messages/${messageId}?skipMarkRead=1`, {
+        token: recipientToken,
+      });
+      expect(preDeleteRecipient.status()).toBe(200);
+
+      // Deleting an unknown id returns 404, not a 500.
+      const missingDelete = await apiRequest(
+        request,
+        'DELETE',
+        '/api/messages/00000000-0000-0000-0000-000000000000',
+        { token: adminToken },
+      );
+      expect(missingDelete.status()).toBe(404);
+
+      // Sender deletes the message.
+      const deleteResponse = await apiRequest(request, 'DELETE', `/api/messages/${messageId}`, {
+        token: adminToken,
+      });
+      expect(deleteResponse.status()).toBe(200);
+      const deleteBody = (await deleteResponse.json()) as { ok?: unknown };
+      expect(deleteBody.ok).toBe(true);
+      // Operation metadata header is attached for undo/audit wiring.
+      expect(deleteResponse.headers()['x-om-operation']).toBeTruthy();
+
+      // Both sender and recipient now get 404 on detail access.
+      const senderDetail = await apiRequest(request, 'GET', `/api/messages/${messageId}`, {
+        token: adminToken,
+      });
+      expect(senderDetail.status()).toBe(404);
+
+      const recipientDetail = await apiRequest(request, 'GET', `/api/messages/${messageId}?skipMarkRead=1`, {
+        token: recipientToken,
+      });
+      expect(recipientDetail.status()).toBe(404);
+
+      // The deleted message is gone from the recipient inbox listing.
+      const inboxResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/messages?folder=inbox&pageSize=100`,
+        { token: recipientToken },
+      );
+      expect(inboxResponse.ok()).toBeTruthy();
+      const inboxBody = (await inboxResponse.json()) as { items?: Array<{ id?: unknown }> };
+      const inboxIds = (inboxBody.items ?? []).map((item) => item.id);
+      expect(inboxIds).not.toContain(messageId);
+
+      // Already deleted — clear the cleanup handle so finally does not double-delete.
+      messageId = null;
+    } finally {
+      await deleteMessageIfExists(request, adminToken, messageId);
+    }
+  });
+});

--- a/packages/core/src/modules/messages/__integration__/TC-API-MSG-015.spec.ts
+++ b/packages/core/src/modules/messages/__integration__/TC-API-MSG-015.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { composeInternalMessage, deleteMessageIfExists } from './helpers';
+
+/**
+ * TC-API-MSG-015: Mark Read and Unread Toggle State
+ * Surface: packages/core/src/modules/messages/api/[id]/read/route.ts (PUT/DELETE)
+ *
+ * Recipient-only state machine: unread -> read (PUT) -> unread (DELETE).
+ * `?skipMarkRead=1` reads the detail without the implicit auto-mark-read so the
+ * isRead flag can be inspected deterministically. A non-recipient (the sender)
+ * cannot toggle read state and receives 403.
+ */
+test.describe('TC-API-MSG-015: Mark Read and Unread Toggle State', () => {
+  test('should toggle read state for the recipient and reject non-recipients', async ({ request }) => {
+    let messageId: string | null = null;
+    let adminToken: string | null = null;
+
+    try {
+      const fixture = await composeInternalMessage(request, {
+        subject: `QA TC-API-MSG-015 ${Date.now()}`,
+      });
+      messageId = fixture.messageId;
+      adminToken = fixture.senderToken;
+      const recipientToken = fixture.recipientToken;
+
+      // Before any read interaction the recipient inbox shows status=unread.
+      // (The list endpoint does not mutate read state.)
+      const inboxBefore = await apiRequest(
+        request,
+        'GET',
+        `/api/messages?folder=inbox&pageSize=100`,
+        { token: recipientToken },
+      );
+      expect(inboxBefore.ok()).toBeTruthy();
+      const inboxBeforeBody = (await inboxBefore.json()) as {
+        items?: Array<{ id?: unknown; status?: unknown }>;
+      };
+      const inboxItem = inboxBeforeBody.items?.find((item) => item.id === messageId);
+      expect(inboxItem).toBeTruthy();
+      expect(inboxItem?.status).toBe('unread');
+
+      // A non-recipient (the sender) cannot mark read -> 403.
+      const senderMarkRead = await apiRequest(request, 'PUT', `/api/messages/${messageId}/read`, {
+        token: adminToken,
+      });
+      expect(senderMarkRead.status()).toBe(403);
+
+      // Recipient marks read.
+      const markRead = await apiRequest(request, 'PUT', `/api/messages/${messageId}/read`, {
+        token: recipientToken,
+      });
+      expect(markRead.status()).toBe(200);
+      const markReadBody = (await markRead.json()) as { ok?: unknown };
+      expect(markReadBody.ok).toBe(true);
+      expect(markRead.headers()['x-om-operation']).toBeTruthy();
+
+      const afterRead = await apiRequest(request, 'GET', `/api/messages/${messageId}?skipMarkRead=1`, {
+        token: recipientToken,
+      });
+      expect(afterRead.status()).toBe(200);
+      const afterReadBody = (await afterRead.json()) as { isRead?: unknown };
+      expect(afterReadBody.isRead).toBe(true);
+
+      // Recipient marks unread again.
+      const markUnread = await apiRequest(request, 'DELETE', `/api/messages/${messageId}/read`, {
+        token: recipientToken,
+      });
+      expect(markUnread.status()).toBe(200);
+      const markUnreadBody = (await markUnread.json()) as { ok?: unknown };
+      expect(markUnreadBody.ok).toBe(true);
+      expect(markUnread.headers()['x-om-operation']).toBeTruthy();
+
+      const afterUnread = await apiRequest(request, 'GET', `/api/messages/${messageId}?skipMarkRead=1`, {
+        token: recipientToken,
+      });
+      expect(afterUnread.status()).toBe(200);
+      const afterUnreadBody = (await afterUnread.json()) as { isRead?: unknown };
+      expect(afterUnreadBody.isRead).toBe(false);
+    } finally {
+      await deleteMessageIfExists(request, adminToken, messageId);
+    }
+  });
+});

--- a/packages/core/src/modules/messages/__integration__/TC-API-MSG-016.spec.ts
+++ b/packages/core/src/modules/messages/__integration__/TC-API-MSG-016.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  composeMessageWithToken,
+  decodeJwtSubject,
+  deleteMessageIfExists,
+  replyToMessageWithToken,
+} from './helpers';
+
+/**
+ * TC-API-MSG-016: Forward Preview and Body Truncation
+ * Surface: packages/core/src/modules/messages/api/[id]/forward-preview/route.ts (GET)
+ *
+ * The forward preview returns { subject, body } where `body` is the rendered
+ * forward block for the thread slice UP TO (and including) the selected
+ * message — later replies are excluded. Only participants (sender/recipient)
+ * can preview; others get 403. When the rendered body exceeds the forward
+ * length cap (50k) the route returns 413.
+ */
+test.describe('TC-API-MSG-016: Forward Preview and Body Truncation', () => {
+  test('should scope the preview to the selected slice and reject non-participants', async ({ request }) => {
+    let rootId: string | null = null;
+    let replyId: string | null = null;
+    let adminToken: string | null = null;
+    let superadminToken: string | null = null;
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      superadminToken = await getAuthToken(request, 'superadmin');
+      const employeeToken = await getAuthToken(request, 'employee');
+      const superadminUserId = decodeJwtSubject(superadminToken);
+
+      const timestamp = Date.now();
+      const rootBody = `Root preview body ${timestamp}`;
+      const replyBody = `Reply preview body ${timestamp}`;
+
+      rootId = await composeMessageWithToken(request, adminToken, {
+        recipients: [{ userId: superadminUserId, type: 'to' }],
+        subject: `QA TC-API-MSG-016 ${timestamp}`,
+        body: rootBody,
+        sendViaEmail: false,
+      });
+      replyId = await replyToMessageWithToken(request, superadminToken, rootId, replyBody);
+
+      // Previewing the reply (deepest node) includes the whole visible slice.
+      const replyPreview = await apiRequest(request, 'GET', `/api/messages/${replyId}/forward-preview`, {
+        token: adminToken,
+      });
+      expect(replyPreview.status()).toBe(200);
+      const replyPreviewBody = (await replyPreview.json()) as { subject?: unknown; body?: unknown };
+      expect(typeof replyPreviewBody.subject).toBe('string');
+      expect(replyPreviewBody.subject as string).toMatch(/^Fwd:/i);
+      expect(typeof replyPreviewBody.body).toBe('string');
+      expect(replyPreviewBody.body as string).toContain(rootBody);
+      expect(replyPreviewBody.body as string).toContain(replyBody);
+
+      // Previewing the root excludes the later reply (slice up to selected message).
+      const rootPreview = await apiRequest(request, 'GET', `/api/messages/${rootId}/forward-preview`, {
+        token: adminToken,
+      });
+      expect(rootPreview.status()).toBe(200);
+      const rootPreviewBody = (await rootPreview.json()) as { body?: unknown };
+      expect(rootPreviewBody.body as string).toContain(rootBody);
+      expect(rootPreviewBody.body as string).not.toContain(replyBody);
+
+      // A non-participant (employee — same org, has messages.compose, but neither
+      // sender nor recipient of this thread) is denied.
+      const outsiderPreview = await apiRequest(request, 'GET', `/api/messages/${replyId}/forward-preview`, {
+        token: employeeToken,
+      });
+      expect(outsiderPreview.status()).toBe(403);
+    } finally {
+      await deleteMessageIfExists(request, superadminToken, replyId);
+      await deleteMessageIfExists(request, adminToken, rootId);
+    }
+  });
+
+  test('should return 413 when the rendered forward body exceeds the length cap', async ({ request }) => {
+    let rootId: string | null = null;
+    let replyId: string | null = null;
+    let adminToken: string | null = null;
+    let employeeToken: string | null = null;
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      employeeToken = await getAuthToken(request, 'employee');
+      const employeeUserId = decodeJwtSubject(employeeToken);
+
+      const timestamp = Date.now();
+      // Two ~30k bodies render to a forward block above the 50k cap.
+      const rootBody = 'A'.repeat(30000);
+      const replyBody = 'B'.repeat(30000);
+
+      rootId = await composeMessageWithToken(request, adminToken, {
+        recipients: [{ userId: employeeUserId, type: 'to' }],
+        subject: `QA TC-API-MSG-016 oversized ${timestamp}`,
+        body: rootBody,
+        sendViaEmail: false,
+      });
+      replyId = await replyToMessageWithToken(request, employeeToken, rootId, replyBody);
+
+      const preview = await apiRequest(request, 'GET', `/api/messages/${replyId}/forward-preview`, {
+        token: adminToken,
+      });
+      expect(preview.status()).toBe(413);
+      const previewBody = (await preview.json()) as { error?: unknown };
+      expect(typeof previewBody.error).toBe('string');
+    } finally {
+      await deleteMessageIfExists(request, employeeToken, replyId);
+      await deleteMessageIfExists(request, adminToken, rootId);
+    }
+  });
+});

--- a/packages/core/src/modules/messages/__integration__/TC-API-MSG-017.spec.ts
+++ b/packages/core/src/modules/messages/__integration__/TC-API-MSG-017.spec.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from 'node:crypto';
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  composeMessageWithToken,
+  decodeJwtSubject,
+  deleteMessageIfExists,
+  uploadAttachmentToMessage,
+} from './helpers';
+
+/**
+ * TC-API-MSG-017: Attachment Management on Draft Messages
+ * Surface: packages/core/src/modules/messages/api/[id]/attachments/route.ts (GET/POST/DELETE)
+ *
+ * Drafts support listing, linking, and unlinking attachments. Linking
+ * re-parents an existing attachment to the draft; unlinking hard-deletes the
+ * association row. Only the sender may mutate; mutations are rejected with 409
+ * once the message is no longer a draft.
+ */
+test.describe('TC-API-MSG-017: Attachment Management on Draft Messages', () => {
+  test('should list, link, and unlink draft attachments with sender/draft guards', async ({ request }) => {
+    let draftId: string | null = null;
+    let sentId: string | null = null;
+    let adminToken: string | null = null;
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      const employeeToken = await getAuthToken(request, 'employee');
+      const employeeUserId = decodeJwtSubject(employeeToken);
+
+      const timestamp = Date.now();
+      draftId = await composeMessageWithToken(request, adminToken, {
+        isDraft: true,
+        recipients: [{ userId: employeeUserId, type: 'to' }],
+        subject: `QA TC-API-MSG-017 draft ${timestamp}`,
+        body: 'Draft body content',
+        sendViaEmail: false,
+      });
+
+      // Upload an attachment directly onto the draft (record_id = draftId).
+      const directAttachmentId = await uploadAttachmentToMessage(request, adminToken, draftId, {
+        fileName: `tc-api-msg-017-direct-${timestamp}.txt`,
+      });
+
+      const listWithDirect = await apiRequest(request, 'GET', `/api/messages/${draftId}/attachments`, {
+        token: adminToken,
+      });
+      expect(listWithDirect.status()).toBe(200);
+      const listWithDirectBody = (await listWithDirect.json()) as {
+        attachments?: Array<{ id?: unknown; fileName?: unknown; url?: unknown }>;
+      };
+      const directItem = (listWithDirectBody.attachments ?? []).find((item) => item.id === directAttachmentId);
+      expect(directItem).toBeTruthy();
+      expect(typeof directItem?.fileName).toBe('string');
+      expect(typeof directItem?.url).toBe('string');
+
+      // Unlink hard-deletes the association — the listing is empty again.
+      const unlinkDirect = await apiRequest(request, 'DELETE', `/api/messages/${draftId}/attachments`, {
+        token: adminToken,
+        data: { attachmentIds: [directAttachmentId] },
+      });
+      expect(unlinkDirect.status()).toBe(200);
+      expect(((await unlinkDirect.json()) as { ok?: unknown }).ok).toBe(true);
+      expect(unlinkDirect.headers()['x-om-operation']).toBeTruthy();
+
+      const listAfterUnlink = await apiRequest(request, 'GET', `/api/messages/${draftId}/attachments`, {
+        token: adminToken,
+      });
+      const listAfterUnlinkBody = (await listAfterUnlink.json()) as { attachments?: Array<{ id?: unknown }> };
+      expect((listAfterUnlinkBody.attachments ?? []).some((item) => item.id === directAttachmentId)).toBe(false);
+
+      // Upload a second attachment against a neutral record, then LINK it to the draft.
+      const linkableAttachmentId = await uploadAttachmentToMessage(request, adminToken, randomUUID(), {
+        fileName: `tc-api-msg-017-linkable-${timestamp}.txt`,
+      });
+
+      const linkResponse = await apiRequest(request, 'POST', `/api/messages/${draftId}/attachments`, {
+        token: adminToken,
+        data: { attachmentIds: [linkableAttachmentId] },
+      });
+      expect(linkResponse.status()).toBe(200);
+      expect(((await linkResponse.json()) as { ok?: unknown }).ok).toBe(true);
+      expect(linkResponse.headers()['x-om-operation']).toBeTruthy();
+
+      const listAfterLink = await apiRequest(request, 'GET', `/api/messages/${draftId}/attachments`, {
+        token: adminToken,
+      });
+      const listAfterLinkBody = (await listAfterLink.json()) as { attachments?: Array<{ id?: unknown }> };
+      expect((listAfterLinkBody.attachments ?? []).some((item) => item.id === linkableAttachmentId)).toBe(true);
+
+      // Non-sender cannot mutate draft attachments -> 403.
+      const employeeLink = await apiRequest(request, 'POST', `/api/messages/${draftId}/attachments`, {
+        token: employeeToken,
+        data: { attachmentIds: [linkableAttachmentId] },
+      });
+      expect(employeeLink.status()).toBe(403);
+
+      // Clean up the linked attachment (also exercises unlink a second time).
+      const unlinkLinked = await apiRequest(request, 'DELETE', `/api/messages/${draftId}/attachments`, {
+        token: adminToken,
+        data: { attachmentIds: [linkableAttachmentId] },
+      });
+      expect(unlinkLinked.status()).toBe(200);
+
+      // Sent (non-draft) messages reject attachment mutations with 409.
+      sentId = await composeMessageWithToken(request, adminToken, {
+        recipients: [{ userId: employeeUserId, type: 'to' }],
+        subject: `QA TC-API-MSG-017 sent ${timestamp}`,
+        body: 'Sent body content',
+        sendViaEmail: false,
+      });
+      const linkOnSent = await apiRequest(request, 'POST', `/api/messages/${sentId}/attachments`, {
+        token: adminToken,
+        data: { attachmentIds: [randomUUID()] },
+      });
+      expect(linkOnSent.status()).toBe(409);
+      const linkOnSentBody = (await linkOnSent.json()) as { error?: unknown };
+      expect(typeof linkOnSentBody.error).toBe('string');
+    } finally {
+      await deleteMessageIfExists(request, adminToken, draftId);
+      await deleteMessageIfExists(request, adminToken, sentId);
+    }
+  });
+});

--- a/packages/core/src/modules/messages/__integration__/TC-API-MSG-018.spec.ts
+++ b/packages/core/src/modules/messages/__integration__/TC-API-MSG-018.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  composeMessageWithToken,
+  decodeJwtSubject,
+  deleteMessageIfExists,
+  replyToMessageWithToken,
+} from './helpers';
+
+/**
+ * TC-API-MSG-018: Conversation-Level Mutations (Archive, Mark Unread, Delete)
+ * Surfaces:
+ *  - api/[id]/conversation/archive/route.ts (PUT)
+ *  - api/[id]/conversation/read/route.ts (DELETE — mark unread)
+ *  - api/[id]/conversation/route.ts (DELETE)
+ *
+ * Conversation mutations are actor-scoped: they affect only the calling user's
+ * recipient rows (and, for delete, the caller's own sent messages). All return
+ * { ok, affectedCount } with the operation metadata header. A recipient
+ * deleting a conversation does not remove the other participant's sent
+ * messages.
+ */
+test.describe('TC-API-MSG-018: Conversation-Level Mutations', () => {
+  test('should archive, mark unread, and delete a conversation per actor', async ({ request }) => {
+    let rootId: string | null = null;
+    let replyId: string | null = null;
+    let secondReplyId: string | null = null;
+    let adminToken: string | null = null;
+    let employeeToken: string | null = null;
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      employeeToken = await getAuthToken(request, 'employee');
+      const employeeUserId = decodeJwtSubject(employeeToken);
+
+      const timestamp = Date.now();
+      rootId = await composeMessageWithToken(request, adminToken, {
+        recipients: [{ userId: employeeUserId, type: 'to' }],
+        subject: `QA TC-API-MSG-018 ${timestamp}`,
+        body: `Conversation root ${timestamp}`,
+        sendViaEmail: false,
+      });
+      // employee replies (recipient = admin), then admin replies (recipient = employee).
+      replyId = await replyToMessageWithToken(request, employeeToken, rootId, `Reply one ${timestamp}`);
+      secondReplyId = await replyToMessageWithToken(request, adminToken, replyId, `Reply two ${timestamp}`);
+
+      // Conversation-level mutations are bulk, actor-scoped operations and are
+      // not individually undoable, so (unlike single-message mutations) they do
+      // not emit the x-om-operation metadata header — only the
+      // { ok, affectedCount } body is asserted here.
+
+      // Archive the conversation for the employee.
+      const archive = await apiRequest(request, 'PUT', `/api/messages/${rootId}/conversation/archive`, {
+        token: employeeToken,
+      });
+      expect(archive.status()).toBe(200);
+      const archiveBody = (await archive.json()) as { ok?: unknown; affectedCount?: unknown };
+      expect(archiveBody.ok).toBe(true);
+      expect(typeof archiveBody.affectedCount).toBe('number');
+      expect(archiveBody.affectedCount as number).toBeGreaterThanOrEqual(1);
+
+      // After archiving, the employee inbox no longer surfaces the received messages.
+      const employeeInbox = await apiRequest(request, 'GET', `/api/messages?folder=inbox&pageSize=100`, {
+        token: employeeToken,
+      });
+      const employeeInboxIds = ((await employeeInbox.json()) as { items?: Array<{ id?: unknown }> }).items?.map(
+        (item) => item.id,
+      ) ?? [];
+      expect(employeeInboxIds).not.toContain(rootId);
+      expect(employeeInboxIds).not.toContain(secondReplyId);
+
+      // Mark the whole conversation unread for the employee.
+      const markUnread = await apiRequest(request, 'DELETE', `/api/messages/${rootId}/conversation/read`, {
+        token: employeeToken,
+      });
+      expect(markUnread.status()).toBe(200);
+      const markUnreadBody = (await markUnread.json()) as { ok?: unknown; affectedCount?: unknown };
+      expect(markUnreadBody.ok).toBe(true);
+      expect(markUnreadBody.affectedCount as number).toBeGreaterThanOrEqual(1);
+
+      // Unknown anchor -> 404.
+      const missing = await apiRequest(
+        request,
+        'DELETE',
+        '/api/messages/00000000-0000-0000-0000-000000000000/conversation',
+        { token: employeeToken },
+      );
+      expect(missing.status()).toBe(404);
+
+      // Delete the conversation for the employee.
+      const deleteConversation = await apiRequest(request, 'DELETE', `/api/messages/${rootId}/conversation`, {
+        token: employeeToken,
+      });
+      expect(deleteConversation.status()).toBe(200);
+      const deleteBody = (await deleteConversation.json()) as { ok?: unknown; affectedCount?: unknown };
+      expect(deleteBody.ok).toBe(true);
+      expect(deleteBody.affectedCount as number).toBeGreaterThanOrEqual(1);
+
+      // Delete is actor-scoped per message: the employee's OWN sent message in the
+      // thread (replyId) is globally removed, so even the admin can no longer read it.
+      const replyForAdmin = await apiRequest(request, 'GET', `/api/messages/${replyId}`, {
+        token: adminToken,
+      });
+      expect(replyForAdmin.status()).toBe(404);
+
+      // The employee's received messages drop out of their inbox (recipient rows
+      // soft-deleted). Note: folder=all still surfaces soft-deleted recipient rows,
+      // so we assert against the inbox here, not folder=all.
+      const employeeInboxAfter = await apiRequest(request, 'GET', `/api/messages?folder=inbox&pageSize=100`, {
+        token: employeeToken,
+      });
+      const employeeInboxAfterIds = ((await employeeInboxAfter.json()) as { items?: Array<{ id?: unknown }> }).items?.map(
+        (item) => item.id,
+      ) ?? [];
+      expect(employeeInboxAfterIds).not.toContain(rootId);
+      expect(employeeInboxAfterIds).not.toContain(secondReplyId);
+
+      // Actor-scoped: the admin still sees the messages THEY sent (root + second reply).
+      const adminAll = await apiRequest(request, 'GET', `/api/messages?folder=all&pageSize=100`, {
+        token: adminToken,
+      });
+      const adminAllIds = ((await adminAll.json()) as { items?: Array<{ id?: unknown }> }).items?.map(
+        (item) => item.id,
+      ) ?? [];
+      expect(adminAllIds).toContain(rootId);
+      expect(adminAllIds).toContain(secondReplyId);
+    } finally {
+      await deleteMessageIfExists(request, employeeToken, replyId);
+      await deleteMessageIfExists(request, adminToken, secondReplyId);
+      await deleteMessageIfExists(request, adminToken, rootId);
+    }
+  });
+});

--- a/packages/core/src/modules/messages/__integration__/TC-API-MSG-019.spec.ts
+++ b/packages/core/src/modules/messages/__integration__/TC-API-MSG-019.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+
+/**
+ * TC-API-MSG-019: Metadata Endpoints — Types and Object Types Registration
+ * Surfaces:
+ *  - api/types/route.ts (GET, messages.view)
+ *  - api/object-types/route.ts (GET, messages.compose)
+ *
+ * Both endpoints expose static registry data. They require authentication, and
+ * object-types requires a `messageType` query parameter (400 when missing).
+ */
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000';
+
+test.describe('TC-API-MSG-019: Metadata Endpoints', () => {
+  test('should expose registered message types to authenticated callers only', async ({ request }) => {
+    const unauth = await request.get(`${BASE_URL}/api/messages/types`);
+    expect(unauth.status()).toBe(401);
+
+    const token = await getAuthToken(request, 'admin');
+    const response = await apiRequest(request, 'GET', '/api/messages/types', { token });
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as {
+      items?: Array<{
+        type?: unknown;
+        module?: unknown;
+        labelKey?: unknown;
+        icon?: unknown;
+        allowReply?: unknown;
+        allowForward?: unknown;
+      }>;
+    };
+    expect(Array.isArray(body.items)).toBe(true);
+    expect((body.items ?? []).length).toBeGreaterThan(0);
+
+    const defaultType = (body.items ?? []).find((item) => item.type === 'default');
+    expect(defaultType).toBeTruthy();
+    expect(defaultType?.module).toBe('messages');
+    expect(typeof defaultType?.labelKey).toBe('string');
+    expect(typeof defaultType?.icon).toBe('string');
+    expect(typeof defaultType?.allowReply).toBe('boolean');
+    expect(typeof defaultType?.allowForward).toBe('boolean');
+  });
+
+  test('should require auth and a messageType query for object-types', async ({ request }) => {
+    const unauth = await request.get(`${BASE_URL}/api/messages/object-types?messageType=default`);
+    expect(unauth.status()).toBe(401);
+
+    const token = await getAuthToken(request, 'admin');
+
+    // Missing required query param -> 400.
+    const missingParam = await apiRequest(request, 'GET', '/api/messages/object-types', { token });
+    expect(missingParam.status()).toBe(400);
+    const missingParamBody = (await missingParam.json()) as { error?: unknown };
+    expect(typeof missingParamBody.error).toBe('string');
+
+    // Valid request returns an items array (the core baseline registers none, so
+    // emptiness is acceptable — the contract is the shape, not the contents).
+    const response = await apiRequest(request, 'GET', '/api/messages/object-types?messageType=default', { token });
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as { items?: Array<{ module?: unknown; entityType?: unknown }> };
+    expect(Array.isArray(body.items)).toBe(true);
+    for (const item of body.items ?? []) {
+      expect(typeof item.module).toBe('string');
+      expect(typeof item.entityType).toBe('string');
+    }
+  });
+});

--- a/packages/core/src/modules/messages/__integration__/TC-API-MSG-020.spec.ts
+++ b/packages/core/src/modules/messages/__integration__/TC-API-MSG-020.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from '@playwright/test';
+import {
+  composeInternalMessage,
+  decodeJwtSubject,
+  deleteMessageAccessTokenIfExists,
+  deleteMessageIfExists,
+  readMessageAccessTokenUseCount,
+  seedMessageAccessToken,
+} from './helpers';
+
+/**
+ * TC-API-MSG-020: Public Token-Based Access to Message Detail
+ * Surface: packages/core/src/modules/messages/api/token/[token]/route.ts (GET, requireAuth:false)
+ *
+ * Tokens are minted internally and stored hashed, so we seed rows directly and
+ * rely on the route's raw-token fallback to match a plaintext sentinel. This
+ * exercises the DB-state-dependent lifecycle the route unit tests cannot:
+ * invalid (404), valid consume (200 + use_count increment), expired (410), and
+ * exhausted (409). The auth-preflight/recipient branches are covered by the
+ * route unit tests.
+ */
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000';
+const MAX_TOKEN_USE_COUNT = 25;
+
+test.describe('TC-API-MSG-020: Public Token-Based Access', () => {
+  test('should enforce token validity, expiry, and usage limits', async ({ request }) => {
+    const timestamp = Date.now();
+    const validToken = `tc-api-msg-020-valid-${timestamp}`;
+    const expiredToken = `tc-api-msg-020-expired-${timestamp}`;
+    const exhaustedToken = `tc-api-msg-020-exhausted-${timestamp}`;
+
+    let messageId: string | null = null;
+    let adminToken: string | null = null;
+
+    try {
+      const fixture = await composeInternalMessage(request, {
+        subject: `QA TC-API-MSG-020 ${timestamp}`,
+        body: `Token-accessible body ${timestamp}`,
+      });
+      messageId = fixture.messageId;
+      adminToken = fixture.senderToken;
+      const recipientUserId = decodeJwtSubject(fixture.recipientToken);
+
+      await seedMessageAccessToken({
+        messageId,
+        recipientUserId,
+        token: validToken,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      });
+      await seedMessageAccessToken({
+        messageId,
+        recipientUserId,
+        token: expiredToken,
+        expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      await seedMessageAccessToken({
+        messageId,
+        recipientUserId,
+        token: exhaustedToken,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        useCount: MAX_TOKEN_USE_COUNT,
+      });
+
+      // Unknown token -> 404.
+      const invalid = await request.get(`${BASE_URL}/api/messages/token/tc-api-msg-020-missing-${timestamp}`);
+      expect(invalid.status()).toBe(404);
+
+      // Valid token -> 200 with message detail; no action-required objects so no auth needed.
+      const valid = await request.get(`${BASE_URL}/api/messages/token/${validToken}`);
+      expect(valid.status()).toBe(200);
+      const validBody = (await valid.json()) as {
+        id?: unknown;
+        subject?: unknown;
+        requiresAuth?: unknown;
+        recipientUserId?: unknown;
+      };
+      expect(validBody.id).toBe(messageId);
+      expect(typeof validBody.subject).toBe('string');
+      expect(validBody.requiresAuth).toBe(false);
+      expect(validBody.recipientUserId).toBe(recipientUserId);
+
+      // The consume command incremented the usage counter.
+      expect(await readMessageAccessTokenUseCount(validToken)).toBe(1);
+
+      // Expired token -> 410.
+      const expired = await request.get(`${BASE_URL}/api/messages/token/${expiredToken}`);
+      expect(expired.status()).toBe(410);
+
+      // Usage-exhausted token -> 409.
+      const exhausted = await request.get(`${BASE_URL}/api/messages/token/${exhaustedToken}`);
+      expect(exhausted.status()).toBe(409);
+    } finally {
+      await deleteMessageAccessTokenIfExists(validToken);
+      await deleteMessageAccessTokenIfExists(expiredToken);
+      await deleteMessageAccessTokenIfExists(exhaustedToken);
+      await deleteMessageIfExists(request, adminToken, messageId);
+    }
+  });
+});

--- a/packages/core/src/modules/messages/__integration__/helpers.ts
+++ b/packages/core/src/modules/messages/__integration__/helpers.ts
@@ -1,5 +1,6 @@
 import { expect, type APIRequestContext, type Locator, type Page } from '@playwright/test';
 import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { withClient } from '@open-mercato/core/helpers/integration/dbFixtures';
 
 export type IntegrationRole = 'admin' | 'employee' | 'superadmin';
 
@@ -8,6 +9,7 @@ export type ComposeMessagePayload = {
   subject: string;
   body: string;
   sendViaEmail?: boolean;
+  isDraft?: boolean;
   actionData?: {
     actions: Array<{
       id: string;
@@ -105,6 +107,23 @@ export async function composeInternalMessage(
     senderToken,
     recipientToken,
   };
+}
+
+export async function replyToMessageWithToken(
+  request: APIRequestContext,
+  token: string,
+  parentMessageId: string,
+  body: string,
+): Promise<string> {
+  const response = await apiRequest(request, 'POST', `/api/messages/${parentMessageId}/reply`, {
+    token,
+    data: { body, sendViaEmail: false },
+  });
+
+  expect(response.status()).toBe(201);
+  const payload = (await response.json()) as { id?: unknown };
+  expect(typeof payload.id).toBe('string');
+  return payload.id as string;
 }
 
 export async function uploadAttachmentToMessage(
@@ -249,5 +268,47 @@ export async function deleteMessageIfExists(
   if (!token || !messageId) return;
   await apiRequest(request, 'DELETE', `/api/messages/${encodeURIComponent(messageId)}`, {
     token,
+  }).catch(() => {});
+}
+
+// Public message-access tokens are only ever minted internally (the "view in
+// browser" email link) and are stored hashed, so there is no API to obtain a
+// usable raw token in a test. We seed rows directly via the shared dbFixtures
+// pg client and rely on the token route's raw-token fallback
+// (`findOne({ token: hashed }) ?? findOne({ token: raw })`) so a plaintext
+// sentinel value matches without needing the app's HMAC secret.
+export async function seedMessageAccessToken(input: {
+  messageId: string;
+  recipientUserId: string;
+  token: string;
+  expiresAt: Date;
+  useCount?: number;
+}): Promise<void> {
+  await withClient(async (client) => {
+    // created_at is NOT NULL without a DB default (MikroORM sets it via onCreate),
+    // so a raw insert must provide it explicitly.
+    await client.query(
+      `insert into message_access_tokens (message_id, recipient_user_id, token, expires_at, use_count, created_at)
+       values ($1, $2, $3, $4, $5, now())`,
+      [input.messageId, input.recipientUserId, input.token, input.expiresAt.toISOString(), input.useCount ?? 0],
+    );
+  });
+}
+
+export async function readMessageAccessTokenUseCount(token: string): Promise<number | null> {
+  return withClient(async (client) => {
+    const result = await client.query<{ use_count: number }>(
+      `select use_count from message_access_tokens where token = $1`,
+      [token],
+    );
+    if (result.rows.length === 0) return null;
+    return Number(result.rows[0].use_count);
+  });
+}
+
+export async function deleteMessageAccessTokenIfExists(token: string | null | undefined): Promise<void> {
+  if (!token) return;
+  await withClient(async (client) => {
+    await client.query(`delete from message_access_tokens where token = $1`, [token]);
   }).catch(() => {});
 }


### PR DESCRIPTION
## Summary

Adds integration-test coverage for the `messages` module's previously-untested API
surfaces (issue #2485): explicit message delete, read/unread toggle, forward-preview
+ body-length cap, draft attachment CRUD, conversation-level mutations, type/object-type
metadata, and public token-based access. Product code is unchanged — these are
self-contained Playwright specs that lock in existing behavior and serve as regression guards.

## Changes

- Add `TC-API-MSG-014` — DELETE `/api/messages/[id]`: sender-delete removes access for sender and recipient (404), plus the missing-id boundary.
- Add `TC-API-MSG-015` — PUT/DELETE `/api/messages/[id]/read`: unread→read→unread toggle (via `?skipMarkRead=1`), non-recipient is rejected (403).
- Add `TC-API-MSG-016` — GET `/api/messages/[id]/forward-preview`: slice scoped to the selected message, non-participant 403, and 413 when the rendered forward body exceeds the 50k cap.
- Add `TC-API-MSG-017` — GET/POST/DELETE `/api/messages/[id]/attachments`: list/link/unlink on drafts, sender-only (403) and draft-only (409) guards.
- Add `TC-API-MSG-018` — conversation archive (PUT), mark-unread (DELETE …/read), delete (DELETE …): `{ok,affectedCount}` shape, actor-scoping, and 404 on an unknown anchor.
- Add `TC-API-MSG-019` — GET `/api/messages/types` and `/api/messages/object-types`: 401 without auth, 400 when `messageType` is missing, and response shape.
- Add `TC-API-MSG-020` — GET `/api/messages/token/[token]`: invalid (404), valid + use-count increment (200), expired (410), exhausted (409), seeding tokens via pg with the route's raw-token fallback.
- Extend `messages/__integration__/helpers.ts` with `replyToMessageWithToken`, an `isDraft` compose option, and `seed/read/deleteMessageAccessToken…` helpers.
- Export `withClient` from `helpers/integration/dbFixtures.ts` so the new token helpers reuse the shared pg/env plumbing instead of duplicating it.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — integration-test coverage for existing `messages` routes; no module spec change. Conventions followed per `.ai/qa/AGENTS.md`.

## Testing

List the tests or commands you ran to validate the change.

- `yarn turbo run typecheck --filter=@open-mercato/core` → pass (type-checks the new `__integration__` specs + helpers).
- `yarn turbo run build --filter=@open-mercato/core` → pass.
- `BASE_URL=http://localhost:3016 OM_INTEGRATION_MODULES=messages npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/messages/__integration__/TC-API-MSG-01{4,5,6,7,8,9}.spec.ts packages/core/src/modules/messages/__integration__/TC-API-MSG-020.spec.ts --workers=1` → **9 passed** (dev:app on an isolated DB seeded via `yarn initialize`).
- jest is unaffected (testMatch excludes `__integration__`; no unit test imports the integration helpers).

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- none required: no new strings/generators -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- executable specs live in the module `__integration__/` folder per .ai/qa/AGENTS.md; `.ai/qa/tests` is config-only -->
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A: test coverage for existing routes -->

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI changes (backend/test-only)
- [x] No arbitrary text sizes — N/A, no UI changes
- [x] Empty state handled for list/data pages — N/A, no UI changes
- [x] Loading state handled for async pages — N/A, no UI changes
- [x] `aria-label` on all icon-only buttons — N/A, no UI changes
- [x] Uses existing DS components — N/A, no UI changes

## Linked issues

Fixes #2485.