### PR TITLE
qa: 2582 scheduler undo tests

### DIFF
--- a/packages/scheduler/src/modules/scheduler/__integration__/TC-UNDO-001-scheduler-jobs.spec.ts
+++ b/packages/scheduler/src/modules/scheduler/__integration__/TC-UNDO-001-scheduler-jobs.spec.ts
@@ -1,179 +1,86 @@
-import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
-import { skipIfUndoTestsDisabled } from '@open-mercato/core/helpers/integration/undoHarness'
+import {
+  extractOperation,
+  runCrudUndoRoundTrip,
+  skipIfUndoTestsDisabled,
+} from '@open-mercato/core/helpers/integration/undoHarness'
+import {
+  SCHEDULER_JOBS_PATH,
+  SCHEDULER_TRIGGER_PATH,
+  createScheduleJob,
+  deleteScheduleJob,
+} from './helpers/scheduler'
 
 /**
- * TC-UNDO-001: scheduler.jobs undo round-trip (regression for issue #2504).
+ * TC-UNDO-001 (#2582, refs #2468) — scheduler.jobs undo/redo correctness.
  *
- * Before the fix, every scheduler.jobs undo handler read `logEntry.payload`
- * (always undefined — the command bus persists the undo snapshot under
- * `commandPayload`), so undo returned `{ ok: true }` while silently changing
- * nothing. This spec exercises the real HTTP path end-to-end:
- *   - CREATE -> undo  => job is soft-deleted (no longer listed)
- *   - UPDATE -> undo  => renamed field is restored to its prior value
- *   - DELETE -> undo  => soft-deleted job is re-materialized
+ * Regression lock for #2504: scheduler.jobs undo was a silent no-op because every
+ * undo handler read `logEntry.payload` (always undefined — the command bus persists
+ * the undo snapshot under `commandPayload`), so undo returned `{ ok: true }` while
+ * changing nothing. Fixed in PR #2514 via `extractUndoPayload`. This spec asserts the
+ * corrected behavior (full restoration), driving the real command bus through the
+ * public API + the audit-log undo/redo endpoints.
  *
- * Endpoints covered:
- *   - POST   /api/scheduler/jobs                       (create)
- *   - GET    /api/scheduler/jobs?id=                   (read)
- *   - PUT    /api/scheduler/jobs                       (update)
- *   - DELETE /api/scheduler/jobs                       (delete, cleanup)
- *   - POST   /api/audit_logs/audit-logs/actions/undo   (undo)
+ * scheduler.jobs is a standard `makeCrudRoute` entity (POST/PUT/DELETE on the
+ * collection, `?id=` read-back, camelCase serializer, no custom fields), so the shared
+ * `runCrudUndoRoundTrip` harness covers the full round-trip in one pass:
+ *   - I1 update → undo restores every scalar (and bumps `updatedAt`)
+ *   - I2 delete → undo re-materializes the soft-deleted job
+ *   - I3 create → undo soft-deletes (never hard-deletes)
+ *   - I5 a consumed undo token is rejected on a second undo
+ *   - I6 redo re-applies the command's after-snapshot
+ *
+ * I4 (custom fields) is N/A — `scheduled_job` declares no `ce.ts`, so it has no `cf_*`.
  */
-
-type ScheduleRow = {
-  id: string
-  name: string
-  description: string | null
-  scheduleValue: string
-}
-
-// The undo endpoint only honors the *latest* undoable log for a resource, and
-// `latestUndoableForResource` orders by `created_at` alone. Audit `created_at` is
-// millisecond-precision (`new Date()` at log time), so a create + a follow-up
-// mutation issued within the same millisecond tie and the lookup may resolve to
-// the wrong log. A short settle guarantees the operation under undo is strictly
-// the most recent, keeping the round-trip deterministic.
-async function settleAuditClock(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 50))
-}
-
-function readUndoToken(res: APIResponse): string {
-  const header = res.headers()['x-om-operation'] ?? ''
-  const enc = header.startsWith('omop:') ? header.slice(5) : ''
-  expect(enc, 'x-om-operation header should carry an omop: payload').not.toBe('')
-  const payload = JSON.parse(decodeURIComponent(enc)) as { undoToken?: string }
-  expect(typeof payload.undoToken, 'undoToken present in operation payload').toBe('string')
-  return payload.undoToken as string
-}
-
-async function getById(
-  request: APIRequestContext,
-  token: string,
-  id: string,
-): Promise<ScheduleRow | undefined> {
-  const res = await apiRequest(request, 'GET', `/api/scheduler/jobs?id=${encodeURIComponent(id)}`, { token })
-  expect(res.status()).toBe(200)
-  const body = (await res.json()) as { items?: ScheduleRow[] }
-  return (body.items ?? [])[0]
-}
-
-async function createJob(request: APIRequestContext, token: string, name: string): Promise<{ id: string; res: APIResponse }> {
-  const res = await apiRequest(request, 'POST', '/api/scheduler/jobs', {
-    token,
-    data: {
-      name,
-      description: 'TC-UNDO-001 probe',
-      scopeType: 'tenant',
-      scheduleType: 'cron',
-      scheduleValue: '0 0 * * *',
-      timezone: 'UTC',
-      targetType: 'queue',
-      targetQueue: 'default',
-      isEnabled: true,
-      sourceType: 'user',
-    },
-  })
-  expect(res.status(), 'create returns 201').toBe(201)
-  const id = ((await res.json()) as { id: string }).id
-  expect(id, 'create returns an id').toBeTruthy()
-  return { id, res }
-}
-
-async function undo(request: APIRequestContext, token: string, undoToken: string): Promise<void> {
-  const res = await apiRequest(request, 'POST', '/api/audit_logs/audit-logs/actions/undo', {
-    token,
-    data: { undoToken },
-  })
-  const raw = await res.text()
-  expect(res.status(), `undo returns 200 (body: ${raw})`).toBe(200)
-  const body = JSON.parse(raw) as { ok?: boolean }
-  expect(body.ok, 'undo body is { ok: true }').toBe(true)
-}
-
-async function cleanup(request: APIRequestContext, token: string | null, id: string | null): Promise<void> {
-  if (!token || !id) return
-  try {
-    await apiRequest(request, 'DELETE', '/api/scheduler/jobs', { token, data: { id } })
-  } catch {
-    /* ignore */
+function jobCreatePayload(stamp: string): Record<string, unknown> {
+  return {
+    name: `TC-UNDO-001 Scheduler ${stamp}`,
+    description: 'TC-UNDO-001 undo/redo probe',
+    scopeType: 'organization',
+    scheduleType: 'interval',
+    scheduleValue: '15m',
+    timezone: 'UTC',
+    targetType: 'queue',
+    targetQueue: 'scheduler-execution',
+    isEnabled: true,
+    sourceType: 'user',
   }
 }
 
-test.describe('TC-UNDO-001: scheduler.jobs undo actually restores state (#2504)', () => {
+test.describe('TC-UNDO-001 scheduler.jobs undo/redo (#2504)', () => {
   test.beforeAll(() => {
     skipIfUndoTestsDisabled()
   })
 
-  test('UPDATE -> undo restores the prior name', async ({ request }) => {
-    let token: string | null = null
-    let id: string | null = null
-    try {
-      token = await getAuthToken(request, 'admin')
-      const originalName = `TC-UNDO-001 Update ${Date.now()}`
-      ;({ id } = await createJob(request, token, originalName))
-      await settleAuditClock()
+  test('jobs CRUD commands restore scalar state on undo/redo (I1/I2/I3/I5/I6)', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
 
-      const updateRes = await apiRequest(request, 'PUT', '/api/scheduler/jobs', {
-        token,
-        data: { id, name: `${originalName} RENAMED` },
-      })
-      expect(updateRes.status(), 'update returns 200').toBe(200)
-      expect((await getById(request, token, id))?.name).toBe(`${originalName} RENAMED`)
-
-      await undo(request, token, readUndoToken(updateRes))
-
-      const restored = await getById(request, token, id)
-      expect(restored, 'job still exists after update-undo').toBeTruthy()
-      expect(restored!.name, 'name restored to original by undo').toBe(originalName)
-    } finally {
-      await cleanup(request, token, id)
-    }
+    await runCrudUndoRoundTrip(request, token, {
+      label: 'scheduler.jobs',
+      collectionPath: SCHEDULER_JOBS_PATH,
+      field: 'name',
+      createPayload: jobCreatePayload,
+      updatePayload: (id, stamp) => ({ id, name: `TC-UNDO-001 Scheduler Renamed ${stamp}` }),
+    })
   })
 
-  test('DELETE -> undo re-lists the soft-deleted job', async ({ request }) => {
-    let token: string | null = null
-    let id: string | null = null
+  // §4 — manual trigger is a fire-and-forget enqueue that never goes through the
+  // command bus, so it exposes no undo affordance. The assertion holds regardless of
+  // QUEUE_STRATEGY: async returns 200 (enqueued), local returns 400 (rejected) — neither
+  // issues an `x-om-operation` undo token.
+  test('§4 trigger exposes no undo token', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let jobId: string | null = null
     try {
-      token = await getAuthToken(request, 'admin')
-      const name = `TC-UNDO-001 Delete ${Date.now()}`
-      ;({ id } = await createJob(request, token, name))
-      await settleAuditClock()
-
-      const deleteRes = await apiRequest(request, 'DELETE', '/api/scheduler/jobs', {
+      jobId = await createScheduleJob(request, token)
+      const triggerRes = await apiRequest(request, 'POST', SCHEDULER_TRIGGER_PATH, {
         token,
-        data: { id },
+        data: { id: jobId },
       })
-      expect(deleteRes.status(), 'delete returns 200').toBe(200)
-      expect(await getById(request, token, id), 'job is gone after delete').toBeFalsy()
-
-      await undo(request, token, readUndoToken(deleteRes))
-
-      const restored = await getById(request, token, id)
-      expect(restored, 'job re-materialized by delete-undo').toBeTruthy()
-      expect(restored!.name).toBe(name)
+      expect(extractOperation(triggerRes), 'trigger response carries no undo token (§4)').toBeNull()
     } finally {
-      await cleanup(request, token, id)
-    }
-  })
-
-  test('CREATE -> undo removes the created job', async ({ request }) => {
-    let token: string | null = null
-    let id: string | null = null
-    try {
-      token = await getAuthToken(request, 'admin')
-      const name = `TC-UNDO-001 Create ${Date.now()}`
-      const created = await createJob(request, token, name)
-      id = created.id
-
-      expect(await getById(request, token, id), 'job exists after create').toBeTruthy()
-
-      await undo(request, token, readUndoToken(created.res))
-
-      expect(await getById(request, token, id), 'job removed by create-undo').toBeFalsy()
-      id = null // already undone; nothing to clean up
-    } finally {
-      await cleanup(request, token, id)
+      await deleteScheduleJob(request, token, jobId)
     }
   })
 })


### PR DESCRIPTION
## Summary

Adds the full TC-UNDO-001 integration coverage for the `scheduler` module's undoable
commands, locking the already-merged #2504 fix (scheduler.jobs undo was a silent no-op
that read `logEntry.payload` instead of the command payload). Replaces the partial
hand-rolled stopgap added by #2587 with a spec built on the shared undo/redo harness,
matching the standard set by the customers undo work (#2572).

## Changes

- Rewrote `packages/scheduler/src/modules/scheduler/__integration__/TC-UNDO-001-scheduler-jobs.spec.ts`
  to use the shared harness `@open-mercato/core/helpers/integration/undoHarness`:
  - one `runCrudUndoRoundTrip` call drives `scheduler.jobs` create→update→undo→redo→delete→undo
    and asserts I1 (update→undo restores scalars + bumps `updated_at`), I2 (delete→undo
    re-materializes), I3 (create→undo removes), I5 (consumed token rejected on second undo),
    I6 (redo re-applies the after-snapshot).
  - §4 negative: `POST /api/scheduler/trigger` carries no `x-om-operation` undo token
    (`extractOperation(res) === null`) — a fire-and-forget enqueue that bypasses the command bus.
  - `skipIfUndoTestsDisabled()` in `test.beforeAll` so the suite honors `OM_INTEGRATION_UNDO_TESTS_DISABLED`.
- I4 (custom fields) is N/A — `scheduled_job` declares no custom fields (no `ce.ts`).
- Net change is one test file (+63/−156); no product code touched.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — QA regression coverage for the already-merged #2504 fix; governed by the TC-UNDO-001
convention and issue #2582 (refs #2468, tracking PR #2500), not a separate module spec.

## Testing

List the tests or commands you ran to validate the change.

- `tsc -p packages/scheduler/tsconfig.json --noEmit` → passed (exit 0).
- Skip-gate (no app): `OM_INTEGRATION_UNDO_TESTS_DISABLED=1 OM_INTEGRATION_MODULES=scheduler
  BASE_URL=http://127.0.0.1:9 npx playwright test --config .ai/qa/tests/playwright.config.ts TC-UNDO-001`
  → `2 skipped` (proves the disable flag).
- Live integration: `OM_INTEGRATION_MODULES=scheduler yarn test:integration:ephemeral --filter TC-UNDO-001`
  → `2 passed (2.1s)` against a provisioned app + Postgres:
  - `✓ jobs CRUD commands restore scalar state on undo/redo (I1/I2/I3/I5/I6)`
  - `✓ §4 trigger exposes no undo token`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- none required: test-only addition, no new strings/generators -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- added at the module-local __integration__/ path, the current convention; .ai/qa/tests/ holds only the shared Playwright config -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A: QA coverage for an already-merged fix, no module spec -->

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI (backend integration test)
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled — N/A, no UI
- [x] Loading state handled — N/A, no UI
- [x] `aria-label` on icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2582