### PR TITLE
security(attachments): enforce tenant/org scope invariant at creation (#2109)

### DIFF
--- a/.ai/specs/2026-06-09-attachments-scope-invariant.md
+++ b/.ai/specs/2026-06-09-attachments-scope-invariant.md
@@ -1,0 +1,80 @@
+# SPEC: Attachments scope invariant — audit & hardening
+
+> Status: **Implemented** · Date: 2026-06-09 · Scope: OSS
+> Module: `packages/core/src/modules/attachments/`
+> Issue: [open-mercato/open-mercato#2109](https://github.com/open-mercato/open-mercato/issues/2109) — "consider NOT NULL constraint on attachments.tenant_id and attachments.organization_id"
+> Related: PR #2107 (read-time fail-closed fix), #2012 (mergeIdFilter fail-closed pattern)
+
+## TLDR
+
+`attachments.tenant_id` / `attachments.organization_id` are nullable. Issue #2109 asks
+whether they should be `NOT NULL` to structurally prevent the fail-open class closed at
+read time by PR #2107.
+
+The audit found a **legitimate unscoped use case**: a row with **both** scope columns null
+is an intentional "global attachment", explicitly supported by `isSameScope`
+(`lib/access.ts:19-21`). A blanket `NOT NULL` migration would break that semantic and force
+a sentinel-tenant backfill of legacy rows. This places the issue in **Option B** of its own
+acceptance criteria (document the legitimate unscoped use case + regression coverage) rather
+than the `NOT NULL` migration branch.
+
+The real danger is **partial-null** (one column set, the other null): `isSameScope` fails
+closed on it (#2107), so such a row is unreadable dead data that can only leak through a
+future code path that bypasses `checkAttachmentAccess`. The hardening enforces the
+**both-or-neither** invariant at the creation boundary instead of at the schema level.
+
+## Audit — Attachment creation paths
+
+| Creation site | Scope source | Can produce partial-null? |
+|---------------|--------------|---------------------------|
+| `attachments/api/route.ts:~424` (upload) | `auth.orgId!` / `auth.tenantId!`, gated by precondition | No — both set |
+| `sync_excel/lib/upload-storage.ts:38` | required `organizationId` / `tenantId` inputs | No |
+| `catalog/seed/examples.ts:102` | `SeedScope` (both required) | No |
+| `catalog/commands/variants.ts:553` | `source ?? variant ?? null` (pair) | Only collapses to both-null global |
+| `messages/lib/attachments.ts:177` (`copyAttachmentsForForwardMessages`) | non-null `tenantId` + **nullable** `targetOrganizationId` | **Yes** — tenant-set/org-null |
+
+The access layer (`lib/access.ts`) is already correct and well-tested:
+- both-null → accessible to any authenticated principal (global semantics)
+- partial-null → fail-closed (403) for every non-superadmin principal
+- scoped → exact-match required
+
+## Decision
+
+- **Reject** the `NOT NULL` migration: it would break the supported global-attachment
+  shape and require a risky sentinel backfill, for a `priority-low` hardening task.
+- **Reject** a DB `CHECK ((both null) OR (both set))` for now: it is an Ask-First schema
+  change and would make the `messages` forward-copy path throw at runtime if an org is
+  ever legitimately null there. Recorded below as an optional follow-up.
+- **Adopt** an application-layer fail-closed guard at the creation boundary plus module
+  documentation, matching acceptance-criteria Option B.
+
+## What changed
+
+1. `lib/access.ts` — new exported `assertAttachmentScopeInvariant({ tenantId, organizationId })`
+   throwing on partial-null (blank/whitespace treated as null), accepting both fully-scoped
+   and fully-global rows.
+2. `api/route.ts` — calls the guard before persisting the uploaded attachment.
+3. `AGENTS.md` (new) — documents the scope/access policy, the both-or-neither invariant, and
+   the audited cross-module creation paths.
+4. `lib/__tests__/access.test.ts` — unit tests for the guard (scoped ✓, global ✓, partial-null ✗,
+   blank-string handling, error message naming the missing column).
+
+## Acceptance criteria
+
+- [x] Audit completed; outcome documented in this spec.
+- [x] Legitimate "unscoped attachment" (both-null global) use case documented in module
+  `AGENTS.md` with explicit access-policy notes, plus regression tests asserting the access
+  check refuses cross-scope / partial-null reads (`lib/__tests__/access.test.ts`).
+
+## Backward compatibility
+
+No contract-surface change: nullable columns are unchanged, no API response field changes,
+no event/DI/ACL/route changes. The new guard only rejects rows that are already unreadable
+dead data, so no previously-valid attachment becomes invalid.
+
+## Optional follow-up (not in this change)
+
+If the team wants DB-level enforcement, a future PR could add a
+`CHECK ((organization_id IS NULL AND tenant_id IS NULL) OR (organization_id IS NOT NULL AND tenant_id IS NOT NULL))`
+constraint, **after** first changing `messages/lib/attachments.ts` to copy the source
+attachment's scope pair (so the forward-copy path can never emit a partial-null row).

--- a/packages/core/src/modules/attachments/AGENTS.md
+++ b/packages/core/src/modules/attachments/AGENTS.md
@@ -1,0 +1,79 @@
+# Attachments Module — Agent Guidelines
+
+The `attachments` module owns file uploads, storage drivers, partitions, OCR, and
+the `attachments` table. Every attachment row carries a `tenant_id` /
+`organization_id` scope pair that governs cross-tenant access.
+
+## Scope & Access Policy
+
+`attachments.tenant_id` and `attachments.organization_id` are **nullable** at the
+DB level, but only two scope shapes are valid:
+
+| Shape | `tenant_id` | `organization_id` | Meaning | Who can read it |
+|-------|-------------|-------------------|---------|-----------------|
+| **Scoped** | set | set | Belongs to one tenant + org | Same-scope principals + superadmin |
+| **Global** | null | null | Legacy "global attachment" | Any authenticated principal (and unauthenticated only on a `is_public` partition) |
+| **Partial-null** ❌ | set / null | null / set | **Invalid — never create** | Nobody (fail-closed) except superadmin |
+
+The "both-or-neither" rule is the legitimate-unscoped use case referenced by
+[#2109](https://github.com/open-mercato/open-mercato/issues/2109): a fully-global
+(both-null) attachment is intentionally supported by `isSameScope`, so the columns
+cannot simply be made `NOT NULL` without breaking that semantic or backfilling a
+sentinel tenant onto legacy rows.
+
+### Why partial-null is dangerous
+
+`isSameScope` (`lib/access.ts`) deliberately **fails closed** on partial-null rows
+(#2107): a row with one scope column set and the other null matches no principal's
+auth and is unreadable by everyone except a superadmin. Such a row is therefore
+*dead data* — it can only ever leak through a future code path that reads or
+exports attachments **without** going through `checkAttachmentAccess` (a new export
+endpoint, webhook delivery, OCR worker, or migration backfill). That is exactly the
+fail-open class the access fix closed at read time; the creation guard closes it at
+write time.
+
+## Always
+
+- **MUST call `assertAttachmentScopeInvariant({ tenantId, organizationId })` from
+  `lib/access.ts` before persisting any new `Attachment` row.** It throws on a
+  partial-null scope and accepts both fully-scoped and fully-global rows. The
+  attachments upload route (`api/route.ts`) already guards its creation site.
+- **MUST gate every attachment read through `checkAttachmentAccess`** (`lib/access.ts`)
+  so tenant scoping and partition visibility are enforced consistently.
+- When copying/cloning attachments across records, **carry the source row's scope
+  pair as a unit** (both columns together) rather than overriding one column with a
+  possibly-null value.
+
+## Never
+
+- **Never create a partial-null attachment** (one scope column set, the other null).
+- **Never read or expose attachment rows without `checkAttachmentAccess`** — bypassing
+  it reintroduces the cross-tenant fail-open class.
+
+## Known cross-module creation paths
+
+These paths create `Attachment` rows from other modules and must preserve the
+both-or-neither invariant (audited for #2109):
+
+- `packages/core/src/modules/attachments/api/route.ts` — primary upload; scope comes
+  from authenticated request context (both set). **Guarded.**
+- `packages/core/src/modules/sync_excel/lib/upload-storage.ts` — both scopes are
+  required inputs (type-enforced). Safe.
+- `packages/core/src/modules/catalog/seed/examples.ts` — both scopes required on
+  `SeedScope`. Safe.
+- `packages/core/src/modules/catalog/commands/variants.ts` — clones variant media to
+  the product; inherits the source/variant scope pair (`?? null` only collapses to
+  the global both-null shape).
+- `packages/core/src/modules/messages/lib/attachments.ts`
+  (`copyAttachmentsForForwardMessages`) — copies forwarded message attachments and
+  accepts a nullable `targetOrganizationId` with a non-null `tenantId`. This is the
+  one path that can construct a partial-null row; copy the **source attachment's**
+  scope pair when wiring new callers, and apply the creation guard if this path is
+  refactored.
+
+## Validation Commands
+
+```bash
+yarn workspace @open-mercato/core test -- access
+yarn workspace @open-mercato/core build
+```

--- a/packages/core/src/modules/attachments/api/route.ts
+++ b/packages/core/src/modules/attachments/api/route.ts
@@ -12,6 +12,7 @@ import { requestOcrProcessing } from '../lib/ocrQueue'
 import { StorageDriverFactory } from '../lib/drivers'
 import { OcrService, shouldUseLlmOcr } from '../lib/ocrService'
 import { clearAttachmentThumbnailCache } from '../lib/thumbnailCache'
+import { assertAttachmentScopeInvariant } from '../lib/access'
 import {
   mergeAttachmentMetadata,
   normalizeAttachmentAssignments,
@@ -421,6 +422,7 @@ export async function POST(req: Request) {
   }
   const metadata = mergeAttachmentMetadata(null, { assignments, tags })
   const attachmentId = randomUUID()
+  assertAttachmentScopeInvariant({ tenantId: auth.tenantId, organizationId: auth.orgId })
   const att = em.create(Attachment, {
     id: attachmentId,
     entityId,

--- a/packages/core/src/modules/attachments/lib/__tests__/access.test.ts
+++ b/packages/core/src/modules/attachments/lib/__tests__/access.test.ts
@@ -1,4 +1,4 @@
-import { checkAttachmentAccess } from '../access'
+import { assertAttachmentScopeInvariant, checkAttachmentAccess } from '../access'
 
 function attachment(overrides: Record<string, unknown> = {}) {
   return { tenantId: 'tenant-1', organizationId: 'org-1', ...overrides } as any
@@ -128,5 +128,53 @@ describe('checkAttachmentAccess — partial-null scope fail-closed', () => {
       partition(false),
     )
     expect(result.ok).toBe(true)
+  })
+})
+
+describe('assertAttachmentScopeInvariant — both-or-neither creation guard', () => {
+  it('accepts a fully-scoped attachment (both tenant and organization set)', () => {
+    expect(() =>
+      assertAttachmentScopeInvariant({ tenantId: 'tenant-1', organizationId: 'org-1' }),
+    ).not.toThrow()
+  })
+
+  it('accepts a fully-global attachment (both null)', () => {
+    expect(() =>
+      assertAttachmentScopeInvariant({ tenantId: null, organizationId: null }),
+    ).not.toThrow()
+  })
+
+  it('accepts a fully-global attachment (both undefined)', () => {
+    expect(() => assertAttachmentScopeInvariant({})).not.toThrow()
+  })
+
+  it('rejects a partial-null scope (tenant set, organization null)', () => {
+    expect(() =>
+      assertAttachmentScopeInvariant({ tenantId: 'tenant-1', organizationId: null }),
+    ).toThrow(/scope invariant/i)
+  })
+
+  it('rejects a partial-null scope (organization set, tenant null)', () => {
+    expect(() =>
+      assertAttachmentScopeInvariant({ tenantId: null, organizationId: 'org-1' }),
+    ).toThrow(/scope invariant/i)
+  })
+
+  it('treats blank/whitespace scope strings as null (rejects partial, accepts both-blank)', () => {
+    expect(() =>
+      assertAttachmentScopeInvariant({ tenantId: 'tenant-1', organizationId: '   ' }),
+    ).toThrow(/scope invariant/i)
+    expect(() =>
+      assertAttachmentScopeInvariant({ tenantId: '', organizationId: '' }),
+    ).not.toThrow()
+  })
+
+  it('names the missing column in the error message', () => {
+    expect(() =>
+      assertAttachmentScopeInvariant({ tenantId: 'tenant-1', organizationId: null }),
+    ).toThrow(/organization_id/)
+    expect(() =>
+      assertAttachmentScopeInvariant({ tenantId: null, organizationId: 'org-1' }),
+    ).toThrow(/tenant_id/)
   })
 })

--- a/packages/core/src/modules/attachments/lib/access.ts
+++ b/packages/core/src/modules/attachments/lib/access.ts
@@ -1,6 +1,42 @@
 import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
 import type { Attachment, AttachmentPartition } from '../data/entities'
 
+export type AttachmentScope = {
+  tenantId?: string | null
+  organizationId?: string | null
+}
+
+function normalizeScopeValue(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * Enforce the attachments scope invariant at every creation boundary:
+ * an attachment is either fully **global** (both `tenant_id` and
+ * `organization_id` null) or fully **scoped** (both set) — never partial.
+ *
+ * `isSameScope` deliberately treats a partial-null row as inaccessible to
+ * every non-superadmin principal (fail-closed, #2107), so a partial-null row
+ * is dead data that can only ever leak through a future code path that skips
+ * the access check. Guarding creation keeps that class of fail-open bug from
+ * re-emerging (#2109). Call this before persisting any `Attachment`.
+ */
+export function assertAttachmentScopeInvariant(scope: AttachmentScope): void {
+  const tenantId = normalizeScopeValue(scope.tenantId)
+  const organizationId = normalizeScopeValue(scope.organizationId)
+  const tenantSet = tenantId !== null
+  const organizationSet = organizationId !== null
+  if (tenantSet !== organizationSet) {
+    const missing = tenantSet ? 'organization_id' : 'tenant_id'
+    throw new Error(
+      `[internal] Attachment scope invariant violated: ${missing} is null while the other scope column is set. ` +
+        'Attachments must be either fully scoped (both tenant_id and organization_id) or fully global (both null).',
+    )
+  }
+}
+
 export function isSuperAdminAuth(auth: AuthContext | null | undefined): boolean {
   if (!auth) return false
   if ((auth as any).isSuperAdmin === true) return true


### PR DESCRIPTION
Fixes #2109

## Problem
`attachments.tenant_id` / `attachments.organization_id` are nullable. The issue asks whether they should be `NOT NULL` to structurally prevent the fail-open class closed at read time by PR #2107.

## Root Cause / Audit outcome
Audited every `Attachment` creation path. A row with **both** scope columns null is an **intentional "global attachment"**, explicitly supported by `isSameScope` (`lib/access.ts:19-21`). A blanket `NOT NULL` migration would break that semantic and force a sentinel-tenant backfill of legacy rows — so this is the **Option B** branch of the issue's own acceptance criteria (legitimate unscoped use case exists → document + add coverage), not the migration branch.

The real danger is **partial-null** (one column set, the other null): `isSameScope` already **fails closed** on it (#2107), so such a row is unreadable dead data that can only leak through a future code path that bypasses `checkAttachmentAccess` (a new export endpoint, webhook delivery, OCR worker, or backfill). The one path that can currently construct a partial-null row is `messages/lib/attachments.ts` (`copyAttachmentsForForwardMessages`, nullable `targetOrganizationId` + non-null `tenantId`).

## What Changed
- **`lib/access.ts`** — new exported `assertAttachmentScopeInvariant({ tenantId, organizationId })` that throws on partial-null (blank/whitespace treated as null) and accepts both fully-scoped and fully-global rows.
- **`api/route.ts`** — guards the uploaded-attachment creation site with it.
- **`AGENTS.md`** (new) — documents the scope/access policy, the both-or-neither invariant, and every audited cross-module creation path.
- **`.ai/specs/2026-06-09-attachments-scope-invariant.md`** (new) — records the audit, the decision to reject `NOT NULL`/`CHECK` for now, and an optional DB-`CHECK` follow-up.

## Tests
- `lib/__tests__/access.test.ts` — new unit tests for the guard: scoped ✓, global (both-null / both-undefined) ✓, partial-null ✗ (both directions), blank-string handling, error message names the missing column.
- `yarn workspace @open-mercato/core test -- modules/attachments` → 18 suites / 136 tests pass.
- `yarn build:packages`, `yarn generate`, `yarn typecheck` (all 21 packages) pass.

## Backward Compatibility
No contract-surface change: nullable columns unchanged, no API response field changes, no event/DI/ACL/route/import-path changes. The new guard is additive and only rejects rows that are already unreadable dead data, so no previously-valid attachment becomes invalid.