### PR TITLE
security(api): ignore File-typed multipart tenantId field (#2722)

### DIFF
--- a/apps/mercato/src/__tests__/extract-tenant-candidate.test.ts
+++ b/apps/mercato/src/__tests__/extract-tenant-candidate.test.ts
@@ -1,0 +1,81 @@
+import { NextRequest } from 'next/server'
+
+jest.mock('@/bootstrap', () => ({
+  bootstrap: jest.fn(),
+  isBootstrapped: jest.fn(() => true),
+}))
+
+jest.mock('@/.mercato/generated/api-routes.generated', () => ({
+  apiRoutes: [],
+}))
+
+jest.mock('@/.mercato/generated/backend-routes.generated', () => ({
+  backendRoutes: [],
+}))
+
+import { extractTenantCandidate } from '@/app/api/[...slug]/route'
+
+function buildMultipartRequest(formData: FormData): NextRequest {
+  return new NextRequest('http://localhost:3001/api/example/test', {
+    method: 'POST',
+    body: formData,
+  })
+}
+
+describe('extractTenantCandidate', () => {
+  it('ignores a File-typed tenantId field instead of coercing its filename (security: issue #2722)', async () => {
+    const attackerTenantUuid = '11111111-1111-1111-1111-111111111111'
+    const form = new FormData()
+    form.append('tenantId', new File(['x'], attackerTenantUuid))
+
+    const candidate = await extractTenantCandidate(buildMultipartRequest(form))
+
+    expect(candidate).toBeUndefined()
+  })
+
+  it('still returns a string tenantId multipart field', async () => {
+    const tenantId = '22222222-2222-2222-2222-222222222222'
+    const form = new FormData()
+    form.append('tenantId', tenantId)
+
+    const candidate = await extractTenantCandidate(buildMultipartRequest(form))
+
+    expect(candidate).toBe(tenantId)
+  })
+
+  it('returns undefined when no tenantId multipart field is present', async () => {
+    const form = new FormData()
+    form.append('name', 'example')
+
+    const candidate = await extractTenantCandidate(buildMultipartRequest(form))
+
+    expect(candidate).toBeUndefined()
+  })
+
+  it('still returns a string tenantId from a urlencoded body', async () => {
+    const tenantId = '33333333-3333-3333-3333-333333333333'
+    const request = new NextRequest('http://localhost:3001/api/example/test', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: `tenantId=${tenantId}`,
+    })
+
+    const candidate = await extractTenantCandidate(request)
+
+    expect(candidate).toBe(tenantId)
+  })
+
+  it('prefers the query-string tenantId over the body', async () => {
+    const queryTenant = '44444444-4444-4444-4444-444444444444'
+    const form = new FormData()
+    form.append('tenantId', new File(['x'], 'attacker-filename'))
+    const request = new NextRequest(`http://localhost:3001/api/example/test?tenantId=${queryTenant}`, {
+      method: 'POST',
+      body: form,
+    })
+
+    const candidate = await extractTenantCandidate(request)
+
+    expect(candidate).toBe(queryTenant)
+  })
+})

--- a/apps/mercato/src/app/api/[...slug]/route.ts
+++ b/apps/mercato/src/app/api/[...slug]/route.ts
@@ -236,7 +236,7 @@ function sanitizeTenantCandidate(candidate: unknown): unknown {
   return candidate
 }
 
-async function extractTenantCandidate(req: NextRequest): Promise<unknown> {
+export async function extractTenantCandidate(req: NextRequest): Promise<unknown> {
   const tenantParams = req.nextUrl?.searchParams?.getAll?.('tenantId') ?? []
   if (tenantParams.length > 0) {
     return tenantParams[tenantParams.length - 1]
@@ -261,7 +261,7 @@ async function extractTenantCandidate(req: NextRequest): Promise<unknown> {
       const form = await req.clone().formData()
       if (form.has('tenantId')) {
         const value = form.get('tenantId')
-        if (value instanceof File) return value.name
+        if (value instanceof File) return undefined
         return value
       }
     }

--- a/packages/create-app/template/src/app/api/[...slug]/route.ts
+++ b/packages/create-app/template/src/app/api/[...slug]/route.ts
@@ -236,7 +236,7 @@ function sanitizeTenantCandidate(candidate: unknown): unknown {
   return candidate
 }
 
-async function extractTenantCandidate(req: NextRequest): Promise<unknown> {
+export async function extractTenantCandidate(req: NextRequest): Promise<unknown> {
   const tenantParams = req.nextUrl?.searchParams?.getAll?.('tenantId') ?? []
   if (tenantParams.length > 0) {
     return tenantParams[tenantParams.length - 1]
@@ -261,7 +261,7 @@ async function extractTenantCandidate(req: NextRequest): Promise<unknown> {
       const form = await req.clone().formData()
       if (form.has('tenantId')) {
         const value = form.get('tenantId')
-        if (value instanceof File) return value.name
+        if (value instanceof File) return undefined
         return value
       }
     }


### PR DESCRIPTION
Fixes #2722

## Problem
- When the central API dispatcher (`apps/mercato/src/app/api/[...slug]/route.ts`) parses a `multipart/form-data` or `application/x-www-form-urlencoded` request, it extracts the `tenantId` form field to validate tenant selection. If that field arrived as a `File` rather than a string, the dispatcher returned the uploaded file's `name` as the tenant-id candidate. A filename is fully attacker-controlled and is never a valid tenant identifier.

## Root Cause
- `extractTenantCandidate` had `if (value instanceof File) return value.name`, coercing an attacker-controlled filename into the tenant-id candidate. That value flowed into `sanitizeTenantCandidate` → `normalizeTenantId` → `enforceTenantSelection`, masking the real (missing) `tenantId` field and weakening the tenant-scoping guard's intent (an attacker could name the file with their own actor-tenant UUID to make `tenantDiffers` false). Cross-tenant access stayed blocked downstream, but the branch was logically wrong and should never be reachable.

## What Changed
- `extractTenantCandidate` now returns `undefined` for a File-typed `tenantId` field, so the malformed input is ignored instead of coerced.
- Applied the identical fix to the synced standalone template copy (`packages/create-app/template/src/app/api/[...slug]/route.ts`) to keep both in sync.
- Exported `extractTenantCandidate` (additive) so it can be unit-tested directly.

## Tests
- New `apps/mercato/src/__tests__/extract-tenant-candidate.test.ts` (5 cases): a File-typed `tenantId` is ignored (the regression case, fails before the fix), string multipart/urlencoded `tenantId` still pass through, missing field returns `undefined`, and query-string `tenantId` still takes precedence over the body.
- Verified the regression test fails before the fix and passes after.
- Ran the existing `api-authorization` suite (no regressions), full `yarn generate`, `yarn build:packages`, and `yarn typecheck` (app) — all green.

## Backward Compatibility
- No contract surface removed or broken. Behavior change is the security fix itself (File-typed `tenantId` no longer coerced). The only export change is additive (`extractTenantCandidate` is now exported).