### PR TITLE
security(query_index): redact PII and raw tokens from OM_SEARCH_DEBUG logs (#2709)

### DIFF
--- a/apps/docs/docs/framework/database/query-index.mdx
+++ b/apps/docs/docs/framework/database/query-index.mdx
@@ -88,7 +88,7 @@ Limitations and notes
 
 - Standard debug logs honour `LOG_VERBOSITY=debug` (or a development `NODE_ENV`) and describe which path the hybrid engine picks.
 - To additionally print the SQL emitted for the count and data queries, set `QUERY_ENGINE_DEBUG_SQL=true`. The flag is disabled by default to keep development logs readable.
-- To inspect the tokens generated for search, set `OM_SEARCH_DEBUG=true`. It will log each token and hash produced during indexing, plus a per-record summary, without changing query behaviour.
+- To inspect the tokens generated for search, set `OM_SEARCH_DEBUG=true`. It logs field names, token **hashes**, and per-record counts during indexing — never the raw token text, document values, or decrypted PII — so the index shape can be debugged without disclosing data. Query behaviour is unchanged.
 
 Related files
 - `packages/core/src/modules/query_index/data/entities.ts`

--- a/packages/core/src/modules/query_index/__tests__/reindexer-debug.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/reindexer-debug.test.ts
@@ -1,0 +1,56 @@
+import { buildReindexDecryptDebugPayload } from '../lib/reindexer'
+
+describe('buildReindexDecryptDebugPayload redaction (issue #2709)', () => {
+  const scope = { tenantId: 'tenant-1', organizationId: 'org-1' }
+
+  it('reports only field keys, never decrypted values', () => {
+    const doc = {
+      id: 'rec-1',
+      display_name: 'Jane Doe',
+      first_name: 'Jane',
+      last_name: 'Doe',
+      primary_email: 'jane@example.com',
+      primary_phone: '+15551234567',
+      brand_name: 'Acme',
+      legal_name: 'Acme Inc',
+    }
+
+    const payload = buildReindexDecryptDebugPayload('customers:customer_person_profile', doc, scope)
+
+    expect(payload).toEqual({
+      entityType: 'customers:customer_person_profile',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      keys: ['display_name', 'first_name', 'last_name', 'brand_name', 'legal_name', 'primary_email', 'primary_phone'],
+    })
+
+    const serialized = JSON.stringify(payload)
+    expect(serialized).not.toContain('Jane Doe')
+    expect(serialized).not.toContain('jane@example.com')
+    expect(serialized).not.toContain('+15551234567')
+    expect(serialized).not.toContain('Acme')
+  })
+
+  it('omits keys whose values are missing or empty', () => {
+    const doc = {
+      display_name: 'Present',
+      first_name: '',
+      last_name: null as unknown as string,
+    }
+
+    const payload = buildReindexDecryptDebugPayload('customers:customer_person_profile', doc, scope)
+
+    expect(payload.keys).toEqual(['display_name'])
+  })
+
+  it('normalizes nullish scope identifiers', () => {
+    const payload = buildReindexDecryptDebugPayload('customers:customer_person_profile', {}, {
+      tenantId: null,
+      organizationId: null,
+    })
+
+    expect(payload.tenantId).toBeNull()
+    expect(payload.organizationId).toBeNull()
+    expect(payload.keys).toEqual([])
+  })
+})

--- a/packages/core/src/modules/query_index/__tests__/search-tokens-debug.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/search-tokens-debug.test.ts
@@ -1,0 +1,95 @@
+import { buildSearchTokenRows } from '../lib/search-tokens'
+import type { SearchConfig } from '@open-mercato/shared/lib/search/config'
+
+const config: SearchConfig = {
+  enabled: true,
+  minTokenLength: 3,
+  enablePartials: true,
+  hashAlgorithm: 'sha256',
+  storeRawTokens: false,
+  blocklistedFields: ['password', 'token', 'secret', 'hash'],
+}
+
+const collectDebugPayloads = (calls: unknown[][]): Record<string, unknown>[] => {
+  return calls
+    .filter((args) => typeof args[0] === 'string' && (args[0] as string).startsWith('[search-tokens]'))
+    .map((args) => (args[1] ?? {}) as Record<string, unknown>)
+}
+
+const deepStringValues = (value: unknown, out: string[] = []): string[] => {
+  if (typeof value === 'string') {
+    out.push(value)
+  } else if (Array.isArray(value)) {
+    for (const entry of value) deepStringValues(entry, out)
+  } else if (value && typeof value === 'object') {
+    for (const entry of Object.values(value as Record<string, unknown>)) deepStringValues(entry, out)
+  }
+  return out
+}
+
+describe('buildSearchTokenRows debug logging redaction (issue #2709)', () => {
+  const previousDebug = process.env.OM_SEARCH_DEBUG
+  let debugSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    process.env.OM_SEARCH_DEBUG = 'true'
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    debugSpy.mockRestore()
+    if (previousDebug === undefined) delete process.env.OM_SEARCH_DEBUG
+    else process.env.OM_SEARCH_DEBUG = previousDebug
+  })
+
+  it('does not log raw token text for generated tokens', () => {
+    const secretWord = 'zxqvtopsecretname'
+    buildSearchTokenRows({
+      entityType: 'customers:customer_person_profile',
+      recordId: 'rec-1',
+      doc: { display_name: secretWord },
+      config,
+    })
+
+    const payloads = collectDebugPayloads(debugSpy.mock.calls)
+    expect(payloads.length).toBeGreaterThan(0)
+    const loggedStrings = payloads.flatMap((payload) => deepStringValues(payload))
+    expect(loggedStrings).not.toContain(secretWord)
+    expect(loggedStrings.some((value) => value.includes(secretWord))).toBe(false)
+  })
+
+  it('does not log the deal title or raw deal tokens', () => {
+    const dealTitle = 'qzwxsecretdealtitle'
+    buildSearchTokenRows({
+      entityType: 'customers:customer_deal',
+      recordId: 'deal-1',
+      doc: { title: dealTitle },
+      config,
+    })
+
+    const payloads = collectDebugPayloads(debugSpy.mock.calls)
+    const dealPayloads = payloads.filter((payload) =>
+      JSON.stringify(payload).includes('"tokenCount"') || payload.entityType === 'customers:customer_deal')
+    expect(dealPayloads.length).toBeGreaterThan(0)
+    const loggedStrings = payloads.flatMap((payload) => deepStringValues(payload))
+    expect(loggedStrings).not.toContain(dealTitle)
+    expect(loggedStrings.some((value) => value.includes(dealTitle))).toBe(false)
+  })
+
+  it('still emits hashes so index shape stays debuggable', () => {
+    buildSearchTokenRows({
+      entityType: 'customers:customer_person_profile',
+      recordId: 'rec-2',
+      doc: { display_name: 'Jane Doe Example' },
+      config,
+    })
+
+    const payloads = collectDebugPayloads(debugSpy.mock.calls)
+    const tokenPayloads = payloads.filter((payload) => 'hash' in payload)
+    expect(tokenPayloads.length).toBeGreaterThan(0)
+    for (const payload of tokenPayloads) {
+      expect(typeof payload.hash).toBe('string')
+      expect(payload.hash).not.toBe('')
+    }
+  })
+})

--- a/packages/core/src/modules/query_index/lib/reindexer.ts
+++ b/packages/core/src/modules/query_index/lib/reindexer.ts
@@ -40,6 +40,33 @@ const deriveOrgFromId = new Set<string>(['directory:organization'])
 const COVERAGE_REFRESH_THROTTLE_MS = 5 * 60 * 1000
 const lastCoverageReset = new Map<string, number>()
 
+const REINDEX_DECRYPT_DEBUG_KEYS = ['display_name', 'first_name', 'last_name', 'brand_name', 'legal_name', 'primary_email', 'primary_phone'] as const
+
+export type ReindexDecryptDebugPayload = {
+  entityType: string
+  tenantId: string | null
+  organizationId: string | null
+  keys: string[]
+}
+
+export function buildReindexDecryptDebugPayload(
+  entityType: string,
+  doc: Record<string, unknown>,
+  scope: { organizationId: string | null; tenantId: string | null },
+): ReindexDecryptDebugPayload {
+  const presentKeys: string[] = []
+  for (const key of REINDEX_DECRYPT_DEBUG_KEYS) {
+    const value = doc[key]
+    if (key in doc && value != null && value !== '') presentKeys.push(key)
+  }
+  return {
+    entityType,
+    tenantId: scope.tenantId ?? null,
+    organizationId: scope.organizationId ?? null,
+    keys: presentKeys,
+  }
+}
+
 async function cleanupLegacyJobScopes(
   db: Kysely<any>,
   options: {
@@ -377,18 +404,7 @@ export async function reindexEntity(
           dekKeyCache,
         )
         if (isSearchDebugEnabled()) {
-          const keysOfInterest = ['display_name', 'first_name', 'last_name', 'brand_name', 'legal_name', 'primary_email', 'primary_phone']
-          const snapshot: Record<string, unknown> = {}
-          for (const key of keysOfInterest) {
-            if (key in result) snapshot[key] = (result as Record<string, unknown>)[key]
-          }
-          console.info('[reindex:decrypt]', {
-            entityType: targetEntity,
-            tenantId: scope.tenantId ?? null,
-            organizationId: scope.organizationId ?? null,
-            keys: Object.keys(snapshot),
-            sample: snapshot,
-          })
+          console.info('[reindex:decrypt]', buildReindexDecryptDebugPayload(targetEntity, result as Record<string, unknown>, scope))
         }
         return result
       }

--- a/packages/core/src/modules/query_index/lib/search-tokens.ts
+++ b/packages/core/src/modules/query_index/lib/search-tokens.ts
@@ -78,7 +78,7 @@ export function buildSearchTokenRows(params: BuildTokenOptions): SearchTokenRow[
   if (!params.doc) return []
   const tokens: SearchTokenRow[] = []
   const capturePairs = isSearchDebugEnabled() && params.entityType === 'customers:customer_deal'
-  const debugPairs: Array<{ field: string; token: string; hash: string }> = []
+  const debugPairs: Array<{ field: string; hash: string }> = []
   const scope = {
     organizationId: params.organizationId ?? DEFAULT_SCOPE.organizationId,
     tenantId: params.tenantId ?? DEFAULT_SCOPE.tenantId,
@@ -96,7 +96,7 @@ export function buildSearchTokenRows(params: BuildTokenOptions): SearchTokenRow[
         const dedupeKey = `${field}|${hash}`
         if (seen.has(dedupeKey)) continue
         seen.add(dedupeKey)
-        debug('token.generated', { entityType: params.entityType, recordId: params.recordId, field, token, hash })
+        debug('token.generated', { entityType: params.entityType, recordId: params.recordId, field, hash })
         tokens.push({
           entity_type: params.entityType,
           entity_id: String(params.recordId),
@@ -107,7 +107,7 @@ export function buildSearchTokenRows(params: BuildTokenOptions): SearchTokenRow[
           token: config.storeRawTokens ? token : null,
         })
         if (capturePairs) {
-          debugPairs.push({ field, token, hash })
+          debugPairs.push({ field, hash })
         }
       }
     }
@@ -116,7 +116,7 @@ export function buildSearchTokenRows(params: BuildTokenOptions): SearchTokenRow[
     debug('deal.tokens', {
       entityType: params.entityType,
       recordId: params.recordId,
-      title: params.doc?.title ?? null,
+      tokenCount: debugPairs.length,
       tokens: debugPairs,
     })
   }

--- a/packages/search/src/modules/search/README.md
+++ b/packages/search/src/modules/search/README.md
@@ -463,7 +463,7 @@ yarn mercato search worker fulltext-indexing --concurrency=5
 
 ### Debug Logging
 
-Set `OM_SEARCH_DEBUG=true` to enable verbose debug logging for the search module. This outputs detailed information about indexing operations, strategy selection, and error handling. Errors are always logged regardless of this flag.
+Set `OM_SEARCH_DEBUG=true` to enable verbose debug logging for the search module. This outputs information about indexing operations, strategy selection, and error handling. Debug output is redacted: it includes field names, token hashes, and counts, but never raw token text, document values, or decrypted PII. Errors are always logged regardless of this flag.
 
 ```env
 OM_SEARCH_DEBUG=true


### PR DESCRIPTION
Fixes #2709

## Problem
When `OM_SEARCH_DEBUG` is truthy, the reindex/search-token pipeline wrote already-decrypted, otherwise-encrypted-at-rest content (customer names, emails, phones, deal titles) and raw search tokens to stdout. Any downstream log consumer (Datadog, Sentry, log shippers) then held plaintext PII, defeating at-rest encryption and creating a GDPR/data-minimisation exposure. The flag is documented as a normal troubleshooting aid with no warning.

## Root Cause
Two debug paths logged raw values:
- `query_index/lib/reindexer.ts` — `decryptDoc` copied decrypted PII fields into a `sample` object and logged it via `console.info('[reindex:decrypt]', { sample })`.
- `query_index/lib/search-tokens.ts` — `[search-tokens] token.generated` logged the raw `token`; `[search-tokens] deal.tokens` logged the raw deal `title` plus a `{ field, token, hash }` list.

## What Changed
- `reindexer.ts`: dropped the `sample` payload. Added a pure, exported `buildReindexDecryptDebugPayload` that returns only `{ entityType, tenantId, organizationId, keys }` (present non-empty field names, no values), and called it from the debug path.
- `search-tokens.ts`: `token.generated` now logs `{ field, hash }` (no raw token); the deal summary logs `{ tokenCount, tokens: [{ field, hash }] }` (no raw `title`, no raw tokens). The raw `token` value is still only ever written to the DB column when `OM_SEARCH_STORE_RAW_TOKENS` is enabled — unchanged.
- Docs (`query-index.mdx`, search `README.md`): note the flag logs only field names, token hashes, and counts — never raw token text, document values, or decrypted PII.

No production guard change was needed because the values themselves are now never logged; the debug output is shape-only (keys/hashes/counts).

## Tests
- `search-tokens-debug.test.ts` — asserts `OM_SEARCH_DEBUG` debug output never contains raw token text or the deal title, and still emits hashes.
- `reindexer-debug.test.ts` — asserts `buildReindexDecryptDebugPayload` reports only field keys (never decrypted values), omits empty/missing keys, and normalizes nullish scope.
- Both fail before the fix (proved by reverting source) and pass after. Full `query_index` suite (8 suites / 46 tests) passes. `yarn build:packages`, `yarn generate`, `yarn typecheck` all pass.

## Backward Compatibility
- No contract surface changes. The only public addition is the new `buildReindexDecryptDebugPayload` export (additive). Debug log payload shapes changed, but those are internal dev logs, not a stable contract.