### PR TITLE
security(attachments): dangerous-extension check runs on raw filename before sanitization (#2727)

### DIFF
--- a/packages/core/src/modules/attachments/lib/__tests__/security.test.ts
+++ b/packages/core/src/modules/attachments/lib/__tests__/security.test.ts
@@ -5,6 +5,10 @@ import {
   sanitizeUploadedFileName,
 } from '@open-mercato/core/modules/attachments/lib/security'
 
+const NUL = String.fromCharCode(0)
+const TAB = String.fromCharCode(9)
+const ZERO_WIDTH_SPACE = String.fromCharCode(0x200b)
+
 describe('hasDangerousExecutableExtension', () => {
   it('flags files whose final extension is executable', () => {
     expect(hasDangerousExecutableExtension('malware.exe')).toBe(true)
@@ -49,5 +53,27 @@ describe('hasDangerousExecutableExtension', () => {
     expect(hasDangerousExecutableExtension(raw)).toBe(true)
     expect(sanitizeUploadedFileName(raw)).toBe('faktura_pdf.exe')
     expect(getAttachmentExtension(sanitizeUploadedFileName(raw))).toBe('exe')
+  })
+
+  it('flags executable segments laced with a NUL byte (control-character deny-list bypass)', () => {
+    expect(hasDangerousExecutableExtension(`evil.exe${NUL}.png`)).toBe(true)
+    expect(hasDangerousExecutableExtension(`payload.${NUL}bat.txt`)).toBe(true)
+    expect(hasDangerousExecutableExtension(`shell.s${NUL}h`)).toBe(true)
+  })
+
+  it('flags executable segments laced with other control or invisible characters', () => {
+    expect(hasDangerousExecutableExtension(`evil.e${TAB}xe.png`)).toBe(true)
+    expect(hasDangerousExecutableExtension(`evil.e${ZERO_WIDTH_SPACE}xe.png`)).toBe(true)
+  })
+
+  it('flags executable segments with stray non-filename characters between dots', () => {
+    expect(hasDangerousExecutableExtension('evil.e!xe.png')).toBe(true)
+    expect(hasDangerousExecutableExtension('evil.ex e.png')).toBe(true)
+  })
+
+  it('stays aligned with the sanitized filename for control-character payloads', () => {
+    const raw = `evil.exe${NUL}.png`
+    expect(hasDangerousExecutableExtension(raw)).toBe(true)
+    expect(sanitizeUploadedFileName(raw)).toBe('evil_exe.png')
   })
 })

--- a/packages/core/src/modules/attachments/lib/security.ts
+++ b/packages/core/src/modules/attachments/lib/security.ts
@@ -78,7 +78,7 @@ export function hasDangerousExecutableExtension(fileName: string | null | undefi
   const parts = trimmed.split('.').filter(Boolean)
   if (parts.length < 2) return false
   for (let i = 1; i < parts.length; i += 1) {
-    const segment = parts[i]!.toLowerCase()
+    const segment = parts[i]!.toLowerCase().replace(/[^a-z0-9]/g, '')
     if (DANGEROUS_EXECUTABLE_EXTENSIONS.has(segment)) return true
   }
   return false


### PR DESCRIPTION
Fixes #2727

## Problem
The attachment upload guard `hasDangerousExecutableExtension` ran the executable deny-list against the raw, unsanitized multipart `file.name`. It split on `.` and compared each lowercased segment with exact set membership, so a control character laced into a dangerous segment (e.g. a NUL byte in `evil.exe\0.png`) produced a segment like `exe\0` that never matched `exe` — silently bypassing the executable-upload guard.

## Root Cause
`hasDangerousExecutableExtension` (`packages/core/src/modules/attachments/lib/security.ts`) compared raw, un-normalized filename segments against the deny-list. Any non-`[a-z0-9]` byte inside a segment (NUL, tab, zero-width space, stray punctuation/whitespace) defeated the exact-match comparison, leaving the guard reliant on downstream sanitization and MIME sniffing rather than enforcing its own contract.

## What Changed
- Strip every non-`[a-z0-9]` character from each filename segment before the deny-list comparison, mirroring the normalization `sanitizeUploadedFileName` already applies. The guard now flags `exe`/`bat`/`sh`/… regardless of injected control, whitespace, or invisible characters. One-line change in `security.ts`; no signature or behavior change for legitimate filenames.

## Tests
- Added regression cases in `security.test.ts` covering NUL-byte, tab, zero-width-space, and stray-punctuation/whitespace control-character payloads, plus alignment with `sanitizeUploadedFileName`. These fail before the fix and pass after.
- `yarn workspace @open-mercato/core test -- "attachments/lib"` (88 passed)
- `yarn generate` + full `yarn typecheck` (21/21 pass)

## Backward Compatibility
- No contract surface changes. The exported `hasDangerousExecutableExtension` signature is unchanged; the guard only becomes stricter (correctly rejects inputs that previously bypassed it). No API response fields, event IDs, widget spot IDs, ACL IDs, import paths, or DI names affected.