### PR TITLE
fix(planner): prevent false 409 when deleting an availability schedule (#2847)

### DIFF
--- a/packages/core/src/modules/staff/__tests__/memberScheduleAssignment.test.ts
+++ b/packages/core/src/modules/staff/__tests__/memberScheduleAssignment.test.ts
@@ -1,0 +1,84 @@
+import {
+  updateMemberScheduleAssignment,
+  type OptimisticVersionStore,
+} from '../lib/memberScheduleAssignment'
+
+function makeStore(initial: string | null): OptimisticVersionStore & { value: () => string | null } {
+  let current = initial
+  return {
+    get: () => current,
+    set: (next) => {
+      current = next
+    },
+    value: () => current,
+  }
+}
+
+describe('updateMemberScheduleAssignment', () => {
+  it('sends the currently-known version and refreshes it from the server after success', async () => {
+    const store = makeStore('T0')
+    const sent: (string | null)[] = []
+    await updateMemberScheduleAssignment({
+      versionStore: store,
+      applyAssignment: async (expected) => {
+        sent.push(expected)
+      },
+      readCurrentVersion: async () => 'T1',
+    })
+    expect(sent).toEqual(['T0'])
+    expect(store.value()).toBe('T1')
+  })
+
+  it('uses the refreshed version on a follow-up write (regression: false 409 on schedule delete #2847)', async () => {
+    const store = makeStore('T0')
+    const sent: (string | null)[] = []
+    const serverVersions = ['T1', 'T2']
+    let writes = 0
+    const run = () =>
+      updateMemberScheduleAssignment({
+        versionStore: store,
+        applyAssignment: async (expected) => {
+          sent.push(expected)
+          writes += 1
+        },
+        readCurrentVersion: async () => serverVersions[writes - 1] ?? null,
+      })
+    // 1) user selects a schedule -> bumps the member version server-side
+    await run()
+    // 2) deleting the schedule clears the assignment -> must NOT reuse stale 'T0'
+    await run()
+    expect(sent).toEqual(['T0', 'T1'])
+    expect(store.value()).toBe('T2')
+  })
+
+  it('keeps the last-known version when the refresh read fails', async () => {
+    const store = makeStore('T0')
+    await updateMemberScheduleAssignment({
+      versionStore: store,
+      applyAssignment: async () => {},
+      readCurrentVersion: async () => {
+        throw new Error('network')
+      },
+    })
+    expect(store.value()).toBe('T0')
+  })
+
+  it('propagates a write error and does not refresh on a genuine conflict', async () => {
+    const store = makeStore('T0')
+    let refreshed = false
+    await expect(
+      updateMemberScheduleAssignment({
+        versionStore: store,
+        applyAssignment: async () => {
+          throw new Error('409')
+        },
+        readCurrentVersion: async () => {
+          refreshed = true
+          return 'T1'
+        },
+      }),
+    ).rejects.toThrow('409')
+    expect(refreshed).toBe(false)
+    expect(store.value()).toBe('T0')
+  })
+})

--- a/packages/core/src/modules/staff/backend/staff/team-members/[id]/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/team-members/[id]/page.tsx
@@ -14,6 +14,7 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { createTranslatorWithFallback } from '@open-mercato/shared/lib/i18n/translate'
 import { AvailabilityRulesEditor } from '@open-mercato/core/modules/planner/components/AvailabilityRulesEditor'
 import { buildMemberScheduleItems } from '@open-mercato/core/modules/staff/lib/memberSchedule'
+import { updateMemberScheduleAssignment } from '@open-mercato/core/modules/staff/lib/memberScheduleAssignment'
 import { TeamMemberForm, buildTeamMemberPayload, type TeamMemberFormValues } from '@open-mercato/core/modules/staff/components/TeamMemberForm'
 import { NotesSection } from '@open-mercato/ui/backend/detail'
 import { ActivitiesSection, type SectionAction } from '@open-mercato/ui/backend/detail'
@@ -78,6 +79,11 @@ export default function StaffTeamMemberDetailPage({ params }: { params?: { id?: 
   const [isNotFound, setIsNotFound] = React.useState(false)
   const [availabilityRuleSetId, setAvailabilityRuleSetId] = React.useState<string | null>(null)
   const [activePanel, setActivePanel] = React.useState<'details' | 'availability' | 'jobHistory'>('details')
+  // Tracks the member's current optimistic-lock version for assignment writes.
+  // The member's `updated_at` is bumped on every schedule-assignment write, so
+  // we refresh this from the server after each one to avoid a false 409 on the
+  // follow-up clear performed while deleting a schedule (#2847).
+  const memberUpdatedAtRef = React.useRef<string | null>(null)
   const [activeTab, setActiveTab] = React.useState<'notes' | 'activities' | 'addresses'>('notes')
   const [sectionAction, setSectionAction] = React.useState<SectionAction | null>(null)
   const [activityDictionaryId, setActivityDictionaryId] = React.useState<string | null>(null)
@@ -237,6 +243,7 @@ export default function StaffTeamMemberDetailPage({ params }: { params?: { id?: 
             ...customFields,
           })
           setMemberRecord(record)
+          memberUpdatedAtRef.current = record.updatedAt ?? record.updated_at ?? null
           setAvailabilityRuleSetId(
             typeof record.availabilityRuleSetId === 'string'
               ? record.availabilityRuleSetId
@@ -295,17 +302,37 @@ export default function StaffTeamMemberDetailPage({ params }: { params?: { id?: 
     router.push('/backend/staff/team-members')
   }, [memberId, router, t])
 
+  const readMemberUpdatedAt = React.useCallback(async (): Promise<string | null> => {
+    if (!memberId) return null
+    const params = new URLSearchParams({ page: '1', pageSize: '1', ids: memberId })
+    const payload = await readApiResultOrThrow<TeamMemberResponse>(
+      `/api/staff/team-members?${params.toString()}`,
+      undefined,
+      { errorMessage: t('staff.teamMembers.form.errors.load', 'Failed to load team member.') },
+    )
+    const record = Array.isArray(payload.items) ? payload.items[0] : null
+    if (!record) return null
+    return record.updatedAt ?? record.updated_at ?? null
+  }, [memberId, t])
+
   const handleRulesetChange = React.useCallback(async (nextId: string | null) => {
     if (!memberId) return
-    const headers = buildOptimisticLockHeader(initialValues?.updatedAt)
-    await withScopedApiRequestHeaders(headers, () => (
-      updateCrud('staff/team-members', { id: memberId, availabilityRuleSetId: nextId }, {
-        errorMessage: t('staff.teamMembers.availability.ruleset.updateError', 'Failed to update schedule.'),
-      })
-    ))
+    await updateMemberScheduleAssignment({
+      versionStore: {
+        get: () => memberUpdatedAtRef.current,
+        set: (next) => { memberUpdatedAtRef.current = next },
+      },
+      applyAssignment: (expectedUpdatedAt) => withScopedApiRequestHeaders(
+        buildOptimisticLockHeader(expectedUpdatedAt),
+        () => updateCrud('staff/team-members', { id: memberId, availabilityRuleSetId: nextId }, {
+          errorMessage: t('staff.teamMembers.availability.ruleset.updateError', 'Failed to update schedule.'),
+        }),
+      ),
+      readCurrentVersion: readMemberUpdatedAt,
+    })
     setAvailabilityRuleSetId(nextId)
     flash(t('staff.teamMembers.availability.ruleset.updateSuccess', 'Schedule updated.'), 'success')
-  }, [initialValues?.updatedAt, memberId, t])
+  }, [memberId, readMemberUpdatedAt, t])
 
   const panelTabs = React.useMemo(() => ([
     { id: 'details' as const, label: t('staff.teamMembers.detail.tabs.details', 'Details') },

--- a/packages/core/src/modules/staff/lib/memberScheduleAssignment.ts
+++ b/packages/core/src/modules/staff/lib/memberScheduleAssignment.ts
@@ -1,0 +1,39 @@
+export type OptimisticVersionStore = {
+  get: () => string | null
+  set: (next: string | null) => void
+}
+
+export type UpdateMemberScheduleAssignmentParams = {
+  versionStore: OptimisticVersionStore
+  applyAssignment: (expectedUpdatedAt: string | null) => Promise<unknown>
+  readCurrentVersion: () => Promise<string | null>
+}
+
+/**
+ * Update a team member's availability-schedule assignment while keeping the
+ * member's optimistic-lock version fresh.
+ *
+ * The member's `updated_at` is bumped on every assignment write, so reusing the
+ * page-load version for a follow-up write — e.g. clearing the assignment while
+ * deleting the schedule — sends a stale token and triggers a false 409
+ * `record_modified` even with no concurrent editing (#2847). After a successful
+ * write the tracked version is refreshed from the server so the next assignment
+ * write compares against the current row.
+ *
+ * The version is refreshed ONLY after the write succeeds, which preserves
+ * genuine conflict detection: a concurrent edit from another tab still leaves
+ * the tracked version stale at write time and surfaces a real 409 (the write
+ * throws before the refresh runs).
+ */
+export async function updateMemberScheduleAssignment(
+  params: UpdateMemberScheduleAssignmentParams,
+): Promise<void> {
+  const { versionStore, applyAssignment, readCurrentVersion } = params
+  await applyAssignment(versionStore.get())
+  try {
+    versionStore.set(await readCurrentVersion())
+  } catch {
+    // Keep the last-known version when the refresh read fails; the next write
+    // falls back to the prior token rather than dropping the lock entirely.
+  }
+}


### PR DESCRIPTION
Fixes #2847

## Problem
- Deleting an Availability Schedule from **Backend → Team Members → Availability** returned a **409 `record_modified`** on the first attempt even in a single browser tab with no concurrent editing.
- After the schedule was eventually deleted, it stayed visible in the Schedule dropdown until a manual page refresh.

## Root Cause
- The team-member detail page (`staff/team-members/[id]/page.tsx`) built the optimistic-lock header for **every** availability-schedule assignment write from the page-load `initialValues.updatedAt`.
- Selecting a schedule issues a member update that bumps the member's `updated_at`. The delete flow then performs a **follow-up** member write — `clearAssignment → onRulesetChange(null)` — which reused the now-stale page-load version and got a false **409**.
- That 409 is thrown **after** the rule set was already deleted server-side (inside the same `try`), so `refreshRuleSets` was skipped → the deleted schedule lingered in the dropdown until refresh.

## What Changed
- Track the member's optimistic-lock version in a ref (`memberUpdatedAtRef`), seeded on load.
- After each **successful** assignment write, refresh the tracked version from the server so the follow-up clear compares against the current row instead of a stale token.
- The version is refreshed **only after success**, preserving genuine concurrent-edit detection (a real conflict still throws before the refresh runs).
- Extracted the refresh-after-success invariant into a pure helper `updateMemberScheduleAssignment` (`staff/lib/memberScheduleAssignment.ts`) so it is unit-testable in the node test env.

Fixing the false 409 also resolves the stale-dropdown symptom: the delete now completes end-to-end, so `refreshRuleSets` runs and removes the deleted schedule.

## Tests
- New `staff/__tests__/memberScheduleAssignment.test.ts` (4 cases): sends the current version, **refreshes it so a follow-up write is not stale** (the #2847 regression), keeps the last-known version when the refresh read fails, and propagates a genuine conflict without refreshing.
- `yarn workspace @open-mercato/core test` — 5771 passed.
- `yarn generate`, `yarn build:packages`, `yarn typecheck` — clean.

## Backward Compatibility
- No contract surface changes. New export is additive; no API routes, response fields, event IDs, DI names, or ACL features changed. No DB/encryption code touched.