### PR TITLE
fix(customers,staff,checkout): QA #2529 follow-up select-prefill, domain-clear & stale-delete conflict

### DIFF
--- a/.ai/runs/2026-06-08-qa-2529-followup-fixes.md
+++ b/.ai/runs/2026-06-08-qa-2529-followup-fixes.md
@@ -87,10 +87,10 @@ QA comment id `4638514821` on issue #2529. Three actionable items:
 
 ### Phase 2: Company Domain clearable
 
-- [ ] 2.1 Make `companyDetailsSchema.domain` clearable (nullable) in validators.ts
-- [ ] 2.2 Add `assignClearable(payload, 'domain', …)` + widen `CompanyEditFormValues.domain`
-- [ ] 2.3 Unit tests: validator accepts null/'' and edit payload sends `domain: null`
-- [ ] 2.4 Integration spec: company domain clear persists (Playwright)
+- [x] 2.1 Make `companyDetailsSchema.domain` clearable (nullable) in validators.ts — 527c5f5d7
+- [x] 2.2 Add `assignClearable(payload, 'domain', …)` + widen `CompanyEditFormValues.domain` — 527c5f5d7
+- [x] 2.3 Unit tests: validator accepts null/'' and edit payload sends `domain: null` — 796057e54
+- [x] 2.4 Integration spec: company domain clear persists (Playwright) — 796057e54
 
 ### Phase 3: Checkout template stale-delete conflict
 

--- a/.ai/runs/2026-06-08-qa-2529-followup-fixes.md
+++ b/.ai/runs/2026-06-08-qa-2529-followup-fixes.md
@@ -94,5 +94,5 @@ QA comment id `4638514821` on issue #2529. Three actionable items:
 
 ### Phase 3: Checkout template stale-delete conflict
 
-- [ ] 3.1 Import + call `enforceRecordGoneIsConflict` before 404 in update & delete commands
-- [ ] 3.2 Integration spec: deleted template + lock header → 409 conflict (not 404)
+- [x] 3.1 Import + call `enforceRecordGoneIsConflict` before 404 in update & delete commands — 8fdff7dd2
+- [x] 3.2 Integration spec: deleted template + lock header → 409 conflict (not 404) — 061daf3c0

--- a/.ai/runs/2026-06-08-qa-2529-followup-fixes.md
+++ b/.ai/runs/2026-06-08-qa-2529-followup-fixes.md
@@ -81,9 +81,9 @@ QA comment id `4638514821` on issue #2529. Three actionable items:
 
 ### Phase 1: Team Member team select prefill
 
-- [ ] 1.1 Render saved team label in `<SelectValue>` + add remount `key` in TeamMemberForm
-- [ ] 1.2 Unit test: TeamMemberForm shows saved team label on edit (component render test)
-- [ ] 1.3 Integration spec: team-member edit Team select prefill (Playwright)
+- [x] 1.1 Render saved team label in `<SelectValue>` + add remount `key` in TeamMemberForm — 0fb45873d
+- [x] 1.2 Unit test: TeamMemberForm shows saved team label on edit (component render test) — 0fb45873d
+- [x] 1.3 Integration spec: team-member edit Team select prefill (Playwright) — c444be4eb
 
 ### Phase 2: Company Domain clearable
 

--- a/.ai/runs/2026-06-08-qa-2529-followup-fixes.md
+++ b/.ai/runs/2026-06-08-qa-2529-followup-fixes.md
@@ -1,0 +1,98 @@
+# Execution Plan — QA #2529 follow-up fixes (alinadivante comment 4638514821)
+
+## Goal
+
+Fix the three still-failing / gap items reported by alinadivante in
+https://github.com/open-mercato/open-mercato/issues/2529#issuecomment-4638514821,
+and add integration coverage for each fixed case, in a single PR.
+
+## Source
+
+QA comment id `4638514821` on issue #2529. Three actionable items:
+
+1. ❌ **Team Member "Team" select prefill** still reproduces. On the team-member
+   edit ("Member settings") form the Team select renders as `-` even though the
+   member has a saved team (visible in Highlights). Saving another field can
+   silently detach the member from its team.
+2. ❌ **Company "Domain" field cannot be cleared.** Clearing Domain → save →
+   hard reload restores the old value. (Website clears fine; phone/email already
+   fixed in #2526.)
+3. ⚠️ **Checkout template stale-edit after delete** ends with a raw
+   `Template not found` (404) instead of the unified optimistic-lock conflict
+   bar when the record was deleted in another tab.
+
+## Root causes (verified read-only)
+
+1. `packages/core/src/modules/staff/components/TeamMemberForm.tsx` (~L306-362):
+   the Team field is a custom Radix `<Select>` whose `<SelectValue>` has **no
+   children** and the `<Select>` has **no `key`**, so on first render Radix
+   cannot derive the selected option's label (closed content → item not mounted)
+   and shows the placeholder `—`. The fixed `ResourceCrudForm.tsx` resource-type
+   select (confirmed working by QA) renders `selectedOption?.label` as children
+   of `<SelectValue>` **and** sets a `key` keyed on value+options. The PR-#2608
+   seed-by-id effect already prepends the saved team to `teamOptions`; only the
+   display wiring is missing.
+2. `packages/core/src/modules/customers/components/formConfig.tsx`:
+   `buildCompanyEditPayload` calls `assignClearable` for `primaryEmail`,
+   `primaryPhone`, `websiteUrl` but **not** `domain`, so a blanked domain is
+   dropped by the base `assign()` (`blankToUndefined` → `undefined`) and never
+   transmitted as `null`. The `companyDetailsSchema.domain` validator in
+   `data/validators.ts` (L97) is also non-nullable, so an explicit `null` would
+   be rejected. The update command already writes `profile.domain = parsed.domain
+   ?? null` when `parsed.domain !== undefined` (commands/companies.ts L770).
+3. `packages/checkout/src/modules/checkout/commands/templates.ts`: the update
+   (L269) and delete (L425) command handlers throw `CrudHttpError(404)` when the
+   template is gone **before** any lock check. The shared helper
+   `enforceRecordGoneIsConflict` (optimistic-lock-command.ts L213) converts that
+   to a structured 409 when the client sent the expected-version header — which
+   the `LinkTemplateForm` (CrudForm) already sends and already surfaces via
+   `surfaceRecordConflict`. The helper is fail-open (no header → unchanged 404).
+
+## Scope
+
+- `packages/core/src/modules/staff/components/TeamMemberForm.tsx`
+- `packages/core/src/modules/customers/data/validators.ts`
+- `packages/core/src/modules/customers/components/formConfig.tsx`
+- `packages/checkout/src/modules/checkout/commands/templates.ts`
+- Unit tests (mandatory) + Playwright integration specs (requested) per module.
+
+## Non-goals
+
+- The other "✅ Fixed" items in the same comment (gateway validation, phone
+  clearing, team-role prefill, resource selects, capture method, deal pipeline).
+- The broad select-prefill audit candidates in earlier comments (not in the
+  target comment; no confirmed repro).
+- Touching DB schema (columns already nullable) — no migration.
+
+## Risks
+
+- Team select fix must not regress the team-change side effect (role filtering /
+  `selectedTeamId`) — keep the existing `onValueChange` body intact; only add
+  `key` + `<SelectValue>` children.
+- Domain clearing must not break create flow (base `assign` still lowercases on
+  create; `assignClearable` only overrides in the edit builder, mirroring
+  websiteUrl).
+- Checkout 409 conversion is additive/fail-open; must not change behavior for API
+  clients that never send the lock header.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Team Member team select prefill
+
+- [ ] 1.1 Render saved team label in `<SelectValue>` + add remount `key` in TeamMemberForm
+- [ ] 1.2 Unit test: TeamMemberForm shows saved team label on edit (component render test)
+- [ ] 1.3 Integration spec: team-member edit Team select prefill (Playwright)
+
+### Phase 2: Company Domain clearable
+
+- [ ] 2.1 Make `companyDetailsSchema.domain` clearable (nullable) in validators.ts
+- [ ] 2.2 Add `assignClearable(payload, 'domain', …)` + widen `CompanyEditFormValues.domain`
+- [ ] 2.3 Unit tests: validator accepts null/'' and edit payload sends `domain: null`
+- [ ] 2.4 Integration spec: company domain clear persists (Playwright)
+
+### Phase 3: Checkout template stale-delete conflict
+
+- [ ] 3.1 Import + call `enforceRecordGoneIsConflict` before 404 in update & delete commands
+- [ ] 3.2 Integration spec: deleted template + lock header → 409 conflict (not 404)

--- a/packages/checkout/src/modules/checkout/__integration__/TC-CHKT-041-template-stale-delete-conflict.spec.ts
+++ b/packages/checkout/src/modules/checkout/__integration__/TC-CHKT-041-template-stale-delete-conflict.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import {
+  createFixedTemplateInput,
+  createTemplateFixture,
+  deleteCheckoutEntityIfExists,
+  deleteTemplate,
+  updateTemplate,
+} from './helpers/fixtures'
+
+const OPTIMISTIC_LOCK_HEADER = 'x-om-ext-optimistic-lock-expected-updated-at'
+const STALE_EXPECTED_AT = '2020-01-01T00:00:00.000Z'
+
+function resolveUrl(path: string): string {
+  const base = process.env.BASE_URL?.trim() || null
+  return base ? `${base}${path}` : path
+}
+
+// Regression for #2529 (alinadivante comment 4638514821, "TC A" optimistic-lock gap):
+// editing a checkout template that was deleted in another tab must surface a clean
+// optimistic-lock conflict (409) when the client sent the expected-version header —
+// not a bare "Template not found" 404. Plain API clients that send no header keep the
+// existing 404 (fail-open).
+test.describe('TC-CHKT-041: Checkout template stale-edit after delete', () => {
+  test('PUT with stale optimistic-lock header on a deleted template returns 409 conflict', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let templateId: string | null = null
+
+    try {
+      templateId = await createTemplateFixture(request, token, createFixedTemplateInput({ status: 'draft' }))
+
+      // Simulate "deleted in another tab".
+      const deleteResponse = await deleteTemplate(request, token, templateId)
+      expect(deleteResponse.ok(), 'template delete fixture should succeed').toBeTruthy()
+
+      // Replay a stale edit carrying the optimistic-lock header → expect 409.
+      const conflictResponse = await request.fetch(resolveUrl(`/api/checkout/templates/${encodeURIComponent(templateId)}`), {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          [OPTIMISTIC_LOCK_HEADER]: STALE_EXPECTED_AT,
+        },
+        data: { name: 'QA stale edit' },
+      })
+      expect(conflictResponse.status(), 'stale edit after delete should be a 409 conflict').toBe(409)
+      const conflictBody = await readJsonSafe<{ code?: string }>(conflictResponse)
+      expect(conflictBody?.code, 'conflict body should carry the optimistic-lock code').toBe('optimistic_lock_conflict')
+
+      // Without the header, the same edit keeps the plain 404 (fail-open).
+      const notFoundResponse = await updateTemplate(request, token, templateId, { name: 'QA stale edit no header' })
+      expect(notFoundResponse.status(), 'no-header edit after delete should stay 404').toBe(404)
+    } finally {
+      await deleteCheckoutEntityIfExists(request, token, 'templates', templateId)
+    }
+  })
+})

--- a/packages/checkout/src/modules/checkout/commands/templates.ts
+++ b/packages/checkout/src/modules/checkout/commands/templates.ts
@@ -6,7 +6,7 @@ import { buildCustomFieldResetMap, loadCustomFieldSnapshot } from '@open-mercato
 import { setCustomFieldsIfAny } from '@open-mercato/shared/lib/commands/helpers'
 import { resolveRedoSnapshot } from '@open-mercato/shared/lib/commands/redo'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
-import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
+import { enforceCommandOptimisticLock, enforceRecordGoneIsConflict } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { CheckoutLink, CheckoutLinkTemplate } from '../data/entities'
@@ -266,7 +266,17 @@ const updateTemplateCommand: CommandHandler<Record<string, unknown>, { ok: true 
       tenantId: scope.tenantId,
       deletedAt: null,
     }, undefined, scope)
-    if (!template) throw new CrudHttpError(404, { error: 'Template not found' })
+    if (!template) {
+      // The template was deleted in another tab. When the client opted into
+      // optimistic locking, surface the unified conflict bar instead of a bare
+      // 404 (#2529); otherwise the plain 404 still fires for API consumers.
+      enforceRecordGoneIsConflict({
+        resourceKind: 'checkout.template',
+        resourceId: parsed.id,
+        request: ctx.request ?? null,
+      })
+      throw new CrudHttpError(404, { error: 'Template not found' })
+    }
     enforceCommandOptimisticLock({
       resourceKind: 'checkout.template',
       resourceId: template.id,
@@ -422,7 +432,16 @@ const deleteTemplateCommand: CommandHandler<Record<string, unknown>, { ok: true 
       tenantId: scope.tenantId,
       deletedAt: null,
     }, undefined, scope)
-    if (!template) throw new CrudHttpError(404, { error: 'Template not found' })
+    if (!template) {
+      // Already deleted elsewhere — convert to a 409 conflict when the client
+      // sent the optimistic-lock header so the stale edit surfaces cleanly (#2529).
+      enforceRecordGoneIsConflict({
+        resourceKind: 'checkout.template',
+        resourceId: templateId,
+        request: ctx.request ?? null,
+      })
+      throw new CrudHttpError(404, { error: 'Template not found' })
+    }
     enforceCommandOptimisticLock({
       resourceKind: 'checkout.template',
       resourceId: template.id,

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-080-company-domain-clear.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-080-company-domain-clear.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { deleteGeneralEntityIfExists, expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+const COMPANIES_PATH = '/api/customers/companies'
+
+// Regression for #2529 (alinadivante comment 4638514821, "TC C"): a previously-set
+// company Domain must be clearable. Before the fix the blanked value was dropped
+// from the update payload (and rejected by the non-nullable validator), so the old
+// domain reappeared after reload. Website already cleared correctly.
+test.describe('TC-CRM-080: Company domain is clearable on edit', () => {
+  test('clearing a saved domain persists as empty', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    const domain = `qa-domain-${stamp}.example.com`
+    let companyId: string | null = null
+
+    try {
+      const createResponse = await apiRequest(request, 'POST', COMPANIES_PATH, {
+        token,
+        data: { displayName: `QA Domain Co ${stamp}`, domain },
+      })
+      expect(createResponse.status(), 'company create should return 201').toBe(201)
+      companyId = expectId((await readJsonSafe<{ id?: string }>(createResponse))?.id, 'company id')
+
+      const afterCreate = await apiRequest(request, 'GET', `${COMPANIES_PATH}?ids=${companyId}&pageSize=1`, { token })
+      const created = (await readJsonSafe<{ items?: Array<{ domain?: string | null }> }>(afterCreate))?.items?.[0]
+      expect(created?.domain, 'domain should be saved on create').toBe(domain)
+
+      const clearResponse = await apiRequest(request, 'PUT', COMPANIES_PATH, {
+        token,
+        data: { id: companyId, domain: '' },
+      })
+      expect(clearResponse.status(), 'domain clear update should succeed').toBeLessThan(400)
+
+      const afterClear = await apiRequest(request, 'GET', `${COMPANIES_PATH}?ids=${companyId}&pageSize=1`, { token })
+      const cleared = (await readJsonSafe<{ items?: Array<{ domain?: string | null }> }>(afterClear))?.items?.[0]
+      expect(cleared?.domain ?? null, 'domain should be cleared after save').toBeNull()
+    } finally {
+      await deleteGeneralEntityIfExists(request, token, COMPANIES_PATH, companyId)
+    }
+  })
+})

--- a/packages/core/src/modules/customers/__tests__/validators.test.ts
+++ b/packages/core/src/modules/customers/__tests__/validators.test.ts
@@ -295,4 +295,24 @@ describe('person/company clearable URL & email update fields (#2526)', () => {
       companyUpdateSchema.safeParse({ ...companyBase, primaryEmail: 'not-an-email' }).success,
     ).toBe(false)
   })
+
+  it('coerces empty-string and null company domain to null (#2529)', () => {
+    const empties = companyUpdateSchema.safeParse({ ...companyBase, domain: '' })
+    expect(empties.success).toBe(true)
+    if (empties.success) {
+      expect(empties.data.domain).toBeNull()
+    }
+
+    const nulls = companyUpdateSchema.safeParse({ ...companyBase, domain: null })
+    expect(nulls.success).toBe(true)
+    if (nulls.success) {
+      expect(nulls.data.domain).toBeNull()
+    }
+
+    const set = companyUpdateSchema.safeParse({ ...companyBase, domain: 'acme.com' })
+    expect(set.success).toBe(true)
+    if (set.success) {
+      expect(set.data.domain).toBe('acme.com')
+    }
+  })
 })

--- a/packages/core/src/modules/customers/components/__tests__/formConfig.test.ts
+++ b/packages/core/src/modules/customers/components/__tests__/formConfig.test.ts
@@ -203,6 +203,32 @@ describe('clearing v2 URL & email edit fields (#2526)', () => {
     expect(payload.websiteUrl).toBeNull()
   })
 
+  it('transmits null when a previously-set company domain is blanked (#2529)', () => {
+    const parsed = createCompanyEditSchema().safeParse({
+      id: COMPANY_ID,
+      displayName: 'Acme',
+      domain: '',
+    })
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+
+    const payload = buildCompanyEditPayload(parsed.data as any)
+    expect(payload.domain).toBeNull()
+  })
+
+  it('keeps and lowercases a non-empty company domain on edit (#2529)', () => {
+    const parsed = createCompanyEditSchema().safeParse({
+      id: COMPANY_ID,
+      displayName: 'Acme',
+      domain: 'Acme.COM',
+    })
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+
+    const payload = buildCompanyEditPayload(parsed.data as any)
+    expect(payload.domain).toBe('acme.com')
+  })
+
   it('keeps non-empty company website/email/phone values on edit', () => {
     const parsed = createCompanyEditSchema().safeParse({
       id: COMPANY_ID,

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -1464,11 +1464,12 @@ export function buildCompanyPayload(
 
 // URL/email/phone fields are clearable on edit: blanking a previously-set value transmits null,
 // so the edit-form value types widen to `string | null` to match the edit-schema output. See #2526.
-export type CompanyEditFormValues = Omit<CompanyFormValues, 'addresses' | 'primaryEmail' | 'primaryPhone' | 'websiteUrl'> & {
+export type CompanyEditFormValues = Omit<CompanyFormValues, 'addresses' | 'primaryEmail' | 'primaryPhone' | 'websiteUrl' | 'domain'> & {
   id: string
   primaryEmail?: string | null
   primaryPhone?: string | null
   websiteUrl?: string | null
+  domain?: string | null
 }
 
 export type PersonEditFormValues = Omit<PersonFormValues, 'addresses' | 'primaryEmail' | 'primaryPhone'> & {
@@ -1517,6 +1518,18 @@ const clearableEmailField = () =>
     .transform((val) => (val === '' ? null : val))
     .optional()
 
+// Domain maps to a nullable column; on edit a blanked value must transmit null
+// (not undefined) so it actually clears — mirroring the website field. See #2529.
+const clearableDomainField = () =>
+  z
+    .string()
+    .trim()
+    .max(200)
+    .optional()
+    .or(z.literal(''))
+    .transform((val) => (val === '' ? null : val))
+    .optional()
+
 const clearablePhoneField = () =>
   z
     .string()
@@ -1534,6 +1547,7 @@ export const createCompanyEditSchema = () =>
     primaryEmail: clearableEmailField(),
     primaryPhone: clearablePhoneField(),
     websiteUrl: clearableUrlField(),
+    domain: clearableDomainField(),
   })
 
 export const createPersonEditSchema = () =>
@@ -1844,6 +1858,7 @@ export function buildCompanyEditPayload(values: CompanyEditFormValues, organizat
   assignClearable(payload, 'primaryEmail', values.primaryEmail)
   assignClearable(payload, 'primaryPhone', values.primaryPhone)
   assignClearable(payload, 'websiteUrl', values.websiteUrl)
+  assignClearable(payload, 'domain', typeof values.domain === 'string' ? values.domain.toLowerCase() : values.domain)
 
   return payload
 }

--- a/packages/core/src/modules/customers/data/validators.ts
+++ b/packages/core/src/modules/customers/data/validators.ts
@@ -37,6 +37,13 @@ const clearableUrlSchema = z.preprocess(
   z.string().url().max(300).nullable().optional(),
 )
 
+// Domain is a plain (non-URL) string that maps to a nullable column, so blanking
+// a previously-set value on edit must transmit null to clear it. See #2529.
+const clearableDomainSchema = z.preprocess(
+  emptyStringToNull,
+  z.string().trim().max(200).nullable().optional(),
+)
+
 const interactionPhoneNumberSchema = z.string().trim().max(50).optional().nullable()
 
 const scopedSchema = z.object({
@@ -94,7 +101,7 @@ const personLastNameSchema = z.string().trim().min(1).max(120)
 const companyDetailsSchema = {
   legalName: z.string().trim().max(200).optional(),
   brandName: z.string().trim().max(200).optional(),
-  domain: z.string().trim().max(200).optional(),
+  domain: clearableDomainSchema,
   websiteUrl: clearableUrlSchema,
   industry: z.string().trim().max(150).optional(),
   sizeBucket: z.string().trim().max(100).optional(),

--- a/packages/core/src/modules/staff/__integration__/TC-STAFF-026-team-member-edit-select-prefill.spec.ts
+++ b/packages/core/src/modules/staff/__integration__/TC-STAFF-026-team-member-edit-select-prefill.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { login } from '@open-mercato/core/helpers/integration/auth'
+import { deleteGeneralEntityIfExists, expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+const MEMBERS_PATH = '/api/staff/team-members'
+const TEAMS_PATH = '/api/staff/teams'
+
+// Regression for #2529 (alinadivante comment 4638514821, "TC D"): the saved Team
+// must render inside the Member settings select trigger — not only the Highlights
+// card — otherwise saving another field silently detaches the member from its team.
+test.describe('TC-STAFF-026: Team member edit select prefill', () => {
+  test('member settings team select shows the saved team in the trigger', async ({ page, request }) => {
+    test.slow()
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    let teamId: string | null = null
+    let memberId: string | null = null
+    const teamName = `QA Member Team ${stamp}`
+    const memberName = `QA Member ${stamp}`
+
+    try {
+      const teamResponse = await apiRequest(request, 'POST', TEAMS_PATH, {
+        token,
+        data: { name: teamName, isActive: true },
+      })
+      expect(teamResponse.status(), 'team fixture create should return 201').toBe(201)
+      teamId = expectId((await readJsonSafe<{ id?: string }>(teamResponse))?.id, 'team fixture id')
+
+      const memberResponse = await apiRequest(request, 'POST', MEMBERS_PATH, {
+        token,
+        data: { displayName: memberName, teamId, isActive: true },
+      })
+      expect(memberResponse.status(), 'member fixture create should return 201').toBe(201)
+      memberId = expectId((await readJsonSafe<{ id?: string }>(memberResponse))?.id, 'member fixture id')
+
+      await login(page, 'admin')
+      await page.goto(`/backend/staff/team-members/${encodeURIComponent(memberId)}`, { waitUntil: 'commit' })
+
+      await expect(page.getByRole('heading', { name: 'Member settings' }).first()).toBeVisible()
+      const teamField = page.locator('[data-crud-field-id="teamId"]').first()
+      const teamSelect = teamField.getByRole('combobox').first()
+      await expect(teamSelect).toBeVisible()
+      await expect(teamSelect).toContainText(teamName)
+    } finally {
+      await deleteGeneralEntityIfExists(request, token, MEMBERS_PATH, memberId)
+      await deleteGeneralEntityIfExists(request, token, TEAMS_PATH, teamId)
+    }
+  })
+})

--- a/packages/core/src/modules/staff/components/TeamMemberForm.tsx
+++ b/packages/core/src/modules/staff/components/TeamMemberForm.tsx
@@ -309,6 +309,8 @@ export function TeamMemberForm(props: TeamMemberFormProps) {
         type: 'custom',
         component: ({ value, setValue, setFormValue, values, disabled }) => {
           const currentValue = typeof value === 'string' ? value : ''
+          const selectedOption = teamOptions.find((option) => option.value === currentValue)
+          const optionsKey = teamOptions.map((option) => `${option.value}:${option.label}`).join('\0')
           return (
             <div className="space-y-2">
               <div className="flex items-center justify-between gap-3">
@@ -327,6 +329,7 @@ export function TeamMemberForm(props: TeamMemberFormProps) {
                 </Button>
               </div>
               <Select
+                key={`team:${currentValue}:${optionsKey}`}
                 value={currentValue}
                 onValueChange={(value) => {
                   const nextValue = value || undefined
@@ -346,7 +349,9 @@ export function TeamMemberForm(props: TeamMemberFormProps) {
                 disabled={disabled}
               >
                 <SelectTrigger data-crud-focus-target="">
-                  <SelectValue placeholder={translate('ui.forms.select.emptyOption', '—')} />
+                  <SelectValue placeholder={translate('ui.forms.select.emptyOption', '—')}>
+                    {selectedOption?.label}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {teamOptions.map((option) => (

--- a/packages/core/src/modules/staff/components/__tests__/TeamMemberForm.teamPrefill.test.tsx
+++ b/packages/core/src/modules/staff/components/__tests__/TeamMemberForm.teamPrefill.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { TeamMemberForm } from '../TeamMemberForm'
+
+const TEAM_ID = '11111111-1111-1111-1111-111111111111'
+const TEAM_NAME = 'Engineering'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 0,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(async (url: string) => {
+    if (url.includes('/api/staff/teams')) {
+      return { result: { items: [{ id: TEAM_ID, name: TEAM_NAME }] } }
+    }
+    return { result: { items: [] } }
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/inputs', () => ({
+  LookupSelect: () => <div data-testid="lookup-select" />,
+}))
+
+jest.mock('@open-mercato/ui/backend/detail', () => ({
+  AttachmentsSection: () => <div />,
+  TagsSection: () => <div />,
+}))
+
+// Surface `<SelectValue>` children into the trigger so the test can assert the
+// pre-selected team label renders (the fix). The real Radix `Select` shows the
+// placeholder until content opens unless the label is passed as SelectValue
+// children — exactly what this test guards against.
+jest.mock('@open-mercato/ui/primitives/select', () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="team-select-trigger">{children}</div>
+  ),
+  SelectValue: ({ children, placeholder }: { children?: React.ReactNode; placeholder?: string }) => (
+    <span>{children ?? placeholder}</span>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="team-select-content">{children}</div>
+  ),
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+// Render only the custom field components so the real teamId field logic runs.
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
+  CrudForm: ({
+    fields,
+    initialValues,
+  }: {
+    fields: Array<{ id: string; type: string; component?: (props: Record<string, unknown>) => React.ReactNode }>
+    initialValues: Record<string, unknown>
+  }) => (
+    <div>
+      {(fields || []).map((field) =>
+        field.type === 'custom' && field.component ? (
+          <div key={field.id} data-field={field.id}>
+            {field.component({
+              value: initialValues?.[field.id],
+              setValue: () => {},
+              setFormValue: () => {},
+              values: initialValues,
+              disabled: false,
+            })}
+          </div>
+        ) : null,
+      )}
+    </div>
+  ),
+}))
+
+function renderForm() {
+  return render(
+    <TeamMemberForm
+      embedded
+      title="Edit team member"
+      backHref="/backend/staff/team-members"
+      cancelHref="/backend/staff/team-members"
+      initialValues={{
+        id: '22222222-2222-2222-2222-222222222222',
+        teamId: TEAM_ID,
+        displayName: 'Priya Nair',
+        roleIds: [],
+        isActive: true,
+        updatedAt: '2026-06-01T00:00:00.000Z',
+      }}
+      onSubmit={async () => {}}
+    />,
+  )
+}
+
+describe('TeamMemberForm team select prefill', () => {
+  it('renders the saved team label inside the select trigger on edit', async () => {
+    renderForm()
+    await screen.findByTestId('team-select-trigger')
+    await waitFor(() => {
+      const teamField = screen.getByTestId('team-select-trigger')
+      expect(within(teamField).getByText(TEAM_NAME)).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-08-qa-2529-followup-fixes.md
Status: complete

## Goal
- Fix the three still-failing / gap items raised by @alinadivante in https://github.com/open-mercato/open-mercato/issues/2529#issuecomment-4638514821 and add integration coverage for each.

## What Changed
- **Team Member edit select prefill (#2529 "TC D").** `TeamMemberForm` rendered the Team select via a raw Radix `<Select>` whose `<SelectValue>` had no children and no remount `key`, so the saved team showed as `—` on open and an unrelated save could silently detach the member. Now mirrors the fixed `ResourceCrudForm` pattern: render `selectedOption.label` as `<SelectValue>` children and key the `<Select>` on value+options. The team-change side effect (role filtering) is unchanged.
- **Company Domain not clearable (#2529 "TC C").** `buildCompanyEditPayload` sent `assignClearable` for email/phone/website but not `domain`, and the `domain` validator was non-nullable. Added a clearable domain validator (empty → null), overrode `domain` in the company edit form schema with a clearable field, widened `CompanyEditFormValues.domain` to `string | null`, and send `domain` (lowercased) via `assignClearable` so a blanked domain transmits `null`. The update command already writes `profile.domain = parsed.domain ?? null`.
- **Checkout template stale-edit after delete (#2529 "TC A" optimistic-lock gap).** The update/delete template commands threw a bare 404 before any lock check, so a stale save after another tab deleted the record showed `Template not found` instead of the unified conflict bar. Both handlers now call the shared `enforceRecordGoneIsConflict` before the 404: it converts the gone-record case to a structured 409 when the client sent the expected-version header (which `LinkTemplateForm`/CrudForm already do and already surface via `surfaceRecordConflict`), and stays fail-open (404) for header-less API clients.

## Tests
- Unit: `TeamMemberForm.teamPrefill.test.tsx` (jsdom render — fails on the old code), `formConfig.test.ts` (domain clear + lowercase), `validators.test.ts` (company domain '' / null → null).
- Integration: `TC-STAFF-026` (member-settings Team trigger shows saved team), `TC-CRM-080` (company domain clear persists via API round-trip), `TC-CHKT-041` (deleted template + lock header → 409; header-less → 404).

## Backward Compatibility
- No contract surface removed. Validator/`CompanyEditFormValues` changes are additive widenings (now also accept `null`). The checkout change is additive and fail-open. No event IDs, widget spot IDs, ACL IDs, import paths, DI names, API routes, or DB schema changed. No migration.

## Validation
- `yarn build:packages` ✓ · `yarn generate` ✓ (no drift) · `yarn build:packages` (post-generate) ✓ · `yarn i18n:check-sync` ✓ · `yarn i18n:check-usage` ✓ (advisory) · `yarn typecheck` ✓ · `yarn test` ✓ (one pre-existing unrelated failure: `inbox_ops/executionHelpers.superadmin.test.ts`, introduced on develop by #2804) · `yarn build:app` ✓

## Progress
See [Progress section in the plan](.ai/runs/2026-06-08-qa-2529-followup-fixes.md#progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
