### PR TITLE
feat: 2480 directory integration coverage

### DIFF
--- a/packages/core/src/modules/directory/__integration__/TC-DIR-006.spec.ts
+++ b/packages/core/src/modules/directory/__integration__/TC-DIR-006.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  getTokenContext,
+  deleteGeneralEntityIfExists,
+} from '@open-mercato/core/helpers/integration/generalFixtures';
+
+/**
+ * TC-DIR-006: RBAC enforcement — missing directory.*.manage blocks POST/PUT/DELETE
+ * Covers: POST/PUT/DELETE /api/directory/organizations and /api/directory/tenants
+ *
+ * The employee role is granted no directory features by default — directory/setup.ts
+ * only grants `superadmin: directory.tenants.*` and
+ * `admin: directory.organizations.{view,manage}`. The route metadata feature gate
+ * (requireFeatures) rejects an authenticated-but-unauthorized caller with 403 before
+ * the handler runs, so the superadmin-owned fixtures are never mutated.
+ */
+test.describe('TC-DIR-006: RBAC enforcement on directory writes', () => {
+  let superToken: string | null = null;
+  let employeeToken: string | null = null;
+  let superTenantId = '';
+  let orgId: string | null = null;
+  let tenantId: string | null = null;
+  const stamp = Date.now();
+  const orgName = `QA TC-DIR-006 Org ${stamp}`;
+
+  test.beforeAll(async ({ request }) => {
+    superToken = await getAuthToken(request, 'superadmin');
+    employeeToken = await getAuthToken(request, 'employee');
+    superTenantId = getTokenContext(superToken).tenantId;
+
+    const tenantRes = await apiRequest(request, 'POST', '/api/directory/tenants', {
+      token: superToken,
+      data: { name: `QA TC-DIR-006 Tenant ${stamp}` },
+    });
+    expect(tenantRes.status(), 'superadmin should create the tenant fixture').toBe(201);
+    tenantId = ((await tenantRes.json()) as { id?: string }).id ?? null;
+    expect(tenantId, 'tenant fixture id').toBeTruthy();
+
+    const orgRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      token: superToken,
+      data: { name: orgName, tenantId: superTenantId },
+    });
+    expect(orgRes.status(), 'superadmin should create the organization fixture').toBe(201);
+    orgId = ((await orgRes.json()) as { id?: string }).id ?? null;
+    expect(orgId, 'organization fixture id').toBeTruthy();
+  });
+
+  test.afterAll(async ({ request }) => {
+    await deleteGeneralEntityIfExists(request, superToken, '/api/directory/organizations', orgId);
+    await deleteGeneralEntityIfExists(request, superToken, '/api/directory/tenants', tenantId);
+  });
+
+  test('employee is forbidden from organization writes (POST/PUT/DELETE -> 403)', async ({ request }) => {
+    const token = employeeToken!;
+
+    const createRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      token,
+      data: { name: `QA TC-DIR-006 Denied ${stamp}`, tenantId: superTenantId },
+    });
+    expect(createRes.status(), 'POST /api/directory/organizations should be forbidden').toBe(403);
+
+    const updateRes = await apiRequest(request, 'PUT', '/api/directory/organizations', {
+      token,
+      data: { id: orgId, name: `${orgName} HACKED` },
+    });
+    expect(updateRes.status(), 'PUT /api/directory/organizations should be forbidden').toBe(403);
+
+    const deleteRes = await apiRequest(
+      request,
+      'DELETE',
+      `/api/directory/organizations?id=${encodeURIComponent(orgId!)}`,
+      { token },
+    );
+    expect(deleteRes.status(), 'DELETE /api/directory/organizations should be forbidden').toBe(403);
+  });
+
+  test('employee is forbidden from tenant writes (POST/PUT/DELETE -> 403)', async ({ request }) => {
+    const token = employeeToken!;
+
+    const createRes = await apiRequest(request, 'POST', '/api/directory/tenants', {
+      token,
+      data: { name: `QA TC-DIR-006 Denied Tenant ${stamp}` },
+    });
+    expect(createRes.status(), 'POST /api/directory/tenants should be forbidden').toBe(403);
+
+    const updateRes = await apiRequest(request, 'PUT', '/api/directory/tenants', {
+      token,
+      data: { id: tenantId, name: `QA TC-DIR-006 Tenant ${stamp} HACKED` },
+    });
+    expect(updateRes.status(), 'PUT /api/directory/tenants should be forbidden').toBe(403);
+
+    const deleteRes = await apiRequest(
+      request,
+      'DELETE',
+      `/api/directory/tenants?id=${encodeURIComponent(tenantId!)}`,
+      { token },
+    );
+    expect(deleteRes.status(), 'DELETE /api/directory/tenants should be forbidden').toBe(403);
+  });
+
+  test('denied employee writes left the organization fixture untouched', async ({ request }) => {
+    // Confirms the 403s were gate denials, not handler-level errors after a partial mutation.
+    const getRes = await apiRequest(
+      request,
+      'GET',
+      `/api/directory/organizations?view=options&ids=${encodeURIComponent(orgId!)}&tenantId=${encodeURIComponent(superTenantId)}`,
+      { token: superToken! },
+    );
+    expect(getRes.status(), 'superadmin can still read the fixture').toBe(200);
+    const body = (await getRes.json()) as { items?: Array<{ id?: string; name?: string }> };
+    const org = (body.items ?? []).find((item) => item.id === orgId);
+    expect(org, 'organization fixture should still exist').toBeTruthy();
+    expect(org?.name, 'organization name must be unchanged by the denied PUT').toBe(orgName);
+  });
+});

--- a/packages/core/src/modules/directory/__integration__/TC-DIR-007.spec.ts
+++ b/packages/core/src/modules/directory/__integration__/TC-DIR-007.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  getTokenContext,
+  deleteGeneralEntityIfExists,
+} from '@open-mercato/core/helpers/integration/generalFixtures';
+
+/**
+ * TC-DIR-007: Public organization lookup by slug resolves tenant context
+ * Covers: GET /api/directory/organizations/lookup
+ *
+ * The lookup route declares `requireAuth: false` and is used by portal flows, so it
+ * must resolve without an Authorization header. Validation rejects an empty slug (400)
+ * and a missing organization yields 404.
+ */
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+
+type OrgLookupBody = {
+  ok?: boolean;
+  organization?: { id?: string; name?: string; slug?: string; tenantId?: string | null };
+  error?: string;
+};
+
+test.describe('TC-DIR-007: Public organization lookup by slug', () => {
+  let superToken: string | null = null;
+  let tenantId = '';
+  let orgId: string | null = null;
+  const stamp = Date.now();
+  const orgName = `QA TC-DIR-007 ${stamp}`;
+  const slug = `qa-tc-dir-007-${stamp}`;
+
+  test.beforeAll(async ({ request }) => {
+    superToken = await getAuthToken(request, 'superadmin');
+    tenantId = getTokenContext(superToken).tenantId;
+
+    const createRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      token: superToken,
+      data: { name: orgName, slug, tenantId },
+    });
+    expect(createRes.status(), 'superadmin should create the organization fixture').toBe(201);
+    orgId = ((await createRes.json()) as { id?: string }).id ?? null;
+    expect(orgId, 'organization fixture id').toBeTruthy();
+  });
+
+  test.afterAll(async ({ request }) => {
+    await deleteGeneralEntityIfExists(request, superToken, '/api/directory/organizations', orgId);
+  });
+
+  test('resolves organization metadata for a known slug without authentication', async ({ request }) => {
+    const res = await request.get(
+      `${BASE_URL}/api/directory/organizations/lookup?slug=${encodeURIComponent(slug)}`,
+    );
+    expect(res.status(), 'lookup with a known slug should return 200').toBe(200);
+    const body = (await res.json()) as OrgLookupBody;
+    expect(body.ok, 'ok should be true').toBe(true);
+    expect(body.organization?.id, 'organization.id should match the fixture').toBe(orgId);
+    expect(body.organization?.name, 'organization.name should be returned').toBe(orgName);
+    expect(body.organization?.slug, 'organization.slug should be returned').toBe(slug);
+    expect(body.organization?.tenantId, 'organization.tenantId should match the creating tenant').toBe(tenantId);
+  });
+
+  test('returns 404 for a slug that does not resolve to any organization', async ({ request }) => {
+    const res = await request.get(
+      `${BASE_URL}/api/directory/organizations/lookup?slug=${encodeURIComponent(`missing-${stamp}`)}`,
+    );
+    expect(res.status(), 'unknown slug should return 404').toBe(404);
+    const body = (await res.json()) as OrgLookupBody;
+    expect(body.ok, 'ok should be false for an unknown slug').toBe(false);
+  });
+
+  test('returns 400 for an empty slug', async ({ request }) => {
+    const res = await request.get(`${BASE_URL}/api/directory/organizations/lookup?slug=`);
+    expect(res.status(), 'empty slug should return 400').toBe(400);
+    const body = (await res.json()) as OrgLookupBody;
+    expect(body.ok, 'ok should be false for an empty slug').toBe(false);
+  });
+});

--- a/packages/core/src/modules/directory/__integration__/TC-DIR-008.spec.ts
+++ b/packages/core/src/modules/directory/__integration__/TC-DIR-008.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { deleteGeneralEntityIfExists } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+/**
+ * TC-DIR-008: Public tenant lookup by tenantId resolves metadata
+ * Covers: GET /api/directory/tenants/lookup
+ *
+ * The lookup route declares `requireAuth: false` and backs login/activation flows.
+ * The query schema requires a UUID, so a malformed id is rejected with 400 and a
+ * well-formed-but-unknown id yields 404.
+ */
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+// Well-formed v4 UUID that will not exist as a tenant (deterministic, not seeded).
+const NON_EXISTENT_TENANT_ID = '11111111-1111-4111-8111-111111111111';
+
+type TenantLookupBody = {
+  ok?: boolean;
+  tenant?: { id?: string; name?: string };
+  error?: string;
+};
+
+test.describe('TC-DIR-008: Public tenant lookup by tenantId', () => {
+  let superToken: string | null = null;
+  let tenantId: string | null = null;
+  const stamp = Date.now();
+  const tenantName = `QA TC-DIR-008 ${stamp}`;
+
+  test.beforeAll(async ({ request }) => {
+    superToken = await getAuthToken(request, 'superadmin');
+    const createRes = await apiRequest(request, 'POST', '/api/directory/tenants', {
+      token: superToken,
+      data: { name: tenantName },
+    });
+    expect(createRes.status(), 'superadmin should create the tenant fixture').toBe(201);
+    tenantId = ((await createRes.json()) as { id?: string }).id ?? null;
+    expect(tenantId, 'tenant fixture id').toBeTruthy();
+  });
+
+  test.afterAll(async ({ request }) => {
+    await deleteGeneralEntityIfExists(request, superToken, '/api/directory/tenants', tenantId);
+  });
+
+  test('resolves tenant metadata for a known tenantId without authentication', async ({ request }) => {
+    const res = await request.get(
+      `${BASE_URL}/api/directory/tenants/lookup?tenantId=${encodeURIComponent(tenantId!)}`,
+    );
+    expect(res.status(), 'lookup with a known tenantId should return 200').toBe(200);
+    const body = (await res.json()) as TenantLookupBody;
+    expect(body.ok, 'ok should be true').toBe(true);
+    expect(body.tenant?.id, 'tenant.id should match the requested tenantId').toBe(tenantId);
+    expect(body.tenant?.name, 'tenant.name should be returned').toBe(tenantName);
+  });
+
+  test('returns 400 for a malformed (non-UUID) tenantId', async ({ request }) => {
+    const res = await request.get(`${BASE_URL}/api/directory/tenants/lookup?tenantId=not-a-uuid`);
+    expect(res.status(), 'malformed tenantId should return 400').toBe(400);
+    const body = (await res.json()) as TenantLookupBody;
+    expect(body.ok, 'ok should be false for a malformed tenantId').toBe(false);
+  });
+
+  test('returns 404 for a well-formed but non-existent tenantId', async ({ request }) => {
+    const res = await request.get(
+      `${BASE_URL}/api/directory/tenants/lookup?tenantId=${NON_EXISTENT_TENANT_ID}`,
+    );
+    expect(res.status(), 'unknown tenantId should return 404').toBe(404);
+    const body = (await res.json()) as TenantLookupBody;
+    expect(body.ok, 'ok should be false for an unknown tenantId').toBe(false);
+  });
+});

--- a/packages/core/src/modules/directory/__integration__/TC-DIR-009.spec.ts
+++ b/packages/core/src/modules/directory/__integration__/TC-DIR-009.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  getTokenContext,
+  deleteGeneralEntityIfExists,
+} from '@open-mercato/core/helpers/integration/generalFixtures';
+
+/**
+ * TC-DIR-009: Organization create slug constraint validation
+ * Covers: POST /api/directory/organizations
+ *
+ * `organizationCreateSchema.slug` is `z.string().trim().toLowerCase().regex(/^[a-z0-9\-_]+$/)`.
+ * The regex runs AFTER `.trim().toLowerCase()`, so:
+ *  - slugs containing an internal space or a special character fail validation (the CRUD
+ *    factory maps the ZodError to HTTP 400), while
+ *  - an uppercase slug is normalized to lowercase and accepted (201) — it is NOT rejected.
+ */
+test.describe('TC-DIR-009: Organization slug validation', () => {
+  let superToken: string | null = null;
+  let tenantId = '';
+  const stamp = Date.now();
+  const createdOrgIds: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    superToken = await getAuthToken(request, 'superadmin');
+    tenantId = getTokenContext(superToken).tenantId;
+  });
+
+  test.afterAll(async ({ request }) => {
+    for (const id of createdOrgIds) {
+      await deleteGeneralEntityIfExists(request, superToken, '/api/directory/organizations', id);
+    }
+  });
+
+  test('rejects a slug containing an internal space (400)', async ({ request }) => {
+    const res = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      token: superToken!,
+      data: { name: `QA TC-DIR-009 space ${stamp}`, slug: 'invalid slug', tenantId },
+    });
+    expect(res.status(), 'a slug with a space should fail validation').toBe(400);
+  });
+
+  test('rejects a slug containing a special character (400)', async ({ request }) => {
+    const res = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      token: superToken!,
+      data: { name: `QA TC-DIR-009 special ${stamp}`, slug: 'invalid@slug', tenantId },
+    });
+    expect(res.status(), 'a slug with a special character should fail validation').toBe(400);
+  });
+
+  test('accepts a valid slug (201)', async ({ request }) => {
+    const slug = `valid-slug-${stamp}`;
+    const res = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      token: superToken!,
+      data: { name: `QA TC-DIR-009 valid ${stamp}`, slug, tenantId },
+    });
+    expect(res.status(), 'a valid slug should be accepted').toBe(201);
+    const id = ((await res.json()) as { id?: string }).id ?? null;
+    expect(id, 'organization id should be returned').toBeTruthy();
+    if (id) createdOrgIds.push(id);
+  });
+
+  test('normalizes an uppercase slug to lowercase rather than rejecting it (201)', async ({ request }) => {
+    const requestedSlug = `Upper-Case-${stamp}`;
+    const expectedSlug = requestedSlug.toLowerCase();
+    const res = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      token: superToken!,
+      data: { name: `QA TC-DIR-009 upper ${stamp}`, slug: requestedSlug, tenantId },
+    });
+    expect(res.status(), 'an uppercase slug should be normalized and accepted').toBe(201);
+    const id = ((await res.json()) as { id?: string }).id ?? null;
+    expect(id, 'organization id should be returned').toBeTruthy();
+    if (id) createdOrgIds.push(id);
+
+    const getRes = await apiRequest(
+      request,
+      'GET',
+      `/api/directory/organizations?view=manage&tenantId=${encodeURIComponent(tenantId)}&ids=${encodeURIComponent(id!)}`,
+      { token: superToken! },
+    );
+    expect(getRes.status()).toBe(200);
+    const body = (await getRes.json()) as { items?: Array<{ id?: string; slug?: string | null }> };
+    const stored = (body.items ?? []).find((item) => item.id === id);
+    expect(stored?.slug, 'the persisted slug should be lowercased').toBe(expectedSlug);
+  });
+});

--- a/packages/core/src/modules/directory/__integration__/TC-DIR-010.spec.ts
+++ b/packages/core/src/modules/directory/__integration__/TC-DIR-010.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { deleteGeneralEntityIfExists } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+/**
+ * TC-DIR-010: Tenant create name length constraints
+ * Covers: POST /api/directory/tenants
+ *
+ * `tenantCreateSchema.name` is `z.string().min(1).max(200)`. An empty name and a name
+ * longer than 200 characters both fail validation; the CRUD factory maps the ZodError to
+ * HTTP 400. A name within bounds is accepted (201).
+ */
+test.describe('TC-DIR-010: Tenant name validation', () => {
+  let superToken: string | null = null;
+  let validTenantId: string | null = null;
+  const stamp = Date.now();
+
+  test.beforeAll(async ({ request }) => {
+    superToken = await getAuthToken(request, 'superadmin');
+  });
+
+  test.afterAll(async ({ request }) => {
+    await deleteGeneralEntityIfExists(request, superToken, '/api/directory/tenants', validTenantId);
+  });
+
+  test('rejects an empty name (400)', async ({ request }) => {
+    const res = await apiRequest(request, 'POST', '/api/directory/tenants', {
+      token: superToken!,
+      data: { name: '' },
+    });
+    expect(res.status(), 'an empty name should fail validation').toBe(400);
+    const body = (await res.json()) as { id?: string };
+    expect(body?.id, 'no tenant should be created').toBeFalsy();
+  });
+
+  test('rejects a name longer than 200 characters (400)', async ({ request }) => {
+    const res = await apiRequest(request, 'POST', '/api/directory/tenants', {
+      token: superToken!,
+      data: { name: 'a'.repeat(201) },
+    });
+    expect(res.status(), 'a name over 200 characters should fail validation').toBe(400);
+    const body = (await res.json()) as { id?: string };
+    expect(body?.id, 'no tenant should be created').toBeFalsy();
+  });
+
+  test('accepts a name within the 1-200 character bounds (201)', async ({ request }) => {
+    const res = await apiRequest(request, 'POST', '/api/directory/tenants', {
+      token: superToken!,
+      data: { name: `QA TC-DIR-010 Valid ${stamp}` },
+    });
+    expect(res.status(), 'a valid name should be accepted').toBe(201);
+    validTenantId = ((await res.json()) as { id?: string }).id ?? null;
+    expect(validTenantId, 'tenant id should be returned').toBeTruthy();
+  });
+});

--- a/packages/core/src/modules/directory/__integration__/TC-DIR-011.spec.ts
+++ b/packages/core/src/modules/directory/__integration__/TC-DIR-011.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  getTokenContext,
+  deleteGeneralEntityIfExists,
+} from '@open-mercato/core/helpers/integration/generalFixtures';
+
+/**
+ * TC-DIR-011: Cross-tenant organization read isolation
+ * Covers: GET /api/directory/organizations
+ *
+ * A non-superadmin caller must never read organizations belonging to a tenant they are not
+ * scoped to. The seeded `admin` is scoped to its own tenant; a freshly created tenant B (with
+ * an organization) is the foreign tenant. When the admin requests `?tenantId=<B>`, the route's
+ * `enforceTenantScope` refuses to honor the foreign tenant: it either returns 400
+ * "Tenant scope required" or silently falls back to the admin's own tenant — in both cases the
+ * tenant-B organization must be absent from the response. The security invariant under test is
+ * "no cross-tenant leak", asserted regardless of which of those two safe outcomes occurs.
+ */
+test.describe('TC-DIR-011: Cross-tenant organization read isolation', () => {
+  let superToken: string | null = null;
+  let adminToken: string | null = null;
+  let ownTenantId = '';
+  let foreignTenantId: string | null = null;
+  let foreignOrgId: string | null = null;
+  const stamp = Date.now();
+
+  test.beforeAll(async ({ request }) => {
+    superToken = await getAuthToken(request, 'superadmin');
+    adminToken = await getAuthToken(request, 'admin');
+    ownTenantId = getTokenContext(adminToken).tenantId;
+    expect(ownTenantId, 'admin should be scoped to a tenant').toBeTruthy();
+
+    const tenantRes = await apiRequest(request, 'POST', '/api/directory/tenants', {
+      token: superToken,
+      data: { name: `QA TC-DIR-011 Foreign ${stamp}` },
+    });
+    expect(tenantRes.status(), 'superadmin should create the foreign tenant').toBe(201);
+    foreignTenantId = ((await tenantRes.json()) as { id?: string }).id ?? null;
+    expect(foreignTenantId, 'foreign tenant id').toBeTruthy();
+    expect(foreignTenantId, 'foreign tenant must differ from the admin tenant').not.toBe(ownTenantId);
+
+    const orgRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      token: superToken,
+      data: { name: `QA TC-DIR-011 Foreign Org ${stamp}`, tenantId: foreignTenantId },
+    });
+    expect(orgRes.status(), 'superadmin should create an org in the foreign tenant').toBe(201);
+    foreignOrgId = ((await orgRes.json()) as { id?: string }).id ?? null;
+    expect(foreignOrgId, 'foreign org id').toBeTruthy();
+  });
+
+  test.afterAll(async ({ request }) => {
+    await deleteGeneralEntityIfExists(request, superToken, '/api/directory/organizations', foreignOrgId);
+    await deleteGeneralEntityIfExists(request, superToken, '/api/directory/tenants', foreignTenantId);
+  });
+
+  test('superadmin can see the foreign-tenant organization (fixture sanity)', async ({ request }) => {
+    const res = await apiRequest(
+      request,
+      'GET',
+      `/api/directory/organizations?view=manage&tenantId=${encodeURIComponent(foreignTenantId!)}&ids=${encodeURIComponent(foreignOrgId!)}`,
+      { token: superToken! },
+    );
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { items?: Array<{ id?: string }> };
+    const ids = (body.items ?? []).map((item) => item.id);
+    expect(ids, 'superadmin should resolve the foreign org within its tenant').toContain(foreignOrgId);
+  });
+
+  test('admin requesting the foreign tenant never receives foreign-tenant organizations', async ({ request }) => {
+    const res = await apiRequest(
+      request,
+      'GET',
+      `/api/directory/organizations?view=manage&tenantId=${encodeURIComponent(foreignTenantId!)}`,
+      { token: adminToken! },
+    );
+    // Either a hard scope rejection (400/403) or a silent down-scope to the admin's own tenant (200).
+    expect([200, 400, 403], `unexpected status ${res.status()}`).toContain(res.status());
+    if (res.status() === 200) {
+      const body = (await res.json()) as { items?: Array<{ id?: string; tenantId?: string | null }> };
+      const ids = (body.items ?? []).map((item) => item.id);
+      expect(ids, 'foreign-tenant org must not leak to a non-member admin').not.toContain(foreignOrgId);
+      for (const item of body.items ?? []) {
+        expect(item.tenantId, 'no item may belong to the foreign tenant').not.toBe(foreignTenantId);
+      }
+    }
+  });
+
+  test('admin reading its own tenant gets only its own organizations', async ({ request }) => {
+    const res = await apiRequest(
+      request,
+      'GET',
+      `/api/directory/organizations?view=manage&tenantId=${encodeURIComponent(ownTenantId)}`,
+      { token: adminToken! },
+    );
+    expect(res.status(), 'admin should read its own tenant').toBe(200);
+    const body = (await res.json()) as { items?: Array<{ id?: string; tenantId?: string | null }> };
+    const ids = (body.items ?? []).map((item) => item.id);
+    expect(ids, 'foreign-tenant org must not appear in the own-tenant listing').not.toContain(foreignOrgId);
+    for (const item of body.items ?? []) {
+      expect(item.tenantId, 'every returned org should belong to the admin tenant').toBe(ownTenantId);
+    }
+  });
+});

--- a/packages/core/src/modules/directory/__integration__/TC-DIR-012.spec.ts
+++ b/packages/core/src/modules/directory/__integration__/TC-DIR-012.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { deleteGeneralEntityIfExists } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+/**
+ * TC-DIR-012: Organization slug uniqueness is enforced within a tenant
+ * Covers: POST /api/directory/organizations
+ *
+ * Slug uniqueness per tenant is backed by the DB constraint `organizations_tenant_slug_uniq`
+ * on (tenant_id, slug). The create command does NOT reject a colliding slug — it calls
+ * `resolveUniqueSlug`, which auto-suffixes (`-1`, `-2`, ...) so the second create succeeds with
+ * a distinct slug. The same slug is therefore unique *within* a tenant but allowed *across*
+ * tenants. This test documents that contract: a same-tenant duplicate yields two organizations
+ * with distinct slugs (no rejection), and the identical slug is accepted verbatim in another tenant.
+ */
+type ManageItem = { id?: string; slug?: string | null };
+
+async function fetchOrgSlugs(
+  request: import('@playwright/test').APIRequestContext,
+  token: string,
+  tenantId: string,
+  ids: string[],
+): Promise<Map<string, string | null>> {
+  const res = await apiRequest(
+    request,
+    'GET',
+    `/api/directory/organizations?view=manage&tenantId=${encodeURIComponent(tenantId)}&ids=${encodeURIComponent(ids.join(','))}`,
+    { token },
+  );
+  expect(res.status(), 'manage list should return 200').toBe(200);
+  const body = (await res.json()) as { items?: ManageItem[] };
+  const map = new Map<string, string | null>();
+  for (const item of body.items ?? []) {
+    if (item.id) map.set(item.id, item.slug ?? null);
+  }
+  return map;
+}
+
+test.describe('TC-DIR-012: Organization slug uniqueness within a tenant', () => {
+  let superToken: string | null = null;
+  let tenantA: string | null = null;
+  let tenantB: string | null = null;
+  const orgIds: string[] = [];
+  const stamp = Date.now();
+  const slug = `dir-012-${stamp}`;
+
+  test.beforeAll(async ({ request }) => {
+    superToken = await getAuthToken(request, 'superadmin');
+    const tenantARes = await apiRequest(request, 'POST', '/api/directory/tenants', {
+      token: superToken,
+      data: { name: `QA TC-DIR-012 A ${stamp}` },
+    });
+    expect(tenantARes.status()).toBe(201);
+    tenantA = ((await tenantARes.json()) as { id?: string }).id ?? null;
+    expect(tenantA).toBeTruthy();
+
+    const tenantBRes = await apiRequest(request, 'POST', '/api/directory/tenants', {
+      token: superToken,
+      data: { name: `QA TC-DIR-012 B ${stamp}` },
+    });
+    expect(tenantBRes.status()).toBe(201);
+    tenantB = ((await tenantBRes.json()) as { id?: string }).id ?? null;
+    expect(tenantB).toBeTruthy();
+  });
+
+  test.afterAll(async ({ request }) => {
+    for (const id of orgIds) {
+      await deleteGeneralEntityIfExists(request, superToken, '/api/directory/organizations', id);
+    }
+    await deleteGeneralEntityIfExists(request, superToken, '/api/directory/tenants', tenantA);
+    await deleteGeneralEntityIfExists(request, superToken, '/api/directory/tenants', tenantB);
+  });
+
+  test('a duplicate slug in the same tenant is auto-resolved, not rejected', async ({ request }) => {
+    const firstRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      token: superToken!,
+      data: { name: `QA TC-DIR-012 A1 ${stamp}`, slug, tenantId: tenantA },
+    });
+    expect(firstRes.status(), 'first org with the slug should be created').toBe(201);
+    const firstId = ((await firstRes.json()) as { id?: string }).id!;
+    expect(firstId).toBeTruthy();
+    orgIds.push(firstId);
+
+    const secondRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      token: superToken!,
+      data: { name: `QA TC-DIR-012 A2 ${stamp}`, slug, tenantId: tenantA },
+    });
+    expect(secondRes.status(), 'duplicate slug in the same tenant should NOT be rejected').toBe(201);
+    const secondId = ((await secondRes.json()) as { id?: string }).id!;
+    expect(secondId).toBeTruthy();
+    orgIds.push(secondId);
+
+    const slugs = await fetchOrgSlugs(request, superToken!, tenantA!, [firstId, secondId]);
+    expect(slugs.get(firstId), 'the first org should keep the requested slug').toBe(slug);
+    expect(slugs.get(secondId), 'the second org should receive an auto-resolved slug').toBeTruthy();
+    expect(
+      slugs.get(secondId),
+      'the auto-resolved slug must differ from the original',
+    ).not.toBe(slug);
+  });
+
+  test('the same slug is allowed verbatim in a different tenant', async ({ request }) => {
+    const res = await apiRequest(request, 'POST', '/api/directory/organizations', {
+      token: superToken!,
+      data: { name: `QA TC-DIR-012 B1 ${stamp}`, slug, tenantId: tenantB },
+    });
+    expect(res.status(), 'the same slug should be accepted in another tenant').toBe(201);
+    const id = ((await res.json()) as { id?: string }).id!;
+    expect(id).toBeTruthy();
+    orgIds.push(id);
+
+    const slugs = await fetchOrgSlugs(request, superToken!, tenantB!, [id]);
+    expect(slugs.get(id), 'the slug should be stored verbatim in the other tenant').toBe(slug);
+  });
+});


### PR DESCRIPTION
## Summary

Expands integration-test coverage for the `directory` module (issue #2480) with seven new
executable Playwright specs (TC-DIR-006..012) covering previously untested stable surfaces:
RBAC write-denial, the public organization/tenant lookup endpoints, create-time validation,
cross-tenant read isolation, and slug uniqueness. No product code changes — the tests assert
the module's current, empirically verified behavior. Two scenarios diverge from the issue's
proposed status codes because the issue's assumptions did not match the implementation; the
specs document the real contract.

## Changes

- `TC-DIR-006` — employee (no `directory.*.manage` by default) → 403 on POST/PUT/DELETE for both organizations and tenants; verifies the superadmin-owned fixtures are left unmutated.
- `TC-DIR-007` — public `GET /api/directory/organizations/lookup` (unauthenticated): known slug → 200 with `{id,name,slug,tenantId}`, unknown slug → 404, empty slug → 400.
- `TC-DIR-008` — public `GET /api/directory/tenants/lookup` (unauthenticated): known tenantId → 200, malformed (non-UUID) → 400, well-formed-but-unknown → 404.
- `TC-DIR-009` — org create slug constraints: internal space → 400, special char → 400, valid → 201; uppercase is normalized to lowercase and accepted (201), not rejected (the `slug` field applies `.trim().toLowerCase()` before its regex).
- `TC-DIR-010` — tenant create name constraints: empty → 400, >200 chars → 400, valid → 201.
- `TC-DIR-011` — cross-tenant organization read isolation: a non-member admin never receives a foreign tenant's organizations (strict no-leak invariant); own-tenant read returns only own-tenant orgs.
- `TC-DIR-012` — org slug uniqueness within a tenant is enforced by auto-resolution (`resolveUniqueSlug` suffixes `-1`), so a same-tenant duplicate is accepted (201) with a distinct slug rather than rejected; the same slug is allowed verbatim in a different tenant.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test-coverage task driven by issue #2480 (auto-generated coverage-gap analysis); no `.ai/specs/` spec applies. Conventions per `.ai/qa/AGENTS.md`.

## Testing

- `BASE_URL=http://127.0.0.1:5001 ENABLE_CRUD_API_CACHE=true npx playwright test --config .ai/qa/tests/playwright.config.ts <TC-DIR-006..012> --workers=1` against an ephemeral seeded app → **21 passed**.
- Re-run with `--retries=1` after a prior create/delete cycle → **21 passed** (idempotent, fixtures cleaned up in `afterAll`).
- `yarn turbo run typecheck --filter=@open-mercato/core` → **successful** (type-checks the `__integration__` specs).
- jest / `build:app` / i18n checks: not applicable (Playwright specs, no product code, no user-facing strings); core has no lint gate.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. — N/A; test-only change.
- [x] I added or adjusted tests that cover the change. — the change *is* the tests.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — placed in the module's `__integration__/` folder (the canonical location per `.ai/qa/AGENTS.md`; `.ai/qa/tests/` holds only the shared Playwright config).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A; no spec for this test-coverage task.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI (API/integration-test-only change)
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2480