### PR TITLE
feat: 2471 entities integration tests

### DIFF
--- a/packages/core/src/modules/entities/__integration__/TC-ENTITIES-001.spec.ts
+++ b/packages/core/src/modules/entities/__integration__/TC-ENTITIES-001.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createCustomEntity,
+  deleteCustomEntityIfExists,
+  expectUuid,
+  listCustomEntities,
+  uniqueEntityId,
+} from './helpers/entitiesApi';
+
+/**
+ * TC-ENTITIES-001: Create custom entity definition via API  [P0] (api)
+ * Source: issue #2471 (entities integration coverage).
+ *
+ * Covers the core CRUD happy path for entity-definition management:
+ *   - POST /api/entities/entities  → 200 { ok, item:{ id, entityId, label, description } }
+ *   - GET  /api/entities/entities  → the entity appears with source 'custom'
+ *
+ * Verified contract notes (differ from the issue's prose):
+ *   - The route is `/api/entities/entities` (not `/api/entities`).
+ *   - POST returns HTTP 200 (not 201). The UUID lives on the POST `item.id`;
+ *     the GET list items expose `{ entityId, source, label, description?, count }`
+ *     and do NOT echo `id`/`isActive`. Appearing in the default (isActive-only)
+ *     list is the observable proxy for "active".
+ */
+test.describe('TC-ENTITIES-001: Create custom entity definition via API', () => {
+  test('creates a custom entity and lists it as source=custom', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const entityId = uniqueEntityId('widget');
+    const label = 'TC-ENTITIES-001 Widget';
+    const description = 'Created by TC-ENTITIES-001';
+
+    try {
+      const createRes = await createCustomEntity(request, token, { entityId, label, description });
+      expect(createRes.status(), 'POST /api/entities/entities returns 200').toBe(200);
+      const created = await readJsonSafe<{ ok?: boolean; item?: { id?: string; entityId?: string; label?: string; description?: string } }>(createRes);
+      expect(created?.ok, 'create response ok=true').toBe(true);
+      expectUuid(created?.item?.id, 'created entity id');
+      expect(created?.item?.entityId, 'echoed entityId').toBe(entityId);
+      expect(created?.item?.label, 'echoed label').toBe(label);
+      expect(created?.item?.description, 'echoed description').toBe(description);
+
+      const listRes = await listCustomEntities(request, token);
+      expect(listRes.status(), 'GET /api/entities/entities returns 200').toBe(200);
+      const listBody = await readJsonSafe<{ items?: Array<{ entityId?: string; source?: string; label?: string }> }>(listRes);
+      const mine = (listBody?.items ?? []).find((it) => it.entityId === entityId);
+      expect(mine, 'created entity appears in the list').toBeTruthy();
+      expect(mine?.source, 'entity source is custom').toBe('custom');
+      expect(mine?.label, 'listed label matches').toBe(label);
+    } finally {
+      await deleteCustomEntityIfExists(request, token, entityId);
+    }
+  });
+});

--- a/packages/core/src/modules/entities/__integration__/TC-ENTITIES-002.spec.ts
+++ b/packages/core/src/modules/entities/__integration__/TC-ENTITIES-002.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  deleteCustomEntityIfExists,
+  listCustomEntities,
+  rawRequest,
+  uniqueEntityId,
+} from './helpers/entitiesApi';
+
+/**
+ * TC-ENTITIES-002: Unauthorized access to entity management is rejected  [P0] (api)
+ * Source: issue #2471.
+ *
+ * Entity-definition management requires the `entities.definitions.manage` feature.
+ *   - No Authorization header                → 401 { error: 'Unauthorized' }
+ *   - Authenticated employee (lacks feature) → 403 { error: 'Forbidden', requiredFeatures: [...] }
+ * The seeded `employee` role has NO `entities.*` features (only `admin` does), so it
+ * is the canonical "authenticated but unauthorized" actor. No entity is created.
+ */
+test.describe('TC-ENTITIES-002: Unauthorized access to entity management is rejected', () => {
+  test('returns 401 without auth and 403 for a feature-less user; creates nothing', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin');
+    const employeeToken = await getAuthToken(request, 'employee');
+    const entityId = uniqueEntityId('forbidden');
+    const body = { entityId, label: 'TC-ENTITIES-002 should never persist' };
+
+    try {
+      // POST without authentication → 401
+      const unauthPost = await rawRequest(request, 'POST', '/api/entities/entities', body);
+      expect(unauthPost.status(), 'POST without auth → 401').toBe(401);
+
+      // POST as employee (missing entities.definitions.manage) → 403 with requiredFeatures
+      const employeePost = await apiRequest(request, 'POST', '/api/entities/entities', { token: employeeToken, data: body });
+      expect(employeePost.status(), 'POST as employee → 403').toBe(403);
+      const forbiddenBody = await readJsonSafe<{ error?: string; requiredFeatures?: string[] }>(employeePost);
+      expect(forbiddenBody?.requiredFeatures ?? [], '403 body lists the required feature').toContain('entities.definitions.manage');
+
+      // DELETE without authentication → 401
+      const unauthDelete = await rawRequest(request, 'DELETE', '/api/entities/entities', { entityId });
+      expect(unauthDelete.status(), 'DELETE without auth → 401').toBe(401);
+
+      // DELETE as employee → 403
+      const employeeDelete = await apiRequest(request, 'DELETE', '/api/entities/entities', { token: employeeToken, data: { entityId } });
+      expect(employeeDelete.status(), 'DELETE as employee → 403').toBe(403);
+
+      // Nothing should have been created — admin must not see the probe entity.
+      const listRes = await listCustomEntities(request, adminToken);
+      const listBody = await readJsonSafe<{ items?: Array<{ entityId?: string }> }>(listRes);
+      const present = (listBody?.items ?? []).some((it) => it.entityId === entityId);
+      expect(present, 'rejected requests created no entity').toBe(false);
+    } finally {
+      // Defensive: if any call unexpectedly persisted, remove it.
+      await deleteCustomEntityIfExists(request, adminToken, entityId);
+    }
+  });
+});

--- a/packages/core/src/modules/entities/__integration__/TC-ENTITIES-003.spec.ts
+++ b/packages/core/src/modules/entities/__integration__/TC-ENTITIES-003.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createCustomEntity,
+  deleteCustomEntityIfExists,
+  listFieldDefinitions,
+  saveFieldDefinitions,
+  uniqueEntityId,
+} from './helpers/entitiesApi';
+
+type ManagedDefinition = {
+  id?: string;
+  key?: string;
+  kind?: string;
+  configJson?: { label?: string; priority?: number } | null;
+};
+
+/**
+ * TC-ENTITIES-003: Create custom field definitions for an entity  [P0] (api)
+ * Source: issue #2471.
+ *
+ *   - POST /api/entities/definitions.batch  → 200 { ok: true }
+ *   - GET  /api/entities/definitions.manage → scoped definitions for the entity
+ *
+ * Verified contract notes (differ from the issue's prose):
+ *   - The batch route is `/api/entities/definitions.batch` (dot, not `/definitions/batch`).
+ *   - The read-back route is `/api/entities/definitions.manage` and requires
+ *     `entities.definitions.manage` (not `.view`).
+ *   - Field `key` must be snake_case `^[a-z0-9_]+$`; the batch route stamps
+ *     `configJson.priority` from the definition's array index.
+ */
+test.describe('TC-ENTITIES-003: Create custom field definitions for an entity', () => {
+  test('saves text + integer field definitions and reads them back', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const entityId = uniqueEntityId('fielded');
+
+    try {
+      const createRes = await createCustomEntity(request, token, { entityId, label: 'TC-ENTITIES-003 Entity' });
+      expect(createRes.status(), 'entity create 200').toBe(200);
+
+      const batchRes = await saveFieldDefinitions(request, token, entityId, [
+        { key: 'name', kind: 'text', configJson: { label: 'Name' } },
+        { key: 'quantity', kind: 'integer', configJson: { label: 'Quantity' } },
+      ]);
+      expect(batchRes.status(), 'POST /api/entities/definitions.batch 200').toBe(200);
+      const batchBody = await readJsonSafe<{ ok?: boolean }>(batchRes);
+      expect(batchBody?.ok, 'batch response ok=true').toBe(true);
+
+      const manageRes = await listFieldDefinitions(request, token, entityId);
+      expect(manageRes.status(), 'GET /api/entities/definitions.manage 200').toBe(200);
+      const manageBody = await readJsonSafe<{ items?: ManagedDefinition[]; deletedKeys?: string[] }>(manageRes);
+      const items = manageBody?.items ?? [];
+
+      const nameDef = items.find((d) => d.key === 'name');
+      const quantityDef = items.find((d) => d.key === 'quantity');
+      expect(nameDef, 'name definition is returned').toBeTruthy();
+      expect(nameDef?.kind, 'name kind is text').toBe('text');
+      expect(nameDef?.configJson?.label, 'name label persisted').toBe('Name');
+      expect(typeof nameDef?.configJson?.priority, 'name priority stamped').toBe('number');
+
+      expect(quantityDef, 'quantity definition is returned').toBeTruthy();
+      expect(quantityDef?.kind, 'quantity kind is integer').toBe('integer');
+      expect(quantityDef?.configJson?.label, 'quantity label persisted').toBe('Quantity');
+    } finally {
+      await deleteCustomEntityIfExists(request, token, entityId);
+    }
+  });
+});

--- a/packages/core/src/modules/entities/__integration__/TC-ENTITIES-004.spec.ts
+++ b/packages/core/src/modules/entities/__integration__/TC-ENTITIES-004.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createCustomEntity,
+  createRecord,
+  deleteCustomEntityIfExists,
+  deleteRecordIfExists,
+  expectUuid,
+  listRecords,
+  saveFieldDefinitions,
+  uniqueEntityId,
+} from './helpers/entitiesApi';
+
+type RecordItem = { id?: string; name?: unknown; quantity?: unknown };
+
+/**
+ * TC-ENTITIES-004: Create a custom entity record with field values  [P0] (api)
+ * Source: issue #2471.
+ *
+ * End-to-end happy path: define an entity + fields, then create and read a record.
+ *   - POST /api/entities/records → 200 { ok: true, item: { entityId, recordId } }
+ *   - GET  /api/entities/records → record present with its field values
+ *
+ * Verified contract notes (differ from the issue's prose):
+ *   - The record payload is nested under `values` ({ entityId, values:{...} }),
+ *     NOT flat top-level fields, and the response is `item.recordId` (a UUID),
+ *     not `{ id, items: [...] }`.
+ *   - Field keys must be declared first; the generic records endpoint rejects
+ *     undeclared keys (see TC-ENTITIES-005), so definitions are created up front.
+ *   - List items expose bare field keys (the `cf_` prefix is stripped).
+ */
+test.describe('TC-ENTITIES-004: Create a custom entity record with field values', () => {
+  test('creates a record and reads its values back from the list', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const entityId = uniqueEntityId('record');
+    let recordId: string | null = null;
+
+    try {
+      expect((await createCustomEntity(request, token, { entityId, label: 'TC-ENTITIES-004 Entity' })).status()).toBe(200);
+      expect(
+        (await saveFieldDefinitions(request, token, entityId, [
+          { key: 'name', kind: 'text', configJson: { label: 'Name' } },
+          { key: 'quantity', kind: 'integer', configJson: { label: 'Quantity' } },
+        ])).status(),
+        'field definitions saved',
+      ).toBe(200);
+
+      const createRes = await createRecord(request, token, entityId, { name: 'Test Widget', quantity: 42 });
+      expect(createRes.status(), 'POST /api/entities/records 200').toBe(200);
+      const created = await readJsonSafe<{ ok?: boolean; item?: { entityId?: string; recordId?: string } }>(createRes);
+      expect(created?.ok, 'create response ok=true').toBe(true);
+      expect(created?.item?.entityId, 'echoed entityId').toBe(entityId);
+      recordId = expectUuid(created?.item?.recordId, 'created record id');
+
+      const listRes = await listRecords(request, token, entityId);
+      expect(listRes.status(), 'GET /api/entities/records 200').toBe(200);
+      const listBody = await readJsonSafe<{ items?: RecordItem[]; total?: number }>(listRes);
+      expect((listBody?.total ?? 0), 'list total includes the new record').toBeGreaterThanOrEqual(1);
+      const mine = (listBody?.items ?? []).find((it) => String(it.id) === recordId);
+      expect(mine, 'created record present in list').toBeTruthy();
+      expect(mine?.name, 'text value preserved').toBe('Test Widget');
+      expect(mine?.quantity, 'integer value preserved').toBe(42);
+    } finally {
+      await deleteRecordIfExists(request, token, entityId, recordId);
+      await deleteCustomEntityIfExists(request, token, entityId);
+    }
+  });
+});

--- a/packages/core/src/modules/entities/__integration__/TC-ENTITIES-005.spec.ts
+++ b/packages/core/src/modules/entities/__integration__/TC-ENTITIES-005.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createCustomEntity,
+  createRecord,
+  deleteCustomEntityIfExists,
+  listRecords,
+  saveFieldDefinitions,
+  uniqueEntityId,
+} from './helpers/entitiesApi';
+
+type ValidationFailure = { error?: string; fields?: Record<string, string> };
+
+/**
+ * TC-ENTITIES-005: Field-level validation rejects invalid record values  [P1] (api)
+ * Source: issue #2471.
+ *
+ * POST /api/entities/records validates submitted values against the entity's field
+ * definitions and returns 400 { error: 'Validation failed', fields: { cf_<key>: msg } }
+ * without persisting the record.
+ *
+ * Verified contract notes:
+ *   - Type checking is rule-driven: a `kind: 'integer'` field only rejects a
+ *     non-numeric value when its `configJson.validation` includes an `integer`
+ *     (or `date`) rule. The `fields` map is keyed with the `cf_` prefix regardless
+ *     of how the value was submitted.
+ *   - The endpoint always rejects UNDECLARED keys (mass-assignment guard) with the
+ *     `[internal] Unknown custom field` message — covered as a second case.
+ */
+test.describe('TC-ENTITIES-005: Field-level validation rejects invalid record values', () => {
+  test('rejects bad integer/date values and undeclared keys; persists nothing', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const entityId = uniqueEntityId('validated');
+
+    try {
+      expect((await createCustomEntity(request, token, { entityId, label: 'TC-ENTITIES-005 Entity' })).status()).toBe(200);
+      expect(
+        (await saveFieldDefinitions(request, token, entityId, [
+          { key: 'name', kind: 'text', configJson: { label: 'Name' } },
+          { key: 'age', kind: 'integer', configJson: { label: 'Age', validation: [{ rule: 'integer', message: '[internal] age must be an integer' }] } },
+          { key: 'birth_date', kind: 'date', configJson: { label: 'Birth date', validation: [{ rule: 'date', message: '[internal] birth_date must be a valid date' }] } },
+        ])).status(),
+        'field definitions saved',
+      ).toBe(200);
+
+      // Case A: declared fields with type rules reject the wrong value types.
+      const badTypes = await createRecord(request, token, entityId, {
+        name: 'x',
+        age: 'not_a_number',
+        birth_date: 'invalid-date',
+      });
+      expect(badTypes.status(), 'invalid integer/date → 400').toBe(400);
+      const badBody = await readJsonSafe<ValidationFailure>(badTypes);
+      expect(badBody?.error, 'error label').toBe('Validation failed');
+      expect(badBody?.fields?.cf_age, 'integer field error reported').toBeTruthy();
+      expect(badBody?.fields?.cf_birth_date, 'date field error reported').toBeTruthy();
+
+      // Case B: an undeclared key is rejected by the mass-assignment guard.
+      const undeclared = await createRecord(request, token, entityId, { ghost_field: 'injected' });
+      expect(undeclared.status(), 'undeclared key → 400').toBe(400);
+      const undeclaredBody = await readJsonSafe<ValidationFailure>(undeclared);
+      expect(undeclaredBody?.fields?.cf_ghost_field, 'undeclared key flagged').toBe('[internal] Unknown custom field');
+
+      // No record should have been persisted by either rejected request.
+      const listRes = await listRecords(request, token, entityId);
+      expect(listRes.status(), 'records list 200').toBe(200);
+      const listBody = await readJsonSafe<{ total?: number; items?: unknown[] }>(listRes);
+      expect(listBody?.total ?? 0, 'no record persisted from invalid submissions').toBe(0);
+    } finally {
+      await deleteCustomEntityIfExists(request, token, entityId);
+    }
+  });
+});

--- a/packages/core/src/modules/entities/__integration__/TC-ENTITIES-006.spec.ts
+++ b/packages/core/src/modules/entities/__integration__/TC-ENTITIES-006.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createCustomEntity,
+  createRecord,
+  deleteCustomEntityIfExists,
+  deleteRecordIfExists,
+  listCustomEntities,
+  listRecords,
+  saveFieldDefinitions,
+  uniqueEntityId,
+} from './helpers/entitiesApi';
+
+/**
+ * TC-ENTITIES-006: Soft-deleting a custom entity hides it from the list  [P1] (api)
+ * Source: issue #2471.
+ *
+ *   - DELETE /api/entities/entities → 200 { ok: true } (soft delete: isActive=false, deletedAt set)
+ *   - GET    /api/entities/entities → the entity no longer appears (default list filters isActive)
+ *
+ * Verified behavior note (corrects the issue's premise):
+ *   The issue expected records to disappear after deleting the entity definition.
+ *   In reality, records live in `custom_entities_storage` independently of the
+ *   `custom_entities` definition row, and the records endpoint detects the entity
+ *   from its storage rows — so the entity-definition soft delete is metadata-only
+ *   and its stored records REMAIN queryable. This spec asserts the true invariant:
+ *   the entity vanishes from the entity list while its records persist.
+ */
+test.describe('TC-ENTITIES-006: Soft-deleting a custom entity hides it from the list', () => {
+  test('removes the entity from the default list; stored records persist', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const entityId = uniqueEntityId('doomed');
+    let recordId: string | null = null;
+
+    try {
+      expect((await createCustomEntity(request, token, { entityId, label: 'TC-ENTITIES-006 Entity' })).status()).toBe(200);
+      expect(
+        (await saveFieldDefinitions(request, token, entityId, [{ key: 'name', kind: 'text', configJson: { label: 'Name' } }])).status(),
+        'field definition saved',
+      ).toBe(200);
+      const createRec = await createRecord(request, token, entityId, { name: 'Doomed record' });
+      expect(createRec.status(), 'record created').toBe(200);
+      recordId = (await readJsonSafe<{ item?: { recordId?: string } }>(createRec))?.item?.recordId ?? null;
+
+      // Precondition: entity is visible before deletion.
+      const beforeBody = await readJsonSafe<{ items?: Array<{ entityId?: string }> }>(await listCustomEntities(request, token));
+      expect((beforeBody?.items ?? []).some((it) => it.entityId === entityId), 'entity visible before delete').toBe(true);
+
+      // Soft delete the entity definition.
+      const delRes = await apiRequest(request, 'DELETE', '/api/entities/entities', { token, data: { entityId } });
+      expect(delRes.status(), 'DELETE /api/entities/entities 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(delRes))?.ok, 'delete ok=true').toBe(true);
+
+      // The entity must no longer appear in the default list.
+      const afterBody = await readJsonSafe<{ items?: Array<{ entityId?: string }> }>(await listCustomEntities(request, token));
+      expect((afterBody?.items ?? []).some((it) => it.entityId === entityId), 'entity hidden after soft delete').toBe(false);
+
+      // Stored records remain queryable (definition delete does not purge storage):
+      // the exact record survives AND its values still read back (cf_ mapping intact).
+      const recordsBody = await readJsonSafe<{ total?: number; items?: Array<{ id?: string; name?: unknown }> }>(
+        await listRecords(request, token, entityId),
+      );
+      expect(recordsBody?.total ?? 0, 'records persist after entity soft delete').toBeGreaterThanOrEqual(1);
+      const survivor = (recordsBody?.items ?? []).find((it) => String(it.id) === recordId);
+      expect(survivor, 'the created record survives the entity soft delete').toBeTruthy();
+      expect(survivor?.name, 'record field values still read back after soft delete').toBe('Doomed record');
+    } finally {
+      await deleteRecordIfExists(request, token, entityId, recordId);
+      await deleteCustomEntityIfExists(request, token, entityId);
+    }
+  });
+});

--- a/packages/core/src/modules/entities/__integration__/TC-ENTITIES-007.spec.ts
+++ b/packages/core/src/modules/entities/__integration__/TC-ENTITIES-007.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createOrganizationFixture,
+  createUserFixture,
+  deleteOrganizationIfExists,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+import {
+  createCustomEntity,
+  deleteCustomEntityIfExists,
+  listCustomEntities,
+  uniqueEntityId,
+} from './helpers/entitiesApi';
+
+/**
+ * TC-ENTITIES-007: Organization scoping isolates custom entities  [P1] (api)
+ * Source: issue #2471.
+ *
+ * Custom entity definitions are scoped to the creator's home organization
+ * (`GET /api/entities/entities` filters `organizationId IN (auth.orgId, null)`).
+ * Two users in different organizations of the same tenant must not see each
+ * other's org-scoped entities.
+ *
+ * Setup (all via API — verified against the running app):
+ *   - superadmin creates a second organization in the admin's tenant,
+ *   - creates a user there (roles: []) and grants it the `entities.*` features
+ *     via a per-user ACL,
+ *   - that user logs in with its own home-org JWT.
+ * The seeded `admin` (org 1) and the new user (org 2) then create one entity each.
+ */
+test.describe('TC-ENTITIES-007: Organization scoping isolates custom entities', () => {
+  test('a user in another org cannot see the admin org entity and vice versa', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin');
+    const superToken = await getAuthToken(request, 'superadmin');
+    const { tenantId } = getTokenContext(adminToken);
+    const stamp = `${Date.now().toString(36)}${Math.floor(Math.random() * 46_656).toString(36)}`;
+
+    let org2Id: string | null = null;
+    let user2Id: string | null = null;
+    let user2Token: string | null = null;
+    const entityA = uniqueEntityId('org1'); // created by admin (org 1)
+    const entityB = uniqueEntityId('org2'); // created by user2 (org 2)
+
+    try {
+      org2Id = await createOrganizationFixture(request, superToken, { name: `E2E Entities Scope Org ${stamp}`, tenantId });
+      const user2Email = `e2e-entities-scope-${stamp}@acme.com`;
+      const user2Password = 'Sched-View-1!';
+      user2Id = await createUserFixture(request, superToken, {
+        email: user2Email,
+        password: user2Password,
+        organizationId: org2Id,
+        roles: [],
+      });
+      await setUserAclVisibility(request, superToken, {
+        userId: user2Id,
+        organizations: null,
+        features: ['entities.definitions.view', 'entities.definitions.manage', 'entities.records.view', 'entities.records.manage'],
+      });
+      user2Token = await getAuthToken(request, user2Email, user2Password);
+
+      // Sanity: the new user's JWT really resolves to the second organization.
+      expect(getTokenContext(user2Token).organizationId, 'user2 home org is org 2').toBe(org2Id);
+      expect(getTokenContext(user2Token).tenantId, 'user2 shares the admin tenant').toBe(tenantId);
+
+      expect((await createCustomEntity(request, adminToken, { entityId: entityA, label: 'Scope A (org 1)' })).status(), 'admin creates entity A').toBe(200);
+      expect((await createCustomEntity(request, user2Token, { entityId: entityB, label: 'Scope B (org 2)' })).status(), 'user2 creates entity B').toBe(200);
+
+      const adminList = await readJsonSafe<{ items?: Array<{ entityId?: string }> }>(await listCustomEntities(request, adminToken));
+      const adminIds = new Set((adminList?.items ?? []).map((it) => it.entityId));
+      expect(adminIds.has(entityA), 'admin sees its own org entity A').toBe(true);
+      expect(adminIds.has(entityB), 'admin does NOT see org 2 entity B').toBe(false);
+
+      const user2List = await readJsonSafe<{ items?: Array<{ entityId?: string }> }>(await listCustomEntities(request, user2Token));
+      const user2Ids = new Set((user2List?.items ?? []).map((it) => it.entityId));
+      expect(user2Ids.has(entityB), 'user2 sees its own org entity B').toBe(true);
+      expect(user2Ids.has(entityA), 'user2 does NOT see org 1 entity A').toBe(false);
+    } finally {
+      await deleteCustomEntityIfExists(request, adminToken, entityA);
+      if (user2Token) await deleteCustomEntityIfExists(request, user2Token, entityB);
+      await deleteUserIfExists(request, superToken, user2Id);
+      await deleteOrganizationIfExists(request, superToken, org2Id);
+    }
+  });
+});

--- a/packages/core/src/modules/entities/__integration__/helpers/entitiesApi.ts
+++ b/packages/core/src/modules/entities/__integration__/helpers/entitiesApi.ts
@@ -1,0 +1,146 @@
+import { expect, type APIRequestContext, type APIResponse } from '@playwright/test';
+import { apiRequest } from '@open-mercato/core/helpers/integration/api';
+
+/**
+ * Module-local helpers for the entities API integration specs (issue #2471).
+ *
+ * Shared cross-module helpers (auth tokens, user/org/role fixtures) are imported
+ * by the specs directly from `@open-mercato/core/helpers/integration/*`. This file
+ * only adds the entities-specific request builders, an unauthenticated request
+ * (for 401 coverage) and a regex-valid unique entity id generator.
+ *
+ * Verified route map (generated registry → `/api/<file-path-with-dots>`):
+ *   - POST/GET/DELETE /api/entities/entities            (custom entity definitions)
+ *   - POST            /api/entities/definitions.batch   (field definitions, batch)
+ *   - GET             /api/entities/definitions.manage   (scoped field definitions)
+ *   - POST/GET/DELETE /api/entities/records              (custom entity records)
+ * The bare `/api/entities` and slash variants (`/definitions/batch`) return 404.
+ */
+
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000';
+
+export const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-9a-f][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type FieldDefinitionInput = {
+  key: string;
+  kind: string;
+  configJson?: Record<string, unknown>;
+  isActive?: boolean;
+};
+
+/**
+ * Generates a unique entity id matching the platform regex `^[a-z0-9_]+:[a-z0-9_]+$`.
+ * Uniqueness (timestamp + random) keeps specs idempotent across retries and parallel
+ * workers without colliding with soft-deleted leftovers from previous runs.
+ */
+export function uniqueEntityId(entityPart = 'item'): string {
+  const stamp = Date.now().toString(36);
+  const rand = Math.floor(Math.random() * 46_656).toString(36);
+  return `e2e_ent_${stamp}_${rand}:${entityPart}`;
+}
+
+/** Asserts the value is a UUID string and returns it. */
+export function expectUuid(value: unknown, label: string): string {
+  expect(typeof value === 'string' && UUID_REGEX.test(value as string), `${label} should be a UUID`).toBe(true);
+  return value as string;
+}
+
+/** Authenticated entity-definition upsert: POST /api/entities/entities. */
+export function createCustomEntity(
+  request: APIRequestContext,
+  token: string,
+  body: { entityId: string; label: string; description?: string },
+): Promise<APIResponse> {
+  return apiRequest(request, 'POST', '/api/entities/entities', { token, data: body });
+}
+
+/** Authenticated entity list: GET /api/entities/entities. */
+export function listCustomEntities(request: APIRequestContext, token: string): Promise<APIResponse> {
+  return apiRequest(request, 'GET', '/api/entities/entities', { token });
+}
+
+/** Best-effort soft-delete cleanup for a custom entity definition. */
+export async function deleteCustomEntityIfExists(
+  request: APIRequestContext,
+  token: string | null,
+  entityId: string | null,
+): Promise<void> {
+  if (!token || !entityId) return;
+  await apiRequest(request, 'DELETE', '/api/entities/entities', { token, data: { entityId } }).catch(() => undefined);
+}
+
+/** Batch field-definition upsert: POST /api/entities/definitions.batch. */
+export function saveFieldDefinitions(
+  request: APIRequestContext,
+  token: string,
+  entityId: string,
+  definitions: FieldDefinitionInput[],
+): Promise<APIResponse> {
+  return apiRequest(request, 'POST', '/api/entities/definitions.batch', { token, data: { entityId, definitions } });
+}
+
+/** Scoped field-definition snapshot: GET /api/entities/definitions.manage. */
+export function listFieldDefinitions(
+  request: APIRequestContext,
+  token: string,
+  entityId: string,
+): Promise<APIResponse> {
+  return apiRequest(request, 'GET', `/api/entities/definitions.manage?entityId=${encodeURIComponent(entityId)}`, {
+    token,
+  });
+}
+
+/** Record create: POST /api/entities/records. */
+export function createRecord(
+  request: APIRequestContext,
+  token: string,
+  entityId: string,
+  values: Record<string, unknown>,
+): Promise<APIResponse> {
+  return apiRequest(request, 'POST', '/api/entities/records', { token, data: { entityId, values } });
+}
+
+/** Record list: GET /api/entities/records. */
+export function listRecords(
+  request: APIRequestContext,
+  token: string,
+  entityId: string,
+  extraQuery = '',
+): Promise<APIResponse> {
+  const base = `/api/entities/records?entityId=${encodeURIComponent(entityId)}&page=1&pageSize=50&sortField=id&sortDir=asc`;
+  return apiRequest(request, 'GET', `${base}${extraQuery}`, { token });
+}
+
+/** Best-effort soft-delete cleanup for a single record. */
+export async function deleteRecordIfExists(
+  request: APIRequestContext,
+  token: string | null,
+  entityId: string | null,
+  recordId: string | null,
+): Promise<void> {
+  if (!token || !entityId || !recordId) return;
+  await apiRequest(
+    request,
+    'DELETE',
+    `/api/entities/records?entityId=${encodeURIComponent(entityId)}&recordId=${encodeURIComponent(recordId)}`,
+    { token },
+  ).catch(() => undefined);
+}
+
+/**
+ * Unauthenticated request (no Authorization header) for 401 coverage.
+ * Mirrors {@link apiRequest} but omits the bearer token.
+ */
+export function rawRequest(
+  request: APIRequestContext,
+  method: string,
+  path: string,
+  data?: unknown,
+): Promise<APIResponse> {
+  return request.fetch(`${BASE_URL}${path}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    data: data === undefined ? undefined : JSON.stringify(data),
+  });
+}


### PR DESCRIPTION
## Summary

Adds integration-test coverage for the `entities` module (issue #2471), which previously
had only one narrow spec. Seven executable Playwright specs cover the enumerated P0/P1
scenarios: custom entity-definition CRUD, auth/RBAC enforcement (401/403), field-definition
batch creation, record CRUD with field values, field-level validation, entity soft-delete,
and organization scoping. Test-only change — no product code is modified.

During authoring, several behaviors were verified against a running app and differ from the
issue's prose; the specs assert the true, code-backed contract (see Changes).

## Changes

- Add `packages/core/src/modules/entities/__integration__/TC-ENTITIES-001..007.spec.ts`
  (one scenario per file, mapping 1:1 to the issue's 7 scenarios).
- Add module-local helper `__integration__/helpers/entitiesApi.ts` (entities request
  builders, unauthenticated request for 401 coverage, regex-valid unique entity-id generator);
  shared auth/user/org fixtures are reused from `@open-mercato/core/helpers/integration/*`.
- Verified-contract corrections baked into the assertions:
  - Real routes are `/api/entities/entities`, `/api/entities/definitions.batch`,
    `/api/entities/definitions.manage` (dot paths); the bare/slash variants return 404.
  - Entity create returns HTTP 200 (not 201); record payload is `{ entityId, values:{…} }`
    → `{ ok, item:{ entityId, recordId } }`.
  - Record validation is rule-driven (`configJson.validation`) plus an always-on
    undeclared-key guard → 400 `{ error:'Validation failed', fields:{ cf_<key> } }`.
  - Soft-deleting an entity definition removes it from the entity list but its stored
    records remain queryable (records live in `custom_entities_storage`, independent of the
    definition row) — TC-006 asserts this real invariant rather than the issue's assumption.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — scenarios are enumerated in issue #2471; this is test-only coverage for an existing module.

## Testing

- `BASE_URL=http://127.0.0.1:5001 OM_INTEGRATION_MODULES=entities OM_TEST_AUTH_RATE_LIMIT_MODE=opt-in npx playwright test --config .ai/qa/tests/playwright.config.ts TC-ENTITIES- --retries=0` → 7 passed (run twice; idempotent).
- Full module folder (incl. existing `TC-ENT-2055` regression): `… packages/core/src/modules/entities/__integration__/ --retries=0` → 8 passed.
- `TURBO_FORCE=1 yarn turbo run typecheck --filter=@open-mercato/core` → success (core typecheck includes `__integration__/*.spec.ts`).
- `yarn i18n:check-hardcoded` → exit 0; no new files flagged.
- Exercised against an ephemeral Docker app (`yarn test:integration:ephemeral:start`).

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).  <!-- submitter to confirm — CLA acceptance is the author's attestation -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- N/A — test-only addition; no docs/locale/generator changes required -->
- [x] I added or adjusted tests that cover the change. <!-- this PR IS the tests -->
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- executable specs live in the module's __integration__/ folder per .ai/qa/AGENTS.md; .ai/qa/tests/ is config-only -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — no spec required; scenarios defined in issue #2471 -->

### Design System Compliance
<!-- N/A — backend API integration tests only; no UI, Tailwind, or DS components touched -->
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens  <!-- N/A — no UI -->
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`  <!-- N/A — no UI -->
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)  <!-- N/A — no UI -->
- [x] Loading state handled for async pages  <!-- N/A — no UI -->
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)  <!-- N/A — no UI -->
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements  <!-- N/A — no UI -->

## Linked issues

Fixes #2471