### PR TITLE
security(create-app): stop honoring deprecated requireRoles guard in API dispatcher (#2706)

### DIFF
--- a/apps/mercato/src/__tests__/api-authorization.test.ts
+++ b/apps/mercato/src/__tests__/api-authorization.test.ts
@@ -245,14 +245,14 @@ describe('API Route Authorization', () => {
       expect(await response.json()).toEqual({ error: 'Unauthorized' })
     })
 
-    it('should deny access with insufficient role', async () => {
+    it('should allow access regardless of role when required features pass (requireRoles is advisory only)', async () => {
       mockResolveAuthFromRequestDetailed.mockResolvedValue(authenticatedAuth(['user']))
 
       const request = new NextRequest('http://localhost:3001/api/example/test')
       const response = await GET(request, { params: Promise.resolve({ slug: ['example', 'test'] }) })
 
-      expect(response.status).toBe(403)
-      await expect(response.json()).resolves.toMatchObject({ error: 'Forbidden' })
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('GET success')
     })
 
     it('should deny access when required features are missing (rbac returns false)', async () => {
@@ -318,14 +318,14 @@ describe('API Route Authorization', () => {
       expect(text).toBe('POST success')
     })
 
-    it('should deny access with insufficient role', async () => {
+    it('should allow access regardless of role when required features pass (requireRoles is advisory only)', async () => {
       mockResolveAuthFromRequestDetailed.mockResolvedValue(authenticatedAuth(['user']))
 
       const request = new NextRequest('http://localhost:3001/api/example/test', { method: 'POST' })
       const response = await POST(request, { params: Promise.resolve({ slug: ['example', 'test'] }) })
 
-      expect(response.status).toBe(403)
-      await expect(response.json()).resolves.toMatchObject({ error: 'Forbidden' })
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('POST success')
     })
 
     it('should deny access when required features are missing on POST', async () => {
@@ -443,14 +443,17 @@ describe('API Route Authorization', () => {
       expect(await response.text()).toBe('DELETE success')
     })
 
-    it('should deny access with admin role (requires superuser)', async () => {
+    it('should allow any authenticated user when only deprecated requireRoles is set (no feature gate)', async () => {
+      // DELETE declares only `requireRoles: ['superuser']`. Because role-name guards are
+      // deprecated and advisory-only, a non-superuser authenticated caller is now allowed
+      // through — privileged endpoints MUST add a `requireFeatures` gate instead.
       mockResolveAuthFromRequestDetailed.mockResolvedValue(authenticatedAuth(['admin'], 'admin@test.com'))
 
       const request = new NextRequest('http://localhost:3001/api/example/test', { method: 'DELETE' })
       const response = await DELETE(request, { params: Promise.resolve({ slug: ['example', 'test'] }) })
 
-      expect(response.status).toBe(403)
-      await expect(response.json()).resolves.toMatchObject({ error: 'Forbidden' })
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('DELETE success')
     })
   })
 
@@ -465,24 +468,24 @@ describe('API Route Authorization', () => {
   })
 
   describe('Edge cases', () => {
-    it('should handle empty roles array', async () => {
+    it('should not deny on an empty roles array when required features pass', async () => {
       mockResolveAuthFromRequestDetailed.mockResolvedValue(authenticatedAuth([]))
 
       const request = new NextRequest('http://localhost:3001/api/example/test')
       const response = await GET(request, { params: Promise.resolve({ slug: ['example', 'test'] }) })
 
-      expect(response.status).toBe(403)
-      await expect(response.json()).resolves.toMatchObject({ error: 'Forbidden' })
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('GET success')
     })
 
-    it('should handle undefined roles', async () => {
+    it('should not deny on undefined roles when required features pass', async () => {
       mockResolveAuthFromRequestDetailed.mockResolvedValue(authenticatedAuth(undefined))
 
       const request = new NextRequest('http://localhost:3001/api/example/test')
       const response = await GET(request, { params: Promise.resolve({ slug: ['example', 'test'] }) })
 
-      expect(response.status).toBe(403)
-      await expect(response.json()).resolves.toMatchObject({ error: 'Forbidden' })
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('GET success')
     })
 
     it('should handle empty requireRoles array', async () => {
@@ -506,6 +509,47 @@ describe('API Route Authorization', () => {
       const setCookie = response.headers.get('set-cookie') || ''
       expect(setCookie).toContain('auth_token=;')
       expect(setCookie).toContain('session_token=;')
+    })
+  })
+
+  describe('Deprecated requireRoles is advisory only (security: role names are spoofable)', () => {
+    it('does not grant access via a spoofed role when the required feature is missing', async () => {
+      // GET declares `requireRoles: ['admin']` + `requireFeatures: ['example.todos.view']`.
+      // A tenant admin who renames/creates a role literally named "admin" must NOT pass:
+      // role-name matching is ignored, and the missing feature grant still denies.
+      mockResolveAuthFromRequestDetailed.mockResolvedValue(authenticatedAuth(['admin'], 'spoofer@test.com'))
+      mockRbac.userHasAllFeatures.mockResolvedValueOnce(false)
+
+      const request = new NextRequest('http://localhost:3001/api/example/test')
+      const response = await GET(request, { params: Promise.resolve({ slug: ['example', 'test'] }) })
+
+      expect(response.status).toBe(403)
+      await expect(response.json()).resolves.toMatchObject({ error: 'Forbidden' })
+    })
+
+    it('does not include requiredRoles in the 403 body (role guard no longer participates)', async () => {
+      mockResolveAuthFromRequestDetailed.mockResolvedValue(authenticatedAuth(['admin'], 'admin@test.com'))
+      mockRbac.userHasAllFeatures.mockResolvedValueOnce(false)
+
+      const request = new NextRequest('http://localhost:3001/api/example/test')
+      const response = await GET(request, { params: Promise.resolve({ slug: ['example', 'test'] }) })
+
+      const body = await response.json()
+      expect(body).not.toHaveProperty('requiredRoles')
+      expect(body).toMatchObject({ error: 'Forbidden', requiredFeatures: ['example.todos.view'] })
+    })
+
+    it('allows an authenticated caller whose roles do not match the deprecated requireRoles list', async () => {
+      // DELETE declares only `requireRoles: ['superuser']`. A caller without that role name
+      // is now allowed through because the role guard is advisory only — there is no feature
+      // gate, so any authenticated user passes. (Privileged routes MUST add `requireFeatures`.)
+      mockResolveAuthFromRequestDetailed.mockResolvedValue(authenticatedAuth(['viewer'], 'viewer@test.com'))
+
+      const request = new NextRequest('http://localhost:3001/api/example/test', { method: 'DELETE' })
+      const response = await DELETE(request, { params: Promise.resolve({ slug: ['example', 'test'] }) })
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('DELETE success')
     })
   })
 })

--- a/apps/mercato/src/app/api/[...slug]/route.ts
+++ b/apps/mercato/src/app/api/[...slug]/route.ts
@@ -21,9 +21,21 @@ import { applicationLifecycleEvents, type ApplicationLifecycleEventId } from '@o
 bootstrap()
 registerApiRouteManifests(apiRoutes)
 
+const warnedDeprecatedRequireRoles = new Set<string>()
+
+function warnDeprecatedRequireRoles(pathname: string, method: HttpMethod): void {
+  const warnKey = `${method} ${pathname}`
+  if (warnedDeprecatedRequireRoles.has(warnKey)) return
+  warnedDeprecatedRequireRoles.add(warnKey)
+  console.warn(
+    '[api] Ignoring deprecated `requireRoles` guard — role names are mutable and spoofable, so they no longer authorize requests. Migrate to `requireFeatures` with immutable acl.ts feature IDs.',
+    { path: pathname, method },
+  )
+}
+
 type MethodMetadata = {
   requireAuth?: boolean
-  /** @deprecated Use `requireFeatures` instead — role names are mutable and can be spoofed */
+  /** @deprecated Ignored at runtime — role names are mutable and can be spoofed. Use `requireFeatures` instead. */
   requireRoles?: string[]
   requireFeatures?: string[]
   rateLimit?: RateLimitConfig
@@ -138,14 +150,14 @@ async function checkAuthorization(
     return NextResponse.json({ error: t('api.errors.unauthorized', 'Unauthorized') }, { status: 401 })
   }
 
-  const requiredRoles = methodMetadata?.requireRoles ?? []
   const requiredFeatures = methodMetadata?.requireFeatures ?? []
 
-  if (
-    requiredRoles.length &&
-    (!auth || !Array.isArray(auth.roles) || !requiredRoles.some((role) => auth.roles!.includes(role)))
-  ) {
-    return NextResponse.json({ error: t('api.errors.forbidden', 'Forbidden'), requiredRoles }, { status: 403 })
+  // `requireRoles` is deprecated and intentionally NOT enforced: role names are
+  // tenant-mutable and spoofable, so honoring them would let a tenant admin create
+  // or rename a role to satisfy the guard. Authorization decisions must use
+  // immutable feature IDs via `requireFeatures`. We warn so operators migrate.
+  if (methodMetadata?.requireRoles?.length) {
+    warnDeprecatedRequireRoles(req.nextUrl.pathname, req.method.toUpperCase() as HttpMethod)
   }
 
   let container: Awaited<ReturnType<typeof createRequestContainer>> | null = null

--- a/packages/create-app/src/lib/template-api-dispatcher-require-roles.test.ts
+++ b/packages/create-app/src/lib/template-api-dispatcher-require-roles.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+
+const templateDispatcherUrl = new URL(
+  '../../template/src/app/api/[...slug]/route.ts',
+  import.meta.url,
+)
+const monorepoDispatcherUrl = new URL(
+  '../../../../apps/mercato/src/app/api/[...slug]/route.ts',
+  import.meta.url,
+)
+
+function readSource(url: URL): string {
+  return fs.readFileSync(url, 'utf8')
+}
+
+test('template API dispatcher no longer enforces the deprecated requireRoles guard', () => {
+  const source = readSource(templateDispatcherUrl)
+
+  // The old, spoofable role gate compared mutable role names and returned 403.
+  // It must be gone — role names must never authorize a request.
+  assert.doesNotMatch(
+    source,
+    /requiredRoles\.some\(\(role\) => auth\.roles!\.includes\(role\)\)/,
+    'dispatcher must not authorize based on mutable role-name matching',
+  )
+  assert.doesNotMatch(
+    source,
+    /\{ error: t\('api\.errors\.forbidden', 'Forbidden'\), requiredRoles \}/,
+    'dispatcher must not return a requireRoles-driven 403',
+  )
+
+  // A declared requireRoles guard is now advisory only and emits a deprecation warning.
+  assert.match(
+    source,
+    /warnDeprecatedRequireRoles/,
+    'dispatcher must warn when a route still declares requireRoles',
+  )
+  assert.match(
+    source,
+    /requireFeatures/,
+    'dispatcher must keep the feature-based authorization path',
+  )
+})
+
+test('template API dispatcher stays byte-identical to the monorepo dispatcher (template sync)', () => {
+  assert.equal(
+    readSource(templateDispatcherUrl),
+    readSource(monorepoDispatcherUrl),
+    'template and monorepo API dispatchers must stay in sync',
+  )
+})

--- a/packages/create-app/template/src/app/api/[...slug]/route.ts
+++ b/packages/create-app/template/src/app/api/[...slug]/route.ts
@@ -21,9 +21,21 @@ import { applicationLifecycleEvents, type ApplicationLifecycleEventId } from '@o
 bootstrap()
 registerApiRouteManifests(apiRoutes)
 
+const warnedDeprecatedRequireRoles = new Set<string>()
+
+function warnDeprecatedRequireRoles(pathname: string, method: HttpMethod): void {
+  const warnKey = `${method} ${pathname}`
+  if (warnedDeprecatedRequireRoles.has(warnKey)) return
+  warnedDeprecatedRequireRoles.add(warnKey)
+  console.warn(
+    '[api] Ignoring deprecated `requireRoles` guard — role names are mutable and spoofable, so they no longer authorize requests. Migrate to `requireFeatures` with immutable acl.ts feature IDs.',
+    { path: pathname, method },
+  )
+}
+
 type MethodMetadata = {
   requireAuth?: boolean
-  /** @deprecated Use `requireFeatures` instead — role names are mutable and can be spoofed */
+  /** @deprecated Ignored at runtime — role names are mutable and can be spoofed. Use `requireFeatures` instead. */
   requireRoles?: string[]
   requireFeatures?: string[]
   rateLimit?: RateLimitConfig
@@ -138,14 +150,14 @@ async function checkAuthorization(
     return NextResponse.json({ error: t('api.errors.unauthorized', 'Unauthorized') }, { status: 401 })
   }
 
-  const requiredRoles = methodMetadata?.requireRoles ?? []
   const requiredFeatures = methodMetadata?.requireFeatures ?? []
 
-  if (
-    requiredRoles.length &&
-    (!auth || !Array.isArray(auth.roles) || !requiredRoles.some((role) => auth.roles!.includes(role)))
-  ) {
-    return NextResponse.json({ error: t('api.errors.forbidden', 'Forbidden'), requiredRoles }, { status: 403 })
+  // `requireRoles` is deprecated and intentionally NOT enforced: role names are
+  // tenant-mutable and spoofable, so honoring them would let a tenant admin create
+  // or rename a role to satisfy the guard. Authorization decisions must use
+  // immutable feature IDs via `requireFeatures`. We warn so operators migrate.
+  if (methodMetadata?.requireRoles?.length) {
+    warnDeprecatedRequireRoles(req.nextUrl.pathname, req.method.toUpperCase() as HttpMethod)
   }
 
   let container: Awaited<ReturnType<typeof createRequestContainer>> | null = null


### PR DESCRIPTION
Fixes #2706

## Problem
The standalone-app API dispatcher (`packages/create-app/template/src/app/api/[...slug]/route.ts`, and its byte-identical monorepo twin `apps/mercato/src/app/api/[...slug]/route.ts`) enforced authorization from a `requireRoles` array by matching the caller's current role names with `Array.prototype.includes`. Because role names are tenant-mutable and user-editable in the admin UI, a tenant admin could create or rename a role to match the expected string (e.g. `requireRoles: ['admin']`) and satisfy the guard — privilege escalation with no feature-grant audit trail. The metadata type already marked `requireRoles` `@deprecated`, but the runtime still honored it.

## Root Cause
`checkAuthorization()` returned a 403 unless one of the caller's spoofable role names matched the route's `requireRoles` list, making the guard only as strong as whoever last renamed a role.

## What Changed
- Removed the `requireRoles` authorization gate from both dispatchers. `requireRoles` is now **advisory only**: it never authorizes or denies a request.
- Kept the `requireRoles?: string[]` field in `MethodMetadata` and its parsing for backward compatibility (the registry passthrough and route-author contract are unchanged); updated the `@deprecated` JSDoc to state it is ignored at runtime.
- Added a one-time `console.warn` (deduped per route+method) when a route still declares `requireRoles`, directing migration to `requireFeatures` with immutable `acl.ts` feature IDs.
- The feature-based path (`requireFeatures` / `RbacService.userHasAllFeatures`, wildcard-aware) is unchanged and remains the only authorization mechanism.
- Kept the two dispatcher files byte-identical (template-sync rule).

No real route in the repo declares `requireRoles`, so no shipping route's behavior changes — only the dangerous spoofable code path is removed.

## Tests
- `apps/mercato/src/__tests__/api-authorization.test.ts`: updated the role-based cases to reflect advisory-only behavior and added a dedicated `Deprecated requireRoles is advisory only (security)` block. The four behavior-change tests are red against the old dispatcher and green after the fix (verified by reverting the dispatcher and re-running). Full suite: 27 passing.
- `packages/create-app/src/lib/template-api-dispatcher-require-roles.test.ts` (new): asserts the template dispatcher no longer enforces `requireRoles` and stays byte-identical to the monorepo dispatcher.
- Full validation run: `apps/mercato` jest 122/122, `create-app` node:test 37/37, `feature_toggles` + `registry` guard tests green, `yarn test` (turbo) 22/22 workspace tasks (core 5500 tests), `yarn typecheck`, `yarn build:packages` all pass. (`yarn lint` hits a pre-existing eslint-plugin-react/ESLint-10 environment error on `next.config.ts`, unrelated to this change.)

## Backward Compatibility
- No contract surface removed: `requireRoles` stays in the metadata type and registry passthrough; only its runtime enforcement is dropped (the documented security-deprecation outcome).
- No API response fields removed; feature-gated 403s still return `requiredFeatures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)