### PR TITLE
security(search): include organizationId in merger dedup key (#2442)

### DIFF
--- a/packages/search/src/__tests__/merger.test.ts
+++ b/packages/search/src/__tests__/merger.test.ts
@@ -189,6 +189,43 @@ describe('merger', () => {
       expect(merged[0]?.recordId).toBe('record-1')
       expect(merged[0]?.score).toBeCloseTo(rrf(0, 1.2))
     })
+
+    it('does not coalesce the same entity/record from different organizations', () => {
+      const merged = mergeAndRankResults(
+        [
+          createResult({
+            source: 'tokens',
+            recordId: 'record-1',
+            organizationId: 'org-a',
+            presenter: { title: 'Org A Record' },
+          }),
+          createResult({
+            source: 'fulltext',
+            recordId: 'record-1',
+            organizationId: 'org-b',
+            presenter: { title: 'Org B Record' },
+          }),
+        ],
+        createConfig(),
+      )
+
+      expect(merged).toHaveLength(2)
+      expect(merged.map((result) => result.organizationId).sort()).toEqual(['org-a', 'org-b'])
+    })
+
+    it('still merges the same entity/record within a single organization', () => {
+      const merged = mergeAndRankResults(
+        [
+          createResult({ source: 'tokens', recordId: 'record-1', organizationId: 'org-a' }),
+          createResult({ source: 'fulltext', recordId: 'record-1', organizationId: 'org-a' }),
+        ],
+        createConfig(),
+      )
+
+      expect(merged).toHaveLength(1)
+      expect(merged[0]?.organizationId).toBe('org-a')
+      expect(merged[0]?.metadata?._sources).toEqual(['tokens', 'fulltext'])
+    })
   })
 
   describe('deduplicateResults', () => {
@@ -218,6 +255,19 @@ describe('merger', () => {
         ['record-2', 0.7],
       ])
       expect(deduplicated[0]?.presenter?.title).toBe('Preferred Result')
+    })
+
+    it('keeps the same entity/record from different organizations as distinct entries', () => {
+      const deduplicated = deduplicateResults([
+        createResult({ recordId: 'record-1', organizationId: 'org-a', score: 0.4 }),
+        createResult({ recordId: 'record-1', organizationId: 'org-b', score: 0.9 }),
+      ])
+
+      expect(deduplicated).toHaveLength(2)
+      expect(deduplicated.map((result) => [result.organizationId, result.score])).toEqual([
+        ['org-b', 0.9],
+        ['org-a', 0.4],
+      ])
     })
   })
 

--- a/packages/search/src/lib/merger.ts
+++ b/packages/search/src/lib/merger.ts
@@ -7,6 +7,20 @@ import type { SearchResult, ResultMergeConfig, SearchStrategyId } from '../types
 const RRF_K = 60
 
 /**
+ * Build the deduplication key for a search result.
+ *
+ * The key includes `organizationId` so the same `entityId:recordId` surfaced
+ * for different organizations (for example from a stale index) never collides
+ * into a single merged entry. This is a defense-in-depth guard: the per-strategy
+ * `filterResultsByOrganizationScope()` already drops foreign-org results before
+ * merging, but keying on org here ensures the merger can never silently coalesce
+ * results across tenants if that upstream filter is bypassed.
+ */
+function dedupeKey(result: SearchResult): string {
+  return `${result.organizationId ?? ''}:${result.entityId}:${result.recordId}`
+}
+
+/**
  * Reciprocal Rank Fusion (RRF) algorithm for combining results from multiple search strategies.
  *
  * RRF is a simple but effective method for combining ranked lists. For each result,
@@ -44,7 +58,7 @@ export function mergeAndRankResults(
 
     for (let rank = 0; rank < sourceResults.length; rank++) {
       const result = sourceResults[rank]
-      const key = `${result.entityId}:${result.recordId}`
+      const key = dedupeKey(result)
       const rrfScore = weight / (RRF_K + rank + 1)
 
       const existing = seen.get(key)
@@ -128,7 +142,7 @@ export function deduplicateResults(results: SearchResult[]): SearchResult[] {
   const seen = new Map<string, SearchResult>()
 
   for (const result of results) {
-    const key = `${result.entityId}:${result.recordId}`
+    const key = dedupeKey(result)
     const existing = seen.get(key)
 
     if (!existing || result.score > existing.score) {


### PR DESCRIPTION
Fixes #2442

## Problem
The search result merger deduplicated results using a key of `${entityId}:${recordId}` only. When the same entity/record surfaced for two different organizations (e.g. from a stale index), the entries collided into a single merged result, silently keeping whichever `organizationId` appeared first via `??` coalescing — with no detection or logging.

## Root Cause
`packages/search/src/lib/merger.ts` built the dedup key without `organizationId` in both `mergeAndRankResults` (RRF fusion) and `deduplicateResults` (simple dedup).

## What Changed
- Added a `dedupeKey(result)` helper that prefixes the key with a normalized `organizationId` (`${organizationId ?? ''}:${entityId}:${recordId}`).
- Used it in both `mergeAndRankResults` and `deduplicateResults`.

Results from different organizations now never collide. Within a single organization, same-record results from multiple strategies still merge exactly as before (the org segment is identical), so happy-path behavior is unchanged.

This is the maintainer's recommended remediation option 1 from the issue, and is defense-in-depth behind the existing per-strategy `filterResultsByOrganizationScope()` guard.

## Tests
- Added regression tests in `packages/search/src/__tests__/merger.test.ts`:
  - `mergeAndRankResults` keeps same entity/record from different orgs as 2 entries; still merges within one org (verified `_sources`).
  - `deduplicateResults` keeps cross-org duplicates as distinct entries.
  - Confirmed both fail before the fix and pass after.
- Full `@open-mercato/search` suite: 119 passed.
- `@open-mercato/search` typecheck + build: clean.

## Backward Compatibility
No contract surface changes — function signatures, `SearchResult` shape, exports, and import paths are unchanged. The only behavioral change is in the cross-org collision case, which is the bug being fixed.