### PR TITLE
security(onboarding): trusted base URL for email links & verify redirects (#2712)

### DIFF
--- a/packages/onboarding/src/__tests__/ready-email.test.ts
+++ b/packages/onboarding/src/__tests__/ready-email.test.ts
@@ -1,0 +1,114 @@
+import { OnboardingRequest } from '../modules/onboarding/data/entities'
+
+const sendEmailMock = jest.fn().mockResolvedValue(undefined)
+const findByIdMock = jest.fn()
+const markReadyEmailSentMock = jest.fn().mockResolvedValue(undefined)
+const workspaceReadyEmailMock = jest.fn().mockReturnValue(null)
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn().mockResolvedValue({
+    resolve: () => ({}),
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/email/send', () => ({
+  sendEmail: (...args: unknown[]) => sendEmailMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  loadDictionary: jest.fn().mockResolvedValue({}),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/translate', () => ({
+  createFallbackTranslator: () => (_key: string, fallback: string) => fallback,
+}))
+
+jest.mock('@open-mercato/onboarding/modules/onboarding/lib/service', () => ({
+  OnboardingService: jest.fn().mockImplementation(() => ({
+    findById: (...args: unknown[]) => findByIdMock(...args),
+    markReadyEmailSent: (...args: unknown[]) => markReadyEmailSentMock(...args),
+  })),
+}))
+
+jest.mock('@open-mercato/onboarding/modules/onboarding/emails/WorkspaceReadyEmail', () => ({
+  __esModule: true,
+  default: (props: { loginUrl: string }) => workspaceReadyEmailMock(props),
+}))
+
+import { sendWorkspaceReadyEmail } from '../modules/onboarding/lib/ready-email'
+
+function makeReadyRequest(overrides: Record<string, unknown> = {}) {
+  return Object.assign(new OnboardingRequest(), {
+    id: 'req-1',
+    email: 'owner@example.com',
+    status: 'completed',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    organizationName: 'Acme Corp',
+    locale: 'en',
+    tenantId: 'tenant-uuid',
+    readyEmailSentAt: null,
+    ...overrides,
+  })
+}
+
+describe('sendWorkspaceReadyEmail', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    delete process.env.NEXT_PUBLIC_APP_URL
+    delete process.env.APP_URL
+    delete process.env.APP_ALLOWED_ORIGINS
+    process.env.NODE_ENV = 'test'
+    findByIdMock.mockResolvedValue(makeReadyRequest())
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('builds the login link from the configured APP_URL, not a request header', async () => {
+    process.env.APP_URL = 'https://app.openmercato.com'
+
+    const sent = await sendWorkspaceReadyEmail({ requestId: 'req-1', tenantId: 'tenant-uuid' })
+
+    expect(sent).toBe(true)
+    expect(workspaceReadyEmailMock).toHaveBeenCalledTimes(1)
+    const props = workspaceReadyEmailMock.mock.calls[0][0]
+    expect(props.loginUrl).toBe('https://app.openmercato.com/login?tenant=tenant-uuid')
+    expect(props.loginUrl).not.toContain('evil.com')
+    expect(sendEmailMock).toHaveBeenCalledTimes(1)
+    expect(markReadyEmailSentMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the dev origin outside production when APP_URL is unset', async () => {
+    const sent = await sendWorkspaceReadyEmail({ requestId: 'req-1', tenantId: 'tenant-uuid' })
+
+    expect(sent).toBe(true)
+    const props = workspaceReadyEmailMock.mock.calls[0][0]
+    expect(props.loginUrl).toBe('http://localhost:3000/login?tenant=tenant-uuid')
+  })
+
+  it('throws in production when APP_URL is not configured instead of trusting a host', async () => {
+    process.env.NODE_ENV = 'production'
+
+    await expect(
+      sendWorkspaceReadyEmail({ requestId: 'req-1', tenantId: 'tenant-uuid' }),
+    ).rejects.toThrow(/APP_URL/)
+
+    expect(sendEmailMock).not.toHaveBeenCalled()
+    expect(markReadyEmailSentMock).not.toHaveBeenCalled()
+  })
+
+  it('skips when the request is missing or already notified', async () => {
+    findByIdMock.mockResolvedValueOnce(null)
+    expect(await sendWorkspaceReadyEmail({ requestId: 'req-1', tenantId: 'tenant-uuid' })).toBe(false)
+
+    findByIdMock.mockResolvedValueOnce(makeReadyRequest({ readyEmailSentAt: new Date() }))
+    expect(await sendWorkspaceReadyEmail({ requestId: 'req-1', tenantId: 'tenant-uuid' })).toBe(false)
+
+    expect(sendEmailMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
-import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
+import { getSecurityEmailBaseUrl, mapSecurityEmailUrlError } from '@open-mercato/shared/lib/url'
 import { OnboardingService } from '@open-mercato/onboarding/modules/onboarding/lib/service'
 import { sendWorkspaceReadyEmail } from '@open-mercato/onboarding/modules/onboarding/lib/ready-email'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -26,7 +26,17 @@ export async function GET(req: Request) {
     return NextResponse.json({ ok: false, error: 'Invalid tenant id.' }, { status: 400 })
   }
 
-  const baseUrl = getAppBaseUrl(req)
+  let baseUrl: string
+  try {
+    baseUrl = getSecurityEmailBaseUrl(req)
+  } catch (error) {
+    const mapped = mapSecurityEmailUrlError(error, {
+      scope: 'onboarding.status',
+      configMessage: 'Onboarding status is not configured.',
+    })
+    if (mapped) return NextResponse.json({ ok: false, error: mapped.body.error }, { status: mapped.status })
+    throw error
+  }
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
   const service = new OnboardingService(em)
@@ -43,7 +53,6 @@ export async function GET(req: Request) {
     try {
       emailSent = await sendWorkspaceReadyEmail({
         requestId: request.id,
-        baseUrl,
         tenantId: request.tenantId,
       })
     } catch (error) {
@@ -91,8 +100,9 @@ const onboardingStatusDoc: OpenApiMethodDoc = {
     { status: 200, description: 'Onboarding status resolved.', schema: onboardingStatusSuccessSchema },
   ],
   errors: [
-    { status: 400, description: 'Invalid tenant id.', schema: onboardingStatusErrorSchema },
+    { status: 400, description: 'Invalid tenant id or request origin.', schema: onboardingStatusErrorSchema },
     { status: 404, description: 'Onboarding request not found.', schema: onboardingStatusErrorSchema },
+    { status: 500, description: 'Onboarding status is not configured.', schema: onboardingStatusErrorSchema },
   ],
 }
 

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
@@ -3,7 +3,11 @@ import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { SearchIndexer } from '@open-mercato/search'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
-import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
+import {
+  AppOriginConfigurationError,
+  AppOriginRejectedError,
+  getSecurityEmailBaseUrl,
+} from '@open-mercato/shared/lib/url'
 import { onboardingVerifySchema } from '@open-mercato/onboarding/modules/onboarding/data/validators'
 import { OnboardingService } from '@open-mercato/onboarding/modules/onboarding/lib/service'
 import { sendWorkspaceReadyEmail } from '@open-mercato/onboarding/modules/onboarding/lib/ready-email'
@@ -24,6 +28,21 @@ export const metadata = {
   GET: {
     requireAuth: false,
   },
+}
+
+function resolveTrustedBaseUrl(req: Request): string {
+  try {
+    return getSecurityEmailBaseUrl(req)
+  } catch (error) {
+    if (error instanceof AppOriginRejectedError || error instanceof AppOriginConfigurationError) {
+      console.error('[onboarding.verify] rejected request origin for redirect base', {
+        requestUrl: req.url,
+        reason: error.message,
+      })
+      return new URL(req.url).origin
+    }
+    throw error
+  }
 }
 
 function clearAuthCookies(response: NextResponse) {
@@ -218,7 +237,6 @@ async function rebuildTenantQueryIndexes(args: {
 
 async function runDeferredProvisioning(args: {
   requestId: string
-  baseUrl: string
   tenantId: string
   organizationId: string
 }) {
@@ -256,7 +274,6 @@ async function runDeferredProvisioning(args: {
 
   await sendWorkspaceReadyEmail({
     requestId: args.requestId,
-    baseUrl: args.baseUrl,
     tenantId: args.tenantId,
   }).catch((error) => {
     console.error('[onboarding.verify] ready email failed', {
@@ -289,7 +306,7 @@ async function runDeferredProvisioning(args: {
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const baseUrl = getAppBaseUrl(req)
+  const baseUrl = resolveTrustedBaseUrl(req)
   const token = url.searchParams.get('token') ?? ''
   const parsed = onboardingVerifySchema.safeParse({ token })
   if (!parsed.success) {
@@ -314,7 +331,6 @@ export async function GET(req: Request) {
       after(async () => {
         await sendWorkspaceReadyEmail({
           requestId: request.id,
-          baseUrl,
           tenantId: request.tenantId!,
         }).catch((error) => {
           console.error('[onboarding.verify] retry ready email failed', {
@@ -444,7 +460,6 @@ export async function GET(req: Request) {
     after(async () => {
       await runDeferredProvisioning({
         requestId: request.id,
-        baseUrl,
         tenantId: resolvedTenantId,
         organizationId: resolvedOrganizationId,
       })

--- a/packages/onboarding/src/modules/onboarding/api/post/onboarding.ts
+++ b/packages/onboarding/src/modules/onboarding/api/post/onboarding.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
-import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
+import { getSecurityEmailBaseUrl, mapSecurityEmailUrlError } from '@open-mercato/shared/lib/url'
 import { loadDictionary } from '@open-mercato/shared/lib/i18n/server'
 import { defaultLocale, locales, type Locale } from '@open-mercato/shared/lib/i18n/config'
 import { createFallbackTranslator } from '@open-mercato/shared/lib/i18n/translate'
@@ -125,7 +125,17 @@ export async function POST(req: Request) {
       throw err
     }
 
-    const baseUrl = getAppBaseUrl(req)
+    let baseUrl: string
+    try {
+      baseUrl = getSecurityEmailBaseUrl(req)
+    } catch (error) {
+      const mapped = mapSecurityEmailUrlError(error, {
+        scope: 'onboarding.start',
+        configMessage: 'Self-service onboarding is not configured.',
+      })
+      if (mapped) return NextResponse.json({ ok: false, error: mapped.body.error }, { status: mapped.status })
+      throw error
+    }
     const verifyUrl = `${baseUrl}/api/onboarding/onboarding/verify?token=${token}`
 
     const firstName = request.firstName || parsed.data.firstName

--- a/packages/onboarding/src/modules/onboarding/lib/ready-email.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/ready-email.ts
@@ -4,6 +4,7 @@ import { loadDictionary } from '@open-mercato/shared/lib/i18n/server'
 import { defaultLocale, locales, type Locale } from '@open-mercato/shared/lib/i18n/config'
 import { createFallbackTranslator } from '@open-mercato/shared/lib/i18n/translate'
 import { sendEmail } from '@open-mercato/shared/lib/email/send'
+import { getSecurityEmailBaseUrl } from '@open-mercato/shared/lib/url'
 import { OnboardingService } from '@open-mercato/onboarding/modules/onboarding/lib/service'
 import WorkspaceReadyEmail from '@open-mercato/onboarding/modules/onboarding/emails/WorkspaceReadyEmail'
 
@@ -14,7 +15,6 @@ function resolveLocale(rawLocale: string | null | undefined): Locale {
 
 export async function sendWorkspaceReadyEmail(args: {
   requestId: string
-  baseUrl: string
   tenantId: string
 }) {
   const container = await createRequestContainer()
@@ -25,7 +25,8 @@ export async function sendWorkspaceReadyEmail(args: {
   const locale = resolveLocale(request.locale)
   const dict = await loadDictionary(locale)
   const translate = createFallbackTranslator(dict)
-  const loginUrl = `${args.baseUrl}/login?tenant=${encodeURIComponent(args.tenantId)}`
+  const baseUrl = getSecurityEmailBaseUrl()
+  const loginUrl = `${baseUrl}/login?tenant=${encodeURIComponent(args.tenantId)}`
   const firstName = request.firstName?.trim() || request.organizationName?.trim() || request.email
   const subject = translate('onboarding.readyEmail.subject', 'Your Open Mercato workspace is ready')
   const emailCopy = {


### PR DESCRIPTION
Fixes #2712

## Problem
Two unauthenticated onboarding GET endpoints (`status`, `verify`) and the unauthenticated `POST /onboarding` start endpoint built outbound URLs from `getAppBaseUrl(req)`, which falls back to the request-controlled `Host`/`X-Forwarded-Host` headers when `APP_URL`/`NEXT_PUBLIC_APP_URL` is unset.

- **Issue 1 (phishing):** a spoofed `X-Forwarded-Host` poisoned the login link embedded in the workspace-ready email (and the verify link in the verification email) — durable attacker-controlled content delivered to a trusted inbox.
- **Issue 2 (open redirect + logout):** `verify`'s three redirect helpers built `${baseUrl}/...` targets from the same header-derived base with no allowlist check, while every redirect also clears `auth_token`/`session_token`/`om_login_tenant`.

The hardened `getSecurityEmailBaseUrl` / `assertAllowedAppOrigin` helpers already existed in `@open-mercato/shared/lib/url` but were not used here.

## Root Cause
Header-trusted `getAppBaseUrl(req)` was used to build outbound email links and unauthenticated redirect targets instead of the allowlist-asserting `getSecurityEmailBaseUrl`.

## What Changed
- `lib/ready-email.ts`: `sendWorkspaceReadyEmail` now derives the login link from the configured `APP_URL` via `getSecurityEmailBaseUrl()` (no longer accepts a caller-supplied `baseUrl`). Defense-in-depth: the email link tracks `APP_URL` regardless of any request header, and throws in production when `APP_URL` is unset.
- `api/get/onboarding/status.ts` and `api/post/onboarding.ts`: build the base with `getSecurityEmailBaseUrl(req)`; rejected origins map to `400`, missing-config to `500` via `mapSecurityEmailUrlError` (mirrors `customer_accounts/signup.ts`).
- `api/get/onboarding/verify.ts`: redirects build off a trusted base; on a rejected origin / missing prod config they fall back to `new URL(req.url).origin` (the literal request URL origin, header-independent) instead of echoing `X-Forwarded-Host`.

## Tests
- New `packages/onboarding/src/__tests__/ready-email.test.ts` (4 cases): login link tracks the configured `APP_URL` (and never an attacker host), dev fallback to `http://localhost:3000` when unset, throws in production when `APP_URL` is missing, and skips when the request is missing/already notified. Verified red against the pre-fix code, green after.
- `yarn workspace @open-mercato/onboarding test` — 45/45 pass.
- `yarn build:packages`, `yarn typecheck` — pass.
- Header-poisoning rejection of `getSecurityEmailBaseUrl`/`assertAllowedAppOrigin` is already covered by `packages/shared/src/lib/__tests__/url.test.ts`.

## Backward Compatibility
- No public contract surface removed. API route paths, success response shapes, and event/DI/ACL identifiers are unchanged.
- Additive: new `400` (invalid origin) / `500` (not configured) error responses on the onboarding endpoints, documented in their `openApi` error lists.
- `sendWorkspaceReadyEmail` is an internal module lib helper; its signature dropped the `baseUrl` arg and all in-repo call sites were updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)