### PR TITLE
fix: 2744 deep decrypt collections

### DIFF
--- a/packages/shared/src/lib/encryption/__tests__/subscriber.deep-decrypt-collections.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/subscriber.deep-decrypt-collections.test.ts
@@ -1,0 +1,123 @@
+import { ReferenceKind } from '@mikro-orm/core'
+import { TenantEncryptionSubscriber } from '../subscriber'
+import { registerEntityIds } from '../entityIds'
+import type { TenantDataEncryptionService } from '../tenantDataEncryptionService'
+
+// Regression coverage for issue #2744: a loaded *-to-many Collection relation must be expanded into
+// its items during deep-decrypt. extractEntities() previously matched the MikroORM Reference branch
+// first — both a Collection and a Reference expose isInitialized() — so a Collection (which has no
+// unwrap()/__entity) was returned as the wrapper itself and decrypt() ran on the Collection instead
+// of each item, leaving encrypted child fields as ciphertext in populated response graphs.
+
+// Mirrors a MikroORM Collection: exposes isInitialized() + getItems(), but NO unwrap()/__entity.
+function makeCollection(items: Record<string, unknown>[], initialized = true) {
+  return {
+    isInitialized: () => initialized,
+    getItems: () => items,
+  }
+}
+
+// Mirrors a MikroORM Reference: exposes isInitialized() + unwrap(), but NO getItems().
+function makeReference(entity: Record<string, unknown>, initialized = true) {
+  return {
+    isInitialized: () => initialized,
+    unwrap: () => entity,
+  }
+}
+
+const CHILD_META = { className: 'Child', tableName: 'children', properties: {} } as any
+
+const parentMeta = (childKind: ReferenceKind, relationName: string) =>
+  ({
+    className: 'Parent',
+    tableName: 'parents',
+    properties: { [relationName]: { name: relationName, kind: childKind } },
+  }) as any
+
+function makeEm() {
+  return { getMetadata: () => undefined, getComparator: () => undefined }
+}
+
+// Decrypts by stripping an "enc:" prefix; records every entity id it was asked to decrypt.
+function makeService(decryptedEntityIds: string[]): TenantDataEncryptionService {
+  return {
+    isEnabled: () => true,
+    async decryptEntityPayload(entityId: string, target: Record<string, unknown>) {
+      decryptedEntityIds.push(entityId)
+      const value = target.secret
+      if (typeof value === 'string' && value.startsWith('enc:')) {
+        return { secret: value.slice('enc:'.length) }
+      }
+      return {}
+    },
+  } as unknown as TenantDataEncryptionService
+}
+
+describe('TenantEncryptionSubscriber deep-decrypt of loaded collection relations (issue #2744)', () => {
+  const originalToggle = process.env.TENANT_DATA_ENCRYPTION
+
+  beforeEach(() => {
+    delete process.env.TENANT_DATA_ENCRYPTION // default => encryption enabled
+    registerEntityIds({ test: { parent: 'test:parent', child: 'test:child' } })
+  })
+
+  afterEach(() => {
+    if (originalToggle === undefined) delete process.env.TENANT_DATA_ENCRYPTION
+    else process.env.TENANT_DATA_ENCRYPTION = originalToggle
+    jest.restoreAllMocks()
+  })
+
+  it('decrypts every item of an initialized ONE_TO_MANY collection', async () => {
+    const decryptedEntityIds: string[] = []
+    const childA = { secret: 'enc:alpha', tenantId: 't1', __meta: CHILD_META }
+    const childB = { secret: 'enc:beta', tenantId: 't1', __meta: CHILD_META }
+    const meta = parentMeta(ReferenceKind.ONE_TO_MANY, 'children')
+    const parent = { tenantId: 't1', children: makeCollection([childA, childB]), __meta: meta }
+
+    const subscriber = new TenantEncryptionSubscriber(makeService(decryptedEntityIds))
+    await subscriber.decryptEntityGraph(parent, meta, makeEm(), { syncOriginal: true })
+
+    expect(childA.secret).toBe('alpha')
+    expect(childB.secret).toBe('beta')
+    expect(decryptedEntityIds.filter((id) => id === 'test:child')).toHaveLength(2)
+  })
+
+  it('decrypts every item of an initialized MANY_TO_MANY collection', async () => {
+    const decryptedEntityIds: string[] = []
+    const child = { secret: 'enc:gamma', tenantId: 't1', __meta: CHILD_META }
+    const meta = parentMeta(ReferenceKind.MANY_TO_MANY, 'children')
+    const parent = { tenantId: 't1', children: makeCollection([child]), __meta: meta }
+
+    const subscriber = new TenantEncryptionSubscriber(makeService(decryptedEntityIds))
+    await subscriber.decryptEntityGraph(parent, meta, makeEm(), { syncOriginal: true })
+
+    expect(child.secret).toBe('gamma')
+    expect(decryptedEntityIds).toContain('test:child')
+  })
+
+  it('leaves an uninitialized collection untouched (does not decrypt unloaded items)', async () => {
+    const decryptedEntityIds: string[] = []
+    const child = { secret: 'enc:delta', tenantId: 't1', __meta: CHILD_META }
+    const meta = parentMeta(ReferenceKind.ONE_TO_MANY, 'children')
+    const parent = { tenantId: 't1', children: makeCollection([child], false), __meta: meta }
+
+    const subscriber = new TenantEncryptionSubscriber(makeService(decryptedEntityIds))
+    await subscriber.decryptEntityGraph(parent, meta, makeEm(), { syncOriginal: true })
+
+    expect(child.secret).toBe('enc:delta')
+    expect(decryptedEntityIds).not.toContain('test:child')
+  })
+
+  it('still decrypts a single-valued MANY_TO_ONE Reference (reorder must not regress references)', async () => {
+    const decryptedEntityIds: string[] = []
+    const child = { secret: 'enc:epsilon', tenantId: 't1', __meta: CHILD_META }
+    const meta = parentMeta(ReferenceKind.MANY_TO_ONE, 'child')
+    const parent = { tenantId: 't1', child: makeReference(child), __meta: meta }
+
+    const subscriber = new TenantEncryptionSubscriber(makeService(decryptedEntityIds))
+    await subscriber.decryptEntityGraph(parent, meta, makeEm(), { syncOriginal: true })
+
+    expect(child.secret).toBe('epsilon')
+    expect(decryptedEntityIds).toContain('test:child')
+  })
+})

--- a/packages/shared/src/lib/encryption/subscriber.ts
+++ b/packages/shared/src/lib/encryption/subscriber.ts
@@ -320,6 +320,17 @@ export class TenantEncryptionSubscriber implements EventSubscriber<any> {
     try {
       const extractEntities = (value: any): any[] => {
         if (!value) return []
+        // MikroORM Collection wrapper — MUST be checked before the Reference branch: both wrappers
+        // expose isInitialized(), but only a Collection exposes getItems(). Matching the Reference
+        // branch first returned the Collection wrapper itself instead of its items, so collection
+        // relations were never deep-decrypted and leaked ciphertext (issue #2744).
+        if (typeof value === 'object' && typeof (value as any).isInitialized === 'function' && typeof (value as any).getItems === 'function') {
+          try {
+            return (value as any).isInitialized() ? (value as any).getItems() ?? [] : []
+          } catch {
+            return []
+          }
+        }
         // MikroORM Reference wrapper
         if (typeof value === 'object' && typeof (value as any).isInitialized === 'function') {
           try {
@@ -331,14 +342,6 @@ export class TenantEncryptionSubscriber implements EventSubscriber<any> {
             // ignore
           }
           return []
-        }
-        // Collection wrapper
-        if (typeof value === 'object' && typeof (value as any).isInitialized === 'function' && typeof (value as any).getItems === 'function') {
-          try {
-            return (value as any).isInitialized() ? (value as any).getItems() ?? [] : []
-          } catch {
-            return []
-          }
         }
         if (Array.isArray(value)) return value
         if (typeof value === 'object') return [value]


### PR DESCRIPTION
## Summary

The tenant-encryption MikroORM subscriber's deep-decrypt helper misordered its wrapper type checks: in `extractEntities()` the `Reference` branch (which only tests `isInitialized()`) was checked before the `Collection` branch. Both a `Reference` and a `Collection` expose `isInitialized()`, but a `Collection` has no `unwrap()`/`__entity`, so it fell through and was returned as the wrapper itself (`[collection]`), making the dedicated Collection branch (which tests `getItems()`) unreachable. As a result, items of an initialized ONE_TO_MANY / MANY_TO_MANY relation of an entity with encrypted fields were never decrypted — ciphertext leaked into populated response graphs (API responses, exports, downstream commands). This reorders the checks so the Collection branch (the only one with `getItems()`) runs first, making the two branches mutually exclusive and expanding collections into their items.

## Changes

- `packages/shared/src/lib/encryption/subscriber.ts`: in `extractEntities()`, check the MikroORM `Collection` branch (`isInitialized()` + `getItems()`) before the `Reference` branch (`isInitialized()` + `unwrap()`/`__entity`). Pure reorder + rationale comment; no other logic changed.
- `packages/shared/src/lib/encryption/__tests__/subscriber.deep-decrypt-collections.test.ts`: new regression test — initialized ONE_TO_MANY and MANY_TO_MANY collections decrypt every item; an uninitialized collection is left untouched; a single-valued MANY_TO_ONE `Reference` still decrypts (guards the reorder against regressing references).

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — single-function branch-ordering bug fix in a shared library.

## Testing

- `yarn workspace @open-mercato/shared test subscriber.deep-decrypt-collections` — 4/4 (red before the fix: `Received "enc:alpha"`/`"enc:gamma"`; green after).
- `yarn workspace @open-mercato/shared test` — 110 suites / 1185 tests pass (incl. existing encryption regressions #2498, #2235).
- `yarn test` — full monorepo, 22/22 turbo tasks (core 5494 tests), 0 failures.
- `yarn typecheck` — 21/21 packages. `yarn build:packages` — 21/21. `yarn build:app` — OK. `yarn i18n:check-sync` — in sync.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — internal logic; i18n sync passes.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Documented: the defect is a pure unit-level wrapper-dispatch ordering bug in a shared MikroORM subscriber, covered deterministically by new unit tests that fail without the fix (including a reference-path regression guard). An end-to-end test would require provisioning an encrypted entity with a populated `*-to-many` relation of another encrypted entity, which is disproportionate for a one-function dispatch fix.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A, minor fix.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI (backend/shared-lib change)
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled — N/A, no UI
- [x] Loading state handled — N/A, no UI
- [x] `aria-label` on icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2744