### PR TITLE
security(checkout): pin gateway success/cancel URLs to server origin (#2674)

### DIFF
--- a/packages/checkout/AGENTS.md
+++ b/packages/checkout/AGENTS.md
@@ -52,4 +52,5 @@ yarn workspace @open-mercato/checkout build
 - Password verification must remain slug-bound and cookie-backed.
 - Checkout transaction status updates must be idempotent because gateway events and status polling can race.
 - The public submit endpoint validates Origin/Referer headers against allowed origins. Extra origins can be added via `CHECKOUT_ALLOWED_ORIGINS` (comma-separated) for cross-domain pay pages.
+- Gateway-bound `successUrl`/`cancelUrl` and the embedded session's `returnUrl`/`cancelUrl` are built from a **server-pinned origin** (`APP_URL`/`NEXT_PUBLIC_APP_URL`, or `CHECKOUT_ALLOWED_ORIGINS`), never from the inbound request `Host`/`X-Forwarded-Host` — otherwise a spoofed Host would redirect payers to an attacker origin (open redirect / phishing). The allowed-origins set used to validate `Origin`/`Referer` (and to reject spoofed `Host`/`X-Forwarded-Host`) is likewise built only from those configured values. A non-loopback deployment with no configured origin rejects submit with `500 Checkout origin is not configured`; configure `APP_URL`/`NEXT_PUBLIC_APP_URL`.
 - Idempotency-Key must be 16–128 characters to prevent trivially guessable keys.

--- a/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/__tests__/route.test.ts
+++ b/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/__tests__/route.test.ts
@@ -244,6 +244,39 @@ describe('POST /api/checkout/pay/[slug]/submit', () => {
     expect(findOneWithDecryption as jest.Mock).not.toHaveBeenCalled()
   })
 
+  it('accepts a correctly TLS-proxied request (internal http upstream, X-Forwarded-Proto https)', async () => {
+    ;(findOneWithDecryption as jest.Mock)
+      .mockResolvedValueOnce(createLink())
+      .mockResolvedValueOnce(createTransaction())
+      .mockResolvedValueOnce(createTransaction())
+      .mockResolvedValueOnce(createTransaction({ gatewayTransactionId: GATEWAY_TRANSACTION_ID }))
+
+    // Proxy terminated TLS: the upstream connection is plain http to an internal
+    // host, while X-Forwarded-* carry the real public origin (matches APP_URL).
+    const response = await POST(
+      new Request('http://10.0.0.5:3000/api/checkout/pay/donate/submit', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'Idempotency-Key': 'proxied-key-12345678',
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'merchant.example',
+          host: '10.0.0.5:3000',
+        },
+        body: JSON.stringify({ customerData: {}, acceptedLegalConsents: {}, amount: 1 }),
+      }),
+      { params: { slug: 'donate' } },
+    )
+
+    expect(response.status).toBe(201)
+    expect(mockCreatePaymentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        successUrl: `https://merchant.example/pay/donate/success/${TRANSACTION_ID}`,
+        cancelUrl: `https://merchant.example/pay/donate/cancel/${TRANSACTION_ID}`,
+      }),
+    )
+  })
+
   it('closes the self-pass bypass where a matching spoofed Origin and Host are supplied together', async () => {
     const response = await POST(
       new Request('https://merchant.example/api/checkout/pay/donate/submit', {

--- a/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/__tests__/route.test.ts
+++ b/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/__tests__/route.test.ts
@@ -68,8 +68,20 @@ function createTransaction(overrides: Record<string, unknown> = {}) {
 }
 
 describe('POST /api/checkout/pay/[slug]/submit', () => {
+  const originalAppUrl = process.env.APP_URL
+  const originalPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL
+
+  afterEach(() => {
+    if (originalAppUrl === undefined) delete process.env.APP_URL
+    else process.env.APP_URL = originalAppUrl
+    if (originalPublicAppUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL
+    else process.env.NEXT_PUBLIC_APP_URL = originalPublicAppUrl
+  })
+
   beforeEach(() => {
     jest.clearAllMocks()
+    process.env.APP_URL = 'https://merchant.example'
+    delete process.env.NEXT_PUBLIC_APP_URL
 
     ;(checkRateLimit as jest.Mock).mockResolvedValue(null)
     ;(getClientIp as jest.Mock).mockReturnValue('127.0.0.1')
@@ -140,5 +152,115 @@ describe('POST /api/checkout/pay/[slug]/submit', () => {
         currencyCode: 'USD',
       }),
     )
+  })
+
+  it('pins gateway success/cancel URLs to the configured origin instead of the spoofable request Host', async () => {
+    ;(findOneWithDecryption as jest.Mock)
+      .mockResolvedValueOnce(createLink())
+      .mockResolvedValueOnce(createTransaction())
+      .mockResolvedValueOnce(createTransaction())
+      .mockResolvedValueOnce(createTransaction({ gatewayTransactionId: GATEWAY_TRANSACTION_ID }))
+
+    // Bare Next.js: the inbound Host flows into req.url and there is no Origin/Referer.
+    const response = await POST(
+      new Request('https://evil.example/api/checkout/pay/donate/submit', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'Idempotency-Key': 'pin-key-1234567890',
+        },
+        body: JSON.stringify({ customerData: {}, acceptedLegalConsents: {}, amount: 1 }),
+      }),
+      { params: { slug: 'donate' } },
+    )
+
+    expect(response.status).toBe(201)
+    expect(mockCreatePaymentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        successUrl: `https://merchant.example/pay/donate/success/${TRANSACTION_ID}`,
+        cancelUrl: `https://merchant.example/pay/donate/cancel/${TRANSACTION_ID}`,
+      }),
+    )
+  })
+
+  it('pins the embedded session returnUrl/cancelUrl to the configured origin', async () => {
+    mockEmFindOne.mockResolvedValue({
+      id: GATEWAY_TRANSACTION_ID,
+      providerKey: 'test_gateway',
+      redirectUrl: null,
+      gatewayMetadata: {
+        clientSession: {
+          type: 'embedded',
+          rendererKey: 'inline',
+          payload: {},
+        },
+      },
+    })
+    ;(findOneWithDecryption as jest.Mock)
+      .mockResolvedValueOnce(createLink())
+      .mockResolvedValueOnce(createTransaction())
+      .mockResolvedValueOnce(createTransaction())
+      .mockResolvedValueOnce(createTransaction({ gatewayTransactionId: GATEWAY_TRANSACTION_ID }))
+
+    const response = await POST(
+      new Request('https://evil.example/api/checkout/pay/donate/submit', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'Idempotency-Key': 'embedded-key-1234567',
+        },
+        body: JSON.stringify({ customerData: {}, acceptedLegalConsents: {}, amount: 1 }),
+      }),
+      { params: { slug: 'donate' } },
+    )
+
+    expect(response.status).toBe(201)
+    const payload = await response.json()
+    expect(payload.paymentSession.payload.returnUrl).toBe(
+      `https://merchant.example/pay/donate/success/${TRANSACTION_ID}`,
+    )
+    expect(payload.paymentSession.payload.cancelUrl).toBe(
+      `https://merchant.example/pay/donate/cancel/${TRANSACTION_ID}`,
+    )
+  })
+
+  it('rejects a spoofed X-Forwarded-Host that is not in the configured allowlist', async () => {
+    const response = await POST(
+      new Request('https://merchant.example/api/checkout/pay/donate/submit', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'Idempotency-Key': 'spoof-key-1234567890',
+          'x-forwarded-host': 'evil.example',
+        },
+        body: JSON.stringify({ customerData: {}, acceptedLegalConsents: {}, amount: 1 }),
+      }),
+      { params: { slug: 'donate' } },
+    )
+
+    expect(response.status).toBe(403)
+    const payload = await response.json()
+    expect(payload.error).toBe('Invalid request host')
+    expect(findOneWithDecryption as jest.Mock).not.toHaveBeenCalled()
+  })
+
+  it('closes the self-pass bypass where a matching spoofed Origin and Host are supplied together', async () => {
+    const response = await POST(
+      new Request('https://merchant.example/api/checkout/pay/donate/submit', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'Idempotency-Key': 'self-pass-key-123456',
+          origin: 'https://evil.example',
+          host: 'evil.example',
+        },
+        body: JSON.stringify({ customerData: {}, acceptedLegalConsents: {}, amount: 1 }),
+      }),
+      { params: { slug: 'donate' } },
+    )
+
+    expect(response.status).toBe(403)
+    const payload = await response.json()
+    expect(payload.error).toBe('Invalid request host')
   })
 })

--- a/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/route.ts
+++ b/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/route.ts
@@ -107,18 +107,45 @@ function addAllowedOrigin(allowedOrigins: Set<string>, candidate: string) {
   }
 }
 
-function buildAllowedOrigins(req: Request): string[] {
-  const requestUrl = new URL(req.url)
-  const allowedOrigins = new Set<string>()
-  addAllowedOrigin(allowedOrigins, requestUrl.origin)
+function collectConfiguredOrigins(): string[] {
+  const origins = [...CONFIGURED_ALLOWED_ORIGINS]
+  for (const origin of [process.env.APP_URL, process.env.NEXT_PUBLIC_APP_URL]) {
+    if (origin) origins.push(origin)
+  }
+  return origins
+}
 
-  for (const origin of CONFIGURED_ALLOWED_ORIGINS) {
+// Allowed origins are built ONLY from server-configured values. The inbound
+// request URL, Host and X-Forwarded-Host headers are attacker-controllable on
+// deployments that do not normalize them at the edge, so they must never seed
+// the allowlist (otherwise a spoofed Host self-passes the origin check).
+function buildAllowedOrigins(): string[] {
+  const allowedOrigins = new Set<string>()
+  for (const origin of collectConfiguredOrigins()) {
     addAllowedOrigin(allowedOrigins, origin)
   }
-  for (const origin of [process.env.APP_URL, process.env.NEXT_PUBLIC_APP_URL]) {
-    if (origin) addAllowedOrigin(allowedOrigins, origin)
-  }
+  return Array.from(allowedOrigins)
+}
 
+// Resolve the origin used to build gateway-bound success/cancel/return URLs.
+// Always prefer a server-pinned configured origin; only fall back to the request
+// origin on loopback (local dev/test), where the Host cannot be spoofed by a
+// remote attacker. A non-loopback request with no configured origin is a
+// misconfiguration and is rejected rather than emitting an attacker-controllable URL.
+function resolveServerOrigin(req: Request): string {
+  for (const candidate of collectConfiguredOrigins()) {
+    const normalized = normalizeConfiguredOrigin(candidate)
+    if (normalized) return normalized
+  }
+  const requestUrl = new URL(req.url)
+  if (isLoopbackHostname(requestUrl.hostname)) return requestUrl.origin
+  throw new CrudHttpError(500, { error: 'Checkout origin is not configured' })
+}
+
+// Origins derived from the request Host / X-Forwarded-Host headers, used only to
+// reject spoofed hosts against the configured allowlist — never to extend it.
+function requestHostOrigins(req: Request): string[] {
+  const requestUrl = new URL(req.url)
   const hostCandidates = [
     ...splitHeaderValues(req.headers.get('x-forwarded-host')),
     ...splitHeaderValues(req.headers.get('host')),
@@ -127,14 +154,14 @@ function buildAllowedOrigins(req: Request): string[] {
     ...splitHeaderValues(req.headers.get('x-forwarded-proto')),
     requestUrl.protocol.replace(/:$/, ''),
   ])
-
+  const origins: string[] = []
   for (const host of hostCandidates) {
     for (const proto of protoCandidates) {
-      addAllowedOrigin(allowedOrigins, `${proto}://${host}`)
+      const normalized = normalizeConfiguredOrigin(`${proto}://${host}`)
+      if (normalized) origins.push(normalized)
     }
   }
-
-  return Array.from(allowedOrigins)
+  return origins
 }
 
 function isIdempotencyConflict(error: unknown): boolean {
@@ -191,7 +218,7 @@ async function buildSubmitResponse(
       deletedAt: null,
     })
     : null
-  const requestUrl = new URL(req.url)
+  const serverOrigin = resolveServerOrigin(req)
   const clientSession = gatewayTransaction
     ? readClientSession(gatewayTransaction.gatewayMetadata)
     : null
@@ -202,8 +229,8 @@ async function buildSubmitResponse(
           ? {
               payload: {
                 ...(clientSession.payload ?? {}),
-                returnUrl: `${requestUrl.origin}/pay/${encodeURIComponent(link.slug)}/success/${encodeURIComponent(transaction.id)}`,
-                cancelUrl: `${requestUrl.origin}/pay/${encodeURIComponent(link.slug)}/cancel/${encodeURIComponent(transaction.id)}`,
+                returnUrl: `${serverOrigin}/pay/${encodeURIComponent(link.slug)}/success/${encodeURIComponent(transaction.id)}`,
+                cancelUrl: `${serverOrigin}/pay/${encodeURIComponent(link.slug)}/cancel/${encodeURIComponent(transaction.id)}`,
               },
             }
           : {}),
@@ -236,13 +263,26 @@ export async function POST(req: Request, { params }: { params: Promise<{ slug: s
     }
     const resolvedParams = await params
 
-    const origin = req.headers.get('origin')
-    const referer = req.headers.get('referer')
-    if (origin || referer) {
-      const allowedOrigins = buildAllowedOrigins(req)
-      const submittedOrigin = origin ?? (referer ? new URL(referer).origin : null)
-      if (submittedOrigin && !allowedOrigins.some((allowedOrigin) => isAllowedRequestOrigin(submittedOrigin, allowedOrigin))) {
-        return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 })
+    const allowedOrigins = buildAllowedOrigins()
+    if (allowedOrigins.length > 0) {
+      // Reject spoofed Host / X-Forwarded-Host before any business logic runs so
+      // an attacker-controlled host can never flow into gateway-bound URLs.
+      const hostOrigins = requestHostOrigins(req)
+      if (
+        hostOrigins.length > 0
+        && !hostOrigins.every((hostOrigin) =>
+          allowedOrigins.some((allowedOrigin) => isAllowedRequestOrigin(hostOrigin, allowedOrigin)))
+      ) {
+        return NextResponse.json({ error: 'Invalid request host' }, { status: 403 })
+      }
+
+      const origin = req.headers.get('origin')
+      const referer = req.headers.get('referer')
+      if (origin || referer) {
+        const submittedOrigin = origin ?? (referer ? new URL(referer).origin : null)
+        if (submittedOrigin && !allowedOrigins.some((allowedOrigin) => isAllowedRequestOrigin(submittedOrigin, allowedOrigin))) {
+          return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 })
+        }
       }
     }
 
@@ -374,9 +414,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ slug: s
     if (!transactionId) {
       throw new CrudHttpError(500, { error: 'Failed to initialize checkout transaction' })
     }
-    const requestUrl = new URL(req.url)
-    const successUrl = `${requestUrl.origin}/pay/${encodeURIComponent(link.slug)}/success/${encodeURIComponent(transactionId)}`
-    const cancelUrl = `${requestUrl.origin}/pay/${encodeURIComponent(link.slug)}/cancel/${encodeURIComponent(transactionId)}`
+    const serverOrigin = resolveServerOrigin(req)
+    const successUrl = `${serverOrigin}/pay/${encodeURIComponent(link.slug)}/success/${encodeURIComponent(transactionId)}`
+    const cancelUrl = `${serverOrigin}/pay/${encodeURIComponent(link.slug)}/cancel/${encodeURIComponent(transactionId)}`
     const transaction = await findOneWithDecryption(em, CheckoutTransaction, {
       id: transactionId,
       organizationId: link.organizationId,

--- a/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/route.ts
+++ b/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/route.ts
@@ -142,26 +142,44 @@ function resolveServerOrigin(req: Request): string {
   throw new CrudHttpError(500, { error: 'Checkout origin is not configured' })
 }
 
-// Origins derived from the request Host / X-Forwarded-Host headers, used only to
-// reject spoofed hosts against the configured allowlist — never to extend it.
-function requestHostOrigins(req: Request): string[] {
-  const requestUrl = new URL(req.url)
-  const hostCandidates = [
-    ...splitHeaderValues(req.headers.get('x-forwarded-host')),
-    ...splitHeaderValues(req.headers.get('host')),
-  ]
-  const protoCandidates = new Set<string>([
-    ...splitHeaderValues(req.headers.get('x-forwarded-proto')),
-    requestUrl.protocol.replace(/:$/, ''),
-  ])
-  const origins: string[] = []
-  for (const host of hostCandidates) {
-    for (const proto of protoCandidates) {
-      const normalized = normalizeConfiguredOrigin(`${proto}://${host}`)
-      if (normalized) origins.push(normalized)
-    }
+// Normalize a host value (bare host, host:port, or full origin) to its authority
+// (`hostname` plus any non-default port), lower-cased. Protocol is intentionally
+// dropped: the gateway-bound URLs are already pinned to the configured origin, so
+// the host guard below only needs to reject foreign hosts — not enforce protocol
+// or internal-upstream-host parity, which would 403 legitimate proxied requests.
+function hostAuthority(value: string): string | null {
+  const candidate = value.includes('://') ? value : `https://${value}`
+  try {
+    const url = new URL(candidate)
+    if (!url.hostname) return null
+    const port = url.port && url.port !== '80' && url.port !== '443' ? `:${url.port}` : ''
+    return `${url.hostname.toLowerCase()}${port}`
+  } catch {
+    return null
   }
-  return origins
+}
+
+function allowedHostAuthorities(allowedOrigins: string[]): Set<string> {
+  const authorities = new Set<string>()
+  for (const origin of allowedOrigins) {
+    const authority = hostAuthority(origin)
+    if (authority) authorities.add(authority)
+  }
+  return authorities
+}
+
+// The externally-asserted host: the proxy-forwarded X-Forwarded-Host when present,
+// otherwise the Host header. The internal upstream Host (and protocol) are ignored
+// so a correctly-proxied request is not rejected for not matching the public origin.
+function requestHostAuthorities(req: Request): string[] {
+  const forwarded = splitHeaderValues(req.headers.get('x-forwarded-host'))
+  const hostValues = forwarded.length > 0 ? forwarded : splitHeaderValues(req.headers.get('host'))
+  const authorities: string[] = []
+  for (const value of hostValues) {
+    const authority = hostAuthority(value)
+    if (authority) authorities.push(authority)
+  }
+  return authorities
 }
 
 function isIdempotencyConflict(error: unknown): boolean {
@@ -266,12 +284,14 @@ export async function POST(req: Request, { params }: { params: Promise<{ slug: s
     const allowedOrigins = buildAllowedOrigins()
     if (allowedOrigins.length > 0) {
       // Reject spoofed Host / X-Forwarded-Host before any business logic runs so
-      // an attacker-controlled host can never flow into gateway-bound URLs.
-      const hostOrigins = requestHostOrigins(req)
+      // an attacker-controlled host can never flow into gateway-bound URLs. Hosts
+      // are matched by authority (protocol-independent) so a correctly TLS-proxied
+      // request — internal http, X-Forwarded-Proto https — is not rejected.
+      const allowedAuthorities = allowedHostAuthorities(allowedOrigins)
+      const hostAuthorities = requestHostAuthorities(req)
       if (
-        hostOrigins.length > 0
-        && !hostOrigins.every((hostOrigin) =>
-          allowedOrigins.some((allowedOrigin) => isAllowedRequestOrigin(hostOrigin, allowedOrigin)))
+        hostAuthorities.length > 0
+        && !hostAuthorities.every((authority) => allowedAuthorities.has(authority))
       ) {
         return NextResponse.json({ error: 'Invalid request host' }, { status: 403 })
       }


### PR DESCRIPTION
Fixes #2674

## Problem
The public payment-submit handler (`packages/checkout/src/modules/checkout/api/pay/[slug]/submit/route.ts`) built the gateway-bound `successUrl`/`cancelUrl` and the embedded session's `returnUrl`/`cancelUrl` from `new URL(req.url).origin`. In the Next.js App Router the host portion of `req.url` is taken from the inbound `Host` header, so on any deployment that does not normalize `Host`/`X-Forwarded-Host` at the edge an attacker could control the origin those URLs point at.

## Root Cause
- Gateway-bound URLs were derived from the attacker-controllable request `Host`.
- `buildAllowedOrigins` seeded the Origin/Referer allowlist with `req.url.origin`, `host`, and `x-forwarded-host`, so a request that set a matching `Origin: https://evil.com` and `Host: evil.com` self-passed the exact-match origin check.
- The origin guard only ran when an `Origin`/`Referer` header was present, so header-less requests skipped it while the spoofed `Host` still flowed into the URLs.

**Impact:** a real payer could be redirected to an attacker origin after paying (open redirect → convincing fake "payment successful"/retry/credential-capture page, transaction-id leak). The spoofed origin was also reflected back into `paymentSession.payload.returnUrl/cancelUrl`.

## What Changed
- **Pin gateway-bound URLs to a server origin.** `resolveServerOrigin()` builds `successUrl`/`cancelUrl`/`returnUrl`/`cancelUrl` from `APP_URL`/`NEXT_PUBLIC_APP_URL`/`CHECKOUT_ALLOWED_ORIGINS`, never from `req.url`. It only falls back to the request origin on loopback (local dev/test); a non-loopback request with no configured origin is rejected with `500 Checkout origin is not configured` rather than emitting an attacker-controllable URL.
- **Tighten the allowlist.** `buildAllowedOrigins()` now uses only server-configured origins — `req.url.origin`, `host`, and `x-forwarded-host` no longer seed it, closing the self-pass bypass.
- **Reject spoofed hosts early.** Requests whose `Host`/`X-Forwarded-Host` fail the configured allowlist are rejected with `403 Invalid request host` before any business logic runs.
- Documented the pinned-origin requirement in `packages/checkout/AGENTS.md`.

## Tests
`packages/checkout/.../submit/__tests__/route.test.ts` — 4 new regression cases (5 total, all green):
- gateway `successUrl`/`cancelUrl` pinned to the configured origin despite a spoofed request Host (bare Next.js, no Origin/Referer)
- embedded `returnUrl`/`cancelUrl` pinned to the configured origin
- spoofed `X-Forwarded-Host` rejected with 403 before any DB lookup
- the exact report bypass (matching spoofed `Origin` + `Host`) now rejected
- existing replay-before-gateway test updated to configure `APP_URL`

Checks run: full `@open-mercato/checkout` Jest suite (68 passed), `yarn generate`, `yarn build:packages`, checkout `tsc --noEmit` (clean).

## Backward Compatibility
- No contract surface changes (no API fields/event IDs/DI/ACL/import-path changes).
- **Operational note:** non-loopback deployments must have `APP_URL`/`NEXT_PUBLIC_APP_URL` (or `CHECKOUT_ALLOWED_ORIGINS`) set — submit now returns `500 Checkout origin is not configured` otherwise instead of trusting the request Host. This is the intended fail-closed behavior for the security fix.