### PR TITLE
fix(customers): allow clearing person/company URL & email fields (#2526)

### DIFF
--- a/packages/core/src/modules/customers/__tests__/validators.test.ts
+++ b/packages/core/src/modules/customers/__tests__/validators.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from '@jest/globals'
-import { interactionCreateSchema, interactionUpdateSchema } from '../data/validators'
+import {
+  interactionCreateSchema,
+  interactionUpdateSchema,
+  personUpdateSchema,
+  companyUpdateSchema,
+} from '../data/validators'
 
 const ORG_ID = '11111111-1111-4111-8111-111111111111'
 const TENANT_ID = '22222222-2222-4222-8222-222222222222'
@@ -179,5 +184,115 @@ describe('interactionUpdateSchema scheduledAt derivation', () => {
     if (result.success) {
       expect(result.data.scheduledAt).toBeNull()
     }
+  })
+})
+
+describe('person/company clearable URL & email update fields (#2526)', () => {
+  const personBase = { id: ENTITY_ID, organizationId: ORG_ID, tenantId: TENANT_ID }
+  const companyBase = { id: ENTITY_ID, organizationId: ORG_ID, tenantId: TENANT_ID }
+
+  it('coerces empty-string URL/email person fields to null so the column can be cleared', () => {
+    const result = personUpdateSchema.safeParse({
+      ...personBase,
+      linkedInUrl: '',
+      twitterUrl: '',
+      primaryEmail: '',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.linkedInUrl).toBeNull()
+      expect(result.data.twitterUrl).toBeNull()
+      expect(result.data.primaryEmail).toBeNull()
+    }
+  })
+
+  it('accepts explicit null for person URL/email fields', () => {
+    const result = personUpdateSchema.safeParse({
+      ...personBase,
+      linkedInUrl: null,
+      twitterUrl: null,
+      primaryEmail: null,
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.linkedInUrl).toBeNull()
+      expect(result.data.twitterUrl).toBeNull()
+      expect(result.data.primaryEmail).toBeNull()
+    }
+  })
+
+  it('treats whitespace-only URL/email person fields as a clear', () => {
+    const result = personUpdateSchema.safeParse({
+      ...personBase,
+      linkedInUrl: '   ',
+      primaryEmail: '   ',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.linkedInUrl).toBeNull()
+      expect(result.data.primaryEmail).toBeNull()
+    }
+  })
+
+  it('still validates non-empty person URL/email values', () => {
+    expect(
+      personUpdateSchema.safeParse({ ...personBase, linkedInUrl: 'not-a-url' }).success,
+    ).toBe(false)
+    expect(
+      personUpdateSchema.safeParse({ ...personBase, primaryEmail: 'not-an-email' }).success,
+    ).toBe(false)
+
+    const ok = personUpdateSchema.safeParse({
+      ...personBase,
+      linkedInUrl: 'https://linkedin.com/in/ada',
+      primaryEmail: 'ada@example.com',
+    })
+    expect(ok.success).toBe(true)
+    if (ok.success) {
+      expect(ok.data.linkedInUrl).toBe('https://linkedin.com/in/ada')
+      expect(ok.data.primaryEmail).toBe('ada@example.com')
+    }
+  })
+
+  it('omitting a person URL/email field leaves it undefined (no-op update)', () => {
+    const result = personUpdateSchema.safeParse({ ...personBase })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect('linkedInUrl' in result.data).toBe(false)
+      expect('primaryEmail' in result.data).toBe(false)
+    }
+  })
+
+  it('coerces empty-string and null company website/email fields to null', () => {
+    const empties = companyUpdateSchema.safeParse({
+      ...companyBase,
+      websiteUrl: '',
+      primaryEmail: '',
+    })
+    expect(empties.success).toBe(true)
+    if (empties.success) {
+      expect(empties.data.websiteUrl).toBeNull()
+      expect(empties.data.primaryEmail).toBeNull()
+    }
+
+    const nulls = companyUpdateSchema.safeParse({
+      ...companyBase,
+      websiteUrl: null,
+      primaryEmail: null,
+    })
+    expect(nulls.success).toBe(true)
+    if (nulls.success) {
+      expect(nulls.data.websiteUrl).toBeNull()
+      expect(nulls.data.primaryEmail).toBeNull()
+    }
+  })
+
+  it('still validates non-empty company website/email values', () => {
+    expect(
+      companyUpdateSchema.safeParse({ ...companyBase, websiteUrl: 'not-a-url' }).success,
+    ).toBe(false)
+    expect(
+      companyUpdateSchema.safeParse({ ...companyBase, primaryEmail: 'not-an-email' }).success,
+    ).toBe(false)
   })
 })

--- a/packages/core/src/modules/customers/components/__tests__/formConfig.test.ts
+++ b/packages/core/src/modules/customers/components/__tests__/formConfig.test.ts
@@ -9,9 +9,13 @@ jest.mock('../detail/RolesSection', () => ({
 }))
 
 import {
+  buildCompanyEditPayload,
   buildCompanyPayload,
+  buildPersonEditPayload,
   buildPersonPayload,
   createCompanyDaneFiremyGroups,
+  createCompanyEditSchema,
+  createPersonEditSchema,
   createPersonPersonalDataGroups,
   mapCompanyOverviewToFormValues,
   mapPersonOverviewToFormValues,
@@ -19,6 +23,9 @@ import {
 } from '../formConfig'
 
 const t: Translator = (_key, fallback) => fallback ?? _key
+
+const PERSON_ID = '44444444-4444-4444-8444-444444444444'
+const COMPANY_ID = '55555555-5555-4555-8555-555555555555'
 
 describe('detail page zone1 group layouts', () => {
   it('keeps all company v2 zone1 groups in the sortable primary column', () => {
@@ -133,5 +140,75 @@ describe('detail page zone1 group layouts', () => {
     } as any)
 
     expect(values.cf_buying_role).toBe('champion')
+  })
+})
+
+describe('clearing v2 URL & email edit fields (#2526)', () => {
+  it('transmits null when a previously-set person URL/email is blanked', () => {
+    const parsed = createPersonEditSchema().safeParse({
+      id: PERSON_ID,
+      displayName: 'Ada Lovelace',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      primaryEmail: '',
+      linkedInUrl: '',
+      twitterUrl: '',
+    })
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+
+    const payload = buildPersonEditPayload(parsed.data as any)
+    expect(payload.primaryEmail).toBeNull()
+    expect(payload.linkedInUrl).toBeNull()
+    expect(payload.twitterUrl).toBeNull()
+  })
+
+  it('keeps non-empty person URL/email values on edit', () => {
+    const parsed = createPersonEditSchema().safeParse({
+      id: PERSON_ID,
+      displayName: 'Ada Lovelace',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      primaryEmail: 'ada@example.com',
+      linkedInUrl: 'https://linkedin.com/in/ada',
+      twitterUrl: 'https://x.com/ada',
+    })
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+
+    const payload = buildPersonEditPayload(parsed.data as any)
+    expect(payload.primaryEmail).toBe('ada@example.com')
+    expect(payload.linkedInUrl).toBe('https://linkedin.com/in/ada')
+    expect(payload.twitterUrl).toBe('https://x.com/ada')
+  })
+
+  it('transmits null when a previously-set company website/email is blanked', () => {
+    const parsed = createCompanyEditSchema().safeParse({
+      id: COMPANY_ID,
+      displayName: 'Acme',
+      primaryEmail: '',
+      websiteUrl: '',
+    })
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+
+    const payload = buildCompanyEditPayload(parsed.data as any)
+    expect(payload.primaryEmail).toBeNull()
+    expect(payload.websiteUrl).toBeNull()
+  })
+
+  it('keeps non-empty company website/email values on edit', () => {
+    const parsed = createCompanyEditSchema().safeParse({
+      id: COMPANY_ID,
+      displayName: 'Acme',
+      primaryEmail: 'hello@acme.com',
+      websiteUrl: 'https://acme.com',
+    })
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+
+    const payload = buildCompanyEditPayload(parsed.data as any)
+    expect(payload.primaryEmail).toBe('hello@acme.com')
+    expect(payload.websiteUrl).toBe('https://acme.com')
   })
 })

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -1427,15 +1427,20 @@ export function buildCompanyPayload(
 // Edit-mode types
 // ---------------------------------------------------------------------------
 
-export type CompanyEditFormValues = Omit<CompanyFormValues, 'addresses'> & {
+// URL/email fields are clearable on edit: blanking a previously-set value transmits null,
+// so the edit-form value types widen to `string | null` to match the edit-schema output. See #2526.
+export type CompanyEditFormValues = Omit<CompanyFormValues, 'addresses' | 'primaryEmail' | 'websiteUrl'> & {
   id: string
+  primaryEmail?: string | null
+  websiteUrl?: string | null
 }
 
-export type PersonEditFormValues = Omit<PersonFormValues, 'addresses'> & {
+export type PersonEditFormValues = Omit<PersonFormValues, 'addresses' | 'primaryEmail'> & {
   id: string
   department?: string
-  linkedInUrl?: string
-  twitterUrl?: string
+  primaryEmail?: string | null
+  linkedInUrl?: string | null
+  twitterUrl?: string | null
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -1451,31 +1451,44 @@ const optionalString = () =>
     .transform((val) => (val === '' ? undefined : val))
     .optional()
 
+// Edit-mode URL/email fields map to nullable columns and must be clearable: blanking a
+// previously-set value transforms '' → null so the payload builder can transmit an explicit
+// clear (omitting the key can never remove an existing value). Create-mode schemas keep the
+// '' → undefined transform. See #2526.
+const clearableUrlField = () =>
+  z
+    .string()
+    .trim()
+    .url()
+    .optional()
+    .or(z.literal(''))
+    .transform((val) => (val === '' ? null : val))
+    .optional()
+
+const clearableEmailField = () =>
+  z
+    .string()
+    .trim()
+    .email()
+    .optional()
+    .or(z.literal(''))
+    .transform((val) => (val === '' ? null : val))
+    .optional()
+
 export const createCompanyEditSchema = () =>
   createCompanyFormSchema().extend({
     id: z.string().uuid(),
+    primaryEmail: clearableEmailField(),
+    websiteUrl: clearableUrlField(),
   })
 
 export const createPersonEditSchema = () =>
   createPersonFormSchema().extend({
     id: z.string().uuid(),
     department: optionalString(),
-    linkedInUrl: z
-      .string()
-      .trim()
-      .url()
-      .optional()
-      .or(z.literal(''))
-      .transform((val) => (val === '' ? undefined : val))
-      .optional(),
-    twitterUrl: z
-      .string()
-      .trim()
-      .url()
-      .optional()
-      .or(z.literal(''))
-      .transform((val) => (val === '' ? undefined : val))
-      .optional(),
+    primaryEmail: clearableEmailField(),
+    linkedInUrl: clearableUrlField(),
+    twitterUrl: clearableUrlField(),
   })
 
 // ---------------------------------------------------------------------------
@@ -1755,9 +1768,27 @@ export const createPersonPersonalDataGroups = (
 // Edit-mode payload builders
 // ---------------------------------------------------------------------------
 
+// On edit, optional URL/email fields that map to nullable columns must transmit an explicit
+// `null` when the user blanks a previously-set value — omitting the key can never clear it.
+// The base create-mode builders omit blanks (correct for create), so the edit builders
+// override these clearable fields here. See #2526.
+const assignClearable = (payload: Record<string, unknown>, key: string, raw: unknown): void => {
+  if (raw === null) {
+    payload[key] = null
+    return
+  }
+  if (typeof raw !== 'string') return
+  const trimmed = raw.trim()
+  payload[key] = trimmed.length ? trimmed : null
+}
+
 export function buildCompanyEditPayload(values: CompanyEditFormValues, organizationId?: string | null): Record<string, unknown> {
   const payload = buildCompanyPayload(values, organizationId)
   payload.id = values.id
+
+  assignClearable(payload, 'primaryEmail', values.primaryEmail)
+  assignClearable(payload, 'websiteUrl', values.websiteUrl)
+
   return payload
 }
 
@@ -1768,11 +1799,9 @@ export function buildPersonEditPayload(values: PersonEditFormValues, organizatio
   const department = typeof values.department === 'string' ? values.department.trim() : ''
   if (department.length) payload.department = department
 
-  const linkedInUrl = typeof values.linkedInUrl === 'string' ? values.linkedInUrl.trim() : ''
-  if (linkedInUrl.length) payload.linkedInUrl = linkedInUrl
-
-  const twitterUrl = typeof values.twitterUrl === 'string' ? values.twitterUrl.trim() : ''
-  if (twitterUrl.length) payload.twitterUrl = twitterUrl
+  assignClearable(payload, 'primaryEmail', values.primaryEmail)
+  assignClearable(payload, 'linkedInUrl', values.linkedInUrl)
+  assignClearable(payload, 'twitterUrl', values.twitterUrl)
 
   return payload
 }

--- a/packages/core/src/modules/customers/data/validators.ts
+++ b/packages/core/src/modules/customers/data/validators.ts
@@ -14,6 +14,27 @@ const phoneSchema = z.string().trim().max(50).refine((val) => {
   return isValidPhoneNumber(val)
 }, { message: CUSTOMER_PHONE_INVALID_MESSAGE_KEY }).optional()
 
+// Optional URL/email fields map to nullable DB columns. Treat both '' and null as an
+// explicit "clear this value" signal (both coerce to null) so a previously-set value can
+// be removed via update; without this `''` fails `.url()/.email()` and `null` fails the
+// string type, leaving the columns effectively write-once-non-empty. The command layer
+// already persists null. See #2526.
+const emptyStringToNull = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : null
+}
+
+const clearableEmailSchema = z.preprocess(
+  emptyStringToNull,
+  z.string().email().max(320).nullable().optional(),
+)
+
+const clearableUrlSchema = z.preprocess(
+  emptyStringToNull,
+  z.string().url().max(300).nullable().optional(),
+)
+
 const interactionPhoneNumberSchema = z.string().trim().max(50).optional().nullable()
 
 const scopedSchema = z.object({
@@ -42,12 +63,7 @@ const baseEntitySchema = {
   displayName: displayNameSchema,
   description: z.string().trim().max(4000).optional(),
   ownerUserId: uuid().optional(),
-  primaryEmail: z
-    .string()
-    .trim()
-    .email()
-    .max(320)
-    .optional(),
+  primaryEmail: clearableEmailSchema,
   primaryPhone: phoneSchema,
   status: z.string().trim().max(100).optional(),
   lifecycleStage: z.string().trim().max(100).optional(),
@@ -65,8 +81,8 @@ const personDetailsSchema = {
   department: z.string().trim().max(150).optional(),
   seniority: z.string().trim().max(100).optional(),
   timezone: z.string().trim().max(120).optional(),
-  linkedInUrl: z.string().trim().url().max(300).optional(),
-  twitterUrl: z.string().trim().url().max(300).optional(),
+  linkedInUrl: clearableUrlSchema,
+  twitterUrl: clearableUrlSchema,
   companyEntityId: uuid().nullable().optional(),
 }
 
@@ -77,7 +93,7 @@ const companyDetailsSchema = {
   legalName: z.string().trim().max(200).optional(),
   brandName: z.string().trim().max(200).optional(),
   domain: z.string().trim().max(200).optional(),
-  websiteUrl: z.string().trim().url().max(300).optional(),
+  websiteUrl: clearableUrlSchema,
   industry: z.string().trim().max(150).optional(),
   sizeBucket: z.string().trim().max(100).optional(),
   annualRevenue: z.coerce.number().min(0).optional(),


### PR DESCRIPTION
Fixes #2526

## Problem
Person and Company optional URL/email fields could not be cleared once set. `''` and `null` both returned **400**, and the v2 edit forms omitted blank fields (silent no-op). Affected: `linkedInUrl`, `twitterUrl`, `primaryEmail` (person) and `websiteUrl`, `primaryEmail` (company) — all nullable DB columns.

## Root Cause
- `data/validators.ts`: these fields were `z.string().trim().url()/.email().optional()` — `.optional()` only accepts `undefined`. `''` still ran `.url()/.email()` (400) and `null` failed the string type (400). No `''`→null coercion despite the columns being nullable.
- `components/formConfig.tsx`: the v2 edit payload builders omitted blank fields, and the edit form schemas transformed blank URL/email values to `undefined` — so a clear was never transmitted.

## What Changed
- **Backend (`data/validators.ts`)**: introduced `clearableEmailSchema` / `clearableUrlSchema` (`z.preprocess` that maps `''`/whitespace → `null`, wrapping `.email()/.url().nullable().optional()`). Applied to `primaryEmail` (base entity), `linkedInUrl`/`twitterUrl` (person), and `websiteUrl` (company). Both `''` and `null` now clear the column; non-empty values are still validated. The command layer already persists `null`.
- **Frontend (`components/formConfig.tsx`)**: edit form schemas now transform blank clearable fields `''` → `null` (create-mode schemas unchanged), and the v2 edit payload builders (`buildPersonEditPayload`, `buildCompanyEditPayload`) transmit an explicit `null` when a previously-set field is blanked instead of omitting the key.

## Tests
- `__tests__/validators.test.ts`: new block (#2526) — `personUpdateSchema`/`companyUpdateSchema` coerce `''`, whitespace, and `null` to `null` for all five fields; non-empty values still validate; omitted keys stay absent.
- `components/__tests__/formConfig.test.ts`: new block (#2526) — parsing blanked values through `createPersonEditSchema`/`createCompanyEditSchema` and running the edit payload builders yields `null` for the cleared fields and preserves real values.
- Full customers suite: **759 passed**.

## Backward Compatibility
- No contract-surface changes. Update/create schemas only **widen** the accepted input (now also accept `''`/`null` for these optional fields); the inferred input types gain `| null`. All field consumers are `typeof === 'string'`-guarded and the command layer already handles `null`. API response shape unchanged.