### PR TITLE
fix(workflows): duplicate info icon in Alert callouts (#2759)

### DIFF
--- a/apps/mercato/src/modules/example/backend/payments/page.tsx
+++ b/apps/mercato/src/modules/example/backend/payments/page.tsx
@@ -20,8 +20,6 @@ import {
   Ban,
   ArrowDownToLine,
   Undo2,
-  CheckCircle2,
-  AlertCircle,
   Info,
   Zap,
 } from 'lucide-react'
@@ -433,7 +431,6 @@ export default function PaymentGatewayDemoPage() {
           {/* Error Display */}
           {error && (
             <Alert variant="destructive">
-              <AlertCircle className="size-4" />
               <AlertTitle>{t('example.payments.error.title', 'Error')}</AlertTitle>
               <AlertDescription>{error}</AlertDescription>
             </Alert>
@@ -442,7 +439,6 @@ export default function PaymentGatewayDemoPage() {
           {/* Action Result */}
           {actionResult && (
             <Alert variant="success">
-              <CheckCircle2 className="size-4" />
               <AlertTitle>{t('example.payments.success.title', 'Success')}</AlertTitle>
               <AlertDescription>{actionResult}</AlertDescription>
             </Alert>

--- a/packages/core/src/__tests__/alert-duplicate-icon-coverage.test.ts
+++ b/packages/core/src/__tests__/alert-duplicate-icon-coverage.test.ts
@@ -1,0 +1,80 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+/**
+ * Alert duplicate-icon regression audit (#2759).
+ *
+ * The redesigned `Alert` primitive (`packages/ui/src/primitives/alert.tsx`)
+ * renders its own leading status icon automatically (`showIcon` defaults to
+ * `true`). Passing an icon element as the Alert's first child — the legacy
+ * pre-redesign pattern — draws the icon twice. Plain status banners should
+ * let `Alert` render the default icon; intentional custom icons belong on
+ * the `icon` prop (which replaces the default instead of adding to it).
+ *
+ * This audit flags any `<Alert …>` whose first JSX child on the next line
+ * is a self-closing, icon-shaped component (capitalized tag whose className
+ * carries a bare sizing utility such as `size-4` or `h-4 w-4`).
+ */
+
+const SCAN_ROOTS = [
+  'packages/core/src/modules',
+  'packages/ui/src',
+  'packages/webhooks/src',
+  'packages/enterprise/src',
+  'apps/mercato/src/modules',
+  'packages/create-app/template/src/modules',
+]
+
+const ALERT_OPEN = /<Alert\b[^>]*>$/
+const ICON_CHILD =
+  /^<[A-Z][A-Za-z0-9]*\s[^>]*className="[^"]*(?:\bsize-\d|\bh-\d+(?:\.\d+)?\s+w-\d+(?:\.\d+)?|\bw-\d+(?:\.\d+)?\s+h-\d+(?:\.\d+)?)[^"]*"[^>]*\/>$/
+
+const repoRoot = join(__dirname, '..', '..', '..', '..')
+
+function collectTsx(dir: string, acc: string[]): void {
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return
+  }
+  for (const name of entries) {
+    const full = join(dir, name)
+    const stat = statSync(full)
+    if (stat.isDirectory()) {
+      if (name === 'node_modules' || name === '__tests__' || name === 'generated' || name === 'dist') continue
+      collectTsx(full, acc)
+    } else if (name.endsWith('.tsx') && !name.endsWith('.test.tsx')) {
+      acc.push(full)
+    }
+  }
+}
+
+describe('Alert callouts do not double the leading icon (#2759)', () => {
+  const files: string[] = []
+  for (const root of SCAN_ROOTS) {
+    collectTsx(join(repoRoot, root), files)
+  }
+
+  it('discovered tsx files to scan', () => {
+    expect(files.length).toBeGreaterThan(100)
+  })
+
+  it('no <Alert> passes an icon element as its first child — use the icon prop instead', () => {
+    const violations: string[] = []
+    for (const full of files) {
+      const source = readFileSync(full, 'utf8')
+      if (!source.includes('<Alert')) continue
+      const lines = source.split('\n')
+      for (let index = 0; index < lines.length - 1; index += 1) {
+        if (!ALERT_OPEN.test(lines[index].trimEnd())) continue
+        const child = lines[index + 1].trim()
+        if (ICON_CHILD.test(child)) {
+          const rel = relative(repoRoot, full).split(sep).join('/')
+          violations.push(`${rel}:${index + 2} → ${child}`)
+        }
+      }
+    }
+    expect(violations).toEqual([])
+  })
+})

--- a/packages/core/src/modules/customer_accounts/backend/customer_accounts/settings/domain/components/Diagnostics.tsx
+++ b/packages/core/src/modules/customer_accounts/backend/customer_accounts/settings/domain/components/Diagnostics.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import * as React from 'react'
-import { AlertTriangle } from 'lucide-react'
 import { Alert, AlertTitle, AlertDescription } from '@open-mercato/ui/primitives/alert'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type { DomainMappingRow } from './types'
@@ -15,7 +14,6 @@ export function DnsDiagnostics({ mapping }: DiagnosticsProps) {
   if (mapping.status !== 'dns_failed') return null
   return (
     <Alert variant="destructive">
-      <AlertTriangle className="h-4 w-4" aria-hidden />
       <AlertTitle>
         {t('customer_accounts.domainMapping.dns.diagnostics.title', 'DNS configuration issue')}
       </AlertTitle>
@@ -41,7 +39,6 @@ export function TlsDiagnostics({ mapping }: DiagnosticsProps) {
   if (mapping.status !== 'tls_failed') return null
   return (
     <Alert variant="warning">
-      <AlertTriangle className="h-4 w-4" aria-hidden />
       <AlertTitle>
         {t('customer_accounts.domainMapping.tls.diagnostics.title', 'SSL certificate issue')}
       </AlertTitle>

--- a/packages/core/src/modules/customers/components/detail/ConfirmDealLostDialog.tsx
+++ b/packages/core/src/modules/customers/components/detail/ConfirmDealLostDialog.tsx
@@ -116,7 +116,6 @@ export function ConfirmDealLostDialog({
 
           <div className="space-y-6 px-7 py-6">
             <Alert variant="warning" className="rounded-md">
-              <AlertTriangle className="size-4" />
               <AlertTitle>
                 {t('customers.deals.detail.lost.warningTitle', 'This action closes the deal')}
               </AlertTitle>

--- a/packages/core/src/modules/customers/components/detail/ScheduleActivityDialog.tsx
+++ b/packages/core/src/modules/customers/components/detail/ScheduleActivityDialog.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Users, Phone, Check, Mail, Calendar, AlertTriangle, X, StickyNote } from 'lucide-react'
+import { Users, Phone, Check, Mail, Calendar, X, StickyNote } from 'lucide-react'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { validatePhoneNumber } from '@open-mercato/shared/lib/phone'
@@ -498,7 +498,6 @@ export function ScheduleActivityDialog({
         {/* Conflict warning */}
         {state.conflict && (
           <Alert variant="warning" className="rounded-lg">
-            <AlertTriangle className="size-5" />
             <AlertTitle>
               {t('customers.schedule.conflict.title', 'Calendar conflict')}
             </AlertTitle>

--- a/packages/core/src/modules/workflows/backend/definitions/create/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/create/page.tsx
@@ -53,8 +53,7 @@ export default function CreateWorkflowDefinitionPage() {
   return (
     <Page>
       <PageBody>
-        <Alert variant="info" className="mb-6">
-          <Zap className="w-4 h-4" />
+        <Alert variant="info" icon={<Zap aria-hidden="true" />} className="mb-6">
           <AlertTitle>{t('workflows.create.eventTriggersTitle')}</AlertTitle>
           <AlertDescription>
             {t('workflows.create.eventTriggersDescription')}

--- a/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
@@ -36,7 +36,7 @@ import { apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/u
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
-import { CircleQuestionMark, Info, PanelTopClose, PanelTopOpen, Play, Save, Trash2 } from 'lucide-react'
+import { CircleQuestionMark, PanelTopClose, PanelTopOpen, Play, Save, Trash2 } from 'lucide-react'
 import { NODE_TYPE_ICONS, NODE_TYPE_COLORS, NODE_TYPE_LABELS } from '../../../lib/node-type-icons'
 import { DefinitionTriggersEditor } from '../../../components/DefinitionTriggersEditor'
 import { MobileVisualEditor } from '../../../components/mobile/MobileVisualEditor'
@@ -1139,7 +1139,6 @@ export default function VisualEditorPage() {
 
               {/* Instructions */}
               <Alert variant="info" className="mt-6">
-                <Info className="size-4" />
                 <AlertTitle className="text-xs">{t('workflows.visualEditor.howToUse', 'How to use:')}</AlertTitle>
                 <div className="mt-2">
                   <ul className="list-inside list-disc space-y-1 text-xs">

--- a/packages/core/src/modules/workflows/components/DefinitionTriggersEditor.tsx
+++ b/packages/core/src/modules/workflows/components/DefinitionTriggersEditor.tsx
@@ -26,7 +26,7 @@ import {
 import { Alert, AlertDescription, AlertTitle } from '@open-mercato/ui/primitives/alert'
 import { EventPatternInput } from '@open-mercato/ui/backend/inputs/EventPatternInput'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
-import { Plus, Trash2, Edit2, Zap, Info, X } from 'lucide-react'
+import { Plus, Trash2, Edit2, Zap, X } from 'lucide-react'
 import type { WorkflowDefinitionTrigger } from '../data/entities'
 
 interface DefinitionTriggersEditorProps {
@@ -302,7 +302,6 @@ export function DefinitionTriggersEditor({
 
         {value.length === 0 ? (
           <Alert variant="info">
-            <Info className="w-4 h-4" />
             <AlertTitle>{t('workflows.triggers.empty.title', 'No triggers configured')}</AlertTitle>
             <AlertDescription>
               {t('workflows.triggers.empty.description', 'Click "Add Trigger" to create an event trigger that automatically starts this workflow.')}

--- a/packages/core/src/modules/workflows/components/NodeEditDialog.tsx
+++ b/packages/core/src/modules/workflows/components/NodeEditDialog.tsx
@@ -14,7 +14,7 @@ import {
   SelectValue,
 } from '@open-mercato/ui/primitives/select'
 import {Alert, AlertDescription} from '@open-mercato/ui/primitives/alert'
-import {ChevronDown, Info, Plus, Trash2} from 'lucide-react'
+import {ChevronDown, Plus, Trash2} from 'lucide-react'
 import {sanitizeId} from '../lib/graph-utils'
 import {WorkflowDefinition, WorkflowSelector} from './WorkflowSelector'
 import {JsonBuilder} from '@open-mercato/ui/backend/JsonBuilder'
@@ -539,7 +539,6 @@ export function NodeEditDialog({ node, isOpen, onClose, onSave, onDelete }: Node
         <div className="space-y-4">
           {!isEditable ? (
             <Alert variant="info">
-              <Info className="size-4" />
               <AlertDescription>
                 {t('workflows.nodeEditor.endStepsNotEditable')}
               </AlertDescription>
@@ -548,7 +547,6 @@ export function NodeEditDialog({ node, isOpen, onClose, onSave, onDelete }: Node
             <div className="space-y-4">
               {/* Info Alert for START nodes */}
               <Alert variant="info">
-                <Info className="size-4" />
                 <AlertDescription>
                   {t('workflows.nodeEditor.startStepsInfo')}
                 </AlertDescription>
@@ -693,7 +691,6 @@ export function NodeEditDialog({ node, isOpen, onClose, onSave, onDelete }: Node
                     {/* JSON Schema Format Notice */}
                     {isJsonSchemaFormat && (
                       <Alert variant="info" className="mb-3">
-                        <Info className="size-4" />
                         <AlertDescription>
                           {t('workflows.nodeEditor.jsonSchemaFormat')}
                         </AlertDescription>

--- a/packages/core/src/modules/workflows/components/NodeEditDialogCrudForm.tsx
+++ b/packages/core/src/modules/workflows/components/NodeEditDialogCrudForm.tsx
@@ -6,7 +6,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } f
 import { Badge } from '@open-mercato/ui/primitives/badge'
 import { Alert, AlertDescription } from '@open-mercato/ui/primitives/alert'
 import { Button } from '@open-mercato/ui/primitives/button'
-import { Info, Trash2 } from 'lucide-react'
+import { Trash2 } from 'lucide-react'
 import { CrudForm, type CrudFormGroup, type CrudField, type CrudCustomFieldRenderProps } from '@open-mercato/ui/backend/CrudForm'
 import { JsonBuilder } from '@open-mercato/ui/backend/JsonBuilder'
 import { FormFieldArrayEditor } from './fields/FormFieldArrayEditor'
@@ -115,8 +115,7 @@ export function NodeEditDialogCrudForm({ node, isOpen, onClose, onSave, onDelete
           column: 1,
           bare: true,
           component: () => (
-            <Alert variant="default" className="border-blue-200 bg-blue-50">
-              <Info className="size-4" />
+            <Alert variant="info">
               <AlertDescription>
                 End nodes cannot be edited. They mark the completion of the workflow.
               </AlertDescription>
@@ -134,8 +133,7 @@ export function NodeEditDialogCrudForm({ node, isOpen, onClose, onSave, onDelete
           column: 1,
           bare: true,
           component: () => (
-            <Alert variant="default" className="border-blue-200 bg-blue-50 mb-4">
-              <Info className="size-4" />
+            <Alert variant="info" className="mb-4">
               <AlertDescription>
                 Start nodes mark the beginning of the workflow. You can define pre-conditions that must pass before the workflow can be started.
               </AlertDescription>
@@ -476,8 +474,7 @@ export function NodeEditDialogCrudForm({ node, isOpen, onClose, onSave, onDelete
         <div className="flex-1 overflow-y-auto min-h-0 px-6">
           {/* JSON Schema Conversion Warning */}
           {showJsonSchemaWarning && (
-            <Alert variant="default" className="border-blue-200 bg-blue-50 mb-4">
-              <Info className="size-4" />
+            <Alert variant="info" className="mb-4">
               <AlertDescription className="text-xs">
                 This form uses JSON Schema format. Fields have been converted for visual editing.
                 When you save, it will be converted to the simplified format. To preserve the original JSON Schema,

--- a/packages/core/src/modules/workflows/components/WorkflowGraphImpl.tsx
+++ b/packages/core/src/modules/workflows/components/WorkflowGraphImpl.tsx
@@ -221,8 +221,7 @@ export default function WorkflowGraphImpl({
 
         {editable && !isCompactViewport && (
           <Panel position="top-left" style={{ margin: 10 }}>
-            <Alert variant="info" className="max-w-sm">
-              <Edit3 className="size-4" />
+            <Alert variant="info" icon={<Edit3 aria-hidden="true" />} className="max-w-sm">
               <AlertDescription className="font-medium">
                 {t('workflows.graph.editModeInfo')}
               </AlertDescription>

--- a/packages/core/src/modules/workflows/components/fields/FormFieldArrayEditor.tsx
+++ b/packages/core/src/modules/workflows/components/fields/FormFieldArrayEditor.tsx
@@ -15,7 +15,7 @@ import {
   SelectValue,
 } from '@open-mercato/ui/primitives/select'
 import { Alert, AlertDescription } from '@open-mercato/ui/primitives/alert'
-import { ChevronDown, Plus, Trash2, Info } from 'lucide-react'
+import { ChevronDown, Plus, Trash2 } from 'lucide-react'
 import type { CrudCustomFieldRenderProps } from '@open-mercato/ui/backend/CrudForm'
 
 /**
@@ -134,8 +134,7 @@ export function FormFieldArrayEditor({
 
       {/* JSON Schema Format Notice */}
       {isJsonSchemaFormat && (
-        <Alert variant="default" className="border-blue-200 bg-blue-50">
-          <Info className="size-4" />
+        <Alert variant="info">
           <AlertDescription className="text-xs">
             {t('workflows.fieldEditors.formFields.jsonSchemaNotice')}
           </AlertDescription>

--- a/packages/create-app/template/src/modules/example/backend/payments/page.tsx
+++ b/packages/create-app/template/src/modules/example/backend/payments/page.tsx
@@ -20,8 +20,6 @@ import {
   Ban,
   ArrowDownToLine,
   Undo2,
-  CheckCircle2,
-  AlertCircle,
   Info,
   Zap,
 } from 'lucide-react'
@@ -433,7 +431,6 @@ export default function PaymentGatewayDemoPage() {
           {/* Error Display */}
           {error && (
             <Alert variant="destructive">
-              <AlertCircle className="size-4" />
               <AlertTitle>{t('example.payments.error.title', 'Error')}</AlertTitle>
               <AlertDescription>{error}</AlertDescription>
             </Alert>
@@ -442,7 +439,6 @@ export default function PaymentGatewayDemoPage() {
           {/* Action Result */}
           {actionResult && (
             <Alert variant="success">
-              <CheckCircle2 className="size-4" />
               <AlertTitle>{t('example.payments.success.title', 'Success')}</AlertTitle>
               <AlertDescription>{actionResult}</AlertDescription>
             </Alert>

--- a/packages/ui/src/backend/dashboard/DashboardScreen.tsx
+++ b/packages/ui/src/backend/dashboard/DashboardScreen.tsx
@@ -10,7 +10,7 @@ import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { getDashboardWidgets, loadDashboardWidgetModule } from './widgetRegistry'
 import type { DashboardWidgetModule } from '@open-mercato/shared/modules/dashboard/widgets'
 import { cn } from '@open-mercato/shared/lib/utils'
-import { GripVertical, Info, Plus, RefreshCw, Settings2, Trash2, X, Loader2 } from 'lucide-react'
+import { GripVertical, Plus, RefreshCw, Settings2, Trash2, X, Loader2 } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { InjectionSpot } from '../injection/InjectionSpot'
@@ -366,7 +366,6 @@ export function DashboardScreen() {
   if (!hasRegisteredWidgets && layout.length === 0) {
     return (
       <Alert variant="info">
-        <Info className="h-4 w-4" aria-hidden />
         <AlertTitle>{t('dashboard.empty.noWidgets.title', 'No dashboard widgets yet')}</AlertTitle>
         <AlertDescription>
           {t(

--- a/packages/ui/src/primitives/__tests__/alert.test.tsx
+++ b/packages/ui/src/primitives/__tests__/alert.test.tsx
@@ -133,6 +133,22 @@ describe('Alert primitive', () => {
       render(<Alert status="information" style="light" icon={<Custom />}>Info</Alert>)
       expect(screen.getByTestId('custom-icon')).toBeInTheDocument()
     })
+
+    it('renders exactly one leading icon by default (#2759)', () => {
+      const { container } = render(<Alert status="information">Info</Alert>)
+      expect(container.querySelectorAll('[data-slot="alert-icon-badge"]')).toHaveLength(1)
+      expect(container.querySelectorAll('[data-slot="alert-icon-badge"] > svg')).toHaveLength(1)
+    })
+
+    it('icon prop REPLACES the default status icon instead of adding a second one (#2759)', () => {
+      const Custom = () => <svg data-testid="custom-icon" aria-hidden="true" />
+      const { container } = render(
+        <Alert status="information" icon={<Custom />}>Info</Alert>,
+      )
+      expect(container.querySelectorAll('[data-slot="alert-icon-badge"]')).toHaveLength(1)
+      expect(container.querySelectorAll('[data-slot="alert-icon-badge"] > svg')).toHaveLength(1)
+      expect(screen.getByTestId('custom-icon')).toBeInTheDocument()
+    })
   })
 
   describe('Action slot + dismiss', () => {

--- a/packages/webhooks/src/modules/webhooks/__integration__/TC-LOCK-OSS-043.spec.ts
+++ b/packages/webhooks/src/modules/webhooks/__integration__/TC-LOCK-OSS-043.spec.ts
@@ -220,9 +220,12 @@ test.describe('TC-LOCK-OSS-043: webhooks + inbox settings + data-sync schedule o
   // wait for the filtered list GET to settle, open the kebab, click Delete, confirm, then
   // assert the unified conflict bar (never the success toast).
   test('WHK-01 stale webhook DELETE in the list surfaces the conflict bar', async ({ page }) => {
+    // Heavy browser flow (login + list load + portalled RowActions menu) routinely
+    // exceeds Playwright's 20s default on a loaded ephemeral shard; opt into the
+    // sanctioned per-test budget (see TC-LOCK-OSS-029). Global bump is disallowed.
+    test.setTimeout(60_000)
     const token = await getAuthToken(page.request, 'admin')
     const stamp = Date.now()
-    const webhookName = `QA Lock 043 ${stamp}`
     let webhookId: string | null = null
     try {
       const webhook = await createWebhook(page.request, token, stamp)
@@ -243,7 +246,11 @@ test.describe('TC-LOCK-OSS-043: webhooks + inbox settings + data-sync schedule o
         )
         .catch(() => undefined)
 
-      const row = page.getByRole('row', { name: new RegExp(`${webhookName}\\b`) }).first()
+      // The out-of-band PUT below renames the fixture to "QA Lock 043 bumped <stamp>";
+      // tolerate both names so a mid-test list re-render cannot orphan the row locator.
+      const row = page
+        .getByRole('row', { name: new RegExp(`QA Lock 043 (?:bumped )?${stamp}\\b`) })
+        .first()
       await expect(row, 'created webhook should appear in the list').toBeVisible({ timeout: 20_000 })
 
       // Advance updated_at out-of-band → the in-page row token is now stale.
@@ -255,12 +262,19 @@ test.describe('TC-LOCK-OSS-043: webhooks + inbox settings + data-sync schedule o
 
       // Open the row's RowActions kebab (opens on click) and trigger Delete. The
       // menu renders in a portal on document.body, so query it at the page level.
+      // The list re-renders as data settles, so the menu can detach between "open"
+      // and "click" — retry (re)open-menu + click-Delete atomically (same fix as
+      // TC-LOCK-OSS-029); the confirm dialog gates the DELETE, so a repeated
+      // click is safe.
       const kebab = row.getByRole('button', { name: /open actions/i })
-      await expect(kebab, 'row should expose an Open actions trigger').toBeVisible()
-      await kebab.click()
       const deleteItem = page.getByRole('menuitem', { name: /^delete$/i })
-      await expect(deleteItem, 'delete menu item should be visible').toBeVisible({ timeout: 10_000 })
-      await deleteItem.click()
+      await expect(async () => {
+        if (!(await deleteItem.isVisible().catch(() => false))) {
+          await kebab.click({ timeout: 2_000 }).catch(() => {})
+          await expect(deleteItem).toBeVisible({ timeout: 1_500 })
+        }
+        await deleteItem.click({ timeout: 2_000 })
+      }).toPass({ timeout: 30_000 })
 
       // Confirm the destructive alertdialog (the row still holds the stale
       // updated_at captured at render time, so the DELETE 409s).

--- a/packages/webhooks/src/modules/webhooks/widgets/injection/integration-setup/widget.client.tsx
+++ b/packages/webhooks/src/modules/webhooks/widgets/injection/integration-setup/widget.client.tsx
@@ -158,8 +158,7 @@ export default function IntegrationSetupWidget({ context }: InjectionWidgetCompo
         )}
       </p>
 
-      <Alert>
-        <Webhook className="h-4 w-4" />
+      <Alert icon={<Webhook aria-hidden="true" />}>
         <AlertTitle>
           {isEnabled
             ? t('webhooks.integrationSetup.enabledTitle', 'Delivery processing is enabled')


### PR DESCRIPTION
Fixes #2759

## Problem
Several info callouts in the Workflows UI rendered **two info icons** — the auto-rendered circular status badge plus a second inline icon next to the heading ("How to use:", "Edit Mode", "No triggers configured", node-edit hints).

## Root Cause
The redesigned `Alert` primitive (`packages/ui/src/primitives/alert.tsx`) renders its own leading status icon automatically (`showIcon` defaults to `true`; `information` status defaults to `Info`). Multiple call sites still passed an explicit `<Info />` / `<Edit3 />` / `<AlertTriangle />` etc. as an `Alert` child — the legacy pre-redesign pattern — so the icon was drawn twice.

## What Changed
- **Workflows** (issue scope): dropped explicit `<Info />` children in `DefinitionTriggersEditor`, `visual-editor/page`, `NodeEditDialog` (×3), `NodeEditDialogCrudForm` (×3), `FormFieldArrayEditor`; moved the intentional custom icons to the `Alert` `icon` prop (`<Edit3 />` in `WorkflowGraphImpl`, `<Zap />` in `definitions/create`), which replaces the default icon instead of adding to it.
- **Boy Scout (lines touched)**: migrated `variant="default"` + raw `border-blue-200 bg-blue-50` callouts to the semantic `variant="info"` (DS status tokens).
- **Same anti-pattern outside workflows** (sweep requested by the issue): `DashboardScreen` (ui), `Diagnostics` (customer_accounts), `ConfirmDealLostDialog` + `ScheduleActivityDialog` (customers), example payments page (apps/mercato + create-app template kept in sync), and the webhooks integration-setup widget (`<Webhook />` → `icon` prop).
- Removed now-unused lucide imports.

## Tests
- `packages/ui/src/primitives/__tests__/alert.test.tsx`: two new tests asserting the Alert renders **exactly one** leading icon by default and that the `icon` prop **replaces** (not duplicates) the default icon.
- `packages/core/src/__tests__/alert-duplicate-icon-coverage.test.ts` (new static regression audit, same pattern as `optimistic-lock-ui-coverage.test.ts`): scans core/ui/webhooks/enterprise/app/template `.tsx` sources and fails when any `<Alert>` passes an icon-shaped self-closing element as its first child. Verified it **fails on the pre-fix code** (flags the exact lines from the issue) and passes after.
- Full gate: `build:packages` → `generate` → `build:packages`, `typecheck`, `i18n:check-sync`/`check-usage`, `yarn test` (core 5502 ✅, ui 1508 ✅, all other workspaces ✅; the only failure is the known local-env `cli dev-env-reload` inotify ENOSPC flake, unrelated), `build:app` ✅.

## Backward Compatibility
- No contract surface changes — the `Alert` primitive API is untouched (only call sites and tests changed). No API routes, event IDs, widget spot IDs, ACL features, DI keys, or DB schema affected.
