### PR TITLE
docs(release): update 0.6.4 changelog with post-0.6.4 develop merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-# 0.6.4 (2026-06-02)
+# 0.6.4 (2026-06-05)
 
 ## Highlights
 
@@ -8,6 +8,8 @@ Open Mercato `0.6.4` is a hardening-and-scale release that builds directly on `0
 On the access-control side, the new **ACL feature dependency bundles** let modules declare `dependsOn` so the platform warns at edit time when a granted feature is missing its prerequisites, rolled out across sixteen core and provider modules. Security hardening tightens tenant/org scoping in catalog, customers, search, and customer-portal SSE, requires super-admin for global feature-toggle and system-scheduler writes, fails closed on missing credential DEKs and org-scope checks, and rejects undeclared custom-field keys.
 
 UI ships **DS Foundation v5** (12 new primitives plus rewrites and adoptions), completes the three-phase `RecordNotFoundState` rollout across backend pages, redesigns the create-deal page to the Figma spec, and adds auto-hiding completed progress operations. Rounding it out: a dev-mode `NODE_OPTIONS` heap cap and Redis LRU/eviction tuning, a time-bomb scanner for clock-dependent tests, a broad flaky-test stabilization sweep, and new specs for Railway one-command deployment and PARALLEL_FORK/PARALLEL_JOIN workflow support. Enjoy!
+
+This update also lands a broad **module integration-test coverage sweep** spanning two dozen modules, a batch of **undo/redo and tenant-encryption correctness fixes** across customers, scheduler, workflows, encryption, feature toggles, and checkout, plus **PARALLEL_FORK / PARALLEL_JOIN** workflow-engine execution and `CrudForm` dot-path field handling.
 
 ## ✨ Features
 - ✨ OSS optimistic-locking guard is now **default ON** across every CRUD entity exposed via `makeCrudRoute`. Opt out with `OM_OPTIMISTIC_LOCK=off` (also accepts `false` / `0` / `no` / `disabled` / `none`). Runtime stays strictly additive — requests without the `x-om-ext-optimistic-lock-expected-updated-at` header continue to pass through. See [`UPGRADE_NOTES.md`](UPGRADE_NOTES.md) → "OSS optimistic locking default-ON" and [`.ai/specs/2026-05-25-oss-optimistic-locking.md`](.ai/specs/2026-05-25-oss-optimistic-locking.md) §3.4 + §4. (#1981 / #2055 Phase 14) *(@pkarw)*
@@ -23,6 +25,8 @@ UI ships **DS Foundation v5** (12 new primitives plus rewrites and adoptions), c
 - ✨ Adopt `RecordNotFoundState` across backend pages — Phases 1–3 (Phase 1 supersedes #2106). (#2185, #2264, #2404) *(@izqzmyli, via @pkarw)*
 - ✨ Auto-hide completed progress operations after a configurable timeout (fixes #2206). (#2308) *(@izqzmyli)*
 - ✨ Planner: delete availability schedules from the team-member screen. (#2329) *(@adeptofvoltron)*
+- ✨ Workflows: PARALLEL_FORK / PARALLEL_JOIN engine execution support. (#2428) *(@adeptofvoltron)*
+- ✨ `CrudForm` honors dot-path ids for declared base fields. (#2515) *(@pkarw)*
 
 ### 🔐 ACL feature dependency bundles
 - 🔐 ACL dependency bundles — declare `dependsOn` and warn at edit time when a granted feature is missing its prerequisites. (#2141, #2220) *(@pkarw)*
@@ -39,6 +43,7 @@ UI ships **DS Foundation v5** (12 new primitives plus rewrites and adoptions), c
 - 🔒 Fail closed when the integrations credentials DEK is unavailable. (#2299) *(@WXYZx)*
 - 🔒 Validate uploads and harden downloads in `storage_s3` (fixes #2269). (#2320) *(@rengare)*
 - 🔒 Reject undeclared custom-field keys on entities. (#2396) *(@mat89c)*
+- 🔒 Fix 4 high-severity CodeQL alerts in `communication_channels` email-MIME assembly. (#2447) *(@pkarw)*
 
 ## 🐛 Fixes
 - 🐛 Correct AI assistant `participantCount` and revoke-404 contract deviations (fixes #2189). (#2192) *(@adeptofvoltron)*
@@ -61,6 +66,16 @@ UI ships **DS Foundation v5** (12 new primitives plus rewrites and adoptions), c
 - 🐛 Validate deal pipeline stage assignments. (#2439) *(@pmadajthey)*
 - 🐛 Avoid a false unsaved-changes prompt on a clean person detail page. (#2437) *(@pmadajthey)*
 - 🐳 Add the `NODE_OPTIONS` heap cap to the production fullapp Docker stack (#2371). (#2438) *(@Kotmin)*
+- 🐛 Catalog: tier-pricing tie-break now selects the higher `minQuantity` (fixes #1706). (#2454) *(@jakubmatwiejew-wq)*
+- 💰 Sales: preserve payment totals and derive tax from net/gross on document reads (fixes #2455, #2457). (#2467) *(@pkarw)*
+- 🔐 Encryption: fix `people.update` undo no-op by preserving pending changes during deep-decrypt re-baseline (fixes #2498). (#2508) *(@pkarw)*
+- 🔐 Customers: stop `personCompanyLinks` undo handlers from losing writes under tenant encryption (fixes #2507). (#2509) *(@adeptofvoltron)*
+- 🐛 Workflows: Definition form now persists Category/Tags/Icon (`metadata.*`) (fixes #2503). (#2513) *(@pkarw)*
+- 🐛 Scheduler: jobs undo is no longer a silent no-op — use `extractUndoPayload` (fixes #2504). (#2514) *(@pkarw)*
+- 🐛 Feature toggles: hydrate the global edit form's Type / Default Value (fixes #2524). (#2528) *(@pkarw)*
+- 🐛 Customers: allow clearing person/company URL and email fields (fixes #2526). (#2533) *(@pkarw)*
+- 🐛 Scheduler: job-edit Scope field was editable but silently stripped on save (fixes #2527). (#2535) *(@pkarw)*
+- 🐛 Checkout: template/pay-link edit no longer 400s when `gatewayProviderKey` is null (fixes #2505). (#2540) *(@pkarw)*
 
 ### 🔧 Transaction safety — atomic multi-entity writes
 - 🔧 Harden `withAtomicFlush` + a repository-wide SQL transaction-safety audit. (#2343) *(@pkarw)*
@@ -118,6 +133,12 @@ UI ships **DS Foundation v5** (12 new primitives plus rewrites and adoptions), c
 - 🧪 Stabilize flaky TC-MSG-009 and TC-AUTH-009. (#2419) *(@pkarw)*
 - 🧪 Add `RecordNotFoundState` integration coverage — Phase 5 (#2101). (#2436) *(@izqzmyli)*
 - 🧪 Clear a CodeQL incomplete-URL-sanitization false positive in the command-menu test. (#2427) *(@pkarw)*
+- 🧪 Sales: document the order GET payment-total read-back contract. (#2421) *(@pkarw)*
+- 🧪 configs + api_keys integration coverage + cache-stats OpenAPI schema fix (fixes #2465, #2470). (#2497) *(@pkarw)*
+- 🧪 Catalog: integration coverage for the tier-pricing tie-break (follow-up to #2454). (#2499) *(@pkarw)*
+- 🧪 Core: `CrudForm` field-persistence integration harness + skip flag (#2466). (#2548) *(@pkarw)*
+- 🧪 Sales: de-flake TC-LOCK-OSS-029 list-delete. (#2554) *(@pkarw)*
+- 🧪 Expand module integration coverage across `ai_assistant`, `attachments`, `business_rules`, `catalog`, `communication_channels`, `currencies`, `dashboards`, `data_sync`, `dictionaries`, `directory`, `feature_toggles`, `inbox_ops`, `integrations`, `messages`, `payment_gateways`, `perspectives`, `progress`, `scheduler`, `search`, `shipping_carriers`, `sync_excel`, `translations`, and `webhooks`. (#2516, #2517, #2518, #2519, #2520, #2521, #2522, #2523, #2525, #2530, #2531, #2532, #2534, #2536, #2537, #2538, #2539, #2541, #2542, #2543, #2544, #2547, #2550) *(@haxiorz)*
 
 ## 📝 Specs & Documentation
 - 📝 Spec: Railway one-command deployment from the Open Mercato CLI. (#1898) *(@pkarw)*
@@ -125,6 +146,9 @@ UI ships **DS Foundation v5** (12 new primitives plus rewrites and adoptions), c
 - 📝 Document in-process dev watcher/workers + parallelism flags. (#2203) *(@pkarw)*
 - 📝 Add a Page URL field to the bug-report issue template. (#2331) *(@adeptofvoltron)*
 - 📝 Spec: PARALLEL_FORK / PARALLEL_JOIN workflow engine support. (#2385) *(@adeptofvoltron)*
+- 📝 QA scenarios: Timesheets (#2456) and Undo/Redo (#2468). (#2469) *(@pkarw)*
+- 📝 Spec: AI input moderation and safety identifiers (#2510). (#2511) *(@adeptofvoltron)*
+- 📝 Spec: reconcile the Railway one-command deploy spec. (#2512) *(@WXYZx)*
 
 ## 👥 Contributors
 
@@ -140,6 +164,7 @@ UI ships **DS Foundation v5** (12 new primitives plus rewrites and adoptions), c
 - @Marynat
 - @Kotmin
 - @MStaniaszek1998
+- @jakubmatwiejew-wq
 
 ---
 


### PR DESCRIPTION
## What

Updates the `0.6.4` CHANGELOG section on `develop` with every PR merged to `develop` after the original `0.6.4` draft cutoff (PR #2420). Per maintainer request, this keeps **one** `0.6.4` release — the email-integration / `RecordNotFoundState` work was already folded into develop's `0.6.4` section, so this change is purely **additive** (no new heading, no restructure). The `0.6.4` heading date is bumped `2026-06-02 → 2026-06-05` to reflect the extended window.

Generated via the `auto-update-changelog` workflow (categorization + Supersede Credit Rule), applied deterministically in a fresh worktree off `origin/develop`.

## Added entries

- **🔒 Security** — communication_channels email-MIME CodeQL fixes (#2447)
- **✨ Features** — workflows PARALLEL_FORK/JOIN engine (#2428); `CrudForm` dot-path ids (#2515)
- **🐛 Fixes** — undo / tenant-encryption / scheduler / workflows / feature-toggle / checkout / customers / catalog (#2454, #2467, #2508, #2509, #2513, #2514, #2528, #2533, #2535, #2540)
- **🧪 Testing** — module integration-coverage sweep across 24 modules (#2516–#2550, coalesced) + harness/de-flake work (#2421, #2497, #2499, #2548, #2554)
- **📝 Specs & Docs** — QA scenarios (#2469), AI input-moderation spec (#2511), Railway deploy spec reconcile (#2512)
- **👥 Contributors** — added @jakubmatwiejew-wq

## Notes for the reviewer

- **Highlights** got one factual summary paragraph appended; please refine the narrative before release.
- **Pre-existing miscredits (not touched here):** develop's `0.6.4` already credits three carry-forwards to @pkarw that should credit the original authors per the Supersede Credit Rule — #2434 → @pmadajthey, #2435 → @izqzmyli, #2433 → @pmadajthey (all `via @pkarw`). Left as-is to keep this PR additive; worth a follow-up.
- Diff is `CHANGELOG.md` only (26 insertions, 1 deletion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)