### PR TITLE
security(auth): refuse hardcoded consent integrity key in production (#2690)

### DIFF
--- a/packages/core/src/modules/auth/lib/__tests__/consentIntegrity.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/consentIntegrity.test.ts
@@ -1,0 +1,108 @@
+type ConsentIntegrityModule = typeof import('@open-mercato/core/modules/auth/lib/consentIntegrity')
+
+const sampleInput = {
+  userId: '11111111-1111-4111-8111-111111111111',
+  consentType: 'marketing',
+  isGranted: true,
+  grantedAt: new Date('2026-01-01T00:00:00.000Z'),
+  withdrawnAt: null,
+  ipAddress: '203.0.113.7',
+  source: 'portal',
+}
+
+function loadModule(): ConsentIntegrityModule {
+  let mod: ConsentIntegrityModule | undefined
+  jest.isolateModules(() => {
+    mod = require('@open-mercato/core/modules/auth/lib/consentIntegrity')
+  })
+  if (!mod) throw new Error('failed to load consentIntegrity module')
+  return mod
+}
+
+describe('consentIntegrity secret resolution', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    delete process.env.CONSENT_INTEGRITY_SECRET
+    delete process.env.NEXTAUTH_SECRET
+    delete process.env.NODE_ENV
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    jest.restoreAllMocks()
+  })
+
+  it('refuses to compute a hash in production when no secret is configured', () => {
+    process.env.NODE_ENV = 'production'
+    const { computeConsentIntegrityHash } = loadModule()
+
+    expect(() => computeConsentIntegrityHash(sampleInput)).toThrow(/Refusing to compute or verify/)
+  })
+
+  it('refuses to verify a hash in production when no secret is configured', () => {
+    process.env.NODE_ENV = 'production'
+    const { verifyConsentIntegrityHash } = loadModule()
+
+    expect(() => verifyConsentIntegrityHash(sampleInput, 'deadbeef')).toThrow(/Refusing to compute or verify/)
+  })
+
+  it('does not fall back to a hardcoded literal key in production', () => {
+    process.env.NODE_ENV = 'production'
+    const { computeConsentIntegrityHash } = loadModule()
+
+    expect(() => computeConsentIntegrityHash(sampleInput)).toThrow()
+  })
+
+  it('produces a different hash with a real secret than with the dev-only default', () => {
+    process.env.NODE_ENV = 'development'
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    process.env.CONSENT_INTEGRITY_SECRET = 'a-real-secret'
+    const { computeConsentIntegrityHash: computeWithSecret } = loadModule()
+    const withSecret = computeWithSecret(sampleInput)
+
+    delete process.env.CONSENT_INTEGRITY_SECRET
+    const { computeConsentIntegrityHash: computeDev } = loadModule()
+    const devHash = computeDev(sampleInput)
+
+    expect(withSecret).not.toEqual(devHash)
+  })
+
+  it('uses the configured CONSENT_INTEGRITY_SECRET in production without throwing', () => {
+    process.env.NODE_ENV = 'production'
+    process.env.CONSENT_INTEGRITY_SECRET = 'prod-secret'
+    const { computeConsentIntegrityHash } = loadModule()
+
+    expect(() => computeConsentIntegrityHash(sampleInput)).not.toThrow()
+  })
+
+  it('falls back to NEXTAUTH_SECRET in production without throwing', () => {
+    process.env.NODE_ENV = 'production'
+    process.env.NEXTAUTH_SECRET = 'nextauth-prod-secret'
+    const { computeConsentIntegrityHash } = loadModule()
+
+    expect(() => computeConsentIntegrityHash(sampleInput)).not.toThrow()
+  })
+
+  it('emits the missing-secret warning once outside production and still computes a hash', () => {
+    process.env.NODE_ENV = 'development'
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const { computeConsentIntegrityHash } = loadModule()
+
+    const first = computeConsentIntegrityHash(sampleInput)
+    const second = computeConsentIntegrityHash(sampleInput)
+
+    expect(first).toEqual(second)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('round-trips compute and verify when a secret is configured', () => {
+    process.env.CONSENT_INTEGRITY_SECRET = 'round-trip-secret'
+    const { computeConsentIntegrityHash, verifyConsentIntegrityHash } = loadModule()
+
+    const hash = computeConsentIntegrityHash(sampleInput)
+    expect(verifyConsentIntegrityHash(sampleInput, hash)).toBe(true)
+    expect(verifyConsentIntegrityHash({ ...sampleInput, isGranted: false }, hash)).toBe(false)
+  })
+})

--- a/packages/core/src/modules/auth/lib/consentIntegrity.ts
+++ b/packages/core/src/modules/auth/lib/consentIntegrity.ts
@@ -10,12 +10,28 @@ type ConsentHashInput = {
   source: string | null | undefined
 }
 
+const DEV_ONLY_SECRET = 'om-consent-integrity-dev-only-secret'
+let missingSecretWarned = false
+
 function getSecret(): string {
   const secret = process.env.CONSENT_INTEGRITY_SECRET || process.env.NEXTAUTH_SECRET
   if (!secret) {
-    console.warn('[consentIntegrity] CONSENT_INTEGRITY_SECRET and NEXTAUTH_SECRET are not set — integrity hashes are insecure')
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        '[consentIntegrity] No CONSENT_INTEGRITY_SECRET/NEXTAUTH_SECRET set. ' +
+        'Refusing to compute or verify consent integrity hashes in production without a real secret.',
+      )
+    }
+    if (!missingSecretWarned) {
+      missingSecretWarned = true
+      console.warn(
+        '[consentIntegrity] No CONSENT_INTEGRITY_SECRET/NEXTAUTH_SECRET set — ' +
+        'using insecure dev-only default. Set a secret before deploying to production.',
+      )
+    }
+    return DEV_ONLY_SECRET
   }
-  return secret || 'om-consent-integrity-default-key'
+  return secret
 }
 
 function normalizeDate(date: Date | string | null | undefined): string {


### PR DESCRIPTION
Fixes #2690

## Problem
- `consentIntegrity.ts`'s `getSecret()` returned a publicly known literal key (`om-consent-integrity-default-key`) whenever both `CONSENT_INTEGRITY_SECRET` and `NEXTAUTH_SECRET` were unset, emitting only a `console.warn`. Unlike the sibling `tokenHash.ts`, it never refused to run in production, so a misconfigured deployment silently computed and verified every `user_consents` integrity hash with an attacker-known key — collapsing the tamper-evidence guarantee surfaced as `integrityValid` on `/api/auth/users/consents`.

## Root Cause
- `getSecret()` used `return secret || 'om-consent-integrity-default-key'` with no production guard, so a missing secret degraded silently instead of failing closed.

## What Changed
- `packages/core/src/modules/auth/lib/consentIntegrity.ts`: when no secret is configured, `getSecret()` now **throws in production** (refusing to compute or verify consent integrity hashes), and only returns a clearly-labeled dev-only default outside production with a one-time `console.warn`. This mirrors the existing `tokenHash.ts` pattern.
- Removed the hardcoded default key; the dev-only fallback is renamed to `om-consent-integrity-dev-only-secret` and is unreachable in production.

## Tests
- Added `packages/core/src/modules/auth/lib/__tests__/consentIntegrity.test.ts` (8 cases): production refusal for both compute and verify, no hardcoded-key fallback, real secret / `NEXTAUTH_SECRET` fallback work in production, warn-emitted-once in dev, real-secret vs dev-default hashes differ, and compute/verify round-trip.
- Verified red-before-fix: 4 of the 8 cases fail against the pre-fix code, all 8 pass after.
- Existing `users-consents.route.test.ts` still passes.
- `yarn workspace @open-mercato/core typecheck` passes clean.

## Backward Compatibility
- No contract surface changes (no API responses, types, import paths, event/DI/ACL IDs altered). The only behavioral change is fail-closed startup in production when no consent secret is configured — the intended security hardening. Deployments that relied on the silent insecure default must now set `CONSENT_INTEGRITY_SECRET` or `NEXTAUTH_SECRET`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)