### PR TITLE
security(security): validate sudo step-up token payload shape at parse time (#2711)

### DIFF
--- a/packages/enterprise/src/modules/security/services/SudoChallengeService.ts
+++ b/packages/enterprise/src/modules/security/services/SudoChallengeService.ts
@@ -1,4 +1,5 @@
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+import { z } from 'zod'
 import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { User } from '@open-mercato/core/modules/auth/data/entities'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -38,14 +39,16 @@ export type SudoProtectionResolution = {
   config?: SudoChallengeConfig
 }
 
-type SignedSudoTokenPayload = {
-  sid: string
-  sub: string
-  tid: string | null
-  oid: string | null
-  tgt: string
-  exp: number
-}
+const signedSudoTokenPayloadSchema = z.object({
+  sid: z.string(),
+  sub: z.string(),
+  tid: z.string().nullable(),
+  oid: z.string().nullable(),
+  tgt: z.string(),
+  exp: z.number(),
+})
+
+type SignedSudoTokenPayload = z.infer<typeof signedSudoTokenPayloadSchema>
 
 type UserScope = {
   id: string
@@ -665,9 +668,11 @@ export class SudoChallengeService {
     if (!timingSafeEqual(signatureBuffer, expectedBuffer)) return null
 
     try {
-      const parsed = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as SignedSudoTokenPayload
-      if (!parsed || typeof parsed !== 'object') return null
-      return parsed
+      const parsed = signedSudoTokenPayloadSchema.safeParse(
+        JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')),
+      )
+      if (!parsed.success) return null
+      return parsed.data
     } catch {
       return null
     }

--- a/packages/enterprise/src/modules/security/services/__tests__/SudoChallengeService.test.ts
+++ b/packages/enterprise/src/modules/security/services/__tests__/SudoChallengeService.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'node:crypto'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { ChallengeMethod, SudoChallengeConfig } from '../../data/entities'
@@ -39,6 +40,21 @@ type SessionRecord = {
 }
 
 const mockedFindOneWithDecryption = findOneWithDecryption as jest.MockedFunction<typeof findOneWithDecryption>
+
+function getSudoTestSecret(): string {
+  return process.env.OM_SECURITY_SUDO_SECRET
+    ?? process.env.AUTH_JWT_SECRET
+    ?? process.env.JWT_SECRET
+    ?? 'open-mercato-sudo-secret'
+}
+
+function signSudoTokenWithPayload(payload: unknown): string {
+  const encodedPayload = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url')
+  const signature = createHmac('sha256', getSudoTestSecret())
+    .update(encodedPayload)
+    .digest('base64url')
+  return `${encodedPayload}.${signature}`
+}
 
 function createServiceContext(
   securityConfig: SecurityModuleConfig = defaultSecurityModuleConfig,
@@ -437,6 +453,99 @@ describe('SudoChallengeService', () => {
 
       await service.deleteConfig('config-a', superAdminScope)
       expect(configs[0].deletedAt).toBeInstanceOf(Date)
+    })
+  })
+
+  describe('signed token payload shape validation', () => {
+    const validPayload = {
+      sid: 'session-shape-1',
+      sub: 'user-1',
+      tid: 'tenant-1',
+      oid: 'org-1',
+      tgt: 'security.sudo.manage',
+      exp: Date.now() + 60_000,
+    }
+
+    function seedMatchingSession(sessions: SessionRecord[], token: string) {
+      sessions.push({
+        id: validPayload.sid,
+        userId: validPayload.sub,
+        tenantId: 'tenant-1',
+        sessionToken: token,
+        challengeMethod: 'password',
+        expiresAt: new Date(Date.now() + 60_000),
+        createdAt: new Date(),
+      })
+    }
+
+    test('rejects an HMAC-valid token whose payload is missing the exp field even when a live session exists', async () => {
+      const { service, sessions } = createServiceContext()
+      const { exp: _exp, ...withoutExp } = validPayload
+      const token = signSudoTokenWithPayload(withoutExp)
+      seedMatchingSession(sessions, token)
+
+      await expect(
+        service.validateToken(token, 'security.sudo.manage', {
+          expectedUserId: 'user-1',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+        }),
+      ).resolves.toBe(false)
+    })
+
+    test('rejects an HMAC-valid token whose exp is not numeric even when a live session exists', async () => {
+      const { service, sessions } = createServiceContext()
+      const token = signSudoTokenWithPayload({ ...validPayload, exp: 'not-a-number' })
+      seedMatchingSession(sessions, token)
+
+      await expect(
+        service.validateToken(token, 'security.sudo.manage', {
+          expectedUserId: 'user-1',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+        }),
+      ).resolves.toBe(false)
+    })
+
+    test('rejects an HMAC-valid token whose payload is not an object', async () => {
+      const { service } = createServiceContext()
+      const token = signSudoTokenWithPayload('totally-not-a-payload')
+
+      await expect(
+        service.validateToken(token, 'security.sudo.manage', {
+          expectedUserId: 'user-1',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+        }),
+      ).resolves.toBe(false)
+    })
+
+    test('rejects an HMAC-valid token whose tid has the wrong type even when a live session exists', async () => {
+      const { service, sessions } = createServiceContext()
+      const token = signSudoTokenWithPayload({ ...validPayload, tid: 42 })
+      seedMatchingSession(sessions, token)
+
+      await expect(
+        service.validateToken(token, 'security.sudo.manage', {
+          expectedUserId: 'user-1',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+        }),
+      ).resolves.toBe(false)
+    })
+
+    test('accepts an HMAC-valid token with a well-formed payload and a live session', async () => {
+      const { service, sessions } = createServiceContext()
+      const token = signSudoTokenWithPayload(validPayload)
+      seedMatchingSession(sessions, token)
+
+      await expect(
+        service.validateToken(token, 'security.sudo.manage', {
+          expectedUserId: 'user-1',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+        }),
+      ).resolves.toBe(true)
     })
   })
 })


### PR DESCRIPTION
Fixes #2711

## Problem
`readSignedToken` in `SudoChallengeService` parsed the HMAC-verified token JSON and only checked that the result was a non-null object before casting it to `SignedSudoTokenPayload`. None of the individual fields (`exp`, `tgt`, `sub`, `tid`, `oid`) were validated at runtime.

## Root Cause
With a structurally invalid payload reaching `validateToken`, the freshness check `payload.exp <= Date.now()` becomes `undefined <= Date.now()` (`false`), silently skipping the in-token TTL check and leaving only the DB `expiresAt` row check as the surviving TTL enforcement. This is a defense-in-depth / fail-open weakness that invites a regression (report.md finding #89, MEDIUM).

## What Changed
- Added a `signedSudoTokenPayloadSchema` zod schema (`sid`/`sub`/`tgt` strings, `tid`/`oid` nullable strings, `exp` number) and derived `SignedSudoTokenPayload` from it via `z.infer` (identical shape — no contract change).
- `readSignedToken` now `safeParse`s the decoded JSON against the schema and returns `null` when the shape does not match, so a structurally invalid token is rejected outright instead of being trusted downstream.

## Tests
- Added a `signed token payload shape validation` suite to `SudoChallengeService.test.ts`. The missing-`exp` and non-numeric-`exp` cases seed a live matching session so that, before the fix, `validateToken` fails open and returns `true`; both now correctly return `false`. Also covers a non-object payload, a wrong-typed `tid`, and a positive control (well-formed payload + live session ⇒ `true`).
- Verified red-before-fix: the two `exp` cases returned `true` with the fix reverted, then pass after re-applying it.
- `yarn workspace @open-mercato/enterprise jest` for `SudoChallengeService.test.ts` (16 passed) and `challenge.route.test.ts` (4 passed).
- `yarn build:packages`, `yarn generate`, and `yarn workspace @open-mercato/enterprise typecheck` all pass clean.

## Backward Compatibility
- No contract surface changes. `SignedSudoTokenPayload` is an internal, non-exported type; the zod-derived type is structurally identical. zod is already a production dependency. No API response fields, event IDs, DI names, or import paths changed. Behavior is strictly fail-closed.