### PR TITLE
[codex] Fix deal undo date snapshots

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-UNDO-003-deal-expected-close-date.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-UNDO-003-deal-expected-close-date.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { getAuthToken, apiRequest } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { expectOperation, undoOk } from '@open-mercato/core/helpers/integration/undoHarness'
+
+/**
+ * TC-UNDO-003 — Regression for deal update undo with JSON-serialized Date snapshots.
+ *
+ * Action log payloads are persisted as JSON, so CustomerDeal.expectedCloseAt is read back
+ * as an ISO string during undo. Undo must coerce that string to Date before assigning it
+ * to MikroORM's Date property, otherwise the undo endpoint returns "Undo failed".
+ */
+
+const DEALS = '/api/customers/deals'
+
+function findStringByKeys(value: unknown, keys: readonly string[]): string | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  for (const key of keys) {
+    const candidate = record[key]
+    if (typeof candidate === 'string' && candidate.trim().length > 0) return candidate.trim()
+  }
+  for (const nested of Object.values(record)) {
+    if (Array.isArray(nested)) continue
+    const found = findStringByKeys(nested, keys)
+    if (found) return found
+  }
+  return null
+}
+
+async function getDeal(request: APIRequestContext, token: string, id: string): Promise<Record<string, unknown>> {
+  const res = await apiRequest(request, 'GET', `${DEALS}/${id}`, { token })
+  const body = (await readJsonSafe(res)) as Record<string, unknown> | null
+  expect(res.ok(), `GET deal ${id} failed: status ${res.status()} body ${JSON.stringify(body)}`).toBeTruthy()
+  const deal = body?.deal ?? body
+  expect(deal && typeof deal === 'object', `GET deal ${id} should return a deal object`).toBeTruthy()
+  return deal as Record<string, unknown>
+}
+
+test.describe('TC-UNDO-003 customers.deals.update undo restores expectedCloseAt', () => {
+  test('update expectedCloseAt → undo restores the prior date from the audit-log snapshot', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    const beforeCloseAt = '2026-07-20T12:00:00.000Z'
+    const afterCloseAt = '2026-08-15T09:30:00.000Z'
+    let dealId: string | null = null
+
+    try {
+      const createRes = await apiRequest(request, 'POST', DEALS, {
+        token,
+        data: {
+          title: `Undo Date Deal ${stamp}`,
+          expectedCloseAt: beforeCloseAt,
+          valueAmount: 1250,
+          valueCurrency: 'USD',
+        },
+      })
+      const createBody = await readJsonSafe(createRes)
+      expect(createRes.ok(), `create deal failed: status ${createRes.status()} body ${JSON.stringify(createBody)}`).toBeTruthy()
+      const createOp = expectOperation(createRes, 'customers.deals.create')
+      dealId = createOp.resourceId ?? findStringByKeys(createBody, ['dealId', 'id', 'entityId'])
+      expect(dealId, 'create should yield a deal resource id').toBeTruthy()
+
+      const beforeState = await getDeal(request, token, dealId as string)
+      expect(beforeState.expectedCloseAt, 'deal expectedCloseAt after create').toBe(beforeCloseAt)
+
+      const updateRes = await apiRequest(request, 'PUT', DEALS, {
+        token,
+        data: {
+          id: dealId,
+          expectedCloseAt: afterCloseAt,
+        },
+      })
+      const updateBody = await readJsonSafe(updateRes)
+      expect(updateRes.ok(), `update deal failed: status ${updateRes.status()} body ${JSON.stringify(updateBody)}`).toBeTruthy()
+      const updateOp = expectOperation(updateRes, 'customers.deals.update')
+
+      const changedState = await getDeal(request, token, dealId as string)
+      expect(changedState.expectedCloseAt, 'deal expectedCloseAt changed before undo').toBe(afterCloseAt)
+
+      await undoOk(request, token, updateOp.undoToken, 'undo customers.deals.update expectedCloseAt')
+
+      const afterUndo = await getDeal(request, token, dealId as string)
+      expect(afterUndo.expectedCloseAt, 'deal expectedCloseAt restored after undo').toBe(beforeCloseAt)
+    } finally {
+      if (dealId) {
+        await apiRequest(request, 'DELETE', `${DEALS}?id=${encodeURIComponent(dealId)}`, { token }).catch(() => {})
+      }
+    }
+  })
+})

--- a/packages/core/src/modules/customers/commands/__tests__/undo.custom-fields.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/undo.custom-fields.test.ts
@@ -589,7 +589,7 @@ describe('customers commands undo custom fields', () => {
               valueAmount: '1000',
               valueCurrency: 'USD',
               probability: 20,
-              expectedCloseAt: null,
+              expectedCloseAt: '2026-07-20T12:00:00.000Z',
               ownerUserId: 'user-8',
               source: 'event',
             },
@@ -609,7 +609,7 @@ describe('customers commands undo custom fields', () => {
               valueAmount: '5000',
               valueCurrency: 'USD',
               probability: 90,
-              expectedCloseAt: new Date('2024-01-01'),
+              expectedCloseAt: '2024-01-01T00:00:00.000Z',
               ownerUserId: 'user-10',
               source: 'referral',
             },
@@ -634,6 +634,7 @@ describe('customers commands undo custom fields', () => {
       })
     )
     expect(existingDeal.title).toBe('Before Deal')
+    expect(existingDeal.expectedCloseAt).toEqual(new Date('2026-07-20T12:00:00.000Z'))
   })
 
   it('activities.update undo restores custom fields', async () => {

--- a/packages/core/src/modules/customers/commands/deals.ts
+++ b/packages/core/src/modules/customers/commands/deals.ts
@@ -73,8 +73,26 @@ type DealStageTransitionSnapshot = {
   stageId: string
   stageLabel: string
   stageOrder: number
-  transitionedAt: Date
+  transitionedAt: Date | string
   transitionedByUserId: string | null
+}
+
+function coerceSnapshotDate(value: Date | string | null | undefined, fieldName: string): Date | null {
+  if (value === undefined || value === null) return null
+  if (value instanceof Date) return value
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`[internal] Invalid ${fieldName} undo snapshot date: ${value}`)
+  }
+  return date
+}
+
+function coerceRequiredSnapshotDate(value: Date | string, fieldName: string): Date {
+  const date = coerceSnapshotDate(value, fieldName)
+  if (!date) {
+    throw new Error(`[internal] Missing ${fieldName} undo snapshot date`)
+  }
+  return date
 }
 
 async function loadPipelineStageSnapshot(
@@ -220,7 +238,7 @@ async function restoreDealStageTransitions(
       stageId: transitionSnapshot.stageId,
       stageLabel: transitionSnapshot.stageLabel,
       stageOrder: transitionSnapshot.stageOrder,
-      transitionedAt: transitionSnapshot.transitionedAt,
+      transitionedAt: coerceRequiredSnapshotDate(transitionSnapshot.transitionedAt, 'transitionedAt'),
       transitionedByUserId: transitionSnapshot.transitionedByUserId,
       isActive: true,
     })
@@ -242,7 +260,7 @@ type DealSnapshot = {
     valueAmount: string | null
     valueCurrency: string | null
     probability: number | null
-    expectedCloseAt: Date | null
+    expectedCloseAt: Date | string | null
     ownerUserId: string | null
     source: string | null
     closureOutcome: string | null
@@ -744,7 +762,7 @@ const updateDealCommand: CommandHandler<DealUpdateInput, { dealId: string }> = {
         valueAmount: before.deal.valueAmount,
         valueCurrency: before.deal.valueCurrency,
         probability: before.deal.probability,
-        expectedCloseAt: before.deal.expectedCloseAt,
+        expectedCloseAt: coerceSnapshotDate(before.deal.expectedCloseAt, 'expectedCloseAt'),
         ownerUserId: before.deal.ownerUserId,
         source: before.deal.source,
         closureOutcome: before.deal.closureOutcome,
@@ -776,7 +794,7 @@ const updateDealCommand: CommandHandler<DealUpdateInput, { dealId: string }> = {
         deal.valueAmount = before.deal.valueAmount
         deal.valueCurrency = before.deal.valueCurrency
         deal.probability = before.deal.probability
-        deal.expectedCloseAt = before.deal.expectedCloseAt
+        deal.expectedCloseAt = coerceSnapshotDate(before.deal.expectedCloseAt, 'expectedCloseAt')
         deal.ownerUserId = before.deal.ownerUserId
         deal.source = before.deal.source
         deal.closureOutcome = before.deal.closureOutcome
@@ -914,7 +932,7 @@ const deleteDealCommand: CommandHandler<{ body?: Record<string, unknown>; query?
           valueAmount: before.deal.valueAmount,
           valueCurrency: before.deal.valueCurrency,
           probability: before.deal.probability,
-          expectedCloseAt: before.deal.expectedCloseAt,
+          expectedCloseAt: coerceSnapshotDate(before.deal.expectedCloseAt, 'expectedCloseAt'),
           ownerUserId: before.deal.ownerUserId,
           source: before.deal.source,
           closureOutcome: before.deal.closureOutcome,


### PR DESCRIPTION
## Summary

- Coerce JSON-serialized deal undo snapshot dates back to `Date` before assigning them to MikroORM `Date` fields.
- Cover `CustomerDeal.expectedCloseAt` and restored deal stage transition `transitionedAt` snapshots.
- Add `TC-UNDO-003` integration coverage for create -> update expected close date -> undo through the public audit-log undo endpoint.

## Root Cause

Deal undo snapshots are stored in action-log JSON. `CustomerDeal.expectedCloseAt` therefore returns from the persisted undo payload as an ISO string, but the undo handler assigned it directly to MikroORM's `Date` property, causing validation to fail during flush.

## Validation

- `BASE_URL=http://127.0.0.1:5001 npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/customers/__integration__/TC-UNDO-003-deal-expected-close-date.spec.ts --retries=0`
- `yarn workspace @open-mercato/core test packages/core/src/modules/customers/commands/__tests__/undo.custom-fields.test.ts --runInBand`
- `yarn workspace @open-mercato/core test packages/core/src/modules/customers/commands/__tests__/deals.stage-transitions.test.ts --runInBand`
- `./node_modules/.bin/tsc --noEmit -p packages/core/tsconfig.json`

Note: the direct Playwright run against `localhost:3000` timed out because that local app port accepted connections without responding. The focused integration test passed against the repo ephemeral app at `127.0.0.1:5001`.