### PR TITLE
fix(catalog,customers): hydrate saved select values omitted by capped option lists (#2615)

### DIFF
--- a/packages/core/src/modules/catalog/backend/catalog/products/[id]/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[id]/page.tsx
@@ -90,6 +90,10 @@ import {
   type CatalogProductOptionSchema,
   type CatalogProductType,
 } from "@open-mercato/core/modules/catalog/data/types";
+import {
+  normalizeTaxRateSummary,
+  useEnsureSelectedTaxRates,
+} from "@open-mercato/core/modules/catalog/components/products/taxRateOptions";
 import { MetadataEditor } from "@open-mercato/core/modules/catalog/components/products/MetadataEditor";
 import {
   buildAttachmentImageUrl,
@@ -519,35 +523,14 @@ export default function EditCatalogProductPage({
           fallback: { items: [] },
         });
         const items = Array.isArray(payload.items) ? payload.items : [];
+        const unnamedLabel = t(
+          "catalog.products.create.taxRates.unnamed",
+          "Untitled tax rate",
+        );
         setTaxRates(
-          items.map((item) => {
-            const rawRate =
-              typeof item.rate === "number"
-                ? item.rate
-                : Number(item.rate ?? Number.NaN);
-            return {
-              id: String(item.id),
-              name:
-                typeof item.name === "string" && item.name.trim().length
-                  ? item.name
-                  : t(
-                      "catalog.products.create.taxRates.unnamed",
-                      "Untitled tax rate",
-                    ),
-              code:
-                typeof item.code === "string" && item.code.trim().length
-                  ? item.code
-                  : null,
-              rate: Number.isFinite(rawRate) ? rawRate : null,
-              isDefault: Boolean(
-                typeof item.isDefault === "boolean"
-                  ? item.isDefault
-                  : typeof item.is_default === "boolean"
-                    ? item.is_default
-                    : false,
-              ),
-            };
-          }),
+          items
+            .map((item) => normalizeTaxRateSummary(item, unnamedLabel))
+            .filter((rate): rate is TaxRateSummary => rate !== null),
         );
       } catch (err) {
         console.error("sales.tax-rates.fetch failed", err);
@@ -556,6 +539,20 @@ export default function EditCatalogProductPage({
     };
     loadTaxRates().catch(() => {});
   }, [t]);
+
+  useEnsureSelectedTaxRates({
+    taxRates,
+    setTaxRates,
+    selectedIds: [initialValues?.taxRateId ?? null],
+    unnamedLabel: t(
+      "catalog.products.create.taxRates.unnamed",
+      "Untitled tax rate",
+    ),
+    errorMessage: t(
+      "catalog.products.create.taxRates.error",
+      "Failed to load tax rates.",
+    ),
+  });
 
   React.useEffect(() => {
     if (!productId) {

--- a/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/[variantId]/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/[variantId]/page.tsx
@@ -33,6 +33,10 @@ import {
 } from '@open-mercato/core/modules/catalog/components/products/productForm'
 import { parseNumericInput } from '@open-mercato/core/modules/catalog/components/products/productFormUtils'
 import {
+  normalizeTaxRateSummary,
+  useEnsureSelectedTaxRates,
+} from '@open-mercato/core/modules/catalog/components/products/taxRateOptions'
+import {
   VariantBasicsSection,
   VariantOptionValuesSection,
   VariantDimensionsSection,
@@ -145,26 +149,11 @@ export default function EditVariantPage({ params }: { params?: { productId?: str
           { errorMessage: t('catalog.products.create.taxRates.error', 'Failed to load tax rates.'), fallback: { items: [] } },
         )
         const items = Array.isArray(payload.items) ? payload.items : []
+        const unnamedLabel = t('catalog.products.create.taxRates.unnamed', 'Untitled tax rate')
         setTaxRates(
-          items.map((item) => {
-            const rawRate = typeof item.rate === 'number' ? item.rate : Number(item.rate ?? Number.NaN)
-            return {
-              id: String(item.id),
-              name:
-                typeof item.name === 'string' && item.name.trim().length
-                  ? item.name
-                  : t('catalog.products.create.taxRates.unnamed', 'Untitled tax rate'),
-              code: typeof item.code === 'string' && item.code.trim().length ? item.code : null,
-              rate: Number.isFinite(rawRate) ? rawRate : null,
-              isDefault: Boolean(
-                typeof item.isDefault === 'boolean'
-                  ? item.isDefault
-                  : typeof item.is_default === 'boolean'
-                    ? item.is_default
-                    : false,
-              ),
-            }
-          }),
+          items
+            .map((item) => normalizeTaxRateSummary(item, unnamedLabel))
+            .filter((rate): rate is TaxRateSummary => rate !== null),
         )
       } catch (err) {
         console.error('sales.tax-rates.fetch failed', err)
@@ -173,6 +162,14 @@ export default function EditVariantPage({ params }: { params?: { productId?: str
     }
     loadTaxRates().catch(() => {})
   }, [t])
+
+  useEnsureSelectedTaxRates({
+    taxRates,
+    setTaxRates,
+    selectedIds: [initialValues?.taxRateId ?? null, productTaxRateId],
+    unnamedLabel: t('catalog.products.create.taxRates.unnamed', 'Untitled tax rate'),
+    errorMessage: t('catalog.products.create.taxRates.error', 'Failed to load tax rates.'),
+  })
 
   React.useEffect(() => {
     if (!variantId || isCreateSentinel || priceKinds.length === 0) return

--- a/packages/core/src/modules/catalog/components/products/__tests__/taxRateOptions.test.tsx
+++ b/packages/core/src/modules/catalog/components/products/__tests__/taxRateOptions.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { renderHook, waitFor } from '@testing-library/react'
+
+const mockReadApiResultOrThrow = jest.fn()
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  readApiResultOrThrow: (...args: unknown[]) => mockReadApiResultOrThrow(...args),
+}))
+
+import {
+  collectMissingTaxRateIds,
+  mergeTaxRateSummaries,
+  normalizeTaxRateSummary,
+  useEnsureSelectedTaxRates,
+} from '../taxRateOptions'
+import type { TaxRateSummary } from '../productForm'
+
+const rate = (id: string, name = id): TaxRateSummary => ({
+  id,
+  name,
+  code: null,
+  rate: 23,
+  isDefault: false,
+})
+
+describe('normalizeTaxRateSummary', () => {
+  it('maps snake_case and camelCase API items into the summary shape', () => {
+    expect(
+      normalizeTaxRateSummary(
+        { id: 'tax-1', name: 'VAT', code: 'vat', rate: 23, is_default: true },
+        'Untitled',
+      ),
+    ).toEqual({ id: 'tax-1', name: 'VAT', code: 'vat', rate: 23, isDefault: true })
+  })
+
+  it('falls back to the unnamed label and null code/rate', () => {
+    expect(normalizeTaxRateSummary({ id: 'tax-2', rate: 'nope' }, 'Untitled')).toEqual({
+      id: 'tax-2',
+      name: 'Untitled',
+      code: null,
+      rate: null,
+      isDefault: false,
+    })
+  })
+
+  it('returns null for items without an id', () => {
+    expect(normalizeTaxRateSummary({ name: 'no id' }, 'Untitled')).toBeNull()
+    expect(normalizeTaxRateSummary(null, 'Untitled')).toBeNull()
+  })
+})
+
+describe('collectMissingTaxRateIds', () => {
+  it('returns selected ids not present in the loaded list', () => {
+    const loaded = [rate('a'), rate('b')]
+    expect(collectMissingTaxRateIds(loaded, ['a', 'c', null, undefined, 'd', 'd'])).toEqual([
+      'c',
+      'd',
+    ])
+  })
+
+  it('returns an empty array when every selection is present', () => {
+    expect(collectMissingTaxRateIds([rate('a')], ['a', null])).toEqual([])
+  })
+})
+
+describe('mergeTaxRateSummaries', () => {
+  it('appends new entries and de-duplicates by id', () => {
+    const merged = mergeTaxRateSummaries([rate('a')], [rate('a', 'changed'), rate('b')])
+    expect(merged.map((entry) => entry.id)).toEqual(['a', 'b'])
+    // existing entry is preserved (not overwritten by the incoming duplicate)
+    expect(merged[0].name).toBe('a')
+  })
+
+  it('returns the existing list unchanged when there is nothing to merge', () => {
+    const existing = [rate('a')]
+    expect(mergeTaxRateSummaries(existing, [])).toBe(existing)
+  })
+})
+
+describe('useEnsureSelectedTaxRates', () => {
+  beforeEach(() => {
+    mockReadApiResultOrThrow.mockReset()
+  })
+
+  it('fetches selected ids missing from the capped list and merges them', async () => {
+    mockReadApiResultOrThrow.mockResolvedValue({
+      items: [{ id: 'omitted', name: 'Omitted VAT', code: 'om', rate: 8, is_default: false }],
+    })
+    const merged: TaxRateSummary[][] = []
+    const taxRates = [rate('loaded')]
+    const setTaxRates = ((updater: (prev: TaxRateSummary[]) => TaxRateSummary[]) => {
+      const next = updater(taxRates)
+      merged.push(next)
+    }) as React.Dispatch<React.SetStateAction<TaxRateSummary[]>>
+
+    renderHook(() =>
+      useEnsureSelectedTaxRates({
+        taxRates,
+        setTaxRates,
+        selectedIds: ['loaded', 'omitted'],
+        unnamedLabel: 'Untitled',
+        errorMessage: 'failed',
+      }),
+    )
+
+    await waitFor(() => expect(merged.length).toBeGreaterThan(0))
+    const url = mockReadApiResultOrThrow.mock.calls[0][0] as string
+    expect(url).toContain('/api/sales/tax-rates?ids=omitted')
+    expect(merged[0].map((entry) => entry.id)).toEqual(['loaded', 'omitted'])
+  })
+
+  it('does not fetch when every selection is already present', async () => {
+    renderHook(() =>
+      useEnsureSelectedTaxRates({
+        taxRates: [rate('loaded')],
+        setTaxRates: jest.fn(),
+        selectedIds: ['loaded', null],
+        unnamedLabel: 'Untitled',
+        errorMessage: 'failed',
+      }),
+    )
+    await Promise.resolve()
+    expect(mockReadApiResultOrThrow).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/catalog/components/products/taxRateOptions.ts
+++ b/packages/core/src/modules/catalog/components/products/taxRateOptions.ts
@@ -1,0 +1,129 @@
+import * as React from 'react'
+import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import type { TaxRateSummary } from './productForm'
+
+type TaxRateListResult = { items?: unknown[] }
+
+/**
+ * Normalizes a raw tax-rate API item into the `TaxRateSummary` shape used by the
+ * product/variant select controls. Mirrors the inline mapping used by the
+ * capped list loaders so seeded (fetched-by-id) entries are shaped identically.
+ */
+export function normalizeTaxRateSummary(item: unknown, unnamedLabel: string): TaxRateSummary | null {
+  if (!item || typeof item !== 'object') return null
+  const record = item as Record<string, unknown>
+  const id =
+    typeof record.id === 'string' && record.id.length
+      ? record.id
+      : record.id != null
+        ? String(record.id)
+        : null
+  if (!id) return null
+  const rawRate = typeof record.rate === 'number' ? record.rate : Number(record.rate ?? Number.NaN)
+  const name =
+    typeof record.name === 'string' && record.name.trim().length ? record.name : unnamedLabel
+  const code =
+    typeof record.code === 'string' && record.code.trim().length ? record.code : null
+  const isDefault = Boolean(
+    typeof record.isDefault === 'boolean'
+      ? record.isDefault
+      : typeof record.is_default === 'boolean'
+        ? record.is_default
+        : false,
+  )
+  return { id, name, code, rate: Number.isFinite(rawRate) ? rawRate : null, isDefault }
+}
+
+/**
+ * Returns the subset of selected ids that are not present in the loaded tax-rate
+ * list. These are the persisted values that would render blank because no
+ * matching `SelectItem` exists for them.
+ */
+export function collectMissingTaxRateIds(
+  taxRates: TaxRateSummary[],
+  selectedIds: Array<string | null | undefined>,
+): string[] {
+  const present = new Set(taxRates.map((rate) => rate.id))
+  const missing = new Set<string>()
+  for (const id of selectedIds) {
+    if (typeof id === 'string' && id.length && !present.has(id)) missing.add(id)
+  }
+  return Array.from(missing)
+}
+
+/**
+ * Merges fetched tax rates into the existing list, de-duplicating by id and
+ * keeping the existing ordering (capped list first, seeded entries appended).
+ */
+export function mergeTaxRateSummaries(
+  existing: TaxRateSummary[],
+  incoming: TaxRateSummary[],
+): TaxRateSummary[] {
+  if (!incoming.length) return existing
+  const byId = new Map<string, TaxRateSummary>()
+  for (const rate of existing) byId.set(rate.id, rate)
+  for (const rate of incoming) {
+    if (!byId.has(rate.id)) byId.set(rate.id, rate)
+  }
+  return Array.from(byId.values())
+}
+
+export type UseEnsureSelectedTaxRatesArgs = {
+  taxRates: TaxRateSummary[]
+  setTaxRates: React.Dispatch<React.SetStateAction<TaxRateSummary[]>>
+  selectedIds: Array<string | null | undefined>
+  unnamedLabel: string
+  errorMessage: string
+}
+
+/**
+ * Ensures persisted tax-rate selections survive capped option lists. When a
+ * selected id is missing from the loaded `taxRates` (e.g. the saved record sorts
+ * past the first page), this fetches the missing records by id via the CRUD
+ * `?ids=` filter and merges them into the option list so controlled selects
+ * render their saved label instead of a blank/placeholder trigger.
+ */
+export function useEnsureSelectedTaxRates({
+  taxRates,
+  setTaxRates,
+  selectedIds,
+  unnamedLabel,
+  errorMessage,
+}: UseEnsureSelectedTaxRatesArgs): void {
+  const requestedRef = React.useRef<Set<string>>(new Set())
+  const selectedKey = selectedIds
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    .sort()
+    .join(',')
+
+  React.useEffect(() => {
+    const selected = selectedKey.length ? selectedKey.split(',') : []
+    const missing = collectMissingTaxRateIds(taxRates, selected).filter(
+      (id) => !requestedRef.current.has(id),
+    )
+    if (!missing.length) return
+    for (const id of missing) requestedRef.current.add(id)
+    let cancelled = false
+    void (async () => {
+      try {
+        const payload = await readApiResultOrThrow<TaxRateListResult>(
+          `/api/sales/tax-rates?ids=${encodeURIComponent(missing.join(','))}&pageSize=200`,
+          undefined,
+          { errorMessage, fallback: { items: [] } },
+        )
+        const items = Array.isArray(payload.items) ? payload.items : []
+        const normalized = items
+          .map((item) => normalizeTaxRateSummary(item, unnamedLabel))
+          .filter((rate): rate is TaxRateSummary => rate !== null)
+        if (!cancelled && normalized.length) {
+          setTaxRates((prev) => mergeTaxRateSummaries(prev, normalized))
+        }
+      } catch (err) {
+        console.error('sales.tax-rates.ensure-selected failed', err)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [selectedKey, taxRates, setTaxRates, unnamedLabel, errorMessage])
+}

--- a/packages/core/src/modules/customers/components/__tests__/CompanySelectField.test.tsx
+++ b/packages/core/src/modules/customers/components/__tests__/CompanySelectField.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+// Radix Select uses pointer capture / scrollIntoView APIs that jsdom lacks.
+if (typeof window !== 'undefined') {
+  if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false
+  if (!Element.prototype.releasePointerCapture)
+    Element.prototype.releasePointerCapture = () => undefined
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => undefined
+}
+
+const mockReadApiResultOrThrow = jest.fn()
+const mockApiCallOrThrow = jest.fn()
+const mockApiCall = jest.fn()
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  readApiResultOrThrow: (...args: unknown[]) => mockReadApiResultOrThrow(...args),
+  apiCallOrThrow: (...args: unknown[]) => mockApiCallOrThrow(...args),
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+}))
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({ flash: jest.fn() }))
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({}))
+jest.mock('../AddressTiles', () => ({ CustomerAddressTiles: () => null }))
+jest.mock('../detail/RolesSection', () => ({ RolesSection: () => null }))
+jest.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({}) }))
+jest.mock('@open-mercato/core/modules/dictionaries/components/DictionaryEntrySelect', () => ({
+  DictionaryEntrySelect: () => null,
+  __esModule: true,
+}))
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({ useT: () => (k: string, f?: string) => f ?? k }))
+
+import { CompanySelectField } from '../formConfig'
+
+const labels = {
+  placeholder: 'Select company',
+  addLabel: 'Add company',
+  dialogTitle: 'Add company',
+  inputLabel: 'Name',
+  inputPlaceholder: 'Name',
+  emptyError: 'Required',
+  cancelLabel: 'Cancel',
+  saveLabel: 'Save',
+  errorLoad: 'Failed to load',
+  errorSave: 'Failed to save',
+  loadingLabel: 'Loading',
+}
+
+const cappedList = {
+  items: [
+    { id: 'co-visible', display_name: 'Visible Company' },
+  ],
+}
+
+describe('CompanySelectField', () => {
+  beforeEach(() => {
+    mockReadApiResultOrThrow.mockReset()
+    mockApiCallOrThrow.mockReset()
+    mockApiCall.mockReset()
+  })
+
+  it('seeds a saved company missing from the capped list via the ?ids= filter', async () => {
+    mockReadApiResultOrThrow.mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('ids=co-omitted')) {
+        return Promise.resolve({ items: [{ id: 'co-omitted', display_name: 'Omitted Company' }] })
+      }
+      return Promise.resolve(cappedList)
+    })
+
+    render(<CompanySelectField value="co-omitted" onChange={jest.fn()} labels={labels} />)
+
+    await waitFor(() => {
+      const calledIdsFetch = mockReadApiResultOrThrow.mock.calls.some(
+        (call) => typeof call[0] === 'string' && (call[0] as string).includes('ids=co-omitted'),
+      )
+      expect(calledIdsFetch).toBe(true)
+    })
+
+    // The saved company becomes an available option once seeded.
+    const trigger = screen.getByRole('combobox')
+    fireEvent.pointerDown(
+      trigger,
+      new MouseEvent('pointerdown', { bubbles: true, button: 0 }) as unknown as PointerEvent,
+    )
+    await waitFor(() => {
+      expect(screen.getAllByText('Omitted Company').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('does not issue an ?ids= seed fetch when the saved company is already in the list', async () => {
+    mockReadApiResultOrThrow.mockResolvedValue(cappedList)
+
+    render(<CompanySelectField value="co-visible" onChange={jest.fn()} labels={labels} />)
+
+    // Allow the load + potential seed effect to settle.
+    await waitFor(() => expect(mockReadApiResultOrThrow).toHaveBeenCalled())
+    await Promise.resolve()
+
+    const calledIdsFetch = mockReadApiResultOrThrow.mock.calls.some(
+      (call) => typeof call[0] === 'string' && (call[0] as string).includes('ids='),
+    )
+    expect(calledIdsFetch).toBe(false)
+  })
+})

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -474,11 +474,13 @@ function normalizeCompanyOption(raw: unknown): CompanyOption | null {
 
 export function CompanySelectField({ value, onChange, labels }: CompanySelectFieldProps) {
   const [options, setOptions] = React.useState<CompanyOption[]>([])
+  const [seededOptions, setSeededOptions] = React.useState<CompanyOption[]>([])
   const [loading, setLoading] = React.useState(true)
   const [dialogOpen, setDialogOpen] = React.useState(false)
   const [newCompany, setNewCompany] = React.useState('')
   const [saving, setSaving] = React.useState(false)
   const [formError, setFormError] = React.useState<string | null>(null)
+  const requestedSeedRef = React.useRef<Set<string>>(new Set())
 
   const loadOptions = React.useCallback(async () => {
     setLoading(true)
@@ -508,6 +510,61 @@ export function CompanySelectField({ value, onChange, labels }: CompanySelectFie
   React.useEffect(() => {
     loadOptions().catch(() => {})
   }, [loadOptions])
+
+  // Persisted selections can sort past the capped option page. When the saved
+  // company is missing from the loaded list, fetch it by id and merge it so the
+  // controlled Select renders the saved label instead of a blank trigger.
+  React.useEffect(() => {
+    if (loading) return
+    if (!value) return
+    if (options.some((option) => option.value === value)) return
+    if (seededOptions.some((option) => option.value === value)) return
+    if (requestedSeedRef.current.has(value)) return
+    requestedSeedRef.current.add(value)
+    let cancelled = false
+    void (async () => {
+      try {
+        const payload = await readApiResultOrThrow<{ items?: unknown[] }>(
+          `/api/customers/companies?ids=${encodeURIComponent(value)}&pageSize=1`,
+          undefined,
+          { errorMessage: labels.errorLoad, fallback: { items: [] } },
+        )
+        const items = Array.isArray(payload?.items) ? payload.items : []
+        const normalized = items
+          .map((item: unknown) => normalizeCompanyOption(item))
+          .filter((item: CompanyOption | null): item is CompanyOption => item !== null)
+        if (!cancelled && normalized.length) {
+          setSeededOptions((prev) => {
+            const seen = new Set(prev.map((option) => option.value))
+            const next = [...prev]
+            for (const option of normalized) {
+              if (!seen.has(option.value)) {
+                seen.add(option.value)
+                next.push(option)
+              }
+            }
+            return next
+          })
+        }
+      } catch (err) {
+        console.error('customers.companies.seed-selected failed', err)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [loading, value, options, seededOptions, labels.errorLoad])
+
+  const displayOptions = React.useMemo(() => {
+    const merged: CompanyOption[] = []
+    const seen = new Set<string>()
+    for (const option of [...seededOptions, ...options]) {
+      if (seen.has(option.value)) continue
+      seen.add(option.value)
+      merged.push(option)
+    }
+    return merged
+  }, [options, seededOptions])
 
   const handleDialogChange = React.useCallback((open: boolean) => {
     setDialogOpen(open)
@@ -582,7 +639,7 @@ export function CompanySelectField({ value, onChange, labels }: CompanySelectFie
             <SelectValue placeholder={labels.placeholder} />
           </SelectTrigger>
           <SelectContent>
-            {options.map((option) => (
+            {displayOptions.map((option) => (
               <SelectItem key={option.value} value={option.value}>
                 {option.label}
               </SelectItem>


### PR DESCRIPTION
Fixes #2615

## Problem
Persisted select values render as an empty/placeholder trigger in edit mode when the saved record is not part of the capped async option list (e.g. a company that sorts past `pageSize=100`, or a tax rate past the capped tax-rate page). The controlled Radix `Select` has no matching `SelectItem` for its `value`, so it renders blank even though the value is saved.

Confirmed affected paths (from the issue):
- Customers person → company edit select.
- Catalog product → tax class select.
- Catalog variant → tax override select (same capped `taxRates` source).

## Root Cause
These controls set a persisted selected id as the `Select` `value`, but only render `SelectItem`s from a capped async list. When the saved id falls outside that list, Radix has no item to resolve the selected label from.

## What Changed
- **New shared helper/hook** `packages/core/src/modules/catalog/components/products/taxRateOptions.ts`:
  - `normalizeTaxRateSummary` (extracted from the duplicated inline mappers),
  - `collectMissingTaxRateIds` / `mergeTaxRateSummaries` (pure, de-duped merge),
  - `useEnsureSelectedTaxRates` — fetches selected tax-rate ids missing from the loaded list via the CRUD `?ids=` filter and merges them into the option list.
- **Product edit page** (`backend/catalog/products/[id]/page.tsx`): refactored to the shared normalizer and ensures `values.taxRateId` is hydrated.
- **Variant edit page** (`backend/catalog/products/[productId]/variants/[variantId]/page.tsx`): same, covering both the variant tax override and the inherited product tax id. Because `VariantBuilder` consumes the page's `taxRates`, its selects are covered by the same merge.
- **CompanySelectField** (`customers/components/formConfig.tsx`): when the saved `value` is absent from the capped `pageSize=100` list, fetch it by `?ids=<id>` and merge it (de-duped) into the rendered options.

## Tests
- `catalog/components/products/__tests__/taxRateOptions.test.tsx` — unit tests for `normalizeTaxRateSummary`, `collectMissingTaxRateIds`, `mergeTaxRateSummaries`, plus a `renderHook` test proving `useEnsureSelectedTaxRates` fetches the missing id via `?ids=` and merges it (and is a no-op when present).
- `customers/components/__tests__/CompanySelectField.test.tsx` — jsdom render test proving a saved company missing from the capped list is seeded via `?ids=` and becomes an available option (and that no seed fetch fires when already present).
- Existing `VariantBuilder` / `catalogComponentsRender` / `formConfig` suites still pass.
- `tsc -p packages/core/tsconfig.json --noEmit` clean.

## Backward Compatibility
- No contract surface changes. New additive exports only; existing API request shapes use the already-supported CRUD `?ids=` filter.

## Notes
- The capped-list select-prefill class of bug is also addressed for other modules (dictionaries/resources/staff/checkout) by the separate in-flight PR #2608; this PR covers the customers/catalog paths #2615 explicitly called out, which #2608 does not touch.