### PR TITLE
security(search): search_get / search_aggregate AI tools enforce per-entity ACL & field policy (#2715)

### DIFF
--- a/packages/core/src/modules/customers/search.ts
+++ b/packages/core/src/modules/customers/search.ts
@@ -693,6 +693,7 @@ export const searchConfig: SearchModuleConfig = {
         hashOnly: ['primary_email', 'primary_phone', 'personal_email'],
         excluded: ['date_of_birth', 'government_id', 'ssn', 'tax_id'],
       },
+      aclFeatures: ['customers.people.view'],
     },
 
     // =========================================================================
@@ -782,6 +783,7 @@ export const searchConfig: SearchModuleConfig = {
         hashOnly: ['tax_id', 'registration_number'],
         excluded: ['bank_account', 'billing_info', 'credit_info'],
       },
+      aclFeatures: ['customers.companies.view'],
     },
 
     // =========================================================================
@@ -858,6 +860,7 @@ export const searchConfig: SearchModuleConfig = {
         hashOnly: [],
         excluded: [],
       },
+      aclFeatures: ['customers.activities.view'],
     },
 
     // =========================================================================
@@ -944,6 +947,7 @@ export const searchConfig: SearchModuleConfig = {
         hashOnly: [],
         excluded: ['value_amount', 'value_currency'],
       },
+      aclFeatures: ['customers.deals.view'],
     },
 
     // =========================================================================
@@ -1016,6 +1020,7 @@ export const searchConfig: SearchModuleConfig = {
         hashOnly: [],
         excluded: [],
       },
+      aclFeatures: ['customers.activities.view'],
     },
 
     // =========================================================================
@@ -1082,6 +1087,7 @@ export const searchConfig: SearchModuleConfig = {
         hashOnly: [],
         excluded: [],
       },
+      aclFeatures: ['customers.activities.view'],
     },
   ],
 }

--- a/packages/search/src/modules/search/__tests__/ai-tools.aggregate.test.ts
+++ b/packages/search/src/modules/search/__tests__/ai-tools.aggregate.test.ts
@@ -3,16 +3,35 @@ import { aiTools } from '../ai-tools'
 const aggregateTool = aiTools.find((t) => t.name === 'search_aggregate')
 if (!aggregateTool) throw new Error('search_aggregate tool not found in aiTools — was it renamed?')
 
-function makeCtx(queryResult: { items: unknown[]; total: number }) {
+const ENTITY_CONFIGS: Record<string, { aclFeatures: string[]; fieldPolicy: { searchable: string[]; hashOnly?: string[]; excluded?: string[] } }> = {
+  'customers:customer_deal': {
+    aclFeatures: ['customers.deals.view'],
+    fieldPolicy: { searchable: ['title', 'status', 'pipeline_stage', 'source'], hashOnly: [], excluded: ['value_amount'] },
+  },
+  'catalog:product': {
+    aclFeatures: ['catalog.products.view'],
+    fieldPolicy: { searchable: ['category', 'status'], hashOnly: [], excluded: [] },
+  },
+}
+
+const DEFAULT_FEATURES = ['search.view', 'customers.deals.view', 'catalog.products.view']
+
+function makeCtx(
+  queryResult: { items: unknown[]; total: number },
+  overrides: { userFeatures?: string[]; isSuperAdmin?: boolean } = {},
+) {
   const mockQuery = jest.fn().mockResolvedValue(queryResult)
+  const searchIndexer = {
+    getEntityConfig: (entityId: string) => ENTITY_CONFIGS[entityId],
+  }
   const ctx = {
     tenantId: 'tenant-1',
     organizationId: 'org-1',
     userId: null,
-    userFeatures: ['search.view'],
-    isSuperAdmin: false,
+    userFeatures: overrides.userFeatures ?? DEFAULT_FEATURES,
+    isSuperAdmin: overrides.isSuperAdmin ?? false,
     container: {
-      resolve: (_name: string) => ({ query: mockQuery }),
+      resolve: (name: string) => (name === 'searchIndexer' ? searchIndexer : { query: mockQuery }),
     },
   }
   return { ctx, mockQuery }
@@ -109,5 +128,71 @@ describe('search_aggregate tool', () => {
     await expect(
       aggregateTool.handler({ entityType: 'customers:customer_deal', groupBy: 'status', limit: 20 }, noTenantCtx),
     ).rejects.toThrow('Tenant context is required')
+  })
+
+  it('denies callers holding only search.view without the per-entity view feature', async () => {
+    const { ctx, mockQuery } = makeCtx({ items: [{ status: 'open' }], total: 1 }, { userFeatures: ['search.view'] })
+
+    await expect(
+      aggregateTool.handler({ entityType: 'customers:customer_deal', groupBy: 'status', limit: 20 }, ctx),
+    ).rejects.toThrow(/Insufficient permissions/)
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+
+  it('allows callers holding the per-entity view feature', async () => {
+    const { ctx, mockQuery } = makeCtx({ items: [{ status: 'open' }], total: 1 }, { userFeatures: ['customers.deals.view'] })
+
+    const result = await aggregateTool.handler(
+      { entityType: 'customers:customer_deal', groupBy: 'status', limit: 20 },
+      ctx,
+    ) as { total: number }
+    expect(result.total).toBe(1)
+    expect(mockQuery).toHaveBeenCalled()
+  })
+
+  it('honors wildcard module grants for the per-entity view feature', async () => {
+    const { ctx } = makeCtx({ items: [{ status: 'open' }], total: 1 }, { userFeatures: ['customers.*'] })
+
+    const result = await aggregateTool.handler(
+      { entityType: 'customers:customer_deal', groupBy: 'status', limit: 20 },
+      ctx,
+    ) as { total: number }
+    expect(result.total).toBe(1)
+  })
+
+  it('allows super admins regardless of features', async () => {
+    const { ctx } = makeCtx({ items: [{ status: 'open' }], total: 1 }, { userFeatures: [], isSuperAdmin: true })
+
+    const result = await aggregateTool.handler(
+      { entityType: 'customers:customer_deal', groupBy: 'status', limit: 20 },
+      ctx,
+    ) as { total: number }
+    expect(result.total).toBe(1)
+  })
+
+  it('rejects groupBy on an excluded (sensitive) field', async () => {
+    const { ctx, mockQuery } = makeCtx({ items: [{ value_amount: 100 }], total: 1 })
+
+    await expect(
+      aggregateTool.handler({ entityType: 'customers:customer_deal', groupBy: 'value_amount', limit: 20 }, ctx),
+    ).rejects.toThrow(/not an allowed grouping key/)
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+
+  it('rejects groupBy on a field not in the searchable allowlist (e.g. PII enumeration)', async () => {
+    const { ctx, mockQuery } = makeCtx({ items: [{ email: 'a@b.c' }], total: 1 })
+
+    await expect(
+      aggregateTool.handler({ entityType: 'customers:customer_deal', groupBy: 'email', limit: 20 }, ctx),
+    ).rejects.toThrow(/not an allowed grouping key/)
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+
+  it('fails closed for entity types not configured for search', async () => {
+    const { ctx } = makeCtx({ items: [], total: 0 })
+
+    await expect(
+      aggregateTool.handler({ entityType: 'secret:unconfigured', groupBy: 'status', limit: 20 }, ctx),
+    ).rejects.toThrow(/not configured for search/)
   })
 })

--- a/packages/search/src/modules/search/__tests__/ai-tools.get.test.ts
+++ b/packages/search/src/modules/search/__tests__/ai-tools.get.test.ts
@@ -1,0 +1,118 @@
+import { aiTools } from '../ai-tools'
+
+const getTool = aiTools.find((t) => t.name === 'search_get')
+if (!getTool) throw new Error('search_get tool not found in aiTools — was it renamed?')
+
+const PERSON_CONFIG = {
+  aclFeatures: ['customers.people.view'],
+  fieldPolicy: {
+    searchable: ['first_name', 'last_name'],
+    hashOnly: ['primary_email', 'primary_phone'],
+    excluded: ['ssn', 'date_of_birth'],
+  },
+}
+
+function makeCtx(
+  record: Record<string, unknown> | undefined,
+  overrides: { userFeatures?: string[]; isSuperAdmin?: boolean } = {},
+) {
+  const items = record ? [record] : []
+  const mockQuery = jest.fn().mockResolvedValue({ items, total: items.length })
+  const searchIndexer = {
+    getEntityConfig: (entityId: string) =>
+      entityId === 'customers:customer_person_profile' ? PERSON_CONFIG : undefined,
+  }
+  const ctx = {
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    userId: null,
+    userFeatures: overrides.userFeatures ?? ['customers.people.view'],
+    isSuperAdmin: overrides.isSuperAdmin ?? false,
+    container: {
+      resolve: (name: string) => (name === 'searchIndexer' ? searchIndexer : { query: mockQuery }),
+    },
+  }
+  return { ctx, mockQuery }
+}
+
+describe('search_get tool', () => {
+  it('denies callers holding only search.view without the per-entity view feature', async () => {
+    const { ctx, mockQuery } = makeCtx(
+      { id: 'rec-1', first_name: 'Jane', ssn: '123-45-6789' },
+      { userFeatures: ['search.view'] },
+    )
+
+    await expect(
+      getTool.handler({ entityType: 'customers:customer_person_profile', recordId: 'rec-1' }, ctx),
+    ).rejects.toThrow(/Insufficient permissions/)
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+
+  it('returns the record for callers holding the per-entity view feature', async () => {
+    const { ctx, mockQuery } = makeCtx({ id: 'rec-1', first_name: 'Jane', last_name: 'Doe' })
+
+    const result = await getTool.handler(
+      { entityType: 'customers:customer_person_profile', recordId: 'rec-1' },
+      ctx,
+    ) as { found: boolean; record: Record<string, unknown> }
+    expect(result.found).toBe(true)
+    expect(result.record.first_name).toBe('Jane')
+    expect(mockQuery).toHaveBeenCalled()
+  })
+
+  it('strips hashOnly and excluded (PII) fields from the returned record', async () => {
+    const { ctx } = makeCtx({
+      id: 'rec-1',
+      first_name: 'Jane',
+      primary_email: 'jane@example.com',
+      primary_phone: '+1555',
+      ssn: '123-45-6789',
+      date_of_birth: '1990-01-01',
+    })
+
+    const result = await getTool.handler(
+      { entityType: 'customers:customer_person_profile', recordId: 'rec-1' },
+      ctx,
+    ) as { record: Record<string, unknown> }
+    expect(result.record.first_name).toBe('Jane')
+    expect(result.record.id).toBe('rec-1')
+    expect(result.record.primary_email).toBeUndefined()
+    expect(result.record.primary_phone).toBeUndefined()
+    expect(result.record.ssn).toBeUndefined()
+    expect(result.record.date_of_birth).toBeUndefined()
+  })
+
+  it('honors wildcard grants and super admins', async () => {
+    const wildcard = makeCtx({ id: 'rec-1', first_name: 'Jane' }, { userFeatures: ['*'] })
+    const wildcardResult = await getTool.handler(
+      { entityType: 'customers:customer_person_profile', recordId: 'rec-1' },
+      wildcard.ctx,
+    ) as { found: boolean }
+    expect(wildcardResult.found).toBe(true)
+
+    const superAdmin = makeCtx({ id: 'rec-1', first_name: 'Jane' }, { userFeatures: [], isSuperAdmin: true })
+    const superResult = await getTool.handler(
+      { entityType: 'customers:customer_person_profile', recordId: 'rec-1' },
+      superAdmin.ctx,
+    ) as { found: boolean }
+    expect(superResult.found).toBe(true)
+  })
+
+  it('fails closed for entity types not configured for search', async () => {
+    const { ctx, mockQuery } = makeCtx({ id: 'rec-1' })
+
+    await expect(
+      getTool.handler({ entityType: 'secret:unconfigured', recordId: 'rec-1' }, ctx),
+    ).rejects.toThrow(/not configured for search/)
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+
+  it('throws when tenantId is missing', async () => {
+    const { ctx } = makeCtx({ id: 'rec-1' })
+    const noTenantCtx = { ...ctx, tenantId: null }
+
+    await expect(
+      getTool.handler({ entityType: 'customers:customer_person_profile', recordId: 'rec-1' }, noTenantCtx),
+    ).rejects.toThrow('Tenant context is required')
+  })
+})

--- a/packages/search/src/modules/search/ai-tools.ts
+++ b/packages/search/src/modules/search/ai-tools.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod'
-import type { SearchResult, SearchStrategyId } from '@open-mercato/shared/modules/search'
+import type {
+  SearchEntityConfig,
+  SearchResult,
+  SearchStrategyId,
+} from '@open-mercato/shared/modules/search'
+import { hasAllFeatures } from '@open-mercato/shared/security/features'
 
 /**
  * AI Tools definitions for the Search module.
@@ -45,6 +50,97 @@ type AiToolDefinition = {
    */
   isMutation?: boolean
   handler: (input: any, ctx: ToolContext) => Promise<unknown>
+}
+
+/**
+ * Minimal shape of the `searchIndexer` DI service consumed by the per-entity
+ * ACL / field-policy resolution below. Kept local to avoid importing the full
+ * `SearchIndexer` class into the tool module.
+ */
+type SearchIndexerLike = {
+  getEntityConfig: (entityId: string) => SearchEntityConfig | undefined
+}
+
+class SearchToolAuthorizationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SearchToolAuthorizationError'
+  }
+}
+
+/**
+ * Resolve the search config for an entity type and enforce the per-entity view
+ * feature(s). Data-returning tools (`search_get` / `search_aggregate`) MUST NOT
+ * rely on the search-administration `search.view` feature to gate record reads.
+ *
+ * Fails closed: when the entity is not configured for search, or has no
+ * `aclFeatures` declared, access is denied so records are never exposed without
+ * an explicit owning-module grant.
+ */
+function authorizeEntityAccess(entityType: string, ctx: ToolContext): SearchEntityConfig {
+  const searchIndexer = ctx.container.resolve<SearchIndexerLike>('searchIndexer')
+  const config = searchIndexer.getEntityConfig(entityType)
+
+  if (!config) {
+    throw new SearchToolAuthorizationError(
+      `[internal] Entity type "${entityType}" is not configured for search`
+    )
+  }
+
+  if (ctx.isSuperAdmin) return config
+
+  const required = config.aclFeatures
+  if (!required || required.length === 0) {
+    throw new SearchToolAuthorizationError(
+      `[internal] Entity type "${entityType}" does not declare aclFeatures; access denied`
+    )
+  }
+
+  if (!hasAllFeatures(ctx.userFeatures, required)) {
+    throw new SearchToolAuthorizationError(
+      `[internal] Insufficient permissions for entity "${entityType}". Required: ${required.join(', ')}`
+    )
+  }
+
+  return config
+}
+
+/**
+ * Strip fields that the entity's field policy marks as sensitive
+ * (`hashOnly` exact-match PII or fully `excluded`) from a query-engine record.
+ * Defense-in-depth so even an authorized caller never receives decrypted PII or
+ * fields a `fieldPolicy` keeps out of search.
+ */
+function stripSensitiveFields(
+  record: Record<string, unknown>,
+  config: SearchEntityConfig
+): Record<string, unknown> {
+  const sensitive = new Set<string>([
+    ...(config.fieldPolicy?.hashOnly ?? []),
+    ...(config.fieldPolicy?.excluded ?? []),
+  ])
+  if (sensitive.size === 0) return record
+  const safe: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(record)) {
+    if (sensitive.has(key)) continue
+    safe[key] = value
+  }
+  return safe
+}
+
+/**
+ * Determine whether a field is a safe aggregation grouping key for an entity.
+ * Only fields explicitly declared `searchable` are allowed; `hashOnly` and
+ * `excluded` (PII / sensitive) fields can never be enumerated via group-by.
+ */
+function isGroupByAllowed(field: string, config: SearchEntityConfig): boolean {
+  const sensitive = new Set<string>([
+    ...(config.fieldPolicy?.hashOnly ?? []),
+    ...(config.fieldPolicy?.excluded ?? []),
+  ])
+  if (sensitive.has(field)) return false
+  const searchable = config.fieldPolicy?.searchable ?? []
+  return searchable.includes(field)
 }
 
 // =============================================================================
@@ -169,6 +265,8 @@ const searchGetTool: AiToolDefinition = {
       throw new Error('Tenant context is required')
     }
 
+    const entityConfig = authorizeEntityAccess(input.entityType, ctx)
+
     const queryEngine = ctx.container.resolve<{
       query: (entityId: string, options: any) => Promise<{ items: unknown[]; total: number }>
     }>('queryEngine')
@@ -181,8 +279,8 @@ const searchGetTool: AiToolDefinition = {
       page: { page: 1, pageSize: 1 },
     })
 
-    const record = result.items[0] as Record<string, unknown> | undefined
-    if (!record) {
+    const rawRecord = result.items[0] as Record<string, unknown> | undefined
+    if (!rawRecord) {
       return {
         found: false,
         entityType: input.entityType,
@@ -190,6 +288,8 @@ const searchGetTool: AiToolDefinition = {
         error: 'Record not found',
       }
     }
+
+    const record = stripSensitiveFields(rawRecord, entityConfig)
 
     // Extract custom fields
     const customFields: Record<string, unknown> = {}
@@ -327,6 +427,14 @@ const searchAggregateTool: AiToolDefinition = {
   handler: async (input, ctx) => {
     if (!ctx.tenantId) {
       throw new Error('Tenant context is required')
+    }
+
+    const entityConfig = authorizeEntityAccess(input.entityType, ctx)
+
+    if (!isGroupByAllowed(input.groupBy, entityConfig)) {
+      throw new SearchToolAuthorizationError(
+        `[internal] Field "${input.groupBy}" is not an allowed grouping key for "${input.entityType}"`
+      )
     }
 
     const queryEngine = ctx.container.resolve<{

--- a/packages/shared/src/modules/search.ts
+++ b/packages/shared/src/modules/search.ts
@@ -279,6 +279,15 @@ export type SearchEntityConfig = {
   resolveLinks?: (ctx: SearchBuildContext) => Promise<SearchResultLink[] | null> | SearchResultLink[] | null
   /** Define which fields are searchable vs hash-only */
   fieldPolicy?: SearchFieldPolicy
+  /**
+   * Per-entity view feature(s) required to read this entity's records through
+   * data-returning surfaces (e.g. the `search_get` / `search_aggregate` AI tools).
+   * These tools must NOT rely on the search-administration `search.view` feature
+   * to gate record reads — callers must additionally hold the owning module's
+   * `<entity>.view` feature(s) declared here. When omitted, those tools fail
+   * closed (deny) so an entity is never exposed without an explicit grant.
+   */
+  aclFeatures?: string[]
 }
 
 /**


### PR DESCRIPTION
Fixes #2715

## Problem
Two search AI tools were gated only by the search-administration `search.view` feature and never checked the per-entity view feature or `fieldPolicy` for the data they returned:
- `search_get` returned full query-engine records (including custom fields and decrypted PII) to any `search.view` holder.
- `search_aggregate` accepted an unrestricted `groupBy: z.string()` and ran it over decrypted output, enabling enumeration of arbitrary fields (`email`, `phone`, `tax_id`, …) — including fields a `fieldPolicy` marks `hashOnly`/`excluded`.

## Root Cause
`search.view` is a search-administration permission, not a read-everything grant. The two data-returning tools used it as the sole gate and passed the requested `entityType` straight to `queryEngine.query(...)` with only tenant/org scope.

## What Changed
- `SearchEntityConfig` gains an additive optional `aclFeatures?: string[]` declaring the owning-module view feature(s) required to read an entity's records through data-returning surfaces.
- `search_get` and `search_aggregate` now resolve the entity's search config via `searchIndexer.getEntityConfig(...)` and enforce its `aclFeatures` with the shared wildcard-aware `hasAllFeatures` matcher (super-admin bypass). They **fail closed** when the entity is not configured or declares no `aclFeatures`.
- `search_get` strips `fieldPolicy.hashOnly`/`excluded` (PII / sensitive) fields from the returned record (defense in depth).
- `search_aggregate` restricts `groupBy` to the entity's `fieldPolicy.searchable` allowlist and rejects `hashOnly`/`excluded` fields, preventing PII enumeration.
- Populated `aclFeatures` on every customers search entity config (people → `customers.people.view`, companies → `customers.companies.view`, deals → `customers.deals.view`, comments/activities/todos → `customers.activities.view`).

## Tests
- New `ai-tools.get.test.ts` + expanded `ai-tools.aggregate.test.ts`: deny when caller holds only `search.view`, allow with the per-entity feature, honor `module.*` / `*` wildcard grants, super-admin bypass, PII field stripping, `groupBy` allowlist enforcement, and fail-closed for unconfigured entity types. Verified red before fix (7 failing) → green after. Full `@open-mercato/search` suite: 129 passing.
- `yarn build:packages`, `yarn generate`, `yarn typecheck` all pass.

## Backward Compatibility
- `aclFeatures` is an additive optional field — existing search configs typecheck unchanged. No API response fields, event IDs, widget spot IDs, ACL IDs, import paths, or DI names were removed or renamed. The fail-closed posture and PII stripping are the intended security tightening; the AI tool payload shape is not a frozen contract surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)