### PR TITLE
fix(ui): make JsonBuilder Raw JSON editable and confirm destructive type changes (#2817)

### DIFF
--- a/packages/ui/src/backend/JsonBuilder.tsx
+++ b/packages/ui/src/backend/JsonBuilder.tsx
@@ -13,6 +13,8 @@ import {
   SelectValue,
 } from '../primitives/select'
 import { Plus, Trash2, ChevronRight, ChevronDown, Code, LayoutList } from 'lucide-react'
+import { useConfirmDialog } from './confirm-dialog'
+import type { ConfirmDialogOptions } from './confirm-dialog'
 
 function cn(...classes: (string | undefined | null | false)[]) {
     return classes.filter(Boolean).join(' ')
@@ -27,10 +29,29 @@ export type JsonBuilderProps = {
 
 type JsonNodeType = 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null'
 
+type ConfirmFn = (options?: ConfirmDialogOptions) => Promise<boolean>
+
 function getJsonType(value: any): JsonNodeType {
     if (value === null) return 'null'
     if (Array.isArray(value)) return 'array'
     return typeof value as JsonNodeType
+}
+
+function defaultValueForType(type: JsonNodeType): any {
+    switch (type) {
+        case 'string': return ""
+        case 'number': return 0
+        case 'boolean': return false
+        case 'object': return {}
+        case 'array': return []
+        case 'null': return null
+    }
+}
+
+function toRawString(value: any): string {
+    if (value === null || value === undefined) return '{}'
+    if (typeof value === 'object') return JSON.stringify(value, null, 2)
+    return String(value)
 }
 
 export function JsonBuilder({
@@ -40,28 +61,32 @@ export function JsonBuilder({
     error
 }: JsonBuilderProps) {
     const [mode, setMode] = React.useState<'raw' | 'builder'>('raw')
-    const [rawString, setRawString] = React.useState(() => {
-        if (value === null) return '{}'
-        return typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value || '{}')
-    })
+    const [rawString, setRawString] = React.useState(() => toRawString(value))
+    const [rawDirty, setRawDirty] = React.useState(false)
     const [parseError, setParseError] = React.useState<string | null>(null)
+    const { confirm, ConfirmDialogElement } = useConfirmDialog()
 
     React.useEffect(() => {
-        if (value === null) {
-            if (!disabled) {
-                onChange({})
-            }
-            setRawString('{}')
-            setParseError(null)
-            return
-        }
-        if (typeof value === 'object') {
-            setRawString(JSON.stringify(value, null, 2))
-            setParseError(null)
+        if (value === null && !disabled) {
+            onChange({})
         }
     }, [value, disabled, onChange])
 
+    // Mirror external value changes (e.g. async record load, builder edits) into
+    // the raw textarea only while the user has NOT started typing in it. Once the
+    // textarea is dirty it becomes the source of truth, so re-deriving it from
+    // `value` on every keystroke — the parent's onChange identity changes each
+    // render — would clobber typing and make Raw JSON uneditable (issue #2817).
+    React.useEffect(() => {
+        if (rawDirty) return
+        if (value !== null && typeof value === 'object') {
+            setRawString(JSON.stringify(value, null, 2))
+            setParseError(null)
+        }
+    }, [value, rawDirty])
+
     const handleRawChange = (str: string) => {
+        setRawDirty(true)
         setRawString(str)
         try {
             if (str.trim() === '') {
@@ -76,6 +101,15 @@ export function JsonBuilder({
             onChange(str)
             setParseError("Invalid JSON")
         }
+    }
+
+    const switchToRaw = () => {
+        // Re-sync the textarea from the current value and let it mirror external
+        // changes again until the user edits it.
+        setRawDirty(false)
+        setRawString(toRawString(value))
+        setParseError(null)
+        setMode('raw')
     }
 
     const switchToBuilder = () => {
@@ -97,7 +131,7 @@ export function JsonBuilder({
                     variant="ghost"
                     size="sm"
                     className={cn(mode === 'raw' && "bg-muted text-foreground")}
-                    onClick={() => setMode('raw')}
+                    onClick={switchToRaw}
                 >
                     <Code className="w-4 h-4" />
                     Raw JSON
@@ -140,6 +174,7 @@ export function JsonBuilder({
                             data={value}
                             onChange={onChange}
                             readOnly={disabled}
+                            confirm={confirm}
                             isRoot
                         />
                     ) : (
@@ -151,6 +186,7 @@ export function JsonBuilder({
             )}
 
             {error && <div className="text-xs text-red-600">{error}</div>}
+            {ConfirmDialogElement}
         </div>
     )
 }
@@ -162,24 +198,39 @@ interface JsonNodeProps {
     readOnly?: boolean
     label?: string
     isRoot?: boolean
+    confirm?: ConfirmFn
 }
 
-function JsonNode({ data, onChange, onDelete, readOnly, label, isRoot }: JsonNodeProps) {
+function JsonNode({ data, onChange, onDelete, readOnly, label, isRoot, confirm }: JsonNodeProps) {
     const type = getJsonType(data)
     const isContainer = type === 'object' || type === 'array'
     const [collapsed, setCollapsed] = React.useState(false)
 
-    const handleTypeChange = (newType: JsonNodeType) => {
-        let newVal: any = ''
-        switch (newType) {
-            case 'string': newVal = ""; break;
-            case 'number': newVal = 0; break;
-            case 'boolean': newVal = false; break;
-            case 'object': newVal = {}; break;
-            case 'array': newVal = []; break;
-            case 'null': newVal = null; break;
+    const handleTypeChange = async (newType: JsonNodeType) => {
+        if (newType === type) return
+        // Switching away from a non-empty container discards its contents. Ask
+        // for confirmation first so configured properties aren't lost silently
+        // (issue #2817). The Select is controlled by the derived type, so when
+        // the user cancels we simply leave the data untouched and the control
+        // snaps back to its previous value.
+        const itemCount = type === 'object'
+            ? Object.keys(data).length
+            : type === 'array'
+                ? (data as any[]).length
+                : 0
+        if (itemCount > 0 && confirm) {
+            const noun = type === 'object'
+                ? `${itemCount} ${itemCount === 1 ? 'property' : 'properties'}`
+                : `${itemCount} ${itemCount === 1 ? 'item' : 'items'}`
+            const confirmed = await confirm({
+                title: 'Change value type?',
+                text: `Changing the type from ${type} to ${newType} will discard the ${noun} currently configured. This cannot be undone.`,
+                confirmText: 'Discard and change',
+                variant: 'destructive',
+            })
+            if (!confirmed) return
         }
-        onChange(newVal)
+        onChange(defaultValueForType(newType))
     }
 
     const handleAddKey = () => {
@@ -250,7 +301,7 @@ function JsonNode({ data, onChange, onDelete, readOnly, label, isRoot }: JsonNod
                     {!readOnly && (
                         <Select
                             value={type}
-                            onValueChange={(next) => handleTypeChange(next as JsonNodeType)}
+                            onValueChange={(next) => { void handleTypeChange(next as JsonNodeType) }}
                         >
                             <SelectTrigger size="sm" className="w-auto min-w-[6rem]">
                                 <SelectValue />
@@ -342,6 +393,7 @@ function JsonNode({ data, onChange, onDelete, readOnly, label, isRoot }: JsonNod
                                     onChange={(v) => handleChildChange(key, v)}
                                     onDelete={() => handleChildDelete(key)}
                                     readOnly={readOnly}
+                                    confirm={confirm}
                                 />
                             </div>
                         </div>
@@ -355,6 +407,7 @@ function JsonNode({ data, onChange, onDelete, readOnly, label, isRoot }: JsonNod
                             onChange={(v) => handleChildChange(idx, v)}
                             onDelete={() => handleChildDelete(idx)}
                             readOnly={readOnly}
+                            confirm={confirm}
                         />
                     ))}
 

--- a/packages/ui/src/backend/__tests__/JsonBuilder.test.tsx
+++ b/packages/ui/src/backend/__tests__/JsonBuilder.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { JsonBuilder } from '../JsonBuilder'
+
+// Radix Select uses pointer capture / scrollIntoView APIs that jsdom doesn't implement.
+// The confirm dialog uses the native <dialog> showModal/close APIs. Polyfill both so the
+// component can be exercised end to end (issue #2817).
+if (typeof window !== 'undefined') {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => undefined
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => undefined
+  }
+  Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+    configurable: true,
+    value(this: HTMLDialogElement) {
+      this.setAttribute('open', '')
+    },
+  })
+  Object.defineProperty(HTMLDialogElement.prototype, 'close', {
+    configurable: true,
+    value(this: HTMLDialogElement) {
+      this.removeAttribute('open')
+    },
+  })
+}
+
+function ControlledHarness({ initial = {} as any }: { initial?: any }) {
+  const [value, setValue] = React.useState<any>(initial)
+  // Inline onChange recreated each render — mirrors how WebhookCustomHeadersField
+  // wires the builder. A stale effect dependency on this identity is what made
+  // Raw JSON uneditable before the fix.
+  return (
+    <>
+      <JsonBuilder value={value} onChange={(next) => setValue(next)} />
+      <div data-testid="value">{JSON.stringify(value)}</div>
+    </>
+  )
+}
+
+describe('JsonBuilder', () => {
+  it('lets the user type JSON in Raw mode without clobbering the text', () => {
+    renderWithProviders(<ControlledHarness />)
+
+    const textarea = screen.getByPlaceholderText('{"key": "value"}') as HTMLTextAreaElement
+
+    act(() => {
+      fireEvent.change(textarea, { target: { value: '{"a":"1"}' } })
+    })
+
+    // The exact typed text is preserved (not reformatted/reset by a value echo).
+    expect(textarea.value).toBe('{"a":"1"}')
+    // ...and the parsed object propagated to the parent.
+    expect(screen.getByTestId('value').textContent).toBe('{"a":"1"}')
+  })
+
+  it('mirrors an external value into the Raw textarea until the user edits it', () => {
+    function ExternalHarness() {
+      const [value, setValue] = React.useState<any>({})
+      return (
+        <>
+          <button type="button" onClick={() => setValue({ injected: 'hello' })}>
+            load
+          </button>
+          <JsonBuilder value={value} onChange={setValue} />
+        </>
+      )
+    }
+
+    renderWithProviders(<ExternalHarness />)
+    const textarea = screen.getByPlaceholderText('{"key": "value"}') as HTMLTextAreaElement
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'load' }))
+    })
+
+    expect(textarea.value).toContain('injected')
+    expect(textarea.value).toContain('hello')
+  })
+
+  async function openBuilderAndChangeRootType() {
+    renderWithProviders(<ControlledHarness initial={{ foo: 'bar' }} />)
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Builder' }))
+    })
+
+    const rootTrigger = screen
+      .getAllByRole('combobox')
+      .find((element) => element.textContent?.trim() === 'Object')
+    expect(rootTrigger).toBeDefined()
+
+    fireEvent.pointerDown(rootTrigger!, { button: 0, ctrlKey: false })
+    fireEvent.click(rootTrigger!)
+
+    const stringOption = screen.getByRole('option', { name: 'String' })
+    await act(async () => {
+      fireEvent.pointerDown(stringOption)
+      fireEvent.click(stringOption)
+    })
+  }
+
+  it('asks for confirmation before a destructive root type change and preserves data on cancel', async () => {
+    await openBuilderAndChangeRootType()
+
+    const cancelButton = await screen.findByRole('button', { name: 'Cancel' })
+    await act(async () => {
+      fireEvent.click(cancelButton)
+    })
+
+    // Cancelling leaves the configured properties intact.
+    expect(screen.getByTestId('value').textContent).toBe('{"foo":"bar"}')
+  })
+
+  it('discards data only after the destructive root type change is confirmed', async () => {
+    await openBuilderAndChangeRootType()
+
+    const confirmButton = await screen.findByRole('button', { name: 'Discard and change' })
+    await act(async () => {
+      fireEvent.click(confirmButton)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('value').textContent).toBe('""')
+    })
+  })
+})


### PR DESCRIPTION
Fixes #2817

## Problem
In **Backend → Webhooks → Advanced → Custom Headers**, the `JsonBuilder` editor:
- **Raw JSON** mode was presented but could not be edited — typing was immediately reset/reformatted, so direct JSON entry was impossible.
- **Builder** mode silently cleared all configured properties the moment the root **type** selector changed (Object → another type), losing data with no warning.

## Root Cause
- **Raw JSON:** an effect re-derived the textarea contents from `value` on every render. The host (`WebhookCustomHeadersField`) passes an inline `onChange` whose identity changes each render, and that `onChange` was an effect dependency — so the effect ran on every keystroke and overwrote the textarea (reformatting valid JSON, resetting partial input). Direct editing was effectively blocked.
- **Builder type change:** `handleTypeChange` immediately replaced the node value with an empty default for the new type, discarding any existing object/array contents without confirmation.

## What Changed
`packages/ui/src/backend/JsonBuilder.tsx`:
- Raw mode now treats the textarea as the source of truth once the user starts typing (`rawDirty` flag). External `value` changes (async record load, Builder edits) still mirror into the textarea **until** the user edits it; switching back from Builder re-syncs it. `onChange` is no longer a sync dependency, so typing is never clobbered.
- Changing a **non-empty** object/array node's type now prompts via the shared `ConfirmDialog` before discarding data. Cancelling leaves the data untouched (the type `Select` is controlled by the derived type, so it snaps back); confirming applies the change. Applies to the root node and nested nodes.

## Tests
- New `packages/ui/src/backend/__tests__/JsonBuilder.test.tsx`:
  - Raw JSON: typed text is preserved (not reformatted/reset) and the parsed object propagates to the parent.
  - External value mirrors into the Raw textarea before the user edits (guards edit-form async load).
  - Destructive root type change asks for confirmation; **cancel preserves data**, **confirm discards**.
- Verified the 3 behavioral tests fail against the pre-fix source and pass after the fix.
- Full `@open-mercato/ui` suite: 1470 tests pass (7 pre-existing `@open-mercato/ai-assistant` module-resolution suite failures are unrelated to this change). `typecheck` passes.

## Backward Compatibility
- No contract surface changes. `JsonBuilderProps` is unchanged; the fix is internal behavior only.

## Notes / Follow-up
- This primitive has no i18n wiring today; all of its copy (existing toggle labels and the new confirm-dialog copy) is hardcoded English. Threading `useT` through it is out of scope for this fix and can be a follow-up.