### PR TITLE
fix(webhooks): stabilize TC-LOCK-OSS-043 stale-row locator after out-of-band bump

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -950,6 +950,16 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 
 **Applies to**: Radix-backed `Select` wrappers, custom `CrudForm` select components, dictionary selects, relation selects, and any async edit form whose option list may be loaded after the initial value.
 
+## Out-of-band bumps in browser optimistic-lock tests must not change the row's visible name
+
+**Context**: `TC-LOCK-OSS-043` browser test for WHK-01 bumped the webhook's `name` field out-of-band to advance `updated_at` and make the in-page lock token stale.
+
+**Problem**: If Next.js or the client re-fetches the list after the out-of-band PUT, the row's accessible name changes (`"QA Lock 043 bumped ${stamp}"`), so the Playwright row locator `/QA Lock 043 ${stamp}\b/` no longer matches. The test failed intermittently with `element(s) not found` on `getByRole('button', { name: /open actions/i })` scoped inside the now-gone row.
+
+**Rule**: In browser-driven optimistic-lock tests, the out-of-band bump must touch only fields that are not part of the row's visible text or accessible name (e.g. `description`, a hidden metadata field, an unrendered flag). This ensures the row locator remains stable regardless of whether the page re-fetches data after the bump.
+
+**Applies to**: All `TC-LOCK-*` browser tests that locate a row by its name and then trigger an out-of-band write before interacting with the row's actions.
+
 ## Use cryptographic randomness in auth-adjacent test helpers
 
 **Context**: CodeQL reported insecure randomness in integration helpers where generated fixture values flowed through authenticated API requests and auth rate-limit tests.

--- a/packages/webhooks/src/modules/webhooks/__integration__/TC-LOCK-OSS-043.spec.ts
+++ b/packages/webhooks/src/modules/webhooks/__integration__/TC-LOCK-OSS-043.spec.ts
@@ -247,9 +247,11 @@ test.describe('TC-LOCK-OSS-043: webhooks + inbox settings + data-sync schedule o
       await expect(row, 'created webhook should appear in the list').toBeVisible({ timeout: 20_000 })
 
       // Advance updated_at out-of-band → the in-page row token is now stale.
+      // NOTE: bump description (not name) so the row locator stays valid even if
+      // the list re-fetches after the PUT.
       const bump = await apiRequest(page.request, 'PUT', `${WEBHOOKS_API}/${webhookId}`, {
         token,
-        data: { name: `QA Lock 043 bumped ${stamp}` },
+        data: { description: `bumped-${stamp}` },
       })
       expect(bump.status(), 'out-of-band webhook PUT should succeed').toBeLessThan(300)
 


### PR DESCRIPTION
## Summary
  
`TC-LOCK-OSS-043` browser test (WHK-01 stale DELETE in the list) failed intermittently in CI (shard 15/15) because the out-of-band webhook bump changed the `name` field. When Next.js re-fetched the list after the PUT, the Playwright row locator `/QA Lock 043 ${stamp}\b/` no longer matched the renamed row, causing `element(s) not found` on the kebab button.
  
  Fix: bump `description` (non-visible field) instead of `name` so the row locator stays stable regardless of re-fetches.
  
  ## Changes
  
  - `TC-LOCK-OSS-043.spec.ts`: out-of-band bump uses `description` field, not `name`
  - `.ai/lessons.md`: documents root cause and rule for browser optimistic-lock tests

  ## Specification
  
  **Does a spec exist for this feature/module?**
  - [x] N/A (minor change, no spec needed)

  **Spec file path:**
  
  ## Testing

  Reproduces the CI failure from release 0.6.4 shard 15/15. The test now passes with the corrected bump field.
  
  ## Checklist
  
  - [x] This pull request targets `develop`.
  - [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
  - [x] I updated documentation, locales, or generators if the change requires it.
  - [x] I added or adjusted tests that cover the change.
  - [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
  - [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
  
  ### Design System Compliance
  
  N/A — no UI changes.

  ## Linked issues