### PR TITLE
fix: 2461 resources integration coverage

### DIFF
--- a/packages/core/src/modules/resources/__integration__/TC-RESO-003.spec.ts
+++ b/packages/core/src/modules/resources/__integration__/TC-RESO-003.spec.ts
@@ -1,0 +1,178 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createResourceTypeFixture,
+  deleteResourceTypeIfExists,
+  deleteResourceIfExists,
+} from './helpers/resourcesFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['resources'],
+};
+
+/**
+ * TC-RESO-003 (issue #2461): Resource Types CRUD happy path + referential
+ * delete guard.
+ *
+ * Resource types are a secondary CRUD entity (1 type : N resources). This spec
+ * exercises create/read/search/update over `/api/resources/resource-types`,
+ * links a resource to the type, and verifies the ACTUAL delete contract: the
+ * `resources.resourceTypes.delete` command counts non-deleted resources bound to
+ * the type and BLOCKS deletion with HTTP 400 while any remain
+ * ("Resource type has assigned resources."), only soft-deleting once the type is
+ * unused. Scope (tenantId/organizationId) is injected from the auth token, so
+ * payloads omit it. List reads are query-index backed, so reads poll briefly.
+ */
+type ListBody = { items?: Array<Record<string, unknown>>; total?: number };
+
+async function listResourceTypes(
+  request: APIRequestContext,
+  token: string,
+  query: string,
+): Promise<Array<Record<string, unknown>>> {
+  const res = await apiRequest(request, 'GET', `/api/resources/resource-types${query}`, { token });
+  expect(res.ok(), `resource-types list should succeed (status ${res.status()})`).toBeTruthy();
+  const body = await readJsonSafe<ListBody>(res);
+  return body?.items ?? [];
+}
+
+test.describe('TC-RESO-003: Resource Types CRUD + referential delete guard', () => {
+  test('creates, searches, updates, links a resource, blocks in-use delete, then soft-deletes', async ({ request }) => {
+    test.slow();
+    const token = await getAuthToken(request, 'admin');
+    const stamp = Date.now();
+    const typeName = `QA Type ${stamp}`;
+
+    let typeId: string | null = null;
+    let resourceId: string | null = null;
+    try {
+      typeId = await createResourceTypeFixture(request, token, {
+        name: typeName,
+        description: 'climate-controlled',
+        appearanceIcon: 'box',
+        appearanceColor: '#aabbcc',
+      });
+
+      // Appears in search with the persisted fields + resourceCount enrichment.
+      await expect
+        .poll(
+          async () => {
+            const items = await listResourceTypes(request, token, `?search=${encodeURIComponent(typeName)}&pageSize=50`);
+            return items.some((item) => item.id === typeId);
+          },
+          { timeout: 8000, message: 'created resource type should appear in search results' },
+        )
+        .toBe(true);
+
+      const created = (await listResourceTypes(request, token, `?search=${encodeURIComponent(typeName)}&pageSize=50`)).find(
+        (item) => item.id === typeId,
+      );
+      expect(created, 'created type present in search').toBeTruthy();
+      expect(created!.name).toBe(typeName);
+      expect(created!.appearance_icon).toBe('box');
+      expect(created!.appearance_color).toBe('#aabbcc');
+      expect(created!.resourceCount).toBe(0);
+      expect(typeof created!.created_at).toBe('string');
+      expect(typeof created!.updated_at).toBe('string');
+
+      // Update name + color.
+      const updatedName = `QA Type UPDATED ${stamp}`;
+      const updateRes = await apiRequest(request, 'PUT', '/api/resources/resource-types', {
+        token,
+        data: { id: typeId, name: updatedName, appearanceColor: '#001122' },
+      });
+      expect(updateRes.status(), 'update resource type should return 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(updateRes))?.ok, 'update reports ok').toBe(true);
+
+      await expect
+        .poll(
+          async () => {
+            const items = await listResourceTypes(request, token, `?ids=${encodeURIComponent(typeId!)}`);
+            return items[0]?.name ?? null;
+          },
+          { timeout: 8000, message: 'updated name should be readable by id' },
+        )
+        .toBe(updatedName);
+      const afterUpdate = (await listResourceTypes(request, token, `?ids=${encodeURIComponent(typeId)}`))[0];
+      expect(afterUpdate.appearance_color).toBe('#001122');
+
+      // Link a resource to the type.
+      const resCreate = await apiRequest(request, 'POST', '/api/resources/resources', {
+        token,
+        data: { name: `QA Typed Resource ${stamp}`, resourceTypeId: typeId, isActive: true },
+      });
+      expect(resCreate.status(), 'create resource linked to type should return 201').toBe(201);
+      resourceId = (await readJsonSafe<{ id?: string }>(resCreate))?.id ?? null;
+      expect(resourceId, 'linked resource id returned').toBeTruthy();
+
+      // Resource persists resource_type_id; the type's resourceCount reflects it.
+      await expect
+        .poll(
+          async () => {
+            const res = await apiRequest(request, 'GET', `/api/resources/resources?ids=${encodeURIComponent(resourceId!)}`, {
+              token,
+            });
+            const body = await readJsonSafe<ListBody>(res);
+            return body?.items?.[0]?.resource_type_id ?? null;
+          },
+          { timeout: 8000, message: 'resource should persist resource_type_id' },
+        )
+        .toBe(typeId);
+      await expect
+        .poll(
+          async () => {
+            const items = await listResourceTypes(request, token, `?ids=${encodeURIComponent(typeId!)}`);
+            return items[0]?.resourceCount ?? null;
+          },
+          { timeout: 8000, message: 'type resourceCount should reflect the linked resource' },
+        )
+        .toBe(1);
+
+      // In-use delete is blocked by the referential guard (HTTP 400).
+      const blockedDelete = await apiRequest(
+        request,
+        'DELETE',
+        `/api/resources/resource-types?id=${encodeURIComponent(typeId)}`,
+        { token },
+      );
+      expect(blockedDelete.status(), 'deleting an in-use resource type must be blocked with 400').toBe(400);
+      const blockedBody = await readJsonSafe<{ error?: string }>(blockedDelete);
+      expect(typeof blockedBody?.error, 'blocked delete returns an error message').toBe('string');
+      expect(
+        (await listResourceTypes(request, token, `?ids=${encodeURIComponent(typeId)}`)).length,
+        'blocked type must still exist',
+      ).toBe(1);
+
+      // Remove the dependent resource, then the now-unused type soft-deletes.
+      const delResource = await apiRequest(
+        request,
+        'DELETE',
+        `/api/resources/resources?id=${encodeURIComponent(resourceId!)}`,
+        { token },
+      );
+      expect(delResource.status(), 'delete dependent resource should return 200').toBe(200);
+      resourceId = null;
+
+      const okDelete = await apiRequest(
+        request,
+        'DELETE',
+        `/api/resources/resource-types?id=${encodeURIComponent(typeId)}`,
+        { token },
+      );
+      expect(okDelete.status(), 'delete unused resource type should return 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(okDelete))?.ok, 'delete reports ok').toBe(true);
+
+      await expect
+        .poll(
+          async () => (await listResourceTypes(request, token, `?ids=${encodeURIComponent(typeId!)}`)).length,
+          { timeout: 8000, message: 'soft-deleted type should disappear from the list' },
+        )
+        .toBe(0);
+      typeId = null;
+    } finally {
+      await deleteResourceIfExists(request, token, resourceId);
+      await deleteResourceTypeIfExists(request, token, typeId);
+    }
+  });
+});

--- a/packages/core/src/modules/resources/__integration__/TC-RESO-004.spec.ts
+++ b/packages/core/src/modules/resources/__integration__/TC-RESO-004.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { slugifyTagLabel } from '@open-mercato/shared/lib/utils';
+import {
+  createResourceFixture,
+  deleteResourceIfExists,
+  deleteResourceTagIfExists,
+} from './helpers/resourcesFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['resources'],
+};
+
+/**
+ * TC-RESO-004 (issue #2461): Resource Tags CRUD happy path.
+ *
+ * Tags are a many-to-many concept with dedicated CRUD over `/api/resources/tags`.
+ * This spec verifies create (slug auto-derived from the label via
+ * `slugifyTagLabel` when omitted), search by label OR slug, update, and the
+ * ACTUAL delete contract: the `resources.resourceTags.delete` command performs a
+ * HARD delete and atomically `nativeDelete`s the tag's assignments, so deleting a
+ * tag also removes it from any resource it was assigned to. The tags list is
+ * served directly from the ORM (camelCase items, `{ items, total }` shape) rather
+ * than the query index.
+ */
+type TagListBody = { items?: Array<Record<string, unknown>>; total?: number };
+
+async function listTags(
+  request: APIRequestContext,
+  token: string,
+  query: string,
+): Promise<Array<Record<string, unknown>>> {
+  const res = await apiRequest(request, 'GET', `/api/resources/tags${query}`, { token });
+  expect(res.ok(), `tags list should succeed (status ${res.status()})`).toBeTruthy();
+  const body = await readJsonSafe<TagListBody>(res);
+  return body?.items ?? [];
+}
+
+async function resourceTagIds(
+  request: APIRequestContext,
+  token: string,
+  resourceId: string,
+): Promise<string[]> {
+  const res = await apiRequest(request, 'GET', `/api/resources/resources?ids=${encodeURIComponent(resourceId)}`, { token });
+  const body = await readJsonSafe<{ items?: Array<{ id?: string; tags?: Array<{ id?: string }> }> }>(res);
+  const item = (body?.items ?? []).find((entry) => entry.id === resourceId);
+  const tags = Array.isArray(item?.tags) ? item!.tags : [];
+  return tags
+    .map((tag) => (typeof tag?.id === 'string' ? tag.id : null))
+    .filter((id): id is string => typeof id === 'string');
+}
+
+test.describe('TC-RESO-004: Resource Tags CRUD + slug autogen + hard-delete cascade', () => {
+  test('creates with auto slug, searches by label/slug, updates, assigns, and hard-deletes with cascade', async ({ request }) => {
+    test.slow();
+    const token = await getAuthToken(request, 'admin');
+    const stamp = Date.now();
+    const label = `QA Tag ${stamp}`;
+    const expectedSlug = slugifyTagLabel(label);
+
+    let tagId: string | null = null;
+    let resourceId: string | null = null;
+    try {
+      // Create with slug omitted -> auto-derived from the label.
+      const createRes = await apiRequest(request, 'POST', '/api/resources/tags', {
+        token,
+        data: { label, color: '#112233', description: 'urgent' },
+      });
+      expect(createRes.status(), 'create tag should return 201').toBe(201);
+      tagId = (await readJsonSafe<{ id?: string }>(createRes))?.id ?? null;
+      expect(tagId, 'tag id returned').toBeTruthy();
+
+      // Searchable by label; fields round-trip; slug auto-derived.
+      const byLabel = (await listTags(request, token, `?search=${encodeURIComponent(label)}`)).find((tag) => tag.id === tagId);
+      expect(byLabel, 'tag should be searchable by label').toBeTruthy();
+      expect(byLabel!.label).toBe(label);
+      expect(byLabel!.slug).toBe(expectedSlug);
+      expect(byLabel!.color).toBe('#112233');
+      expect(byLabel!.description).toBe('urgent');
+
+      // Searchable by slug too.
+      const bySlug = await listTags(request, token, `?search=${encodeURIComponent(expectedSlug)}`);
+      expect(bySlug.some((tag) => tag.id === tagId), 'tag should be searchable by slug').toBe(true);
+
+      // Update label + color.
+      const renamed = `QA Tag RENAMED ${stamp}`;
+      const updateRes = await apiRequest(request, 'PUT', '/api/resources/tags', {
+        token,
+        data: { id: tagId, label: renamed, color: '#445566' },
+      });
+      expect(updateRes.status(), 'update tag should return 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(updateRes))?.ok, 'update reports ok').toBe(true);
+
+      const afterUpdate = (await listTags(request, token, `?search=${encodeURIComponent(renamed)}`)).find((tag) => tag.id === tagId);
+      expect(afterUpdate?.label).toBe(renamed);
+      expect(afterUpdate?.color).toBe('#445566');
+
+      // Assign the tag to a resource and confirm it shows up on the resource.
+      resourceId = await createResourceFixture(request, token, `QA Tagged Resource ${stamp}`);
+      const assignRes = await apiRequest(request, 'POST', '/api/resources/resources/tags/assign', {
+        token,
+        data: { resourceId, tagId },
+      });
+      expect(assignRes.status(), 'assign tag to resource should return 201').toBe(201);
+      await expect
+        .poll(async () => (await resourceTagIds(request, token, resourceId!)).includes(tagId!), {
+          timeout: 8000,
+          message: 'assigned tag should appear on the resource',
+        })
+        .toBe(true);
+
+      // Hard delete the tag -> it disappears AND its assignment is cascade-removed.
+      const delRes = await apiRequest(request, 'DELETE', `/api/resources/tags?id=${encodeURIComponent(tagId!)}`, { token });
+      expect(delRes.status(), 'delete tag should return 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(delRes))?.ok, 'delete reports ok').toBe(true);
+
+      const afterDelete = await listTags(request, token, `?search=${encodeURIComponent(renamed)}`);
+      expect(afterDelete.some((tag) => tag.id === tagId), 'deleted tag must be gone from the list').toBe(false);
+      await expect
+        .poll(async () => (await resourceTagIds(request, token, resourceId!)).includes(tagId!), {
+          timeout: 8000,
+          message: 'tag delete should cascade-remove its assignments',
+        })
+        .toBe(false);
+      tagId = null;
+    } finally {
+      await deleteResourceTagIfExists(request, token, tagId);
+      await deleteResourceIfExists(request, token, resourceId);
+    }
+  });
+});

--- a/packages/core/src/modules/resources/__integration__/TC-RESO-005.spec.ts
+++ b/packages/core/src/modules/resources/__integration__/TC-RESO-005.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { createResourceFixture, deleteResourceIfExists } from './helpers/resourcesFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['resources'],
+};
+
+/**
+ * TC-RESO-005 (issue #2461): Resource Comments CRUD + author enrichment.
+ *
+ * Comments are timeline notes on a resource, created over `/api/resources/comments`
+ * with `entityId` = the resource id. This spec verifies that the author defaults
+ * to the authenticated user when `authorUserId` is omitted (via
+ * `normalizeAuthorUserId`), that the list `afterList` hook enriches each row with
+ * `authorEmail` looked up from the User entity (the comment row stores only
+ * `author_user_id`), update of the body, and removal from the timeline on delete.
+ * The comment list is query-index backed, so reads poll briefly.
+ */
+type CommentListBody = { items?: Array<Record<string, unknown>> };
+
+async function listComments(
+  request: APIRequestContext,
+  token: string,
+  resourceId: string,
+): Promise<Array<Record<string, unknown>>> {
+  const res = await apiRequest(
+    request,
+    'GET',
+    `/api/resources/comments?entityId=${encodeURIComponent(resourceId)}&pageSize=100`,
+    { token },
+  );
+  expect(res.ok(), `comments list should succeed (status ${res.status()})`).toBeTruthy();
+  const body = await readJsonSafe<CommentListBody>(res);
+  return body?.items ?? [];
+}
+
+async function pollForComment(
+  request: APIRequestContext,
+  token: string,
+  resourceId: string,
+  commentId: string,
+): Promise<Record<string, unknown>> {
+  await expect
+    .poll(async () => (await listComments(request, token, resourceId)).some((comment) => comment.id === commentId), {
+      timeout: 8000,
+      message: 'comment should appear in the timeline',
+    })
+    .toBe(true);
+  const item = (await listComments(request, token, resourceId)).find((comment) => comment.id === commentId);
+  expect(item, 'comment present after poll').toBeTruthy();
+  return item as Record<string, unknown>;
+}
+
+test.describe('TC-RESO-005: Resource Comments CRUD + author enrichment', () => {
+  test('creates a comment with auto author, enriches author email, updates the body, and deletes', async ({ request }) => {
+    test.slow();
+    const token = await getAuthToken(request, 'admin');
+    const { userId } = getTokenScope(token);
+    const stamp = Date.now();
+
+    let resourceId: string | null = null;
+    let commentId: string | null = null;
+    try {
+      resourceId = await createResourceFixture(request, token, `QA Comment Resource ${stamp}`);
+
+      const body = `QA comment ${stamp}`;
+      const createRes = await apiRequest(request, 'POST', '/api/resources/comments', {
+        token,
+        data: { entityId: resourceId, body },
+      });
+      expect(createRes.status(), 'create comment should return 201').toBe(201);
+      const createBody = await readJsonSafe<{ id?: string; authorUserId?: string }>(createRes);
+      commentId = createBody?.id ?? null;
+      expect(commentId, 'comment id returned').toBeTruthy();
+      // Author defaults to the authenticated user when omitted.
+      expect(createBody?.authorUserId, 'comment author defaults to the caller').toBe(userId);
+
+      const item = await pollForComment(request, token, resourceId, commentId!);
+      expect(item.resource_id).toBe(resourceId);
+      expect(item.body).toBe(body);
+      expect(item.author_user_id).toBe(userId);
+      // Enrichment: the email is loaded from the User table during list (the row stores only author_user_id).
+      expect(typeof item.authorEmail, 'authorEmail enriched from User entity').toBe('string');
+      expect((item.authorEmail as string).length, 'authorEmail is non-empty').toBeGreaterThan(0);
+      expect('authorName' in item, 'authorName key present from enrichment').toBe(true);
+
+      // Update the body.
+      const updatedBody = `QA comment UPDATED ${stamp}`;
+      const updateRes = await apiRequest(request, 'PUT', '/api/resources/comments', {
+        token,
+        data: { id: commentId, body: updatedBody },
+      });
+      expect(updateRes.status(), 'update comment should return 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(updateRes))?.ok, 'update reports ok').toBe(true);
+
+      await expect
+        .poll(
+          async () => (await listComments(request, token, resourceId!)).find((comment) => comment.id === commentId)?.body ?? null,
+          { timeout: 8000, message: 'updated body should be readable' },
+        )
+        .toBe(updatedBody);
+      const afterUpdate = (await listComments(request, token, resourceId)).find((comment) => comment.id === commentId);
+      expect(typeof afterUpdate?.authorEmail, 'author still enriched after update').toBe('string');
+
+      // Delete -> removed from the timeline.
+      const delRes = await apiRequest(request, 'DELETE', `/api/resources/comments?id=${encodeURIComponent(commentId!)}`, { token });
+      expect(delRes.status(), 'delete comment should return 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(delRes))?.ok, 'delete reports ok').toBe(true);
+
+      await expect
+        .poll(async () => (await listComments(request, token, resourceId!)).some((comment) => comment.id === commentId), {
+          timeout: 8000,
+          message: 'deleted comment should be gone from the timeline',
+        })
+        .toBe(false);
+      commentId = null;
+    } finally {
+      if (commentId) {
+        await apiRequest(request, 'DELETE', `/api/resources/comments?id=${encodeURIComponent(commentId)}`, { token }).catch(
+          () => {},
+        );
+      }
+      await deleteResourceIfExists(request, token, resourceId);
+    }
+  });
+});

--- a/packages/core/src/modules/resources/__integration__/TC-RESO-006.spec.ts
+++ b/packages/core/src/modules/resources/__integration__/TC-RESO-006.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { createResourceFixture, deleteResourceIfExists } from './helpers/resourcesFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['resources'],
+};
+
+/**
+ * TC-RESO-006 (issue #2461): Resource Activities CRUD (timeline events).
+ *
+ * Activities are time-scoped timeline entries created over
+ * `/api/resources/activities` (makeActivityRoute) with `entityId` = the parent
+ * resource id. The list transforms rows to camelCase (`entityId`, `activityType`,
+ * `occurredAt`, ...) and enriches the author from the User entity. This spec
+ * verifies create (author defaults to the caller; `occurredAt` round-trips as the
+ * provided ISO timestamp), update of the subject, and removal on delete. Reads
+ * are query-index backed and poll briefly.
+ */
+type ActivityListBody = { items?: Array<Record<string, unknown>> };
+
+async function listActivities(
+  request: APIRequestContext,
+  token: string,
+  resourceId: string,
+): Promise<Array<Record<string, unknown>>> {
+  const res = await apiRequest(
+    request,
+    'GET',
+    `/api/resources/activities?entityId=${encodeURIComponent(resourceId)}&pageSize=100`,
+    { token },
+  );
+  expect(res.ok(), `activities list should succeed (status ${res.status()})`).toBeTruthy();
+  const body = await readJsonSafe<ActivityListBody>(res);
+  return body?.items ?? [];
+}
+
+test.describe('TC-RESO-006: Resource Activities CRUD (timeline events)', () => {
+  test('creates an activity with author + occurredAt, updates the subject, and deletes', async ({ request }) => {
+    test.slow();
+    const token = await getAuthToken(request, 'admin');
+    const { userId } = getTokenScope(token);
+    const stamp = Date.now();
+    const occurredAt = '2026-01-15T10:00:00.000Z';
+
+    let resourceId: string | null = null;
+    let activityId: string | null = null;
+    try {
+      resourceId = await createResourceFixture(request, token, `QA Activity Resource ${stamp}`);
+
+      const subject = `Filter replacement ${stamp}`;
+      const createRes = await apiRequest(request, 'POST', '/api/resources/activities', {
+        token,
+        data: {
+          entityId: resourceId,
+          activityType: 'maintenance',
+          subject,
+          body: 'Completed filter maintenance',
+          occurredAt,
+        },
+      });
+      expect(createRes.status(), 'create activity should return 201').toBe(201);
+      const createBody = await readJsonSafe<{ id?: string; authorUserId?: string }>(createRes);
+      activityId = createBody?.id ?? null;
+      expect(activityId, 'activity id returned').toBeTruthy();
+      expect(createBody?.authorUserId, 'activity author defaults to the caller').toBe(userId);
+
+      await expect
+        .poll(async () => (await listActivities(request, token, resourceId!)).some((activity) => activity.id === activityId), {
+          timeout: 8000,
+          message: 'activity should appear in the timeline',
+        })
+        .toBe(true);
+      const item = (await listActivities(request, token, resourceId)).find((activity) => activity.id === activityId)!;
+      expect(item.entityId).toBe(resourceId);
+      expect(item.activityType).toBe('maintenance');
+      expect(item.subject).toBe(subject);
+      expect(item.body).toBe('Completed filter maintenance');
+      expect(item.occurredAt).toBe(occurredAt);
+      expect(item.authorUserId).toBe(userId);
+
+      // Update the subject.
+      const updatedSubject = `Filter replacement (completed) ${stamp}`;
+      const updateRes = await apiRequest(request, 'PUT', '/api/resources/activities', {
+        token,
+        data: { id: activityId, subject: updatedSubject },
+      });
+      expect(updateRes.status(), 'update activity should return 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(updateRes))?.ok, 'update reports ok').toBe(true);
+
+      await expect
+        .poll(
+          async () =>
+            (await listActivities(request, token, resourceId!)).find((activity) => activity.id === activityId)?.subject ?? null,
+          { timeout: 8000, message: 'updated subject should be readable' },
+        )
+        .toBe(updatedSubject);
+      const afterUpdate = (await listActivities(request, token, resourceId)).find((activity) => activity.id === activityId)!;
+      expect(afterUpdate.occurredAt, 'occurredAt unchanged by subject update').toBe(occurredAt);
+
+      // Delete -> gone from the timeline.
+      const delRes = await apiRequest(request, 'DELETE', `/api/resources/activities?id=${encodeURIComponent(activityId!)}`, {
+        token,
+      });
+      expect(delRes.status(), 'delete activity should return 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(delRes))?.ok, 'delete reports ok').toBe(true);
+
+      await expect
+        .poll(async () => (await listActivities(request, token, resourceId!)).some((activity) => activity.id === activityId), {
+          timeout: 8000,
+          message: 'deleted activity should be gone',
+        })
+        .toBe(false);
+      activityId = null;
+    } finally {
+      if (activityId) {
+        await apiRequest(request, 'DELETE', `/api/resources/activities?id=${encodeURIComponent(activityId)}`, { token }).catch(
+          () => {},
+        );
+      }
+      await deleteResourceIfExists(request, token, resourceId);
+    }
+  });
+});

--- a/packages/core/src/modules/resources/__integration__/TC-RESO-007.spec.ts
+++ b/packages/core/src/modules/resources/__integration__/TC-RESO-007.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createResourceFixture,
+  deleteResourceIfExists,
+  createResourceTagFixture,
+  deleteResourceTagIfExists,
+} from './helpers/resourcesFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['resources', 'audit_logs'],
+};
+
+/**
+ * TC-RESO-007 (issue #2461): Tag assign/unassign custom routes + undo.
+ *
+ * `POST /api/resources/resources/tags/assign` and `.../unassign` are custom
+ * (non-CRUD) write routes that mutate the tag-assignment set and emit an undo
+ * token in the `x-om-operation` header. This spec verifies the real contract:
+ *   - assign -> 201 (+ undo token); unassign -> 200 (+ undo token)
+ *   - the assignment is reflected on the resource's `tags` array
+ *   - duplicate assign -> 409 ("Tag already assigned.")
+ *   - assign of an unknown (valid-UUID) tag -> 404; malformed tagId -> 400
+ *   - unassign of an absent assignment -> 404
+ *   - undo of unassign restores the assignment; undo of assign removes it
+ */
+const UNDO_PATH = '/api/audit_logs/audit-logs/actions/undo';
+const UNKNOWN_UUID = '00000000-0000-4000-8000-000000000000';
+
+function parseUndoToken(res: APIResponse): string {
+  const header = res.headers()['x-om-operation'] ?? '';
+  const encoded = header.replace(/^omop:/, '');
+  const payload = JSON.parse(decodeURIComponent(encoded)) as { undoToken?: string };
+  expect(typeof payload.undoToken, 'operation header should carry an undo token').toBe('string');
+  return payload.undoToken as string;
+}
+
+async function resourceTagIds(
+  request: APIRequestContext,
+  token: string,
+  resourceId: string,
+): Promise<string[]> {
+  const res = await apiRequest(request, 'GET', `/api/resources/resources?ids=${encodeURIComponent(resourceId)}`, { token });
+  const body = await readJsonSafe<{ items?: Array<{ id?: string; tags?: Array<{ id?: string }> }> }>(res);
+  const item = (body?.items ?? []).find((entry) => entry.id === resourceId);
+  const tags = Array.isArray(item?.tags) ? item!.tags : [];
+  return tags
+    .map((tag) => (typeof tag?.id === 'string' ? tag.id : null))
+    .filter((id): id is string => typeof id === 'string')
+    .sort((a, b) => a.localeCompare(b));
+}
+
+async function expectResourceTags(
+  request: APIRequestContext,
+  token: string,
+  resourceId: string,
+  expected: string[],
+  message: string,
+): Promise<void> {
+  const sorted = [...expected].sort((a, b) => a.localeCompare(b));
+  await expect
+    .poll(async () => resourceTagIds(request, token, resourceId), { timeout: 8000, message })
+    .toEqual(sorted);
+}
+
+test.describe('TC-RESO-007: tag assign/unassign routes + undo', () => {
+  test('assigns, unassigns, enforces 409/404/400 edges, and undoes both directions', async ({ request }) => {
+    test.slow();
+    const token = await getAuthToken(request, 'admin');
+    const stamp = Date.now();
+
+    let resourceId: string | null = null;
+    let tagAId: string | null = null;
+    let tagBId: string | null = null;
+    try {
+      tagAId = await createResourceTagFixture(request, token, { label: `QA Assign A ${stamp}` });
+      tagBId = await createResourceTagFixture(request, token, { label: `QA Assign B ${stamp}` });
+      resourceId = await createResourceFixture(request, token, `QA Assign Resource ${stamp}`);
+
+      // Assign A -> 201 + undo token; resource tags = [A].
+      const assignA = await apiRequest(request, 'POST', '/api/resources/resources/tags/assign', {
+        token,
+        data: { resourceId, tagId: tagAId },
+      });
+      expect(assignA.status(), 'assign tag A should return 201').toBe(201);
+      const assignAUndo = parseUndoToken(assignA);
+      await expectResourceTags(request, token, resourceId, [tagAId], 'resource should carry tag A after assign');
+
+      // Assign B -> 201; resource tags = [A, B].
+      const assignB = await apiRequest(request, 'POST', '/api/resources/resources/tags/assign', {
+        token,
+        data: { resourceId, tagId: tagBId },
+      });
+      expect(assignB.status(), 'assign tag B should return 201').toBe(201);
+      const assignBUndo = parseUndoToken(assignB);
+      await expectResourceTags(request, token, resourceId, [tagAId, tagBId], 'resource should carry tags A and B');
+
+      // Unassign A -> 200 + undo token; resource tags = [B].
+      const unassignA = await apiRequest(request, 'POST', '/api/resources/resources/tags/unassign', {
+        token,
+        data: { resourceId, tagId: tagAId },
+      });
+      expect(unassignA.status(), 'unassign tag A should return 200').toBe(200);
+      const unassignAUndo = parseUndoToken(unassignA);
+      await expectResourceTags(request, token, resourceId, [tagBId], 'resource should carry only tag B after unassign');
+
+      // Edge cases.
+      const duplicate = await apiRequest(request, 'POST', '/api/resources/resources/tags/assign', {
+        token,
+        data: { resourceId, tagId: tagBId },
+      });
+      expect(duplicate.status(), 'assigning an already-assigned tag must return 409').toBe(409);
+
+      const unknownTag = await apiRequest(request, 'POST', '/api/resources/resources/tags/assign', {
+        token,
+        data: { resourceId, tagId: UNKNOWN_UUID },
+      });
+      expect(unknownTag.status(), 'assigning an unknown (valid-UUID) tag must return 404').toBe(404);
+
+      const malformedTag = await apiRequest(request, 'POST', '/api/resources/resources/tags/assign', {
+        token,
+        data: { resourceId, tagId: 'not-a-uuid' },
+      });
+      expect(malformedTag.status(), 'assigning a malformed tag id must return 400').toBe(400);
+
+      const unassignAbsent = await apiRequest(request, 'POST', '/api/resources/resources/tags/unassign', {
+        token,
+        data: { resourceId, tagId: tagAId },
+      });
+      expect(unassignAbsent.status(), 'unassigning an absent assignment must return 404').toBe(404);
+
+      // Undo the unassign of A -> A is restored; resource tags = [A, B].
+      const undoUnassign = await apiRequest(request, 'POST', UNDO_PATH, { token, data: { undoToken: unassignAUndo } });
+      expect(undoUnassign.status(), 'undo of unassign should return 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(undoUnassign))?.ok, 'undo reports ok').toBe(true);
+      await expectResourceTags(request, token, resourceId, [tagAId, tagBId], 'undo of unassign restores tag A');
+
+      // Undo the assign of B -> B is removed; resource tags = [A].
+      const undoAssign = await apiRequest(request, 'POST', UNDO_PATH, { token, data: { undoToken: assignBUndo } });
+      expect(undoAssign.status(), 'undo of assign should return 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(undoAssign))?.ok, 'undo reports ok').toBe(true);
+      await expectResourceTags(request, token, resourceId, [tagAId], 'undo of assign removes tag B');
+
+      // assignAUndo is intentionally left unused: tag A stays assigned and is cleaned up via tag deletion below.
+      expect(typeof assignAUndo, 'assign A also issued an undo token').toBe('string');
+    } finally {
+      await deleteResourceTagIfExists(request, token, tagAId);
+      await deleteResourceTagIfExists(request, token, tagBId);
+      await deleteResourceIfExists(request, token, resourceId);
+    }
+  });
+});

--- a/packages/core/src/modules/resources/__integration__/TC-RESO-008.spec.ts
+++ b/packages/core/src/modules/resources/__integration__/TC-RESO-008.spec.ts
@@ -1,0 +1,155 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+import { deleteUserAclInDb } from '@open-mercato/core/helpers/integration/dbFixtures';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { deleteResourceIfExists } from './helpers/resourcesFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['resources'],
+};
+
+/**
+ * TC-RESO-008 (issue #2461): RBAC permission gates on the resources routes.
+ *
+ * The module declares `resources.view` (read) and `resources.manage_resources`
+ * (write, depends on view). This spec asserts the three permission tiers with a
+ * SEPARATE user per tier so each route-guard evaluation reflects that user's
+ * pre-set ACL (avoiding any same-session guard caching):
+ *   - no features  -> 403 on GET/POST/PUT/DELETE and on tag assign
+ *   - view only     -> GET 200, but writes (POST + assign) 403 (view != manage)
+ *   - view + manage -> POST 201
+ * Scope is injected from each user's token.
+ */
+const UNKNOWN_UUID = '00000000-0000-4000-8000-000000000000';
+
+test.describe('TC-RESO-008: RBAC permission gates (403)', () => {
+  test('no-access -> 403 everywhere; view-only -> read 200 / writes 403; manage -> writes succeed', async ({ request }) => {
+    test.slow();
+    const adminToken = await getAuthToken(request, 'admin');
+    const { organizationId } = getTokenContext(adminToken);
+    const stamp = Date.now();
+    const password = 'Secret123!';
+    const noAccessEmail = `tc-reso-008-noaccess-${stamp}@example.com`;
+    const viewerEmail = `tc-reso-008-viewer-${stamp}@example.com`;
+    const managerEmail = `tc-reso-008-manager-${stamp}@example.com`;
+
+    let roleId: string | null = null;
+    let noAccessUserId: string | null = null;
+    let viewerUserId: string | null = null;
+    let managerUserId: string | null = null;
+    let createdResourceId: string | null = null;
+    try {
+      roleId = await createRoleFixture(request, adminToken, { name: `TC-RESO-008 Role ${stamp}` });
+
+      // --- Tier 1: no features (empty role, no user ACL) ---
+      noAccessUserId = await createUserFixture(request, adminToken, {
+        email: noAccessEmail,
+        password,
+        organizationId,
+        roles: [roleId],
+      });
+      const noAccessToken = await getAuthToken(request, noAccessEmail, password);
+
+      expect(
+        (await apiRequest(request, 'GET', '/api/resources/resources?pageSize=1', { token: noAccessToken })).status(),
+        'no-access GET must be 403',
+      ).toBe(403);
+      expect(
+        (await apiRequest(request, 'POST', '/api/resources/resources', { token: noAccessToken, data: { name: 'nope' } })).status(),
+        'no-access POST must be 403',
+      ).toBe(403);
+      expect(
+        (
+          await apiRequest(request, 'PUT', '/api/resources/resources', {
+            token: noAccessToken,
+            data: { id: UNKNOWN_UUID, name: 'nope' },
+          })
+        ).status(),
+        'no-access PUT must be 403',
+      ).toBe(403);
+      expect(
+        (await apiRequest(request, 'DELETE', `/api/resources/resources?id=${UNKNOWN_UUID}`, { token: noAccessToken })).status(),
+        'no-access DELETE must be 403',
+      ).toBe(403);
+      expect(
+        (
+          await apiRequest(request, 'POST', '/api/resources/resources/tags/assign', {
+            token: noAccessToken,
+            data: { resourceId: UNKNOWN_UUID, tagId: UNKNOWN_UUID },
+          })
+        ).status(),
+        'no-access assign must be 403',
+      ).toBe(403);
+
+      // --- Tier 2: resources.view only ---
+      viewerUserId = await createUserFixture(request, adminToken, {
+        email: viewerEmail,
+        password,
+        organizationId,
+        roles: [roleId],
+      });
+      await setUserAclVisibility(request, adminToken, {
+        userId: viewerUserId,
+        features: ['resources.view'],
+        organizations: null,
+      });
+      const viewerToken = await getAuthToken(request, viewerEmail, password);
+
+      expect(
+        (await apiRequest(request, 'GET', '/api/resources/resources?pageSize=1', { token: viewerToken })).status(),
+        'viewer GET must be 200',
+      ).toBe(200);
+      expect(
+        (await apiRequest(request, 'POST', '/api/resources/resources', { token: viewerToken, data: { name: 'nope' } })).status(),
+        'viewer POST must be 403 (view != manage)',
+      ).toBe(403);
+      expect(
+        (
+          await apiRequest(request, 'POST', '/api/resources/resources/tags/assign', {
+            token: viewerToken,
+            data: { resourceId: UNKNOWN_UUID, tagId: UNKNOWN_UUID },
+          })
+        ).status(),
+        'viewer assign must be 403',
+      ).toBe(403);
+
+      // --- Tier 3: resources.view + resources.manage_resources ---
+      managerUserId = await createUserFixture(request, adminToken, {
+        email: managerEmail,
+        password,
+        organizationId,
+        roles: [roleId],
+      });
+      await setUserAclVisibility(request, adminToken, {
+        userId: managerUserId,
+        features: ['resources.view', 'resources.manage_resources'],
+        organizations: null,
+      });
+      const managerToken = await getAuthToken(request, managerEmail, password);
+
+      const managerPost = await apiRequest(request, 'POST', '/api/resources/resources', {
+        token: managerToken,
+        data: { name: `QA RBAC Resource ${stamp}` },
+      });
+      expect(managerPost.status(), 'manager POST must succeed (201)').toBe(201);
+      createdResourceId = (await readJsonSafe<{ id?: string }>(managerPost))?.id ?? null;
+      expect(createdResourceId, 'manager create returns an id').toBeTruthy();
+    } finally {
+      await deleteResourceIfExists(request, adminToken, createdResourceId);
+      await deleteUserIfExists(request, adminToken, noAccessUserId);
+      await deleteUserIfExists(request, adminToken, viewerUserId);
+      await deleteUserIfExists(request, adminToken, managerUserId);
+      await deleteUserAclInDb(noAccessUserId ?? '').catch(() => undefined);
+      await deleteUserAclInDb(viewerUserId ?? '').catch(() => undefined);
+      await deleteUserAclInDb(managerUserId ?? '').catch(() => undefined);
+      await deleteRoleIfExists(request, adminToken, roleId);
+    }
+  });
+});

--- a/packages/core/src/modules/resources/__integration__/TC-RESO-009.spec.ts
+++ b/packages/core/src/modules/resources/__integration__/TC-RESO-009.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createResourceTypeFixture,
+  deleteResourceTypeIfExists,
+  createResourceTagFixture,
+  deleteResourceTagIfExists,
+  deleteResourceIfExists,
+} from './helpers/resourcesFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['resources'],
+};
+
+/**
+ * TC-RESO-009 (issue #2461): Resource list search & filters + pagination.
+ *
+ * The resources list (`/api/resources/resources`) supports `search` (ILIKE on
+ * name), `isActive`, `resourceTypeId`, and `tagIds` (comma-separated; matches ANY
+ * tag) filters with AND semantics when combined, plus page/pageSize pagination.
+ * Every fixture name embeds a unique stamp so the suite stays isolated from any
+ * other data. Reads are query-index backed, so each assertion polls until the
+ * index reflects the fixtures.
+ */
+type ResourceListBody = {
+  items?: Array<Record<string, unknown>>;
+  total?: number;
+  page?: number;
+  pageSize?: number;
+  totalPages?: number;
+};
+
+async function fetchList(request: APIRequestContext, token: string, query: string): Promise<ResourceListBody> {
+  const res = await apiRequest(request, 'GET', `/api/resources/resources${query}`, { token });
+  expect(res.ok(), `resources list ${query} should succeed (status ${res.status()})`).toBeTruthy();
+  return (await readJsonSafe<ResourceListBody>(res)) ?? { items: [] };
+}
+
+function namesOf(body: ResourceListBody): string[] {
+  return (body.items ?? [])
+    .map((item) => item.name)
+    .filter((name): name is string => typeof name === 'string')
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function idsOf(body: ResourceListBody): string[] {
+  return (body.items ?? [])
+    .map((item) => item.id)
+    .filter((id): id is string => typeof id === 'string')
+    .sort((a, b) => a.localeCompare(b));
+}
+
+async function createResource(
+  request: APIRequestContext,
+  token: string,
+  data: { name: string; resourceTypeId?: string; isActive?: boolean; tags?: string[] },
+): Promise<string> {
+  const res = await apiRequest(request, 'POST', '/api/resources/resources', { token, data });
+  expect(res.status(), `create resource "${data.name}" should return 201`).toBe(201);
+  const id = (await readJsonSafe<{ id?: string }>(res))?.id ?? null;
+  expect(id, 'created resource id returned').toBeTruthy();
+  return id as string;
+}
+
+test.describe('TC-RESO-009: Resource list search & filters', () => {
+  test('filters by search, isActive, resourceTypeId, tagIds, combines them (AND), and paginates', async ({ request }) => {
+    test.slow();
+    const token = await getAuthToken(request, 'admin');
+    const stamp = Date.now();
+
+    let typeId: string | null = null;
+    let tagId: string | null = null;
+    const resourceIds: string[] = [];
+    try {
+      typeId = await createResourceTypeFixture(request, token, { name: `QA FilterType ${stamp}` });
+      tagId = await createResourceTagFixture(request, token, { label: `QA FilterTag ${stamp}` });
+
+      const warehouseA = `Warehouse A ${stamp}`;
+      const warehouseB = `Warehouse B ${stamp}`;
+      const storageCabinet = `Storage Cabinet ${stamp}`;
+      const oldResource = `Old Resource ${stamp}`;
+      const archivedItem = `Archived Item ${stamp}`;
+
+      const whA = await createResource(request, token, { name: warehouseA, resourceTypeId: typeId, isActive: true, tags: [tagId] });
+      const whB = await createResource(request, token, { name: warehouseB, resourceTypeId: typeId, isActive: true, tags: [tagId] });
+      const storage = await createResource(request, token, {
+        name: storageCabinet,
+        resourceTypeId: typeId,
+        isActive: true,
+        tags: [tagId],
+      });
+      const oldR = await createResource(request, token, { name: oldResource, isActive: false });
+      const archived = await createResource(request, token, { name: archivedItem, isActive: false });
+      resourceIds.push(whA, whB, storage, oldR, archived);
+
+      // Barrier: wait until all 5 fixtures are indexed (every name contains the stamp).
+      await expect
+        .poll(async () => namesOf(await fetchList(request, token, `?search=${stamp}&pageSize=100`)).length, {
+          timeout: 10000,
+          message: 'all 5 fixtures should be indexed',
+        })
+        .toBe(5);
+
+      // search by name fragment
+      await expect
+        .poll(async () => namesOf(await fetchList(request, token, `?search=${encodeURIComponent(`Warehouse ${stamp}`)}&pageSize=100`)), {
+          timeout: 8000,
+          message: 'search should match both Warehouse rows',
+        })
+        .toEqual([warehouseA, warehouseB].sort((a, b) => a.localeCompare(b)));
+
+      // isActive=true / false (scoped to our stamp)
+      await expect
+        .poll(async () => namesOf(await fetchList(request, token, `?search=${stamp}&isActive=true&pageSize=100`)), {
+          timeout: 8000,
+          message: 'isActive=true should return the 3 active rows',
+        })
+        .toEqual([warehouseA, warehouseB, storageCabinet].sort((a, b) => a.localeCompare(b)));
+      await expect
+        .poll(async () => namesOf(await fetchList(request, token, `?search=${stamp}&isActive=false&pageSize=100`)), {
+          timeout: 8000,
+          message: 'isActive=false should return the 2 inactive rows',
+        })
+        .toEqual([oldResource, archivedItem].sort((a, b) => a.localeCompare(b)));
+
+      // resourceTypeId filter
+      await expect
+        .poll(async () => idsOf(await fetchList(request, token, `?resourceTypeId=${typeId}&pageSize=100`)), {
+          timeout: 8000,
+          message: 'resourceTypeId should return only the typed rows',
+        })
+        .toEqual([whA, whB, storage].sort((a, b) => a.localeCompare(b)));
+
+      // tagIds filter
+      await expect
+        .poll(async () => idsOf(await fetchList(request, token, `?tagIds=${tagId}&pageSize=100`)), {
+          timeout: 8000,
+          message: 'tagIds should return only the tagged rows',
+        })
+        .toEqual([whA, whB, storage].sort((a, b) => a.localeCompare(b)));
+
+      // combined filters apply AND semantics
+      await expect
+        .poll(
+          async () =>
+            namesOf(
+              await fetchList(
+                request,
+                token,
+                `?search=${encodeURIComponent(`Warehouse ${stamp}`)}&isActive=true&tagIds=${tagId}&pageSize=100`,
+              ),
+            ),
+          { timeout: 8000, message: 'combined filters should intersect to the 2 Warehouse rows' },
+        )
+        .toEqual([warehouseA, warehouseB].sort((a, b) => a.localeCompare(b)));
+
+      // pagination
+      const page1 = await fetchList(request, token, `?search=${stamp}&page=1&pageSize=2`);
+      expect(page1.items?.length, 'page 1 holds pageSize items').toBe(2);
+      expect(page1.total, 'total reflects all 5 fixtures').toBe(5);
+      expect(page1.page, 'page echoes 1').toBe(1);
+      expect(page1.pageSize, 'pageSize echoes 2').toBe(2);
+      expect(page1.totalPages, 'totalPages = ceil(5 / 2)').toBe(3);
+    } finally {
+      for (const id of resourceIds) {
+        await deleteResourceIfExists(request, token, id);
+      }
+      await deleteResourceTagIfExists(request, token, tagId);
+      await deleteResourceTypeIfExists(request, token, typeId);
+    }
+  });
+});

--- a/packages/core/src/modules/resources/__integration__/helpers/resourcesFixtures.ts
+++ b/packages/core/src/modules/resources/__integration__/helpers/resourcesFixtures.ts
@@ -1,5 +1,5 @@
 import { expect, type APIRequestContext } from "@playwright/test";
-import { apiRequest } from "@open-mercato/core/modules/core/__integration__/helpers/api";
+import { apiRequest } from "@open-mercato/core/helpers/integration/api";
 
 function readStringId(payload: unknown): string | null {
   if (!payload || typeof payload !== "object") return null;
@@ -45,6 +45,70 @@ export async function deleteResourceIfExists(
     request,
     "DELETE",
     `/api/resources/resources?id=${encodeURIComponent(resourceId)}`,
+    { token },
+  ).catch(() => {});
+}
+
+export async function createResourceTypeFixture(
+  request: APIRequestContext,
+  token: string,
+  input: { name: string; description?: string; appearanceIcon?: string; appearanceColor?: string },
+): Promise<string> {
+  const response = await apiRequest(request, "POST", "/api/resources/resource-types", {
+    token,
+    data: input,
+  });
+  expect(
+    response.status(),
+    `Resource type fixture should be created (status ${response.status()})`,
+  ).toBe(201);
+  const typeId = readStringId(await response.json());
+  expect(typeId, "Resource type id should be returned by create response").toBeTruthy();
+  return typeId as string;
+}
+
+export async function deleteResourceTypeIfExists(
+  request: APIRequestContext,
+  token: string | null,
+  typeId: string | null,
+): Promise<void> {
+  if (!token || !typeId) return;
+  await apiRequest(
+    request,
+    "DELETE",
+    `/api/resources/resource-types?id=${encodeURIComponent(typeId)}`,
+    { token },
+  ).catch(() => {});
+}
+
+export async function createResourceTagFixture(
+  request: APIRequestContext,
+  token: string,
+  input: { label: string; slug?: string; color?: string; description?: string },
+): Promise<string> {
+  const response = await apiRequest(request, "POST", "/api/resources/tags", {
+    token,
+    data: input,
+  });
+  expect(
+    response.status(),
+    `Resource tag fixture should be created (status ${response.status()})`,
+  ).toBe(201);
+  const tagId = readStringId(await response.json());
+  expect(tagId, "Resource tag id should be returned by create response").toBeTruthy();
+  return tagId as string;
+}
+
+export async function deleteResourceTagIfExists(
+  request: APIRequestContext,
+  token: string | null,
+  tagId: string | null,
+): Promise<void> {
+  if (!token || !tagId) return;
+  await apiRequest(
+    request,
+    "DELETE",
+    `/api/resources/tags?id=${encodeURIComponent(tagId)}`,
     { token },
   ).catch(() => {});
 }


### PR DESCRIPTION
## Summary

Expands integration-test coverage for the `resources` module (closes #2461) with 7
new Playwright API specs: resource-types, tags, comments, and activities CRUD; the
tag assign/unassign custom routes with undo; RBAC permission gates; and list
search/filters with pagination. The specs encode the module's **verified real
behavior** (the issue was auto-generated and several of its proposed assertions were
inaccurate — e.g. flat comment/activity routes, a 400 referential guard on
in-use resource-type delete, hard-delete cascade for tags, `occurredAt` staying null
when omitted, and 409/404/400 assign edges). No product code is changed.

## Changes

- Add `TC-RESO-003` — Resource Types CRUD + referential delete guard (in-use → 400; soft-delete when unused)
- Add `TC-RESO-004` — Tags CRUD, auto-slug via `slugifyTagLabel`, hard-delete with assignment cascade
- Add `TC-RESO-005` — Comments CRUD, auto-author, `authorEmail` enrichment from the User entity
- Add `TC-RESO-006` — Activities CRUD, `occurredAt` round-trip, hard delete
- Add `TC-RESO-007` — Tag assign/unassign + undo (audit_logs) + edges (409/404/400, unassign-absent 404)
- Add `TC-RESO-008` — RBAC 403 gates across no-access / view-only / manage tiers (one user each)
- Add `TC-RESO-009` — search, isActive, resourceTypeId, tagIds, AND-combination, and pagination
- Extend `resources/__integration__/helpers/resourcesFixtures.ts` with resource-type and tag fixture creators/deleters

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test-only coverage following `.ai/qa/AGENTS.md`; scenarios enumerated in issue #2461.

## Testing

- `yarn turbo run typecheck --filter=@open-mercato/core` → clean (core typecheck covers `__integration__` specs)
- `yarn test:integration:ephemeral:start` then, against the ephemeral env, ran twice (idempotent):
  `BASE_URL=<baseUrl> DATABASE_URL=<ephemeral pg> ENABLE_CRUD_API_CACHE=true npx playwright test --config .ai/qa/tests/playwright.config.ts 'TC-RESO-00[3-9]'` → **7/7 passed** both runs
- `yarn i18n:check-sync` → all locales in sync
- `yarn turbo run test --filter=@open-mercato/core` → 663 suites / 5490 tests passed
- `yarn workspace @open-mercato/core build` → built successfully

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). _(author to confirm)_
- [x] I updated documentation, locales, or generators if the change requires it. _(none required; i18n:check-sync passes)_
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). _(specs live in the module `__integration__/` folder per current `.ai/qa/AGENTS.md`; `.ai/qa/tests/` is config-only)_
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). _(N/A — no design spec; scenarios enumerated in #2461)_

### Design System Compliance
_N/A — backend test-only change, no UI._
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #2461