### PR TITLE
docs(perf): cache-with-invalidation FR specs for hottest API endpoints

### DIFF
--- a/.ai/analysis/2026-06-08-cache-perf-frs/01-cache-catalog-categories-list.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/01-cache-catalog-categories-list.md
@@ -1,148 +1,112 @@
 > Auto-generated cache-performance Feature Request — candidate 1 of 9
 > Endpoint: `GET /api/catalog/categories` · ROI 86 · Verdict: strong-quick-win
 > Source: `packages/core/src/modules/catalog/api/categories/route.ts`
+> Revised 2026-06-09: invalidation now piggybacks on the **already-flushed** `crud:catalog.category:*` tags from the command bus — the previously proposed subscriber + bespoke tags are dropped.
 
 ## Summary
 
-`GET /api/catalog/categories` is served by a **custom `export async function GET`** handler (not the `makeCrudRoute` GET), so it completely bypasses the generic CRUD list cache gated behind `ENABLE_CRUD_API_CACHE`. On every call it loads the full category set for the org, recomputes the entire hierarchy (`computeHierarchyForCategories` — a recursive ancestor/descendant/path walk), and for the `manage` view additionally runs a per-record custom-field aggregation (`loadCustomFieldValues`) over the paged rows. This data changes on the order of weeks but is read on nearly every product form load and category browse. Add a manual tenant-scoped get-then-set cache (mirroring `domainMappingService.ts`) with tag-based invalidation fired from the existing `catalog.category.{created,updated,deleted}` event subscribers.
+`GET /api/catalog/categories` is served by a **custom `export async function GET`** handler (not the `makeCrudRoute` GET), so it completely bypasses the generic CRUD list cache gated behind `ENABLE_CRUD_API_CACHE`. On every call it loads the full category set for the org, recomputes the entire hierarchy (`computeHierarchyForCategories` — a recursive ancestor/descendant/path walk), and for the `manage` view additionally runs a per-record custom-field aggregation (`loadCustomFieldValues`) over the paged rows. This data changes on the order of weeks but is read on nearly every product form load and category browse.
+
+Add a manual tenant-scoped get-then-set cache **tagged with the same `crud:catalog.category:…:collection` tags the command bus already flushes** on every category command (`packages/shared/src/lib/commands/command-bus.ts:610`). Zero new invalidation wiring: no subscribers, no new tags, no per-write `deleteByTags` calls.
 
 ## Why (impact)
 
 - **Hotness (high):** The category picker is rendered on every product create/edit form, the category browse/tree page, and dashboard category widgets. High read:write ratio — categories are mutated rarely (weeks), read constantly.
-- **Cost (medium-high):** Per request the handler does: 1 `em.find` over all org categories (`route.ts:173`), a full recursive hierarchy computation (`computeHierarchyForCategories`, `categoryHierarchy.ts:40`) building ancestor/descendant/path-label maps, tree-node assembly for `view=tree`, and for `view=manage` a custom-field-values aggregation `loadCustomFieldValues` over the paged record ids (`route.ts:238-247`). That is 2 queries + an O(N) graph walk + a CFV EAV aggregation on each hit.
-- **Est. win:** Near-elimination of the hierarchy recompute and the CFV aggregation on cache hits. For a tenant whose categories are stable, virtually every request after the first becomes a single cache `get`. Expect the dominant per-request cost (graph walk + CFV load) to drop to ~0 on hits within the TTL/convergence window.
+- **Cost (medium-high):** Per request: 1 `em.find` over all org categories (`route.ts:173`), a full recursive hierarchy computation (`computeHierarchyForCategories`, `categoryHierarchy.ts:40`), tree-node assembly for `view=tree`, and for `view=manage` a custom-field-values aggregation `loadCustomFieldValues` over the paged record ids (`route.ts:238-247`).
+- **Est. win:** Near-elimination of the hierarchy recompute and the CFV aggregation on cache hits — virtually every request after the first becomes a single cache `get` within the TTL/invalidation window.
 
 ## Current behavior
 
 File: `packages/core/src/modules/catalog/api/categories/route.ts`
 
-- `GET` is a fully custom handler (`route.ts:131`), distinct from `crud.POST/PUT/DELETE` (`route.ts:285-287`). The CRUD list cache in `packages/shared/src/lib/crud/cache.ts` is therefore **never** consulted for this read — even if `ENABLE_CRUD_API_CACHE` were on, only factory GETs are covered.
-- `route.ts:173-177` — `em.find(CatalogProductCategory, { organizationId, tenantId, deletedAt: null }, { orderBy: { name: 'ASC' } })`.
-- `route.ts:179` — `computeHierarchyForCategories(categories)` (recursive walk in `packages/core/src/modules/catalog/lib/categoryHierarchy.ts:40-166`).
-- `route.ts:181-205` — `view=tree`: builds nested `TreeNode` roots.
-- `route.ts:207-271` — `view=manage`: status/search/ids filtering, pagination, then `loadCustomFieldValues(...)` (`route.ts:238-247`) and row assembly merging category scalars + CFV.
-- Response is deterministic for a given `(tenantId, organizationId, categories snapshot, custom-field values, query params)`. No clock-sensitivity, no per-user secrets — the only auth-scoped axis is `(tenantId, organizationId)`, which is already the cache tenant/key boundary.
+- `GET` is a fully custom handler (`route.ts:131`), distinct from `crud.POST/PUT/DELETE` (`route.ts:285-287`). The CRUD list cache is **never** consulted for this read.
+- `route.ts:173-177` — `em.find(CatalogProductCategory, { organizationId, tenantId, deletedAt: null })`; `route.ts:179` — `computeHierarchyForCategories(categories)`; `route.ts:207-271` — `view=manage` filtering/pagination + `loadCustomFieldValues`.
+- **All category writes flow through commands** with `resourceKind: 'catalog.category'` (`commands/categories.ts:228/393/538`). After every execute/undo the command bus calls `invalidateCrudCache` (`command-bus.ts:610/642`), which flushes — post-commit, inside `runWithCacheTenant(tenantId, …)` — exactly these tags:
+  - `crud:catalog.category:tenant:<T>:org:<O>:collection`
+  - `crud:catalog.category:tenant:<T>:record:<id>`
+- Custom-field edits also route through `catalog.categories.update` → same flush. The response is deterministic for `(tenantId, organizationId, categories snapshot, CFV, query params)`.
 
 ## Proposed cache
 
-Manual get-then-set inside the `GET` handler, scoped with `runWithCacheTenant(tenantId, …)`. Key includes the org plus the full query shape (view/page/pageSize/search/status/ids) so distinct views/pages cache independently.
+Manual get-then-set inside the `GET` handler. The API dispatcher already wraps the handler in `runWithCacheTenant(auth.tenantId, …)` (`apps/mercato/src/app/api/[...slug]/route.ts:382`), so `get`/`set` land in the correct tenant namespace automatically — the same namespace `invalidateCrudCache` flushes into.
 
 ```ts
-import { runWithCacheTenant, type CacheStrategy } from '@open-mercato/cache'
+import { buildCollectionTags, isCrudCacheEnabled } from '@open-mercato/shared/lib/crud/cache'
 
-const CATEGORY_LIST_TAG = 'catalog.categories.list'
-const CATEGORY_LIST_TTL_MS = 10 * 60_000 // 10 min backstop; tags carry correctness
+const CATEGORY_LIST_TTL_MS = 10 * 60_000 // backstop; the crud:* tag flush carries correctness
 
 function categoryListCacheKey(organizationId: string, q: QueryShape): string {
   return [
-    'catalog:categories:list',
-    organizationId,
-    q.view,
-    `p${q.page}`,
-    `s${q.pageSize}`,
-    `st:${q.status ?? 'all'}`,
-    `q:${sanitizeSearch(q.search ?? null)}`,
-    `ids:${(parseIds(q.ids) ?? []).join(',')}`,
+    'catalog:categories:list', organizationId, q.view,
+    `p${q.page}`, `s${q.pageSize}`, `st:${q.status ?? 'all'}`,
+    `q:${sanitizeSearch(q.search ?? null)}`, `ids:${(parseIds(q.ids) ?? []).join(',')}`,
   ].join('|')
 }
 
 // inside GET, after organizationId/tenantId are resolved:
-const cache = (() => { try { return container.resolve('cache') as CacheStrategy } catch { return null } })()
+const cacheEnabled = isCrudCacheEnabled() // MUST gate on the same flag the flush path checks
+const cache = cacheEnabled ? (() => { try { return container.resolve('cache') } catch { return null } })() : null
 const cacheKey = categoryListCacheKey(organizationId, query)
 
 if (cache) {
-  const hit = await runWithCacheTenant(tenantId, () => cache.get(cacheKey))
-  if (hit !== undefined && hit !== null) {
-    return NextResponse.json(hit)
-  }
+  const hit = await cache.get(cacheKey)
+  if (hit !== undefined && hit !== null) return NextResponse.json(hit)
 }
 
 // ... existing compute → build `payload` (the exact object passed to NextResponse.json today) ...
 
 if (cache) {
-  await runWithCacheTenant(tenantId, () =>
-    cache.set(cacheKey, payload, {
-      ttl: CATEGORY_LIST_TTL_MS,
-      tags: [
-        CATEGORY_LIST_TAG,
-        `${CATEGORY_LIST_TAG}:org:${organizationId}`,
-      ],
-    }),
-  )
+  await cache.set(cacheKey, payload, {
+    ttl: CATEGORY_LIST_TTL_MS,
+    tags: buildCollectionTags('catalog.category', tenantId, [organizationId]),
+  })
 }
 ```
-
-Tenant scoping: `runWithCacheTenant(tenantId, …)` auto-prefixes/namespaces keys and tags per tenant, so org-A can never read org-B's entry even though the literal key only carries `organizationId`. Always wrap both the `get` and the `set` (and the invalidation `deleteByTags`) in `runWithCacheTenant(tenantId, …)`.
-
-TTL justification: 10 minutes is a pure backstop against missed invalidations (e.g. an out-of-band SQL edit or a failed best-effort `deleteByTags`). Correctness comes from the event-driven tag invalidation; category data tolerates a multi-minute convergence window comfortably since it changes on the order of weeks.
 
 ## Cache tags
 
-- `catalog.categories.list` — broad tag on every cached category-list entry for the tenant. Lets a single `deleteByTags(['catalog.categories.list'])` flush all views/pages/filters for the tenant on any category mutation. (Tenant-namespaced internally, so it only clears the writing tenant.)
-- `catalog.categories.list:org:<organizationId>` — narrows invalidation to one organization within the tenant. Use when the mutation's org is known (it always is, from the event payload) to avoid clearing sibling orgs' caches.
+- `crud:catalog.category:tenant:<T>:org:<O>:collection` — **reused, already flushed** by the command bus on every `catalog.categories.create|update|delete` execute and undo, post-commit. Built with the shared helper `buildCollectionTags('catalog.category', tenantId, [organizationId])` so the literal shape can never drift from the flusher's.
 
-(Both literal strings are written under `runWithCacheTenant(tenantId, …)`, which prepends the tenant namespace — so the effective tag is tenant-scoped.)
+No new tags. No subscribers.
 
 ## Invalidation
 
-Add one ephemeral subscriber per category event (or one subscriber handling all three). Invalidation MUST run on the event, which is emitted **post-commit** by `emitCrudSideEffects` (outside `withAtomicFlush`) in `packages/core/src/modules/catalog/commands/categories.ts` — so it is already after the DB commit. A single category write rebuilds the hierarchy for the whole org (`rebuildCategoryHierarchyForOrganization`), so every mutation must clear the org-scoped tag, not just one record.
-
-| Trigger (route/command/event) | Where to call deleteByTags | Tags invalidated |
+| Trigger (route/command/event) | Where the flush already happens | Tags invalidated |
 |---|---|---|
-| `catalog.category.created` (emitted by command `catalog.categories.create`, `commands/categories.ts:205`) | New subscriber `subscribers/category-cache-invalidate.ts`; `runWithCacheTenant(payload.tenantId, () => cache.deleteByTags([...]))` | `catalog.categories.list:org:<payload.organizationId>` (and/or `catalog.categories.list` as a coarse fallback) |
-| `catalog.category.updated` (command `catalog.categories.update`, `commands/categories.ts:369`) | same subscriber | `catalog.categories.list:org:<payload.organizationId>` |
-| `catalog.category.deleted` (command `catalog.categories.delete`, `commands/categories.ts:519`) | same subscriber | `catalog.categories.list:org:<payload.organizationId>` |
-| Category **custom-field** edit (also flows through `catalog.categories.update` → `setCustomFieldsIfAny` then `emitCrudSideEffects`, `commands/categories.ts:360-379`) | same subscriber via `catalog.category.updated` | `catalog.categories.list:org:<payload.organizationId>` — covers the CFV columns merged into `manage` rows |
-| Command **undo/redo** (re-emit the same `catalog.category.*` events) | same subscriber | same as above |
+| `catalog.categories.create` (`commands/categories.ts:205`) | command bus `invalidateCacheAfterExecute` (`command-bus.ts:610`) — existing | `crud:catalog.category:tenant:<T>:org:<O>:collection` + record tag |
+| `catalog.categories.update` (incl. custom-field edits, `commands/categories.ts:360-379`) | same — existing | same |
+| `catalog.categories.delete` (`commands/categories.ts:519`) | same — existing | same |
+| Command undo/redo | command bus `invalidateCacheAfterUndo` (`command-bus.ts:642`) — existing | same |
 
-Subscriber sketch (`packages/core/src/modules/catalog/subscribers/category-cache-invalidate.ts`):
+**Nothing to add on the write side.**
 
-```ts
-export const metadata = { event: 'catalog.category.updated', persistent: false, id: 'category-cache-invalidate-updated' }
-export default async function handler(payload, ctx) {
-  const cache = ctx.resolve?.('cache') ?? ctx.container?.resolve('cache')
-  if (!cache?.deleteByTags) return
-  const orgTag = `catalog.categories.list:org:${payload.organizationId}`
-  try {
-    await runWithCacheTenant(payload.tenantId, () => cache.deleteByTags([orgTag, 'catalog.categories.list']))
-  } catch { /* best-effort; TTL is the backstop */ }
-}
-```
+## Safety / non-invalidation risks (double-checked)
 
-(Repeat the export for `.created` and `.deleted`, or register one file per event id per the subscriber auto-discovery contract. The event payloads already carry `{ id, organizationId, tenantId }` per `buildPayload` in `commands/categories.ts:27-31`.)
+- **`ENABLE_CRUD_API_CACHE` gate:** `invalidateCrudCache` no-ops when the flag is off (`packages/shared/lib/crud/cache.ts:180`). The read-side cache is therefore gated on `isCrudCacheEnabled()` — flag off ⇒ no caching ⇒ behavior identical to today. Never ship this cache ungated.
+- **Org-axis mismatch:** the command-bus flush targets the org recorded in the command metadata. If a category command ever logged a null `organizationId`, only the `org:null` collection tag would flush and an org-scoped entry would persist until TTL. The 10-min TTL is the backstop; `buildPayload` for categories always carries the org (`buildPayload`, `commands/categories.ts:27-31`), so this is theoretical.
+- **Tenant namespace:** read-side set happens inside the dispatcher's `runWithCacheTenant(auth.tenantId)`; the flush wraps in `runWithCacheTenant(tenantId)` with the write's tenant — same namespace for same-tenant writes. Cross-tenant superadmin writes resolve `tenantId` from the record, still matching.
+- **Out-of-band SQL edits / missed flushes:** bounded by the 10-min TTL. Category data is non-financial, read-mostly.
+- **Never cache the `401`/`400` early-return branches** — only the successful computed payload.
+- **Cache absence:** all paths guarded; if `cache` does not resolve, behavior is identical to today.
 
 ## Implementation steps
 
-- [ ] Refactor the tail of `GET` so the response object is assembled into a single `payload` variable before `NextResponse.json(payload)` (both `tree` and `manage` branches), so caching wraps one value.
-- [ ] Add `categoryListCacheKey()` + the get-then-set block in `route.ts` using `container.resolve('cache')` guarded by try/catch (cache optional), wrapping `get`/`set` in `runWithCacheTenant(tenantId, …)`.
-- [ ] Do NOT cache the `401`/`400` early-return branches — only cache the successful computed payload.
-- [ ] Add `subscribers/category-cache-invalidate*.ts` for `catalog.category.created|updated|deleted` (ephemeral, `persistent: false`), each calling `runWithCacheTenant(payload.tenantId, () => cache.deleteByTags([...]))`.
-- [ ] Run `yarn generate` so the new subscribers are discovered.
-- [ ] Add tags `catalog.categories.list` and `catalog.categories.list:org:<org>` on `set`.
-- [ ] Verify nothing relies on the response being uncached/clock-fresh (it does not — no timestamps computed at request time beyond `updatedAt` which comes from the row).
+- [ ] Refactor the tail of `GET` so the response object is assembled into a single `payload` variable before `NextResponse.json(payload)` (both `tree` and `manage` branches).
+- [ ] Add `categoryListCacheKey()` + the get-then-set block gated on `isCrudCacheEnabled()`, with tags from `buildCollectionTags('catalog.category', tenantId, [organizationId])`.
+- [ ] Do NOT cache the `401`/`400` early-return branches.
+- [ ] Verify nothing relies on the response being uncached/clock-fresh (it does not).
 - [ ] `yarn workspace @open-mercato/core build` + `yarn workspace @open-mercato/core test`.
-
-## Risks & staleness window
-
-- **Staleness window:** Between a category write committing and the best-effort `deleteByTags` completing, concurrent reads may briefly see the pre-write hierarchy. Bounded by the 10-minute TTL even if invalidation fails. Acceptable: category structure is non-financial, non-stock, read-mostly, and changes on a weeks cadence.
-- **Cross-tenant safety:** Enforced by `runWithCacheTenant(tenantId, …)` on every `get`/`set`/`deleteByTags`. The literal key carries only `organizationId`; tenant isolation is the namespace, never the key.
-- **Org-scope correctness:** A single category mutation rebuilds the whole org hierarchy, so the invalidation clears the org-scoped tag (covering all views/pages/filters), not a single record tag — matching the blast radius of `rebuildCategoryHierarchyForOrganization`.
-- **Custom-field edits:** Covered because CF writes route through `catalog.categories.update` → `catalog.category.updated`; the `manage` view's merged CFV columns are invalidated alongside.
-- **Cache absence:** All paths are guarded — if `cache` does not resolve, behavior is identical to today.
-- **Not the CRUD list cache:** This is deliberately a manual cache, because the read is a custom handler the factory cache cannot reach. Enabling `ENABLE_CRUD_API_CACHE` would NOT cache this endpoint.
 
 ## Acceptance criteria / tests
 
-- [ ] Unit/integration: two successive identical `GET /api/catalog/categories?view=manage` calls for the same tenant/org — the second is a cache hit (assert via cache spy or `[crud][cache]`-style debug, or by asserting the hierarchy compute path is not re-entered).
-- [ ] Creating a category (`POST`) then re-fetching the list returns the new category (tag invalidation fired on `catalog.category.created`).
-- [ ] Updating a category's `name`/`parentId` then re-fetching reflects the change and the recomputed `pathLabel`/`depth`.
-- [ ] Editing a category **custom field** then re-fetching `view=manage` returns the new CFV values (proves `catalog.category.updated` clears the manage cache).
-- [ ] Deleting a category then re-fetching omits it.
-- [ ] Tenant isolation: org-B writes do not invalidate or read org-A's cached entry; two tenants with identical org ids never collide (namespace test).
-- [ ] `view=tree` and `view=manage` are cached independently (different keys); pagination/search/status/ids variants do not bleed into each other.
+- [ ] With `ENABLE_CRUD_API_CACHE=on`: two successive identical `GET /api/catalog/categories?view=manage` calls — the second is a cache hit (hierarchy compute not re-entered).
+- [ ] Creating/updating/deleting a category then re-fetching reflects the change immediately (command-bus tag flush, no TTL wait).
+- [ ] Editing a category **custom field** then re-fetching `view=manage` returns the new CFV values.
+- [ ] With `ENABLE_CRUD_API_CACHE` off: no cache get/set occurs; behavior byte-identical to today.
+- [ ] Tenant isolation: two tenants with identical org ids never collide; org-B writes do not affect org-A entries.
+- [ ] `view=tree` / `view=manage` / pagination / search / status / ids variants cache independently.
 - [ ] With cache unavailable (DI throws), the endpoint still returns correct data.
 
 ## Labels
 
 `feature`, `performance`, `priority-medium`
-

--- a/.ai/analysis/2026-06-08-cache-perf-frs/01-cache-catalog-categories-list.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/01-cache-catalog-categories-list.md
@@ -1,0 +1,148 @@
+> Auto-generated cache-performance Feature Request — candidate 1 of 9
+> Endpoint: `GET /api/catalog/categories` · ROI 86 · Verdict: strong-quick-win
+> Source: `packages/core/src/modules/catalog/api/categories/route.ts`
+
+## Summary
+
+`GET /api/catalog/categories` is served by a **custom `export async function GET`** handler (not the `makeCrudRoute` GET), so it completely bypasses the generic CRUD list cache gated behind `ENABLE_CRUD_API_CACHE`. On every call it loads the full category set for the org, recomputes the entire hierarchy (`computeHierarchyForCategories` — a recursive ancestor/descendant/path walk), and for the `manage` view additionally runs a per-record custom-field aggregation (`loadCustomFieldValues`) over the paged rows. This data changes on the order of weeks but is read on nearly every product form load and category browse. Add a manual tenant-scoped get-then-set cache (mirroring `domainMappingService.ts`) with tag-based invalidation fired from the existing `catalog.category.{created,updated,deleted}` event subscribers.
+
+## Why (impact)
+
+- **Hotness (high):** The category picker is rendered on every product create/edit form, the category browse/tree page, and dashboard category widgets. High read:write ratio — categories are mutated rarely (weeks), read constantly.
+- **Cost (medium-high):** Per request the handler does: 1 `em.find` over all org categories (`route.ts:173`), a full recursive hierarchy computation (`computeHierarchyForCategories`, `categoryHierarchy.ts:40`) building ancestor/descendant/path-label maps, tree-node assembly for `view=tree`, and for `view=manage` a custom-field-values aggregation `loadCustomFieldValues` over the paged record ids (`route.ts:238-247`). That is 2 queries + an O(N) graph walk + a CFV EAV aggregation on each hit.
+- **Est. win:** Near-elimination of the hierarchy recompute and the CFV aggregation on cache hits. For a tenant whose categories are stable, virtually every request after the first becomes a single cache `get`. Expect the dominant per-request cost (graph walk + CFV load) to drop to ~0 on hits within the TTL/convergence window.
+
+## Current behavior
+
+File: `packages/core/src/modules/catalog/api/categories/route.ts`
+
+- `GET` is a fully custom handler (`route.ts:131`), distinct from `crud.POST/PUT/DELETE` (`route.ts:285-287`). The CRUD list cache in `packages/shared/src/lib/crud/cache.ts` is therefore **never** consulted for this read — even if `ENABLE_CRUD_API_CACHE` were on, only factory GETs are covered.
+- `route.ts:173-177` — `em.find(CatalogProductCategory, { organizationId, tenantId, deletedAt: null }, { orderBy: { name: 'ASC' } })`.
+- `route.ts:179` — `computeHierarchyForCategories(categories)` (recursive walk in `packages/core/src/modules/catalog/lib/categoryHierarchy.ts:40-166`).
+- `route.ts:181-205` — `view=tree`: builds nested `TreeNode` roots.
+- `route.ts:207-271` — `view=manage`: status/search/ids filtering, pagination, then `loadCustomFieldValues(...)` (`route.ts:238-247`) and row assembly merging category scalars + CFV.
+- Response is deterministic for a given `(tenantId, organizationId, categories snapshot, custom-field values, query params)`. No clock-sensitivity, no per-user secrets — the only auth-scoped axis is `(tenantId, organizationId)`, which is already the cache tenant/key boundary.
+
+## Proposed cache
+
+Manual get-then-set inside the `GET` handler, scoped with `runWithCacheTenant(tenantId, …)`. Key includes the org plus the full query shape (view/page/pageSize/search/status/ids) so distinct views/pages cache independently.
+
+```ts
+import { runWithCacheTenant, type CacheStrategy } from '@open-mercato/cache'
+
+const CATEGORY_LIST_TAG = 'catalog.categories.list'
+const CATEGORY_LIST_TTL_MS = 10 * 60_000 // 10 min backstop; tags carry correctness
+
+function categoryListCacheKey(organizationId: string, q: QueryShape): string {
+  return [
+    'catalog:categories:list',
+    organizationId,
+    q.view,
+    `p${q.page}`,
+    `s${q.pageSize}`,
+    `st:${q.status ?? 'all'}`,
+    `q:${sanitizeSearch(q.search ?? null)}`,
+    `ids:${(parseIds(q.ids) ?? []).join(',')}`,
+  ].join('|')
+}
+
+// inside GET, after organizationId/tenantId are resolved:
+const cache = (() => { try { return container.resolve('cache') as CacheStrategy } catch { return null } })()
+const cacheKey = categoryListCacheKey(organizationId, query)
+
+if (cache) {
+  const hit = await runWithCacheTenant(tenantId, () => cache.get(cacheKey))
+  if (hit !== undefined && hit !== null) {
+    return NextResponse.json(hit)
+  }
+}
+
+// ... existing compute → build `payload` (the exact object passed to NextResponse.json today) ...
+
+if (cache) {
+  await runWithCacheTenant(tenantId, () =>
+    cache.set(cacheKey, payload, {
+      ttl: CATEGORY_LIST_TTL_MS,
+      tags: [
+        CATEGORY_LIST_TAG,
+        `${CATEGORY_LIST_TAG}:org:${organizationId}`,
+      ],
+    }),
+  )
+}
+```
+
+Tenant scoping: `runWithCacheTenant(tenantId, …)` auto-prefixes/namespaces keys and tags per tenant, so org-A can never read org-B's entry even though the literal key only carries `organizationId`. Always wrap both the `get` and the `set` (and the invalidation `deleteByTags`) in `runWithCacheTenant(tenantId, …)`.
+
+TTL justification: 10 minutes is a pure backstop against missed invalidations (e.g. an out-of-band SQL edit or a failed best-effort `deleteByTags`). Correctness comes from the event-driven tag invalidation; category data tolerates a multi-minute convergence window comfortably since it changes on the order of weeks.
+
+## Cache tags
+
+- `catalog.categories.list` — broad tag on every cached category-list entry for the tenant. Lets a single `deleteByTags(['catalog.categories.list'])` flush all views/pages/filters for the tenant on any category mutation. (Tenant-namespaced internally, so it only clears the writing tenant.)
+- `catalog.categories.list:org:<organizationId>` — narrows invalidation to one organization within the tenant. Use when the mutation's org is known (it always is, from the event payload) to avoid clearing sibling orgs' caches.
+
+(Both literal strings are written under `runWithCacheTenant(tenantId, …)`, which prepends the tenant namespace — so the effective tag is tenant-scoped.)
+
+## Invalidation
+
+Add one ephemeral subscriber per category event (or one subscriber handling all three). Invalidation MUST run on the event, which is emitted **post-commit** by `emitCrudSideEffects` (outside `withAtomicFlush`) in `packages/core/src/modules/catalog/commands/categories.ts` — so it is already after the DB commit. A single category write rebuilds the hierarchy for the whole org (`rebuildCategoryHierarchyForOrganization`), so every mutation must clear the org-scoped tag, not just one record.
+
+| Trigger (route/command/event) | Where to call deleteByTags | Tags invalidated |
+|---|---|---|
+| `catalog.category.created` (emitted by command `catalog.categories.create`, `commands/categories.ts:205`) | New subscriber `subscribers/category-cache-invalidate.ts`; `runWithCacheTenant(payload.tenantId, () => cache.deleteByTags([...]))` | `catalog.categories.list:org:<payload.organizationId>` (and/or `catalog.categories.list` as a coarse fallback) |
+| `catalog.category.updated` (command `catalog.categories.update`, `commands/categories.ts:369`) | same subscriber | `catalog.categories.list:org:<payload.organizationId>` |
+| `catalog.category.deleted` (command `catalog.categories.delete`, `commands/categories.ts:519`) | same subscriber | `catalog.categories.list:org:<payload.organizationId>` |
+| Category **custom-field** edit (also flows through `catalog.categories.update` → `setCustomFieldsIfAny` then `emitCrudSideEffects`, `commands/categories.ts:360-379`) | same subscriber via `catalog.category.updated` | `catalog.categories.list:org:<payload.organizationId>` — covers the CFV columns merged into `manage` rows |
+| Command **undo/redo** (re-emit the same `catalog.category.*` events) | same subscriber | same as above |
+
+Subscriber sketch (`packages/core/src/modules/catalog/subscribers/category-cache-invalidate.ts`):
+
+```ts
+export const metadata = { event: 'catalog.category.updated', persistent: false, id: 'category-cache-invalidate-updated' }
+export default async function handler(payload, ctx) {
+  const cache = ctx.resolve?.('cache') ?? ctx.container?.resolve('cache')
+  if (!cache?.deleteByTags) return
+  const orgTag = `catalog.categories.list:org:${payload.organizationId}`
+  try {
+    await runWithCacheTenant(payload.tenantId, () => cache.deleteByTags([orgTag, 'catalog.categories.list']))
+  } catch { /* best-effort; TTL is the backstop */ }
+}
+```
+
+(Repeat the export for `.created` and `.deleted`, or register one file per event id per the subscriber auto-discovery contract. The event payloads already carry `{ id, organizationId, tenantId }` per `buildPayload` in `commands/categories.ts:27-31`.)
+
+## Implementation steps
+
+- [ ] Refactor the tail of `GET` so the response object is assembled into a single `payload` variable before `NextResponse.json(payload)` (both `tree` and `manage` branches), so caching wraps one value.
+- [ ] Add `categoryListCacheKey()` + the get-then-set block in `route.ts` using `container.resolve('cache')` guarded by try/catch (cache optional), wrapping `get`/`set` in `runWithCacheTenant(tenantId, …)`.
+- [ ] Do NOT cache the `401`/`400` early-return branches — only cache the successful computed payload.
+- [ ] Add `subscribers/category-cache-invalidate*.ts` for `catalog.category.created|updated|deleted` (ephemeral, `persistent: false`), each calling `runWithCacheTenant(payload.tenantId, () => cache.deleteByTags([...]))`.
+- [ ] Run `yarn generate` so the new subscribers are discovered.
+- [ ] Add tags `catalog.categories.list` and `catalog.categories.list:org:<org>` on `set`.
+- [ ] Verify nothing relies on the response being uncached/clock-fresh (it does not — no timestamps computed at request time beyond `updatedAt` which comes from the row).
+- [ ] `yarn workspace @open-mercato/core build` + `yarn workspace @open-mercato/core test`.
+
+## Risks & staleness window
+
+- **Staleness window:** Between a category write committing and the best-effort `deleteByTags` completing, concurrent reads may briefly see the pre-write hierarchy. Bounded by the 10-minute TTL even if invalidation fails. Acceptable: category structure is non-financial, non-stock, read-mostly, and changes on a weeks cadence.
+- **Cross-tenant safety:** Enforced by `runWithCacheTenant(tenantId, …)` on every `get`/`set`/`deleteByTags`. The literal key carries only `organizationId`; tenant isolation is the namespace, never the key.
+- **Org-scope correctness:** A single category mutation rebuilds the whole org hierarchy, so the invalidation clears the org-scoped tag (covering all views/pages/filters), not a single record tag — matching the blast radius of `rebuildCategoryHierarchyForOrganization`.
+- **Custom-field edits:** Covered because CF writes route through `catalog.categories.update` → `catalog.category.updated`; the `manage` view's merged CFV columns are invalidated alongside.
+- **Cache absence:** All paths are guarded — if `cache` does not resolve, behavior is identical to today.
+- **Not the CRUD list cache:** This is deliberately a manual cache, because the read is a custom handler the factory cache cannot reach. Enabling `ENABLE_CRUD_API_CACHE` would NOT cache this endpoint.
+
+## Acceptance criteria / tests
+
+- [ ] Unit/integration: two successive identical `GET /api/catalog/categories?view=manage` calls for the same tenant/org — the second is a cache hit (assert via cache spy or `[crud][cache]`-style debug, or by asserting the hierarchy compute path is not re-entered).
+- [ ] Creating a category (`POST`) then re-fetching the list returns the new category (tag invalidation fired on `catalog.category.created`).
+- [ ] Updating a category's `name`/`parentId` then re-fetching reflects the change and the recomputed `pathLabel`/`depth`.
+- [ ] Editing a category **custom field** then re-fetching `view=manage` returns the new CFV values (proves `catalog.category.updated` clears the manage cache).
+- [ ] Deleting a category then re-fetching omits it.
+- [ ] Tenant isolation: org-B writes do not invalidate or read org-A's cached entry; two tenants with identical org ids never collide (namespace test).
+- [ ] `view=tree` and `view=manage` are cached independently (different keys); pagination/search/status/ids variants do not bleed into each other.
+- [ ] With cache unavailable (DI throws), the endpoint still returns correct data.
+
+## Labels
+
+`feature`, `performance`, `priority-medium`
+

--- a/.ai/analysis/2026-06-08-cache-perf-frs/02-cache-organization-switcher-menu.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/02-cache-organization-switcher-menu.md
@@ -1,0 +1,136 @@
+> Auto-generated cache-performance Feature Request — candidate 2 of 9
+> Endpoint: `GET /api/directory/organization-switcher` · ROI 84 · Verdict: good
+> Source: `packages/core/src/modules/directory/api/organization-switcher/route.ts`
+
+## Summary
+
+Add a tenant-scoped, get-then-set response cache to `GET /api/directory/organization-switcher` (`packages/core/src/modules/directory/api/organization-switcher/route.ts`). The handler is invoked on essentially every backend page load (the global `OrganizationSwitcher` chrome component) yet recomputes a stable org tree + RBAC scope on each call. Cache the full response payload keyed by `(userId, tenantId, selectedOrg)` with a short TTL (60s) and invalidate via tags on `directory.organization.*` and `directory.tenant.*` events. **The hard part — tag-based invalidation — is already wired** (`packages/core/src/modules/directory/subscribers/invalidateOrgScopeCache.ts` fires on `directory.organization.*`); this FR reuses the same tag namespace and adds a tenant-event hook so the new entry stays correct.
+
+## Why (impact)
+
+- **Hotness: very high.** `apps/mercato/src/components/OrganizationSwitcher.tsx:195` calls this URL on mount of the backend header chrome (every backend navigation that remounts the switcher), `packages/create-app/template/src/components/OrganizationSwitcher.tsx:195` does the same in scaffolded apps, and it is additionally fetched by `packages/core/src/modules/api_keys/backend/api-keys/create/page.tsx:39` and `packages/core/src/modules/customer_accounts/backend/customer_accounts/settings/domain/page.tsx:97`. Read:write ratio is extremely high — the org tree changes weekly at most.
+- **Cost: moderate-to-heavy and compounding.** Per call the handler does: `em.find(Tenant)` (superadmin path), `rbac.loadAcl` (route.ts:142), `rbac.userHasAllFeatures` (route.ts:147), `em.find(Organization)` (route.ts:157), `computeHierarchyForOrganizations` (a recursive tree walk with per-level name sorting — `packages/core/src/modules/directory/lib/hierarchy.ts:37`), then `resolveOrganizationScope` (route.ts:166) which itself does a **second** `rbac.loadAcl` (organizationScope.ts:226) plus another `em.find(Organization)` for descendant expansion (organizationScope.ts:163), and finally `buildOrganizationMenu`. That is ~2 ACL loads + 2 org-table scans + tree compute on every page view.
+- **Est. win:** eliminates 2 RBAC ACL loads, 2 `organizations` scans, and the hierarchy/menu compute for the ~60s window after the first hit per user — i.e. nearly every navigation within a session becomes a single cache read. This is the dominant per-navigation directory cost.
+
+## Current behavior
+
+`packages/core/src/modules/directory/api/organization-switcher/route.ts`:
+- `route.ts:92` `GET` resolves auth, then on every request builds a fresh request container (`route.ts:101`).
+- `route.ts:116` superadmin branch loads all tenants via `em.find(Tenant, { deletedAt: null })`.
+- `route.ts:142` `rbac.loadAcl(...)` and `route.ts:147` `rbac.userHasAllFeatures([... 'directory.organizations.manage'])`.
+- `route.ts:157` `em.find(Organization, { tenant, deletedAt: null })`.
+- `route.ts:162` `computeHierarchyForOrganizations(orgEntities, tenantId)` (`hierarchy.ts:37`).
+- `route.ts:166` `resolveOrganizationScope(...)` — note it calls the **uncached** `resolveOrganizationScope`, NOT the cached wrapper `resolveOrganizationScopeForRequest` (organizationScope.ts:317). Inside it does a second `rbac.loadAcl` (organizationScope.ts:226) and `loadOrgDescendantMap` org query (organizationScope.ts:163).
+- `route.ts:178` `buildOrganizationMenu(hierarchy, accessible)` builds the final node tree + selectable set.
+- `route.ts:199-221` assembles `{ items, selectedId, canManage, canViewAllOrganizations, tenantId, tenants, isSuperAdmin }`, calls `logCrudAccess`, and returns.
+
+There is **no response cache** today. A partial cache exists for `resolveOrganizationScope` (the `org-scope:*` cache in `organizationScope.ts:317`, default-off behind `OM_ORG_SCOPE_CACHE_TTL_MS`), but this route bypasses it by calling the raw function, so even with that flag on the route stays uncached.
+
+## Proposed cache
+
+Wrap the existing compute in a get-then-set around the **assembled response object**, scoped to the tenant with `runWithCacheTenant`. `logCrudAccess` must still run on every request (audit must not be cached), so cache only the payload, not the side effect.
+
+Key shape (hashed + tenant-namespaced internally by the cache layer, but be explicit):
+
+```
+org-switcher:v1:<userId>:<tenantId>:<selectedOrg|none|all>
+```
+
+Code sketch (inside the `try` block, after `tenantId` is resolved and before the heavy compute at route.ts:142):
+
+```typescript
+import { runWithCacheTenant } from '@open-mercato/cache'
+import type { CacheStrategy } from '@open-mercato/cache'
+
+const ORG_SWITCHER_CACHE_PREFIX = 'org-switcher:v1'
+const ORG_SWITCHER_TTL_MS = 60_000
+
+const cache = (() => {
+  try {
+    const c = container.resolve('cache') as CacheStrategy | undefined
+    return c && typeof c.get === 'function' && typeof c.set === 'function' ? c : null
+  } catch { return null }
+})()
+
+const rawSelected = getSelectedOrganizationFromRequest(req)
+const requestedAll = isAllOrganizationsSelection(rawSelected)
+const selectedKeyPart = requestedAll ? 'all' : (rawSelected ?? 'none')
+const cacheKey = `${ORG_SWITCHER_CACHE_PREFIX}:${auth.sub}:${tenantId}:${selectedKeyPart}`
+const cacheTags = [
+  `org-scope:tenant:${tenantId}`,        // reuse existing org-mutation invalidation
+  `org-switcher:tenant:${tenantId}`,     // new: targeted switcher tag
+  `org-switcher:user:${auth.sub}`,       // new: per-user (role/ACL change)
+]
+
+const buildPayload = async () => { /* existing route.ts:142..207 compute, returns `response` */ }
+
+const response = await runWithCacheTenant(tenantId, async () => {
+  if (cache) {
+    try {
+      const hit = await cache.get(cacheKey)
+      if (hit && typeof hit === 'object') return hit as Awaited<ReturnType<typeof buildPayload>>
+    } catch (err) { console.warn('[org-switcher:cache] read failed', err) }
+  }
+  const built = await buildPayload()
+  if (cache) {
+    try { await cache.set(cacheKey, built, { ttl: ORG_SWITCHER_TTL_MS, tags: cacheTags }) }
+    catch (err) { console.warn('[org-switcher:cache] write failed', err) }
+  }
+  return built
+})
+
+// audit ALWAYS runs, never cached:
+await logCrudAccess({ container, auth, request: req, items: response.items, ... })
+return NextResponse.json(response)
+```
+
+Notes:
+- TTL 60s mirrors the sibling `org-scope` cache default and bounds staleness for membership/visibility changes that do not emit a directory event.
+- For the superadmin tenant-list portion, the `org-switcher:tenant:<tenantId>` + tenant-event invalidation (below) keeps it fresh; the 60s TTL is the backstop for cross-tenant tenant renames a superadmin might not have a direct tag for. If exactness of the *other-tenant* list matters, gate the superadmin path out of the cache (`if (actorIsSuperAdmin) skip set`) — recommended as a conservative v1.
+
+## Cache tags
+
+- `org-scope:tenant:<tenantId>` — **reused** from the existing org-scope cache. Already invalidated by `packages/core/src/modules/directory/subscribers/invalidateOrgScopeCache.ts` on `directory.organization.*`. Tagging the switcher entry with it means org create/update/delete already busts this entry with zero new wiring.
+- `org-switcher:tenant:<tenantId>` — new. Represents "any switcher entry for this tenant" (org tree + tenant-active state). Invalidated on org and tenant mutations for that tenant.
+- `org-switcher:user:<userId>` — new. Represents "this user's allowed-org / role view". Invalidated when the user's role/ACL/org membership changes (so a permission grant is reflected without waiting for TTL).
+
+## Invalidation
+
+| Trigger (route/command/event) | Where to call deleteByTags | Tags invalidated |
+|---|---|---|
+| `directory.organization.created` / `.updated` / `.deleted` (emitted by `packages/core/src/modules/directory/commands/organizations.ts`, post-commit after `rebuildHierarchyForTenant`) | Already handled by existing subscriber `directory/subscribers/invalidateOrgScopeCache.ts` (event `directory.organization.*`); extend it to also delete `org-switcher:tenant:${tenantId}` | `org-scope:tenant:<id>` (existing), add `org-switcher:tenant:<id>` |
+| `directory.tenant.created` / `.updated` / `.deleted` (`directory/commands/tenants.ts`, post-commit) | New ephemeral subscriber `directory/subscribers/invalidateOrgSwitcherOnTenant.ts` (event `directory.tenant.*`) calling `cache.deleteByTags(['org-switcher:tenant:'+tenantId])` (rename/deactivate affects the superadmin tenant list + active flag) | `org-switcher:tenant:<id>` |
+| User role/ACL/org-membership change (auth/RBAC writes; e.g. user-organization assignment) | In the same post-commit hook that already calls `invalidateOrganizationScopeCacheForUser(container, userId)` (organizationScope.ts:78), also delete `org-switcher:user:${userId}`. If that helper has no current caller wired, add a subscriber on the user-org-membership event | `org-switcher:user:<id>` (and reuse `org-scope:user:<id>`) |
+
+All `deleteByTags` calls fire **post-commit** (outside `withAtomicFlush`), consistent with the existing `invalidateOrgScopeCache` subscriber which runs on the persisted, post-write event. TTL (60s) is the backstop for any membership/visibility change that does not emit a directory event.
+
+## Implementation steps
+
+- [ ] In `route.ts`, after `tenantId` resolution (route.ts:130), resolve `cache` from `container` defensively and compute `cacheKey` + `cacheTags` from `auth.sub`, `tenantId`, and the selected-org cookie.
+- [ ] Extract the existing compute (route.ts:142..207) into a local `buildPayload()` returning the `response` object; wrap the get/set in `runWithCacheTenant(tenantId, ...)`.
+- [ ] Keep `logCrudAccess` (route.ts:209) and the `NextResponse.json` OUTSIDE/AFTER the cache so audit fires every request.
+- [ ] (Conservative v1) skip the cache `set` when `actorIsSuperAdmin` to avoid caching cross-tenant tenant lists, OR add tenant-tag invalidation per the table.
+- [ ] Extend `directory/subscribers/invalidateOrgScopeCache.ts` to also `deleteByTags(['org-switcher:tenant:'+tenantId])`.
+- [ ] Add `directory/subscribers/invalidateOrgSwitcherOnTenant.ts` (event `directory.tenant.*`, `persistent: false`) deleting `org-switcher:tenant:<tenantId>`.
+- [ ] Wire `org-switcher:user:<userId>` deletion into the same place that already invalidates `org-scope:user:<userId>` on role/membership change; if none exists, add a subscriber on the user-organization assignment event.
+- [ ] `yarn generate` (new subscriber auto-discovery), then `yarn workspace @open-mercato/core build` + `test`.
+
+## Risks & staleness window
+
+- **Staleness window: ≤60s** for changes with no emitted event (e.g. a direct DB org edit). For org/tenant CRUD and role changes done through commands, invalidation is near-immediate (post-commit event) with TTL as backstop.
+- **Cross-tenant leakage: none** — keyed and namespaced by `tenantId` via `runWithCacheTenant`, and the key embeds `userId`. Conservative v1 also excludes the superadmin all-tenants list from caching.
+- **Not auth/financial data** — this is read-mostly navigation metadata; a brief convergence window is acceptable. `selectedId` correction logic (route.ts:181) still runs inside the cached payload per `(userId, selectedOrg)` key, so per-selection responses stay correct.
+- **Audit integrity preserved** — `logCrudAccess` deliberately stays outside the cache.
+- Verdict is `good` (not strong-quick-win) because partial infrastructure exists but the route currently bypasses it, the superadmin tenant-list branch needs a deliberate cache decision, and one user-level invalidation hook may need to be located/added.
+
+## Acceptance criteria / tests
+
+- [ ] Unit: a cache double records one `set` for the first `GET` and zero ACL/org `em.find` calls on the immediate second `GET` with identical `(userId, tenantId, selectedOrg)` (extend `directory/utils/__tests__/organizationScopeCache.test.ts` style).
+- [ ] Unit: `set` is tagged with all three tags; `deleteByTags(['org-switcher:tenant:<id>'])` (and the reused `org-scope:tenant:<id>`) removes the entry.
+- [ ] Integration (extend `directory/__integration__/TC-DIR-004.spec.ts`): create an organization, then `GET /api/directory/organization-switcher` returns the new org within the convergence window (event-driven invalidation), proving no stale tree is served after a write.
+- [ ] Integration: two different users in the same tenant get correctly different `items`/`canManage` (key isolation by `userId`).
+- [ ] Audit: `audit_logs` still records one access row per request even on cache hits.
+
+## Labels
+
+`feature`, `performance`, `priority-medium`

--- a/.ai/analysis/2026-06-08-cache-perf-frs/02-cache-organization-switcher-menu.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/02-cache-organization-switcher-menu.md
@@ -1,134 +1,100 @@
 > Auto-generated cache-performance Feature Request — candidate 2 of 9
 > Endpoint: `GET /api/directory/organization-switcher` · ROI 84 · Verdict: good
 > Source: `packages/core/src/modules/directory/api/organization-switcher/route.ts`
+> Revised 2026-06-09: all invalidation now rides **existing flushed tags** (`org-scope:tenant:*`, `rbac:user:*`); the previously proposed new tags + tenant-event subscriber are dropped. Includes one safety fix to the existing org-scope subscriber.
 
 ## Summary
 
-Add a tenant-scoped, get-then-set response cache to `GET /api/directory/organization-switcher` (`packages/core/src/modules/directory/api/organization-switcher/route.ts`). The handler is invoked on essentially every backend page load (the global `OrganizationSwitcher` chrome component) yet recomputes a stable org tree + RBAC scope on each call. Cache the full response payload keyed by `(userId, tenantId, selectedOrg)` with a short TTL (60s) and invalidate via tags on `directory.organization.*` and `directory.tenant.*` events. **The hard part — tag-based invalidation — is already wired** (`packages/core/src/modules/directory/subscribers/invalidateOrgScopeCache.ts` fires on `directory.organization.*`); this FR reuses the same tag namespace and adds a tenant-event hook so the new entry stays correct.
+Add a tenant-scoped, get-then-set response cache to `GET /api/directory/organization-switcher` (`packages/core/src/modules/directory/api/organization-switcher/route.ts`). The handler is invoked on essentially every backend page load (the global `OrganizationSwitcher` chrome component) yet recomputes a stable org tree + RBAC scope on each call. Cache the full response payload keyed by `(userId, tenantId, selectedOrg)` with a 60 s TTL and **invalidate via two tags that are already flushed today**:
+
+- `org-scope:tenant:<tenantId>` — flushed by the existing subscriber `directory/subscribers/invalidateOrgScopeCache.ts` on every `directory.organization.*` event.
+- `rbac:user:<userId>` — flushed by `auth/services/rbacService.ts` on every role/ACL change for the user (`deleteCacheByTags` flushes across the current, global, and hinted tenant namespaces).
+
+No new tags, no new subscribers. One safety fix is required (below) so the existing org-scope flush always lands in the right tenant namespace.
 
 ## Why (impact)
 
-- **Hotness: very high.** `apps/mercato/src/components/OrganizationSwitcher.tsx:195` calls this URL on mount of the backend header chrome (every backend navigation that remounts the switcher), `packages/create-app/template/src/components/OrganizationSwitcher.tsx:195` does the same in scaffolded apps, and it is additionally fetched by `packages/core/src/modules/api_keys/backend/api-keys/create/page.tsx:39` and `packages/core/src/modules/customer_accounts/backend/customer_accounts/settings/domain/page.tsx:97`. Read:write ratio is extremely high — the org tree changes weekly at most.
-- **Cost: moderate-to-heavy and compounding.** Per call the handler does: `em.find(Tenant)` (superadmin path), `rbac.loadAcl` (route.ts:142), `rbac.userHasAllFeatures` (route.ts:147), `em.find(Organization)` (route.ts:157), `computeHierarchyForOrganizations` (a recursive tree walk with per-level name sorting — `packages/core/src/modules/directory/lib/hierarchy.ts:37`), then `resolveOrganizationScope` (route.ts:166) which itself does a **second** `rbac.loadAcl` (organizationScope.ts:226) plus another `em.find(Organization)` for descendant expansion (organizationScope.ts:163), and finally `buildOrganizationMenu`. That is ~2 ACL loads + 2 org-table scans + tree compute on every page view.
-- **Est. win:** eliminates 2 RBAC ACL loads, 2 `organizations` scans, and the hierarchy/menu compute for the ~60s window after the first hit per user — i.e. nearly every navigation within a session becomes a single cache read. This is the dominant per-navigation directory cost.
+- **Hotness: very high.** `apps/mercato/src/components/OrganizationSwitcher.tsx:195` calls this URL on mount of the backend header chrome (every backend navigation that remounts the switcher); also fetched by `api_keys/backend/api-keys/create/page.tsx:39` and `customer_accounts/backend/customer_accounts/settings/domain/page.tsx:97`.
+- **Cost: moderate-to-heavy and compounding.** Per call: `em.find(Tenant)` (superadmin path), `rbac.loadAcl` (route.ts:142), `rbac.userHasAllFeatures` (route.ts:147), `em.find(Organization)` (route.ts:157), `computeHierarchyForOrganizations` (`hierarchy.ts:37`), then `resolveOrganizationScope` (route.ts:166) which does a **second** `rbac.loadAcl` (organizationScope.ts:226) plus another `em.find(Organization)` (organizationScope.ts:163), and finally `buildOrganizationMenu`. ~2 ACL loads + 2 org-table scans + tree compute on every page view.
+- **Est. win:** eliminates 2 RBAC ACL loads, 2 `organizations` scans, and the hierarchy/menu compute for the ~60 s window after the first hit per user — nearly every navigation within a session becomes a single cache read.
 
 ## Current behavior
 
-`packages/core/src/modules/directory/api/organization-switcher/route.ts`:
-- `route.ts:92` `GET` resolves auth, then on every request builds a fresh request container (`route.ts:101`).
-- `route.ts:116` superadmin branch loads all tenants via `em.find(Tenant, { deletedAt: null })`.
-- `route.ts:142` `rbac.loadAcl(...)` and `route.ts:147` `rbac.userHasAllFeatures([... 'directory.organizations.manage'])`.
-- `route.ts:157` `em.find(Organization, { tenant, deletedAt: null })`.
-- `route.ts:162` `computeHierarchyForOrganizations(orgEntities, tenantId)` (`hierarchy.ts:37`).
-- `route.ts:166` `resolveOrganizationScope(...)` — note it calls the **uncached** `resolveOrganizationScope`, NOT the cached wrapper `resolveOrganizationScopeForRequest` (organizationScope.ts:317). Inside it does a second `rbac.loadAcl` (organizationScope.ts:226) and `loadOrgDescendantMap` org query (organizationScope.ts:163).
-- `route.ts:178` `buildOrganizationMenu(hierarchy, accessible)` builds the final node tree + selectable set.
-- `route.ts:199-221` assembles `{ items, selectedId, canManage, canViewAllOrganizations, tenantId, tenants, isSuperAdmin }`, calls `logCrudAccess`, and returns.
+`packages/core/src/modules/directory/api/organization-switcher/route.ts`: see line references above. There is **no response cache** today. A partial cache exists for `resolveOrganizationScope` (the `org-scope:*` cache in `organizationScope.ts`, default-off behind `OM_ORG_SCOPE_CACHE_TTL_MS`), but this route bypasses it by calling the raw function.
 
-There is **no response cache** today. A partial cache exists for `resolveOrganizationScope` (the `org-scope:*` cache in `organizationScope.ts:317`, default-off behind `OM_ORG_SCOPE_CACHE_TTL_MS`), but this route bypasses it by calling the raw function, so even with that flag on the route stays uncached.
+The invalidation infrastructure, however, **already exists**:
+- `directory/subscribers/invalidateOrgScopeCache.ts` (event `directory.organization.*`, ephemeral) flushes `org-scope:tenant:<tenantId>` on every org create/update/delete.
+- `invalidateOrganizationScopeCacheForUser(container, userId)` (`organizationScope.ts:78`) flushes `org-scope:user:<userId>` on membership changes.
+- `rbacService` flushes `rbac:user:<userId>` on every user/role ACL write (`auth/commands/users.ts:1052`, `auth/api/users/acl/route.ts:243`, `auth/api/roles/acl/route.ts:254` flushes `rbac:tenant:<tenantId>`).
 
 ## Proposed cache
 
-Wrap the existing compute in a get-then-set around the **assembled response object**, scoped to the tenant with `runWithCacheTenant`. `logCrudAccess` must still run on every request (audit must not be cached), so cache only the payload, not the side effect.
+Wrap the existing compute in a get-then-set around the **assembled response object**. `logCrudAccess` must still run on every request (audit must not be cached), so cache only the payload, not the side effect. The dispatcher's `runWithCacheTenant(auth.tenantId, …)` wrapper provides the tenant namespace.
 
-Key shape (hashed + tenant-namespaced internally by the cache layer, but be explicit):
+Key: `org-switcher:v1:<userId>:<tenantId>:<selectedOrg|none|all>`
 
-```
-org-switcher:v1:<userId>:<tenantId>:<selectedOrg|none|all>
-```
-
-Code sketch (inside the `try` block, after `tenantId` is resolved and before the heavy compute at route.ts:142):
-
-```typescript
-import { runWithCacheTenant } from '@open-mercato/cache'
-import type { CacheStrategy } from '@open-mercato/cache'
-
-const ORG_SWITCHER_CACHE_PREFIX = 'org-switcher:v1'
+```ts
 const ORG_SWITCHER_TTL_MS = 60_000
 
-const cache = (() => {
-  try {
-    const c = container.resolve('cache') as CacheStrategy | undefined
-    return c && typeof c.get === 'function' && typeof c.set === 'function' ? c : null
-  } catch { return null }
-})()
-
-const rawSelected = getSelectedOrganizationFromRequest(req)
-const requestedAll = isAllOrganizationsSelection(rawSelected)
+const cache = (() => { try { return container.resolve('cache') } catch { return null } })()
 const selectedKeyPart = requestedAll ? 'all' : (rawSelected ?? 'none')
-const cacheKey = `${ORG_SWITCHER_CACHE_PREFIX}:${auth.sub}:${tenantId}:${selectedKeyPart}`
+const cacheKey = `org-switcher:v1:${auth.sub}:${tenantId}:${selectedKeyPart}`
 const cacheTags = [
-  `org-scope:tenant:${tenantId}`,        // reuse existing org-mutation invalidation
-  `org-switcher:tenant:${tenantId}`,     // new: targeted switcher tag
-  `org-switcher:user:${auth.sub}`,       // new: per-user (role/ACL change)
+  `org-scope:tenant:${tenantId}`, // existing org-mutation flush — zero new wiring
+  `rbac:user:${auth.sub}`,        // existing role/ACL-change flush — zero new wiring
 ]
 
-const buildPayload = async () => { /* existing route.ts:142..207 compute, returns `response` */ }
-
-const response = await runWithCacheTenant(tenantId, async () => {
-  if (cache) {
-    try {
-      const hit = await cache.get(cacheKey)
-      if (hit && typeof hit === 'object') return hit as Awaited<ReturnType<typeof buildPayload>>
-    } catch (err) { console.warn('[org-switcher:cache] read failed', err) }
-  }
-  const built = await buildPayload()
-  if (cache) {
-    try { await cache.set(cacheKey, built, { ttl: ORG_SWITCHER_TTL_MS, tags: cacheTags }) }
-    catch (err) { console.warn('[org-switcher:cache] write failed', err) }
-  }
-  return built
-})
-
-// audit ALWAYS runs, never cached:
-await logCrudAccess({ container, auth, request: req, items: response.items, ... })
+// Conservative v1: skip the cache entirely for superadmins (cross-tenant tenant list).
+if (cache && !actorIsSuperAdmin) {
+  const hit = await cache.get(cacheKey)
+  if (hit && typeof hit === 'object') { await logCrudAccess(...); return NextResponse.json(hit) }
+}
+const response = await buildPayload() // existing route.ts:142..207 compute
+if (cache && !actorIsSuperAdmin) {
+  try { await cache.set(cacheKey, response, { ttl: ORG_SWITCHER_TTL_MS, tags: cacheTags }) } catch {}
+}
+await logCrudAccess(...) // audit ALWAYS runs, never cached
 return NextResponse.json(response)
 ```
 
-Notes:
-- TTL 60s mirrors the sibling `org-scope` cache default and bounds staleness for membership/visibility changes that do not emit a directory event.
-- For the superadmin tenant-list portion, the `org-switcher:tenant:<tenantId>` + tenant-event invalidation (below) keeps it fresh; the 60s TTL is the backstop for cross-tenant tenant renames a superadmin might not have a direct tag for. If exactness of the *other-tenant* list matters, gate the superadmin path out of the cache (`if (actorIsSuperAdmin) skip set`) — recommended as a conservative v1.
-
 ## Cache tags
 
-- `org-scope:tenant:<tenantId>` — **reused** from the existing org-scope cache. Already invalidated by `packages/core/src/modules/directory/subscribers/invalidateOrgScopeCache.ts` on `directory.organization.*`. Tagging the switcher entry with it means org create/update/delete already busts this entry with zero new wiring.
-- `org-switcher:tenant:<tenantId>` — new. Represents "any switcher entry for this tenant" (org tree + tenant-active state). Invalidated on org and tenant mutations for that tenant.
-- `org-switcher:user:<userId>` — new. Represents "this user's allowed-org / role view". Invalidated when the user's role/ACL/org membership changes (so a permission grant is reflected without waiting for TTL).
+- `org-scope:tenant:<tenantId>` — **reused.** Flushed by the existing `invalidateOrgScopeCache` subscriber on `directory.organization.*`; covers org create/update/delete and hierarchy rebuilds.
+- `rbac:user:<userId>` — **reused.** Flushed by `rbacService.deleteCacheByTags` on user-ACL and role-grant changes; covers "user's allowed-org / role view changed". `rbacService` flushes across current + global + hinted tenant namespaces (`rbacService.ts:167-187`), so it reaches the request-namespace entry.
 
 ## Invalidation
 
-| Trigger (route/command/event) | Where to call deleteByTags | Tags invalidated |
+| Trigger | Where the flush already happens | Tags |
 |---|---|---|
-| `directory.organization.created` / `.updated` / `.deleted` (emitted by `packages/core/src/modules/directory/commands/organizations.ts`, post-commit after `rebuildHierarchyForTenant`) | Already handled by existing subscriber `directory/subscribers/invalidateOrgScopeCache.ts` (event `directory.organization.*`); extend it to also delete `org-switcher:tenant:${tenantId}` | `org-scope:tenant:<id>` (existing), add `org-switcher:tenant:<id>` |
-| `directory.tenant.created` / `.updated` / `.deleted` (`directory/commands/tenants.ts`, post-commit) | New ephemeral subscriber `directory/subscribers/invalidateOrgSwitcherOnTenant.ts` (event `directory.tenant.*`) calling `cache.deleteByTags(['org-switcher:tenant:'+tenantId])` (rename/deactivate affects the superadmin tenant list + active flag) | `org-switcher:tenant:<id>` |
-| User role/ACL/org-membership change (auth/RBAC writes; e.g. user-organization assignment) | In the same post-commit hook that already calls `invalidateOrganizationScopeCacheForUser(container, userId)` (organizationScope.ts:78), also delete `org-switcher:user:${userId}`. If that helper has no current caller wired, add a subscriber on the user-org-membership event | `org-switcher:user:<id>` (and reuse `org-scope:user:<id>`) |
+| `directory.organization.created/updated/deleted` | existing subscriber `directory/subscribers/invalidateOrgScopeCache.ts` | `org-scope:tenant:<T>` |
+| User role/ACL/membership change | existing `rbacService` flushes (`auth/commands/users.ts:1051-1052`, ACL routes) | `rbac:user:<U>` |
+| Tenant rename/deactivate (superadmin tenant list) | not hooked — superadmin path is **not cached** (conservative v1); 60 s TTL backstops the non-superadmin `tenantId`-derived fields | (TTL) |
 
-All `deleteByTags` calls fire **post-commit** (outside `withAtomicFlush`), consistent with the existing `invalidateOrgScopeCache` subscriber which runs on the persisted, post-write event. TTL (60s) is the backstop for any membership/visibility change that does not emit a directory event.
+**Required safety fix (small, part of this FR):** the existing subscriber calls `cache.deleteByTags(['org-scope:tenant:…'])` **without** `runWithCacheTenant(payload.tenantId, …)`. When the subscriber runs synchronously inside the request it inherits the request's tenant namespace and matches; when it runs from a queue/async context it lands in the `global` namespace and silently misses tenant-scoped entries. Wrap the subscriber's flush in `runWithCacheTenant(tenantId, …)` (and the same in `invalidateOrganizationScopeCacheForUser/Tenant`) so the flush always matches request-namespace entries. This also hardens the existing org-scope cache, not just this FR.
+
+## Safety / non-invalidation risks (double-checked)
+
+- **Staleness window ≤ 60 s** for changes with no flushed tag (e.g. direct DB org edit, tenant rename affecting `tenants[]` metadata). Org/role changes through commands invalidate near-immediately.
+- **Cross-tenant superadmin ACL edits:** `rbac:user:<U>` is flushed in the actor's + global namespaces (+hints); if a superadmin in tenant A edits a user of tenant B, the tenant-B-namespace entry may survive until TTL. Accepted: 60 s.
+- **Cross-tenant leakage: none** — key embeds `userId` + `tenantId`; namespace isolation via the dispatcher wrapper. Superadmin responses are never cached in v1.
+- **Audit integrity preserved** — `logCrudAccess` stays outside the cache.
+- **Not auth-enforcing data:** the switcher payload is navigation metadata; actual access checks re-run server-side per request elsewhere.
 
 ## Implementation steps
 
-- [ ] In `route.ts`, after `tenantId` resolution (route.ts:130), resolve `cache` from `container` defensively and compute `cacheKey` + `cacheTags` from `auth.sub`, `tenantId`, and the selected-org cookie.
-- [ ] Extract the existing compute (route.ts:142..207) into a local `buildPayload()` returning the `response` object; wrap the get/set in `runWithCacheTenant(tenantId, ...)`.
-- [ ] Keep `logCrudAccess` (route.ts:209) and the `NextResponse.json` OUTSIDE/AFTER the cache so audit fires every request.
-- [ ] (Conservative v1) skip the cache `set` when `actorIsSuperAdmin` to avoid caching cross-tenant tenant lists, OR add tenant-tag invalidation per the table.
-- [ ] Extend `directory/subscribers/invalidateOrgScopeCache.ts` to also `deleteByTags(['org-switcher:tenant:'+tenantId])`.
-- [ ] Add `directory/subscribers/invalidateOrgSwitcherOnTenant.ts` (event `directory.tenant.*`, `persistent: false`) deleting `org-switcher:tenant:<tenantId>`.
-- [ ] Wire `org-switcher:user:<userId>` deletion into the same place that already invalidates `org-scope:user:<userId>` on role/membership change; if none exists, add a subscriber on the user-organization assignment event.
-- [ ] `yarn generate` (new subscriber auto-discovery), then `yarn workspace @open-mercato/core build` + `test`.
-
-## Risks & staleness window
-
-- **Staleness window: ≤60s** for changes with no emitted event (e.g. a direct DB org edit). For org/tenant CRUD and role changes done through commands, invalidation is near-immediate (post-commit event) with TTL as backstop.
-- **Cross-tenant leakage: none** — keyed and namespaced by `tenantId` via `runWithCacheTenant`, and the key embeds `userId`. Conservative v1 also excludes the superadmin all-tenants list from caching.
-- **Not auth/financial data** — this is read-mostly navigation metadata; a brief convergence window is acceptable. `selectedId` correction logic (route.ts:181) still runs inside the cached payload per `(userId, selectedOrg)` key, so per-selection responses stay correct.
-- **Audit integrity preserved** — `logCrudAccess` deliberately stays outside the cache.
-- Verdict is `good` (not strong-quick-win) because partial infrastructure exists but the route currently bypasses it, the superadmin tenant-list branch needs a deliberate cache decision, and one user-level invalidation hook may need to be located/added.
+- [ ] In `route.ts`, after `tenantId` resolution (route.ts:130), resolve `cache` defensively; compute `cacheKey` + the two reused tags; extract the existing compute into `buildPayload()`; add the get-then-set, skipping cache for superadmins.
+- [ ] Keep `logCrudAccess` (route.ts:209) outside/after the cache so audit fires on every request.
+- [ ] Safety fix: wrap the flushes in `directory/subscribers/invalidateOrgScopeCache.ts` and `invalidateOrganizationScopeCacheForUser/Tenant` (`organizationScope.ts:78-102`) in `runWithCacheTenant(tenantId, …)`.
+- [ ] `yarn workspace @open-mercato/core build` + `test`.
 
 ## Acceptance criteria / tests
 
-- [ ] Unit: a cache double records one `set` for the first `GET` and zero ACL/org `em.find` calls on the immediate second `GET` with identical `(userId, tenantId, selectedOrg)` (extend `directory/utils/__tests__/organizationScopeCache.test.ts` style).
-- [ ] Unit: `set` is tagged with all three tags; `deleteByTags(['org-switcher:tenant:<id>'])` (and the reused `org-scope:tenant:<id>`) removes the entry.
-- [ ] Integration (extend `directory/__integration__/TC-DIR-004.spec.ts`): create an organization, then `GET /api/directory/organization-switcher` returns the new org within the convergence window (event-driven invalidation), proving no stale tree is served after a write.
-- [ ] Integration: two different users in the same tenant get correctly different `items`/`canManage` (key isolation by `userId`).
+- [ ] A cache double records one `set` for the first `GET` and zero ACL/org `em.find` calls on the immediate second `GET` with identical `(userId, tenantId, selectedOrg)`.
+- [ ] `set` is tagged `org-scope:tenant:<T>` + `rbac:user:<U>`; `deleteByTags` on either removes the entry.
+- [ ] Integration (extend `directory/__integration__/TC-DIR-004.spec.ts`): create an organization → `GET` returns the new org promptly (existing subscriber flush, not TTL).
+- [ ] Granting/revoking a role feature for a user → that user's next `GET` reflects new `canManage`/`items` (rbac tag flush).
+- [ ] Two different users in the same tenant get correctly different `items`/`canManage` (key isolation by `userId`).
+- [ ] Superadmin requests are never cached.
 - [ ] Audit: `audit_logs` still records one access row per request even on cache hits.
 
 ## Labels

--- a/.ai/analysis/2026-06-08-cache-perf-frs/03-cache-notifications-unread-count.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/03-cache-notifications-unread-count.md
@@ -1,155 +1,87 @@
 > Auto-generated cache-performance Feature Request — candidate 3 of 9
 > Endpoint: `GET /api/notifications/unread-count` · ROI 82 · Verdict: good
 > Source: `packages/core/src/modules/notifications/api/unread-count/route.ts`
+> Revised 2026-06-09: simplified to a **TTL-only v1** — notification writes do not go through the command bus, so there is no existing flushed tag to connect to, and the previously proposed 10+ bespoke invalidation call sites are exactly the complexity this backlog now avoids. A 10 s TTL alone keeps the badge fresh within one poll cycle.
 
 ## Summary
 
-Add a short-TTL, tag-invalidated cache to the unread notification count so the per-user `COUNT(*)` query stops running on every poll tick. The count is rendered by the notification bell badge on every backoffice page and is **polled every 5 seconds** (`useNotificationsPoll.ts`, `POLL_INTERVAL = 5000`). Caching it with a small TTL plus per-user tag invalidation eliminates the vast majority of these COUNT queries while keeping the badge effectively real-time (every mutation that changes the count invalidates the cache immediately).
+Add a short-TTL cache to the unread notification count so the per-user `COUNT(*)` query stops running on every poll tick. The count is rendered by the notification bell badge on every backoffice page and is **polled every 5 seconds** (`useNotificationsPoll.ts`, `POLL_INTERVAL = 5000`).
 
-This is NOT a `makeCrudRoute` endpoint — it is a custom GET handler that bypasses the generic CRUD list cache (`ENABLE_CRUD_API_CACHE` in `packages/shared/src/lib/crud/factory.ts`), so it needs a small, explicit manual cache following the reference pattern in `packages/core/src/modules/customer_accounts/services/domainMappingService.ts`.
+**v1 is TTL-only (10 s), no invalidation wiring.** Rationale: the notifications module has **no `commands/` directory** — all writes flow through `createNotificationService` + `eventBus`, so the command bus never flushes any `crud:*` tag for notifications, and there is no existing module tag to reuse. Wiring per-user `deleteByTags` into ~10 service write sites (the original proposal) buys at most ~5 s of extra freshness over a 10 s TTL on a UI badge — not worth the wiring. The SSE path (`useNotificationsSse.ts`) already pushes real-time updates where SSE is enabled.
+
+**v2 (optional, deferred):** a single `invalidateUnreadCount(cache, tenantId, userId)` helper called from the one service chokepoint (`createNotificationService`) if sub-TTL badge freshness is ever required.
 
 ## Why (impact)
 
-- **Hotness — very high.** `packages/ui/src/backend/notifications/useNotificationsPoll.ts:60` calls `apiCall('/api/notifications/unread-count')` inside a `setInterval(fetchNotifications, 5000)` loop (line 149). The SSE variant `useNotificationsSse.ts:70` also hits it on (re)connect/refresh. With the bell mounted in the app shell, every authenticated session issues ~12 COUNT queries/minute purely for the badge, independent of any real activity.
-- **Cost — low per call, high in aggregate.** Each request runs `em.count(Notification, { recipientUserId, tenantId, status: 'unread' })` (`route.ts:14-18`). The query is cheap individually, but the request volume (10s–100s per user per session, multiplied by concurrent users) makes the cumulative DB load and request-handling overhead the real cost. Caching collapses the steady-state to ~1 DB COUNT per user per TTL window.
-- **Est. win.** With a 10s TTL and immediate invalidation on writes, steady-state COUNT queries for an idle user drop from ~1 every 5s to ~1 every 10s, and a high-traffic deployment with many simultaneously-open dashboards sees the unread-count DB load drop by roughly 50–90% (higher with a larger TTL). No new infra — uses the existing DI `cache` service.
+- **Hotness — very high.** `packages/ui/src/backend/notifications/useNotificationsPoll.ts:60` calls `apiCall('/api/notifications/unread-count')` inside a `setInterval(..., 5000)` loop (line 149). The SSE variant also hits it on (re)connect/refresh. Every authenticated session issues ~12 COUNT queries/minute purely for the badge.
+- **Cost — low per call, high in aggregate.** Each request runs `em.count(Notification, { recipientUserId, tenantId, status: 'unread' })` (`route.ts:14-18`). The request volume makes the cumulative DB load the real cost.
+- **Est. win.** With a 10 s TTL, steady-state COUNT queries drop from ~12/min to ~6/min per idle session, and far more under multi-tab usage. No new infra, ~15 lines of code.
 
 ## Current behavior
 
 `packages/core/src/modules/notifications/api/unread-count/route.ts`:
 
-- `route.ts:10-11` — `GET` resolves notification context via `resolveNotificationContext(req)` (`lib/routeHelpers.ts:53`), which yields `scope = { tenantId, organizationId, userId }`.
-- `route.ts:12` — resolves `em` from the DI container.
-- `route.ts:14-18` — `await em.count(Notification, { recipientUserId: scope.userId, tenantId: scope.tenantId, status: 'unread' })`. **Note the filter dimensions: `recipientUserId` + `tenantId` + `status` only — `organizationId` is NOT part of the count.** The cache key and tags must mirror exactly these dimensions (user-scoped, tenant-scoped, not org-scoped).
-- `route.ts:20` — returns `Response.json({ unreadCount: count })`.
-
-The same count is computed by `NotificationService.getUnreadCount` (`lib/notificationService.ts:506-513`) and inside `getPollData` (`lib/notificationService.ts:531-535`); both use the identical filter. All notification writes flow through `createNotificationService` in `lib/notificationService.ts`, so it is the single correct place to invalidate.
-
-There is no existing cache on this path; it is not wired through `makeCrudRoute`, so the gated generic CRUD cache does not cover it.
+- `route.ts:10-11` — `resolveNotificationContext(req)` yields `scope = { tenantId, organizationId, userId }`.
+- `route.ts:14-18` — `em.count(Notification, { recipientUserId: scope.userId, tenantId: scope.tenantId, status: 'unread' })`. **The filter is user + tenant only — `organizationId` is NOT part of the count**, so the key must not include the org (or org-switching users would see inconsistent badges).
+- No existing cache on this path; not `makeCrudRoute`, so the generic CRUD cache does not cover it. All notification writes flow through `createNotificationService` (`lib/notificationService.ts`) — **not** through the command bus.
 
 ## Proposed cache
 
-Add a tiny cache helper in `packages/core/src/modules/notifications/lib/` (e.g. `unreadCountCache.ts`) and use it from both the route and the service. Tenant scoping uses `runWithCacheTenant` so the cache layer auto-prefixes keys+tags per tenant; the user id is carried in the key/tags because the count is per-recipient.
-
-```ts
-// packages/core/src/modules/notifications/lib/unreadCountCache.ts
-import { runWithCacheTenant } from '@open-mercato/cache'
-
-const UNREAD_COUNT_TAG = 'notifications:unread-count'
-const UNREAD_COUNT_TTL_MS = 10_000 // 10s backstop; invalidation is the primary freshness mechanism
-
-type CacheService = {
-  get(key: string): Promise<unknown>
-  set(key: string, value: unknown, options?: { ttl?: number; tags?: string[] }): Promise<void>
-  deleteByTags(tags: string[]): Promise<number>
-}
-
-const keyFor = (userId: string) => `${UNREAD_COUNT_TAG}:user:${userId}`
-const tagsFor = (userId: string) => [UNREAD_COUNT_TAG, `${UNREAD_COUNT_TAG}:user:${userId}`]
-
-export async function getCachedUnreadCount(
-  cache: CacheService | null,
-  tenantId: string,
-  userId: string,
-  compute: () => Promise<number>,
-): Promise<number> {
-  if (!cache || !userId) return compute()
-  return runWithCacheTenant(tenantId, async () => {
-    const cached = (await cache.get(keyFor(userId))) as number | null | undefined
-    if (typeof cached === 'number') return cached
-    const value = await compute()
-    await cache.set(keyFor(userId), value, { ttl: UNREAD_COUNT_TTL_MS, tags: tagsFor(userId) })
-    return value
-  })
-}
-
-export async function invalidateUnreadCount(
-  cache: CacheService | null,
-  tenantId: string,
-  userId: string | null | undefined,
-): Promise<void> {
-  if (!cache || !userId) return
-  try {
-    await runWithCacheTenant(tenantId, () => cache.deleteByTags([`${UNREAD_COUNT_TAG}:user:${userId}`]))
-  } catch {
-    // best-effort; TTL is the backstop
-  }
-}
-```
-
-Route usage (resolve `cache` defensively — it may not be registered in every context, mirroring how the service resolves `commandBus`):
-
 ```ts
 // route.ts GET
+const UNREAD_COUNT_TTL_MS = 10_000
+
 const { scope, ctx } = await resolveNotificationContext(req)
 const em = ctx.container.resolve('em') as EntityManager
-let cache: CacheService | null = null
-try { cache = ctx.container.resolve('cache') as CacheService } catch { cache = null }
+const cache = (() => { try { return ctx.container.resolve('cache') } catch { return null } })()
+const cacheKey = `notifications:unread-count:user:${scope.userId}`
 
-const count = await getCachedUnreadCount(cache, scope.tenantId, scope.userId ?? '', () =>
-  em.count(Notification, {
-    recipientUserId: scope.userId,
-    tenantId: scope.tenantId,
-    status: 'unread',
-  }),
-)
+if (cache && scope.userId) {
+  const cached = await cache.get(cacheKey)
+  if (typeof cached === 'number') return Response.json({ unreadCount: cached })
+}
+const count = await em.count(Notification, { recipientUserId: scope.userId, tenantId: scope.tenantId, status: 'unread' })
+if (cache && scope.userId) {
+  try { await cache.set(cacheKey, count, { ttl: UNREAD_COUNT_TTL_MS }) } catch {}
+}
 return Response.json({ unreadCount: count })
 ```
 
-Wire the same `getCachedUnreadCount` into `NotificationService.getUnreadCount` (`lib/notificationService.ts:506`) so the count is consistent regardless of caller, and (optionally) into the `getPollData` count.
+Tenant scoping is automatic: the API dispatcher wraps the handler in `runWithCacheTenant(auth.tenantId, …)` (`apps/mercato/src/app/api/[...slug]/route.ts:382`), so the key is tenant-namespaced without carrying the tenant literal.
 
 ## Cache tags
 
-- `notifications:unread-count` — coarse tag covering every cached unread-count entry in the tenant. Used for blanket invalidation (e.g. `cleanupExpired`, where the affected recipient set is not cheaply known).
-- `notifications:unread-count:user:<userId>` — per-recipient tag. The precise invalidation target for any write that changes a single user's unread set (mark read, dismiss, restore-to-unread, action, single create). Tenant namespacing is applied automatically by `runWithCacheTenant`, so `<userId>` alone is sufficient within the tenant scope.
-
-Cache key: `notifications:unread-count:user:<userId>` (tenant-prefixed internally). One entry per recipient per tenant.
+None in v1 — freshness is carried entirely by the 10 s TTL. (If v2 chokepoint invalidation is ever added, tag with `notifications:unread-count:user:<userId>` and flush from `createNotificationService` post-commit.)
 
 ## Invalidation
 
-All notification writes are centralized in `createNotificationService` (`packages/core/src/modules/notifications/lib/notificationService.ts`). Resolve `cache` in `resolveNotificationService` (alongside `em`/`eventBus`/`commandBus`) and call `invalidateUnreadCount` **after** the transaction/`flush()` commits (post-commit, never inside `transactional`/`withAtomicFlush`), right next to the existing `eventBus.emit(...)` calls.
-
-| Trigger (route / command / event) | Where to call `deleteByTags` | Tags invalidated |
+| Trigger | Where | Effect |
 |---|---|---|
-| `create` — `POST /api/notifications/batch` & internal single create (`notificationService.ts:214-232`) | after `eventBus.emit(NOTIFICATION_SSE_EVENTS.CREATED, ...)` | `notifications:unread-count:user:<recipientUserId>` |
-| `createBatch` — `POST /api/notifications/batch` (`notificationService.ts:234-252`) | after `emitNotificationSseEvents(...)` | `notifications:unread-count:user:<id>` for each distinct `recipientUserId` |
-| `createForRole` — `POST /api/notifications/role` (`notificationService.ts:254-280`) | after `emitNotificationSseEvents(...)` | per-user tag for each `uniqueRecipientUserIds` |
-| `createForFeature` — `POST /api/notifications/feature` (`notificationService.ts:282-311`) | after `emitNotificationSseEvents(...)` | per-user tag for each `uniqueRecipientUserIds` |
-| `markAsRead` — `PUT /api/notifications/[id]/read` (`notificationService.ts:313-330`) | after `eventBus.emit(NOTIFICATION_EVENTS.READ, ...)`; only needed when status actually changed from `unread` | `notifications:unread-count:user:<ctx.userId>` |
-| `markAllAsRead` — `PUT /api/notifications/mark-all-read` (`notificationService.ts:332-391`) | after the per-notification emit loop, when `result > 0` | `notifications:unread-count:user:<ctx.userId>` |
-| `dismiss` — `PUT /api/notifications/[id]/dismiss` (`notificationService.ts:393-408`) | after `eventBus.emit(NOTIFICATION_EVENTS.DISMISSED, ...)` (dismissing an unread item lowers the count) | `notifications:unread-count:user:<ctx.userId>` |
-| `restoreDismissed` (`notificationService.ts:410-438`) | after `eventBus.emit(NOTIFICATION_EVENTS.RESTORED, ...)`, when restored to `unread` (or always, cheaply) | `notifications:unread-count:user:<ctx.userId>` |
-| `executeAction` — `PUT /api/notifications/[id]/...` action (`notificationService.ts:440-504`) | after `eventBus.emit(NOTIFICATION_EVENTS.ACTIONED, ...)` (an unread item becomes `actioned`) | `notifications:unread-count:user:<ctx.userId>` |
-| `cleanupExpired` (`notificationService.ts:549-564`, scheduled) | after the bulk update returns | coarse `notifications:unread-count` (recipient set not enumerated; blanket clear is acceptable for a maintenance job) |
-| `deleteBySource` (`notificationService.ts:566-578`) | after the delete; if recipient ids are not loaded, use coarse `notifications:unread-count` | coarse `notifications:unread-count` (or per-user if you select affected `recipient_user_id`s first) |
+| Any notification write (create/read/dismiss/action) | none — **TTL-only** | badge converges within ≤10 s (≤2 poll ticks) |
+| SSE-enabled clients | existing `useNotificationsSse` push | near-real-time regardless of this cache |
 
-Note: invalidation is keyed only by `userId` (+ tenant), matching the count's filter dimensions — do **not** add `organizationId` to the tag, or org-switching users will see a stale badge because the count itself is org-agnostic.
+## Safety / non-invalidation risks (double-checked)
+
+- **Worst-case staleness = TTL = 10 s**, deterministic and unconditional — there is no missed-invalidation failure mode because there is no invalidation to miss. This is the safest possible cache shape.
+- **Badge-only data**: not money/stock/auth. A ≤10 s stale unread count is a UI affordance lag, identical in magnitude to the poll interval users already experience.
+- **Per-user key**: `userId` is in the key; tenant isolation via the dispatcher namespace. One user can never read another's badge.
+- **Org-agnostic by design**: the underlying count ignores `organizationId`, so the key deliberately omits it — org switching never shows a wrong-org badge because there is no org axis.
+- **No-op without cache service**: defensive resolution preserves today's behavior exactly.
+- **Do not pick a TTL above the poll interval × 2** (10 s): larger values visibly delay the badge after "mark all read".
 
 ## Implementation steps
 
-- [ ] Add `packages/core/src/modules/notifications/lib/unreadCountCache.ts` with `getCachedUnreadCount`, `invalidateUnreadCount`, the `UNREAD_COUNT_TAG`/`UNREAD_COUNT_TTL_MS` constants, and `keyFor`/`tagsFor` helpers (per the sketch above). Use `runWithCacheTenant` from `@open-mercato/cache`.
-- [ ] Update `api/unread-count/route.ts` to resolve `cache` defensively from `ctx.container` and wrap the `em.count(...)` in `getCachedUnreadCount`.
-- [ ] Add `cache` resolution to `resolveNotificationService` (`notificationService.ts:586-602`) using the same try/catch pattern as `commandBus`, and thread it into `createNotificationService` deps.
-- [ ] Route `getUnreadCount` (`notificationService.ts:506`) through `getCachedUnreadCount` so service callers share the cache. Optionally cache the `getPollData` count too (same key/tags).
-- [ ] Add post-commit `invalidateUnreadCount(...)` calls at every write site in the table above, immediately after the existing `eventBus.emit(...)`/`emitNotificationSseEvents(...)` calls — never inside a `transactional`/`flush` block.
-- [ ] Confirm there is no `OM_*` gating requirement; this is module-local manual caching, on by default but a no-op when no `cache` service is registered.
+- [ ] Add the get-then-set block to `api/unread-count/route.ts` (sketch above) — ~15 lines, no new files.
+- [ ] Do NOT cache when `scope.userId` is empty.
 - [ ] `yarn workspace @open-mercato/core build && yarn workspace @open-mercato/core test`.
-
-## Risks & staleness window
-
-- **Staleness window ≤ TTL (10s), but normally near-zero.** Every mutation that changes a user's unread set invalidates that user's tag post-commit, so the badge updates on the next poll (≤5s) after any read/dismiss/action/create that goes through the service. The TTL only bounds the window for paths that bypass per-user invalidation (e.g. a future direct-SQL writer, or the coarse `cleanupExpired`/`deleteBySource` clears).
-- **Read-mostly, non-financial.** Unread count is a UI affordance, not money/stock/auth — a brief convergence window is acceptable per the cache-safety guidance (invalidate after commit, TTL as backstop).
-- **Best-effort invalidation.** `deleteByTags` failures are swallowed; the 10s TTL guarantees eventual convergence even if a single invalidation call throws.
-- **Tenant isolation.** `runWithCacheTenant(scope.tenantId, ...)` namespaces keys+tags so no tenant can read another's count. The key/tag also include `userId`, so one user can never read another user's badge.
-- **No-op when `cache` is unregistered.** The defensive `try/catch` resolution means the route degrades to today's direct `em.count` if no cache service is present.
 
 ## Acceptance criteria / tests
 
-- [ ] Unit: `getCachedUnreadCount` returns the computed value on a cache miss, persists it with `ttl: 10_000` and tags `['notifications:unread-count', 'notifications:unread-count:user:<userId>']`, and returns the cached value on a subsequent hit without calling `compute` again.
-- [ ] Unit: `invalidateUnreadCount` calls `deleteByTags(['notifications:unread-count:user:<userId>'])` within `runWithCacheTenant(tenantId, ...)`, and is a no-op when `cache` is null or `userId` is empty.
-- [ ] Unit/service: `markAsRead`, `markAllAsRead`, `dismiss`, `executeAction`, `restoreDismissed`, and each `create*` variant call `invalidateUnreadCount` for the correct recipient(s) **after** flush.
-- [ ] Integration (colocate in `packages/core/src/modules/notifications/__integration__/`): create a notification for a user → `GET /api/notifications/unread-count` returns N → mark it read → next `GET` returns N-1 within one poll interval (proves invalidation), and two back-to-back GETs with no writes in between are served identically (proves the cache is engaged). Tenant-isolation assertion: a second tenant's identical user id never sees the first tenant's count.
-- [ ] Verify the bell badge in a browser updates promptly after marking a notification read (no >TTL lag).
+- [ ] Two back-to-back GETs run `em.count` once; the second is served from cache.
+- [ ] After the TTL elapses, the next GET re-counts.
+- [ ] Marking a notification read is reflected in the badge within ≤10 s (integration: poll until converged, assert ≤ 2 poll ticks).
+- [ ] Tenant isolation: a second tenant's identical user id never sees the first tenant's count.
+- [ ] With cache unavailable, behavior is byte-identical to today.
 
 ## Labels
 

--- a/.ai/analysis/2026-06-08-cache-perf-frs/03-cache-notifications-unread-count.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/03-cache-notifications-unread-count.md
@@ -1,0 +1,156 @@
+> Auto-generated cache-performance Feature Request — candidate 3 of 9
+> Endpoint: `GET /api/notifications/unread-count` · ROI 82 · Verdict: good
+> Source: `packages/core/src/modules/notifications/api/unread-count/route.ts`
+
+## Summary
+
+Add a short-TTL, tag-invalidated cache to the unread notification count so the per-user `COUNT(*)` query stops running on every poll tick. The count is rendered by the notification bell badge on every backoffice page and is **polled every 5 seconds** (`useNotificationsPoll.ts`, `POLL_INTERVAL = 5000`). Caching it with a small TTL plus per-user tag invalidation eliminates the vast majority of these COUNT queries while keeping the badge effectively real-time (every mutation that changes the count invalidates the cache immediately).
+
+This is NOT a `makeCrudRoute` endpoint — it is a custom GET handler that bypasses the generic CRUD list cache (`ENABLE_CRUD_API_CACHE` in `packages/shared/src/lib/crud/factory.ts`), so it needs a small, explicit manual cache following the reference pattern in `packages/core/src/modules/customer_accounts/services/domainMappingService.ts`.
+
+## Why (impact)
+
+- **Hotness — very high.** `packages/ui/src/backend/notifications/useNotificationsPoll.ts:60` calls `apiCall('/api/notifications/unread-count')` inside a `setInterval(fetchNotifications, 5000)` loop (line 149). The SSE variant `useNotificationsSse.ts:70` also hits it on (re)connect/refresh. With the bell mounted in the app shell, every authenticated session issues ~12 COUNT queries/minute purely for the badge, independent of any real activity.
+- **Cost — low per call, high in aggregate.** Each request runs `em.count(Notification, { recipientUserId, tenantId, status: 'unread' })` (`route.ts:14-18`). The query is cheap individually, but the request volume (10s–100s per user per session, multiplied by concurrent users) makes the cumulative DB load and request-handling overhead the real cost. Caching collapses the steady-state to ~1 DB COUNT per user per TTL window.
+- **Est. win.** With a 10s TTL and immediate invalidation on writes, steady-state COUNT queries for an idle user drop from ~1 every 5s to ~1 every 10s, and a high-traffic deployment with many simultaneously-open dashboards sees the unread-count DB load drop by roughly 50–90% (higher with a larger TTL). No new infra — uses the existing DI `cache` service.
+
+## Current behavior
+
+`packages/core/src/modules/notifications/api/unread-count/route.ts`:
+
+- `route.ts:10-11` — `GET` resolves notification context via `resolveNotificationContext(req)` (`lib/routeHelpers.ts:53`), which yields `scope = { tenantId, organizationId, userId }`.
+- `route.ts:12` — resolves `em` from the DI container.
+- `route.ts:14-18` — `await em.count(Notification, { recipientUserId: scope.userId, tenantId: scope.tenantId, status: 'unread' })`. **Note the filter dimensions: `recipientUserId` + `tenantId` + `status` only — `organizationId` is NOT part of the count.** The cache key and tags must mirror exactly these dimensions (user-scoped, tenant-scoped, not org-scoped).
+- `route.ts:20` — returns `Response.json({ unreadCount: count })`.
+
+The same count is computed by `NotificationService.getUnreadCount` (`lib/notificationService.ts:506-513`) and inside `getPollData` (`lib/notificationService.ts:531-535`); both use the identical filter. All notification writes flow through `createNotificationService` in `lib/notificationService.ts`, so it is the single correct place to invalidate.
+
+There is no existing cache on this path; it is not wired through `makeCrudRoute`, so the gated generic CRUD cache does not cover it.
+
+## Proposed cache
+
+Add a tiny cache helper in `packages/core/src/modules/notifications/lib/` (e.g. `unreadCountCache.ts`) and use it from both the route and the service. Tenant scoping uses `runWithCacheTenant` so the cache layer auto-prefixes keys+tags per tenant; the user id is carried in the key/tags because the count is per-recipient.
+
+```ts
+// packages/core/src/modules/notifications/lib/unreadCountCache.ts
+import { runWithCacheTenant } from '@open-mercato/cache'
+
+const UNREAD_COUNT_TAG = 'notifications:unread-count'
+const UNREAD_COUNT_TTL_MS = 10_000 // 10s backstop; invalidation is the primary freshness mechanism
+
+type CacheService = {
+  get(key: string): Promise<unknown>
+  set(key: string, value: unknown, options?: { ttl?: number; tags?: string[] }): Promise<void>
+  deleteByTags(tags: string[]): Promise<number>
+}
+
+const keyFor = (userId: string) => `${UNREAD_COUNT_TAG}:user:${userId}`
+const tagsFor = (userId: string) => [UNREAD_COUNT_TAG, `${UNREAD_COUNT_TAG}:user:${userId}`]
+
+export async function getCachedUnreadCount(
+  cache: CacheService | null,
+  tenantId: string,
+  userId: string,
+  compute: () => Promise<number>,
+): Promise<number> {
+  if (!cache || !userId) return compute()
+  return runWithCacheTenant(tenantId, async () => {
+    const cached = (await cache.get(keyFor(userId))) as number | null | undefined
+    if (typeof cached === 'number') return cached
+    const value = await compute()
+    await cache.set(keyFor(userId), value, { ttl: UNREAD_COUNT_TTL_MS, tags: tagsFor(userId) })
+    return value
+  })
+}
+
+export async function invalidateUnreadCount(
+  cache: CacheService | null,
+  tenantId: string,
+  userId: string | null | undefined,
+): Promise<void> {
+  if (!cache || !userId) return
+  try {
+    await runWithCacheTenant(tenantId, () => cache.deleteByTags([`${UNREAD_COUNT_TAG}:user:${userId}`]))
+  } catch {
+    // best-effort; TTL is the backstop
+  }
+}
+```
+
+Route usage (resolve `cache` defensively — it may not be registered in every context, mirroring how the service resolves `commandBus`):
+
+```ts
+// route.ts GET
+const { scope, ctx } = await resolveNotificationContext(req)
+const em = ctx.container.resolve('em') as EntityManager
+let cache: CacheService | null = null
+try { cache = ctx.container.resolve('cache') as CacheService } catch { cache = null }
+
+const count = await getCachedUnreadCount(cache, scope.tenantId, scope.userId ?? '', () =>
+  em.count(Notification, {
+    recipientUserId: scope.userId,
+    tenantId: scope.tenantId,
+    status: 'unread',
+  }),
+)
+return Response.json({ unreadCount: count })
+```
+
+Wire the same `getCachedUnreadCount` into `NotificationService.getUnreadCount` (`lib/notificationService.ts:506`) so the count is consistent regardless of caller, and (optionally) into the `getPollData` count.
+
+## Cache tags
+
+- `notifications:unread-count` — coarse tag covering every cached unread-count entry in the tenant. Used for blanket invalidation (e.g. `cleanupExpired`, where the affected recipient set is not cheaply known).
+- `notifications:unread-count:user:<userId>` — per-recipient tag. The precise invalidation target for any write that changes a single user's unread set (mark read, dismiss, restore-to-unread, action, single create). Tenant namespacing is applied automatically by `runWithCacheTenant`, so `<userId>` alone is sufficient within the tenant scope.
+
+Cache key: `notifications:unread-count:user:<userId>` (tenant-prefixed internally). One entry per recipient per tenant.
+
+## Invalidation
+
+All notification writes are centralized in `createNotificationService` (`packages/core/src/modules/notifications/lib/notificationService.ts`). Resolve `cache` in `resolveNotificationService` (alongside `em`/`eventBus`/`commandBus`) and call `invalidateUnreadCount` **after** the transaction/`flush()` commits (post-commit, never inside `transactional`/`withAtomicFlush`), right next to the existing `eventBus.emit(...)` calls.
+
+| Trigger (route / command / event) | Where to call `deleteByTags` | Tags invalidated |
+|---|---|---|
+| `create` — `POST /api/notifications/batch` & internal single create (`notificationService.ts:214-232`) | after `eventBus.emit(NOTIFICATION_SSE_EVENTS.CREATED, ...)` | `notifications:unread-count:user:<recipientUserId>` |
+| `createBatch` — `POST /api/notifications/batch` (`notificationService.ts:234-252`) | after `emitNotificationSseEvents(...)` | `notifications:unread-count:user:<id>` for each distinct `recipientUserId` |
+| `createForRole` — `POST /api/notifications/role` (`notificationService.ts:254-280`) | after `emitNotificationSseEvents(...)` | per-user tag for each `uniqueRecipientUserIds` |
+| `createForFeature` — `POST /api/notifications/feature` (`notificationService.ts:282-311`) | after `emitNotificationSseEvents(...)` | per-user tag for each `uniqueRecipientUserIds` |
+| `markAsRead` — `PUT /api/notifications/[id]/read` (`notificationService.ts:313-330`) | after `eventBus.emit(NOTIFICATION_EVENTS.READ, ...)`; only needed when status actually changed from `unread` | `notifications:unread-count:user:<ctx.userId>` |
+| `markAllAsRead` — `PUT /api/notifications/mark-all-read` (`notificationService.ts:332-391`) | after the per-notification emit loop, when `result > 0` | `notifications:unread-count:user:<ctx.userId>` |
+| `dismiss` — `PUT /api/notifications/[id]/dismiss` (`notificationService.ts:393-408`) | after `eventBus.emit(NOTIFICATION_EVENTS.DISMISSED, ...)` (dismissing an unread item lowers the count) | `notifications:unread-count:user:<ctx.userId>` |
+| `restoreDismissed` (`notificationService.ts:410-438`) | after `eventBus.emit(NOTIFICATION_EVENTS.RESTORED, ...)`, when restored to `unread` (or always, cheaply) | `notifications:unread-count:user:<ctx.userId>` |
+| `executeAction` — `PUT /api/notifications/[id]/...` action (`notificationService.ts:440-504`) | after `eventBus.emit(NOTIFICATION_EVENTS.ACTIONED, ...)` (an unread item becomes `actioned`) | `notifications:unread-count:user:<ctx.userId>` |
+| `cleanupExpired` (`notificationService.ts:549-564`, scheduled) | after the bulk update returns | coarse `notifications:unread-count` (recipient set not enumerated; blanket clear is acceptable for a maintenance job) |
+| `deleteBySource` (`notificationService.ts:566-578`) | after the delete; if recipient ids are not loaded, use coarse `notifications:unread-count` | coarse `notifications:unread-count` (or per-user if you select affected `recipient_user_id`s first) |
+
+Note: invalidation is keyed only by `userId` (+ tenant), matching the count's filter dimensions — do **not** add `organizationId` to the tag, or org-switching users will see a stale badge because the count itself is org-agnostic.
+
+## Implementation steps
+
+- [ ] Add `packages/core/src/modules/notifications/lib/unreadCountCache.ts` with `getCachedUnreadCount`, `invalidateUnreadCount`, the `UNREAD_COUNT_TAG`/`UNREAD_COUNT_TTL_MS` constants, and `keyFor`/`tagsFor` helpers (per the sketch above). Use `runWithCacheTenant` from `@open-mercato/cache`.
+- [ ] Update `api/unread-count/route.ts` to resolve `cache` defensively from `ctx.container` and wrap the `em.count(...)` in `getCachedUnreadCount`.
+- [ ] Add `cache` resolution to `resolveNotificationService` (`notificationService.ts:586-602`) using the same try/catch pattern as `commandBus`, and thread it into `createNotificationService` deps.
+- [ ] Route `getUnreadCount` (`notificationService.ts:506`) through `getCachedUnreadCount` so service callers share the cache. Optionally cache the `getPollData` count too (same key/tags).
+- [ ] Add post-commit `invalidateUnreadCount(...)` calls at every write site in the table above, immediately after the existing `eventBus.emit(...)`/`emitNotificationSseEvents(...)` calls — never inside a `transactional`/`flush` block.
+- [ ] Confirm there is no `OM_*` gating requirement; this is module-local manual caching, on by default but a no-op when no `cache` service is registered.
+- [ ] `yarn workspace @open-mercato/core build && yarn workspace @open-mercato/core test`.
+
+## Risks & staleness window
+
+- **Staleness window ≤ TTL (10s), but normally near-zero.** Every mutation that changes a user's unread set invalidates that user's tag post-commit, so the badge updates on the next poll (≤5s) after any read/dismiss/action/create that goes through the service. The TTL only bounds the window for paths that bypass per-user invalidation (e.g. a future direct-SQL writer, or the coarse `cleanupExpired`/`deleteBySource` clears).
+- **Read-mostly, non-financial.** Unread count is a UI affordance, not money/stock/auth — a brief convergence window is acceptable per the cache-safety guidance (invalidate after commit, TTL as backstop).
+- **Best-effort invalidation.** `deleteByTags` failures are swallowed; the 10s TTL guarantees eventual convergence even if a single invalidation call throws.
+- **Tenant isolation.** `runWithCacheTenant(scope.tenantId, ...)` namespaces keys+tags so no tenant can read another's count. The key/tag also include `userId`, so one user can never read another user's badge.
+- **No-op when `cache` is unregistered.** The defensive `try/catch` resolution means the route degrades to today's direct `em.count` if no cache service is present.
+
+## Acceptance criteria / tests
+
+- [ ] Unit: `getCachedUnreadCount` returns the computed value on a cache miss, persists it with `ttl: 10_000` and tags `['notifications:unread-count', 'notifications:unread-count:user:<userId>']`, and returns the cached value on a subsequent hit without calling `compute` again.
+- [ ] Unit: `invalidateUnreadCount` calls `deleteByTags(['notifications:unread-count:user:<userId>'])` within `runWithCacheTenant(tenantId, ...)`, and is a no-op when `cache` is null or `userId` is empty.
+- [ ] Unit/service: `markAsRead`, `markAllAsRead`, `dismiss`, `executeAction`, `restoreDismissed`, and each `create*` variant call `invalidateUnreadCount` for the correct recipient(s) **after** flush.
+- [ ] Integration (colocate in `packages/core/src/modules/notifications/__integration__/`): create a notification for a user → `GET /api/notifications/unread-count` returns N → mark it read → next `GET` returns N-1 within one poll interval (proves invalidation), and two back-to-back GETs with no writes in between are served identically (proves the cache is engaged). Tenant-isolation assertion: a second tenant's identical user id never sees the first tenant's count.
+- [ ] Verify the bell badge in a browser updates promptly after marking a notification read (no >TTL lag).
+
+## Labels
+
+`feature`, `performance`, `priority-low`

--- a/.ai/analysis/2026-06-08-cache-perf-frs/04-cache-inbox-ops-proposals-list.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/04-cache-inbox-ops-proposals-list.md
@@ -1,0 +1,165 @@
+> Auto-generated cache-performance Feature Request — candidate 4 of 9
+> Endpoint: `GET /api/inbox_ops/proposals` · ROI 82 · Verdict: good
+> Source: `packages/core/src/modules/inbox_ops/api/proposals/route.ts`
+
+## Summary
+
+Add a tenant-scoped, tag-invalidated read cache to the custom (non-`makeCrudRoute`) handler `GET /api/inbox_ops/proposals` (`packages/core/src/modules/inbox_ops/api/proposals/route.ts`). The handler runs a decrypted `findAndCountWithDecryption` plus three parallel `findWithDecryption` joins (emails, actions, discrepancies) and an in-memory enrichment loop on every page load and every poll of the proposals table.
+
+This is a **reuse-the-existing-infrastructure** change, not new infrastructure. The sibling badge endpoint `GET /api/inbox_ops/proposals/counts` is **already cached** with the canonical pattern (`runWithCacheTenant` + `cache.get`/`cache.set` with `ttl` + `tags`, helper module `lib/cache.ts`), and invalidation is **already wired into 8 mutating call sites** via `invalidateCountsCache`. We extend that same `lib/cache.ts` module with a list-cache key/tag/TTL + `invalidateProposalsListCache`, cache the list response in the handler, and add one `invalidateProposalsListCache(...)` call next to each existing `invalidateCountsCache(...)` call (and fix the `reprocess` route, which currently invalidates neither cache).
+
+## Why (impact)
+
+- **Hotness — high.** Primary intake/triage workflow surface. Loaded on the proposals page and re-fetched on filter/tab/pagination changes; the page already polls `/proposals/counts` for badges (which is why that endpoint was cached first). The list itself is the most-read endpoint of the module.
+- **Cost — high.** Per request the handler executes (route.ts):
+  - `findAndCountWithDecryption(InboxProposal, …)` — paginated list **with decryption overhead** (lines 52-62).
+  - `Promise.all` of three more decrypted queries: `InboxEmail` by id-set, `InboxProposalAction` by proposal-id-set, `InboxDiscrepancy` (unresolved) by proposal-id-set (lines 68-78).
+  - An enrichment loop that maps relationships and computes `actionCount` / `pendingActionCount` / `discrepancyCount` / email subject/from/receivedAt per row (lines 82-96).
+  That is 4 decrypted round-trips + O(rows × actions) in-memory filtering per request, all of it identical across repeated reads between writes.
+- **Est. win.** Read:write ratio is high (proposals are read-mostly until a triage action). A 30s TTL cache (matching the counts endpoint) collapses the common "load page → switch tab → page back" burst and the poll cadence to a single DB hit per (tenant, filter, page) per TTL window. Expect the large majority of list reads served from cache with zero decryption work.
+
+## Current behavior
+
+`packages/core/src/modules/inbox_ops/api/proposals/route.ts`:
+- `route.ts:18-24` — parses `status`, `category`, `search`, `page`, `pageSize` (schema `proposalListQuerySchema`, `data/validators.ts:267-273`; `pageSize` max 100, default 25).
+- `route.ts:26` — `resolveRequestContext(req)` yields `ctx.tenantId`, `ctx.organizationId`, `ctx.scope`, forked `ctx.em`, `ctx.container`.
+- `route.ts:52-62` — `findAndCountWithDecryption(ctx.em, InboxProposal, where, { limit, offset, orderBy }, ctx.scope)`.
+- `route.ts:68-78` — three parallel `findWithDecryption` calls (emails / actions / discrepancies).
+- `route.ts:82-96` — enrichment loop producing `actionCount`, `pendingActionCount`, `discrepancyCount`, `emailSubject`, `emailFrom`, `receivedAt`.
+- `route.ts:98-104` — returns `{ items, total, page, pageSize, totalPages }`.
+
+No caching today. Not a `makeCrudRoute` route, so the generic `ENABLE_CRUD_API_CACHE` list cache does **not** apply — manual cache is the correct fix.
+
+Existing infrastructure to reuse:
+- `packages/core/src/modules/inbox_ops/lib/cache.ts` — `resolveCache(container)`, `createCountsCacheKey/Tag`, `invalidateCountsCache`, TTL constants. We add list-cache equivalents here.
+- `packages/core/src/modules/inbox_ops/api/proposals/counts/route.ts:24-83` — the exact get-then-set-with-tenant-scope pattern to copy.
+
+## Proposed cache
+
+**Key** — tenant-scoped via `runWithCacheTenant` (which already prefixes/namespaces per tenant), plus the query params that change the result set. Keep the key stable/short by hashing the param tuple:
+
+```ts
+// lib/cache.ts (additions)
+const PROPOSALS_LIST_CACHE_PREFIX = 'inbox_ops:proposals:list'
+export const PROPOSALS_LIST_CACHE_TTL_MS = 30 * 1000 // mirror COUNTS_CACHE_TTL_MS
+
+export function createProposalsListCacheKey(
+  tenantId: string,
+  organizationId: string,
+  params: { status?: string; category?: string; search?: string; page: number; pageSize: number },
+): string {
+  const parts = [
+    organizationId,
+    params.status ?? '',
+    params.category ?? '',
+    params.search ?? '',
+    String(params.page),
+    String(params.pageSize),
+  ].join('|')
+  return `${PROPOSALS_LIST_CACHE_PREFIX}:${tenantId}:${parts}`
+}
+
+export function createProposalsListCacheTag(tenantId: string): string {
+  return `${PROPOSALS_LIST_CACHE_PREFIX}:${tenantId}`
+}
+
+export async function invalidateProposalsListCache(
+  cache: CacheStrategy | null | undefined,
+  tenantId: string,
+): Promise<void> {
+  if (!cache?.deleteByTags) return
+  try {
+    await cache.deleteByTags([createProposalsListCacheTag(tenantId)])
+  } catch (err) {
+    console.warn('[inbox_ops:cache] Failed to invalidate proposals list cache', err)
+  }
+}
+```
+
+**Handler** — wrap get-then-set in `runWithCacheTenant`, identical structure to the counts route:
+
+```ts
+// route.ts, after parsing query + resolveRequestContext
+const cache = resolveCache(ctx.container)
+const cacheKey = createProposalsListCacheKey(ctx.tenantId, ctx.organizationId, query)
+
+if (cache) {
+  const cached = await runWithCacheTenant(ctx.tenantId, () => cache.get(cacheKey))
+  if (cached) return NextResponse.json(cached)
+}
+
+// ... existing find + enrichment ...
+const responseBody = { items: enrichedItems, total, page: query.page, pageSize: query.pageSize, totalPages: Math.ceil(total / query.pageSize) }
+
+if (cache) {
+  try {
+    await runWithCacheTenant(ctx.tenantId, () =>
+      cache.set(cacheKey, responseBody, {
+        ttl: PROPOSALS_LIST_CACHE_TTL_MS,
+        tags: [createProposalsListCacheTag(ctx.tenantId)],
+      }),
+    )
+  } catch (err) {
+    console.warn('[inbox_ops:proposals] Failed to set list cache', err)
+  }
+}
+return NextResponse.json(responseBody)
+```
+
+**Tenant scoping.** `organizationId` is folded into the key (an org switch produces a different key); `tenantId` drives `runWithCacheTenant` so one tenant can never read another's entry, matching the counts endpoint's contract. `cache` resolution is best-effort (`resolveCache` returns `null` if DI has no `cache`), so the route degrades to today's behavior when caching is unavailable.
+
+## Cache tags
+
+- `inbox_ops:proposals:list:<tenantId>` — single coarse tag covering **all** list entries for a tenant (every status/category/search/page variant). One `deleteByTags` call clears the whole tenant's list cache on any write that can change list contents or the per-row counts. This intentionally mirrors the counts cache's 1:1 tenant tag (`inbox_ops:counts:<tenantId>`); the result set is small per tenant and a 30s TTL backstops anything missed, so per-status/per-page tag granularity is unnecessary and riskier.
+
+## Invalidation
+
+Every site that today calls `invalidateCountsCache(cache, tenantId)` also changes the list (status transitions, action accept/reject/complete/edit, categorization, accept-all) and must additionally call `invalidateProposalsListCache(cache, tenantId)` in the same `runWithCacheTenant` block, **post-commit** (these routes already place the call after the domain write returns). The `reprocess` route currently invalidates **neither** cache and must invalidate both.
+
+| Trigger (route / command / event) | Where to call `deleteByTags` (via `invalidateProposalsListCache`) | Tags invalidated |
+|---|---|---|
+| `POST /proposals/[id]/accept-all` (`api/proposals/[id]/accept-all/route.ts:35`) | next to existing `invalidateCountsCache`, post-commit | `inbox_ops:proposals:list:<tenantId>` |
+| `POST /proposals/[id]/reject` (`api/proposals/[id]/reject/route.ts:27`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
+| `POST /proposals/[id]/categorize` (`api/proposals/[id]/categorize/route.ts:35`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
+| `PUT/PATCH /proposals/[id]/actions/[actionId]` (`api/proposals/[id]/actions/[actionId]/route.ts:46`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
+| `POST /proposals/[id]/actions/[actionId]/accept` (`.../accept/route.ts:55`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
+| `POST /proposals/[id]/actions/[actionId]/reject` (`.../reject/route.ts:31`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
+| `POST /proposals/[id]/actions/[actionId]/complete` (`.../complete/route.ts:84`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
+| Extraction worker creates proposals/discrepancies (`subscribers/extractionWorker.ts:541`) | next to existing `invalidateCountsCache`, after flush | `inbox_ops:proposals:list:<tenantId>` |
+| AI tool mutation (`ai-tools.ts:355-358`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
+| `POST /emails/[id]/reprocess` (`api/emails/[id]/reprocess/route.ts`) — supersedes proposals, voids actions, deletes discrepancies; **currently invalidates nothing** | add post-commit `invalidateCountsCache` **and** `invalidateProposalsListCache` (resolve `cache` via `resolveCache(ctx.container)`) | `inbox_ops:proposals:list:<tenantId>` (+ `inbox_ops:counts:<tenantId>`) |
+
+No event-subscriber hook is required: the module invalidates inline at the write sites (its established pattern). The 30s TTL is the backstop for the `reprocess` async path if a worker-side write lands outside these sites.
+
+## Implementation steps
+
+- [ ] Extend `packages/core/src/modules/inbox_ops/lib/cache.ts` with `PROPOSALS_LIST_CACHE_TTL_MS` (30s), `createProposalsListCacheKey(tenantId, organizationId, params)`, `createProposalsListCacheTag(tenantId)`, and `invalidateProposalsListCache(cache, tenantId)` — mirroring the existing counts helpers.
+- [ ] In `api/proposals/route.ts`: import the new helpers + `resolveCache` + `runWithCacheTenant`; build the key from the parsed `query`; add the cache-get short-circuit before the DB work and the cache-set after building `responseBody`, both inside `runWithCacheTenant(ctx.tenantId, …)`, with best-effort try/catch on the set.
+- [ ] Add `invalidateProposalsListCache(cache, ctx.tenantId)` alongside each of the 9 existing `invalidateCountsCache` call sites (7 routes + extraction worker + ai-tools), within the same `runWithCacheTenant` block, post-commit.
+- [ ] Fix `api/emails/[id]/reprocess/route.ts`: resolve `cache`, and after the supersede/void/flush completes (post-commit) call both `invalidateCountsCache` and `invalidateProposalsListCache`.
+- [ ] Confirm `category` filter splitting (route.ts:38-45) and `search` are captured verbatim in the key (raw `query.category` / `query.search` strings, pre-split) so distinct filters get distinct entries.
+- [ ] Run `yarn workspace @open-mercato/core test` and `yarn typecheck`.
+
+## Risks & staleness window
+
+- **Staleness window:** up to the 30s TTL only if an invalidation site is missed; all known mutation paths invalidate explicitly, so the practical window after a write is near-zero (next read repopulates). Matches the already-shipped counts cache exactly — no new staleness contract.
+- **Low-risk data:** proposals list is read-mostly triage data; `actionCount` / `pendingActionCount` / `discrepancyCount` tolerate a brief convergence window. **No money, stock, auth tokens, or per-write-exact values** are involved.
+- **Tenant isolation:** enforced by `runWithCacheTenant(tenantId, …)` + `organizationId` in the key; cannot leak across tenants/orgs.
+- **Search/filter cardinality:** free-text `search` (max 200 chars) could create many distinct keys; the coarse tenant tag invalidates them all at once and the 30s TTL bounds their lifetime, so memory growth is naturally capped.
+- **Invalidation is best-effort** (try/catch + warn), with TTL as backstop — never blocks the write path. Cache set/get is wrapped so a cache outage degrades to current behavior.
+
+## Acceptance criteria / tests
+
+- [ ] Unit: `createProposalsListCacheKey` produces distinct keys for differing `status` / `category` / `search` / `page` / `pageSize` / `organizationId`, and a stable key for identical params.
+- [ ] Integration (`packages/core/src/modules/inbox_ops/__integration__/`): two identical `GET /api/inbox_ops/proposals?status=pending` requests return identical bodies and the second is served from cache (assert single DB population, e.g. via spy/profile or a controlled fixture mutation between calls being invisible until invalidation).
+- [ ] Integration: after `POST /proposals/[id]/reject` (and after `POST /emails/[id]/reprocess`), a subsequent list request reflects the change immediately (invalidation fired), not after TTL.
+- [ ] Integration: tenant A's list write does not evict or expose tenant B's cached list (cross-tenant isolation).
+- [ ] No behavior change when `cache` is unavailable (`resolveCache` returns `null`): handler returns the same payload as today.
+- [ ] `yarn workspace @open-mercato/core test` and `yarn typecheck` pass.
+
+## Labels
+
+- `feature`
+- `performance`
+- `priority-low` (opportunistic quick win; the hottest sub-surface — badge counts — is already cached, so this is incremental)
+

--- a/.ai/analysis/2026-06-08-cache-perf-frs/04-cache-inbox-ops-proposals-list.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/04-cache-inbox-ops-proposals-list.md
@@ -1,46 +1,33 @@
 > Auto-generated cache-performance Feature Request — candidate 4 of 9
 > Endpoint: `GET /api/inbox_ops/proposals` · ROI 82 · Verdict: good
 > Source: `packages/core/src/modules/inbox_ops/api/proposals/route.ts`
+> Revised 2026-06-09: the list cache now carries the **existing** `inbox_ops:counts:<tenantId>` tag that all 9 mutation sites already flush — the previously proposed parallel `invalidateProposalsListCache` calls at every site are dropped. Only the `reprocess` route (which flushes nothing today) gains one call.
 
 ## Summary
 
-Add a tenant-scoped, tag-invalidated read cache to the custom (non-`makeCrudRoute`) handler `GET /api/inbox_ops/proposals` (`packages/core/src/modules/inbox_ops/api/proposals/route.ts`). The handler runs a decrypted `findAndCountWithDecryption` plus three parallel `findWithDecryption` joins (emails, actions, discrepancies) and an in-memory enrichment loop on every page load and every poll of the proposals table.
+Add a tenant-scoped, tag-invalidated read cache to the custom (non-`makeCrudRoute`) handler `GET /api/inbox_ops/proposals`. The handler runs a decrypted `findAndCountWithDecryption` plus three parallel `findWithDecryption` joins (emails, actions, discrepancies) and an in-memory enrichment loop on every page load and poll of the proposals table.
 
-This is a **reuse-the-existing-infrastructure** change, not new infrastructure. The sibling badge endpoint `GET /api/inbox_ops/proposals/counts` is **already cached** with the canonical pattern (`runWithCacheTenant` + `cache.get`/`cache.set` with `ttl` + `tags`, helper module `lib/cache.ts`), and invalidation is **already wired into 8 mutating call sites** via `invalidateCountsCache`. We extend that same `lib/cache.ts` module with a list-cache key/tag/TTL + `invalidateProposalsListCache`, cache the list response in the handler, and add one `invalidateProposalsListCache(...)` call next to each existing `invalidateCountsCache(...)` call (and fix the `reprocess` route, which currently invalidates neither cache).
+**Key simplification:** the sibling badge endpoint `GET /api/inbox_ops/proposals/counts` is already cached and **every mutation that changes the list also changes the counts** — all 9 mutating sites already call `invalidateCountsCache(cache, tenantId)`, which flushes the tag `inbox_ops:counts:<tenantId>` (`lib/cache.ts`). Tag the new list entries with **that same tag** and the entire existing flush wiring invalidates the list for free. Zero new flush calls — except the `reprocess` route, which today invalidates *neither* cache and gets the one missing `invalidateCountsCache` call (fixing the counts cache too).
 
 ## Why (impact)
 
-- **Hotness — high.** Primary intake/triage workflow surface. Loaded on the proposals page and re-fetched on filter/tab/pagination changes; the page already polls `/proposals/counts` for badges (which is why that endpoint was cached first). The list itself is the most-read endpoint of the module.
-- **Cost — high.** Per request the handler executes (route.ts):
-  - `findAndCountWithDecryption(InboxProposal, …)` — paginated list **with decryption overhead** (lines 52-62).
-  - `Promise.all` of three more decrypted queries: `InboxEmail` by id-set, `InboxProposalAction` by proposal-id-set, `InboxDiscrepancy` (unresolved) by proposal-id-set (lines 68-78).
-  - An enrichment loop that maps relationships and computes `actionCount` / `pendingActionCount` / `discrepancyCount` / email subject/from/receivedAt per row (lines 82-96).
-  That is 4 decrypted round-trips + O(rows × actions) in-memory filtering per request, all of it identical across repeated reads between writes.
-- **Est. win.** Read:write ratio is high (proposals are read-mostly until a triage action). A 30s TTL cache (matching the counts endpoint) collapses the common "load page → switch tab → page back" burst and the poll cadence to a single DB hit per (tenant, filter, page) per TTL window. Expect the large majority of list reads served from cache with zero decryption work.
+- **Hotness — high.** Primary intake/triage workflow surface. Loaded on the proposals page and re-fetched on filter/tab/pagination changes.
+- **Cost — high.** Per request: `findAndCountWithDecryption(InboxProposal, …)` (route.ts:52-62), `Promise.all` of three more decrypted queries (route.ts:68-78), and an enrichment loop (route.ts:82-96). 4 decrypted round-trips + O(rows × actions) in-memory work, identical across repeated reads between writes.
+- **Est. win.** A 30 s TTL cache (matching the counts endpoint) collapses the "load page → switch tab → page back" burst to a single DB hit per (tenant, filter, page) per window, with zero decryption work on hits.
 
 ## Current behavior
 
-`packages/core/src/modules/inbox_ops/api/proposals/route.ts`:
-- `route.ts:18-24` — parses `status`, `category`, `search`, `page`, `pageSize` (schema `proposalListQuerySchema`, `data/validators.ts:267-273`; `pageSize` max 100, default 25).
-- `route.ts:26` — `resolveRequestContext(req)` yields `ctx.tenantId`, `ctx.organizationId`, `ctx.scope`, forked `ctx.em`, `ctx.container`.
-- `route.ts:52-62` — `findAndCountWithDecryption(ctx.em, InboxProposal, where, { limit, offset, orderBy }, ctx.scope)`.
-- `route.ts:68-78` — three parallel `findWithDecryption` calls (emails / actions / discrepancies).
-- `route.ts:82-96` — enrichment loop producing `actionCount`, `pendingActionCount`, `discrepancyCount`, `emailSubject`, `emailFrom`, `receivedAt`.
-- `route.ts:98-104` — returns `{ items, total, page, pageSize, totalPages }`.
+`packages/core/src/modules/inbox_ops/api/proposals/route.ts`: parses `status`/`category`/`search`/`page`/`pageSize` (route.ts:18-24), `resolveRequestContext` (route.ts:26), the four decrypted queries and enrichment (route.ts:52-96), returns `{ items, total, page, pageSize, totalPages }`. No caching today; not `makeCrudRoute`.
 
-No caching today. Not a `makeCrudRoute` route, so the generic `ENABLE_CRUD_API_CACHE` list cache does **not** apply — manual cache is the correct fix.
-
-Existing infrastructure to reuse:
-- `packages/core/src/modules/inbox_ops/lib/cache.ts` — `resolveCache(container)`, `createCountsCacheKey/Tag`, `invalidateCountsCache`, TTL constants. We add list-cache equivalents here.
-- `packages/core/src/modules/inbox_ops/api/proposals/counts/route.ts:24-83` — the exact get-then-set-with-tenant-scope pattern to copy.
+Existing infrastructure to reuse (`lib/cache.ts`):
+- `createCountsCacheTag(tenantId)` → literal `inbox_ops:counts:<tenantId>` (key and tag share the value intentionally).
+- `invalidateCountsCache(cache, tenantId)` — already called, post-commit, at **9 sites**: `accept-all`, `reject`, `categorize`, action `PUT/PATCH`, action `accept`, action `reject`, action `complete` routes, `subscribers/extractionWorker.ts:541`, and `ai-tools.ts:355-358` (the worker/AI sites wrap in `runWithCacheTenant(tenantId, …)`).
+- `api/proposals/counts/route.ts:24-83` — the get-then-set pattern to copy.
 
 ## Proposed cache
 
-**Key** — tenant-scoped via `runWithCacheTenant` (which already prefixes/namespaces per tenant), plus the query params that change the result set. Keep the key stable/short by hashing the param tuple:
-
 ```ts
 // lib/cache.ts (additions)
-const PROPOSALS_LIST_CACHE_PREFIX = 'inbox_ops:proposals:list'
 export const PROPOSALS_LIST_CACHE_TTL_MS = 30 * 1000 // mirror COUNTS_CACHE_TTL_MS
 
 export function createProposalsListCacheKey(
@@ -48,38 +35,14 @@ export function createProposalsListCacheKey(
   organizationId: string,
   params: { status?: string; category?: string; search?: string; page: number; pageSize: number },
 ): string {
-  const parts = [
-    organizationId,
-    params.status ?? '',
-    params.category ?? '',
-    params.search ?? '',
-    String(params.page),
-    String(params.pageSize),
-  ].join('|')
-  return `${PROPOSALS_LIST_CACHE_PREFIX}:${tenantId}:${parts}`
-}
-
-export function createProposalsListCacheTag(tenantId: string): string {
-  return `${PROPOSALS_LIST_CACHE_PREFIX}:${tenantId}`
-}
-
-export async function invalidateProposalsListCache(
-  cache: CacheStrategy | null | undefined,
-  tenantId: string,
-): Promise<void> {
-  if (!cache?.deleteByTags) return
-  try {
-    await cache.deleteByTags([createProposalsListCacheTag(tenantId)])
-  } catch (err) {
-    console.warn('[inbox_ops:cache] Failed to invalidate proposals list cache', err)
-  }
+  const parts = [organizationId, params.status ?? '', params.category ?? '', params.search ?? '', String(params.page), String(params.pageSize)].join('|')
+  return `inbox_ops:proposals:list:${tenantId}:${parts}`
 }
 ```
 
-**Handler** — wrap get-then-set in `runWithCacheTenant`, identical structure to the counts route:
+Handler (`route.ts`), mirroring the counts route exactly:
 
 ```ts
-// route.ts, after parsing query + resolveRequestContext
 const cache = resolveCache(ctx.container)
 const cacheKey = createProposalsListCacheKey(ctx.tenantId, ctx.organizationId, query)
 
@@ -87,79 +50,61 @@ if (cache) {
   const cached = await runWithCacheTenant(ctx.tenantId, () => cache.get(cacheKey))
   if (cached) return NextResponse.json(cached)
 }
-
-// ... existing find + enrichment ...
-const responseBody = { items: enrichedItems, total, page: query.page, pageSize: query.pageSize, totalPages: Math.ceil(total / query.pageSize) }
-
+// ... existing find + enrichment → responseBody ...
 if (cache) {
   try {
     await runWithCacheTenant(ctx.tenantId, () =>
       cache.set(cacheKey, responseBody, {
         ttl: PROPOSALS_LIST_CACHE_TTL_MS,
-        tags: [createProposalsListCacheTag(ctx.tenantId)],
+        tags: [createCountsCacheTag(ctx.tenantId)], // REUSE the already-flushed tag
       }),
     )
-  } catch (err) {
-    console.warn('[inbox_ops:proposals] Failed to set list cache', err)
-  }
+  } catch (err) { console.warn('[inbox_ops:proposals] Failed to set list cache', err) }
 }
 return NextResponse.json(responseBody)
 ```
 
-**Tenant scoping.** `organizationId` is folded into the key (an org switch produces a different key); `tenantId` drives `runWithCacheTenant` so one tenant can never read another's entry, matching the counts endpoint's contract. `cache` resolution is best-effort (`resolveCache` returns `null` if DI has no `cache`), so the route degrades to today's behavior when caching is unavailable.
-
 ## Cache tags
 
-- `inbox_ops:proposals:list:<tenantId>` — single coarse tag covering **all** list entries for a tenant (every status/category/search/page variant). One `deleteByTags` call clears the whole tenant's list cache on any write that can change list contents or the per-row counts. This intentionally mirrors the counts cache's 1:1 tenant tag (`inbox_ops:counts:<tenantId>`); the result set is small per tenant and a 30s TTL backstops anything missed, so per-status/per-page tag granularity is unnecessary and riskier.
+- `inbox_ops:counts:<tenantId>` — **reused.** Every write that can change the list (status transition, action accept/reject/complete/edit, categorization, accept-all, extraction) already flushes this tag because it also changes the badge counts. Tagging the list entries with it gives the list the exact same freshness contract as the already-shipped counts cache, with zero new flush wiring. (Semantically the tag now means "inbox_ops proposal state changed"; optionally alias it as `PROPOSALS_STATE_TAG = createCountsCacheTag` in `lib/cache.ts` for readability.)
 
 ## Invalidation
 
-Every site that today calls `invalidateCountsCache(cache, tenantId)` also changes the list (status transitions, action accept/reject/complete/edit, categorization, accept-all) and must additionally call `invalidateProposalsListCache(cache, tenantId)` in the same `runWithCacheTenant` block, **post-commit** (these routes already place the call after the domain write returns). The `reprocess` route currently invalidates **neither** cache and must invalidate both.
-
-| Trigger (route / command / event) | Where to call `deleteByTags` (via `invalidateProposalsListCache`) | Tags invalidated |
+| Trigger | Where the flush already happens | Tags |
 |---|---|---|
-| `POST /proposals/[id]/accept-all` (`api/proposals/[id]/accept-all/route.ts:35`) | next to existing `invalidateCountsCache`, post-commit | `inbox_ops:proposals:list:<tenantId>` |
-| `POST /proposals/[id]/reject` (`api/proposals/[id]/reject/route.ts:27`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
-| `POST /proposals/[id]/categorize` (`api/proposals/[id]/categorize/route.ts:35`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
-| `PUT/PATCH /proposals/[id]/actions/[actionId]` (`api/proposals/[id]/actions/[actionId]/route.ts:46`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
-| `POST /proposals/[id]/actions/[actionId]/accept` (`.../accept/route.ts:55`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
-| `POST /proposals/[id]/actions/[actionId]/reject` (`.../reject/route.ts:31`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
-| `POST /proposals/[id]/actions/[actionId]/complete` (`.../complete/route.ts:84`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
-| Extraction worker creates proposals/discrepancies (`subscribers/extractionWorker.ts:541`) | next to existing `invalidateCountsCache`, after flush | `inbox_ops:proposals:list:<tenantId>` |
-| AI tool mutation (`ai-tools.ts:355-358`) | next to existing `invalidateCountsCache` | `inbox_ops:proposals:list:<tenantId>` |
-| `POST /emails/[id]/reprocess` (`api/emails/[id]/reprocess/route.ts`) — supersedes proposals, voids actions, deletes discrepancies; **currently invalidates nothing** | add post-commit `invalidateCountsCache` **and** `invalidateProposalsListCache` (resolve `cache` via `resolveCache(ctx.container)`) | `inbox_ops:proposals:list:<tenantId>` (+ `inbox_ops:counts:<tenantId>`) |
+| `accept-all` / `reject` / `categorize` / action `PUT/PATCH` / action `accept` / action `reject` / action `complete` routes | existing `invalidateCountsCache` calls, post-commit | `inbox_ops:counts:<T>` |
+| Extraction worker creates proposals/discrepancies (`subscribers/extractionWorker.ts:541`) | existing call (already wrapped in `runWithCacheTenant`) | `inbox_ops:counts:<T>` |
+| AI tool mutation (`ai-tools.ts:355-358`) | existing call (already wrapped) | `inbox_ops:counts:<T>` |
+| `POST /emails/[id]/reprocess` — **currently flushes nothing** (pre-existing gap that already affects the counts cache) | **add one post-commit `invalidateCountsCache(cache, ctx.tenantId)` call** (inside `runWithCacheTenant`) | `inbox_ops:counts:<T>` |
 
-No event-subscriber hook is required: the module invalidates inline at the write sites (its established pattern). The 30s TTL is the backstop for the `reprocess` async path if a worker-side write lands outside these sites.
+## Safety / non-invalidation risks (double-checked)
+
+- **Tenant-namespace matching:** the route handler's get/set inherit the request namespace (dispatcher wrapper) and additionally wrap in `runWithCacheTenant(ctx.tenantId, …)` exactly like the counts route; the worker/AI flush sites already wrap explicitly. Route-level `invalidateCountsCache` calls run inside the mutating request (same tenant) — namespaces match everywhere.
+- **Blast radius:** one tag flushes every cached list variant for the tenant on any proposal write. That is intentionally coarse (matches the counts cache) — proposal mutations are triage actions, not high-frequency writes, and recomputing a 25-row page is cheap.
+- **Staleness window:** ≤30 s TTL only if a flush is missed; all known mutation paths already flush. The `reprocess` async tail is additionally TTL-bounded.
+- **Per-org correctness:** `organizationId` is in the key, so an org switch produces a different key; the tenant-wide tag still flushes all org variants together.
+- **Search/filter key cardinality:** free-text `search` creates many keys; the shared tag flushes them all and the 30 s TTL caps memory.
+- **Low-risk data:** read-mostly triage rows; no money/stock/auth. Best-effort flush + TTL backstop, never blocking the write path.
 
 ## Implementation steps
 
-- [ ] Extend `packages/core/src/modules/inbox_ops/lib/cache.ts` with `PROPOSALS_LIST_CACHE_TTL_MS` (30s), `createProposalsListCacheKey(tenantId, organizationId, params)`, `createProposalsListCacheTag(tenantId)`, and `invalidateProposalsListCache(cache, tenantId)` — mirroring the existing counts helpers.
-- [ ] In `api/proposals/route.ts`: import the new helpers + `resolveCache` + `runWithCacheTenant`; build the key from the parsed `query`; add the cache-get short-circuit before the DB work and the cache-set after building `responseBody`, both inside `runWithCacheTenant(ctx.tenantId, …)`, with best-effort try/catch on the set.
-- [ ] Add `invalidateProposalsListCache(cache, ctx.tenantId)` alongside each of the 9 existing `invalidateCountsCache` call sites (7 routes + extraction worker + ai-tools), within the same `runWithCacheTenant` block, post-commit.
-- [ ] Fix `api/emails/[id]/reprocess/route.ts`: resolve `cache`, and after the supersede/void/flush completes (post-commit) call both `invalidateCountsCache` and `invalidateProposalsListCache`.
-- [ ] Confirm `category` filter splitting (route.ts:38-45) and `search` are captured verbatim in the key (raw `query.category` / `query.search` strings, pre-split) so distinct filters get distinct entries.
-- [ ] Run `yarn workspace @open-mercato/core test` and `yarn typecheck`.
-
-## Risks & staleness window
-
-- **Staleness window:** up to the 30s TTL only if an invalidation site is missed; all known mutation paths invalidate explicitly, so the practical window after a write is near-zero (next read repopulates). Matches the already-shipped counts cache exactly — no new staleness contract.
-- **Low-risk data:** proposals list is read-mostly triage data; `actionCount` / `pendingActionCount` / `discrepancyCount` tolerate a brief convergence window. **No money, stock, auth tokens, or per-write-exact values** are involved.
-- **Tenant isolation:** enforced by `runWithCacheTenant(tenantId, …)` + `organizationId` in the key; cannot leak across tenants/orgs.
-- **Search/filter cardinality:** free-text `search` (max 200 chars) could create many distinct keys; the coarse tenant tag invalidates them all at once and the 30s TTL bounds their lifetime, so memory growth is naturally capped.
-- **Invalidation is best-effort** (try/catch + warn), with TTL as backstop — never blocks the write path. Cache set/get is wrapped so a cache outage degrades to current behavior.
+- [ ] Extend `lib/cache.ts` with `PROPOSALS_LIST_CACHE_TTL_MS` and `createProposalsListCacheKey(...)` (no new tag helpers — reuse `createCountsCacheTag`).
+- [ ] In `api/proposals/route.ts`: add the cache-get short-circuit and the cache-set with `tags: [createCountsCacheTag(ctx.tenantId)]`, both inside `runWithCacheTenant(ctx.tenantId, …)`.
+- [ ] Fix `api/emails/[id]/reprocess/route.ts`: resolve `cache`, and after the supersede/void/flush completes call `invalidateCountsCache` post-commit.
+- [ ] Confirm `category`/`search` are captured verbatim in the key so distinct filters get distinct entries.
+- [ ] `yarn workspace @open-mercato/core test` and `yarn typecheck`.
 
 ## Acceptance criteria / tests
 
-- [ ] Unit: `createProposalsListCacheKey` produces distinct keys for differing `status` / `category` / `search` / `page` / `pageSize` / `organizationId`, and a stable key for identical params.
-- [ ] Integration (`packages/core/src/modules/inbox_ops/__integration__/`): two identical `GET /api/inbox_ops/proposals?status=pending` requests return identical bodies and the second is served from cache (assert single DB population, e.g. via spy/profile or a controlled fixture mutation between calls being invisible until invalidation).
-- [ ] Integration: after `POST /proposals/[id]/reject` (and after `POST /emails/[id]/reprocess`), a subsequent list request reflects the change immediately (invalidation fired), not after TTL.
-- [ ] Integration: tenant A's list write does not evict or expose tenant B's cached list (cross-tenant isolation).
-- [ ] No behavior change when `cache` is unavailable (`resolveCache` returns `null`): handler returns the same payload as today.
-- [ ] `yarn workspace @open-mercato/core test` and `yarn typecheck` pass.
+- [ ] Unit: `createProposalsListCacheKey` produces distinct keys for differing params and a stable key for identical params.
+- [ ] Integration (`packages/core/src/modules/inbox_ops/__integration__/`): two identical `GET /api/inbox_ops/proposals?status=pending` calls — the second served from cache.
+- [ ] After `POST /proposals/[id]/reject`, a subsequent list reflects the change immediately (existing counts-tag flush, not TTL).
+- [ ] After `POST /emails/[id]/reprocess`, both the counts badge and the list reflect the supersede immediately (new flush call).
+- [ ] Tenant A's writes do not evict or expose tenant B's cached list.
+- [ ] No behavior change when `cache` is unavailable.
 
 ## Labels
 
 - `feature`
 - `performance`
-- `priority-low` (opportunistic quick win; the hottest sub-surface — badge counts — is already cached, so this is incremental)
-
+- `priority-low` (the hottest sub-surface — badge counts — is already cached; this is incremental)

--- a/.ai/analysis/2026-06-08-cache-perf-frs/05-cache-dictionaries-list.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/05-cache-dictionaries-list.md
@@ -1,128 +1,29 @@
 > Auto-generated cache-performance Feature Request — candidate 5 of 9
-> Endpoint: `GET /api/dictionaries` · ROI 82 · Verdict: good
+> Endpoint: `GET /api/dictionaries` · ROI 82 → re-audited · Verdict: **skip — overlaps an existing cache / low hotness**
 > Source: `packages/core/src/modules/dictionaries/api/route.ts`
+> Revised 2026-06-09: overlap audit against existing caches demoted this FR. Recommendation: close issue #2910 (or keep as low-priority backlog) — see analysis below.
 
-## Summary
+## Summary (revised verdict)
 
-Add a manual, tenant-scoped, tag-invalidated cache to the custom `GET /api/dictionaries` list handler in `packages/core/src/modules/dictionaries/api/route.ts`. This endpoint is a hand-rolled handler (NOT `makeCrudRoute`), so it bypasses the generic CRUD list cache in `packages/shared/src/lib/crud/factory.ts` entirely. It is read-mostly (dictionary definitions are admin-managed) and is hit on nearly every form/filter that references a dictionary, making it a clean hotness × cost × low-risk win.
+The original FR proposed a manual cache for the custom `GET /api/dictionaries` list handler. The 2026-06-09 overlap audit found that **the hot dictionary read surface is already cached elsewhere**, and this endpoint itself is not hot enough to justify new cache code:
 
-Copy the get-then-set + `deleteByTags` pattern from `packages/core/src/modules/customer_accounts/services/domainMappingService.ts`, scoping every cache op with `runWithCacheTenant` from `@open-mercato/cache`.
+1. **The hot path is the customers module's dictionary API, which is already cached.** Dictionary-backed select controls in customer forms hit `GET /api/customers/dictionaries/[kind]`, which has a full get-then-set cache with 5-minute TTL and tag invalidation (`packages/core/src/modules/customers/api/dictionaries/cache.ts` — keys `customers:dictionaries:<T>:<kind>:org=…`, tags `customers:dictionaries:<T>:<kind>[…:org:<O>]`, flushed by `invalidateDictionaryCache` on entry writes).
+2. **Dictionary-backed custom-field selects hit the entries endpoint, not this list.** `packages/core/src/modules/entities/api/definitions.ts:366` wires `optionsUrl = /api/dictionaries/${dictionaryId}/entries` — that per-dictionary entries endpoint is the genuinely hot, uncached surface, and it is now covered by **FR 12** (`12-cache-dictionary-entries.md`), where invalidation piggybacks on the already-flushed `crud:dictionaries.entry:*` tags.
+3. **What remains for `GET /api/dictionaries`** is the admin dictionaries manager page listing dictionary *definitions* — an admin-only, low-frequency surface (a handful of requests per admin session). Its cost (one org-ancestor lookup + one `em.find(Dictionary)`) does not clear the bar for new cache code plus three bespoke inline invalidation sites (the module's definition writes are plain `em.flush()` routes with no commands and no events, so there is **no existing flushed tag to connect to** — invalidation would have to be hand-wired, which is the complexity this backlog avoids for low-value surfaces).
 
-## Why (impact)
+## Recommendation
 
-- **Hotness**: The dictionary list is loaded whenever a form or filter that references a dictionary opens (entry-select controls, filter bars, the dictionaries manager page). Multiple calls per user session during data-entry workflows; high read:write ratio.
-- **Cost**: The handler runs `resolveDictionariesRouteContext` (which itself does an `Organization` lookup to expand the readable-org inheritance set — `context.ts:68-86`) and then an org-scoped `em.find(Dictionary, …)` over the inheritance set with `orderBy: { name: 'asc' }` and a per-row response mapping (`route.ts:35-61`). Every request re-resolves the org ancestor set and re-queries.
-- **Est. win**: Eliminates two DB round-trips (org-ancestor resolution + dictionary scan) per cache hit. For workflows that open many dictionary-backed selects, this turns a per-open query into an in-process/Redis read. Writes are rare (admin CRUD), so hit rate is very high.
+- **Close #2910** as not-planned (or relabel `priority-low` backlog). Implementing it would duplicate freshness machinery for a cold endpoint.
+- Implement **FR 12** instead — same module, the actually-hot endpoint, with zero new invalidation wiring.
+- If the dictionaries manager page ever becomes hot (e.g. embedded as a picker), revisit with the then-current write-path situation; if dictionary-definition writes are migrated to commands by then, the cache can ride `crud:dictionaries.dictionary:*` tags for free.
 
-## Current behavior
+## Original analysis (kept for the record)
 
-`packages/core/src/modules/dictionaries/api/route.ts`:
-- `route.ts:25` `GET(req)` — custom handler, no `makeCrudRoute`, so the generic CRUD cache (`ENABLE_CRUD_API_CACHE`) does NOT apply here.
-- `route.ts:27` resolves `resolveDictionariesRouteContext(req)`, which at `context.ts:68-86` queries `Organization` to compute `readableOrganizationIds` (the org + its `ancestorIds`).
-- `route.ts:29` reads `includeInactive` from query.
-- `route.ts:31-44` builds `organizationFilter` over `readableOrganizationIds` and runs `em.find(Dictionary, { organizationId $in, tenantId, deletedAt: null, isActive? }, { orderBy: name asc })`.
-- `route.ts:46-61` maps each row to a DTO (adds computed `isInherited` and `entrySortMode`).
-- Returns ONLY dictionary **definitions** — it does NOT read dictionary **entries**. Entry mutations (`dictionaries.entry.*` events) therefore do not affect this payload and must NOT trigger invalidation of this cache.
+The original proposal (manual cache keyed by `readableOrganizationIds` + `includeInactive` + selected org, 5-minute TTL, tenant-wide `dictionaries:list` tag, inline `deleteByTags` after `em.flush()` in the three definition write routes) is preserved in git history (PR #2905, commit `3616b2071`). Its correctness analysis remains valid; only its cost/benefit verdict changed:
 
-Writes that DO affect this list (all plain `em.flush()`, no command, no domain event for the dictionary aggregate):
-- `route.ts:90-104` `POST` create.
-- `packages/core/src/modules/dictionaries/api/[dictionaryId]/route.ts:107-173` `PATCH` update (name/key/description/isActive/entrySortMode; isActive=false also soft-deletes).
-- `packages/core/src/modules/dictionaries/api/[dictionaryId]/route.ts:199-211` `DELETE` soft-delete.
-
-## Proposed cache
-
-The result set depends on `tenantId`, the caller's `readableOrganizationIds` set, and `includeInactive`. Build the key from a stable, sorted hash of the readable-org set plus the `includeInactive` flag; tenant scoping is handled by `runWithCacheTenant`.
-
-- **TTL**: `5 * 60_000` ms (5 min), matching the reference `RESOLVE_TTL_MS` backstop in `domainMappingService.ts:18`. Dictionaries change rarely; tag invalidation is the primary freshness mechanism and TTL is only the backstop.
-- **Tenant scoping**: wrap get/set/deleteByTags in `runWithCacheTenant(context.tenantId, …)` so keys/tags are auto-namespaced per tenant — never serve one tenant's list to another.
-
-Code sketch (inside `GET`, after `resolveDictionariesRouteContext` and computing `includeInactive`):
-
-```typescript
-import { runWithCacheTenant } from '@open-mercato/cache'
-import { DICTIONARIES_LIST_TAG, buildDictionariesListKey } from '@open-mercato/core/modules/dictionaries/lib/cache'
-
-const cache = context.container.resolve('cache') as {
-  get(key: string): Promise<unknown>
-  set(key: string, value: unknown, opts?: { ttl?: number; tags?: string[] }): Promise<void>
-  deleteByTags(tags: string[]): Promise<number>
-}
-
-const cacheKey = buildDictionariesListKey(context.readableOrganizationIds, includeInactive)
-
-const cached = await runWithCacheTenant(context.tenantId, () => cache.get(cacheKey)) as
-  { items: unknown[] } | null | undefined
-if (cached) return NextResponse.json(cached)
-
-const items = await context.em.find(Dictionary, { /* unchanged */ }, { orderBy: { name: 'asc' } })
-const body = { items: items.map((dictionary) => ({ /* unchanged mapping */ })) }
-
-await runWithCacheTenant(context.tenantId, () =>
-  cache.set(cacheKey, body, { ttl: 5 * 60_000, tags: [DICTIONARIES_LIST_TAG] }))
-
-return NextResponse.json(body)
-```
-
-`buildDictionariesListKey` (new helper in `packages/core/src/modules/dictionaries/lib/cache.ts`) should sort + join the readable-org ids and append the `includeInactive` flag, e.g. `dictionaries:list:${includeInactive ? 'all' : 'active'}:${[...ids].sort().join(',')}`. The cache layer hashes + tenant-namespaces internally, so a long org list is fine.
-
-Note: `isInherited` in the mapping is derived from `context.organizationId` (the selected org), which can differ between two callers who share the same `readableOrganizationIds` set. Include `context.organizationId` in the key as well (e.g. as a `sel:<orgId>` segment) so the `isInherited` flag is never served stale across selected-org contexts.
-
-## Cache tags
-
-- `dictionaries:list` — tenant-wide collection tag (literal: `DICTIONARIES_LIST_TAG = 'dictionaries:list'`). Represents "any variant of the dictionary definitions list for this tenant." Because dictionary writes are rare and any create/update/delete can shift the list across org-inheritance variants, a single tenant-wide tag (busting all key variants on any write) is the correct, simplest choice — `runWithCacheTenant` namespaces it per tenant so cross-tenant invalidation never happens.
-
-## Invalidation
-
-All invalidation fires AFTER `em.flush()` commits (post-commit, best-effort; TTL is the backstop). Entry-level events are intentionally excluded — the list payload contains no entry data.
-
-| Trigger (route/command/event) | Where to call deleteByTags | Tags invalidated |
-|---|---|---|
-| `POST /api/dictionaries` create — `packages/core/src/modules/dictionaries/api/route.ts:104` | Immediately after `await context.em.flush()` (line 104), before building the 201 response | `['dictionaries:list']` |
-| `PATCH /api/dictionaries/:id` update — `packages/core/src/modules/dictionaries/api/[dictionaryId]/route.ts:173` | After `await context.em.flush()` (line 173), before the response | `['dictionaries:list']` |
-| `DELETE /api/dictionaries/:id` soft-delete — `packages/core/src/modules/dictionaries/api/[dictionaryId]/route.ts:211` | After `await context.em.flush()` (line 211), before `{ ok: true }` | `['dictionaries:list']` |
-| `dictionaries.entry.created/updated/deleted` events | NOT invalidated — list contains no entry data | (none) |
-
-Each invalidation call:
-
-```typescript
-await runWithCacheTenant(context.tenantId, () =>
-  (context.container.resolve('cache') as { deleteByTags(t: string[]): Promise<number> })
-    .deleteByTags([DICTIONARIES_LIST_TAG]))
-```
-
-Wrap in a `try/catch` that logs and swallows (best-effort) so a cache outage never fails the write.
-
-## Implementation steps
-
-1. Add `packages/core/src/modules/dictionaries/lib/cache.ts` exporting `DICTIONARIES_LIST_TAG = 'dictionaries:list'` and `buildDictionariesListKey(readableOrganizationIds: string[], includeInactive: boolean, selectedOrganizationId: string | null): string` (sorted org ids + flags + selected-org segment).
-2. In `api/route.ts` `GET`: resolve `cache` from `context.container`, attempt `cache.get` (tenant-scoped) before the `em.find`, return the cached body on hit, otherwise compute and `cache.set` with `ttl: 5 * 60_000` and `tags: [DICTIONARIES_LIST_TAG]`.
-3. In `api/route.ts` `POST`: after `em.flush()` (line 104), `deleteByTags([DICTIONARIES_LIST_TAG])` tenant-scoped, in a swallow-on-error block.
-4. In `api/[dictionaryId]/route.ts` `PATCH` (after line 173) and `DELETE` (after line 211): same post-commit `deleteByTags`.
-5. Add a unit test asserting (a) second identical GET hits cache (mock `em.find` called once), (b) POST/PATCH/DELETE each call `deleteByTags(['dictionaries:list'])` post-flush, (c) keys differ across `includeInactive` and across `readableOrganizationIds`/selected-org.
-6. Confirm `runWithCacheTenant` import resolves from `@open-mercato/cache` and `cache` is registered in the request container (it is — used by `domainMappingService`).
-7. Run `yarn workspace @open-mercato/core test` and `yarn workspace @open-mercato/core build`.
-
-## Risks & staleness window
-
-- **Staleness**: After a dictionary create/update/delete, other cached key variants (different org-inheritance sets) for the same tenant are all busted by the shared `dictionaries:list` tag, so no stale-after-write window for the editing tenant beyond the best-effort invalidation latency. If a `deleteByTags` call is dropped (cache outage), the 5-min TTL bounds staleness. Dictionary definitions are admin-managed and non-financial — a brief convergence window is acceptable (explicitly in-scope per the cache guidance: not money/stock/auth).
-- **Cross-tenant safety**: `runWithCacheTenant(context.tenantId, …)` namespaces keys/tags; one tenant can never read or invalidate another's entries.
-- **isInherited correctness**: handled by including `context.organizationId` in the key (see Proposed cache) so the per-caller `isInherited` flag is never served from a different selected-org context.
-- **No entry coupling**: entry mutations don't touch this payload, so excluding them from invalidation is correct and avoids needless cache churn.
-
-## Acceptance criteria / tests
-
-- [ ] Two identical `GET /api/dictionaries` requests in the same tenant/org scope execute `em.find(Dictionary, …)` only once (second served from cache).
-- [ ] `GET` with `?includeInactive=true` uses a distinct cache key from the default (active-only) request.
-- [ ] Distinct `readableOrganizationIds` sets or distinct selected `organizationId` produce distinct cache keys.
-- [ ] `POST`, `PATCH`, and `DELETE` each invoke `deleteByTags(['dictionaries:list'])` (tenant-scoped) AFTER `em.flush()`.
-- [ ] A subsequent `GET` after any write returns the updated list (cache miss → recompute).
-- [ ] Cache get/set/deleteByTags failures are swallowed and never fail the request (best-effort).
-- [ ] No cross-tenant read: a second tenant's GET never returns the first tenant's cached body.
-- [ ] `yarn workspace @open-mercato/core test` and `build` pass.
+- Hotness was overestimated: form selects do not call this endpoint (see audit above).
+- Invalidation required three bespoke inline flush sites because definition writes bypass the command bus — against the revised doctrine of connecting to already-flushed tags.
 
 ## Labels
 
-- `feature`
-- `performance`
-- `priority-low`
-
+`performance`, `priority-low` (recommended: close)

--- a/.ai/analysis/2026-06-08-cache-perf-frs/05-cache-dictionaries-list.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/05-cache-dictionaries-list.md
@@ -1,0 +1,128 @@
+> Auto-generated cache-performance Feature Request — candidate 5 of 9
+> Endpoint: `GET /api/dictionaries` · ROI 82 · Verdict: good
+> Source: `packages/core/src/modules/dictionaries/api/route.ts`
+
+## Summary
+
+Add a manual, tenant-scoped, tag-invalidated cache to the custom `GET /api/dictionaries` list handler in `packages/core/src/modules/dictionaries/api/route.ts`. This endpoint is a hand-rolled handler (NOT `makeCrudRoute`), so it bypasses the generic CRUD list cache in `packages/shared/src/lib/crud/factory.ts` entirely. It is read-mostly (dictionary definitions are admin-managed) and is hit on nearly every form/filter that references a dictionary, making it a clean hotness × cost × low-risk win.
+
+Copy the get-then-set + `deleteByTags` pattern from `packages/core/src/modules/customer_accounts/services/domainMappingService.ts`, scoping every cache op with `runWithCacheTenant` from `@open-mercato/cache`.
+
+## Why (impact)
+
+- **Hotness**: The dictionary list is loaded whenever a form or filter that references a dictionary opens (entry-select controls, filter bars, the dictionaries manager page). Multiple calls per user session during data-entry workflows; high read:write ratio.
+- **Cost**: The handler runs `resolveDictionariesRouteContext` (which itself does an `Organization` lookup to expand the readable-org inheritance set — `context.ts:68-86`) and then an org-scoped `em.find(Dictionary, …)` over the inheritance set with `orderBy: { name: 'asc' }` and a per-row response mapping (`route.ts:35-61`). Every request re-resolves the org ancestor set and re-queries.
+- **Est. win**: Eliminates two DB round-trips (org-ancestor resolution + dictionary scan) per cache hit. For workflows that open many dictionary-backed selects, this turns a per-open query into an in-process/Redis read. Writes are rare (admin CRUD), so hit rate is very high.
+
+## Current behavior
+
+`packages/core/src/modules/dictionaries/api/route.ts`:
+- `route.ts:25` `GET(req)` — custom handler, no `makeCrudRoute`, so the generic CRUD cache (`ENABLE_CRUD_API_CACHE`) does NOT apply here.
+- `route.ts:27` resolves `resolveDictionariesRouteContext(req)`, which at `context.ts:68-86` queries `Organization` to compute `readableOrganizationIds` (the org + its `ancestorIds`).
+- `route.ts:29` reads `includeInactive` from query.
+- `route.ts:31-44` builds `organizationFilter` over `readableOrganizationIds` and runs `em.find(Dictionary, { organizationId $in, tenantId, deletedAt: null, isActive? }, { orderBy: name asc })`.
+- `route.ts:46-61` maps each row to a DTO (adds computed `isInherited` and `entrySortMode`).
+- Returns ONLY dictionary **definitions** — it does NOT read dictionary **entries**. Entry mutations (`dictionaries.entry.*` events) therefore do not affect this payload and must NOT trigger invalidation of this cache.
+
+Writes that DO affect this list (all plain `em.flush()`, no command, no domain event for the dictionary aggregate):
+- `route.ts:90-104` `POST` create.
+- `packages/core/src/modules/dictionaries/api/[dictionaryId]/route.ts:107-173` `PATCH` update (name/key/description/isActive/entrySortMode; isActive=false also soft-deletes).
+- `packages/core/src/modules/dictionaries/api/[dictionaryId]/route.ts:199-211` `DELETE` soft-delete.
+
+## Proposed cache
+
+The result set depends on `tenantId`, the caller's `readableOrganizationIds` set, and `includeInactive`. Build the key from a stable, sorted hash of the readable-org set plus the `includeInactive` flag; tenant scoping is handled by `runWithCacheTenant`.
+
+- **TTL**: `5 * 60_000` ms (5 min), matching the reference `RESOLVE_TTL_MS` backstop in `domainMappingService.ts:18`. Dictionaries change rarely; tag invalidation is the primary freshness mechanism and TTL is only the backstop.
+- **Tenant scoping**: wrap get/set/deleteByTags in `runWithCacheTenant(context.tenantId, …)` so keys/tags are auto-namespaced per tenant — never serve one tenant's list to another.
+
+Code sketch (inside `GET`, after `resolveDictionariesRouteContext` and computing `includeInactive`):
+
+```typescript
+import { runWithCacheTenant } from '@open-mercato/cache'
+import { DICTIONARIES_LIST_TAG, buildDictionariesListKey } from '@open-mercato/core/modules/dictionaries/lib/cache'
+
+const cache = context.container.resolve('cache') as {
+  get(key: string): Promise<unknown>
+  set(key: string, value: unknown, opts?: { ttl?: number; tags?: string[] }): Promise<void>
+  deleteByTags(tags: string[]): Promise<number>
+}
+
+const cacheKey = buildDictionariesListKey(context.readableOrganizationIds, includeInactive)
+
+const cached = await runWithCacheTenant(context.tenantId, () => cache.get(cacheKey)) as
+  { items: unknown[] } | null | undefined
+if (cached) return NextResponse.json(cached)
+
+const items = await context.em.find(Dictionary, { /* unchanged */ }, { orderBy: { name: 'asc' } })
+const body = { items: items.map((dictionary) => ({ /* unchanged mapping */ })) }
+
+await runWithCacheTenant(context.tenantId, () =>
+  cache.set(cacheKey, body, { ttl: 5 * 60_000, tags: [DICTIONARIES_LIST_TAG] }))
+
+return NextResponse.json(body)
+```
+
+`buildDictionariesListKey` (new helper in `packages/core/src/modules/dictionaries/lib/cache.ts`) should sort + join the readable-org ids and append the `includeInactive` flag, e.g. `dictionaries:list:${includeInactive ? 'all' : 'active'}:${[...ids].sort().join(',')}`. The cache layer hashes + tenant-namespaces internally, so a long org list is fine.
+
+Note: `isInherited` in the mapping is derived from `context.organizationId` (the selected org), which can differ between two callers who share the same `readableOrganizationIds` set. Include `context.organizationId` in the key as well (e.g. as a `sel:<orgId>` segment) so the `isInherited` flag is never served stale across selected-org contexts.
+
+## Cache tags
+
+- `dictionaries:list` — tenant-wide collection tag (literal: `DICTIONARIES_LIST_TAG = 'dictionaries:list'`). Represents "any variant of the dictionary definitions list for this tenant." Because dictionary writes are rare and any create/update/delete can shift the list across org-inheritance variants, a single tenant-wide tag (busting all key variants on any write) is the correct, simplest choice — `runWithCacheTenant` namespaces it per tenant so cross-tenant invalidation never happens.
+
+## Invalidation
+
+All invalidation fires AFTER `em.flush()` commits (post-commit, best-effort; TTL is the backstop). Entry-level events are intentionally excluded — the list payload contains no entry data.
+
+| Trigger (route/command/event) | Where to call deleteByTags | Tags invalidated |
+|---|---|---|
+| `POST /api/dictionaries` create — `packages/core/src/modules/dictionaries/api/route.ts:104` | Immediately after `await context.em.flush()` (line 104), before building the 201 response | `['dictionaries:list']` |
+| `PATCH /api/dictionaries/:id` update — `packages/core/src/modules/dictionaries/api/[dictionaryId]/route.ts:173` | After `await context.em.flush()` (line 173), before the response | `['dictionaries:list']` |
+| `DELETE /api/dictionaries/:id` soft-delete — `packages/core/src/modules/dictionaries/api/[dictionaryId]/route.ts:211` | After `await context.em.flush()` (line 211), before `{ ok: true }` | `['dictionaries:list']` |
+| `dictionaries.entry.created/updated/deleted` events | NOT invalidated — list contains no entry data | (none) |
+
+Each invalidation call:
+
+```typescript
+await runWithCacheTenant(context.tenantId, () =>
+  (context.container.resolve('cache') as { deleteByTags(t: string[]): Promise<number> })
+    .deleteByTags([DICTIONARIES_LIST_TAG]))
+```
+
+Wrap in a `try/catch` that logs and swallows (best-effort) so a cache outage never fails the write.
+
+## Implementation steps
+
+1. Add `packages/core/src/modules/dictionaries/lib/cache.ts` exporting `DICTIONARIES_LIST_TAG = 'dictionaries:list'` and `buildDictionariesListKey(readableOrganizationIds: string[], includeInactive: boolean, selectedOrganizationId: string | null): string` (sorted org ids + flags + selected-org segment).
+2. In `api/route.ts` `GET`: resolve `cache` from `context.container`, attempt `cache.get` (tenant-scoped) before the `em.find`, return the cached body on hit, otherwise compute and `cache.set` with `ttl: 5 * 60_000` and `tags: [DICTIONARIES_LIST_TAG]`.
+3. In `api/route.ts` `POST`: after `em.flush()` (line 104), `deleteByTags([DICTIONARIES_LIST_TAG])` tenant-scoped, in a swallow-on-error block.
+4. In `api/[dictionaryId]/route.ts` `PATCH` (after line 173) and `DELETE` (after line 211): same post-commit `deleteByTags`.
+5. Add a unit test asserting (a) second identical GET hits cache (mock `em.find` called once), (b) POST/PATCH/DELETE each call `deleteByTags(['dictionaries:list'])` post-flush, (c) keys differ across `includeInactive` and across `readableOrganizationIds`/selected-org.
+6. Confirm `runWithCacheTenant` import resolves from `@open-mercato/cache` and `cache` is registered in the request container (it is — used by `domainMappingService`).
+7. Run `yarn workspace @open-mercato/core test` and `yarn workspace @open-mercato/core build`.
+
+## Risks & staleness window
+
+- **Staleness**: After a dictionary create/update/delete, other cached key variants (different org-inheritance sets) for the same tenant are all busted by the shared `dictionaries:list` tag, so no stale-after-write window for the editing tenant beyond the best-effort invalidation latency. If a `deleteByTags` call is dropped (cache outage), the 5-min TTL bounds staleness. Dictionary definitions are admin-managed and non-financial — a brief convergence window is acceptable (explicitly in-scope per the cache guidance: not money/stock/auth).
+- **Cross-tenant safety**: `runWithCacheTenant(context.tenantId, …)` namespaces keys/tags; one tenant can never read or invalidate another's entries.
+- **isInherited correctness**: handled by including `context.organizationId` in the key (see Proposed cache) so the per-caller `isInherited` flag is never served from a different selected-org context.
+- **No entry coupling**: entry mutations don't touch this payload, so excluding them from invalidation is correct and avoids needless cache churn.
+
+## Acceptance criteria / tests
+
+- [ ] Two identical `GET /api/dictionaries` requests in the same tenant/org scope execute `em.find(Dictionary, …)` only once (second served from cache).
+- [ ] `GET` with `?includeInactive=true` uses a distinct cache key from the default (active-only) request.
+- [ ] Distinct `readableOrganizationIds` sets or distinct selected `organizationId` produce distinct cache keys.
+- [ ] `POST`, `PATCH`, and `DELETE` each invoke `deleteByTags(['dictionaries:list'])` (tenant-scoped) AFTER `em.flush()`.
+- [ ] A subsequent `GET` after any write returns the updated list (cache miss → recompute).
+- [ ] Cache get/set/deleteByTags failures are swallowed and never fail the request (best-effort).
+- [ ] No cross-tenant read: a second tenant's GET never returns the first tenant's cached body.
+- [ ] `yarn workspace @open-mercato/core test` and `build` pass.
+
+## Labels
+
+- `feature`
+- `performance`
+- `priority-low`
+

--- a/.ai/analysis/2026-06-08-cache-perf-frs/06-enable-and-fix-catalog-products-list-cache.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/06-enable-and-fix-catalog-products-list-cache.md
@@ -1,6 +1,7 @@
 > Auto-generated cache-performance Feature Request — candidate 6 of 9
 > Endpoint: `GET /api/catalog/products` · ROI 78 · Verdict: good
 > Source: `packages/core/src/modules/catalog/api/products/route.ts`
+> Revised 2026-06-09: this FR is the **keystone of the whole backlog** — `invalidateCrudCache` no-ops while `ENABLE_CRUD_API_CACHE` is off (`packages/shared/src/lib/crud/cache.ts:180`), so every other FR that piggybacks on `crud:*` tags (01, 09, 10, 12, 13, 14) depends on this flag being enabled. Roll this out first. Scope extended to also alias `catalog.offer` (absorbing rescoped FR 08).
 
 ## Summary
 
@@ -78,7 +79,7 @@ All invalidation fires **post-commit** via the command bus (`invalidateCacheAfte
 | Trigger (route/command/event) | Where to call deleteByTags | Tags invalidated |
 |---|---|---|
 | `catalog.products.create` / `.update` / `.delete` (`route.ts:848/869/887`) | Already handled by command bus from `resourceKind: 'catalog.product'` (`commands/products.ts:1408/1765/1972`) → `invalidateCrudCache` (`command-bus.ts:610`) | `crud:catalog.product:tenant:<T>:org:<O>:collection`, `crud:catalog.product:tenant:<T>:record:<P>` |
-| `catalog.prices.create/update/delete` (`commands/prices.ts:432/734/874`, resourceKind `catalog.price`) | Add `context: { cacheAliases: ['catalog.product'] }` to each price command's log metadata so `extractAliasList` (`command-bus.ts:182-194`) adds the product alias; invalidation runs in `invalidateCacheAfterExecute` | `crud:catalog.price:...` (own) **+** `crud:catalog.product:tenant:<T>:org:<O>:collection` |
+| `catalog.prices.create/update/delete` (`commands/prices.ts:432/734/874`, resourceKind `catalog.price`) | Add `context: { cacheAliases: ['catalog.product', 'catalog.offer'] }` to each price command's log metadata so `extractAliasList` (`command-bus.ts:182-194`) adds both aliases; invalidation runs in `invalidateCacheAfterExecute`. (The `catalog.offer` alias keeps the offers list cache correct too — absorbed from rescoped FR 08.) | `crud:catalog.price:...` (own) **+** `crud:catalog.product:tenant:<T>:org:<O>:collection` **+** `crud:catalog.offer:...:collection` |
 | `catalog.offers.create/update/delete` (`commands/offers.ts:193/358/482`, resourceKind `catalog.offer`) | Add `context: { cacheAliases: ['catalog.product'] }` to offer command metadata | `crud:catalog.offer:...` **+** `crud:catalog.product:...:collection` |
 | `catalog.categories.*` + category **assignment** writes (`commands/categories.ts:228/393/538`) | Add `cacheAliases: ['catalog.product']` to the category-**assignment** command(s) (assignment is what changes a product's embedded `categories[]`); plain category rename also affects embedded `name`, so include it there too | `crud:catalog.category:...` **+** `crud:catalog.product:...:collection` |
 | Tag-assignment writes (`CatalogProductTagAssignment`) | Add `cacheAliases: ['catalog.product']` to the tag-assignment command metadata. NOTE: tags have **no declared event** in `events.ts`, so an event-subscriber hook is NOT available — `cacheAliases` is the correct mechanism | `crud:catalog.product:...:collection` |
@@ -104,6 +105,8 @@ Event-subscriber alternative (only viable where an event id exists): a single ep
 - **Tenant isolation**: enforced by `runWithCacheTenant` + tenant-segmented keys/tags; no cross-tenant exposure.
 - **Hit-path re-run of `afterList`**: the factory re-runs `afterList` on hits (`factory.ts:1556`), so even with a missed invalidation the decorated fields can be refreshed on read for the part the decorator recomputes; the cached portion is the base list. This further reduces staleness blast radius.
 - **Cross-resource alias correctness**: the main risk is forgetting one related command (e.g. a future new entity embedded into the decorator). Mitigate by listing the dependency set in a code comment on `decorateProductsAfterList` and asserting it in tests.
+- **Org-axis flush mismatch (double-checked)**: `invalidateCrudCache` flushes the collection tag for the org recorded in the command metadata (`cache.ts:191-198`). A command whose metadata lacks `organizationId` flushes only `org:null`, leaving org-scoped entries until TTL. Verify each aliased command (prices/offers/variants/tag-assignments/unit-conversions) records `organizationId` in its log metadata; the 120 s TTL backstops any that cannot.
+- **Tenant-namespace matching (double-checked)**: the factory's `cache.set` inherits the request namespace from the API dispatcher (`apps/mercato/src/app/api/[...slug]/route.ts:382`); `invalidateCrudCache` wraps its flush in `runWithCacheTenant(tenantId, …)` with the write's tenant — these match. Any future flush from a queue worker must wrap explicitly or it lands in the `global` namespace and silently misses.
 
 ## Acceptance criteria / tests
 

--- a/.ai/analysis/2026-06-08-cache-perf-frs/06-enable-and-fix-catalog-products-list-cache.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/06-enable-and-fix-catalog-products-list-cache.md
@@ -1,0 +1,124 @@
+> Auto-generated cache-performance Feature Request — candidate 6 of 9
+> Endpoint: `GET /api/catalog/products` · ROI 78 · Verdict: good
+> Source: `packages/core/src/modules/catalog/api/products/route.ts`
+
+## Summary
+
+`GET /api/catalog/products` is the hottest, most expensive read in the catalog module. It is built with `makeCrudRoute` (`packages/core/src/modules/catalog/api/products/route.ts:759`), so it is **already covered by the generic CRUD list cache** in `packages/shared/src/lib/crud/factory.ts` — but that cache is gated OFF behind `ENABLE_CRUD_API_CACHE` (`packages/shared/src/lib/crud/cache.ts:12-16`).
+
+The fix here is therefore **not net-new caching code**. It is two coordinated pieces:
+
+1. Enable + verify the generic CRUD list cache for this route.
+2. **Close a real invalidation gap**: the route's `afterList` decorator (`decorateProductsAfterList`, `route.ts:351-741`) embeds offers, channels, categories, tags, variants and resolved prices into each cached product row. Those related entities are written by their **own** commands (`catalog.prices.*`, `catalog.offers.*`, `catalog.categories.*`, variants, tag assignments) whose command-bus invalidation only clears their own resource tags (`catalog.price`, `catalog.offer`, `catalog.category`, …) — **never `catalog.product`**. With the cache naively enabled, a price/offer/category change would leave a stale embedded payload in the cached product list, bounded only by TTL.
+
+This FR enables the cache and makes the related-entity writes also invalidate the `catalog.product` collection tag (via cross-resource `cacheAliases`), so the cached list stays correct.
+
+## Why (impact)
+
+- **Hotness**: highest-traffic catalog read — product list page, product pickers in sales order/quote forms, dashboard product widgets, inventory screens, and the merchandising AI assistant selection. High read:write ratio (products and their prices/offers change far less often than they are listed).
+- **Cost**: the `afterList` decorator (`route.ts:351-741`) is heavy: per page it runs parallel `findWithDecryption` lookups for offers, sales channels, category assignments (+ parent categories, populated), tag assignments (populated), variants, and prices (populated `offer`/`variant`/`product`/`priceKind`), unit conversions, then a full `catalogPricingService.resolvePriceMany(...)` resolution (`route.ts:693`). That is ~8-10 DB round-trips plus the pricing pipeline on every list call, on top of the base query-engine list query.
+- **Est. win**: a cache hit collapses the entire base list query + the decorator's 8-10 queries + pricing resolution into a single cache `get`. For repeated navigation/pagination/picker reuse within the TTL window this is the dominant latency and DB-load reduction in the module.
+
+## Current behavior
+
+- Route is `makeCrudRoute(...)` — `packages/core/src/modules/catalog/api/products/route.ts:759`, with `hooks.afterList: decorateProductsAfterList` (`route.ts:844`).
+- `decorateProductsAfterList` (`route.ts:351-741`) loads and embeds, per product: `offers[]` + channel name/code, `categories[]` (+ parentName), `tags[]`, `pricing{}` from `resolvePriceMany` (`route.ts:693-726`). It also re-sorts by search relevance.
+- Generic CRUD cache flow in `factory.ts`:
+  - Miss path: base query → `transformItem` → custom fields → **`afterList` runs (`factory.ts:1798`)** → interceptors → **`enrichAndStorePayload` stores the payload (`factory.ts:1818`)**. So the cached payload **already contains the decorated offers/categories/tags/pricing** — good for hit latency, but it means the cache entry's correctness depends on invalidation covering every related entity the decorator reads.
+  - Hit path (`factory.ts:1521-1591`): cached payload is cloned and `afterList` is **re-run on the hit** (`factory.ts:1556`). (For this route that means the decorator re-runs anyway on a hit — partial win — unless the cached decorated fields are trusted; either way the base list query + custom-field decoration are saved.)
+- **Cache key** already partitions by the full query string — `query:${serializeSearchParams(url.searchParams)}` (`factory.ts:903`), plus tenant, `selectedOrg`, and org scope (`factory.ts:895-904`). This means the pricing-context params (`offerId`, `customerId`, `customerGroupId`, `userId`, `userGroupId`, `quantity`, `quantityUnit`, `channelId`, `priceDate`) are part of the key — different pricing contexts get distinct entries, so embedded prices are not cross-served between contexts. This removes the main correctness worry about caching resolved prices.
+- **Tags** are built by `buildCollectionTags` / `buildRecordTag` (`packages/shared/src/lib/crud/cache.ts:63-90`) and stored on `cache.set(...)` (`factory.ts:1456`).
+- **Write path**: products are written via commands (`actions.create/update/delete` → `catalog.products.create|update|delete`, `route.ts:848/869/887`). In the command path the factory returns **without** calling `invalidateCrudCache` (`factory.ts:2120-2125`); invalidation is done by the command bus in `invalidateCacheAfterExecute` (`command-bus.ts:556-625`) from `metadata.resourceKind` + `deriveResourceFromCommandId`. The product commands set `resourceKind: 'catalog.product'` (`commands/products.ts:1408/1765/1972`), so product writes correctly clear the `catalog.product` collection + record tags.
+- **The gap**: the related-entity commands set their own resourceKind only:
+  - `commands/prices.ts:432/734/874` → `catalog.price`
+  - `commands/offers.ts:193/358/482` → `catalog.offer`
+  - `commands/categories.ts:228/393/538` → `catalog.category`
+  - variants and tag assignments similarly scoped to their own resource.
+  None of them invalidate `catalog.product`, yet all of them change what `decorateProductsAfterList` embeds into the cached product rows. (Offers and tag assignments don't even declare events in `events.ts`, so an event-subscriber-only invalidation strategy can't cover them — see Invalidation.)
+
+## Proposed cache
+
+No new cache key/TTL code is required for the list itself — reuse the generic CRUD list cache. The only new code is cross-resource invalidation (below). For reference, the existing behavior this FR relies on:
+
+Key shape (already implemented, `factory.ts:884-916`, tenant-scoped + query-scoped):
+
+```
+crud|catalog.product|GET|/api/catalog/products|tenant:<tenantId>|selectedOrg:<orgId>|scope:<orgIds>|query:<serialized search params>
+```
+
+The cache service is resolved and tenant-scoped exactly as the reference pattern (`packages/core/src/modules/customer_accounts/services/domainMappingService.ts`) and the factory do:
+
+```ts
+import { runWithCacheTenant } from '@open-mercato/cache'
+const cache = container.resolve('cache')
+// read
+const hit = await runWithCacheTenant(tenantId, () => cache.get(key))
+// write with tags + ttl backstop
+await runWithCacheTenant(tenantId, () => cache.set(key, value, { ttl, tags }))
+// invalidate
+await runWithCacheTenant(tenantId, () => cache.deleteByTags(tags))
+```
+
+TTL: set the generic CRUD list TTL to **120s** for this route (backstop only; tag invalidation is the primary mechanism). Justification: product/offer/category/price data is read-mostly and non-financial at read time (this list feeds quotation/exploration UI, not settlement), so a worst-case 120s convergence window if a tag invalidation is missed is acceptable. Keep it ≤120s so even fully-missed invalidations self-heal quickly.
+
+Tenant scoping: enforced automatically — `buildCrudCacheKey` namespaces by `tenant:<tenantId>` and `invalidateCrudCache` wraps `deleteByTags` in `runWithCacheTenant(tenantId, …)` (`cache.ts:210`). No cross-tenant read is possible.
+
+## Cache tags
+
+For tenant `T`, org `O`, product id `P` (literal shapes from `buildCollectionTags` / `buildRecordTag`, `cache.ts:63-90`):
+
+- `crud:catalog.product:tenant:<T>:org:<O>:collection` — the product **list** cache entry for tenant `T`, org `O`. This is the tag every product-list cache entry carries and the one that MUST be invalidated whenever any data embedded into the list changes.
+- `crud:catalog.product:tenant:<T>:org:null:collection` — null-org variant (cross-org / unscoped listing).
+- `crud:catalog.product:tenant:<T>:record:<P>` — per-record tag for product `P` (used by detail caches / single-record invalidation).
+
+## Invalidation
+
+All invalidation fires **post-commit** via the command bus (`invalidateCacheAfterExecute`, `command-bus.ts:556-625`), which runs after `commandBus.execute(...)` — i.e. after the domain write commits and outside `withAtomicFlush`. The fix is to make the related commands include `catalog.product` in `context.cacheAliases` so the same post-commit hook also clears the product collection tag.
+
+| Trigger (route/command/event) | Where to call deleteByTags | Tags invalidated |
+|---|---|---|
+| `catalog.products.create` / `.update` / `.delete` (`route.ts:848/869/887`) | Already handled by command bus from `resourceKind: 'catalog.product'` (`commands/products.ts:1408/1765/1972`) → `invalidateCrudCache` (`command-bus.ts:610`) | `crud:catalog.product:tenant:<T>:org:<O>:collection`, `crud:catalog.product:tenant:<T>:record:<P>` |
+| `catalog.prices.create/update/delete` (`commands/prices.ts:432/734/874`, resourceKind `catalog.price`) | Add `context: { cacheAliases: ['catalog.product'] }` to each price command's log metadata so `extractAliasList` (`command-bus.ts:182-194`) adds the product alias; invalidation runs in `invalidateCacheAfterExecute` | `crud:catalog.price:...` (own) **+** `crud:catalog.product:tenant:<T>:org:<O>:collection` |
+| `catalog.offers.create/update/delete` (`commands/offers.ts:193/358/482`, resourceKind `catalog.offer`) | Add `context: { cacheAliases: ['catalog.product'] }` to offer command metadata | `crud:catalog.offer:...` **+** `crud:catalog.product:...:collection` |
+| `catalog.categories.*` + category **assignment** writes (`commands/categories.ts:228/393/538`) | Add `cacheAliases: ['catalog.product']` to the category-**assignment** command(s) (assignment is what changes a product's embedded `categories[]`); plain category rename also affects embedded `name`, so include it there too | `crud:catalog.category:...` **+** `crud:catalog.product:...:collection` |
+| Tag-assignment writes (`CatalogProductTagAssignment`) | Add `cacheAliases: ['catalog.product']` to the tag-assignment command metadata. NOTE: tags have **no declared event** in `events.ts`, so an event-subscriber hook is NOT available — `cacheAliases` is the correct mechanism | `crud:catalog.product:...:collection` |
+| `catalog.variant.created/updated/deleted` (variant commands) | Add `cacheAliases: ['catalog.product']` (variants change pricing rows that resolve into `pricing{}`) | `crud:catalog.variant:...` **+** `crud:catalog.product:...:collection` |
+| Unit-conversion writes (`catalog.product_unit_conversion.*`) | Add `cacheAliases: ['catalog.product']` (conversions affect normalized pricing quantity) | `crud:catalog.product:...:collection` |
+
+Event-subscriber alternative (only viable where an event id exists): a single ephemeral subscriber on `catalog.price.updated` / `catalog.category.updated` / `catalog.variant.updated` could call `invalidateCrudCache(container, 'catalog.product', …)`. **Reject this as the primary mechanism** because offers and tag assignments emit no events — use `cacheAliases` uniformly so coverage is complete, and keep TTL as the backstop.
+
+## Implementation steps
+
+- [ ] Set `ENABLE_CRUD_API_CACHE=on` in the target environment(s) and confirm `isCrudCacheEnabled()` (`cache.ts:12`) returns true; verify the route emits `x-om-cache: hit|miss` headers (`factory.ts:1516`).
+- [ ] Configure / confirm the generic CRUD list TTL is 120s for this route (or globally acceptable).
+- [ ] Add `context: { cacheAliases: ['catalog.product'] }` to the log metadata of every related command that feeds `decorateProductsAfterList`: prices (`commands/prices.ts`), offers (`commands/offers.ts`), category + category-assignment (`commands/categories.ts`), variant commands, tag-assignment command, and unit-conversion command. Mirror the existing `context: { cacheAliases: resourceTargets }` shape used by the factory (`factory.ts:2084/2386/2715`).
+- [ ] Verify `deriveResourceFromCommandId` + `extractAliasList` produce both the own-resource tag and `catalog.product` for each (`command-bus.ts:604-617`).
+- [ ] Confirm invalidation is post-commit (command bus calls it after `execute`, outside `withAtomicFlush`) — no change needed, just verify no command moved invalidation inside the flush.
+- [ ] Confirm the cache key already varies by pricing context params; no key change needed (`factory.ts:903`).
+- [ ] Add/extend integration tests (below) in `packages/core/src/modules/catalog/__integration__/`.
+
+## Risks & staleness window
+
+- **Convergence window**: up to the TTL (120s) only if a tag invalidation is missed; normal path is immediate post-commit invalidation. Non-financial read surface (quotation/exploration), so acceptable.
+- **Embedded resolved prices**: safe to cache because the key partitions by pricing-context query params (`offerId`, `customerId`, `customerGroupId`, `userId`, `userGroupId`, `quantity`, `quantityUnit`, `channelId`, `priceDate`) — no cross-context price leakage.
+- **Tenant isolation**: enforced by `runWithCacheTenant` + tenant-segmented keys/tags; no cross-tenant exposure.
+- **Hit-path re-run of `afterList`**: the factory re-runs `afterList` on hits (`factory.ts:1556`), so even with a missed invalidation the decorated fields can be refreshed on read for the part the decorator recomputes; the cached portion is the base list. This further reduces staleness blast radius.
+- **Cross-resource alias correctness**: the main risk is forgetting one related command (e.g. a future new entity embedded into the decorator). Mitigate by listing the dependency set in a code comment on `decorateProductsAfterList` and asserting it in tests.
+
+## Acceptance criteria / tests
+
+- [ ] With cache enabled, two identical `GET /api/catalog/products` requests in the same tenant/org/query return the same payload and the second carries `x-om-cache: hit`.
+- [ ] After `catalog.products.update` on a listed product, the next list request is a `miss` and reflects the change.
+- [ ] After a **price** write (`catalog.prices.update`) on a listed product, the next list request reflects the new `pricing{}` (proves `cacheAliases: ['catalog.product']` invalidation) — this test FAILS before the fix and PASSES after.
+- [ ] After an **offer** write, the next list reflects updated `offers[]`/`channelIds` (FAILS before fix).
+- [ ] After a **category-assignment** and a **tag-assignment** write, the next list reflects updated `categories[]` / `tags[]` (tag test specifically proves the no-event path is covered by `cacheAliases`).
+- [ ] Cross-tenant test: a write in tenant A never invalidates and never serves tenant B's cached list.
+- [ ] Different pricing-context query params produce distinct cache entries (no price cross-serving).
+- [ ] Tests are self-contained: create products/prices/offers/categories/tags via API fixtures in setup, clean up in teardown; no reliance on seeded data. Place under `packages/core/src/modules/catalog/__integration__/`.
+
+## Labels
+
+- `feature`
+- `performance`
+- `priority-medium`
+

--- a/.ai/analysis/2026-06-08-cache-perf-frs/07-cache-dashboards-layout-bootstrap.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/07-cache-dashboards-layout-bootstrap.md
@@ -1,0 +1,136 @@
+> Auto-generated cache-performance Feature Request — candidate 7 of 9
+> Endpoint: `GET /api/dashboards/layout` · ROI 72 · Verdict: good
+> Source: `packages/core/src/modules/dashboards/api/layout/route.ts`
+
+## Summary
+
+Add a manual, tenant-scoped, tag-invalidated cache to the `GET` handler of `/api/dashboards/layout` (`packages/core/src/modules/dashboards/api/layout/route.ts`). The endpoint is bootstrap-critical (hit on every backoffice app init and on every org switch) and recomputes an expensive per-user view (allowed widget resolution across user-override + role-widget + role-membership + ACL feature filtering, plus a decrypted `User` lookup) on every request.
+
+This is **not** a `makeCrudRoute` endpoint, so the generic CRUD list cache in `packages/shared/src/lib/crud/factory.ts` does **not** cover it. It needs a small, hand-written get-then-set cache modeled on `packages/core/src/modules/customer_accounts/services/domainMappingService.ts`.
+
+**Important nuance that makes this `good` and not a trivial quick win:** the `GET` handler is not a pure read. On first load it creates+persists a default `DashboardLayout`, and on later loads it prunes now-disallowed widgets and re-normalizes order, flushing when `hasChanged` (route.ts:105-143). The cache must store the **already-healed** response so a hit can be served without re-running the heal, and invalidation must fire on every input that changes the healed output — including cross-module role-membership/ACL changes. Design below accounts for this.
+
+## Why (impact)
+
+- **Hotness: very high.** Called on every dashboard render — app init and every organization switch re-fetch it. High read:write ratio; a given user reconfigures their layout rarely but loads it constantly.
+- **Cost: high per call.** `GET` performs, per request:
+  - `rbac.loadAcl(...)` (route.ts:86)
+  - `resolveAllowedWidgetIds(...)` which itself runs `em.findOne(DashboardUserWidgets)` + `findWithDecryption(UserRole, { populate: ['role'] })` + `em.find(DashboardRoleWidgets, { roleId: { $in: ... } })` + per-widget feature filtering (`packages/core/src/modules/dashboards/lib/access.ts:37-107`)
+  - `loadScopeLayout` (`em.findOne(DashboardLayout)`, route.ts:33-40, 101)
+  - `findOneWithDecryption(User, ...)` for the display label (route.ts:150-156)
+  - deep response mapping over all allowed widgets (route.ts:176-188)
+  - `loadAllWidgets()` (route.ts:87) is already process-memoized (`widgetEntriesPromise` + `widgetCache` in `packages/core/src/modules/dashboards/lib/widgets.ts`), so it is cheap after warm-up and is **not** the target — the target is the per-user resolution + decryption layer.
+- **Est. win:** eliminate ~4 DB round-trips (two of them decryption-decorated) plus widget-set filtering on the hot path for cached `(user, tenant, org)` tuples. On a cache hit the handler returns a serialized payload with zero query-engine/decryption work. Expected p95 reduction on dashboard bootstrap proportional to those round-trips, multiplied across every page load and org switch.
+
+## Current behavior
+
+File: `packages/core/src/modules/dashboards/api/layout/route.ts`
+
+- `GET` (route.ts:70-192):
+  - builds `scope = { userId, tenantId, organizationId }` from auth (route.ts:80-84)
+  - `acl = await rbac.loadAcl(...)` (route.ts:86)
+  - `widgets = await loadAllWidgets()` (route.ts:87)
+  - `allowedIds = await resolveAllowedWidgetIds(em, {...}, widgets)` (route.ts:88-98) — the expensive multi-query resolution in `lib/access.ts`
+  - `layout = await loadScopeLayout(em, scope)` (route.ts:101)
+  - self-heal: creates a default layout on first load and persists it (route.ts:105-122), or prunes disallowed items + renormalizes order and flushes when `hasChanged` (route.ts:123-143)
+  - `findOneWithDecryption(User, ...)` for `userName`/`userEmail`/`userLabel` (route.ts:150-161)
+  - returns `{ layout: { items }, allowedWidgetIds, canConfigure, context, widgets: [...] }` (route.ts:166-191)
+- `PUT` (route.ts:194-270) writes `DashboardLayout.layoutJson` for the scope.
+- Sibling writers that change cached inputs:
+  - `PATCH /api/dashboards/layout/[itemId]` — mutates one layout item (`packages/core/src/modules/dashboards/api/layout/[itemId]/route.ts:22-81`)
+  - `PUT /api/dashboards/roles/widgets` — writes `DashboardRoleWidgets` (`packages/core/src/modules/dashboards/api/roles/widgets/route.ts:87-150`)
+  - `PUT /api/dashboards/users/widgets` — writes `DashboardUserWidgets` (`packages/core/src/modules/dashboards/api/users/widgets/route.ts:87-152`)
+
+No caching exists today. There is no `events.ts` in the dashboards module, so invalidation must be wired directly in each writing route (post-commit), not via an event subscriber.
+
+## Proposed cache
+
+Cache the **healed** `GET` response object keyed by the `(userId, tenantId, organizationId)` tuple, tenant-scoped via `runWithCacheTenant`. The handler runs the heal/persist on a miss, then stores the final response; on a hit it returns the stored response directly.
+
+- **Cache KEY shape** (hashed + tenant-namespaced internally by the cache service):
+  `dashboards:layout:resp:${userId}:${organizationId ?? 'none'}` — wrapped in `runWithCacheTenant(scope.tenantId, ...)` so the tenant prefix is applied automatically. (userId already encodes tenant membership, but keep org in the key because allowed-widget resolution is org-scoped — see `lib/access.ts:73-75`.)
+- **TTL:** `15 * 60_000` (15 min). Justification: layout/role/user-widget changes are infrequent and we invalidate explicitly on every writer below, so TTL is only a backstop for the cross-module ACL/role-membership case (see Invalidation table — those are best-effort). 15 min bounds worst-case staleness if a role-membership change is made through a path we do not hook, without holding stale widget access for a meaningful session.
+
+Code sketch (drop into the `GET` handler, after building `scope`):
+
+```ts
+import { runWithCacheTenant } from '@open-mercato/cache'
+
+const cache = container.resolve('cache') as {
+  get(key: string): Promise<unknown>
+  set(key: string, val: unknown, opts?: { ttl?: number; tags?: string[] }): Promise<void>
+  deleteByTags(tags: string[]): Promise<number>
+}
+
+const cacheKey = `dashboards:layout:resp:${scope.userId}:${scope.organizationId ?? 'none'}`
+const cacheTags = [
+  'dashboards:layout',
+  `dashboards:layout:user:${scope.userId}`,
+  scope.organizationId ? `dashboards:layout:org:${scope.organizationId}` : 'dashboards:layout:org:none',
+]
+
+const cached = await runWithCacheTenant(scope.tenantId, () => cache.get(cacheKey))
+if (cached) return NextResponse.json(cached)
+
+// ... existing resolution + self-heal (loadAcl, loadAllWidgets, resolveAllowedWidgetIds,
+//     loadScopeLayout, persist/flush, findOneWithDecryption(User), build `response`) ...
+
+await runWithCacheTenant(scope.tenantId, () =>
+  cache.set(cacheKey, response, { ttl: 15 * 60_000, tags: cacheTags }),
+)
+return NextResponse.json(response)
+```
+
+Note: the heal/persist still runs on every miss (i.e., first request after any invalidation), so the default-layout creation and pruning are never skipped — the cache only short-circuits steady-state repeat reads.
+
+## Cache tags
+
+- `dashboards:layout` — coarse tag on every cached layout response; lets a broad widget-catalog or module-level change blow away all dashboard layout caches at once.
+- `dashboards:layout:user:${userId}` — all cached responses for one user (currently one per org); invalidated by user-scoped layout/override writes and by that user's role-membership/ACL changes.
+- `dashboards:layout:org:${organizationId}` (or `dashboards:layout:org:none`) — all cached responses scoped to one organization; invalidated by org-scoped role-widget assignment changes that affect every member.
+
+## Invalidation
+
+All `deleteByTags` calls MUST run **post-commit** (after `await em.flush()` / `em.remove(...).flush()`), wrapped in `runWithCacheTenant(scope.tenantId, ...)`, and be best-effort (try/catch, TTL is the backstop) — same contract as `invalidateCacheFor` in `domainMappingService.ts:479-488`.
+
+| Trigger (route/command/event) | Where to call `deleteByTags` | Tags invalidated |
+|---|---|---|
+| `PUT /api/dashboards/layout` (`api/layout/route.ts` `PUT`, after `await em.flush()` at line 267) | end of `PUT`, post-flush | `dashboards:layout:user:${scope.userId}` |
+| `PATCH /api/dashboards/layout/[itemId]` (`api/layout/[itemId]/route.ts`, after `await em.flush()` at line 78) | end of `PATCH`, post-flush | `dashboards:layout:user:${scope.userId}` |
+| `PUT /api/dashboards/users/widgets` (`api/users/widgets/route.ts` `PUT`, after each `flush`/`remove(...).flush()` at lines 132/149) | post-flush; use the **target** `parsed.data.userId` (admin edits another user) | `dashboards:layout:user:${parsed.data.userId}` |
+| `PUT /api/dashboards/roles/widgets` (`api/roles/widgets/route.ts` `PUT`, after `flush`/`remove(...).flush()` at lines 131/147) | post-flush; role change affects all members in scope | `dashboards:layout:org:${organizationId ?? 'none'}` **and** `dashboards:layout` (role membership per user is not known here, so fall back to the org-wide + coarse tags) |
+| Role-membership / ACL feature change (cross-module: `auth` UserRole / RBAC grants) | Not directly hooked in v1 — rely on the **15 min TTL backstop**. Optionally, follow-up: emit/handle an `auth.user_role.changed`-style event and call `deleteByTags(['dashboards:layout:user:${userId}'])` in a dashboards subscriber once such an event id exists. | `dashboards:layout:user:${userId}` (future) |
+
+Rationale for the role-widget writer using the coarse + org tags: `DashboardRoleWidgets` changes affect every user holding that role, and the writer does not enumerate members. Invalidating `dashboards:layout:org:${organizationId}` (members share the org scope) plus the coarse `dashboards:layout` tag guarantees correctness; the blast radius is acceptable because role-widget edits are rare admin actions.
+
+## Implementation steps
+
+- [ ] In `api/layout/route.ts` `GET`, resolve `cache` from the existing `container`, build `cacheKey` + `cacheTags`, add the `runWithCacheTenant` get-then-set around the existing resolution/heal/response build (sketch above). Serve cached payload on hit; keep the heal/persist on miss.
+- [ ] Add post-commit, best-effort `deleteByTags` (wrapped in `runWithCacheTenant(tenantId, ...)`, try/catch) to: `api/layout/route.ts` `PUT`, `api/layout/[itemId]/route.ts` `PATCH`, `api/users/widgets/route.ts` `PUT`, `api/roles/widgets/route.ts` `PUT` — using the tag mapping in the Invalidation table.
+- [ ] Extract a shared helper (e.g. `lib/cacheKeys.ts` in the dashboards module) exporting the key builder and tag builders so the GET and all writers stay in sync (single source of truth for tag strings).
+- [ ] Confirm no PII leaks across tenants: key+tags are tenant-scoped via `runWithCacheTenant`; the cached payload contains the user's own decrypted name/email only, never another tenant's data.
+- [ ] Gate behind an env flag if desired for staged rollout (optional; the per-endpoint cache is low-risk enough to ship on).
+- [ ] Run `yarn workspace @open-mercato/core test` and add the integration test below.
+
+## Risks & staleness window
+
+- **Self-heal skipped on hit (acceptable):** because invalidation fires whenever an input that the heal depends on changes (layout, user-override, role-widget assignment), a cache hit only occurs when the healed output is still valid. The first request after any change is a miss and re-runs the heal/persist.
+- **Cross-module convergence window:** role-membership / ACL grant changes are not directly hooked in v1, so a user could briefly (up to the 15 min TTL) see widgets per their previous role set. Risk is low: widget *visibility* is cosmetic, not a security boundary — actual widget data endpoints (`api/widgets/data/route.ts`) re-check ACL independently, so a stale `allowedWidgetIds` cannot expose data the user is not entitled to. The follow-up event hook closes the window entirely when available.
+- **Not financial/stock/auth data** — short staleness is tolerable per the cache-safety contract (`packages/cache/AGENTS.md` → Consistency vs commit timing).
+- Invalidation is best-effort; TTL guarantees eventual convergence.
+
+## Acceptance criteria / tests
+
+- [ ] `GET /api/dashboards/layout` returns identical payloads on a cold call vs a warm (cached) call for the same `(user, tenant, org)`.
+- [ ] After `PUT /api/dashboards/layout`, the next `GET` reflects the new layout (cache invalidated for `dashboards:layout:user:${userId}`).
+- [ ] After `PATCH /api/dashboards/layout/[itemId]`, the next `GET` reflects the new size/settings.
+- [ ] After `PUT /api/dashboards/users/widgets` for a target user, that target user's next `GET` reflects the new `allowedWidgetIds` (invalidated by target userId, not the admin's userId).
+- [ ] After `PUT /api/dashboards/roles/widgets`, affected members' next `GET` reflects the change (org-tag + coarse invalidation).
+- [ ] Tenant isolation: a cached entry for tenant A is never served to a request in tenant B (assert distinct `runWithCacheTenant` namespaces).
+- [ ] First load for a brand-new user still creates+persists the default `DashboardLayout` (heal runs on the miss path); a subsequent load is served from cache without re-persisting.
+- [ ] Integration test colocated at `packages/core/src/modules/dashboards/__integration__/` (per the per-module integration-test convention), creating fixtures via API and cleaning up in teardown.
+
+## Labels
+
+`feature`, `performance`, `priority-medium`
+

--- a/.ai/analysis/2026-06-08-cache-perf-frs/07-cache-dashboards-layout-bootstrap.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/07-cache-dashboards-layout-bootstrap.md
@@ -67,6 +67,7 @@ const cacheTags = [
   'dashboards:layout',
   `dashboards:layout:user:${scope.userId}`,
   scope.organizationId ? `dashboards:layout:org:${scope.organizationId}` : 'dashboards:layout:org:none',
+  `rbac:user:${scope.userId}`, // REUSED: flushed by rbacService on every role/ACL change — closes the cross-module gap for free
 ]
 
 const cached = await runWithCacheTenant(scope.tenantId, () => cache.get(cacheKey))
@@ -99,7 +100,7 @@ All `deleteByTags` calls MUST run **post-commit** (after `await em.flush()` / `e
 | `PATCH /api/dashboards/layout/[itemId]` (`api/layout/[itemId]/route.ts`, after `await em.flush()` at line 78) | end of `PATCH`, post-flush | `dashboards:layout:user:${scope.userId}` |
 | `PUT /api/dashboards/users/widgets` (`api/users/widgets/route.ts` `PUT`, after each `flush`/`remove(...).flush()` at lines 132/149) | post-flush; use the **target** `parsed.data.userId` (admin edits another user) | `dashboards:layout:user:${parsed.data.userId}` |
 | `PUT /api/dashboards/roles/widgets` (`api/roles/widgets/route.ts` `PUT`, after `flush`/`remove(...).flush()` at lines 131/147) | post-flush; role change affects all members in scope | `dashboards:layout:org:${organizationId ?? 'none'}` **and** `dashboards:layout` (role membership per user is not known here, so fall back to the org-wide + coarse tags) |
-| Role-membership / ACL feature change (cross-module: `auth` UserRole / RBAC grants) | Not directly hooked in v1 — rely on the **15 min TTL backstop**. Optionally, follow-up: emit/handle an `auth.user_role.changed`-style event and call `deleteByTags(['dashboards:layout:user:${userId}'])` in a dashboards subscriber once such an event id exists. | `dashboards:layout:user:${userId}` (future) |
+| Role-membership / ACL feature change (cross-module: `auth` UserRole / RBAC grants) | **Already flushed** — the cached entry carries the existing `rbac:user:${userId}` tag, which `auth/services/rbacService.ts` flushes on every user/role ACL write (`deleteCacheByTags` covers the current, global, and hinted tenant namespaces, `rbacService.ts:167-187`). No new wiring; no subscriber needed. | `rbac:user:${userId}` (existing) |
 
 Rationale for the role-widget writer using the coarse + org tags: `DashboardRoleWidgets` changes affect every user holding that role, and the writer does not enumerate members. Invalidating `dashboards:layout:org:${organizationId}` (members share the org scope) plus the coarse `dashboards:layout` tag guarantees correctness; the blast radius is acceptable because role-widget edits are rare admin actions.
 
@@ -115,7 +116,8 @@ Rationale for the role-widget writer using the coarse + org tags: `DashboardRole
 ## Risks & staleness window
 
 - **Self-heal skipped on hit (acceptable):** because invalidation fires whenever an input that the heal depends on changes (layout, user-override, role-widget assignment), a cache hit only occurs when the healed output is still valid. The first request after any change is a miss and re-runs the heal/persist.
-- **Cross-module convergence window:** role-membership / ACL grant changes are not directly hooked in v1, so a user could briefly (up to the 15 min TTL) see widgets per their previous role set. Risk is low: widget *visibility* is cosmetic, not a security boundary — actual widget data endpoints (`api/widgets/data/route.ts`) re-check ACL independently, so a stale `allowedWidgetIds` cannot expose data the user is not entitled to. The follow-up event hook closes the window entirely when available.
+- **Cross-module convergence window (double-checked):** role/ACL changes flush the reused `rbac:user:${userId}` tag immediately, so the previous-role widget set disappears on the next load — no 15-min wait. Residual edge: a superadmin editing a user's ACL from *another tenant's* request context flushes in the actor's + global namespaces, which may miss the target tenant's namespace; bounded by the 15 min TTL. Either way widget *visibility* is cosmetic, not a security boundary — widget data endpoints (`api/widgets/data/route.ts`) re-check ACL independently, so a stale `allowedWidgetIds` can never expose data the user is not entitled to.
+- **Module-local writes need inline flushes (unavoidable, but small):** the dashboards module has no commands and no events, so its four write routes cannot piggyback on command-bus tags — the four post-flush `deleteByTags` calls in the table above are the minimal possible wiring, kept in one shared `lib/cacheKeys.ts` helper. These run inside the mutating request, so the tenant namespace matches the GET-side entries automatically.
 - **Not financial/stock/auth data** — short staleness is tolerable per the cache-safety contract (`packages/cache/AGENTS.md` → Consistency vs commit timing).
 - Invalidation is best-effort; TTL guarantees eventual convergence.
 

--- a/.ai/analysis/2026-06-08-cache-perf-frs/08-catalog-offers-decoration-cache.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/08-catalog-offers-decoration-cache.md
@@ -1,0 +1,138 @@
+> Auto-generated cache-performance Feature Request — candidate 8 of 9
+> Endpoint: `GET /api/catalog/offers` · ROI 72 · Verdict: good
+> Source: `packages/core/src/modules/catalog/api/offers/route.ts`
+
+## Summary
+
+`GET /api/catalog/offers` is built with `makeCrudRoute`, but its expensive work lives in the `afterList` hook (`decorateOffersWithDetails`, `packages/core/src/modules/catalog/api/offers/route.ts:84-337`), which fires **8+ queries per page** (products fetch, two `findWithDecryption` price queries with `priceKind` populate, default-variant fetch, plus fallback-price priority scoring).
+
+The generic CRUD list cache (`ENABLE_CRUD_API_CACHE`, gated off by default) caches only the **base list payload** built by the query engine — and re-runs `afterList` on **both** the cache-hit and cache-miss paths (`packages/shared/src/lib/crud/factory.ts:1556`). So even with the env flag enabled, the costly product/price decoration runs on **every** request. The base-list cache alone does not remove the hot cost here.
+
+This FR proposes a **dedicated decoration cache** inside `decorateOffersWithDetails` (manual get-then-set, tenant-scoped) so the product/price/fallback-price computation is reused across requests, with explicit cross-entity tag invalidation (offers, prices, products) since price writes go through a *different* route that does not invalidate any offer cache today.
+
+## Why (impact)
+
+- **Hotness — high.** The offers list backs channel/offer admin lists, sales-channel context switching, and offer pickers in channel-scoped workflows. High read:write ratio (browse-heavy; offers and their prices change far less often than they are listed).
+- **Cost — high.** `decorateOffersWithDetails` runs `Promise.all` of three queries (`packages/core/src/modules/catalog/api/offers/route.ts:111-137`) then a second `findWithDecryption` for fallback prices with `priceKind` populate (`route.ts:238-260`), followed by the `assignFallbackPrice` channel/variant priority scoring (`route.ts:210-319`). Two of these are decryption-aware price queries (SKU/price fields encrypted at rest), which are the most expensive in the set.
+- **Est. win.** On warm cache, the decoration queries collapse from 8+ DB round-trips (2 of them decryption-aware) to a single cache `get` per page. For a page of 50 offers this removes the per-request product+price fan-out — the dominant latency in this handler.
+
+## Current behavior
+
+- `route.ts:339-435` — `makeCrudRoute` config. List query runs through the query engine; the per-item shape is produced by `transformItem` (`route.ts:373-392`).
+- `route.ts:428-434` — `hooks.afterList` calls `decorateOffersWithDetails(items, ctx)` for every non-empty page.
+- `route.ts:84-337` — `decorateOffersWithDetails`:
+  - Collects `offerIds` and `productIds` from the page (`route.ts:89-94`).
+  - `Promise.all` of: products fetch (`route.ts:113-120`), offer prices via `findWithDecryption` with `populate: ['priceKind']` (`route.ts:121-129`), default variants (`route.ts:130-136`).
+  - A second `findWithDecryption` for offer-less fallback prices filtered by channel set (`route.ts:238-260`).
+  - Builds `productMap`, `priceMap`, `productChannelPriceMap` with priority scoring (`route.ts:210-223`), then writes `item.product`, `item.prices`, `item.productChannelPrice`, `item.productDefaultPrices` (`route.ts:320-336`).
+- Factory cache interaction (`packages/shared/src/lib/crud/factory.ts:1521-1588`): on a cache **hit** the stored base payload is cloned and `afterList` is invoked again (`factory.ts:1556`) — confirming the decoration is **not** covered by the base list cache.
+
+**makeCrudRoute write invalidation already wired** for the offer entity itself: `factory.ts:2266` (created), `factory.ts:2597` (updated), `factory.ts:2882` (deleted) call `invalidateCrudCache(ctx.container, resourceKind, …)` with `resourceKind = catalog.offer`. The **gap**: prices are written by a separate route/command (`catalog.product_price`, `packages/core/src/modules/catalog/commands/prices.ts:409`) using `emitCrudSideEffects` with `entityId: E.catalog.catalog_product_price` — that path invalidates the `catalog.price` resource, **never** `catalog.offer`. So a price edit changes the decorated `productChannelPrice`/`productDefaultPrices` output but invalidates nothing on the offers side.
+
+## Proposed cache
+
+Cache the **decoration result keyed by the exact inputs that produce it**: the set of offer ids + product ids + channel ids on the page. Do the get-then-set inside `decorateOffersWithDetails`, tenant-scoped via `runWithCacheTenant`. There is no `getOrSet` — do manual get → compute → set, mirroring `packages/core/src/modules/customer_accounts/services/domainMappingService.ts`.
+
+```typescript
+// inside decorateOffersWithDetails, after computing offerIds/productIds/channel ids
+import { runWithCacheTenant, type CacheStrategy } from '@open-mercato/cache'
+import { createHash } from 'node:crypto'
+
+const cache = (() => {
+  try { return ctx.container.resolve('cache') as CacheStrategy } catch { return null }
+})()
+
+// Deterministic key fragment from the inputs the decoration depends on.
+const sortedOfferIds = [...offerIds].sort()
+const sortedProductIds = [...productIds].sort()
+const channelKeyIds = Array.from(new Set(
+  items.map((i) => (typeof i?.channelId === 'string' ? i.channelId
+    : typeof i?.channel_id === 'string' ? i.channel_id : null))
+)).filter((v): v is string => !!v).sort()
+const orgKey = scopeOrgIds.length ? [...scopeOrgIds].sort().join(',') : 'null'
+const inputHash = createHash('sha1')
+  .update(JSON.stringify({ orgKey, sortedOfferIds, sortedProductIds, channelKeyIds }))
+  .digest('hex')
+const cacheKey = `catalog:offers:decoration:${inputHash}`
+
+// Tags: offer-collection + per-product + per-price-channel surfaces.
+const tags = [
+  `catalog:offers:decoration:tenant:${scopeTenantId}`,
+  ...sortedProductIds.map((pid) => `catalog:product:tenant:${scopeTenantId}:record:${pid}`),
+  ...sortedOfferIds.map((oid) => `catalog:offer:tenant:${scopeTenantId}:record:${oid}`),
+]
+
+if (cache) {
+  const cached = await runWithCacheTenant(scopeTenantId, () => cache.get(cacheKey)) as
+    | { productMapEntries: [string, unknown][]; perOffer: Record<string, unknown> }
+    | undefined
+  if (cached) {
+    // apply cached decoration to items, then return early
+    applyCachedDecoration(items, cached)
+    return
+  }
+}
+
+// ... existing compute path (the three Promise.all queries + fallback query + scoring) ...
+
+if (cache) {
+  const snapshot = buildDecorationSnapshot(items) // product/prices/productChannelPrice/productDefaultPrices per id
+  await runWithCacheTenant(scopeTenantId, () =>
+    cache.set(cacheKey, snapshot, { ttl: 300, tags })
+  )
+}
+```
+
+Tenant scoping: `runWithCacheTenant(scopeTenantId, …)` hashes + namespaces keys and tags per tenant — `scopeTenantId` is already required and asserted at `route.ts:97-100`. This is mandatory because SKU/price fields are encryption-at-rest and must never cross tenants.
+
+TTL: **300s (5 min)** as a backstop. Justification: offers and prices are browse-mostly; promotional offer prices update on the order of hours; a 5-minute convergence window on a *browse list* is acceptable and matches the read-mostly profile. Tag invalidation (below) handles correctness on real writes; TTL only bounds drift from writes we did not tag.
+
+## Cache tags
+
+Literal tag strings (before tenant-namespacing applied internally by `runWithCacheTenant`):
+
+- `catalog:offers:decoration:tenant:<tenantId>` — the whole decorated-offers surface for the tenant. Invalidate on any offer create/update/delete and any price create/update/delete in the tenant (coarse backstop).
+- `catalog:offer:tenant:<tenantId>:record:<offerId>` — one decorated offer row. Invalidate when that offer is created/updated/deleted.
+- `catalog:product:tenant:<tenantId>:record:<productId>` — product-derived fields (`item.product`, and product-scoped fallback prices). Invalidate when the product or any of its prices/variants change.
+
+## Invalidation
+
+| Trigger (route/command/event) | Where to call `deleteByTags` | Tags invalidated |
+|---|---|---|
+| Offer create/update/delete via `crud.POST/PUT/DELETE` (`packages/core/src/modules/catalog/api/offers/route.ts:437-440`) — already calls `invalidateCrudCache` at `factory.ts:2266/2597/2882` | Add a post-commit `deleteByTags` in the offer commands `execute`/`undo` AFTER `em.flush()` (e.g. `packages/core/src/modules/catalog/commands/offers.ts:174` create, and the update/delete equivalents), OR subscribe to `catalog.offer.created/updated/deleted` | `catalog:offers:decoration:tenant:<tenantId>`, `catalog:offer:tenant:<tenantId>:record:<offerId>` |
+| Price create/update/delete (`packages/core/src/modules/catalog/commands/prices.ts:409/710/855`, `emitCrudSideEffects` with `entityId: catalog_product_price`) — **today invalidates only `catalog.price`, never offers** | Add post-commit `deleteByTags` keyed by the price's `productId`/channel (after the `emitCrudSideEffects` call, post-commit), OR add a subscriber on `catalog.price.created/updated/deleted` | `catalog:offers:decoration:tenant:<tenantId>`, `catalog:product:tenant:<tenantId>:record:<productId>` |
+| Product update (title/media/sku) via `catalog.products.update` (`packages/core/src/modules/catalog/commands/products.ts:275`) | Subscriber on `catalog.product.updated` calling `deleteByTags` | `catalog:product:tenant:<tenantId>:record:<productId>` |
+| Default-variant change via `catalog.variants.*` (`packages/core/src/modules/catalog/commands/variants.ts`) — affects fallback price routing through `variantToProductMap` (`route.ts:194-206`) | Subscriber on `catalog.variant.updated/created/deleted` calling `deleteByTags` on the owning product | `catalog:product:tenant:<tenantId>:record:<productId>`, `catalog:offers:decoration:tenant:<tenantId>` |
+
+Preferred wiring: a single ephemeral subscriber (`persistent: false`) in `packages/core/src/modules/catalog/subscribers/` listening to `catalog.offer.*`, `catalog.price.*`, `catalog.product.updated`, and `catalog.variant.*`, resolving `cache` from DI and calling `runWithCacheTenant(tenantId, () => cache.deleteByTags(tags))` post-commit. This keeps invalidation out of the hot read path and centralizes the cross-entity mapping (price → product, variant → product). All invalidation must fire AFTER the domain write commits — never inside `withAtomicFlush`.
+
+## Implementation steps
+
+- [ ] In `decorateOffersWithDetails` (`route.ts:84`), resolve `cache` defensively from `ctx.container` (tolerate absence — return to plain compute).
+- [ ] Build the deterministic `cacheKey` from sorted `offerIds` + `productIds` + page channel ids + org scope; build the `tags` array (decoration-tenant + per-offer + per-product).
+- [ ] Gate the whole thing behind a feature flag env (e.g. `ENABLE_CATALOG_OFFERS_DECORATION_CACHE`, default off) so it can ship dark and be enabled per environment, consistent with `ENABLE_CRUD_API_CACHE`.
+- [ ] On cache hit, apply the stored per-id decoration to `items` and return early (skip the queries).
+- [ ] On miss, run the existing compute path, then `cache.set(key, snapshot, { ttl: 300, tags })` inside `runWithCacheTenant`.
+- [ ] Add a `catalog/subscribers/offers-decoration-cache-invalidate.ts` ephemeral subscriber mapping `catalog.offer.*`, `catalog.price.*`, `catalog.product.updated`, `catalog.variant.*` to `deleteByTags` (price/variant → resolve owning `productId`). Run `yarn generate` after adding it.
+- [ ] Verify the price command already emits `catalog.price.*` events the subscriber can hook (check `priceCrudEvents` in `commands/prices.ts`); if a needed event id is missing, add it to `catalog/events.ts` and `yarn generate`.
+- [ ] Add unit tests for key/tag derivation and the hit/miss branch; add an integration test under `packages/core/src/modules/catalog/__integration__/` covering: list → edit a price → list again returns updated `productChannelPrice` (proves cross-entity invalidation), and offer update → list reflects change.
+
+## Risks & staleness window
+
+- **Staleness window:** up to the 5-min TTL only for writes not covered by a tag (defense-in-depth). All real offer/price/product/variant writes invalidate immediately via the subscriber, so the practical window is the brief convergence between post-commit invalidation and the next read.
+- **Not financial-exact:** this caches a *browse* projection (`productChannelPrice`, `productDefaultPrices`). It is never the source of truth for checkout pricing — checkout uses `selectBestPrice`/`catalogPricingService` (`packages/core/src/modules/catalog/AGENTS.md`), which is unaffected. So a short browse-list staleness window carries no money-correctness risk.
+- **Encryption / tenant isolation:** SKU and price fields are encrypted at rest; `runWithCacheTenant(scopeTenantId, …)` namespaces keys+tags per tenant and the key includes org scope — no cross-tenant or cross-org read. `scopeTenantId` is already asserted non-null (`route.ts:97-100`).
+- **Cross-entity invalidation completeness is the main risk.** The price/variant→product mapping in the subscriber must be correct or a price edit could leave a stale decorated row until TTL. Mitigated by the coarse `catalog:offers:decoration:tenant:<tenantId>` tag on every price/variant write and bounded by TTL.
+
+## Acceptance criteria / tests
+
+- [ ] With the flag on, a second identical `GET /api/catalog/offers` for the same page performs zero decoration DB queries (verify via `OM_PROFILE=catalog.*` / `[crud:profile]` showing no product/price fan-out on the warm path).
+- [ ] Editing a price for a product on the page (`catalog.product_price` write) invalidates and the next list returns the updated `productChannelPrice`/`productDefaultPrices` within one request (integration test).
+- [ ] Updating/deleting an offer invalidates its decorated row immediately (integration test).
+- [ ] Two tenants listing offers never read each other's decoration entry (key/tag tenant-isolation unit test).
+- [ ] With the flag off, behavior is byte-for-byte identical to today (no cache get/set).
+- [ ] `yarn workspace @open-mercato/core test` and the new catalog integration test pass.
+
+## Labels
+
+`feature`, `performance`, `priority-medium`

--- a/.ai/analysis/2026-06-08-cache-perf-frs/08-catalog-offers-decoration-cache.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/08-catalog-offers-decoration-cache.md
@@ -1,138 +1,40 @@
 > Auto-generated cache-performance Feature Request — candidate 8 of 9
-> Endpoint: `GET /api/catalog/offers` · ROI 72 · Verdict: good
+> Endpoint: `GET /api/catalog/offers` · ROI 72 → re-audited · Verdict: **rescoped — fold into FR 06's `cacheAliases` mechanism; defer the decoration cache**
 > Source: `packages/core/src/modules/catalog/api/offers/route.ts`
+> Revised 2026-06-09: the originally proposed dedicated decoration cache (snapshot store + apply-cached-decoration path + a 4-event-family subscriber + price→product mapping) is exactly the bespoke invalidation complexity this backlog now avoids. v1 keeps only the part that connects to existing infrastructure.
 
-## Summary
+## Summary (revised scope)
 
-`GET /api/catalog/offers` is built with `makeCrudRoute`, but its expensive work lives in the `afterList` hook (`decorateOffersWithDetails`, `packages/core/src/modules/catalog/api/offers/route.ts:84-337`), which fires **8+ queries per page** (products fetch, two `findWithDecryption` price queries with `priceKind` populate, default-variant fetch, plus fallback-price priority scoring).
+`GET /api/catalog/offers` is built with `makeCrudRoute`; its expensive work lives in the `afterList` hook (`decorateOffersWithDetails`, `route.ts:84-337` — 8+ queries per page, two of them decryption-aware price queries).
 
-The generic CRUD list cache (`ENABLE_CRUD_API_CACHE`, gated off by default) caches only the **base list payload** built by the query engine — and re-runs `afterList` on **both** the cache-hit and cache-miss paths (`packages/shared/src/lib/crud/factory.ts:1556`). So even with the env flag enabled, the costly product/price decoration runs on **every** request. The base-list cache alone does not remove the hot cost here.
+The original FR proposed a dedicated decoration cache with its own snapshot format and a new cross-entity invalidation subscriber. **Rescoped v1** does neither. Instead:
 
-This FR proposes a **dedicated decoration cache** inside `decorateOffersWithDetails` (manual get-then-set, tenant-scoped) so the product/price/fallback-price computation is reused across requests, with explicit cross-entity tag invalidation (offers, prices, products) since price writes go through a *different* route that does not invalidate any offer cache today.
+1. **Base-list caching comes from FR 06** — enabling `ENABLE_CRUD_API_CACHE` covers this route's base list payload (query-engine query + custom-field decoration) with zero new code, invalidated by the existing `crud:catalog.offer:*` tags the factory and command bus already flush.
+2. **Cross-resource correctness comes from one metadata line** — add `'catalog.offer'` to the `cacheAliases` of the price commands (and variant commands where they affect offer-channel fallback pricing), exactly the mechanism FR 06 already introduces for `catalog.product`. The command bus (`command-bus.ts:604-617`) then flushes `crud:catalog.offer:tenant:<T>:org:<O>:collection` on every price/variant write — closing the gap where a price edit changes the decorated output but invalidates nothing on the offers side. **This work item is merged into FR 06's implementation table** (see `06-enable-and-fix-catalog-products-list-cache.md`).
+3. **The decoration itself intentionally re-runs on every request** — the factory re-runs `afterList` on cache hits (`factory.ts:1556`) by design, which is also what keeps the embedded prices fresh without bespoke machinery. The remaining per-request cost is the decoration fan-out only (the base query + CF decoration are saved on hits).
 
-## Why (impact)
+## What was deferred, and why
 
-- **Hotness — high.** The offers list backs channel/offer admin lists, sales-channel context switching, and offer pickers in channel-scoped workflows. High read:write ratio (browse-heavy; offers and their prices change far less often than they are listed).
-- **Cost — high.** `decorateOffersWithDetails` runs `Promise.all` of three queries (`packages/core/src/modules/catalog/api/offers/route.ts:111-137`) then a second `findWithDecryption` for fallback prices with `priceKind` populate (`route.ts:238-260`), followed by the `assignFallbackPrice` channel/variant priority scoring (`route.ts:210-319`). Two of these are decryption-aware price queries (SKU/price fields encrypted at rest), which are the most expensive in the set.
-- **Est. win.** On warm cache, the decoration queries collapse from 8+ DB round-trips (2 of them decryption-aware) to a single cache `get` per page. For a page of 50 offers this removes the per-request product+price fan-out — the dominant latency in this handler.
+The dedicated decoration cache would additionally save the ~8-query decoration fan-out on warm pages. It required:
+- a snapshot/apply format for per-offer decoration output,
+- per-offer + per-product record tags maintained by hand,
+- a new ephemeral subscriber over `catalog.offer.*`, `catalog.price.*`, `catalog.product.updated`, `catalog.variant.*`,
+- a price→product and variant→product mapping inside that subscriber to target the right tags.
 
-## Current behavior
+That is four new failure surfaces for one endpoint, duplicating freshness machinery the command bus already provides at the list level. Per the revised invalidation doctrine (README → "Invalidation doctrine"), this is deferred until profiling of the post-FR-06 state shows the decoration fan-out is still a top cost. The original full design is preserved in git history (PR #2905, commit `3616b2071`) and can be revived as a follow-up FR with that evidence.
 
-- `route.ts:339-435` — `makeCrudRoute` config. List query runs through the query engine; the per-item shape is produced by `transformItem` (`route.ts:373-392`).
-- `route.ts:428-434` — `hooks.afterList` calls `decorateOffersWithDetails(items, ctx)` for every non-empty page.
-- `route.ts:84-337` — `decorateOffersWithDetails`:
-  - Collects `offerIds` and `productIds` from the page (`route.ts:89-94`).
-  - `Promise.all` of: products fetch (`route.ts:113-120`), offer prices via `findWithDecryption` with `populate: ['priceKind']` (`route.ts:121-129`), default variants (`route.ts:130-136`).
-  - A second `findWithDecryption` for offer-less fallback prices filtered by channel set (`route.ts:238-260`).
-  - Builds `productMap`, `priceMap`, `productChannelPriceMap` with priority scoring (`route.ts:210-223`), then writes `item.product`, `item.prices`, `item.productChannelPrice`, `item.productDefaultPrices` (`route.ts:320-336`).
-- Factory cache interaction (`packages/shared/src/lib/crud/factory.ts:1521-1588`): on a cache **hit** the stored base payload is cloned and `afterList` is invoked again (`factory.ts:1556`) — confirming the decoration is **not** covered by the base list cache.
+## Remaining work in this FR (small)
 
-**makeCrudRoute write invalidation already wired** for the offer entity itself: `factory.ts:2266` (created), `factory.ts:2597` (updated), `factory.ts:2882` (deleted) call `invalidateCrudCache(ctx.container, resourceKind, …)` with `resourceKind = catalog.offer`. The **gap**: prices are written by a separate route/command (`catalog.product_price`, `packages/core/src/modules/catalog/commands/prices.ts:409`) using `emitCrudSideEffects` with `entityId: E.catalog.catalog_product_price` — that path invalidates the `catalog.price` resource, **never** `catalog.offer`. So a price edit changes the decorated `productChannelPrice`/`productDefaultPrices` output but invalidates nothing on the offers side.
+- [ ] (With FR 06) Add `'catalog.offer'` to `context.cacheAliases` on price commands (`commands/prices.ts:432/734/874`) and variant commands where variant changes affect offer fallback pricing.
+- [ ] Integration test under `packages/core/src/modules/catalog/__integration__/`: with `ENABLE_CRUD_API_CACHE=on`, list offers (warm the cache) → edit a price for a listed product → next `GET /api/catalog/offers` is a cache **miss** and returns updated `productChannelPrice`/`productDefaultPrices` (proves the alias flush). This test FAILS before the alias is added.
+- [ ] Verify offer create/update/delete already invalidates correctly via the factory path (`factory.ts:2266/2597/2882`, resourceKind `catalog.offer`) — expected no-op, assert in the same test.
 
-## Proposed cache
+## Safety / non-invalidation risks (double-checked)
 
-Cache the **decoration result keyed by the exact inputs that produce it**: the set of offer ids + product ids + channel ids on the page. Do the get-then-set inside `decorateOffersWithDetails`, tenant-scoped via `runWithCacheTenant`. There is no `getOrSet` — do manual get → compute → set, mirroring `packages/core/src/modules/customer_accounts/services/domainMappingService.ts`.
-
-```typescript
-// inside decorateOffersWithDetails, after computing offerIds/productIds/channel ids
-import { runWithCacheTenant, type CacheStrategy } from '@open-mercato/cache'
-import { createHash } from 'node:crypto'
-
-const cache = (() => {
-  try { return ctx.container.resolve('cache') as CacheStrategy } catch { return null }
-})()
-
-// Deterministic key fragment from the inputs the decoration depends on.
-const sortedOfferIds = [...offerIds].sort()
-const sortedProductIds = [...productIds].sort()
-const channelKeyIds = Array.from(new Set(
-  items.map((i) => (typeof i?.channelId === 'string' ? i.channelId
-    : typeof i?.channel_id === 'string' ? i.channel_id : null))
-)).filter((v): v is string => !!v).sort()
-const orgKey = scopeOrgIds.length ? [...scopeOrgIds].sort().join(',') : 'null'
-const inputHash = createHash('sha1')
-  .update(JSON.stringify({ orgKey, sortedOfferIds, sortedProductIds, channelKeyIds }))
-  .digest('hex')
-const cacheKey = `catalog:offers:decoration:${inputHash}`
-
-// Tags: offer-collection + per-product + per-price-channel surfaces.
-const tags = [
-  `catalog:offers:decoration:tenant:${scopeTenantId}`,
-  ...sortedProductIds.map((pid) => `catalog:product:tenant:${scopeTenantId}:record:${pid}`),
-  ...sortedOfferIds.map((oid) => `catalog:offer:tenant:${scopeTenantId}:record:${oid}`),
-]
-
-if (cache) {
-  const cached = await runWithCacheTenant(scopeTenantId, () => cache.get(cacheKey)) as
-    | { productMapEntries: [string, unknown][]; perOffer: Record<string, unknown> }
-    | undefined
-  if (cached) {
-    // apply cached decoration to items, then return early
-    applyCachedDecoration(items, cached)
-    return
-  }
-}
-
-// ... existing compute path (the three Promise.all queries + fallback query + scoring) ...
-
-if (cache) {
-  const snapshot = buildDecorationSnapshot(items) // product/prices/productChannelPrice/productDefaultPrices per id
-  await runWithCacheTenant(scopeTenantId, () =>
-    cache.set(cacheKey, snapshot, { ttl: 300, tags })
-  )
-}
-```
-
-Tenant scoping: `runWithCacheTenant(scopeTenantId, …)` hashes + namespaces keys and tags per tenant — `scopeTenantId` is already required and asserted at `route.ts:97-100`. This is mandatory because SKU/price fields are encryption-at-rest and must never cross tenants.
-
-TTL: **300s (5 min)** as a backstop. Justification: offers and prices are browse-mostly; promotional offer prices update on the order of hours; a 5-minute convergence window on a *browse list* is acceptable and matches the read-mostly profile. Tag invalidation (below) handles correctness on real writes; TTL only bounds drift from writes we did not tag.
-
-## Cache tags
-
-Literal tag strings (before tenant-namespacing applied internally by `runWithCacheTenant`):
-
-- `catalog:offers:decoration:tenant:<tenantId>` — the whole decorated-offers surface for the tenant. Invalidate on any offer create/update/delete and any price create/update/delete in the tenant (coarse backstop).
-- `catalog:offer:tenant:<tenantId>:record:<offerId>` — one decorated offer row. Invalidate when that offer is created/updated/deleted.
-- `catalog:product:tenant:<tenantId>:record:<productId>` — product-derived fields (`item.product`, and product-scoped fallback prices). Invalidate when the product or any of its prices/variants change.
-
-## Invalidation
-
-| Trigger (route/command/event) | Where to call `deleteByTags` | Tags invalidated |
-|---|---|---|
-| Offer create/update/delete via `crud.POST/PUT/DELETE` (`packages/core/src/modules/catalog/api/offers/route.ts:437-440`) — already calls `invalidateCrudCache` at `factory.ts:2266/2597/2882` | Add a post-commit `deleteByTags` in the offer commands `execute`/`undo` AFTER `em.flush()` (e.g. `packages/core/src/modules/catalog/commands/offers.ts:174` create, and the update/delete equivalents), OR subscribe to `catalog.offer.created/updated/deleted` | `catalog:offers:decoration:tenant:<tenantId>`, `catalog:offer:tenant:<tenantId>:record:<offerId>` |
-| Price create/update/delete (`packages/core/src/modules/catalog/commands/prices.ts:409/710/855`, `emitCrudSideEffects` with `entityId: catalog_product_price`) — **today invalidates only `catalog.price`, never offers** | Add post-commit `deleteByTags` keyed by the price's `productId`/channel (after the `emitCrudSideEffects` call, post-commit), OR add a subscriber on `catalog.price.created/updated/deleted` | `catalog:offers:decoration:tenant:<tenantId>`, `catalog:product:tenant:<tenantId>:record:<productId>` |
-| Product update (title/media/sku) via `catalog.products.update` (`packages/core/src/modules/catalog/commands/products.ts:275`) | Subscriber on `catalog.product.updated` calling `deleteByTags` | `catalog:product:tenant:<tenantId>:record:<productId>` |
-| Default-variant change via `catalog.variants.*` (`packages/core/src/modules/catalog/commands/variants.ts`) — affects fallback price routing through `variantToProductMap` (`route.ts:194-206`) | Subscriber on `catalog.variant.updated/created/deleted` calling `deleteByTags` on the owning product | `catalog:product:tenant:<tenantId>:record:<productId>`, `catalog:offers:decoration:tenant:<tenantId>` |
-
-Preferred wiring: a single ephemeral subscriber (`persistent: false`) in `packages/core/src/modules/catalog/subscribers/` listening to `catalog.offer.*`, `catalog.price.*`, `catalog.product.updated`, and `catalog.variant.*`, resolving `cache` from DI and calling `runWithCacheTenant(tenantId, () => cache.deleteByTags(tags))` post-commit. This keeps invalidation out of the hot read path and centralizes the cross-entity mapping (price → product, variant → product). All invalidation must fire AFTER the domain write commits — never inside `withAtomicFlush`.
-
-## Implementation steps
-
-- [ ] In `decorateOffersWithDetails` (`route.ts:84`), resolve `cache` defensively from `ctx.container` (tolerate absence — return to plain compute).
-- [ ] Build the deterministic `cacheKey` from sorted `offerIds` + `productIds` + page channel ids + org scope; build the `tags` array (decoration-tenant + per-offer + per-product).
-- [ ] Gate the whole thing behind a feature flag env (e.g. `ENABLE_CATALOG_OFFERS_DECORATION_CACHE`, default off) so it can ship dark and be enabled per environment, consistent with `ENABLE_CRUD_API_CACHE`.
-- [ ] On cache hit, apply the stored per-id decoration to `items` and return early (skip the queries).
-- [ ] On miss, run the existing compute path, then `cache.set(key, snapshot, { ttl: 300, tags })` inside `runWithCacheTenant`.
-- [ ] Add a `catalog/subscribers/offers-decoration-cache-invalidate.ts` ephemeral subscriber mapping `catalog.offer.*`, `catalog.price.*`, `catalog.product.updated`, `catalog.variant.*` to `deleteByTags` (price/variant → resolve owning `productId`). Run `yarn generate` after adding it.
-- [ ] Verify the price command already emits `catalog.price.*` events the subscriber can hook (check `priceCrudEvents` in `commands/prices.ts`); if a needed event id is missing, add it to `catalog/events.ts` and `yarn generate`.
-- [ ] Add unit tests for key/tag derivation and the hit/miss branch; add an integration test under `packages/core/src/modules/catalog/__integration__/` covering: list → edit a price → list again returns updated `productChannelPrice` (proves cross-entity invalidation), and offer update → list reflects change.
-
-## Risks & staleness window
-
-- **Staleness window:** up to the 5-min TTL only for writes not covered by a tag (defense-in-depth). All real offer/price/product/variant writes invalidate immediately via the subscriber, so the practical window is the brief convergence between post-commit invalidation and the next read.
-- **Not financial-exact:** this caches a *browse* projection (`productChannelPrice`, `productDefaultPrices`). It is never the source of truth for checkout pricing — checkout uses `selectBestPrice`/`catalogPricingService` (`packages/core/src/modules/catalog/AGENTS.md`), which is unaffected. So a short browse-list staleness window carries no money-correctness risk.
-- **Encryption / tenant isolation:** SKU and price fields are encrypted at rest; `runWithCacheTenant(scopeTenantId, …)` namespaces keys+tags per tenant and the key includes org scope — no cross-tenant or cross-org read. `scopeTenantId` is already asserted non-null (`route.ts:97-100`).
-- **Cross-entity invalidation completeness is the main risk.** The price/variant→product mapping in the subscriber must be correct or a price edit could leave a stale decorated row until TTL. Mitigated by the coarse `catalog:offers:decoration:tenant:<tenantId>` tag on every price/variant write and bounded by TTL.
-
-## Acceptance criteria / tests
-
-- [ ] With the flag on, a second identical `GET /api/catalog/offers` for the same page performs zero decoration DB queries (verify via `OM_PROFILE=catalog.*` / `[crud:profile]` showing no product/price fan-out on the warm path).
-- [ ] Editing a price for a product on the page (`catalog.product_price` write) invalidates and the next list returns the updated `productChannelPrice`/`productDefaultPrices` within one request (integration test).
-- [ ] Updating/deleting an offer invalidates its decorated row immediately (integration test).
-- [ ] Two tenants listing offers never read each other's decoration entry (key/tag tenant-isolation unit test).
-- [ ] With the flag off, behavior is byte-for-byte identical to today (no cache get/set).
-- [ ] `yarn workspace @open-mercato/core test` and the new catalog integration test pass.
+- **No new staleness surface is introduced by v1**: the base-list cache entry carries the factory's own `crud:catalog.offer:*` tags; price/variant writes flush them via the alias; the decoration re-runs on every request, so decorated prices are always live-computed.
+- **Gate dependency**: everything here is inert until `ENABLE_CRUD_API_CACHE=on` (FR 06 rollout). The alias metadata is harmless when the flag is off (`invalidateCrudCache` no-ops, `cache.ts:180`).
+- **Checkout pricing is unaffected** either way — checkout uses `selectBestPrice`/`catalogPricingService`, never this browse projection.
 
 ## Labels
 
-`feature`, `performance`, `priority-medium`
+`feature`, `performance`, `priority-low` (was priority-medium; the substantive work now ships with FR 06 / #2911)

--- a/.ai/analysis/2026-06-08-cache-perf-frs/09-cache-messages-list-per-user.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/09-cache-messages-list-per-user.md
@@ -1,0 +1,125 @@
+> Auto-generated cache-performance Feature Request — candidate 9 of 9
+> Endpoint: `GET /api/messages` · ROI 58 · Verdict: good
+> Source: `packages/core/src/modules/messages/api/route.ts`
+
+## Summary
+
+Add a manual, tenant-scoped, tag-invalidated cache to the custom `GET /api/messages` list handler (`packages/core/src/modules/messages/api/route.ts`). The handler is NOT a `makeCrudRoute` endpoint, so the generic CRUD list cache (`ENABLE_CRUD_API_CACHE`, `packages/shared/src/lib/crud/factory.ts`) never touches it. It runs 5-6 heavy queries per call (Kysely base + count, `findWithDecryption` on `Message`, `em.find` on `MessageObject`, two Kysely `group by` aggregations, and `findWithDecryption` on `User` for sender metadata with per-message decryption). Caching the assembled response per `(user, folder, filter-signature, page)` removes that work for repeat reads (pagination, polling, navigation) within a short TTL window.
+
+This is rated **good**, not a strong-quick-win: the list is **per-user** (folder membership, `recipient_status`, and `read_at` all derive from `scope.userId` via the `message_recipients` join), so cache keys are user-scoped (lower cross-user reuse) and the read-state mutations (`read` / `marked_unread` / `archived`) that change the list are frequent. Reuse comes from a single user re-fetching the same folder/page and from the many filter permutations a single session repeats.
+
+## Why (impact)
+
+- **Hotness**: Loaded on every messages page view, and re-fetched on every pagination, folder switch, and filter change. (Note: the continuously-polled unread badge is a *separate* endpoint, `GET /api/messages/unread-count` — `packages/core/src/modules/messages/api/unread-count/route.ts` — not this list; that endpoint is the better polling-cache candidate and should be a sibling FR.)
+- **Cost**: Per request the handler issues: `buildBaseQuery().count` (route.ts:191-194), `buildBaseQuery()` scope page query (route.ts:197-208), `findWithDecryption(Message, …)` (route.ts:213-221, AES decryption per row), `em.find(MessageObject, …)` (route.ts:228-230), attachment-count `group by` (route.ts:238-246), recipient-count `group by` (route.ts:253-261), and `findWithDecryption(User, …)` for sender metadata (route.ts:269-277). The base query is built and executed twice (count + page).
+- **Est. win**: A cache hit collapses all of the above to a single `cache.get`, eliminating ~6 DB round-trips and the per-row decryption loop. Effective on repeated same-key reads within the TTL; sharply reduced by the per-user key space.
+
+## Current behavior
+
+File: `packages/core/src/modules/messages/api/route.ts`
+
+- `GET` resolves scope via `resolveMessageContext(req)` (route.ts:59) → `{ tenantId, organizationId, userId }` from `ctx.auth` (`lib/routeHelpers.ts`).
+- Input parsed by `listMessagesSchema.parse(params)` (route.ts:63): `folder` (`inbox|archived|sent|drafts|all`), `status`, `type`, `visibility`, `sourceEntityType`, `sourceEntityId`, `externalEmail`, `senderId`, `search`, `since`, `hasObjects`, `hasAttachments`, `hasActions`, `page`, `pageSize`.
+- `buildBaseQuery` (route.ts:75-189) joins `message_recipients` against `scope.userId` for folder semantics — **the result set is user-specific**, and `recipient_status` / `read_at` columns (route.ts:201-204, 311, 323) are per-user.
+- Response (route.ts:285-332) returns `{ items, page, pageSize, total, totalPages }`.
+- No `makeCrudRoute`, no existing cache usage anywhere in the module (`grep` for `resolve('cache')` / `deleteByTags` / `runWithCacheTenant` under `packages/core/src/modules/messages` returns nothing).
+
+## Proposed cache
+
+Cache the full JSON response keyed by tenant + user + folder + a deterministic signature of all filter/pagination inputs. Scope every read/write with `runWithCacheTenant(scope.tenantId, …)` so keys/tags are tenant-namespaced and one tenant can never read another's entry.
+
+```ts
+import { runWithCacheTenant } from '@open-mercato/cache'
+
+const MESSAGES_LIST_TAG = 'messages:list'
+const MESSAGES_LIST_TTL_MS = 30_000 // 30s backstop; invalidation is the primary mechanism
+
+// after: const input = listMessagesSchema.parse(params)
+const cache = ctx.container.resolve('cache') as {
+  get(key: string): Promise<unknown>
+  set(key: string, val: unknown, opts?: { ttl?: number; tags?: string[] }): Promise<void>
+  deleteByTags(tags: string[]): Promise<number>
+}
+
+// Deterministic signature: sort keys so param order never changes the key.
+const filterSignature = JSON.stringify(
+  Object.fromEntries(Object.entries(input).sort(([a], [b]) => a.localeCompare(b)))
+)
+const cacheKey = `messages:list:u=${scope.userId}:org=${scope.organizationId ?? 'null'}:f=${input.folder}:${filterSignature}`
+
+const userListTag = `messages:list:user:${scope.userId}`
+
+const response = await runWithCacheTenant(scope.tenantId, async () => {
+  const cached = await cache.get(cacheKey)
+  if (cached) return cached as Record<string, unknown>
+
+  // ... existing query/assembly producing `payload` (items/page/pageSize/total/totalPages) ...
+
+  await cache.set(cacheKey, payload, {
+    ttl: MESSAGES_LIST_TTL_MS,
+    tags: [MESSAGES_LIST_TAG, userListTag],
+  })
+  return payload
+})
+
+return Response.json(response)
+```
+
+Note the existing handler already returns inline via `Response.json({...})` (route.ts:285); refactor that object into a `payload` const so it can be cached and returned on both miss and hit.
+
+## Cache tags
+
+- `messages:list` — coarse tag on every cached list entry across all users in the tenant. Lets a tenant-wide blunt invalidation (rare; safety hatch) flush all message lists.
+- `messages:list:user:<userId>` — per-user tag. Every mutation that changes *this* user's view (a message sent to them, their read/unread/archive state change, a soft-delete affecting their recipient row) invalidates `messages:list:user:<recipientUserId>`. This is the primary invalidation tag and keeps blast radius to the affected user.
+
+(Tenant namespacing is applied automatically by `runWithCacheTenant`, so these literal strings are safe to reuse across tenants.)
+
+## Invalidation
+
+Invalidation must fire **post-commit** (outside `withAtomicFlush`). The cleanest hook is an ephemeral cache-invalidation subscriber (`persistent: false`, per `packages/core/AGENTS.md` → Event Subscribers, which lists cache invalidation as the canonical ephemeral use). All the relevant events are already declared in `packages/core/src/modules/messages/events.ts` with `clientBroadcast: true`. A new subscriber `subscribers/messages-list-cache-invalidate.ts` should resolve `cache` from the container and call `deleteByTags` for the affected user(s). Because the list is per-recipient, the subscriber must invalidate `messages:list:user:<userId>` for **every recipient** of the message (resolve recipient user ids from `message_recipients`), plus the sender for `sent`/`drafts` folders.
+
+| Trigger (route/command/event) | Where to call deleteByTags | Tags invalidated |
+|---|---|---|
+| Compose/send — command `messages.messages.compose` (route.ts:354) emits `messages.message.sent` | subscriber on `messages.message.sent` (post-commit, ephemeral) | `messages:list:user:<senderUserId>` + `messages:list:user:<each recipientUserId>` |
+| Mark read — command `messages.recipients.mark_read` (`api/[id]/read/route.ts:59`) emits `messages.message.read` | subscriber on `messages.message.read` | `messages:list:user:<recipientUserId>` |
+| Mark unread — command `messages.recipients.mark_unread` (`api/[id]/read/route.ts:89`) emits `messages.message.marked_unread` | subscriber on `messages.message.marked_unread` | `messages:list:user:<recipientUserId>` |
+| Archive — `api/[id]/archive` + `api/[id]/conversation/archive` emit `messages.message.archived` / `messages.message.unarchived` | subscriber on `messages.message.archived` / `messages.message.unarchived` | `messages:list:user:<recipientUserId>` |
+| Delete (soft) — emits `messages.message.deleted` | subscriber on `messages.message.deleted` | `messages:list:user:<senderUserId>` + `messages:list:user:<each recipientUserId>` |
+| Action taken — emits `messages.message.action_taken` (changes `hasActions`/`actionTaken` in the row) | subscriber on `messages.message.action_taken` | `messages:list:user:<each recipientUserId>` + `messages:list:user:<senderUserId>` |
+| Sender profile rename (cross-module) — `auth` user update changing `name`/`email` (affects `senderName`/`senderEmail`, route.ts:294-299) | accept short staleness (TTL backstop). Optional: subscriber on the auth user-updated event flushing `messages:list` tenant-wide. Recommend NOT wiring initially — rare event, covered by 30s TTL. | (optional) `messages:list` |
+
+If the per-event payloads do not already carry the full recipient user-id list, the subscriber must look them up from `message_recipients` (where `deleted_at is null`) for the message id — keep that query lean and tenant/org scoped.
+
+## Implementation steps
+
+- [ ] Refactor the inline `Response.json({...})` at `route.ts:285` into a `payload` object so it can be both cached and returned.
+- [ ] In `GET`, after `listMessagesSchema.parse`, resolve `cache` from `ctx.container`, build the deterministic `filterSignature` + `cacheKey`, and wrap the read/compute/set in `runWithCacheTenant(scope.tenantId, …)`. Set `{ ttl: 30_000, tags: ['messages:list', 'messages:list:user:'+scope.userId] }`.
+- [ ] Guard the whole cache behind an env flag (e.g. `ENABLE_MESSAGES_LIST_CACHE`, default off) so it can ship dark and be enabled per-tenant/per-env, mirroring the `ENABLE_CRUD_API_CACHE` gating convention.
+- [ ] Add `subscribers/messages-list-cache-invalidate.ts` with `metadata = { event: 'messages.message.sent', persistent: false, id: 'messages-list-cache-invalidate-sent' }` (one subscriber per event, or a small shared helper invoked from several subscriber files). Resolve recipient user ids from `message_recipients` when not present in the payload; call `runWithCacheTenant(tenantId, () => cache.deleteByTags([...userTags]))`.
+- [ ] Wire subscribers for `messages.message.read`, `messages.message.marked_unread`, `messages.message.archived`, `messages.message.unarchived`, `messages.message.deleted`, `messages.message.action_taken`.
+- [ ] Run `yarn generate` so the new subscribers are discovered.
+- [ ] Confirm invalidation fires post-commit only (subscribers run after the command's domain write — verify none of the emitting commands emit inside `withAtomicFlush`).
+- [ ] Add unit tests: cache miss populates with correct tags; cache hit skips DB; each event subscriber calls `deleteByTags` with the right user tag(s).
+- [ ] Add an integration test (`packages/core/src/modules/messages/__integration__/`): send → list (cached) → mark-read → list reflects new `read_at` (proves invalidation), and verify user A's mutation never invalidates/leaks user B's entry.
+
+## Risks & staleness window
+
+- **Per-user correctness is critical**: the list embeds `recipient_status` and `read_at` for the requesting user. The cache key MUST include `scope.userId`; a key collision across users would leak another user's read-state and folder membership. Tenant namespacing via `runWithCacheTenant` plus the explicit `u=<userId>` key segment prevents this — assert it in tests.
+- **Staleness window**: bounded by the 30s TTL even if a tag invalidation is missed (best-effort). For a message list (non-financial, read-mostly) a sub-30s convergence window is acceptable; a freshly-read message could briefly still show as unread on a stale hit.
+- **Invalidation breadth**: read/unread/archive happen often and each invalidates a user tag — under heavy interaction the hit rate for that user drops, which is why ROI is rated `good` not `strong`. The cache still wins on pagination, folder re-entry, and back-navigation between mutations.
+- **Key fragmentation**: many filter/search permutations create many keys; the per-user `messages:list:user:<id>` tag still flushes all of them together, so correctness holds, but memory footprint per active user can grow — the 30s TTL caps it.
+- **Search results** (`input.search`) depend on the search index (`findMessageIdsBySearchTokens`); caching them is fine within the TTL but they will not reflect a reindex until expiry — acceptable.
+
+## Acceptance criteria / tests
+
+- [ ] With the flag on, two identical `GET /api/messages` calls for the same user/folder/filters issue the DB queries once; the second is served from cache (assert via spy/profiler).
+- [ ] Marking a message read invalidates `messages:list:user:<recipientUserId>` and a subsequent list reflects the new `read_at`/`status` within the same request (no TTL wait).
+- [ ] Sending a message invalidates the sender's and every recipient's `messages:list:user:*` tag.
+- [ ] User A's read/archive/send never invalidates user B's cached list and never exposes A's `read_at` to B.
+- [ ] Cross-tenant isolation: identical keys in two tenants resolve to distinct entries (TTL/tag flush in one tenant does not affect the other).
+- [ ] With the flag off, behavior is byte-identical to today.
+
+## Labels
+
+`feature`, `performance`, `priority-low`
+

--- a/.ai/analysis/2026-06-08-cache-perf-frs/09-cache-messages-list-per-user.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/09-cache-messages-list-per-user.md
@@ -1,125 +1,103 @@
 > Auto-generated cache-performance Feature Request — candidate 9 of 9
 > Endpoint: `GET /api/messages` · ROI 58 · Verdict: good
 > Source: `packages/core/src/modules/messages/api/route.ts`
+> Revised 2026-06-09: invalidation now piggybacks on the **already-flushed** `crud:messages.message:*` tags from the command bus — the previously proposed 7 event subscribers and the per-recipient tag fan-out are dropped.
 
 ## Summary
 
-Add a manual, tenant-scoped, tag-invalidated cache to the custom `GET /api/messages` list handler (`packages/core/src/modules/messages/api/route.ts`). The handler is NOT a `makeCrudRoute` endpoint, so the generic CRUD list cache (`ENABLE_CRUD_API_CACHE`, `packages/shared/src/lib/crud/factory.ts`) never touches it. It runs 5-6 heavy queries per call (Kysely base + count, `findWithDecryption` on `Message`, `em.find` on `MessageObject`, two Kysely `group by` aggregations, and `findWithDecryption` on `User` for sender metadata with per-message decryption). Caching the assembled response per `(user, folder, filter-signature, page)` removes that work for repeat reads (pagination, polling, navigation) within a short TTL window.
+Add a manual, tenant-scoped cache to the custom `GET /api/messages` list handler. The handler is NOT a `makeCrudRoute` endpoint, so the generic CRUD list cache never touches it. It runs 5-6 heavy queries per call (Kysely base + count, `findWithDecryption` on `Message`, `em.find` on `MessageObject`, two Kysely `group by` aggregations, and `findWithDecryption` on `User` for sender metadata).
 
-This is rated **good**, not a strong-quick-win: the list is **per-user** (folder membership, `recipient_status`, and `read_at` all derive from `scope.userId` via the `message_recipients` join), so cache keys are user-scoped (lower cross-user reuse) and the read-state mutations (`read` / `marked_unread` / `archived`) that change the list are frequent. Reuse comes from a single user re-fetching the same folder/page and from the many filter permutations a single session repeats.
+**Key simplification:** every write that changes this list — compose/send, mark read, mark unread, archive/unarchive, delete, action taken — is a **command** with `resourceKind: 'messages.message'` (verified: `commands/messages.ts:444/667/822/974/1088`, `commands/recipients.ts:64`, `commands/actions.ts:144`, `commands/confirmations.ts:135`, `commands/attachments.ts:86/175`, `commands/shared.ts:350`). The command bus already flushes `crud:messages.message:tenant:<T>:org:<O>:collection` + record tags after every execute/undo, post-commit (`command-bus.ts:610/642`). Tag the cached list entries with that collection tag and **all seven previously-proposed subscribers become unnecessary**.
+
+The trade: the existing flush is org-wide, not per-recipient — any message write in the org flushes every user's cached list. At a 30 s TTL on a read-mostly list this coarseness is fine (a flush just means the next read recomputes), and it eliminates the per-recipient tag fan-out, the recipient-lookup query in subscribers, and the risk of missing a recipient.
 
 ## Why (impact)
 
-- **Hotness**: Loaded on every messages page view, and re-fetched on every pagination, folder switch, and filter change. (Note: the continuously-polled unread badge is a *separate* endpoint, `GET /api/messages/unread-count` — `packages/core/src/modules/messages/api/unread-count/route.ts` — not this list; that endpoint is the better polling-cache candidate and should be a sibling FR.)
-- **Cost**: Per request the handler issues: `buildBaseQuery().count` (route.ts:191-194), `buildBaseQuery()` scope page query (route.ts:197-208), `findWithDecryption(Message, …)` (route.ts:213-221, AES decryption per row), `em.find(MessageObject, …)` (route.ts:228-230), attachment-count `group by` (route.ts:238-246), recipient-count `group by` (route.ts:253-261), and `findWithDecryption(User, …)` for sender metadata (route.ts:269-277). The base query is built and executed twice (count + page).
-- **Est. win**: A cache hit collapses all of the above to a single `cache.get`, eliminating ~6 DB round-trips and the per-row decryption loop. Effective on repeated same-key reads within the TTL; sharply reduced by the per-user key space.
+- **Hotness**: loaded on every messages page view, pagination, folder switch, and filter change. (The continuously-polled unread badge is `GET /api/messages/unread-count` — covered by FR 10.)
+- **Cost**: per request: `buildBaseQuery().count` (route.ts:191-194), the page query (route.ts:197-208), `findWithDecryption(Message, …)` (route.ts:213-221, AES per row), `em.find(MessageObject)` (route.ts:228-230), two `group by` aggregations (route.ts:238-261), `findWithDecryption(User, …)` (route.ts:269-277).
+- **Est. win**: a hit collapses ~6 DB round-trips + per-row decryption into one cache `get`, for repeat reads (pagination, folder re-entry, back-navigation) within the window.
 
 ## Current behavior
 
-File: `packages/core/src/modules/messages/api/route.ts`
-
-- `GET` resolves scope via `resolveMessageContext(req)` (route.ts:59) → `{ tenantId, organizationId, userId }` from `ctx.auth` (`lib/routeHelpers.ts`).
-- Input parsed by `listMessagesSchema.parse(params)` (route.ts:63): `folder` (`inbox|archived|sent|drafts|all`), `status`, `type`, `visibility`, `sourceEntityType`, `sourceEntityId`, `externalEmail`, `senderId`, `search`, `since`, `hasObjects`, `hasAttachments`, `hasActions`, `page`, `pageSize`.
-- `buildBaseQuery` (route.ts:75-189) joins `message_recipients` against `scope.userId` for folder semantics — **the result set is user-specific**, and `recipient_status` / `read_at` columns (route.ts:201-204, 311, 323) are per-user.
-- Response (route.ts:285-332) returns `{ items, page, pageSize, total, totalPages }`.
-- No `makeCrudRoute`, no existing cache usage anywhere in the module (`grep` for `resolve('cache')` / `deleteByTags` / `runWithCacheTenant` under `packages/core/src/modules/messages` returns nothing).
+File: `packages/core/src/modules/messages/api/route.ts` — `resolveMessageContext(req)` (route.ts:59), `listMessagesSchema.parse` (route.ts:63), `buildBaseQuery` joins `message_recipients` against `scope.userId` (route.ts:75-189) — **the result set is per-user** (`recipient_status`, `read_at`). Response `{ items, page, pageSize, total, totalPages }` (route.ts:285-332). No cache usage anywhere in the module today.
 
 ## Proposed cache
 
-Cache the full JSON response keyed by tenant + user + folder + a deterministic signature of all filter/pagination inputs. Scope every read/write with `runWithCacheTenant(scope.tenantId, …)` so keys/tags are tenant-namespaced and one tenant can never read another's entry.
+Key = tenant (via dispatcher namespace) + user + org + folder + deterministic filter signature. Gate on `isCrudCacheEnabled()` — the tag this cache relies on is only flushed when `ENABLE_CRUD_API_CACHE` is on (see Safety).
 
 ```ts
-import { runWithCacheTenant } from '@open-mercato/cache'
+import { buildCollectionTags, isCrudCacheEnabled } from '@open-mercato/shared/lib/crud/cache'
 
-const MESSAGES_LIST_TAG = 'messages:list'
-const MESSAGES_LIST_TTL_MS = 30_000 // 30s backstop; invalidation is the primary mechanism
+const MESSAGES_LIST_TTL_MS = 30_000 // backstop; the crud:* flush carries correctness
 
 // after: const input = listMessagesSchema.parse(params)
-const cache = ctx.container.resolve('cache') as {
-  get(key: string): Promise<unknown>
-  set(key: string, val: unknown, opts?: { ttl?: number; tags?: string[] }): Promise<void>
-  deleteByTags(tags: string[]): Promise<number>
-}
+const cacheEnabled = isCrudCacheEnabled()
+const cache = cacheEnabled ? (() => { try { return ctx.container.resolve('cache') } catch { return null } })() : null
+const filterSignature = JSON.stringify(Object.fromEntries(Object.entries(input).sort(([a], [b]) => a.localeCompare(b))))
+const cacheKey = `messages:list:u=${scope.userId}:org=${scope.organizationId ?? 'null'}:${filterSignature}`
 
-// Deterministic signature: sort keys so param order never changes the key.
-const filterSignature = JSON.stringify(
-  Object.fromEntries(Object.entries(input).sort(([a], [b]) => a.localeCompare(b)))
-)
-const cacheKey = `messages:list:u=${scope.userId}:org=${scope.organizationId ?? 'null'}:f=${input.folder}:${filterSignature}`
-
-const userListTag = `messages:list:user:${scope.userId}`
-
-const response = await runWithCacheTenant(scope.tenantId, async () => {
+if (cache) {
   const cached = await cache.get(cacheKey)
-  if (cached) return cached as Record<string, unknown>
-
-  // ... existing query/assembly producing `payload` (items/page/pageSize/total/totalPages) ...
-
-  await cache.set(cacheKey, payload, {
-    ttl: MESSAGES_LIST_TTL_MS,
-    tags: [MESSAGES_LIST_TAG, userListTag],
-  })
-  return payload
-})
-
-return Response.json(response)
+  if (cached) return Response.json(cached)
+}
+// ... existing query/assembly producing `payload` ...
+if (cache) {
+  try {
+    await cache.set(cacheKey, payload, {
+      ttl: MESSAGES_LIST_TTL_MS,
+      tags: buildCollectionTags('messages.message', scope.tenantId, [scope.organizationId ?? null]),
+    })
+  } catch {}
+}
+return Response.json(payload)
 ```
 
-Note the existing handler already returns inline via `Response.json({...})` (route.ts:285); refactor that object into a `payload` const so it can be cached and returned on both miss and hit.
+(The handler runs inside the API dispatcher's `runWithCacheTenant(auth.tenantId, …)` wrapper — same namespace `invalidateCrudCache` flushes into.)
 
 ## Cache tags
 
-- `messages:list` — coarse tag on every cached list entry across all users in the tenant. Lets a tenant-wide blunt invalidation (rare; safety hatch) flush all message lists.
-- `messages:list:user:<userId>` — per-user tag. Every mutation that changes *this* user's view (a message sent to them, their read/unread/archive state change, a soft-delete affecting their recipient row) invalidates `messages:list:user:<recipientUserId>`. This is the primary invalidation tag and keeps blast radius to the affected user.
+- `crud:messages.message:tenant:<T>:org:<O>:collection` — **reused, already flushed** by the command bus after every message command execute/undo. Built with the shared `buildCollectionTags('messages.message', …)` helper so the shape cannot drift.
 
-(Tenant namespacing is applied automatically by `runWithCacheTenant`, so these literal strings are safe to reuse across tenants.)
+No new tags. No subscribers.
 
 ## Invalidation
 
-Invalidation must fire **post-commit** (outside `withAtomicFlush`). The cleanest hook is an ephemeral cache-invalidation subscriber (`persistent: false`, per `packages/core/AGENTS.md` → Event Subscribers, which lists cache invalidation as the canonical ephemeral use). All the relevant events are already declared in `packages/core/src/modules/messages/events.ts` with `clientBroadcast: true`. A new subscriber `subscribers/messages-list-cache-invalidate.ts` should resolve `cache` from the container and call `deleteByTags` for the affected user(s). Because the list is per-recipient, the subscriber must invalidate `messages:list:user:<userId>` for **every recipient** of the message (resolve recipient user ids from `message_recipients`), plus the sender for `sent`/`drafts` folders.
-
-| Trigger (route/command/event) | Where to call deleteByTags | Tags invalidated |
+| Trigger | Where the flush already happens | Tags |
 |---|---|---|
-| Compose/send — command `messages.messages.compose` (route.ts:354) emits `messages.message.sent` | subscriber on `messages.message.sent` (post-commit, ephemeral) | `messages:list:user:<senderUserId>` + `messages:list:user:<each recipientUserId>` |
-| Mark read — command `messages.recipients.mark_read` (`api/[id]/read/route.ts:59`) emits `messages.message.read` | subscriber on `messages.message.read` | `messages:list:user:<recipientUserId>` |
-| Mark unread — command `messages.recipients.mark_unread` (`api/[id]/read/route.ts:89`) emits `messages.message.marked_unread` | subscriber on `messages.message.marked_unread` | `messages:list:user:<recipientUserId>` |
-| Archive — `api/[id]/archive` + `api/[id]/conversation/archive` emit `messages.message.archived` / `messages.message.unarchived` | subscriber on `messages.message.archived` / `messages.message.unarchived` | `messages:list:user:<recipientUserId>` |
-| Delete (soft) — emits `messages.message.deleted` | subscriber on `messages.message.deleted` | `messages:list:user:<senderUserId>` + `messages:list:user:<each recipientUserId>` |
-| Action taken — emits `messages.message.action_taken` (changes `hasActions`/`actionTaken` in the row) | subscriber on `messages.message.action_taken` | `messages:list:user:<each recipientUserId>` + `messages:list:user:<senderUserId>` |
-| Sender profile rename (cross-module) — `auth` user update changing `name`/`email` (affects `senderName`/`senderEmail`, route.ts:294-299) | accept short staleness (TTL backstop). Optional: subscriber on the auth user-updated event flushing `messages:list` tenant-wide. Recommend NOT wiring initially — rare event, covered by 30s TTL. | (optional) `messages:list` |
+| Compose/send (`messages.messages.compose`) | command bus `invalidateCacheAfterExecute` — existing | `crud:messages.message:…:collection` + record |
+| Mark read / unread (`messages.recipients.mark_read` / `mark_unread`, resourceKind `messages.message`) | same — existing | same |
+| Archive / unarchive, delete (soft), action taken, confirmations, attachments | same — existing (all log `resourceKind: 'messages.message'`) | same |
+| Command undo/redo | `invalidateCacheAfterUndo` — existing | same |
+| Sender profile rename (cross-module `auth` user update) | not flushed — affects only `senderName`/`senderEmail` cosmetics | 30 s TTL backstop |
 
-If the per-event payloads do not already carry the full recipient user-id list, the subscriber must look them up from `message_recipients` (where `deleted_at is null`) for the message id — keep that query lean and tenant/org scoped.
+**Nothing to add on the write side.**
+
+## Safety / non-invalidation risks (double-checked)
+
+- **Per-user leakage — the critical one:** the payload embeds the requesting user's `recipient_status`/`read_at` and folder membership. The key MUST include `scope.userId` (it does: `u=<userId>`); the org axis is also in the key. A key collision across users is impossible; assert in tests.
+- **`ENABLE_CRUD_API_CACHE` gate:** the `crud:*` flush no-ops when the flag is off (`cache.ts:180`), so this cache is gated on `isCrudCacheEnabled()` — flag off ⇒ no caching ⇒ today's behavior. Never ship ungated.
+- **Org-axis mismatch:** `null`-org messages are tagged/flushed under `org:null`; org-scoped under `org:<O>`. A command whose metadata resolves a different org than the read scope leaves the entry until TTL (30 s). Message commands carry `organizationId` in their identifiers; residual drift is TTL-bounded.
+- **Coarse flush ⇒ lower hit rate, never staleness:** any org member's message activity flushes all members' lists. That only costs recomputes, never correctness.
+- **`messages.conversation` resourceKind:** conversation-level archive/read routes log `resourceKind 'messages.message'` via the shared command helpers (`commands/shared.ts:350`); verify during implementation that no conversation command logs only `messages.conversation` — if one does, add `cacheAliases: ['messages.message']` to its metadata (one line, same mechanism as FR 06).
+- **Search staleness:** cached search results won't reflect a reindex until expiry — acceptable at 30 s.
+- **Key fragmentation:** many filter permutations per user; the org-collection tag flushes them all and the TTL caps memory.
 
 ## Implementation steps
 
-- [ ] Refactor the inline `Response.json({...})` at `route.ts:285` into a `payload` object so it can be both cached and returned.
-- [ ] In `GET`, after `listMessagesSchema.parse`, resolve `cache` from `ctx.container`, build the deterministic `filterSignature` + `cacheKey`, and wrap the read/compute/set in `runWithCacheTenant(scope.tenantId, …)`. Set `{ ttl: 30_000, tags: ['messages:list', 'messages:list:user:'+scope.userId] }`.
-- [ ] Guard the whole cache behind an env flag (e.g. `ENABLE_MESSAGES_LIST_CACHE`, default off) so it can ship dark and be enabled per-tenant/per-env, mirroring the `ENABLE_CRUD_API_CACHE` gating convention.
-- [ ] Add `subscribers/messages-list-cache-invalidate.ts` with `metadata = { event: 'messages.message.sent', persistent: false, id: 'messages-list-cache-invalidate-sent' }` (one subscriber per event, or a small shared helper invoked from several subscriber files). Resolve recipient user ids from `message_recipients` when not present in the payload; call `runWithCacheTenant(tenantId, () => cache.deleteByTags([...userTags]))`.
-- [ ] Wire subscribers for `messages.message.read`, `messages.message.marked_unread`, `messages.message.archived`, `messages.message.unarchived`, `messages.message.deleted`, `messages.message.action_taken`.
-- [ ] Run `yarn generate` so the new subscribers are discovered.
-- [ ] Confirm invalidation fires post-commit only (subscribers run after the command's domain write — verify none of the emitting commands emit inside `withAtomicFlush`).
-- [ ] Add unit tests: cache miss populates with correct tags; cache hit skips DB; each event subscriber calls `deleteByTags` with the right user tag(s).
-- [ ] Add an integration test (`packages/core/src/modules/messages/__integration__/`): send → list (cached) → mark-read → list reflects new `read_at` (proves invalidation), and verify user A's mutation never invalidates/leaks user B's entry.
-
-## Risks & staleness window
-
-- **Per-user correctness is critical**: the list embeds `recipient_status` and `read_at` for the requesting user. The cache key MUST include `scope.userId`; a key collision across users would leak another user's read-state and folder membership. Tenant namespacing via `runWithCacheTenant` plus the explicit `u=<userId>` key segment prevents this — assert it in tests.
-- **Staleness window**: bounded by the 30s TTL even if a tag invalidation is missed (best-effort). For a message list (non-financial, read-mostly) a sub-30s convergence window is acceptable; a freshly-read message could briefly still show as unread on a stale hit.
-- **Invalidation breadth**: read/unread/archive happen often and each invalidates a user tag — under heavy interaction the hit rate for that user drops, which is why ROI is rated `good` not `strong`. The cache still wins on pagination, folder re-entry, and back-navigation between mutations.
-- **Key fragmentation**: many filter/search permutations create many keys; the per-user `messages:list:user:<id>` tag still flushes all of them together, so correctness holds, but memory footprint per active user can grow — the 30s TTL caps it.
-- **Search results** (`input.search`) depend on the search index (`findMessageIdsBySearchTokens`); caching them is fine within the TTL but they will not reflect a reindex until expiry — acceptable.
+- [ ] Refactor the inline `Response.json({...})` at `route.ts:285` into a `payload` object.
+- [ ] Add the gated get-then-set (sketch above) with `buildCollectionTags('messages.message', scope.tenantId, [scope.organizationId ?? null])`.
+- [ ] Audit conversation-level commands for resourceKind coverage (see Safety); add a `cacheAliases` line if needed.
+- [ ] Unit tests: key includes user+org; tags match the command-bus flush shape; no caching when flag off.
+- [ ] Integration (`packages/core/src/modules/messages/__integration__/`): send → list (cached) → mark-read → list reflects new `read_at` immediately (command-bus flush, not TTL); user A's mutation never leaks user B's entry.
 
 ## Acceptance criteria / tests
 
-- [ ] With the flag on, two identical `GET /api/messages` calls for the same user/folder/filters issue the DB queries once; the second is served from cache (assert via spy/profiler).
-- [ ] Marking a message read invalidates `messages:list:user:<recipientUserId>` and a subsequent list reflects the new `read_at`/`status` within the same request (no TTL wait).
-- [ ] Sending a message invalidates the sender's and every recipient's `messages:list:user:*` tag.
-- [ ] User A's read/archive/send never invalidates user B's cached list and never exposes A's `read_at` to B.
-- [ ] Cross-tenant isolation: identical keys in two tenants resolve to distinct entries (TTL/tag flush in one tenant does not affect the other).
+- [ ] With the flag on, two identical `GET /api/messages` calls issue the DB queries once.
+- [ ] Marking a message read → subsequent list reflects the new `read_at` without waiting for TTL.
+- [ ] Sending a message → all org members' next list reads recompute (coarse flush).
+- [ ] User A never reads user B's cached entry; cross-tenant isolation holds.
 - [ ] With the flag off, behavior is byte-identical to today.
 
 ## Labels
 
 `feature`, `performance`, `priority-low`
-

--- a/.ai/analysis/2026-06-08-cache-perf-frs/10-cache-messages-unread-count.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/10-cache-messages-unread-count.md
@@ -1,0 +1,79 @@
+> Cache-performance Feature Request — round-2 candidate 10
+> Endpoint: `GET /api/messages/unread-count` · Verdict: strong-quick-win
+> Source: `packages/core/src/modules/messages/api/unread-count/route.ts`
+> Added 2026-06-09 (round 2): verified non-cached; invalidation piggybacks on existing `crud:messages.message:*` tags.
+
+## Summary
+
+The messages unread badge is **polled every 5 seconds** by `packages/ui/src/backend/messages/useMessagesPoll.ts` (`POLL_INTERVAL = 5000`) from the app shell. Every tick runs a Kysely `COUNT(*)` joining `message_recipients` × `messages` with 7 filter conditions (`route.ts:20-38`). Cache the count per `(userId, organizationId)` with a 10 s TTL, tagged with the **already-flushed** `crud:messages.message:tenant:<T>:org:<O>:collection` tag so any message command (send, mark read/unread, archive, delete — all log `resourceKind: 'messages.message'`, see FR 09) invalidates it immediately via the command bus. Zero new flush wiring.
+
+## Why (impact)
+
+- **Hotness — extreme.** ~12 requests/min per open session, multiplied by tabs and users, independent of activity.
+- **Cost** — one indexed COUNT per call; cheap individually, dominant in aggregate (same profile as FR 03).
+- **Est. win** — steady-state COUNTs drop ~50%+ from TTL alone; after the tag flush, the badge updates on the next poll tick (≤5 s) following any real message activity.
+
+## Current behavior
+
+`route.ts:15-41` — `resolveMessageContext`, then a single Kysely count: `message_recipients r JOIN messages m` filtered by `r.recipient_user_id = userId`, `r.status='unread'`, `r.deleted_at/archived_at IS NULL`, `m.tenant_id`, `m.organization_id` (or `IS NULL`), `m.deleted_at IS NULL`. **Note: unlike the notifications badge, this count IS org-scoped** — the key must include the org axis. No cache anywhere in the module.
+
+## Proposed cache
+
+```ts
+import { buildCollectionTags, isCrudCacheEnabled } from '@open-mercato/shared/lib/crud/cache'
+
+const UNREAD_TTL_MS = 10_000
+
+const cacheEnabled = isCrudCacheEnabled()
+const cache = cacheEnabled ? (() => { try { return ctx.container.resolve('cache') } catch { return null } })() : null
+const cacheKey = `messages:unread-count:u=${scope.userId}:org=${scope.organizationId ?? 'null'}`
+
+if (cache) {
+  const cached = await cache.get(cacheKey)
+  if (typeof cached === 'number') return Response.json({ unreadCount: cached })
+}
+const count = /* existing Kysely count */
+if (cache) {
+  try {
+    await cache.set(cacheKey, count, {
+      ttl: UNREAD_TTL_MS,
+      tags: buildCollectionTags('messages.message', scope.tenantId, [scope.organizationId ?? null]),
+    })
+  } catch {}
+}
+return Response.json({ unreadCount: count })
+```
+
+Tenant namespace comes from the API dispatcher wrapper (`apps/mercato/src/app/api/[...slug]/route.ts:382`) — the same namespace `invalidateCrudCache` flushes into.
+
+## Cache tags
+
+- `crud:messages.message:tenant:<T>:org:<O>:collection` — **reused**, flushed post-commit by the command bus after every message command execute/undo (`command-bus.ts:610/642`). Built with the shared `buildCollectionTags` helper.
+
+## Invalidation
+
+| Trigger | Where the flush already happens | Tags |
+|---|---|---|
+| Send / mark read / mark unread / archive / delete / action (all `messages.*` commands, resourceKind `messages.message`) | command bus — existing | `crud:messages.message:…:collection` |
+| Undo/redo | command bus — existing | same |
+
+**Nothing to add on the write side.**
+
+## Safety / non-invalidation risks (double-checked)
+
+- **Gate:** the tag flush no-ops while `ENABLE_CRUD_API_CACHE` is off (`cache.ts:180`) — the cache is gated on `isCrudCacheEnabled()`; flag off ⇒ uncached, today's behavior. (Optionally fall back to a tags-free 5 s TTL-only cache when the flag is off — safe because there is then no invalidation to miss.)
+- **Per-user + per-org key** — the count is user- and org-scoped; both axes are in the key. No cross-user/cross-org bleed.
+- **Coarse flush** — any org member's message activity flushes everyone's badge entry; costs one recount on the next poll, never staleness.
+- **Worst-case staleness = 10 s TTL** (e.g. out-of-band write) — equal to two poll ticks; badge-only data.
+- **No-op without cache service.**
+
+## Implementation steps
+
+- [ ] Add the gated get-then-set to `api/unread-count/route.ts` (~15 lines, no new files).
+- [ ] Unit test: key includes user + org; tags match `buildCollectionTags('messages.message', …)`; no caching when flag off.
+- [ ] Integration: send a message to user → badge converges on next read after the command flush (no TTL wait); mark-read converges likewise.
+- [ ] `yarn workspace @open-mercato/core build && test`.
+
+## Labels
+
+`feature`, `performance`, `priority-low`

--- a/.ai/analysis/2026-06-08-cache-perf-frs/11-cache-notifications-list.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/11-cache-notifications-list.md
@@ -1,0 +1,71 @@
+> Cache-performance Feature Request — round-2 candidate 11
+> Endpoint: `GET /api/notifications` (list) · Verdict: good
+> Source: `packages/core/src/modules/notifications/api/route.ts`
+> Added 2026-06-09 (round 2): verified non-cached; **TTL-only v1** (same rationale as FR 03 — notifications have no command-bus writes, so no existing tag to connect to).
+
+## Summary
+
+The notifications dropdown/panel list is fetched by the same 5-second poll loop as the unread badge (`packages/ui/src/backend/notifications/useNotificationsPoll.ts`, `POLL_INTERVAL = 5000`) and on every panel open. Each call runs `em.find(Notification, …)` + `em.count(Notification, …)` (`route.ts:56-63`) filtered by `recipientUserId`/status/type/severity. Cache the assembled page per `(userId, filter-signature)` with a short **TTL-only** cache (10 s) — the same shape and rationale as FR 03: the notifications module has no `commands/` directory, all writes flow through `createNotificationService`, so there is no already-flushed tag to ride and bespoke per-write invalidation across ~10 service sites is not worth ≤10 s of badge-panel freshness. SSE-enabled clients get pushes regardless.
+
+## Why (impact)
+
+- **Hotness — extreme**: same 5 s poll cadence as the badge; the panel list payload is bigger than the count (two queries + row mapping per tick).
+- **Cost** — `em.find` + `em.count` (two round-trips) every 5 s per session.
+- **Est. win** — halves steady-state list queries (10 s TTL vs 5 s poll); more under multi-tab.
+
+## Current behavior
+
+`packages/core/src/modules/notifications/api/route.ts:22-74` — `resolveNotificationContext`, parse filters (status/type/severity/source), then `Promise.all([em.find(Notification, where, { orderBy, limit, offset }), em.count(Notification, where)])`, row mapping, `{ items, total, … }`. Not `makeCrudRoute`; no module cache; writes via `createNotificationService` + eventBus only (no command bus → no `crud:*` flushes exist for notifications).
+
+## Proposed cache
+
+```ts
+const NOTIFICATIONS_LIST_TTL_MS = 10_000
+
+const cache = (() => { try { return ctx.container.resolve('cache') } catch { return null } })()
+const filterSignature = JSON.stringify(Object.fromEntries(Object.entries(parsedQuery).sort(([a], [b]) => a.localeCompare(b))))
+const cacheKey = `notifications:list:u=${scope.userId}:${filterSignature}`
+
+if (cache && scope.userId) {
+  const cached = await cache.get(cacheKey)
+  if (cached) return Response.json(cached)
+}
+// ... existing find + count + mapping → payload ...
+if (cache && scope.userId) {
+  try { await cache.set(cacheKey, payload, { ttl: NOTIFICATIONS_LIST_TTL_MS }) } catch {}
+}
+return Response.json(payload)
+```
+
+Tenant namespace via the API dispatcher wrapper. Match the key's user/org axes to the underlying query's filter dimensions exactly (user + tenant; include org in the key only if the query filters by it).
+
+## Cache tags
+
+None in v1 — TTL-only. (v2, if ever needed: a `notifications:user:<userId>` tag flushed from the single `createNotificationService` chokepoint, post-commit.)
+
+## Invalidation
+
+| Trigger | Where | Effect |
+|---|---|---|
+| Any notification write | none — TTL-only | list converges within ≤10 s (≤2 poll ticks) |
+| SSE-enabled clients | existing SSE push | near-real-time regardless |
+
+## Safety / non-invalidation risks (double-checked)
+
+- **Deterministic staleness**: worst case = TTL = 10 s, unconditional; there is no invalidation that can be missed. Safest cache shape.
+- **Mark-read echo**: after the user marks a notification read, the cached page may show it unread for ≤10 s. Mitigate in v1 by having the mark-read/dismiss UI paths delete the user's entries (`cache.delete(...)` from the mutating route, which is module-local and runs in-request) — or accept the ≤10 s echo; either is safe. Recommend the simple accept-the-echo v1 since the panel updates optimistically client-side anyway.
+- **Per-user key** mandatory (`u=<userId>`): the payload is the recipient's private notification list.
+- **TTL must stay ≤ 2× poll interval** to keep the panel feeling live.
+- **No-op without cache service.**
+
+## Implementation steps
+
+- [ ] Add the get-then-set to `api/route.ts` GET (~15 lines).
+- [ ] Decide v1 echo handling (accept vs in-route `cache.delete` on mark-read/dismiss/mark-all-read in the same module's mutating routes — no cross-module wiring either way).
+- [ ] Unit test: per-user key isolation; distinct filter signatures → distinct keys.
+- [ ] Integration: poll convergence ≤ 2 ticks after create/mark-read; cross-user isolation.
+- [ ] `yarn workspace @open-mercato/core build && test`.
+
+## Labels
+
+`feature`, `performance`, `priority-low`

--- a/.ai/analysis/2026-06-08-cache-perf-frs/12-cache-dictionary-entries.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/12-cache-dictionary-entries.md
@@ -1,0 +1,84 @@
+> Cache-performance Feature Request — round-2 candidate 12
+> Endpoint: `GET /api/dictionaries/[dictionaryId]/entries` · Verdict: strong-quick-win
+> Source: `packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/route.ts`
+> Added 2026-06-09 (round 2): this is the **actually-hot** dictionaries surface (replaces demoted FR 05); invalidation piggybacks on existing `crud:dictionaries.entry:*` tags.
+
+## Summary
+
+Every **dictionary-backed custom field** renders a select whose options come from this endpoint — `packages/core/src/modules/entities/api/definitions.ts:366` wires `optionsUrl = /api/dictionaries/${dictionaryId}/entries` into custom-field definitions, so every CrudForm open with a dictionary CF hits it (often several times per form for multiple CFs). Each call runs `findWithDecryption(DictionaryEntry, …)` (per-row decryption) plus a `sortDictionaryEntries` pass.
+
+Unlike dictionary *definitions* (plain `em.flush()` routes — see demoted FR 05), dictionary **entries are written through commands** with `resourceKind: 'dictionaries.entry'` (`commands/entries.ts:36`, `commands/entry-operations.ts:189/387`, factory-based commands `commands/factory.ts:278/376/456`). The command bus therefore already flushes `crud:dictionaries.entry:tenant:<T>:org:<O>:collection` post-commit on every entry write — tag the cached options payload with that and invalidation is free.
+
+## Why (impact)
+
+- **Hotness — high**: fires on form bootstrap for every dictionary-backed CF across all modules; read:write ratio is extreme (entries are admin-curated).
+- **Cost** — decryption-decorated `find` + sort per call.
+- **Est. win** — options lists become a single cache `get` for the 5-minute window; forms with several dictionary CFs save several decrypted queries per open.
+
+## Current behavior
+
+`api/[dictionaryId]/entries/route.ts` — `loadDictionary` (`em.findOne`), then `findWithDecryption(DictionaryEntry, { dictionary, organizationId, tenantId }, …)` (route.ts:71-81), `sortDictionaryEntries(entries, sortMode)` (route.ts:82), DTO mapping. Custom handler; no module cache. (The separately-cached `customers:dictionaries:*` surface covers only the customers module's own kinds API — different endpoint, no overlap.)
+
+## Proposed cache
+
+```ts
+import { buildCollectionTags, buildRecordTag, isCrudCacheEnabled } from '@open-mercato/shared/lib/crud/cache'
+
+const ENTRIES_TTL_MS = 5 * 60_000
+
+const cacheEnabled = isCrudCacheEnabled()
+const cache = cacheEnabled ? (() => { try { return ctx.container.resolve('cache') } catch { return null } })() : null
+const cacheKey = `dictionaries:entries:${dictionaryId}:org=${ctx.organizationId ?? 'null'}:sort=${sortMode}`
+
+if (cache) {
+  const cached = await cache.get(cacheKey)
+  if (cached) return NextResponse.json(cached)
+}
+// ... existing load + sort + mapping → payload ...
+if (cache) {
+  try {
+    await cache.set(cacheKey, payload, {
+      ttl: ENTRIES_TTL_MS,
+      tags: [
+        ...buildCollectionTags('dictionaries.entry', ctx.tenantId, [ctx.organizationId ?? null]),
+        buildRecordTag('dictionaries.dictionary', ctx.tenantId, dictionaryId), // definition rename/delete (PATCH/DELETE are plain routes — TTL backstop, see Safety)
+      ],
+    })
+  } catch {}
+}
+return NextResponse.json(payload)
+```
+
+## Cache tags
+
+- `crud:dictionaries.entry:tenant:<T>:org:<O>:collection` — **reused**, flushed post-commit by the command bus on every entry create/update/delete/undo. Zero new wiring.
+- `crud:dictionaries.dictionary:tenant:<T>:record:<dictionaryId>` — carried for forward-compatibility: it becomes live automatically if/when definition writes are migrated to commands. Today definition PATCH/DELETE are plain `em.flush()` routes, so definition-level changes (rename, `entrySortMode`, soft-delete) converge via the 5-minute TTL — acceptable for admin-curated metadata. (Alternative if faster convergence is required: one `deleteByTags` line after the flush in the two definition write routes.)
+
+## Invalidation
+
+| Trigger | Where the flush already happens | Tags |
+|---|---|---|
+| Entry create/update/delete (commands, resourceKind `dictionaries.entry`) | command bus — existing | `crud:dictionaries.entry:…:collection` |
+| Entry command undo/redo | command bus — existing | same |
+| Dictionary definition PATCH/DELETE (plain routes) | none — **TTL backstop (5 min)**; or one optional inline flush | (TTL) |
+
+## Safety / non-invalidation risks (double-checked)
+
+- **Gate:** the entry-tag flush no-ops while `ENABLE_CRUD_API_CACHE` is off — cache gated on `isCrudCacheEnabled()`.
+- **Definition-change staleness:** a renamed/soft-deleted dictionary's *entries* payload may be served ≤5 min (the entries themselves are unchanged; the parent rename does not alter option values, and a deleted dictionary's options stop being requested once the CF definition refreshes). If this window matters, add the optional inline flush noted above.
+- **Org inheritance:** the entries query is org-scoped (`organizationId` in filter and in the key). Entry writes in a parent org flush the parent-org collection tag; if the read path resolves inherited entries across orgs, include the resolved org set in the key (mirror the route's actual filter — verify during implementation).
+- **Coarse flush:** any entry write in the org flushes all dictionaries' options for that org — costs a recompute, never staleness.
+- **Encrypted values:** cached payload contains decrypted labels — tenant-namespace isolation (dispatcher wrapper) is mandatory and automatic; never cache cross-tenant.
+- **No-op without cache service; never cache 401/404 branches.**
+
+## Implementation steps
+
+- [ ] Add the gated get-then-set to `api/[dictionaryId]/entries/route.ts`; assemble the response into a `payload` first.
+- [ ] Mirror the route's exact filter axes in the key (org / sortMode / any inactive flag).
+- [ ] Unit tests: key axes; tag shapes match the command-bus flush; no caching when flag off.
+- [ ] Integration: create/update an entry via the API → options reflect it immediately (command flush); definition rename converges ≤ TTL.
+- [ ] `yarn workspace @open-mercato/core build && test`.
+
+## Labels
+
+`feature`, `performance`, `priority-medium`

--- a/.ai/analysis/2026-06-08-cache-perf-frs/13-cache-currencies-options.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/13-cache-currencies-options.md
@@ -1,0 +1,80 @@
+> Cache-performance Feature Request — round-2 candidate 13
+> Endpoint: `GET /api/currencies/options` · Verdict: good
+> Source: `packages/core/src/modules/currencies/api/currencies/options/route.ts`
+> Added 2026-06-09 (round 2): verified non-cached; invalidation piggybacks on existing `crud:currencies.currency:*` tags.
+
+## Summary
+
+Currency option lists back the currency selects in pricing, sales-document, and product forms. The endpoint is a custom GET running an org-scoped `em.find(Currency, …)` with an optional `$or` ILIKE search filter and response mapping on every form open. Currencies are near-static reference data (writes are rare admin actions) — a textbook cache case.
+
+Currency writes go through **commands** with `resourceKind: 'currencies.currency'` (`commands/currencies.ts:170/301`, plus delete), so the command bus already flushes `crud:currencies.currency:tenant:<T>:org:<O>:collection` post-commit. Tag the cached options with that tag — zero new flush wiring.
+
+## Why (impact)
+
+- **Hotness — medium-high**: every form with a money field loads options; sessions doing order/price entry hit it repeatedly.
+- **Cost** — one filtered/sorted `find` + mapping per call; ILIKE search variants multiply it.
+- **Est. win** — options become a cache `get` for the 5-minute window; reference data hit rate is near 100 %.
+
+## Current behavior
+
+`api/currencies/options/route.ts` (~line 70-73): `em.find(Currency, { tenantId, organizationId, deletedAt: null, isActive?, $or: [code ILIKE, name ILIKE]? }, { orderBy: { code: 'ASC' }, limit })` → option DTO mapping. Custom handler; no module cache. Writes: `currencies.currencies.create/update/delete` commands (resourceKind `currencies.currency`); exchange-rate writes are a different resource (`currencies.exchange_rate`) and do not affect this payload.
+
+## Proposed cache
+
+```ts
+import { buildCollectionTags, isCrudCacheEnabled } from '@open-mercato/shared/lib/crud/cache'
+
+const CURRENCY_OPTIONS_TTL_MS = 5 * 60_000
+
+const cacheEnabled = isCrudCacheEnabled()
+const cache = cacheEnabled ? (() => { try { return container.resolve('cache') } catch { return null } })() : null
+const cacheKey = `currencies:options:org=${orgId ?? 'null'}:active=${activeFlag ?? 'all'}:q=${searchTerm ?? ''}:limit=${limit}`
+
+if (cache) {
+  const cached = await cache.get(cacheKey)
+  if (cached) return NextResponse.json(cached)
+}
+// ... existing find + mapping → payload ...
+if (cache) {
+  try {
+    await cache.set(cacheKey, payload, {
+      ttl: CURRENCY_OPTIONS_TTL_MS,
+      tags: buildCollectionTags('currencies.currency', tenantId, [orgId ?? null]),
+    })
+  } catch {}
+}
+return NextResponse.json(payload)
+```
+
+## Cache tags
+
+- `crud:currencies.currency:tenant:<T>:org:<O>:collection` — **reused**, flushed post-commit by the command bus on every currency command execute/undo. Zero new wiring.
+
+## Invalidation
+
+| Trigger | Where the flush already happens | Tags |
+|---|---|---|
+| Currency create/update/delete (commands, resourceKind `currencies.currency`) | command bus — existing | `crud:currencies.currency:…:collection` |
+| Undo/redo | command bus — existing | same |
+| Exchange-rate writes | n/a — not in this payload | none needed |
+
+**Nothing to add on the write side.**
+
+## Safety / non-invalidation risks (double-checked)
+
+- **Gate:** flush no-ops while `ENABLE_CRUD_API_CACHE` is off — cache gated on `isCrudCacheEnabled()`.
+- **This is option metadata, not rates:** the payload is code/name/symbol option rows. Money amounts and conversion rates are computed elsewhere; a stale option list cannot mis-price anything.
+- **Search-variant cardinality:** ILIKE search creates a key per term; the collection tag flushes them all and the 5-min TTL caps memory. (Optionally skip caching when `searchTerm` is set — the non-search bootstrap call is the hot one.)
+- **Org axis** in key and tags; tenant namespace via the dispatcher wrapper.
+- **No-op without cache service; never cache 401/400 branches.**
+
+## Implementation steps
+
+- [ ] Add the gated get-then-set to `api/currencies/options/route.ts` (consider skipping cache when `searchTerm` is present).
+- [ ] Unit tests: key axes; tags match command-bus shape; flag-off ⇒ no caching.
+- [ ] Integration: create/deactivate a currency → options reflect it immediately (command flush).
+- [ ] `yarn workspace @open-mercato/core build && test`.
+
+## Labels
+
+`feature`, `performance`, `priority-low`

--- a/.ai/analysis/2026-06-08-cache-perf-frs/14-cache-auth-roles-list.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/14-cache-auth-roles-list.md
@@ -1,0 +1,88 @@
+> Cache-performance Feature Request — round-2 candidate 14
+> Endpoint: `GET /api/auth/roles` · Verdict: good
+> Source: `packages/core/src/modules/auth/api/roles/route.ts`
+> Added 2026-06-09 (round 2): verified non-cached; invalidation piggybacks on existing `crud:auth.role:*` + `crud:auth.user:*` tags, with `rbac:tenant:*` as a bonus axis.
+
+## Summary
+
+The roles list backs the admin roles page and role-select dropdowns in user management. The custom GET is query-heavy per call: `em.findAndCount(Role)` + a `findWithDecryption(UserRole)` sweep to compute per-role **user counts** + `findWithDecryption(Tenant)` for tenant names + `loadCustomFieldValues` for role CFs (`route.ts:193-237`). Cache the assembled page per `(tenant, query-shape)` with a 120 s TTL, tagged with the **already-flushed** `crud:auth.role:*` and `crud:auth.user:*` collection tags so role CRUD and user-role grants invalidate it via the command bus, with no new wiring.
+
+## Why (impact)
+
+- **Hotness — medium** (admin surface, but bursty: every user-management session reloads it repeatedly).
+- **Cost — high per call**: 3-4 round-trips, two decryption-decorated; user-count sweep grows with user count.
+- **Est. win** — the expensive user-count sweep collapses to a cache `get` for the window.
+
+## Current behavior
+
+`api/roles/route.ts:133-268` — custom handler (not `makeCrudRoute`): `em.findAndCount(Role, where, { limit, offset })` (route.ts:193), `findWithDecryption(UserRole, …)` per-role user counting (route.ts:197-202), `findWithDecryption(Tenant, …)` (route.ts:210), `loadCustomFieldValues(E.auth.role, …)` (route.ts:230-237). No module cache on this path. Writes: role CRUD via commands with `resourceKind: 'auth.role'` (`commands/roles.ts:188/385/506`); user-role grants via `auth.users.*` commands (`commands/users.ts`, resourceKind `auth.user`) which also flush `rbac:user:*` / `rbac:tenant:*` tags.
+
+## Proposed cache
+
+```ts
+import { buildCollectionTags, isCrudCacheEnabled } from '@open-mercato/shared/lib/crud/cache'
+
+const ROLES_LIST_TTL_MS = 120_000
+
+const cacheEnabled = isCrudCacheEnabled()
+const cache = cacheEnabled ? (() => { try { return container.resolve('cache') } catch { return null } })() : null
+const cacheKey = `auth:roles:list:${querySignature /* page,pageSize,search,sort */}`
+
+if (cache) {
+  const cached = await cache.get(cacheKey)
+  if (cached) return NextResponse.json(cached)
+}
+// ... existing queries + assembly → payload ...
+if (cache) {
+  try {
+    await cache.set(cacheKey, payload, {
+      ttl: ROLES_LIST_TTL_MS,
+      tags: [
+        ...buildCollectionTags('auth.role', tenantId, [null]),  // roles are tenant-level (org:null)
+        ...buildCollectionTags('auth.user', tenantId, [null]),  // user-role grants change the userCount column
+        `rbac:tenant:${tenantId}`,                              // existing rbac flush on role-ACL writes (bonus axis)
+      ],
+    })
+  } catch {}
+}
+return NextResponse.json(payload)
+```
+
+## Cache tags
+
+- `crud:auth.role:tenant:<T>:org:null:collection` — **reused**, flushed by the command bus on `auth.roles.create/update/delete` execute/undo.
+- `crud:auth.user:tenant:<T>:org:null:collection` — **reused**, flushed on `auth.users.*` commands; covers the per-role `userCount` changing when a user is granted/revoked a role or deleted.
+- `rbac:tenant:<T>` — **reused**, flushed by `auth/api/roles/acl/route.ts:254` on role-ACL writes (`rbacService.deleteCacheByTags` covers current + global + hinted namespaces).
+
+No new tags. No subscribers.
+
+## Invalidation
+
+| Trigger | Where the flush already happens | Tags |
+|---|---|---|
+| Role create/update/delete (commands, `auth.role`) | command bus — existing | `crud:auth.role:…:collection` |
+| User create/update/delete + role grant/revoke (commands, `auth.user`) | command bus — existing | `crud:auth.user:…:collection` |
+| Role ACL feature change | `roles/acl` route — existing | `rbac:tenant:<T>` |
+| Undo/redo | command bus — existing | same crud tags |
+
+**Nothing to add on the write side.**
+
+## Safety / non-invalidation risks (double-checked)
+
+- **Gate:** the `crud:*` flushes no-op while `ENABLE_CRUD_API_CACHE` is off — cache gated on `isCrudCacheEnabled()`. (`rbac:tenant:*` flushes are NOT flag-gated, but alone they don't cover role/user CRUD — so the flag gate stands.)
+- **Org axis of grants:** verify during implementation whether `auth.users.*` command metadata records an `organizationId`; if it does, the flush targets `org:<O>` while this entry is tagged `org:null` — in that case also tag with the actor org axis or rely on the 120 s TTL. List this as an explicit implementation checkpoint, not an assumption.
+- **No ACL bypass:** the cached payload is the same RBAC-guarded response the route returns today; the route's `requireFeatures` guard runs before the cache lookup. The cache stores per-tenant data only; key carries the query shape, namespace carries the tenant.
+- **Role custom fields:** CF edits on roles route through `auth.roles.update` → covered by the role collection tag.
+- **120 s TTL backstop** for anything missed (e.g. direct SQL).
+
+## Implementation steps
+
+- [ ] Add the gated get-then-set to `api/roles/route.ts`; assemble the response into a `payload` first.
+- [ ] Verify the org-axis of `auth.users.*` command metadata (see Safety) and adjust tags if needed.
+- [ ] Unit tests: key axes; tag shapes; flag-off ⇒ no caching.
+- [ ] Integration: grant a role to a user → roles list `userCount` updates immediately; create/delete a role → list updates immediately.
+- [ ] `yarn workspace @open-mercato/core build && test`.
+
+## Labels
+
+`feature`, `performance`, `priority-low`

--- a/.ai/analysis/2026-06-08-cache-perf-frs/15-cache-sidebar-preferences.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/15-cache-sidebar-preferences.md
@@ -1,0 +1,84 @@
+> Cache-performance Feature Request — round-2 candidate 15
+> Endpoint: `GET /api/auth/sidebar/preferences` · Verdict: strong-quick-win
+> Source: `packages/core/src/modules/auth/api/sidebar/preferences/route.ts`
+> Added 2026-06-09 (round 2): the GET is uncached, but its PUT **already flushes a complete tag set** (`nav:sidebar:user/role/scope`) — caching the GET with those exact tags needs zero new flush wiring. (The sibling `GET /api/auth/admin/nav` is already cached on these tags — `nav.ts:138/166` — proving the pattern.)
+
+## Summary
+
+The sidebar-preferences GET feeds sidebar customization state on backend shell bootstrap. For admins (`canApplyToRoles=true`) it is query-heavy: `findWithDecryption(Role)` for all roles plus a per-role `RoleSidebarPreference` lookup, plus the user-scoped preference row (`route.ts:100-117, 206-226`).
+
+The module already defines the freshness contract: the PUT handler flushes `nav:sidebar:user:<userId>`, `nav:sidebar:scope:<userId>:<tenantId>:<orgId>:<locale>`, and `nav:sidebar:role:<roleId>` post-commit (`route.ts:488-503`), and the already-cached `GET /api/auth/admin/nav` consumes these same tags. This FR simply caches the preferences GET payload under the same tags — the existing flush wiring invalidates it for free, and the two nav surfaces stay consistent by construction.
+
+## Why (impact)
+
+- **Hotness — high**: part of backend shell bootstrap; re-fetched on sidebar customization UI opens.
+- **Cost** — for admins: roles enumeration with decryption + N per-role preference lookups; for everyone: user preference + role payload assembly.
+- **Est. win** — bootstrap reads become a cache `get`; the N+1 role-preference sweep disappears from the hot path.
+
+## Current behavior
+
+`api/sidebar/preferences/route.ts` — GET: `loadSidebarPreference` (`em.findOne(SidebarPreference)`), `loadRolesPayload` (`findWithDecryption(Role)` + `em.findOne(RoleSidebarPreference)` per role), assembly. No `cache.get`/`cache.set` on the GET path (verified). PUT: writes user/role preferences and **already** flushes the `nav:sidebar:*` tags listed above. The admin-nav GET (`api/admin/nav.ts:138/166`) already caches its payload with `nav:sidebar:role:<id>`-family tags.
+
+## Proposed cache
+
+```ts
+const SIDEBAR_PREFS_TTL_MS = 15 * 60_000 // backstop; the PUT flush carries correctness
+
+const cache = (() => { try { return container.resolve('cache') } catch { return null } })()
+const cacheKey = `nav:sidebar:prefs:${auth.sub}:${auth.orgId ?? 'null'}:${locale}`
+const cacheTags = [
+  `nav:sidebar:user:${auth.sub}`,
+  `nav:sidebar:scope:${auth.sub}:${auth.tenantId ?? 'null'}:${auth.orgId ?? 'null'}:${locale}`,
+  ...userRoleIds.map((roleId) => `nav:sidebar:role:${roleId}`),
+]
+
+if (cache) {
+  const cached = await cache.get(cacheKey)
+  if (cached) return NextResponse.json(cached)
+}
+// ... existing load + assembly → payload ...
+if (cache) {
+  try { await cache.set(cacheKey, payload, { ttl: SIDEBAR_PREFS_TTL_MS, tags: cacheTags }) } catch {}
+}
+return NextResponse.json(payload)
+```
+
+Note: **not** gated on `ENABLE_CRUD_API_CACHE` — the `nav:sidebar:*` flushes in the PUT are unconditional module-local calls, independent of the CRUD-cache flag.
+
+## Cache tags
+
+All **reused** — the PUT already flushes every one of them (`route.ts:488-503`):
+
+- `nav:sidebar:user:<userId>` — user-scoped preference writes.
+- `nav:sidebar:scope:<userId>:<tenantId>:<orgId>:<locale>` — scope-precise variant.
+- `nav:sidebar:role:<roleId>` — role-preference writes (flushed for each updated/cleared role).
+
+## Invalidation
+
+| Trigger | Where the flush already happens | Tags |
+|---|---|---|
+| User saves sidebar prefs (PUT, user scope) | existing flush `route.ts:494-503` | `nav:sidebar:user:<U>` + scope tag |
+| Admin saves/clears role sidebar prefs (PUT, role scope) | existing flush `route.ts:488-492` | `nav:sidebar:role:<R>` per role |
+| Role created/deleted, user role membership change | not flushed by nav tags — **TTL backstop (15 min)**; affects only which roles appear in the admin's roles payload | (TTL) |
+
+**Nothing to add on the write side.**
+
+## Safety / non-invalidation risks (double-checked)
+
+- **Namespace matching:** both the PUT flush and the GET set run inside mutating/reading requests of the same tenant — the dispatcher's `runWithCacheTenant(auth.tenantId)` wrapper puts them in the same namespace. (Same contract the already-shipped admin-nav cache relies on.)
+- **Role-membership drift:** a user gaining/losing a role changes which `nav:sidebar:role:*` tags their entry *should* carry; the stale entry survives ≤ TTL. Cosmetic (sidebar layout preference), and rbac changes also flush `rbac:user:<U>` — optionally carry that tag too to close the window for free.
+- **Per-user + locale key**: preferences are personal; `userId` + `locale` + org are all in the key.
+- **Never cache 401 branches; no-op without cache service.**
+- **Locale axis**: the PUT flushes the scope tag with the writing locale; the broad `nav:sidebar:user:<U>` tag covers cross-locale variants — keep it on every entry (it is).
+
+## Implementation steps
+
+- [ ] Add the get-then-set to the GET handler; assemble the response into a `payload` first; collect `userRoleIds` before tagging.
+- [ ] Optionally add `rbac:user:${auth.sub}` to the tag list (existing rbac flush closes the role-membership window).
+- [ ] Unit tests: tags exactly match the PUT's flush strings; per-user/locale key isolation.
+- [ ] Integration: save sidebar prefs → next GET reflects them immediately (existing flush); admin role-pref save → affected users' next GET reflects it.
+- [ ] `yarn workspace @open-mercato/core build && test`.
+
+## Labels
+
+`feature`, `performance`, `priority-low`

--- a/.ai/analysis/2026-06-08-cache-perf-frs/16-cache-product-media.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/16-cache-product-media.md
@@ -1,0 +1,79 @@
+> Cache-performance Feature Request — round-2 candidate 16
+> Endpoint: `GET /api/catalog/product-media` · Verdict: good
+> Source: `packages/core/src/modules/catalog/api/product-media/route.ts`
+> Added 2026-06-09 (round 2): verified non-cached; invalidation rides the existing `crud:catalog.product:*:record:<id>` tag + a short TTL for attachment-only changes.
+
+## Summary
+
+Product media is fetched on every product detail open and media-tab render. The custom GET runs two queries per call — a product scope check (`em.findOne(CatalogProduct)`) and the attachments fetch (`em.find(Attachment, { entityId: catalog_product, recordId })`) — plus URL building (`route.ts:36-69`).
+
+Cache the media payload per product, tagged with the **already-flushed** `crud:catalog.product:tenant:<T>:record:<productId>` tag (every product command flushes it via the command bus). Attachment upload/delete does **not** go through the command bus (the attachments module has events but its writes are route-level), so attachment-only changes converge via a deliberately short **60 s TTL** — no bespoke subscriber in v1.
+
+## Why (impact)
+
+- **Hotness — medium**: product detail/media tab during catalog browsing; bursty during merchandising sessions.
+- **Cost** — 2 queries + URL mapping per call.
+- **Est. win** — repeat opens within a minute become a cache `get`; pairs well with FR 06's product-list caching for browse flows.
+
+## Current behavior
+
+`api/product-media/route.ts:36-69` — `em.findOne(CatalogProduct, { id, organizationId, tenantId })` scope check, `em.find(Attachment, { entityId: E.catalog.catalog_product, recordId: productId, … })`, `buildAttachmentImageUrl` mapping. Custom handler; no module cache. Writes affecting the payload: attachment upload/delete via `/api/attachments` routes (module declares `attachments.attachment.created/updated/deleted` events in `attachments/events.ts` but writes are not command-bus commands), and product delete via `catalog.products.delete` (command).
+
+## Proposed cache
+
+```ts
+import { buildRecordTag, isCrudCacheEnabled } from '@open-mercato/shared/lib/crud/cache'
+
+const PRODUCT_MEDIA_TTL_MS = 60_000 // short: attachment writes have no command-bus flush
+
+const cacheEnabled = isCrudCacheEnabled()
+const cache = cacheEnabled ? (() => { try { return container.resolve('cache') } catch { return null } })() : null
+const cacheKey = `catalog:product-media:${productId}:org=${orgId ?? 'null'}`
+
+if (cache) {
+  const cached = await cache.get(cacheKey)
+  if (cached) return NextResponse.json(cached)
+}
+// ... existing scope check + find + mapping → payload ...
+if (cache) {
+  try {
+    await cache.set(cacheKey, payload, {
+      ttl: PRODUCT_MEDIA_TTL_MS,
+      tags: [buildRecordTag('catalog.product', tenantId, productId)],
+    })
+  } catch {}
+}
+return NextResponse.json(payload)
+```
+
+## Cache tags
+
+- `crud:catalog.product:tenant:<T>:record:<productId>` — **reused**, flushed by the command bus on every `catalog.products.update/delete` execute/undo. Covers product deletion/update (and media changes made through product commands, if any).
+
+## Invalidation
+
+| Trigger | Where the flush already happens | Tags |
+|---|---|---|
+| Product update/delete (commands, resourceKind `catalog.product`) | command bus — existing | `crud:catalog.product:…:record:<id>` |
+| Attachment upload/delete (`/api/attachments` routes — no command) | none in v1 — **60 s TTL backstop** | (TTL) |
+| Optional v2 (only if 60 s lag is unacceptable) | one ephemeral subscriber on `attachments.attachment.created/deleted` (events already declared in `attachments/events.ts`) flushing the product record tag — MUST wrap in `runWithCacheTenant(payload.tenantId, …)` | `crud:catalog.product:…:record:<id>` |
+
+## Safety / non-invalidation risks (double-checked)
+
+- **The dominant risk is attachment-write staleness**, which is why the TTL is 60 s (not minutes): after uploading media, the editor's own media tab could show the old set for ≤60 s on a cached read. If product-edit UX refetches with cache-busting or the v2 subscriber ships, this disappears. Decide v1-acceptability with the product-team; the spec defaults to v1 + explicit callout.
+- **Gate:** the record-tag flush no-ops while `ENABLE_CRUD_API_CACHE` is off — cache gated on `isCrudCacheEnabled()`.
+- **Scope check stays live**: the 404/forbidden early-return for a wrong-org product is never cached (only the successful payload is), so the cache cannot leak media across orgs; key carries org, namespace carries tenant.
+- **v2 subscriber namespace rule**: subscriber flushes run outside the request ALS context — the `runWithCacheTenant(payload.tenantId, …)` wrap is mandatory or the flush lands in the `global` namespace and never matches (see README doctrine §2).
+- **No-op without cache service.**
+
+## Implementation steps
+
+- [ ] Add the gated get-then-set to `api/product-media/route.ts`.
+- [ ] Confirm with UX whether the product media editor refetches after upload (if it posts then refetches the same GET, consider the v2 subscriber in the same PR).
+- [ ] Unit tests: per-product key; record-tag shape; flag-off ⇒ no caching; 404 branch never cached.
+- [ ] Integration: product update → media payload recomputed immediately; attachment upload → converges ≤60 s (or immediately with v2).
+- [ ] `yarn workspace @open-mercato/core build && test`.
+
+## Labels
+
+`feature`, `performance`, `priority-low`

--- a/.ai/analysis/2026-06-08-cache-perf-frs/README.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/README.md
@@ -1,70 +1,86 @@
 # Cache Performance — Feature Request Backlog
 
 > Generated 2026-06-08 by a multi-agent workflow (4 discovery lanes → 9 deep-dive agents).
+> Revised 2026-06-09: invalidation reworked to **connect to already-flushed tags** instead of adding bespoke per-entity flush wiring; overlap with the existing CRUD API cache audited (2 FRs rescoped/demoted); 7 new candidates added (FR 10–16).
 > Goal: highest-ROI API endpoints to cache **with tag-based invalidation** so data stays fresh. Quick wins, most-used read paths.
 
 ## How caching works here (read first)
 
 - **Cache service**: `container.resolve('cache')` — API `get/set(key,val,{ttl,tags})/deleteByTags(tags[])`. No `getOrSet`; do manual get-then-set.
-- **Tenant scoping is mandatory**: wrap every `get`/`set`/`deleteByTags` in `runWithCacheTenant(tenantId, …)` from `@open-mercato/cache`. It namespaces keys+tags per tenant, so cross-tenant reads are impossible even when the literal key omits the tenant.
-- **Reference pattern to copy**: `packages/core/src/modules/customer_accounts/services/domainMappingService.ts` (get-then-set + ttl + tags, `deleteByTags` on every mutation, TTL as backstop).
-- **Invalidation timing**: fire `deleteByTags` **post-commit** (outside `withAtomicFlush`) — event subscribers and `emitCrudSideEffects` already run post-commit. Tags carry correctness; TTL is only a backstop for missed invalidations.
-- **Generic CRUD list cache already exists** (`packages/shared/src/lib/crud/factory.ts`) but is gated OFF behind env `ENABLE_CRUD_API_CACHE`. It only covers `makeCrudRoute` GETs and invalidates via collection/record tags from the command bus. **Custom GET handlers bypass it entirely** — those are the biggest manual-cache quick wins.
+- **Tenant scoping is automatic in API handlers**: the API dispatcher wraps every route handler in `runWithCacheTenant(auth.tenantId, …)` (`apps/mercato/src/app/api/[...slug]/route.ts:382`). Keys and tags are SHA1-hashed under a `tenant:<id>:` namespace (`packages/cache/src/service.ts`), so cross-tenant reads are impossible even when the literal key omits the tenant.
+- **Generic CRUD list cache already exists** (`packages/shared/src/lib/crud/factory.ts`) but is gated OFF behind env `ENABLE_CRUD_API_CACHE`. It only covers `makeCrudRoute` GETs. **Custom GET handlers bypass it entirely** — those are the manual-cache quick wins below.
 
-## Two classes of work
+## Invalidation doctrine: connect to already-flushed tags (do NOT add bespoke flush wiring)
 
-1. **Manual cache on custom GET handlers** (bypass the factory cache) — most of the wins below.
-2. **Enable + harden the generic CRUD cache** for hot `makeCrudRoute` reads — turn on `ENABLE_CRUD_API_CACHE` and close cross-resource invalidation gaps (see FR 06 / 08).
+The platform already flushes a rich set of tags post-commit. A new manual cache should **carry one of these existing tags** so it is invalidated for free — new subscribers or per-write `deleteByTags` calls are a last resort, not the default.
+
+**Tags that are already flushed today:**
+
+| Tag (literal) | Flushed by | When |
+|---|---|---|
+| `crud:<module>.<entity>:tenant:<T>:org:<O>:collection` | `makeCrudRoute` POST/PUT/DELETE (`factory.ts:2266/2597/2882`) **and** the command bus after every command execute/undo (`packages/shared/src/lib/commands/command-bus.ts:610/642`, resource derived from `resourceKind` + `deriveResourceFromCommandId` + `context.cacheAliases`) | post-commit, every domain write |
+| `crud:<module>.<entity>:tenant:<T>:record:<id>` | same | post-commit |
+| `org-scope:tenant:<T>`, `org-scope:user:<U>` | `directory/subscribers/invalidateOrgScopeCache.ts` + `invalidateOrganizationScopeCacheForUser/Tenant` | org create/update/delete, membership change |
+| `rbac:user:<U>`, `rbac:tenant:<T>`, `rbac:org:<O>`, `rbac:all` | `auth/services/rbacService.ts` (`deleteCacheByTags` flushes across current + global + hinted tenant namespaces) | role/user ACL change |
+| `nav:sidebar:user:<U>`, `nav:sidebar:role:<R>`, `nav:sidebar:scope:<U>:<T>:<O>:<locale>` | `auth/api/sidebar/preferences/route.ts` PUT (lines 488–503) | sidebar preference write |
+| `inbox_ops:counts:<T>` | `invalidateCountsCache` at 9 write sites (7 routes + extraction worker + ai-tools) | every proposal mutation |
+| `customers:dictionaries:<T>:<kind>[…:org:<O>]` | `customers/api/dictionaries/cache.ts` `invalidateDictionaryCache` | customer dictionary entry write |
+| `feature_toggles:identifier:<id>`, `module-config:module:<id>`, `domain_routing`, `perspectives:*`, `custom-entity:*`, `nav:entities:<T>` | their owning modules | respective writes |
+
+**Two safety rules that make piggybacking correct:**
+
+1. **The `ENABLE_CRUD_API_CACHE` gate.** Every `crud:*` flush goes through `invalidateCrudCache`, which **no-ops when the flag is off** (`packages/shared/src/lib/crud/cache.ts:180`). Therefore any manual cache that carries `crud:*` tags MUST itself be gated on `isCrudCacheEnabled()` — when the flag is off, skip caching (fall back to uncached behavior or a very short TTL-only cache). Otherwise entries would never be invalidated and would serve stale data for the full TTL.
+2. **Tenant-namespace matching.** Tags only match within the same tenant namespace. Request-side `get`/`set` inherit the namespace from the dispatcher wrapper; `invalidateCrudCache` wraps its flush in `runWithCacheTenant(tenantId, …)` explicitly — these match. But a flush issued from a **subscriber or queue worker** without an explicit `runWithCacheTenant(payload.tenantId, …)` wrapper lands in the `global` namespace and silently misses tenant-scoped entries. Any subscriber-based flush MUST wrap explicitly (FR 02 fixes one such latent gap in the existing org-scope subscriber).
+
+**Universal safety backstops (every FR below assumes these):**
+
+- Always set a TTL. Tags carry correctness; TTL bounds staleness when a flush is missed (e.g. a command whose metadata lacks `organizationId` flushes only the `org:null` collection tag, leaving org-scoped entries until TTL; or an out-of-band SQL write).
+- Never cache error/early-return responses (401/400/empty-auth branches).
+- Per-user payloads MUST include `userId` in the cache key; per-org payloads MUST include the org axis in key or tags.
+- Cache resolution is defensive (`try { container.resolve('cache') } catch { null }`) — behavior with no cache service is byte-identical to today.
+- Audit side effects (`logCrudAccess`) always run outside the cached block.
+
+## Overlap audit (vs the existing CRUD API cache and module caches)
+
+- **FR 05 `GET /api/dictionaries` — demoted (skip).** The hot dictionary-select surface is the **customers** module's dictionary API, which is **already cached** (`customers:dictionaries:*`, 5 min TTL + invalidation). The `dictionaries`-module list endpoint mostly serves the admin manager page — low traffic, not worth the change. Issue #2910 recommended for closure.
+- **FR 08 `GET /api/catalog/offers` — rescoped.** The originally proposed decoration cache (snapshot store + 4-event subscriber + price→product mapping) is exactly the bespoke complexity this backlog now avoids. v1 is reduced to extending FR 06's `cacheAliases` mechanism (`['catalog.offer']` on price/variant commands) so the generic CRUD offers list cache stays correct; the decoration cache is explicitly deferred.
+- `catalog/variants` and `catalog/prices` (from the original candidate ranking) are `makeCrudRoute` reads — enabling `ENABLE_CRUD_API_CACHE` (FR 06) covers them; **no separate FR is warranted**.
+- `GET /api/auth/admin/nav` and `GET /api/entities/definitions` are **already cached** (`nav.ts:138/166`; `definitions.cache.ts`) — disqualified as new candidates.
 
 ## FR issues (deep-analyzed, filed)
 
 Tracked in GitHub (proposed in PR #2905):
 
-| # | ROI | Endpoint | Verdict | Class | Issue | FR file |
+| # | ROI | Endpoint | Verdict | Invalidation source | Issue | FR file |
 |---|---|---|---|---|---|---|
-| 1 | 86 | `GET /api/catalog/categories` | strong-quick-win | Manual cache | #2906 | [01-cache-catalog-categories-list.md](./01-cache-catalog-categories-list.md) |
-| 2 | 84 | `GET /api/directory/organization-switcher` | good | Manual cache | #2907 | [02-cache-organization-switcher-menu.md](./02-cache-organization-switcher-menu.md) |
-| 3 | 82 | `GET /api/notifications/unread-count` | good | Manual cache | #2908 | [03-cache-notifications-unread-count.md](./03-cache-notifications-unread-count.md) |
-| 4 | 82 | `GET /api/inbox_ops/proposals` | good | Manual cache | #2909 | [04-cache-inbox-ops-proposals-list.md](./04-cache-inbox-ops-proposals-list.md) |
-| 5 | 82 | `GET /api/dictionaries` | good | Manual cache | #2910 | [05-cache-dictionaries-list.md](./05-cache-dictionaries-list.md) |
-| 6 | 78 | `GET /api/catalog/products` | good | CRUD cache | #2911 | [06-enable-and-fix-catalog-products-list-cache.md](./06-enable-and-fix-catalog-products-list-cache.md) |
-| 7 | 72 | `GET /api/dashboards/layout` | good | Manual cache | #2912 | [07-cache-dashboards-layout-bootstrap.md](./07-cache-dashboards-layout-bootstrap.md) |
-| 8 | 72 | `GET /api/catalog/offers` | good | CRUD cache | #2913 | [08-catalog-offers-decoration-cache.md](./08-catalog-offers-decoration-cache.md) |
-| 9 | 58 | `GET /api/messages` | good | Manual cache | #2914 | [09-cache-messages-list-per-user.md](./09-cache-messages-list-per-user.md) |
+| 1 | 86 | `GET /api/catalog/categories` | strong-quick-win | existing `crud:catalog.category:*` tags (command bus) | #2906 | [01](./01-cache-catalog-categories-list.md) |
+| 2 | 84 | `GET /api/directory/organization-switcher` | good | existing `org-scope:tenant:*` + `rbac:user:*` tags | #2907 | [02](./02-cache-organization-switcher-menu.md) |
+| 3 | 82 | `GET /api/notifications/unread-count` | good | TTL-only v1 (no command-bus writes exist) | #2908 | [03](./03-cache-notifications-unread-count.md) |
+| 4 | 82 | `GET /api/inbox_ops/proposals` | good | existing `inbox_ops:counts:<T>` tag (9 sites already flush it) | #2909 | [04](./04-cache-inbox-ops-proposals-list.md) |
+| 5 | 82 | `GET /api/dictionaries` | **skip — overlap** | n/a (hot surface already cached in customers module) | #2910 | [05](./05-cache-dictionaries-list.md) |
+| 6 | 78 | `GET /api/catalog/products` | good | enable CRUD cache + `cacheAliases` cross-resource fix | #2911 | [06](./06-enable-and-fix-catalog-products-list-cache.md) |
+| 7 | 72 | `GET /api/dashboards/layout` | good | module-local writes (4 routes) + existing `rbac:user:*` tag | #2912 | [07](./07-cache-dashboards-layout-bootstrap.md) |
+| 8 | 72 | `GET /api/catalog/offers` | **rescoped** | folded into FR 06's `cacheAliases` mechanism | #2913 | [08](./08-catalog-offers-decoration-cache.md) |
+| 9 | 58 | `GET /api/messages` | good | existing `crud:messages.message:*` tags (command bus) | #2914 | [09](./09-cache-messages-list-per-user.md) |
 
-## Full candidate ranking (20 discovered; top 9 deep-dived above)
+## New candidates (round 2 — verified non-cached, invalidation piggybacks on existing tags)
 
-Remaining candidates are pre-vetted but not yet written up — good follow-up backlog.
-
-| ROI | Endpoint | Module | makeCrudRoute? | Why it is a candidate |
+| # | Endpoint | Hotness | Invalidation source | FR file |
 |---|---|---|---|---|
-| 92 ✅ FR | `GET /api/directory/organization-switcher` | directory | no | Heavy compute: em.find(Organization), em.find(Tenant), computeHierarchyForOrganizations (builds ancestor/descendant maps for each org), reso… |
-| 92 ✅ FR | `GET /api/catalog/products` | catalog | yes | Massive afterList enricher (decorateProductsAfterList, lines 351–741): parallel lookups of offers, channels, categories, tags, variants, pri… |
-| 92 ✅ FR | `GET /api/messages` | messages | no | 5-6 sequential/parallel queries: Kysely base query + findWithDecryption (Message entities with encryption overhead) + em.find (MessageObject… |
-| 88 ✅ FR | `GET /api/notifications/unread-count` | notifications | no | Single em.count(Notification) query, but the COUNT is executed on every request without batching or coalescing. Lightweight query but extrem… |
-| 88 ✅ FR | `GET /api/catalog/categories` | catalog | no | Custom GET (no makeCrudRoute): full hierarchy computation (computeHierarchyForCategories), tree-view node construction, custom field values … |
-| 88 ✅ FR | `GET /api/dashboards/layout` | dashboards | no | Custom GET: loadAllWidgets (dynamic imports of ~40+ dashboard widgets across all modules + Promise.all(widgetEntries.map...)), loadScopeLayo… |
-| 88 ✅ FR | `GET /api/inbox_ops/proposals` | inbox_ops | no | findAndCountWithDecryption (proposals with encryption overhead) + Promise.all parallel fetch of InboxEmail, InboxProposalAction, InboxDiscre… |
-| 85 ✅ FR | `GET /api/dictionaries` | dictionaries | no | Custom GET handler with em.find() to fetch all active dictionaries, org-scoped filtering, inheritance resolution (reads both org and parent-… |
-| 85 ✅ FR | `GET /api/catalog/offers` | catalog | yes | decorateOffersWithDetails (lines 84–337): Promise.all of products fetch, prices with priceKind populate, variant defaults. Then complex pric… |
-| 85 | `GET /api/messages/unread-count` | messages | no | Joins message_recipients table to messages with 6+ filter conditions (status, deleted_at, archived_at, organization scoping, tenant scoping)… |
-| 82 | `GET /api/dictionaries/[dictionaryId]/entries` | dictionaries | no | Custom handler: loadDictionary (em.findOne), findWithDecryption for all entries (encryption overhead), sortDictionaryEntries computation, ma… |
-| 82 | `GET /api/catalog/product-media` | catalog | no | Custom GET (not makeCrudRoute): findOne product scope check + find attachments. Lightweight but called at high frequency (product detail pag… |
-| 80 | `GET /api/currencies/options` | currencies | no | Custom GET: em.find with complex $or search filter (code + name), optional active/inactive filter, limit loop, response mapping to options f… |
-| 80 | `GET /api/notifications` | notifications | no | em.find (main query) + em.count (separate count query, 2 ORM calls). Filter applied in code requires both queries to run before filtering. F… |
-| 78 | `GET /api/auth/roles` | auth | no | Multiple em.find/em.count calls per request: findWithDecryption(UserRole) to count users per role (count grows with users), findWithDecrypti… |
-| 78 | `GET /api/catalog/variants` | catalog | yes | makeCrudRoute with buildCustomFieldFiltersFromQuery + decorateCustomFields. Custom field resolution per variant can be 100+ items per page. … |
-| 75 | `GET /api/catalog/prices` | catalog | yes | resolveNormalizedQuantityForFilter (lines 67–139) runs on filter and in afterList hook: variant + product lookups, unit-conversion table sca… |
-| 72 | `GET /api/messages/types` | messages | no | Registry lookup via getAllMessageTypes() + JS transformation/map. Cost is in-memory only (not database), but the response is large (all mess… |
-| 70 | `GET /api/auth/sidebar/preferences` | auth | no | Multiple helper calls: loadSidebarPreference (em.findOne), loadRolesPayload (em.find(Role) + em.findOne RoleSidebarPreference per role), loa… |
-| 65 | `GET /api/auth/roles/acl` | auth | no | Simple em.findOne(RoleAcl) query but called with full validation chain: resolveIsSuperAdmin (rbacService.loadAcl), assertActorCanModifySuper… |
+| 10 | `GET /api/messages/unread-count` | polled every 5 s (`useMessagesPoll.ts`) | existing `crud:messages.message:*` tags | [10](./10-cache-messages-unread-count.md) |
+| 11 | `GET /api/notifications` (list) | polled every 5 s (`useNotificationsPoll.ts`) | TTL-only v1 (no command-bus writes) | [11](./11-cache-notifications-list.md) |
+| 12 | `GET /api/dictionaries/[dictionaryId]/entries` | every dictionary-backed custom-field select (`entities/api/definitions.ts:366`) | existing `crud:dictionaries.entry:*` tags | [12](./12-cache-dictionary-entries.md) |
+| 13 | `GET /api/currencies/options` | currency selects in pricing/order forms | existing `crud:currencies.currency:*` tags | [13](./13-cache-currencies-options.md) |
+| 14 | `GET /api/auth/roles` | admin roles page + role selects; N+1 per-role user counts | existing `crud:auth.role:*` + `crud:auth.user:*` tags | [14](./14-cache-auth-roles-list.md) |
+| 15 | `GET /api/auth/sidebar/preferences` | sidebar bootstrap | existing `nav:sidebar:*` tags (PUT already flushes them) | [15](./15-cache-sidebar-preferences.md) |
+| 16 | `GET /api/catalog/product-media` | product detail media | `crud:catalog.product:*:record:<id>` tag + TTL | [16](./16-cache-product-media.md) |
 
 ## Suggested rollout order
 
-1. **FR 03 `notifications/unread-count`** + **`messages/unread-count`** — polled badges, extreme request volume, tiny risk, short TTL. Biggest QPS reduction for least code.
-2. **FR 01 `catalog/categories`** + **FR 05 `dictionaries`** — read-mostly reference data, expensive hierarchy/inheritance compute, simple event-tag invalidation.
-3. **FR 02 `directory/organization-switcher`** + **FR 07 `dashboards/layout`** — bootstrap-critical, per-user scoped, invalidate on org/layout mutation.
-4. **FR 06 `catalog/products`** + **FR 08 `catalog/offers`** — enable `ENABLE_CRUD_API_CACHE` AND close the cross-resource (price/offer/category) invalidation gap into `catalog.product`. Highest payoff, highest care.
-5. **FR 04 `inbox_ops/proposals`** + **FR 09 `messages`** — encrypted-decryption-heavy lists, per-user scope.
+1. **FR 06** — enable `ENABLE_CRUD_API_CACHE` + `cacheAliases` fix. This is the keystone: most other FRs piggyback on `crud:*` flushes, which are live only when this flag is on.
+2. **FR 03 + FR 10 + FR 11** — polled badges/lists, extreme request volume, tiny risk, short TTL. Biggest QPS reduction for least code.
+3. **FR 01 + FR 12 + FR 13** — read-mostly reference data on existing `crud:*` tags, zero new flush wiring.
+4. **FR 02 + FR 07 + FR 15** — bootstrap-critical per-user payloads on existing `org-scope`/`rbac`/`nav:sidebar` tags.
+5. **FR 04 + FR 09 + FR 14 + FR 16** — remaining list/detail surfaces.
 
 > Each FR file contains: exact cache key shape, literal tag strings, a Trigger→Where→Tags invalidation table, an implementation checklist, risks/staleness window, and acceptance tests.

--- a/.ai/analysis/2026-06-08-cache-perf-frs/README.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/README.md
@@ -65,15 +65,15 @@ Tracked in GitHub (proposed in PR #2905):
 
 ## New candidates (round 2 — verified non-cached, invalidation piggybacks on existing tags)
 
-| # | Endpoint | Hotness | Invalidation source | FR file |
-|---|---|---|---|---|
-| 10 | `GET /api/messages/unread-count` | polled every 5 s (`useMessagesPoll.ts`) | existing `crud:messages.message:*` tags | [10](./10-cache-messages-unread-count.md) |
-| 11 | `GET /api/notifications` (list) | polled every 5 s (`useNotificationsPoll.ts`) | TTL-only v1 (no command-bus writes) | [11](./11-cache-notifications-list.md) |
-| 12 | `GET /api/dictionaries/[dictionaryId]/entries` | every dictionary-backed custom-field select (`entities/api/definitions.ts:366`) | existing `crud:dictionaries.entry:*` tags | [12](./12-cache-dictionary-entries.md) |
-| 13 | `GET /api/currencies/options` | currency selects in pricing/order forms | existing `crud:currencies.currency:*` tags | [13](./13-cache-currencies-options.md) |
-| 14 | `GET /api/auth/roles` | admin roles page + role selects; N+1 per-role user counts | existing `crud:auth.role:*` + `crud:auth.user:*` tags | [14](./14-cache-auth-roles-list.md) |
-| 15 | `GET /api/auth/sidebar/preferences` | sidebar bootstrap | existing `nav:sidebar:*` tags (PUT already flushes them) | [15](./15-cache-sidebar-preferences.md) |
-| 16 | `GET /api/catalog/product-media` | product detail media | `crud:catalog.product:*:record:<id>` tag + TTL | [16](./16-cache-product-media.md) |
+| # | Endpoint | Hotness | Invalidation source | Issue | FR file |
+|---|---|---|---|---|---|
+| 10 | `GET /api/messages/unread-count` | polled every 5 s (`useMessagesPoll.ts`) | existing `crud:messages.message:*` tags | #2915 | [10](./10-cache-messages-unread-count.md) |
+| 11 | `GET /api/notifications` (list) | polled every 5 s (`useNotificationsPoll.ts`) | TTL-only v1 (no command-bus writes) | #2916 | [11](./11-cache-notifications-list.md) |
+| 12 | `GET /api/dictionaries/[dictionaryId]/entries` | every dictionary-backed custom-field select (`entities/api/definitions.ts:366`) | existing `crud:dictionaries.entry:*` tags | #2917 | [12](./12-cache-dictionary-entries.md) |
+| 13 | `GET /api/currencies/options` | currency selects in pricing/order forms | existing `crud:currencies.currency:*` tags | #2918 | [13](./13-cache-currencies-options.md) |
+| 14 | `GET /api/auth/roles` | admin roles page + role selects; N+1 per-role user counts | existing `crud:auth.role:*` + `crud:auth.user:*` tags | #2919 | [14](./14-cache-auth-roles-list.md) |
+| 15 | `GET /api/auth/sidebar/preferences` | sidebar bootstrap | existing `nav:sidebar:*` tags (PUT already flushes them) | #2920 | [15](./15-cache-sidebar-preferences.md) |
+| 16 | `GET /api/catalog/product-media` | product detail media | `crud:catalog.product:*:record:<id>` tag + TTL | #2921 | [16](./16-cache-product-media.md) |
 
 ## Suggested rollout order
 

--- a/.ai/analysis/2026-06-08-cache-perf-frs/README.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/README.md
@@ -16,19 +16,21 @@
 1. **Manual cache on custom GET handlers** (bypass the factory cache) — most of the wins below.
 2. **Enable + harden the generic CRUD cache** for hot `makeCrudRoute` reads — turn on `ENABLE_CRUD_API_CACHE` and close cross-resource invalidation gaps (see FR 06 / 08).
 
-## FR issues (deep-analyzed, ready to file)
+## FR issues (deep-analyzed, filed)
 
-| # | ROI | Endpoint | Verdict | Class | FR file |
-|---|---|---|---|---|---|
-| 1 | 86 | `GET /api/catalog/categories` | strong-quick-win | Manual cache | [01-cache-catalog-categories-list.md](./01-cache-catalog-categories-list.md) |
-| 2 | 84 | `GET /api/directory/organization-switcher` | good | Manual cache | [02-cache-organization-switcher-menu.md](./02-cache-organization-switcher-menu.md) |
-| 3 | 82 | `GET /api/notifications/unread-count` | good | Manual cache | [03-cache-notifications-unread-count.md](./03-cache-notifications-unread-count.md) |
-| 4 | 82 | `GET /api/inbox_ops/proposals` | good | Manual cache | [04-cache-inbox-ops-proposals-list.md](./04-cache-inbox-ops-proposals-list.md) |
-| 5 | 82 | `GET /api/dictionaries` | good | Manual cache | [05-cache-dictionaries-list.md](./05-cache-dictionaries-list.md) |
-| 6 | 78 | `GET /api/catalog/products` | good | CRUD cache | [06-enable-and-fix-catalog-products-list-cache.md](./06-enable-and-fix-catalog-products-list-cache.md) |
-| 7 | 72 | `GET /api/dashboards/layout` | good | Manual cache | [07-cache-dashboards-layout-bootstrap.md](./07-cache-dashboards-layout-bootstrap.md) |
-| 8 | 72 | `GET /api/catalog/offers` | good | CRUD cache | [08-catalog-offers-decoration-cache.md](./08-catalog-offers-decoration-cache.md) |
-| 9 | 58 | `GET /api/messages` | good | Manual cache | [09-cache-messages-list-per-user.md](./09-cache-messages-list-per-user.md) |
+Tracked in GitHub (proposed in PR #2905):
+
+| # | ROI | Endpoint | Verdict | Class | Issue | FR file |
+|---|---|---|---|---|---|---|
+| 1 | 86 | `GET /api/catalog/categories` | strong-quick-win | Manual cache | #2906 | [01-cache-catalog-categories-list.md](./01-cache-catalog-categories-list.md) |
+| 2 | 84 | `GET /api/directory/organization-switcher` | good | Manual cache | #2907 | [02-cache-organization-switcher-menu.md](./02-cache-organization-switcher-menu.md) |
+| 3 | 82 | `GET /api/notifications/unread-count` | good | Manual cache | #2908 | [03-cache-notifications-unread-count.md](./03-cache-notifications-unread-count.md) |
+| 4 | 82 | `GET /api/inbox_ops/proposals` | good | Manual cache | #2909 | [04-cache-inbox-ops-proposals-list.md](./04-cache-inbox-ops-proposals-list.md) |
+| 5 | 82 | `GET /api/dictionaries` | good | Manual cache | #2910 | [05-cache-dictionaries-list.md](./05-cache-dictionaries-list.md) |
+| 6 | 78 | `GET /api/catalog/products` | good | CRUD cache | #2911 | [06-enable-and-fix-catalog-products-list-cache.md](./06-enable-and-fix-catalog-products-list-cache.md) |
+| 7 | 72 | `GET /api/dashboards/layout` | good | Manual cache | #2912 | [07-cache-dashboards-layout-bootstrap.md](./07-cache-dashboards-layout-bootstrap.md) |
+| 8 | 72 | `GET /api/catalog/offers` | good | CRUD cache | #2913 | [08-catalog-offers-decoration-cache.md](./08-catalog-offers-decoration-cache.md) |
+| 9 | 58 | `GET /api/messages` | good | Manual cache | #2914 | [09-cache-messages-list-per-user.md](./09-cache-messages-list-per-user.md) |
 
 ## Full candidate ranking (20 discovered; top 9 deep-dived above)
 

--- a/.ai/analysis/2026-06-08-cache-perf-frs/README.md
+++ b/.ai/analysis/2026-06-08-cache-perf-frs/README.md
@@ -1,0 +1,68 @@
+# Cache Performance — Feature Request Backlog
+
+> Generated 2026-06-08 by a multi-agent workflow (4 discovery lanes → 9 deep-dive agents).
+> Goal: highest-ROI API endpoints to cache **with tag-based invalidation** so data stays fresh. Quick wins, most-used read paths.
+
+## How caching works here (read first)
+
+- **Cache service**: `container.resolve('cache')` — API `get/set(key,val,{ttl,tags})/deleteByTags(tags[])`. No `getOrSet`; do manual get-then-set.
+- **Tenant scoping is mandatory**: wrap every `get`/`set`/`deleteByTags` in `runWithCacheTenant(tenantId, …)` from `@open-mercato/cache`. It namespaces keys+tags per tenant, so cross-tenant reads are impossible even when the literal key omits the tenant.
+- **Reference pattern to copy**: `packages/core/src/modules/customer_accounts/services/domainMappingService.ts` (get-then-set + ttl + tags, `deleteByTags` on every mutation, TTL as backstop).
+- **Invalidation timing**: fire `deleteByTags` **post-commit** (outside `withAtomicFlush`) — event subscribers and `emitCrudSideEffects` already run post-commit. Tags carry correctness; TTL is only a backstop for missed invalidations.
+- **Generic CRUD list cache already exists** (`packages/shared/src/lib/crud/factory.ts`) but is gated OFF behind env `ENABLE_CRUD_API_CACHE`. It only covers `makeCrudRoute` GETs and invalidates via collection/record tags from the command bus. **Custom GET handlers bypass it entirely** — those are the biggest manual-cache quick wins.
+
+## Two classes of work
+
+1. **Manual cache on custom GET handlers** (bypass the factory cache) — most of the wins below.
+2. **Enable + harden the generic CRUD cache** for hot `makeCrudRoute` reads — turn on `ENABLE_CRUD_API_CACHE` and close cross-resource invalidation gaps (see FR 06 / 08).
+
+## FR issues (deep-analyzed, ready to file)
+
+| # | ROI | Endpoint | Verdict | Class | FR file |
+|---|---|---|---|---|---|
+| 1 | 86 | `GET /api/catalog/categories` | strong-quick-win | Manual cache | [01-cache-catalog-categories-list.md](./01-cache-catalog-categories-list.md) |
+| 2 | 84 | `GET /api/directory/organization-switcher` | good | Manual cache | [02-cache-organization-switcher-menu.md](./02-cache-organization-switcher-menu.md) |
+| 3 | 82 | `GET /api/notifications/unread-count` | good | Manual cache | [03-cache-notifications-unread-count.md](./03-cache-notifications-unread-count.md) |
+| 4 | 82 | `GET /api/inbox_ops/proposals` | good | Manual cache | [04-cache-inbox-ops-proposals-list.md](./04-cache-inbox-ops-proposals-list.md) |
+| 5 | 82 | `GET /api/dictionaries` | good | Manual cache | [05-cache-dictionaries-list.md](./05-cache-dictionaries-list.md) |
+| 6 | 78 | `GET /api/catalog/products` | good | CRUD cache | [06-enable-and-fix-catalog-products-list-cache.md](./06-enable-and-fix-catalog-products-list-cache.md) |
+| 7 | 72 | `GET /api/dashboards/layout` | good | Manual cache | [07-cache-dashboards-layout-bootstrap.md](./07-cache-dashboards-layout-bootstrap.md) |
+| 8 | 72 | `GET /api/catalog/offers` | good | CRUD cache | [08-catalog-offers-decoration-cache.md](./08-catalog-offers-decoration-cache.md) |
+| 9 | 58 | `GET /api/messages` | good | Manual cache | [09-cache-messages-list-per-user.md](./09-cache-messages-list-per-user.md) |
+
+## Full candidate ranking (20 discovered; top 9 deep-dived above)
+
+Remaining candidates are pre-vetted but not yet written up — good follow-up backlog.
+
+| ROI | Endpoint | Module | makeCrudRoute? | Why it is a candidate |
+|---|---|---|---|---|
+| 92 ✅ FR | `GET /api/directory/organization-switcher` | directory | no | Heavy compute: em.find(Organization), em.find(Tenant), computeHierarchyForOrganizations (builds ancestor/descendant maps for each org), reso… |
+| 92 ✅ FR | `GET /api/catalog/products` | catalog | yes | Massive afterList enricher (decorateProductsAfterList, lines 351–741): parallel lookups of offers, channels, categories, tags, variants, pri… |
+| 92 ✅ FR | `GET /api/messages` | messages | no | 5-6 sequential/parallel queries: Kysely base query + findWithDecryption (Message entities with encryption overhead) + em.find (MessageObject… |
+| 88 ✅ FR | `GET /api/notifications/unread-count` | notifications | no | Single em.count(Notification) query, but the COUNT is executed on every request without batching or coalescing. Lightweight query but extrem… |
+| 88 ✅ FR | `GET /api/catalog/categories` | catalog | no | Custom GET (no makeCrudRoute): full hierarchy computation (computeHierarchyForCategories), tree-view node construction, custom field values … |
+| 88 ✅ FR | `GET /api/dashboards/layout` | dashboards | no | Custom GET: loadAllWidgets (dynamic imports of ~40+ dashboard widgets across all modules + Promise.all(widgetEntries.map...)), loadScopeLayo… |
+| 88 ✅ FR | `GET /api/inbox_ops/proposals` | inbox_ops | no | findAndCountWithDecryption (proposals with encryption overhead) + Promise.all parallel fetch of InboxEmail, InboxProposalAction, InboxDiscre… |
+| 85 ✅ FR | `GET /api/dictionaries` | dictionaries | no | Custom GET handler with em.find() to fetch all active dictionaries, org-scoped filtering, inheritance resolution (reads both org and parent-… |
+| 85 ✅ FR | `GET /api/catalog/offers` | catalog | yes | decorateOffersWithDetails (lines 84–337): Promise.all of products fetch, prices with priceKind populate, variant defaults. Then complex pric… |
+| 85 | `GET /api/messages/unread-count` | messages | no | Joins message_recipients table to messages with 6+ filter conditions (status, deleted_at, archived_at, organization scoping, tenant scoping)… |
+| 82 | `GET /api/dictionaries/[dictionaryId]/entries` | dictionaries | no | Custom handler: loadDictionary (em.findOne), findWithDecryption for all entries (encryption overhead), sortDictionaryEntries computation, ma… |
+| 82 | `GET /api/catalog/product-media` | catalog | no | Custom GET (not makeCrudRoute): findOne product scope check + find attachments. Lightweight but called at high frequency (product detail pag… |
+| 80 | `GET /api/currencies/options` | currencies | no | Custom GET: em.find with complex $or search filter (code + name), optional active/inactive filter, limit loop, response mapping to options f… |
+| 80 | `GET /api/notifications` | notifications | no | em.find (main query) + em.count (separate count query, 2 ORM calls). Filter applied in code requires both queries to run before filtering. F… |
+| 78 | `GET /api/auth/roles` | auth | no | Multiple em.find/em.count calls per request: findWithDecryption(UserRole) to count users per role (count grows with users), findWithDecrypti… |
+| 78 | `GET /api/catalog/variants` | catalog | yes | makeCrudRoute with buildCustomFieldFiltersFromQuery + decorateCustomFields. Custom field resolution per variant can be 100+ items per page. … |
+| 75 | `GET /api/catalog/prices` | catalog | yes | resolveNormalizedQuantityForFilter (lines 67–139) runs on filter and in afterList hook: variant + product lookups, unit-conversion table sca… |
+| 72 | `GET /api/messages/types` | messages | no | Registry lookup via getAllMessageTypes() + JS transformation/map. Cost is in-memory only (not database), but the response is large (all mess… |
+| 70 | `GET /api/auth/sidebar/preferences` | auth | no | Multiple helper calls: loadSidebarPreference (em.findOne), loadRolesPayload (em.find(Role) + em.findOne RoleSidebarPreference per role), loa… |
+| 65 | `GET /api/auth/roles/acl` | auth | no | Simple em.findOne(RoleAcl) query but called with full validation chain: resolveIsSuperAdmin (rbacService.loadAcl), assertActorCanModifySuper… |
+
+## Suggested rollout order
+
+1. **FR 03 `notifications/unread-count`** + **`messages/unread-count`** — polled badges, extreme request volume, tiny risk, short TTL. Biggest QPS reduction for least code.
+2. **FR 01 `catalog/categories`** + **FR 05 `dictionaries`** — read-mostly reference data, expensive hierarchy/inheritance compute, simple event-tag invalidation.
+3. **FR 02 `directory/organization-switcher`** + **FR 07 `dashboards/layout`** — bootstrap-critical, per-user scoped, invalidate on org/layout mutation.
+4. **FR 06 `catalog/products`** + **FR 08 `catalog/offers`** — enable `ENABLE_CRUD_API_CACHE` AND close the cross-resource (price/offer/category) invalidation gap into `catalog.product`. Highest payoff, highest care.
+5. **FR 04 `inbox_ops/proposals`** + **FR 09 `messages`** — encrypted-decryption-heavy lists, per-user scope.
+
+> Each FR file contains: exact cache key shape, literal tag strings, a Trigger→Where→Tags invalidation table, an implementation checklist, risks/staleness window, and acceptance tests.


### PR DESCRIPTION
## Summary

Multi-agent analysis of all **444 API routes** to find the highest-ROI read endpoints to cache **with tag-based invalidation** (quick wins, most-used paths, data always fresh). Adds **16 Feature Request specs** + an index README under `.ai/analysis/2026-06-08-cache-perf-frs/`.

**Docs/analysis only — no application code changed.**

## Revision (2026-06-09)

The backlog was reworked around a single doctrine: **manual caches must connect to tags the platform already flushes** (`crud:*` via the command bus / `makeCrudRoute`, `org-scope:*`, `rbac:*`, `nav:sidebar:*`, `inbox_ops:counts:*`) instead of adding bespoke subscribers and per-write flush calls. Key outcomes:

- **Safety pass on non-invalidation risks**: documented that `invalidateCrudCache` no-ops while `ENABLE_CRUD_API_CACHE` is off (so every `crud:*`-tag piggyback is gated on `isCrudCacheEnabled()`), the tenant-namespace matching rules (tags are SHA1-hashed per tenant; subscriber/worker flushes must wrap in `runWithCacheTenant`), org-axis flush mismatches, and mandatory TTL backstops. See README → "Invalidation doctrine".
- **Overlap audit vs existing caches**: FR 05 (`/api/dictionaries`) demoted — the hot dictionary surface is already cached in the customers module; FR 08 (offers decoration cache) rescoped into FR 06's `cacheAliases` mechanism; `catalog/variants`+`prices` and the already-cached `auth/admin/nav` + `entities/definitions` disqualified.
- **7 new round-2 FRs (10–16)** — verified non-cached endpoints whose invalidation rides existing tags with zero or near-zero new wiring.
- FR 06 (`ENABLE_CRUD_API_CACHE` enablement) is the **keystone** — it must roll out first since most FRs depend on the `crud:*` flushes it activates.

## FRs

| # | ROI | Endpoint | Verdict / invalidation source | Issue |
|---|-----|----------|-------------------------------|-------|
| 01 | 86 | `GET /api/catalog/categories` | existing `crud:catalog.category:*` tags | #2906 |
| 02 | 84 | `GET /api/directory/organization-switcher` | existing `org-scope:*` + `rbac:user:*` tags | #2907 |
| 03 | 82 | `GET /api/notifications/unread-count` | TTL-only v1 (no command-bus writes) | #2908 |
| 04 | 82 | `GET /api/inbox_ops/proposals` | existing `inbox_ops:counts:<T>` tag | #2909 |
| 05 | 82 | `GET /api/dictionaries` | **skip — overlaps existing cache** (recommend close) | #2910 |
| 06 | 78 | `GET /api/catalog/products` | **keystone**: enable CRUD cache + `cacheAliases` | #2911 |
| 07 | 72 | `GET /api/dashboards/layout` | module-local flushes + existing `rbac:user:*` tag | #2912 |
| 08 | 72 | `GET /api/catalog/offers` | **rescoped** into #2911 (`cacheAliases`) | #2913 |
| 09 | 58 | `GET /api/messages` | existing `crud:messages.message:*` tags | #2914 |
| 10 | — | `GET /api/messages/unread-count` (5 s poll) | existing `crud:messages.message:*` tags | #2915 |
| 11 | — | `GET /api/notifications` list (5 s poll) | TTL-only v1 | #2916 |
| 12 | — | `GET /api/dictionaries/[id]/entries` (CF selects) | existing `crud:dictionaries.entry:*` tags | #2917 |
| 13 | — | `GET /api/currencies/options` | existing `crud:currencies.currency:*` tags | #2918 |
| 14 | — | `GET /api/auth/roles` | existing `crud:auth.role/user:*` + `rbac:tenant:*` tags | #2919 |
| 15 | — | `GET /api/auth/sidebar/preferences` | existing `nav:sidebar:*` tags (PUT already flushes) | #2920 |
| 16 | — | `GET /api/catalog/product-media` | `crud:catalog.product:*:record:<id>` tag + short TTL | #2921 |

Each spec contains the exact cache key shape, literal tag strings, a Trigger → Where → Tags invalidation table (post-commit, tenant-scoped), TTL backstop, a **double-checked "Safety / non-invalidation risks" section**, and acceptance tests. The README carries the shared invalidation doctrine and rollout order.

## Test plan

N/A — documentation/analysis only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Tracking issues

These specs are filed as GitHub issues (do **not** auto-close on merge — they track the implementation work):

- [ ] #2906 — `catalog/categories` (crud-tag piggyback)
- [ ] #2907 — `directory/organization-switcher` (org-scope + rbac tags)
- [ ] #2908 — `notifications/unread-count` (TTL-only v1)
- [ ] #2909 — `inbox_ops/proposals` (reuse counts tag)
- [ ] #2910 — `dictionaries` (**demoted — recommend close**)
- [ ] #2911 — `catalog/products` — **keystone**: enable CRUD cache + `cacheAliases` (absorbs #2913 v1)
- [ ] #2912 — `dashboards/layout`
- [ ] #2913 — `catalog/offers` (**rescoped** into #2911; decoration cache deferred)
- [ ] #2914 — `messages` (crud-tag piggyback)
- [ ] #2915 — `messages/unread-count` (round 2)
- [ ] #2916 — `notifications` list (round 2)
- [ ] #2917 — `dictionaries/[id]/entries` (round 2)
- [ ] #2918 — `currencies/options` (round 2)
- [ ] #2919 — `auth/roles` (round 2)
- [ ] #2920 — `auth/sidebar/preferences` (round 2)
- [ ] #2921 — `catalog/product-media` (round 2)
