### PR TITLE
feat: 2460 staff integration coverage

### DIFF
--- a/packages/core/src/modules/staff/__integration__/TC-STAFF-006.spec.ts
+++ b/packages/core/src/modules/staff/__integration__/TC-STAFF-006.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createStaffTeamMemberFixture,
+  deleteStaffEntityIfExists,
+} from '@open-mercato/core/helpers/integration/staffFixtures'
+
+/**
+ * TC-STAFF-006: Leave Request Rejection via API with Decision Comment
+ * Source: GitHub issue #2460 (staff coverage expansion).
+ *
+ * Reject is the untested twin of the approve flow (TC-STAFF-004). A manager
+ * rejects a pending leave request with a decision comment; the request must land
+ * in `rejected` with the comment, decider, and decision timestamp persisted.
+ *
+ * Verified contract (against the real route/command):
+ * - POST /api/staff/leave-requests/reject -> 200 { ok: true, id } (NOT 201).
+ * - Read-back via GET ?ids= returns snake_case fields (decision_comment,
+ *   decided_at, decided_by_user_id); decided_by_user_id equals the actor user id.
+ */
+const LEAVE_REQUESTS_PATH = '/api/staff/leave-requests'
+const REJECT_PATH = '/api/staff/leave-requests/reject'
+const MEMBERS_PATH = '/api/staff/team-members'
+
+async function readLeaveRequest(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<Record<string, unknown> | null> {
+  const response = await apiRequest(request, 'GET', `${LEAVE_REQUESTS_PATH}?ids=${encodeURIComponent(id)}`, { token })
+  expect(response.status(), 'GET /api/staff/leave-requests should return 200').toBe(200)
+  const body = await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(response)
+  return (body?.items ?? []).find((item) => item.id === id) ?? null
+}
+
+test.describe('TC-STAFF-006: Leave Request Rejection via API with Decision Comment', () => {
+  test('rejects a pending leave request and persists the decision', async ({ request }) => {
+    let token: string | null = null
+    let memberId: string | null = null
+    let leaveRequestId: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+      const actorUserId = getTokenScope(token).userId
+
+      memberId = await createStaffTeamMemberFixture(request, token, {
+        displayName: `QA TC-STAFF-006 ${Date.now()}`,
+      })
+
+      const startDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+      const endDate = new Date(Date.now() + 35 * 24 * 60 * 60 * 1000).toISOString()
+      const createResponse = await apiRequest(request, 'POST', LEAVE_REQUESTS_PATH, {
+        token,
+        data: { memberId, startDate, endDate, timezone: 'UTC' },
+      })
+      expect(createResponse.status(), 'POST /api/staff/leave-requests should return 201').toBe(201)
+      leaveRequestId = (await readJsonSafe<{ id?: string }>(createResponse))?.id ?? null
+      expect(leaveRequestId, 'create response should include an id').toBeTruthy()
+
+      const decisionComment = 'Rejected by QA automation — conflicting coverage window.'
+      const rejectResponse = await apiRequest(request, 'POST', REJECT_PATH, {
+        token,
+        data: { id: leaveRequestId, decisionComment },
+      })
+      expect(rejectResponse.status(), 'POST /api/staff/leave-requests/reject should return 200').toBe(200)
+      const rejectBody = await readJsonSafe<{ ok?: boolean; id?: string }>(rejectResponse)
+      expect(rejectBody?.ok, 'reject response should set ok: true').toBe(true)
+      expect(rejectBody?.id, 'reject response id should match the request').toBe(leaveRequestId)
+
+      const item = await readLeaveRequest(request, token, leaveRequestId!)
+      expect(item, 'rejected leave request should be retrievable').toBeTruthy()
+      expect(item!.status, 'status should be rejected').toBe('rejected')
+      expect(item!.decision_comment, 'decision comment should persist').toBe(decisionComment)
+      const decidedAt = item!.decided_at
+      expect(
+        typeof decidedAt === 'string' && decidedAt.length > 0,
+        'decided_at should be a recent ISO timestamp',
+      ).toBe(true)
+      expect(item!.decided_by_user_id, 'decided_by_user_id should match the authenticated user').toBe(actorUserId)
+    } finally {
+      // Finalized (rejected) leave requests cannot be deleted via the API (delete
+      // requires pending status), so this mirrors TC-STAFF-004's best-effort
+      // cleanup; the member fixture is removed regardless.
+      await deleteStaffEntityIfExists(request, token, LEAVE_REQUESTS_PATH, leaveRequestId)
+      await deleteStaffEntityIfExists(request, token, MEMBERS_PATH, memberId)
+    }
+  })
+})

--- a/packages/core/src/modules/staff/__integration__/TC-STAFF-007.spec.ts
+++ b/packages/core/src/modules/staff/__integration__/TC-STAFF-007.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createStaffTeamMemberFixture,
+  deleteStaffEntityIfExists,
+} from '@open-mercato/core/helpers/integration/staffFixtures'
+
+/**
+ * TC-STAFF-007: Team Member Update via PUT API
+ * Source: GitHub issue #2460 (staff coverage expansion).
+ *
+ * Create and delete are covered (TC-STAFF-002 covers team CRUD; the member
+ * fixture covers create); the PUT/update path was never asserted. Updating a
+ * member's display name and description must persist while leaving created_at
+ * and is_active untouched and advancing updated_at.
+ *
+ * Verified contract: PUT /api/staff/team-members -> 200 { ok: true }; read-back
+ * via GET ?ids= returns snake_case fields (display_name, description, is_active).
+ */
+const MEMBERS_PATH = '/api/staff/team-members'
+
+async function readMember(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<Record<string, unknown> | null> {
+  const response = await apiRequest(request, 'GET', `${MEMBERS_PATH}?ids=${encodeURIComponent(id)}`, { token })
+  expect(response.status(), 'GET /api/staff/team-members should return 200').toBe(200)
+  const body = await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(response)
+  return (body?.items ?? []).find((item) => item.id === id) ?? null
+}
+
+test.describe('TC-STAFF-007: Team Member Update via PUT API', () => {
+  test('updates display name and description, leaving created_at and is_active intact', async ({ request }) => {
+    let token: string | null = null
+    let memberId: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+      memberId = await createStaffTeamMemberFixture(request, token, {
+        displayName: `QA TC-STAFF-007 Original ${Date.now()}`,
+      })
+
+      const before = await readMember(request, token, memberId)
+      expect(before, 'created member should be retrievable').toBeTruthy()
+
+      const updatedName = `QA TC-STAFF-007 Updated ${Date.now()}`
+      const putResponse = await apiRequest(request, 'PUT', MEMBERS_PATH, {
+        token,
+        data: { id: memberId, displayName: updatedName, description: 'New description' },
+      })
+      expect(putResponse.status(), 'PUT /api/staff/team-members should return 200').toBe(200)
+      const putBody = await readJsonSafe<{ ok?: boolean }>(putResponse)
+      expect(putBody?.ok, 'update response should set ok: true').toBe(true)
+
+      const after = await readMember(request, token, memberId)
+      expect(after, 'updated member should be retrievable').toBeTruthy()
+      expect(after!.display_name, 'display_name should reflect the update').toBe(updatedName)
+      expect(after!.description, 'description should reflect the update').toBe('New description')
+      expect(after!.is_active, 'is_active should be unchanged').toBe(before!.is_active)
+      expect(after!.created_at, 'created_at should be unchanged').toBe(before!.created_at)
+      expect(
+        Date.parse(String(after!.updated_at)) > Date.parse(String(before!.updated_at)),
+        'updated_at should advance on update',
+      ).toBe(true)
+    } finally {
+      await deleteStaffEntityIfExists(request, token, MEMBERS_PATH, memberId)
+    }
+  })
+})

--- a/packages/core/src/modules/staff/__integration__/TC-STAFF-008.spec.ts
+++ b/packages/core/src/modules/staff/__integration__/TC-STAFF-008.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createStaffTeamMemberFixture,
+  deleteStaffEntityIfExists,
+} from '@open-mercato/core/helpers/integration/staffFixtures'
+
+/**
+ * TC-STAFF-008: Team Member Comments CRUD via API
+ * Source: GitHub issue #2460 (staff coverage expansion).
+ *
+ * Comments are a flat CRUD route scoped to a member via `entityId` (NOT a nested
+ * /team-members/<id>/comments route). The note text field is `body`.
+ *
+ * Verified contract:
+ * - POST /api/staff/comments { entityId, body } -> 201 { id, authorUserId }.
+ * - GET  /api/staff/comments?entityId=<memberId> lists snake_case fields (body).
+ * - PUT  /api/staff/comments { id, body } -> 200 { ok: true }.
+ * - DELETE /api/staff/comments?id=<id> -> 200 { ok: true } (soft delete; the
+ *   record drops out of the list).
+ */
+const COMMENTS_PATH = '/api/staff/comments'
+const MEMBERS_PATH = '/api/staff/team-members'
+
+async function listComments(
+  request: APIRequestContext,
+  token: string,
+  memberId: string,
+): Promise<Array<Record<string, unknown>>> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${COMMENTS_PATH}?entityId=${encodeURIComponent(memberId)}`,
+    { token },
+  )
+  expect(response.status(), 'GET /api/staff/comments should return 200').toBe(200)
+  const body = await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(response)
+  return body?.items ?? []
+}
+
+test.describe('TC-STAFF-008: Team Member Comments CRUD via API', () => {
+  test('creates, lists, updates, and deletes a team member comment', async ({ request }) => {
+    let token: string | null = null
+    let memberId: string | null = null
+    let commentId: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+      memberId = await createStaffTeamMemberFixture(request, token, {
+        displayName: `QA TC-STAFF-008 ${Date.now()}`,
+      })
+
+      const createResponse = await apiRequest(request, 'POST', COMMENTS_PATH, {
+        token,
+        data: { entityId: memberId, body: 'Initial comment' },
+      })
+      expect(createResponse.status(), 'POST /api/staff/comments should return 201').toBe(201)
+      commentId = (await readJsonSafe<{ id?: string }>(createResponse))?.id ?? null
+      expect(commentId, 'create should return a comment id').toBeTruthy()
+
+      const created = (await listComments(request, token, memberId)).find((comment) => comment.id === commentId)
+      expect(created, 'created comment should appear in the list').toBeTruthy()
+      expect(created!.body, 'comment body should persist').toBe('Initial comment')
+      const createdUpdatedAt = Date.parse(String(created!.updated_at))
+
+      const putResponse = await apiRequest(request, 'PUT', COMMENTS_PATH, {
+        token,
+        data: { id: commentId, body: 'Updated comment' },
+      })
+      expect(putResponse.status(), 'PUT /api/staff/comments should return 200').toBe(200)
+
+      const updated = (await listComments(request, token, memberId)).find((comment) => comment.id === commentId)
+      expect(updated, 'updated comment should still be listed').toBeTruthy()
+      expect(updated!.body, 'comment body should reflect the update').toBe('Updated comment')
+      expect(
+        Date.parse(String(updated!.updated_at)) > createdUpdatedAt,
+        'updated_at should advance on update',
+      ).toBe(true)
+
+      const deleteResponse = await apiRequest(
+        request,
+        'DELETE',
+        `${COMMENTS_PATH}?id=${encodeURIComponent(commentId!)}`,
+        { token },
+      )
+      expect(deleteResponse.status(), 'DELETE /api/staff/comments should return 200').toBe(200)
+      const deletedId = commentId
+      commentId = null
+
+      const remaining = (await listComments(request, token, memberId)).find((comment) => comment.id === deletedId)
+      expect(remaining, 'deleted comment should no longer be listed').toBeFalsy()
+    } finally {
+      await deleteStaffEntityIfExists(request, token, COMMENTS_PATH, commentId)
+      await deleteStaffEntityIfExists(request, token, MEMBERS_PATH, memberId)
+    }
+  })
+})

--- a/packages/core/src/modules/staff/__integration__/TC-STAFF-009.spec.ts
+++ b/packages/core/src/modules/staff/__integration__/TC-STAFF-009.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createStaffTeamMemberFixture,
+  deleteStaffEntityIfExists,
+} from '@open-mercato/core/helpers/integration/staffFixtures'
+
+/**
+ * TC-STAFF-009: Team Member Addresses CRUD via API
+ * Source: GitHub issue #2460 (staff coverage expansion).
+ *
+ * Addresses are a flat CRUD route scoped to a member via `entityId`. The
+ * required line field is `addressLine1` (there is no `street` field). Responses
+ * are snake_case (address_line1, postal_code).
+ *
+ * Verified contract:
+ * - POST /api/staff/addresses { entityId, addressLine1, ... } -> 201 { id }.
+ * - GET  /api/staff/addresses?entityId=<memberId> lists the address.
+ * - PUT  /api/staff/addresses { id, city, postalCode } -> 200 { ok: true }.
+ * - DELETE /api/staff/addresses?id=<id> -> 200 { ok: true } (hard delete; the
+ *   record drops out of the list).
+ */
+const ADDRESSES_PATH = '/api/staff/addresses'
+const MEMBERS_PATH = '/api/staff/team-members'
+
+async function listAddresses(
+  request: APIRequestContext,
+  token: string,
+  memberId: string,
+): Promise<Array<Record<string, unknown>>> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${ADDRESSES_PATH}?entityId=${encodeURIComponent(memberId)}`,
+    { token },
+  )
+  expect(response.status(), 'GET /api/staff/addresses should return 200').toBe(200)
+  const body = await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(response)
+  return body?.items ?? []
+}
+
+test.describe('TC-STAFF-009: Team Member Addresses CRUD via API', () => {
+  test('creates, lists, updates, and deletes a team member address', async ({ request }) => {
+    let token: string | null = null
+    let memberId: string | null = null
+    let addressId: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+      memberId = await createStaffTeamMemberFixture(request, token, {
+        displayName: `QA TC-STAFF-009 ${Date.now()}`,
+      })
+
+      const createResponse = await apiRequest(request, 'POST', ADDRESSES_PATH, {
+        token,
+        data: {
+          entityId: memberId,
+          addressLine1: '123 Market Street',
+          city: 'Springfield',
+          region: 'IL',
+          postalCode: '62704',
+          country: 'United States',
+        },
+      })
+      expect(createResponse.status(), 'POST /api/staff/addresses should return 201').toBe(201)
+      addressId = (await readJsonSafe<{ id?: string }>(createResponse))?.id ?? null
+      expect(addressId, 'create should return an address id').toBeTruthy()
+
+      const created = (await listAddresses(request, token, memberId)).find((address) => address.id === addressId)
+      expect(created, 'created address should appear in the list').toBeTruthy()
+      expect(created!.address_line1, 'address_line1 should persist').toBe('123 Market Street')
+      expect(created!.city, 'city should persist').toBe('Springfield')
+      expect(created!.postal_code, 'postal_code should persist').toBe('62704')
+      expect(created!.country, 'country should persist').toBe('United States')
+
+      const putResponse = await apiRequest(request, 'PUT', ADDRESSES_PATH, {
+        token,
+        data: { id: addressId, city: 'Shelbyville', postalCode: '62565' },
+      })
+      expect(putResponse.status(), 'PUT /api/staff/addresses should return 200').toBe(200)
+
+      const updated = (await listAddresses(request, token, memberId)).find((address) => address.id === addressId)
+      expect(updated, 'updated address should still be listed').toBeTruthy()
+      expect(updated!.city, 'city should reflect the update').toBe('Shelbyville')
+      expect(updated!.postal_code, 'postal_code should reflect the update').toBe('62565')
+      expect(updated!.address_line1, 'untouched address_line1 should remain').toBe('123 Market Street')
+
+      const deleteResponse = await apiRequest(
+        request,
+        'DELETE',
+        `${ADDRESSES_PATH}?id=${encodeURIComponent(addressId!)}`,
+        { token },
+      )
+      expect(deleteResponse.status(), 'DELETE /api/staff/addresses should return 200').toBe(200)
+      const deletedId = addressId
+      addressId = null
+
+      const remaining = (await listAddresses(request, token, memberId)).find((address) => address.id === deletedId)
+      expect(remaining, 'deleted address should no longer be listed').toBeFalsy()
+    } finally {
+      await deleteStaffEntityIfExists(request, token, ADDRESSES_PATH, addressId)
+      await deleteStaffEntityIfExists(request, token, MEMBERS_PATH, memberId)
+    }
+  })
+})

--- a/packages/core/src/modules/staff/__integration__/TC-STAFF-015.spec.ts
+++ b/packages/core/src/modules/staff/__integration__/TC-STAFF-015.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createStaffTeamMemberFixture,
+  deleteStaffEntityIfExists,
+} from '@open-mercato/core/helpers/integration/staffFixtures'
+
+/**
+ * TC-STAFF-015: Team Member Tag Lifecycle (Assign and Unassign)
+ * Source: GitHub issue #2460 (staff coverage expansion).
+ *
+ * Both the assign and unassign routes exist; neither was exercised. Tags live as
+ * a string array on the member (`tags`), so the lifecycle is read back via the
+ * team-members list.
+ *
+ * Verified contract:
+ * - POST /api/staff/team-members/tags/assign { memberId, tag } -> 201 { id }
+ *   (409 'Tag already assigned.' on a duplicate).
+ * - POST /api/staff/team-members/tags/unassign { memberId, tag } -> 200 { id }
+ *   (404 'Tag assignment not found.' when the tag is absent).
+ * - GET /api/staff/team-members?ids=<id> returns the live `tags` array.
+ */
+const MEMBERS_PATH = '/api/staff/team-members'
+const ASSIGN_PATH = '/api/staff/team-members/tags/assign'
+const UNASSIGN_PATH = '/api/staff/team-members/tags/unassign'
+
+async function readMemberTags(
+  request: APIRequestContext,
+  token: string,
+  memberId: string,
+): Promise<string[]> {
+  const response = await apiRequest(request, 'GET', `${MEMBERS_PATH}?ids=${encodeURIComponent(memberId)}`, { token })
+  expect(response.status(), 'GET /api/staff/team-members should return 200').toBe(200)
+  const body = await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(response)
+  const member = (body?.items ?? []).find((item) => item.id === memberId)
+  const tags = member?.tags
+  return Array.isArray(tags) ? tags.filter((tag): tag is string => typeof tag === 'string') : []
+}
+
+test.describe('TC-STAFF-015: Team Member Tag Lifecycle (Assign and Unassign)', () => {
+  test('assigns multiple tags and unassigns one without disturbing the rest', async ({ request }) => {
+    let token: string | null = null
+    let memberId: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+      memberId = await createStaffTeamMemberFixture(request, token, {
+        displayName: `QA TC-STAFF-015 ${Date.now()}`,
+      })
+
+      const assignContractor = await apiRequest(request, 'POST', ASSIGN_PATH, {
+        token,
+        data: { memberId, tag: 'contractor' },
+      })
+      expect(assignContractor.status(), 'first tag assign should return 201').toBe(201)
+      expect((await readJsonSafe<{ id?: string }>(assignContractor))?.id, 'assign should echo the member id').toBe(memberId)
+
+      let tags = await readMemberTags(request, token, memberId!)
+      expect(tags, "member tags should include 'contractor'").toContain('contractor')
+
+      const assignSenior = await apiRequest(request, 'POST', ASSIGN_PATH, {
+        token,
+        data: { memberId, tag: 'senior' },
+      })
+      expect(assignSenior.status(), 'second tag assign should return 201').toBe(201)
+
+      tags = await readMemberTags(request, token, memberId!)
+      expect(tags, "member tags should include 'contractor'").toContain('contractor')
+      expect(tags, "member tags should include 'senior'").toContain('senior')
+
+      // Re-assigning an existing tag is rejected as a conflict.
+      const duplicateAssign = await apiRequest(request, 'POST', ASSIGN_PATH, {
+        token,
+        data: { memberId, tag: 'senior' },
+      })
+      expect(duplicateAssign.status(), 're-assigning an existing tag should return 409').toBe(409)
+
+      const unassignContractor = await apiRequest(request, 'POST', UNASSIGN_PATH, {
+        token,
+        data: { memberId, tag: 'contractor' },
+      })
+      expect(unassignContractor.status(), 'tag unassign should return 200').toBe(200)
+
+      tags = await readMemberTags(request, token, memberId!)
+      expect(tags, "unassigned 'contractor' should be gone").not.toContain('contractor')
+      expect(tags, "'senior' should remain after unassigning 'contractor'").toContain('senior')
+
+      // Unassigning a tag that is no longer present is a not-found error.
+      const unassignMissing = await apiRequest(request, 'POST', UNASSIGN_PATH, {
+        token,
+        data: { memberId, tag: 'contractor' },
+      })
+      expect(unassignMissing.status(), 'unassigning an absent tag should return 404').toBe(404)
+    } finally {
+      await deleteStaffEntityIfExists(request, token, MEMBERS_PATH, memberId)
+    }
+  })
+})

--- a/packages/core/src/modules/staff/__integration__/TC-STAFF-016.spec.ts
+++ b/packages/core/src/modules/staff/__integration__/TC-STAFF-016.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createStaffTeamMemberFixture,
+  deleteStaffEntityIfExists,
+} from '@open-mercato/core/helpers/integration/staffFixtures'
+
+/**
+ * TC-STAFF-016: Team Member Job History CRUD via API
+ * Source: GitHub issue #2460 (staff coverage expansion).
+ *
+ * Job histories are a flat CRUD route scoped to a member via `entityId`.
+ * TC-LOCK-OSS-036 exercises the optimistic-lock conflict bar on the nested edit;
+ * the plain create/list/update/delete lifecycle was never asserted.
+ *
+ * Verified contract:
+ * - POST /api/staff/job-histories { entityId, name, startDate, ... } -> 201 { id }.
+ * - GET  /api/staff/job-histories?entityId=<memberId> lists snake_case fields.
+ * - PUT  /api/staff/job-histories { id, endDate } -> 200 { ok: true } (no lock
+ *   header -> proceeds).
+ * - DELETE /api/staff/job-histories?id=<id> -> 200 { ok: true } (hard delete).
+ */
+const JOB_HISTORIES_PATH = '/api/staff/job-histories'
+const MEMBERS_PATH = '/api/staff/team-members'
+
+async function listJobHistories(
+  request: APIRequestContext,
+  token: string,
+  memberId: string,
+): Promise<Array<Record<string, unknown>>> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${JOB_HISTORIES_PATH}?entityId=${encodeURIComponent(memberId)}`,
+    { token },
+  )
+  expect(response.status(), 'GET /api/staff/job-histories should return 200').toBe(200)
+  const body = await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(response)
+  return body?.items ?? []
+}
+
+test.describe('TC-STAFF-016: Team Member Job History CRUD via API', () => {
+  test('creates, lists, updates, and deletes a team member job history entry', async ({ request }) => {
+    let token: string | null = null
+    let memberId: string | null = null
+    let jobHistoryId: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+      memberId = await createStaffTeamMemberFixture(request, token, {
+        displayName: `QA TC-STAFF-016 ${Date.now()}`,
+      })
+
+      const createResponse = await apiRequest(request, 'POST', JOB_HISTORIES_PATH, {
+        token,
+        data: {
+          entityId: memberId,
+          name: 'Senior Engineer',
+          companyName: 'Globex Corporation',
+          startDate: '2020-01-15',
+          endDate: '2022-12-31',
+        },
+      })
+      expect(createResponse.status(), 'POST /api/staff/job-histories should return 201').toBe(201)
+      jobHistoryId = (await readJsonSafe<{ id?: string }>(createResponse))?.id ?? null
+      expect(jobHistoryId, 'create should return a job history id').toBeTruthy()
+
+      const created = (await listJobHistories(request, token, memberId)).find((entry) => entry.id === jobHistoryId)
+      expect(created, 'created job history should appear in the list').toBeTruthy()
+      expect(created!.name, 'name should persist').toBe('Senior Engineer')
+      expect(created!.company_name, 'company_name should persist').toBe('Globex Corporation')
+      expect(
+        String(created!.start_date).startsWith('2020-01-15'),
+        'start_date should persist',
+      ).toBe(true)
+      expect(
+        String(created!.end_date).startsWith('2022-12-31'),
+        'end_date should persist',
+      ).toBe(true)
+
+      const putResponse = await apiRequest(request, 'PUT', JOB_HISTORIES_PATH, {
+        token,
+        data: { id: jobHistoryId, endDate: '2023-06-30' },
+      })
+      expect(putResponse.status(), 'PUT /api/staff/job-histories should return 200').toBe(200)
+
+      const updated = (await listJobHistories(request, token, memberId)).find((entry) => entry.id === jobHistoryId)
+      expect(updated, 'updated job history should still be listed').toBeTruthy()
+      expect(
+        String(updated!.end_date).startsWith('2023-06-30'),
+        'end_date should reflect the update',
+      ).toBe(true)
+      expect(updated!.name, 'untouched name should remain').toBe('Senior Engineer')
+
+      const deleteResponse = await apiRequest(
+        request,
+        'DELETE',
+        `${JOB_HISTORIES_PATH}?id=${encodeURIComponent(jobHistoryId!)}`,
+        { token },
+      )
+      expect(deleteResponse.status(), 'DELETE /api/staff/job-histories should return 200').toBe(200)
+      const deletedId = jobHistoryId
+      jobHistoryId = null
+
+      const remaining = (await listJobHistories(request, token, memberId)).find((entry) => entry.id === deletedId)
+      expect(remaining, 'deleted job history should no longer be listed').toBeFalsy()
+    } finally {
+      await deleteStaffEntityIfExists(request, token, JOB_HISTORIES_PATH, jobHistoryId)
+      await deleteStaffEntityIfExists(request, token, MEMBERS_PATH, memberId)
+    }
+  })
+})

--- a/packages/core/src/modules/staff/__integration__/TC-STAFF-025.spec.ts
+++ b/packages/core/src/modules/staff/__integration__/TC-STAFF-025.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createStaffTeamMemberFixture,
+  deleteStaffEntityIfExists,
+} from '@open-mercato/core/helpers/integration/staffFixtures'
+
+/**
+ * TC-STAFF-025: Leave Request Rejection — Already-Decided State Guard
+ * Source: GitHub issue #2460 (proposed there as "TC-STAFF-024"; renumbered to
+ * 025 because TC-STAFF-024 already exists as the time-entries date-filter
+ * regression guard).
+ *
+ * A leave request may only be decided once. Approving and then rejecting the
+ * same request must be blocked by the `ensurePendingStatus` guard.
+ *
+ * Verified contract (against the real route/command):
+ * - Reject on a non-pending request -> 400 { error: 'Leave request is already
+ *   finalized.' }. The command throws CrudHttpError(400); it is NOT 409, and the
+ *   message says "finalized" (not "already decided"/"already approved").
+ * - The original decision (status, decided_at) is left untouched.
+ */
+const LEAVE_REQUESTS_PATH = '/api/staff/leave-requests'
+const ACCEPT_PATH = '/api/staff/leave-requests/accept'
+const REJECT_PATH = '/api/staff/leave-requests/reject'
+const MEMBERS_PATH = '/api/staff/team-members'
+
+async function readLeaveRequest(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<Record<string, unknown> | null> {
+  const response = await apiRequest(request, 'GET', `${LEAVE_REQUESTS_PATH}?ids=${encodeURIComponent(id)}`, { token })
+  expect(response.status(), 'GET /api/staff/leave-requests should return 200').toBe(200)
+  const body = await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(response)
+  return (body?.items ?? []).find((item) => item.id === id) ?? null
+}
+
+test.describe('TC-STAFF-025: Leave Request Rejection — Already-Decided State Guard', () => {
+  test('cannot reject a leave request that was already approved', async ({ request }) => {
+    let token: string | null = null
+    let memberId: string | null = null
+    let leaveRequestId: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+
+      memberId = await createStaffTeamMemberFixture(request, token, {
+        displayName: `QA TC-STAFF-025 ${Date.now()}`,
+      })
+
+      const startDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+      const endDate = new Date(Date.now() + 35 * 24 * 60 * 60 * 1000).toISOString()
+      const createResponse = await apiRequest(request, 'POST', LEAVE_REQUESTS_PATH, {
+        token,
+        data: { memberId, startDate, endDate, timezone: 'UTC' },
+      })
+      expect(createResponse.status(), 'POST /api/staff/leave-requests should return 201').toBe(201)
+      leaveRequestId = (await readJsonSafe<{ id?: string }>(createResponse))?.id ?? null
+      expect(leaveRequestId, 'create response should include an id').toBeTruthy()
+
+      const acceptResponse = await apiRequest(request, 'POST', ACCEPT_PATH, {
+        token,
+        data: { id: leaveRequestId, decisionComment: 'Approved by QA automation' },
+      })
+      expect(acceptResponse.status(), 'POST /api/staff/leave-requests/accept should return 200').toBe(200)
+
+      const approved = await readLeaveRequest(request, token, leaveRequestId!)
+      expect(approved?.status, 'status should be approved after acceptance').toBe('approved')
+      const decidedAtAfterAccept = approved?.decided_at
+
+      const rejectResponse = await apiRequest(request, 'POST', REJECT_PATH, {
+        token,
+        data: { id: leaveRequestId, decisionComment: 'Late rejection attempt' },
+      })
+      expect(rejectResponse.status(), 'rejecting an already-decided request must fail with 400').toBe(400)
+      const rejectBody = await readJsonSafe<{ error?: string }>(rejectResponse)
+      expect(
+        typeof rejectBody?.error === 'string' && rejectBody!.error.length > 0,
+        'a 400 error message should be present',
+      ).toBe(true)
+      expect(
+        String(rejectBody?.error).toLowerCase(),
+        'error should explain the request is already finalized',
+      ).toContain('finalized')
+
+      const afterReject = await readLeaveRequest(request, token, leaveRequestId!)
+      expect(afterReject?.status, 'status must remain approved after the failed reject').toBe('approved')
+      expect(
+        afterReject?.decided_at,
+        'decided_at must be unchanged after the failed reject',
+      ).toBe(decidedAtAfterAccept)
+    } finally {
+      // Approved leave requests cannot be deleted via the API (delete requires
+      // pending status); best-effort cleanup, member fixture removed regardless.
+      await deleteStaffEntityIfExists(request, token, LEAVE_REQUESTS_PATH, leaveRequestId)
+      await deleteStaffEntityIfExists(request, token, MEMBERS_PATH, memberId)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Expands integration-test coverage for the `staff` module per #2460, adding the high-value gaps from the coverage analysis: leave-request rejection (happy path + already-decided guard), team-member update (PUT), full CRUD on member comments/addresses/job-histories, and the tag assign/unassign lifecycle. All specs are self-contained (API fixtures created per test, cleaned up in `finally`) and assert the module's *real* behavior — the auto-generated issue carried several incorrect API assumptions that were corrected against source.

## Changes

- Add `TC-STAFF-006` — leave-request reject with decision comment (`POST /api/staff/leave-requests/reject` → 200; persists `status=rejected`, `decision_comment`, `decided_at`, `decided_by_user_id`).
- Add `TC-STAFF-025` — reject "already-decided" state guard (accept → reject is refused with **400 "Leave request is already finalized."**, original decision untouched). Implements the issue's "TC-STAFF-024" scenario, **renumbered to 025** because `TC-STAFF-024` already exists as the time-entries date-filter regression guard.
- Add `TC-STAFF-007` — team-member update via `PUT /api/staff/team-members` (200; `created_at`/`is_active` unchanged, `updated_at` advances).
- Add `TC-STAFF-008` — team-member comments CRUD (`/api/staff/comments?entityId=`; create 201, update/delete 200; soft delete).
- Add `TC-STAFF-009` — team-member addresses CRUD (`/api/staff/addresses?entityId=`; required field `addressLine1`; hard delete).
- Add `TC-STAFF-016` — team-member job-history CRUD (`/api/staff/job-histories?entityId=`; hard delete).
- Add `TC-STAFF-015` — tag assign (201) / unassign (200) lifecycle, plus 409-on-duplicate and 404-on-missing edges.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test-only coverage expansion, no behavior change. Source of truth is issue #2460.

## Testing

List the tests or commands you ran to validate the change.

- `BASE_URL=http://127.0.0.1:5001 npx playwright test --config .ai/qa/tests/playwright.config.ts TC-STAFF-006 TC-STAFF-007 TC-STAFF-008 TC-STAFF-009 TC-STAFF-015 TC-STAFF-016 TC-STAFF-025` → **7 passed**, and **7 passed again** on rerun (idempotent).
- `BASE_URL=http://127.0.0.1:5001 OM_INTEGRATION_MODULES=staff npx playwright test --config .ai/qa/tests/playwright.config.ts` → **46 passed, 1 skipped (pre-existing TC-STAFF-022), 0 failed** (new specs coexist with all existing staff specs, stable across run order).
- `yarn turbo run typecheck --filter=@open-mercato/core` → **pass** (compiles the new `__integration__` specs).
- Verified against a self-contained Docker ephemeral app (`yarn test:integration:ephemeral:start`), then torn down.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — test-only; no docs/locale/generator inputs touched.)
- [x] I added or adjusted tests that cover the change. (The change *is* the tests.)
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Placed in the module's `__integration__/` folder, the canonical executable-spec location per `.ai/qa/AGENTS.md`; `.ai/qa/tests/` is reserved for the shared Playwright config.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no behavior change; coverage expansion driven by issue #2460.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI (API integration tests).
- [x] No arbitrary text sizes — N/A, no UI.
- [x] Empty state handled for list/data pages — N/A, no UI.
- [x] Loading state handled for async pages — N/A, no UI.
- [x] `aria-label` on all icon-only buttons — N/A, no UI.
- [x] Uses existing DS components — N/A, no UI.

## Linked issues

Fixes #2460