### PR TITLE
fix(staff): surface and recover from optimistic-lock 409 on availability schedule switch (#2848)

### DIFF
--- a/packages/core/src/modules/staff/api/team-members.ts
+++ b/packages/core/src/modules/staff/api/team-members.ts
@@ -225,7 +225,12 @@ const crud = makeCrudRoute({
         const { translate } = await resolveTranslations()
         return parseScopedCommandInput(staffTeamMemberUpdateSchema, raw ?? {}, ctx, translate)
       },
-      response: () => ({ ok: true }),
+      // Surface the freshly-bumped updatedAt so inline (non-CrudForm) callers can
+      // refresh their optimistic-lock token between sequential edits (#2848).
+      response: (arg: { result?: { updatedAt?: string | null } | null }) => ({
+        ok: true,
+        updatedAt: arg?.result?.updatedAt ?? null,
+      }),
     },
     delete: {
       commandId: 'staff.team-members.delete',
@@ -287,7 +292,9 @@ export const openApi = createStaffCrudOpenApi({
   },
   update: {
     schema: staffTeamMemberUpdateSchema,
-    responseSchema: defaultOkResponseSchema,
+    responseSchema: defaultOkResponseSchema.extend({
+      updatedAt: z.string().nullable().optional(),
+    }),
     description: 'Updates a team member by id.',
   },
   del: {

--- a/packages/core/src/modules/staff/backend/staff/team-members/[id]/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/team-members/[id]/page.tsx
@@ -5,10 +5,10 @@ import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { Button } from '@open-mercato/ui/primitives/button'
-import { readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
+import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { extractCustomFieldEntries } from '@open-mercato/shared/lib/crud/custom-fields-client'
 import { updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
-import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { switchTeamMemberSchedule } from '@open-mercato/core/modules/staff/lib/scheduleSwitch'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { createTranslatorWithFallback } from '@open-mercato/shared/lib/i18n/translate'
@@ -297,12 +297,17 @@ export default function StaffTeamMemberDetailPage({ params }: { params?: { id?: 
 
   const handleRulesetChange = React.useCallback(async (nextId: string | null) => {
     if (!memberId) return
-    const headers = buildOptimisticLockHeader(initialValues?.updatedAt)
-    await withScopedApiRequestHeaders(headers, () => (
-      updateCrud('staff/team-members', { id: memberId, availabilityRuleSetId: nextId }, {
-        errorMessage: t('staff.teamMembers.availability.ruleset.updateError', 'Failed to update schedule.'),
-      })
-    ))
+    const { updatedAt: nextUpdatedAt } = await switchTeamMemberSchedule({
+      memberId,
+      nextRuleSetId: nextId,
+      expectedUpdatedAt: initialValues?.updatedAt,
+      t,
+    })
+    // Advance the optimistic-lock token so the next sequential switch sends the
+    // fresh updatedAt instead of the stale one and does not falsely 409 (#2848).
+    if (nextUpdatedAt) {
+      setInitialValues((prev) => (prev ? { ...prev, updatedAt: nextUpdatedAt } : prev))
+    }
     setAvailabilityRuleSetId(nextId)
     flash(t('staff.teamMembers.availability.ruleset.updateSuccess', 'Schedule updated.'), 'success')
   }, [initialValues?.updatedAt, memberId, t])

--- a/packages/core/src/modules/staff/backend/staff/team-members/[id]/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/team-members/[id]/page.tsx
@@ -276,6 +276,11 @@ export default function StaffTeamMemberDetailPage({ params }: { params?: { id?: 
     }
   }, [memberId, router, searchParams, t])
 
+  // optimistic-lock-exempt: the inline updateCrud/deleteCrud below run inside the
+  // TeamMemberForm <CrudForm> host, which auto-derives the version header from
+  // initialValues.updatedAt and surfaces 409 conflicts for both submit and delete.
+  // The availability-schedule switch is version-locked separately via
+  // switchTeamMemberSchedule (see ../../../../lib/scheduleSwitch).
   const handleSubmit = React.useCallback(async (values: TeamMemberFormValues) => {
     if (!memberId) return
     const payload = buildTeamMemberPayload(values, { id: memberId })

--- a/packages/core/src/modules/staff/commands/team-members.ts
+++ b/packages/core/src/modules/staff/commands/team-members.ts
@@ -292,7 +292,7 @@ const createTeamMemberCommand: CommandHandler<StaffTeamMemberCreateInput, { memb
   },
 }
 
-const updateTeamMemberCommand: CommandHandler<StaffTeamMemberUpdateInput, { memberId: string }> = {
+const updateTeamMemberCommand: CommandHandler<StaffTeamMemberUpdateInput, { memberId: string; updatedAt: string | null }> = {
   id: 'staff.team-members.update',
   async prepare(rawInput, ctx) {
     const { parsed } = parseWithCustomFields(staffTeamMemberUpdateSchema, rawInput)
@@ -368,7 +368,10 @@ const updateTeamMemberCommand: CommandHandler<StaffTeamMemberUpdateInput, { memb
       indexer: teamMemberCrudIndexer,
     })
 
-    return { memberId: member.id }
+    // Return the freshly-bumped updatedAt so non-CrudForm callers (e.g. the
+    // availability schedule switcher) can refresh their optimistic-lock token
+    // and not falsely 409 on the next sequential edit (#2848).
+    return { memberId: member.id, updatedAt: member.updatedAt ? member.updatedAt.toISOString() : null }
   },
   buildLog: async ({ snapshots, ctx }) => {
     const before = snapshots.before as TeamMemberSnapshot | undefined

--- a/packages/core/src/modules/staff/lib/__tests__/scheduleSwitch.test.ts
+++ b/packages/core/src/modules/staff/lib/__tests__/scheduleSwitch.test.ts
@@ -1,0 +1,136 @@
+/** @jest-environment jsdom */
+
+import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+
+const updateCrudMock = jest.fn()
+const surfaceRecordConflictMock = jest.fn()
+const scopedHeaderCalls: Array<Record<string, string>> = []
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  updateCrud: (...args: unknown[]) => updateCrudMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  withScopedApiRequestHeaders: <T,>(headers: Record<string, string>, run: () => Promise<T>) => {
+    scopedHeaderCalls.push(headers)
+    return run()
+  },
+}))
+
+jest.mock('@open-mercato/ui/backend/conflicts', () => ({
+  surfaceRecordConflict: (...args: unknown[]) => surfaceRecordConflictMock(...args),
+}))
+
+import { switchTeamMemberSchedule } from '../scheduleSwitch'
+
+const t = (_key: string, fallback?: string) => fallback ?? _key
+const MEMBER_ID = 'member-1'
+const V0 = '2026-06-08T08:00:00.000Z'
+const V1 = '2026-06-08T08:00:05.000Z'
+const V2 = '2026-06-08T08:00:09.000Z'
+
+describe('switchTeamMemberSchedule', () => {
+  beforeEach(() => {
+    updateCrudMock.mockReset()
+    surfaceRecordConflictMock.mockReset().mockReturnValue(true)
+    scopedHeaderCalls.length = 0
+  })
+
+  it('sends the optimistic-lock header derived from the current updatedAt', async () => {
+    updateCrudMock.mockResolvedValue({ result: { ok: true, updatedAt: V1 } })
+
+    await switchTeamMemberSchedule({
+      memberId: MEMBER_ID,
+      nextRuleSetId: 'ruleset-a',
+      expectedUpdatedAt: V0,
+      t,
+    })
+
+    expect(updateCrudMock).toHaveBeenCalledTimes(1)
+    expect(updateCrudMock).toHaveBeenCalledWith(
+      'staff/team-members',
+      { id: MEMBER_ID, availabilityRuleSetId: 'ruleset-a' },
+      expect.objectContaining({ errorMessage: expect.any(String) }),
+    )
+    expect(scopedHeaderCalls).toContainEqual({ [OPTIMISTIC_LOCK_HEADER_NAME]: V0 })
+  })
+
+  it('returns the freshly-bumped updatedAt from the response', async () => {
+    updateCrudMock.mockResolvedValue({ result: { ok: true, updatedAt: V1 } })
+
+    const result = await switchTeamMemberSchedule({
+      memberId: MEMBER_ID,
+      nextRuleSetId: 'ruleset-a',
+      expectedUpdatedAt: V0,
+      t,
+    })
+
+    expect(result.updatedAt).toBe(V1)
+  })
+
+  // Regression for #2848: the second sequential switch must send the version
+  // returned by the first switch, not the stale initial version.
+  it('advances the lock token across sequential switches', async () => {
+    updateCrudMock.mockResolvedValueOnce({ result: { ok: true, updatedAt: V1 } })
+    updateCrudMock.mockResolvedValueOnce({ result: { ok: true, updatedAt: V2 } })
+
+    // Mirror the page: thread the returned updatedAt into the next call.
+    let version: string | null = V0
+    const first = await switchTeamMemberSchedule({
+      memberId: MEMBER_ID,
+      nextRuleSetId: 'ruleset-a',
+      expectedUpdatedAt: version,
+      t,
+    })
+    version = first.updatedAt
+    await switchTeamMemberSchedule({
+      memberId: MEMBER_ID,
+      nextRuleSetId: 'ruleset-b',
+      expectedUpdatedAt: version,
+      t,
+    })
+
+    expect(scopedHeaderCalls).toEqual([
+      { [OPTIMISTIC_LOCK_HEADER_NAME]: V0 },
+      { [OPTIMISTIC_LOCK_HEADER_NAME]: V1 },
+    ])
+  })
+
+  it('surfaces the conflict bar and re-throws on an optimistic-lock 409', async () => {
+    const conflict = Object.assign(new Error('conflict'), {
+      status: 409,
+      code: 'optimistic_lock_conflict',
+      currentUpdatedAt: V1,
+      expectedUpdatedAt: V0,
+    })
+    updateCrudMock.mockRejectedValue(conflict)
+
+    await expect(
+      switchTeamMemberSchedule({
+        memberId: MEMBER_ID,
+        nextRuleSetId: 'ruleset-a',
+        expectedUpdatedAt: V0,
+        t,
+      }),
+    ).rejects.toBe(conflict)
+
+    expect(surfaceRecordConflictMock).toHaveBeenCalledWith(conflict, t)
+  })
+
+  it('re-throws non-conflict errors after attempting to surface them', async () => {
+    surfaceRecordConflictMock.mockReturnValue(false)
+    const failure = Object.assign(new Error('boom'), { status: 500 })
+    updateCrudMock.mockRejectedValue(failure)
+
+    await expect(
+      switchTeamMemberSchedule({
+        memberId: MEMBER_ID,
+        nextRuleSetId: 'ruleset-a',
+        expectedUpdatedAt: V0,
+        t,
+      }),
+    ).rejects.toBe(failure)
+
+    expect(surfaceRecordConflictMock).toHaveBeenCalledWith(failure, t)
+  })
+})

--- a/packages/core/src/modules/staff/lib/scheduleSwitch.ts
+++ b/packages/core/src/modules/staff/lib/scheduleSwitch.ts
@@ -1,0 +1,46 @@
+import { withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
+import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
+import { updateCrud } from '@open-mercato/ui/backend/utils/crud'
+
+type Translate = (key: string, fallback?: string) => string
+
+export type TeamMemberScheduleSwitchResult = {
+  /** The team member's freshly-bumped updatedAt, used to refresh the optimistic-lock token. */
+  updatedAt: string | null
+}
+
+/**
+ * Persist a team member's selected availability schedule.
+ *
+ * Sends the optimistic-lock header derived from the caller's current
+ * `expectedUpdatedAt` and returns the server's freshly-bumped `updatedAt` so the
+ * caller can advance its token before the next sequential switch — otherwise the
+ * second switch reuses a stale version and falsely 409s (#2848).
+ *
+ * On an optimistic-lock conflict the shared conflict bar is surfaced before the
+ * error is re-thrown, so the selection reverts AND the user sees visible feedback
+ * instead of a silent revert.
+ */
+export async function switchTeamMemberSchedule(args: {
+  memberId: string
+  nextRuleSetId: string | null
+  expectedUpdatedAt: string | null | undefined
+  t: Translate
+}): Promise<TeamMemberScheduleSwitchResult> {
+  const { memberId, nextRuleSetId, expectedUpdatedAt, t } = args
+  const headers = buildOptimisticLockHeader(expectedUpdatedAt)
+  try {
+    const call = await withScopedApiRequestHeaders(headers, () => (
+      updateCrud<{ ok?: boolean; updatedAt?: string | null }>(
+        'staff/team-members',
+        { id: memberId, availabilityRuleSetId: nextRuleSetId },
+        { errorMessage: t('staff.teamMembers.availability.ruleset.updateError', 'Failed to update schedule.') },
+      )
+    ))
+    return { updatedAt: call?.result?.updatedAt ?? null }
+  } catch (error) {
+    surfaceRecordConflict(error, t)
+    throw error
+  }
+}


### PR DESCRIPTION
Fixes #2848

## Problem
On **Backend → Team Members → Availability**, switching between availability schedules worked once, then silently broke: a background **409 Conflict** appeared in the console, the selection reverted to the previous value, and switching stayed broken until the page was refreshed — with no user-facing feedback.

## Root Cause
The detail page's `handleRulesetChange` sent the optimistic-lock header derived from the team member's `initialValues.updatedAt` (loaded once on mount) but **never advanced that token after a successful update**. The staff team-members update command/route returned only `{ ok: true }`, so the client had no way to learn the new `updated_at`.

Sequence:
1. First switch → header sends the loaded `updatedAt` (T0) → server bumps `updated_at` to T1 → success, but the page still holds T0.
2. Second switch → header sends the **stale T0** → server compares against T1 → **409**.

The 409 was then swallowed: `AvailabilityRulesEditor` re-threw the error, but the `<Select onValueChange>` used `void handleRuleSetChange(...)`, discarding the rejection — so the user saw only a silent revert.

## What Changed
- **`staff.team-members.update` command** now returns the freshly-bumped `updatedAt` alongside `memberId`.
- **`api/team-members.ts`** update response surfaces `updatedAt` (OpenAPI schema extended additively).
- **Team member detail page** advances `initialValues.updatedAt` from the response after each successful switch, so the next sequential switch sends the fresh token and no longer falsely 409s.
- Genuine optimistic-lock conflicts now surface through the shared conflict bar via `surfaceRecordConflict(err, t)` instead of silently reverting.
- Extracted the network + conflict logic into a testable `switchTeamMemberSchedule` helper (`staff/lib/scheduleSwitch.ts`).

This mirrors the existing customers inline-edit optimistic-lock fix (#2055).

## Tests
- New `staff/lib/__tests__/scheduleSwitch.test.ts` (5 cases): header derived from current `updatedAt`; returns the fresh `updatedAt`; **sequential switches advance the lock token (regression for #2848)**; 409 surfaces the conflict bar and re-throws; non-conflict errors still propagate.
- Full staff suite green (81 tests). `yarn generate`, `yarn build:packages`, `yarn typecheck`, `yarn i18n:check-sync`, and `yarn build:app` all pass.

## Backward Compatibility
- Additive only: command result gains `updatedAt`, PUT response gains `updatedAt`, OpenAPI update schema extended. No fields removed, no event/widget/ACL/import-path/DI changes.
- No new user-facing strings (reuses existing `staff.teamMembers.availability.ruleset.*` keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)