### PR TITLE
fix(auth): Enforce user ACL grant boundaries

### DIFF
--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-051-user-acl-grant-boundary.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-051-user-acl-grant-boundary.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test';
+import { randomInt } from 'node:crypto';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+
+/**
+ * TC-AUTH-051 [P0]: User ACL grants are bounded by the actor's effective ACL (#2238)
+ *
+ * A non-superadmin actor with `auth.acl.manage` can edit user-level ACLs, but must not
+ * be able to grant features they do not personally hold. This covers the vertical
+ * privilege escalation where PUT /api/auth/users/acl previously persisted arbitrary
+ * module wildcards such as `sales.*`.
+ */
+const MANAGE_ACL_FEATURE = 'auth.acl.manage';
+const OUT_OF_SCOPE_FEATURE = 'sales.*';
+
+test.describe('TC-AUTH-051: user ACL grant boundary (#2238)', () => {
+  test('non-superadmin cannot grant features outside their effective ACL', async ({ request }) => {
+    const superadminToken = await getAuthToken(request, 'superadmin');
+    const { organizationId } = getTokenContext(superadminToken);
+    const stamp = `${Date.now()}-${randomInt(1_000_000)}`;
+    const actorEmail = `qa-tc-auth-051-actor-${stamp}@example.com`;
+    const targetEmail = `qa-tc-auth-051-target-${stamp}@example.com`;
+    const password = 'StrongSecret123!';
+    let actorRoleId: string | null = null;
+    let actorUserId: string | null = null;
+    let targetUserId: string | null = null;
+
+    try {
+      actorRoleId = await createRoleFixture(request, superadminToken, { name: `qa-tc-auth-051-${stamp}` });
+      await setRoleAclFeatures(request, superadminToken, {
+        roleId: actorRoleId,
+        features: [MANAGE_ACL_FEATURE],
+      });
+
+      actorUserId = await createUserFixture(request, superadminToken, {
+        email: actorEmail,
+        password,
+        organizationId,
+        roles: [actorRoleId],
+        name: 'QA TC-AUTH-051 Actor',
+      });
+      targetUserId = await createUserFixture(request, superadminToken, {
+        email: targetEmail,
+        password,
+        organizationId,
+        roles: [],
+        name: 'QA TC-AUTH-051 Target',
+      });
+
+      const actorToken = await getAuthToken(request, actorEmail, password);
+
+      const deniedGrant = await apiRequest(request, 'PUT', '/api/auth/users/acl', {
+        token: actorToken,
+        data: {
+          userId: targetUserId,
+          features: [MANAGE_ACL_FEATURE, OUT_OF_SCOPE_FEATURE],
+        },
+      });
+      const deniedBody = await readJsonSafe<{ error?: string }>(deniedGrant);
+      expect(deniedGrant.status(), 'out-of-scope user ACL grant should be forbidden').toBe(403);
+      expect(deniedBody?.error ?? '', 'error should name the denied feature wildcard').toContain(OUT_OF_SCOPE_FEATURE);
+
+      const aclAfterDeniedGrant = await readJsonSafe<{ hasCustomAcl?: boolean; features?: string[] }>(
+        await apiRequest(request, 'GET', `/api/auth/users/acl?userId=${encodeURIComponent(targetUserId)}`, {
+          token: superadminToken,
+        }),
+      );
+      expect(aclAfterDeniedGrant?.features ?? [], 'denied feature should not persist').not.toContain(OUT_OF_SCOPE_FEATURE);
+
+      const allowedGrant = await apiRequest(request, 'PUT', '/api/auth/users/acl', {
+        token: actorToken,
+        data: {
+          userId: targetUserId,
+          features: [MANAGE_ACL_FEATURE],
+        },
+      });
+      const allowedBody = await readJsonSafe<{ ok?: boolean }>(allowedGrant);
+      expect(allowedGrant.status(), 'actor may grant features they already hold').toBe(200);
+      expect(allowedBody?.ok, 'allowed user ACL update should report ok=true').toBe(true);
+
+      const aclAfterAllowedGrant = await readJsonSafe<{ hasCustomAcl?: boolean; features?: string[] }>(
+        await apiRequest(request, 'GET', `/api/auth/users/acl?userId=${encodeURIComponent(targetUserId)}`, {
+          token: superadminToken,
+        }),
+      );
+      expect(aclAfterAllowedGrant?.hasCustomAcl, 'target should have a custom ACL after allowed grant').toBe(true);
+      expect(aclAfterAllowedGrant?.features ?? [], 'allowed feature should persist').toContain(MANAGE_ACL_FEATURE);
+      expect(aclAfterAllowedGrant?.features ?? [], 'out-of-scope feature should still be absent').not.toContain(OUT_OF_SCOPE_FEATURE);
+    } finally {
+      await deleteUserIfExists(request, superadminToken, targetUserId);
+      await deleteUserIfExists(request, superadminToken, actorUserId);
+      await deleteRoleIfExists(request, superadminToken, actorRoleId);
+    }
+  });
+});

--- a/packages/core/src/modules/auth/api/users/acl/__tests__/grant-check.test.ts
+++ b/packages/core/src/modules/auth/api/users/acl/__tests__/grant-check.test.ts
@@ -1,0 +1,92 @@
+/** @jest-environment node */
+
+import { UserAcl } from '@open-mercato/core/modules/auth/data/entities'
+import { PUT } from '../route'
+
+const ACTOR_TENANT_ID = '123e4567-e89b-12d3-a456-426614174001'
+const ACTOR_USER_ID = '123e4567-e89b-12d3-a456-426614174002'
+const TARGET_USER_ID = '123e4567-e89b-12d3-a456-426614174003'
+
+const mockGetAuthFromRequest = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockDeleteByTags = jest.fn()
+
+const mockEm = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  persist: jest.fn(),
+  remove: jest.fn(),
+}
+
+const mockRbacService = {
+  loadAcl: jest.fn(),
+  invalidateUserCache: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'rbacService') return mockRbacService
+    if (token === 'cache') return { deleteByTags: mockDeleteByTags }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/flush', () => ({
+  withAtomicFlush: jest.fn(async (_em: unknown, phases: Array<() => unknown>) => {
+    for (const phase of phases) await phase()
+  }),
+}))
+
+describe('user ACL grant-boundary enforcement', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: ACTOR_USER_ID,
+      tenantId: ACTOR_TENANT_ID,
+      orgId: 'org-1',
+    })
+    mockFindWithDecryption.mockResolvedValue([])
+    mockRbacService.loadAcl.mockResolvedValue({
+      isSuperAdmin: false,
+      features: ['auth.acl.manage'],
+      organizations: null,
+    })
+    mockEm.findOne.mockResolvedValue(null)
+    mockEm.create.mockImplementation((_entity: unknown, values: Record<string, unknown>) => ({ ...values }))
+  })
+
+  it('PUT rejects feature grants outside the actor effective ACL', async () => {
+    const res = await PUT(
+      new Request('http://localhost/api/auth/users/acl', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          userId: TARGET_USER_ID,
+          features: ['auth.acl.manage', 'sales.*'],
+        }),
+      }),
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(403)
+    expect(body.error).toContain('Cannot grant feature wildcard sales.*')
+    expect(mockEm.create).not.toHaveBeenCalledWith(UserAcl, expect.anything())
+    expect(mockEm.persist).not.toHaveBeenCalled()
+    expect(mockRbacService.invalidateUserCache).not.toHaveBeenCalled()
+    expect(mockDeleteByTags).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/auth/api/users/acl/route.ts
+++ b/packages/core/src/modules/auth/api/users/acl/route.ts
@@ -10,7 +10,9 @@ import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
 import { UserAcl } from '@open-mercato/core/modules/auth/data/entities'
 import {
   assertActorCanAccessUserTarget,
+  assertActorCanGrantAcl,
   assertActorCanModifySuperAdminUserTarget,
+  normalizeGrantFeatureList,
 } from '@open-mercato/core/modules/auth/lib/grantChecks'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import type { EntityManager } from '@mikro-orm/postgresql'
@@ -148,8 +150,8 @@ export async function PUT(req: Request) {
     }
   }
 
-  const requestedFeatures = normalizeFeatureList(parsed.data.features)
-  const organizations = Array.isArray(parsed.data.organizations) ? parsed.data.organizations : null
+  const requestedFeatures = normalizeGrantFeatureList(parsed.data.features)
+  const organizations = normalizeOrganizations(parsed.data.organizations)
 
   let acl = await em.findOne(UserAcl, { user: parsed.data.userId as any, tenantId: auth.tenantId as any })
   // Optimistic lock: refuse a stale per-user ACL overwrite so concurrent edits
@@ -169,13 +171,30 @@ export async function PUT(req: Request) {
     }
   }
   const existingIsSuperAdmin = acl ? !!acl.isSuperAdmin : false
-  const existingFeatures = acl && Array.isArray(acl.featuresJson) ? normalizeFeatureList(acl.featuresJson) : []
+  const existingFeatures = acl ? normalizeGrantFeatureList(acl.featuresJson) : []
+
+  const requestedIsSuperAdmin = parsed.data.isSuperAdmin ?? false
+
+  try {
+    await assertActorCanGrantAcl({
+      em: em as EntityManager,
+      rbacService: rbacService as RbacService,
+      actorUserId: auth.sub,
+      tenantId: auth.tenantId ?? null,
+      organizationId: auth.orgId ?? null,
+      isSuperAdmin: requestedIsSuperAdmin,
+      features: requestedFeatures,
+      organizations,
+    })
+  } catch (err) {
+    if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
+    throw err
+  }
 
   const effectiveFeatures = actorIsSuperAdmin
     ? requestedFeatures
     : sanitizeTenantFeatures(requestedFeatures)
 
-  const requestedIsSuperAdmin = parsed.data.isSuperAdmin ?? false
   let effectiveIsSuperAdmin = requestedIsSuperAdmin
 
   if (!actorIsSuperAdmin) {
@@ -230,16 +249,9 @@ export async function PUT(req: Request) {
   })
 }
 
-function normalizeFeatureList(features: unknown): string[] {
-  if (!Array.isArray(features)) return []
-  const dedup = new Set<string>()
-  for (const value of features) {
-    if (typeof value !== 'string') continue
-    const trimmed = value.trim()
-    if (!trimmed) continue
-    dedup.add(trimmed)
-  }
-  return Array.from(dedup)
+function normalizeOrganizations(organizations: unknown): string[] | null {
+  if (!Array.isArray(organizations)) return null
+  return normalizeGrantFeatureList(organizations)
 }
 
 function sanitizeTenantFeatures(features: string[]): string[] {


### PR DESCRIPTION
## Summary

Fixes a vertical privilege-escalation gap in `PUT /api/auth/users/acl` where a non-superadmin actor with only `auth.acl.manage` could grant features they did not hold, such as `sales.*`. The user-ACL route now mirrors the role-ACL guard path by validating the requested ACL snapshot with `assertActorCanGrantAcl` before any ACL row is created, updated, or removed.

## Changes

- Enforce actor grant boundaries before persisting user-level ACL overrides.
- Reuse `normalizeGrantFeatureList` and normalize organization grants consistently with the role-ACL route.
- Add route-level regression coverage and module-local Playwright integration coverage for the #2238 attack path.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor security bug fix, no spec needed)

**Spec file path:**
N/A

## Testing

- Red check before fix: `corepack yarn workspace @open-mercato/core test --runTestsByPath src/modules/auth/api/users/acl/__tests__/grant-check.test.ts` failed with `Expected: 403, Received: 200`.
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" corepack yarn workspace @open-mercato/core test --runTestsByPath src/modules/auth/api/users/acl/__tests__/grant-check.test.ts src/modules/auth/api/roles/acl/__tests__/tenant-scoping.test.ts src/modules/auth/lib/__tests__/grantChecks.test.ts`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" corepack yarn test:integration:ephemeral --filter 'TC-AUTH-0(43|51)' --no-screenshots`
- `corepack yarn build:packages`
- `corepack yarn generate` followed by `corepack yarn build:packages`
- `git diff --check`
- `PATH="$PWD/node_modules/.bin:$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" corepack yarn workspace @open-mercato/core typecheck`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in module-local `__integration__/` coverage per `.ai/qa/AGENTS.md`.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (N/A: minor security bug fix).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes open-mercato/open-mercato#2238