### PR TITLE
fix(attachments): require forkable EM for background OCR (#2728)

### DIFF
--- a/packages/core/src/modules/attachments/lib/__tests__/ocrQueue.test.ts
+++ b/packages/core/src/modules/attachments/lib/__tests__/ocrQueue.test.ts
@@ -1,0 +1,48 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { requestOcrProcessing } from '../ocrQueue'
+import type { Attachment } from '../../data/entities'
+import type { StorageDriver } from '../drivers/types'
+
+const makeAttachment = (): Attachment =>
+  ({
+    id: 'attachment-1',
+    mimeType: 'application/pdf',
+    partitionCode: 'docs',
+    organizationId: 'org-1',
+    tenantId: 'tenant-1',
+  }) as unknown as Attachment
+
+const driver = {} as StorageDriver
+
+describe('requestOcrProcessing EntityManager isolation', () => {
+  let setImmediateSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    setImmediateSpy = jest.spyOn(global, 'setImmediate').mockImplementation((() => undefined) as never)
+  })
+
+  afterEach(() => {
+    setImmediateSpy.mockRestore()
+  })
+
+  it('forks the EntityManager for the background worker instead of reusing the request EM', async () => {
+    const forkedEm = { id: 'forked' } as unknown as EntityManager
+    const fork = jest.fn(() => forkedEm)
+    const requestEm = { fork } as unknown as EntityManager
+
+    await requestOcrProcessing(requestEm, makeAttachment(), driver, 'docs/attachment-1.pdf')
+
+    expect(fork).toHaveBeenCalledTimes(1)
+    expect(setImmediateSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws loudly when the EntityManager cannot fork instead of silently reusing it', async () => {
+    const requestEm = {} as unknown as EntityManager
+
+    await expect(
+      requestOcrProcessing(requestEm, makeAttachment(), driver, 'docs/attachment-1.pdf'),
+    ).rejects.toThrow(/requires an EntityManager that exposes fork/)
+
+    expect(setImmediateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/attachments/lib/ocrQueue.ts
+++ b/packages/core/src/modules/attachments/lib/ocrQueue.ts
@@ -88,8 +88,16 @@ export async function requestOcrProcessing(
     tenantId: attachment.tenantId ?? null,
   }
 
+  if (typeof (em as { fork?: unknown })?.fork !== 'function') {
+    throw new Error(
+      '[internal] attachments OCR background processing requires an EntityManager that exposes fork(); ' +
+        'reusing the request-scoped EntityManager in the async worker would race with later request mutations.',
+    )
+  }
+
+  const workerEm = em.fork()
+
   setImmediate(() => {
-    const workerEm = typeof (em as any)?.fork === 'function' ? (em as any).fork() : em
     processAttachmentOcr(workerEm, payload, driver).catch((error) => {
       console.error(`[attachments.ocr] Background processing error:`, error)
     })


### PR DESCRIPTION
Fixes #2728

## Problem
Background OCR processing is queued via `setImmediate` after the upload request handler returns. The worker only forked a fresh `EntityManager` when the passed-in `em` exposed `fork()`; the ternary silently fell back to reusing the request-scoped `em` (`: em`) when `fork` was absent.

## Root Cause
`requestOcrProcessing` (`packages/core/src/modules/attachments/lib/ocrQueue.ts`) used `typeof em.fork === 'function' ? em.fork() : em`. With a wrapped EM, a subset interface, or a non-ORM stub, the async worker would run `em.findOne(...)` and `em.persist(...).flush()` on the same EntityManager the request handler already used — after the request returned. This races with later request mutations, can flush unrelated dirty entities, or hit a disposed request container, producing data corruption / intermittent failures the fallback hides instead of surfacing.

## What Changed
- Removed the silent `: em` fallback.
- Fork the EM synchronously (before `setImmediate`) and throw a clear `[internal]` error when the EM cannot fork, so misuse fails loudly on the caller's stack (the call site already wraps the call in `.catch`, so the upload still succeeds and the queuing failure is logged).
- Production behavior is unchanged: the real MikroORM EM always exposes `fork()`.

## Tests
- Added `packages/core/src/modules/attachments/lib/__tests__/ocrQueue.test.ts`:
  - forks the EM for the worker (and forks before `setImmediate`, proving isolation)
  - throws loudly and does not queue the worker when the EM cannot fork
- Both tests fail against the original code and pass after the fix.
- `yarn jest` attachments suite: 117 passed.
- `yarn workspace @open-mercato/core typecheck`: clean.

## Backward Compatibility
- No contract surface changes. `requestOcrProcessing`'s signature (`em: EntityManager`, which already declares `fork`) is unchanged; no API responses, event IDs, ACL IDs, import paths, or DI names touched.