### PR TITLE
security(enterprise): tenant-scope MFA admin & enforcement views (#2612)

### DIFF
--- a/.ai/specs/enterprise/2026-06-05-security-mfa-cross-tenant-authorization.md
+++ b/.ai/specs/enterprise/2026-06-05-security-mfa-cross-tenant-authorization.md
@@ -1,6 +1,6 @@
 # Enterprise Security — MFA Admin & Enforcement Cross-Tenant Authorization
 
-> **Status:** Draft — ready for implementation review
+> **Status:** Implemented 2026-06-06 (branch `fix/2612-enterprise-security-mfa`, stacked on the OSS branch) — all phases landed; see Final Compliance Report + Changelog
 > **Issue:** [open-mercato#2612](https://github.com/open-mercato/open-mercato/issues/2612) (comment 3 — enterprise variants)
 > **Scope:** Enterprise — `security` module (`packages/enterprise/src/modules/security`)
 > **Parent OSS spec:** [`.ai/specs/2026-06-05-tenant-ownership-and-module-acl-authorization.md`](../2026-06-05-tenant-ownership-and-module-acl-authorization.md)
@@ -137,17 +137,20 @@ _No open questions remain blocking._
 
 ## Final Compliance Report
 
-_To be completed during implementation (per spec-writing checklist)._ Gates to verify before merge:
-- [ ] `scope=PLATFORM` and arbitrary `tenantId`/`scopeId` rejected for non-superadmins at the route handler (unfiltered `em.find(User, …)` never reached).
-- [ ] Target-user guard on `mfa/status` + `mfa/reset`; `404` cross-tenant even with valid sudo.
-- [ ] All four policy-CRUD methods enforce scope ownership (list/create/update/delete).
-- [ ] Services take an actor-context backstop; `findUserById` uses `findOneWithDecryption` with non-superadmin tenant criteria.
-- [ ] `TC-SEC-007` fixtures made same-tenant + cross-tenant negative case added; `TC-SEC-005` still green (superadmin).
-- [ ] Reused `enforceTenantSelection`/`resolveIsSuperAdmin` imported from `@open-mercato/core/modules/auth/lib/tenantAccess` (no hand-rolled superadmin checks).
-- [ ] Enterprise RELEASE_NOTES entry (platform/cross-tenant views now superadmin-only); merge order coordinated with parent OSS spec.
-- [ ] `yarn typecheck`, `yarn lint`, `yarn test`, enterprise integration specs green.
+Implemented 2026-06-06 on branch `fix/2612-enterprise-security-mfa` (stacked on the OSS branch). Gate status:
+- [x] `scope=PLATFORM` and arbitrary `tenantId`/`scopeId` rejected for non-superadmins at the route handler via `assertActorOwnsEnforcementScope`; the service backstop (`assertActorOwnsScopeFilters`) guards before `em.find(User, …)`, so the unfiltered PLATFORM query is unreachable for non-superadmins.
+- [x] Target-user guard `assertActorCanAccessSecurityUserTarget` on `mfa/status` + `mfa/reset`; `404` cross-tenant even with valid sudo (guard runs independently of sudo).
+- [x] All four policy-CRUD methods enforce scope ownership: route-level (`create` pre-dispatch, `update`/`delete` load-then-assert via new `getPolicyById`) + `MfaEnforcementService` actor-context backstop; `listPolicies` constrains non-superadmins to their own tenant.
+- [x] Services take an optional, backward-compatible actor-context backstop (`{ tenantId, isSuperAdmin }`); `MfaAdminService.findUserById` uses `findOneWithDecryption` (global load) with the actor-context tenant comparison enforcing ownership.
+- [x] `TC-SEC-007` positive path is same-tenant (documented); cross-tenant negatives covered by route/service unit tests (harness provisions no 2nd tenant). `TC-SEC-005` unchanged — superadmin token, stays green.
+- [x] Reused `enforceTenantSelection`/`resolveIsSuperAdmin` from `@open-mercato/core/modules/auth/lib/tenantAccess` (no hand-rolled superadmin checks).
+- [x] Breaking-change entry added to `UPGRADE_NOTES.md` (`0.6.4 → 0.6.5`). Stacked on the OSS branch; merge after the parent OSS PR (#2636) or rebase onto `develop` once it lands.
+- [x] `yarn workspace @open-mercato/enterprise build` + `typecheck` green (zero errors); full security suite **171 tests** green. (No `lint` script in the enterprise workspace; the TS build is the authoritative gate.)
+
+> **Note on enum spelling:** the module uses British `EnforcementScope.ORGANISATION` (`'organisation'`) — reflected in the guards and tests.
 
 ## Changelog
 
 - 2026-06-05 — Initial draft from issue #2612 comment 3 (all enterprise variants verified in code). Split from the parent OSS spec per spec-separation rules and the issue's own follow-up suggestion.
 - 2026-06-05 — Applied pre-implementation analysis remediations (`.ai/specs/analysis/ANALYSIS-2026-06-05-security-mfa-cross-tenant-authorization.md`): enumerated the four policy-CRUD methods + the unfiltered `PLATFORM` query in § C; resolved Open Questions #1 (404/403 convention) and #2 (explicit actor-context); added the `TC-SEC-007` same-tenant + negative-test note and existing-test impact to § Test Plan; added Risks & Impact Review and Final Compliance Report sections.
+- 2026-06-06 — Implemented (branch `fix/2612-enterprise-security-mfa`, stacked on the OSS branch). **Users-MFA vertical:** added `assertActorCanAccessSecurityUserTarget` + `assertActorOwnsTenantScope` to `api/users/_shared.ts`; wired target-user guards into `mfa/status` + `mfa/reset` (404 cross-tenant even with sudo) and `enforceTenantSelection` into `mfa/compliance`; `MfaAdminService.findUserById` → `findOneWithDecryption` + optional `{ tenantId, isSuperAdmin }` actor-context backstop on status/reset/compliance; actor-context threaded through the reset command. **Enforcement vertical:** added `assertActorOwnsEnforcementScope` (PLATFORM→superadmin, TENANT/ORGANISATION ownership) to `api/enforcement/_shared.ts`; wired it into compliance + list/create/update/delete (the latter two load the policy via new `getPolicyById` then assert current+new scope ownership); `MfaEnforcementService` gained an actor-context backstop on `getComplianceReport`/`listPolicies`/`createPolicy`/`updatePolicy`/`deletePolicy` with the unfiltered PLATFORM `em.find` guarded behind it; actor-context threaded through the create/update/delete commands. Added route + service unit tests; full `security` suite green (171). Enterprise build + typecheck green (zero errors). `UPGRADE_NOTES.md` updated.

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -36,6 +36,16 @@ Closes a class of Broken Access Control (OWASP A01 / BOLA+BFLA) defects where th
 
 No DB schema change. No ACL feature IDs were renamed or removed (only enforced). See [`.ai/specs/2026-06-05-tenant-ownership-and-module-acl-authorization.md`](.ai/specs/2026-06-05-tenant-ownership-and-module-acl-authorization.md). Enterprise `security` (MFA admin/enforcement) variants are tracked separately in [`.ai/specs/enterprise/2026-06-05-security-mfa-cross-tenant-authorization.md`](.ai/specs/enterprise/2026-06-05-security-mfa-cross-tenant-authorization.md).
 
+### Enterprise `security` — MFA admin & enforcement views are now tenant-scoped (#2612)
+
+Same root cause as above, in the enterprise `security` module. Because `security/setup.ts` grants default admins `security.*`, every tenant admin held `security.admin.manage` — which previously let them read/act across **all** tenants. Now enforced (super-admin/platform required for cross-tenant or platform-wide views):
+
+1. **Per-user MFA admin (IDOR closed).** `GET /api/security/users/[id]/mfa/status` and `POST /api/security/users/[id]/mfa/reset` now verify the target user belongs to the actor's tenant — a foreign-tenant target returns `404` even with a valid sudo token (sudo validates the actor, not the target).
+2. **MFA compliance.** `GET /api/security/users/mfa/compliance?tenantId=…` no longer prefers a caller-supplied `tenantId`; a non-super-admin requesting a foreign tenant gets `403`.
+3. **Enforcement compliance & policies.** `GET /api/security/enforcement/compliance` now requires platform-admin for `scope=platform` (previously it counted users across all tenants) and validates `scope=tenant|organisation` ownership; enforcement policy list/create/update/delete reject foreign-tenant/org scopes for non-super-admins (`403`). The unfiltered `em.find(User, { deletedAt: null })` is unreachable for non-super-admins.
+
+*Action for downstream:* none unless internal tooling relied on a tenant admin viewing other tenants' MFA posture or using `scope=platform` — those calls now require a platform/super-admin. No DB schema change; no ACL feature IDs renamed. Service methods (`MfaAdminService`, `MfaEnforcementService`) gained an **optional** actor-context backstop param — additive, existing callers unaffected. Reuses the core `enforceTenantSelection`/`resolveIsSuperAdmin` helpers, so the enterprise build must be paired with a core that has them (true since ≤ 0.6.4). See [`.ai/specs/enterprise/2026-06-05-security-mfa-cross-tenant-authorization.md`](.ai/specs/enterprise/2026-06-05-security-mfa-cross-tenant-authorization.md).
+
 ### New `om-prepare-issue` skill (deferred-work capture)
 
 A new bundled skill, [`om-prepare-issue`](.ai/skills/om-prepare-issue/SKILL.md), codifies the "park this idea for later" workflow. Given a free-form feature brief it (1) researches and writes a spec under `.ai/specs/` to `om-spec-writing` standards, (2) opens a **docs-only spec PR** against `develop` (labels `documentation` + `skip-qa`, reusing `om-auto-create-pr` worktree/branch/label mechanics), and (3) opens a **tracking GitHub issue** that links the spec path and the spec PR and names the implementer skill (`om-implement-spec` / `om-auto-fix-github`) for later pickup. It never implements the feature — the only file it adds is the spec.

--- a/packages/enterprise/src/modules/security/__integration__/TC-SEC-007.spec.ts
+++ b/packages/enterprise/src/modules/security/__integration__/TC-SEC-007.spec.ts
@@ -8,6 +8,13 @@ import {
   loginViaApi,
 } from './helpers/securityFixtures'
 
+// Positive path (admin + target/control users) is intentionally same-tenant: every
+// fixture user is created with the same admin token, so the tenant-ownership guard
+// added for issue #2612 passes and the 200 assertions below remain valid.
+// The cross-tenant negative case (tenant-A admin -> tenant-B user => 404, and
+// foreign-tenant compliance => 403) is covered by the route/service unit tests
+// (mfa-status.route.test.ts, mfa-reset.route.test.ts, mfa-compliance.route.test.ts,
+// MfaAdminService.test.ts) because this harness does not provision a second tenant.
 test.describe('TC-SEC-007: Admin MFA reset and status reporting', () => {
   let adminToken: string
   let targetUserId: string | null = null

--- a/packages/enterprise/src/modules/security/api/enforcement/[id]/route.ts
+++ b/packages/enterprise/src/modules/security/api/enforcement/[id]/route.ts
@@ -2,13 +2,47 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import { updateEnforcementPolicySchema } from '../../../data/validators'
+import { EnforcementScope } from '../../../data/entities'
+import type { MfaEnforcementPolicy } from '../../../data/entities'
+import type { UpdateEnforcementPolicyInput } from '../../../data/validators'
 import { buildSecurityOpenApi, securityErrorSchema } from '../../openapi'
 import { securityApiError } from '../../i18n'
-import { mapEnforcementError, resolveEnforcementContext } from '../_shared'
+import {
+  assertActorOwnsEnforcementScope,
+  mapEnforcementError,
+  resolveEnforcementContext,
+  type EnforcementRequestContext,
+} from '../_shared'
 
 const paramsSchema = z.object({
   id: z.string().uuid(),
 })
+
+function scopeIdFromPolicy(policy: {
+  scope: EnforcementScope
+  tenantId?: string | null
+  organizationId?: string | null
+}): string | null {
+  if (policy.scope === EnforcementScope.TENANT) {
+    return policy.tenantId ?? null
+  }
+  if (policy.scope === EnforcementScope.ORGANISATION) {
+    if (!policy.tenantId || !policy.organizationId) return null
+    return `${policy.tenantId}:${policy.organizationId}`
+  }
+  return null
+}
+
+async function assertActorOwnsRequestedPolicyScope(
+  context: EnforcementRequestContext,
+  current: MfaEnforcementPolicy,
+  data: UpdateEnforcementPolicyInput,
+): Promise<void> {
+  const scope = data.scope ?? current.scope
+  const tenantId = data.tenantId ?? current.tenantId ?? null
+  const organizationId = data.organizationId ?? current.organizationId ?? null
+  await assertActorOwnsEnforcementScope(context, scope, scopeIdFromPolicy({ scope, tenantId, organizationId }))
+}
 
 const okResponseSchema = z.object({
   ok: z.literal(true),
@@ -41,6 +75,13 @@ export async function PUT(req: Request, context: { params: Promise<{ id: string 
   }
 
   try {
+    const policy = await requestContext.enforcementService.getPolicyById(params.data.id)
+    if (!policy) {
+      return securityApiError(404, 'Enforcement policy not found')
+    }
+    await assertActorOwnsEnforcementScope(requestContext, policy.scope, scopeIdFromPolicy(policy))
+    await assertActorOwnsRequestedPolicyScope(requestContext, policy, parsedBody.data)
+
     const commandBus = requestContext.container.resolve<CommandBus>('commandBus')
     const { result } = await commandBus.execute('security.enforcement.update', {
       input: {
@@ -65,6 +106,12 @@ export async function DELETE(req: Request, context: { params: Promise<{ id: stri
   }
 
   try {
+    const policy = await requestContext.enforcementService.getPolicyById(params.data.id)
+    if (!policy) {
+      return securityApiError(404, 'Enforcement policy not found')
+    }
+    await assertActorOwnsEnforcementScope(requestContext, policy.scope, scopeIdFromPolicy(policy))
+
     const commandBus = requestContext.container.resolve<CommandBus>('commandBus')
     const { result } = await commandBus.execute('security.enforcement.delete', {
       input: { id: params.data.id },
@@ -92,6 +139,7 @@ export const openApi = buildSecurityOpenApi({
       errors: [
         { status: 400, description: 'Invalid input', schema: securityErrorSchema },
         { status: 401, description: 'Unauthorized', schema: securityErrorSchema },
+        { status: 403, description: 'Not authorized for the requested scope', schema: securityErrorSchema },
         { status: 404, description: 'Policy not found', schema: securityErrorSchema },
         { status: 409, description: 'Conflict', schema: securityErrorSchema },
       ],
@@ -105,6 +153,7 @@ export const openApi = buildSecurityOpenApi({
       errors: [
         { status: 400, description: 'Invalid policy id', schema: securityErrorSchema },
         { status: 401, description: 'Unauthorized', schema: securityErrorSchema },
+        { status: 403, description: 'Not authorized for the requested scope', schema: securityErrorSchema },
         { status: 404, description: 'Policy not found', schema: securityErrorSchema },
       ],
     },

--- a/packages/enterprise/src/modules/security/api/enforcement/__tests__/compliance.route.test.ts
+++ b/packages/enterprise/src/modules/security/api/enforcement/__tests__/compliance.route.test.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server'
+import { forbidden } from '@open-mercato/shared/lib/crud/errors'
+import { EnforcementScope } from '../../../data/entities'
+import { GET } from '../compliance/route'
+import {
+  assertActorOwnsEnforcementScope,
+  resolveActorContext,
+  resolveEnforcementContext,
+} from '../_shared'
+
+jest.mock('../../i18n', () => ({
+  securityApiError: jest.fn((status: number, message: string) => NextResponse.json({ error: message }, { status })),
+}))
+
+jest.mock('../_shared', () => ({
+  resolveEnforcementContext: jest.fn(),
+  assertActorOwnsEnforcementScope: jest.fn(),
+  resolveActorContext: jest.fn(),
+  mapEnforcementError: jest.fn((error: unknown) => {
+    if (error instanceof Error && 'status' in error && 'body' in error) {
+      const status = (error as Error & { status: number }).status
+      const body = (error as Error & { body?: unknown }).body
+      return NextResponse.json(body, { status })
+    }
+    return NextResponse.json({ error: 'Failed to process enforcement request.' }, { status: 500 })
+  }),
+}))
+
+const mockedResolveEnforcementContext = resolveEnforcementContext as jest.MockedFunction<typeof resolveEnforcementContext>
+const mockedAssertActorOwnsEnforcementScope = assertActorOwnsEnforcementScope as jest.MockedFunction<typeof assertActorOwnsEnforcementScope>
+const mockedResolveActorContext = resolveActorContext as jest.MockedFunction<typeof resolveActorContext>
+
+const tenantA = '33333333-3333-4333-8333-333333333333'
+const tenantB = '44444444-4444-4444-8444-444444444444'
+
+function buildContext(getComplianceReport: jest.Mock) {
+  return {
+    auth: { sub: 'admin-1', tenantId: tenantA, orgId: 'org-1' },
+    container: { resolve: jest.fn() },
+    commandContext: {} as never,
+    enforcementService: { getComplianceReport } as never,
+  } as never
+}
+
+describe('security enforcement compliance route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedResolveActorContext.mockResolvedValue({ tenantId: tenantA, isSuperAdmin: false })
+    mockedAssertActorOwnsEnforcementScope.mockResolvedValue(undefined)
+  })
+
+  test('returns 403 for a non-superadmin requesting platform scope', async () => {
+    const getComplianceReport = jest.fn()
+    mockedResolveEnforcementContext.mockResolvedValue(buildContext(getComplianceReport))
+    mockedAssertActorOwnsEnforcementScope.mockRejectedValueOnce(
+      forbidden('Platform scope requires platform administrator privileges.'),
+    )
+
+    const req = new Request('https://example.test/api/security/enforcement/compliance?scope=platform', { method: 'GET' })
+    const response = await GET(req)
+
+    expect(response.status).toBe(403)
+    expect(getComplianceReport).not.toHaveBeenCalled()
+  })
+
+  test('returns 403 for a foreign tenant scope', async () => {
+    const getComplianceReport = jest.fn()
+    mockedResolveEnforcementContext.mockResolvedValue(buildContext(getComplianceReport))
+    mockedAssertActorOwnsEnforcementScope.mockRejectedValueOnce(forbidden('Not authorized to target this tenant.'))
+
+    const req = new Request(
+      `https://example.test/api/security/enforcement/compliance?scope=tenant&scopeId=${tenantB}`,
+      { method: 'GET' },
+    )
+    const response = await GET(req)
+
+    expect(response.status).toBe(403)
+    expect(getComplianceReport).not.toHaveBeenCalled()
+  })
+
+  test('returns 200 for an owned tenant scope', async () => {
+    const getComplianceReport = jest.fn(async () => ({ total: 1, enrolled: 1, pending: 0, overdue: 0 }))
+    mockedResolveEnforcementContext.mockResolvedValue(buildContext(getComplianceReport))
+
+    const req = new Request(
+      `https://example.test/api/security/enforcement/compliance?scope=tenant&scopeId=${tenantA}`,
+      { method: 'GET' },
+    )
+    const response = await GET(req)
+
+    expect(response.status).toBe(200)
+    expect(getComplianceReport).toHaveBeenCalledWith(EnforcementScope.TENANT, tenantA, {
+      tenantId: tenantA,
+      isSuperAdmin: false,
+    })
+  })
+
+  test('returns 200 for a superadmin requesting platform scope', async () => {
+    const getComplianceReport = jest.fn(async () => ({ total: 5, enrolled: 5, pending: 0, overdue: 0 }))
+    mockedResolveEnforcementContext.mockResolvedValue(buildContext(getComplianceReport))
+    mockedResolveActorContext.mockResolvedValue({ tenantId: tenantA, isSuperAdmin: true })
+
+    const req = new Request('https://example.test/api/security/enforcement/compliance?scope=platform', { method: 'GET' })
+    const response = await GET(req)
+
+    expect(response.status).toBe(200)
+    expect(getComplianceReport).toHaveBeenCalledWith(EnforcementScope.PLATFORM, undefined, {
+      tenantId: tenantA,
+      isSuperAdmin: true,
+    })
+  })
+})

--- a/packages/enterprise/src/modules/security/api/enforcement/__tests__/id.route.test.ts
+++ b/packages/enterprise/src/modules/security/api/enforcement/__tests__/id.route.test.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from 'next/server'
+import { forbidden } from '@open-mercato/shared/lib/crud/errors'
+import { EnforcementScope } from '../../../data/entities'
+import { DELETE, PUT } from '../[id]/route'
+import { assertActorOwnsEnforcementScope, resolveEnforcementContext } from '../_shared'
+
+jest.mock('../../i18n', () => ({
+  securityApiError: jest.fn((status: number, message: string) => NextResponse.json({ error: message }, { status })),
+}))
+
+jest.mock('../_shared', () => ({
+  resolveEnforcementContext: jest.fn(),
+  assertActorOwnsEnforcementScope: jest.fn(),
+  mapEnforcementError: jest.fn((error: unknown) => {
+    if (error instanceof Error && 'status' in error && 'body' in error) {
+      const status = (error as Error & { status: number }).status
+      const body = (error as Error & { body?: unknown }).body
+      return NextResponse.json(body, { status })
+    }
+    return NextResponse.json({ error: 'Failed to process enforcement request.' }, { status: 500 })
+  }),
+}))
+
+const mockedResolveEnforcementContext = resolveEnforcementContext as jest.MockedFunction<typeof resolveEnforcementContext>
+const mockedAssertActorOwnsEnforcementScope = assertActorOwnsEnforcementScope as jest.MockedFunction<typeof assertActorOwnsEnforcementScope>
+
+const tenantA = '33333333-3333-4333-8333-333333333333'
+const tenantB = '44444444-4444-4444-8444-444444444444'
+const policyId = '55555555-5555-4555-8555-555555555555'
+
+function buildContext(options: { getPolicyById?: jest.Mock; commandExecute?: jest.Mock } = {}) {
+  const execute = options.commandExecute ?? jest.fn(async () => ({ result: { ok: true } }))
+  return {
+    auth: { sub: 'admin-1', tenantId: tenantA, orgId: 'org-1' },
+    container: { resolve: jest.fn(() => ({ execute })) },
+    commandContext: {} as never,
+    enforcementService: {
+      getPolicyById:
+        options.getPolicyById ??
+        jest.fn(async () => ({
+          id: policyId,
+          scope: EnforcementScope.TENANT,
+          tenantId: tenantB,
+          organizationId: null,
+        })),
+    } as never,
+  } as never
+}
+
+function params() {
+  return { params: Promise.resolve({ id: policyId }) }
+}
+
+describe('security enforcement [id] route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedAssertActorOwnsEnforcementScope.mockResolvedValue(undefined)
+  })
+
+  test('update rejects when actor does not own the current policy scope', async () => {
+    const commandExecute = jest.fn()
+    mockedResolveEnforcementContext.mockResolvedValue(buildContext({ commandExecute }))
+    mockedAssertActorOwnsEnforcementScope.mockRejectedValueOnce(forbidden('Not authorized to target this tenant.'))
+
+    const req = new Request(`https://example.test/api/security/enforcement/${policyId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ isEnforced: false }),
+    })
+    const response = await PUT(req, params())
+
+    expect(response.status).toBe(403)
+    expect(commandExecute).not.toHaveBeenCalled()
+  })
+
+  test('delete rejects when actor does not own the policy scope', async () => {
+    const commandExecute = jest.fn()
+    mockedResolveEnforcementContext.mockResolvedValue(buildContext({ commandExecute }))
+    mockedAssertActorOwnsEnforcementScope.mockRejectedValueOnce(forbidden('Not authorized to target this tenant.'))
+
+    const req = new Request(`https://example.test/api/security/enforcement/${policyId}`, { method: 'DELETE' })
+    const response = await DELETE(req, params())
+
+    expect(response.status).toBe(403)
+    expect(commandExecute).not.toHaveBeenCalled()
+  })
+
+  test('delete dispatches the command for an owned policy scope', async () => {
+    const commandExecute = jest.fn(async () => ({ result: { ok: true } }))
+    const getPolicyById = jest.fn(async () => ({
+      id: policyId,
+      scope: EnforcementScope.TENANT,
+      tenantId: tenantA,
+      organizationId: null,
+    }))
+    mockedResolveEnforcementContext.mockResolvedValue(buildContext({ commandExecute, getPolicyById }))
+
+    const req = new Request(`https://example.test/api/security/enforcement/${policyId}`, { method: 'DELETE' })
+    const response = await DELETE(req, params())
+
+    expect(response.status).toBe(200)
+    expect(commandExecute).toHaveBeenCalled()
+  })
+
+  test('delete returns 404 when the policy does not exist', async () => {
+    const commandExecute = jest.fn()
+    const getPolicyById = jest.fn(async () => null)
+    mockedResolveEnforcementContext.mockResolvedValue(buildContext({ commandExecute, getPolicyById }))
+
+    const req = new Request(`https://example.test/api/security/enforcement/${policyId}`, { method: 'DELETE' })
+    const response = await DELETE(req, params())
+
+    expect(response.status).toBe(404)
+    expect(commandExecute).not.toHaveBeenCalled()
+  })
+})

--- a/packages/enterprise/src/modules/security/api/enforcement/__tests__/route.test.ts
+++ b/packages/enterprise/src/modules/security/api/enforcement/__tests__/route.test.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from 'next/server'
+import { forbidden } from '@open-mercato/shared/lib/crud/errors'
+import { EnforcementScope } from '../../../data/entities'
+import { GET, POST } from '../route'
+import {
+  assertActorOwnsEnforcementScope,
+  attachPolicyScopeNames,
+  resolveActorContext,
+  resolveEnforcementContext,
+} from '../_shared'
+
+jest.mock('../../i18n', () => ({
+  securityApiError: jest.fn((status: number, message: string) => NextResponse.json({ error: message }, { status })),
+}))
+
+jest.mock('../_shared', () => ({
+  resolveEnforcementContext: jest.fn(),
+  assertActorOwnsEnforcementScope: jest.fn(),
+  resolveActorContext: jest.fn(),
+  attachPolicyScopeNames: jest.fn(async () => []),
+  mapEnforcementError: jest.fn((error: unknown) => {
+    if (error instanceof Error && 'status' in error && 'body' in error) {
+      const status = (error as Error & { status: number }).status
+      const body = (error as Error & { body?: unknown }).body
+      return NextResponse.json(body, { status })
+    }
+    return NextResponse.json({ error: 'Failed to process enforcement request.' }, { status: 500 })
+  }),
+}))
+
+const mockedResolveEnforcementContext = resolveEnforcementContext as jest.MockedFunction<typeof resolveEnforcementContext>
+const mockedAssertActorOwnsEnforcementScope = assertActorOwnsEnforcementScope as jest.MockedFunction<typeof assertActorOwnsEnforcementScope>
+const mockedResolveActorContext = resolveActorContext as jest.MockedFunction<typeof resolveActorContext>
+const mockedAttachPolicyScopeNames = attachPolicyScopeNames as jest.MockedFunction<typeof attachPolicyScopeNames>
+
+const tenantA = '33333333-3333-4333-8333-333333333333'
+const tenantB = '44444444-4444-4444-8444-444444444444'
+
+function buildContext(options: { listPolicies?: jest.Mock; commandExecute?: jest.Mock } = {}) {
+  const execute = options.commandExecute ?? jest.fn(async () => ({ result: { id: 'policy-1' } }))
+  return {
+    auth: { sub: 'admin-1', tenantId: tenantA, orgId: 'org-1' },
+    container: { resolve: jest.fn(() => ({ execute })) },
+    commandContext: {} as never,
+    enforcementService: { listPolicies: options.listPolicies ?? jest.fn(async () => []) } as never,
+  } as never
+}
+
+describe('security enforcement list/create route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedResolveActorContext.mockResolvedValue({ tenantId: tenantA, isSuperAdmin: false })
+    mockedAssertActorOwnsEnforcementScope.mockResolvedValue(undefined)
+    mockedAttachPolicyScopeNames.mockResolvedValue([])
+  })
+
+  test('list passes actor context to the service for a non-superadmin', async () => {
+    const listPolicies = jest.fn(async () => [])
+    mockedResolveEnforcementContext.mockResolvedValue(buildContext({ listPolicies }))
+
+    const req = new Request('https://example.test/api/security/enforcement', { method: 'GET' })
+    const response = await GET(req)
+
+    expect(response.status).toBe(200)
+    expect(listPolicies).toHaveBeenCalledWith({ scope: undefined }, { tenantId: tenantA, isSuperAdmin: false })
+  })
+
+  test('create rejects a foreign tenant scope before dispatching the command', async () => {
+    const commandExecute = jest.fn()
+    mockedResolveEnforcementContext.mockResolvedValue(buildContext({ commandExecute }))
+    mockedAssertActorOwnsEnforcementScope.mockRejectedValueOnce(forbidden('Not authorized to target this tenant.'))
+
+    const req = new Request('https://example.test/api/security/enforcement', {
+      method: 'POST',
+      body: JSON.stringify({ scope: 'tenant', tenantId: tenantB, isEnforced: true }),
+    })
+    const response = await POST(req)
+
+    expect(response.status).toBe(403)
+    expect(commandExecute).not.toHaveBeenCalled()
+  })
+
+  test('create dispatches the command for an owned tenant scope', async () => {
+    const commandExecute = jest.fn(async () => ({ result: { id: 'policy-1' } }))
+    mockedResolveEnforcementContext.mockResolvedValue(buildContext({ commandExecute }))
+
+    const req = new Request('https://example.test/api/security/enforcement', {
+      method: 'POST',
+      body: JSON.stringify({ scope: 'tenant', tenantId: tenantA, isEnforced: true }),
+    })
+    const response = await POST(req)
+
+    expect(response.status).toBe(201)
+    expect(mockedAssertActorOwnsEnforcementScope).toHaveBeenCalledWith(expect.anything(), EnforcementScope.TENANT, tenantA)
+    expect(commandExecute).toHaveBeenCalled()
+  })
+})

--- a/packages/enterprise/src/modules/security/api/enforcement/_shared.ts
+++ b/packages/enterprise/src/modules/security/api/enforcement/_shared.ts
@@ -2,15 +2,22 @@ import { NextResponse } from 'next/server'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { Organization, Tenant } from '@open-mercato/core/modules/directory/data/entities'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, forbidden } from '@open-mercato/shared/lib/crud/errors'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
-import type { MfaEnforcementPolicy } from '../../data/entities'
+import { enforceTenantSelection, resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+import { EnforcementScope, type MfaEnforcementPolicy } from '../../data/entities'
 import type { MfaEnforcementServiceError, MfaEnforcementService } from '../../services/MfaEnforcementService'
 import { localizeSecurityApiBody, securityApiError } from '../i18n'
 
 type RequestContainer = Awaited<ReturnType<typeof createRequestContainer>>
 type Auth = NonNullable<Awaited<ReturnType<typeof getAuthFromRequest>>>
+
+export type EnforcementActorContext = {
+  tenantId: string | null
+  isSuperAdmin: boolean
+}
 
 export type EnforcementRequestContext = {
   auth: Auth
@@ -39,6 +46,80 @@ export async function resolveEnforcementContext(req: Request): Promise<Enforceme
     },
     enforcementService: container.resolve<MfaEnforcementService>('mfaEnforcementService'),
   }
+}
+
+function normalizeNullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function normalizeOrganizationList(values: unknown): string[] | null {
+  if (values === null || values === undefined) return null
+  if (!Array.isArray(values)) return null
+  const result: string[] = []
+  for (const value of values) {
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (trimmed) result.push(trimmed)
+  }
+  return result
+}
+
+export async function resolveActorContext(ctx: EnforcementRequestContext): Promise<EnforcementActorContext> {
+  const isSuperAdmin = await resolveIsSuperAdmin({ auth: ctx.auth, container: ctx.container })
+  return {
+    tenantId: normalizeNullableString(ctx.auth.tenantId),
+    isSuperAdmin,
+  }
+}
+
+async function assertActorOwnsOrganization(
+  ctx: EnforcementRequestContext,
+  organizationId: string,
+): Promise<void> {
+  const rbacService = ctx.container.resolve<RbacService>('rbacService')
+  const acl = await rbacService.loadAcl(ctx.auth.sub, {
+    tenantId: normalizeNullableString(ctx.auth.tenantId),
+    organizationId: normalizeNullableString(ctx.auth.orgId),
+  })
+  const organizations = normalizeOrganizationList(acl?.organizations)
+  if (organizations === null || organizations.includes('__all__')) return
+  if (!organizations.includes(organizationId)) {
+    throw forbidden('Not authorized to target this organization.')
+  }
+}
+
+export async function assertActorOwnsEnforcementScope(
+  ctx: EnforcementRequestContext,
+  scope: EnforcementScope,
+  scopeId: string | null | undefined,
+): Promise<void> {
+  if (scope === EnforcementScope.PLATFORM) {
+    const isSuperAdmin = await resolveIsSuperAdmin({ auth: ctx.auth, container: ctx.container })
+    if (!isSuperAdmin) {
+      throw forbidden('Platform scope requires platform administrator privileges.')
+    }
+    return
+  }
+
+  if (scope === EnforcementScope.TENANT) {
+    await enforceTenantSelection({ auth: ctx.auth, container: ctx.container }, scopeId)
+    return
+  }
+
+  const normalizedScopeId = normalizeNullableString(scopeId)
+  if (!normalizedScopeId) {
+    throw new CrudHttpError(400, { error: "organisation scopeId must use '<tenantId>:<organizationId>' format" })
+  }
+  const [tenantId, organizationId] = normalizedScopeId.split(':')
+  if (!tenantId || !organizationId) {
+    throw new CrudHttpError(400, { error: "organisation scopeId must use '<tenantId>:<organizationId>' format" })
+  }
+
+  await enforceTenantSelection({ auth: ctx.auth, container: ctx.container }, tenantId)
+
+  const isSuperAdmin = await resolveIsSuperAdmin({ auth: ctx.auth, container: ctx.container })
+  if (isSuperAdmin) return
+  await assertActorOwnsOrganization(ctx, organizationId)
 }
 
 export async function mapEnforcementError(error: unknown): Promise<NextResponse> {

--- a/packages/enterprise/src/modules/security/api/enforcement/compliance/route.ts
+++ b/packages/enterprise/src/modules/security/api/enforcement/compliance/route.ts
@@ -3,7 +3,12 @@ import { z } from 'zod'
 import { EnforcementScope } from '../../../data/entities'
 import { buildSecurityOpenApi, securityErrorSchema } from '../../openapi'
 import { securityApiError } from '../../i18n'
-import { mapEnforcementError, resolveEnforcementContext } from '../_shared'
+import {
+  assertActorOwnsEnforcementScope,
+  mapEnforcementError,
+  resolveActorContext,
+  resolveEnforcementContext,
+} from '../_shared'
 
 const complianceQuerySchema = z.object({
   scope: z.nativeEnum(EnforcementScope).default(EnforcementScope.PLATFORM),
@@ -37,9 +42,12 @@ export async function GET(req: Request) {
   }
 
   try {
+    await assertActorOwnsEnforcementScope(context, parsedQuery.data.scope, parsedQuery.data.scopeId)
+    const actor = await resolveActorContext(context)
     const report = await context.enforcementService.getComplianceReport(
       parsedQuery.data.scope,
       parsedQuery.data.scopeId,
+      actor,
     )
     return NextResponse.json({
       scope: parsedQuery.data.scope,
@@ -63,6 +71,7 @@ export const openApi = buildSecurityOpenApi({
       errors: [
         { status: 400, description: 'Invalid query parameters', schema: securityErrorSchema },
         { status: 401, description: 'Unauthorized', schema: securityErrorSchema },
+        { status: 403, description: 'Not authorized for the requested scope', schema: securityErrorSchema },
       ],
     },
   },

--- a/packages/enterprise/src/modules/security/api/enforcement/route.ts
+++ b/packages/enterprise/src/modules/security/api/enforcement/route.ts
@@ -5,7 +5,13 @@ import { enforcementPolicySchema } from '../../data/validators'
 import { EnforcementScope } from '../../data/entities'
 import { buildSecurityOpenApi, securityErrorSchema } from '../openapi'
 import { securityApiError } from '../i18n'
-import { attachPolicyScopeNames, mapEnforcementError, resolveEnforcementContext } from './_shared'
+import {
+  assertActorOwnsEnforcementScope,
+  attachPolicyScopeNames,
+  mapEnforcementError,
+  resolveActorContext,
+  resolveEnforcementContext,
+} from './_shared'
 
 const enforcementPolicyResponseSchema = z.object({
   id: z.string().uuid(),
@@ -52,7 +58,8 @@ export async function GET(req: Request) {
       return securityApiError(400, 'Invalid query parameters', { issues: parsedQuery.error.issues })
     }
 
-    const policies = await context.enforcementService.listPolicies(parsedQuery.data)
+    const actor = await resolveActorContext(context)
+    const policies = await context.enforcementService.listPolicies(parsedQuery.data, actor)
     return NextResponse.json({
       items: await attachPolicyScopeNames(context.container, policies),
     })
@@ -78,6 +85,11 @@ export async function POST(req: Request) {
   }
 
   try {
+    await assertActorOwnsEnforcementScope(
+      context,
+      parsedBody.data.scope,
+      scopeIdFromPolicyInput(parsedBody.data),
+    )
     const commandBus = context.container.resolve<CommandBus>('commandBus')
     const { result } = await commandBus.execute('security.enforcement.create', {
       input: parsedBody.data,
@@ -87,6 +99,21 @@ export async function POST(req: Request) {
   } catch (error) {
     return await mapEnforcementError(error)
   }
+}
+
+function scopeIdFromPolicyInput(data: {
+  scope: EnforcementScope
+  tenantId?: string | null
+  organizationId?: string | null
+}): string | null {
+  if (data.scope === EnforcementScope.TENANT) {
+    return data.tenantId ?? null
+  }
+  if (data.scope === EnforcementScope.ORGANISATION) {
+    if (!data.tenantId || !data.organizationId) return null
+    return `${data.tenantId}:${data.organizationId}`
+  }
+  return null
 }
 
 export const openApi = buildSecurityOpenApi({
@@ -115,6 +142,7 @@ export const openApi = buildSecurityOpenApi({
       errors: [
         { status: 400, description: 'Invalid payload', schema: securityErrorSchema },
         { status: 401, description: 'Unauthorized', schema: securityErrorSchema },
+        { status: 403, description: 'Not authorized for the requested scope', schema: securityErrorSchema },
         { status: 409, description: 'Conflict', schema: securityErrorSchema },
       ],
     },

--- a/packages/enterprise/src/modules/security/api/users/[id]/mfa/reset/route.ts
+++ b/packages/enterprise/src/modules/security/api/users/[id]/mfa/reset/route.ts
@@ -3,7 +3,11 @@ import { z } from 'zod'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import { buildSecurityOpenApi, securityErrorSchema } from '../../../../openapi'
 import { securityApiError } from '../../../../i18n'
-import { mapSecurityUsersError, resolveSecurityUsersContext } from '../../../_shared'
+import {
+  assertActorCanAccessSecurityUserTarget,
+  mapSecurityUsersError,
+  resolveSecurityUsersContext,
+} from '../../../_shared'
 import { requireSudo } from '../../../../../lib/sudo-middleware'
 
 const paramsSchema = z.object({
@@ -44,6 +48,7 @@ export async function POST(req: Request, routeContext: { params: Promise<{ id: s
   }
 
   try {
+    await assertActorCanAccessSecurityUserTarget(context, parsedParams.data.id)
     await requireSudo(req, 'security.admin.mfa.reset')
     const commandBus = context.container.resolve<CommandBus>('commandBus')
     const { result } = await commandBus.execute('security.admin.mfa.reset', {

--- a/packages/enterprise/src/modules/security/api/users/[id]/mfa/status/route.ts
+++ b/packages/enterprise/src/modules/security/api/users/[id]/mfa/status/route.ts
@@ -2,7 +2,12 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { buildSecurityOpenApi, securityErrorSchema } from '../../../../openapi'
 import { securityApiError } from '../../../../i18n'
-import { mapSecurityUsersError, resolveSecurityUsersContext } from '../../../_shared'
+import { resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
+import {
+  assertActorCanAccessSecurityUserTarget,
+  mapSecurityUsersError,
+  resolveSecurityUsersContext,
+} from '../../../_shared'
 
 const paramsSchema = z.object({
   id: z.string().uuid(),
@@ -35,7 +40,12 @@ export async function GET(req: Request, routeContext: { params: Promise<{ id: st
   }
 
   try {
-    const status = await context.mfaAdminService.getUserMfaStatus(parsedParams.data.id)
+    await assertActorCanAccessSecurityUserTarget(context, parsedParams.data.id)
+    const isSuperAdmin = await resolveIsSuperAdmin({ auth: context.auth, container: context.container })
+    const status = await context.mfaAdminService.getUserMfaStatus(parsedParams.data.id, {
+      tenantId: context.auth.tenantId ?? null,
+      isSuperAdmin,
+    })
     return NextResponse.json({
       ...status,
       methods: status.methods.map((method) => ({
@@ -60,6 +70,7 @@ export const openApi = buildSecurityOpenApi({
       errors: [
         { status: 400, description: 'Invalid user id', schema: securityErrorSchema },
         { status: 401, description: 'Unauthorized', schema: securityErrorSchema },
+        { status: 403, description: 'Not authorized to access this user', schema: securityErrorSchema },
         { status: 404, description: 'User not found', schema: securityErrorSchema },
       ],
     },

--- a/packages/enterprise/src/modules/security/api/users/__tests__/mfa-compliance.route.test.ts
+++ b/packages/enterprise/src/modules/security/api/users/__tests__/mfa-compliance.route.test.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server'
+import { forbidden } from '@open-mercato/shared/lib/crud/errors'
+import { GET } from '../mfa/compliance/route'
+import { resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
+import { assertActorOwnsTenantScope, resolveSecurityUsersContext } from '../_shared'
+
+jest.mock('@open-mercato/core/modules/auth/lib/tenantAccess', () => ({
+  resolveIsSuperAdmin: jest.fn(),
+}))
+
+jest.mock('../../i18n', () => ({
+  securityApiError: jest.fn((status: number, message: string) => NextResponse.json({ error: message }, { status })),
+}))
+
+jest.mock('../_shared', () => ({
+  resolveSecurityUsersContext: jest.fn(),
+  assertActorOwnsTenantScope: jest.fn(),
+  mapSecurityUsersError: jest.fn((error: unknown) => {
+    if (error instanceof Error && 'status' in error && 'body' in error) {
+      const status = (error as Error & { status: number }).status
+      const body = (error as Error & { body?: unknown }).body
+      return NextResponse.json(body, { status })
+    }
+    return NextResponse.json({ error: 'Failed to process user security request.' }, { status: 500 })
+  }),
+}))
+
+const mockedResolveSecurityUsersContext = resolveSecurityUsersContext as jest.MockedFunction<typeof resolveSecurityUsersContext>
+const mockedAssertActorOwnsTenantScope = assertActorOwnsTenantScope as jest.MockedFunction<typeof assertActorOwnsTenantScope>
+const mockedResolveIsSuperAdmin = resolveIsSuperAdmin as jest.MockedFunction<typeof resolveIsSuperAdmin>
+
+const tenantA = '33333333-3333-4333-8333-333333333333'
+const tenantB = '44444444-4444-4444-8444-444444444444'
+
+function buildContext(bulkComplianceCheck: jest.Mock) {
+  return {
+    auth: { sub: 'admin-1', tenantId: tenantA, orgId: 'org-1' },
+    container: { resolve: jest.fn() },
+    commandContext: {} as never,
+    mfaAdminService: { bulkComplianceCheck } as never,
+  } as never
+}
+
+describe('security users mfa compliance route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedResolveIsSuperAdmin.mockResolvedValue(false)
+  })
+
+  test('returns 200 for own-tenant compliance', async () => {
+    const bulkComplianceCheck = jest.fn(async () => [])
+    mockedResolveSecurityUsersContext.mockResolvedValue(buildContext(bulkComplianceCheck))
+    mockedAssertActorOwnsTenantScope.mockResolvedValue(tenantA)
+
+    const req = new Request('https://example.test/api/security/users/mfa/compliance', { method: 'GET' })
+    const response = await GET(req)
+
+    expect(response.status).toBe(200)
+    expect(bulkComplianceCheck).toHaveBeenCalledWith(tenantA, { tenantId: tenantA, isSuperAdmin: false })
+  })
+
+  test('returns 403 when requesting a foreign tenant as a non-superadmin', async () => {
+    const bulkComplianceCheck = jest.fn()
+    mockedResolveSecurityUsersContext.mockResolvedValue(buildContext(bulkComplianceCheck))
+    mockedAssertActorOwnsTenantScope.mockRejectedValueOnce(forbidden('Not authorized to target this tenant.'))
+
+    const req = new Request(`https://example.test/api/security/users/mfa/compliance?tenantId=${tenantB}`, { method: 'GET' })
+    const response = await GET(req)
+
+    expect(response.status).toBe(403)
+    expect(bulkComplianceCheck).not.toHaveBeenCalled()
+  })
+
+  test('allows a superadmin to query a foreign tenant', async () => {
+    const bulkComplianceCheck = jest.fn(async () => [])
+    mockedResolveSecurityUsersContext.mockResolvedValue(buildContext(bulkComplianceCheck))
+    mockedAssertActorOwnsTenantScope.mockResolvedValue(tenantB)
+    mockedResolveIsSuperAdmin.mockResolvedValue(true)
+
+    const req = new Request(`https://example.test/api/security/users/mfa/compliance?tenantId=${tenantB}`, { method: 'GET' })
+    const response = await GET(req)
+
+    expect(response.status).toBe(200)
+    expect(bulkComplianceCheck).toHaveBeenCalledWith(tenantB, { tenantId: tenantA, isSuperAdmin: true })
+  })
+
+  test('returns 400 when no tenant context resolves', async () => {
+    const bulkComplianceCheck = jest.fn()
+    mockedResolveSecurityUsersContext.mockResolvedValue(buildContext(bulkComplianceCheck))
+    mockedAssertActorOwnsTenantScope.mockResolvedValue(null)
+
+    const req = new Request('https://example.test/api/security/users/mfa/compliance', { method: 'GET' })
+    const response = await GET(req)
+
+    expect(response.status).toBe(400)
+    expect(bulkComplianceCheck).not.toHaveBeenCalled()
+  })
+})

--- a/packages/enterprise/src/modules/security/api/users/__tests__/mfa-reset.route.test.ts
+++ b/packages/enterprise/src/modules/security/api/users/__tests__/mfa-reset.route.test.ts
@@ -1,11 +1,18 @@
 import { NextResponse } from 'next/server'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { POST } from '../[id]/mfa/reset/route'
 import { requireSudo, SudoRequiredError } from '../../../lib/sudo-middleware'
-import { resolveSecurityUsersContext } from '../_shared'
+import { assertActorCanAccessSecurityUserTarget, resolveSecurityUsersContext } from '../_shared'
 
 jest.mock('../_shared', () => ({
   resolveSecurityUsersContext: jest.fn(),
+  assertActorCanAccessSecurityUserTarget: jest.fn().mockResolvedValue(undefined),
   mapSecurityUsersError: jest.fn((error: unknown) => {
+    if (error instanceof Error && 'status' in error && 'body' in error) {
+      const status = (error as Error & { status: number }).status
+      const body = (error as Error & { body?: unknown }).body
+      return NextResponse.json(body, { status })
+    }
     if (error instanceof Error && 'statusCode' in error) {
       const statusCode = (error as Error & { statusCode: number }).statusCode
       const body = 'body' in error ? (error as Error & { body?: unknown }).body : { error: error.message }
@@ -25,12 +32,14 @@ jest.mock('../../../lib/sudo-middleware', () => ({
 
 const mockedRequireSudo = requireSudo as jest.MockedFunction<typeof requireSudo>
 const mockedResolveSecurityUsersContext = resolveSecurityUsersContext as jest.MockedFunction<typeof resolveSecurityUsersContext>
+const mockedAssertActorCanAccessSecurityUserTarget = assertActorCanAccessSecurityUserTarget as jest.MockedFunction<typeof assertActorCanAccessSecurityUserTarget>
 
 describe('security user mfa reset route', () => {
   const userId = '11111111-1111-4111-8111-111111111111'
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockedAssertActorCanAccessSecurityUserTarget.mockResolvedValue(undefined)
   })
 
   test('requires sudo before executing the reset command', async () => {
@@ -82,5 +91,36 @@ describe('security user mfa reset route', () => {
     })
 
     expect(response.status).toBe(403)
+  })
+
+  test('returns 404 for a cross-tenant target even with valid sudo', async () => {
+    const execute = jest.fn(async () => ({ result: { ok: true } }))
+    mockedResolveSecurityUsersContext.mockResolvedValue({
+      auth: { sub: 'admin-1', tenantId: 'tenant-1', orgId: 'org-1' },
+      container: {
+        resolve: (name: string) => {
+          if (name === 'commandBus') return { execute }
+          throw new Error(`Unexpected dependency: ${name}`)
+        },
+      },
+      commandContext: {} as never,
+      mfaAdminService: {} as never,
+    } as never)
+    mockedAssertActorCanAccessSecurityUserTarget.mockRejectedValueOnce(
+      new CrudHttpError(404, { error: 'User not found' }),
+    )
+
+    const req = new Request(`https://example.test/api/security/users/${userId}/mfa/reset`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-sudo-token': 'sudo-token' },
+      body: JSON.stringify({ reason: 'security incident' }),
+    })
+
+    const response = await POST(req, {
+      params: Promise.resolve({ id: userId }),
+    })
+
+    expect(response.status).toBe(404)
+    expect(execute).not.toHaveBeenCalled()
   })
 })

--- a/packages/enterprise/src/modules/security/api/users/__tests__/mfa-status.route.test.ts
+++ b/packages/enterprise/src/modules/security/api/users/__tests__/mfa-status.route.test.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server'
+import { CrudHttpError, forbidden } from '@open-mercato/shared/lib/crud/errors'
+import { GET } from '../[id]/mfa/status/route'
+import { resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
+import { assertActorCanAccessSecurityUserTarget, resolveSecurityUsersContext } from '../_shared'
+
+jest.mock('@open-mercato/core/modules/auth/lib/tenantAccess', () => ({
+  resolveIsSuperAdmin: jest.fn(),
+}))
+
+jest.mock('../_shared', () => ({
+  resolveSecurityUsersContext: jest.fn(),
+  assertActorCanAccessSecurityUserTarget: jest.fn().mockResolvedValue(undefined),
+  mapSecurityUsersError: jest.fn((error: unknown) => {
+    if (error instanceof Error && 'status' in error && 'body' in error) {
+      const status = (error as Error & { status: number }).status
+      const body = (error as Error & { body?: unknown }).body
+      return NextResponse.json(body, { status })
+    }
+    return NextResponse.json({ error: 'Failed to process user security request.' }, { status: 500 })
+  }),
+}))
+
+const mockedResolveSecurityUsersContext = resolveSecurityUsersContext as jest.MockedFunction<typeof resolveSecurityUsersContext>
+const mockedAssertActorCanAccessSecurityUserTarget = assertActorCanAccessSecurityUserTarget as jest.MockedFunction<typeof assertActorCanAccessSecurityUserTarget>
+const mockedResolveIsSuperAdmin = resolveIsSuperAdmin as jest.MockedFunction<typeof resolveIsSuperAdmin>
+
+const tenantBUserId = '22222222-2222-4222-8222-222222222222'
+
+function buildContext(getUserMfaStatus: jest.Mock) {
+  return {
+    auth: { sub: 'admin-1', tenantId: 'tenant-a', orgId: 'org-1' },
+    container: { resolve: jest.fn() },
+    commandContext: {} as never,
+    mfaAdminService: { getUserMfaStatus } as never,
+  } as never
+}
+
+describe('security user mfa status route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedAssertActorCanAccessSecurityUserTarget.mockResolvedValue(undefined)
+    mockedResolveIsSuperAdmin.mockResolvedValue(false)
+  })
+
+  test('returns 200 with status for an in-tenant target', async () => {
+    const getUserMfaStatus = jest.fn(async () => ({
+      enrolled: true,
+      methods: [],
+      recoveryCodesRemaining: 2,
+      compliant: true,
+    }))
+    mockedResolveSecurityUsersContext.mockResolvedValue(buildContext(getUserMfaStatus))
+
+    const req = new Request(`https://example.test/api/security/users/${tenantBUserId}/mfa/status`, { method: 'GET' })
+    const response = await GET(req, { params: Promise.resolve({ id: tenantBUserId }) })
+
+    expect(response.status).toBe(200)
+    expect(getUserMfaStatus).toHaveBeenCalledWith(tenantBUserId, { tenantId: 'tenant-a', isSuperAdmin: false })
+  })
+
+  test('returns 404 for a cross-tenant target', async () => {
+    const getUserMfaStatus = jest.fn()
+    mockedResolveSecurityUsersContext.mockResolvedValue(buildContext(getUserMfaStatus))
+    mockedAssertActorCanAccessSecurityUserTarget.mockRejectedValueOnce(new CrudHttpError(404, { error: 'User not found' }))
+
+    const req = new Request(`https://example.test/api/security/users/${tenantBUserId}/mfa/status`, { method: 'GET' })
+    const response = await GET(req, { params: Promise.resolve({ id: tenantBUserId }) })
+
+    expect(response.status).toBe(404)
+    expect(getUserMfaStatus).not.toHaveBeenCalled()
+  })
+
+  test('returns 403 for an out-of-org in-tenant target', async () => {
+    const getUserMfaStatus = jest.fn()
+    mockedResolveSecurityUsersContext.mockResolvedValue(buildContext(getUserMfaStatus))
+    mockedAssertActorCanAccessSecurityUserTarget.mockRejectedValueOnce(forbidden('Not authorized to access this user.'))
+
+    const req = new Request(`https://example.test/api/security/users/${tenantBUserId}/mfa/status`, { method: 'GET' })
+    const response = await GET(req, { params: Promise.resolve({ id: tenantBUserId }) })
+
+    expect(response.status).toBe(403)
+    expect(getUserMfaStatus).not.toHaveBeenCalled()
+  })
+
+  test('passes superadmin flag through to the service', async () => {
+    const getUserMfaStatus = jest.fn(async () => ({
+      enrolled: false,
+      methods: [],
+      recoveryCodesRemaining: 0,
+      compliant: true,
+    }))
+    mockedResolveSecurityUsersContext.mockResolvedValue(buildContext(getUserMfaStatus))
+    mockedResolveIsSuperAdmin.mockResolvedValue(true)
+
+    const req = new Request(`https://example.test/api/security/users/${tenantBUserId}/mfa/status`, { method: 'GET' })
+    const response = await GET(req, { params: Promise.resolve({ id: tenantBUserId }) })
+
+    expect(response.status).toBe(200)
+    expect(getUserMfaStatus).toHaveBeenCalledWith(tenantBUserId, { tenantId: 'tenant-a', isSuperAdmin: true })
+  })
+})

--- a/packages/enterprise/src/modules/security/api/users/_shared.ts
+++ b/packages/enterprise/src/modules/security/api/users/_shared.ts
@@ -1,8 +1,13 @@
 import { NextResponse } from 'next/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
+import { CrudHttpError, forbidden } from '@open-mercato/shared/lib/crud/errors'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { enforceTenantSelection, resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
+import { User } from '@open-mercato/core/modules/auth/data/entities'
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { isSudoRequiredError } from '../../lib/sudo-middleware'
 import type { MfaAdminService, MfaAdminServiceError } from '../../services/MfaAdminService'
 import { localizeSecurityApiBody, securityApiError } from '../i18n'
@@ -39,6 +44,69 @@ export async function resolveSecurityUsersContext(
     },
     mfaAdminService: container.resolve<MfaAdminService>('mfaAdminService'),
   }
+}
+
+function normalizeNullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function normalizeOrganizationList(values: unknown): string[] | null {
+  if (values === null || values === undefined) return null
+  if (!Array.isArray(values)) return null
+  const result: string[] = []
+  for (const value of values) {
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (trimmed) result.push(trimmed)
+  }
+  return result
+}
+
+export async function assertActorCanAccessSecurityUserTarget(
+  ctx: SecurityUsersRequestContext,
+  targetUserId: string,
+): Promise<void> {
+  const isSuperAdmin = await resolveIsSuperAdmin({ auth: ctx.auth, container: ctx.container })
+  if (isSuperAdmin) return
+
+  const em = ctx.container.resolve<EntityManager>('em')
+  const target = await findOneWithDecryption(
+    em,
+    User,
+    { id: targetUserId, deletedAt: null } as FilterQuery<User>,
+    {},
+    { tenantId: null, organizationId: null },
+  )
+  if (!target) {
+    throw new CrudHttpError(404, { error: 'User not found' })
+  }
+
+  const actorTenantId = normalizeNullableString(ctx.auth.tenantId)
+  const targetTenantId = normalizeNullableString((target as { tenantId?: string | null }).tenantId)
+  if (!targetTenantId || targetTenantId !== actorTenantId) {
+    throw new CrudHttpError(404, { error: 'User not found' })
+  }
+
+  const rbacService = ctx.container.resolve<RbacService>('rbacService')
+  const acl = await rbacService.loadAcl(ctx.auth.sub, {
+    tenantId: actorTenantId,
+    organizationId: normalizeNullableString(ctx.auth.orgId),
+  })
+  const organizations = normalizeOrganizationList(acl?.organizations)
+  if (organizations !== null && !organizations.includes('__all__')) {
+    const targetOrganizationId = normalizeNullableString((target as { organizationId?: string | null }).organizationId)
+    if (!targetOrganizationId || !organizations.includes(targetOrganizationId)) {
+      throw forbidden('Not authorized to access this user.')
+    }
+  }
+}
+
+export async function assertActorOwnsTenantScope(
+  ctx: SecurityUsersRequestContext,
+  requestedTenantId: string | null | undefined,
+): Promise<string | null> {
+  const resolved = await enforceTenantSelection({ auth: ctx.auth, container: ctx.container }, requestedTenantId)
+  return resolved ?? ctx.auth.tenantId ?? null
 }
 
 export async function mapSecurityUsersError(error: unknown): Promise<NextResponse> {

--- a/packages/enterprise/src/modules/security/api/users/mfa/compliance/route.ts
+++ b/packages/enterprise/src/modules/security/api/users/mfa/compliance/route.ts
@@ -2,7 +2,12 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { buildSecurityOpenApi, securityErrorSchema } from '../../../openapi'
 import { securityApiError } from '../../../i18n'
-import { mapSecurityUsersError, resolveSecurityUsersContext } from '../../_shared'
+import { resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
+import {
+  assertActorOwnsTenantScope,
+  mapSecurityUsersError,
+  resolveSecurityUsersContext,
+} from '../../_shared'
 
 const querySchema = z.object({
   tenantId: z.string().uuid().optional(),
@@ -37,13 +42,16 @@ export async function GET(req: Request) {
     return securityApiError(400, 'Invalid query parameters', { issues: parsedQuery.error.issues })
   }
 
-  const tenantId = parsedQuery.data.tenantId ?? context.auth.tenantId ?? null
-  if (!tenantId) {
-    return securityApiError(400, 'Tenant context is required.')
-  }
-
   try {
-    const items = await context.mfaAdminService.bulkComplianceCheck(tenantId)
+    const tenantId = await assertActorOwnsTenantScope(context, parsedQuery.data.tenantId)
+    if (!tenantId) {
+      return securityApiError(400, 'Tenant context is required.')
+    }
+    const isSuperAdmin = await resolveIsSuperAdmin({ auth: context.auth, container: context.container })
+    const items = await context.mfaAdminService.bulkComplianceCheck(tenantId, {
+      tenantId: context.auth.tenantId ?? null,
+      isSuperAdmin,
+    })
     return NextResponse.json({ items })
   } catch (error) {
     return await mapSecurityUsersError(error)
@@ -62,6 +70,7 @@ export const openApi = buildSecurityOpenApi({
       errors: [
         { status: 400, description: 'Invalid query or missing tenant context', schema: securityErrorSchema },
         { status: 401, description: 'Unauthorized', schema: securityErrorSchema },
+        { status: 403, description: 'Not authorized for the requested tenant scope', schema: securityErrorSchema },
       ],
     },
   },

--- a/packages/enterprise/src/modules/security/commands/createEnforcementPolicy.ts
+++ b/packages/enterprise/src/modules/security/commands/createEnforcementPolicy.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { registerCommand } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import { resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
 import { enforcementPolicySchema } from '../data/validators'
 import type { MfaEnforcementService } from '../services/MfaEnforcementService'
 
@@ -34,8 +35,12 @@ registerCommand({
     }
 
     const enforcementService = ctx.container.resolve<MfaEnforcementService>('mfaEnforcementService')
+    const isSuperAdmin = await resolveIsSuperAdmin({ auth: ctx.auth, container: ctx.container })
     try {
-      const policy = await enforcementService.createPolicy(parsed.data, ctx.auth.sub)
+      const policy = await enforcementService.createPolicy(parsed.data, ctx.auth.sub, {
+        tenantId: ctx.auth.tenantId ?? null,
+        isSuperAdmin,
+      })
       return { id: policy.id }
     } catch (error) {
       if (isEnforcementServiceError(error)) {

--- a/packages/enterprise/src/modules/security/commands/deleteEnforcementPolicy.ts
+++ b/packages/enterprise/src/modules/security/commands/deleteEnforcementPolicy.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { registerCommand } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import { resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
 import type { MfaEnforcementService } from '../services/MfaEnforcementService'
 
 export const commandId = 'security.enforcement.delete'
@@ -35,8 +36,12 @@ registerCommand({
     }
 
     const enforcementService = ctx.container.resolve<MfaEnforcementService>('mfaEnforcementService')
+    const isSuperAdmin = await resolveIsSuperAdmin({ auth: ctx.auth, container: ctx.container })
     try {
-      await enforcementService.deletePolicy(parsed.data.id)
+      await enforcementService.deletePolicy(parsed.data.id, {
+        tenantId: ctx.auth.tenantId ?? null,
+        isSuperAdmin,
+      })
       return { ok: true as const }
     } catch (error) {
       if (isEnforcementServiceError(error)) {

--- a/packages/enterprise/src/modules/security/commands/resetUserMfa.ts
+++ b/packages/enterprise/src/modules/security/commands/resetUserMfa.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { registerCommand } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import { resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
 import type { MfaAdminService } from '../services/MfaAdminService'
 
 export const commandId = 'security.admin.mfa.reset'
@@ -36,8 +37,12 @@ registerCommand({
     }
 
     const mfaAdminService = ctx.container.resolve<MfaAdminService>('mfaAdminService')
+    const isSuperAdmin = await resolveIsSuperAdmin({ auth: ctx.auth, container: ctx.container })
     try {
-      await mfaAdminService.resetUserMfa(ctx.auth.sub, parsed.data.userId, parsed.data.reason)
+      await mfaAdminService.resetUserMfa(ctx.auth.sub, parsed.data.userId, parsed.data.reason, {
+        tenantId: ctx.auth.tenantId ?? null,
+        isSuperAdmin,
+      })
       return { ok: true as const }
     } catch (error) {
       if (isMfaAdminServiceError(error)) {

--- a/packages/enterprise/src/modules/security/commands/updateEnforcementPolicy.ts
+++ b/packages/enterprise/src/modules/security/commands/updateEnforcementPolicy.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { registerCommand } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import { resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
 import { updateEnforcementPolicySchema } from '../data/validators'
 import type { MfaEnforcementService } from '../services/MfaEnforcementService'
 
@@ -37,8 +38,12 @@ registerCommand({
     }
 
     const enforcementService = ctx.container.resolve<MfaEnforcementService>('mfaEnforcementService')
+    const isSuperAdmin = await resolveIsSuperAdmin({ auth: ctx.auth, container: ctx.container })
     try {
-      await enforcementService.updatePolicy(parsed.data.id, parsed.data.data, ctx.auth.sub)
+      await enforcementService.updatePolicy(parsed.data.id, parsed.data.data, ctx.auth.sub, {
+        tenantId: ctx.auth.tenantId ?? null,
+        isSuperAdmin,
+      })
       return { ok: true as const }
     } catch (error) {
       if (isEnforcementServiceError(error)) {

--- a/packages/enterprise/src/modules/security/services/MfaAdminService.ts
+++ b/packages/enterprise/src/modules/security/services/MfaAdminService.ts
@@ -1,6 +1,6 @@
-import type { EntityManager } from '@mikro-orm/postgresql'
+import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { User } from '@open-mercato/core/modules/auth/data/entities'
-import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { MfaRecoveryCode, UserMfaMethod } from '../data/entities'
 import { emitSecurityEvent } from '../events'
 import type { MfaEnforcementService } from './MfaEnforcementService'
@@ -27,6 +27,11 @@ type BulkComplianceStatus = {
   lastLoginAt?: Date
 }
 
+type ActorContext = {
+  tenantId: string | null
+  isSuperAdmin: boolean
+}
+
 export class MfaAdminServiceError extends Error {
   constructor(
     message: string,
@@ -43,7 +48,7 @@ export class MfaAdminService {
     private readonly mfaEnforcementService: MfaEnforcementService,
   ) {}
 
-  async resetUserMfa(adminId: string, userId: string, reason: string): Promise<void> {
+  async resetUserMfa(adminId: string, userId: string, reason: string, actor?: ActorContext): Promise<void> {
     if (!adminId.trim()) {
       throw new MfaAdminServiceError('Admin ID is required', 400)
     }
@@ -60,6 +65,7 @@ export class MfaAdminService {
     if (!user) {
       throw new MfaAdminServiceError('User not found', 404)
     }
+    this.assertActorOwnsUser(user, actor)
 
     const activeMethods = await this.em.find(UserMfaMethod, {
       userId,
@@ -95,7 +101,7 @@ export class MfaAdminService {
     })
   }
 
-  async getUserMfaStatus(userId: string): Promise<UserMfaStatus> {
+  async getUserMfaStatus(userId: string, actor?: ActorContext): Promise<UserMfaStatus> {
     if (!userId.trim()) {
       throw new MfaAdminServiceError('User ID is required', 400)
     }
@@ -104,6 +110,7 @@ export class MfaAdminService {
     if (!user) {
       throw new MfaAdminServiceError('User not found', 404)
     }
+    this.assertActorOwnsUser(user, actor)
 
     const methods = await this.em.find(
       UserMfaMethod,
@@ -136,9 +143,12 @@ export class MfaAdminService {
     }
   }
 
-  async bulkComplianceCheck(tenantId: string): Promise<BulkComplianceStatus[]> {
+  async bulkComplianceCheck(tenantId: string, actor?: ActorContext): Promise<BulkComplianceStatus[]> {
     if (!tenantId.trim()) {
       throw new MfaAdminServiceError('Tenant ID is required', 400)
+    }
+    if (actor && !actor.isSuperAdmin && tenantId !== actor.tenantId) {
+      throw new MfaAdminServiceError('Not authorized for the requested tenant scope.', 403)
     }
 
     const users = await findWithDecryption(
@@ -186,8 +196,21 @@ export class MfaAdminService {
     })
   }
 
+  private assertActorOwnsUser(user: User, actor?: ActorContext): void {
+    if (!actor || actor.isSuperAdmin) return
+    if (!user.tenantId || user.tenantId !== actor.tenantId) {
+      throw new MfaAdminServiceError('User not found', 404)
+    }
+  }
+
   private async findUserById(userId: string): Promise<User | null> {
-    return this.em.findOne(User, { id: userId, deletedAt: null })
+    return findOneWithDecryption(
+      this.em,
+      User,
+      { id: userId, deletedAt: null } as FilterQuery<User>,
+      {},
+      { tenantId: null, organizationId: null },
+    )
   }
 }
 

--- a/packages/enterprise/src/modules/security/services/MfaEnforcementService.ts
+++ b/packages/enterprise/src/modules/security/services/MfaEnforcementService.ts
@@ -28,6 +28,11 @@ type EnforcementPolicyListFilters = {
   scope?: EnforcementScope
 }
 
+export type EnforcementActorContext = {
+  tenantId: string | null
+  isSuperAdmin: boolean
+}
+
 type UserCompliance = {
   compliant: boolean
   deadline?: Date
@@ -65,12 +70,21 @@ export class MfaEnforcementService {
     return { enforced: true, policy }
   }
 
-  async listPolicies(filters?: EnforcementPolicyListFilters): Promise<MfaEnforcementPolicy[]> {
+  async getPolicyById(id: string): Promise<MfaEnforcementPolicy | null> {
+    return this.em.findOne(MfaEnforcementPolicy, { id, deletedAt: null })
+  }
+
+  async listPolicies(
+    filters?: EnforcementPolicyListFilters,
+    actor?: EnforcementActorContext,
+  ): Promise<MfaEnforcementPolicy[]> {
+    const tenantConstraint = actor && !actor.isSuperAdmin ? { tenantId: actor.tenantId } : {}
     return this.em.find(
       MfaEnforcementPolicy,
       {
         deletedAt: null,
         ...(filters?.scope ? { scope: filters.scope } : {}),
+        ...tenantConstraint,
       },
       {
         orderBy: { updatedAt: 'desc' },
@@ -81,8 +95,10 @@ export class MfaEnforcementService {
   async getComplianceReport(
     scope: EnforcementScope,
     scopeId?: string,
+    actor?: EnforcementActorContext,
   ): Promise<ComplianceReport> {
     const { tenantId, organizationId } = this.resolveScopeFilters(scope, scopeId)
+    this.assertActorOwnsScopeFilters(actor, scope, tenantId)
     const users = await this.em.find(User, {
       deletedAt: null,
       ...(tenantId ? { tenantId } : {}),
@@ -123,8 +139,10 @@ export class MfaEnforcementService {
   async createPolicy(
     data: EnforcementPolicyInput,
     adminId: string,
+    actor?: EnforcementActorContext,
   ): Promise<MfaEnforcementPolicy> {
     const normalized = this.normalizePolicyInput(data)
+    this.assertActorOwnsScopeFilters(actor, normalized.scope, normalized.tenantId)
     const existing = await this.findPolicyByScope(
       normalized.scope,
       normalized.tenantId ?? undefined,
@@ -176,6 +194,7 @@ export class MfaEnforcementService {
     id: string,
     data: UpdateEnforcementPolicyInput,
     adminId: string,
+    actor?: EnforcementActorContext,
   ): Promise<MfaEnforcementPolicy> {
     const policy = await this.em.findOne(MfaEnforcementPolicy, {
       id,
@@ -184,6 +203,7 @@ export class MfaEnforcementService {
     if (!policy) {
       throw new MfaEnforcementServiceError('Enforcement policy not found', 404)
     }
+    this.assertActorOwnsScopeFilters(actor, policy.scope, policy.tenantId ?? null)
 
     const mergedInput = this.normalizePolicyInput({
       scope: data.scope ?? policy.scope,
@@ -196,6 +216,8 @@ export class MfaEnforcementService {
           ? (policy.enforcementDeadline ?? null)
           : data.enforcementDeadline,
     })
+
+    this.assertActorOwnsScopeFilters(actor, mergedInput.scope, mergedInput.tenantId)
 
     if (
       mergedInput.scope !== policy.scope ||
@@ -231,7 +253,7 @@ export class MfaEnforcementService {
     return policy
   }
 
-  async deletePolicy(id: string): Promise<void> {
+  async deletePolicy(id: string, actor?: EnforcementActorContext): Promise<void> {
     const policy = await this.em.findOne(MfaEnforcementPolicy, {
       id,
       deletedAt: null,
@@ -239,6 +261,7 @@ export class MfaEnforcementService {
     if (!policy) {
       throw new MfaEnforcementServiceError('Enforcement policy not found', 404)
     }
+    this.assertActorOwnsScopeFilters(actor, policy.scope, policy.tenantId ?? null)
 
     const now = new Date()
     policy.deletedAt = now
@@ -312,6 +335,23 @@ export class MfaEnforcementService {
         orderBy: { updatedAt: 'desc' },
       },
     )
+  }
+
+  private assertActorOwnsScopeFilters(
+    actor: EnforcementActorContext | undefined,
+    scope: EnforcementScope,
+    tenantId: string | null | undefined,
+  ): void {
+    if (!actor || actor.isSuperAdmin) return
+    if (scope === EnforcementScope.PLATFORM) {
+      throw new MfaEnforcementServiceError(
+        'Platform scope requires platform administrator privileges.',
+        403,
+      )
+    }
+    if (!tenantId || tenantId !== actor.tenantId) {
+      throw new MfaEnforcementServiceError('Not authorized for the requested scope.', 403)
+    }
   }
 
   private resolveScopeFilters(

--- a/packages/enterprise/src/modules/security/services/__tests__/MfaAdminService.test.ts
+++ b/packages/enterprise/src/modules/security/services/__tests__/MfaAdminService.test.ts
@@ -1,5 +1,5 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { emitSecurityEvent } from '../../events'
 import { MfaAdminService, MfaAdminServiceError } from '../MfaAdminService'
 
@@ -9,6 +9,7 @@ jest.mock('../../events', () => ({
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findWithDecryption: jest.fn(),
+  findOneWithDecryption: jest.fn(),
 }))
 
 type MockMethod = {
@@ -29,10 +30,28 @@ type MockRecoveryCode = {
   usedAt?: Date | null
 }
 
+type MockUser = {
+  id: string
+  tenantId: string
+  organizationId: string
+  email: string
+  deletedAt: null
+}
+
 function createContext() {
   const methods: MockMethod[] = []
   const recoveryCodes: MockRecoveryCode[] = []
-  const users = new Set<string>(['user-1'])
+  const users = new Map<string, MockUser>([
+    ['user-1', { id: 'user-1', tenantId: 'tenant-1', organizationId: 'org-1', email: 'user@example.com', deletedAt: null }],
+  ])
+
+  mockedFindOneWithDecryption.mockImplementation(async (_em, _entity, query) => {
+    const id = (query as { id?: string }).id
+    if (typeof id === 'string' && users.has(id)) {
+      return users.get(id) as never
+    }
+    return null as never
+  })
 
   const em = {
     find: jest.fn(async (_entity: unknown, query: Record<string, unknown>) => {
@@ -57,13 +76,7 @@ function createContext() {
     }),
     findOne: jest.fn(async (_entity: unknown, query: Record<string, unknown>) => {
       if (typeof query.id === 'string' && users.has(query.id) && query.deletedAt === null) {
-        return {
-          id: query.id,
-          tenantId: 'tenant-1',
-          organizationId: 'org-1',
-          email: 'user@example.com',
-          deletedAt: null,
-        }
+        return users.get(query.id) ?? null
       }
       return null
     }),
@@ -96,6 +109,7 @@ function createContext() {
 }
 
 const mockedFindWithDecryption = findWithDecryption as jest.MockedFunction<typeof findWithDecryption>
+const mockedFindOneWithDecryption = findOneWithDecryption as jest.MockedFunction<typeof findOneWithDecryption>
 const mockedEmitSecurityEvent = emitSecurityEvent as jest.MockedFunction<typeof emitSecurityEvent>
 
 describe('MfaAdminService', () => {
@@ -184,7 +198,7 @@ describe('MfaAdminService', () => {
 
   test('bulkComplianceCheck returns compliance data for all tenant users', async () => {
     const { service, methods, users, mfaEnforcementService } = createContext()
-    users.add('user-2')
+    users.set('user-2', { id: 'user-2', tenantId: 'tenant-1', organizationId: 'org-2', email: 'two@example.com', deletedAt: null })
     mockedFindWithDecryption.mockResolvedValue([
       {
         id: 'user-1',
@@ -251,5 +265,56 @@ describe('MfaAdminService', () => {
       statusCode: 400,
       message: 'Tenant ID is required',
     } satisfies Partial<MfaAdminServiceError>)
+  })
+
+  test('getUserMfaStatus rejects a foreign-tenant target for a non-superadmin actor with 404', async () => {
+    const { service } = createContext()
+    await expect(
+      service.getUserMfaStatus('user-1', { tenantId: 'tenant-2', isSuperAdmin: false }),
+    ).rejects.toMatchObject({
+      name: 'MfaAdminServiceError',
+      statusCode: 404,
+      message: 'User not found',
+    } satisfies Partial<MfaAdminServiceError>)
+  })
+
+  test('getUserMfaStatus allows a same-tenant target for a non-superadmin actor', async () => {
+    const { service } = createContext()
+    const status = await service.getUserMfaStatus('user-1', { tenantId: 'tenant-1', isSuperAdmin: false })
+    expect(status.enrolled).toBe(false)
+  })
+
+  test('getUserMfaStatus allows a superadmin actor regardless of tenant', async () => {
+    const { service } = createContext()
+    const status = await service.getUserMfaStatus('user-1', { tenantId: 'tenant-2', isSuperAdmin: true })
+    expect(status.enrolled).toBe(false)
+  })
+
+  test('resetUserMfa rejects a foreign-tenant target for a non-superadmin actor with 404', async () => {
+    const { service } = createContext()
+    await expect(
+      service.resetUserMfa('admin-1', 'user-1', 'security incident', { tenantId: 'tenant-2', isSuperAdmin: false }),
+    ).rejects.toMatchObject({
+      name: 'MfaAdminServiceError',
+      statusCode: 404,
+      message: 'User not found',
+    } satisfies Partial<MfaAdminServiceError>)
+  })
+
+  test('bulkComplianceCheck rejects a foreign tenant for a non-superadmin actor with 403', async () => {
+    const { service } = createContext()
+    await expect(
+      service.bulkComplianceCheck('tenant-2', { tenantId: 'tenant-1', isSuperAdmin: false }),
+    ).rejects.toMatchObject({
+      name: 'MfaAdminServiceError',
+      statusCode: 403,
+    } satisfies Partial<MfaAdminServiceError>)
+  })
+
+  test('bulkComplianceCheck allows a superadmin actor to query any tenant', async () => {
+    const { service } = createContext()
+    mockedFindWithDecryption.mockResolvedValue([] as never)
+    const result = await service.bulkComplianceCheck('tenant-2', { tenantId: 'tenant-1', isSuperAdmin: true })
+    expect(result).toEqual([])
   })
 })

--- a/packages/enterprise/src/modules/security/services/__tests__/MfaEnforcementService.test.ts
+++ b/packages/enterprise/src/modules/security/services/__tests__/MfaEnforcementService.test.ts
@@ -295,6 +295,102 @@ describe('MfaEnforcementService', () => {
     })
   })
 
+  test('getComplianceReport rejects platform scope for a non-superadmin without querying users', async () => {
+    const { service, em } = createContext()
+
+    await expect(
+      service.getComplianceReport(EnforcementScope.PLATFORM, undefined, {
+        tenantId: 'tenant-1',
+        isSuperAdmin: false,
+      }),
+    ).rejects.toMatchObject({ statusCode: 403 })
+
+    expect(em.find).not.toHaveBeenCalledWith(User, expect.anything())
+  })
+
+  test('getComplianceReport rejects a foreign tenant for a non-superadmin without querying users', async () => {
+    const { service, em } = createContext()
+
+    await expect(
+      service.getComplianceReport(EnforcementScope.TENANT, 'tenant-2', {
+        tenantId: 'tenant-1',
+        isSuperAdmin: false,
+      }),
+    ).rejects.toMatchObject({ statusCode: 403 })
+
+    expect(em.find).not.toHaveBeenCalledWith(User, expect.anything())
+  })
+
+  test('getComplianceReport allows a superadmin to query platform scope', async () => {
+    const { service, users } = createContext()
+    users.push({ id: 'user-1', tenantId: 'tenant-1', organizationId: 'org-1', deletedAt: null })
+
+    const report = await service.getComplianceReport(EnforcementScope.PLATFORM, undefined, {
+      tenantId: 'tenant-9',
+      isSuperAdmin: true,
+    })
+
+    expect(report.total).toBe(1)
+  })
+
+  test('listPolicies constrains a non-superadmin to its own tenant', async () => {
+    const { service, em } = createContext()
+
+    await service.listPolicies(undefined, { tenantId: 'tenant-1', isSuperAdmin: false })
+
+    expect(em.find).toHaveBeenCalledWith(
+      MfaEnforcementPolicy,
+      expect.objectContaining({ tenantId: 'tenant-1' }),
+      expect.anything(),
+    )
+  })
+
+  test('listPolicies does not constrain a superadmin', async () => {
+    const { service, em } = createContext()
+
+    await service.listPolicies(undefined, { tenantId: 'tenant-1', isSuperAdmin: true })
+
+    const call = em.find.mock.calls.find((entry) => entry[0] === MfaEnforcementPolicy)
+    expect(call?.[1]).not.toHaveProperty('tenantId')
+  })
+
+  test('createPolicy rejects a foreign tenant scope for a non-superadmin', async () => {
+    const { service, policies } = createContext()
+
+    await expect(
+      service.createPolicy(
+        { scope: EnforcementScope.TENANT, tenantId: 'tenant-2', isEnforced: true },
+        'admin-1',
+        { tenantId: 'tenant-1', isSuperAdmin: false },
+      ),
+    ).rejects.toMatchObject({ statusCode: 403 })
+
+    expect(policies).toHaveLength(0)
+  })
+
+  test('deletePolicy rejects when the actor does not own the policy scope', async () => {
+    const { service, policies } = createContext()
+    policies.push({
+      id: 'policy-1',
+      scope: EnforcementScope.TENANT,
+      tenantId: 'tenant-2',
+      organizationId: null,
+      isEnforced: true,
+      allowedMethods: null,
+      enforcementDeadline: null,
+      enforcedBy: 'admin-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    })
+
+    await expect(
+      service.deletePolicy('policy-1', { tenantId: 'tenant-1', isSuperAdmin: false }),
+    ).rejects.toMatchObject({ statusCode: 403 })
+
+    expect(policies[0].deletedAt).toBeNull()
+  })
+
   test('checkUserCompliance enforces allowed methods filter', async () => {
     const { service, policies, methods } = createContext()
     mockedFindOneWithDecryption.mockResolvedValue({


### PR DESCRIPTION
## Summary

Implements the **enterprise** portion of #2612 (comment 3) — the cross-tenant authorization defects in the `security` module (`packages/enterprise`). Same root cause as the OSS PR (capability checked, target/scope ownership not), but the **easiest-to-exploit** instances: every tenant admin holds `security.admin.manage` (via the `security.*` default grant), which previously allowed reading/acting across **all** tenants.

Spec: [`.ai/specs/enterprise/2026-06-05-security-mfa-cross-tenant-authorization.md`](.ai/specs/enterprise/2026-06-05-security-mfa-cross-tenant-authorization.md).

> ⚠️ **Stacked on #2636** (the OSS PR). Base is `fix/2612-tenant-ownership-module-acl`, not `develop`, so this PR's diff stays focused on the enterprise changes. The enterprise spec doc lives in #2636. Merge after #2636, or rebase onto `develop` once it lands. (The reused `enforceTenantSelection`/`resolveIsSuperAdmin` helpers already exist on `develop`, so there is no hard code dependency — only the shared spec doc.)

## What landed (2 verticals + docs)

**Users-MFA vertical**
- `api/users/_shared.ts`: `assertActorCanAccessSecurityUserTarget` (foreign/null-tenant/unknown target → `404`, out-of-org → `403`) and `assertActorOwnsTenantScope` (`enforceTenantSelection`).
- `mfa/status` + `mfa/reset` gate the target user — **`404` cross-tenant even with a valid sudo token** (sudo validates the actor, not the target).
- `mfa/compliance` resolves the tenant via `enforceTenantSelection` (foreign `tenantId` → `403`).
- `MfaAdminService`: `findUserById` → `findOneWithDecryption`; optional `{ tenantId, isSuperAdmin }` actor-context backstop.

**Enforcement vertical**
- `api/enforcement/_shared.ts`: `assertActorOwnsEnforcementScope` — `PLATFORM` → super-admin; `TENANT`/`ORGANISATION` → tenant + org-membership ownership.
- Compliance, list (non-super-admin constrained to own tenant), create (pre-dispatch ownership), update/delete (load policy via new `getPolicyById`, assert current + requested scope).
- `MfaEnforcementService`: actor-context backstop on `getComplianceReport`/`listPolicies`/`createPolicy`/`updatePolicy`/`deletePolicy`; the unfiltered `em.find(User, { deletedAt: null })` `PLATFORM` path is now **unreachable for non-super-admins**.

## Behavior change (see `UPGRADE_NOTES.md` → 0.6.4 → 0.6.5)
Platform-wide and cross-tenant MFA-admin / enforcement views now require a platform/super-admin. A non-super-admin gets `404` (foreign user target) or `403` (`scope=platform`, foreign tenant/org scope). Service methods gained an **optional, backward-compatible** actor-context param. No DB schema change; no ACL feature IDs renamed.

## Validation
- `yarn workspace @open-mercato/enterprise build` + `typecheck` green (**zero** errors).
- Full `security` module suite: **171 tests** green (45 new/changed across both verticals).
- `TC-SEC-005` (superadmin enforcement) unchanged; `TC-SEC-007` positive path is same-tenant, cross-tenant negatives covered by route/service unit tests.
- No `lint` script in the enterprise workspace; the TS build is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
