### PR TITLE
security(shared/auth): fingerprint API key secrets before caching (#2717)

### DIFF
--- a/packages/shared/src/lib/auth/__tests__/apiKeyAuthCache.test.ts
+++ b/packages/shared/src/lib/auth/__tests__/apiKeyAuthCache.test.ts
@@ -114,4 +114,39 @@ describe('createApiKeyAuthCache', () => {
     cache.setMiss('')
     expect(cache.get('')).toBeUndefined()
   })
+
+  it('never retains the plaintext secret as a cache key (success and miss paths)', () => {
+    const clock = fakeClock()
+    const cache = createApiKeyAuthCache({ successTtlMs: 60_000, negativeTtlMs: 5_000, now: clock.now })
+    const liveSecret = 'sk_live_0123456789abcdef'
+    const badGuess = 'sk_live_brute_force_guess'
+
+    cache.setSuccess(liveSecret, sampleAuth, null)
+    cache.setMiss(badGuess)
+
+    expect(cache.get(liveSecret)).toEqual(sampleAuth)
+    expect(cache.get(badGuess)).toBeNull()
+
+    const storedKeys = cache.inspectEntryKeysForTests()
+    expect(storedKeys.length).toBe(2)
+    for (const key of storedKeys) {
+      expect(key).not.toContain(liveSecret)
+      expect(key).not.toContain(badGuess)
+      expect(key).toMatch(/^[0-9a-f]{32}$/)
+    }
+  })
+
+  it('uses an independent per-cache key so the same secret fingerprints differently across caches', () => {
+    const clock = fakeClock()
+    const secret = 'sk_live_shared_secret'
+    const cacheA = createApiKeyAuthCache({ successTtlMs: 60_000, now: clock.now })
+    const cacheB = createApiKeyAuthCache({ successTtlMs: 60_000, now: clock.now })
+
+    cacheA.setSuccess(secret, sampleAuth, null)
+    cacheB.setSuccess(secret, sampleAuth, null)
+
+    expect(cacheA.get(secret)).toEqual(sampleAuth)
+    expect(cacheB.get(secret)).toEqual(sampleAuth)
+    expect(cacheA.inspectEntryKeysForTests()[0]).not.toBe(cacheB.inspectEntryKeysForTests()[0])
+  })
 })

--- a/packages/shared/src/lib/auth/apiKeyAuthCache.ts
+++ b/packages/shared/src/lib/auth/apiKeyAuthCache.ts
@@ -1,7 +1,15 @@
+import { createHmac, randomBytes } from 'node:crypto'
+
 const DEFAULT_SUCCESS_TTL_MS = 30_000
 const DEFAULT_NEGATIVE_TTL_MS = 5_000
 const DEFAULT_LAST_USED_WRITE_INTERVAL_MS = 60_000
 const DEFAULT_MAX_ENTRIES = 1_000
+const FINGERPRINT_BYTES = 16
+
+function createSecretFingerprinter(): (secret: string) => string {
+  const key = randomBytes(32)
+  return (secret) => createHmac('sha256', key).update(secret, 'utf8').digest('hex').slice(0, FINGERPRINT_BYTES * 2)
+}
 
 export type CachedApiKeyAuth = Record<string, unknown> | null
 
@@ -27,6 +35,7 @@ export type ApiKeyAuthCache = {
   shouldWriteLastUsed(keyId: string): boolean
   clear(): void
   size(): number
+  inspectEntryKeysForTests(): string[]
 }
 
 function resolveTtlEnv(name: string, fallback: number): number {
@@ -46,6 +55,7 @@ export function createApiKeyAuthCache(options: ApiKeyAuthCacheOptions = {}): Api
   )
   const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES
   const now = options.now ?? (() => Date.now())
+  const fingerprint = createSecretFingerprinter()
 
   const entries = new Map<string, CachedEntry>()
   const lastUsedWrites = new Map<string, number>()
@@ -68,12 +78,13 @@ export function createApiKeyAuthCache(options: ApiKeyAuthCacheOptions = {}): Api
   return {
     get(secret) {
       if (!secret) return undefined
-      const entry = entries.get(secret)
+      const key = fingerprint(secret)
+      const entry = entries.get(key)
       if (!entry) return undefined
       const currentMs = now()
-      if (purgeStale(secret, entry, currentMs)) return undefined
-      entries.delete(secret)
-      entries.set(secret, entry)
+      if (purgeStale(key, entry, currentMs)) return undefined
+      entries.delete(key)
+      entries.set(key, entry)
       return entry.auth
     },
     setSuccess(secret, auth, expiresAtMs) {
@@ -83,13 +94,13 @@ export function createApiKeyAuthCache(options: ApiKeyAuthCacheOptions = {}): Api
       const ttlEnd = currentMs + successTtlMs
       const effectiveExpiry = expiresAtMs != null ? Math.min(ttlEnd, expiresAtMs) : ttlEnd
       if (effectiveExpiry <= currentMs) return
-      touch(secret, { auth, cachedAtMs: currentMs, expiresAtMs: effectiveExpiry })
+      touch(fingerprint(secret), { auth, cachedAtMs: currentMs, expiresAtMs: effectiveExpiry })
     },
     setMiss(secret) {
       if (!secret) return
       if (negativeTtlMs <= 0) return
       const currentMs = now()
-      touch(secret, { auth: null, cachedAtMs: currentMs, expiresAtMs: currentMs + negativeTtlMs })
+      touch(fingerprint(secret), { auth: null, cachedAtMs: currentMs, expiresAtMs: currentMs + negativeTtlMs })
     },
     invalidateByKeyId(keyId) {
       if (!keyId) return
@@ -116,6 +127,9 @@ export function createApiKeyAuthCache(options: ApiKeyAuthCacheOptions = {}): Api
     },
     size() {
       return entries.size
+    },
+    inspectEntryKeysForTests() {
+      return Array.from(entries.keys())
     },
   }
 }


### PR DESCRIPTION
Fixes #2717

## Problem
The shared API key auth cache (`packages/shared/src/lib/auth/apiKeyAuthCache.ts`) used the full plaintext API key secret directly as the key of its in-memory `Map`. Live secrets — and invalid brute-force/credential-stuffing guesses passed to `setMiss` — were retained verbatim in process memory for the configured TTL (default 30s success / 5s negative), up to `DEFAULT_MAX_ENTRIES = 1000` at once. Any heap dump, attached debugger, accidental `--inspect`, or memory exporter could recover them and authenticate as the corresponding tenant/org/user.

## Root Cause
`get`/`setSuccess`/`setMiss` stored entries under the raw `secret` string with no hashing at any layer. The DB representation is bcrypt-hashed, so this cache was the only place the literal secret lingered.

## What Changed
- Added a per-process secret fingerprinter: `HMAC-SHA256` keyed on a fresh 32-byte random key generated when the cache is constructed, truncated to 16 bytes (32 hex chars).
- `get`/`setSuccess`/`setMiss` now derive `fingerprint(secret)` and use that as the Map key, applied consistently. Lookups still resolve correctly since the same derivation is used on read and write.
- The cache now retains only non-reversible fingerprints; the random per-process key defeats precomputation/rainbow tables and means identical secrets fingerprint differently across cache instances.
- `invalidateByKeyId`, `shouldWriteLastUsed`, TTL handling, and LRU eviction are unchanged (they never used the secret as the matching value).
- Added a narrow, test-only `inspectEntryKeysForTests()` accessor to assert the no-plaintext invariant.

## Tests
- `packages/shared/src/lib/auth/__tests__/apiKeyAuthCache.test.ts`:
  - never retains the plaintext secret as a cache key (success + miss paths); stored keys match `^[0-9a-f]{32}$`
  - independent per-cache key — same secret fingerprints differently across two cache instances
  - Verified red-before-fix: both new tests fail against the pre-fix source, pass after.
- Existing 10 cache tests + `server.apiKeyCache` tests remain green (12 + 3 passing).
- `yarn typecheck` (all 21 packages) and `yarn workspace @open-mercato/shared build` pass.

## Backward Compatibility
- No removed contract surface. The change to `ApiKeyAuthCache` is additive (one new method); the only producer of the interface is `createApiKeyAuthCache`. Behavioral contract of `get`/`setSuccess`/`setMiss`/`invalidateByKeyId` is preserved. No API response fields, event IDs, DI names, or import paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)