### PR TITLE
fix: 2741 sso unverified email error

### DIFF
--- a/packages/enterprise/src/modules/sso/api/callback/oidc/route.ts
+++ b/packages/enterprise/src/modules/sso/api/callback/oidc/route.ts
@@ -4,6 +4,7 @@ import { toAbsoluteUrl } from '@open-mercato/shared/lib/url'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { SsoService } from '../../../services/ssoService'
 import { emitSsoEvent } from '../../../events'
+import { resolveSsoCallbackErrorCode } from '../../../lib/errors'
 
 export const metadata = {
   GET: { requireAuth: false },
@@ -82,8 +83,7 @@ async function handleCallback(req: Request): Promise<NextResponse> {
     void emitSsoEvent('sso.login.failed', {
       reason: err instanceof Error ? err.message : 'callback_failed',
     }).catch((e) => console.error('[SSO Event]', e))
-    const message = err instanceof Error ? err.message : ''
-    const errorCode = message.includes('email is not verified') ? 'sso_email_not_verified' : 'sso_failed'
+    const errorCode = resolveSsoCallbackErrorCode(err)
     return NextResponse.redirect(toAbsoluteUrl(req, `/login?error=${errorCode}`))
   }
 }

--- a/packages/enterprise/src/modules/sso/lib/errors.ts
+++ b/packages/enterprise/src/modules/sso/lib/errors.ts
@@ -1,0 +1,35 @@
+// Use Symbol.for so the marker survives module duplication across bundle
+// boundaries: the OIDC callback route and the account-linking service can be
+// bundled into separate chunks where `instanceof` silently returns false
+// (same rationale as isCrudHttpError in @open-mercato/shared).
+const EMAIL_NOT_VERIFIED_ERROR_MARKER = Symbol.for('@open-mercato/sso/EmailNotVerifiedError')
+
+export class EmailNotVerifiedError extends Error {
+  readonly [EMAIL_NOT_VERIFIED_ERROR_MARKER] = true
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = 'EmailNotVerifiedError'
+  }
+}
+
+/**
+ * Type-safe check that works across module/bundle boundaries. Prefer this over
+ * `instanceof EmailNotVerifiedError` because the SSO callback route may be
+ * bundled separately from the service that throws the error.
+ */
+export function isEmailNotVerifiedError(err: unknown): err is EmailNotVerifiedError {
+  return !!err && typeof err === 'object' && (err as Record<symbol, unknown>)[EMAIL_NOT_VERIFIED_ERROR_MARKER] === true
+}
+
+export type SsoCallbackErrorCode = 'sso_email_not_verified' | 'sso_failed'
+
+/**
+ * Maps an error thrown during the OIDC callback to the login-page UX error code.
+ * Keyed off the error type rather than a substring of the human-readable message,
+ * which previously drifted out of sync and left `sso_email_not_verified`
+ * unreachable (#2741).
+ */
+export function resolveSsoCallbackErrorCode(err: unknown): SsoCallbackErrorCode {
+  return isEmailNotVerifiedError(err) ? 'sso_email_not_verified' : 'sso_failed'
+}

--- a/packages/enterprise/src/modules/sso/services/__tests__/accountLinkingService.errors.test.ts
+++ b/packages/enterprise/src/modules/sso/services/__tests__/accountLinkingService.errors.test.ts
@@ -1,0 +1,44 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { AccountLinkingService } from '../accountLinkingService'
+import { isEmailNotVerifiedError, resolveSsoCallbackErrorCode } from '../../lib/errors'
+import type { SsoConfig } from '../../data/entities'
+import type { SsoIdentityPayload } from '../../lib/types'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn().mockResolvedValue(null),
+  findWithDecryption: jest.fn().mockResolvedValue([]),
+}))
+
+const config = { id: 'cfg-1', organizationId: 'org-1' } as unknown as SsoConfig
+
+async function captureThrow(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn()
+  } catch (err) {
+    return err
+  }
+  throw new Error('Expected the call to throw, but it resolved')
+}
+
+describe('OIDC callback unverified-email error mapping (#2741)', () => {
+  it('resolveUser throws an error the callback classifies as sso_email_not_verified', async () => {
+    const service = new AccountLinkingService({} as unknown as EntityManager)
+    const payload: SsoIdentityPayload = {
+      subject: 'sub-1',
+      email: 'user@example.com',
+      emailVerified: false,
+    }
+
+    const thrown = await captureThrow(() => service.resolveUser(config, payload, 'tenant-1'))
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect(isEmailNotVerifiedError(thrown)).toBe(true)
+    expect(resolveSsoCallbackErrorCode(thrown)).toBe('sso_email_not_verified')
+  })
+
+  it('classifies unrelated callback failures as sso_failed', () => {
+    expect(resolveSsoCallbackErrorCode(new Error('State mismatch — possible CSRF attack'))).toBe('sso_failed')
+    expect(resolveSsoCallbackErrorCode(new Error('SSO configuration no longer active'))).toBe('sso_failed')
+    expect(resolveSsoCallbackErrorCode(undefined)).toBe('sso_failed')
+  })
+})

--- a/packages/enterprise/src/modules/sso/services/accountLinkingService.ts
+++ b/packages/enterprise/src/modules/sso/services/accountLinkingService.ts
@@ -4,6 +4,7 @@ import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { computeEmailHash } from '@open-mercato/core/modules/auth/lib/emailHash'
 import { SsoConfig, SsoIdentity, SsoRoleGrant, ScimToken } from '../data/entities'
 import { emitSsoEvent } from '../events'
+import { EmailNotVerifiedError } from '../lib/errors'
 import type { SsoIdentityPayload } from '../lib/types'
 
 export class AccountLinkingService {
@@ -21,7 +22,7 @@ export class AccountLinkingService {
     }
 
     if (idpPayload.emailVerified === false) {
-      throw new Error('IdP explicitly reported email as unverified — cannot link or provision account')
+      throw new EmailNotVerifiedError('IdP explicitly reported email as unverified — cannot link or provision account')
     }
 
     const emailDomain = idpPayload.email.split('@')[1]?.toLowerCase()


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The OIDC SSO callback surfaced a generic `sso_failed` error for every
unverified-email login because it classified the failure with a substring
match (`message.includes('email is not verified')`) that never matched the
string actually thrown by the account-linking service
(`'…email as unverified…'`). The dedicated `sso_email_not_verified` code — and
its localized "please verify your email" message — were therefore unreachable.

This keys the callback's error→code mapping off a typed error
(`EmailNotVerifiedError`) instead of a brittle message substring, so the
unverified-email case is correctly surfaced and the failure class can no longer
silently drift out of sync.

## Changes

- Add `packages/enterprise/src/modules/sso/lib/errors.ts`: `EmailNotVerifiedError`,
  a `Symbol.for`-tagged `isEmailNotVerifiedError` guard (cross-bundle safe, mirrors
  `isCrudHttpError`), and a `resolveSsoCallbackErrorCode(err)` mapping seam.
- `accountLinkingService.ts`: throw `EmailNotVerifiedError` (same message) instead of
  a plain `Error` when the IdP reports `emailVerified === false`.
- `api/callback/oidc/route.ts`: derive the login error code via
  `resolveSsoCallbackErrorCode(err)`; removes the dead substring check. The
  `sso.login.failed` event emission is unchanged.
- Add unit test `services/__tests__/accountLinkingService.errors.test.ts` covering the
  unverified-email → `sso_email_not_verified` mapping and the `sso_failed` fallback.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — minor bug fix.

## Testing

List the tests or commands you ran to validate the change.

- `yarn workspace @open-mercato/enterprise test accountLinkingService.errors` — new repro test, red before the fix → green after (2 passed).
- `yarn workspace @open-mercato/enterprise test` — full enterprise suite, 289 passed (no regressions).
- `yarn build:packages` — 21/21 successful.
- `yarn i18n:check-sync` — all locales in sync.
- `yarn typecheck` — 21/21 successful.
- `yarn build:app` — compiled successfully.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (Not required — reuses the existing `sso.login.errors.emailNotVerified` locale key; no generated files affected.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required — the end-to-end path needs a live OIDC IdP returning `emailVerified:false`, which the integration harness does not provision; the error-classification logic is fully covered by a deterministic unit test that drives the real service.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — minor bug fix.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens *(N/A — backend-only, no UI changes)*
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` *(N/A — no UI)*
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) *(N/A — no UI)*
- [x] Loading state handled for async pages *(N/A — no UI)*
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) *(N/A — no UI)*
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements *(N/A — no UI)*

## Linked issues

Fixes #2741