### PR TITLE
build(deps): bump dompurify from 3.3.3 to 3.4.8

### DIFF
--- a/.ai/runs/2026-06-09-bump-dompurify-3.4.8.md
+++ b/.ai/runs/2026-06-09-bump-dompurify-3.4.8.md
@@ -35,8 +35,8 @@ pre-bump state, so the bump applies cleanly.
 
 ### Phase 1: Apply the bump
 
-- [ ] 1.1 Update `yarn.lock` so dompurify resolves to 3.4.8 (single consolidated entry)
-- [ ] 1.2 Validate lockfile consistency with Yarn
+- [x] 1.1 Update `yarn.lock` so dompurify resolves to 3.4.8 (single consolidated entry) — 1ef49d88c
+- [x] 1.2 Validate lockfile consistency with Yarn — 1ef49d88c (yarn install --mode=update-lockfile: resolution clean, no dompurify drift)
 
 ### Phase 2: Ship
 

--- a/.ai/runs/2026-06-09-bump-dompurify-3.4.8.md
+++ b/.ai/runs/2026-06-09-bump-dompurify-3.4.8.md
@@ -40,5 +40,5 @@ pre-bump state, so the bump applies cleanly.
 
 ### Phase 2: Ship
 
-- [ ] 2.1 Open PR against `develop` with normalized labels
-- [ ] 2.2 Close original Dependabot PR #2864 with a migration note
+- [x] 2.1 Open PR against `develop` with normalized labels — PR #2866 (review, dependencies, skip-qa)
+- [x] 2.2 Close original Dependabot PR #2864 with a migration note — closed, superseded by #2866

--- a/.ai/runs/2026-06-09-bump-dompurify-3.4.8.md
+++ b/.ai/runs/2026-06-09-bump-dompurify-3.4.8.md
@@ -1,0 +1,44 @@
+# Execution plan: bump dompurify 3.3.3/3.4.2 → 3.4.8 (migrate #2864 to develop)
+
+## Goal
+
+Migrate Dependabot PR #2864 (`build(deps): bump dompurify from 3.3.3 to 3.4.8`,
+opened against `main`) onto `develop`, and close the original PR. The change is a
+lockfile-only transitive dependency bump; `develop` carries the identical
+pre-bump state, so the bump applies cleanly.
+
+## Scope
+
+- `yarn.lock` only: consolidate the two `dompurify` ranges (`^3.2.5` → 3.3.3 and
+  `^3.3.1` → 3.4.2, both pulled transitively by `mermaid`) into a single
+  `^3.2.5, ^3.3.1` → 3.4.8 entry, matching #2864.
+- Close Dependabot PR #2864 with a comment pointing at the develop-targeted PR.
+
+### Non-goals
+
+- No `package.json` changes (dompurify is transitive only, via `mermaid`; the
+  `^3.2.5` / `^3.3.1` constraints already permit 3.4.8).
+- No application code changes. dompurify is a docs/mermaid transitive dep.
+- No bump of any other dependency.
+
+## Risks
+
+- DOMPurify is an HTML sanitizer; a major-version behavior change could affect
+  rendered output. This is a patch/minor bump (3.x → 3.4.8) used only
+  transitively by `mermaid` in docs rendering; risk is minimal.
+- Lockfile drift: mitigated by running Yarn to regenerate/validate the lockfile
+  rather than hand-merging hunks blindly.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Apply the bump
+
+- [ ] 1.1 Update `yarn.lock` so dompurify resolves to 3.4.8 (single consolidated entry)
+- [ ] 1.2 Validate lockfile consistency with Yarn
+
+### Phase 2: Ship
+
+- [ ] 2.1 Open PR against `develop` with normalized labels
+- [ ] 2.2 Close original Dependabot PR #2864 with a migration note

--- a/yarn.lock
+++ b/yarn.lock
@@ -16089,27 +16089,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.2.5":
-  version: 3.3.3
-  resolution: "dompurify@npm:3.3.3"
+"dompurify@npm:^3.2.5, dompurify@npm:^3.3.1":
+  version: 3.4.8
+  resolution: "dompurify@npm:3.4.8"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10/4cc9c539ed7136d46c6577613b8e20871c2b6165db01dfbd2a3c11c75f9e339c496ac6519a1c3190115def8cadae3720bef0417fc43fa28802c7407bab174da9
-  languageName: node
-  linkType: hard
-
-"dompurify@npm:^3.3.1":
-  version: 3.4.2
-  resolution: "dompurify@npm:3.4.2"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: 10/8681a27f17412e754b38d080e39abb36fb14dbf58194d520eedd45b47986323966a0391df540a2011bce72dd37d67f2a015246a58f39d48e3e8f6051274fb974
+  checksum: 10/d661322889a8938bfb99ee27853e9e78661949398e803f344865fd94f8378a494efadd329faea0b16e8085efae1bfeed5f5df372909c3a2be3e583686a0a48fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-09-bump-dompurify-3.4.8.md
Status: complete

## Goal
- Migrate Dependabot PR #2864 (`build(deps): bump dompurify from 3.3.3 to 3.4.8`, opened against `main`) onto `develop`, and close the original PR.

## What Changed
- `yarn.lock`: consolidated the two transitive `dompurify` ranges — `^3.2.5` (was 3.3.3) and `^3.3.1` (was 3.4.2), both pulled by `mermaid` — into a single `^3.2.5, ^3.3.1` → `3.4.8` resolution. Identical to #2864.
- No `package.json` changes: dompurify is transitive only; the existing `^3.2.5` / `^3.3.1` constraints already permit 3.4.8.

## Tests
- `yarn install --mode=update-lockfile`: resolution clean, no dompurify drift.
- `yarn install --immutable`: lockfile accepted unchanged; dompurify@3.4.8 fetched and linked (verified `node_modules/dompurify` reports `3.4.8`). The only build warning is the pre-existing optional `cpu-features` (ssh2) native build failing in the sandbox — unrelated to this change.
- Full CI (typecheck/test/build) runs on this PR.

## Backward Compatibility
- No contract surface changes. Lockfile-only transitive dependency bump.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-09-bump-dompurify-3.4.8.md#progress).
