### PR TITLE
security(customer_accounts): scope admin user role/company lookups to caller org (#2693)

### DIFF
--- a/packages/core/src/helpers/integration/customerAccountsFixtures.ts
+++ b/packages/core/src/helpers/integration/customerAccountsFixtures.ts
@@ -107,12 +107,50 @@ export async function setCustomerRoleAcl(
   expect(res.status(), 'PUT /admin/roles/[id]/acl should return 200').toBe(200)
 }
 
+/**
+ * Create a real owned CRM company (staff admin) and return its `CustomerEntity`
+ * id. `POST /admin/users` validates `customerEntityId` against an owned company
+ * in the caller's tenant+org (kind=company), so portal scoping fixtures must
+ * link users to a company that actually exists rather than a synthetic UUID.
+ */
+export async function createCustomerCompanyFixture(
+  request: APIRequestContext,
+  adminToken: string,
+  displayName?: string,
+): Promise<string> {
+  const name = displayName ?? `QA Portal Company ${uniqueSuffix()}`
+  const res = await apiRequest(request, 'POST', '/api/customers/companies', {
+    token: adminToken,
+    data: { displayName: name },
+  })
+  expect(res.status(), 'POST /customers/companies should return 201').toBe(201)
+  const body = await readJsonSafe<{ id?: string; entityId?: string }>(res)
+  return expectId(body?.id ?? body?.entityId, 'Company creation response should include the entity id')
+}
+
+/** Best-effort soft-delete of a CRM company (cleanup). */
+export async function deleteCustomerCompanyFixture(
+  request: APIRequestContext,
+  adminToken: string | null,
+  companyEntityId: string | null,
+): Promise<void> {
+  if (!adminToken || !companyEntityId) return
+  await apiRequest(request, 'DELETE', `/api/customers/companies?id=${companyEntityId}`, {
+    token: adminToken,
+  }).catch(() => undefined)
+}
+
 export type CreateCustomerUserInput = {
   email?: string
   password?: string
   displayName?: string
   roleIds?: string[]
-  /** Synthetic CRM company id (no FK is enforced) used for portal company scoping. */
+  /**
+   * Owned CRM company id (a `CustomerEntity` of kind=company in the caller's
+   * tenant+org) used for portal company scoping. `POST /admin/users` rejects an
+   * id that is not an owned company, so create one via
+   * {@link createCustomerCompanyFixture} rather than passing a synthetic UUID.
+   */
   customerEntityId?: string | null
 }
 

--- a/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-003.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-003.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test'
-import { randomUUID } from 'node:crypto'
 import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
 import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
 import {
+  createCustomerCompanyFixture,
   createCustomerRoleFixture,
   createCustomerUserFixture,
+  deleteCustomerCompanyFixture,
   deleteCustomerRoleFixture,
   deleteCustomerUserFixture,
   portalCookieHeaders,
@@ -18,8 +19,8 @@ import {
  * Surface: GET /api/customer_accounts/portal/users
  * Source: issue #2463.
  *
- * Scoping is by `customerEntityId` (a synthetic CRM company id; no FK is
- * enforced) AND `tenantId` — NOT by organization. Default pageSize is 25.
+ * Scoping is by `customerEntityId` (an owned CRM company id) AND `tenantId` —
+ * NOT by organization. Default pageSize is 25.
  */
 
 type PortalUser = {
@@ -51,12 +52,15 @@ test.describe('TC-PORTAL-003: portal users list scoping and pagination', () => {
     const adminToken = await getAuthToken(request, 'admin')
     const { tenantId } = getTokenContext(adminToken)
 
-    const companyA = randomUUID()
-    const companyB = randomUUID()
     const createdUserIds: string[] = []
+    const createdCompanyIds: string[] = []
     let roleId: string | null = null
 
     try {
+      const companyA = await createCustomerCompanyFixture(request, adminToken)
+      const companyB = await createCustomerCompanyFixture(request, adminToken)
+      createdCompanyIds.push(companyA, companyB)
+
       const role = await createCustomerRoleFixture(request, adminToken, {
         features: ['portal.users.view'],
       })
@@ -171,6 +175,7 @@ test.describe('TC-PORTAL-003: portal users list scoping and pagination', () => {
     } finally {
       for (const id of createdUserIds) await deleteCustomerUserFixture(request, adminToken, id)
       await deleteCustomerRoleFixture(request, adminToken, roleId)
+      for (const id of createdCompanyIds) await deleteCustomerCompanyFixture(request, adminToken, id)
     }
   })
 

--- a/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-004.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-004.spec.ts
@@ -4,8 +4,10 @@ import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
 import { withClient } from '@open-mercato/core/helpers/integration/dbFixtures'
 import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
 import {
+  createCustomerCompanyFixture,
   createCustomerRoleFixture,
   createCustomerUserFixture,
+  deleteCustomerCompanyFixture,
   deleteCustomerRoleFixture,
   deleteCustomerUserFixture,
   portalCookieHeaders,
@@ -33,12 +35,14 @@ test.describe('TC-PORTAL-004: portal user deletion guards', () => {
     const adminToken = await getAuthToken(request, 'admin')
     const { tenantId } = getTokenContext(adminToken)
 
-    const company = randomUUID()
+    let company: string | null = null
     let roleId: string | null = null
     let userAId: string | null = null
     let userBId: string | null = null
 
     try {
+      company = await createCustomerCompanyFixture(request, adminToken)
+
       const role = await createCustomerRoleFixture(request, adminToken, {
         features: ['portal.users.manage'],
       })
@@ -128,6 +132,7 @@ test.describe('TC-PORTAL-004: portal user deletion guards', () => {
       await deleteCustomerUserFixture(request, adminToken, userAId)
       await deleteCustomerUserFixture(request, adminToken, userBId)
       await deleteCustomerRoleFixture(request, adminToken, roleId)
+      await deleteCustomerCompanyFixture(request, adminToken, company)
     }
   })
 
@@ -135,11 +140,12 @@ test.describe('TC-PORTAL-004: portal user deletion guards', () => {
     const adminToken = await getAuthToken(request, 'admin')
     const { tenantId } = getTokenContext(adminToken)
 
-    const company = randomUUID()
+    let company: string | null = null
     let roleId: string | null = null
     let userId: string | null = null
 
     try {
+      company = await createCustomerCompanyFixture(request, adminToken)
       // Role without portal.users.manage — the feature gate runs before the
       // company / self / lookup checks, so any DELETE target returns 403.
       const role = await createCustomerRoleFixture(request, adminToken, {
@@ -167,6 +173,7 @@ test.describe('TC-PORTAL-004: portal user deletion guards', () => {
     } finally {
       await deleteCustomerUserFixture(request, adminToken, userId)
       await deleteCustomerRoleFixture(request, adminToken, roleId)
+      await deleteCustomerCompanyFixture(request, adminToken, company)
     }
   })
 })

--- a/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-005.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-PORTAL-005.spec.ts
@@ -3,8 +3,10 @@ import { randomUUID } from 'node:crypto'
 import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
 import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
 import {
+  createCustomerCompanyFixture,
   createCustomerRoleFixture,
   createCustomerUserFixture,
+  deleteCustomerCompanyFixture,
   deleteCustomerRoleFixture,
   deleteCustomerUserFixture,
   portalCookieHeaders,
@@ -50,11 +52,12 @@ test.describe('TC-PORTAL-005: portal user role assignment', () => {
     const adminToken = await getAuthToken(request, 'admin')
     const { tenantId } = getTokenContext(adminToken)
 
-    const company = randomUUID()
+    let company: string | null = null
     const roleIds: string[] = []
     const userIds: string[] = []
 
     try {
+      company = await createCustomerCompanyFixture(request, adminToken)
       // Caller can both manage roles and view the company roster (for read-back).
       const callerRole = await createCustomerRoleFixture(request, adminToken, {
         features: ['portal.users.roles.manage', 'portal.users.view'],
@@ -119,6 +122,7 @@ test.describe('TC-PORTAL-005: portal user role assignment', () => {
     } finally {
       for (const id of userIds) await deleteCustomerUserFixture(request, adminToken, id)
       for (const id of roleIds) await deleteCustomerRoleFixture(request, adminToken, id)
+      await deleteCustomerCompanyFixture(request, adminToken, company)
     }
   })
 
@@ -126,11 +130,12 @@ test.describe('TC-PORTAL-005: portal user role assignment', () => {
     const adminToken = await getAuthToken(request, 'admin')
     const { tenantId } = getTokenContext(adminToken)
 
-    const company = randomUUID()
+    let company: string | null = null
     const roleIds: string[] = []
     const userIds: string[] = []
 
     try {
+      company = await createCustomerCompanyFixture(request, adminToken)
       const callerRole = await createCustomerRoleFixture(request, adminToken, {
         features: ['portal.users.roles.manage'],
       })
@@ -184,6 +189,7 @@ test.describe('TC-PORTAL-005: portal user role assignment', () => {
     } finally {
       for (const id of userIds) await deleteCustomerUserFixture(request, adminToken, id)
       for (const id of roleIds) await deleteCustomerRoleFixture(request, adminToken, id)
+      await deleteCustomerCompanyFixture(request, adminToken, company)
     }
   })
 })

--- a/packages/core/src/modules/customer_accounts/api/admin/__tests__/user-detail.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/__tests__/user-detail.route.test.ts
@@ -1,0 +1,161 @@
+/** @jest-environment node */
+import {
+  CustomerRole,
+  CustomerUserRole,
+} from '@open-mercato/core/modules/customer_accounts/data/entities'
+
+const mockGetAuth = jest.fn()
+const mockRbac = { userHasAllFeatures: jest.fn() }
+const mockEmFind = jest.fn()
+const mockEmFindOne = jest.fn()
+const mockEmCreate = jest.fn()
+const mockEmPersist = jest.fn()
+const mockEmFlush = jest.fn()
+const mockEmNativeUpdate = jest.fn()
+const mockEmNativeDelete = jest.fn()
+const mockInvalidateUserCache = jest.fn()
+
+const mockEm: Record<string, unknown> = {
+  find: mockEmFind,
+  findOne: mockEmFindOne,
+  create: mockEmCreate,
+  persist: mockEmPersist,
+  flush: mockEmFlush,
+  nativeUpdate: mockEmNativeUpdate,
+  nativeDelete: mockEmNativeDelete,
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'rbacService') return mockRbac
+    if (token === 'em') return mockEm
+    if (token === 'customerRbacService') return { invalidateUserCache: mockInvalidateUserCache }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuth(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (em: any, entity: any, where: any, options?: any) => em.find(entity, where, options),
+  findOneWithDecryption: (em: any, entity: any, where: any, options?: any) => em.findOne(entity, where, options),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/events', () => ({
+  emitCustomerAccountsEvent: jest.fn(async () => undefined),
+}))
+
+import { PUT } from '@open-mercato/core/modules/customer_accounts/api/admin/users/[id]'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+const adminId = '33333333-3333-4333-8333-333333333333'
+const userId = '44444444-4444-4444-8444-444444444444'
+const roleId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+const targetUser = {
+  id: userId,
+  email: 'target@example.com',
+  displayName: 'Target',
+  isActive: true,
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+}
+
+function buildRequest(body: unknown) {
+  return new Request(`http://localhost/api/customer_accounts/admin/users/${userId}`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('admin PUT /api/customer_accounts/admin/users/[id] — scoped role + company ownership', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuth.mockResolvedValue({ sub: adminId, tenantId, orgId })
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+    mockEmCreate.mockImplementation((_entity: unknown, data: unknown) => data)
+  })
+
+  it('scopes the role lookup to tenant AND organization', async () => {
+    mockEmFindOne.mockResolvedValue(targetUser)
+    mockEmFind.mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerRole) return [{ id: roleId, name: 'Alpha' }]
+      return []
+    })
+
+    const res = await PUT(buildRequest({ roleIds: [roleId] }), { params: { id: userId } })
+
+    expect(res.status).toBe(200)
+    const roleFinds = mockEmFind.mock.calls.filter((call) => call[0] === CustomerRole)
+    expect(roleFinds).toHaveLength(1)
+    expect(roleFinds[0][1]).toMatchObject({
+      id: { $in: [roleId] },
+      tenantId,
+      organizationId: orgId,
+      deletedAt: null,
+    })
+  })
+
+  it('rejects with 400 when a requested role is out of scope', async () => {
+    mockEmFindOne.mockResolvedValue(targetUser)
+    mockEmFind.mockResolvedValue([])
+
+    const res = await PUT(buildRequest({ roleIds: [roleId] }), { params: { id: userId } })
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.ok).toBe(false)
+    expect(body.error).toContain(roleId)
+    const roleLinkDeletes = mockEmNativeDelete.mock.calls.filter((call) => call[0] === CustomerUserRole)
+    expect(roleLinkDeletes).toHaveLength(0)
+  })
+
+  it('rejects with 400 when customerEntityId is not an owned company in the caller scope', async () => {
+    const foreignCompanyId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+    // First findOne resolves the user; second resolves the company lookup (null = not owned).
+    mockEmFindOne
+      .mockResolvedValueOnce(targetUser)
+      .mockResolvedValueOnce(null)
+
+    const res = await PUT(buildRequest({ customerEntityId: foreignCompanyId }), { params: { id: userId } })
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.ok).toBe(false)
+    const companyLookup = mockEmFindOne.mock.calls.find(
+      (call) => (call[1] as any)?.id === foreignCompanyId,
+    )
+    expect(companyLookup).toBeDefined()
+    expect(companyLookup![1]).toMatchObject({
+      id: foreignCompanyId,
+      tenantId,
+      organizationId: orgId,
+      kind: 'company',
+      deletedAt: null,
+    })
+    // The user row is never updated when the company link is rejected.
+    expect(mockEmNativeUpdate).not.toHaveBeenCalled()
+  })
+
+  it('persists customerEntityId when it is an owned company in the caller scope', async () => {
+    const ownedCompanyId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+    mockEmFindOne
+      .mockResolvedValueOnce(targetUser)
+      .mockResolvedValueOnce({ id: ownedCompanyId, kind: 'company' })
+
+    const res = await PUT(buildRequest({ customerEntityId: ownedCompanyId }), { params: { id: userId } })
+
+    expect(res.status).toBe(200)
+    const userUpdate = mockEmNativeUpdate.mock.calls.find(
+      (call) => (call[2] as any)?.customerEntityId === ownedCompanyId,
+    )
+    expect(userUpdate).toBeDefined()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/admin/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/__tests__/users.route.test.ts
@@ -169,6 +169,54 @@ describe('admin /api/customer_accounts/admin/users — GET listing', () => {
     )
     expect(customerUserRoleCalls).toHaveLength(0)
   })
+
+  it('returns an empty page and never queries the junction table when roleId is out of scope', async () => {
+    // roleId filter must first validate the role against the scoped CustomerRole
+    // set so the junction table cannot be used as a role-UUID existence oracle (#2693).
+    mockEmFindOne.mockResolvedValue(null)
+
+    const crossOrgRoleId = roleAlpha.id
+    const res = await GET(
+      buildRequest(`http://localhost/api/customer_accounts/admin/users?roleId=${crossOrgRoleId}`),
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true, items: [], total: 0, totalPages: 1, page: 1 })
+    const roleLookup = mockEmFindOne.mock.calls.find((call) => call[0] === CustomerRole)
+    expect(roleLookup).toBeDefined()
+    expect(roleLookup![1]).toMatchObject({
+      id: crossOrgRoleId,
+      tenantId,
+      organizationId: orgId,
+      deletedAt: null,
+    })
+    // The junction table is never touched once the role is out of scope.
+    const junctionCalls = mockEmFind.mock.calls.filter((call) => call[0] === CustomerUserRole)
+    expect(junctionCalls).toHaveLength(0)
+    expect(mockEmFindAndCount).not.toHaveBeenCalled()
+  })
+
+  it('queries the junction table only after an in-scope roleId is validated', async () => {
+    mockEmFindOne.mockResolvedValue({ id: roleAlpha.id, name: 'Alpha' })
+    mockEmFind.mockImplementation(async (entity: unknown, where: any) => {
+      if (entity !== CustomerUserRole) return []
+      // The role-filter lookup keys on `role`; the page role-batch keys on `user`.
+      if (where?.role) return [{ user: { id: 'u1' } }]
+      return [{ user: { id: 'u1' }, role: roleAlpha }]
+    })
+    mockEmFindAndCount.mockResolvedValue([[makeUser('u1')], 1])
+
+    const res = await GET(
+      buildRequest(`http://localhost/api/customer_accounts/admin/users?roleId=${roleAlpha.id}`),
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.total).toBe(1)
+    const junctionCalls = mockEmFind.mock.calls.filter((call) => call[0] === CustomerUserRole)
+    expect(junctionCalls.length).toBeGreaterThanOrEqual(1)
+  })
 })
 
 describe('admin /api/customer_accounts/admin/users — GET search', () => {
@@ -272,7 +320,7 @@ describe('admin /api/customer_accounts/admin/users — POST role validation', ()
     mockEmFind.mockResolvedValue([])
   })
 
-  it('validates all requested roles via a single $in query instead of per-role lookups', async () => {
+  it('validates all requested roles via a single $in query scoped to tenant AND organization', async () => {
     mockEmFind.mockImplementation(async (entity: unknown, where: any) => {
       if (entity === CustomerRole) {
         return [
@@ -304,10 +352,111 @@ describe('admin /api/customer_accounts/admin/users — POST role validation', ()
     expect(roleFinds[0][1]).toMatchObject({
       id: { $in: [roleAlpha.id, roleBeta.id] },
       tenantId,
+      organizationId: orgId,
       deletedAt: null,
     })
     // Two persists for the user-role links (one per valid role)
     const userRoleCreates = mockEmCreate.mock.calls.filter((call) => call[0] === CustomerUserRole)
     expect(userRoleCreates).toHaveLength(2)
+  })
+
+  it('rejects with 400 when a requested role is missing from the scoped set (cross-org role UUID)', async () => {
+    // Role from another org in the same tenant: the org-scoped lookup returns
+    // only the in-scope role, so the cross-org UUID is rejected, not dropped.
+    mockEmFind.mockImplementation(async (entity: unknown, where: any) => {
+      if (entity === CustomerRole) {
+        return [{ id: roleAlpha.id, name: 'Alpha' }].filter((role) =>
+          (where?.id?.$in as string[]).includes(role.id),
+        )
+      }
+      return []
+    })
+
+    const crossOrgRoleId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+    const body = {
+      email: 'new@example.com',
+      password: 'Secret123!',
+      displayName: 'New User',
+      roleIds: [roleAlpha.id, crossOrgRoleId],
+    }
+    const req = buildRequest('http://localhost/api/customer_accounts/admin/users', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    const res = await POST(req)
+    const resBody = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(resBody.ok).toBe(false)
+    expect(resBody.error).toContain(crossOrgRoleId)
+    // No user is created when role validation fails.
+    expect(mockCreateUser).not.toHaveBeenCalled()
+  })
+
+  it('rejects with 400 when customerEntityId is not an owned company in the caller scope', async () => {
+    mockEmFind.mockResolvedValue([])
+    // Company lookup (findOneWithDecryption -> em.findOne) returns nothing:
+    // the company belongs to another org, so the link must be rejected.
+    mockEmFindOne.mockResolvedValue(null)
+
+    const foreignCompanyId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+    const body = {
+      email: 'new@example.com',
+      password: 'Secret123!',
+      displayName: 'New User',
+      customerEntityId: foreignCompanyId,
+    }
+    const req = buildRequest('http://localhost/api/customer_accounts/admin/users', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    const res = await POST(req)
+    const resBody = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(resBody.ok).toBe(false)
+    // The company ownership lookup is scoped to tenant + org + kind=company.
+    const companyLookup = mockEmFindOne.mock.calls.find(
+      (call) => (call[1] as any)?.id === foreignCompanyId,
+    )
+    expect(companyLookup).toBeDefined()
+    expect(companyLookup![1]).toMatchObject({
+      id: foreignCompanyId,
+      tenantId,
+      organizationId: orgId,
+      kind: 'company',
+      deletedAt: null,
+    })
+    expect(mockCreateUser).not.toHaveBeenCalled()
+  })
+
+  it('persists a customerEntityId that is an owned company in the caller scope', async () => {
+    mockEmFind.mockResolvedValue([])
+    const ownedCompanyId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+    mockEmFindOne.mockResolvedValue({ id: ownedCompanyId, kind: 'company' })
+
+    const body = {
+      email: 'new@example.com',
+      password: 'Secret123!',
+      displayName: 'New User',
+      customerEntityId: ownedCompanyId,
+    }
+    const req = buildRequest('http://localhost/api/customer_accounts/admin/users', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(201)
+    const companyUpdate = mockEmNativeUpdate.mock.calls.find(
+      (call) => (call[2] as any)?.customerEntityId === ownedCompanyId,
+    )
+    expect(companyUpdate).toBeDefined()
   })
 })

--- a/packages/core/src/modules/customer_accounts/api/admin/users.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users.ts
@@ -9,7 +9,8 @@ import { CustomerUser, CustomerUserRole, CustomerRole } from '@open-mercato/core
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { adminCreateUserSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
 import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
-import { findAndCountWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { findAndCountWithDecryption, findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { isOwnedCompanyEntity } from '@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership'
 import { hashForLookup } from '@open-mercato/shared/lib/encryption/aes'
 import { E } from '#generated/entities.ids.generated'
 import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
@@ -106,6 +107,26 @@ export async function GET(req: Request) {
 
   let userIds: string[] | null = null
   if (roleId) {
+    // Validate the roleId against the scoped CustomerRole set before touching the
+    // junction table. CustomerUserRole carries no tenant/org column of its own,
+    // so an unscoped lookup here is a role-UUID existence oracle and is brittle
+    // against future code that reads the link rows directly (#2693, defence-in-depth).
+    const scopedRole = await findOneWithDecryption(
+      em,
+      CustomerRole,
+      { id: roleId, tenantId: auth.tenantId, organizationId: auth.orgId, deletedAt: null } as any,
+      undefined,
+      { tenantId: auth.tenantId, organizationId: auth.orgId },
+    )
+    if (!scopedRole) {
+      return NextResponse.json({
+        ok: true,
+        items: [],
+        total: 0,
+        totalPages: 1,
+        page,
+      })
+    }
     const roleLinks = await findWithDecryption(
       em,
       CustomerUserRole,
@@ -219,6 +240,47 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: 'A user with this email already exists' }, { status: 409 })
   }
 
+  // Resolve roles up front, scoped to the caller's tenant AND organization, and
+  // reject the request if any requested role is missing from the scoped set.
+  // CustomerRole is org-scoped, so omitting organizationId here would let an
+  // admin in org A link roles from org B in the same tenant — a cross-org
+  // privilege grant (#2693). Invalid IDs must be rejected, not silently dropped.
+  let resolvedRoles: Array<{ id: string }> = []
+  if (parsed.data.roleIds && parsed.data.roleIds.length > 0) {
+    const requestedRoleIds = parsed.data.roleIds
+    const validRoles = await findWithDecryption(
+      em,
+      CustomerRole,
+      {
+        id: { $in: requestedRoleIds } as any,
+        tenantId: auth.tenantId,
+        organizationId: auth.orgId,
+        deletedAt: null,
+      } as any,
+      undefined,
+      { tenantId: auth.tenantId, organizationId: auth.orgId },
+    )
+    if (validRoles.length !== requestedRoleIds.length) {
+      const foundIds = new Set(validRoles.map((role) => role.id))
+      const missingId = requestedRoleIds.find((roleId) => !foundIds.has(roleId))
+      return NextResponse.json({ ok: false, error: `Role ${missingId} not found` }, { status: 400 })
+    }
+    resolvedRoles = validRoles
+  }
+
+  // Reject a customerEntityId the caller does not own. Without this check a
+  // mislinked company FK persists indefinitely and cross-links the user into
+  // another org/company's portal context (#2693).
+  if (parsed.data.customerEntityId) {
+    const owned = await isOwnedCompanyEntity(em, parsed.data.customerEntityId, {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+    })
+    if (!owned) {
+      return NextResponse.json({ ok: false, error: 'Company not found' }, { status: 400 })
+    }
+  }
+
   const user = await customerUserService.createUser(
     parsed.data.email,
     parsed.data.password,
@@ -238,26 +300,13 @@ export async function POST(req: Request) {
       await tx.nativeUpdate(CustomerUser, { id: user.id }, { customerEntityId: parsed.data.customerEntityId })
     }
 
-    if (parsed.data.roleIds && parsed.data.roleIds.length > 0) {
-      const validRoles = await findWithDecryption(
-        tx,
-        CustomerRole,
-        {
-          id: { $in: parsed.data.roleIds } as any,
-          tenantId: auth.tenantId,
-          deletedAt: null,
-        } as any,
-        undefined,
-        { tenantId: auth.tenantId, organizationId: auth.orgId },
-      )
-      for (const role of validRoles) {
-        const userRole = tx.create(CustomerUserRole, {
-          user,
-          role,
-          createdAt: new Date(),
-        } as any)
-        tx.persist(userRole)
-      }
+    for (const role of resolvedRoles) {
+      const userRole = tx.create(CustomerUserRole, {
+        user,
+        role,
+        createdAt: new Date(),
+      } as any)
+      tx.persist(userRole)
     }
   })
 

--- a/packages/core/src/modules/customer_accounts/api/admin/users/[id].ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users/[id].ts
@@ -11,6 +11,7 @@ import { CustomerRbacService } from '@open-mercato/core/modules/customer_account
 import { adminUpdateUserSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
 import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { isOwnedCompanyEntity } from '@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership'
 import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 
@@ -153,6 +154,20 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
     throw err
   }
 
+  // Reject a customerEntityId the caller does not own before persisting it.
+  // Without this check a mislinked company FK cross-links the user into another
+  // org/company's portal context and persists indefinitely (#2693). A null value
+  // (unlink) needs no ownership check.
+  if (parsed.data.customerEntityId) {
+    const owned = await isOwnedCompanyEntity(em, parsed.data.customerEntityId, {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+    })
+    if (!owned) {
+      return NextResponse.json({ ok: false, error: 'Company not found' }, { status: 400 })
+    }
+  }
+
   // Always bump updated_at so the optimistic-lock version advances on every save.
   // `nativeUpdate` bypasses MikroORM's `onUpdate` hook, so set it explicitly — without
   // this the version never changes and concurrent edits cannot be detected (#2055).
@@ -169,6 +184,9 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
   let rolesChanged = false
   if (parsed.data.roleIds !== undefined) {
     const requestedRoleIds = parsed.data.roleIds
+    // Scope role resolution to the caller's organization too — CustomerRole is
+    // org-scoped, so a tenant-only filter would let an admin link roles from
+    // another org in the same tenant (#2693).
     const validRoles = requestedRoleIds.length > 0
       ? await findWithDecryption(
           em,
@@ -176,6 +194,7 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
           {
             id: { $in: requestedRoleIds } as any,
             tenantId: auth.tenantId,
+            organizationId: auth.orgId,
             deletedAt: null,
           } as any,
           undefined,

--- a/packages/core/src/modules/customer_accounts/lib/customerEntityOwnership.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerEntityOwnership.ts
@@ -1,0 +1,39 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+
+export type CustomerEntityScope = {
+  tenantId: string | null | undefined
+  organizationId: string | null | undefined
+}
+
+/**
+ * Confirms that a caller-supplied `customerEntityId` (the CRM company FK linked
+ * onto a customer user) exists, is a company, is not soft-deleted, and belongs
+ * to the caller's tenant and organization.
+ *
+ * Without this check an admin in org A could pass a company UUID from org B in
+ * the same tenant and cross-link a customer user into another org's portal
+ * context (#2693). The lookup is org-scoped to match how `CustomerEntity` rows
+ * are created and listed.
+ */
+export async function isOwnedCompanyEntity(
+  em: EntityManager,
+  customerEntityId: string,
+  scope: CustomerEntityScope,
+): Promise<boolean> {
+  const { CustomerEntity } = await import('@open-mercato/core/modules/customers/data/entities')
+  const entity = await findOneWithDecryption(
+    em,
+    CustomerEntity,
+    {
+      id: customerEntityId,
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      kind: 'company',
+      deletedAt: null,
+    } as any,
+    undefined,
+    { tenantId: scope.tenantId, organizationId: scope.organizationId },
+  )
+  return !!entity
+}


### PR DESCRIPTION
Fixes #2693

## Problem
The `customer_accounts` admin user routes accepted caller-supplied `roleIds` and `customerEntityId` and used them without scoping the lookups to the caller's organization. These routes bypass `customerInvitationService`, so the invite-path fix (#2252) did not cover them.

- **Issue 1 (create):** role lookup was scoped by `{ tenantId, deletedAt }` only. `CustomerRole` is org-scoped, so an admin in org A could pass role UUIDs from org B in the same tenant and have those roles (and ACL grants) linked to a new user. Invalid IDs were silently dropped.
- **Issue 2 (create + update):** `customerEntityId` (the CRM company FK) was persisted with only UUID-format validation — no check that the company exists, is a company, or belongs to the caller's tenant/org. The value flows into the customer session/JWT and drives portal "company users", so a mislinked id cross-links a user into another org/company's portal context and persists indefinitely.
- **Issue 3 (list, defence-in-depth):** the `roleId` list filter queried the `CustomerUserRole` junction table without first validating the role, making it a role-UUID existence oracle and brittle against future code that reads link rows directly.

## Root Cause
Role and company lookups omitted the caller's `organizationId` (and, for the company FK, any ownership/kind/soft-delete checks), trusting client-supplied UUIDs.

## What Changed
- `api/admin/users.ts` (POST): resolve `roleIds` scoped to tenant **and** org; reject with 400 when any requested role is missing from the scoped set (no more silent drops). Validate `customerEntityId` ownership before persisting.
- `api/admin/users/[id].ts` (PUT): scope role resolution to tenant **and** org; validate `customerEntityId` ownership before persisting.
- `api/admin/users.ts` (GET): validate `roleId` against the scoped `CustomerRole` set before touching the junction table.
- New `lib/customerEntityOwnership.ts` → `isOwnedCompanyEntity(em, id, scope)` centralizes the company ownership check (`kind=company`, tenant+org-scoped, not soft-deleted) for both create and update.

## Tests
- `__tests__/users.route.test.ts`: org-scoped role `$in` assertion, cross-org role → 400, company-ownership reject/accept on create, and the `roleId` list-filter scope guard (out-of-scope → empty + junction untouched; in-scope → junction queried).
- `__tests__/user-detail.route.test.ts` (new): PUT role lookup org-scope, out-of-scope role → 400, company-ownership reject/accept on update.
- Verified red-before-fix (7 new assertions fail on the develop baseline source) and green after. Full `customer_accounts` suite: 299/299 passing. `@open-mercato/core` typecheck clean.

## Backward Compatibility
No contract-surface changes. Same routes, same response shapes, same DI/event/ACL names. The new behaviour is strictly more restrictive: requests that previously linked cross-org roles or unowned companies now get a 400 instead of a silent mislink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)