### PR TITLE
fix(ai_assistant): load generated AI tools + API route manifest in standalone MCP servers

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/generated-registry-loader.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/generated-registry-loader.test.ts
@@ -1,0 +1,140 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import * as registry from '@open-mercato/shared/modules/registry'
+import {
+  rewriteGeneratedAliasImports,
+  findGeneratedFile,
+  ensureApiRouteManifestsRegistered,
+} from '../generated-registry-loader'
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'om-gen-loader-'))
+}
+
+describe('rewriteGeneratedAliasImports', () => {
+  // Regression for the MCP dev-server crash:
+  //   "Cannot find package '@/.mercato' imported from .../tool-loader.js"
+  // Generated registries use the Next.js `@/` alias, which a standalone Node
+  // process cannot resolve. The rewrite turns it into an absolute file URL.
+
+  it('rewrites a static `from "@/..."` import to an absolute file URL', () => {
+    const appRoot = makeTempDir()
+    const out = rewriteGeneratedAliasImports(
+      `import { x } from '@/.mercato/generated/entities'`,
+      appRoot,
+    )
+    const expectedUrl = pathToFileURL(
+      path.join(appRoot, '.mercato/generated/entities'),
+    ).href
+    expect(out).toBe(`import { x } from ${JSON.stringify(expectedUrl)}`)
+    expect(out).not.toContain('@/')
+  })
+
+  it('rewrites a dynamic `import("@/...")` call to an absolute file URL', () => {
+    const appRoot = makeTempDir()
+    const out = rewriteGeneratedAliasImports(
+      `const tools = () => import("@/.mercato/generated/ai-tools.generated")`,
+      appRoot,
+    )
+    const expectedUrl = pathToFileURL(
+      path.join(appRoot, '.mercato/generated/ai-tools.generated'),
+    ).href
+    expect(out).toBe(`const tools = () => import(${JSON.stringify(expectedUrl)})`)
+    expect(out).not.toContain('@/')
+  })
+
+  it('appends `.ts` when the aliased target exists only as a TypeScript file', () => {
+    const appRoot = makeTempDir()
+    fs.mkdirSync(path.join(appRoot, 'src'), { recursive: true })
+    fs.writeFileSync(path.join(appRoot, 'src', 'thing.ts'), 'export const a = 1\n')
+
+    const out = rewriteGeneratedAliasImports(`import x from '@/src/thing'`, appRoot)
+
+    const expectedUrl = pathToFileURL(path.join(appRoot, 'src', 'thing.ts')).href
+    expect(out).toBe(`import x from ${JSON.stringify(expectedUrl)}`)
+  })
+
+  it('leaves non-alias imports untouched', () => {
+    const source = [
+      `import { z } from 'zod'`,
+      `import x from './local'`,
+      `import y from '@open-mercato/shared/x'`,
+    ].join('\n')
+    expect(rewriteGeneratedAliasImports(source, makeTempDir())).toBe(source)
+  })
+})
+
+describe('findGeneratedFile', () => {
+  let cwdSpy: jest.SpyInstance
+
+  afterEach(() => {
+    cwdSpy?.mockRestore()
+  })
+
+  it('returns null when the file exists nowhere on the search path', () => {
+    // A name that cannot exist anywhere up the tree or under cwd.
+    expect(findGeneratedFile('definitely-not-real-xyz.generated.ts')).toBeNull()
+  })
+
+  it('locates the file under <cwd>/.mercato/generated (standalone app layout)', () => {
+    const appRoot = makeTempDir()
+    const generatedDir = path.join(appRoot, '.mercato', 'generated')
+    fs.mkdirSync(generatedDir, { recursive: true })
+    const target = path.join(generatedDir, 'unique-standalone.generated.ts')
+    fs.writeFileSync(target, 'export const apiRoutes = []\n')
+    cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(appRoot)
+
+    expect(findGeneratedFile('unique-standalone.generated.ts')).toBe(target)
+  })
+
+  it('locates the file under <cwd>/apps/mercato/.mercato/generated (monorepo layout)', () => {
+    const root = makeTempDir()
+    const generatedDir = path.join(root, 'apps', 'mercato', '.mercato', 'generated')
+    fs.mkdirSync(generatedDir, { recursive: true })
+    const target = path.join(generatedDir, 'unique-monorepo.generated.ts')
+    fs.writeFileSync(target, 'export const apiRoutes = []\n')
+    cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(root)
+
+    expect(findGeneratedFile('unique-monorepo.generated.ts')).toBe(target)
+  })
+
+  it('prefers the apps/mercato layout over the cwd-root layout when both exist', () => {
+    const root = makeTempDir()
+    const appsDir = path.join(root, 'apps', 'mercato', '.mercato', 'generated')
+    const rootDir = path.join(root, '.mercato', 'generated')
+    fs.mkdirSync(appsDir, { recursive: true })
+    fs.mkdirSync(rootDir, { recursive: true })
+    const fileName = 'unique-both.generated.ts'
+    fs.writeFileSync(path.join(appsDir, fileName), 'export const apiRoutes = []\n')
+    fs.writeFileSync(path.join(rootDir, fileName), 'export const apiRoutes = []\n')
+    cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(root)
+
+    expect(findGeneratedFile(fileName)).toBe(path.join(appsDir, fileName))
+  })
+})
+
+describe('ensureApiRouteManifestsRegistered', () => {
+  // Regression for "Operation runner manifest unavailable: No API route manifest
+  // registered" when calling API-backed module tools over MCP. The standalone
+  // MCP servers must register the manifest, but must NOT clobber the in-app
+  // agents-framework manifest registered at bootstrap.
+
+  it('is a no-op when a manifest is already registered (does not interfere with bootstrap)', async () => {
+    const getSpy = jest
+      .spyOn(registry, 'getApiRouteManifests')
+      .mockReturnValue([{ id: 'existing' }] as never)
+    const registerSpy = jest
+      .spyOn(registry, 'registerApiRouteManifests')
+      .mockImplementation(() => {})
+
+    const count = await ensureApiRouteManifestsRegistered()
+
+    expect(count).toBe(1)
+    expect(registerSpy).not.toHaveBeenCalled()
+
+    getSpy.mockRestore()
+    registerSpy.mockRestore()
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-registry.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-registry.ts
@@ -8,9 +8,37 @@ import {
   type AiAgentOverrideConfigEntry,
 } from './ai-overrides'
 import { TASK_PLAN_TOOL_NAME } from './task-plan-labels'
+import { findGeneratedFile, compileAndImportGenerated } from './generated-registry-loader'
 
 const agentsById = new Map<string, AiAgentDefinition>()
 let loaded = false
+
+/**
+ * Import the generated `ai-agents.generated.ts` registry.
+ *
+ * Dual-strategy, mirroring `tool-loader`'s `importGeneratedAiToolsModule`:
+ *  1. Prefer the `@/` path-alias import — the Next.js bundler resolves it at
+ *     build time, so the in-app agent runtime is unchanged.
+ *  2. Fall back to locating + compiling the file from disk when the alias
+ *     import throws. That only happens in a standalone Node process (the
+ *     `mcp:dev` / `mcp:serve` MCP servers), where `@/` is not a real package
+ *     specifier and Node throws `ERR_MODULE_NOT_FOUND`. Without this the
+ *     `meta.list_agents` / `meta.describe_agent` tools return an empty agent
+ *     registry over MCP.
+ *
+ * Returns `null` when no generated file exists (pre-generate builds, tests).
+ */
+async function importGeneratedAiAgentsModule(): Promise<Record<string, unknown> | null> {
+  try {
+    return (await import(
+      '@/.mercato/generated/ai-agents.generated'
+    )) as Record<string, unknown>
+  } catch {
+    const tsPath = findGeneratedFile('ai-agents.generated.ts')
+    if (!tsPath) return null
+    return compileAndImportGenerated(tsPath)
+  }
+}
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === 'string')
@@ -170,10 +198,10 @@ function populateFromAgents(agents: unknown[]): void {
 
 async function loadOverrideEntries(): Promise<AiAgentOverrideConfigEntry[]> {
   try {
-    const mod = (await import(
-      '@/.mercato/generated/ai-agents.generated'
-    )) as { aiAgentOverrideEntries?: unknown[] }
-    return Array.isArray(mod.aiAgentOverrideEntries)
+    const mod = (await importGeneratedAiAgentsModule()) as {
+      aiAgentOverrideEntries?: unknown[]
+    } | null
+    return mod && Array.isArray(mod.aiAgentOverrideEntries)
       ? (mod.aiAgentOverrideEntries as AiAgentOverrideConfigEntry[])
       : []
   } catch {
@@ -196,12 +224,13 @@ function applyOverridesToRegistry(entries: readonly AiAgentOverrideConfigEntry[]
 
 async function loadExtensionEntries(): Promise<AiAgentExtension[]> {
   try {
-    const mod = (await import(
-      '@/.mercato/generated/ai-agents.generated'
-    )) as { aiAgentExtensionEntries?: unknown[] }
-    const entries = Array.isArray(mod.aiAgentExtensionEntries)
-      ? (mod.aiAgentExtensionEntries as AiAgentExtensionConfigEntry[])
-      : []
+    const mod = (await importGeneratedAiAgentsModule()) as {
+      aiAgentExtensionEntries?: unknown[]
+    } | null
+    const entries =
+      mod && Array.isArray(mod.aiAgentExtensionEntries)
+        ? (mod.aiAgentExtensionEntries as AiAgentExtensionConfigEntry[])
+        : []
     return composeAgentExtensionEntries(entries).filter(isAiAgentExtension)
   } catch {
     return []
@@ -249,10 +278,10 @@ function applyExtensionsToRegistry(extensions: readonly AiAgentExtension[]): voi
 export async function loadAgentRegistry(): Promise<void> {
   if (loaded) return
   try {
-    const mod = (await import(
-      '@/.mercato/generated/ai-agents.generated'
-    )) as { allAiAgents?: unknown[] }
-    const agents = Array.isArray(mod.allAiAgents) ? mod.allAiAgents : []
+    const mod = (await importGeneratedAiAgentsModule()) as {
+      allAiAgents?: unknown[]
+    } | null
+    const agents = mod && Array.isArray(mod.allAiAgents) ? mod.allAiAgents : []
     populateFromAgents(agents)
   } catch (error) {
     console.error(

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/generated-registry-loader.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/generated-registry-loader.ts
@@ -1,0 +1,161 @@
+/**
+ * Runtime loader for `.mercato/generated/*.generated.ts` registry files.
+ *
+ * The generated registries import their entries through the `@/` path alias
+ * (e.g. `@/.mercato/generated/ai-tools.generated`). That alias is only
+ * understood by the Next.js bundler — in a standalone Node process (the
+ * `mcp:dev` / `mcp:serve` MCP servers, the CLI tool-test runner) a raw
+ * `import('@/.mercato/...')` throws `ERR_MODULE_NOT_FOUND: Cannot find
+ * package '@/.mercato'` because Node treats `@/` as a package specifier.
+ *
+ * These helpers locate the generated `.ts` file on disk and compile-and-import
+ * it with esbuild (transpile-only), rewriting `@/` aliases to absolute paths.
+ * This mirrors `loadBootstrapData` in
+ * `@open-mercato/shared/lib/bootstrap/dynamicLoader` and works in both the
+ * monorepo and standalone apps.
+ */
+import path from 'node:path'
+import fs from 'node:fs'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+/**
+ * Locate a generated registry file (e.g. `ai-tools.generated.ts`) without
+ * hardcoding the workspace layout. Searches upward from this module's compiled
+ * location for a `apps/mercato/.mercato/generated/<fileName>` (monorepo), then
+ * falls back to cwd-relative lookups (standalone apps run from the app dir).
+ */
+export function findGeneratedFile(fileName: string): string | null {
+  const here = (() => {
+    try {
+      return fileURLToPath(import.meta.url)
+    } catch {
+      return null
+    }
+  })()
+
+  if (here) {
+    let cursor = path.dirname(here)
+    for (let i = 0; i < 12; i++) {
+      const candidate = path.join(cursor, 'apps', 'mercato', '.mercato', 'generated', fileName)
+      if (fs.existsSync(candidate)) return candidate
+      const next = path.dirname(cursor)
+      if (next === cursor) break
+      cursor = next
+    }
+  }
+  // Fallbacks: cwd-based lookup (CLI invoked from apps/mercato, or a standalone
+  // app whose root holds `.mercato/generated`).
+  const fromCwd = path.resolve(process.cwd(), 'apps', 'mercato', '.mercato', 'generated', fileName)
+  if (fs.existsSync(fromCwd)) return fromCwd
+  const fromCwdDirect = path.resolve(process.cwd(), '.mercato', 'generated', fileName)
+  if (fs.existsSync(fromCwdDirect)) return fromCwdDirect
+  return null
+}
+
+/**
+ * Compile-and-import a generated registry file on the fly. Resolves the `@/`
+ * alias to the app root, transpiles TS → ESM, and emits a sibling `.mjs` we can
+ * `import()` from Node. Cached on mtime so repeat calls in the same process
+ * don't recompile.
+ *
+ * Transpile-only (no bundling): the generated registries declare an array
+ * literal whose entries are static `import("…")` arrow functions — we want
+ * those `import()` strings to stay as runtime imports so Node resolves them
+ * lazily through the workspace's normal module resolution. Eagerly bundling
+ * pulls Next.js / route-handler internals into the `.mjs` and breaks at runtime
+ * (e.g. `next/server` package-exports map).
+ */
+export async function compileAndImportGenerated(tsPath: string): Promise<Record<string, unknown>> {
+  const jsPath = tsPath.replace(/\.ts$/, '.mjs')
+  // appRoot is two directories up from `.mercato/generated/<file>.ts`.
+  const appRoot = path.dirname(path.dirname(path.dirname(tsPath)))
+
+  if (!fs.existsSync(tsPath)) {
+    throw new Error(`Generated file not found: ${tsPath}`)
+  }
+
+  const jsExists = fs.existsSync(jsPath)
+  const needsCompile =
+    !jsExists || fs.statSync(tsPath).mtimeMs > fs.statSync(jsPath).mtimeMs
+
+  if (needsCompile) {
+    const esbuild = await import('esbuild')
+    const tsSource = fs.readFileSync(tsPath, 'utf-8')
+    const aliasRewritten = rewriteGeneratedAliasImports(tsSource, appRoot)
+    const result = await esbuild.transform(aliasRewritten, {
+      loader: 'ts',
+      format: 'esm',
+      target: 'node18',
+      sourcemap: false,
+      sourcefile: tsPath,
+    })
+    fs.writeFileSync(jsPath, result.code)
+  }
+
+  return (await import(pathToFileURL(jsPath).href)) as Record<string, unknown>
+}
+
+/**
+ * Rewrite `@/...` path-alias imports (both `from "@/x"` and dynamic
+ * `import("@/x")`) in generated-registry source to absolute `file://` URLs
+ * rooted at `appRoot`. The `@/` alias is a Next.js bundler convention; outside
+ * the bundler Node treats `@/...` as a bare package specifier and throws
+ * `ERR_MODULE_NOT_FOUND`. Exported for unit testing.
+ */
+export function rewriteGeneratedAliasImports(source: string, appRoot: string): string {
+  const resolveAlias = (relativePath: string): string => {
+    const target = path.join(appRoot, relativePath)
+    const candidate = fs.existsSync(target)
+      ? target
+      : fs.existsSync(target + '.ts')
+        ? target + '.ts'
+        : target
+    return pathToFileURL(candidate).href
+  }
+  return source
+    .replace(/from\s+["']@\/([^"']+)["']/g, (_match, relativePath: string) => {
+      return `from ${JSON.stringify(resolveAlias(relativePath))}`
+    })
+    .replace(/import\s*\(\s*["']@\/([^"']+)["']\s*\)/g, (_match, relativePath: string) => {
+      return `import(${JSON.stringify(resolveAlias(relativePath))})`
+    })
+}
+
+/**
+ * Compile-and-import `api-routes.generated.ts` and register its manifest with
+ * the shared registry. Many module tools are "API-backed" — their handlers
+ * delegate to `createAiApiOperationRunner`, which fails closed with
+ * "No API route manifest registered" unless the manifest is present. In the
+ * Next.js app this is wired at bootstrap, but the standalone MCP servers
+ * (`mcp:dev` / `mcp:serve`) bootstrap DI without it, so we register it here.
+ *
+ * Idempotent: `registerApiRouteManifests` replaces the stored manifest, so
+ * calling this repeatedly (e.g. per-request HTTP handlers) is safe. Returns the
+ * number of registered routes (0 when the generated file is absent).
+ */
+export async function ensureApiRouteManifestsRegistered(): Promise<number> {
+  const registry = await import('@open-mercato/shared/modules/registry')
+  // Already wired (e.g. the Next.js app bootstrap, or a prior call). Leave the
+  // existing manifest untouched so we never interfere with the in-app agents
+  // framework, which registers it at bootstrap with its own override pipeline.
+  const existing = registry.getApiRouteManifests()
+  if (existing.length > 0) return existing.length
+
+  const tsPath = findGeneratedFile('api-routes.generated.ts')
+  if (!tsPath) return 0
+  try {
+    const mod = await compileAndImportGenerated(tsPath)
+    const apiRoutes = (mod as { apiRoutes?: unknown }).apiRoutes
+    if (!Array.isArray(apiRoutes)) return 0
+    registry.registerApiRouteManifests(
+      apiRoutes as Parameters<typeof registry.registerApiRouteManifests>[0],
+    )
+    return apiRoutes.length
+  } catch (error) {
+    console.warn(
+      '[MCP Tools] Could not register api-routes manifest:',
+      error instanceof Error ? error.message : error,
+    )
+    return 0
+  }
+}

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/tool-loader.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/tool-loader.ts
@@ -8,6 +8,11 @@ import {
 } from './ai-overrides'
 import type { McpToolDefinition, McpToolContext } from './types'
 import { ToolSearchService } from './tool-search'
+import {
+  findGeneratedFile,
+  compileAndImportGenerated,
+  ensureApiRouteManifestsRegistered,
+} from './generated-registry-loader'
 
 /**
  * Module tool definition as exported from ai-tools.ts files.
@@ -144,6 +149,33 @@ export function applyAiToolOverrideEntries(
 }
 
 /**
+ * Import the generated `ai-tools.generated.ts` registry.
+ *
+ * Dual-strategy so the same code works in every runtime without changing the
+ * existing Next.js / agents-framework behavior:
+ *  1. Prefer the `@/` path-alias import. Inside the Next.js bundler this
+ *     resolves at build time exactly as before — the in-app agents framework
+ *     path is untouched.
+ *  2. Fall back to locating + compiling the file from disk when the alias
+ *     import throws. That only happens in a standalone Node process (the
+ *     `mcp:dev` / `mcp:serve` MCP servers), where `@/` is not a real package
+ *     specifier and Node throws `ERR_MODULE_NOT_FOUND`.
+ *
+ * Returns `null` when no generated file exists (pre-generate builds, tests).
+ */
+async function importGeneratedAiToolsModule(): Promise<Record<string, unknown> | null> {
+  try {
+    return (await import(
+      '@/.mercato/generated/ai-tools.generated'
+    )) as Record<string, unknown>
+  } catch {
+    const tsPath = findGeneratedFile('ai-tools.generated.ts')
+    if (!tsPath) return null
+    return compileAndImportGenerated(tsPath)
+  }
+}
+
+/**
  * Read `aiToolOverrideEntries` from `ai-tools.generated.ts` and apply
  * them on top of the live tool registry. Safe to call when the file is
  * missing (pre-generate builds, tests) — applies only the
@@ -152,12 +184,13 @@ export function applyAiToolOverrideEntries(
 export async function loadGeneratedAiToolOverrides(): Promise<void> {
   let entries: AiToolOverrideConfigEntry[] = []
   try {
-    const mod = (await import(
-      '@/.mercato/generated/ai-tools.generated'
-    )) as { aiToolOverrideEntries?: unknown[] }
-    entries = Array.isArray(mod.aiToolOverrideEntries)
-      ? (mod.aiToolOverrideEntries as AiToolOverrideConfigEntry[])
-      : []
+    const mod = (await importGeneratedAiToolsModule()) as {
+      aiToolOverrideEntries?: unknown[]
+    } | null
+    entries =
+      mod && Array.isArray(mod.aiToolOverrideEntries)
+        ? (mod.aiToolOverrideEntries as AiToolOverrideConfigEntry[])
+        : []
   } catch {
     // No override file generated.
   }
@@ -172,9 +205,13 @@ export async function loadGeneratedAiToolOverrides(): Promise<void> {
  */
 export async function loadGeneratedModuleAiTools(): Promise<number> {
   try {
-    const mod = (await import(
-      '@/.mercato/generated/ai-tools.generated'
-    )) as { aiToolConfigEntries?: AiToolConfigEntry[] }
+    const mod = (await importGeneratedAiToolsModule()) as {
+      aiToolConfigEntries?: AiToolConfigEntry[]
+    } | null
+    if (!mod) {
+      // No generated file (pre-generate build or tests).
+      return 0
+    }
     const entries = Array.isArray(mod.aiToolConfigEntries)
       ? mod.aiToolConfigEntries
       : []
@@ -227,6 +264,20 @@ export async function loadAllModuleTools(): Promise<void> {
     )
   } catch (error) {
     console.error('[MCP Tools] Could not load module AI tools:', error)
+  }
+
+  // 4. Register the API route manifest so API-backed module tools can run.
+  // Their handlers delegate to createAiApiOperationRunner, which fails closed
+  // with "No API route manifest registered" outside the Next.js bootstrap.
+  try {
+    const routeCount = await ensureApiRouteManifestsRegistered()
+    if (routeCount > 0) {
+      console.error(
+        `[MCP Tools] Registered ${routeCount} API route manifests for API-backed tools`
+      )
+    }
+  } catch (error) {
+    console.error('[MCP Tools] Could not register API route manifests:', error)
   }
 }
 

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/tool-test-runner.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/tool-test-runner.ts
@@ -14,9 +14,6 @@
  *   - Tools without an explicit fixture entry are skipped with reason
  *     `'no fixture'` rather than failing.
  */
-import path from 'node:path'
-import fs from 'node:fs'
-import { fileURLToPath, pathToFileURL } from 'node:url'
 import type { AwilixContainer } from 'awilix'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { McpToolContext, AiToolDefinition } from './types'
@@ -24,6 +21,11 @@ import type { AiAgentDefinition, AiAgentMutationPolicy } from './ai-agent-defini
 import { getFixture, type ToolFixture } from './tool-test-fixtures'
 import { prepareMutation } from './prepare-mutation'
 import { executePendingActionConfirm } from './pending-action-executor'
+import {
+  findGeneratedFile,
+  compileAndImportGenerated,
+  ensureApiRouteManifestsRegistered,
+} from './generated-registry-loader'
 
 export type ToolTestStatus = 'pass' | 'fail' | 'skip'
 
@@ -63,143 +65,15 @@ function isToolDefinition(value: unknown): value is AiToolDefinition {
   )
 }
 
-/**
- * Locate `apps/mercato/.mercato/generated/ai-tools.generated.ts` without
- * hardcoding the workspace layout. Searches upward from this file's
- * compiled location; in the monorepo dist this is
- * `packages/ai-assistant/dist/...` so we walk up until we hit a directory
- * containing `apps/mercato/.mercato/generated`.
- */
-function findGeneratedAiToolsPath(): string | null {
-  const here = (() => {
-    try {
-      return fileURLToPath(import.meta.url)
-    } catch {
-      return null
-    }
-  })()
-  if (!here) return null
-  let cursor = path.dirname(here)
-  for (let i = 0; i < 12; i++) {
-    const candidate = path.join(cursor, 'apps', 'mercato', '.mercato', 'generated', 'ai-tools.generated.ts')
-    if (fs.existsSync(candidate)) return candidate
-    const next = path.dirname(cursor)
-    if (next === cursor) break
-    cursor = next
-  }
-  // Fallback: cwd-based lookup (when CLI is invoked from apps/mercato).
-  const fromCwd = path.resolve(process.cwd(), 'apps', 'mercato', '.mercato', 'generated', 'ai-tools.generated.ts')
-  if (fs.existsSync(fromCwd)) return fromCwd
-  const fromCwdDirect = path.resolve(process.cwd(), '.mercato', 'generated', 'ai-tools.generated.ts')
-  if (fs.existsSync(fromCwdDirect)) return fromCwdDirect
-  return null
-}
-
-/**
- * Compile-and-import `ai-tools.generated.ts` on the fly. Mirrors the approach
- * used by `loadBootstrapData` in `@open-mercato/shared/lib/bootstrap/dynamicLoader`:
- * resolves the `@/` alias to the app root, marks every other package import as
- * external, and emits a sibling `.mjs` we can `import()` from Node. Cached on
- * mtime so repeat runs in the same process don't recompile.
- */
-async function compileAndImportGenerated(tsPath: string): Promise<RawAiToolsModule> {
-  const jsPath = tsPath.replace(/\.ts$/, '.mjs')
-  // appRoot is two directories up from `.mercato/generated/<file>.ts`.
-  const appRoot = path.dirname(path.dirname(path.dirname(tsPath)))
-  const tsExists = fs.existsSync(tsPath)
-  if (!tsExists) {
-    throw new Error(`Generated file not found: ${tsPath}`)
-  }
-  const jsExists = fs.existsSync(jsPath)
-  const needsCompile =
-    !jsExists || fs.statSync(tsPath).mtimeMs > fs.statSync(jsPath).mtimeMs
-  if (needsCompile) {
-    const esbuild = await import('esbuild')
-    // Transpile-only: don't bundle. Generated registry files only declare an
-    // array literal whose entries are static `import("…")` arrow functions —
-    // we want those `import()` strings to stay as runtime imports so Node
-    // resolves them lazily through the workspace's normal module resolution.
-    // Eagerly bundling them pulls Next.js / route handler internals into the
-    // .mjs and breaks at runtime (e.g. `next/server` package-exports map).
-    const tsSource = fs.readFileSync(tsPath, 'utf-8')
-    // Rewrite `@/...` aliases to absolute paths so Node can resolve them.
-    const aliasRewritten = tsSource.replace(
-      /from\s+["']@\/([^"']+)["']/g,
-      (_match, p1: string) => {
-        const target = path.join(appRoot, p1)
-        const candidate = fs.existsSync(target)
-          ? target
-          : fs.existsSync(target + '.ts')
-            ? target + '.ts'
-            : target
-        return `from ${JSON.stringify(pathToFileURL(candidate).href)}`
-      },
-    ).replace(
-      /import\s*\(\s*["']@\/([^"']+)["']\s*\)/g,
-      (_match, p1: string) => {
-        const target = path.join(appRoot, p1)
-        const candidate = fs.existsSync(target)
-          ? target
-          : fs.existsSync(target + '.ts')
-            ? target + '.ts'
-            : target
-        return `import(${JSON.stringify(pathToFileURL(candidate).href)})`
-      },
-    )
-    const result = await esbuild.transform(aliasRewritten, {
-      loader: 'ts',
-      format: 'esm',
-      target: 'node18',
-      sourcemap: false,
-      sourcefile: tsPath,
-    })
-    fs.writeFileSync(jsPath, result.code)
-  }
-  return (await import(pathToFileURL(jsPath).href)) as RawAiToolsModule
-}
-
-/**
- * Compile-and-import `api-routes.generated.ts` and register its manifest with
- * the shared registry. Many tool handlers delegate to `aiApiOperationRunner`
- * which fails closed when no manifest is registered. Idempotent: registering
- * the same array twice is safe.
- */
-async function ensureApiRouteManifestsRegistered(generatedDir: string): Promise<void> {
-  const tsPath = path.join(generatedDir, 'api-routes.generated.ts')
-  if (!fs.existsSync(tsPath)) return
-  try {
-    const mod = (await compileAndImportGenerated(tsPath)) as Record<string, unknown>
-    const apiRoutes = (mod as { apiRoutes?: unknown }).apiRoutes
-    if (!Array.isArray(apiRoutes)) {
-      console.warn('[tool-test-runner] api-routes.generated.mjs returned no apiRoutes array')
-      return
-    }
-    const registry = await import('@open-mercato/shared/modules/registry')
-    registry.registerApiRouteManifests(
-      apiRoutes as Parameters<typeof registry.registerApiRouteManifests>[0],
-    )
-    if (process.env.OM_TOOL_TEST_DEBUG === '1') {
-      console.log(
-        `[tool-test-runner] Registered ${apiRoutes.length} api-route manifests; getApiRouteManifests().length=${registry.getApiRouteManifests().length}`,
-      )
-    }
-  } catch (error) {
-    console.warn(
-      '[tool-test-runner] Could not register api-routes manifest:',
-      error instanceof Error ? error.message : error,
-    )
-  }
-}
-
 async function loadGeneratedTools(): Promise<{ moduleId: string; tools: AiToolDefinition[] }[]> {
-  const tsPath = findGeneratedAiToolsPath()
+  const tsPath = findGeneratedFile('ai-tools.generated.ts')
   if (!tsPath) {
     throw new Error(
       'Could not locate apps/<app>/.mercato/generated/ai-tools.generated.ts. Run `yarn generate` first.',
     )
   }
-  await ensureApiRouteManifestsRegistered(path.dirname(tsPath))
-  const mod = await compileAndImportGenerated(tsPath)
+  await ensureApiRouteManifestsRegistered()
+  const mod = (await compileAndImportGenerated(tsPath)) as RawAiToolsModule
   const entries = mod.aiToolConfigEntriesRaw ?? mod.aiToolConfigEntries ?? []
   const result: { moduleId: string; tools: AiToolDefinition[] }[] = []
   for (const entry of entries) {


### PR DESCRIPTION
## Why

Connecting **Claude Code → Open Mercato `mcp:dev`** surfaced two errors:

1. ```
   [MCP Tools] Could not load ai-tools.generated.ts (module tools unavailable):
   ERR_MODULE_NOT_FOUND: Cannot find package '@/.mercato' imported from
   .../dist/modules/ai_assistant/lib/tool-loader.js
   [MCP Tools] Registered 0 module-contributed AI tools
   ```
2. After (1) is fixed and tools load, calling an API-backed tool:
   ```
   Error: Operation runner manifest unavailable: No API route manifest registered.
   ```

### Root cause

The `mcp:dev` / `mcp:serve` servers run the **compiled package directly under Node**, outside the Next.js bundler.

- `tool-loader` imported the generated registry through the **`@/` path alias** (`@/.mercato/generated/ai-tools.generated`). That alias only exists in the Next.js bundler; in a standalone Node process Node treats `@/` as a bare package name → `ERR_MODULE_NOT_FOUND`. The `catch` swallowed it, so **0 module tools** were registered (only `context_whoami` + Code Mode `search`/`execute`).
- This is **why it never showed up before**: in the Next.js app the alias resolves fine, and module tools simply never loaded in the standalone MCP server — so their handlers (which need the API route manifest) were never reachable. Once they load, the second latent gap appears: the standalone servers never call `registerApiRouteManifests` (the Next.js app does it at bootstrap), so API-backed tools fail closed.

## What

- **New** `lib/generated-registry-loader.ts` — `findGeneratedFile`, `compileAndImportGenerated`, `rewriteGeneratedAliasImports`, `ensureApiRouteManifestsRegistered`. Extracted from the approach already proven in `tool-test-runner`, which is **de-duplicated** to consume it.
- `tool-loader` uses a **dual strategy**: prefer the `@/` bundler import (Next.js path **unchanged**), fall back to locating + compiling the generated file from disk only when that import throws (standalone Node).
- `loadAllModuleTools` now registers the API route manifest, **guarded to skip when one is already registered** — so the in-app **agents framework** bootstrap is never clobbered.
- Unit tests for the alias rewrite, on-disk file resolution (standalone + monorepo layouts + precedence), and the no-clobber manifest guard.

## No interference with the agents framework

By design: inside Next.js the `@/` import still resolves at build time (fallback never runs), and the manifest registration is a no-op when bootstrap already registered one. The standalone MCP server is the only path whose behavior changes.

## Verification

- `yarn workspace @open-mercato/ai-assistant build` ✅
- Full unit suite: **1200 passed / 84 suites** ✅ (16 in the touched area)
- `yarn mercato ai_assistant mcp:list-tools` now boots:
  ```
  [MCP Tools] Registered 67 module-contributed AI tools from ai-tools.generated.ts
  [MCP Tools] Registered 511 API route manifests for API-backed tools
  Registered MCP Tools (70)
  ```
  No `@/.mercato` error, no manifest-unavailable error.

## Follow-up (not in this PR)

The ai-assistant docs have **no MCP setup/extension page** (`mcp:dev`, `.mcp.json`, Claude Code, what tools are exposed, RBAC/ACL gating). Worth adding a `framework/ai-assistant/mcp.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)