### PR TITLE
feat: 2555 crudform tests catalog

### DIFF
--- a/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
@@ -16,7 +16,7 @@ delete in `finally`. All gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISAB
 |-------|--------|---------|-------------------|--------|----|--------|
 | A1 | resources | core | resource (CF text/number/select/boolean), resource-type · capacityUnit dict deferred (example-seeded) | feat/crudform-tests-resources | #2551 | 🔵 PR open (stacked on #2548) |
 | A2 | staff | core | team-member (role_ids/tags multiselect + 6-kind CF), team, team-role, timesheet-project | feat/crudform-tests-staff | #2553 | 🔵 PR open (stacked on #2548) |
-| A3 | catalog | core | product (multichoice CF), variant (prices), category | `feat/crudform-tests-catalog` | — | ⬜ |
+| A3 | catalog | core | product (multichoice CF), variant (prices), category | feat/2555-crudform-tests-catalog | — | 🔵 specs ready (TC-CAT-CRUDFORM-001..003, #2555); off develop (#2548 merged); PR pending |
 | A4 | customers | core | person/company/deal (inline + CF + dictionary) | `feat/crudform-tests-customers` | — | ⬜ |
 | A5 | currencies | core | currency (scalars), exchange-rate | feat/crudform-integration-tests | #2548 | 🔵 currency covered in foundation PR #2548 |
 | A6 | auth | core | user (roles[] + CF + ACL), role (CF + ACL) | `feat/crudform-tests-auth` | — | ⬜ |

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-CRUDFORM-001.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-CRUDFORM-001.spec.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from 'node:crypto';
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  assertScalarFieldsPersisted,
+  getCustomFieldValue,
+  skipIfCrudFormExtensionTestsDisabled,
+  type CrudRecord,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+import { deleteCatalogProductIfExists } from '@open-mercato/core/helpers/integration/catalogFixtures';
+
+/**
+ * TC-CAT-CRUDFORM-001: Product CrudForm persists scalars + custom fields (#2466, #2555).
+ *
+ * Catalog's `ce.ts` declares NO system custom fields, so the rich-field coverage the sweep
+ * requires is exercised through self-contained custom-field DEFINITIONS created via the
+ * entities API. This proves the product CrudForm round-trips:
+ *   - scalars (title, subtitle, description, sku, handle, isActive), and
+ *   - custom fields of several kinds: a **multichoice** (multi-select), a text field, and an
+ *     integer field — on BOTH create and update.
+ *
+ * Verified contract:
+ * - `/api/catalog/products` is a makeCrud route: POST=201 `{ id }`, PUT=200 `{ ok }`,
+ *   DELETE via `?id=`. The list GET filters a single record by `?id=` (not `?ids=`).
+ * - Request bodies are camelCase; scalar responses snake_case. Custom fields submit under a
+ *   top-level `customFields: { <key>: value }` object (split by `splitCustomFieldPayload` on
+ *   both create and update) and read back under `customValues` (the harness resolver handles
+ *   the shape). Multi-select values are arrays whose element order is not guaranteed, so the
+ *   assertions compare sorted copies.
+ * - The data engine awaits `query_index.upsert_one` before the write returns, so an immediate
+ *   read-back is consistent — no polling.
+ *
+ * Self-contained: creates its own field definitions + product, deletes them in `finally`.
+ * Gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
+ */
+const PRODUCTS_PATH = '/api/catalog/products';
+const DEFINITIONS_PATH = '/api/entities/definitions';
+const PRODUCT_ENTITY_ID = 'catalog:catalog_product';
+
+type ProductFieldDefinition = {
+  key: string;
+  kind: 'select' | 'text' | 'integer';
+  configJson: Record<string, unknown>;
+};
+
+async function createProductDefinition(
+  request: APIRequestContext,
+  token: string,
+  definition: ProductFieldDefinition,
+): Promise<void> {
+  const response = await apiRequest(request, 'POST', DEFINITIONS_PATH, {
+    token,
+    data: {
+      entityId: PRODUCT_ENTITY_ID,
+      key: definition.key,
+      kind: definition.kind,
+      configJson: definition.configJson,
+    },
+  });
+  expect(
+    response.status(),
+    `create custom field definition "${definition.key}" should be 200`,
+  ).toBe(200);
+}
+
+async function deleteProductDefinition(
+  request: APIRequestContext,
+  token: string | null,
+  key: string,
+): Promise<void> {
+  if (!token) return;
+  const response = await apiRequest(request, 'DELETE', DEFINITIONS_PATH, {
+    token,
+    data: { entityId: PRODUCT_ENTITY_ID, key },
+  });
+  expect([200, 404]).toContain(response.status());
+}
+
+async function readProductById(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<CrudRecord | null> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${PRODUCTS_PATH}?id=${encodeURIComponent(id)}&page=1&pageSize=1`,
+    { token },
+  );
+  expect(response.status(), `read-back products failed: ${response.status()}`).toBe(200);
+  const body = await readJsonSafe<{ items?: CrudRecord[] }>(response);
+  return (body?.items ?? []).find((item) => item.id === id) ?? null;
+}
+
+function sortedStrings(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map((entry) => String(entry)).sort();
+  if (value === null || value === undefined) return [];
+  return [String(value)];
+}
+
+test.describe('TC-CAT-CRUDFORM-001: Product CrudForm persists scalars + custom fields', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  test('round-trips scalars + multichoice/text/integer custom fields on create and update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = `${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 8)}`;
+    const multiKey = `qa_prod_multi_${stamp}`;
+    const textKey = `qa_prod_text_${stamp}`;
+    const intKey = `qa_prod_warranty_${stamp}`;
+    const multiOptions = ['ceramic', 'glass', 'steel', 'wood'];
+    let productId: string | null = null;
+
+    try {
+      await createProductDefinition(request, token, {
+        key: multiKey,
+        kind: 'select',
+        configJson: { label: `QA Materials ${stamp}`, multi: true, options: multiOptions },
+      });
+      await createProductDefinition(request, token, {
+        key: textKey,
+        kind: 'text',
+        configJson: { label: `QA Care Instructions ${stamp}` },
+      });
+      await createProductDefinition(request, token, {
+        key: intKey,
+        kind: 'integer',
+        configJson: { label: `QA Warranty Months ${stamp}` },
+      });
+
+      // CREATE — scalars + every custom field kind.
+      const createResponse = await apiRequest(request, 'POST', PRODUCTS_PATH, {
+        token,
+        data: {
+          title: `QA CRUDFORM Product ${stamp}`,
+          subtitle: 'Original subtitle',
+          description: 'Original product description for QA CrudForm coverage.',
+          sku: `QA-CF-${stamp}`,
+          handle: `qa-cf-${stamp}`,
+          isActive: true,
+          customFields: {
+            [multiKey]: ['ceramic', 'steel'],
+            [textKey]: 'Hand wash only',
+            [intKey]: 24,
+          },
+        },
+      });
+      expect(
+        createResponse.status(),
+        `create products failed: ${createResponse.status()}`,
+      ).toBe(201);
+      productId = expectId(
+        (await readJsonSafe<{ id?: string }>(createResponse))?.id,
+        'product create should return an id',
+      );
+
+      const afterCreate = await readProductById(request, token, productId);
+      expect(afterCreate, `created product ${productId} should be readable`).toBeTruthy();
+      assertScalarFieldsPersisted(
+        afterCreate as CrudRecord,
+        {
+          title: `QA CRUDFORM Product ${stamp}`,
+          subtitle: 'Original subtitle',
+          description: 'Original product description for QA CrudForm coverage.',
+          sku: `QA-CF-${stamp}`,
+          handle: `qa-cf-${stamp}`,
+          is_active: true,
+        },
+        'after-create',
+      );
+      expect(
+        sortedStrings(getCustomFieldValue(afterCreate as CrudRecord, multiKey)),
+        'after-create multichoice custom field',
+      ).toEqual(['ceramic', 'steel']);
+      expect(
+        getCustomFieldValue(afterCreate as CrudRecord, textKey),
+        'after-create text custom field',
+      ).toBe('Hand wash only');
+      expect(
+        Number(getCustomFieldValue(afterCreate as CrudRecord, intKey)),
+        'after-create integer custom field',
+      ).toBe(24);
+
+      // UPDATE — change scalars and replace every custom field value.
+      const updateResponse = await apiRequest(request, 'PUT', PRODUCTS_PATH, {
+        token,
+        data: {
+          id: productId,
+          title: `QA CRUDFORM Product ${stamp} EDITED`,
+          subtitle: 'Updated subtitle',
+          description: 'Updated product description.',
+          isActive: false,
+          customFields: {
+            [multiKey]: ['glass', 'wood'],
+            [textKey]: 'Machine washable',
+            [intKey]: 36,
+          },
+        },
+      });
+      expect(
+        updateResponse.status(),
+        `update products failed: ${updateResponse.status()}`,
+      ).toBe(200);
+
+      const afterUpdate = await readProductById(request, token, productId);
+      expect(afterUpdate, `updated product ${productId} should be readable`).toBeTruthy();
+      assertScalarFieldsPersisted(
+        afterUpdate as CrudRecord,
+        {
+          title: `QA CRUDFORM Product ${stamp} EDITED`,
+          subtitle: 'Updated subtitle',
+          description: 'Updated product description.',
+          is_active: false,
+        },
+        'after-update',
+      );
+      const updatedMulti = sortedStrings(getCustomFieldValue(afterUpdate as CrudRecord, multiKey));
+      expect(updatedMulti, 'after-update multichoice custom field').toEqual(['glass', 'wood']);
+      expect(updatedMulti, 'after-update multichoice clears old values').not.toContain('ceramic');
+      expect(updatedMulti, 'after-update multichoice clears old values').not.toContain('steel');
+      expect(
+        getCustomFieldValue(afterUpdate as CrudRecord, textKey),
+        'after-update text custom field',
+      ).toBe('Machine washable');
+      expect(
+        Number(getCustomFieldValue(afterUpdate as CrudRecord, intKey)),
+        'after-update integer custom field',
+      ).toBe(36);
+    } finally {
+      await deleteCatalogProductIfExists(request, token, productId);
+      await deleteProductDefinition(request, token, multiKey);
+      await deleteProductDefinition(request, token, textKey);
+      await deleteProductDefinition(request, token, intKey);
+    }
+  });
+});

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-CRUDFORM-002.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-CRUDFORM-002.spec.ts
@@ -1,0 +1,217 @@
+import { randomUUID } from 'node:crypto';
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  deleteGeneralEntityIfExists,
+  expectId,
+  readJsonSafe,
+} from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  runCrudFormRoundTrip,
+  skipIfCrudFormExtensionTestsDisabled,
+  type CrudRecord,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+import {
+  createProductFixture,
+  createVariantFixture,
+  deleteCatalogProductIfExists,
+} from '@open-mercato/core/helpers/integration/catalogFixtures';
+
+/**
+ * TC-CAT-CRUDFORM-002: Variant CrudForm persists scalars + prices (#2466, #2555).
+ *
+ * The variant surface in the sweep is "variant (prices)". Two facets:
+ *   1. The variant's own scalars (name, sku, barcode, is_default, is_active) and the
+ *      `option_values` JSON map round-trip on create + update — driven by the shared
+ *      `runCrudFormRoundTrip` harness against the makeCrud `/api/catalog/variants` route.
+ *   2. A variant's PRICE persists on create + update. Prices are a SEPARATE sub-resource
+ *      (`/api/catalog/prices`) keyed by `variantId`, not an inline field on the variant
+ *      payload, so the price facet is exercised inline.
+ *
+ * Verified contract:
+ * - `/api/catalog/variants`: POST=201 `{ id }` (requires `productId`; org/tenant inherited
+ *   from the product), PUT=200 `{ ok }`, DELETE via `?id=`, list filters a single record by
+ *   `?id=`. Bodies camelCase; responses snake_case (`product_id`, `is_active`, ...).
+ * - `/api/catalog/prices`: POST=201 `{ id }` (requires `currencyCode` + `priceKindId`),
+ *   PUT=200 `{ ok }`, hard-delete via `?id=`, read-back filtered by `?variantId=`. Numeric
+ *   columns may serialize as strings, so amount/quantity assertions coerce with `Number()`.
+ *
+ * Self-contained: creates its own product, price-kind, and variant fixtures and deletes them
+ * in `finally`. Gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off).
+ */
+const PRODUCTS_PATH = '/api/catalog/products';
+const VARIANTS_PATH = '/api/catalog/variants';
+const PRICES_PATH = '/api/catalog/prices';
+const PRICE_KINDS_PATH = '/api/catalog/price-kinds';
+
+function uniqueStamp(): string {
+  return `${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 8)}`;
+}
+
+async function createPriceKindFixture(
+  request: APIRequestContext,
+  token: string,
+  stamp: string,
+): Promise<string> {
+  const response = await apiRequest(request, 'POST', PRICE_KINDS_PATH, {
+    token,
+    data: { code: `qa_pk_${stamp}`, title: `QA CRUDFORM Price Kind ${stamp}` },
+  });
+  expect(response.status(), `price-kind fixture create should be 201`).toBe(201);
+  return expectId(
+    (await readJsonSafe<{ id?: string }>(response))?.id,
+    'price-kind fixture should return an id',
+  );
+}
+
+async function readPriceById(
+  request: APIRequestContext,
+  token: string,
+  variantId: string,
+  priceId: string,
+): Promise<CrudRecord | null> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${PRICES_PATH}?variantId=${encodeURIComponent(variantId)}&page=1&pageSize=100`,
+    { token },
+  );
+  expect(response.status(), `read-back prices failed: ${response.status()}`).toBe(200);
+  const body = await readJsonSafe<{ items?: CrudRecord[] }>(response);
+  return (body?.items ?? []).find((item) => item.id === priceId) ?? null;
+}
+
+test.describe('TC-CAT-CRUDFORM-002: Variant CrudForm persists scalars + prices', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  test('round-trips variant scalars + optionValues on create and update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = uniqueStamp();
+    let productId: string | null = null;
+
+    try {
+      productId = await createProductFixture(request, token, {
+        title: `QA CRUDFORM Variant Product ${stamp}`,
+        sku: `QA-VP-${stamp}`,
+      });
+
+      await runCrudFormRoundTrip({
+        request,
+        token,
+        collectionPath: VARIANTS_PATH,
+        create: {
+          payload: {
+            productId,
+            name: `QA CRUDFORM Variant ${stamp}`,
+            sku: `QA-VAR-${stamp}`,
+            barcode: `BC-${stamp}`,
+            isDefault: true,
+            isActive: true,
+            optionValues: { size: 'L', color: 'red' },
+          },
+        },
+        expectAfterCreate: {
+          scalars: {
+            product_id: productId,
+            name: `QA CRUDFORM Variant ${stamp}`,
+            sku: `QA-VAR-${stamp}`,
+            barcode: `BC-${stamp}`,
+            is_default: true,
+            is_active: true,
+            option_values: { size: 'L', color: 'red' },
+          },
+        },
+        update: {
+          payload: (id) => ({
+            id,
+            name: `QA CRUDFORM Variant ${stamp} EDITED`,
+            barcode: `BC-${stamp}-E`,
+            isActive: false,
+            optionValues: { size: 'XL', color: 'blue' },
+          }),
+        },
+        expectAfterUpdate: {
+          scalars: {
+            name: `QA CRUDFORM Variant ${stamp} EDITED`,
+            barcode: `BC-${stamp}-E`,
+            is_active: false,
+            option_values: { size: 'XL', color: 'blue' },
+          },
+        },
+      });
+    } finally {
+      await deleteCatalogProductIfExists(request, token, productId);
+    }
+  });
+
+  test('variant price persists on create and update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = uniqueStamp();
+    let productId: string | null = null;
+    let priceKindId: string | null = null;
+    let variantId: string | null = null;
+    let priceId: string | null = null;
+
+    try {
+      productId = await createProductFixture(request, token, {
+        title: `QA CRUDFORM Price Product ${stamp}`,
+        sku: `QA-PP-${stamp}`,
+      });
+      priceKindId = await createPriceKindFixture(request, token, stamp);
+      variantId = await createVariantFixture(request, token, {
+        productId,
+        name: `QA CRUDFORM Price Variant ${stamp}`,
+        sku: `QA-PVAR-${stamp}`,
+      });
+
+      // CREATE price for the variant.
+      const createResponse = await apiRequest(request, 'POST', PRICES_PATH, {
+        token,
+        data: {
+          productId,
+          variantId,
+          priceKindId,
+          currencyCode: 'USD',
+          minQuantity: 1,
+          unitPriceGross: 49.99,
+        },
+      });
+      expect(createResponse.status(), `create price failed: ${createResponse.status()}`).toBe(201);
+      priceId = expectId(
+        (await readJsonSafe<{ id?: string }>(createResponse))?.id,
+        'price create should return an id',
+      );
+
+      const afterCreate = await readPriceById(request, token, variantId, priceId);
+      expect(afterCreate, `created price ${priceId} should be readable`).toBeTruthy();
+      expect(afterCreate!.variant_id, 'price links to variant').toBe(variantId);
+      expect(afterCreate!.product_id, 'price links to product').toBe(productId);
+      expect(afterCreate!.price_kind_id, 'price links to price-kind').toBe(priceKindId);
+      expect(afterCreate!.currency_code, 'price currency persists').toBe('USD');
+      expect(Number(afterCreate!.min_quantity), 'price min_quantity persists').toBe(1);
+      expect(Number(afterCreate!.unit_price_gross), 'price unit_price_gross persists').toBe(49.99);
+
+      // UPDATE the price.
+      const updateResponse = await apiRequest(request, 'PUT', PRICES_PATH, {
+        token,
+        data: { id: priceId, unitPriceGross: 59.95, minQuantity: 5 },
+      });
+      expect(updateResponse.status(), `update price failed: ${updateResponse.status()}`).toBe(200);
+
+      const afterUpdate = await readPriceById(request, token, variantId, priceId);
+      expect(afterUpdate, `updated price ${priceId} should be readable`).toBeTruthy();
+      expect(Number(afterUpdate!.unit_price_gross), 'updated unit_price_gross persists').toBe(59.95);
+      expect(Number(afterUpdate!.min_quantity), 'updated min_quantity persists').toBe(5);
+      expect(afterUpdate!.currency_code, 'currency unchanged on update').toBe('USD');
+      expect(afterUpdate!.variant_id, 'variant link unchanged on update').toBe(variantId);
+      expect(afterUpdate!.product_id, 'product link unchanged on update').toBe(productId);
+    } finally {
+      await deleteGeneralEntityIfExists(request, token, PRICES_PATH, priceId);
+      await deleteGeneralEntityIfExists(request, token, VARIANTS_PATH, variantId);
+      await deleteGeneralEntityIfExists(request, token, PRICE_KINDS_PATH, priceKindId);
+      await deleteCatalogProductIfExists(request, token, productId);
+    }
+  });
+});

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-CRUDFORM-003.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-CRUDFORM-003.spec.ts
@@ -1,0 +1,114 @@
+import { randomUUID } from 'node:crypto';
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  runCrudFormRoundTrip,
+  skipIfCrudFormExtensionTestsDisabled,
+  type CrudRecord,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+import {
+  createCategoryFixture,
+  deleteCatalogCategoryIfExists,
+} from '@open-mercato/core/helpers/integration/catalogFixtures';
+
+/**
+ * TC-CAT-CRUDFORM-003: Category CrudForm persists scalars + parent link (#2466, #2555).
+ *
+ * Proves the category CrudForm round-trips its scalars (name, slug, description, isActive) and
+ * the `parentId` hierarchy link on both create and update.
+ *
+ * Verified contract:
+ * - `/api/catalog/categories` POST/PUT/DELETE are makeCrud actions: POST=201 `{ id }`,
+ *   PUT=200 `{ ok }`, DELETE via `?id=`. The GET is HAND-WRITTEN (the `manage` view) and
+ *   returns **camelCase** rows filtered by `?ids=` (comma-separated) — there is no `?id=`
+ *   single filter — so a custom `readById` is supplied. Because responses are camelCase, the
+ *   asserted scalar keys are camelCase (`parentId`, `isActive`, ...), unlike the snake_case
+ *   product/variant routes.
+ * - Categories do not accept custom fields on create/update, so this surface is scalars-only.
+ *
+ * Self-contained: creates its own parent category, deletes it in `finally`; the harness
+ * deletes the child category it creates. Gated by
+ * `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
+ */
+const CATEGORIES_PATH = '/api/catalog/categories';
+
+async function readCategoryById(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<CrudRecord | null> {
+  const response = await apiRequest(
+    request,
+    'GET',
+    `${CATEGORIES_PATH}?ids=${encodeURIComponent(id)}&page=1&pageSize=100`,
+    { token },
+  );
+  expect(response.status(), `read-back categories failed: ${response.status()}`).toBe(200);
+  const body = await readJsonSafe<{ items?: CrudRecord[] }>(response);
+  return (body?.items ?? []).find((item) => item.id === id) ?? null;
+}
+
+test.describe('TC-CAT-CRUDFORM-003: Category CrudForm persists scalars + parent', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  test('round-trips name/slug/description/parentId/isActive on create and update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = `${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 8)}`;
+    let parentId: string | null = null;
+
+    try {
+      parentId = await createCategoryFixture(request, token, {
+        name: `QA CRUDFORM Parent ${stamp}`,
+      });
+
+      await runCrudFormRoundTrip({
+        request,
+        token,
+        collectionPath: CATEGORIES_PATH,
+        readById: (id) => readCategoryById(request, token, id),
+        create: {
+          payload: {
+            name: `QA CRUDFORM Category ${stamp}`,
+            slug: `qa-crudform-cat-${stamp}`,
+            description: 'Original category description',
+            parentId,
+            isActive: true,
+          },
+        },
+        expectAfterCreate: {
+          scalars: {
+            name: `QA CRUDFORM Category ${stamp}`,
+            slug: `qa-crudform-cat-${stamp}`,
+            description: 'Original category description',
+            parentId,
+            isActive: true,
+          },
+        },
+        update: {
+          payload: (id) => ({
+            id,
+            name: `QA CRUDFORM Category ${stamp} EDITED`,
+            slug: `qa-crudform-cat-${stamp}-e`,
+            description: 'Updated category description',
+            isActive: false,
+          }),
+        },
+        expectAfterUpdate: {
+          scalars: {
+            name: `QA CRUDFORM Category ${stamp} EDITED`,
+            slug: `qa-crudform-cat-${stamp}-e`,
+            description: 'Updated category description',
+            // parentId is omitted from the update payload — a partial update retains it.
+            parentId,
+            isActive: false,
+          },
+        },
+      });
+    } finally {
+      await deleteCatalogCategoryIfExists(request, token, parentId);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds Playwright integration coverage for the **catalog** module's CrudForm field-persistence
(umbrella #2466), proving the product, variant, and category surfaces save AND reload every
field — scalars, custom fields (multichoice/text/integer), the variant→price sub-resource, and
the category parent link — on both create and update. Closes the `catalog` (A3) row of the
CrudForm sweep.

## Changes

- Add `packages/core/src/modules/catalog/__integration__/TC-CAT-CRUDFORM-001.spec.ts` — product:
  scalars + a self-defined **multichoice** custom field (+ text + integer), created via
  `/api/entities/definitions` and cleaned up (catalog ships no system CFs).
- Add `packages/core/src/modules/catalog/__integration__/TC-CAT-CRUDFORM-002.spec.ts` — variant
  scalars + `optionValues` round-trip, plus variant **prices** (separate `/api/catalog/prices`
  sub-resource) create/update persistence with a self-made price-kind fixture.
- Add `packages/core/src/modules/catalog/__integration__/TC-CAT-CRUDFORM-003.spec.ts` — category
  scalars + `parentId` hierarchy (hand-written camelCase `?ids=` read-back).
- Update `.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md` — mark row A3 (catalog).

All specs are self-contained (create every fixture via the API, delete in `finally`) and gated by
`OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md (CrudForm sweep program, umbrella #2466) — row A3 updated in this PR

## Testing

List the tests or commands you ran to validate the change.

- `yarn turbo run typecheck --filter=@open-mercato/core` → pass (typechecks the new `__integration__` specs)
- `yarn test:integration:ephemeral TC-CAT-CRUDFORM` → **4 passed (32.7s)**: product (multichoice/text/integer CF + scalars), variant scalars + optionValues, variant price create/update, category scalars + parent

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (Updated the sweep ledger; no locale/generator changes needed — test-only.)
- [x] I added or adjusted tests that cover the change. (This PR is the tests.)
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Added Playwright specs under the module's `__integration__/`, which the QA runner discovers.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (Updated the program ledger for the #2466 sweep; no separate `.ai/specs/` doc required.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled — N/A, no UI
- [x] Loading state handled — N/A, no UI
- [x] `aria-label` on icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2555