### PR TITLE
feat: crudform tests planner

### DIFF
--- a/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
@@ -30,7 +30,7 @@ delete in `finally`. All gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISAB
 | B1 | business_rules | core | rule, rule-set (+members[]) | `feat/crudform-tests-business-rules` | — | ⬜ |
 | B2 | integrations | core | credentials (secret/text/select round-trip) | `feat/crudform-tests-integrations` | — | ⬜ |
 | B3 | customer_accounts | core | customer-role (+portal perms), customer-user | `feat/crudform-tests-customer-accounts` | — | ⬜ |
-| B4 | planner | core | availability-ruleset | `feat/crudform-tests-planner` | — | ⬜ |
+| B4 | planner | core | availability-ruleset (scalars: name/description/timezone — no CF/dict/multiselect declared) | `feat/crudform-tests-planner` | — | 🔵 spec written (TC-PLAN-CRUDFORM-001); PR pending |
 | B5 | webhooks | webhooks | webhook (events multiselect + headers JSON) | `feat/crudform-tests-webhooks` | — | ⬜ |
 | B6 | scheduler | scheduler | scheduled-job (scope/target/payload JSON) | `feat/crudform-tests-scheduler` | — | ⬜ |
 | B7 | checkout | checkout | link-template, pay-link | `feat/crudform-tests-checkout` | — | ⬜ |

--- a/packages/core/src/modules/planner/__integration__/TC-PLAN-CRUDFORM-001.spec.ts
+++ b/packages/core/src/modules/planner/__integration__/TC-PLAN-CRUDFORM-001.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  runCrudFormRoundTrip,
+  skipIfCrudFormExtensionTestsDisabled,
+  type CrudRecord,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+
+/**
+ * TC-PLAN-CRUDFORM-001: Availability rule-set CrudForm persists every field (#2466).
+ *
+ * Planner's availability rule-set is a Tier B surface (MODULE-LEDGER B4): the create/edit pages
+ * build the save payload by hand (`buildAvailabilityRuleSetPayload`) on top of a makeCrud route,
+ * so this spec proves that hand-written save path + the route round-trip every field the form
+ * exposes — on both create and update.
+ *
+ * The rule-set surface is scalar-only: `name`, `description`, `timezone`. The planner module
+ * declares no custom fields (`ce.ts` is empty and nothing defines `cf.*` for the entity) and the
+ * `PlannerAvailabilityRuleSet` entity has no dictionary references or multiselect/array columns.
+ * So — per the sweep's "where applicable" rule — this mirrors the pure-scalar currencies
+ * reference (TC-CUR-CRUDFORM-001). The route still wires custom-field decoration, but there are
+ * none declared to assert.
+ *
+ * Verified contract:
+ * - Create returns 201 `{ id }` (mapped from the command's `ruleSetId`); update returns 200 `{ ok }`.
+ * - The list GET filters by `?ids=` (comma-separated), NOT `?id=` — so a custom `readById`.
+ * - Request bodies are camelCase; the list response exposes `name`/`description`/`timezone`.
+ * - Scope (`organizationId`/`tenantId`) is taken from the caller's token.
+ * - Self-contained: the only record created is the rule-set itself, deleted by the harness in `finally`.
+ *
+ * Gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
+ */
+const RULE_SETS_PATH = '/api/planner/availability-rule-sets';
+
+async function readRuleSetByIds(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<CrudRecord | null> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${RULE_SETS_PATH}?ids=${encodeURIComponent(id)}&page=1&pageSize=100`,
+    { token },
+  );
+  expect(response.status(), `read-back availability rule-sets failed: ${response.status()}`).toBe(200);
+  const body = await readJsonSafe<{ items?: CrudRecord[] }>(response);
+  return (body?.items ?? []).find((item) => item.id === id) ?? null;
+}
+
+test.describe('TC-PLAN-CRUDFORM-001: Availability rule-set CrudForm persists every field', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  test('round-trips name, description, timezone scalars on create and update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const { organizationId, tenantId } = getTokenContext(token);
+    const stamp = Date.now();
+
+    await runCrudFormRoundTrip({
+      request,
+      token,
+      collectionPath: RULE_SETS_PATH,
+      readById: (id) => readRuleSetByIds(request, token, id),
+      create: {
+        payload: {
+          organizationId,
+          tenantId,
+          name: `QA CRUDFORM Schedule ${stamp}`,
+          description: 'Original schedule description',
+          timezone: 'America/New_York',
+        },
+      },
+      expectAfterCreate: {
+        scalars: {
+          name: `QA CRUDFORM Schedule ${stamp}`,
+          description: 'Original schedule description',
+          timezone: 'America/New_York',
+        },
+      },
+      update: {
+        payload: (id) => ({
+          id,
+          name: `QA CRUDFORM Schedule ${stamp} EDITED`,
+          description: 'Updated schedule description',
+          timezone: 'Europe/Warsaw',
+        }),
+      },
+      expectAfterUpdate: {
+        scalars: {
+          name: `QA CRUDFORM Schedule ${stamp} EDITED`,
+          description: 'Updated schedule description',
+          timezone: 'Europe/Warsaw',
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add Playwright integration coverage proving the planner `availability-rule-sets` CrudForm
surface persists every applicable field on both create and update. Part of the CrudForm
field-persistence sweep (umbrella #2466, foundation #2548), ledger row B4 (Tier B —
hand-written save). The rule-set is a scalar-only surface, so this mirrors the merged
currencies reference (TC-CUR-CRUDFORM-001).

## Changes

- Add `packages/core/src/modules/planner/__integration__/TC-PLAN-CRUDFORM-001.spec.ts`:
  create → read-back (`?ids=`) → assert name/description/timezone → update → read-back →
  assert → delete in `finally`, via the shared `runCrudFormRoundTrip` harness, gated by
  `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED`.
- Update `.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md` row B4 to
  `🔵 spec written (TC-PLAN-CRUDFORM-001)` and annotate the surface as scalar-only
  (no CF/dict/multiselect declared).

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — governed by umbrella issue #2466 + foundation #2548; sweep tracked in
`.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md` (row B4 updated).

## Testing

List the tests or commands you ran to validate the change.

- `yarn turbo run typecheck --filter=@open-mercato/core` → exit 0 (typechecks the `__integration__` spec).
- `yarn test:integration:ephemeral TC-PLAN-CRUDFORM-001` → **1 passed (37.0s)**; full fresh
  prod build + seeded ephemeral app, spec green (create+update round-trip all assertions, record
  deleted in `finally`).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (MODULE-LEDGER row updated; no locales/generators needed — test-only.)
- [x] I added or adjusted tests that cover the change. (This change *is* the test.)
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Per current convention, executable specs live in module-local `__integration__/`; `.ai/qa/tests/` retains only the shared Playwright config.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — sweep tracked via MODULE-LEDGER.md, row B4 updated.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI (integration test only)
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2563