### PR TITLE
security(inbox_ops): reject replayed reply send via replySentAt guard (#2697)

### DIFF
--- a/packages/core/src/modules/inbox_ops/api/proposals/[id]/replies/[replyId]/send/__tests__/route.test.ts
+++ b/packages/core/src/modules/inbox_ops/api/proposals/[id]/replies/[replyId]/send/__tests__/route.test.ts
@@ -220,6 +220,55 @@ describe('POST /api/inbox_ops/proposals/[id]/replies/[replyId]/send', () => {
     expect(payload.error).toContain('must be accepted first')
   })
 
+  it('returns 409 when the reply was already sent (replySentAt set)', async () => {
+    const proposal = {
+      id: 'proposal-1',
+      inboxEmailId: 'email-1',
+      isActive: true,
+    } as unknown as InboxProposal
+
+    const action = {
+      id: 'reply-1',
+      proposalId: 'proposal-1',
+      actionType: 'draft_reply',
+      status: 'executed',
+      payload: { to: 'customer@example.com', subject: 'Re: Order inquiry', body: 'Thank you.' },
+      metadata: { replySentAt: '2026-06-07T10:00:00.000Z', sentMessageId: 'sent-msg-prev' },
+    } as unknown as InboxProposalAction
+
+    mockFindOneWithDecryption
+      .mockResolvedValueOnce(proposal)
+      .mockResolvedValueOnce(action)
+
+    const response = await POST(makeRequest())
+    const payload = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(payload.error).toContain('already been sent')
+    expect(mockResendSend).not.toHaveBeenCalled()
+    expect(mockEm.flush).not.toHaveBeenCalled()
+  })
+
+  it('marks replySentAt after a successful send so a replay is rejected', async () => {
+    const { action } = setupHappyPath()
+
+    const first = await POST(makeRequest())
+    expect(first.status).toBe(200)
+    expect((action.metadata as Record<string, unknown>).replySentAt).toBeTruthy()
+
+    mockResendSend.mockClear()
+    mockFindOneWithDecryption
+      .mockResolvedValueOnce({ id: 'proposal-1', inboxEmailId: 'email-1', isActive: true } as unknown as InboxProposal)
+      .mockResolvedValueOnce(action)
+
+    const second = await POST(makeRequest())
+    const secondPayload = await second.json()
+
+    expect(second.status).toBe(409)
+    expect(secondPayload.error).toContain('already been sent')
+    expect(mockResendSend).not.toHaveBeenCalled()
+  })
+
   it('returns 502 when Resend fails', async () => {
     setupHappyPath()
     mockResendSend.mockResolvedValueOnce({

--- a/packages/core/src/modules/inbox_ops/api/proposals/[id]/replies/[replyId]/send/route.ts
+++ b/packages/core/src/modules/inbox_ops/api/proposals/[id]/replies/[replyId]/send/route.ts
@@ -58,6 +58,15 @@ export async function POST(req: Request) {
       )
     }
 
+    const existingMetadata =
+      action.metadata && typeof action.metadata === 'object' ? action.metadata : {}
+    if ((existingMetadata as Record<string, unknown>).replySentAt) {
+      return NextResponse.json(
+        { error: 'Reply has already been sent for this action' },
+        { status: 409 },
+      )
+    }
+
     const email = await findOneWithDecryption(
       ctx.em,
       InboxEmail,
@@ -131,7 +140,7 @@ export async function POST(req: Request) {
     )
 
     action.metadata = {
-      ...(action.metadata && typeof action.metadata === 'object' ? action.metadata : {}),
+      ...existingMetadata,
       replySentAt: new Date().toISOString(),
       sentMessageId,
       ...(messagesResult ? { messageRecordId: messagesResult.messageId } : {}),


### PR DESCRIPTION
Fixes #2697

## Problem
- The draft-reply send endpoint (`POST /api/inbox_ops/proposals/{id}/replies/{replyId}/send`) could be replayed indefinitely. Each call re-invoked `resend.emails.send`, re-delivering the email, creating a duplicate message record, and re-emitting `inbox_ops.reply.sent`. Any user with `inbox_ops.replies.send` could spam a recipient, harm sender reputation, and inflate billed Resend volume.

## Root Cause
- The handler gated only on `action.status === 'executed'`, but a successful send never transitions the action out of `executed` and never re-checked the `replySentAt` it persists. So the status guard kept passing and `replySentAt` was ignored on every subsequent POST.

## What Changed
- `send/route.ts`: after the existing status check, reject with **409** when `action.metadata.replySentAt` is already set, before any external Resend call. After the first successful send `replySentAt` is persisted (unchanged behavior), so any replay is now refused. The 409 response was already declared in the route's `openApi` spec — no contract surface change.

## Tests
- New regression cases in `send/__tests__/route.test.ts`:
  - a pre-set `replySentAt` returns 409, never calls Resend, never flushes
  - a successful send followed by a second send returns 409 and never calls Resend again
- Both fail against the unfixed route (replay returns 200) and pass with the fix. Full `inbox_ops` suite: 318/318 passing. Repo `typecheck` green.

## Backward Compatibility
- No contract surface changes. The `InboxActionStatus` enum, API response shape, and event IDs are untouched; the new 409 is already in the documented response list.