### PR TITLE
fix(staff): enforce single-active-timer invariant on timer-start (#2855)

### DIFF
--- a/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/timer-start/route.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/timer-start/route.ts
@@ -120,6 +120,36 @@ export async function POST(req: Request) {
         })
       }
 
+      // Single-active-timer invariant (issue #2855): reject the start when the
+      // staff member already has another running entry (started_at set,
+      // ended_at null). Without this guard a second surface (dashboard widget,
+      // another tab) could create and start a parallel timer, leaving two
+      // concurrent running entries and the "stopped timer comes back running"
+      // symptom reported in #2456.
+      const otherRunningEntry = await findOneWithDecryption(
+        trx,
+        StaffTimeEntry,
+        {
+          tenantId,
+          organizationId,
+          staffMemberId: lockedEntry.staffMemberId,
+          id: { $ne: lockedEntry.id },
+          startedAt: { $ne: null },
+          endedAt: null,
+          deletedAt: null,
+        },
+        {},
+        scopeCtx,
+      )
+      if (otherRunningEntry) {
+        throw new CrudHttpError(409, {
+          error: translate(
+            'staff.timesheets.errors.timerAlreadyRunning',
+            'Another timer is already running. Stop it before starting a new one.',
+          ),
+        })
+      }
+
       const startedAt = new Date()
       lockedEntry.startedAt = startedAt
       lockedEntry.source = 'timer'
@@ -184,7 +214,7 @@ export const openApi: OpenApiRouteDoc = {
       responses: [
         { status: 200, description: 'Timer started', schema: z.object({ ok: z.literal(true) }) },
         { status: 404, description: 'Time entry not found', schema: z.object({ error: z.string() }) },
-        { status: 409, description: 'Timer already started', schema: z.object({ error: z.string() }) },
+        { status: 409, description: 'Timer already started, or another timer is already running for this staff member', schema: z.object({ error: z.string() }) },
         { status: 401, description: 'Unauthorized', schema: z.object({ error: z.string() }) },
       ],
     },

--- a/packages/core/src/modules/staff/api/timesheets/time-entries/__tests__/timer-segment-atomic-write.test.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/__tests__/timer-segment-atomic-write.test.ts
@@ -139,8 +139,14 @@ describe('timer-start atomic write (#2416)', () => {
   }
 
   test('starts the timer inside a locking transaction', async () => {
-    mockFindOneWithDecryption.mockImplementation(async (_em, _cls, _where, opts) => {
+    mockFindOneWithDecryption.mockImplementation(async (_em, _cls, where, opts) => {
       if (opts) findOneOptions.push(opts)
+      // The cross-entry single-active-timer guard (#2855) queries with
+      // id: { $ne }; it must find no other running entry for this start to
+      // proceed.
+      if ((where as Record<string, unknown>).id && typeof (where as Record<string, unknown>).id === 'object') {
+        return null
+      }
       return makeEntry()
     })
 
@@ -155,6 +161,57 @@ describe('timer-start atomic write (#2416)', () => {
       segmentType: 'work',
     }))
     expect(lastTrxFlushCount).toBe(1)
+  })
+
+  test('rejects the start when the staff member already has another running entry (#2855)', async () => {
+    const otherRunningEntry = makeEntry({
+      id: '99999999-9999-4999-8999-999999999999',
+      startedAt: new Date('2026-01-01T07:00:00.000Z'),
+      endedAt: null,
+    })
+    let call = 0
+    mockFindOneWithDecryption.mockImplementation(async (_em, _cls, where, opts) => {
+      if (opts) findOneOptions.push(opts)
+      call += 1
+      // Calls 1 (unlocked load) and 2 (locked re-read) target this entry and
+      // see it as not-yet-started; the third lookup is the cross-entry guard
+      // querying for any OTHER running entry by the same staff member.
+      if ((where as Record<string, unknown>).id && typeof (where as Record<string, unknown>).id === 'object') {
+        return otherRunningEntry
+      }
+      return makeEntry()
+    })
+
+    const { POST } = await import('../[id]/timer-start/route')
+    const res = await POST(request())
+    const body = (await res.json()) as Record<string, unknown>
+
+    expect(res.status).toBe(409)
+    expect(String(body.error)).toMatch(/already running/i)
+    expect(lockOptionWasUsed()).toBe(true)
+    // No new entry/segment work happened — the guard short-circuited the start.
+    expect(mockEm.create).not.toHaveBeenCalled()
+    expect(lastTrxFlushCount).toBe(0)
+  })
+
+  test('starts when no other running entry exists for the staff member (#2855)', async () => {
+    mockFindOneWithDecryption.mockImplementation(async (_em, _cls, where, opts) => {
+      if (opts) findOneOptions.push(opts)
+      // The cross-entry guard query (id: { $ne }) finds no other running entry.
+      if ((where as Record<string, unknown>).id && typeof (where as Record<string, unknown>).id === 'object') {
+        return null
+      }
+      return makeEntry()
+    })
+
+    const { POST } = await import('../[id]/timer-start/route')
+    const res = await POST(request())
+
+    expect(res.status).toBe(200)
+    expect(mockEm.create).toHaveBeenCalledWith(StaffTimeEntrySegment, expect.objectContaining({
+      timeEntryId: ENTRY_ID,
+      segmentType: 'work',
+    }))
   })
 
   test('rejects a concurrent start when the lock observes startedAt already set', async () => {

--- a/packages/core/src/modules/staff/i18n/de.json
+++ b/packages/core/src/modules/staff/i18n/de.json
@@ -950,6 +950,7 @@
   "staff.timesheets.errors.projectsKpis": "Failed to load project KPIs.",
   "staff.timesheets.errors.segmentCreate": "Zeiteintragssegment konnte nicht erstellt werden.",
   "staff.timesheets.errors.staffMemberNotFound": "Mitarbeiter nicht gefunden oder nicht zugänglich.",
+  "staff.timesheets.errors.timerAlreadyRunning": "Es läuft bereits ein anderer Timer. Stoppen Sie ihn, bevor Sie einen neuen starten.",
   "staff.timesheets.errors.timerAlreadyStarted": "Der Timer ist für diesen Eintrag bereits gestartet.",
   "staff.timesheets.errors.timerStart": "Timer konnte nicht gestartet werden.",
   "staff.timesheets.errors.timerStop": "Timer konnte nicht gestoppt werden.",

--- a/packages/core/src/modules/staff/i18n/en.json
+++ b/packages/core/src/modules/staff/i18n/en.json
@@ -950,6 +950,7 @@
   "staff.timesheets.errors.projectsKpis": "Failed to load project KPIs.",
   "staff.timesheets.errors.segmentCreate": "Failed to create time entry segment.",
   "staff.timesheets.errors.staffMemberNotFound": "Staff member not found or not accessible.",
+  "staff.timesheets.errors.timerAlreadyRunning": "Another timer is already running. Stop it before starting a new one.",
   "staff.timesheets.errors.timerAlreadyStarted": "Timer is already started for this entry.",
   "staff.timesheets.errors.timerStart": "Failed to start timer.",
   "staff.timesheets.errors.timerStop": "Failed to stop timer.",

--- a/packages/core/src/modules/staff/i18n/es.json
+++ b/packages/core/src/modules/staff/i18n/es.json
@@ -950,6 +950,7 @@
   "staff.timesheets.errors.projectsKpis": "Failed to load project KPIs.",
   "staff.timesheets.errors.segmentCreate": "No se pudo crear el segmento del registro de tiempo.",
   "staff.timesheets.errors.staffMemberNotFound": "Miembro del personal no encontrado o no accesible.",
+  "staff.timesheets.errors.timerAlreadyRunning": "Ya hay otro temporizador en marcha. Detenlo antes de iniciar uno nuevo.",
   "staff.timesheets.errors.timerAlreadyStarted": "El temporizador ya está iniciado para este registro.",
   "staff.timesheets.errors.timerStart": "No se pudo iniciar el temporizador.",
   "staff.timesheets.errors.timerStop": "No se pudo detener el temporizador.",

--- a/packages/core/src/modules/staff/i18n/pl.json
+++ b/packages/core/src/modules/staff/i18n/pl.json
@@ -950,6 +950,7 @@
   "staff.timesheets.errors.projectsKpis": "Failed to load project KPIs.",
   "staff.timesheets.errors.segmentCreate": "Nie udało się utworzyć segmentu wpisu czasu.",
   "staff.timesheets.errors.staffMemberNotFound": "Pracownik nie został znaleziony lub jest niedostępny.",
+  "staff.timesheets.errors.timerAlreadyRunning": "Inny licznik czasu jest już uruchomiony. Zatrzymaj go przed rozpoczęciem nowego.",
   "staff.timesheets.errors.timerAlreadyStarted": "Czasomierz jest już uruchomiony dla tego wpisu.",
   "staff.timesheets.errors.timerStart": "Nie udało się uruchomić czasomierza.",
   "staff.timesheets.errors.timerStop": "Nie udało się zatrzymać czasomierza.",


### PR DESCRIPTION
Fixes #2855

## Problem
A staff member could hold more than one `StaffTimeEntry` with `started_at` set and `ended_at = null` at the same time (the P1 in #2855). Starting a timer from a second surface (dashboard Time-Reporting widget, another tab) created a parallel running entry, producing the *"stopped timer comes back running"* symptom reported in the #2456 umbrella.

## Root Cause
- `TimerBar.handleStart()` creates a **new** entry on every start, then calls `timer-start`.
- `timer-start` only re-checked `startedAt` **on that one entry** (under the #2416 PESSIMISTIC_WRITE lock). There was **no server-side guard** rejecting a start when the staff member already had another running entry, and the page-level single-`activeEntryId` guard isn't shared across surfaces.

## What Changed
- `packages/core/src/modules/staff/api/timesheets/time-entries/[id]/timer-start/route.ts`: inside the existing locking transaction, after the per-entry `startedAt` re-check, query (tenant/org/staff-scoped, via `findOneWithDecryption`) for any **other** entry by the same staff member with `started_at` set and `ended_at = null`. If one exists, reject with **409** and `staff.timesheets.errors.timerAlreadyRunning`.
- Added the `staff.timesheets.errors.timerAlreadyRunning` message to all four locales (en, es, de, pl).
- Updated the OpenAPI 409 description to cover the new reason.

## Tests
- Extended `timer-segment-atomic-write.test.ts` with two cases: start is rejected with 409 when another running entry exists for the staff member; start succeeds when none exists. Updated the existing happy-path mock so the new cross-entry guard query resolves to "no other running entry".
- `@open-mercato/core` timesheets suite: 47 passing (5 suites).
- `yarn build:packages`, `yarn generate`, `yarn typecheck`, `yarn i18n:check-sync`, `yarn i18n:check-usage` all green.

## Scope note
This closes the documented sequential repro (start A, then start B from another surface → B is rejected). A true simultaneous double-start of two *different* fresh entries by the same staff member is a much narrower race not serialized by the per-entry row lock; if that becomes a concern a per-staff-member advisory lock would be the follow-up. The remaining #2855 items (P3 view-switch week, P3 grid range/duration display, minor grid-totals-on-blur) are UI-only and left out of this minimal fix.

## Backward Compatibility
- No contract surface changes. Same 409 status and `{ error }` body shape already used by the endpoint; new i18n key is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)