### PR TITLE
security(ai_assistant): redact session token & API-key secret in MCP HTTP logs (#2668)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/log-redaction.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/log-redaction.test.ts
@@ -1,0 +1,56 @@
+import { createHash } from 'node:crypto'
+import { redactSecretForLog, deriveApiKeySessionId } from '../log-redaction'
+
+describe('redactSecretForLog', () => {
+  it('never emits the full session token', () => {
+    const token = `sess_${'a'.repeat(32)}`
+    const redacted = redactSecretForLog(token)
+    expect(redacted).not.toBe(token)
+    expect(redacted).not.toContain(token)
+    expect(token.startsWith(redacted.replace(/\.\.\.$/, ''))).toBe(true)
+  })
+
+  it('reveals at most a short leading fingerprint and never more than half', () => {
+    const token = `sess_${'b'.repeat(32)}`
+    const redacted = redactSecretForLog(token)
+    const visible = redacted.replace(/\.\.\.$/, '')
+    expect(redacted.endsWith('...')).toBe(true)
+    expect(visible.length).toBeLessThanOrEqual(12)
+    expect(visible.length).toBeLessThanOrEqual(Math.floor(token.length / 2))
+    expect(token.startsWith(visible)).toBe(true)
+  })
+
+  it('does not leak short values', () => {
+    expect(redactSecretForLog('abcd')).toBe('ab...')
+  })
+
+  it('returns a placeholder for empty or non-string input', () => {
+    expect(redactSecretForLog('')).toBe('<redacted>')
+    expect(redactSecretForLog(undefined)).toBe('<redacted>')
+    expect(redactSecretForLog(null)).toBe('<redacted>')
+    expect(redactSecretForLog(12345)).toBe('<redacted>')
+  })
+})
+
+describe('deriveApiKeySessionId', () => {
+  it('does not embed any slice of the secret', () => {
+    const secret = 'omk_publicprefix_secretbodythatmustnotleak'
+    const sessionId = deriveApiKeySessionId(secret)
+    expect(sessionId.startsWith('apikey_')).toBe(true)
+    expect(sessionId).not.toContain(secret.slice(0, 16))
+    expect(sessionId).not.toContain('secretbody')
+    const digestPart = sessionId.slice('apikey_'.length)
+    expect(secret).not.toContain(digestPart)
+  })
+
+  it('is a stable truncated sha-256 digest of the secret', () => {
+    const secret = 'omk_test_secret_value'
+    const expected = `apikey_${createHash('sha256').update(secret).digest('hex').slice(0, 16)}`
+    expect(deriveApiKeySessionId(secret)).toBe(expected)
+    expect(deriveApiKeySessionId(secret)).toBe(deriveApiKeySessionId(secret))
+  })
+
+  it('maps distinct secrets to distinct ids', () => {
+    expect(deriveApiKeySessionId('secret-one')).not.toBe(deriveApiKeySessionId('secret-two'))
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/http-server.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/http-server.ts
@@ -9,6 +9,7 @@ import { executeTool } from './tool-executor'
 import { loadAllModuleTools, indexToolsForSearch } from './tool-loader'
 import { authenticateMcpRequest, extractApiKeyFromHeaders, hasRequiredFeatures } from './auth'
 import { jsonSchemaToZod, toSafeZodSchema } from './schema-utils'
+import { redactSecretForLog, deriveApiKeySessionId } from './log-redaction'
 import type { McpServerConfig, McpToolContext } from './types'
 import type { SearchService } from '@open-mercato/search/service'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
@@ -42,7 +43,7 @@ async function resolveSessionContext(
     const sessionResult = await findSessionApiKeyWithSecret(em, sessionToken)
     if (!sessionResult) {
       if (debug) {
-        console.error(`[MCP HTTP] Session token not found, expired, or secret unavailable: ${sessionToken}`)
+        console.error(`[MCP HTTP] Session token not found, expired, or secret unavailable: ${redactSecretForLog(sessionToken)}`)
       }
       return null
     }
@@ -277,7 +278,7 @@ function createMcpServerForRequest(
             if (!effectiveContext.sessionId && effectiveContext.apiKeySecret) {
               effectiveContext = {
                 ...effectiveContext,
-                sessionId: 'apikey_' + effectiveContext.apiKeySecret.slice(0, 16),
+                sessionId: deriveApiKeySessionId(effectiveContext.apiKeySecret),
               }
             }
           }

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/log-redaction.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/log-redaction.ts
@@ -1,0 +1,24 @@
+import { createHash } from 'node:crypto'
+
+/**
+ * Redact a bearer-style secret (session token, API key) for safe logging.
+ * Reveals at most a short leading fingerprint and never more than half of the
+ * value, so durable logs never carry a replayable credential.
+ */
+export function redactSecretForLog(value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0) return '<redacted>'
+  const prefixLength = Math.min(12, Math.floor(value.length / 2))
+  if (prefixLength <= 0) return '<redacted>'
+  return `${value.slice(0, prefixLength)}...`
+}
+
+/**
+ * Derive a stable, non-reversible session-memory id from an API key secret.
+ * The same secret always maps to the same id (so tool calls on one MCP
+ * connection share a memory cache), but no secret material is exposed because
+ * the id is a truncated SHA-256 digest rather than a slice of the secret.
+ */
+export function deriveApiKeySessionId(apiKeySecret: string): string {
+  const digest = createHash('sha256').update(apiKeySecret).digest('hex')
+  return `apikey_${digest.slice(0, 16)}`
+}


### PR DESCRIPTION
Fixes #2668

## Problem
- `http-server.ts:45` logged the **full raw** `${sessionToken}` whenever `findSessionApiKeyWithSecret` returned null. That happens for three reasons, the worst being case (c): the token is a valid, live credential in the DB but its encrypted secret cannot be decrypted (KMS/DEK failure). The token (a `sess_{32 hex}` bearer credential, TTL up to 120 min) then lands in durable debug logs and can be replayed.
- `http-server.ts:280` derived the API-key fallback session id as `'apikey_' + apiKeySecret.slice(0, 16)`. The first 12 chars are the public key prefix, but chars 13-16 are part of the secret body — so a 16-bit slice of the live secret was bundled into the session id and into any log line carrying it.

## Root Cause
- The session-token debug log interpolated the raw credential directly, unlike the rest of the file (`http-server.ts:510` already truncates to a `${keyPrefix}...` fingerprint, and the per-tool log only emits `hasSessionToken: !!sessionToken`). Line 45 was the only raw-credential log path.
- The fallback session id was built by slicing the secret rather than hashing it.

## What Changed
- New `lib/log-redaction.ts` with two pure, unit-tested helpers:
  - `redactSecretForLog(value)` — reveals at most a short leading fingerprint and never more than half the value (`<redacted>` for empty/non-string input).
  - `deriveApiKeySessionId(secret)` — returns `apikey_` + first 16 hex of `sha256(secret)`. Non-reversible, but still stable per secret and distinct across secrets, so the per-connection session-memory cache key behaves identically.
- `http-server.ts:45` now logs `redactSecretForLog(sessionToken)`.
- `http-server.ts:280` now uses `deriveApiKeySessionId(effectiveContext.apiKeySecret)`.

## Tests
- New `lib/__tests__/log-redaction.test.ts` (7 cases): full token never appears in the redacted output; fingerprint ≤ 12 chars and ≤ half the length; short-value and empty/non-string handling; the session id never contains `secret.slice(0,16)` or the secret body (the assertion that fails on the pre-fix code); the id is a stable truncated SHA-256 digest; distinct secrets → distinct ids.
- Full `@open-mercato/ai-assistant` jest suite: **1188 passing, 83 suites**. Production typecheck of the package: 0 errors.

## Backward Compatibility
- No contract surface changes. `log-redaction.ts` is an internal module helper (not a documented contract surface); its exports are additive.
- The fallback `sessionId` is an internal per-connection cache key with no external consumer; its format changes from `apikey_<secret-slice>` to `apikey_<sha256-prefix>` but its semantics (stable per secret, unique per secret) are unchanged.

## Security impact
- Removes durable logging of a replayable session bearer token (the decrypt-failure case leaked a still-valid credential) and eliminates the partial API-key-secret disclosure embedded in the session id. Directly enforces the module rule "Never log credentials, session tokens, API keys".
- Sibling finding #2660 covers the same `http-server.ts:45` log path from the lookup-failure angle; this fix redacts that line for all three null cases.