### PR TITLE
fix(cli): stop esbuild service after OpenAPI bundle to avoid exit deadlock

### DIFF
--- a/packages/cli/src/lib/generators/openapi.ts
+++ b/packages/cli/src/lib/generators/openapi.ts
@@ -485,6 +485,9 @@ process.stdout.write(JSON.stringify(deepClone(doc), (_, v) =>
     }
     return null
   } finally {
+    // Shut down esbuild's persistent Go service so it does not deadlock at
+    // process exit when a plugin request is still in flight.
+    try { await esbuild.stop() } catch {}
     // Clean up old files from previous tsx-based approach
     for (const file of ['_openapi-register.mjs', '_openapi-loader.mjs', '_next-stub.cjs']) {
       try { fs.unlinkSync(path.join(cacheDir, file)) } catch {}


### PR DESCRIPTION
## Problem

`yarn generate` (turbo `@open-mercato/app:generate`) completed successfully but then dumped a Go panic to stderr:

```
fatal error: all goroutines are asleep - deadlock!
goroutine ... github.com/evanw/esbuild/internal/bundler.ScanBundle ...
```

The trace appeared **after** `All generators completed` / `Done in 10040ms`, and turbo still reported `1 successful` — so generation output was correct, but the noise looked like a hard failure.

## Root cause

`generateOpenApiViaBundle` (`packages/cli/src/lib/generators/openapi.ts`) starts esbuild's persistent Go service via `esbuild.build({ plugins: [...] })` but never disposes it. The plugins use the JS↔Go request protocol (`onResolve`/`onLoad`). When the Node process exits while the service still has a plugin request in flight, the Go side blocks forever on a channel waiting for a response that never arrives, and Go's runtime panics with the deadlock dump. Well-known esbuild teardown race.

## Fix

Call `esbuild.stop()` in the `finally` block (guarded with `try/catch`) so the service shuts down gracefully before Node exits.

## Why this hides nothing

- The build's own failures keep their existing `try/catch` + static-fallback path (`openapi.ts` build call) — untouched. No build error is masked.
- The guarded `catch {}` only swallows errors from the shutdown handshake itself, which carry no product signal.
- The panic was always post-completion stderr noise and never affected the written output.

## Verification

- Rebuilt `@open-mercato/cli`, re-ran `yarn generate`: clean exit 0, **no deadlock panic**, identical OpenAPI output (`397 paths, 281 with requestBody`).

## Notes

`skip-qa`: CLI/build-tooling only, no runtime or customer-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)