### PR TITLE
feat: 2569 dictionaries crudform

### DIFF
--- a/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
+++ b/.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md
@@ -42,7 +42,7 @@ delete in `finally`. All gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISAB
 | C1 | directory | core | organization, tenant | — | — | ⏭️ covered by #2539 (TC-DIR-006..012) |
 | C2 | feature_toggles | core | global toggle (superadmin) | `feat/crudform-tests-feature-toggles` | — | ⬜ |
 | C3 | api_keys | core | api-key | `feat/crudform-tests-api-keys` | — | ⬜ |
-| C4 | dictionaries | core | dictionary entry | `feat/crudform-tests-dictionaries` | — | ⬜ |
+| C4 | dictionaries | core | dictionary entry (scalars: value/label/color/icon/position/isDefault) | feat/2569-dictionaries-crudform | #2569 | 🔵 spec staged (inline round-trip — entry routes are PATCH + path-param, runCrudFormRoundTrip N/A) |
 | C5 | communication_channels | core | channel | `feat/crudform-tests-comm-channels` | — | ⬜ |
 
 ## Notes

--- a/packages/core/src/modules/dictionaries/__integration__/TC-DICT-CRUDFORM-001.spec.ts
+++ b/packages/core/src/modules/dictionaries/__integration__/TC-DICT-CRUDFORM-001.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  deleteEntityByPathIfExists,
+  expectId,
+  readJsonSafe,
+} from '@open-mercato/core/helpers/integration/generalFixtures';
+import { createDictionaryFixture } from '@open-mercato/core/helpers/integration/dictionariesFixtures';
+import {
+  assertScalarFieldsPersisted,
+  skipIfCrudFormExtensionTestsDisabled,
+  type CrudRecord,
+} from '@open-mercato/core/helpers/integration/crudFormPersistence';
+
+/**
+ * TC-DICT-CRUDFORM-001: Dictionary entry CrudForm persists every field (#2466 / #2569).
+ *
+ * The dictionary entry is a scalar-only surface (no custom fields — the module ships no
+ * `ce.ts` — and no dictionary/multiselect sub-fields of its own). It proves create + update
+ * round-trip every editable field: value, label, color, icon, position, isDefault.
+ *
+ * Verified API contract (why the shared `runCrudFormRoundTrip` does NOT fit this surface):
+ * - Entries are nested under a dictionary: create is `POST /api/dictionaries/{id}/entries`
+ *   (201), but detail mutations use the **path-param** route
+ *   `PATCH|DELETE /api/dictionaries/{id}/entries/{entryId}` — update is **PATCH, not PUT**,
+ *   and delete is by path, not `?id=`. The harness hard-codes PUT + `?id=` DELETE on one
+ *   collection path, so this spec runs the canonical create→read→assert→update→read→assert
+ *   cycle inline while reusing the shared sweep gate + `assertScalarFieldsPersisted`.
+ * - Responses are **camelCase** (`{ id, value, label, color, icon, position, isDefault, ... }`),
+ *   so the expectation keys are camelCase too.
+ * - The entries list GET returns every entry (no `?ids=` filter), so read-back lists and
+ *   matches on `id`.
+ * - `color` is normalized to **lowercase** hex by the command; expectations use lowercase.
+ *
+ * Gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
+ */
+test.describe('TC-DICT-CRUDFORM-001: Dictionary entry CrudForm persists every field on create + update', () => {
+  test.beforeAll(() => {
+    skipIfCrudFormExtensionTestsDisabled();
+  });
+
+  test('round-trips all scalar fields through the nested dictionary entry routes', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const stamp = Date.now();
+    let dictionaryId: string | null = null;
+    let entryId: string | null = null;
+
+    try {
+      // Self-contained fixture: a fresh dictionary to host the entry.
+      dictionaryId = await createDictionaryFixture(request, token, {
+        key: `qa_dict_crudform_${stamp}`,
+        name: `QA CRUDFORM Dictionary ${stamp}`,
+      });
+      const entriesPath = `/api/dictionaries/${encodeURIComponent(dictionaryId)}/entries`;
+
+      const readEntryById = async (id: string): Promise<CrudRecord | null> => {
+        const response = await apiRequest(request, 'GET', entriesPath, { token });
+        expect(response.status(), `read-back entries failed: ${response.status()}`).toBe(200);
+        const body = await readJsonSafe<{ items?: CrudRecord[] }>(response);
+        return (body?.items ?? []).find((item) => item.id === id) ?? null;
+      };
+
+      // Create with every editable field populated.
+      const createResponse = await apiRequest(request, 'POST', entriesPath, {
+        token,
+        data: {
+          value: `qa-crudform-${stamp}`,
+          label: 'QA CRUDFORM Entry',
+          color: '#3366ff',
+          icon: 'lucide:book',
+          position: 3,
+        },
+      });
+      expect(createResponse.status(), 'create entry should be 201').toBe(201);
+      entryId = expectId(
+        (await readJsonSafe<{ id?: string }>(createResponse))?.id,
+        'create entry response should include an id',
+      );
+
+      const afterCreate = await readEntryById(entryId);
+      expect(afterCreate, `created entry ${entryId} should be readable`).toBeTruthy();
+      assertScalarFieldsPersisted(
+        afterCreate as CrudRecord,
+        {
+          value: `qa-crudform-${stamp}`,
+          label: 'QA CRUDFORM Entry',
+          color: '#3366ff',
+          icon: 'lucide:book',
+          position: 3,
+          isDefault: false,
+        },
+        'after-create',
+      );
+
+      // Update every field via PATCH (path-param detail route, not PUT on the collection).
+      const updateResponse = await apiRequest(
+        request,
+        'PATCH',
+        `${entriesPath}/${encodeURIComponent(entryId)}`,
+        {
+          token,
+          data: {
+            value: `qa-crudform-${stamp}-edited`,
+            label: 'QA CRUDFORM Entry EDITED',
+            color: '#aa1133',
+            icon: 'lucide:bookmark',
+            position: 7,
+            isDefault: true,
+          },
+        },
+      );
+      expect(updateResponse.status(), 'update entry should be 200').toBe(200);
+
+      const afterUpdate = await readEntryById(entryId);
+      expect(afterUpdate, `updated entry ${entryId} should be readable`).toBeTruthy();
+      assertScalarFieldsPersisted(
+        afterUpdate as CrudRecord,
+        {
+          value: `qa-crudform-${stamp}-edited`,
+          label: 'QA CRUDFORM Entry EDITED',
+          color: '#aa1133',
+          icon: 'lucide:bookmark',
+          position: 7,
+          isDefault: true,
+        },
+        'after-update',
+      );
+    } finally {
+      await deleteEntityByPathIfExists(
+        request,
+        token,
+        dictionaryId && entryId
+          ? `/api/dictionaries/${encodeURIComponent(dictionaryId)}/entries/${encodeURIComponent(entryId)}`
+          : null,
+      );
+      await deleteEntityByPathIfExists(
+        request,
+        token,
+        dictionaryId ? `/api/dictionaries/${encodeURIComponent(dictionaryId)}` : null,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add Playwright integration coverage proving the `dictionaries` (core) **dictionary-entry** CrudForm surface persists **all** editable field values — value, label, color, icon, position, isDefault — on both create and update. Part of the CrudForm field-persistence QA sweep (umbrella #2466, foundation #2548); mirrors resources (#2551) / staff (#2553).

The dictionary-entry routes are not `makeCrud` (nested path-param `PATCH`/`DELETE .../entries/{entryId}`, list GET with no `?ids=` filter, camelCase responses, no custom fields), so the shared `runCrudFormRoundTrip` does not fit — the spec runs the canonical create→read-back→assert→update→read-back→assert→delete cycle inline while reusing the shared sweep gate (`skipIfCrudFormExtensionTestsDisabled`) and `assertScalarFieldsPersisted`.

## Changes

- Add `packages/core/src/modules/dictionaries/__integration__/TC-DICT-CRUDFORM-001.spec.ts` — self-contained spec (creates its own dictionary fixture via the API, cleans up entry + dictionary in `finally`); gated by `OM_INTEGRATION_CRUDFORM_EXTENSION_TESTS_DISABLED` (default off → runs).
- Update `.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md` row C4 (dictionaries) with the branch and status.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
Tracked by the sweep run ledger: `.ai/runs/2026-06-04-crudform-integration-tests/MODULE-LEDGER.md` (row C4)

## Testing

- `yarn turbo run typecheck --filter=@open-mercato/core` → green (core typechecks `__integration__` specs).
- `yarn test:integration:ephemeral TC-DICT-CRUDFORM` → `1 passed (36.5s)` — spec ran green against a fresh prod-build ephemeral environment.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — test-only; updated the sweep ledger.)
- [x] I added or adjusted tests that cover the change. (The PR is the test.)
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Lives module-local in `packages/core/src/modules/dictionaries/__integration__/` per the sweep convention.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — updated the sweep run ledger instead.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI (backend test-only)
- [x] No arbitrary text sizes — N/A, no UI (backend test-only)
- [x] Empty state handled for list/data pages — N/A, no UI (backend test-only)
- [x] Loading state handled for async pages — N/A, no UI (backend test-only)
- [x] `aria-label` on all icon-only buttons — N/A, no UI (backend test-only)
- [x] Uses existing DS components — N/A, no UI (backend test-only)

## Linked issues

Fixes #2569