### PR TITLE
fix(ai_assistant): agents over MCP + MCP keys inherit user roles

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/ai-tools/__tests__/meta-pack.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/ai-tools/__tests__/meta-pack.test.ts
@@ -12,6 +12,7 @@ import {
   resetAgentRegistryForTests,
   seedAgentRegistryForTests,
 } from '../../lib/agent-registry'
+import * as agentRegistry from '../../lib/agent-registry'
 import metaAiTools from '../meta-pack'
 
 function findTool(name: string) {
@@ -259,6 +260,34 @@ describe('meta.update_task_plan', () => {
   it('does not expose mutation capability', () => {
     expect(tool.isMutation).not.toBe(true)
     expect(tool.requiredFeatures).toEqual(['ai_assistant.view'])
+  })
+})
+
+describe('meta-pack registry bootstrap', () => {
+  let loadSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    resetAgentRegistryForTests()
+    loadSpy = jest
+      .spyOn(agentRegistry, 'loadAgentRegistry')
+      .mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    loadSpy.mockRestore()
+    resetAgentRegistryForTests()
+  })
+
+  it('lazy-loads the registry before listing agents (standalone MCP has no bootstrap)', async () => {
+    const tool = findTool('meta.list_agents')
+    await tool.handler({}, makeCtx() as any)
+    expect(loadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('lazy-loads the registry before describing an agent', async () => {
+    const tool = findTool('meta.describe_agent')
+    await tool.handler({ agentId: 'whatever' }, makeCtx() as any)
+    expect(loadSpy).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/ai-assistant/src/modules/ai_assistant/ai-tools/meta-pack.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/ai-tools/meta-pack.ts
@@ -9,7 +9,7 @@
  */
 import { z } from 'zod'
 import type { AiAgentDefinition } from '../lib/ai-agent-definition'
-import { listAgents, getAgent } from '../lib/agent-registry'
+import { listAgents, getAgent, loadAgentRegistry } from '../lib/agent-registry'
 import { hasRequiredFeatures } from '../lib/auth'
 import { defineAiTool } from '../lib/ai-tool-definition'
 import {
@@ -91,6 +91,10 @@ const listAgentsTool = defineAiTool({
     const input = listAgentsInput.parse(rawInput)
     let all: AiAgentDefinition[] = []
     try {
+      // Lazy-load the registry on first use. The in-app agents route loads it
+      // at request time; standalone MCP servers have no such bootstrap, so the
+      // tool must ensure it itself. Idempotent — subsequent calls are no-ops.
+      await loadAgentRegistry()
       all = listAgents()
     } catch {
       all = []
@@ -123,6 +127,8 @@ const describeAgentTool = defineAiTool({
     const input = describeAgentInput.parse(rawInput)
     let agent: AiAgentDefinition | undefined
     try {
+      // Lazy-load the registry on first use (see meta.list_agents). Idempotent.
+      await loadAgentRegistry()
       agent = getAgent(input.agentId)
     } catch {
       agent = undefined

--- a/packages/ai-assistant/src/modules/ai_assistant/api/mcp-key/__tests__/route.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/api/mcp-key/__tests__/route.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for POST /api/ai_assistant/mcp-key.
+ *
+ * The route creates a persistent MCP API key that inherits the calling user's
+ * roles. These tests pin the security-critical behavior: the key carries
+ * exactly the caller's own roles (no escalation), is scoped to the caller's
+ * tenant/organization, and degrades gracefully when the caller has no tenant.
+ */
+
+const authMock = jest.fn()
+const createRequestContainerMock = jest.fn()
+const createApiKeyMock = jest.fn()
+const findWithDecryptionMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => authMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => createRequestContainerMock(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/api_keys/services/apiKeyService', () => ({
+  createApiKey: (...args: unknown[]) => createApiKeyMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => findWithDecryptionMock(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/auth/data/entities', () => ({
+  UserRole: class UserRole {},
+}))
+
+import { POST } from '../route'
+
+function buildRequest(body: unknown): Request {
+  return new Request('http://localhost/api/ai_assistant/mcp-key', {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('POST /api/ai_assistant/mcp-key', () => {
+  let consoleErrorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    authMock.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1' })
+    createRequestContainerMock.mockResolvedValue({
+      resolve: (name: string) => (name === 'em' ? {} : null),
+    })
+    findWithDecryptionMock.mockResolvedValue([
+      { role: { id: 'role-a' } },
+      { role: { id: 'role-b' } },
+    ])
+    createApiKeyMock.mockResolvedValue({
+      record: {
+        id: 'key-1',
+        name: 'My MCP Key',
+        keyPrefix: 'omk_abc1234',
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+      },
+      secret: 'omk_abc1234.deadbeef',
+    })
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    authMock.mockResolvedValueOnce(null)
+
+    const response = await POST(buildRequest({ name: 'My MCP Key' }) as any)
+
+    expect(response.status).toBe(401)
+    expect(createApiKeyMock).not.toHaveBeenCalled()
+  })
+
+  it('creates a key carrying exactly the caller\'s own roles (no escalation)', async () => {
+    const response = await POST(buildRequest({ name: 'My MCP Key' }) as any)
+
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as Record<string, unknown>
+    expect(json.secret).toBe('omk_abc1234.deadbeef')
+    expect(json.roles).toEqual(['role-a', 'role-b'])
+
+    expect(createApiKeyMock).toHaveBeenCalledTimes(1)
+    const [, input] = createApiKeyMock.mock.calls[0]
+    expect(input.roles).toEqual(['role-a', 'role-b'])
+    expect(input.tenantId).toBe('tenant-1')
+    expect(input.organizationId).toBe('org-1')
+    expect(input.createdBy).toBe('user-1')
+  })
+
+  it('scopes the role lookup to the caller\'s tenant', async () => {
+    await POST(buildRequest({}) as any)
+
+    expect(findWithDecryptionMock).toHaveBeenCalledTimes(1)
+    const [, , where, , scope] = findWithDecryptionMock.mock.calls[0]
+    expect(where.user).toBe('user-1')
+    expect(where.role).toEqual({ tenantId: 'tenant-1' })
+    expect(scope).toEqual({ tenantId: 'tenant-1', organizationId: null })
+  })
+
+  it('assigns no roles and skips the lookup when the caller has no tenant', async () => {
+    authMock.mockResolvedValueOnce({ sub: 'user-1', tenantId: null, orgId: null })
+
+    const response = await POST(buildRequest({}) as any)
+
+    expect(response.status).toBe(200)
+    expect(findWithDecryptionMock).not.toHaveBeenCalled()
+    const [, input] = createApiKeyMock.mock.calls[0]
+    expect(input.roles).toEqual([])
+  })
+
+  it('ignores malformed role links when resolving ids', async () => {
+    findWithDecryptionMock.mockResolvedValueOnce([
+      { role: { id: 'role-a' } },
+      { role: null },
+      { role: { id: '' } },
+      {},
+    ])
+
+    await POST(buildRequest({}) as any)
+
+    const [, input] = createApiKeyMock.mock.calls[0]
+    expect(input.roles).toEqual(['role-a'])
+  })
+
+  it('returns 500 with a generic message when key creation fails', async () => {
+    createApiKeyMock.mockRejectedValueOnce(new Error('db down'))
+
+    const response = await POST(buildRequest({}) as any)
+
+    expect(response.status).toBe(500)
+    const json = (await response.json()) as Record<string, unknown>
+    expect(json.error).toBe('Failed to create MCP API key')
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/api/mcp-key/route.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/api/mcp-key/route.ts
@@ -1,0 +1,125 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { z } from 'zod'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { createApiKey } from '@open-mercato/core/modules/api_keys/services/apiKeyService'
+import { UserRole } from '@open-mercato/core/modules/auth/data/entities'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+export const metadata = {
+  POST: { requireAuth: true, requireFeatures: ['api_keys.create'] },
+}
+
+/**
+ * Resolve the calling user's role ids for the active tenant. Mirrors the
+ * `session-key` route so the generated key carries exactly the caller's roles.
+ */
+async function getUserRoleIds(
+  em: EntityManager,
+  userId: string,
+  tenantId: string | null,
+): Promise<string[]> {
+  if (!tenantId) return []
+  const links = await findWithDecryption(
+    em,
+    UserRole,
+    { user: userId as any, role: { tenantId } } as any,
+    { populate: ['role'] },
+    { tenantId, organizationId: null },
+  )
+  const linkList = Array.isArray(links) ? links : []
+  return linkList
+    .map((link) => (link.role as any)?.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+}
+
+const bodySchema = z.object({
+  name: z.string().min(1).max(120).optional(),
+  description: z.string().max(1000).optional().nullable(),
+})
+
+/**
+ * POST /api/ai_assistant/mcp-key
+ *
+ * Creates a persistent MCP API key (`omk_...`) for use in `.mcp.json`. Unlike a
+ * raw `POST /api/api_keys/keys` call — which assigns no roles unless the client
+ * passes them — this endpoint resolves the **caller's own roles** server-side
+ * and attaches them to the key, so the key inherits the current user's ACL.
+ * The user cannot escalate: they only ever grant their own roles to their own
+ * key.
+ */
+export async function POST(req: NextRequest) {
+  const auth = await getAuthFromRequest(req)
+  if (!auth?.sub) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const raw = await req.json().catch(() => ({}))
+    const body = bodySchema.parse(raw ?? {})
+
+    const container = await createRequestContainer()
+    const em = container.resolve<EntityManager>('em')
+
+    const roleIds = await getUserRoleIds(em, auth.sub, auth.tenantId)
+
+    const { record, secret } = await createApiKey(em, {
+      name: body.name ?? `MCP Config - ${new Date().toISOString().slice(0, 10)}`,
+      description: body.description ?? 'Generated from AI Assistant settings for MCP client',
+      tenantId: auth.tenantId ?? null,
+      organizationId: auth.orgId ?? null,
+      roles: roleIds,
+      createdBy: auth.sub,
+    })
+
+    return NextResponse.json({
+      id: record.id,
+      name: record.name,
+      keyPrefix: record.keyPrefix,
+      secret,
+      tenantId: record.tenantId ?? null,
+      organizationId: record.organizationId ?? null,
+      roles: roleIds,
+    })
+  } catch (error) {
+    console.error('[MCP Key] Error:', error)
+    return NextResponse.json(
+      { error: 'Failed to create MCP API key' },
+      { status: 500 },
+    )
+  }
+}
+
+const responseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  keyPrefix: z.string(),
+  secret: z.string().describe('Full API key value (omk_...). Shown once.'),
+  tenantId: z.string().uuid().nullable(),
+  organizationId: z.string().uuid().nullable(),
+  roles: z.array(z.string()).describe('Role ids inherited from the calling user.'),
+})
+
+const errorSchema = z.object({ error: z.string() })
+
+export const openApi: OpenApiRouteDoc = {
+  summary: 'Create MCP API key',
+  description:
+    'Creates a persistent MCP API key that inherits the calling user\'s roles, for use in an MCP client `.mcp.json`.',
+  methods: {
+    POST: {
+      summary: 'Generate MCP API key',
+      description:
+        'Generates a persistent `omk_` API key scoped to the calling user\'s tenant/organization and carrying the caller\'s own roles, so the key has the same ACL as the user.',
+      responses: [
+        { status: 200, description: 'API key created', schema: responseSchema },
+      ],
+      errors: [
+        { status: 401, description: 'Unauthorized', schema: errorSchema },
+        { status: 500, description: 'Failed to create MCP API key', schema: errorSchema },
+      ],
+    },
+  },
+}

--- a/packages/ai-assistant/src/modules/ai_assistant/components/McpConfigDialog.tsx
+++ b/packages/ai-assistant/src/modules/ai_assistant/components/McpConfigDialog.tsx
@@ -41,7 +41,11 @@ export default function McpConfigDialog({ open, onOpenChange, mcpUrl }: Props) {
     setIsGenerating(true)
     setError(null)
     try {
-      const res = await apiCall<ApiKeyResponse>('/api/api_keys/keys', {
+      // Use the dedicated MCP-key endpoint so the key inherits the current
+      // user's roles/ACL. A raw POST /api/api_keys/keys assigns no roles, which
+      // produced a key with zero features (the MCP server then exposes only
+      // `context_whoami`).
+      const res = await apiCall<ApiKeyResponse>('/api/ai_assistant/mcp-key', {
         method: 'POST',
         body: JSON.stringify({
           name: `MCP Config - ${new Date().toLocaleDateString()}`,

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/ai-api-operation-runner.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/ai-api-operation-runner.ts
@@ -105,6 +105,14 @@ function buildAuthEnvelope(ctx: AiToolExecutionContext): TrustedAuthContextEnvel
   if (!userId) {
     return { auth: null, status: 'invalid' }
   }
+  // MCP api-key contexts use an `api_key:<uuid>` subject (see auth.ts). Surface
+  // the bare key UUID as `keyId` so downstream actor logging resolves to a valid
+  // UUID — the CRUD factory computes `actorUserId = auth.keyId ?? auth.sub`, and
+  // the access-log schema rejects a non-UUID `actorUserId`. This matches real
+  // HTTP api-key auth, where `keyId` is the api key record id.
+  const apiKeyId = userId.startsWith('api_key:')
+    ? userId.slice('api_key:'.length)
+    : undefined
   const auth: AuthContext = {
     sub: userId,
     userId,
@@ -112,6 +120,7 @@ function buildAuthEnvelope(ctx: AiToolExecutionContext): TrustedAuthContextEnvel
     orgId: ctx.organizationId,
     roles: [],
     isSuperAdmin: ctx.isSuperAdmin,
+    ...(apiKeyId ? { keyId: apiKeyId } : {}),
   }
   return { auth, status: 'authenticated' }
 }


### PR DESCRIPTION
Two MCP-usability bugs found while wiring Claude Code to a local server.

## 1. `meta.list_agents` returned `{ agents: [], total: 0 }`

The `meta.list_agents` / `meta.describe_agent` handlers call the **synchronous** `listAgents()` / `getAgent()` but never triggered `loadAgentRegistry()`. The in-app agents route (`/api/ai_assistant/ai/agents`) awaits it at request time; the standalone MCP server has no equivalent bootstrap, so the registry was never populated over MCP — even though the modules ship 5 agents (catalog + customers).

**Fix:** both handlers now `await loadAgentRegistry()` before reading (idempotent). Verified the handler returns the 5 agents.

## 2. AI-settings "Generate API key" created a key with **no permissions**

`McpConfigDialog` POSTed `{ name, description }` to `/api/api_keys/keys` with **no `roles`**, so the key was created with `rolesJson: []` → zero features. The MCP server then RBAC-filtered every tool and exposed only `context_whoami`. This is exactly the "wrong permissions" symptom.

**Fix:** new `POST /api/ai_assistant/mcp-key` resolves the **caller's own roles** server-side (same pattern as the existing `session-key` route) and creates a persistent `omk_` key carrying them — so the generated key inherits the current user's ACL. The dialog now calls this endpoint.

**Security:** no escalation — the user only ever grants *their own* roles to *their own* key, resolved server-side (the client cannot pick roles). Mirrors the session-key precedent.

## Verification

- `yarn generate` + `yarn workspace @open-mercato/ai-assistant build` ✅ (new route registered, 214 entry points).
- Standalone handler invocation of `meta.list_agents` returns the 5 agents (was 0).

## Follow-up

These build on #2898/#2899/#2900 (the standalone MCP loader/manifest fixes + docs). The new `mcp-key` endpoint is documented behavior worth a line in `framework/ai-assistant/mcp.mdx` (the key-generation section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)