### PR TITLE
fix: 2739 query index job toctou

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/jobs.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/jobs.test.ts
@@ -1,0 +1,156 @@
+import { prepareJob, type JobScope } from '../lib/jobs'
+
+type RecordedOp = {
+  kind: 'select' | 'insert' | 'update' | 'delete'
+  table: string
+  onConflict: boolean
+}
+
+type FakeDbConfig = {
+  /** Row id returned by a SELECT ... executeTakeFirst (the legacy read-then-write probe). */
+  existingId?: string | null
+  /** Row id returned by the atomic INSERT ... ON CONFLICT ... RETURNING. */
+  upsertId?: string | null
+  /** Force the ON CONFLICT upsert to throw so the degraded fallback path is exercised. */
+  upsertThrows?: boolean
+}
+
+/**
+ * Minimal Kysely test double for the job helpers. Records every top-level
+ * operation (`selectFrom`/`insertInto`/`updateTable`) and whether an insert used
+ * `onConflict`, so the test can assert the TOCTOU read-then-write window is gone.
+ */
+function createFakeDb(config: FakeDbConfig = {}) {
+  const ops: RecordedOp[] = []
+  const existingId = config.existingId ?? null
+  const upsertId = config.upsertId ?? 'job-upserted'
+  const upsertThrows = config.upsertThrows ?? false
+
+  const makeOcStub = (): any => {
+    const oc: any = {
+      columns: () => oc,
+      column: () => oc,
+      constraint: () => oc,
+      expression: () => oc,
+      where: () => oc,
+      doUpdateSet: () => oc,
+      doNothing: () => oc,
+    }
+    return oc
+  }
+
+  const selectChain = (table: string): any => {
+    const chain: any = {
+      select: () => chain,
+      selectAll: () => chain,
+      where: () => chain,
+      orderBy: () => chain,
+      executeTakeFirst: async () => (existingId ? { id: existingId } : undefined),
+      execute: async () => (existingId ? [{ id: existingId }] : []),
+    }
+    return chain
+  }
+
+  const insertChain = (table: string): any => {
+    const op: RecordedOp = { kind: 'insert', table, onConflict: false }
+    ops.push(op)
+    const chain: any = {
+      values: () => chain,
+      onConflict: (cb: unknown) => {
+        op.onConflict = true
+        if (typeof cb === 'function') {
+          try { (cb as (oc: any) => unknown)(makeOcStub()) } catch { /* builder shape only */ }
+        }
+        return chain
+      },
+      returning: () => chain,
+      execute: async () => {
+        if (upsertThrows && op.onConflict) {
+          throw new Error('no unique or exclusion constraint matching the ON CONFLICT specification')
+        }
+        return upsertId ? [{ id: upsertId }] : []
+      },
+    }
+    return chain
+  }
+
+  const mutateChain = (kind: 'update' | 'delete', table: string): any => {
+    ops.push({ kind, table, onConflict: false })
+    const chain: any = {
+      set: () => chain,
+      where: () => chain,
+      returning: () => chain,
+      execute: async () => ({ numUpdatedRows: BigInt(1), numDeletedRows: BigInt(0) }),
+      executeTakeFirst: async () => ({ numUpdatedRows: BigInt(1) }),
+    }
+    return chain
+  }
+
+  const db: any = {
+    _ops: ops,
+    selectFrom: (table: unknown) => {
+      ops.push({ kind: 'select', table: String(table), onConflict: false })
+      return selectChain(String(table))
+    },
+    insertInto: (table: unknown) => insertChain(String(table)),
+    updateTable: (table: unknown) => mutateChain('update', String(table)),
+    deleteFrom: (table: unknown) => mutateChain('delete', String(table)),
+  }
+  return { db, ops }
+}
+
+const SCOPE: JobScope = {
+  entityType: 'example:todo',
+  organizationId: null,
+  tenantId: 't1',
+  partitionIndex: null,
+  partitionCount: null,
+}
+
+describe('prepareJob concurrency safety (#2739)', () => {
+  it('performs a single atomic upsert with no separate read-then-write window', async () => {
+    const { db, ops } = createFakeDb({ upsertId: 'job-1' })
+
+    const jobId = await prepareJob(db, SCOPE, 'reindexing', { totalCount: 10 })
+
+    // The TOCTOU window came from a standalone SELECT on entity_index_jobs that
+    // a concurrent scheduler could interleave with. There must be no such read.
+    const reads = ops.filter((op) => op.kind === 'select' && op.table.includes('entity_index_jobs'))
+    expect(reads).toHaveLength(0)
+
+    // Exactly one write, and it must be an INSERT ... ON CONFLICT upsert.
+    const inserts = ops.filter((op) => op.kind === 'insert' && op.table.includes('entity_index_jobs'))
+    expect(inserts).toHaveLength(1)
+    expect(inserts[0].onConflict).toBe(true)
+
+    // No standalone UPDATE write on the happy path — the upsert covers both branches.
+    const updates = ops.filter((op) => op.kind === 'update' && op.table.includes('entity_index_jobs'))
+    expect(updates).toHaveLength(0)
+
+    expect(jobId).toBe('job-1')
+  })
+
+  it('returns the upserted row id whether the scope row pre-existed or not', async () => {
+    // A pre-existing row must not change the code path: still one atomic upsert.
+    const { db, ops } = createFakeDb({ existingId: 'pre-existing', upsertId: 'job-2' })
+
+    const jobId = await prepareJob(db, SCOPE, 'purging')
+
+    expect(ops.filter((op) => op.kind === 'select' && op.table.includes('entity_index_jobs'))).toHaveLength(0)
+    expect(jobId).toBe('job-2')
+  })
+
+  it('falls back to read-then-write when the atomic upsert is unsupported by the schema', async () => {
+    // Mirrors indexer.ts: if the unique index is absent (e.g. mid-migration), the
+    // upsert raises and prepareJob degrades to the legacy update-or-insert path.
+    const { db, ops } = createFakeDb({ upsertThrows: true, existingId: null, upsertId: 'job-3' })
+
+    const jobId = await prepareJob(db, SCOPE, 'reindexing')
+
+    // The fallback attempted the atomic upsert first...
+    expect(ops.some((op) => op.kind === 'insert' && op.onConflict)).toBe(true)
+    // ...then degraded to the read-then-write probe.
+    expect(ops.some((op) => op.kind === 'select' && op.table.includes('entity_index_jobs'))).toBe(true)
+    expect(jobId).toBeTruthy()
+  })
+})

--- a/packages/core/src/modules/query_index/data/entities.ts
+++ b/packages/core/src/modules/query_index/data/entities.ts
@@ -89,6 +89,16 @@ export class EntityIndexRow {
 
 // Track long-running index jobs (reindex/purge) per entity and org scope
 @Entity({ tableName: 'entity_index_jobs' })
+// Coalesced-scope unique index so prepareJob can upsert atomically and two
+// concurrent schedulers cannot insert duplicate rows for the same scope (#2739).
+// Declared via @Unique with a raw expression (not properties) because the scope
+// columns are nullable and NULLs must collapse to one bucket via coalesce; mirrors
+// the entity_indexes coalesced uniqueness and the domain_mappings expression unique.
+@Unique({
+  name: 'entity_index_jobs_scope_unique',
+  expression:
+    `create unique index "entity_index_jobs_scope_unique" on "entity_index_jobs" ("entity_type", coalesce("organization_id", '00000000-0000-0000-0000-000000000000'::uuid), coalesce("tenant_id", '00000000-0000-0000-0000-000000000000'::uuid), coalesce("partition_index", -1), coalesce("partition_count", -1))`,
+})
 export class EntityIndexJob {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string

--- a/packages/core/src/modules/query_index/lib/jobs.ts
+++ b/packages/core/src/modules/query_index/lib/jobs.ts
@@ -20,6 +20,17 @@ function applyScopeWhere<QB extends { where: (...args: any[]) => QB }>(
   return q
 }
 
+// True when ON CONFLICT could not infer an arbiter index (Postgres SQLSTATE
+// 42P10) — i.e. entity_index_jobs_scope_unique is not present yet. Used to scope
+// prepareJob's fallback to the missing-index case only.
+function isMissingConflictArbiterError(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null | undefined)?.code
+  if (code === '42P10') return true
+  const message = (err as { message?: unknown } | null | undefined)?.message
+  return typeof message === 'string'
+    && /no unique or exclusion constraint matching the on conflict/i.test(message)
+}
+
 export async function prepareJob(
   db: Kysely<any>,
   scope: JobScope,
@@ -39,6 +50,52 @@ export async function prepareJob(
     total_count: options.totalCount ?? null,
   }
 
+  // Single atomic upsert keyed by the coalesced scope tuple. This closes the
+  // read-then-write race where two concurrent schedulers each see "no row" and
+  // both INSERT a duplicate for the same scope, after which updateJobProgress /
+  // finalizeJob corrupt each other's progress and finish state (#2739). The
+  // ON CONFLICT target must match entity_index_jobs_scope_unique exactly.
+  try {
+    const upserted = await db
+      .insertInto('entity_index_jobs' as any)
+      .values({ entity_type: scope.entityType, ...base } as any)
+      .onConflict((oc: any) => oc
+        .expression(sql`
+          "entity_type",
+          coalesce("organization_id", '00000000-0000-0000-0000-000000000000'::uuid),
+          coalesce("tenant_id", '00000000-0000-0000-0000-000000000000'::uuid),
+          coalesce("partition_index", -1),
+          coalesce("partition_count", -1)
+        `)
+        .doUpdateSet({
+          status,
+          started_at: sql`now()`,
+          finished_at: null,
+          heartbeat_at: sql`now()`,
+          processed_count: 0,
+          total_count: options.totalCount ?? null,
+        } as any))
+      .returning(['id' as any])
+      .execute() as Array<{ id: string }>
+    return upserted?.[0]?.id ?? null
+  } catch (err) {
+    // Only degrade to the legacy path when the scope unique index is absent
+    // (e.g. a rolling deploy running this code against the pre-migration schema):
+    // Postgres raises 42P10. Any other failure is real and must surface rather
+    // than silently fall back to the racy read-then-write path and re-open #2739.
+    if (!isMissingConflictArbiterError(err)) throw err
+    return prepareJobLegacy(db, scope, base)
+  }
+}
+
+// Pre-#2739 read-then-write path. Retained only as a fallback when the
+// entity_index_jobs scope unique index is unavailable; it carries the original
+// (racy) semantics and must never be reached once the migration has applied.
+async function prepareJobLegacy(
+  db: Kysely<any>,
+  scope: JobScope,
+  base: Record<string, unknown>,
+): Promise<string | null> {
   const existing = await applyScopeWhere(
     db.selectFrom('entity_index_jobs' as any).select(['id' as any]),
     scope,

--- a/packages/core/src/modules/query_index/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/query_index/migrations/.snapshot-open-mercato.json
@@ -409,6 +409,15 @@
           "keyName": "entity_index_jobs_type_idx",
           "primary": false,
           "unique": false
+        },
+        {
+          "columnNames": [],
+          "composite": false,
+          "constraint": true,
+          "keyName": "entity_index_jobs_scope_unique",
+          "primary": false,
+          "unique": true,
+          "expression": "create unique index \"entity_index_jobs_scope_unique\" on \"entity_index_jobs\" (\"entity_type\", coalesce(\"organization_id\", '00000000-0000-0000-0000-000000000000'::uuid), coalesce(\"tenant_id\", '00000000-0000-0000-0000-000000000000'::uuid), coalesce(\"partition_index\", -1), coalesce(\"partition_count\", -1))"
         }
       ],
       "checks": [],

--- a/packages/core/src/modules/query_index/migrations/Migration20260606205453_query_index.ts
+++ b/packages/core/src/modules/query_index/migrations/Migration20260606205453_query_index.ts
@@ -1,0 +1,39 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260606205453_query_index extends Migration {
+
+  override up(): void | Promise<void> {
+    // De-duplicate scope rows that the pre-#2739 read-then-write prepareJob could
+    // create when two schedulers raced. Keep the most relevant per coalesced scope
+    // (still-running first, then most recently started). Required before the unique
+    // index can be created.
+    this.addSql(`
+      delete from "entity_index_jobs" loser
+      using (
+        select "id"
+        from (
+          select
+            "id",
+            row_number() over (
+              partition by
+                "entity_type",
+                coalesce("organization_id", '00000000-0000-0000-0000-000000000000'::uuid),
+                coalesce("tenant_id", '00000000-0000-0000-0000-000000000000'::uuid),
+                coalesce("partition_index", -1),
+                coalesce("partition_count", -1)
+              order by ("finished_at" is null) desc, "started_at" desc, "id" desc
+            ) as row_number
+          from "entity_index_jobs"
+        ) ranked
+        where ranked.row_number > 1
+      ) duplicates
+      where loser."id" = duplicates."id";
+    `);
+    this.addSql(`create unique index if not exists "entity_index_jobs_scope_unique" on "entity_index_jobs" ("entity_type", coalesce("organization_id", '00000000-0000-0000-0000-000000000000'::uuid), coalesce("tenant_id", '00000000-0000-0000-0000-000000000000'::uuid), coalesce("partition_index", -1), coalesce("partition_count", -1));`);
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`drop index if exists "entity_index_jobs_scope_unique";`);
+  }
+
+}


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

`prepareJob` (`packages/core/src/modules/query_index/lib/jobs.ts`) chose update-vs-insert with a `SELECT` followed by a separate `UPDATE`/`INSERT`, with no transaction or row lock — a TOCTOU race. Because `entity_index_jobs` had no unique key over its scope tuple `(entity_type, organization_id, tenant_id, partition_index, partition_count)` (all nullable), two concurrent reindex/purge schedulers each saw "no row" and each inserted a duplicate. The scope-wide `updateJobProgress`/`finalizeJob` updates then corrupted each other's progress counters and finish state — an operator could see a job reported "finished" while indexing was still running (#2739).

This makes `prepareJob` idempotent under concurrency: a coalesced-scope unique index plus a single atomic `INSERT … ON CONFLICT … DO UPDATE`, so concurrent schedulers collapse onto one row instead of duplicating.

## Changes

- `query_index/lib/jobs.ts`: rewrote `prepareJob` as a single `INSERT … ON CONFLICT (entity_type, coalesce(organization_id,…), coalesce(tenant_id,…), coalesce(partition_index,-1), coalesce(partition_count,-1)) DO UPDATE … RETURNING id`. The previous read-then-write is retained as `prepareJobLegacy`, reached only when the unique index is absent (Postgres SQLSTATE `42P10`, e.g. a rolling deploy on the pre-migration schema); any other error is rethrown so a transient failure cannot silently fall back to the racy path.
- `query_index/data/entities.ts`: declared `@Unique({ name: 'entity_index_jobs_scope_unique', expression: … })` — a coalesced expression index so the nullable scope columns collapse to a single bucket (mirrors the `entity_indexes` coalesced uniqueness and the `domain_mappings` expression-unique precedent).
- New migration `Migration20260606205453_query_index.ts`: de-duplicates any pre-existing duplicate scope rows (keeping the still-running, then most-recently-started row) before creating the unique index; `down()` drops it.
- Updated `query_index/migrations/.snapshot-open-mercato.json` for the new index.
- `updateJobProgress`/`finalizeJob` are unchanged — they are now safe because at most one row exists per scope.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — concurrency/data-integrity bug fix (report.md finding #157).

## Testing

List the tests or commands you ran to validate the change.

- `yarn test --testPathPatterns query_index/__tests__/jobs.test` — new repro test: RED on the old read-then-write code (a standalone `SELECT` on `entity_index_jobs` is present), GREEN after the fix.
- `yarn workspace @open-mercato/core test` (query_index suite): 7 suites / 43 tests pass.
- `yarn workspace @open-mercato/search test`: 11 suites / 116 tests pass (search consumes `prepareJob`).
- `yarn typecheck`: 21/21. `yarn build:packages`: 21/21. `yarn build:app`: success. `yarn i18n:check-sync`: in sync. `yarn generate`: clean.
- Migration SQL + `ON CONFLICT` inference verified directly against PostgreSQL 17.9 in an isolated, rolled-back scratch table: dedup keeps the running row, the expression unique index is created, the arbiter is inferred, NULL-scope and partitioned-scope upserts each collapse to one row, and `DO UPDATE` applies.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No docs/locales required; `yarn generate` re-run, no changes.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (N/A — query_index has no real-DB/SQL concurrency harness; the SQL was verified against real PG 17.9 and the unit test guards the atomic-upsert / no-read-then-write contract.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — bug fix, no spec.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2739