### PR TITLE
fix(customers): link Cmd+K search results to v2 customer detail pages (#2843)

### DIFF
--- a/packages/core/src/modules/customers/__tests__/search.test.ts
+++ b/packages/core/src/modules/customers/__tests__/search.test.ts
@@ -42,4 +42,26 @@ describe('customers search config', () => {
     )
     expect(query.mock.calls[0]?.[1]).not.toHaveProperty('customFieldSources')
   })
+
+  test('person search results link to the v2 detail page (#2843)', async () => {
+    const personConfig = searchConfig.entities.find((entity) => entity.entityId === 'customers:customer_person_profile')
+    const ctx = { record: { entity_id: 'entity-1' } } as any
+
+    const url = await personConfig!.resolveUrl!(ctx)
+    expect(url).toBe('/backend/customers/people-v2/entity-1')
+
+    const links = await personConfig!.resolveLinks!(ctx)
+    expect(links?.[0]?.href).toContain('/backend/customers/people-v2/entity-1')
+  })
+
+  test('company search results link to the v2 detail page (#2843)', async () => {
+    const companyConfig = searchConfig.entities.find((entity) => entity.entityId === 'customers:customer_company_profile')
+    const ctx = { record: { entity_id: 'entity-2' } } as any
+
+    const url = await companyConfig!.resolveUrl!(ctx)
+    expect(url).toBe('/backend/customers/companies-v2/entity-2')
+
+    const links = await companyConfig!.resolveLinks!(ctx)
+    expect(links?.[0]?.href).toContain('/backend/customers/companies-v2/entity-2')
+  })
 })

--- a/packages/core/src/modules/customers/search.ts
+++ b/packages/core/src/modules/customers/search.ts
@@ -363,9 +363,9 @@ async function getLinkedTodo(ctx: SearchContext) {
 function buildCustomerUrl(kind: string | null | undefined, id?: string | null): string | null {
   if (!id) return null
   const encoded = encodeURIComponent(id)
-  if (kind === 'person') return `/backend/customers/people/${encoded}`
-  if (kind === 'company') return `/backend/customers/companies/${encoded}`
-  return `/backend/customers/companies/${encoded}`
+  if (kind === 'person') return `/backend/customers/people-v2/${encoded}`
+  if (kind === 'company') return `/backend/customers/companies-v2/${encoded}`
+  return `/backend/customers/companies-v2/${encoded}`
 }
 
 function formatDealValue(record: Record<string, unknown>): string | undefined {


### PR DESCRIPTION
Closes #2843

## Problem

Customer (person / company) results in the **Cmd+K** global search linked to the legacy **v1** detail routes:

- `/backend/customers/people/<id>`
- `/backend/customers/companies/<id>`

Everywhere else in the app — the people/companies list rows, their row actions (`onRowClick`, "Open in new tab"), and the CRM integration tests (`TC-CRM-001/002/004`, `TC-WF-008`) — navigates to the **v2** detail pages (`people-v2` / `companies-v2`). So Cmd+K dropped users on the old v1.0 pages while the rest of the UI used v2.0.

## Fix

Point `buildCustomerUrl` (the single helper feeding search `resolveUrl` and `resolveLinks` for both people and companies) at the `*-v2` routes, matching the canonical detail surface used app-wide.

## Tests

Added regression tests in `customers/__tests__/search.test.ts` asserting the person and company search configs resolve to `people-v2` / `companies-v2` URLs.

```
NODE_ENV=test yarn jest src/modules/customers/__tests__/search.test.ts  # 3 passed
```

## Notes / out of scope

- The secondary **"Edit"** search action appends `/edit` to the detail URL. There is **no** `/edit` route for people, companies, **or** deals — all three edit inline on their `[id]` detail page — so that link is a pre-existing dead end across all customer search results, unrelated to this v1→v2 report. Left untouched to keep the diff tight; worth a separate follow-up.
- `customer_accounts/.../users/[id]/page.tsx` also links a person to the v1 route — another surface, out of scope for this Cmd+K issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)