### PR TITLE
fix(customers): degrade owner filters when optional staff module is absent (#2649)

### DIFF
--- a/packages/core/src/modules/customers/components/detail/__tests__/assignableStaff.test.ts
+++ b/packages/core/src/modules/customers/components/detail/__tests__/assignableStaff.test.ts
@@ -1,0 +1,82 @@
+const readApiResultOrThrowMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  readApiResultOrThrow: (...args: unknown[]) => readApiResultOrThrowMock(...args),
+}))
+
+import {
+  fetchAssignableStaffMembers,
+  fetchAssignableStaffMembersPage,
+} from '../assignableStaff'
+
+function httpError(status: number): Error & { status: number } {
+  const error = new Error(`Request failed (${status})`) as Error & { status: number }
+  error.status = status
+  return error
+}
+
+describe('fetchAssignableStaffMembersPage', () => {
+  beforeEach(() => {
+    readApiResultOrThrowMock.mockReset()
+  })
+
+  it('maps and dedupes assignable staff on success', async () => {
+    readApiResultOrThrowMock.mockResolvedValueOnce({
+      items: [
+        { userId: 'user-1', displayName: 'Ada Lovelace', user: { email: 'ada@example.com' }, team: { name: 'Sales' } },
+        { userId: 'user-1', displayName: 'Ada (dup)' },
+        { userId: 'user-2', displayName: 'Grace Hopper' },
+      ],
+      total: 2,
+      page: 1,
+      pageSize: 24,
+    })
+
+    const result = await fetchAssignableStaffMembersPage('', { pageSize: 24 })
+
+    expect(result.items).toHaveLength(2)
+    expect(result.items[0]).toMatchObject({
+      userId: 'user-1',
+      displayName: 'Ada Lovelace',
+      email: 'ada@example.com',
+      teamName: 'Sales',
+    })
+    expect(result.total).toBe(2)
+  })
+
+  // Regression for issue #2649: the assignable-staff endpoint is owned by the optional
+  // `staff` module. When that module is disabled the route 404s, and entering the deals
+  // (or people / companies) list must not break — it should degrade to an empty roster.
+  it('returns an empty page when the staff endpoint is missing (404)', async () => {
+    readApiResultOrThrowMock.mockRejectedValueOnce(httpError(404))
+
+    const result = await fetchAssignableStaffMembersPage('', { page: 1, pageSize: 100 })
+
+    expect(result).toEqual({ items: [], total: 0, page: 1, pageSize: 100 })
+  })
+
+  it('propagates non-404 failures (e.g. forbidden, server error)', async () => {
+    readApiResultOrThrowMock.mockRejectedValueOnce(httpError(403))
+    await expect(fetchAssignableStaffMembersPage('', { pageSize: 100 })).rejects.toMatchObject({ status: 403 })
+
+    readApiResultOrThrowMock.mockRejectedValueOnce(httpError(500))
+    await expect(fetchAssignableStaffMembersPage('', { pageSize: 100 })).rejects.toMatchObject({ status: 500 })
+
+    readApiResultOrThrowMock.mockRejectedValueOnce(new Error('Network down'))
+    await expect(fetchAssignableStaffMembersPage('', { pageSize: 100 })).rejects.toThrow('Network down')
+  })
+})
+
+describe('fetchAssignableStaffMembers', () => {
+  beforeEach(() => {
+    readApiResultOrThrowMock.mockReset()
+  })
+
+  it('returns an empty list when the staff endpoint is missing (404)', async () => {
+    readApiResultOrThrowMock.mockRejectedValueOnce(httpError(404))
+
+    const items = await fetchAssignableStaffMembers('', { pageSize: 100 })
+
+    expect(items).toEqual([])
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/assignableStaff.ts
+++ b/packages/core/src/modules/customers/components/detail/assignableStaff.ts
@@ -23,22 +23,46 @@ export type AssignableStaffMembersPage = {
   pageSize: number
 }
 
+// The assignable-staff roster is owned by the optional, ejectable `staff` module.
+// When that module is disabled, its `/api/staff/team-members/assignable` endpoint is
+// absent and the request resolves to 404. Customers UI (deals / people / companies
+// owner filters, role-assignment dialogs) is core and always enabled, so it must not
+// break in that case — a missing staff module simply means there is no roster to
+// offer. Treat the 404 as an empty page and let any other failure propagate.
+function isAssignableEndpointMissing(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { status?: unknown }).status === 404
+  )
+}
+
 export async function fetchAssignableStaffMembersPage(
   query: string,
   options?: { page?: number; pageSize?: number; signal?: AbortSignal },
 ): Promise<AssignableStaffMembersPage> {
+  const page = options?.page ?? 1
+  const pageSize = options?.pageSize ?? 24
   const params = new URLSearchParams()
-  params.set('page', String(options?.page ?? 1))
-  params.set('pageSize', String(options?.pageSize ?? 24))
+  params.set('page', String(page))
+  params.set('pageSize', String(pageSize))
   const normalizedQuery = query.trim()
   if (normalizedQuery.length > 0) {
     params.set('search', normalizedQuery)
   }
 
-  const data = await readApiResultOrThrow<AssignableStaffResponse>(
-    `/api/staff/team-members/assignable?${params.toString()}`,
-    options?.signal ? { signal: options.signal } : undefined,
-  )
+  let data: AssignableStaffResponse
+  try {
+    data = await readApiResultOrThrow<AssignableStaffResponse>(
+      `/api/staff/team-members/assignable?${params.toString()}`,
+      options?.signal ? { signal: options.signal } : undefined,
+    )
+  } catch (error) {
+    if (isAssignableEndpointMissing(error)) {
+      return { items: [], total: 0, page, pageSize }
+    }
+    throw error
+  }
 
   const rawItems = Array.isArray(data?.items) ? data.items : []
   const deduped = new Map<string, AssignableStaffMember>()
@@ -108,11 +132,11 @@ export async function fetchAssignableStaffMembersPage(
     page:
       typeof data?.page === 'number' && Number.isFinite(data.page)
         ? data.page
-        : options?.page ?? 1,
+        : page,
     pageSize:
       typeof data?.pageSize === 'number' && Number.isFinite(data.pageSize)
         ? data.pageSize
-        : options?.pageSize ?? 24,
+        : pageSize,
   }
 }
 


### PR DESCRIPTION
Fixes #2649

## Problem
Entering the **Deals** list (and the People / Companies lists) fires a request to `GET /api/staff/team-members/assignable?page=1&pageSize=100` to populate the **Owner** filter. The reporter saw this request return **404** (red in the network panel) on list load.

## Root Cause
The assignable-staff roster was moved into the optional, **ejectable** `staff` module (staff decoupling, #1946). The deals/people/companies list pages live in `customers` (core, always enabled) and call the staff endpoint directly via the shared `fetchAssignableStaffMembersPage` helper.

When the `staff` module is **not enabled** in a deployment, its route is never registered, so the catch-all API handler returns **404** — and `readApiResultOrThrow` turns that into a thrown error. The deals list happened to swallow it (empty owner filter), but the shared role-assignment dialogs (`AssignRoleDialog`, `ChangeOwnerDialog`, `ParticipantsField`, `RoleAssignmentRow`) did not, and every list load logged a failed request.

(Verified the route generates correctly when `staff` is enabled — confirmed it is present at `/staff/team-members/assignable` in the generated manifest — so this only manifests when the optional module is absent.)

## What Changed
- `packages/core/src/modules/customers/components/detail/assignableStaff.ts`: treat a **404** from the assignable endpoint as an **empty roster** (`{ items: [], total: 0, … }`) instead of throwing. A missing `staff` module simply means there are no assignable staff to offer. All other failures (403/500/network) still propagate unchanged.

This keeps core customers UI resilient to the optional `staff` module being disabled, matching the module-decoupling contract ("core must not break when optional modules are disabled").

## Tests
- New `__tests__/assignableStaff.test.ts`:
  - 404 → empty page / empty list (the regression).
  - non-404 errors (403, 500, network) still propagate.
  - success path still maps + dedupes correctly.
- Full `@open-mercato/core` suite green (703 suites / 5787 tests), root `yarn typecheck` green, `yarn generate` + `yarn build:packages` green.

## Backward Compatibility
No contract surface changes. Helper signature and success-path behavior unchanged; only the 404 case is now handled gracefully.