### PR TITLE
security(customers): structural tenant scope on company/people GET detail (#2695)

### DIFF
--- a/packages/core/src/modules/customers/api/companies/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/route.ts
@@ -38,6 +38,7 @@ import {
 import { resolveCustomerInteractionFeatureFlags } from '../../../lib/interactionFeatureFlags'
 import { hydrateCanonicalInteractions } from '../../../lib/interactionReadModel'
 import { buildEmailVisibilityMikroFilter } from '../../../lib/visibilityFilter'
+import { resolveCustomerDetailTenantScope } from '../../../lib/detailTenantScope'
 import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -375,10 +376,13 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
   const interactionFlags = await resolveCustomerInteractionFeatureFlags(container, scope?.tenantId ?? auth.tenantId)
   const interactionMode = interactionFlags.unified ? 'canonical' : 'legacy'
 
+  const tenantScope = resolveCustomerDetailTenantScope(parse.data.id, 'company', auth)
+  if (!tenantScope.allowed) return notFound('Company not found')
+
   const company = await findOneWithDecryption(
     em,
     CustomerEntity,
-    { id: parse.data.id, kind: 'company', deletedAt: null },
+    tenantScope.where,
     { populate: ['companyProfile'] },
     {
       tenantId: auth.tenantId ?? null,
@@ -387,7 +391,6 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
   )
   if (!company) return notFound('Company not found')
 
-  if (auth.tenantId && company.tenantId !== auth.tenantId) return notFound('Company not found')
   if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: company.organizationId })) {
     return forbidden('Access denied')
   }

--- a/packages/core/src/modules/customers/api/people/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/route.ts
@@ -41,6 +41,7 @@ import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/dire
 import { loadPersonCompanyLinks, summarizePersonCompanies } from '../../../lib/personCompanies'
 import { normalizeCustomerDetailCustomFields } from '../../detailCustomFields'
 import { buildEmailVisibilityMikroFilter } from '../../../lib/visibilityFilter'
+import { resolveCustomerDetailTenantScope } from '../../../lib/detailTenantScope'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.people.view'] },
@@ -454,10 +455,17 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
     })
     const em = (container.resolve('em') as EntityManager)
 
+    const tenantScope = resolveCustomerDetailTenantScope(parse.data.id, 'person', auth)
+    if (!tenantScope.allowed) {
+      statusCode = 404
+      profileMeta = { reason: 'person_tenant_mismatch' }
+      return notFound('Person not found')
+    }
+
     const person = await findOneWithDecryption(
       em,
       CustomerEntity,
-      { id: parse.data.id, kind: 'person', deletedAt: null },
+      tenantScope.where,
       {},
       {
         tenantId: scope?.tenantId ?? auth.tenantId ?? null,
@@ -471,11 +479,6 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
       return notFound('Person not found')
     }
 
-    if (auth.tenantId && person.tenantId !== auth.tenantId) {
-      statusCode = 404
-      profileMeta = { reason: 'person_tenant_mismatch' }
-      return notFound('Person not found')
-    }
     if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: person.organizationId })) {
       statusCode = 403
       profileMeta = { reason: 'organization_forbidden' }

--- a/packages/core/src/modules/customers/lib/__tests__/detailTenantScope.test.ts
+++ b/packages/core/src/modules/customers/lib/__tests__/detailTenantScope.test.ts
@@ -1,0 +1,70 @@
+import { resolveCustomerDetailTenantScope } from '../detailTenantScope'
+
+const RECORD_ID = '123e4567-e89b-41d3-a456-426614174000'
+const TENANT_ID = '123e4567-e89b-41d3-a456-426614174010'
+
+describe('resolveCustomerDetailTenantScope', () => {
+  it('injects the caller tenant into the WHERE clause for a tenant-bound principal', () => {
+    const result = resolveCustomerDetailTenantScope(RECORD_ID, 'company', {
+      tenantId: TENANT_ID,
+      isSuperAdmin: false,
+    })
+
+    expect(result.allowed).toBe(true)
+    expect(result.where).toEqual({
+      id: RECORD_ID,
+      kind: 'company',
+      deletedAt: null,
+      tenantId: TENANT_ID,
+    })
+  })
+
+  it('denies a non-super-admin principal whose tenantId is null (issue #2695)', () => {
+    const result = resolveCustomerDetailTenantScope(RECORD_ID, 'company', {
+      tenantId: null,
+      isSuperAdmin: false,
+    })
+
+    expect(result.allowed).toBe(false)
+    expect(result.where).toBeNull()
+  })
+
+  it('denies a null-tenant principal when isSuperAdmin is undefined', () => {
+    const result = resolveCustomerDetailTenantScope(RECORD_ID, 'person', {
+      tenantId: null,
+    })
+
+    expect(result.allowed).toBe(false)
+    expect(result.where).toBeNull()
+  })
+
+  it('allows a super-admin with no tenant scope to read without a tenant filter', () => {
+    const result = resolveCustomerDetailTenantScope(RECORD_ID, 'person', {
+      tenantId: null,
+      isSuperAdmin: true,
+    })
+
+    expect(result.allowed).toBe(true)
+    expect(result.where).toEqual({
+      id: RECORD_ID,
+      kind: 'person',
+      deletedAt: null,
+    })
+    expect((result.where as Record<string, unknown>).tenantId).toBeUndefined()
+  })
+
+  it('still scopes by tenant for a super-admin who has an active tenant binding', () => {
+    const result = resolveCustomerDetailTenantScope(RECORD_ID, 'company', {
+      tenantId: TENANT_ID,
+      isSuperAdmin: true,
+    })
+
+    expect(result.allowed).toBe(true)
+    expect(result.where).toEqual({
+      id: RECORD_ID,
+      kind: 'company',
+      deletedAt: null,
+      tenantId: TENANT_ID,
+    })
+  })
+})

--- a/packages/core/src/modules/customers/lib/detailTenantScope.ts
+++ b/packages/core/src/modules/customers/lib/detailTenantScope.ts
@@ -1,0 +1,36 @@
+export type CustomerDetailKind = 'person' | 'company'
+
+export type CustomerDetailAuthScope = {
+  tenantId?: string | null
+  isSuperAdmin?: boolean
+}
+
+export type CustomerDetailWhere = {
+  id: string
+  kind: CustomerDetailKind
+  deletedAt: null
+  tenantId?: string
+}
+
+export type CustomerDetailTenantScopeResult =
+  | { allowed: true; where: CustomerDetailWhere }
+  | { allowed: false; where: null }
+
+export function resolveCustomerDetailTenantScope(
+  id: string,
+  kind: CustomerDetailKind,
+  auth: CustomerDetailAuthScope,
+): CustomerDetailTenantScopeResult {
+  const tenantId = auth.tenantId ?? null
+  const base: CustomerDetailWhere = { id, kind, deletedAt: null }
+
+  if (tenantId) {
+    return { allowed: true, where: { ...base, tenantId } }
+  }
+
+  if (auth.isSuperAdmin === true) {
+    return { allowed: true, where: base }
+  }
+
+  return { allowed: false, where: null }
+}


### PR DESCRIPTION
Fixes #2695

## Problem
`GET /api/customers/companies/[id]` (and the sibling `GET /api/customers/people/[id]`) loaded the requested record with a WHERE clause that omitted `tenantId`, then relied on a post-fetch check that only ran when `auth.tenantId` was truthy. A non-super-admin principal whose `auth.tenantId` is `null` (e.g. an API key created without a tenant binding) skipped the tenant boundary entirely and could read any tenant's company/person — including its decrypted profile — by guessing an enumerable UUID. Cross-tenant data exposure.

## Root Cause
The guard `if (auth.tenantId && record.tenantId !== auth.tenantId) return notFound(...)` short-circuits whenever `auth.tenantId` is falsy. `findOneWithDecryption` passes the WHERE clause through verbatim, so no tenant filter was injected; the row was loaded (and decryption attempted with the caller's key) before the conditional post-check.

## What Changed
- Added a small pure helper `resolveCustomerDetailTenantScope(id, kind, auth)` in `customers/lib/detailTenantScope.ts` that makes the tenant boundary **structural**:
  - tenant-bound principal → injects `tenantId` into the WHERE clause
  - super-admin with no tenant scope → reads without a tenant filter
  - non-super-admin with `tenantId === null` → **denied** (returns `{ allowed: false }`)
- Wired the helper into both the companies and people detail GET handlers, replacing the conditional `auth.tenantId && …` post-check. Foreign-tenant rows are now never loaded, which also closes the wasteful cross-tenant decryption attempt noted in the issue.

## Tests
- New unit test `customers/lib/__tests__/detailTenantScope.test.ts` (5 cases) covering: tenant injection, the null-tenant non-super-admin deny path (the #2695 vuln), undefined `isSuperAdmin`, super-admin no-scope read, and super-admin with an active tenant binding. Verified red-before/green-after by temporarily reverting the helper to the vulnerable behavior.
- `yarn workspace @open-mercato/core test -- src/modules/customers` — 770 passed.
- `yarn typecheck` (full workspace) — pass.
- `yarn build:packages` / `yarn generate` — pass.

## Backward Compatibility
- No contract-surface changes (no API response fields, event IDs, widget spot IDs, ACL IDs, import paths, or DI names removed).
- Behavior preserved for all legitimate callers (tenant-bound principals and super-admins). The only behavior change is closing the cross-tenant leak for null-tenant non-super-admin principals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)