### PR TITLE
fix(integrations): validate URL credential fields on save (#2816)

### DIFF
--- a/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
@@ -9,6 +9,7 @@ import {
   isCredentialsEncryptionUnavailableError,
   type CredentialsService,
 } from '../../../lib/credentials-service'
+import { collectCredentialUrlValidationErrors } from '../../../lib/credentials-field-validation'
 import {
   resolveUserFeatures,
   runIntegrationMutationGuardAfterSuccess,
@@ -128,6 +129,17 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
 
   const credentialsService = container.resolve('integrationCredentialsService') as CredentialsService
   const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+
+  const credentialFieldErrors = collectCredentialUrlValidationErrors(
+    credentialsService.getSchema(integration.id),
+    payloadData.credentials,
+  )
+  if (Object.keys(credentialFieldErrors).length > 0) {
+    return NextResponse.json(
+      { error: 'Invalid credentials payload', details: { fieldErrors: credentialFieldErrors } },
+      { status: 422 },
+    )
+  }
 
   try {
     await credentialsService.save(integration.id, payloadData.credentials, scope)

--- a/packages/core/src/modules/integrations/api/__tests__/credentials-route.test.ts
+++ b/packages/core/src/modules/integrations/api/__tests__/credentials-route.test.ts
@@ -1,0 +1,108 @@
+/** @jest-environment node */
+
+import type { IntegrationCredentialsSchema } from '@open-mercato/shared/modules/integrations/types'
+
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getIntegration } from '@open-mercato/shared/modules/integrations/types'
+import { emitIntegrationsEvent } from '../../events'
+import {
+  resolveUserFeatures,
+  runIntegrationMutationGuardAfterSuccess,
+  runIntegrationMutationGuards,
+} from '../guards'
+import { PUT } from '../[id]/credentials/route'
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/modules/integrations/types', () => ({
+  ...jest.requireActual('@open-mercato/shared/modules/integrations/types'),
+  getIntegration: jest.fn(),
+}))
+
+jest.mock('../../events', () => ({
+  emitIntegrationsEvent: jest.fn(),
+}))
+
+jest.mock('../guards', () => ({
+  resolveUserFeatures: jest.fn(() => []),
+  runIntegrationMutationGuards: jest.fn(),
+  runIntegrationMutationGuardAfterSuccess: jest.fn(),
+}))
+
+const akeneoSchema: IntegrationCredentialsSchema = {
+  fields: [
+    { key: 'apiUrl', label: 'Akeneo URL', type: 'url', required: true },
+    { key: 'clientId', label: 'Client ID', type: 'text', required: true },
+  ],
+}
+
+function buildRequest(credentials: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/integrations/sync_akeneo/credentials', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ credentials }),
+  })
+}
+
+describe('integrations credentials PUT route — URL validation', () => {
+  const saveMock = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    saveMock.mockReset()
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ tenantId: 't1', orgId: 'o1', sub: 'u1' })
+    ;(getIntegration as jest.Mock).mockReturnValue({ id: 'sync_akeneo', title: 'Akeneo PIM' })
+    ;(runIntegrationMutationGuards as jest.Mock).mockResolvedValue({ ok: true })
+    ;(createRequestContainer as jest.Mock).mockResolvedValue({
+      resolve: (key: string) => {
+        if (key === 'integrationCredentialsService') {
+          return { getSchema: () => akeneoSchema, save: saveMock }
+        }
+        throw new Error(`unexpected resolve(${key})`)
+      },
+    })
+  })
+
+  it('rejects a script fragment in a url field with 422 and does not persist', async () => {
+    const response = await PUT(buildRequest({ apiUrl: '<script>alert(1)</script>', clientId: 'abc' }), {
+      params: { id: 'sync_akeneo' },
+    })
+    expect(response.status).toBe(422)
+    const body = await response.json()
+    expect(body.details.fieldErrors.apiUrl).toBe('Akeneo URL must be a valid http(s) URL.')
+    expect(saveMock).not.toHaveBeenCalled()
+    expect(emitIntegrationsEvent).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed url with embedded markup', async () => {
+    const response = await PUT(
+      buildRequest({ apiUrl: 'http://example.com<script>alert(1)</script>', clientId: 'abc' }),
+      { params: { id: 'sync_akeneo' } },
+    )
+    expect(response.status).toBe(422)
+    expect(saveMock).not.toHaveBeenCalled()
+  })
+
+  it('persists a valid http(s) url', async () => {
+    const response = await PUT(
+      buildRequest({ apiUrl: 'https://your-instance.cloud.akeneo.com', clientId: 'abc' }),
+      { params: { id: 'sync_akeneo' } },
+    )
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toEqual({ ok: true })
+    expect(saveMock).toHaveBeenCalledWith(
+      'sync_akeneo',
+      { apiUrl: 'https://your-instance.cloud.akeneo.com', clientId: 'abc' },
+      { organizationId: 'o1', tenantId: 't1' },
+    )
+    expect(runIntegrationMutationGuardAfterSuccess).toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
@@ -47,6 +47,7 @@ import {
   resolveIntegrationDetailWidgetSpotId,
   resolveRequestedIntegrationDetailTab,
 } from '../detail-page-widgets'
+import { isValidCredentialUrl } from '../../../lib/credentials-field-validation'
 
 type CredentialField = IntegrationCredentialField
 type BuiltInIntegrationDetailTab = 'credentials' | 'version' | 'health' | 'logs' | 'data-sync-schedule'
@@ -870,6 +871,18 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
             code: z.ZodIssueCode.custom,
             path: [field.key],
             message: t('integrations.detail.credentials.validation.tooLong', 'Value is too long.'),
+          })
+        }
+
+        if (
+          field.type === 'url'
+          && normalizedValue.trim().length > 0
+          && !isValidCredentialUrl(normalizedValue.trim())
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [field.key],
+            message: t('integrations.detail.credentials.validation.url', '{field} must be a valid http(s) URL.', { field: field.label }),
           })
         }
 

--- a/packages/core/src/modules/integrations/i18n/de.json
+++ b/packages/core/src/modules/integrations/i18n/de.json
@@ -96,6 +96,7 @@
   "integrations.detail.credentials.validation.required": "{field} is required.",
   "integrations.detail.credentials.validation.text": "Enter a valid value.",
   "integrations.detail.credentials.validation.tooLong": "Value is too long.",
+  "integrations.detail.credentials.validation.url": "{field} must be a valid http(s) URL.",
   "integrations.detail.disable": "Deaktivieren",
   "integrations.detail.enable": "Aktivieren",
   "integrations.detail.health.check": "Prüfung ausführen",

--- a/packages/core/src/modules/integrations/i18n/en.json
+++ b/packages/core/src/modules/integrations/i18n/en.json
@@ -96,6 +96,7 @@
   "integrations.detail.credentials.validation.required": "{field} is required.",
   "integrations.detail.credentials.validation.text": "Enter a valid value.",
   "integrations.detail.credentials.validation.tooLong": "Value is too long.",
+  "integrations.detail.credentials.validation.url": "{field} must be a valid http(s) URL.",
   "integrations.detail.disable": "Disable",
   "integrations.detail.enable": "Enable",
   "integrations.detail.health.check": "Run Check",

--- a/packages/core/src/modules/integrations/i18n/es.json
+++ b/packages/core/src/modules/integrations/i18n/es.json
@@ -96,6 +96,7 @@
   "integrations.detail.credentials.validation.required": "{field} is required.",
   "integrations.detail.credentials.validation.text": "Enter a valid value.",
   "integrations.detail.credentials.validation.tooLong": "Value is too long.",
+  "integrations.detail.credentials.validation.url": "{field} must be a valid http(s) URL.",
   "integrations.detail.disable": "Desactivar",
   "integrations.detail.enable": "Activar",
   "integrations.detail.health.check": "Ejecutar verificación",

--- a/packages/core/src/modules/integrations/i18n/pl.json
+++ b/packages/core/src/modules/integrations/i18n/pl.json
@@ -96,6 +96,7 @@
   "integrations.detail.credentials.validation.required": "{field} is required.",
   "integrations.detail.credentials.validation.text": "Enter a valid value.",
   "integrations.detail.credentials.validation.tooLong": "Value is too long.",
+  "integrations.detail.credentials.validation.url": "{field} must be a valid http(s) URL.",
   "integrations.detail.disable": "Wyłącz",
   "integrations.detail.enable": "Włącz",
   "integrations.detail.health.check": "Sprawdź",

--- a/packages/core/src/modules/integrations/lib/__tests__/credentials-field-validation.test.ts
+++ b/packages/core/src/modules/integrations/lib/__tests__/credentials-field-validation.test.ts
@@ -1,0 +1,82 @@
+/** @jest-environment node */
+
+import type { IntegrationCredentialsSchema } from '@open-mercato/shared/modules/integrations/types'
+import {
+  collectCredentialUrlValidationErrors,
+  isValidCredentialUrl,
+} from '../credentials-field-validation'
+
+describe('isValidCredentialUrl', () => {
+  it('accepts valid http(s) URLs', () => {
+    expect(isValidCredentialUrl('https://your-instance.cloud.akeneo.com')).toBe(true)
+    expect(isValidCredentialUrl('http://example.com')).toBe(true)
+    expect(isValidCredentialUrl('https://example.com:8443/path?query=1')).toBe(true)
+  })
+
+  it('rejects script fragments and malformed URLs from the bug report', () => {
+    expect(isValidCredentialUrl('<script>alert(1)</script>')).toBe(false)
+    expect(isValidCredentialUrl('http://example.com<script>alert(1)</script>')).toBe(false)
+  })
+
+  it('rejects arbitrary text and non-http protocols', () => {
+    expect(isValidCredentialUrl('not a url')).toBe(false)
+    expect(isValidCredentialUrl('example.com')).toBe(false)
+    expect(isValidCredentialUrl('javascript:alert(1)')).toBe(false)
+    expect(isValidCredentialUrl('ftp://example.com')).toBe(false)
+    expect(isValidCredentialUrl('')).toBe(false)
+  })
+})
+
+describe('collectCredentialUrlValidationErrors', () => {
+  const schema: IntegrationCredentialsSchema = {
+    fields: [
+      { key: 'apiUrl', label: 'Akeneo URL', type: 'url', required: true },
+      { key: 'clientId', label: 'Client ID', type: 'text', required: true },
+      { key: 'clientSecret', label: 'Client Secret', type: 'secret', required: true },
+    ],
+  }
+
+  it('flags an invalid url field with a field-keyed message', () => {
+    const errors = collectCredentialUrlValidationErrors(schema, {
+      apiUrl: '<script>alert(1)</script>',
+      clientId: 'abc',
+      clientSecret: 'def',
+    })
+    expect(errors).toEqual({ apiUrl: 'Akeneo URL must be a valid http(s) URL.' })
+  })
+
+  it('returns no errors for a valid url', () => {
+    const errors = collectCredentialUrlValidationErrors(schema, {
+      apiUrl: 'https://your-instance.cloud.akeneo.com',
+      clientId: 'abc',
+    })
+    expect(errors).toEqual({})
+  })
+
+  it('skips empty/absent url values (required-ness is enforced elsewhere)', () => {
+    expect(collectCredentialUrlValidationErrors(schema, { apiUrl: '' })).toEqual({})
+    expect(collectCredentialUrlValidationErrors(schema, { apiUrl: '   ' })).toEqual({})
+    expect(collectCredentialUrlValidationErrors(schema, {})).toEqual({})
+  })
+
+  it('does not validate non-url field types as URLs', () => {
+    const errors = collectCredentialUrlValidationErrors(schema, {
+      clientId: 'not-a-url',
+      clientSecret: '<script>alert(1)</script>',
+    })
+    expect(errors).toEqual({})
+  })
+
+  it('supports a custom message builder', () => {
+    const errors = collectCredentialUrlValidationErrors(
+      schema,
+      { apiUrl: 'broken' },
+      (field) => `bad:${field.key}`,
+    )
+    expect(errors).toEqual({ apiUrl: 'bad:apiUrl' })
+  })
+
+  it('returns no errors when the schema is undefined', () => {
+    expect(collectCredentialUrlValidationErrors(undefined, { apiUrl: 'broken' })).toEqual({})
+  })
+})

--- a/packages/core/src/modules/integrations/lib/credentials-field-validation.ts
+++ b/packages/core/src/modules/integrations/lib/credentials-field-validation.ts
@@ -1,0 +1,53 @@
+import type { IntegrationCredentialsSchema } from '@open-mercato/shared/modules/integrations/types'
+
+const ALLOWED_CREDENTIAL_URL_PROTOCOLS = new Set(['http:', 'https:'])
+
+/**
+ * Validates that a credential value declared as `type: 'url'` is a syntactically
+ * valid http(s) URL. Rejects free text, script fragments, and malformed URLs such as
+ * `<script>alert(1)</script>` or `http://example.com<script>alert(1)</script>` — the
+ * WHATWG URL parser refuses forbidden host code points (`<`, `>`) and missing schemes.
+ */
+export function isValidCredentialUrl(value: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(value)
+  } catch {
+    return false
+  }
+  if (!ALLOWED_CREDENTIAL_URL_PROTOCOLS.has(parsed.protocol)) return false
+  if (!parsed.hostname) return false
+  return true
+}
+
+export type CredentialUrlMessageBuilder = (field: { key: string; label: string }) => string
+
+const defaultUrlMessageBuilder: CredentialUrlMessageBuilder = (field) =>
+  `${field.label || field.key} must be a valid http(s) URL.`
+
+/**
+ * Collects field-level validation errors for `url`-typed credential fields against the
+ * supplied integration credentials schema. Empty/absent values are skipped (required-ness
+ * is enforced separately); only non-empty string values are checked for URL validity.
+ *
+ * Used by both the server-side credentials route (security enforcement) and the
+ * client-side credential form (immediate feedback) so the rule stays single-sourced.
+ */
+export function collectCredentialUrlValidationErrors(
+  schema: IntegrationCredentialsSchema | undefined,
+  credentials: Record<string, unknown>,
+  buildMessage: CredentialUrlMessageBuilder = defaultUrlMessageBuilder,
+): Record<string, string> {
+  const fieldErrors: Record<string, string> = {}
+  if (!schema?.fields) return fieldErrors
+  for (const field of schema.fields) {
+    if (field.type !== 'url') continue
+    const value = credentials[field.key]
+    if (typeof value !== 'string') continue
+    if (value.trim().length === 0) continue
+    if (!isValidCredentialUrl(value)) {
+      fieldErrors[field.key] = buildMessage({ key: field.key, label: field.label })
+    }
+  }
+  return fieldErrors
+}


### PR DESCRIPTION
Fixes #2816

## Problem
The Akeneo PIM **Akeneo URL** credential field (and any integration credential field declared as `type: 'url'`) accepted arbitrary text, including script fragments like `<script>alert(1)</script>` or `http://example.com<script>alert(1)</script>`. The value was saved and the request returned `200 OK` — no URL validation existed on either the client form or the server route.

## Root Cause
- `packages/core/src/modules/integrations/api/[id]/credentials/route.ts` validated only the generic `saveCredentialsSchema` (record of strings/numbers/booleans). It never checked submitted values against the integration's declared per-field types.
- The client credential form (`backend/integrations/[id]/page.tsx`) validated `boolean`, required, length, and `select` options, but had no branch for `url`-typed fields.

## What Changed
- New single-sourced helper `packages/core/src/modules/integrations/lib/credentials-field-validation.ts`:
  - `isValidCredentialUrl(value)` — accepts only syntactically valid `http(s)` URLs (rejects script fragments, missing schemes, forbidden host characters, non-http protocols).
  - `collectCredentialUrlValidationErrors(schema, credentials)` — returns field-keyed errors for invalid `url` fields; empty/absent values are skipped (required-ness is handled separately).
- **Server (security enforcement):** the credentials `PUT` route now rejects invalid `url` values with `422` and `details.fieldErrors` **before** persisting.
- **Client (UX):** the credential form surfaces an inline validation message for invalid `url` fields, via a new i18n key `integrations.detail.credentials.validation.url` (added to en/de/es/pl).

The fix is generic — it protects every integration that declares a `url` credential field, not only Akeneo.

## Tests
- `lib/__tests__/credentials-field-validation.test.ts` — unit coverage for the helper, including the exact payloads from the issue.
- `api/__tests__/credentials-route.test.ts` — proves the `PUT` route returns `422` and does not persist for script/malformed URLs, and persists valid `http(s)` URLs.
- Ran: `@open-mercato/core` unit tests (new + all 40 existing integrations tests pass), `yarn build:packages`, `yarn generate`, core `typecheck`, `yarn i18n:check-sync` (in sync). `yarn i18n:check-usage` is advisory.

## Backward Compatibility
- No contract surface changes. The `422` body reuses the existing `{ error, details: { fieldErrors } }` shape the client already reads. New helper exports and the i18n key are additive. The only behavior change is rejecting previously-accepted invalid URLs — the intended fix.

## Security impact
- Adds input validation (allow-list to `http`/`https`) on integration credential URL fields at the API boundary, closing a stored-text/markup acceptance gap (no encryption/auth/logging surfaces changed).