### PR TITLE
test(ci): stabilize currency integration fixtures

### DIFF
--- a/.ai/runs/2026-06-05-ci-2425-stabilization.md
+++ b/.ai/runs/2026-06-05-ci-2425-stabilization.md
@@ -33,6 +33,9 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 - PR #2606 merged into `develop`; follow-up branch continues from merged `origin/develop` with only the remaining stabilization alignments.
 - Diagnostic full ephemeral run after PR #2606 fixes: `/tmp/ci-2425-full-ephemeral-run-2-after-auth.log` on app `http://127.0.0.1:45819`, DB `localhost:32870`, invalid/not counted because it used a pre-follow-up app bundle. It ended with exactly 3 failures (`TC-INT-004`, `TC-LOCK-OSS-014` CRM-01, `TC-LOCK-OSS-015` stale person edit) and 1419 passed / 69 skipped. This run proved the merged fixes held for auth reset, multi-value custom fields, catalog AI sheet specs, and the other OSS lock suites.
 - Follow-up targeted rerun log after `CrudForm` dirty-state and `TC-INT-004` login synchronization fixes: `/tmp/ci-2425-followup-targeted.log` (6 passed, 1 intentionally skipped, `--retries=0`) on fresh rebuilt app `http://127.0.0.1:45367`, DB `localhost:32872`.
+- Follow-up full ephemeral proof run 1 log: `/tmp/ci-2425-followup-full-run-1.log` on app `http://127.0.0.1:45367`, DB `localhost:32872`, `--retries=0`: 1441 passed, 70 skipped, 0 failed in 21.4m. Covered `TC-INT-004`, `TC-CRM-CF-MULTI-EDIT-001`, `TC-LOCK-OSS-014`, `TC-LOCK-OSS-015`, currency lock specs, catalog AI sheet specs, and auth reset specs.
+- Follow-up full ephemeral proof run 2 attempt log: `/tmp/ci-2425-followup-full-run-2.log` on app `http://127.0.0.1:44713`, DB `localhost:32873`, invalid/not counted: `TC-CUR-ATOMIC-VERIFY` hit the three-letter currency code namespace collision exposed by soft-delete-aware DB uniqueness. The run was stopped after the known failure was patched, so later connection errors are from the stopped app and are not counted.
+- Currency fixture targeted rerun log after aligning remaining ad hoc currency code generators to the shared full-namespace allocator: `/tmp/ci-2425-followup-targeted-currency.log` (26 passed, 1 intentionally skipped, `--retries=0`) on fresh rebuilt app `http://127.0.0.1:46205`, DB `localhost:32875`.
 
 ## Implementation Plan
 
@@ -74,6 +77,7 @@ Stabilize the develop branch feeding PR #2425 by fixing the failures observed in
 - [x] 2.4 Stabilize shared EAV multi-value replacement after PR #2606 CI failure — 881d42dcc
 - [x] 2.4a Stabilize auth form hydration interactions exposed by full proof run 2 — 92ebbb417
 - [x] 2.4b Stabilize late `CrudForm` initialValues refresh and raw login synchronization after diagnostic full run — feee7b679
+- [x] 2.4c Stabilize currency integration fixtures against soft-delete-visible code uniqueness
 - [ ] 2.5 Run two independent full ephemeral integration runs
 
 ### Phase 3: PR

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-ATOMIC-001.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-ATOMIC-001.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type APIRequestContext } from '@playwright/test';
 import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { generateUniqueCurrencyCode } from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures';
 import { getTokenContext } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
 
 /**
@@ -17,10 +18,7 @@ import { getTokenContext } from '@open-mercato/core/modules/core/__integration__
  * is always single-valued, and a rejected create leaves no partial row.
  */
 
-const randomCode = (): string => {
-  const letter = () => String.fromCharCode(65 + Math.floor(Math.random() * 26));
-  return `Q${letter()}${letter()}`;
-};
+const randomCode = generateUniqueCurrencyCode;
 
 type CurrencyRow = { id: string; code: string; isBase: boolean };
 

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-ATOMIC-VERIFY.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-ATOMIC-VERIFY.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test';
 import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { generateUniqueCurrencyCode } from '@open-mercato/core/helpers/integration/currenciesFixtures';
 import { getTokenContext } from '@open-mercato/core/helpers/integration/generalFixtures';
 
 /**
@@ -36,10 +37,7 @@ type CurrencyRow = {
   isActive: boolean;
 };
 
-const randomCode = (): string => {
-  const letter = () => String.fromCharCode(65 + Math.floor(Math.random() * 26));
-  return `Q${letter()}${letter()}`;
-};
+const randomCode = generateUniqueCurrencyCode;
 
 function readUndoToken(res: APIResponse): string {
   const header = res.headers()['x-om-operation'] ?? '';

--- a/packages/core/src/modules/currencies/__integration__/TC-CURR-2453.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CURR-2453.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type APIRequestContext } from '@playwright/test';
 import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { generateUniqueCurrencyCode } from '@open-mercato/core/helpers/integration/currenciesFixtures';
 import { getTokenContext } from '@open-mercato/core/helpers/integration/generalFixtures';
 
 /**
@@ -40,10 +41,7 @@ type CurrencyRow = {
   isActive: boolean;
 };
 
-function randomCode(): string {
-  const letter = () => String.fromCharCode(65 + Math.floor(Math.random() * 26));
-  return `Q${letter()}${letter()}`;
-}
+const randomCode = generateUniqueCurrencyCode;
 
 async function getById(
   request: APIRequestContext,

--- a/packages/core/src/modules/currencies/__integration__/TC-LOCK-OSS-040.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-LOCK-OSS-040.spec.ts
@@ -4,6 +4,7 @@ import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/he
 import {
   createCurrencyFixture,
   deleteCurrenciesEntityIfExists,
+  generateUniqueCurrencyCode,
 } from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures'
 import {
   bumpRecordViaApi,
@@ -25,12 +26,7 @@ import { fillControlledInput } from '@open-mercato/core/modules/core/__integrati
  * `packages/core/src/modules/sales/__integration__/__concurrent_edit_pattern.md`.
  */
 
-function randomCode(): string {
-  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-  let out = ''
-  for (let i = 0; i < 3; i += 1) out += letters[Math.floor(Math.random() * letters.length)]
-  return out
-}
+const randomCode = generateUniqueCurrencyCode
 
 test.describe('TC-LOCK-OSS-040: currency edit optimistic-lock conflict bar', () => {
   test('stale currency edit shows the conflict bar; clean edit does not', async ({ page }) => {

--- a/packages/core/src/modules/currencies/__integration__/TC-LOCK-OSS-045.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-LOCK-OSS-045.spec.ts
@@ -4,6 +4,7 @@ import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/he
 import {
   createCurrencyFixture,
   deleteCurrenciesEntityIfExists,
+  generateUniqueCurrencyCode,
 } from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures'
 import {
   bumpRecordViaApi,
@@ -44,12 +45,7 @@ import { fillControlledInput } from '@open-mercato/core/modules/core/__integrati
 
 const CURRENCY_API_BASE = '/api/currencies/currencies'
 
-function randomCode(): string {
-  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-  let out = ''
-  for (let i = 0; i < 3; i += 1) out += letters[Math.floor(Math.random() * letters.length)]
-  return out
-}
+const randomCode = generateUniqueCurrencyCode
 
 /**
  * Create a currency fixture with a unique three-letter code, retrying on the

--- a/packages/core/src/modules/currencies/__integration__/TC-LOCK-OSS-046.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-LOCK-OSS-046.spec.ts
@@ -3,6 +3,7 @@ import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__inte
 import {
   createCurrencyFixture,
   deleteCurrenciesEntityIfExists,
+  generateUniqueCurrencyCode,
 } from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures'
 import { createCompanyFixture, deleteEntityIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
 import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth'
@@ -45,12 +46,7 @@ import {
 
 const CURRENCY_API_BASE = '/api/currencies/currencies'
 
-function randomCode(): string {
-  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-  let out = ''
-  for (let i = 0; i < 3; i += 1) out += letters[Math.floor(Math.random() * letters.length)]
-  return out
-}
+const randomCode = generateUniqueCurrencyCode
 
 test.describe('TC-LOCK-OSS-046: optimistic-lock negative / additive contract', () => {
   test('NEG-01: a header-less PUT and DELETE always succeed (no 409)', async ({ page }) => {


### PR DESCRIPTION
## Summary\n- Align remaining currency integration specs with the shared unique currency-code allocator.\n- Avoid ad hoc tiny currency code namespaces that collide with soft-deleted rows still covered by the DB unique constraint.\n- Record the follow-up evidence in the CI stabilization run ledger.\n\n## Validation\n- git diff --check\n- npx playwright test --config .ai/qa/tests/playwright.config.ts --retries=0 packages/core/src/modules/currencies/__integration__/TC-CUR-ATOMIC-001.spec.ts packages/core/src/modules/currencies/__integration__/TC-CUR-ATOMIC-VERIFY.spec.ts packages/core/src/modules/currencies/__integration__/TC-CURR-2453.spec.ts packages/core/src/modules/currencies/__integration__/TC-LOCK-OSS-040.spec.ts packages/core/src/modules/currencies/__integration__/TC-LOCK-OSS-045.spec.ts packages/core/src/modules/currencies/__integration__/TC-LOCK-OSS-046.spec.ts packages/core/src/modules/core/__integration__/integration/TC-INT-004.spec.ts packages/core/src/modules/customers/__integration__/TC-CRM-CF-MULTI-EDIT-001.spec.ts packages/core/src/modules/customers/__integration__/TC-LOCK-OSS-014.spec.ts packages/core/src/modules/customers/__integration__/TC-LOCK-OSS-015.spec.ts (26 passed, 1 skipped, retries disabled)\n\nFull ephemeral proof runs are continuing after this PR opens.