### PR TITLE
security(inbox_ops): fail closed when required feature is empty/undefined (#2700)

### DIFF
--- a/packages/core/src/modules/inbox_ops/lib/__tests__/executionEngine.test.ts
+++ b/packages/core/src/modules/inbox_ops/lib/__tests__/executionEngine.test.ts
@@ -150,6 +150,20 @@ describe('executionEngine', () => {
       expect(em.nativeUpdate).not.toHaveBeenCalled()
     })
 
+    it('fails closed (403) when the action type has no required feature mapped (#2700)', async () => {
+      mockRbacService.userHasAllFeatures.mockResolvedValue(true)
+      const em = createMockEm()
+      const action = makeAction({ actionType: 'unknown_action_without_feature' as never })
+
+      const result = await executeAction(action, makeCtx(em))
+
+      expect(result.success).toBe(false)
+      expect(result.statusCode).toBe(403)
+      expect(result.error).toContain('No required feature')
+      expect(mockRbacService.userHasAllFeatures).not.toHaveBeenCalled()
+      expect(em.nativeUpdate).not.toHaveBeenCalled()
+    })
+
     it('returns 409 when optimistic lock fails (action already processed)', async () => {
       const em = createMockEm()
       em.nativeUpdate.mockResolvedValue(0)

--- a/packages/core/src/modules/inbox_ops/lib/__tests__/executionHelpers.userHasFeature.test.ts
+++ b/packages/core/src/modules/inbox_ops/lib/__tests__/executionHelpers.userHasFeature.test.ts
@@ -1,0 +1,97 @@
+/** @jest-environment node */
+
+import { userHasFeature } from '../executionHelpers'
+import type { ExecutionHelperContext } from '../executionHelpers'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn(),
+}))
+
+const mockRbacService = {
+  userHasAllFeatures: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'rbacService') return mockRbacService
+    return null
+  }),
+}
+
+function makeCtx(overrides?: Partial<ExecutionHelperContext>): ExecutionHelperContext {
+  return {
+    em: {} as ExecutionHelperContext['em'],
+    userId: 'user-1',
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    container: mockContainer as unknown as ExecutionHelperContext['container'],
+    ...overrides,
+  } as ExecutionHelperContext
+}
+
+describe('userHasFeature (#2700 fail-closed)', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    mockRbacService.userHasAllFeatures.mockResolvedValue(true)
+    mockContainer.resolve.mockImplementation((token: string) => {
+      if (token === 'rbacService') return mockRbacService
+      return null
+    })
+  })
+
+  it.each([
+    ['empty string', ''],
+    ['whitespace-only string', '   '],
+    ['undefined', undefined as unknown as string],
+    ['null', null as unknown as string],
+  ])('fails closed when feature is %s', async (_label, feature) => {
+    const result = await userHasFeature(makeCtx(), feature)
+
+    expect(result).toBe(false)
+    expect(mockRbacService.userHasAllFeatures).not.toHaveBeenCalled()
+  })
+
+  it('does not grant access to a non-superadmin when feature is missing', async () => {
+    const result = await userHasFeature(
+      makeCtx({ auth: { isSuperAdmin: false } as ExecutionHelperContext['auth'] }),
+      '',
+    )
+    expect(result).toBe(false)
+  })
+
+  it('does not grant access to a superadmin when feature is missing (fail closed first)', async () => {
+    const result = await userHasFeature(
+      makeCtx({ auth: { isSuperAdmin: true } as ExecutionHelperContext['auth'] }),
+      '',
+    )
+    expect(result).toBe(false)
+  })
+
+  it('delegates to rbacService when a concrete feature is supplied', async () => {
+    mockRbacService.userHasAllFeatures.mockResolvedValue(true)
+    const result = await userHasFeature(makeCtx(), 'sales.orders.manage')
+
+    expect(result).toBe(true)
+    expect(mockRbacService.userHasAllFeatures).toHaveBeenCalledWith(
+      'user-1',
+      ['sales.orders.manage'],
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+  })
+
+  it('denies when rbacService reports the user lacks the feature', async () => {
+    mockRbacService.userHasAllFeatures.mockResolvedValue(false)
+    const result = await userHasFeature(makeCtx(), 'sales.orders.manage')
+    expect(result).toBe(false)
+  })
+
+  it('grants a superadmin a concrete feature without calling rbacService', async () => {
+    const result = await userHasFeature(
+      makeCtx({ auth: { isSuperAdmin: true } as ExecutionHelperContext['auth'] }),
+      'sales.orders.manage',
+    )
+    expect(result).toBe(true)
+    expect(mockRbacService.userHasAllFeatures).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/inbox_ops/lib/executionEngine.ts
+++ b/packages/core/src/modules/inbox_ops/lib/executionEngine.ts
@@ -452,7 +452,12 @@ async function resolveUnknownContactDiscrepanciesInProposal(
 
 async function ensureUserCanExecuteAction(action: InboxProposalAction, ctx: ExecutionContext): Promise<void> {
   const requiredFeature = getRequiredFeatureForAction(action)
-  if (!requiredFeature) return
+  if (!requiredFeature || requiredFeature.trim().length === 0) {
+    throw new ExecutionError(
+      `No required feature is mapped for action type "${action.actionType}"; refusing to execute`,
+      403,
+    )
+  }
 
   const rbacService = ctx.container.resolve('rbacService') as {
     userHasAllFeatures: (

--- a/packages/core/src/modules/inbox_ops/lib/executionHelpers.ts
+++ b/packages/core/src/modules/inbox_ops/lib/executionHelpers.ts
@@ -136,7 +136,7 @@ export async function userHasFeature(
   ctx: ExecutionHelperContext,
   feature: string,
 ): Promise<boolean> {
-  if (!feature) return true
+  if (!feature || feature.trim().length === 0) return false
   if (hasSuperAdminAccess(ctx.auth)) return true
 
   try {


### PR DESCRIPTION
Fixes #2700

## Problem
The exported RBAC helper `userHasFeature()` returned `true` unconditionally when the `feature` argument was falsy (`if (!feature) return true`) — a fail-open default for a permission check. The sibling enforcement `ensureUserCanExecuteAction()` in `executionEngine.ts` had the same `if (!requiredFeature) return` shortcut, silently allowing execution when no feature was mapped.

## Root Cause
Both code paths treated a missing/empty feature as "allow everyone" instead of denying. Any caller passing `''`, `undefined`, or `null` (e.g. a third-party inbox action whose `requiredFeature` is blank, or a future programmatic caller) would degrade silently from feature-gated to "any authenticated user allowed" — a latent privilege-escalation foothold.

## What Changed
- `packages/core/src/modules/inbox_ops/lib/executionHelpers.ts`: `userHasFeature()` now returns `false` when `feature` is empty, whitespace-only, `undefined`, or `null` (fail closed), before any superadmin/rbac evaluation.
- `packages/core/src/modules/inbox_ops/lib/executionEngine.ts`: `ensureUserCanExecuteAction()` now throws a `403 ExecutionError` when an action type has no mapped required feature, instead of returning early and permitting execution.

## Tests
- New `executionHelpers.userHasFeature.test.ts`: covers fail-closed for empty/whitespace/undefined/null (including superadmin), and the normal delegate/deny/superadmin-grant paths.
- `executionEngine.test.ts`: added a regression case asserting `executeAction` returns `403` (and does not call rbac/claim the action) when the action type has no required feature.
- Verified red-before-fix (7 failures with original source) → green-after-fix. Full `inbox_ops` unit suite (245 tests) passes; `@open-mercato/core` typecheck clean.

## Backward Compatibility
- No contract surface changes. `userHasFeature` signature unchanged. The behavior change is a security hardening (fail-closed); no in-tree caller relied on the previous fail-open path (`REQUIRED_FEATURES_MAP` always supplies a non-empty feature for known action types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)