### PR TITLE
security(customer_accounts): close login account-enumeration timing/error oracle (#2694)

### DIFF
--- a/packages/core/src/modules/customer_accounts/__tests__/signup-login-tenant-binding.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/signup-login-tenant-binding.test.ts
@@ -89,6 +89,23 @@ describe('customer_accounts login — emailVerifiedAt gate blocks unverified acc
     expect(source).toMatch(gateBlockPattern)
     expect(source).not.toMatch(/Please verify your email/i)
   })
+
+  test('inactive and locked branches pay the bcrypt floor so they are not a timing oracle (#2694)', () => {
+    expect(source).toMatch(/from\s+['"]bcryptjs['"]/)
+    expect(source).toMatch(/TIMING_EQUALIZATION_HASH\s*=\s*['"]\$2[aby]\$10\$/)
+
+    const inactiveBranch = source.match(/if\s*\(\s*!\s*user\.isActive\s*\)\s*\{([\s\S]*?)\n\s{2}\}/)?.[1] ?? ''
+    expect(inactiveBranch).toMatch(/await\s+bcryptCompare\s*\(\s*password\s*,\s*TIMING_EQUALIZATION_HASH\s*\)/)
+
+    const lockoutBranch = source.match(/checkLockout\(user\)\s*\)\s*\{([\s\S]*?)\n\s{2}\}/)?.[1] ?? ''
+    expect(lockoutBranch).toMatch(/await\s+bcryptCompare\s*\(\s*password\s*,\s*TIMING_EQUALIZATION_HASH\s*\)/)
+  })
+
+  test('inactive and locked branches return the generic 401 body, never a distinct status or message (#2694)', () => {
+    expect(source).not.toMatch(/Account is deactivated/)
+    expect(source).not.toMatch(/Account is temporarily locked/)
+    expect(source).not.toMatch(/status:\s*423/)
+  })
 })
 
 describe('customer_accounts admin create — admin-vouched users are marked verified', () => {

--- a/packages/core/src/modules/customer_accounts/api/__tests__/login.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/__tests__/login.route.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @jest-environment node
+ *
+ * Regression coverage for issue #2694: the customer login handler must not leak
+ * account existence through differential error responses or a bcrypt timing oracle.
+ * Every failed-login branch (unknown email, missing hash, inactive, locked, wrong
+ * password) must return the same generic 401 body and run a constant-time bcrypt
+ * comparison so the response cannot be used to enumerate accounts per tenant.
+ */
+import { POST } from '@open-mercato/core/modules/customer_accounts/api/login'
+
+const mockCheckAuthRateLimit = jest.fn()
+const mockResolveTenantContext = jest.fn()
+const mockFindByEmail = jest.fn()
+const mockVerifyPassword = jest.fn()
+const mockCheckLockout = jest.fn()
+const mockIncrementFailedAttempts = jest.fn()
+const mockBcryptCompare = jest.fn()
+const mockEmitCustomerAccountsEvent = jest.fn()
+
+const mockCustomerUserService = {
+  findByEmail: mockFindByEmail,
+  verifyPassword: mockVerifyPassword,
+  checkLockout: mockCheckLockout,
+  incrementFailedAttempts: mockIncrementFailedAttempts,
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'customerUserService') return mockCustomerUserService
+    if (token === 'customerSessionService') return {}
+    if (token === 'customerRbacService') return {}
+    return null
+  }),
+}
+
+jest.mock('bcryptjs', () => ({
+  compare: (...args: unknown[]) => mockBcryptCompare(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/ratelimit/helpers', () => ({
+  rateLimitErrorSchema: {},
+  getClientIp: jest.fn(() => '127.0.0.1'),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/rateLimiter', () => ({
+  checkAuthRateLimit: jest.fn((args: unknown) => mockCheckAuthRateLimit(args)),
+  resetAuthRateLimit: jest.fn(),
+  customerLoginRateLimitConfig: {},
+  customerLoginIpRateLimitConfig: {},
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/resolveTenantContext', () => ({
+  resolveTenantContext: jest.fn((...args: unknown[]) => mockResolveTenantContext(...args)),
+  TenantResolutionError: class TenantResolutionError extends Error {
+    status: number
+    constructor(message: string, status = 400) {
+      super(message)
+      this.status = status
+    }
+  },
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/events', () => ({
+  emitCustomerAccountsEvent: jest.fn((...args: unknown[]) => mockEmitCustomerAccountsEvent(...args)),
+}))
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/customer_accounts/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function baseBody(overrides: Record<string, unknown> = {}) {
+  return { email: 'probe@example.com', password: 'Secret123!', tenantId, ...overrides }
+}
+
+describe('POST /api/customer_accounts/login — account-enumeration hardening (#2694)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCheckAuthRateLimit.mockResolvedValue({ error: null, compoundKey: null })
+    mockResolveTenantContext.mockResolvedValue({ tenantId })
+    mockBcryptCompare.mockResolvedValue(false)
+    mockCheckLockout.mockReturnValue(false)
+    mockVerifyPassword.mockResolvedValue(false)
+    mockEmitCustomerAccountsEvent.mockResolvedValue(undefined)
+  })
+
+  test('unknown email runs the bcrypt timing floor and returns generic 401', async () => {
+    mockFindByEmail.mockResolvedValueOnce(null)
+
+    const res = await POST(makeRequest(baseBody()))
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body).toEqual({ ok: false, error: 'Invalid email or password' })
+    expect(mockBcryptCompare).toHaveBeenCalledWith('Secret123!', expect.stringMatching(/^\$2[aby]\$10\$/))
+  })
+
+  test('account with no password hash runs the bcrypt timing floor and returns generic 401', async () => {
+    mockFindByEmail.mockResolvedValueOnce({ id: 'u1', isActive: true, passwordHash: null })
+
+    const res = await POST(makeRequest(baseBody()))
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body).toEqual({ ok: false, error: 'Invalid email or password' })
+    expect(mockBcryptCompare).toHaveBeenCalledTimes(1)
+  })
+
+  test('inactive account returns generic 401 (no "deactivated" disclosure) and pays the bcrypt floor', async () => {
+    mockFindByEmail.mockResolvedValueOnce({ id: 'u1', isActive: false, passwordHash: 'hash' })
+
+    const res = await POST(makeRequest(baseBody()))
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body).toEqual({ ok: false, error: 'Invalid email or password' })
+    expect(body.error).not.toMatch(/deactivat/i)
+    expect(mockBcryptCompare).toHaveBeenCalledTimes(1)
+    expect(mockVerifyPassword).not.toHaveBeenCalled()
+  })
+
+  test('locked account returns generic 401 (not 423) and pays the bcrypt floor', async () => {
+    mockFindByEmail.mockResolvedValueOnce({ id: 'u1', isActive: true, passwordHash: 'hash' })
+    mockCheckLockout.mockReturnValueOnce(true)
+
+    const res = await POST(makeRequest(baseBody()))
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body).toEqual({ ok: false, error: 'Invalid email or password' })
+    expect(body.error).not.toMatch(/lock/i)
+    expect(mockBcryptCompare).toHaveBeenCalledTimes(1)
+    expect(mockVerifyPassword).not.toHaveBeenCalled()
+  })
+
+  test('wrong password for a real account returns the same generic 401 body', async () => {
+    mockFindByEmail.mockResolvedValueOnce({ id: 'u1', isActive: true, passwordHash: 'hash', emailVerifiedAt: new Date() })
+    mockVerifyPassword.mockResolvedValueOnce(false)
+
+    const res = await POST(makeRequest(baseBody()))
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body).toEqual({ ok: false, error: 'Invalid email or password' })
+    expect(mockIncrementFailedAttempts).toHaveBeenCalledTimes(1)
+  })
+
+  test('every failed branch yields an identical status + body (no observable difference)', async () => {
+    const scenarios = [
+      () => mockFindByEmail.mockResolvedValueOnce(null),
+      () => mockFindByEmail.mockResolvedValueOnce({ id: 'u1', isActive: true, passwordHash: null }),
+      () => mockFindByEmail.mockResolvedValueOnce({ id: 'u1', isActive: false, passwordHash: 'hash' }),
+      () => {
+        mockFindByEmail.mockResolvedValueOnce({ id: 'u1', isActive: true, passwordHash: 'hash' })
+        mockCheckLockout.mockReturnValueOnce(true)
+      },
+      () => {
+        mockFindByEmail.mockResolvedValueOnce({ id: 'u1', isActive: true, passwordHash: 'hash', emailVerifiedAt: new Date() })
+        mockVerifyPassword.mockResolvedValueOnce(false)
+      },
+    ]
+
+    const responses: { status: number; body: unknown }[] = []
+    for (const setup of scenarios) {
+      setup()
+      const res = await POST(makeRequest(baseBody()))
+      responses.push({ status: res.status, body: await res.json() })
+    }
+
+    const [first, ...rest] = responses
+    for (const response of rest) {
+      expect(response).toEqual(first)
+    }
+    expect(first).toEqual({ status: 401, body: { ok: false, error: 'Invalid email or password' } })
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/login.ts
+++ b/packages/core/src/modules/customer_accounts/api/login.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { compare as bcryptCompare } from 'bcryptjs'
 import { z } from 'zod'
 import type { OpenApiRouteDoc, OpenApiMethodDoc } from '@open-mercato/shared/lib/openapi'
 import { loginSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
@@ -21,6 +22,11 @@ import {
 } from '@open-mercato/core/modules/customer_accounts/lib/resolveTenantContext'
 
 export const metadata: { path?: string; requireAuth?: boolean } = { requireAuth: false }
+
+// Precomputed bcrypt cost-10 hash of an unknowable random 32-byte input; used to equalize
+// response latency between the real-account and unknown/inactive/locked/no-hash login branches
+// so account existence cannot be inferred from a timing side channel. Mirrors signup.ts.
+const TIMING_EQUALIZATION_HASH = '$2b$10$.F2A6UHFzk.d8trNdfqt4OLz05Nf3IOuMmN6VJKflhD4.rz.prR8i'
 
 export async function POST(req: Request) {
   let body: unknown
@@ -61,18 +67,28 @@ export async function POST(req: Request) {
   const customerRbacService = container.resolve('customerRbacService') as CustomerRbacService
 
   const user = await customerUserService.findByEmail(email, tenantId)
+
+  // Equalize response timing and error responses across every failed-login branch so an
+  // attacker cannot enumerate which emails have an account in this tenant. Unknown,
+  // password-less, inactive, locked, wrong-password, and unverified accounts all run a
+  // bcrypt comparison and return the same generic 401 — lockout/deactivation guidance is
+  // conveyed out-of-band (e.g. email), never in the synchronous response.
   if (!user || !user.passwordHash) {
+    await bcryptCompare(password, TIMING_EQUALIZATION_HASH)
     void emitCustomerAccountsEvent('customer_accounts.login.failed', { email, reason: 'invalid_credentials', tenantId }).catch(() => undefined)
     return NextResponse.json({ ok: false, error: 'Invalid email or password' }, { status: 401 })
   }
 
   if (!user.isActive) {
-    return NextResponse.json({ ok: false, error: 'Account is deactivated' }, { status: 401 })
+    await bcryptCompare(password, TIMING_EQUALIZATION_HASH)
+    void emitCustomerAccountsEvent('customer_accounts.login.failed', { email, reason: 'inactive', tenantId }).catch(() => undefined)
+    return NextResponse.json({ ok: false, error: 'Invalid email or password' }, { status: 401 })
   }
 
   if (customerUserService.checkLockout(user)) {
+    await bcryptCompare(password, TIMING_EQUALIZATION_HASH)
     void emitCustomerAccountsEvent('customer_accounts.login.failed', { email, reason: 'locked', tenantId }).catch(() => undefined)
-    return NextResponse.json({ ok: false, error: 'Account is temporarily locked. Please try again later.' }, { status: 423 })
+    return NextResponse.json({ ok: false, error: 'Invalid email or password' }, { status: 401 })
   }
 
   const passwordValid = await customerUserService.verifyPassword(user, password)
@@ -171,7 +187,6 @@ const methodDoc: OpenApiMethodDoc = {
   errors: [
     { status: 400, description: 'Validation failed', schema: errorSchema },
     { status: 401, description: 'Invalid credentials', schema: errorSchema },
-    { status: 423, description: 'Account locked', schema: errorSchema },
     { status: 429, description: 'Too many login attempts', schema: rateLimitErrorSchema },
   ],
 }

--- a/packages/core/src/modules/portal/__tests__/loginPage.test.tsx
+++ b/packages/core/src/modules/portal/__tests__/loginPage.test.tsx
@@ -54,26 +54,15 @@ describe('PortalLoginPage', () => {
     // here (jsdom Location replacement is brittle); negative-path tests cover the
     // error-rendering branches.
     expect(queryByText(/invalid email or password/i)).toBeNull()
-    expect(queryByText(/account locked/i)).toBeNull()
   })
 
-  it('renders the locked-account message on HTTP 423', async () => {
-    apiCallMock.mockResolvedValueOnce({ ok: false, status: 423, result: { ok: false, error: 'locked' } })
+  it('renders the generic invalid-credentials message on every HTTP 401 (no account enumeration)', async () => {
+    // The login API collapses unknown, inactive, locked, and unverified accounts into a
+    // single generic 401 so the UI must not reveal which case occurred. Any prior
+    // account-specific body (e.g. a deactivated/locked marker) must still render generically.
+    apiCallMock.mockResolvedValueOnce({ ok: false, status: 401, result: { ok: false, error: 'Account is deactivated' } })
 
-    const { getByLabelText, getByRole, findByText } = renderWithProviders(<PortalLoginPage params={{ orgSlug: 'acme' }} />)
-    fireEvent.change(getByLabelText(/email/i), { target: { value: 'u@example.com' } })
-    fireEvent.change(getByLabelText(/^password$/i), { target: { value: 'pw' } })
-    await act(async () => {
-      fireEvent.click(getByRole('button', { name: /sign in/i }))
-    })
-
-    await findByText(/account locked/i)
-  })
-
-  it('renders the invalid-credentials message on HTTP 401', async () => {
-    apiCallMock.mockResolvedValueOnce({ ok: false, status: 401, result: { ok: false, error: 'nope' } })
-
-    const { getByLabelText, getByRole, findByText } = renderWithProviders(<PortalLoginPage params={{ orgSlug: 'acme' }} />)
+    const { getByLabelText, getByRole, findByText, queryByText } = renderWithProviders(<PortalLoginPage params={{ orgSlug: 'acme' }} />)
     fireEvent.change(getByLabelText(/email/i), { target: { value: 'u@example.com' } })
     fireEvent.change(getByLabelText(/^password$/i), { target: { value: 'pw' } })
     await act(async () => {
@@ -81,6 +70,8 @@ describe('PortalLoginPage', () => {
     })
 
     await findByText(/invalid email or password/i)
+    expect(queryByText(/not active/i)).toBeNull()
+    expect(queryByText(/account locked/i)).toBeNull()
   })
 
   it('shows the org-not-found guard when tenantId is missing and never calls the API', async () => {

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/__tests__/auth-pages.test.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/__tests__/auth-pages.test.tsx
@@ -9,7 +9,7 @@ import PortalSignupPage from '../signup/page'
 const mockApiCall = jest.fn()
 
 const mockTranslations: Record<string, string> = {
-  'portal.login.error.inactive': 'Your account is not active yet. An administrator must activate it before you can log in.',
+  'portal.login.error.invalidCredentials': 'Invalid email or password.',
   'portal.signup.success.description': 'If your registration was accepted, check your email for next steps before signing in. Some organizations require an administrator to activate new accounts.',
   'portal.signup.success.title': 'Check your email',
 }
@@ -78,7 +78,9 @@ describe('portal auth pages', () => {
     expect(screen.queryByText('Your account has been created. You can now log in.')).not.toBeInTheDocument()
   })
 
-  it('surfaces inactive-account login errors instead of showing invalid credentials', async () => {
+  it('shows the generic invalid-credentials message for an inactive-account 401 (no enumeration leak)', async () => {
+    // The login API no longer differentiates inactive/locked accounts in the synchronous
+    // response, so the UI must render the generic message even if a legacy body slips through.
     mockApiCall.mockResolvedValue({
       status: 401,
       ok: false,
@@ -95,8 +97,8 @@ describe('portal auth pages', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sign In' }))
 
     await waitFor(() => {
-      expect(screen.getByText(mockTranslations['portal.login.error.inactive'])).toBeInTheDocument()
+      expect(screen.getByText(mockTranslations['portal.login.error.invalidCredentials'])).toBeInTheDocument()
     })
-    expect(screen.queryByText('Invalid email or password.')).not.toBeInTheDocument()
+    expect(screen.queryByText('Your account is not active yet. An administrator must activate it before you can log in.')).not.toBeInTheDocument()
   })
 })

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/login/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/login/page.tsx
@@ -51,16 +51,10 @@ export default function PortalLoginPage({ params }: Props) {
           return
         }
 
-        if (result.status === 423) {
-          setError(t('portal.login.error.locked', 'Account locked. Try again later.'))
-        } else if (result.status === 401 && result.result?.error === 'Account is deactivated') {
-          setError(
-            t(
-              'portal.login.error.inactive',
-              'Your account is not active yet. An administrator must activate it before you can log in.',
-            ),
-          )
-        } else if (result.status === 401) {
+        if (result.status === 401) {
+          // The login API intentionally returns a single generic 401 for unknown, inactive,
+          // locked, and unverified accounts so account existence cannot be enumerated.
+          // Lockout/deactivation guidance is delivered out-of-band (e.g. email), never here.
           setError(t('portal.login.error.invalidCredentials', 'Invalid email or password.'))
         } else {
           setError(result.result?.error || t('portal.login.error.generic', 'Login failed. Please try again.'))


### PR DESCRIPTION
Fixes #2694

## Problem
The customer portal login handler (`packages/core/src/modules/customer_accounts/api/login.ts`) let an attacker enumerate which emails have a registered account per tenant through two oracles:
- **Timing**: unknown emails returned immediately with no bcrypt work, while real accounts ran `verifyPassword` (bcrypt cost-10) — a measurable per-request difference.
- **Differential responses**: a deactivated account returned `Account is deactivated` (401) and a locked account returned `Account is temporarily locked…` (423), both before any password check, positively confirming the email exists in the tenant.

This violated the module's own documented rule ("MUST return minimal error messages on auth endpoints — never reveal whether an email exists") and was inconsistent with the sibling signup endpoint, which already neutralizes the same attack.

## Root Cause
The unknown/inactive/locked branches short-circuited with distinct status codes/bodies and skipped the bcrypt comparison, so both response content and latency leaked account existence.

## What Changed
- Every failed-login branch (unknown email, missing password hash, inactive, locked, wrong password, unverified) now runs a constant-time `bcryptCompare(password, TIMING_EQUALIZATION_HASH)` against a fixed placeholder hash and returns the same generic `Invalid email or password` 401 — mirroring `signup.ts`'s `TIMING_EQUALIZATION_HASH` pattern.
- Removed the differential `Account is deactivated` (401) body and the `423` locked status from the synchronous response; lockout/deactivation guidance is delivered out-of-band (e.g. email). Lockout enforcement itself is preserved.
- Dropped the now-unused `423` entry from the route's OpenAPI errors.
- Updated the portal login page to render a single generic message for any 401 (the API no longer differentiates), removing the dead 423/`Account is deactivated` branches.

## Tests
- New `api/__tests__/login.route.test.ts`: proves unknown/no-hash/inactive/locked/wrong-password all return an identical 401 generic body and each pays the bcrypt timing floor; asserts no `deactivat`/`lock` disclosure.
- Extended `signup-login-tenant-binding.test.ts` source guards: inactive & locked branches must call the bcrypt floor and must not emit a distinct status/message (`423`, `Account is deactivated`, `Account is temporarily locked`).
- Updated portal UI tests (`loginPage.test.tsx`, `auth-pages.test.tsx`) to assert the generic-message behavior (previously asserted the vulnerable differential responses).
- Verified red-before-fix (7 failures on develop), green-after-fix. Full `customer_accounts` + `portal` suites: 315 passing. `yarn typecheck`, `yarn i18n:check-sync` pass; `i18n:check-usage` advisory-only.

## Backward Compatibility
Intentional security-hardening change to the login response contract: HTTP 423 and the distinct `Account is deactivated` 401 body are removed in favor of a uniform generic 401. The differential responses *were* the vulnerability, so this is a deliberate, scoped behavior change with the sole in-repo consumer (portal login page) updated in the same PR. No event IDs, DI names, ACL IDs, or import paths changed; the new `reason: 'inactive'` telemetry value is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)