### PR TITLE
fix(auth): list-users CLI falls back to org/tenant id prefix when name is missing (#2732)

### DIFF
--- a/packages/core/src/modules/auth/__tests__/cli-list-users.test.ts
+++ b/packages/core/src/modules/auth/__tests__/cli-list-users.test.ts
@@ -1,0 +1,95 @@
+/** @jest-environment node */
+jest.mock('@open-mercato/shared/lib/encryption/toggles', () => ({
+  isTenantDataEncryptionEnabled: () => false,
+  isEncryptionDebugEnabled: () => false,
+}))
+
+import cli from '@open-mercato/core/modules/auth/cli'
+
+const ORG_ID = 'aaaa1111-2222-3333-4444-555566667777'
+const TENANT_ID = 'bbbb8888-9999-0000-1111-222233334444'
+
+const find = jest.fn()
+const findOne = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (_: string) => ({ find, findOne }),
+  }),
+}))
+
+const listUsersCommand = cli.find((c: any) => c.command === 'list-users')!
+
+const baseUser = {
+  id: 'cccc0000-1111-2222-3333-444455556666',
+  email: 'user@example.com',
+  name: 'Test User',
+  organizationId: ORG_ID,
+  tenantId: TENANT_ID,
+}
+
+describe('mercato auth list-users org/tenant name fallback', () => {
+  let logSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    find.mockImplementation(async (Entity: any) => {
+      const entityName = (Entity && Entity.name) || ''
+      if (entityName === 'User') return [baseUser]
+      return []
+    })
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+  })
+
+  function loggedOutput(): string {
+    return logSpy.mock.calls.map((call) => call.map(String).join(' ')).join('\n')
+  }
+
+  it('falls back to the id prefix when org/tenant rows have no name', async () => {
+    findOne.mockImplementation(async (Entity: any) => {
+      const entityName = (Entity && Entity.name) || ''
+      if (entityName === 'Organization') return { id: ORG_ID, name: null }
+      if (entityName === 'Tenant') return { id: TENANT_ID, name: null }
+      return null
+    })
+
+    await listUsersCommand.run([])
+
+    const output = loggedOutput()
+    expect(output).not.toContain('undefined...')
+    expect(output).toContain(`${ORG_ID.substring(0, 8)}...`)
+    expect(output).toContain(`${TENANT_ID.substring(0, 8)}...`)
+  })
+
+  it('falls back to the id prefix when org/tenant lookups return nothing', async () => {
+    findOne.mockResolvedValue(null)
+
+    await listUsersCommand.run([])
+
+    const output = loggedOutput()
+    expect(output).not.toContain('undefined...')
+    expect(output).toContain(`${ORG_ID.substring(0, 8)}...`)
+    expect(output).toContain(`${TENANT_ID.substring(0, 8)}...`)
+  })
+
+  it('keeps showing the truncated name when org/tenant rows are named', async () => {
+    findOne.mockImplementation(async (Entity: any) => {
+      const entityName = (Entity && Entity.name) || ''
+      if (entityName === 'Organization') return { id: ORG_ID, name: 'Acme Corporation International' }
+      if (entityName === 'Tenant') return { id: TENANT_ID, name: 'Primary Tenant Holdings Group' }
+      return null
+    })
+
+    await listUsersCommand.run([])
+
+    const output = loggedOutput()
+    expect(output).toContain(`${'Acme Corporation International'.substring(0, 19)}...`)
+    expect(output).toContain(`${'Primary Tenant Holdings Group'.substring(0, 19)}...`)
+    expect(output).not.toContain(`${ORG_ID.substring(0, 8)}...`)
+    expect(output).not.toContain(`${TENANT_ID.substring(0, 8)}...`)
+  })
+})

--- a/packages/core/src/modules/auth/cli.ts
+++ b/packages/core/src/modules/auth/cli.ts
@@ -698,12 +698,12 @@ const listUsers: ModuleCli = {
 
       if (user.organizationId) {
         const org = await em.findOne(Organization, { id: user.organizationId })
-        orgName = org?.name?.substring(0, 19) + '...' || user.organizationId.substring(0, 8) + '...'
+        orgName = org?.name ? `${org.name.substring(0, 19)}...` : `${user.organizationId.substring(0, 8)}...`
       }
 
       if (user.tenantId) {
         const tenant = await em.findOne(Tenant, { id: user.tenantId })
-        tenantName = tenant?.name?.substring(0, 19) + '...' || user.tenantId.substring(0, 8) + '...'
+        tenantName = tenant?.name ? `${tenant.name.substring(0, 19)}...` : `${user.tenantId.substring(0, 8)}...`
       }
 
       const id = user.id || 'N/A'


### PR DESCRIPTION
Fixes #2732

## Problem
`mercato auth list-users` renders the literal text `undefined...` in the Organization/Tenant columns whenever the org/tenant row has no `name` (or the lookup returns nothing), instead of the id-prefix fallback the code intended — and which the docs page (`apps/docs/docs/cli/auth-list-users.mdx`) already shows as the expected output (`81c3b8b0...`).

## Root Cause
Operator precedence: in

```ts
orgName = org?.name?.substring(0, 19) + '...' || user.organizationId.substring(0, 8) + '...'
```

`+` binds tighter than `||`, so when `org?.name` is `undefined`, `undefined + '...'` produces the truthy string `'undefined...'` and the `||` fallback never triggers. Same defect on the tenant line.

## What Changed
- `packages/core/src/modules/auth/cli.ts` — the two column expressions now branch explicitly: a present name renders `name.substring(0, 19) + '...'` exactly as before; a missing/empty name (or missing row) renders the 8-char id prefix + `...` as originally intended. Two-line change, no other behavior touched.

## Tests
- New `packages/core/src/modules/auth/__tests__/cli-list-users.test.ts` (self-contained, mocked DI, follows the existing `cli-setup-orgslug.test.ts` pattern):
  - falls back to id prefix when org/tenant rows have `name: null` — **failed before the fix, passes after**
  - falls back to id prefix when org/tenant lookups return nothing — **failed before the fix, passes after**
  - keeps the truncated-name rendering for named org/tenant rows (behavior preservation) — passes before and after
- Validation gate: `yarn build:packages` ✅, `yarn generate` ✅, `yarn typecheck` ✅, `yarn test` ✅ (one pre-existing local-environment failure: `packages/cli` `dev-env-reload.test.ts` fails on this machine on any branch due to exhausted inotify watches — verified with a raw `fs.watch` probe returning `ENOSPC`; `@open-mercato/core` 5503/5503 and `@open-mercato/ui` 1506/1506 pass), `yarn build:app` ✅. i18n checks not applicable (no user-facing string/locale changes).

## Backward Compatibility
- No contract surface changes: CLI command name/arguments unchanged; only the human-readable table cell content is corrected, which is the reported defect. Output now matches the documented example in `apps/docs/docs/cli/auth-list-users.mdx`.

## Security impact
- None beyond the report's own assessment: cosmetic display fix in an operator-facing CLI; no auth, access-control, encryption, or logging behavior changed. (Issue carries the `security` label as a triage-hygiene finding — misleading output during incident response.)

## Notes (pre-existing, intentionally not touched)
- The same `list-users` loop uses raw `em.find(User, …)` / `em.findOne(Organization|Tenant, …)`. Converting the `User` query to `findWithDecryption` needs per-record tenant scope and is a behavior change beyond this cosmetic fix, so it is left for a separate issue if maintainers want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
