### PR TITLE
fix(catalog): strip markdown from product list description

### DIFF
--- a/packages/core/src/modules/catalog/backend/catalog/products/__tests__/ProductsDataTable.test.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/__tests__/ProductsDataTable.test.tsx
@@ -13,6 +13,10 @@ import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/u
 
 const mockTranslate = (key: string, fallback?: string) => fallback ?? key
 
+// Captures the column definitions passed to the (mocked) DataTable so individual
+// cell renderers can be exercised directly in tests.
+let mockLatestColumns: any[] = []
+
 jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
   I18nProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
@@ -24,7 +28,9 @@ jest.mock('@open-mercato/ui/backend/DataTable', () => ({
     ...mappedRow,
     ...Object.fromEntries(Object.entries(sourceItem).filter(([key]) => key.startsWith('_'))),
   }),
-  DataTable: (props: any) => (
+  DataTable: (props: any) => {
+    mockLatestColumns = props.columns
+    return (
     <div data-testid="data-table-mock">
       <div data-testid="data-table-title">{props.title}</div>
       <div data-testid="data-table-cache-status">{props.pagination?.cacheStatus ?? ''}</div>
@@ -42,7 +48,8 @@ jest.mock('@open-mercato/ui/backend/DataTable', () => ({
       ) : null}
       {props.actions}
     </div>
-  ),
+    )
+  },
 }))
 
 jest.mock('@open-mercato/ui/primitives/button', () => ({
@@ -181,5 +188,23 @@ describe('ProductsDataTable', () => {
     fireEvent.click(refreshButton)
 
     await waitFor(() => expect(apiCall).toHaveBeenCalledTimes(2))
+  })
+
+  it('strips markdown formatting from the product description cell', async () => {
+    render(<ProductsDataTable />)
+    await waitFor(() => expect(mockLatestColumns.length).toBeGreaterThan(0))
+
+    const titleColumn = mockLatestColumns.find((col) => col.accessorKey === 'title')
+    expect(titleColumn).toBeTruthy()
+
+    const cell = titleColumn.cell({
+      row: { original: { id: 'p1', title: 'Widget', description: '# Heading\n\n**bold** _em_' } },
+    }) as React.ReactElement
+    const { container } = render(cell)
+
+    expect(container.textContent).toContain('Heading bold em')
+    expect(container.textContent).not.toContain('**')
+    expect(container.textContent).not.toContain('#')
+    expect(container.textContent).not.toContain('_')
   })
 })

--- a/packages/core/src/modules/catalog/components/products/ProductsDataTable.tsx
+++ b/packages/core/src/modules/catalog/components/products/ProductsDataTable.tsx
@@ -16,6 +16,7 @@ import { applyCustomFieldVisibility } from '@open-mercato/ui/backend/utils/custo
 import type { FilterDef, FilterValues } from '@open-mercato/ui/backend/FilterBar'
 import type { FilterOption } from '@open-mercato/ui/backend/FilterOverlay'
 import { BooleanIcon } from '@open-mercato/ui/backend/ValueIcons'
+import { markdownToPlainText } from '@open-mercato/ui/backend/markdown/markdownToPlainText'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
@@ -416,7 +417,7 @@ export default function ProductsDataTable({
               <span className="text-xs text-muted-foreground">/{row.original.handle}</span>
             ) : null}
             {row.original.description ? (
-              <span className="text-xs text-muted-foreground">{row.original.description}</span>
+              <span className="text-xs text-muted-foreground">{markdownToPlainText(row.original.description)}</span>
             ) : null}
           </div>
         ),


### PR DESCRIPTION
 <!--
  Please ensure this pull request targets the `develop` branch.
  Checking the CLA box below confirms you accept the terms in docs/cla.md.
  -->

  ## Summary

  The catalog **Products & services** list rendered the product `description` verbatim, so Markdown syntax (`**bold**`, `#` headings,
  list markers) leaked into the compact list cell instead of showing as plain text (#2654).

  This runs the description through the existing `markdownToPlainText` helper (`@open-mercato/ui/backend/markdown/markdownToPlainText`)

  — already used by the planner, resources and staff list pages for "compact, read-only contexts such as DataTable list cells". No new dependency; descriptions still render as rich Markdown in the product detail/editor view.

  ### Before
<img width="1455" height="379" alt="przed" src="https://github.com/user-attachments/assets/d79be73d-070e-4ed3-b9fe-43cac7c415e5" />


  ### After
<img width="1080" height="202" alt="po" src="https://github.com/user-attachments/assets/39f94211-b50a-49e9-b0a7-aebd5fa24e96" />



  ## Changes

  - `ProductsDataTable.tsx`: wrap the description cell with `markdownToPlainText(...)` (+ import).
  - `ProductsDataTable.test.tsx`: regression test asserting the title-column description cell strips Markdown.

  ## Specification

  <!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

  **Does a spec exist for this feature/module?**
  - [ ] Yes
  - [ ] No (created a new spec)
  - [x] N/A (minor change, no spec needed)

  **Spec file path:**
  N/A

  ## Testing

  - `yarn workspace @open-mercato/core test ProductsDataTable` → 4/4 pass (incl. new regression test)
  - `yarn workspace @open-mercato/ui test markdownToPlainText` → 7/7 pass
  - Type-checked the changed file: `description?: string | null` matches the helper's `string | null | undefined`.

  ## Checklist

  - [x] This pull request targets `develop`.
  - [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
  - [x] I updated documentation, locales, or generators if the change requires it. (None required.)
  - [x] I added or adjusted tests that cover the change.
  - [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Not
  required: display-only transform reusing a unit-tested helper; covered by the new component regression test plus the existing
  `markdownToPlainText` tests; no new user flow.
  - [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A.

  ### Design System Compliance
  - [x] No hardcoded status colors — reuses the existing `text-muted-foreground` token.
  - [x] No arbitrary text sizes — keeps the existing `text-xs`.
  - [x] Empty state handled for list/data pages — unchanged; the list already uses `ListEmptyState`.
  - [x] Loading state handled for async pages — unchanged.
  - [x] `aria-label` on all icon-only buttons — no icon-only buttons added.
  - [x] Uses existing DS components — reuses the `markdownToPlainText` helper, no custom replacements.

  ## Linked issues

  Fixes #2654