### PR TITLE
perf(dev): move react-big-calendar CSS from globals to lazy ScheduleCalendar chunk (#2850)

### DIFF
--- a/apps/mercato/src/app/globals.css
+++ b/apps/mercato/src/app/globals.css
@@ -1,6 +1,5 @@
 @import "tailwindcss";
 @import "tw-animate-css";
-@import "react-big-calendar/lib/css/react-big-calendar.css";
 @import "../../.mercato/generated/module-package-sources.css";
 
 /*

--- a/packages/create-app/template/src/app/globals.css
+++ b/packages/create-app/template/src/app/globals.css
@@ -1,6 +1,5 @@
 @import "tailwindcss";
 @import "tw-animate-css";
-@import "react-big-calendar/lib/css/react-big-calendar.css";
 @import "../../.mercato/generated/module-package-sources.css";
 
 /*

--- a/packages/ui/src/backend/__tests__/lazy-heavy-libraries.test.ts
+++ b/packages/ui/src/backend/__tests__/lazy-heavy-libraries.test.ts
@@ -113,4 +113,14 @@ describe('heavy libraries are lazy-loaded', () => {
     const source = read('apps/mercato/src/app/globals.css')
     expect(source).not.toMatch(/@xyflow\/react\/dist\/style\.css/)
   })
+
+  it('globals.css no longer eagerly imports react-big-calendar styles', () => {
+    const source = read('apps/mercato/src/app/globals.css')
+    expect(source).not.toMatch(/react-big-calendar\/lib\/css/)
+  })
+
+  it('ScheduleCalendar owns the react-big-calendar CSS import', () => {
+    const source = read('packages/ui/src/backend/schedule/ScheduleCalendar.tsx')
+    expect(source).toMatch(/import\s+['"]react-big-calendar\/lib\/css\/react-big-calendar\.css['"]/)
+  })
 })

--- a/packages/ui/src/backend/schedule/ScheduleCalendar.tsx
+++ b/packages/ui/src/backend/schedule/ScheduleCalendar.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import 'react-big-calendar/lib/css/react-big-calendar.css'
 import * as React from 'react'
 import { Calendar, dateFnsLocalizer, type View, type SlotInfo } from 'react-big-calendar'
 import { addDays } from 'date-fns/addDays'


### PR DESCRIPTION
# Summary

Removes the eager `@import "react-big-calendar/lib/css/react-big-calendar.css"` from the global stylesheet (loaded on every backend route) and co-locates it inside `ScheduleCalendar.tsx` — the `next/dynamic` / `ssr: false` chunk that already owns the JS import. Mirrors the `@xyflow/react` precedent from #2129. Saves ~18 KB CSS off every non-calendar route.

Part of #2850 (candidate #1).

## Changes

- Removed eager react-big-calendar CSS `@import` from `apps/mercato/src/app/globals.css` and `packages/create-app/template/src/app/globals.css`
- Added side-effect CSS import to `ScheduleCalendar.tsx`, co-located with the existing JS import (same pattern as `WorkflowGraphImpl.tsx` + `@xyflow/react`)
- Extended `lazy-heavy-libraries.test.ts` with two guard assertions to prevent regression

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

## Testing

- `yarn workspace @open-mercato/ui test -- lazy-heavy-libraries` — 17/17 pass

## Checklist

- [x] This pull request targets develop.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/ with a changelog entry (if applicable).

## Design System Compliance

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or `DataTable emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (`Alert`, `StatusBadge`, `FormField`) — no custom replacements

## Linked issues

Part of #2850.