### PR TITLE
security(ui): harden URL-controlled flash banner against content spoofing (#2721)

### DIFF
--- a/packages/ui/src/backend/FlashMessages.tsx
+++ b/packages/ui/src/backend/FlashMessages.tsx
@@ -11,6 +11,30 @@ const flashKindToAlertStatus: Record<FlashKind, AlertStatus> = {
   info: 'information',
 }
 
+function normalizeFlashKind(value: string | null | undefined): FlashKind {
+  if (value && Object.prototype.hasOwnProperty.call(flashKindToAlertStatus, value)) {
+    return value as FlashKind
+  }
+  return 'success'
+}
+
+// A URL-supplied flash is only trustworthy when the navigation that carried it
+// originated from the same origin (an in-app POST->GET redirect or client-side
+// navigation). Cross-origin links — the phishing/content-spoofing vector — must
+// not be allowed to render attacker-controlled copy inside an authoritative banner.
+function isSameOriginFlashNavigation(): boolean {
+  if (typeof window === 'undefined') return false
+  const referrer = document.referrer
+  // No referrer (direct load, bookmark, or referrer stripped) is ambiguous, not a
+  // cross-origin redirect we can attribute to an attacker page; allow it.
+  if (!referrer) return true
+  try {
+    return new URL(referrer).origin === window.location.origin
+  } catch {
+    return false
+  }
+}
+
 // Programmatic API to show a flash message without navigation.
 // Consumers can import { flash } and call flash('text', 'error').
 export function flash(message: string, type: FlashKind = 'info') {
@@ -125,12 +149,17 @@ function FlashMessagesInner() {
     if (typeof window === 'undefined') return
     const url = new URL(window.location.href)
     const message = url.searchParams.get('flash')
-    const type = (url.searchParams.get('type') as FlashKind | null) || 'success'
+    const type = normalizeFlashKind(url.searchParams.get('type'))
     if (message) {
-      showFlash(message, type)
+      // Always strip the params so a spoofed link does not linger in history,
+      // but only render the banner for same-origin navigations.
+      const trusted = isSameOriginFlashNavigation()
       url.searchParams.delete('flash')
       url.searchParams.delete('type')
       window.history.replaceState({}, '', url.toString())
+      if (trusted) {
+        showFlash(message, type)
+      }
     }
   }, [locationKey, showFlash])
 

--- a/packages/ui/src/backend/__tests__/FlashMessages.test.tsx
+++ b/packages/ui/src/backend/__tests__/FlashMessages.test.tsx
@@ -3,16 +3,25 @@ import { act, screen } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { FlashMessages, flash } from '../FlashMessages'
 
+function setReferrer(value: string) {
+  Object.defineProperty(document, 'referrer', {
+    configurable: true,
+    value,
+  })
+}
+
 describe('FlashMessages', () => {
   beforeEach(() => {
     jest.useFakeTimers()
     window.history.replaceState({}, '', 'http://localhost/backend')
+    setReferrer('')
   })
 
   afterEach(() => {
     jest.runOnlyPendingTimers()
     jest.useRealTimers()
     window.history.replaceState({}, '', 'http://localhost/backend')
+    setReferrer('')
   })
 
   it('auto-dismisses URL-based flashes after stripping query params', () => {
@@ -28,6 +37,44 @@ describe('FlashMessages', () => {
     })
 
     expect(screen.queryByText('Saved')).not.toBeInTheDocument()
+  })
+
+  it('honors same-origin referrer flashes', () => {
+    setReferrer('http://localhost/backend/checkout/templates')
+    window.history.replaceState({}, '', 'http://localhost/backend/checkout/pay-links?flash=Saved&type=success')
+
+    renderWithProviders(<FlashMessages />)
+
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+    expect(window.location.search).toBe('')
+  })
+
+  it('suppresses cross-origin referrer flashes but still strips the params', () => {
+    setReferrer('https://attacker.example.com/phish')
+    window.history.replaceState(
+      {},
+      '',
+      'http://localhost/backend/dashboard?flash=Your+account+was+suspended&type=error',
+    )
+
+    renderWithProviders(<FlashMessages />)
+
+    expect(screen.queryByText('Your account was suspended')).not.toBeInTheDocument()
+    expect(window.location.search).toBe('')
+  })
+
+  it('falls back to a safe kind when the type param is not an allowed FlashKind', () => {
+    window.history.replaceState(
+      {},
+      '',
+      'http://localhost/backend/dashboard?flash=Saved&type=javascript',
+    )
+
+    renderWithProviders(<FlashMessages />)
+
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+    const badge = document.querySelector('[data-slot="alert-icon-badge"]')
+    expect(badge?.getAttribute('data-status')).toBe('success')
   })
 
   it('auto-dismisses programmatic flashes', () => {


### PR DESCRIPTION
Fixes #2721

## Problem
The backend flash banner read `flash` (message text) and `type` (severity) straight from `window.location.search`. `type` was cast to `FlashKind` with no runtime validation and `flash` was rendered as arbitrary free text. Because the handler immediately strips both params via `history.replaceState`, an attacker who got an authenticated user to click a crafted cross-origin link (e.g. `?flash=Your+account+was+suspended…&type=error`) could display attacker-controlled copy inside an authoritative-looking banner with a clean URL — a convincing phishing/social-engineering surface (not XSS; React escapes the text).

## Root Cause
`FlashMessagesInner` honored the URL flash params for any navigation, including cross-origin entry, and never validated `type` against the `FlashKind` allowlist.

## What Changed
- `packages/ui/src/backend/FlashMessages.tsx`:
  - `normalizeFlashKind(...)` validates `type` against the `FlashKind` allowlist (`success`/`error`/`warning`/`info`) and falls back to the prior default (`success`) instead of casting an arbitrary string.
  - `isSameOriginFlashNavigation()` only renders a URL-supplied flash when `document.referrer` is same-origin (or absent — direct load/bookmark). Cross-origin referrers (the phishing vector) are suppressed. Params are still always stripped from history so a spoofed link does not linger.

Legitimate flows are unaffected: in-app POST→GET redirects and Next.js client navigations (`router.push`, same-origin `window.location`) load the document same-origin, so the referrer is same-origin or empty.

## Tests
- `packages/ui/src/backend/__tests__/FlashMessages.test.tsx`: added regression coverage for same-origin (honored), cross-origin (suppressed, params still stripped), and invalid `type` (safe `success` fallback). Existing flash tests retained.
- `yarn workspace @open-mercato/ui test` — 174 suites / 1509 tests pass.
- `yarn workspace @open-mercato/ui typecheck` — passes.
- `yarn build:packages` / `yarn generate` — pass.

## Backward Compatibility
No contract surface changes. `FlashKind`, the exported `flash()` API, and `FlashMessages` export are unchanged; the new helpers are module-private. The default `type` remains `success`, matching prior behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)