### PR TITLE
security(observability): stop leaking credential headers to New Relic (#2666)

### DIFF
--- a/apps/mercato/src/__tests__/newrelic-config.test.ts
+++ b/apps/mercato/src/__tests__/newrelic-config.test.ts
@@ -1,0 +1,43 @@
+/** @jest-environment node */
+// Regression for issue #2666 — the New Relic agent config must not ship credential
+// or signing-secret request headers (most importantly `x-api-key`, the canonical
+// staff/API bearer credential) onto transaction traces or forwarded logs.
+import path from 'path'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const newrelicConfig = require(path.resolve(__dirname, '../../../../newrelic.js')) as {
+  sensitiveRequestHeaders: string[]
+  config: {
+    allow_all_headers?: boolean
+    attributes?: { include?: string[]; exclude?: string[] }
+  }
+}
+
+describe('newrelic.js header capture policy', () => {
+  it('does not enable allow_all_headers (fails closed for unknown custom headers)', () => {
+    // The leak in #2666 was `allow_all_headers: true`, which captures every inbound
+    // header — including credential headers the platform reads (x-api-key, x-sudo-token,
+    // webhook signatures). Keeping it disabled means future custom auth headers are not
+    // captured by default, so they cannot silently leak.
+    expect(newrelicConfig.config.allow_all_headers).not.toBe(true)
+  })
+
+  it('excludes every known credential/secret-bearing request header', () => {
+    const exclude = newrelicConfig.config.attributes?.exclude ?? []
+    const requiredSensitiveHeaders = [
+      'cookie',
+      'authorization',
+      'x-api-key',
+      'x-sudo-token',
+      'x-domain-check-secret',
+      'x-domain-resolve-secret',
+      'x-force-host-secret',
+      'x-webhook-signature',
+      'svix-signature',
+    ]
+    for (const header of requiredSensitiveHeaders) {
+      expect(newrelicConfig.sensitiveRequestHeaders).toContain(header)
+      expect(exclude).toContain(`request.headers.${header}`)
+    }
+  })
+})

--- a/newrelic.js
+++ b/newrelic.js
@@ -1,4 +1,25 @@
 'use strict'
+
+// Request headers that carry credentials or signing secrets and must never reach
+// New Relic transaction traces or forwarded logs. `allow_all_headers` is deliberately
+// NOT enabled: with it off the agent only records its built-in safe header set, so any
+// future custom auth header fails closed (is not captured) instead of leaking until
+// someone remembers to add it here. The explicit exclude list is defense-in-depth that
+// also covers forwarded log records and anything in the agent's default header set.
+const sensitiveRequestHeaders = [
+  'cookie',
+  'authorization',
+  'x-api-key',
+  'x-sudo-token',
+  'x-domain-check-secret',
+  'x-domain-resolve-secret',
+  'x-force-host-secret',
+  'x-webhook-signature',
+  'svix-signature',
+]
+
+exports.sensitiveRequestHeaders = sensitiveRequestHeaders
+
 exports.config = {
   app_name: [process.env.NEW_RELIC_APP_NAME || 'open-mercato'],
   license_key: process.env.NEW_RELIC_LICENSE_KEY,
@@ -10,9 +31,11 @@ exports.config = {
   },
   slow_sql: {
     enabled: true,
-  },  
+  },
   logging: { level: 'info' },
   application_logging: { forwarding: { enabled: true } },
-  allow_all_headers: true,
-  attributes: { include: ['request.*'], exclude: ['request.headers.cookie', 'request.headers.authorization'] },
+  attributes: {
+    include: ['request.*'],
+    exclude: sensitiveRequestHeaders.map((name) => `request.headers.${name}`),
+  },
 }


### PR DESCRIPTION
Fixes #2666

## Problem
`newrelic.js` set `allow_all_headers: true`, which instructs the New Relic Node agent to capture **every** inbound request header on transaction traces and forwarded logs. The matching `attributes.exclude` list only filtered `cookie` and `authorization`. This platform authenticates API/staff requests via the `x-api-key` header (`packages/shared/src/lib/auth/server.ts` `extractApiKey`), so every authenticated request shipped its plaintext `x-api-key` — a long-lived bearer credential — into New Relic, where anyone with NR access could read and replay it. The same gap exposed other credential/secret-bearing headers (`x-sudo-token`, webhook signing headers).

## Root Cause
`newrelic.js:16-17` — `allow_all_headers: true` combined with an exclude list of only two headers.

## What Changed
- Removed `allow_all_headers: true`. With it off the agent only records its built-in safe header set, so any **future** custom auth header fails closed (is not captured) rather than leaking until someone updates a deny list.
- Added an explicit credential/secret header deny list as defense-in-depth — covering forwarded log records and the agent's default header set — built by enumerating the secret-bearing request headers the platform actually reads (`x-api-key`, `x-sudo-token`, `x-domain-check-secret`, `x-domain-resolve-secret`, `x-force-host-secret`, `x-webhook-signature`, `svix-signature`, plus the original `cookie`/`authorization`).

## Tests
- `apps/mercato/src/__tests__/newrelic-config.test.ts`: new guard test asserting (1) `allow_all_headers` is not enabled, and (2) every known credential header is present in both the deny list and the resolved `attributes.exclude`. Regresses if the leak is reintroduced.

## Security impact
Stops durable storage of replayable bearer credentials (API keys, sudo/step-up tokens, webhook signatures) in a third-party observability platform. Fail-closed posture: unknown headers are no longer captured by default. No application behavior, API responses, or contract surfaces change — only observability capture is narrowed. Non-secret request attributes (`request.*` minus the excluded headers) are still collected for tracing.

## Backward Compatibility
No contract surface changes. Operators who relied on `allow_all_headers` to inspect arbitrary custom headers in New Relic will no longer see credential headers; non-sensitive request attributes remain captured.