### PR TITLE
fix(entities): validate multi-value custom fields element-by-element (#2650)

### DIFF
--- a/packages/shared/src/modules/entities/__tests__/validation.test.ts
+++ b/packages/shared/src/modules/entities/__tests__/validation.test.ts
@@ -56,6 +56,44 @@ describe('validateValuesAgainstDefs', () => {
     expect(r.ok).toBe(true)
   })
 
+  it('validates multi-value fields against rules element-by-element', () => {
+    const defs = [
+      { key: 'labels', kind: 'text', configJson: { validation: [ { rule: 'regex', param: '^[a-z0-9_-]+$', message: 'Labels must be slug-like' } ] } },
+    ]
+
+    // A single tag (single-element array) is slug-like → valid
+    let r = validateValuesAgainstDefs({ labels: ['frontend'] }, defs as any)
+    expect(r.ok).toBe(true)
+
+    // Multiple slug-like tags must pass (regression for #2650 — previously the
+    // array was stringified to "frontend,backend" and failed on the comma)
+    r = validateValuesAgainstDefs({ labels: ['frontend', 'backend', 'ops'] }, defs as any)
+    expect(r.ok).toBe(true)
+    expect(Object.keys(r.fieldErrors).length).toBe(0)
+
+    // A non-slug element still fails, reporting the rule message
+    r = validateValuesAgainstDefs({ labels: ['frontend', 'Not OK!'] }, defs as any)
+    expect(r.ok).toBe(false)
+    expect(r.fieldErrors['cf_labels']).toBe('Labels must be slug-like')
+
+    // An empty multi-value array is treated as empty (no regex error)
+    r = validateValuesAgainstDefs({ labels: [] }, defs as any)
+    expect(r.ok).toBe(true)
+  })
+
+  it('still enforces required against empty multi-value arrays', () => {
+    const defs = [
+      { key: 'tags', kind: 'text', configJson: { validation: [ { rule: 'required', message: 'tags required' }, { rule: 'regex', param: '^[a-z0-9_-]+$', message: 'bad tag' } ] } },
+    ]
+
+    let r = validateValuesAgainstDefs({ tags: [] }, defs as any)
+    expect(r.ok).toBe(false)
+    expect(r.fieldErrors['cf_tags']).toBe('tags required')
+
+    r = validateValuesAgainstDefs({ tags: ['a', 'b'] }, defs as any)
+    expect(r.ok).toBe(true)
+  })
+
   it('evaluates dangerous backtracking regex rules in bounded time', () => {
     const defs = [
       {

--- a/packages/shared/src/modules/entities/validation.ts
+++ b/packages/shared/src/modules/entities/validation.ts
@@ -52,8 +52,22 @@ export type CustomFieldDefLike = {
   configJson?: any
 }
 
-// Evaluate a single rule against a value
+// Evaluate a single rule against a value. Multi-value fields (e.g. tags inputs
+// with `multi: true`) submit arrays, so every rule except `required` is applied
+// element-by-element — otherwise the array is stringified to "a,b" and rules
+// such as a slug regex fail on the join separator (issue #2650).
 function evalRule(rule: ValidationRule, value: any, kind: string): string | null {
+  if (rule.rule !== 'required' && Array.isArray(value)) {
+    for (const element of value) {
+      const msg = evalRuleScalar(rule, element, kind)
+      if (msg) return msg
+    }
+    return null
+  }
+  return evalRuleScalar(rule, value, kind)
+}
+
+function evalRuleScalar(rule: ValidationRule, value: any, kind: string): string | null {
   const isEmpty = (v: any) => v == null || (typeof v === 'string' && v.trim() === '') || (Array.isArray(v) && v.length === 0)
 
   switch (rule.rule) {


### PR DESCRIPTION
Fixes #2650

## Problem
The `labels` field on `example/todo` (a `multi: true` tags input with a `regex` slug rule) would not let the user multi-select, and values were not saved or repopulated. Adding a second tag triggered the `Labels must be slug-like` error and blocked the save.

## Root Cause
`evalRule` in `packages/shared/src/modules/entities/validation.ts` ran the regex rule against `String(value)`. For a multi-value field the submitted value is an array, so `String(['frontend','backend'])` becomes `"frontend,backend"`, which fails the slug pattern `^[a-z0-9_-]+$` on the comma separator. A single tag (single-element array) stringified to a bare value and passed, which is why only multi-select appeared broken. This validator runs both client-side (`useDealCustomFields`) and server-side (`entities/lib/validation.ts` → `entities/api/records.ts`), so saves were rejected end to end.

## What Changed
- Apply every validation rule **except `required`** element-by-element when the value is an array, so each tag is validated individually instead of the comma-joined string.
- `required` keeps operating on the whole value, so empty multi-value arrays still fail presence checks.
- No exported API changed — the fix is confined to the internal `evalRule` (split into `evalRule` + `evalRuleScalar`).

## Tests
- Added unit tests in `validation.test.ts`: multi-value regex pass (multiple slug-like tags), fail (a non-slug element), empty array, and `required` on empty/non-empty arrays. Confirmed they fail before the fix and pass after.
- `yarn build:packages` green across all 21 packages.

## Backward Compatibility
No contract surface changes. Exported `validateValuesAgainstDefs` signature and behavior for scalar values are unchanged; only multi-value (array) handling is corrected.