### PR TITLE
security(auth): pin logout/session-refresh redirects to allowlisted origin (#2686)

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/logout.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/logout.test.ts
@@ -15,9 +15,13 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: (...args: unknown[]) => createRequestContainer(...args),
 }))
 
-jest.mock('@open-mercato/core/modules/auth/lib/requestRedirect', () => ({
-  buildRequestOriginUrl: (_req: Request, path: string) => `http://localhost${path}`,
-}))
+jest.mock('@open-mercato/core/modules/auth/lib/requestRedirect', () => {
+  const { NextResponse } = require('next/server')
+  return {
+    buildSafeRedirectResponse: (_req: Request, path: string) =>
+      new NextResponse(null, { status: 307, headers: { Location: `http://localhost${path}` } }),
+  }
+})
 
 import * as logoutRoute from '@open-mercato/core/modules/auth/api/logout'
 import { POST } from '@open-mercato/core/modules/auth/api/logout'

--- a/packages/core/src/modules/auth/api/__tests__/session.refresh.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/session.refresh.test.ts
@@ -40,24 +40,44 @@ describe('/api/auth/session/refresh', () => {
     process.env.APP_URL = originalAppUrl
   })
 
-  it('GET clears cookies and redirects to the request host when session cookie is missing', async () => {
-    const response = await GET(new Request('https://develop.openmercato.com/api/auth/session/refresh?redirect=%2Fbackend'))
+  it('GET clears cookies and redirects to the allowlisted app origin when session cookie is missing', async () => {
+    const response = await GET(new Request('https://demo.openmercato.com/api/auth/session/refresh?redirect=%2Fbackend'))
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('https://develop.openmercato.com/login?redirect=%2Fbackend')
+    expect(response.headers.get('location')).toBe('https://demo.openmercato.com/login?redirect=%2Fbackend')
     const setCookie = response.headers.get('set-cookie') || ''
     expect(setCookie).toContain('auth_token=;')
     expect(setCookie).toContain('session_token=;')
   })
 
-  it('GET sanitizes a // open-redirect bypass before forwarding to /login', async () => {
-    const response = await GET(new Request('https://develop.openmercato.com/api/auth/session/refresh?redirect=%2Fbackend%2F%2Fevil.com'))
+  it('GET falls back to a host-relative redirect when the request origin is not allowlisted', async () => {
+    const response = await GET(new Request('https://develop.openmercato.com/api/auth/session/refresh?redirect=%2Fbackend'))
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('https://develop.openmercato.com/login?redirect=%2F')
+    // No absolute origin is emitted — the browser resolves the relative
+    // Location against the real request URL, never a spoofed forwarded host.
+    expect(response.headers.get('location')).toBe('/login?redirect=%2Fbackend')
   })
 
-  it('GET redirects valid browser refreshes to the request host', async () => {
+  it('GET does not honour a spoofed X-Forwarded-Host as the redirect origin', async () => {
+    const response = await GET(new Request('https://demo.openmercato.com/api/auth/session/refresh?redirect=%2Fbackend', {
+      headers: { 'x-forwarded-host': 'attacker.example' },
+    }))
+
+    expect(response.status).toBe(307)
+    const location = response.headers.get('location') || ''
+    expect(location).not.toContain('attacker.example')
+    expect(location).toBe('/login?redirect=%2Fbackend')
+  })
+
+  it('GET sanitizes a // open-redirect bypass before forwarding to /login', async () => {
+    const response = await GET(new Request('https://demo.openmercato.com/api/auth/session/refresh?redirect=%2Fbackend%2F%2Fevil.com'))
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://demo.openmercato.com/login?redirect=%2F')
+  })
+
+  it('GET redirects valid browser refreshes to the allowlisted app origin', async () => {
     refreshFromSessionToken.mockResolvedValue({
       user: {
         id: 'user-1',
@@ -68,14 +88,14 @@ describe('/api/auth/session/refresh', () => {
       roles: ['admin'],
     })
 
-    const response = await GET(new Request('https://develop.openmercato.com/api/auth/session/refresh?redirect=%2Fbackend', {
+    const response = await GET(new Request('https://demo.openmercato.com/api/auth/session/refresh?redirect=%2Fbackend', {
       headers: {
         cookie: 'session_token=refresh-token',
       },
     }))
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('https://develop.openmercato.com/backend')
+    expect(response.headers.get('location')).toBe('https://demo.openmercato.com/backend')
     expect(refreshFromSessionToken).toHaveBeenCalledWith('refresh-token')
   })
 

--- a/packages/core/src/modules/auth/api/logout.ts
+++ b/packages/core/src/modules/auth/api/logout.ts
@@ -1,9 +1,8 @@
-import { NextResponse } from 'next/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { AuthService } from '@open-mercato/core/modules/auth/services/authService'
 import { verifyJwt } from '@open-mercato/shared/lib/auth/jwt'
-import { buildRequestOriginUrl } from '@open-mercato/core/modules/auth/lib/requestRedirect'
+import { buildSafeRedirectResponse } from '@open-mercato/core/modules/auth/lib/requestRedirect'
 
 function parseCookie(req: Request, name: string): string | null {
   const cookie = req.headers.get('cookie') || ''
@@ -39,7 +38,7 @@ export async function POST(req: Request) {
       }
     } catch {}
   }
-  const res = NextResponse.redirect(buildRequestOriginUrl(req, '/login'))
+  const res = buildSafeRedirectResponse(req, '/login')
   res.cookies.set('auth_token', '', { path: '/', maxAge: 0 })
   res.cookies.set('session_token', '', { path: '/', maxAge: 0 })
   return res

--- a/packages/core/src/modules/auth/api/session/refresh.ts
+++ b/packages/core/src/modules/auth/api/session/refresh.ts
@@ -6,9 +6,8 @@ import { signJwt } from '@open-mercato/shared/lib/auth/jwt'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { refreshSessionRequestSchema } from '@open-mercato/core/modules/auth/data/validators'
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
-import { buildRequestOriginUrl } from '@open-mercato/core/modules/auth/lib/requestRedirect'
+import { buildSafeRedirectResponse, resolveTrustedRedirectBase } from '@open-mercato/core/modules/auth/lib/requestRedirect'
 import { sanitizeRedirectPath } from '@open-mercato/core/modules/auth/lib/safeRedirect'
-import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/config'
 import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
 import { z } from 'zod'
@@ -46,12 +45,12 @@ function clearStaffAuthCookies(response: NextResponse) {
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const baseUrl = getAppBaseUrl(req)
+  const baseUrl = resolveTrustedRedirectBase(req) ?? url.origin
   const redirectTo = sanitizeRedirectPath(url.searchParams.get('redirect'), baseUrl, '/')
   const token = parseCookie(req, 'session_token')
   if (!token) {
     return clearStaffAuthCookies(
-      NextResponse.redirect(buildRequestOriginUrl(req, '/login?redirect=' + encodeURIComponent(redirectTo)))
+      buildSafeRedirectResponse(req, '/login?redirect=' + encodeURIComponent(redirectTo))
     )
   }
   const c = await createRequestContainer()
@@ -59,12 +58,12 @@ export async function GET(req: Request) {
   const ctx = await auth.refreshFromSessionToken(token)
   if (!ctx) {
     return clearStaffAuthCookies(
-      NextResponse.redirect(buildRequestOriginUrl(req, '/login?redirect=' + encodeURIComponent(redirectTo)))
+      buildSafeRedirectResponse(req, '/login?redirect=' + encodeURIComponent(redirectTo))
     )
   }
   const { user, roles, session } = ctx
   const jwt = signJwt({ sub: String(user.id), sid: session ? String(session.id) : undefined, tenantId: String(user.tenantId), orgId: String(user.organizationId), email: user.email, roles })
-  const res = NextResponse.redirect(buildRequestOriginUrl(req, redirectTo))
+  const res = buildSafeRedirectResponse(req, redirectTo)
   res.cookies.set('auth_token', jwt, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: 60 * 60 * 8 })
   return res
 }

--- a/packages/core/src/modules/auth/lib/__tests__/requestRedirect.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/requestRedirect.test.ts
@@ -1,0 +1,94 @@
+/** @jest-environment node */
+import {
+  buildSafeRedirectResponse,
+  resolveSafeRedirectLocation,
+  resolveTrustedRedirectBase,
+} from '@open-mercato/core/modules/auth/lib/requestRedirect'
+
+const ENV_KEYS = ['APP_URL', 'NEXT_PUBLIC_APP_URL', 'APP_ALLOWED_ORIGINS', 'NODE_ENV'] as const
+const original: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) original[key] = process.env[key]
+  delete process.env.APP_URL
+  delete process.env.NEXT_PUBLIC_APP_URL
+  delete process.env.APP_ALLOWED_ORIGINS
+})
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (original[key] === undefined) delete process.env[key]
+    else process.env[key] = original[key]
+  }
+})
+
+describe('resolveSafeRedirectLocation', () => {
+  it('builds an absolute URL on the allowlisted app origin when the request origin is trusted', () => {
+    process.env.APP_URL = 'https://app.example.com'
+    const req = new Request('https://app.example.com/api/auth/logout', { method: 'POST' })
+
+    expect(resolveSafeRedirectLocation(req, '/login')).toBe('https://app.example.com/login')
+  })
+
+  it('does not honour a spoofed X-Forwarded-Host', () => {
+    process.env.APP_URL = 'https://app.example.com'
+    const req = new Request('https://app.example.com/api/auth/logout', {
+      method: 'POST',
+      headers: { 'x-forwarded-host': 'attacker.example' },
+    })
+
+    const location = resolveSafeRedirectLocation(req, '/login')
+    expect(location).not.toContain('attacker.example')
+    expect(location).toBe('/login')
+  })
+
+  it('falls back to a host-relative path when the request origin is not allowlisted', () => {
+    process.env.APP_URL = 'https://app.example.com'
+    const req = new Request('https://evil.example.com/api/auth/logout', { method: 'POST' })
+
+    expect(resolveSafeRedirectLocation(req, '/login')).toBe('/login')
+  })
+
+  it('never resolves a protocol-relative path into a cross-origin URL', () => {
+    process.env.APP_URL = 'https://app.example.com'
+    const req = new Request('https://app.example.com/api/auth/logout', { method: 'POST' })
+
+    // `new URL('//evil.com', base)` would otherwise resolve to https://evil.com/
+    expect(resolveSafeRedirectLocation(req, '//evil.com')).toBe('https://app.example.com/evil.com')
+  })
+
+  it('collapses a protocol-relative fallback path to a single-slash relative path', () => {
+    process.env.APP_URL = 'https://app.example.com'
+    const req = new Request('https://evil.example.com/api/auth/logout', { method: 'POST' })
+
+    expect(resolveSafeRedirectLocation(req, '//evil.com')).toBe('/evil.com')
+  })
+
+  it('hard-fails closed to a relative redirect in production when APP_URL is missing', () => {
+    process.env.NODE_ENV = 'production'
+    const req = new Request('https://anything.example.com/api/auth/logout', { method: 'POST' })
+
+    expect(resolveTrustedRedirectBase(req)).toBeNull()
+    expect(resolveSafeRedirectLocation(req, '/login')).toBe('/login')
+  })
+
+  it('preserves the query string when building the redirect', () => {
+    process.env.APP_URL = 'https://app.example.com'
+    const req = new Request('https://app.example.com/api/auth/session/refresh', { method: 'GET' })
+
+    expect(resolveSafeRedirectLocation(req, '/login?redirect=%2Fbackend')).toBe(
+      'https://app.example.com/login?redirect=%2Fbackend',
+    )
+  })
+})
+
+describe('buildSafeRedirectResponse', () => {
+  it('returns a 307 redirect carrying the safe Location header', () => {
+    process.env.APP_URL = 'https://app.example.com'
+    const req = new Request('https://app.example.com/api/auth/logout', { method: 'POST' })
+
+    const res = buildSafeRedirectResponse(req, '/login')
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe('https://app.example.com/login')
+  })
+})

--- a/packages/core/src/modules/auth/lib/requestRedirect.ts
+++ b/packages/core/src/modules/auth/lib/requestRedirect.ts
@@ -1,5 +1,47 @@
-import { resolveRequestOrigin } from '@open-mercato/shared/lib/url'
+import { NextResponse } from 'next/server'
+import { getSecurityEmailBaseUrl } from '@open-mercato/shared/lib/url'
 
+function toRelativeRedirectPath(path: string): string {
+  // Strip any scheme/authority so the value is always treated as a path on the
+  // current origin. Both `new URL(path, base)` and the browser would otherwise
+  // honour a protocol-relative (`//host`) or backslash-smuggled value as a
+  // cross-origin target supplied by a spoofed Host / X-Forwarded-Host.
+  const withoutBackslashes = path.replace(/\\/g, '/')
+  const rooted = withoutBackslashes.startsWith('/') ? withoutBackslashes : `/${withoutBackslashes}`
+  return rooted.replace(/^\/+/, '/')
+}
+
+export function resolveTrustedRedirectBase(req: Request): string | null {
+  try {
+    return getSecurityEmailBaseUrl(req)
+  } catch {
+    return null
+  }
+}
+
+export function resolveSafeRedirectLocation(req: Request, path: string): string {
+  const safePath = toRelativeRedirectPath(path)
+  const base = resolveTrustedRedirectBase(req)
+  if (base) return new URL(safePath, base).toString()
+  return safePath
+}
+
+export function buildSafeRedirectResponse(req: Request, path: string, status: number = 307): NextResponse {
+  return new NextResponse(null, {
+    status,
+    headers: { Location: resolveSafeRedirectLocation(req, path) },
+  })
+}
+
+/**
+ * @deprecated Use {@link buildSafeRedirectResponse} or {@link resolveSafeRedirectLocation}.
+ * Previously derived the redirect origin from raw request headers, which
+ * allowed open redirects via a spoofed Host / X-Forwarded-Host. It now returns
+ * an allowlist-validated app origin when the request origin is trusted, and a
+ * host-relative path otherwise — the latter may be a relative URL, so callers
+ * MUST NOT pass the result to `NextResponse.redirect` (use
+ * {@link buildSafeRedirectResponse} instead).
+ */
 export function buildRequestOriginUrl(req: Request, path: string): string {
-  return new URL(path, resolveRequestOrigin(req)).toString()
+  return resolveSafeRedirectLocation(req, path)
 }


### PR DESCRIPTION
Fixes #2686

## Problem
`/api/auth/logout` and `/api/auth/session/refresh` built their 302 `Location` from unvalidated request headers (`Host` / `X-Forwarded-Host`) through `buildRequestOriginUrl` → `resolveRequestOrigin`, with no allowlist check. On a deployment where `APP_URL`/`NEXT_PUBLIC_APP_URL` is unset, or behind a proxy/CDN that forwards a client-supplied `X-Forwarded-Host`, a victim following an attacker-crafted link was issued a 302 to `https://attacker.example/...`:
- **logout** — lands the freshly-logged-out victim on a look-alike login page (credential phishing)
- **refresh** — flips the address bar to the attacker origin and creates a cache-poisoning hazard; the `?redirect=` param was validated against the same poisoned base, so the check self-passed.

(report.md findings #46, #48, MEDIUM)

## Root Cause
`resolveRequestOrigin` (in `packages/shared/src/lib/url.ts`) assembles the origin from `x-forwarded-proto`/`x-forwarded-host` (falling back to `Host`) with no allowlist validation. The allowlist guard `assertAllowedAppOrigin` existed in the same module but was never invoked from these routes.

## What Changed
- `packages/core/src/modules/auth/lib/requestRedirect.ts`
  - New `resolveTrustedRedirectBase(req)` returns a server-pinned, allowlist-validated origin via `getSecurityEmailBaseUrl` (the same path `reset.ts` already uses), or `null` when the request origin cannot be trusted (spoofed host) or `APP_URL` is missing in production.
  - New `resolveSafeRedirectLocation(req, path)` / `buildSafeRedirectResponse(req, path)` build the redirect: an absolute URL on the allowlisted app origin when trusted, otherwise a **host-relative** `Location` that the browser resolves against the real request URL — which can never point cross-origin. Paths are normalized so a protocol-relative (`//host`) or backslash-smuggled value can't be reinterpreted as an absolute cross-origin URL.
  - `buildRequestOriginUrl` kept as a `@deprecated` alias (now hardened) for backward compatibility.
- `logout.ts` and `session/refresh.ts` now use `buildSafeRedirectResponse`; refresh validates `?redirect=` against the trusted base (falling back to the request origin for path-only extraction).

### Availability note
The issue suggested hard-failing (500) in production when `APP_URL` is missing. For logout/refresh this is implemented as a **relative-redirect fallback** instead of a 500: a relative `Location` is fully safe against the open-redirect vector, and a 500 on logout would leave session cookies uncleared. Misconfiguration is still surfaced via the existing `getSecurityEmailBaseUrl` warning/error logging.

## Tests
- New `packages/core/src/modules/auth/lib/__tests__/requestRedirect.test.ts` — trusted origin → absolute allowlisted URL; spoofed `X-Forwarded-Host` → relative fallback (not attacker); non-allowlisted host → relative fallback; protocol-relative path never becomes cross-origin; production + missing `APP_URL` → relative fallback; query string preserved; `buildSafeRedirectResponse` → 307 + safe Location.
- Updated `session.refresh.test.ts` — replaced the assertions that encoded the vulnerable "redirect to the request host" behavior with hardened expectations (absolute to allowlisted origin on match, host-relative otherwise, spoofed `X-Forwarded-Host` ignored).
- Updated `logout.test.ts` mock to the new response builder.
- `yarn workspace @open-mercato/core test` for `auth/api` + `auth/lib`: 255 passed. `yarn build:packages`, `yarn generate`, `yarn typecheck`: green.

## Backward Compatibility
- No API response fields, event IDs, ACL IDs, or import paths removed.
- `buildRequestOriginUrl` retained as a `@deprecated` alias (now returns an allowlist-validated/relative value); its result may be relative, so callers must not pass it to `NextResponse.redirect` — use `buildSafeRedirectResponse`. Only this module's two routes consumed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)