### PR TITLE
fix(customers): escape ILIKE wildcards and validate from/to dates in interactions list (#2734)

### DIFF
--- a/packages/core/src/modules/customers/api/interactions/__tests__/listSearchAndDates.test.ts
+++ b/packages/core/src/modules/customers/api/interactions/__tests__/listSearchAndDates.test.ts
@@ -1,0 +1,117 @@
+import {
+  Kysely,
+  PostgresAdapter,
+  PostgresQueryCompiler,
+  PostgresIntrospector,
+  DummyDriver,
+  type CompiledQuery,
+} from 'kysely'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+
+const recordedQueries: CompiledQuery[] = []
+
+function createRecordingKysely(): Kysely<any> {
+  const db = new Kysely<any>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+      createIntrospector: (instance: Kysely<any>) => new PostgresIntrospector(instance),
+    },
+  })
+  ;(db.getExecutor() as any).executeQuery = async (compiledQuery: CompiledQuery) => {
+    recordedQueries.push(compiledQuery)
+    return { rows: [] }
+  }
+  return db
+}
+
+const fakeEm = {
+  fork() {
+    return {
+      getKysely: () => createRecordingKysely(),
+    }
+  },
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (token: string) => {
+      if (token === 'em') return fakeEm
+      return undefined
+    },
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: async () => ({
+    tenantId,
+    orgId,
+    sub: null,
+    isApiKey: true,
+  }),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: async () => ({ filterIds: [orgId], selectedId: orgId }),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({ translate: (_key: string, fallback: string) => fallback }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/enricher-runner', () => ({
+  applyResponseEnrichers: async (items: unknown[]) => ({ items }),
+}))
+
+import { GET, listSchema } from '../route'
+
+const rowsQuery = () =>
+  recordedQueries.find((entry) => entry.sql.includes('customer_interactions'))
+
+beforeEach(() => {
+  recordedQueries.length = 0
+})
+
+describe('interactions list — search escaping and date validation (#2734)', () => {
+  test('listSchema rejects an unparseable from/to date with a validation error', () => {
+    expect(() => listSchema.parse({ from: 'not-a-date' })).toThrow()
+    expect(() => listSchema.parse({ to: 'also-not-a-date' })).toThrow()
+  })
+
+  test('listSchema coerces valid ISO date strings into Date instances', () => {
+    const parsed = listSchema.parse({ from: '2026-01-01T00:00:00.000Z', to: '2026-02-01' })
+    expect(parsed.from).toBeInstanceOf(Date)
+    expect(parsed.to).toBeInstanceOf(Date)
+  })
+
+  test('an unparseable from date yields a clean 400 instead of a 500', async () => {
+    const res = await GET(new Request('https://example.test/api/customers/interactions?from=not-a-date'))
+    expect(res.status).toBe(400)
+  })
+
+  test('search wildcards are escaped before being wrapped in the ILIKE pattern', async () => {
+    const res = await GET(new Request('https://example.test/api/customers/interactions?search=' + encodeURIComponent('50%_off')))
+    expect(res.status).toBe(200)
+    const compiled = rowsQuery()
+    expect(compiled).toBeDefined()
+    expect(compiled!.sql.toLowerCase()).toContain('ilike')
+    expect(compiled!.parameters).toContain('%50\\%\\_off%')
+    expect(compiled!.parameters).not.toContain('%50%_off%')
+  })
+
+  test('valid from/to filters bind Date parameters on the occurred/scheduled/created range', async () => {
+    const res = await GET(
+      new Request(
+        'https://example.test/api/customers/interactions?from=2026-01-01T00:00:00.000Z&to=2026-02-01T00:00:00.000Z',
+      ),
+    )
+    expect(res.status).toBe(200)
+    const compiled = rowsQuery()
+    expect(compiled).toBeDefined()
+    const dateParams = compiled!.parameters.filter((value): value is Date => value instanceof Date)
+    expect(dateParams.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/core/src/modules/customers/api/interactions/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/route.ts
@@ -9,6 +9,7 @@ import { normalizeCustomFieldResponse } from '@open-mercato/shared/lib/custom-fi
 import { applyResponseEnrichers } from '@open-mercato/shared/lib/crud/enricher-runner'
 import type { EnricherContext } from '@open-mercato/shared/lib/crud/response-enricher'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -39,7 +40,7 @@ const interactionSortFieldSchema = z.enum([
   'title',
 ])
 
-const listSchema = z
+export const listSchema = z
   .object({
     limit: z.coerce.number().min(1).max(100).default(25),
     cursor: z.string().optional(),
@@ -50,8 +51,8 @@ const listSchema = z
     type: z.string().optional(),
     excludeInteractionType: z.string().optional(),
     search: z.string().trim().min(1).optional(),
-    from: z.string().optional(),
-    to: z.string().optional(),
+    from: z.coerce.date().optional(),
+    to: z.coerce.date().optional(),
     pinned: z.enum(['true', 'false']).optional(),
     sortField: interactionSortFieldSchema.optional(),
     sortDir: z.enum(['asc', 'desc']).optional(),
@@ -430,14 +431,14 @@ export async function GET(req: Request) {
       // columns is unsupported, the same documented limitation as
       // customer_activity / customer_comment. The returned page's title/body are
       // still decrypted for display further below.
-      const searchTerm = `%${query.search}%`
+      const searchTerm = `%${escapeLikePattern(query.search)}%`
       rowsQuery = rowsQuery.where(sql<boolean>`coalesce(title, '') ilike ${searchTerm} or coalesce(body, '') ilike ${searchTerm}`)
     }
     if (query.from) {
-      rowsQuery = rowsQuery.where(sql<boolean>`coalesce(occurred_at, scheduled_at, created_at) >= ${new Date(query.from)}`)
+      rowsQuery = rowsQuery.where(sql<boolean>`coalesce(occurred_at, scheduled_at, created_at) >= ${query.from}`)
     }
     if (query.to) {
-      rowsQuery = rowsQuery.where(sql<boolean>`coalesce(occurred_at, scheduled_at, created_at) <= ${new Date(query.to)}`)
+      rowsQuery = rowsQuery.where(sql<boolean>`coalesce(occurred_at, scheduled_at, created_at) <= ${query.to}`)
     }
 
     if (cursor) {


### PR DESCRIPTION
Fixes #2734

## Problem
The `GET /api/customers/interactions` list handler:
- built its ILIKE search term as `` `%${query.search}%` `` without escaping `%`/`_`, so caller-supplied wildcards were interpreted as LIKE patterns (e.g. `search=%` matched every row, turning the filter into a no-op / enabling cheap broad scans).
- passed `query.from`/`query.to` straight into `new Date(...)` with no validation, so a malformed value (`from=not-a-date`) produced `Invalid Date`, which Postgres rejected and surfaced as an opaque 500 instead of a clean 400.

Neither is SQL injection (values are parameterized via Kysely tagged templates), but both are robustness gaps and diverge from every sibling route in this module (`deals`, `people`, `companies`, `tags`), which already escape search input.

## Root Cause
- `searchTerm` was constructed without `escapeLikePattern`.
- `from`/`to` were typed as `z.string()` in `listSchema` and only converted to `Date` at query-build time, so invalid input reached the database layer.

## What Changed
`packages/core/src/modules/customers/api/interactions/route.ts`:
- Import `escapeLikePattern` from `@open-mercato/shared/lib/db/escapeLikePattern` and run `query.search` through it before wrapping with `%…%` (matching `deals`/`people`/`companies`/`tags`).
- Change `from`/`to` in `listSchema` to `z.coerce.date()`, so malformed dates fail validation and return the route's existing clean `400` (`ZodError` branch), and valid ISO strings still coerce. The query-build sites now bind the validated `Date` directly instead of re-wrapping with `new Date(...)`.
- Export `listSchema` so it can be unit-tested.

## Tests
Added `api/interactions/__tests__/listSearchAndDates.test.ts` (5 cases), verified red-before / green-after:
- `listSchema` rejects unparseable `from`/`to` and coerces valid ISO strings to `Date`.
- `GET ?from=not-a-date` returns `400` (not `500`).
- Search `50%_off` is bound as `%50\%\_off%` (escaped), never `%50%_off%`, with `ILIKE` in the compiled SQL. The handler is driven against a recording Kysely (Postgres dialect + `DummyDriver`) that captures the compiled query parameters.
- Valid `from`/`to` bind `Date` parameters on the range filter.

Checks run: `yarn build:packages`, `yarn generate`, `yarn workspace @open-mercato/core typecheck` (clean), and the full `interaction|customers/api` suites (38 suites / 170 tests pass).

## Backward Compatibility
- No contract surface changes. `listSchema` was module-private and is now additively exported.
- No API response fields removed. The endpoint still accepts ISO date strings for `from`/`to` (they coerce); only previously-500 malformed dates now return a clean 400 — a robustness improvement.