### PR TITLE
fix: 2736 customers exclude link tenant scope

### DIFF
--- a/packages/core/src/modules/customers/api/companies/route.ts
+++ b/packages/core/src/modules/customers/api/companies/route.ts
@@ -35,6 +35,8 @@ import {
 import {
   filterActivePersonCompanyLinks,
   withActiveCustomerPersonCompanyLinkFilter,
+  withCustomerPersonCompanyLinkScope,
+  withScopedCustomerDealLinkWhere,
 } from '../../lib/personCompanyLinkTable'
 import { normalizeCompanyProfilePayload } from './payload'
 
@@ -222,7 +224,7 @@ const crud = makeCrudRoute({
           }
           const linkWhere = await withActiveCustomerPersonCompanyLinkFilter(
             em,
-            { person: query.excludeLinkedPersonId },
+            withCustomerPersonCompanyLinkScope({ person: query.excludeLinkedPersonId }, decryptionScope),
             'customers.companies.GET',
           )
           const links = filterActivePersonCompanyLinks(
@@ -255,9 +257,7 @@ const crud = makeCrudRoute({
           const links = await findWithDecryption(
             em,
             CustomerDealCompanyLink,
-            {
-              deal: query.excludeLinkedDealId,
-            },
+            withScopedCustomerDealLinkWhere(query.excludeLinkedDealId, decryptionScope),
             { populate: ['company'] },
             decryptionScope,
           )

--- a/packages/core/src/modules/customers/api/people/route.ts
+++ b/packages/core/src/modules/customers/api/people/route.ts
@@ -31,6 +31,8 @@ import {
 import {
   filterActivePersonCompanyLinks,
   withActiveCustomerPersonCompanyLinkFilter,
+  withCustomerPersonCompanyLinkScope,
+  withScopedCustomerDealLinkWhere,
 } from '../../lib/personCompanyLinkTable'
 import { normalizeProfilePayload } from './payload'
 
@@ -227,7 +229,7 @@ const crud = makeCrudRoute({
           }
           const linkWhere = await withActiveCustomerPersonCompanyLinkFilter(
             em,
-            { company: query.excludeLinkedCompanyId },
+            withCustomerPersonCompanyLinkScope({ company: query.excludeLinkedCompanyId }, decryptionScope),
             'customers.people.GET',
           )
           const links = filterActivePersonCompanyLinks(
@@ -257,9 +259,7 @@ const crud = makeCrudRoute({
           const links = await findWithDecryption(
             em,
             CustomerDealPersonLink,
-            {
-              deal: query.excludeLinkedDealId,
-            },
+            withScopedCustomerDealLinkWhere(query.excludeLinkedDealId, decryptionScope),
             { populate: ['person'] },
             decryptionScope,
           )

--- a/packages/core/src/modules/customers/lib/__tests__/personCompanyLinkTable.test.ts
+++ b/packages/core/src/modules/customers/lib/__tests__/personCompanyLinkTable.test.ts
@@ -1,0 +1,64 @@
+import {
+  withActiveCustomerPersonCompanyLinkFilter,
+  withCustomerPersonCompanyLinkScope,
+  withScopedCustomerDealLinkWhere,
+} from '../personCompanyLinkTable'
+
+// Regression guard for #2736: the people/companies list routes resolve their
+// `excludeLinked*` params by querying the person↔company and deal↔person/company
+// link tables. `findWithDecryption` forwards the WHERE verbatim to `em.find` and
+// uses tenant/org only for decryption fallback — so the link lookups MUST carry
+// tenant/org in the WHERE clause itself. These helpers are the single source of
+// truth for that scoping; before the fix the lookups were unbounded by tenant.
+describe('customer link-table tenant/org scoping (#2736)', () => {
+  const tenantId = '11111111-1111-4111-8111-111111111111'
+  const organizationId = '22222222-2222-4222-8222-222222222222'
+
+  describe('withCustomerPersonCompanyLinkScope', () => {
+    it('adds tenant and organization columns when both are present', () => {
+      const where = withCustomerPersonCompanyLinkScope({ company: 'company-1' }, { tenantId, organizationId })
+      expect(where).toEqual({ company: 'company-1', tenantId, organizationId })
+    })
+
+    it('adds only the tenant column when organization scope is absent', () => {
+      const where = withCustomerPersonCompanyLinkScope({ person: 'person-1' }, { tenantId, organizationId: null })
+      expect(where).toEqual({ person: 'person-1', tenantId })
+      expect(where).not.toHaveProperty('organizationId')
+    })
+
+    it('leaves the base WHERE untouched when no scope is available', () => {
+      const where = withCustomerPersonCompanyLinkScope({ company: 'company-1' }, { tenantId: null, organizationId: null })
+      expect(where).toEqual({ company: 'company-1' })
+    })
+
+    it('does not mutate the caller-provided WHERE object', () => {
+      const base = { company: 'company-1' }
+      withCustomerPersonCompanyLinkScope(base, { tenantId, organizationId })
+      expect(base).toEqual({ company: 'company-1' })
+    })
+
+    it('composes with the active-link filter to a fully scoped WHERE', async () => {
+      const scoped = withCustomerPersonCompanyLinkScope({ company: 'company-1' }, { tenantId, organizationId })
+      const where = await withActiveCustomerPersonCompanyLinkFilter({} as never, scoped, 'test')
+      expect(where).toEqual({ company: 'company-1', tenantId, organizationId, deletedAt: null })
+    })
+  })
+
+  describe('withScopedCustomerDealLinkWhere', () => {
+    it('scopes deal-link lookups through the tenant-owned deal aggregate', () => {
+      const where = withScopedCustomerDealLinkWhere('deal-1', { tenantId, organizationId })
+      expect(where).toEqual({ deal: { id: 'deal-1', tenantId, organizationId } })
+    })
+
+    it('omits the organization filter when organization scope is absent', () => {
+      const where = withScopedCustomerDealLinkWhere('deal-1', { tenantId, organizationId: null })
+      expect(where).toEqual({ deal: { id: 'deal-1', tenantId } })
+      expect(where.deal).not.toHaveProperty('organizationId')
+    })
+
+    it('omits the tenant filter when tenant scope is absent', () => {
+      const where = withScopedCustomerDealLinkWhere('deal-1', { tenantId: null, organizationId })
+      expect(where).toEqual({ deal: { id: 'deal-1', organizationId } })
+    })
+  })
+})

--- a/packages/core/src/modules/customers/lib/personCompanyLinkTable.ts
+++ b/packages/core/src/modules/customers/lib/personCompanyLinkTable.ts
@@ -57,3 +57,42 @@ export function filterActivePersonCompanyLinks<T extends { deletedAt?: Date | st
   if (!Array.isArray(links)) return []
   return links.filter((entry) => entry?.deletedAt == null)
 }
+
+export type CustomerLinkTenantScope = {
+  tenantId?: string | null
+  organizationId?: string | null
+}
+
+/**
+ * Bound a person↔company link lookup to the caller's tenant/organization.
+ * `customer_person_company_links` carries `tenant_id`/`organization_id`
+ * directly, so each scope column is added to the WHERE clause when present.
+ * The people/companies list routes use this when resolving `excludeLinked*`
+ * params so the lookup is bounded by tenant instead of scanning the whole link
+ * table — `findWithDecryption` forwards the WHERE verbatim and treats the
+ * tenant/org scope as decryption-only (#2736).
+ */
+export function withCustomerPersonCompanyLinkScope<T extends Record<string, unknown>>(
+  where: T,
+  scope: CustomerLinkTenantScope,
+): T & { tenantId?: string; organizationId?: string } {
+  const scoped: T & { tenantId?: string; organizationId?: string } = { ...where }
+  if (scope.tenantId) scoped.tenantId = scope.tenantId
+  if (scope.organizationId) scoped.organizationId = scope.organizationId
+  return scoped
+}
+
+/**
+ * Build a tenant/organization-scoped WHERE for deal↔person and deal↔company
+ * link lookups. Those link tables carry no tenant columns, so the scope is
+ * applied through the tenant-owned `deal` aggregate (#2736).
+ */
+export function withScopedCustomerDealLinkWhere(
+  dealId: string,
+  scope: CustomerLinkTenantScope,
+): { deal: { id: string; tenantId?: string; organizationId?: string } } {
+  const deal: { id: string; tenantId?: string; organizationId?: string } = { id: dealId }
+  if (scope.tenantId) deal.tenantId = scope.tenantId
+  if (scope.organizationId) deal.organizationId = scope.organizationId
+  return { deal }
+}


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The `customers` people/companies list routes resolve their `excludeLinked*` query
params by querying the person↔company and deal↔person/company link tables, but the
link-table WHERE clauses carried no `tenant_id`/`organization_id` filter — they
filtered only on the related-entity id (+ `deletedAt: null`). `findWithDecryption`
forwards the WHERE verbatim to `em.find` and uses the tenant/org scope only for
decryption fallback, so the link-table scan was unbounded by tenant. Not a direct
cross-tenant disclosure today (the resolved ids only narrow an already tenant-scoped
main query and UUIDs don't collide), but a defense-in-depth gap: the query surface is
unbounded, the query scope no longer matches the decryption scope, and reusing the
helper to *expand* rather than narrow would become a genuine leak. This closes it at
the query boundary by scoping all four lookups by tenant (and organization where
available), reusing the scope already computed for decryption.

## Changes

- Add two pure WHERE-scoping helpers to `customers/lib/personCompanyLinkTable.ts`:
  - `withCustomerPersonCompanyLinkScope(where, scope)` — adds `tenantId`/`organizationId` (when present) to a person↔company link WHERE (`customer_person_company_links` carries both columns directly).
  - `withScopedCustomerDealLinkWhere(dealId, scope)` — scopes deal↔person/company link lookups through the tenant-owned `deal` aggregate (`{ deal: { id, tenantId?, organizationId? } }`), since those link tables have no tenant columns.
- Wire `customers/api/people/route.ts` (`excludeLinkedCompanyId` → `CustomerPersonCompanyLink`; `excludeLinkedDealId` → `CustomerDealPersonLink`) through the helpers.
- Wire `customers/api/companies/route.ts` (`excludeLinkedPersonId` → `CustomerPersonCompanyLink`; `excludeLinkedDealId` → `CustomerDealCompanyLink`) through the helpers.
- Add `customers/lib/__tests__/personCompanyLinkTable.test.ts` covering the scoped-WHERE shape (regression guard for the unscoped-lookup bug).

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — minor security hardening fix scoped to existing list routes.


## Testing

Local gate (all exit 0):
- `yarn jest --config jest.config.cjs personCompanyLinkTable` (in `packages/core`) — red→green, 8 passed
- `yarn build:packages` — 21/21
- `yarn typecheck` — 21/21 (core fresh)
- `yarn i18n:check-sync` — all locales in sync
- `yarn test` — core 665 suites / 5502 tests passed
- `yarn build:app` — compiled successfully

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — internal query scoping, no new strings/generated files.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Not required: per the issue this fix has **no observable API-response change** (the lookup only narrows an already tenant-scoped query; UUIDs don't collide across tenants). The security property lives at the query-WHERE boundary, which an HTTP-level integration test cannot distinguish fixed-vs-unfixed; it is covered deterministically by the new unit test on the WHERE-building helpers.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A (minor fix, no spec).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens — N/A, no UI
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` — N/A, no UI
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) — N/A, no UI
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements — N/A, no UI

## Linked issues

Fixes #2736.