### PR TITLE
security(auth): remove raw (unhashed) token fallback lookups (#2691)

### DIFF
--- a/packages/core/src/modules/auth/services/__tests__/authService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/authService.test.ts
@@ -51,7 +51,7 @@ describe('AuthService', () => {
     expect(row.token).not.toBe(result.token)
   })
 
-  it('deleteSessionByToken tries hashed token first then falls back to raw', async () => {
+  it('deleteSessionByToken deletes only by the hashed token', async () => {
     const { em } = makeEm()
     em.nativeDelete.mockResolvedValueOnce(1)
     const svc = new AuthService(em)
@@ -60,38 +60,47 @@ describe('AuthService', () => {
     expect((em.nativeDelete as jest.Mock).mock.calls[0][1]).toEqual({ token: hashAuthToken('raw-token-value') })
   })
 
-  it('deleteSessionByToken falls back to raw token when hashed lookup deletes nothing', async () => {
+  // -------------------------------------------------------------------------
+  // Regression: no raw (unhashed) token fallback at rest (issue #2691)
+  // The stored token column value must never be accepted as a usable credential.
+  // -------------------------------------------------------------------------
+
+  it('deleteSessionByToken never falls back to a raw-token delete when the hashed lookup misses', async () => {
     const { em } = makeEm()
-    em.nativeDelete.mockResolvedValueOnce(0).mockResolvedValueOnce(1)
+    em.nativeDelete.mockResolvedValueOnce(0)
     const svc = new AuthService(em)
     await svc.deleteSessionByToken('raw-token-value')
-    expect(em.nativeDelete).toHaveBeenCalledTimes(2)
-    expect((em.nativeDelete as jest.Mock).mock.calls[0][1]).toEqual({ token: hashAuthToken('raw-token-value') })
-    expect((em.nativeDelete as jest.Mock).mock.calls[1][1]).toEqual({ token: 'raw-token-value' })
+    expect(em.nativeDelete).toHaveBeenCalledTimes(1)
+    const rawCall = (em.nativeDelete as jest.Mock).mock.calls.find(
+      (call) => call[1] && call[1].token === 'raw-token-value',
+    )
+    expect(rawCall).toBeUndefined()
   })
 
-  it('refreshFromSessionToken looks up by hashed token first', async () => {
+  it('refreshFromSessionToken looks up by the hashed token only', async () => {
     const { em } = makeEm()
-    em.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+    em.findOne.mockResolvedValueOnce(null)
     const svc = new AuthService(em)
     await svc.refreshFromSessionToken('raw-token-value')
-    const findCall = (em.findOne as jest.Mock).mock.calls[0]
-    expect(findCall[1]).toEqual({ token: hashAuthToken('raw-token-value') })
+    expect(em.findOne).toHaveBeenCalledTimes(1)
+    expect((em.findOne as jest.Mock).mock.calls[0][1]).toEqual({ token: hashAuthToken('raw-token-value') })
   })
 
-  it('refreshFromSessionToken falls back to raw token for legacy sessions', async () => {
+  it('refreshFromSessionToken rejects a raw (legacy plaintext) session token', async () => {
     const { em } = makeEm()
     const legacySession = { token: 'raw-token-value', expiresAt: new Date(Date.now() + 60000), user: { id: 'u1' } }
-    const user = { id: 'u1', tenantId: 't1', organizationId: 'o1' }
-    em.findOne
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(legacySession)
-      .mockResolvedValueOnce(user)
-    em.find.mockResolvedValueOnce([])
+    em.findOne.mockImplementation(async (_cls: any, filter: any) =>
+      filter && filter.token === 'raw-token-value' ? legacySession : null,
+    )
     const svc = new AuthService(em)
     const result = await svc.refreshFromSessionToken('raw-token-value')
-    expect(result).not.toBeNull()
-    expect((em.findOne as jest.Mock).mock.calls[1][1]).toEqual({ token: 'raw-token-value' })
+    expect(result).toBeNull()
+    expect(em.findOne).toHaveBeenCalledTimes(1)
+    expect((em.findOne as jest.Mock).mock.calls[0][1]).toEqual({ token: hashAuthToken('raw-token-value') })
+    const rawCall = (em.findOne as jest.Mock).mock.calls.find(
+      (call) => call[1] && call[1].token === 'raw-token-value',
+    )
+    expect(rawCall).toBeUndefined()
   })
 
   it('requestPasswordReset persists hashed token and returns raw token', async () => {
@@ -110,26 +119,33 @@ describe('AuthService', () => {
     expect(row.token).not.toBe(rawToken)
   })
 
-  it('confirmPasswordReset looks up by hashed token first', async () => {
+  it('confirmPasswordReset looks up by the hashed token only', async () => {
     const { em } = makeEm()
-    em.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+    em.findOne.mockResolvedValueOnce(null)
     const svc = new AuthService(em)
     const result = await svc.confirmPasswordReset('raw-token-value', 'NewPass1!')
     expect(result).toBeNull()
-    const findCall = (em.findOne as jest.Mock).mock.calls[0]
-    expect(findCall[1]).toEqual({ token: hashAuthToken('raw-token-value') })
+    expect(em.findOne).toHaveBeenCalledTimes(1)
+    expect((em.findOne as jest.Mock).mock.calls[0][1]).toEqual({ token: hashAuthToken('raw-token-value') })
   })
 
-  it('confirmPasswordReset falls back to raw token for legacy resets', async () => {
+  it('confirmPasswordReset rejects a raw (legacy plaintext) reset token', async () => {
     const { em } = makeEm()
-    em.findOne
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({ token: 'raw-token-value', expiresAt: new Date(Date.now() + 60000), usedAt: null, user: { id: 'u1' } })
-      .mockResolvedValueOnce(null)
+    em.findOne.mockImplementation(async (_cls: any, filter: any) =>
+      filter && filter.token === 'raw-token-value'
+        ? { token: 'raw-token-value', expiresAt: new Date(Date.now() + 60000), usedAt: null, user: { id: 'u1' } }
+        : null,
+    )
     const svc = new AuthService(em)
     const result = await svc.confirmPasswordReset('raw-token-value', 'NewPass1!')
     expect(result).toBeNull()
-    expect((em.findOne as jest.Mock).mock.calls[1][1]).toEqual({ token: 'raw-token-value' })
+    expect(em.findOne).toHaveBeenCalledTimes(1)
+    expect((em.findOne as jest.Mock).mock.calls[0][1]).toEqual({ token: hashAuthToken('raw-token-value') })
+    const rawCall = (em.findOne as jest.Mock).mock.calls.find(
+      (call) => call[1] && call[1].token === 'raw-token-value',
+    )
+    expect(rawCall).toBeUndefined()
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
   })
 
   it('deleteSessionById invokes nativeDelete with the id filter', async () => {

--- a/packages/core/src/modules/auth/services/authService.ts
+++ b/packages/core/src/modules/auth/services/authService.ts
@@ -84,10 +84,7 @@ export class AuthService {
 
   async deleteSessionByToken(token: string) {
     const hashedToken = hashAuthToken(token)
-    const deleted = await this.em.nativeDelete(Session, { token: hashedToken })
-    if (!deleted) {
-      await this.em.nativeDelete(Session, { token })
-    }
+    await this.em.nativeDelete(Session, { token: hashedToken })
   }
 
   async deleteSessionById(sessionId: string) {
@@ -108,10 +105,7 @@ export class AuthService {
   async refreshFromSessionToken(token: string) {
     const now = new Date()
     const hashedToken = hashAuthToken(token)
-    let sess = await this.em.findOne(Session, { token: hashedToken })
-    if (!sess) {
-      sess = await this.em.findOne(Session, { token })
-    }
+    const sess = await this.em.findOne(Session, { token: hashedToken })
     if (!sess || sess.expiresAt <= now) return null
     const user = await findOneWithDecryption(this.em, User, { id: sess.user.id, deletedAt: null })
     if (!user) return null
@@ -133,10 +127,7 @@ export class AuthService {
   async confirmPasswordReset(token: string, newPassword: string): Promise<User | null> {
     const now = new Date()
     const hashedToken = hashAuthToken(token)
-    let row = await this.em.findOne(PasswordReset, { token: hashedToken })
-    if (!row) {
-      row = await this.em.findOne(PasswordReset, { token })
-    }
+    const row = await this.em.findOne(PasswordReset, { token: hashedToken })
     if (!row || (row.usedAt && row.usedAt <= now) || row.expiresAt <= now) return null
 
     // Atomic compare-and-set: only mark used if still unused — prevents token replay under concurrency


### PR DESCRIPTION
Fixes #2691

## Problem
Session and password-reset tokens are stored HMAC-SHA-256 hashed at rest, but three `AuthService` lookup paths fell back to querying with the RAW token when the hashed lookup missed. This made the on-disk `sessions.token` / `password_resets.token` column value itself a usable credential, defeating the point of hashing tokens at rest.

## Root Cause
`deleteSessionByToken`, `refreshFromSessionToken`, and `confirmPasswordReset` each retried with `{ token }` (the plaintext value) after the `{ token: hashedToken }` lookup returned nothing. The fallback existed purely as a transitional bridge for legacy plaintext rows, but no backfill/migration ever removed those rows, so the bridge remained a live attack surface: anyone who can read the token column (DB backup leak, replica snapshot, accidental log/dump, SQL injection in another module) could present the stored value directly to refresh a session or confirm a password reset.

## What Changed
- `packages/core/src/modules/auth/services/authService.ts`
  - `deleteSessionByToken` — deletes only by the hashed token; removed the raw-token retry.
  - `refreshFromSessionToken` — looks up the session only by the hashed token; removed the raw-token retry.
  - `confirmPasswordReset` — looks up the reset row only by the hashed token; removed the raw-token retry.

Tokens are still written hashed (`createSession`, `requestPasswordReset`); only the insecure read/delete fallbacks are removed. Public method signatures and return types are unchanged.

## Tests
- Updated/added regression tests in `authService.test.ts`:
  - `deleteSessionByToken` never issues a raw-token delete when the hashed lookup misses
  - `refreshFromSessionToken` looks up by the hashed token only and rejects a raw (legacy plaintext) session token
  - `confirmPasswordReset` looks up by the hashed token only and rejects a raw (legacy plaintext) reset token
- Verified red-before-fix: the five new assertions fail against the pre-fix code and pass after.
- `yarn workspace @open-mercato/core test src/modules/auth` → 337 passed
- `yarn build:packages`, `yarn generate`, `yarn typecheck` → all green

## Backward Compatibility
- No contract surface changes: method signatures, return types, API routes, event IDs, DI names, and ACL features are untouched.
- Behavioral note: any remaining legacy rows holding a plaintext token can no longer be resolved. Hashed tokens (issued since hashing was introduced) are unaffected; legacy sessions/resets simply require re-login / re-request, which is the intended security posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)