### PR TITLE
security(inbox_ops): drop role-name super-admin fallback (#2699)

### DIFF
--- a/packages/core/src/modules/inbox_ops/__tests__/executionHelpers.superadmin.test.ts
+++ b/packages/core/src/modules/inbox_ops/__tests__/executionHelpers.superadmin.test.ts
@@ -1,0 +1,137 @@
+import type { AwilixContainer } from 'awilix'
+import { userHasFeature, type ExecutionHelperContext } from '../lib/executionHelpers'
+
+type RbacStub = {
+  userHasAllFeatures: jest.Mock<Promise<boolean>, [string, string[], { tenantId: string; organizationId: string }]>
+}
+
+function makeContext(
+  auth: ExecutionHelperContext['auth'],
+  rbac: RbacStub,
+): ExecutionHelperContext {
+  const container = {
+    resolve: (key: string) => {
+      if (key === 'rbacService') return rbac
+      throw new Error(`[internal] unexpected resolve(${key})`)
+    },
+  } as unknown as AwilixContainer
+
+  return {
+    em: {} as ExecutionHelperContext['em'],
+    userId: 'user-1',
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    container,
+    auth,
+  }
+}
+
+describe('inbox_ops userHasFeature super-admin gate', () => {
+  let rbac: RbacStub
+
+  beforeEach(() => {
+    rbac = {
+      userHasAllFeatures: jest.fn().mockResolvedValue(false),
+    }
+  })
+
+  it('does NOT bypass the feature check for a role literally named "superadmin" without the isSuperAdmin flag', async () => {
+    // Regression for #2699: a tenant-mutable role name must never grant a feature bypass.
+    const ctx = makeContext(
+      {
+        sub: 'user-1',
+        tenantId: 'tenant-1',
+        orgId: 'org-1',
+        roles: ['superadmin'],
+        isSuperAdmin: false,
+      } as ExecutionHelperContext['auth'],
+      rbac,
+    )
+
+    const allowed = await userHasFeature(ctx, 'inbox_ops.execute')
+
+    expect(allowed).toBe(false)
+    expect(rbac.userHasAllFeatures).toHaveBeenCalledWith(
+      'user-1',
+      ['inbox_ops.execute'],
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+  })
+
+  it('does not bypass for spoofed role names with mixed case or whitespace', async () => {
+    const ctx = makeContext(
+      {
+        sub: 'user-1',
+        tenantId: 'tenant-1',
+        orgId: 'org-1',
+        roles: [' SuperAdmin ', 'Super Admin'],
+        isSuperAdmin: false,
+      } as ExecutionHelperContext['auth'],
+      rbac,
+    )
+
+    const allowed = await userHasFeature(ctx, 'inbox_ops.execute')
+
+    expect(allowed).toBe(false)
+    expect(rbac.userHasAllFeatures).toHaveBeenCalledTimes(1)
+  })
+
+  it('bypasses the feature check only when the immutable isSuperAdmin flag is true', async () => {
+    const ctx = makeContext(
+      {
+        sub: 'user-1',
+        tenantId: 'tenant-1',
+        orgId: 'org-1',
+        roles: [],
+        isSuperAdmin: true,
+      } as ExecutionHelperContext['auth'],
+      rbac,
+    )
+
+    const allowed = await userHasFeature(ctx, 'inbox_ops.execute')
+
+    expect(allowed).toBe(true)
+    expect(rbac.userHasAllFeatures).not.toHaveBeenCalled()
+  })
+
+  it('delegates to the rbac feature matcher for a regular user with a granted feature', async () => {
+    rbac.userHasAllFeatures.mockResolvedValue(true)
+    const ctx = makeContext(
+      {
+        sub: 'user-1',
+        tenantId: 'tenant-1',
+        orgId: 'org-1',
+        roles: ['employee'],
+        isSuperAdmin: false,
+      } as ExecutionHelperContext['auth'],
+      rbac,
+    )
+
+    const allowed = await userHasFeature(ctx, 'inbox_ops.execute')
+
+    expect(allowed).toBe(true)
+    expect(rbac.userHasAllFeatures).toHaveBeenCalledWith(
+      'user-1',
+      ['inbox_ops.execute'],
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+  })
+
+  it('short-circuits to true for an empty feature requirement', async () => {
+    const ctx = makeContext(
+      {
+        sub: 'user-1',
+        tenantId: 'tenant-1',
+        orgId: 'org-1',
+        roles: ['employee'],
+        isSuperAdmin: false,
+      } as ExecutionHelperContext['auth'],
+      rbac,
+    )
+
+    const allowed = await userHasFeature(ctx, '')
+
+    expect(allowed).toBe(true)
+    expect(rbac.userHasAllFeatures).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/inbox_ops/lib/executionHelpers.ts
+++ b/packages/core/src/modules/inbox_ops/lib/executionHelpers.ts
@@ -65,14 +65,15 @@ interface FeatureCheckingRbacService {
   ) => Promise<boolean>
 }
 
+// Super-admin status is the immutable `isSuperAdmin` flag derived from the ACL
+// `is_super_admin` column at session resolution. Never fall back to comparing the
+// auth context's `roles` against a literal like 'superadmin' — role names are
+// tenant-mutable and trivially spoofable, so a role-name fallback would let a tenant
+// admin mint a `superadmin`-named role to bypass every inbox-ops feature gate
+// (#2699). Mirrors the scheduler module's hardened gate.
 function hasSuperAdminAccess(auth: ExecutionHelperContext['auth']): boolean {
   if (!auth || typeof auth !== 'object') return false
-  if ((auth as Record<string, unknown>).isSuperAdmin === true) return true
-  const roles = (auth as Record<string, unknown>).roles
-  if (!Array.isArray(roles)) return false
-  return roles.some(
-    (role) => typeof role === 'string' && role.trim().toLowerCase() === 'superadmin',
-  )
+  return (auth as Record<string, unknown>).isSuperAdmin === true
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2699

## Problem
The inbox-ops execution super-admin gate (`hasSuperAdminAccess` in `packages/core/src/modules/inbox_ops/lib/executionHelpers.ts`, used by `userHasFeature()`) trusted the immutable `auth.isSuperAdmin` flag but **also** fell back to returning `true` whenever the auth context's `roles` array contained the literal string `superadmin` (case- and whitespace-insensitive).

## Root Cause
The `roles` field on the auth context is populated from role *names*, which are tenant-mutable and trivially spoofable. A tenant admin who creates or renames a custom role to `superadmin` could grant holders of that role a silent bypass of every inbox-ops feature check — without ever being granted the real ACL `isSuperAdmin` flag. This contradicts the project's RBAC guidance (role names must never gate access) and is a privilege-escalation path.

## What Changed
- Dropped the role-name fallback in `hasSuperAdminAccess`; it now trusts only `auth.isSuperAdmin === true` (derived from the immutable ACL `is_super_admin` column at session resolution).
- This mirrors the scheduler module's already-hardened gate (`isSuperAdminActor`) and the canonical `isSuperAdminAuth` helper in `packages/shared/src/lib/auth/server.ts`.
- Added a short rationale comment so the gate is not "softened" back later.

## Tests
- New `packages/core/src/modules/inbox_ops/__tests__/executionHelpers.superadmin.test.ts` — RED before the fix, GREEN after:
  - a `roles: ['superadmin']` actor with `isSuperAdmin: false` does **not** bypass and is delegated to `rbacService.userHasAllFeatures`
  - mixed-case / whitespace-padded spoof variants (` SuperAdmin `, `Super Admin`) also do not bypass
  - a genuine `isSuperAdmin: true` actor still bypasses (no rbac call)
  - a regular user with a granted feature is delegated and allowed
  - empty feature requirement short-circuits to `true`
- Full `modules/inbox_ops` suite: 27 suites / 321 tests pass.
- `@open-mercato/core` typecheck: clean.

## Backward Compatibility
No contract surface changes. `hasSuperAdminAccess` is a module-internal helper; no exported signature, API response field, event ID, ACL ID, DI name, or import path changed. The change only tightens an over-permissive security gate (intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)