### PR TITLE
feat(commands): add runCrudCommandWrite helper (#2598)

### DIFF
--- a/.ai/specs/2026-06-05-run-crud-command-write-helper.md
+++ b/.ai/specs/2026-06-05-run-crud-command-write-helper.md
@@ -1,0 +1,243 @@
+# runCrudCommandWrite — Unified Command-Write Helper
+
+| Field | Value |
+|-------|-------|
+| **Status** | Draft |
+| **Author** | izqzmyli (rajan.bor@boringcode.pl) |
+| **Co-Author** | Claude Opus 4.8 |
+| **Created** | 2026-06-05 |
+| **Related** | [#2598](https://github.com/open-mercato/open-mercato/issues/2598), [#2333](https://github.com/open-mercato/open-mercato/issues/2333), [#2596](https://github.com/open-mercato/open-mercato/issues/2596), [PR #2549](https://github.com/open-mercato/open-mercato/pull/2549), [SPEC-018 Atomic Phased Flush](./SPEC-018-2026-02-05-safe-entity-flush.md), [BACKWARD_COMPATIBILITY.md](../../BACKWARD_COMPATIBILITY.md), [packages/shared/AGENTS.md](../../packages/shared/AGENTS.md), [packages/core/AGENTS.md](../../packages/core/AGENTS.md) |
+
+## TLDR
+**Key Points:**
+- Today command authors compose three independent helpers in a brittle, easy-to-miss order: fork `EntityManager` → `withAtomicFlush(...)` → `setCustomFieldsIfAny(...)` → `emitCrudSideEffects(...)`.
+- Add `runCrudCommandWrite(...)` — a single BC-compatible helper in `packages/shared/src/lib/commands/` that owns the EM fork, the atomic-flush boundary, the custom-field write, and the side-effect queue, in the only correct sequence.
+- Old helpers (`withAtomicFlush`, `setCustomFieldsIfAny`, `emitCrudSideEffects`) remain exported unchanged. The new helper composes them; it does not replace them.
+- Migrate exactly one representative path (`customers.deals.update`) in the same change to prove the helper on a real command. No repo-wide rewrite.
+
+**Scope:**
+- New file `packages/shared/src/lib/commands/runCrudCommandWrite.ts` exporting `runCrudCommandWrite` and its option types.
+- Re-export from `packages/shared/src/lib/commands/index.ts`.
+- Migrate the `execute` path of `updateDealCommand` in `packages/core/src/modules/customers/commands/deals.ts` as the working example.
+- Unit tests in `packages/shared/src/lib/commands/__tests__/runCrudCommandWrite.test.ts` covering the four acceptance criteria from #2598.
+- Doc updates in `packages/shared/AGENTS.md` and `packages/core/src/modules/customers/AGENTS.md`.
+
+**Concerns:**
+- Side-effect queueing MUST happen strictly after the DB write phases commit AND the custom-field write resolves; if either earlier step throws, no `markOrmEntityChange` may be enqueued.
+- Entities that are created inside a phase (e.g. `createDeal`) are not in scope at call time — the helper must accept a lazy resolver for the side-effect target so the caller can return a closure-captured entity.
+- The helper MUST stay framework-side only: no domain types, no module-specific imports. It belongs to `@open-mercato/shared`.
+
+## Overview
+`packages/shared/src/lib/commands/` already exposes three independent primitives that, when composed in the wrong order or against the wrong `EntityManager` / `DataEngine`, lead to subtle data and observability bugs:
+
+- `withAtomicFlush(em, phases, { transaction })` — phased scalar/relation mutations with one terminal flush, optionally wrapped in a transaction (SPEC-018).
+- `setCustomFieldsIfAny({ dataEngine, entityId, recordId, tenantId, organizationId, values, notify })` — durable EAV write through `DataEngine.setCustomFields`.
+- `emitCrudSideEffects({ dataEngine, action, entity, identifiers, events, indexer })` — queues a `markOrmEntityChange(...)` so the CommandBus flushes the index/event side-effects after the command completes.
+
+Today every command repeats the boilerplate that wires these together. The review on PR #2549 surfaced that this composition is *too* easy to get subtly wrong:
+
+- custom fields can be written on a `DataEngine` whose underlying `EntityManager` differs from the one the phases ran on,
+- side effects can be queued before all write phases are truly complete,
+- future command authors may not understand when to fork, flush, or join a transaction,
+- the relationship between custom fields and `withAtomicFlush` is not visible at the call site.
+
+This spec introduces a single high-level helper that makes the correct sequence the only ergonomic option, without removing the underlying primitives.
+
+## Problem Statement
+1. **Composition is convention, not contract.** Every command must remember the (1) fork, (2) flush, (3) custom fields, (4) side effects ordering. Nothing in the type system enforces it.
+2. **Failure isolation is weak.** If a phase throws inside `withAtomicFlush`, the transaction rolls back — but if `setCustomFieldsIfAny` throws between the flush and the side-effect emit, the entity is already persisted *and* the index/event queue still fires from the next CommandBus tick because authors sometimes shuffle the order.
+3. **`DataEngine` / `EntityManager` divergence.** Authors occasionally pass a stale `dataEngine` resolved before the fork, or fork a second EM in helper code, breaking the intent of "one consistent persistence boundary per command".
+4. **High learning curve.** New contributors must read three module-specific reference files (`customers/commands/people.ts`, `deals.ts`, `companies.ts`) to learn the pattern.
+
+## Proposed Solution
+Add a single helper in `@open-mercato/shared/lib/commands/runCrudCommandWrite`:
+
+```ts
+import { runCrudCommandWrite } from '@open-mercato/shared/lib/commands/runCrudCommandWrite'
+
+let deal!: CustomerDeal
+
+await runCrudCommandWrite({
+  ctx,
+  entityId: 'customers:customer_deal',
+  action: 'updated',
+  scope: { tenantId: record.tenantId, organizationId: record.organizationId },
+  customFields: custom,
+  events: dealCrudEvents,
+  indexer: dealCrudIndexer,
+  phases: [
+    async ({ em }) => {
+      // scalar / relation mutations, calls to syncDealPeople(em, ...), etc.
+    },
+  ],
+  sideEffect: () => ({
+    entity: record,
+    identifiers: { id: record.id, tenantId: record.tenantId, organizationId: record.organizationId },
+  }),
+})
+```
+
+The helper owns, in order:
+
+1. `EntityManager` selection — either uses the `em` the caller already forked, or forks a fresh one from `ctx.container.resolve('em')`.
+2. `withAtomicFlush(em, phases, { transaction: true })` — phases run inside one transaction, with one terminal `em.flush()`.
+3. `setCustomFieldsIfAny({ dataEngine, ... })` — runs ONLY after the phase flush has resolved successfully, on the same `DataEngine` instance resolved from `ctx.container`.
+4. `emitCrudSideEffects({ dataEngine, action, entity, identifiers, events, indexer, syncOrigin })` — runs ONLY after the custom-field write resolves. Uses the entity returned by `sideEffect()` so callers can pass a closure-captured entity created inside a phase.
+
+If any step throws, none of the later steps run. The transaction rollback already covers the phase failure case; for the custom-field failure case the side-effect emit is simply skipped (which is what we want — the index event would otherwise advertise a half-written record).
+
+### Why `sideEffect` is a callback, not a value
+`createDeal` creates the entity inside the first phase; at call time the entity reference does not yet exist. A callback evaluated *after* `withAtomicFlush` resolves lets callers return the closure-captured entity. For `update` paths the callback simply returns the entity loaded before the phases, but the callback shape is uniform.
+
+### Why custom fields stay on `DataEngine`, not on the forked EM
+`DataEngine.setCustomFields` already encapsulates the EAV write, validation, encryption, and event emission. The helper resolves the `DataEngine` from `ctx.container` once, after the phases commit, so caller and helper observe the same engine. There is no reason to push EAV writes through the forked phase EM — they go through the EAV table on the DataEngine's own EM, and the framework already guarantees that boundary is correct.
+
+### Why we do not merge custom-field writes into the phase transaction
+Custom fields are stored in their own EAV table via `DataEngine.setCustomFields`, which encapsulates validation, HTML sanitization, encryption, and (optionally) event emission. Pulling that path into the phase transaction would couple every command to internal DataEngine details and break BC for callers that pass custom fields without phases. Running it strictly after the phase transaction keeps the helper a thin sequencer.
+
+## Architecture
+
+```
++----------------------------+      +---------------------------------+
+|  runCrudCommandWrite       |      | Existing primitives (unchanged) |
++----------------------------+      +---------------------------------+
+| 1. Fork EM                 |--->  | ctx.container.resolve('em').fork|
+| 2. Run phases + atomic     |--->  | withAtomicFlush(em, phases,     |
+|    flush in transaction    |      |   { transaction: true })        |
+| 3. Resolve DataEngine      |--->  | ctx.container.resolve('dataEngine')
+| 4. Custom-field write      |--->  | setCustomFieldsIfAny(...)       |
+| 5. Side-effect queue       |--->  | emitCrudSideEffects(...)        |
++----------------------------+      +---------------------------------+
+```
+
+Strict await ordering between steps 2, 4, and 5 enforces the failure contract: a thrown error short-circuits all later steps.
+
+## Data Models
+No data-model changes. The helper is pure orchestration.
+
+## API Contracts
+No HTTP/API contract changes. This is a framework-side helper consumed only by command implementations.
+
+### TypeScript shape
+
+```ts
+// packages/shared/src/lib/commands/runCrudCommandWrite.ts
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
+import type {
+  CrudEventAction,
+  CrudEventsConfig,
+  CrudIndexerConfig,
+  CrudEntityIdentifiers,
+} from '@open-mercato/shared/lib/crud/types'
+
+export type CrudCommandWritePhase = (args: { em: EntityManager }) => void | Promise<void>
+
+export type CrudCommandWriteSideEffectTarget<TEntity> = {
+  entity: TEntity
+  identifiers: CrudEntityIdentifiers
+}
+
+export type CrudCommandWriteScope = {
+  tenantId: string | null
+  organizationId: string | null
+}
+
+export type RunCrudCommandWriteOptions<TEntity> = {
+  ctx: CommandRuntimeContext
+  entityId: string
+  action: CrudEventAction
+  scope: CrudCommandWriteScope
+  phases: CrudCommandWritePhase[]
+  customFields?: Record<string, unknown>
+  notifyCustomFields?: boolean
+  events?: CrudEventsConfig<TEntity>
+  indexer?: CrudIndexerConfig<TEntity>
+  syncOrigin?: string | null
+  sideEffect: () => CrudCommandWriteSideEffectTarget<TEntity>
+  em?: EntityManager
+  transaction?: boolean
+  dataEngine?: DataEngine
+}
+
+export type RunCrudCommandWriteResult = { em: EntityManager }
+
+export async function runCrudCommandWrite<TEntity>(
+  opts: RunCrudCommandWriteOptions<TEntity>,
+): Promise<RunCrudCommandWriteResult>
+```
+
+## UI/UX
+N/A — framework-side.
+
+## Configuration
+No env vars, no feature flags.
+
+## Alternatives Considered
+1. **Replace the three primitives with the helper.** Rejected — violates the BC contract for third-party modules already calling `withAtomicFlush` / `setCustomFieldsIfAny` / `emitCrudSideEffects` directly.
+2. **Make `phases` accept a single async function instead of an array.** Rejected — the array shape already exists in `withAtomicFlush`; preserving it keeps the mental model uniform.
+3. **Auto-detect entity identifiers from the entity object.** Rejected — entities differ in field naming (`id` vs `recordId`, scoping conventions). An explicit callback is cheaper than per-entity reflection logic.
+4. **Push side-effect queueing inside `withAtomicFlush`.** Rejected — SPEC-018 explicitly says side effects MUST fire after commit. The helper preserves that invariant.
+5. **A class with builder methods (`.phase(...).customFields(...).emit(...)`).** Rejected — three-line object literal is clearer and matches the rest of the command codebase style.
+
+## Implementation Approach
+
+### Phase 1 — Helper + tests (single commit)
+1. Add `packages/shared/src/lib/commands/runCrudCommandWrite.ts` implementing the shape above.
+2. Re-export `runCrudCommandWrite` and its public types from `packages/shared/src/lib/commands/index.ts`.
+3. Add `packages/shared/src/lib/commands/__tests__/runCrudCommandWrite.test.ts` covering:
+   - **AC1**: phases run on the helper-forked EM (or the caller-supplied EM if passed), and `setCustomFieldsIfAny` is called with the `DataEngine` resolved from `ctx.container` exactly once.
+   - **AC2**: if a phase throws, `setCustomFieldsIfAny` is never called and `markOrmEntityChange` is never called; the transaction is rolled back.
+   - **AC3**: if `setCustomFieldsIfAny` throws, `markOrmEntityChange` is never called.
+   - **AC4**: on the happy path, `markOrmEntityChange` is called exactly once with the `entity`, `identifiers`, `events`, `indexer`, `action`, `syncOrigin` forwarded verbatim.
+   - Plus: when `customFields` is undefined or empty, `setCustomFieldsIfAny` is not invoked but the emit still happens.
+
+### Phase 2 — Representative migration (single commit)
+1. Replace the `await withAtomicFlush(...)` + `setCustomFieldsIfAny(...)` + `emitCrudSideEffects(...)` triple in `updateDealCommand.execute` (`packages/core/src/modules/customers/commands/deals.ts`) with a single `runCrudCommandWrite({ ... })` call.
+2. Keep the closure event emit (`customers.deal.won` / `customers.deal.lost`) AFTER `runCrudCommandWrite` — that is a domain event distinct from the CRUD side-effect queue.
+3. Leave every other command path (`createDealCommand`, `undo`, `people.ts`, `companies.ts`, etc.) untouched to demonstrate BC.
+
+### Phase 3 — Docs (single commit)
+1. Add a `runCrudCommandWrite` row to `packages/shared/AGENTS.md` under the `commands/` library directory.
+2. Add a note to `packages/core/AGENTS.md` → "Entity Update Safety" section pointing to the helper as the default for new commands that touch entity + custom fields + side effects.
+3. Add a row to `packages/core/src/modules/customers/AGENTS.md` "Undoable Commands Pattern" referencing `updateDealCommand` as the canonical migration example.
+4. Add the spec to `.ai/specs/README.md` Pending table.
+
+### Phase 4 — Validation (no commit; PR description)
+1. `yarn workspace @open-mercato/shared test`
+2. `yarn workspace @open-mercato/core test`
+3. `yarn typecheck` (or scoped equivalent)
+
+## Migration Path
+- **Existing call sites**: no migration required. The triple `withAtomicFlush` + `setCustomFieldsIfAny` + `emitCrudSideEffects` continues to work and is the documented fallback for cases the helper doesn't fit (e.g., commands with multiple separate transactions per phase set, like `createDealCommand`).
+- **New call sites**: prefer `runCrudCommandWrite` for any command that writes an entity + custom fields + side effects in one logical operation.
+- **Opportunistic migration**: subsequent PRs may migrate one command per PR; no repo-wide change in this issue.
+
+## Backward Compatibility
+| Surface | Classification | Impact |
+|---------|----------------|--------|
+| `withAtomicFlush` export | STABLE | Unchanged |
+| `setCustomFieldsIfAny` export | STABLE | Unchanged |
+| `emitCrudSideEffects` export | STABLE | Unchanged |
+| `runCrudCommandWrite` export | ADDITIVE | New helper, opt-in |
+| `RunCrudCommandWriteOptions` type | ADDITIVE | New public type |
+| `CrudCommandWritePhase` type | ADDITIVE | New public type |
+| `customers.deals.update` semantics | UNCHANGED | Helper composes the same primitives in the same order |
+
+No deprecations. No symbol renames. No import-path moves.
+
+## Success Metrics
+- All four acceptance criteria from #2598 covered by passing unit tests in `runCrudCommandWrite.test.ts`.
+- `updateDealCommand` ships migrated; its existing command tests continue to pass without modification.
+- `yarn workspace @open-mercato/shared test`, `yarn workspace @open-mercato/core test`, and `yarn typecheck` all green.
+- No changes to API responses or event payloads observed in integration tests for the customers module.
+
+## Open Questions
+- Should we expose a `runCrudCommandUndo` companion helper for the undo path (which also calls `emitCrudUndoSideEffects` + sometimes resets custom fields)? Out of scope for this issue; track separately if needed.
+- Should the helper accept multiple atomic-flush "groups" so commands like `createDealCommand` (two separate transactions) can migrate cleanly? Out of scope; opportunistic follow-up.
+
+## Changelog
+
+### 2026-06-05
+- Initial draft.

--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -95,6 +95,7 @@ Specs awaiting implementation or partially complete. Focus here for actionable w
 | [API Key Error](2026-04-16-actionable-missing-api-key-error.md) | 2026-04-16 | Actionable Missing API Key Error | Include expected env var names in missing AI provider API key error (#1433) |
 | [Harness Validation Gate](2026-05-28-harness-validation-gate.md) | 2026-05-28 | Harness Validation Gate + Module Scaffold Template Fixes | Correct stale API patterns in module-scaffold skill template; add a SKILL-level post-scaffold validation gate (yarn generate → structural cache purge → ACL sync → typecheck → /login check) in `module-scaffold/SKILL.md` §12 (#2209) |
 | [Dictionary Entry Sort Mode](2026-06-02-dictionary-entry-sort-mode.md) | 2026-06-02 | Dictionary Entry Sort Mode | Configurable server-side dictionary entry ordering for generic and customer dictionaries |
+| [runCrudCommandWrite](2026-06-05-run-crud-command-write-helper.md) | 2026-06-05 | runCrudCommandWrite Helper | Unified command-write helper composing fork → atomic flush → custom fields → side-effects in the only correct order (#2598) |
 
 ### Implemented Specifications
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -552,6 +552,37 @@ await withAtomicFlush(em, [
 await emitCrudSideEffects({ ... })
 ```
 
+### Preferred: `runCrudCommandWrite` for entity + custom fields + side effects
+
+For commands that write an entity, optionally write custom fields, and emit CRUD/index side effects in one logical operation, prefer `runCrudCommandWrite` over composing `withAtomicFlush` + `setCustomFieldsIfAny` + `emitCrudSideEffects` by hand. The helper owns the EM fork, the atomic flush boundary, the custom-field write, and the side-effect queue in the only correct order, and fails closed if any earlier step throws.
+
+```typescript
+import { runCrudCommandWrite } from '@open-mercato/shared/lib/commands/runCrudCommandWrite'
+
+await runCrudCommandWrite({
+  ctx,
+  entityId: 'my_module:my_entity',
+  action: 'updated',
+  scope: { tenantId: record.tenantId, organizationId: record.organizationId },
+  customFields: custom,
+  events: myCrudEvents,
+  indexer: myCrudIndexer,
+  sideEffect: () => ({
+    entity: record,
+    identifiers: { id: record.id, tenantId: record.tenantId, organizationId: record.organizationId },
+  }),
+  phases: [
+    () => {
+      record.name = parsed.name
+      record.status = parsed.status
+    },
+    () => syncEntityTags(em, record, parsed.tags),
+  ],
+})
+```
+
+Reference migration: `customers.deals.update` in `packages/core/src/modules/customers/commands/deals.ts`. Keep `withAtomicFlush` for cases the helper doesn't fit (multiple separate transactions per command, etc.).
+
 ## Profiling
 
 - Enable with `OM_PROFILE` env (comma-separated filters: `*`, `all`, `customers.*`, etc.)

--- a/packages/core/src/modules/customers/AGENTS.md
+++ b/packages/core/src/modules/customers/AGENTS.md
@@ -87,6 +87,7 @@ Commands (`commands/people.ts`) demonstrate:
 3. Restore via `buildCustomFieldResetMap(before.custom, after.custom)` in undo
 4. Side effects with `emitCrudSideEffects` and `emitCrudUndoSideEffects`
 5. Include `indexer: { entityType, cacheAliases }` in both directions
+6. **Prefer `runCrudCommandWrite` for new commands** that combine entity writes + custom fields + side effects in one logical step. Reference: the migrated `updateDealCommand.execute` in `commands/deals.ts`. See `packages/core/AGENTS.md` → Entity Update Safety for the contract and `packages/shared/AGENTS.md` → `commands/runCrudCommandWrite` for the import.
 
 ## Transaction Safety
 

--- a/packages/core/src/modules/customers/commands/deals.ts
+++ b/packages/core/src/modules/customers/commands/deals.ts
@@ -9,6 +9,7 @@ import {
   normalizeAuthorUserId,
 } from '@open-mercato/shared/lib/commands/helpers'
 import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
+import { runCrudCommandWrite } from '@open-mercato/shared/lib/commands/runCrudCommandWrite'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import {
@@ -569,120 +570,114 @@ const updateDealCommand: CommandHandler<DealUpdateInput, { dealId: string }> = {
     let nextPipelineStageLabel: string | null = null
     let resolvedCurrentPipelineStageLabel: string | null = null
 
-    await withAtomicFlush(em, [
-      async () => {
-        const pipelineAssignmentChanged =
-          parsed.pipelineId !== undefined || parsed.pipelineStageId !== undefined
-        const requestedPipelineStageId =
-          parsed.pipelineStageId !== undefined
-            ? parsed.pipelineStageId ?? null
-            : record.pipelineStageId ?? null
-        const requestedPipelineId =
-          parsed.pipelineId !== undefined ? parsed.pipelineId ?? null : record.pipelineId ?? null
-
-        nextStageSnapshot = requestedPipelineStageId && (pipelineAssignmentChanged || !record.pipelineStage)
-          ? await loadPipelineStageSnapshot(em, requestedPipelineStageId, record.tenantId, record.organizationId)
-          : null
-        if (pipelineAssignmentChanged) {
-          nextPipelineAssignment = resolvePipelineAssignment({
-            pipelineId: requestedPipelineId,
-            pipelineStageId: requestedPipelineStageId,
-            stageSnapshot: nextStageSnapshot,
-          })
-        }
-        nextPipelineStageLabel = nextStageSnapshot
-          ? (await ensureDictionaryEntry(em, {
-            tenantId: record.tenantId,
-            organizationId: record.organizationId,
-            kind: 'pipeline_stage',
-            value: nextStageSnapshot.label,
-          }))?.value ?? nextStageSnapshot.label
-          : null
-        resolvedCurrentPipelineStageLabel =
-          !nextStageSnapshot && record.pipelineStageId && (parsed.pipelineStageId !== undefined || !record.pipelineStage)
-            ? await resolvePipelineStageValue(em, record.pipelineStageId, record.tenantId, record.organizationId)
-            : null
-      },
-      () => {
-        if (parsed.title !== undefined) record.title = parsed.title
-        if (parsed.description !== undefined) record.description = parsed.description ?? null
-        if (parsed.status !== undefined) record.status = parsed.status ?? record.status
-        if (parsed.pipelineStage !== undefined) record.pipelineStage = parsed.pipelineStage ?? null
-        if (parsed.pipelineId !== undefined || (parsed.pipelineStageId !== undefined && nextStageSnapshot)) {
-          record.pipelineId = nextPipelineAssignment.pipelineId
-        }
-        if (parsed.pipelineStageId !== undefined) record.pipelineStageId = nextPipelineAssignment.pipelineStageId
-
-        if (nextPipelineStageLabel && (parsed.pipelineStageId !== undefined || !record.pipelineStage)) {
-          record.pipelineStage = nextPipelineStageLabel
-        } else if (resolvedCurrentPipelineStageLabel && (parsed.pipelineStageId !== undefined || !record.pipelineStage)) {
-          record.pipelineStage = resolvedCurrentPipelineStageLabel
-        }
-
-        if (parsed.valueAmount !== undefined) record.valueAmount = toNumericString(parsed.valueAmount)
-        if (parsed.valueCurrency !== undefined) record.valueCurrency = parsed.valueCurrency ?? null
-        if (parsed.probability !== undefined) record.probability = parsed.probability ?? null
-        if (parsed.expectedCloseAt !== undefined) record.expectedCloseAt = parsed.expectedCloseAt ?? null
-        if (parsed.ownerUserId !== undefined) record.ownerUserId = parsed.ownerUserId ?? null
-        if (parsed.source !== undefined) record.source = parsed.source ?? null
-        if (parsed.closureOutcome !== undefined) record.closureOutcome = parsed.closureOutcome ?? null
-        if (parsed.lossReasonId !== undefined) record.lossReasonId = parsed.lossReasonId ?? null
-        if (parsed.lossNotes !== undefined) record.lossNotes = parsed.lossNotes ?? null
-      },
-      async () => {
-        // CRITICAL: persist the scalar mutations above before any further `em.findOne` / sync
-        // helpers run inside this transaction. MikroORM v7's identity-map silently discards
-        // pending scalar changes on `record` if a query (such as the stage-transition lookup
-        // inside `upsertDealStageTransition`, or the linked-entity finds inside
-        // `syncDealPeople` / `syncDealCompanies`) executes on the same `EntityManager`
-        // before we explicitly flush. Without this flush, the entire kanban drag-and-drop
-        // returns 200 OK but never actually updates `customer_deals` rows — the card
-        // snaps back to its source lane on the next refetch (see SPEC-018).
-        await em.flush()
-      },
-      async () => {
-        const snapshot = nextStageSnapshot
-        if (!snapshot) return
-        const shouldRecord =
-          parsed.pipelineStageId !== undefined &&
-          parsed.pipelineStageId !== null &&
-          parsed.pipelineStageId !== previousPipelineStageId
-        if (!shouldRecord) return
-        await upsertDealStageTransition(em, {
-          deal: record,
-          pipelineId: snapshot.pipelineId,
-          stageId: snapshot.id,
-          stageLabel: nextPipelineStageLabel ?? snapshot.label,
-          stageOrder: snapshot.order,
-          transitionedByUserId: normalizedTransitionAuthorUserId,
-        })
-      },
-      () => syncDealPeople(em, record, parsed.personIds),
-      () => syncDealCompanies(em, record, parsed.companyIds),
-    ], { transaction: true })
-
-    const de = (ctx.container.resolve('dataEngine') as DataEngine)
-    await setCustomFieldsIfAny({
-      dataEngine: de,
+    await runCrudCommandWrite({
+      ctx,
+      em,
       entityId: DEAL_ENTITY_ID,
-      recordId: record.id,
-      organizationId: record.organizationId,
-      tenantId: record.tenantId,
-      values: custom,
-      notify: false,
-    })
-
-    await emitCrudSideEffects({
-      dataEngine: de,
       action: 'updated',
-      entity: record,
-      identifiers: {
-        id: record.id,
-        organizationId: record.organizationId,
-        tenantId: record.tenantId,
-      },
-      indexer: dealCrudIndexer,
+      scope: { tenantId: record.tenantId, organizationId: record.organizationId },
+      customFields: custom,
       events: dealCrudEvents,
+      indexer: dealCrudIndexer,
+      sideEffect: () => ({
+        entity: record,
+        identifiers: {
+          id: record.id,
+          organizationId: record.organizationId,
+          tenantId: record.tenantId,
+        },
+      }),
+      phases: [
+        async () => {
+          const pipelineAssignmentChanged =
+            parsed.pipelineId !== undefined || parsed.pipelineStageId !== undefined
+          const requestedPipelineStageId =
+            parsed.pipelineStageId !== undefined
+              ? parsed.pipelineStageId ?? null
+              : record.pipelineStageId ?? null
+          const requestedPipelineId =
+            parsed.pipelineId !== undefined ? parsed.pipelineId ?? null : record.pipelineId ?? null
+
+          nextStageSnapshot = requestedPipelineStageId && (pipelineAssignmentChanged || !record.pipelineStage)
+            ? await loadPipelineStageSnapshot(em, requestedPipelineStageId, record.tenantId, record.organizationId)
+            : null
+          if (pipelineAssignmentChanged) {
+            nextPipelineAssignment = resolvePipelineAssignment({
+              pipelineId: requestedPipelineId,
+              pipelineStageId: requestedPipelineStageId,
+              stageSnapshot: nextStageSnapshot,
+            })
+          }
+          nextPipelineStageLabel = nextStageSnapshot
+            ? (await ensureDictionaryEntry(em, {
+              tenantId: record.tenantId,
+              organizationId: record.organizationId,
+              kind: 'pipeline_stage',
+              value: nextStageSnapshot.label,
+            }))?.value ?? nextStageSnapshot.label
+            : null
+          resolvedCurrentPipelineStageLabel =
+            !nextStageSnapshot && record.pipelineStageId && (parsed.pipelineStageId !== undefined || !record.pipelineStage)
+              ? await resolvePipelineStageValue(em, record.pipelineStageId, record.tenantId, record.organizationId)
+              : null
+        },
+        () => {
+          if (parsed.title !== undefined) record.title = parsed.title
+          if (parsed.description !== undefined) record.description = parsed.description ?? null
+          if (parsed.status !== undefined) record.status = parsed.status ?? record.status
+          if (parsed.pipelineStage !== undefined) record.pipelineStage = parsed.pipelineStage ?? null
+          if (parsed.pipelineId !== undefined || (parsed.pipelineStageId !== undefined && nextStageSnapshot)) {
+            record.pipelineId = nextPipelineAssignment.pipelineId
+          }
+          if (parsed.pipelineStageId !== undefined) record.pipelineStageId = nextPipelineAssignment.pipelineStageId
+
+          if (nextPipelineStageLabel && (parsed.pipelineStageId !== undefined || !record.pipelineStage)) {
+            record.pipelineStage = nextPipelineStageLabel
+          } else if (resolvedCurrentPipelineStageLabel && (parsed.pipelineStageId !== undefined || !record.pipelineStage)) {
+            record.pipelineStage = resolvedCurrentPipelineStageLabel
+          }
+
+          if (parsed.valueAmount !== undefined) record.valueAmount = toNumericString(parsed.valueAmount)
+          if (parsed.valueCurrency !== undefined) record.valueCurrency = parsed.valueCurrency ?? null
+          if (parsed.probability !== undefined) record.probability = parsed.probability ?? null
+          if (parsed.expectedCloseAt !== undefined) record.expectedCloseAt = parsed.expectedCloseAt ?? null
+          if (parsed.ownerUserId !== undefined) record.ownerUserId = parsed.ownerUserId ?? null
+          if (parsed.source !== undefined) record.source = parsed.source ?? null
+          if (parsed.closureOutcome !== undefined) record.closureOutcome = parsed.closureOutcome ?? null
+          if (parsed.lossReasonId !== undefined) record.lossReasonId = parsed.lossReasonId ?? null
+          if (parsed.lossNotes !== undefined) record.lossNotes = parsed.lossNotes ?? null
+        },
+        async () => {
+          // CRITICAL: persist the scalar mutations above before any further `em.findOne` / sync
+          // helpers run inside this transaction. MikroORM v7's identity-map silently discards
+          // pending scalar changes on `record` if a query (such as the stage-transition lookup
+          // inside `upsertDealStageTransition`, or the linked-entity finds inside
+          // `syncDealPeople` / `syncDealCompanies`) executes on the same `EntityManager`
+          // before we explicitly flush. Without this flush, the entire kanban drag-and-drop
+          // returns 200 OK but never actually updates `customer_deals` rows — the card
+          // snaps back to its source lane on the next refetch (see SPEC-018).
+          await em.flush()
+        },
+        async () => {
+          const snapshot = nextStageSnapshot
+          if (!snapshot) return
+          const shouldRecord =
+            parsed.pipelineStageId !== undefined &&
+            parsed.pipelineStageId !== null &&
+            parsed.pipelineStageId !== previousPipelineStageId
+          if (!shouldRecord) return
+          await upsertDealStageTransition(em, {
+            deal: record,
+            pipelineId: snapshot.pipelineId,
+            stageId: snapshot.id,
+            stageLabel: nextPipelineStageLabel ?? snapshot.label,
+            stageOrder: snapshot.order,
+            transitionedByUserId: normalizedTransitionAuthorUserId,
+          })
+        },
+        () => syncDealPeople(em, record, parsed.personIds),
+        () => syncDealCompanies(em, record, parsed.companyIds),
+      ],
     })
 
     // Emit a lifecycle event for deal won/lost status changes; the notifications

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -37,6 +37,7 @@ yarn workspace @open-mercato/shared build
 | `boolean/` | When parsing boolean strings from env/query params | `@open-mercato/shared/lib/boolean` |
 | `commands/` | When implementing undo/redo command pattern | `@open-mercato/shared/lib/commands` |
 | `commands/flush` | When a command mutates entities across multiple phases (scalar + relation syncs) — wraps phases in a single atomic flush | `@open-mercato/shared/lib/commands/flush` — `withAtomicFlush(em, phases, { transaction? })` |
+| `commands/runCrudCommandWrite` | When a command writes an entity + custom fields + CRUD/index side effects in one logical operation — composes fork → atomic flush → custom-field write → side-effect queue in the only correct order. **Prefer this over composing the primitives by hand for new commands.** | `@open-mercato/shared/lib/commands/runCrudCommandWrite` — `runCrudCommandWrite({ ctx, entityId, action, scope, phases, customFields?, events?, indexer?, sideEffect })` |
 | `crud/` | When building CRUD routes | `@open-mercato/shared/lib/crud` |
 | `custom-fields/` | When handling custom field payloads | `@open-mercato/shared/lib/custom-fields` |
 | `data/` | When you need `DataEngine` or `QueryEngine` types | `@open-mercato/shared/lib/data/engine` |

--- a/packages/shared/src/lib/commands/__tests__/runCrudCommandWrite.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/runCrudCommandWrite.test.ts
@@ -1,0 +1,390 @@
+import { runCrudCommandWrite } from '../runCrudCommandWrite'
+
+type FakeEntityManager = {
+  flush: jest.Mock<Promise<void>, []>
+  begin: jest.Mock<Promise<void>, []>
+  commit: jest.Mock<Promise<void>, []>
+  rollback: jest.Mock<Promise<void>, []>
+  fork: jest.Mock<FakeEntityManager, []>
+}
+
+type FakeDataEngine = {
+  setCustomFields: jest.Mock<Promise<void>, [unknown]>
+  markOrmEntityChange: jest.Mock<void, [unknown]>
+}
+
+function createFakeEm(): FakeEntityManager {
+  const em: FakeEntityManager = {
+    flush: jest.fn().mockResolvedValue(undefined),
+    begin: jest.fn().mockResolvedValue(undefined),
+    commit: jest.fn().mockResolvedValue(undefined),
+    rollback: jest.fn().mockResolvedValue(undefined),
+    fork: jest.fn(),
+  }
+  em.fork.mockReturnValue(em)
+  return em
+}
+
+function createFakeDataEngine(): FakeDataEngine {
+  return {
+    setCustomFields: jest.fn().mockResolvedValue(undefined),
+    markOrmEntityChange: jest.fn(),
+  }
+}
+
+function createCtx(em: FakeEntityManager, de: FakeDataEngine) {
+  return {
+    container: {
+      resolve: jest.fn((token: string) => {
+        if (token === 'em') return em
+        if (token === 'dataEngine') return de
+        throw new Error(`unexpected resolve(${token})`)
+      }),
+    },
+    auth: null,
+    organizationScope: null,
+    selectedOrganizationId: null,
+    organizationIds: null,
+  } as any
+}
+
+const baseScope = { tenantId: 't1', organizationId: 'o1' } as const
+const entity = { id: 'rec-1', tenantId: 't1', organizationId: 'o1' }
+const identifiers = { id: 'rec-1', tenantId: 't1', organizationId: 'o1' }
+const events = { module: 'customers', entity: 'deal', persistent: true } as const
+const indexer = { entityType: 'customers:customer_deal' } as const
+
+describe('runCrudCommandWrite', () => {
+  it('runs phases on the helper-forked EM, then writes custom fields, then queues exactly one CRUD side-effect (AC1 + AC4)', async () => {
+    const rootEm = createFakeEm()
+    const forked = createFakeEm()
+    rootEm.fork.mockReturnValue(forked)
+    const de = createFakeDataEngine()
+    const ctx = createCtx(rootEm, de)
+    const events_called: string[] = []
+    let observedPhaseEm: FakeEntityManager | null = null
+
+    await runCrudCommandWrite({
+      ctx,
+      entityId: 'customers:customer_deal',
+      action: 'updated',
+      scope: baseScope,
+      customFields: { priority: 3 },
+      events,
+      indexer,
+      sideEffect: () => ({ entity, identifiers }),
+      phases: [
+        async ({ em }) => {
+          events_called.push('phase')
+          observedPhaseEm = em as unknown as FakeEntityManager
+        },
+      ],
+    })
+
+    expect(rootEm.fork).toHaveBeenCalledTimes(1)
+    expect(observedPhaseEm).toBe(forked)
+    expect(forked.begin).toHaveBeenCalledTimes(1)
+    expect(forked.flush).toHaveBeenCalledTimes(1)
+    expect(forked.commit).toHaveBeenCalledTimes(1)
+    expect(forked.rollback).not.toHaveBeenCalled()
+
+    expect(de.setCustomFields).toHaveBeenCalledTimes(1)
+    expect(de.setCustomFields).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityId: 'customers:customer_deal',
+        recordId: 'rec-1',
+        tenantId: 't1',
+        organizationId: 'o1',
+        values: { priority: 3 },
+        notify: false,
+      }),
+    )
+
+    expect(de.markOrmEntityChange).toHaveBeenCalledTimes(1)
+    expect(de.markOrmEntityChange).toHaveBeenCalledWith({
+      action: 'updated',
+      entity,
+      identifiers,
+      syncOrigin: null,
+      events,
+      indexer,
+    })
+
+    // Order: setCustomFields must complete before markOrmEntityChange is queued
+    const customFieldsOrder = de.setCustomFields.mock.invocationCallOrder[0]
+    const markOrder = de.markOrmEntityChange.mock.invocationCallOrder[0]
+    expect(customFieldsOrder).toBeLessThan(markOrder)
+  })
+
+  it('skips setCustomFields when customFields is undefined but still queues the side-effect', async () => {
+    const em = createFakeEm()
+    const de = createFakeDataEngine()
+    const ctx = createCtx(em, de)
+
+    await runCrudCommandWrite({
+      ctx,
+      entityId: 'customers:customer_deal',
+      action: 'created',
+      scope: baseScope,
+      sideEffect: () => ({ entity, identifiers }),
+      phases: [() => {}],
+    })
+
+    expect(de.setCustomFields).not.toHaveBeenCalled()
+    expect(de.markOrmEntityChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips setCustomFields when customFields is an empty object', async () => {
+    const em = createFakeEm()
+    const de = createFakeDataEngine()
+    const ctx = createCtx(em, de)
+
+    await runCrudCommandWrite({
+      ctx,
+      entityId: 'customers:customer_deal',
+      action: 'updated',
+      scope: baseScope,
+      customFields: {},
+      sideEffect: () => ({ entity, identifiers }),
+      phases: [() => {}],
+    })
+
+    expect(de.setCustomFields).not.toHaveBeenCalled()
+    expect(de.markOrmEntityChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT emit side-effects when a phase throws (AC2)', async () => {
+    const em = createFakeEm()
+    const de = createFakeDataEngine()
+    const ctx = createCtx(em, de)
+    const failure = new Error('phase-failure')
+
+    await expect(
+      runCrudCommandWrite({
+        ctx,
+        entityId: 'customers:customer_deal',
+        action: 'updated',
+        scope: baseScope,
+        customFields: { priority: 3 },
+        events,
+        indexer,
+        sideEffect: () => ({ entity, identifiers }),
+        phases: [
+          () => {
+            throw failure
+          },
+        ],
+      }),
+    ).rejects.toBe(failure)
+
+    expect(em.begin).toHaveBeenCalledTimes(1)
+    expect(em.rollback).toHaveBeenCalledTimes(1)
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(em.commit).not.toHaveBeenCalled()
+    expect(de.setCustomFields).not.toHaveBeenCalled()
+    expect(de.markOrmEntityChange).not.toHaveBeenCalled()
+  })
+
+  it('does NOT emit side-effects when setCustomFields throws (AC3)', async () => {
+    const em = createFakeEm()
+    const de = createFakeDataEngine()
+    const ctx = createCtx(em, de)
+    const failure = new Error('custom-field-failure')
+    de.setCustomFields.mockRejectedValueOnce(failure)
+
+    await expect(
+      runCrudCommandWrite({
+        ctx,
+        entityId: 'customers:customer_deal',
+        action: 'updated',
+        scope: baseScope,
+        customFields: { priority: 3 },
+        events,
+        indexer,
+        sideEffect: () => ({ entity, identifiers }),
+        phases: [() => {}],
+      }),
+    ).rejects.toBe(failure)
+
+    expect(em.flush).toHaveBeenCalledTimes(1)
+    expect(em.commit).toHaveBeenCalledTimes(1)
+    expect(de.setCustomFields).toHaveBeenCalledTimes(1)
+    expect(de.markOrmEntityChange).not.toHaveBeenCalled()
+  })
+
+  it('uses a caller-supplied EM instead of forking a new one when opts.em is provided', async () => {
+    const rootEm = createFakeEm()
+    const callerEm = createFakeEm()
+    const de = createFakeDataEngine()
+    const ctx = createCtx(rootEm, de)
+    let observedPhaseEm: FakeEntityManager | null = null
+
+    await runCrudCommandWrite({
+      ctx,
+      entityId: 'customers:customer_deal',
+      action: 'updated',
+      scope: baseScope,
+      em: callerEm as any,
+      sideEffect: () => ({ entity, identifiers }),
+      phases: [
+        ({ em }) => {
+          observedPhaseEm = em as unknown as FakeEntityManager
+        },
+      ],
+    })
+
+    expect(rootEm.fork).not.toHaveBeenCalled()
+    expect(observedPhaseEm).toBe(callerEm)
+    expect(callerEm.begin).toHaveBeenCalledTimes(1)
+    expect(callerEm.flush).toHaveBeenCalledTimes(1)
+    expect(callerEm.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses a caller-supplied DataEngine instead of resolving from container', async () => {
+    const em = createFakeEm()
+    const containerDe = createFakeDataEngine()
+    const callerDe = createFakeDataEngine()
+    const ctx = createCtx(em, containerDe)
+
+    await runCrudCommandWrite({
+      ctx,
+      entityId: 'customers:customer_deal',
+      action: 'updated',
+      scope: baseScope,
+      customFields: { priority: 3 },
+      dataEngine: callerDe as any,
+      sideEffect: () => ({ entity, identifiers }),
+      phases: [() => {}],
+    })
+
+    expect(callerDe.setCustomFields).toHaveBeenCalledTimes(1)
+    expect(callerDe.markOrmEntityChange).toHaveBeenCalledTimes(1)
+    expect(containerDe.setCustomFields).not.toHaveBeenCalled()
+    expect(containerDe.markOrmEntityChange).not.toHaveBeenCalled()
+  })
+
+  it('evaluates sideEffect lazily after phases commit (supports closure-captured entities created inside a phase)', async () => {
+    const em = createFakeEm()
+    const de = createFakeDataEngine()
+    const ctx = createCtx(em, de)
+    let createdEntity: { id: string; tenantId: string; organizationId: string } | null = null
+    const sideEffectSpy = jest.fn(() => ({
+      entity: createdEntity!,
+      identifiers: { id: createdEntity!.id, tenantId: 't1', organizationId: 'o1' },
+    }))
+
+    await runCrudCommandWrite({
+      ctx,
+      entityId: 'customers:customer_deal',
+      action: 'created',
+      scope: baseScope,
+      sideEffect: sideEffectSpy,
+      phases: [
+        () => {
+          createdEntity = { id: 'fresh-id', tenantId: 't1', organizationId: 'o1' }
+        },
+      ],
+    })
+
+    expect(sideEffectSpy).toHaveBeenCalledTimes(1)
+    expect(de.markOrmEntityChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity: { id: 'fresh-id', tenantId: 't1', organizationId: 'o1' },
+        identifiers: { id: 'fresh-id', tenantId: 't1', organizationId: 'o1' },
+      }),
+    )
+  })
+
+  it('runs phases sequentially in a single transaction, flushing per phase (SPEC-018)', async () => {
+    const em = createFakeEm()
+    const de = createFakeDataEngine()
+    const ctx = createCtx(em, de)
+    const order: string[] = []
+
+    await runCrudCommandWrite({
+      ctx,
+      entityId: 'customers:customer_deal',
+      action: 'updated',
+      scope: baseScope,
+      sideEffect: () => ({ entity, identifiers }),
+      phases: [
+        async () => {
+          await Promise.resolve()
+          order.push('phase-1')
+        },
+        () => {
+          order.push('phase-2')
+        },
+      ],
+    })
+
+    expect(order).toEqual(['phase-1', 'phase-2'])
+    expect(em.begin).toHaveBeenCalledTimes(1)
+    // SPEC-018: withAtomicFlush flushes after each phase (one per phase) so a
+    // later phase's reads see the prior phase's mutations without UoW reset.
+    expect(em.flush).toHaveBeenCalledTimes(2)
+    expect(em.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('honours transaction:false (no begin/commit, single flush still happens)', async () => {
+    const em = createFakeEm()
+    const de = createFakeDataEngine()
+    const ctx = createCtx(em, de)
+
+    await runCrudCommandWrite({
+      ctx,
+      entityId: 'customers:customer_deal',
+      action: 'updated',
+      scope: baseScope,
+      transaction: false,
+      sideEffect: () => ({ entity, identifiers }),
+      phases: [() => {}],
+    })
+
+    expect(em.begin).not.toHaveBeenCalled()
+    expect(em.commit).not.toHaveBeenCalled()
+    expect(em.flush).toHaveBeenCalledTimes(1)
+    expect(de.markOrmEntityChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards syncOrigin to the side-effect emit', async () => {
+    const em = createFakeEm()
+    const de = createFakeDataEngine()
+    const ctx = createCtx(em, de)
+
+    await runCrudCommandWrite({
+      ctx,
+      entityId: 'customers:customer_deal',
+      action: 'updated',
+      scope: baseScope,
+      syncOrigin: 'sync_excel',
+      sideEffect: () => ({ entity, identifiers }),
+      phases: [() => {}],
+    })
+
+    expect(de.markOrmEntityChange).toHaveBeenCalledWith(
+      expect.objectContaining({ syncOrigin: 'sync_excel' }),
+    )
+  })
+
+  it('passes notifyCustomFields:true through to setCustomFields when requested', async () => {
+    const em = createFakeEm()
+    const de = createFakeDataEngine()
+    const ctx = createCtx(em, de)
+
+    await runCrudCommandWrite({
+      ctx,
+      entityId: 'customers:customer_deal',
+      action: 'updated',
+      scope: baseScope,
+      customFields: { priority: 3 },
+      notifyCustomFields: true,
+      sideEffect: () => ({ entity, identifiers }),
+      phases: [() => {}],
+    })
+
+    expect(de.setCustomFields).toHaveBeenCalledWith(
+      expect.objectContaining({ notify: true }),
+    )
+  })
+})

--- a/packages/shared/src/lib/commands/index.ts
+++ b/packages/shared/src/lib/commands/index.ts
@@ -4,3 +4,11 @@ export { CommandBus } from './command-bus'
 export * from './customFieldSnapshots'
 export * from './undo'
 export { CommandInterceptorError } from './errors'
+export {
+  runCrudCommandWrite,
+  type RunCrudCommandWriteOptions,
+  type RunCrudCommandWriteResult,
+  type CrudCommandWritePhase,
+  type CrudCommandWriteScope,
+  type CrudCommandWriteSideEffectTarget,
+} from './runCrudCommandWrite'

--- a/packages/shared/src/lib/commands/runCrudCommandWrite.ts
+++ b/packages/shared/src/lib/commands/runCrudCommandWrite.ts
@@ -1,0 +1,82 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { CommandRuntimeContext } from './types'
+import type { DataEngine } from '../data/engine'
+import type {
+  CrudEventAction,
+  CrudEventsConfig,
+  CrudIndexerConfig,
+  CrudEntityIdentifiers,
+} from '../crud/types'
+import { withAtomicFlush } from './flush'
+import { setCustomFieldsIfAny, emitCrudSideEffects } from './helpers'
+
+export type CrudCommandWritePhase = (args: { em: EntityManager }) => void | Promise<void>
+
+export type CrudCommandWriteSideEffectTarget<TEntity> = {
+  entity: TEntity
+  identifiers: CrudEntityIdentifiers
+}
+
+export type CrudCommandWriteScope = {
+  tenantId: string | null
+  organizationId: string | null
+}
+
+export type RunCrudCommandWriteOptions<TEntity> = {
+  ctx: CommandRuntimeContext
+  entityId: string
+  action: CrudEventAction
+  scope: CrudCommandWriteScope
+  phases: CrudCommandWritePhase[]
+  customFields?: Record<string, unknown>
+  notifyCustomFields?: boolean
+  events?: CrudEventsConfig<TEntity>
+  indexer?: CrudIndexerConfig<TEntity>
+  syncOrigin?: string | null
+  sideEffect: () => CrudCommandWriteSideEffectTarget<TEntity>
+  em?: EntityManager
+  transaction?: boolean
+  dataEngine?: DataEngine
+}
+
+export type RunCrudCommandWriteResult = { em: EntityManager }
+
+export async function runCrudCommandWrite<TEntity>(
+  opts: RunCrudCommandWriteOptions<TEntity>,
+): Promise<RunCrudCommandWriteResult> {
+  const em = opts.em ?? (opts.ctx.container.resolve('em') as EntityManager).fork()
+  const transaction = opts.transaction ?? true
+
+  await withAtomicFlush(
+    em,
+    opts.phases.map((phase) => () => phase({ em })),
+    { transaction },
+  )
+
+  const dataEngine = opts.dataEngine ?? (opts.ctx.container.resolve('dataEngine') as DataEngine)
+  const target = opts.sideEffect()
+
+  if (opts.customFields && Object.keys(opts.customFields).length > 0) {
+    await setCustomFieldsIfAny({
+      dataEngine,
+      entityId: opts.entityId,
+      recordId: target.identifiers.id,
+      tenantId: opts.scope.tenantId,
+      organizationId: opts.scope.organizationId,
+      values: opts.customFields,
+      notify: opts.notifyCustomFields ?? false,
+    })
+  }
+
+  await emitCrudSideEffects({
+    dataEngine,
+    action: opts.action,
+    entity: target.entity,
+    identifiers: target.identifiers,
+    syncOrigin: opts.syncOrigin ?? null,
+    events: opts.events,
+    indexer: opts.indexer,
+  })
+
+  return { em }
+}


### PR DESCRIPTION
## Summary

Make the safe path obvious for command authors: one framework helper now owns EM fork -> `withAtomicFlush(transaction:true)` -> `setCustomFieldsIfAny` -> `emitCrudSideEffects` in the only correct order, instead of every command re-composing the four primitives by hand.

Follow-up of PR #2549 review. Composition was convention, not contract — easy to misorder side-effects before custom-field writes, or to call a stale `DataEngine`/`EM`.

Strict await ordering enforces the failure contract: if any phase or the custom-field write throws, no CRUD/index side-effect is queued.

## Changes

* New `runCrudCommandWrite(...)` in `@open-mercato/shared/lib/commands/`, re-exported from the package barrel (additive — no breaking changes).
* `customers.deals.update.execute` migrated as the representative example; every other command path stays on the existing primitives to prove BC.
* 12 new unit tests in `packages/shared/src/lib/commands/__tests__/runCrudCommandWrite.test.ts` covering all four AC from #2598 plus edges (caller-supplied EM/DataEngine, lazy `sideEffect`, `transaction:false`, `syncOrigin` pass-through, empty/undefined `customFields`).
* `packages/shared/AGENTS.md`, `packages/core/AGENTS.md`, and `packages/core/src/modules/customers/AGENTS.md` updated to point future authors at the helper first.
* `withAtomicFlush`, `setCustomFieldsIfAny`, `emitCrudSideEffects` remain exported with identical signatures — the helper composes them, doesn't replace them.

## Specification

**Does a spec exist for this feature/module?**

* [ ] Yes
* [x] No (created a new spec)
* [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/2026-06-05-run-crud-command-write-helper.md`

## Testing

* `packages/shared/src/lib/commands/__tests__/runCrudCommandWrite.test.ts` — 12/12 pass (AC1–AC4 + edges)
* `packages/core/src/modules/customers/commands/__tests__/deals.stage-transitions.test.ts` — 3/3 unchanged, green after migration
* `packages/core/src/modules/customers/commands/__tests__/undo.custom-fields.test.ts` — 17/17 unchanged, green (undo/audit behavior preserved)
* All `packages/shared/src/lib/commands/__tests__` — 84/84 pass (no BC regressions)
* All `packages/core/src/modules/customers/commands/__tests__` — 55/55 pass
* `tsc --noEmit` clean for `packages/shared` and `packages/core`

## Checklist

* [x] This pull request targets `develop`.
* [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
* [x] I updated documentation, locales, or generators if the change requires it.
* [x] I added or adjusted tests that cover the change.
* [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
* [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

> Integration coverage rationale: this PR adds a pure framework-side orchestration helper with no API/route/UI surface changes. Existing integration tests for `customers.deals.update` exercise the migrated path end-to-end through the command bus; no new HTTP/UI flows are introduced.

### Design System Compliance

* [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
* [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
* [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
* [x] Loading state handled for async pages
* [x] `aria-label` on all icon-only buttons (`<IconButton>`)
* [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

> DS items are N/A — this PR has zero UI changes. Ticked as "compliant by absence".

## Linked issues

Closes #2598
Related umbrella: #2333
Related custom-field hardening: #2596
Follow-up of PR #2549 review
