### PR TITLE
test(core): CrudForm field-persistence integration harness + skip flag (#2466)

### DIFF
--- a/.ai/qa/AGENTS.md
+++ b/.ai/qa/AGENTS.md
@@ -117,6 +117,51 @@ Queue-backed tests:
 
 ---
 
+## CrudForm Field-Persistence Sweep (#2466)
+
+Automated follow-up to the manual CrudForm data-persistence QA (umbrella #2466). Every
+CrudForm / detail-edit surface gets a spec proving it **saves and reloads every field type**
+— scalars, dictionary references, multiselect/array values, and **custom fields** — on both
+create and update. Specs land per-module under `__integration__/TC-<MOD>-CRUDFORM-*.spec.ts`.
+
+### Shared harness
+
+`@open-mercato/core/helpers/integration/crudFormPersistence`:
+
+- `skipIfCrudFormExtensionTestsDisabled()` — call in `test.beforeAll`; skips the spec when the
+  sweep is disabled (see flag below).
+- `runCrudFormRoundTrip(config)` — runs create → read-back → assert all fields → update →
+  read-back → assert → delete for a makeCrud collection route. Pass `expectAfterCreate` /
+  `expectAfterUpdate` as `{ scalars?, customFields? }`. Supply `readById` for detail-GET routes.
+- `assertScalarFieldsPersisted(record, expected)` / `assertCustomFieldsPersisted(record, expected)`
+  — for hand-written specs that don't fit the round-trip runner.
+- `getCustomFieldValue(record, name)` — resolves a custom field from any response shape
+  (`customValues` bare keys, top-level `cf_<name>` / `cf:<name>`, or a `customFields[]` array).
+
+Reference spec: `packages/core/src/modules/currencies/__integration__/TC-CUR-CRUDFORM-001.spec.ts`.
+
+### Disable flag
+
+`OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default **false** → the sweep runs). Set
+truthy (`1`/`true`/`yes`/`on`) to skip every CrudForm-persistence spec wholesale without
+deleting them — parsed via `parseBooleanWithDefault` from `@open-mercato/shared/lib/boolean`.
+
+### Re-run the whole sweep
+
+```bash
+# All CrudForm-persistence specs across all modules (against a running app on :3000):
+npx playwright test --config .ai/qa/tests/playwright.config.ts CRUDFORM
+# One module only:
+OM_INTEGRATION_MODULES=currencies npx playwright test --config .ai/qa/tests/playwright.config.ts CRUDFORM
+# Disable the sweep (e.g. on a constrained CI lane):
+OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED=1 yarn test:integration
+```
+
+The pure harness logic (env-gate + custom-field resolution) is unit-tested under jest at
+`packages/core/src/helpers/integration/__tests__/crudFormFields.test.ts` (runs in `yarn test`).
+
+---
+
 ## Scenarios Are Optional
 
 Markdown test scenarios (`.ai/qa/scenarios/TC-*.md`) are **optional reference material**. Tests can be generated through any of these paths:

--- a/.ai/runs/2026-06-04-crudform-integration-tests/HANDOFF.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/HANDOFF.md
@@ -1,31 +1,40 @@
 # Handoff — 2026-06-04-crudform-integration-tests
 
-**Last updated:** 2026-06-04T20:55:00Z
-**Branch:** feat/crudform-integration-tests (off origin/develop @ 0bd8b3aab)
-**PR:** (opening now)
-**Current phase/step:** Phase 1 COMPLETE (foundation). All 5 Tasks-table rows `done`.
-**Last commit:** docs(qa) sweep documentation (8e50cbbab)
+**Last updated:** 2026-06-04T21:45:00Z
+**Foundation branch:** feat/crudform-integration-tests (off origin/develop @ 0bd8b3aab)
+**Master ledger:** `.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md` (this branch is authoritative)
 
-## What just happened
-- Shipped the foundation: shared harness + skip-gate + jest unit tests + currencies reference
-  spec + `.ai/qa/AGENTS.md` docs.
-- Final gate green: typecheck 21/21, i18n in sync, core jest 21/21, build:packages clean.
-- Integration-verified against live :3000: currencies spec passes; skip-gate skips with the flag.
+## PRs shipped this session (all green + verified vs live :3000)
+- **#2548** — foundation: harness + `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` flag + jest unit
+  tests + currencies reference spec + `.ai/qa/AGENTS.md` docs. Base develop. (currencies = A5)
+- **#2551** — resources (A1): scalars + custom fields (text/integer/select/boolean). Stacked on #2548.
+- **#2553** — staff (A2): scalars + multiselect (role_ids/tags) + 6-kind custom fields. Stacked on #2548.
 
-## Next concrete action
-- Open the foundation PR (this branch). Then start the per-module program from `MODULE-LEDGER.md`
-  (A1 = resources, first custom-field end-to-end coverage), each as its own stacked PR branched
-  off `feat/crudform-integration-tests`.
+## How to continue (per-module recipe — proven 3×)
+1. `git checkout feat/crudform-integration-tests && git checkout -b feat/crudform-tests-<module>`
+2. Dispatch a research subagent: read the module's `api/**` + `data/validators.ts` + `ce.ts`/fieldsets
+   + `setup.ts` (seedDefaults vs seedExamples), and **live-probe :3000** (admin@acme.com/secret) to
+   get exact create/update bodies + response JSON. Confirm `?id=` vs `?ids=` for read-back.
+3. Write `packages/<pkg>/src/modules/<module>/__integration__/TC-<MOD>-CRUDFORM-001.spec.ts` using
+   `runCrudFormRoundTrip` (override `readById` when the list ignores `?id=`); add `meta.ts` if missing.
+4. Verify: `BASE_URL=http://localhost:3000 OM_INTEGRATION_MODULES=<module> npx playwright test --config .ai/qa/tests/playwright.config.ts TC-<MOD>-CRUDFORM-001 --retries=0`
+5. Also confirm skip: re-run with `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED=1` → 1 skipped.
+6. `yarn typecheck` (cached, fast). Commit, push, open PR with **base = feat/crudform-integration-tests**.
+   Claim (assignee + in-progress + comment), label `review` + `skip-qa`, summary, release lock.
+7. Update the ledger (this branch) with the PR number.
 
-## Blockers / open questions
-- Per-module PRs go fully green in CI only once this foundation merges (they import the harness).
-  Stack them off this branch; rebase onto develop after merge.
+## Next up (Tier-A remaining): A3 catalog (multichoice CF), A4 customers (inline + dict), A6 auth
+(roles[]+ACL+CF), A7 sales channels, A8 workflows (metadata.* dot-path #2503). Then Tier B/C — see ledger.
 
-## Environment caveats
-- Dev runtime runnable: YES — live app on :3000 (login 200). Used for integration smoke.
-- Playwright / browser checks: API-only (`request` fixture) — no browser needed for these specs.
-- Database/migration state: clean — tests only, no schema changes.
+## Recurring contract gotchas (confirmed)
+- Many core list routes ignore `?id=` and require **`?ids=`** for single-record read-back (resources, staff).
+- Request bodies camelCase; responses snake_case. org/tenant injected from token — don't send them.
+- Custom fields submit as `cf_<key>`; responses vary (`customValues` bare / top-level `cf_` / `customFields[]`)
+  — the harness resolver handles all. PUT is partial — omitted CFs are retained.
+- No optimistic-lock header needed on these makeCrud PUTs. Single-element multi-text CF can collapse to a scalar.
+- Don't rely on seedExamples data (e.g. capacity units, demo teams) — create your own fixtures.
 
-## Worktree
-- Path: .ai/tmp/auto-create-pr/crudform-integration-tests-20260604-220428
-- Created this run: yes
+## Environment
+- Live app on :3000 (admin@acme.com/secret) used for verification. API-only specs (`request` fixture) — no browser.
+- Worktree: `.ai/tmp/auto-create-pr/crudform-integration-tests-20260604-220428` (created this run).
+- Stacked PRs retarget base develop after #2548 merges.

--- a/.ai/runs/2026-06-04-crudform-integration-tests/HANDOFF.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/HANDOFF.md
@@ -1,0 +1,27 @@
+# Handoff — 2026-06-04-crudform-integration-tests
+
+**Last updated:** 2026-06-04T20:10:00Z
+**Branch:** feat/crudform-integration-tests (off origin/develop @ 0bd8b3aab)
+**PR:** not yet opened
+**Current phase/step:** Phase 1, Step 1.1 (seed)
+**Last commit:** — (seed pending)
+
+## What just happened
+- Classified as Spec-implementation run; created run folder + module ledger.
+- Decisions (user-confirmed): foundation PR first then stacked per-module PRs; Tier-A first.
+- Studied house pattern (TC-DIR-006/007, TC-CRM-028), shared helpers (api.ts, generalFixtures).
+
+## Next concrete action
+- Step 1.2: write `packages/core/src/helpers/integration/crudFormPersistence.ts`.
+
+## Blockers / open questions
+- none
+
+## Environment caveats
+- Dev runtime runnable: unknown (will verify integration green via ephemeral runner / :3000 at checkpoint)
+- Playwright / browser checks: integration specs need BASE_URL app; jest unit tests need no server
+- Database/migration state: N/A — tests only, no schema changes
+
+## Worktree
+- Path: .ai/tmp/auto-create-pr/crudform-integration-tests-20260604-220428
+- Created this run: yes

--- a/.ai/runs/2026-06-04-crudform-integration-tests/HANDOFF.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/HANDOFF.md
@@ -1,26 +1,30 @@
 # Handoff — 2026-06-04-crudform-integration-tests
 
-**Last updated:** 2026-06-04T20:10:00Z
+**Last updated:** 2026-06-04T20:55:00Z
 **Branch:** feat/crudform-integration-tests (off origin/develop @ 0bd8b3aab)
-**PR:** not yet opened
-**Current phase/step:** Phase 1, Step 1.1 (seed)
-**Last commit:** — (seed pending)
+**PR:** (opening now)
+**Current phase/step:** Phase 1 COMPLETE (foundation). All 5 Tasks-table rows `done`.
+**Last commit:** docs(qa) sweep documentation (8e50cbbab)
 
 ## What just happened
-- Classified as Spec-implementation run; created run folder + module ledger.
-- Decisions (user-confirmed): foundation PR first then stacked per-module PRs; Tier-A first.
-- Studied house pattern (TC-DIR-006/007, TC-CRM-028), shared helpers (api.ts, generalFixtures).
+- Shipped the foundation: shared harness + skip-gate + jest unit tests + currencies reference
+  spec + `.ai/qa/AGENTS.md` docs.
+- Final gate green: typecheck 21/21, i18n in sync, core jest 21/21, build:packages clean.
+- Integration-verified against live :3000: currencies spec passes; skip-gate skips with the flag.
 
 ## Next concrete action
-- Step 1.2: write `packages/core/src/helpers/integration/crudFormPersistence.ts`.
+- Open the foundation PR (this branch). Then start the per-module program from `MODULE-LEDGER.md`
+  (A1 = resources, first custom-field end-to-end coverage), each as its own stacked PR branched
+  off `feat/crudform-integration-tests`.
 
 ## Blockers / open questions
-- none
+- Per-module PRs go fully green in CI only once this foundation merges (they import the harness).
+  Stack them off this branch; rebase onto develop after merge.
 
 ## Environment caveats
-- Dev runtime runnable: unknown (will verify integration green via ephemeral runner / :3000 at checkpoint)
-- Playwright / browser checks: integration specs need BASE_URL app; jest unit tests need no server
-- Database/migration state: N/A — tests only, no schema changes
+- Dev runtime runnable: YES — live app on :3000 (login 200). Used for integration smoke.
+- Playwright / browser checks: API-only (`request` fixture) — no browser needed for these specs.
+- Database/migration state: clean — tests only, no schema changes.
 
 ## Worktree
 - Path: .ai/tmp/auto-create-pr/crudform-integration-tests-20260604-220428

--- a/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
@@ -15,7 +15,7 @@ delete in `finally`. All gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISAB
 | Order | Module | Package | Surfaces (entity) | Branch | PR | Status |
 |-------|--------|---------|-------------------|--------|----|--------|
 | A1 | resources | core | resource (CF text/number/select/boolean), resource-type · capacityUnit dict deferred (example-seeded) | feat/crudform-tests-resources | #2551 | 🔵 PR open (stacked on #2548) |
-| A2 | staff | core | team-member (roleIds[]/tags[] + 5 CF), team, team-role, timesheet-project | `feat/crudform-tests-staff` | — | ⬜ |
+| A2 | staff | core | team-member (role_ids/tags multiselect + 6-kind CF), team, team-role, timesheet-project | feat/crudform-tests-staff | #2553 | 🔵 PR open (stacked on #2548) |
 | A3 | catalog | core | product (multichoice CF), variant (prices), category | `feat/crudform-tests-catalog` | — | ⬜ |
 | A4 | customers | core | person/company/deal (inline + CF + dictionary) | `feat/crudform-tests-customers` | — | ⬜ |
 | A5 | currencies | core | currency (scalars), exchange-rate | feat/crudform-integration-tests | #2548 | 🔵 currency covered in foundation PR #2548 |

--- a/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
@@ -1,0 +1,53 @@
+# MODULE LEDGER — CrudForm field-persistence sweep (cross-PR program)
+
+Resumable matrix for the module-by-module rollout (#2466 automated follow-up). Each module
+ships as its **own stacked PR** branched off `feat/crudform-integration-tests`, targeting
+`develop`. Update this file as PRs open/merge so any session can resume.
+
+Status: ⬜ todo · 🔵 PR open · ✅ merged · ⏭️ skip (covered elsewhere / out of scope)
+
+Spec id convention: `TC-<MOD>-CRUDFORM-NNN`. Each spec: create → read-back → assert ALL
+fields (scalars + dict + **custom fields** + multiselect) → update → read-back → assert →
+delete in `finally`. All gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED`.
+
+## Tier A — rich fields (custom fields / dictionary / multiselect) — do first
+
+| Order | Module | Package | Surfaces (entity) | Branch | PR | Status |
+|-------|--------|---------|-------------------|--------|----|--------|
+| A1 | resources | core | resource (capacityUnit dict + CF text/number/select/date), resource-type | `feat/crudform-tests-resources` | — | ⬜ |
+| A2 | staff | core | team-member (roleIds[]/tags[] + 5 CF), team, team-role, timesheet-project | `feat/crudform-tests-staff` | — | ⬜ |
+| A3 | catalog | core | product (multichoice CF), variant (prices), category | `feat/crudform-tests-catalog` | — | ⬜ |
+| A4 | customers | core | person/company/deal (inline + CF + dictionary) | `feat/crudform-tests-customers` | — | ⬜ |
+| A5 | currencies | core | currency (scalars), exchange-rate | — | foundation | 🔵 (currency in foundation PR) |
+| A6 | auth | core | user (roles[] + CF + ACL), role (CF + ACL) | `feat/crudform-tests-auth` | — | ⬜ |
+| A7 | sales | core | channel (CF), channel-offer | `feat/crudform-tests-sales` | — | ⬜ |
+| A8 | workflows | core | definition (metadata.* dot-path — see #2503) | `feat/crudform-tests-workflows` | — | ⬜ |
+
+## Tier B — hand-written / non-makeCrud saves
+
+| Order | Module | Package | Surfaces | Branch | PR | Status |
+|-------|--------|---------|----------|--------|----|--------|
+| B1 | business_rules | core | rule, rule-set (+members[]) | `feat/crudform-tests-business-rules` | — | ⬜ |
+| B2 | integrations | core | credentials (secret/text/select round-trip) | `feat/crudform-tests-integrations` | — | ⬜ |
+| B3 | customer_accounts | core | customer-role (+portal perms), customer-user | `feat/crudform-tests-customer-accounts` | — | ⬜ |
+| B4 | planner | core | availability-ruleset | `feat/crudform-tests-planner` | — | ⬜ |
+| B5 | webhooks | webhooks | webhook (events multiselect + headers JSON) | `feat/crudform-tests-webhooks` | — | ⬜ |
+| B6 | scheduler | scheduler | scheduled-job (scope/target/payload JSON) | `feat/crudform-tests-scheduler` | — | ⬜ |
+| B7 | checkout | checkout | link-template, pay-link | `feat/crudform-tests-checkout` | — | ⬜ |
+
+## Tier C — remaining makeCrud / scalar surfaces
+
+| Order | Module | Package | Surfaces | Branch | PR | Status |
+|-------|--------|---------|----------|--------|----|--------|
+| C1 | directory | core | organization, tenant | — | — | ⏭️ covered by #2539 (TC-DIR-006..012) |
+| C2 | feature_toggles | core | global toggle (superadmin) | `feat/crudform-tests-feature-toggles` | — | ⬜ |
+| C3 | api_keys | core | api-key | `feat/crudform-tests-api-keys` | — | ⬜ |
+| C4 | dictionaries | core | dictionary entry | `feat/crudform-tests-dictionaries` | — | ⬜ |
+| C5 | communication_channels | core | channel | `feat/crudform-tests-comm-channels` | — | ⬜ |
+
+## Notes
+
+- `example` (todos) lives under `apps/mercato/src/modules/` (app, not a package) — no
+  `__integration__` test files added there; its CF behavior is already exercised by
+  `TC-CRM-028`.
+- Enterprise sudo/security surfaces (#33/#34) are enterprise+sudo gated — defer / out of scope.

--- a/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
@@ -18,7 +18,7 @@ delete in `finally`. All gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISAB
 | A2 | staff | core | team-member (roleIds[]/tags[] + 5 CF), team, team-role, timesheet-project | `feat/crudform-tests-staff` | — | ⬜ |
 | A3 | catalog | core | product (multichoice CF), variant (prices), category | `feat/crudform-tests-catalog` | — | ⬜ |
 | A4 | customers | core | person/company/deal (inline + CF + dictionary) | `feat/crudform-tests-customers` | — | ⬜ |
-| A5 | currencies | core | currency (scalars), exchange-rate | — | foundation | 🔵 (currency in foundation PR) |
+| A5 | currencies | core | currency (scalars), exchange-rate | feat/crudform-integration-tests | #2548 | 🔵 currency covered in foundation PR #2548 |
 | A6 | auth | core | user (roles[] + CF + ACL), role (CF + ACL) | `feat/crudform-tests-auth` | — | ⬜ |
 | A7 | sales | core | channel (CF), channel-offer | `feat/crudform-tests-sales` | — | ⬜ |
 | A8 | workflows | core | definition (metadata.* dot-path — see #2503) | `feat/crudform-tests-workflows` | — | ⬜ |

--- a/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
@@ -14,7 +14,7 @@ delete in `finally`. All gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISAB
 
 | Order | Module | Package | Surfaces (entity) | Branch | PR | Status |
 |-------|--------|---------|-------------------|--------|----|--------|
-| A1 | resources | core | resource (capacityUnit dict + CF text/number/select/date), resource-type | `feat/crudform-tests-resources` | — | ⬜ |
+| A1 | resources | core | resource (CF text/number/select/boolean), resource-type · capacityUnit dict deferred (example-seeded) | feat/crudform-tests-resources | #2551 | 🔵 PR open (stacked on #2548) |
 | A2 | staff | core | team-member (roleIds[]/tags[] + 5 CF), team, team-role, timesheet-project | `feat/crudform-tests-staff` | — | ⬜ |
 | A3 | catalog | core | product (multichoice CF), variant (prices), category | `feat/crudform-tests-catalog` | — | ⬜ |
 | A4 | customers | core | person/company/deal (inline + CF + dictionary) | `feat/crudform-tests-customers` | — | ⬜ |

--- a/.ai/runs/2026-06-04-crudform-integration-tests/NOTIFY.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/NOTIFY.md
@@ -13,3 +13,12 @@
   2. Tier-A rich-field modules first (resources/staff/catalog/customers/auth/sales/workflows),
      then sweep the rest.
 - Base: origin/develop @ 0bd8b3aab (user asked to use latest develop).
+
+## 2026-06-04T20:55:00Z — foundation complete + final gate green
+- Steps 1.1–1.5 landed (5 lean commits). Harness + skip-gate + jest unit tests + currencies
+  reference spec + docs.
+- Final gate: build:packages ✅, generate ✅, typecheck 21/21 ✅, i18n:check-sync ✅,
+  core jest 21/21 ✅. build:app/test:create-app/ds-guardian skipped (tests+docs only — justified).
+- Integration smoke on live :3000: TC-CUR-CRUDFORM-001 passes (default) and skips when
+  OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED=1. Harness proven end-to-end + skippable.
+- Opening foundation PR; per-module rollout tracked in MODULE-LEDGER.md.

--- a/.ai/runs/2026-06-04-crudform-integration-tests/NOTIFY.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/NOTIFY.md
@@ -22,3 +22,12 @@
 - Integration smoke on live :3000: TC-CUR-CRUDFORM-001 passes (default) and skips when
   OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED=1. Harness proven end-to-end + skippable.
 - Opening foundation PR; per-module rollout tracked in MODULE-LEDGER.md.
+
+## 2026-06-04T21:45:00Z — 3 green PRs shipped; per-module pattern proven
+- #2548 foundation (currencies A5), #2551 resources (A1), #2553 staff (A2). All verified green
+  vs live :3000 (create→read→assert→update→read→assert→delete) AND skip with the disable flag.
+- Coverage proven across the hardest cases: custom fields (text/int/select/boolean/date/float/
+  currency), multiselect arrays (role_ids/tags), FK prerequisites, partial-update CF retention.
+- Used research+live-probe subagents per module (resources, staff) — fast, accurate contracts.
+- Remaining Tier-A/B/C modules are mechanical applications of the same harness; recipe + gotchas
+  captured in HANDOFF.md, status in MODULE-LEDGER.md. Resumable.

--- a/.ai/runs/2026-06-04-crudform-integration-tests/NOTIFY.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/NOTIFY.md
@@ -1,0 +1,15 @@
+# Notify — 2026-06-04-crudform-integration-tests
+
+> Append-only log. Every entry is UTC-timestamped. Never rewrite prior entries.
+
+## 2026-06-04T20:10:00Z — run started
+- Brief: author automated CrudForm field-persistence integration tests (incl. custom fields),
+  one stacked PR per module, gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED`
+  (default false → run; set → skip). Resumable. Source: #2466 + prior manual-QA run folder.
+- External skill URLs: none
+- Decisions (user-confirmed via AskUserQuestion):
+  1. Foundation PR first (shared harness + flag + docs + 1 reference module), then stacked
+     per-module PRs branched off it.
+  2. Tier-A rich-field modules first (resources/staff/catalog/customers/auth/sales/workflows),
+     then sweep the rest.
+- Base: origin/develop @ 0bd8b3aab (user asked to use latest develop).

--- a/.ai/runs/2026-06-04-crudform-integration-tests/PLAN.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/PLAN.md
@@ -19,7 +19,7 @@ module). Per-module coverage ships as separate stacked PRs tracked in `MODULE-LE
 | 1 | 1.1 | Run-folder plan + module ledger (seed commit) | done | seed |
 | 1 | 1.2 | Shared harness: env skip-gate + tolerant field/CF assertions + makeCrud round-trip runner | done | 2de7d217a |
 | 1 | 1.3 | Jest unit tests for harness pure logic (env parse, dual-shape CF assertion) | done | 9ebc56b66 |
-| 1 | 1.4 | Currencies reference integration spec + meta (scalar round-trip via harness) | todo | — |
+| 1 | 1.4 | Currencies reference integration spec + meta (scalar round-trip via harness) | done | 9ebdfebe5 |
 | 1 | 1.5 | Document flag + harness + re-run procedure in `.ai/qa/AGENTS.md` | todo | — |
 
 ## Goal

--- a/.ai/runs/2026-06-04-crudform-integration-tests/PLAN.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/PLAN.md
@@ -17,7 +17,7 @@ module). Per-module coverage ships as separate stacked PRs tracked in `MODULE-LE
 | Phase | Step | Title | Status | Commit |
 |-------|------|-------|--------|--------|
 | 1 | 1.1 | Run-folder plan + module ledger (seed commit) | done | seed |
-| 1 | 1.2 | Shared harness: env skip-gate + tolerant field/CF assertions + makeCrud round-trip runner | todo | — |
+| 1 | 1.2 | Shared harness: env skip-gate + tolerant field/CF assertions + makeCrud round-trip runner | done | 2de7d217a |
 | 1 | 1.3 | Jest unit tests for harness pure logic (env parse, dual-shape CF assertion) | todo | — |
 | 1 | 1.4 | Currencies reference integration spec + meta (scalar round-trip via harness) | todo | — |
 | 1 | 1.5 | Document flag + harness + re-run procedure in `.ai/qa/AGENTS.md` | todo | — |

--- a/.ai/runs/2026-06-04-crudform-integration-tests/PLAN.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/PLAN.md
@@ -18,7 +18,7 @@ module). Per-module coverage ships as separate stacked PRs tracked in `MODULE-LE
 |-------|------|-------|--------|--------|
 | 1 | 1.1 | Run-folder plan + module ledger (seed commit) | done | seed |
 | 1 | 1.2 | Shared harness: env skip-gate + tolerant field/CF assertions + makeCrud round-trip runner | done | 2de7d217a |
-| 1 | 1.3 | Jest unit tests for harness pure logic (env parse, dual-shape CF assertion) | todo | — |
+| 1 | 1.3 | Jest unit tests for harness pure logic (env parse, dual-shape CF assertion) | done | 9ebc56b66 |
 | 1 | 1.4 | Currencies reference integration spec + meta (scalar round-trip via harness) | todo | — |
 | 1 | 1.5 | Document flag + harness + re-run procedure in `.ai/qa/AGENTS.md` | todo | — |
 

--- a/.ai/runs/2026-06-04-crudform-integration-tests/PLAN.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/PLAN.md
@@ -20,7 +20,7 @@ module). Per-module coverage ships as separate stacked PRs tracked in `MODULE-LE
 | 1 | 1.2 | Shared harness: env skip-gate + tolerant field/CF assertions + makeCrud round-trip runner | done | 2de7d217a |
 | 1 | 1.3 | Jest unit tests for harness pure logic (env parse, dual-shape CF assertion) | done | 9ebc56b66 |
 | 1 | 1.4 | Currencies reference integration spec + meta (scalar round-trip via harness) | done | 9ebdfebe5 |
-| 1 | 1.5 | Document flag + harness + re-run procedure in `.ai/qa/AGENTS.md` | todo | — |
+| 1 | 1.5 | Document flag + harness + re-run procedure in `.ai/qa/AGENTS.md` | done | 8e50cbbab |
 
 ## Goal
 

--- a/.ai/runs/2026-06-04-crudform-integration-tests/PLAN.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/PLAN.md
@@ -1,0 +1,63 @@
+# PLAN — CrudForm field-persistence integration sweep (foundation)
+
+**Source umbrella:** https://github.com/open-mercato/open-mercato/issues/2466
+**Prior manual-QA run:** `.ai/runs/2026-06-04-crudform-qa-2466/` (browser sweep + 5 bugs filed)
+**This run:** authoring **automated** integration tests that prove every CrudForm surface
+persists all fields (scalars, dictionaries, **custom fields**, multiselect/arrays) on
+create + update, gated behind `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED`.
+
+This PR delivers the **foundation only** (shared harness + skip-gate + docs + one reference
+module). Per-module coverage ships as separate stacked PRs tracked in `MODULE-LEDGER.md`.
+
+## Tasks
+
+> Authoritative status table. `Status` is `todo` or `done`. On landing a Step, flip to `done`
+> and fill the short SHA. First non-`done` row is the resume point.
+
+| Phase | Step | Title | Status | Commit |
+|-------|------|-------|--------|--------|
+| 1 | 1.1 | Run-folder plan + module ledger (seed commit) | done | seed |
+| 1 | 1.2 | Shared harness: env skip-gate + tolerant field/CF assertions + makeCrud round-trip runner | todo | — |
+| 1 | 1.3 | Jest unit tests for harness pure logic (env parse, dual-shape CF assertion) | todo | — |
+| 1 | 1.4 | Currencies reference integration spec + meta (scalar round-trip via harness) | todo | — |
+| 1 | 1.5 | Document flag + harness + re-run procedure in `.ai/qa/AGENTS.md` | todo | — |
+
+## Goal
+
+A reusable, re-runnable automated verification that CrudForm saves persist every field
+type — so #2466's manual sweep becomes a CI-able regression net.
+
+## Scope (this PR)
+
+- `packages/core/src/helpers/integration/crudFormPersistence.ts` — shared harness.
+- `packages/core/src/helpers/integration/__tests__/crudFormPersistence.test.ts` — unit tests.
+- `packages/core/src/modules/currencies/__integration__/TC-CUR-CRUDFORM-001.spec.ts` + `meta.ts`.
+- `.ai/qa/AGENTS.md` — sweep documentation + the env flag contract.
+- `.ai/runs/2026-06-04-crudform-integration-tests/*` — tracking.
+
+## Non-goals (this PR)
+
+- Per-module CrudForm specs beyond the currencies reference (those are stacked PRs — see ledger).
+- Touching any production module code / behavior. **Tests only.**
+- The EAV custom-record surface (owned by another agent per #2466).
+
+## Env flag contract
+
+- `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default **false** → tests run).
+- When truthy (`1`/`true`/`yes`), every CrudForm-persistence spec calls `test.skip(...)` in
+  `beforeAll`, so the sweep can be disabled wholesale without deleting specs.
+- Parsed via `parseBooleanWithDefault` from `@open-mercato/shared/lib/boolean`.
+
+## Risks
+
+- Integration specs require a running seeded app (BASE_URL, default :3000) or the ephemeral
+  runner; CI `yarn test` covers only the jest unit portion. Integration green is verified via
+  `yarn test:integration` / ephemeral runner at checkpoint/final-gate.
+- Currency `code` is unique incl. soft-deleted rows (prior run hit a dup 500). Spec uses a
+  random 3-letter code and deletes its fixture in `finally`.
+
+## Stacked-PR strategy
+
+Per-module PRs branch off `feat/crudform-integration-tests` (this branch) so they get the
+harness, and target `develop`. They go fully green once this foundation merges. Order +
+status live in `MODULE-LEDGER.md`.

--- a/.ai/runs/2026-06-04-crudform-integration-tests/final-gate-checks.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/final-gate-checks.md
@@ -1,0 +1,39 @@
+# Final gate — crudform-integration-tests foundation PR
+
+Spec-completion gate for the foundation phase (Steps 1.1–1.5). Tests + docs only; no
+production / UI / module-structure / generated-file changes.
+
+## Validation gate
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| `yarn build:packages` | ✅ | clean (worktree build) |
+| `yarn generate` | ✅ | produced ephemeral generated files (core `entities.ids.generated.ts`) |
+| `yarn typecheck` | ✅ | 21/21 packages successful |
+| `yarn i18n:check-sync` | ✅ | all 4 locales in sync; no keys added |
+| `yarn test` (core helpers) | ✅ | `crudFormFields.test.ts` 21/21 |
+| `yarn build:app` | ⏭️ skipped | tests+docs only, no app/production code; typecheck covers compilation |
+
+## Integration verification (against live app on :3000)
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| `TC-CUR-CRUDFORM-001` (flag default) | ✅ | 1 passed (749ms) — create→read→assert→update→read→assert→delete |
+| `TC-CUR-CRUDFORM-001` (`OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED=1`) | ✅ | 1 skipped — skip-gate proven |
+
+Command:
+```
+BASE_URL=http://localhost:3000 OM_INTEGRATION_MODULES=currencies \
+  npx playwright test --config .ai/qa/tests/playwright.config.ts TC-CUR-CRUDFORM-001 --retries=0
+```
+
+## Skipped suites (justified)
+
+- Full `yarn test:integration` — only the new currencies spec is relevant; ran it targeted (green).
+- `yarn test:create-app:integration` — no packaging/template/shared-export changes.
+- `ds-guardian` — no UI / design-system surface touched (test helpers + docs only).
+
+## i18n note
+
+Harness error strings (e.g. `create ... failed`) are test-internal (Playwright spec output),
+not user-facing — no `t(...)` routing or locale keys required.

--- a/packages/core/src/helpers/integration/__tests__/crudFormFields.test.ts
+++ b/packages/core/src/helpers/integration/__tests__/crudFormFields.test.ts
@@ -1,0 +1,58 @@
+import {
+  CRUDFORM_EXTENSION_TESTS_DISABLED_ENV,
+  crudFormExtensionTestsDisabled,
+  getCustomFieldValue,
+} from '../crudFormFields';
+
+describe('crudFormExtensionTestsDisabled', () => {
+  it('defaults to false when the flag is unset (sweep runs)', () => {
+    expect(crudFormExtensionTestsDisabled({})).toBe(false);
+  });
+
+  it.each(['1', 'true', 'TRUE', 'yes', 'on', 'enabled'])('treats %s as disabled', (value) => {
+    expect(crudFormExtensionTestsDisabled({ [CRUDFORM_EXTENSION_TESTS_DISABLED_ENV]: value })).toBe(true);
+  });
+
+  it.each(['0', 'false', 'no', 'off', 'disabled'])('treats %s as enabled (sweep runs)', (value) => {
+    expect(crudFormExtensionTestsDisabled({ [CRUDFORM_EXTENSION_TESTS_DISABLED_ENV]: value })).toBe(false);
+  });
+
+  it('falls back to false for unparseable values', () => {
+    expect(crudFormExtensionTestsDisabled({ [CRUDFORM_EXTENSION_TESTS_DISABLED_ENV]: 'maybe' })).toBe(false);
+  });
+
+  it('uses the real env name', () => {
+    expect(CRUDFORM_EXTENSION_TESTS_DISABLED_ENV).toBe('OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED');
+  });
+});
+
+describe('getCustomFieldValue', () => {
+  it('reads a bare key from customValues', () => {
+    expect(getCustomFieldValue({ customValues: { priority: 3 } }, 'priority')).toBe(3);
+  });
+
+  it('reads a top-level cf_ prefixed key', () => {
+    expect(getCustomFieldValue({ cf_severity: 'high' }, 'severity')).toBe('high');
+  });
+
+  it('reads a top-level cf: prefixed key', () => {
+    expect(getCustomFieldValue({ 'cf:blocked': true }, 'blocked')).toBe(true);
+  });
+
+  it('reads a value from a customFields definition array', () => {
+    const record = { customFields: [{ key: 'labels', value: ['a', 'b'] }] };
+    expect(getCustomFieldValue(record, 'labels')).toEqual(['a', 'b']);
+  });
+
+  it('prefers customValues over a redundant cf_ key', () => {
+    expect(getCustomFieldValue({ customValues: { priority: 5 }, cf_priority: 1 }, 'priority')).toBe(5);
+  });
+
+  it('preserves an explicit null under customValues (presence beats fallthrough)', () => {
+    expect(getCustomFieldValue({ customValues: { description: null }, cf_description: 'stale' }, 'description')).toBeNull();
+  });
+
+  it('returns undefined when the field is absent everywhere', () => {
+    expect(getCustomFieldValue({ customValues: { other: 1 } }, 'priority')).toBeUndefined();
+  });
+});

--- a/packages/core/src/helpers/integration/crudFormFields.ts
+++ b/packages/core/src/helpers/integration/crudFormFields.ts
@@ -1,0 +1,48 @@
+import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean';
+
+/**
+ * Pure, runner-agnostic helpers for the CrudForm field-persistence sweep (umbrella #2466).
+ *
+ * Kept free of any `@playwright/test` import so this logic is unit-testable under jest.
+ * The Playwright harness (`crudFormPersistence.ts`) re-exports everything here.
+ */
+
+export const CRUDFORM_EXTENSION_TESTS_DISABLED_ENV = 'OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED';
+
+export type CrudRecord = Record<string, unknown>;
+
+/**
+ * Reads the sweep disable flag. Default `false` so the sweep runs unless explicitly turned off
+ * via `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED=1` (or `true`/`yes`/`on`).
+ */
+export function crudFormExtensionTestsDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseBooleanWithDefault(env[CRUDFORM_EXTENSION_TESTS_DISABLED_ENV], false);
+}
+
+/**
+ * Resolves a custom-field value from a CRUD response record, tolerating every shape the
+ * platform emits: bare keys under `customValues`, top-level `cf_<name>` / `cf:<name>`, or a
+ * `customFields` definition array carrying `value`. Returns `undefined` when absent.
+ */
+export function getCustomFieldValue(record: CrudRecord, fieldName: string): unknown {
+  const customValues = record.customValues;
+  if (customValues && typeof customValues === 'object' && fieldName in (customValues as CrudRecord)) {
+    return (customValues as CrudRecord)[fieldName];
+  }
+  const prefixedUnderscore = record[`cf_${fieldName}`];
+  if (prefixedUnderscore !== undefined) return prefixedUnderscore;
+  const prefixedColon = record[`cf:${fieldName}`];
+  if (prefixedColon !== undefined) return prefixedColon;
+  const customFields = record.customFields;
+  if (Array.isArray(customFields)) {
+    const match = customFields.find((entry) => {
+      if (!entry || typeof entry !== 'object') return false;
+      const candidate = entry as CrudRecord;
+      return candidate.key === fieldName || candidate.id === fieldName || candidate.name === fieldName;
+    });
+    if (match && typeof match === 'object') {
+      return (match as CrudRecord).value;
+    }
+  }
+  return undefined;
+}

--- a/packages/core/src/helpers/integration/crudFormPersistence.ts
+++ b/packages/core/src/helpers/integration/crudFormPersistence.ts
@@ -1,0 +1,166 @@
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test';
+import { apiRequest } from './api';
+import { expectId, readJsonSafe } from './generalFixtures';
+import {
+  CRUDFORM_EXTENSION_TESTS_DISABLED_ENV,
+  crudFormExtensionTestsDisabled,
+  getCustomFieldValue,
+  type CrudRecord,
+} from './crudFormFields';
+
+/**
+ * Playwright harness for the CrudForm field-persistence sweep (umbrella #2466).
+ *
+ * Every spec proves a CrudForm surface saves AND reloads every field type — scalars,
+ * dictionary references, multiselect/array values, and **custom fields** — on both create
+ * and update.
+ *
+ * The whole sweep is gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED`
+ * (default `false` → tests run). When set truthy the specs `test.skip()` themselves, so the
+ * sweep can be disabled wholesale without deleting any spec.
+ */
+
+export {
+  CRUDFORM_EXTENSION_TESTS_DISABLED_ENV,
+  crudFormExtensionTestsDisabled,
+  getCustomFieldValue,
+  type CrudRecord,
+};
+
+/**
+ * Call inside `test.beforeAll` (or a test body) to skip the spec when the sweep is disabled.
+ * Uses Playwright's `test.skip(condition, reason)` so the spec is reported as skipped, not failed.
+ */
+export function skipIfCrudFormExtensionTestsDisabled(): void {
+  test.skip(
+    crudFormExtensionTestsDisabled(),
+    `${CRUDFORM_EXTENSION_TESTS_DISABLED_ENV} is set — CrudForm field-persistence sweep skipped`,
+  );
+}
+
+/** Asserts each expected scalar field round-tripped (deep equality so arrays/objects work). */
+export function assertScalarFieldsPersisted(record: CrudRecord, expected: CrudRecord, label = 'record'): void {
+  for (const [key, value] of Object.entries(expected)) {
+    expect(record[key], `${label}.${key} should persist`).toEqual(value);
+  }
+}
+
+/** Asserts each expected custom field round-tripped, regardless of response shape. */
+export function assertCustomFieldsPersisted(record: CrudRecord, expected: CrudRecord, label = 'record'): void {
+  for (const [name, value] of Object.entries(expected)) {
+    expect(getCustomFieldValue(record, name), `${label} custom field "${name}" should persist`).toEqual(value);
+  }
+}
+
+async function safeText(response: APIResponse): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 500);
+  } catch {
+    return '<unreadable body>';
+  }
+}
+
+export type CrudFormExpectation = {
+  scalars?: CrudRecord;
+  customFields?: CrudRecord;
+};
+
+export type CrudFormRoundTripConfig = {
+  request: APIRequestContext;
+  token: string;
+  /** Collection route handling POST/PUT/DELETE and a `?id=` list GET, e.g. `/api/currencies/currencies`. */
+  collectionPath: string;
+  create: { payload: CrudRecord; expectedStatus?: number };
+  /** Build the PUT body from the created id. MUST include the id the route expects. */
+  update: { payload: (id: string) => CrudRecord; expectedStatus?: number };
+  expectAfterCreate: CrudFormExpectation;
+  expectAfterUpdate: CrudFormExpectation;
+  /** Override id extraction from the create response (default: `id` ?? `entityId`). */
+  idFromCreate?: (body: CrudRecord) => string;
+  /** Override read-back (default: list `?id=` and match on `id`). Useful for detail-GET routes. */
+  readById?: (id: string) => Promise<CrudRecord | null>;
+  /** Delete the fixture in `finally` (default true). */
+  cleanup?: boolean;
+};
+
+async function defaultReadById(
+  request: APIRequestContext,
+  token: string,
+  collectionPath: string,
+  id: string,
+): Promise<CrudRecord | null> {
+  const separator = collectionPath.includes('?') ? '&' : '?';
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${collectionPath}${separator}id=${encodeURIComponent(id)}&page=1&pageSize=100`,
+    { token },
+  );
+  expect(response.status(), `read-back ${collectionPath} failed: ${response.status()}`).toBe(200);
+  const body = await readJsonSafe<{ items?: CrudRecord[] } & CrudRecord>(response);
+  if (Array.isArray(body?.items)) {
+    return body!.items.find((item) => item.id === id) ?? null;
+  }
+  // Detail routes may return the record directly.
+  return body && body.id === id ? (body as CrudRecord) : null;
+}
+
+/**
+ * Runs the canonical create → read-back → assert → update → read-back → assert → delete
+ * cycle for a makeCrud collection route and asserts every declared field persisted.
+ */
+export async function runCrudFormRoundTrip(config: CrudFormRoundTripConfig): Promise<void> {
+  const { request, token, collectionPath } = config;
+  const read = config.readById ?? ((id: string) => defaultReadById(request, token, collectionPath, id));
+  let id: string | null = null;
+
+  try {
+    const createResponse = await apiRequest(request, 'POST', collectionPath, {
+      token,
+      data: config.create.payload,
+    });
+    expect(
+      createResponse.status(),
+      `create ${collectionPath} failed (${createResponse.status()}): ${await safeText(createResponse)}`,
+    ).toBe(config.create.expectedStatus ?? 201);
+    const createBody = (await readJsonSafe<CrudRecord>(createResponse)) ?? {};
+    const rawId = config.idFromCreate
+      ? config.idFromCreate(createBody)
+      : (createBody.id ?? createBody.entityId);
+    id = expectId(rawId, `create response should include an id (${collectionPath})`);
+
+    const afterCreate = await read(id);
+    expect(afterCreate, `created record ${id} should be readable from ${collectionPath}`).toBeTruthy();
+    if (config.expectAfterCreate.scalars) {
+      assertScalarFieldsPersisted(afterCreate as CrudRecord, config.expectAfterCreate.scalars, 'after-create');
+    }
+    if (config.expectAfterCreate.customFields) {
+      assertCustomFieldsPersisted(afterCreate as CrudRecord, config.expectAfterCreate.customFields, 'after-create');
+    }
+
+    const updateResponse = await apiRequest(request, 'PUT', collectionPath, {
+      token,
+      data: config.update.payload(id),
+    });
+    expect(
+      updateResponse.status(),
+      `update ${collectionPath} failed (${updateResponse.status()}): ${await safeText(updateResponse)}`,
+    ).toBe(config.update.expectedStatus ?? 200);
+
+    const afterUpdate = await read(id);
+    expect(afterUpdate, `updated record ${id} should be readable from ${collectionPath}`).toBeTruthy();
+    if (config.expectAfterUpdate.scalars) {
+      assertScalarFieldsPersisted(afterUpdate as CrudRecord, config.expectAfterUpdate.scalars, 'after-update');
+    }
+    if (config.expectAfterUpdate.customFields) {
+      assertCustomFieldsPersisted(afterUpdate as CrudRecord, config.expectAfterUpdate.customFields, 'after-update');
+    }
+  } finally {
+    if (id && config.cleanup !== false) {
+      const separator = collectionPath.includes('?') ? '&' : '?';
+      await apiRequest(request, 'DELETE', `${collectionPath}${separator}id=${encodeURIComponent(id)}`, {
+        token,
+      }).catch(() => undefined);
+    }
+  }
+}

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-CRUDFORM-001.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-CRUDFORM-001.spec.ts
@@ -1,0 +1,72 @@
+import { test } from '@playwright/test';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenContext } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { generateUniqueCurrencyCode } from '@open-mercato/core/helpers/integration/currenciesFixtures';
+import {
+  runCrudFormRoundTrip,
+  skipIfCrudFormExtensionTestsDisabled,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+
+/**
+ * TC-CUR-CRUDFORM-001: Reference spec for the CrudForm field-persistence sweep (#2466).
+ *
+ * Proves the shared `runCrudFormRoundTrip` harness against a pure-scalar makeCrud route:
+ * create → read-back → assert every field → update → read-back → assert → delete.
+ *
+ * Gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
+ */
+test.describe('TC-CUR-CRUDFORM-001: Currency CrudForm persists every field on create + update', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  test('round-trips all scalar fields through the currencies CRUD route', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const { organizationId, tenantId } = getTokenContext(token);
+    const code = generateUniqueCurrencyCode();
+
+    await runCrudFormRoundTrip({
+      request,
+      token,
+      collectionPath: '/api/currencies/currencies',
+      create: {
+        payload: {
+          organizationId,
+          tenantId,
+          code,
+          name: 'QA CrudForm Currency',
+          symbol: 'Ƀ',
+          decimalPlaces: 3,
+          isActive: true,
+        },
+      },
+      expectAfterCreate: {
+        scalars: {
+          code,
+          name: 'QA CrudForm Currency',
+          symbol: 'Ƀ',
+          decimalPlaces: 3,
+          isActive: true,
+        },
+      },
+      update: {
+        payload: (id) => ({
+          id,
+          name: 'QA CrudForm Currency (edited)',
+          symbol: '₿',
+          decimalPlaces: 0,
+          isActive: false,
+        }),
+      },
+      expectAfterUpdate: {
+        scalars: {
+          code,
+          name: 'QA CrudForm Currency (edited)',
+          symbol: '₿',
+          decimalPlaces: 0,
+          isActive: false,
+        },
+      },
+    });
+  });
+});

--- a/packages/core/src/modules/resources/__integration__/TC-RESO-CRUDFORM-001.spec.ts
+++ b/packages/core/src/modules/resources/__integration__/TC-RESO-CRUDFORM-001.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { deleteGeneralEntityIfExists, expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  runCrudFormRoundTrip,
+  skipIfCrudFormExtensionTestsDisabled,
+  type CrudRecord,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+
+/**
+ * TC-RESO-CRUDFORM-001: Resource CrudForm persists scalars + custom fields (#2466).
+ *
+ * Resources is the canonical rich-field surface: scalars (name, capacity, appearance,
+ * resourceTypeId FK, isActive) plus custom fields of several kinds (text, integer, select,
+ * boolean). Proves create + update round-trip every value.
+ *
+ * Notes from the verified API contract:
+ * - The list GET filters by `?ids=` (comma-separated), NOT `?id=` — so a custom `readById`.
+ * - Request bodies are camelCase; responses are snake_case. Custom fields submit + return as
+ *   top-level `cf_<key>` (the harness resolver handles that shape).
+ * - capacityUnitValue is intentionally omitted: its dictionary values are example-seeded, not
+ *   default-seeded, so relying on them would violate the self-contained-fixtures rule.
+ *
+ * Gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
+ */
+const RESOURCES_PATH = '/api/resources/resources';
+const RESOURCE_TYPES_PATH = '/api/resources/resource-types';
+
+async function readResourceByIds(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<CrudRecord | null> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${RESOURCES_PATH}?ids=${encodeURIComponent(id)}&page=1&pageSize=100`,
+    { token },
+  );
+  expect(response.status(), `read-back resources failed: ${response.status()}`).toBe(200);
+  const body = await readJsonSafe<{ items?: CrudRecord[] }>(response);
+  return (body?.items ?? []).find((item) => item.id === id) ?? null;
+}
+
+test.describe('TC-RESO-CRUDFORM-001: Resource CrudForm persists scalars + custom fields', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  test('round-trips scalars + custom fields (text/number/select/boolean) on create and update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = Date.now();
+    let resourceTypeId: string | null = null;
+
+    try {
+      const typeResponse = await apiRequest(request, 'POST', RESOURCE_TYPES_PATH, {
+        token,
+        data: { name: `QA CRUDFORM Resource Type ${stamp}` },
+      });
+      expect(typeResponse.status(), 'resource-type fixture create should be 201').toBe(201);
+      resourceTypeId = expectId(
+        (await readJsonSafe<{ id?: string }>(typeResponse))?.id,
+        'resource-type fixture should return an id',
+      );
+
+      await runCrudFormRoundTrip({
+        request,
+        token,
+        collectionPath: RESOURCES_PATH,
+        readById: (id) => readResourceByIds(request, token, id),
+        create: {
+          payload: {
+            name: `QA CRUDFORM Resource ${stamp}`,
+            description: 'Original resource description',
+            resourceTypeId,
+            capacity: 4,
+            appearanceIcon: 'lucide:laptop',
+            appearanceColor: '#22c55e',
+            isActive: true,
+            cf_laptop_serial: 'SN-CRUDFORM-001',
+            cf_laptop_ram_gb: 16,
+            cf_laptop_os: 'macos',
+            cf_asset_tag: 'AT-CRUDFORM-001',
+            cf_room_projector: true,
+          },
+        },
+        expectAfterCreate: {
+          scalars: {
+            name: `QA CRUDFORM Resource ${stamp}`,
+            description: 'Original resource description',
+            resource_type_id: resourceTypeId,
+            capacity: 4,
+            is_active: true,
+            appearance_icon: 'lucide:laptop',
+            appearance_color: '#22c55e',
+          },
+          customFields: {
+            laptop_serial: 'SN-CRUDFORM-001',
+            laptop_ram_gb: 16,
+            laptop_os: 'macos',
+            asset_tag: 'AT-CRUDFORM-001',
+            room_projector: true,
+          },
+        },
+        update: {
+          payload: (id) => ({
+            id,
+            name: `QA CRUDFORM Resource ${stamp} EDITED`,
+            description: 'Updated resource description',
+            capacity: 8,
+            isActive: false,
+            cf_laptop_serial: 'SN-CRUDFORM-EDIT',
+            cf_laptop_ram_gb: 32,
+            cf_laptop_os: 'linux',
+            cf_room_projector: false,
+          }),
+        },
+        expectAfterUpdate: {
+          scalars: {
+            name: `QA CRUDFORM Resource ${stamp} EDITED`,
+            description: 'Updated resource description',
+            capacity: 8,
+            is_active: false,
+          },
+          customFields: {
+            laptop_serial: 'SN-CRUDFORM-EDIT',
+            laptop_ram_gb: 32,
+            laptop_os: 'linux',
+            room_projector: false,
+            asset_tag: 'AT-CRUDFORM-001',
+          },
+        },
+      });
+    } finally {
+      await deleteGeneralEntityIfExists(request, token, RESOURCE_TYPES_PATH, resourceTypeId);
+    }
+  });
+});

--- a/packages/core/src/modules/resources/__integration__/meta.ts
+++ b/packages/core/src/modules/resources/__integration__/meta.ts
@@ -1,0 +1,3 @@
+export const integrationMeta = {
+  dependsOnModules: ['resources'],
+};

--- a/packages/core/src/modules/staff/__integration__/TC-STAFF-CRUDFORM-001.spec.ts
+++ b/packages/core/src/modules/staff/__integration__/TC-STAFF-CRUDFORM-001.spec.ts
@@ -1,0 +1,158 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { deleteGeneralEntityIfExists, expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  runCrudFormRoundTrip,
+  skipIfCrudFormExtensionTestsDisabled,
+  type CrudRecord,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+
+/**
+ * TC-STAFF-CRUDFORM-001: Team Member CrudForm persists scalars, multiselect arrays + custom fields (#2466).
+ *
+ * The richest core surface: scalars (displayName, description, teamId FK, isActive), two
+ * multiselect arrays (roleIds[] → role_ids, tags[]), and custom fields of several kinds
+ * (date/text, float, integer, select, boolean, currency). Proves create + update round-trip.
+ *
+ * Verified contract:
+ * - Read-back uses `?ids=` (the list route ignores `?id=`).
+ * - Request bodies camelCase; responses snake_case (`role_ids`, `is_active`, ...). Custom fields
+ *   submit as `cf_<key>` and return under `customValues` (the harness resolver handles it).
+ * - PUT is a partial update — omitted custom fields are retained.
+ * - Self-contained: creates its own team + two team-roles, deletes them in `finally`.
+ *
+ * Gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
+ */
+const MEMBERS_PATH = '/api/staff/team-members';
+const TEAMS_PATH = '/api/staff/teams';
+const ROLES_PATH = '/api/staff/team-roles';
+
+async function createStaffFixture(
+  request: APIRequestContext,
+  token: string,
+  path: string,
+  data: CrudRecord,
+): Promise<string> {
+  const response = await apiRequest(request, 'POST', path, { token, data });
+  expect(response.status(), `fixture create ${path} should be 201`).toBe(201);
+  return expectId((await readJsonSafe<{ id?: string }>(response))?.id, `fixture ${path} should return an id`);
+}
+
+async function readMemberByIds(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<CrudRecord | null> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${MEMBERS_PATH}?ids=${encodeURIComponent(id)}&page=1&pageSize=100`,
+    { token },
+  );
+  expect(response.status(), `read-back team-members failed: ${response.status()}`).toBe(200);
+  const body = await readJsonSafe<{ items?: CrudRecord[] }>(response);
+  return (body?.items ?? []).find((item) => item.id === id) ?? null;
+}
+
+test.describe('TC-STAFF-CRUDFORM-001: Team Member CrudForm persists scalars, multiselect + custom fields', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  test('round-trips scalars, role_ids/tags arrays, and custom fields on create and update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = Date.now();
+    let teamId: string | null = null;
+    let roleAId: string | null = null;
+    let roleBId: string | null = null;
+
+    try {
+      teamId = await createStaffFixture(request, token, TEAMS_PATH, {
+        name: `QA CRUDFORM Team ${stamp}`,
+        isActive: true,
+      });
+      roleAId = await createStaffFixture(request, token, ROLES_PATH, { name: `QA CRUDFORM Role A ${stamp}` });
+      roleBId = await createStaffFixture(request, token, ROLES_PATH, { name: `QA CRUDFORM Role B ${stamp}` });
+
+      await runCrudFormRoundTrip({
+        request,
+        token,
+        collectionPath: MEMBERS_PATH,
+        readById: (id) => readMemberByIds(request, token, id),
+        create: {
+          payload: {
+            displayName: `QA CRUDFORM Member ${stamp}`,
+            description: 'Original member description',
+            teamId,
+            roleIds: [roleAId, roleBId],
+            tags: ['alpha', 'beta'],
+            isActive: true,
+            cf_employment_date: '2024-03-15',
+            cf_hourly_rate: 125.5,
+            cf_currency_code: 'USD',
+            cf_employment_type: 'full_time',
+            cf_work_mode: 'hybrid',
+            cf_onboarded: true,
+            cf_years_of_experience: 7,
+          },
+        },
+        expectAfterCreate: {
+          scalars: {
+            display_name: `QA CRUDFORM Member ${stamp}`,
+            description: 'Original member description',
+            team_id: teamId,
+            role_ids: [roleAId, roleBId],
+            tags: ['alpha', 'beta'],
+            is_active: true,
+          },
+          customFields: {
+            employment_date: '2024-03-15',
+            hourly_rate: 125.5,
+            currency_code: 'USD',
+            employment_type: 'full_time',
+            work_mode: 'hybrid',
+            onboarded: true,
+            years_of_experience: 7,
+          },
+        },
+        update: {
+          payload: (id) => ({
+            id,
+            displayName: `QA CRUDFORM Member ${stamp} EDITED`,
+            description: 'Updated member description',
+            roleIds: [roleAId],
+            tags: ['gamma'],
+            isActive: false,
+            cf_hourly_rate: 200,
+            cf_employment_type: 'contract',
+            cf_work_mode: 'remote',
+            cf_onboarded: false,
+            cf_years_of_experience: 12,
+          }),
+        },
+        expectAfterUpdate: {
+          scalars: {
+            display_name: `QA CRUDFORM Member ${stamp} EDITED`,
+            description: 'Updated member description',
+            role_ids: [roleAId],
+            tags: ['gamma'],
+            is_active: false,
+          },
+          customFields: {
+            hourly_rate: 200,
+            employment_type: 'contract',
+            work_mode: 'remote',
+            onboarded: false,
+            years_of_experience: 12,
+            employment_date: '2024-03-15',
+            currency_code: 'USD',
+          },
+        },
+      });
+    } finally {
+      await deleteGeneralEntityIfExists(request, token, ROLES_PATH, roleAId);
+      await deleteGeneralEntityIfExists(request, token, ROLES_PATH, roleBId);
+      await deleteGeneralEntityIfExists(request, token, TEAMS_PATH, teamId);
+    }
+  });
+});


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-04-crudform-integration-tests/PLAN.md
Tracking run folder: .ai/runs/2026-06-04-crudform-integration-tests/
Status: complete

## Goal
- Foundation for an automated, re-runnable **CrudForm field-persistence sweep** (umbrella #2466):
  prove every CrudForm surface saves AND reloads every field type — scalars, dictionaries,
  multiselect/arrays, and **custom fields** — on create and update. Per-module specs follow as
  stacked PRs (see `MODULE-LEDGER.md`).

## What Changed
- **Shared harness** `@open-mercato/core/helpers/integration/crudFormPersistence`:
  `runCrudFormRoundTrip` (create → read-back → assert all fields → update → read-back → assert →
  delete), `skipIfCrudFormExtensionTestsDisabled`, and tolerant assertions
  (`assertScalarFieldsPersisted` / `assertCustomFieldsPersisted` / `getCustomFieldValue`) that
  resolve custom fields from any response shape (`customValues` / `cf_` / `cf:` / `customFields[]`).
- **Pure logic** split into `crudFormFields.ts` (no `@playwright/test` import) so it is jest-unit-testable.
- **Skip flag** `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default **false** → sweep runs;
  set truthy → every sweep spec `test.skip()`s). Parsed via `parseBooleanWithDefault`.
- **Reference spec** `TC-CUR-CRUDFORM-001` exercising the harness on the scalar currencies route.
- **Docs** in `.ai/qa/AGENTS.md` (harness, flag, how to re-run the whole sweep / per-module / disabled).

## Tests
- Jest unit tests (`crudFormFields.test.ts`, 21 cases) for env parsing + custom-field resolution — green in `yarn test`.
- Integration: `TC-CUR-CRUDFORM-001` against a live app — passes by default, **skips** with the flag set.
- Gate: `yarn typecheck` 21/21, `yarn i18n:check-sync` in sync, `yarn build:packages` clean.

## Backward Compatibility
- Additive only. New test helpers + one new spec + docs. No production code, routes, entities,
  events, DI names, ACL features, or generated files touched.

## Progress
See the [Tasks table in the plan](.ai/runs/2026-06-04-crudform-integration-tests/PLAN.md#tasks) — all rows `done`.

## Handoff & Notifications
- Live handoff: `.ai/runs/2026-06-04-crudform-integration-tests/HANDOFF.md`
- Module rollout ledger: `.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md`
- Notifications log: `.ai/runs/2026-06-04-crudform-integration-tests/NOTIFY.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
