### PR TITLE
fix: 2474 notifications integration coverage

### DIFF
--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-CF-MULTI-EDIT-001.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-CF-MULTI-EDIT-001.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test, type APIRequestContext } from '@playwright/test';
 import {
   createProductFixture,
@@ -90,7 +91,7 @@ function asStringArray(value: unknown): string[] {
 
 test.describe('TC-CAT-CF-MULTI-EDIT-001: product multichoice custom field persists on edit', () => {
   test('updating a product multi-select replaces the old values', async ({ request }) => {
-    const stamp = Date.now();
+    const stamp = `${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 12)}`;
     const fieldKey = `qa_prod_multi_${stamp}`;
     const fieldLabel = `QA Resources ${stamp}`;
     const options = ['stylist', 'therapist', 'treatment_room', 'wash_station'];

--- a/packages/core/src/modules/notifications/__integration__/TC-NOTIF-004.spec.ts
+++ b/packages/core/src/modules/notifications/__integration__/TC-NOTIF-004.spec.ts
@@ -1,0 +1,46 @@
+import { test } from '@playwright/test'
+import { expectJsonError, rawApiRequest } from './helpers/notificationsApi'
+
+const UNKNOWN_NOTIFICATION_ID = '00000000-0000-4000-8000-000000000004'
+
+test.describe('TC-NOTIF-004: Notification APIs require authentication', () => {
+  test('returns 401 with an error body for anonymous notification requests', async ({ request }) => {
+    const cases = [
+      {
+        method: 'GET',
+        path: '/api/notifications',
+        label: 'GET /api/notifications without auth',
+      },
+      {
+        method: 'POST',
+        path: '/api/notifications',
+        data: {
+          type: 'qa.notifications.unauthenticated',
+          title: 'Anonymous notification attempt',
+          recipientUserId: UNKNOWN_NOTIFICATION_ID,
+        },
+        label: 'POST /api/notifications without auth',
+      },
+      {
+        method: 'GET',
+        path: '/api/notifications/unread-count',
+        label: 'GET /api/notifications/unread-count without auth',
+      },
+      {
+        method: 'PUT',
+        path: '/api/notifications/mark-all-read',
+        label: 'PUT /api/notifications/mark-all-read without auth',
+      },
+      {
+        method: 'PUT',
+        path: `/api/notifications/${UNKNOWN_NOTIFICATION_ID}/read`,
+        label: 'PUT /api/notifications/{id}/read without auth',
+      },
+    ]
+
+    for (const entry of cases) {
+      const response = await rawApiRequest(request, entry.method, entry.path, { data: entry.data })
+      await expectJsonError(response, 401, entry.label)
+    }
+  })
+})

--- a/packages/core/src/modules/notifications/__integration__/TC-NOTIF-005.spec.ts
+++ b/packages/core/src/modules/notifications/__integration__/TC-NOTIF-005.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import { getTokenScope } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  expectJsonError,
+  expectRequiredFeature,
+} from './helpers/notificationsApi'
+
+test.describe('TC-NOTIF-005: notifications.create gates create endpoints', () => {
+  test('denies notification creation endpoints to a user without notifications.create', async ({ request }) => {
+    const stamp = Date.now()
+    const password = 'Valid1!Pass'
+    const email = `qa-notif-create-rbac-${stamp}@acme.com`
+    const roleName = `qa_notif_create_rbac_${stamp}`
+
+    let superadminToken: string | null = null
+    let restrictedToken: string | null = null
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      superadminToken = await getAuthToken(request, 'superadmin')
+      const scope = getTokenScope(superadminToken)
+      roleId = await createRoleFixture(request, superadminToken, {
+        name: roleName,
+        tenantId: scope.tenantId,
+      })
+      await setRoleAclFeatures(request, superadminToken, {
+        roleId,
+        features: ['notifications.view'],
+        organizations: null,
+      })
+      userId = await createUserFixture(request, superadminToken, {
+        email,
+        password,
+        organizationId: scope.organizationId,
+        roles: [roleId],
+      })
+      restrictedToken = await getAuthToken(request, email, password)
+
+      const cases = [
+        {
+          path: '/api/notifications',
+          data: {
+            type: `qa.notifications.create.rbac.${stamp}`,
+            title: 'Blocked direct notification',
+            recipientUserId: scope.userId,
+          },
+          label: 'POST /api/notifications without notifications.create',
+        },
+        {
+          path: '/api/notifications/batch',
+          data: {
+            type: `qa.notifications.batch.rbac.${stamp}`,
+            title: 'Blocked batch notification',
+            recipientUserIds: [scope.userId],
+          },
+          label: 'POST /api/notifications/batch without notifications.create',
+        },
+        {
+          path: '/api/notifications/role',
+          data: {
+            type: `qa.notifications.role.rbac.${stamp}`,
+            title: 'Blocked role notification',
+            roleId,
+          },
+          label: 'POST /api/notifications/role without notifications.create',
+        },
+        {
+          path: '/api/notifications/feature',
+          data: {
+            type: `qa.notifications.feature.rbac.${stamp}`,
+            title: 'Blocked feature notification',
+            requiredFeature: 'notifications.view',
+          },
+          label: 'POST /api/notifications/feature without notifications.create',
+        },
+      ]
+
+      for (const entry of cases) {
+        const response = await apiRequest(request, 'POST', entry.path, {
+          token: restrictedToken,
+          data: entry.data,
+        })
+        const body = await expectJsonError(response, 403, entry.label)
+        expectRequiredFeature(body, 'notifications.create')
+      }
+
+      expect(userId, 'restricted user fixture should be created').toBeTruthy()
+    } finally {
+      await deleteUserIfExists(request, superadminToken, userId)
+      await deleteRoleIfExists(request, superadminToken, roleId)
+    }
+  })
+})

--- a/packages/core/src/modules/notifications/__integration__/TC-NOTIF-006.spec.ts
+++ b/packages/core/src/modules/notifications/__integration__/TC-NOTIF-006.spec.ts
@@ -1,0 +1,79 @@
+import { test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import { getTokenScope } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  expectJsonError,
+  expectRequiredFeature,
+} from './helpers/notificationsApi'
+
+test.describe('TC-NOTIF-006: notifications.manage gates settings endpoints', () => {
+  test('denies notification settings management to a user without notifications.manage', async ({ request }) => {
+    const stamp = Date.now()
+    const password = 'Valid1!Pass'
+    const email = `qa-notif-settings-rbac-${stamp}@acme.com`
+    const roleName = `qa_notif_settings_rbac_${stamp}`
+
+    let superadminToken: string | null = null
+    let restrictedToken: string | null = null
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      superadminToken = await getAuthToken(request, 'superadmin')
+      const scope = getTokenScope(superadminToken)
+      roleId = await createRoleFixture(request, superadminToken, {
+        name: roleName,
+        tenantId: scope.tenantId,
+      })
+      await setRoleAclFeatures(request, superadminToken, {
+        roleId,
+        features: ['notifications.view'],
+        organizations: null,
+      })
+      userId = await createUserFixture(request, superadminToken, {
+        email,
+        password,
+        organizationId: scope.organizationId,
+        roles: [roleId],
+      })
+      restrictedToken = await getAuthToken(request, email, password)
+
+      const getResponse = await apiRequest(request, 'GET', '/api/notifications/settings', {
+        token: restrictedToken,
+      })
+      const getBody = await expectJsonError(
+        getResponse,
+        403,
+        'GET /api/notifications/settings without notifications.manage',
+      )
+      expectRequiredFeature(getBody, 'notifications.manage')
+
+      const postResponse = await apiRequest(request, 'POST', '/api/notifications/settings', {
+        token: restrictedToken,
+        data: {
+          appUrl: 'https://qa.example.test',
+          panelPath: '/backend/notifications',
+          strategies: {
+            database: { enabled: true },
+          },
+        },
+      })
+      const postBody = await expectJsonError(
+        postResponse,
+        403,
+        'POST /api/notifications/settings without notifications.manage',
+      )
+      expectRequiredFeature(postBody, 'notifications.manage')
+    } finally {
+      await deleteUserIfExists(request, superadminToken, userId)
+      await deleteRoleIfExists(request, superadminToken, roleId)
+    }
+  })
+})

--- a/packages/core/src/modules/notifications/__integration__/TC-NOTIF-007.spec.ts
+++ b/packages/core/src/modules/notifications/__integration__/TC-NOTIF-007.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import {
+  deleteGeneralEntityIfExists,
+  expectId,
+  getTokenScope,
+  readJsonSafe,
+} from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createNotificationFixture,
+  dismissNotificationIfExists,
+  listNotifications,
+} from '@open-mercato/core/helpers/integration/notificationsFixtures'
+
+test.describe('TC-NOTIF-007: Notification list is scoped by tenant and user', () => {
+  test('shows each tenant user only their own notification when type values overlap', async ({ request }) => {
+    const stamp = Date.now()
+    const password = 'Valid1!Pass'
+    const type = `qa.notifications.cross.tenant.${stamp}`
+    const t1Email = `qa-notif-t1-${stamp}@acme.com`
+    const t2Email = `qa-notif-t2-${stamp}@acme.com`
+
+    let superadminToken: string | null = null
+    let t1Token: string | null = null
+    let t2Token: string | null = null
+    let t1RoleId: string | null = null
+    let t1UserId: string | null = null
+    let t2TenantId: string | null = null
+    let t2OrgId: string | null = null
+    let t2RoleId: string | null = null
+    let t2UserId: string | null = null
+    let t1NotificationId: string | null = null
+    let t2NotificationId: string | null = null
+
+    try {
+      superadminToken = await getAuthToken(request, 'superadmin')
+      const t1Scope = getTokenScope(superadminToken)
+
+      t1RoleId = await createRoleFixture(request, superadminToken, {
+        name: `qa_notif_t1_viewer_${stamp}`,
+        tenantId: t1Scope.tenantId,
+      })
+      await setRoleAclFeatures(request, superadminToken, {
+        roleId: t1RoleId,
+        features: ['notifications.view'],
+        organizations: null,
+      })
+      t1UserId = await createUserFixture(request, superadminToken, {
+        email: t1Email,
+        password,
+        organizationId: t1Scope.organizationId,
+        roles: [t1RoleId],
+      })
+      t1Token = await getAuthToken(request, t1Email, password)
+
+      const tenantResponse = await apiRequest(request, 'POST', '/api/directory/tenants', {
+        token: superadminToken,
+        data: { name: `QA Notifications Tenant ${stamp}` },
+      })
+      expect(tenantResponse.status(), 'POST /api/directory/tenants should return 201').toBe(201)
+      t2TenantId = expectId(
+        (await readJsonSafe<{ id?: string }>(tenantResponse))?.id,
+        'tenant create response should include id',
+      )
+
+      const orgResponse = await apiRequest(request, 'POST', '/api/directory/organizations', {
+        token: superadminToken,
+        data: { tenantId: t2TenantId, name: `QA Notifications Tenant Org ${stamp}` },
+      })
+      expect(orgResponse.status(), 'POST /api/directory/organizations should return 201').toBe(201)
+      t2OrgId = expectId(
+        (await readJsonSafe<{ id?: string }>(orgResponse))?.id,
+        'organization create response should include id',
+      )
+
+      t2RoleId = await createRoleFixture(request, superadminToken, {
+        name: `qa_notif_t2_creator_${stamp}`,
+        tenantId: t2TenantId,
+      })
+      await setRoleAclFeatures(request, superadminToken, {
+        roleId: t2RoleId,
+        features: ['notifications.view', 'notifications.create'],
+        organizations: null,
+      })
+
+      t2UserId = await createUserFixture(request, superadminToken, {
+        email: t2Email,
+        password,
+        organizationId: t2OrgId,
+        roles: [t2RoleId],
+      })
+      t2Token = await getAuthToken(request, t2Email, password)
+
+      t1NotificationId = await createNotificationFixture(request, superadminToken, {
+        type,
+        title: `Tenant one notification ${stamp}`,
+        recipientUserId: t1UserId,
+      })
+      t2NotificationId = await createNotificationFixture(request, t2Token, {
+        type,
+        title: `Tenant two notification ${stamp}`,
+        recipientUserId: t2UserId,
+      })
+
+      const t1List = await listNotifications(request, t1Token, { type, pageSize: 10 })
+      expect(t1List.items).toHaveLength(1)
+      expect(t1List.items.map((item) => item.id)).toContain(t1NotificationId)
+      expect(t1List.items.map((item) => item.id)).not.toContain(t2NotificationId)
+      expect(t1List.items[0]?.title).toBe(`Tenant one notification ${stamp}`)
+
+      const t2List = await listNotifications(request, t2Token, { type, pageSize: 10 })
+      expect(t2List.items).toHaveLength(1)
+      expect(t2List.items.map((item) => item.id)).toContain(t2NotificationId)
+      expect(t2List.items.map((item) => item.id)).not.toContain(t1NotificationId)
+      expect(t2List.items[0]?.title).toBe(`Tenant two notification ${stamp}`)
+    } finally {
+      await dismissNotificationIfExists(request, t1Token, t1NotificationId)
+      await dismissNotificationIfExists(request, t2Token, t2NotificationId)
+      await deleteUserIfExists(request, superadminToken, t1UserId)
+      await deleteUserIfExists(request, superadminToken, t2UserId)
+      await deleteRoleIfExists(request, superadminToken, t1RoleId)
+      await deleteRoleIfExists(request, superadminToken, t2RoleId)
+      await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/organizations', t2OrgId)
+      await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/tenants', t2TenantId)
+    }
+  })
+})

--- a/packages/core/src/modules/notifications/__integration__/TC-NOTIF-008.spec.ts
+++ b/packages/core/src/modules/notifications/__integration__/TC-NOTIF-008.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenScope } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { expectJsonError } from './helpers/notificationsApi'
+
+test.describe('TC-NOTIF-008: Notification create payload validation', () => {
+  test('rejects create and batch payloads missing both title and titleKey', async ({ request }) => {
+    const token = await getAuthToken(request, 'superadmin')
+    const scope = getTokenScope(token)
+    const stamp = Date.now()
+
+    const createResponse = await apiRequest(request, 'POST', '/api/notifications', {
+      token,
+      data: {
+        type: `qa.notifications.validation.single.${stamp}`,
+        recipientUserId: scope.userId,
+      },
+    })
+    const createBody = await expectJsonError(
+      createResponse,
+      400,
+      'POST /api/notifications without title or titleKey',
+    )
+    expect(String(createBody.error ?? createBody.message)).toMatch(/titleKey|title/i)
+
+    const batchResponse = await apiRequest(request, 'POST', '/api/notifications/batch', {
+      token,
+      data: {
+        type: `qa.notifications.validation.batch.${stamp}`,
+        recipientUserIds: [scope.userId],
+      },
+    })
+    const batchBody = await expectJsonError(
+      batchResponse,
+      400,
+      'POST /api/notifications/batch without title or titleKey',
+    )
+    expect(String(batchBody.error ?? batchBody.message)).toMatch(/titleKey|title/i)
+  })
+})

--- a/packages/core/src/modules/notifications/__integration__/TC-NOTIF-009.spec.ts
+++ b/packages/core/src/modules/notifications/__integration__/TC-NOTIF-009.spec.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import {
+  getTokenScope,
+} from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createNotificationFixture,
+  dismissNotificationIfExists,
+  listNotifications,
+} from '@open-mercato/core/helpers/integration/notificationsFixtures'
+import { expectJsonError } from './helpers/notificationsApi'
+
+test.describe('TC-NOTIF-009: Users cannot access other users notifications', () => {
+  test('hides and rejects read, dismiss, and action attempts for another user notification', async ({ request }) => {
+    const stamp = Date.now()
+    const password = 'Valid1!Pass'
+    const userOneEmail = `qa-notif-owner-${stamp}@acme.com`
+    const userTwoEmail = `qa-notif-other-${stamp}@acme.com`
+    const type = `qa.notifications.cross.user.${stamp}`
+    const sourceEntityId = randomUUID()
+
+    let superadminToken: string | null = null
+    let userOneToken: string | null = null
+    let userTwoToken: string | null = null
+    let roleId: string | null = null
+    let userOneId: string | null = null
+    let userTwoId: string | null = null
+    let notificationId: string | null = null
+
+    try {
+      superadminToken = await getAuthToken(request, 'superadmin')
+      const scope = getTokenScope(superadminToken)
+      roleId = await createRoleFixture(request, superadminToken, {
+        name: `qa_notif_cross_user_viewer_${stamp}`,
+        tenantId: scope.tenantId,
+      })
+      await setRoleAclFeatures(request, superadminToken, {
+        roleId,
+        features: ['notifications.view'],
+        organizations: null,
+      })
+      userOneId = await createUserFixture(request, superadminToken, {
+        email: userOneEmail,
+        password,
+        organizationId: scope.organizationId,
+        roles: [roleId],
+      })
+      userTwoId = await createUserFixture(request, superadminToken, {
+        email: userTwoEmail,
+        password,
+        organizationId: scope.organizationId,
+        roles: [roleId],
+      })
+      userOneToken = await getAuthToken(request, userOneEmail, password)
+      userTwoToken = await getAuthToken(request, userTwoEmail, password)
+
+      notificationId = await createNotificationFixture(request, superadminToken, {
+        type,
+        title: 'Notification for another user',
+        recipientUserId: userOneId,
+        sourceEntityId,
+        actions: [
+          {
+            id: 'approve',
+            label: 'Approve',
+            href: '/backend/example/{sourceEntityId}',
+          },
+        ],
+      })
+
+      const otherUserList = await listNotifications(request, userTwoToken, { type, pageSize: 10 })
+      expect(otherUserList.items.some((item) => item.id === notificationId)).toBe(false)
+      expect(otherUserList.items.length).toBe(0)
+
+      const readResponse = await apiRequest(
+        request,
+        'PUT',
+        `/api/notifications/${encodeURIComponent(notificationId)}/read`,
+        { token: userTwoToken },
+      )
+      await expectJsonError(readResponse, 404, 'other user read attempt should not find notification')
+
+      const dismissResponse = await apiRequest(
+        request,
+        'PUT',
+        `/api/notifications/${encodeURIComponent(notificationId)}/dismiss`,
+        { token: userTwoToken },
+      )
+      await expectJsonError(dismissResponse, 404, 'other user dismiss attempt should not find notification')
+
+      const actionResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/notifications/${encodeURIComponent(notificationId)}/action`,
+        { token: userTwoToken, data: { actionId: 'approve', payload: {} } },
+      )
+      await expectJsonError(actionResponse, 404, 'other user action attempt should not find notification')
+    } finally {
+      await dismissNotificationIfExists(request, userOneToken, notificationId)
+      await deleteUserIfExists(request, superadminToken, userOneId)
+      await deleteUserIfExists(request, superadminToken, userTwoId)
+      await deleteRoleIfExists(request, superadminToken, roleId)
+    }
+  })
+})

--- a/packages/core/src/modules/notifications/__integration__/TC-NOTIF-010.spec.ts
+++ b/packages/core/src/modules/notifications/__integration__/TC-NOTIF-010.spec.ts
@@ -1,0 +1,49 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createNotificationFixture,
+  dismissNotificationIfExists,
+} from '@open-mercato/core/helpers/integration/notificationsFixtures'
+
+test.describe('TC-NOTIF-010: Notification action execution', () => {
+  test('executes a notification action and returns result and resolved href', async ({ request }) => {
+    const token = await getAuthToken(request, 'superadmin')
+    const scope = getTokenScope(token)
+    const stamp = Date.now()
+    const sourceEntityId = randomUUID()
+    let notificationId: string | null = null
+
+    try {
+      notificationId = await createNotificationFixture(request, token, {
+        type: `qa.notifications.action.${stamp}`,
+        title: 'Actionable notification',
+        recipientUserId: scope.userId,
+        sourceEntityId,
+        actions: [
+          {
+            id: 'approve',
+            label: 'Approve',
+            href: '/backend/example/{sourceEntityId}',
+          },
+        ],
+      })
+
+      const response = await apiRequest(
+        request,
+        'POST',
+        `/api/notifications/${encodeURIComponent(notificationId)}/action`,
+        { token, data: { actionId: 'approve', payload: {} } },
+      )
+      expect(response.status(), 'POST /api/notifications/{id}/action should return 200').toBe(200)
+      const body = await readJsonSafe<{ ok?: boolean; result?: unknown; href?: string }>(response)
+      expect(body?.ok).toBe(true)
+      expect(body).toHaveProperty('result')
+      expect(body?.result).toBeNull()
+      expect(body?.href).toBe(`/backend/example/${sourceEntityId}`)
+    } finally {
+      await dismissNotificationIfExists(request, token, notificationId)
+    }
+  })
+})

--- a/packages/core/src/modules/notifications/__integration__/helpers/notificationsApi.ts
+++ b/packages/core/src/modules/notifications/__integration__/helpers/notificationsApi.ts
@@ -1,0 +1,41 @@
+import { expect, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+const BASE_URL = process.env.BASE_URL?.trim() || null
+
+export function resolveApiUrl(path: string): string {
+  return BASE_URL ? `${BASE_URL}${path}` : path
+}
+
+export async function rawApiRequest(
+  request: APIRequestContext,
+  method: string,
+  path: string,
+  options: { token?: string | null; data?: unknown; headers?: Record<string, string> } = {},
+): Promise<APIResponse> {
+  const headers: Record<string, string> = { ...(options.headers ?? {}) }
+  if (options.token) headers.Authorization = `Bearer ${options.token}`
+  if (options.data !== undefined) headers['Content-Type'] = 'application/json'
+  return request.fetch(resolveApiUrl(path), { method, headers, data: options.data })
+}
+
+export async function expectJsonError(
+  response: APIResponse,
+  status: number,
+  label: string,
+): Promise<Record<string, unknown>> {
+  expect(response.status(), label).toBe(status)
+  const body = await readJsonSafe<Record<string, unknown>>(response)
+  const message = body?.error ?? body?.message
+  expect(
+    typeof message === 'string' && message.length > 0,
+    `${label} should include an error or message`,
+  ).toBe(true)
+  return body ?? {}
+}
+
+export function expectRequiredFeature(body: Record<string, unknown>, feature: string): void {
+  const requiredFeatures = body.requiredFeatures
+  expect(Array.isArray(requiredFeatures), `response should list missing feature ${feature}`).toBe(true)
+  expect(requiredFeatures).toContain(feature)
+}

--- a/packages/core/src/modules/notifications/__tests__/notificationService.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/notificationService.test.ts
@@ -2,7 +2,7 @@ import { createNotificationService } from '../lib/notificationService'
 import { NOTIFICATION_EVENTS, NOTIFICATION_SSE_EVENTS } from '../lib/events'
 import type { Notification } from '../data/entities'
 import { getRecipientUserIdsForFeature } from '../lib/notificationRecipients'
-import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 jest.mock('../lib/notificationRecipients', () => ({
   getRecipientUserIdsForRole: jest.fn(),
@@ -10,6 +10,7 @@ jest.mock('../lib/notificationRecipients', () => ({
 }))
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
   findWithDecryption: jest.fn(),
 }))
 
@@ -186,7 +187,7 @@ describe('notification service', () => {
       readAt: null,
     } as Notification
 
-    em.findOneOrFail.mockResolvedValue(notification)
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValue(notification)
 
     const result = await service.markAsRead(notification.id, baseCtx)
 
@@ -201,6 +202,21 @@ describe('notification service', () => {
         tenantId: baseCtx.tenantId,
       })
     )
+  })
+
+  it('maps scoped notification misses to a 404 error', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+    const service = createNotificationService({ em, eventBus })
+
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValue(null)
+
+    await expect(service.markAsRead('missing-note', baseCtx)).rejects.toMatchObject({
+      status: 404,
+      body: { error: 'Notification not found' },
+    })
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalled()
   })
 
   it('marks all as read, scopes by org, and emits events per notification', async () => {
@@ -327,7 +343,7 @@ describe('notification service', () => {
       },
     } as Notification
 
-    em.findOneOrFail.mockResolvedValue(notification)
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValue(notification)
 
     const result = await service.executeAction(
       notification.id,

--- a/packages/core/src/modules/notifications/api/[id]/action/route.ts
+++ b/packages/core/src/modules/notifications/api/[id]/action/route.ts
@@ -1,6 +1,10 @@
 import { executeActionSchema } from '../../../data/validators'
 import { actionResultResponseSchema, errorResponseSchema } from '../../openapi'
-import { resolveNotificationContext } from '../../../lib/routeHelpers'
+import {
+  notificationCrudErrorResponse,
+  notificationValidationErrorResponse,
+  resolveNotificationContext,
+} from '../../../lib/routeHelpers'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 
 export const metadata = {
@@ -12,7 +16,11 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
   const { service, scope } = await resolveNotificationContext(req)
 
   const body = await req.json().catch(() => ({}))
-  const input = executeActionSchema.parse(body)
+  const parsed = executeActionSchema.safeParse(body)
+  if (!parsed.success) {
+    return notificationValidationErrorResponse(parsed.error)
+  }
+  const input = parsed.data
 
   try {
     const { notification, result } = await service.executeAction(id, input, scope)
@@ -26,6 +34,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
       href,
     })
   } catch (error) {
+    const errorResponse = notificationCrudErrorResponse(error)
+    if (errorResponse) return errorResponse
+
     const { t } = await resolveTranslations()
     const fallback = t('notifications.error.action', 'Failed to execute action')
     const message = error instanceof Error && error.message ? error.message : fallback

--- a/packages/core/src/modules/notifications/api/route.ts
+++ b/packages/core/src/modules/notifications/api/route.ts
@@ -3,7 +3,11 @@ import type { EntityManager } from '@mikro-orm/core'
 import { Notification } from '../data/entities'
 import { listNotificationsSchema, createNotificationSchema } from '../data/validators'
 import { toNotificationDto } from '../lib/notificationMapper'
-import { resolveNotificationContext } from '../lib/routeHelpers'
+import {
+  notificationCrudErrorResponse,
+  notificationValidationErrorResponse,
+  resolveNotificationContext,
+} from '../lib/routeHelpers'
 import {
   buildNotificationsCrudOpenApi,
   createPagedListResponseSchema,
@@ -73,11 +77,20 @@ export async function POST(req: Request) {
   const { service, scope } = await resolveNotificationContext(req)
 
   const body = await req.json().catch(() => ({}))
-  const input = createNotificationSchema.parse(body)
+  const parsed = createNotificationSchema.safeParse(body)
+  if (!parsed.success) {
+    return notificationValidationErrorResponse(parsed.error)
+  }
 
-  const notification = await service.create(input, scope)
+  try {
+    const notification = await service.create(parsed.data, scope)
 
-  return Response.json({ id: notification.id }, { status: 201 })
+    return Response.json({ id: notification.id }, { status: 201 })
+  } catch (error) {
+    const errorResponse = notificationCrudErrorResponse(error)
+    if (errorResponse) return errorResponse
+    throw error
+  }
 }
 
 export const openApi = buildNotificationsCrudOpenApi({

--- a/packages/core/src/modules/notifications/lib/notificationService.ts
+++ b/packages/core/src/modules/notifications/lib/notificationService.ts
@@ -1,10 +1,11 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { type Kysely, sql } from 'kysely'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { Notification, type NotificationStatus } from '../data/entities'
 import type { CreateNotificationInput, CreateBatchNotificationInput, CreateRoleNotificationInput, CreateFeatureNotificationInput, ExecuteActionInput } from '../data/validators'
 import type { NotificationPollData } from '@open-mercato/shared/modules/notifications/types'
 import { NOTIFICATION_EVENTS, NOTIFICATION_SSE_EVENTS } from './events'
-import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import {
   buildNotificationEntity,
   emitNotificationCreated,
@@ -74,6 +75,31 @@ function applyNotificationContent(
   notification.actionTaken = null
   notification.actionResult = null
   notification.createdAt = new Date()
+}
+
+async function findScopedNotificationOrThrow(
+  em: EntityManager,
+  notificationId: string,
+  ctx: NotificationServiceContext,
+): Promise<Notification> {
+  const notification = await findOneWithDecryption(
+    em,
+    Notification,
+    {
+      id: notificationId,
+      recipientUserId: ctx.userId,
+      tenantId: ctx.tenantId,
+    },
+    undefined,
+    {
+      tenantId: ctx.tenantId,
+      organizationId: ctx.organizationId ?? null,
+    },
+  )
+  if (!notification) {
+    throw new CrudHttpError(404, { error: 'Notification not found' })
+  }
+  return notification
 }
 
 async function emitNotificationSseEvents(
@@ -286,11 +312,7 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
 
     async markAsRead(notificationId, ctx) {
       const em = rootEm.fork()
-      const notification = await em.findOneOrFail(Notification, {
-        id: notificationId,
-        recipientUserId: ctx.userId,
-        tenantId: ctx.tenantId,
-      })
+      const notification = await findScopedNotificationOrThrow(em, notificationId, ctx)
 
       if (notification.status === 'unread') {
         notification.status = 'read'
@@ -370,11 +392,7 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
 
     async dismiss(notificationId, ctx) {
       const em = rootEm.fork()
-      const notification = await em.findOneOrFail(Notification, {
-        id: notificationId,
-        recipientUserId: ctx.userId,
-        tenantId: ctx.tenantId,
-      })
+      const notification = await findScopedNotificationOrThrow(em, notificationId, ctx)
 
       notification.status = 'dismissed'
       notification.dismissedAt = new Date()
@@ -391,11 +409,7 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
 
     async restoreDismissed(notificationId, status, ctx) {
       const em = rootEm.fork()
-      const notification = await em.findOneOrFail(Notification, {
-        id: notificationId,
-        recipientUserId: ctx.userId,
-        tenantId: ctx.tenantId,
-      })
+      const notification = await findScopedNotificationOrThrow(em, notificationId, ctx)
 
       if (notification.status !== 'dismissed') {
         return notification
@@ -425,11 +439,7 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
 
     async executeAction(notificationId, input, ctx) {
       const em = rootEm.fork()
-      const notification = await em.findOneOrFail(Notification, {
-        id: notificationId,
-        recipientUserId: ctx.userId,
-        tenantId: ctx.tenantId,
-      })
+      const notification = await findScopedNotificationOrThrow(em, notificationId, ctx)
 
       const actionData = notification.actionData
       const action = actionData?.actions?.find((a) => a.id === input.actionId)

--- a/packages/core/src/modules/notifications/lib/routeHelpers.ts
+++ b/packages/core/src/modules/notifications/lib/routeHelpers.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 import { resolveRequestContext } from '@open-mercato/shared/lib/api/context'
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveNotificationService, type NotificationService } from './notificationService'
 
 /**
@@ -18,6 +20,30 @@ export interface NotificationRequestContext {
   service: NotificationService
   scope: NotificationScope
   ctx: Awaited<ReturnType<typeof resolveRequestContext>>['ctx']
+}
+
+function formatZodIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.length ? `${issue.path.join('.')}: ` : ''
+      return `${path}${issue.message}`
+    })
+    .join('; ')
+}
+
+export async function notificationValidationErrorResponse(error: z.ZodError): Promise<Response> {
+  const { t } = await resolveTranslations()
+  const prefix = t('api.errors.invalidPayload', 'Invalid request body')
+  const details = formatZodIssues(error)
+  return Response.json(
+    { error: details ? `${prefix}: ${details}` : prefix },
+    { status: 400 },
+  )
+}
+
+export function notificationCrudErrorResponse(error: unknown): Response | null {
+  if (!isCrudHttpError(error)) return null
+  return Response.json(error.body ?? { error: 'Notification request failed' }, { status: error.status })
 }
 
 /**
@@ -49,15 +75,24 @@ export function createBulkNotificationRoute<TSchema extends z.ZodTypeAny>(
     const { service, scope } = await resolveNotificationContext(req)
 
     const body = await req.json().catch(() => ({}))
-    const input = schema.parse(body)
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) {
+      return notificationValidationErrorResponse(parsed.error)
+    }
 
-    const notifications = await service[serviceMethod](input as never, scope)
+    try {
+      const notifications = await service[serviceMethod](parsed.data as never, scope)
 
-    return Response.json({
-      ok: true,
-      count: notifications.length,
-      ids: notifications.map((n) => n.id),
-    }, { status: 201 })
+      return Response.json({
+        ok: true,
+        count: notifications.length,
+        ids: notifications.map((n) => n.id),
+      }, { status: 201 })
+    } catch (error) {
+      const errorResponse = notificationCrudErrorResponse(error)
+      if (errorResponse) return errorResponse
+      throw error
+    }
   }
 }
 
@@ -111,7 +146,13 @@ export function createSingleNotificationActionRoute(
     const { id } = await params
     const { service, scope } = await resolveNotificationContext(req)
 
-    await service[serviceMethod](id, scope)
+    try {
+      await service[serviceMethod](id, scope)
+    } catch (error) {
+      const errorResponse = notificationCrudErrorResponse(error)
+      if (errorResponse) return errorResponse
+      throw error
+    }
 
     return Response.json({ ok: true })
   }


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Expands notification integration coverage for auth, RBAC, tenant/user scoping, validation, preferences, and action execution. Fixes notification API error handling so invalid create/action payloads return JSON 400s and inaccessible notifications return scoped 404s instead of leaking internal 500s.

## Changes

- Added module-local Playwright integration specs for notification auth, create RBAC, settings RBAC, tenant/user scoping, payload validation, cross-user denial, and action execution.
- Added shared notification integration helpers for raw API requests and JSON error assertions.
- Centralized notification validation/CRUD error responses in route helpers.
- Updated notification create/action routes and single-notification action wrappers to return stable JSON errors.
- Changed scoped notification lookup for read/dismiss/restore/action to use `findOneWithDecryption` and return a 404 miss.
- Added unit coverage for scoped notification misses.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — issue-scoped integration coverage and API error handling fix.


## Testing

- PASS `yarn install`
- RED→GREEN `BASE_URL=http://127.0.0.1:63517 ENABLE_CRUD_API_CACHE=true npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/notifications/__integration__/TC-NOTIF-004.spec.ts packages/core/src/modules/notifications/__integration__/TC-NOTIF-005.spec.ts packages/core/src/modules/notifications/__integration__/TC-NOTIF-006.spec.ts packages/core/src/modules/notifications/__integration__/TC-NOTIF-007.spec.ts packages/core/src/modules/notifications/__integration__/TC-NOTIF-008.spec.ts packages/core/src/modules/notifications/__integration__/TC-NOTIF-009.spec.ts packages/core/src/modules/notifications/__integration__/TC-NOTIF-010.spec.ts --retries=0` — 7 passed
- PASS `yarn workspace @open-mercato/core test packages/core/src/modules/notifications/__tests__/notificationService.test.ts --runInBand`
- PASS `yarn build:packages`
- PASS `yarn generate`
- PASS `yarn build:packages`
- PASS `yarn i18n:check-sync`
- PASS `yarn typecheck`
- PASS `yarn test`
- PASS `yarn build:app`
- PASS `git diff --cached --check`
- Advisory existing baseline: `yarn i18n:check-usage` reports missing keys outside notifications.
- Existing tooling baseline: `yarn lint` fails before changed files due `eslint-plugin-react` error while linting `apps/mercato/next.config.ts`.
- Existing template baseline: `yarn template:sync` reports example/template dependency drift outside notifications.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

Note: integration tests were added in the module-local `packages/core/src/modules/notifications/__integration__/` suite and run with the `.ai/qa/tests/playwright.config.ts` harness. CLA checkbox is left for the human PR author.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI files or visual components changed.

## Linked issues

Fixes #2474