### PR TITLE
security(auth): close login account-enumeration oracle + timing leak (#2242)

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/login.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/login.test.ts
@@ -258,3 +258,70 @@ describe('POST /api/auth/login with custom route interceptors', () => {
     expect(setCookie).not.toContain('session_token=')
   })
 })
+
+describe('account enumeration hardening (issue #2242)', () => {
+  beforeEach(() => {
+    registerApiInterceptors([])
+    jest.clearAllMocks()
+  })
+
+  function loginRequest(extra: Record<string, string> = {}) {
+    return new Request('http://localhost/api/auth/login', {
+      method: 'POST',
+      body: makeFormData({ email: 'user@example.com', password: 'secret', ...extra }),
+    })
+  }
+
+  test('an email registered in multiple tenants returns a uniform 401, never a 400 tenant oracle', async () => {
+    authServiceMock.findUsersByEmail.mockResolvedValueOnce([
+      { id: 1, email: 'user@example.com', passwordHash: 'h1', tenantId, organizationId: orgId },
+      { id: 2, email: 'user@example.com', passwordHash: 'h2', tenantId: randomUUID(), organizationId: orgId },
+    ])
+
+    const res = await POST(loginRequest())
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body).toEqual({ ok: false, error: 'Invalid email or password' })
+
+    // The ambiguous match must not resolve a single user; the password check
+    // still runs (against a null user) so latency matches the other failures.
+    expect(authServiceMock.verifyPassword).toHaveBeenCalledWith(null, 'secret')
+  })
+
+  test('unknown email, wrong password, and multi-tenant cases return byte-identical 401 bodies', async () => {
+    // Unknown email
+    authServiceMock.findUsersByEmail.mockResolvedValueOnce([])
+    const unknownRes = await POST(loginRequest())
+    const unknownBody = await unknownRes.json()
+
+    // Wrong password (single user, verification fails)
+    authServiceMock.findUsersByEmail.mockResolvedValueOnce([
+      { id: 1, email: 'user@example.com', passwordHash: 'h1', tenantId, organizationId: orgId },
+    ])
+    authServiceMock.verifyPassword.mockResolvedValueOnce(false)
+    const wrongPasswordRes = await POST(loginRequest())
+    const wrongPasswordBody = await wrongPasswordRes.json()
+
+    // Multi-tenant ambiguous match
+    authServiceMock.findUsersByEmail.mockResolvedValueOnce([
+      { id: 1, email: 'user@example.com', passwordHash: 'h1', tenantId, organizationId: orgId },
+      { id: 2, email: 'user@example.com', passwordHash: 'h2', tenantId: randomUUID(), organizationId: orgId },
+    ])
+    const multiTenantRes = await POST(loginRequest())
+    const multiTenantBody = await multiTenantRes.json()
+
+    expect(unknownRes.status).toBe(401)
+    expect(wrongPasswordRes.status).toBe(401)
+    expect(multiTenantRes.status).toBe(401)
+    expect(unknownBody).toEqual({ ok: false, error: 'Invalid email or password' })
+    expect(wrongPasswordBody).toEqual(unknownBody)
+    expect(multiTenantBody).toEqual(unknownBody)
+  })
+
+  test('always runs the password comparison even for an unknown email (timing equalizer)', async () => {
+    authServiceMock.findUsersByEmail.mockResolvedValueOnce([])
+    const res = await POST(loginRequest())
+    expect(res.status).toBe(401)
+    expect(authServiceMock.verifyPassword).toHaveBeenCalledWith(null, 'secret')
+  })
+})

--- a/packages/core/src/modules/auth/api/login.ts
+++ b/packages/core/src/modules/auth/api/login.ts
@@ -108,21 +108,21 @@ export async function POST(req: Request) {
     user = await auth.findUserByEmailAndTenant(parsed.data.email, tenantId)
   } else {
     const users = await auth.findUsersByEmail(parsed.data.email)
-    if (users.length > 1) {
-      return NextResponse.json({
-        ok: false,
-        error: translate('auth.login.errors.tenantRequired', 'Use the login link provided with your tenant activation to continue.'),
-      }, { status: 400 })
-    }
-    user = users[0] ?? null
+    // Never disclose that an email is registered across multiple tenants — a
+    // password-independent 400-vs-401 response is an account/topology oracle
+    // (issue #2242). Treat an ambiguous match as no resolvable user and fall
+    // through to the uniform invalid-credentials path; tenant-selection
+    // guidance is delivered out-of-band via the activation/login link.
+    user = users.length === 1 ? users[0] : null
   }
-  if (!user || !user.passwordHash) {
-    void emitAuthEvent('auth.login.failed', { email: parsed.data.email, reason: 'invalid_credentials' }).catch(() => undefined)
-    return NextResponse.json({ ok: false, error: translate('auth.login.errors.invalidCredentials', 'Invalid email or password') }, { status: 401 })
-  }
+  // Always verify the password — verifyPassword runs a constant-time bcrypt
+  // comparison even when the user is missing or has no hash — so unknown-email,
+  // wrong-password, and multi-tenant cases return an identical 401 with
+  // identical latency.
   const ok = await auth.verifyPassword(user, parsed.data.password)
-  if (!ok) {
-    void emitAuthEvent('auth.login.failed', { email: parsed.data.email, reason: 'invalid_password' }).catch(() => undefined)
+  if (!user || !ok) {
+    const reason = user?.passwordHash ? 'invalid_password' : 'invalid_credentials'
+    void emitAuthEvent('auth.login.failed', { email: parsed.data.email, reason }).catch(() => undefined)
     return NextResponse.json({ ok: false, error: translate('auth.login.errors.invalidCredentials', 'Invalid email or password') }, { status: 401 })
   }
   // Optional role requirement

--- a/packages/core/src/modules/auth/i18n/de.json
+++ b/packages/core/src/modules/auth/i18n/de.json
@@ -43,7 +43,6 @@
   "auth.login.errors.invalidCredentials": "Ungültige E-Mail oder ungültiges Passwort",
   "auth.login.errors.permissionDenied": "Du hast keine Berechtigung, auf diesen Bereich zuzugreifen. Bitte wende dich an deine Administration.",
   "auth.login.errors.tenantInvalid": "Tenant nicht gefunden. Entferne die Tenant-Auswahl und versuche es erneut.",
-  "auth.login.errors.tenantRequired": "Nutze den Login-Link aus deiner Tenant-Aktivierung, um fortzufahren.",
   "auth.login.featureDenied": "Du hast keinen Zugriff auf diese Funktion ({feature}). Bitte wende dich an deine Administration.",
   "auth.login.forgotPassword": "Passwort vergessen?",
   "auth.login.loading": "Wird geladen ...",

--- a/packages/core/src/modules/auth/i18n/en.json
+++ b/packages/core/src/modules/auth/i18n/en.json
@@ -43,7 +43,6 @@
   "auth.login.errors.invalidCredentials": "Invalid email or password",
   "auth.login.errors.permissionDenied": "You do not have permission to access this area. Please contact your administrator.",
   "auth.login.errors.tenantInvalid": "Tenant not found. Clear the tenant selection and try again.",
-  "auth.login.errors.tenantRequired": "Use the login link provided with your tenant activation to continue.",
   "auth.login.featureDenied": "You don't have access to this feature ({feature}). Please contact your administrator.",
   "auth.login.forgotPassword": "Forgot password?",
   "auth.login.loading": "Loading...",

--- a/packages/core/src/modules/auth/i18n/es.json
+++ b/packages/core/src/modules/auth/i18n/es.json
@@ -43,7 +43,6 @@
   "auth.login.errors.invalidCredentials": "Correo electrónico o contraseña no válidos",
   "auth.login.errors.permissionDenied": "No tienes permiso para acceder a esta área. Ponte en contacto con tu administrador.",
   "auth.login.errors.tenantInvalid": "No se encontró el inquilino. Borra la selección e inténtalo de nuevo.",
-  "auth.login.errors.tenantRequired": "Usa el enlace de inicio de sesión proporcionado con la activación de tu inquilino para continuar.",
   "auth.login.featureDenied": "No tienes acceso a esta funcionalidad ({feature}). Ponte en contacto con tu administrador.",
   "auth.login.forgotPassword": "¿Olvidaste tu contraseña?",
   "auth.login.loading": "Cargando...",

--- a/packages/core/src/modules/auth/i18n/pl.json
+++ b/packages/core/src/modules/auth/i18n/pl.json
@@ -43,7 +43,6 @@
   "auth.login.errors.invalidCredentials": "Nieprawidłowy email lub hasło",
   "auth.login.errors.permissionDenied": "Nie masz uprawnień do tego obszaru. Skontaktuj się z administratorem.",
   "auth.login.errors.tenantInvalid": "Nie znaleziono najemcy. Wyczyść wybór i spróbuj ponownie.",
-  "auth.login.errors.tenantRequired": "Użyj linku logowania z aktywacji najemcy, aby kontynuować.",
   "auth.login.featureDenied": "Nie masz dostępu do tej funkcji ({feature}). Skontaktuj się z administratorem.",
   "auth.login.forgotPassword": "Nie pamiętasz hasła?",
   "auth.login.loading": "Ładowanie...",

--- a/packages/core/src/modules/auth/services/__tests__/verifyPassword-timing.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/verifyPassword-timing.test.ts
@@ -1,0 +1,52 @@
+/** @jest-environment node */
+// Regression: timing-based account enumeration via the login password check (issue #2242).
+// verifyPassword MUST run a bcrypt comparison on every path — including the
+// missing-user and no-password-hash cases — so a failed login spends the same
+// CPU time regardless of whether the account exists.
+import { AuthService } from '@open-mercato/core/modules/auth/services/authService'
+
+const mockCompare = jest.fn()
+
+jest.mock('bcryptjs', () => ({
+  compare: (...args: unknown[]) => mockCompare(...args),
+  hash: jest.fn(async () => 'hashed'),
+}))
+
+describe('AuthService.verifyPassword timing-safe (issue #2242)', () => {
+  beforeEach(() => {
+    mockCompare.mockReset()
+  })
+
+  it('runs a bcrypt comparison against a fixed dummy hash when the user is null', async () => {
+    mockCompare.mockResolvedValue(false)
+    const svc = new AuthService({} as any)
+    const ok = await svc.verifyPassword(null, 'secret')
+    expect(ok).toBe(false)
+    expect(mockCompare).toHaveBeenCalledTimes(1)
+    expect(mockCompare.mock.calls[0][0]).toBe('secret')
+    expect(mockCompare.mock.calls[0][1]).toMatch(/^\$2[aby]\$/)
+  })
+
+  it('runs a bcrypt comparison even when the user has no password hash', async () => {
+    mockCompare.mockResolvedValue(false)
+    const svc = new AuthService({} as any)
+    const ok = await svc.verifyPassword({ passwordHash: null } as any, 'secret')
+    expect(ok).toBe(false)
+    expect(mockCompare).toHaveBeenCalledTimes(1)
+  })
+
+  it('never authenticates a user without a hash even if the dummy comparison resolves true', async () => {
+    mockCompare.mockResolvedValue(true)
+    const svc = new AuthService({} as any)
+    await expect(svc.verifyPassword(null, 'secret')).resolves.toBe(false)
+    await expect(svc.verifyPassword({ passwordHash: null } as any, 'secret')).resolves.toBe(false)
+  })
+
+  it('compares against the real hash and returns true on a match', async () => {
+    mockCompare.mockResolvedValue(true)
+    const svc = new AuthService({} as any)
+    const ok = await svc.verifyPassword({ passwordHash: 'real-hash' } as any, 'secret')
+    expect(ok).toBe(true)
+    expect(mockCompare).toHaveBeenCalledWith('secret', 'real-hash')
+  })
+})

--- a/packages/core/src/modules/auth/services/authService.ts
+++ b/packages/core/src/modules/auth/services/authService.ts
@@ -5,6 +5,13 @@ import { emailHashLookupValues } from '@open-mercato/core/modules/auth/lib/email
 import { generateAuthToken, hashAuthToken } from '@open-mercato/core/modules/auth/lib/tokenHash'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
+// A fixed, valid bcrypt hash (cost 10) of a throwaway value no real password
+// can match. verifyPassword compares against it whenever the user is missing or
+// has no password hash, so a failed login spends the same bcrypt CPU time
+// regardless of whether the account exists — closing the timing side channel
+// for account enumeration (issue #2242).
+const TIMING_EQUALIZER_PASSWORD_HASH = '$2b$10$OcZrhmZpIzJOjkfwUrk7d.Nl0eHNzOvalBcBlt5Ran.4lj8R3HZg6'
+
 export class AuthService {
   constructor(private em: EntityManager) {}
 
@@ -48,9 +55,13 @@ export class AuthService {
     )
   }
 
-  async verifyPassword(user: User, password: string) {
-    if (!user.passwordHash) return false
-    return compare(password, user.passwordHash)
+  async verifyPassword(user: User | null, password: string) {
+    const storedHash = user?.passwordHash ?? null
+    // Always run a bcrypt comparison — against a fixed dummy hash when the user
+    // is absent or has no password — so login latency does not reveal whether
+    // the account exists (timing-based enumeration, issue #2242).
+    const matched = await compare(password, storedHash ?? TIMING_EQUALIZER_PASSWORD_HASH)
+    return storedHash !== null && matched
   }
 
   async updateLastLoginAt(user: User) {


### PR DESCRIPTION
Fixes #2242

## Problem
The unauthenticated login handler leaked account existence and multi-tenant topology:
- An email registered in **more than one tenant** returned **HTTP 400** (`tenantRequired`), while unknown email / wrong password returned **HTTP 401** (`invalidCredentials`) — a deterministic, password-independent oracle confirming a real multi-tenant account on the **first** request.
- `verifyPassword` ran bcrypt **only when a user with a `passwordHash` was found**, so non-existent emails responded measurably faster (timing-based enumeration in the single-tenant case).

This violated the auth module's own rule: *"Never reveal whether an email exists through auth error messages."* (OWASP A07).

## Root Cause
- `api/login.ts` returned a distinct `400` for the `users.length > 1` branch and skipped `verifyPassword` entirely on the `!user || !user.passwordHash` path.
- `services/authService.ts` `verifyPassword` short-circuited with `return false` before running bcrypt when no hash was present.

## What Changed
- **`api/login.ts`** — an ambiguous multi-tenant match is now treated as *no resolvable user* and falls through to the single uniform `401 invalidCredentials` path. Tenant-selection guidance stays out-of-band (activation/login link), never in the synchronous HTTP body. `verifyPassword` is always invoked so unknown-email, wrong-password, and multi-tenant cases share one status, body, **and** latency.
- **`services/authService.ts`** — `verifyPassword` now accepts a nullable user and always performs a bcrypt comparison, against a fixed dummy hash when the user is missing or has no password, closing the timing side channel. It still returns `false` whenever no real hash exists (a truthy dummy comparison can never authenticate).
- Removed the now-unused `auth.login.errors.tenantRequired` key from all 4 locale files.
- Rate limiting (5/min/email, 20/min/ip) is unchanged.

## Tests
- `services/__tests__/verifyPassword-timing.test.ts` (new) — bcrypt runs for null / hashless users, never authenticates without a real hash, matches on a real hash.
- `api/__tests__/login.test.ts` (+3) — multi-tenant returns a uniform 401 (never the 400 oracle); unknown-email, wrong-password, and multi-tenant produce byte-identical 401 bodies; the password comparison always runs (timing equalizer).
- Validation: `yarn typecheck` (21/21), `yarn i18n:check-sync` (in sync), 721 auth + customer_accounts jest tests pass.

## Backward Compatibility
- `verifyPassword`'s parameter type was *widened* (`User` → `User | null`) — additive, all existing callers still compile.
- No removed API response fields; `400` and `401` remain documented login error statuses. The multi-tenant case moving from `400` to `401` is the intended security hardening requested in the issue.
- No event ID, widget spot, ACL, DI, or import-path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)