### PR TITLE
security(search): vector index field-leak + fail-open encryption (#2716)

### DIFF
--- a/packages/search/src/__tests__/vector-index-security.test.ts
+++ b/packages/search/src/__tests__/vector-index-security.test.ts
@@ -1,0 +1,230 @@
+import { VectorIndexService } from '../vector/services/vector-index.service'
+import type { EmbeddingService } from '../vector/services/embedding'
+import type { VectorDriver, VectorDriverDocument } from '../vector/types'
+import type { VectorModuleConfig } from '@open-mercato/shared/modules/vector'
+import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
+import type { TenantDataEncryptionService } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
+
+type CapturedEmbeddingInput = { value: string | string[] | null }
+
+function createEmbeddingService(captured: CapturedEmbeddingInput): EmbeddingService {
+  return {
+    available: true,
+    createEmbedding: async (input: string | string[]) => {
+      captured.value = input
+      return [0.1, 0.2, 0.3]
+    },
+  } as unknown as EmbeddingService
+}
+
+function createDriver(overrides: Partial<VectorDriver> = {}): VectorDriver & { upsertCalls: VectorDriverDocument[] } {
+  const upsertCalls: VectorDriverDocument[] = []
+  const driver = {
+    id: 'pgvector' as const,
+    ensureReady: async () => {},
+    upsert: async (doc: VectorDriverDocument) => {
+      upsertCalls.push(doc)
+    },
+    delete: async () => {},
+    query: async () => [],
+    getChecksum: async () => null,
+    list: async () => [],
+    upsertCalls,
+    ...overrides,
+  }
+  return driver as VectorDriver & { upsertCalls: VectorDriverDocument[] }
+}
+
+function createQueryEngine(record: Record<string, unknown>): QueryEngine {
+  return {
+    query: async () => ({ items: [record], total: 1 }),
+  } as unknown as QueryEngine
+}
+
+function createService(args: {
+  driver: VectorDriver
+  embeddingService: EmbeddingService
+  queryEngine: QueryEngine
+  moduleConfigs: VectorModuleConfig[]
+  encryptionService?: TenantDataEncryptionService | null
+}): VectorIndexService {
+  return new VectorIndexService({
+    drivers: [args.driver],
+    embeddingService: args.embeddingService,
+    queryEngine: args.queryEngine,
+    moduleConfigs: args.moduleConfigs,
+    containerResolver: () => ({
+      resolve: (name: string) => {
+        if (name === 'tenantEncryptionService') {
+          if (!args.encryptionService) throw new Error('not registered')
+          return args.encryptionService
+        }
+        throw new Error(`unexpected resolve: ${name}`)
+      },
+    }),
+  })
+}
+
+describe('VectorIndexService default source field protection (issue #2716)', () => {
+  it('excludes snake_case scope and timestamp fields from the default embedding source', async () => {
+    const captured: CapturedEmbeddingInput = { value: null }
+    const record = {
+      id: 'rec-1',
+      tenant_id: 'tenant-secret',
+      organization_id: 'org-secret',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-02T00:00:00.000Z',
+      deleted_at: null,
+      name: 'Visible Name',
+      description: 'Visible Description',
+    }
+    const service = createService({
+      driver: createDriver(),
+      embeddingService: createEmbeddingService(captured),
+      queryEngine: createQueryEngine(record),
+      moduleConfigs: [{ entities: [{ entityId: 'demo:item' }] }],
+    })
+
+    await service.indexRecord({ entityId: 'demo:item', recordId: 'rec-1', tenantId: 'tenant-secret' })
+
+    const lines = Array.isArray(captured.value) ? captured.value.join('\n') : String(captured.value)
+    expect(lines).toContain('name: Visible Name')
+    expect(lines).toContain('description: Visible Description')
+    expect(lines).not.toContain('tenant-secret')
+    expect(lines).not.toContain('org-secret')
+    expect(lines).not.toContain('tenant_id')
+    expect(lines).not.toContain('organization_id')
+    expect(lines).not.toContain('created_at')
+    expect(lines).not.toContain('updated_at')
+  })
+
+  it('honors fieldPolicy.excluded/hashOnly and the searchable allowlist for record and custom fields', async () => {
+    const captured: CapturedEmbeddingInput = { value: null }
+    const record = {
+      id: 'rec-2',
+      tenant_id: 'tenant-1',
+      name: 'Allowed Name',
+      ssn: '123-45-6789',
+      email: 'person@example.com',
+      'cf:notes': 'Allowed note',
+      'cf:secret_token': 'sk-should-not-leak',
+    }
+    const service = createService({
+      driver: createDriver(),
+      embeddingService: createEmbeddingService(captured),
+      queryEngine: createQueryEngine(record),
+      moduleConfigs: [
+        {
+          entities: [
+            {
+              entityId: 'demo:item',
+              fieldPolicy: {
+                searchable: ['name', 'notes'],
+                hashOnly: ['email'],
+                excluded: ['ssn', 'secret_token'],
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    await service.indexRecord({ entityId: 'demo:item', recordId: 'rec-2', tenantId: 'tenant-1' })
+
+    const lines = Array.isArray(captured.value) ? captured.value.join('\n') : String(captured.value)
+    expect(lines).toContain('name: Allowed Name')
+    expect(lines).toContain('custom.notes: Allowed note')
+    expect(lines).not.toContain('123-45-6789')
+    expect(lines).not.toContain('person@example.com')
+    expect(lines).not.toContain('sk-should-not-leak')
+  })
+})
+
+describe('VectorIndexService encryption fail-closed (issue #2716)', () => {
+  const enabledEncryptionThatThrows = (): TenantDataEncryptionService =>
+    ({
+      isEnabled: () => true,
+      encryptEntityPayload: async () => {
+        throw new Error('KMS outage')
+      },
+      decryptEntityPayload: async () => {
+        throw new Error('KMS outage')
+      },
+    }) as unknown as TenantDataEncryptionService
+
+  it('does not persist plaintext when encryption is enabled but encryption throws', async () => {
+    const driver = createDriver()
+    const captured: CapturedEmbeddingInput = { value: null }
+    const record = { id: 'rec-3', tenant_id: 'tenant-1', name: 'Sensitive Title' }
+    const service = createService({
+      driver,
+      embeddingService: createEmbeddingService(captured),
+      queryEngine: createQueryEngine(record),
+      moduleConfigs: [{ entities: [{ entityId: 'demo:item' }] }],
+      encryptionService: enabledEncryptionThatThrows(),
+    })
+
+    await expect(
+      service.indexRecord({ entityId: 'demo:item', recordId: 'rec-3', tenantId: 'tenant-1' }),
+    ).rejects.toThrow('KMS outage')
+    expect(driver.upsertCalls).toHaveLength(0)
+  })
+
+  it('fails closed on decrypt when encryption is enabled but decryption throws', async () => {
+    const driver = createDriver({
+      query: async () => [
+        {
+          entityId: 'demo:item',
+          recordId: 'rec-4',
+          organizationId: null,
+          score: 0.9,
+          checksum: 'abc',
+          resultTitle: 'cipher-title',
+          resultSubtitle: null,
+          resultIcon: null,
+          resultBadge: null,
+          resultSnapshot: null,
+          primaryLinkHref: null,
+          primaryLinkLabel: null,
+          links: null,
+          payload: null,
+        },
+      ],
+    })
+    const captured: CapturedEmbeddingInput = { value: null }
+    const service = createService({
+      driver,
+      embeddingService: createEmbeddingService(captured),
+      queryEngine: createQueryEngine({ id: 'rec-4' }),
+      moduleConfigs: [{ entities: [{ entityId: 'demo:item' }] }],
+      encryptionService: enabledEncryptionThatThrows(),
+    })
+
+    await expect(
+      service.search({ tenantId: 'tenant-1', query: 'anything' }),
+    ).rejects.toThrow('KMS outage')
+  })
+
+  it('falls back to plaintext when encryption is explicitly disabled', async () => {
+    const driver = createDriver()
+    const captured: CapturedEmbeddingInput = { value: null }
+    const record = { id: 'rec-5', tenant_id: 'tenant-1', name: 'Title' }
+    const disabledEncryption = {
+      isEnabled: () => false,
+      encryptEntityPayload: async () => {
+        throw new Error('should not be called when disabled')
+      },
+    } as unknown as TenantDataEncryptionService
+    const service = createService({
+      driver,
+      embeddingService: createEmbeddingService(captured),
+      queryEngine: createQueryEngine(record),
+      moduleConfigs: [{ entities: [{ entityId: 'demo:item' }] }],
+      encryptionService: disabledEncryption,
+    })
+
+    await service.indexRecord({ entityId: 'demo:item', recordId: 'rec-5', tenantId: 'tenant-1' })
+    expect(driver.upsertCalls).toHaveLength(1)
+    expect(driver.upsertCalls[0].resultTitle).toBe('Title')
+  })
+})

--- a/packages/search/src/vector/services/vector-index.service.ts
+++ b/packages/search/src/vector/services/vector-index.service.ts
@@ -14,6 +14,7 @@ import {
   type VectorIndexEntry,
 } from '../types'
 import type { VectorDriver } from '../types'
+import type { SearchFieldPolicy } from '@open-mercato/shared/modules/search'
 import { computeChecksum } from './checksum'
 import { EmbeddingService } from './embedding'
 import { logVectorOperation } from '../lib/vector-logs'
@@ -21,6 +22,20 @@ import { searchDebug, searchDebugWarn } from '../../lib/debug'
 
 type ContainerResolver = () => unknown
 const VECTOR_ENTRY_ENCRYPTION_ENTITY_ID = 'vector:vector_search'
+
+const DEFAULT_SOURCE_SCOPE_FIELDS = new Set<string>([
+  'id',
+  'tenant_id',
+  'tenantId',
+  'organization_id',
+  'organizationId',
+  'created_at',
+  'createdAt',
+  'updated_at',
+  'updatedAt',
+  'deleted_at',
+  'deletedAt',
+])
 
 const ENRICHMENT_FIELD_HINTS: Record<EntityId, string[]> = {
   'customers:customer_entity': [
@@ -191,17 +206,16 @@ export class VectorIndexService {
         links: ((encrypted as any).links ?? args.links) as any,
         payload: ((encrypted as any).payload ?? args.payload) as any,
       }
-    } catch {
-      return {
-        resultTitle: args.resultTitle,
-        resultSubtitle: args.resultSubtitle,
-        resultIcon: args.resultIcon,
-        resultSnapshot: args.resultSnapshot,
-        primaryLinkHref: args.primaryLinkHref,
-        primaryLinkLabel: args.primaryLinkLabel,
-        links: args.links,
-        payload: args.payload,
-      }
+    } catch (err) {
+      searchDebugWarn('vector.index', 'Vector entry encryption failed; refusing to persist plaintext', {
+        entityId: VECTOR_ENTRY_ENCRYPTION_ENTITY_ID,
+        tenantId: args.tenantId,
+        organizationId: args.organizationId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      throw err instanceof Error
+        ? err
+        : new Error('[internal] Vector entry encryption failed')
     }
   }
 
@@ -265,17 +279,16 @@ export class VectorIndexService {
         links: ((decrypted as any).links ?? args.links) as any,
         payload: ((decrypted as any).payload ?? args.payload) as any,
       }
-    } catch {
-      return {
-        resultTitle: args.resultTitle,
-        resultSubtitle: args.resultSubtitle,
-        resultIcon: args.resultIcon,
-        resultSnapshot: args.resultSnapshot,
-        primaryLinkHref: args.primaryLinkHref,
-        primaryLinkLabel: args.primaryLinkLabel,
-        links: args.links,
-        payload: args.payload,
-      }
+    } catch (err) {
+      searchDebugWarn('vector.index', 'Vector entry decryption failed; refusing to return ciphertext as plaintext', {
+        entityId: VECTOR_ENTRY_ENCRYPTION_ENTITY_ID,
+        tenantId: args.tenantId,
+        organizationId: args.organizationId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      throw err instanceof Error
+        ? err
+        : new Error('[internal] Vector entry decryption failed')
     }
   }
 
@@ -641,9 +654,26 @@ export class VectorIndexService {
     return null
   }
 
-  private buildDefaultSource(entityId: EntityId, payload: { record: Record<string, any>; customFields: Record<string, any> }): VectorIndexSource {
+  private buildDefaultSource(
+    entityId: EntityId,
+    payload: { record: Record<string, any>; customFields: Record<string, any> },
+    fieldPolicy?: SearchFieldPolicy,
+  ): VectorIndexSource {
     const { record, customFields } = payload
     const lines: string[] = []
+
+    const searchableWhitelist = fieldPolicy?.searchable ? new Set(fieldPolicy.searchable) : null
+    const excludedFields = new Set<string>([
+      ...(fieldPolicy?.excluded ?? []),
+      ...(fieldPolicy?.hashOnly ?? []),
+    ])
+
+    const isEligibleField = (field: string): boolean => {
+      if (DEFAULT_SOURCE_SCOPE_FIELDS.has(field)) return false
+      if (excludedFields.has(field)) return false
+      if (searchableWhitelist && !searchableWhitelist.has(field)) return false
+      return true
+    }
 
     const pushEntry = (label: string, value: unknown) => {
       if (value === null || value === undefined) return
@@ -657,16 +687,18 @@ export class VectorIndexService {
 
     const preferredFields = ['title', 'name', 'displayName', 'summary', 'subject']
     for (const field of preferredFields) {
+      if (!isEligibleField(field)) continue
       if (record[field] != null) pushEntry(field, record[field])
     }
 
     for (const [key, value] of Object.entries(record)) {
       if (preferredFields.includes(key)) continue
-      if (key === 'id' || key === 'tenantId' || key === 'organizationId' || key === 'createdAt' || key === 'updatedAt') continue
+      if (!isEligibleField(key)) continue
       pushEntry(key, value)
     }
 
     for (const [key, value] of Object.entries(customFields)) {
+      if (!isEligibleField(key)) continue
       pushEntry(`custom.${key}`, value)
     }
 
@@ -700,7 +732,7 @@ export class VectorIndexService {
       if (built) return built
       return null
     }
-    return this.buildDefaultSource(entityId, { record: ctx.record, customFields: ctx.customFields })
+    return this.buildDefaultSource(entityId, { record: ctx.record, customFields: ctx.customFields }, config.fieldPolicy)
   }
 
   private async resolvePresenter(

--- a/packages/shared/src/modules/vector.ts
+++ b/packages/shared/src/modules/vector.ts
@@ -1,5 +1,6 @@
 import type { EntityId } from './entities'
 import type { QueryEngine } from '../lib/query/types'
+import type { SearchFieldPolicy } from './search'
 
 export type VectorDriverId = 'pgvector' | 'qdrant' | 'chromadb'
 
@@ -71,6 +72,12 @@ export type VectorEntityConfig = {
    * Provide extra deep links rendered next to the search result.
    */
   resolveLinks?: (ctx: VectorBuildContext) => Promise<VectorLinkDescriptor[] | null> | VectorLinkDescriptor[] | null
+  /**
+   * Controls which record/custom fields are eligible for the default embedding source builder.
+   * Applied only when `buildSource` is not provided. `excluded`/`hashOnly` fields are never embedded;
+   * when `searchable` is defined it acts as an allowlist for both record and custom fields.
+   */
+  fieldPolicy?: SearchFieldPolicy
 }
 
 export type VectorModuleConfig = {


### PR DESCRIPTION
Fixes #2716

## Problem
The vector index service had two data-protection gaps:
1. Its default source builder (`buildDefaultSource`) serialized nearly the whole record into the embedding text — excluding only the camelCase system keys, so the actual snake_case `tenant_id`/`organization_id` columns and every custom field were embedded (and sent to the embedding provider) unfiltered.
2. `encryptResultFields`/`decryptResultFields` caught any crypto exception and returned the original plaintext. The `isEnabled()` short-circuit only covered the disabled case, so when encryption was **enabled** but the service threw (KMS/Vault outage, key-resolution error), plaintext was written verbatim to the vector store.

## Root Cause
- The exclusion list in `buildDefaultSource` was camelCase-only and there was no field-policy contract on the default (no-`buildSource`) path.
- The `try/catch` blocks failed open instead of failing closed when encryption was active.

## What Changed
- `buildDefaultSource` now drops scope/timestamp fields in **both** snake_case and camelCase (`id`, `tenant_id`/`tenantId`, `organization_id`/`organizationId`, `created_at`/`createdAt`, `updated_at`/`updatedAt`, `deleted_at`/`deletedAt`) and applies a `fieldPolicy`: `excluded`/`hashOnly` fields are never embedded, and when `searchable` is set it acts as an allowlist for both record and custom fields.
- Added an optional, additive `fieldPolicy?: SearchFieldPolicy` to `VectorEntityConfig` (`@open-mercato/shared/modules/vector`), threaded into `buildDefaultSource` via `resolveSource`.
- `encryptResultFields`/`decryptResultFields` now log (without payload values) and rethrow when encryption is enabled, so a crypto failure aborts the upsert / read instead of persisting or returning plaintext. The explicitly-disabled path still falls back to plaintext unchanged.

## Tests
- New `packages/search/src/__tests__/vector-index-security.test.ts` (5 cases): scope-field exclusion in default source, `fieldPolicy` enforcement on record + custom fields, encrypt fail-closed (no `upsert`), decrypt fail-closed on `search`, and unchanged plaintext fallback when encryption is disabled.
- Verified red-before-fix: 4/5 fail on develop, all pass after the fix.
- `yarn workspace @open-mercato/search test` (121 passed), `yarn build:packages`, `yarn workspace @open-mercato/shared typecheck`, `yarn workspace @open-mercato/search typecheck` all green.
- No user-facing strings or locale files touched (internal `searchDebugWarn` + `[internal]`-prefixed errors), so i18n checks are not applicable.

## Backward Compatibility
- `VectorEntityConfig.fieldPolicy` is additive/optional — no existing config breaks.
- `buildDefaultSource` is private; public method signatures unchanged. No API response fields, event IDs, ACL IDs, DI names, or import paths altered. The fail-closed change is a security hardening of existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)