### PR TITLE
fix(dev): don't crash dev runtime when ps memory-monitor spawn throws

### DIFF
--- a/apps/mercato/scripts/dev.mjs
+++ b/apps/mercato/scripts/dev.mjs
@@ -1086,9 +1086,17 @@ async function getProcessTreeMemoryBytes(rootPid) {
   if (process.platform === 'win32') return null
 
   return new Promise((resolve) => {
-    const inspector = spawn('ps', ['-axo', 'pid=,ppid=,rss='], {
-      stdio: ['ignore', 'pipe', 'ignore'],
-    })
+    let inspector
+    try {
+      inspector = spawn('ps', ['-axo', 'pid=,ppid=,rss='], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+    } catch {
+      // spawn can throw synchronously (e.g. ENAMETOOLONG); the memory monitor
+      // is cosmetic, so degrade to "no sample" instead of crashing the runtime.
+      resolve(null)
+      return
+    }
 
     let output = ''
     inspector.stdout?.setEncoding('utf8')


### PR DESCRIPTION
## What

Wrap the `spawn('ps', ...)` call in `getProcessTreeMemoryBytes()` (`apps/mercato/scripts/dev.mjs`) in a `try/catch`. If `spawn` throws **synchronously**, the dev runtime now degrades to "no memory sample" (resolves `null`) instead of crashing.

## Why

`child_process.spawn` can throw synchronously in some environments (e.g. `ENAMETOOLONG`, or other platform-level failures) before any `error` event is emitted. The dev-mode memory monitor is purely cosmetic — it samples process-tree RSS for display — so a failure to sample should never take down the whole dev server. Previously an unhandled synchronous throw here could crash the runtime.

## Change

- `apps/mercato/scripts/dev.mjs`: `try/catch` around the `ps` spawn; on throw, `resolve(null)` and return early.

## Notes for reviewers

- Behavior is unchanged on the happy path; the existing async `error`-event handling still applies once the process is spawned.
- One file, +11/-3. No public contract surface touched.
- Opened from a fork (`hkpostam:fix/dev-memory-monitor-spawn-crash`) because the author currently has read-only access to the upstream repo — note the project's label/QA automation may need a maintainer to kick it off since this is a cross-fork PR.

Closes #2682
