### PR TITLE
security(audit_logs): close TOCTOU race in undo token replay (#2729)

### DIFF
--- a/packages/core/src/modules/audit_logs/data/entities.ts
+++ b/packages/core/src/modules/audit_logs/data/entities.ts
@@ -1,7 +1,7 @@
 import { Entity, Index, PrimaryKey, Property } from '@mikro-orm/decorators/legacy'
 import type { ActionLogProjectionType, ActionLogSourceKey } from '@open-mercato/core/modules/audit_logs/lib/projections'
 
-export type ActionLogExecutionState = 'done' | 'undone' | 'failed' | 'redone'
+export type ActionLogExecutionState = 'done' | 'undoing' | 'undone' | 'failed' | 'redone'
 
 @Entity({ tableName: 'action_logs' })
 @Index({ name: 'action_logs_tenant_idx', properties: ['tenantId', 'createdAt'] })

--- a/packages/core/src/modules/audit_logs/services/__tests__/actionLogService.test.ts
+++ b/packages/core/src/modules/audit_logs/services/__tests__/actionLogService.test.ts
@@ -303,3 +303,43 @@ describe('ActionLogService.list pagination', () => {
     expect(result.totalPages).toBe(1)
   })
 })
+
+describe('ActionLogService.claimForUndo / releaseUndoClaim (TOCTOU guard)', () => {
+  function buildServiceWithNativeUpdate(affected: number) {
+    const nativeUpdate = jest.fn(async () => affected)
+    const fakeEm = { nativeUpdate }
+    const service = new ActionLogService(
+      fakeEm as unknown as ConstructorParameters<typeof ActionLogService>[0],
+    )
+    return { service, nativeUpdate }
+  }
+
+  it('claimForUndo issues a compare-and-set guarded on the done state', async () => {
+    const { service, nativeUpdate } = buildServiceWithNativeUpdate(1)
+
+    const claimed = await service.claimForUndo('log-1')
+
+    expect(claimed).toBe(true)
+    expect(nativeUpdate).toHaveBeenCalledTimes(1)
+    const [, filter, update] = nativeUpdate.mock.calls[0]
+    expect(filter).toMatchObject({ id: 'log-1', executionState: 'done', deletedAt: null })
+    expect(update).toEqual({ executionState: 'undoing' })
+  })
+
+  it('claimForUndo returns false when the row was already claimed (0 rows affected)', async () => {
+    const { service } = buildServiceWithNativeUpdate(0)
+
+    expect(await service.claimForUndo('log-1')).toBe(false)
+  })
+
+  it('releaseUndoClaim reverts an undoing row back to done', async () => {
+    const { service, nativeUpdate } = buildServiceWithNativeUpdate(1)
+
+    const released = await service.releaseUndoClaim('log-1')
+
+    expect(released).toBe(true)
+    const [, filter, update] = nativeUpdate.mock.calls[0]
+    expect(filter).toMatchObject({ id: 'log-1', executionState: 'undoing', deletedAt: null })
+    expect(update).toEqual({ executionState: 'done' })
+  })
+})

--- a/packages/core/src/modules/audit_logs/services/actionLogService.ts
+++ b/packages/core/src/modules/audit_logs/services/actionLogService.ts
@@ -508,6 +508,24 @@ export class ActionLogService {
     return entry
   }
 
+  async claimForUndo(id: string): Promise<boolean> {
+    const affected = await this.em.nativeUpdate(
+      ActionLog,
+      { id, executionState: 'done', deletedAt: null },
+      { executionState: 'undoing' },
+    )
+    return affected === 1
+  }
+
+  async releaseUndoClaim(id: string): Promise<boolean> {
+    const affected = await this.em.nativeUpdate(
+      ActionLog,
+      { id, executionState: 'undoing', deletedAt: null },
+      { executionState: 'done' },
+    )
+    return affected === 1
+  }
+
   async markUndone(id: string, traceInput?: ActionLogCreateInput) {
     const fork = this.em.fork()
     const log = await fork.findOne(ActionLog, { id, deletedAt: null })

--- a/packages/shared/src/lib/commands/__tests__/command-bus.cache.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/command-bus.cache.test.ts
@@ -61,6 +61,8 @@ describe('CommandBus cache invalidation for sales documents', () => {
       actionLogService: asValue({
         log: logMock,
         findByUndoToken: jest.fn(async () => logRecord),
+        claimForUndo: jest.fn(async () => true),
+        releaseUndoClaim: jest.fn(async () => true),
         markUndone: jest.fn(async () => {}),
       }),
       dataEngine: asValue({ flushOrmEntityChanges: jest.fn() }),

--- a/packages/shared/src/lib/commands/__tests__/command-bus.undo-audit.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/command-bus.undo-audit.test.ts
@@ -42,6 +42,8 @@ describe('CommandBus undo audit trace', () => {
             lastName: { from: 'Before', to: 'After' },
           },
         })),
+        claimForUndo: jest.fn(async () => true),
+        releaseUndoClaim: jest.fn(async () => true),
         markUndone: markUndoneMock,
       }),
       dataEngine: asValue({ flushOrmEntityChanges: jest.fn(async () => undefined) }),

--- a/packages/shared/src/lib/commands/__tests__/command-bus.undo-toctou.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/command-bus.undo-toctou.test.ts
@@ -1,0 +1,122 @@
+import { asValue, createContainer, InjectionMode } from 'awilix'
+import { CommandBus, registerCommand, unregisterCommand } from '@open-mercato/shared/lib/commands'
+
+type ActionLogServiceMock = {
+  findByUndoToken: jest.Mock
+  claimForUndo: jest.Mock
+  releaseUndoClaim: jest.Mock
+  markUndone: jest.Mock
+}
+
+function buildContainer(service: ActionLogServiceMock) {
+  const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+  container.register({
+    actionLogService: asValue(service),
+    dataEngine: asValue({ flushOrmEntityChanges: jest.fn(async () => undefined) }),
+  })
+  return container
+}
+
+function buildLogStub() {
+  return {
+    id: 'log-1',
+    commandId: 'customers.people.update',
+    actionLabel: 'Update person',
+    actorUserId: 'user-1',
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    resourceKind: 'customers.person',
+    resourceId: 'person-1',
+    parentResourceKind: null,
+    parentResourceId: null,
+    relatedResourceKind: null,
+    relatedResourceId: null,
+    commandPayload: { id: 'person-1' },
+    snapshotBefore: { id: 'person-1', lastName: 'Before' },
+    snapshotAfter: { id: 'person-1', lastName: 'After' },
+    changesJson: null,
+  }
+}
+
+const ctx = {
+  container: null as unknown,
+  auth: { sub: 'user-2', tenantId: 'tenant-1', orgId: 'org-1' },
+  organizationScope: null,
+  selectedOrganizationId: 'org-1',
+  organizationIds: null,
+}
+
+describe('CommandBus.undo TOCTOU race guard', () => {
+  afterEach(() => {
+    unregisterCommand('customers.people.update')
+  })
+
+  it('claims the row atomically before invoking the undo handler', async () => {
+    const callOrder: string[] = []
+    const undoMock = jest.fn(async () => {
+      callOrder.push('undo')
+    })
+    registerCommand({ id: 'customers.people.update', execute: jest.fn(), undo: undoMock })
+
+    const service: ActionLogServiceMock = {
+      findByUndoToken: jest.fn(async () => buildLogStub()),
+      claimForUndo: jest.fn(async () => {
+        callOrder.push('claim')
+        return true
+      }),
+      releaseUndoClaim: jest.fn(async () => true),
+      markUndone: jest.fn(async () => null),
+    }
+
+    const bus = new CommandBus()
+    await bus.undo('undo-token', { ...ctx, container: buildContainer(service) } as never)
+
+    expect(service.claimForUndo).toHaveBeenCalledWith('log-1')
+    expect(undoMock).toHaveBeenCalledTimes(1)
+    expect(callOrder).toEqual(['claim', 'undo'])
+    expect(service.markUndone).toHaveBeenCalledTimes(1)
+    expect(service.releaseUndoClaim).not.toHaveBeenCalled()
+  })
+
+  it('does not run the undo handler when the claim is lost to a concurrent request', async () => {
+    const undoMock = jest.fn(async () => {})
+    registerCommand({ id: 'customers.people.update', execute: jest.fn(), undo: undoMock })
+
+    const service: ActionLogServiceMock = {
+      findByUndoToken: jest.fn(async () => buildLogStub()),
+      claimForUndo: jest.fn(async () => false),
+      releaseUndoClaim: jest.fn(async () => true),
+      markUndone: jest.fn(async () => null),
+    }
+
+    const bus = new CommandBus()
+    await expect(
+      bus.undo('undo-token', { ...ctx, container: buildContainer(service) } as never),
+    ).rejects.toThrow('Undo token already consumed')
+
+    expect(undoMock).not.toHaveBeenCalled()
+    expect(service.markUndone).not.toHaveBeenCalled()
+  })
+
+  it('releases the claim when the undo handler fails so the action stays retryable', async () => {
+    const undoMock = jest.fn(async () => {
+      throw new Error('handler boom')
+    })
+    registerCommand({ id: 'customers.people.update', execute: jest.fn(), undo: undoMock })
+
+    const service: ActionLogServiceMock = {
+      findByUndoToken: jest.fn(async () => buildLogStub()),
+      claimForUndo: jest.fn(async () => true),
+      releaseUndoClaim: jest.fn(async () => true),
+      markUndone: jest.fn(async () => null),
+    }
+
+    const bus = new CommandBus()
+    await expect(
+      bus.undo('undo-token', { ...ctx, container: buildContainer(service) } as never),
+    ).rejects.toThrow('handler boom')
+
+    expect(service.markUndone).not.toHaveBeenCalled()
+    expect(service.releaseUndoClaim).toHaveBeenCalledWith('log-1')
+  })
+})

--- a/packages/shared/src/lib/commands/command-bus.ts
+++ b/packages/shared/src/lib/commands/command-bus.ts
@@ -306,53 +306,67 @@ export class CommandBus {
       throw new Error(`Command ${log.commandId} is not undoable`)
     }
 
-    // Run beforeUndo command interceptors
-    const allInterceptors = getAllCommandInterceptorInstances()
-    let undoInterceptorMetadata = new Map<string, Record<string, unknown>>()
-    const userFeatures = allInterceptors.length
-      ? await this.resolveUserFeaturesForInterceptors(ctx)
-      : []
-    if (allInterceptors.length) {
-      const undoCtx = { input: log.commandPayload, logEntry: log, undoToken }
-      const interceptorCtx: CommandInterceptorContext = {
-        commandId: log.commandId,
-        auth: ctx.auth ?? null,
-        selectedOrganizationId: ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null,
-        container: ctx.container,
+    // Atomically claim the action-log row before running any undo side effects.
+    // Two concurrent requests holding the same undo token can both pass
+    // findByUndoToken/executionState checks; the compare-and-set below ensures
+    // only one transitions `done` -> `undoing` and proceeds, the other bails out.
+    const claimed = await service.claimForUndo(log.id)
+    if (!claimed) throw new Error('Undo token already consumed')
+
+    try {
+      // Run beforeUndo command interceptors
+      const allInterceptors = getAllCommandInterceptorInstances()
+      let undoInterceptorMetadata = new Map<string, Record<string, unknown>>()
+      const userFeatures = allInterceptors.length
+        ? await this.resolveUserFeaturesForInterceptors(ctx)
+        : []
+      if (allInterceptors.length) {
+        const undoCtx = { input: log.commandPayload, logEntry: log, undoToken }
+        const interceptorCtx: CommandInterceptorContext = {
+          commandId: log.commandId,
+          auth: ctx.auth ?? null,
+          selectedOrganizationId: ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null,
+          container: ctx.container,
+        }
+        const beforeResult = await runCommandInterceptorsBeforeUndo(
+          allInterceptors, log.commandId, undoCtx, interceptorCtx, userFeatures,
+        )
+        if (!beforeResult.ok) {
+          throw new CommandInterceptorError(beforeResult.error!.message)
+        }
+        undoInterceptorMetadata = beforeResult.metadataByInterceptor
       }
-      const beforeResult = await runCommandInterceptorsBeforeUndo(
-        allInterceptors, log.commandId, undoCtx, interceptorCtx, userFeatures,
-      )
-      if (!beforeResult.ok) {
-        throw new CommandInterceptorError(beforeResult.error!.message)
+
+      await handler.undo({
+        input: log.commandPayload as Parameters<NonNullable<typeof handler.undo>>[0]['input'],
+        ctx,
+        logEntry: log,
+      })
+      await service.markUndone(log.id, this.buildUndoTraceLog(log, ctx))
+
+      // Run afterUndo command interceptors
+      if (allInterceptors.length) {
+        const undoCtx = { input: log.commandPayload, logEntry: log, undoToken }
+        const interceptorCtx: CommandInterceptorContext = {
+          commandId: log.commandId,
+          auth: ctx.auth ?? null,
+          selectedOrganizationId: ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null,
+          container: ctx.container,
+        }
+        await runCommandInterceptorsAfterUndo(
+          allInterceptors, log.commandId, undoCtx, interceptorCtx,
+          userFeatures, undoInterceptorMetadata,
+        )
       }
-      undoInterceptorMetadata = beforeResult.metadataByInterceptor
+
+      await this.invalidateCacheAfterUndo(log, ctx)
+      await this.flushCrudSideEffects(ctx.container)
+    } catch (err) {
+      // Undo failed after claiming the row — release the claim so the action
+      // remains retryable instead of being stranded in the `undoing` state.
+      await service.releaseUndoClaim(log.id).catch(() => {})
+      throw err
     }
-
-    await handler.undo({
-      input: log.commandPayload as Parameters<NonNullable<typeof handler.undo>>[0]['input'],
-      ctx,
-      logEntry: log,
-    })
-    await service.markUndone(log.id, this.buildUndoTraceLog(log, ctx))
-
-    // Run afterUndo command interceptors
-    if (allInterceptors.length) {
-      const undoCtx = { input: log.commandPayload, logEntry: log, undoToken }
-      const interceptorCtx: CommandInterceptorContext = {
-        commandId: log.commandId,
-        auth: ctx.auth ?? null,
-        selectedOrganizationId: ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null,
-        container: ctx.container,
-      }
-      await runCommandInterceptorsAfterUndo(
-        allInterceptors, log.commandId, undoCtx, interceptorCtx,
-        userFeatures, undoInterceptorMetadata,
-      )
-    }
-
-    await this.invalidateCacheAfterUndo(log, ctx)
-    await this.flushCrudSideEffects(ctx.container)
   }
 
   private buildUndoTraceLog(log: ActionLog, ctx: CommandRuntimeContext): ActionLogCreateInput | undefined {


### PR DESCRIPTION
Fixes #2729

## Problem
Two concurrent undo requests holding the same undo token can both pass the existence/state checks and both execute the undo handler. The `done` -> `undone` transition was a non-atomic read-modify-write with no database-level lock or compare-and-set, so depending on the handler's idempotency this could double-restore deleted records, double-revert updates, or otherwise corrupt entity state.

## Root Cause
The undo route reads the log via `findByUndoToken` and checks `executionState === 'done'`, then `CommandBus.undo` re-reads the token, runs `handler.undo(...)`, and only afterward calls `markUndone(...)` to clear the token and flip the state. `markUndone` did a plain read-then-write with no `WHERE executionState = 'done'` guard. There was no gate that atomically claimed the row before the undo handler ran.

## What Changed
- Added an intermediate `'undoing'` value to `ActionLogExecutionState` (text column — no DB schema/enum change required).
- Added `ActionLogService.claimForUndo(id)`: an atomic compare-and-set via `nativeUpdate(ActionLog, { id, executionState: 'done', deletedAt: null }, { executionState: 'undoing' })`, returning `true` only when exactly one row was claimed. This mirrors the existing atomic-CAS pattern in `confirmPasswordReset`.
- Added `ActionLogService.releaseUndoClaim(id)`: reverts `'undoing'` -> `'done'` so a failed undo stays retryable.
- `CommandBus.undo` now claims the row before running any interceptors or the undo handler; the request that loses the claim bails with `Undo token already consumed`. The post-claim work is wrapped in try/catch so the claim is released if the handler fails. Since the undoable-lookup queries filter on `executionState: 'done'`, an in-flight `'undoing'` row is no longer offered as undoable.

## Tests
- `command-bus.undo-toctou.test.ts` (new): claim happens before the handler runs; a lost claim does not invoke the handler or `markUndone`; a failed handler releases the claim. Verified these fail on the pre-fix code.
- `actionLogService.test.ts`: `claimForUndo`/`releaseUndoClaim` issue the guarded CAS and return based on rows affected.
- Updated existing `command-bus.undo-audit.test.ts` and `command-bus.cache.test.ts` mocks to provide the new service methods.
- `yarn typecheck` (all packages), `@open-mercato/shared` commands suite (116 tests) and `@open-mercato/core` audit_logs suite (43 tests) pass.

## Backward Compatibility
- Additive only: new union member on `ActionLogExecutionState` and two new `ActionLogService` methods. No removed fields, signatures, event IDs, DI names, ACL features, or API response shapes. No migration required (column is `text`, no enum/check constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)