### PR TITLE
security(shared/encryption): reject forged ciphertext shapes on encrypt (#2720)

### DIFF
--- a/packages/shared/src/lib/encryption/__tests__/tenantDataEncryptionService.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/tenantDataEncryptionService.test.ts
@@ -1,4 +1,4 @@
-import { encryptWithAesGcm } from '../aes'
+import { decryptWithAesGcm, encryptWithAesGcm, hashForLookup } from '../aes'
 import {
   TenantDataEncryptionService,
   parseDecryptedFieldValue,
@@ -126,6 +126,73 @@ describe('TenantDataEncryptionService.decryptFields (issue #1734)', () => {
     )
     expect(out.display_name).toBe('true')
     expect(out.description).toBe('null')
+  })
+})
+
+describe('TenantDataEncryptionService.encryptFields (issue #2720)', () => {
+  function makeService() {
+    type Anything = Record<string, unknown>
+    const service = new TenantDataEncryptionService({} as never) as unknown as {
+      encryptFields: (
+        obj: Anything,
+        fields: { field: string; hashField?: string | null }[],
+        dek: { key: string },
+      ) => Anything
+    }
+    return service
+  }
+
+  it('encrypts a forged ciphertext-shaped value instead of storing it verbatim', () => {
+    const service = makeService()
+    const forged = 'aaaa:bbbb:cccc:v1'
+    const out = service.encryptFields(
+      { email: forged },
+      [{ field: 'email', hashField: 'email_hash' }],
+      { key: fixedKey } as never,
+    )
+    expect(out.email).not.toBe(forged)
+    expect(typeof out.email).toBe('string')
+    // The stored value must be real ciphertext that decrypts back to the forged input.
+    expect(decryptWithAesGcm(out.email as string, fixedKey)).toBe(forged)
+    // The lookup hash must be generated (the bypass previously skipped it).
+    expect(out.email_hash).toBe(hashForLookup(forged))
+  })
+
+  it('does not re-encrypt a value that genuinely decrypts under the DEK', () => {
+    const service = makeService()
+    const real = encryptWithAesGcm('mail@example.com', fixedKey).value as string
+    const out = service.encryptFields(
+      { email: real },
+      [{ field: 'email' }],
+      { key: fixedKey } as never,
+    )
+    expect(out.email).toBe(real)
+  })
+
+  it('encrypts a structurally-valid payload that was sealed with a different key', () => {
+    const service = makeService()
+    const otherKey = Buffer.alloc(32, 2).toString('base64')
+    const sealedElsewhere = encryptWithAesGcm('secret', otherKey).value as string
+    const out = service.encryptFields(
+      { email: sealedElsewhere },
+      [{ field: 'email' }],
+      { key: fixedKey } as never,
+    )
+    expect(out.email).not.toBe(sealedElsewhere)
+    expect(decryptWithAesGcm(out.email as string, fixedKey)).toBe(sealedElsewhere)
+  })
+
+  it('encrypts plaintext that happens to look like a v1 payload', () => {
+    const service = makeService()
+    const plaintext = 'user:supplied:colon:v1'
+    const out = service.encryptFields(
+      { email: plaintext },
+      [{ field: 'email', hashField: 'email_hash' }],
+      { key: fixedKey } as never,
+    )
+    expect(out.email).not.toBe(plaintext)
+    expect(decryptWithAesGcm(out.email as string, fixedKey)).toBe(plaintext)
+    expect(out.email_hash).toBe(hashForLookup(plaintext))
   })
 })
 

--- a/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
+++ b/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
@@ -86,10 +86,20 @@ export function parseDecryptedFieldValue(decrypted: string): unknown {
   }
 }
 
-function isEncryptedPayload(value: unknown): boolean {
+/**
+ * A value is only treated as "already encrypted" when it actually decrypts
+ * under the tenant DEK — i.e. the AES-GCM authentication tag verifies. A purely
+ * structural `<iv>:<ct>:<tag>:v1` shape check is forgeable: attacker-controlled
+ * field values (e.g. their own profile email/phone) could impersonate ciphertext
+ * to skip encryption-at-rest and the lookup hash entirely (issue #2720). Binding
+ * the check to a successful authenticated decrypt makes forgery infeasible, so a
+ * fake payload simply gets encrypted like any other plaintext.
+ */
+function isEncryptedWithDek(value: unknown, dek: TenantDek): boolean {
   if (typeof value !== 'string') return false
   const parts = value.split(':')
-  return parts.length === 4 && parts[3] === 'v1'
+  if (parts.length !== 4 || parts[3] !== 'v1') return false
+  return decryptWithAesGcm(value, dek.key) !== null
 }
 
 export class TenantDataEncryptionService {
@@ -260,8 +270,10 @@ export class TenantDataEncryptionService {
       if (!key) continue
       const value = clone[key]
       if (value === null || value === undefined) continue
-       // Avoid double-encrypting already encrypted payloads
-      if (isEncryptedPayload(value)) continue
+      // Avoid double-encrypting payloads that genuinely decrypt under this DEK.
+      // A forged ciphertext-shaped string fails this check and is encrypted as
+      // plaintext, closing the encryption-at-rest bypass (issue #2720).
+      if (isEncryptedWithDek(value, dek)) continue
       const serialized = typeof value === 'string' ? value : JSON.stringify(value)
       const payload = encryptWithAesGcm(serialized, dek.key)
       clone[key] = payload.value


### PR DESCRIPTION
Fixes #2720

## Problem
The encryption layer detected "already encrypted" values with a purely structural check: any `<iv>:<ct>:<tag>:v1` string was treated as ciphertext. There was no integrity marker, so attacker-controlled field values could impersonate ciphertext, skip encryption entirely, and be stored verbatim in columns meant to be encrypted at rest. The associated `hashField` (used for lookup-by-email/phone) was also skipped.

## Root Cause
`isEncryptedPayload` in `tenantDataEncryptionService.ts` returned `true` for any 4-segment colon-separated string ending in `v1`. In `encryptFields`, a matching value caused the loop to `continue`, so a forged payload like `aaaa:bbbb:cccc:v1` was written to the DB without encryption and without a lookup hash.

## What Changed
- Replaced the forgeable structural check with `isEncryptedWithDek(value, dek)`, which treats a value as already-encrypted **only** when it actually decrypts under the tenant DEK (AES-GCM auth tag verifies).
- A value that does not genuinely decrypt (forged shape, plaintext that happens to look like a `v1` payload, or ciphertext sealed with a different key) is now encrypted as plaintext, restoring encryption-at-rest and the `hashField`.
- Genuine ciphertext under the current DEK is still skipped (no double-encryption).

## Tests
- New `encryptFields` regression suite (issue #2720):
  - forged `aaaa:bbbb:cccc:v1` is encrypted and its lookup hash generated
  - a genuinely-encrypted value is not re-encrypted
  - a payload sealed with a different key is re-encrypted under the current DEK
  - plaintext shaped like `user:supplied:colon:v1` is encrypted
- 3 of the 4 new tests fail against the pre-fix source and pass after the fix.
- Full `@open-mercato/shared` suite: 1185 passing; typecheck clean.

## Backward Compatibility
- `isEncryptedPayload` was module-private (never exported) — renaming it to `isEncryptedWithDek` touches no contract surface.
- No exported signatures, API response fields, event/DI/ACL IDs, or import paths changed.
- On read, a previously-forged value now round-trips as ciphertext rather than passing through as raw plaintext — no behavioral regression for legitimate data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)