### PR TITLE
refactor(shared): add buildIlikeTerm() search-term helper (#2367)

### DIFF
--- a/packages/core/src/modules/attachments/api/library/route.ts
+++ b/packages/core/src/modules/attachments/api/library/route.ts
@@ -10,7 +10,7 @@ import { buildAttachmentImageUrl, slugifyAttachmentFileName } from '../../lib/im
 import { readAttachmentMetadata } from '../../lib/metadata'
 import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
 import { applyAssignmentEnrichments, resolveAssignmentEnrichments } from '../../lib/assignmentDetails'
-import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { buildIlikeTerm } from '@open-mercato/shared/lib/db/buildIlikeTerm'
 import { ensureDefaultPartitions } from '../../lib/partitions'
 import {
   attachmentsTag,
@@ -85,7 +85,7 @@ export async function GET(req: Request) {
   }
   qb.where(baseFilter)
   if (search && search.trim().length > 0) {
-    qb.andWhere({ fileName: { $ilike: `%${escapeLikePattern(search.trim())}%` } })
+    qb.andWhere({ fileName: { $ilike: buildIlikeTerm(search.trim()) } })
   }
   if (partition && partition.trim().length > 0) {
     qb.andWhere({ partitionCode: partition.trim() })

--- a/packages/core/src/modules/customers/api/companies/route.ts
+++ b/packages/core/src/modules/customers/api/companies/route.ts
@@ -23,7 +23,7 @@ import {
   extractAllCustomFieldEntries,
   splitCustomFieldPayload,
 } from '@open-mercato/shared/lib/crud/custom-fields'
-import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { buildIlikeTerm } from '@open-mercato/shared/lib/db/buildIlikeTerm'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { consumeAdvancedFilterState, mergeAdvancedFilterTree } from '@open-mercato/shared/lib/crud/advanced-filter-integration'
@@ -178,7 +178,7 @@ const crud = makeCrudRoute({
         if (matchingIds !== null && matchingIds.length > 0) {
           applyEntityIdRestriction(filters, matchingIds)
         } else {
-          const searchPattern = `%${escapeLikePattern(query.search)}%`
+          const searchPattern = buildIlikeTerm(query.search)
           filters.$or = [
             { display_name: { $ilike: searchPattern } },
             { primary_email: { $ilike: searchPattern } },
@@ -276,9 +276,9 @@ const crud = makeCrudRoute({
       if (email) {
         filters.primary_email = { $eq: email }
       } else if (emailStartsWith) {
-        filters.primary_email = { $ilike: `${escapeLikePattern(emailStartsWith)}%` }
+        filters.primary_email = { $ilike: buildIlikeTerm(emailStartsWith, 'startsWith') }
       } else if (emailContains) {
-        filters.primary_email = { $ilike: `%${escapeLikePattern(emailContains)}%` }
+        filters.primary_email = { $ilike: buildIlikeTerm(emailContains) }
       }
       const hasEmail = parseBooleanToken(query.hasEmail)
       if (!email && !emailStartsWith && !emailContains && hasEmail !== null) {

--- a/packages/core/src/modules/customers/api/people/route.ts
+++ b/packages/core/src/modules/customers/api/people/route.ts
@@ -19,7 +19,7 @@ import {
   withScopedPayload,
 } from '../utils'
 import { buildCustomFieldFiltersFromQuery, extractAllCustomFieldEntries, splitCustomFieldPayload } from '@open-mercato/shared/lib/crud/custom-fields'
-import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { buildIlikeTerm } from '@open-mercato/shared/lib/db/buildIlikeTerm'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { consumeAdvancedFilterState, mergeAdvancedFilterTree } from '@open-mercato/shared/lib/crud/advanced-filter-integration'
@@ -173,7 +173,7 @@ const crud = makeCrudRoute({
         if (matchingIds !== null && matchingIds.length > 0) {
           applyEntityIdRestriction(filters, matchingIds)
         } else {
-          const searchPattern = `%${escapeLikePattern(query.search)}%`
+          const searchPattern = buildIlikeTerm(query.search)
           filters.$or = [
             { display_name: { $ilike: searchPattern } },
             { primary_email: { $ilike: searchPattern } },
@@ -189,9 +189,9 @@ const crud = makeCrudRoute({
       if (email) {
         filters.primary_email = { $eq: email }
       } else if (emailStartsWith) {
-        filters.primary_email = { $ilike: `${escapeLikePattern(emailStartsWith)}%` }
+        filters.primary_email = { $ilike: buildIlikeTerm(emailStartsWith, 'startsWith') }
       } else if (emailContains) {
-        filters.primary_email = { $ilike: `%${escapeLikePattern(emailContains)}%` }
+        filters.primary_email = { $ilike: buildIlikeTerm(emailContains) }
       }
       if (query.status) {
         filters.status = { $eq: query.status }

--- a/packages/core/src/modules/payment_gateways/api/transactions/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/transactions/route.ts
@@ -5,14 +5,11 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { GatewayTransaction } from '../../data/entities'
 import { listTransactionsQuerySchema } from '../../data/validators'
 import { paymentGatewaysTag } from '../openapi'
+import { buildIlikeTerm } from '@open-mercato/shared/lib/db/buildIlikeTerm'
 
 export const metadata = {
   path: '/payment_gateways/transactions',
   GET: { requireAuth: true, requireFeatures: ['payment_gateways.view'] },
-}
-
-function escapeLikePattern(value: string): string {
-  return value.replace(/[\\%_]/g, '\\$&')
 }
 
 function formatDateValue(value: unknown): string | null {
@@ -58,7 +55,7 @@ export async function GET(req: Request) {
     qb.andWhere({ unifiedStatus: status })
   }
   if (search) {
-    const pattern = `%${escapeLikePattern(search)}%`
+    const pattern = buildIlikeTerm(search)
     qb.andWhere(`(
       cast(gt.id as text) ilike ?
       or cast(gt.payment_id as text) ilike ?

--- a/packages/core/src/modules/resources/api/resources.ts
+++ b/packages/core/src/modules/resources/api/resources.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveCrudRecordId, parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
-import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { buildIlikeTerm } from '@open-mercato/shared/lib/db/buildIlikeTerm'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { ResourcesResource, ResourcesResourceTagAssignment, ResourcesResourceTag } from '../data/entities'
 import { resourcesResourceCreateSchema, resourcesResourceUpdateSchema } from '../data/validators'
@@ -107,8 +107,7 @@ const crud = makeCrudRoute({
       }
       const term = sanitizeSearchTerm(query.search)
       if (term) {
-        const like = `%${escapeLikePattern(term)}%`
-        filters[F.name] = { $ilike: like }
+        filters[F.name] = { $ilike: buildIlikeTerm(term) }
       }
       if (query.resourceTypeId) {
         filters[F.resource_type_id] = query.resourceTypeId

--- a/packages/core/src/modules/sales/api/documents/factory.ts
+++ b/packages/core/src/modules/sales/api/documents/factory.ts
@@ -17,7 +17,7 @@ import {
 } from '../openapi'
 import { parseScopedCommandInput, resolveCrudRecordId } from '../utils'
 import { documentUpdateSchema } from '../../commands/documents'
-import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { buildIlikeTerm } from '@open-mercato/shared/lib/db/buildIlikeTerm'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { recalculateOrderTotalsForDisplay } from '../../commands/returns'
@@ -101,7 +101,7 @@ function buildFilters(query: ListQuery, numberColumn: string, kind: DocumentKind
   const filters: Record<string, unknown> = {}
   if (query.id) filters.id = { $eq: query.id }
   if (query.search && query.search.trim().length > 0) {
-    const term = `%${escapeLikePattern(query.search.trim())}%`
+    const term = buildIlikeTerm(query.search.trim())
     filters[numberColumn] = { $ilike: term }
   }
   if (query.customerId) {

--- a/packages/shared/src/lib/db/__tests__/buildIlikeTerm.test.ts
+++ b/packages/shared/src/lib/db/__tests__/buildIlikeTerm.test.ts
@@ -1,0 +1,40 @@
+import { buildIlikeTerm } from '../buildIlikeTerm'
+import { escapeLikePattern } from '../escapeLikePattern'
+
+describe('buildIlikeTerm', () => {
+  it('wraps the escaped term in leading and trailing wildcards by default', () => {
+    expect(buildIlikeTerm('acme')).toBe('%acme%')
+  })
+
+  it('matches the legacy inline contains pattern exactly', () => {
+    const term = 'Acme Corp'
+    expect(buildIlikeTerm(term)).toBe(`%${escapeLikePattern(term)}%`)
+    expect(buildIlikeTerm(term, 'contains')).toBe(`%${escapeLikePattern(term)}%`)
+  })
+
+  it('builds a startsWith pattern with only a trailing wildcard', () => {
+    const term = 'user@example.com'
+    expect(buildIlikeTerm(term, 'startsWith')).toBe(`${escapeLikePattern(term)}%`)
+  })
+
+  it('builds an endsWith pattern with only a leading wildcard', () => {
+    const term = 'example.com'
+    expect(buildIlikeTerm(term, 'endsWith')).toBe(`%${escapeLikePattern(term)}`)
+  })
+
+  it('escapes LIKE metacharacters so they match literally', () => {
+    expect(buildIlikeTerm('50%_off')).toBe('%50\\%\\_off%')
+    expect(buildIlikeTerm('back\\slash')).toBe('%back\\\\slash%')
+  })
+
+  it('keeps user wildcards literal across every mode', () => {
+    expect(buildIlikeTerm('a%b', 'startsWith')).toBe('a\\%b%')
+    expect(buildIlikeTerm('a_b', 'endsWith')).toBe('%a\\_b')
+  })
+
+  it('handles an empty term as a wildcard-only pattern', () => {
+    expect(buildIlikeTerm('')).toBe('%%')
+    expect(buildIlikeTerm('', 'startsWith')).toBe('%')
+    expect(buildIlikeTerm('', 'endsWith')).toBe('%')
+  })
+})

--- a/packages/shared/src/lib/db/buildIlikeTerm.ts
+++ b/packages/shared/src/lib/db/buildIlikeTerm.ts
@@ -1,0 +1,16 @@
+import { escapeLikePattern } from './escapeLikePattern'
+
+export type IlikeMatchMode = 'contains' | 'startsWith' | 'endsWith'
+
+export const buildIlikeTerm = (value: string, mode: IlikeMatchMode = 'contains'): string => {
+  const escaped = escapeLikePattern(value)
+  switch (mode) {
+    case 'startsWith':
+      return `${escaped}%`
+    case 'endsWith':
+      return `%${escaped}`
+    case 'contains':
+    default:
+      return `%${escaped}%`
+  }
+}

--- a/packages/shared/src/lib/query/advanced-filter-tree.ts
+++ b/packages/shared/src/lib/query/advanced-filter-tree.ts
@@ -1,7 +1,7 @@
 // packages/shared/src/lib/query/advanced-filter-tree.ts
 import type { FilterOperator } from './advanced-filter'
 import { isValuelessOperator } from './advanced-filter'
-import { escapeLikePattern } from '../db/escapeLikePattern'
+import { buildIlikeTerm } from '../db/buildIlikeTerm'
 
 export type FilterCombinator = 'and' | 'or'
 
@@ -102,22 +102,22 @@ function compileRule(rule: FilterRule): Record<string, unknown> | null {
     case 'contains': {
       const v = normalizeSingleValue(rule.value)
       if (v === null) return null
-      filter[rule.field] = { $ilike: `%${escapeLikePattern(String(v))}%` }; break
+      filter[rule.field] = { $ilike: buildIlikeTerm(String(v)) }; break
     }
     case 'does_not_contain': {
       const v = normalizeSingleValue(rule.value)
       if (v === null) return null
-      filter[rule.field] = { $not: { $ilike: `%${escapeLikePattern(String(v))}%` } }; break
+      filter[rule.field] = { $not: { $ilike: buildIlikeTerm(String(v)) } }; break
     }
     case 'starts_with': {
       const v = normalizeSingleValue(rule.value)
       if (v === null) return null
-      filter[rule.field] = { $ilike: `${escapeLikePattern(String(v))}%` }; break
+      filter[rule.field] = { $ilike: buildIlikeTerm(String(v), 'startsWith') }; break
     }
     case 'ends_with': {
       const v = normalizeSingleValue(rule.value)
       if (v === null) return null
-      filter[rule.field] = { $ilike: `%${escapeLikePattern(String(v))}` }; break
+      filter[rule.field] = { $ilike: buildIlikeTerm(String(v), 'endsWith') }; break
     }
     case 'is_empty': filter[rule.field] = { $exists: false }; break
     case 'is_not_empty': filter[rule.field] = { $exists: true }; break

--- a/packages/shared/src/lib/query/advanced-filter.ts
+++ b/packages/shared/src/lib/query/advanced-filter.ts
@@ -1,4 +1,4 @@
-import { escapeLikePattern } from '../db/escapeLikePattern'
+import { buildIlikeTerm } from '../db/buildIlikeTerm'
 
 export type FilterOperator =
   | 'is' | 'is_not' | 'contains' | 'does_not_contain' | 'starts_with' | 'ends_with' | 'is_empty' | 'is_not_empty'
@@ -190,19 +190,19 @@ function buildConditionFilter(condition: FilterCondition): Record<string, unknow
       break
     case 'contains':
       if (normalizeSingleValue(condition.value) === null) return null
-      filter[condition.field] = { $ilike: `%${escapeLikePattern(String(normalizeSingleValue(condition.value)))}%` }
+      filter[condition.field] = { $ilike: buildIlikeTerm(String(normalizeSingleValue(condition.value))) }
       break
     case 'does_not_contain':
       if (normalizeSingleValue(condition.value) === null) return null
-      filter[condition.field] = { $not: { $ilike: `%${escapeLikePattern(String(normalizeSingleValue(condition.value)))}%` } }
+      filter[condition.field] = { $not: { $ilike: buildIlikeTerm(String(normalizeSingleValue(condition.value))) } }
       break
     case 'starts_with':
       if (normalizeSingleValue(condition.value) === null) return null
-      filter[condition.field] = { $ilike: `${escapeLikePattern(String(normalizeSingleValue(condition.value)))}%` }
+      filter[condition.field] = { $ilike: buildIlikeTerm(String(normalizeSingleValue(condition.value)), 'startsWith') }
       break
     case 'ends_with':
       if (normalizeSingleValue(condition.value) === null) return null
-      filter[condition.field] = { $ilike: `%${escapeLikePattern(String(normalizeSingleValue(condition.value)))}` }
+      filter[condition.field] = { $ilike: buildIlikeTerm(String(normalizeSingleValue(condition.value)), 'endsWith') }
       break
     case 'is_empty':
       filter[condition.field] = { $exists: false }


### PR DESCRIPTION
Fixes #2367

## Problem
- The `{ $ilike: \`%${escapeLikePattern(term)}%\` }` search-term pattern was reimplemented inline across 15+ routes (some via intermediate `const like = ...`, some inline), with three shape variants (contains / startsWith / endsWith) hand-rolled each time. One route (`payment_gateways/api/transactions`) even shipped its own private `escapeLikePattern` copy.

## Root Cause
- No shared helper existed for building an escaped LIKE term, so every search route open-coded the wildcard wrapping around `escapeLikePattern`.

## What Changed
- Added `buildIlikeTerm(value, mode?)` in `@open-mercato/shared/lib/db/buildIlikeTerm` — escapes LIKE metacharacters once (via the existing `escapeLikePattern`) and wraps wildcards by `mode` (`contains` default, `startsWith`, `endsWith`).
- Adopted it in the issue-named sample routes (`sales/api/documents/factory`, `resources/api/resources`, `attachments/api/library`) and the customers people/companies search + email filters (covering the `startsWith` mode).
- Adopted it in the shared advanced-filter builders (`advanced-filter.ts`, `advanced-filter-tree.ts`), which exercise all three modes plus `$not` wrapping.
- Removed the duplicate private `escapeLikePattern` in `payment_gateways/api/transactions/route.ts` (equivalent escaping) in favor of the shared helper.
- Remaining call sites can adopt the helper incrementally, as the issue suggests.

## Tests
- New `packages/shared/src/lib/db/__tests__/buildIlikeTerm.test.ts` (7 cases): default contains, equivalence to the legacy inline pattern, startsWith/endsWith modes, metacharacter escaping (`%`, `_`, `\\`), and empty-term behavior.
- Existing advanced-filter suites (102 tests) confirm the migrated builders produce byte-identical output.
- Full gate: `yarn build:packages`, `yarn generate`, `yarn typecheck` (21/21), `yarn workspace @open-mercato/shared test` (1233), core tests for touched modules (1297), `yarn build:app` — all green. (`yarn lint` fails only in `@open-mercato/app` due to a pre-existing broken eslint-plugin-react env issue, unrelated to this change.)

## Backward Compatibility
- Additive only: new helper + new export path. No API response fields, event IDs, DI names, ACL features, or import paths removed. The removed `escapeLikePattern` in payment_gateways was a file-local, non-exported function — not a contract surface.