### PR TITLE
security(query_index): reject unregistered entityType in reindex (#2705)

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/reindexer-entity-guard.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/reindexer-entity-guard.test.ts
@@ -1,0 +1,81 @@
+import { reindexEntity } from '../lib/reindexer'
+
+function createTrackingKysely() {
+  const selectedTables: string[] = []
+  const chain: any = {
+    select: () => chain,
+    selectAll: () => chain,
+    where: () => chain,
+    orderBy: () => chain,
+    limit: () => chain,
+    groupBy: () => chain,
+    execute: async () => [],
+    executeTakeFirst: async () => undefined,
+  }
+  const db: any = {
+    selectFrom: (table: any) => {
+      selectedTables.push(String(table))
+      return chain
+    },
+    deleteFrom: () => chain,
+    insertInto: () => chain,
+    updateTable: () => chain,
+  }
+  return { db, selectedTables }
+}
+
+function makeEm(metaByClass: Record<string, string>) {
+  const { db, selectedTables } = createTrackingKysely()
+  const all = Object.entries(metaByClass).map(([className, tableName]) => ({ className, tableName }))
+  const em: any = {
+    getKysely: () => db,
+    getMetadata: () => ({
+      find: (className: string) => {
+        const tableName = metaByClass[className]
+        return tableName ? { tableName } : undefined
+      },
+      getAll: () => all,
+    }),
+  }
+  return { em, selectedTables }
+}
+
+describe('reindexEntity entity-type guard (issue #2705)', () => {
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('refuses to reindex an entity type that does not resolve to registered metadata', async () => {
+    const { em, selectedTables } = makeEm({ Todo: 'todos' })
+
+    const result = await reindexEntity(em, { entityType: 'foo:auth_user', tenantId: 't1', organizationId: 'o1' })
+
+    expect(result).toEqual({ processed: 0, total: 0, tenantScopes: [], scopes: [] })
+    // The attacker-derived table (`auth_users`) must never be read from.
+    expect(selectedTables).toEqual([])
+  })
+
+  it('does not pluralize an arbitrary id into an existing system table', async () => {
+    const { em, selectedTables } = makeEm({ Todo: 'todos' })
+
+    const result = await reindexEntity(em, { entityType: 'foo:user', tenantId: 't1', organizationId: 'o1' })
+
+    expect(result.processed).toBe(0)
+    expect(selectedTables).toEqual([])
+  })
+
+  it('still rejects the search_tokens table guard for registered tokens', async () => {
+    const { em, selectedTables } = makeEm({ SearchToken: 'search_tokens' })
+
+    const result = await reindexEntity(em, { entityType: 'query_index:search_token', tenantId: 't1', organizationId: 'o1' })
+
+    expect(result).toEqual({ processed: 0, total: 0, tenantScopes: [], scopes: [] })
+    expect(selectedTables).toEqual([])
+  })
+})

--- a/packages/core/src/modules/query_index/api/openapi.ts
+++ b/packages/core/src/modules/query_index/api/openapi.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { ENTITY_ID_PATTERN } from '@open-mercato/shared/lib/query/engine'
 
 export const queryIndexTag = 'Query Index'
 
@@ -80,7 +81,7 @@ export const queryIndexStatusResponseSchema = z.object({
 })
 
 export const queryIndexReindexRequestSchema = z.object({
-  entityType: z.string().min(1),
+  entityType: z.string().min(1).regex(ENTITY_ID_PATTERN),
   force: z.boolean().optional(),
   batchSize: z.number().int().positive().optional(),
   partitionCount: z.number().int().positive().optional(),

--- a/packages/core/src/modules/query_index/api/reindex.ts
+++ b/packages/core/src/modules/query_index/api/reindex.ts
@@ -4,6 +4,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { queryIndexTag, queryIndexErrorSchema, queryIndexOkSchema, queryIndexReindexRequestSchema } from './openapi'
 import { recordIndexerLog } from '@open-mercato/shared/lib/indexers/status-log'
+import { isValidEntityIdShape } from '@open-mercato/shared/lib/query/engine'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['query_index.reindex'] },
@@ -15,6 +16,9 @@ export async function POST(req: Request) {
   const body = await req.json().catch(() => ({})) as any
   const entityType = String(body?.entityType || '')
   if (!entityType) return NextResponse.json({ error: 'Missing entityType' }, { status: 400 })
+  if (!isValidEntityIdShape(entityType)) {
+    return NextResponse.json({ error: 'Invalid entityType' }, { status: 400 })
+  }
   const force = Boolean(body?.force)
   const batchSize = Number.isFinite(body?.batchSize) ? Math.max(1, Math.trunc(body.batchSize)) : undefined
   const partitionCountInput = Number(body?.partitionCount)

--- a/packages/core/src/modules/query_index/lib/reindexer.ts
+++ b/packages/core/src/modules/query_index/lib/reindexer.ts
@@ -1,6 +1,6 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { type Kysely, sql } from 'kysely'
-import { resolveEntityTableName } from '@open-mercato/shared/lib/query/engine'
+import { resolveRegisteredEntityTableName } from '@open-mercato/shared/lib/query/engine'
 import { resolveTenantEncryptionService } from '@open-mercato/shared/lib/encryption/customFieldValues'
 import { decryptIndexDocForSearch, encryptIndexDocForStorage } from '@open-mercato/shared/lib/encryption/indexDoc'
 import { upsertIndexBatch, type AnyRow } from './batch'
@@ -145,8 +145,18 @@ export async function reindexEntity(
   const resetCoverage = options?.resetCoverage ?? (!usingPartitions || partitionIndex === 0)
 
   const db = (em as any).getKysely() as Kysely<any>
-  const table = resolveEntityTableName(em, entityType)
-  if (entityType === 'query_index:search_token' || table === 'search_tokens') {
+  // Resolve the source table strictly via registered MikroORM metadata. We must
+  // never fall back to a pluralized guess derived from the caller-supplied id
+  // here: doing so would let a principal with `query_index.reindex` point the
+  // reindexer at arbitrary tables (e.g. `auth_users`, `users`) and read their
+  // rows into the index, bypassing tenant scoping and entity-level encryption.
+  const table = resolveRegisteredEntityTableName(em, entityType)
+  if (!table || entityType === 'query_index:search_token' || table === 'search_tokens') {
+    if (!table) {
+      console.warn('[HybridQueryEngine] Refusing to reindex unregistered entity type', {
+        entityType,
+      })
+    }
     return {
       processed: 0,
       total: 0,

--- a/packages/shared/src/lib/query/__tests__/resolve-registered-entity-table.test.ts
+++ b/packages/shared/src/lib/query/__tests__/resolve-registered-entity-table.test.ts
@@ -1,0 +1,83 @@
+import {
+  resolveRegisteredEntityTableName,
+  resolveEntityTableName,
+  isValidEntityIdShape,
+  ENTITY_ID_PATTERN,
+} from '../engine'
+
+function makeEm(metaByClass: Record<string, string>) {
+  const all = Object.entries(metaByClass).map(([className, tableName]) => ({ className, tableName }))
+  return {
+    getMetadata: () => ({
+      find: (className: string) => {
+        const tableName = metaByClass[className]
+        return tableName ? { tableName } : undefined
+      },
+      getAll: () => all,
+    }),
+  } as any
+}
+
+describe('resolveRegisteredEntityTableName', () => {
+  it('resolves a registered entity via class-name metadata', () => {
+    const em = makeEm({ Todo: 'todos' })
+    expect(resolveRegisteredEntityTableName(em, 'example:todo')).toBe('todos')
+  })
+
+  it('resolves a registered entity via the secondary table-name lookup', () => {
+    const em = makeEm({ SomeOtherClass: 'directory_organizations' })
+    expect(resolveRegisteredEntityTableName(em, 'directory:organization')).toBe('directory_organizations')
+  })
+
+  it('returns null for an entity type that does not map to any registered metadata', () => {
+    const em = makeEm({ Todo: 'todos' })
+    expect(resolveRegisteredEntityTableName(em, 'foo:auth_user')).toBeNull()
+    expect(resolveRegisteredEntityTableName(em, 'foo:user')).toBeNull()
+  })
+
+  it('returns null when no metadata is available', () => {
+    expect(resolveRegisteredEntityTableName(undefined, 'example:todo')).toBeNull()
+    expect(resolveRegisteredEntityTableName({} as any, 'example:todo')).toBeNull()
+  })
+
+  it('never pluralizes attacker-chosen ids into a real table name', () => {
+    const em = makeEm({})
+    expect(resolveRegisteredEntityTableName(em, 'foo:auth_user')).toBeNull()
+    expect(resolveRegisteredEntityTableName(em, 'foo:user')).toBeNull()
+  })
+})
+
+describe('resolveEntityTableName fallback (broad query path)', () => {
+  it('still falls back to a pluralized guess for unregistered ids', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const em = makeEm({})
+      expect(resolveEntityTableName(em, 'foo:never_registered_widget')).toBe('never_registered_widgets')
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+})
+
+describe('isValidEntityIdShape', () => {
+  it('accepts canonical module:entity ids', () => {
+    expect(isValidEntityIdShape('example:todo')).toBe(true)
+    expect(isValidEntityIdShape('directory:organization')).toBe(true)
+    expect(isValidEntityIdShape('query_index:search_token')).toBe(true)
+  })
+
+  it('rejects ids without exactly two snake_case segments', () => {
+    expect(isValidEntityIdShape('todos')).toBe(false)
+    expect(isValidEntityIdShape('auth_users')).toBe(false)
+    expect(isValidEntityIdShape('foo:bar:baz')).toBe(false)
+    expect(isValidEntityIdShape('Foo:Bar')).toBe(false)
+    expect(isValidEntityIdShape('1bad:entity')).toBe(false)
+    expect(isValidEntityIdShape('foo:')).toBe(false)
+    expect(isValidEntityIdShape(':bar')).toBe(false)
+    expect(isValidEntityIdShape('foo bar:baz')).toBe(false)
+  })
+
+  it('exposes the pattern for schema reuse', () => {
+    expect(ENTITY_ID_PATTERN.test('example:todo')).toBe(true)
+  })
+})

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -42,6 +42,15 @@ type ResolvedCustomFieldSource = {
 
 type ResultRow = Record<string, unknown>
 
+/**
+ * Canonical `module:entity` entity-id shape (both segments snake_case,
+ * starting with a lowercase letter). Used to validate caller-supplied entity
+ * ids at security-sensitive boundaries before they reach table resolution.
+ */
+export const ENTITY_ID_PATTERN = /^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$/
+
+export const isValidEntityIdShape = (value: string): boolean => ENTITY_ID_PATTERN.test(value)
+
 const pluralizeBaseName = (name: string): string => {
   if (!name) return name
   if (name.endsWith('s')) return name
@@ -65,44 +74,64 @@ const candidateClassNames = (rawName: string): string[] => {
   return Array.from(candidates)
 }
 
+/**
+ * Resolve an entity id to a table name strictly via registered MikroORM metadata.
+ *
+ * Unlike {@link resolveEntityTableName}, this never falls back to a pluralized
+ * guess: it returns `null` when no registered entity matches. Use it for
+ * security-sensitive call sites (e.g. the reindexer) that must refuse to read
+ * arbitrary, attacker-chosen tables that happen to exist in the schema.
+ */
+export function resolveRegisteredEntityTableName(
+  em: EntityManager | undefined,
+  entity: EntityId,
+): string | null {
+  const parts = String(entity || '').split(':')
+  const rawName = (parts[1] && parts[1].trim().length > 0) ? parts[1] : (parts[0] || '').trim()
+  const metadata = (em as any)?.getMetadata?.()
+
+  if (!metadata || !rawName) return null
+
+  const candidates = candidateClassNames(rawName)
+  for (const candidate of candidates) {
+    try {
+      const meta = metadata.find?.(candidate)
+      if (meta?.tableName) {
+        return String(meta.tableName)
+      }
+    } catch {}
+  }
+
+  // Secondary lookup: search ORM metadata by candidate table names
+  const modulePrefix = parts[0] ?? ''
+  const candidateTables = [
+    `${modulePrefix}_${rawName}`,
+    pluralizeBaseName(rawName),
+    `${modulePrefix}_${pluralizeBaseName(rawName)}`,
+  ]
+  try {
+    const allMeta: any[] = metadata.getAll?.() ?? []
+    for (const meta of allMeta) {
+      if (meta?.tableName && candidateTables.includes(String(meta.tableName))) {
+        return String(meta.tableName)
+      }
+    }
+  } catch {}
+
+  return null
+}
+
 export function resolveEntityTableName(em: EntityManager | undefined, entity: EntityId): string {
   if (entityTableCache.has(entity)) {
     return entityTableCache.get(entity)!
   }
   const parts = String(entity || '').split(':')
   const rawName = (parts[1] && parts[1].trim().length > 0) ? parts[1] : (parts[0] || '').trim()
-  const metadata = (em as any)?.getMetadata?.()
 
-  if (metadata && rawName) {
-    const candidates = candidateClassNames(rawName)
-    for (const candidate of candidates) {
-      try {
-        const meta = metadata.find?.(candidate)
-        if (meta?.tableName) {
-          const tableName = String(meta.tableName)
-          entityTableCache.set(entity, tableName)
-          return tableName
-        }
-      } catch {}
-    }
-
-    // Secondary lookup: search ORM metadata by candidate table names
-    const modulePrefix = parts[0] ?? ''
-    const candidateTables = [
-      `${modulePrefix}_${rawName}`,
-      pluralizeBaseName(rawName),
-      `${modulePrefix}_${pluralizeBaseName(rawName)}`,
-    ]
-    try {
-      const allMeta: any[] = metadata.getAll?.() ?? []
-      for (const meta of allMeta) {
-        if (meta?.tableName && candidateTables.includes(String(meta.tableName))) {
-          const tableName = String(meta.tableName)
-          entityTableCache.set(entity, tableName)
-          return tableName
-        }
-      }
-    } catch {}
+  const registered = resolveRegisteredEntityTableName(em, entity)
+  if (registered) {
+    entityTableCache.set(entity, registered)
+    return registered
   }
 
   const fallback = pluralizeBaseName(rawName || '')


### PR DESCRIPTION
Fixes #2705

## Problem
The reindex endpoint (`POST /api/query_index/reindex`, gated only by `query_index.reindex`) accepted an arbitrary `entityType` and, when ORM metadata lookup failed, silently derived a SQL table name from it instead of rejecting. A caller could point the reindexer at tables it was never meant to touch (e.g. `foo:auth_user` → `auth_users`, `foo:user` → `users`), reading their rows into `entity_indexes.doc` — unscoped for tables without a `tenant_id` column and unencrypted for unregistered entity types.

## Root Cause
`reindexEntity` resolved the source table via `resolveEntityTableName(em, entityType)`, which, on a metadata miss, `console.warn`s and falls back to `pluralizeBaseName(rawName)` derived from the attacker-chosen id. The resulting name was interpolated into `db.selectFrom(\`${table} as b\`)` and read with `selectAll('b')`. The only guard was a single-table `search_tokens` deny.

## What Changed
- **shared/query/engine**: added `resolveRegisteredEntityTableName(em, entity)` — resolves strictly via registered MikroORM metadata and returns `null` on a miss (no pluralize fallback, no warning). `resolveEntityTableName` now delegates to it and keeps its existing pluralize fallback + warning for the broad query path, so behavior is unchanged for all existing callers.
- **query_index/lib/reindexer**: resolves the source table strictly and refuses to proceed (no-op result + warn) when the `entityType` is not a registered entity, so the reindex worker never reads an attacker-chosen table.
- **query_index/api/reindex + openapi**: validate the `entityType` shape (`^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$`) at the API boundary and in the OpenAPI request schema via the shared `ENTITY_ID_PATTERN`, returning `400 Invalid entityType` for malformed ids.

Defense in depth: the API boundary, the request schema, and the reindexer itself each reject bad/unregistered ids — so the worker path is covered regardless of how the `query_index.reindex` event is emitted.

## Tests
- `packages/shared/src/lib/query/__tests__/resolve-registered-entity-table.test.ts`: `resolveRegisteredEntityTableName` resolves registered entities (class-name and table-name lookup), returns `null` for unregistered/arbitrary ids and never pluralizes them into a real table; `resolveEntityTableName` still falls back for the broad query path; `isValidEntityIdShape` shape coverage.
- `packages/core/src/modules/query_index/__tests__/reindexer-entity-guard.test.ts`: `reindexEntity` refuses unregistered types and issues **no** `selectFrom` against the derived table (proves the attacker table is never read). Verified red-before-fix (reverted source → reindexer proceeds into `prepareJob`; new strict export missing).
- Full `query_index` (43) and shared `query` (150) suites pass; `shared` + `core` typecheck clean (after `yarn generate`).

## Backward Compatibility
- Additive shared exports (`resolveRegisteredEntityTableName`, `isValidEntityIdShape`, `ENTITY_ID_PATTERN`); `resolveEntityTableName` signature and behavior unchanged.
- No API response fields removed; no event IDs, DI names, or ACL features changed. The new `400` on malformed `entityType` only rejects ids that never named a real registered entity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)