### PR TITLE
feat: 2458 customers crm coverage

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-075.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-075.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createPipelineFixture,
+  createPipelineStageFixture,
+  createDealFixture,
+  deleteEntityByBody,
+  deleteEntityIfExists,
+} from '@open-mercato/core/helpers/integration/crmFixtures';
+
+/**
+ * TC-CRM-075: Pipeline and stage CRUD via the settings API.
+ * Issue: https://github.com/open-mercato/open-mercato/issues/2458
+ *
+ * Verified-against-source deviations from the (auto-generated) issue surfaces:
+ * - There is no `GET /api/customers/pipelines/[id]` detail route. Stage ordering
+ *   is read via `GET /api/customers/pipeline-stages?pipelineId=` (ordered by `order`).
+ * - There is no `PUT|DELETE /api/customers/pipeline-stages/[id]` subroute. Stage
+ *   update/delete go to the collection route with the id in the BODY.
+ * - POST pipeline / stage return 201 `{ id }`; reorder takes `{ stages: [{ id, order }] }`.
+ * - Deleting a stage that still has active deals returns 409.
+ */
+test.describe('TC-CRM-075: Pipeline and stage CRUD via settings API', () => {
+  test('creates a pipeline, manages stages, and guards stage-with-deals deletion', async ({ request }) => {
+    test.slow();
+
+    const stamp = Date.now();
+    let token: string | null = null;
+    let pipelineId: string | null = null;
+    const stageIds: string[] = [];
+    let dealId: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+
+      // 1. Create a pipeline.
+      pipelineId = await createPipelineFixture(request, token, { name: `TC-CRM-075 Renewals ${stamp}` });
+
+      // 2. Create 3 stages.
+      const qualificationId = await createPipelineStageFixture(request, token, { pipelineId, label: 'Qualification', order: 0 });
+      const proposalId = await createPipelineStageFixture(request, token, { pipelineId, label: 'Proposal', order: 1 });
+      const closedWonId = await createPipelineStageFixture(request, token, { pipelineId, label: 'Closed Won', order: 2 });
+      stageIds.push(qualificationId, proposalId, closedWonId);
+
+      // 3. Reorder so 'Closed Won' is first.
+      const reorder = await apiRequest(request, 'POST', '/api/customers/pipeline-stages/reorder', {
+        token,
+        data: {
+          stages: [
+            { id: closedWonId, order: 0 },
+            { id: qualificationId, order: 1 },
+            { id: proposalId, order: 2 },
+          ],
+        },
+      });
+      expect(reorder.status(), 'reorder returns 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(reorder))?.ok).toBe(true);
+
+      // 4. Verify the new order via the stages list.
+      const afterReorder = await apiRequest(request, 'GET', `/api/customers/pipeline-stages?pipelineId=${pipelineId}`, { token });
+      expect(afterReorder.status()).toBe(200);
+      const reorderedItems = (await readJsonSafe<{ items: Array<{ id: string; label: string; order: number }> }>(afterReorder))?.items ?? [];
+      expect(reorderedItems.map((stage) => stage.id)).toEqual([closedWonId, qualificationId, proposalId]);
+      expect(reorderedItems[0]?.label).toBe('Closed Won');
+
+      // 5. Update a stage label (collection route, id in body).
+      const update = await apiRequest(request, 'PUT', '/api/customers/pipeline-stages', {
+        token,
+        data: { id: qualificationId, label: 'Qualification (Updated)' },
+      });
+      expect(update.status(), 'stage update returns 200').toBe(200);
+      const afterUpdate = await apiRequest(request, 'GET', `/api/customers/pipeline-stages?pipelineId=${pipelineId}`, { token });
+      const updatedStage = (await readJsonSafe<{ items: Array<{ id: string; label: string }> }>(afterUpdate))?.items?.find((stage) => stage.id === qualificationId);
+      expect(updatedStage?.label).toBe('Qualification (Updated)');
+
+      // 6. Delete a stage (collection route, id in body) and confirm removal.
+      const del = await apiRequest(request, 'DELETE', '/api/customers/pipeline-stages', { token, data: { id: proposalId } });
+      expect(del.status(), 'stage delete returns 200').toBe(200);
+      stageIds.splice(stageIds.indexOf(proposalId), 1);
+      const afterDelete = await apiRequest(request, 'GET', `/api/customers/pipeline-stages?pipelineId=${pipelineId}`, { token });
+      const remainingIds = (await readJsonSafe<{ items: Array<{ id: string }> }>(afterDelete))?.items?.map((stage) => stage.id) ?? [];
+      expect(remainingIds).not.toContain(proposalId);
+      expect(remainingIds).toEqual(expect.arrayContaining([qualificationId, closedWonId]));
+
+      // 7. The pipeline is listed.
+      const pipelines = await apiRequest(request, 'GET', '/api/customers/pipelines', { token });
+      const pipelineIds = (await readJsonSafe<{ items: Array<{ id: string }> }>(pipelines))?.items?.map((pipeline) => pipeline.id) ?? [];
+      expect(pipelineIds).toContain(pipelineId);
+
+      // 8. Deleting a stage that still has active deals is blocked with 409.
+      dealId = await createDealFixture(request, token, { title: `TC-CRM-075 Deal ${stamp}`, pipelineId, pipelineStageId: qualificationId });
+      const blocked = await apiRequest(request, 'DELETE', '/api/customers/pipeline-stages', { token, data: { id: qualificationId } });
+      expect(blocked.status(), 'deleting a stage with active deals returns 409').toBe(409);
+    } finally {
+      // Delete the deal first so the remaining stages are no longer referenced by active deals.
+      await deleteEntityIfExists(request, token, '/api/customers/deals', dealId);
+      for (const stageId of stageIds) {
+        await deleteEntityByBody(request, token, '/api/customers/pipeline-stages', stageId);
+      }
+      await deleteEntityByBody(request, token, '/api/customers/pipelines', pipelineId);
+    }
+  });
+});

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-076.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-076.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createCompanyFixture,
+  createPersonFixture,
+  createDealFixture,
+  deleteEntityIfExists,
+} from '@open-mercato/core/helpers/integration/crmFixtures';
+
+/**
+ * TC-CRM-076: Deal participant association (link/unlink people & companies).
+ * Issue: https://github.com/open-mercato/open-mercato/issues/2458
+ *
+ * Verified-against-source deviations from the (auto-generated) issue surfaces:
+ * - `/api/customers/deals/[id]/people` and `/api/customers/deals/[id]/companies`
+ *   are GET-only; there are no POST/DELETE participant endpoints and deal
+ *   participants carry no `role`. Associations are managed through the deal
+ *   create/update payload (`personIds`/`companyIds`) with REPLACE semantics
+ *   (full set replaces, omitted = untouched, duplicates de-duplicated), and are
+ *   verified through `GET /api/customers/deals/[id]` (`counts` / `linkedPersonIds`).
+ */
+test.describe('TC-CRM-076: Deal participant association (link/unlink people & companies)', () => {
+  test('links and unlinks people/companies on a deal via the deal payload', async ({ request }) => {
+    test.slow();
+
+    const stamp = Date.now();
+    let token: string | null = null;
+    let companyId: string | null = null;
+    let person1Id: string | null = null;
+    let person2Id: string | null = null;
+    let dealId: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+      const authToken = token; // non-null binding for the readDeal closure below
+      companyId = await createCompanyFixture(request, token, `TC-CRM-076 Co ${stamp}`);
+      person1Id = await createPersonFixture(request, token, { firstName: 'Dana', lastName: 'One', displayName: `TC-CRM-076 P1 ${stamp}` });
+      person2Id = await createPersonFixture(request, token, { firstName: 'Evan', lastName: 'Two', displayName: `TC-CRM-076 P2 ${stamp}` });
+
+      // Create a deal linked to the company and person1.
+      dealId = await createDealFixture(request, token, {
+        title: `TC-CRM-076 Deal ${stamp}`,
+        companyIds: [companyId],
+        personIds: [person1Id],
+      });
+
+      const readDeal = async () => {
+        const resp = await apiRequest(request, 'GET', `/api/customers/deals/${dealId}`, { token: authToken });
+        expect(resp.status()).toBe(200);
+        return readJsonSafe<{
+          counts: { people: number; companies: number };
+          linkedPersonIds: string[];
+          linkedCompanyIds: string[];
+        }>(resp);
+      };
+
+      // Initial associations.
+      let detail = await readDeal();
+      expect(detail?.counts.people).toBe(1);
+      expect(detail?.counts.companies).toBe(1);
+      expect(detail?.linkedPersonIds).toContain(person1Id);
+      expect(detail?.linkedCompanyIds).toContain(companyId);
+
+      // Add person2 (replace semantics — send the full desired set).
+      const addP2 = await apiRequest(request, 'PUT', '/api/customers/deals', { token, data: { id: dealId, personIds: [person1Id, person2Id] } });
+      expect(addP2.status()).toBe(200);
+      detail = await readDeal();
+      expect(detail?.counts.people).toBe(2);
+      expect(detail?.linkedPersonIds).toEqual(expect.arrayContaining([person1Id, person2Id]));
+
+      // Duplicate ids are de-duplicated (no double-link).
+      const dup = await apiRequest(request, 'PUT', '/api/customers/deals', { token, data: { id: dealId, personIds: [person1Id, person1Id, person2Id] } });
+      expect(dup.status()).toBe(200);
+      detail = await readDeal();
+      expect(detail?.counts.people).toBe(2);
+
+      // Unlink person1 (send the reduced set).
+      const removeP1 = await apiRequest(request, 'PUT', '/api/customers/deals', { token, data: { id: dealId, personIds: [person2Id] } });
+      expect(removeP1.status()).toBe(200);
+      detail = await readDeal();
+      expect(detail?.counts.people).toBe(1);
+      expect(detail?.linkedPersonIds).toEqual([person2Id]);
+
+      // Unlink the company (empty set) — people stay untouched because companyIds-only update.
+      const removeCo = await apiRequest(request, 'PUT', '/api/customers/deals', { token, data: { id: dealId, companyIds: [] } });
+      expect(removeCo.status()).toBe(200);
+      detail = await readDeal();
+      expect(detail?.counts.companies).toBe(0);
+      expect(detail?.counts.people).toBe(1);
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/deals', dealId);
+      await deleteEntityIfExists(request, token, '/api/customers/people', person1Id);
+      await deleteEntityIfExists(request, token, '/api/customers/people', person2Id);
+      await deleteEntityIfExists(request, token, '/api/customers/companies', companyId);
+    }
+  });
+});

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-077.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-077.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createCompanyFixture,
+  createPersonFixture,
+  deleteEntityIfExists,
+} from '@open-mercato/core/helpers/integration/crmFixtures';
+
+/**
+ * TC-CRM-077: Person-company link lifecycle (link, list, unlink).
+ * Issue: https://github.com/open-mercato/open-mercato/issues/2458
+ *
+ * Verified-against-source contract:
+ * - `POST /api/customers/people/[id]/companies` body `{ companyId }` → 200
+ *   `{ ok: true, result: { id, companyId, displayName, isPrimary } }` (the link id is `result.id`).
+ * - `GET /api/customers/people/[id]/companies` → `{ items: [{ id, companyId, displayName, isPrimary }] }`.
+ * - `DELETE /api/customers/people/[id]/companies/[linkId]` → 200 `{ ok: true }` (soft-deletes the link only).
+ */
+test.describe('TC-CRM-077: Person-company link lifecycle', () => {
+  test('links a company to a person and unlinks it without deleting the person', async ({ request }) => {
+    test.slow();
+
+    const stamp = Date.now();
+    let token: string | null = null;
+    let companyId: string | null = null;
+    let personId: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+      companyId = await createCompanyFixture(request, token, `TC-CRM-077 Co ${stamp}`);
+      personId = await createPersonFixture(request, token, { firstName: 'Lena', lastName: 'Link', displayName: `TC-CRM-077 P ${stamp}` });
+
+      // Link company → person.
+      const linkResp = await apiRequest(request, 'POST', `/api/customers/people/${personId}/companies`, { token, data: { companyId } });
+      expect(linkResp.status(), 'POST person-company link returns 200').toBe(200);
+      const linkBody = await readJsonSafe<{ ok: boolean; result: { id: string; companyId: string } }>(linkResp);
+      expect(linkBody?.ok).toBe(true);
+      const linkId = linkBody?.result.id ?? '';
+      expect(linkId.length > 0, 'link response carries a link id').toBe(true);
+      expect(linkBody?.result.companyId).toBe(companyId);
+
+      // The link appears in the list.
+      const listBefore = await apiRequest(request, 'GET', `/api/customers/people/${personId}/companies`, { token });
+      expect(listBefore.status()).toBe(200);
+      const beforeItems = (await readJsonSafe<{ items: Array<{ id: string; companyId: string }> }>(listBefore))?.items ?? [];
+      expect(beforeItems.some((entry) => entry.companyId === companyId)).toBe(true);
+
+      // Unlink.
+      const unlink = await apiRequest(request, 'DELETE', `/api/customers/people/${personId}/companies/${linkId}`, { token });
+      expect(unlink.status(), 'DELETE link returns 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(unlink))?.ok).toBe(true);
+
+      // The link is gone from the list.
+      const listAfter = await apiRequest(request, 'GET', `/api/customers/people/${personId}/companies`, { token });
+      const afterItems = (await readJsonSafe<{ items: Array<{ companyId: string }> }>(listAfter))?.items ?? [];
+      expect(afterItems.some((entry) => entry.companyId === companyId)).toBe(false);
+
+      // The person itself remains readable (only the link was removed).
+      const personDetail = await apiRequest(request, 'GET', `/api/customers/people/${personId}`, { token });
+      expect(personDetail.status(), 'person remains readable after unlink').toBe(200);
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/people', personId);
+      await deleteEntityIfExists(request, token, '/api/customers/companies', companyId);
+    }
+  });
+});

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-078.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-078.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createCompanyFixture,
+  createPersonFixture,
+  deleteEntityIfExists,
+} from '@open-mercato/core/helpers/integration/crmFixtures';
+
+/**
+ * TC-CRM-078: Entity role assignment lifecycle (person & company).
+ * Issue: https://github.com/open-mercato/open-mercato/issues/2458
+ *
+ * Verified-against-source contract:
+ * - Roles assign a USER to an entity with a free-text `roleType`. The client body
+ *   is `{ roleType, userId }` (not `{ role }`); the route injects entity/scope.
+ * - `POST /api/customers/{people|companies}/[id]/roles` → 201 `{ id }`.
+ *   Gated by `customers.roles.manage` (admin has it via `customers.*`).
+ * - `DELETE` uses a `?roleId=` QUERY param (there is no `/roles/[roleId]` subroute) → 200 `{ ok }`.
+ * - Uniqueness is per `(entityType, entityId, roleType)`, so two distinct role types
+ *   for the same user/entity coexist.
+ */
+test.describe('TC-CRM-078: Entity role assignment lifecycle', () => {
+  test('assigns and unassigns roles on a person and a company', async ({ request }) => {
+    test.slow();
+
+    const stamp = Date.now();
+    let token: string | null = null;
+    let personId: string | null = null;
+    let companyId: string | null = null;
+    const createdPersonRoleIds: string[] = [];
+    const createdCompanyRoleIds: string[] = [];
+
+    try {
+      token = await getAuthToken(request, 'admin');
+      const { userId } = getTokenScope(token);
+      expect(userId.length > 0, 'admin token carries a user id').toBe(true);
+
+      personId = await createPersonFixture(request, token, { firstName: 'Rhea', lastName: 'Role', displayName: `TC-CRM-078 P ${stamp}` });
+      companyId = await createCompanyFixture(request, token, `TC-CRM-078 Co ${stamp}`);
+
+      // Assign 'decision_maker' on the person.
+      const createDecisionMaker = await apiRequest(request, 'POST', `/api/customers/people/${personId}/roles`, { token, data: { roleType: 'decision_maker', userId } });
+      expect(createDecisionMaker.status(), 'role create returns 201').toBe(201);
+      const decisionMakerRoleId = (await readJsonSafe<{ id: string }>(createDecisionMaker))?.id ?? '';
+      expect(decisionMakerRoleId.length > 0, 'role create returns an id').toBe(true);
+      createdPersonRoleIds.push(decisionMakerRoleId);
+
+      const listAfterFirst = await apiRequest(request, 'GET', `/api/customers/people/${personId}/roles`, { token });
+      expect(listAfterFirst.status()).toBe(200);
+      const itemsAfterFirst = (await readJsonSafe<{ items: Array<{ id: string; roleType: string; userId: string }> }>(listAfterFirst))?.items ?? [];
+      expect(itemsAfterFirst.some((role) => role.roleType === 'decision_maker' && role.userId === userId)).toBe(true);
+
+      // Assign a second role ('influencer') — distinct role type, so both coexist.
+      const createInfluencer = await apiRequest(request, 'POST', `/api/customers/people/${personId}/roles`, { token, data: { roleType: 'influencer', userId } });
+      expect(createInfluencer.status()).toBe(201);
+      const influencerRoleId = (await readJsonSafe<{ id: string }>(createInfluencer))?.id ?? '';
+      createdPersonRoleIds.push(influencerRoleId);
+
+      const listAfterSecond = await apiRequest(request, 'GET', `/api/customers/people/${personId}/roles`, { token });
+      const roleTypesAfterSecond = (await readJsonSafe<{ items: Array<{ roleType: string }> }>(listAfterSecond))?.items?.map((role) => role.roleType) ?? [];
+      expect(roleTypesAfterSecond).toEqual(expect.arrayContaining(['decision_maker', 'influencer']));
+
+      // Unassign 'decision_maker' via the ?roleId= query param.
+      const deleteDecisionMaker = await apiRequest(request, 'DELETE', `/api/customers/people/${personId}/roles?roleId=${decisionMakerRoleId}`, { token });
+      expect(deleteDecisionMaker.status(), 'role delete returns 200').toBe(200);
+
+      const listAfterDelete = await apiRequest(request, 'GET', `/api/customers/people/${personId}/roles`, { token });
+      const itemsAfterDelete = (await readJsonSafe<{ items: Array<{ id: string; roleType: string }> }>(listAfterDelete))?.items ?? [];
+      expect(itemsAfterDelete.some((role) => role.roleType === 'decision_maker')).toBe(false);
+      expect(itemsAfterDelete.some((role) => role.id === influencerRoleId)).toBe(true);
+
+      // Company roles mirror person roles.
+      const createCompanyRole = await apiRequest(request, 'POST', `/api/customers/companies/${companyId}/roles`, { token, data: { roleType: 'vendor', userId } });
+      expect(createCompanyRole.status()).toBe(201);
+      const companyRoleId = (await readJsonSafe<{ id: string }>(createCompanyRole))?.id ?? '';
+      createdCompanyRoleIds.push(companyRoleId);
+
+      const deleteCompanyRole = await apiRequest(request, 'DELETE', `/api/customers/companies/${companyId}/roles?roleId=${companyRoleId}`, { token });
+      expect(deleteCompanyRole.status()).toBe(200);
+
+      const listCompanyRoles = await apiRequest(request, 'GET', `/api/customers/companies/${companyId}/roles`, { token });
+      const companyRoleItems = (await readJsonSafe<{ items: unknown[] }>(listCompanyRoles))?.items ?? [];
+      expect(companyRoleItems.length).toBe(0);
+    } finally {
+      // Delete every role row we created (id-linked rows are NOT cascaded by the
+      // soft-delete of the parent person/company), idempotently and failure-safe.
+      for (const roleId of createdPersonRoleIds) {
+        if (token && personId) {
+          await apiRequest(request, 'DELETE', `/api/customers/people/${personId}/roles?roleId=${roleId}`, { token }).catch(() => undefined);
+        }
+      }
+      for (const roleId of createdCompanyRoleIds) {
+        if (token && companyId) {
+          await apiRequest(request, 'DELETE', `/api/customers/companies/${companyId}/roles?roleId=${roleId}`, { token }).catch(() => undefined);
+        }
+      }
+      await deleteEntityIfExists(request, token, '/api/customers/people', personId);
+      await deleteEntityIfExists(request, token, '/api/customers/companies', companyId);
+    }
+  });
+});

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-079.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-079.spec.ts
@@ -1,0 +1,129 @@
+import path from 'node:path';
+import { config as loadEnv } from 'dotenv';
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createCompanyFixture,
+  createPipelineFixture,
+  createPipelineStageFixture,
+  createDealFixture,
+  deleteEntityByBody,
+  deleteEntityIfExists,
+} from '@open-mercato/core/helpers/integration/crmFixtures';
+import { drainIntegrationQueue } from '@open-mercato/core/helpers/integration/queue';
+
+/**
+ * TC-CRM-079: Bulk update deal stage and owner via the dedicated endpoints.
+ * Issue: https://github.com/open-mercato/open-mercato/issues/2458
+ *
+ * Verified-against-source contract:
+ * - `POST /api/customers/deals/bulk-update-stage` `{ ids, pipelineStageId }` and
+ *   `POST /api/customers/deals/bulk-update-owner` `{ ids, ownerUserId }` are
+ *   ASYNCHRONOUS: they enqueue a background job and return 202 `{ ok, progressJobId }`.
+ *   The per-deal update happens in a worker, so we drain the queue and poll the
+ *   deal detail until the change lands (portable across auto-spawn / CI lanes).
+ * - An empty `ids` list fails validation (`min(1)`) → 400.
+ */
+const APP_ROOT = process.env.OM_TEST_APP_ROOT?.trim()
+  ? path.resolve(process.env.OM_TEST_APP_ROOT as string)
+  : path.resolve(process.cwd(), 'apps/mercato');
+
+// Local (non-standalone) runs need QUEUE_BASE_DIR pointed at the app's queue dir so
+// `drainIntegrationQueue` reads the same file-backed queue the app server writes to.
+if (!process.env.OM_TEST_APP_ROOT?.trim()) {
+  loadEnv({ path: path.resolve(APP_ROOT, '.env') });
+  process.env.QUEUE_BASE_DIR = path.resolve(APP_ROOT, '.mercato/queue');
+}
+
+const STAGE_QUEUE = 'customers-deals-bulk-update-stage';
+const OWNER_QUEUE = 'customers-deals-bulk-update-owner';
+
+async function drainAndPollDeals(
+  request: APIRequestContext,
+  token: string,
+  queueName: string,
+  dealIds: string[],
+  predicate: (deal: Record<string, unknown>) => boolean,
+): Promise<boolean> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    await drainIntegrationQueue(queueName, { appRoot: APP_ROOT });
+    const checks = await Promise.all(
+      dealIds.map(async (id) => {
+        const resp = await apiRequest(request, 'GET', `/api/customers/deals/${id}`, { token });
+        if (!resp.ok()) return false;
+        const body = await readJsonSafe<{ deal?: Record<string, unknown> }>(resp);
+        return predicate(body?.deal ?? {});
+      }),
+    );
+    if (checks.every(Boolean)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  }
+  return false;
+}
+
+test.describe('TC-CRM-079: Bulk update deal stage and owner', () => {
+  test('bulk-updates stage and owner for multiple deals and rejects empty id lists', async ({ request }) => {
+    test.slow();
+
+    const stamp = Date.now();
+    let token: string | null = null;
+    let companyId: string | null = null;
+    let pipelineId: string | null = null;
+    const stageIds: string[] = [];
+    const dealIds: string[] = [];
+
+    try {
+      token = await getAuthToken(request, 'admin');
+      const { userId } = getTokenScope(token);
+      expect(userId.length > 0, 'admin token carries a user id').toBe(true);
+
+      companyId = await createCompanyFixture(request, token, `TC-CRM-079 Co ${stamp}`);
+      pipelineId = await createPipelineFixture(request, token, { name: `TC-CRM-079 Pipe ${stamp}` });
+      const stageAId = await createPipelineStageFixture(request, token, { pipelineId, label: 'Stage A', order: 0 });
+      const stageBId = await createPipelineStageFixture(request, token, { pipelineId, label: 'Stage B', order: 1 });
+      stageIds.push(stageAId, stageBId);
+
+      for (let index = 0; index < 3; index += 1) {
+        const dealId = await createDealFixture(request, token, {
+          title: `TC-CRM-079 Deal ${index} ${stamp}`,
+          companyIds: [companyId],
+          pipelineId,
+          pipelineStageId: stageAId,
+        });
+        dealIds.push(dealId);
+      }
+
+      // Bulk move all deals to stage B (async → 202 + progress job).
+      const stageResp = await apiRequest(request, 'POST', '/api/customers/deals/bulk-update-stage', { token, data: { ids: dealIds, pipelineStageId: stageBId } });
+      expect(stageResp.status(), 'bulk-update-stage returns 202').toBe(202);
+      const stageBody = await readJsonSafe<{ ok: boolean; progressJobId: string | null }>(stageResp);
+      expect(stageBody?.ok).toBe(true);
+      expect((stageBody?.progressJobId ?? '').length > 0, 'bulk-update-stage returns a progress job id').toBe(true);
+
+      const stageApplied = await drainAndPollDeals(request, token, STAGE_QUEUE, dealIds, (deal) => deal.pipelineStageId === stageBId);
+      expect(stageApplied, 'all deals moved to stage B after the bulk job drains').toBe(true);
+
+      // Bulk reassign owner (async → 202 + progress job).
+      const ownerResp = await apiRequest(request, 'POST', '/api/customers/deals/bulk-update-owner', { token, data: { ids: dealIds, ownerUserId: userId } });
+      expect(ownerResp.status(), 'bulk-update-owner returns 202').toBe(202);
+      const ownerBody = await readJsonSafe<{ ok: boolean; progressJobId: string | null }>(ownerResp);
+      expect(ownerBody?.ok).toBe(true);
+      expect((ownerBody?.progressJobId ?? '').length > 0, 'bulk-update-owner returns a progress job id').toBe(true);
+
+      const ownerApplied = await drainAndPollDeals(request, token, OWNER_QUEUE, dealIds, (deal) => deal.ownerUserId === userId);
+      expect(ownerApplied, 'all deals reassigned to the new owner after the bulk job drains').toBe(true);
+
+      // Empty ids list is rejected.
+      const emptyResp = await apiRequest(request, 'POST', '/api/customers/deals/bulk-update-stage', { token, data: { ids: [], pipelineStageId: stageBId } });
+      expect(emptyResp.status(), 'empty ids list is rejected with 400').toBe(400);
+    } finally {
+      // Soft-delete the deals before the stages so stage deletion is not blocked (409) by active deals.
+      for (const id of dealIds) await deleteEntityIfExists(request, token, '/api/customers/deals', id);
+      for (const id of stageIds) await deleteEntityByBody(request, token, '/api/customers/pipeline-stages', id);
+      await deleteEntityByBody(request, token, '/api/customers/pipelines', pipelineId);
+      await deleteEntityIfExists(request, token, '/api/customers/companies', companyId);
+    }
+  });
+});

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-080.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-080.spec.ts
@@ -36,10 +36,13 @@ test.describe('TC-CRM-080: Interaction cancellation and conflict detection', () 
 
       companyId = await createCompanyFixture(request, token, `TC-CRM-080 Co ${stamp}`);
 
-      // A fixed, far-future UTC slot keeps the conflict-window math deterministic.
-      const scheduledDate = '2030-06-17';
-      const scheduledTime = '10:00';
-      const scheduledAt = `${scheduledDate}T${scheduledTime}:00.000Z`;
+      // A future UTC slot computed at runtime (no static date literal / time-bomb)
+      // while keeping the conflict-window math deterministic within the run.
+      const slot = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+      slot.setUTCHours(10, 0, 0, 0);
+      const scheduledAt = slot.toISOString();
+      const scheduledDate = scheduledAt.slice(0, 10);
+      const scheduledTime = scheduledAt.slice(11, 16);
 
       const createResp = await apiRequest(request, 'POST', '/api/customers/interactions', {
         token,

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-080.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-080.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createCompanyFixture,
+  deleteEntityIfExists,
+} from '@open-mercato/core/helpers/integration/crmFixtures';
+
+/**
+ * TC-CRM-080: Interaction cancellation and conflict detection.
+ * Issue: https://github.com/open-mercato/open-mercato/issues/2458
+ *
+ * Verified-against-source deviations from the (auto-generated) issue surfaces:
+ * - Conflict detection is `GET /api/customers/interactions/conflicts` with
+ *   `date`/`startTime`/`duration`/`userId` query params (not a POST), returning
+ *   `{ ok, result: { hasConflicts, conflicts } }`. It surfaces overlapping
+ *   PLANNED interactions for the given owner/author.
+ * - `POST /api/customers/interactions/cancel` `{ id }` → 200 `{ ok }`, sets
+ *   status to `'canceled'` (US spelling), and is idempotent.
+ * - There is no `GET /api/customers/interactions/[id]`; status is read via the
+ *   list endpoint (`?entityId=`, `?status=planned`).
+ */
+test.describe('TC-CRM-080: Interaction cancellation and conflict detection', () => {
+  test('detects scheduling conflicts and cancels an interaction idempotently', async ({ request }) => {
+    test.slow();
+
+    const stamp = Date.now();
+    let token: string | null = null;
+    let companyId: string | null = null;
+    let interactionId: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+      const { userId } = getTokenScope(token);
+      expect(userId.length > 0, 'admin token carries a user id').toBe(true);
+
+      companyId = await createCompanyFixture(request, token, `TC-CRM-080 Co ${stamp}`);
+
+      // A fixed, far-future UTC slot keeps the conflict-window math deterministic.
+      const scheduledDate = '2030-06-17';
+      const scheduledTime = '10:00';
+      const scheduledAt = `${scheduledDate}T${scheduledTime}:00.000Z`;
+
+      const createResp = await apiRequest(request, 'POST', '/api/customers/interactions', {
+        token,
+        data: {
+          entityId: companyId,
+          interactionType: 'meeting',
+          status: 'planned',
+          scheduledAt,
+          ownerUserId: userId,
+          title: `TC-CRM-080 Planned ${stamp}`,
+        },
+      });
+      expect(createResp.status(), 'interaction create returns 201').toBe(201);
+      interactionId = (await readJsonSafe<{ id: string }>(createResp))?.id ?? null;
+      expect((interactionId ?? '').length > 0, 'interaction create returns an id').toBe(true);
+
+      // Conflict detection over the overlapping window for this owner.
+      const conflictResp = await apiRequest(
+        request,
+        'GET',
+        `/api/customers/interactions/conflicts?date=${scheduledDate}&startTime=${scheduledTime}&duration=60&userId=${userId}`,
+        { token },
+      );
+      expect(conflictResp.status(), 'conflicts GET returns 200').toBe(200);
+      const conflictBody = await readJsonSafe<{ ok: boolean; result: { hasConflicts: boolean; conflicts: Array<{ id: string }> } }>(conflictResp);
+      expect(conflictBody?.ok).toBe(true);
+      expect(conflictBody?.result.hasConflicts).toBe(true);
+      expect(conflictBody?.result.conflicts.some((conflict) => conflict.id === interactionId)).toBe(true);
+
+      // Cancel the interaction.
+      const cancel = await apiRequest(request, 'POST', '/api/customers/interactions/cancel', { token, data: { id: interactionId } });
+      expect(cancel.status(), 'cancel returns 200').toBe(200);
+      expect((await readJsonSafe<{ ok?: boolean }>(cancel))?.ok).toBe(true);
+
+      // Status is now 'canceled' and the interaction leaves the planned list.
+      const listAll = await apiRequest(request, 'GET', `/api/customers/interactions?entityId=${companyId}`, { token });
+      const allItems = (await readJsonSafe<{ items: Array<{ id: string; status: string }> }>(listAll))?.items ?? [];
+      expect(allItems.find((item) => item.id === interactionId)?.status).toBe('canceled');
+
+      const listPlanned = await apiRequest(request, 'GET', `/api/customers/interactions?entityId=${companyId}&status=planned`, { token });
+      const plannedIds = (await readJsonSafe<{ items: Array<{ id: string }> }>(listPlanned))?.items?.map((item) => item.id) ?? [];
+      expect(plannedIds).not.toContain(interactionId);
+
+      // Cancelling again is idempotent.
+      const cancelAgain = await apiRequest(request, 'POST', '/api/customers/interactions/cancel', { token, data: { id: interactionId } });
+      expect(cancelAgain.status(), 're-cancel is idempotent (200)').toBe(200);
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/interactions', interactionId);
+      await deleteEntityIfExists(request, token, '/api/customers/companies', companyId);
+    }
+  });
+});

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-081.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-081.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { createPersonFixture, deleteEntityIfExists } from '@open-mercato/core/helpers/integration/crmFixtures';
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+
+/**
+ * TC-CRM-081: RBAC denial on protected customers endpoints.
+ * Issue: https://github.com/open-mercato/open-mercato/issues/2458
+ *
+ * Verified-against-source contract:
+ * - `POST|PUT|DELETE /api/customers/people` require `customers.people.manage`;
+ *   `POST /api/customers/deals` requires `customers.deals.manage`.
+ * - A user granted only the `.view` features (via the ACL API, which invalidates
+ *   the RBAC cache) can list but is denied (403) on every manage operation.
+ */
+test.describe('TC-CRM-081: RBAC denial on protected customers endpoints', () => {
+  test('denies manage operations for a view-only user (403)', async ({ request }) => {
+    test.slow();
+
+    const stamp = Date.now();
+    const password = 'Secret123!';
+    const restrictedEmail = `tc-crm-081-${stamp}@example.com`;
+    let adminToken: string | null = null;
+    let roleId: string | null = null;
+    let userId: string | null = null;
+    let personId: string | null = null;
+
+    try {
+      adminToken = await getAuthToken(request, 'admin');
+      const { organizationId, tenantId } = getTokenContext(adminToken);
+      expect(organizationId.length > 0 && tenantId.length > 0, 'admin token carries org + tenant').toBe(true);
+
+      // A real person for the PUT/DELETE attempts (the feature gate runs before lookup, but be realistic).
+      personId = await createPersonFixture(request, adminToken, { firstName: 'View', lastName: 'Only', displayName: `TC-CRM-081 P ${stamp}` });
+
+      // View-only role + user, granted ONLY the `.view` features at the user level.
+      roleId = await createRoleFixture(request, adminToken, { name: `TC-CRM-081 Viewer ${stamp}`, tenantId });
+      userId = await createUserFixture(request, adminToken, {
+        email: restrictedEmail,
+        password,
+        organizationId,
+        roles: [roleId],
+        name: 'TC-CRM-081 Restricted',
+      });
+      await setUserAclVisibility(request, adminToken, {
+        userId,
+        organizations: [organizationId],
+        features: ['customers.people.view', 'customers.deals.view'],
+      });
+      const restrictedToken = await getAuthToken(request, restrictedEmail, password);
+
+      // Sanity: the view feature is honored.
+      const canView = await apiRequest(request, 'GET', '/api/customers/people', { token: restrictedToken });
+      expect(canView.status(), 'view-only user can list people').toBe(200);
+
+      // Manage operations are denied.
+      const denyCreate = await apiRequest(request, 'POST', '/api/customers/people', {
+        token: restrictedToken,
+        data: { firstName: 'No', lastName: 'Access', displayName: `TC-CRM-081 denied ${stamp}` },
+      });
+      expect(denyCreate.status(), 'POST people without manage → 403').toBe(403);
+
+      const denyUpdate = await apiRequest(request, 'PUT', '/api/customers/people', {
+        token: restrictedToken,
+        data: { id: personId, description: 'denied' },
+      });
+      expect(denyUpdate.status(), 'PUT people without manage → 403').toBe(403);
+
+      const denyDelete = await apiRequest(request, 'DELETE', '/api/customers/people', {
+        token: restrictedToken,
+        data: { id: personId },
+      });
+      expect(denyDelete.status(), 'DELETE people without manage → 403').toBe(403);
+
+      const denyDeal = await apiRequest(request, 'POST', '/api/customers/deals', {
+        token: restrictedToken,
+        data: { title: `TC-CRM-081 denied deal ${stamp}` },
+      });
+      expect(denyDeal.status(), 'POST deals without manage → 403').toBe(403);
+    } finally {
+      await deleteEntityIfExists(request, adminToken, '/api/customers/people', personId);
+      await deleteUserIfExists(request, adminToken, userId);
+      await deleteRoleIfExists(request, adminToken, roleId);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds API-level integration coverage for the `customers` (CRM) module — the 7 scenarios enumerated in #2458 (TC-CRM-075…081). The issue's documented endpoint shapes were auto-generated and inaccurate in several places; each spec was written against the **actual** route/validator/command behavior (verified from source and a live run), and each file's header documents where reality differs from the issue text (e.g. stage PUT/DELETE on the collection route with id in body; deal participants via the deal payload, not a dedicated endpoint; bulk updates are async 202+queue; conflicts is a GET; cancel sets `'canceled'`).

## Changes

- Add `packages/core/src/modules/customers/__integration__/TC-CRM-075.spec.ts` — pipeline + stage CRUD (create/reorder/update/delete via collection route), stage-list ordering, and the 409 guard when deleting a stage with active deals.
- Add `TC-CRM-076.spec.ts` — deal participant link/unlink (people & companies) through the deal create/update payload (replace semantics + dedup), verified via deal-detail counts/linked ids.
- Add `TC-CRM-077.spec.ts` — person↔company link → list → unlink, asserting the person itself survives.
- Add `TC-CRM-078.spec.ts` — entity-role assign/unassign on a person and a company (`{roleType, userId}`, DELETE via `?roleId=`), with failure-safe cleanup of all created role rows.
- Add `TC-CRM-079.spec.ts` — bulk update deal stage and owner (async 202 + progress job → drain queue → poll), plus empty-`ids` 400.
- Add `TC-CRM-080.spec.ts` — interaction conflict detection (GET) and idempotent cancellation (status `canceled`, removed from the planned list).
- Add `TC-CRM-081.spec.ts` — RBAC: a view-only user is denied (403) on people POST/PUT/DELETE and deal POST.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — test-coverage only for an existing module; the scenarios are enumerated in issue #2458.

## Testing

- `yarn turbo run typecheck --filter=@open-mercato/core` → pass (core's tsc typechecks the `__integration__` specs).
- Booted app-only dev on an isolated DB and ran the 7 specs against it:
  `BASE_URL=http://localhost:3037 OM_TEST_APP_ROOT=$PWD/apps/mercato OM_INTEGRATION_TEST=1 npx playwright test --config .ai/qa/tests/playwright.config.ts --workers=1 <the 7 specs>` → **7 passed (37.6s)**, no retries.
- All fixtures are created via API and cleaned up in `finally`; specs are self-contained and data-independent.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- N/A — test-only; none required -->
- [x] I added or adjusted tests that cover the change. <!-- this PR is the tests -->
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- executable specs live in the module `__integration__/` folder per .ai/qa/AGENTS.md; `.ai/qa/tests/` is config-only -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — no module spec change -->

### Design System Compliance
- [x] No hardcoded status colors — <!-- N/A — no UI -->
- [x] No arbitrary text sizes — <!-- N/A — no UI -->
- [x] Empty state handled for list/data pages — <!-- N/A — no UI -->
- [x] Loading state handled for async pages — <!-- N/A — no UI -->
- [x] `aria-label` on all icon-only buttons — <!-- N/A — no UI -->
- [x] Uses existing DS components — <!-- N/A — no UI -->

## Linked issues

Fixes #2458