### PR TITLE
feat: 2482 webhooks integration coverage

### DIFF
--- a/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-004.spec.ts
+++ b/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-004.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  createWebhookFixture,
+  deleteWebhookIfExists,
+  getWebhookDetail,
+  rotateWebhookSecret,
+} from './helpers/fixtures';
+
+/**
+ * TC-WEBHOOK-004: Secret rotation with previous secret retention
+ * Source: https://github.com/open-mercato/open-mercato/issues/2482
+ *
+ * Verifies the security-critical rotate-secret flow: a new whsec_ secret is issued,
+ * the previous secret is retained (so deliveries can dual-sign during rollout), and
+ * the detail endpoint reflects the masked new secret plus the rotation timestamp.
+ */
+test.describe('TC-WEBHOOK-004: Secret rotation with previous secret retention', () => {
+  test('should rotate the signing secret, retain the previous one, and mask it on read', async ({ request }) => {
+    const token = await getAuthToken(request);
+    let webhookId: string | null = null;
+
+    try {
+      const created = await createWebhookFixture(request, token, {
+        name: `Webhook Rotate ${Date.now()}`,
+        url: 'https://example.com/webhook-rotate',
+        subscribedEvents: ['sales.quote.created'],
+      });
+      webhookId = created.id;
+      expect(created.secret.startsWith('whsec_')).toBe(true);
+
+      const beforeRotation = await getWebhookDetail(request, token, created.id);
+      expect(beforeRotation.previousSecretSetAt).toBeNull();
+
+      const rotation = await rotateWebhookSecret(request, token, created.id);
+      expect(rotation.success).toBe(true);
+      expect(rotation.secret.startsWith('whsec_')).toBe(true);
+      expect(rotation.secret).not.toBe(created.secret);
+      expect(typeof rotation.previousSecretSetAt).toBe('string');
+      expect(Number.isNaN(Date.parse(rotation.previousSecretSetAt as string))).toBe(false);
+
+      const afterRotation = await getWebhookDetail(request, token, created.id);
+      // The detail endpoint never exposes the raw secret — only a masked form that
+      // reveals the constant "whsec_" prefix (maskSecret => `${secret.slice(0, 6)}••••••••`).
+      expect(afterRotation.maskedSecret.startsWith('whsec_')).toBe(true);
+      expect(afterRotation.maskedSecret).not.toBe(rotation.secret);
+      expect(afterRotation.maskedSecret).not.toBe(created.secret);
+      expect(afterRotation.maskedSecret.length).toBeLessThan(rotation.secret.length);
+      // previousSecretSetAt proves the prior secret is retained for dual-sign verification
+      // (delivery signing reads webhook.previousSecret; covered at unit level in lib/__tests__).
+      expect(afterRotation.previousSecretSetAt).toBe(rotation.previousSecretSetAt);
+
+      const secondRotation = await rotateWebhookSecret(request, token, created.id);
+      expect(secondRotation.secret).not.toBe(rotation.secret);
+      expect(typeof secondRotation.previousSecretSetAt).toBe('string');
+      expect(Date.parse(secondRotation.previousSecretSetAt as string)).toBeGreaterThanOrEqual(
+        Date.parse(rotation.previousSecretSetAt as string),
+      );
+    } finally {
+      await deleteWebhookIfExists(request, token, webhookId);
+    }
+  });
+});

--- a/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-005.spec.ts
+++ b/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-005.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenScope } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  cleanupWebhooksUser,
+  createWebhookFixture,
+  deleteWebhookIfExists,
+  provisionWebhooksUser,
+  type ProvisionedWebhooksUser,
+} from './helpers/fixtures';
+
+/**
+ * TC-WEBHOOK-005: RBAC permission gates — unauthorized access by feature flag
+ * Source: https://github.com/open-mercato/open-mercato/issues/2482
+ *
+ * Verifies every webhooks API surface is gated by its declared feature:
+ *   webhooks.view    → GET list + GET detail + deliveries
+ *   webhooks.manage  → POST + PUT + DELETE
+ *   webhooks.secrets → POST rotate-secret
+ *   webhooks.test    → POST test
+ * A viewer holding only webhooks.view passes reads but is denied every write/secret/test
+ * surface; a user holding no webhooks features is denied reads. Admin (webhooks.*) proves
+ * the positive paths. Denials accept 401 or 403 per the issue's acceptance criteria.
+ */
+test.describe('TC-WEBHOOK-005: RBAC permission gates by feature flag', () => {
+  test('should gate each webhooks surface behind its declared feature', async ({ request }) => {
+    const adminToken = await getAuthToken(request);
+    const scope = getTokenScope(adminToken);
+
+    let webhookId: string | null = null;
+    let viewer: ProvisionedWebhooksUser | null = null;
+    let noAccess: ProvisionedWebhooksUser | null = null;
+
+    try {
+      viewer = await provisionWebhooksUser(request, adminToken, {
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        features: ['webhooks.view'],
+        slug: 'viewer',
+      });
+      noAccess = await provisionWebhooksUser(request, adminToken, {
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        features: [],
+        slug: 'noaccess',
+      });
+
+      // --- Positive: admin (webhooks.*) can exercise every surface ---
+      const created = await createWebhookFixture(request, adminToken, {
+        name: `Webhook RBAC ${Date.now()}`,
+        url: 'https://example.com/webhook-rbac',
+        subscribedEvents: ['catalog.product.created'],
+        customHeaders: { 'x-mock-webhook-signature': 'valid' },
+      });
+      webhookId = created.id;
+
+      const adminList = await apiRequest(request, 'GET', '/api/webhooks', { token: adminToken });
+      expect(adminList.status()).toBe(200);
+      const adminDetail = await apiRequest(request, 'GET', `/api/webhooks/${created.id}`, { token: adminToken });
+      expect(adminDetail.status()).toBe(200);
+
+      // --- webhooks.view gate ---
+      const viewerList = await apiRequest(request, 'GET', '/api/webhooks', { token: viewer.token });
+      expect(viewerList.status()).toBe(200);
+      const viewerDetail = await apiRequest(request, 'GET', `/api/webhooks/${created.id}`, { token: viewer.token });
+      expect(viewerDetail.status()).toBe(200);
+
+      const noAccessList = await apiRequest(request, 'GET', '/api/webhooks', { token: noAccess.token });
+      expect([401, 403]).toContain(noAccessList.status());
+      const noAccessDetail = await apiRequest(request, 'GET', `/api/webhooks/${created.id}`, { token: noAccess.token });
+      expect([401, 403]).toContain(noAccessDetail.status());
+
+      // --- webhooks.manage gate (viewer lacks manage) ---
+      const viewerCreate = await apiRequest(request, 'POST', '/api/webhooks', {
+        token: viewer.token,
+        data: {
+          name: `Webhook RBAC Denied ${Date.now()}`,
+          url: 'https://example.com/webhook-denied',
+          subscribedEvents: ['catalog.product.created'],
+        },
+      });
+      expect([401, 403]).toContain(viewerCreate.status());
+
+      const viewerUpdate = await apiRequest(request, 'PUT', `/api/webhooks/${created.id}`, {
+        token: viewer.token,
+        data: { name: `Webhook RBAC Hijack ${Date.now()}` },
+      });
+      expect([401, 403]).toContain(viewerUpdate.status());
+
+      const viewerDelete = await apiRequest(request, 'DELETE', `/api/webhooks/${created.id}`, { token: viewer.token });
+      expect([401, 403]).toContain(viewerDelete.status());
+
+      // --- webhooks.secrets gate (viewer lacks secrets) ---
+      const viewerRotate = await apiRequest(request, 'POST', `/api/webhooks/${created.id}/rotate-secret`, {
+        token: viewer.token,
+      });
+      expect([401, 403]).toContain(viewerRotate.status());
+
+      // --- webhooks.test gate (viewer lacks test) ---
+      const viewerTest = await apiRequest(request, 'POST', `/api/webhooks/${created.id}/test`, {
+        token: viewer.token,
+        data: { eventType: 'catalog.product.created' },
+      });
+      expect([401, 403]).toContain(viewerTest.status());
+
+      // The webhook must still exist — none of the denied writes mutated it.
+      const stillThere = await apiRequest(request, 'GET', `/api/webhooks/${created.id}`, { token: adminToken });
+      expect(stillThere.status()).toBe(200);
+
+      // --- Positive secrets + test paths (admin holds both features) ---
+      const adminRotate = await apiRequest(request, 'POST', `/api/webhooks/${created.id}/rotate-secret`, {
+        token: adminToken,
+      });
+      expect(adminRotate.status()).toBe(200);
+      const adminTest = await apiRequest(request, 'POST', `/api/webhooks/${created.id}/test`, {
+        token: adminToken,
+        data: { eventType: 'catalog.product.created' },
+      });
+      expect(adminTest.status()).toBe(200);
+    } finally {
+      await deleteWebhookIfExists(request, adminToken, webhookId);
+      await cleanupWebhooksUser(request, adminToken, viewer);
+      await cleanupWebhooksUser(request, adminToken, noAccess);
+    }
+  });
+});

--- a/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-006.spec.ts
+++ b/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-006.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  buildMockInboundUrl,
+  createWebhookFixture,
+  deleteWebhookIfExists,
+  listWebhookDeliveries,
+  sendTestDelivery,
+} from './helpers/fixtures';
+
+/**
+ * TC-WEBHOOK-006: Webhook deactivation blocks delivery
+ * Source: https://github.com/open-mercato/open-mercato/issues/2482
+ *
+ * The isActive flag must prevent delivery. The synchronous test route still records a
+ * delivery attempt, but the delivery engine short-circuits inactive webhooks: the
+ * delivery is marked `expired` with "Webhook is inactive" and no HTTP request is made
+ * (responseStatus stays null). Re-activating restores successful delivery.
+ */
+test.describe('TC-WEBHOOK-006: Webhook deactivation blocks delivery', () => {
+  test('should deliver while active, block while inactive, and resume after re-activation', async ({ request }) => {
+    const token = await getAuthToken(request);
+    let webhookId: string | null = null;
+
+    try {
+      const created = await createWebhookFixture(request, token, {
+        name: `Webhook Deactivation ${Date.now()}`,
+        url: buildMockInboundUrl(),
+        subscribedEvents: ['catalog.product.created'],
+        customHeaders: { 'x-mock-webhook-signature': 'valid' },
+      });
+      webhookId = created.id;
+
+      // 1) Active webhook delivers successfully.
+      const activeDelivery = await sendTestDelivery(request, token, created.id, {
+        eventType: 'catalog.product.created',
+      });
+      expect(activeDelivery.delivery.status).toBe('delivered');
+      expect(activeDelivery.delivery.responseStatus).toBe(200);
+
+      // 2) Deactivate.
+      const deactivate = await apiRequest(request, 'PUT', `/api/webhooks/${created.id}`, {
+        token,
+        data: { isActive: false },
+      });
+      expect(deactivate.status()).toBe(200);
+
+      // 3) Inactive webhook does not reach the endpoint — delivery is expired, no HTTP attempt.
+      const blockedDelivery = await sendTestDelivery(request, token, created.id, {
+        eventType: 'catalog.product.created',
+      });
+      expect(blockedDelivery.delivery.status).toBe('expired');
+      expect(blockedDelivery.delivery.errorMessage).toBe('Webhook is inactive');
+      expect(blockedDelivery.delivery.responseStatus).toBeNull();
+
+      // The blocked attempt is visible in the delivery log with a non-delivered status.
+      const expiredDeliveries = await listWebhookDeliveries(
+        request,
+        token,
+        created.id,
+        `/api/webhooks/deliveries?webhookId=${encodeURIComponent(created.id)}&status=expired`,
+      );
+      expect(expiredDeliveries.items.some((item) => item.id === blockedDelivery.delivery.id)).toBe(true);
+      expect(expiredDeliveries.items.every((item) => item.status === 'expired')).toBe(true);
+
+      // 4) Re-activate and confirm delivery resumes.
+      const reactivate = await apiRequest(request, 'PUT', `/api/webhooks/${created.id}`, {
+        token,
+        data: { isActive: true },
+      });
+      expect(reactivate.status()).toBe(200);
+
+      const resumedDelivery = await sendTestDelivery(request, token, created.id, {
+        eventType: 'catalog.product.created',
+      });
+      expect(resumedDelivery.delivery.status).toBe('delivered');
+      expect(resumedDelivery.delivery.responseStatus).toBe(200);
+    } finally {
+      await deleteWebhookIfExists(request, token, webhookId);
+    }
+  });
+});

--- a/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-007.spec.ts
+++ b/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-007.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenScope } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { createOrganizationInDb, deleteOrganizationInDb } from '@open-mercato/core/helpers/integration/dbFixtures';
+import {
+  cleanupWebhooksUser,
+  createWebhookFixture,
+  deleteWebhookIfExists,
+  listWebhooks,
+  provisionWebhooksUser,
+  type ProvisionedWebhooksUser,
+  type WebhookCreateResponse,
+} from './helpers/fixtures';
+
+/**
+ * TC-WEBHOOK-007: Tenant/organization scoping isolation
+ * Source: https://github.com/open-mercato/open-mercato/issues/2482
+ *
+ * Webhooks are scoped by tenantId + organizationId. Within one tenant, two
+ * organization-restricted users must not see or mutate each other's webhooks:
+ * the list excludes out-of-scope rows and detail/update/delete on a foreign
+ * webhook returns 404 (existence is not revealed across the org boundary).
+ */
+const MANAGE_FEATURES = ['webhooks.view', 'webhooks.manage'];
+
+test.describe('TC-WEBHOOK-007: Tenant/organization scoping isolation', () => {
+  test('should isolate webhooks between organizations within the same tenant', async ({ request }) => {
+    const adminToken = await getAuthToken(request);
+    const { tenantId, organizationId: orgA } = getTokenScope(adminToken);
+
+    let orgB: string | null = null;
+    let userA: ProvisionedWebhooksUser | null = null;
+    let userB: ProvisionedWebhooksUser | null = null;
+    let webhookA: WebhookCreateResponse | null = null;
+    let webhookB: WebhookCreateResponse | null = null;
+
+    try {
+      orgB = await createOrganizationInDb({ name: `TC-WEBHOOK-007 Org B ${Date.now()}`, tenantId });
+
+      userA = await provisionWebhooksUser(request, adminToken, {
+        tenantId,
+        organizationId: orgA,
+        features: MANAGE_FEATURES,
+        organizations: [orgA],
+        slug: 'org-a',
+      });
+      userB = await provisionWebhooksUser(request, adminToken, {
+        tenantId,
+        organizationId: orgB,
+        features: MANAGE_FEATURES,
+        organizations: [orgB],
+        slug: 'org-b',
+      });
+
+      webhookA = await createWebhookFixture(request, userA.token, {
+        name: `TC-WEBHOOK-007 A ${Date.now()}`,
+        url: 'https://example.com/webhook-org-a',
+        subscribedEvents: ['catalog.product.created'],
+      });
+      webhookB = await createWebhookFixture(request, userB.token, {
+        name: `TC-WEBHOOK-007 B ${Date.now()}`,
+        url: 'https://example.com/webhook-org-b',
+        subscribedEvents: ['catalog.product.created'],
+      });
+
+      // Lists are scoped: each user sees only their own organization's webhook.
+      const listA = await listWebhooks(request, userA.token);
+      expect(listA.items.some((item) => item.id === webhookA!.id)).toBe(true);
+      expect(listA.items.some((item) => item.id === webhookB!.id)).toBe(false);
+
+      const listB = await listWebhooks(request, userB.token);
+      expect(listB.items.some((item) => item.id === webhookB!.id)).toBe(true);
+      expect(listB.items.some((item) => item.id === webhookA!.id)).toBe(false);
+
+      // Cross-org reads/writes are not found.
+      const crossGet = await apiRequest(request, 'GET', `/api/webhooks/${webhookB.id}`, { token: userA.token });
+      expect(crossGet.status()).toBe(404);
+
+      const crossUpdate = await apiRequest(request, 'PUT', `/api/webhooks/${webhookB.id}`, {
+        token: userA.token,
+        data: { name: `TC-WEBHOOK-007 cross-org hijack ${Date.now()}` },
+      });
+      expect(crossUpdate.status()).toBe(404);
+
+      const crossDelete = await apiRequest(request, 'DELETE', `/api/webhooks/${webhookB.id}`, { token: userA.token });
+      expect(crossDelete.status()).toBe(404);
+
+      const crossGetReverse = await apiRequest(request, 'GET', `/api/webhooks/${webhookA.id}`, { token: userB.token });
+      expect(crossGetReverse.status()).toBe(404);
+
+      // In-scope access still works after the cross-org attempts.
+      const ownGet = await apiRequest(request, 'GET', `/api/webhooks/${webhookA.id}`, { token: userA.token });
+      expect(ownGet.status()).toBe(200);
+    } finally {
+      await deleteWebhookIfExists(request, userA?.token ?? null, webhookA?.id ?? null);
+      await deleteWebhookIfExists(request, userB?.token ?? null, webhookB?.id ?? null);
+      await cleanupWebhooksUser(request, adminToken, userA);
+      await cleanupWebhooksUser(request, adminToken, userB);
+      await deleteOrganizationInDb(orgB);
+    }
+  });
+});

--- a/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-008.spec.ts
+++ b/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-008.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  buildMockInboundUrl,
+  createWebhookFixture,
+  deleteWebhookIfExists,
+  listWebhookDeliveries,
+  sendTestDelivery,
+} from './helpers/fixtures';
+
+/**
+ * TC-WEBHOOK-008: Delivery list filtering by status and event type
+ * Source: https://github.com/open-mercato/open-mercato/issues/2482
+ *
+ * GET /api/webhooks/deliveries supports webhookId, status, and eventType filters.
+ * Seeds three deliveries on one webhook — delivered(created), delivered(updated),
+ * expired(created) — then verifies each filter and their intersection.
+ */
+const EVENT_CREATED = 'catalog.product.created';
+const EVENT_UPDATED = 'catalog.product.updated';
+
+function deliveriesPath(webhookId: string, extra: Record<string, string> = {}): string {
+  const params = new URLSearchParams({ webhookId, ...extra });
+  return `/api/webhooks/deliveries?${params.toString()}`;
+}
+
+test.describe('TC-WEBHOOK-008: Delivery list filtering by status and event type', () => {
+  test('should filter delivery logs by status, event type, and their combination', async ({ request }) => {
+    const token = await getAuthToken(request);
+    let webhookId: string | null = null;
+
+    try {
+      const created = await createWebhookFixture(request, token, {
+        name: `Webhook Filter ${Date.now()}`,
+        url: buildMockInboundUrl(),
+        subscribedEvents: [EVENT_CREATED, EVENT_UPDATED],
+        customHeaders: { 'x-mock-webhook-signature': 'valid' },
+      });
+      webhookId = created.id;
+
+      const deliveredCreated = await sendTestDelivery(request, token, created.id, { eventType: EVENT_CREATED });
+      expect(deliveredCreated.delivery.status).toBe('delivered');
+      const deliveredUpdated = await sendTestDelivery(request, token, created.id, { eventType: EVENT_UPDATED });
+      expect(deliveredUpdated.delivery.status).toBe('delivered');
+
+      // Flip the mock signature to invalid so the next attempt fails terminally (expired).
+      const invalidate = await apiRequest(request, 'PUT', `/api/webhooks/${created.id}`, {
+        token,
+        data: { customHeaders: { 'x-mock-webhook-signature': 'invalid' } },
+      });
+      expect(invalidate.status()).toBe(200);
+
+      const expiredCreated = await sendTestDelivery(request, token, created.id, { eventType: EVENT_CREATED });
+      expect(expiredCreated.delivery.status).toBe('expired');
+
+      const d1 = deliveredCreated.delivery.id;
+      const d2 = deliveredUpdated.delivery.id;
+      const d3 = expiredCreated.delivery.id;
+
+      // Unfiltered (by webhook): all three present.
+      const all = await listWebhookDeliveries(request, token, created.id, deliveriesPath(created.id));
+      expect(all.total).toBeGreaterThanOrEqual(3);
+      for (const id of [d1, d2, d3]) {
+        expect(all.items.some((item) => item.id === id)).toBe(true);
+      }
+
+      // status=delivered → d1, d2 only.
+      const delivered = await listWebhookDeliveries(request, token, created.id, deliveriesPath(created.id, { status: 'delivered' }));
+      expect(delivered.items.every((item) => item.status === 'delivered')).toBe(true);
+      expect(delivered.items.some((item) => item.id === d1)).toBe(true);
+      expect(delivered.items.some((item) => item.id === d2)).toBe(true);
+      expect(delivered.items.some((item) => item.id === d3)).toBe(false);
+
+      // status=expired → d3 only.
+      const expired = await listWebhookDeliveries(request, token, created.id, deliveriesPath(created.id, { status: 'expired' }));
+      expect(expired.items.every((item) => item.status === 'expired')).toBe(true);
+      expect(expired.items.some((item) => item.id === d3)).toBe(true);
+      expect(expired.items.some((item) => item.id === d1)).toBe(false);
+
+      // eventType=created → d1, d3 only.
+      const createdEvents = await listWebhookDeliveries(request, token, created.id, deliveriesPath(created.id, { eventType: EVENT_CREATED }));
+      expect(createdEvents.items.every((item) => item.eventType === EVENT_CREATED)).toBe(true);
+      expect(createdEvents.items.some((item) => item.id === d1)).toBe(true);
+      expect(createdEvents.items.some((item) => item.id === d3)).toBe(true);
+      expect(createdEvents.items.some((item) => item.id === d2)).toBe(false);
+
+      // Combined status=delivered & eventType=created → d1 only.
+      const combined = await listWebhookDeliveries(
+        request,
+        token,
+        created.id,
+        deliveriesPath(created.id, { status: 'delivered', eventType: EVENT_CREATED }),
+      );
+      expect(combined.items.every((item) => item.status === 'delivered' && item.eventType === EVENT_CREATED)).toBe(true);
+      expect(combined.items.some((item) => item.id === d1)).toBe(true);
+      expect(combined.items.some((item) => item.id === d2)).toBe(false);
+      expect(combined.items.some((item) => item.id === d3)).toBe(false);
+
+      // Non-matching filter → empty result set with pagination metadata.
+      const empty = await listWebhookDeliveries(request, token, created.id, deliveriesPath(created.id, { status: 'pending' }));
+      expect(empty.items).toEqual([]);
+      expect(empty.total).toBe(0);
+      expect(empty.page).toBe(1);
+      expect(empty.totalPages).toBe(0);
+    } finally {
+      await deleteWebhookIfExists(request, token, webhookId);
+    }
+  });
+});

--- a/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-009.spec.ts
+++ b/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-009.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { createWebhookFixture, deleteWebhookIfExists } from './helpers/fixtures';
+
+/**
+ * TC-WEBHOOK-009: Invalid and unsafe URL rejection
+ * Source: https://github.com/open-mercato/open-mercato/issues/2482
+ *
+ * Webhook URLs go through the shared outbound-URL safety check. Forbidden schemes,
+ * embedded credentials, and malformed URLs are rejected with 400 on both create and
+ * update regardless of configuration. Private/loopback hosts are rejected unless the
+ * deployment opts in via OM_WEBHOOKS_ALLOW_PRIVATE_URLS (the integration env enables
+ * it so the loopback mock receiver works) — this spec asserts whichever behavior the
+ * active flag dictates. Exhaustive private-IP coverage lives in the unit suites
+ * (data/__tests__/validators.test.ts, lib/__tests__/url-safety.test.ts).
+ */
+const PRIVATE_URLS_ALLOWED = ['1', 'true', 'yes', 'on'].includes(
+  (process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS ?? '').trim().toLowerCase(),
+);
+
+const ALWAYS_UNSAFE_URLS = [
+  'ftp://example.com/webhook',
+  'file:///etc/passwd',
+  'http://user:pass@example.com/webhook',
+  'not-a-valid-url',
+];
+
+const PRIVATE_HOST_URLS = [
+  'http://127.0.0.1:9001/webhook',
+  'http://10.0.0.1/webhook',
+  'http://[::1]:9001/webhook',
+];
+
+function createBody(url: string) {
+  return {
+    name: `Webhook URL Safety ${Date.now()}`,
+    url,
+    subscribedEvents: ['catalog.product.created'],
+  };
+}
+
+test.describe('TC-WEBHOOK-009: Invalid and unsafe URL rejection', () => {
+  test('should reject unsafe webhook URLs on create and update and accept valid external URLs', async ({ request }) => {
+    const token = await getAuthToken(request);
+    let webhookId: string | null = null;
+    const strayPrivateWebhookIds: string[] = [];
+
+    try {
+      // Always-unsafe URLs are rejected at create regardless of the private-URL flag.
+      for (const url of ALWAYS_UNSAFE_URLS) {
+        const response = await apiRequest(request, 'POST', '/api/webhooks', { token, data: createBody(url) });
+        expect(response.status(), `POST should reject unsafe url ${url}`).toBe(400);
+      }
+
+      // A valid external https URL is accepted.
+      const created = await createWebhookFixture(request, token, {
+        name: `Webhook URL Safety Valid ${Date.now()}`,
+        url: 'https://example.com/webhook-url-safety',
+        subscribedEvents: ['catalog.product.created'],
+      });
+      webhookId = created.id;
+
+      // Updating an existing webhook to an unsafe URL is rejected; the record is unchanged.
+      for (const url of ALWAYS_UNSAFE_URLS) {
+        const response = await apiRequest(request, 'PUT', `/api/webhooks/${created.id}`, { token, data: { url } });
+        expect(response.status(), `PUT should reject unsafe url ${url}`).toBe(400);
+      }
+
+      // Updating to another valid external URL succeeds.
+      const validUpdate = await apiRequest(request, 'PUT', `/api/webhooks/${created.id}`, {
+        token,
+        data: { url: 'https://example.org/webhook-url-safety-updated' },
+      });
+      expect(validUpdate.status()).toBe(200);
+
+      // Private/loopback hosts: behavior depends on the deployment flag.
+      for (const url of PRIVATE_HOST_URLS) {
+        const response = await apiRequest(request, 'POST', '/api/webhooks', { token, data: createBody(url) });
+        if (PRIVATE_URLS_ALLOWED) {
+          expect(response.status(), `POST should accept private url ${url} when allowed`).toBe(201);
+          const body = await readJsonSafe<{ id?: string }>(response);
+          if (body?.id) strayPrivateWebhookIds.push(body.id);
+        } else {
+          expect(response.status(), `POST should reject private url ${url} when not allowed`).toBe(400);
+        }
+      }
+    } finally {
+      await deleteWebhookIfExists(request, token, webhookId);
+      for (const id of strayPrivateWebhookIds) {
+        await deleteWebhookIfExists(request, token, id);
+      }
+    }
+  });
+});

--- a/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-010.spec.ts
+++ b/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-010.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  buildMockInboundUrl,
+  createWebhookFixture,
+  deleteWebhookIfExists,
+  getDeliveryDetail,
+  sendTestDelivery,
+} from './helpers/fixtures';
+
+/**
+ * TC-WEBHOOK-010: Delivery detail response includes full payload and response body
+ * Source: https://github.com/open-mercato/open-mercato/issues/2482
+ *
+ * The delivery detail endpoint must expose the complete sent payload and the full
+ * response captured from the endpoint (status, body, headers) plus attempt/timing
+ * metadata, so admins can debug a delivery end-to-end.
+ */
+const EVENT_TYPE = 'webhooks.test.detail';
+
+test.describe('TC-WEBHOOK-010: Delivery detail full payload and response body', () => {
+  test('should expose the complete payload and response details for a delivery', async ({ request }) => {
+    const token = await getAuthToken(request);
+    let webhookId: string | null = null;
+
+    try {
+      const created = await createWebhookFixture(request, token, {
+        name: `Webhook Detail ${Date.now()}`,
+        url: buildMockInboundUrl(),
+        subscribedEvents: ['catalog.product.created'],
+        customHeaders: { 'x-mock-webhook-signature': 'valid' },
+      });
+      webhookId = created.id;
+
+      const eventData = { sku: 'TEST-123', nested: { value: 42 } };
+
+      const testResult = await sendTestDelivery(request, token, created.id, {
+        eventType: EVENT_TYPE,
+        payload: eventData,
+      });
+      expect(testResult.delivery.status).toBe('delivered');
+      const deliveryId = testResult.delivery.id;
+
+      const detail = await getDeliveryDetail(request, token, deliveryId);
+
+      // Identity + routing
+      expect(detail.id).toBe(deliveryId);
+      expect(detail.webhookId).toBe(created.id);
+      expect(detail.eventType).toBe(EVENT_TYPE);
+      expect(detail.targetUrl).toBe(created.url);
+      expect(typeof detail.messageId).toBe('string');
+      expect(detail.messageId.length).toBeGreaterThan(0);
+
+      // Outcome
+      expect(detail.status).toBe('delivered');
+      expect(detail.responseStatus).toBe(200);
+      expect(detail.errorMessage).toBeNull();
+
+      // The delivery body wraps the event data in the Standard-Webhooks envelope
+      // { type, timestamp, data }; the sent payload is preserved under `data`.
+      expect(detail.payload).toMatchObject({
+        type: EVENT_TYPE,
+        data: { sku: 'TEST-123', nested: { value: 42 } },
+      });
+      const envelopeTimestamp = (detail.payload as { timestamp?: unknown }).timestamp;
+      expect(typeof envelopeTimestamp).toBe('string');
+      expect(Number.isNaN(Date.parse(envelopeTimestamp as string))).toBe(false);
+
+      // Full captured response (the mock receiver replies { ok: true } as JSON)
+      expect(detail.responseBody).toBe(JSON.stringify({ ok: true }));
+      expect(detail.responseHeaders).not.toBeNull();
+      expect(detail.responseHeaders?.['content-type']).toContain('application/json');
+
+      // Attempt + timing metadata
+      expect(detail.attemptNumber).toBeGreaterThanOrEqual(1);
+      expect(detail.maxAttempts).toBeGreaterThanOrEqual(1);
+      expect(typeof detail.durationMs).toBe('number');
+      expect(detail.durationMs as number).toBeGreaterThanOrEqual(0);
+      expect(detail.nextRetryAt).toBeNull();
+
+      for (const timestamp of [detail.createdAt, detail.enqueuedAt, detail.lastAttemptAt, detail.deliveredAt, detail.updatedAt]) {
+        expect(typeof timestamp).toBe('string');
+        expect(Number.isNaN(Date.parse(timestamp as string))).toBe(false);
+      }
+    } finally {
+      await deleteWebhookIfExists(request, token, webhookId);
+    }
+  });
+});

--- a/packages/webhooks/src/modules/webhooks/__integration__/helpers/fixtures.ts
+++ b/packages/webhooks/src/modules/webhooks/__integration__/helpers/fixtures.ts
@@ -1,6 +1,8 @@
 import { expect, type APIRequestContext } from '@playwright/test';
-import { apiRequest } from '@open-mercato/core/helpers/integration/api';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
 import { expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { createUserFixture, deleteUserIfExists } from '@open-mercato/core/helpers/integration/authFixtures';
+import { deleteUserAclInDb, setUserAclInDb } from '@open-mercato/core/helpers/integration/dbFixtures';
 
 const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000';
 
@@ -246,4 +248,102 @@ export async function deleteWebhookIfExists(
   } catch {
     return;
   }
+}
+
+export type WebhookRotateSecretResponse = {
+  success: true;
+  secret: string;
+  previousSecretSetAt: string | null;
+};
+
+export async function rotateWebhookSecret(
+  request: APIRequestContext,
+  token: string,
+  webhookId: string,
+  path = `/api/webhooks/${webhookId}/rotate-secret`,
+): Promise<WebhookRotateSecretResponse> {
+  const response = await apiRequest(request, 'POST', path, { token });
+  expect(response.status()).toBe(200);
+  const body = await readJsonSafe<WebhookRotateSecretResponse>(response);
+  if (!body) {
+    throw new Error(`Expected rotate-secret response for ${webhookId}`);
+  }
+  return body;
+}
+
+export type WebhookTestDeliveryResponse = {
+  success: true;
+  delivery: WebhookDeliveryDetailResponse;
+};
+
+export async function sendTestDelivery(
+  request: APIRequestContext,
+  token: string,
+  webhookId: string,
+  input: { eventType?: string; payload?: Record<string, unknown> } = {},
+  path = `/api/webhooks/${webhookId}/test`,
+): Promise<WebhookTestDeliveryResponse> {
+  const response = await apiRequest(request, 'POST', path, { token, data: input });
+  expect(response.status()).toBe(200);
+  const body = await readJsonSafe<WebhookTestDeliveryResponse>(response);
+  if (!body) {
+    throw new Error(`Expected test delivery response for ${webhookId}`);
+  }
+  return body;
+}
+
+export type ProvisionedWebhooksUser = {
+  userId: string;
+  email: string;
+  password: string;
+  token: string;
+};
+
+/**
+ * Creates a self-contained, role-less user and grants it an exact webhooks feature
+ * set (and optional organization-visibility list) through a per-user ACL row, then
+ * logs it in. The DB ACL path mirrors the org-scope fixtures: granting features via
+ * the ACL API requires a super-admin actor, while `setUserAclInDb` keeps the spec
+ * self-contained and deterministic. Login happens AFTER the ACL is written so the
+ * fresh session resolves the new grants.
+ */
+export async function provisionWebhooksUser(
+  request: APIRequestContext,
+  adminToken: string,
+  input: {
+    tenantId: string;
+    organizationId: string;
+    features: string[];
+    organizations?: string[] | null;
+    slug: string;
+  },
+): Promise<ProvisionedWebhooksUser> {
+  const unique = `${Date.now()}${Math.floor(Math.random() * 1_000_000)}`;
+  const email = `qa-webhooks-${input.slug}-${unique}@acme.com`;
+  const password = 'Valid1!Webhooks';
+  const userId = await createUserFixture(request, adminToken, {
+    email,
+    password,
+    organizationId: input.organizationId,
+    roles: [],
+    name: `QA Webhooks ${input.slug}`,
+  });
+  await setUserAclInDb({
+    userId,
+    tenantId: input.tenantId,
+    features: input.features,
+    organizations: input.organizations ?? null,
+  });
+  const token = await getAuthToken(request, email, password);
+  return { userId, email, password, token };
+}
+
+export async function cleanupWebhooksUser(
+  request: APIRequestContext,
+  adminToken: string | null,
+  user: ProvisionedWebhooksUser | null,
+): Promise<void> {
+  if (!user) return;
+  await deleteUserAclInDb(user.userId).catch(() => undefined);
+  await deleteUserIfExists(request, adminToken, user.userId).catch(() => undefined);
 }


### PR DESCRIPTION
## Summary

Expands integration-test coverage for the `webhooks` module per #2482, adding the seven
high-value scenarios (TC-WEBHOOK-004…010) that were previously untested: secret rotation,
RBAC feature gates, deactivation-blocks-delivery, tenant/organization scoping isolation,
delivery-log filtering, unsafe-URL rejection, and full delivery-detail completeness. These
complement the existing TC-WEBHOOK-001 (CRUD), -002 (delivery lifecycle), and -003 (inbound).
Test-only change — no product code is modified.

## Changes

- Add `packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-004.spec.ts` — secret rotation with previous-secret retention (`webhooks.secrets`).
- Add `…/TC-WEBHOOK-005.spec.ts` — RBAC gates for `webhooks.view/manage/secrets/test` (a view-only user and a no-feature user vs admin).
- Add `…/TC-WEBHOOK-006.spec.ts` — `isActive=false` blocks delivery (delivery marked `expired` / "Webhook is inactive"), resumes on re-activation.
- Add `…/TC-WEBHOOK-007.spec.ts` — organization-scoping isolation within a tenant (cross-org detail/update/delete → 404; lists exclude foreign rows).
- Add `…/TC-WEBHOOK-008.spec.ts` — delivery-log filtering by `status`, `eventType`, and their intersection, plus empty-result pagination.
- Add `…/TC-WEBHOOK-009.spec.ts` — unsafe-URL rejection on create/update (forbidden scheme, embedded credentials, malformed always 400; private/loopback hosts asserted per the active `OM_WEBHOOKS_ALLOW_PRIVATE_URLS` flag).
- Add `…/TC-WEBHOOK-010.spec.ts` — delivery-detail completeness (full payload envelope, response status/body/headers, attempt & timing metadata).
- Extend `…/__integration__/helpers/fixtures.ts` with `rotateWebhookSecret`, `sendTestDelivery`, and `provisionWebhooksUser`/`cleanupWebhooksUser` helpers (purely additive).

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test-only integration coverage, no behavior/contract change. Existing module spec (unchanged): `.ai/specs/implemented/SPEC-057-2026-03-04-webhooks-module.md`. Scenarios are defined in issue #2482.

## Testing

All run against a live isolated app + database (Docker-free: `dev:app` on an isolated DB, `OM_WEBHOOKS_ALLOW_PRIVATE_URLS=1`):

- `npx playwright test --config .ai/qa/tests/playwright.config.ts TC-WEBHOOK` → **11 passed** (TC-WEBHOOK-001…010, incl. the existing baseline).
- `… TC-WEBHOOK-00[4-9] TC-WEBHOOK-010 --repeat-each=2 --retries=0` → **14 passed** (idempotency / re-run stability).
- `tsc -p packages/webhooks/tsconfig.json --noEmit` → **clean** (the package tsconfig includes `__integration__`).
- `yarn workspace @open-mercato/webhooks test` → **91 passed** (unit suite, no regression).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. — N/A: test-only, none required.
- [x] I added or adjusted tests that cover the change. — the change *is* the tests.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — placed in the module's `__integration__/` folder per `.ai/qa/AGENTS.md` (`.ai/qa/tests/` is reserved for the shared Playwright config).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A: no behavior change.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI (backend integration tests).
- [x] No arbitrary text sizes — N/A, no UI.
- [x] Empty state handled for list/data pages — N/A, no UI.
- [x] Loading state handled for async pages — N/A, no UI.
- [x] `aria-label` on all icon-only buttons — N/A, no UI.
- [x] Uses existing DS components — N/A, no UI.

## Linked issues

Fixes #2482