### PR TITLE
security(inbox_ops): bind inbound webhook to tenant + fail-closed rate limiter (#2698)

### DIFF
--- a/packages/core/src/modules/inbox_ops/__tests__/encryption.test.ts
+++ b/packages/core/src/modules/inbox_ops/__tests__/encryption.test.ts
@@ -59,7 +59,18 @@ describe('inbox_ops defaultEncryptionMaps', () => {
     expect(emailFieldNames).not.toContain('references')
     expect(emailFieldNames).not.toContain('content_hash')
 
+    // inbox_address remains plaintext (UNIQUE-indexed, used in the webhook
+    // WHERE lookup); only the per-tenant webhook_secret credential is encrypted.
     const settingsEntry = defaultEncryptionMaps.find((m) => m.entityId === 'inbox_ops:inbox_settings')
-    expect(settingsEntry).toBeUndefined()
+    const settingsFieldNames = (settingsEntry?.fields ?? []).map((f) => f.field)
+    expect(settingsFieldNames).not.toContain('inbox_address')
+  })
+
+  it('encrypts the per-tenant inbound webhook secret at rest (issue #2698)', () => {
+    const entry = defaultEncryptionMaps.find((m) => m.entityId === 'inbox_ops:inbox_settings')
+    expect(entry).toBeDefined()
+    expect(entry!.fields).toEqual(expect.arrayContaining([
+      { field: 'webhook_secret' },
+    ]))
   })
 })

--- a/packages/core/src/modules/inbox_ops/api/settings/__tests__/optimistic-lock.test.ts
+++ b/packages/core/src/modules/inbox_ops/api/settings/__tests__/optimistic-lock.test.ts
@@ -61,6 +61,7 @@ describe('inbox_ops settings optimistic locking', () => {
     jest.clearAllMocks()
     delete process.env.OM_OPTIMISTIC_LOCK
     mockSettings.updatedAt = new Date(CURRENT_VERSION)
+    ;(mockSettings as { webhookSecret?: string | null }).webhookSecret = null
     mockFindOneWithDecryption.mockResolvedValue(mockSettings)
   })
 
@@ -84,5 +85,39 @@ describe('inbox_ops settings optimistic locking', () => {
   it('is a no-op (no 409) without the expected-version header', async () => {
     const res = await PATCH(patchRequest(null))
     expect(res.status).toBe(200)
+  })
+
+  it('sets the per-tenant webhook secret and never echoes the value (issue #2698)', async () => {
+    const secret = 'a-strong-per-tenant-secret-1234'
+    const req = new Request('http://localhost/api/inbox_ops/settings', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ webhookSecret: secret }),
+    })
+
+    const res = await PATCH(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect((mockSettings as { webhookSecret?: string | null }).webhookSecret).toBe(secret)
+    expect(body.settings.webhookSecretSet).toBe(true)
+    expect(JSON.stringify(body)).not.toContain(secret)
+    expect(mockEm.flush).toHaveBeenCalled()
+  })
+
+  it('clears the per-tenant webhook secret when null is provided', async () => {
+    ;(mockSettings as { webhookSecret?: string | null }).webhookSecret = 'existing-secret-value-000'
+    const req = new Request('http://localhost/api/inbox_ops/settings', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ webhookSecret: null }),
+    })
+
+    const res = await PATCH(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect((mockSettings as { webhookSecret?: string | null }).webhookSecret).toBeNull()
+    expect(body.settings.webhookSecretSet).toBe(false)
   })
 })

--- a/packages/core/src/modules/inbox_ops/api/settings/route.ts
+++ b/packages/core/src/modules/inbox_ops/api/settings/route.ts
@@ -51,6 +51,8 @@ export async function GET(req: Request) {
         inboxAddress: settings.inboxAddress,
         isActive: settings.isActive,
         workingLanguage: settings.workingLanguage,
+        // Surface only whether a per-tenant secret exists — never the value.
+        webhookSecretSet: Boolean(settings.webhookSecret),
         updatedAt: settings.updatedAt instanceof Date ? settings.updatedAt.toISOString() : (settings.updatedAt ?? null),
       } : null,
     }
@@ -119,6 +121,10 @@ export async function PATCH(req: Request) {
     if (parsed.data.isActive !== undefined) {
       settings.isActive = parsed.data.isActive
     }
+    if (parsed.data.webhookSecret !== undefined) {
+      // Empty/null clears the per-tenant secret (reverts to the global key).
+      settings.webhookSecret = parsed.data.webhookSecret ? parsed.data.webhookSecret : null
+    }
 
     await ctx.em.flush()
 
@@ -132,6 +138,7 @@ export async function PATCH(req: Request) {
         inboxAddress: settings.inboxAddress,
         isActive: settings.isActive,
         workingLanguage: settings.workingLanguage,
+        webhookSecretSet: Boolean(settings.webhookSecret),
         updatedAt: settings.updatedAt instanceof Date ? settings.updatedAt.toISOString() : (settings.updatedAt ?? null),
       },
     })

--- a/packages/core/src/modules/inbox_ops/api/webhook/__tests__/inbound.test.ts
+++ b/packages/core/src/modules/inbox_ops/api/webhook/__tests__/inbound.test.ts
@@ -323,6 +323,27 @@ describe('POST /api/inbox_ops/webhook/inbound', () => {
     expect(response.headers.get('Retry-After')).toBe('30')
   })
 
+  it('keys the pre-DB global bucket on the secret, not the per-request signature (issue #2698)', async () => {
+    // Regression: keying the global bucket on the mutable per-request signature
+    // would mint a fresh bucket for every request (different body/timestamp), so
+    // the throttle could never accumulate. The key must be request-invariant for
+    // a fixed signing secret so a flood with a rotating body is still capped.
+    const { checkRateLimit } = jest.requireMock('@open-mercato/core/modules/inbox_ops/lib/rateLimiter') as {
+      checkRateLimit: jest.Mock
+    }
+    mockFindOneWithDecryption.mockResolvedValue(null)
+
+    await POST(makeSignedRequest({ ...validPayload, subject: 'first body variant' }))
+    await POST(makeSignedRequest({ ...validPayload, subject: 'second different body' }))
+
+    const customGlobalKeys = checkRateLimit.mock.calls
+      .map((call) => call[1] as string)
+      .filter((key) => key.startsWith('webhook:secret:'))
+
+    expect(customGlobalKeys.length).toBe(2)
+    expect(customGlobalKeys[0]).toBe(customGlobalKeys[1])
+  })
+
   describe('per-tenant webhook secret binding (issue #2698)', () => {
     const TENANT_SECRET = 'per-tenant-secret-abcdefabcdef'
     const settingsWithSecret = { ...mockSettings, webhookSecret: TENANT_SECRET }

--- a/packages/core/src/modules/inbox_ops/api/webhook/__tests__/inbound.test.ts
+++ b/packages/core/src/modules/inbox_ops/api/webhook/__tests__/inbound.test.ts
@@ -48,17 +48,21 @@ jest.mock('@open-mercato/core/modules/inbox_ops/lib/rateLimiter', () => ({
 
 const WEBHOOK_SECRET = 'test-webhook-secret'
 
-function makeSignature(body: string, timestamp: string) {
-  const expected = createHmac('sha256', WEBHOOK_SECRET)
+function makeSignatureWith(secret: string, body: string, timestamp: string) {
+  const expected = createHmac('sha256', secret)
     .update(`${timestamp}.${body}`)
     .digest('hex')
   return `sha256=${expected}`
 }
 
-function makeSignedRequest(payload: Record<string, unknown>) {
+function makeSignature(body: string, timestamp: string) {
+  return makeSignatureWith(WEBHOOK_SECRET, body, timestamp)
+}
+
+function makeSignedRequestWith(secret: string, payload: Record<string, unknown>) {
   const body = JSON.stringify(payload)
   const timestamp = String(Math.floor(Date.now() / 1000))
-  const signature = makeSignature(body, timestamp)
+  const signature = makeSignatureWith(secret, body, timestamp)
 
   return new Request('http://localhost/api/inbox_ops/webhook/inbound', {
     method: 'POST',
@@ -70,6 +74,10 @@ function makeSignedRequest(payload: Record<string, unknown>) {
     },
     body,
   })
+}
+
+function makeSignedRequest(payload: Record<string, unknown>) {
+  return makeSignedRequestWith(WEBHOOK_SECRET, payload)
 }
 
 const validPayload = {
@@ -313,5 +321,73 @@ describe('POST /api/inbox_ops/webhook/inbound', () => {
     expect(response.status).toBe(429)
     expect(result.error).toContain('Rate limit')
     expect(response.headers.get('Retry-After')).toBe('30')
+  })
+
+  describe('per-tenant webhook secret binding (issue #2698)', () => {
+    const TENANT_SECRET = 'per-tenant-secret-abcdefabcdef'
+    const settingsWithSecret = { ...mockSettings, webhookSecret: TENANT_SECRET }
+
+    it('rejects the GLOBAL secret when the target inbox has its own secret', async () => {
+      // Settings (with a per-tenant secret) resolve fine, but the request was
+      // signed with the global secret — it must NOT be accepted for this inbox.
+      mockFindOneWithDecryption.mockResolvedValueOnce(settingsWithSecret)
+
+      const response = await POST(makeSignedRequestWith(WEBHOOK_SECRET, validPayload))
+      const result = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(result.error).toContain('Invalid signature')
+      expect(mockEm.create).not.toHaveBeenCalled()
+    })
+
+    it('accepts a signature made with the inbox-specific secret', async () => {
+      mockFindOneWithDecryption
+        .mockResolvedValueOnce(settingsWithSecret) // settings found
+        .mockResolvedValueOnce(null) // no dup by messageId
+        .mockResolvedValueOnce(null) // no dup by contentHash
+
+      const response = await POST(makeSignedRequestWith(TENANT_SECRET, validPayload))
+      const result = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(result.ok).toBe(true)
+      expect(mockEm.create).toHaveBeenCalled()
+    })
+
+    it('still accepts the global secret when the inbox has no per-tenant secret', async () => {
+      mockFindOneWithDecryption
+        .mockResolvedValueOnce(mockSettings) // no webhookSecret on this inbox
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+
+      const response = await POST(makeSignedRequestWith(WEBHOOK_SECRET, validPayload))
+      const result = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(result.ok).toBe(true)
+      expect(mockEm.create).toHaveBeenCalled()
+    })
+
+    it('returns silent 200 for an unknown inbox only when the global signature is valid', async () => {
+      mockFindOneWithDecryption.mockResolvedValueOnce(null) // no settings for this `to`
+
+      const response = await POST(makeSignedRequestWith(WEBHOOK_SECRET, validPayload))
+      const result = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(result.ok).toBe(true)
+      expect(mockEm.create).not.toHaveBeenCalled()
+    })
+
+    it('rejects a bogus-secret signature for an unknown inbox (no probe oracle)', async () => {
+      mockFindOneWithDecryption.mockResolvedValueOnce(null)
+
+      const response = await POST(makeSignedRequestWith('attacker-guessed-secret-xyz', validPayload))
+      const result = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(result.error).toContain('Invalid signature')
+      expect(mockEm.create).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/core/src/modules/inbox_ops/api/webhook/inbound.ts
+++ b/packages/core/src/modules/inbox_ops/api/webhook/inbound.ts
@@ -72,9 +72,10 @@ function verifyHmacAgainstAny(
   return false
 }
 
-// Stable, non-reversible identifier for the per-secret global rate-limit bucket.
-// Keying on a fingerprint of the presented secret (rather than the attacker-set
-// `to`) means rotating recipients no longer dilutes the limit.
+// Stable, non-reversible identifier for the pre-DB global rate-limit bucket.
+// Keying on the configured signing secret (rather than the attacker-set `to` or
+// the per-request signature) means the bucket is request-invariant for a given
+// secret, so rotating recipients or mutating the body cannot dilute the limit.
 function secretFingerprint(secret: string): string {
   return createHmac('sha256', 'inbox_ops:rate_limit:salt').update(secret).digest('hex').slice(0, 32)
 }
@@ -275,13 +276,15 @@ export async function POST(req: Request) {
     // bucket instead of waving the request through.
   }
 
-  // Global bucket keyed on the presented secret (custom) or the static Resend
-  // path, NOT on the attacker-controllable `to`. This caps total inbound volume
-  // for one secret even when the recipient is rotated to dilute the per-inbox
-  // bucket. Runs BEFORE the encrypted-column settings lookup so a flood cannot
-  // amplify DB work.
+  // Pre-DB global bucket keyed on the configured signing secret (custom) or the
+  // static Resend path, NOT on the attacker-controllable `to` and NOT on the
+  // per-request signature (which mutates with timestamp/body, so it would mint a
+  // fresh bucket every request and never throttle). The per-tenant secret lives
+  // behind the encrypted-column lookup, so the only secret available here without
+  // a DB hit is the global one — keying on it caps total inbound volume for the
+  // custom path and runs BEFORE the lookup so a flood cannot amplify DB work.
   const globalBucketKey = verified.data.kind === 'custom'
-    ? `webhook:secret:${secretFingerprint(verified.data.signature)}`
+    ? `webhook:secret:${secretFingerprint(process.env.INBOX_OPS_WEBHOOK_SECRET || '')}`
     : 'webhook:resend'
   const globalRateCheck = await checkRateLimit(cache, globalBucketKey)
   if (!globalRateCheck.allowed) {

--- a/packages/core/src/modules/inbox_ops/api/webhook/inbound.ts
+++ b/packages/core/src/modules/inbox_ops/api/webhook/inbound.ts
@@ -20,6 +20,13 @@ export const metadata = {
 const MAX_PAYLOAD_SIZE = 2 * 1024 * 1024 // 2MB
 const REPLAY_WINDOW_MS = 5 * 60 * 1000 // 5 minutes
 
+function isTimestampFresh(timestamp: string): boolean {
+  if (!timestamp) return false
+  const timestampMs = parseInt(timestamp, 10) * 1000
+  if (isNaN(timestampMs)) return false
+  return Math.abs(Date.now() - timestampMs) <= REPLAY_WINDOW_MS
+}
+
 function verifyHmacSignature(
   payload: string,
   signature: string,
@@ -28,9 +35,7 @@ function verifyHmacSignature(
 ): boolean {
   if (!signature || !timestamp || !secret) return false
 
-  const timestampMs = parseInt(timestamp, 10) * 1000
-  if (isNaN(timestampMs)) return false
-  if (Math.abs(Date.now() - timestampMs) > REPLAY_WINDOW_MS) return false
+  if (!isTimestampFresh(timestamp)) return false
 
   const expected = createHmac('sha256', secret)
     .update(`${timestamp}.${payload}`)
@@ -48,6 +53,30 @@ function verifyHmacSignature(
   } catch {
     return false
   }
+}
+
+// True when the signature verifies against ANY of the candidate secrets. Used
+// to bind the inbound signature to the resolved tenant: once the target inbox
+// declares its own per-tenant secret, the global INBOX_OPS_WEBHOOK_SECRET is no
+// longer accepted for that inbox, so a holder of the global key alone cannot
+// forge mail into a tenant that opted into a dedicated secret.
+function verifyHmacAgainstAny(
+  payload: string,
+  signature: string,
+  timestamp: string,
+  secrets: string[],
+): boolean {
+  for (const secret of secrets) {
+    if (secret && verifyHmacSignature(payload, signature, timestamp, secret)) return true
+  }
+  return false
+}
+
+// Stable, non-reversible identifier for the per-secret global rate-limit bucket.
+// Keying on a fingerprint of the presented secret (rather than the attacker-set
+// `to`) means rotating recipients no longer dilutes the limit.
+function secretFingerprint(secret: string): string {
+  return createHmac('sha256', 'inbox_ops:rate_limit:salt').update(secret).digest('hex').slice(0, 32)
 }
 
 function verifySvixSignature(
@@ -102,7 +131,7 @@ async function fetchResendEmail(emailId: string): Promise<{
 }
 
 type VerifiedPayload =
-  | { kind: 'custom'; payload: Record<string, unknown> }
+  | { kind: 'custom'; payload: Record<string, unknown>; signature: string; timestamp: string }
   | { kind: 'resend'; emailFields: Awaited<ReturnType<typeof fetchResendEmail>>; to: string[] }
 
 async function verifyAndParse(req: Request, rawBody: string): Promise<
@@ -119,7 +148,11 @@ async function verifyAndParse(req: Request, rawBody: string): Promise<
       return { ok: false, response: NextResponse.json({ error: 'Service unavailable' }, { status: 503 }) }
     }
     const timestamp = req.headers.get('x-webhook-timestamp') || ''
-    if (!verifyHmacSignature(rawBody, customSig, timestamp, webhookSecret)) {
+    // Cheap, secret-independent gate first: reject replayed/stale requests
+    // before parsing. The HMAC itself is verified later, against the secret
+    // bound to the resolved inbox (see the POST handler), so a holder of the
+    // global secret cannot inject into a tenant that owns its own secret.
+    if (!isTimestampFresh(timestamp)) {
       return { ok: false, response: NextResponse.json({ error: 'Invalid signature' }, { status: 400 }) }
     }
     let payload: Record<string, unknown>
@@ -128,7 +161,7 @@ async function verifyAndParse(req: Request, rawBody: string): Promise<
     } catch {
       return { ok: false, response: NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }) }
     }
-    return { ok: true, data: { kind: 'custom', payload } }
+    return { ok: true, data: { kind: 'custom', payload, signature: customSig, timestamp } }
   }
 
   if (svixId) {
@@ -238,23 +271,27 @@ export async function POST(req: Request) {
   try {
     cache = container.resolve('cache') as CacheStrategy
   } catch {
-    // Cache not available — proceed without rate limiting
+    // Cache not available — the limiter now fails closed with a process-local
+    // bucket instead of waving the request through.
   }
 
-  const rateCheck = await checkRateLimit(cache, `webhook:${toAddress}`)
-  if (!rateCheck.allowed) {
-    return NextResponse.json(
-      { error: 'Rate limit exceeded' },
-      {
-        status: 429,
-        headers: rateCheck.retryAfterSeconds
-          ? { 'Retry-After': String(rateCheck.retryAfterSeconds) }
-          : undefined,
-      },
-    )
+  // Global bucket keyed on the presented secret (custom) or the static Resend
+  // path, NOT on the attacker-controllable `to`. This caps total inbound volume
+  // for one secret even when the recipient is rotated to dilute the per-inbox
+  // bucket. Runs BEFORE the encrypted-column settings lookup so a flood cannot
+  // amplify DB work.
+  const globalBucketKey = verified.data.kind === 'custom'
+    ? `webhook:secret:${secretFingerprint(verified.data.signature)}`
+    : 'webhook:resend'
+  const globalRateCheck = await checkRateLimit(cache, globalBucketKey)
+  if (!globalRateCheck.allowed) {
+    return rateLimitedResponse(globalRateCheck.retryAfterSeconds)
   }
+
   const em = (container.resolve('em') as EntityManager).fork()
 
+  // No explicit scope: decryptEntitiesWithFallbackScope reads tenant/org off the
+  // resolved row, which is exactly what binds webhook_secret to its own tenant.
   const settings = await findOneWithDecryption(
     em,
     InboxSettings,
@@ -265,8 +302,39 @@ export async function POST(req: Request) {
     },
   )
 
+  // Final HMAC verification for the custom provider path: bind the signature to
+  // the resolved tenant. When the inbox declares its own secret, ONLY that
+  // secret is accepted; otherwise the global secret is accepted (back-compat).
+  // For an unknown `to` we still require the global secret so the endpoint never
+  // behaves as an unauthenticated probe oracle.
+  if (verified.data.kind === 'custom') {
+    const globalSecret = process.env.INBOX_OPS_WEBHOOK_SECRET || ''
+    const inboxSecret = settings?.webhookSecret || ''
+    const acceptableSecrets = inboxSecret ? [inboxSecret] : [globalSecret]
+    const signatureValid = verifyHmacAgainstAny(
+      rawBody,
+      verified.data.signature,
+      verified.data.timestamp,
+      acceptableSecrets,
+    )
+    if (!signatureValid) {
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 400 })
+    }
+  }
+
   if (!settings) {
     return NextResponse.json({ ok: true })
+  }
+
+  // Per-tenant bucket keyed on the RESOLVED tenant (not the raw `to`), so it
+  // cannot be diluted by alias addresses that map to the same inbox.
+  const tenantRateCheck = await checkRateLimit(
+    cache,
+    `webhook:tenant:${settings.tenantId}`,
+    settings.tenantId,
+  )
+  if (!tenantRateCheck.allowed) {
+    return rateLimitedResponse(tenantRateCheck.retryAfterSeconds)
   }
 
   const parsed = parseInboundEmail(emailInput)
@@ -326,6 +394,16 @@ export async function POST(req: Request) {
   }
 
   return NextResponse.json({ ok: true })
+}
+
+function rateLimitedResponse(retryAfterSeconds?: number): NextResponse {
+  return NextResponse.json(
+    { error: 'Rate limit exceeded' },
+    {
+      status: 429,
+      headers: retryAfterSeconds ? { 'Retry-After': String(retryAfterSeconds) } : undefined,
+    },
+  )
 }
 
 function extractToAddress(payload: Record<string, unknown>): string | null {

--- a/packages/core/src/modules/inbox_ops/data/entities.ts
+++ b/packages/core/src/modules/inbox_ops/data/entities.ts
@@ -82,6 +82,13 @@ export class InboxSettings {
   @Property({ name: 'inbox_address', type: 'text' })
   inboxAddress!: string
 
+  // Per-tenant inbound-webhook secret. When set, custom-provider webhook
+  // signatures for this inbox MUST verify against THIS secret (not the global
+  // INBOX_OPS_WEBHOOK_SECRET), binding the shared signing key to a single
+  // tenant and preventing cross-tenant injection by a holder of the global key.
+  @Property({ name: 'webhook_secret', type: 'text', nullable: true })
+  webhookSecret?: string | null
+
   @Property({ name: 'is_active', type: 'boolean', default: true })
   isActive: boolean = true
 

--- a/packages/core/src/modules/inbox_ops/data/validators.ts
+++ b/packages/core/src/modules/inbox_ops/data/validators.ts
@@ -254,6 +254,10 @@ export const translateProposalSchema = z.object({
 export const updateSettingsSchema = z.object({
   workingLanguage: z.enum(['en', 'de', 'es', 'pl']).optional(),
   isActive: z.boolean().optional(),
+  // Per-tenant inbound-webhook secret. Write-only: it is never returned by the
+  // settings GET. A non-empty value binds custom-provider webhook signatures for
+  // this inbox to this secret; null/empty clears it and reverts to the global key.
+  webhookSecret: z.string().trim().min(16).max(256).nullable().optional(),
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/modules/inbox_ops/encryption.ts
+++ b/packages/core/src/modules/inbox_ops/encryption.ts
@@ -8,6 +8,15 @@ import type { ModuleEncryptionMap } from '@open-mercato/shared/modules/encryptio
 // the inbound-webhook lookups, which is out of scope for this fix.
 export const defaultEncryptionMaps: ModuleEncryptionMap[] = [
   {
+    // `webhook_secret` is a tenant-scoped signing credential, never used in a
+    // WHERE/ILIKE lookup (it is loaded via the settings row, then compared with
+    // timingSafeEqual), so it is safe — and required — to encrypt at rest.
+    entityId: 'inbox_ops:inbox_settings',
+    fields: [
+      { field: 'webhook_secret' },
+    ],
+  },
+  {
     entityId: 'inbox_ops:inbox_email',
     fields: [
       { field: 'subject' },

--- a/packages/core/src/modules/inbox_ops/lib/__tests__/rateLimiter.test.ts
+++ b/packages/core/src/modules/inbox_ops/lib/__tests__/rateLimiter.test.ts
@@ -1,0 +1,81 @@
+/** @jest-environment node */
+
+import type { CacheStrategy } from '@open-mercato/cache'
+import { checkRateLimit, __resetRateLimiterFallback } from '../rateLimiter'
+
+const config = { maxPerMinute: 3, maxPerHour: 100, maxPerDay: 1000 }
+
+function makeMemoryCache(): CacheStrategy {
+  const store = new Map<string, unknown>()
+  return {
+    get: jest.fn(async (key: string) => (store.has(key) ? store.get(key) : null)),
+    set: jest.fn(async (key: string, value: unknown) => {
+      store.set(key, value)
+    }),
+    has: jest.fn(async (key: string) => store.has(key)),
+    delete: jest.fn(async (key: string) => store.delete(key)),
+    deleteByTags: jest.fn(async () => 0),
+    clear: jest.fn(async () => {
+      const size = store.size
+      store.clear()
+      return size
+    }),
+    keys: jest.fn(async () => Array.from(store.keys())),
+    stats: jest.fn(async () => ({ size: store.size, expired: 0 })),
+  } as unknown as CacheStrategy
+}
+
+describe('checkRateLimit', () => {
+  beforeEach(() => {
+    __resetRateLimiterFallback()
+  })
+
+  it('allows requests under the limit and blocks once exceeded (cache-backed)', async () => {
+    const cache = makeMemoryCache()
+    expect((await checkRateLimit(cache, 'k', undefined, config)).allowed).toBe(true)
+    expect((await checkRateLimit(cache, 'k', undefined, config)).allowed).toBe(true)
+    expect((await checkRateLimit(cache, 'k', undefined, config)).allowed).toBe(true)
+
+    const blocked = await checkRateLimit(cache, 'k', undefined, config)
+    expect(blocked.allowed).toBe(false)
+    expect(blocked.retryAfterSeconds).toBeGreaterThan(0)
+  })
+
+  it('fails CLOSED when no cache is available (process-local fallback)', async () => {
+    expect((await checkRateLimit(null, 'no-cache', undefined, config)).allowed).toBe(true)
+    expect((await checkRateLimit(null, 'no-cache', undefined, config)).allowed).toBe(true)
+    expect((await checkRateLimit(null, 'no-cache', undefined, config)).allowed).toBe(true)
+
+    // Without a cache the limiter must NOT wave everything through.
+    const blocked = await checkRateLimit(null, 'no-cache', undefined, config)
+    expect(blocked.allowed).toBe(false)
+  })
+
+  it('fails CLOSED when the cache throws (does not bypass throttling)', async () => {
+    const erroringCache = {
+      get: jest.fn(async () => {
+        throw new Error('cache down')
+      }),
+      set: jest.fn(async () => {
+        throw new Error('cache down')
+      }),
+    } as unknown as CacheStrategy
+
+    expect((await checkRateLimit(erroringCache, 'err', undefined, config)).allowed).toBe(true)
+    expect((await checkRateLimit(erroringCache, 'err', undefined, config)).allowed).toBe(true)
+    expect((await checkRateLimit(erroringCache, 'err', undefined, config)).allowed).toBe(true)
+
+    const blocked = await checkRateLimit(erroringCache, 'err', undefined, config)
+    expect(blocked.allowed).toBe(false)
+  })
+
+  it('isolates buckets per key so one key cannot dilute another', async () => {
+    const cache = makeMemoryCache()
+    for (let i = 0; i < config.maxPerMinute; i += 1) {
+      await checkRateLimit(cache, 'tenant-a', undefined, config)
+    }
+    // tenant-a is now exhausted, tenant-b should still be allowed.
+    expect((await checkRateLimit(cache, 'tenant-a', undefined, config)).allowed).toBe(false)
+    expect((await checkRateLimit(cache, 'tenant-b', undefined, config)).allowed).toBe(true)
+  })
+})

--- a/packages/core/src/modules/inbox_ops/lib/rateLimiter.ts
+++ b/packages/core/src/modules/inbox_ops/lib/rateLimiter.ts
@@ -16,50 +16,106 @@ const MINUTE_MS = 60 * 1000
 const HOUR_MS = 60 * 60 * 1000
 const DAY_MS = 24 * 60 * 60 * 1000
 
+export type RateLimitResult = { allowed: boolean; retryAfterSeconds?: number }
+
+// Process-local fallback used when the shared cache is unavailable or errors.
+// Keeping a bounded map here means the limiter fails CLOSED instead of open:
+// throttling still applies (per process) even if Redis/SQLite is down. The map
+// is pruned opportunistically so it cannot grow without bound.
+const fallbackBuckets = new Map<string, number[]>()
+const FALLBACK_MAX_KEYS = 10000
+
+function pruneFallbackBuckets(now: number): void {
+  if (fallbackBuckets.size <= FALLBACK_MAX_KEYS) return
+  for (const [key, timestamps] of fallbackBuckets) {
+    const recent = timestamps.filter((timestamp) => timestamp > now - DAY_MS)
+    if (recent.length === 0) {
+      fallbackBuckets.delete(key)
+    } else {
+      fallbackBuckets.set(key, recent)
+    }
+    if (fallbackBuckets.size <= FALLBACK_MAX_KEYS) break
+  }
+}
+
+function evaluate(
+  timestamps: number[],
+  now: number,
+  config: RateLimitConfig,
+): { result: RateLimitResult; nextTimestamps: number[] } {
+  const cutoffDay = now - DAY_MS
+  const recentTimestamps = timestamps.filter((timestamp) => timestamp > cutoffDay)
+
+  const countPerMinute = recentTimestamps.filter((timestamp) => timestamp > now - MINUTE_MS).length
+  if (countPerMinute >= config.maxPerMinute) {
+    const oldestInWindow = recentTimestamps.find((timestamp) => timestamp > now - MINUTE_MS)
+    const retryAfter = oldestInWindow ? Math.ceil((oldestInWindow + MINUTE_MS - now) / 1000) : 60
+    return { result: { allowed: false, retryAfterSeconds: retryAfter }, nextTimestamps: recentTimestamps }
+  }
+
+  const countPerHour = recentTimestamps.filter((timestamp) => timestamp > now - HOUR_MS).length
+  if (countPerHour >= config.maxPerHour) {
+    const oldestInWindow = recentTimestamps.find((timestamp) => timestamp > now - HOUR_MS)
+    const retryAfter = oldestInWindow ? Math.ceil((oldestInWindow + HOUR_MS - now) / 1000) : 3600
+    return { result: { allowed: false, retryAfterSeconds: retryAfter }, nextTimestamps: recentTimestamps }
+  }
+
+  if (recentTimestamps.length >= config.maxPerDay) {
+    const oldestInWindow = recentTimestamps[0]
+    const retryAfter = oldestInWindow ? Math.ceil((oldestInWindow + DAY_MS - now) / 1000) : 86400
+    return { result: { allowed: false, retryAfterSeconds: retryAfter }, nextTimestamps: recentTimestamps }
+  }
+
+  recentTimestamps.push(now)
+  return { result: { allowed: true }, nextTimestamps: recentTimestamps }
+}
+
+function checkFallback(key: string, now: number, config: RateLimitConfig): RateLimitResult {
+  const cacheKey = `inbox_ops:rate_limit:${key}`
+  const existing = fallbackBuckets.get(cacheKey) ?? []
+  const { result, nextTimestamps } = evaluate(existing, now, config)
+  fallbackBuckets.set(cacheKey, nextTimestamps)
+  pruneFallbackBuckets(now)
+  return result
+}
+
 export async function checkRateLimit(
   cache: CacheStrategy | null,
   key: string,
   tenantId?: string,
   config: RateLimitConfig = DEFAULT_CONFIG,
-): Promise<{ allowed: boolean; retryAfterSeconds?: number }> {
-  if (!cache) return { allowed: true }
-
+): Promise<RateLimitResult> {
   const now = Date.now()
+
+  // Fail CLOSED: when the shared cache is unavailable, fall back to a bounded
+  // process-local limiter instead of waving every request through.
+  if (!cache) {
+    return checkFallback(key, now, config)
+  }
+
   const cacheKey = `inbox_ops:rate_limit:${key}`
 
   try {
     const raw = await cache.get(cacheKey)
     const timestamps: number[] = Array.isArray(raw) ? (raw as number[]) : []
 
-    const cutoffDay = now - DAY_MS
-    const recentTimestamps = timestamps.filter((t) => t > cutoffDay)
-
-    const countPerMinute = recentTimestamps.filter((t) => t > now - MINUTE_MS).length
-    if (countPerMinute >= config.maxPerMinute) {
-      const oldestInWindow = recentTimestamps.find((t) => t > now - MINUTE_MS)
-      const retryAfter = oldestInWindow ? Math.ceil((oldestInWindow + MINUTE_MS - now) / 1000) : 60
-      return { allowed: false, retryAfterSeconds: retryAfter }
+    const { result, nextTimestamps } = evaluate(timestamps, now, config)
+    if (!result.allowed) {
+      return result
     }
 
-    const countPerHour = recentTimestamps.filter((t) => t > now - HOUR_MS).length
-    if (countPerHour >= config.maxPerHour) {
-      const oldestInWindow = recentTimestamps.find((t) => t > now - HOUR_MS)
-      const retryAfter = oldestInWindow ? Math.ceil((oldestInWindow + HOUR_MS - now) / 1000) : 3600
-      return { allowed: false, retryAfterSeconds: retryAfter }
-    }
-
-    if (recentTimestamps.length >= config.maxPerDay) {
-      const oldestInWindow = recentTimestamps[0]
-      const retryAfter = oldestInWindow ? Math.ceil((oldestInWindow + DAY_MS - now) / 1000) : 86400
-      return { allowed: false, retryAfterSeconds: retryAfter }
-    }
-
-    recentTimestamps.push(now)
     const tags = tenantId ? [`inbox_ops:rate_limit:${tenantId}`] : []
-    await cache.set(cacheKey, recentTimestamps, { ttl: DAY_MS, tags })
+    await cache.set(cacheKey, nextTimestamps, { ttl: DAY_MS, tags })
 
-    return { allowed: true }
+    return result
   } catch {
-    return { allowed: true }
+    // Cache error: do not fail open — apply the process-local limiter so a
+    // degraded cache cannot be used to bypass throttling.
+    return checkFallback(key, now, config)
   }
+}
+
+// Exposed for tests to reset process-local state between cases.
+export function __resetRateLimiterFallback(): void {
+  fallbackBuckets.clear()
 }

--- a/packages/core/src/modules/inbox_ops/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/inbox_ops/migrations/.snapshot-open-mercato.json
@@ -1651,6 +1651,22 @@
           "enumItems": [],
           "mappedType": "text"
         },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
         "is_active": {
           "name": "is_active",
           "type": "boolean",

--- a/packages/core/src/modules/inbox_ops/migrations/.snapshot-openmercato.json
+++ b/packages/core/src/modules/inbox_ops/migrations/.snapshot-openmercato.json
@@ -1035,6 +1035,22 @@
           "nullable": false,
           "mappedType": "text"
         },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
         "is_active": {
           "name": "is_active",
           "type": "boolean",

--- a/packages/core/src/modules/inbox_ops/migrations/Migration20260607205834.ts
+++ b/packages/core/src/modules/inbox_ops/migrations/Migration20260607205834.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260607205834 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "inbox_settings" add column "webhook_secret" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "inbox_settings" drop column "webhook_secret";`);
+  }
+
+}


### PR DESCRIPTION
Fixes #2698

## Problem
The inbound-email webhook (`POST /api/inbox_ops/webhook/inbound`) authenticated custom-provider requests with one tenant-agnostic secret and derived the target tenant from the attacker-controllable `to` address, while its rate limiter keyed on that same `to` value and failed open. Together these let anyone holding the single secret inject arbitrary email into any tenant's inbox with little throttling.

## Root Cause
- **Issue 1 (cross-tenant injection):** `INBOX_OPS_WEBHOOK_SECRET` was a single global secret with no per-tenant binding; after HMAC verification the handler resolved the tenant from the body's `to` address, so a holder of the global secret could forge mail into any tenant.
- **Issue 2 (throttle bypass):** `checkRateLimit` returned `{ allowed: true }` when the cache was missing or threw (fail-open), bucketed only on `toAddress` (rotating `to` diluted the limit), and ran before the settings lookup (DB amplification).

## What Changed
**Issue 1 — tenant binding**
- Added an optional per-tenant `webhook_secret` column to `InboxSettings` (encrypted at rest via `encryption.ts`; never returned by the settings GET — only a boolean `webhookSecretSet`).
- Reordered the webhook so the candidate inbox is resolved by `to` first, then the HMAC is verified against that inbox's own secret when set. The global secret is no longer accepted for an inbox that opted into a dedicated secret. Unknown recipients still require the global secret, so the endpoint never acts as an unauthenticated probe oracle.
- Settings `PATCH` can set/clear the per-tenant secret (write-only; min length enforced).

**Issue 2 — rate limiter**
- Fails **closed**: falls back to a bounded process-local limiter when the cache is missing or errors, instead of waving every request through.
- Added a global bucket keyed on a non-reversible fingerprint of the presented secret (not the rotatable `to`), checked **before** the encrypted-column lookup so a flood can't amplify DB work.
- The per-inbox bucket is now keyed on the resolved `tenantId`, so alias addresses mapping to one inbox can't dilute it.

## Tests
- `api/webhook/__tests__/inbound.test.ts`: per-tenant secret binding — global secret rejected for an inbox with its own secret, inbox secret accepted, back-compat global path, and probe-oracle rejection for unknown inboxes. (Verified red against the pre-fix handler: the binding/oracle cases fail; green after the fix.)
- `lib/__tests__/rateLimiter.test.ts` (new): fails closed with no cache and on cache error; per-key isolation.
- `api/settings/__tests__/optimistic-lock.test.ts`: PATCH sets/clears the secret and never echoes the value.
- `__tests__/encryption.test.ts`: updated to expect the encrypted `webhook_secret` while keeping `inbox_address` plaintext.
- Full `inbox_ops` suite (328) green; `yarn typecheck`, `yarn i18n:check-sync`, and the optimistic-lock guard suites pass. (`yarn lint` fails repo-wide on a pre-existing eslint 10 / eslint-plugin-react incompatibility in `next.config.ts`, unrelated to this change.)

## Backward Compatibility
- Additive nullable DB column (`webhook_secret`) with migration + snapshot; additive optional validator field; additive `webhookSecretSet` response field. No API fields removed, no event/DI/ACL/import-path changes. Default behavior (no per-tenant secret configured) is unchanged — the global secret still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)