### PR TITLE
feat: crudform tests feature toggles

### DIFF
--- a/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
@@ -40,7 +40,7 @@ delete in `finally`. All gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISAB
 | Order | Module | Package | Surfaces | Branch | PR | Status |
 |-------|--------|---------|----------|--------|----|--------|
 | C1 | directory | core | organization, tenant | — | — | ⏭️ covered by #2539 (TC-DIR-006..012) |
-| C2 | feature_toggles | core | global toggle (superadmin) | `feat/crudform-tests-feature-toggles` | — | ⬜ |
+| C2 | feature_toggles | core | global toggle (superadmin) · scalars + typed defaultValue (boolean/string/number/json) | `feat/crudform-tests-feature-toggles` | — | 🔵 PR pending (#2567 · TC-FT-CRUDFORM-001) |
 | C3 | api_keys | core | api-key | `feat/crudform-tests-api-keys` | — | ⬜ |
 | C4 | dictionaries | core | dictionary entry | `feat/crudform-tests-dictionaries` | — | ⬜ |
 | C5 | communication_channels | core | channel | `feat/crudform-tests-comm-channels` | — | ⬜ |

--- a/packages/core/src/modules/feature_toggles/__integration__/TC-FT-CRUDFORM-001.spec.ts
+++ b/packages/core/src/modules/feature_toggles/__integration__/TC-FT-CRUDFORM-001.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  runCrudFormRoundTrip,
+  skipIfCrudFormExtensionTestsDisabled,
+  type CrudRecord,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+
+/**
+ * TC-FT-CRUDFORM-001: Global feature toggle CrudForm persists scalars + typed default value (#2466).
+ *
+ * The single feature_toggles CrudForm surface is the global toggle (Tier C — scalar surface,
+ * no custom fields). Its persistence risk lives in the `type` + `defaultValue` pair: the value
+ * is `jsonb`, so its shape depends on `type` (boolean / string / number / json), and a partial
+ * edit must not drop either field — exactly the regression fixed in #2524/#2528 ("hydrate
+ * global edit form Type/Default Value"). This spec proves create + update round-trip every
+ * scalar for all four toggle types. It complements TC-FT-004 (type-hydration for a single
+ * `number` toggle) by sweeping all four types and additionally proving the falsy defaults
+ * (`false`/`0`) and nested json values survive the update command's `?? existing` merge.
+ *
+ * Verified contract:
+ * - Writing a global toggle requires the **super administrator** (`feature_toggles.global.manage`,
+ *   enforced by `assertGlobalToggleSuperAdmin`), so this authenticates as `superadmin`, not `admin`.
+ * - `/api/feature_toggles/global` is a `makeCrudRoute` collection route: POST → 201, PUT → 200
+ *   (id in body), DELETE → 200 (`?id=`). The harness defaults match, so no status overrides.
+ * - Read-back uses the detail GET `/api/feature_toggles/global/[id]` — the same endpoint the edit
+ *   page loads to hydrate the form (#2524). The toggle is platform-wide (no tenant_id), and the
+ *   detail route returns the record directly; the harness resolves that direct-record shape.
+ * - Request bodies are camelCase; `defaultValue` round-trips verbatim through jsonb (incl. the
+ *   falsy values `false`/`0` and nested object/array values).
+ * - The update payload intentionally omits `identifier` and `type` so a partial save proves both
+ *   survive (the #2524 regression), while name/description/category/defaultValue change.
+ *
+ * Gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
+ */
+const GLOBAL_PATH = '/api/feature_toggles/global';
+
+type ToggleType = 'boolean' | 'string' | 'number' | 'json';
+
+type TypedToggleCase = {
+  type: ToggleType;
+  title: string;
+  createValue: unknown;
+  updateValue: unknown;
+};
+
+// feature_toggles.identifier is globally unique (no tenant scoping on the column), so use crypto
+// randomness to stay collision-free across parallel Playwright workers and avoid the CodeQL
+// insecure-randomness flag on Math.random(). The pattern `^[a-z][a-z0-9_.-]*$` is satisfied by the
+// leading `qa_ft_crudform_` prefix plus the hex UUID body.
+function uniqueIdentifier(kind: ToggleType): string {
+  return `qa_ft_crudform_${kind}_${randomUUID().replace(/-/g, '')}`;
+}
+
+async function readToggleById(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<CrudRecord | null> {
+  const response = await apiRequest(request, 'GET', `${GLOBAL_PATH}/${encodeURIComponent(id)}`, { token });
+  if (response.status() === 404) return null;
+  expect(response.status(), `read-back feature toggle failed: ${response.status()}`).toBe(200);
+  const body = await readJsonSafe<CrudRecord>(response);
+  return body && body.id === id ? body : null;
+}
+
+const TYPED_CASES: TypedToggleCase[] = [
+  // Boolean true → false proves the falsy default survives the update command's `?? existing` merge.
+  { type: 'boolean', title: 'boolean toggle round-trips scalars + boolean default (true → false)', createValue: true, updateValue: false },
+  { type: 'string', title: 'string toggle round-trips scalars + string default', createValue: 'flag-original', updateValue: 'flag-edited' },
+  // Number 42 → 0 proves the falsy numeric default survives the update as well.
+  { type: 'number', title: 'number toggle round-trips scalars + numeric default (42 → 0)', createValue: 42, updateValue: 0 },
+  {
+    type: 'json',
+    title: 'json toggle round-trips scalars + nested object/array default',
+    createValue: { enabled: true, threshold: 10, tiers: ['alpha', 'beta'] },
+    updateValue: { enabled: false, threshold: 99, tiers: ['gamma'] },
+  },
+];
+
+test.describe('TC-FT-CRUDFORM-001: Global feature toggle CrudForm persists scalars + typed default value', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  for (const toggleCase of TYPED_CASES) {
+    test(toggleCase.title, async ({ request }) => {
+      const token = await getAuthToken(request, 'superadmin');
+      const stamp = Date.now();
+      const identifier = uniqueIdentifier(toggleCase.type);
+      const baseName = `QA CRUDFORM Toggle ${toggleCase.type} ${stamp}`;
+
+      await runCrudFormRoundTrip({
+        request,
+        token,
+        collectionPath: GLOBAL_PATH,
+        readById: (id) => readToggleById(request, token, id),
+        create: {
+          payload: {
+            identifier,
+            name: baseName,
+            description: 'Original toggle description',
+            category: 'qa-crudform',
+            type: toggleCase.type,
+            defaultValue: toggleCase.createValue,
+          },
+        },
+        expectAfterCreate: {
+          scalars: {
+            identifier,
+            name: baseName,
+            description: 'Original toggle description',
+            category: 'qa-crudform',
+            type: toggleCase.type,
+            defaultValue: toggleCase.createValue,
+          },
+        },
+        update: {
+          // Partial save: omit identifier + type so the round-trip proves both survive (#2524).
+          payload: (id) => ({
+            id,
+            name: `${baseName} EDITED`,
+            description: 'Updated toggle description',
+            category: 'qa-crudform-edited',
+            defaultValue: toggleCase.updateValue,
+          }),
+        },
+        expectAfterUpdate: {
+          scalars: {
+            identifier,
+            name: `${baseName} EDITED`,
+            description: 'Updated toggle description',
+            category: 'qa-crudform-edited',
+            type: toggleCase.type,
+            defaultValue: toggleCase.updateValue,
+          },
+        },
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds Playwright integration coverage proving the `feature_toggles` **global-toggle** CrudForm
surface persists every field — scalars (identifier, name, description, category, type) and the
typed `defaultValue` (boolean / string / number / json) — on both **create and update**. This
closes the Tier C `feature_toggles` row of the #2466 CrudForm field-persistence sweep
(siblings: resources #2551, staff #2553; foundation #2548). Test-only; no product code changes.

## Changes

- Add `packages/core/src/modules/feature_toggles/__integration__/TC-FT-CRUDFORM-001.spec.ts` —
  four data-driven round-trips (boolean/string/number/json) via the shared `runCrudFormRoundTrip`
  harness. Authenticates as `superadmin` (global writes require `feature_toggles.global.manage`);
  reads back through the detail GET `/api/feature_toggles/global/[id]` (the edit form's loader);
  the update omits `identifier`+`type` to prove partial-save retention (#2524) and flips
  `defaultValue` to falsy (`false`/`0`) / a different nested json to prove the update command's
  `?? existing` merge and jsonb-verbatim round-trip. Self-contained (toggle deleted in `finally`);
  gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED`.
- Update `.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md` — flip the C2
  `feature_toggles` row to 🔵 (branch + spec id).

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — governed by umbrella issue #2466; program ledger at
`.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md` (row C2, updated here).

## Testing

- `yarn turbo run typecheck --filter=@open-mercato/core` → pass (compiles the new `__integration__` spec).
- Behavioral: dev:app on an isolated, freshly-`mercato init`-seeded DB, then
  `BASE_URL=http://localhost:3020 OM_INTEGRATION_MODULES=feature_toggles npx playwright test --config .ai/qa/tests/playwright.config.ts CRUDFORM`
  → **4 passed** (boolean/string/number/json).
- Non-vacuity probe: temporarily broke one `expectAfterUpdate` value → harness assertion failed for
  the right reason (`after-update.description should persist`) → reverted → 4 green again.
- `yarn i18n:check-sync` → pass (all 4 locales in sync; no i18n changes).
- `yarn test` (jest) / `yarn build:app` → N/A: Playwright `__integration__` spec + markdown only;
  jest excludes `__integration__` and neither is part of the app/package build (no runtime code changed).

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm — legal attestation, not auto-checkable -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- updated the #2466 MODULE-LEDGER; no locales/generators needed -->
- [x] I added or adjusted tests that cover the change. <!-- the change IS the test -->
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- spec lives in the module `__integration__/` folder per AGENTS.md; `.ai/qa/tests/` is config-only -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — governed by #2466 umbrella; MODULE-LEDGER row updated -->

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens <!-- N/A — backend/test-only, no UI -->
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` <!-- N/A — no UI -->
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) <!-- N/A — no UI -->
- [x] Loading state handled for async pages <!-- N/A — no UI -->
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) <!-- N/A — no UI -->
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements <!-- N/A — no UI -->

## Linked issues

Fixes #2567