### PR TITLE
security(customer_accounts): rate-limit and dedupe customer invitation endpoints (#2692)

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/__tests__/users-invite-rate-limit.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/__tests__/users-invite-rate-limit.test.ts
@@ -1,0 +1,133 @@
+/** @jest-environment node */
+
+import { NextResponse } from 'next/server'
+import type { RateLimitConfig } from '@open-mercato/shared/lib/ratelimit/types'
+
+const inviteIpConfig: RateLimitConfig = { points: 20, duration: 60, blockDuration: 120, keyPrefix: 'customer-invite-ip' }
+const inviteCompoundConfig: RateLimitConfig = { points: 5, duration: 60, blockDuration: 120, keyPrefix: 'customer-invite' }
+
+const mockCheckAuthRateLimit = jest.fn()
+const mockCreateInvitation = jest.fn()
+const mockUserHasAllFeatures = jest.fn()
+const mockGetAuthFromRequest = jest.fn()
+const mockGetCustomerAuthFromRequest = jest.fn()
+const mockRequireCustomerFeature = jest.fn()
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/rateLimiter', () => ({
+  checkAuthRateLimit: (...args: unknown[]) => mockCheckAuthRateLimit(...args),
+  customerInviteIpRateLimitConfig: inviteIpConfig,
+  customerInviteRateLimitConfig: inviteCompoundConfig,
+}))
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'rbacService') return { userHasAllFeatures: mockUserHasAllFeatures }
+    if (token === 'customerRbacService') return {}
+    if (token === 'customerInvitationService') return { createInvitation: mockCreateInvitation }
+    if (token === 'em') return { find: jest.fn() }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuth', () => ({
+  getCustomerAuthFromRequest: (...args: unknown[]) => mockGetCustomerAuthFromRequest(...args),
+  requireCustomerFeature: (...args: unknown[]) => mockRequireCustomerFeature(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(async () => []),
+  findOneWithDecryption: jest.fn(async () => null),
+}))
+
+function makeInviteRequest(path: string, email: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, roleIds: ['11111111-1111-4111-8111-111111111111'] }),
+  })
+}
+
+function rateLimitResponse(): NextResponse {
+  return NextResponse.json({ error: 'Too many requests' }, { status: 429 })
+}
+
+const tenantId = '22222222-2222-4222-8222-222222222222'
+const organizationId = '33333333-3333-4333-8333-333333333333'
+
+describe('customer invitation endpoints — rate limiting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCheckAuthRateLimit.mockResolvedValue({ error: null, compoundKey: null })
+    mockUserHasAllFeatures.mockResolvedValue(true)
+    mockRequireCustomerFeature.mockResolvedValue(undefined)
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'staff-1', tenantId, orgId: organizationId })
+    mockGetCustomerAuthFromRequest.mockResolvedValue({
+      sub: 'portal-1',
+      tenantId,
+      orgId: organizationId,
+      customerEntityId: '44444444-4444-4444-8444-444444444444',
+    })
+    mockCreateInvitation.mockResolvedValue({
+      invitation: { id: 'inv-1', email: 'buyer@example.com', expiresAt: new Date().toISOString() },
+      rawToken: 'raw',
+    })
+  })
+
+  it('admin route checks the invite rate limit with the normalized invitee email', async () => {
+    const { POST } = await import('../admin/users-invite')
+    const req = makeInviteRequest('/api/customer_accounts/admin/users-invite', '  Buyer@Example.COM  ')
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: inviteIpConfig,
+      compoundConfig: inviteCompoundConfig,
+      compoundIdentifier: 'buyer@example.com',
+    })
+  })
+
+  it('admin route returns the 429 and never reaches the invitation service when rate limited', async () => {
+    mockCheckAuthRateLimit.mockResolvedValue({ error: rateLimitResponse(), compoundKey: null })
+    const { POST } = await import('../admin/users-invite')
+    const req = makeInviteRequest('/api/customer_accounts/admin/users-invite', 'buyer@example.com')
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(429)
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
+  })
+
+  it('portal route checks the invite rate limit with the normalized invitee email', async () => {
+    const { POST } = await import('../portal/users-invite')
+    const req = makeInviteRequest('/api/customer_accounts/portal/users-invite', '  Buyer@Example.COM  ')
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: inviteIpConfig,
+      compoundConfig: inviteCompoundConfig,
+      compoundIdentifier: 'buyer@example.com',
+    })
+  })
+
+  it('portal route returns the 429 and never reaches the invitation service when rate limited', async () => {
+    mockCheckAuthRateLimit.mockResolvedValue({ error: rateLimitResponse(), compoundKey: null })
+    const { POST } = await import('../portal/users-invite')
+    const req = makeInviteRequest('/api/customer_accounts/portal/users-invite', 'buyer@example.com')
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(429)
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/admin/users-invite.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users-invite.ts
@@ -6,6 +6,13 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { CustomerInvitationService } from '@open-mercato/core/modules/customer_accounts/services/customerInvitationService'
 import { inviteUserSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
+import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
+import {
+  checkAuthRateLimit,
+  customerInviteRateLimitConfig,
+  customerInviteIpRateLimitConfig,
+} from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
+import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 
 export const metadata = {}
 
@@ -14,6 +21,15 @@ export async function POST(req: Request) {
   if (!auth) {
     return NextResponse.json({ ok: false, error: 'Authentication required' }, { status: 401 })
   }
+
+  const rateLimitEmail = await readNormalizedEmailFromJsonRequest(req)
+  const { error: rateLimitError } = await checkAuthRateLimit({
+    req,
+    ipConfig: customerInviteIpRateLimitConfig,
+    compoundConfig: customerInviteRateLimitConfig,
+    compoundIdentifier: rateLimitEmail,
+  })
+  if (rateLimitError) return rateLimitError
 
   const container = await createRequestContainer()
   const rbacService = container.resolve('rbacService') as RbacService
@@ -77,6 +93,7 @@ const methodDoc: OpenApiMethodDoc = {
     { status: 400, description: 'Validation failed', schema: errorSchema },
     { status: 401, description: 'Not authenticated', schema: errorSchema },
     { status: 403, description: 'Insufficient permissions', schema: errorSchema },
+    { status: 429, description: 'Too many invitation requests', schema: rateLimitErrorSchema },
   ],
 }
 

--- a/packages/core/src/modules/customer_accounts/api/portal/users-invite.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/users-invite.ts
@@ -8,6 +8,13 @@ import { CustomerRbacService } from '@open-mercato/core/modules/customer_account
 import { CustomerRole } from '@open-mercato/core/modules/customer_accounts/data/entities'
 import { inviteUserSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
+import {
+  checkAuthRateLimit,
+  customerInviteRateLimitConfig,
+  customerInviteIpRateLimitConfig,
+} from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
+import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 
 export const metadata: { path?: string; requireAuth?: boolean } = { requireAuth: false }
 
@@ -16,6 +23,15 @@ export async function POST(req: Request) {
   if (!auth) {
     return NextResponse.json({ ok: false, error: 'Authentication required' }, { status: 401 })
   }
+
+  const rateLimitEmail = await readNormalizedEmailFromJsonRequest(req)
+  const { error: rateLimitError } = await checkAuthRateLimit({
+    req,
+    ipConfig: customerInviteIpRateLimitConfig,
+    compoundConfig: customerInviteRateLimitConfig,
+    compoundIdentifier: rateLimitEmail,
+  })
+  if (rateLimitError) return rateLimitError
 
   const container = await createRequestContainer()
   const customerRbacService = container.resolve('customerRbacService') as CustomerRbacService
@@ -109,6 +125,7 @@ const methodDoc: OpenApiMethodDoc = {
     { status: 400, description: 'Validation failed', schema: errorSchema },
     { status: 401, description: 'Not authenticated', schema: errorSchema },
     { status: 403, description: 'Insufficient permissions or non-assignable role', schema: errorSchema },
+    { status: 429, description: 'Too many invitation requests', schema: rateLimitErrorSchema },
   ],
 }
 

--- a/packages/core/src/modules/customer_accounts/lib/rateLimiter.ts
+++ b/packages/core/src/modules/customer_accounts/lib/rateLimiter.ts
@@ -33,6 +33,20 @@ export const customerMagicLinkIpRateLimitConfig = readEndpointRateLimitConfig('C
   points: 10, duration: 60, blockDuration: 120, keyPrefix: 'customer-magic-link-ip',
 })
 
+// Staff- and portal-facing customer invitation endpoints
+// (`/api/customer_accounts/admin/users-invite`, `/api/customer_accounts/portal/users-invite`).
+// Both are authenticated, but a single authorized actor must not be able to mint
+// unbounded invitation rows/tokens. The compound layer caps repeated invitations
+// targeting the same recipient address from the same client, while the IP layer
+// caps overall invitation throughput per client.
+export const customerInviteRateLimitConfig = readEndpointRateLimitConfig('CUSTOMER_INVITE', {
+  points: 5, duration: 60, blockDuration: 120, keyPrefix: 'customer-invite',
+})
+
+export const customerInviteIpRateLimitConfig = readEndpointRateLimitConfig('CUSTOMER_INVITE_IP', {
+  points: 20, duration: 60, blockDuration: 120, keyPrefix: 'customer-invite-ip',
+})
+
 // Bulk custom-domain warm-up endpoint (`/api/customer_accounts/domain-resolve/all`).
 // Single shared `DOMAIN_RESOLVE_SECRET` gates a payload that lists every active
 // custom-domain mapping in the deployment, so we cap requests per IP to make

--- a/packages/core/src/modules/customer_accounts/services/__tests__/customerInvitationService.test.ts
+++ b/packages/core/src/modules/customer_accounts/services/__tests__/customerInvitationService.test.ts
@@ -114,3 +114,107 @@ describe('CustomerInvitationService.acceptInvitation — role lookup batching', 
     expect(roleFinds).toHaveLength(0)
   })
 })
+
+describe('CustomerInvitationService.createInvitation — pending-invitation dedupe', () => {
+  const roleIds = [
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+  ]
+  const tenantId = '11111111-1111-4111-8111-111111111111'
+  const organizationId = '22222222-2222-4222-8222-222222222222'
+
+  let mockEm: jest.Mocked<Pick<EntityManager, 'find' | 'findOne' | 'create' | 'persist' | 'flush'>>
+  let service: CustomerInvitationService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      create: jest.fn((_: unknown, data: unknown) => data as any),
+      persist: jest.fn(() => mockEm),
+      flush: jest.fn(async () => undefined),
+    } as unknown as jest.Mocked<Pick<EntityManager, 'find' | 'findOne' | 'create' | 'persist' | 'flush'>>
+    service = new CustomerInvitationService(mockEm as unknown as EntityManager)
+  })
+
+  it('reuses an existing pending invitation instead of inserting a new row', async () => {
+    const existing = {
+      id: 'inv-existing',
+      email: 'old@example.com',
+      tenantId,
+      organizationId,
+      emailHash: 'email-hash',
+      token: 'old-hashed-token',
+      customerEntityId: null,
+      roleIdsJson: ['old-role'],
+      invitedByUserId: null,
+      invitedByCustomerUserId: null,
+      displayName: 'Old Name',
+      expiresAt: new Date(Date.now() + 60_000),
+      acceptedAt: null,
+      cancelledAt: null,
+    } as unknown as CustomerUserInvitation
+
+    ;(mockEm.findOne as jest.Mock).mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerUserInvitation) return existing
+      return null
+    })
+
+    const beforeExpiresAt = existing.expiresAt.getTime()
+    const result = await service.createInvitation(
+      ' New@Example.COM ',
+      { tenantId, organizationId },
+      { roleIds, invitedByUserId: 'inviter-1', displayName: 'Refreshed Name' },
+    )
+
+    expect(mockEm.create).not.toHaveBeenCalled()
+    expect(result.invitation).toBe(existing)
+    expect(result.rawToken).toBe('raw-token')
+    expect(existing.email).toBe('new@example.com')
+    expect(existing.token).toBe('hashed-token')
+    expect(existing.roleIdsJson).toEqual(roleIds)
+    expect(existing.invitedByUserId).toBe('inviter-1')
+    expect(existing.displayName).toBe('Refreshed Name')
+    expect(existing.expiresAt.getTime()).toBeGreaterThan(beforeExpiresAt)
+    expect(mockEm.flush).toHaveBeenCalled()
+
+    const dedupeFinds = (mockEm.findOne as jest.Mock).mock.calls.filter(
+      (call) => call[0] === CustomerUserInvitation,
+    )
+    expect(dedupeFinds).toHaveLength(1)
+    expect(dedupeFinds[0][1]).toMatchObject({
+      tenantId,
+      organizationId,
+      emailHash: 'email-hash',
+      acceptedAt: null,
+      cancelledAt: null,
+    })
+    expect(dedupeFinds[0][1].expiresAt).toHaveProperty('$gt')
+  })
+
+  it('inserts a new invitation row when no pending invitation exists', async () => {
+    ;(mockEm.findOne as jest.Mock).mockResolvedValue(null)
+
+    const result = await service.createInvitation(
+      'fresh@example.com',
+      { tenantId, organizationId },
+      { roleIds, invitedByUserId: 'inviter-2', displayName: 'Fresh' },
+    )
+
+    const invitationCreates = (mockEm.create as jest.Mock).mock.calls.filter(
+      (call) => call[0] === CustomerUserInvitation,
+    )
+    expect(invitationCreates).toHaveLength(1)
+    expect(invitationCreates[0][1]).toMatchObject({
+      tenantId,
+      organizationId,
+      email: 'fresh@example.com',
+      emailHash: 'email-hash',
+      token: 'hashed-token',
+      roleIdsJson: roleIds,
+    })
+    expect(mockEm.persist).toHaveBeenCalled()
+    expect(result.rawToken).toBe('raw-token')
+  })
+})

--- a/packages/core/src/modules/customer_accounts/services/customerInvitationService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerInvitationService.ts
@@ -29,13 +29,46 @@ export class CustomerInvitationService {
   ): Promise<{ invitation: CustomerUserInvitation; rawToken: string }> {
     const token = generateSecureToken()
     const emailHash = hashForLookup(email)
+    const normalizedEmail = email.toLowerCase().trim()
     const expiresAt = new Date(Date.now() + INVITATION_TTL_MS)
-
     const tokenHashed = hashToken(token)
+
+    // Dedupe: reuse an existing pending (not accepted, not cancelled, unexpired)
+    // invitation for the same recipient instead of inserting a new row. This caps
+    // row/token growth and keeps a single live token per concurrently-pending
+    // (tenant, organization, email) tuple.
+    const existing = await findOneWithDecryption(
+      this.em,
+      CustomerUserInvitation,
+      {
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        emailHash,
+        acceptedAt: null,
+        cancelledAt: null,
+        expiresAt: { $gt: new Date() },
+      } as any,
+      undefined,
+      { tenantId: scope.tenantId, organizationId: scope.organizationId },
+    )
+
+    if (existing) {
+      existing.email = normalizedEmail
+      existing.token = tokenHashed
+      existing.customerEntityId = options.customerEntityId || null
+      existing.roleIdsJson = options.roleIds
+      existing.invitedByUserId = options.invitedByUserId || null
+      existing.invitedByCustomerUserId = options.invitedByCustomerUserId || null
+      existing.displayName = options.displayName || null
+      existing.expiresAt = expiresAt
+      await this.em.flush()
+      return { invitation: existing, rawToken: token }
+    }
+
     const invitation = this.em.create(CustomerUserInvitation, {
       tenantId: scope.tenantId,
       organizationId: scope.organizationId,
-      email: email.toLowerCase().trim(),
+      email: normalizedEmail,
       emailHash,
       token: tokenHashed,
       customerEntityId: options.customerEntityId || null,


### PR DESCRIPTION
Fixes #2692

## Problem
The staff- and portal-facing customer invitation endpoints (`api/admin/users-invite.ts`, `api/portal/users-invite.ts`) created a new `customer_user_invitations` row on every request with no throttling, no dedupe of pending invitations, and no per-tenant quota. A single authorized actor (or any abuse path reaching the handler) could mint unbounded invitation rows and valid 72h tokens — a row/token-flooding and dormant-credential concern.

## Root Cause
- Both routes declared `metadata = {}` / `requireAuth: false` and never invoked the shared `checkRateLimit` helper used by login/reset/signup.
- `CustomerInvitationService.createInvitation` unconditionally generated a token and inserted a row; it never looked for an existing pending invitation for `(tenantId, organizationId, emailHash)`.

## What Changed
- **Rate limiting**: Added `customerInviteRateLimitConfig` (5/min compound IP+email) and `customerInviteIpRateLimitConfig` (20/min per IP) to `lib/rateLimiter.ts`, wired `checkAuthRateLimit` into both invite routes after the auth check, returning `429` and documenting it in each route's `openApi` errors. Follows the existing signup/reset pattern (env-overridable via `RATE_LIMIT_CUSTOMER_INVITE*`, fail-open when the limiter is unconfigured, disabled in integration tests).
- **Dedupe**: `createInvitation` now uses `findOneWithDecryption` (tenant/org-scoped) to find a non-accepted, non-cancelled, unexpired invitation for the same recipient and reissues its token/expiry/metadata in place instead of inserting a new row. The insert path is unchanged when no pending invitation exists.

## Tests
- `services/__tests__/customerInvitationService.test.ts`: new `createInvitation` dedupe describe block — reuses an existing pending invitation (no `em.create`, refreshes token/expiry/roles) and still inserts when none exists. Proven red before the fix.
- `api/__tests__/users-invite-rate-limit.test.ts` (new): asserts both routes call `checkAuthRateLimit` with the invite configs + normalized invitee email, and that a `429` short-circuits before the invitation service runs. Proven red before the fix.
- `yarn workspace @open-mercato/core test customer_accounts` — 296/296 pass.
- `yarn workspace @open-mercato/core typecheck` — clean (after `yarn build:packages` + `yarn generate`).

## Backward Compatibility
- No contract-surface changes: no removed API fields, no event/widget/ACL/DI/import-path changes. Adds two new rate-limit config exports and a new `429` documented error. The dedupe changes the response only by returning the reissued invitation's id (still a valid pending invitation) rather than a brand-new row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)