### PR TITLE
security(onboarding): bind onboarding status endpoint to tenant cookie (#2713)

### DIFF
--- a/packages/onboarding/src/__tests__/status-endpoint-auth.test.ts
+++ b/packages/onboarding/src/__tests__/status-endpoint-auth.test.ts
@@ -1,0 +1,111 @@
+import { OnboardingRequest } from '../modules/onboarding/data/entities'
+
+const findLatestByTenantId = jest.fn()
+const sendWorkspaceReadyEmail = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (name: string) => {
+      if (name === 'em') return {}
+      throw new Error(`unexpected resolve(${name})`)
+    },
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/url', () => ({
+  getSecurityEmailBaseUrl: () => 'https://app.example.com',
+  mapSecurityEmailUrlError: () => null,
+}))
+
+jest.mock('@open-mercato/onboarding/modules/onboarding/lib/service', () => ({
+  OnboardingService: jest.fn().mockImplementation(() => ({
+    findLatestByTenantId,
+  })),
+}))
+
+jest.mock('@open-mercato/onboarding/modules/onboarding/lib/ready-email', () => ({
+  sendWorkspaceReadyEmail,
+}))
+
+import { GET } from '../modules/onboarding/api/get/onboarding/status'
+
+const TENANT_ID = '11111111-1111-4111-8111-111111111111'
+const OTHER_TENANT_ID = '22222222-2222-4222-8222-222222222222'
+
+function makeRequest(overrides: Record<string, unknown> = {}) {
+  return Object.assign(new OnboardingRequest(), {
+    id: 'req-1',
+    status: 'completed',
+    tenantId: TENANT_ID,
+    organizationId: 'org-1',
+    preparationCompletedAt: new Date(),
+    readyEmailSentAt: new Date(),
+    ...overrides,
+  })
+}
+
+function buildRequest(args: { tenantId: string; cookie?: string }) {
+  const headers = new Headers()
+  if (args.cookie !== undefined) headers.set('cookie', args.cookie)
+  return new Request(`https://app.example.com/api/onboarding/onboarding/status?tenantId=${args.tenantId}`, {
+    headers,
+  })
+}
+
+describe('onboarding status endpoint authorization', () => {
+  beforeEach(() => {
+    findLatestByTenantId.mockReset()
+    sendWorkspaceReadyEmail.mockReset()
+    findLatestByTenantId.mockResolvedValue(makeRequest())
+  })
+
+  it('returns 403 and does not look up tenant state when no om_login_tenant cookie is present', async () => {
+    const res = await GET(buildRequest({ tenantId: TENANT_ID }))
+    expect(res.status).toBe(403)
+    const body = await res.json()
+    expect(body).toEqual({ ok: false, error: 'Not authorized for this tenant.' })
+    expect(findLatestByTenantId).not.toHaveBeenCalled()
+    expect(sendWorkspaceReadyEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when the om_login_tenant cookie is for a different tenant', async () => {
+    const res = await GET(
+      buildRequest({ tenantId: TENANT_ID, cookie: `om_login_tenant=${OTHER_TENANT_ID}` }),
+    )
+    expect(res.status).toBe(403)
+    expect(findLatestByTenantId).not.toHaveBeenCalled()
+    expect(sendWorkspaceReadyEmail).not.toHaveBeenCalled()
+  })
+
+  it('does not trigger the ready email side effect for an unauthorized caller', async () => {
+    findLatestByTenantId.mockResolvedValue(
+      makeRequest({ readyEmailSentAt: null }),
+    )
+    const res = await GET(
+      buildRequest({ tenantId: TENANT_ID, cookie: `om_login_tenant=${OTHER_TENANT_ID}` }),
+    )
+    expect(res.status).toBe(403)
+    expect(sendWorkspaceReadyEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns the status when the om_login_tenant cookie matches the requested tenant', async () => {
+    const res = await GET(
+      buildRequest({ tenantId: TENANT_ID, cookie: `other=foo; om_login_tenant=${TENANT_ID}` }),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.tenantId).toBe(TENANT_ID)
+    expect(body.ready).toBe(true)
+    expect(body.loginUrl).toBe(`https://app.example.com/login?tenant=${TENANT_ID}`)
+    expect(findLatestByTenantId).toHaveBeenCalledWith(TENANT_ID)
+  })
+
+  it('returns 404 for an authorized caller when no onboarding record exists', async () => {
+    findLatestByTenantId.mockResolvedValue(null)
+    const res = await GET(
+      buildRequest({ tenantId: TENANT_ID, cookie: `om_login_tenant=${TENANT_ID}` }),
+    )
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
@@ -14,9 +14,29 @@ export const metadata = {
   },
 }
 
+const ONBOARDING_LOGIN_TENANT_COOKIE = 'om_login_tenant'
+
 const onboardingStatusQuerySchema = z.object({
   tenantId: z.string().uuid(),
 })
+
+function readCookie(req: Request, name: string): string | null {
+  const header = req.headers.get('cookie')
+  if (!header) return null
+  for (const part of header.split(';')) {
+    const separatorIndex = part.indexOf('=')
+    if (separatorIndex === -1) continue
+    const key = part.slice(0, separatorIndex).trim()
+    if (key !== name) continue
+    const rawValue = part.slice(separatorIndex + 1).trim()
+    try {
+      return decodeURIComponent(rawValue)
+    } catch {
+      return rawValue
+    }
+  }
+  return null
+}
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
@@ -24,6 +44,11 @@ export async function GET(req: Request) {
   const parsed = onboardingStatusQuerySchema.safeParse({ tenantId })
   if (!parsed.success) {
     return NextResponse.json({ ok: false, error: 'Invalid tenant id.' }, { status: 400 })
+  }
+
+  const loginTenantCookie = readCookie(req, ONBOARDING_LOGIN_TENANT_COOKIE)
+  if (!loginTenantCookie || loginTenantCookie !== parsed.data.tenantId) {
+    return NextResponse.json({ ok: false, error: 'Not authorized for this tenant.' }, { status: 403 })
   }
 
   let baseUrl: string
@@ -101,6 +126,7 @@ const onboardingStatusDoc: OpenApiMethodDoc = {
   ],
   errors: [
     { status: 400, description: 'Invalid tenant id or request origin.', schema: onboardingStatusErrorSchema },
+    { status: 403, description: 'Caller is not authorized for this tenant.', schema: onboardingStatusErrorSchema },
     { status: 404, description: 'Onboarding request not found.', schema: onboardingStatusErrorSchema },
     { status: 500, description: 'Onboarding status is not configured.', schema: onboardingStatusErrorSchema },
   ],


### PR DESCRIPTION
Fixes #2713

## Problem
The unauthenticated `GET /onboarding/onboarding/status` endpoint (`requireAuth: false`) looked up onboarding records by a caller-supplied tenant UUID with no authorization, signed token, or session binding. Anyone holding (or leaking) a tenant UUID could probe tenant state across the whole installation: existence (404 vs 200), `status`, `emailSent`, `ready`, and a constructed `loginUrl`. The endpoint also triggered `sendWorkspaceReadyEmail` when `ready && !readyEmailSentAt`, so an unauthenticated request could drive an email send for a tenant the caller does not own.

## Root Cause
`status.ts` validated only that `tenantId` is a well-formed UUID, then called `service.findLatestByTenantId(tenantId)` and returned tenant state plus the login URL — with no proof the caller is authorized for that tenant.

## What Changed
- `packages/onboarding/.../api/get/onboarding/status.ts`: parse the `om_login_tenant` cookie (set server-side by the onboarding verify flow) and require it to match the requested `tenantId`. If it is absent or mismatched, return `403` **before** any tenant lookup, data disclosure, or email dispatch.
- Added the `403` error to the route's OpenAPI doc.
- The legitimate preparing-page poll (`PreparingPageClient`) already carries this cookie (set by `verify.ts` with `path: '/'`), so its behavior is unchanged.

## Tests
- New `status-endpoint-auth.test.ts`:
  - `403` + no tenant lookup + no email when the cookie is absent
  - `403` + no lookup + no email when the cookie is for a different tenant
  - email side effect not triggered for unauthorized callers
  - `200` happy path when the cookie matches
  - `404` for an authorized caller with no onboarding record
- Verified red-before-fix (3 authorization assertions fail against the unpatched handler), green after.
- `yarn workspace @open-mercato/onboarding test` — 46 passed
- `yarn workspace @open-mercato/onboarding typecheck` — clean
- `yarn i18n:check-sync` — in sync

## Backward Compatibility
- No frozen/stable contract surface broken: route path, method, `requireAuth: false`, and success response schema are unchanged. The change adds a new `403` error response and a cookie-binding requirement that the only legitimate caller already satisfies. No API response fields removed; no event/widget/ACL/DI/import-path changes.