### PR TITLE
feat: 2483 search integration coverage

### DIFF
--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-003.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-003.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+
+/**
+ * TC-SEARCH-003: Search API requires authentication and feature gates (401/403)
+ * Source: issue #2483 (expand `search` integration coverage)
+ *
+ * Real routes (the `search` module id prefixes every route under /api/search):
+ *   - GET  /api/search/search   requireAuth + requireFeatures ['search.view']
+ *   - POST /api/search/reindex  requireAuth + requireFeatures ['search.reindex']
+ *
+ * The framework route wrapper enforces requireAuth (401) and requireFeatures
+ * (403) BEFORE the handler body runs, so these gates hold independently of each
+ * route's own inline checks. Seeded role features: admin => search.* ,
+ * employee => vector.* only, superadmin => all. A user that holds search.view
+ * but NOT search.reindex must therefore be provisioned explicitly to prove the
+ * granular reindex gate (employee cannot stand in — it lacks search.view too).
+ */
+const VALID_PASSWORD = 'Valid1!Pass'
+
+test.describe('TC-SEARCH-003: search API auth & feature gates (401/403)', () => {
+  test('gates search.view and search.reindex by authentication and feature', async ({ request }) => {
+    test.slow()
+
+    const stamp = Date.now()
+    let adminToken: string | null = null
+    let superToken: string | null = null
+    let roleId: string | null = null
+    let viewerUserId: string | null = null
+    const roleName = `qa-search-003-viewer-${stamp}`
+    const viewerEmail = `qa-search-003-viewer-${stamp}@acme.com`
+
+    try {
+      // 1. Unauthenticated search => 401. q is non-empty, so only the auth gate
+      //    can produce a 401 here (the handler's empty-query 400 is unreachable
+      //    because the framework wrapper denies first).
+      const unauthSearch = await request.get('/api/search/search?q=test')
+      expect(unauthSearch.status(), 'unauthenticated GET /api/search/search must be 401').toBe(401)
+
+      // 2. Unauthenticated reindex => 401.
+      const unauthReindex = await request.post('/api/search/reindex', { data: {} })
+      expect(unauthReindex.status(), 'unauthenticated POST /api/search/reindex must be 401').toBe(401)
+
+      adminToken = await getAuthToken(request, 'admin')
+      const scope = getTokenScope(adminToken)
+
+      // 3. A user with search.view but NOT search.reindex: search is allowed
+      //    (never 401/403), reindex is forbidden (403).
+      roleId = await createRoleFixture(request, adminToken, { name: roleName, tenantId: scope.tenantId })
+      await setRoleAclFeatures(request, adminToken, { roleId, features: ['search.view'] })
+      viewerUserId = await createUserFixture(request, adminToken, {
+        email: viewerEmail,
+        password: VALID_PASSWORD,
+        organizationId: scope.organizationId,
+        roles: [roleName],
+        name: 'QA Search 003 Viewer',
+      })
+      const viewerToken = await getAuthToken(request, viewerEmail, VALID_PASSWORD)
+
+      const viewerSearch = await apiRequest(request, 'GET', '/api/search/search?q=qa-search-003', { token: viewerToken })
+      expect(viewerSearch.status(), 'viewer with search.view must not be unauthorized on search').not.toBe(401)
+      expect(viewerSearch.status(), 'viewer with search.view must not be forbidden on search').not.toBe(403)
+      // The search route resolves searchService and returns 200 with results
+      // (empty when no strategy returns hits) — it does not 503 here — so a passing
+      // gate yields 200.
+      expect(viewerSearch.status(), 'search.view passes the gate, so the search succeeds with 200').toBe(200)
+
+      const viewerReindex = await apiRequest(request, 'POST', '/api/search/reindex', { token: viewerToken, data: {} })
+      expect(viewerReindex.status(), 'viewer lacking search.reindex must be forbidden on reindex').toBe(403)
+
+      // 4. Superadmin can initiate reindex — never blocked by auth/feature gates.
+      //    useQueue:false makes the route clear its own lock in `finally`, so this
+      //    leaves no lingering fulltext lock for other tests; scoping to a single
+      //    entity keeps the synchronous reindex cheap.
+      superToken = await getAuthToken(request, 'superadmin')
+      const superReindex = await apiRequest(request, 'POST', '/api/search/reindex', {
+        token: superToken,
+        data: { entityId: 'customers:customer_company_profile', useQueue: false },
+      })
+      expect(superReindex.status(), 'superadmin reindex must not be unauthorized').not.toBe(401)
+      expect(superReindex.status(), 'superadmin reindex must not be forbidden').not.toBe(403)
+      expect([200, 503], 'superadmin reindex returns ok (200) or service-unavailable (503)').toContain(
+        superReindex.status(),
+      )
+    } finally {
+      // Best-effort: release any fulltext lock, then tear down fixtures.
+      if (superToken) {
+        await apiRequest(request, 'POST', '/api/search/reindex/cancel', { token: superToken }).catch(() => undefined)
+      }
+      await deleteUserIfExists(request, adminToken, viewerUserId)
+      await deleteRoleIfExists(request, adminToken, roleId)
+    }
+  })
+})

--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-004.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-004.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { expectId, getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  apiRequestWithSelectedOrg,
+  createRoleFixture,
+  createUserFixture,
+  deleteOrganizationIfExists,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import { createCompanyFixture, deleteEntityIfExists } from '@open-mercato/core/helpers/integration/crmFixtures'
+
+type SearchResultItem = { entityId?: string; presenter?: { title?: string } | null }
+type SearchResponse = { results?: SearchResultItem[] }
+
+const COMPANY_ENTITY = 'customers:customer_company_profile'
+const VALID_PASSWORD = 'Valid1!Pass'
+
+function titleOf(item: SearchResultItem): string {
+  const presenter = item?.presenter
+  const title = presenter && typeof presenter === 'object' ? (presenter as { title?: unknown }).title : undefined
+  return typeof title === 'string' ? title : ''
+}
+
+async function searchTitles(request: APIRequestContext, token: string, query: string): Promise<string[]> {
+  const params = new URLSearchParams({ q: query, limit: '20', entityTypes: COMPANY_ENTITY })
+  const res = await apiRequest(request, 'GET', `/api/search/search?${params.toString()}`, { token })
+  if (!res.ok()) return []
+  const body = (await readJsonSafe<SearchResponse>(res)) ?? {}
+  return (Array.isArray(body.results) ? body.results : []).map(titleOf)
+}
+
+/**
+ * TC-SEARCH-004: search results are organization-scoped.
+ * Source: issue #2483 (P0 — cross-tenant/org isolation).
+ *
+ * A company created in the admin's home org (orgA) must be invisible to a user
+ * confined to a second organization (orgB) in the same tenant, while that user
+ * still sees a company that lives in their own org. This exercises the
+ * organization scope filter the search route applies. orgB, its scoped user, and
+ * orgB's company are provisioned via API as superadmin; the test skips if a
+ * second organization cannot be provisioned in this environment.
+ */
+test.describe('TC-SEARCH-004: search results are organization-scoped', () => {
+  test('a restricted org-B user cannot see org-A companies via search', async ({ request }) => {
+    test.slow()
+
+    const stamp = Date.now()
+    const unique = `QASRCH004${stamp}`
+    let adminToken: string | null = null
+    let superToken: string | null = null
+    let orgBId: string | null = null
+    let roleId: string | null = null
+    let userBId: string | null = null
+    let companyAId: string | null = null
+    let companyBId: string | null = null
+    const roleName = `qa-search-004-${stamp}`
+    const userBEmail = `qa-search-004-${stamp}@acme.com`
+
+    try {
+      adminToken = await getAuthToken(request, 'admin')
+      superToken = await getAuthToken(request, 'superadmin')
+      const adminScope = getTokenScope(adminToken)
+
+      // Provision a second organization in the admin's tenant (superadmin bypasses
+      // the directory create command's tenant-selection enforcement).
+      const orgResp = await apiRequest(request, 'POST', '/api/directory/organizations', {
+        token: superToken,
+        data: { name: `QA Search 004 OrgB ${stamp}`, tenantId: adminScope.tenantId },
+      })
+      if (orgResp.status() !== 201) {
+        test.skip(true, `cannot provision a second organization in this environment (status ${orgResp.status()})`)
+        return
+      }
+      orgBId = expectId((await readJsonSafe<{ id?: string }>(orgResp))?.id, 'organization create returns an id')
+
+      // Company A in the admin's home org (orgA).
+      companyAId = await createCompanyFixture(request, adminToken, `${unique} A`)
+
+      // Company B placed into orgB via the selected-org cookie (superadmin).
+      const companyBResp = await apiRequestWithSelectedOrg(request, 'POST', '/api/customers/companies', {
+        token: superToken,
+        selectedOrgId: orgBId,
+        data: { displayName: `${unique} B` },
+      })
+      expect(companyBResp.status(), 'create company in orgB should return 201').toBe(201)
+      companyBId = expectId((await readJsonSafe<{ id?: string }>(companyBResp))?.id, 'company B returns an id')
+
+      // A user confined to orgB with search + customers read access.
+      roleId = await createRoleFixture(request, adminToken, { name: roleName, tenantId: adminScope.tenantId })
+      await setRoleAclFeatures(request, adminToken, { roleId, features: ['search.view', 'customers.*'] })
+      userBId = await createUserFixture(request, superToken, {
+        email: userBEmail,
+        password: VALID_PASSWORD,
+        organizationId: orgBId,
+        roles: [roleName],
+        name: 'QA Search 004 OrgB User',
+      })
+      await setUserAclVisibility(request, superToken, {
+        userId: userBId,
+        organizations: [orgBId],
+        features: ['search.view', 'customers.*'],
+      })
+      const userBToken = await getAuthToken(request, userBEmail, VALID_PASSWORD)
+      expect(getTokenScope(userBToken).organizationId, 'org-B user is scoped to orgB').toBe(orgBId)
+
+      // Admin (orgA) can find company A — confirms it is indexed and searchable.
+      await expect
+        .poll(async () => (await searchTitles(request, adminToken!, unique)).includes(`${unique} A`), {
+          timeout: 15_000,
+        })
+        .toBe(true)
+
+      // Org-B user can find company B (their own org) — confirms their search works.
+      await expect
+        .poll(async () => (await searchTitles(request, userBToken, unique)).includes(`${unique} B`), {
+          timeout: 15_000,
+        })
+        .toBe(true)
+
+      // Org-B user must NOT see company A (cross-org isolation — the P0 assertion).
+      const orgBTitles = await searchTitles(request, userBToken, unique)
+      expect(orgBTitles, 'org-B user must not see the org-A company').not.toContain(`${unique} A`)
+    } finally {
+      await deleteEntityIfExists(request, superToken, '/api/customers/companies', companyAId)
+      await deleteEntityIfExists(request, superToken, '/api/customers/companies', companyBId)
+      await deleteUserIfExists(request, superToken, userBId)
+      await deleteRoleIfExists(request, adminToken, roleId)
+      await deleteOrganizationIfExists(request, superToken, orgBId)
+    }
+  })
+})

--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-005.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-005.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+/**
+ * TC-SEARCH-005: Search validates the query parameter (400)
+ * Source: issue #2483.
+ *
+ * Route: GET /api/search/search (requireFeatures ['search.view']). The handler
+ * trims `q` and returns 400 { error: 'Missing query' } when it is empty; a
+ * non-empty query is accepted with 200 (empty results when no strategy matches),
+ * never 400. All cases authenticate as `admin`, which holds search.view, so the
+ * empty-query 400 is produced by the handler rather than the framework gate.
+ */
+test.describe('TC-SEARCH-005: search validates the query parameter (400)', () => {
+  let token = ''
+
+  test.beforeAll(async ({ request }) => {
+    token = await getAuthToken(request, 'admin')
+  })
+
+  test('missing q returns 400', async ({ request }) => {
+    const res = await apiRequest(request, 'GET', '/api/search/search', { token })
+    expect(res.status()).toBe(400)
+    const body = await readJsonSafe<{ error?: string }>(res)
+    expect(typeof body?.error, 'a 400 response carries an error message').toBe('string')
+  })
+
+  test('empty q returns 400', async ({ request }) => {
+    const res = await apiRequest(request, 'GET', '/api/search/search?q=', { token })
+    expect(res.status()).toBe(400)
+  })
+
+  test('whitespace-only q returns 400', async ({ request }) => {
+    const res = await apiRequest(request, 'GET', '/api/search/search?q=%20%20%20', { token })
+    expect(res.status()).toBe(400)
+  })
+
+  test('non-empty q is accepted with 200 (not rejected as 400)', async ({ request }) => {
+    const res = await apiRequest(request, 'GET', `/api/search/search?q=qa-search-005-${Date.now()}`, { token })
+    // The route resolves searchService and returns 200 (empty results when no
+    // strategy matches); it does not 503 on this path. So a valid query is a 200.
+    expect(res.status(), 'a valid query is accepted with 200').toBe(200)
+  })
+})

--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-006.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-006.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+type GlobalSearchSettings = { enabledStrategies?: string[] }
+type GlobalSearchUpdate = { ok?: boolean; enabledStrategies?: string[] }
+type GlobalSearchResponse = { strategiesEnabled?: string[] }
+
+const DEFAULT_STRATEGIES = ['fulltext', 'vector', 'tokens']
+
+/**
+ * TC-SEARCH-006: global (Cmd+K) search honors the saved strategy config over a
+ * URL override. Source: issue #2483.
+ *
+ * Routes:
+ *   - GET/POST /api/search/settings/global-search  (POST requires search.manage)
+ *   - GET /api/search/search/global                 (ignores any `strategies` URL param)
+ *
+ * Saves enabledStrategies = ['tokens'], then calls global search with a
+ * conflicting ?strategies=fulltext,vector and asserts the response's
+ * strategiesEnabled reflects the SAVED config, not the URL. The original config
+ * is restored in `finally`. `admin` holds both search.view and search.manage.
+ */
+test.describe('TC-SEARCH-006: global search honors saved strategy config over URL override', () => {
+  test('persisted enabledStrategies wins over the strategies URL parameter', async ({ request }) => {
+    test.slow()
+
+    let token: string | null = null
+    let originalStrategies: string[] | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+
+      const currentRes = await apiRequest(request, 'GET', '/api/search/settings/global-search', { token })
+      expect(currentRes.ok(), 'GET global-search settings should succeed').toBeTruthy()
+      const current = (await readJsonSafe<GlobalSearchSettings>(currentRes)) ?? {}
+      expect(Array.isArray(current.enabledStrategies), 'settings expose an enabledStrategies array').toBe(true)
+      originalStrategies =
+        Array.isArray(current.enabledStrategies) && current.enabledStrategies.length > 0
+          ? current.enabledStrategies
+          : DEFAULT_STRATEGIES
+
+      const updateRes = await apiRequest(request, 'POST', '/api/search/settings/global-search', {
+        token,
+        data: { enabledStrategies: ['tokens'] },
+      })
+      expect(updateRes.status(), 'POST global-search settings should return 200').toBe(200)
+      const updated = (await readJsonSafe<GlobalSearchUpdate>(updateRes)) ?? {}
+      expect(updated.ok, 'update reports ok').toBe(true)
+      expect(updated.enabledStrategies, 'update echoes the saved strategies').toEqual(['tokens'])
+
+      const globalRes = await apiRequest(
+        request,
+        'GET',
+        `/api/search/search/global?q=qa-search-006-${Date.now()}&strategies=fulltext,vector`,
+        { token },
+      )
+      expect(globalRes.ok(), 'GET global search should succeed').toBeTruthy()
+      const globalBody = (await readJsonSafe<GlobalSearchResponse>(globalRes)) ?? {}
+      expect(
+        globalBody.strategiesEnabled,
+        'global search must use the saved config (tokens), ignoring the strategies URL override',
+      ).toEqual(['tokens'])
+    } finally {
+      if (token && originalStrategies) {
+        await apiRequest(request, 'POST', '/api/search/settings/global-search', {
+          token,
+          data: { enabledStrategies: originalStrategies },
+        }).catch(() => undefined)
+      }
+    }
+  })
+})

--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-007.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-007.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+type ReindexLock = {
+  type?: string
+  action?: string
+  startedAt?: string
+  elapsedMinutes?: number
+  processedCount?: number | null
+  totalCount?: number | null
+}
+type ConflictBody = { error?: string; lock?: ReindexLock }
+
+/**
+ * TC-SEARCH-007: concurrent fulltext reindex returns 409 with lock info.
+ * Source: issue #2483.
+ *
+ * Route: POST /api/search/reindex (requireFeatures ['search.reindex']). The route
+ * acquires a per-tenant DB lock BEFORE any indexing work and, in queue mode
+ * (useQueue:true — the default), does NOT release it in `finally` (workers and
+ * the heartbeat own it). So a first call holds the lock and a second call returns
+ * 409 with the lock descriptor — independent of whether a fulltext backend is
+ * configured, because the lock is taken before the strategy-availability check.
+ * Integration specs run serially (workers:1), so no other test contends for the
+ * shared lock; it is released in `finally` via the cancel endpoint.
+ */
+test.describe('TC-SEARCH-007: concurrent fulltext reindex returns 409 with lock info', () => {
+  test('a second reindex while one is active is rejected with 409', async ({ request }) => {
+    test.slow()
+
+    let token: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+
+      // Start from a clean lock state.
+      await apiRequest(request, 'POST', '/api/search/reindex/cancel', { token }).catch(() => undefined)
+
+      // First reindex acquires (and, in queue mode, holds) the fulltext lock.
+      const first = await apiRequest(request, 'POST', '/api/search/reindex', { token, data: { useQueue: true } })
+      expect(first.status(), 'first reindex must not hit a pre-existing lock').not.toBe(409)
+      expect([200, 503], 'first reindex starts (200) or reports backend unavailable (503)').toContain(first.status())
+
+      // Second reindex is rejected while the first holds the lock.
+      const second = await apiRequest(request, 'POST', '/api/search/reindex', { token, data: { useQueue: true } })
+      expect(second.status(), 'a concurrent reindex must be rejected with 409').toBe(409)
+      const body = (await readJsonSafe<ConflictBody>(second)) ?? {}
+      expect(body.lock?.type, 'the 409 lock descriptor identifies the fulltext lock').toBe('fulltext')
+      expect(typeof body.lock?.action, 'the lock reports its action').toBe('string')
+      expect(typeof body.lock?.startedAt, 'the lock reports when it started').toBe('string')
+      expect(typeof body.lock?.elapsedMinutes, 'the lock reports elapsed minutes').toBe('number')
+    } finally {
+      if (token) {
+        await apiRequest(request, 'POST', '/api/search/reindex/cancel', { token }).catch(() => undefined)
+      }
+    }
+  })
+})

--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-008.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-008.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { createCompanyFixture, deleteEntityIfExists } from '@open-mercato/core/helpers/integration/crmFixtures'
+
+type IndexEntry = { entityId?: string; recordId?: string }
+type IndexResponse = { entries?: IndexEntry[]; limit?: number; offset?: number }
+
+const COMPANY_ENTITY = 'customers:customer_company_profile'
+
+async function getIndex(
+  request: APIRequestContext,
+  token: string,
+  params: Record<string, string>,
+): Promise<{ status: number; body: IndexResponse }> {
+  const qs = new URLSearchParams(params).toString()
+  const res = await apiRequest(request, 'GET', `/api/search/index${qs ? `?${qs}` : ''}`, { token })
+  const body = res.ok() ? ((await readJsonSafe<IndexResponse>(res)) ?? {}) : {}
+  return { status: res.status(), body }
+}
+
+/**
+ * TC-SEARCH-008: vector index list pagination & entityId filter.
+ * Source: issue #2483.
+ *
+ * Route: GET /api/search/index (requireFeatures ['search.view']) returns the
+ * vector-store entries (VectorIndexEntry: entityId, recordId, … — there is no
+ * surrogate `id`) with limit/offset paging and an optional entityId filter.
+ * Exercising it requires a working embedding pipeline (a provider key AND an
+ * applied embedding config that produces indexed rows). When the index is not
+ * listable — the endpoint returns 503 (vector strategy unavailable) or 500 (no
+ * embedding config / vector table) — this test skips, mirroring how the
+ * fulltext-dependent specs skip when Meilisearch is absent. The full pagination
+ * contract runs only when the vector index is queryable and rows materialize.
+ */
+test.describe('TC-SEARCH-008: vector index list pagination & entityId filter', () => {
+  test('paginates entries and filters by entityId', async ({ request }) => {
+    test.slow()
+
+    let token: string | null = null
+    const companyIds: string[] = []
+    const stamp = Date.now()
+
+    try {
+      token = await getAuthToken(request, 'admin')
+
+      // The endpoint must be queryable (200). A 503 (vector strategy unavailable)
+      // or 500 (no embedding config / vector table) means the index cannot be
+      // paginated in this environment — skip rather than fail.
+      const probe = await getIndex(request, token, {})
+      if (probe.status !== 200) {
+        test.skip(true, `vector index is not listable in this environment (status ${probe.status})`)
+        return
+      }
+
+      for (let i = 0; i < 3; i += 1) {
+        companyIds.push(await createCompanyFixture(request, token, `QASRCH008-${stamp}-${i}`))
+      }
+
+      // Trigger a (queued) vector reindex and wait for rows to materialize.
+      await apiRequest(request, 'POST', '/api/search/embeddings/reindex', {
+        token,
+        data: { entityId: COMPANY_ENTITY },
+      }).catch(() => undefined)
+
+      let entries: IndexEntry[] = []
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        entries = (await getIndex(request, token, {})).body.entries ?? []
+        if (entries.length >= 2) break
+        await new Promise((resolve) => setTimeout(resolve, 1_000))
+      }
+      if (entries.length < 2) {
+        test.skip(true, 'vector index did not reach 2 entries; the embedding pipeline does not produce rows here')
+        return
+      }
+
+      // Default paging metadata, with enough rows to page over.
+      const base = await getIndex(request, token, {})
+      expect(base.body.limit, 'default limit is 50').toBe(50)
+      expect(base.body.offset, 'default offset is 0').toBe(0)
+      expect((base.body.entries ?? []).length, 'index has at least two entries to page over').toBeGreaterThanOrEqual(2)
+
+      // limit caps the page size and is echoed back.
+      const limited = await getIndex(request, token, { limit: '1', offset: '0' })
+      expect(limited.body.limit, 'response echoes the requested limit').toBe(1)
+      expect(limited.body.entries?.length ?? 0, 'limit=1 returns at most one entry').toBeLessThanOrEqual(1)
+
+      // A two-row page returns two DISTINCT records — proves paging yields
+      // distinct rows (keyed on recordId, the stable per-record identifier).
+      const pageOfTwo = await getIndex(request, token, { limit: '2', offset: '0' })
+      const twoIds = (pageOfTwo.body.entries ?? []).map((entry) => entry.recordId)
+      expect(twoIds.length, 'a limit=2 page returns two rows').toBe(2)
+      expect(twoIds[0], 'each paged entry exposes a recordId').toBeTruthy()
+      expect(twoIds[1], 'the two paged entries are distinct records').not.toBe(twoIds[0])
+
+      // offset advances the window to a different record and is echoed back.
+      const page2 = await getIndex(request, token, { limit: '1', offset: '1' })
+      expect(page2.body.offset, 'response echoes the requested offset').toBe(1)
+      const offset0Id = limited.body.entries?.[0]?.recordId
+      const offset1Id = page2.body.entries?.[0]?.recordId
+      expect(offset1Id, 'offset=1 returns a record').toBeTruthy()
+      expect(offset1Id, 'offset=1 returns a different record than offset=0').not.toBe(offset0Id)
+
+      // entityId filter narrows to the requested entity type (and is non-empty,
+      // so the uniformity assertion is not vacuous).
+      const filtered = await getIndex(request, token, { entityId: COMPANY_ENTITY, limit: '50' })
+      expect((filtered.body.entries ?? []).length, 'company entityId filter returns at least our fixtures').toBeGreaterThan(
+        0,
+      )
+      for (const entry of filtered.body.entries ?? []) {
+        expect(entry.entityId, 'entityId filter returns only that entity type').toBe(COMPANY_ENTITY)
+      }
+    } finally {
+      // Vector reindex acquires a lock that its route does NOT release (workers
+      // own it), so explicitly cancel to avoid leaving a lock behind.
+      if (token) {
+        await apiRequest(request, 'POST', '/api/search/embeddings/reindex/cancel', { token }).catch(() => undefined)
+      }
+      for (const id of companyIds) {
+        await deleteEntityIfExists(request, token, '/api/customers/companies', id)
+      }
+    }
+  })
+})

--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-009.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-009.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createCompanyFixture,
+  createPersonFixture,
+  deleteEntityIfExists,
+} from '@open-mercato/core/helpers/integration/crmFixtures'
+
+type SearchResultItem = { entityId?: string; presenter?: { title?: string } | null }
+type SearchResponse = { results?: SearchResultItem[] }
+
+const COMPANY_ENTITY = 'customers:customer_company_profile'
+const PERSON_ENTITY = 'customers:customer_person_profile'
+
+async function searchResults(
+  request: APIRequestContext,
+  token: string,
+  query: string,
+  entityTypes: string,
+): Promise<SearchResultItem[]> {
+  const params = new URLSearchParams({ q: query, limit: '20', entityTypes })
+  const res = await apiRequest(request, 'GET', `/api/search/search?${params.toString()}`, { token })
+  if (!res.ok()) return []
+  const body = (await readJsonSafe<SearchResponse>(res)) ?? {}
+  return Array.isArray(body.results) ? body.results : []
+}
+
+/**
+ * TC-SEARCH-009: search entityTypes filter isolates entity types
+ * Source: issue #2483.
+ *
+ * Creates a company and a person that share a unique token in their searchable
+ * text, then asserts that filtering by entity type returns only that type. Token
+ * search (PostgreSQL) is always available; indexing is asynchronous, so results
+ * are polled. The unique query token only matches these two fixtures, so a
+ * type-filtered response that is non-empty AND uniform proves the filter holds.
+ */
+test.describe('TC-SEARCH-009: search entityTypes filter isolates entity types', () => {
+  test('filtering by company / person type returns only that type', async ({ request }) => {
+    test.slow()
+
+    const stamp = Date.now()
+    const unique = `QASRCH009${stamp}`
+    let token: string | null = null
+    let companyId: string | null = null
+    let personId: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+
+      companyId = await createCompanyFixture(request, token, `${unique} Co`)
+      personId = await createPersonFixture(request, token, {
+        firstName: 'QA',
+        lastName: `S9 ${stamp}`,
+        displayName: `${unique} Person`,
+      })
+
+      // Company-type filter: results appear and every hit is a company.
+      await expect
+        .poll(
+          async () => {
+            const results = await searchResults(request, token!, unique, COMPANY_ENTITY)
+            return results.length > 0 && results.every((r) => r.entityId === COMPANY_ENTITY)
+          },
+          { timeout: 15_000 },
+        )
+        .toBe(true)
+
+      // Person-type filter: results appear and every hit is a person (no company leaks in).
+      await expect
+        .poll(
+          async () => {
+            const results = await searchResults(request, token!, unique, PERSON_ENTITY)
+            return results.length > 0 && results.every((r) => r.entityId === PERSON_ENTITY)
+          },
+          { timeout: 15_000 },
+        )
+        .toBe(true)
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/people', personId)
+      await deleteEntityIfExists(request, token, '/api/customers/companies', companyId)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Expand integration-test coverage for the `search` module (issue #2483) with seven
self-contained Playwright API specs covering the previously untested
security- and contract-sensitive surfaces: authentication/feature gating,
organization scoping, query validation, global-search config isolation, the
concurrent-reindex lock, vector-index pagination, and entityType filtering.
No product code changes — tests only.

## Changes

- Add `packages/search/src/modules/search/__integration__/TC-SEARCH-003.spec.ts` — auth (401) + feature gates: `search.view` for search, `search.reindex` for reindex (403 via a custom role with only `search.view`; superadmin allowed).
- Add `…/TC-SEARCH-004.spec.ts` — search results are organization-scoped: an org-B-confined user cannot see an org-A company (P0 cross-org isolation).
- Add `…/TC-SEARCH-005.spec.ts` — missing/empty/whitespace `q` → 400; a valid `q` → 200.
- Add `…/TC-SEARCH-006.spec.ts` — global (Cmd+K) search uses the saved `enabledStrategies` and ignores a conflicting `?strategies` URL override; original config restored.
- Add `…/TC-SEARCH-007.spec.ts` — a second fulltext reindex while one holds the lock returns 409 with the lock descriptor (`type:'fulltext'`, action, startedAt, elapsedMinutes); lock released via the cancel endpoint.
- Add `…/TC-SEARCH-008.spec.ts` — vector index list honors limit/offset paging and the entityId filter; skips when the vector index is not listable (no embedding pipeline), mirroring fulltext-absent skips.
- Add `…/TC-SEARCH-009.spec.ts` — the `entityTypes` filter returns only the requested entity type (company vs person).

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — adds integration coverage for existing `search` behavior (no module behavior change); scenarios sourced directly from issue #2483 and `.ai/qa/AGENTS.md`.

## Testing

Booted an app on an isolated DB (`yarn dev:app --database-name=… --update-env`, `yarn initialize`, `AUTO_SPAWN_WORKERS=1`) and ran, twice (idempotent):

- `BASE_URL=http://localhost:3005 ENABLE_CRUD_API_CACHE=true OM_INTEGRATION_MODULES=search npx playwright test --config .ai/qa/tests/playwright.config.ts TC-SEARCH-003 … TC-SEARCH-009` → **9 passed, 1 skipped** (TC-SEARCH-008 skips when the vector index is not listable in the environment).
- `yarn turbo run typecheck --filter=@open-mercato/search` → **1 successful** (the package tsconfig type-checks `__integration__` specs).
- `yarn turbo run build --filter=@open-mercato/search` → **built successfully**.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — tests only; no docs/locale/generator impact.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Added 7 specs in the module’s `__integration__/` folder — the preferred executable-spec location per `.ai/qa/AGENTS.md`; `.ai/qa/tests/` holds shared Playwright config only.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — coverage for existing behavior, no spec.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, backend API tests, no UI.
- [x] No arbitrary text sizes — N/A, backend API tests, no UI.
- [x] Empty state handled for list/data pages — N/A, backend API tests, no UI.
- [x] Loading state handled for async pages — N/A, backend API tests, no UI.
- [x] `aria-label` on all icon-only buttons — N/A, backend API tests, no UI.
- [x] Uses existing DS components — N/A, backend API tests, no UI.

## Linked issues

Fixes #2483