### PR TITLE
feat: 2484 catalog integration coverage

### DIFF
--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-027.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-027.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createCategoryFixture,
+  deleteCatalogCategoryIfExists,
+} from '@open-mercato/core/helpers/integration/catalogFixtures'
+
+/**
+ * TC-CAT-027: Categories LIST API — manage vs tree views.
+ * Source: issue #2484 (catalog integration coverage), scenario TC-CAT-027.
+ *
+ * `GET /api/catalog/categories` has a custom handler with two shapes:
+ *  - `view=manage` → paginated flat list; each item carries `parentId`,
+ *    `childCount` and `descendantCount` computed over the full hierarchy.
+ *  - `view=tree` → nested forest of root nodes, each with a `children` array.
+ * Both envelopes are `{ items: [...] }`. Existing specs only exercise the
+ * category CRUD/UI form, never the list API directly.
+ */
+test.describe('TC-CAT-027: Categories tree and manage views', () => {
+  test('manage view returns parentId, childCount and descendantCount with correct hierarchy', async ({
+    request,
+  }) => {
+    const suffix = Date.now()
+    let token: string | null = null
+    let parentId: string | null = null
+    let childId: string | null = null
+
+    try {
+      token = await getAuthToken(request)
+
+      parentId = await createCategoryFixture(request, token, { name: `QA Cat Parent ${suffix}` })
+
+      const childRes = await apiRequest(request, 'POST', '/api/catalog/categories', {
+        token,
+        data: { name: `QA Cat Child ${suffix}`, parentId },
+      })
+      expect(childRes.ok(), `Failed to create child category: ${childRes.status()}`).toBeTruthy()
+      childId = ((await childRes.json()) as { id?: string }).id ?? null
+      expect(childId, 'Child category id is required').toBeTruthy()
+
+      const manageRes = await apiRequest(
+        request,
+        'GET',
+        `/api/catalog/categories?view=manage&search=${encodeURIComponent(String(suffix))}&page=1&pageSize=50`,
+        { token },
+      )
+      expect(manageRes.ok(), `manage view failed: ${manageRes.status()}`).toBeTruthy()
+      const manageBody = (await manageRes.json()) as {
+        items?: Array<{
+          id: string
+          parentId: string | null
+          childCount?: number
+          descendantCount?: number
+        }>
+      }
+      const items = manageBody.items ?? []
+
+      const parentRow = items.find((item) => item.id === parentId)
+      const childRow = items.find((item) => item.id === childId)
+
+      expect(parentRow, 'Parent category should be present in manage view').toBeTruthy()
+      expect(childRow, 'Child category should be present in manage view').toBeTruthy()
+
+      // Flat list exposes the hierarchy via fields, not nesting.
+      expect(childRow?.parentId).toBe(parentId)
+      expect(parentRow?.childCount ?? 0).toBeGreaterThanOrEqual(1)
+      expect(parentRow?.descendantCount ?? 0).toBeGreaterThanOrEqual(1)
+    } finally {
+      await deleteCatalogCategoryIfExists(request, token, childId)
+      await deleteCatalogCategoryIfExists(request, token, parentId)
+    }
+  })
+
+  test('tree view nests the child under its parent in a children array', async ({ request }) => {
+    const suffix = Date.now()
+    let token: string | null = null
+    let parentId: string | null = null
+    let childId: string | null = null
+
+    try {
+      token = await getAuthToken(request)
+
+      parentId = await createCategoryFixture(request, token, { name: `QA Tree Parent ${suffix}` })
+
+      const childRes = await apiRequest(request, 'POST', '/api/catalog/categories', {
+        token,
+        data: { name: `QA Tree Child ${suffix}`, parentId },
+      })
+      expect(childRes.ok(), `Failed to create child category: ${childRes.status()}`).toBeTruthy()
+      childId = ((await childRes.json()) as { id?: string }).id ?? null
+      expect(childId, 'Child category id is required').toBeTruthy()
+
+      const treeRes = await apiRequest(request, 'GET', '/api/catalog/categories?view=tree', {
+        token,
+      })
+      expect(treeRes.ok(), `tree view failed: ${treeRes.status()}`).toBeTruthy()
+      const treeBody = (await treeRes.json()) as {
+        items?: Array<{ id: string; children?: Array<{ id: string }> }>
+      }
+      const roots = treeBody.items ?? []
+
+      // The newly created parent has no parent of its own, so it is a root node.
+      const parentNode = roots.find((node) => node.id === parentId)
+      expect(parentNode, 'Parent should appear as a root node in the tree').toBeTruthy()
+      const nestedChildIds = (parentNode?.children ?? []).map((node) => node.id)
+      expect(nestedChildIds).toContain(childId)
+    } finally {
+      await deleteCatalogCategoryIfExists(request, token, childId)
+      await deleteCatalogCategoryIfExists(request, token, parentId)
+    }
+  })
+})

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-028.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-028.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createProductFixture,
+  deleteCatalogProductIfExists,
+} from '@open-mercato/core/helpers/integration/catalogFixtures'
+
+/**
+ * TC-CAT-028: Product-unit-conversions reject a duplicate unit on the same product.
+ * Source: issue #2484 (catalog integration coverage), scenario TC-CAT-028.
+ *
+ * `(product_id, unit_code)` is unique (`catalog_product_unit_conversions_unique`).
+ * The create command catches the violation and re-throws it as
+ * `HTTP 409 { error: 'uom.duplicate_conversion' }`. TC-CAT-014 covers unit
+ * canonicalization but never the uniqueness constraint.
+ */
+test.describe('TC-CAT-028: Product unit conversion duplicate rejection', () => {
+  test('rejects a second conversion with the same unit code on a product', async ({ request }) => {
+    const suffix = Date.now()
+    let token: string | null = null
+    let productId: string | null = null
+    let conversionId: string | null = null
+
+    try {
+      token = await getAuthToken(request)
+
+      productId = await createProductFixture(request, token, {
+        title: `QA Unit Dup ${suffix}`,
+        sku: `QA-CAT-028-${suffix}`,
+      })
+
+      const firstRes = await apiRequest(request, 'POST', '/api/catalog/product-unit-conversions', {
+        token,
+        data: { productId, unitCode: 'box', toBaseFactor: 12 },
+      })
+      expect(firstRes.status(), `First conversion should be created: ${firstRes.status()}`).toBe(201)
+      conversionId = ((await firstRes.json()) as { id?: string }).id ?? null
+      expect(conversionId, 'Conversion id is required').toBeTruthy()
+
+      const duplicateRes = await apiRequest(
+        request,
+        'POST',
+        '/api/catalog/product-unit-conversions',
+        {
+          token,
+          data: { productId, unitCode: 'box', toBaseFactor: 24 },
+        },
+      )
+      expect(duplicateRes.status(), 'Duplicate unit on the same product must conflict').toBe(409)
+      const duplicateBody = (await duplicateRes.json()) as { error?: string }
+      expect(duplicateBody.error).toBe('uom.duplicate_conversion')
+    } finally {
+      if (token && conversionId) {
+        await apiRequest(
+          request,
+          'DELETE',
+          `/api/catalog/product-unit-conversions?id=${encodeURIComponent(conversionId)}`,
+          { token },
+        ).catch(() => undefined)
+      }
+      await deleteCatalogProductIfExists(request, token, productId)
+    }
+  })
+})

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-029.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-029.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { deleteCatalogProductIfExists } from '@open-mercato/core/helpers/integration/catalogFixtures'
+
+/**
+ * TC-CAT-029: Option schemas — delete is blocked while a product references the schema.
+ * Source: issue #2484 (catalog integration coverage), scenario TC-CAT-029.
+ *
+ * Note: the issue framed this around a *variant* reference, but variants carry
+ * no option-schema FK in the data model. The referential link lives on the
+ * PRODUCT (`optionSchemaId` / `isConfigurable`), and the delete command blocks
+ * with `HTTP 400 { error: 'Detach products from this schema before deleting it.' }`
+ * while any product is attached. TC-CAT-019 asserts only `status >= 400`; this
+ * spec pins the exact status + message, proves the schema survives the failed
+ * delete, and proves the delete succeeds once the product is detached.
+ */
+test.describe('TC-CAT-029: Option schema referential integrity on delete', () => {
+  test('blocks delete while attached, then succeeds after the product is detached', async ({
+    request,
+  }) => {
+    const stamp = Date.now()
+    let token: string | null = null
+    let schemaId: string | null = null
+    let productId: string | null = null
+
+    try {
+      token = await getAuthToken(request)
+
+      const createSchemaRes = await apiRequest(request, 'POST', '/api/catalog/option-schemas', {
+        token,
+        data: {
+          name: `QA Schema Ref ${stamp}`,
+          schema: {
+            options: [
+              {
+                code: 'size',
+                label: 'Size',
+                inputType: 'select',
+                choices: [
+                  { code: 's', label: 'S' },
+                  { code: 'm', label: 'M' },
+                ],
+              },
+            ],
+          },
+        },
+      })
+      expect(
+        createSchemaRes.ok(),
+        `Failed to create option schema: ${createSchemaRes.status()}`,
+      ).toBeTruthy()
+      schemaId = ((await createSchemaRes.json()) as { id?: string }).id ?? null
+      expect(schemaId, 'Option schema id is required').toBeTruthy()
+
+      const createProductRes = await apiRequest(request, 'POST', '/api/catalog/products', {
+        token,
+        data: {
+          title: `QA TC-CAT-029 Product ${stamp}`,
+          sku: `QA-CAT-029-${stamp}`,
+          description:
+            'Long enough description for the option-schema referential-integrity test. This text keeps the create validation satisfied.',
+          optionSchemaId: schemaId,
+          isConfigurable: true,
+        },
+      })
+      expect(
+        createProductRes.ok(),
+        `Failed to create product referencing schema: ${createProductRes.status()}`,
+      ).toBeTruthy()
+      productId = ((await createProductRes.json()) as { id?: string }).id ?? null
+      expect(productId, 'Product id is required').toBeTruthy()
+
+      // Delete must be blocked while the product references the schema.
+      const blockedRes = await apiRequest(
+        request,
+        'DELETE',
+        `/api/catalog/option-schemas?id=${encodeURIComponent(schemaId as string)}`,
+        { token },
+      )
+      expect(blockedRes.status(), 'Delete of an in-use schema must be blocked').toBe(400)
+      const blockedBody = (await blockedRes.json()) as { error?: string }
+      expect(blockedBody.error).toBe('Detach products from this schema before deleting it.')
+
+      // The schema must still exist after the failed delete.
+      const stillThereRes = await apiRequest(
+        request,
+        'GET',
+        `/api/catalog/option-schemas?page=1&pageSize=50&id=${encodeURIComponent(schemaId as string)}`,
+        { token },
+      )
+      expect(stillThereRes.ok()).toBeTruthy()
+      const stillThereBody = (await stillThereRes.json()) as { items?: Array<{ id: string }> }
+      expect((stillThereBody.items ?? []).some((item) => item.id === schemaId)).toBeTruthy()
+
+      // Detach the product, then the delete should succeed.
+      const detachRes = await apiRequest(request, 'PUT', '/api/catalog/products', {
+        token,
+        data: { id: productId, optionSchemaId: null, isConfigurable: false },
+      })
+      expect(detachRes.ok(), `Failed to detach product from schema: ${detachRes.status()}`).toBeTruthy()
+
+      const deleteRes = await apiRequest(
+        request,
+        'DELETE',
+        `/api/catalog/option-schemas?id=${encodeURIComponent(schemaId as string)}`,
+        { token },
+      )
+      expect(deleteRes.ok(), `Detached schema should delete: ${deleteRes.status()}`).toBeTruthy()
+
+      const goneRes = await apiRequest(
+        request,
+        'GET',
+        `/api/catalog/option-schemas?page=1&pageSize=50&id=${encodeURIComponent(schemaId as string)}`,
+        { token },
+      )
+      expect(goneRes.ok()).toBeTruthy()
+      const goneBody = (await goneRes.json()) as { items?: Array<{ id: string }> }
+      expect((goneBody.items ?? []).some((item) => item.id === schemaId)).toBeFalsy()
+
+      schemaId = null
+    } finally {
+      await deleteCatalogProductIfExists(request, token, productId)
+      if (token && schemaId) {
+        await apiRequest(
+          request,
+          'DELETE',
+          `/api/catalog/option-schemas?id=${encodeURIComponent(schemaId as string)}`,
+          { token },
+        ).catch(() => undefined)
+      }
+    }
+  })
+})

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-030.meta.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-030.meta.ts
@@ -1,0 +1,6 @@
+// The currency dictionary is seeded by the customers module's seedDefaults,
+// while the unit dictionary is seeded by catalog. Gate this test on both so it
+// is excluded when either module is disabled.
+export const integrationMeta = {
+  dependsOnModules: ['catalog', 'customers'],
+}

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-030.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-030.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+
+/**
+ * TC-CAT-030: Dictionary lookup for the catalog `currency` and `unit` dictionaries.
+ * Source: issue #2484 (catalog integration coverage), scenario TC-CAT-030.
+ *
+ * `GET /api/catalog/dictionaries/[key]` resolves `keys = KEY_ALIASES[key] ?? [key]`
+ * and matches stored dictionaries with `key IN keys`. The aliases are keyed by the
+ * CANONICAL request key, so requesting `currency` also matches a dictionary stored
+ * under `currencies`/`measurement_units`, but requesting the plural form directly
+ * is NOT mapped back to the canonical key — it resolves to `[plural]`, finds no
+ * stored dictionary, and returns 404. The `currency` and `unit` dictionaries are
+ * always-present reference data (`seedDefaults`: catalog seeds `unit`, customers
+ * seeds `currency`); the sibling `.meta.ts` gates this test on both modules.
+ *
+ * Note for #2484: the issue assumed the plural alias resolves to the same
+ * dictionary. It does not (see assertions below) — flagged as a likely-unintended
+ * asymmetry in the KEY_ALIASES lookup.
+ */
+type DictionaryResponse = {
+  id?: string
+  entries?: Array<{ id: string; value: string; label: string; color: string | null; icon: string | null }>
+}
+
+test.describe('TC-CAT-030: Dictionary key lookup', () => {
+  test('currency canonical key returns the seeded dictionary; the plural form is not a request alias', async ({
+    request,
+  }) => {
+    const token = await getAuthToken(request)
+
+    const currencyRes = await apiRequest(request, 'GET', '/api/catalog/dictionaries/currency', {
+      token,
+    })
+    expect(currencyRes.status(), `currency lookup failed: ${currencyRes.status()}`).toBe(200)
+    const currency = (await currencyRes.json()) as DictionaryResponse
+    expect(typeof currency.id === 'string' && currency.id.length > 0).toBeTruthy()
+    expect(Array.isArray(currency.entries) && (currency.entries?.length ?? 0) > 0).toBeTruthy()
+    const firstEntry = currency.entries?.[0]
+    expect(firstEntry).toHaveProperty('id')
+    expect(firstEntry).toHaveProperty('value')
+    expect(firstEntry).toHaveProperty('label')
+    expect(firstEntry).toHaveProperty('color')
+    expect(firstEntry).toHaveProperty('icon')
+
+    // KEY_ALIASES maps the canonical key to accepted STORED keys, not the reverse,
+    // so the plural request key has no backing dictionary.
+    const pluralRes = await apiRequest(request, 'GET', '/api/catalog/dictionaries/currencies', {
+      token,
+    })
+    expect(pluralRes.status()).toBe(404)
+  })
+
+  test('unit canonical key returns the seeded dictionary; the plural form is not a request alias', async ({
+    request,
+  }) => {
+    const token = await getAuthToken(request)
+
+    const unitRes = await apiRequest(request, 'GET', '/api/catalog/dictionaries/unit', { token })
+    expect(unitRes.status(), `unit lookup failed: ${unitRes.status()}`).toBe(200)
+    const unit = (await unitRes.json()) as DictionaryResponse
+    expect(typeof unit.id === 'string' && unit.id.length > 0).toBeTruthy()
+    expect(Array.isArray(unit.entries) && (unit.entries?.length ?? 0) > 0).toBeTruthy()
+
+    const pluralRes = await apiRequest(request, 'GET', '/api/catalog/dictionaries/units', { token })
+    expect(pluralRes.status()).toBe(404)
+  })
+
+  test('an unmapped dictionary key returns 404', async ({ request }) => {
+    const token = await getAuthToken(request)
+    const missingKey = `qa-nonexistent-${Date.now()}`
+
+    const res = await apiRequest(
+      request,
+      'GET',
+      `/api/catalog/dictionaries/${encodeURIComponent(missingKey)}`,
+      { token },
+    )
+    expect(res.status()).toBe(404)
+    const body = (await res.json()) as { error?: string }
+    expect(body.error).toBe('Dictionary not found.')
+  })
+})

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-031.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-031.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createProductFixture,
+  deleteCatalogProductIfExists,
+} from '@open-mercato/core/helpers/integration/catalogFixtures'
+
+/**
+ * TC-CAT-031: Tag filtering with multiple tagIds.
+ * Source: issue #2484 (catalog integration coverage), scenario TC-CAT-031.
+ *
+ * Products are written with tag *labels* (`tags: [...]`) but the list API
+ * filters by tag *UUIDs* (`?tagIds=a,b`), so a label→UUID round-trip via
+ * `/api/catalog/tags?search=` is required. Multiple `tagIds` are combined as a
+ * UNION (a product matching ANY listed tag is returned) — not an intersection.
+ * TC-CAT-020 only covers the single-tag case.
+ */
+async function resolveTagId(
+  request: Parameters<typeof apiRequest>[0],
+  token: string,
+  label: string,
+): Promise<string> {
+  const res = await apiRequest(
+    request,
+    'GET',
+    `/api/catalog/tags?page=1&pageSize=50&search=${encodeURIComponent(label)}`,
+    { token },
+  )
+  expect(res.ok(), `Failed to list tags: ${res.status()}`).toBeTruthy()
+  const body = (await res.json()) as { items?: Array<{ id: string; label?: string }> }
+  const match = (body.items ?? []).find((tag) => tag.label === label)
+  expect(match?.id, `Should resolve tag UUID for "${label}"`).toBeTruthy()
+  return match!.id
+}
+
+test.describe('TC-CAT-031: Multi-tag product filtering', () => {
+  test('filters by single and multiple tagIds (union semantics)', async ({ request }) => {
+    const suffix = Date.now()
+    const tagA = `qa-tag-a-${suffix}`
+    const tagB = `qa-tag-b-${suffix}`
+    let token: string | null = null
+    let productBothId: string | null = null
+    let productAId: string | null = null
+    let productNoneId: string | null = null
+
+    try {
+      token = await getAuthToken(request)
+
+      productBothId = await createProductFixture(request, token, {
+        title: `QA Tags Both ${suffix}`,
+        sku: `QA-CAT-031-BOTH-${suffix}`,
+      })
+      productAId = await createProductFixture(request, token, {
+        title: `QA Tags A ${suffix}`,
+        sku: `QA-CAT-031-A-${suffix}`,
+      })
+      productNoneId = await createProductFixture(request, token, {
+        title: `QA Tags None ${suffix}`,
+        sku: `QA-CAT-031-NONE-${suffix}`,
+      })
+
+      await apiRequest(request, 'PUT', '/api/catalog/products', {
+        token,
+        data: { id: productBothId, tags: [tagA, tagB] },
+      })
+      await apiRequest(request, 'PUT', '/api/catalog/products', {
+        token,
+        data: { id: productAId, tags: [tagA] },
+      })
+
+      const tagAId = await resolveTagId(request, token, tagA)
+      const tagBId = await resolveTagId(request, token, tagB)
+
+      const idsFor = async (queryTagIds: string): Promise<string[]> => {
+        const res = await apiRequest(
+          request,
+          'GET',
+          `/api/catalog/products?tagIds=${queryTagIds}&page=1&pageSize=50`,
+          { token: token as string },
+        )
+        expect(res.ok(), `Tag filter failed: ${res.status()}`).toBeTruthy()
+        const body = (await res.json()) as { items?: Array<{ id: string }> }
+        return (body.items ?? []).map((item) => item.id)
+      }
+
+      // Single tag A → both the two-tag product and the A-only product.
+      const byA = await idsFor(tagAId)
+      expect(byA).toContain(productBothId)
+      expect(byA).toContain(productAId)
+      expect(byA).not.toContain(productNoneId)
+
+      // Single tag B → only the two-tag product.
+      const byB = await idsFor(tagBId)
+      expect(byB).toContain(productBothId)
+      expect(byB).not.toContain(productAId)
+      expect(byB).not.toContain(productNoneId)
+
+      // Both tags → union: the two-tag product AND the A-only product.
+      const byBoth = await idsFor(`${tagAId},${tagBId}`)
+      expect(byBoth).toContain(productBothId)
+      expect(byBoth).toContain(productAId)
+      expect(byBoth).not.toContain(productNoneId)
+    } finally {
+      await deleteCatalogProductIfExists(request, token, productBothId)
+      await deleteCatalogProductIfExists(request, token, productAId)
+      await deleteCatalogProductIfExists(request, token, productNoneId)
+    }
+  })
+})

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-032.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-032.spec.ts
@@ -1,0 +1,186 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createProductFixture,
+  createVariantFixture,
+  deleteCatalogProductIfExists,
+} from '@open-mercato/core/helpers/integration/catalogFixtures'
+
+/**
+ * TC-CAT-032: Price create validation — quantity bounds and amounts.
+ * Source: issue #2484 (catalog integration coverage), scenario TC-CAT-032.
+ *
+ * Verified against `priceCreateSchema` / `lib/priceValidation.ts`:
+ *  - `minQuantity` / `maxQuantity` must be integers >= 1 (0, negatives and
+ *    fractions are rejected) and are optional (omit to leave a bound unset).
+ *  - `unitPriceGross` rejects negatives and malformed/over-precise values but
+ *    explicitly ALLOWS 0.
+ *  - There is NO cross-field `minQuantity <= maxQuantity` guard — the issue
+ *    assumed one exists; the last test documents the real (accepted) behavior.
+ *
+ * Each test uses its OWN price kind so every successful create lands on a unique
+ * `(variant, priceKind, currency, minQuantity)` scope — creating two prices on the
+ * same scope hits an uncaught unique-constraint 500 (flagged for #2484), so tests
+ * must never share a price scope across attempts/retries.
+ */
+async function createPriceKind(
+  request: APIRequestContext,
+  token: string,
+  suffix: string,
+): Promise<string> {
+  const res = await apiRequest(request, 'POST', '/api/catalog/price-kinds', {
+    token,
+    data: {
+      code: `qa_cat_032_${suffix}`,
+      title: `QA TC-CAT-032 ${suffix}`,
+      displayMode: 'including-tax',
+      currencyCode: 'USD',
+    },
+  })
+  expect(res.ok(), `Failed to create price kind: ${res.status()}`).toBeTruthy()
+  const id = ((await res.json()) as { id?: string }).id
+  expect(typeof id === 'string' && id.length > 0, 'price kind id').toBeTruthy()
+  return id as string
+}
+
+async function deleteByQueryId(
+  request: APIRequestContext,
+  token: string | null,
+  path: string,
+  id: string | null,
+): Promise<void> {
+  if (!token || !id) return
+  await apiRequest(request, 'DELETE', `${path}?id=${encodeURIComponent(id)}`, { token }).catch(
+    () => undefined,
+  )
+}
+
+test.describe('TC-CAT-032: Price create validation', () => {
+  let token: string
+  let productId: string
+  let variantId: string
+  // Track every product created by beforeAll so a suite-level retry (which re-runs
+  // beforeAll in a fresh worker) cannot leak the earlier attempt's product.
+  const createdProductIds: string[] = []
+
+  test.beforeAll(async ({ request }) => {
+    const stamp = Date.now()
+    token = await getAuthToken(request)
+    productId = await createProductFixture(request, token, {
+      title: `QA Price Validation ${stamp}`,
+      sku: `QA-CAT-032-${stamp}`,
+    })
+    createdProductIds.push(productId)
+    variantId = await createVariantFixture(request, token, {
+      productId,
+      name: 'Default',
+      sku: `QA-CAT-032-V-${stamp}`,
+      isDefault: true,
+    })
+  })
+
+  test.afterAll(async ({ request }) => {
+    for (const id of createdProductIds) {
+      await deleteCatalogProductIfExists(request, token ?? null, id)
+    }
+  })
+
+  const postPrice = (
+    request: APIRequestContext,
+    priceKindId: string,
+    extra: Record<string, unknown>,
+  ) =>
+    apiRequest(request, 'POST', '/api/catalog/prices', {
+      token,
+      data: { productId, variantId, priceKindId, currencyCode: 'USD', ...extra },
+    })
+
+  test('rejects an out-of-range minQuantity', async ({ request }) => {
+    const priceKindId = await createPriceKind(request, token, `min-${Date.now()}`)
+    try {
+      const zeroRes = await postPrice(request, priceKindId, { minQuantity: 0, unitPriceGross: 5 })
+      expect(zeroRes.status(), 'minQuantity 0 must be rejected').toBe(400)
+      expect(((await zeroRes.json()) as { error?: string }).error).toBe('Invalid input')
+
+      const negativeRes = await postPrice(request, priceKindId, {
+        minQuantity: -1,
+        unitPriceGross: 5,
+      })
+      expect(negativeRes.status(), 'negative minQuantity must be rejected').toBe(400)
+
+      const fractionalRes = await postPrice(request, priceKindId, {
+        minQuantity: 1.5,
+        unitPriceGross: 5,
+      })
+      expect(fractionalRes.status(), 'non-integer minQuantity must be rejected').toBe(400)
+    } finally {
+      await deleteByQueryId(request, token, '/api/catalog/price-kinds', priceKindId)
+    }
+  })
+
+  test('rejects malformed or negative price amounts', async ({ request }) => {
+    const priceKindId = await createPriceKind(request, token, `amount-${Date.now()}`)
+    try {
+      const negativeRes = await postPrice(request, priceKindId, { unitPriceGross: -5 })
+      expect(negativeRes.status(), 'negative amount must be rejected').toBe(400)
+
+      const commaRes = await postPrice(request, priceKindId, { unitPriceGross: '99,9999' })
+      expect(commaRes.status(), 'comma-formatted amount must be rejected').toBe(400)
+
+      const tooLongRes = await postPrice(request, priceKindId, { unitPriceGross: '1000000000000' })
+      expect(tooLongRes.status(), 'amount with >12 integer digits must be rejected').toBe(400)
+    } finally {
+      await deleteByQueryId(request, token, '/api/catalog/price-kinds', priceKindId)
+    }
+  })
+
+  test('accepts a valid price with no quantity bounds', async ({ request }) => {
+    const priceKindId = await createPriceKind(request, token, `valid-${Date.now()}`)
+    let priceId: string | null = null
+    try {
+      const res = await postPrice(request, priceKindId, { unitPriceGross: 19.99 })
+      expect(res.status(), 'unbounded price should be created').toBe(201)
+      priceId = ((await res.json()) as { id?: string }).id ?? null
+      expect(priceId, 'created price id').toBeTruthy()
+    } finally {
+      await deleteByQueryId(request, token, '/api/catalog/prices', priceId)
+      await deleteByQueryId(request, token, '/api/catalog/price-kinds', priceKindId)
+    }
+  })
+
+  test('accepts a zero amount', async ({ request }) => {
+    const priceKindId = await createPriceKind(request, token, `zero-${Date.now()}`)
+    let priceId: string | null = null
+    try {
+      // Zero is explicitly allowed by the amount validator (only negatives fail).
+      const res = await postPrice(request, priceKindId, { unitPriceGross: 0 })
+      expect(res.status(), 'zero amount is allowed').toBe(201)
+      priceId = ((await res.json()) as { id?: string }).id ?? null
+      expect(priceId, 'created price id').toBeTruthy()
+    } finally {
+      await deleteByQueryId(request, token, '/api/catalog/prices', priceId)
+      await deleteByQueryId(request, token, '/api/catalog/price-kinds', priceKindId)
+    }
+  })
+
+  test('does not cross-validate minQuantity against maxQuantity (documents current behavior)', async ({
+    request,
+  }) => {
+    const priceKindId = await createPriceKind(request, token, `range-${Date.now()}`)
+    let priceId: string | null = null
+    try {
+      // priceCreateSchema has no min<=max refine, so an inverted range is accepted.
+      // Documented for #2484 as a potential validation gap rather than enforced here.
+      const res = await postPrice(request, priceKindId, {
+        minQuantity: 100,
+        maxQuantity: 50,
+        unitPriceGross: 9.99,
+      })
+      expect(res.status(), 'inverted min/max range is currently accepted').toBe(201)
+      priceId = ((await res.json()) as { id?: string }).id ?? null
+    } finally {
+      await deleteByQueryId(request, token, '/api/catalog/prices', priceId)
+      await deleteByQueryId(request, token, '/api/catalog/price-kinds', priceKindId)
+    }
+  })
+})

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-033.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-033.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createRoleFixture,
+  setRoleAclFeatures,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import { getTokenContext } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+/**
+ * TC-CAT-033: RBAC enforcement on the price-kinds API.
+ * Source: issue #2484 (catalog integration coverage), scenario TC-CAT-026
+ *   (renumbered to 033 — TC-CAT-026 is occupied by the tier-pricing tie-break test).
+ *
+ * All price-kinds methods (GET/POST/PUT/DELETE) are gated by the single feature
+ * `catalog.settings.manage`. The issue assumed GET was view-only; in reality a
+ * user lacking the feature is forbidden from every method, and an unauthenticated
+ * request is rejected with 401. A user granted the feature can read and create.
+ */
+const PRICE_KINDS_PATH = '/api/catalog/price-kinds'
+const NON_EXISTENT_ID = '00000000-0000-0000-0000-000000000000'
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
+const USER_PASSWORD = 'Valid1!Pass'
+
+test.describe('TC-CAT-033: Price-kinds RBAC enforcement', () => {
+  test('forbids every method for a user without catalog.settings.manage', async ({ request }) => {
+    const suffix = Date.now()
+    const adminToken = await getAuthToken(request, 'admin')
+    const { organizationId } = getTokenContext(adminToken)
+
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      roleId = await createRoleFixture(request, adminToken, {
+        name: `qa-cat-033-noaccess-${suffix}`,
+      })
+      // A real but unrelated catalog feature — authenticated, yet lacking settings.manage.
+      await setRoleAclFeatures(request, adminToken, {
+        roleId,
+        features: ['catalog.products.view'],
+      })
+
+      const userEmail = `qa-cat-033-noaccess-${suffix}@test.invalid`
+      userId = await createUserFixture(request, adminToken, {
+        email: userEmail,
+        password: USER_PASSWORD,
+        organizationId,
+        roles: [roleId],
+      })
+      const userToken = await getAuthToken(request, userEmail, USER_PASSWORD)
+
+      const getRes = await apiRequest(request, 'GET', PRICE_KINDS_PATH, { token: userToken })
+      expect(getRes.status(), 'GET is also gated by catalog.settings.manage').toBe(403)
+
+      const postRes = await apiRequest(request, 'POST', PRICE_KINDS_PATH, {
+        token: userToken,
+        data: { code: `qa_cat_033_denied_${suffix}`, title: `Denied ${suffix}` },
+      })
+      expect(postRes.status(), 'POST without the feature must be forbidden').toBe(403)
+
+      const putRes = await apiRequest(request, 'PUT', PRICE_KINDS_PATH, {
+        token: userToken,
+        data: { id: NON_EXISTENT_ID, title: `Denied ${suffix}` },
+      })
+      expect(putRes.status(), 'PUT without the feature must be forbidden').toBe(403)
+
+      const deleteRes = await apiRequest(
+        request,
+        'DELETE',
+        `${PRICE_KINDS_PATH}?id=${NON_EXISTENT_ID}`,
+        { token: userToken },
+      )
+      expect(deleteRes.status(), 'DELETE without the feature must be forbidden').toBe(403)
+
+      // No bearer token at all → unauthenticated, not merely forbidden.
+      const unauthRes = await request.fetch(`${BASE_URL}${PRICE_KINDS_PATH}`, { method: 'GET' })
+      expect(unauthRes.status(), 'unauthenticated request must be 401').toBe(401)
+    } finally {
+      await deleteUserIfExists(request, adminToken, userId)
+      await deleteRoleIfExists(request, adminToken, roleId)
+    }
+  })
+
+  test('allows read and create for a user granted catalog.settings.manage', async ({ request }) => {
+    const suffix = Date.now()
+    const adminToken = await getAuthToken(request, 'admin')
+    const { organizationId } = getTokenContext(adminToken)
+
+    let roleId: string | null = null
+    let userId: string | null = null
+    let priceKindId: string | null = null
+
+    try {
+      roleId = await createRoleFixture(request, adminToken, {
+        name: `qa-cat-033-manage-${suffix}`,
+      })
+      await setRoleAclFeatures(request, adminToken, {
+        roleId,
+        features: ['catalog.settings.manage'],
+      })
+
+      const userEmail = `qa-cat-033-manage-${suffix}@test.invalid`
+      userId = await createUserFixture(request, adminToken, {
+        email: userEmail,
+        password: USER_PASSWORD,
+        organizationId,
+        roles: [roleId],
+      })
+      const userToken = await getAuthToken(request, userEmail, USER_PASSWORD)
+
+      const getRes = await apiRequest(request, 'GET', PRICE_KINDS_PATH, { token: userToken })
+      expect(getRes.status(), 'feature grant allows GET').toBe(200)
+
+      const postRes = await apiRequest(request, 'POST', PRICE_KINDS_PATH, {
+        token: userToken,
+        data: {
+          code: `qa_cat_033_allowed_${suffix}`,
+          title: `Allowed ${suffix}`,
+          displayMode: 'excluding-tax',
+        },
+      })
+      expect(postRes.status(), 'feature grant allows POST').toBe(201)
+      priceKindId = ((await postRes.json()) as { id?: string }).id ?? null
+      expect(priceKindId, 'created price-kind id').toBeTruthy()
+    } finally {
+      if (priceKindId) {
+        await apiRequest(
+          request,
+          'DELETE',
+          `${PRICE_KINDS_PATH}?id=${encodeURIComponent(priceKindId)}`,
+          { token: adminToken },
+        ).catch(() => undefined)
+      }
+      await deleteUserIfExists(request, adminToken, userId)
+      await deleteRoleIfExists(request, adminToken, roleId)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Adds integration-test coverage for previously-untested `catalog` module API surfaces (issue #2484): RBAC on price-kinds, the categories list API (tree/manage views), option-schema referential integrity on delete, the dictionaries lookup, multi-tag filtering, and price-create validation. All seven specs are self-contained (API fixtures created in setup, cleaned up in `finally`/`afterAll`) and assert behavior verified against the route/validator source. Several scenario assumptions in the issue were incorrect; the tests assert real behavior and flag the discrepancies for follow-up.

The issue numbered the scenarios TC-CAT-026…032, but TC-CAT-026 is already taken by the tier-pricing tie-break spec (#2499), so the RBAC scenario is added as TC-CAT-033; the other six keep their issue numbers.

## Changes

- TC-CAT-027 — categories `GET ?view=manage` (parentId/childCount/descendantCount) and `?view=tree` (nested `children`)
- TC-CAT-028 — product-unit-conversion duplicate `(product, unitCode)` → 409 `uom.duplicate_conversion`
- TC-CAT-029 — option-schema delete blocked while a product references it → 400, schema survives, deletes after detach (stronger than TC-CAT-019's `>=400`)
- TC-CAT-030 (+ `.meta.ts` gating on `catalog`+`customers`) — dictionary lookup: `currency`/`unit` → 200 with shape, plural keys → 404, unmapped → 404
- TC-CAT-031 — multi-`tagIds` product filtering (union semantics)
- TC-CAT-032 — price-create validation (minQuantity ≥1 / optional, negative & malformed amounts rejected, 0 allowed, no min≤max cross-guard; one fresh price-kind per test to avoid the duplicate-scope 500)
- TC-CAT-033 — price-kinds RBAC: 403 on every method without `catalog.settings.manage`, 401 unauthenticated, 200/201 with the grant
- Discovered (flagged, not fixed here): plural dictionary aliases 404; prices lack a min≤max guard; duplicate-scope price create returns an uncaught 500 (vs the 409 the unit-conversions route returns)

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — scenarios are defined in issue #2484; this is test-only coverage of existing shipped APIs.

## Testing

- New specs (7 files, 15 tests) against a seeded Docker ephemeral app: **15 passed**.
- Full `packages/core/src/modules/catalog/__integration__/` folder (CI affected-module parity): **87 passed**, 0 failed — no cross-test interference.
- `tsc -p packages/core/tsconfig.json --noEmit` (typechecks `__integration__` specs): **0 errors**.
- `yarn i18n:check-sync`: **all translation files in sync**.
- Fresh-context adversarial review: no blockers.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). _(author to confirm)_
- [x] I updated documentation, locales, or generators if the change requires it. _(N/A — test-only; no docs/locale/generator changes required)_
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). _(Added module-local `__integration__` specs — the current convention; `.ai/qa/tests/` is config-only per `.ai/qa/AGENTS.md`.)_
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). _(N/A — no spec; scenarios defined in issue #2484.)_

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled — N/A, no UI
- [x] Loading state handled — N/A, no UI
- [x] `aria-label` on icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2484