### PR TITLE
security(onboarding): verify endpoint no longer clears auth cookies on error paths (#2714)

### DIFF
--- a/packages/onboarding/src/__tests__/verify-redirects.test.ts
+++ b/packages/onboarding/src/__tests__/verify-redirects.test.ts
@@ -1,0 +1,75 @@
+/** @jest-environment node */
+import {
+  redirectToLogin,
+  redirectToPreparing,
+  redirectWithStatus,
+} from '../modules/onboarding/lib/verify-redirects'
+
+const AUTH_COOKIES = ['auth_token', 'session_token', 'om_login_tenant'] as const
+
+function getCookie(response: ReturnType<typeof redirectWithStatus>, name: string) {
+  return response.cookies.get(name)
+}
+
+describe('onboarding verify redirect helpers', () => {
+  describe('redirectWithStatus (validation / error paths)', () => {
+    it('does NOT clear auth cookies on any status path (logout CSRF guard)', () => {
+      for (const status of ['invalid', 'error', 'already_exists']) {
+        const response = redirectWithStatus('https://app.example.com', status)
+        for (const cookieName of AUTH_COOKIES) {
+          expect(getCookie(response, cookieName)).toBeUndefined()
+        }
+      }
+    })
+
+    it('redirects to the onboarding status URL', () => {
+      const response = redirectWithStatus('https://app.example.com', 'invalid')
+      expect(response.headers.get('location')).toBe(
+        'https://app.example.com/onboarding?status=invalid',
+      )
+    })
+
+    it('does not mutate cookies even for an attacker-supplied error path', () => {
+      const response = redirectWithStatus('https://app.example.com', 'error')
+      expect(response.cookies.getAll()).toHaveLength(0)
+    })
+  })
+
+  describe('redirectToPreparing (success transition)', () => {
+    it('clears auth_token and session_token', () => {
+      const response = redirectToPreparing('https://app.example.com', 'tenant-123')
+      expect(getCookie(response, 'auth_token')?.value).toBe('')
+      expect(getCookie(response, 'auth_token')?.maxAge).toBe(0)
+      expect(getCookie(response, 'session_token')?.value).toBe('')
+      expect(getCookie(response, 'session_token')?.maxAge).toBe(0)
+    })
+
+    it('sets om_login_tenant to the provisioned tenant id', () => {
+      const response = redirectToPreparing('https://app.example.com', 'tenant-123')
+      const tenantCookie = getCookie(response, 'om_login_tenant')
+      expect(tenantCookie?.value).toBe('tenant-123')
+      expect(tenantCookie?.maxAge).toBeGreaterThan(0)
+    })
+
+    it('clears om_login_tenant when no tenant id is provided', () => {
+      const response = redirectToPreparing('https://app.example.com', null)
+      expect(getCookie(response, 'om_login_tenant')?.value).toBe('')
+      expect(getCookie(response, 'om_login_tenant')?.maxAge).toBe(0)
+    })
+  })
+
+  describe('redirectToLogin (success transition)', () => {
+    it('clears auth_token and session_token', () => {
+      const response = redirectToLogin('https://app.example.com', 'tenant-123')
+      expect(getCookie(response, 'auth_token')?.value).toBe('')
+      expect(getCookie(response, 'auth_token')?.maxAge).toBe(0)
+      expect(getCookie(response, 'session_token')?.value).toBe('')
+      expect(getCookie(response, 'session_token')?.maxAge).toBe(0)
+    })
+
+    it('sets om_login_tenant to the provisioned tenant id', () => {
+      const response = redirectToLogin('https://app.example.com', 'tenant-123')
+      expect(getCookie(response, 'om_login_tenant')?.value).toBe('tenant-123')
+    })
+  })
+})

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
@@ -1,4 +1,4 @@
-import { after, NextResponse } from 'next/server'
+import { after } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { SearchIndexer } from '@open-mercato/search'
@@ -11,6 +11,11 @@ import {
 import { onboardingVerifySchema } from '@open-mercato/onboarding/modules/onboarding/data/validators'
 import { OnboardingService } from '@open-mercato/onboarding/modules/onboarding/lib/service'
 import { sendWorkspaceReadyEmail } from '@open-mercato/onboarding/modules/onboarding/lib/ready-email'
+import {
+  redirectToLogin,
+  redirectToPreparing,
+  redirectWithStatus,
+} from '@open-mercato/onboarding/modules/onboarding/lib/verify-redirects'
 import { setupInitialTenant } from '@open-mercato/core/modules/auth/lib/setup-app'
 import { UserConsent } from '@open-mercato/core/modules/auth/data/entities'
 import { computeConsentIntegrityHash } from '@open-mercato/core/modules/auth/lib/consentIntegrity'
@@ -43,50 +48,6 @@ function resolveTrustedBaseUrl(req: Request): string {
     }
     throw error
   }
-}
-
-function clearAuthCookies(response: NextResponse) {
-  response.cookies.set('auth_token', '', { path: '/', maxAge: 0 })
-  response.cookies.set('session_token', '', { path: '/', maxAge: 0 })
-  response.cookies.set('om_login_tenant', '', { path: '/', maxAge: 0 })
-}
-
-function redirectWithStatus(baseUrl: string, status: string) {
-  const response = NextResponse.redirect(`${baseUrl}/onboarding?status=${encodeURIComponent(status)}`)
-  clearAuthCookies(response)
-  return response
-}
-
-function redirectToPreparing(baseUrl: string, tenantId: string | null) {
-  const tenantParam = tenantId ? `?tenant=${encodeURIComponent(tenantId)}` : ''
-  const response = NextResponse.redirect(`${baseUrl}/onboarding/preparing${tenantParam}`)
-  clearAuthCookies(response)
-  if (tenantId) {
-    response.cookies.set('om_login_tenant', tenantId, {
-      httpOnly: false,
-      sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
-      path: '/',
-      maxAge: 60 * 60 * 24 * 14,
-    })
-  }
-  return response
-}
-
-function redirectToLogin(baseUrl: string, tenantId: string | null) {
-  const tenantParam = tenantId ? `?tenant=${encodeURIComponent(tenantId)}` : ''
-  const response = NextResponse.redirect(`${baseUrl}/login${tenantParam}`)
-  clearAuthCookies(response)
-  if (tenantId) {
-    response.cookies.set('om_login_tenant', tenantId, {
-      httpOnly: false,
-      sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
-      path: '/',
-      maxAge: 60 * 60 * 24 * 14,
-    })
-  }
-  return response
 }
 
 const VECTOR_REINDEX_ENQUEUE_TIMEOUT_MS = 5_000

--- a/packages/onboarding/src/modules/onboarding/lib/verify-redirects.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/verify-redirects.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+
+const TENANT_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 14
+
+function clearAuthCookies(response: NextResponse) {
+  response.cookies.set('auth_token', '', { path: '/', maxAge: 0 })
+  response.cookies.set('session_token', '', { path: '/', maxAge: 0 })
+  response.cookies.set('om_login_tenant', '', { path: '/', maxAge: 0 })
+}
+
+function setTenantCookie(response: NextResponse, tenantId: string) {
+  response.cookies.set('om_login_tenant', tenantId, {
+    httpOnly: false,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: TENANT_COOKIE_MAX_AGE_SECONDS,
+  })
+}
+
+export function redirectWithStatus(baseUrl: string, status: string) {
+  return NextResponse.redirect(`${baseUrl}/onboarding?status=${encodeURIComponent(status)}`)
+}
+
+export function redirectToPreparing(baseUrl: string, tenantId: string | null) {
+  const tenantParam = tenantId ? `?tenant=${encodeURIComponent(tenantId)}` : ''
+  const response = NextResponse.redirect(`${baseUrl}/onboarding/preparing${tenantParam}`)
+  clearAuthCookies(response)
+  if (tenantId) {
+    setTenantCookie(response, tenantId)
+  }
+  return response
+}
+
+export function redirectToLogin(baseUrl: string, tenantId: string | null) {
+  const tenantParam = tenantId ? `?tenant=${encodeURIComponent(tenantId)}` : ''
+  const response = NextResponse.redirect(`${baseUrl}/login${tenantParam}`)
+  clearAuthCookies(response)
+  if (tenantId) {
+    setTenantCookie(response, tenantId)
+  }
+  return response
+}


### PR DESCRIPTION
Fixes #2714

## Problem
The onboarding token-verification endpoint (`GET /onboarding/onboarding/verify`, `requireAuth: false`, no CSRF/Origin/Referer protection) cleared the visitor's `auth_token`, `session_token`, and `om_login_tenant` cookies on **every** redirect path — including all validation-failure paths (schema-invalid, unknown token, expired, wrong status, missing password, and the `error`/`already_exists` catch paths). Because the route only requires a 32+ character `token` value, any third-party page could embed the URL (`<img>`, iframe, link, auto-redirect) and force a logged-in staff user's session cookies to be wiped — a logout CSRF.

## Root Cause
`redirectWithStatus()` — used by all error/validation responses — called `clearAuthCookies()` unconditionally. Those responses merely report validation status to the onboarding UI and have no reason to mutate an existing session.

## What Changed
- Extracted the three redirect helpers (`redirectWithStatus`, `redirectToPreparing`, `redirectToLogin`) and `clearAuthCookies` into a dependency-light `lib/verify-redirects.ts` so the cookie behavior is unit-testable in isolation.
- `redirectWithStatus()` no longer clears auth cookies. Cookie clearing now happens only on the legitimate success transitions (`redirectToPreparing` / `redirectToLogin`), where the user is being moved into the newly provisioned tenant.
- `verify.ts` now imports these helpers; dropped the now-unused `NextResponse` import.

The route path, HTTP method, `requireAuth: false`, query schema, and OpenAPI doc are all unchanged.

## Tests
- New `src/__tests__/verify-redirects.test.ts`:
  - asserts `redirectWithStatus` sets **zero** cookies for `invalid` / `error` / `already_exists` (the logout-CSRF guard) — verified red before the fix, green after.
  - asserts `redirectToPreparing` / `redirectToLogin` still clear `auth_token`/`session_token` and set `om_login_tenant` on the success transitions.
- Full onboarding suite: 49/49 passing. `yarn typecheck` clean. `yarn build:packages` + `yarn generate` produce no churn.

## Backward Compatibility
- No contract surface changes. Route metadata, query schema, and OpenAPI doc unchanged. The extracted helpers were previously private (not exported); exporting them from a new lib module is additive.
- Intentional behavior change: error/validation responses no longer reset the visitor's session — this is the security fix itself.