### PR TITLE
fix(dev): guard ps memory-monitor against synchronous spawn throw (#2682)

### DIFF
--- a/apps/mercato/scripts/__tests__/dev-memory-monitor.test.mjs
+++ b/apps/mercato/scripts/__tests__/dev-memory-monitor.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import {
+  getProcessTreeMemoryBytes,
+  parseProcessTreeMemoryBytes,
+} from '../dev-memory-monitor.mjs'
+
+function createFakeChild() {
+  const child = new EventEmitter()
+  child.stdout = new EventEmitter()
+  child.stdout.setEncoding = () => {}
+  return child
+}
+
+test('resolves null without throwing when spawn throws synchronously', async () => {
+  const throwingSpawn = () => {
+    throw Object.assign(new Error('spawn ps ENAMETOOLONG'), { code: 'ENAMETOOLONG' })
+  }
+
+  const result = await getProcessTreeMemoryBytes(1234, { spawn: throwingSpawn })
+  assert.equal(result, null)
+})
+
+test('resolves null for non-positive or non-integer pids without spawning', async () => {
+  let spawnCalls = 0
+  const trackingSpawn = () => {
+    spawnCalls += 1
+    return createFakeChild()
+  }
+
+  assert.equal(await getProcessTreeMemoryBytes(0, { spawn: trackingSpawn }), null)
+  assert.equal(await getProcessTreeMemoryBytes(-1, { spawn: trackingSpawn }), null)
+  assert.equal(await getProcessTreeMemoryBytes(1.5, { spawn: trackingSpawn }), null)
+  assert.equal(spawnCalls, 0)
+})
+
+test('resolves null when ps exits with a non-zero code', async () => {
+  const child = createFakeChild()
+  const result = getProcessTreeMemoryBytes(1234, { spawn: () => child })
+  child.emit('close', 1)
+  assert.equal(await result, null)
+})
+
+test('sums RSS of the process subtree on the happy path', async () => {
+  const child = createFakeChild()
+  const result = getProcessTreeMemoryBytes(100, { spawn: () => child })
+
+  child.stdout.emit('data', '100 1 2048\n')
+  child.stdout.emit('data', '200 100 1024\n300 999 4096\n')
+  child.emit('close', 0)
+
+  assert.equal(await result, (2048 + 1024) * 1024)
+})
+
+test('parseProcessTreeMemoryBytes returns null when the root pid is absent', () => {
+  assert.equal(parseProcessTreeMemoryBytes('200 1 1024\n', 100), null)
+})

--- a/apps/mercato/scripts/dev-memory-monitor.mjs
+++ b/apps/mercato/scripts/dev-memory-monitor.mjs
@@ -1,0 +1,78 @@
+import defaultSpawn from 'cross-spawn'
+
+export function parseProcessTreeMemoryBytes(output, rootPid) {
+  const nodes = new Map()
+
+  for (const rawLine of output.split('\n')) {
+    const line = rawLine.trim()
+    if (!line) continue
+
+    const match = line.match(/^(\d+)\s+(\d+)\s+(\d+)$/)
+    if (!match) continue
+
+    const pid = Number.parseInt(match[1], 10)
+    const ppid = Number.parseInt(match[2], 10)
+    const rssKb = Number.parseInt(match[3], 10)
+    nodes.set(pid, { ppid, rssKb })
+  }
+
+  if (!nodes.has(rootPid)) return null
+
+  let totalKb = 0
+  const pending = [rootPid]
+  const seen = new Set()
+
+  while (pending.length > 0) {
+    const pid = pending.pop()
+    if (!Number.isInteger(pid) || seen.has(pid)) continue
+    seen.add(pid)
+
+    const node = nodes.get(pid)
+    if (node) {
+      totalKb += node.rssKb
+    }
+
+    for (const [candidatePid, candidateNode] of nodes.entries()) {
+      if (candidateNode.ppid === pid && !seen.has(candidatePid)) {
+        pending.push(candidatePid)
+      }
+    }
+  }
+
+  return totalKb > 0 ? totalKb * 1024 : null
+}
+
+export async function getProcessTreeMemoryBytes(rootPid, options = {}) {
+  if (!Number.isInteger(rootPid) || rootPid <= 0) return null
+  if (process.platform === 'win32') return null
+
+  const spawn = options.spawn ?? defaultSpawn
+
+  return new Promise((resolve) => {
+    let inspector
+    try {
+      inspector = spawn('ps', ['-axo', 'pid=,ppid=,rss='], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+    } catch {
+      resolve(null)
+      return
+    }
+
+    let output = ''
+    inspector.stdout?.setEncoding('utf8')
+    inspector.stdout?.on('data', (chunk) => {
+      output += chunk
+    })
+
+    inspector.on('error', () => resolve(null))
+    inspector.on('close', (code) => {
+      if ((code ?? 1) !== 0) {
+        resolve(null)
+        return
+      }
+
+      resolve(parseProcessTreeMemoryBytes(output, rootPid))
+    })
+  })
+}

--- a/apps/mercato/scripts/dev.mjs
+++ b/apps/mercato/scripts/dev.mjs
@@ -6,6 +6,7 @@ import {
   createRuntimeNoiseFilter,
   isStatelessRuntimeNoiseLine,
 } from './dev-runtime-log-policy.mjs'
+import { getProcessTreeMemoryBytes } from './dev-memory-monitor.mjs'
 
 function resolveSplashHelpersImport() {
   const candidates = [
@@ -1079,74 +1080,6 @@ function maybeStartTargetedRouteWarmup() {
   if (runtimeWarmupState.failed) return
   if (!runtimeWarmupState.baseUrl || !runtimeWarmupState.readySignalSeen) return
   runtimeWarmupState.promise = runTargetedRouteWarmup()
-}
-
-async function getProcessTreeMemoryBytes(rootPid) {
-  if (!Number.isInteger(rootPid) || rootPid <= 0) return null
-  if (process.platform === 'win32') return null
-
-  return new Promise((resolve) => {
-    const inspector = spawn('ps', ['-axo', 'pid=,ppid=,rss='], {
-      stdio: ['ignore', 'pipe', 'ignore'],
-    })
-
-    let output = ''
-    inspector.stdout?.setEncoding('utf8')
-    inspector.stdout?.on('data', (chunk) => {
-      output += chunk
-    })
-
-    inspector.on('error', () => resolve(null))
-    inspector.on('close', (code) => {
-      if ((code ?? 1) !== 0) {
-        resolve(null)
-        return
-      }
-
-      const nodes = new Map()
-
-      for (const rawLine of output.split('\n')) {
-        const line = rawLine.trim()
-        if (!line) continue
-
-        const match = line.match(/^(\d+)\s+(\d+)\s+(\d+)$/)
-        if (!match) continue
-
-        const pid = Number.parseInt(match[1], 10)
-        const ppid = Number.parseInt(match[2], 10)
-        const rssKb = Number.parseInt(match[3], 10)
-        nodes.set(pid, { ppid, rssKb })
-      }
-
-      if (!nodes.has(rootPid)) {
-        resolve(null)
-        return
-      }
-
-      let totalKb = 0
-      const pending = [rootPid]
-      const seen = new Set()
-
-      while (pending.length > 0) {
-        const pid = pending.pop()
-        if (!Number.isInteger(pid) || seen.has(pid)) continue
-        seen.add(pid)
-
-        const node = nodes.get(pid)
-        if (node) {
-          totalKb += node.rssKb
-        }
-
-        for (const [candidatePid, candidateNode] of nodes.entries()) {
-          if (candidateNode.ppid === pid && !seen.has(candidatePid)) {
-            pending.push(candidatePid)
-          }
-        }
-      }
-
-      resolve(totalKb > 0 ? totalKb * 1024 : null)
-    })
-  })
 }
 
 function stopMemoryMonitor() {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "template:sync:ask": "tsx scripts/template-sync.ts --ask",
     "test:create-app": "tsx scripts/test-create-app.ts",
     "test:create-app:integration": "tsx scripts/test-create-app-integration.ts",
-    "test:scripts": "node --test scripts/__tests__/*.test.mjs",
+    "test:scripts": "node --test scripts/__tests__/*.test.mjs apps/mercato/scripts/__tests__/*.test.mjs",
     "official-modules": "node scripts/official-modules.mjs",
     "postinstall": "node scripts/official-modules-setup.mjs",
     "test:integration": "cross-env ENABLE_CRUD_API_CACHE=true npx playwright test --config .ai/qa/tests/playwright.config.ts",


### PR DESCRIPTION
Fixes #2682

## Problem
- The dev-mode memory monitor in `apps/mercato/scripts/dev.mjs` (`getProcessTreeMemoryBytes`) calls `spawn('ps', ...)` without guarding a **synchronous** throw. `child_process.spawn` (via `cross-spawn`) can throw synchronously in some environments (e.g. `ENAMETOOLONG` or other platform-level failures) before any async `error` event fires. The throw rejects the promise and, since the call site `await`s it without a try/catch, crashes the entire `yarn dev` runtime.

## Root Cause
- The `spawn` call sat in a `new Promise(...)` executor with only async `error`/`close` handlers. A synchronous throw was never caught, so it propagated out of `getProcessTreeMemoryBytes` and took down the dev orchestrator. The memory monitor is purely cosmetic (RSS sampling for display), so a sampling failure must never be fatal.

## What Changed
- Extracted `getProcessTreeMemoryBytes` (and the pure `parseProcessTreeMemoryBytes` parser) into a new testable sibling module `apps/mercato/scripts/dev-memory-monitor.mjs`, mirroring the existing `dev-runtime-log-policy.mjs` pattern (`dev.mjs` auto-runs on import, so it cannot be unit-tested directly).
- Wrapped the `spawn` call in `try/catch`; on a synchronous throw it now `resolve(null)` (degrade to "no sample") and keeps the dev server running. Behavior on the happy path is unchanged; the existing async `error`-event handling still applies.
- `getProcessTreeMemoryBytes(rootPid, { spawn } = {})` gained an optional injectable `spawn` (defaults to `cross-spawn`) purely for deterministic testing — the call site is unchanged.
- Extended the root `test:scripts` glob to also run `apps/mercato/scripts/__tests__/*.test.mjs`, which additionally wires the pre-existing (previously un-run) `dev-runtime-log-policy` tests into CI.

## Tests
- New `apps/mercato/scripts/__tests__/dev-memory-monitor.test.mjs` (`node:test`):
  - **regression**: injects a `spawn` that throws synchronously → resolves `null` without throwing (fails on the pre-fix code, passes after).
  - invalid/non-integer pid returns `null` without spawning.
  - non-zero `ps` exit code → `null`.
  - happy-path subtree RSS summation.
  - parser returns `null` when the root pid is absent.
- Full `node --test scripts/__tests__/*.test.mjs apps/mercato/scripts/__tests__/*.test.mjs`: **198 passing, 0 failing**.

## Backward Compatibility
- No contract surface changes. `getProcessTreeMemoryBytes` was a private, non-exported helper inside a runtime script; the new module exports and the optional `spawn` param are additive. The `test:scripts` glob change is additive.

## Notes
- Supersedes the CLA-blocked #2681 (closed unmerged) with the same core fix plus regression coverage.
- This is a dev-tooling / test-only change with no customer-facing behavior.