### PR TITLE
test(resources): CrudForm field-persistence — scalars + custom fields (#2466)

### DIFF
--- a/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
@@ -14,7 +14,7 @@ delete in `finally`. All gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISAB
 
 | Order | Module | Package | Surfaces (entity) | Branch | PR | Status |
 |-------|--------|---------|-------------------|--------|----|--------|
-| A1 | resources | core | resource (capacityUnit dict + CF text/number/select/date), resource-type | `feat/crudform-tests-resources` | — | ⬜ |
+| A1 | resources | core | resource (CF text/number/select/boolean), resource-type · capacityUnit dict deferred (example-seeded) | feat/crudform-tests-resources | #2551 | 🔵 PR open (stacked on #2548) |
 | A2 | staff | core | team-member (roleIds[]/tags[] + 5 CF), team, team-role, timesheet-project | `feat/crudform-tests-staff` | — | ⬜ |
 | A3 | catalog | core | product (multichoice CF), variant (prices), category | `feat/crudform-tests-catalog` | — | ⬜ |
 | A4 | customers | core | person/company/deal (inline + CF + dictionary) | `feat/crudform-tests-customers` | — | ⬜ |

--- a/packages/core/src/modules/resources/__integration__/TC-RESO-CRUDFORM-001.spec.ts
+++ b/packages/core/src/modules/resources/__integration__/TC-RESO-CRUDFORM-001.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { deleteGeneralEntityIfExists, expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  runCrudFormRoundTrip,
+  skipIfCrudFormExtensionTestsDisabled,
+  type CrudRecord,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+
+/**
+ * TC-RESO-CRUDFORM-001: Resource CrudForm persists scalars + custom fields (#2466).
+ *
+ * Resources is the canonical rich-field surface: scalars (name, capacity, appearance,
+ * resourceTypeId FK, isActive) plus custom fields of several kinds (text, integer, select,
+ * boolean). Proves create + update round-trip every value.
+ *
+ * Notes from the verified API contract:
+ * - The list GET filters by `?ids=` (comma-separated), NOT `?id=` — so a custom `readById`.
+ * - Request bodies are camelCase; responses are snake_case. Custom fields submit + return as
+ *   top-level `cf_<key>` (the harness resolver handles that shape).
+ * - capacityUnitValue is intentionally omitted: its dictionary values are example-seeded, not
+ *   default-seeded, so relying on them would violate the self-contained-fixtures rule.
+ *
+ * Gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
+ */
+const RESOURCES_PATH = '/api/resources/resources';
+const RESOURCE_TYPES_PATH = '/api/resources/resource-types';
+
+async function readResourceByIds(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<CrudRecord | null> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${RESOURCES_PATH}?ids=${encodeURIComponent(id)}&page=1&pageSize=100`,
+    { token },
+  );
+  expect(response.status(), `read-back resources failed: ${response.status()}`).toBe(200);
+  const body = await readJsonSafe<{ items?: CrudRecord[] }>(response);
+  return (body?.items ?? []).find((item) => item.id === id) ?? null;
+}
+
+test.describe('TC-RESO-CRUDFORM-001: Resource CrudForm persists scalars + custom fields', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  test('round-trips scalars + custom fields (text/number/select/boolean) on create and update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = Date.now();
+    let resourceTypeId: string | null = null;
+
+    try {
+      const typeResponse = await apiRequest(request, 'POST', RESOURCE_TYPES_PATH, {
+        token,
+        data: { name: `QA CRUDFORM Resource Type ${stamp}` },
+      });
+      expect(typeResponse.status(), 'resource-type fixture create should be 201').toBe(201);
+      resourceTypeId = expectId(
+        (await readJsonSafe<{ id?: string }>(typeResponse))?.id,
+        'resource-type fixture should return an id',
+      );
+
+      await runCrudFormRoundTrip({
+        request,
+        token,
+        collectionPath: RESOURCES_PATH,
+        readById: (id) => readResourceByIds(request, token, id),
+        create: {
+          payload: {
+            name: `QA CRUDFORM Resource ${stamp}`,
+            description: 'Original resource description',
+            resourceTypeId,
+            capacity: 4,
+            appearanceIcon: 'lucide:laptop',
+            appearanceColor: '#22c55e',
+            isActive: true,
+            cf_laptop_serial: 'SN-CRUDFORM-001',
+            cf_laptop_ram_gb: 16,
+            cf_laptop_os: 'macos',
+            cf_asset_tag: 'AT-CRUDFORM-001',
+            cf_room_projector: true,
+          },
+        },
+        expectAfterCreate: {
+          scalars: {
+            name: `QA CRUDFORM Resource ${stamp}`,
+            description: 'Original resource description',
+            resource_type_id: resourceTypeId,
+            capacity: 4,
+            is_active: true,
+            appearance_icon: 'lucide:laptop',
+            appearance_color: '#22c55e',
+          },
+          customFields: {
+            laptop_serial: 'SN-CRUDFORM-001',
+            laptop_ram_gb: 16,
+            laptop_os: 'macos',
+            asset_tag: 'AT-CRUDFORM-001',
+            room_projector: true,
+          },
+        },
+        update: {
+          payload: (id) => ({
+            id,
+            name: `QA CRUDFORM Resource ${stamp} EDITED`,
+            description: 'Updated resource description',
+            capacity: 8,
+            isActive: false,
+            cf_laptop_serial: 'SN-CRUDFORM-EDIT',
+            cf_laptop_ram_gb: 32,
+            cf_laptop_os: 'linux',
+            cf_room_projector: false,
+          }),
+        },
+        expectAfterUpdate: {
+          scalars: {
+            name: `QA CRUDFORM Resource ${stamp} EDITED`,
+            description: 'Updated resource description',
+            capacity: 8,
+            is_active: false,
+          },
+          customFields: {
+            laptop_serial: 'SN-CRUDFORM-EDIT',
+            laptop_ram_gb: 32,
+            laptop_os: 'linux',
+            room_projector: false,
+            asset_tag: 'AT-CRUDFORM-001',
+          },
+        },
+      });
+    } finally {
+      await deleteGeneralEntityIfExists(request, token, RESOURCE_TYPES_PATH, resourceTypeId);
+    }
+  });
+});

--- a/packages/core/src/modules/resources/__integration__/meta.ts
+++ b/packages/core/src/modules/resources/__integration__/meta.ts
@@ -1,0 +1,3 @@
+export const integrationMeta = {
+  dependsOnModules: ['resources'],
+};


### PR DESCRIPTION
**Stacked on #2548** (base = `feat/crudform-integration-tests`). Retarget to `develop` after the foundation merges.

## Goal
- First Tier-A module of the CrudForm field-persistence sweep (#2466): prove the **resources**
  CRUD surface saves AND reloads scalars + **custom fields** on create and update.

## What Changed
- `TC-RESO-CRUDFORM-001` (+ `meta.ts`) using the shared `runCrudFormRoundTrip` harness.
- Covers scalars (name, description, resourceTypeId FK, capacity, appearance icon/color, isActive)
  and custom fields of four kinds: **text** (`laptop_serial`, `asset_tag`), **integer**
  (`laptop_ram_gb`), **select** (`laptop_os`), **boolean** (`room_projector`).
- Asserts partial-update semantics: an omitted custom field (`asset_tag`) stays intact.

## Tests
- `TC-RESO-CRUDFORM-001` verified green against a live app (create→read→assert→update→read→assert→delete).
- Skips when `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED=1`.
- `yarn typecheck` 21/21.

## Notes
- Uses `?ids=` for read-back (the resources list route ignores `?id=`).
- Self-contained: creates its own resource-type fixture, deletes it in `finally`. `capacityUnitValue`
  omitted (its dictionary values are example-seeded, not default-seeded — relying on them would
  violate the self-contained-fixtures rule); capacity-unit dictionary round-trip is deferred.

## Backward Compatibility
- Additive test-only. No production code, routes, entities, or generated files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Merge maintenance (auto-continue-pr)
- Merged base `feat/crudform-integration-tests` into the branch and resolved the only conflict — the A2/staff row in `MODULE-LEDGER.md` (took the base version reflecting staff PR #2553 now open). Resources test files unchanged; PR is now `MERGEABLE / CLEAN`.
