### PR TITLE
fix(workflows): persist FAILED status and trigger compensation when execution fails (#2291)

### DIFF
--- a/packages/core/src/modules/workflows/lib/__tests__/workflow-executor.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/workflow-executor.test.ts
@@ -13,6 +13,10 @@ jest.mock('../transition-handler', () => ({
   executeTransition: jest.fn(),
 }))
 
+jest.mock('../compensation-handler', () => ({
+  compensateWorkflow: jest.fn(),
+}))
+
 describe('Workflow Executor (Unit Tests)', () => {
   let mockEm: jest.Mocked<EntityManager>
   let mockContainer: jest.Mocked<AwilixContainer>
@@ -642,6 +646,157 @@ describe('Workflow Executor (Unit Tests)', () => {
 
       expect(result.status).toBe('FAILED')
       expect(result.errors).toContain('Activities failed: Email delivery error')
+    })
+  })
+
+  // ============================================================================
+  // Failure Persistence Tests (issue #2291)
+  // ============================================================================
+
+  describe('failure persistence (issue #2291)', () => {
+    const buildRunningInstance = (): WorkflowInstance =>
+      ({
+        id: testInstanceId,
+        definitionId: testDefinitionId,
+        workflowId: 'simple-workflow',
+        version: 1,
+        status: 'RUNNING',
+        currentStepId: 'start',
+        context: {},
+        tenantId: testTenantId,
+        organizationId: testOrgId,
+        startedAt: new Date(),
+        retryCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }) as WorkflowInstance
+
+    const mockFindOneByIds = (
+      instance: WorkflowInstance,
+      definition: Partial<WorkflowDefinition>
+    ) => {
+      mockEm.findOne.mockImplementation(async (_entity: unknown, where: unknown) => {
+        if ((where as Record<string, unknown>)?.id === testInstanceId) {
+          return instance
+        }
+        if ((where as Record<string, unknown>)?.id === testDefinitionId) {
+          return definition as WorkflowDefinition
+        }
+        return null
+      })
+    }
+
+    const mockValidStartToEndTransition = () => {
+      const transitionHandler = jest.requireMock('../transition-handler') as {
+        findValidTransitions: jest.Mock
+        executeTransition: jest.Mock
+      }
+      transitionHandler.findValidTransitions.mockResolvedValue([
+        {
+          isValid: true,
+          transition: {
+            transitionId: 'start-to-end',
+            fromStepId: 'start',
+            toStepId: 'end',
+            trigger: 'auto',
+          },
+        },
+      ])
+      return transitionHandler
+    }
+
+    test('should persist FAILED status, error message and WORKFLOW_FAILED event when transition is rejected', async () => {
+      const instance = buildRunningInstance()
+      mockFindOneByIds(instance, mockDefinition)
+      const transitionHandler = mockValidStartToEndTransition()
+      transitionHandler.executeTransition.mockResolvedValue({
+        success: false,
+        error: 'Activities failed: Email delivery error',
+      })
+
+      const result = await workflowExecutor.executeWorkflow(mockEm, mockContainer, testInstanceId)
+
+      expect(result.status).toBe('FAILED')
+      expect(instance.status).toBe('FAILED')
+      expect(instance.errorMessage).toBe('Activities failed: Email delivery error')
+      expect(instance.completedAt).toBeDefined()
+      expect(mockEm.flush).toHaveBeenCalled()
+      expect(mockEm.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ eventType: 'WORKFLOW_FAILED' })
+      )
+    })
+
+    test('should persist FAILED status and WORKFLOW_FAILED event when transition execution throws', async () => {
+      const instance = buildRunningInstance()
+      mockFindOneByIds(instance, mockDefinition)
+      const transitionHandler = mockValidStartToEndTransition()
+      transitionHandler.executeTransition.mockRejectedValue(new Error('Webhook target unreachable'))
+
+      const result = await workflowExecutor.executeWorkflow(mockEm, mockContainer, testInstanceId)
+
+      expect(result.status).toBe('FAILED')
+      expect(result.errors).toContain('Webhook target unreachable')
+      expect(instance.status).toBe('FAILED')
+      expect(instance.errorMessage).toBe('Webhook target unreachable')
+      expect(mockEm.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ eventType: 'WORKFLOW_FAILED' })
+      )
+    })
+
+    test('should trigger compensation when transition fails on a definition with compensatable activities', async () => {
+      const compensationHandler = jest.requireMock('../compensation-handler') as {
+        compensateWorkflow: jest.Mock
+      }
+      compensationHandler.compensateWorkflow.mockResolvedValue({
+        status: 'COMPENSATED',
+        compensatedActivities: 1,
+        totalActivities: 1,
+      })
+
+      const compensatableDefinition: Partial<WorkflowDefinition> = {
+        ...mockDefinition,
+        definition: {
+          steps: mockDefinition.definition!.steps,
+          transitions: [
+            {
+              transitionId: 'start-to-end',
+              fromStepId: 'start',
+              toStepId: 'end',
+              trigger: 'auto',
+              priority: 0,
+              activities: [
+                {
+                  activityId: 'reserve-stock',
+                  activityType: 'CALL_API',
+                  compensation: { activityId: 'release-stock' },
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const instance = buildRunningInstance()
+      mockFindOneByIds(instance, compensatableDefinition)
+      const transitionHandler = mockValidStartToEndTransition()
+      transitionHandler.executeTransition.mockResolvedValue({
+        success: false,
+        error: 'Activities failed: stock reservation rejected',
+      })
+
+      const result = await workflowExecutor.executeWorkflow(mockEm, mockContainer, testInstanceId)
+
+      expect(result.status).toBe('FAILED')
+      expect(instance.errorMessage).toBe('Activities failed: stock reservation rejected')
+      expect(compensationHandler.compensateWorkflow).toHaveBeenCalledWith(
+        mockEm,
+        mockContainer,
+        instance,
+        compensatableDefinition,
+        expect.objectContaining({ continueOnError: true })
+      )
     })
   })
 

--- a/packages/core/src/modules/workflows/lib/workflow-executor.ts
+++ b/packages/core/src/modules/workflows/lib/workflow-executor.ts
@@ -433,6 +433,14 @@ export async function executeWorkflow(
             console.error(`[WORKFLOW] Transition rejected (instance: ${currentInstance.id}, workflow: ${currentInstance.workflowId}, step: ${currentInstance.currentStepId} → ${selectedTransition.toStepId}): ${rejectionMessage}`)
             errors.push(rejectionMessage)
 
+            await completeWorkflow(trx, container, instanceId, 'FAILED', {
+              error: rejectionMessage,
+            })
+            events.push({
+              eventType: 'WORKFLOW_FAILED',
+              occurredAt: new Date(),
+            })
+
             return {
               status: 'FAILED',
               currentStep: currentInstance.currentStepId,
@@ -499,6 +507,15 @@ export async function executeWorkflow(
               transitionId: selectedTransition.transitionId,
               error: errorMessage,
             },
+          })
+
+          await completeWorkflow(trx, container, instanceId, 'FAILED', {
+            error: errorMessage,
+            details: error instanceof WorkflowExecutionError ? error.details : undefined,
+          })
+          events.push({
+            eventType: 'WORKFLOW_FAILED',
+            occurredAt: new Date(),
           })
 
           return {


### PR DESCRIPTION
Fixes #2291

## Problem
When a step or transition activity failed, the workflow instance stayed at `status=RUNNING` with `errorMessage=null` indefinitely. The failure was only visible in the event log (`STEP_FAILED` / `ACTIVITY_FAILED`); the instance never reached the terminal `FAILED` state documented in the module's `AGENTS.md`. Because the failure path never went through `completeWorkflow('FAILED')`, saga compensation never fired for real runtime failures either.

## Root Cause
In `lib/workflow-executor.ts` the execution loop **returned** `{ status: 'FAILED', ... }` on two branches without persisting anything:
- the `!transitionResult.success` branch (rejected transition), and
- the inner `catch` around `transitionHandler.executeTransition` (thrown transition error).

Only the outer `catch` (thrown errors that escape the loop) persisted `FAILED`. The REST start route runs execution via `setImmediate` and ignores the returned value, so the returned `FAILED` result was dropped entirely.

## What Changed
Both failure branches now call `completeWorkflow(trx, container, instanceId, 'FAILED', { error })` before returning — the same pattern already used by the parallel-branch failure path (#2428). `completeWorkflow` persists `status='FAILED'` + `errorMessage`/`errorDetails`, logs a persistent `WORKFLOW_FAILED` event, and triggers saga compensation when the definition has compensatable activities. The in-memory result also gains a `WORKFLOW_FAILED` event summary, mirroring the `COMPLETED` branch.

17 lines of production change in `packages/core/src/modules/workflows/lib/workflow-executor.ts`; no change to the REST route was needed since the executor now persists terminal state itself.

## Tests
New regression tests in `lib/__tests__/workflow-executor.test.ts` (all three failed before the fix):
- rejected transition → instance persisted as `FAILED` with `errorMessage`, `completedAt`, and a `WORKFLOW_FAILED` event
- thrown transition error → same persistence guarantees
- failing transition on a definition with compensatable activities → `compensateWorkflow` is invoked (saga regression from the issue)

Checks run: `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage` (10 missing keys are pre-existing on clean `develop`, verified via stash), `yarn typecheck` (21/21), `yarn test` (5467/5467), `yarn build:app`. Workflows module suite: 540/540.

## Backward Compatibility
- No contract surface changes: no signature, event-ID, API-shape, DI, ACL, or schema changes. `WORKFLOW_FAILED` is a pre-existing event type already emitted by the outer catch.
- Behavior change is the bug fix itself: instances that previously lingered as `RUNNING` now reach `FAILED`, and compensation fires where it was silently skipped — this is the documented state-machine behavior (`RUNNING → COMPLETED|FAILED|CANCELLED`).
