### PR TITLE
perf(sales): trim detail-only JSONB snapshots from document list projection (#2233)

### DIFF
--- a/apps/docs/docs/framework/api/crud-factory.mdx
+++ b/apps/docs/docs/framework/api/crud-factory.mdx
@@ -184,6 +184,40 @@ list: {
 }
 ```
 
+#### Per-request projection (function-form `fields`)
+
+`fields` accepts either a static array or a function `(query, ctx) => string[]` that resolves the projection per request. The function form lets a route narrow the columns the Query Engine selects based on the validated query — most usefully to drop large detail-only columns (encrypted JSONB snapshots, payload blobs) from grid listings while still selecting them for single-record fetches.
+
+This matters because those columns are fetched over the wire **and decrypted per row** for every list page even when no grid column renders them; the cost scales with row width × page size.
+
+```ts
+const detailOnlyColumns = new Set([
+  'billing_address_snapshot',
+  'shipping_address_snapshot',
+  'totals_snapshot',
+  'metadata',
+]);
+
+const allFields = ['id', 'number', 'status', 'customer_snapshot', ...detailOnlyColumns];
+const gridFields = allFields.filter((field) => !detailOnlyColumns.has(field));
+
+list: {
+  schema: listSchema,
+  entityId: E.sales.sales_order,
+  // The detail page fetches a single record through this same list route with an
+  // `?id=` filter (there is no separate detail endpoint), so it needs the full
+  // projection. Grid listings (no `id`) use the trimmed projection.
+  fields: (query) =>
+    typeof query.id === 'string' && query.id.length ? allFields : gridFields,
+}
+```
+
+Notes:
+
+- The function is resolved on the Query Engine path only (the route must set both `entityId` and `fields`). The array form is fully backward compatible — pass an array whenever the projection is static.
+- Keep response keys stable. Dropped columns still serialize (e.g. as `null` via `transformItem`), so the wire contract / OpenAPI schema stays unchanged as long as those response fields are already `nullable().optional()`.
+- Only narrow columns the list view never renders. Keep any column the grid derives a displayed value from (for sales documents, `customer_snapshot` is kept because the grid renders the customer name/email from it).
+
 #### Advanced Filtering with `buildFilters`
 
 The `buildFilters` function transforms query parameters into Query Engine compatible filters:
@@ -459,6 +493,8 @@ The factory automatically:
 - Supports batch export operations
 - Caches custom field definitions
 - Parallelizes custom field loading
+
+Routes can further trim per-request work by passing a [function-form `fields`](#per-request-projection-function-form-fields) projection that drops large detail-only columns from grid listings, avoiding fetching and decrypting blobs the list never renders.
 
 ### Export Performance
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -151,6 +151,23 @@ makeCrudRoute({
 })
 ```
 
+#### Trimming the list projection (`list.fields` function form)
+
+`list.fields` accepts a static array **or** a function `(query, ctx) => string[]` resolved per request on the Query Engine path. Use the function form to drop large detail-only columns (encrypted JSONB snapshots, payload blobs) from grid listings while still selecting them for single-record fetches — those columns are otherwise fetched and decrypted **per row** on every list page even when no grid column renders them.
+
+```typescript
+list: {
+  entityId: E.sales.sales_order,
+  // Detail page reuses this list route with `?id=`, so it needs the full projection;
+  // grid listings (no id) get the trimmed one.
+  fields: (query) => (typeof query.id === 'string' && query.id.length ? allFields : gridFields),
+}
+```
+
+- The array form is unchanged and fully backward compatible — use it whenever the projection is static.
+- Keep response keys stable: dropped columns must still serialize (e.g. `null` via `transformItem`) so the OpenAPI schema (already `nullable().optional()`) is preserved.
+- Only narrow columns the grid never renders; keep any column a list column derives a value from (e.g. `customer_snapshot` for the customer name/email column). Reference: `src/modules/sales/api/documents/factory.ts` (#2233). Full docs: [`apps/docs/docs/framework/api/crud-factory.mdx`](../../apps/docs/docs/framework/api/crud-factory.mdx) → "Per-request projection".
+
 ### Custom Entities CRUD
 
 Follow the customers module API patterns (CRUD factory + query engine):

--- a/packages/core/src/modules/sales/api/__tests__/documents.factory.test.ts
+++ b/packages/core/src/modules/sales/api/__tests__/documents.factory.test.ts
@@ -95,4 +95,80 @@ describe('buildDocumentCrudOptions', () => {
       expect(filters).toEqual({})
     })
   })
+
+  describe('list projection (#2233)', () => {
+    const orderBinding = {
+      kind: 'order' as const,
+      entity: SalesOrder,
+      entityId: E.sales.sales_order,
+      numberField: 'orderNumber' as const,
+      createCommandId: 'sales.orders.create',
+      updateCommandId: 'sales.orders.update',
+      deleteCommandId: 'sales.orders.delete',
+      manageFeature: 'sales.orders.manage',
+      viewFeature: 'sales.orders.view',
+    }
+
+    const detailOnlySnapshotColumns = [
+      'billing_address_snapshot',
+      'shipping_address_snapshot',
+      'shipping_method_snapshot',
+      'payment_method_snapshot',
+      'totals_snapshot',
+      'metadata',
+    ]
+
+    const resolveFields = (query: Record<string, unknown>): string[] => {
+      const options = buildDocumentCrudOptions(orderBinding)
+      const fields = options.list.fields
+      expect(typeof fields).toBe('function')
+      return (fields as (q: any) => string[])(query)
+    }
+
+    it('drops large detail-only JSONB snapshot columns from grid listings', () => {
+      const gridFields = resolveFields({})
+      for (const column of detailOnlySnapshotColumns) {
+        expect(gridFields).not.toContain(column)
+      }
+    })
+
+    it('keeps customer_snapshot in grid listings (grid renders customer name/email)', () => {
+      const gridFields = resolveFields({})
+      expect(gridFields).toContain('customer_snapshot')
+    })
+
+    it('keeps the scalar columns the grid renders', () => {
+      const gridFields = resolveFields({})
+      for (const column of [
+        'id',
+        'order_number',
+        'status',
+        'channel_id',
+        'currency_code',
+        'line_item_count',
+        'grand_total_net_amount',
+        'grand_total_gross_amount',
+        'placed_at',
+        'created_at',
+        'updated_at',
+      ]) {
+        expect(gridFields).toContain(column)
+      }
+    })
+
+    it('returns the full projection (including detail-only snapshots) for single-document fetches', () => {
+      const detailFields = resolveFields({ id: '11111111-1111-1111-1111-111111111111' })
+      for (const column of detailOnlySnapshotColumns) {
+        expect(detailFields).toContain(column)
+      }
+      expect(detailFields).toContain('customer_snapshot')
+    })
+
+    it('does not narrow the projection when filtering a grid by customerId (multiple rows)', () => {
+      const gridFields = resolveFields({ customerId: '22222222-2222-2222-2222-222222222222' })
+      for (const column of detailOnlySnapshotColumns) {
+        expect(gridFields).not.toContain(column)
+      }
+    })
+  })
 })

--- a/packages/core/src/modules/sales/api/documents/factory.ts
+++ b/packages/core/src/modules/sales/api/documents/factory.ts
@@ -344,6 +344,27 @@ export function buildDocumentCrudOptions(binding: DocumentBinding) {
     ...(binding.kind === 'order' ? orderOnlyFields : quoteOnlyFields),
   ]
 
+  // Large JSONB snapshot/payload columns that only the detail page renders. The
+  // grid never reads them, so selecting them for list pages fetches and decrypts
+  // blobs over the wire for nothing (#2233). `customer_snapshot` is intentionally
+  // kept because the grid derives the customer name/email column from it.
+  const detailOnlyProjectionFields = new Set([
+    'billing_address_snapshot',
+    'shipping_address_snapshot',
+    'shipping_method_snapshot',
+    'payment_method_snapshot',
+    'totals_snapshot',
+    'metadata',
+  ])
+
+  const gridFields = listFields.filter((field) => !detailOnlyProjectionFields.has(field))
+
+  // The detail page fetches a single document through this same list route with an
+  // `?id=` filter (there is no separate detail endpoint), so it needs the full
+  // projection. Grid listings (no `id`) use the trimmed projection.
+  const resolveListFields = (query: ListQuery) =>
+    query && typeof query.id === 'string' && query.id.length ? listFields : gridFields
+
   return {
     metadata: routeMetadata,
     orm: {
@@ -359,7 +380,7 @@ export function buildDocumentCrudOptions(binding: DocumentBinding) {
     list: {
       schema: listSchema,
       entityId: binding.entityId,
-      fields: listFields,
+      fields: (query: ListQuery) => resolveListFields(query),
       sortFieldMap: buildSortMap(numberColumn),
       buildFilters: async (query: any) => buildFilters(query, numberColumn, binding.kind),
       decorateCustomFields: { entityIds: [binding.entityId] },

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -335,6 +335,32 @@ describe('CRUD Factory', () => {
     })
   })
 
+  it('GET resolves a function-form list.fields projection per request (#2233)', async () => {
+    const fieldsResolver = jest.fn((query: any) =>
+      query?.id ? ['id', 'title', 'is_done', 'snapshot'] : ['id', 'title'],
+    )
+    const projectionRoute = makeCrudRoute({
+      metadata: { GET: { requireAuth: true } },
+      orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+      indexer: { entityType: 'example.todo' },
+      list: {
+        schema: querySchema.extend({ id: z.string().optional() }),
+        entityId: 'example.todo',
+        fields: fieldsResolver,
+        buildFilters: () => ({} as any),
+      },
+    })
+
+    await projectionRoute.GET(new Request('http://x/api/example/todos?page=1&pageSize=10&sortField=id&sortDir=asc'))
+    const gridArgs = queryEngine.query.mock.calls.at(-1)?.[1]
+    expect(gridArgs?.fields).toEqual(['id', 'title'])
+
+    await projectionRoute.GET(new Request('http://x/api/example/todos?page=1&pageSize=10&sortField=id&sortDir=asc&id=abc'))
+    const detailArgs = queryEngine.query.mock.calls.at(-1)?.[1]
+    expect(detailArgs?.fields).toEqual(['id', 'title', 'is_done', 'snapshot'])
+    expect(fieldsResolver).toHaveBeenCalled()
+  })
+
   it('GET normalizes custom field sort selectors for the query engine path', async () => {
     await route.GET(new Request('http://x/api/example/todos?page=1&pageSize=10&sortField=cf_priority&sortDir=desc'))
 

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -189,9 +189,13 @@ export type CrudListCustomFieldDecorator = {
 
 export type ListConfig<TList> = {
   schema: z.ZodType<TList>
-  // Optional: use the QueryEngine when entityId + fields are provided
+  // Optional: use the QueryEngine when entityId + fields are provided.
+  // A function form lets a route narrow the projection per request — e.g. drop
+  // large detail-only JSONB columns from grid listings while still selecting
+  // them for single-document fetches (`?id=`). Returning fewer columns avoids
+  // fetching and decrypting blobs the list never renders (#2233).
   entityId?: any
-  fields?: any[]
+  fields?: any[] | ((query: TList, ctx: CrudCtx) => any[])
   sortFieldMap?: Record<string, any>
   buildFilters?: (query: TList, ctx: CrudCtx) => Where<any> | Promise<Where<any>>
   transformItem?: (item: any) => any
@@ -1654,8 +1658,11 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
           finishProfile({ result: 'empty_scope', cacheStatus, itemCount: 0, total: 0 })
           return response
         }
+        const resolvedListFields = typeof opts.list.fields === 'function'
+          ? (opts.list.fields as (query: any, ctx: CrudCtx) => any[])(validated as any, ctx)
+          : opts.list.fields
         const queryOpts: any = {
-          fields: opts.list.fields!,
+          fields: resolvedListFields!,
           includeCustomFields: true,
           sort,
           page,


### PR DESCRIPTION
Fixes #2233

## Problem
Query-engine list queries selected every column shared by the sales document list/detail views — including large encrypted JSONB snapshot/payload columns (`billing_address_snapshot`, `shipping_address_snapshot`, `shipping_method_snapshot`, `payment_method_snapshot`, `totals_snapshot`, `metadata`). Those blobs were fetched over the wire and decrypted **per row** for every grid page even though no list column renders them; the cost scales with row width × page size.

## Root Cause
The sales documents factory passed a single static `list.fields` projection containing all snapshot columns. Because the detail page reuses the same list route with an `?id=` filter (there is **no** separate detail endpoint), the snapshots couldn't simply be removed — the detail view depends on them. So both list and detail paid the full projection cost.

## What Changed
- `packages/shared/src/lib/crud/factory.ts`: `ListConfig.fields` now also accepts a `(query, ctx) => fields` function. The query-engine path resolves it per request before building query options. Array form is unchanged (fully backward compatible).
- `packages/core/src/modules/sales/api/documents/factory.ts`: the documents list now returns
  - the **full** projection (incl. all snapshots) for single-document fetches (`?id=` present — the detail page), and
  - a **trimmed** grid projection that drops the six detail-only JSONB columns. `customer_snapshot` is intentionally kept because the grid derives the customer name/email column from it.

Grid list responses keep all response keys (the dropped snapshots serialize as `null` via the existing `transformItem`), so the wire contract / OpenAPI schema (already `nullable().optional()`) is preserved; the detail view is unaffected.

## Tests
- `packages/core/.../documents.factory.test.ts`: asserts the grid projection drops the detail-only snapshots, keeps `customer_snapshot` + the rendered scalar columns, returns the full projection for `?id=` fetches, and does not narrow when filtering a grid by `customerId`.
- `packages/shared/.../crud-factory.test.ts`: asserts a function-form `list.fields` is resolved per request and the resolved columns reach `queryEngine.query`.
- Ran: `yarn workspace @open-mercato/core test` (documents factory) + `yarn workspace @open-mercato/shared test` (crud factory), `yarn generate`, `yarn build:packages`, `yarn typecheck` — all green.

## Backward Compatibility
- Additive contract change only: `ListConfig.fields` gains a function overload; existing array usage is untouched.
- No API response fields removed (dropped grid snapshots serialize as `null`, schema already optional/nullable). No event IDs, DI names, import paths, or DB schema changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)