### PR TITLE
security(security): atomic MFA attempt counter + enforce allowedMethods (#2710)

### DIFF
--- a/packages/enterprise/src/modules/security/api/mfa/prepare/route.ts
+++ b/packages/enterprise/src/modules/security/api/mfa/prepare/route.ts
@@ -15,7 +15,7 @@ const responseSchema = z.object({
 })
 
 export const metadata = {
-  POST: { requireAuth: true },
+  POST: { requireAuth: true, rateLimit: { points: 20, duration: 60, keyPrefix: 'security_mfa_prepare' } },
 }
 
 export async function POST(req: Request) {

--- a/packages/enterprise/src/modules/security/api/mfa/recovery/route.ts
+++ b/packages/enterprise/src/modules/security/api/mfa/recovery/route.ts
@@ -15,7 +15,7 @@ const responseSchema = z.object({
 })
 
 export const metadata = {
-  POST: { requireAuth: true },
+  POST: { requireAuth: true, rateLimit: { points: 10, duration: 60, keyPrefix: 'security_mfa_recovery' } },
 }
 
 export async function POST(req: Request) {

--- a/packages/enterprise/src/modules/security/api/mfa/verify/route.ts
+++ b/packages/enterprise/src/modules/security/api/mfa/verify/route.ts
@@ -17,7 +17,7 @@ const responseSchema = z.object({
 })
 
 export const metadata = {
-  POST: { requireAuth: true },
+  POST: { requireAuth: true, rateLimit: { points: 10, duration: 60, keyPrefix: 'security_mfa_verify' } },
 }
 
 export async function POST(req: Request) {

--- a/packages/enterprise/src/modules/security/services/MfaVerificationService.ts
+++ b/packages/enterprise/src/modules/security/services/MfaVerificationService.ts
@@ -87,6 +87,7 @@ export class MfaVerificationService {
     context?: MfaProviderRuntimeContext,
   ): Promise<{ clientData?: Record<string, unknown> }> {
     const challenge = await this.getValidChallenge(challengeId)
+    await this.assertMethodAllowedByPolicy(challenge.userId, methodType)
     const provider = this.mfaProviderRegistry.get(methodType)
     if (!provider) {
       throw new MfaVerificationServiceError(`MFA provider '${methodType}' is not registered`, 400)
@@ -119,12 +120,10 @@ export class MfaVerificationService {
       return false
     }
 
+    await this.assertMethodAllowedByPolicy(challenge.userId, methodType)
+
     if (challenge.methodType && challenge.methodType !== methodType) {
-      challenge.attempts += 1
-      if (challenge.attempts >= this.securityConfig.mfa.maxAttempts) {
-        challenge.expiresAt = new Date()
-      }
-      await this.em.flush()
+      await this.registerFailedAttempt(challenge)
       return false
     }
 
@@ -160,11 +159,7 @@ export class MfaVerificationService {
       return true
     }
 
-    challenge.attempts += 1
-    if (challenge.attempts >= this.securityConfig.mfa.maxAttempts) {
-      challenge.expiresAt = new Date()
-    }
-    await this.em.flush()
+    await this.registerFailedAttempt(challenge)
     return false
   }
 
@@ -184,6 +179,34 @@ export class MfaVerificationService {
       throw new MfaVerificationServiceError('MFA challenge expired', 400)
     }
     return challenge
+  }
+
+  private async assertMethodAllowedByPolicy(userId: string, methodType: string): Promise<void> {
+    const policy = await this.mfaEnforcementService.getEffectivePolicyForUser(userId)
+    if (!policy?.isEnforced || !policy.allowedMethods?.length) {
+      return
+    }
+    if (!policy.allowedMethods.includes(methodType)) {
+      throw new MfaVerificationServiceError(`MFA method '${methodType}' is not allowed by the enforcement policy`, 403)
+    }
+  }
+
+  private async registerFailedAttempt(challenge: MfaChallenge): Promise<void> {
+    const maxAttempts = this.securityConfig.mfa.maxAttempts
+    const rows = await this.em.getConnection().execute<Array<{ attempts: number }>>(
+      'UPDATE mfa_challenges SET attempts = attempts + 1 WHERE id = ? AND verified_at IS NULL AND attempts < ? RETURNING attempts',
+      [challenge.id, maxAttempts],
+    )
+    const updatedAttempts = rows.length > 0 ? Number(rows[0].attempts) : maxAttempts
+    challenge.attempts = updatedAttempts
+    if (updatedAttempts >= maxAttempts) {
+      const now = new Date()
+      await this.em.getConnection().execute(
+        'UPDATE mfa_challenges SET expires_at = ? WHERE id = ?',
+        [now, challenge.id],
+      )
+      challenge.expiresAt = now
+    }
   }
 
   private async getActiveMethods(userId: string): Promise<UserMfaMethod[]> {

--- a/packages/enterprise/src/modules/security/services/__tests__/MfaVerificationService.test.ts
+++ b/packages/enterprise/src/modules/security/services/__tests__/MfaVerificationService.test.ts
@@ -59,6 +59,27 @@ function createServiceContext(
     verifiedAt?: Date | null
   }> = []
 
+  const execute = jest.fn(async (sql: string, params: unknown[]) => {
+    if (sql.startsWith('UPDATE mfa_challenges SET attempts = attempts + 1')) {
+      const [id, maxAttempts] = params as [string, number]
+      const challenge = challenges.find((item) => item.id === id)
+      if (!challenge || challenge.verifiedAt || challenge.attempts >= maxAttempts) {
+        return []
+      }
+      challenge.attempts += 1
+      return [{ attempts: challenge.attempts }]
+    }
+    if (sql.startsWith('UPDATE mfa_challenges SET expires_at')) {
+      const [expiresAt, id] = params as [Date, string]
+      const challenge = challenges.find((item) => item.id === id)
+      if (challenge) {
+        challenge.expiresAt = expiresAt
+      }
+      return []
+    }
+    return []
+  })
+
   const em = {
     create: jest.fn((_entity: unknown, data: Record<string, unknown>) => ({
       id: `challenge-${challenges.length + 1}`,
@@ -75,6 +96,7 @@ function createServiceContext(
       challenges.push(challenge)
     }),
     flush: jest.fn().mockResolvedValue(undefined),
+    getConnection: jest.fn(() => ({ execute })),
     find: jest.fn(async () => methods),
     findOne: jest.fn(async (_entity: unknown, query: Record<string, unknown>) => {
       if ('id' in query && 'userId' in query) {
@@ -296,6 +318,82 @@ describe('MfaVerificationService', () => {
       name: 'MfaVerificationServiceError',
       statusCode: 400,
       message: 'MFA challenge already verified',
+    })
+  })
+
+  test('verifyChallenge increments attempts atomically via a conditional UPDATE', async () => {
+    const { service, challenges, em, registry } = createServiceContext()
+    const provider = registry.get('totp')
+    if (!provider) {
+      throw new Error('Expected TOTP provider to be registered')
+    }
+    provider.verify = jest.fn(async () => false)
+    const created = await service.createChallenge('user-1')
+
+    await service.verifyChallenge(created.challengeId, 'totp', { code: '000000' })
+
+    expect(challenges[0].attempts).toBe(1)
+    const execute = em.getConnection().execute as jest.Mock
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE mfa_challenges SET attempts = attempts + 1'),
+      [created.challengeId, defaultSecurityModuleConfig.mfa.maxAttempts],
+    )
+  })
+
+  test('verifyChallenge never advances attempts past the cap and locks out', async () => {
+    const { service, challenges, registry } = createServiceContext({
+      ...defaultSecurityModuleConfig,
+      mfa: {
+        ...defaultSecurityModuleConfig.mfa,
+        maxAttempts: 3,
+      },
+    })
+    const provider = registry.get('totp')
+    if (!provider) {
+      throw new Error('Expected TOTP provider to be registered')
+    }
+    provider.verify = jest.fn(async () => false)
+    const created = await service.createChallenge('user-1')
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      try {
+        await service.verifyChallenge(created.challengeId, 'totp', { code: '000000' })
+      } catch {
+        // After lockout the challenge is expired and getValidChallenge rejects further attempts.
+      }
+    }
+
+    expect(challenges[0].attempts).toBe(3)
+    expect(challenges[0].expiresAt.getTime()).toBeLessThanOrEqual(Date.now())
+  })
+
+  test('verifyChallenge rejects a method type disallowed by the enforcement policy', async () => {
+    const { service, mfaEnforcementService } = createServiceContext()
+    const created = await service.createChallenge('user-1')
+    mfaEnforcementService.getEffectivePolicyForUser.mockResolvedValue({
+      id: 'policy-1',
+      isEnforced: true,
+      allowedMethods: ['passkey'],
+    })
+
+    await expect(service.verifyChallenge(created.challengeId, 'totp', { code: '123456' })).rejects.toMatchObject({
+      name: 'MfaVerificationServiceError',
+      statusCode: 403,
+    })
+  })
+
+  test('prepareChallenge rejects a method type disallowed by the enforcement policy', async () => {
+    const { service, mfaEnforcementService } = createServiceContext()
+    const created = await service.createChallenge('user-1')
+    mfaEnforcementService.getEffectivePolicyForUser.mockResolvedValue({
+      id: 'policy-1',
+      isEnforced: true,
+      allowedMethods: ['passkey'],
+    })
+
+    await expect(service.prepareChallenge(created.challengeId, 'totp')).rejects.toMatchObject({
+      name: 'MfaVerificationServiceError',
+      statusCode: 403,
     })
   })
 


### PR DESCRIPTION
Fixes #2710

## Problem
The MFA verify path had two security weaknesses:
1. **Non-atomic attempts counter (brute-force past `maxAttempts`).** `verifyChallenge` read `challenge.attempts`, checked it, then did `challenge.attempts += 1` + `em.flush()`. Each request uses its own forked EntityManager and `MfaChallenge` has no version column, so concurrent failing verifications all read the same starting value and flushed the same increment (lost update). The cap (default 5) could be bypassed by firing many parallel verifies, and the verify route declared no `rateLimit`, so the dispatcher provided no IP fallback.
2. **`allowedMethods` not enforced on prepare/verify (policy bypass).** `findMethod`/`findMethodById` queried `UserMfaMethod` with no policy intersection. A user under `{ isEnforced: true, allowedMethods: ['passkey'] }` who still had a weaker enrolled factor (e.g. legacy TOTP) could `POST /api/security/mfa/verify` with `methodType='totp'` and authenticate with the disallowed factor.

## Root Cause
- The attempt increment ran as a read-modify-write inside the request-scoped UoW instead of an atomic DB statement, so simultaneous requests lost updates.
- The enforcement policy's `allowedMethods` list was applied only when building the challenge UI (`getActiveMethods`), never on the actual prepare/verify resolution where `methodType` comes straight from the request body.

## What Changed
- `MfaVerificationService.registerFailedAttempt` now performs an **atomic conditional UPDATE** — `UPDATE mfa_challenges SET attempts = attempts + 1 WHERE id = ? AND verified_at IS NULL AND attempts < ? RETURNING attempts`. Zero returned rows means the cap is reached, which triggers immediate lockout (`expires_at = now`). Both the method-mismatch path and the failed-verify path go through this helper.
- New `assertMethodAllowedByPolicy(userId, methodType)` helper is invoked at the top of both `prepareChallenge` and `verifyChallenge`; it resolves `getEffectivePolicyForUser` and rejects a `methodType` that is not in `allowedMethods` (when enforced) with a 403.
- Added per-IP `rateLimit` metadata to the `mfa/verify`, `mfa/prepare`, and `mfa/recovery` routes so the dispatcher throttles brute-force attempts at the IP layer.

## Tests
- Added 4 regression unit tests in `MfaVerificationService.test.ts`:
  - attempts increment goes through the atomic conditional UPDATE
  - attempts never advance past the cap and the challenge locks out
  - `verifyChallenge` rejects a method type disallowed by the enforcement policy (403)
  - `prepareChallenge` rejects a method type disallowed by the enforcement policy (403)
- Verified the new tests are **red against the original service** and green after the fix.
- Full enterprise suite passes (`291 passed`); security module suite `142 passed`.
- `yarn typecheck` clean (after `yarn generate`), `yarn i18n:check-sync` in sync, `yarn build:packages` succeeds.

## Backward Compatibility
- No contract surface removed. Service public method signatures are unchanged. `rateLimit` route metadata is additive. The new 403 is the intended security behavior (enforcing the existing `allowedMethods` policy). No API response fields, event IDs, DI names, or ACL IDs changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)