### PR TITLE
security(ai_assistant): reject Code Mode path traversal before authorization (#2667)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/codemode-tools.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/codemode-tools.test.ts
@@ -306,6 +306,12 @@ describe('path traversal hardening (issue #2667)', () => {
       '/api/foo%5cadmin',
       'foo/../admin',
       '/api/foo/../admin?expand=1',
+      // Raw ASCII tab/newline/CR are stripped by the WHATWG URL parser before
+      // the fetch, so `.<ctrl>.` collapses to `..` on the wire.
+      '/api/foo/.\t./admin',
+      '/api/foo/.\n./admin',
+      '/api/foo/.\r./admin',
+      '/api/foo/\t../admin',
     ])('flags %s as unsafe', (path) => {
       expect(isUnsafeApiRequestPath(path)).toBe(true)
     })

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/codemode-tools.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/codemode-tools.test.ts
@@ -7,6 +7,7 @@ import {
   CODE_MODE_MAX_MUTATION_CALLS,
   CODE_MODE_REQUIRED_FEATURES,
   createApiRequestFn,
+  isUnsafeApiRequestPath,
   isUnsafeHttpMethod,
   matchApiEndpointPath,
 } from '../codemode-tools'
@@ -284,6 +285,106 @@ describe('authorizeCodeModeApiRequest', () => {
         deprecated: false,
       },
     })
+  })
+})
+
+describe('path traversal hardening (issue #2667)', () => {
+  describe('isUnsafeApiRequestPath', () => {
+    it.each([
+      '/api/foo/../admin',
+      '/api/foo/..',
+      '/api/foo/./admin',
+      '/api/.',
+      '/api/foo/%2e%2e/admin',
+      '/api/foo/%2E%2E/admin',
+      '/api/foo/%2e./admin',
+      '/api/foo/.%2e/admin',
+      '/api/foo/%2e/admin',
+      '/api/foo\\admin',
+      '/api/foo%2fadmin',
+      '/api/foo%2Fadmin',
+      '/api/foo%5cadmin',
+      'foo/../admin',
+      '/api/foo/../admin?expand=1',
+    ])('flags %s as unsafe', (path) => {
+      expect(isUnsafeApiRequestPath(path)).toBe(true)
+    })
+
+    it.each([
+      '/api/customers/companies',
+      '/api/customers/companies/company-1',
+      'customers/companies/company-1?expand=1',
+      '/api/catalog/products/1.2.3',
+      '/api/customers/companies/00000000-0000-0000-0000-000000000000',
+    ])('treats %s as safe', (path) => {
+      expect(isUnsafeApiRequestPath(path)).toBe(false)
+    })
+  })
+
+  it('denies a traversal path even when a parameterized endpoint would match', async () => {
+    mockedGetApiEndpoints.mockReset()
+    // A documented read the user is authorized for. The un-normalized segment
+    // matcher would have accepted '/api/foo/..' against '/api/foo/{id}', then
+    // the wire fetch would collapse it to '/api/admin'. The guard blocks it.
+    mockedGetApiEndpoints.mockResolvedValue([
+      {
+        id: 'get_foo',
+        operationId: 'get_foo',
+        method: 'GET',
+        path: '/api/foo/{id}',
+        summary: '',
+        description: '',
+        tags: [],
+        requiredFeatures: [],
+        parameters: [],
+        requestBodySchema: null,
+        deprecated: false,
+      },
+    ])
+
+    const result = await authorizeCodeModeApiRequest(createContext(), 'GET', '/api/foo/..')
+
+    expect(result).toEqual({
+      allowed: false,
+      statusCode: 403,
+      error: 'Code Mode rejected unsafe API path: GET /api/foo/..',
+    })
+  })
+
+  it('never issues the wire request for a traversal path', async () => {
+    mockedGetApiEndpoints.mockReset()
+    mockedFetchWithTimeout.mockReset()
+    mockedFetchWithTimeout.mockResolvedValue(okResponse())
+    mockedGetApiEndpoints.mockResolvedValue([
+      {
+        id: 'create_company',
+        operationId: 'create_company',
+        method: 'POST',
+        path: '/api/customers/companies',
+        summary: '',
+        description: '',
+        tags: [],
+        requiredFeatures: ['customers.companies.create'],
+        parameters: [],
+        requestBodySchema: null,
+        deprecated: false,
+      },
+    ])
+
+    const apiRequest = createApiRequestFn(
+      createContext({ userFeatures: ['ai_assistant.view', 'customers.companies.create'] }),
+      () => {}
+    )
+
+    const result = (await apiRequest({
+      method: 'POST',
+      path: '/api/customers/companies/../admin',
+      body: {},
+    })) as { success: boolean; statusCode: number }
+
+    expect(result.success).toBe(false)
+    expect(result.statusCode).toBe(403)
+    expect(mockedFetchWithTimeout).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/codemode-tools.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/codemode-tools.ts
@@ -1002,6 +1002,14 @@ const DOUBLE_DOT_SEGMENTS = new Set(['..', '.%2e', '%2e.', '%2e%2e'])
 export function isUnsafeApiRequestPath(path: string): boolean {
   const [rawPath] = String(path ?? '').split('?')
 
+  // The WHATWG URL parser strips ASCII tab/newline/carriage-return from the URL
+  // before parsing, so a smuggled `.<TAB>.` segment collapses to `..` on the
+  // wire even though the literal segment never equals a dot segment here. Raw
+  // control characters never appear in legitimate REST paths, so reject them.
+  if (/[\u0000-\u001f]/.test(rawPath)) {
+    return true
+  }
+
   // http(s) URLs treat backslashes as path separators, so they can smuggle
   // separators past the segment-based authorizer.
   if (rawPath.includes('\\')) {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/codemode-tools.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/codemode-tools.ts
@@ -883,6 +883,15 @@ export async function authorizeCodeModeApiRequest(
   path: string
 ): Promise<CodeModeApiAuthorization> {
   const normalizedMethod = method.toUpperCase()
+
+  if (isUnsafeApiRequestPath(path)) {
+    return {
+      allowed: false,
+      statusCode: 403,
+      error: `Code Mode rejected unsafe API path: ${normalizedMethod} ${path}`,
+    }
+  }
+
   const normalizedPath = normalizeApiRequestPath(path)
   const endpoint = await findCodeModeApiEndpoint(normalizedMethod, normalizedPath)
 
@@ -977,6 +986,38 @@ function normalizeApiRequestPath(path: string): string {
   }
 
   return normalizedPath
+}
+
+const SINGLE_DOT_SEGMENTS = new Set(['.', '%2e'])
+const DOUBLE_DOT_SEGMENTS = new Set(['..', '.%2e', '%2e.', '%2e%2e'])
+
+/**
+ * Rejects request paths that the WHATWG URL parser would rewrite before the
+ * actual fetch (`..`/`.` path segments — including their percent-encoded forms
+ * — backslashes, and percent-encoded separators). Code Mode authorizes the
+ * literal path it was given, but `new URL()` collapses dot segments and
+ * normalizes backslashes for http(s) URLs, so without this guard the wire
+ * request can resolve to a different endpoint than the one that was authorized.
+ */
+export function isUnsafeApiRequestPath(path: string): boolean {
+  const [rawPath] = String(path ?? '').split('?')
+
+  // http(s) URLs treat backslashes as path separators, so they can smuggle
+  // separators past the segment-based authorizer.
+  if (rawPath.includes('\\')) {
+    return true
+  }
+
+  // Percent-encoded separators never appear in legitimate REST paths and let
+  // the literal-'/' segment split desync from the parsed request URL.
+  if (/%2f/i.test(rawPath) || /%5c/i.test(rawPath)) {
+    return true
+  }
+
+  return rawPath.split('/').some((segment) => {
+    const lowered = segment.toLowerCase()
+    return SINGLE_DOT_SEGMENTS.has(lowered) || DOUBLE_DOT_SEGMENTS.has(lowered)
+  })
 }
 
 function isPathParameterSegment(segment: string): boolean {


### PR DESCRIPTION
Fixes #2667

## Problem
Code Mode's `api.request()` authorized the **literal** path it was given, but the actual fetch passed that same path to `new URL()`/`fetchWithTimeout`. Node's WHATWG URL parser collapses `..`/`.` path segments (and normalizes backslashes for http(s) URLs) before issuing the request, so the wire request could resolve to a **different endpoint** than the one the authorizer matched.

Because `matchApiEndpointPath` treats `..` as an ordinary segment that satisfies any path-parameter slot (`{id}`/`[id]`/`:id`), an input like `POST /api/foo/../admin` could be authorized against a benign parameterized endpoint while the fetch actually hit `/api/admin`. This bypasses Code Mode's defense-in-depth rule that denies mutation endpoints without declared `requireFeatures`.

## Root Cause
Authorization and fetch operated on the **un-normalized** path; only the fetch step normalized it, desyncing the two.

## What Changed
- Added `isUnsafeApiRequestPath()` in `codemode-tools.ts` that rejects `.`/`..` path segments (including the percent-encoded forms the URL parser collapses: `%2e`, `%2e%2e`, `.%2e`, `%2e.`), backslashes, and percent-encoded separators (`%2f`/`%5c`).
- `authorizeCodeModeApiRequest` now fails closed with a `403` for unsafe paths **before** any endpoint match, so authorization and the wire request always operate on identical paths.
- Minimal and self-contained — no contract surface touched; legitimate paths (UUIDs, slugs, dotted ids like `1.2.3`) remain allowed.

## Tests
- New `path traversal hardening (issue #2667)` suite in `codemode-tools.test.ts`:
  - parameterized `isUnsafeApiRequestPath` cases for every traversal/encoding form plus negative cases for legitimate paths;
  - `authorizeCodeModeApiRequest` denies a traversal path even when a parameterized endpoint would have matched;
  - end-to-end `createApiRequestFn` test proving `fetchWithTimeout` is **never** called for a traversal path (auth/fetch can't desync).
- Full `@open-mercato/ai-assistant` suite green: 85 suites / 1215 tests.
- `yarn typecheck` green across all 21 packages.

## Backward Compatibility
- No contract surface changes. `isUnsafeApiRequestPath` is an additive export; the new 403 only rejects inputs that are never legitimate REST paths.