### PR TITLE
security(commands): make ensureOrganizationScope unscoped path observable (#2441)

### DIFF
--- a/packages/shared/src/lib/commands/__tests__/scope.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/scope.test.ts
@@ -83,4 +83,52 @@ describe('ensureOrganizationScope', () => {
       expect(() => ensureOrganizationScope(ctx, 'org-b')).toThrow(CrudHttpError)
     })
   })
+
+  describe('fail-open-by-omission hardening (#2441)', () => {
+    const originalNodeEnv = process.env.NODE_ENV
+    const originalStrict = process.env.OM_ENFORCE_ORG_SCOPE_STRICT
+    let warnSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      // The scope loggers suppress output under NODE_ENV==='test'; flip it so the
+      // observability signal becomes assertable, then restore in afterEach.
+      process.env.NODE_ENV = 'development'
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      warnSpy.mockRestore()
+      if (originalNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = originalNodeEnv
+      if (originalStrict === undefined) delete process.env.OM_ENFORCE_ORG_SCOPE_STRICT
+      else process.env.OM_ENFORCE_ORG_SCOPE_STRICT = originalStrict
+    })
+
+    it('emits an observability warning when scope and currentOrg are both null', () => {
+      delete process.env.OM_ENFORCE_ORG_SCOPE_STRICT
+      const ctx = buildCtx({ orgId: null, selectedOrganizationId: null, organizationScope: null })
+      expect(() => ensureOrganizationScope(ctx, 'org-b')).not.toThrow()
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[scope] Unscoped organization command executed without organization context',
+        expect.objectContaining({ targetOrganizationId: 'org-b', strictEnforcement: false })
+      )
+    })
+
+    it('throws when OM_ENFORCE_ORG_SCOPE_STRICT is enabled', () => {
+      process.env.OM_ENFORCE_ORG_SCOPE_STRICT = 'true'
+      const ctx = buildCtx({ orgId: null, selectedOrganizationId: null, organizationScope: null })
+      expect(() => ensureOrganizationScope(ctx, 'org-b')).toThrow(CrudHttpError)
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[scope] Unscoped organization command executed without organization context',
+        expect.objectContaining({ targetOrganizationId: 'org-b', strictEnforcement: true })
+      )
+    })
+
+    it('does not warn or throw when there is no target organization to validate', () => {
+      delete process.env.OM_ENFORCE_ORG_SCOPE_STRICT
+      const ctx = buildCtx({ orgId: null, selectedOrganizationId: null, organizationScope: null })
+      expect(() => ensureOrganizationScope(ctx, '')).not.toThrow()
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/shared/src/lib/commands/scope.ts
+++ b/packages/shared/src/lib/commands/scope.ts
@@ -1,7 +1,43 @@
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { isOrganizationAccessAllowed } from '@open-mercato/shared/lib/auth/organizationAccess'
+import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import { env } from 'process'
+
+function buildScopeLogContext(ctx: CommandRuntimeContext) {
+  const requestInfo =
+    ctx.request && typeof ctx.request === 'object'
+      ? {
+          method: (ctx.request as Request).method ?? undefined,
+          url: (ctx.request as Request).url ?? undefined,
+        }
+      : null
+  const scope = ctx.organizationScope
+    ? {
+        selectedId: ctx.organizationScope.selectedId ?? null,
+        tenantId: ctx.organizationScope.tenantId ?? null,
+        allowedIdsCount: Array.isArray(ctx.organizationScope.allowedIds)
+          ? ctx.organizationScope.allowedIds.length
+          : null,
+        filterIdsCount: Array.isArray(ctx.organizationScope.filterIds)
+          ? ctx.organizationScope.filterIds.length
+          : null,
+      }
+    : null
+  return {
+    userId: ctx.auth?.sub ?? null,
+    actorTenantId: ctx.auth?.tenantId ?? null,
+    actorOrganizationId: ctx.auth?.orgId ?? null,
+    selectedOrganizationId: ctx.selectedOrganizationId ?? null,
+    organizationIdsCount: Array.isArray(ctx.organizationIds) ? ctx.organizationIds.length : null,
+    scope,
+    request: requestInfo,
+  }
+}
+
+function isStrictOrganizationScopeEnforced(): boolean {
+  return parseBooleanWithDefault(env.OM_ENFORCE_ORG_SCOPE_STRICT, false)
+}
 
 function logScopeViolation(
   ctx: CommandRuntimeContext,
@@ -9,36 +45,25 @@ function logScopeViolation(
   actual: string | null
 ): void {
   try {
-    const requestInfo =
-      ctx.request && typeof ctx.request === 'object'
-        ? {
-            method: (ctx.request as Request).method ?? undefined,
-            url: (ctx.request as Request).url ?? undefined,
-          }
-        : null
-    const scope = ctx.organizationScope
-      ? {
-          selectedId: ctx.organizationScope.selectedId ?? null,
-          tenantId: ctx.organizationScope.tenantId ?? null,
-          allowedIdsCount: Array.isArray(ctx.organizationScope.allowedIds)
-            ? ctx.organizationScope.allowedIds.length
-            : null,
-          filterIdsCount: Array.isArray(ctx.organizationScope.filterIds)
-            ? ctx.organizationScope.filterIds.length
-            : null,
-        }
-      : null
     if (env.NODE_ENV !== 'test') {
       console.warn('[scope] Forbidden organization scope mismatch detected', {
         expectedId: expected,
         actualId: actual,
-        userId: ctx.auth?.sub ?? null,
-        actorTenantId: ctx.auth?.tenantId ?? null,
-        actorOrganizationId: ctx.auth?.orgId ?? null,
-        selectedOrganizationId: ctx.selectedOrganizationId ?? null,
-        organizationIdsCount: Array.isArray(ctx.organizationIds) ? ctx.organizationIds.length : null,
-        scope,
-        request: requestInfo,
+        ...buildScopeLogContext(ctx),
+      })
+    }
+  } catch {
+    // best-effort logging
+  }
+}
+
+function logUnscopedOrganizationAccess(ctx: CommandRuntimeContext, organizationId: string): void {
+  try {
+    if (env.NODE_ENV !== 'test') {
+      console.warn('[scope] Unscoped organization command executed without organization context', {
+        targetOrganizationId: organizationId,
+        strictEnforcement: isStrictOrganizationScopeEnforced(),
+        ...buildScopeLogContext(ctx),
       })
     }
   } catch {
@@ -52,36 +77,11 @@ function logTenantScopeViolation(
   actualTenantId: string | null
 ): void {
   try {
-    const requestInfo =
-      ctx.request && typeof ctx.request === 'object'
-        ? {
-            method: (ctx.request as Request).method ?? undefined,
-            url: (ctx.request as Request).url ?? undefined,
-          }
-        : null
-    const scope = ctx.organizationScope
-      ? {
-          selectedId: ctx.organizationScope.selectedId ?? null,
-          tenantId: ctx.organizationScope.tenantId ?? null,
-          allowedIdsCount: Array.isArray(ctx.organizationScope.allowedIds)
-            ? ctx.organizationScope.allowedIds.length
-            : null,
-          filterIdsCount: Array.isArray(ctx.organizationScope.filterIds)
-            ? ctx.organizationScope.filterIds.length
-            : null,
-        }
-      : null
     if (env.NODE_ENV !== 'test') {
       console.warn('[scope] Forbidden tenant scope mismatch detected', {
         expectedTenantId,
         actualTenantId,
-        userId: ctx.auth?.sub ?? null,
-        actorTenantId: ctx.auth?.tenantId ?? null,
-        actorOrganizationId: ctx.auth?.orgId ?? null,
-        selectedOrganizationId: ctx.selectedOrganizationId ?? null,
-        organizationIdsCount: Array.isArray(ctx.organizationIds) ? ctx.organizationIds.length : null,
-        scope,
-        request: requestInfo,
+        ...buildScopeLogContext(ctx),
       })
     }
   } catch {
@@ -100,9 +100,24 @@ export function ensureOrganizationScope(ctx: CommandRuntimeContext, organization
   if (!scope) {
     if (isSuperAdmin) return
     const currentOrg = ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null
-    if (currentOrg && currentOrg !== organizationId) {
-      logScopeViolation(ctx, organizationId, currentOrg)
-      throw new CrudHttpError(403, { error: 'Forbidden' })
+    if (currentOrg) {
+      if (currentOrg !== organizationId) {
+        logScopeViolation(ctx, organizationId, currentOrg)
+        throw new CrudHttpError(403, { error: 'Forbidden' })
+      }
+      return
+    }
+    // No current org could be resolved either. This branch previously returned
+    // with no validation and no signal — a fail-open-by-omission shape (#2441):
+    // a new command path reaching here with `organizationScope: null` would act
+    // on an arbitrary target org silently. Preserve the legacy allow behavior by
+    // default (the path is load-bearing) but make the unscoped access observable,
+    // and let operators harden it into a deny via OM_ENFORCE_ORG_SCOPE_STRICT.
+    if (organizationId) {
+      logUnscopedOrganizationAccess(ctx, organizationId)
+      if (isStrictOrganizationScopeEnforced()) {
+        throw new CrudHttpError(403, { error: 'Forbidden' })
+      }
     }
     return
   }


### PR DESCRIPTION
Fixes #2441

## Problem
`ensureOrganizationScope` (`packages/shared/src/lib/commands/scope.ts`) has a Pattern-C branch for command contexts built with `organizationScope: null` (system/worker/payment/scheduled flows). When both `scope` **and** the resolved `currentOrg` (`selectedOrganizationId ?? auth.orgId`) were `null`, the function returned **without validating the target `organizationId` at all** — and without any signal. This is the same fail-open-by-omission shape as the previously fixed `ensureOrganizationScope` regression: a new command path that accidentally reaches this branch would operate on an arbitrary org silently.

## Root Cause
The null-scope fallback only threw on a `currentOrg` *mismatch*. The "no current org at all" case fell through to a bare `return`, so the target org was never checked and nothing was logged.

## What Changed
- Restructured the Pattern-C branch so the "no resolvable current org" case is explicit.
- That case now calls a new `logUnscopedOrganizationAccess(ctx, organizationId)` helper, emitting a critical `console.warn` (`[scope] Unscoped organization command executed without organization context`) so the unscoped path is **observable** in production.
- Added an opt-in `OM_ENFORCE_ORG_SCOPE_STRICT` env flag (default off, parsed via `parseBooleanWithDefault`) that converts the silent return into a `403` — enabling a later hardening pass once legitimate null-scope callers are audited.
- Extracted the duplicated request/scope log-payload construction shared by the three scope loggers into `buildScopeLogContext(ctx)` (no behavior change).
- **Behavior-preserving by default**: super-admin, current-org-match, and current-org-mismatch paths are unchanged; the legacy allow behavior for scope-less command contexts is retained unless the new flag is enabled.

## Tests
- `packages/shared/src/lib/commands/__tests__/scope.test.ts`: added a `fail-open-by-omission hardening (#2441)` suite covering (1) the observability warning is emitted when scope and currentOrg are both null, (2) `OM_ENFORCE_ORG_SCOPE_STRICT=true` throws `CrudHttpError`, and (3) no warn/throw when there is no target org to validate. Existing Pattern-C tests continue to pass.
- `yarn workspace @open-mercato/shared test` → 1184 passed.
- `yarn build:packages`, `yarn generate`, `yarn typecheck` → all green.

## Backward Compatibility
- No contract surface changes. `ensureOrganizationScope` signature, exports, and default runtime behavior are unchanged.
- The strict-deny behavior is gated behind a new, default-off env flag (`OM_ENFORCE_ORG_SCOPE_STRICT`); the only always-on change is an additional `console.warn` on the previously-silent unscoped path.

## Security impact
Hardens an authorization primitive on the command surface. Makes a latent fail-open path observable and provides an opt-in deny switch. No currently-exploitable caller was identified (latent hardening, per the issue).