### PR TITLE
fix(checkout): template/pay-link edit no longer 400s when gatewayProviderKey is null (#2505)

### DIFF
--- a/packages/checkout/src/modules/checkout/__integration__/TC-CHKT-039-null-gateway-edit.spec.ts
+++ b/packages/checkout/src/modules/checkout/__integration__/TC-CHKT-039-null-gateway-edit.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import {
+  createFixedTemplateInput,
+  createLinkFixture,
+  createTemplateFixture,
+  deleteCheckoutEntityIfExists,
+  readLink,
+  readTemplate,
+  updateLink,
+  updateTemplate,
+} from './helpers/fixtures'
+
+test.describe('TC-CHKT-039: Draft template/pay-link edits tolerate a null gateway provider (issue #2505)', () => {
+  test('template: clearing the gateway provider on a draft saves and round-trips as null', async ({ request }) => {
+    let token: string | null = null
+    let templateId: string | null = null
+
+    try {
+      token = await getAuthToken(request)
+      templateId = await createTemplateFixture(request, token, createFixedTemplateInput({ status: 'draft' }))
+
+      const clearResponse = await updateTemplate(request, token, templateId, {
+        name: 'Consulting Fee (no gateway)',
+        pricingMode: 'fixed',
+        fixedPriceAmount: 49.99,
+        fixedPriceCurrencyCode: 'USD',
+        status: 'draft',
+        gatewayProviderKey: null,
+      })
+      expect(
+        clearResponse.ok(),
+        `Clearing the gateway on a draft template should succeed: ${clearResponse.status()} ${JSON.stringify(await readJsonSafe(clearResponse))}`,
+      ).toBeTruthy()
+
+      const cleared = await readTemplate(request, token, templateId)
+      expect(cleared.gatewayProviderKey ?? null).toBeNull()
+      expect(cleared.name).toBe('Consulting Fee (no gateway)')
+
+      const renameResponse = await updateTemplate(request, token, templateId, {
+        name: 'Consulting Fee renamed',
+        gatewayProviderKey: null,
+      })
+      expect(
+        renameResponse.ok(),
+        `Editing a field on a gateway-less draft template should succeed: ${renameResponse.status()} ${JSON.stringify(await readJsonSafe(renameResponse))}`,
+      ).toBeTruthy()
+
+      const renamed = await readTemplate(request, token, templateId)
+      expect(renamed.gatewayProviderKey ?? null).toBeNull()
+      expect(renamed.name).toBe('Consulting Fee renamed')
+
+      const blankResponse = await updateTemplate(request, token, templateId, {
+        gatewayProviderKey: '   ',
+      })
+      expect(
+        blankResponse.ok(),
+        `A blank gateway should normalize to null on a draft template: ${blankResponse.status()} ${JSON.stringify(await readJsonSafe(blankResponse))}`,
+      ).toBeTruthy()
+
+      const blanked = await readTemplate(request, token, templateId)
+      expect(blanked.gatewayProviderKey ?? null).toBeNull()
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'templates', templateId)
+    }
+  })
+
+  test('pay-link: clearing the gateway provider on a draft saves and round-trips as null', async ({ request }) => {
+    let token: string | null = null
+    let linkId: string | null = null
+
+    try {
+      token = await getAuthToken(request)
+      const link = await createLinkFixture(request, token, createFixedTemplateInput({ status: 'draft' }))
+      linkId = link.id
+
+      const clearResponse = await updateLink(request, token, link.id, {
+        name: 'Pay link (no gateway)',
+        pricingMode: 'fixed',
+        fixedPriceAmount: 49.99,
+        fixedPriceCurrencyCode: 'USD',
+        status: 'draft',
+        gatewayProviderKey: null,
+      })
+      expect(
+        clearResponse.ok(),
+        `Clearing the gateway on a draft pay-link should succeed: ${clearResponse.status()} ${JSON.stringify(await readJsonSafe(clearResponse))}`,
+      ).toBeTruthy()
+
+      const cleared = await readLink(request, token, link.id)
+      expect(cleared.gatewayProviderKey ?? null).toBeNull()
+      expect(cleared.name).toBe('Pay link (no gateway)')
+
+      const renameResponse = await updateLink(request, token, link.id, {
+        name: 'Pay link renamed',
+        gatewayProviderKey: null,
+      })
+      expect(
+        renameResponse.ok(),
+        `Editing a field on a gateway-less draft pay-link should succeed: ${renameResponse.status()} ${JSON.stringify(await readJsonSafe(renameResponse))}`,
+      ).toBeTruthy()
+
+      const renamed = await readLink(request, token, link.id)
+      expect(renamed.gatewayProviderKey ?? null).toBeNull()
+      expect(renamed.name).toBe('Pay link renamed')
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'links', linkId)
+    }
+  })
+
+  test('pay-link: publishing still requires a gateway provider', async ({ request }) => {
+    let token: string | null = null
+    let linkId: string | null = null
+
+    try {
+      token = await getAuthToken(request)
+      const link = await createLinkFixture(request, token, createFixedTemplateInput({ status: 'draft' }))
+      linkId = link.id
+
+      const publishResponse = await updateLink(request, token, link.id, {
+        status: 'active',
+        gatewayProviderKey: null,
+      })
+      expect([400, 422]).toContain(publishResponse.status())
+      const body = await readJsonSafe<{ error?: string; fieldErrors?: { gatewayProviderKey?: string } }>(publishResponse)
+      const fieldError = typeof body?.fieldErrors?.gatewayProviderKey === 'string' ? body.fieldErrors.gatewayProviderKey : ''
+      const errorMessage = typeof body?.error === 'string' ? body.error : ''
+      expect(`${fieldError} ${errorMessage}`.toLowerCase()).toContain('gateway')
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'links', linkId)
+    }
+  })
+})

--- a/packages/checkout/src/modules/checkout/components/LinkTemplateForm.tsx
+++ b/packages/checkout/src/modules/checkout/components/LinkTemplateForm.tsx
@@ -260,6 +260,7 @@ function normalizeFormValues(value: FormValues | null | undefined, t?: Translate
     primaryColor: readString(source.primaryColor).trim() || defaults.primaryColor,
     secondaryColor: readString(source.secondaryColor).trim() || defaults.secondaryColor,
     backgroundColor: readString(source.backgroundColor).trim() || defaults.backgroundColor,
+    gatewayProviderKey: readString(source.gatewayProviderKey).trim(),
     gatewaySettings: isRecord(source.gatewaySettings) ? source.gatewaySettings : {},
     customFieldsetCode: readString(source.customFieldsetCode).trim() || null,
     collectCustomerDetails: readBoolean(source.collectCustomerDetails, true),

--- a/packages/checkout/src/modules/checkout/data/__tests__/validators.test.ts
+++ b/packages/checkout/src/modules/checkout/data/__tests__/validators.test.ts
@@ -1,4 +1,11 @@
-import { createLinkSchema, createTemplateSchema } from '../validators'
+import {
+  createLinkSchema,
+  createTemplateSchema,
+  updateLinkSchema,
+  updateTemplateSchema,
+} from '../validators'
+
+const TEMPLATE_ID = '020b29c5-db01-4ee3-8080-1d9b185c5e29'
 
 describe('checkout validators', () => {
   test('createTemplateSchema accepts payloads that omit optional normalized fields', () => {
@@ -43,5 +50,56 @@ describe('checkout validators', () => {
 
     expect(result.slug).toBeNull()
     expect(result.password).toBeNull()
+  })
+
+  test('updateTemplateSchema accepts a null gatewayProviderKey (issue #2505)', () => {
+    const result = updateTemplateSchema.parse({
+      id: TEMPLATE_ID,
+      name: 'Consulting Fee',
+      pricingMode: 'fixed',
+      fixedPriceAmount: 49.99,
+      fixedPriceCurrencyCode: 'USD',
+      gatewayProviderKey: null,
+    })
+
+    expect(result.gatewayProviderKey).toBeNull()
+  })
+
+  test('updateTemplateSchema normalizes a blank gatewayProviderKey to null (issue #2505)', () => {
+    const result = updateTemplateSchema.parse({
+      id: TEMPLATE_ID,
+      name: 'Consulting Fee',
+      pricingMode: 'fixed',
+      fixedPriceAmount: 49.99,
+      fixedPriceCurrencyCode: 'USD',
+      gatewayProviderKey: '   ',
+    })
+
+    expect(result.gatewayProviderKey).toBeNull()
+  })
+
+  test('updateLinkSchema accepts a null gatewayProviderKey (issue #2505)', () => {
+    const result = updateLinkSchema.parse({
+      id: TEMPLATE_ID,
+      name: 'Consulting Fee link',
+      pricingMode: 'fixed',
+      fixedPriceAmount: 49.99,
+      fixedPriceCurrencyCode: 'USD',
+      gatewayProviderKey: null,
+    })
+
+    expect(result.gatewayProviderKey).toBeNull()
+  })
+
+  test('createTemplateSchema still rejects a null gatewayProviderKey', () => {
+    expect(() =>
+      createTemplateSchema.parse({
+        name: 'QA template',
+        pricingMode: 'fixed',
+        fixedPriceAmount: 49.99,
+        fixedPriceCurrencyCode: 'USD',
+        gatewayProviderKey: null,
+      }),
+    ).toThrow()
   })
 })

--- a/packages/checkout/src/modules/checkout/data/validators.ts
+++ b/packages/checkout/src/modules/checkout/data/validators.ts
@@ -109,7 +109,7 @@ const checkoutContentSchema = z.object({
   customAmountMax: positiveMoneySchema.optional().nullable(),
   customAmountCurrencyCode: currencyCodeSchema.optional().nullable(),
   priceListItems: z.array(priceListItemSchema).optional().nullable(),
-  gatewayProviderKey: requiredTrimmedString('checkout.validation.gatewayProviderKey.required'),
+  gatewayProviderKey: optionalTrimmedString,
   gatewaySettings: gatewaySettingsSchema,
   customFieldsetCode: optionalFieldsetCodeSchema,
   collectCustomerDetails: z.boolean().default(true),
@@ -174,7 +174,16 @@ function validatePricingConsistency<T extends z.infer<typeof checkoutContentSche
   }
 }
 
-export const createTemplateSchema = checkoutContentSchema.superRefine(validatePricingConsistency)
+export const createTemplateSchema = checkoutContentSchema.superRefine((value, ctx) => {
+  validatePricingConsistency(value, ctx)
+  if (!value.gatewayProviderKey) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'checkout.validation.gatewayProviderKey.required',
+      path: ['gatewayProviderKey'],
+    })
+  }
+})
 
 function applyPartialPricingConsistency(value: Record<string, unknown>, ctx: z.RefinementCtx) {
   if (!value.pricingMode) return


### PR DESCRIPTION
Fixes #2505

## Problem
A checkout **payment-link template** (and **pay-link**) with `gatewayProviderKey = null` loaded fine but could not be re-saved. Editing any field → Save → `PUT` returned **400** `{"fieldErrors":{"gatewayProviderKey":"Invalid input: expected string, received null"}}`. The failure was **silent** (console error only — no toast, no visible field error), so the user's edits were lost without explanation. Affected **both** `/api/checkout/templates/{id}` and `/api/checkout/links/{id}`.

## Root Cause
Schema asymmetry — the UPDATE path rejected a `null` that the DB, create command, and update command all tolerate:
- DB column `gateway_provider_key` is `nullable: true`; the command layer already does `gatewayProviderKey ?? null`.
- But the base validator declared `gatewayProviderKey` as a **required, non-nullable** string. `updateTemplateSchema` / `updateLinkSchema` are derived via `.partial()`, which adds `undefined` to the union **but not `null`** — so a legitimately gateway-less record failed to re-save.

## What Changed
- **`data/validators.ts`** — base `gatewayProviderKey` is now `optionalTrimmedString` (nullable), matching the DB + command tolerance. Both update schemas inherit this directly (no per-schema override, which conflicted with `safeExtend`).
- **`data/validators.ts`** — `createTemplateSchema` (and `createLinkSchema` via it) now enforces a non-empty gateway through an explicit refinement, so the **create** contract is unchanged.
- **`components/LinkTemplateForm.tsx`** — normalize the loaded `gatewayProviderKey` to a trimmed string so the empty select round-trips as `''` (normalized back to `null` server-side) instead of PUTing a raw `null`.

"Publish requires a gateway" is **unchanged** — it is enforced in the command layer, so publishing a gateway-less link still fails with `422`.

## Tests
- **Unit** (`data/__tests__/validators.test.ts`): update schemas accept `null` / blank gateway and normalize to `null`; create schema still rejects a `null` gateway.
- **Integration** (`__integration__/TC-CHKT-039-null-gateway-edit.spec.ts`): draft template & pay-link edits with a null gateway save and round-trip as `null`; editing further fields keeps working; publishing still requires a gateway.
- Full checkout integration suite re-run green (44 passed, 1 conditional skip); full monorepo `typecheck` green.
- **Browser-verified**: opened a template with a null gateway, edited the name, Saved → `flash=Saved&type=success`, edit persisted with `gatewayProviderKey` still `null` (previously a silent 400).

## Backward Compatibility
- No API response fields, event IDs, ACL features, DI names, routes, or import paths changed.
- UPDATE validation is **loosened** (now accepts `null`); CREATE keeps requiring a gateway. The `CreateTemplateInput['gatewayProviderKey']` input type widens from `string` to `string | null | undefined` — additive for callers passing valid data.

Part of umbrella #2466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)