### PR TITLE
security(directory): block cross-tenant org disclosure via ?ids= (#2696)

### DIFF
--- a/packages/core/src/modules/directory/api/organizations/__tests__/route.test.ts
+++ b/packages/core/src/modules/directory/api/organizations/__tests__/route.test.ts
@@ -1,0 +1,148 @@
+/** @jest-environment node */
+
+const foreignTenantId = '11111111-1111-4111-8111-111111111111'
+const foreignOrgId = '22222222-2222-4222-8222-222222222222'
+const tenantlessUserId = '33333333-3333-4333-8333-333333333333'
+const superAdminUserId = '44444444-4444-4444-8444-444444444444'
+const allowedOrgId = '55555555-5555-4555-8555-555555555555'
+
+const authMock = jest.fn()
+const resolveIsSuperAdminMock = jest.fn()
+const enforceTenantSelectionMock = jest.fn()
+const resolveOrganizationScopeMock = jest.fn()
+const findWithDecryptionMock = jest.fn()
+const findOneWithDecryptionMock = jest.fn()
+const emFind = jest.fn()
+const emFindOne = jest.fn()
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return { find: emFind, findOne: emFindOne }
+    throw new Error(`[internal] Unexpected container resolve: ${name}`)
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => authMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/core/modules/auth/lib/tenantAccess', () => {
+  const actual = jest.requireActual('@open-mercato/core/modules/auth/lib/tenantAccess')
+  return {
+    ...actual,
+    resolveIsSuperAdmin: (...args: unknown[]) => resolveIsSuperAdminMock(...args),
+    enforceTenantSelection: (...args: unknown[]) => enforceTenantSelectionMock(...args),
+  }
+})
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: (...args: unknown[]) => resolveOrganizationScopeMock(...args),
+  getSelectedOrganizationFromRequest: () => null,
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => findWithDecryptionMock(...args),
+  findOneWithDecryption: (...args: unknown[]) => findOneWithDecryptionMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn(async () => ({})),
+}))
+
+import { GET } from '../route'
+import { forbidden } from '@open-mercato/shared/lib/crud/errors'
+
+describe('directory organizations GET — cross-tenant ?ids= guard (#2696)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    emFind.mockResolvedValue([])
+    emFindOne.mockResolvedValue(null)
+    findOneWithDecryptionMock.mockResolvedValue(null)
+  })
+
+  it('refuses a tenantless non-super-admin pivoting into another tenant via ?ids=', async () => {
+    authMock.mockResolvedValue({ sub: tenantlessUserId, tenantId: null, orgId: null })
+    resolveIsSuperAdminMock.mockResolvedValue(false)
+    // tenantless caller has no permitted organization scope
+    resolveOrganizationScopeMock.mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId: null,
+    })
+
+    const response = await GET(
+      new Request(`http://localhost/api/directory/organizations?view=options&ids=${foreignOrgId}`),
+    )
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toBe('Tenant scope required')
+    // The unscoped foreign-tenant discovery query must never run for this caller
+    expect(findWithDecryptionMock).not.toHaveBeenCalled()
+    // No foreign-tenant org rows leaked
+    expect(Array.isArray(body.items)).toBe(true)
+    expect(body.items).toHaveLength(0)
+  })
+
+  it('re-runs enforceTenantSelection on the derived tenant and refuses on a 403', async () => {
+    authMock.mockResolvedValue({ sub: tenantlessUserId, tenantId: null, orgId: null })
+    resolveIsSuperAdminMock.mockResolvedValue(false)
+    // Caller is allowed to see allowedOrgId, but passes a foreign org id too.
+    resolveOrganizationScopeMock.mockResolvedValue({
+      selectedId: allowedOrgId,
+      filterIds: [allowedOrgId],
+      allowedIds: [allowedOrgId],
+      tenantId: null,
+    })
+    findWithDecryptionMock.mockResolvedValue([
+      { id: allowedOrgId, tenant: { id: foreignTenantId } },
+    ])
+    enforceTenantSelectionMock.mockImplementation(async () => {
+      throw forbidden('Not authorized to target this tenant.')
+    })
+
+    const response = await GET(
+      new Request(
+        `http://localhost/api/directory/organizations?view=options&ids=${allowedOrgId},${foreignOrgId}`,
+      ),
+    )
+
+    // Only the in-scope id is used for discovery; the foreign id is filtered out.
+    expect(findWithDecryptionMock).toHaveBeenCalledTimes(1)
+    const filter = findWithDecryptionMock.mock.calls[0][2] as { id: { $in: string[] } }
+    expect(filter.id.$in).toEqual([allowedOrgId])
+    // enforceTenantSelection rejects the pivot → clean 403, no org graph returned.
+    expect(response.status).toBe(403)
+  })
+
+  it('still allows a super-admin to derive the tenant from ?ids=', async () => {
+    authMock.mockResolvedValue({ sub: superAdminUserId, tenantId: null, orgId: null })
+    resolveIsSuperAdminMock.mockResolvedValue(true)
+    findWithDecryptionMock.mockResolvedValue([
+      { id: foreignOrgId, tenant: { id: foreignTenantId } },
+    ])
+    enforceTenantSelectionMock.mockResolvedValue(foreignTenantId)
+    emFind.mockResolvedValue([
+      { id: foreignOrgId, name: 'Foreign Org', parentId: null, isActive: true, depth: 0, treePath: foreignOrgId },
+    ])
+
+    const response = await GET(
+      new Request(`http://localhost/api/directory/organizations?view=options&ids=${foreignOrgId}`),
+    )
+
+    // Super-admins bypass the scope intersection — discovery runs on the raw ids.
+    expect(findWithDecryptionMock).toHaveBeenCalledTimes(1)
+    const filter = findWithDecryptionMock.mock.calls[0][2] as { id: { $in: string[] } }
+    expect(filter.id.$in).toEqual([foreignOrgId])
+    expect(resolveOrganizationScopeMock).not.toHaveBeenCalled()
+    expect(enforceTenantSelectionMock).toHaveBeenCalledWith(expect.anything(), foreignTenantId)
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.items).toHaveLength(1)
+  })
+})

--- a/packages/core/src/modules/directory/api/organizations/route.ts
+++ b/packages/core/src/modules/directory/api/organizations/route.ts
@@ -28,7 +28,8 @@ import {
   directoryOkSchema,
   organizationListResponseSchema,
 } from '../openapi'
-import { resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
+import { resolveIsSuperAdmin, enforceTenantSelection } from '@open-mercato/core/modules/auth/lib/tenantAccess'
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 type CrudInput = Record<string, unknown>
@@ -154,22 +155,42 @@ export async function GET(req: Request) {
   const includeInactive = parseBooleanToken(query.includeInactive) === true || status !== 'active'
 
   if (!allowAllTenants && !tenantId && !authTenantId && ids?.length) {
-    const scopedOrgs: Organization[] = await findWithDecryption(
-      em,
-      Organization,
-      { id: { $in: ids }, deletedAt: null },
-      { populate: ['tenant'] },
-      { tenantId: authTenantId, organizationId: null },
-    )
-    const tenantCandidates = new Set<string>()
-    for (const org of scopedOrgs) {
-      const orgTenantId = org.tenant?.id ? stringId(org.tenant.id) : ''
-      if (orgTenantId) tenantCandidates.add(orgTenantId)
+    let scopedIds = ids
+    if (!isSuperAdmin) {
+      let allowedIds: string[] | null = null
+      try {
+        const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
+        allowedIds = Array.isArray(scope.allowedIds) ? scope.allowedIds : null
+      } catch {}
+      const allowedSet = allowedIds ? new Set(allowedIds) : new Set<string>()
+      scopedIds = ids.filter((id) => allowedSet.has(id))
     }
-    if (tenantCandidates.size === 1) {
-      tenantId = Array.from(tenantCandidates)[0] ?? null
-    } else if (tenantCandidates.size > 1) {
-      return NextResponse.json({ items: [], error: 'Tenant scope required' }, { status: 400 })
+    if (scopedIds.length) {
+      const scopedOrgs: Organization[] = await findWithDecryption(
+        em,
+        Organization,
+        { id: { $in: scopedIds }, deletedAt: null },
+        { populate: ['tenant'] },
+        { tenantId: authTenantId, organizationId: null },
+      )
+      const tenantCandidates = new Set<string>()
+      for (const org of scopedOrgs) {
+        const orgTenantId = org.tenant?.id ? stringId(org.tenant.id) : ''
+        if (orgTenantId) tenantCandidates.add(orgTenantId)
+      }
+      if (tenantCandidates.size === 1) {
+        const candidateTenantId = Array.from(tenantCandidates)[0] ?? null
+        try {
+          tenantId = await enforceTenantSelection({ auth, container }, candidateTenantId)
+        } catch (error) {
+          if (isCrudHttpError(error)) {
+            return NextResponse.json(error.body, { status: error.status })
+          }
+          throw error
+        }
+      } else if (tenantCandidates.size > 1) {
+        return NextResponse.json({ items: [], error: 'Tenant scope required' }, { status: 400 })
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #2696

## Problem
The directory organizations list endpoint (`GET /api/directory/organizations`) let an authenticated non-super-admin caller with **no actor tenant** (`auth.tenantId === null`) but the `directory.organizations.view` feature read another tenant's full organization graph (names, parents, hierarchy, slugs, custom-field values) by passing `?ids=<uuid-in-other-tenant>`.

## Root Cause
The `?ids=` fallback branch (route.ts ~L156) derived the target tenant from the supplied organization UUIDs using an **unscoped** `findWithDecryption(Organization, { id: { $in: ids } })` query, then assigned that foreign tenant to `tenantId`. The central tenant guard `enforceTenantSelection` only runs when the request carries a `tenantId` query/body param — a GET supplying only `?ids=` never trips it, so the trust boundary was never enforced for this path.

## What Changed
`packages/core/src/modules/directory/api/organizations/route.ts`:
- For non-super-admins, the `?ids=` branch now resolves the caller's permitted organization scope via `resolveOrganizationScopeForRequest` and **intersects the supplied ids with `scope.allowedIds`** before any discovery query. A tenantless caller has an empty scope, so no foreign-tenant query runs and the request falls through to the existing `Tenant scope required` (400) refusal.
- After a candidate tenant is derived, it is re-validated through **`enforceTenantSelection({ auth, container }, candidateTenantId)`**, so a non-super-admin can never pivot into a foreign tenant; the thrown `CrudHttpError` (403) is surfaced as a clean JSON response.
- Super-admin `?ids=` discovery is preserved unchanged (scope intersection is skipped; `enforceTenantSelection` returns the requested tenant for super-admins).

## Tests
New `packages/core/src/modules/directory/api/organizations/__tests__/route.test.ts`:
- tenantless non-super-admin with `?ids=<foreign-org>` is refused (400) and the unscoped discovery query never runs;
- scope intersection keeps only in-scope ids and `enforceTenantSelection` rejection yields a 403 (no org graph returned);
- super-admin `?ids=` path still derives the tenant and returns 200.

All three tests are red on `develop` and green with the fix. Verified with `yarn build:packages`, `yarn generate`, `yarn typecheck` (all pass) and the full directory module suite (66 passed).

## Backward Compatibility
No contract surface changes — same route URL, response shape, ACL features, event IDs, and DI names. The only behavior change tightens a cross-tenant disclosure; super-admin behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)