### PR TITLE
feat: 2462 workflows integration coverage

### DIFF
--- a/packages/core/src/helpers/integration/workflowsFixtures.ts
+++ b/packages/core/src/helpers/integration/workflowsFixtures.ts
@@ -120,3 +120,234 @@ export async function cancelWorkflowInstanceIfExists(
     { token },
   ).catch(() => undefined);
 }
+
+/**
+ * Definition with a single USER_TASK queued to a role (not a specific user), so the
+ * generated task is claimable. The array form of `assignedTo` is intentional: the step
+ * handler stores an array `assignedTo` as `assignedToRoles` (a role queue) and leaves
+ * `assignedTo` null — the precondition `claimUserTask` requires. The post-task transition
+ * is `auto` so completing the task advances the instance to END (COMPLETED).
+ */
+export function buildClaimableUserTaskDefinitionPayload(timestamp: number, suffix = '') {
+  const id = `qa-wf-claim${suffix}-${timestamp}`;
+  return {
+    workflowId: id,
+    workflowName: `QA Claimable User Task${suffix} ${timestamp}`,
+    description: `Integration test definition ${id}`,
+    version: 1,
+    definition: {
+      steps: [
+        { stepId: 'start', stepName: 'Start', stepType: 'START' },
+        {
+          stepId: 'review',
+          stepName: 'Review',
+          stepType: 'USER_TASK',
+          userTaskConfig: {
+            assignedTo: ['admin'],
+            formSchema: {
+              properties: {
+                approved: { type: 'boolean' },
+                comments: { type: 'string' },
+              },
+              required: ['approved'],
+            },
+          },
+        },
+        { stepId: 'end', stepName: 'End', stepType: 'END' },
+      ],
+      transitions: [
+        { transitionId: 'start-to-review', fromStepId: 'start', toStepId: 'review', trigger: 'auto' },
+        { transitionId: 'review-to-end', fromStepId: 'review', toStepId: 'end', trigger: 'auto' },
+      ],
+    },
+    enabled: true,
+  };
+}
+
+/**
+ * Definition with a single USER_TASK assigned directly to one user id, so the generated
+ * task carries `assignedTo=<userId>` (and is therefore filterable by `assignedTo`/`myTasks`
+ * and NOT claimable from a role queue).
+ */
+export function buildAssignedUserTaskDefinitionPayload(timestamp: number, assignedUserId: string, suffix = '') {
+  const id = `qa-wf-assigned${suffix}-${timestamp}`;
+  return {
+    workflowId: id,
+    workflowName: `QA Assigned User Task${suffix} ${timestamp}`,
+    description: `Integration test definition ${id}`,
+    version: 1,
+    definition: {
+      steps: [
+        { stepId: 'start', stepName: 'Start', stepType: 'START' },
+        {
+          stepId: 'review',
+          stepName: 'Review',
+          stepType: 'USER_TASK',
+          userTaskConfig: {
+            assignedTo: assignedUserId,
+            formSchema: { properties: { approved: { type: 'boolean' } } },
+          },
+        },
+        { stepId: 'end', stepName: 'End', stepType: 'END' },
+      ],
+      transitions: [
+        { transitionId: 'start-to-review', fromStepId: 'start', toStepId: 'review', trigger: 'auto' },
+        { transitionId: 'review-to-end', fromStepId: 'review', toStepId: 'end', trigger: 'auto' },
+      ],
+    },
+    enabled: true,
+  };
+}
+
+/**
+ * Definition that pauses at a WAIT_FOR_SIGNAL step until the named signal arrives. The
+ * post-signal transition is `auto` so a matching signal resumes the instance to COMPLETED.
+ */
+export function buildSignalDefinitionPayload(timestamp: number, signalName = 'approval', suffix = '') {
+  const id = `qa-wf-signal${suffix}-${timestamp}`;
+  return {
+    workflowId: id,
+    workflowName: `QA Signal Workflow${suffix} ${timestamp}`,
+    description: `Integration test definition ${id}`,
+    version: 1,
+    definition: {
+      steps: [
+        { stepId: 'start', stepName: 'Start', stepType: 'START' },
+        { stepId: 'wait', stepName: 'Wait For Signal', stepType: 'WAIT_FOR_SIGNAL', signalConfig: { signalName } },
+        { stepId: 'end', stepName: 'End', stepType: 'END' },
+      ],
+      transitions: [
+        { transitionId: 'start-to-wait', fromStepId: 'start', toStepId: 'wait', trigger: 'auto' },
+        { transitionId: 'wait-to-end', fromStepId: 'wait', toStepId: 'end', trigger: 'auto' },
+      ],
+    },
+    enabled: true,
+  };
+}
+
+/**
+ * Linear START → mid → END definition whose transitions are all `manual`. The background
+ * executor never auto-fires them, so the instance rests at each step (RUNNING) until the
+ * `/advance` endpoint moves it on — the precondition for exercising manual progression.
+ */
+export function buildManualAdvanceDefinitionPayload(timestamp: number, suffix = '') {
+  const id = `qa-wf-advance${suffix}-${timestamp}`;
+  return {
+    workflowId: id,
+    workflowName: `QA Manual Advance Workflow${suffix} ${timestamp}`,
+    description: `Integration test definition ${id}`,
+    version: 1,
+    definition: {
+      steps: [
+        { stepId: 'start', stepName: 'Start', stepType: 'START' },
+        { stepId: 'mid', stepName: 'Middle', stepType: 'AUTOMATED' },
+        { stepId: 'end', stepName: 'End', stepType: 'END' },
+      ],
+      transitions: [
+        { transitionId: 'start-to-mid', fromStepId: 'start', toStepId: 'mid', trigger: 'manual' },
+        { transitionId: 'mid-to-end', fromStepId: 'mid', toStepId: 'end', trigger: 'manual' },
+      ],
+    },
+    enabled: true,
+  };
+}
+
+export type WorkflowInstanceSnapshot = {
+  id?: string;
+  status?: string;
+  currentStepId?: string;
+  retryCount?: number;
+  correlationKey?: string;
+  context?: Record<string, unknown>;
+};
+
+export async function getWorkflowInstanceSnapshot(
+  request: APIRequestContext,
+  token: string,
+  instanceId: string,
+): Promise<WorkflowInstanceSnapshot | null> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `/api/workflows/instances/${encodeURIComponent(instanceId)}`,
+    { token },
+  );
+  if (response.status() !== 200) return null;
+  const body = await readJsonSafe<{ data?: WorkflowInstanceSnapshot }>(response);
+  return body?.data ?? null;
+}
+
+/**
+ * Polls instance detail until `predicate` holds or the timeout elapses. Required because
+ * `POST /api/workflows/instances` runs execution in a background `setImmediate` callback,
+ * so the instance reaches its pause/terminal state asynchronously after the 201 response.
+ * Returns the last snapshot seen (so callers can assert on a timeout too).
+ */
+export async function pollWorkflowInstance(
+  request: APIRequestContext,
+  token: string,
+  instanceId: string,
+  predicate: (instance: WorkflowInstanceSnapshot) => boolean,
+  options: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<WorkflowInstanceSnapshot | null> {
+  const timeoutMs = options.timeoutMs ?? 8_000;
+  const intervalMs = options.intervalMs ?? 250;
+  const deadline = Date.now() + timeoutMs;
+  let last: WorkflowInstanceSnapshot | null = null;
+  for (;;) {
+    last = await getWorkflowInstanceSnapshot(request, token, instanceId);
+    if (last && predicate(last)) return last;
+    if (Date.now() >= deadline) return last;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+export type UserTaskSnapshot = {
+  id?: string;
+  status?: string;
+  assignedTo?: string | null;
+  assignedToRoles?: string[] | null;
+  claimedBy?: string | null;
+  completedBy?: string | null;
+  completedAt?: string | null;
+  workflowInstanceId?: string;
+};
+
+export async function listWorkflowInstanceTasks(
+  request: APIRequestContext,
+  token: string,
+  instanceId: string,
+): Promise<UserTaskSnapshot[]> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `/api/workflows/tasks?workflowInstanceId=${encodeURIComponent(instanceId)}`,
+    { token },
+  );
+  if (response.status() !== 200) return [];
+  const body = await readJsonSafe<{ data?: UserTaskSnapshot[] }>(response);
+  return body?.data ?? [];
+}
+
+/**
+ * Polls the task list scoped to `instanceId` until a task in one of `statuses` appears
+ * (default PENDING/IN_PROGRESS), accommodating the same background-execution delay.
+ */
+export async function findInstanceUserTask(
+  request: APIRequestContext,
+  token: string,
+  instanceId: string,
+  options: { timeoutMs?: number; intervalMs?: number; statuses?: string[] } = {},
+): Promise<UserTaskSnapshot | null> {
+  const timeoutMs = options.timeoutMs ?? 8_000;
+  const intervalMs = options.intervalMs ?? 250;
+  const statuses = options.statuses ?? ['PENDING', 'IN_PROGRESS'];
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const tasks = await listWorkflowInstanceTasks(request, token, instanceId);
+    const match = tasks.find((task) => typeof task.status === 'string' && statuses.includes(task.status));
+    if (match?.id) return match;
+    if (Date.now() >= deadline) return null;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-023.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-023.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  buildClaimableUserTaskDefinitionPayload,
+  cancelWorkflowInstanceIfExists,
+  createWorkflowDefinitionFixture,
+  deleteWorkflowDefinitionIfExists,
+  findInstanceUserTask,
+  pollWorkflowInstance,
+  startWorkflowInstanceFixture,
+  type UserTaskSnapshot,
+} from '@open-mercato/core/helpers/integration/workflowsFixtures'
+
+/**
+ * TC-WF-023 (issue #2462 scenario TC-WF-014) [P0]: User task claim + complete API flow
+ *
+ * Surfaces under test:
+ * - POST /api/workflows/tasks/[id]/claim
+ * - POST /api/workflows/tasks/[id]/complete
+ * - GET  /api/workflows/tasks/[id]
+ *
+ * Real-behavior notes (verified against task-handler.ts + the route error mapping):
+ * - `claimUserTask` only matches a PENDING task and requires it to be queued to a role
+ *   (assignedToRoles non-empty, assignedTo null). The claimable fixture uses the array form
+ *   of `assignedTo` which the step handler stores as a role queue.
+ * - Re-claiming an already-claimed (IN_PROGRESS) task throws "Task not found or already
+ *   claimed"; the route checks the 'not found' substring before 'already', so the response
+ *   is 404 (NOT the 409 the issue assumed).
+ */
+test.describe('TC-WF-023: user task claim and complete API flow (#2462)', () => {
+  test('claims a role-queue task, completes it, and resumes the workflow', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const userId = getTokenScope(token).userId
+    const timestamp = Date.now()
+    const defPayload = buildClaimableUserTaskDefinitionPayload(timestamp)
+    let definitionId: string | null = null
+    let instanceId: string | null = null
+
+    try {
+      definitionId = await createWorkflowDefinitionFixture(request, token, defPayload)
+      instanceId = await startWorkflowInstanceFixture(request, token, {
+        workflowId: defPayload.workflowId,
+        initialContext: { orderId: `order-${timestamp}` },
+      })
+
+      // The instance pauses at the USER_TASK; the PENDING task is created asynchronously
+      // by the background executor, so poll for it.
+      const pendingTask = await findInstanceUserTask(request, token, instanceId, { statuses: ['PENDING'] })
+      expect(pendingTask?.id, 'a PENDING user task should be created for the instance').toBeTruthy()
+      const taskId = pendingTask!.id!
+      expect(pendingTask?.status).toBe('PENDING')
+      expect(pendingTask?.assignedTo ?? null, 'a role-queue task is not assigned to a specific user').toBeNull()
+      expect(pendingTask?.assignedToRoles ?? [], 'task is queued to the admin role').toContain('admin')
+
+      // CLAIM — task moves to IN_PROGRESS and is attributed to the caller.
+      const claimResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/tasks/${encodeURIComponent(taskId)}/claim`,
+        { token },
+      )
+      expect(claimResponse.status(), `claim should return 200 (got ${claimResponse.status()})`).toBe(200)
+      const claimBody = await readJsonSafe<{ data?: UserTaskSnapshot }>(claimResponse)
+      expect(claimBody?.data?.status).toBe('IN_PROGRESS')
+      expect(claimBody?.data?.claimedBy).toBe(userId)
+
+      // GET detail reflects the claimed state.
+      const detailResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/workflows/tasks/${encodeURIComponent(taskId)}`,
+        { token },
+      )
+      expect(detailResponse.status(), 'GET task detail should return 200').toBe(200)
+      const detailBody = await readJsonSafe<{ data?: UserTaskSnapshot }>(detailResponse)
+      expect(detailBody?.data?.status).toBe('IN_PROGRESS')
+      expect(detailBody?.data?.claimedBy).toBe(userId)
+
+      // Re-claiming an already-claimed task returns 404 (see real-behavior note above).
+      const reclaimResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/tasks/${encodeURIComponent(taskId)}/claim`,
+        { token },
+      )
+      expect(reclaimResponse.status(), 'claiming an already-claimed task returns 404').toBe(404)
+
+      // COMPLETE — submit valid form data; task moves to COMPLETED.
+      const completeResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/tasks/${encodeURIComponent(taskId)}/complete`,
+        { token, data: { formData: { approved: true, comments: 'qa-approved' } } },
+      )
+      expect(completeResponse.status(), `complete should return 200 (got ${completeResponse.status()})`).toBe(200)
+      const completeBody = await readJsonSafe<{ data?: UserTaskSnapshot }>(completeResponse)
+      expect(completeBody?.data?.status).toBe('COMPLETED')
+      expect(completeBody?.data?.completedBy).toBe(userId)
+      expect(completeBody?.data?.completedAt, 'completedAt should be set').toBeTruthy()
+
+      // The `review -> end` auto transition resumes the instance to COMPLETED.
+      const finalInstance = await pollWorkflowInstance(
+        request,
+        token,
+        instanceId,
+        (instance) => instance.status === 'COMPLETED',
+      )
+      expect(finalInstance?.status, 'instance should resume past the USER_TASK and complete').toBe('COMPLETED')
+      instanceId = null // terminal — nothing to cancel
+    } finally {
+      await cancelWorkflowInstanceIfExists(request, token, instanceId)
+      await deleteWorkflowDefinitionIfExists(request, token, definitionId)
+    }
+  })
+
+  test('completing a missing task returns 404', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const response = await apiRequest(
+      request,
+      'POST',
+      `/api/workflows/tasks/${encodeURIComponent('00000000-0000-4000-8000-000000000000')}/complete`,
+      { token, data: { formData: { approved: true } } },
+    )
+    expect(response.status(), 'completing a non-existent task returns 404').toBe(404)
+  })
+})

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-024.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-024.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { withClient } from '@open-mercato/core/helpers/integration/dbFixtures'
+import {
+  buildAssignedUserTaskDefinitionPayload,
+  buildClaimableUserTaskDefinitionPayload,
+  cancelWorkflowInstanceIfExists,
+  createWorkflowDefinitionFixture,
+  deleteWorkflowDefinitionIfExists,
+  findInstanceUserTask,
+  startWorkflowInstanceFixture,
+  type UserTaskSnapshot,
+} from '@open-mercato/core/helpers/integration/workflowsFixtures'
+
+/**
+ * TC-WF-024 (issue #2462 scenario TC-WF-015) [P1]: User task list filtering
+ *
+ * Surface under test: GET /api/workflows/tasks (+ query filters)
+ *
+ * Filter assertions are scoped by `workflowInstanceId` so they stay deterministic against a
+ * shared database (other suites may have their own tasks). The overdue case forces a past
+ * `due_date` directly in the DB because there is no API to set it.
+ */
+type TaskListBody = {
+  data?: UserTaskSnapshot[]
+  pagination?: { total?: number; limit?: number; offset?: number; hasMore?: boolean }
+}
+
+const idsOf = (body: TaskListBody | null): string[] => (body?.data ?? []).map((task) => task.id ?? '')
+
+test.describe('TC-WF-024: user task list filtering (#2462)', () => {
+  test('filters tasks by status, assignee, instance, overdue, myTasks and paginates', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const userId = getTokenScope(token).userId
+    const timestamp = Date.now()
+    const assignedDef = buildAssignedUserTaskDefinitionPayload(timestamp, userId, '-a')
+    const claimableDef = buildClaimableUserTaskDefinitionPayload(timestamp, '-b')
+    let assignedDefId: string | null = null
+    let claimableDefId: string | null = null
+    let assignedInstanceId: string | null = null
+    let claimableInstanceId: string | null = null
+
+    const listTasks = async (query: string): Promise<TaskListBody | null> => {
+      const response = await apiRequest(request, 'GET', `/api/workflows/tasks${query}`, { token })
+      expect(response.status(), `GET /api/workflows/tasks${query} should return 200`).toBe(200)
+      return readJsonSafe<TaskListBody>(response)
+    }
+
+    try {
+      assignedDefId = await createWorkflowDefinitionFixture(request, token, assignedDef)
+      claimableDefId = await createWorkflowDefinitionFixture(request, token, claimableDef)
+
+      assignedInstanceId = await startWorkflowInstanceFixture(request, token, { workflowId: assignedDef.workflowId })
+      claimableInstanceId = await startWorkflowInstanceFixture(request, token, { workflowId: claimableDef.workflowId })
+
+      // TA: assigned directly to the caller (stays PENDING).
+      const assignedTask = await findInstanceUserTask(request, token, assignedInstanceId, { statuses: ['PENDING'] })
+      expect(assignedTask?.id, 'assigned task should exist').toBeTruthy()
+      const assignedTaskId = assignedTask!.id!
+      expect(assignedTask?.assignedTo, 'task is assigned to the caller').toBe(userId)
+
+      // TB: role-queue task we claim so it becomes IN_PROGRESS.
+      const claimableTask = await findInstanceUserTask(request, token, claimableInstanceId, { statuses: ['PENDING'] })
+      expect(claimableTask?.id, 'claimable task should exist').toBeTruthy()
+      const claimableTaskId = claimableTask!.id!
+      const claimResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/tasks/${encodeURIComponent(claimableTaskId)}/claim`,
+        { token },
+      )
+      expect(claimResponse.status(), 'claim should return 200').toBe(200)
+
+      // workflowInstanceId scoping narrows to exactly the instance's task.
+      const byAssignedInstance = await listTasks(`?workflowInstanceId=${encodeURIComponent(assignedInstanceId)}`)
+      expect(idsOf(byAssignedInstance)).toEqual([assignedTaskId])
+      const byClaimableInstance = await listTasks(`?workflowInstanceId=${encodeURIComponent(claimableInstanceId)}`)
+      expect(idsOf(byClaimableInstance)).toEqual([claimableTaskId])
+      expect(byClaimableInstance?.data?.[0]?.status, 'claimed task is IN_PROGRESS').toBe('IN_PROGRESS')
+
+      // status filter (single) within an instance scope.
+      const assignedPending = await listTasks(
+        `?workflowInstanceId=${encodeURIComponent(assignedInstanceId)}&status=PENDING`,
+      )
+      expect(idsOf(assignedPending)).toEqual([assignedTaskId])
+      const assignedInProgress = await listTasks(
+        `?workflowInstanceId=${encodeURIComponent(assignedInstanceId)}&status=IN_PROGRESS`,
+      )
+      expect(idsOf(assignedInProgress), 'a PENDING task is excluded by status=IN_PROGRESS').toEqual([])
+      const claimableInProgress = await listTasks(
+        `?workflowInstanceId=${encodeURIComponent(claimableInstanceId)}&status=IN_PROGRESS`,
+      )
+      expect(idsOf(claimableInProgress)).toEqual([claimableTaskId])
+
+      // status filter (comma-separated union) matches either status.
+      const assignedUnion = await listTasks(
+        `?workflowInstanceId=${encodeURIComponent(assignedInstanceId)}&status=PENDING,IN_PROGRESS`,
+      )
+      expect(idsOf(assignedUnion)).toEqual([assignedTaskId])
+      const claimableUnion = await listTasks(
+        `?workflowInstanceId=${encodeURIComponent(claimableInstanceId)}&status=PENDING,IN_PROGRESS`,
+      )
+      expect(idsOf(claimableUnion)).toEqual([claimableTaskId])
+
+      // assignedTo filter matches only the directly-assigned task.
+      const byAssignee = await listTasks(
+        `?workflowInstanceId=${encodeURIComponent(assignedInstanceId)}&assignedTo=${encodeURIComponent(userId)}`,
+      )
+      expect(idsOf(byAssignee)).toEqual([assignedTaskId])
+      const claimableByAssignee = await listTasks(
+        `?workflowInstanceId=${encodeURIComponent(claimableInstanceId)}&assignedTo=${encodeURIComponent(userId)}`,
+      )
+      expect(idsOf(claimableByAssignee), 'a role-queue task is not matched by assignedTo=<user>').toEqual([])
+
+      // myTasks includes a task assigned to the caller.
+      const myTasks = await listTasks(
+        `?workflowInstanceId=${encodeURIComponent(assignedInstanceId)}&myTasks=true`,
+      )
+      expect(idsOf(myTasks)).toEqual([assignedTaskId])
+
+      // Pagination: limit caps the page; total/hasMore reflect the full result set.
+      const firstPage = await listTasks('?limit=1&offset=0')
+      expect((firstPage?.data ?? []).length, 'limit=1 returns at most one item').toBeLessThanOrEqual(1)
+      expect(firstPage?.pagination?.limit).toBe(1)
+      expect(firstPage?.pagination?.total ?? 0, 'at least the two fixtures exist').toBeGreaterThanOrEqual(2)
+      expect(firstPage?.pagination?.hasMore, 'more pages exist beyond limit=1').toBe(true)
+
+      // overdue: force a past due date, then the overdue filter surfaces the PENDING task and
+      // still excludes the IN_PROGRESS task that has no due date.
+      await withClient(async (client) => {
+        await client.query(
+          "update user_tasks set due_date = now() - interval '1 day', updated_at = now() where id = $1",
+          [assignedTaskId],
+        )
+      })
+      const overdueAssigned = await listTasks(
+        `?workflowInstanceId=${encodeURIComponent(assignedInstanceId)}&overdue=true`,
+      )
+      expect(idsOf(overdueAssigned), 'past-due PENDING task is overdue').toEqual([assignedTaskId])
+      const overdueClaimable = await listTasks(
+        `?workflowInstanceId=${encodeURIComponent(claimableInstanceId)}&overdue=true`,
+      )
+      expect(idsOf(overdueClaimable), 'a task without a due date is not overdue').toEqual([])
+    } finally {
+      await cancelWorkflowInstanceIfExists(request, token, assignedInstanceId)
+      await cancelWorkflowInstanceIfExists(request, token, claimableInstanceId)
+      await deleteWorkflowDefinitionIfExists(request, token, assignedDefId)
+      await deleteWorkflowDefinitionIfExists(request, token, claimableDefId)
+    }
+  })
+})

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-025.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-025.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  buildSignalDefinitionPayload,
+  cancelWorkflowInstanceIfExists,
+  createWorkflowDefinitionFixture,
+  deleteWorkflowDefinitionIfExists,
+  pollWorkflowInstance,
+  startWorkflowInstanceFixture,
+} from '@open-mercato/core/helpers/integration/workflowsFixtures'
+
+/**
+ * TC-WF-025 (issue #2462 scenario TC-WF-016) [P0]: Instance signal send (direct + correlation)
+ *
+ * Surfaces under test:
+ * - POST /api/workflows/instances/[id]/signal
+ * - POST /api/workflows/signals
+ *
+ * The definition pauses at a WAIT_FOR_SIGNAL("approval") step; a matching signal resumes it
+ * via the auto `wait -> end` transition. Instances must be polled to PAUSED before signalling
+ * (they are briefly RUNNING at START while the background executor advances to the wait step).
+ */
+const SIGNAL_NAME = 'approval'
+
+test.describe('TC-WF-025: instance signal send (#2462)', () => {
+  test('sends a direct signal to a paused instance and rejects invalid signal states', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const timestamp = Date.now()
+    const defPayload = buildSignalDefinitionPayload(timestamp, SIGNAL_NAME, '-direct')
+    let definitionId: string | null = null
+    let instanceId: string | null = null
+
+    try {
+      definitionId = await createWorkflowDefinitionFixture(request, token, defPayload)
+      instanceId = await startWorkflowInstanceFixture(request, token, {
+        workflowId: defPayload.workflowId,
+        correlationKey: `qa-direct-${timestamp}`,
+      })
+
+      const paused = await pollWorkflowInstance(request, token, instanceId, (i) => i.status === 'PAUSED')
+      expect(paused?.status, 'instance should pause waiting for the signal').toBe('PAUSED')
+      expect(paused?.currentStepId).toBe('wait')
+
+      // Wrong signal name → 400 (SIGNAL_NAME_MISMATCH); the instance stays paused.
+      const mismatchResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/instances/${encodeURIComponent(instanceId)}/signal`,
+        { token, data: { signalName: 'not-the-expected-signal' } },
+      )
+      expect(mismatchResponse.status(), 'a mismatched signal name returns 400').toBe(400)
+
+      // Correct signal → 200 and the instance resumes to COMPLETED.
+      const signalResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/instances/${encodeURIComponent(instanceId)}/signal`,
+        { token, data: { signalName: SIGNAL_NAME, payload: { decidedBy: 'qa' } } },
+      )
+      expect(signalResponse.status(), `signal should return 200 (got ${signalResponse.status()})`).toBe(200)
+      const signalBody = await readJsonSafe<{ success?: boolean }>(signalResponse)
+      expect(signalBody?.success).toBe(true)
+
+      const completed = await pollWorkflowInstance(request, token, instanceId, (i) => i.status === 'COMPLETED')
+      expect(completed?.status, 'instance should resume past the WAIT_FOR_SIGNAL step').toBe('COMPLETED')
+
+      // Signalling a now-terminal (non-paused) instance → 409 (WORKFLOW_NOT_PAUSED).
+      const notPausedResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/instances/${encodeURIComponent(instanceId)}/signal`,
+        { token, data: { signalName: SIGNAL_NAME } },
+      )
+      expect(notPausedResponse.status(), 'signalling a non-paused instance returns 409').toBe(409)
+      instanceId = null // completed — nothing to cancel
+
+      // Signalling a non-existent instance → 404 (INSTANCE_NOT_FOUND).
+      const missingResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/instances/${encodeURIComponent('00000000-0000-4000-8000-000000000000')}/signal`,
+        { token, data: { signalName: SIGNAL_NAME } },
+      )
+      expect(missingResponse.status(), 'signalling a missing instance returns 404').toBe(404)
+    } finally {
+      await cancelWorkflowInstanceIfExists(request, token, instanceId)
+      await deleteWorkflowDefinitionIfExists(request, token, definitionId)
+    }
+  })
+
+  test('sends a signal to all instances matching a correlation key', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const timestamp = Date.now()
+    const defPayload = buildSignalDefinitionPayload(timestamp, SIGNAL_NAME, '-corr')
+    const correlationKey = `qa-corr-${timestamp}`
+    let definitionId: string | null = null
+    let firstInstanceId: string | null = null
+    let secondInstanceId: string | null = null
+
+    try {
+      definitionId = await createWorkflowDefinitionFixture(request, token, defPayload)
+      firstInstanceId = await startWorkflowInstanceFixture(request, token, {
+        workflowId: defPayload.workflowId,
+        correlationKey,
+      })
+      secondInstanceId = await startWorkflowInstanceFixture(request, token, {
+        workflowId: defPayload.workflowId,
+        correlationKey,
+      })
+
+      const firstPaused = await pollWorkflowInstance(request, token, firstInstanceId, (i) => i.status === 'PAUSED')
+      const secondPaused = await pollWorkflowInstance(request, token, secondInstanceId, (i) => i.status === 'PAUSED')
+      expect(firstPaused?.status).toBe('PAUSED')
+      expect(secondPaused?.status).toBe('PAUSED')
+
+      // A correlation-key signal with no matching paused instance returns count=0 (no throw).
+      const noMatchResponse = await apiRequest(request, 'POST', '/api/workflows/signals', {
+        token,
+        data: { correlationKey: `qa-no-match-${timestamp}`, signalName: SIGNAL_NAME },
+      })
+      expect(noMatchResponse.status(), 'no-match correlation signal returns 200').toBe(200)
+      const noMatchBody = await readJsonSafe<{ count?: number }>(noMatchResponse)
+      expect(noMatchBody?.count, 'no instances match the unused correlation key').toBe(0)
+
+      // The real correlation signal fans out to both paused instances.
+      const fanOutResponse = await apiRequest(request, 'POST', '/api/workflows/signals', {
+        token,
+        data: { correlationKey, signalName: SIGNAL_NAME },
+      })
+      expect(fanOutResponse.status(), `correlation signal should return 200 (got ${fanOutResponse.status()})`).toBe(200)
+      const fanOutBody = await readJsonSafe<{ count?: number }>(fanOutResponse)
+      expect(fanOutBody?.count, 'both correlated instances receive the signal').toBe(2)
+
+      const firstCompleted = await pollWorkflowInstance(request, token, firstInstanceId, (i) => i.status === 'COMPLETED')
+      const secondCompleted = await pollWorkflowInstance(request, token, secondInstanceId, (i) => i.status === 'COMPLETED')
+      expect(firstCompleted?.status).toBe('COMPLETED')
+      expect(secondCompleted?.status).toBe('COMPLETED')
+      firstInstanceId = null
+      secondInstanceId = null
+    } finally {
+      await cancelWorkflowInstanceIfExists(request, token, firstInstanceId)
+      await cancelWorkflowInstanceIfExists(request, token, secondInstanceId)
+      await deleteWorkflowDefinitionIfExists(request, token, definitionId)
+    }
+  })
+})

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-026.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-026.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { withClient } from '@open-mercato/core/helpers/integration/dbFixtures'
+import {
+  buildMinimalDefinitionPayload,
+  buildSignalDefinitionPayload,
+  cancelWorkflowInstanceIfExists,
+  createWorkflowDefinitionFixture,
+  deleteWorkflowDefinitionIfExists,
+  pollWorkflowInstance,
+  startWorkflowInstanceFixture,
+} from '@open-mercato/core/helpers/integration/workflowsFixtures'
+
+/**
+ * TC-WF-026 (issue #2462 scenario TC-WF-017) [P1]: Instance retry API for failed workflows
+ *
+ * Surface under test: POST /api/workflows/instances/[id]/retry
+ *
+ * There is no API to fail a workflow deterministically, so the happy path completes a minimal
+ * workflow and then forces the row into FAILED before retrying — the same approach the issue
+ * sanctions ("manually set to FAILED via fixture"). The forced instance still points at its END
+ * step, so the retry proves the FAILED -> RUNNING recovery and retryCount increment (re-detecting
+ * END to completion), not mid-flow step re-execution. The guards confirm only FAILED instances
+ * may be retried.
+ */
+test.describe('TC-WF-026: instance retry API (#2462)', () => {
+  test('retries a failed instance, incrementing retryCount and clearing the failure', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const timestamp = Date.now()
+    const defPayload = buildMinimalDefinitionPayload(timestamp, '-retry')
+    let definitionId: string | null = null
+    let instanceId: string | null = null
+
+    try {
+      definitionId = await createWorkflowDefinitionFixture(request, token, defPayload)
+      instanceId = await startWorkflowInstanceFixture(request, token, { workflowId: defPayload.workflowId })
+
+      // Let the minimal workflow finish, then force a FAILED state to retry from.
+      await pollWorkflowInstance(request, token, instanceId, (i) => i.status === 'COMPLETED')
+      await withClient(async (client) => {
+        await client.query(
+          "update workflow_instances set status = 'FAILED', retry_count = 0, error_message = '[qa] forced failure', error_details = null, completed_at = null, updated_at = now() where id = $1",
+          [instanceId],
+        )
+      })
+
+      const retryResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/instances/${encodeURIComponent(instanceId)}/retry`,
+        { token },
+      )
+      expect(retryResponse.status(), `retry should return 200 (got ${retryResponse.status()})`).toBe(200)
+      const retryBody = await readJsonSafe<{ data?: { instance?: { status?: string; retryCount?: number } } }>(retryResponse)
+      expect(retryBody?.data?.instance?.retryCount, 'retryCount is incremented to 1').toBe(1)
+      expect(retryBody?.data?.instance?.status, 'instance is no longer FAILED after retry').not.toBe('FAILED')
+
+      const recovered = await pollWorkflowInstance(request, token, instanceId, (i) => i.status === 'COMPLETED')
+      expect(recovered?.status, 'retried instance resumes and completes').toBe('COMPLETED')
+      instanceId = null
+    } finally {
+      await cancelWorkflowInstanceIfExists(request, token, instanceId)
+      await deleteWorkflowDefinitionIfExists(request, token, definitionId)
+    }
+  })
+
+  test('rejects retry of a completed instance with 400', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const timestamp = Date.now()
+    const defPayload = buildMinimalDefinitionPayload(timestamp, '-retry-completed')
+    let definitionId: string | null = null
+    let instanceId: string | null = null
+
+    try {
+      definitionId = await createWorkflowDefinitionFixture(request, token, defPayload)
+      instanceId = await startWorkflowInstanceFixture(request, token, { workflowId: defPayload.workflowId })
+      const completed = await pollWorkflowInstance(request, token, instanceId, (i) => i.status === 'COMPLETED')
+      expect(completed?.status).toBe('COMPLETED')
+
+      const retryResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/instances/${encodeURIComponent(instanceId)}/retry`,
+        { token },
+      )
+      expect(retryResponse.status(), 'retrying a COMPLETED instance returns 400').toBe(400)
+      instanceId = null
+    } finally {
+      await cancelWorkflowInstanceIfExists(request, token, instanceId)
+      await deleteWorkflowDefinitionIfExists(request, token, definitionId)
+    }
+  })
+
+  test('rejects retry of a cancelled instance with 400', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const timestamp = Date.now()
+    const defPayload = buildSignalDefinitionPayload(timestamp, 'approval', '-retry-cancelled')
+    let definitionId: string | null = null
+    let instanceId: string | null = null
+
+    try {
+      definitionId = await createWorkflowDefinitionFixture(request, token, defPayload)
+      instanceId = await startWorkflowInstanceFixture(request, token, { workflowId: defPayload.workflowId })
+
+      // Pause at the signal step, then cancel so the instance is in a terminal CANCELLED state.
+      const paused = await pollWorkflowInstance(request, token, instanceId, (i) => i.status === 'PAUSED')
+      expect(paused?.status).toBe('PAUSED')
+      const cancelResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/instances/${encodeURIComponent(instanceId)}/cancel`,
+        { token },
+      )
+      expect(cancelResponse.status(), 'cancel should return 200').toBe(200)
+
+      const retryResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/instances/${encodeURIComponent(instanceId)}/retry`,
+        { token },
+      )
+      expect(retryResponse.status(), 'retrying a CANCELLED instance returns 400').toBe(400)
+      instanceId = null
+    } finally {
+      await cancelWorkflowInstanceIfExists(request, token, instanceId)
+      await deleteWorkflowDefinitionIfExists(request, token, definitionId)
+    }
+  })
+})

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-027.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-027.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  buildManualAdvanceDefinitionPayload,
+  cancelWorkflowInstanceIfExists,
+  createWorkflowDefinitionFixture,
+  deleteWorkflowDefinitionIfExists,
+  pollWorkflowInstance,
+  startWorkflowInstanceFixture,
+} from '@open-mercato/core/helpers/integration/workflowsFixtures'
+
+/**
+ * TC-WF-027 (issue #2462 scenario TC-WF-018) [P2]: Instance advance API for manual progression
+ *
+ * Surface under test: POST /api/workflows/instances/[id]/advance
+ *
+ * The definition (START -> mid -> END, all manual transitions) never auto-advances, so each
+ * `/advance` call drives exactly one step. The advance response reports `currentStepId` from a
+ * pre-auto-progress snapshot, so terminal completion is confirmed by polling.
+ */
+type AdvanceBody = {
+  data?: {
+    instance?: {
+      status?: string
+      currentStepId?: string
+      previousStepId?: string
+      transitionFired?: string
+      context?: Record<string, unknown>
+    }
+  }
+}
+
+test.describe('TC-WF-027: instance advance API (#2462)', () => {
+  test('advances a manual workflow step by step and rejects advancing a completed instance', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const timestamp = Date.now()
+    const defPayload = buildManualAdvanceDefinitionPayload(timestamp)
+    let definitionId: string | null = null
+    let instanceId: string | null = null
+
+    try {
+      definitionId = await createWorkflowDefinitionFixture(request, token, defPayload)
+      instanceId = await startWorkflowInstanceFixture(request, token, { workflowId: defPayload.workflowId })
+
+      // Manual transitions never auto-fire, so the instance rests at START.
+      const atStart = await pollWorkflowInstance(
+        request,
+        token,
+        instanceId,
+        (i) => i.status === 'RUNNING' && i.currentStepId === 'start',
+      )
+      expect(atStart?.currentStepId, 'instance rests at START awaiting manual advance').toBe('start')
+
+      // Advancing to a non-existent step is rejected; the instance stays at START.
+      const badTargetResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/instances/${encodeURIComponent(instanceId)}/advance`,
+        { token, data: { toStepId: 'does-not-exist' } },
+      )
+      expect(badTargetResponse.status(), 'advancing to an invalid step returns 400').toBe(400)
+
+      // Advance with an explicit target + context updates.
+      const toMidResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/instances/${encodeURIComponent(instanceId)}/advance`,
+        { token, data: { toStepId: 'mid', contextUpdates: { advancedBy: 'qa' } } },
+      )
+      expect(toMidResponse.status(), `advance to mid should return 200 (got ${toMidResponse.status()})`).toBe(200)
+      const toMidBody = await readJsonSafe<AdvanceBody>(toMidResponse)
+      expect(toMidBody?.data?.instance?.currentStepId).toBe('mid')
+      expect(toMidBody?.data?.instance?.previousStepId).toBe('start')
+      expect(toMidBody?.data?.instance?.transitionFired).toBe('start-to-mid')
+      expect(toMidBody?.data?.instance?.context?.advancedBy, 'contextUpdates merge into the workflow context').toBe('qa')
+
+      // Advance without a target auto-selects the only valid transition (mid -> end).
+      const toEndResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/instances/${encodeURIComponent(instanceId)}/advance`,
+        { token, data: {} },
+      )
+      expect(toEndResponse.status(), `advance to end should return 200 (got ${toEndResponse.status()})`).toBe(200)
+      const toEndBody = await readJsonSafe<AdvanceBody>(toEndResponse)
+      expect(toEndBody?.data?.instance?.currentStepId).toBe('end')
+      expect(toEndBody?.data?.instance?.transitionFired).toBe('mid-to-end')
+
+      // Reaching END auto-completes the instance.
+      const completed = await pollWorkflowInstance(request, token, instanceId, (i) => i.status === 'COMPLETED')
+      expect(completed?.status, 'instance completes after reaching END').toBe('COMPLETED')
+
+      // Advancing a completed instance is rejected.
+      const afterCompleteResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/workflows/instances/${encodeURIComponent(instanceId)}/advance`,
+        { token, data: {} },
+      )
+      expect(afterCompleteResponse.status(), 'advancing a COMPLETED instance returns 400').toBe(400)
+      instanceId = null
+    } finally {
+      await cancelWorkflowInstanceIfExists(request, token, instanceId)
+      await deleteWorkflowDefinitionIfExists(request, token, definitionId)
+    }
+  })
+})

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-028.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-028.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from '@playwright/test'
+import { randomInt } from 'node:crypto'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createOrganizationFixture,
+  createRoleFixture,
+  createUserFixture,
+  deleteOrganizationIfExists,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import {
+  buildMinimalDefinitionPayload,
+  createWorkflowDefinitionFixture,
+  deleteWorkflowDefinitionIfExists,
+} from '@open-mercato/core/helpers/integration/workflowsFixtures'
+
+/**
+ * TC-WF-028 (issue #2462 scenario TC-WF-019) [P0]: Permission gate enforcement (RBAC)
+ *
+ * Surfaces under test (mutation gates):
+ * - POST /api/workflows/definitions, /api/workflows/instances
+ * - POST /api/workflows/tasks/[id]/claim, /complete
+ * - POST /api/workflows/instances/[id]/signal
+ *
+ * The restricted role gets view-only workflows features, so it clears the declarative view
+ * guards and we exercise the create-specific inner checks (definitions/instances) as well as
+ * the declarative mutation guards (claim/complete/signal). A wildcard-granted admin is the
+ * positive control. Fabricated UUIDs are used because the gates run before any record lookup.
+ */
+const FABRICATED_ID = '00000000-0000-4000-8000-000000000000'
+
+test.describe('TC-WF-028: workflow permission gate enforcement (#2462)', () => {
+  test('denies mutations to a user without the required workflows features', async ({ request }) => {
+    const superadminToken = await getAuthToken(request, 'superadmin')
+    const stamp = `${Date.now()}-${randomInt(1_000_000)}`
+    const password = 'StrongSecret123!'
+    let tenantId = getTokenContext(superadminToken).tenantId
+    if (!tenantId) {
+      const existing = await apiRequest(request, 'GET', '/api/directory/organizations?page=1&pageSize=1', { token: superadminToken })
+      const body = await readJsonSafe<{ items?: Array<{ tenantId?: string | null }> }>(existing)
+      tenantId = body?.items?.[0]?.tenantId ?? ''
+    }
+    const tenantOpt = tenantId ? { tenantId } : {}
+
+    let orgId: string | null = null
+    let roleId: string | null = null
+    let userId: string | null = null
+    let adminDefinitionId: string | null = null
+    const adminToken = await getAuthToken(request, 'admin')
+
+    try {
+      orgId = await createOrganizationFixture(request, superadminToken, { name: `qa-tc-wf-028-${stamp}`, ...tenantOpt })
+      roleId = await createRoleFixture(request, superadminToken, { name: `qa-tc-wf-028-${stamp}`, ...tenantOpt })
+      // View-only: clears declarative view guards but lacks every mutation feature.
+      await setRoleAclFeatures(request, superadminToken, {
+        roleId,
+        features: ['workflows.view', 'workflows.definitions.view', 'workflows.instances.view', 'workflows.tasks.view'],
+        organizations: null,
+      })
+      userId = await createUserFixture(request, superadminToken, {
+        email: `qa-tc-wf-028-${stamp}@example.com`,
+        password,
+        organizationId: orgId,
+        roles: [roleId],
+        name: 'QA TC-WF-028',
+      })
+      const userToken = await getAuthToken(request, `qa-tc-wf-028-${stamp}@example.com`, password)
+
+      const definitionPayload = buildMinimalDefinitionPayload(Date.now(), '-rbac')
+
+      const createDefinition = await apiRequest(request, 'POST', '/api/workflows/definitions', {
+        token: userToken,
+        data: definitionPayload,
+      })
+      expect(createDefinition.status(), 'create definition without workflows.definitions.create is forbidden').toBe(403)
+
+      const startInstance = await apiRequest(request, 'POST', '/api/workflows/instances', {
+        token: userToken,
+        data: { workflowId: definitionPayload.workflowId },
+      })
+      expect(startInstance.status(), 'start instance without workflows.instances.create is forbidden').toBe(403)
+
+      const claim = await apiRequest(request, 'POST', `/api/workflows/tasks/${FABRICATED_ID}/claim`, { token: userToken })
+      expect(claim.status(), 'claim without workflows.tasks.claim is forbidden').toBe(403)
+
+      const complete = await apiRequest(request, 'POST', `/api/workflows/tasks/${FABRICATED_ID}/complete`, {
+        token: userToken,
+        data: { formData: { approved: true } },
+      })
+      expect(complete.status(), 'complete without workflows.tasks.complete is forbidden').toBe(403)
+
+      const signal = await apiRequest(request, 'POST', `/api/workflows/instances/${FABRICATED_ID}/signal`, {
+        token: userToken,
+        data: { signalName: 'approval' },
+      })
+      expect(signal.status(), 'signal without workflows.instances.signal is forbidden').toBe(403)
+
+      // Unauthenticated requests are rejected before any feature check.
+      const unauthenticated = await apiRequest(request, 'GET', '/api/workflows/definitions', {
+        token: 'not-a-valid-session-token',
+      })
+      expect(unauthenticated.status(), 'an invalid token returns 401').toBe(401)
+
+      // Positive control: an admin holding the workflows.* wildcard can create a definition.
+      adminDefinitionId = await createWorkflowDefinitionFixture(request, adminToken, definitionPayload)
+      expect(adminDefinitionId, 'wildcard-granted admin can create a definition').toBeTruthy()
+    } finally {
+      await deleteWorkflowDefinitionIfExists(request, adminToken, adminDefinitionId)
+      await deleteUserIfExists(request, superadminToken, userId)
+      await deleteRoleIfExists(request, superadminToken, roleId)
+      await deleteOrganizationIfExists(request, superadminToken, orgId)
+    }
+  })
+})

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-029.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-029.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from '@playwright/test'
+import { randomInt } from 'node:crypto'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createOrganizationFixture,
+  createRoleFixture,
+  createUserFixture,
+  deleteOrganizationIfExists,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import {
+  buildMinimalDefinitionPayload,
+  cancelWorkflowInstanceIfExists,
+  createWorkflowDefinitionFixture,
+  deleteWorkflowDefinitionIfExists,
+  startWorkflowInstanceFixture,
+} from '@open-mercato/core/helpers/integration/workflowsFixtures'
+
+/**
+ * TC-WF-029 (issue #2462 scenario TC-WF-020) [P0]: Organization scoping / cross-org isolation
+ *
+ * Surfaces under test:
+ * - GET  /api/workflows/definitions, /api/workflows/definitions/[id]
+ * - GET  /api/workflows/instances, /api/workflows/instances/[id]
+ * - POST /api/workflows/instances
+ *
+ * Two organization-restricted users in the same tenant prove the workflows routes honor the
+ * organization scope filter (unlike the directory list): a user in org B cannot list, read, or
+ * start workflows that belong to org A. Negative list assertions use `?workflowId=` so they
+ * stay deterministic regardless of pagination. Positive controls prove the records exist.
+ */
+type DefinitionListBody = { data?: Array<{ id?: string; workflowId?: string }> }
+type InstanceListBody = { data?: Array<{ id?: string }> }
+
+test.describe('TC-WF-029: workflow organization scoping (#2462)', () => {
+  test('isolates workflow definitions and instances across organizations', async ({ request }) => {
+    const superadminToken = await getAuthToken(request, 'superadmin')
+    const stamp = `${Date.now()}-${randomInt(1_000_000)}`
+    const password = 'StrongSecret123!'
+    let tenantId = getTokenContext(superadminToken).tenantId
+    if (!tenantId) {
+      const existing = await apiRequest(request, 'GET', '/api/directory/organizations?page=1&pageSize=1', { token: superadminToken })
+      const body = await readJsonSafe<{ items?: Array<{ tenantId?: string | null }> }>(existing)
+      tenantId = body?.items?.[0]?.tenantId ?? ''
+    }
+    const tenantOpt = tenantId ? { tenantId } : {}
+
+    let orgAId: string | null = null
+    let orgBId: string | null = null
+    let roleId: string | null = null
+    let userAId: string | null = null
+    let userBId: string | null = null
+    let definitionId: string | null = null
+    let instanceId: string | null = null
+    let tokenA = ''
+
+    try {
+      orgAId = await createOrganizationFixture(request, superadminToken, { name: `qa-tc-wf-029-a-${stamp}`, ...tenantOpt })
+      orgBId = await createOrganizationFixture(request, superadminToken, { name: `qa-tc-wf-029-b-${stamp}`, ...tenantOpt })
+      roleId = await createRoleFixture(request, superadminToken, { name: `qa-tc-wf-029-${stamp}`, ...tenantOpt })
+      await setRoleAclFeatures(request, superadminToken, { roleId, features: ['workflows.*'], organizations: null })
+
+      userAId = await createUserFixture(request, superadminToken, {
+        email: `qa-tc-wf-029-a-${stamp}@example.com`,
+        password,
+        organizationId: orgAId,
+        roles: [roleId],
+        name: 'QA TC-WF-029 A',
+      })
+      userBId = await createUserFixture(request, superadminToken, {
+        email: `qa-tc-wf-029-b-${stamp}@example.com`,
+        password,
+        organizationId: orgBId,
+        roles: [roleId],
+        name: 'QA TC-WF-029 B',
+      })
+      // Restrict each user's visibility to their own organization (sets the scope filter).
+      await setUserAclVisibility(request, superadminToken, { userId: userAId, organizations: [orgAId] })
+      await setUserAclVisibility(request, superadminToken, { userId: userBId, organizations: [orgBId] })
+
+      tokenA = await getAuthToken(request, `qa-tc-wf-029-a-${stamp}@example.com`, password)
+      const tokenB = await getAuthToken(request, `qa-tc-wf-029-b-${stamp}@example.com`, password)
+
+      // User A creates a definition + instance in org A.
+      const definitionPayload = buildMinimalDefinitionPayload(Date.now(), '-scope')
+      definitionId = await createWorkflowDefinitionFixture(request, tokenA, definitionPayload)
+      instanceId = await startWorkflowInstanceFixture(request, tokenA, { workflowId: definitionPayload.workflowId })
+
+      // Positive control: user A can list and read its own org's records.
+      const ownDefList = await apiRequest(
+        request,
+        'GET',
+        `/api/workflows/definitions?workflowId=${encodeURIComponent(definitionPayload.workflowId)}`,
+        { token: tokenA },
+      )
+      const ownDefBody = await readJsonSafe<DefinitionListBody>(ownDefList)
+      expect((ownDefBody?.data ?? []).map((d) => d.id), 'owner lists its own definition').toContain(definitionId)
+      const ownDefDetail = await apiRequest(request, 'GET', `/api/workflows/definitions/${encodeURIComponent(definitionId)}`, { token: tokenA })
+      expect(ownDefDetail.status(), 'owner reads its own definition').toBe(200)
+      const ownInstanceDetail = await apiRequest(request, 'GET', `/api/workflows/instances/${encodeURIComponent(instanceId)}`, { token: tokenA })
+      expect(ownInstanceDetail.status(), 'owner reads its own instance').toBe(200)
+
+      // Cross-org user B cannot see org A's definition in its list...
+      const crossDefList = await apiRequest(
+        request,
+        'GET',
+        `/api/workflows/definitions?workflowId=${encodeURIComponent(definitionPayload.workflowId)}`,
+        { token: tokenB },
+      )
+      const crossDefBody = await readJsonSafe<DefinitionListBody>(crossDefList)
+      expect((crossDefBody?.data ?? []).map((d) => d.id), 'cross-org user does not list org A definition').not.toContain(definitionId)
+
+      // ...nor read it by id (404, not 403 — the row is simply out of scope).
+      const crossDefDetail = await apiRequest(request, 'GET', `/api/workflows/definitions/${encodeURIComponent(definitionId)}`, { token: tokenB })
+      expect(crossDefDetail.status(), 'cross-org definition detail returns 404').toBe(404)
+
+      // Cross-org user B cannot see or read org A's instance.
+      const crossInstanceList = await apiRequest(
+        request,
+        'GET',
+        `/api/workflows/instances?workflowId=${encodeURIComponent(definitionPayload.workflowId)}`,
+        { token: tokenB },
+      )
+      const crossInstanceBody = await readJsonSafe<InstanceListBody>(crossInstanceList)
+      expect((crossInstanceBody?.data ?? []).map((i) => i.id), 'cross-org user does not list org A instance').not.toContain(instanceId)
+      const crossInstanceDetail = await apiRequest(request, 'GET', `/api/workflows/instances/${encodeURIComponent(instanceId)}`, { token: tokenB })
+      expect(crossInstanceDetail.status(), 'cross-org instance detail returns 404').toBe(404)
+
+      // Cross-org user B cannot start an instance from org A's definition (not found in its scope).
+      const crossStart = await apiRequest(request, 'POST', '/api/workflows/instances', {
+        token: tokenB,
+        data: { workflowId: definitionPayload.workflowId },
+      })
+      expect(crossStart.status(), 'starting another org definition returns 404').toBe(404)
+    } finally {
+      await cancelWorkflowInstanceIfExists(request, tokenA || superadminToken, instanceId)
+      await deleteWorkflowDefinitionIfExists(request, tokenA || superadminToken, definitionId)
+      await deleteUserIfExists(request, superadminToken, userAId)
+      await deleteUserIfExists(request, superadminToken, userBId)
+      await deleteRoleIfExists(request, superadminToken, roleId)
+      await deleteOrganizationIfExists(request, superadminToken, orgAId)
+      await deleteOrganizationIfExists(request, superadminToken, orgBId)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Adds the integration-test scenarios proposed in #2462 for the `workflows` module — user
tasks (claim/complete/list-filtering), instance signals (direct + correlation), retry,
manual advance, RBAC permission gates, and cross-organization scoping. The issue's proposed
TC-WF-014–020 numbers were already taken by unrelated merged tests (#2503 metadata, #2428
PARALLEL_FORK/JOIN), so these land as TC-WF-023–029. Where the issue's assumed behavior
differed from the implementation, the tests assert the real contract (e.g. re-claim → 404,
not 409; role-queue tasks require array `assignedTo`).

## Changes

- Add `packages/core/src/helpers/integration/workflowsFixtures.ts` helpers (additive): claimable/assigned user-task, signal, and manual-advance definition builders; background-execution-aware pollers (`pollWorkflowInstance`, `findInstanceUserTask`) and list/snapshot helpers.
- Add `TC-WF-023` [P0] — user task claim + complete API flow (claim → IN_PROGRESS, complete → COMPLETED, workflow resumes; re-claim → 404; missing task → 404).
- Add `TC-WF-024` [P1] — user task list filtering (status, comma-status union, assignedTo, myTasks, workflowInstanceId, overdue, pagination).
- Add `TC-WF-025` [P0] — instance signal send: direct (200; 400 name mismatch; 409 not-paused; 404 missing) and by correlation key (fan-out count=2; no-match count=0).
- Add `TC-WF-026` [P1] — instance retry (failed → recovered with retryCount incremented; COMPLETED/CANCELLED → 400 guards).
- Add `TC-WF-027` [P2] — instance advance (explicit/auto target, contextUpdates merge, invalid target → 400, completed → 400).
- Add `TC-WF-028` [P0] — RBAC gates: definitions/instances/claim/complete/signal mutations → 403 without features; invalid token → 401; wildcard admin positive control.
- Add `TC-WF-029` [P0] — organization scoping: a user in org B cannot list/read/start org A's definitions or instances (404), with owner positive controls.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test-coverage expansion driven by issue #2462; no `.ai/specs/` entry required.

## Testing

- `yarn turbo run typecheck --filter=@open-mercato/core` — pass (typechecks the new specs + helpers).
- `yarn workspace @open-mercato/core build` — pass.
- `BASE_URL=http://localhost:3013 OM_INTEGRATION_MODULES=workflows npx playwright test --config .ai/qa/tests/playwright.config.ts "TC-WF-02[3-9]"` — **11 passed**, run twice (idempotent across re-runs).
- Full `workflows/__integration__` suite — **69 passed**, no regressions.
- `yarn i18n:check-sync` — all locales in sync; `yarn i18n:check-hardcoded` — no new violations from changed files.
- Verified against a `dev:app` instance on an isolated seeded database.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — test-only; no docs/locale/generator changes needed.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Added in the module's `__integration__/` folder per `.ai/qa/AGENTS.md`; `.ai/qa/tests/` holds the shared Playwright config only.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec required for this coverage expansion.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens (N/A — backend/integration tests, no UI)
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` (N/A — no UI)
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) (N/A — no UI)
- [x] Loading state handled for async pages (N/A — no UI)
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) (N/A — no UI)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements (N/A — no UI)

## Linked issues

Fixes #2462