### PR TITLE
security(auth): bind staff session lookup to JWT subject (#2733)

### DIFF
--- a/packages/core/src/modules/auth/lib/__tests__/sessionIntegrity.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/sessionIntegrity.test.ts
@@ -35,12 +35,15 @@ function mockFindOneByEntity(store: MockStore & { session?: SessionLookupResult 
   })
 }
 
-type SessionLookupResult = { id: string; deletedAt: Date | null; expiresAt: Date } | null
+type SessionLookupResult =
+  | { id: string; deletedAt: Date | null; expiresAt: Date; user?: { id: string } | string }
+  | null
 
 const validSession: SessionLookupResult = {
   id: sessionId,
   deletedAt: null,
   expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+  user: { id: userId },
 }
 
 describe('isAuthContextValid', () => {
@@ -224,12 +227,55 @@ describe('isAuthContextValid', () => {
       id: sessionId,
       deletedAt: null,
       expiresAt: new Date(Date.now() - 1000),
+      user: { id: userId },
     }
     findOneWithDecryption.mockImplementation(async (...args: unknown[]) => {
       const entity = args[1]
       if (entity === Session) return expiredSession
       return null
     })
+
+    await expect(
+      isAuthContextValid(em, { sub: userId, sid: sessionId, tenantId, orgId: organizationId, roles: [] }),
+    ).resolves.toBe(false)
+  })
+
+  it('binds the session lookup to the token subject', async () => {
+    mockFindOneByEntity({ session: validSession, user: { id: userId, tenantId, organizationId } })
+
+    await expect(
+      isAuthContextValid(em, { sub: userId, sid: sessionId, tenantId, orgId: organizationId, roles: [] }),
+    ).resolves.toBe(true)
+
+    expect(findOneWithDecryption).toHaveBeenCalledWith(
+      em,
+      Session,
+      { id: sessionId, user: userId, deletedAt: null },
+    )
+  })
+
+  it('rejects a live session that belongs to a different subject', async () => {
+    const otherUserId = '99999999-9999-4999-8999-999999999999'
+    const foreignSession: SessionLookupResult = {
+      id: sessionId,
+      deletedAt: null,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      user: { id: otherUserId },
+    }
+    mockFindOneByEntity({ session: foreignSession, user: { id: userId, tenantId, organizationId } })
+
+    await expect(
+      isAuthContextValid(em, { sub: userId, sid: sessionId, tenantId, orgId: organizationId, roles: [] }),
+    ).resolves.toBe(false)
+  })
+
+  it('rejects a session whose user relation carries no resolvable id', async () => {
+    const unboundSession = {
+      id: sessionId,
+      deletedAt: null,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    } as unknown as SessionLookupResult
+    mockFindOneByEntity({ session: unboundSession, user: { id: userId, tenantId, organizationId } })
 
     await expect(
       isAuthContextValid(em, { sub: userId, sid: sessionId, tenantId, orgId: organizationId, roles: [] }),

--- a/packages/core/src/modules/auth/lib/sessionIntegrity.ts
+++ b/packages/core/src/modules/auth/lib/sessionIntegrity.ts
@@ -69,8 +69,14 @@ export async function resolveCanonicalStaffAuthContext(
   // round-trips into one. The `em` here is a fresh request-scoped EntityManager
   // (resolved per request, never inside an explicit transaction), so concurrent
   // reads on it are safe.
+  //
+  // The session lookup is bound to the token subject (`user: subjectId`) so the
+  // referenced session must actually belong to the JWT's subject. Without this
+  // binding, a forged-but-otherwise-valid token could pair `sub` for one user with
+  // a still-live `sid` belonging to another, evading per-user session revocation
+  // (logout / deleteAllUserSessions / password reset).
   const sessionPromise = sessionId !== null
-    ? findOneWithDecryption(em, Session, { id: sessionId, deletedAt: null })
+    ? findOneWithDecryption(em, Session, { id: sessionId, user: subjectId, deletedAt: null })
     : Promise.resolve(null)
   const userPromise = findOneWithDecryption(
     em,
@@ -83,6 +89,7 @@ export async function resolveCanonicalStaffAuthContext(
 
   if (sessionId !== null) {
     if (!session) return null
+    if (resolveSessionUserId(session) !== subjectId) return null
     if (session.expiresAt.getTime() < Date.now()) return null
   }
 
@@ -141,6 +148,16 @@ export async function resolveCanonicalStaffAuthContext(
     roles,
     isSuperAdmin,
   }
+}
+
+function resolveSessionUserId(session: Session): string | null {
+  const owner = (session as { user?: unknown }).user
+  if (typeof owner === 'string') return owner
+  if (owner && typeof owner === 'object') {
+    const ownerId = (owner as { id?: unknown }).id
+    if (typeof ownerId === 'string') return ownerId
+  }
+  return null
 }
 
 async function userAclGrantsSuperAdmin(


### PR DESCRIPTION
Fixes #2733

## Problem
When a staff JWT carries a `sid` claim, `resolveCanonicalStaffAuthContext` looked the session up by id alone and only checked existence + expiry. It never verified that the resolved session belonged to the token's subject (`sub`), so the `Session -> User` binding was never enforced at auth time.

## Root Cause
The session lookup (`packages/core/src/modules/auth/lib/sessionIntegrity.ts`) queried `{ id: sessionId, deletedAt: null }` and the post-load guard only asserted `!session` / `session.expiresAt`. Missing defense-in-depth: if `JWT_SECRET` were compromised, an attacker could forge a token for user A while embedding a still-valid `sid` belonging to user B, evading per-user session revocation (logout, `deleteAllUserSessions`, password reset).

## What Changed
- Bound the session lookup to the token subject: `findOneWithDecryption(em, Session, { id: sessionId, user: subjectId, deletedAt: null })` (same FK-filter pattern already used for `UserRole`/`UserAcl` lookups in this file).
- Added a defensive post-load guard `resolveSessionUserId(session) !== subjectId` that rejects any session whose `user` relation does not resolve to the subject (handles both populated-entity and reference shapes, fails closed when the owner id is unresolvable).
- This turns session revocation into a true per-user kill switch and closes the binding gap.

## Tests
- Updated existing fixtures so `validSession` / `expiredSession` carry their owner (`user: { id }`).
- Added 3 regression tests (verified failing before the fix, passing after):
  - binds the session lookup to the token subject (asserts the `user: subjectId` query)
  - rejects a live session that belongs to a different subject
  - rejects a session whose user relation carries no resolvable id
- `yarn workspace @open-mercato/core test auth` — 413 passed (51 suites).
- `yarn workspace @open-mercato/core typecheck` — clean (after `yarn build:packages` + `yarn generate`).

## Backward Compatibility
- No contract surface changes: function signature, API responses, event IDs, DI names, ACL features, and import paths are all unchanged. Pure internal security hardening. No DB schema change (the `sessions.user_id` FK already exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)