### PR TITLE
security(ai_assistant): enforce Code Mode mutation cap on observed HTTP method (#2724)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/codemode-tools.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/codemode-tools.test.ts
@@ -1,8 +1,13 @@
 import type { McpToolContext } from '../types'
 import { getApiEndpoints } from '../api-endpoint-index'
+import { fetchWithTimeout } from '@open-mercato/shared/lib/http/fetchWithTimeout'
 import {
   authorizeCodeModeApiRequest,
+  CODE_MODE_MAX_API_CALLS,
+  CODE_MODE_MAX_MUTATION_CALLS,
   CODE_MODE_REQUIRED_FEATURES,
+  createApiRequestFn,
+  isUnsafeHttpMethod,
   matchApiEndpointPath,
 } from '../codemode-tools'
 
@@ -11,7 +16,46 @@ jest.mock('../api-endpoint-index', () => ({
   getRawOpenApiSpec: jest.fn(),
 }))
 
+jest.mock('@open-mercato/shared/lib/http/fetchWithTimeout', () => ({
+  fetchWithTimeout: jest.fn(),
+  resolveTimeoutMs: jest.fn(() => 30000),
+}))
+
 const mockedGetApiEndpoints = jest.mocked(getApiEndpoints)
+const mockedFetchWithTimeout = jest.mocked(fetchWithTimeout)
+
+function okResponse() {
+  return {
+    ok: true,
+    status: 200,
+    text: jest.fn().mockResolvedValue('{}'),
+  } as unknown as Response
+}
+
+/**
+ * Replicate the execute() handler's per-run counters so the regression test
+ * exercises the same accounting that gates real api.request() calls.
+ */
+function createCountingOnCall() {
+  let apiCallCount = 0
+  let mutationCallCount = 0
+  const onCall = (normalizedMethod: string) => {
+    apiCallCount++
+    if (apiCallCount > CODE_MODE_MAX_API_CALLS) {
+      throw new Error(`API call limit exceeded (max ${CODE_MODE_MAX_API_CALLS})`)
+    }
+    if (isUnsafeHttpMethod(normalizedMethod)) {
+      mutationCallCount++
+      if (mutationCallCount > CODE_MODE_MAX_MUTATION_CALLS) {
+        throw new Error(`Mutation API call limit exceeded (max ${CODE_MODE_MAX_MUTATION_CALLS})`)
+      }
+    }
+  }
+  return {
+    onCall,
+    counts: () => ({ apiCallCount, mutationCallCount }),
+  }
+}
 
 type MockRbacService = {
   hasAllFeatures: jest.Mock<boolean, [string[], string[]]>
@@ -240,5 +284,89 @@ describe('authorizeCodeModeApiRequest', () => {
         deprecated: false,
       },
     })
+  })
+})
+
+describe('mutation call cap (issue #2724)', () => {
+  beforeEach(() => {
+    mockedGetApiEndpoints.mockReset()
+    mockedFetchWithTimeout.mockReset()
+    mockedFetchWithTimeout.mockResolvedValue(okResponse())
+    // Documented, feature-authorized POST endpoint so RBAC always allows the call.
+    mockedGetApiEndpoints.mockResolvedValue([
+      {
+        id: 'create_company',
+        operationId: 'create_company',
+        method: 'POST',
+        path: '/api/customers/companies',
+        summary: '',
+        description: '',
+        tags: [],
+        requiredFeatures: ['customers.companies.create'],
+        parameters: [],
+        requestBodySchema: null,
+        deprecated: false,
+      },
+    ])
+  })
+
+  function authorizedContext(): McpToolContext {
+    return createContext({
+      userFeatures: ['ai_assistant.view', 'customers.companies.create'],
+    })
+  }
+
+  it('counts a dynamically-built POST method against the mutation cap', async () => {
+    const { onCall, counts } = createCountingOnCall()
+    const apiRequest = createApiRequestFn(authorizedContext(), onCall)
+
+    // The method string is built at runtime — the old static regex never saw it.
+    const dynamicMethod = 'PO' + 'ST'
+    await apiRequest({ method: dynamicMethod, path: '/api/customers/companies', body: {} })
+
+    expect(counts()).toEqual({ apiCallCount: 1, mutationCallCount: 1 })
+  })
+
+  it('refuses once the dynamically-built mutation cap is exceeded', async () => {
+    const { onCall } = createCountingOnCall()
+    const apiRequest = createApiRequestFn(authorizedContext(), onCall)
+
+    const dynamicMethod = ['P', 'O', 'S', 'T'].join('')
+    for (let index = 0; index < CODE_MODE_MAX_MUTATION_CALLS; index++) {
+      await apiRequest({ method: dynamicMethod, path: '/api/customers/companies', body: {} })
+    }
+
+    await expect(
+      apiRequest({ method: dynamicMethod, path: '/api/customers/companies', body: {} })
+    ).rejects.toThrow(`Mutation API call limit exceeded (max ${CODE_MODE_MAX_MUTATION_CALLS})`)
+
+    // Authorized mutations actually hit fetch up to the cap; the cap throws before fetch on the overflow call.
+    expect(mockedFetchWithTimeout).toHaveBeenCalledTimes(CODE_MODE_MAX_MUTATION_CALLS)
+  })
+
+  it('does not charge GET reads against the mutation cap', async () => {
+    mockedGetApiEndpoints.mockResolvedValue([
+      {
+        id: 'list_companies',
+        operationId: 'list_companies',
+        method: 'GET',
+        path: '/api/customers/companies',
+        summary: '',
+        description: '',
+        tags: [],
+        requiredFeatures: [],
+        parameters: [],
+        requestBodySchema: null,
+        deprecated: false,
+      },
+    ])
+    const { onCall, counts } = createCountingOnCall()
+    const apiRequest = createApiRequestFn(createContext(), onCall)
+
+    for (let index = 0; index < CODE_MODE_MAX_MUTATION_CALLS + 5; index++) {
+      await apiRequest({ method: 'get', path: '/api/customers/companies' })
+    }
+
+    expect(counts()).toEqual({ apiCallCount: CODE_MODE_MAX_MUTATION_CALLS + 5, mutationCallCount: 0 })
   })
 })

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/codemode-tools.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/codemode-tools.ts
@@ -550,22 +550,10 @@ function buildEntitySchemas(graph: EntityGraph) {
   })
 }
 
-/**
- * Detect mutation HTTP methods in code via static analysis.
- * Returns which methods were found (POST, PUT, PATCH, DELETE).
- */
-function detectMutationInCode(code: string): { hasMutation: boolean; methods: string[] } {
-  const methods: string[] = []
-  const pattern = /method:\s*['"](\w+)['"]/gi
-  let match
-  while ((match = pattern.exec(code)) !== null) {
-    const method = match[1].toUpperCase()
-    if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
-      methods.push(method)
-    }
-  }
-  return { hasMutation: methods.length > 0, methods }
-}
+/** Maximum api.request() calls allowed per execute() run, regardless of method. */
+export const CODE_MODE_MAX_API_CALLS = 50
+/** Maximum mutation (non-GET/HEAD/OPTIONS) api.request() calls allowed per execute() run. */
+export const CODE_MODE_MAX_MUTATION_CALLS = 20
 
 /**
  * Load and register the two Code Mode tools.
@@ -701,18 +689,23 @@ RULES: For FIND/LIST → GET only (1 call). For UPDATE → PUT to collection pat
           }
         }
 
-        // Detect mutations via static analysis — cap API calls for safety
-        const mutationInfo = detectMutationInCode(input.code)
-        const maxApiCalls = mutationInfo.hasMutation ? 20 : 50
-        if (mutationInfo.hasMutation) {
-          console.error(`[AI Usage] execute: MUTATION DETECTED (${mutationInfo.methods.join(',')}) — capping API calls to ${maxApiCalls}`)
-        }
+        // Cap API calls for safety. The mutation cap is enforced against the
+        // actually-observed HTTP method, not a static scan of the source — so a
+        // dynamically-built method (e.g. 'PO' + 'ST') can never escape it.
+        const maxApiCalls = CODE_MODE_MAX_API_CALLS
         let apiCallCount = 0
+        let mutationCallCount = 0
 
-        const apiRequestFn = createApiRequestFn(ctx, () => {
+        const apiRequestFn = createApiRequestFn(ctx, (normalizedMethod) => {
           apiCallCount++
           if (apiCallCount > maxApiCalls) {
             throw new Error(`API call limit exceeded (max ${maxApiCalls})`)
+          }
+          if (isUnsafeHttpMethod(normalizedMethod)) {
+            mutationCallCount++
+            if (mutationCallCount > CODE_MODE_MAX_MUTATION_CALLS) {
+              throw new Error(`Mutation API call limit exceeded (max ${CODE_MODE_MAX_MUTATION_CALLS})`)
+            }
           }
         })
 
@@ -761,9 +754,9 @@ RULES: For FIND/LIST → GET only (1 call). For UPDATE → PUT to collection pat
 /**
  * Create the api.request() function for the execute sandbox.
  */
-function createApiRequestFn(
+export function createApiRequestFn(
   ctx: McpToolContext,
-  onCall: () => void
+  onCall: (normalizedMethod: string) => void
 ): (params: {
   method: string
   path: string
@@ -777,11 +770,10 @@ function createApiRequestFn(
     'http://localhost:3000'
 
   return async (params) => {
-    onCall()
-
     const { method, path, query, body } = params
     const callStart = Date.now()
-    const normalizedMethod = method.toUpperCase()
+    const normalizedMethod = String(method ?? '').toUpperCase()
+    onCall(normalizedMethod)
     const apiPath = normalizeApiRequestPath(path)
     const authorization = await authorizeCodeModeApiRequest(ctx, normalizedMethod, apiPath)
 
@@ -995,7 +987,7 @@ function isPathParameterSegment(segment: string): boolean {
   )
 }
 
-function isUnsafeHttpMethod(method: string): boolean {
+export function isUnsafeHttpMethod(method: string): boolean {
   return !['GET', 'HEAD', 'OPTIONS'].includes(method.toUpperCase())
 }
 


### PR DESCRIPTION
Fixes #2724

## Problem
The Code Mode `execute` tool decided its per-execution API-call cap by scanning AI-generated JavaScript for mutation HTTP methods with a static regex (`detectMutationInCode`, `/method:\s*['"](\w+)['"]/gi`). The regex only matched method names written as string literals directly after `method:`, so code that built the method indirectly — e.g. `const m = 'PO' + 'ST'; api.request({ method: m, ... })` or `opts.method = 'POST'` — was treated as read-only and granted the higher 50-call budget instead of the 20-call mutation budget, doubling the allowed write calls per execution.

## Root Cause
Mutation detection on arbitrary user-supplied JS via static regex is unreliable. The cap (a defense-in-depth abuse-rate control) was sized from source-text analysis rather than the actually-executed request.

## What Changed
- Removed `detectMutationInCode` (static regex sizing).
- `execute()` now keeps an overall per-run cap of 50 calls and adds a separate mutation counter that increments whenever the **actually-observed** normalized method is non-GET/HEAD/OPTIONS, refusing once it exceeds 20 — independent of how the method string was constructed.
- `createApiRequestFn`'s `onCall` callback now receives the normalized method and runs after normalization; added a `String(method ?? '')` guard for non-string inputs.
- Exposed `CODE_MODE_MAX_API_CALLS`, `CODE_MODE_MAX_MUTATION_CALLS`, `createApiRequestFn`, and `isUnsafeHttpMethod` for testability (internal `lib/` symbols).
- Per-endpoint RBAC (`authorizeCodeModeApiRequest`) is unchanged and still runs on every call.

## Tests
- New regression tests in `codemode-tools.test.ts` proving a dynamically-built `POST` (`'PO' + 'ST'` / `['P','O','S','T'].join('')`) is counted against the mutation cap and refused at >20, and that GET reads never charge the mutation counter.
- `yarn workspace @open-mercato/ai-assistant test` — 1179 passed.
- `yarn build:packages` — OK.
- `turbo run typecheck --force` — all 21 packages pass.

## Backward Compatibility
No contract surface changes. Only additive exports of internal `lib/` symbols; the removed `detectMutationInCode` was module-private and unexported. No API routes, event IDs, DI names, ACL IDs, or import paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)