### PR TITLE
docs(agents): trim AGENTS.md under the 40k context limit

### DIFF
--- a/.ai/docs/module-development.md
+++ b/.ai/docs/module-development.md
@@ -1,0 +1,76 @@
+# Module Development Quick Reference
+
+> Linked from the root `AGENTS.md` (Task Router → Module Development). All paths use `src/modules/<module>/` as shorthand. See `packages/core/AGENTS.md` for full details.
+
+## Auto-Discovery Paths
+
+- Frontend pages: `frontend/<path>.tsx` → `/<path>`
+- Backend pages: `backend/<path>.tsx` → `/backend/<path>` (special: `backend/page.tsx` → `/backend/<module>`)
+- API routes: `api/<method>/<path>.ts` → `/api/<path>` (dispatched by method)
+- Subscribers: `subscribers/*.ts` — export default handler + `metadata` with `{ event, persistent?, id? }`
+- Workers: `workers/*.ts` — export default handler + `metadata` with `{ queue, id?, concurrency? }`
+
+## Optional Module Files
+
+| File | Export | Purpose |
+|------|--------|---------|
+| `index.ts` | `metadata` | Module metadata |
+| `cli.ts` | default | CLI commands |
+| `di.ts` | `register(container)` | DI registrar (Awilix) |
+| `acl.ts` | `features` | Feature-based permissions |
+| `setup.ts` | `setup: ModuleSetupConfig` | Tenant initialization, role features, customer role features |
+| `ce.ts` | `entities` | Custom entities / custom field sets |
+| `search.ts` | `searchConfig` | Search indexing configuration |
+| `events.ts` | `eventsConfig` | Typed event declarations |
+| `translations.ts` | `translatableFields` | Translatable field declarations per entity |
+| `notifications.ts` | `notificationTypes` | Notification type definitions |
+| `notifications.client.ts` | — | Client-side notification renderers |
+| `generators.ts` | `generatorPlugins` | Generator plugin declarations for additional aggregated output files |
+| `ai-tools.ts` | `aiTools` | MCP AI tool definitions |
+| `ai-agents.ts` | `aiAgents` | AI agent definitions (chat/object runtimes, tool allowlists, mutation policy) |
+| `api/interceptors.ts` | `interceptors` | API route interception hooks (before/after) |
+| `data/entities.ts` | — | MikroORM entities |
+| `data/validators.ts` | — | Zod validation schemas |
+| `data/extensions.ts` | `extensions` | Entity extensions (module links) |
+| `widgets/injection/` | — | Injected UI widgets |
+| `widgets/injection-table.ts` | — | Widget-to-slot mappings |
+| `widgets/components.ts` | `componentOverrides` | Component replacement/wrapper/props override definitions |
+| `data/enrichers.ts` | `enrichers` | Response enrichers for data federation |
+
+## Module Rules
+
+- API routes MUST export `openApi` for documentation generation
+- CRUD routes: use `makeCrudRoute` with `indexer: { entityType }` for query index coverage
+- Write operations: implement via the Command pattern (see `packages/core/src/modules/customers/commands/*`)
+- Feature naming convention: `<module>.<action>` (e.g., `example.view`, `example.create`).
+- setup.ts: always declare `defaultRoleFeatures` when adding features to `acl.ts`; grant admin and any appropriate default roles automatically, then run `yarn mercato auth sync-role-acls` so existing tenants receive the new ACLs
+- Every module with guarded routes or pages MUST declare features in `acl.ts` — never ship an empty `acl.ts` with `requireRoles` guards
+- Custom fields: use `collectCustomFieldValues()` from `@open-mercato/ui/backend/utils/customFieldValues`
+- Detail/read-model APIs that expose `customFields` MUST normalize response keys to bare field names via `normalizeCustomFieldResponse()` (for example `{ priority: 3 }`). Reserve `cf_` / `cf:` prefixes for request payloads, query-engine selectors, and form wiring.
+- Events: use `createModuleEvents()` with `as const` for typed emit
+- Translations: when adding entities with user-facing text fields (title, name, description, label), create `translations.ts` at module root declaring translatable fields. Run `yarn generate` after adding.
+- Widget injection: declare in `widgets/injection/`, map via `injection-table.ts`
+- API interception: declare interceptors in `api/interceptors.ts`; keep hooks fail-closed and scoped by route + method
+- Interceptors that narrow CRUD list results SHOULD prefer rewriting `query.ids` (comma-separated UUID list) instead of post-filtering response arrays
+- Component replacement: use handle-based IDs (`page:*`, `data-table:*`, `crud-form:*`, `section:*`) for deterministic overrides
+- Generated files split into two buckets — see [Generated Files: versioned vs ephemeral](#generated-files-versioned-vs-ephemeral):
+  - **Ephemeral** (gitignored, regenerated on every `yarn generate`, wiped by `yarn clean-generated`): `apps/mercato/.mercato/generated/`, `packages/*/generated/`, `src/generated/`. Never edit manually and never depend on them being present in a fresh clone before `yarn generate` runs.
+  - **Versioned** (committed `*.generated.ts` files living next to source — e.g. `apps/mercato/src/official-modules.generated.ts`, `packages/core/src/generated-shims/entities.ids.generated.ts`, `packages/ui/src/backend/fields/registry.generated.ts`): also never edit by hand, but they MUST stay in git because they encode source-of-truth state (module activation, frozen ID maps, registry shape) that must travel with the repo and survive `yarn clean-generated`.
+- Enable modules in your app’s `src/modules.ts` (e.g. `apps/mercato/src/modules.ts`)
+- Run `yarn generate` after adding/modifying module files
+- Agents MUST automatically run `yarn mercato configs cache structural --all-tenants` after enabling/disabling modules in `src/modules.ts`, adding/removing backend or frontend pages, or changing sidebar/navigation injection — stale `nav:*` cache and stale Turbopack module-graph fingerprints can both hide structural changes until they are purged. The structural command purges `nav:*` Redis keys and bumps mtimes on `.mercato/generated/*.generated.{ts,checksum}` so Turbopack re-evaluates the import graph without a dev-server restart. If Turbopack still serves a stale compiled chunk after that, run `yarn dev:reset` to clear `.mercato/next/dev` plus legacy `.next` caches and restart `yarn dev`.
+- New integration providers MUST own their env-backed preconfiguration inside the provider package: implement preset reading/application in the provider module, apply it from `setup.ts`, expose a rerunnable provider CLI command when practical, and document the env variables. Do not add provider-specific preconfiguration logic to core modules.
+- AI agents: put definitions in `<module>/ai-agents.ts` and run `yarn generate`. Every agent declares `moduleId`, `label`, `executionMode`, `requiredFeatures`, `allowedTools`, `mutationPolicy`, and `defaultModel` (optional). See `packages/ai-assistant/AGENTS.md` and `/framework/ai-assistant/agents`.
+- AI-driven mutations MUST go through `prepareMutation(...)` + pending-action approval; never write directly inside a mutation tool handler — the runtime fails closed if the approval contract is bypassed.
+- AI provider keys: at least one of `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY` must be set. Per-module model overrides use `OM_AI_<MODULE>_MODEL` (uppercased module id).
+
+## Generated Files: versioned vs ephemeral
+
+The codebase has two categories of generated files. Both are auto-written by tooling and MUST NOT be hand-edited, but they live in different places for different reasons.
+
+| Category | Where it lives | Tracked in git? | Survives `yarn clean-generated`? | Use it for |
+|---|---|---|---|---|
+| **Ephemeral** | `apps/mercato/.mercato/generated/`, `packages/*/generated/`, `src/generated/` (all matched by `.gitignore`) | No | No — wiped by `find -name generated -exec rm -rf` in `scripts/clean-generated.sh` | Per-build artifacts that `yarn generate` re-emits deterministically from in-repo source (module registries, indexer barrels, OpenAPI types, etc.). Safe to delete; safe to re-run. |
+| **Versioned** | Next to source as `<name>.generated.ts` / `<name>.generated.tsx` / `<name>-generated.d.ts` — e.g. `apps/mercato/src/official-modules.generated.ts`, `packages/core/src/generated-shims/entities.ids.generated.ts`, `packages/ui/src/backend/fields/registry.generated.ts`, `packages/ui/src/backend/icons/lucideRegistry.generated.tsx`, `packages/ai-assistant/src/modules/ai_assistant/lib/ai-{tools,agents}-generated.d.ts` | Yes | Yes — they are NOT inside any `generated/` folder and NOT inside `.mercato`, so the find-and-delete pattern doesn't match them | Source-of-truth state that must travel with the repo: module-activation config (`official-modules.json` → `official-modules.generated.ts`), frozen entity-id maps that protect against typos at type-check time, and registry shapes that other typed code imports. |
+
+**Before moving a versioned generated file into a `generated/` folder:** read `.ai/specs/2026-05-19-official-modules-generated-location-decision.md` — `scripts/clean-generated.sh` wipes every `generated/` folder, so a move requires coordinated changes to `.gitignore` and the clean script. Don't do it piecemeal.

--- a/.ai/specs/2026-06-05-ai-harness-single-shot-optimization.md
+++ b/.ai/specs/2026-06-05-ai-harness-single-shot-optimization.md
@@ -1,0 +1,111 @@
+# AI Harness Single-Shot Optimization — Skills & Task Router Gaps
+
+- **Status:** Draft (analysis complete; implementation not started)
+- **Date:** 2026-06-05
+- **Owner:** TBD
+- **Type:** Process / developer-experience (AI harness: `AGENTS.md`, `.ai/skills/`, standalone-app agentic templates)
+- **Related:** PR #2594 (AGENTS.md trim + first router quick-wins, already shipped), [[cf-async-index-read-after-write]], [[feedback-root-cause-not-timeout-bumps]]
+
+> ⚠️ This spec is the output of an automated analysis. The proposed skills and rules **require their own regression tests and a second optimization pass** before they can be considered done. Treat the priorities and PR groupings as evidence, not as a finished design.
+
+## 1. Goal
+
+Make coding agents (both monorepo contributors and standalone-app builders) succeed **in a single shot** — no human round-trips and no follow-up "fix" PR. The lever is the harness itself: the Task Router rows agents read first, the skills they can invoke, and the AGENTS.md rules that fail them closed.
+
+## 2. Method
+
+Two background workflows (kept separate per the request) each fanned 6 subagents across **all 317 PRs merged in the last 30 days** (window `merged:>=2026-05-06`), categorized them by task type, and mined the **128 `fix` PRs** for recurring root-causes an upfront skill/rule could have prevented. Findings were grounded against the live monorepo Task Router and the standalone `agentic/shared/AGENTS.md.template` + shipped skills.
+
+- `standalone-harness-gap-analysis` → `/tmp/standalone-harness-findings.md` (full report archived in the run transcript)
+- `monorepo-harness-gap-analysis` → `/tmp/monorepo-harness-findings.md`
+
+## 3. Headline finding (both workflows converge)
+
+The top three work buckets — **integration testing, data-integrity writes, and tenant/security scoping** — account for roughly half of all merged work and contain nearly all of the *repeated* failures. Yet these are exactly the Task Router rows that cite **no skill** today. The same five root-causes recur across dozens of modules because each agent rediscovers them rather than reading one rule.
+
+Convergent top failure classes (with representative fix PRs):
+
+| Failure class | Representative fix PRs | Single-shot fix |
+|---|---|---|
+| Non-atomic multi-table writes (entity + custom fields + links flushed separately) | 2383, 2377, 2376, 2374, 2368, 2360, 2356, 2355, 2354, 2343, 2420 | one transaction (`withAtomicFlush`) + "inject mid-write failure → assert no partial row" test |
+| CrudForm field doesn't survive save→reload (dot-path, nullable, custom fields) | 2540, 2535, 2533, 2528, 2515, 2513, 2467, 2408, 2405, 2396, 2415 | field round-trip checklist + the #2466 field-persistence harness |
+| Reads not scoped to tenant+org; fail-OPEN on null scope | 2320, 2300, 2299, 2296, 2294, 2212, 2198, 2197, 2196, 2124, 2122, 2107 | "scope or deny" guard test (model on `optimistic-lock-ui-coverage.test.ts`) |
+| Undo/redo handlers silently no-op or lose writes under encryption re-baseline | 2586, 2514, 2509, 2508, 2417, 2347, 2346, 2345 | `extractUndoPayload` + preserve-pending pattern + #2468 coverage matrix |
+| ACL feature dependencies (`dependsOn`) not declared → gated runtimes never run | 2297, 2295, 2289–2249 range, 2208, 2201, 2220, 2141 | scaffold emits `dependsOn` + `sync-role-acls` reminder |
+| Encrypted-column read paths (search/sort/filter/label) assume plaintext | 2040, 2065, 2282, 2447 | `findWithDecryption` + search-token + query-index decrypt checklist |
+| Flaky tests: async-index read-after-write + fixed date literals | 2554, 2450, 2393, 2391, 2369, 2418, 2419, 2213, 2202, 2226 | poll-after-write rule + time-bomb date scanner as CI gate |
+| `instanceof` across Turbopack split chunks | 2066, 2059, 1850, 1916 | one rule: use `is*()` type guards, read `{error:{code,message}}` defensively |
+
+## 4. Analysis A — Standalone apps
+
+Structural issue: there are **two** standalone AGENTS.md files and they disagree.
+
+1. `packages/create-app/template/AGENTS.md` — the root file shipped to **every** scaffolded app (bare + imported ready apps). It has **no Task Router**, so an agent reading only it is blind to all 19 shipped skills.
+2. `packages/create-app/agentic/shared/AGENTS.md.template` — generated **only when the agentic wizard runs**. It has a good Task→Context map but is missing rows for the three P0 themes (atomic writes, field round-trip, fail-closed scoping).
+
+Per `packages/create-app/AGENTS.md` rule #8, both files must be updated in the same change. **Caveat to resolve during implementation:** skills are installed by the agentic wizard, so referencing them from the bare-scaffold `template/AGENTS.md` only helps if those apps also receive the skills — confirm install paths before adding skill links to the bare template (otherwise the bare template should link docs/URLs, not `.ai/skills/...`).
+
+Standalone task distribution (by PR volume): integration tests > admin/CRUD UI > auth/ACL > tenant scoping > atomic writes > performance > custom fields > undo/redo. Full root-cause list and per-skill improvement notes in `/tmp/standalone-harness-findings.md`.
+
+## 5. Analysis B — Monorepo
+
+The Task Router cites a skill on only **6 of ~36 rows**. Module Development, Data integrity, Encryption, Security/scoping, CrudForm/DataTable, and Performance rows point only at AGENTS.md prose — and those are exactly where the repeated fixes land. Monorepo task distribution: integration tests (~45) > data integrity (~28) > security scoping (~25) ≈ UI primitives (~25) > ACL deps (~19) > performance (~18). Full report in `/tmp/monorepo-harness-findings.md`.
+
+Already shipped in PR #2594 (quick-win citations): `om-backend-ui-design`/`om-ds-guardian` on the UI/CrudForm/DataTable/portal rows, `om-spec-writing` on the spec-lifecycle row, `om-module-scaffold` note + `.ai/docs/module-development.md` link on the "create a module" row.
+
+## 6. Proposed NEW skills
+
+Unified across both ecosystems (standalone names install as `om-*`). Each MUST ship with a regression test/gate, not prose alone.
+
+| Skill | Priority | Scope | Required test/gate | Justifying PRs |
+|---|---|---|---|---|
+| `atomic-write` (a.k.a. `data-integrity-writes`) | **P0** | Any command writing an entity + its custom fields/links/relations/cascades uses one `withAtomicFlush`/locking transaction; serialize concurrent timer/segment/counter writes | "inject mid-write failure → assert no partial row" template | 2383, 2377, 2376, 2374, 2368, 2360, 2356, 2355, 2354, 2343, 2420 |
+| `crudform-field` (a.k.a. `crud-field-persistence`) | **P0** | Every editable field round-trips: declared in validator → serialized in detail GET → hydrated into `initialValues` → clearable to null; reject undeclared cf keys; dirty-baseline from `initialValues`; resolve UUIDs to labels | #2466 field-persistence harness as the default check | 2540, 2535, 2533, 2528, 2515, 2513, 2467, 2408, 2405, 2396, 2415, 2437 |
+| `scope-guard` (a.k.a. `tenant-scoping-and-fail-closed`) | **P0** | "Scope or deny" on every read surface (em.find/findOne, enrichers, search, SSE filters, command `require*`); fail CLOSED on null scope; super-admin gate on global/system writes | guard test modeled on `optimistic-lock-ui-coverage.test.ts` | 2320, 2300, 2299, 2296, 2294, 2212, 2198, 2197, 2196, 2124, 2122, 2107, 2279, 2278 |
+| `undo-redo` | **P1** | Snapshot via `extractUndoPayload`; preserve pending under encryption deep-decrypt re-baseline; single lock on compound ops; public-undo-API reachability | #2468 undo coverage matrix | 2586, 2514, 2509, 2508, 2417, 2347, 2346, 2345 |
+| `acl-feature-dependencies` (or a `module-scaffold` section) | **P1** | Scaffold emits `dependsOn` bundles + a working `getGrantedFeatures`; every gated route/enricher/AI-tool/menu declares transitive features; grant in `setup.ts` + `sync-role-acls` | ACL-dependency guard test | 2297, 2295, 2289–2249, 2208, 2201, 2220, 2141 |
+| `encrypted-field` | **P1** | Search/sort/filter/label-display over encrypted columns routes through search-token + `findWithDecryption` + query-index label decryption; never DB-sort encrypted columns | encrypted-read-path checklist + test | 2040, 2065, 2282, 2447 |
+| `perf-pattern` (a.k.a. `perf-list-and-afterlist`) | **P2** | `$in`/`Promise.all` batching and per-process memoization as the default; push pagination to DB; skip enrichers on list cache hits | N+1 lint/review check | 2318–2310, 2290, 2263, 2211, 2210, 2314 |
+
+## 7. Task Router changes
+
+### 7.1 Monorepo root `AGENTS.md`
+Add rows for `atomic-write`, `scope-guard`, `crudform-field`, `undo-redo`, `encrypted-field` (strengthen the existing Encryption row), and a Performance batching row; wire the existing autonomous-fix chain (`om-root-cause` → `om-fix` → `om-verify-in-repo`) into the "Autonomous bug fixing" principle; cite `om-smart-test` + the root-cause-over-timeout memory on the Testing row; cite `om-create-agents-md` on the new-module/package row; add `om-dev-container-maintenance` + `om-check-and-commit` rows.
+
+### 7.2 Standalone `template/AGENTS.md` + `agentic/shared/AGENTS.md.template`
+Add a Task Router to the bare `template/AGENTS.md` (resolving the install caveat in §4) and add the three missing P0 rows to the agentic map. Keep both files in sync (rule #8).
+
+## 8. Existing-skill improvements
+
+- **`om-module-scaffold`**: add a Custom Fields section (`collectCustomFieldValues`, reject undeclared cf keys, `normalizeCustomFieldResponse`); an "atomic writes" rule; a `dependsOn` ACL example; a read-model parity rule (detail/list GET returns every editable field incl. `updatedAt`); an `instanceof`-across-chunks rule. *(Partially started in PR #2594: stale `api/get|post`, feature-id, and entity-file conventions corrected in `references/naming-conventions.md`.)* Unresolved: the `page.meta.ts` icon guidance contradicts `template/AGENTS.md` (skill says `lucide-react`; template says inline `React.createElement('svg')` in meta files) — **needs a maintainer decision**.
+- **`om-system-extension`**: transaction safety for guard-driven sibling writes; skip-enrichers-on-cache-hit + memoization note; `query.ids` narrowing + boolean/SQL-cast filter rule; fail-closed scoping for interceptors/guards/enrichers.
+- **`om-data-model-design`**: `updated_at` must be returned in list/detail responses; encrypted/relation columns register a query-index decrypt/search-token step; history writes share the entity-write transaction.
+- **`om-integration-tests`**: poll-after-write against the async index; forbid fixed date literals (time-bomb scanner); deterministic readiness wait before clicking portalled row menus.
+- **`om-code-review`**: add five checklist items — atomic-write, write-then-read field parity, fail-closed-on-null-scope, `dependsOn` declaration, no-`instanceof`-across-chunks.
+- **`om-backend-ui-design`**: unwrap structured error envelopes via `raiseCrudError`/`readApiResultOrThrow`; combobox label resolution + portal layering; never render raw FK UUIDs; clean detail must not report dirty.
+
+## 9. Tests & verification (REQUIRED — this spec is not done without them)
+
+Each new skill is only credible with an enforcing gate. Minimum:
+1. `scope-guard` CI test that fails when a read path lacks org+tenant predicates (mirror `optimistic-lock-ui-coverage.test.ts`).
+2. `atomic-write` regression template (mid-write failure → no partial row) wired into at least one core module as the worked example.
+3. Field-persistence harness (#2466) promoted to a reusable fixture and referenced by `crudform-field`.
+4. Time-bomb date-literal scanner promoted from advisory to a CI gate for `__integration__` specs.
+5. `makeCrudRoute`-missing-`indexer` generate-time guard (themes 2083/2086/2076/2073).
+
+## 10. Phasing
+
+- **Phase 1 (quick wins, mostly docs):** Task Router citations of existing skills (monorepo done in #2594; standalone pending), the four one-line AGENTS.md rules (atomic-write, fail-closed scope, no-`instanceof`, poll-after-write), `om-module-scaffold` custom-fields + `dependsOn` sections.
+- **Phase 2 (P0 skills + gates):** `atomic-write`, `crudform-field`, `scope-guard` with their tests.
+- **Phase 3 (P1/P2 skills):** `undo-redo`, `acl-feature-dependencies`, `encrypted-field`, `perf-pattern`; existing-skill improvements; second optimization pass re-measuring the next 30-day window.
+
+## 11. Backward compatibility
+
+All changes are **additive**: new skills, new Task Router rows, new AGENTS.md rules, and doc edits. No contract surface (per `BACKWARD_COMPATIBILITY.md`) is removed or renamed. The one rename already in the tree (`module-scaffold` → `om-module-scaffold`) predates this spec and is not introduced here. New CI gates must land as advisory first, then enforcing, to avoid blocking in-flight PRs.
+
+## 12. Open questions
+
+1. New skills vs. sections in existing skills — `acl-feature-dependencies` and `encrypted-field` may be better as `om-module-scaffold`/`om-data-model-design` sections than standalone skills.
+2. Resolve the `page.meta.ts` icon contradiction (skill vs. template).
+3. Confirm `create-ai-agent` actually ships to standalone apps (`template/AGENTS.md` references it; verify it is in the installed skill set).
+4. Decide whether the bare `template/AGENTS.md` should link `.ai/skills/...` (only valid if skills are installed there) or docs URLs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ IMPORTANT: Before any research or coding, match the task to the root `AGENTS.md`
 | Task | Guide |
 |------|-------|
 | **Module Development** | |
-| Creating a new module, scaffolding module files, auto-discovery paths | `packages/core/AGENTS.md` |
+| Creating a new module, scaffolding module files, auto-discovery paths | `packages/core/AGENTS.md` + [`.ai/docs/module-development.md`](.ai/docs/module-development.md). **Standalone apps**: the `module-scaffold` skill scaffolds a module end-to-end (routes, pages, DI, ACL, events, search) — great to use here. |
 | Working on official modules via the `external/official-modules` submodule, activating them (`yarn official-modules`, `official-modules.json`), committing to the submodule's git | this file → `external/official-modules/` (git submodule) |
 | Building CRUD API routes, adding OpenAPI specs, using `makeCrudRoute`, query engine integration | `packages/core/AGENTS.md` → API Routes |
 | Adding `setup.ts` for tenant init, declaring role features, syncing new ACL grants to roles, seeding defaults/examples | `packages/core/AGENTS.md` → Module Setup |
@@ -76,7 +76,7 @@ IMPORTANT: Before any research or coding, match the task to the root `AGENTS.md`
 | Filtering CRUD list APIs by multiple IDs (`?ids=uuid1,uuid2`), including interceptor-driven ID narrowing | `packages/core/AGENTS.md` → API Interceptors + `packages/shared/AGENTS.md` |
 | Preventing silent lost updates on concurrent CRUD edits (optimistic locking via `updated_at`, **default ON** across every `makeCrudRoute` entity, opt out with `OM_OPTIMISTIC_LOCK=off`); structured 409 conflict body and client helpers (`buildOptimisticLockHeader`, `extractOptimisticLockConflict`). For Command-pattern / non-`makeCrudRoute` writes (sales document sub-resources, action endpoints), enforce the same check in the handler with `enforceCommandOptimisticLock` (document-aggregate: guard the parent order/quote) or the DI-overridable `createCommandOptimisticLockGuardService({ resolveExpected? })` (enterprise seam, #2232). Surface the 409 via the unified conflict bar with `surfaceRecordConflict(err, t)` from `@open-mercato/ui/backend/conflicts` (`CrudForm`/`useGuardedMutation` do it automatically) | `apps/docs/docs/framework/data-integrity/concurrency-locking.mdx` (§ Protecting command/action endpoints) + `.ai/specs/2026-05-25-oss-optimistic-locking.md` + `.ai/specs/2026-05-28-optimistic-locking-coverage-completion.md` + `packages/shared/src/lib/crud/optimistic-lock.ts` + `packages/shared/src/lib/crud/optimistic-lock-command.ts` (command-level + `createCommandOptimisticLockGuardService` seam) + `packages/ui/src/backend/conflicts/` (unified conflict bar) + `packages/shared/src/lib/di/container.ts` (default service) + `packages/core/src/modules/customers/di.ts` (polymorphic-table override) + `packages/core/src/modules/sales/commands/shared.ts` (sales wrapper) |
 | Adding DOM Event Bridge (SSE-based real-time events to browser), `useAppEvent`, `useOperationProgress` | `packages/events/AGENTS.md` → DOM Event Bridge |
-| Building customer portal pages, portal auth, portal nav injection, portal event bridge | `packages/ui/AGENTS.md` → Portal Extension |
+| Building customer portal pages, portal auth, portal nav injection, portal event bridge | `packages/ui/AGENTS.md` → Portal Extension + `om-backend-ui-design` skill |
 | Adding new widget event handlers (`onFieldChange`, `onBeforeNavigate`, transformers) | `packages/ui/AGENTS.md` |
 | Building AI agents/tools (`ai-agents.ts`, `ai-tools.ts`, tool packs, mutation approval via `prepareMutation`, attachments, provider/model selection) | `.ai/skills/om-create-ai-agent/SKILL.md` + `packages/ai-assistant/AGENTS.md` + `apps/docs/docs/framework/ai-assistant/*.mdx` |
 | AI agent loop controls + overrides (`loop.stopWhen/prepareStep/budget`, per-tenant settings, replacing/disabling agents/tools, module-level `entry.overrides`) | `packages/ai-assistant/AGENTS.md` → Loop controls + How to Override + `.ai/specs/2026-04-28-ai-agents-agentic-loop-controls.md` + `.ai/specs/2026-04-30-ai-overrides-and-module-disable.md` + `.ai/specs/2026-05-04-modules-ts-unified-overrides.md` |
@@ -86,8 +86,8 @@ IMPORTANT: Before any research or coding, match the task to the root `AGENTS.md`
 | Building a new integration provider (adapter, health check, credentials, bundle wiring) | `.ai/skills/om-integration-builder/SKILL.md` + `packages/core/src/modules/integrations/AGENTS.md` + `packages/core/src/modules/data_sync/AGENTS.md` |
 | **Packages** | |
 | Adding reusable utilities, encryption helpers, i18n translations (`useT`/`resolveTranslations`), boolean parsing, data engine types, request scoping | `packages/shared/AGENTS.md` |
-| Building forms (`CrudForm`), data tables (`DataTable`), loading/error states, flash messages, `FormHeader`/`FormFooter`, dialog UX (`Cmd+Enter`/`Escape`) | `packages/ui/AGENTS.md` |
-| Backend page components, `apiCall` usage, `RowActions` ids, `LoadingMessage`/`ErrorMessage` | `packages/ui/src/backend/AGENTS.md` |
+| Building forms (`CrudForm`), data tables (`DataTable`), loading/error states, flash messages, `FormHeader`/`FormFooter`, dialog UX (`Cmd+Enter`/`Escape`) | `packages/ui/AGENTS.md` + `om-backend-ui-design` skill (+ `om-ds-guardian` skill for DS-token compliance) |
+| Backend page components, `apiCall` usage, `RowActions` ids, `LoadingMessage`/`ErrorMessage` | `packages/ui/src/backend/AGENTS.md` + `om-backend-ui-design` skill |
 | Configuring fulltext/vector/token search, writing `search.ts`, reindexing entities, debugging search, search CLI commands | `packages/search/AGENTS.md` |
 | Adding MCP tools (`registerMcpTool`), modifying OpenCode config, debugging AI chat, session tokens, command palette, two-tier auth | `packages/ai-assistant/AGENTS.md` |
 | Running generators (`yarn generate`), creating database migrations (`yarn db:generate`), scaffolding modules, build order | `packages/cli/AGENTS.md` |
@@ -105,7 +105,7 @@ IMPORTANT: Before any research or coding, match the task to the root `AGENTS.md`
 | **Testing** | |
 | Integration testing, creating/running Playwright tests, converting markdown test cases to TypeScript, CI test pipeline | `.ai/qa/AGENTS.md` + `.ai/skills/om-integration-tests/SKILL.md` |
 | **Spec & PR Automation** | |
-| Spec lifecycle (pre-implement → implement → write/update), code review, DS review | Browse `.ai/skills/{om-pre-implement-spec,om-implement-spec,om-code-review,om-ds-guardian}/SKILL.md` + `.ai/specs/AGENTS.md` + `.ai/ds-rules.md` |
+| Spec lifecycle (pre-implement → implement → write/update), code review, DS review | Browse `.ai/skills/{om-spec-writing,om-pre-implement-spec,om-implement-spec,om-code-review,om-ds-guardian}/SKILL.md` + `.ai/specs/AGENTS.md` + `.ai/ds-rules.md` |
 | PR/issue automation (one-shot auto-PR, resumable loop variants, review/merge-buddy, post-merge sync, changelog). **Default for one-off bug fixes / small features:** `om-auto-create-pr` | Browse `.ai/skills/{om-auto-create-pr,om-auto-continue-pr,om-auto-create-pr-loop,om-auto-continue-pr-loop,om-auto-review-pr,om-merge-buddy,om-review-prs,om-sync-merged-pr-issues,om-auto-update-changelog}/SKILL.md` |
 
 ## Core Principles

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,7 @@ All packages use the `@open-mercato/<package>` naming convention:
 - Put shared utilities and types in `packages/shared/src/lib/` or `packages/shared/src/modules/`
 - Put UI components in `packages/ui/src/`
 - Put user/app-specific modules in `apps/mercato/src/modules/<module>/`
-- MUST NOT add code directly in `apps/mercato/src/` — it's a boilerplate for user apps. Narrow exception: committed, typed *generated registries* (files matching `*.generated.ts`) consumed by `modules.ts` or other root entry points may live in `apps/mercato/src/` when they must survive `yarn clean-generated` and travel with the repo — see [Generated Files: versioned vs ephemeral](#generated-files-versioned-vs-ephemeral).
+- MUST NOT add code directly in `apps/mercato/src/` — it's a boilerplate for user apps. Narrow exception: committed, typed *generated registries* (files matching `*.generated.ts`) consumed by `modules.ts` or other root entry points may live in `apps/mercato/src/` when they must survive `yarn clean-generated` and travel with the repo — see [Generated Files: versioned vs ephemeral](.ai/docs/module-development.md#generated-files-versioned-vs-ephemeral).
 
 ### `external/official-modules/` (git submodule)
 
@@ -229,80 +229,7 @@ Import strategy:
 
 ## Module Development Quick Reference
 
-All paths use `src/modules/<module>/` as shorthand. See `packages/core/AGENTS.md` for full details.
-
-### Auto-Discovery Paths
-
-- Frontend pages: `frontend/<path>.tsx` → `/<path>`
-- Backend pages: `backend/<path>.tsx` → `/backend/<path>` (special: `backend/page.tsx` → `/backend/<module>`)
-- API routes: `api/<method>/<path>.ts` → `/api/<path>` (dispatched by method)
-- Subscribers: `subscribers/*.ts` — export default handler + `metadata` with `{ event, persistent?, id? }`
-- Workers: `workers/*.ts` — export default handler + `metadata` with `{ queue, id?, concurrency? }`
-
-### Optional Module Files
-
-| File | Export | Purpose |
-|------|--------|---------|
-| `index.ts` | `metadata` | Module metadata |
-| `cli.ts` | default | CLI commands |
-| `di.ts` | `register(container)` | DI registrar (Awilix) |
-| `acl.ts` | `features` | Feature-based permissions |
-| `setup.ts` | `setup: ModuleSetupConfig` | Tenant initialization, role features, customer role features |
-| `ce.ts` | `entities` | Custom entities / custom field sets |
-| `search.ts` | `searchConfig` | Search indexing configuration |
-| `events.ts` | `eventsConfig` | Typed event declarations |
-| `translations.ts` | `translatableFields` | Translatable field declarations per entity |
-| `notifications.ts` | `notificationTypes` | Notification type definitions |
-| `notifications.client.ts` | — | Client-side notification renderers |
-| `generators.ts` | `generatorPlugins` | Generator plugin declarations for additional aggregated output files |
-| `ai-tools.ts` | `aiTools` | MCP AI tool definitions |
-| `ai-agents.ts` | `aiAgents` | AI agent definitions (chat/object runtimes, tool allowlists, mutation policy) |
-| `api/interceptors.ts` | `interceptors` | API route interception hooks (before/after) |
-| `data/entities.ts` | — | MikroORM entities |
-| `data/validators.ts` | — | Zod validation schemas |
-| `data/extensions.ts` | `extensions` | Entity extensions (module links) |
-| `widgets/injection/` | — | Injected UI widgets |
-| `widgets/injection-table.ts` | — | Widget-to-slot mappings |
-| `widgets/components.ts` | `componentOverrides` | Component replacement/wrapper/props override definitions |
-| `data/enrichers.ts` | `enrichers` | Response enrichers for data federation |
-
-### Module Rules
-
-- API routes MUST export `openApi` for documentation generation
-- CRUD routes: use `makeCrudRoute` with `indexer: { entityType }` for query index coverage
-- Write operations: implement via the Command pattern (see `packages/core/src/modules/customers/commands/*`)
-- Feature naming convention: `<module>.<action>` (e.g., `example.view`, `example.create`).
-- setup.ts: always declare `defaultRoleFeatures` when adding features to `acl.ts`; grant admin and any appropriate default roles automatically, then run `yarn mercato auth sync-role-acls` so existing tenants receive the new ACLs
-- Every module with guarded routes or pages MUST declare features in `acl.ts` — never ship an empty `acl.ts` with `requireRoles` guards
-- Custom fields: use `collectCustomFieldValues()` from `@open-mercato/ui/backend/utils/customFieldValues`
-- Detail/read-model APIs that expose `customFields` MUST normalize response keys to bare field names via `normalizeCustomFieldResponse()` (for example `{ priority: 3 }`). Reserve `cf_` / `cf:` prefixes for request payloads, query-engine selectors, and form wiring.
-- Events: use `createModuleEvents()` with `as const` for typed emit
-- Translations: when adding entities with user-facing text fields (title, name, description, label), create `translations.ts` at module root declaring translatable fields. Run `yarn generate` after adding.
-- Widget injection: declare in `widgets/injection/`, map via `injection-table.ts`
-- API interception: declare interceptors in `api/interceptors.ts`; keep hooks fail-closed and scoped by route + method
-- Interceptors that narrow CRUD list results SHOULD prefer rewriting `query.ids` (comma-separated UUID list) instead of post-filtering response arrays
-- Component replacement: use handle-based IDs (`page:*`, `data-table:*`, `crud-form:*`, `section:*`) for deterministic overrides
-- Generated files split into two buckets — see [Generated Files: versioned vs ephemeral](#generated-files-versioned-vs-ephemeral):
-  - **Ephemeral** (gitignored, regenerated on every `yarn generate`, wiped by `yarn clean-generated`): `apps/mercato/.mercato/generated/`, `packages/*/generated/`, `src/generated/`. Never edit manually and never depend on them being present in a fresh clone before `yarn generate` runs.
-  - **Versioned** (committed `*.generated.ts` files living next to source — e.g. `apps/mercato/src/official-modules.generated.ts`, `packages/core/src/generated-shims/entities.ids.generated.ts`, `packages/ui/src/backend/fields/registry.generated.ts`): also never edit by hand, but they MUST stay in git because they encode source-of-truth state (module activation, frozen ID maps, registry shape) that must travel with the repo and survive `yarn clean-generated`.
-- Enable modules in your app’s `src/modules.ts` (e.g. `apps/mercato/src/modules.ts`)
-- Run `yarn generate` after adding/modifying module files
-- Agents MUST automatically run `yarn mercato configs cache structural --all-tenants` after enabling/disabling modules in `src/modules.ts`, adding/removing backend or frontend pages, or changing sidebar/navigation injection — stale `nav:*` cache and stale Turbopack module-graph fingerprints can both hide structural changes until they are purged. The structural command purges `nav:*` Redis keys and bumps mtimes on `.mercato/generated/*.generated.{ts,checksum}` so Turbopack re-evaluates the import graph without a dev-server restart. If Turbopack still serves a stale compiled chunk after that, run `yarn dev:reset` to clear `.mercato/next/dev` plus legacy `.next` caches and restart `yarn dev`.
-- New integration providers MUST own their env-backed preconfiguration inside the provider package: implement preset reading/application in the provider module, apply it from `setup.ts`, expose a rerunnable provider CLI command when practical, and document the env variables. Do not add provider-specific preconfiguration logic to core modules.
-- AI agents: put definitions in `<module>/ai-agents.ts` and run `yarn generate`. Every agent declares `moduleId`, `label`, `executionMode`, `requiredFeatures`, `allowedTools`, `mutationPolicy`, and `defaultModel` (optional). See `packages/ai-assistant/AGENTS.md` and `/framework/ai-assistant/agents`.
-- AI-driven mutations MUST go through `prepareMutation(...)` + pending-action approval; never write directly inside a mutation tool handler — the runtime fails closed if the approval contract is bypassed.
-- AI provider keys: at least one of `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY` must be set. Per-module model overrides use `OM_AI_<MODULE>_MODEL` (uppercased module id).
-
-### Generated Files: versioned vs ephemeral
-
-The codebase has two categories of generated files. Both are auto-written by tooling and MUST NOT be hand-edited, but they live in different places for different reasons.
-
-| Category | Where it lives | Tracked in git? | Survives `yarn clean-generated`? | Use it for |
-|---|---|---|---|---|
-| **Ephemeral** | `apps/mercato/.mercato/generated/`, `packages/*/generated/`, `src/generated/` (all matched by `.gitignore`) | No | No — wiped by `find -name generated -exec rm -rf` in `scripts/clean-generated.sh` | Per-build artifacts that `yarn generate` re-emits deterministically from in-repo source (module registries, indexer barrels, OpenAPI types, etc.). Safe to delete; safe to re-run. |
-| **Versioned** | Next to source as `<name>.generated.ts` / `<name>.generated.tsx` / `<name>-generated.d.ts` — e.g. `apps/mercato/src/official-modules.generated.ts`, `packages/core/src/generated-shims/entities.ids.generated.ts`, `packages/ui/src/backend/fields/registry.generated.ts`, `packages/ui/src/backend/icons/lucideRegistry.generated.tsx`, `packages/ai-assistant/src/modules/ai_assistant/lib/ai-{tools,agents}-generated.d.ts` | Yes | Yes — they are NOT inside any `generated/` folder and NOT inside `.mercato`, so the find-and-delete pattern doesn't match them | Source-of-truth state that must travel with the repo: module-activation config (`official-modules.json` → `official-modules.generated.ts`), frozen entity-id maps that protect against typos at type-check time, and registry shapes that other typed code imports. |
-
-**Before moving a versioned generated file into a `generated/` folder:** read `.ai/specs/2026-05-19-official-modules-generated-location-decision.md` — `scripts/clean-generated.sh` wipes every `generated/` folder, so a move requires coordinated changes to `.gitignore` and the clean script. Don't do it piecemeal.
+> Moved to [`.ai/docs/module-development.md`](.ai/docs/module-development.md) to keep this file lean. Read it when scaffolding or editing a module — it covers auto-discovery paths, the optional-files table, module rules, and the versioned-vs-ephemeral generated-files contract. See `packages/core/AGENTS.md` for full details.
 
 ## Backward Compatibility Contract
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ IMPORTANT: Before any research or coding, match the task to the root `AGENTS.md`
 | Task | Guide |
 |------|-------|
 | **Module Development** | |
-| Creating a new module, scaffolding module files, auto-discovery paths | `packages/core/AGENTS.md` + [`.ai/docs/module-development.md`](.ai/docs/module-development.md). **Standalone apps**: the `module-scaffold` skill scaffolds a module end-to-end (routes, pages, DI, ACL, events, search) — great to use here. |
+| Creating a new module, scaffolding module files, auto-discovery paths | `packages/core/AGENTS.md` + [`.ai/docs/module-development.md`](.ai/docs/module-development.md). **Standalone apps**: the `om-module-scaffold` skill scaffolds a module end-to-end (routes, pages, DI, ACL, events, search) — great to use here. |
 | Working on official modules via the `external/official-modules` submodule, activating them (`yarn official-modules`, `official-modules.json`), committing to the submodule's git | this file → `external/official-modules/` (git submodule) |
 | Building CRUD API routes, adding OpenAPI specs, using `makeCrudRoute`, query engine integration | `packages/core/AGENTS.md` → API Routes |
 | Adding `setup.ts` for tenant init, declaring role features, syncing new ACL grants to roles, seeding defaults/examples | `packages/core/AGENTS.md` → Module Setup |

--- a/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/naming-conventions.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/naming-conventions.md
@@ -7,7 +7,7 @@
 | Module ID | plural, snake_case | `fleet_vehicles`, `loyalty_points` |
 | Module folder | same as module ID | `src/modules/fleet_vehicles/` |
 | Entity class | PascalCase, singular | `FleetVehicle`, `LoyaltyPoint` |
-| Entity file | PascalCase, singular | `entities/FleetVehicle.ts` |
+| Entity file | single `data/entities.ts` (one class per entity) | `data/entities.ts` → `class FleetVehicle` |
 | Table name | plural, snake_case | `fleet_vehicles`, `loyalty_points` |
 | Column name | snake_case | `vehicle_type`, `point_balance` |
 
@@ -17,7 +17,7 @@
 |---------|-----------|---------|
 | JS/TS fields | camelCase | `vehicleType`, `pointBalance` |
 | Event ID | `module.entity.action` (dots, singular entity, past tense) | `fleet_vehicles.vehicle.created` |
-| Feature ID | `module.action` | `fleet_vehicles.view`, `fleet_vehicles.create` |
+| Feature ID | `module.entity.action` (per-entity; use `view` / `manage`) | `fleet_vehicles.vehicle.view`, `fleet_vehicles.vehicle.manage` |
 | Enricher ID | `module.enricher-name` | `fleet_vehicles.maintenance-stats` |
 | Widget ID | `module.injection.widget-name` | `fleet_vehicles.injection.status-column` |
 | Interceptor ID | `module.interceptor-name` | `fleet_vehicles.validate-vin` |
@@ -39,12 +39,11 @@ deleted_at: Date | null // Soft delete timestamp
 
 ## API Routes
 
-| Method | File Path | URL |
-|--------|----------|-----|
-| GET | `api/get/<entities>.ts` | `GET /api/<module>/<entities>` |
-| POST | `api/post/<entities>.ts` | `POST /api/<module>/<entities>` |
-| PUT | `api/put/<entities>.ts` | `PUT /api/<module>/<entities>` |
-| DELETE | `api/delete/<entities>.ts` | `DELETE /api/<module>/<entities>` |
+All HTTP methods live in a **single** `api/<entities>/route.ts` that exports named handlers `{ GET, POST, PUT, DELETE }` + `metadata` + `openApi` (not separate `api/get/`, `api/post/` files).
+
+| File Path | Methods | URL |
+|-----------|---------|-----|
+| `api/<entities>/route.ts` | `GET` / `POST` / `PUT` / `DELETE` | `/api/<module>/<entities>` |
 
 ## Backend Pages
 


### PR DESCRIPTION
## Why

`AGENTS.md` grew to **42.5k chars**, tripping the *"over the 40.0k-char limit"* warning. Since it loads into every agent's context, it must stay lean. This PR trims it **and** improves how the harness surfaces skills to agents (follow-up scope requested on the same branch).

## What

**1. Trim AGENTS.md under the limit (42.5k → 34.0k)**
- Moved the *Module Development Quick Reference* into [`.ai/docs/module-development.md`](.ai/docs/module-development.md), leaving a one-line pointer + repointed anchor.

**2. Surface skills in the Task Router (quick wins)**
- `om-backend-ui-design` (+ `om-ds-guardian`) on the CrudForm/DataTable/backend-page/portal rows.
- `om-spec-writing` on the spec-lifecycle row.
- `om-module-scaffold` note + link to the new doc on the "create a module" row.

**3. Fix `om-module-scaffold` skill drift**
- `references/naming-conventions.md`: single `api/<entities>/route.ts` (not stale `api/get|post`); per-entity `module.entity.action` feature IDs; single `data/entities.ts`.

**4. AI harness optimization spec**
- [`.ai/specs/2026-06-05-ai-harness-single-shot-optimization.md`](.ai/specs/2026-06-05-ai-harness-single-shot-optimization.md), synthesized from two background workflows that analyzed **all 317 PRs merged in the last 30 days** (128 fixes) to find the skills + router rows that would make agents succeed in one shot.

## Follow-up issues

- #2597 — implement the harness optimization spec (new skills + gates). ⚠️ requires its own tests + a second optimization pass.
- #2599 — Task Router skill-coverage checklist (quick wins + rows needing new skills).

## Result

| | Before | After |
|---|---|---|
| `AGENTS.md` | 42.5k | **34.0k** (~6k under the limit) |

Built on a separate branch/worktree so the in-flight PR #2549 work was untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)