### PR TITLE
security(messages): drop raw-token fallback in access-token lookups (#2702)

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -276,6 +276,7 @@ jobs:
           DATABASE_URL=postgres://mercato:secret@localhost:5432/mercato_test
           APP_URL=http://localhost:3001
           NEXT_PUBLIC_APP_URL=http://localhost:3001
+          AUTH_SECRET=ci-standalone-test-auth-secret
           JWT_SECRET=ci-standalone-test-jwt-secret
           OM_SECURITY_MFA_SETUP_SECRET=ci-standalone-test-mfa-setup-secret
           TENANT_DATA_ENCRYPTION_FALLBACK_KEY=ci-standalone-test-fallback-key
@@ -361,6 +362,7 @@ jobs:
           DATABASE_URL: postgres://mercato:secret@localhost:5432/mercato_test
           APP_URL: http://localhost:3001
           NEXT_PUBLIC_APP_URL: http://localhost:3001
+          AUTH_SECRET: ci-standalone-test-auth-secret
           JWT_SECRET: ci-standalone-test-jwt-secret
           TENANT_DATA_ENCRYPTION_FALLBACK_KEY: ci-standalone-test-fallback-key
           OM_SECURITY_MFA_SETUP_SECRET: ci-standalone-test-mfa-setup-secret

--- a/packages/core/src/modules/messages/__integration__/TC-API-MSG-020.spec.ts
+++ b/packages/core/src/modules/messages/__integration__/TC-API-MSG-020.spec.ts
@@ -12,12 +12,12 @@ import {
  * TC-API-MSG-020: Public Token-Based Access to Message Detail
  * Surface: packages/core/src/modules/messages/api/token/[token]/route.ts (GET, requireAuth:false)
  *
- * Tokens are minted internally and stored hashed, so we seed rows directly and
- * rely on the route's raw-token fallback to match a plaintext sentinel. This
- * exercises the DB-state-dependent lifecycle the route unit tests cannot:
- * invalid (404), valid consume (200 + use_count increment), expired (410), and
- * exhausted (409). The auth-preflight/recipient branches are covered by the
- * route unit tests.
+ * Tokens are minted internally and stored hashed, so we seed rows directly with
+ * the same HMAC hash the route derives from the URL token (the seed helper hashes
+ * the raw sentinel; the run and app server share JWT_SECRET). This exercises the
+ * DB-state-dependent lifecycle the route unit tests cannot: invalid (404), valid
+ * consume (200 + use_count increment), expired (410), and exhausted (409). The
+ * auth-preflight/recipient branches are covered by the route unit tests.
  */
 const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000';
 const MAX_TOKEN_USE_COUNT = 25;

--- a/packages/core/src/modules/messages/__integration__/helpers.ts
+++ b/packages/core/src/modules/messages/__integration__/helpers.ts
@@ -1,6 +1,7 @@
 import { expect, type APIRequestContext, type Locator, type Page } from '@playwright/test';
 import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
 import { withClient } from '@open-mercato/core/helpers/integration/dbFixtures';
+import { hashAuthToken } from '@open-mercato/core/modules/auth/lib/tokenHash';
 
 export type IntegrationRole = 'admin' | 'employee' | 'superadmin';
 
@@ -272,11 +273,13 @@ export async function deleteMessageIfExists(
 }
 
 // Public message-access tokens are only ever minted internally (the "view in
-// browser" email link) and are stored hashed, so there is no API to obtain a
-// usable raw token in a test. We seed rows directly via the shared dbFixtures
-// pg client and rely on the token route's raw-token fallback
-// (`findOne({ token: hashed }) ?? findOne({ token: raw })`) so a plaintext
-// sentinel value matches without needing the app's HMAC secret.
+// browser" email link) and are stored HMAC-SHA-256 hashed at rest, so there is
+// no API to obtain a usable raw token in a test. We seed rows directly via the
+// shared dbFixtures pg client and store the same hash the route computes from
+// the URL token (`hashAuthToken(raw)`), so the route's hashed-only lookup
+// matches. The integration run and the app server share `JWT_SECRET`, so the
+// hash computed here equals the one the route derives. Callers pass the raw
+// sentinel for both seeding and lookup; these helpers hash it internally.
 export async function seedMessageAccessToken(input: {
   messageId: string;
   recipientUserId: string;
@@ -290,7 +293,13 @@ export async function seedMessageAccessToken(input: {
     await client.query(
       `insert into message_access_tokens (message_id, recipient_user_id, token, expires_at, use_count, created_at)
        values ($1, $2, $3, $4, $5, now())`,
-      [input.messageId, input.recipientUserId, input.token, input.expiresAt.toISOString(), input.useCount ?? 0],
+      [
+        input.messageId,
+        input.recipientUserId,
+        hashAuthToken(input.token),
+        input.expiresAt.toISOString(),
+        input.useCount ?? 0,
+      ],
     );
   });
 }
@@ -299,7 +308,7 @@ export async function readMessageAccessTokenUseCount(token: string): Promise<num
   return withClient(async (client) => {
     const result = await client.query<{ use_count: number }>(
       `select use_count from message_access_tokens where token = $1`,
-      [token],
+      [hashAuthToken(token)],
     );
     if (result.rows.length === 0) return null;
     return Number(result.rows[0].use_count);
@@ -309,6 +318,6 @@ export async function readMessageAccessTokenUseCount(token: string): Promise<num
 export async function deleteMessageAccessTokenIfExists(token: string | null | undefined): Promise<void> {
   if (!token) return;
   await withClient(async (client) => {
-    await client.query(`delete from message_access_tokens where token = $1`, [token]);
+    await client.query(`delete from message_access_tokens where token = $1`, [hashAuthToken(token)]);
   }).catch(() => {});
 }

--- a/packages/core/src/modules/messages/api/token/[token]/__tests__/route.test.ts
+++ b/packages/core/src/modules/messages/api/token/[token]/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import {
   MessageObject,
   MessageRecipient,
 } from '@open-mercato/core/modules/messages/data/entities'
+import { hashAuthToken } from '@open-mercato/core/modules/auth/lib/tokenHash'
 
 const createRequestContainerMock = jest.fn()
 const getAuthFromRequestMock = jest.fn()
@@ -59,7 +60,7 @@ describe('messages /api/messages/token/[token]', () => {
   function createValidToken() {
     return {
       id: 'token-1',
-      token: 'ok',
+      token: hashAuthToken('ok'),
       messageId: 'message-1',
       recipientUserId: 'user-1',
       expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
@@ -103,10 +104,10 @@ describe('messages /api/messages/token/[token]', () => {
 
   it('returns 410 when token is expired', async () => {
     const { commandBus } = setupContainer(async (entity, where) => {
-      if (entity === MessageAccessToken && where.token === 'expired') {
+      if (entity === MessageAccessToken && where.token === hashAuthToken('expired')) {
         return {
           ...createValidToken(),
-          token: 'expired',
+          token: hashAuthToken('expired'),
           expiresAt: new Date('2020-01-01T00:00:00.000Z'),
         }
       }
@@ -122,10 +123,10 @@ describe('messages /api/messages/token/[token]', () => {
 
   it('returns 409 when token usage exceeds max count', async () => {
     const { commandBus } = setupContainer(async (entity, where) => {
-      if (entity === MessageAccessToken && where.token === 'limit') {
+      if (entity === MessageAccessToken && where.token === hashAuthToken('limit')) {
         return {
           ...createValidToken(),
-          token: 'limit',
+          token: hashAuthToken('limit'),
           useCount: 25,
         }
       }
@@ -143,7 +144,7 @@ describe('messages /api/messages/token/[token]', () => {
     const message = createMessage()
 
     const { em, commandBus } = setupContainer(async (entity, where) => {
-      if (entity === MessageAccessToken && where.token === 'ok') return createValidToken()
+      if (entity === MessageAccessToken && where.token === hashAuthToken('ok')) return createValidToken()
       if (entity === Message && where.id === 'message-1') return message
       if (entity === MessageRecipient && where.messageId === 'message-1') return createRecipient()
       return null
@@ -180,7 +181,7 @@ describe('messages /api/messages/token/[token]', () => {
 
   it('returns only auth preflight for protected token when unauthenticated', async () => {
     const { em, commandBus } = setupContainer(async (entity, where) => {
-      if (entity === MessageAccessToken && where.token === 'ok') return createValidToken()
+      if (entity === MessageAccessToken && where.token === hashAuthToken('ok')) return createValidToken()
       if (entity === Message && where.id === 'message-1') return createMessage()
       if (entity === MessageRecipient && where.messageId === 'message-1') return createRecipient()
       return null
@@ -210,7 +211,7 @@ describe('messages /api/messages/token/[token]', () => {
   it('returns 403 for protected token when authenticated user is not the recipient', async () => {
     getAuthFromRequestMock.mockResolvedValueOnce({ sub: 'other-user', tenantId: 'tenant-1', orgId: 'org-1' })
     const { em, commandBus } = setupContainer(async (entity, where) => {
-      if (entity === MessageAccessToken && where.token === 'ok') return createValidToken()
+      if (entity === MessageAccessToken && where.token === hashAuthToken('ok')) return createValidToken()
       if (entity === Message && where.id === 'message-1') return createMessage()
       if (entity === MessageRecipient && where.messageId === 'message-1') return createRecipient()
       return null
@@ -236,7 +237,7 @@ describe('messages /api/messages/token/[token]', () => {
   it('returns protected payload for the authenticated recipient', async () => {
     getAuthFromRequestMock.mockResolvedValueOnce({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1' })
     const { em, commandBus } = setupContainer(async (entity, where) => {
-      if (entity === MessageAccessToken && where.token === 'ok') return createValidToken()
+      if (entity === MessageAccessToken && where.token === hashAuthToken('ok')) return createValidToken()
       if (entity === Message && where.id === 'message-1') return createMessage()
       if (entity === MessageRecipient && where.messageId === 'message-1') return createRecipient()
       return null
@@ -274,5 +275,36 @@ describe('messages /api/messages/token/[token]', () => {
         }),
       }),
     )
+  })
+
+  it('looks the token up only by HMAC hash, never by the raw request value', async () => {
+    const { em } = setupContainer(async (entity, where) => {
+      if (entity === MessageAccessToken && where.token === hashAuthToken('ok')) return createValidToken()
+      return null
+    })
+
+    await GET(new Request('http://localhost'), { params: { token: 'ok' } })
+
+    expect(em.findOne).toHaveBeenCalledWith(MessageAccessToken, { token: hashAuthToken('ok') })
+    expect(em.findOne).not.toHaveBeenCalledWith(MessageAccessToken, { token: 'ok' })
+  })
+
+  it('rejects a stored raw (unhashed) token value presented directly as the URL token', async () => {
+    const legacyRawToken = 'legacy-plaintext-token-value'
+    const { em, commandBus } = setupContainer(async (entity, where) => {
+      if (entity === MessageAccessToken && where.token === legacyRawToken) {
+        return { ...createValidToken(), token: legacyRawToken }
+      }
+      return null
+    })
+
+    const response = await GET(new Request('http://localhost'), { params: { token: legacyRawToken } })
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid or expired link' })
+    expect(commandBus.execute).not.toHaveBeenCalled()
+    expect(em.findOne).toHaveBeenCalledTimes(1)
+    expect(em.findOne).toHaveBeenCalledWith(MessageAccessToken, { token: hashAuthToken(legacyRawToken) })
+    expect(em.findOne).not.toHaveBeenCalledWith(MessageAccessToken, { token: legacyRawToken })
   })
 })

--- a/packages/core/src/modules/messages/api/token/[token]/route.ts
+++ b/packages/core/src/modules/messages/api/token/[token]/route.ts
@@ -37,9 +37,7 @@ function responseForTokenError(error: unknown): Response | null {
 
 async function resolveTokenAccess(em: EntityManager, token: string): Promise<TokenAccess> {
   const hashedToken = hashAuthToken(token)
-  const accessToken =
-    (await findOneWithDecryption(em, MessageAccessToken, { token: hashedToken })) ??
-    (await findOneWithDecryption(em, MessageAccessToken, { token }))
+  const accessToken = await findOneWithDecryption(em, MessageAccessToken, { token: hashedToken })
   if (!accessToken) {
     throw new Error('Invalid or expired link')
   }

--- a/packages/core/src/modules/messages/commands/__tests__/tokens.test.ts
+++ b/packages/core/src/modules/messages/commands/__tests__/tokens.test.ts
@@ -111,7 +111,7 @@ describe('messages.tokens.consume command', () => {
       expect(em.findOne).toHaveBeenCalledWith(MessageAccessToken, { token: stored.token })
     })
 
-    it('falls back to raw-token lookup for tokens written before hashing rollout', async () => {
+    it('rejects a stored raw (unhashed) token presented as the request token', async () => {
       const legacyRawToken = 'legacy-raw-token-3333333333333333333333333333333333333333333333333333'
       const stored: TokenRecord = {
         id: 'tok-1',
@@ -124,11 +124,12 @@ describe('messages.tokens.consume command', () => {
       }
       const { ctx, em } = buildCtx(stored)
 
-      const result = await consumeCommand.execute({ token: legacyRawToken }, ctx)
-
-      expect(result).toEqual({ messageId: 'message-1', recipientUserId: 'user-1' })
+      await expect(consumeCommand.execute({ token: legacyRawToken }, ctx)).rejects.toThrow(
+        /Invalid or expired link/,
+      )
+      expect(em.findOne).toHaveBeenCalledTimes(1)
       expect(em.findOne).toHaveBeenNthCalledWith(1, MessageAccessToken, { token: hashAuthToken(legacyRawToken) })
-      expect(em.findOne).toHaveBeenNthCalledWith(2, MessageAccessToken, { token: legacyRawToken })
+      expect(em.findOne).not.toHaveBeenCalledWith(MessageAccessToken, { token: legacyRawToken })
     })
 
     it('throws when neither hashed nor raw lookup matches', async () => {

--- a/packages/core/src/modules/messages/commands/tokens.ts
+++ b/packages/core/src/modules/messages/commands/tokens.ts
@@ -19,9 +19,7 @@ const consumeTokenCommand: CommandHandler<unknown, { messageId: string; recipien
     const em = (ctx.container.resolve('em') as EntityManager).fork()
 
     const hashedToken = hashAuthToken(input.token)
-    const accessToken =
-      (await em.findOne(MessageAccessToken, { token: hashedToken })) ??
-      (await em.findOne(MessageAccessToken, { token: input.token }))
+    const accessToken = await em.findOne(MessageAccessToken, { token: hashedToken })
     if (!accessToken) {
       throw new Error('Invalid or expired link')
     }


### PR DESCRIPTION
Fixes #2702

## Problem
Message access tokens are stored HMAC-SHA-256 hashed at rest (via `hashAuthToken`), but every lookup path first tried the hashed token and then fell back to querying with the RAW token. The stored `message_access_tokens.token` column value was therefore itself a usable credential, defeating the purpose of hashing tokens at rest.

## Root Cause
- `resolveTokenAccess` (`api/token/[token]/route.ts`) did `findOneWithDecryption(..., { token: hashedToken }) ?? findOneWithDecryption(..., { token })`.
- The `messages.tokens.consume` command (`commands/tokens.ts`) repeated the same `em.findOne(...) ?? em.findOne(... raw ...)` pattern.

New tokens are always written hashed by `createMessageAccessToken`, so the raw fallback existed solely to keep legacy plaintext rows working. An attacker with read access to the table (DB backup leak, replication snapshot, accidental dump, or SQL injection elsewhere) could present the stored column value directly to `GET /api/messages/token/{token}` and read — and where no action is required, mark read — the linked message without ever knowing `AUTH_TOKEN_SECRET`.

## What Changed
- Removed the raw-token fallback in `resolveTokenAccess`; it now looks up only by `hashAuthToken(token)`.
- Removed the raw-token fallback in the `messages.tokens.consume` command; it now looks up only by the HMAC hash.

Tokens expire within 7 days (`ACCESS_TOKEN_EXPIRY_HOURS`), so the legacy plaintext window is already closed — no backfill/transition flag is required.

## Tests
- Updated `commands/__tests__/tokens.test.ts`: replaced the old "falls back to raw-token lookup" assertion with a regression test that a stored raw (unhashed) token is rejected and only the hashed lookup is attempted.
- Updated `api/token/[token]/__tests__/route.test.ts`: existing fixtures now store/match the hashed token; added two regression tests — the lookup uses only the HMAC hash (never the raw value), and a stored raw token presented directly as the URL token returns 404 without invoking the consume command.
- Verified red-before-fix: with the source reverted, exactly the two new regression tests fail (2 failed, 14 passed); with the fix they pass.
- `yarn workspace @open-mercato/core test --testPathPattern modules/messages` → 47 suites / 189 tests passing.
- `yarn workspace @open-mercato/core typecheck` → clean.

## Backward Compatibility
- No contract-surface changes: same API route, request/response shape, event IDs, DI names, and ACL features. Behavior change is an intentional security hardening of an internal lookup path; legacy plaintext tokens have already expired, so no deprecation bridge is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)