### PR TITLE
fix: 2745 ephemeral container cleanup

### DIFF
--- a/scripts/__tests__/dev-cache-purge.test.mjs
+++ b/scripts/__tests__/dev-cache-purge.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import {
   GREENFIELD_PURGE_TARGETS,
@@ -205,12 +206,37 @@ test('dev wrappers own shutdown notice and suppress duplicate runtime notices', 
 })
 
 test('ephemeral dev owns warmup marker and shutdown notice', async () => {
-  const here = path.dirname(new URL(import.meta.url).pathname)
+  const here = path.dirname(fileURLToPath(import.meta.url))
   const source = fs.readFileSync(path.resolve(here, '..', 'dev-ephemeral.ts'), 'utf8')
 
   assert.match(source, /OM_DEV_WARMUP_READY_FILE: warmupReadyFilePath/)
   assert.match(source, /function announceShutdown\(\): void/)
   assert.match(source, /Shutting down services\.\.\./)
-  assert.match(source, /process\.on\('SIGINT', \(\) => forwardSignal\('SIGINT'\)\)/)
-  assert.match(source, /announceShutdown\(\)\n\s+if \(!devCommand\.killed\)/)
+
+  // Shutdown + signal coordination is delegated to the dedicated controller.
+  assert.match(source, /createEphemeralShutdownController\(/)
+  assert.match(source, /shutdownController\.installSignalHandlers\(\)/)
+
+  // Issue #2745: signal handlers must be installed before the ephemeral
+  // PostgreSQL container is created, so an interrupt during initialization
+  // still removes the container instead of leaking it.
+  const installIdx = source.indexOf('shutdownController.installSignalHandlers()')
+  const startContainerIdx = source.indexOf('await startEphemeralPostgres()')
+  assert.notEqual(installIdx, -1, 'main() must install signal handlers')
+  assert.notEqual(startContainerIdx, -1, 'main() must start the ephemeral container')
+  assert.ok(
+    installIdx < startContainerIdx,
+    'signal handlers must be installed before the ephemeral container is created (#2745)',
+  )
+
+  // Issue #2745: the dev child exit handler must be registered before readiness
+  // is awaited, so a signal-forwarded kill during that window still cleans up.
+  const exitHandlerIdx = source.indexOf("devCommand.on('exit'")
+  const readinessIdx = source.indexOf('waitForDevServerReady(loopbackUrl)')
+  assert.notEqual(exitHandlerIdx, -1, 'startDevServer must handle the dev child exit')
+  assert.notEqual(readinessIdx, -1, 'startDevServer must wait for readiness')
+  assert.ok(
+    exitHandlerIdx < readinessIdx,
+    'the dev child exit handler must be registered before waiting for readiness (#2745)',
+  )
 })

--- a/scripts/__tests__/dev-ephemeral-shutdown.test.mjs
+++ b/scripts/__tests__/dev-ephemeral-shutdown.test.mjs
@@ -1,0 +1,184 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { createEphemeralShutdownController } from '../dev-ephemeral-shutdown.mjs'
+
+// Regression guard for issue #2745: the ephemeral PostgreSQL container must be
+// removed (awaited) before the process exits, and a SIGINT/SIGTERM that fires
+// during initialization — before any dev child exists — must still remove the
+// container instead of letting the process die and leak it.
+
+function createDeferred() {
+  let resolve = () => {}
+  const promise = new Promise((resolveFn) => {
+    resolve = resolveFn
+  })
+  return { promise, resolve }
+}
+
+function flushAsync() {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
+test('shutdown awaits container removal before exiting (#2745)', async () => {
+  const events = []
+  const stopGate = createDeferred()
+  const controller = createEphemeralShutdownController({
+    stopContainer: async (containerId) => {
+      events.push(`stop:start:${containerId}`)
+      await stopGate.promise
+      events.push(`stop:done:${containerId}`)
+    },
+    exit: (code) => {
+      events.push(`exit:${code}`)
+    },
+  })
+  controller.setActiveContainerId('container-abc')
+
+  const shuttingDown = controller.shutdown(7)
+
+  // The container removal is still in flight, so the process must NOT have
+  // exited yet. The previous fire-and-forget implementation called
+  // process.exit() here, tearing Node down before `docker rm -f` ran.
+  assert.deepEqual(events, ['stop:start:container-abc'])
+
+  stopGate.resolve()
+  await shuttingDown
+
+  assert.deepEqual(events, ['stop:start:container-abc', 'stop:done:container-abc', 'exit:7'])
+})
+
+test('concurrent shutdown calls share one cleanup and exit once (#2745)', async () => {
+  const events = []
+  const stopGate = createDeferred()
+  const controller = createEphemeralShutdownController({
+    stopContainer: async (containerId) => {
+      events.push(`stop:start:${containerId}`)
+      await stopGate.promise
+      events.push(`stop:done:${containerId}`)
+    },
+    exit: (code) => {
+      events.push(`exit:${code}`)
+    },
+  })
+  controller.setActiveContainerId('container-abc')
+
+  // A signal-initiated shutdown begins, then main() independently calls shutdown
+  // again before cleanup finishes (e.g. the interrupted `initialize` step fails).
+  // The second call must await the same in-flight cleanup, not exit early —
+  // otherwise its process.exit() pre-empts the still-running `docker rm -f`.
+  const first = controller.shutdown(0)
+  const second = controller.shutdown(5)
+
+  assert.deepEqual(events, ['stop:start:container-abc'], 'must not exit before cleanup completes')
+
+  stopGate.resolve()
+  await Promise.all([first, second])
+
+  assert.deepEqual(events, ['stop:start:container-abc', 'stop:done:container-abc', 'exit:0'])
+})
+
+test('a signal during initialization removes the container before exiting (#2745)', async () => {
+  const events = []
+  const processRef = new EventEmitter()
+  const stopGate = createDeferred()
+  const controller = createEphemeralShutdownController({
+    stopContainer: async (containerId) => {
+      events.push(`stop:${containerId}`)
+      await stopGate.promise
+    },
+    exit: (code) => {
+      events.push(`exit:${code}`)
+    },
+    onInterrupt: () => {
+      events.push('announce')
+    },
+    processRef,
+  })
+
+  // Handlers installed up front (before the container exists) and only then is
+  // the container registered — mirroring the fixed ordering in main().
+  controller.installSignalHandlers()
+  controller.setActiveContainerId('container-xyz')
+
+  processRef.emit('SIGINT')
+
+  // The handler must begin removing the container; it must not have exited yet.
+  assert.deepEqual(events, ['announce', 'stop:container-xyz'])
+
+  stopGate.resolve()
+  await flushAsync()
+
+  assert.ok(events.includes('exit:0'), 'process must exit after the container is removed')
+  assert.ok(
+    events.indexOf('stop:container-xyz') < events.indexOf('exit:0'),
+    'the container must be removed before the process exits',
+  )
+})
+
+test('a signal while the dev runtime is running forwards the signal for a graceful shutdown', () => {
+  const events = []
+  const processRef = new EventEmitter()
+  const devChild = {
+    killed: false,
+    kill: (signal) => events.push(`kill:${signal}`),
+  }
+  const controller = createEphemeralShutdownController({
+    stopContainer: async () => {
+      events.push('stop')
+    },
+    exit: (code) => {
+      events.push(`exit:${code}`)
+    },
+    onInterrupt: () => {
+      events.push('announce')
+    },
+    processRef,
+  })
+  controller.installSignalHandlers()
+  controller.setActiveContainerId('container-1')
+  controller.setActiveChild(devChild)
+
+  processRef.emit('SIGTERM')
+
+  // With a live dev child the signal is forwarded so the runtime can shut down
+  // gracefully; its own exit handler removes the container afterwards. The
+  // controller must not force-stop or exit directly here.
+  assert.deepEqual(events, ['announce', 'kill:SIGTERM'])
+})
+
+test('installSignalHandlers is idempotent', () => {
+  const processRef = new EventEmitter()
+  const controller = createEphemeralShutdownController({
+    stopContainer: async () => {},
+    exit: () => {},
+    processRef,
+  })
+
+  controller.installSignalHandlers()
+  controller.installSignalHandlers()
+
+  assert.equal(processRef.listenerCount('SIGINT'), 1)
+  assert.equal(processRef.listenerCount('SIGTERM'), 1)
+})
+
+test('shutdown exits even when no container was started', async () => {
+  const events = []
+  const controller = createEphemeralShutdownController({
+    stopContainer: async () => {
+      events.push('stop')
+    },
+    exit: (code) => {
+      events.push(`exit:${code}`)
+    },
+  })
+
+  await controller.shutdown(3)
+
+  assert.deepEqual(events, ['exit:3'])
+})
+
+test('requires a stopContainer function', () => {
+  assert.throws(() => createEphemeralShutdownController({}), TypeError)
+})

--- a/scripts/dev-ephemeral-shutdown.mjs
+++ b/scripts/dev-ephemeral-shutdown.mjs
@@ -1,0 +1,80 @@
+// Coordinates graceful shutdown of the ephemeral dev runner (scripts/dev-ephemeral.ts).
+//
+// Owns the active PostgreSQL container id and the running dev child so that a
+// single place decides how the process tears down. Fixes issue #2745:
+//  - the container removal is awaited before `process.exit` (it used to be a
+//    fire-and-forget call right before exiting, which tore Node down before
+//    `docker rm -f` ran and leaked the container);
+//  - signal handlers are installed up front (before the container is created)
+//    and remove the active container, so a SIGINT/SIGTERM that arrives during
+//    initialization still cleans up instead of leaking the container.
+export function createEphemeralShutdownController({
+  stopContainer,
+  beforeExit = () => {},
+  onInterrupt = () => {},
+  exit = (code) => process.exit(code),
+  processRef = process,
+} = {}) {
+  if (typeof stopContainer !== 'function') {
+    throw new TypeError('createEphemeralShutdownController requires a stopContainer(containerId) function')
+  }
+
+  let activeContainerId = null
+  let activeChild = null
+  let shutdownPromise = null
+  let handlersInstalled = false
+
+  const setActiveContainerId = (containerId) => {
+    activeContainerId = containerId || null
+  }
+
+  const setActiveChild = (child) => {
+    activeChild = child ?? null
+  }
+
+  const runShutdown = async (exitCode) => {
+    beforeExit()
+    const containerId = activeContainerId
+    if (containerId) {
+      activeContainerId = null
+      try {
+        await stopContainer(containerId)
+      } catch {
+        // Best-effort cleanup: never block the exit on a docker error.
+      }
+    }
+    return exit(exitCode)
+  }
+
+  // Deduplicate into a single in-flight shutdown: a signal handler can start the
+  // teardown while main() independently calls shutdown again (e.g. the
+  // interrupted step reports failure). Both must await the SAME cleanup so the
+  // second caller cannot process.exit() before the container removal completes.
+  const shutdown = (exitCode) => {
+    if (!shutdownPromise) {
+      shutdownPromise = runShutdown(exitCode)
+    }
+    return shutdownPromise
+  }
+
+  const handleSignal = (signal) => {
+    onInterrupt()
+    if (activeChild && typeof activeChild.kill === 'function' && !activeChild.killed) {
+      // The dev runtime is up — forward the signal so it shuts down gracefully;
+      // its exit handler removes the container and the main flow then exits.
+      activeChild.kill(signal)
+      return
+    }
+    // No dev child yet (still initializing) — remove the container and exit.
+    void shutdown(0)
+  }
+
+  const installSignalHandlers = () => {
+    if (handlersInstalled) return
+    handlersInstalled = true
+    processRef.on('SIGINT', () => handleSignal('SIGINT'))
+    processRef.on('SIGTERM', () => handleSignal('SIGTERM'))
+  }
+
+  return { shutdown, installSignalHandlers, setActiveContainerId, setActiveChild }
+}

--- a/scripts/dev-ephemeral.ts
+++ b/scripts/dev-ephemeral.ts
@@ -13,6 +13,7 @@ import {
   redactPostgresUrl,
 } from '../packages/cli/src/lib/testing/runtime-utils'
 import { createDevSplashCodingFlow } from './dev-splash-coding-flow.mjs'
+import { createEphemeralShutdownController } from './dev-ephemeral-shutdown.mjs'
 import { normalizeSplashDisplayState } from './dev-splash-state.mjs'
 import {
   resolveDevBaseUrl,
@@ -443,8 +444,6 @@ function closeSplashServer(): void {
   rmSync(splashChildStateFilePath, { force: true })
 }
 
-let activePostgresContainerId: string | null = null
-
 function announceShutdown(): void {
   if (shuttingDown) return
   shuttingDown = true
@@ -459,15 +458,19 @@ function announceShutdown(): void {
   console.log(message)
 }
 
-function shutdown(exitCode: number): never {
-  if (!shuttingDown) {
+const shutdownController = createEphemeralShutdownController({
+  stopContainer: (containerId: string) => stopPostgresContainer(containerId),
+  beforeExit: () => {
     announceShutdown()
     closeSplashServer()
-    if (activePostgresContainerId) {
-      stopPostgresContainer(activePostgresContainerId).catch(() => {})
-    }
-  }
-  process.exit(exitCode)
+  },
+  onInterrupt: () => {
+    announceShutdown()
+  },
+})
+
+async function shutdown(exitCode: number): Promise<never> {
+  return shutdownController.shutdown(exitCode)
 }
 
 async function fileExists(filePath: string): Promise<boolean> {
@@ -956,6 +959,7 @@ function openUrlInBrowser(url: string): Promise<boolean> {
 async function waitForDevServerReady(baseUrl: string): Promise<boolean> {
   const deadline = Date.now() + startupTimeoutMs
   while (Date.now() < deadline) {
+    if (shuttingDown) return false
     const responsive = await isEndpointResponsive(`${baseUrl}/backend/login`, probeTimeoutMs)
     if (responsive) {
       return true
@@ -1003,6 +1007,39 @@ async function startDevServer(port: number, postgres: EphemeralPostgresHandle): 
   if (!Number.isInteger(devCommand.pid) || devCommand.pid <= 0) {
     throw new Error('Failed to start development runtime process.')
   }
+
+  shutdownController.setActiveChild(devCommand)
+
+  let resolveExit: (code: number) => void = () => {}
+  let rejectExit: (reason: Error) => void = () => {}
+  const devExitPromise = new Promise<number>((resolve, reject) => {
+    resolveExit = resolve
+    rejectExit = reject
+  })
+  // The real handling happens via `await` in main(); suppress Node's
+  // unhandled-rejection guard for the window before that await is attached.
+  devExitPromise.catch(() => {})
+
+  // Register the child lifecycle handlers immediately so a signal that arrives
+  // while waiting for readiness (which forwards a kill to the child) still runs
+  // cleanup — otherwise the 'exit' event would fire before any handler exists.
+  devCommand.on('error', async (error) => {
+    shutdownController.setActiveChild(null)
+    await unregisterCurrentDevInstance(devCommand.pid as number)
+    await stopPostgresContainer(postgres.containerId)
+    shutdownController.setActiveContainerId(null)
+    closeSplashServer()
+    rejectExit(error)
+  })
+
+  devCommand.on('exit', async (code, _signal) => {
+    shutdownController.setActiveChild(null)
+    await unregisterCurrentDevInstance(devCommand.pid as number)
+    await stopPostgresContainer(postgres.containerId)
+    shutdownController.setActiveContainerId(null)
+    closeSplashServer()
+    resolveExit(code ?? 1)
+  })
 
   const instanceState: DevEphemeralInstance = {
     id: `${devCommand.pid}:${new Date().toISOString()}`,
@@ -1068,35 +1105,12 @@ async function startDevServer(port: number, postgres: EphemeralPostgresHandle): 
     }
   }
 
-  const forwardSignal = (signal: NodeJS.Signals): void => {
-    announceShutdown()
-    if (!devCommand.killed) {
-      devCommand.kill(signal)
-    }
-  }
-
-  process.on('SIGINT', () => forwardSignal('SIGINT'))
-  process.on('SIGTERM', () => forwardSignal('SIGTERM'))
-
-  return new Promise((resolve, reject) => {
-    devCommand.on('error', async (error) => {
-      await unregisterCurrentDevInstance(devCommand.pid as number)
-      await stopPostgresContainer(postgres.containerId)
-      closeSplashServer()
-      reject(error)
-    })
-
-    devCommand.on('exit', async (code, _signal) => {
-      await unregisterCurrentDevInstance(devCommand.pid as number)
-      await stopPostgresContainer(postgres.containerId)
-      closeSplashServer()
-      resolve(code ?? 1)
-    })
-  })
+  return devExitPromise
 }
 
 async function main(): Promise<void> {
   try {
+    shutdownController.installSignalHandlers()
     await startSplashServer()
     assertNode24Runtime({
       context: 'dev ephemeral mode',
@@ -1114,7 +1128,7 @@ async function main(): Promise<void> {
     })
     if (installExitCode !== 0) {
       await waitForSplashFailureRender()
-      shutdown(installExitCode)
+      await shutdown(installExitCode)
       return
     }
 
@@ -1126,7 +1140,7 @@ async function main(): Promise<void> {
     })
     if (buildPackagesExitCode !== 0) {
       await waitForSplashFailureRender()
-      shutdown(buildPackagesExitCode)
+      await shutdown(buildPackagesExitCode)
       return
     }
 
@@ -1138,7 +1152,7 @@ async function main(): Promise<void> {
     })
     if (generateExitCode !== 0) {
       await waitForSplashFailureRender()
-      shutdown(generateExitCode)
+      await shutdown(generateExitCode)
       return
     }
 
@@ -1153,7 +1167,7 @@ async function main(): Promise<void> {
       activity: 'Starting isolated PostgreSQL',
     })
     const postgres = await startEphemeralPostgres()
-    activePostgresContainerId = postgres.containerId
+    shutdownController.setActiveContainerId(postgres.containerId)
     const baseUrl = resolveDevBaseUrl(process.env, {
       actualPort: port,
       defaultHostname: '127.0.0.1',
@@ -1180,15 +1194,14 @@ async function main(): Promise<void> {
       },
     )
     if (initializeExitCode !== 0) {
-      await stopPostgresContainer(postgres.containerId)
       await waitForSplashFailureRender()
-      shutdown(initializeExitCode)
+      await shutdown(initializeExitCode)
       return
     }
 
     console.log(`[dev:ephemeral] Starting development runtime on ${baseUrl}/backend`)
     const exitCode = await startDevServer(port, postgres)
-    shutdown(exitCode)
+    await shutdown(exitCode)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     updateSplashState({
@@ -1203,7 +1216,7 @@ async function main(): Promise<void> {
     })
     await waitForSplashFailureRender()
     console.error(`[dev:ephemeral] ${message}`)
-    shutdown(1)
+    await shutdown(1)
   }
 }
 


### PR DESCRIPTION
## Summary

The `yarn dev:ephemeral` runner (`scripts/dev-ephemeral.ts`) could leak its isolated
PostgreSQL Docker container. `shutdown()` ran `stopPostgresContainer(...).catch(() => {})`
(fire-and-forget) immediately before `process.exit()`, so Node exited before `docker rm -f`
ran; and the `SIGINT`/`SIGTERM` handlers were only installed inside `startDevServer`, after
the container was created during the long `yarn initialize` step — so an interrupt during
initialization killed the process with Node defaults and never removed the container.

This extracts the shutdown/signal logic into a small dependency-injected controller that
(1) awaits container removal before exiting and (2) installs signal handlers up front
(before the container is created), and wires it into the dev runner.

## Changes

- Add `scripts/dev-ephemeral-shutdown.mjs`: a shutdown/signal controller that awaits
  `docker rm -f` before `process.exit`, installs `SIGINT`/`SIGTERM` handlers eagerly,
  forwards signals to the running dev child (else cleans up directly), and dedupes
  concurrent shutdowns into one in-flight promise so a second caller can't exit before
  cleanup completes.
- `scripts/dev-ephemeral.ts`: install handlers at the top of `main()` (before
  `startEphemeralPostgres()`); register the dev child `exit`/`error` handlers right after
  spawn so a signal-forwarded kill during readiness still cleans up; bail the readiness
  loop on shutdown; `await` every `shutdown(...)`; drop the now-redundant explicit container
  stop in the initialize-failure path.
- Add `scripts/__tests__/dev-ephemeral-shutdown.test.mjs`: behavioral coverage for awaited
  cleanup, signal-during-init cleanup, concurrent-shutdown dedup, graceful signal forwarding,
  and idempotent handler install.
- Update the `ephemeral dev owns warmup marker and shutdown notice` guard in
  `scripts/__tests__/dev-cache-purge.test.mjs` to the new wiring and add #2745 ordering
  assertions.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — dev-tooling bug fix.

## Testing

- `node --test scripts/__tests__/dev-ephemeral-shutdown.test.mjs` → 7/7 pass (red → green on unfixed code).
- `yarn test:scripts` → 182/186 pass. The 4 failures are a pre-existing, unrelated env issue
  (worktree path contains a space → `%20` from `new URL(import.meta.url).pathname` in other
  `dev-cache-purge` tests); not introduced by this change.
- `node --check scripts/dev-ephemeral-shutdown.mjs` and esbuild transpile of `scripts/dev-ephemeral.ts` — both clean.
- `typecheck` / `lint` / `test` / `build:app` / `i18n:check-sync` are N/A: `scripts/` is in no tsconfig
  (run via `tsx`), has no eslint coverage, no package/app imports the changed files, and no
  locale/user-facing strings or entities changed.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- none required -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- N/A: scripts/dev-ephemeral.ts is a dev-orchestration script not exercised by the Playwright integration harness; covered by node --test script tests instead -->
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A: no spec -->

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2745