### PR TITLE
perf(directory): per-request memoize org-scope + wire org-scope:user invalidation (#2259)

### DIFF
--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -4,6 +4,7 @@ import { ApiKey } from '@open-mercato/core/modules/api_keys/data/entities'
 import { createMemoryStrategy } from '@open-mercato/cache'
 import type { CacheStrategy } from '@open-mercato/cache'
 import * as enabledModulesRegistry from '@open-mercato/shared/security/enabledModulesRegistry'
+import { buildOrgScopeUserCacheTag, buildOrgScopeTenantCacheTag } from '@open-mercato/core/modules/directory/utils/organizationScope'
 
 // Minimal mock of MikroORM EntityManager surface used by RbacService
 type MockEm = {
@@ -638,6 +639,33 @@ describe('RbacService', () => {
       await service.loadAcl(user2.id, { tenantId: 'tenant-1', organizationId: null })
 
       expect(em.findOne).toHaveBeenCalledTimes(initialCalls + callsForScopes(1) * 2) // Both users queried again (first load per user)
+    })
+
+    // Issue #2259 — the resolved OrganizationScope (directory) cache derives its
+    // accessible-org set from the same ACL/role grants the RBAC cache holds.
+    // RBAC invalidation must therefore also drop the matching org-scope entries,
+    // so the cross-request scope TTL can be enabled without serving stale scope
+    // after a membership change.
+    it('invalidateUserCache also drops org-scope:user entries', async () => {
+      const key = 'org-scope:user-1:tenant-1:none:none'
+      const scope = { selectedId: null, filterIds: null, allowedIds: null, tenantId: 'tenant-1' }
+      await cache.set(key, scope, { ttl: 60_000, tags: [buildOrgScopeUserCacheTag('user-1')] })
+      expect(await cache.get(key)).not.toBeNull()
+
+      await service.invalidateUserCache('user-1')
+
+      expect(await cache.get(key)).toBeNull()
+    })
+
+    it('invalidateTenantCache also drops org-scope:tenant entries', async () => {
+      const key = 'org-scope:user-9:tenant-1:none:none'
+      const scope = { selectedId: null, filterIds: null, allowedIds: null, tenantId: 'tenant-1' }
+      await cache.set(key, scope, { ttl: 60_000, tags: [buildOrgScopeTenantCacheTag('tenant-1')] })
+      expect(await cache.get(key)).not.toBeNull()
+
+      await service.invalidateTenantCache('tenant-1')
+
+      expect(await cache.get(key)).toBeNull()
     })
 
     it('should not affect other tenants when invalidating specific tenant cache', async () => {

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -4,6 +4,7 @@ import { getCurrentCacheTenant, runWithCacheTenant } from '@open-mercato/cache'
 import { UserAcl, RoleAcl, User, UserRole } from '@open-mercato/core/modules/auth/data/entities'
 import { ApiKey } from '@open-mercato/core/modules/api_keys/data/entities'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { buildOrgScopeUserCacheTag, buildOrgScopeTenantCacheTag } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { matchFeature as sharedMatchFeature, hasAllFeatures as sharedHasAllFeatures } from '@open-mercato/shared/lib/auth/featureMatch'
 import { filterGrantsByEnabledModules, getOwningModuleId, getEnabledModuleIds } from '@open-mercato/shared/security/enabledModulesRegistry'
 
@@ -130,7 +131,12 @@ export class RbacService {
    */
   async invalidateUserCache(userId: string): Promise<void> {
     this.globalSuperAdminCache.delete(userId)
-    await this.deleteCacheByTags([this.getUserTag(userId)])
+    // Also drop the directory OrganizationScope cache for this user. That scope's
+    // accessible-org set is derived from this user's ACL/role grants, so any
+    // permission change that invalidates the RBAC cache must invalidate the
+    // resolved scope too. This is the missing `org-scope:user:*` caller required
+    // before the cross-request scope TTL can be safely enabled (issue #2259).
+    await this.deleteCacheByTags([this.getUserTag(userId), buildOrgScopeUserCacheTag(userId)])
   }
 
   /**
@@ -142,7 +148,10 @@ export class RbacService {
    */
   async invalidateTenantCache(tenantId: string): Promise<void> {
     this.globalSuperAdminCache.clear()
-    await this.deleteCacheByTags([this.getTenantTag(tenantId)], [tenantId])
+    // Role ACL changes invalidate every user in the tenant; the resolved
+    // OrganizationScope for those users derives from the same grants, so drop
+    // the tenant-tagged scope entries alongside the RBAC ones (issue #2259).
+    await this.deleteCacheByTags([this.getTenantTag(tenantId), buildOrgScopeTenantCacheTag(tenantId)], [tenantId])
   }
 
   /**

--- a/packages/core/src/modules/directory/subscribers/invalidateOrgScopeCache.ts
+++ b/packages/core/src/modules/directory/subscribers/invalidateOrgScopeCache.ts
@@ -7,6 +7,8 @@
 // drop every cache entry tagged for that tenant; the TTL is the backstop
 // for races where the event fires after a request reads the cache.
 
+import { buildOrgScopeTenantCacheTag } from '@open-mercato/core/modules/directory/utils/organizationScope'
+
 type CacheService = {
   deleteByTags(tags: string[]): Promise<number>
 }
@@ -32,7 +34,7 @@ export default async function handle(
   }
   if (!cache) return
   try {
-    await cache.deleteByTags([`org-scope:tenant:${tenantId}`])
+    await cache.deleteByTags([buildOrgScopeTenantCacheTag(tenantId)])
   } catch {
     // best-effort; TTL is the backstop.
   }

--- a/packages/core/src/modules/directory/utils/__tests__/organizationScopeCache.test.ts
+++ b/packages/core/src/modules/directory/utils/__tests__/organizationScopeCache.test.ts
@@ -96,6 +96,38 @@ describe('resolveOrganizationScopeForRequest caching (Phase 4)', () => {
     expect((rbac.loadAcl as jest.Mock).mock.calls.length).toBe(1)
   })
 
+  it('memoizes resolution per request, deduping the double resolution (issue #2259)', async () => {
+    // TTL off: the cross-request cache is disabled, so any dedupe must come from
+    // the per-request memo keyed on the shared Request instance.
+    process.env.OM_ORG_SCOPE_CACHE_TTL_MS = '0'
+    const em = createMockEm([{ id: 'org-home', descendantIds: [] }])
+    const rbac = createMockRbac()
+    const cache = createMemoryCache()
+    const container = createContainer(em, rbac, cache)
+    const request = {} as unknown as Request
+
+    const first = await resolveOrganizationScopeForRequest({ container, auth: auth(), request })
+    const second = await resolveOrganizationScopeForRequest({ container, auth: auth(), request })
+
+    expect(first).toBe(second)
+    expect(cache.set).not.toHaveBeenCalled()
+    expect((rbac.loadAcl as jest.Mock).mock.calls.length).toBe(1)
+    expect((em.find as jest.Mock).mock.calls.length).toBe(1)
+  })
+
+  it('does not share the per-request memo across distinct requests (issue #2259)', async () => {
+    process.env.OM_ORG_SCOPE_CACHE_TTL_MS = '0'
+    const em = createMockEm([{ id: 'org-home', descendantIds: [] }])
+    const rbac = createMockRbac()
+    const cache = createMemoryCache()
+    const container = createContainer(em, rbac, cache)
+
+    await resolveOrganizationScopeForRequest({ container, auth: auth(), request: {} as unknown as Request })
+    await resolveOrganizationScopeForRequest({ container, auth: auth(), request: {} as unknown as Request })
+
+    expect((rbac.loadAcl as jest.Mock).mock.calls.length).toBe(2)
+  })
+
   it('does not cache when OM_ORG_SCOPE_CACHE_TTL_MS=0', async () => {
     process.env.OM_ORG_SCOPE_CACHE_TTL_MS = '0'
     const em = createMockEm([{ id: 'org-home', descendantIds: [] }])

--- a/packages/core/src/modules/directory/utils/organizationScope.ts
+++ b/packages/core/src/modules/directory/utils/organizationScope.ts
@@ -21,9 +21,11 @@ export type OrganizationScope = {
 // OrganizationScope is a pure function of (userId, tenantId, selectedOrgId,
 // requestedTenant) between membership changes; caching it bypasses 1
 // SELECT on `organizations` per CRUD request. TTL is short (60s default)
-// to keep staleness bounded for membership/visibility changes. Tag-based
-// invalidation kicks the cache when user_organizations or organizations
-// mutate (wired via invalidateOrganizationScopeCacheFor).
+// to keep staleness bounded as a backstop. Tag-based invalidation also fires
+// eagerly: per-user entries are dropped by RbacService.invalidateUserCache
+// (every ACL/role grant change goes through it — see buildOrgScopeUserCacheTag)
+// and per-tenant entries by the directory.organization.* subscriber plus
+// RbacService.invalidateTenantCache (role-ACL changes).
 const ORG_SCOPE_CACHE_KEY_PREFIX = 'org-scope'
 // Phase 4 default-off until the same readiness probe (`GET /api/customers/people`)
 // stays green with the cache layer engaged. Set `OM_ORG_SCOPE_CACHE_TTL_MS=60000`
@@ -49,10 +51,23 @@ function buildOrgScopeCacheKey(parts: {
   return `${ORG_SCOPE_CACHE_KEY_PREFIX}:${parts.userId}:${parts.effectiveTenantId}:${selected}:${requested}`
 }
 
+// Tag builders are exported so the modules that own the "this user's scope
+// changed" / "this tenant's org tree changed" signals (auth RBAC invalidation,
+// the directory.organization.* subscriber) can drop the matching cross-request
+// cache entries without re-deriving the tag format. Keeping the format in one
+// place is what lets the TTL be enabled safely (issue #2259).
+export function buildOrgScopeUserCacheTag(userId: string): string {
+  return `${ORG_SCOPE_CACHE_KEY_PREFIX}:user:${userId}`
+}
+
+export function buildOrgScopeTenantCacheTag(tenantId: string): string {
+  return `${ORG_SCOPE_CACHE_KEY_PREFIX}:tenant:${tenantId}`
+}
+
 function buildOrgScopeCacheTags(parts: { userId: string; effectiveTenantId: string }): string[] {
   return [
-    `${ORG_SCOPE_CACHE_KEY_PREFIX}:user:${parts.userId}`,
-    `${ORG_SCOPE_CACHE_KEY_PREFIX}:tenant:${parts.effectiveTenantId}`,
+    buildOrgScopeUserCacheTag(parts.userId),
+    buildOrgScopeTenantCacheTag(parts.effectiveTenantId),
   ]
 }
 
@@ -82,7 +97,7 @@ export async function invalidateOrganizationScopeCacheForUser(
   const cache = resolveCacheFromContainer(container)
   if (!cache?.deleteByTags) return
   try {
-    await cache.deleteByTags([`${ORG_SCOPE_CACHE_KEY_PREFIX}:user:${userId}`])
+    await cache.deleteByTags([buildOrgScopeUserCacheTag(userId)])
   } catch (err) {
     console.warn('[org-scope:cache] invalidate user failed', err)
   }
@@ -95,10 +110,34 @@ export async function invalidateOrganizationScopeCacheForTenant(
   const cache = resolveCacheFromContainer(container)
   if (!cache?.deleteByTags) return
   try {
-    await cache.deleteByTags([`${ORG_SCOPE_CACHE_KEY_PREFIX}:tenant:${tenantId}`])
+    await cache.deleteByTags([buildOrgScopeTenantCacheTag(tenantId)])
   } catch (err) {
     console.warn('[org-scope:cache] invalidate tenant failed', err)
   }
+}
+
+// Issue #2259 — per-request memoization. resolveOrganizationScopeForRequest
+// runs at least twice per CRUD request: once for the route-level feature check
+// (resolveFeatureCheckContext) and once inside the shared factory's withCtx.
+// Those two call sites use different request-scoped DI containers but are handed
+// the SAME Request instance, so memoizing the resolved scope on a WeakMap keyed
+// by that request collapses the duplicate work — and the duplicate
+// `organizations` SELECT — into a single resolution. The inner map is keyed by
+// the same identity tuple as the cross-request cache key, so distinct explicit
+// selectedId/tenant overrides on one request stay independent. There is no
+// staleness risk: the memo lives only for the lifetime of one request and is
+// dropped with the request object by the GC.
+const orgScopeRequestMemo = new WeakMap<object, Map<string, Promise<OrganizationScope>>>()
+
+function getRequestScopeMemo(request: unknown): Map<string, Promise<OrganizationScope>> | null {
+  if (!request || (typeof request !== 'object' && typeof request !== 'function')) return null
+  const key = request as object
+  let memo = orgScopeRequestMemo.get(key)
+  if (!memo) {
+    memo = new Map<string, Promise<OrganizationScope>>()
+    orgScopeRequestMemo.set(key, memo)
+  }
+  return memo
 }
 
 function normalizeOrganizationId(value: unknown): string | null {
@@ -402,35 +441,51 @@ export async function resolveOrganizationScopeForRequest({
       })
     : null
 
-  if (cache && cacheKey && typeof cache.get === 'function') {
-    try {
-      const cached = await cache.get(cacheKey)
-      if (isValidCachedScope(cached)) return cached
-    } catch (err) {
-      console.warn('[org-scope:cache] read failed', err)
-    }
+  const requestMemo = getRequestScopeMemo(request)
+  if (requestMemo && cacheKey) {
+    const memoized = requestMemo.get(cacheKey)
+    if (memoized) return memoized
   }
 
-  const baseScope = await resolveOrganizationScope({
-    em,
-    rbac,
-    auth: scopedAuth,
-    selectedId: rawSelected,
-    tenantId: effectiveTenantId,
-  })
-
-  if (cache && cacheKey && userId && typeof cache.set === 'function') {
-    try {
-      await cache.set(cacheKey, baseScope, {
-        ttl: ttlMs,
-        tags: buildOrgScopeCacheTags({ userId, effectiveTenantId }),
-      })
-    } catch (err) {
-      console.warn('[org-scope:cache] write failed', err)
+  const resolveScope = async (): Promise<OrganizationScope> => {
+    if (cache && cacheKey && typeof cache.get === 'function') {
+      try {
+        const cached = await cache.get(cacheKey)
+        if (isValidCachedScope(cached)) return cached
+      } catch (err) {
+        console.warn('[org-scope:cache] read failed', err)
+      }
     }
+
+    const baseScope = await resolveOrganizationScope({
+      em,
+      rbac,
+      auth: scopedAuth,
+      selectedId: rawSelected,
+      tenantId: effectiveTenantId,
+    })
+
+    if (cache && cacheKey && userId && typeof cache.set === 'function') {
+      try {
+        await cache.set(cacheKey, baseScope, {
+          ttl: ttlMs,
+          tags: buildOrgScopeCacheTags({ userId, effectiveTenantId }),
+        })
+      } catch (err) {
+        console.warn('[org-scope:cache] write failed', err)
+      }
+    }
+
+    return baseScope
   }
 
-  return baseScope
+  if (requestMemo && cacheKey) {
+    const pending = resolveScope()
+    requestMemo.set(cacheKey, pending)
+    return pending
+  }
+
+  return resolveScope()
 }
 
 export type FeatureCheckContext = {


### PR DESCRIPTION
Fixes #2259

## Problem
`resolveOrganizationScopeForRequest` runs on virtually every authenticated list/detail request and is resolved **more than once per request** — the route-level feature check (`resolveFeatureCheckContext`) and the shared CRUD factory's `withCtx` each call it, each issuing an `organizations` SELECT. Separately, the `org-scope:user:*` cross-request cache tag had **no production invalidation caller** (only tests referenced the helpers), so enabling the cross-request TTL would serve stale scope after a membership change — a security-relevant correctness gap.

(The single-round-trip `collectWithDescendants` dedup from the linked #2228 was already in place via `loadOrgDescendantMap`; this PR covers the two remaining items from the #2259 fix plan.)

## Root Cause
- The two resolution call sites use different request-scoped DI containers, so a container-keyed cache could not dedupe them — but both are handed the **same `Request` instance** (`apps/mercato/src/app/api/[...slug]/route.ts` passes the same `req` to the feature check and to the dispatched factory handler).
- `invalidateOrganizationScopeCacheForUser/ForTenant` existed but were never called outside tests; the `org-scope` scope set is derived from `rbac.loadAcl(...).organizations`, so it goes stale on the exact mutations that already invalidate the RBAC cache.

## What Changed
- **Per-request memoization** (`organizationScope.ts`): memoize the resolved scope on a `WeakMap<Request, Map<cacheKey, Promise>>`. Keyed by the same identity tuple as the cross-request cache key, so distinct explicit `selectedId`/`tenant` overrides on one request stay independent. Lives only for the request's lifetime (GC-dropped with the request) — no staleness.
- **User/tenant invalidation wiring** (`rbacService.ts`): `invalidateUserCache` / `invalidateTenantCache` now also drop `org-scope:user:*` / `org-scope:tenant:*`. This is the canonical "permissions changed" hook every ACL/role mutation routes through — including the **eventless** `PUT /api/auth/users/acl` path — so it closes the membership-invalidation prerequisite. **TTL stays OFF** (`ORG_SCOPE_DEFAULT_TTL_MS = 0` unchanged); this only makes a future opt-in safe.
- Exported `buildOrgScopeUserCacheTag` / `buildOrgScopeTenantCacheTag` (additive) so the tag format lives in one place; DRY'd the existing `directory.organization.*` subscriber and the invalidator helpers.

## Tests
- `organizationScopeCache.test.ts`: per-request memo dedupes the double resolution (one `loadAcl` / one `em.find` for two calls with the same request, TTL off); distinct requests are not shared.
- `rbacService.test.ts`: `invalidateUserCache` drops `org-scope:user:*` entries; `invalidateTenantCache` drops `org-scope:tenant:*` entries.
- `yarn generate`, `yarn build:packages`, `yarn typecheck`, and the touched jest suites all pass.

## Backward Compatibility
- Additive only: two new exported tag-builder functions; no removed/renamed exports, no signature changes, no event/route/DI/ACL/schema changes. Default behavior unchanged (TTL still 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)