### PR TITLE
feat: 2463 portal api coverage

### DIFF
--- a/packages/core/src/helpers/integration/customerAccountsFixtures.ts
+++ b/packages/core/src/helpers/integration/customerAccountsFixtures.ts
@@ -1,0 +1,218 @@
+import { expect, type APIRequestContext } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
+import { apiRequest } from './api'
+import { expectId, readJsonSafe } from './generalFixtures'
+
+/**
+ * Customer-portal / customer_accounts integration fixtures.
+ *
+ * The portal API (`/api/customer_accounts/portal/*`) authenticates with a pair
+ * of httpOnly cookies (`customer_auth_token` JWT + `customer_session_token`),
+ * not the staff Bearer token. Against the ephemeral PROD build the login route
+ * sets those cookies with `Secure: true`, which Playwright's cookie jar refuses
+ * to replay over plain `http://`. So {@link portalLogin} extracts the cookie
+ * values from the `set-cookie` header and callers pass them back as an explicit
+ * `Cookie:` header — this also keeps multiple portal actors isolated in one test
+ * (each call sends exactly the header it is given, never a shared jar).
+ *
+ * Staff-admin setup calls (create role/user, set ACL, cleanup) reuse the shared
+ * Bearer-token `apiRequest` helper.
+ */
+
+/** Short, collision-resistant token for unique emails/slugs (crypto-backed). */
+export function uniqueSuffix(): string {
+  return randomUUID().replace(/-/g, '').slice(0, 12)
+}
+
+/**
+ * A password that satisfies common complexity rules (upper + lower + digit +
+ * symbol) and the customer_accounts length bounds (8–128 chars).
+ */
+export function customerTestPassword(): string {
+  return `Aa1!${uniqueSuffix()}`
+}
+
+export type CustomerRoleFixture = { id: string; name: string; slug: string }
+
+export type CustomerUserFixture = {
+  id: string
+  email: string
+  password: string
+  displayName: string
+  customerEntityId: string | null
+}
+
+export type CreateCustomerRoleInput = {
+  /** Defaults to a unique generated name. */
+  name?: string
+  /** Defaults to a unique generated slug (lowercased, `[a-z0-9_-]`). */
+  slug?: string
+  /** When provided, the role's ACL is set to these features after creation. */
+  features?: string[]
+  /** When provided, sets the portal-admin bypass flag on the role ACL. */
+  isPortalAdmin?: boolean
+  /** Allow assignment via the portal `users/[id]/roles` endpoint. */
+  customerAssignable?: boolean
+}
+
+/**
+ * Create a customer role (staff admin) and, when `features`/`isPortalAdmin` are
+ * provided, set its ACL. Returns the created role identity.
+ */
+export async function createCustomerRoleFixture(
+  request: APIRequestContext,
+  adminToken: string,
+  input: CreateCustomerRoleInput = {},
+): Promise<CustomerRoleFixture> {
+  const suffix = uniqueSuffix()
+  const name = input.name ?? `QA Portal Role ${suffix}`
+  const slug = input.slug ?? `qa-portal-role-${suffix}`
+
+  const createRes = await apiRequest(request, 'POST', '/api/customer_accounts/admin/roles', {
+    token: adminToken,
+    data: {
+      name,
+      slug,
+      description: 'Integration fixture role',
+      customerAssignable: input.customerAssignable ?? false,
+    },
+  })
+  expect(createRes.status(), 'POST /admin/roles should return 201').toBe(201)
+  const body = await readJsonSafe<{ role?: { id?: string } }>(createRes)
+  const id = expectId(body?.role?.id, 'Role creation response should include role.id')
+
+  if (input.features || typeof input.isPortalAdmin === 'boolean') {
+    await setCustomerRoleAcl(request, adminToken, id, {
+      features: input.features ?? [],
+      isPortalAdmin: input.isPortalAdmin,
+    })
+  }
+
+  return { id, name, slug }
+}
+
+/** Set a customer role's ACL (features + optional portal-admin flag). */
+export async function setCustomerRoleAcl(
+  request: APIRequestContext,
+  adminToken: string,
+  roleId: string,
+  input: { features: string[]; isPortalAdmin?: boolean },
+): Promise<void> {
+  const data: { features: string[]; isPortalAdmin?: boolean } = { features: input.features }
+  if (typeof input.isPortalAdmin === 'boolean') data.isPortalAdmin = input.isPortalAdmin
+  const res = await apiRequest(request, 'PUT', `/api/customer_accounts/admin/roles/${roleId}/acl`, {
+    token: adminToken,
+    data,
+  })
+  expect(res.status(), 'PUT /admin/roles/[id]/acl should return 200').toBe(200)
+}
+
+export type CreateCustomerUserInput = {
+  email?: string
+  password?: string
+  displayName?: string
+  roleIds?: string[]
+  /** Synthetic CRM company id (no FK is enforced) used for portal company scoping. */
+  customerEntityId?: string | null
+}
+
+/**
+ * Create a customer user (staff admin). Admin-created users are email-verified
+ * automatically, so the returned credentials can log in immediately.
+ */
+export async function createCustomerUserFixture(
+  request: APIRequestContext,
+  adminToken: string,
+  input: CreateCustomerUserInput = {},
+): Promise<CustomerUserFixture> {
+  const suffix = uniqueSuffix()
+  const email = input.email ?? `qa-portal-${suffix}@test.local`
+  const password = input.password ?? customerTestPassword()
+  const displayName = input.displayName ?? `QA Portal User ${suffix}`
+
+  const data: Record<string, unknown> = { email, password, displayName }
+  if (input.roleIds && input.roleIds.length > 0) data.roleIds = input.roleIds
+  if (input.customerEntityId) data.customerEntityId = input.customerEntityId
+
+  const res = await apiRequest(request, 'POST', '/api/customer_accounts/admin/users', {
+    token: adminToken,
+    data,
+  })
+  expect(res.status(), 'POST /admin/users should return 201').toBe(201)
+  const body = await readJsonSafe<{ user?: { id?: string } }>(res)
+  const id = expectId(body?.user?.id, 'User creation response should include user.id')
+
+  return { id, email, password, displayName, customerEntityId: input.customerEntityId ?? null }
+}
+
+export type PortalSession = {
+  /** Raw `customer_auth_token` (JWT) cookie value. */
+  authToken: string
+  /** Raw `customer_session_token` cookie value. */
+  sessionToken: string
+  /** Ready-to-send `Cookie:` header carrying both portal cookies. */
+  cookieHeader: string
+}
+
+/** Build portal request options carrying the session's `Cookie` header. */
+export function portalCookieHeaders(
+  session: PortalSession,
+  extra?: Record<string, string>,
+): Record<string, string> {
+  return { Cookie: session.cookieHeader, ...(extra ?? {}) }
+}
+
+/**
+ * Log a customer in and return the portal cookies. Pass `session.cookieHeader`
+ * as the `Cookie` request header on subsequent portal calls (see
+ * {@link portalCookieHeaders}). Logging in the same user twice yields two
+ * distinct sessions.
+ */
+export async function portalLogin(
+  request: APIRequestContext,
+  input: { email: string; password: string; tenantId: string },
+): Promise<PortalSession> {
+  const res = await request.post('/api/customer_accounts/login', {
+    data: { email: input.email, password: input.password, tenantId: input.tenantId },
+    headers: { 'Content-Type': 'application/json' },
+  })
+  expect(res.ok(), `portal login should succeed (status ${res.status()})`).toBeTruthy()
+
+  const setCookie = res.headers()['set-cookie'] ?? ''
+  const authMatch = setCookie.match(/customer_auth_token=([^;]+)/)
+  const sessionMatch = setCookie.match(/customer_session_token=([^;]+)/)
+  expect(authMatch, 'login must set customer_auth_token').toBeTruthy()
+  expect(sessionMatch, 'login must set customer_session_token').toBeTruthy()
+
+  const authToken = authMatch![1]
+  const sessionToken = sessionMatch![1]
+  return {
+    authToken,
+    sessionToken,
+    cookieHeader: `customer_auth_token=${authToken}; customer_session_token=${sessionToken}`,
+  }
+}
+
+/** Best-effort soft-delete of a customer user (cleanup). */
+export async function deleteCustomerUserFixture(
+  request: APIRequestContext,
+  adminToken: string | null,
+  userId: string | null,
+): Promise<void> {
+  if (!adminToken || !userId) return
+  await apiRequest(request, 'DELETE', `/api/customer_accounts/admin/users/${userId}`, {
+    token: adminToken,
+  }).catch(() => undefined)
+}
+
+/** Best-effort delete of a customer role (cleanup). */
+export async function deleteCustomerRoleFixture(
+  request: APIRequestContext,
+  adminToken: string | null,
+  roleId: string | null,
+): Promise<void> {
+  if (!adminToken || !roleId) return
+  await apiRequest(request, 'DELETE', `/api/customer_accounts/admin/roles/${roleId}`, {
+    token: adminToken,
+  }).catch(() => undefined)
+}

--- a/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-001.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-001.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createCustomerRoleFixture,
+  createCustomerUserFixture,
+  deleteCustomerRoleFixture,
+  deleteCustomerUserFixture,
+  portalCookieHeaders,
+  portalLogin,
+} from '@open-mercato/core/helpers/integration/customerAccountsFixtures'
+
+/**
+ * TC-PORTAL-001 [P0]: Portal profile GET returns the authenticated user profile
+ * with roles and ACL-resolved features.
+ *
+ * Surface: GET /api/customer_accounts/portal/profile
+ * Source: issue #2463.
+ */
+
+type ProfileResponse = {
+  ok: boolean
+  user?: {
+    id: string
+    email: string
+    displayName: string
+    emailVerified: boolean
+    isActive: boolean
+    createdAt: string
+    lastLoginAt: string | null
+    customerEntityId: string | null
+    personEntityId: string | null
+  }
+  roles?: Array<{ id: string; name: string; slug: string }>
+  resolvedFeatures?: string[]
+  isPortalAdmin?: boolean
+  error?: string
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+test.describe('TC-PORTAL-001: portal profile returns user, roles and features', () => {
+  test('GET /portal/profile returns the authenticated profile and rejects anonymous callers', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenContext(adminToken)
+
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      // Anonymous request must be rejected before any fixture exists.
+      const anon = await request.get('/api/customer_accounts/portal/profile')
+      expect(anon.status(), 'profile should be 401 without auth').toBe(401)
+      const anonBody = await readJsonSafe<ProfileResponse>(anon)
+      expect(anonBody?.ok).toBe(false)
+      expect(anonBody?.error).toBe('Authentication required')
+
+      const role = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.account.manage'],
+      })
+      roleId = role.id
+
+      const user = await createCustomerUserFixture(request, adminToken, {
+        roleIds: [role.id],
+      })
+      userId = user.id
+
+      const session = await portalLogin(request, {
+        email: user.email,
+        password: user.password,
+        tenantId,
+      })
+
+      const res = await request.get('/api/customer_accounts/portal/profile', {
+        headers: portalCookieHeaders(session),
+      })
+      expect(res.status(), 'authenticated profile should be 200').toBe(200)
+      const body = await readJsonSafe<ProfileResponse>(res)
+      expect(body?.ok).toBe(true)
+
+      const profile = body?.user
+      expect(profile, 'response.user should be present').toBeTruthy()
+      expect(profile!.id).toBe(user.id)
+      expect(profile!.id).toMatch(UUID_RE)
+      expect(profile!.email).toBe(user.email)
+      expect(profile!.displayName).toBe(user.displayName)
+      expect(typeof profile!.emailVerified).toBe('boolean')
+      expect(profile!.emailVerified, 'admin-created users are email-verified').toBe(true)
+      expect(profile!.isActive).toBe(true)
+      expect(typeof profile!.createdAt).toBe('string')
+      expect(Number.isNaN(Date.parse(profile!.createdAt))).toBe(false)
+
+      expect(Array.isArray(body?.roles)).toBe(true)
+      expect(body!.roles!.length).toBeGreaterThanOrEqual(1)
+      const assigned = body!.roles!.find((entry) => entry.id === role.id)
+      expect(assigned, 'assigned role should be present in roles[]').toBeTruthy()
+      expect(assigned!.slug).toBe(role.slug)
+      expect(assigned!.name).toBe(role.name)
+
+      expect(Array.isArray(body?.resolvedFeatures)).toBe(true)
+      expect(body!.resolvedFeatures).toContain('portal.account.manage')
+      expect(body?.isPortalAdmin).toBe(false)
+    } finally {
+      await deleteCustomerUserFixture(request, adminToken, userId)
+      await deleteCustomerRoleFixture(request, adminToken, roleId)
+    }
+  })
+})

--- a/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-002.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-002.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createCustomerRoleFixture,
+  createCustomerUserFixture,
+  deleteCustomerRoleFixture,
+  deleteCustomerUserFixture,
+  portalCookieHeaders,
+  portalLogin,
+} from '@open-mercato/core/helpers/integration/customerAccountsFixtures'
+
+/**
+ * TC-PORTAL-002 [P1]: Portal profile PUT updates displayName behind the
+ * `portal.account.manage` feature gate and validates its input.
+ *
+ * Surface: PUT /api/customer_accounts/portal/profile
+ * Source: issue #2463.
+ *
+ * Verified contract:
+ *   - happy PUT → 200 { ok, user: { id, email, displayName } } (no full profile)
+ *   - missing portal.account.manage → 403 { ok:false, error:'Insufficient permissions' }
+ *   - empty displayName → 400 { ok:false, error:'Validation failed' }
+ */
+
+type PutResponse = {
+  ok: boolean
+  user?: { id: string; email: string; displayName: string }
+  error?: string
+}
+
+type ProfileResponse = { ok: boolean; user?: { displayName: string } }
+
+const JSON_HEADER = { 'Content-Type': 'application/json' }
+
+test.describe('TC-PORTAL-002: portal profile update is gated and validated', () => {
+  test('updates displayName, persists it, and rejects empty input', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenContext(adminToken)
+
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      const role = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.account.manage'],
+      })
+      roleId = role.id
+      const user = await createCustomerUserFixture(request, adminToken, { roleIds: [role.id] })
+      userId = user.id
+      const session = await portalLogin(request, {
+        email: user.email,
+        password: user.password,
+        tenantId,
+      })
+
+      const newName = `Updated Name ${user.id.slice(0, 8)}`
+      const putRes = await request.put('/api/customer_accounts/portal/profile', {
+        data: { displayName: newName },
+        headers: portalCookieHeaders(session, JSON_HEADER),
+      })
+      expect(putRes.status(), 'profile update should be 200').toBe(200)
+      const putBody = await readJsonSafe<PutResponse>(putRes)
+      expect(putBody?.ok).toBe(true)
+      expect(putBody?.user?.displayName).toBe(newName)
+
+      // Persistence: re-read via GET reflects the new name.
+      const getRes = await request.get('/api/customer_accounts/portal/profile', {
+        headers: portalCookieHeaders(session),
+      })
+      expect(getRes.status()).toBe(200)
+      const getBody = await readJsonSafe<ProfileResponse>(getRes)
+      expect(getBody?.user?.displayName).toBe(newName)
+
+      // Validation: empty displayName fails the min(1) zod rule.
+      const invalidRes = await request.put('/api/customer_accounts/portal/profile', {
+        data: { displayName: '' },
+        headers: portalCookieHeaders(session, JSON_HEADER),
+      })
+      expect(invalidRes.status(), 'empty displayName should be 400').toBe(400)
+      const invalidBody = await readJsonSafe<PutResponse>(invalidRes)
+      expect(invalidBody?.ok).toBe(false)
+      expect(invalidBody?.error).toBe('Validation failed')
+    } finally {
+      await deleteCustomerUserFixture(request, adminToken, userId)
+      await deleteCustomerRoleFixture(request, adminToken, roleId)
+    }
+  })
+
+  test('denies the update when the role lacks portal.account.manage', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenContext(adminToken)
+
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      // Role with an unrelated feature only — no portal.account.manage.
+      const role = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.catalog.view'],
+      })
+      roleId = role.id
+      const user = await createCustomerUserFixture(request, adminToken, { roleIds: [role.id] })
+      userId = user.id
+      const session = await portalLogin(request, {
+        email: user.email,
+        password: user.password,
+        tenantId,
+      })
+
+      const res = await request.put('/api/customer_accounts/portal/profile', {
+        data: { displayName: 'Should Be Rejected' },
+        headers: portalCookieHeaders(session, JSON_HEADER),
+      })
+      expect(res.status(), 'update without feature should be 403').toBe(403)
+      const body = await readJsonSafe<PutResponse>(res)
+      expect(body?.ok).toBe(false)
+      expect(body?.error).toBe('Insufficient permissions')
+    } finally {
+      await deleteCustomerUserFixture(request, adminToken, userId)
+      await deleteCustomerRoleFixture(request, adminToken, roleId)
+    }
+  })
+})

--- a/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-003.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-003.spec.ts
@@ -1,0 +1,210 @@
+import { expect, test } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createCustomerRoleFixture,
+  createCustomerUserFixture,
+  deleteCustomerRoleFixture,
+  deleteCustomerUserFixture,
+  portalCookieHeaders,
+  portalLogin,
+} from '@open-mercato/core/helpers/integration/customerAccountsFixtures'
+
+/**
+ * TC-PORTAL-003 [P1]: Portal users list is scoped to the caller's company
+ * (`customerEntityId`), paginated, clamped, and gated by `portal.users.view`.
+ *
+ * Surface: GET /api/customer_accounts/portal/users
+ * Source: issue #2463.
+ *
+ * Scoping is by `customerEntityId` (a synthetic CRM company id; no FK is
+ * enforced) AND `tenantId` — NOT by organization. Default pageSize is 25.
+ */
+
+type PortalUser = {
+  id: string
+  email: string
+  displayName: string
+  emailVerified: boolean
+  isActive: boolean
+  createdAt: string
+  lastLoginAt: string | null
+  roles: Array<{ id: string; name: string; slug: string }>
+}
+
+type UsersListResponse = {
+  ok: boolean
+  users?: PortalUser[]
+  total?: number
+  totalPages?: number
+  page?: number
+  pageSize?: number
+  error?: string
+}
+
+const COMPANY_A_SIZE = 3
+const COMPANY_B_SIZE = 2
+
+test.describe('TC-PORTAL-003: portal users list scoping and pagination', () => {
+  test('lists only same-company users, paginates, clamps, and isolates other companies', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenContext(adminToken)
+
+    const companyA = randomUUID()
+    const companyB = randomUUID()
+    const createdUserIds: string[] = []
+    let roleId: string | null = null
+
+    try {
+      const role = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.users.view'],
+      })
+      roleId = role.id
+
+      const companyAUsers: string[] = []
+      let companyALogin: { email: string; password: string } | null = null
+      for (let i = 0; i < COMPANY_A_SIZE; i += 1) {
+        const user = await createCustomerUserFixture(request, adminToken, {
+          roleIds: [role.id],
+          customerEntityId: companyA,
+        })
+        companyAUsers.push(user.id)
+        createdUserIds.push(user.id)
+        if (!companyALogin) companyALogin = { email: user.email, password: user.password }
+      }
+
+      let companyBLogin: { email: string; password: string } | null = null
+      for (let i = 0; i < COMPANY_B_SIZE; i += 1) {
+        const user = await createCustomerUserFixture(request, adminToken, {
+          roleIds: [role.id],
+          customerEntityId: companyB,
+        })
+        createdUserIds.push(user.id)
+        if (!companyBLogin) companyBLogin = { email: user.email, password: user.password }
+      }
+
+      const sessionA = await portalLogin(request, {
+        email: companyALogin!.email,
+        password: companyALogin!.password,
+        tenantId,
+      })
+
+      // Company A caller: full list scoped to company A only.
+      const listRes = await request.get('/api/customer_accounts/portal/users', {
+        headers: portalCookieHeaders(sessionA),
+      })
+      expect(listRes.status(), 'list should be 200').toBe(200)
+      const list = await readJsonSafe<UsersListResponse>(listRes)
+      expect(list?.ok).toBe(true)
+      expect(list?.total).toBe(COMPANY_A_SIZE)
+      expect(list?.page).toBe(1)
+      expect(list?.pageSize, 'default pageSize is 25').toBe(25)
+      expect(list?.totalPages).toBe(1)
+      expect(list?.users?.length).toBe(COMPANY_A_SIZE)
+
+      const listedIds = new Set((list?.users ?? []).map((u) => u.id))
+      for (const id of companyAUsers) expect(listedIds.has(id), `company A user ${id} should be listed`).toBe(true)
+
+      // Shape + ordering (createdAt DESC: non-increasing across the page).
+      for (const entry of list!.users!) {
+        expect(typeof entry.id).toBe('string')
+        expect(typeof entry.email).toBe('string')
+        expect(typeof entry.displayName).toBe('string')
+        expect(typeof entry.emailVerified).toBe('boolean')
+        expect(typeof entry.isActive).toBe('boolean')
+        expect(typeof entry.createdAt).toBe('string')
+        expect(Array.isArray(entry.roles)).toBe(true)
+      }
+      const timestamps = list!.users!.map((u) => Date.parse(u.createdAt))
+      for (let i = 1; i < timestamps.length; i += 1) {
+        expect(timestamps[i - 1] >= timestamps[i], 'users ordered by createdAt DESC').toBe(true)
+      }
+
+      // Pagination: pageSize 2 splits 3 company-A users into 2 + 1 with no overlap.
+      const page1Res = await request.get('/api/customer_accounts/portal/users?page=1&pageSize=2', {
+        headers: portalCookieHeaders(sessionA),
+      })
+      const page1 = await readJsonSafe<UsersListResponse>(page1Res)
+      expect(page1?.users?.length).toBe(2)
+      expect(page1?.total).toBe(COMPANY_A_SIZE)
+      expect(page1?.pageSize).toBe(2)
+      expect(page1?.totalPages).toBe(2)
+      expect(page1?.page).toBe(1)
+
+      const page2Res = await request.get('/api/customer_accounts/portal/users?page=2&pageSize=2', {
+        headers: portalCookieHeaders(sessionA),
+      })
+      const page2 = await readJsonSafe<UsersListResponse>(page2Res)
+      expect(page2?.users?.length).toBe(1)
+      expect(page2?.page).toBe(2)
+
+      const pagedIds = new Set([
+        ...(page1?.users ?? []).map((u) => u.id),
+        ...(page2?.users ?? []).map((u) => u.id),
+      ])
+      expect(pagedIds.size, 'pages cover all company-A users with no overlap').toBe(COMPANY_A_SIZE)
+
+      // Clamping: pageSize > 100 → 100; page < 1 → 1.
+      const clampRes = await request.get('/api/customer_accounts/portal/users?page=0&pageSize=500', {
+        headers: portalCookieHeaders(sessionA),
+      })
+      const clamp = await readJsonSafe<UsersListResponse>(clampRes)
+      expect(clamp?.pageSize, 'pageSize clamped to 100').toBe(100)
+      expect(clamp?.page, 'page clamped to 1').toBe(1)
+
+      // Cross-company isolation: company B caller never sees company A users.
+      expect(companyBLogin, 'company B login should exist').toBeTruthy()
+      const sessionB = await portalLogin(request, {
+        email: companyBLogin!.email,
+        password: companyBLogin!.password,
+        tenantId,
+      })
+      const bListRes = await request.get('/api/customer_accounts/portal/users', {
+        headers: portalCookieHeaders(sessionB),
+      })
+      const bList = await readJsonSafe<UsersListResponse>(bListRes)
+      expect(bList?.total).toBe(COMPANY_B_SIZE)
+      expect(bList?.users?.length).toBe(COMPANY_B_SIZE)
+      const bIds = new Set((bList?.users ?? []).map((u) => u.id))
+      for (const id of companyAUsers) expect(bIds.has(id), 'company A user must not leak to company B').toBe(false)
+    } finally {
+      for (const id of createdUserIds) await deleteCustomerUserFixture(request, adminToken, id)
+      await deleteCustomerRoleFixture(request, adminToken, roleId)
+    }
+  })
+
+  test('returns 403 when the caller has no company association', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenContext(adminToken)
+
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      const role = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.users.view'],
+      })
+      roleId = role.id
+      // No customerEntityId → no company association.
+      const user = await createCustomerUserFixture(request, adminToken, { roleIds: [role.id] })
+      userId = user.id
+      const session = await portalLogin(request, {
+        email: user.email,
+        password: user.password,
+        tenantId,
+      })
+
+      const res = await request.get('/api/customer_accounts/portal/users', {
+        headers: portalCookieHeaders(session),
+      })
+      expect(res.status(), 'no company association should be 403').toBe(403)
+      const body = await readJsonSafe<UsersListResponse>(res)
+      expect(body?.ok).toBe(false)
+      expect(body?.error).toBe('No company association')
+    } finally {
+      await deleteCustomerUserFixture(request, adminToken, userId)
+      await deleteCustomerRoleFixture(request, adminToken, roleId)
+    }
+  })
+})

--- a/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-004.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-004.spec.ts
@@ -1,0 +1,172 @@
+import { expect, test } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { withClient } from '@open-mercato/core/helpers/integration/dbFixtures'
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createCustomerRoleFixture,
+  createCustomerUserFixture,
+  deleteCustomerRoleFixture,
+  deleteCustomerUserFixture,
+  portalCookieHeaders,
+  portalLogin,
+} from '@open-mercato/core/helpers/integration/customerAccountsFixtures'
+
+/**
+ * TC-PORTAL-004 [P0]: Portal user DELETE blocks self-deletion and revokes the
+ * deleted user's sessions atomically.
+ *
+ * Surface: DELETE /api/customer_accounts/portal/users/[id]
+ * Source: issue #2463.
+ *
+ * Verified contract:
+ *   - delete self → 400 { error:'Cannot delete your own account' } (no soft delete)
+ *   - delete same-company user → 200 { ok:true } + soft delete + session revoked
+ *   - re-delete the same user → 404 (proves soft delete)
+ *   - missing portal.users.manage → 403 (the feature gate runs first)
+ */
+
+type OkResponse = { ok: boolean; error?: string }
+
+test.describe('TC-PORTAL-004: portal user deletion guards', () => {
+  test('blocks self-deletion, removes others, and revokes their sessions', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenContext(adminToken)
+
+    const company = randomUUID()
+    let roleId: string | null = null
+    let userAId: string | null = null
+    let userBId: string | null = null
+
+    try {
+      const role = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.users.manage'],
+      })
+      roleId = role.id
+
+      const userA = await createCustomerUserFixture(request, adminToken, {
+        roleIds: [role.id],
+        customerEntityId: company,
+      })
+      userAId = userA.id
+      const userB = await createCustomerUserFixture(request, adminToken, {
+        roleIds: [role.id],
+        customerEntityId: company,
+      })
+      userBId = userB.id
+
+      const sessionA = await portalLogin(request, {
+        email: userA.email,
+        password: userA.password,
+        tenantId,
+      })
+      const sessionB = await portalLogin(request, {
+        email: userB.email,
+        password: userB.password,
+        tenantId,
+      })
+
+      // Self-delete is rejected.
+      const selfRes = await request.delete(`/api/customer_accounts/portal/users/${userA.id}`, {
+        headers: portalCookieHeaders(sessionA),
+      })
+      expect(selfRes.status(), 'self-delete should be 400').toBe(400)
+      const selfBody = await readJsonSafe<OkResponse>(selfRes)
+      expect(selfBody?.ok).toBe(false)
+      expect(selfBody?.error).toBe('Cannot delete your own account')
+
+      // userA is unaffected by the rejected self-delete.
+      const stillAlive = await request.get('/api/customer_accounts/portal/profile', {
+        headers: portalCookieHeaders(sessionA),
+      })
+      expect(stillAlive.status(), 'userA session should remain valid').toBe(200)
+
+      // userB's session is valid before deletion.
+      const bBefore = await request.get('/api/customer_accounts/portal/profile', {
+        headers: portalCookieHeaders(sessionB),
+      })
+      expect(bBefore.status(), 'userB session valid before delete').toBe(200)
+
+      // Delete userB (same company) succeeds.
+      const delRes = await request.delete(`/api/customer_accounts/portal/users/${userB.id}`, {
+        headers: portalCookieHeaders(sessionA),
+      })
+      expect(delRes.status(), 'deleting another user should be 200').toBe(200)
+      const delBody = await readJsonSafe<OkResponse>(delRes)
+      expect(delBody?.ok).toBe(true)
+
+      // userB's sessions are revoked → its portal calls are now rejected.
+      const bAfter = await request.get('/api/customer_accounts/portal/profile', {
+        headers: portalCookieHeaders(sessionB),
+      })
+      expect(bAfter.status(), 'userB session revoked after deletion').toBe(401)
+
+      // The 401 above is also produced by the user soft-delete, so assert the
+      // session rows directly: revokeAllUserSessions must have set deleted_at on
+      // every CustomerUserSession for userB (the atomic-revocation side effect).
+      const sessionRows = await withClient((client) =>
+        client
+          .query<{ deleted_at: Date | null }>(
+            'select deleted_at from customer_user_sessions where user_id = $1',
+            [userB.id],
+          )
+          .then((result) => result.rows),
+      )
+      expect(sessionRows.length, 'userB should have had at least one session row').toBeGreaterThanOrEqual(1)
+      expect(
+        sessionRows.every((row) => row.deleted_at !== null),
+        'all of userB sessions must be revoked (deleted_at set)',
+      ).toBe(true)
+
+      // Re-deleting userB returns 404 — it is soft-deleted (no longer active).
+      const reDelRes = await request.delete(`/api/customer_accounts/portal/users/${userB.id}`, {
+        headers: portalCookieHeaders(sessionA),
+      })
+      expect(reDelRes.status(), 'second delete should be 404 (soft-deleted)').toBe(404)
+      userBId = null // already deleted
+    } finally {
+      await deleteCustomerUserFixture(request, adminToken, userAId)
+      await deleteCustomerUserFixture(request, adminToken, userBId)
+      await deleteCustomerRoleFixture(request, adminToken, roleId)
+    }
+  })
+
+  test('denies deletion when the caller lacks portal.users.manage', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenContext(adminToken)
+
+    const company = randomUUID()
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      // Role without portal.users.manage — the feature gate runs before the
+      // company / self / lookup checks, so any DELETE target returns 403.
+      const role = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.account.manage'],
+      })
+      roleId = role.id
+      const user = await createCustomerUserFixture(request, adminToken, {
+        roleIds: [role.id],
+        customerEntityId: company,
+      })
+      userId = user.id
+      const session = await portalLogin(request, {
+        email: user.email,
+        password: user.password,
+        tenantId,
+      })
+
+      const res = await request.delete(`/api/customer_accounts/portal/users/${randomUUID()}`, {
+        headers: portalCookieHeaders(session),
+      })
+      expect(res.status(), 'delete without manage feature should be 403').toBe(403)
+      const body = await readJsonSafe<OkResponse>(res)
+      expect(body?.ok).toBe(false)
+      expect(body?.error).toBe('Insufficient permissions')
+    } finally {
+      await deleteCustomerUserFixture(request, adminToken, userId)
+      await deleteCustomerRoleFixture(request, adminToken, roleId)
+    }
+  })
+})

--- a/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-005.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-005.spec.ts
@@ -1,0 +1,189 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createCustomerRoleFixture,
+  createCustomerUserFixture,
+  deleteCustomerRoleFixture,
+  deleteCustomerUserFixture,
+  portalCookieHeaders,
+  portalLogin,
+  type PortalSession,
+} from '@open-mercato/core/helpers/integration/customerAccountsFixtures'
+
+/**
+ * TC-PORTAL-005 [P1]: Portal user roles PUT atomically replaces the role set and
+ * only accepts `customerAssignable` roles.
+ *
+ * Surface: PUT /api/customer_accounts/portal/users/[id]/roles
+ * Source: issue #2463.
+ *
+ * Verified contract:
+ *   - non-assignable role / unknown valid-UUID role → 400 'Role not found or not assignable'
+ *   - assignable role → 200 { ok:true }, replacing (not appending) the role set
+ *   - empty roleIds → 400 'Validation failed' (schema requires >= 1)
+ *   - missing portal.users.roles.manage → 403 'Insufficient permissions'
+ */
+
+type OkResponse = { ok: boolean; error?: string }
+type PortalUser = { id: string; roles: Array<{ id: string; slug: string }> }
+type UsersListResponse = { ok: boolean; users?: PortalUser[] }
+
+const JSON_HEADER = { 'Content-Type': 'application/json' }
+
+async function findUserRoles(
+  request: APIRequestContext,
+  session: PortalSession,
+  userId: string,
+): Promise<Array<{ id: string; slug: string }> | null> {
+  const res = await request.get('/api/customer_accounts/portal/users?pageSize=100', {
+    headers: portalCookieHeaders(session),
+  })
+  const body = await readJsonSafe<UsersListResponse>(res)
+  const found = (body?.users ?? []).find((u) => u.id === userId)
+  return found ? found.roles : null
+}
+
+test.describe('TC-PORTAL-005: portal user role assignment', () => {
+  test('replaces roles atomically and enforces customerAssignable', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenContext(adminToken)
+
+    const company = randomUUID()
+    const roleIds: string[] = []
+    const userIds: string[] = []
+
+    try {
+      // Caller can both manage roles and view the company roster (for read-back).
+      const callerRole = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.users.roles.manage', 'portal.users.view'],
+      })
+      roleIds.push(callerRole.id)
+      const assignableA = await createCustomerRoleFixture(request, adminToken, { customerAssignable: true })
+      roleIds.push(assignableA.id)
+      const assignableB = await createCustomerRoleFixture(request, adminToken, { customerAssignable: true })
+      roleIds.push(assignableB.id)
+      const nonAssignable = await createCustomerRoleFixture(request, adminToken, { customerAssignable: false })
+      roleIds.push(nonAssignable.id)
+
+      const caller = await createCustomerUserFixture(request, adminToken, {
+        roleIds: [callerRole.id],
+        customerEntityId: company,
+      })
+      userIds.push(caller.id)
+      // Target starts with assignableA (admin-create bypasses the assignable gate).
+      const target = await createCustomerUserFixture(request, adminToken, {
+        roleIds: [assignableA.id],
+        customerEntityId: company,
+      })
+      userIds.push(target.id)
+
+      const adminSession = await portalLogin(request, {
+        email: caller.email,
+        password: caller.password,
+        tenantId,
+      })
+
+      const targetRolesUrl = `/api/customer_accounts/portal/users/${target.id}/roles`
+
+      // Non-assignable role is rejected.
+      const nonAssignRes = await request.put(targetRolesUrl, {
+        data: { roleIds: [nonAssignable.id] },
+        headers: portalCookieHeaders(adminSession, JSON_HEADER),
+      })
+      expect(nonAssignRes.status(), 'non-assignable role should be 400').toBe(400)
+      expect((await readJsonSafe<OkResponse>(nonAssignRes))?.error).toBe('Role not found or not assignable')
+
+      // Unknown but well-formed role id is rejected the same way.
+      const unknownRes = await request.put(targetRolesUrl, {
+        data: { roleIds: [randomUUID()] },
+        headers: portalCookieHeaders(adminSession, JSON_HEADER),
+      })
+      expect(unknownRes.status(), 'unknown role id should be 400').toBe(400)
+      expect((await readJsonSafe<OkResponse>(unknownRes))?.error).toBe('Role not found or not assignable')
+
+      // Valid assignable role replaces the existing set (A → B, not A+B).
+      const okRes = await request.put(targetRolesUrl, {
+        data: { roleIds: [assignableB.id] },
+        headers: portalCookieHeaders(adminSession, JSON_HEADER),
+      })
+      expect(okRes.status(), 'assignable role should be 200').toBe(200)
+      expect((await readJsonSafe<OkResponse>(okRes))?.ok).toBe(true)
+
+      const rolesAfter = await findUserRoles(request, adminSession, target.id)
+      expect(rolesAfter, 'target should be visible in the company roster').toBeTruthy()
+      expect(rolesAfter!.length, 'role set replaced, not appended').toBe(1)
+      expect(rolesAfter![0].id).toBe(assignableB.id)
+      expect(rolesAfter!.some((r) => r.id === assignableA.id), 'previous role removed').toBe(false)
+    } finally {
+      for (const id of userIds) await deleteCustomerUserFixture(request, adminToken, id)
+      for (const id of roleIds) await deleteCustomerRoleFixture(request, adminToken, id)
+    }
+  })
+
+  test('rejects an empty role set and unauthorized callers', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenContext(adminToken)
+
+    const company = randomUUID()
+    const roleIds: string[] = []
+    const userIds: string[] = []
+
+    try {
+      const callerRole = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.users.roles.manage'],
+      })
+      roleIds.push(callerRole.id)
+      const plainRole = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.account.manage'],
+      })
+      roleIds.push(plainRole.id)
+
+      const manager = await createCustomerUserFixture(request, adminToken, {
+        roleIds: [callerRole.id],
+        customerEntityId: company,
+      })
+      userIds.push(manager.id)
+      const target = await createCustomerUserFixture(request, adminToken, {
+        customerEntityId: company,
+      })
+      userIds.push(target.id)
+      const plain = await createCustomerUserFixture(request, adminToken, {
+        roleIds: [plainRole.id],
+        customerEntityId: company,
+      })
+      userIds.push(plain.id)
+
+      const managerSession = await portalLogin(request, {
+        email: manager.email,
+        password: manager.password,
+        tenantId,
+      })
+      const plainSession = await portalLogin(request, {
+        email: plain.email,
+        password: plain.password,
+        tenantId,
+      })
+
+      // Empty roleIds fails validation (schema requires at least one).
+      const emptyRes = await request.put(`/api/customer_accounts/portal/users/${target.id}/roles`, {
+        data: { roleIds: [] },
+        headers: portalCookieHeaders(managerSession, JSON_HEADER),
+      })
+      expect(emptyRes.status(), 'empty roleIds should be 400').toBe(400)
+      expect((await readJsonSafe<OkResponse>(emptyRes))?.error).toBe('Validation failed')
+
+      // Caller without portal.users.roles.manage is rejected.
+      const deniedRes = await request.put(`/api/customer_accounts/portal/users/${target.id}/roles`, {
+        data: { roleIds: [callerRole.id] },
+        headers: portalCookieHeaders(plainSession, JSON_HEADER),
+      })
+      expect(deniedRes.status(), 'caller without feature should be 403').toBe(403)
+      expect((await readJsonSafe<OkResponse>(deniedRes))?.error).toBe('Insufficient permissions')
+    } finally {
+      for (const id of userIds) await deleteCustomerUserFixture(request, adminToken, id)
+      for (const id of roleIds) await deleteCustomerRoleFixture(request, adminToken, id)
+    }
+  })
+})

--- a/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-006.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-006.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createCustomerUserFixture,
+  deleteCustomerUserFixture,
+  portalCookieHeaders,
+  portalLogin,
+} from '@open-mercato/core/helpers/integration/customerAccountsFixtures'
+
+/**
+ * TC-PORTAL-006 [P1]: Portal session listing flags the current session, and
+ * revocation deletes non-current sessions but protects the current one.
+ *
+ * Surfaces:
+ *   - GET /api/customer_accounts/portal/sessions
+ *   - DELETE /api/customer_accounts/portal/sessions/[id]
+ * Source: issue #2463.
+ *
+ * No feature gate — any authenticated customer manages their own sessions.
+ * Two logins of the same user create two independent sessions.
+ */
+
+type PortalSessionEntry = {
+  id: string
+  ipAddress: string | null
+  userAgent: string | null
+  lastUsedAt: string | null
+  createdAt: string
+  expiresAt: string
+  isCurrent: boolean
+}
+
+type SessionsResponse = { ok: boolean; sessions?: PortalSessionEntry[] }
+type OkResponse = { ok: boolean; error?: string }
+
+test.describe('TC-PORTAL-006: portal session listing and revocation', () => {
+  test('lists sessions, marks the current one, and guards current-session revocation', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenContext(adminToken)
+
+    let userId: string | null = null
+
+    try {
+      // No auth → 401 (before any fixture).
+      const anon = await request.get('/api/customer_accounts/portal/sessions')
+      expect(anon.status(), 'sessions list should be 401 without auth').toBe(401)
+
+      const user = await createCustomerUserFixture(request, adminToken, {})
+      userId = user.id
+
+      // Two independent logins → two active sessions for the same user.
+      const sessionOne = await portalLogin(request, {
+        email: user.email,
+        password: user.password,
+        tenantId,
+      })
+      const sessionTwo = await portalLogin(request, {
+        email: user.email,
+        password: user.password,
+        tenantId,
+      })
+
+      const listRes = await request.get('/api/customer_accounts/portal/sessions', {
+        headers: portalCookieHeaders(sessionOne),
+      })
+      expect(listRes.status()).toBe(200)
+      const list = await readJsonSafe<SessionsResponse>(listRes)
+      expect(list?.ok).toBe(true)
+      expect(Array.isArray(list?.sessions)).toBe(true)
+      expect(list!.sessions!.length, 'two logins → at least two sessions').toBeGreaterThanOrEqual(2)
+
+      for (const entry of list!.sessions!) {
+        expect(typeof entry.id).toBe('string')
+        expect(typeof entry.createdAt).toBe('string')
+        expect(typeof entry.expiresAt).toBe('string')
+        expect(typeof entry.isCurrent).toBe('boolean')
+        expect('ipAddress' in entry).toBe(true)
+        expect('userAgent' in entry).toBe(true)
+        expect('lastUsedAt' in entry).toBe(true)
+      }
+
+      const currentSessions = list!.sessions!.filter((s) => s.isCurrent)
+      expect(currentSessions.length, 'exactly one session is current for this caller').toBe(1)
+      const current = currentSessions[0]
+      const other = list!.sessions!.find((s) => !s.isCurrent)
+      expect(other, 'a non-current session should exist').toBeTruthy()
+
+      // Revoke the non-current session → 200, and that session stops working.
+      const revokeRes = await request.delete(`/api/customer_accounts/portal/sessions/${other!.id}`, {
+        headers: portalCookieHeaders(sessionOne),
+      })
+      expect(revokeRes.status(), 'revoking a non-current session should be 200').toBe(200)
+      expect((await readJsonSafe<OkResponse>(revokeRes))?.ok).toBe(true)
+
+      const otherAfter = await request.get('/api/customer_accounts/portal/profile', {
+        headers: portalCookieHeaders(sessionTwo),
+      })
+      expect(otherAfter.status(), 'revoked session can no longer authenticate').toBe(401)
+
+      // Revoking a non-existent session → 404.
+      const missingRes = await request.delete(`/api/customer_accounts/portal/sessions/${randomUUID()}`, {
+        headers: portalCookieHeaders(sessionOne),
+      })
+      expect(missingRes.status(), 'unknown session should be 404').toBe(404)
+      expect((await readJsonSafe<OkResponse>(missingRes))?.error).toBe('Session not found')
+
+      // Revoking the current session is blocked → 400.
+      const selfRevoke = await request.delete(`/api/customer_accounts/portal/sessions/${current.id}`, {
+        headers: portalCookieHeaders(sessionOne),
+      })
+      expect(selfRevoke.status(), 'revoking the current session should be 400').toBe(400)
+      expect((await readJsonSafe<OkResponse>(selfRevoke))?.error).toBe('Cannot revoke current session. Use logout instead.')
+    } finally {
+      await deleteCustomerUserFixture(request, adminToken, userId)
+    }
+  })
+})

--- a/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-007.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-007.spec.ts
@@ -1,0 +1,179 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createCustomerRoleFixture,
+  createCustomerUserFixture,
+  deleteCustomerRoleFixture,
+  deleteCustomerUserFixture,
+  portalCookieHeaders,
+  portalLogin,
+} from '@open-mercato/core/helpers/integration/customerAccountsFixtures'
+
+/**
+ * TC-PORTAL-007 [P2]: Portal feature-check returns the granted subset of the
+ * requested features, honouring wildcard grants and the portal-admin bypass.
+ *
+ * Surface: POST /api/customer_accounts/portal/feature-check
+ * Source: issue #2463.
+ *
+ * Verified contract:
+ *   - granted = requested features that match the user's ACL (wildcard-aware)
+ *   - portal admin (isPortalAdmin) → all requested features granted
+ *   - 401 without auth; body schema requires 1..100 features (empty → 400)
+ */
+
+type FeatureCheckResponse = { ok: boolean; granted?: string[]; error?: string }
+
+const ENDPOINT = '/api/customer_accounts/portal/feature-check'
+const JSON_HEADER = { 'Content-Type': 'application/json' }
+
+test.describe('TC-PORTAL-007: portal feature-check matching', () => {
+  test('matches exact and wildcard grants and bypasses for portal admins', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenContext(adminToken)
+
+    const roleIds: string[] = []
+    const userIds: string[] = []
+
+    try {
+      const specificRole = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.users.view', 'portal.users.manage'],
+      })
+      roleIds.push(specificRole.id)
+      const wildcardRole = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.*'],
+      })
+      roleIds.push(wildcardRole.id)
+      const adminRole = await createCustomerRoleFixture(request, adminToken, {
+        features: [],
+        isPortalAdmin: true,
+      })
+      roleIds.push(adminRole.id)
+
+      const specificUser = await createCustomerUserFixture(request, adminToken, { roleIds: [specificRole.id] })
+      userIds.push(specificUser.id)
+      const wildcardUser = await createCustomerUserFixture(request, adminToken, { roleIds: [wildcardRole.id] })
+      userIds.push(wildcardUser.id)
+      const adminUser = await createCustomerUserFixture(request, adminToken, { roleIds: [adminRole.id] })
+      userIds.push(adminUser.id)
+
+      const specificSession = await portalLogin(request, {
+        email: specificUser.email,
+        password: specificUser.password,
+        tenantId,
+      })
+      const wildcardSession = await portalLogin(request, {
+        email: wildcardUser.email,
+        password: wildcardUser.password,
+        tenantId,
+      })
+      const adminSession = await portalLogin(request, {
+        email: adminUser.email,
+        password: adminUser.password,
+        tenantId,
+      })
+
+      const requested = [
+        'portal.users.view',
+        'portal.users.manage',
+        'portal.users.roles.manage',
+        'nonexistent.feature',
+      ]
+
+      // Exact grants only — no wildcard, no unrelated feature.
+      const specificRes = await request.post(ENDPOINT, {
+        data: { features: requested },
+        headers: portalCookieHeaders(specificSession, JSON_HEADER),
+      })
+      expect(specificRes.status()).toBe(200)
+      const specific = await readJsonSafe<FeatureCheckResponse>(specificRes)
+      expect(specific?.ok).toBe(true)
+      const specificGranted = specific?.granted ?? []
+      expect(specificGranted).toContain('portal.users.view')
+      expect(specificGranted).toContain('portal.users.manage')
+      expect(specificGranted).not.toContain('portal.users.roles.manage')
+      expect(specificGranted).not.toContain('nonexistent.feature')
+
+      // Wildcard portal.* matches every requested portal.* feature.
+      const wildcardRes = await request.post(ENDPOINT, {
+        data: { features: requested },
+        headers: portalCookieHeaders(wildcardSession, JSON_HEADER),
+      })
+      expect(wildcardRes.status()).toBe(200)
+      const wildcard = await readJsonSafe<FeatureCheckResponse>(wildcardRes)
+      const wildcardGranted = wildcard?.granted ?? []
+      expect(wildcardGranted).toContain('portal.users.view')
+      expect(wildcardGranted).toContain('portal.users.manage')
+      expect(wildcardGranted).toContain('portal.users.roles.manage')
+      expect(wildcardGranted).not.toContain('nonexistent.feature')
+
+      // Portal admin is granted everything it asks for, even non-portal features.
+      const adminRes = await request.post(ENDPOINT, {
+        data: { features: ['admin.audit', 'anything.else'] },
+        headers: portalCookieHeaders(adminSession, JSON_HEADER),
+      })
+      expect(adminRes.status()).toBe(200)
+      const adminBody = await readJsonSafe<FeatureCheckResponse>(adminRes)
+      expect(adminBody?.granted).toEqual(['admin.audit', 'anything.else'])
+    } finally {
+      for (const id of userIds) await deleteCustomerUserFixture(request, adminToken, id)
+      for (const id of roleIds) await deleteCustomerRoleFixture(request, adminToken, id)
+    }
+  })
+
+  test('requires auth and a 1..100 features array', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenContext(adminToken)
+
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      // Unauthenticated → 401.
+      const anon = await request.post(ENDPOINT, {
+        data: { features: ['portal.users.view'] },
+        headers: JSON_HEADER,
+      })
+      expect(anon.status(), 'feature-check should be 401 without auth').toBe(401)
+
+      const role = await createCustomerRoleFixture(request, adminToken, {
+        features: ['portal.account.manage'],
+      })
+      roleId = role.id
+      const user = await createCustomerUserFixture(request, adminToken, { roleIds: [role.id] })
+      userId = user.id
+      const session = await portalLogin(request, {
+        email: user.email,
+        password: user.password,
+        tenantId,
+      })
+
+      // Empty features array violates the min(1) schema → 400.
+      const emptyRes = await request.post(ENDPOINT, {
+        data: { features: [] },
+        headers: portalCookieHeaders(session, JSON_HEADER),
+      })
+      expect(emptyRes.status(), 'empty features should be 400').toBe(400)
+      expect((await readJsonSafe<FeatureCheckResponse>(emptyRes))?.ok).toBe(false)
+
+      // Exactly 100 features is accepted (schema upper bound).
+      const maxFeatures = Array.from({ length: 100 }, (_, i) => `portal.feature.${i}`)
+      const maxRes = await request.post(ENDPOINT, {
+        data: { features: maxFeatures },
+        headers: portalCookieHeaders(session, JSON_HEADER),
+      })
+      expect(maxRes.status(), '100 features should be accepted').toBe(200)
+
+      // 101 features exceeds the limit → 400.
+      const overRes = await request.post(ENDPOINT, {
+        data: { features: [...maxFeatures, 'portal.feature.100'] },
+        headers: portalCookieHeaders(session, JSON_HEADER),
+      })
+      expect(overRes.status(), '101 features should be 400').toBe(400)
+    } finally {
+      await deleteCustomerUserFixture(request, adminToken, userId)
+      await deleteCustomerRoleFixture(request, adminToken, roleId)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Adds integration-test coverage for the customer portal API (issue #2463). The
`/api/customer_accounts/portal/*` surface was previously untested; this adds the
seven issue-defined scenarios (TC-PORTAL-001..007) over profile, company users,
user deletion, role assignment, session management, and feature-check, plus a
reusable customer_accounts portal fixture helper. Test-only change — no
production code is modified.

## Changes

- Add `packages/core/src/helpers/integration/customerAccountsFixtures.ts`: portal
  login (returns an explicit `Cookie` header — the ephemeral prod build sets
  `Secure` cookies the Playwright jar won't replay over http), role/ACL/user
  fixtures, and cleanup helpers.
- Add `TC-PORTAL-001` (P0): `GET /portal/profile` returns user/roles/resolved
  features; 401 when anonymous.
- Add `TC-PORTAL-002` (P1): `PUT /portal/profile` updates + persists displayName;
  403 without `portal.account.manage`; 400 on empty input.
- Add `TC-PORTAL-003` (P1): `GET /portal/users` scoped to the caller's company,
  paginated/clamped, with cross-company isolation and the no-company 403.
- Add `TC-PORTAL-004` (P0): `DELETE /portal/users/[id]` self-delete guard,
  same-company delete, session revocation asserted at the DB row level, soft-delete
  proof, and the missing-feature 403.
- Add `TC-PORTAL-005` (P1): `PUT /portal/users/[id]/roles` enforces
  `customerAssignable`, replaces (not appends) the role set, and rejects empty /
  unauthorized requests.
- Add `TC-PORTAL-006` (P1): `GET/DELETE /portal/sessions[/id]` lists sessions,
  flags the current one, revokes non-current sessions, and protects the current one.
- Add `TC-PORTAL-007` (P2): `POST /portal/feature-check` exact + wildcard grants,
  portal-admin bypass, 401, and the 1..100 features bound.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — issue #2463 defines the scenarios; additive test coverage, no `.ai/specs` entry exists or is required.

## Testing

- `BASE_URL=<ephemeral> DATABASE_URL=<ephemeral> npx playwright test --config .ai/qa/tests/playwright.config.ts TC-PORTAL` → **12/12 passed** (run 4×, including `--retries=0` and CI-default `retries=1`; idempotent across reruns).
- `yarn turbo run typecheck --filter=@open-mercato/core` → pass (typechecks the `__integration__` specs + helper).
- `yarn i18n:check-sync` → all translation files in sync.
- `lint` → `@open-mercato/core` has no lint task; new files are `any`-free with no unused symbols.
- `build:app` → exercised by the ephemeral production build used to run the suite.
- Validated against a live ephemeral Postgres + production Next build.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — none required for a test-only change.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Specs live in the module's `__integration__/` folder per `.ai/qa/AGENTS.md`; `.ai/qa/tests/` holds Playwright config only.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — issue-driven test coverage, no spec.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, backend API tests, no UI.
- [x] No arbitrary text sizes — N/A, no UI.
- [x] Empty state handled for list/data pages — N/A, no UI.
- [x] Loading state handled for async pages — N/A, no UI.
- [x] `aria-label` on all icon-only buttons — N/A, no UI.
- [x] Uses existing DS components — N/A, no UI.

## Linked issues

Fixes #2463