### PR TITLE
fix: 2737 inbox ops price validator scoping

### DIFF
--- a/packages/core/src/modules/inbox_ops/lib/__tests__/priceValidator.test.ts
+++ b/packages/core/src/modules/inbox_ops/lib/__tests__/priceValidator.test.ts
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 
 import { validatePrices } from '../priceValidator'
+import { selectBestPrice } from '@open-mercato/core/modules/catalog/lib/pricing'
 
 const mockFindWithDecryption = jest.fn()
 
@@ -16,7 +17,15 @@ const scope = {
   organizationId: 'org-1',
 }
 
-const deps = { catalogProductPriceClass: MockPriceClass }
+// Mirror the production wiring: prices are resolved through the catalog pricing
+// engine (selectBestPrice + resolver pipeline) via the `catalogPricingService` DI
+// token, never a bespoke "newest row" heuristic. Delegating to the real
+// selectBestPrice exercises the actual channel/customer/quantity/time scoring.
+const catalogPricingService = {
+  resolvePrice: (rows: any[], context: any) => Promise.resolve(selectBestPrice(rows, context)),
+}
+
+const deps = { catalogProductPriceClass: MockPriceClass, catalogPricingService }
 
 describe('validatePrices', () => {
   beforeEach(() => {
@@ -34,9 +43,27 @@ describe('validatePrices', () => {
     expect(mockFindWithDecryption).not.toHaveBeenCalled()
   })
 
+  it('returns empty array when the catalog pricing service is unavailable', async () => {
+    const result = await validatePrices(mockEm, [
+      {
+        actionType: 'create_order',
+        payload: {
+          currencyCode: 'EUR',
+          lineItems: [
+            { productName: 'Widget A', productId: 'prod-1', unitPrice: '110', quantity: '1' },
+          ],
+        },
+        index: 0,
+      },
+    ], scope, { catalogProductPriceClass: MockPriceClass } as any)
+
+    expect(result).toEqual([])
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+
   it('detects warning-level price mismatch (5-20%)', async () => {
     mockFindWithDecryption.mockResolvedValueOnce([
-      { unitPriceNet: '100.00', currencyCode: 'EUR' },
+      { kind: 'regular', unitPriceNet: '100.00', currencyCode: 'EUR' },
     ])
 
     const result = await validatePrices(mockEm, [
@@ -62,7 +89,7 @@ describe('validatePrices', () => {
 
   it('detects error-level price mismatch (>20%)', async () => {
     mockFindWithDecryption.mockResolvedValueOnce([
-      { unitPriceNet: '100.00', currencyCode: 'EUR' },
+      { kind: 'regular', unitPriceNet: '100.00', currencyCode: 'EUR' },
     ])
 
     const result = await validatePrices(mockEm, [
@@ -84,7 +111,7 @@ describe('validatePrices', () => {
 
   it('detects currency mismatch between order and catalog', async () => {
     mockFindWithDecryption.mockResolvedValueOnce([
-      { unitPriceNet: '100.00', currencyCode: 'USD' },
+      { kind: 'regular', unitPriceNet: '100.00', currencyCode: 'USD' },
     ])
 
     const result = await validatePrices(mockEm, [
@@ -161,7 +188,7 @@ describe('validatePrices', () => {
 
   it('passes when price is within threshold', async () => {
     mockFindWithDecryption.mockResolvedValueOnce([
-      { unitPriceNet: '100.00', currencyCode: 'EUR' },
+      { kind: 'regular', unitPriceNet: '100.00', currencyCode: 'EUR' },
     ])
 
     const result = await validatePrices(mockEm, [
@@ -184,7 +211,7 @@ describe('validatePrices', () => {
     process.env.INBOX_OPS_PRICE_MISMATCH_THRESHOLD = '0.10'
 
     mockFindWithDecryption.mockResolvedValueOnce([
-      { unitPriceNet: '100.00', currencyCode: 'EUR' },
+      { kind: 'regular', unitPriceNet: '100.00', currencyCode: 'EUR' },
     ])
 
     // 8% diff - under 10% custom threshold
@@ -206,8 +233,8 @@ describe('validatePrices', () => {
 
   it('handles multiple line items and multiple actions', async () => {
     mockFindWithDecryption
-      .mockResolvedValueOnce([{ unitPriceNet: '10', currencyCode: 'EUR' }])   // prod-1: 10 vs 10 = ok
-      .mockResolvedValueOnce([{ unitPriceNet: '50', currencyCode: 'EUR' }])   // prod-2: 50 vs 100 = 100% diff
+      .mockResolvedValueOnce([{ kind: 'regular', unitPriceNet: '10', currencyCode: 'EUR' }])   // prod-1: 10 vs 10 = ok
+      .mockResolvedValueOnce([{ kind: 'regular', unitPriceNet: '50', currencyCode: 'EUR' }])   // prod-2: 50 vs 100 = 100% diff
 
     const result = await validatePrices(mockEm, [
       {
@@ -250,6 +277,154 @@ describe('validatePrices', () => {
       {
         actionType: 'create_order',
         payload: { lineItems: [] },
+        index: 0,
+      },
+    ], scope, deps)
+
+    expect(result).toEqual([])
+  })
+
+  // --- Regression: validator must resolve prices through the catalog pricing engine,
+  // honoring every pricing dimension instead of "most recently created row" (#2737). ---
+
+  it('ignores an expired promotional price and compares against the valid base price', async () => {
+    // Rows ordered promo-first to emulate the buggy "newest row wins" path.
+    mockFindWithDecryption.mockResolvedValueOnce([
+      { kind: 'promotion', unitPriceNet: '50.00', currencyCode: 'EUR', endsAt: new Date('2020-01-01T00:00:00Z') },
+      { kind: 'regular', unitPriceNet: '100.00', currencyCode: 'EUR' },
+    ])
+
+    const result = await validatePrices(mockEm, [
+      {
+        actionType: 'create_order',
+        payload: {
+          currencyCode: 'EUR',
+          lineItems: [
+            { productName: 'Widget A', productId: 'prod-1', unitPrice: '100', quantity: '1' },
+          ],
+        },
+        index: 0,
+      },
+    ], scope, deps)
+
+    expect(result).toEqual([])
+  })
+
+  it('ignores a price scoped to a different sales channel when the order has no channel', async () => {
+    mockFindWithDecryption.mockResolvedValueOnce([
+      { kind: 'regular', unitPriceNet: '70.00', currencyCode: 'EUR', channelId: 'channel-x' },
+      { kind: 'regular', unitPriceNet: '100.00', currencyCode: 'EUR' },
+    ])
+
+    const result = await validatePrices(mockEm, [
+      {
+        actionType: 'create_order',
+        payload: {
+          currencyCode: 'EUR',
+          lineItems: [
+            { productName: 'Widget A', productId: 'prod-1', unitPrice: '100', quantity: '1' },
+          ],
+        },
+        index: 0,
+      },
+    ], scope, deps)
+
+    expect(result).toEqual([])
+  })
+
+  it('respects quantity tiers when selecting the applicable price', async () => {
+    // Below-tier quantity: the bulk tier must not apply, so the base price wins.
+    mockFindWithDecryption.mockResolvedValueOnce([
+      { kind: 'tier', unitPriceNet: '8.00', currencyCode: 'EUR', minQuantity: 100 },
+      { kind: 'regular', unitPriceNet: '10.00', currencyCode: 'EUR', minQuantity: 1 },
+    ])
+    // At/above tier quantity: the bulk tier applies.
+    mockFindWithDecryption.mockResolvedValueOnce([
+      { kind: 'tier', unitPriceNet: '8.00', currencyCode: 'EUR', minQuantity: 100 },
+      { kind: 'regular', unitPriceNet: '10.00', currencyCode: 'EUR', minQuantity: 1 },
+    ])
+
+    const result = await validatePrices(mockEm, [
+      {
+        actionType: 'create_order',
+        payload: {
+          currencyCode: 'EUR',
+          lineItems: [
+            { productName: 'Below tier', productId: 'prod-1', unitPrice: '10', quantity: '5' },
+            { productName: 'At tier', productId: 'prod-2', unitPrice: '8', quantity: '100' },
+          ],
+        },
+        index: 0,
+      },
+    ], scope, deps)
+
+    expect(result).toEqual([])
+  })
+
+  it('uses a customer-specific price when the order carries the customer reference', async () => {
+    mockFindWithDecryption.mockResolvedValueOnce([
+      { kind: 'regular', unitPriceNet: '100.00', currencyCode: 'EUR' },
+      { kind: 'custom', unitPriceNet: '80.00', currencyCode: 'EUR', customerId: 'cust-1' },
+    ])
+
+    const result = await validatePrices(mockEm, [
+      {
+        actionType: 'create_order',
+        payload: {
+          currencyCode: 'EUR',
+          customerEntityId: 'cust-1',
+          lineItems: [
+            { productName: 'Widget A', productId: 'prod-1', unitPrice: '80', quantity: '1' },
+          ],
+        },
+        index: 0,
+      },
+    ], scope, deps)
+
+    expect(result).toEqual([])
+  })
+
+  it('does not treat a customer-specific price as the default when the order omits the customer', async () => {
+    mockFindWithDecryption.mockResolvedValueOnce([
+      { kind: 'custom', unitPriceNet: '80.00', currencyCode: 'EUR', customerId: 'cust-1' },
+      { kind: 'regular', unitPriceNet: '100.00', currencyCode: 'EUR' },
+    ])
+
+    const result = await validatePrices(mockEm, [
+      {
+        actionType: 'create_order',
+        payload: {
+          currencyCode: 'EUR',
+          lineItems: [
+            // Order claims the discounted price but provides no customer reference,
+            // so it must be compared against the base price and flagged.
+            { productName: 'Widget A', productId: 'prod-1', unitPrice: '80', quantity: '1' },
+          ],
+        },
+        index: 0,
+      },
+    ], scope, deps)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('price_mismatch')
+    expect(result[0].expectedValue).toBe('100.00')
+  })
+
+  it('selects the price matching the order currency instead of an unrelated-currency row', async () => {
+    mockFindWithDecryption.mockResolvedValueOnce([
+      { kind: 'regular', unitPriceNet: '100.00', currencyCode: 'USD' },
+      { kind: 'regular', unitPriceNet: '90.00', currencyCode: 'EUR' },
+    ])
+
+    const result = await validatePrices(mockEm, [
+      {
+        actionType: 'create_order',
+        payload: {
+          currencyCode: 'EUR',
+          lineItems: [
+            { productName: 'Widget A', productId: 'prod-1', unitPrice: '90', quantity: '1' },
+          ],
+        },
         index: 0,
       },
     ], scope, deps)

--- a/packages/core/src/modules/inbox_ops/lib/priceValidator.ts
+++ b/packages/core/src/modules/inbox_ops/lib/priceValidator.ts
@@ -29,6 +29,8 @@ interface PriceValidatorScope {
 
 interface CatalogProductPriceLike {
   product?: unknown
+  priceKind?: unknown
+  offer?: unknown
   unitPriceNet?: string | null
   unitPriceGross?: string | null
   currencyCode?: string | null
@@ -38,18 +40,54 @@ interface CatalogProductPriceLike {
   createdAt?: Date
 }
 
+// Minimal structural view of catalog's `PricingContext`. The validator resolves
+// prices through the catalog pricing engine so channel/customer/quantity/time/kind
+// scoping is honored consistently with the rest of the platform.
+export interface CatalogPricingContext {
+  channelId?: string | null
+  customerId?: string | null
+  customerGroupId?: string | null
+  quantity: number
+  date: Date
+}
+
+// Minimal structural view of the `catalogPricingService` DI token. Using the engine
+// (selectBestPrice + resolver pipeline) instead of a bespoke query is mandated by
+// packages/core/src/modules/catalog/AGENTS.md and ensures tenant pricing overrides apply.
+export interface CatalogPricingServiceLike {
+  resolvePrice(
+    rows: CatalogProductPriceLike[],
+    context: CatalogPricingContext,
+  ): Promise<CatalogProductPriceLike | null>
+}
+
+interface PriceValidatorDeps {
+  catalogProductPriceClass: EntityClass<CatalogProductPriceLike>
+  catalogPricingService: CatalogPricingServiceLike
+}
+
 const DEFAULT_MISMATCH_THRESHOLD = 0.05 // 5%
+
+function readUuid(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function parsePositiveQuantity(value: unknown): number {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? parseFloat(value) : NaN
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1
+}
 
 export async function validatePrices(
   em: EntityManager,
   actions: { actionType: string; payload: Record<string, unknown>; index: number }[],
   scope: PriceValidatorScope,
-  deps?: { catalogProductPriceClass: EntityClass<CatalogProductPriceLike> },
+  deps?: PriceValidatorDeps,
 ): Promise<PriceDiscrepancy[]> {
-  if (!deps?.catalogProductPriceClass) return []
+  if (!deps?.catalogProductPriceClass || !deps?.catalogPricingService) return []
 
   const threshold = parseFloat(process.env.INBOX_OPS_PRICE_MISMATCH_THRESHOLD || String(DEFAULT_MISMATCH_THRESHOLD))
   const discrepancies: PriceDiscrepancy[] = []
+  const now = new Date()
 
   for (const action of actions) {
     if (action.actionType !== 'create_order' && action.actionType !== 'create_quote') {
@@ -62,11 +100,32 @@ export async function validatePrices(
       ? action.payload.currencyCode.trim().toUpperCase()
       : null
 
+    // Channel and customer scoping come from the proposal payload (or the caller's
+    // scope as a fallback). When unknown, the engine correctly excludes channel/
+    // customer-specific rows and falls back to the generally-applicable price.
+    const channelId = readUuid(action.payload.channelId) ?? scope.channelId ?? null
+    const customerId = readUuid(action.payload.customerEntityId) ?? scope.customerId ?? null
+
     for (const line of lineItems) {
       if (!line.productId || !line.unitPrice) continue
 
       try {
-        const catalogResult = await lookupCatalogPrice(em, line.productId, scope, deps.catalogProductPriceClass)
+        const pricingContext: CatalogPricingContext = {
+          channelId,
+          customerId,
+          customerGroupId: null,
+          quantity: parsePositiveQuantity(line.quantity),
+          date: now,
+        }
+        const catalogResult = await lookupCatalogPrice(
+          em,
+          line.productId,
+          scope,
+          deps.catalogProductPriceClass,
+          deps.catalogPricingService,
+          pricingContext,
+          orderCurrency,
+        )
         if (catalogResult === null) continue
 
         if (orderCurrency && catalogResult.currencyCode && orderCurrency !== catalogResult.currencyCode.toUpperCase()) {
@@ -113,9 +172,15 @@ async function lookupCatalogPrice(
   productId: string,
   scope: PriceValidatorScope,
   entityClass: EntityClass<CatalogProductPriceLike>,
+  pricingService: CatalogPricingServiceLike,
+  pricingContext: CatalogPricingContext,
+  orderCurrency: string | null,
 ): Promise<{ price: string; currencyCode: string | null } | null> {
   try {
-    const prices = await findWithDecryption(
+    // Load all non-deleted price rows for the product (populating the relations the
+    // pricing engine scores on), then let the engine pick the applicable one — never
+    // the "most recently created" row, which ignores every pricing dimension (#2737).
+    const rows = await findWithDecryption(
       em,
       entityClass,
       {
@@ -124,13 +189,23 @@ async function lookupCatalogPrice(
         organizationId: scope.organizationId,
         tenantId: scope.tenantId,
       },
-      { limit: 10, orderBy: { createdAt: 'DESC' } },
+      { populate: ['priceKind', 'offer'] },
       { tenantId: scope.tenantId, organizationId: scope.organizationId },
     )
 
-    if (!prices || prices.length === 0) return null
+    if (!rows || rows.length === 0) return null
 
-    const priceRecord = prices[0]
+    // Prefer rows in the order's currency so we compare like-for-like instead of
+    // raising a spurious currency mismatch against an unrelated-currency row; fall
+    // back to all rows (which surfaces a genuine mismatch when no match exists).
+    const sameCurrencyRows = orderCurrency
+      ? rows.filter((row) => (row.currencyCode ?? '').toUpperCase() === orderCurrency)
+      : rows
+    const candidateRows = sameCurrencyRows.length > 0 ? sameCurrencyRows : rows
+
+    const priceRecord = await pricingService.resolvePrice(candidateRows, pricingContext)
+    if (!priceRecord) return null
+
     const priceValue = priceRecord.unitPriceNet ?? priceRecord.unitPriceGross ?? null
     if (!priceValue) return null
 

--- a/packages/core/src/modules/inbox_ops/subscribers/extractionWorker.ts
+++ b/packages/core/src/modules/inbox_ops/subscribers/extractionWorker.ts
@@ -10,7 +10,7 @@ import { buildExtractionSystemPrompt, buildExtractionUserPrompt } from '../lib/e
 import { REQUIRED_FEATURES_MAP } from '../lib/constants'
 import { fetchCatalogProductsForExtraction } from '../lib/catalogLookup'
 import { enrichOrderPayload } from '../lib/payloadEnrichment'
-import { validatePrices } from '../lib/priceValidator'
+import { validatePrices, type CatalogPricingServiceLike } from '../lib/priceValidator'
 import { extractParticipantsFromThread } from '../lib/emailParser'
 import { runExtractionWithConfiguredProvider } from '../lib/llmProvider'
 import { safeParsePayloadJson } from '../lib/validation'
@@ -216,8 +216,11 @@ export default async function handle(payload: EmailReceivedPayload, ctx: Resolve
       }))
       .filter((a) => a.actionType === 'create_order' || a.actionType === 'create_quote')
 
+    const catalogPricingService = tryResolve<CatalogPricingServiceLike>(ctx, 'catalogPricingService')
     const priceDiscrepancies = await validatePrices(em, orderActions, scope,
-      entityClasses.catalogProductPrice ? { catalogProductPriceClass: entityClasses.catalogProductPrice } : undefined,
+      entityClasses.catalogProductPrice && catalogPricingService
+        ? { catalogProductPriceClass: entityClasses.catalogProductPrice, catalogPricingService }
+        : undefined,
     )
 
     // Step 4b: Check for duplicate orders by customerReference


### PR DESCRIPTION
## Summary

The `inbox_ops` price-discrepancy validator reimplemented catalog price lookup with a naive query: it filtered `CatalogProductPrice` by product/tenant/org/`deletedAt`, ordered by `createdAt DESC`, and compared against the **most-recently-created row**. That collapses every pricing dimension the entity models — `channelId`, `customerId`/`customerGroupId`, `minQuantity`/`maxQuantity`, `startsAt`/`endsAt`, `kind`, and currency — into "newest wins," so the validator could compare an order against an expired promo, a foreign-channel or per-customer price, the wrong currency, or the wrong quantity tier. The result was false-positive (and missed) `price_mismatch`/`currency_mismatch` warnings shown to staff, and a violation of the catalog contract (`MUST use selectBestPrice` and the `catalogPricingService` DI token).

This routes price resolution through the catalog pricing engine via the `catalogPricingService` DI token: load all non-deleted price rows for the product and let `resolvePrice` (selectBestPrice + resolver pipeline) pick the applicable one for a proper context (channel, customer, quantity, `at: now`). Channel/customer are derived from the proposal payload; an order-currency pre-filter keeps the comparison like-for-like while still surfacing a genuine currency mismatch when the product has no price in the order's currency. The `createdAt DESC` heuristic and the `limit: 10` are removed.

## Changes

- `priceValidator.ts`: `lookupCatalogPrice` now loads all candidate rows (populating `priceKind`/`offer`) and resolves via the injected `catalogPricingService.resolvePrice(rows, context)`; builds a `PricingContext` from per-line quantity + per-action `channelId`/`customerEntityId` + `date: now`; adds an order-currency pre-filter; `validatePrices` now requires `catalogPricingService` in `deps` (returns `[]` when absent, matching the existing `catalogProductPriceClass` guard).
- `subscribers/extractionWorker.ts`: resolves `catalogPricingService` from DI (`tryResolve`) and passes it to `validatePrices`.
- `lib/__tests__/priceValidator.test.ts`: existing assertions preserved and wired to the real `selectBestPrice` engine via the new dep; added regression tests for expired-promo exclusion, foreign-channel exclusion, quantity tiers, customer-specific pricing (threaded from `customerEntityId`), customer-specific-not-treated-as-default, and order-currency selection, plus a "pricing service unavailable → no validation" guard.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — bug fix to existing behavior; the governing contract is `packages/core/src/modules/catalog/AGENTS.md` (use `selectBestPrice` / `catalogPricingService`).

## Testing

- `yarn workspace @open-mercato/core test priceValidator` — 19/19 (7 regression cases were red on the pre-fix code).
- `yarn workspace @open-mercato/core test inbox_ops` — 26 suites / 323 tests pass.
- `yarn workspace @open-mercato/core test` — 664 suites / 5501 tests pass.
- `yarn turbo run typecheck --filter=@open-mercato/core` — pass.
- `yarn build:packages` — 21/21 tasks pass (core built).
- `yarn i18n:check-sync` — all locales in sync (no new strings).
- `yarn generate` — no registry drift.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (Not required — no new user-facing strings, entities, or registries; `yarn generate` produced no drift.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required — the fix is a pure price-selection helper covered by deterministic unit tests; the surrounding extraction flow is LLM-gated and the pricing logic has no independent HTTP/UI surface, so unit-level regression is the correct altitude.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2737