### PR TITLE
fix: 2583 checkout undo integration

### DIFF
--- a/packages/checkout/src/modules/checkout/__integration__/TC-UNDO-001-no-undo-affordance.spec.ts
+++ b/packages/checkout/src/modules/checkout/__integration__/TC-UNDO-001-no-undo-affordance.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { extractOperation, skipIfUndoTestsDisabled } from '@open-mercato/core/helpers/integration/undoHarness'
+import {
+  createCustomerData,
+  createFixedTemplateInput,
+  createLinkFixture,
+  createTemplateFixture,
+  deleteCheckoutEntityIfExists,
+  submitPayLink,
+} from './helpers/fixtures'
+
+/**
+ * TC-UNDO-001 (§4 checkout) — non-undoable commands expose no undo affordance.
+ *
+ * Public checkout submissions create a CheckoutTransaction via the `checkout.transaction.*`
+ * commands, which are intentionally NOT undoable (financial events). The mutating response
+ * must therefore carry no `x-om-operation` undo envelope: `extractOperation(res) === null`.
+ */
+
+test.describe('TC-UNDO-001 checkout §4 — non-undoable commands expose no undo token', () => {
+  test.beforeAll(() => {
+    skipIfUndoTestsDisabled()
+  })
+
+  test('public checkout submit creates a transaction with no undo token', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let templateId: string | null = null
+    let linkId: string | null = null
+    try {
+      templateId = await createTemplateFixture(request, token, createFixedTemplateInput({ status: 'draft' }))
+      const link = await createLinkFixture(request, token, createFixedTemplateInput({ status: 'active', templateId }))
+      linkId = link.id
+
+      const submitRes = await submitPayLink(request, link.slug, {
+        customerData: createCustomerData(),
+        acceptedLegalConsents: {},
+        amount: 49.99,
+      })
+      expect(submitRes.status(), `submit status ${submitRes.status()}`).toBe(201)
+
+      expect(
+        extractOperation(submitRes),
+        'a financial checkout submit must expose no undo token (§4)',
+      ).toBeNull()
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'links', linkId)
+      await deleteCheckoutEntityIfExists(request, token, 'templates', templateId)
+    }
+  })
+})

--- a/packages/checkout/src/modules/checkout/__integration__/TC-UNDO-001-pay-link.spec.ts
+++ b/packages/checkout/src/modules/checkout/__integration__/TC-UNDO-001-pay-link.spec.ts
@@ -1,0 +1,266 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  expectOperation,
+  undoOk,
+  redoOk,
+  expectTokenConsumed,
+  skipIfUndoTestsDisabled,
+} from '@open-mercato/core/helpers/integration/undoHarness'
+import {
+  createFixedTemplateInput,
+  createLinkFixture,
+  deleteCheckoutEntityIfExists,
+  deleteLink,
+  updateLink,
+} from './helpers/fixtures'
+
+/**
+ * TC-UNDO-001 (§3 checkout.pay-link) — Undo/Redo correctness for the checkout pay-link
+ * command bus, driven through the real `/api/checkout/links` routes plus the
+ * `/api/audit_logs/audit-logs/actions/undo|redo` endpoints.
+ *
+ * Invariants asserted: I1 (update→undo restores), I2 (delete→undo re-materializes),
+ * I3 (create→undo soft-deletes), I4 (custom fields restore), I5 (token consumed),
+ * I6 (redo reproduces post-state). checkout.link.create ships an id-preserving redo
+ * handler, so the create→undo→redo SAME-id leg is asserted as corrected behaviour.
+ *
+ * Also covers the #2540 fix: a draft pay-link may persist a null gatewayProviderKey,
+ * and editing it to null then undoing must restore the prior gateway.
+ */
+
+const LINKS = '/api/checkout/links'
+
+type LinkRecord = {
+  id?: string
+  name?: string
+  slug?: string
+  updatedAt?: string
+  gatewayProviderKey?: string | null
+  customFields?: Record<string, unknown>
+}
+
+// The undo endpoint resolves the *latest* undoable log for a resource ordered by
+// millisecond-precision created_at, so consecutive mutations issued within the same
+// millisecond can tie. A short settle keeps each round-trip deterministic.
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 50))
+}
+
+async function getLink(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<{ status: number; body: LinkRecord | null }> {
+  const res = await apiRequest(request, 'GET', `${LINKS}/${encodeURIComponent(id)}`, { token })
+  return { status: res.status(), body: await readJsonSafe<LinkRecord>(res) }
+}
+
+test.describe('TC-UNDO-001 checkout.pay-link undo/redo', () => {
+  test.beforeAll(() => {
+    skipIfUndoTestsDisabled()
+  })
+
+  test('create → undo soft-deletes (I3) + token consumed (I5)', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let linkId: string | null = null
+    try {
+      const createRes = await apiRequest(request, 'POST', LINKS, {
+        token,
+        data: createFixedTemplateInput({ status: 'draft' }),
+      })
+      expect(createRes.status(), `create status ${createRes.status()}`).toBe(201)
+      const createOp = expectOperation(createRes, 'checkout.link.create')
+      linkId = createOp.resourceId
+      expect(linkId, 'create returns a resource id').toBeTruthy()
+
+      expect((await getLink(request, token, linkId as string)).status, 'pay-link exists after create').toBe(200)
+
+      await undoOk(request, token, createOp.undoToken, 'undo create pay-link')
+      expect(
+        (await getLink(request, token, linkId as string)).status,
+        'pay-link is gone after undoing create (I3 — soft-deleted, not readable)',
+      ).not.toBe(200)
+
+      await expectTokenConsumed(request, token, createOp.undoToken, 'checkout.link.create double-undo (I5)')
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'links', linkId)
+    }
+  })
+
+  test('update → undo restores scalars (I1) → redo re-applies (I6)', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let linkId: string | null = null
+    try {
+      const link = await createLinkFixture(request, token, createFixedTemplateInput({ status: 'draft' }))
+      linkId = link.id
+      const before = await getLink(request, token, linkId)
+      const beforeName = before.body?.name
+      expect(beforeName, 'pay-link name readable before update').toBeTruthy()
+
+      await settle()
+      const changedName = `Renamed by undo test ${Date.now()}`
+      const updateRes = await updateLink(request, token, linkId, { name: changedName })
+      expect(updateRes.status(), `update status ${updateRes.status()}`).toBe(200)
+      const updateOp = expectOperation(updateRes, 'checkout.link.update')
+      expect((await getLink(request, token, linkId)).body?.name, 'update changed the name').toBe(changedName)
+
+      await settle()
+      await undoOk(request, token, updateOp.undoToken, 'undo update pay-link')
+      const afterUndo = await getLink(request, token, linkId)
+      expect(afterUndo.body?.name, 'update→undo restores the prior name (I1)').toBe(beforeName)
+      expect(typeof afterUndo.body?.updatedAt, 'pay-link surfaces updatedAt').toBe('string')
+      expect(afterUndo.body?.updatedAt, 'undo bumps updatedAt (I1)').not.toBe(before.body?.updatedAt)
+
+      await redoOk(request, token, updateOp.logId, 'redo update pay-link')
+      expect((await getLink(request, token, linkId)).body?.name, 'redo re-applies the renamed value (I6)').toBe(changedName)
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'links', linkId)
+    }
+  })
+
+  test('delete → undo re-materializes (I2) → redo re-deletes (I6)', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let linkId: string | null = null
+    try {
+      const link = await createLinkFixture(request, token, createFixedTemplateInput({ status: 'draft' }))
+      linkId = link.id
+      const beforeName = (await getLink(request, token, linkId)).body?.name
+
+      await settle()
+      const deleteRes = await deleteLink(request, token, linkId)
+      expect(deleteRes.ok(), `delete status ${deleteRes.status()}`).toBeTruthy()
+      const deleteOp = expectOperation(deleteRes, 'checkout.link.delete')
+      expect((await getLink(request, token, linkId)).status, 'gone after delete').not.toBe(200)
+
+      await undoOk(request, token, deleteOp.undoToken, 'undo delete pay-link')
+      const afterUndo = await getLink(request, token, linkId)
+      expect(afterUndo.status, 'delete→undo re-materializes the row (I2)').toBe(200)
+      expect(afterUndo.body?.name, 're-materialized record keeps its scalars (I2)').toBe(beforeName)
+
+      await redoOk(request, token, deleteOp.logId, 'redo delete pay-link')
+      expect((await getLink(request, token, linkId)).status, 'gone again after redo delete (I6)').not.toBe(200)
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'links', linkId)
+    }
+  })
+
+  test('create → undo → redo restores the SAME record (I6)', async ({ request }) => {
+    // checkout.link.create registers an id-preserving redo handler, so redo must restore
+    // the original soft-deleted row — not mint a new id (the #2468 customers.people defect).
+    const token = await getAuthToken(request, 'admin')
+    let linkId: string | null = null
+    try {
+      const createRes = await apiRequest(request, 'POST', LINKS, {
+        token,
+        data: createFixedTemplateInput({ status: 'draft' }),
+      })
+      const createOp = expectOperation(createRes, 'checkout.link.create')
+      linkId = createOp.resourceId
+
+      await settle()
+      const undoLogId = await undoOk(request, token, createOp.undoToken, 'undo create pay-link')
+      expect((await getLink(request, token, linkId as string)).status, 'gone after undo create').not.toBe(200)
+
+      await redoOk(request, token, undoLogId, 'redo create pay-link')
+      const afterRedo = await getLink(request, token, linkId as string)
+      expect(afterRedo.status, 'same pay-link restored after redo (I6)').toBe(200)
+      expect(afterRedo.body?.id, 'redo preserves the original id (I6)').toBe(linkId)
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'links', linkId)
+    }
+  })
+
+  test('custom fields revert on undo and re-apply on redo (I4)', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let linkId: string | null = null
+    try {
+      const beforeValue = `before ${Date.now()}`
+      const link = await createLinkFixture(
+        request,
+        token,
+        createFixedTemplateInput({
+          status: 'draft',
+          customFieldsetCode: 'service_package',
+          customFields: { delivery_timeline: beforeValue },
+        }),
+      )
+      linkId = link.id
+      expect(
+        (await getLink(request, token, linkId)).body?.customFields?.delivery_timeline,
+        'custom field persisted on create',
+      ).toBe(beforeValue)
+
+      await settle()
+      const afterValue = `after ${Date.now()}`
+      const updateRes = await updateLink(request, token, linkId, { customFields: { delivery_timeline: afterValue } })
+      const updateOp = expectOperation(updateRes, 'checkout.link.update')
+      expect(
+        (await getLink(request, token, linkId)).body?.customFields?.delivery_timeline,
+        'update changed the custom field',
+      ).toBe(afterValue)
+
+      await settle()
+      await undoOk(request, token, updateOp.undoToken, 'undo update custom field')
+      expect(
+        (await getLink(request, token, linkId)).body?.customFields?.delivery_timeline,
+        'custom field reverts on undo (I4)',
+      ).toBe(beforeValue)
+
+      await redoOk(request, token, updateOp.logId, 'redo update custom field')
+      expect(
+        (await getLink(request, token, linkId)).body?.customFields?.delivery_timeline,
+        'custom field re-applies on redo (I4)',
+      ).toBe(afterValue)
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'links', linkId)
+    }
+  })
+
+  test('null gatewayProviderKey edit → undo restores the prior gateway (#2540, I1)', async ({ request }) => {
+    // #2540: a draft pay-link may persist a null gatewayProviderKey. Editing the gateway to
+    // null must round-trip, and undoing the edit must restore the prior gateway value.
+    const token = await getAuthToken(request, 'admin')
+    let linkId: string | null = null
+    try {
+      const link = await createLinkFixture(request, token, createFixedTemplateInput({ status: 'draft' }))
+      linkId = link.id
+      const before = await getLink(request, token, linkId)
+      expect(before.body?.gatewayProviderKey, 'pay-link starts with the mock gateway').toBe('mock')
+
+      await settle()
+      const updateRes = await updateLink(request, token, linkId, {
+        name: 'Pay link (no gateway)',
+        pricingMode: 'fixed',
+        fixedPriceAmount: 49.99,
+        fixedPriceCurrencyCode: 'USD',
+        status: 'draft',
+        gatewayProviderKey: null,
+      })
+      expect(
+        updateRes.ok(),
+        `clearing the gateway on a draft pay-link should succeed: ${updateRes.status()}`,
+      ).toBeTruthy()
+      const updateOp = expectOperation(updateRes, 'checkout.link.update (null gateway)')
+
+      const afterUpdate = await getLink(request, token, linkId)
+      expect(afterUpdate.body?.gatewayProviderKey ?? null, 'gateway cleared to null after edit').toBeNull()
+      expect(afterUpdate.body?.name, 'name changed by edit').toBe('Pay link (no gateway)')
+
+      await settle()
+      await undoOk(request, token, updateOp.undoToken, 'undo null-gateway edit')
+      const afterUndo = await getLink(request, token, linkId)
+      expect(afterUndo.body?.gatewayProviderKey, 'undo restores the prior gateway (#2540, I1)').toBe('mock')
+      expect(afterUndo.body?.name, 'undo restores the prior name (I1)').toBe(before.body?.name)
+
+      await redoOk(request, token, updateOp.logId, 'redo null-gateway edit')
+      expect(
+        (await getLink(request, token, linkId)).body?.gatewayProviderKey ?? null,
+        'redo re-clears the gateway to null (I6)',
+      ).toBeNull()
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'links', linkId)
+    }
+  })
+})

--- a/packages/checkout/src/modules/checkout/__integration__/TC-UNDO-001-template.spec.ts
+++ b/packages/checkout/src/modules/checkout/__integration__/TC-UNDO-001-template.spec.ts
@@ -1,0 +1,228 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  expectOperation,
+  undoOk,
+  redoOk,
+  expectTokenConsumed,
+  skipIfUndoTestsDisabled,
+} from '@open-mercato/core/helpers/integration/undoHarness'
+import {
+  createFixedTemplateInput,
+  createTemplateFixture,
+  deleteCheckoutEntityIfExists,
+  deleteTemplate,
+  updateTemplate,
+} from './helpers/fixtures'
+
+/**
+ * TC-UNDO-001 (§3 checkout.template) — Undo/Redo correctness for the checkout template
+ * command bus, driven through the real `/api/checkout/templates` routes plus the
+ * `/api/audit_logs/audit-logs/actions/undo|redo` endpoints.
+ *
+ * Invariants asserted (per the #2468 tracking issue):
+ *   I1 update→undo restores scalars (and bumps updatedAt)
+ *   I2 delete→undo re-materializes the soft-deleted row
+ *   I3 create→undo soft-deletes (never hard-deletes)
+ *   I4 custom fields revert on undo and re-apply on redo
+ *   I5 a consumed undo token is rejected on a second undo
+ *   I6 redo reproduces the command's post-state
+ *
+ * Unlike the customers.people pilot (where create→undo→redo mints a new id, #2468),
+ * checkout.template.create ships an id-preserving redo handler, so the SAME-id redo
+ * leg is asserted as corrected behaviour rather than quarantined.
+ */
+
+const TEMPLATES = '/api/checkout/templates'
+
+type TemplateRecord = {
+  id?: string
+  name?: string
+  updatedAt?: string
+  gatewayProviderKey?: string | null
+  customFields?: Record<string, unknown>
+}
+
+// The undo endpoint resolves the *latest* undoable log for a resource ordered by
+// millisecond-precision created_at, so consecutive mutations issued within the same
+// millisecond can tie. A short settle keeps each round-trip deterministic.
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 50))
+}
+
+async function getTemplate(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<{ status: number; body: TemplateRecord | null }> {
+  const res = await apiRequest(request, 'GET', `${TEMPLATES}/${encodeURIComponent(id)}`, { token })
+  return { status: res.status(), body: await readJsonSafe<TemplateRecord>(res) }
+}
+
+test.describe('TC-UNDO-001 checkout.template undo/redo', () => {
+  test.beforeAll(() => {
+    skipIfUndoTestsDisabled()
+  })
+
+  test('create → undo soft-deletes (I3) + token consumed (I5)', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let templateId: string | null = null
+    try {
+      const createRes = await apiRequest(request, 'POST', TEMPLATES, {
+        token,
+        data: createFixedTemplateInput({ status: 'draft' }),
+      })
+      expect(createRes.status(), `create status ${createRes.status()}`).toBe(201)
+      const createOp = expectOperation(createRes, 'checkout.template.create')
+      templateId = createOp.resourceId
+      expect(templateId, 'create returns a resource id').toBeTruthy()
+
+      expect((await getTemplate(request, token, templateId as string)).status, 'template exists after create').toBe(200)
+
+      await undoOk(request, token, createOp.undoToken, 'undo create template')
+      expect(
+        (await getTemplate(request, token, templateId as string)).status,
+        'template is gone after undoing create (I3 — soft-deleted, not readable)',
+      ).not.toBe(200)
+
+      await expectTokenConsumed(request, token, createOp.undoToken, 'checkout.template.create double-undo (I5)')
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'templates', templateId)
+    }
+  })
+
+  test('update → undo restores scalars (I1) → redo re-applies (I6)', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let templateId: string | null = null
+    try {
+      templateId = await createTemplateFixture(request, token, createFixedTemplateInput({ status: 'draft' }))
+      const before = await getTemplate(request, token, templateId)
+      const beforeName = before.body?.name
+      expect(beforeName, 'template name readable before update').toBeTruthy()
+
+      await settle()
+      const changedName = `Renamed by undo test ${Date.now()}`
+      const updateRes = await updateTemplate(request, token, templateId, { name: changedName })
+      expect(updateRes.status(), `update status ${updateRes.status()}`).toBe(200)
+      const updateOp = expectOperation(updateRes, 'checkout.template.update')
+      expect((await getTemplate(request, token, templateId)).body?.name, 'update changed the name').toBe(changedName)
+
+      await settle()
+      await undoOk(request, token, updateOp.undoToken, 'undo update template')
+      const afterUndo = await getTemplate(request, token, templateId)
+      expect(afterUndo.body?.name, 'update→undo restores the prior name (I1)').toBe(beforeName)
+      expect(typeof afterUndo.body?.updatedAt, 'template surfaces updatedAt').toBe('string')
+      expect(afterUndo.body?.updatedAt, 'undo bumps updatedAt (I1)').not.toBe(before.body?.updatedAt)
+
+      await redoOk(request, token, updateOp.logId, 'redo update template')
+      expect(
+        (await getTemplate(request, token, templateId)).body?.name,
+        'redo re-applies the renamed value (I6)',
+      ).toBe(changedName)
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'templates', templateId)
+    }
+  })
+
+  test('delete → undo re-materializes (I2) → redo re-deletes (I6)', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let templateId: string | null = null
+    try {
+      templateId = await createTemplateFixture(request, token, createFixedTemplateInput({ status: 'draft' }))
+      const beforeName = (await getTemplate(request, token, templateId)).body?.name
+
+      await settle()
+      const deleteRes = await deleteTemplate(request, token, templateId)
+      expect(deleteRes.ok(), `delete status ${deleteRes.status()}`).toBeTruthy()
+      const deleteOp = expectOperation(deleteRes, 'checkout.template.delete')
+      expect((await getTemplate(request, token, templateId)).status, 'gone after delete').not.toBe(200)
+
+      await undoOk(request, token, deleteOp.undoToken, 'undo delete template')
+      const afterUndo = await getTemplate(request, token, templateId)
+      expect(afterUndo.status, 'delete→undo re-materializes the row (I2)').toBe(200)
+      expect(afterUndo.body?.name, 're-materialized record keeps its scalars (I2)').toBe(beforeName)
+
+      await redoOk(request, token, deleteOp.logId, 'redo delete template')
+      expect(
+        (await getTemplate(request, token, templateId)).status,
+        'gone again after redo delete (I6)',
+      ).not.toBe(200)
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'templates', templateId)
+    }
+  })
+
+  test('create → undo → redo restores the SAME record (I6)', async ({ request }) => {
+    // checkout.template.create registers an id-preserving redo handler, so redo must restore
+    // the original soft-deleted row — not mint a new id (the #2468 customers.people defect).
+    const token = await getAuthToken(request, 'admin')
+    let templateId: string | null = null
+    try {
+      const createRes = await apiRequest(request, 'POST', TEMPLATES, {
+        token,
+        data: createFixedTemplateInput({ status: 'draft' }),
+      })
+      const createOp = expectOperation(createRes, 'checkout.template.create')
+      templateId = createOp.resourceId
+
+      await settle()
+      const undoLogId = await undoOk(request, token, createOp.undoToken, 'undo create template')
+      expect((await getTemplate(request, token, templateId as string)).status, 'gone after undo create').not.toBe(200)
+
+      await redoOk(request, token, undoLogId, 'redo create template')
+      const afterRedo = await getTemplate(request, token, templateId as string)
+      expect(afterRedo.status, 'same template restored after redo (I6)').toBe(200)
+      expect(afterRedo.body?.id, 'redo preserves the original id (I6)').toBe(templateId)
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'templates', templateId)
+    }
+  })
+
+  test('custom fields revert on undo and re-apply on redo (I4)', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let templateId: string | null = null
+    try {
+      const beforeValue = `before ${Date.now()}`
+      templateId = await createTemplateFixture(
+        request,
+        token,
+        createFixedTemplateInput({
+          status: 'draft',
+          customFieldsetCode: 'service_package',
+          customFields: { delivery_timeline: beforeValue },
+        }),
+      )
+      expect(
+        (await getTemplate(request, token, templateId)).body?.customFields?.delivery_timeline,
+        'custom field persisted on create',
+      ).toBe(beforeValue)
+
+      await settle()
+      const afterValue = `after ${Date.now()}`
+      const updateRes = await updateTemplate(request, token, templateId, {
+        customFields: { delivery_timeline: afterValue },
+      })
+      const updateOp = expectOperation(updateRes, 'checkout.template.update')
+      expect(
+        (await getTemplate(request, token, templateId)).body?.customFields?.delivery_timeline,
+        'update changed the custom field',
+      ).toBe(afterValue)
+
+      await settle()
+      await undoOk(request, token, updateOp.undoToken, 'undo update custom field')
+      expect(
+        (await getTemplate(request, token, templateId)).body?.customFields?.delivery_timeline,
+        'custom field reverts on undo (I4)',
+      ).toBe(beforeValue)
+
+      await redoOk(request, token, updateOp.logId, 'redo update custom field')
+      expect(
+        (await getTemplate(request, token, templateId)).body?.customFields?.delivery_timeline,
+        'custom field re-applies on redo (I4)',
+      ).toBe(afterValue)
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'templates', templateId)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Automates TC-UNDO-001 (the #2468 undo/redo verification series) for the `checkout`
module — package `@open-mercato/checkout`. Adds self-contained Playwright integration
coverage that drives every undoable checkout command (pay-link **template** and
**pay-link**) through the real `/api/checkout/*` routes plus the `/api/audit_logs/.../undo|redo`
endpoints, asserting full undo/redo state restoration. No product code changes — test-only.

## Changes

- Add `TC-UNDO-001-template.spec.ts` — template create→undo (I3 soft-delete) + token-consumed (I5),
  update→undo (I1) → redo (I6), delete→undo (I2) → redo (I6), create→undo→redo restores the SAME id (I6),
  and custom-field revert/re-apply (I4).
- Add `TC-UNDO-001-pay-link.spec.ts` — the same matrix for pay-links, plus the #2540 case
  (a draft pay-link edited to a null `gatewayProviderKey`, then undone, restoring the prior gateway).
- Add `TC-UNDO-001-no-undo-affordance.spec.ts` — §4 negative: a public checkout submit creates a
  non-undoable `checkout.transaction.*` and exposes no `x-om-operation` undo token.
- Specs reuse the shared `undoHarness.ts` helpers and the existing `OM_INTEGRATION_UNDO_TESTS_DISABLED`
  gate (`skipIfUndoTestsDisabled()` in `beforeAll`). Checkout's bespoke command bus uses detail `/[id]`
  routes, so the cycle is hand-rolled (mirroring the `customers.people` pilot) rather than using
  `runCrudUndoRoundTrip`. All legs pass — no `test.fixme` quarantine was required.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
Test plan defined by issue #2583 / TC-UNDO-001 (#2468 series, tracking PR #2500). No new spec file.

## Testing

- `tsc --noEmit -p packages/checkout/tsconfig.json` → 0 errors (typechecks the new `__integration__` specs, cross-package imports, fixture types).
- `BASE_URL=http://127.0.0.1:5001 ENABLE_CRUD_API_CACHE=true OM_INTEGRATION_MODULES=checkout npx playwright test --config .ai/qa/tests/playwright.config.ts TC-UNDO-001 --retries=0` → **12 passed** against a fresh seeded ephemeral env.
- Same command with `OM_INTEGRATION_UNDO_TESTS_DISABLED=1` → **12 skipped** (reported skipped, not failed) — proves the disable-flag gate.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — test-only; no generated/auto-discovered files, locales, or docs affected.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Added module-local under `packages/checkout/src/modules/checkout/__integration__/` per the current convention; `.ai/qa/tests/` holds the shared Playwright config only.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec change.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI (integration test files only)
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2583