### PR TITLE
fix: 2735 customers get dict seeding

### DIFF
--- a/packages/core/src/modules/customers/api/dictionaries/[kind]/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/dictionaries/[kind]/__tests__/route.test.ts
@@ -4,12 +4,15 @@ const organizationId = '22222222-2222-4222-8222-222222222222'
 const em = {
   find: jest.fn(),
   findOne: jest.fn(),
+  create: jest.fn(),
+  persist: jest.fn(),
+  flush: jest.fn(),
 }
 
 jest.mock('../../context', () => ({
   mapDictionaryKind: jest.fn((kind?: string) => ({
     kind,
-    mappedKind: kind === 'statuses' ? 'status' : kind,
+    mappedKind: kind === 'statuses' ? 'status' : kind === 'pipeline-stages' ? 'pipeline_stage' : kind,
   })),
   resolveDictionaryRouteContext: jest.fn(async () => ({
     translate: (_key: string, fallback?: string) => fallback ?? 'error',
@@ -126,5 +129,35 @@ describe('customer dictionary route', () => {
       expect.any(Request),
       expect.objectContaining({ selectedId: organizationId }),
     )
+  })
+
+  it('does not seed/persist pipeline_stage entries for stages lacking one (read-only GET, #2735)', async () => {
+    const stage = {
+      id: '33333333-3333-4333-8333-333333333333',
+      label: 'Legacy Stage Without Entry',
+      organizationId,
+      tenantId,
+    }
+    // First find loads dictionary entries (none); second loads pipeline stages.
+    em.find.mockResolvedValueOnce([]).mockResolvedValueOnce([stage])
+    em.findOne.mockResolvedValue(null)
+    em.create.mockImplementation((_entity: unknown, payload: Record<string, unknown>) => ({
+      id: 'seeded-entry',
+      normalizedValue: String((payload as { value?: string }).value ?? '').trim().toLowerCase(),
+      ...payload,
+    }))
+
+    const response = await GET(
+      new Request('http://localhost/api/customers/dictionaries/pipeline-stages'),
+      { params: { kind: 'pipeline-stages' } },
+    )
+
+    expect(response.status).toBe(200)
+
+    // A GET must not have write side effects — a pipeline stage missing its
+    // dictionary entry must NOT be auto-seeded inside the read handler (#2735).
+    expect(em.create).not.toHaveBeenCalled()
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/customers/api/dictionaries/[kind]/route.ts
+++ b/packages/core/src/modules/customers/api/dictionaries/[kind]/route.ts
@@ -4,8 +4,7 @@ import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/er
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { CommandExecuteResult } from '@open-mercato/shared/lib/commands/types'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
-import { CustomerDictionaryEntry, CustomerPipelineStage } from '../../../data/entities'
-import { ensureDictionaryEntry } from '../../../commands/shared'
+import { CustomerDictionaryEntry } from '../../../data/entities'
 import { mapDictionaryKind, resolveDictionaryActorId, resolveDictionaryRouteContext } from '../context'
 import { createDictionaryCacheKey, createDictionaryCacheTags, invalidateDictionaryCache, DICTIONARY_CACHE_TTL_MS } from '../cache'
 import { loadCustomerSettings } from '../../../commands/settings'
@@ -82,25 +81,6 @@ export async function GET(req: Request, ctx: { params?: { kind?: string } }) {
       { orderBy: { label: 'asc' } },
       { tenantId, organizationId },
     )
-
-    if (mappedKind === 'pipeline_stage' && organizationId) {
-      const existingNormalized = new Set(entries.map((e) => e.normalizedValue))
-      const pipelineStages = await findWithDecryption(em, CustomerPipelineStage, { organizationId, tenantId }, {}, { tenantId, organizationId })
-      for (const stage of pipelineStages) {
-        if (!existingNormalized.has(stage.label.trim().toLowerCase())) {
-          const created = await ensureDictionaryEntry(em, {
-            tenantId,
-            organizationId,
-            kind: 'pipeline_stage',
-            value: stage.label,
-          })
-          if (created) {
-            entries.push(created)
-            existingNormalized.add(created.normalizedValue)
-          }
-        }
-      }
-    }
 
     const inheritedPriority = new Map(scopedOrganizationIds.map((id, index) => [id, index]))
     const sortByLabel = (left: CustomerDictionaryEntry, right: CustomerDictionaryEntry) =>

--- a/packages/core/src/modules/customers/api/pipeline-stages/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/pipeline-stages/__tests__/route.test.ts
@@ -1,0 +1,114 @@
+/** @jest-environment node */
+
+import { CustomerPipelineStage, CustomerDictionaryEntry } from '../../../data/entities'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+
+const em = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  persist: jest.fn(),
+  flush: jest.fn(),
+}
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: 'user-1', tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({
+    selectedId: organizationId,
+    filterIds: [organizationId],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+import { GET } from '../route'
+
+const makeStage = (overrides: Record<string, unknown> = {}) => ({
+  id: '33333333-3333-4333-8333-333333333333',
+  pipelineId: '44444444-4444-4444-8444-444444444444',
+  label: 'Brand New Stage',
+  order: 0,
+  organizationId,
+  tenantId,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+  ...overrides,
+})
+
+describe('customers pipeline-stages GET', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    em.findOne.mockResolvedValue(null)
+    em.create.mockImplementation((_entity: unknown, payload: Record<string, unknown>) => ({
+      id: 'seeded-entry',
+      normalizedValue: String((payload as { value?: string }).value ?? '').trim().toLowerCase(),
+      ...payload,
+    }))
+    em.persist.mockReturnValue(undefined)
+    em.flush.mockResolvedValue(undefined)
+  })
+
+  it('does not persist dictionary entries when a stage has no matching entry (read-only GET, #2735)', async () => {
+    const stage = makeStage()
+    em.find.mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerPipelineStage) return [stage]
+      if (entity === CustomerDictionaryEntry) return []
+      return []
+    })
+
+    const response = await GET(new Request('http://localhost/api/customers/pipeline-stages'))
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { items: Array<Record<string, unknown>>; total: number }
+    expect(body.total).toBe(1)
+    expect(body.items[0]).toMatchObject({ id: stage.id, label: stage.label, color: null, icon: null })
+
+    // A GET must not have write side effects — the missing dictionary entry must
+    // NOT be auto-seeded inside the read handler (issue #2735).
+    expect(em.create).not.toHaveBeenCalled()
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('returns color/icon from an existing dictionary entry without writing', async () => {
+    const stage = makeStage({ label: 'Opportunity' })
+    const entry = {
+      normalizedValue: 'opportunity',
+      color: '#38bdf8',
+      icon: 'lucide:target',
+    }
+    em.find.mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerPipelineStage) return [stage]
+      if (entity === CustomerDictionaryEntry) return [entry]
+      return []
+    })
+
+    const response = await GET(new Request('http://localhost/api/customers/pipeline-stages'))
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { items: Array<Record<string, unknown>> }
+    expect(body.items[0]).toMatchObject({ color: '#38bdf8', icon: 'lucide:target' })
+    expect(em.create).not.toHaveBeenCalled()
+    expect(em.persist).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/pipeline-stages/route.ts
+++ b/packages/core/src/modules/customers/api/pipeline-stages/route.ts
@@ -15,7 +15,6 @@ import {
   type PipelineStageDeleteInput,
 } from '../../data/validators'
 import { withScopedPayload } from '../utils'
-import { ensureDictionaryEntry } from '../../commands/shared'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
@@ -75,19 +74,6 @@ export async function GET(req: Request) {
       : []
     const dictByNormalized = new Map<string, CustomerDictionaryEntry>()
     dictEntries.forEach((entry) => dictByNormalized.set(entry.normalizedValue, entry))
-
-    const missingStages = stages.filter((s) => !dictByNormalized.has(s.label.trim().toLowerCase()))
-    if (missingStages.length) {
-      for (const stage of missingStages) {
-        const created = await ensureDictionaryEntry(em, {
-          tenantId,
-          organizationId,
-          kind: 'pipeline_stage',
-          value: stage.label,
-        })
-        if (created) dictByNormalized.set(created.normalizedValue, created)
-      }
-    }
 
     const items = stages.map((stage) => {
       const dictEntry = dictByNormalized.get(stage.label.trim().toLowerCase())


### PR DESCRIPTION
## Summary

`GET /api/customers/pipeline-stages` (and the sibling `GET /api/customers/dictionaries/[kind]` for the `pipeline_stage` kind) auto-seeded missing `pipeline_stage` dictionary entries inside a loop via `ensureDictionaryEntry()`, which only calls `em.persist()` with no `em.flush()`. On the request-scoped EntityManager (AUTO flush mode, no request-end flush hook), only the *next* query flushes the *previous* persist — so the last newly-created entry per request was silently discarded, every subsequent GET re-attempted it (wasted work), and a read endpoint was performing DB writes (read-no-side-effects / `security`).

This removes the dictionary auto-seeding from both read handlers entirely, making the GETs side-effect-free. The seeding is redundant: `pipeline_stage` dictionary entries are already seeded (with colors/icons) at tenant setup via `seedCustomerDictionaries` and on every stage create/update command (inside `withAtomicFlush({ transaction: true })`). This is the issue's preferred fix ("seed on stage create/update or during setup, where it belongs").

## Changes

- `customers/api/pipeline-stages/route.ts` — removed the `missingStages` auto-seeding loop from `GET` and the now-unused `ensureDictionaryEntry` import. GET response is unchanged (stages with no dictionary entry already mapped to `color: null` / `icon: null`).
- `customers/api/dictionaries/[kind]/route.ts` — removed the `if (mappedKind === 'pipeline_stage')` auto-seeding block from `GET` and the now-unused `ensureDictionaryEntry` / `CustomerPipelineStage` imports.
- `ensureDictionaryEntry` (`customers/commands/shared.ts`) is intentionally unchanged — it persists-without-flush by design; its remaining callers (commands, setup) own the flush.
- Added read-only regression unit tests for both GET handlers (assert no `em.create`/`em.persist`/`em.flush`); these fail on the pre-fix code and pass on the fix.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — minor bug/security fix.

## Testing

- `yarn jest customers/api/pipeline-stages customers/api/dictionaries` (core) — 10 passed; the two new repro tests fail on pre-fix code and pass on the fix.
- `yarn turbo run typecheck --filter=@open-mercato/core` — pass.
- `yarn turbo run test --filter=@open-mercato/core` — 665 suites / 5497 tests pass.
- `yarn i18n:check-sync` — all 4 locales in sync.
- `yarn build:packages` — 21/21 successful.
- `yarn build:app` — successful.
- Note: `yarn lint` currently crashes locally with an unrelated ESLint 10.4.1 toolchain error (`scopeManager.addGlobals is not a function`) in `@open-mercato/app`, which this change does not touch; the `customers` (core) package has no lint task and its typecheck gate passes.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (Not required — no public API, locale, or generated-file changes.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). Documented: the read-no-side-effects contract is verified by handler unit tests that fail on the old code and pass on the fix; the command-path seeding this fix relies on is already integration-covered by `customers/__integration__/TC-CRM-2453-PIPELINE-STAGE.spec.ts`; and reproducing the GET side-effect via Playwright is unreliable because the original bug (no flush) means the side-effect is not even persisted, making DB observation order-dependent.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). N/A — no spec.

### Design System Compliance
- [x] No hardcoded status colors — N/A, backend-only, no UI.
- [x] No arbitrary text sizes — N/A, backend-only, no UI.
- [x] Empty state handled for list/data pages — N/A, backend-only, no UI.
- [x] Loading state handled for async pages — N/A, backend-only, no UI.
- [x] `aria-label` on all icon-only buttons — N/A, backend-only, no UI.
- [x] Uses existing DS components — N/A, backend-only, no UI.

## Linked issues

Fixes #2735