### PR TITLE
refactor(ui): share formatCurrency/formatDate for AI record cards (#2365)

### DIFF
--- a/packages/ui/src/ai/records/ActivityCard.tsx
+++ b/packages/ui/src/ai/records/ActivityCard.tsx
@@ -15,13 +15,7 @@ import type { LucideIcon } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { KeyValueList, RecordCardShell, TagRow, statusToTagVariant } from './RecordCardShell'
 import type { ActivityRecordPayload } from './types'
-
-function formatDate(value: string | null | undefined): string | null {
-  if (!value) return null
-  const d = new Date(value)
-  if (Number.isNaN(d.getTime())) return value
-  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
-}
+import { formatDate } from '../../utils/format'
 
 function pickActivityIcon(type: string | null | undefined): LucideIcon {
   if (!type) return ActivityIcon

--- a/packages/ui/src/ai/records/DealCard.tsx
+++ b/packages/ui/src/ai/records/DealCard.tsx
@@ -5,31 +5,7 @@ import { Briefcase, Building2, CalendarDays, CircleDollarSign, User } from 'luci
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { KeyValueList, RecordCardShell, TagRow, statusToTagVariant } from './RecordCardShell'
 import type { DealRecordPayload } from './types'
-
-function formatAmount(amount: string | number | null | undefined, currency?: string | null): string | null {
-  if (amount === null || amount === undefined || amount === '') return null
-  const value = typeof amount === 'number' ? amount : Number(amount)
-  if (!Number.isFinite(value)) {
-    return typeof amount === 'string' ? amount : null
-  }
-  const code = currency && currency.length === 3 ? currency.toUpperCase() : undefined
-  try {
-    if (code) {
-      return new Intl.NumberFormat(undefined, { style: 'currency', currency: code }).format(value)
-    }
-  } catch {
-    // fall through to fallback
-  }
-  const formatted = new Intl.NumberFormat().format(value)
-  return code ? `${formatted} ${code}` : formatted
-}
-
-function formatDate(value: string | null | undefined): string | null {
-  if (!value) return null
-  const d = new Date(value)
-  if (Number.isNaN(d.getTime())) return value
-  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
-}
+import { formatCurrency, formatDate } from '../../utils/format'
 
 export interface DealCardProps extends DealRecordPayload {}
 
@@ -39,7 +15,7 @@ export function DealCard(props: DealCardProps) {
     ? { label: props.status, variant: statusToTagVariant(props.status) }
     : null
   const stage = props.stage && props.stage !== props.status ? props.stage : null
-  const amount = formatAmount(props.amount, props.currency)
+  const amount = formatCurrency(props.amount, props.currency)
   const closeDate = formatDate(props.closeDate)
 
   const items = [

--- a/packages/ui/src/ai/records/ProductCard.tsx
+++ b/packages/ui/src/ai/records/ProductCard.tsx
@@ -5,24 +5,7 @@ import { Package, Tag as TagIcon } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { KeyValueList, RecordCardShell, TagRow, statusToTagVariant } from './RecordCardShell'
 import type { ProductRecordPayload } from './types'
-
-function formatPrice(price: string | number | null | undefined, currency?: string | null): string | null {
-  if (price === null || price === undefined || price === '') return null
-  const value = typeof price === 'number' ? price : Number(price)
-  if (!Number.isFinite(value)) {
-    return typeof price === 'string' ? price : null
-  }
-  const code = currency && currency.length === 3 ? currency.toUpperCase() : undefined
-  try {
-    if (code) {
-      return new Intl.NumberFormat(undefined, { style: 'currency', currency: code }).format(value)
-    }
-  } catch {
-    // fall through
-  }
-  const formatted = new Intl.NumberFormat().format(value)
-  return code ? `${formatted} ${code}` : formatted
-}
+import { formatCurrency } from '../../utils/format'
 
 export interface ProductCardProps extends ProductRecordPayload {}
 
@@ -31,7 +14,7 @@ export function ProductCard(props: ProductCardProps) {
   const status = props.status
     ? { label: props.status, variant: statusToTagVariant(props.status) }
     : null
-  const price = formatPrice(props.price, props.currency)
+  const price = formatCurrency(props.price, props.currency)
 
   const leading = props.imageUrl ? (
     <div className="relative size-12 overflow-hidden rounded-md border border-border bg-muted">

--- a/packages/ui/src/utils/__tests__/format.test.ts
+++ b/packages/ui/src/utils/__tests__/format.test.ts
@@ -1,0 +1,58 @@
+import { formatCurrency, formatDate } from '../format'
+
+describe('formatCurrency', () => {
+  it('returns null for empty input', () => {
+    expect(formatCurrency(null)).toBeNull()
+    expect(formatCurrency(undefined)).toBeNull()
+    expect(formatCurrency('')).toBeNull()
+  })
+
+  it('echoes back a non-numeric string', () => {
+    expect(formatCurrency('n/a')).toBe('n/a')
+  })
+
+  it('returns null for a non-finite number', () => {
+    expect(formatCurrency(Number.NaN)).toBeNull()
+  })
+
+  it('formats a numeric value with an ISO currency code', () => {
+    const result = formatCurrency(1234.5, 'usd')
+    expect(result).toMatch(/1,234\.5/)
+    expect(result).toMatch(/\$|USD/)
+  })
+
+  it('formats a numeric string the same as a number', () => {
+    expect(formatCurrency('1234.5', 'USD')).toBe(formatCurrency(1234.5, 'USD'))
+  })
+
+  it('falls back to a plain number without a currency code', () => {
+    expect(formatCurrency(1000)).toBe(new Intl.NumberFormat().format(1000))
+  })
+
+  it('ignores currency codes that are not three characters', () => {
+    expect(formatCurrency(1000, 'US')).toBe(new Intl.NumberFormat().format(1000))
+  })
+})
+
+describe('formatDate', () => {
+  it('returns null for empty input', () => {
+    expect(formatDate(null)).toBeNull()
+    expect(formatDate(undefined)).toBeNull()
+    expect(formatDate('')).toBeNull()
+  })
+
+  it('echoes back an unparseable date', () => {
+    expect(formatDate('not-a-date')).toBe('not-a-date')
+  })
+
+  it('formats a valid ISO date as a localized short date', () => {
+    const result = formatDate('2026-06-09T00:00:00.000Z')
+    expect(result).toEqual(
+      new Date('2026-06-09T00:00:00.000Z').toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      }),
+    )
+  })
+})

--- a/packages/ui/src/utils/format.ts
+++ b/packages/ui/src/utils/format.ts
@@ -1,0 +1,40 @@
+/**
+ * Format a monetary value with an optional ISO-4217 currency code.
+ *
+ * Returns `null` for empty input, the original string for non-numeric input,
+ * and falls back to a plain number format (optionally suffixed with the code)
+ * when the currency code is missing or rejected by `Intl.NumberFormat`.
+ */
+export function formatCurrency(
+  value: string | number | null | undefined,
+  currency?: string | null,
+): string | null {
+  if (value === null || value === undefined || value === '') return null
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) {
+    return typeof value === 'string' ? value : null
+  }
+  const code = currency && currency.length === 3 ? currency.toUpperCase() : undefined
+  try {
+    if (code) {
+      return new Intl.NumberFormat(undefined, { style: 'currency', currency: code }).format(numeric)
+    }
+  } catch {
+    // fall through to plain number formatting
+  }
+  const formatted = new Intl.NumberFormat().format(numeric)
+  return code ? `${formatted} ${code}` : formatted
+}
+
+/**
+ * Format an ISO date string as a localized short date (e.g. `Jun 9, 2026`).
+ *
+ * Returns `null` for empty input and echoes the original value back when it is
+ * not a parseable date.
+ */
+export function formatDate(value: string | null | undefined): string | null {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}


### PR DESCRIPTION
Fixes #2365

## Problem
- `formatPrice` (ProductCard) and `formatAmount` (DealCard) were byte-for-byte identical `Intl.NumberFormat` currency helpers.
- `formatDate` was duplicated verbatim in DealCard and ActivityCard.

## Root Cause
- Each AI record card defined its own private formatting helper instead of sharing one implementation — a DRY violation flagged in a monorepo audit.

## What Changed
- Added `packages/ui/src/utils/format.ts` exporting `formatCurrency(value, currency?)` and `formatDate(value)` (behavior preserved exactly from the originals).
- `ProductCard`, `DealCard`, and `ActivityCard` now import the shared helpers and drop their local copies.

## Tests
- New `packages/ui/src/utils/__tests__/format.test.ts` covers empty/non-numeric/NaN handling, ISO-currency formatting, short-/invalid-length currency codes, plain-number fallback, and date parse/echo (10 cases).
- `yarn jest src/ai` (22 suites / 146 tests) and `yarn typecheck` for `@open-mercato/ui` both pass.

## Backward Compatibility
- No contract surface changes. The extracted helpers are internal; component props are unchanged and the new file is not added to the package's public export map.