### PR TITLE
Fix Todo assignee checkbox auto-submit

### DIFF
--- a/.ai/runs/2026-06-06-todo-assignee-checkbox-submit.md
+++ b/.ai/runs/2026-06-06-todo-assignee-checkbox-submit.md
@@ -1,0 +1,46 @@
+# Fix Todo Assignee Checkbox Auto-Submit
+
+## Goal
+Prevent clicking example Todo Assignees checkbox/listbox options inside `CrudForm` from submitting the whole form.
+
+## Scope
+- Shared backend form controls in `packages/ui`.
+- Example Todo custom-field regression coverage only where needed to prove the behavior.
+
+## Non-goals
+- No visual redesign of custom fields or Todo pages.
+- No API contract changes.
+- No database or generated-file changes.
+
+## Implementation Plan
+
+### Phase 1: Root Cause
+- Confirm which interactive control triggers native form submit.
+- Add a focused regression test around multi-select/listbox custom-field selection inside `CrudForm`.
+
+### Phase 2: Fix
+- Patch the shared control so checkbox/listbox clicks are non-submit interactions inside forms.
+- Keep existing value-change behavior intact.
+
+### Phase 3: Validation and PR
+- Run focused UI tests and typecheck if needed.
+- Push a branch and open a PR against `develop` with bug/needs-qa labels.
+
+## Risks
+- `Checkbox` is a shared primitive. The fix must preserve normal checked/indeterminate behavior while preventing accidental native form submission.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Root Cause
+
+- [ ] 1.1 Confirm submit trigger and add regression test
+
+### Phase 2: Fix
+
+- [ ] 2.1 Patch checkbox/listbox non-submit behavior
+
+### Phase 3: Validation and PR
+
+- [ ] 3.1 Run focused validation and open PR

--- a/.ai/runs/2026-06-06-todo-assignee-checkbox-submit.md
+++ b/.ai/runs/2026-06-06-todo-assignee-checkbox-submit.md
@@ -35,12 +35,12 @@ Prevent clicking example Todo Assignees checkbox/listbox options inside `CrudFor
 
 ### Phase 1: Root Cause
 
-- [ ] 1.1 Confirm submit trigger and add regression test
+- [x] 1.1 Confirm submit trigger and add regression test — 07d053f2a
 
 ### Phase 2: Fix
 
-- [ ] 2.1 Patch checkbox/listbox non-submit behavior
+- [x] 2.1 Patch checkbox/listbox non-submit behavior — 07d053f2a
 
 ### Phase 3: Validation and PR
 
-- [ ] 3.1 Run focused validation and open PR
+- [x] 3.1 Run focused validation and open PR — 07d053f2a

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -4132,6 +4132,7 @@ const ListboxMultiSelect = React.memo(function ListboxMultiSelect({
           return (
             <Button
               key={opt.value}
+              type="button"
               variant="ghost"
               size="sm"
               onClick={() => toggle(opt.value)}

--- a/packages/ui/src/backend/__tests__/CrudForm.render.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.render.test.tsx
@@ -26,7 +26,7 @@ jest.mock('../injection/useInjectionDataWidgets', () => ({
 
 import * as React from 'react'
 import { renderToString } from 'react-dom/server'
-import { act, fireEvent, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { CrudForm, type CrudField } from '../CrudForm'
 import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
@@ -116,6 +116,41 @@ describe('CrudForm initialValues', () => {
     await waitFor(() => {
       expect(getByRole('combobox')).toHaveTextContent('Engineering')
     })
+  })
+
+  it('does not submit when a listbox multi-select option is clicked', async () => {
+    const onSubmit = jest.fn()
+    const fields: CrudField[] = [
+      {
+        id: 'assignees',
+        label: 'Assignees',
+        type: 'select',
+        multiple: true,
+        listbox: true,
+        options: [
+          { value: 'alice', label: 'alice' },
+          { value: 'bob', label: 'bob' },
+        ],
+      },
+    ]
+
+    renderWithProviders(
+      <CrudForm title="Form" fields={fields} initialValues={{ assignees: [] }} onSubmit={onSubmit} />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+          'ui.forms.listbox.searchPlaceholder': 'Search...',
+          'ui.forms.listbox.noMatches': 'No matches',
+        },
+      },
+    )
+
+    const aliceOption = screen.getByRole('button', { name: 'alice' })
+    expect(aliceOption).toHaveAttribute('type', 'button')
+
+    fireEvent.click(aliceOption)
+
+    expect(onSubmit).not.toHaveBeenCalled()
   })
 
   it('does not re-invoke loadOptions on parent re-render (#814)', async () => {

--- a/packages/ui/src/primitives/__tests__/checkbox.test.tsx
+++ b/packages/ui/src/primitives/__tests__/checkbox.test.tsx
@@ -1,0 +1,28 @@
+/** @jest-environment jsdom */
+
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Checkbox } from '../checkbox'
+
+describe('Checkbox', () => {
+  it('does not submit a parent form by default', () => {
+    const onSubmit = jest.fn((event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+    })
+    const onCheckedChange = jest.fn()
+
+    render(
+      <form onSubmit={onSubmit}>
+        <Checkbox aria-label="Assignee alice" onCheckedChange={onCheckedChange} />
+      </form>,
+    )
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Assignee alice' })
+    expect(checkbox).toHaveAttribute('type', 'button')
+
+    fireEvent.click(checkbox)
+
+    expect(onCheckedChange).toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/packages/ui/src/primitives/checkbox.tsx
+++ b/packages/ui/src/primitives/checkbox.tsx
@@ -31,11 +31,12 @@ export type CheckboxProps = React.ComponentPropsWithoutRef<typeof CheckboxPrimit
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   CheckboxProps
->(({ className, size, ...props }, ref) => {
+>(({ className, size, type = "button", ...props }, ref) => {
   const iconClass = indicatorIconBySize[size ?? "sm"]
   return (
     <CheckboxPrimitive.Root
       ref={ref}
+      type={type}
       className={cn(checkboxVariants({ size, className }))}
       {...props}
     >


### PR DESCRIPTION
## Summary
- Prevent CrudForm listbox multi-select options from acting as implicit submit buttons inside forms.
- Default the shared Checkbox primitive to `type="button"` so checkbox controls do not submit parent forms unless explicitly overridden.
- Add regression tests for the Todo-style listbox assignee path and checkbox-in-form behavior.

## Root cause
The Assignees custom field renders as a CrudForm listbox. Each option row used the shared Button primitive without `type="button"`, so the browser treated it as a submit button inside the form. Clicking an assignee therefore fired the full CrudForm submit.

## Validation
- PASS: `yarn workspace @open-mercato/ui test CrudForm.render --runInBand`
- PASS: `yarn workspace @open-mercato/ui test src/primitives/__tests__/checkbox.test.tsx --runInBand`
- PASS: `yarn exec tsc -p packages/ui/tsconfig.json --noEmit`
- PASS: `yarn build:packages`
- PASS: `yarn generate`
- PASS: `git diff --check`

## Notes
A broad `yarn workspace @open-mercato/ui test checkbox --runInBand` pattern was also attempted, but it matched unrelated AI chat suites that currently fail to resolve `@open-mercato/ai-assistant/modules/ai_assistant/lib/agent-transport`. The exact checkbox regression test passes.

## QA
- Open Example -> Todos edit for a Todo with Assignees.
- Click assignee options such as `alice`, `bob`, or `charlie`.
- Expected: options toggle locally and the form does not save/post until Save is clicked.
