### PR TITLE
security(query_index): coerce sort direction before sql.raw in ORDER BY (#2704)

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -1,4 +1,4 @@
-import { HybridQueryEngine } from '../../query_index/lib/engine'
+import { HybridQueryEngine, coerceSortDirection } from '../../query_index/lib/engine'
 import { SortDir } from '@open-mercato/shared/lib/query/types'
 
 type KyselyMockConfig = {
@@ -649,5 +649,74 @@ describe('HybridQueryEngine', () => {
     const reindexCalls = emitEvent.mock.calls.filter(([name]) => name === 'query_index.reindex')
     expect(reindexCalls).toHaveLength(0)
     warnSpy.mockRestore()
+  })
+})
+
+describe('sort direction coercion (#2704)', () => {
+  const INJECTED_DIR = "asc, CASE WHEN (SELECT secret FROM vault) LIKE '%a%' THEN pg_sleep(2) ELSE 0 END"
+
+  const serializeOrderBys = (db: any): string => {
+    const orderByArgs = (db._chains as ChainLog[]).flatMap((chain) => chain.orderBys).flat()
+    expect(orderByArgs.length).toBeGreaterThan(0)
+    return JSON.stringify(orderByArgs.map((arg: any) =>
+      typeof arg?.toOperationNode === 'function' ? arg.toOperationNode() : arg,
+    ))
+  }
+
+  test('coerceSortDirection only ever returns asc or desc', () => {
+    expect(coerceSortDirection(SortDir.Asc)).toBe(SortDir.Asc)
+    expect(coerceSortDirection(SortDir.Desc)).toBe(SortDir.Desc)
+    expect(coerceSortDirection('DESC')).toBe(SortDir.Desc)
+    expect(coerceSortDirection(undefined)).toBe(SortDir.Asc)
+    expect(coerceSortDirection(null)).toBe(SortDir.Asc)
+    expect(coerceSortDirection(INJECTED_DIR)).toBe(SortDir.Asc)
+  })
+
+  test('hybrid cf sort never inlines an attacker-controlled direction', async () => {
+    const db = createFakeKysely({ baseTable: 'todos', hasIndexAny: true, baseCount: 5, indexCount: 5 })
+    const em = buildEm(db)
+    const fallback = { query: jest.fn() }
+    const emitEvent = jest.fn().mockResolvedValue(undefined)
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent }))
+
+    await engine.query('example:todo', {
+      fields: ['id', 'cf:priority'],
+      includeCustomFields: true,
+      organizationId: 'org1',
+      tenantId: 't1',
+      sort: [{ field: 'cf:priority', dir: INJECTED_DIR as SortDir }],
+    })
+
+    expect(fallback.query).not.toHaveBeenCalled()
+    const serialized = serializeOrderBys(db)
+    expect(serialized).not.toContain('pg_sleep')
+    expect(serialized).not.toContain('vault')
+  })
+
+  test('custom entity doc sort never inlines an attacker-controlled direction', async () => {
+    const db = createFakeKysely({
+      baseTable: 'todos',
+      hasIndexAny: false,
+      baseCount: 0,
+      indexCount: 0,
+      rows: { custom_entities_storage: [] },
+    })
+    const em = buildEm(db)
+    const fallback = { query: jest.fn() }
+    const emitEvent = jest.fn().mockResolvedValue(undefined)
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent }))
+    jest.spyOn(engine as any, 'isCustomEntity').mockResolvedValue(true)
+
+    await engine.query('example:custom_thing', {
+      fields: ['id', 'title'],
+      organizationId: 'org1',
+      tenantId: 't1',
+      sort: [{ field: 'title', dir: INJECTED_DIR as SortDir }],
+    })
+
+    expect(fallback.query).not.toHaveBeenCalled()
+    const serialized = serializeOrderBys(db)
+    expect(serialized).not.toContain('pg_sleep')
+    expect(serialized).not.toContain('vault')
   })
 })

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -58,6 +58,10 @@ function resolveBooleanEnv(names: readonly string[], defaultValue: boolean): boo
   return defaultValue
 }
 
+export function coerceSortDirection(dir: unknown): SortDir {
+  return String(dir ?? SortDir.Asc).toLowerCase() === SortDir.Desc ? SortDir.Desc : SortDir.Asc
+}
+
 function resolveDebugVerbosity(): boolean {
   const queryIndexDebug = process.env.OM_QUERY_INDEX_DEBUG
   if (queryIndexDebug !== undefined) {
@@ -801,7 +805,7 @@ export class HybridQueryEngine implements QueryEngine {
           if (fieldName.startsWith('cf:')) {
             const textExpr = this.buildCfTextExprSql(fieldName, indexSources)
             if (textExpr) {
-              const direction = sql.raw(String(s.dir ?? SortDir.Asc))
+              const direction = sql.raw(coerceSortDirection(s.dir))
               next = next.orderBy(sql`${textExpr} ${direction}`)
             }
           } else {
@@ -1627,7 +1631,7 @@ export class HybridQueryEngine implements QueryEngine {
         } else if (s.field === 'created_at' || s.field === 'updated_at' || s.field === 'deleted_at') {
           next = next.orderBy(`${alias}.${s.field}`, s.dir ?? SortDir.Asc)
         } else {
-          const direction = sql.raw(String(s.dir ?? SortDir.Asc))
+          const direction = sql.raw(coerceSortDirection(s.dir))
           next = next.orderBy(sql`(${sql.ref(alias + '.doc')} ->> ${s.field}) ${direction}`)
         }
       }


### PR DESCRIPTION
Fixes #2704

## Problem
- `HybridQueryEngine` built the ORDER BY direction with `sql.raw(String(s.dir ?? SortDir.Asc))` in both `applySort` blocks (hybrid path and custom-entity path). `SortDir` is erased at runtime, so any caller forwarding an attacker-influenced string as `Sort.dir` landed it literally in the emitted SQL — structural ORDER BY injection (boolean/timing side channels via crafted expressions).

## Root Cause
- No runtime validation between the public `query()` API's `sort[*].dir` input and `sql.raw()`. The type system was the only guard, and in-tree callers happened to normalize — the public engine API itself did not.

## What Changed
- Added `coerceSortDirection(dir: unknown): SortDir` in `packages/core/src/modules/query_index/lib/engine.ts` — maps anything that isn't (case-insensitively) `desc` to `asc`.
- Both `sql.raw` ORDER BY sites (hybrid `applySort` and custom-entity `applySort`) now pass through the coercion, so only the `asc`/`desc` keywords can ever reach `sql.raw`.
- The remaining `orderBy(column, s.dir ?? SortDir.Asc)` sites were already safe: they go through Kysely's own direction parser, not `sql.raw`.

## Tests
- `coerceSortDirection` unit coverage: enum values, uppercase, `undefined`/`null`, injection payload.
- Behavioural regression tests for both paths (`hybrid cf sort` / `custom entity doc sort`): query with an injected `dir` payload and assert the captured ORDER BY operation nodes never contain it. Both fail against the unfixed code (verified) and pass with the fix.
- Full gate run: `yarn generate`, `yarn build:packages` (21/21), `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck` (21/21), `yarn test`, `yarn build:app` — all green.

## Security impact
- Defense-in-depth hardening of a documented public query API consumed by third-party modules and AI tools. Closes an ORDER BY SQL-injection vector for any future/external caller that forwards user input as `Sort.dir`. No credentials, RBAC, or encryption surfaces touched.

## Backward Compatibility
- No contract surface changes. `coerceSortDirection` is a new additive export. Valid `SortDir` values produce byte-identical SQL; only previously-injectable invalid strings change behavior (now coerced to `asc`).
