### PR TITLE
release: align package versions to 0.6.4

### DIFF
--- a/packages/channel-gmail/package.json
+++ b/packages/channel-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/channel-gmail",
-  "version": "0.1.0",
+  "version": "0.6.4",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/channel-imap/package.json
+++ b/packages/channel-imap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/channel-imap",
-  "version": "0.1.0",
+  "version": "0.6.4",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/ui",
-  "version": "0.7.0",
+  "version": "0.6.4",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
## What changed

Aligned the package manifest versions for `@open-mercato/ui`, `@open-mercato/channel-imap`, and `@open-mercato/channel-gmail` to the root monorepo version `0.6.4`.

## Why

The release version-alignment check reported those packages as mismatched against root `package.json`.

## Validation

- `yarn check:dep-versions`
- workspace manifest alignment check for real `@open-mercato/*` packages
