### PR TITLE
security(entities): use crypto randomness for scoped fixture credentials

### DIFF
--- a/.ai/runs/2026-06-05-codeql-insecure-randomness.md
+++ b/.ai/runs/2026-06-05-codeql-insecure-randomness.md
@@ -42,6 +42,13 @@ No existing spec directly covers this CodeQL remediation. This is a narrow secur
 - `yarn build:packages` — passed.
 - `yarn generate` — passed; emitted generated local artifacts and one non-fatal structural-cache warning.
 - `yarn typecheck --filter=@open-mercato/core` — passed after generation.
+- `yarn build:packages` (post-generate rebuild) — passed.
+- `yarn i18n:check-sync` — passed.
+- `yarn i18n:check-usage` — failed on 10 unrelated missing baseline keys in webhooks, scheduler, sso, integrations, inbox_ops, data_sync, and currencies pages; no changed files use translations.
+- `yarn typecheck` — passed.
+- `yarn test` — passed.
+- `yarn build:app` — passed, with existing dynamic import/NFT tracing warnings.
+- `yarn template:sync` — failed on unrelated existing template drift in the example module and dependency versions.
 
 ## Progress
 

--- a/.ai/runs/2026-06-05-codeql-insecure-randomness.md
+++ b/.ai/runs/2026-06-05-codeql-insecure-randomness.md
@@ -1,0 +1,44 @@
+# Fix CodeQL Insecure Randomness Alert
+
+## Overview
+
+Goal: clear CodeQL alert #134 by removing `Math.random()` from the password-adjacent entities integration fixture flow.
+
+Scope:
+- `packages/core/src/modules/entities/__integration__/TC-ENTITIES-007.spec.ts`
+- Targeted validation for the touched test file/package
+
+Non-goals:
+- Broad cleanup of unrelated `Math.random()` call sites.
+- Runtime behavior changes.
+- API, schema, ACL, event, or import contract changes.
+
+Existing specs checked:
+- `.ai/specs/`
+- `.ai/specs/enterprise/`
+
+No existing spec directly covers this CodeQL remediation. This is a narrow security/test-helper fix, so no new architectural spec is needed.
+
+## Implementation Plan
+
+### Phase 1: Remediate Alert Source
+
+1. Replace the test stamp suffix generated with `Math.random()` in `TC-ENTITIES-007.spec.ts` with a crypto-backed random value.
+2. Run targeted static checks for remaining `Math.random()` usage in the touched file and a focused validation command for the affected package/test.
+3. Run self-review against CodeQL intent and backward compatibility rules.
+
+## Risks
+
+- Low risk: the change only affects fixture uniqueness in one integration test.
+- The random value remains non-user-facing test data, but CodeQL treats the flow as security-sensitive because it reaches login credentials.
+- No tenant isolation, RBAC, DB schema, or public contract surfaces are changed.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append `— <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Remediate Alert Source
+
+- [ ] 1.1 Replace insecure test stamp randomness
+- [ ] 1.2 Validate affected test surface
+- [ ] 1.3 Complete self-review and BC review

--- a/.ai/runs/2026-06-05-codeql-insecure-randomness.md
+++ b/.ai/runs/2026-06-05-codeql-insecure-randomness.md
@@ -33,12 +33,22 @@ No existing spec directly covers this CodeQL remediation. This is a narrow secur
 - The random value remains non-user-facing test data, but CodeQL treats the flow as security-sensitive because it reaches login credentials.
 - No tenant isolation, RBAC, DB schema, or public contract surfaces are changed.
 
+## Validation Notes
+
+- `rg "Math\.random\(" packages/core/src/modules/entities/__integration__/TC-ENTITIES-007.spec.ts packages/core/src/helpers/integration/api.ts -n` — no matches.
+- `git diff --check` — passed.
+- `yarn workspace @open-mercato/core typecheck` — failed before validation because the workspace script cannot resolve `tsc` directly.
+- `yarn typecheck --filter=@open-mercato/core` — initially failed because generated `#generated/*` shims were missing in the clean worktree.
+- `yarn build:packages` — passed.
+- `yarn generate` — passed; emitted generated local artifacts and one non-fatal structural-cache warning.
+- `yarn typecheck --filter=@open-mercato/core` — passed after generation.
+
 ## Progress
 
 > Convention: `- [ ]` pending, `- [x]` done. Append `— <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Remediate Alert Source
 
-- [ ] 1.1 Replace insecure test stamp randomness
-- [ ] 1.2 Validate affected test surface
-- [ ] 1.3 Complete self-review and BC review
+- [x] 1.1 Replace insecure test stamp randomness — c9b71a97a
+- [x] 1.2 Validate affected test surface — c9b71a97a
+- [x] 1.3 Complete self-review and BC review — c9b71a97a

--- a/packages/core/src/modules/entities/__integration__/TC-ENTITIES-007.spec.ts
+++ b/packages/core/src/modules/entities/__integration__/TC-ENTITIES-007.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
 import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
@@ -36,7 +37,7 @@ test.describe('TC-ENTITIES-007: Organization scoping isolates custom entities', 
     const adminToken = await getAuthToken(request, 'admin');
     const superToken = await getAuthToken(request, 'superadmin');
     const { tenantId } = getTokenContext(adminToken);
-    const stamp = `${Date.now().toString(36)}${Math.floor(Math.random() * 46_656).toString(36)}`;
+    const stamp = `${Date.now().toString(36)}${randomUUID().replaceAll('-', '').slice(0, 8)}`;
 
     let org2Id: string | null = null;
     let user2Id: string | null = null;


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-05-codeql-insecure-randomness.md
Status: complete

## Goal
- Clear CodeQL alert #134 by removing Math.random() from the password-adjacent entities integration fixture flow.

## What Changed
- Replaced the random suffix in TC-ENTITIES-007 fixture stamp generation with node:crypto randomUUID().
- Added an auto-create-pr run plan with validation notes.

## Tests
- rg "Math\.random\(" packages/core/src/modules/entities/__integration__/TC-ENTITIES-007.spec.ts packages/core/src/helpers/integration/api.ts -n
- git diff --check
- yarn build:packages
- yarn generate
- yarn build:packages
- yarn i18n:check-sync
- yarn typecheck
- yarn test
- yarn build:app

Known baseline caveats:
- yarn i18n:check-usage currently reports 10 unrelated missing keys outside this PR's changed files.
- yarn template:sync reports unrelated existing drift in the example template and dependency versions.

## Backward Compatibility
- No contract surface changes. Test-only fixture uniqueness change.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-05-codeql-insecure-randomness.md#progress).