### PR TITLE
security(auth): tenant-scope findRoleInScope DB query (#2730)

### DIFF
--- a/packages/core/src/modules/auth/api/sidebar/preferences/__tests__/find-role-tenant-scope.test.ts
+++ b/packages/core/src/modules/auth/api/sidebar/preferences/__tests__/find-role-tenant-scope.test.ts
@@ -1,0 +1,105 @@
+/** @jest-environment node */
+
+import { GET } from '../route'
+
+const TENANT_ID = '123e4567-e89b-12d3-a456-426614174001'
+const OTHER_TENANT_ID = '123e4567-e89b-12d3-a456-426614174099'
+const ORG_ID = '123e4567-e89b-12d3-a456-426614174002'
+const ROLE_ID = '123e4567-e89b-12d3-a456-426614174050'
+
+const mockGetAuthFromRequest = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockLoadRoleSidebarPreferences = jest.fn()
+const mockLoadRoleSidebarPreferenceUpdatedAt = jest.fn()
+
+const mockEm = { find: jest.fn(), findOne: jest.fn() }
+
+const mockRbacService = { userHasAllFeatures: jest.fn() }
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'rbacService') return mockRbacService
+    if (token === 'cache') return {}
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({ locale: 'en' })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...args),
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
+}))
+
+jest.mock('../../../../services/sidebarPreferencesService', () => ({
+  loadRoleSidebarPreferences: (...args: unknown[]) => mockLoadRoleSidebarPreferences(...args),
+  loadRoleSidebarPreferenceUpdatedAt: (...args: unknown[]) => mockLoadRoleSidebarPreferenceUpdatedAt(...args),
+  loadRoleSidebarPreferenceUpdatedAtBatch: jest.fn(),
+  loadSidebarPreference: jest.fn(),
+  loadSidebarPreferenceUpdatedAt: jest.fn(),
+  saveRoleSidebarPreference: jest.fn(),
+  saveSidebarPreference: jest.fn(),
+}))
+
+function roleReadRequest(): Request {
+  return new Request(`http://localhost/api/auth/sidebar/preferences?roleId=${ROLE_ID}`, {
+    method: 'GET',
+  })
+}
+
+describe('findRoleInScope tenant-scoped query (issue #2730)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRbacService.userHasAllFeatures.mockResolvedValue(true)
+    mockLoadRoleSidebarPreferences.mockResolvedValue(new Map())
+    mockLoadRoleSidebarPreferenceUpdatedAt.mockResolvedValue(null)
+    mockFindWithDecryption.mockResolvedValue([])
+  })
+
+  it('passes a tenant-scoped where clause to the DB query when tenantId is set', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: TENANT_ID, orgId: ORG_ID })
+    mockFindOneWithDecryption.mockResolvedValue({ id: ROLE_ID, name: 'Editor', tenantId: TENANT_ID })
+
+    const res = await GET(roleReadRequest())
+    expect(res.status).toBe(200)
+
+    expect(mockFindOneWithDecryption).toHaveBeenCalledTimes(1)
+    const where = mockFindOneWithDecryption.mock.calls[0][2]
+    expect(where).toEqual({
+      id: ROLE_ID,
+      $or: [{ tenantId: TENANT_ID }, { tenantId: null }],
+    })
+  })
+
+  it('scopes the DB query to global roles only when tenantId is null', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: null, orgId: null })
+    mockFindOneWithDecryption.mockResolvedValue({ id: ROLE_ID, name: 'Global', tenantId: null })
+
+    const res = await GET(roleReadRequest())
+    expect(res.status).toBe(200)
+
+    const where = mockFindOneWithDecryption.mock.calls[0][2]
+    expect(where).toEqual({ id: ROLE_ID, tenantId: null })
+  })
+
+  it('still rejects a cross-tenant role row as a defense-in-depth post-check', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: TENANT_ID, orgId: ORG_ID })
+    // Simulate the DB returning a foreign-tenant row (e.g. if the where clause were later weakened).
+    mockFindOneWithDecryption.mockResolvedValue({ id: ROLE_ID, name: 'Foreign', tenantId: OTHER_TENANT_ID })
+
+    const res = await GET(roleReadRequest())
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/core/src/modules/auth/api/sidebar/preferences/route.ts
+++ b/packages/core/src/modules/auth/api/sidebar/preferences/route.ts
@@ -121,16 +121,23 @@ async function findRoleInScope(
   em: EntityManager,
   options: { roleId: string; tenantId: string | null },
 ): Promise<Role | null> {
+  // Scope the DB query so MikroORM only fetches in-scope rows: a role belongs to either
+  // the auth tenant or the global (null tenant) pool. Mirrors loadRolesPayload()'s scoping
+  // so cross-tenant role rows are never loaded or decrypted into memory in the first place.
+  const roleScope: FilterQuery<Role> = options.tenantId
+    ? { id: options.roleId, $or: [{ tenantId: options.tenantId }, { tenantId: null }] }
+    : { id: options.roleId, tenantId: null }
   const role = await findOneWithDecryption(
     em,
     Role,
-    { id: options.roleId },
+    roleScope,
     undefined,
     { tenantId: options.tenantId, organizationId: null },
   )
   if (!role) return null
-  // Cross-tenant guard: a role belongs to either the auth tenant or the global (null tenant) pool.
-  // Reject the lookup otherwise so a multi-tenant deployment can't leak across tenants.
+  // Cross-tenant guard (defense-in-depth): a role belongs to either the auth tenant or the
+  // global (null tenant) pool. Reject the lookup otherwise so a multi-tenant deployment can't
+  // leak across tenants even if the query above is later changed.
   if (role.tenantId && options.tenantId && role.tenantId !== options.tenantId) return null
   if (role.tenantId && !options.tenantId) return null
   return role


### PR DESCRIPTION
Fixes #2730

## Problem
- `findRoleInScope()` in the sidebar-preferences route fetched a role with `findOneWithDecryption(em, Role, { id: roleId }, …)` and only enforced tenant scoping with an in-memory post-check. The DB query was not tenant-scoped, so a cross-tenant role row was loaded and decrypted into memory before the guard rejected it.

## Root Cause
- The decryption helpers pass the `where` clause through verbatim to `em.findOne` and never inject tenant filters — the `scope` argument is used only to resolve the decryption key. So `{ id: roleId }` matched rows in any tenant; only the follow-up `if (role.tenantId && … !== options.tenantId)` checks stopped a leak.

## What Changed
- `packages/core/src/modules/auth/api/sidebar/preferences/route.ts`: `findRoleInScope()` now builds a tenant-scoped `where` clause, mirroring `loadRolesPayload()` in the same file:
  - tenant set: `{ id, $or: [{ tenantId }, { tenantId: null }] }`
  - tenant null: `{ id, tenantId: null }`
- The existing post-check is kept as explicit defense-in-depth (comment updated to say so).

## Tests
- New unit test `__tests__/find-role-tenant-scope.test.ts` exercises the GET role-scoped read and asserts:
  - the `where` clause passed to `findOneWithDecryption` is tenant-scoped (`$or` over tenant/null) when a tenant is set
  - it scopes to global roles only (`tenantId: null`) when tenant is null
  - the defense-in-depth post-check still 404s a foreign-tenant row
  - Verified the two scoping assertions fail before the fix and pass after.
- `yarn workspace @open-mercato/core test -- sidebar` → 18 passed.
- `yarn workspace @open-mercato/core typecheck` → clean (after `yarn build:packages` + `yarn generate`).

## Backward Compatibility
- No contract surface changes. `findRoleInScope` is a private (non-exported) helper; API responses, ACL features, event IDs, and import paths are unchanged. The change only tightens the DB query (security hardening); valid in-scope reads behave identically.