### PR TITLE
fix(scheduler): job edit Scope field is editable but silently stripped on save (#2527)

### DIFF
--- a/packages/scheduler/src/modules/scheduler/backend/config/scheduled-jobs/[id]/edit/page.tsx
+++ b/packages/scheduler/src/modules/scheduler/backend/config/scheduled-jobs/[id]/edit/page.tsx
@@ -88,7 +88,7 @@ export default function EditSchedulePage({ params }: { params: { id: string } })
   const formSchema = React.useMemo(() => scheduledJobFormSchema(t), [t])
 
   const fields = React.useMemo(
-    () => scheduledJobFields(t, { loadQueueOptions, loadCommandOptions, loadTimezoneOptions }),
+    () => scheduledJobFields(t, { loadQueueOptions, loadCommandOptions, loadTimezoneOptions }, { lockScope: true }),
     [t, loadQueueOptions, loadCommandOptions]
   )
 

--- a/packages/scheduler/src/modules/scheduler/data/__tests__/validators.test.ts
+++ b/packages/scheduler/src/modules/scheduler/data/__tests__/validators.test.ts
@@ -506,6 +506,23 @@ describe('scheduleUpdateSchema', () => {
 
     expect(result.targetPayload).toBeNull()
   })
+
+  it('should strip scope fields so scope stays immutable after creation', () => {
+    const result = scheduleUpdateSchema.parse({
+      id: scheduleId,
+      name: 'Updated name',
+      scopeType: 'organization',
+      organizationId,
+      tenantId,
+    })
+
+    // Scope is derived from the creator's auth context at create time and must
+    // not be mutable via update. The edit form locks the Scope field to mirror
+    // this contract (see scheduledJobFormConfig lockScope).
+    expect((result as Record<string, unknown>).scopeType).toBeUndefined()
+    expect((result as Record<string, unknown>).organizationId).toBeUndefined()
+    expect((result as Record<string, unknown>).tenantId).toBeUndefined()
+  })
 })
 
 describe('scheduleDeleteSchema', () => {

--- a/packages/scheduler/src/modules/scheduler/i18n/de.json
+++ b/packages/scheduler/src/modules/scheduler/i18n/de.json
@@ -99,6 +99,7 @@
   "scheduler.form.schedule_value.description": "Für Cron: verwenden Sie Cron-Ausdruck (z.B. \"0 0 * * *\"). Für Intervall: verwenden Sie Format wie \"15m\", \"2h\", \"1d\" (s=Sekunden, m=Minuten, h=Stunden, d=Tage)",
   "scheduler.form.schedule_value.placeholder": "z.B. 0 */6 * * * oder 15m",
   "scheduler.form.scope_type": "Bereich",
+  "scheduler.form.scope_type.locked_description": "Der Bereich wird bei der Erstellung des Zeitplans festgelegt und kann danach nicht mehr geändert werden.",
   "scheduler.form.submit": "Zeitplan erstellen",
   "scheduler.form.target_command": "Zielbefehl",
   "scheduler.form.target_command.placeholder": "Befehle suchen...",

--- a/packages/scheduler/src/modules/scheduler/i18n/en.json
+++ b/packages/scheduler/src/modules/scheduler/i18n/en.json
@@ -99,6 +99,7 @@
   "scheduler.form.schedule_value.description": "For cron: use cron expression (e.g., \"0 0 * * *\"). For interval: use format like \"15m\", \"2h\", \"1d\" (s=seconds, m=minutes, h=hours, d=days)",
   "scheduler.form.schedule_value.placeholder": "e.g. 0 */6 * * * or 15m",
   "scheduler.form.scope_type": "Scope",
+  "scheduler.form.scope_type.locked_description": "Scope is set when the schedule is created and cannot be changed afterwards.",
   "scheduler.form.submit": "Create Schedule",
   "scheduler.form.target_command": "Target Command",
   "scheduler.form.target_command.placeholder": "Search commands...",

--- a/packages/scheduler/src/modules/scheduler/i18n/es.json
+++ b/packages/scheduler/src/modules/scheduler/i18n/es.json
@@ -99,6 +99,7 @@
   "scheduler.form.schedule_value.description": "Para cron: use expresión cron (ej. \"0 0 * * *\"). Para intervalo: use formato como \"15m\", \"2h\", \"1d\" (s=segundos, m=minutos, h=horas, d=días)",
   "scheduler.form.schedule_value.placeholder": "ej. 0 */6 * * * o 15m",
   "scheduler.form.scope_type": "Ámbito",
+  "scheduler.form.scope_type.locked_description": "El ámbito se establece al crear la programación y no se puede cambiar posteriormente.",
   "scheduler.form.submit": "Crear programación",
   "scheduler.form.target_command": "Comando de destino",
   "scheduler.form.target_command.placeholder": "Buscar comandos...",

--- a/packages/scheduler/src/modules/scheduler/i18n/pl.json
+++ b/packages/scheduler/src/modules/scheduler/i18n/pl.json
@@ -99,6 +99,7 @@
   "scheduler.form.schedule_value.description": "Dla cron: użyj wyrażenia cron (np. \"0 0 * * *\"). Dla interwału: użyj formatu jak \"15m\", \"2h\", \"1d\" (s=sekundy, m=minuty, h=godziny, d=dni)",
   "scheduler.form.schedule_value.placeholder": "np. 0 */6 * * * lub 15m",
   "scheduler.form.scope_type": "Zakres",
+  "scheduler.form.scope_type.locked_description": "Zakres jest ustalany podczas tworzenia harmonogramu i nie można go później zmienić.",
   "scheduler.form.submit": "Utwórz harmonogram",
   "scheduler.form.target_command": "Polecenie docelowe",
   "scheduler.form.target_command.placeholder": "Szukaj poleceń...",

--- a/packages/scheduler/src/modules/scheduler/lib/__tests__/scheduledJobFormConfig.test.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/__tests__/scheduledJobFormConfig.test.ts
@@ -83,6 +83,30 @@ describe('scheduledJobFormConfig target fields', () => {
   })
 })
 
+describe('scheduledJobFormConfig scope field', () => {
+  const t = (_key: string, fallback: string) => fallback
+  const loaders = {
+    loadQueueOptions: async () => [],
+    loadCommandOptions: async () => [],
+    loadTimezoneOptions: async () => [],
+  }
+
+  it('keeps the scope field editable on create (no lockScope)', () => {
+    const fields = scheduledJobFields(t, loaders)
+    const scope = fields.find((f) => f.id === 'scopeType')
+    expect(scope).toBeDefined()
+    expect(scope?.disabled).toBeFalsy()
+  })
+
+  it('locks the scope field on edit so the value cannot be deceptively changed then silently dropped', () => {
+    const fields = scheduledJobFields(t, loaders, { lockScope: true })
+    const scope = fields.find((f) => f.id === 'scopeType')
+    expect(scope).toBeDefined()
+    expect(scope?.disabled).toBe(true)
+    expect(scope?.description).toBeTruthy()
+  })
+})
+
 describe('loadTimezoneOptions', () => {
   it('includes UTC even when Intl.supportedValuesOf does not list it', async () => {
     const options = await loadTimezoneOptions('utc')

--- a/packages/scheduler/src/modules/scheduler/lib/scheduledJobFormConfig.tsx
+++ b/packages/scheduler/src/modules/scheduler/lib/scheduledJobFormConfig.tsx
@@ -149,8 +149,10 @@ export function scheduledJobFields(
     loadQueueOptions: (query?: string) => Promise<ComboboxOption[]>
     loadCommandOptions: (query?: string) => Promise<ComboboxOption[]>
     loadTimezoneOptions: (query?: string) => Promise<ComboboxOption[]>
-  }
+  },
+  options?: { lockScope?: boolean }
 ): CrudField[] {
+  const lockScope = options?.lockScope ?? false
   return [
     {
       id: 'name',
@@ -168,6 +170,14 @@ export function scheduledJobFields(
       type: 'select',
       label: t('scheduler.form.scope_type', 'Scope'),
       required: true,
+      // Scope is derived from the creator's auth context at create time and is
+      // immutable afterwards (the update schema/command never persist it). Lock
+      // the field on edit so it does not deceptively accept input that is then
+      // silently dropped on save.
+      disabled: lockScope,
+      description: lockScope
+        ? t('scheduler.form.scope_type.locked_description', 'Scope is set when the schedule is created and cannot be changed afterwards.')
+        : undefined,
       options: [
         { value: 'system', label: t('scheduler.scope.system', 'System') },
         { value: 'organization', label: t('scheduler.scope.organization', 'Organization') },


### PR DESCRIPTION
Fixes #2527

## Problem
On the **Scheduled Job edit** form, the **Scope** field was rendered as a required, editable `<select>`, but `scheduleUpdateSchema` omits `scopeType` (and `organizationId`/`tenantId`). `z.object` silently stripped the changed value, so a user could change Scope, get a success flash, and have the job keep its original scope — a deceptive no-op.

## Root Cause
- The form rendered `scopeType` as a required editable select (`scheduledJobFormConfig.tsx`), and the edit submit spread `...values` (incl. `scopeType`) via `buildScheduledJobPayload`.
- `scheduleUpdateSchema` does **not** include `scopeType`/`organizationId`/`tenantId`, and `update.mapInput` just does `scheduleUpdateSchema.parse(raw)` (no scope handling, unlike `create.mapInput`). Unknown keys are stripped, so the scope edit was discarded.
- Scope is derived from the creator's auth context at create time and is intentionally immutable afterwards.

## What Changed
Chose remediation **(a)**: make Scope **read-only on edit** so the form truthfully reflects the immutable-after-create backend contract, rather than introducing a security-sensitive cross-tenant scope-mutation path on update.

- `scheduledJobFields(...)` gains an optional `{ lockScope }` arg. When set, the `scopeType` field is `disabled` and shows an explanatory description. Create flow is unchanged (still editable).
- The edit page passes `lockScope: true`.
- Added `scheduler.form.scope_type.locked_description` to `en`/`de`/`pl`/`es` locale files.

## Tests
- `scheduledJobFormConfig.test.ts`: asserts the scope field stays editable on create and is disabled (with a description) on edit. The edit assertion fails before the fix and passes after.
- `validators.test.ts`: documents the immutability contract — `scheduleUpdateSchema` strips `scopeType`/`organizationId`/`tenantId`.
- Full scheduler suite: 315 passed.

## Checks
`yarn generate`, `yarn build:packages`, `yarn typecheck` (full repo), `yarn test` (scheduler), `yarn i18n:check-sync` (clean), `yarn i18n:check-usage` (only pre-existing unrelated advisory keys), `yarn build:app` — all green.

## Backward Compatibility
No contract surface changes. `scheduledJobFields` gains an **optional** parameter (additive); the update schema, API routes, event IDs, DI names, and ACL features are untouched.

Part of umbrella #2466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)