### PR TITLE
fix(ai_assistant): align hasRequiredFeatures fallback with canonical wildcard matcher (#2723)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/auth.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/auth.test.ts
@@ -1,4 +1,5 @@
 import { extractApiKeyFromHeaders, hasRequiredFeatures } from '../auth'
+import { hasAllFeatures } from '@open-mercato/shared/lib/auth/featureMatch'
 
 describe('extractApiKeyFromHeaders', () => {
   describe('plain object headers', () => {
@@ -90,6 +91,32 @@ describe('hasRequiredFeatures', () => {
     expect(
       hasRequiredFeatures(['sales.view'], ['customers.*'], false)
     ).toBe(false)
+  })
+
+  it('grants a bare-segment requirement from a prefix wildcard (issue #2723)', () => {
+    expect(
+      hasRequiredFeatures(['entities'], ['entities.*'], false)
+    ).toBe(true)
+  })
+
+  it('matches the canonical matcher for bare-segment requirements with and without rbacService', () => {
+    const rbacService = {
+      hasAllFeatures: jest.fn((required: string[], granted: string[]) =>
+        hasAllFeatures(required, granted)
+      ),
+    }
+
+    const withService = hasRequiredFeatures(
+      ['entities'],
+      ['entities.*'],
+      false,
+      rbacService as any
+    )
+    const withoutService = hasRequiredFeatures(['entities'], ['entities.*'], false)
+
+    expect(withService).toBe(true)
+    expect(withoutService).toBe(true)
+    expect(withService).toBe(withoutService)
   })
 
   it('requires all features (AND logic)', () => {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/auth.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/auth.ts
@@ -1,6 +1,7 @@
 import type { AwilixContainer } from 'awilix'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+import { hasAllFeatures } from '@open-mercato/shared/lib/auth/featureMatch'
 
 /**
  * Successful authentication result.
@@ -118,7 +119,8 @@ export async function authenticateMcpRequest(
  * - Super admin bypass (always returns true)
  * - Direct feature match (e.g., 'customers.view')
  * - Global wildcard ('*' grants all features)
- * - Prefix wildcard (e.g., 'customers.*' grants 'customers.people.view')
+ * - Prefix wildcard (e.g., 'customers.*' grants 'customers.people.view' and the
+ *   bare 'customers' segment itself)
  *
  * @param requiredFeatures - List of features required for access
  * @param userFeatures - List of features the user has
@@ -140,20 +142,12 @@ export function hasRequiredFeatures(
     return rbacService.hasAllFeatures(requiredFeatures, userFeatures)
   }
 
-  // Fallback for cases without rbacService (keeps backward compatibility)
-  return requiredFeatures.every((required) => {
-    if (userFeatures.includes(required)) return true
-    if (userFeatures.includes('*')) return true
-
-    // Check wildcard patterns (e.g., 'customers.*' grants 'customers.people.view')
-    return userFeatures.some((feature) => {
-      if (feature.endsWith('.*')) {
-        const prefix = feature.slice(0, -2)
-        return required.startsWith(prefix + '.')
-      }
-      return false
-    })
-  })
+  // Fallback for cases without rbacService: delegate to the canonical
+  // wildcard-aware matcher so this path stays consistent with
+  // RbacService.hasAllFeatures (which uses the same helper). The previous
+  // bespoke loop rejected a bare-segment requirement (e.g. 'entities')
+  // against an 'entities.*' grant, diverging from the canonical matcher.
+  return hasAllFeatures(requiredFeatures, userFeatures)
 }
 
 /**


### PR DESCRIPTION
Fixes #2723

## Problem
`hasRequiredFeatures` in `packages/ai-assistant/src/modules/ai_assistant/lib/auth.ts` had two code paths that disagreed depending on whether a caller passed `rbacService`. The no-`rbacService` fallback matched a granted `prefix.*` wildcard only against required strings starting with `prefix.`, so it rejected a bare-segment requirement equal to `prefix` (e.g. required `entities` against grant `entities.*`). The canonical shared matcher (`matchFeature` / `hasAllFeatures`) treats `prefix.*` as also matching the exact `prefix`.

## Root Cause
The fallback used a bespoke loop (`required.startsWith(prefix + '.')`) that never handled the bare-segment case, diverging from the canonical `hasAllFeatures` matcher used by `RbacService.hasAllFeatures` and the `rbacService`-passing call sites. This is fail-closed (strictly more restrictive), so it is a correctness/consistency defect, not an access-control bypass — but it produced inconsistent, hard-to-debug denials across the fallback callers (`lib/agent-policy.ts`, `ai-tools/meta-pack.ts`, `lib/pending-action-recheck.ts`, `api/ai/agents/[agentId]/models/route.ts`).

## What Changed
- `auth.ts`: deleted the bespoke fallback loop and delegated to the canonical `hasAllFeatures` from `@open-mercato/shared/lib/auth/featureMatch` (the same helper `RbacService.hasAllFeatures` uses), so both paths behave identically. Updated the JSDoc to note that `prefix.*` also grants the bare `prefix` segment.

## Tests
- `auth.test.ts`: added a regression test asserting `hasRequiredFeatures(['entities'], ['entities.*'], false) === true` (fails on the old implementation, passes after the fix), plus a test asserting parity between the `rbacService` and fallback paths for bare-segment requirements.
- Verified the new regression test fails against the pre-fix `auth.ts` and passes after.
- Full `@open-mercato/ai-assistant` suite: 1178 passed / 81 suites.
- `yarn build:packages` (validates the new import resolves) and `yarn typecheck` pass.

## Backward Compatibility
- No contract surface changes. `hasRequiredFeatures` signature is unchanged.
- The new behavior is a strict superset of the old fallback (the old path was over-restrictive); the `rbacService` path is unchanged. No API fields, event IDs, widget spot IDs, ACL IDs, import paths, or DI names changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)