### PR TITLE
security(inbox_ops): userHasFeature() fails open when required feature is empty (#2700)

### DIFF
--- a/packages/core/src/modules/inbox_ops/lib/__tests__/executionEngine.test.ts
+++ b/packages/core/src/modules/inbox_ops/lib/__tests__/executionEngine.test.ts
@@ -150,6 +150,19 @@ describe('executionEngine', () => {
       expect(em.nativeUpdate).not.toHaveBeenCalled()
     })
 
+    it('fails closed with 403 when the action type has no required feature', async () => {
+      const em = createMockEm()
+      const action = makeAction({ actionType: 'no_such_action' as InboxProposalAction['actionType'] })
+
+      const result = await executeAction(action, makeCtx(em))
+
+      expect(result.success).toBe(false)
+      expect(result.statusCode).toBe(403)
+      expect(result.error).toContain('No required feature')
+      expect(em.nativeUpdate).not.toHaveBeenCalled()
+      expect(mockRbacService.userHasAllFeatures).not.toHaveBeenCalled()
+    })
+
     it('returns 409 when optimistic lock fails (action already processed)', async () => {
       const em = createMockEm()
       em.nativeUpdate.mockResolvedValue(0)

--- a/packages/core/src/modules/inbox_ops/lib/__tests__/executionHelpers.test.ts
+++ b/packages/core/src/modules/inbox_ops/lib/__tests__/executionHelpers.test.ts
@@ -1,0 +1,91 @@
+/** @jest-environment node */
+
+import { userHasFeature, type ExecutionHelperContext } from '../executionHelpers'
+
+const mockRbacService = {
+  userHasAllFeatures: jest.fn(),
+}
+
+function makeCtx(overrides?: Partial<ExecutionHelperContext>): ExecutionHelperContext {
+  return {
+    em: {} as ExecutionHelperContext['em'],
+    userId: 'user-1',
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    container: {
+      resolve: jest.fn((token: string) => (token === 'rbacService' ? mockRbacService : null)),
+    } as unknown as ExecutionHelperContext['container'],
+    ...overrides,
+  }
+}
+
+describe('userHasFeature', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    mockRbacService.userHasAllFeatures.mockResolvedValue(true)
+  })
+
+  it('fails closed (returns false) when the feature is an empty string', async () => {
+    const result = await userHasFeature(makeCtx(), '')
+    expect(result).toBe(false)
+    expect(mockRbacService.userHasAllFeatures).not.toHaveBeenCalled()
+  })
+
+  it('fails closed (returns false) when the feature is undefined', async () => {
+    const result = await userHasFeature(makeCtx(), undefined as unknown as string)
+    expect(result).toBe(false)
+    expect(mockRbacService.userHasAllFeatures).not.toHaveBeenCalled()
+  })
+
+  it('fails closed (returns false) when the feature is null', async () => {
+    const result = await userHasFeature(makeCtx(), null as unknown as string)
+    expect(result).toBe(false)
+    expect(mockRbacService.userHasAllFeatures).not.toHaveBeenCalled()
+  })
+
+  it('does not grant access on a missing feature even for super admins', async () => {
+    const ctx = makeCtx({ auth: { isSuperAdmin: true } as ExecutionHelperContext['auth'] })
+    const result = await userHasFeature(ctx, '')
+    expect(result).toBe(false)
+  })
+
+  it('grants access to super admins when a concrete feature is supplied', async () => {
+    const ctx = makeCtx({ auth: { isSuperAdmin: true } as ExecutionHelperContext['auth'] })
+    const result = await userHasFeature(ctx, 'sales.orders.manage')
+    expect(result).toBe(true)
+    expect(mockRbacService.userHasAllFeatures).not.toHaveBeenCalled()
+  })
+
+  it('delegates to the RBAC service for a concrete feature and returns its grant', async () => {
+    mockRbacService.userHasAllFeatures.mockResolvedValue(true)
+    const result = await userHasFeature(makeCtx(), 'sales.orders.manage')
+    expect(result).toBe(true)
+    expect(mockRbacService.userHasAllFeatures).toHaveBeenCalledWith(
+      'user-1',
+      ['sales.orders.manage'],
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+  })
+
+  it('returns false when the RBAC service denies the feature', async () => {
+    mockRbacService.userHasAllFeatures.mockResolvedValue(false)
+    const result = await userHasFeature(makeCtx(), 'sales.orders.manage')
+    expect(result).toBe(false)
+  })
+
+  it('fails closed when the RBAC service is unavailable', async () => {
+    const ctx = makeCtx({
+      container: {
+        resolve: jest.fn(() => null),
+      } as unknown as ExecutionHelperContext['container'],
+    })
+    const result = await userHasFeature(ctx, 'sales.orders.manage')
+    expect(result).toBe(false)
+  })
+
+  it('fails closed when the RBAC service throws', async () => {
+    mockRbacService.userHasAllFeatures.mockRejectedValue(new Error('rbac down'))
+    const result = await userHasFeature(makeCtx(), 'sales.orders.manage')
+    expect(result).toBe(false)
+  })
+})

--- a/packages/core/src/modules/inbox_ops/lib/executionEngine.ts
+++ b/packages/core/src/modules/inbox_ops/lib/executionEngine.ts
@@ -452,7 +452,9 @@ async function resolveUnknownContactDiscrepanciesInProposal(
 
 async function ensureUserCanExecuteAction(action: InboxProposalAction, ctx: ExecutionContext): Promise<void> {
   const requiredFeature = getRequiredFeatureForAction(action)
-  if (!requiredFeature) return
+  if (!requiredFeature) {
+    throw new ExecutionError(`No required feature is defined for action type: ${action.actionType}`, 403)
+  }
 
   const rbacService = ctx.container.resolve('rbacService') as {
     userHasAllFeatures: (

--- a/packages/core/src/modules/inbox_ops/lib/executionHelpers.ts
+++ b/packages/core/src/modules/inbox_ops/lib/executionHelpers.ts
@@ -136,7 +136,7 @@ export async function userHasFeature(
   ctx: ExecutionHelperContext,
   feature: string,
 ): Promise<boolean> {
-  if (!feature) return true
+  if (!feature) return false
   if (hasSuperAdminAccess(ctx.auth)) return true
 
   try {
@@ -144,7 +144,7 @@ export async function userHasFeature(
     if (!rbacService || typeof rbacService.userHasAllFeatures !== 'function') {
       return false
     }
-    return rbacService.userHasAllFeatures(
+    return await rbacService.userHasAllFeatures(
       ctx.userId,
       [feature],
       { tenantId: ctx.tenantId, organizationId: ctx.organizationId },


### PR DESCRIPTION
Fixes #2700

## Problem
The exported RBAC helper `userHasFeature()` (`packages/core/src/modules/inbox_ops/lib/executionHelpers.ts`) returned `true` unconditionally whenever the `feature` argument was falsy (`if (!feature) return true`) — a fail-open default for a permission check. The sibling enforcement `ensureUserCanExecuteAction()` in `lib/executionEngine.ts` had the same `if (!requiredFeature) return` shortcut, silently allowing execution when an action's required feature did not resolve.

## Root Cause
Both helpers treated a missing/blank feature as "allow everyone" instead of denying. Today `REQUIRED_FEATURES_MAP` populates a non-empty feature for every known `InboxActionType`, so the in-tree flow does not hit this branch — but `userHasFeature()` is exported and generic, and `getRequiredFeatureForAction()`/`getInboxAction(type)?.requiredFeature` can yield `undefined` for third-party or future action definitions. A single action with a blank/omitted `requiredFeature` would degrade from "feature-gated" to "any authenticated user allowed" with no error and no audit signal — a latent privilege-escalation foothold.

Additionally, `userHasFeature()` returned the `rbacService.userHasAllFeatures(...)` promise **unawaited** inside its `try`, so a rejected permission check escaped the `catch` and propagated instead of failing closed.

## What Changed
- `userHasFeature()`: `if (!feature) return false` (fail closed instead of fail open).
- `userHasFeature()`: `return await rbacService.userHasAllFeatures(...)` so a rejected RBAC call is caught and the helper fails closed.
- `ensureUserCanExecuteAction()`: throw `ExecutionError(..., 403)` when no required feature resolves, instead of silently allowing the action.

No signatures, import paths, event IDs, ACL IDs, or DI names changed.

## Tests
- New `lib/__tests__/executionHelpers.test.ts`: covers `userHasFeature()` fail-closed on empty/`undefined`/`null` feature (including super-admins), super-admin allow on a concrete feature, RBAC grant/deny delegation, and fail-closed when the RBAC service is missing or throws.
- `lib/__tests__/executionEngine.test.ts`: added a case asserting `executeAction()` returns 403 (and never claims/mutates the action) when the action type has no resolvable required feature.
- `yarn workspace @open-mercato/core test` — 5510 passed.
- `yarn typecheck` (full monorepo) — 21/21 passed.

## Backward Compatibility
No contract surface changes. `userHasFeature()` keeps its signature; only the fail-open behavior is hardened to fail closed (the security fix). `ensureUserCanExecuteAction()` is module-internal.

## Security impact
Closes a fail-open RBAC default that could authorize inbox-ops action execution for any authenticated user when an action's required feature is blank/omitted. After this change, missing-feature paths fail closed (deny / 403) and RBAC-service errors no longer bypass the check.