### PR TITLE
fix(dev): pin HMR WebSocket origin allowlist contract (#2446)

### DIFF
--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -30,6 +30,10 @@ NEXTAUTH_SECRET=
 APP_URL=http://localhost:3000
 # Additional trusted origins for app requests that must pass host validation.
 # APP_URL is required in production for security-sensitive email links.
+# In dev mode these values also govern the HMR WebSocket (/_next/webpack-hmr):
+# add your public/reverse-proxy/Tailscale host here so remote dev access works,
+# then restart the dev server. Non-allowlisted origins are still rejected.
+# In Docker dev, the value must also be forwarded into the app container (see #2449).
 # Example: APP_ALLOWED_ORIGINS=https://admin.example.com,https://ops.example.com
 # APP_ALLOWED_ORIGINS=
 

--- a/apps/mercato/src/__tests__/hmr-ws-origin.test.ts
+++ b/apps/mercato/src/__tests__/hmr-ws-origin.test.ts
@@ -1,0 +1,126 @@
+// Regression guard for issue #2446: the dev HMR WebSocket (`/_next/webpack-hmr`)
+// must honor the same `allowedDevOrigins` allowlist as HTTP `_next` resources, so
+// dev mode is usable behind a reverse proxy / Tailscale host — while still blocking
+// cross-site WebSocket hijacking (CSWSH) from non-allowlisted origins.
+//
+// This exercises Next.js' real `blockCrossSiteDEV` (the function the dev server's
+// upgrade handler calls in `next/dist/server/lib/router-server.js`) fed with the
+// origins Open Mercato resolves from `APP_URL` / `APP_ALLOWED_ORIGINS`. It is the
+// integration point that broke on Next 16.2.6 and is asserted here so a future
+// Next bump or helper change cannot silently regress remote dev access.
+import { resolveAllowedDevOrigins } from '../lib/dev-origins'
+
+// Deep import into Next internals is deliberate: it makes this test a tripwire for
+// changes to the dev-server origin guard. If Next relocates or reshapes this module,
+// fail loudly with an actionable message instead of a confusing resolution error so
+// the maintainer re-verifies the HMR WebSocket origin handling for #2446.
+type BlockCrossSiteDEV = (
+  req: { url?: string; headers: Record<string, string | string[] | undefined> },
+  res: { end: (body?: string) => void; statusCode?: number },
+  allowedDevOrigins: string[] | undefined,
+  hostname: string | undefined,
+) => boolean
+
+function loadBlockCrossSiteDEV(): BlockCrossSiteDEV {
+  const modulePath = 'next/dist/server/lib/router-utils/block-cross-site-dev'
+  let mod: { blockCrossSiteDEV?: unknown }
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    mod = require(modulePath)
+  } catch (err) {
+    throw new Error(
+      `Could not load Next.js dev cross-site guard from "${modulePath}". Next internals moved; ` +
+        're-verify the HMR WebSocket origin handling for issue #2446 and update this path. ' +
+        `Original error: ${(err as Error).message}`,
+    )
+  }
+  if (typeof mod.blockCrossSiteDEV !== 'function') {
+    throw new Error(
+      'Next.js no longer exports blockCrossSiteDEV; re-verify the HMR WebSocket origin handling for issue #2446.',
+    )
+  }
+  return mod.blockCrossSiteDEV as BlockCrossSiteDEV
+}
+
+// Mirror how `router-server.js` invokes the guard for a WebSocket upgrade:
+//   blockCrossSiteDEV(req, socket, development.config.allowedDevOrigins, opts.hostname)
+// A `true` return means the upgrade was blocked (socket ended → non-101 response).
+function isHmrUpgradeBlocked(options: {
+  allowedDevOrigins: string[]
+  origin?: string
+  hostname?: string
+  url?: string
+}): boolean {
+  const blockCrossSiteDEV = loadBlockCrossSiteDEV()
+  const headers: Record<string, string | string[] | undefined> = {}
+  if (options.origin !== undefined) headers['origin'] = options.origin
+  const req = { url: options.url ?? '/_next/webpack-hmr?page=%2F', headers }
+  let ended = false
+  const socket = {
+    statusCode: undefined as number | undefined,
+    end: () => {
+      ended = true
+    },
+  }
+  const returnedBlock = blockCrossSiteDEV(req, socket, options.allowedDevOrigins, options.hostname ?? 'localhost')
+  return returnedBlock || ended
+}
+
+describe('dev HMR WebSocket origin allowlist (issue #2446)', () => {
+  const publicHostConfig = {
+    APP_URL: 'http://localhost:3000',
+    NEXT_PUBLIC_APP_URL: '',
+    APP_ALLOWED_ORIGINS: 'https://dev.example.com',
+  }
+
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    // Next's guard logs a one-time warning when it blocks; keep test output clean.
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('allows the HMR upgrade from a public host configured via APP_ALLOWED_ORIGINS', () => {
+    const allowedDevOrigins = resolveAllowedDevOrigins(publicHostConfig)
+    expect(allowedDevOrigins).toContain('dev.example.com')
+    expect(isHmrUpgradeBlocked({ allowedDevOrigins, origin: 'https://dev.example.com' })).toBe(false)
+  })
+
+  it('allows the HMR upgrade from localhost and same-host loopback aliases', () => {
+    const allowedDevOrigins = resolveAllowedDevOrigins(publicHostConfig)
+    expect(isHmrUpgradeBlocked({ allowedDevOrigins, origin: 'http://localhost:3000' })).toBe(false)
+    expect(isHmrUpgradeBlocked({ allowedDevOrigins, origin: 'http://127.0.0.1:3000' })).toBe(false)
+  })
+
+  it('allows the HMR upgrade when no Origin header is present (same-origin GET)', () => {
+    const allowedDevOrigins = resolveAllowedDevOrigins(publicHostConfig)
+    expect(isHmrUpgradeBlocked({ allowedDevOrigins, origin: undefined })).toBe(false)
+  })
+
+  it('blocks the HMR upgrade from a non-allowlisted origin (CSWSH protection)', () => {
+    const allowedDevOrigins = resolveAllowedDevOrigins(publicHostConfig)
+    expect(isHmrUpgradeBlocked({ allowedDevOrigins, origin: 'https://evil.example.com' })).toBe(true)
+  })
+
+  it('blocks a public host that was never added to the allowlist (reporter failure mode)', () => {
+    // No APP_ALLOWED_ORIGINS / APP_URL host configured: the proxied public origin is
+    // rejected. This is exactly what remote users saw before configuring the allowlist
+    // (and why the Docker dev compose must forward APP_ALLOWED_ORIGINS — see #2449).
+    const allowedDevOrigins = resolveAllowedDevOrigins({ APP_URL: '', NEXT_PUBLIC_APP_URL: '', APP_ALLOWED_ORIGINS: '' })
+    expect(isHmrUpgradeBlocked({ allowedDevOrigins, origin: 'https://dev.example.com' })).toBe(true)
+  })
+
+  it('honors wildcard host patterns for the HMR upgrade', () => {
+    const allowedDevOrigins = resolveAllowedDevOrigins({
+      APP_URL: '',
+      NEXT_PUBLIC_APP_URL: '',
+      APP_ALLOWED_ORIGINS: '*.preview.example.com',
+    })
+    expect(isHmrUpgradeBlocked({ allowedDevOrigins, origin: 'https://pr-42.preview.example.com' })).toBe(false)
+    expect(isHmrUpgradeBlocked({ allowedDevOrigins, origin: 'https://preview.example.com' })).toBe(true)
+  })
+})

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -30,6 +30,10 @@ NEXTAUTH_SECRET=
 APP_URL=http://localhost:3000
 # Additional trusted origins for app requests that must pass host validation.
 # APP_URL is required in production for security-sensitive email links.
+# In dev mode these values also govern the HMR WebSocket (/_next/webpack-hmr):
+# add your public/reverse-proxy/Tailscale host here so remote dev access works,
+# then restart the dev server. Non-allowlisted origins are still rejected.
+# In Docker dev, the value must also be forwarded into the app container.
 # Example: APP_ALLOWED_ORIGINS=https://admin.example.com,https://ops.example.com
 # APP_ALLOWED_ORIGINS=
 


### PR DESCRIPTION
Fixes #2446

## Problem
In dev mode the HMR WebSocket (`/_next/webpack-hmr`) rejected any non-`localhost` origin. Behind a reverse proxy / Tailscale host, HMR never connects, the page never hydrates, and client-gated controls (e.g. the login "Sign in" button) stay disabled — making dev mode unusable for remote users.

## Root Cause
Framework-level: **Next 16.2.6** did not apply `allowedDevOrigins` to the WebSocket **upgrade** path the way it did for HTTP `_next` resources. Setting `APP_URL` / `APP_ALLOWED_ORIGINS` fixed cross-origin checks for HTTP `_next` but not the WS handshake.

The **Next 16.2.7** bump (already on `develop`) routes the WS upgrade through the same `blockCrossSiteDEV` allowlist as HTTP resources (`next/dist/server/lib/router-server.js` → `blockCrossSiteDEV(req, socket, allowedDevOrigins, hostname)`). I verified this against Next's real implementation: with the public host in `allowedDevOrigins` the WS upgrade is **allowed**; a non-allowlisted origin is **blocked** (CSWSH-safe); localhost and no-origin handshakes are allowed.

So the functional behavior the issue asked for is satisfied once the public host is configured. This PR **locks that contract** so a future Next bump or helper change can't silently regress remote dev access, and **documents** the env's effect on the HMR WebSocket.

## What Changed
- **Regression guard** (`apps/mercato/src/__tests__/hmr-ws-origin.test.ts`): drives Next's real `blockCrossSiteDEV` with Open Mercato's `resolveAllowedDevOrigins` output and asserts the WS-upgrade contract — configured public host (via `APP_ALLOWED_ORIGINS`), localhost, and no-origin are allowed; a non-allowlisted origin and an unconfigured public host are blocked; wildcard host patterns work. The deep import into Next internals is intentional (a tripwire) and fails with an actionable message if Next relocates the guard.
- **Docs** (`apps/mercato/.env.example` + `packages/create-app/template/.env.example`): clarify that `APP_URL` / `APP_ALLOWED_ORIGINS` also govern the dev HMR WebSocket, that a dev-server restart is required, and that Docker dev must forward the var.

## Tests
- New `hmr-ws-origin.test.ts` (6 cases) — passes.
- Full app Jest suite: 29 suites / 135 tests pass.
- Gate: `yarn build:packages` → `yarn generate` → `yarn build:packages` → app `tsc --noEmit` all clean.

## Scope notes
- The Docker dev compose env-forwarding gap (`APP_ALLOWED_ORIGINS` not passed into the app container) is the maintainer-owned FR **#2449** and is intentionally **not** changed here to avoid duplicate/conflicting PRs — it's referenced in the docs instead.

## Backward Compatibility
- No contract surface changes. Additive only (one test + doc comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)