### PR TITLE
security(audit_logs): fail closed on null-tenant/org undo scope (#2685)

### DIFF
--- a/packages/core/src/modules/audit_logs/api/__tests__/undo.route.test.ts
+++ b/packages/core/src/modules/audit_logs/api/__tests__/undo.route.test.ts
@@ -152,4 +152,69 @@ describe('POST /api/audit_logs/audit-logs/actions/undo', () => {
     )
     expect(mockCommandBus.undo).toHaveBeenCalledWith('token-org-1', expect.anything())
   })
+
+  // Regression for issue #2685 — a caller with a null tenantId (tenant-less global
+  // account or unscoped API key) must NOT undo a tenant-scoped row. The old guard
+  // (`target.tenantId && auth.tenantId && ...`) short-circuited to "allow" whenever
+  // auth.tenantId was null, leaking cross-tenant undo.
+  it('rejects a tenant-less caller undoing a tenant-scoped row', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: null,
+      orgId: null,
+    })
+    const target = {
+      id: 'log-1',
+      actorUserId: 'user-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      resourceKind: 'auth.user',
+      resourceId: 'user-42',
+      executionState: 'done',
+    }
+    mockLogs.findByUndoToken.mockResolvedValue(target)
+    mockLogs.latestUndoableForResource.mockResolvedValue(target)
+    mockLogs.latestUndoableForActor.mockResolvedValue(target)
+
+    const res = await POST(makeRequest({ undoToken: 'token-1' }))
+    expect(res.status).toBe(400)
+    expect(mockCommandBus.undo).not.toHaveBeenCalled()
+  })
+
+  // Regression for issue #2685 — a regular caller (no audit_logs.undo_tenant) whose
+  // organization scope resolves to null must NOT undo an org-scoped row. The old org
+  // guard (`target.organizationId && scopedOrgId && ...`) skipped rejection when
+  // scopedOrgId was null; only tenant-level undoers may legitimately leave org null.
+  it('rejects a regular caller with null org scope undoing an org-scoped row', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    const { resolveFeatureCheckContext } = await import('@open-mercato/core/modules/directory/utils/organizationScope')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: null,
+    })
+    ;(resolveFeatureCheckContext as jest.Mock).mockResolvedValue({
+      organizationId: null,
+      scope: { allowedIds: null },
+    })
+    mockRbac.userHasAllFeatures.mockResolvedValue(false)
+
+    const target = {
+      id: 'log-2',
+      actorUserId: 'user-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      resourceKind: 'auth.user',
+      resourceId: 'user-42',
+      executionState: 'done',
+    }
+    mockLogs.findByUndoToken.mockResolvedValue(target)
+    mockLogs.latestUndoableForResource.mockResolvedValue(target)
+    mockLogs.latestUndoableForActor.mockResolvedValue(target)
+
+    const res = await POST(makeRequest({ undoToken: 'token-2' }))
+    expect(res.status).toBe(400)
+    expect(mockCommandBus.undo).not.toHaveBeenCalled()
+  })
 })

--- a/packages/core/src/modules/audit_logs/api/audit-logs/actions/undo/route.ts
+++ b/packages/core/src/modules/audit_logs/api/audit-logs/actions/undo/route.ts
@@ -65,11 +65,22 @@ export async function POST(req: Request) {
   if (target.actorUserId && target.actorUserId !== auth.sub && !canUndoTenant) {
     return NextResponse.json({ error: 'Undo token not available' }, { status: 400 })
   }
-  if (target.tenantId && auth.tenantId && target.tenantId !== auth.tenantId) {
+  // Fail closed on tenant scope: `audit_logs.undo_tenant` only widens scope WITHIN a
+  // tenant, never across tenants, so a tenant-scoped target always requires a caller
+  // bound to that same tenant. A caller whose tenantId is null (tenant-less global
+  // account or unscoped API key) must never undo a tenant-scoped row (issue #2685).
+  if (target.tenantId && target.tenantId !== (auth.tenantId ?? null)) {
     return NextResponse.json({ error: 'Undo token not available' }, { status: 400 })
   }
   const scopedOrgId = canUndoTenant ? organizationId ?? null : organizationId ?? auth.orgId ?? null
-  if (target.organizationId && scopedOrgId && target.organizationId !== scopedOrgId) {
+  // Tenant-level undoers may undo across organizations within the tenant, so an
+  // unresolved (null) caller org is allowed and only an explicit mismatch is rejected.
+  // Every other caller must resolve to the target's own organization — a null caller
+  // org must not bypass an org-scoped target (issue #2685).
+  const orgScopeMismatch = canUndoTenant
+    ? Boolean(target.organizationId && scopedOrgId && target.organizationId !== scopedOrgId)
+    : Boolean(target.organizationId && target.organizationId !== scopedOrgId)
+  if (orgScopeMismatch) {
     return NextResponse.json({ error: 'Undo token not available' }, { status: 400 })
   }
 


### PR DESCRIPTION
Fixes #2685

## Problem
The audit-log undo endpoint's tenant/organization guards only rejected a mismatch when **both** the target row **and** the authenticated principal carried a non-null value. A principal whose `auth.tenantId` (or resolved org) is null — a misconfigured global account or a tenant-less API key — short-circuited the cross-tenant check to "allow" and could undo an action log belonging to a different tenant (given the row's undo token and being recorded as its actor).

## Root Cause
`packages/core/src/modules/audit_logs/api/audit-logs/actions/undo/route.ts`:
- `if (target.tenantId && auth.tenantId && target.tenantId !== auth.tenantId)` — the `auth.tenantId &&` term made a null caller tenant skip rejection.
- `if (target.organizationId && scopedOrgId && target.organizationId !== scopedOrgId)` — the `scopedOrgId &&` term let a null caller org bypass an org-scoped target.

The null-org bypass is **intentional only** for tenant-level undoers (`audit_logs.undo_tenant`), who may undo across organizations within their tenant (issue #2398). For every other caller it was a hole.

## What Changed
- Tenant guard is now unconditional: a tenant-scoped target always requires a caller bound to that same tenant (`undo_tenant` widens scope *within* a tenant, never across), so a null caller tenant is rejected.
- Org guard branches on `canUndoTenant`: tenant-level undoers keep the existing optional-org-pin latitude; every other caller must resolve to the target's own organization, so a null caller org no longer bypasses an org-scoped target.

## Tests
- `packages/core/src/modules/audit_logs/api/__tests__/undo.route.test.ts`: two new regression tests — (1) a tenant-less caller cannot undo a tenant-scoped row; (2) a regular caller with null org scope cannot undo an org-scoped row. Both assert `commandBus.undo` is never called.
- Existing undo tests (including the #2398 tenant-level org-undo case) and the full `audit_logs/api/__tests__` suite (18 tests) still pass.

## Security impact
Closes a cross-tenant authorization bypass on a state-mutating endpoint (undo replays a command). The fix is fail-closed: ambiguous/unscoped principals are now denied rather than allowed. No API response fields, event IDs, DI names, or other contract surfaces changed.

## Backward Compatibility
No contract surface changes. Behavior is preserved for correctly-scoped callers and for tenant-level undoers; only the previously-leaky null-scope paths now fail closed.