### PR TITLE
test(inbox_ops): align empty-feature gate test with #2700 fail-closed contract

### DIFF
--- a/packages/core/src/modules/inbox_ops/__tests__/executionHelpers.superadmin.test.ts
+++ b/packages/core/src/modules/inbox_ops/__tests__/executionHelpers.superadmin.test.ts
@@ -117,7 +117,9 @@ describe('inbox_ops userHasFeature super-admin gate', () => {
     )
   })
 
-  it('short-circuits to true for an empty feature requirement', async () => {
+  it('fails closed for an empty feature requirement without consulting rbac', async () => {
+    // Aligns with the #2700 fail-closed contract: a missing/empty feature
+    // requirement must never grant access (see executionHelpers.userHasFeature.test.ts).
     const ctx = makeContext(
       {
         sub: 'user-1',
@@ -131,7 +133,7 @@ describe('inbox_ops userHasFeature super-admin gate', () => {
 
     const allowed = await userHasFeature(ctx, '')
 
-    expect(allowed).toBe(true)
+    expect(allowed).toBe(false)
     expect(rbac.userHasAllFeatures).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Fixes the failing `test` CI job currently red on `develop` (and therefore on every open PR).

## Problem
`packages/core/src/modules/inbox_ops/__tests__/executionHelpers.superadmin.test.ts` (added by #2804 / #2699) asserts that `userHasFeature(ctx, "")` — an empty feature requirement — short-circuits to `true`. That directly contradicts the dedicated **#2700 fail-closed** suite `executionHelpers.userHasFeature.test.ts`, which asserts that an empty / whitespace / `undefined` / `null` / missing feature requirement MUST return `false` — *even for a superadmin* ("fail closed first"). With both suites present, the build is red.

## Root Cause
The two suites encode opposite contracts for the same input. The implementation (`executionHelpers.ts:140`) already fails closed (`if (!feature || feature.trim().length === 0) return false`) per #2700. The `.superadmin.test.ts` assertion is the stale/incorrect one — flipping the code to satisfy it would re-open the access-control hole #2700 deliberately closed (a missing feature requirement granting access).

## What Changed
- Updated the single contradicting assertion in `executionHelpers.superadmin.test.ts` to expect `false` (fail-closed) for an empty feature requirement, keeping the `rbac.userHasAllFeatures` not-called expectation (the code short-circuits before consulting rbac). Added a one-line comment pointing at the #2700 contract.
- **No production code change** — `executionHelpers.ts` keeps its fail-closed behavior.

## Tests
- `executionHelpers.superadmin.test.ts`: 5/5 pass.
- Full `inbox_ops` suite: **358 passing, 29 suites** (was 6 failing across the two contradictory files before alignment).

## Backward Compatibility
- No contract surface changes; test-only.

## Security impact
- Preserves the #2700 fail-closed access-control guarantee (empty/missing feature requirement never grants access, including for superadmins). Rejects the tempting "empty → allow" reading that would reintroduce the vulnerability.