### PR TITLE
feat: crudform tests scheduler

### DIFF
--- a/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
@@ -32,7 +32,7 @@ delete in `finally`. All gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISAB
 | B3 | customer_accounts | core | customer-role (+portal perms), customer-user | `feat/crudform-tests-customer-accounts` | — | ⬜ |
 | B4 | planner | core | availability-ruleset | `feat/crudform-tests-planner` | — | ⬜ |
 | B5 | webhooks | webhooks | webhook (events multiselect + headers JSON) | `feat/crudform-tests-webhooks` | — | ⬜ |
-| B6 | scheduler | scheduler | scheduled-job (scope/target/payload JSON) | `feat/crudform-tests-scheduler` | — | ⬜ |
+| B6 | scheduler | scheduler | scheduled-job (scope/target/payload JSON) — TC-SCHED-CRUDFORM-001 | feat/crudform-tests-scheduler | — | 🔵 PR open (targets develop; #2548/#2551/#2553 merged) |
 | B7 | checkout | checkout | link-template, pay-link | `feat/crudform-tests-checkout` | — | ⬜ |
 
 ## Tier C — remaining makeCrud / scalar surfaces

--- a/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-CRUDFORM-001.spec.ts
+++ b/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-CRUDFORM-001.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  runCrudFormRoundTrip,
+  skipIfCrudFormExtensionTestsDisabled,
+  type CrudRecord,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+
+/**
+ * TC-SCHED-CRUDFORM-001: Scheduled Job CrudForm persists scope, target + payload JSON (#2466).
+ *
+ * The scheduler's scheduled-job is the Tier-B "JSON-bearing scalar" surface: scope
+ * (scopeType, server-derived org/tenant), schedule (scheduleType/scheduleValue/timezone),
+ * target (targetType/targetQueue), and a nested `targetPayload` JSON object. Proves create +
+ * update round-trip every value.
+ *
+ * Verified contract (differs from the makeCrud-default reference specs):
+ * - The list GET filters by `?id=` (single uuid), not the `?ids=` other sweep modules use; the
+ *   explicit `readById` documents that contract and mirrors the sibling specs (the shared
+ *   harness default reads back via `?id=` too).
+ * - Read-back is camelCase: the list `transformItem` maps every column to camelCase
+ *   (`scopeType`, `scheduleType`, `targetPayload`, `isEnabled`, ...), so the scalar
+ *   expectations use camelCase keys (not the snake_case of resources/staff).
+ * - The scheduled-job declares no custom entity (no `ce.ts`), so there are no `cf_*` fields —
+ *   the surface is scalars + nested JSON only.
+ * - Scope is derived server-side from the caller's auth context and is immutable on update:
+ *   `scopeType: 'organization'` fills org+tenant from the admin token and survives the edit.
+ * - Update is a partial PUT: omitted target fields are retained, so the update changes the
+ *   payload JSON while proving `targetType`/`targetQueue` survive untouched.
+ * - Harness cleanup deletes via `?id=`; the scheduler delete resolves the id from the query
+ *   string, so the default `finally` cleanup removes the fixture.
+ *
+ * Self-contained: the job needs no pre-created fixtures (queue target + inline JSON), and the
+ * harness deletes it in `finally`.
+ *
+ * Gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
+ */
+const SCHEDULER_JOBS_PATH = '/api/scheduler/jobs';
+
+async function readScheduledJobById(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<CrudRecord | null> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${SCHEDULER_JOBS_PATH}?id=${encodeURIComponent(id)}&page=1&pageSize=100`,
+    { token },
+  );
+  expect(response.status(), `read-back scheduler jobs failed: ${response.status()}`).toBe(200);
+  const body = await readJsonSafe<{ items?: CrudRecord[] }>(response);
+  return (body?.items ?? []).find((item) => item.id === id) ?? null;
+}
+
+test.describe('TC-SCHED-CRUDFORM-001: Scheduled Job CrudForm persists scope, target + payload JSON', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  test('round-trips scalars, scope, target + nested payload JSON on create and update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = Date.now();
+
+    const createPayload = {
+      source: 'integration-test',
+      attempts: 3,
+      retries: { max: 5, backoff: 'exponential' },
+      tags: ['alpha', 'beta'],
+    };
+    const updatePayload = {
+      source: 'integration-test-edited',
+      attempts: 1,
+      retries: { max: 0, backoff: 'fixed' },
+      tags: ['gamma'],
+    };
+
+    await runCrudFormRoundTrip({
+      request,
+      token,
+      collectionPath: SCHEDULER_JOBS_PATH,
+      readById: (id) => readScheduledJobById(request, token, id),
+      create: {
+        payload: {
+          name: `QA CRUDFORM Scheduled Job ${stamp}`,
+          description: 'Original scheduled job description',
+          scopeType: 'organization',
+          scheduleType: 'interval',
+          scheduleValue: '15m',
+          timezone: 'UTC',
+          targetType: 'queue',
+          targetQueue: 'scheduler-execution',
+          targetPayload: createPayload,
+          isEnabled: true,
+          sourceType: 'user',
+        },
+      },
+      expectAfterCreate: {
+        scalars: {
+          name: `QA CRUDFORM Scheduled Job ${stamp}`,
+          description: 'Original scheduled job description',
+          scopeType: 'organization',
+          scheduleType: 'interval',
+          scheduleValue: '15m',
+          timezone: 'UTC',
+          targetType: 'queue',
+          targetQueue: 'scheduler-execution',
+          targetCommand: null,
+          targetPayload: createPayload,
+          isEnabled: true,
+          sourceType: 'user',
+        },
+      },
+      update: {
+        payload: (id) => ({
+          id,
+          name: `QA CRUDFORM Scheduled Job ${stamp} EDITED`,
+          description: 'Updated scheduled job description',
+          scheduleType: 'cron',
+          scheduleValue: '0 0 * * *',
+          timezone: 'Europe/Warsaw',
+          targetPayload: updatePayload,
+          isEnabled: false,
+        }),
+      },
+      expectAfterUpdate: {
+        scalars: {
+          name: `QA CRUDFORM Scheduled Job ${stamp} EDITED`,
+          description: 'Updated scheduled job description',
+          scopeType: 'organization',
+          scheduleType: 'cron',
+          scheduleValue: '0 0 * * *',
+          timezone: 'Europe/Warsaw',
+          targetType: 'queue',
+          targetQueue: 'scheduler-execution',
+          targetCommand: null,
+          targetPayload: updatePayload,
+          isEnabled: false,
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Playwright integration coverage proving the scheduler `scheduled-job` CrudForm surface persists **every** field — scalars, scope, target, and nested `targetPayload` JSON — on both create and update. Part of the CrudForm field-persistence QA sweep (umbrella #2466; foundation #2548; mirrors merged resources #2551 and staff #2553).

## Changes

- Add `packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-CRUDFORM-001.spec.ts` — a self-contained create → read-back → assert-all → update → read-back → assert → delete (`finally`) round-trip on `/api/scheduler/jobs`, via the shared `runCrudFormRoundTrip` harness, gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
- Update `.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md` row B6 (scheduler) → 🔵 PR open.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
Test-only coverage governed by umbrella #2466 and the program ledger `.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md` (row B6) — no `.ai/specs/` spec applies.

## Testing

Run from `feat/crudform-tests-scheduler` (based on current `develop`):

- `yarn turbo run typecheck --filter=@open-mercato/scheduler` → pass (typechecks the new `__integration__` spec).
- `yarn turbo run test --filter=@open-mercato/scheduler` → 14 suites / 321 tests pass (jest matches only `__tests__/**`; ignores the Playwright spec).
- Behavioral run against a fresh prod-built ephemeral env (`yarn mercato test:ephemeral`):
  `BASE_URL=http://127.0.0.1:5001 OM_INTEGRATION_MODULES=scheduler npx playwright test --config .ai/qa/tests/playwright.config.ts -g "TC-SCHED-CRUDFORM-001"` → 1 passed (248ms).
- DB self-containment check on the ephemeral Postgres: fixture is soft-deleted with 0 active (`deleted_at is null`) leaks; the soft-deleted row confirms the update persisted (`…EDITED`, `scope_type=organization`, `schedule_type=cron`).
- `build:app` proven by the ephemeral prod build (completed; app served requests).

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm: legal attestation, not auto-tickable on your behalf -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- N/A — test-only; none required -->
- [x] I added or adjusted tests that cover the change. <!-- the change is the test -->
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- executable specs now live in module-local __integration__/ per current convention; .ai/qa/tests/ holds only the shared Playwright config -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — no .ai/specs/ spec; updated program ledger MODULE-LEDGER.md row B6 -->

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens <!-- N/A — no UI -->
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` <!-- N/A — no UI -->
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) <!-- N/A — no UI -->
- [x] Loading state handled for async pages <!-- N/A — no UI -->
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) <!-- N/A — no UI -->
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements <!-- N/A — no UI -->

## Linked issues

Fixes #2565