### PR TITLE
fix(entities): validate multi-value custom fields per-element (#2650)

### DIFF
--- a/packages/shared/src/modules/entities/__tests__/validation.test.ts
+++ b/packages/shared/src/modules/entities/__tests__/validation.test.ts
@@ -56,6 +56,43 @@ describe('validateValuesAgainstDefs', () => {
     expect(r.ok).toBe(true)
   })
 
+  it('applies value rules per-element for multi-value (array) fields', () => {
+    const defs = [
+      { key: 'labels', kind: 'text', configJson: { validation: [ { rule: 'regex', param: '^[a-z0-9_-]+$', message: 'Labels must be slug-like' } ] } },
+    ]
+
+    // Multiple slug-like labels must pass — the regex is checked per element,
+    // not against the comma-joined string representation (issue #2650).
+    let r = validateValuesAgainstDefs({ labels: ['frontend', 'backend', 'ops'] }, defs as any)
+    expect(r.ok).toBe(true)
+    expect(Object.keys(r.fieldErrors).length).toBe(0)
+
+    // A single slug-like label still passes.
+    r = validateValuesAgainstDefs({ labels: ['frontend'] }, defs as any)
+    expect(r.ok).toBe(true)
+
+    // Any non-conforming element fails the whole field.
+    r = validateValuesAgainstDefs({ labels: ['frontend', 'Not Valid!'] }, defs as any)
+    expect(r.ok).toBe(false)
+    expect(r.fieldErrors['cf_labels']).toBe('Labels must be slug-like')
+
+    // An empty array is treated as empty (no value rules apply).
+    r = validateValuesAgainstDefs({ labels: [] }, defs as any)
+    expect(r.ok).toBe(true)
+  })
+
+  it('enforces required on multi-value fields by array emptiness, not per-element', () => {
+    const defs = [
+      { key: 'labels', kind: 'text', configJson: { validation: [ { rule: 'required', message: 'labels required' } ] } },
+    ]
+    let r = validateValuesAgainstDefs({ labels: [] }, defs as any)
+    expect(r.ok).toBe(false)
+    expect(r.fieldErrors['cf_labels']).toBe('labels required')
+
+    r = validateValuesAgainstDefs({ labels: ['frontend', 'backend'] }, defs as any)
+    expect(r.ok).toBe(true)
+  })
+
   it('evaluates dangerous backtracking regex rules in bounded time', () => {
     const defs = [
       {

--- a/packages/shared/src/modules/entities/validation.ts
+++ b/packages/shared/src/modules/entities/validation.ts
@@ -52,10 +52,28 @@ export type CustomFieldDefLike = {
   configJson?: any
 }
 
-// Evaluate a single rule against a value
-function evalRule(rule: ValidationRule, value: any, kind: string): string | null {
-  const isEmpty = (v: any) => v == null || (typeof v === 'string' && v.trim() === '') || (Array.isArray(v) && v.length === 0)
+const isEmpty = (v: any) => v == null || (typeof v === 'string' && v.trim() === '') || (Array.isArray(v) && v.length === 0)
 
+// Evaluate a single rule against a value. Multi-value fields (e.g. `text` with
+// `multi: true`) carry array values; every rule except `required` is applied to
+// each element so a regex like `^[a-z0-9_-]+$` is checked per tag instead of the
+// comma-joined string representation.
+function evalRule(rule: ValidationRule, value: any, kind: string): string | null {
+  if (rule.rule === 'required') {
+    return isEmpty(value) ? rule.message : null
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const msg = evalScalarRule(rule, item, kind)
+      if (msg) return msg
+    }
+    return null
+  }
+  return evalScalarRule(rule, value, kind)
+}
+
+// Evaluate a single rule against a scalar (non-array) value.
+function evalScalarRule(rule: ValidationRule, value: any, kind: string): string | null {
   switch (rule.rule) {
     case 'required':
       return isEmpty(value) ? rule.message : null


### PR DESCRIPTION
Fixes #2650

## Problem
Custom-field labels with a `must be sluglike` regex (e.g. the `example/todo` `labels` field) could not be multi-selected, and entered values were not saved or repopulated. Adding a single label worked; adding a second one made the save fail.

## Root Cause
`labels` is a `text` custom field with `multi: true`, so its value is an array. In `evalRule` (`packages/shared/src/modules/entities/validation.ts`), value-shape rules stringified the whole value before testing — `String(['frontend','backend'])` → `"frontend,backend"`. The regex `^[a-z0-9_-]+$` then failed on the comma, so any 2+ element array was rejected with the "must be slug-like" error. Because validation failed, nothing was persisted, which also explains the non-repopulation.

This affected every value-shape rule (`regex`, `integer`, `float`, `lt/lte/gt/gte`, `eq/ne`, `date`) on multi-value fields, not just `regex`.

## What Changed
- `evalRule` now evaluates array (multi-value) inputs **element-wise** for every rule except `required`; `required` still checks array emptiness as before.
- Extracted the existing scalar switch into `evalScalarRule`; `evalRule` dispatches scalars directly and arrays per element, returning the first failing element's message.
- No change to the exported `validateValuesAgainstDefs` signature or behavior for scalar fields. ReDoS bounds (`testLinearRegex` pattern/input length limits) are preserved per element.

## Tests
- Added unit tests in `packages/shared/src/modules/entities/__tests__/validation.test.ts`:
  - per-element regex passes for multiple slug-like labels, fails when any element is non-conforming, and treats an empty array as empty
  - `required` on a multi-value field is enforced by array emptiness, not per element
- `yarn workspace @open-mercato/shared test` → 1226 passed
- `yarn test` (all packages) → 22/22 successful
- `yarn typecheck` → 21/21
- `yarn build:packages`, `yarn generate`, `yarn build:app` → all pass
- `yarn lint` crashes inside `eslint-plugin-react`'s `usedPropTypes.js` on `apps/mercato` — a pre-existing tooling failure unrelated to this non-React `packages/shared` change.

## Backward Compatibility
No contract surface changes. `evalRule` is module-internal; the public `validateValuesAgainstDefs` signature is unchanged. The behavior change only corrects previously-broken validation of multi-value fields.