### PR TITLE
security(auth): add-user CLI must not re-scope a shared global role to a single tenant (#2731)

### DIFF
--- a/packages/core/src/modules/auth/__tests__/cli-add-user-role-scope.test.ts
+++ b/packages/core/src/modules/auth/__tests__/cli-add-user-role-scope.test.ts
@@ -1,0 +1,126 @@
+/** @jest-environment node */
+jest.mock('@open-mercato/shared/lib/encryption/toggles', () => ({
+  isTenantDataEncryptionEnabled: () => false,
+  isEncryptionDebugEnabled: () => false,
+}))
+
+import { registerModules } from '@open-mercato/shared/lib/modules/registry'
+import { registerCliModules } from '@open-mercato/shared/modules/registry'
+import type { Module } from '@open-mercato/shared/modules/registry'
+import cli from '@open-mercato/core/modules/auth/cli'
+
+jest.setTimeout(60_000)
+
+const testModules: Module[] = [
+  { id: 'auth', setup: { defaultRoleFeatures: { admin: ['auth.*'] } } },
+  { id: 'directory', setup: { defaultRoleFeatures: { admin: ['directory.*'] } } },
+]
+registerModules(testModules)
+registerCliModules(testModules)
+
+const TENANT_ID = 'tenant-1'
+
+type FakeRole = { id: string; name: string; tenantId: string | null }
+
+let createdRoles: FakeRole[]
+let globalRole: FakeRole
+let findOne: jest.Mock
+let create: jest.Mock
+let persist: jest.Mock
+let flush: jest.Mock
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (_: string) => ({
+      findOne,
+      findOneOrFail: jest.fn(),
+      create,
+      find: jest.fn(async () => []),
+      persist,
+      flush,
+    }),
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(async () => []),
+  findOneWithDecryption: jest.fn(async (_em: any, Entity: any, where: any) => {
+    const name = (Entity && Entity.name) || ''
+    if (name === 'Organization' && where?.id === 'org-1') {
+      return { id: 'org-1', tenant: { id: TENANT_ID } }
+    }
+    return null
+  }),
+}))
+
+const addUserCommand = cli.find((c: any) => c.command === 'add-user')!
+
+const BASE_ARGS = [
+  '--email', 'agent@acme.com',
+  '--password', 'Str0ng!Passw0rd',
+  '--organizationId', 'org-1',
+]
+
+describe('mercato auth add-user role scoping', () => {
+  let logSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    globalRole = { id: 'global-role', name: 'shared', tenantId: null }
+    createdRoles = []
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    findOne = jest.fn(async (Entity: any, where: any) => {
+      const name = (Entity && Entity.name) || ''
+      if (name === 'Role') {
+        const tenantId = where?.tenantId ?? null
+        if (where?.name === globalRole.name && tenantId === globalRole.tenantId) return globalRole
+        const created = createdRoles.find((r) => r.name === where?.name && r.tenantId === tenantId)
+        return created ?? null
+      }
+      return null
+    })
+    create = jest.fn((Entity: any, data: any) => {
+      const name = (Entity && Entity.name) || ''
+      if (name === 'Role') {
+        const role: FakeRole = { id: 'role-' + createdRoles.length, name: data.name, tenantId: data.tenantId ?? null }
+        createdRoles.push(role)
+        return role
+      }
+      return { id: 'entity-' + name, ...data }
+    })
+    persist = jest.fn(function persist(this: any) { return this })
+    flush = jest.fn(async () => {})
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+  })
+
+  it('never re-scopes a global role to the tenant and creates a tenant-scoped role instead', async () => {
+    await addUserCommand.run([...BASE_ARGS, '--roles', 'shared'])
+
+    expect(globalRole.tenantId).toBeNull()
+
+    const tenantScoped = createdRoles.find((r) => r.name === 'shared' && r.tenantId === TENANT_ID)
+    expect(tenantScoped).toBeDefined()
+
+    const globalLookup = findOne.mock.calls.find(([Entity, where]: [any, any]) => {
+      const name = (Entity && Entity.name) || ''
+      return name === 'Role' && (where?.tenantId ?? null) === null
+    })
+    expect(globalLookup).toBeUndefined()
+  })
+
+  it('reuses an existing tenant-scoped role without creating a duplicate', async () => {
+    createdRoles.push({ id: 'existing', name: 'shared', tenantId: TENANT_ID })
+    const createdBefore = createdRoles.length
+
+    await addUserCommand.run([...BASE_ARGS, '--roles', 'shared'])
+
+    expect(globalRole.tenantId).toBeNull()
+    const sharedTenantRoles = createdRoles.filter((r) => r.name === 'shared' && r.tenantId === TENANT_ID)
+    expect(sharedTenantRoles).toHaveLength(1)
+    expect(createdRoles.length).toBe(createdBefore)
+  })
+})

--- a/packages/core/src/modules/auth/cli.ts
+++ b/packages/core/src/modules/auth/cli.ts
@@ -20,6 +20,14 @@ import { formatPasswordRequirements, getPasswordPolicy, validatePassword } from 
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { getCliModules } from '@open-mercato/shared/modules/registry'
 
+async function resolveTenantScopedRole(em: any, name: string, normalizedTenantId: string | null) {
+  const existing = await em.findOne(Role, { name, tenantId: normalizedTenantId })
+  if (existing) return existing
+  const role = em.create(Role, { name, tenantId: normalizedTenantId, createdAt: new Date() })
+  await em.persist(role).flush()
+  return role
+}
+
 const addUser: ModuleCli = {
   command: 'add-user',
   async run(rest) {
@@ -63,17 +71,7 @@ const addUser: ModuleCli = {
     if (rolesCsv) {
       const names = rolesCsv.split(',').map(s => s.trim()).filter(Boolean)
       for (const name of names) {
-        let role = await em.findOne(Role, { name, tenantId: normalizedTenantId })
-        if (!role && normalizedTenantId !== null) {
-          role = await em.findOne(Role, { name, tenantId: null })
-        }
-        if (!role) {
-          role = em.create(Role, { name, tenantId: normalizedTenantId, createdAt: new Date() })
-          await em.persist(role).flush()
-        } else if (normalizedTenantId !== null && role.tenantId !== normalizedTenantId) {
-          role.tenantId = normalizedTenantId
-          await em.persist(role).flush()
-        }
+        const role = await resolveTenantScopedRole(em, name, normalizedTenantId)
         const link = em.create(UserRole, { user: u, role })
         await em.persist(link).flush()
       }


### PR DESCRIPTION
Fixes #2731

## Problem
`mercato auth add-user --roles <name>` looked up each requested role in the target tenant's scope and, when no tenant-scoped copy existed, fell back to a global role (`tenantId: null`) and then **overwrote that global role's `tenantId`** with the current tenant. A role intended to apply globally was thereby privately re-scoped to the first tenant that referenced it.

## Root Cause
`packages/core/src/modules/auth/cli.ts` (`add-user`) contained:

```ts
let role = await em.findOne(Role, { name, tenantId: normalizedTenantId })
if (!role && normalizedTenantId !== null) {
  role = await em.findOne(Role, { name, tenantId: null })
}
if (!role) {
  role = em.create(Role, { name, tenantId: normalizedTenantId, createdAt: new Date() })
  await em.persist(role).flush()
} else if (normalizedTenantId !== null && role.tenantId !== normalizedTenantId) {
  role.tenantId = normalizedTenantId   // <-- destructive re-scope of a shared global role
  await em.persist(role).flush()
}
```

This is a destructive convergence step disguised as a lookup. Once a global role's `tenantId` is rewritten, every other tenant loses the shared definition, subsequent `add-user` runs for other tenants create per-tenant duplicate `Role` rows, and any logic that assumes a single global definition keyed by `(name, tenantId: null)` silently breaks. It also contradicts the module's own invariant — `ensureRoles` in `lib/setup-app.ts` throws "global roles are not supported" when `tenantId` is null.

## What Changed
- Dropped the global fallback entirely. Role resolution now goes through a small module-local helper `resolveTenantScopedRole(em, name, normalizedTenantId)` that:
  - looks up only the tenant-scoped role, and
  - creates a tenant-scoped role when none exists.
- The global (`tenantId: null`) role is never queried for and never mutated, consistent with how `ensureRoles` already provisions tenant-scoped roles.

## Tests
- Added `packages/core/src/modules/auth/__tests__/cli-add-user-role-scope.test.ts`:
  - drives `add-user` with a global role present and the tenant-scoped copy absent; asserts the global role's `tenantId` stays `null` and a tenant-scoped role is created instead (this test fails against the pre-fix code, where the global role's `tenantId` was mutated to the tenant id).
  - asserts an existing tenant-scoped role is reused without creating a duplicate.
- Verified the test fails on the buggy code and passes on the fix.
- `yarn workspace @open-mercato/core test -- auth/__tests__/cli` — 18 passed.
- `yarn workspace @open-mercato/core typecheck` — clean.

## Backward Compatibility
- No contract surface changes. The `add-user` CLI command name, arguments, and output are unchanged; `resolveTenantScopedRole` is a module-local (unexported) helper. No API response fields, event IDs, widget spot IDs, ACL IDs, import paths, or DI names were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)