### PR TITLE
feat: 2479 inbox ops integration coverage

### DIFF
--- a/packages/core/src/helpers/integration/inboxFixtures.ts
+++ b/packages/core/src/helpers/integration/inboxFixtures.ts
@@ -92,3 +92,39 @@ export async function listInboxProposals(
   const body = await readJsonSafe<{ items?: Array<Record<string, unknown>>; total?: number }>(response);
   return { items: body?.items ?? [], total: body?.total ?? 0 };
 }
+
+export type InboxProposalActionDetail = {
+  id: string;
+  actionType: string;
+  status: string;
+  payload: Record<string, unknown>;
+  description?: string;
+  createdEntityId?: string | null;
+  createdEntityType?: string | null;
+};
+
+export type InboxProposalDetail = {
+  id: string;
+  status: string;
+  category?: string | null;
+  workingLanguage?: string | null;
+  isActive?: boolean;
+  actions: InboxProposalActionDetail[];
+};
+
+export async function fetchProposalDetail(
+  request: APIRequestContext,
+  token: string,
+  proposalId: string,
+): Promise<InboxProposalDetail | null> {
+  const response = await apiRequest(request, 'GET', `/api/inbox_ops/proposals/${proposalId}`, { token });
+  if (!response.ok()) return null;
+  const body = await readJsonSafe<{ proposal?: InboxProposalDetail }>(response);
+  return body?.proposal ?? null;
+}
+
+export function findPendingAction(
+  actions: InboxProposalActionDetail[],
+): InboxProposalActionDetail | null {
+  return actions.find((action) => action.status === 'pending') ?? actions[0] ?? null;
+}

--- a/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-003.spec.ts
+++ b/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-003.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
+import {
+  submitTextExtraction,
+  waitForEmailProcessed,
+  deleteInboxEmail,
+  fetchProposalDetail,
+  findPendingAction,
+} from '@open-mercato/core/modules/core/__integration__/helpers/inboxFixtures';
+
+/**
+ * TC-INBOX-003: Single Action Accept — API execution and entity creation
+ * Source: GitHub issue #2479 (inbox_ops integration coverage)
+ *
+ * Accepting a pending action executes it in the target module: the action
+ * transitions to `executed`, optionally records the created entity, and the
+ * proposal status is recalculated. Asserts only invariants that hold across
+ * LLM-derived action types (the concrete action set is non-deterministic).
+ *
+ * Extraction requires a configured LLM provider. When none is available the
+ * worker marks the email `failed`; the execution assertions are then skipped,
+ * matching the established TC-INBOX-P2-* pattern.
+ */
+test.describe('TC-INBOX-003: Single Action Accept', () => {
+  let token: string;
+  const createdEmailIds: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    test.setTimeout(90000);
+    token = await getAuthToken(request, 'admin');
+  });
+
+  test.afterAll(async ({ request }) => {
+    for (const emailId of createdEmailIds) {
+      await deleteInboxEmail(request, token, emailId);
+    }
+  });
+
+  test('accepting a pending action executes it and updates the proposal', async ({ request }) => {
+    test.setTimeout(75000);
+
+    const result = await submitTextExtraction(request, token, {
+      text: [
+        'From: Giulia Bianchi <giulia@bianchi-forniture.it>',
+        'Subject: Order PO-TC003',
+        '',
+        'Hello,',
+        'Please process this order:',
+        '- 8x Steel Bracket SB-12 at $14.00 each',
+        '- 4x Mounting Plate MP-30 at $22.00 each',
+        '',
+        'Customer reference: PO-TC003',
+        'Ship to: Via Verdi 9, 20121 Milano, Italy',
+        '',
+        'Thanks,',
+        'Giulia Bianchi',
+      ].join('\n'),
+      title: 'TC-INBOX-003 accept action fixture',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.emailId).toBeTruthy();
+    if (result.emailId) createdEmailIds.push(result.emailId);
+
+    const processed = await waitForEmailProcessed(request, token, result.emailId!, 45000);
+    expect(processed).toBeTruthy();
+    if (!processed || processed.status === 'failed' || !processed.proposalId) {
+      test.skip(true, 'LLM extraction unavailable (no API key configured)');
+      return;
+    }
+
+    const proposalId = processed.proposalId;
+    const detail = await fetchProposalDetail(request, token, proposalId);
+    expect(detail).toBeTruthy();
+    const action = findPendingAction(detail!.actions);
+    expect(action, 'proposal should expose at least one pending action').toBeTruthy();
+
+    const acceptResponse = await apiRequest(
+      request,
+      'POST',
+      `/api/inbox_ops/proposals/${proposalId}/actions/${action!.id}/accept`,
+      { token },
+    );
+    expect(acceptResponse.status()).toBe(200);
+    const acceptBody = await readJsonSafe<{
+      ok: boolean;
+      action: { id: string; status: string; createdEntityId: string | null; createdEntityType: string | null } | null;
+      proposal: { id: string; status: string } | null;
+    }>(acceptResponse);
+
+    expect(acceptBody?.ok).toBe(true);
+    expect(acceptBody?.action?.id).toBe(action!.id);
+    expect(acceptBody?.action?.status).toBe('executed');
+    // createdEntityId/createdEntityType depend on the action type; when set they must be non-empty.
+    if (acceptBody?.action?.createdEntityId != null) {
+      expect(typeof acceptBody.action.createdEntityId).toBe('string');
+      expect(acceptBody.action.createdEntityId.length).toBeGreaterThan(0);
+      expect(typeof acceptBody.action.createdEntityType).toBe('string');
+      expect((acceptBody.action.createdEntityType as string).length).toBeGreaterThan(0);
+    }
+    // After a successful single-action accept the proposal is no longer fully pending.
+    expect(['partial', 'accepted']).toContain(acceptBody?.proposal?.status);
+
+    // The undo header is present only for command-backed actions; assert shape when present.
+    const operationHeader = acceptResponse.headers()['x-om-operation'];
+    if (operationHeader) {
+      expect(operationHeader.length).toBeGreaterThan(0);
+    }
+
+    // Re-read the proposal: the accepted action is now executed.
+    const afterDetail = await fetchProposalDetail(request, token, proposalId);
+    expect(afterDetail).toBeTruthy();
+    const afterAction = afterDetail!.actions.find((candidate) => candidate.id === action!.id);
+    expect(afterAction?.status).toBe('executed');
+
+    // Counts endpoint remains well-formed after acceptance (no global delta assertions —
+    // counts are tenant-wide and other parallel specs mutate them).
+    const countsResponse = await apiRequest(request, 'GET', '/api/inbox_ops/proposals/counts', { token });
+    expect(countsResponse.status()).toBe(200);
+    const counts = await readJsonSafe<{ pending: number; accepted: number; partial: number; rejected: number }>(countsResponse);
+    expect(typeof counts?.pending).toBe('number');
+    expect(typeof counts?.accepted).toBe('number');
+  });
+});

--- a/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-004.spec.ts
+++ b/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-004.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
+import {
+  submitTextExtraction,
+  waitForEmailProcessed,
+  deleteInboxEmail,
+  fetchProposalDetail,
+  findPendingAction,
+} from '@open-mercato/core/modules/core/__integration__/helpers/inboxFixtures';
+
+/**
+ * TC-INBOX-004: Action Already Processed — 409 on retry accept/reject
+ * Source: GitHub issue #2479 (inbox_ops integration coverage)
+ *
+ * Accepting an action is idempotency-guarded: a second accept, and a reject of
+ * an already-executed action, both return 409 "Action already processed" and
+ * leave the action in `executed` state. LLM-gated like the other proposal flows.
+ */
+test.describe('TC-INBOX-004: Action Already Processed (409)', () => {
+  let token: string;
+  const createdEmailIds: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    test.setTimeout(90000);
+    token = await getAuthToken(request, 'admin');
+  });
+
+  test.afterAll(async ({ request }) => {
+    for (const emailId of createdEmailIds) {
+      await deleteInboxEmail(request, token, emailId);
+    }
+  });
+
+  test('a processed action rejects repeated accept and reject with 409', async ({ request }) => {
+    test.setTimeout(75000);
+
+    const result = await submitTextExtraction(request, token, {
+      text: [
+        'From: Tomas Novak <tomas@novak-trade.cz>',
+        'Subject: Order PO-TC004',
+        '',
+        'Hi,',
+        'Please place this order:',
+        '- 12x Cable Tie CT-200 at $3.50 each',
+        '',
+        'Customer reference: PO-TC004',
+        '',
+        'Regards,',
+        'Tomas Novak',
+      ].join('\n'),
+      title: 'TC-INBOX-004 already-processed fixture',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.emailId) createdEmailIds.push(result.emailId);
+
+    const processed = await waitForEmailProcessed(request, token, result.emailId!, 45000);
+    if (!processed || processed.status === 'failed' || !processed.proposalId) {
+      test.skip(true, 'LLM extraction unavailable (no API key configured)');
+      return;
+    }
+
+    const proposalId = processed.proposalId;
+    const detail = await fetchProposalDetail(request, token, proposalId);
+    const action = findPendingAction(detail?.actions ?? []);
+    expect(action, 'proposal should expose at least one pending action').toBeTruthy();
+    const actionPath = `/api/inbox_ops/proposals/${proposalId}/actions/${action!.id}`;
+
+    // First accept succeeds.
+    const firstAccept = await apiRequest(request, 'POST', `${actionPath}/accept`, { token });
+    expect(firstAccept.status()).toBe(200);
+    const firstBody = await readJsonSafe<{ ok: boolean; action: { status: string } | null }>(firstAccept);
+    expect(firstBody?.ok).toBe(true);
+    expect(firstBody?.action?.status).toBe('executed');
+
+    // Second accept of the same action is rejected as already processed.
+    const secondAccept = await apiRequest(request, 'POST', `${actionPath}/accept`, { token });
+    expect(secondAccept.status()).toBe(409);
+    const secondBody = await readJsonSafe<{ error?: string }>(secondAccept);
+    expect(secondBody?.error ?? '').toMatch(/already processed/i);
+
+    // Rejecting an already-executed action is also a 409.
+    const rejectAfterAccept = await apiRequest(request, 'POST', `${actionPath}/reject`, { token });
+    expect(rejectAfterAccept.status()).toBe(409);
+    const rejectBody = await readJsonSafe<{ error?: string }>(rejectAfterAccept);
+    expect(rejectBody?.error ?? '').toMatch(/already processed/i);
+
+    // The action remains executed — retries did not mutate it.
+    const afterDetail = await fetchProposalDetail(request, token, proposalId);
+    const afterAction = afterDetail?.actions.find((candidate) => candidate.id === action!.id);
+    expect(afterAction?.status).toBe('executed');
+  });
+});

--- a/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-005.spec.ts
+++ b/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-005.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from '@playwright/test';
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
+import {
+  submitTextExtraction,
+  waitForEmailProcessed,
+  deleteInboxEmail,
+  fetchProposalDetail,
+  findPendingAction,
+} from '@open-mercato/core/modules/core/__integration__/helpers/inboxFixtures';
+
+/**
+ * TC-INBOX-005: Edit Action Payload — PATCH before acceptance
+ * Source: GitHub issue #2479 (inbox_ops integration coverage)
+ *
+ * PATCH deep-merges the supplied payload onto the action and re-validates it for
+ * the action type. Validation (400) and not-found (404) are exercised without an
+ * LLM (the body is validated before the action lookup); the merge/persist and the
+ * edit-after-execute 409 guard run when extraction produces a real action.
+ */
+test.describe('TC-INBOX-005: Edit Action Payload', () => {
+  const FAKE_ID = '00000000-0000-4000-8000-000000000000';
+  let token: string;
+  const createdEmailIds: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    test.setTimeout(90000);
+    token = await getAuthToken(request, 'admin');
+  });
+
+  test.afterAll(async ({ request }) => {
+    for (const emailId of createdEmailIds) {
+      await deleteInboxEmail(request, token, emailId);
+    }
+  });
+
+  test('rejects a malformed edit body with 400', async ({ request }) => {
+    const response = await apiRequest(
+      request,
+      'PATCH',
+      `/api/inbox_ops/proposals/${FAKE_ID}/actions/${FAKE_ID}`,
+      { token, data: {} },
+    );
+    expect(response.status()).toBe(400);
+    const body = await readJsonSafe<{ error?: string }>(response);
+    expect(body?.error ?? '').toMatch(/invalid payload/i);
+  });
+
+  test('returns 404 when editing a non-existent action', async ({ request }) => {
+    const response = await apiRequest(
+      request,
+      'PATCH',
+      `/api/inbox_ops/proposals/${FAKE_ID}/actions/${FAKE_ID}`,
+      { token, data: { payload: {} } },
+    );
+    expect(response.status()).toBe(404);
+    const body = await readJsonSafe<{ error?: string }>(response);
+    expect(body?.error ?? '').toMatch(/not found/i);
+  });
+
+  test('merges and persists a payload edit, then blocks editing after execution', async ({ request }) => {
+    test.setTimeout(75000);
+
+    const result = await submitTextExtraction(request, token, {
+      text: [
+        'From: Lena Schäfer <lena@schaefer-handel.de>',
+        'Subject: Order PO-TC005',
+        '',
+        'Hello,',
+        'Order request:',
+        '- 6x Hinge Set HS-9 at $9.00 each',
+        '',
+        'Customer reference: PO-TC005',
+        '',
+        'Best,',
+        'Lena Schäfer',
+      ].join('\n'),
+      title: 'TC-INBOX-005 edit fixture',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.emailId) createdEmailIds.push(result.emailId);
+
+    const processed = await waitForEmailProcessed(request, token, result.emailId!, 45000);
+    if (!processed || processed.status === 'failed' || !processed.proposalId) {
+      test.skip(true, 'LLM extraction unavailable (no API key configured)');
+      return;
+    }
+
+    const proposalId = processed.proposalId;
+    const detail = await fetchProposalDetail(request, token, proposalId);
+    const action = findPendingAction(detail?.actions ?? []);
+    expect(action, 'proposal should expose at least one pending action').toBeTruthy();
+    const originalKeys = Object.keys(action!.payload ?? {});
+    const actionPath = `/api/inbox_ops/proposals/${proposalId}/actions/${action!.id}`;
+
+    // An unknown marker key survives the deep merge (action schemas are non-strict,
+    // so it is stripped at validation time but persisted on the stored payload).
+    const markerKey = '__tcInbox005Marker';
+    const markerValue = `edited-${processed.proposalId}`;
+    const editResponse = await apiRequest(request, 'PATCH', actionPath, {
+      token,
+      data: { payload: { [markerKey]: markerValue } },
+    });
+    expect(editResponse.status()).toBe(200);
+    const editBody = await readJsonSafe<{ ok: boolean; action: { status: string; payload: Record<string, unknown> } }>(editResponse);
+    expect(editBody?.ok).toBe(true);
+    expect(editBody?.action?.status).toBe('pending');
+    expect(editBody?.action?.payload?.[markerKey]).toBe(markerValue);
+    // Existing payload keys are preserved by the merge.
+    for (const key of originalKeys) {
+      expect(editBody?.action?.payload).toHaveProperty(key);
+    }
+
+    // Edit persists across a fresh read.
+    const afterEdit = await fetchProposalDetail(request, token, proposalId);
+    const editedAction = afterEdit?.actions.find((candidate) => candidate.id === action!.id);
+    expect(editedAction?.payload?.[markerKey]).toBe(markerValue);
+
+    // The edited action still executes; afterwards a further edit is a 409.
+    const acceptResponse = await apiRequest(request, 'POST', `${actionPath}/accept`, { token });
+    expect(acceptResponse.status()).toBe(200);
+
+    const editAfterAccept = await apiRequest(request, 'PATCH', actionPath, {
+      token,
+      data: { payload: { [markerKey]: 'second-edit' } },
+    });
+    expect(editAfterAccept.status()).toBe(409);
+    const conflictBody = await readJsonSafe<{ error?: string }>(editAfterAccept);
+    expect(conflictBody?.error ?? '').toMatch(/already processed/i);
+  });
+});

--- a/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-006.spec.ts
+++ b/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-006.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
+
+/**
+ * TC-INBOX-006: Settings PATCH — update working language and active status
+ * Source: GitHub issue #2479 (inbox_ops integration coverage)
+ *
+ * GET seeds (or returns) tenant settings; PATCH updates workingLanguage / isActive,
+ * invalidates the settings cache (subsequent GET reflects the new value), and
+ * rejects an out-of-enum language with 400. The original settings are restored in
+ * `finally` so the tenant-shared row is left untouched. Needs no LLM extraction.
+ */
+test.describe('TC-INBOX-006: Settings PATCH', () => {
+  type Settings = { id: string; inboxAddress: string; isActive: boolean; workingLanguage: string };
+  const LOCALES = ['de', 'es', 'pl', 'en'];
+  let token: string;
+
+  test.beforeAll(async ({ request }) => {
+    token = await getAuthToken(request, 'admin');
+  });
+
+  test('updates language and active status, invalidates cache, validates input', async ({ request }) => {
+    const initialResponse = await apiRequest(request, 'GET', '/api/inbox_ops/settings', { token });
+    expect(initialResponse.status()).toBe(200);
+    const initialBody = await readJsonSafe<{ settings: Settings | null }>(initialResponse);
+    expect(initialBody?.settings, 'settings are auto-provisioned for the tenant').toBeTruthy();
+
+    const original = initialBody!.settings!;
+    const originalLanguage = original.workingLanguage;
+    const originalActive = original.isActive;
+    const nextLanguage = LOCALES.find((locale) => locale !== originalLanguage)!;
+
+    try {
+      // PATCH working language → returns the updated settings object.
+      const patchLanguage = await apiRequest(request, 'PATCH', '/api/inbox_ops/settings', {
+        token,
+        data: { workingLanguage: nextLanguage },
+      });
+      expect(patchLanguage.status()).toBe(200);
+      const patchLanguageBody = await readJsonSafe<{ ok: boolean; settings: Settings }>(patchLanguage);
+      expect(patchLanguageBody?.ok).toBe(true);
+      expect(patchLanguageBody?.settings?.workingLanguage).toBe(nextLanguage);
+
+      // Subsequent GET reflects the change (settings cache was invalidated).
+      const reread = await apiRequest(request, 'GET', '/api/inbox_ops/settings', { token });
+      expect(reread.status()).toBe(200);
+      const rereadBody = await readJsonSafe<{ settings: Settings }>(reread);
+      expect(rereadBody?.settings?.workingLanguage).toBe(nextLanguage);
+
+      // PATCH active status independently.
+      const patchActive = await apiRequest(request, 'PATCH', '/api/inbox_ops/settings', {
+        token,
+        data: { isActive: !originalActive },
+      });
+      expect(patchActive.status()).toBe(200);
+      const patchActiveBody = await readJsonSafe<{ ok: boolean; settings: Settings }>(patchActive);
+      expect(patchActiveBody?.settings?.isActive).toBe(!originalActive);
+      // The language change is retained alongside the active-status update.
+      expect(patchActiveBody?.settings?.workingLanguage).toBe(nextLanguage);
+
+      // Out-of-enum language is rejected before persistence.
+      const invalid = await apiRequest(request, 'PATCH', '/api/inbox_ops/settings', {
+        token,
+        data: { workingLanguage: 'invalid' },
+      });
+      expect(invalid.status()).toBe(400);
+      const invalidBody = await readJsonSafe<{ error?: string }>(invalid);
+      expect(invalidBody?.error ?? '').toMatch(/invalid request/i);
+    } finally {
+      await apiRequest(request, 'PATCH', '/api/inbox_ops/settings', {
+        token,
+        data: { workingLanguage: originalLanguage, isActive: originalActive },
+      }).catch(() => undefined);
+    }
+  });
+});

--- a/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-007.spec.ts
+++ b/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-007.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '@playwright/test';
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
+import {
+  submitTextExtraction,
+  waitForEmailProcessed,
+  deleteInboxEmail,
+  fetchProposalDetail,
+  findPendingAction,
+} from '@open-mercato/core/modules/core/__integration__/helpers/inboxFixtures';
+
+/**
+ * TC-INBOX-007: Email Reprocess — retire active proposals and re-queue extraction
+ * Source: GitHub issue #2479 (inbox_ops integration coverage)
+ *
+ * Reprocess retires the email's active proposals, resets its status to `received`,
+ * and re-queues extraction. A second reprocess while queued is a 409 ("already
+ * queued"); reprocess after an action was executed is a 409 ("cannot reprocess").
+ * The not-found path runs without an LLM; the retire/guard paths are LLM-gated.
+ */
+test.describe('TC-INBOX-007: Email Reprocess', () => {
+  const FAKE_ID = '00000000-0000-4000-8000-000000000000';
+  let token: string;
+  const createdEmailIds: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    test.setTimeout(90000);
+    token = await getAuthToken(request, 'admin');
+  });
+
+  test.afterAll(async ({ request }) => {
+    for (const emailId of createdEmailIds) {
+      await deleteInboxEmail(request, token, emailId);
+    }
+  });
+
+  test('returns 404 reprocessing a non-existent email', async ({ request }) => {
+    const response = await apiRequest(request, 'POST', `/api/inbox_ops/emails/${FAKE_ID}/reprocess`, { token });
+    expect(response.status()).toBe(404);
+    const body = await readJsonSafe<{ error?: string }>(response);
+    expect(body?.error ?? '').toMatch(/not found/i);
+  });
+
+  test('retires the active proposal and rejects an immediate second reprocess', async ({ request }) => {
+    test.setTimeout(75000);
+
+    const result = await submitTextExtraction(request, token, {
+      text: [
+        'From: Pierre Dubois <pierre@dubois-sarl.fr>',
+        'Subject: Order PO-TC007A',
+        '',
+        'Bonjour,',
+        'Please process:',
+        '- 5x Valve Assembly VA-7 at $30.00 each',
+        '',
+        'Customer reference: PO-TC007A',
+        '',
+        'Cordialement,',
+        'Pierre Dubois',
+      ].join('\n'),
+      title: 'TC-INBOX-007 retire fixture',
+    });
+    expect(result.ok).toBe(true);
+    if (result.emailId) createdEmailIds.push(result.emailId);
+
+    const processed = await waitForEmailProcessed(request, token, result.emailId!, 45000);
+    if (!processed || processed.status === 'failed' || !processed.proposalId) {
+      test.skip(true, 'LLM extraction unavailable (no API key configured)');
+      return;
+    }
+    const proposalId = processed.proposalId;
+
+    // The proposal is active before reprocess.
+    const before = await apiRequest(request, 'GET', `/api/inbox_ops/proposals/${proposalId}`, { token });
+    expect(before.status()).toBe(200);
+
+    const reprocess = await apiRequest(request, 'POST', `/api/inbox_ops/emails/${result.emailId}/reprocess`, { token });
+    expect(reprocess.status()).toBe(200);
+    const reprocessBody = await readJsonSafe<{ ok: boolean; retiredProposalCount: number; retiredActionCount: number }>(reprocess);
+    expect(reprocessBody?.ok).toBe(true);
+    expect(reprocessBody?.retiredProposalCount).toBeGreaterThanOrEqual(1);
+    expect(typeof reprocessBody?.retiredActionCount).toBe('number');
+
+    // The retired proposal is no longer active (detail lookup filters isActive).
+    const after = await apiRequest(request, 'GET', `/api/inbox_ops/proposals/${proposalId}`, { token });
+    expect(after.status()).toBe(404);
+
+    // Reprocess set the email back to `received`; a back-to-back second call is rejected.
+    const reprocessAgain = await apiRequest(request, 'POST', `/api/inbox_ops/emails/${result.emailId}/reprocess`, { token });
+    expect(reprocessAgain.status()).toBe(409);
+    const conflictBody = await readJsonSafe<{ error?: string }>(reprocessAgain);
+    expect(conflictBody?.error ?? '').toMatch(/already queued/i);
+  });
+
+  test('refuses to reprocess once an action has been executed', async ({ request }) => {
+    test.setTimeout(75000);
+
+    const result = await submitTextExtraction(request, token, {
+      text: [
+        'From: Sofia Ramirez <sofia@ramirez-suministros.es>',
+        'Subject: Order PO-TC007B',
+        '',
+        'Hola,',
+        'Order request:',
+        '- 9x Gasket GK-3 at $4.50 each',
+        '',
+        'Customer reference: PO-TC007B',
+        '',
+        'Saludos,',
+        'Sofia Ramirez',
+      ].join('\n'),
+      title: 'TC-INBOX-007 executed-guard fixture',
+    });
+    expect(result.ok).toBe(true);
+    if (result.emailId) createdEmailIds.push(result.emailId);
+
+    const processed = await waitForEmailProcessed(request, token, result.emailId!, 45000);
+    if (!processed || processed.status === 'failed' || !processed.proposalId) {
+      test.skip(true, 'LLM extraction unavailable (no API key configured)');
+      return;
+    }
+
+    const detail = await fetchProposalDetail(request, token, processed.proposalId);
+    const action = findPendingAction(detail?.actions ?? []);
+    expect(action, 'proposal should expose at least one pending action').toBeTruthy();
+
+    const accept = await apiRequest(
+      request,
+      'POST',
+      `/api/inbox_ops/proposals/${processed.proposalId}/actions/${action!.id}/accept`,
+      { token },
+    );
+    expect(accept.status()).toBe(200);
+
+    const reprocess = await apiRequest(request, 'POST', `/api/inbox_ops/emails/${result.emailId}/reprocess`, { token });
+    expect(reprocess.status()).toBe(409);
+    const body = await readJsonSafe<{ error?: string }>(reprocess);
+    expect(body?.error ?? '').toMatch(/cannot reprocess/i);
+  });
+});

--- a/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-008.spec.ts
+++ b/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-008.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '@playwright/test';
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures';
+
+/**
+ * TC-INBOX-008: Permission gates — non-admin users lack inbox_ops.proposals.manage
+ * Source: GitHub issue #2479 (inbox_ops integration coverage)
+ *
+ * RBAC is enforced declaratively (route `requireFeatures`) before any resource
+ * lookup, so mutation endpoints return 403 for a view-only principal regardless
+ * of whether the target ids exist — this spec needs no LLM extraction and always
+ * runs. A dedicated `inbox_ops.proposals.view`-only role is created because the
+ * seeded `employee` role already holds `proposals.manage` and would not be denied.
+ */
+test.describe('TC-INBOX-008: Permission gates', () => {
+  // Well-formed but non-existent ids: the feature gate fires before the lookup,
+  // so these never need to resolve to real records for the 403 assertions.
+  const FAKE_ID = '00000000-0000-4000-8000-000000000000';
+  const stamp = Date.now();
+  const viewerEmail = `inbox-viewer-${stamp}@example.com`;
+  const viewerPassword = 'Viewer123!';
+
+  let adminToken: string;
+  let viewerToken: string;
+  let roleId: string | null = null;
+  let userId: string | null = null;
+
+  test.beforeAll(async ({ request }) => {
+    test.setTimeout(60000);
+    adminToken = await getAuthToken(request, 'admin');
+    const { organizationId } = getTokenContext(adminToken);
+
+    roleId = await createRoleFixture(request, adminToken, { name: `inbox-viewer-${stamp}` });
+    await setRoleAclFeatures(request, adminToken, {
+      roleId,
+      features: ['inbox_ops.proposals.view'],
+    });
+    userId = await createUserFixture(request, adminToken, {
+      email: viewerEmail,
+      password: viewerPassword,
+      organizationId,
+      roles: [roleId],
+      name: 'Inbox Viewer (TC-INBOX-008)',
+    });
+    viewerToken = await getAuthToken(request, viewerEmail, viewerPassword);
+  });
+
+  test.afterAll(async ({ request }) => {
+    await deleteUserIfExists(request, adminToken, userId);
+    await deleteRoleIfExists(request, adminToken, roleId);
+  });
+
+  test('view-only user can read proposals and counts', async ({ request }) => {
+    const list = await apiRequest(request, 'GET', '/api/inbox_ops/proposals?pageSize=5', { token: viewerToken });
+    expect(list.status()).toBe(200);
+
+    const counts = await apiRequest(request, 'GET', '/api/inbox_ops/proposals/counts', { token: viewerToken });
+    expect(counts.status()).toBe(200);
+  });
+
+  test('view-only user is denied every proposals.manage mutation with 403', async ({ request }) => {
+    const accept = await apiRequest(
+      request,
+      'POST',
+      `/api/inbox_ops/proposals/${FAKE_ID}/actions/${FAKE_ID}/accept`,
+      { token: viewerToken },
+    );
+    expect(accept.status()).toBe(403);
+
+    const reject = await apiRequest(
+      request,
+      'POST',
+      `/api/inbox_ops/proposals/${FAKE_ID}/reject`,
+      { token: viewerToken },
+    );
+    expect(reject.status()).toBe(403);
+
+    const edit = await apiRequest(
+      request,
+      'PATCH',
+      `/api/inbox_ops/proposals/${FAKE_ID}/actions/${FAKE_ID}`,
+      { token: viewerToken, data: { payload: {} } },
+    );
+    expect(edit.status()).toBe(403);
+
+    const reprocess = await apiRequest(
+      request,
+      'POST',
+      `/api/inbox_ops/emails/${FAKE_ID}/reprocess`,
+      { token: viewerToken },
+    );
+    expect(reprocess.status()).toBe(403);
+  });
+
+  test('view-only user is denied settings access (settings.manage)', async ({ request }) => {
+    const read = await apiRequest(request, 'GET', '/api/inbox_ops/settings', { token: viewerToken });
+    expect(read.status()).toBe(403);
+
+    const write = await apiRequest(request, 'PATCH', '/api/inbox_ops/settings', {
+      token: viewerToken,
+      data: { workingLanguage: 'en' },
+    });
+    expect(write.status()).toBe(403);
+  });
+
+  test('an authorized admin passes the feature gate (404, not 403) on the same mutation', async ({ request }) => {
+    // Admin holds proposals.manage, so the gate lets the request reach the handler,
+    // which then reports the fabricated action as not found. This proves the 403s
+    // above are feature-driven, not a blanket block.
+    const accept = await apiRequest(
+      request,
+      'POST',
+      `/api/inbox_ops/proposals/${FAKE_ID}/actions/${FAKE_ID}/accept`,
+      { token: adminToken },
+    );
+    expect(accept.status()).toBe(404);
+    const body = await readJsonSafe<{ error?: string }>(accept);
+    expect(body?.error ?? '').toMatch(/not found/i);
+  });
+});

--- a/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-009.spec.ts
+++ b/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-009.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test';
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
+import {
+  submitTextExtraction,
+  waitForEmailProcessed,
+  deleteInboxEmail,
+  fetchProposalDetail,
+} from '@open-mercato/core/modules/core/__integration__/helpers/inboxFixtures';
+
+/**
+ * TC-INBOX-009: Translate proposal — language validation and cache behavior
+ * Source: GitHub issue #2479 (inbox_ops integration coverage)
+ *
+ * Translate returns 404 for a missing proposal, 400 for an out-of-enum locale or a
+ * same-language request, and caches results (cached=false then cached=true). The
+ * not-found path runs without an LLM; validation needs a real proposal; the caching
+ * happy-path additionally needs a configured translation provider.
+ */
+test.describe('TC-INBOX-009: Translate proposal', () => {
+  const FAKE_ID = '00000000-0000-4000-8000-000000000000';
+  const LOCALES = ['en', 'de', 'es', 'pl'];
+  let token: string;
+  let proposalId: string | null = null;
+  let proposalLanguage = 'en';
+  const createdEmailIds: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    test.setTimeout(90000);
+    token = await getAuthToken(request, 'admin');
+
+    const result = await submitTextExtraction(request, token, {
+      text: [
+        'From: Henry Walker <henry@walker-supplies.co.uk>',
+        'Subject: Order PO-TC009',
+        '',
+        'Hello,',
+        'Please process this order:',
+        '- 7x Filter Cartridge FC-5 at $11.00 each',
+        '',
+        'Customer reference: PO-TC009',
+        '',
+        'Regards,',
+        'Henry Walker',
+      ].join('\n'),
+      title: 'TC-INBOX-009 translate fixture',
+    });
+    if (result.emailId) createdEmailIds.push(result.emailId);
+
+    const processed = await waitForEmailProcessed(request, token, result.emailId!, 45000);
+    if (processed && processed.status !== 'failed' && processed.proposalId) {
+      proposalId = processed.proposalId;
+      const detail = await fetchProposalDetail(request, token, proposalId);
+      proposalLanguage = detail?.workingLanguage || 'en';
+    }
+  });
+
+  test.afterAll(async ({ request }) => {
+    for (const emailId of createdEmailIds) {
+      await deleteInboxEmail(request, token, emailId);
+    }
+  });
+
+  test('returns 404 translating a non-existent proposal', async ({ request }) => {
+    const response = await apiRequest(request, 'POST', `/api/inbox_ops/proposals/${FAKE_ID}/translate`, {
+      token,
+      data: { targetLocale: 'de' },
+    });
+    expect(response.status()).toBe(404);
+    const body = await readJsonSafe<{ error?: string }>(response);
+    expect(body?.error ?? '').toMatch(/not found/i);
+  });
+
+  test('rejects an out-of-enum locale and a same-language request with 400', async ({ request }) => {
+    test.skip(!proposalId, 'LLM extraction unavailable (no API key configured)');
+
+    const invalidLocale = await apiRequest(request, 'POST', `/api/inbox_ops/proposals/${proposalId}/translate`, {
+      token,
+      data: { targetLocale: 'zz' },
+    });
+    expect(invalidLocale.status()).toBe(400);
+    const invalidBody = await readJsonSafe<{ error?: string }>(invalidLocale);
+    expect(invalidBody?.error ?? '').toMatch(/invalid request/i);
+
+    // Same-language is only expressible when the proposal language is one of the
+    // supported target locales (English fixtures resolve to "en").
+    if (LOCALES.includes(proposalLanguage)) {
+      const sameLanguage = await apiRequest(request, 'POST', `/api/inbox_ops/proposals/${proposalId}/translate`, {
+        token,
+        data: { targetLocale: proposalLanguage },
+      });
+      expect(sameLanguage.status()).toBe(400);
+      const sameBody = await readJsonSafe<{ error?: string }>(sameLanguage);
+      expect(sameBody?.error ?? '').toMatch(/already in the requested language/i);
+    }
+  });
+
+  test('translates to a new locale and serves the cached result on repeat', async ({ request }) => {
+    test.skip(!proposalId, 'LLM extraction unavailable (no API key configured)');
+
+    const targetLocale = LOCALES.find((locale) => locale !== proposalLanguage)!;
+
+    const first = await apiRequest(request, 'POST', `/api/inbox_ops/proposals/${proposalId}/translate`, {
+      token,
+      data: { targetLocale },
+    });
+    // The happy path additionally requires a translation provider; skip cleanly if absent.
+    test.skip(first.status() !== 200, 'translation provider unavailable');
+
+    const firstBody = await readJsonSafe<{ translation: { summary: string; actions: Record<string, string> }; cached: boolean }>(first);
+    expect(firstBody?.cached).toBe(false);
+    expect(firstBody?.translation?.summary).toBeTruthy();
+
+    const second = await apiRequest(request, 'POST', `/api/inbox_ops/proposals/${proposalId}/translate`, {
+      token,
+      data: { targetLocale },
+    });
+    expect(second.status()).toBe(200);
+    const secondBody = await readJsonSafe<{ translation: { summary: string }; cached: boolean }>(second);
+    expect(secondBody?.cached).toBe(true);
+    expect(secondBody?.translation?.summary).toBe(firstBody?.translation?.summary);
+  });
+});


### PR DESCRIPTION
## Summary

Expands `inbox_ops` integration-test coverage (Fixes #2479) with 7 new API-level Playwright
specs (TC-INBOX-003…009): single-action accept/execution, idempotency 409 on repeat
accept/reject, action-payload editing, settings PATCH + cache invalidation, email reprocess
(retire + guards), RBAC permission gates, and proposal translation. Tests only — no product
code changed — plus two additive shared test helpers. LLM-dependent scenarios skip gracefully
when no AI provider key is configured (matching the existing TC-INBOX-P2-* specs); the
deterministic RBAC/validation/settings paths always run.

## Changes

- TC-INBOX-003 (P0): accepting a pending action executes it (status→`executed`, records the
  created entity, recalculates proposal status); counts/undo-header asserted defensively.
- TC-INBOX-004 (P0): a second accept and a reject of an executed action both return 409
  "Action already processed"; the action stays `executed`.
- TC-INBOX-005 (P1): PATCH deep-merges & persists the action payload; 400 on malformed body,
  404 on a missing action, 409 when editing an already-executed action.
- TC-INBOX-006 (P1): settings PATCH updates `workingLanguage`/`isActive`, invalidates the
  settings cache (subsequent GET reflects it), rejects an out-of-enum locale (400); originals
  restored in `finally`.
- TC-INBOX-007 (P1): reprocess retires active proposals (retired detail → 404); 404 on a
  missing email; 409 "already queued" on a back-to-back call; 409 "cannot reprocess" once an
  action is executed.
- TC-INBOX-008 (P0): a dedicated `inbox_ops.proposals.view`-only role/user is denied every
  `proposals.manage` and `settings.manage` mutation (403) while view endpoints return 200;
  admin passes the gate (404, not 403), proving the deny is feature-driven. (Note: the seeded
  `employee` role already holds `proposals.manage`, so a view-only role is required here.)
- TC-INBOX-009 (P2): translate returns 404 (missing proposal), 400 (out-of-enum locale /
  same-language), and caches results (cached=false → cached=true).
- Adds two additive shared helpers (`fetchProposalDetail`, `findPendingAction`) to
  `packages/core/src/helpers/integration/inboxFixtures.ts`.

## Specification

We follow spec-driven development. Please check if a spec exists and update it accordingly.

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test-only coverage for existing `inbox_ops` behavior (module behavior is specified under
SPEC-029 Inbox Ops Agent); no spec change required.

## Testing

List the tests or commands you ran to validate the change.

- `yarn turbo run typecheck --filter=@open-mercato/core` → pass (typechecks the new `__integration__` specs).
- `yarn workspace @open-mercato/core build` → pass (new helpers compiled into `dist` for runtime/CI resolution).
- `npx playwright test --config .ai/qa/tests/playwright.config.ts inbox_ops --list` → all 16 new tests discovered/parsed.
- `yarn test:integration:ephemeral --filter inbox_ops` (Docker, real auto-seeded DB+app) → **31 passed, 14 skipped, 0 failed**. All deterministic always-run tests passed (TC-INBOX-008 RBAC ×4, TC-INBOX-006 settings, the 400/404 paths in 005/007/009); LLM-gated scenarios skipped cleanly with no AI key (same as CI); no regressions in the 6 existing inbox specs.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (Test-only — none required.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Added in the module's `__integration__/` folder — the preferred executable-spec location per `.ai/qa/AGENTS.md`; `.ai/qa/tests/` is config-only.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — test-only.)

### Design System Compliance
- [x] No hardcoded status colors — N/A (backend/API test-only, no UI).
- [x] No arbitrary text sizes — N/A (no UI).
- [x] Empty state handled for list/data pages — N/A (no UI).
- [x] Loading state handled for async pages — N/A (no UI).
- [x] `aria-label` on all icon-only buttons — N/A (no UI).
- [x] Uses existing DS components — N/A (no UI).

## Linked issues

Fixes #2479