### PR TITLE
test(ui): guard CrudForm delete-conflict against false success toast (#2409)

### DIFF
--- a/packages/ui/src/backend/__tests__/CrudForm.optimisticLock.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.optimisticLock.test.tsx
@@ -58,6 +58,9 @@ import { dismissRecordConflict, getRecordConflictForTest } from '../conflicts'
 
 const dict = {
   'ui.forms.actions.save': 'Save',
+  'ui.forms.actions.delete': 'Delete',
+  'ui.forms.flash.deleteSuccess': 'Record deleted.',
+  'ui.forms.flash.deleteError': 'Failed to delete record.',
   'ui.forms.flash.recordModified': 'This record was modified by someone else. Refresh and try again.',
 }
 
@@ -170,6 +173,55 @@ describe('CrudForm — optimisticLockUpdatedAt prop wiring', () => {
       'This record was modified by someone else. Refresh and try again.',
       'error',
     )
+  })
+
+  it('delete: a 409 conflict surfaces the conflict bar and never shows a success toast (regression #2409)', async () => {
+    // Regression guard for #2409: when an optimistic-lock conflict (409) is
+    // thrown from onDelete, CrudForm must route it to the unified conflict bar
+    // and MUST NOT flash a "Record deleted." success toast. A previous version
+    // of the planner Availability Schedule page swallowed the delete error, so
+    // CrudForm treated the failed delete as a success and showed a false toast.
+    dismissRecordConflict()
+    const conflict = Object.assign(new Error('record_modified'), {
+      status: 409,
+      error: 'record_modified',
+      code: OPTIMISTIC_LOCK_CONFLICT_CODE,
+      currentUpdatedAt: '2026-05-25T08:42:19.000Z',
+      expectedUpdatedAt: '2026-05-25T08:42:18.000Z',
+    })
+    const onSubmit = jest.fn(async () => undefined)
+    const onDelete = jest.fn(async () => {
+      throw conflict
+    })
+    const { container } = renderWithProviders(
+      <CrudForm<{ displayName: string; id?: string }>
+        fields={fields}
+        initialValues={{ id: 'rec-1', displayName: 'old' }}
+        onSubmit={onSubmit}
+        onDelete={onDelete}
+        optimisticLockUpdatedAt="2026-05-25T08:42:18.000Z"
+      />,
+      { dict },
+    )
+
+    const deleteButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Delete',
+    ) as HTMLButtonElement
+    expect(deleteButton).toBeTruthy()
+
+    await act(async () => {
+      fireEvent.click(deleteButton)
+    })
+
+    await waitFor(() => expect(onDelete).toHaveBeenCalledTimes(1))
+    await waitFor(() => {
+      const entry = getRecordConflictForTest()
+      expect(entry).not.toBeNull()
+      expect(entry?.message).toBe('This record was modified by someone else. Refresh and try again.')
+    })
+    // The false success toast is the actual bug — it must never fire on a 409.
+    expect(flashMock).not.toHaveBeenCalledWith('Record deleted.', 'success')
+    expect(flashMock).not.toHaveBeenCalledWith(expect.anything(), 'success')
   })
 })
 


### PR DESCRIPTION
Fixes #2409

## Problem
When an optimistic-lock conflict (HTTP 409) occurred while deleting an Availability Schedule **after** the conflict banner was already shown, the UI displayed a false "Schedule deleted." success toast even though the record was kept.

## Root Cause
The original planner Availability Schedule edit page swallowed the failed `DELETE` error, so `CrudForm.handleDelete` treated the rejected delete as a success and flashed its success toast. This was already corrected in #2055 — the page now lets a non-ok `DELETE` (including the 409) propagate so `CrudForm` routes it to the unified conflict bar and skips the success toast. Both delete entry points (the edit page via `CrudForm` and the list-page row action) handle the 409 correctly on `develop`.

However, the delete path had **no regression guard** — only the save path was covered by `CrudForm.optimisticLock.test.tsx`. A future refactor could silently reintroduce the swallow.

## What Changed
- Added a regression test to `packages/ui/src/backend/__tests__/CrudForm.optimisticLock.test.tsx` that renders a `CrudForm` whose `onDelete` throws a 409 optimistic-lock conflict, clicks Delete, and asserts:
  - the unified conflict bar receives the localized "record modified" message, and
  - **no** success toast (`flash(..., 'success')`) is ever fired.

No production code changed — the fix already lives on `develop` (via #2055); this PR locks the behavior in.

## Tests
- `CrudForm.optimisticLock.test.tsx` — new delete-conflict regression case (14 tests pass in-file; full `CrudForm` suite: 74 pass).
- Verified the new test **fails** when the bug is simulated (success toast forced on a thrown delete) and **passes** against current `develop`.
- `yarn workspace @open-mercato/ui typecheck` passes.

## Backward Compatibility
- No contract surface changes. Test-only addition.