### PR TITLE
fix(ai_assistant): Avoid duplicate MCP stdio server spawn

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-client.integration.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-client.integration.test.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { McpClient } from '../mcp-client'
+
+describe('McpClient stdio integration', () => {
+  it('starts exactly one SDK-managed server process for one stdio client connection', async () => {
+    const previousSpawnLog = process.env.MCP_SPAWN_LOG
+    const logPath = path.join(os.tmpdir(), `open-mercato-mcp-spawn-${Date.now()}.log`)
+    process.env.MCP_SPAWN_LOG = logPath
+
+    const serverCode = `
+import fs from 'node:fs';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+fs.appendFileSync(process.env.MCP_SPAWN_LOG, String(process.pid) + '\\n');
+const server = new Server(
+  { name: 'open-mercato-spawn-proof', version: '1.0.0' },
+  { capabilities: { tools: {} } }
+);
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+await server.connect(new StdioServerTransport());
+`
+
+    try {
+      const client = await McpClient.connect({
+        transport: 'stdio',
+        apiKeySecret: 'test-secret',
+        command: process.execPath,
+        args: ['--input-type=module', '-e', serverCode],
+        cwd: process.cwd(),
+      })
+
+      try {
+        await expect(client.listTools()).resolves.toEqual([])
+      } finally {
+        await client.close()
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      const pids = fs.readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean)
+      expect(pids).toHaveLength(1)
+    } finally {
+      if (previousSpawnLog === undefined) {
+        delete process.env.MCP_SPAWN_LOG
+      } else {
+        process.env.MCP_SPAWN_LOG = previousSpawnLog
+      }
+      fs.rmSync(logPath, { force: true })
+    }
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-client.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-client.test.ts
@@ -1,0 +1,74 @@
+import { EventEmitter } from 'node:events'
+import { spawn } from 'node:child_process'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { McpClient } from '../mcp-client'
+
+const mockClientConnect = jest.fn(async () => undefined)
+const mockClientClose = jest.fn(async () => undefined)
+const mockClientListTools = jest.fn(async () => ({ tools: [] }))
+const mockTransportClose = jest.fn(async () => undefined)
+const mockTransportStderr = new EventEmitter()
+const mockManualChildKill = jest.fn()
+
+jest.mock('node:child_process', () => ({
+  spawn: jest.fn(() => ({
+    stderr: new EventEmitter(),
+    kill: mockManualChildKill,
+  })),
+}))
+
+jest.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: jest.fn().mockImplementation(() => ({
+    connect: mockClientConnect,
+    close: mockClientClose,
+    listTools: mockClientListTools,
+  })),
+}))
+
+jest.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: jest.fn().mockImplementation(() => ({
+    close: mockTransportClose,
+    stderr: mockTransportStderr,
+  })),
+}))
+
+jest.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: jest.fn().mockImplementation(() => ({
+    close: jest.fn(async () => undefined),
+  })),
+}))
+
+describe('McpClient stdio transport', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('delegates process spawning to StdioClientTransport without a manual duplicate spawn', async () => {
+    const client = await McpClient.connect({
+      transport: 'stdio',
+      apiKeySecret: 'test-secret',
+      command: 'node',
+      args: ['server.js'],
+      cwd: '/tmp/open-mercato',
+    })
+
+    expect(Client).toHaveBeenCalledTimes(1)
+    expect(StdioClientTransport).toHaveBeenCalledWith({
+      command: 'node',
+      args: ['server.js'],
+      cwd: '/tmp/open-mercato',
+      env: process.env,
+      stderr: 'pipe',
+    })
+    expect(mockClientConnect).toHaveBeenCalledTimes(1)
+    expect(mockClientConnect).toHaveBeenCalledWith(expect.any(Object))
+    expect(spawn).not.toHaveBeenCalled()
+
+    await client.close()
+
+    expect(mockClientClose).toHaveBeenCalledTimes(1)
+    expect(mockTransportClose).toHaveBeenCalledTimes(1)
+    expect(mockManualChildKill).not.toHaveBeenCalled()
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-client.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-client.ts
@@ -1,4 +1,3 @@
-import { spawn, type ChildProcess } from 'node:child_process'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
@@ -45,19 +44,16 @@ export type McpClientOptions = StdioClientOptions | HttpClientOptions
 export class McpClient implements McpClientInterface {
   private client: Client
   private transport: StdioClientTransport | StreamableHTTPClientTransport
-  private childProcess?: ChildProcess
   private apiKeySecret: string
 
   private constructor(
     client: Client,
     transport: StdioClientTransport | StreamableHTTPClientTransport,
-    apiKeySecret: string,
-    childProcess?: ChildProcess
+    apiKeySecret: string
   ) {
     this.client = client
     this.transport = transport
     this.apiKeySecret = apiKeySecret
-    this.childProcess = childProcess
   }
 
   /**
@@ -85,25 +81,18 @@ export class McpClient implements McpClientInterface {
     ]
     const cwd = options.cwd ?? process.cwd()
 
-    const childProcess = spawn(command, args, {
-      cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env },
-    })
-
-    // Forward stderr for debugging
-    childProcess.stderr?.on('data', (data) => {
-      const message = data.toString().trim()
-      if (message) {
-        console.error(`[MCP Client] ${message}`)
-      }
-    })
-
     const transport = new StdioClientTransport({
       command,
       args,
       cwd,
       env: process.env as Record<string, string>,
+      stderr: 'pipe',
+    })
+    transport.stderr?.on('data', (data) => {
+      const message = data.toString().trim()
+      if (message) {
+        console.error(`[MCP Client] ${message}`)
+      }
     })
 
     const client = new Client(
@@ -113,7 +102,7 @@ export class McpClient implements McpClientInterface {
 
     await client.connect(transport)
 
-    return new McpClient(client, transport, options.apiKeySecret, childProcess)
+    return new McpClient(client, transport, options.apiKeySecret)
   }
 
   /**
@@ -213,9 +202,5 @@ export class McpClient implements McpClientInterface {
       // Ignore close errors
     }
 
-    if (this.childProcess) {
-      this.childProcess.kill()
-      this.childProcess = undefined
-    }
   }
 }


### PR DESCRIPTION
`McpClient.connect({ transport: 'stdio' })` now lets `StdioClientTransport` own the server subprocess instead of spawning a second, unmanaged process before connecting. This removes the leaked idle MCP server process, avoids the unread stdout pipe/deadlock risk, and keeps stderr forwarding through the SDK-managed transport.

**Stdio process ownership**

The manual `child_process.spawn()` path and manual child kill bookkeeping were removed. The client now configures `stderr: 'pipe'` on `StdioClientTransport`, forwards that stream for debugging, and closes only the SDK client/transport.

**Regression coverage**

Added a unit regression that asserts stdio connection setup does not call `node:child_process.spawn` directly, plus an integration-style stdio test that starts a real fake MCP server and proves one client connection starts exactly one server process.

**Compatibility**

No public API, database, OpenAPI, event, ACL, or import-path contract changes. This is a resource-management/security hardening fix inside the AI assistant MCP client.

Fixes #2664

Verification:
- Red proof before fix: fake stdio MCP server e2e recorded `spawnCount: 2` for one `McpClient.connect()`.
- Post-fix proof: same e2e recorded `spawnCount: 1`.
- `node node_modules/jest/bin/jest.js --config packages/ai-assistant/jest.config.cjs --runTestsByPath packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-client.test.ts packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-client.integration.test.ts`
- `yarn workspace @open-mercato/ai-assistant test`
- `yarn workspace @open-mercato/ai-assistant build`
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn check:dep-versions`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage` (exit 0; advisory unused-key report only)
- `yarn typecheck`
- `yarn build:app`

Known baseline note:
- Full root `yarn test` currently has one deterministic failure outside this change on current upstream: `packages/core/src/modules/inbox_ops/__tests__/executionHelpers.superadmin.test.ts` expects `userHasFeature(ctx, '')` to return `true`, but receives `false`. The touched package suite is green.

CLA: acknowledged.