### PR TITLE
fix(catalog): list_offers AI tool must declare sales.channels.manage

### DIFF
--- a/packages/core/src/modules/catalog/__tests__/ai-tools/prices-offers-pack.test.ts
+++ b/packages/core/src/modules/catalog/__tests__/ai-tools/prices-offers-pack.test.ts
@@ -185,6 +185,17 @@ describe('catalog.list_offers', () => {
     expect(tool.isMutation).toBeFalsy()
   })
 
+  it('covers the GET /catalog/offers route features so the api runner does not fail closed', () => {
+    // The offers route declares `requireFeatures: ['sales.channels.manage']`
+    // and the api-backed runner refuses to call a route whose required
+    // features the tool does not cover. Regression guard for #2899: without
+    // sales.channels.manage the tool was unreachable. catalog.products.view
+    // stays for the variant→offer resolution path.
+    expect(tool.requiredFeatures).toEqual(
+      expect.arrayContaining(['catalog.products.view', 'sales.channels.manage']),
+    )
+  })
+
   it('caps limit at 100', () => {
     expect(tool.inputSchema.safeParse({ limit: 200 }).success).toBe(false)
   })

--- a/packages/core/src/modules/catalog/__tests__/ai-tools/shared.ts
+++ b/packages/core/src/modules/catalog/__tests__/ai-tools/shared.ts
@@ -2,6 +2,7 @@
  * Shared test helpers for the catalog AI tool pack tests.
  */
 import features from '../../acl'
+import salesFeatures from '../../../sales/acl'
 
 export type FakeCtx = {
   tenantId: string | null
@@ -55,4 +56,11 @@ export function makeCtx(overrides: Partial<FakeCtx & { organizationId: string | 
   }
 }
 
-export const knownFeatureIds = new Set(features.map((entry) => entry.id))
+// Catalog AI tools may legitimately call routes owned by other modules and so
+// must declare those routes' features (e.g. catalog.list_offers reaches
+// GET /catalog/offers, which requires sales.channels.manage). Union the acl of
+// every module whose features the catalog tools reference so the typo-guard
+// still rejects unknown ids without flagging valid cross-module grants.
+export const knownFeatureIds = new Set(
+  [...features, ...salesFeatures].map((entry) => entry.id),
+)

--- a/packages/core/src/modules/catalog/ai-tools/prices-offers-pack.ts
+++ b/packages/core/src/modules/catalog/ai-tools/prices-offers-pack.ts
@@ -293,7 +293,11 @@ const listOffersTool = defineApiBackedAiTool<
   description:
     'List catalog offers for the caller tenant + organization, optionally narrowed to a product (or a variant via its prices).',
   inputSchema: listOffersInput,
-  requiredFeatures: ['catalog.products.view'],
+  // Must cover the underlying route. `GET /catalog/offers` requires
+  // `sales.channels.manage` (offers are sales-channel scoped); the API-backed
+  // runner fails closed when the tool's features don't cover the route's.
+  // `catalog.products.view` stays for the variant→offer resolution path.
+  requiredFeatures: ['catalog.products.view', 'sales.channels.manage'],
   toOperation: async (input, ctx) => {
     const { tenantId } = assertTenantScope(ctx as unknown as CatalogToolContext)
     const limit = input.limit ?? 50


### PR DESCRIPTION
## Why

Calling the `catalog.list_offers` AI tool (e.g. over MCP) failed with:

```
Error: AI tool "catalog.list_offers" requiredFeatures do not cover route GET /catalog/offers requiredFeatures
```

The API-backed operation runner enforces **tool `requiredFeatures` ⊇ route `requireFeatures`** — an AI tool must declare authorization at least as strict as the endpoint it calls, so it can never become a privilege-escalation path. The tool declared only `catalog.products.view`, but [`GET /catalog/offers`](../blob/develop/packages/core/src/modules/catalog/api/offers/route.ts#L43) requires `sales.channels.manage`, so the runner failed closed.

It was **latent** until the standalone MCP server started loading + executing module tools (the in-app path simply hadn't exercised this tool). A scan of all **21** api-backed tools confirms `list_offers` is the **only** mismatch.

## What

Align the tool to its route — no API security posture changes, purely makes the tool's ACL honest:

```diff
- requiredFeatures: ['catalog.products.view'],
+ requiredFeatures: ['catalog.products.view', 'sales.channels.manage'],
```

`catalog.products.view` is kept for the tool's variant→offer resolution path.

## Verification

- Static coverage scan of all api-backed tools: **0 mismatches** after the change.
- `yarn workspace @open-mercato/core build` ✅
- `mcp:list-tools --verbose` now shows `catalog.list_offers → Requires: catalog.products.view, sales.channels.manage`.

## Follow-up (not in this PR)

Worth adding a CI guard (extending the `tool-test-runner` integration) that asserts every api-backed tool's `requiredFeatures` covers its route's `requireFeatures`, so this class of mismatch is caught automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)