### PR TITLE
fix(crud): address checkout and customer QA regressions

### DIFF
--- a/.ai/runs/2026-06-06-alinadivante-qa-fixes.md
+++ b/.ai/runs/2026-06-06-alinadivante-qa-fixes.md
@@ -74,15 +74,15 @@ Add integration tests that exercise the failing edit flows through the UI/API su
 
 ### Phase 1: Root Cause And Fixes
 
-- [ ] 1.1 Identify checkout template create/edit validation asymmetry and enforce required gateway provider consistently
-- [ ] 1.2 Identify why empty customer phone values are lost on people-v2 and companies-v2 saves, then normalize/save the cleared value without regressing email/url clearing
+- [x] 1.1 Identify checkout template create/edit validation asymmetry and enforce required gateway provider consistently — 7612e680e
+- [x] 1.2 Identify why empty customer phone values are lost on people-v2 and companies-v2 saves, then normalize/save the cleared value without regressing email/url clearing — 7612e680e
 
 ### Phase 2: Integration Coverage
 
-- [ ] 2.1 Add checkout integration coverage for editing an existing template and clearing the gateway provider
-- [ ] 2.2 Add customers integration coverage for clearing primary phone on both people-v2 and companies-v2 records
+- [x] 2.1 Add checkout integration coverage for editing an existing template and clearing the gateway provider — 7612e680e
+- [x] 2.2 Add customers integration coverage for clearing primary phone on both people-v2 and companies-v2 records — 7612e680e
 
 ### Phase 3: Validation And PR
 
-- [ ] 3.1 Run targeted validation for checkout, customers, and the new integration tests
+- [x] 3.1 Run targeted validation for checkout, customers, and the new integration tests — 7612e680e
 - [ ] 3.2 Run the full auto-create-pr validation gate, self-review against `om-code-review` and `BACKWARD_COMPATIBILITY.md`, open the PR, run the `om-auto-review-pr` autofix pass, and post the required summary comment including tested coverage

--- a/.ai/runs/2026-06-06-alinadivante-qa-fixes.md
+++ b/.ai/runs/2026-06-06-alinadivante-qa-fixes.md
@@ -1,0 +1,88 @@
+# alinadivante QA fixes
+
+## Overview
+
+Goal: fix the remaining regressions reported by `alinadivante` in GitHub issue comment `4634643036` for issue `#2529`, then cover the fixes with executable integration tests.
+
+Source issue comment: https://github.com/open-mercato/open-mercato/issues/2529#issuecomment-4634643036
+
+Affected areas:
+- Checkout template edit validation in `packages/checkout/src/modules/checkout`.
+- Customers people-v2 and companies-v2 phone clearing in `packages/core/src/modules/customers`.
+- Integration coverage under module-local `__integration__` folders.
+
+Guides read:
+- Root `AGENTS.md` task router.
+- `packages/checkout/AGENTS.md`.
+- `packages/core/AGENTS.md`.
+- `packages/core/src/modules/customers/AGENTS.md`.
+- `packages/ui/AGENTS.md`.
+- `packages/ui/src/backend/AGENTS.md`.
+- `.ai/qa/AGENTS.md`.
+- `BACKWARD_COMPATIBILITY.md`.
+- `.ai/lessons.md`.
+
+Relevant specs checked:
+- `.ai/specs/implemented/2026-03-19-checkout-pay-links.md`.
+- `.ai/specs/implemented/2026-04-12-customers-people-nested-profile-update-contract.md`.
+- `.ai/specs/implemented/SPEC-046-2026-02-25-customer-detail-pages-v2.md`.
+
+## Scope
+
+Fix only the two failed QA cases:
+- Editing an existing Checkout Template must reject a cleared required Gateway provider the same way creation does.
+- Clearing a person/company primary phone in Customers v2 must persist as empty after save and reload.
+
+Add integration tests that exercise the failing edit flows through the UI/API surface used by the product.
+
+## Non-goals
+
+- Do not change checkout payment state transitions, public pay-page contracts, or gateway provider APIs.
+- Do not redesign customer profile/contact data models.
+- Do not touch the QA items that already passed in the issue comment.
+- Do not apply database migrations locally.
+
+## Implementation Plan
+
+### Phase 1: Root Cause And Fixes
+
+1.1 Identify checkout template create/edit validation asymmetry and enforce required gateway provider consistently.
+
+1.2 Identify why empty customer phone values are lost on people-v2 and companies-v2 saves, then normalize/save the cleared value without regressing email/url clearing.
+
+### Phase 2: Integration Coverage
+
+2.1 Add checkout integration coverage for editing an existing template and clearing the gateway provider.
+
+2.2 Add customers integration coverage for clearing primary phone on both people-v2 and companies-v2 records.
+
+### Phase 3: Validation And PR
+
+3.1 Run targeted validation for checkout, customers, and the new integration tests.
+
+3.2 Run the full auto-create-pr validation gate, self-review against `om-code-review` and `BACKWARD_COMPATIBILITY.md`, open the PR, run the `om-auto-review-pr` autofix pass, and post the required summary comment including tested coverage.
+
+## Risks
+
+- Checkout templates may have intentionally allowed gateway-less drafts; the UI already marks the field required and create validation rejects missing gateway, so this fix aligns edit behavior with the existing visible contract.
+- Phone clearing may fail either in form serialization or API normalization. The fix must preserve `undefined` as "unchanged" where applicable while treating submitted empty strings/nulls as an explicit clear.
+- Integration tests must not rely on seeded demo records; fixtures should be created and cleaned up inside the tests.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Root Cause And Fixes
+
+- [ ] 1.1 Identify checkout template create/edit validation asymmetry and enforce required gateway provider consistently
+- [ ] 1.2 Identify why empty customer phone values are lost on people-v2 and companies-v2 saves, then normalize/save the cleared value without regressing email/url clearing
+
+### Phase 2: Integration Coverage
+
+- [ ] 2.1 Add checkout integration coverage for editing an existing template and clearing the gateway provider
+- [ ] 2.2 Add customers integration coverage for clearing primary phone on both people-v2 and companies-v2 records
+
+### Phase 3: Validation And PR
+
+- [ ] 3.1 Run targeted validation for checkout, customers, and the new integration tests
+- [ ] 3.2 Run the full auto-create-pr validation gate, self-review against `om-code-review` and `BACKWARD_COMPATIBILITY.md`, open the PR, run the `om-auto-review-pr` autofix pass, and post the required summary comment including tested coverage

--- a/.ai/runs/2026-06-06-alinadivante-qa-fixes.md
+++ b/.ai/runs/2026-06-06-alinadivante-qa-fixes.md
@@ -85,4 +85,4 @@ Add integration tests that exercise the failing edit flows through the UI/API su
 ### Phase 3: Validation And PR
 
 - [x] 3.1 Run targeted validation for checkout, customers, and the new integration tests — 7612e680e
-- [ ] 3.2 Run the full auto-create-pr validation gate, self-review against `om-code-review` and `BACKWARD_COMPATIBILITY.md`, open the PR, run the `om-auto-review-pr` autofix pass, and post the required summary comment including tested coverage
+- [x] 3.2 Run the full auto-create-pr validation gate, self-review against `om-code-review` and `BACKWARD_COMPATIBILITY.md`, open the PR, run the `om-auto-review-pr` autofix pass, and post the required summary comment including tested coverage — f7d637c4b

--- a/packages/checkout/src/modules/checkout/__integration__/TC-CHKT-039-null-gateway-edit.spec.ts
+++ b/packages/checkout/src/modules/checkout/__integration__/TC-CHKT-039-null-gateway-edit.spec.ts
@@ -12,8 +12,8 @@ import {
   updateTemplate,
 } from './helpers/fixtures'
 
-test.describe('TC-CHKT-039: Draft template/pay-link edits tolerate a null gateway provider (issue #2505)', () => {
-  test('template: clearing the gateway provider on a draft saves and round-trips as null', async ({ request }) => {
+test.describe('TC-CHKT-039: Draft template/pay-link gateway provider edit validation', () => {
+  test('template: clearing the required gateway provider is rejected and preserves the previous value', async ({ request }) => {
     let token: string | null = null
     let templateId: string | null = null
 
@@ -29,38 +29,35 @@ test.describe('TC-CHKT-039: Draft template/pay-link edits tolerate a null gatewa
         status: 'draft',
         gatewayProviderKey: null,
       })
-      expect(
-        clearResponse.ok(),
-        `Clearing the gateway on a draft template should succeed: ${clearResponse.status()} ${JSON.stringify(await readJsonSafe(clearResponse))}`,
-      ).toBeTruthy()
+      expect(clearResponse.status()).toBe(400)
+      const clearBody = await readJsonSafe<{ fieldErrors?: { gatewayProviderKey?: string }; error?: string }>(clearResponse)
+      expect(clearBody?.fieldErrors?.gatewayProviderKey ?? clearBody?.error ?? '').toContain('checkout.validation.gatewayProviderKey.required')
 
       const cleared = await readTemplate(request, token, templateId)
-      expect(cleared.gatewayProviderKey ?? null).toBeNull()
-      expect(cleared.name).toBe('Consulting Fee (no gateway)')
+      expect(cleared.gatewayProviderKey).toBe('mock')
+      expect(cleared.name).not.toBe('Consulting Fee (no gateway)')
 
       const renameResponse = await updateTemplate(request, token, templateId, {
         name: 'Consulting Fee renamed',
-        gatewayProviderKey: null,
       })
       expect(
         renameResponse.ok(),
-        `Editing a field on a gateway-less draft template should succeed: ${renameResponse.status()} ${JSON.stringify(await readJsonSafe(renameResponse))}`,
+        `Editing a field while retaining the existing gateway should succeed: ${renameResponse.status()} ${JSON.stringify(await readJsonSafe(renameResponse))}`,
       ).toBeTruthy()
 
       const renamed = await readTemplate(request, token, templateId)
-      expect(renamed.gatewayProviderKey ?? null).toBeNull()
+      expect(renamed.gatewayProviderKey).toBe('mock')
       expect(renamed.name).toBe('Consulting Fee renamed')
 
       const blankResponse = await updateTemplate(request, token, templateId, {
         gatewayProviderKey: '   ',
       })
-      expect(
-        blankResponse.ok(),
-        `A blank gateway should normalize to null on a draft template: ${blankResponse.status()} ${JSON.stringify(await readJsonSafe(blankResponse))}`,
-      ).toBeTruthy()
+      expect(blankResponse.status()).toBe(400)
+      const blankBody = await readJsonSafe<{ fieldErrors?: { gatewayProviderKey?: string }; error?: string }>(blankResponse)
+      expect(blankBody?.fieldErrors?.gatewayProviderKey ?? blankBody?.error ?? '').toContain('checkout.validation.gatewayProviderKey.required')
 
       const blanked = await readTemplate(request, token, templateId)
-      expect(blanked.gatewayProviderKey ?? null).toBeNull()
+      expect(blanked.gatewayProviderKey).toBe('mock')
     } finally {
       await deleteCheckoutEntityIfExists(request, token, 'templates', templateId)
     }

--- a/packages/checkout/src/modules/checkout/data/__tests__/validators.test.ts
+++ b/packages/checkout/src/modules/checkout/data/__tests__/validators.test.ts
@@ -52,30 +52,37 @@ describe('checkout validators', () => {
     expect(result.password).toBeNull()
   })
 
-  test('updateTemplateSchema accepts a null gatewayProviderKey (issue #2505)', () => {
-    const result = updateTemplateSchema.parse({
-      id: TEMPLATE_ID,
-      name: 'Consulting Fee',
-      pricingMode: 'fixed',
-      fixedPriceAmount: 49.99,
-      fixedPriceCurrencyCode: 'USD',
-      gatewayProviderKey: null,
-    })
+  test('updateTemplateSchema rejects a cleared gatewayProviderKey', () => {
+    expect(() =>
+      updateTemplateSchema.parse({
+        id: TEMPLATE_ID,
+        name: 'Consulting Fee',
+        pricingMode: 'fixed',
+        fixedPriceAmount: 49.99,
+        fixedPriceCurrencyCode: 'USD',
+        gatewayProviderKey: null,
+      }),
+    ).toThrow()
 
-    expect(result.gatewayProviderKey).toBeNull()
+    expect(() =>
+      updateTemplateSchema.parse({
+        id: TEMPLATE_ID,
+        name: 'Consulting Fee',
+        pricingMode: 'fixed',
+        fixedPriceAmount: 49.99,
+        fixedPriceCurrencyCode: 'USD',
+        gatewayProviderKey: '   ',
+      }),
+    ).toThrow()
   })
 
-  test('updateTemplateSchema normalizes a blank gatewayProviderKey to null (issue #2505)', () => {
+  test('updateTemplateSchema accepts edits that omit gatewayProviderKey', () => {
     const result = updateTemplateSchema.parse({
       id: TEMPLATE_ID,
-      name: 'Consulting Fee',
-      pricingMode: 'fixed',
-      fixedPriceAmount: 49.99,
-      fixedPriceCurrencyCode: 'USD',
-      gatewayProviderKey: '   ',
+      name: 'Consulting Fee renamed',
     })
 
-    expect(result.gatewayProviderKey).toBeNull()
+    expect(Object.prototype.hasOwnProperty.call(result, 'gatewayProviderKey')).toBe(false)
   })
 
   test('updateLinkSchema accepts a null gatewayProviderKey (issue #2505)', () => {

--- a/packages/checkout/src/modules/checkout/data/validators.ts
+++ b/packages/checkout/src/modules/checkout/data/validators.ts
@@ -204,6 +204,13 @@ export const updateTemplateSchema = checkoutContentSchema.partial().extend({
   customerFieldsSchema: z.array(customerFieldDefinitionSchema).optional(),
 }).superRefine((value, ctx) => {
   applyPartialPricingConsistency(value, ctx)
+  if (Object.prototype.hasOwnProperty.call(value, 'gatewayProviderKey') && !value.gatewayProviderKey) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'checkout.validation.gatewayProviderKey.required',
+      path: ['gatewayProviderKey'],
+    })
+  }
 })
 
 export const createLinkSchema = createTemplateSchema.safeExtend({

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-076-clear-phone-v2.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-076-clear-phone-v2.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createCompanyFixture,
+  createPersonFixture,
+  deleteEntityByBody,
+  readJsonSafe,
+} from '@open-mercato/core/helpers/integration/crmFixtures'
+
+const OPTIMISTIC_LOCK_HEADER = 'x-om-ext-optimistic-lock-expected-updated-at'
+const BASE_URL = process.env.BASE_URL?.trim() || null
+
+function resolveUrl(path: string): string {
+  return BASE_URL ? `${BASE_URL}${path}` : path
+}
+
+type CustomerDetail = {
+  company?: {
+    id?: string | null
+    displayName?: string | null
+    primaryPhone?: string | null
+    updatedAt?: string | null
+    updated_at?: string | null
+  }
+  person?: {
+    id?: string | null
+    displayName?: string | null
+    primaryPhone?: string | null
+    updatedAt?: string | null
+    updated_at?: string | null
+  }
+}
+
+function resolveVersion(detail: CustomerDetail): string {
+  const record = detail.company ?? detail.person
+  const raw = record?.updatedAt ?? record?.updated_at
+  expect(typeof raw, 'customer detail should expose updatedAt for optimistic locking').toBe('string')
+  return new Date(Date.parse(raw as string)).toISOString()
+}
+
+async function readCustomerDetail(
+  request: APIRequestContext,
+  token: string,
+  kind: 'companies' | 'people',
+  id: string,
+): Promise<CustomerDetail> {
+  const response = await apiRequest(request, 'GET', `/api/customers/${kind}/${encodeURIComponent(id)}`, { token })
+  const body = await readJsonSafe<CustomerDetail>(response)
+  expect(response.ok(), `Failed to read ${kind} detail: ${response.status()} ${JSON.stringify(body)}`).toBeTruthy()
+  return body ?? {}
+}
+
+async function updateCustomer(
+  request: APIRequestContext,
+  token: string,
+  kind: 'companies' | 'people',
+  detail: CustomerDetail,
+  data: Record<string, unknown>,
+) {
+  const response = await request.fetch(resolveUrl(`/api/customers/${kind}`), {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      [OPTIMISTIC_LOCK_HEADER]: resolveVersion(detail),
+    },
+    data,
+  })
+  const body = await readJsonSafe(response)
+  expect(response.ok(), `Failed to update ${kind}: ${response.status()} ${JSON.stringify(body)}`).toBeTruthy()
+}
+
+test.describe('TC-CRM-076: Customers v2 phone clearing persists after reload', () => {
+  test('person primaryPhone can be cleared', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let personId: string | null = null
+
+    try {
+      const stamp = Date.now()
+      personId = await createPersonFixture(request, token, {
+        firstName: 'Phone',
+        lastName: `Clear ${stamp}`,
+        displayName: `Phone Clear Person ${stamp}`,
+      })
+
+      const created = await readCustomerDetail(request, token, 'people', personId)
+      await updateCustomer(request, token, 'people', created, {
+        id: personId,
+        firstName: 'Phone',
+        lastName: `Clear ${stamp}`,
+        displayName: `Phone Clear Person ${stamp}`,
+        primaryPhone: '+1 212 555 0176',
+      })
+
+      const withPhone = await readCustomerDetail(request, token, 'people', personId)
+      expect(withPhone.person?.primaryPhone).toBe('+1 212 555 0176')
+
+      await updateCustomer(request, token, 'people', withPhone, {
+        id: personId,
+        firstName: 'Phone',
+        lastName: `Clear ${stamp}`,
+        displayName: `Phone Clear Person ${stamp}`,
+        primaryPhone: null,
+      })
+
+      const cleared = await readCustomerDetail(request, token, 'people', personId)
+      expect(cleared.person?.primaryPhone ?? null).toBeNull()
+    } finally {
+      await deleteEntityByBody(request, token, '/api/customers/people', personId)
+    }
+  })
+
+  test('company primaryPhone can be cleared', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let companyId: string | null = null
+
+    try {
+      const stamp = Date.now()
+      const displayName = `Phone Clear Company ${stamp}`
+      companyId = await createCompanyFixture(request, token, displayName)
+
+      const created = await readCustomerDetail(request, token, 'companies', companyId)
+      await updateCustomer(request, token, 'companies', created, {
+        id: companyId,
+        displayName,
+        primaryPhone: '+1 212 555 0276',
+      })
+
+      const withPhone = await readCustomerDetail(request, token, 'companies', companyId)
+      expect(withPhone.company?.primaryPhone).toBe('+1 212 555 0276')
+
+      await updateCustomer(request, token, 'companies', withPhone, {
+        id: companyId,
+        displayName,
+        primaryPhone: null,
+      })
+
+      const cleared = await readCustomerDetail(request, token, 'companies', companyId)
+      expect(cleared.company?.primaryPhone ?? null).toBeNull()
+    } finally {
+      await deleteEntityByBody(request, token, '/api/customers/companies', companyId)
+    }
+  })
+})

--- a/packages/core/src/modules/customers/components/__tests__/formConfig.test.ts
+++ b/packages/core/src/modules/customers/components/__tests__/formConfig.test.ts
@@ -144,13 +144,14 @@ describe('detail page zone1 group layouts', () => {
 })
 
 describe('clearing v2 URL & email edit fields (#2526)', () => {
-  it('transmits null when a previously-set person URL/email is blanked', () => {
+  it('transmits null when a previously-set person URL/email/phone is blanked', () => {
     const parsed = createPersonEditSchema().safeParse({
       id: PERSON_ID,
       displayName: 'Ada Lovelace',
       firstName: 'Ada',
       lastName: 'Lovelace',
       primaryEmail: '',
+      primaryPhone: '',
       linkedInUrl: '',
       twitterUrl: '',
     })
@@ -159,17 +160,19 @@ describe('clearing v2 URL & email edit fields (#2526)', () => {
 
     const payload = buildPersonEditPayload(parsed.data as any)
     expect(payload.primaryEmail).toBeNull()
+    expect(payload.primaryPhone).toBeNull()
     expect(payload.linkedInUrl).toBeNull()
     expect(payload.twitterUrl).toBeNull()
   })
 
-  it('keeps non-empty person URL/email values on edit', () => {
+  it('keeps non-empty person URL/email/phone values on edit', () => {
     const parsed = createPersonEditSchema().safeParse({
       id: PERSON_ID,
       displayName: 'Ada Lovelace',
       firstName: 'Ada',
       lastName: 'Lovelace',
       primaryEmail: 'ada@example.com',
+      primaryPhone: '+1 212 555 0101',
       linkedInUrl: 'https://linkedin.com/in/ada',
       twitterUrl: 'https://x.com/ada',
     })
@@ -178,15 +181,17 @@ describe('clearing v2 URL & email edit fields (#2526)', () => {
 
     const payload = buildPersonEditPayload(parsed.data as any)
     expect(payload.primaryEmail).toBe('ada@example.com')
+    expect(payload.primaryPhone).toBe('+1 212 555 0101')
     expect(payload.linkedInUrl).toBe('https://linkedin.com/in/ada')
     expect(payload.twitterUrl).toBe('https://x.com/ada')
   })
 
-  it('transmits null when a previously-set company website/email is blanked', () => {
+  it('transmits null when a previously-set company website/email/phone is blanked', () => {
     const parsed = createCompanyEditSchema().safeParse({
       id: COMPANY_ID,
       displayName: 'Acme',
       primaryEmail: '',
+      primaryPhone: '',
       websiteUrl: '',
     })
     expect(parsed.success).toBe(true)
@@ -194,14 +199,16 @@ describe('clearing v2 URL & email edit fields (#2526)', () => {
 
     const payload = buildCompanyEditPayload(parsed.data as any)
     expect(payload.primaryEmail).toBeNull()
+    expect(payload.primaryPhone).toBeNull()
     expect(payload.websiteUrl).toBeNull()
   })
 
-  it('keeps non-empty company website/email values on edit', () => {
+  it('keeps non-empty company website/email/phone values on edit', () => {
     const parsed = createCompanyEditSchema().safeParse({
       id: COMPANY_ID,
       displayName: 'Acme',
       primaryEmail: 'hello@acme.com',
+      primaryPhone: '+1 212 555 0202',
       websiteUrl: 'https://acme.com',
     })
     expect(parsed.success).toBe(true)
@@ -209,6 +216,7 @@ describe('clearing v2 URL & email edit fields (#2526)', () => {
 
     const payload = buildCompanyEditPayload(parsed.data as any)
     expect(payload.primaryEmail).toBe('hello@acme.com')
+    expect(payload.primaryPhone).toBe('+1 212 555 0202')
     expect(payload.websiteUrl).toBe('https://acme.com')
   })
 })

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -412,7 +412,7 @@ const createPrimaryPhoneField = (t: Translator): CrudField => ({
     return (
       <PhoneNumberField
         value={typeof value === 'string' ? value : null}
-        onValueChange={(next) => setValue(typeof next === 'string' ? next : undefined)}
+        onValueChange={(next) => setValue(typeof next === 'string' ? next : '')}
         externalError={error}
         autoFocus={autoFocus}
         disabled={disabled}
@@ -1234,7 +1234,7 @@ export const createCompanyFormFields = (t: Translator): CrudField[] => {
       component: ({ value, setValue, error, disabled, autoFocus }: CrudCustomFieldRenderProps) => (
         <PhoneNumberField
           value={typeof value === 'string' ? value : null}
-          onValueChange={(next) => setValue(typeof next === 'string' ? next : undefined)}
+          onValueChange={(next) => setValue(typeof next === 'string' ? next : '')}
           externalError={error}
           autoFocus={autoFocus}
           disabled={disabled}
@@ -1462,18 +1462,20 @@ export function buildCompanyPayload(
 // Edit-mode types
 // ---------------------------------------------------------------------------
 
-// URL/email fields are clearable on edit: blanking a previously-set value transmits null,
+// URL/email/phone fields are clearable on edit: blanking a previously-set value transmits null,
 // so the edit-form value types widen to `string | null` to match the edit-schema output. See #2526.
-export type CompanyEditFormValues = Omit<CompanyFormValues, 'addresses' | 'primaryEmail' | 'websiteUrl'> & {
+export type CompanyEditFormValues = Omit<CompanyFormValues, 'addresses' | 'primaryEmail' | 'primaryPhone' | 'websiteUrl'> & {
   id: string
   primaryEmail?: string | null
+  primaryPhone?: string | null
   websiteUrl?: string | null
 }
 
-export type PersonEditFormValues = Omit<PersonFormValues, 'addresses' | 'primaryEmail'> & {
+export type PersonEditFormValues = Omit<PersonFormValues, 'addresses' | 'primaryEmail' | 'primaryPhone'> & {
   id: string
   department?: string
   primaryEmail?: string | null
+  primaryPhone?: string | null
   linkedInUrl?: string | null
   twitterUrl?: string | null
 }
@@ -1491,7 +1493,7 @@ const optionalString = () =>
     .transform((val) => (val === '' ? undefined : val))
     .optional()
 
-// Edit-mode URL/email fields map to nullable columns and must be clearable: blanking a
+// Edit-mode URL/email/phone fields map to nullable columns and must be clearable: blanking a
 // previously-set value transforms '' → null so the payload builder can transmit an explicit
 // clear (omitting the key can never remove an existing value). Create-mode schemas keep the
 // '' → undefined transform. See #2526.
@@ -1515,10 +1517,22 @@ const clearableEmailField = () =>
     .transform((val) => (val === '' ? null : val))
     .optional()
 
+const clearablePhoneField = () =>
+  z
+    .string()
+    .trim()
+    .max(50)
+    .refine((value) => value === '' || isValidPhoneNumber(value), { message: CUSTOMER_PHONE_INVALID_MESSAGE_KEY })
+    .optional()
+    .or(z.literal(''))
+    .transform((val) => (val === '' ? null : val))
+    .optional()
+
 export const createCompanyEditSchema = () =>
   createCompanyFormSchema().extend({
     id: z.string().uuid(),
     primaryEmail: clearableEmailField(),
+    primaryPhone: clearablePhoneField(),
     websiteUrl: clearableUrlField(),
   })
 
@@ -1527,6 +1541,7 @@ export const createPersonEditSchema = () =>
     id: z.string().uuid(),
     department: optionalString(),
     primaryEmail: clearableEmailField(),
+    primaryPhone: clearablePhoneField(),
     linkedInUrl: clearableUrlField(),
     twitterUrl: clearableUrlField(),
   })
@@ -1808,7 +1823,7 @@ export const createPersonPersonalDataGroups = (
 // Edit-mode payload builders
 // ---------------------------------------------------------------------------
 
-// On edit, optional URL/email fields that map to nullable columns must transmit an explicit
+// On edit, optional URL/email/phone fields that map to nullable columns must transmit an explicit
 // `null` when the user blanks a previously-set value — omitting the key can never clear it.
 // The base create-mode builders omit blanks (correct for create), so the edit builders
 // override these clearable fields here. See #2526.
@@ -1827,6 +1842,7 @@ export function buildCompanyEditPayload(values: CompanyEditFormValues, organizat
   payload.id = values.id
 
   assignClearable(payload, 'primaryEmail', values.primaryEmail)
+  assignClearable(payload, 'primaryPhone', values.primaryPhone)
   assignClearable(payload, 'websiteUrl', values.websiteUrl)
 
   return payload
@@ -1840,6 +1856,7 @@ export function buildPersonEditPayload(values: PersonEditFormValues, organizatio
   if (department.length) payload.department = department
 
   assignClearable(payload, 'primaryEmail', values.primaryEmail)
+  assignClearable(payload, 'primaryPhone', values.primaryPhone)
   assignClearable(payload, 'linkedInUrl', values.linkedInUrl)
   assignClearable(payload, 'twitterUrl', values.twitterUrl)
 

--- a/packages/core/src/modules/customers/data/validators.ts
+++ b/packages/core/src/modules/customers/data/validators.ts
@@ -10,20 +10,27 @@ export const ACTIVITY_TIME_REQUIRED_MESSAGE_KEY = 'customers.activities.errors.t
 export const ACTIVITY_PHONE_REQUIRED_MESSAGE_KEY = 'customers.activities.errors.phoneRequired'
 export const ACTIVITY_PHONE_INVALID_MESSAGE_KEY = 'customers.activities.errors.phoneInvalid'
 
-const phoneSchema = z.string().trim().max(50).refine((val) => {
-  return isValidPhoneNumber(val)
-}, { message: CUSTOMER_PHONE_INVALID_MESSAGE_KEY }).optional()
-
-// Optional URL/email fields map to nullable DB columns. Treat both '' and null as an
+// Optional URL/email/phone fields map to nullable DB columns. Treat both '' and null as an
 // explicit "clear this value" signal (both coerce to null) so a previously-set value can
-// be removed via update; without this `''` fails `.url()/.email()` and `null` fails the
-// string type, leaving the columns effectively write-once-non-empty. The command layer
-// already persists null. See #2526.
+// be removed via update; without this, validators either reject blank/null values or omit
+// the field, leaving the columns effectively write-once-non-empty. The command layer already
+// persists null. See #2526.
 const emptyStringToNull = (value: unknown): unknown => {
   if (typeof value !== 'string') return value
   const trimmed = value.trim()
   return trimmed.length ? trimmed : null
 }
+
+const phoneSchema = z.preprocess(
+  emptyStringToNull,
+  z
+    .string()
+    .trim()
+    .max(50)
+    .refine((val) => isValidPhoneNumber(val), { message: CUSTOMER_PHONE_INVALID_MESSAGE_KEY })
+    .nullable()
+    .optional(),
+)
 
 const clearableEmailSchema = z.preprocess(
   emptyStringToNull,

--- a/packages/core/src/modules/customers/data/validators.ts
+++ b/packages/core/src/modules/customers/data/validators.ts
@@ -10,11 +10,6 @@ export const ACTIVITY_TIME_REQUIRED_MESSAGE_KEY = 'customers.activities.errors.t
 export const ACTIVITY_PHONE_REQUIRED_MESSAGE_KEY = 'customers.activities.errors.phoneRequired'
 export const ACTIVITY_PHONE_INVALID_MESSAGE_KEY = 'customers.activities.errors.phoneInvalid'
 
-// Optional URL/email/phone fields map to nullable DB columns. Treat both '' and null as an
-// explicit "clear this value" signal (both coerce to null) so a previously-set value can
-// be removed via update; without this, validators either reject blank/null values or omit
-// the field, leaving the columns effectively write-once-non-empty. The command layer already
-// persists null. See #2526.
 const emptyStringToNull = (value: unknown): unknown => {
   if (typeof value !== 'string') return value
   const trimmed = value.trim()


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-06-alinadivante-qa-fixes.md
Status: complete

## Goal
- Fix the remaining alinadivante QA failures from issue #2529: checkout template gateway validation and customer phone clearing.

## What Changed
- Checkout template updates now reject an explicit cleared `gatewayProviderKey`, preserving the existing provider and returning the same required-field validation key used by create.
- Customers v2 edit forms now submit cleared `primaryPhone` values as `null` for people and companies instead of omitting the field.
- Customer API phone validators now accept `null`/blank-as-null so the command layer can persist explicit phone clears.
- Added/updated executable integration coverage for checkout template gateway clearing and people/company phone clearing.

## Tests
- `yarn workspace @open-mercato/checkout test --runInBand packages/checkout/src/modules/checkout/data/__tests__/validators.test.ts`
- `yarn workspace @open-mercato/core test --runInBand packages/core/src/modules/customers/components/__tests__/formConfig.test.ts`
- `BASE_URL=http://127.0.0.1:63212 npx playwright test --config .ai/qa/tests/playwright.config.ts packages/checkout/src/modules/checkout/__integration__/TC-CHKT-039-null-gateway-edit.spec.ts packages/core/src/modules/customers/__integration__/TC-CRM-076-clear-phone-v2.spec.ts --retries=0`
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage` (advisory unused-key report only)
- `yarn typecheck`
- `yarn test`
- `yarn build:app`

## Backward Compatibility
- No API routes, response fields, DB schema, event IDs, widget spots, DI names, ACL IDs, or import paths were removed.
- Checkout template update validation now rejects explicit blank/null `gatewayProviderKey` to align edit behavior with the existing required UI/create contract.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-06-alinadivante-qa-fixes.md#progress).
