### PR TITLE
security(webhooks): normalize empty-string organizationId to null in outbound dispatch decryption scope (#2443)

### DIFF
--- a/packages/webhooks/src/modules/webhooks/subscribers/__tests__/outbound-dispatch.test.ts
+++ b/packages/webhooks/src/modules/webhooks/subscribers/__tests__/outbound-dispatch.test.ts
@@ -102,6 +102,37 @@ describe('webhooks outbound dispatch subscriber', () => {
     })
   })
 
+  it('normalizes a missing organizationId to null in the decryption scope', async () => {
+    const { rootEm } = createDispatchEntityManagers()
+
+    ;(findWithDecryption as jest.Mock).mockResolvedValue([])
+
+    await handler(
+      {
+        id: 'product-1',
+        tenantId: 'tenant-1',
+      },
+      {
+        eventName: 'catalog.product.deleted',
+        resolve: <T,>(name: string): T => {
+          if (name === 'em') return rootEm as T
+          throw new Error(`Unexpected dependency: ${name}`)
+        },
+      },
+    )
+
+    expect(findWithDecryption).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ tenantId: 'tenant-1' }),
+      expect.anything(),
+      { tenantId: 'tenant-1', organizationId: null },
+    )
+    const decryptionScope = (findWithDecryption as jest.Mock).mock.calls[0][4]
+    expect(decryptionScope.organizationId).toBeNull()
+    expect(decryptionScope.organizationId).not.toBe('')
+  })
+
   it('checks integration state once per organization when multiple webhooks match', async () => {
     const { rootEm, handlerEm } = createDispatchEntityManagers()
 

--- a/packages/webhooks/src/modules/webhooks/subscribers/outbound-dispatch.ts
+++ b/packages/webhooks/src/modules/webhooks/subscribers/outbound-dispatch.ts
@@ -67,7 +67,7 @@ export default async function handler(
       ...(organizationId ? { organizationId } : {}),
     },
     {},
-    { tenantId, organizationId: organizationId ?? '' },
+    { tenantId, organizationId: organizationId ?? null },
   )
 
   if (!webhooks.length) return


### PR DESCRIPTION
Fixes #2443

## Problem
`packages/webhooks/src/modules/webhooks/subscribers/outbound-dispatch.ts:70` passed `organizationId ?? ''` as the decryption scope. When an event has no `organizationId`, this hands an empty string to the decryption helpers instead of `null`.

## Root Cause
`decryptEntitiesWithFallbackScope` normalizes with `?? null`, but `'' ?? null` is `''` — the empty string survives. As a result the exact-scope key lookup runs `organization_id IS NOT DISTINCT FROM ''` (silently missing any `NULL` org-scoped key row) and the key cache gains a spurious `...:` segment instead of `...:null`. Every other decryption call site (`find.ts:33/53/76`, `customers/api/deals/[id]/route.ts`) normalizes with `?? null`; this one diverged.

## What Changed
- `outbound-dispatch.ts`: `organizationId ?? ''` → `organizationId ?? null`, matching every other decryption call site.

## Tests
- Added a regression test in `outbound-dispatch.test.ts` asserting the decryption scope normalizes a missing `organizationId` to `null` (and explicitly not `''`). It fails on the old code and passes with the fix.
- Full `@open-mercato/webhooks` suite: 96 passing (13 suites).
- `@open-mercato/webhooks` typecheck passes after `yarn build:packages` + `yarn generate`.

## Backward Compatibility
- No contract surface changes. Internal subscriber behavior only; aligns scope normalization with the rest of the codebase.

## Security impact
- Corrects the decryption scope/cache-key handling for webhook secret reads on events without an `organizationId`. Practical impact today is minor (the candidate cascade still resolves tenant-level keys), but this removes a latent failure mode once org-scoped webhook secrets exist and stops cache pollution. No keys were exposed.