### PR TITLE
security(shared/encryption): key lookup hashes with HMAC pepper (#2718)

### DIFF
--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -232,6 +232,11 @@ TENANT_DATA_ENCRYPTION_DEBUG=false
 TENANT_DATA_ENCRYPTION_FALLBACK_KEY=dev-tenant-encryption-fallback-key-32chars
 # Legacy secondary fallback secret (optional)
 TENANT_DATA_ENCRYPTION_KEY=
+# Dedicated high-entropy pepper used to key lookup hashes (email_hash, external_email_hash, …)
+# so they cannot be attacked with offline rainbow tables or correlated across installations
+# (issue #2718). When unset, the encryption fallback/legacy keys above are used; if none are
+# configured the lookup hash falls back to the legacy unkeyed digest. Never reuse AUTH_SECRET here.
+LOOKUP_HASH_PEPPER=
 # HashiCorp Vault configuration (disabled by default in local dev).
 # Uncomment only if you actually run Vault locally; otherwise the fallback key above
 # is used immediately.

--- a/packages/core/src/modules/auth/cli.ts
+++ b/packages/core/src/modules/auth/cli.ts
@@ -7,7 +7,7 @@ import { Tenant, Organization } from '@open-mercato/core/modules/directory/data/
 import { rebuildHierarchyForTenant } from '@open-mercato/core/modules/directory/lib/hierarchy'
 import { ensureRoles, setupInitialTenant, ensureDefaultRoleAcls, ensureCustomRoleAcls, OrgSlugExistsError } from './lib/setup-app'
 import { normalizeTenantId } from './lib/tenantAccess'
-import { computeEmailHash } from './lib/emailHash'
+import { computeEmailHash, emailHashLookupValues } from './lib/emailHash'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { isTenantDataEncryptionEnabled } from '@open-mercato/shared/lib/encryption/toggles'
 import { createKmsService } from '@open-mercato/shared/lib/encryption/kms'
@@ -732,8 +732,13 @@ const setPassword: ModuleCli = {
 
     const { resolve } = await createRequestContainer()
     const em = resolve('em') as any
-    const emailHash = computeEmailHash(email)
-    const user = await em.findOne(User, { $or: [{ email }, { emailHash }] })
+    const user = await findOneWithDecryption(
+      em,
+      User,
+      { $or: [{ email }, { emailHash: { $in: emailHashLookupValues(email) } }] } as any,
+      undefined,
+      { tenantId: null, organizationId: null },
+    )
 
     if (!user) {
       console.error(`User with email "${email}" not found`)

--- a/packages/core/src/modules/auth/commands/users.ts
+++ b/packages/core/src/modules/auth/commands/users.ts
@@ -28,7 +28,7 @@ import { extractUndoPayload, type UndoPayload } from '@open-mercato/shared/lib/c
 import { resolveRedoSnapshot } from '@open-mercato/shared/lib/commands/redo'
 import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
 import { normalizeTenantId } from '@open-mercato/core/modules/auth/lib/tenantAccess'
-import { computeEmailHash } from '@open-mercato/core/modules/auth/lib/emailHash'
+import { computeEmailHash, emailHashLookupValues } from '@open-mercato/core/modules/auth/lib/emailHash'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { buildNotificationFromType } from '@open-mercato/core/modules/notifications/lib/notificationBuilder'
 import { resolveNotificationService } from '@open-mercato/core/modules/notifications/lib/notificationService'
@@ -206,7 +206,7 @@ const createUserCommand: CommandHandler<Record<string, unknown>, CreateUserResul
     if (!organization) throw new CrudHttpError(400, { error: 'Organization not found' })
 
     const emailHash = computeEmailHash(parsed.email)
-    const duplicate = await findOneWithDecryption(em, User, { $or: [{ email: parsed.email }, { emailHash }], deletedAt: null } as any, {}, { tenantId: null, organizationId: null })
+    const duplicate = await findOneWithDecryption(em, User, { $or: [{ email: parsed.email }, { emailHash: { $in: emailHashLookupValues(parsed.email) } }], deletedAt: null } as any, {}, { tenantId: null, organizationId: null })
     if (duplicate) await throwDuplicateEmailError()
 
     let passwordHash: string | null = null
@@ -519,12 +519,11 @@ const updateUserCommand: CommandHandler<Record<string, unknown>, User> = {
       : null
 
     if (parsed.email !== undefined) {
-      const emailHash = computeEmailHash(parsed.email)
       const duplicate = await findOneWithDecryption(
         em,
         User,
         {
-          $or: [{ email: parsed.email }, { emailHash }],
+          $or: [{ email: parsed.email }, { emailHash: { $in: emailHashLookupValues(parsed.email) } }],
           deletedAt: null,
           id: { $ne: parsed.id } as any,
         } as FilterQuery<User>,

--- a/packages/core/src/modules/auth/lib/emailHash.ts
+++ b/packages/core/src/modules/auth/lib/emailHash.ts
@@ -1,5 +1,9 @@
-import { hashForLookup } from '@open-mercato/shared/lib/encryption/aes'
+import { hashForLookup, lookupHashCandidates } from '@open-mercato/shared/lib/encryption/aes'
 
 export function computeEmailHash(email: string): string {
   return hashForLookup(email)
+}
+
+export function emailHashLookupValues(email: string): string[] {
+  return lookupHashCandidates(email)
 }

--- a/packages/core/src/modules/auth/services/authService.ts
+++ b/packages/core/src/modules/auth/services/authService.ts
@@ -1,7 +1,7 @@
 import { EntityManager } from '@mikro-orm/postgresql'
 import { compare, hash } from 'bcryptjs'
 import { User, Role, UserRole, Session, PasswordReset } from '@open-mercato/core/modules/auth/data/entities'
-import { computeEmailHash } from '@open-mercato/core/modules/auth/lib/emailHash'
+import { emailHashLookupValues } from '@open-mercato/core/modules/auth/lib/emailHash'
 import { generateAuthToken, hashAuthToken } from '@open-mercato/core/modules/auth/lib/tokenHash'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
@@ -9,29 +9,29 @@ export class AuthService {
   constructor(private em: EntityManager) {}
 
   async findUserByEmail(email: string) {
-    const emailHash = computeEmailHash(email)
+    const emailHashes = emailHashLookupValues(email)
     return findOneWithDecryption(this.em, User, {
       deletedAt: null,
       $or: [
         { email },
-        { emailHash },
+        { emailHash: { $in: emailHashes } },
       ],
     } as any)
   }
 
   async findUsersByEmail(email: string) {
-    const emailHash = computeEmailHash(email)
+    const emailHashes = emailHashLookupValues(email)
     return findWithDecryption(this.em, User, {
       deletedAt: null,
       $or: [
         { email },
-        { emailHash },
+        { emailHash: { $in: emailHashes } },
       ],
     } as any)
   }
 
   async findUserByEmailAndTenant(email: string, tenantId: string) {
-    const emailHash = computeEmailHash(email)
+    const emailHashes = emailHashLookupValues(email)
     return findOneWithDecryption(
       this.em,
       User,
@@ -40,7 +40,7 @@ export class AuthService {
         deletedAt: null,
         $or: [
           { email },
-          { emailHash },
+          { emailHash: { $in: emailHashes } },
         ],
       } as any,
       undefined,

--- a/packages/core/src/modules/customer_accounts/api/admin/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/__tests__/users.route.test.ts
@@ -275,7 +275,7 @@ describe('admin /api/customer_accounts/admin/users — GET search', () => {
     expect(Array.isArray(whereArg.$or)).toBe(true)
     expect(whereArg.$or).toEqual(expect.arrayContaining([
       { id: { $in: [tokenId] } },
-      expect.objectContaining({ emailHash: expect.any(String) }),
+      expect.objectContaining({ emailHash: { $in: expect.arrayContaining([expect.any(String)]) } }),
     ]))
   })
 
@@ -300,7 +300,7 @@ describe('admin /api/customer_accounts/admin/users — GET search', () => {
     expect(res.status).toBe(200)
     expect(mockEmFindAndCount).toHaveBeenCalled()
     const whereArg = mockEmFindAndCount.mock.calls[0][1] as Record<string, any>
-    expect(whereArg.$or).toEqual([expect.objectContaining({ emailHash: expect.any(String) })])
+    expect(whereArg.$or).toEqual([expect.objectContaining({ emailHash: { $in: expect.arrayContaining([expect.any(String)]) } })])
     expect(body.total).toBe(0)
   })
 })

--- a/packages/core/src/modules/customer_accounts/api/admin/users.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users.ts
@@ -11,7 +11,7 @@ import { adminCreateUserSchema } from '@open-mercato/core/modules/customer_accou
 import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 import { findAndCountWithDecryption, findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { isOwnedCompanyEntity } from '@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership'
-import { hashForLookup } from '@open-mercato/shared/lib/encryption/aes'
+import { lookupHashCandidates } from '@open-mercato/shared/lib/encryption/aes'
 import { E } from '#generated/entities.ids.generated'
 import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
 import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
@@ -83,7 +83,7 @@ export async function GET(req: Request) {
 
     // Also support exact email lookup via emailHash
     if (EMAIL_LIKE_PATTERN.test(search)) {
-      searchFilter.push({ emailHash: hashForLookup(search) })
+      searchFilter.push({ emailHash: { $in: lookupHashCandidates(search) } })
     }
 
     if (searchFilter.length > 0) {

--- a/packages/core/src/modules/customer_accounts/services/customerUserService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerUserService.ts
@@ -1,7 +1,8 @@
 import { EntityManager } from '@mikro-orm/postgresql'
 import { hash, compare } from 'bcryptjs'
 import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
-import { hashForLookup } from '@open-mercato/shared/lib/encryption/aes'
+import { hashForLookup, lookupHashCandidates } from '@open-mercato/shared/lib/encryption/aes'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 const BCRYPT_COST = 10
 const MAX_FAILED_ATTEMPTS = 5
@@ -33,12 +34,17 @@ export class CustomerUserService {
   }
 
   async findByEmail(email: string, tenantId: string): Promise<CustomerUser | null> {
-    const emailHash = hashForLookup(email)
-    return this.em.findOne(CustomerUser, {
-      emailHash,
-      tenantId,
-      deletedAt: null,
-    })
+    return findOneWithDecryption(
+      this.em,
+      CustomerUser,
+      {
+        emailHash: { $in: lookupHashCandidates(email) },
+        tenantId,
+        deletedAt: null,
+      } as any,
+      undefined,
+      { tenantId },
+    )
   }
 
   async findById(id: string, tenantId: string): Promise<CustomerUser | null> {

--- a/packages/core/src/modules/customer_accounts/subscribers/autoLinkCrmReverse.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/autoLinkCrmReverse.ts
@@ -1,6 +1,6 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
-import { hashForLookup } from '@open-mercato/shared/lib/encryption/aes'
+import { lookupHashCandidates } from '@open-mercato/shared/lib/encryption/aes'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 export const metadata = {
@@ -50,14 +50,14 @@ export default async function handle(
     const email = (entity as any).primaryEmail as string | null
     if (!email) return
 
-    const emailHash = hashForLookup(email.toLowerCase().trim())
+    const emailHashes = lookupHashCandidates(email.toLowerCase().trim())
 
     const { CustomerPersonProfile } = await import('@open-mercato/core/modules/customers/data/entities')
     const personProfile = await em.findOne(CustomerPersonProfile as any, { entity: (entity as any).id } as any) as any
     const companyEntityId = personProfile?.companyEntityId as string | undefined
 
     const customerUser = await em.findOne(CustomerUser, {
-      emailHash,
+      emailHash: { $in: emailHashes },
       tenantId,
       deletedAt: null,
       personEntityId: null,

--- a/packages/core/src/modules/messages/api/route.ts
+++ b/packages/core/src/modules/messages/api/route.ts
@@ -4,7 +4,7 @@ import { type Kysely, sql } from 'kysely'
 import type { CommandBus } from '@open-mercato/shared/lib/commands/command-bus'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi/types'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-import { hashForLookup } from '@open-mercato/shared/lib/encryption/aes'
+import { lookupHashCandidates } from '@open-mercato/shared/lib/encryption/aes'
 import { User } from '../../auth/data/entities'
 import { Message, MessageObject } from '../data/entities'
 import { composeMessageSchema, listMessagesSchema } from '../data/validators'
@@ -136,7 +136,7 @@ export async function GET(req: Request) {
     if (input.visibility) q = q.where('m.visibility', '=', input.visibility)
     if (input.sourceEntityType) q = q.where('m.source_entity_type', '=', input.sourceEntityType)
     if (input.sourceEntityId) q = q.where('m.source_entity_id', '=', input.sourceEntityId)
-    if (input.externalEmail) q = q.where('m.external_email_hash', '=', hashForLookup(input.externalEmail))
+    if (input.externalEmail) q = q.where('m.external_email_hash', 'in', lookupHashCandidates(input.externalEmail))
     if (input.senderId) q = q.where('m.sender_user_id', '=', input.senderId)
 
     if (input.search) {

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -222,6 +222,11 @@ TENANT_DATA_ENCRYPTION_DEBUG=false
 TENANT_DATA_ENCRYPTION_FALLBACK_KEY=dev-tenant-encryption-fallback-key-32chars
 # Legacy secondary fallback secret (optional)
 TENANT_DATA_ENCRYPTION_KEY=
+# Dedicated high-entropy pepper used to key lookup hashes (email_hash, external_email_hash, …)
+# so they cannot be attacked with offline rainbow tables or correlated across installations
+# (issue #2718). When unset, the encryption fallback/legacy keys above are used; if none are
+# configured the lookup hash falls back to the legacy unkeyed digest. Never reuse AUTH_SECRET here.
+LOOKUP_HASH_PEPPER=
 # HashiCorp Vault configuration (disabled by default in local dev).
 # Uncomment only if you actually run Vault locally; otherwise the fallback key above
 # is used immediately.

--- a/packages/shared/src/lib/encryption/__tests__/lookupHash.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/lookupHash.test.ts
@@ -1,0 +1,113 @@
+import crypto from 'node:crypto'
+import { hashForLookup, legacyHashForLookup, lookupHashCandidates } from '../aes'
+
+const originalEnv = { ...process.env }
+
+function clearLookupEnv() {
+  delete process.env.LOOKUP_HASH_PEPPER
+  delete process.env.TENANT_DATA_ENCRYPTION_FALLBACK_KEY
+  delete process.env.TENANT_DATA_ENCRYPTION_KEY
+}
+
+describe('hashForLookup keyed digest (issue #2718)', () => {
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('emits a keyed v2 HMAC when a lookup pepper is configured', () => {
+    clearLookupEnv()
+    process.env.LOOKUP_HASH_PEPPER = 'installation-pepper-secret-value'
+    const digest = hashForLookup('User@Example.com')
+    expect(digest.startsWith('v2:')).toBe(true)
+    const expected = crypto
+      .createHmac('sha256', 'installation-pepper-secret-value')
+      .update('user@example.com')
+      .digest('hex')
+    expect(digest).toBe(`v2:${expected}`)
+  })
+
+  it('is not equal to the legacy unkeyed sha256 (defeats precomputed rainbow tables)', () => {
+    clearLookupEnv()
+    process.env.LOOKUP_HASH_PEPPER = 'installation-pepper-secret-value'
+    const keyed = hashForLookup('user@example.com')
+    const legacy = legacyHashForLookup('user@example.com')
+    expect(keyed).not.toBe(legacy)
+    // The legacy digest is exactly what an attacker would precompute.
+    const naive = crypto.createHash('sha256').update('user@example.com').digest('hex')
+    expect(legacy).toBe(naive)
+    expect(keyed).not.toContain(naive)
+  })
+
+  it('produces different digests across installations (no cross-installation correlation)', () => {
+    clearLookupEnv()
+    process.env.LOOKUP_HASH_PEPPER = 'pepper-installation-a'
+    const a = hashForLookup('user@example.com')
+    process.env.LOOKUP_HASH_PEPPER = 'pepper-installation-b'
+    const b = hashForLookup('user@example.com')
+    expect(a).not.toBe(b)
+  })
+
+  it('binds the digest to the optional field/entity context (not portable across columns)', () => {
+    clearLookupEnv()
+    process.env.LOOKUP_HASH_PEPPER = 'installation-pepper-secret-value'
+    const withoutContext = hashForLookup('user@example.com')
+    const emailContext = hashForLookup('user@example.com', 'auth.user:email')
+    const phoneContext = hashForLookup('user@example.com', 'auth.user:phone')
+    expect(emailContext).not.toBe(withoutContext)
+    expect(emailContext).not.toBe(phoneContext)
+  })
+
+  it('normalizes case and surrounding whitespace before hashing', () => {
+    clearLookupEnv()
+    process.env.LOOKUP_HASH_PEPPER = 'installation-pepper-secret-value'
+    expect(hashForLookup('  User@Example.com  ')).toBe(hashForLookup('user@example.com'))
+  })
+
+  it('resolves the pepper from existing encryption secrets when no dedicated pepper is set', () => {
+    clearLookupEnv()
+    process.env.TENANT_DATA_ENCRYPTION_FALLBACK_KEY = 'fallback-secret'
+    const fromFallback = hashForLookup('user@example.com')
+    expect(fromFallback.startsWith('v2:')).toBe(true)
+
+    clearLookupEnv()
+    process.env.TENANT_DATA_ENCRYPTION_KEY = 'fallback-secret'
+    const fromKey = hashForLookup('user@example.com')
+    expect(fromKey).toBe(fromFallback)
+  })
+
+  it('prefers LOOKUP_HASH_PEPPER over the encryption fallback secrets', () => {
+    clearLookupEnv()
+    process.env.LOOKUP_HASH_PEPPER = 'dedicated-pepper'
+    process.env.TENANT_DATA_ENCRYPTION_FALLBACK_KEY = 'fallback-secret'
+    const expected = crypto
+      .createHmac('sha256', 'dedicated-pepper')
+      .update('user@example.com')
+      .digest('hex')
+    expect(hashForLookup('user@example.com')).toBe(`v2:${expected}`)
+  })
+
+  it('falls back to the legacy unkeyed digest only when no secret is configured', () => {
+    clearLookupEnv()
+    const digest = hashForLookup('user@example.com')
+    expect(digest.startsWith('v2:')).toBe(false)
+    expect(digest).toBe(legacyHashForLookup('user@example.com'))
+  })
+
+  it('exposes keyed and legacy candidates for migration-window reads', () => {
+    clearLookupEnv()
+    process.env.LOOKUP_HASH_PEPPER = 'installation-pepper-secret-value'
+    const candidates = lookupHashCandidates('user@example.com')
+    expect(candidates).toEqual([
+      hashForLookup('user@example.com'),
+      legacyHashForLookup('user@example.com'),
+    ])
+    expect(candidates).toHaveLength(2)
+  })
+
+  it('collapses candidates to a single value when running in legacy (no-pepper) mode', () => {
+    clearLookupEnv()
+    const candidates = lookupHashCandidates('user@example.com')
+    expect(candidates).toEqual([legacyHashForLookup('user@example.com')])
+    expect(candidates).toHaveLength(1)
+  })
+})

--- a/packages/shared/src/lib/encryption/aes.ts
+++ b/packages/shared/src/lib/encryption/aes.ts
@@ -80,8 +80,84 @@ export function decryptWithAesGcm(payload: string, dekBase64: string): string | 
   }
 }
 
-export function hashForLookup(value: string): string {
-  return crypto.createHash('sha256').update(value.toLowerCase().trim()).digest('hex')
+const LOOKUP_HASH_V2_PREFIX = 'v2:'
+
+function normalizeLookupValue(value: string): string {
+  return value.toLowerCase().trim()
+}
+
+/**
+ * Legacy, unkeyed lookup digest (`sha256(lower(trim(value)))`).
+ *
+ * @deprecated Unkeyed digests are vulnerable to offline rainbow-table attacks and
+ * cross-installation correlation (issue #2718). New writes use {@link hashForLookup},
+ * which emits a keyed `v2:` HMAC when a lookup pepper is configured. This helper is
+ * retained only so existing `*_hash` columns written before the keyed format can still
+ * be matched (see {@link lookupHashCandidates}) until a backfill migration recomputes them.
+ */
+export function legacyHashForLookup(value: string): string {
+  return crypto.createHash('sha256').update(normalizeLookupValue(value)).digest('hex')
+}
+
+/**
+ * Resolve the installation-wide lookup pepper used to key lookup hashes.
+ *
+ * Order of precedence (never `AUTH_SECRET`, per issue #2718):
+ * 1. `LOOKUP_HASH_PEPPER` — dedicated secret for lookup hashing
+ * 2. `TENANT_DATA_ENCRYPTION_FALLBACK_KEY` — existing encryption fallback secret
+ * 3. `TENANT_DATA_ENCRYPTION_KEY` — existing encryption secret
+ *
+ * Returns `null` when no secret is configured, in which case {@link hashForLookup}
+ * falls back to the legacy unkeyed digest so deployments without any configured key
+ * keep working unchanged.
+ */
+function resolveLookupPepper(): string | null {
+  const candidates = [
+    process.env.LOOKUP_HASH_PEPPER,
+    process.env.TENANT_DATA_ENCRYPTION_FALLBACK_KEY,
+    process.env.TENANT_DATA_ENCRYPTION_KEY,
+  ]
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue
+    const normalized = candidate.trim().replace(/(?:^['"]|['"]$)/g, '')
+    if (normalized) return normalized
+  }
+  return null
+}
+
+/**
+ * Compute a deterministic lookup hash for a low-entropy PII value (email, phone, …).
+ *
+ * When a lookup pepper is configured the result is a keyed HMAC-SHA-256 prefixed with
+ * `v2:` and bound to the optional `context` (entity/field) so digests are not portable
+ * across columns, installations, or tenants without the secret. When no pepper is
+ * configured it falls back to the legacy unkeyed digest for backward compatibility.
+ *
+ * The `context` MUST be supplied identically on both the write and the read side for a
+ * given column; callers that do not pass one stay mutually consistent.
+ */
+export function hashForLookup(value: string, context?: string): string {
+  const pepper = resolveLookupPepper()
+  const normalized = normalizeLookupValue(value)
+  if (!pepper) {
+    return legacyHashForLookup(value)
+  }
+  const message = context ? `${context}:${normalized}` : normalized
+  const digest = crypto.createHmac('sha256', pepper).update(message).digest('hex')
+  return `${LOOKUP_HASH_V2_PREFIX}${digest}`
+}
+
+/**
+ * Candidate lookup hashes for matching a value against `*_hash` columns that may hold
+ * either the new keyed (`v2:`) digest or a legacy unkeyed digest. Use this in `$in` /
+ * `IN (...)` filters during the migration window so reads keep matching rows written
+ * before the keyed format. Once a backfill has recomputed all columns this can collapse
+ * back to a single {@link hashForLookup} value.
+ */
+export function lookupHashCandidates(value: string, context?: string): string[] {
+  const primary = hashForLookup(value, context)
+  const legacy = legacyHashForLookup(value)
+  return primary === legacy ? [primary] : [primary, legacy]
 }
 
 /**


### PR DESCRIPTION
Fixes #2718

## Problem
`hashForLookup` computed a plain `sha256(value.toLowerCase().trim())` with no salt, pepper, HMAC key, or field/tenant context. Its output is stored in lookup columns (`email_hash`, `external_email_hash`, …) right next to the AES-GCM ciphertext of the same low-entropy PII. An attacker with read access to a DB dump could:
- run existence/dictionary attacks (deterministic normalization),
- apply one precomputed rainbow table across every tenant of every deployment (no per-installation pepper),
- correlate the same value across tenants and columns.

This defeats the at-rest encryption guarantee for the indexed PII even when the ciphertext column is sound.

## Root Cause
`packages/shared/src/lib/encryption/aes.ts` `hashForLookup` used an unkeyed digest. The same digest was written by `tenantDataEncryptionService` for every `hashField` and read back by auth, messages, and customer_accounts lookups.

## What Changed
- `hashForLookup(value, context?)` now emits a **keyed HMAC-SHA-256** prefixed with `v2:` when a lookup pepper is configured, bound to optional entity/field `context` so digests are not portable across columns/installations/tenants without the secret. When no pepper is configured it falls back to the legacy unkeyed digest so unconfigured deployments keep working.
- Pepper resolution order: `LOOKUP_HASH_PEPPER` → `TENANT_DATA_ENCRYPTION_FALLBACK_KEY` → `TENANT_DATA_ENCRYPTION_KEY`. **Never `AUTH_SECRET`** (per the issue).
- Added `legacyHashForLookup` (`@deprecated`) and `lookupHashCandidates(value, context?)` for migration-window dual-read.
- New writes emit the keyed `v2:` hash; every **read** site now matches both the keyed and legacy digests via `$in` / `IN (...)` (`emailHashLookupValues` / `lookupHashCandidates`) so logins, duplicate checks, message lookups, and customer_accounts lookups keep matching rows written before the keyed format — no backfill required to stay functional. A backfill can collapse the dual-read later.
- Read sites updated: `authService` (3 lookups), auth `commands/users` duplicate checks (create + update), auth `cli setPassword` (also moved off raw `em.findOne` to `findOneWithDecryption`), `customerUserService.findByEmail`, customer_accounts admin user search, `autoLinkCrmReverse`, messages list `external_email` filter.
- Documented `LOOKUP_HASH_PEPPER` in `apps/mercato/.env.example` and the create-app template `.env.example`.

## Tests
- New `packages/shared/src/lib/encryption/__tests__/lookupHash.test.ts` (10 cases): keyed `v2` HMAC output, not-equal-to-legacy / no-rainbow-table property, cross-installation non-portability, field/context binding, normalization, pepper resolution order + precedence, legacy no-pepper fallback, and dual-read candidate behavior (keyed+legacy / collapsed). Verified red-before-fix (9 failed without the change) → green-after (10 pass).
- `yarn workspace @open-mercato/shared test` — 1191 pass.
- Related core suites pass (`authService`, `emailHash`, `customerUser`, auth command users, messages: 191 + 16 pass).
- `yarn build:packages`, `yarn generate`, `yarn typecheck` (all 21 workspaces) pass.
- `yarn i18n:check-sync` clean (no translation keys changed).

Note: app-level `yarn lint` fails with a pre-existing ESLint/Next plugin tooling error (`react/no-direct-mutation-state: contextOrFilename.getFilename is not a function`) on `develop`, unrelated to this change (no app/.tsx files touched).

## Backward Compatibility
- `hashForLookup` signature is additive (optional `context`) — no caller breakage. New exports are additive. `kms.ts` re-export unchanged.
- Hash **values** change to `v2:` when a pepper is configured; this is runtime data, not a typed contract surface. Existing `*_hash` columns remain matchable via the dual-read at every read site, so logins/lookups keep working without first running a backfill.
- No API response fields, event IDs, widget spot IDs, ACL IDs, DI names, or import paths changed.