### PR TITLE
feat: 2475 data sync coverage

### DIFF
--- a/packages/core/src/modules/data_sync/__integration__/TC-DS-004.spec.ts
+++ b/packages/core/src/modules/data_sync/__integration__/TC-DS-004.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { isSchedulerUnavailable, readJson, uniqueIntegrationId, type JsonRecord } from './helpers/support'
+import { deleteSyncSchedulesByIntegration } from './helpers/db'
+
+/**
+ * TC-DS-004: Data sync schedule CRUD APIs
+ *
+ * Implements issue #2475 scenario "TC-DS-003 — Schedule CRUD operations"
+ * (renumbered: TC-DS-003 is already used by the options-endpoint smoke test).
+ *
+ * Exercises POST/GET/PUT/DELETE for `/api/data_sync/schedules`. Schedule writes
+ * delegate to the optional `scheduler` module; when it is not registered the API
+ * returns 422 ("Scheduler module is not available") and the test self-skips.
+ * Cleanup hard-deletes by the per-run-unique integration id.
+ */
+
+test.describe('TC-DS-004: Data sync schedule CRUD APIs', () => {
+  test('create, read, update, and delete a sync schedule', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const integrationId = uniqueIntegrationId('test_ds004')
+
+    try {
+      const createResponse = await apiRequest(request, 'POST', '/api/data_sync/schedules', {
+        token,
+        data: {
+          integrationId,
+          entityType: 'catalog.product',
+          direction: 'import',
+          scheduleType: 'cron',
+          scheduleValue: '0 0 * * *',
+          timezone: 'UTC',
+        },
+      })
+      const createBody = await readJson(createResponse)
+      if (createResponse.status() === 422 && isSchedulerUnavailable(createBody)) {
+        test.skip(true, 'Scheduler module not available — skipping schedule CRUD tests')
+        return
+      }
+
+      expect(createResponse.status()).toBe(201)
+      const scheduleId = String(createBody.id)
+      expect(scheduleId).toMatch(/^[0-9a-f-]{36}$/i)
+      expect(createBody.integrationId).toBe(integrationId)
+      expect(createBody.entityType).toBe('catalog.product')
+      expect(createBody.direction).toBe('import')
+      expect(createBody.scheduleType).toBe('cron')
+      expect(createBody.scheduleValue).toBe('0 0 * * *')
+      expect(createBody.timezone).toBe('UTC')
+      expect(createBody.fullSync).toBe(false)
+      expect(createBody.isEnabled).toBe(true)
+      expect(typeof createBody.createdAt).toBe('string')
+      expect(typeof createBody.updatedAt).toBe('string')
+
+      // List schedules — created schedule must appear with the paginated envelope
+      const listResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/data_sync/schedules?integrationId=${integrationId}`,
+        { token },
+      )
+      expect(listResponse.status()).toBe(200)
+      const listBody = await readJson(listResponse)
+      expect(Array.isArray(listBody.items)).toBe(true)
+      const listItems = listBody.items as JsonRecord[]
+      expect(listItems.map((item) => String(item.id))).toContain(scheduleId)
+      expect(listBody).toHaveProperty('total')
+      expect(listBody.page).toBe(1)
+      expect(typeof listBody.pageSize).toBe('number')
+      expect(typeof listBody.totalPages).toBe('number')
+
+      // Get by id — full object
+      const getResponse = await apiRequest(request, 'GET', `/api/data_sync/schedules/${scheduleId}`, { token })
+      expect(getResponse.status()).toBe(200)
+      const getBody = await readJson(getResponse)
+      expect(getBody.id).toBe(scheduleId)
+      expect(getBody.integrationId).toBe(integrationId)
+      expect(getBody.scheduleValue).toBe('0 0 * * *')
+      expect(getBody.timezone).toBe('UTC')
+
+      // Update timezone
+      const updateResponse = await apiRequest(request, 'PUT', `/api/data_sync/schedules/${scheduleId}`, {
+        token,
+        data: { timezone: 'America/New_York' },
+      })
+      expect(updateResponse.status()).toBe(200)
+      const updateBody = await readJson(updateResponse)
+      expect(updateBody.id).toBe(scheduleId)
+      expect(updateBody.timezone).toBe('America/New_York')
+      expect(new Date(String(updateBody.updatedAt)).getTime()).toBeGreaterThanOrEqual(
+        new Date(String(createBody.createdAt)).getTime(),
+      )
+
+      // Verify update persisted
+      const verifyResponse = await apiRequest(request, 'GET', `/api/data_sync/schedules/${scheduleId}`, { token })
+      expect(verifyResponse.status()).toBe(200)
+      const verifyBody = await readJson(verifyResponse)
+      expect(verifyBody.timezone).toBe('America/New_York')
+
+      // Delete (also unregisters the scheduler job)
+      const deleteResponse = await apiRequest(request, 'DELETE', `/api/data_sync/schedules/${scheduleId}`, { token })
+      expect(deleteResponse.status()).toBe(200)
+      const deleteBody = await readJson(deleteResponse)
+      expect(deleteBody.deleted).toBe(true)
+
+      // Subsequent get returns 404
+      const afterDeleteResponse = await apiRequest(request, 'GET', `/api/data_sync/schedules/${scheduleId}`, { token })
+      expect(afterDeleteResponse.status()).toBe(404)
+    } finally {
+      await deleteSyncSchedulesByIntegration(integrationId)
+    }
+  })
+})

--- a/packages/core/src/modules/data_sync/__integration__/TC-DS-005.spec.ts
+++ b/packages/core/src/modules/data_sync/__integration__/TC-DS-005.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJson, uniqueIntegrationId, type JsonRecord } from './helpers/support'
+import { decodeTokenScope, deleteSyncRunsByIntegration, seedSyncRuns } from './helpers/db'
+
+/**
+ * TC-DS-005: Data sync run list filtering by status and direction
+ *
+ * Implements issue #2475 scenario "TC-DS-004 — Run list filtering by status and
+ * direction" (renumbered to avoid the existing TC-DS-003/004 files).
+ *
+ * Run status cannot be controlled deterministically through the API (the queue
+ * worker advances runs asynchronously), so runs are seeded directly in Postgres
+ * under a per-run-unique integration id. Filtering by that id isolates the seeded
+ * rows so `status`/`direction` assertions are exact. Cleanup hard-deletes them.
+ */
+
+test.describe('TC-DS-005: Data sync run list filtering', () => {
+  test('filters runs by status, direction, and combined query params', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const scope = decodeTokenScope(token)
+    const integrationId = uniqueIntegrationId('test_ds005')
+    const entityType = 'catalog.product'
+    const now = Date.now()
+
+    // Seeded newest → oldest so the unfiltered list order is deterministic.
+    const [completedId, failedId, pendingId] = await seedSyncRuns([
+      { ...scope, integrationId, entityType, direction: 'import', status: 'completed', createdAt: new Date(now) },
+      {
+        ...scope,
+        integrationId,
+        entityType,
+        direction: 'export',
+        status: 'failed',
+        lastError: 'TC-DS-005 seeded failure',
+        createdAt: new Date(now - 1000),
+      },
+      { ...scope, integrationId, entityType, direction: 'import', status: 'pending', createdAt: new Date(now - 2000) },
+    ])
+
+    const idsFor = (body: JsonRecord): string[] => (body.items as JsonRecord[]).map((item) => String(item.id))
+
+    try {
+      // status=completed → only the completed run
+      const completedRes = await apiRequest(
+        request,
+        'GET',
+        `/api/data_sync/runs?integrationId=${integrationId}&status=completed`,
+        { token },
+      )
+      expect(completedRes.status()).toBe(200)
+      const completedBody = await readJson(completedRes)
+      expect(idsFor(completedBody)).toEqual([completedId])
+      expect((completedBody.items as JsonRecord[]).every((item) => item.status === 'completed')).toBe(true)
+
+      // status=failed → only the failed run, with its persisted lastError
+      const failedRes = await apiRequest(
+        request,
+        'GET',
+        `/api/data_sync/runs?integrationId=${integrationId}&status=failed`,
+        { token },
+      )
+      const failedBody = await readJson(failedRes)
+      expect(idsFor(failedBody)).toEqual([failedId])
+      expect((failedBody.items as JsonRecord[])[0].lastError).toBe('TC-DS-005 seeded failure')
+
+      // direction=export → only the export run (the failed one)
+      const exportRes = await apiRequest(
+        request,
+        'GET',
+        `/api/data_sync/runs?integrationId=${integrationId}&direction=export`,
+        { token },
+      )
+      const exportBody = await readJson(exportRes)
+      expect(idsFor(exportBody)).toEqual([failedId])
+
+      // combined integrationId + entityType + direction + status → only the pending import run
+      const combinedRes = await apiRequest(
+        request,
+        'GET',
+        `/api/data_sync/runs?integrationId=${integrationId}&entityType=${entityType}&direction=import&status=pending`,
+        { token },
+      )
+      const combinedBody = await readJson(combinedRes)
+      expect(idsFor(combinedBody)).toEqual([pendingId])
+
+      // No status/direction filter → all three for this integration, ordered createdAt DESC
+      const allRes = await apiRequest(request, 'GET', `/api/data_sync/runs?integrationId=${integrationId}`, { token })
+      const allBody = await readJson(allRes)
+      expect(allBody.total).toBe(3)
+      expect(idsFor(allBody)).toEqual([completedId, failedId, pendingId])
+    } finally {
+      await deleteSyncRunsByIntegration(integrationId)
+    }
+  })
+})

--- a/packages/core/src/modules/data_sync/__integration__/TC-DS-006.spec.ts
+++ b/packages/core/src/modules/data_sync/__integration__/TC-DS-006.spec.ts
@@ -1,0 +1,119 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { BASE_URL, isSchedulerUnavailable, readJson, uniqueIntegrationId } from './helpers/support'
+import { deleteSyncSchedulesByIntegration } from './helpers/db'
+
+/**
+ * TC-DS-006: Authorization enforcement on schedule endpoints
+ *
+ * Implements issue #2475 scenario "TC-DS-005 — Authorization enforcement on
+ * schedule endpoints" (renumbered to avoid the existing TC-DS files).
+ *
+ * Schedule endpoints require the `data_sync.configure` feature. The seeded
+ * `employee` role holds `data_sync.view` but NOT `data_sync.configure`, so it is
+ * rejected with 403. `requireFeatures` is enforced before the handler runs, so
+ * employee 403s land even on fabricated ids without touching the database.
+ */
+
+const SCHEDULE_PATH = '/api/data_sync/schedules'
+
+test.describe('TC-DS-006: Data sync schedule authorization', () => {
+  test('unauthenticated requests are rejected with 401', async ({ request }) => {
+    const getResponse = await request.get(`${BASE_URL}${SCHEDULE_PATH}`)
+    expect(getResponse.status()).toBe(401)
+
+    const postResponse = await request.post(`${BASE_URL}${SCHEDULE_PATH}`, {
+      data: {
+        integrationId: 'unauthenticated',
+        entityType: 'catalog.product',
+        direction: 'import',
+        scheduleType: 'cron',
+        scheduleValue: '0 0 * * *',
+      },
+    })
+    expect(postResponse.status()).toBe(401)
+
+    const putResponse = await request.put(`${BASE_URL}${SCHEDULE_PATH}/${randomUUID()}`, {
+      data: { timezone: 'UTC' },
+    })
+    expect(putResponse.status()).toBe(401)
+
+    const deleteResponse = await request.delete(`${BASE_URL}${SCHEDULE_PATH}/${randomUUID()}`)
+    expect(deleteResponse.status()).toBe(401)
+  })
+
+  test('employee without data_sync.configure is rejected with 403', async ({ request }) => {
+    const employeeToken = await getAuthToken(request, 'employee')
+
+    const getResponse = await apiRequest(request, 'GET', SCHEDULE_PATH, { token: employeeToken })
+    expect(getResponse.status()).toBe(403)
+
+    const postResponse = await apiRequest(request, 'POST', SCHEDULE_PATH, {
+      token: employeeToken,
+      data: {
+        integrationId: 'employee-forbidden',
+        entityType: 'catalog.product',
+        direction: 'import',
+        scheduleType: 'cron',
+        scheduleValue: '0 0 * * *',
+      },
+    })
+    expect(postResponse.status()).toBe(403)
+
+    // requireFeatures runs before the handler, so a fabricated id still 403s (not 404)
+    const putResponse = await apiRequest(request, 'PUT', `${SCHEDULE_PATH}/${randomUUID()}`, {
+      token: employeeToken,
+      data: { timezone: 'UTC' },
+    })
+    expect(putResponse.status()).toBe(403)
+
+    const deleteResponse = await apiRequest(request, 'DELETE', `${SCHEDULE_PATH}/${randomUUID()}`, {
+      token: employeeToken,
+    })
+    expect(deleteResponse.status()).toBe(403)
+  })
+
+  test('admin with data_sync.configure can read and manage schedules', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    // Read access is always available to admin (no scheduler dependency)
+    const listResponse = await apiRequest(request, 'GET', SCHEDULE_PATH, { token })
+    expect(listResponse.status()).toBe(200)
+
+    // Positive write baseline (create/update/delete) needs the scheduler module.
+    const integrationId = uniqueIntegrationId('test_ds006')
+    try {
+      const createResponse = await apiRequest(request, 'POST', SCHEDULE_PATH, {
+        token,
+        data: {
+          integrationId,
+          entityType: 'catalog.product',
+          direction: 'import',
+          scheduleType: 'cron',
+          scheduleValue: '0 0 * * *',
+          timezone: 'UTC',
+        },
+      })
+      const createBody = await readJson(createResponse)
+      if (createResponse.status() === 422 && isSchedulerUnavailable(createBody)) {
+        // 401/403 enforcement above is the security-critical surface; the positive
+        // write path is environment-dependent and covered by TC-DS-004.
+        return
+      }
+      expect(createResponse.status()).toBe(201)
+      const scheduleId = String(createBody.id)
+
+      const updateResponse = await apiRequest(request, 'PUT', `${SCHEDULE_PATH}/${scheduleId}`, {
+        token,
+        data: { timezone: 'UTC' },
+      })
+      expect(updateResponse.status()).toBe(200)
+
+      const deleteResponse = await apiRequest(request, 'DELETE', `${SCHEDULE_PATH}/${scheduleId}`, { token })
+      expect(deleteResponse.status()).toBe(200)
+    } finally {
+      await deleteSyncSchedulesByIntegration(integrationId)
+    }
+  })
+})

--- a/packages/core/src/modules/data_sync/__integration__/TC-DS-007.spec.ts
+++ b/packages/core/src/modules/data_sync/__integration__/TC-DS-007.spec.ts
@@ -1,0 +1,67 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJson, uniqueIntegrationId } from './helpers/support'
+import { decodeTokenScope, deleteSyncRunsByIntegration, seedSyncRuns } from './helpers/db'
+
+/**
+ * TC-DS-007: Run retry state validation
+ *
+ * Implements issue #2475 scenario "TC-DS-006 — Run state validation: prevent
+ * retry of completed/running runs" (renumbered to avoid existing TC-DS files).
+ *
+ * `POST /api/data_sync/runs/:id/retry` only allows runs in `failed`/`cancelled`
+ * state (retry.ts) — any other state returns 409, and a missing run returns 404.
+ * Runs are seeded directly in Postgres to control status deterministically.
+ *
+ * The positive path (failed/cancelled → 201 new run, inheriting integration +
+ * entity + direction) is already covered by TC-DS-001; this spec covers the
+ * state-guard rejections that TC-DS-001 does not exercise.
+ */
+
+test.describe('TC-DS-007: Data sync run retry state validation', () => {
+  test('rejects retry of completed, running, and missing runs', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const scope = decodeTokenScope(token)
+    const integrationId = uniqueIntegrationId('test_ds007')
+    const entityType = 'catalog.product'
+
+    const [completedId, runningId] = await seedSyncRuns([
+      { ...scope, integrationId, entityType, direction: 'import', status: 'completed' },
+      { ...scope, integrationId, entityType, direction: 'import', status: 'running' },
+    ])
+
+    try {
+      // Completed run cannot be retried
+      const completedRetry = await apiRequest(
+        request,
+        'POST',
+        `/api/data_sync/runs/${completedId}/retry`,
+        { token, data: { fromBeginning: false } },
+      )
+      expect(completedRetry.status()).toBe(409)
+      const completedBody = await readJson(completedRetry)
+      expect(String(completedBody.error ?? '')).toMatch(/only failed or cancelled runs can be retried/i)
+
+      // Running run cannot be retried
+      const runningRetry = await apiRequest(
+        request,
+        'POST',
+        `/api/data_sync/runs/${runningId}/retry`,
+        { token, data: { fromBeginning: false } },
+      )
+      expect(runningRetry.status()).toBe(409)
+
+      // Missing run returns 404 (well-formed uuid that does not exist)
+      const missingRetry = await apiRequest(
+        request,
+        'POST',
+        `/api/data_sync/runs/${randomUUID()}/retry`,
+        { token, data: { fromBeginning: false } },
+      )
+      expect(missingRetry.status()).toBe(404)
+    } finally {
+      await deleteSyncRunsByIntegration(integrationId)
+    }
+  })
+})

--- a/packages/core/src/modules/data_sync/__integration__/TC-DS-008.spec.ts
+++ b/packages/core/src/modules/data_sync/__integration__/TC-DS-008.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJson, uniqueIntegrationId, type JsonRecord } from './helpers/support'
+import { decodeTokenScope, deleteSyncRunsByIntegration, seedSyncRuns, type SeedSyncRunInput } from './helpers/db'
+
+/**
+ * TC-DS-008: Run list pagination boundaries and maxPageSize
+ *
+ * Implements issue #2475 scenario "TC-DS-007 — Run list pagination boundaries
+ * and maxPageSize" (renumbered to avoid existing TC-DS files).
+ *
+ * `listSyncRunsQuerySchema` enforces page >= 1 and 1 <= pageSize <= 100; out-of-
+ * range values return 400 ("Invalid query") before any DB access. Page math is
+ * verified against deterministically-seeded runs (distinct createdAt → stable
+ * DESC ordering) scoped to a per-run-unique integration id.
+ */
+
+test.describe('TC-DS-008: Data sync run list pagination', () => {
+  test('rejects out-of-range page and pageSize with 400', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const maxAllowed = await apiRequest(request, 'GET', '/api/data_sync/runs?page=1&pageSize=100', { token })
+    expect(maxAllowed.status()).toBe(200)
+
+    const tooLarge = await apiRequest(request, 'GET', '/api/data_sync/runs?page=1&pageSize=101', { token })
+    expect(tooLarge.status()).toBe(400)
+
+    const zeroPage = await apiRequest(request, 'GET', '/api/data_sync/runs?page=0&pageSize=20', { token })
+    expect(zeroPage.status()).toBe(400)
+
+    const zeroPageSize = await apiRequest(request, 'GET', '/api/data_sync/runs?page=1&pageSize=0', { token })
+    expect(zeroPageSize.status()).toBe(400)
+  })
+
+  test('paginates seeded runs with correct page math and ordering', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const scope = decodeTokenScope(token)
+    const integrationId = uniqueIntegrationId('test_ds008')
+    const entityType = 'catalog.product'
+
+    const total = 25
+    const now = Date.now()
+    // index 0 = newest; createdAt steps of 1s keep DESC ordering stable
+    const seeds: SeedSyncRunInput[] = Array.from({ length: total }, (_, index) => ({
+      ...scope,
+      integrationId,
+      entityType,
+      direction: 'import',
+      status: 'completed',
+      createdAt: new Date(now - index * 1000),
+    }))
+    const seededIds = await seedSyncRuns(seeds)
+
+    const idsFor = (body: JsonRecord): string[] => (body.items as JsonRecord[]).map((item) => String(item.id))
+
+    try {
+      const page1Res = await apiRequest(
+        request,
+        'GET',
+        `/api/data_sync/runs?integrationId=${integrationId}&page=1&pageSize=20`,
+        { token },
+      )
+      expect(page1Res.status()).toBe(200)
+      const page1 = await readJson(page1Res)
+      expect(page1.total).toBe(total)
+      expect(page1.page).toBe(1)
+      expect(page1.pageSize).toBe(20)
+      expect(page1.totalPages).toBe(2)
+      const page1Ids = idsFor(page1)
+      expect(page1Ids).toHaveLength(20)
+      expect(page1Ids).toEqual(seededIds.slice(0, 20))
+
+      const page2Res = await apiRequest(
+        request,
+        'GET',
+        `/api/data_sync/runs?integrationId=${integrationId}&page=2&pageSize=20`,
+        { token },
+      )
+      const page2 = await readJson(page2Res)
+      const page2Ids = idsFor(page2)
+      expect(page2Ids).toHaveLength(5)
+      expect(page2Ids).toEqual(seededIds.slice(20))
+
+      // Pages are disjoint
+      const page1IdSet = new Set(page1Ids)
+      expect(page2Ids.every((id) => !page1IdSet.has(id))).toBe(true)
+
+      // pageSize=100 returns the whole set in a single page
+      const allRes = await apiRequest(
+        request,
+        'GET',
+        `/api/data_sync/runs?integrationId=${integrationId}&page=1&pageSize=100`,
+        { token },
+      )
+      const all = await readJson(allRes)
+      expect(idsFor(all)).toHaveLength(total)
+      expect(all.totalPages).toBe(1)
+    } finally {
+      await deleteSyncRunsByIntegration(integrationId)
+    }
+  })
+})

--- a/packages/core/src/modules/data_sync/__integration__/TC-DS-009.spec.ts
+++ b/packages/core/src/modules/data_sync/__integration__/TC-DS-009.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { isSchedulerUnavailable, readJson, uniqueIntegrationId } from './helpers/support'
+import { deleteSyncSchedulesByIntegration } from './helpers/db'
+
+/**
+ * TC-DS-009: Schedule create validation (schema + cron/interval expression)
+ *
+ * Implements issue #2475 scenario "TC-DS-008 — Schedule create with invalid cron
+ * expression" (renumbered to avoid existing TC-DS files).
+ *
+ * Two validation layers return 422:
+ *  - the zod `createSyncScheduleSchema` (empty value, missing field, bad enum), and
+ *  - the scheduler's cron/interval parser, invoked when the schedule is registered.
+ * The cron/interval cases depend on the optional `scheduler` module and self-skip
+ * when it is unavailable. A malformed expression persists a row before the parser
+ * throws, so cleanup hard-deletes by integration id.
+ */
+
+const SCHEDULE_PATH = '/api/data_sync/schedules'
+
+test.describe('TC-DS-009: Data sync schedule validation', () => {
+  test('rejects payloads that fail schema validation with 422', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    // Empty scheduleValue (zod .min(1)) — rejected before the service runs
+    const emptyValue = await apiRequest(request, 'POST', SCHEDULE_PATH, {
+      token,
+      data: {
+        integrationId: uniqueIntegrationId('test_ds009_empty'),
+        entityType: 'catalog.product',
+        direction: 'import',
+        scheduleType: 'cron',
+        scheduleValue: '',
+      },
+    })
+    expect(emptyValue.status()).toBe(422)
+
+    // Missing required integrationId
+    const missingField = await apiRequest(request, 'POST', SCHEDULE_PATH, {
+      token,
+      data: {
+        entityType: 'catalog.product',
+        direction: 'import',
+        scheduleType: 'cron',
+        scheduleValue: '0 0 * * *',
+      },
+    })
+    expect(missingField.status()).toBe(422)
+
+    // Invalid scheduleType enum
+    const badType = await apiRequest(request, 'POST', SCHEDULE_PATH, {
+      token,
+      data: {
+        integrationId: uniqueIntegrationId('test_ds009_enum'),
+        entityType: 'catalog.product',
+        direction: 'import',
+        scheduleType: 'weekly',
+        scheduleValue: '0 0 * * *',
+      },
+    })
+    expect(badType.status()).toBe(422)
+  })
+
+  test('rejects invalid cron and interval expressions with 422', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const cronIntegration = uniqueIntegrationId('test_ds009_cron')
+    const intervalIntegration = uniqueIntegrationId('test_ds009_interval')
+    const validIntegration = uniqueIntegrationId('test_ds009_valid')
+
+    try {
+      // Valid baseline first — also probes scheduler availability
+      const validRes = await apiRequest(request, 'POST', SCHEDULE_PATH, {
+        token,
+        data: {
+          integrationId: validIntegration,
+          entityType: 'catalog.product',
+          direction: 'import',
+          scheduleType: 'cron',
+          scheduleValue: '0 0 * * *',
+          timezone: 'UTC',
+        },
+      })
+      const validBody = await readJson(validRes)
+      if (validRes.status() === 422 && isSchedulerUnavailable(validBody)) {
+        test.skip(true, 'Scheduler module not available — cron/interval validation lives in the scheduler')
+        return
+      }
+      expect(validRes.status()).toBe(201)
+      const validId = String(validBody.id)
+
+      // Invalid cron expression — rejected by the scheduler's cron parser
+      const badCron = await apiRequest(request, 'POST', SCHEDULE_PATH, {
+        token,
+        data: {
+          integrationId: cronIntegration,
+          entityType: 'catalog.product',
+          direction: 'import',
+          scheduleType: 'cron',
+          scheduleValue: 'invalid cron!@#',
+          timezone: 'UTC',
+        },
+      })
+      expect(badCron.status()).toBe(422)
+
+      // Invalid interval expression — rejected by the scheduler's interval parser
+      const badInterval = await apiRequest(request, 'POST', SCHEDULE_PATH, {
+        token,
+        data: {
+          integrationId: intervalIntegration,
+          entityType: 'catalog.product',
+          direction: 'import',
+          scheduleType: 'interval',
+          scheduleValue: 'not-a-number',
+          timezone: 'UTC',
+        },
+      })
+      expect(badInterval.status()).toBe(422)
+
+      // Clean up the valid schedule through the API so the scheduler job is unregistered
+      const deleteValid = await apiRequest(request, 'DELETE', `${SCHEDULE_PATH}/${validId}`, { token })
+      expect(deleteValid.status()).toBe(200)
+    } finally {
+      await deleteSyncSchedulesByIntegration(cronIntegration)
+      await deleteSyncSchedulesByIntegration(intervalIntegration)
+      await deleteSyncSchedulesByIntegration(validIntegration)
+    }
+  })
+})

--- a/packages/core/src/modules/data_sync/__integration__/helpers/db.ts
+++ b/packages/core/src/modules/data_sync/__integration__/helpers/db.ts
@@ -1,0 +1,153 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { Client } from 'pg'
+
+/**
+ * Direct-Postgres fixtures for data_sync integration specs.
+ *
+ * Sync run status (`completed`/`failed`/`running`) is normally only reachable by
+ * letting the queue worker process a run, which is non-deterministic in a test
+ * (and, under AUTO_SPAWN_WORKERS, auto-completes real imports). These helpers
+ * insert `sync_runs` rows directly so run status, ordering, and counts can be
+ * asserted deterministically without going through the queue — the same
+ * `pg`-based approach already used by the shared `dbFixtures` helpers.
+ *
+ * They talk to `DATABASE_URL`, so the spec MUST run under a coherent app+DB
+ * stack (the `yarn test:integration` harness) where the app server and these
+ * fixtures share the same database.
+ */
+
+function resolveAppRoot(): string {
+  const fromEnv = process.env.OM_TEST_APP_ROOT?.trim()
+  return fromEnv ? path.resolve(fromEnv) : path.resolve(process.cwd(), 'apps/mercato')
+}
+
+function readEnvValue(key: string): string | undefined {
+  if (process.env[key]) return process.env[key]
+  const candidatePaths = [
+    path.resolve(resolveAppRoot(), '.env'),
+    path.resolve(process.cwd(), 'apps/mercato/.env'),
+    path.resolve(process.cwd(), '.env'),
+  ]
+  for (const envPath of candidatePaths) {
+    try {
+      const content = readFileSync(envPath, 'utf-8')
+      const match = content.match(new RegExp(`^${key}=(.+)$`, 'm'))
+      if (match?.[1]) return match[1].trim()
+    } catch {
+      continue
+    }
+  }
+  return undefined
+}
+
+function resolveDatabaseUrl(): string {
+  const url = readEnvValue('DATABASE_URL')
+  if (!url) throw new Error('[internal] DATABASE_URL is not configured for data_sync DB fixtures')
+  return url
+}
+
+async function withClient<T>(run: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client({ connectionString: resolveDatabaseUrl() })
+  await client.connect()
+  try {
+    return await run(client)
+  } finally {
+    await client.end()
+  }
+}
+
+export type SyncRunScope = {
+  organizationId: string
+  tenantId: string
+}
+
+export type SeedSyncRunInput = SyncRunScope & {
+  id?: string
+  integrationId: string
+  entityType: string
+  direction: 'import' | 'export'
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'paused'
+  createdAt?: Date
+  updatedAt?: Date
+  lastError?: string | null
+}
+
+/**
+ * Decodes the tenant/organization scope from an integration-test JWT so seeded
+ * rows match the scope the API filters by (`auth.orgId` / `auth.tenantId`).
+ */
+export function decodeTokenScope(token: string): SyncRunScope {
+  const parts = token.split('.')
+  if (parts.length < 2) throw new Error('[internal] malformed auth token')
+  const normalized = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+  const payload = JSON.parse(Buffer.from(padded, 'base64').toString('utf8')) as {
+    tenantId?: string
+    orgId?: string | null
+  }
+  if (!payload.orgId || !payload.tenantId) {
+    throw new Error('[internal] auth token is missing orgId/tenantId claims')
+  }
+  return { organizationId: payload.orgId, tenantId: payload.tenantId }
+}
+
+/**
+ * Inserts `sync_runs` rows directly (bypassing the queue/worker) so run status
+ * and ordering are deterministic. Returns the row ids in input order.
+ */
+export async function seedSyncRuns(rows: SeedSyncRunInput[]): Promise<string[]> {
+  if (rows.length === 0) return []
+  return withClient(async (client) => {
+    const ids: string[] = []
+    for (const row of rows) {
+      const id = row.id ?? randomUUID()
+      const createdAt = row.createdAt ?? new Date()
+      const updatedAt = row.updatedAt ?? createdAt
+      await client.query(
+        `insert into sync_runs
+           (id, integration_id, entity_type, direction, status,
+            created_count, updated_count, skipped_count, failed_count, batches_completed,
+            last_error, organization_id, tenant_id, created_at, updated_at)
+         values ($1, $2, $3, $4, $5, 0, 0, 0, 0, 0, $6, $7, $8, $9, $10)`,
+        [
+          id,
+          row.integrationId,
+          row.entityType,
+          row.direction,
+          row.status,
+          row.lastError ?? null,
+          row.organizationId,
+          row.tenantId,
+          createdAt,
+          updatedAt,
+        ],
+      )
+      ids.push(id)
+    }
+    return ids
+  })
+}
+
+/** Convenience wrapper to seed a single run and return its id. */
+export async function seedSyncRun(row: SeedSyncRunInput): Promise<string> {
+  const [id] = await seedSyncRuns([row])
+  return id
+}
+
+/** Hard-deletes every `sync_runs` row for an integration (best-effort cleanup). */
+export async function deleteSyncRunsByIntegration(integrationId: string): Promise<void> {
+  if (!integrationId) return
+  await withClient(async (client) => {
+    await client.query('delete from sync_runs where integration_id = $1', [integrationId])
+  })
+}
+
+/** Hard-deletes every `sync_schedules` row for an integration (best-effort cleanup). */
+export async function deleteSyncSchedulesByIntegration(integrationId: string): Promise<void> {
+  if (!integrationId) return
+  await withClient(async (client) => {
+    await client.query('delete from sync_schedules where integration_id = $1', [integrationId])
+  })
+}

--- a/packages/core/src/modules/data_sync/__integration__/helpers/support.ts
+++ b/packages/core/src/modules/data_sync/__integration__/helpers/support.ts
@@ -1,0 +1,29 @@
+import { type APIResponse } from '@playwright/test'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
+
+export type JsonRecord = Record<string, unknown>
+
+export const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
+
+export async function readJson(response: APIResponse): Promise<JsonRecord> {
+  return ((await readJsonSafe<JsonRecord>(response)) ?? {}) as JsonRecord
+}
+
+/**
+ * Builds a per-run-unique integration id so each spec's seeded runs/schedules are
+ * isolated from any other rows in the shared tenant — list/filter assertions can
+ * then be exact, and cleanup can hard-delete by integration id.
+ */
+export function uniqueIntegrationId(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+}
+
+/**
+ * `POST/PUT /api/data_sync/schedules` returns 422 when the optional `scheduler`
+ * module is not registered (the schedule service throws before persisting a job).
+ * Schedule write tests treat that as an environment skip rather than a failure.
+ */
+export function isSchedulerUnavailable(body: JsonRecord): boolean {
+  const message = String(body.error ?? body.message ?? '')
+  return /scheduler module is not available/i.test(message)
+}


### PR DESCRIPTION
## Summary

Adds integration-test coverage for the `data_sync` module (closes the gaps called out in #2475): schedule CRUD, schedule authorization, schedule validation, run list filtering, run retry state-validation, and run list pagination. All specs are self-contained, create fixtures via API or direct Postgres, and clean up in `finally`.

The issue proposed scenarios `TC-DS-003`..`TC-DS-008`, but `TC-DS-003.spec.ts` is already used by the options-endpoint smoke test (landed via #2055). The new specs are therefore renumbered to **TC-DS-004..009**, and each docblock cross-references its original #2475 scenario.

## Changes

- `TC-DS-004` — schedule CRUD (POST/GET/PUT/DELETE → 201/200/200/200; 404 after delete). Self-skips when the optional `scheduler` module is absent.
- `TC-DS-005` — run list filtering by `status`, `direction`, and combined params; unfiltered order is `createdAt DESC`.
- `TC-DS-006` — schedule authorization: 401 unauthenticated, 403 for `employee` (lacks `data_sync.configure`), admin baseline.
- `TC-DS-007` — retry state guards: completed/running → 409, missing run → 404 (the positive `failed/cancelled → 201` path is already covered by TC-DS-001).
- `TC-DS-008` — pagination bounds (`pageSize=101`/`page=0`/`pageSize=0` → 400) plus page-math over 25 seeded runs.
- `TC-DS-009` — schema validation (empty value / missing field / bad enum → 422) and invalid cron/interval → 422 (validated by the scheduler, caught by the route).
- `helpers/db.ts` — direct-Postgres seeding of `sync_runs` (run status can't be driven deterministically through the queue) + JWT-scope decode + hard-delete cleanup.
- `helpers/support.ts` — shared `readJson` / `uniqueIntegrationId` / scheduler-availability probe.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test-only coverage addition driven by the scenarios enumerated in #2475; no `.ai/specs/` change required.

## Testing

- `yarn turbo run typecheck --filter=@open-mercato/core` — pass (core's `tsc` type-checks `__integration__` specs).
- `OM_INTEGRATION_MODULES=data_sync ENABLE_CRUD_API_CACHE=true yarn mercato test:integration` (fresh ephemeral Docker env) — **37 passed, 1 skipped, exit 0**; all TC-DS-004..009 green. Re-confirmed via the reuse path (37 passed).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — test-only.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Specs live in the module-local `__integration__/` folder per `.ai/qa/AGENTS.md`, which is what the shared `.ai/qa/tests/playwright.config.ts` discovers.)
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2475