### PR TITLE
security(ai_assistant): parameterize tool-test-runner tenant lookups (#2725)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/tool-test-runner-pick-default-tenant.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/tool-test-runner-pick-default-tenant.test.ts
@@ -1,0 +1,70 @@
+import type { AwilixContainer } from 'awilix'
+import { pickDefaultTenant } from '../tool-test-runner'
+
+type ExecuteCall = { sql: string; params?: unknown[] }
+
+function makeContainer(
+  rowsBySql: (sql: string) => Record<string, unknown>[],
+  calls: ExecuteCall[],
+): AwilixContainer {
+  const connection = {
+    execute: async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params })
+      return rowsBySql(sql)
+    },
+  }
+  const em = { getConnection: () => connection }
+  return {
+    resolve: (token: string) => {
+      if (token === 'em') return em
+      throw new Error(`[internal] unexpected resolve token: ${token}`)
+    },
+  } as unknown as AwilixContainer
+}
+
+describe('pickDefaultTenant SQL safety (#2725)', () => {
+  it('binds the tenant id as a query parameter instead of interpolating it', async () => {
+    const calls: ExecuteCall[] = []
+    const tenantId = '11111111-2222-3333-4444-555555555555'
+    const orgId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+    const userId = 'ffffffff-0000-1111-2222-333333333333'
+    const container = makeContainer((sql) => {
+      if (sql.includes('FROM tenants')) return [{ id: tenantId }]
+      if (sql.includes('FROM organizations')) return [{ id: orgId }]
+      if (sql.includes('FROM users')) return [{ id: userId }]
+      return []
+    }, calls)
+
+    const result = await pickDefaultTenant(container)
+
+    expect(result).toEqual({ tenantId, organizationId: orgId, userId })
+
+    const orgCall = calls.find((call) => call.sql.includes('FROM organizations'))
+    const userCall = calls.find((call) => call.sql.includes('FROM users'))
+    expect(orgCall).toBeDefined()
+    expect(userCall).toBeDefined()
+
+    // Tenant value flows through bound parameters, never string-interpolated.
+    expect(orgCall?.params).toEqual([tenantId])
+    expect(userCall?.params).toEqual([tenantId])
+    expect(orgCall?.sql).toContain('tenant_id = ?')
+    expect(userCall?.sql).toContain('tenant_id = ?')
+
+    // No call may embed the tenant value or hand-rolled quote-escaping in SQL.
+    for (const call of calls) {
+      expect(call.sql).not.toContain(tenantId)
+      expect(call.sql).not.toContain("''")
+    }
+  })
+
+  it('returns null when no tenant exists without issuing scoped lookups', async () => {
+    const calls: ExecuteCall[] = []
+    const container = makeContainer(() => [], calls)
+
+    const result = await pickDefaultTenant(container)
+
+    expect(result).toBeNull()
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.sql).toContain('FROM tenants')
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/tool-test-runner.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/tool-test-runner.ts
@@ -212,14 +212,18 @@ async function loadGeneratedTools(): Promise<{ moduleId: string; tools: AiToolDe
   return result
 }
 
-async function pickDefaultTenant(
+export async function pickDefaultTenant(
   container: AwilixContainer,
 ): Promise<{ tenantId: string; organizationId: string | null; userId: string | null } | null> {
   try {
     const em = container.resolve<{
-      getConnection: () => { execute: (sql: string) => Promise<unknown[]> }
+      getConnection: () => {
+        execute: (sql: string, params?: unknown[]) => Promise<Record<string, unknown>[]>
+      }
     }>('em') as unknown as {
-      getConnection: () => { execute: (sql: string) => Promise<Record<string, unknown>[]> }
+      getConnection: () => {
+        execute: (sql: string, params?: unknown[]) => Promise<Record<string, unknown>[]>
+      }
     }
     const conn = em.getConnection()
     const tenantRows = await conn.execute(
@@ -230,16 +234,17 @@ async function pickDefaultTenant(
         ? String((tenantRows[0] as Record<string, unknown>).id)
         : null
     if (!tenantId) return null
-    const escaped = tenantId.replace(/'/g, "''")
     const orgRows = await conn.execute(
-      `SELECT id FROM organizations WHERE tenant_id = '${escaped}' AND deleted_at IS NULL ORDER BY created_at ASC LIMIT 1`,
+      `SELECT id FROM organizations WHERE tenant_id = ? AND deleted_at IS NULL ORDER BY created_at ASC LIMIT 1`,
+      [tenantId],
     )
     const organizationId =
       Array.isArray(orgRows) && orgRows[0]
         ? String((orgRows[0] as Record<string, unknown>).id)
         : null
     const userRows = await conn.execute(
-      `SELECT id FROM users WHERE tenant_id = '${escaped}' AND deleted_at IS NULL ORDER BY created_at ASC LIMIT 1`,
+      `SELECT id FROM users WHERE tenant_id = ? AND deleted_at IS NULL ORDER BY created_at ASC LIMIT 1`,
+      [tenantId],
     )
     const userId =
       Array.isArray(userRows) && userRows[0]


### PR DESCRIPTION
Fixes #2725

## Problem
- `pickDefaultTenant()` in the AI tool-test runner interpolated a tenant id into raw SQL using hand-rolled single-quote escaping (`tenantId.replace(/'/g, "''")`) and string-template concatenation instead of a parameterized query.

## Root Cause
- The `organizations` and `users` lookups embedded the tenant value directly in the SQL string. Today the value is a server-generated UUID (no current exploit), but the pattern is a latent SQL-injection footgun: any future refactor routing a less-trusted value through the helper would turn the manual escaping into a real injection. Manual `''`-doubling is also incomplete (backslash-escape variants when `standard_conforming_strings` is off, multibyte abuses on non-UTF8 connections).

## What Changed
- `packages/ai-assistant/src/modules/ai_assistant/lib/tool-test-runner.ts`: replaced the two interpolated lookups with parameterized `conn.execute(sql, [tenantId])` calls using `tenant_id = ?` placeholders, and removed the hand-rolled `replace(/'/g, "''")` escaping entirely. Widened the local connection type to declare the optional `params?: unknown[]` argument (matches MikroORM's `execute` signature).
- Exported `pickDefaultTenant` so the behavior can be unit-tested.

## Tests
- Added `lib/__tests__/tool-test-runner-pick-default-tenant.test.ts`: asserts the tenant id flows through bound `params` (`[tenantId]`), the SQL uses `tenant_id = ?`, and the tenant value / `''`-escaping never appear in the SQL text; plus a null-tenant short-circuit case. Verified the test fails against the old interpolated code and passes after the fix.
- Full `@open-mercato/ai-assistant` suite: 82 suites / 1178 tests pass. Package build (tsc/tsup) succeeds.

## Backward Compatibility
- No contract-surface changes. `pickDefaultTenant` lives in the module's internal `lib/` path (not a documented public contract per `BACKWARD_COMPATIBILITY.md`); the new `export` is purely additive. No API routes, event IDs, DI names, ACL features, or CLI commands changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)