### PR TITLE
feat: crudform tests sales

### DIFF
--- a/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
@@ -20,7 +20,7 @@ delete in `finally`. All gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISAB
 | A4 | customers | core | person/company/deal (inline + CF + dictionary) | `feat/crudform-tests-customers` | — | ⬜ |
 | A5 | currencies | core | currency (scalars), exchange-rate | feat/crudform-integration-tests | #2548 | 🔵 currency covered in foundation PR #2548 |
 | A6 | auth | core | user (roles[] + CF + ACL), role (CF + ACL) | `feat/crudform-tests-auth` | — | ⬜ |
-| A7 | sales | core | channel (CF), channel-offer | `feat/crudform-tests-sales` | — | ⬜ |
+| A7 | sales | core | channel (CF + multi-select), channel-offer | feat/crudform-tests-sales | #2558 | 🔵 specs written; PR pending |
 | A8 | workflows | core | definition (metadata.* dot-path — see #2503) | `feat/crudform-tests-workflows` | — | ⬜ |
 
 ## Tier B — hand-written / non-makeCrud saves

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-CRUDFORM-001.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-CRUDFORM-001.spec.ts
@@ -1,0 +1,231 @@
+import { randomUUID } from 'node:crypto';
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  runCrudFormRoundTrip,
+  skipIfCrudFormExtensionTestsDisabled,
+  type CrudRecord,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+
+/**
+ * TC-SALES-CRUDFORM-001: Sales Channel CrudForm persists scalars + custom fields (#2466).
+ *
+ * Sales channels are the sales-module rich-field surface: scalars (name, code, description,
+ * isActive, websiteUrl, contactEmail, address fields) plus custom fields of several kinds
+ * (text, integer, boolean, single-select) and a multi-select array. Proves create + update
+ * round-trip every value.
+ *
+ * Notes from the verified API contract:
+ * - The list GET filters by `?ids=` (comma-separated), so a custom `readById`.
+ * - Request bodies are camelCase; the channel list response returns scalars camelCase (`isActive`,
+ *   `websiteUrl`, ...) and custom fields under `customValues` (a bare-key object) plus a
+ *   `customFields` definition array — both already handled by the harness `getCustomFieldValue`.
+ * - `channelUpdateSchema` requires `id` AND `code`; PUT is a partial update so omitted scalars
+ *   and omitted custom fields are retained.
+ * - Custom fields submit as `cf_<key>`. Sales channels declare no default custom fields, so the
+ *   spec creates its own definitions via the entities API and tombstones them in `finally`
+ *   (self-contained). Keys are stamped per run so retries/parallel workers never collide.
+ * - The native `statusEntryId` dictionary reference is intentionally omitted: it requires a
+ *   dictionary-entry fixture with no self-contained helper (mirrors the resources spec deferring
+ *   `capacityUnitValue`). The dictionary/multiselect dimension is covered by the multi-select CF.
+ *
+ * Gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
+ */
+const CHANNELS_PATH = '/api/sales/channels';
+const DEFINITIONS_PATH = '/api/entities/definitions';
+const CHANNEL_ENTITY_ID = 'sales:sales_channel';
+
+type ChannelCustomFieldDefinition = {
+  key: string;
+  kind: string;
+  label: string;
+  multi?: boolean;
+  options?: string[];
+};
+
+async function createChannelCustomFieldDefinition(
+  request: APIRequestContext,
+  token: string,
+  input: ChannelCustomFieldDefinition,
+): Promise<void> {
+  const configJson: CrudRecord = { label: input.label };
+  if (input.multi !== undefined) configJson.multi = input.multi;
+  if (input.options) configJson.options = input.options;
+  const response = await apiRequest(request, 'POST', DEFINITIONS_PATH, {
+    token,
+    data: { entityId: CHANNEL_ENTITY_ID, key: input.key, kind: input.kind, configJson },
+  });
+  expect(
+    response.status(),
+    `POST ${DEFINITIONS_PATH} should create channel custom field "${input.key}"`,
+  ).toBe(200);
+}
+
+async function deleteChannelCustomFieldDefinition(
+  request: APIRequestContext,
+  token: string | null,
+  key: string,
+): Promise<void> {
+  if (!token) return;
+  const response = await apiRequest(request, 'DELETE', DEFINITIONS_PATH, {
+    token,
+    data: { entityId: CHANNEL_ENTITY_ID, key },
+  });
+  expect([200, 404]).toContain(response.status());
+}
+
+// Custom-field multi-select rows have no guaranteed read order, so normalize array values to a
+// stable sort before the harness compares them (the catalog CF multi-select spec does the same).
+// The channel list response exposes custom fields under `customValues` (a bare-key object), which
+// `getCustomFieldValue` reads first, so sort the array values held there.
+function normalizeArrayCustomFields(record: CrudRecord | null): CrudRecord | null {
+  if (!record) return record;
+  const customValues = record.customValues;
+  if (customValues && typeof customValues === 'object' && !Array.isArray(customValues)) {
+    for (const [key, value] of Object.entries(customValues as CrudRecord)) {
+      if (Array.isArray(value)) {
+        (customValues as CrudRecord)[key] = [...value].map((entry) => String(entry)).sort();
+      }
+    }
+  }
+  return record;
+}
+
+async function readChannelByIds(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<CrudRecord | null> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${CHANNELS_PATH}?ids=${encodeURIComponent(id)}&page=1&pageSize=100`,
+    { token },
+  );
+  expect(response.status(), `read-back sales channels failed: ${response.status()}`).toBe(200);
+  const body = await readJsonSafe<{ items?: CrudRecord[] }>(response);
+  const record = (body?.items ?? []).find((item) => item.id === id) ?? null;
+  return normalizeArrayCustomFields(record);
+}
+
+test.describe('TC-SALES-CRUDFORM-001: Sales Channel CrudForm persists scalars + custom fields', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  test('round-trips scalars + custom fields (text/integer/boolean/select) and a multi-select on create and update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = `${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 8)}`;
+    const tierKey = `tier_${stamp}`;
+    const priorityKey = `priority_${stamp}`;
+    const memoKey = `memo_${stamp}`;
+    const featuredKey = `featured_${stamp}`;
+    const regionsKey = `regions_${stamp}`;
+    const definitionKeys = [tierKey, priorityKey, memoKey, featuredKey, regionsKey];
+
+    try {
+      await createChannelCustomFieldDefinition(request, token, {
+        key: tierKey,
+        kind: 'select',
+        label: 'Channel Tier',
+        options: ['bronze', 'silver', 'gold'],
+      });
+      await createChannelCustomFieldDefinition(request, token, { key: priorityKey, kind: 'integer', label: 'Channel Priority' });
+      await createChannelCustomFieldDefinition(request, token, { key: memoKey, kind: 'text', label: 'Channel Memo' });
+      await createChannelCustomFieldDefinition(request, token, { key: featuredKey, kind: 'boolean', label: 'Channel Featured' });
+      await createChannelCustomFieldDefinition(request, token, {
+        key: regionsKey,
+        kind: 'select',
+        label: 'Channel Regions',
+        multi: true,
+        options: ['emea', 'amer', 'apac'],
+      });
+
+      await runCrudFormRoundTrip({
+        request,
+        token,
+        collectionPath: CHANNELS_PATH,
+        readById: (id) => readChannelByIds(request, token, id),
+        create: {
+          payload: {
+            name: `QA CRUDFORM Channel ${stamp}`,
+            code: `qa-crudform-${stamp}`,
+            description: 'Original channel description',
+            isActive: true,
+            websiteUrl: 'https://qa-crudform.example.com',
+            contactEmail: 'qa-crudform@example.com',
+            city: 'Warsaw',
+            region: 'Mazovia',
+            postalCode: '00-001',
+            country: 'PL',
+            [`cf_${tierKey}`]: 'gold',
+            [`cf_${priorityKey}`]: 3,
+            [`cf_${memoKey}`]: 'Original channel memo',
+            [`cf_${featuredKey}`]: true,
+            [`cf_${regionsKey}`]: ['emea', 'apac'],
+          },
+        },
+        expectAfterCreate: {
+          scalars: {
+            name: `QA CRUDFORM Channel ${stamp}`,
+            code: `qa-crudform-${stamp}`,
+            description: 'Original channel description',
+            isActive: true,
+            websiteUrl: 'https://qa-crudform.example.com',
+            contactEmail: 'qa-crudform@example.com',
+            city: 'Warsaw',
+            region: 'Mazovia',
+            postalCode: '00-001',
+            country: 'PL',
+          },
+          customFields: {
+            [tierKey]: 'gold',
+            [priorityKey]: 3,
+            [memoKey]: 'Original channel memo',
+            [featuredKey]: true,
+            [regionsKey]: ['apac', 'emea'],
+          },
+        },
+        update: {
+          payload: (id) => ({
+            id,
+            code: `qa-crudform-${stamp}`,
+            name: `QA CRUDFORM Channel ${stamp} EDITED`,
+            description: 'Updated channel description',
+            isActive: false,
+            websiteUrl: 'https://qa-crudform-edited.example.com',
+            city: 'Krakow',
+            [`cf_${tierKey}`]: 'silver',
+            [`cf_${priorityKey}`]: 7,
+            [`cf_${featuredKey}`]: false,
+            [`cf_${regionsKey}`]: ['amer', 'emea'],
+          }),
+        },
+        expectAfterUpdate: {
+          scalars: {
+            name: `QA CRUDFORM Channel ${stamp} EDITED`,
+            code: `qa-crudform-${stamp}`,
+            description: 'Updated channel description',
+            isActive: false,
+            websiteUrl: 'https://qa-crudform-edited.example.com',
+            city: 'Krakow',
+            region: 'Mazovia',
+            country: 'PL',
+          },
+          customFields: {
+            [tierKey]: 'silver',
+            [priorityKey]: 7,
+            [featuredKey]: false,
+            [regionsKey]: ['amer', 'emea'],
+            [memoKey]: 'Original channel memo',
+          },
+        },
+      });
+    } finally {
+      for (const key of definitionKeys) {
+        await deleteChannelCustomFieldDefinition(request, token, key);
+      }
+    }
+  });
+});

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-CRUDFORM-002.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-CRUDFORM-002.spec.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from 'node:crypto';
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { createProductFixture, deleteCatalogProductIfExists } from '@open-mercato/core/helpers/integration/catalogFixtures';
+import { expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  runCrudFormRoundTrip,
+  skipIfCrudFormExtensionTestsDisabled,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+
+/**
+ * TC-SALES-CRUDFORM-002: Channel-offer CrudForm persists scalars (#2466).
+ *
+ * An offer links a catalog product to a sales channel (the "channel-offer" surface), served by
+ * the catalog offers route but gated by `sales.channels.manage`. Proves create + update
+ * round-trip every scalar — including the `channelId` / `productId` foreign keys retained across
+ * a partial update and a JSON `metadata` blob.
+ *
+ * Verified contract:
+ * - Route `/api/catalog/offers`: POST 201 `{ id }`, PUT/DELETE 200 `{ ok: true }`, list `?id=`.
+ * - Request bodies camelCase; responses camelCase (`channelId`, `productId`, `isActive`, ...).
+ * - Create requires `channelId`, `productId`, `title`; PUT is partial so omitted FKs are retained.
+ * - Self-contained: creates its own channel + product, deletes them in `finally`; the offer is
+ *   deleted by the harness round-trip.
+ * - The offer has no default custom fields, so this surface covers scalars + FK + JSON metadata.
+ *
+ * Gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
+ */
+const OFFERS_PATH = '/api/catalog/offers';
+const CHANNELS_PATH = '/api/sales/channels';
+
+async function createChannelFixture(
+  request: APIRequestContext,
+  token: string,
+  stamp: string,
+): Promise<string> {
+  const response = await apiRequest(request, 'POST', CHANNELS_PATH, {
+    token,
+    data: { name: `QA CRUDFORM Offer Channel ${stamp}`, code: `qa-offer-${stamp}` },
+  });
+  expect(response.status(), 'channel fixture create should be 201').toBe(201);
+  return expectId((await readJsonSafe<{ id?: string }>(response))?.id, 'channel fixture should return an id');
+}
+
+async function deleteChannelIfExists(
+  request: APIRequestContext,
+  token: string | null,
+  channelId: string | null,
+): Promise<void> {
+  if (!token || !channelId) return;
+  await apiRequest(request, 'DELETE', `${CHANNELS_PATH}?id=${encodeURIComponent(channelId)}`, { token }).catch(
+    () => undefined,
+  );
+}
+
+test.describe('TC-SALES-CRUDFORM-002: Channel-offer CrudForm persists scalars', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  test('round-trips title, description, isActive, media url, metadata and retains FKs on create and update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = `${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 8)}`;
+    let channelId: string | null = null;
+    let productId: string | null = null;
+
+    try {
+      channelId = await createChannelFixture(request, token, stamp);
+      productId = await createProductFixture(request, token, {
+        title: `QA CRUDFORM Offer Product ${stamp}`,
+        sku: `QA-OFFER-${stamp}`,
+      });
+
+      await runCrudFormRoundTrip({
+        request,
+        token,
+        collectionPath: OFFERS_PATH,
+        create: {
+          payload: {
+            channelId,
+            productId,
+            title: `QA CRUDFORM Offer ${stamp}`,
+            description: 'Original offer description',
+            isActive: true,
+            defaultMediaUrl: 'https://cdn.example.com/qa-offer-original.png',
+            metadata: { source: 'qa-crudform', tier: 1 },
+          },
+        },
+        expectAfterCreate: {
+          scalars: {
+            channelId,
+            productId,
+            title: `QA CRUDFORM Offer ${stamp}`,
+            description: 'Original offer description',
+            isActive: true,
+            defaultMediaUrl: 'https://cdn.example.com/qa-offer-original.png',
+            metadata: { source: 'qa-crudform', tier: 1 },
+          },
+        },
+        update: {
+          payload: (id) => ({
+            id,
+            title: `QA CRUDFORM Offer ${stamp} EDITED`,
+            description: 'Updated offer description',
+            isActive: false,
+            defaultMediaUrl: 'https://cdn.example.com/qa-offer-edited.png',
+            metadata: { source: 'qa-crudform', tier: 2 },
+          }),
+        },
+        expectAfterUpdate: {
+          scalars: {
+            channelId,
+            productId,
+            title: `QA CRUDFORM Offer ${stamp} EDITED`,
+            description: 'Updated offer description',
+            isActive: false,
+            defaultMediaUrl: 'https://cdn.example.com/qa-offer-edited.png',
+            metadata: { source: 'qa-crudform', tier: 2 },
+          },
+        },
+      });
+    } finally {
+      await deleteCatalogProductIfExists(request, token, productId);
+      await deleteChannelIfExists(request, token, channelId);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add Playwright integration coverage proving the `sales` module's CrudForm surfaces persist
**all** field values — scalars, custom fields, and multi-select/array fields — on both create
and update. Part of the CrudForm field-persistence QA sweep (umbrella #2466; foundation #2548;
mirrors resources #2551 and staff #2553). Surfaces covered: **channel** (with custom fields)
and **channel-offer**.

## Changes

- Add `packages/core/src/modules/sales/__integration__/TC-SALES-CRUDFORM-001.spec.ts` — Sales
  Channel CrudForm: scalars (name/code/description/isActive/websiteUrl/contactEmail/address) +
  custom fields (text/integer/boolean/single-select) + a multi-select array, round-tripped on
  create and update. Channel declares no default custom fields, so the spec creates its own
  definitions via `POST /api/entities/definitions` and tombstones them in `finally`
  (self-contained; CF keys stamped per run for retry/parallel safety).
- Add `packages/core/src/modules/sales/__integration__/TC-SALES-CRUDFORM-002.spec.ts` —
  channel-offer CrudForm (`/api/catalog/offers`, gated by `sales.channels.manage`): title,
  description, isActive, default media URL, JSON metadata, and `channelId`/`productId` FK
  retention across a partial update. Creates its own channel + product fixtures, cleaned up in
  `finally`.
- Update `.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md` row A7 (sales).

Both specs reuse the shared sweep harness (`runCrudFormRoundTrip` +
`skipIfCrudFormExtensionTestsDisabled`, gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED`,
default off → runs). No product/harness code changed.

Known, documented coverage note: the channel's native `statusEntryId` dictionary reference is
deferred (no self-contained dictionary-entry fixture helper exists), mirroring the resources spec
deferring `capacityUnitValue`; the dictionary/multi-select dimension is exercised via the
multi-select custom field.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md` (CrudForm sweep program, umbrella #2466; row A7 updated in this PR)

## Testing

- `yarn workspace @open-mercato/core test crudFormFields` → 21 passed (sweep helper unit tests; unchanged)
- `yarn turbo run typecheck --filter=@open-mercato/core` → pass (type-checks the new `__integration__` specs)
- `yarn mercato test:integration TC-SALES-CRUDFORM` → 2 passed (ephemeral env: full prod build + migrations + seed + run)

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). _(author to confirm on submit)_
- [x] I updated documentation, locales, or generators if the change requires it. _(MODULE-LEDGER row A7; no locales/generators affected)_
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). _(module specs live in `packages/core/src/modules/sales/__integration__/`, run by `.ai/qa/tests/playwright.config.ts` — same convention as resources #2551 / staff #2553)_
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). _(N/A — sweep tracked in MODULE-LEDGER, updated)_

### Design System Compliance
- [x] No hardcoded status colors — _N/A, no UI (integration tests only)_
- [x] No arbitrary text sizes — _N/A, no UI_
- [x] Empty state handled for list/data pages — _N/A, no UI_
- [x] Loading state handled for async pages — _N/A, no UI_
- [x] `aria-label` on all icon-only buttons — _N/A, no UI_
- [x] Uses existing DS components — _N/A, no UI_

## Linked issues

Fixes #2558