### PR TITLE
fix(customers): align example seed data with dictionary values

### DIFF
--- a/packages/core/src/modules/customers/__tests__/seedDictionaryScope.test.ts
+++ b/packages/core/src/modules/customers/__tests__/seedDictionaryScope.test.ts
@@ -1,0 +1,56 @@
+import {
+  CUSTOMER_EXAMPLES,
+  ENTITY_STATUS_DEFAULTS,
+  ENTITY_SOURCE_DEFAULTS,
+  ENTITY_LIFECYCLE_STAGE_DEFAULTS,
+  DEAL_STATUS_DEFAULTS,
+  PIPELINE_STAGE_DEFAULTS,
+} from '../cli'
+
+const valuesOf = (dict: ReadonlyArray<{ value: string }>) => new Set(dict.map((d) => d.value))
+
+// Regression guard for #2645: every dictionary-backed value used in the curated
+// customer seed data (CUSTOMER_EXAMPLES) must be a member of the dictionary the UI
+// binds that field to — otherwise the seeded record renders an out-of-scope value
+// (e.g. a `status: 'customer'` that actually belongs to the lifecycle_stage dictionary).
+describe('customers seed data stays within dictionary scope (#2645)', () => {
+  it('uses only dictionary-backed status/source/lifecycle/pipeline values', () => {
+    const statusValues = valuesOf(ENTITY_STATUS_DEFAULTS)
+    const sourceValues = valuesOf(ENTITY_SOURCE_DEFAULTS)
+    const lifecycleValues = valuesOf(ENTITY_LIFECYCLE_STAGE_DEFAULTS)
+    const dealStatusValues = valuesOf(DEAL_STATUS_DEFAULTS)
+    const pipelineValues = valuesOf(PIPELINE_STAGE_DEFAULTS)
+
+    const violations: string[] = []
+    const check = (
+      where: string,
+      field: string,
+      value: string | undefined,
+      allowed: Set<string>,
+    ) => {
+      if (value != null && !allowed.has(value)) {
+        violations.push(`${where}: ${field}="${value}"`)
+      }
+    }
+
+    for (const company of CUSTOMER_EXAMPLES) {
+      const c = `company "${company.slug}"`
+      check(c, 'status', company.status, statusValues)
+      check(c, 'source', company.source, sourceValues)
+      check(c, 'lifecycleStage', company.lifecycleStage, lifecycleValues)
+
+      for (const person of company.people ?? []) {
+        check(`person "${person.slug}"`, 'source', person.source, sourceValues)
+      }
+
+      for (const deal of company.deals ?? []) {
+        const d = `deal "${deal.slug}"`
+        check(d, 'status', deal.status, dealStatusValues)
+        check(d, 'pipelineStage', deal.pipelineStage, pipelineValues)
+        check(d, 'source', deal.source, sourceValues)
+      }
+    }
+
+    expect(violations).toEqual([])
+  })
+})

--- a/packages/core/src/modules/customers/cli.ts
+++ b/packages/core/src/modules/customers/cli.ts
@@ -53,7 +53,7 @@ type DictionaryDefault = {
 type CustomFieldValuesPayload = Parameters<DataEngine['setCustomFields']>[0]['values']
 type ProgressBarHandle = ReturnType<typeof createProgressBar>
 
-const DEAL_STATUS_DEFAULTS: DictionaryDefault[] = [
+export const DEAL_STATUS_DEFAULTS: DictionaryDefault[] = [
   { value: 'open', label: 'Open', color: '#2563eb', icon: 'lucide:circle' },
   { value: 'closed', label: 'Closed', color: '#6b7280', icon: 'lucide:check-circle' },
   { value: 'win', label: 'Win', color: '#22c55e', icon: 'lucide:trophy' },
@@ -61,7 +61,7 @@ const DEAL_STATUS_DEFAULTS: DictionaryDefault[] = [
   { value: 'in_progress', label: 'In progress', color: '#f59e0b', icon: 'lucide:activity' },
 ]
 
-const PIPELINE_STAGE_DEFAULTS: DictionaryDefault[] = [
+export const PIPELINE_STAGE_DEFAULTS: DictionaryDefault[] = [
   { value: 'opportunity', label: 'Opportunity', color: '#38bdf8', icon: 'lucide:target' },
   { value: 'marketing_qualified_lead', label: 'Marketing Qualified Lead', color: '#a855f7', icon: 'lucide:sparkles' },
   { value: 'sales_qualified_lead', label: 'Sales Qualified Lead', color: '#f97316', icon: 'lucide:users' },
@@ -72,14 +72,14 @@ const PIPELINE_STAGE_DEFAULTS: DictionaryDefault[] = [
   { value: 'stalled', label: 'Stalled', color: '#6b7280', icon: 'lucide:alert-circle' },
 ]
 
-const ENTITY_STATUS_DEFAULTS: DictionaryDefault[] = [
+export const ENTITY_STATUS_DEFAULTS: DictionaryDefault[] = [
   { value: 'active', label: 'Active', color: '#22c55e', icon: 'lucide:user-check' },
   { value: 'inactive', label: 'Inactive', color: '#94a3b8', icon: 'lucide:pause-circle' },
   { value: 'pending', label: 'Pending', color: '#f59e0b', icon: 'lucide:clock' },
   { value: 'archived', label: 'Archived', color: '#64748b', icon: 'lucide:archive' },
 ]
 
-const ENTITY_LIFECYCLE_STAGE_DEFAULTS: DictionaryDefault[] = [
+export const ENTITY_LIFECYCLE_STAGE_DEFAULTS: DictionaryDefault[] = [
   { value: 'lead', label: 'Lead', color: '#3b82f6', icon: 'lucide:sparkles' },
   { value: 'prospect', label: 'Prospect', color: '#8b5cf6', icon: 'lucide:eye' },
   { value: 'customer', label: 'Customer', color: '#22c55e', icon: 'lucide:handshake' },
@@ -88,7 +88,7 @@ const ENTITY_LIFECYCLE_STAGE_DEFAULTS: DictionaryDefault[] = [
   { value: 'other', label: 'Other', color: '#94a3b8', icon: 'lucide:circle' },
 ]
 
-const ENTITY_SOURCE_DEFAULTS: DictionaryDefault[] = [
+export const ENTITY_SOURCE_DEFAULTS: DictionaryDefault[] = [
   { value: 'linkedin', label: 'LinkedIn', color: '#0a66c2', icon: 'lucide:linkedin' },
   { value: 'email', label: 'Email', color: '#3b82f6', icon: 'lucide:mail' },
   { value: 'web_form', label: 'Web form', color: '#22c55e', icon: 'lucide:globe' },
@@ -291,7 +291,7 @@ function isoDaysFromNow(days: number, options?: { hour?: number; minute?: number
   return base.toISOString()
 }
 
-const CUSTOMER_EXAMPLES: ExampleCompany[] = [
+export const CUSTOMER_EXAMPLES: ExampleCompany[] = [
   {
     slug: 'brightside-solar',
     displayName: 'Brightside Solar',
@@ -307,7 +307,7 @@ const CUSTOMER_EXAMPLES: ExampleCompany[] = [
     primaryPhone: '+1 415-555-0148',
     source: 'partner_referral',
     lifecycleStage: 'customer',
-    status: 'customer',
+    status: 'active',
     custom: {
       relationship_health: 'healthy',
       renewal_quarter: 'Q3',
@@ -364,7 +364,7 @@ const CUSTOMER_EXAMPLES: ExampleCompany[] = [
         phone: '+1 628-555-0199',
         timezone: 'America/Los_Angeles',
         linkedInUrl: 'https://www.linkedin.com/in/danielcho-energy/',
-        source: 'outbound_campaign',
+        source: 'cold_outreach',
         custom: {
           buying_role: 'economic_buyer',
           preferred_pronouns: 'he/him',
@@ -438,7 +438,7 @@ const CUSTOMER_EXAMPLES: ExampleCompany[] = [
         valueCurrency: 'USD',
         expectedCloseAt: isoDaysFromNow(65),
         probability: 40,
-        source: 'inbound_web',
+        source: 'web_form',
         custom: {
           competitive_risk: 'high',
           implementation_complexity: 'complex',
@@ -513,7 +513,7 @@ const CUSTOMER_EXAMPLES: ExampleCompany[] = [
       'Boston-based analytics platform helping consumer brands optimize merchandising decisions.',
     primaryEmail: 'info@harborviewanalytics.com',
     primaryPhone: '+1 617-555-0024',
-    source: 'industry_event',
+    source: 'event',
     lifecycleStage: 'prospect',
     status: 'active',
     custom: {
@@ -545,7 +545,7 @@ const CUSTOMER_EXAMPLES: ExampleCompany[] = [
         phone: '+1 617-555-0168',
         timezone: 'America/New_York',
         linkedInUrl: 'https://www.linkedin.com/in/arjunpatel-sales/',
-        source: 'industry_event',
+        source: 'event',
         custom: {
           buying_role: 'economic_buyer',
           preferred_pronouns: 'he/him',
@@ -563,7 +563,7 @@ const CUSTOMER_EXAMPLES: ExampleCompany[] = [
         phone: '+1 617-555-0179',
         timezone: 'America/New_York',
         linkedInUrl: 'https://www.linkedin.com/in/lenaortiz-retail/',
-        source: 'industry_event',
+        source: 'event',
         custom: {
           buying_role: 'champion',
           preferred_pronouns: 'she/her',
@@ -582,7 +582,7 @@ const CUSTOMER_EXAMPLES: ExampleCompany[] = [
         valueCurrency: 'USD',
         expectedCloseAt: isoDaysFromNow(-25),
         probability: 100,
-        source: 'industry_event',
+        source: 'event',
         custom: {
           competitive_risk: 'low',
           implementation_complexity: 'standard',
@@ -637,7 +637,7 @@ const CUSTOMER_EXAMPLES: ExampleCompany[] = [
         valueCurrency: 'USD',
         expectedCloseAt: isoDaysFromNow(120),
         probability: 35,
-        source: 'outbound_campaign',
+        source: 'cold_outreach',
         custom: {
           competitive_risk: 'medium',
           implementation_complexity: 'complex',
@@ -715,7 +715,7 @@ const CUSTOMER_EXAMPLES: ExampleCompany[] = [
     primaryPhone: '+1 512-555-0456',
     source: 'customer_referral',
     lifecycleStage: 'customer',
-    status: 'customer',
+    status: 'active',
     custom: {
       relationship_health: 'healthy',
       renewal_quarter: 'Q1',


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

 ## Summary

  The curated customer example seed (`CUSTOMER_EXAMPLES` in `customers/cli.ts`) used several values outside the dictionaries
  the UI binds those fields to. Seeded records therefore showed out-of-scope values — e.g. a company **Status** of
  `customer`, which is actually a `lifecycle_stage` value (visible on "Brightside Solar" in #2645). #2608 only patched the
  Radix Select to inject those phantom values so they render; this fixes the underlying seed data.

before: 
<img width="1351" height="833" alt="przed" src="https://github.com/user-attachments/assets/75027cdf-aa06-41f8-b0d5-601e46e6ee64" />


after:
<img width="405" height="387" alt="poo" src="https://github.com/user-attachments/assets/9d43ed4d-fbcf-4d76-ac77-d22337d9e994" />



  Brought every dictionary-backed value in the curated examples into scope:
  - `status: 'customer'` → `'active'` (Brightside Solar, Copperleaf Design) — `customer` stays as the `lifecycleStage`, which
  is valid there.
  - `source: 'industry_event'` → `'event'`
  - `source: 'outbound_campaign'` → `'cold_outreach'`
  - `source: 'inbound_web'` → `'web_form'`

  Deal `status`/`pipelineStage`, `lifecycleStage`, and the `customer_referral`/`partner_referral` sources were already in
  scope and are unchanged. The synthetic stress-test marker `STRESS_TEST_SOURCE = 'stress_test'` (opt-in `--stresstest`) is
  intentionally left out of scope.

  **Before:** <przeciągnij zrzut: Status = `customer`, widmo nad 4 prawdziwymi opcjami>

  **After:** <przeciągnij zrzut: Status = `Active`, tylko 4 opcje w słowniku>

  ## Changes

  - `customers/cli.ts`: corrected the out-of-scope `status`/`source` values above; exported `CUSTOMER_EXAMPLES` and the
  dictionary-default arrays so they are testable.
  - `customers/__tests__/seedDictionaryScope.test.ts`: regression test asserting every
  `status`/`source`/`lifecycleStage`/`pipelineStage` in `CUSTOMER_EXAMPLES` is a member of its dictionary.

  ## Specification

  **Does a spec exist for this feature/module?**
  - [ ] Yes
  - [ ] No (created a new spec)
  - [x] N/A (minor change, no spec needed)

  **Spec file path:**
  N/A

  ## Testing

  - `yarn workspace @open-mercato/core test seedDictionaryScope` → 1/1 pass
  - `yarn workspace @open-mercato/core build` → built successfully
  - Re-seeded a tenant (`yarn reinstall`) and verified in the DB and UI: company Status now resolves to `active` (no phantom
  `customer` option), and all `source` values are dictionary members (`event`, `cold_outreach`, `web_form`, …).

  ## Checklist

  - [x] This pull request targets `develop`.
  - [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
  - [x] I updated documentation, locales, or generators if the change requires it. (None required.)
  - [x] I added or adjusted tests that cover the change.
  - [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). —
  Not required: corrects seed-data constants, guarded by the new unit regression test; no runtime or user-flow change.
  - [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A.

  ### Design System Compliance
  N/A — data-only change (seed constants + a unit test); no UI is touched, so none of the DS items apply.

  ## Linked issues

  Fixes #2645