### PR TITLE
fix(ui): RecordNotFoundState neutral empty state (#2127)

### DIFF
--- a/.ai/specs/2026-06-04-record-not-found-default.md
+++ b/.ai/specs/2026-06-04-record-not-found-default.md
@@ -1,0 +1,152 @@
+# RecordNotFoundState — Improve UX and make it the default not-found component
+
+- Date: 2026-06-04
+- Issue: [#2127](https://github.com/open-mercato/open-mercato/issues/2127)
+- Scope: OSS (`packages/ui`, `packages/core`)
+- Status: Draft
+
+## Problem
+
+`RecordNotFoundState` (`packages/ui/src/backend/detail/RecordNotFoundState.tsx`) renders its body
+through `ErrorMessage`, which is a **destructive alert** (`border-destructive/50 bg-destructive/5
+text-destructive`, `role="alert"`, `AlertCircle` icon). A missing record therefore looks like a
+critical, alarming error (red box, red text) instead of a calm, neutral "nothing here" state.
+
+The component is already adopted as the de-facto not-found UI across **39 backend detail/edit pages**,
+but because the component itself wraps `ErrorMessage`, every one of those pages shows the same red
+alert. It also has **no unit test** and **no entry** in the DS component reference. A handful of
+backend detail/edit pages still render their own not-found state via `ErrorMessage`/`throw` instead
+of using the component.
+
+## Goals
+
+1. Rewrite `RecordNotFoundState` to render a neutral, centered empty state using the existing
+   `EmptyState` primitive (`variant="subtle"`), fixing the UX on all 39 adopters at once.
+2. Keep the public API **1:1 backward compatible** so no adopter changes are required.
+3. Add a unit test for the component.
+4. Document it in `.ai/ui-components.md` and correct the guidance in `packages/ui/AGENTS.md`.
+5. Migrate the 4 remaining backend detail/edit stragglers that still hand-roll not-found.
+6. Bring the portal / public / embedded not-found surfaces into the same neutral UX. They render a
+   destructive red alert / raw red text today (same root problem as the bug). Where the backend
+   `RecordNotFoundState` API does not fit (frontend/portal layer, no backend "back to list"), render
+   the shared `EmptyState` primitive (`variant="subtle"`) directly to keep neutral, DS-consistent UX.
+
+## Non-goals (explicitly out of scope)
+
+- `auth/frontend/login.tsx` inline "Tenant not found" (~line 387): an inline warning rendered inside
+  the login card during tenant selection, not a page-level record-not-found. Leave as-is.
+- Generalizing `RecordNotFoundState` itself into a frontend/portal export path (its `@open-mercato/ui/
+  backend/detail` location and `backHref`-to-backend-list shape stay backend-scoped); portal/public use
+  the `EmptyState` primitive instead.
+
+## Design
+
+### Component rewrite (`packages/ui/src/backend/detail/RecordNotFoundState.tsx`)
+
+Compose `EmptyState` from `@open-mercato/ui/primitives/empty-state` instead of `ErrorMessage`:
+
+- `variant="subtle"` — no dashed box; round muted icon container; reads as a full-page state.
+- Default leading icon (`SearchX` from `lucide-react`), overridable via a new optional `icon` prop.
+- `title` = `label`; `description` = `description`.
+- Action = the provided `action` node, else the default back button when `backHref` is set:
+  `<Button asChild variant="outline" size="sm"><Link href={backHref}>{backLabel ?? t(...)}</Link></Button>`.
+  The back affordance **MUST remain a real `<a>` (role `link`)** — integration tests assert
+  `getByRole('link', { name: /back to .../i })` + `href`.
+- Keep the outer centering wrapper (`min-h-[50vh]`, centered) and `className` passthrough.
+- Preserve the `formatErrorMessageLabel` safety net (reuse the exported helper) so a leaked technical
+  i18n key still renders readably.
+
+**Public API** (unchanged + additive):
+
+```ts
+export type RecordNotFoundStateProps = {
+  label: string
+  description?: string
+  backHref?: string
+  backLabel?: string
+  action?: React.ReactNode
+  className?: string
+  icon?: React.ReactNode   // NEW, optional, additive — defaults to <SearchX />
+}
+```
+
+No exports removed; only an optional prop added → additive, non-breaking per `BACKWARD_COMPATIBILITY.md`.
+
+### Straggler migration (4 backend detail/edit pages)
+
+Each currently does `if (!record) throw new Error(t('...notFound...'))` inside the loader, folds it
+into the generic `error` state, and renders `<ErrorMessage label={error ?? notFound} />`. Migrate to
+the same shape `currencies/[id]/page.tsx` already uses: a dedicated `isNotFound` boolean rendered via
+`RecordNotFoundState`, with `ErrorMessage` reserved for genuine load failures.
+
+| # | File | Back target |
+|---|------|-------------|
+| 1 | `packages/core/src/modules/staff/backend/staff/timesheets/projects/[id]/page.tsx` | projects list |
+| 2 | `packages/core/src/modules/staff/backend/staff/timesheets/projects/[id]/edit/page.tsx` | project detail/list |
+| 3 | `packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/create/page.tsx` | parent product (`/backend/catalog/products/${productId}`) |
+| 4 | `packages/core/src/modules/resources/backend/resources/resource-types/[id]/edit/page.tsx` | resource-types list |
+
+For #3 the parent **product** is the missing record; show `RecordNotFoundState` (back to product)
+instead of rendering the create form behind an inline error banner.
+
+`currencies/[id]/page.tsx` is already correct (uses `RecordNotFoundState` + a separate generic
+`ErrorMessage`) and is intentionally NOT in this list.
+
+### Portal / public / embedded not-found (neutral `EmptyState`)
+
+These also render a red alarm today and move to a neutral state. Backend `RecordNotFoundState` is not
+used here (see Non-goals); instead render the `EmptyState` primitive with `variant="subtle"`.
+
+| # | File | Current | Approach |
+|---|------|---------|----------|
+| 5 | `packages/core/src/modules/portal/frontend/[orgSlug]/portal/page.tsx` | `<Alert variant="destructive">` org-not-found | `EmptyState` `subtle` `lg`, message `portal.org.invalid`, no back-to-list action |
+| 6 | `packages/core/src/modules/portal/frontend/[orgSlug]/portal/login/page.tsx` | same | same |
+| 7 | `packages/core/src/modules/portal/frontend/[orgSlug]/portal/signup/page.tsx` | same | same |
+| 8 | `packages/core/src/modules/portal/frontend/[orgSlug]/portal/reset-password/page.tsx` | same | same |
+| 9 | `packages/core/src/modules/sales/frontend/quote/[token]/page.tsx` | raw `<p className="text-destructive">` | `EmptyState` `subtle`, message `sales.quotes.public.notFound`; keep the combined `error || !data` branch |
+| 10 | `packages/core/src/modules/sales/components/channels/ChannelOfferForm.tsx` | `throw notFound` swallowed into a generic load error | split a `notFound` flag from the generic error; render `RecordNotFoundState` (backend sales) at the top-level return, `backHref` → the channel's offers list |
+
+Item 10 is the highest-risk change (a 1300-line form where not-found is currently buried) and will be
+handled last, after the component and the simpler migrations are green.
+
+## Backward Compatibility
+
+- `RecordNotFoundState` props/exports unchanged; one optional `icon` prop added (additive).
+- Visual change (red alert → neutral empty state) is the intended bug fix.
+- The 4 dedicated integration tests (`TC-UX-006/007/008/009`) assert on the not-found **text** and the
+  **back link** (`role=link` + href), not on `role="alert"` or destructive styling — verified
+  compatible with the rewrite.
+
+## Test / Integration Coverage
+
+- **Unit (new):** `packages/ui/src/backend/detail/__tests__/RecordNotFoundState.test.tsx` — renders
+  title, renders back link with correct href when `backHref` set, renders custom `action`, is **not**
+  `role="alert"` (regression guard against reintroducing the destructive box).
+- **Existing integration (must stay green):** `TC-UX-006` (people), `TC-UX-007` (documents),
+  `TC-UX-008` (back nav / companies), `TC-UX-009` (document orders) — cover the 39-adopter rendering
+  path through the rewritten component.
+- **Migrated stragglers:** covered by typecheck + the shared rendering path; an integration test for a
+  migrated staff-timesheets-project not-found is optional follow-up (no new API surface).
+- **Portal / public / `ChannelOfferForm`:** UI-only swaps (destructive alert / raw red text →
+  neutral `EmptyState`; buried throw → explicit not-found). No API or route changes. Existing portal
+  and sales suites must stay green; verify the affected pages still mount with `yarn typecheck` +
+  targeted UI mounting.
+
+## Validation
+
+```bash
+yarn build:packages
+yarn typecheck
+yarn lint
+yarn workspace @open-mercato/ui test
+# + the four TC-UX-00x integration specs via the ephemeral runner
+```
+
+## Changelog
+
+- `RecordNotFoundState` now renders a neutral empty state (was a destructive red alert); fixes #2127.
+- Added unit test + DS reference entry; corrected `packages/ui/AGENTS.md` not-found guidance.
+- Migrated 4 backend detail/edit pages to `RecordNotFoundState`.
+- Portal "Organization not found" (4 pages) and the public quote page now use a neutral `EmptyState`
+  instead of a destructive alert / raw red text.
+- `ChannelOfferForm` distinguishes a missing offer from a load error and renders a neutral not-found.

--- a/.ai/specs/2026-06-05-record-load-error-classification.md
+++ b/.ai/specs/2026-06-05-record-load-error-classification.md
@@ -1,0 +1,110 @@
+# Consistent record-load error classification (bad/invalid id → neutral not-found)
+
+- Date: 2026-06-05
+- Scope: OSS (`packages/ui`, detail/edit pages across `packages/core` + provider packages)
+- Status: Draft (follow-up to #2127)
+- Related: #2127 (`RecordNotFoundState` DS component) — this spec builds on it but is intentionally a separate PR.
+
+## Problem
+
+When a backend detail/edit page is opened with a **malformed or stale id** in the URL, the UX is
+inconsistent and often poor:
+
+- Strict pages (e.g. scheduler `/backend/config/scheduled-jobs/<bad>`) validate the id (route-level
+  zod / `isUuid`) → the API returns `400 { error: 'Invalid input' }` → the page shows a bare, scary
+  red `ErrorMessage` ("Error / Invalid input"). From the user's perspective the record simply does
+  not exist; a 400 alarm is the wrong signal.
+- CRUD-list pages using `?ids=<id>` go through `parseIdsParam`, which **silently drops** invalid
+  UUIDs (`parseIdsParam('invalid') → []`). Depending on how the empty-ids filter is treated
+  (match-none vs filter-skipped) the page may show a neutral not-found **or** an unrelated record —
+  **needs audit**.
+- Net result: the same user action ("open a bad/old URL") produces a red error on one page, a
+  not-found on another, and possibly a wrong record on a third.
+
+The id validation has **no single choke-point** — it is distributed across:
+- `packages/shared/src/lib/crud/factory.ts:539` — `ZodError` → `400 'Invalid input'`
+- `factory.ts` update path — `if (!isUuid(id)) return json({ error: 'Invalid id' }, { status: 400 })`
+- per-route query schemas validating `id`/`ids`
+- custom catch-all routes (scheduler, etc.)
+
+## Goal
+
+A malformed/missing id should land the user on the **neutral `RecordNotFoundState`** (from #2127),
+not a destructive error — consistently across every record-backed detail/edit page. Genuine failures
+(5xx / network) keep the red `ErrorMessage`; authorization failures keep `AccessDeniedMessage`.
+
+## Design — client-side classification helper (NOT an API contract change)
+
+Because the validation is distributed and changing API status codes (400 → 200/404) risks breaking
+consumers and integration tests, classify on the **client** at load time.
+
+Add a shared helper (e.g. `@open-mercato/ui/backend/detail`):
+
+```ts
+export type RecordLoadOutcome = 'notFound' | 'forbidden' | 'error'
+
+/** Classify a thrown load error so detail pages pick the right page state. */
+export function classifyRecordLoadError(err: unknown): RecordLoadOutcome {
+  const status = extractHttpStatus(err) // reads status off CrudHttpError / apiCall errors
+  if (status === 404) return 'notFound'
+  if (status === 400) return 'notFound' // malformed id ⇒ "this record can't exist"
+  if (status === 401 || status === 403) return 'forbidden'
+  return 'error' // 5xx, network, unknown
+}
+```
+
+Detail/edit pages then converge on:
+
+```ts
+catch (err) {
+  const outcome = classifyRecordLoadError(err)
+  if (outcome === 'notFound') setIsNotFound(true)
+  else if (outcome === 'forbidden') setIsForbidden(true) // AccessDeniedMessage
+  else setError(message)
+}
+```
+
+Open option (optimization): pages whose id is always a UUID may **pre-validate** the route id and set
+`isNotFound` without a network round-trip. Decide per-page; not required for correctness.
+
+### Caveat to resolve during implementation
+- Confirm `400` should map to `notFound` universally. A 400 from a *body/payload* validation on a
+  mutation is different from a 400 on a *bad id GET*. The helper is for the **record-load (GET)** path
+  only — do not route mutation/validation 400s through it.
+
+## Scope
+
+All record-backed detail/edit pages that already render `RecordNotFoundState` (the ~40 adopters from
+#2127) plus any that still hand-roll load handling. Reference list: derive from
+`grep -rl RecordNotFoundState --include=*.tsx packages apps` (backend pages). Notable strict-validation
+page to fix first (the reported case): `packages/scheduler/.../config/scheduled-jobs/[id]/page.tsx`.
+
+Also audit and fix the `?ids=` "drops invalid id" behavior so a dropped id yields **not-found**, never
+the full list / a wrong record.
+
+## Backward Compatibility
+
+- **No API changes** — status codes and payloads stay as-is; classification is client-only.
+- Pages keep the red `ErrorMessage` for genuine 5xx/network errors and `AccessDeniedMessage` for 401/403.
+- Builds on #2127's `RecordNotFoundState`; no contract surface changes.
+
+## Test / Integration Coverage
+
+- **Unit:** `classifyRecordLoadError` — 404/400 → notFound, 401/403 → forbidden, 500/network → error;
+  plus `extractHttpStatus` across `CrudHttpError` / `apiCall` error shapes.
+- **Integration (key UI path):** open a detail page with a **malformed id** → assert the neutral
+  not-found (title + back link, `role!="alert"`), NOT a red "Invalid input" box. Add for at least one
+  strict-validation page (scheduler) and one CRUD-list page (customers companies).
+
+## Validation
+
+```bash
+yarn build:packages && yarn typecheck && yarn lint
+yarn workspace @open-mercato/ui test
+# + the new malformed-id integration specs via the ephemeral runner
+```
+
+## Out of scope
+
+- Changing API HTTP status codes for malformed ids (kept 400/404 — classification is client-side).
+- The `RecordNotFoundState` component itself (delivered in #2127).

--- a/.ai/ui-components.md
+++ b/.ai/ui-components.md
@@ -2165,6 +2165,67 @@ Title type scale: `text-sm` for `sm` / `default`, `text-base` for `lg`. Descript
 
 ---
 
+## RecordNotFoundState
+
+```typescript
+import { RecordNotFoundState, type RecordNotFoundStateProps } from '@open-mercato/ui/backend/detail'
+```
+
+The **default not-found state for backend detail/edit pages**. When a record id resolves to nothing,
+render this instead of a `CrudForm`/detail layout. It composes `EmptyState` (`variant='subtle'`) into
+a page-centered, neutral state — a missing record is **not** an error, so it must never be shown
+through the destructive `ErrorMessage`. Keep `ErrorMessage` for genuine load/validation failures.
+
+### Quick usage
+
+```tsx
+if (isNotFound) {
+  return (
+    <Page>
+      <PageBody>
+        <RecordNotFoundState
+          label={t('customers.companies.detail.error.notFound', 'Company not found.')}
+          backHref="/backend/customers/companies"
+          backLabel={t('customers.companies.backToList', 'Back to companies')}
+        />
+      </PageBody>
+    </Page>
+  )
+}
+```
+
+### Props
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `label` | `string` | — | Required. The title (e.g. "Company not found."). Pass an already-translated string. |
+| `description` | `string` | — | Optional muted line under the title. |
+| `backHref` | `string` | — | When set, renders a default "back" link (`<Button asChild variant="outline">` wrapping a `next/link`, so it stays a real `<a>` / `role="link"`). |
+| `backLabel` | `string` | `t('ui.recordNotFound.backToList', 'Back to list')` | Label for the default back link. |
+| `action` | `React.ReactNode` | — | Custom recovery action; replaces the default back link entirely. |
+| `icon` | `React.ReactNode` | `<SearchX className="h-6 w-6" />` | Optional leading icon, wrapped in EmptyState's round muted box. |
+| `className` | `string` | — | Applied to the outer centering wrapper (`min-h-[50vh]`). |
+
+### MUST rules
+
+- Use it for the dedicated `notFound` page state on record-backed backend detail/edit pages — keep it
+  separate from a generic `error` state (which still uses `ErrorMessage`).
+- Always pass a `backHref` (or a custom `action`) so the user has a recovery path; do not render a
+  dead-end not-found.
+- Pass `label`/`backLabel` through `useT()` — the component only defaults the back label.
+- Portal / public (frontend) pages have no backend "back to list": use `EmptyState`
+  (`variant='subtle'`, `size='lg'`) directly there instead of this backend component.
+
+### Anti-patterns
+
+- Rendering not-found through `ErrorMessage` (red `role="alert"` box) → use `RecordNotFoundState`.
+- Ad hoc `<div className="text-destructive">…not found…</div>` or `<Alert variant="destructive">` for a
+  missing record → neutral `RecordNotFoundState` / `EmptyState`.
+- `throw new Error('… not found')` inside the loader and folding it into the generic `error` state →
+  set a dedicated `isNotFound` flag and render `RecordNotFoundState`.
+
+---
+
 ## Skeleton
 
 ```typescript

--- a/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/create/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/create/page.tsx
@@ -9,7 +9,7 @@ import { createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors
 import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customFieldValues'
 import { apiCall, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
-import { ErrorMessage } from '@open-mercato/ui/backend/detail'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { E } from '#generated/entities.ids.generated'
 import {
@@ -70,6 +70,7 @@ export default function CreateVariantPage({ params }: { params?: { productId?: s
   const [productTaxRate, setProductTaxRate] = React.useState<number | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
 
   React.useEffect(() => {
     const loadPriceKinds = async () => {
@@ -133,13 +134,17 @@ export default function CreateVariantPage({ params }: { params?: { productId?: s
     async function load() {
       setLoading(true)
       setError(null)
+      setIsNotFound(false)
       try {
         const res = await apiCall<ProductResponse>(
           `/api/catalog/products?id=${encodeURIComponent(productId!)}&page=1&pageSize=1`,
         )
         if (!res.ok) throw new Error(t('catalog.variants.form.errors.load', 'Failed to load product context.'))
         const record = Array.isArray(res.result?.items) ? res.result?.items?.[0] : undefined
-        if (!record) throw new Error(t('catalog.products.edit.errors.notFound', 'Product not found.'))
+        if (!record) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         const metadata = (record.metadata ?? {}) as Record<string, unknown>
         const taxRateId =
           typeof (record as any).tax_rate_id === 'string'
@@ -283,9 +288,21 @@ export default function CreateVariantPage({ params }: { params?: { productId?: s
     return (
       <Page>
         <PageBody>
-          <div className="rounded border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-            {t('catalog.variants.form.errors.productMissing', 'Product identifier is missing.')}
-          </div>
+          <ErrorMessage label={t('catalog.variants.form.errors.productMissing', 'Product identifier is missing.')} />
+        </PageBody>
+      </Page>
+    )
+  }
+
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('catalog.products.edit.errors.notFound', 'Product not found.')}
+            backHref="/backend/catalog/products"
+            backLabel={t('catalog.products.edit.actions.backToList', 'Back to products')}
+          />
         </PageBody>
       </Page>
     )

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/login/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/login/page.tsx
@@ -7,6 +7,8 @@ import { PasswordInput } from '@open-mercato/ui/primitives/password-input'
 import { Label } from '@open-mercato/ui/primitives/label'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Alert, AlertDescription } from '@open-mercato/ui/primitives/alert'
+import { EmptyState } from '@open-mercato/ui/primitives/empty-state'
+import { SearchX } from 'lucide-react'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { usePortalContext } from '@open-mercato/ui/portal/PortalContext'
@@ -84,9 +86,12 @@ export default function PortalLoginPage({ params }: Props) {
   if (tenant.error) {
     return (
       <div className="mx-auto w-full max-w-md py-12">
-        <Alert variant="destructive">
-          <AlertDescription>{t('portal.org.invalid', 'Organization not found.')}</AlertDescription>
-        </Alert>
+        <EmptyState
+          variant="subtle"
+          size="lg"
+          icon={<SearchX className="h-6 w-6" aria-hidden />}
+          title={t('portal.org.invalid', 'Organization not found.')}
+        />
       </div>
     )
   }

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/page.tsx
@@ -5,37 +5,14 @@ import { useRouter } from 'next/navigation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
-import { Alert, AlertDescription } from '@open-mercato/ui/primitives/alert'
+import { EmptyState } from '@open-mercato/ui/primitives/empty-state'
+import { SearchX, ShoppingBag, User, Shield } from 'lucide-react'
 import { usePortalContext } from '@open-mercato/ui/portal/PortalContext'
 import { PortalFeatureCard } from '@open-mercato/ui/portal/components/PortalFeatureCard'
 import { InjectionSpot } from '@open-mercato/ui/backend/injection/InjectionSpot'
 import { PortalInjectionSpots } from '@open-mercato/ui/backend/injection/spotIds'
 
 type Props = { params: { orgSlug: string } }
-
-function ShoppingBagIcon({ className }: { className?: string }) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4Z" /><line x1="3" x2="21" y1="6" y2="6" /><path d="M16 10a4 4 0 0 1-8 0" />
-    </svg>
-  )
-}
-
-function UserIcon({ className }: { className?: string }) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" />
-    </svg>
-  )
-}
-
-function ShieldIcon({ className }: { className?: string }) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
-    </svg>
-  )
-}
 
 export default function PortalLandingPage({ params }: Props) {
   const t = useT()
@@ -62,9 +39,12 @@ export default function PortalLandingPage({ params }: Props) {
   if (tenant.error) {
     return (
       <div className="mx-auto w-full max-w-md py-12">
-        <Alert variant="destructive">
-          <AlertDescription>{t('portal.org.invalid', 'Organization not found.')}</AlertDescription>
-        </Alert>
+        <EmptyState
+          variant="subtle"
+          size="lg"
+          icon={<SearchX className="h-6 w-6" aria-hidden />}
+          title={t('portal.org.invalid', 'Organization not found.')}
+        />
       </div>
     )
   }
@@ -98,17 +78,17 @@ export default function PortalLandingPage({ params }: Props) {
 
       <section className="grid gap-4 sm:grid-cols-3">
         <PortalFeatureCard
-          icon={<ShoppingBagIcon className="size-5" />}
+          icon={<ShoppingBag className="size-5" />}
           title={t('portal.landing.feature.orders', 'Orders & Invoices')}
           description={t('portal.landing.feature.orders.description', 'Track your orders, download invoices, and view delivery status in real time.')}
         />
         <PortalFeatureCard
-          icon={<UserIcon className="size-5" />}
+          icon={<User className="size-5" />}
           title={t('portal.landing.feature.account', 'Account Management')}
           description={t('portal.landing.feature.account.description', 'Update your profile, manage team members, and configure your preferences.')}
         />
         <PortalFeatureCard
-          icon={<ShieldIcon className="size-5" />}
+          icon={<Shield className="size-5" />}
           title={t('portal.landing.feature.security', 'Secure Access')}
           description={t('portal.landing.feature.security.description', 'Role-based permissions, session management, and full audit trail.')}
         />

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/reset-password/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/reset-password/page.tsx
@@ -7,6 +7,8 @@ import { PasswordInput } from '@open-mercato/ui/primitives/password-input'
 import { Label } from '@open-mercato/ui/primitives/label'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Alert, AlertDescription } from '@open-mercato/ui/primitives/alert'
+import { EmptyState } from '@open-mercato/ui/primitives/empty-state'
+import { SearchX } from 'lucide-react'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { usePortalContext } from '@open-mercato/ui/portal/PortalContext'
@@ -96,9 +98,12 @@ export default function PortalResetPasswordPage({ params }: Props) {
   if (tenant.error) {
     return (
       <div className="mx-auto w-full max-w-md py-12">
-        <Alert variant="destructive">
-          <AlertDescription>{t('portal.org.invalid', 'Organization not found.')}</AlertDescription>
-        </Alert>
+        <EmptyState
+          variant="subtle"
+          size="lg"
+          icon={<SearchX className="h-6 w-6" aria-hidden />}
+          title={t('portal.org.invalid', 'Organization not found.')}
+        />
       </div>
     )
   }

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/signup/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/signup/page.tsx
@@ -8,6 +8,8 @@ import { PasswordInput } from '@open-mercato/ui/primitives/password-input'
 import { Label } from '@open-mercato/ui/primitives/label'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Alert, AlertDescription } from '@open-mercato/ui/primitives/alert'
+import { EmptyState } from '@open-mercato/ui/primitives/empty-state'
+import { SearchX, Check } from 'lucide-react'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { usePortalContext } from '@open-mercato/ui/portal/PortalContext'
@@ -74,9 +76,12 @@ export default function PortalSignupPage({ params }: Props) {
   if (tenant.error) {
     return (
       <div className="mx-auto w-full max-w-md py-12">
-        <Alert variant="destructive">
-          <AlertDescription>{t('portal.org.invalid', 'Organization not found.')}</AlertDescription>
-        </Alert>
+        <EmptyState
+          variant="subtle"
+          size="lg"
+          icon={<SearchX className="h-6 w-6" aria-hidden />}
+          title={t('portal.org.invalid', 'Organization not found.')}
+        />
       </div>
     )
   }
@@ -85,9 +90,7 @@ export default function PortalSignupPage({ params }: Props) {
     return (
       <div className="mx-auto w-full max-w-sm text-center">
         <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-foreground text-background">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-6">
-            <polyline points="20 6 9 17 4 12" />
-          </svg>
+          <Check className="size-6" />
         </div>
         <h1 className="text-2xl font-bold tracking-tight">{t('portal.signup.success.title', 'Check your email')}</h1>
         <p className="mt-1.5 text-sm text-muted-foreground">{t(

--- a/packages/core/src/modules/resources/backend/resources/resource-types/[id]/edit/page.tsx
+++ b/packages/core/src/modules/resources/backend/resources/resource-types/[id]/edit/page.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import { useRouter } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
-import { ErrorMessage } from '@open-mercato/ui/backend/detail'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
@@ -22,6 +22,7 @@ export default function ResourcesResourceTypeEditPage({ params }: { params?: { i
   const [initialValues, setInitialValues] = React.useState<ResourceTypeFormValues | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [resourceCount, setResourceCount] = React.useState(0)
 
   React.useEffect(() => {
@@ -30,6 +31,7 @@ export default function ResourcesResourceTypeEditPage({ params }: { params?: { i
     async function load() {
       setLoading(true)
       setError(null)
+      setIsNotFound(false)
       try {
         const payload = await readApiResultOrThrow<ResourceTypesResponse>(
           `/api/resources/resource-types?ids=${encodeURIComponent(resourceTypeId)}&page=1&pageSize=1`,
@@ -37,7 +39,10 @@ export default function ResourcesResourceTypeEditPage({ params }: { params?: { i
           { errorMessage: t('resources.resourceTypes.errors.load', 'Failed to load resource types.') },
         )
         const item = Array.isArray(payload.items) ? payload.items[0] : null
-        if (!item) throw new Error(t('resources.resourceTypes.errors.notFound', 'Resource type not found.'))
+        if (!item) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         if (!cancelled) {
           const customValues = extractCustomFieldValues(item)
           setInitialValues({
@@ -102,6 +107,20 @@ export default function ResourcesResourceTypeEditPage({ params }: { params?: { i
     flash(t('resources.resourceTypes.messages.deleted', 'Resource type deleted.'), 'success')
     router.push('/backend/resources/resource-types')
   }, [resourceCount, resourceTypeId, router, t])
+
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('resources.resourceTypes.errors.notFound', 'Resource type not found.')}
+            backHref="/backend/resources/resource-types"
+            backLabel={t('resources.resourceTypes.actions.backToList', 'Back to resource types')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
 
   return (
     <Page>

--- a/packages/core/src/modules/resources/i18n/de.json
+++ b/packages/core/src/modules/resources/i18n/de.json
@@ -191,6 +191,7 @@
   "resources.errors.unauthorized": "Nicht autorisiert",
   "resources.nav.group": "Ressourcenplanung",
   "resources.resourceTypes.actions.add": "Ressourcentyp hinzufügen",
+  "resources.resourceTypes.actions.backToList": "Zurück zu Ressourcentypen",
   "resources.resourceTypes.actions.delete": "Löschen",
   "resources.resourceTypes.actions.deleteConfirm": "Ressourcentyp \"{{name}}\" löschen?",
   "resources.resourceTypes.actions.edit": "Bearbeiten",

--- a/packages/core/src/modules/resources/i18n/en.json
+++ b/packages/core/src/modules/resources/i18n/en.json
@@ -191,6 +191,7 @@
   "resources.errors.unauthorized": "Unauthorized",
   "resources.nav.group": "Resource planning",
   "resources.resourceTypes.actions.add": "Add resource type",
+  "resources.resourceTypes.actions.backToList": "Back to resource types",
   "resources.resourceTypes.actions.delete": "Delete",
   "resources.resourceTypes.actions.deleteConfirm": "Delete resource type \"{{name}}\"?",
   "resources.resourceTypes.actions.edit": "Edit",

--- a/packages/core/src/modules/resources/i18n/es.json
+++ b/packages/core/src/modules/resources/i18n/es.json
@@ -191,6 +191,7 @@
   "resources.errors.unauthorized": "No autorizado",
   "resources.nav.group": "Planificación de recursos",
   "resources.resourceTypes.actions.add": "Agregar tipo de recurso",
+  "resources.resourceTypes.actions.backToList": "Volver a tipos de recursos",
   "resources.resourceTypes.actions.delete": "Eliminar",
   "resources.resourceTypes.actions.deleteConfirm": "Eliminar el tipo de recurso \"{{name}}\"?",
   "resources.resourceTypes.actions.edit": "Editar",

--- a/packages/core/src/modules/resources/i18n/pl.json
+++ b/packages/core/src/modules/resources/i18n/pl.json
@@ -191,6 +191,7 @@
   "resources.errors.unauthorized": "Brak autoryzacji",
   "resources.nav.group": "Planowanie zasobów",
   "resources.resourceTypes.actions.add": "Dodaj typ zasobu",
+  "resources.resourceTypes.actions.backToList": "Powrót do typów zasobów",
   "resources.resourceTypes.actions.delete": "Usuń",
   "resources.resourceTypes.actions.deleteConfirm": "Usunąć typ zasobu \"{{name}}\"?",
   "resources.resourceTypes.actions.edit": "Edytuj",

--- a/packages/core/src/modules/sales/components/channels/ChannelOfferForm.tsx
+++ b/packages/core/src/modules/sales/components/channels/ChannelOfferForm.tsx
@@ -11,6 +11,7 @@ import { readApiResultOrThrow, apiCall, withScopedApiRequestHeaders } from '@ope
 import { buildOptimisticLockHeader, extractOptimisticLockConflict } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Input } from '@open-mercato/ui/primitives/input'
 import {
@@ -136,6 +137,7 @@ export function ChannelOfferForm({ channelId: lockedChannelId, offerId, mode }: 
     : null)
   const [loading, setLoading] = React.useState(mode === 'edit')
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
   const [priceKinds, setPriceKinds] = React.useState<PriceKindSummary[]>([])
   const [mediaOptions, setMediaOptions] = React.useState<MediaOption[]>([])
   const attachmentCache = React.useRef<Map<string, MediaOption[]>>(new Map())
@@ -291,6 +293,7 @@ export function ChannelOfferForm({ channelId: lockedChannelId, offerId, mode }: 
     async function loadOffer() {
       setLoading(true)
       setError(null)
+      setIsNotFound(false)
       try {
         const payload = await readApiResultOrThrow<OfferResponse>(
           `/api/catalog/offers?id=${encodeURIComponent(offerKey)}&pageSize=1`,
@@ -298,7 +301,10 @@ export function ChannelOfferForm({ channelId: lockedChannelId, offerId, mode }: 
           { errorMessage: t('sales.channels.offers.errors.loadOffer', 'Failed to load offer.') },
         )
         const offer = Array.isArray(payload.items) ? payload.items[0] : null
-        if (!offer) throw new Error(t('sales.channels.offers.errors.notFound', 'Offer not found.'))
+        if (!offer) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         const values = mapOfferToFormValues(offer, lockedChannelId)
         const pricePayload = await readApiResultOrThrow<PriceResponse>(
           `/api/catalog/prices?offerId=${encodeURIComponent(offer.id as string)}&pageSize=${MAX_LIST_PAGE_SIZE}`,
@@ -674,13 +680,19 @@ export function ChannelOfferForm({ channelId: lockedChannelId, offerId, mode }: 
     router.push(buildChannelOffersHref(targetChannel))
   }, [initialValues?.channelId, lockedChannelId, offerId, router, t])
 
+  if (isNotFound) {
+    return (
+      <RecordNotFoundState
+        label={t('sales.channels.offers.errors.notFound', 'Offer not found.')}
+        backHref={channelOffersHref}
+        backLabel={t('sales.channels.offers.actions.backToList', 'Back to offers')}
+      />
+    )
+  }
+
   return (
     <div>
-      {error ? (
-        <div className="mb-4 rounded border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {error}
-        </div>
-      ) : null}
+      {error ? <ErrorMessage label={error} className="mb-4" /> : null}
       <CrudForm<OfferFormValues>
         title={mode === 'create'
           ? t('sales.channels.offers.form.createTitle', 'Create offer')

--- a/packages/core/src/modules/sales/frontend/quote/[token]/page.tsx
+++ b/packages/core/src/modules/sales/frontend/quote/[token]/page.tsx
@@ -4,6 +4,8 @@ import * as React from 'react'
 import { apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
+import { EmptyState } from '@open-mercato/ui/primitives/empty-state'
+import { SearchX } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 
 type PublicQuoteResponse = {
@@ -110,7 +112,12 @@ export default function QuotePublicPage({ params }: { params: { token: string } 
     return (
       <main className="mx-auto max-w-3xl p-6 space-y-2">
         <h1 className="text-2xl font-semibold">{t('sales.quotes.public.pageTitle')}</h1>
-        <p className="text-sm text-destructive">{error ?? t('sales.quotes.public.notFound')}</p>
+        <EmptyState
+          variant="subtle"
+          size="lg"
+          icon={<SearchX className="h-6 w-6" aria-hidden />}
+          title={error ?? t('sales.quotes.public.notFound')}
+        />
       </main>
     )
   }

--- a/packages/core/src/modules/sales/i18n/de.json
+++ b/packages/core/src/modules/sales/i18n/de.json
@@ -94,6 +94,7 @@
   "sales.channels.form.updateSubmit": "Änderungen speichern",
   "sales.channels.form.websiteUrl": "Website-URL",
   "sales.channels.nav.title": "Vertriebskanäle",
+  "sales.channels.offers.actions.backToList": "Zurück zu Angeboten",
   "sales.channels.offers.actions.create": "Angebot hinzufügen",
   "sales.channels.offers.actions.delete": "Löschen",
   "sales.channels.offers.actions.edit": "Bearbeiten",

--- a/packages/core/src/modules/sales/i18n/en.json
+++ b/packages/core/src/modules/sales/i18n/en.json
@@ -94,6 +94,7 @@
   "sales.channels.form.updateSubmit": "Save changes",
   "sales.channels.form.websiteUrl": "Website URL",
   "sales.channels.nav.title": "Sales channels",
+  "sales.channels.offers.actions.backToList": "Back to offers",
   "sales.channels.offers.actions.create": "Add offer",
   "sales.channels.offers.actions.delete": "Delete",
   "sales.channels.offers.actions.edit": "Edit",

--- a/packages/core/src/modules/sales/i18n/es.json
+++ b/packages/core/src/modules/sales/i18n/es.json
@@ -94,6 +94,7 @@
   "sales.channels.form.updateSubmit": "Guardar cambios",
   "sales.channels.form.websiteUrl": "URL del sitio web",
   "sales.channels.nav.title": "Canales de ventas",
+  "sales.channels.offers.actions.backToList": "Volver a ofertas",
   "sales.channels.offers.actions.create": "Añadir oferta",
   "sales.channels.offers.actions.delete": "Eliminar",
   "sales.channels.offers.actions.edit": "Editar",

--- a/packages/core/src/modules/sales/i18n/pl.json
+++ b/packages/core/src/modules/sales/i18n/pl.json
@@ -94,6 +94,7 @@
   "sales.channels.form.updateSubmit": "Zapisz zmiany",
   "sales.channels.form.websiteUrl": "Adres URL strony",
   "sales.channels.nav.title": "Kanały sprzedaży",
+  "sales.channels.offers.actions.backToList": "Powrót do ofert",
   "sales.channels.offers.actions.create": "Dodaj ofertę",
   "sales.channels.offers.actions.delete": "Usuń",
   "sales.channels.offers.actions.edit": "Edytuj",

--- a/packages/core/src/modules/staff/backend/staff/timesheets/projects/[id]/edit/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/timesheets/projects/[id]/edit/page.tsx
@@ -9,7 +9,7 @@ import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { E } from '#generated/entities.ids.generated'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
-import { LoadingMessage, ErrorMessage } from '@open-mercato/ui/backend/detail'
+import { LoadingMessage, ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import {
@@ -31,6 +31,7 @@ export default function TimesheetProjectEditPage({ params }: { params?: { id?: s
   const [initialValues, setInitialValues] = React.useState<ProjectFormValues | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
 
   const formSchema = React.useMemo(() => createProjectFormSchema(), [])
   const fields = React.useMemo(() => createProjectFormFields(t), [t])
@@ -42,6 +43,7 @@ export default function TimesheetProjectEditPage({ params }: { params?: { id?: s
     async function load() {
       setLoading(true)
       setError(null)
+      setIsNotFound(false)
       try {
         const payload = await readApiResultOrThrow<{ items?: Array<Record<string, unknown>> }>(
           `/api/staff/timesheets/time-projects?ids=${projectId}&pageSize=1`,
@@ -49,7 +51,10 @@ export default function TimesheetProjectEditPage({ params }: { params?: { id?: s
           { errorMessage: t('staff.timesheets.projects.errors.load', 'Failed to load project.') },
         )
         const record = Array.isArray(payload.items) ? payload.items[0] : null
-        if (!record) throw new Error(t('staff.timesheets.projects.errors.notFound', 'Project not found.'))
+        if (!record) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         if (!cancelled) {
           setInitialValues({
             id: String(record.id ?? ''),
@@ -82,8 +87,22 @@ export default function TimesheetProjectEditPage({ params }: { params?: { id?: s
     return <Page><PageBody><LoadingMessage label={t('staff.timesheets.projects.loading', 'Loading project...')} /></PageBody></Page>
   }
 
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('staff.timesheets.projects.errors.notFound', 'Project not found.')}
+            backHref={LIST_HREF}
+            backLabel={t('staff.timesheets.projects.actions.backToList', 'Back to projects')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
   if (error || !initialValues) {
-    return <Page><PageBody><ErrorMessage label={error ?? t('staff.timesheets.projects.errors.notFound', 'Project not found.')} /></PageBody></Page>
+    return <Page><PageBody><ErrorMessage label={error ?? t('staff.timesheets.projects.errors.load', 'Failed to load project.')} /></PageBody></Page>
   }
 
   const detailHref = `/backend/staff/timesheets/projects/${projectId}`

--- a/packages/core/src/modules/staff/backend/staff/timesheets/projects/[id]/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/timesheets/projects/[id]/page.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { Button } from '@open-mercato/ui/primitives/button'
+import { Badge } from '@open-mercato/ui/primitives/badge'
 import { Input } from '@open-mercato/ui/primitives/input'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@open-mercato/ui/primitives/dialog'
 import { LookupSelect } from '@open-mercato/ui/backend/inputs/LookupSelect'
@@ -13,7 +14,7 @@ import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { LoadingMessage } from '@open-mercato/ui/backend/detail'
-import { ErrorMessage } from '@open-mercato/ui/backend/detail'
+import { ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { ArrowLeft, Plus, Pencil, ChevronDown, Trash2, User } from 'lucide-react'
 import Link from 'next/link'
 
@@ -75,6 +76,7 @@ export default function TimesheetProjectDetailPage({ params }: { params?: { id?:
   const [project, setProject] = React.useState<ProjectRecord | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [isNotFound, setIsNotFound] = React.useState(false)
 
   const [employees, setEmployees] = React.useState<EmployeeAssignment[]>([])
   const [employeesLoading, setEmployeesLoading] = React.useState(false)
@@ -118,6 +120,7 @@ export default function TimesheetProjectDetailPage({ params }: { params?: { id?:
     async function loadProject() {
       setLoading(true)
       setError(null)
+      setIsNotFound(false)
       try {
         const queryParams = new URLSearchParams({ page: '1', pageSize: '1', ids: projectId! })
         const payload = await readApiResultOrThrow<ProjectResponse>(
@@ -126,7 +129,10 @@ export default function TimesheetProjectDetailPage({ params }: { params?: { id?:
           { errorMessage: t('staff.timesheets.projects.errors.load', 'Failed to load project.') },
         )
         const record = Array.isArray(payload.items) ? payload.items[0] : null
-        if (!record) throw new Error(t('staff.timesheets.projects.errors.notFound', 'Project not found.'))
+        if (!record) {
+          if (!cancelled) setIsNotFound(true)
+          return
+        }
         if (!cancelled) setProject(record)
       } catch (loadError) {
         if (!cancelled) {
@@ -302,11 +308,25 @@ export default function TimesheetProjectDetailPage({ params }: { params?: { id?:
     )
   }
 
+  if (isNotFound) {
+    return (
+      <Page>
+        <PageBody>
+          <RecordNotFoundState
+            label={t('staff.timesheets.projects.errors.notFound', 'Project not found.')}
+            backHref={BACK_HREF}
+            backLabel={t('staff.timesheets.projects.actions.backToList', 'Back to projects')}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
   if (error || !project) {
     return (
       <Page>
         <PageBody>
-          <ErrorMessage label={error ?? t('staff.timesheets.projects.errors.notFound', 'Project not found.')} />
+          <ErrorMessage label={error ?? t('staff.timesheets.projects.errors.load', 'Failed to load project.')} />
         </PageBody>
       </Page>
     )
@@ -355,9 +375,12 @@ export default function TimesheetProjectDetailPage({ params }: { params?: { id?:
                 <div>
                   <dt className="font-medium text-muted-foreground">{t('staff.timesheets.projects.form.status', 'Status')}</dt>
                   <dd>
-                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${projectStatus === 'active' ? 'bg-green-100 text-green-800' : projectStatus === 'on_hold' ? 'bg-yellow-100 text-yellow-800' : 'bg-gray-100 text-gray-800'}`}>
+                    <Badge
+                      variant={projectStatus === 'active' ? 'success' : projectStatus === 'on_hold' ? 'warning' : 'neutral'}
+                      className="capitalize"
+                    >
                       {projectStatus}
-                    </span>
+                    </Badge>
                   </dd>
                 </div>
                 {projectType ? (
@@ -447,9 +470,12 @@ export default function TimesheetProjectDetailPage({ params }: { params?: { id?:
                           </div>
                         </div>
                         <div className="flex items-center gap-3 shrink-0">
-                          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${emp.status === 'active' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'}`}>
+                          <Badge
+                            variant={(emp.status ?? 'active') === 'active' ? 'success' : 'neutral'}
+                            className="capitalize"
+                          >
                             {emp.status ?? 'active'}
-                          </span>
+                          </Badge>
                           {emp.assignedStartDate ? (
                             <span className="text-xs text-muted-foreground hidden sm:inline">
                               {emp.assignedStartDate}

--- a/packages/core/src/modules/staff/i18n/de.json
+++ b/packages/core/src/modules/staff/i18n/de.json
@@ -1021,6 +1021,7 @@
   "staff.timesheets.nav.projects": "Projects",
   "staff.timesheets.projects.actions.add": "Add Project",
   "staff.timesheets.projects.actions.addFirst": "+ Add first project",
+  "staff.timesheets.projects.actions.backToList": "Zurück zu Projekten",
   "staff.timesheets.projects.actions.delete": "Delete",
   "staff.timesheets.projects.actions.deleteConfirm": "Delete project \"{{name}}\"?",
   "staff.timesheets.projects.actions.refresh": "Refresh",

--- a/packages/core/src/modules/staff/i18n/en.json
+++ b/packages/core/src/modules/staff/i18n/en.json
@@ -1021,6 +1021,7 @@
   "staff.timesheets.nav.projects": "Projects",
   "staff.timesheets.projects.actions.add": "Add Project",
   "staff.timesheets.projects.actions.addFirst": "+ Add first project",
+  "staff.timesheets.projects.actions.backToList": "Back to projects",
   "staff.timesheets.projects.actions.delete": "Delete",
   "staff.timesheets.projects.actions.deleteConfirm": "Delete project \"{{name}}\"?",
   "staff.timesheets.projects.actions.refresh": "Refresh",

--- a/packages/core/src/modules/staff/i18n/es.json
+++ b/packages/core/src/modules/staff/i18n/es.json
@@ -1021,6 +1021,7 @@
   "staff.timesheets.nav.projects": "Projects",
   "staff.timesheets.projects.actions.add": "Add Project",
   "staff.timesheets.projects.actions.addFirst": "+ Add first project",
+  "staff.timesheets.projects.actions.backToList": "Volver a proyectos",
   "staff.timesheets.projects.actions.delete": "Delete",
   "staff.timesheets.projects.actions.deleteConfirm": "Delete project \"{{name}}\"?",
   "staff.timesheets.projects.actions.refresh": "Refresh",

--- a/packages/core/src/modules/staff/i18n/pl.json
+++ b/packages/core/src/modules/staff/i18n/pl.json
@@ -1021,6 +1021,7 @@
   "staff.timesheets.nav.projects": "Projects",
   "staff.timesheets.projects.actions.add": "Add Project",
   "staff.timesheets.projects.actions.addFirst": "+ Add first project",
+  "staff.timesheets.projects.actions.backToList": "Powrót do projektów",
   "staff.timesheets.projects.actions.delete": "Delete",
   "staff.timesheets.projects.actions.deleteConfirm": "Delete project \"{{name}}\"?",
   "staff.timesheets.projects.actions.refresh": "Refresh",

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -391,7 +391,7 @@ Notes:
 
 - For list/detail data loading, use `LoadingMessage` and `ErrorMessage` from `@open-mercato/ui/backend/detail`.
 - For record-backed backend detail/edit pages, treat `notFound` as a dedicated page state, separate from generic `error`.
-- When a record is missing, return early with a page-level `ErrorMessage` and a clear recovery action ("Back to list"); do not render `CrudForm`, detail sections, tabs, or record actions.
+- When a record is missing, return early with `RecordNotFoundState` from `@open-mercato/ui/backend/detail` (a neutral, centered empty state with a recovery action) and pass `backHref`/`backLabel`; do not render `CrudForm`, detail sections, tabs, or record actions. A missing record is NOT an error — never render not-found through the destructive `ErrorMessage`. Reserve `ErrorMessage` for genuine load/validation failures.
 - Don't use ad hoc centered `<div>` error markup when shared backend detail primitives can express the state.
 - Use `TabEmptyState` when a section is empty but otherwise healthy.
 - Keep loading flags local to the section; reset errors before each load.

--- a/packages/ui/src/backend/detail/RecordNotFoundState.tsx
+++ b/packages/ui/src/backend/detail/RecordNotFoundState.tsx
@@ -2,8 +2,10 @@
 
 import * as React from "react";
 import Link from "next/link";
+import { SearchX } from "lucide-react";
 import { Button } from "@open-mercato/ui/primitives/button";
-import { ErrorMessage } from "./ErrorMessage";
+import { EmptyState } from "@open-mercato/ui/primitives/empty-state";
+import { formatErrorMessageLabel } from "./ErrorMessage";
 import { cn } from "@open-mercato/shared/lib/utils";
 import { useT } from "@open-mercato/shared/lib/i18n/context";
 
@@ -13,6 +15,8 @@ export type RecordNotFoundStateProps = {
   backHref?: string;
   backLabel?: string;
   action?: React.ReactNode;
+  /** Optional leading icon. Defaults to a neutral "search / not found" glyph. */
+  icon?: React.ReactNode;
   className?: string;
 };
 
@@ -22,12 +26,13 @@ export function RecordNotFoundState({
   backHref,
   backLabel,
   action,
+  icon,
   className,
 }: RecordNotFoundStateProps) {
   const t = useT();
   const defaultAction = backHref ? (
     <Button asChild variant="outline" size="sm">
-      <Link href={backHref}>{backLabel ?? t('ui.recordNotFound.backToList','Back to list')}</Link>
+      <Link href={backHref}>{backLabel ?? t('ui.recordNotFound.backToList', 'Back to list')}</Link>
     </Button>
   ) : null;
 
@@ -38,10 +43,12 @@ export function RecordNotFoundState({
         className,
       )}
     >
-      <ErrorMessage
-        label={label}
-        description={description}
-        action={action ?? defaultAction}
+      <EmptyState
+        variant="subtle"
+        icon={icon ?? <SearchX className="h-6 w-6" aria-hidden />}
+        title={formatErrorMessageLabel(label)}
+        description={description ? formatErrorMessageLabel(description) : undefined}
+        actions={action ?? defaultAction}
       />
     </div>
   );

--- a/packages/ui/src/backend/detail/__tests__/RecordNotFoundState.test.tsx
+++ b/packages/ui/src/backend/detail/__tests__/RecordNotFoundState.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { RecordNotFoundState } from '../RecordNotFoundState'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+}))
+
+jest.mock('next/link', () => {
+  const React = require('react')
+  return React.forwardRef(
+    ({ children, href, ...rest }: any, ref: React.ForwardedRef<HTMLAnchorElement>) => (
+      <a href={typeof href === 'string' ? href : href?.toString?.()} ref={ref} {...rest}>
+        {children}
+      </a>
+    ),
+  )
+})
+
+describe('RecordNotFoundState', () => {
+  it('renders the label as the empty-state title', () => {
+    render(<RecordNotFoundState label="Company not found." />)
+    expect(screen.getByText('Company not found.')).toBeInTheDocument()
+  })
+
+  it('renders a back link (role=link) with the given href and default label', () => {
+    render(<RecordNotFoundState label="Company not found." backHref="/backend/customers/companies" />)
+    const backLink = screen.getByRole('link', { name: /back to list/i })
+    expect(backLink).toBeInTheDocument()
+    expect(backLink).toHaveAttribute('href', '/backend/customers/companies')
+  })
+
+  it('uses a custom backLabel when provided', () => {
+    render(
+      <RecordNotFoundState
+        label="Company not found."
+        backHref="/backend/customers/companies"
+        backLabel="Back to companies"
+      />,
+    )
+    expect(screen.getByRole('link', { name: /back to companies/i })).toBeInTheDocument()
+  })
+
+  it('renders a custom action instead of the default back link', () => {
+    render(
+      <RecordNotFoundState
+        label="Company not found."
+        backHref="/ignored"
+        action={<button type="button">Retry</button>}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('renders no action when neither backHref nor action is provided', () => {
+    render(<RecordNotFoundState label="Company not found." />)
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('is a neutral empty state, not a destructive alert (regression guard for #2127)', () => {
+    render(<RecordNotFoundState label="Company not found." backHref="/backend/customers/companies" />)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('renders a custom icon when provided', () => {
+    render(
+      <RecordNotFoundState
+        label="Company not found."
+        icon={<svg data-testid="custom-icon" />}
+      />,
+    )
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

`RecordNotFoundState` wrapped the destructive `ErrorMessage`, so a missing record rendered as a red "critical error" alert (red border, red text, `role="alert"`). A missing record is not an error — this rewrites it to a calm, neutral empty state and adopts it across the remaining backend detail/edit pages.

## Changes

- `RecordNotFoundState` now composes the `EmptyState` primitive (`variant="subtle"`, neutral `SearchX` icon); public API kept 1:1 (+ optional `icon`), so all 39 existing adopters get the calmer UX automatically. Back affordance stays a real `<a>`.
- Migrated 4 stragglers that hand-rolled not-found (staff timesheets projects detail+edit, catalog variant-create, resources resource-type edit) — split a dedicated `isNotFound` state from generic load errors.
- Portal "Organization not found" (4 pages) + the public quote page now use a neutral `EmptyState` instead of a destructive `Alert` / raw red text.
- `ChannelOfferForm` distinguishes a missing offer from a load error.
- DS cleanup on touched files: status `Badge` for hardcoded colors, lucide icons for inline SVG, `ErrorMessage` for ad-hoc destructive divs.
- Docs: `RecordNotFoundState` entry in `.ai/ui-components.md`; corrected not-found guidance in `packages/ui/AGENTS.md`. i18n: `*.actions.backToList` (resources, staff, sales) × en/pl/de/es.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [x] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:** `.ai/specs/2026-06-04-record-not-found-default.md` (plus follow-up `.ai/specs/2026-06-05-record-load-error-classification.md`)

## Testing

- `yarn workspace @open-mercato/ui test` — added `RecordNotFoundState.test.tsx` (incl. regression guard: not `role="alert"`).
- Existing `TC-UX-006/007/008/009` integration specs stay green (assert text + back link).
- `turbo run typecheck` ✅ · `yarn i18n:check-sync` ✅ · full `yarn test:integration:ephemeral` ✅ (no net new regressions).

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (existing TC-UX-006..009 cover this; no new ones required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors — use semantic tokens
- [x] No arbitrary text sizes — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #2127
