### PR TITLE
fix(shared): batch encrypted custom-field decryption with Promise.all (#2229)

### DIFF
--- a/packages/shared/src/lib/crud/__tests__/custom-fields.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/custom-fields.test.ts
@@ -243,6 +243,97 @@ describe('loadCustomFieldValues (encryption)', () => {
     })
     expect(values['rec-1'].cf_priority).toBe(42)
   })
+
+  it('decrypts rows concurrently rather than sequentially (regression: issue #2229)', async () => {
+    const deks: Record<string, string> = {
+      'tenant-1': Buffer.alloc(32, 1).toString('base64'),
+      'tenant-2': Buffer.alloc(32, 2).toString('base64'),
+      'tenant-3': Buffer.alloc(32, 3).toString('base64'),
+    }
+    const rows = [
+      { recordId: 'rec-1', tenantId: 'tenant-1', plaintext: 'note-1' },
+      { recordId: 'rec-2', tenantId: 'tenant-2', plaintext: 'note-2' },
+      { recordId: 'rec-3', tenantId: 'tenant-3', plaintext: 'note-3' },
+    ].map((row) => ({
+      ...row,
+      valueText: encryptWithAesGcm(row.plaintext, deks[row.tenantId]).value,
+    }))
+    const em = {
+      find: jest.fn().mockImplementation((_, where) => {
+        if ((where as any).recordId) {
+          return Promise.resolve(
+            rows.map((row) => ({
+              recordId: row.recordId,
+              fieldKey: 'note',
+              organizationId: null,
+              tenantId: row.tenantId,
+              valueText: row.valueText,
+              valueMultiline: null,
+              valueInt: null,
+              valueFloat: null,
+              valueBool: null,
+              deletedAt: null,
+            })),
+          )
+        }
+        return Promise.resolve([
+          { key: 'note', entityId: 'demo:entity', organizationId: null, tenantId: null, kind: 'text', configJson: { encrypted: true }, isActive: true },
+        ])
+      }),
+    }
+    let inFlight = 0
+    let maxInFlight = 0
+    const mockService = {
+      isEnabled: () => true,
+      getDek: jest.fn(async (tenantId: string) => {
+        inFlight += 1
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        inFlight -= 1
+        return { key: deks[tenantId] }
+      }),
+    }
+    const values = await loadCustomFieldValues({
+      em: em as any,
+      entityId: 'demo:entity',
+      recordIds: ['rec-1', 'rec-2', 'rec-3'],
+      tenantIdByRecord: { 'rec-1': 'tenant-1', 'rec-2': 'tenant-2', 'rec-3': 'tenant-3' },
+      encryptionService: mockService as any,
+    })
+    expect(values['rec-1'].cf_note).toBe('note-1')
+    expect(values['rec-2'].cf_note).toBe('note-2')
+    expect(values['rec-3'].cf_note).toBe('note-3')
+    // Sequential await-in-loop would cap concurrency at 1; batching lifts it.
+    expect(maxInFlight).toBeGreaterThan(1)
+  })
+
+  it('preserves multi-value grouping order for encrypted fields (regression: issue #2229)', async () => {
+    const dek = Buffer.alloc(32, 2).toString('base64')
+    const first = encryptWithAesGcm('alpha', dek).value
+    const second = encryptWithAesGcm('beta', dek).value
+    const em = {
+      find: jest.fn().mockImplementation((_, where) => {
+        if ((where as any).recordId) {
+          return Promise.resolve([
+            { recordId: 'rec-1', fieldKey: 'tags', organizationId: null, tenantId: 'tenant-1', valueText: first, valueMultiline: null, valueInt: null, valueFloat: null, valueBool: null, deletedAt: null },
+            { recordId: 'rec-1', fieldKey: 'tags', organizationId: null, tenantId: 'tenant-1', valueText: second, valueMultiline: null, valueInt: null, valueFloat: null, valueBool: null, deletedAt: null },
+          ])
+        }
+        return Promise.resolve([
+          { key: 'tags', entityId: 'demo:entity', organizationId: null, tenantId: 'tenant-1', kind: 'text', configJson: { encrypted: true, multi: true }, isActive: true },
+        ])
+      }),
+    }
+    const mockService = { isEnabled: () => true, getDek: async () => ({ key: dek }) }
+    const values = await loadCustomFieldValues({
+      em: em as any,
+      entityId: 'demo:entity',
+      recordIds: ['rec-1'],
+      tenantIdByRecord: { 'rec-1': 'tenant-1' },
+      encryptionService: mockService as any,
+    })
+    expect(values['rec-1'].cf_tags).toEqual(['alpha', 'beta'])
+  })
 })
 
 describe('decorateRecordWithCustomFields', () => {

--- a/packages/shared/src/lib/crud/custom-fields.ts
+++ b/packages/shared/src/lib/crud/custom-fields.ts
@@ -632,7 +632,7 @@ export async function loadCustomFieldValues(opts: {
   type Bucket = { orgId: string | null; tenantId: string | null; values: unknown[]; def?: CustomFieldDef | null; encrypted?: boolean }
   const buckets = new Map<string, Bucket>()
 
-  for (const row of cfRows) {
+  const rowInfos = cfRows.map((row) => {
     const recordId = String(row.recordId)
     const key = String(row.fieldKey)
     const bucketKey = `${recordId}::${key}`
@@ -643,26 +643,39 @@ export async function loadCustomFieldValues(opts: {
     const def = pickDefinition(key, resolvedOrgId, resolvedTenantId)
     const encrypted = Boolean(def?.configJson && (def as any).configJson?.encrypted)
     const value = valueFromRow(row)
-    const decrypted = encrypted
-      ? await decryptCustomFieldValue(
-          value,
-          resolvedTenantId ?? tenantId ?? null,
-          getEncryptionService(),
-          encryptionCache,
-          { kind: def?.kind ?? null },
-        )
-      : value
-    const existing = buckets.get(bucketKey)
+    return { bucketKey, resolvedOrgId, resolvedTenantId, tenantId, def, encrypted, value }
+  })
+
+  // Decrypt every encrypted value concurrently so a list of N rows × M encrypted
+  // fields costs the slowest single decryption rather than the sum (issue #2229).
+  // The shared encryptionCache keeps DEK lookups deduped per tenant.
+  const decryptedValues = await Promise.all(
+    rowInfos.map((info) =>
+      info.encrypted
+        ? decryptCustomFieldValue(
+            info.value,
+            info.resolvedTenantId ?? info.tenantId ?? null,
+            getEncryptionService(),
+            encryptionCache,
+            { kind: info.def?.kind ?? null },
+          )
+        : info.value,
+    ),
+  )
+
+  rowInfos.forEach((info, index) => {
+    const decrypted = decryptedValues[index]
+    const existing = buckets.get(info.bucketKey)
     if (existing) {
-      if (existing.orgId == null && resolvedOrgId) existing.orgId = resolvedOrgId
-      if (existing.tenantId == null && resolvedTenantId) existing.tenantId = resolvedTenantId
-      if (existing.def == null && def) existing.def = def
-      existing.encrypted = existing.encrypted || encrypted
+      if (existing.orgId == null && info.resolvedOrgId) existing.orgId = info.resolvedOrgId
+      if (existing.tenantId == null && info.resolvedTenantId) existing.tenantId = info.resolvedTenantId
+      if (existing.def == null && info.def) existing.def = info.def
+      existing.encrypted = existing.encrypted || info.encrypted
       existing.values.push(decrypted)
     } else {
-      buckets.set(bucketKey, { orgId: resolvedOrgId, tenantId: resolvedTenantId, values: [decrypted], def: def ?? null, encrypted })
+      buckets.set(info.bucketKey, { orgId: info.resolvedOrgId, tenantId: info.resolvedTenantId, values: [decrypted], def: info.def ?? null, encrypted: info.encrypted })
     }
-  }
+  })
 
   const result: Record<string, Record<string, unknown>> = {}
   for (const [compoundKey, bucket] of buckets.entries()) {


### PR DESCRIPTION
Fixes #2229

## Problem
- `loadCustomFieldValues` (the list-decoration hot path used by `customers/*` and any catalog/sales list with encrypted custom fields) decrypted encrypted custom-field values **one row at a time** with a sequential `await` inside the bucket-assembly loop. For a list of N rows × M encrypted custom fields this serialized N×M decryption round-trips instead of running them as a parallel batch.

## Root Cause
- `packages/shared/src/lib/crud/custom-fields.ts` resolved metadata, awaited `decryptCustomFieldValue`, and assembled buckets all inside a single `for…of` loop, so every encrypted value blocked the loop until its decryption resolved.

## What Changed
- Split the loop into three phases in `loadCustomFieldValues`:
  1. Resolve per-row metadata (record/field/bucket key, org/tenant, definition, encrypted flag, raw value) in a `map`.
  2. Decrypt all encrypted values concurrently via `await Promise.all(...)`. DEK lookups still flow through the shared `encryptionCache`, so per-tenant key resolution stays deduped.
  3. Assemble buckets in the **original row order** so multi-value / `multi` grouping is byte-for-byte unchanged.
- No signature, return-shape, or contract change. The non-encrypted path stays a plain pass-through.

## Tests
- `packages/shared/src/lib/crud/__tests__/custom-fields.test.ts`:
  - New regression test asserts decryption now runs **concurrently** (max in-flight DEK resolutions > 1 across 3 distinct tenants) — fails on the old sequential code.
  - New regression test asserts multi-value grouping order is preserved for encrypted fields (`['alpha','beta']`).
  - Existing encryption decode tests (string/numeric-text/typed-integer) still pass.
- Ran: `yarn workspace @open-mercato/shared test` (custom-fields suites, 24 passing), `yarn workspace @open-mercato/shared build`, `yarn workspace @open-mercato/shared typecheck` — all green.

## Backward Compatibility
- No contract surface changes. Decoded values are identical; only decryption scheduling changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)