### PR TITLE
security(ai_assistant): enforce tenant scope on AI attachment resolver (#2663)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/attachment-parts.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/attachment-parts.test.ts
@@ -349,6 +349,118 @@ describe('resolveAttachmentParts — tenant / org scope enforcement', () => {
     expect(parts).toEqual([])
     expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('not found'))
   })
+
+  // Regression for #2663 — null-scoped rows used to bypass the tenant check via
+  // a truthiness short-circuit and leak into the caller's LLM context.
+  it('drops a null-tenant (global) record for a non super-admin caller', async () => {
+    findOneWithDecryptionMock.mockResolvedValueOnce(
+      makeRow({
+        id: 'null-tenant-1',
+        tenantId: null,
+        organizationId: null,
+        mimeType: 'image/png',
+        fileSize: 64,
+        content: 'secret OCR text',
+      }),
+    )
+
+    const parts = await resolveAttachmentParts({
+      attachmentIds: ['null-tenant-1'],
+      authContext: makeAuth({ tenantId: 'tenant-1', organizationId: 'org-1' }),
+      container: makeContainer(),
+    })
+
+    expect(parts).toEqual([])
+    expect(fsReadFileMock).not.toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('out of scope'))
+  })
+
+  // Regression for #2663 — `tenantId='X', organizationId=null` used to be
+  // readable by every org within tenant X.
+  it('drops a null-org record in the caller tenant for an org-scoped caller', async () => {
+    findOneWithDecryptionMock.mockResolvedValueOnce(
+      makeRow({
+        id: 'null-org-1',
+        tenantId: 'tenant-1',
+        organizationId: null,
+        mimeType: 'image/png',
+        fileSize: 64,
+      }),
+    )
+
+    const parts = await resolveAttachmentParts({
+      attachmentIds: ['null-org-1'],
+      authContext: makeAuth({ tenantId: 'tenant-1', organizationId: 'org-1' }),
+      container: makeContainer(),
+    })
+
+    expect(parts).toEqual([])
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('out of scope'))
+  })
+
+  it('lets a tenant-wide caller (null org) read any org within its tenant', async () => {
+    findOneWithDecryptionMock.mockResolvedValueOnce(
+      makeRow({
+        id: 'same-tenant-other-org',
+        tenantId: 'tenant-1',
+        organizationId: 'org-OTHER',
+        mimeType: 'application/zip',
+        fileSize: 64,
+        content: null,
+      }),
+    )
+
+    const parts = await resolveAttachmentParts({
+      attachmentIds: ['same-tenant-other-org'],
+      authContext: makeAuth({ tenantId: 'tenant-1', organizationId: null }),
+      container: makeContainer(),
+    })
+
+    expect(parts).toHaveLength(1)
+    expect(parts[0].attachmentId).toBe('same-tenant-other-org')
+  })
+
+  it('scopes the ORM query by tenant + org for a non super-admin caller', async () => {
+    findOneWithDecryptionMock.mockResolvedValueOnce(makeRow({ id: 'att-scope-1', fileSize: 0 }))
+
+    await resolveAttachmentParts({
+      attachmentIds: ['att-scope-1'],
+      authContext: makeAuth({ tenantId: 'tenant-1', organizationId: 'org-1' }),
+      container: makeContainer(),
+    })
+
+    const whereArg = findOneWithDecryptionMock.mock.calls[0][2]
+    expect(whereArg).toEqual({ id: 'att-scope-1', tenantId: 'tenant-1', organizationId: 'org-1' })
+  })
+
+  it('omits org from the ORM query for a tenant-wide caller (null org)', async () => {
+    findOneWithDecryptionMock.mockResolvedValueOnce(makeRow({ id: 'att-scope-2', fileSize: 0 }))
+
+    await resolveAttachmentParts({
+      attachmentIds: ['att-scope-2'],
+      authContext: makeAuth({ tenantId: 'tenant-1', organizationId: null }),
+      container: makeContainer(),
+    })
+
+    const whereArg = findOneWithDecryptionMock.mock.calls[0][2]
+    expect(whereArg).toEqual({ id: 'att-scope-2', tenantId: 'tenant-1' })
+    expect(whereArg).not.toHaveProperty('organizationId')
+  })
+
+  it('does not scope the ORM query for super-admin callers', async () => {
+    findOneWithDecryptionMock.mockResolvedValueOnce(
+      makeRow({ id: 'att-scope-3', tenantId: 'tenant-OTHER', organizationId: 'org-OTHER', fileSize: 0 }),
+    )
+
+    await resolveAttachmentParts({
+      attachmentIds: ['att-scope-3'],
+      authContext: makeAuth({ isSuperAdmin: true }),
+      container: makeContainer(),
+    })
+
+    const whereArg = findOneWithDecryptionMock.mock.calls[0][2]
+    expect(whereArg).toEqual({ id: 'att-scope-3' })
+  })
 })
 
 describe('resolveAttachmentParts — unavailable service graceful skip', () => {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/attachment-parts.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/attachment-parts.ts
@@ -128,10 +128,23 @@ async function loadAttachmentRow(
   // core package owns the MikroORM metadata and is the only place tests would
   // need to bootstrap for real DB access.
   const { Attachment } = await import('@open-mercato/core/modules/attachments/data/entities')
+  // Tenant isolation is enforced in the SQL WHERE clause, not just the JS
+  // post-filter below: the decryption scope (5th arg) only drives field
+  // decryption, so omitting tenant/org from `where` would let `em.findOne`
+  // return a row from another tenant. Super-admins bypass the scope. Org-scoped
+  // callers also constrain by org; tenant-wide callers (organizationId === null)
+  // may read any org within their tenant.
+  const where: Record<string, unknown> = { id: attachmentId }
+  if (!authContext.isSuperAdmin) {
+    where.tenantId = authContext.tenantId
+    if (authContext.organizationId != null) {
+      where.organizationId = authContext.organizationId
+    }
+  }
   const record = await findOneWithDecryption(
     em,
     Attachment as never,
-    { id: attachmentId } as never,
+    where as never,
     undefined,
     {
       tenantId: authContext.tenantId,
@@ -157,10 +170,18 @@ async function loadAttachmentRow(
 
 function rowBelongsToCaller(row: AttachmentRow, authContext: AiChatRequestContext): boolean {
   if (authContext.isSuperAdmin) return true
-  // Tenant scope: if the record is tenant-scoped, it MUST match the caller tenant.
-  if (row.tenantId && row.tenantId !== authContext.tenantId) return false
-  // Organization scope: if the record is org-scoped, it MUST match the caller org.
-  if (row.organizationId && row.organizationId !== authContext.organizationId) return false
+  // Tenant scope: fail closed. The record MUST carry the caller's tenant.
+  // A null `tenant_id` (a supported "global"/unscoped attachment state) is NOT
+  // accessible through the AI path: it has no `partition.isPublic` gate, so a
+  // truthiness short-circuit here would leak the bytes / extracted text into a
+  // different tenant's LLM context (cross-tenant IDOR, issue #2663). Requiring
+  // strict equality also rejects a non-super-admin caller with a null tenant.
+  if (authContext.tenantId == null || row.tenantId !== authContext.tenantId) return false
+  // Organization scope: when the caller is org-scoped, the record MUST match
+  // that organization (this also rejects null-org rows for an org-scoped
+  // caller). Tenant-wide callers (organizationId === null) may read any org
+  // within their tenant.
+  if (authContext.organizationId != null && row.organizationId !== authContext.organizationId) return false
   return true
 }
 


### PR DESCRIPTION
Fixes #2663

## Problem
The AI-assistant attachment resolver (`resolveAttachmentParts` → `loadAttachmentRow`) fetched an attachment **by id only** and relied on a JS post-filter (`rowBelongsToCaller`) that used truthiness short-circuits. An attachment with `tenantId: null` (a supported state — the entity declares both scope columns nullable) bypassed the tenant check and was returned to any authenticated caller. Its filename, mime type, raw bytes (inlined as base64 data URLs), and OCR/extracted `content` then flowed into the chat message sent to the LLM provider. The same flaw applied to the org check (`tenantId='X', organizationId=null` was readable by every org in tenant X). This is a cross-tenant IDOR distinct from the core attachment-delivery routes (#2108–#2110), which use `checkAttachmentAccess`/`isSameScope`; this code path did not.

## Root Cause
- `findOneWithDecryption` passes its `where` straight to `em.findOne`; the `DecryptionScope` (5th arg) is consumed only by field decryption, **not** added to the SQL WHERE. Isolation therefore depended entirely on the post-filter.
- `rowBelongsToCaller` guarded with `if (row.tenantId && row.tenantId !== authContext.tenantId)`, so a `null` `tenantId` skipped the check and the row was accepted regardless of the caller's tenant.

## What Changed
`packages/ai-assistant/src/modules/ai_assistant/lib/attachment-parts.ts`
- **`loadAttachmentRow`** — for non-super-admin callers, add `tenant_id` (and `organization_id` when the caller is org-scoped) to the ORM WHERE clause so SQL enforces isolation (defense in depth). Super-admins are unscoped; tenant-wide callers (`organizationId === null`) may still read any org within their tenant.
- **`rowBelongsToCaller`** — fail closed: require strict `row.tenantId === authContext.tenantId` (rejects null-tenant "global" rows and null-tenant callers) and, for org-scoped callers, strict `row.organizationId === authContext.organizationId` (rejects null-org rows). Super-admin still bypasses.

## Tests
`packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/attachment-parts.test.ts` — 8 new cases:
- null-tenant (global) record dropped for a non-super-admin caller (the reported IDOR)
- null-org record in caller's tenant dropped for an org-scoped caller
- tenant-wide caller (null org) reads another org within its tenant
- ORM WHERE is scoped by tenant+org / tenant-only / unscoped per caller class
- Full suite: 1199 ai-assistant tests pass; `yarn build:packages` clean.

## Backward Compatibility
No contract surface changes — internal `lib/` function bodies only. No API responses, event IDs, DI names, or import paths changed. Super-admin and same-tenant behavior is preserved; only genuinely out-of-scope (null/cross-tenant) reads are now refused.