### PR TITLE
fix: 2746 dek lifecycle

### DIFF
--- a/packages/shared/src/lib/encryption/__tests__/dek-lifecycle.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/dek-lifecycle.test.ts
@@ -1,0 +1,194 @@
+import { decryptWithAesGcm, generateDek } from '../aes'
+import { HashicorpVaultKmsService, type KmsService, type TenantDek } from '../kms'
+import { TenantDataEncryptionService } from '../tenantDataEncryptionService'
+
+const originalEnv = { ...process.env }
+
+type DuckResponse = { ok: boolean; status: number; json: () => Promise<unknown> }
+
+function jsonResponse(status: number, body: Record<string, unknown>): DuckResponse {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+
+// Minimal in-memory Vault KV v2 simulator: GET reads the stored key, POST writes
+// it unless a `cas: 0` write loses to an existing version (concurrent create).
+function makeVaultSim() {
+  const store = new Map<string, string>()
+  const counts = { reads: 0, posts: 0, persisted: 0 }
+  const fetchMock = jest.fn(async (input: unknown, init?: RequestInit): Promise<DuckResponse> => {
+    const url = String(input)
+    const path = url.slice(url.indexOf('/v1/') + '/v1/'.length)
+    const method = (init?.method || 'GET').toUpperCase()
+    if (method === 'GET') {
+      counts.reads++
+      const key = store.get(path)
+      if (!key) return jsonResponse(404, { errors: [] })
+      return jsonResponse(200, { data: { data: { key } } })
+    }
+    counts.posts++
+    const body = init?.body ? (JSON.parse(String(init.body)) as { data?: { key?: string }; options?: { cas?: number } }) : {}
+    const cas = body.options?.cas
+    if (cas === 0 && store.has(path)) {
+      return jsonResponse(400, { errors: ['check-and-set parameter did not match the current version'] })
+    }
+    store.set(path, body.data?.key ?? '')
+    counts.persisted++
+    return jsonResponse(200, { data: { version: 1 } })
+  })
+  return { store, counts, fetchMock }
+}
+
+function installFetch(fetchMock: jest.Mock) {
+  ;(globalThis as { fetch?: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+}
+
+const fixedKey = (fill: number) => Buffer.alloc(32, fill).toString('base64')
+
+describe('HashicorpVaultKmsService DEK creation race (issue #2746)', () => {
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    jest.restoreAllMocks()
+  })
+
+  it('reuses an existing Vault DEK instead of overwriting it (read-before-write)', async () => {
+    const { store, counts, fetchMock } = makeVaultSim()
+    installFetch(fetchMock)
+    const service = new HashicorpVaultKmsService({ vaultAddr: 'http://vault.test', vaultToken: 'token' })
+    const existingKey = fixedKey(7)
+    store.set('secret/data/tenant_key_tenant-existing', existingKey)
+
+    const dek = await service.createTenantDek('tenant-existing')
+
+    expect(dek?.key).toBe(existingKey)
+    expect(counts.persisted).toBe(0) // never overwrote the active key
+  })
+
+  it('converges concurrent createTenantDek calls on a single key via CAS', async () => {
+    const { counts, fetchMock } = makeVaultSim()
+    installFetch(fetchMock)
+    const service = new HashicorpVaultKmsService({ vaultAddr: 'http://vault.test', vaultToken: 'token' })
+
+    const [a, b] = await Promise.all([
+      service.createTenantDek('tenant-cas'),
+      service.createTenantDek('tenant-cas'),
+    ])
+
+    expect(a?.key).toBeTruthy()
+    expect(a?.key).toBe(b?.key) // both adopt the same winning key — no orphaned rows
+    expect(counts.persisted).toBe(1) // exactly one key persisted, last-write-wins eliminated
+  })
+
+  it('invalidateDek forces a re-read from Vault', async () => {
+    const { store, counts, fetchMock } = makeVaultSim()
+    installFetch(fetchMock)
+    const service = new HashicorpVaultKmsService({ vaultAddr: 'http://vault.test', vaultToken: 'token' })
+    const path = 'secret/data/tenant_key_tenant-inv'
+    store.set(path, fixedKey(3))
+
+    const first = await service.getTenantDek('tenant-inv')
+    await service.getTenantDek('tenant-inv') // served from the KMS TTL cache
+    expect(counts.reads).toBe(1)
+
+    store.set(path, fixedKey(9)) // operator rotates the key in Vault
+    service.invalidateDek('tenant-inv')
+    const rotated = await service.getTenantDek('tenant-inv')
+
+    expect(counts.reads).toBe(2)
+    expect(rotated?.key).not.toBe(first?.key)
+  })
+})
+
+describe('TenantDataEncryptionService DEK lifecycle (issue #2746)', () => {
+  const entityId = 'customers:person'
+  let tenantSeq = 0
+  const uniqueTenant = (label: string) => `tenant-${label}-2746-${tenantSeq++}`
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  function makeCreatingKms() {
+    const created: string[] = []
+    const kms: KmsService = {
+      isHealthy: () => true,
+      getTenantDek: jest.fn(async (): Promise<TenantDek | null> => null),
+      createTenantDek: jest.fn(async (tenantId: string): Promise<TenantDek | null> => {
+        const key = generateDek()
+        created.push(key)
+        return { tenantId, key, fetchedAt: Date.now() }
+      }),
+    }
+    return { kms, created }
+  }
+
+  function makeFetchingKms() {
+    const kms: KmsService = {
+      isHealthy: () => true,
+      getTenantDek: jest.fn(async (tenantId: string): Promise<TenantDek | null> => ({
+        tenantId,
+        key: generateDek(),
+        fetchedAt: Date.now(),
+      })),
+      createTenantDek: jest.fn(async (): Promise<TenantDek | null> => null),
+    }
+    return { kms }
+  }
+
+  it('dedupes concurrent first-time DEK creation so no row is orphaned', async () => {
+    const { kms, created } = makeCreatingKms()
+    const service = new TenantDataEncryptionService({} as never, { kms })
+    jest.spyOn(service, 'isEnabled').mockReturnValue(true)
+    ;(service as unknown as { getMap: () => Promise<{ entityId: string; fields: { field: string }[] }> }).getMap =
+      jest.fn(async () => ({ entityId, fields: [{ field: 'secret' }] }))
+    const tenantId = uniqueTenant('race')
+
+    const rows = await Promise.all(
+      Array.from({ length: 12 }, (_, i) =>
+        service.encryptEntityPayload(entityId, { secret: `value-${i}` }, tenantId),
+      ),
+    )
+
+    expect((kms.createTenantDek as jest.Mock)).toHaveBeenCalledTimes(1)
+    expect(new Set(created).size).toBe(1)
+
+    const dek = await service.getDek(tenantId)
+    expect(dek).not.toBeNull()
+    rows.forEach((row, i) => {
+      expect(decryptWithAesGcm(String(row.secret), (dek as TenantDek).key)).toBe(`value-${i}`)
+    })
+  })
+
+  it('re-fetches a cached DEK after the TTL elapses (no stale key after rotation)', async () => {
+    const { kms } = makeFetchingKms()
+    const service = new TenantDataEncryptionService({} as never, { kms })
+    const tenantId = uniqueTenant('ttl')
+    let now = 1_700_000_000_000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+
+    await service.getDek(tenantId)
+    await service.getDek(tenantId)
+    expect((kms.getTenantDek as jest.Mock)).toHaveBeenCalledTimes(1) // cached within TTL
+
+    now += 15 * 60 * 1000 + 1
+    await service.getDek(tenantId)
+    expect((kms.getTenantDek as jest.Mock)).toHaveBeenCalledTimes(2) // expired → re-fetch
+  })
+
+  it('invalidateDek clears both the service cache and the KMS cache', async () => {
+    const { kms } = makeFetchingKms()
+    const kmsInvalidate = jest.fn()
+    ;(kms as KmsService).invalidateDek = kmsInvalidate
+    const service = new TenantDataEncryptionService({} as never, { kms })
+    const tenantId = uniqueTenant('invalidate')
+
+    await service.getDek(tenantId)
+    await service.getDek(tenantId)
+    expect((kms.getTenantDek as jest.Mock)).toHaveBeenCalledTimes(1)
+
+    service.invalidateDek(tenantId)
+    expect(kmsInvalidate).toHaveBeenCalledWith(tenantId)
+
+    await service.getDek(tenantId)
+    expect((kms.getTenantDek as jest.Mock)).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/shared/src/lib/encryption/__tests__/kms.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/kms.test.ts
@@ -9,11 +9,17 @@ describe('kms timeout handling', () => {
   })
 
   it('marks Vault unhealthy after a timed out write', async () => {
-    const fetchMock = jest.fn((_url: string, init?: RequestInit) =>
-      new Promise((_resolve, reject) => {
+    // createTenantDek now reads-before-write (#2746): the read probe answers fast
+    // with no existing key so the flow reaches the write, which then times out.
+    const fetchMock = jest.fn((_url: string, init?: RequestInit) => {
+      const method = (init?.method || 'GET').toUpperCase()
+      if (method === 'GET') {
+        return Promise.resolve({ ok: true, status: 200, json: async () => ({ data: { data: {} } }) })
+      }
+      return new Promise((_resolve, reject) => {
         init?.signal?.addEventListener('abort', () => reject(new Error('aborted')))
-      }),
-    )
+      })
+    })
     ;(globalThis as { fetch?: typeof fetch }).fetch = fetchMock as typeof fetch
 
     const service = new HashicorpVaultKmsService({
@@ -24,7 +30,7 @@ describe('kms timeout handling', () => {
 
     await expect(service.createTenantDek('tenant-1')).resolves.toBeNull()
     expect(service.isHealthy()).toBe(false)
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2) // read probe + the timed-out write
   })
 
   it('falls back to derived keys after the primary Vault call times out', async () => {

--- a/packages/shared/src/lib/encryption/kms.ts
+++ b/packages/shared/src/lib/encryption/kms.ts
@@ -22,6 +22,7 @@ export interface KmsService {
   getTenantDek(tenantId: string): Promise<TenantDek | null>
   createTenantDek(tenantId: string): Promise<TenantDek | null>
   isHealthy(): boolean
+  invalidateDek?(tenantId: string): void
 }
 
 class FallbackKmsService implements KmsService {
@@ -76,6 +77,11 @@ class FallbackKmsService implements KmsService {
     }
     return null
   }
+
+  invalidateDek(tenantId: string): void {
+    this.primary.invalidateDek?.(tenantId)
+    this.fallback?.invalidateDek?.(tenantId)
+  }
 }
 
 type VaultClientOpts = {
@@ -89,6 +95,10 @@ type VaultClientOpts = {
 type VaultReadResponse = {
   data?: { data?: { key?: string; version?: number }; metadata?: Record<string, unknown> }
 }
+
+// 'conflict' = a check-and-set write lost to a concurrent writer (normal race
+// outcome, Vault still healthy); 'error' = the write genuinely failed.
+type VaultWriteOutcome = 'ok' | 'conflict' | 'error'
 
 function normalizeEnv(value: string | undefined): string {
   if (!value) return ''
@@ -230,11 +240,13 @@ export class HashicorpVaultKmsService implements KmsService {
     }
   }
 
-  private async writeVault(path: string, key: string): Promise<boolean> {
+  private async writeVault(path: string, key: string, opts?: { cas?: number }): Promise<VaultWriteOutcome> {
     if (!this.vaultAddr || !this.vaultToken) {
       this.healthy = false
-      return false
+      return 'error'
     }
+    const body: { data: { key: string }; options?: { cas: number } } = { data: { key } }
+    if (typeof opts?.cas === 'number') body.options = { cas: opts.cas }
     try {
       const res = await fetchWithTimeout(`${this.vaultAddr}/v1/${path}`, {
         method: 'POST',
@@ -242,14 +254,23 @@ export class HashicorpVaultKmsService implements KmsService {
           'X-Vault-Token': this.vaultToken,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ data: { key } }),
+        body: JSON.stringify(body),
         timeoutMs: this.requestTimeoutMs,
       })
-      this.healthy = res.ok
-      if (!res.ok) {
-        console.warn('⚠️ [encryption][kms] Vault write failed', { path, status: res.status })
+      if (res.ok) {
+        this.healthy = true
+        return 'ok'
       }
-      return res.ok
+      // KV v2 returns 400 when a check-and-set write loses to a concurrent
+      // writer (path already at a newer version). That is a normal race outcome,
+      // not an unhealthy Vault — don't flip `healthy`.
+      if (typeof opts?.cas === 'number' && res.status === 400) {
+        console.warn('⚠️ [encryption][kms] Vault write CAS conflict (concurrent DEK create)', { path, status: res.status })
+        return 'conflict'
+      }
+      this.healthy = false
+      console.warn('⚠️ [encryption][kms] Vault write failed', { path, status: res.status })
+      return 'error'
     } catch (err) {
       this.healthy = false
       console.warn('⚠️ [encryption][kms] Vault write error', {
@@ -257,7 +278,7 @@ export class HashicorpVaultKmsService implements KmsService {
         error: (err as Error)?.message || String(err),
         timeoutMs: this.requestTimeoutMs,
       })
-      return false
+      return 'error'
     }
   }
 
@@ -287,16 +308,40 @@ export class HashicorpVaultKmsService implements KmsService {
   }
 
   async createTenantDek(tenantId: string): Promise<TenantDek | null> {
-    const key = generateDek()
     const path = this.buildKeyPath(tenantId)
-    const ok = await this.writeVault(path, key)
-    if (ok) {
-      console.info('🔑 [encryption][kms] Stored tenant DEK in Vault', { tenantId, path })
-    } else {
-      console.warn('⚠️ [encryption][kms] Failed to store tenant DEK in Vault', { tenantId, path })
+    // Read-before-write: if a DEK already exists for this tenant (another request
+    // or process created it first), adopt it instead of overwriting the active
+    // key — overwriting orphans every row already encrypted under it (#2746).
+    const existing = await this.readVault(path)
+    const existingKey = existing?.data?.data?.key
+    if (existingKey) {
+      return this.remember({ tenantId, key: existingKey, fetchedAt: this.now() })
     }
-    if (!ok) return null
-    return this.remember({ tenantId, key, fetchedAt: this.now() })
+    // A read failure (timeout / 5xx) flips `healthy` off; don't blind-write a new
+    // key over a possibly-existing one we just couldn't read — let the caller fall back.
+    if (!this.healthy) return null
+    const key = generateDek()
+    const outcome = await this.writeVault(path, key, { cas: 0 })
+    if (outcome === 'ok') {
+      console.info('🔑 [encryption][kms] Stored tenant DEK in Vault', { tenantId, path })
+      return this.remember({ tenantId, key, fetchedAt: this.now() })
+    }
+    if (outcome === 'conflict') {
+      // A concurrent create won the CAS race — adopt the winner's key so both
+      // callers encrypt under the same DEK.
+      const winner = await this.readVault(path)
+      const winnerKey = winner?.data?.data?.key
+      if (winnerKey) {
+        console.info('🔑 [encryption][kms] Adopted concurrently-created tenant DEK', { tenantId, path })
+        return this.remember({ tenantId, key: winnerKey, fetchedAt: this.now() })
+      }
+    }
+    console.warn('⚠️ [encryption][kms] Failed to store tenant DEK in Vault', { tenantId, path })
+    return null
+  }
+
+  invalidateDek(tenantId: string): void {
+    this.cache.delete(tenantId)
   }
 }
 

--- a/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
+++ b/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
@@ -22,6 +22,10 @@ type MapCacheKey = {
 }
 
 const MAP_MISS_TTL_MS = 5 * 60 * 1000
+// Mirror the Vault KMS default DEK TTL so a rotated/revoked tenant key is picked
+// up by long-lived processes without a restart (#2746). The service-level cache
+// previously had no TTL and shadowed the KMS's own 15-minute expiry.
+const DEK_CACHE_TTL_MS = 15 * 60 * 1000
 
 function cacheKey(key: MapCacheKey): string {
   return [
@@ -96,11 +100,13 @@ export class TenantDataEncryptionService {
   private static globalMemoryCache = new Map<string, EncryptionMapRecord>()
   private static globalInflightMaps = new Map<string, Promise<EncryptionMapRecord | null>>()
   private static globalDekCache = new Map<string, TenantDek>()
+  private static globalInflightDeks = new Map<string, Promise<TenantDek | null>>()
   private static globalMissCache = new Map<string, number>()
   private readonly kms: KmsService
   private readonly cache?: CacheStrategy
   private readonly memoryCache = TenantDataEncryptionService.globalMemoryCache
   private readonly dekCache = TenantDataEncryptionService.globalDekCache
+  private readonly inflightDeks = TenantDataEncryptionService.globalInflightDeks
   private readonly inflightMaps = TenantDataEncryptionService.globalInflightMaps
   private readonly missCache = TenantDataEncryptionService.globalMissCache
 
@@ -116,10 +122,15 @@ export class TenantDataEncryptionService {
     return isTenantDataEncryptionEnabled() && this.kms.isHealthy()
   }
 
+  private isDekExpired(dek: TenantDek): boolean {
+    return Date.now() - dek.fetchedAt > DEK_CACHE_TTL_MS
+  }
+
   async getDek(tenantId: string | null | undefined): Promise<TenantDek | null> {
     if (!tenantId) return null
     const cached = this.dekCache.get(tenantId)
-    if (cached) return cached
+    if (cached && !this.isDekExpired(cached)) return cached
+    if (cached) this.dekCache.delete(tenantId)
     const dek = await this.kms.getTenantDek(tenantId)
     if (!dek) {
       debug('🔎 dek.miss', { tenantId })
@@ -134,9 +145,22 @@ export class TenantDataEncryptionService {
     const existing = await this.getDek(tenantId)
     if (existing || !tenantId) return existing ?? null
     if (typeof this.kms.createTenantDek !== 'function') return existing ?? null
-    const created = await this.kms.createTenantDek(tenantId)
-    if (created) this.dekCache.set(tenantId, created)
-    return created ?? null
+    // Dedupe concurrent first-time creation within this process so two callers
+    // can't each generate a distinct DEK and overwrite one another (#2746).
+    // Mirrors the encryption-map inflight dedupe (`globalInflightMaps`).
+    const pending = this.inflightDeks.get(tenantId)
+    if (pending) return pending
+    const creation = (async () => {
+      const created = await this.kms.createTenantDek(tenantId)
+      if (created) this.dekCache.set(tenantId, created)
+      return created ?? null
+    })()
+    this.inflightDeks.set(tenantId, creation)
+    try {
+      return await creation
+    } finally {
+      this.inflightDeks.delete(tenantId)
+    }
   }
 
   async createDek(tenantId: string): Promise<TenantDek | null> {
@@ -234,6 +258,15 @@ export class TenantDataEncryptionService {
     if (this.cache && typeof (this.cache as any).delete === 'function') {
       await (this.cache as any).delete(tag)
     }
+  }
+
+  // Force a flush of a tenant's cached DEK across the service-level cache and the
+  // underlying KMS cache so an operator can pick up a rotated/revoked key without
+  // a process restart (#2746).
+  invalidateDek(tenantId: string): void {
+    this.dekCache.delete(tenantId)
+    this.inflightDeks.delete(tenantId)
+    this.kms.invalidateDek?.(tenantId)
   }
 
   async getEncryptedFieldNames(


### PR DESCRIPTION
## Summary

Fixes two related defects in tenant data-encryption-key (DEK) management (#2746).

1. **Creation race overwrote the active key (data loss).** `HashicorpVaultKmsService.createTenantDek` did an unconditional `generateDek()` + write with no read-before-write, CAS, or inflight dedupe, and `TenantDataEncryptionService.resolveDekForEncrypt` had no inflight Promise map. Two concurrent first-time requests for a new tenant each generated and persisted a distinct DEK (last-write-wins at the Vault path); rows encrypted under the discarded key became permanently undecryptable.
2. **Cached DEKs never expired (rotation/revocation needed a restart).** `getDek` returned the module-static cached entry with no TTL check and offered no invalidation API, shadowing the KMS's own 15-minute TTL.

The fix closes the race at both layers (in-process inflight dedupe + cross-process Vault CAS arbitration with read-before-write) and makes the service-level DEK cache expire (15 min, mirroring the KMS) with an operator-forced `invalidateDek`. Backward compatible: `invalidateDek?` is optional on the `KmsService` interface; `writeVault` is private; all other signatures are unchanged.

## Changes

- `packages/shared/src/lib/encryption/kms.ts`: `createTenantDek` reads-before-write and adopts any existing key; bails on a read failure instead of blind-overwriting; writes with `options.cas=0` and, on a KV v2 `400` CAS conflict, re-reads and adopts the winner without marking Vault unhealthy. Added `invalidateDek` to `HashicorpVaultKmsService` and `FallbackKmsService`, plus optional `invalidateDek?` on the `KmsService` interface. `writeVault` now returns `'ok' | 'conflict' | 'error'`.
- `packages/shared/src/lib/encryption/tenantDataEncryptionService.ts`: `getDek` honors a 15-min TTL and evicts on expiry; `resolveDekForEncrypt` dedupes concurrent first-time creation via a new `globalInflightDeks` map; new public `invalidateDek(tenantId)` flushes the service cache, inflight entry, and the underlying KMS cache.
- `packages/shared/src/lib/encryption/__tests__/dek-lifecycle.test.ts` (new): reproduces both defects (race/data-loss, TTL expiry, invalidation) at the KMS and service layers.
- `packages/shared/src/lib/encryption/__tests__/kms.test.ts`: updated the timeout test to genuinely exercise the write timeout after read-before-write.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — focused security bug fix scoped to two files; no architectural decision.

## Testing

Local verification gate (all exit 0):
- `yarn workspace @open-mercato/shared test dek-lifecycle` — 6/6 (red before fix → green after)
- `yarn workspace @open-mercato/shared test encryption/__tests__` — 37/37 (7 suites)
- `yarn build:packages` — 21/21
- `yarn typecheck` — 21/21 (consumers cache-hit → no BC break)
- `yarn i18n:check-sync` — all 4 locales in sync
- `yarn test` — 22/22 tasks (shared 1187, core 5494)
- `yarn build:app` — success

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — internal infra; console-log strings are not i18n surfaces; no generators/locales affected.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (N/A — a Vault CAS race and a 15-minute in-memory TTL are not exercisable via Playwright; covered precisely by deterministic unit tests at the KMS/service layer.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec for this bug fix.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI (backend infra change)
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2746