### PR TITLE
security(auth): logout endpoint POST-only to prevent CSRF logout (#2687)

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/logout.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/logout.test.ts
@@ -19,6 +19,7 @@ jest.mock('@open-mercato/core/modules/auth/lib/requestRedirect', () => ({
   buildRequestOriginUrl: (_req: Request, path: string) => `http://localhost${path}`,
 }))
 
+import * as logoutRoute from '@open-mercato/core/modules/auth/api/logout'
 import { POST } from '@open-mercato/core/modules/auth/api/logout'
 
 beforeAll(() => {
@@ -127,5 +128,19 @@ describe('POST /api/auth/logout — session revocation', () => {
     await POST(req)
 
     expect(deleteSessionById).not.toHaveBeenCalled()
+  })
+})
+
+describe('logout route — CSRF hardening (POST-only)', () => {
+  it('does not expose a GET handler so a cross-origin embed cannot trigger logout', () => {
+    expect((logoutRoute as Record<string, unknown>).GET).toBeUndefined()
+  })
+
+  it('declares only POST in route metadata', () => {
+    expect(Object.keys(logoutRoute.metadata)).toEqual(['POST'])
+  })
+
+  it('documents only POST in the OpenAPI spec', () => {
+    expect(Object.keys(logoutRoute.openApi.methods)).toEqual(['POST'])
   })
 })

--- a/packages/core/src/modules/auth/api/logout.ts
+++ b/packages/core/src/modules/auth/api/logout.ts
@@ -45,12 +45,7 @@ export async function POST(req: Request) {
   return res
 }
 
-export async function GET(req: Request) {
-  return POST(req)
-}
-
 export const metadata = {
-  GET: { requireAuth: true },
   POST: { requireAuth: true },
 }
 
@@ -61,13 +56,6 @@ export const openApi: OpenApiRouteDoc = {
     POST: {
       summary: 'Invalidate session and redirect',
       description: 'Clears authentication cookies and redirects the browser to the login page.',
-      responses: [
-        { status: 302, description: 'Redirect to login after successful logout', mediaType: 'text/html' },
-      ],
-    },
-    GET: {
-      summary: 'Log out (legacy GET)',
-      description: 'For convenience, the GET variant performs the same logout logic as POST and issues a redirect.',
       responses: [
         { status: 302, description: 'Redirect to login after successful logout', mediaType: 'text/html' },
       ],


### PR DESCRIPTION
Fixes #2687

## Problem
The logout route (`packages/core/src/modules/auth/api/logout.ts`) exposed a `GET` handler that delegated to `POST`, performing a state-changing side effect (session destruction + auth-cookie clearing) on a method HTTP semantics require to be safe and idempotent. With no CSRF token or same-origin check, any third-party page could force-logout an authenticated staff user via an embedded cross-origin GET such as `<img src="https://app/api/auth/logout">`.

## Root Cause
`export async function GET(req) { return POST(req) }` plus matching `metadata.GET` / `openApi.methods.GET` entries made the destructive logout reachable via a credentialed cross-origin GET.

## What Changed
- Removed the `GET` handler from the logout route.
- Dropped the `GET` entry from `metadata` and from the `openApi` spec, leaving logout `POST`-only.

All in-app logout call sites already submit via `method="POST"` forms (`packages/ui/src/backend/UserMenu.tsx`, `packages/ui/src/backend/ProfileDropdown.tsx`), so no client changes are required. The portal logout uses a separate `POST /api/customer_accounts/portal/logout` and is unaffected.

## Tests
- Extended `packages/core/src/modules/auth/api/__tests__/logout.test.ts` with a CSRF-hardening block asserting:
  - the route module exports no `GET` handler,
  - `metadata` declares only `POST`,
  - the OpenAPI spec documents only `POST`.
- Existing POST session-revocation tests retained. Full auth API suite green (135/135). `yarn typecheck` passes across all packages.

## Backward Compatibility
Intentional, security-motivated contract change: `GET /api/auth/logout` is removed because it was the vulnerability itself. No internal caller relied on it (all use POST). The `SameSite=Lax` cookies remain, so cross-origin form POSTs do not carry credentials either.

### Security impact
Closes a CSRF logout vector (forced session destruction / login-CSRF) on the staff auth surface. Reduces logout to a safe, POST-only, same-origin-form-driven action.