### PR TITLE
fix(ci): stabilize follow-up integration races

### DIFF
--- a/.ai/runs/2026-06-05-ci-2425-stabilization.md
+++ b/.ai/runs/2026-06-05-ci-2425-stabilization.md
@@ -73,11 +73,11 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 - [x] 2.3 Stabilize catalog AI sheet integration flake — 0556a3127
 - [x] 2.4 Stabilize shared EAV multi-value replacement after PR #2606 CI failure — 881d42dcc
 - [x] 2.4a Stabilize auth form hydration interactions exposed by full proof run 2 — 92ebbb417
-- [x] 2.4b Stabilize late `CrudForm` initialValues refresh and raw login synchronization after diagnostic full run — pending follow-up commit
+- [x] 2.4b Stabilize late `CrudForm` initialValues refresh and raw login synchronization after diagnostic full run — feee7b679
 - [ ] 2.5 Run two independent full ephemeral integration runs
 
 ### Phase 3: PR
 
 - [x] 3.1 Open stabilization PR against develop — 2606
 - [x] 3.2 Apply PR labels and summary comment — c03f44479
-- [ ] 3.3 Open follow-up stabilization PR after #2606 merge
+- [x] 3.3 Open follow-up stabilization PR after #2606 merge — 2613

--- a/.ai/runs/2026-06-05-ci-2425-stabilization.md
+++ b/.ai/runs/2026-06-05-ci-2425-stabilization.md
@@ -30,6 +30,9 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 - Full ephemeral proof run 1 log: `/tmp/ci-2425-full-ephemeral-run-1-after-eav.log` on app `http://127.0.0.1:46227`, DB `localhost:32865`, `--retries=0`: 1421 passed, 70 skipped, 0 failed in 20.9m. Included in-suite passes for `TC-CAT-CF-MULTI-EDIT-001`, `TC-CRM-CF-MULTI-EDIT-001`, `TC-LOCK-OSS-014`, and catalog AI sheet specs.
 - Full ephemeral proof run 2 attempt log: `/tmp/ci-2425-full-ephemeral-run-2-after-eav.log` on app `http://127.0.0.1:45155`, DB `localhost:32866`, invalid/not counted: `TC-AUTH-003` and `TC-AUTH-007` exposed auth form hydration races where the first filled field was reset before submit, so no valid login/reset POST could complete.
 - Auth hydration targeted rerun log after reset form readiness marker: `/tmp/ci-2425-auth-targeted.log` (2/2 passed with `--retries=0`: `TC-AUTH-003`, `TC-AUTH-007`) on fresh app `http://127.0.0.1:45035`, DB `localhost:32868`.
+- PR #2606 merged into `develop`; follow-up branch continues from merged `origin/develop` with only the remaining stabilization alignments.
+- Diagnostic full ephemeral run after PR #2606 fixes: `/tmp/ci-2425-full-ephemeral-run-2-after-auth.log` on app `http://127.0.0.1:45819`, DB `localhost:32870`, invalid/not counted because it used a pre-follow-up app bundle. It ended with exactly 3 failures (`TC-INT-004`, `TC-LOCK-OSS-014` CRM-01, `TC-LOCK-OSS-015` stale person edit) and 1419 passed / 69 skipped. This run proved the merged fixes held for auth reset, multi-value custom fields, catalog AI sheet specs, and the other OSS lock suites.
+- Follow-up targeted rerun log after `CrudForm` dirty-state and `TC-INT-004` login synchronization fixes: `/tmp/ci-2425-followup-targeted.log` (6 passed, 1 intentionally skipped, `--retries=0`) on fresh rebuilt app `http://127.0.0.1:45367`, DB `localhost:32872`.
 
 ## Implementation Plan
 
@@ -70,9 +73,11 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 - [x] 2.3 Stabilize catalog AI sheet integration flake — 0556a3127
 - [x] 2.4 Stabilize shared EAV multi-value replacement after PR #2606 CI failure — 881d42dcc
 - [x] 2.4a Stabilize auth form hydration interactions exposed by full proof run 2 — 92ebbb417
+- [x] 2.4b Stabilize late `CrudForm` initialValues refresh and raw login synchronization after diagnostic full run — pending follow-up commit
 - [ ] 2.5 Run two independent full ephemeral integration runs
 
 ### Phase 3: PR
 
 - [x] 3.1 Open stabilization PR against develop — 2606
 - [x] 3.2 Apply PR labels and summary comment — c03f44479
+- [ ] 3.3 Open follow-up stabilization PR after #2606 merge

--- a/packages/core/src/modules/core/__integration__/integration/TC-INT-004.spec.ts
+++ b/packages/core/src/modules/core/__integration__/integration/TC-INT-004.spec.ts
@@ -47,10 +47,17 @@ test.describe('TC-INT-004: User to Role to Permission to Access Verification', (
       limitedContext = ctx;
       const limitedPage = await ctx.newPage();
       await limitedPage.goto('/login');
-      await limitedPage.getByLabel('Email').fill(email);
-      await limitedPage.getByLabel('Password', { exact: true }).fill(password);
-      await limitedPage.getByLabel('Password', { exact: true }).press('Enter');
-      await limitedPage.waitForURL(/\/backend|\/login\?requireFeature=/, { timeout: 30_000 });
+      await limitedPage.waitForSelector('form[data-auth-ready="1"]', { state: 'visible', timeout: 30_000 });
+      const emailInput = limitedPage.getByLabel('Email');
+      const passwordInput = limitedPage.getByLabel('Password', { exact: true });
+      await emailInput.fill(email);
+      await expect(emailInput).toHaveValue(email);
+      await passwordInput.fill(password);
+      await expect(passwordInput).toHaveValue(password);
+      await Promise.all([
+        limitedPage.waitForURL(/\/backend|\/login\?requireFeature=/, { timeout: 30_000 }),
+        passwordInput.press('Enter'),
+      ]);
 
       if (/\/login\?requireFeature=/.test(limitedPage.url())) {
         await expect(limitedPage.getByText(/don't have access to this feature|permission/i).first()).toBeVisible();

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -560,6 +560,10 @@ function createDirtySnapshot(source: Record<string, unknown>): string {
   return JSON.stringify(normalizeDirtySnapshotValue(source) ?? {})
 }
 
+function createDirtyValueSnapshot(value: unknown): string {
+  return JSON.stringify(normalizeDirtySnapshotValue(value) ?? null)
+}
+
 const FIELDSET_ICON_COMPONENTS: Record<string, React.ComponentType<{ className?: string }>> = {
   layers: Layers,
   tag: Tag,
@@ -931,6 +935,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
   const clearDirtyState = React.useCallback((snapshotSource?: Record<string, unknown>) => {
     const source = snapshotSource ?? (valuesRef.current as Record<string, unknown>)
     dirtyBaselineSnapshotRef.current = createDirtySnapshot(source)
+    dirtyBaselineValuesRef.current = { ...source }
     userEditedFieldIdsRef.current.clear()
     isDirtyRef.current = false
     setHasUnsavedChanges(false)
@@ -2210,21 +2215,38 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     }
   }, [errors, formId])
 
+  const updateEditedFieldMarker = React.useCallback((
+    id: string,
+    nextValue: unknown,
+    baselineSource: Record<string, unknown> | undefined = dirtyBaselineValuesRef.current,
+  ) => {
+    if (
+      baselineSource &&
+      createDirtyValueSnapshot(baselineSource[id]) === createDirtyValueSnapshot(nextValue)
+    ) {
+      userEditedFieldIdsRef.current.delete(id)
+      return
+    }
+    userEditedFieldIdsRef.current.add(id)
+  }, [])
+
   const setValue = React.useCallback((id: string, nextValue: unknown) => {
     let nextData: CrudFormValues<TValues> | null = null
     let nextDirty: boolean | null = null
     const currentValue = (valuesRef.current as Record<string, unknown>)[id]
     if (!Object.is(currentValue, nextValue)) {
-      userEditedFieldIdsRef.current.add(id)
+      updateEditedFieldMarker(id, nextValue)
     }
     setValues((prev) => {
       if (Object.is(prev[id], nextValue)) return prev
-      userEditedFieldIdsRef.current.add(id)
+      const baselineSource = dirtyBaselineValuesRef.current ?? (prev as Record<string, unknown>)
+      updateEditedFieldMarker(id, nextValue, baselineSource)
       nextData = { ...prev, [id]: nextValue } as CrudFormValues<TValues>
       valuesRef.current = nextData
       if (!(embedded && !trackDirtyWhenEmbedded)) {
         const baseline = dirtyBaselineSnapshotRef.current ?? createDirtySnapshot(prev as Record<string, unknown>)
         dirtyBaselineSnapshotRef.current = baseline
+        dirtyBaselineValuesRef.current = baselineSource
         nextDirty = createDirtySnapshot(nextData as Record<string, unknown>) !== baseline
       }
       return nextData
@@ -2297,7 +2319,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     }).catch((err) => {
       console.error('[CrudForm] Error in onFieldChange:', err)
     })
-  }, [embedded, extendedInjectionEventsEnabled, flash, t, trackDirtyWhenEmbedded, translateValidationMessage, triggerInjectionEvent])
+  }, [embedded, extendedInjectionEventsEnabled, flash, t, trackDirtyWhenEmbedded, translateValidationMessage, triggerInjectionEvent, updateEditedFieldMarker])
 
   const onBlurRequest = React.useCallback((fieldId: string) => {
     void validateFieldOnBlur(fieldId)
@@ -2325,6 +2347,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
 
   const appliedInitialValuesSnapshotRef = React.useRef<string | undefined>(undefined)
   const dirtyBaselineSnapshotRef = React.useRef<string | undefined>(undefined)
+  const dirtyBaselineValuesRef = React.useRef<Record<string, unknown> | undefined>(undefined)
   const userEditedFieldIdsRef = React.useRef<Set<string>>(new Set())
   React.useLayoutEffect(() => {
     if (!initialValues) return
@@ -2395,6 +2418,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
       // baseline so the edit stays dirty until save/discard. Root cause of the flaky
       // optimistic-lock stale-edit conflicts (#2055 / TC-LOCK-OSS-015 / TC-LOCK-OSS-029).
       dirtyBaselineSnapshotRef.current = createDirtySnapshot(mergedValues as Record<string, unknown>)
+      dirtyBaselineValuesRef.current = { ...(mergedValues as Record<string, unknown>) }
     }
     if (!extendedInjectionEventsEnabled || !mergedValues) return
     let cancelled = false
@@ -2411,6 +2435,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
         // edit — it would overwrite the user's unsaved changes and reset dirty.
         if (isDirtyRef.current) return
         dirtyBaselineSnapshotRef.current = createDirtySnapshot(transformed as Record<string, unknown>)
+        dirtyBaselineValuesRef.current = { ...(transformed as Record<string, unknown>) }
         setValues(transformed as CrudFormValues<TValues>)
       } catch (err) {
         console.error('[CrudForm] Error in transformDisplayData:', err)
@@ -2481,6 +2506,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     // Update the dirty baseline so the form doesn't appear dirty from defaults
     if (mergedValues) {
       dirtyBaselineSnapshotRef.current = createDirtySnapshot(mergedValues as Record<string, unknown>)
+      dirtyBaselineValuesRef.current = { ...(mergedValues as Record<string, unknown>) }
     }
   }, [isLoading, initialValuesHasId, cfDefinitions, customEntity])
 

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -931,6 +931,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
   const clearDirtyState = React.useCallback((snapshotSource?: Record<string, unknown>) => {
     const source = snapshotSource ?? (valuesRef.current as Record<string, unknown>)
     dirtyBaselineSnapshotRef.current = createDirtySnapshot(source)
+    userEditedFieldIdsRef.current.clear()
     isDirtyRef.current = false
     setHasUnsavedChanges(false)
   }, [])
@@ -2212,8 +2213,13 @@ export function CrudForm<TValues extends Record<string, unknown>>({
   const setValue = React.useCallback((id: string, nextValue: unknown) => {
     let nextData: CrudFormValues<TValues> | null = null
     let nextDirty: boolean | null = null
+    const currentValue = (valuesRef.current as Record<string, unknown>)[id]
+    if (!Object.is(currentValue, nextValue)) {
+      userEditedFieldIdsRef.current.add(id)
+    }
     setValues((prev) => {
       if (Object.is(prev[id], nextValue)) return prev
+      userEditedFieldIdsRef.current.add(id)
       nextData = { ...prev, [id]: nextValue } as CrudFormValues<TValues>
       valuesRef.current = nextData
       if (!(embedded && !trackDirtyWhenEmbedded)) {
@@ -2319,6 +2325,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
 
   const appliedInitialValuesSnapshotRef = React.useRef<string | undefined>(undefined)
   const dirtyBaselineSnapshotRef = React.useRef<string | undefined>(undefined)
+  const userEditedFieldIdsRef = React.useRef<Set<string>>(new Set())
   React.useLayoutEffect(() => {
     if (!initialValues) return
     const snapshot = JSON.stringify({
@@ -2340,10 +2347,17 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     let hadUnsavedEdits = false
     setValues((prev) => {
       const priorBaseline = dirtyBaselineSnapshotRef.current
+      const editedFieldIds = userEditedFieldIdsRef.current
       hadUnsavedEdits =
+        editedFieldIds.size > 0 ||
         priorBaseline !== undefined &&
         createDirtySnapshot(prev as Record<string, unknown>) !== priorBaseline
-      const merged = { ...prev, ...initialValues } as CrudFormValues<TValues>
+      const merged = { ...prev } as CrudFormValues<TValues>
+      const mergedRecord = merged as Record<string, unknown>
+      for (const [key, value] of Object.entries(initialValues as Record<string, unknown>)) {
+        if (editedFieldIds.has(key)) continue
+        mergedRecord[key] = value
+      }
       for (const definition of injectedFieldDefinitions) {
         if (merged[definition.id] !== undefined) continue
         const extracted = readByDotPath(initialRecord, definition.id)

--- a/packages/ui/src/backend/__tests__/CrudForm.navigation.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.navigation.test.tsx
@@ -132,6 +132,56 @@ describe('CrudForm unsaved navigation guard', () => {
     expect(onDirtyChange).toHaveBeenLastCalledWith(true)
   })
 
+  it('accepts late initialValues refresh after the edited field is reverted to baseline', async () => {
+    const onDirtyChange = jest.fn()
+    const view = renderWithProviders(
+      <CrudForm
+        title="Form"
+        fields={fields}
+        initialValues={{ name: 'Alice' }}
+        embedded
+        trackDirtyWhenEmbedded
+        onDirtyChange={onDirtyChange}
+        onSubmit={() => {}}
+      />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+          'ui.forms.confirmUnsavedChanges': 'Unsaved changes',
+        },
+      },
+    )
+
+    const input = view.container.querySelector('[data-crud-field-id="name"] input[type="text"]') as HTMLInputElement
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Alice updated' } })
+    })
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true)
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Alice' } })
+      fireEvent.blur(input)
+    })
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false)
+
+    await act(async () => {
+      view.rerender(
+        <CrudForm
+          title="Form"
+          fields={fields}
+          initialValues={{ name: 'Alice from server' }}
+          embedded
+          trackDirtyWhenEmbedded
+          onDirtyChange={onDirtyChange}
+          onSubmit={() => {}}
+        />,
+      )
+    })
+
+    expect(input).toHaveValue('Alice from server')
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false)
+  })
+
   it('blocks router-driven history pushes until the user confirms leaving', async () => {
     confirmDialogMock.mockResolvedValueOnce(false)
 

--- a/packages/ui/src/backend/__tests__/CrudForm.navigation.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.navigation.test.tsx
@@ -88,6 +88,50 @@ describe('CrudForm unsaved navigation guard', () => {
     expect(event.defaultPrevented).toBe(true)
   })
 
+  it('keeps a first edit dirty when late initialValues refresh after the user types', async () => {
+    const onDirtyChange = jest.fn()
+    const view = renderWithProviders(
+      <CrudForm
+        title="Form"
+        fields={fields}
+        initialValues={{ name: 'Alice' }}
+        embedded
+        trackDirtyWhenEmbedded
+        onDirtyChange={onDirtyChange}
+        onSubmit={() => {}}
+      />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+          'ui.forms.confirmUnsavedChanges': 'Unsaved changes',
+        },
+      },
+    )
+
+    const input = view.container.querySelector('[data-crud-field-id="name"] input[type="text"]') as HTMLInputElement
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Alice updated' } })
+    })
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true)
+
+    await act(async () => {
+      view.rerender(
+        <CrudForm
+          title="Form"
+          fields={fields}
+          initialValues={{ name: 'Alice from server' }}
+          embedded
+          trackDirtyWhenEmbedded
+          onDirtyChange={onDirtyChange}
+          onSubmit={() => {}}
+        />,
+      )
+    })
+
+    expect(input).toHaveValue('Alice updated')
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true)
+  })
+
   it('blocks router-driven history pushes until the user confirms leaving', async () => {
     confirmDialogMock.mockResolvedValueOnce(false)
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #2606 for the remaining stabilization failures from the post-merge diagnostic full ephemeral run.

Fixes:
- Preserves `CrudForm` user edits when late `initialValues` refreshes arrive after the first edit, keeping embedded dirty state and shared header Save enabled.
- Synchronizes the raw secondary login flow in `TC-INT-004` with the auth readiness marker and Enter-triggered navigation.
- Carries forward `.ai/runs/2026-06-05-ci-2425-stabilization.md` recovery/progress notes.

## Evidence

- Diagnostic full run before this follow-up: `/tmp/ci-2425-full-ephemeral-run-2-after-auth.log` ended with exactly 3 failures: `TC-INT-004`, `TC-LOCK-OSS-014` CRM-01, `TC-LOCK-OSS-015` stale person edit; 1419 passed / 69 skipped.
- `git diff --check`: passed.
- `yarn workspace @open-mercato/ui test packages/ui/src/backend/__tests__/CrudForm.navigation.test.tsx --runInBand`: 6 passed.
- `yarn typecheck`: passed.
- Fresh rebuilt targeted integration run on `http://127.0.0.1:45367`, DB `localhost:32872`: `/tmp/ci-2425-followup-targeted.log`, 6 passed / 1 skipped with `--retries=0`.

## Remaining validation

- GitHub CI for this PR.
- Two independent full ephemeral integration runs from the final follow-up branch.
