### PR TITLE
fix: 2738 query index search alias counter

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/search-alias-concurrency.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/search-alias-concurrency.test.ts
@@ -1,0 +1,86 @@
+import { HybridQueryEngine } from '../lib/engine'
+
+/**
+ * Regression coverage for #2738.
+ *
+ * `HybridQueryEngine` used to keep its search-token alias counter as instance
+ * state (`searchAliasSeq`) and reset it to `0` at the top of every `query()`
+ * call. Because the DI container shares one engine instance per request scope,
+ * a second `query()` running concurrently resets the counter mid-flight, so the
+ * first call re-emits an `st_N` alias it already used inside the same SQL
+ * statement — which Postgres rejects at parse time.
+ *
+ * The fix makes alias allocation owned per `query()` invocation. These tests
+ * drive the two methods that mint `search_tokens` aliases and inject the exact
+ * mid-statement reset a concurrent call performs; statement-unique aliases must
+ * survive it.
+ */
+
+/**
+ * Minimal expression-builder double that records the alias of every
+ * `search_tokens as st_N` subquery the engine builds. Every other builder
+ * method is a no-op that keeps the chain fluent.
+ */
+function createAliasCapturingBuilder(aliases: string[]): any {
+  const builder: any = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'selectFrom') {
+          return (raw: unknown) => {
+            const match = /search_tokens\s+as\s+(\S+)/i.exec(String(raw))
+            if (match) aliases.push(match[1])
+            return builder
+          }
+        }
+        return () => builder
+      },
+    },
+  )
+  return builder
+}
+
+function mintTwiceAcrossConcurrentReset(
+  method: 'applySearchTokens' | 'buildSearchTokensSub',
+): string[] {
+  const engine = new HybridQueryEngine(
+    { getKysely: () => ({}) } as any,
+    { query: jest.fn() } as any,
+  )
+  const aliases: string[] = []
+  const builder = createAliasCapturingBuilder(aliases)
+  let perCallSeq = 0
+  const tokenOpts = {
+    entity: 'example:todo',
+    field: 'title',
+    hashes: ['hash-1'],
+    recordIdColumn: 'b.id',
+    tenantId: 't1',
+    // Per-call alias minter — consumed after the fix, ignored by the buggy code.
+    mintAlias: () => `st_${perCallSeq++}`,
+  }
+
+  // Query A enters query(): the pre-fix code resets the shared counter here.
+  ;(engine as any).searchAliasSeq = 0
+  ;(engine as any)[method](builder, tokenOpts)
+
+  // A concurrent query() on the SAME engine instance enters and resets the
+  // shared counter mid-statement — the `this.searchAliasSeq = 0` from #2738.
+  ;(engine as any).searchAliasSeq = 0
+  ;(engine as any)[method](builder, tokenOpts)
+
+  return aliases
+}
+
+describe('query_index search-alias allocation under concurrency (#2738)', () => {
+  test.each(['applySearchTokens', 'buildSearchTokensSub'] as const)(
+    '%s keeps statement aliases unique when a concurrent query() resets mid-flight',
+    (method) => {
+      const aliases = mintTwiceAcrossConcurrentReset(method)
+
+      expect(aliases).toHaveLength(2)
+      // Duplicate `st_N` aliases inside one statement are an invalid SQL parse.
+      expect(new Set(aliases).size).toBe(aliases.length)
+    },
+  )
+})

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -87,6 +87,8 @@ type SearchRuntime = {
   organizationScope?: { ids: string[]; includeNull: boolean } | null
   tenantId?: string | null
   searchSources?: SearchTokenSource[]
+  /** Per-`query()` alias minter for `search_tokens` subqueries (see #2738). */
+  mintAlias: () => string
 }
 
 type EncryptionResolver = () => {
@@ -96,6 +98,18 @@ type EncryptionResolver = () => {
 } | null
 
 type SearchTokenSource = { entity: string; recordIdColumn: string }
+
+/**
+ * Mints `search_tokens` subquery aliases (`st_0`, `st_1`, …). Aliases only need
+ * to be unique within a single SQL statement, so every `query()` invocation owns
+ * a fresh minter. Keeping the counter call-local (rather than on the shared
+ * engine instance) means concurrent queries can never reset or collide on each
+ * other's sequence (#2738).
+ */
+function createSearchAliasMinter(): () => string {
+  let seq = 0
+  return () => `st_${seq++}`
+}
 
 function createQueryProfiler(entity: string): Profiler {
   const enabled = shouldEnableProfiler(entity)
@@ -120,7 +134,6 @@ export class HybridQueryEngine implements QueryEngine {
   private autoReindexEnabled: boolean | null = null
   private coverageOptimizationEnabled: boolean | null = null
   private pendingCoverageRefreshKeys = new Set<string>()
-  private searchAliasSeq = 0
 
   constructor(
     private em: EntityManager,
@@ -201,7 +214,6 @@ export class HybridQueryEngine implements QueryEngine {
     try {
       const debugEnabled = this.isDebugVerbosity()
       if (debugEnabled) this.debug('query:start', { entity })
-      this.searchAliasSeq = 0
 
       const isCustom = await this.isCustomEntity(entity)
       if (isCustom) {
@@ -375,6 +387,7 @@ export class HybridQueryEngine implements QueryEngine {
         config: searchConfig,
         organizationScope: orgScope,
         tenantId: opts.tenantId ?? null,
+        mintAlias: createSearchAliasMinter(),
       }
 
       // Prepare index sources for JSONB custom-field access.
@@ -725,6 +738,7 @@ export class HybridQueryEngine implements QueryEngine {
           recordIdColumn: `${join.alias}.id`,
           tenantId: opts.tenantId ?? null,
           organizationScope: orgScope,
+          mintAlias: searchRuntime.mintAlias,
         })
       }
 
@@ -1040,6 +1054,7 @@ export class HybridQueryEngine implements QueryEngine {
       tenantId?: string | null
       organizationScope?: { ids: string[]; includeNull: boolean } | null
       combineWith?: 'and' | 'or'
+      mintAlias: () => string
     }
   ): boolean {
     if (!opts.hashes.length) {
@@ -1049,7 +1064,7 @@ export class HybridQueryEngine implements QueryEngine {
       })
       return false
     }
-    const alias = `st_${this.searchAliasSeq++}`
+    const alias = opts.mintAlias()
     this.logSearchDebug('search:apply-search-tokens', {
       entity: opts.entity, field: opts.field, alias,
       tokenCount: opts.hashes.length,
@@ -1221,6 +1236,7 @@ export class HybridQueryEngine implements QueryEngine {
           recordIdColumn: `${source.alias}.entity_id`,
           tenantId: search.tenantId ?? null,
           organizationScope: search.organizationScope ?? null,
+          mintAlias: search.mintAlias,
         }))
       )
     ))
@@ -1237,9 +1253,10 @@ export class HybridQueryEngine implements QueryEngine {
       recordIdColumn: string
       tenantId?: string | null
       organizationScope?: { ids: string[]; includeNull: boolean } | null
+      mintAlias: () => string
     }
   ): any {
-    const alias = `st_${this.searchAliasSeq++}`
+    const alias = opts.mintAlias()
     let sub = eb
       .selectFrom(`search_tokens as ${alias}`)
       .select(sql<number>`1`.as('one'))
@@ -1280,6 +1297,7 @@ export class HybridQueryEngine implements QueryEngine {
           recordIdColumn: `${alias}.entity_id`,
           tenantId: search.tenantId ?? null,
           organizationScope: search.organizationScope ?? null,
+          mintAlias: search.mintAlias,
         })))
         this.logSearchDebug('search:cf-filter', {
           entity: entityType, field: key, tokens: tokens.tokens, hashes, applied: true,
@@ -1351,6 +1369,7 @@ export class HybridQueryEngine implements QueryEngine {
           entity: entityType, field: key, hashes, recordIdColumn,
           tenantId: search.tenantId ?? null,
           organizationScope: search.organizationScope ?? null,
+          mintAlias: search.mintAlias,
         })))
         this.logSearchDebug('search:index-doc-filter', {
           entity: entityType, field: key, tokens: tokens.tokens, hashes, applied: true,
@@ -1436,6 +1455,7 @@ export class HybridQueryEngine implements QueryEngine {
                 recordIdColumn: src.recordIdColumn,
                 tenantId: searchRuntime.tenantId ?? null,
                 organizationScope: searchRuntime.organizationScope ?? null,
+                mintAlias: searchRuntime.mintAlias,
               })),
             ),
           )
@@ -1526,6 +1546,7 @@ export class HybridQueryEngine implements QueryEngine {
       config: searchConfig,
       organizationScope: orgScope,
       tenantId: opts.tenantId ?? null,
+      mintAlias: createSearchAliasMinter(),
     }
 
     const normalizedFilters = normalizeFilters(opts.filters)
@@ -2106,6 +2127,7 @@ export class HybridQueryEngine implements QueryEngine {
                 recordIdColumn: src.recordIdColumn,
                 tenantId: search.tenantId ?? null,
                 organizationScope: search.organizationScope ?? null,
+                mintAlias: search.mintAlias,
               })))
           ))
           this.logSearchDebug('search:filter', {


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

`HybridQueryEngine` kept its `search_tokens` alias counter (`searchAliasSeq`) as
instance state and reset it to `0` at the top of every `query()` call. Because the
DI container shares one engine instance per request scope, two concurrent `query()`
calls clobber each other's counter — one call's reset rewinds the other's sequence,
so a single SQL statement re-emits an `st_N` alias it already used, which Postgres
rejects at parse time. This fix makes search-token alias allocation owned per
`query()` invocation, so concurrent queries can never reset or collide on each
other's sequence. Latent today (no audited caller parallelizes `queryEngine.query`),
but a real correctness/security foot-gun.

## Changes

- Removed the shared `HybridQueryEngine.searchAliasSeq` instance field and its
  per-`query()` reset.
- Added `createSearchAliasMinter()` — a per-call closure that mints `st_0`, `st_1`, …
  from a call-local counter.
- Added a `mintAlias` field to the engine-local `SearchRuntime` type and to the opts
  of `applySearchTokens` / `buildSearchTokensSub`; seed one minter per `query()` call
  (both the regular and custom-entity paths) and thread it to every search-token
  subquery builder. Object spreads share the same minter reference, so all mints in a
  call stay on one sequence.
- Added a deterministic regression test that drives both mint methods and injects the
  mid-statement reset a concurrent `query()` performs, asserting statement-unique aliases.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- N/A — small concurrency bug fix, no spec required -->


## Testing

List the tests or commands you ran to validate the change.

- `yarn workspace @open-mercato/core test src/modules/query_index/__tests__/search-alias-concurrency.test.ts` — new regression test (red before the fix → green after).
- `yarn turbo run typecheck --filter=@open-mercato/core` — ✅ passed.
- `yarn workspace @open-mercato/core test` — ✅ 665 suites / 5496 tests passed.
- `yarn workspace @open-mercato/core test src/modules/query_index` — ✅ 7 suites / 42 tests passed.
- `yarn i18n:check-sync` — ✅ all locales in sync.
- `yarn build:packages` — ✅ 21 tasks successful.
- `yarn build:app` — ✅ compiled successfully, TypeScript passed.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — internal engine fix; no docs/locale/generator changes needed.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (N/A — latent internal concurrency bug with no API/UI surface change; a deterministic unit regression test is the appropriate guard.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — minor bug fix, no spec.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens — N/A, no UI
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` — N/A, no UI
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) — N/A, no UI
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements — N/A, no UI

## Linked issues

Fixes #2738