### PR TITLE
fix(staff): remove doubled "Tags" heading in team member edit view (#2872)

### DIFF
--- a/packages/core/src/modules/staff/components/TeamMemberForm.tsx
+++ b/packages/core/src/modules/staff/components/TeamMemberForm.tsx
@@ -454,9 +454,12 @@ export function TeamMemberForm(props: TeamMemberFormProps) {
     ]
 
     if (!tagsSection) {
+      // The tags field lives in its own card whose group title already reads
+      // "Tags" (see groups below). Leave the field label empty so the heading
+      // is not rendered twice in the team member edit view.
       baseFields.splice(5, 0, {
         id: 'tags',
-        label: translate('staff.teamMembers.form.fields.tags', 'Tags'),
+        label: '',
         type: 'tags',
         placeholder: translate('staff.teamMembers.form.fields.tags.placeholder', 'Add tags'),
       })

--- a/packages/core/src/modules/staff/components/__tests__/TeamMemberForm.tagsHeading.test.tsx
+++ b/packages/core/src/modules/staff/components/__tests__/TeamMemberForm.tagsHeading.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { TeamMemberForm } from '../TeamMemberForm'
+
+const TEAM_ID = '11111111-1111-1111-1111-111111111111'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 0,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(async () => ({ result: { items: [] } })),
+}))
+
+jest.mock('@open-mercato/ui/backend/inputs', () => ({
+  LookupSelect: () => <div data-testid="lookup-select" />,
+}))
+
+jest.mock('@open-mercato/ui/backend/detail', () => ({
+  AttachmentsSection: () => <div />,
+  TagsSection: () => <div />,
+}))
+
+// Render BOTH the group titles and the field labels so that any duplicated
+// "Tags" heading (group title + field label pointing at the same key) would
+// surface as two matching nodes. This is the regression guarded by issue #2872.
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
+  CrudForm: ({
+    fields,
+    groups,
+  }: {
+    fields: Array<{ id: string; label?: string }>
+    groups: Array<{ id: string; title?: string }>
+  }) => (
+    <div>
+      {(groups || []).map((group) =>
+        group.title ? (
+          <div key={`group-${group.id}`} data-group-title={group.id}>
+            {group.title}
+          </div>
+        ) : null,
+      )}
+      {(fields || []).map((field) =>
+        field.label && field.label.trim().length > 0 ? (
+          <div key={`field-${field.id}`} data-field-label={field.id}>
+            {field.label}
+          </div>
+        ) : null,
+      )}
+    </div>
+  ),
+}))
+
+function renderForm() {
+  return render(
+    <TeamMemberForm
+      embedded
+      title="Edit team member"
+      backHref="/backend/staff/team-members"
+      cancelHref="/backend/staff/team-members"
+      initialValues={{
+        id: '22222222-2222-2222-2222-222222222222',
+        teamId: TEAM_ID,
+        displayName: 'Priya Nair',
+        roleIds: [],
+        tags: ['vip'],
+        isActive: true,
+        updatedAt: '2026-06-01T00:00:00.000Z',
+      }}
+      onSubmit={async () => {}}
+    />,
+  )
+}
+
+describe('TeamMemberForm tags heading', () => {
+  it('renders the "Tags" heading exactly once in the edit view', async () => {
+    renderForm()
+    await waitFor(() => {
+      expect(screen.getAllByText('Tags')).toHaveLength(1)
+    })
+  })
+
+  it('keeps the "Tags" heading on the group card and clears the redundant field label', async () => {
+    renderForm()
+    await waitFor(() => {
+      expect(screen.getByText('Tags')).toHaveAttribute('data-group-title', 'tags')
+    })
+    expect(screen.queryByText('Tags', { selector: '[data-field-label]' })).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #2872

## Problem
- The team member edit view rendered the "Tags" heading twice (see issue screenshot).

## Root Cause
- `TeamMemberForm` adds a `tags` field whose `label` resolves to `staff.teamMembers.form.fields.tags` ("Tags") **and** wraps it in a `CrudFormGroup` whose `title` resolves to the same key. `CrudForm` renders the group title as the card header *and* the field label inside it, so "Tags" appeared twice (both as `text-sm font-medium`).

## What Changed
- Cleared the redundant `tags` field `label` (set to `""`, which `CrudForm` skips rendering) so only the group card title "Tags" shows — matching the sibling "Custom Attributes" and "Attachments" cards, which use a titled card with no duplicated inner label. The intended `tagsSection` design (the `TagsSection` component) already renders a single titled card, so this aligns the field fallback with it.

## Tests
- Added `TeamMemberForm.tagsHeading.test.tsx`: asserts the "Tags" heading renders exactly once and that it comes from the group card title (not a field label). Verified the test fails on the pre-fix code.
- Full `@open-mercato/core` suite green (701 suites / 5781 tests); `yarn typecheck` and `yarn build:packages` pass.

## Backward Compatibility
- No contract surface changes. No exported types, signatures, event/widget/ACL IDs, API routes, DB schema, or i18n keys removed (the `staff.teamMembers.form.fields.tags` key is still used by the group title).