### PR TITLE
fix: 2742 onboarding verify race

### DIFF
--- a/packages/onboarding/src/__tests__/service.test.ts
+++ b/packages/onboarding/src/__tests__/service.test.ts
@@ -75,6 +75,38 @@ function createMockEm(overrides: Record<string, unknown> = {}): MockEm {
   } as unknown as MockEm
 }
 
+type DbRow = { id: string; status: string; processingStartedAt: Date | null }
+
+// EntityManager mock backed by a single persisted row. `nativeUpdate` honours the
+// status guard in its WHERE clause (so it returns 0 when the row has already moved
+// on), while `flush` writes the tracked managed entity's scalars back to the row —
+// reproducing MikroORM's last-write-wins behaviour for the unconditional code path.
+function createRowBackedEm(dbRow: DbRow, trackedEntity?: OnboardingRequest): EntityManager {
+  const flush = jest.fn(async () => {
+    if (!trackedEntity) return
+    dbRow.status = trackedEntity.status
+    dbRow.processingStartedAt = trackedEntity.processingStartedAt ?? null
+  })
+  const nativeUpdate = jest.fn(
+    async (_entity: unknown, where: Record<string, unknown>, data: Record<string, unknown>) => {
+      const matches = Object.entries(where).every(
+        ([key, value]) => (dbRow as unknown as Record<string, unknown>)[key] === value,
+      )
+      if (!matches) return 0
+      if ('status' in data) dbRow.status = data.status as string
+      if ('processingStartedAt' in data) dbRow.processingStartedAt = (data.processingStartedAt as Date | null) ?? null
+      return 1
+    },
+  )
+  return {
+    findOne: jest.fn().mockResolvedValue(null),
+    create: jest.fn(),
+    persist: jest.fn(() => ({ flush })),
+    flush,
+    nativeUpdate,
+  } as unknown as EntityManager
+}
+
 describe('OnboardingService', () => {
   describe('createOrUpdateRequest', () => {
     it('creates a new pending request when no existing email found', async () => {
@@ -124,6 +156,56 @@ describe('OnboardingService', () => {
       expect(request.status).toBe('completed')
       expect(request.passwordHash).toBeNull()
       expect(em.flush).toHaveBeenCalled()
+    })
+  })
+
+  // Regression coverage for #2742: two concurrent verify requests carrying the same
+  // token must not corrupt the persisted state. The fix makes the pending→processing
+  // transition an atomic claim and the processing→pending reset conditional, so a
+  // request that lost the race can never clobber a sibling that already completed.
+  describe('startProcessing (atomic claim, #2742)', () => {
+    it('lets only one concurrent caller claim a pending request', async () => {
+      const dbRow: DbRow = { id: 'req-1', status: 'pending', processingStartedAt: null }
+      const em = createRowBackedEm(dbRow)
+      const service = new OnboardingService(em)
+      const requestA = makeRequest({ id: 'req-1', status: 'pending', processingStartedAt: null })
+      const requestB = makeRequest({ id: 'req-1', status: 'pending', processingStartedAt: null })
+
+      const claimedA = await service.startProcessing(requestA, new Date())
+      const claimedB = await service.startProcessing(requestB, new Date())
+
+      expect(claimedA).toBe(true)
+      expect(claimedB).toBe(false)
+      expect(dbRow.status).toBe('processing')
+    })
+  })
+
+  describe('resetProcessing (conditional revert, #2742)', () => {
+    it('does not revert a request a concurrent worker already completed', async () => {
+      // A sibling worker already advanced the persisted row to 'completed'.
+      const dbRow: DbRow = { id: 'req-1', status: 'completed', processingStartedAt: null }
+      // This worker still holds an in-memory copy it believes is 'processing'.
+      const staleRequest = makeRequest({ id: 'req-1', status: 'processing', processingStartedAt: new Date() })
+      const em = createRowBackedEm(dbRow, staleRequest)
+      const service = new OnboardingService(em)
+
+      const reverted = await service.resetProcessing(staleRequest)
+
+      expect(reverted).toBe(false)
+      expect(dbRow.status).toBe('completed')
+    })
+
+    it('reverts a request that is still processing', async () => {
+      const dbRow: DbRow = { id: 'req-1', status: 'processing', processingStartedAt: new Date() }
+      const request = makeRequest({ id: 'req-1', status: 'processing', processingStartedAt: new Date() })
+      const em = createRowBackedEm(dbRow, request)
+      const service = new OnboardingService(em)
+
+      const reverted = await service.resetProcessing(request)
+
+      expect(reverted).toBe(true)
+      expect(dbRow.status).toBe('pending')
+      expect(dbRow.processingStartedAt).toBeNull()
     })
   })
 })

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
@@ -340,7 +340,20 @@ export async function GET(req: Request) {
   if (request.status !== 'pending') {
     return redirectWithStatus(baseUrl, 'invalid')
   }
-  await service.startProcessing(request, new Date())
+  const claimed = await service.startProcessing(request, new Date())
+  if (!claimed) {
+    // A concurrent verify request already claimed this token (pending → processing).
+    // Re-read on a fresh fork — the request EM's identity map still holds the stale
+    // pre-claim copy — and route off the winner's committed state instead of re-running
+    // provisioning, which would throw USER_EXISTS and could strand the request (#2742).
+    const current = await new OnboardingService(em.fork()).findById(request.id)
+    if (current?.status === 'completed' && current.tenantId) {
+      return current.preparationCompletedAt
+        ? redirectToLogin(baseUrl, current.tenantId)
+        : redirectToPreparing(baseUrl, current.tenantId)
+    }
+    return redirectToPreparing(baseUrl, current?.tenantId ?? request.tenantId ?? null)
+  }
   if (!request.passwordHash) {
     console.error('[onboarding.verify] missing password hash for request', request.id)
     await service.resetProcessing(request)

--- a/packages/onboarding/src/modules/onboarding/lib/service.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/service.ts
@@ -97,16 +97,28 @@ export class OnboardingService {
     )
   }
 
-  async startProcessing(request: OnboardingRequest, startedAt: Date) {
+  async startProcessing(request: OnboardingRequest, startedAt: Date): Promise<boolean> {
+    const claimedRows = await this.em.nativeUpdate(
+      OnboardingRequest,
+      { id: request.id, status: 'pending' },
+      { status: 'processing', processingStartedAt: startedAt, updatedAt: new Date() },
+    )
+    if (claimedRows === 0) return false
     request.status = 'processing'
     request.processingStartedAt = startedAt
-    await this.em.flush()
+    return true
   }
 
-  async resetProcessing(request: OnboardingRequest) {
+  async resetProcessing(request: OnboardingRequest): Promise<boolean> {
+    const revertedRows = await this.em.nativeUpdate(
+      OnboardingRequest,
+      { id: request.id, status: 'processing' },
+      { status: 'pending', processingStartedAt: null, updatedAt: new Date() },
+    )
+    if (revertedRows === 0) return false
     request.status = 'pending'
     request.processingStartedAt = null
-    await this.em.flush()
+    return true
   }
 
   async updateProvisioningIds(request: OnboardingRequest, data: { tenantId: string; organizationId: string; userId: string }) {


### PR DESCRIPTION
## Summary

Two concurrent `GET /onboarding/onboarding/verify` requests carrying the same valid token could corrupt the persisted onboarding state. The `pending → processing → completed` transition was a non-atomic read-modify-write (mutate the in-memory `OnboardingRequest`, then unconditional `em.flush()`), so both requests passed the in-memory `pending` guard and both entered `setupInitialTenant`. The winner created the tenant and marked the row `completed`; the loser hit `USER_EXISTS` and its unconditional `resetProcessing` clobbered the row back to `status='pending'` — but with `tenantId` already saved. Every later verify then re-enters provisioning → `USER_EXISTS` → `?status=already_exists`, permanently locking out a user whose tenant already exists, with no self-service recovery.

This makes the state transition race-safe with an atomic conditional claim plus a conditional revert (no schema migration), mirroring the existing `claimRecipientDelivery` pattern in `messages/workers/send-email.worker.ts`.

## Changes

- `packages/onboarding/src/modules/onboarding/lib/service.ts`
  - `startProcessing` → atomic **claim**: `em.nativeUpdate(OnboardingRequest, { id, status: 'pending' }, { status: 'processing', processingStartedAt, updatedAt })`; returns `true` only when it claimed the row (`affectedRows > 0`), so exactly one concurrent caller proceeds to provisioning.
  - `resetProcessing` → **conditional** revert: `em.nativeUpdate(OnboardingRequest, { id, status: 'processing' }, { status: 'pending', processingStartedAt: null, updatedAt })`; can never overwrite a row a sibling already advanced to `completed`.
- `packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts`
  - When the claim is lost, re-read the request on a fresh `em.fork()` and route off the winner's committed state (login when completed, otherwise preparing) instead of re-running `setupInitialTenant`.
- `packages/onboarding/src/__tests__/service.test.ts`
  - Added 3 regression tests for the concurrency contract using a row-backed mock EM that honours `nativeUpdate`'s status guard and models last-write-wins `flush`.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — security bug fix, no spec change required.

## Testing

- `yarn workspace @open-mercato/onboarding test` — 44 passed (3 new race-condition tests + 41 existing); the new tests fail on the pre-fix code for the right reason and pass after the fix.
- `yarn i18n:check-sync` — all 4 locales in sync (no new strings).
- `yarn typecheck` — 21/21 packages pass.
- `yarn test` — 22/22 packages pass (core 5500, onboarding 44).
- `yarn build:packages` + `yarn generate` — ok.
- `yarn turbo run build --filter=@open-mercato/app --force` — Next.js app compiles + typechecks (forced, no cache).
- `db:generate` — not run; no entity/schema change (the fix uses an atomic conditional UPDATE, no new column or migration).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no user-facing strings, routes, events, or generated registries changed; `i18n:check-sync` passes.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Not added: a genuine wall-clock concurrent double-submit race is non-deterministic to exercise reliably in Playwright. The regression is locked at the service-contract level (atomic claim + conditional revert), consistent with this module's existing unit-test-only strategy and the `claimRecipientDelivery` precedent.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A (minor security fix).

### Design System Compliance
- [x] No hardcoded status colors — N/A, backend-only (no UI).
- [x] No arbitrary text sizes — N/A, backend-only (no UI).
- [x] Empty state handled for list/data pages — N/A, backend-only (no UI).
- [x] Loading state handled for async pages — N/A, backend-only (no UI).
- [x] `aria-label` on all icon-only buttons — N/A, backend-only (no UI).
- [x] Uses existing DS components — N/A, backend-only (no UI).

## Linked issues

Fixes #2742