### PR TITLE
security(shared/encryption): redact derived-key fallback secret in banner (#2719)

### DIFF
--- a/packages/shared/src/lib/encryption/__tests__/kms.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/kms.test.ts
@@ -1,4 +1,5 @@
-import { createKmsService, HashicorpVaultKmsService } from '../kms'
+import crypto from 'node:crypto'
+import { buildDerivedKeyFallbackBannerLines, createKmsService, HashicorpVaultKmsService } from '../kms'
 
 const originalEnv = { ...process.env }
 
@@ -65,6 +66,37 @@ describe('kms timeout handling', () => {
 
     expect(service.isHealthy()).toBe(false)
     expect(dek).toBeNull()
+  })
+
+  it('never prints the explicit fallback secret verbatim in the banner, regardless of NODE_ENV', () => {
+    const secret = 'super-secret-tenant-encryption-key'
+    for (const nodeEnv of ['development', 'staging', 'preview', 'PRODUCTION', 'production', undefined]) {
+      if (nodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = nodeEnv
+
+      const lines = buildDerivedKeyFallbackBannerLines({
+        secret,
+        source: 'explicit',
+        envName: 'TENANT_DATA_ENCRYPTION_FALLBACK_KEY',
+      })
+      const rendered = lines.join('\n')
+
+      expect(rendered).not.toContain(secret)
+      expect(rendered).toContain('Source: TENANT_DATA_ENCRYPTION_FALLBACK_KEY')
+      const expectedFingerprint = crypto.createHash('sha256').update(secret, 'utf8').digest('hex').slice(0, 16)
+      expect(rendered).toContain(`Secret fingerprint (sha256, truncated): ${expectedFingerprint}`)
+    }
+  })
+
+  it('does not echo the dev default secret verbatim in the banner either', () => {
+    const lines = buildDerivedKeyFallbackBannerLines({
+      secret: 'om-dev-tenant-encryption',
+      source: 'dev-default',
+      envName: 'DEV_DEFAULT',
+    })
+    const rendered = lines.join('\n')
+    expect(rendered).not.toContain('om-dev-tenant-encryption')
+    expect(rendered).toContain('Source: dev default secret (do NOT use in production)')
   })
 
   it('requires an explicit opt-in before using the dev default derived key', async () => {

--- a/packages/shared/src/lib/encryption/kms.ts
+++ b/packages/shared/src/lib/encryption/kms.ts
@@ -302,6 +302,21 @@ export class HashicorpVaultKmsService implements KmsService {
 
 let loggedDerivedKeyFallbackBanner = false
 
+function fingerprintSecret(secret: string): string {
+  return crypto.createHash('sha256').update(secret, 'utf8').digest('hex').slice(0, 16)
+}
+
+export function buildDerivedKeyFallbackBannerLines(opts: DerivedSecret): string[] {
+  const sourceLine =
+    opts.source === 'explicit' ? `Source: ${opts.envName}` : 'Source: dev default secret (do NOT use in production)'
+  return [
+    '🚨 Using derived tenant encryption keys (Vault unavailable / no DEK)',
+    sourceLine,
+    `Secret fingerprint (sha256, truncated): ${fingerprintSecret(opts.secret)}`,
+    'Persist this secret securely. Without it, encrypted tenant data cannot be recovered after restart.',
+  ]
+}
+
 function logDerivedKeyFallbackBanner(opts: DerivedSecret): void {
   if (process.env.NODE_ENV === 'test' || loggedDerivedKeyFallbackBanner) return
   loggedDerivedKeyFallbackBanner = true
@@ -310,15 +325,7 @@ function logDerivedKeyFallbackBanner(opts: DerivedSecret): void {
   const reset = '\x1b[0m'
   const width = 110
   const border = `${redBg}${white}${'━'.repeat(width)}${reset}`
-  const isProduction = process.env.NODE_ENV === 'production'
-  const sourceLine =
-    opts.source === 'explicit' ? `Source: ${opts.envName}` : 'Source: dev default secret (do NOT use in production)'
-  const body = [
-    '🚨 Using derived tenant encryption keys (Vault unavailable / no DEK)',
-    sourceLine,
-    isProduction ? 'Secret: [redacted in production]' : `Secret: ${opts.secret}`,
-    'Persist this secret securely. Without it, encrypted tenant data cannot be recovered after restart.',
-  ]
+  const body = buildDerivedKeyFallbackBannerLines(opts)
   console.warn(border)
   for (const line of body) {
     const padded = line.padEnd(width - 2, ' ')


### PR DESCRIPTION
Fixes #2719

## Problem
- The KMS derived-key fallback banner wrote the literal tenant encryption master secret to `console.warn` in every environment except production. When the fallback secret came from an operator env var (`TENANT_DATA_ENCRYPTION_FALLBACK_KEY` / `TENANT_DATA_ENCRYPTION_KEY`), the real secret used to derive every tenant DEK landed in stdout/stderr and any durable log aggregator (Datadog, ELK, CloudWatch).

## Root Cause
- `logDerivedKeyFallbackBanner` in `packages/shared/src/lib/encryption/kms.ts` printed `Secret: ${opts.secret}` and only redacted when `process.env.NODE_ENV === 'production'`. That exact-string guard skipped redaction in staging/QA/preview and any case-variant or misconfigured `NODE_ENV`.

## What Changed
- Extracted a pure, exported `buildDerivedKeyFallbackBannerLines(opts)` helper.
- The banner now **always** redacts the secret regardless of `NODE_ENV` and instead logs a truncated SHA-256 fingerprint (`Secret fingerprint (sha256, truncated): <16 hex>`), so operators can still verify which secret is active without exposing it.
- Removed the brittle `NODE_ENV === 'production'` redaction branch.

## Tests
- Added unit tests in `packages/shared/src/lib/encryption/__tests__/kms.test.ts`:
  - asserts the explicit fallback secret never appears verbatim across `development`/`staging`/`preview`/`production`/case-variant/unset `NODE_ENV`, and that the expected fingerprint is present.
  - asserts the dev-default secret is likewise never echoed verbatim.
- Verified red-before-fix (the secret-leak assertions fail on the original code), green after.
- `yarn workspace @open-mercato/shared test -- kms.test.ts` → 6 passed; `yarn workspace @open-mercato/shared typecheck` → clean.

## Backward Compatibility
- No contract-surface changes. The only modification is operator-facing banner log text (not an i18n string, not an API/event/DI/ACL surface). `buildDerivedKeyFallbackBannerLines` is a new additive export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)