### PR TITLE
fix: 2743 onboarding consent ip trust proxy

### DIFF
--- a/packages/onboarding/src/__tests__/consentClientIp.test.ts
+++ b/packages/onboarding/src/__tests__/consentClientIp.test.ts
@@ -1,0 +1,47 @@
+import { resolveConsentClientIp } from '@open-mercato/onboarding/modules/onboarding/lib/consentClientIp'
+
+const getCachedRateLimiterService = jest.fn()
+
+jest.mock('@open-mercato/core/bootstrap', () => ({
+  getCachedRateLimiterService: () => getCachedRateLimiterService(),
+}))
+
+function makeRequest(headers: Record<string, string>): Request {
+  return new Request('http://localhost/onboarding/onboarding/verify', { headers })
+}
+
+describe('resolveConsentClientIp', () => {
+  beforeEach(() => {
+    getCachedRateLimiterService.mockReset()
+  })
+
+  it('ignores a spoofed X-Forwarded-For when no proxy is trusted (trustProxyDepth=0)', () => {
+    getCachedRateLimiterService.mockReturnValue({ trustProxyDepth: 0 })
+    const req = makeRequest({ 'x-forwarded-for': '6.6.6.6' })
+    expect(resolveConsentClientIp(req)).toBeNull()
+  })
+
+  it('honors the configured trust depth instead of a hardcoded 1 (trustProxyDepth=2)', () => {
+    getCachedRateLimiterService.mockReturnValue({ trustProxyDepth: 2 })
+    const req = makeRequest({ 'x-forwarded-for': 'client, proxy2, proxy1' })
+    expect(resolveConsentClientIp(req)).toBe('proxy2')
+  })
+
+  it('records the trusted client IP for a single-proxy deployment (trustProxyDepth=1)', () => {
+    getCachedRateLimiterService.mockReturnValue({ trustProxyDepth: 1 })
+    const req = makeRequest({ 'x-forwarded-for': 'client, edge' })
+    expect(resolveConsentClientIp(req)).toBe('edge')
+  })
+
+  it('falls back to X-Real-IP when X-Forwarded-For is untrusted', () => {
+    getCachedRateLimiterService.mockReturnValue({ trustProxyDepth: 0 })
+    const req = makeRequest({ 'x-forwarded-for': '6.6.6.6', 'x-real-ip': '10.0.0.5' })
+    expect(resolveConsentClientIp(req)).toBe('10.0.0.5')
+  })
+
+  it('returns null when the rate limiter service is unavailable', () => {
+    getCachedRateLimiterService.mockReturnValue(null)
+    const req = makeRequest({ 'x-forwarded-for': '6.6.6.6' })
+    expect(resolveConsentClientIp(req)).toBeNull()
+  })
+})

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
@@ -10,7 +10,7 @@ import { sendWorkspaceReadyEmail } from '@open-mercato/onboarding/modules/onboar
 import { setupInitialTenant } from '@open-mercato/core/modules/auth/lib/setup-app'
 import { UserConsent } from '@open-mercato/core/modules/auth/data/entities'
 import { computeConsentIntegrityHash } from '@open-mercato/core/modules/auth/lib/consentIntegrity'
-import { getClientIp } from '@open-mercato/shared/lib/ratelimit/helpers'
+import { resolveConsentClientIp } from '@open-mercato/onboarding/modules/onboarding/lib/consentClientIp'
 import { reindexEntity } from '@open-mercato/core/modules/query_index/lib/reindexer'
 import { purgeIndexScope } from '@open-mercato/core/modules/query_index/lib/purge'
 import { refreshCoverageSnapshot } from '@open-mercato/core/modules/query_index/lib/coverage'
@@ -387,7 +387,7 @@ export async function GET(req: Request) {
 
     if (request.marketingConsent) {
       const now = new Date()
-      const clientIp = getClientIp(req, 1) ?? null
+      const clientIp = resolveConsentClientIp(req)
       const integrityHash = computeConsentIntegrityHash({
         userId: resolvedUserId,
         consentType: 'marketing_email',

--- a/packages/onboarding/src/modules/onboarding/lib/consentClientIp.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/consentClientIp.ts
@@ -1,0 +1,15 @@
+import { getCachedRateLimiterService } from '@open-mercato/core/bootstrap'
+import { getClientIp } from '@open-mercato/shared/lib/ratelimit/helpers'
+
+/**
+ * Resolve the client IP to persist on a legal-consent record, honoring the
+ * deployment-wide reverse-proxy trust depth (`RATE_LIMIT_TRUST_PROXY_DEPTH`)
+ * exposed by the rate limiter service instead of a hardcoded depth. When the
+ * trust depth is unknown, return null so a spoofable `X-Forwarded-For` value is
+ * never signed into the consent integrity hash.
+ */
+export function resolveConsentClientIp(req: Request): string | null {
+  const rateLimiterService = getCachedRateLimiterService()
+  if (!rateLimiterService) return null
+  return getClientIp(req, rateLimiterService.trustProxyDepth) ?? null
+}


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The onboarding consent-verify endpoint recorded the marketing-consent client IP with a
hardcoded reverse-proxy trust depth of `1` (`getClientIp(req, 1)`), trusting the
attacker-controllable `X-Forwarded-For` (falling back to `X-Real-IP`) regardless of the
deployment's actual proxy topology. That IP is folded into the consent record's integrity
HMAC (`computeConsentIntegrityHash`), so a forged address was persisted and later passed
`verifyConsentIntegrityHash` as authentic — degrading the evidentiary value of a GDPR/legal
consent record.

This fix sources the proxy depth from deployment-wide configuration via
`rateLimiterService.trustProxyDepth` (env `RATE_LIMIT_TRUST_PROXY_DEPTH`) — the same pattern
every other trust-aware call site already uses (`quotes/accept/route.ts`, `rateLimitCheck.ts`)
— instead of hardcoding `1`. Operators on a deployment without exactly one trusted proxy can
now set depth `0` so the consent endpoint stops trusting forwarded headers; when the rate
limiter service is unavailable the helper records `null` rather than a possibly-spoofed value.
The default (1) is unchanged, so single-proxy deployments behave exactly as before.

## Changes

- Add `resolveConsentClientIp(req)` helper in
  `packages/onboarding/src/modules/onboarding/lib/consentClientIp.ts` that derives the client
  IP from `getCachedRateLimiterService().trustProxyDepth`, returning `null` when the rate
  limiter service is unavailable so a spoofable header value is never signed into the consent HMAC.
- `packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts`: replace
  `getClientIp(req, 1) ?? null` with `resolveConsentClientIp(req)` (and update the import).
- Add unit tests `packages/onboarding/src/__tests__/consentClientIp.test.ts` covering trust
  depth 0/1/2, the `X-Real-IP` fallback, and the null-service case — including the two cases
  that provably fail against the previous hardcoded `1`.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — security hardening of an existing endpoint; no spec change required.

## Testing

List the tests or commands you ran to validate the change.

- `yarn workspace @open-mercato/onboarding test consentClientIp` → red (4 failed against the
  pre-fix hardcoded `1`) → green (5/5 passed after the fix).
- `yarn workspace @open-mercato/onboarding test` → 6 suites, 46 tests passed.
- `yarn turbo run typecheck --filter=@open-mercato/onboarding` → pass.
- `yarn workspace @open-mercato/onboarding build` → built successfully.
- `yarn i18n:check-sync` → all locales in sync.
- `yarn build:app` → compiled successfully.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — no user-facing strings, no generated files affected.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (N/A — the defect is isolated in a pure IP-derivation seam fully covered by unit tests; a full verify-flow integration test would require DB + tenant provisioning and would add no security-relevant coverage beyond these unit tests.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec.)

### Design System Compliance
- [x] No hardcoded status colors — N/A — no UI
- [x] No arbitrary text sizes — N/A — no UI
- [x] Empty state handled for list/data pages — N/A — no UI
- [x] Loading state handled for async pages — N/A — no UI
- [x] `aria-label` on all icon-only buttons — N/A — no UI
- [x] Uses existing DS components — N/A — no UI

## Linked issues

Fixes #2743