### PR TITLE
Integration tests: expand integrations coverage — provider registrati…

### DIFF
--- a/packages/core/src/helpers/integration/dbFixtures.ts
+++ b/packages/core/src/helpers/integration/dbFixtures.ts
@@ -142,3 +142,17 @@ export async function deleteOrganizationInDb(organizationId: string | null): Pro
     await client.query('delete from organizations where id = $1', [organizationId]);
   });
 }
+
+/**
+ * Hard-deletes integration credential rows for an organization (best-effort test
+ * cleanup). Integration credentials are stored per (integration_id,
+ * organization_id, tenant_id, user_id) with no FK to organizations, so a
+ * throwaway org's credential rows must be removed explicitly when the org row is
+ * torn down.
+ */
+export async function deleteIntegrationCredentialsInDb(organizationId: string | null): Promise<void> {
+  if (!organizationId) return;
+  await withClient(async (client) => {
+    await client.query('delete from integration_credentials where organization_id = $1', [organizationId]);
+  });
+}

--- a/packages/core/src/modules/integrations/__integration__/TC-INT-004.spec.ts
+++ b/packages/core/src/modules/integrations/__integration__/TC-INT-004.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
+
+type JsonRecord = Record<string, unknown>
+
+async function readJson(response: APIResponse): Promise<JsonRecord> {
+  return ((await readJsonSafe<JsonRecord>(response)) ?? {}) as JsonRecord
+}
+
+async function pickIntegrationId(request: APIRequestContext, token: string): Promise<string | null> {
+  const listResponse = await apiRequest(request, 'GET', '/api/integrations', { token })
+  if (listResponse.status() !== 200) return null
+  const body = await readJson(listResponse)
+  const items = Array.isArray(body.items) ? (body.items as JsonRecord[]) : []
+  return items.length > 0 ? String(items[0].id) : null
+}
+
+/**
+ * TC-INT-004: Integration credentials payload validation and constraints [P0]
+ *
+ * Surface: PUT /api/integrations/:id/credentials (requires integrations.credentials.manage)
+ *
+ * saveCredentialsSchema runs BEFORE the encrypted save, so every 422 case here is
+ * independent of the tenant-encryption configuration. Only the valid-save step
+ * touches the encrypted store; when encryption is unavailable the route returns
+ * 503 and the persistence checks skip (the standard harness returns 200, matching
+ * the successful save asserted by TC-INT-002).
+ */
+test.describe('TC-INT-004: Integration credentials payload validation', () => {
+  test('rejects malformed and structurally invalid credential payloads', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const integrationId = await pickIntegrationId(request, token)
+    if (!integrationId) {
+      test.skip(true, 'No integration provider modules registered — skipping credentials validation')
+      return
+    }
+    const path = `/api/integrations/${integrationId}/credentials`
+
+    // Malformed JSON body — req.json() throws, schema parse of null fails => 422.
+    const malformed = await apiRequest(request, 'PUT', path, {
+      token,
+      data: Buffer.from('{ "credentials": ', 'utf8'),
+    })
+    expect(malformed.status(), 'malformed JSON body should be rejected').toBe(422)
+
+    // Missing top-level credentials object => 422.
+    const missing = await apiRequest(request, 'PUT', path, { token, data: {} })
+    expect(missing.status(), 'missing credentials object should be rejected').toBe(422)
+
+    // More than 200 credential fields => 422 with the documented message.
+    const tooManyFields: JsonRecord = {}
+    for (let index = 0; index < 201; index += 1) tooManyFields[`field_${index}`] = 'value'
+    const tooMany = await apiRequest(request, 'PUT', path, { token, data: { credentials: tooManyFields } })
+    expect(tooMany.status(), 'more than 200 credential fields should be rejected').toBe(422)
+    expect(JSON.stringify(await readJson(tooMany))).toContain('At most 200')
+
+    // Credential key longer than 128 chars => 422.
+    const longKey = 'k'.repeat(129)
+    const longKeyResponse = await apiRequest(request, 'PUT', path, {
+      token,
+      data: { credentials: { [longKey]: 'value' } },
+    })
+    expect(longKeyResponse.status(), 'credential key longer than 128 chars should be rejected').toBe(422)
+
+    // Non-primitive credential values (array / nested object) => 422.
+    const arrayValue = await apiRequest(request, 'PUT', path, {
+      token,
+      data: { credentials: { apiKey: ['not', 'allowed'] } },
+    })
+    expect(arrayValue.status(), 'array credential value should be rejected').toBe(422)
+
+    const objectValue = await apiRequest(request, 'PUT', path, {
+      token,
+      data: { credentials: { apiKey: { nested: true } } },
+    })
+    expect(objectValue.status(), 'object credential value should be rejected').toBe(422)
+  })
+
+  test('accepts and persists mixed primitive credential values', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const integrationId = await pickIntegrationId(request, token)
+    if (!integrationId) {
+      test.skip(true, 'No integration provider modules registered — skipping credentials persistence')
+      return
+    }
+    const path = `/api/integrations/${integrationId}/credentials`
+
+    // Capture current credentials so the integration is restored afterwards.
+    const initialResponse = await apiRequest(request, 'GET', path, { token })
+    if (initialResponse.status() === 503) {
+      test.skip(true, 'Integration credentials encryption is unavailable in this environment')
+      return
+    }
+    expect(initialResponse.status()).toBe(200)
+    const initialBody = await readJson(initialResponse)
+    const originalCredentials =
+      initialBody.credentials && typeof initialBody.credentials === 'object'
+        ? (initialBody.credentials as JsonRecord)
+        : {}
+
+    try {
+      const mixed = {
+        stringField: 'integration-test-value',
+        numberField: 42,
+        booleanField: true,
+        nullField: null,
+      }
+      const saveResponse = await apiRequest(request, 'PUT', path, { token, data: { credentials: mixed } })
+      if (saveResponse.status() === 503) {
+        test.skip(true, 'Integration credentials encryption is unavailable in this environment')
+        return
+      }
+      expect(saveResponse.status(), 'valid mixed-type credentials should be accepted').toBe(200)
+
+      const verifyResponse = await apiRequest(request, 'GET', path, { token })
+      expect(verifyResponse.status()).toBe(200)
+      const credentials = ((await readJson(verifyResponse)).credentials ?? {}) as JsonRecord
+      expect(credentials.stringField).toBe('integration-test-value')
+      expect(credentials.numberField).toBe(42)
+      expect(credentials.booleanField).toBe(true)
+      expect(credentials.nullField).toBeNull()
+
+      // An empty object clears all credentials and is a valid payload.
+      const clearResponse = await apiRequest(request, 'PUT', path, { token, data: { credentials: {} } })
+      expect(clearResponse.status(), 'empty credentials object should be accepted').toBe(200)
+      const clearedBody = await readJson(await apiRequest(request, 'GET', path, { token }))
+      expect(clearedBody.credentials).toEqual({})
+    } finally {
+      await apiRequest(request, 'PUT', path, { token, data: { credentials: originalCredentials } }).catch(() => undefined)
+    }
+  })
+})

--- a/packages/core/src/modules/integrations/__integration__/TC-INT-005.spec.ts
+++ b/packages/core/src/modules/integrations/__integration__/TC-INT-005.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
+
+type JsonRecord = Record<string, unknown>
+
+const ENABLED_AT_SKEW_MS = 10_000
+
+async function readJson(response: APIResponse): Promise<JsonRecord> {
+  return ((await readJsonSafe<JsonRecord>(response)) ?? {}) as JsonRecord
+}
+
+async function pickIntegrationId(request: APIRequestContext, token: string): Promise<string | null> {
+  const listResponse = await apiRequest(request, 'GET', '/api/integrations', { token })
+  if (listResponse.status() !== 200) return null
+  const body = await readJson(listResponse)
+  const items = Array.isArray(body.items) ? (body.items as JsonRecord[]) : []
+  return items.length > 0 ? String(items[0].id) : null
+}
+
+async function readState(request: APIRequestContext, token: string, integrationId: string): Promise<JsonRecord> {
+  const detail = await readJson(await apiRequest(request, 'GET', `/api/integrations/${integrationId}`, { token }))
+  return detail.state && typeof detail.state === 'object' ? (detail.state as JsonRecord) : {}
+}
+
+/**
+ * TC-INT-005: Integration state mutation validation and enabledAt timestamp [P0]
+ *
+ * Surface: PUT /api/integrations/:id/state (requires integrations.manage)
+ *
+ * updateStateSchema requires at least one of isEnabled/reauthRequired. The state
+ * service stamps enabledAt only on a false->true transition and leaves it intact
+ * when other fields change. enabledAt is not echoed by the PUT response, so it is
+ * verified via the detail GET.
+ */
+test.describe('TC-INT-005: Integration state mutation validation', () => {
+  test('rejects empty and mistyped state payloads', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const integrationId = await pickIntegrationId(request, token)
+    if (!integrationId) {
+      test.skip(true, 'No integration provider modules registered — skipping state validation')
+      return
+    }
+    const path = `/api/integrations/${integrationId}/state`
+
+    // Empty payload — refine fails because no state field was provided => 422.
+    const empty = await apiRequest(request, 'PUT', path, { token, data: {} })
+    expect(empty.status(), 'empty state payload should be rejected').toBe(422)
+    expect(JSON.stringify(await readJson(empty))).toContain('At least one')
+
+    // isEnabled must be a boolean — a string fails type validation => 422.
+    const mistyped = await apiRequest(request, 'PUT', path, { token, data: { isEnabled: 'true' } })
+    expect(mistyped.status(), 'non-boolean isEnabled should be rejected').toBe(422)
+  })
+
+  test('stamps enabledAt on a disabled->enabled transition and preserves it otherwise', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const integrationId = await pickIntegrationId(request, token)
+    if (!integrationId) {
+      test.skip(true, 'No integration provider modules registered — skipping enabledAt checks')
+      return
+    }
+    const path = `/api/integrations/${integrationId}/state`
+    const initialState = await readState(request, token, integrationId)
+    const originalIsEnabled = typeof initialState.isEnabled === 'boolean' ? initialState.isEnabled : false
+    const originalReauthRequired = typeof initialState.reauthRequired === 'boolean' ? initialState.reauthRequired : false
+
+    try {
+      // Establish a disabled baseline so the next enable is a genuine transition.
+      const disable = await apiRequest(request, 'PUT', path, { token, data: { isEnabled: false, reauthRequired: false } })
+      expect(disable.status()).toBe(200)
+
+      const beforeEnableMs = Date.now()
+      const enable = await apiRequest(request, 'PUT', path, { token, data: { isEnabled: true } })
+      expect(enable.status()).toBe(200)
+      expect((await readJson(enable)).isEnabled).toBe(true)
+      const afterEnableMs = Date.now()
+
+      const enabledState = await readState(request, token, integrationId)
+      expect(typeof enabledState.enabledAt, 'enabledAt should be set on enable').toBe('string')
+      const enabledAtMs = new Date(String(enabledState.enabledAt)).getTime()
+      expect(enabledAtMs).toBeGreaterThanOrEqual(beforeEnableMs - ENABLED_AT_SKEW_MS)
+      expect(enabledAtMs).toBeLessThanOrEqual(afterEnableMs + ENABLED_AT_SKEW_MS)
+
+      // Changing only reauthRequired must NOT move enabledAt.
+      const reauth = await apiRequest(request, 'PUT', path, { token, data: { reauthRequired: true } })
+      expect(reauth.status()).toBe(200)
+      const reauthState = await readState(request, token, integrationId)
+      expect(reauthState.reauthRequired).toBe(true)
+      expect(reauthState.enabledAt, 'enabledAt should be unchanged when only reauthRequired changes').toBe(
+        enabledState.enabledAt,
+      )
+
+      // State persists across both detail and list reads.
+      const listBody = await readJson(await apiRequest(request, 'GET', '/api/integrations?pageSize=100', { token }))
+      const listItems = Array.isArray(listBody.items) ? (listBody.items as JsonRecord[]) : []
+      const listed = listItems.find((item) => String(item.id) === integrationId)
+      expect(listed?.isEnabled, 'enabled state should be reflected in the list endpoint').toBe(true)
+    } finally {
+      await apiRequest(request, 'PUT', path, {
+        token,
+        data: { isEnabled: originalIsEnabled, reauthRequired: originalReauthRequired },
+      }).catch(() => undefined)
+    }
+  })
+})

--- a/packages/core/src/modules/integrations/__integration__/TC-INT-006.spec.ts
+++ b/packages/core/src/modules/integrations/__integration__/TC-INT-006.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
+
+type JsonRecord = Record<string, unknown>
+
+async function readJson(response: APIResponse): Promise<JsonRecord> {
+  return ((await readJsonSafe<JsonRecord>(response)) ?? {}) as JsonRecord
+}
+
+type VersionedIntegration = {
+  id: string
+  versionIds: string[]
+  currentVersion: string | null
+  defaultVersion: string | null
+}
+
+/**
+ * Finds the first registered integration that declares two or more apiVersions.
+ * The list endpoint does not expose apiVersions, so each candidate is probed via
+ * the detail endpoint (integration.apiVersions).
+ */
+async function findVersionedIntegration(
+  request: APIRequestContext,
+  token: string,
+): Promise<VersionedIntegration | null> {
+  const listBody = await readJson(await apiRequest(request, 'GET', '/api/integrations?pageSize=100', { token }))
+  const items = Array.isArray(listBody.items) ? (listBody.items as JsonRecord[]) : []
+  for (const item of items) {
+    const integrationId = String(item.id)
+    const detail = await readJson(await apiRequest(request, 'GET', `/api/integrations/${integrationId}`, { token }))
+    const integration = (detail.integration ?? {}) as JsonRecord
+    const apiVersions = Array.isArray(integration.apiVersions) ? (integration.apiVersions as JsonRecord[]) : []
+    if (apiVersions.length < 2) continue
+    const versionIds = apiVersions.map((version) => String(version.id))
+    const defaultVersion = apiVersions.find((version) => version.default === true)
+    const state = (detail.state ?? {}) as JsonRecord
+    return {
+      id: integrationId,
+      versionIds,
+      currentVersion: typeof state.apiVersion === 'string' ? state.apiVersion : null,
+      defaultVersion: defaultVersion ? String(defaultVersion.id) : versionIds[0],
+    }
+  }
+  return null
+}
+
+/**
+ * TC-INT-006: Integration version persistence and invalid version rejection [P1]
+ *
+ * Surface: PUT /api/integrations/:id/version (requires integrations.manage)
+ *
+ * updateVersionSchema requires a non-empty apiVersion; the route additionally
+ * rejects versions that are not declared on the integration. A valid switch is
+ * persisted on the per-org state and echoed back with the previous version.
+ */
+test.describe('TC-INT-006: Integration version persistence', () => {
+  test('rejects unknown and empty versions, persists a valid switch', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const integration = await findVersionedIntegration(request, token)
+    if (!integration) {
+      test.skip(true, 'No versioned integrations registered in this environment')
+      return
+    }
+    const path = `/api/integrations/${integration.id}/version`
+
+    // Unknown version id => 422 with the documented message.
+    const unknown = await apiRequest(request, 'PUT', path, { token, data: { apiVersion: 'nonexistent-v9999' } })
+    expect(unknown.status(), 'unknown version should be rejected').toBe(422)
+    expect(JSON.stringify(await readJson(unknown))).toContain('Unknown integration version')
+
+    // Empty version string fails the min(1) schema rule => 422.
+    const empty = await apiRequest(request, 'PUT', path, { token, data: { apiVersion: '' } })
+    expect(empty.status(), 'empty version string should be rejected').toBe(422)
+
+    const targetVersion = integration.versionIds.find((id) => id !== integration.currentVersion) ?? integration.versionIds[0]
+    try {
+      const apply = await apiRequest(request, 'PUT', path, { token, data: { apiVersion: targetVersion } })
+      expect(apply.status(), 'a declared version should be accepted').toBe(200)
+      const applyBody = await readJson(apply)
+      expect(applyBody.apiVersion).toBe(targetVersion)
+      expect(typeof applyBody.previousVersion, 'response should report the previous version').toBe('string')
+
+      const detail = await readJson(await apiRequest(request, 'GET', `/api/integrations/${integration.id}`, { token }))
+      const state = (detail.state ?? {}) as JsonRecord
+      expect(state.apiVersion, 'the new version should persist on the integration state').toBe(targetVersion)
+    } finally {
+      const restoreVersion = integration.currentVersion ?? integration.defaultVersion
+      if (restoreVersion) {
+        await apiRequest(request, 'PUT', path, { token, data: { apiVersion: restoreVersion } }).catch(() => undefined)
+      }
+    }
+  })
+})

--- a/packages/core/src/modules/integrations/__integration__/TC-INT-007.spec.ts
+++ b/packages/core/src/modules/integrations/__integration__/TC-INT-007.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
+
+type JsonRecord = Record<string, unknown>
+
+// A fixed, well-formed UUID that no seeded log will reference.
+const NON_MATCHING_UUID = '00000000-0000-4000-8000-000000000000'
+
+async function readJson(response: APIResponse): Promise<JsonRecord> {
+  return ((await readJsonSafe<JsonRecord>(response)) ?? {}) as JsonRecord
+}
+
+async function pickIntegrationId(request: APIRequestContext, token: string): Promise<string> {
+  const listBody = await readJson(await apiRequest(request, 'GET', '/api/integrations', { token }))
+  const items = Array.isArray(listBody.items) ? (listBody.items as JsonRecord[]) : []
+  return items.length > 0 ? String(items[0].id) : 'nonexistent_integration'
+}
+
+/**
+ * TC-INT-007: Integration logs filtering by entity scope and runId [P1]
+ *
+ * Surface: GET /api/integrations/logs (requires integrations.manage)
+ *
+ * The validation and empty-result behaviours are deterministic and need no
+ * seeded data. The list/logs read routes validate their query with a 400 (the
+ * mutation routes use 422 for body validation), so invalid runId/entityId UUIDs
+ * are rejected with 400. AND-filter correctness over real rows is asserted only
+ * when the environment already has logs (none are written without integration
+ * activity).
+ */
+test.describe('TC-INT-007: Integration logs filtering', () => {
+  test('rejects invalid UUID filters with 400', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const badRunId = await apiRequest(request, 'GET', '/api/integrations/logs?runId=not-a-uuid', { token })
+    expect(badRunId.status(), 'a non-UUID runId should be rejected by query validation').toBe(400)
+
+    const badEntityId = await apiRequest(request, 'GET', '/api/integrations/logs?entityId=not-a-uuid', { token })
+    expect(badEntityId.status(), 'a non-UUID entityId should be rejected by query validation').toBe(400)
+  })
+
+  test('returns an empty list (not 404) for non-matching filters', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const response = await apiRequest(
+      request,
+      'GET',
+      `/api/integrations/logs?entityId=${NON_MATCHING_UUID}&runId=${NON_MATCHING_UUID}`,
+      { token },
+    )
+    expect(response.status(), 'a non-matching filter should still return 200').toBe(200)
+    const body = await readJson(response)
+    expect(Array.isArray(body.items)).toBe(true)
+    expect((body.items as unknown[]).length).toBe(0)
+    expect(body.total).toBe(0)
+  })
+
+  test('returns a paginated shape and scopes results to the integrationId filter', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const integrationId = await pickIntegrationId(request, token)
+
+    const response = await apiRequest(
+      request,
+      'GET',
+      `/api/integrations/logs?integrationId=${encodeURIComponent(integrationId)}&page=1&pageSize=25`,
+      { token },
+    )
+    expect(response.status()).toBe(200)
+    const body = await readJson(response)
+    expect(Array.isArray(body.items)).toBe(true)
+    expect(body.page).toBe(1)
+    expect(body.pageSize).toBe(25)
+    expect(typeof body.total).toBe('number')
+    expect(typeof body.totalPages).toBe('number')
+    for (const item of body.items as JsonRecord[]) {
+      expect(item.integrationId, 'every item must satisfy the integrationId filter').toBe(integrationId)
+    }
+  })
+
+  test('applies AND logic across filters when logs exist', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const allLogs = await readJson(await apiRequest(request, 'GET', '/api/integrations/logs?page=1&pageSize=50', { token }))
+    const items = Array.isArray(allLogs.items) ? (allLogs.items as JsonRecord[]) : []
+    if (items.length === 0) {
+      test.skip(true, 'No integration logs present — skipping AND-filter assertions')
+      return
+    }
+
+    const sample = items[0]
+    const integrationId = String(sample.integrationId)
+
+    // Filtering by the sample's integrationId returns only its rows.
+    const scoped = await readJson(
+      await apiRequest(
+        request,
+        'GET',
+        `/api/integrations/logs?integrationId=${encodeURIComponent(integrationId)}&page=1&pageSize=50`,
+        { token },
+      ),
+    )
+    for (const item of scoped.items as JsonRecord[]) {
+      expect(item.integrationId).toBe(integrationId)
+    }
+
+    // Combining the integrationId with a non-matching entityId excludes everything (AND, not OR).
+    const intersected = await readJson(
+      await apiRequest(
+        request,
+        'GET',
+        `/api/integrations/logs?integrationId=${encodeURIComponent(integrationId)}&entityId=${NON_MATCHING_UUID}`,
+        { token },
+      ),
+    )
+    expect((intersected.items as unknown[]).length).toBe(0)
+  })
+})

--- a/packages/core/src/modules/integrations/__integration__/TC-INT-008.spec.ts
+++ b/packages/core/src/modules/integrations/__integration__/TC-INT-008.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import {
+  createOrganizationInDb,
+  deleteIntegrationCredentialsInDb,
+  deleteOrganizationInDb,
+  deleteUserAclInDb,
+} from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+
+type JsonRecord = Record<string, unknown>
+
+async function readJson(response: APIResponse): Promise<JsonRecord> {
+  return ((await readJsonSafe<JsonRecord>(response)) ?? {}) as JsonRecord
+}
+
+async function pickIntegrationId(request: APIRequestContext, token: string): Promise<string | null> {
+  const listResponse = await apiRequest(request, 'GET', '/api/integrations', { token })
+  if (listResponse.status() !== 200) return null
+  const body = await readJson(listResponse)
+  const items = Array.isArray(body.items) ? (body.items as JsonRecord[]) : []
+  return items.length > 0 ? String(items[0].id) : null
+}
+
+async function readCredentials(
+  request: APIRequestContext,
+  token: string,
+  integrationId: string,
+): Promise<{ status: number; credentials: JsonRecord }> {
+  const response = await apiRequest(request, 'GET', `/api/integrations/${integrationId}/credentials`, { token })
+  const body = await readJson(response)
+  const credentials = body.credentials && typeof body.credentials === 'object' ? (body.credentials as JsonRecord) : {}
+  return { status: response.status(), credentials }
+}
+
+/**
+ * TC-INT-008: Integration credentials organization isolation [P0]
+ *
+ * Surfaces: PUT/GET /api/integrations/:id/credentials, GET /api/integrations/:id
+ *
+ * Integration credentials and state are scoped by (organizationId, tenantId).
+ * This exercises that boundary: a second organization is created in the admin's
+ * tenant (directly in the DB, because directory org-create denies non-super-admin
+ * accounts) plus a user whose home org is that second org. Credentials saved by
+ * the home-org admin MUST NOT be visible to the second-org user, and vice versa.
+ *
+ * Mirrors the multi-org choreography proven by TC-CRM-072. It requires a coherent
+ * app+DB stack (the standard yarn test:integration / ephemeral harness) where the
+ * DB fixtures and the app server share one database.
+ */
+test.describe('TC-INT-008: Integration credentials organization isolation', () => {
+  test('credentials saved in one organization are not visible from another', async ({ request }) => {
+    test.slow()
+
+    const stamp = Date.now()
+    const password = 'Secret123!'
+    const userBEmail = `tc-int-008-${stamp}@example.com`
+
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenScope(adminToken)
+    expect(tenantId, 'admin token should carry a tenant id').toBeTruthy()
+
+    const integrationId = await pickIntegrationId(request, adminToken)
+    if (!integrationId) {
+      test.skip(true, 'No integration provider modules registered — skipping org isolation')
+      return
+    }
+
+    // Probe encryption and capture the admin home-org (orgA) credentials for restore.
+    const adminInitial = await readCredentials(request, adminToken, integrationId)
+    if (adminInitial.status === 503) {
+      test.skip(true, 'Integration credentials encryption is unavailable in this environment')
+      return
+    }
+    expect(adminInitial.status).toBe(200)
+    const originalCredentials = adminInitial.credentials
+    const credentialsPath = `/api/integrations/${integrationId}/credentials`
+
+    let orgBId: string | null = null
+    let roleBId: string | null = null
+    let userBId: string | null = null
+    let userBToken: string | null = null
+
+    try {
+      orgBId = await createOrganizationInDb({ name: `TC-INT-008 Org B ${stamp}`, tenantId: tenantId as string })
+      roleBId = await createRoleFixture(request, adminToken, { name: `TC-INT-008 Role ${stamp}` })
+      userBId = await createUserFixture(request, adminToken, {
+        email: userBEmail,
+        password,
+        organizationId: orgBId,
+        roles: [roleBId],
+      })
+      // Grant org-B integration features via the ACL API so the RBAC cache is invalidated.
+      await setUserAclVisibility(request, adminToken, {
+        userId: userBId,
+        features: ['integrations.view', 'integrations.manage', 'integrations.credentials.manage'],
+        organizations: [orgBId],
+      })
+      userBToken = await getAuthToken(request, userBEmail, password)
+
+      const orgAMarker = `org-a-${stamp}`
+      const orgBMarker = `org-b-${stamp}`
+
+      // orgA (admin home org) saves a distinctive credential.
+      const adminSave = await apiRequest(request, 'PUT', credentialsPath, {
+        token: adminToken,
+        data: { credentials: { tcInt008Marker: orgAMarker } },
+      })
+      expect(adminSave.status(), 'admin (org-A) should save credentials').toBe(200)
+
+      // orgB must NOT see orgA's credential.
+      const orgBView = await readCredentials(request, userBToken, integrationId)
+      expect(orgBView.status, 'org-B user reads its own (empty) credentials').toBe(200)
+      expect(orgBView.credentials.tcInt008Marker, 'org-B must not see org-A credentials').toBeUndefined()
+
+      // orgB saves its own distinct credential.
+      const orgBSave = await apiRequest(request, 'PUT', credentialsPath, {
+        token: userBToken,
+        data: { credentials: { tcInt008Marker: orgBMarker } },
+      })
+      expect(orgBSave.status(), 'org-B user should save its own credentials').toBe(200)
+
+      // Each org reads back only its own value — proves bidirectional isolation.
+      const adminAfter = await readCredentials(request, adminToken, integrationId)
+      expect(adminAfter.credentials.tcInt008Marker, 'org-A still reads its own credential').toBe(orgAMarker)
+      const orgBAfter = await readCredentials(request, userBToken, integrationId)
+      expect(orgBAfter.credentials.tcInt008Marker, 'org-B reads its own credential').toBe(orgBMarker)
+
+      // hasCredentials on the detail read is also resolved per-org.
+      const orgBDetail = await readJson(
+        await apiRequest(request, 'GET', `/api/integrations/${integrationId}`, { token: userBToken }),
+      )
+      expect(orgBDetail.hasCredentials, 'org-B detail reflects its own credential state').toBe(true)
+    } finally {
+      // Restore the admin (org-A) credentials and remove every record created for org-B.
+      await apiRequest(request, 'PUT', credentialsPath, { token: adminToken, data: { credentials: originalCredentials } }).catch(
+        () => undefined,
+      )
+      await deleteUserIfExists(request, adminToken, userBId)
+      await deleteUserAclInDb(userBId ?? '').catch(() => undefined)
+      await deleteRoleIfExists(request, adminToken, roleBId)
+      await deleteIntegrationCredentialsInDb(orgBId).catch(() => undefined)
+      await deleteOrganizationInDb(orgBId).catch(() => undefined)
+    }
+  })
+})

--- a/packages/core/src/modules/integrations/__integration__/TC-INT-009.spec.ts
+++ b/packages/core/src/modules/integrations/__integration__/TC-INT-009.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
+
+type JsonRecord = Record<string, unknown>
+
+async function readJson(response: APIResponse): Promise<JsonRecord> {
+  return ((await readJsonSafe<JsonRecord>(response)) ?? {}) as JsonRecord
+}
+
+async function listItems(request: APIRequestContext, token: string, query: string): Promise<JsonRecord[]> {
+  const response = await apiRequest(request, 'GET', `/api/integrations?${query}`, { token })
+  expect(response.status(), `GET /api/integrations?${query} should return 200`).toBe(200)
+  const body = await readJson(response)
+  return Array.isArray(body.items) ? (body.items as JsonRecord[]) : []
+}
+
+/**
+ * TC-INT-009: List endpoint advanced filtering — isEnabled + healthStatus [P1]
+ *
+ * Surface: GET /api/integrations (requires integrations.view)
+ *
+ * isEnabled and healthStatus filters compose with AND semantics. Counts depend on
+ * the registered providers and per-org state, so the assertions check that every
+ * returned row satisfies the active filter(s) rather than asserting exact counts.
+ */
+test.describe('TC-INT-009: Integration list advanced filtering', () => {
+  test('isEnabled and healthStatus filters return only matching rows', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    for (const enabled of [true, false]) {
+      const items = await listItems(request, token, `isEnabled=${enabled}`)
+      for (const item of items) {
+        expect(item.isEnabled, `isEnabled=${enabled} must only return matching rows`).toBe(enabled)
+      }
+    }
+
+    for (const status of ['healthy', 'degraded', 'unhealthy', 'unconfigured']) {
+      const items = await listItems(request, token, `healthStatus=${status}`)
+      for (const item of items) {
+        expect(item.healthStatus, `healthStatus=${status} must only return matching rows`).toBe(status)
+      }
+    }
+  })
+
+  test('combined filters apply AND semantics', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const combined = await listItems(request, token, 'isEnabled=true&healthStatus=unconfigured')
+    for (const item of combined) {
+      expect(item.isEnabled).toBe(true)
+      expect(item.healthStatus).toBe('unconfigured')
+    }
+
+    // The AND result can never exceed either single-filter result set.
+    const enabledOnly = await listItems(request, token, 'isEnabled=true')
+    const unconfiguredOnly = await listItems(request, token, 'healthStatus=unconfigured')
+    expect(combined.length).toBeLessThanOrEqual(enabledOnly.length)
+    expect(combined.length).toBeLessThanOrEqual(unconfiguredOnly.length)
+
+    // A combination with no matches resolves to an empty array, never an error.
+    const emptyCombo = await apiRequest(request, 'GET', '/api/integrations?isEnabled=false&healthStatus=healthy', { token })
+    expect(emptyCombo.status()).toBe(200)
+    expect(Array.isArray((await readJson(emptyCombo)).items)).toBe(true)
+  })
+
+  test('rejects an invalid boolean filter value with 400', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const response = await apiRequest(request, 'GET', '/api/integrations?isEnabled=notabool', { token })
+    expect(response.status(), 'an unparseable isEnabled value should be rejected').toBe(400)
+  })
+})

--- a/packages/core/src/modules/integrations/__integration__/TC-INT-010.spec.ts
+++ b/packages/core/src/modules/integrations/__integration__/TC-INT-010.spec.ts
@@ -1,0 +1,108 @@
+import { expect, request as playwrightRequest, test, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
+
+type JsonRecord = Record<string, unknown>
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
+
+async function readJson(response: APIResponse): Promise<JsonRecord> {
+  return ((await readJsonSafe<JsonRecord>(response)) ?? {}) as JsonRecord
+}
+
+async function pickIntegrationId(request: APIRequestContext, token: string): Promise<string | null> {
+  const listResponse = await apiRequest(request, 'GET', '/api/integrations', { token })
+  if (listResponse.status() !== 200) return null
+  const body = await readJson(listResponse)
+  const items = Array.isArray(body.items) ? (body.items as JsonRecord[]) : []
+  return items.length > 0 ? String(items[0].id) : null
+}
+
+/**
+ * TC-INT-010: Employee vs Admin RBAC — view vs manage permissions [P1]
+ *
+ * Surfaces: GET /api/integrations, GET/PUT /api/integrations/:id/credentials,
+ * PUT /api/integrations/:id/state, PUT /api/integrations/:id/version,
+ * POST /api/integrations/:id/health
+ *
+ * The seeded employee role is granted integrations.view only; admin holds
+ * integrations.* . Manage-gated routes (state/version/credentials/health) must
+ * reject the employee with 403 while admin is authorized. A missing token yields
+ * 401, distinct from the authenticated-but-unauthorized 403.
+ */
+test.describe('TC-INT-010: Integration RBAC view vs manage', () => {
+  test('employee may view but cannot manage; admin is authorized', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const employeeToken = await getAuthToken(request, 'employee')
+    const integrationId = await pickIntegrationId(request, adminToken)
+    if (!integrationId) {
+      test.skip(true, 'No integration provider modules registered — skipping RBAC checks')
+      return
+    }
+
+    // View is granted to the employee.
+    const employeeList = await apiRequest(request, 'GET', '/api/integrations', { token: employeeToken })
+    expect(employeeList.status(), 'employee should be able to list integrations').toBe(200)
+
+    // Manage-gated reads/writes are forbidden for the employee.
+    const manageGatedRequests: Array<{ label: string; response: APIResponse }> = [
+      {
+        label: 'GET credentials',
+        response: await apiRequest(request, 'GET', `/api/integrations/${integrationId}/credentials`, { token: employeeToken }),
+      },
+      {
+        label: 'PUT credentials',
+        response: await apiRequest(request, 'PUT', `/api/integrations/${integrationId}/credentials`, {
+          token: employeeToken,
+          data: { credentials: {} },
+        }),
+      },
+      {
+        label: 'PUT state',
+        response: await apiRequest(request, 'PUT', `/api/integrations/${integrationId}/state`, {
+          token: employeeToken,
+          data: { isEnabled: true },
+        }),
+      },
+      {
+        label: 'PUT version',
+        response: await apiRequest(request, 'PUT', `/api/integrations/${integrationId}/version`, {
+          token: employeeToken,
+          data: { apiVersion: 'any' },
+        }),
+      },
+      {
+        label: 'POST health',
+        response: await apiRequest(request, 'POST', `/api/integrations/${integrationId}/health`, { token: employeeToken }),
+      },
+    ]
+    for (const { label, response } of manageGatedRequests) {
+      expect(response.status(), `employee ${label} should be forbidden`).toBe(403)
+    }
+
+    // Admin clears the manage gate (read paths are authorized; 200 normally, 503 only if encryption is unavailable).
+    const adminCredentials = await apiRequest(request, 'GET', `/api/integrations/${integrationId}/credentials`, { token: adminToken })
+    expect(adminCredentials.status(), 'admin should not be forbidden from reading credentials').not.toBe(403)
+    expect([200, 503]).toContain(adminCredentials.status())
+  })
+
+  test('distinguishes 401 (no token) from 403 (insufficient feature)', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const employeeToken = await getAuthToken(request, 'employee')
+    const integrationId = await pickIntegrationId(request, adminToken)
+    if (!integrationId) {
+      test.skip(true, 'No integration provider modules registered — skipping auth distinction checks')
+      return
+    }
+
+    const anonymous = await playwrightRequest.newContext({ baseURL: BASE_URL })
+    try {
+      const noToken = await anonymous.get(`/api/integrations/${integrationId}/credentials`)
+      expect(noToken.status(), 'unauthenticated credentials read should be 401').toBe(401)
+    } finally {
+      await anonymous.dispose()
+    }
+
+    const employee = await apiRequest(request, 'GET', `/api/integrations/${integrationId}/credentials`, { token: employeeToken })
+    expect(employee.status(), 'authenticated-but-unauthorized credentials read should be 403').toBe(403)
+  })
+})


### PR DESCRIPTION
## Summary

Expands integration-test coverage for the `integrations` module with the seven
low-hanging-fruit scenarios from #2476 (TC-INT-004 → TC-INT-010), targeting
stable API surfaces that were previously untested: credential payload validation,
state-mutation rules and the `enabledAt` timestamp, API-version persistence, log
filtering, organization data isolation, list filtering, and view-vs-manage RBAC.
The module previously had only TC-INT-002/003.

## Changes

- TC-INT-004 `[P0]` — credentials payload validation: malformed JSON, missing `credentials` object, >200 fields (with the "At most 200" message), key >128 chars, non-primitive values → all 422; mixed-type save (string/number/boolean/null) persists; empty `{}` clears.
- TC-INT-005 `[P0]` — state validation: empty/`isEnabled:'true'` → 422; `enabledAt` is stamped on a `false→true` transition and preserved when only `reauthRequired` changes; state persists across detail/list reads.
- TC-INT-006 `[P1]` — version: unknown/empty → 422; a declared version applies, persists, and echoes `previousVersion`.
- TC-INT-007 `[P1]` — logs filtering: invalid `runId`/`entityId` UUID → 400; non-matching filter → 200 empty (not 404); `integrationId` scoping; AND-logic asserted when logs exist.
- TC-INT-008 `[P0]` — organization isolation: credentials saved in one org are invisible to a second org (and vice-versa), proven with a DB-created second org plus a user whose home org is that org.
- TC-INT-009 `[P1]` — list filtering: `isEnabled` / `healthStatus` filters return only matching rows, compose with AND, invalid boolean → 400.
- TC-INT-010 `[P1]` — RBAC: employee can list but cannot read/write credentials, state, version, or health (403); admin is authorized; 401 (no token) is distinct from 403.
- `helpers/integration/dbFixtures.ts` — adds `deleteIntegrationCredentialsInDb()` so TC-INT-008 fully removes its throwaway org's credential row in teardown.

All specs are self-contained: they discover fixtures via the API, skip gracefully
when a provider/version/log precondition is absent, and restore or delete every
record they create in `finally`. The status codes match the real routes — mutation
body validation returns 422 while list/log query validation returns 400.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
The `integrations` module is specified by `.ai/specs/implemented/SPEC-045-2026-02-24-integration-marketplace.md` (+ SPEC-045a). This PR only adds test coverage for the existing, shipped contract — no behavior change, so no spec update.

## Testing

- `yarn turbo run typecheck --filter=@open-mercato/core` → pass (compiles all new specs + the helper).
- `BASE_URL=… OM_INTEGRATION_MODULES=integrations npx playwright test --config .ai/qa/tests/playwright.config.ts "modules/integrations/__integration__"` → **26 passed, 1 skipped**; run twice to confirm idempotency; existing TC-INT-002/003 stay green. Verified against a live `dev:app` on an isolated, seeded database.
- `yarn i18n:check-sync` → all locales in sync.
- The 1 skip is TC-INT-007's conditional AND-filter assertion (a fresh environment writes no integration logs).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — test-only.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Added as module-local `__integration__/TC-INT-*.spec.ts`, the current convention per `.ai/qa/AGENTS.md`.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no contract change.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI (backend integration tests only)
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2476