### PR TITLE
chore(deps): migrate #2836 — bump undici to ^8.4.1 (shared)

### DIFF
--- a/.ai/runs/2026-06-08-migrate-deps-major-group-2836.md
+++ b/.ai/runs/2026-06-08-migrate-deps-major-group-2836.md
@@ -53,5 +53,5 @@ None (`--skill-url` not supplied).
 
 ### Phase 3: Ship & retire original
 
-- [ ] 3.1 Open PR against `develop`, apply labels
-- [ ] 3.2 Close PR #2836 with a pointer to the new PR
+- [x] 3.1 Open PR against `develop`, apply labels — PR #2838 (`dependencies`, `skip-qa`, `review`)
+- [x] 3.2 Close PR #2836 with a pointer to the new PR — closed, commented pointing to #2838

--- a/.ai/runs/2026-06-08-migrate-deps-major-group-2836.md
+++ b/.ai/runs/2026-06-08-migrate-deps-major-group-2836.md
@@ -49,7 +49,7 @@ None (`--skill-url` not supplied).
 
 ### Phase 2: Validate
 
-- [ ] 2.1 Run validation gate (build:packages, typecheck, test, build:app)
+- [x] 2.1 Run validation gate — `yarn build:packages` ✓ (21/21), `yarn generate` ✓, `yarn typecheck` ✓ (21/21), `@open-mercato/shared` tests ✓ (1181/1181). Full `yarn test` / `yarn build:app` scoped down: the root `resolutions` pin keeps the installed dependency graph byte-identical to `develop` (undici 7.24.0 via `yarn why undici`), so no runtime code path changes.
 
 ### Phase 3: Ship & retire original
 

--- a/.ai/runs/2026-06-08-migrate-deps-major-group-2836.md
+++ b/.ai/runs/2026-06-08-migrate-deps-major-group-2836.md
@@ -44,8 +44,8 @@ None (`--skill-url` not supplied).
 
 ### Phase 1: Apply residual bump
 
-- [ ] 1.1 Bump `undici` to `^8.4.1` in `packages/shared/package.json`
-- [ ] 1.2 Relock with `yarn install`; confirm `yarn.lock` diff is scoped to undici
+- [x] 1.1 Bump `undici` to `^8.4.1` in `packages/shared/package.json` — 3a986c5aa
+- [x] 1.2 Relock with `yarn install`; confirm `yarn.lock` diff is scoped to undici — 3a986c5aa (lock diff = single descriptor line; root `resolutions` still pins undici 7.24.0, so installed version is unchanged)
 
 ### Phase 2: Validate
 

--- a/.ai/runs/2026-06-08-migrate-deps-major-group-2836.md
+++ b/.ai/runs/2026-06-08-migrate-deps-major-group-2836.md
@@ -1,0 +1,57 @@
+# Migrate Dependabot PR #2836 to `develop`
+
+## Goal
+
+Recreate the dependency bumps from Dependabot PR #2836 (`chore(deps): bump the major group with 3 updates`, opened against `main`) on top of `develop`, then close the original PR so Dependabot stops tracking the stale `main`-based branch.
+
+## Overview
+
+PR #2836 grouped three bumps:
+
+| Package | PR target | State on `develop` |
+|---------|-----------|--------------------|
+| `pdfjs-dist` | `^5.7.284` → `^6.0.227` | **already `^6.0.227`** (landed earlier) |
+| `isolated-vm` | `^6.1.2` → `^7.0.0` | **already `^7.0.0`** (landed earlier) |
+| `undici` | `^8.3.0` → `^8.4.1` | still `^8.3.0` in `packages/shared/package.json` |
+
+Net migration vs `develop` is therefore a single residual bump: `undici` in `packages/shared` from `^8.3.0` to `^8.4.1`, plus the corresponding `yarn.lock` update. The two major bumps are no-ops on `develop` and must not be re-applied.
+
+This is a dependency-only change: `skip-qa`, `dependencies` category label.
+
+### External References
+
+None (`--skill-url` not supplied).
+
+## Scope
+
+- `packages/shared/package.json` — bump `undici` to `^8.4.1`.
+- `yarn.lock` — relock via `yarn install`.
+
+### Non-goals
+
+- Do not touch `pdfjs-dist` / `isolated-vm` (already at target on `develop`).
+- Do not change the root `package.json` pinned `undici` `7.24.0` (separate, intentional pin).
+- No source/behavioral code changes.
+
+## Risks
+
+- `undici` 8.3 → 8.4 is a minor bump within the same major; low breakage risk. Validation gate (build + tests) confirms.
+- Pre-existing observation: `develop`'s `yarn.lock` resolves `undici` only to `7.24.0` (root pin); the shared `^8.3.0` range had no v8 resolution recorded. `yarn install` after the bump will add the resolved v8 entry; verify the lock diff stays scoped to undici.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Apply residual bump
+
+- [ ] 1.1 Bump `undici` to `^8.4.1` in `packages/shared/package.json`
+- [ ] 1.2 Relock with `yarn install`; confirm `yarn.lock` diff is scoped to undici
+
+### Phase 2: Validate
+
+- [ ] 2.1 Run validation gate (build:packages, typecheck, test, build:app)
+
+### Phase 3: Ship & retire original
+
+- [ ] 3.1 Open PR against `develop`, apply labels
+- [ ] 3.2 Close PR #2836 with a pointer to the new PR

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -98,7 +98,7 @@
     "re2js": "2.8.3",
     "reflect-metadata": "^0.2.2",
     "sanitize-html": "^2.17.4",
-    "undici": "^8.3.0"
+    "undici": "^8.4.1"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6795,7 +6795,7 @@ __metadata:
     reflect-metadata: "npm:^0.2.2"
     sanitize-html: "npm:^2.17.4"
     ts-jest: "npm:^29.4.11"
-    undici: "npm:^8.3.0"
+    undici: "npm:^8.4.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-08-migrate-deps-major-group-2836.md
Status: complete

## Goal
- Migrate Dependabot PR #2836 (`chore(deps): bump the major group with 3 updates`, opened against `main`) onto `develop`, then close the original.

## What Changed
- Bumped `undici` from `^8.3.0` to `^8.4.1` in `packages/shared/package.json` and relocked `yarn.lock`.
- The other two bumps in PR #2836 — `pdfjs-dist` (`^5.7.284` → `^6.0.227`) and `isolated-vm` (`^6.1.2` → `^7.0.0`) — **already landed on `develop`**, so they are intentionally not re-applied here. The residual delta vs `develop` was the single `undici` range.

## Tests
- `yarn build:packages` ✓ (21/21)
- `yarn generate` ✓, `yarn typecheck` ✓ (21/21)
- `@open-mercato/shared` unit tests ✓ (1181/1181)
- Full `yarn test` / `yarn build:app` scoped down: the root `resolutions` pin (`"undici": "7.24.0"`) keeps the installed dependency graph byte-identical to `develop` (`yarn why undici` → 7.24.0 everywhere), so this is a manifest-range sync with no runtime code path change.

## Backward Compatibility
- No contract surface changes. Dependency manifest only; installed versions unchanged.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-08-migrate-deps-major-group-2836.md#progress).
