### PR TITLE
fix(ci): stabilize custom fields and crud form dirty state

### DIFF
--- a/.ai/runs/2026-06-05-ci-2425-stabilization.md
+++ b/.ai/runs/2026-06-05-ci-2425-stabilization.md
@@ -24,6 +24,9 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 - Downloaded artifacts: `/tmp/open-mercato-ci-2549`
 - Full ephemeral run attempt 1 log: `/tmp/ci-2425-full-ephemeral-run-1.log` (invalid: exposed a retry in `TC-AI-INJECT-013`)
 - Catalog AI targeted rerun log: `/tmp/ci-2425-ai-merch-targeted.log` (7/7 passed with `--retries=0`)
+- PR #2606 CI run `27023888378`, job `79760208071`: `ephemeral-integration (8/15)` still failed `TC-CRM-CF-MULTI-EDIT-001` with updated multi-select values reading back as `[]`.
+- Manual catalog reproduction on fresh app `http://127.0.0.1:45643`: first product multi-select PUT read back values, second PUT left zero `custom_field_values` rows for the field, proving the defect was the shared EAV array replacement write, not the catalog route or query-index read path.
+- Custom-field targeted rerun log after shared EAV replacement fix: `/tmp/ci-2425-cf-multi-targeted.log` (3/3 passed with `--retries=0`: catalog product multi-select, CRM deal multi-select, CRM legacy bare-key negative contract).
 
 ## Implementation Plan
 
@@ -61,10 +64,11 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 
 - [x] 2.1 Run targeted integration specs — afd6a28e4
 - [x] 2.2 Run relevant unit/type checks — afd6a28e4
-- [x] 2.3 Stabilize catalog AI sheet integration flake — pending commit
-- [ ] 2.4 Run two independent full ephemeral integration runs
+- [x] 2.3 Stabilize catalog AI sheet integration flake — 0556a3127
+- [x] 2.4 Stabilize shared EAV multi-value replacement after PR #2606 CI failure — pending commit
+- [ ] 2.5 Run two independent full ephemeral integration runs
 
 ### Phase 3: PR
 
 - [x] 3.1 Open stabilization PR against develop — 2606
-- [ ] 3.2 Apply PR labels and summary comment
+- [x] 3.2 Apply PR labels and summary comment — c03f44479

--- a/.ai/runs/2026-06-05-ci-2425-stabilization.md
+++ b/.ai/runs/2026-06-05-ci-2425-stabilization.md
@@ -27,6 +27,9 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 - PR #2606 CI run `27023888378`, job `79760208071`: `ephemeral-integration (8/15)` still failed `TC-CRM-CF-MULTI-EDIT-001` with updated multi-select values reading back as `[]`.
 - Manual catalog reproduction on fresh app `http://127.0.0.1:45643`: first product multi-select PUT read back values, second PUT left zero `custom_field_values` rows for the field, proving the defect was the shared EAV array replacement write, not the catalog route or query-index read path.
 - Custom-field targeted rerun log after shared EAV replacement fix: `/tmp/ci-2425-cf-multi-targeted.log` (3/3 passed with `--retries=0`: catalog product multi-select, CRM deal multi-select, CRM legacy bare-key negative contract).
+- Full ephemeral proof run 1 log: `/tmp/ci-2425-full-ephemeral-run-1-after-eav.log` on app `http://127.0.0.1:46227`, DB `localhost:32865`, `--retries=0`: 1421 passed, 70 skipped, 0 failed in 20.9m. Included in-suite passes for `TC-CAT-CF-MULTI-EDIT-001`, `TC-CRM-CF-MULTI-EDIT-001`, `TC-LOCK-OSS-014`, and catalog AI sheet specs.
+- Full ephemeral proof run 2 attempt log: `/tmp/ci-2425-full-ephemeral-run-2-after-eav.log` on app `http://127.0.0.1:45155`, DB `localhost:32866`, invalid/not counted: `TC-AUTH-003` and `TC-AUTH-007` exposed auth form hydration races where the first filled field was reset before submit, so no valid login/reset POST could complete.
+- Auth hydration targeted rerun log after reset form readiness marker: `/tmp/ci-2425-auth-targeted.log` (2/2 passed with `--retries=0`: `TC-AUTH-003`, `TC-AUTH-007`) on fresh app `http://127.0.0.1:45035`, DB `localhost:32868`.
 
 ## Implementation Plan
 
@@ -66,6 +69,7 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 - [x] 2.2 Run relevant unit/type checks — afd6a28e4
 - [x] 2.3 Stabilize catalog AI sheet integration flake — 0556a3127
 - [x] 2.4 Stabilize shared EAV multi-value replacement after PR #2606 CI failure — 881d42dcc
+- [x] 2.4a Stabilize auth form hydration interactions exposed by full proof run 2 — pending commit
 - [ ] 2.5 Run two independent full ephemeral integration runs
 
 ### Phase 3: PR

--- a/.ai/runs/2026-06-05-ci-2425-stabilization.md
+++ b/.ai/runs/2026-06-05-ci-2425-stabilization.md
@@ -63,5 +63,5 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 
 ### Phase 3: PR
 
-- [ ] 3.1 Open stabilization PR against develop
+- [x] 3.1 Open stabilization PR against develop — 2606
 - [ ] 3.2 Apply PR labels and summary comment

--- a/.ai/runs/2026-06-05-ci-2425-stabilization.md
+++ b/.ai/runs/2026-06-05-ci-2425-stabilization.md
@@ -65,7 +65,7 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 - [x] 2.1 Run targeted integration specs — afd6a28e4
 - [x] 2.2 Run relevant unit/type checks — afd6a28e4
 - [x] 2.3 Stabilize catalog AI sheet integration flake — 0556a3127
-- [x] 2.4 Stabilize shared EAV multi-value replacement after PR #2606 CI failure — pending commit
+- [x] 2.4 Stabilize shared EAV multi-value replacement after PR #2606 CI failure — 881d42dcc
 - [ ] 2.5 Run two independent full ephemeral integration runs
 
 ### Phase 3: PR

--- a/.ai/runs/2026-06-05-ci-2425-stabilization.md
+++ b/.ai/runs/2026-06-05-ci-2425-stabilization.md
@@ -58,7 +58,7 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 ### Phase 2: Verification
 
 - [x] 2.1 Run targeted integration specs — afd6a28e4
-- [ ] 2.2 Run relevant unit/type checks
+- [x] 2.2 Run relevant unit/type checks — afd6a28e4
 - [ ] 2.3 Run two independent full ephemeral integration runs
 
 ### Phase 3: PR

--- a/.ai/runs/2026-06-05-ci-2425-stabilization.md
+++ b/.ai/runs/2026-06-05-ci-2425-stabilization.md
@@ -52,12 +52,12 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 
 ### Phase 1: Root-Cause Requested Failures
 
-- [ ] 1.1 Fix deal custom-field update persistence
-- [ ] 1.2 Fix CRM company clean-save optimistic-lock flow
+- [x] 1.1 Fix deal custom-field update persistence — afd6a28e4
+- [x] 1.2 Fix CRM company clean-save optimistic-lock flow — afd6a28e4
 
 ### Phase 2: Verification
 
-- [ ] 2.1 Run targeted integration specs
+- [x] 2.1 Run targeted integration specs — afd6a28e4
 - [ ] 2.2 Run relevant unit/type checks
 - [ ] 2.3 Run two independent full ephemeral integration runs
 

--- a/.ai/runs/2026-06-05-ci-2425-stabilization.md
+++ b/.ai/runs/2026-06-05-ci-2425-stabilization.md
@@ -69,7 +69,7 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 - [x] 2.2 Run relevant unit/type checks — afd6a28e4
 - [x] 2.3 Stabilize catalog AI sheet integration flake — 0556a3127
 - [x] 2.4 Stabilize shared EAV multi-value replacement after PR #2606 CI failure — 881d42dcc
-- [x] 2.4a Stabilize auth form hydration interactions exposed by full proof run 2 — pending commit
+- [x] 2.4a Stabilize auth form hydration interactions exposed by full proof run 2 — 92ebbb417
 - [ ] 2.5 Run two independent full ephemeral integration runs
 
 ### Phase 3: PR

--- a/.ai/runs/2026-06-05-ci-2425-stabilization.md
+++ b/.ai/runs/2026-06-05-ci-2425-stabilization.md
@@ -22,6 +22,8 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 - Failed shards: `ephemeral-integration (8/15)`, `ephemeral-integration (9/15)`
 - Snapshot standalone run: `27017594026`
 - Downloaded artifacts: `/tmp/open-mercato-ci-2549`
+- Full ephemeral run attempt 1 log: `/tmp/ci-2425-full-ephemeral-run-1.log` (invalid: exposed a retry in `TC-AI-INJECT-013`)
+- Catalog AI targeted rerun log: `/tmp/ci-2425-ai-merch-targeted.log` (7/7 passed with `--retries=0`)
 
 ## Implementation Plan
 
@@ -59,7 +61,8 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 
 - [x] 2.1 Run targeted integration specs — afd6a28e4
 - [x] 2.2 Run relevant unit/type checks — afd6a28e4
-- [ ] 2.3 Run two independent full ephemeral integration runs
+- [x] 2.3 Stabilize catalog AI sheet integration flake — pending commit
+- [ ] 2.4 Run two independent full ephemeral integration runs
 
 ### Phase 3: PR
 

--- a/.ai/runs/2026-06-05-ci-2425-stabilization.md
+++ b/.ai/runs/2026-06-05-ci-2425-stabilization.md
@@ -1,0 +1,67 @@
+# CI 2425 Stabilization
+
+## Goal
+
+Stabilize the develop branch feeding PR #2425 by fixing the failures observed in PR #2549 CI at root cause, then prove the integration suite is stable with two independent full ephemeral runs.
+
+## Scope
+
+- Fix the multi-select custom-field persistence failure in `TC-CRM-CF-MULTI-EDIT-001`.
+- Fix the OSS optimistic-lock clean-save failure in `TC-LOCK-OSS-014`.
+- Triage standalone integration failures from PR #2549 and split unrelated fixes into follow-up PRs if needed.
+
+## Non-goals
+
+- No timeout-only fixes.
+- No broad test deletion or allowlisting.
+- No local database migrations.
+
+## Evidence
+
+- PR #2549 CI run: `27017593992`
+- Failed shards: `ephemeral-integration (8/15)`, `ephemeral-integration (9/15)`
+- Snapshot standalone run: `27017594026`
+- Downloaded artifacts: `/tmp/open-mercato-ci-2549`
+
+## Implementation Plan
+
+### Phase 1: Root-Cause Requested Failures
+
+1. Fix deal custom-field update persistence so `customFields` wrapper values are stored on update and visible through the detail endpoint.
+2. Fix the CRM company clean-save optimistic-lock test path so the form submit produces the intended PUT and asserts the real conflict-bar behavior.
+
+### Phase 2: Verification
+
+1. Run targeted integration specs for the changed areas with retries disabled.
+2. Run the relevant unit/type checks for changed packages.
+3. Run two independent full ephemeral integration runs.
+
+### Phase 3: PR
+
+1. Open a stabilization PR against `develop`.
+2. Apply labels and summary comments per repo workflow.
+
+## Risks
+
+- Full ephemeral runs are long-running and may expose unrelated standalone or shard-level failures. If unrelated, split them into separate stabilization PRs.
+- PR #2425 CI may still be in progress while fixes are prepared against `develop`.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Root-Cause Requested Failures
+
+- [ ] 1.1 Fix deal custom-field update persistence
+- [ ] 1.2 Fix CRM company clean-save optimistic-lock flow
+
+### Phase 2: Verification
+
+- [ ] 2.1 Run targeted integration specs
+- [ ] 2.2 Run relevant unit/type checks
+- [ ] 2.3 Run two independent full ephemeral integration runs
+
+### Phase 3: PR
+
+- [ ] 3.1 Open stabilization PR against develop
+- [ ] 3.2 Apply PR labels and summary comment

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-003.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-003.spec.ts
@@ -13,10 +13,15 @@ test.describe('TC-AUTH-003: Login with Remember Me', () => {
     ]);
 
     await page.goto('/login');
-    await page.getByLabel('Email').fill('admin@acme.com');
-    await page.getByLabel('Password', { exact: true }).fill('secret');
+    await page.waitForSelector('form[data-auth-ready="1"]', { state: 'visible', timeout: 30_000 });
+    const emailInput = page.getByLabel('Email');
+    const passwordInput = page.getByLabel('Password', { exact: true });
+    await emailInput.fill('admin@acme.com');
+    await expect(emailInput).toHaveValue('admin@acme.com');
+    await passwordInput.fill('secret');
+    await expect(passwordInput).toHaveValue('secret');
     await page.getByRole('checkbox', { name: /remember me/i }).check();
-    await page.getByLabel('Password', { exact: true }).press('Enter');
+    await passwordInput.press('Enter');
 
     await expect(page).toHaveURL(/\/backend(?:\/.*)?$/);
 

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-007.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-007.spec.ts
@@ -10,8 +10,13 @@ import { expect, test, type Page } from '@playwright/test';
  * behind the deterministic round-trip.
  */
 async function submitResetAndExpectError(page: Page): Promise<void> {
-  await page.getByLabel(/^new password$/i).fill('Valid1!Pass');
-  await page.getByLabel(/^confirm new password$/i).fill('Valid1!Pass');
+  await page.waitForSelector('form[data-auth-ready="1"]', { state: 'visible', timeout: 30_000 });
+  const passwordInput = page.getByLabel(/^new password$/i);
+  const confirmPasswordInput = page.getByLabel(/^confirm new password$/i);
+  await passwordInput.fill('Valid1!Pass');
+  await expect(passwordInput).toHaveValue('Valid1!Pass');
+  await confirmPasswordInput.fill('Valid1!Pass');
+  await expect(confirmPasswordInput).toHaveValue('Valid1!Pass');
   const confirmResponse = page.waitForResponse(
     (response) =>
       response.url().includes('/api/auth/reset/confirm') &&

--- a/packages/core/src/modules/auth/frontend/reset/[token]/page.tsx
+++ b/packages/core/src/modules/auth/frontend/reset/[token]/page.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@open
 import { Button } from '@open-mercato/ui/primitives/button'
 import { PasswordInput } from '@open-mercato/ui/primitives/password-input'
 import { Label } from '@open-mercato/ui/primitives/label'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -14,11 +14,16 @@ export default function ResetWithTokenPage({ params }: { params: { token: string
   const t = useT()
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
+  const [clientReady, setClientReady] = useState(false)
   const passwordPolicy = getPasswordPolicy()
   const passwordRequirements = formatPasswordRequirements(passwordPolicy, t)
   const passwordDescription = passwordRequirements
     ? t('auth.password.requirements.help', 'Password requirements: {requirements}', { requirements: passwordRequirements })
     : ''
+
+  useEffect(() => {
+    setClientReady(true)
+  }, [])
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -65,7 +70,7 @@ export default function ResetWithTokenPage({ params }: { params: { token: string
           <CardDescription>{t('auth.reset.subtitle', 'Choose a strong password for your account.')}</CardDescription>
         </CardHeader>
         <CardContent>
-          <form className="grid gap-3" onSubmit={onSubmit}>
+          <form className="grid gap-3" onSubmit={onSubmit} data-auth-ready={clientReady ? '1' : '0'}>
             {error && <div className="text-sm text-status-error-text">{error}</div>}
             <div className="grid gap-1">
               <Label htmlFor="password">{t('auth.reset.form.password', 'New password')}</Label>

--- a/packages/core/src/modules/catalog/__integration__/TC-AI-INJECT-013-merchandising-injection.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-AI-INJECT-013-merchandising-injection.spec.ts
@@ -49,7 +49,8 @@ test.describe('TC-AI-INJECT-013: catalog merchandising via injection', () => {
     // split-button caret + agent-picker popover only render when the
     // widget exposes more than one assistant.
     const sheet = page.locator('[data-ai-merchandising-sheet]');
-    const composer = page.locator('#ai-chat-composer');
+    const chatRegion = sheet.locator(`[data-ai-chat-agent="${MERCHANDISING_AGENT_ID}"]`);
+    const composer = chatRegion.locator('#ai-chat-composer');
     // The trigger is server-rendered and can be visible+enabled before React
     // binds its onClick handler, so under heavy CI load a single click is a
     // no-op and the sheet never opens. Re-click (only while the sheet is
@@ -57,10 +58,8 @@ test.describe('TC-AI-INJECT-013: catalog merchandising via injection', () => {
     await expect(async () => {
       if (!(await sheet.isVisible())) await trigger.click();
       await expect(sheet).toBeVisible({ timeout: 3_000 });
+      await expect(chatRegion).toBeVisible({ timeout: 3_000 });
       await expect(composer).toBeVisible({ timeout: 3_000 });
     }).toPass({ timeout: 60_000, intervals: [500, 1_000, 2_000] });
-
-    const chatRegion = page.locator(`[data-ai-chat-agent="${MERCHANDISING_AGENT_ID}"]`);
-    await expect(chatRegion).toBeVisible();
   });
 });

--- a/packages/core/src/modules/catalog/__integration__/TC-AI-MERCHANDISING-008-products-sheet.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-AI-MERCHANDISING-008-products-sheet.spec.ts
@@ -91,15 +91,14 @@ test.describe('TC-AI-MERCHANDISING-008: catalog.merchandising_assistant sheet', 
     // load, making a single click a no-op; re-click (only while closed) until
     // the sheet + composer mount.
     const sheet = page.locator('[data-ai-merchandising-sheet]');
-    const composer = page.locator('#ai-chat-composer');
+    const chatRegion = sheet.locator(`[data-ai-chat-agent="${MERCHANDISING_AGENT_ID}"]`);
+    const composer = chatRegion.locator('#ai-chat-composer');
     await expect(async () => {
       if (!(await sheet.isVisible())) await trigger.click();
       await expect(sheet).toBeVisible({ timeout: 3_000 });
+      await expect(chatRegion).toBeVisible({ timeout: 3_000 });
       await expect(composer).toBeVisible({ timeout: 3_000 });
     }).toPass({ timeout: 60_000, intervals: [500, 1_000, 2_000] });
-
-    const chatRegion = page.locator(`[data-ai-chat-agent="${MERCHANDISING_AGENT_ID}"]`);
-    await expect(chatRegion).toBeVisible();
   });
 
   test('selection pill reflects the current selected count when selection changes', async ({ page }) => {

--- a/packages/core/src/modules/entities/lib/__tests__/helpers.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/helpers.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment node */
 import type { EntityManager } from '@mikro-orm/core'
+import { CustomFieldDef, CustomFieldValue } from '../../data/entities'
 import { setRecordCustomFields } from '../helpers'
 
 describe('setRecordCustomFields', () => {
@@ -69,5 +70,64 @@ describe('setRecordCustomFields', () => {
       }),
     ).rejects.toThrow()
     expect(persist).not.toHaveBeenCalled()
+  })
+
+  it('replaces multi-value custom fields without deleting the replacement rows', async () => {
+    const definition = {
+      key: 'segments',
+      kind: 'select',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      updatedAt: new Date('2026-06-05T00:00:00.000Z'),
+      configJson: { multi: true },
+    }
+    const staleRows = [
+      { id: 'old-alpha', fieldKey: 'segments', valueText: 'alpha' },
+      { id: 'old-beta', fieldKey: 'segments', valueText: 'beta' },
+    ]
+    const persist = jest.fn()
+    const remove = jest.fn()
+    const nativeDelete = jest.fn()
+    const create = jest.fn((entity: unknown, data: Record<string, unknown>) => ({ ...data, entity }))
+    const emMock = {
+      find: jest.fn(async (entity: unknown) => {
+        if (entity === CustomFieldDef) return [definition]
+        if (entity === CustomFieldValue) return staleRows
+        return []
+      }),
+      findOne: jest.fn(async () => null),
+      create,
+      remove,
+      nativeDelete,
+      persist,
+      flush: jest.fn(async () => undefined),
+      begin: jest.fn(async () => undefined),
+      commit: jest.fn(async () => undefined),
+      rollback: jest.fn(async () => undefined),
+      isInTransaction: jest.fn(() => false),
+    }
+    const em = emMock as unknown as EntityManager
+
+    await setRecordCustomFields(em, {
+      entityId: 'customers:customer_deal',
+      recordId: 'deal-1',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      values: { segments: ['gamma', 'delta'] },
+    })
+
+    expect(remove).toHaveBeenCalledTimes(2)
+    expect(remove).toHaveBeenCalledWith(staleRows[0])
+    expect(remove).toHaveBeenCalledWith(staleRows[1])
+    expect(nativeDelete).not.toHaveBeenCalled()
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist).toHaveBeenCalledWith([
+      expect.objectContaining({ fieldKey: 'segments', valueText: 'gamma' }),
+      expect.objectContaining({ fieldKey: 'segments', valueText: 'delta' }),
+    ])
+    expect(emMock.flush).toHaveBeenCalledTimes(1)
+    expect(emMock.begin).toHaveBeenCalledTimes(1)
+    expect(emMock.commit).toHaveBeenCalledTimes(1)
+    expect(emMock.rollback).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/entities/lib/__tests__/helpers.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/helpers.test.ts
@@ -81,18 +81,14 @@ describe('setRecordCustomFields', () => {
       updatedAt: new Date('2026-06-05T00:00:00.000Z'),
       configJson: { multi: true },
     }
-    const staleRows = [
-      { id: 'old-alpha', fieldKey: 'segments', valueText: 'alpha' },
-      { id: 'old-beta', fieldKey: 'segments', valueText: 'beta' },
-    ]
     const persist = jest.fn()
     const remove = jest.fn()
-    const nativeDelete = jest.fn()
+    const nativeDelete = jest.fn(async () => 2)
     const create = jest.fn((entity: unknown, data: Record<string, unknown>) => ({ ...data, entity }))
     const emMock = {
       find: jest.fn(async (entity: unknown) => {
         if (entity === CustomFieldDef) return [definition]
-        if (entity === CustomFieldValue) return staleRows
+        if (entity === CustomFieldValue) return []
         return []
       }),
       findOne: jest.fn(async () => null),
@@ -116,15 +112,21 @@ describe('setRecordCustomFields', () => {
       values: { segments: ['gamma', 'delta'] },
     })
 
-    expect(remove).toHaveBeenCalledTimes(2)
-    expect(remove).toHaveBeenCalledWith(staleRows[0])
-    expect(remove).toHaveBeenCalledWith(staleRows[1])
-    expect(nativeDelete).not.toHaveBeenCalled()
+    expect(remove).not.toHaveBeenCalled()
+    expect(nativeDelete).toHaveBeenCalledTimes(1)
+    expect(nativeDelete).toHaveBeenCalledWith(CustomFieldValue, {
+      entityId: 'customers:customer_deal',
+      recordId: 'deal-1',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      fieldKey: 'segments',
+    })
     expect(persist).toHaveBeenCalledTimes(1)
     expect(persist).toHaveBeenCalledWith([
       expect.objectContaining({ fieldKey: 'segments', valueText: 'gamma' }),
       expect.objectContaining({ fieldKey: 'segments', valueText: 'delta' }),
     ])
+    expect(nativeDelete.mock.invocationCallOrder[0]).toBeLessThan(create.mock.invocationCallOrder[0])
     expect(emMock.flush).toHaveBeenCalledTimes(1)
     expect(emMock.begin).toHaveBeenCalledTimes(1)
     expect(emMock.commit).toHaveBeenCalledTimes(1)

--- a/packages/core/src/modules/entities/lib/helpers.ts
+++ b/packages/core/src/modules/entities/lib/helpers.ts
@@ -149,19 +149,15 @@ export async function setRecordCustomFields(
     const def = defsByKey?.[fieldKey]
     const encrypted = Boolean(def?.configJson && (def as any).configJson?.encrypted)
     const isArray = Array.isArray(raw)
-    // When array (multi-value): replace all existing rows for the key. The old
-    // rows are removed via em.remove (a DEFERRED delete keyed by primary id),
-    // not nativeDelete, so the DELETE and the replacement INSERTs are applied in
-    // the SAME em.flush() — MikroORM wraps a flush in one transaction, making the
-    // replacement atomic (the field can never be left empty by a partial
-    // failure between delete and insert). It also removes the FlushMode.AUTO
-    // footgun the old code had: a nativeDelete issued after em.create()
-    // auto-flushed the new rows and then deleted them by fieldKey, wiping the
-    // value on EDIT. Regression: TC-CAT-CF-MULTI-EDIT-001 / TC-CRM-CF-MULTI-EDIT-001.
+    // When array (multi-value): replace all existing rows for the key. Delete
+    // first, then create replacements, all inside the transaction opened above.
+    // Creating rows before a native delete can auto-flush and delete the new
+    // values; mixing em.remove(stale) with new rows for the same EAV scope was
+    // observed to commit an empty set under MikroORM v7. The explicit order keeps
+    // the replacement atomic without letting old-row cleanup target new rows.
     if (isArray) {
       const arr = raw as Primitive[]
-      const existing = await em.find(CustomFieldValue, { entityId, recordId, organizationId, tenantId, fieldKey })
-      for (const stale of existing) em.remove(stale)
+      await em.nativeDelete(CustomFieldValue, { entityId, recordId, organizationId, tenantId, fieldKey })
       for (const val of arr) {
         const col: keyof CustomFieldValue = encrypted ? 'valueText' : def ? columnFromKind(def.kind) : columnFromJsValue(val)
         const cf = em.create(CustomFieldValue, { entityId, recordId, organizationId, tenantId, fieldKey, createdAt: new Date() })

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -2211,12 +2211,22 @@ export function CrudForm<TValues extends Record<string, unknown>>({
 
   const setValue = React.useCallback((id: string, nextValue: unknown) => {
     let nextData: CrudFormValues<TValues> | null = null
+    let nextDirty: boolean | null = null
     setValues((prev) => {
       if (Object.is(prev[id], nextValue)) return prev
       nextData = { ...prev, [id]: nextValue } as CrudFormValues<TValues>
       valuesRef.current = nextData
+      if (!(embedded && !trackDirtyWhenEmbedded)) {
+        const baseline = dirtyBaselineSnapshotRef.current ?? createDirtySnapshot(prev as Record<string, unknown>)
+        dirtyBaselineSnapshotRef.current = baseline
+        nextDirty = createDirtySnapshot(nextData as Record<string, unknown>) !== baseline
+      }
       return nextData
     })
+    if (nextDirty !== null) {
+      isDirtyRef.current = nextDirty
+      setHasUnsavedChanges(nextDirty)
+    }
     const clearedMessages: string[] = []
     setErrors((prev) => {
       if (!Object.keys(prev).length) return prev
@@ -2281,7 +2291,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     }).catch((err) => {
       console.error('[CrudForm] Error in onFieldChange:', err)
     })
-  }, [extendedInjectionEventsEnabled, flash, t, translateValidationMessage, triggerInjectionEvent])
+  }, [embedded, extendedInjectionEventsEnabled, flash, t, trackDirtyWhenEmbedded, translateValidationMessage, triggerInjectionEvent])
 
   const onBlurRequest = React.useCallback((fieldId: string) => {
     void validateFieldOnBlur(fieldId)

--- a/packages/ui/src/backend/__tests__/CrudForm.navigation.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.navigation.test.tsx
@@ -62,6 +62,32 @@ describe('CrudForm unsaved navigation guard', () => {
     expect(event.returnValue).toBe('')
   })
 
+  it('marks the form dirty on the first edit even when no baseline has been initialized yet', async () => {
+    const onDirtyChange = jest.fn()
+    const { container } = renderWithProviders(
+      <CrudForm title="Form" fields={fields} onSubmit={() => {}} onDirtyChange={onDirtyChange} />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+          'ui.forms.confirmUnsavedChanges': 'Unsaved changes',
+        },
+      },
+    )
+
+    const input = container.querySelector('[data-crud-field-id="name"] input[type="text"]') as HTMLInputElement
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Alice updated' } })
+    })
+
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true)
+
+    const event = new Event('beforeunload', { cancelable: true }) as BeforeUnloadEvent
+    Object.defineProperty(event, 'returnValue', { writable: true, value: undefined })
+    window.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
   it('blocks router-driven history pushes until the user confirms leaving', async () => {
     confirmDialogMock.mockResolvedValueOnce(false)
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-05-ci-2425-stabilization.md
Status: in-progress

## Goal
- Stabilize the develop branch feeding release PR #2425 by addressing the PR #2549 CI failures at root cause.

## What Changed
- Added regression coverage for multi-value custom-field replacement so replacement rows cannot be deleted during the same write.
- Fixed CrudForm dirty-state initialization so first edits mark the form dirty immediately, enabling header-driven saves in embedded forms.
- Added regression coverage for first-edit dirty tracking before the dirty baseline has been initialized.

## Recovery Checklist

### Completed
- [x] Collected PR #2549 CI/artifacts from run 27017593992 and standalone run 27017594026.
- [x] Fixed requested multi-field custom-field failure path.
- [x] Fixed requested OSS lock clean-save failure path.
- [x] Ran focused unit tests for custom fields and CrudForm dirty tracking.
- [x] Ran targeted Playwright specs with retries disabled for TC-CRM-CF-MULTI-EDIT-001 and TC-LOCK-OSS-014.
- [x] Ran yarn build:packages and yarn typecheck locally.
- [x] Opened PR #2606 against develop.

### In Progress
- [ ] Full ephemeral integration run 1: running locally, log at /tmp/ci-2425-full-ephemeral-run-1.log.
- [ ] Full ephemeral integration run 2: pending after run 1 completes cleanly.
- [ ] GitHub CI on this PR: queued/running.

### Pending Before Ready For Review
- [ ] Update this body with run 1 result.
- [ ] Update this body with run 2 result.
- [ ] Remove in-progress, set final pipeline labels, and mark Status: complete once local and GitHub CI are green.

## Tests
- yarn workspace @open-mercato/core test packages/core/src/modules/entities/lib/__tests__/helpers.test.ts --runInBand
- yarn workspace @open-mercato/ui test packages/ui/src/backend/__tests__/CrudForm.navigation.test.tsx --runInBand
- BASE_URL=http://127.0.0.1:5001 npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/customers/__integration__/TC-CRM-CF-MULTI-EDIT-001.spec.ts --retries=0
- BASE_URL=http://127.0.0.1:5001 npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/customers/__integration__/TC-LOCK-OSS-014.spec.ts --retries=0
- yarn build:packages
- yarn typecheck

## Backward Compatibility
- No public API, database schema, event, ACL, import-path, or widget contract changes.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-05-ci-2425-stabilization.md#progress).
