### PR TITLE
security(api): enforce tenant selection against all tenantId candidates (#2665)

### DIFF
--- a/apps/mercato/src/__tests__/extract-tenant-candidate.test.ts
+++ b/apps/mercato/src/__tests__/extract-tenant-candidate.test.ts
@@ -1,4 +1,6 @@
 import { NextRequest } from 'next/server'
+import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
+import { forbidden } from '@open-mercato/shared/lib/crud/errors'
 
 jest.mock('@/bootstrap', () => ({
   bootstrap: jest.fn(),
@@ -13,13 +15,33 @@ jest.mock('@/.mercato/generated/backend-routes.generated', () => ({
   backendRoutes: [],
 }))
 
-import { extractTenantCandidate } from '@/app/api/[...slug]/route'
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({ t: (_key: string, fallback?: string) => fallback ?? _key })),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({ resolve: jest.fn(() => ({})) })),
+}))
+
+jest.mock('@open-mercato/core/modules/auth/lib/tenantAccess', () => {
+  const actual = jest.requireActual('@open-mercato/core/modules/auth/lib/tenantAccess')
+  return { ...actual, enforceTenantSelection: jest.fn() }
+})
+
+import { enforceTenantSelection } from '@open-mercato/core/modules/auth/lib/tenantAccess'
+import { checkAuthorization, extractTenantCandidate, extractTenantCandidates } from '@/app/api/[...slug]/route'
+
+const enforceTenantSelectionMock = enforceTenantSelection as jest.MockedFunction<typeof enforceTenantSelection>
 
 function buildMultipartRequest(formData: FormData): NextRequest {
   return new NextRequest('http://localhost:3001/api/example/test', {
     method: 'POST',
     body: formData,
   })
+}
+
+function buildAuth(tenantId: string | null): AuthContext {
+  return { sub: 'user-1', tenantId, orgId: null }
 }
 
 describe('extractTenantCandidate', () => {
@@ -77,5 +99,119 @@ describe('extractTenantCandidate', () => {
     const candidate = await extractTenantCandidate(request)
 
     expect(candidate).toBe(queryTenant)
+  })
+})
+
+describe('extractTenantCandidates (HTTP parameter pollution, issue #2665)', () => {
+  it('returns every repeated ?tenantId= query param in order', async () => {
+    const targetTenant = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    const ownTenant = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+    const request = new NextRequest(
+      `http://localhost:3001/api/example/test?tenantId=${targetTenant}&tenantId=${ownTenant}`,
+      { method: 'GET' },
+    )
+
+    const candidates = await extractTenantCandidates(request)
+
+    expect(candidates).toEqual([targetTenant, ownTenant])
+  })
+
+  it('surfaces both query and body tenantId candidates from a JSON request', async () => {
+    const queryTenant = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+    const bodyTenant = 'dddddddd-dddd-dddd-dddd-dddddddddddd'
+    const request = new NextRequest(`http://localhost:3001/api/example/test?tenantId=${queryTenant}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ tenantId: bodyTenant }),
+    })
+
+    const candidates = await extractTenantCandidates(request)
+
+    expect(candidates).toEqual([queryTenant, bodyTenant])
+  })
+
+  it('returns an empty list when no tenantId is present', async () => {
+    const request = new NextRequest('http://localhost:3001/api/example/test', { method: 'GET' })
+
+    const candidates = await extractTenantCandidates(request)
+
+    expect(candidates).toEqual([])
+  })
+})
+
+describe('checkAuthorization tenant pollution enforcement (issue #2665)', () => {
+  beforeEach(() => {
+    enforceTenantSelectionMock.mockReset()
+    enforceTenantSelectionMock.mockImplementation(async (_ctx, requested) =>
+      typeof requested === 'string' ? requested : null,
+    )
+  })
+
+  it('rejects when the FIRST query tenantId targets a foreign tenant even though the LAST matches the actor', async () => {
+    const foreignTenant = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
+    const ownTenant = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+    enforceTenantSelectionMock.mockImplementation(async (_ctx, requested) => {
+      if (requested === foreignTenant) throw forbidden('Not authorized to target this tenant.')
+      return typeof requested === 'string' ? requested : null
+    })
+
+    const request = new NextRequest(
+      `http://localhost:3001/api/example/test?tenantId=${foreignTenant}&tenantId=${ownTenant}`,
+      { method: 'GET' },
+    )
+
+    const response = await checkAuthorization(null, buildAuth(ownTenant), request)
+
+    expect(response).not.toBeNull()
+    expect(response?.status).toBe(403)
+    expect(enforceTenantSelectionMock).toHaveBeenCalledWith(expect.anything(), foreignTenant)
+  })
+
+  it('rejects when a body tenantId disagrees with an authorized query tenantId', async () => {
+    const ownTenant = '00000000-0000-0000-0000-000000000001'
+    const foreignTenant = '00000000-0000-0000-0000-000000000002'
+    enforceTenantSelectionMock.mockImplementation(async (_ctx, requested) => {
+      if (requested === foreignTenant) throw forbidden('Not authorized to target this tenant.')
+      return typeof requested === 'string' ? requested : null
+    })
+
+    const request = new NextRequest(`http://localhost:3001/api/example/test?tenantId=${ownTenant}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ tenantId: foreignTenant }),
+    })
+
+    const response = await checkAuthorization(null, buildAuth(ownTenant), request)
+
+    expect(response).not.toBeNull()
+    expect(response?.status).toBe(403)
+    expect(enforceTenantSelectionMock).toHaveBeenCalledWith(expect.anything(), foreignTenant)
+  })
+
+  it('allows a request whose only tenantId matches the actor without invoking the guard', async () => {
+    const ownTenant = '00000000-0000-0000-0000-0000000000aa'
+    const request = new NextRequest(`http://localhost:3001/api/example/test?tenantId=${ownTenant}`, {
+      method: 'GET',
+    })
+
+    const response = await checkAuthorization(null, buildAuth(ownTenant), request)
+
+    expect(response).toBeNull()
+    expect(enforceTenantSelectionMock).not.toHaveBeenCalled()
+  })
+
+  it('enforces each distinct foreign candidate only once', async () => {
+    const ownTenant = '00000000-0000-0000-0000-0000000000bb'
+    const foreignTenant = '00000000-0000-0000-0000-0000000000cc'
+    const request = new NextRequest(
+      `http://localhost:3001/api/example/test?tenantId=${foreignTenant}&tenantId=${foreignTenant}&tenantId=${ownTenant}`,
+      { method: 'GET' },
+    )
+
+    const response = await checkAuthorization(null, buildAuth(ownTenant), request)
+
+    expect(response).toBeNull()
+    expect(enforceTenantSelectionMock).toHaveBeenCalledTimes(1)
+    expect(enforceTenantSelectionMock).toHaveBeenCalledWith(expect.anything(), foreignTenant)
   })
 })

--- a/apps/mercato/src/app/api/[...slug]/route.ts
+++ b/apps/mercato/src/app/api/[...slug]/route.ts
@@ -139,7 +139,7 @@ function normalizeLoadedMetadata(
   return { [method]: metadata }
 }
 
-async function checkAuthorization(
+export async function checkAuthorization(
   methodMetadata: MethodMetadata | null,
   auth: AuthContext,
   req: NextRequest
@@ -167,24 +167,31 @@ async function checkAuthorization(
   }
 
   if (auth && requiresAuthentication) {
-    const rawTenantCandidate = await extractTenantCandidate(req)
-    if (rawTenantCandidate !== undefined) {
+    // HTTP parameter pollution hardening (issue #2665): a request can carry `tenantId`
+    // more than once — repeated `?tenantId=` query params, or in both the query string
+    // and the body. The dispatcher and downstream handlers may disagree on which
+    // occurrence wins (here historically `getAll().last`, handlers use `get()` first),
+    // so the authorization gate must validate EVERY distinct candidate. If any one
+    // targets a tenant the actor may not select, the request is rejected — making this
+    // decision binding regardless of how a handler later parses the same request.
+    const rawTenantCandidates = await extractTenantCandidates(req)
+    const actorTenant = normalizeTenantId(auth.tenantId ?? null) ?? null
+    const enforcedCandidates = new Set<string | null>()
+    for (const rawTenantCandidate of rawTenantCandidates) {
       const tenantCandidate = sanitizeTenantCandidate(rawTenantCandidate)
-      if (tenantCandidate !== undefined) {
-        const normalizedCandidate = normalizeTenantId(tenantCandidate) ?? null
-        const actorTenant = normalizeTenantId(auth.tenantId ?? null) ?? null
-        const tenantDiffers = normalizedCandidate !== actorTenant
-        if (tenantDiffers) {
-          try {
-            const guardContainer = await ensureContainer()
-            await enforceTenantSelection({ auth, container: guardContainer }, tenantCandidate)
-          } catch (error) {
-            if (isCrudHttpError(error)) {
-              return NextResponse.json(error.body ?? { error: t('api.errors.forbidden', 'Forbidden') }, { status: error.status })
-            }
-            throw error
-          }
+      if (tenantCandidate === undefined) continue
+      const normalizedCandidate = normalizeTenantId(tenantCandidate) ?? null
+      if (normalizedCandidate === actorTenant) continue
+      if (enforcedCandidates.has(normalizedCandidate)) continue
+      enforcedCandidates.add(normalizedCandidate)
+      try {
+        const guardContainer = await ensureContainer()
+        await enforceTenantSelection({ auth, container: guardContainer }, tenantCandidate)
+      } catch (error) {
+        if (isCrudHttpError(error)) {
+          return NextResponse.json(error.body ?? { error: t('api.errors.forbidden', 'Forbidden') }, { status: error.status })
         }
+        throw error
       }
     }
   }
@@ -248,17 +255,12 @@ function sanitizeTenantCandidate(candidate: unknown): unknown {
   return candidate
 }
 
-export async function extractTenantCandidate(req: NextRequest): Promise<unknown> {
-  const tenantParams = req.nextUrl?.searchParams?.getAll?.('tenantId') ?? []
-  if (tenantParams.length > 0) {
-    return tenantParams[tenantParams.length - 1]
-  }
-
+function bodyCarriesTenantId(req: NextRequest): boolean {
   const method = (req.method || 'GET').toUpperCase()
-  if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
-    return undefined
-  }
+  return method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS'
+}
 
+async function extractBodyTenantCandidate(req: NextRequest): Promise<unknown> {
   const rawContentType = req.headers.get('content-type')
   if (!rawContentType) return undefined
   const contentType = rawContentType.split(';')[0].trim().toLowerCase()
@@ -282,6 +284,35 @@ export async function extractTenantCandidate(req: NextRequest): Promise<unknown>
   }
 
   return undefined
+}
+
+export async function extractTenantCandidate(req: NextRequest): Promise<unknown> {
+  const tenantParams = req.nextUrl?.searchParams?.getAll?.('tenantId') ?? []
+  if (tenantParams.length > 0) {
+    return tenantParams[tenantParams.length - 1]
+  }
+
+  if (!bodyCarriesTenantId(req)) {
+    return undefined
+  }
+
+  return extractBodyTenantCandidate(req)
+}
+
+// Returns every `tenantId` candidate the request carries — each repeated `?tenantId=`
+// query param plus any body-level value. The dispatcher enforces tenant selection
+// against all of them so a downstream handler that reads a different occurrence
+// (e.g. `searchParams.get()` first vs. `getAll()` last) cannot be tricked into using a
+// candidate that was never authorized (issue #2665).
+export async function extractTenantCandidates(req: NextRequest): Promise<unknown[]> {
+  const candidates: unknown[] = [...(req.nextUrl?.searchParams?.getAll?.('tenantId') ?? [])]
+
+  if (bodyCarriesTenantId(req)) {
+    const bodyCandidate = await extractBodyTenantCandidate(req)
+    if (bodyCandidate !== undefined) candidates.push(bodyCandidate)
+  }
+
+  return candidates
 }
 
 async function handleRequest(

--- a/packages/create-app/template/src/app/api/[...slug]/route.ts
+++ b/packages/create-app/template/src/app/api/[...slug]/route.ts
@@ -139,7 +139,7 @@ function normalizeLoadedMetadata(
   return { [method]: metadata }
 }
 
-async function checkAuthorization(
+export async function checkAuthorization(
   methodMetadata: MethodMetadata | null,
   auth: AuthContext,
   req: NextRequest
@@ -167,24 +167,31 @@ async function checkAuthorization(
   }
 
   if (auth && requiresAuthentication) {
-    const rawTenantCandidate = await extractTenantCandidate(req)
-    if (rawTenantCandidate !== undefined) {
+    // HTTP parameter pollution hardening (issue #2665): a request can carry `tenantId`
+    // more than once — repeated `?tenantId=` query params, or in both the query string
+    // and the body. The dispatcher and downstream handlers may disagree on which
+    // occurrence wins (here historically `getAll().last`, handlers use `get()` first),
+    // so the authorization gate must validate EVERY distinct candidate. If any one
+    // targets a tenant the actor may not select, the request is rejected — making this
+    // decision binding regardless of how a handler later parses the same request.
+    const rawTenantCandidates = await extractTenantCandidates(req)
+    const actorTenant = normalizeTenantId(auth.tenantId ?? null) ?? null
+    const enforcedCandidates = new Set<string | null>()
+    for (const rawTenantCandidate of rawTenantCandidates) {
       const tenantCandidate = sanitizeTenantCandidate(rawTenantCandidate)
-      if (tenantCandidate !== undefined) {
-        const normalizedCandidate = normalizeTenantId(tenantCandidate) ?? null
-        const actorTenant = normalizeTenantId(auth.tenantId ?? null) ?? null
-        const tenantDiffers = normalizedCandidate !== actorTenant
-        if (tenantDiffers) {
-          try {
-            const guardContainer = await ensureContainer()
-            await enforceTenantSelection({ auth, container: guardContainer }, tenantCandidate)
-          } catch (error) {
-            if (isCrudHttpError(error)) {
-              return NextResponse.json(error.body ?? { error: t('api.errors.forbidden', 'Forbidden') }, { status: error.status })
-            }
-            throw error
-          }
+      if (tenantCandidate === undefined) continue
+      const normalizedCandidate = normalizeTenantId(tenantCandidate) ?? null
+      if (normalizedCandidate === actorTenant) continue
+      if (enforcedCandidates.has(normalizedCandidate)) continue
+      enforcedCandidates.add(normalizedCandidate)
+      try {
+        const guardContainer = await ensureContainer()
+        await enforceTenantSelection({ auth, container: guardContainer }, tenantCandidate)
+      } catch (error) {
+        if (isCrudHttpError(error)) {
+          return NextResponse.json(error.body ?? { error: t('api.errors.forbidden', 'Forbidden') }, { status: error.status })
         }
+        throw error
       }
     }
   }
@@ -248,17 +255,12 @@ function sanitizeTenantCandidate(candidate: unknown): unknown {
   return candidate
 }
 
-export async function extractTenantCandidate(req: NextRequest): Promise<unknown> {
-  const tenantParams = req.nextUrl?.searchParams?.getAll?.('tenantId') ?? []
-  if (tenantParams.length > 0) {
-    return tenantParams[tenantParams.length - 1]
-  }
-
+function bodyCarriesTenantId(req: NextRequest): boolean {
   const method = (req.method || 'GET').toUpperCase()
-  if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
-    return undefined
-  }
+  return method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS'
+}
 
+async function extractBodyTenantCandidate(req: NextRequest): Promise<unknown> {
   const rawContentType = req.headers.get('content-type')
   if (!rawContentType) return undefined
   const contentType = rawContentType.split(';')[0].trim().toLowerCase()
@@ -282,6 +284,35 @@ export async function extractTenantCandidate(req: NextRequest): Promise<unknown>
   }
 
   return undefined
+}
+
+export async function extractTenantCandidate(req: NextRequest): Promise<unknown> {
+  const tenantParams = req.nextUrl?.searchParams?.getAll?.('tenantId') ?? []
+  if (tenantParams.length > 0) {
+    return tenantParams[tenantParams.length - 1]
+  }
+
+  if (!bodyCarriesTenantId(req)) {
+    return undefined
+  }
+
+  return extractBodyTenantCandidate(req)
+}
+
+// Returns every `tenantId` candidate the request carries — each repeated `?tenantId=`
+// query param plus any body-level value. The dispatcher enforces tenant selection
+// against all of them so a downstream handler that reads a different occurrence
+// (e.g. `searchParams.get()` first vs. `getAll()` last) cannot be tricked into using a
+// candidate that was never authorized (issue #2665).
+export async function extractTenantCandidates(req: NextRequest): Promise<unknown[]> {
+  const candidates: unknown[] = [...(req.nextUrl?.searchParams?.getAll?.('tenantId') ?? [])]
+
+  if (bodyCarriesTenantId(req)) {
+    const bodyCandidate = await extractBodyTenantCandidate(req)
+    if (bodyCandidate !== undefined) candidates.push(bodyCandidate)
+  }
+
+  return candidates
 }
 
 async function handleRequest(


### PR DESCRIPTION
Fixes #2665

## Problem
The catch-all API dispatcher (`apps/mercato/src/app/api/[...slug]/route.ts`) and downstream handlers disagreed on which `tenantId` an HTTP-parameter-polluted request resolves to:

- The dispatcher read the **LAST** `?tenantId=` query param (`searchParams.getAll('tenantId')[last]`) and only invoked `enforceTenantSelection` when that value differed from `auth.tenantId`.
- Many handlers read the **FIRST** occurrence via `searchParams.get('tenantId')` (per URL spec).

**Attack:** a non-superadmin in tenant A sends `?tenantId=<foreign-B>&tenantId=<own-A>`. The dispatcher sees the last value (A, matches the actor) and **skips** enforcement; a handler then reads the first value (B) for scope resolution. The same disagreement is possible when `tenantId` appears in both the query string and the request body.

## Root Cause
The dispatcher validated only a single representative `tenantId` occurrence, so its "tenant selection is authorized" promise was not binding on handlers that parse the request differently.

## What Changed
- Added `extractTenantCandidates(req)` — returns **every** tenant candidate the request carries: each repeated `?tenantId=` query param **plus** any body-level value (JSON / urlencoded / multipart, preserving the existing File-field rejection from #2722).
- `checkAuthorization` now iterates all distinct candidates and calls `enforceTenantSelection` for each one that differs from the actor's tenant; if any candidate targets an unauthorized tenant the request is rejected with `403`. Superadmins are unaffected (the guard authorizes any tenant for them).
- Kept `extractTenantCandidate` with identical behavior for backward compatibility.
- Mirrored the same change into the create-app template route (`packages/create-app/template/src/app/api/[...slug]/route.ts`) to keep template parity.

## Tests
- New unit coverage in `apps/mercato/src/__tests__/extract-tenant-candidate.test.ts`:
  - `extractTenantCandidates` returns all repeated query params and surfaces both query + body candidates.
  - `checkAuthorization` returns `403` when the FIRST query `tenantId` targets a foreign tenant even though the LAST matches the actor (the core PoC).
  - `checkAuthorization` returns `403` when a body `tenantId` disagrees with an authorized query `tenantId`.
  - A request whose only `tenantId` matches the actor passes without invoking the guard; distinct foreign candidates are enforced once.
- `yarn workspace @open-mercato/app jest` — 28 suites / 136 tests pass.
- `yarn workspace @open-mercato/app typecheck` — clean.
- `yarn template:sync` — no drift introduced by the route change.

## Backward Compatibility
- Additive only: new `extractTenantCandidates` export; `checkAuthorization` is now exported for testability. `extractTenantCandidate` behavior is unchanged.
- No API response fields, event IDs, DI names, ACL IDs, or import paths removed.
- Behavioral change is a security tightening: malformed/polluted multi-`tenantId` requests targeting a foreign tenant are now rejected for non-superadmins; legitimate single-tenant and superadmin requests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)