### PR TITLE
Harden unauthenticated provider webhook failures

### DIFF
--- a/packages/core/src/modules/payment_gateways/api/__tests__/webhook-route.test.ts
+++ b/packages/core/src/modules/payment_gateways/api/__tests__/webhook-route.test.ts
@@ -1,0 +1,111 @@
+/** @jest-environment node */
+import { POST } from '@open-mercato/core/modules/payment_gateways/api/webhook/[provider]/route'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { getWebhookHandler } from '@open-mercato/shared/modules/payment_gateways/types'
+import { getPaymentGatewayQueue } from '@open-mercato/core/modules/payment_gateways/lib/queue'
+import { processPaymentGatewayWebhookJob } from '@open-mercato/core/modules/payment_gateways/lib/webhook-processor'
+
+const mockResolve = jest.fn()
+const mockRateLimiterService = { trustProxyDepth: 1, consume: jest.fn() }
+const mockCredentialsService = { resolve: jest.fn() }
+const mockQueue = { enqueue: jest.fn() }
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: mockResolve,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/modules/payment_gateways/types', () => ({
+  getWebhookHandler: jest.fn(),
+}))
+
+jest.mock('@open-mercato/core/modules/payment_gateways/lib/queue', () => ({
+  getPaymentGatewayQueue: jest.fn(),
+}))
+
+jest.mock('@open-mercato/core/modules/payment_gateways/lib/webhook-processor', () => ({
+  processPaymentGatewayWebhookJob: jest.fn(),
+}))
+
+function createMockRequest(body: string, headers: Record<string, string> = {}): Request {
+  return {
+    method: 'POST',
+    headers: new Headers(headers),
+    text: jest.fn(async () => body),
+  } as unknown as Request
+}
+
+describe('payment gateway webhook route security', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRateLimiterService.consume.mockResolvedValue({
+      allowed: true,
+      remainingPoints: 59,
+      msBeforeNext: 0,
+      consumedPoints: 1,
+    })
+    mockCredentialsService.resolve.mockResolvedValue({})
+    mockResolve.mockImplementation((token: string) => {
+      if (token === 'rateLimiterService') return mockRateLimiterService
+      if (token === 'em') return {}
+      if (token === 'paymentGatewayService') return {}
+      if (token === 'integrationCredentialsService') return mockCredentialsService
+      if (token === 'integrationLogService') return {}
+      throw new Error(`Unexpected token: ${token}`)
+    })
+    ;(getPaymentGatewayQueue as jest.Mock).mockReturnValue(mockQueue)
+  })
+
+  test('rate limits unauthenticated provider webhooks before parsing the body', async () => {
+    const request = createMockRequest('{"session":"sess_1"}', { 'x-forwarded-for': '203.0.113.9' })
+    ;(getWebhookHandler as jest.Mock).mockReturnValue({
+      handler: jest.fn(),
+      readSessionIdHint: jest.fn(),
+    })
+    mockRateLimiterService.consume.mockResolvedValueOnce({
+      allowed: false,
+      remainingPoints: 0,
+      msBeforeNext: 30_000,
+      consumedPoints: 61,
+    })
+
+    const response = await POST(request, { params: { provider: 'stripe' } })
+
+    expect(response.status).toBe(429)
+    expect(mockRateLimiterService.consume).toHaveBeenCalledWith('stripe:203.0.113.9', {
+      points: 60,
+      duration: 60,
+      keyPrefix: 'payment_gateways:webhook',
+    })
+    expect(request.text).not.toHaveBeenCalled()
+    expect(findWithDecryption).not.toHaveBeenCalled()
+  })
+
+  test('does not reflect verifier exception details to unauthenticated callers', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const handler = jest.fn().mockRejectedValue(new Error('secret verifier internals'))
+    ;(getWebhookHandler as jest.Mock).mockReturnValue({
+      handler,
+      readSessionIdHint: () => 'sess_1',
+    })
+    ;(findWithDecryption as jest.Mock).mockResolvedValue([{
+      id: 'txn_1',
+      organizationId: 'org_1',
+      tenantId: 'tenant_1',
+    }])
+
+    const response = await POST(createMockRequest('{"session":"sess_1"}'), { params: { provider: 'stripe' } })
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body).toEqual({ error: 'Webhook verification failed' })
+    expect(JSON.stringify(body)).not.toContain('secret verifier internals')
+    expect(processPaymentGatewayWebhookJob).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+})

--- a/packages/core/src/modules/payment_gateways/api/webhook/[provider]/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/webhook/[provider]/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import { checkRateLimit, getClientIp, RATE_LIMIT_ERROR_FALLBACK } from '@open-mercato/shared/lib/ratelimit/helpers'
+import type { RateLimiterService } from '@open-mercato/shared/lib/ratelimit/service'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { getWebhookHandler } from '@open-mercato/shared/modules/payment_gateways/types'
 import type { IntegrationLogService } from '../../../../integrations/lib/log-service'
@@ -17,6 +19,14 @@ export const metadata = {
   POST: { requireAuth: false },
 }
 
+const WEBHOOK_VERIFICATION_FAILED = 'Webhook verification failed'
+
+const paymentGatewayWebhookRateLimitConfig = {
+  points: 60,
+  duration: 60,
+  keyPrefix: 'payment_gateways:webhook',
+}
+
 export async function POST(req: Request, { params }: { params: Promise<{ provider: string }> | { provider: string } }) {
   const resolvedParams = await params
   const providerKey = resolvedParams.provider
@@ -25,6 +35,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ provide
   if (!registration) {
     return NextResponse.json({ error: `No webhook handler for provider: ${providerKey}` }, { status: 404 })
   }
+
+  const rateLimitResponse = await checkProviderWebhookRateLimit(container, req, providerKey)
+  if (rateLimitResponse) return rateLimitResponse
 
   const rawBody = await req.text()
   const headers: Record<string, string> = {}
@@ -109,8 +122,32 @@ export async function POST(req: Request, { params }: { params: Promise<{ provide
 
     return NextResponse.json({ received: true, queued: true }, { status: 202 })
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : 'Webhook verification failed'
-    return NextResponse.json({ error: message }, { status: 401 })
+    console.warn(`[payment_gateways] Webhook verification failed for provider "${providerKey}"`, err)
+    return NextResponse.json({ error: WEBHOOK_VERIFICATION_FAILED }, { status: 401 })
+  }
+}
+
+async function checkProviderWebhookRateLimit(
+  container: { resolve: (name: string) => unknown },
+  req: Request,
+  providerKey: string,
+): Promise<NextResponse | null> {
+  const rateLimiterService = tryResolve<RateLimiterService>(container, 'rateLimiterService')
+  if (!rateLimiterService) return null
+
+  return checkRateLimit(
+    rateLimiterService,
+    paymentGatewayWebhookRateLimitConfig,
+    `${providerKey}:${getClientIp(req, rateLimiterService.trustProxyDepth) ?? 'unknown'}`,
+    RATE_LIMIT_ERROR_FALLBACK,
+  )
+}
+
+function tryResolve<T>(container: { resolve: (name: string) => unknown }, name: string): T | null {
+  try {
+    return container.resolve(name) as T
+  } catch {
+    return null
   }
 }
 

--- a/packages/core/src/modules/shipping_carriers/api/__tests__/webhook-route.test.ts
+++ b/packages/core/src/modules/shipping_carriers/api/__tests__/webhook-route.test.ts
@@ -1,0 +1,101 @@
+/** @jest-environment node */
+import { POST } from '@open-mercato/core/modules/shipping_carriers/api/webhook/[provider]/route'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { getShippingAdapter } from '@open-mercato/core/modules/shipping_carriers/lib/adapter-registry'
+import { getShippingCarrierQueue } from '@open-mercato/core/modules/shipping_carriers/lib/queue'
+
+const mockResolve = jest.fn()
+const mockRateLimiterService = { trustProxyDepth: 1, consume: jest.fn() }
+const mockCredentialsService = { resolve: jest.fn() }
+const mockQueue = { enqueue: jest.fn() }
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: mockResolve,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(),
+}))
+
+jest.mock('@open-mercato/core/modules/shipping_carriers/lib/adapter-registry', () => ({
+  getShippingAdapter: jest.fn(),
+}))
+
+jest.mock('@open-mercato/core/modules/shipping_carriers/lib/queue', () => ({
+  getShippingCarrierQueue: jest.fn(),
+}))
+
+function createMockRequest(body: string, headers: Record<string, string> = {}): Request {
+  return {
+    method: 'POST',
+    headers: new Headers(headers),
+    text: jest.fn(async () => body),
+  } as unknown as Request
+}
+
+describe('shipping carrier webhook route security', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRateLimiterService.consume.mockResolvedValue({
+      allowed: true,
+      remainingPoints: 59,
+      msBeforeNext: 0,
+      consumedPoints: 1,
+    })
+    mockCredentialsService.resolve.mockResolvedValue({})
+    mockResolve.mockImplementation((token: string) => {
+      if (token === 'rateLimiterService') return mockRateLimiterService
+      if (token === 'em') return {}
+      if (token === 'integrationCredentialsService') return mockCredentialsService
+      throw new Error(`Unexpected token: ${token}`)
+    })
+    ;(getShippingCarrierQueue as jest.Mock).mockReturnValue(mockQueue)
+  })
+
+  test('rate limits unauthenticated provider webhooks before parsing the body', async () => {
+    const request = createMockRequest('{"shipmentId":"ship_1"}', { 'x-forwarded-for': '203.0.113.10' })
+    ;(getShippingAdapter as jest.Mock).mockReturnValue({
+      verifyWebhook: jest.fn(),
+    })
+    mockRateLimiterService.consume.mockResolvedValueOnce({
+      allowed: false,
+      remainingPoints: 0,
+      msBeforeNext: 30_000,
+      consumedPoints: 61,
+    })
+
+    const response = await POST(request, { params: { provider: 'shippo' } })
+
+    expect(response.status).toBe(429)
+    expect(mockRateLimiterService.consume).toHaveBeenCalledWith('shippo:203.0.113.10', {
+      points: 60,
+      duration: 60,
+      keyPrefix: 'shipping_carriers:webhook',
+    })
+    expect(request.text).not.toHaveBeenCalled()
+    expect(findWithDecryption).not.toHaveBeenCalled()
+  })
+
+  test('does not reflect verifier exception details to unauthenticated callers', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+    ;(getShippingAdapter as jest.Mock).mockReturnValue({
+      verifyWebhook: jest.fn().mockRejectedValue(new Error('carrier verifier internals')),
+    })
+    ;(findWithDecryption as jest.Mock).mockResolvedValue([{
+      id: 'shipment_1',
+      organizationId: 'org_1',
+      tenantId: 'tenant_1',
+    }])
+
+    const response = await POST(createMockRequest('{"shipmentId":"ship_1"}'), { params: { provider: 'shippo' } })
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body).toEqual({ error: 'Webhook verification failed' })
+    expect(JSON.stringify(body)).not.toContain('carrier verifier internals')
+    expect(mockQueue.enqueue).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/api/webhook/[provider]/route.ts
+++ b/packages/core/src/modules/shipping_carriers/api/webhook/[provider]/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import { checkRateLimit, getClientIp, RATE_LIMIT_ERROR_FALLBACK } from '@open-mercato/shared/lib/ratelimit/helpers'
+import type { RateLimiterService } from '@open-mercato/shared/lib/ratelimit/service'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { CredentialsService } from '../../../../integrations/lib/credentials-service'
 import { CarrierShipment } from '../../../data/entities'
@@ -12,6 +14,14 @@ import { shippingCarriersTag } from '../../openapi'
 export const metadata = {
   path: '/shipping-carriers/webhook/[provider]',
   POST: { requireAuth: false },
+}
+
+const WEBHOOK_VERIFICATION_FAILED = 'Webhook verification failed'
+
+const shippingCarrierWebhookRateLimitConfig = {
+  points: 60,
+  duration: 60,
+  keyPrefix: 'shipping_carriers:webhook',
 }
 
 function readCarrierShipmentId(payload: Record<string, unknown> | null): string | null {
@@ -34,13 +44,16 @@ export async function POST(req: Request, { params }: { params: Promise<{ provide
     return NextResponse.json({ error: `No shipping adapter for provider: ${providerKey}` }, { status: 404 })
   }
 
+  const container = await createRequestContainer()
+  const rateLimitResponse = await checkProviderWebhookRateLimit(container, req, providerKey)
+  if (rateLimitResponse) return rateLimitResponse
+
   const rawBody = await req.text()
   const headers: Record<string, string> = {}
   req.headers.forEach((value, key) => {
     headers[key] = value
   })
 
-  const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
   const integrationCredentialsService = container.resolve('integrationCredentialsService') as CredentialsService
   const queue = getShippingCarrierQueue('shipping-carriers-webhook')
@@ -101,8 +114,32 @@ export async function POST(req: Request, { params }: { params: Promise<{ provide
 
     return NextResponse.json({ received: true, queued: true }, { status: 202 })
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : 'Webhook verification failed'
-    return NextResponse.json({ error: message }, { status: 401 })
+    console.warn(`[shipping_carriers] Webhook verification failed for provider "${providerKey}"`, error)
+    return NextResponse.json({ error: WEBHOOK_VERIFICATION_FAILED }, { status: 401 })
+  }
+}
+
+async function checkProviderWebhookRateLimit(
+  container: { resolve: (name: string) => unknown },
+  req: Request,
+  providerKey: string,
+): Promise<NextResponse | null> {
+  const rateLimiterService = tryResolve<RateLimiterService>(container, 'rateLimiterService')
+  if (!rateLimiterService) return null
+
+  return checkRateLimit(
+    rateLimiterService,
+    shippingCarrierWebhookRateLimitConfig,
+    `${providerKey}:${getClientIp(req, rateLimiterService.trustProxyDepth) ?? 'unknown'}`,
+    RATE_LIMIT_ERROR_FALLBACK,
+  )
+}
+
+function tryResolve<T>(container: { resolve: (name: string) => unknown }, name: string): T | null {
+  try {
+    return container.resolve(name) as T
+  } catch {
+    return null
   }
 }
 


### PR DESCRIPTION
## Summary
- add provider+IP rate limiting to unauthenticated payment gateway and shipping carrier webhook routes before body parsing
- stop reflecting verifier exception messages to unauthenticated callers; return a constant verification failure response and log details server-side
- add focused route tests covering rate-limit short-circuiting and generic verifier-error responses

Fixes #2247

## Validation
- corepack yarn install --immutable (completed with warnings)
- corepack yarn build:packages
- git diff --check

## Local blockers
- Focused Jest and a broader module Jest run currently fail before test execution with TS5011 rootDir errors from the repo Jest/TS6 transformer. I confirmed an existing untouched test has the same failure mode.
- core typecheck needs generated #generated entity files; yarn generate is blocked in this shell because the repo requires Node 24.x and the local runtime is Node 23.7.0.