### PR TITLE
security(auth): expose hasPassword only on id-scoped user GET (#2688)

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
@@ -177,6 +177,54 @@ describe('GET /api/auth/users', () => {
     expect(mockContainer.resolve).not.toHaveBeenCalled()
   })
 
+  test('omits hasPassword from the bulk list response to avoid invite-state enumeration', async () => {
+    const listedUserId = '423e4567-e89b-12d3-a456-426614174900'
+    mockEm.findAndCount.mockResolvedValueOnce([
+      [
+        {
+          id: listedUserId,
+          email: 'listed@example.com',
+          name: 'Listed User',
+          tenantId,
+          organizationId,
+          passwordHash: '$2a$10$hashedsecretvalue',
+        },
+      ],
+      1,
+    ])
+
+    const response = await GET(makeRequest('/api/auth/users?page=1&pageSize=50'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.items).toHaveLength(1)
+    expect(body.items[0]).not.toHaveProperty('hasPassword')
+  })
+
+  test('exposes hasPassword only on the id-scoped per-user GET used by the edit view', async () => {
+    const targetUserId = '423e4567-e89b-12d3-a456-426614174901'
+    mockEm.findAndCount.mockResolvedValueOnce([
+      [
+        {
+          id: targetUserId,
+          email: 'edit-target@example.com',
+          name: 'Edit Target',
+          tenantId,
+          organizationId,
+          passwordHash: '$2a$10$hashedsecretvalue',
+        },
+      ],
+      1,
+    ])
+
+    const response = await GET(makeRequest(`/api/auth/users?id=${targetUserId}&page=1&pageSize=1`))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.items).toHaveLength(1)
+    expect(body.items[0]).toMatchObject({ id: targetUserId, hasPassword: true })
+  })
+
   test('returns an empty collection for non-superadmin users without tenant context', async () => {
     mockGetAuthFromRequest.mockResolvedValueOnce({
       sub: 'user-1',

--- a/packages/core/src/modules/auth/api/users/route.ts
+++ b/packages/core/src/modules/auth/api/users/route.ts
@@ -81,6 +81,7 @@ const userListItemSchema = z.object({
   tenantName: z.string().nullable(),
   roles: z.array(z.string()),
   roleIds: z.array(z.string().uuid()).optional(),
+  hasPassword: z.boolean().optional(),
   updatedAt: z.string().nullable().optional(),
 })
 
@@ -439,7 +440,7 @@ export async function GET(req: Request) {
       tenantName: u.tenantId ? tenantMap[String(u.tenantId)] ?? String(u.tenantId) : null,
       roles: roleMap[uid] || [],
       roleIds: roleIdMap[uid] || [],
-      hasPassword: !!u.passwordHash,
+      ...(id ? { hasPassword: !!u.passwordHash } : {}),
       updatedAt: u.updatedAt instanceof Date ? u.updatedAt.toISOString() : null,
       ...(cfByUser[uid] || {}),
     }


### PR DESCRIPTION
Fixes #2688

## Problem
`GET /api/auth/users` attached `hasPassword` to **every** row of the bulk list response. Because the create flow supports `sendInviteEmail` (provisioning a user with no password until they accept), this flag let any authenticated caller holding `auth.users.list` distinguish pending-invite accounts (`hasPassword: false`) from activated ones — without opening the per-user edit view. Invite/activation and reset flows tend to carry weaker friction, so pending-invite rows are higher-value targets, and the bulk list made harvesting them trivial.

## Root Cause
The list-item projection in `GET` unconditionally set `hasPassword: !!u.passwordHash` for every row. The same handler serves both the bulk list and the id-scoped per-user fetch (`?id=<uuid>`) that the edit page uses, so the flag leaked on the bulk path even though only the edit view needs it.

## What Changed
- `packages/core/src/modules/auth/api/users/route.ts`
  - Emit `hasPassword` **only** when the request is the id-scoped per-user GET (`?id=<uuid>`); omit it from the bulk list response.
  - Document `hasPassword` as an optional field on `userListItemSchema` (OpenAPI) so the id-scoped exposure is honest. This is additive.
- The edit view (`backend/users/[id]/edit/page.tsx`) reads `hasPassword` via `/api/auth/users?id=…`, so it is unaffected.

## Tests
- Added unit test: bulk list response (no `id`) must **not** include `hasPassword`.
- Added unit test: id-scoped GET (`?id=`) must still return `hasPassword: true`.
- `yarn workspace @open-mercato/core test users.route.test.ts` → 44 passed.
- `yarn turbo run typecheck --filter=@open-mercato/core` → passes.
- Existing integration coverage `TC-AUTH-CRUDFORM-001` reads back via `?id=` (id-scoped), so its `hasPassword: true` assertions remain valid.

## Security impact
- **Information exposure (authorization):** removes an account-state enumeration vector (`invited` vs `activated`) from the bulk `GET /api/auth/users` response. The flag is now scoped to the explicit per-user edit fetch, which already requires knowing the user id.
- No change to authentication, password hashing, session tokens, encryption, or audit trails.
- **Out of scope (deliberate):** the issue also suggests an optional `rateLimit` on the list GET to bound enumeration. Left as a follow-up to keep this fix minimal and low-risk — it requires wiring rate-limit infra into the custom GET handler.

## Backward Compatibility
- The documented `userListItemSchema` never declared `hasPassword`, so no documented contract field is removed; the schema change is additive (`hasPassword?: boolean`).
- Behavioral note: a consumer that read `hasPassword` from the **bulk list** loses it on that path (it remains available on the id-scoped GET). This narrowing is the intended security fix.

Suggested labels: `review`, `security`, `skip-qa` (no UI change; behavior covered by unit tests).