### PR TITLE
fix: 2473 business rules coverage

### DIFF
--- a/packages/core/src/modules/business_rules/__integration__/TC-BR-005.spec.ts
+++ b/packages/core/src/modules/business_rules/__integration__/TC-BR-005.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenScope } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createBusinessRuleFixture,
+  deleteBusinessRuleIfExists,
+} from '@open-mercato/core/helpers/integration/businessRulesFixtures'
+import {
+  BUSINESS_RULES_TEST_PASSWORD,
+  buildBusinessRulePayload,
+  cleanupBusinessRulesUser,
+  createBusinessRulesUser,
+  expectForbidden,
+} from './helpers/businessRulesApi'
+
+test.describe('TC-BR-005: RBAC enforcement for business_rules.manage', () => {
+  test('denies rule create, update, and delete to a user without business_rules.manage', async ({ request }) => {
+    const stamp = Date.now()
+    const userEmail = `tc-br-005-view-${stamp}@example.com`
+
+    let adminToken: string | null = null
+    let roleId: string | null = null
+    let userId: string | null = null
+    let ruleId: string | null = null
+
+    try {
+      adminToken = await getAuthToken(request, 'admin')
+      const { organizationId } = getTokenScope(adminToken)
+      expect(organizationId, 'admin token should carry an organization id').toBeTruthy()
+
+      const limitedUser = await createBusinessRulesUser(request, adminToken, {
+        email: userEmail,
+        password: BUSINESS_RULES_TEST_PASSWORD,
+        organizationId,
+        features: ['business_rules.view'],
+        roleName: `TC-BR-005 View Only ${stamp}`,
+      })
+      roleId = limitedUser.roleId
+      userId = limitedUser.userId
+
+      const deniedCreate = await apiRequest(request, 'POST', '/api/business_rules/rules', {
+        token: limitedUser.token,
+        data: buildBusinessRulePayload(`TC_BR_005_DENIED_${stamp}`),
+      })
+      await expectForbidden(deniedCreate, 'business_rules.manage', 'POST /rules without manage must be forbidden')
+
+      ruleId = await createBusinessRuleFixture(
+        request,
+        adminToken,
+        buildBusinessRulePayload(`TC_BR_005_ALLOWED_${stamp}`, {
+          ruleName: 'TC-BR-005 Allowed Rule',
+        }),
+      )
+
+      const deniedUpdate = await apiRequest(request, 'PUT', '/api/business_rules/rules', {
+        token: limitedUser.token,
+        data: {
+          id: ruleId,
+          ruleName: 'TC-BR-005 Unauthorized Update',
+        },
+      })
+      await expectForbidden(deniedUpdate, 'business_rules.manage', 'PUT /rules without manage must be forbidden')
+
+      const deniedDelete = await apiRequest(
+        request,
+        'DELETE',
+        `/api/business_rules/rules?id=${encodeURIComponent(ruleId)}`,
+        { token: limitedUser.token },
+      )
+      await expectForbidden(deniedDelete, 'business_rules.manage', 'DELETE /rules without manage must be forbidden')
+    } finally {
+      await deleteBusinessRuleIfExists(request, adminToken, ruleId)
+      await cleanupBusinessRulesUser(request, adminToken, userId, roleId)
+    }
+  })
+})

--- a/packages/core/src/modules/business_rules/__integration__/TC-BR-006.spec.ts
+++ b/packages/core/src/modules/business_rules/__integration__/TC-BR-006.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenScope } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createBusinessRuleFixture,
+  createRuleSetFixture,
+  deleteBusinessRuleIfExists,
+  deleteRuleSetIfExists,
+} from '@open-mercato/core/helpers/integration/businessRulesFixtures'
+import {
+  BUSINESS_RULES_TEST_PASSWORD,
+  buildBusinessRulePayload,
+  cleanupBusinessRulesUser,
+  createBusinessRulesUser,
+  expectForbidden,
+} from './helpers/businessRulesApi'
+
+test.describe('TC-BR-006: RBAC enforcement for business_rules.manage_sets', () => {
+  test('denies rule set CRUD and member mutation to a user without business_rules.manage_sets', async ({ request }) => {
+    const stamp = Date.now()
+    const userEmail = `tc-br-006-view-${stamp}@example.com`
+
+    let adminToken: string | null = null
+    let roleId: string | null = null
+    let userId: string | null = null
+    let ruleSetId: string | null = null
+    let ruleId: string | null = null
+
+    try {
+      adminToken = await getAuthToken(request, 'admin')
+      const { organizationId } = getTokenScope(adminToken)
+      expect(organizationId, 'admin token should carry an organization id').toBeTruthy()
+
+      const limitedUser = await createBusinessRulesUser(request, adminToken, {
+        email: userEmail,
+        password: BUSINESS_RULES_TEST_PASSWORD,
+        organizationId,
+        features: ['business_rules.view'],
+        roleName: `TC-BR-006 View Only ${stamp}`,
+      })
+      roleId = limitedUser.roleId
+      userId = limitedUser.userId
+
+      const deniedCreate = await apiRequest(request, 'POST', '/api/business_rules/sets', {
+        token: limitedUser.token,
+        data: {
+          setId: `qa-br-006-denied-${stamp}`,
+          setName: 'TC-BR-006 Denied Set',
+        },
+      })
+      await expectForbidden(deniedCreate, 'business_rules.manage_sets', 'POST /sets without manage_sets must be forbidden')
+
+      ruleSetId = await createRuleSetFixture(request, adminToken, {
+        setId: `qa-br-006-set-${stamp}`,
+        setName: 'TC-BR-006 Fixture Set',
+      })
+      ruleId = await createBusinessRuleFixture(
+        request,
+        adminToken,
+        buildBusinessRulePayload(`TC_BR_006_RULE_${stamp}`),
+      )
+
+      const deniedUpdate = await apiRequest(request, 'PUT', '/api/business_rules/sets', {
+        token: limitedUser.token,
+        data: {
+          id: ruleSetId,
+          setName: 'TC-BR-006 Unauthorized Update',
+        },
+      })
+      await expectForbidden(deniedUpdate, 'business_rules.manage_sets', 'PUT /sets without manage_sets must be forbidden')
+
+      const deniedDelete = await apiRequest(
+        request,
+        'DELETE',
+        `/api/business_rules/sets?id=${encodeURIComponent(ruleSetId)}`,
+        { token: limitedUser.token },
+      )
+      await expectForbidden(deniedDelete, 'business_rules.manage_sets', 'DELETE /sets without manage_sets must be forbidden')
+
+      const deniedMemberCreate = await apiRequest(
+        request,
+        'POST',
+        `/api/business_rules/sets/${encodeURIComponent(ruleSetId)}/members`,
+        {
+          token: limitedUser.token,
+          data: {
+            ruleId,
+            sequence: 10,
+            enabled: true,
+          },
+        },
+      )
+      await expectForbidden(
+        deniedMemberCreate,
+        'business_rules.manage_sets',
+        'POST /sets/[id]/members without manage_sets must be forbidden',
+      )
+    } finally {
+      await deleteBusinessRuleIfExists(request, adminToken, ruleId)
+      await deleteRuleSetIfExists(request, adminToken, ruleSetId)
+      await cleanupBusinessRulesUser(request, adminToken, userId, roleId)
+    }
+  })
+})

--- a/packages/core/src/modules/business_rules/__integration__/TC-BR-007.spec.ts
+++ b/packages/core/src/modules/business_rules/__integration__/TC-BR-007.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createBusinessRuleFixture,
+  deleteBusinessRuleIfExists,
+} from '@open-mercato/core/helpers/integration/businessRulesFixtures'
+import { buildBusinessRulePayload } from './helpers/businessRulesApi'
+
+async function expectBadRequest(response: Awaited<ReturnType<typeof apiRequest>>, expectedText: string) {
+  expect(response.status(), `request should fail validation with ${expectedText}`).toBe(400)
+  const body = await readJsonSafe<{ error?: string }>(response)
+  expect(body?.error ?? '').toContain(expectedText)
+}
+
+test.describe('TC-BR-007: Condition and action validation', () => {
+  test('rejects malformed conditions and actions, then accepts a valid payload', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    let validRuleId: string | null = null
+
+    try {
+      const invalidConditionResponse = await apiRequest(request, 'POST', '/api/business_rules/rules', {
+        token,
+        data: buildBusinessRulePayload(`TC_BR_007_BAD_CONDITION_${stamp}`, {
+          conditionExpression: { operator: 'AND', rules: [] },
+        }),
+      })
+      await expectBadRequest(invalidConditionResponse, 'condition expression')
+
+      const invalidActionResponse = await apiRequest(request, 'POST', '/api/business_rules/rules', {
+        token,
+        data: buildBusinessRulePayload(`TC_BR_007_BAD_ACTION_${stamp}`, {
+          ruleType: 'ACTION',
+          successActions: [{ config: { message: 'Missing type' } }],
+        }),
+      })
+      await expectBadRequest(invalidActionResponse, 'successActions')
+
+      const unsafeConditionResponse = await apiRequest(request, 'POST', '/api/business_rules/rules', {
+        token,
+        data: buildBusinessRulePayload(`TC_BR_007_UNSAFE_${stamp}`, {
+          conditionExpression: {
+            field: `status.${'nested'.repeat(40)}`,
+            operator: '=',
+            value: 'ACTIVE',
+          },
+        }),
+      })
+      await expectBadRequest(unsafeConditionResponse, 'safety limits')
+
+      validRuleId = await createBusinessRuleFixture(
+        request,
+        token,
+        buildBusinessRulePayload(`TC_BR_007_VALID_${stamp}`, {
+          ruleType: 'ACTION',
+          successActions: [{ type: 'LOG', config: { message: 'TC-BR-007 valid action' } }],
+        }),
+      )
+      expect(validRuleId, 'valid rule creation should return an id').toBeTruthy()
+    } finally {
+      await deleteBusinessRuleIfExists(request, token, validRuleId)
+    }
+  })
+})

--- a/packages/core/src/modules/business_rules/__integration__/TC-BR-008.spec.ts
+++ b/packages/core/src/modules/business_rules/__integration__/TC-BR-008.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createBusinessRuleFixture,
+  deleteBusinessRuleIfExists,
+} from '@open-mercato/core/helpers/integration/businessRulesFixtures'
+import {
+  buildBusinessRulePayload,
+  type ExecutionRuleEntry,
+  listRuleLogs,
+} from './helpers/businessRulesApi'
+
+test.describe('TC-BR-008: Dry-run execution mode', () => {
+  test('evaluates a matching rule without persisting execution logs until dryRun is false', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    const entityId = crypto.randomUUID()
+    const entityType = `QaDryRunEntity${stamp}`
+    const ruleKey = `TC_BR_008_${stamp}`
+    let ruleId: string | null = null
+
+    try {
+      ruleId = await createBusinessRuleFixture(
+        request,
+        token,
+        buildBusinessRulePayload(stamp, {
+          ruleId: ruleKey,
+          ruleType: 'ACTION',
+          entityType,
+          successActions: [
+            {
+              type: 'SET_FIELD',
+              config: { field: 'approvalStatus', value: 'APPROVED' },
+            },
+          ],
+        }),
+      )
+
+      const dryRunResponse = await apiRequest(request, 'POST', '/api/business_rules/execute', {
+        token,
+        data: {
+          entityType,
+          eventType: 'beforeSave',
+          entityId,
+          data: { status: 'ACTIVE', approvalStatus: 'PENDING' },
+          dryRun: true,
+        },
+      })
+      expect(dryRunResponse.status(), 'dry-run execution should succeed').toBe(200)
+      const dryRunBody = await readJsonSafe<{
+        allowed?: boolean
+        executedRules?: ExecutionRuleEntry[]
+        logIds?: string[]
+      }>(dryRunResponse)
+      expect(dryRunBody?.allowed).toBe(true)
+      const dryRunEntry = dryRunBody?.executedRules?.find((entry) => entry.ruleId === ruleKey)
+      expect(dryRunEntry?.conditionResult).toBe(true)
+      expect(dryRunEntry?.actionsExecuted?.success).toBe(true)
+      expect(dryRunEntry?.logId, 'dry-run rule entry should not include a persisted log id').toBeUndefined()
+      expect(dryRunBody?.logIds, 'dry-run response should not include persisted log ids').toBeUndefined()
+
+      const logsAfterDryRun = await listRuleLogs(
+        request,
+        token,
+        `?ruleId=${encodeURIComponent(ruleId)}&entityId=${encodeURIComponent(entityId)}`,
+      )
+      expect(logsAfterDryRun.status, 'logs query after dry-run should succeed').toBe(200)
+      expect(logsAfterDryRun.items, 'dry-run must not persist execution logs').toHaveLength(0)
+
+      const liveResponse = await apiRequest(request, 'POST', '/api/business_rules/execute', {
+        token,
+        data: {
+          entityType,
+          eventType: 'beforeSave',
+          entityId,
+          data: { status: 'ACTIVE', approvalStatus: 'PENDING' },
+          dryRun: false,
+        },
+      })
+      expect(liveResponse.status(), 'non-dry-run execution should succeed').toBe(200)
+      const liveBody = await readJsonSafe<{ executedRules?: ExecutionRuleEntry[]; logIds?: string[] }>(liveResponse)
+      const liveEntry = liveBody?.executedRules?.find((entry) => entry.ruleId === ruleKey)
+      expect(liveEntry?.logId, 'non-dry-run entry should include a persisted log id').toBeTruthy()
+      expect(liveBody?.logIds?.length, 'non-dry-run response should include persisted log ids').toBeGreaterThan(0)
+
+      const logsAfterLiveRun = await listRuleLogs(
+        request,
+        token,
+        `?ruleId=${encodeURIComponent(ruleId)}&entityId=${encodeURIComponent(entityId)}`,
+      )
+      expect(logsAfterLiveRun.items.some((item) => item.executionResult === 'SUCCESS')).toBe(true)
+    } finally {
+      await deleteBusinessRuleIfExists(request, token, ruleId)
+    }
+  })
+})

--- a/packages/core/src/modules/business_rules/__integration__/TC-BR-009.spec.ts
+++ b/packages/core/src/modules/business_rules/__integration__/TC-BR-009.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createBusinessRuleFixture,
+  deleteBusinessRuleIfExists,
+} from '@open-mercato/core/helpers/integration/businessRulesFixtures'
+import {
+  buildBusinessRulePayload,
+  type ExecutionRuleEntry,
+  listRuleLogs,
+} from './helpers/businessRulesApi'
+
+test.describe('TC-BR-009: Failure conditions and failureActions', () => {
+  test('executes failureActions and records a FAILURE log when the condition is false', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    const entityId = crypto.randomUUID()
+    const entityType = `QaFailureEntity${stamp}`
+    const ruleKey = `TC_BR_009_${stamp}`
+    let ruleId: string | null = null
+
+    try {
+      ruleId = await createBusinessRuleFixture(
+        request,
+        token,
+        buildBusinessRulePayload(stamp, {
+          ruleId: ruleKey,
+          ruleType: 'ACTION',
+          entityType,
+          conditionExpression: { field: 'status', operator: '=', value: 'ACTIVE' },
+          failureActions: [
+            {
+              type: 'LOG',
+              config: { level: 'warn', message: 'TC-BR-009 failure action executed' },
+            },
+          ],
+        }),
+      )
+
+      const executeResponse = await apiRequest(request, 'POST', '/api/business_rules/execute', {
+        token,
+        data: {
+          entityType,
+          eventType: 'beforeSave',
+          entityId,
+          data: { status: 'INACTIVE' },
+        },
+      })
+      expect(executeResponse.status(), 'execution with false condition should still return 200').toBe(200)
+      const executeBody = await readJsonSafe<{ executedRules?: ExecutionRuleEntry[] }>(executeResponse)
+      const entry = executeBody?.executedRules?.find((item) => item.ruleId === ruleKey)
+      expect(entry?.conditionResult).toBe(false)
+      expect(entry?.actionsExecuted?.success).toBe(true)
+      expect(entry?.actionsExecuted?.results?.map((result) => result.type)).toContain('LOG')
+
+      const logs = await listRuleLogs(
+        request,
+        token,
+        `?ruleId=${encodeURIComponent(ruleId)}&entityId=${encodeURIComponent(entityId)}&executionResult=FAILURE`,
+      )
+      expect(logs.status, 'failure log query should succeed').toBe(200)
+      expect(logs.items, 'a failed condition should create one FAILURE log for this entity').toHaveLength(1)
+      expect(logs.items[0]?.executionResult).toBe('FAILURE')
+      expect(logs.items[0]?.outputContext?.conditionResult).toBe(false)
+      expect(logs.items[0]?.outputContext?.actionsExecuted?.map((action) => action.type)).toContain('LOG')
+    } finally {
+      await deleteBusinessRuleIfExists(request, token, ruleId)
+    }
+  })
+})

--- a/packages/core/src/modules/business_rules/__integration__/TC-BR-010.spec.ts
+++ b/packages/core/src/modules/business_rules/__integration__/TC-BR-010.spec.ts
@@ -1,0 +1,183 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import { deleteUserAclInDb } from '@open-mercato/core/helpers/integration/dbFixtures'
+import {
+  deleteGeneralEntityIfExists,
+  getTokenScope,
+  readJsonSafe,
+} from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createBusinessRuleFixture,
+  deleteBusinessRuleIfExists,
+} from '@open-mercato/core/helpers/integration/businessRulesFixtures'
+import {
+  BUSINESS_RULES_TEST_PASSWORD,
+  buildBusinessRulePayload,
+  createOrganizationInTenant,
+  createTenantFixture,
+  scopeCookie,
+  setRoleAclFeaturesForTenant,
+  type ExecutionRuleEntry,
+} from './helpers/businessRulesApi'
+
+test.describe('TC-BR-010: Tenant and organization scoping', () => {
+  test('does not expose or execute a rule outside the selected tenant or organization', async ({ request }) => {
+    const stamp = Date.now()
+    const orgCUserEmail = `tc-br-010-org-c-${stamp}@example.com`
+    const tenantBUserEmail = `tc-br-010-tenant-b-${stamp}@example.com`
+    const ruleKey = `TC_BR_010_A_${stamp}`
+
+    let adminToken: string | null = null
+    let superadminToken: string | null = null
+    let orgCToken: string | null = null
+    let tenantBToken: string | null = null
+    let organizationCId: string | null = null
+    let roleCId: string | null = null
+    let userCId: string | null = null
+    let tenantBId: string | null = null
+    let organizationBId: string | null = null
+    let roleBId: string | null = null
+    let userBId: string | null = null
+    let ruleAId: string | null = null
+
+    try {
+      adminToken = await getAuthToken(request, 'admin')
+      superadminToken = await getAuthToken(request, 'superadmin')
+      const adminScope = getTokenScope(adminToken)
+      const superScope = getTokenScope(superadminToken)
+      expect(adminScope.tenantId, 'admin token should carry tenant A').toBeTruthy()
+      expect(adminScope.organizationId, 'admin token should carry organization A').toBeTruthy()
+
+      const ruleARecordId = await createBusinessRuleFixture(
+        request,
+        adminToken,
+        buildBusinessRulePayload(stamp, {
+          ruleId: ruleKey,
+          ruleName: 'TC-BR-010 Tenant A Rule',
+          entityType: `QaTenantScopeEntity${stamp}`,
+        }),
+      )
+      ruleAId = ruleARecordId
+
+      const expectRuleHiddenFrom = async (token: string, label: string) => {
+        const listResponse = await apiRequest(
+          request,
+          'GET',
+          `/api/business_rules/rules?ruleId=${encodeURIComponent(ruleKey)}`,
+          { token },
+        )
+        expect(listResponse.status(), `${label} rule list should succeed`).toBe(200)
+        const listBody = await readJsonSafe<{ items?: Array<{ id?: string; ruleId?: string }> }>(listResponse)
+        expect(listBody?.items?.some((item) => item.id === ruleARecordId || item.ruleId === ruleKey)).toBe(false)
+
+        const detailResponse = await apiRequest(
+          request,
+          'GET',
+          `/api/business_rules/rules/${encodeURIComponent(ruleARecordId)}`,
+          { token },
+        )
+        expect(detailResponse.status(), `${label} must not read tenant A organization A rule detail`).toBe(404)
+
+        const updateResponse = await apiRequest(request, 'PUT', '/api/business_rules/rules', {
+          token,
+          data: {
+            id: ruleARecordId,
+            ruleName: `TC-BR-010 Unauthorized ${label} Update`,
+          },
+        })
+        expect(updateResponse.status(), `${label} must not update tenant A organization A rule`).toBe(404)
+
+        const executeResponse = await apiRequest(request, 'POST', '/api/business_rules/execute', {
+          token,
+          data: {
+            entityType: `QaTenantScopeEntity${stamp}`,
+            eventType: 'beforeSave',
+            entityId: crypto.randomUUID(),
+            data: { status: 'ACTIVE' },
+          },
+        })
+        expect(executeResponse.status(), `${label} execute request should stay scoped`).toBe(200)
+        const executeBody = await readJsonSafe<{ executedRules?: ExecutionRuleEntry[] }>(executeResponse)
+        expect(executeBody?.executedRules?.some((entry) => entry.ruleId === ruleKey)).toBe(false)
+      }
+
+      organizationCId = await createOrganizationInTenant(
+        request,
+        superadminToken,
+        scopeCookie(adminScope.tenantId, adminScope.organizationId || null),
+        adminScope.tenantId,
+        `TC-BR-010 Org C ${stamp}`,
+      )
+      roleCId = await createRoleFixture(request, superadminToken, {
+        name: `TC-BR-010 Org C Role ${stamp}`,
+        tenantId: adminScope.tenantId,
+      })
+      await setRoleAclFeaturesForTenant(request, superadminToken, {
+        roleId: roleCId,
+        tenantId: adminScope.tenantId,
+        features: ['business_rules.*'],
+        organizations: null,
+      })
+      userCId = await createUserFixture(request, superadminToken, {
+        email: orgCUserEmail,
+        password: BUSINESS_RULES_TEST_PASSWORD,
+        organizationId: organizationCId,
+        roles: [roleCId],
+      })
+      orgCToken = await getAuthToken(request, orgCUserEmail, BUSINESS_RULES_TEST_PASSWORD)
+      const orgCScope = getTokenScope(orgCToken)
+      expect(orgCScope.tenantId, 'organization C user token should stay in tenant A').toBe(adminScope.tenantId)
+      expect(orgCScope.organizationId, 'organization C user token should be scoped to organization C').toBe(
+        organizationCId,
+      )
+      await expectRuleHiddenFrom(orgCToken, 'same-tenant organization C')
+
+      tenantBId = await createTenantFixture(request, superadminToken, `TC-BR-010 Tenant B ${stamp}`)
+      organizationBId = await createOrganizationInTenant(
+        request,
+        superadminToken,
+        scopeCookie(superScope.tenantId, superScope.organizationId || null),
+        tenantBId,
+        `TC-BR-010 Org B ${stamp}`,
+      )
+      roleBId = await createRoleFixture(request, superadminToken, {
+        name: `TC-BR-010 Tenant B Role ${stamp}`,
+        tenantId: tenantBId,
+      })
+      await setRoleAclFeaturesForTenant(request, superadminToken, {
+        roleId: roleBId,
+        tenantId: tenantBId,
+        features: ['business_rules.*'],
+        organizations: null,
+      })
+      userBId = await createUserFixture(request, superadminToken, {
+        email: tenantBUserEmail,
+        password: BUSINESS_RULES_TEST_PASSWORD,
+        organizationId: organizationBId,
+        roles: [roleBId],
+      })
+      tenantBToken = await getAuthToken(request, tenantBUserEmail, BUSINESS_RULES_TEST_PASSWORD)
+      const tenantBScope = getTokenScope(tenantBToken)
+      expect(tenantBScope.tenantId, 'tenant B user token should be scoped to tenant B').toBe(tenantBId)
+      expect(tenantBScope.organizationId, 'tenant B user token should be scoped to organization B').toBe(organizationBId)
+      await expectRuleHiddenFrom(tenantBToken, 'tenant B')
+    } finally {
+      await deleteBusinessRuleIfExists(request, adminToken, ruleAId)
+      await deleteUserAclInDb(userCId ?? '').catch(() => undefined)
+      await deleteUserIfExists(request, superadminToken, userCId)
+      await deleteRoleIfExists(request, superadminToken, roleCId)
+      await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/organizations', organizationCId)
+      await deleteUserAclInDb(userBId ?? '').catch(() => undefined)
+      await deleteUserIfExists(request, superadminToken, userBId)
+      await deleteRoleIfExists(request, superadminToken, roleBId)
+      await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/organizations', organizationBId)
+      await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/tenants', tenantBId)
+    }
+  })
+})

--- a/packages/core/src/modules/business_rules/__integration__/TC-BR-011.spec.ts
+++ b/packages/core/src/modules/business_rules/__integration__/TC-BR-011.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createBusinessRuleFixture,
+  deleteBusinessRuleIfExists,
+} from '@open-mercato/core/helpers/integration/businessRulesFixtures'
+import { buildBusinessRulePayload, listRuleLogs } from './helpers/businessRulesApi'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+test.describe('TC-BR-011: Execution log filtering', () => {
+  test('filters logs by date range and execution result', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    const entityType = `QaLogFilterEntity${stamp}`
+    const successEntityId = crypto.randomUUID()
+    const failureEntityId = crypto.randomUUID()
+    let ruleId: string | null = null
+
+    try {
+      ruleId = await createBusinessRuleFixture(
+        request,
+        token,
+        buildBusinessRulePayload(`TC_BR_011_${stamp}`, {
+          entityType,
+          conditionExpression: { field: 'status', operator: '=', value: 'ACTIVE' },
+        }),
+      )
+
+      const successResponse = await apiRequest(request, 'POST', '/api/business_rules/execute', {
+        token,
+        data: {
+          entityType,
+          eventType: 'beforeSave',
+          entityId: successEntityId,
+          data: { status: 'ACTIVE' },
+        },
+      })
+      expect(successResponse.status(), 'successful execution should return 200').toBe(200)
+
+      await sleep(50)
+      const afterFirstExecution = new Date().toISOString()
+      await sleep(50)
+
+      const failureResponse = await apiRequest(request, 'POST', '/api/business_rules/execute', {
+        token,
+        data: {
+          entityType,
+          eventType: 'beforeSave',
+          entityId: failureEntityId,
+          data: { status: 'INACTIVE' },
+        },
+      })
+      expect(failureResponse.status(), 'failed condition execution should return 200').toBe(200)
+
+      const allLogs = await listRuleLogs(request, token, `?ruleId=${encodeURIComponent(ruleId)}&pageSize=10`)
+      expect(allLogs.status, 'unfiltered rule log query should return 200').toBe(200)
+      expect(allLogs.items.map((item) => item.entityId)).toEqual(
+        expect.arrayContaining([successEntityId, failureEntityId]),
+      )
+
+      const successLogs = await listRuleLogs(
+        request,
+        token,
+        `?ruleId=${encodeURIComponent(ruleId)}&executionResult=SUCCESS&pageSize=10`,
+      )
+      expect(successLogs.items.length, 'SUCCESS filter should include at least one success log').toBeGreaterThan(0)
+      expect(successLogs.items.every((item) => item.executionResult === 'SUCCESS')).toBe(true)
+      expect(successLogs.items.map((item) => item.entityId)).toContain(successEntityId)
+
+      const dateRangeLogs = await listRuleLogs(
+        request,
+        token,
+        `?ruleId=${encodeURIComponent(ruleId)}&executedAtFrom=${encodeURIComponent(afterFirstExecution)}&pageSize=10`,
+      )
+      expect(dateRangeLogs.items.map((item) => item.entityId)).toContain(failureEntityId)
+      expect(dateRangeLogs.items.map((item) => item.entityId)).not.toContain(successEntityId)
+
+      const combinedLogs = await listRuleLogs(
+        request,
+        token,
+        `?ruleId=${encodeURIComponent(ruleId)}&executedAtFrom=${encodeURIComponent(afterFirstExecution)}&executionResult=FAILURE&pageSize=10`,
+      )
+      expect(combinedLogs.items).toHaveLength(1)
+      expect(combinedLogs.items[0]?.entityId).toBe(failureEntityId)
+      expect(combinedLogs.items[0]?.executionResult).toBe('FAILURE')
+    } finally {
+      await deleteBusinessRuleIfExists(request, token, ruleId)
+    }
+  })
+})

--- a/packages/core/src/modules/business_rules/__integration__/helpers/businessRulesApi.ts
+++ b/packages/core/src/modules/business_rules/__integration__/helpers/businessRulesApi.ts
@@ -1,0 +1,208 @@
+import { expect, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import { deleteUserAclInDb } from '@open-mercato/core/helpers/integration/dbFixtures'
+import { expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+const BASE_URL = process.env.BASE_URL?.trim() || null
+
+export const BUSINESS_RULES_TEST_PASSWORD = 'Secret123!'
+
+export type BusinessRulePayload = {
+  ruleId: string
+  ruleName: string
+  description?: string | null
+  ruleType: 'GUARD' | 'VALIDATION' | 'CALCULATION' | 'ACTION' | 'ASSIGNMENT'
+  ruleCategory?: string | null
+  entityType: string
+  eventType?: string | null
+  conditionExpression?: unknown
+  successActions?: unknown
+  failureActions?: unknown
+  enabled?: boolean
+  priority?: number
+}
+
+export type ExecutionRuleEntry = {
+  ruleId?: string
+  ruleName?: string
+  conditionResult?: boolean
+  actionsExecuted?: {
+    success?: boolean
+    results?: Array<{ type?: string; success?: boolean; error?: string }>
+  } | null
+  logId?: string
+}
+
+export type LogListItem = {
+  id: string
+  ruleId: string
+  entityId: string
+  entityType: string
+  executionResult: 'SUCCESS' | 'FAILURE' | 'ERROR'
+  executedAt: string
+  organizationId?: string | null
+  outputContext?: {
+    conditionResult?: boolean
+    actionsExecuted?: Array<{ type?: string; success?: boolean; error?: string }>
+  } | null
+}
+
+export function buildBusinessRulePayload(
+  stamp: string | number,
+  overrides: Partial<BusinessRulePayload> = {},
+): BusinessRulePayload {
+  return {
+    ruleId: `QA_BR_${stamp}`,
+    ruleName: `QA Business Rule ${stamp}`,
+    ruleType: 'GUARD',
+    entityType: 'QaBusinessRuleEntity',
+    eventType: 'beforeSave',
+    conditionExpression: { field: 'status', operator: '=', value: 'ACTIVE' },
+    successActions: null,
+    failureActions: null,
+    enabled: true,
+    priority: 100,
+    ...overrides,
+  }
+}
+
+export async function expectForbidden(response: APIResponse, feature: string, label: string): Promise<void> {
+  expect(response.status(), label).toBe(403)
+  const body = await readJsonSafe<{ requiredFeatures?: string[] }>(response)
+  expect(body?.requiredFeatures, `${label} should report the missing feature`).toContain(feature)
+}
+
+export async function createBusinessRulesUser(
+  request: APIRequestContext,
+  adminToken: string,
+  input: {
+    email: string
+    organizationId: string
+    features: string[]
+    password?: string
+    roleName?: string
+  },
+): Promise<{ token: string; roleId: string; userId: string }> {
+  const password = input.password ?? BUSINESS_RULES_TEST_PASSWORD
+  const roleId = await createRoleFixture(request, adminToken, {
+    name: input.roleName ?? `Business Rules Test Role ${Date.now()}`,
+  })
+  const userId = await createUserFixture(request, adminToken, {
+    email: input.email,
+    password,
+    organizationId: input.organizationId,
+    roles: [roleId],
+  })
+  await setUserAclVisibility(request, adminToken, {
+    userId,
+    features: input.features,
+    organizations: null,
+  })
+  const token = await getAuthToken(request, input.email, password)
+  return { token, roleId, userId }
+}
+
+export async function cleanupBusinessRulesUser(
+  request: APIRequestContext,
+  adminToken: string | null,
+  userId: string | null,
+  roleId: string | null,
+): Promise<void> {
+  await deleteUserAclInDb(userId ?? '').catch(() => undefined)
+  await deleteUserIfExists(request, adminToken, userId)
+  await deleteRoleIfExists(request, adminToken, roleId)
+}
+
+export async function listRuleLogs(
+  request: APIRequestContext,
+  token: string,
+  query: string,
+): Promise<{ status: number; items: LogListItem[] }> {
+  const response = await apiRequest(request, 'GET', `/api/business_rules/logs${query}`, { token })
+  const body = await readJsonSafe<{ items?: LogListItem[] }>(response)
+  return { status: response.status(), items: body?.items ?? [] }
+}
+
+export function scopeCookie(tenantId: string, organizationId: string | null): string {
+  const parts = [`om_selected_tenant=${encodeURIComponent(tenantId)}`]
+  parts.push(`om_selected_org=${encodeURIComponent(organizationId ?? '__all__')}`)
+  return parts.join('; ')
+}
+
+function resolveUrl(path: string): string {
+  return BASE_URL ? `${BASE_URL}${path}` : path
+}
+
+export async function apiRequestWithCookie(
+  request: APIRequestContext,
+  method: string,
+  path: string,
+  options: { token: string; cookie: string; data?: unknown },
+) {
+  return request.fetch(resolveUrl(path), {
+    method,
+    headers: {
+      Authorization: `Bearer ${options.token}`,
+      'Content-Type': 'application/json',
+      Cookie: options.cookie,
+    },
+    data: options.data,
+  })
+}
+
+export async function createTenantFixture(
+  request: APIRequestContext,
+  token: string,
+  name: string,
+): Promise<string> {
+  const response = await apiRequest(request, 'POST', '/api/directory/tenants', {
+    token,
+    data: { name },
+  })
+  expect(response.status(), 'POST /api/directory/tenants should return 201').toBe(201)
+  const body = await readJsonSafe<{ id?: string }>(response)
+  return expectId(body?.id, 'Tenant creation response should include id')
+}
+
+export async function createOrganizationInTenant(
+  request: APIRequestContext,
+  token: string,
+  cookie: string,
+  tenantId: string,
+  name: string,
+): Promise<string> {
+  const response = await apiRequestWithCookie(request, 'POST', '/api/directory/organizations', {
+    token,
+    cookie,
+    data: { name, tenantId },
+  })
+  expect(response.status(), 'POST /api/directory/organizations should return 201').toBe(201)
+  const body = await readJsonSafe<{ id?: string }>(response)
+  return expectId(body?.id, 'Organization creation response should include id')
+}
+
+export async function setRoleAclFeaturesForTenant(
+  request: APIRequestContext,
+  token: string,
+  input: { roleId: string; tenantId: string; features: string[]; organizations?: string[] | null },
+): Promise<void> {
+  const response = await apiRequest(request, 'PUT', '/api/auth/roles/acl', {
+    token,
+    data: {
+      roleId: input.roleId,
+      tenantId: input.tenantId,
+      features: input.features,
+      organizations: input.organizations ?? null,
+    },
+  })
+  const body = await readJsonSafe<{ ok?: boolean }>(response)
+  expect(response.status(), 'PUT /api/auth/roles/acl should return 200').toBe(200)
+  expect(body?.ok, 'Role ACL update should report ok=true').toBe(true)
+}


### PR DESCRIPTION
## Summary

Adds integration coverage for business_rules issue #2473: RBAC gates, rule validation, dry-run execution, failureActions, tenant/organization scoping, and execution-log filters.

## Changes

- Added TC-BR-005 through TC-BR-011 integration specs for business_rules.
- Added shared business-rules integration API helpers for RBAC users, tenant/org fixtures, scoped cookies, and log queries.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- `yarn build:packages`
- `yarn generate`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- `yarn i18n:check-sync`
- `yarn test:integration:ephemeral --filter packages/core/src/modules/business_rules/__integration__/TC-BR- --no-screenshots`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #2473