### PR TITLE
security(customers): scope require* helpers by tenant/org at query time (#2116)

### DIFF
--- a/packages/core/src/modules/customers/commands/__tests__/shared.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/shared.test.ts
@@ -14,7 +14,9 @@ const {
   ensureSameScope,
   extractUndoPayload,
   assertFound,
+  requireCustomerEntity,
   requireTimelineParentEntity,
+  requireDealInScope,
   ensureDictionaryEntry,
   loadEntityTagIds,
   syncEntityTags,
@@ -67,34 +69,71 @@ describe('customers commands shared utilities', () => {
     })
   })
 
-  describe('requireTimelineParentEntity', () => {
-    const personEntity = Object.assign(new CustomerEntity(), { id: 'person-1', kind: 'person' as const })
-    const companyEntity = Object.assign(new CustomerEntity(), { id: 'company-1', kind: 'company' as const })
-    const invalidKindEntity = Object.assign(new CustomerEntity(), { id: 'weird-1', kind: 'lead' as any })
-    const dealRecord = Object.assign(new CustomerDeal(), { id: 'deal-1' })
+  const SCOPE = { tenantId: 'tenant-1', organizationId: 'org-1' } as const
+  const OTHER_SCOPE = { tenantId: 'tenant-2', organizationId: 'org-2' } as const
 
-    function makeEm(lookups: { entity?: unknown; deal?: unknown }) {
-      return {
-        findOne: jest.fn(async (cls: unknown) => {
-          if (cls === CustomerEntity) return lookups.entity ?? null
-          if (cls === CustomerDeal) return lookups.deal ?? null
-          return null
-        }),
-      }
+  // Scope-aware mock: `findOne` honors the tenantId/organizationId in the where
+  // clause so the tests prove the helpers filter by scope at query time (a
+  // cross-tenant row is simply never returned) rather than fetching-then-checking.
+  function makeEm(lookups: { entity?: any; deal?: any }) {
+    const matchesScope = (record: any, where: any) =>
+      !!record &&
+      (where.tenantId === undefined || record.tenantId === where.tenantId) &&
+      (where.organizationId === undefined || record.organizationId === where.organizationId)
+    return {
+      findOne: jest.fn(async (cls: unknown, where: any) => {
+        if (cls === CustomerEntity) return matchesScope(lookups.entity, where) ? lookups.entity : null
+        if (cls === CustomerDeal) return matchesScope(lookups.deal, where) ? lookups.deal : null
+        return null
+      }),
     }
+  }
+
+  describe('requireCustomerEntity', () => {
+    const personEntity = Object.assign(new CustomerEntity(), { id: 'person-1', kind: 'person' as const, ...SCOPE })
+
+    it('returns the entity when found in scope', async () => {
+      const em = makeEm({ entity: personEntity })
+      await expect(requireCustomerEntity(em as any, 'person-1', SCOPE)).resolves.toBe(personEntity)
+    })
+
+    it('throws 400 when the entity kind does not match', async () => {
+      const em = makeEm({ entity: personEntity })
+      await expect(requireCustomerEntity(em as any, 'person-1', SCOPE, 'company')).rejects.toMatchObject({
+        status: 400,
+        body: { error: 'Invalid entity type' },
+      })
+    })
+
+    it('throws 404 (not 403) for a cross-tenant id so existence is not leaked', async () => {
+      const em = makeEm({ entity: personEntity })
+      await expect(
+        requireCustomerEntity(em as any, 'person-1', OTHER_SCOPE, undefined, 'Customer not found'),
+      ).rejects.toMatchObject({
+        status: 404,
+        body: { error: 'Customer not found' },
+      })
+    })
+  })
+
+  describe('requireTimelineParentEntity', () => {
+    const personEntity = Object.assign(new CustomerEntity(), { id: 'person-1', kind: 'person' as const, ...SCOPE })
+    const companyEntity = Object.assign(new CustomerEntity(), { id: 'company-1', kind: 'company' as const, ...SCOPE })
+    const invalidKindEntity = Object.assign(new CustomerEntity(), { id: 'weird-1', kind: 'lead' as any, ...SCOPE })
+    const dealRecord = Object.assign(new CustomerDeal(), { id: 'deal-1', ...SCOPE })
 
     it('returns a person or company entity', async () => {
       const personEm = makeEm({ entity: personEntity })
       const companyEm = makeEm({ entity: companyEntity })
 
-      await expect(requireTimelineParentEntity(personEm as any, 'person-1')).resolves.toBe(personEntity)
-      await expect(requireTimelineParentEntity(companyEm as any, 'company-1')).resolves.toBe(companyEntity)
+      await expect(requireTimelineParentEntity(personEm as any, 'person-1', SCOPE)).resolves.toBe(personEntity)
+      await expect(requireTimelineParentEntity(companyEm as any, 'company-1', SCOPE)).resolves.toBe(companyEntity)
     })
 
     it('throws 422 when entityId belongs to a deal record', async () => {
       const em = makeEm({ deal: dealRecord })
 
-      await expect(requireTimelineParentEntity(em as any, 'deal-1')).rejects.toMatchObject({
+      await expect(requireTimelineParentEntity(em as any, 'deal-1', SCOPE)).rejects.toMatchObject({
         status: 422,
         body: { error: 'entityId must reference a person or company, not a deal' },
       })
@@ -103,7 +142,7 @@ describe('customers commands shared utilities', () => {
     it('throws 404 when neither a customer entity nor a deal exists', async () => {
       const em = makeEm({})
 
-      await expect(requireTimelineParentEntity(em as any, 'missing-1')).rejects.toMatchObject({
+      await expect(requireTimelineParentEntity(em as any, 'missing-1', SCOPE)).rejects.toMatchObject({
         status: 404,
         body: { error: 'Customer not found' },
       })
@@ -112,9 +151,47 @@ describe('customers commands shared utilities', () => {
     it('throws 422 when the customer entity exists with an unsupported kind', async () => {
       const em = makeEm({ entity: invalidKindEntity })
 
-      await expect(requireTimelineParentEntity(em as any, 'weird-1')).rejects.toMatchObject({
+      await expect(requireTimelineParentEntity(em as any, 'weird-1', SCOPE)).rejects.toMatchObject({
         status: 422,
         body: { error: 'entityId must reference a person or company' },
+      })
+    })
+
+    it('throws 404 (not 403) for a cross-tenant id so existence is not leaked', async () => {
+      const em = makeEm({ entity: personEntity })
+
+      await expect(requireTimelineParentEntity(em as any, 'person-1', OTHER_SCOPE)).rejects.toMatchObject({
+        status: 404,
+        body: { error: 'Customer not found' },
+      })
+    })
+  })
+
+  describe('requireDealInScope', () => {
+    const dealRecord = Object.assign(new CustomerDeal(), { id: 'deal-1', ...SCOPE })
+
+    it('returns null when no dealId is provided', async () => {
+      const em = makeEm({ deal: dealRecord })
+      await expect(
+        requireDealInScope(em as any, null, SCOPE.tenantId, SCOPE.organizationId),
+      ).resolves.toBeNull()
+    })
+
+    it('returns the deal when found in scope', async () => {
+      const em = makeEm({ deal: dealRecord })
+      await expect(
+        requireDealInScope(em as any, 'deal-1', SCOPE.tenantId, SCOPE.organizationId),
+      ).resolves.toBe(dealRecord)
+    })
+
+    it('throws "Deal not found" (not 403) for a cross-tenant id so existence is not leaked', async () => {
+      const em = makeEm({ deal: dealRecord })
+
+      await expect(
+        requireDealInScope(em as any, 'deal-1', OTHER_SCOPE.tenantId, OTHER_SCOPE.organizationId),
+      ).rejects.toMatchObject({
+        status: 400,
+        body: { error: 'Deal not found' },
       })
     })
   })

--- a/packages/core/src/modules/customers/commands/addresses.ts
+++ b/packages/core/src/modules/customers/commands/addresses.ts
@@ -109,7 +109,7 @@ const createAddressCommand: CommandHandler<AddressCreateInput, { addressId: stri
     ensureOrganizationScope(ctx, parsed.organizationId)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const entity = await requireCustomerEntity(em, parsed.entityId, undefined, 'Customer not found')
+    const entity = await requireCustomerEntity(em, parsed.entityId, { tenantId: parsed.tenantId, organizationId: parsed.organizationId }, undefined, 'Customer not found')
     ensureSameScope(entity, parsed.organizationId, parsed.tenantId)
 
     const address = em.create(CustomerAddress, {
@@ -198,7 +198,7 @@ const createAddressCommand: CommandHandler<AddressCreateInput, { addressId: stri
       throw new CrudHttpError(400, { error: '[internal] redo snapshot unavailable for address create' })
     }
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const entity = await requireCustomerEntity(em, after.entityId, undefined, 'Customer not found')
+    const entity = await requireCustomerEntity(em, after.entityId, { tenantId: after.tenantId, organizationId: after.organizationId }, undefined, 'Customer not found')
     let address = await findOneWithDecryption(
       em,
       CustomerAddress,
@@ -293,7 +293,7 @@ const updateAddressCommand: CommandHandler<AddressUpdateInput, { addressId: stri
     ensureOrganizationScope(ctx, address.organizationId)
 
     if (parsed.entityId !== undefined) {
-      const entity = await requireCustomerEntity(em, parsed.entityId, undefined, 'Customer not found')
+      const entity = await requireCustomerEntity(em, parsed.entityId, { tenantId: address.tenantId, organizationId: address.organizationId }, undefined, 'Customer not found')
       ensureSameScope(entity, address.organizationId, address.tenantId)
       address.entity = entity
     }
@@ -396,7 +396,7 @@ const updateAddressCommand: CommandHandler<AddressUpdateInput, { addressId: stri
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     let address = await em.findOne(CustomerAddress, { id: before.id })
-    const entity = await requireCustomerEntity(em, before.entityId, undefined, 'Customer not found')
+    const entity = await requireCustomerEntity(em, before.entityId, { tenantId: before.tenantId, organizationId: before.organizationId }, undefined, 'Customer not found')
     if (!address) {
       address = em.create(CustomerAddress, {
         id: before.id,
@@ -523,7 +523,7 @@ const deleteAddressCommand: CommandHandler<{ body?: Record<string, unknown>; que
       const before = payload?.before
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const entity = await requireCustomerEntity(em, before.entityId, undefined, 'Customer not found')
+      const entity = await requireCustomerEntity(em, before.entityId, { tenantId: before.tenantId, organizationId: before.organizationId }, undefined, 'Customer not found')
       let address = await em.findOne(CustomerAddress, { id: before.id })
       if (!address) {
         address = em.create(CustomerAddress, {

--- a/packages/core/src/modules/customers/commands/comments.ts
+++ b/packages/core/src/modules/customers/commands/comments.ts
@@ -84,7 +84,7 @@ const createCommentCommand: CommandHandler<CommentCreateInput, { commentId: stri
     const normalizedAuthor = normalizeAuthorUserId(parsed.authorUserId, ctx.auth)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const entity = await requireTimelineParentEntity(em, parsed.entityId)
+    const entity = await requireTimelineParentEntity(em, parsed.entityId, { tenantId: parsed.tenantId, organizationId: parsed.organizationId })
     ensureSameScope(entity, parsed.organizationId, parsed.tenantId)
     const deal = await requireDealInScope(em, parsed.dealId, parsed.tenantId, parsed.organizationId)
 
@@ -176,7 +176,7 @@ const createCommentCommand: CommandHandler<CommentCreateInput, { commentId: stri
       appearanceColor: snapshot.appearanceColor,
     }),
     beforeRestore: async ({ em, snapshot }) => {
-      const entity = await requireTimelineParentEntity(em, snapshot.entityId)
+      const entity = await requireTimelineParentEntity(em, snapshot.entityId, { tenantId: snapshot.tenantId, organizationId: snapshot.organizationId })
       const deal = await requireDealInScope(em, snapshot.dealId, snapshot.tenantId, snapshot.organizationId)
       return { entity, deal }
     },
@@ -201,7 +201,7 @@ const updateCommentCommand: CommandHandler<CommentUpdateInput, { commentId: stri
     ensureOrganizationScope(ctx, comment.organizationId)
 
     if (parsed.entityId !== undefined) {
-      const entity = await requireTimelineParentEntity(em, parsed.entityId)
+      const entity = await requireTimelineParentEntity(em, parsed.entityId, { tenantId: comment.tenantId, organizationId: comment.organizationId })
       ensureSameScope(entity, comment.organizationId, comment.tenantId)
       comment.entity = entity
     }
@@ -275,7 +275,7 @@ const updateCommentCommand: CommandHandler<CommentUpdateInput, { commentId: stri
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     let comment = await em.findOne(CustomerComment, { id: before.id })
-    const entity = await requireTimelineParentEntity(em, before.entityId)
+    const entity = await requireTimelineParentEntity(em, before.entityId, { tenantId: before.tenantId, organizationId: before.organizationId })
     const deal = await requireDealInScope(em, before.dealId, before.tenantId, before.organizationId)
 
     if (!comment) {
@@ -380,7 +380,7 @@ const deleteCommentCommand: CommandHandler<{ body?: Record<string, unknown>; que
       const before = payload?.before
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const entity = await requireTimelineParentEntity(em, before.entityId)
+      const entity = await requireTimelineParentEntity(em, before.entityId, { tenantId: before.tenantId, organizationId: before.organizationId })
       const deal = await requireDealInScope(em, before.dealId, before.tenantId, before.organizationId)
       let comment = await em.findOne(CustomerComment, { id: before.id })
       if (!comment) {

--- a/packages/core/src/modules/customers/commands/deals.ts
+++ b/packages/core/src/modules/customers/commands/deals.ts
@@ -376,7 +376,7 @@ async function syncDealPeople(
   if (!personIds || !personIds.length) return
   const unique = Array.from(new Set(personIds))
   for (const personId of unique) {
-    const person = await requireCustomerEntity(em, personId, 'person', 'Person not found')
+    const person = await requireCustomerEntity(em, personId, { tenantId: deal.tenantId, organizationId: deal.organizationId }, 'person', 'Person not found')
     ensureSameScope(person, deal.organizationId, deal.tenantId)
     const link = em.create(CustomerDealPersonLink, {
       deal,
@@ -396,7 +396,7 @@ async function syncDealCompanies(
   if (!companyIds || !companyIds.length) return
   const unique = Array.from(new Set(companyIds))
   for (const companyId of unique) {
-    const company = await requireCustomerEntity(em, companyId, 'company', 'Company not found')
+    const company = await requireCustomerEntity(em, companyId, { tenantId: deal.tenantId, organizationId: deal.organizationId }, 'company', 'Company not found')
     ensureSameScope(company, deal.organizationId, deal.tenantId)
     const link = em.create(CustomerDealCompanyLink, {
       deal,

--- a/packages/core/src/modules/customers/commands/entity-roles.ts
+++ b/packages/core/src/modules/customers/commands/entity-roles.ts
@@ -137,7 +137,7 @@ const createEntityRoleCommand: CommandHandler<EntityRoleCreateInput, { roleId: s
     ensureOrganizationScope(ctx, parsed.organizationId)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const entity = await requireCustomerEntity(em, parsed.entityId, parsed.entityType, 'Customer not found')
+    const entity = await requireCustomerEntity(em, parsed.entityId, { tenantId: parsed.tenantId, organizationId: parsed.organizationId }, parsed.entityType, 'Customer not found')
     ensureSameScope(entity, parsed.organizationId, parsed.tenantId)
 
     const activeExisting = await findOneWithDecryption(
@@ -495,6 +495,7 @@ const deleteEntityRoleCommand: CommandHandler<EntityRoleDeleteInput, { roleId: s
     const entity = await requireCustomerEntity(
       em,
       before.role.entityId,
+      { tenantId: before.role.tenantId, organizationId: before.role.organizationId },
       before.role.entityType,
       'Customer not found',
     )

--- a/packages/core/src/modules/customers/commands/interactions.ts
+++ b/packages/core/src/modules/customers/commands/interactions.ts
@@ -374,7 +374,7 @@ const createInteractionCommand: CommandHandler<InteractionCreateInput, { interac
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const normalizedAuthor = normalizeAuthorUserId(parsed.authorUserId ?? null, ctx.auth)
     const { interaction, entityId, nextInteractionId } = await runInTransaction(em, async (trx) => {
-      const entity = await requireTimelineParentEntity(trx, parsed.entityId)
+      const entity = await requireTimelineParentEntity(trx, parsed.entityId, { tenantId: parsed.tenantId, organizationId: parsed.organizationId })
       ensureTenantScope(ctx, entity.tenantId)
       ensureOrganizationScope(ctx, entity.organizationId)
 
@@ -510,7 +510,7 @@ const createInteractionCommand: CommandHandler<InteractionCreateInput, { interac
     }
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const { interaction, nextInteractionId } = await runInTransaction(em, async (trx) => {
-      const entity = await requireTimelineParentEntity(trx, after.interaction.entityId)
+      const entity = await requireTimelineParentEntity(trx, after.interaction.entityId, { tenantId: after.interaction.tenantId, organizationId: after.interaction.organizationId })
       let interaction = await findOneWithDecryption(trx, CustomerInteraction, { id: after.interaction.id })
       if (!interaction) {
         interaction = buildInteractionGraph(trx, {
@@ -781,7 +781,7 @@ const updateInteractionCommand: CommandHandler<InteractionUpdateInput, { interac
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const { interaction, nextInteractionId } = await runInTransaction(em, async (trx) => {
       let interaction = await findOneWithDecryption(trx, CustomerInteraction, { id: before.interaction.id })
-      const entity = await requireTimelineParentEntity(trx, before.interaction.entityId)
+      const entity = await requireTimelineParentEntity(trx, before.interaction.entityId, { tenantId: before.interaction.tenantId, organizationId: before.interaction.organizationId })
 
       if (!interaction) {
         interaction = trx.create(CustomerInteraction, {
@@ -1252,7 +1252,7 @@ const deleteInteractionCommand: CommandHandler<{ body?: Record<string, unknown>;
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
       const { interaction, nextInteractionId } = await runInTransaction(em, async (trx) => {
-        const entity = await requireTimelineParentEntity(trx, before.interaction.entityId)
+        const entity = await requireTimelineParentEntity(trx, before.interaction.entityId, { tenantId: before.interaction.tenantId, organizationId: before.interaction.organizationId })
         let interaction = await findOneWithDecryption(trx, CustomerInteraction, { id: before.interaction.id })
         if (!interaction) {
           interaction = trx.create(CustomerInteraction, {
@@ -1372,7 +1372,10 @@ const recomputeNextCommand: CommandHandler<{ entityId: string }, { entityId: str
     const parsed = recomputeNextSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const projection = await recomputeNextInteraction(em, parsed.entityId)
-    const entity = await requireTimelineParentEntity(em, parsed.entityId)
+    const entity = await requireTimelineParentEntity(em, parsed.entityId, {
+      tenantId: ctx.auth?.tenantId ?? '',
+      organizationId: ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? '',
+    })
     await emitNextInteractionUpdatedEvent(ctx, {
       entityId: parsed.entityId,
       nextInteractionId: projection.nextInteractionId,

--- a/packages/core/src/modules/customers/commands/shared.ts
+++ b/packages/core/src/modules/customers/commands/shared.ts
@@ -26,13 +26,24 @@ export function normalizeDictionaryIcon(input: unknown): string | null {
 
 export { assertFound } from '@open-mercato/shared/lib/crud/errors'
 
+export type CustomerEntityScope = {
+  tenantId: string
+  organizationId: string
+}
+
 export async function requireCustomerEntity(
   em: EntityManager,
   id: string,
+  scope: CustomerEntityScope,
   kind?: CustomerEntityKind,
   message = 'Customer entity not found'
 ): Promise<CustomerEntity> {
-  const entity = await em.findOne(CustomerEntity, { id, deletedAt: null })
+  const entity = await em.findOne(CustomerEntity, {
+    id,
+    deletedAt: null,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+  })
   if (!entity) throw new CrudHttpError(404, { error: message })
   if (kind && entity.kind !== kind) {
     throw new CrudHttpError(400, { error: 'Invalid entity type' })
@@ -43,15 +54,26 @@ export async function requireCustomerEntity(
 export async function requireTimelineParentEntity(
   em: EntityManager,
   id: string,
+  scope: CustomerEntityScope,
 ): Promise<CustomerEntity> {
-  const entity = await em.findOne(CustomerEntity, { id, deletedAt: null })
+  const entity = await em.findOne(CustomerEntity, {
+    id,
+    deletedAt: null,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+  })
   if (entity) {
     if (entity.kind !== 'person' && entity.kind !== 'company') {
       throw new CrudHttpError(422, { error: 'entityId must reference a person or company' })
     }
     return entity
   }
-  const deal = await em.findOne(CustomerDeal, { id, deletedAt: null })
+  const deal = await em.findOne(CustomerDeal, {
+    id,
+    deletedAt: null,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+  })
   if (deal) {
     throw new CrudHttpError(422, { error: 'entityId must reference a person or company, not a deal' })
   }
@@ -111,7 +133,7 @@ export async function requireDealInScope(
   organizationId: string
 ): Promise<CustomerDeal | null> {
   if (!dealId) return null
-  const deal = await em.findOne(CustomerDeal, { id: dealId, deletedAt: null })
+  const deal = await em.findOne(CustomerDeal, { id: dealId, deletedAt: null, tenantId, organizationId })
   if (!deal) throw new CrudHttpError(400, { error: 'Deal not found' })
   ensureSameScope(deal, organizationId, tenantId)
   return deal

--- a/packages/core/src/modules/customers/commands/tags.ts
+++ b/packages/core/src/modules/customers/commands/tags.ts
@@ -387,7 +387,7 @@ const assignTagCommand: CommandHandler<TagAssignmentInput, { assignmentId: strin
     const em = (ctx.container.resolve('em') as EntityManager).fork()
   const tag = await em.findOne(CustomerTag, { id: parsed.tagId, tenantId: parsed.tenantId, organizationId: parsed.organizationId })
   if (!tag) throw new CrudHttpError(404, { error: 'Tag not found' })
-  const entity = await requireCustomerEntity(em, parsed.entityId, undefined, 'Customer not found')
+  const entity = await requireCustomerEntity(em, parsed.entityId, { tenantId: parsed.tenantId, organizationId: parsed.organizationId }, undefined, 'Customer not found')
   ensureSameScope(entity, parsed.organizationId, parsed.tenantId)
   const tagIds = await loadEntityTagIds(em, entity)
     if (tagIds.includes(parsed.tagId)) {
@@ -478,7 +478,7 @@ const assignTagCommand: CommandHandler<TagAssignmentInput, { assignmentId: strin
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const tag = await em.findOne(CustomerTag, { id: before.tagId })
     if (!tag) throw new CrudHttpError(404, { error: 'Tag not found' })
-    const entity = await requireCustomerEntity(em, before.entityId, undefined, 'Customer not found')
+    const entity = await requireCustomerEntity(em, before.entityId, { tenantId: before.tenantId, organizationId: before.organizationId }, undefined, 'Customer not found')
     ensureSameScope(entity, before.organizationId, before.tenantId)
 
     let assignment = await em.findOne(CustomerTagAssignment, {
@@ -589,7 +589,7 @@ const unassignTagCommand: CommandHandler<TagAssignmentInput, { assignmentId: str
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const tag = await em.findOne(CustomerTag, { id: before.tagId })
-    const entity = await requireCustomerEntity(em, before.entityId, undefined, 'Customer not found')
+    const entity = await requireCustomerEntity(em, before.entityId, { tenantId: before.tenantId, organizationId: before.organizationId }, undefined, 'Customer not found')
     ensureSameScope(entity, before.organizationId, before.tenantId)
     if (!tag) throw new CrudHttpError(404, { error: 'Tag not found' })
     const existing = await em.findOne(CustomerTagAssignment, {


### PR DESCRIPTION
Fixes #2116

## Problem
`requireCustomerEntity`, `requireTimelineParentEntity`, and `requireDealInScope` in `packages/core/src/modules/customers/commands/shared.ts` looked records up by `id` (and `deletedAt`) **only**, with no `tenantId`/`organizationId` filter. They relied on a separate post-fetch `ensureSameScope(entity, …)` to reject cross-tenant rows.

- Several undo/redo paths skipped the follow-up `ensureSameScope`, so those code paths could return another tenant's row.
- The 404-vs-403 differential leaked whether a UUID existed in another tenant (cross-tenant existence oracle; subsumes audit finding C-05).
- Timing-attack surface.

## Root Cause
Scope was validated *after* the lookup instead of being part of the `where` clause, so the query itself could match cross-tenant rows.

## What Changed
- `requireCustomerEntity` and `requireTimelineParentEntity` now take a required `scope: { tenantId, organizationId }` argument applied directly in the `em.findOne` `where` clause.
- `requireDealInScope` already received `tenantId`/`organizationId`; those are now applied in the `where` clause too (no signature change).
- All call sites updated to thread scope from the available context (`parsed`, snapshot `before`/`after`, the owning entity, or — for the no-scope `recompute_next` command — `ctx.auth`).
- The post-fetch `ensureSameScope` checks are kept as belt-and-braces.
- A cross-tenant id now returns the same not-found response as a non-existent id (404 for the entity helpers, "Deal not found" 400 for the deal helper), removing the existence oracle.

## Tests
- `packages/core/src/modules/customers/commands/__tests__/shared.test.ts`: made the `findOne` mock scope-aware, threaded scope through existing cases, and added per-helper cross-tenant regression tests asserting 404/not-found (not 403) for all three helpers.
- `yarn workspace @open-mercato/core test src/modules/customers` → 798 passed.
- `yarn build:packages`, `yarn generate`, `yarn typecheck` → green.

## Backward Compatibility
- `requireCustomerEntity` / `requireTimelineParentEntity` are module-internal command helpers (no importers outside the customers module) — adding a required `scope` arg is not a public contract-surface change. `requireDealInScope`'s signature is unchanged.