### PR TITLE
feat(deploy): manual Dokploy Dev compose deployment workflow

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy to Dokploy Dev
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dev-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Trigger Dokploy compose deploy
+        env:
+          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY_DEV_DEPLOY }}
+          DOKPLOY_DEV_COMPOSE_ID: ${{ secrets.DOKPLOY_DEV_COMPOSE_ID }}
+          DOKPLOY_BASE_URL: ${{ secrets.DOKPLOY_URL }}
+        run: |
+          if [ -z "$DOKPLOY_API_KEY" ] || [ -z "$DOKPLOY_DEV_COMPOSE_ID" ] || [ -z "$DOKPLOY_BASE_URL" ]; then
+            echo "::error::Missing DOKPLOY_API_KEY, DOKPLOY_DEV_COMPOSE_ID, or DOKPLOY_BASE_URL secret"
+            exit 1
+          fi
+
+          http_status=$(curl -sS -o response.json -w "%{http_code}" \
+            -X POST "${DOKPLOY_BASE_URL%/}/api/compose.deploy" \
+            -H "accept: application/json" \
+            -H "x-api-key: ${DOKPLOY_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "{\"composeId\":\"${DOKPLOY_DEV_COMPOSE_ID}\"}")
+
+          echo "Dokploy responded with HTTP ${http_status}"
+          cat response.json
+
+          if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]; then
+            echo "::error::Dokploy deploy request failed (HTTP ${http_status})"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a manually-triggered (`workflow_dispatch`) GitHub Actions workflow that deploys the **develop** environment via the Dokploy API.

- Triggers a **compose** deployment (`/api/compose.deploy` with `composeId`) rather than an application deployment.
- Reads the Dokploy host from a `DOKPLOY_URL` secret so the domain is not exposed in the repo (trailing slash is stripped automatically).
- Fails fast if any required secret is missing and surfaces the HTTP status / response body.

## Required repository secrets

- `DOKPLOY_API_KEY_DEV_DEPLOY` — Dokploy API key
- `DOKPLOY_DEV_COMPOSE_ID` — compose service id
- `DOKPLOY_URL` — Dokploy base URL (e.g. `https://dp.example.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)