### PR TITLE
fix(directory): make organization Tenant field read-only on edit

### DIFF
--- a/packages/core/src/modules/directory/backend/directory/organizations/[id]/edit/page.tsx
+++ b/packages/core/src/modules/directory/backend/directory/organizations/[id]/edit/page.tsx
@@ -4,7 +4,6 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { extractCustomFieldEntries } from '@open-mercato/shared/lib/crud/custom-fields-client'
 import { E } from '#generated/entities.ids.generated'
 import { OrganizationSelect } from '@open-mercato/core/modules/directory/components/OrganizationSelect'
-import { TenantSelect } from '@open-mercato/core/modules/directory/components/TenantSelect'
 import {
   buildOrganizationTreeOptions,
   type OrganizationTreeNode,
@@ -49,6 +48,7 @@ export default function EditOrganizationPage({ params }: { params?: { id?: strin
   const [initialValues, setInitialValues] = React.useState<Record<string, unknown> | null>(null)
   const [pathLabel, setPathLabel] = React.useState<string>('')
   const [tenantId, setTenantId] = React.useState<string | null>(null)
+  const [tenantName, setTenantName] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
   const [isNotFound, setIsNotFound] = React.useState(false)
@@ -130,6 +130,7 @@ export default function EditOrganizationPage({ params }: { params?: { id?: strin
         }
         const resolvedTenantId = record.tenantId || null
         setTenantId(resolvedTenantId)
+        setTenantName(record.tenantName ?? null)
         const baseTree = await loadParentTree(resolvedTenantId, record.descendantIds ?? [])
         const fullTree = buildOrganizationTreeOptions(baseTree)
         const nodeMap = new Map(fullTree.map((opt) => [opt.value, opt]))
@@ -196,18 +197,13 @@ export default function EditOrganizationPage({ params }: { params?: { id?: strin
         id: 'tenantId',
         label: t('directory.organizations.form.field.tenant', 'Tenant'),
         type: 'custom',
-        component: ({ value, setValue }) => (
-          <TenantSelect
-            id="tenantId"
-            value={typeof value === 'string' ? value : tenantId}
-            onChange={(next) => {
-              const normalized = next ?? null
-              setTenantId(normalized)
-              setValue(normalized)
-            }}
-            includeEmptyOption={false}
-            className="w-full h-9 rounded border px-2 text-sm"
-          />
+        component: () => (
+          <div>
+            <p className="text-sm">{tenantName ?? '—'}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t('directory.organizations.form.field.tenant.readonly', 'Tenant cannot be changed for an existing organization.')}
+            </p>
+          </div>
         ),
       } as CrudField,
     ] : []),
@@ -257,7 +253,7 @@ export default function EditOrganizationPage({ params }: { params?: { id?: strin
       },
     },
     { id: 'isActive', label: t('directory.organizations.form.field.isActive', 'Active'), type: 'checkbox' },
-  ], [actorIsSuperAdmin, childSummary, parentTree, t, tenantId])
+  ], [actorIsSuperAdmin, childSummary, parentTree, t, tenantId, tenantName])
 
   const detailFields = React.useMemo(() => (
     actorIsSuperAdmin

--- a/packages/core/src/modules/directory/i18n/de.json
+++ b/packages/core/src/modules/directory/i18n/de.json
@@ -31,6 +31,7 @@
   "directory.organizations.form.field.slug": "Slug",
   "directory.organizations.form.field.slug.description": "URL-sicherer Bezeichner für das Kundenportal (Kleinbuchstaben, Zahlen, Bindestriche, Unterstriche).",
   "directory.organizations.form.field.tenant": "Mandant",
+  "directory.organizations.form.field.tenant.readonly": "Der Mandant kann für eine bestehende Organisation nicht geändert werden.",
   "directory.organizations.form.group.customFields": "Benutzerdefinierte Daten",
   "directory.organizations.form.group.details": "Details",
   "directory.organizations.form.loading": "Organisation wird geladen...",

--- a/packages/core/src/modules/directory/i18n/en.json
+++ b/packages/core/src/modules/directory/i18n/en.json
@@ -31,6 +31,7 @@
   "directory.organizations.form.field.slug": "Slug",
   "directory.organizations.form.field.slug.description": "URL-safe identifier used for the customer portal (lowercase letters, numbers, hyphens, underscores).",
   "directory.organizations.form.field.tenant": "Tenant",
+  "directory.organizations.form.field.tenant.readonly": "Tenant cannot be changed for an existing organization.",
   "directory.organizations.form.group.customFields": "Custom Data",
   "directory.organizations.form.group.details": "Details",
   "directory.organizations.form.loading": "Loading organization...",

--- a/packages/core/src/modules/directory/i18n/es.json
+++ b/packages/core/src/modules/directory/i18n/es.json
@@ -31,6 +31,7 @@
   "directory.organizations.form.field.slug": "Slug",
   "directory.organizations.form.field.slug.description": "Identificador seguro para URL usado en el portal de clientes (minúsculas, números, guiones, guiones bajos).",
   "directory.organizations.form.field.tenant": "Inquilino",
+  "directory.organizations.form.field.tenant.readonly": "El inquilino no se puede cambiar para una organización existente.",
   "directory.organizations.form.group.customFields": "Datos personalizados",
   "directory.organizations.form.group.details": "Detalles",
   "directory.organizations.form.loading": "Cargando organización...",

--- a/packages/core/src/modules/directory/i18n/pl.json
+++ b/packages/core/src/modules/directory/i18n/pl.json
@@ -31,6 +31,7 @@
   "directory.organizations.form.field.slug": "Identyfikator URL",
   "directory.organizations.form.field.slug.description": "Identyfikator używany w adresie portalu klienta (małe litery, cyfry, myślniki, podkreślenia).",
   "directory.organizations.form.field.tenant": "Najemca",
+  "directory.organizations.form.field.tenant.readonly": "Najemcy nie można zmienić dla istniejącej organizacji.",
   "directory.organizations.form.group.customFields": "Dane niestandardowe",
   "directory.organizations.form.group.details": "Szczegóły",
   "directory.organizations.form.loading": "Ładowanie organizacji...",


### PR DESCRIPTION
### <!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

 For an existing organization, the edit form showed superadmins an **editable Tenant selector** (`<TenantSelect>`), implying
  the org's tenant could be changed. But the `directory.organizations.update` command never reassigns `entity.tenant`, so
  picking a different tenant and saving silently did nothing — the save reported success while the org stayed in its original
  tenant (#1217).

  Per the maintainer's suggestion on the issue ("just disable tenant editing"), this makes the Tenant field **read-only** on
  the edit page: it now shows the current tenant name plus a short note, instead of an editable dropdown. The create page
  (where `TenantSelect` works correctly) is untouched. Moving an organization across tenants is a heavy, isolation-breaking
  data operation, not a simple field edit — so the right fix for this "misleading UI" bug is to stop offering the affordance.

  Because the field no longer mutates `values.tenantId`, `submitUpdateOrganization` keeps sending the original tenant
  (existing behavior), so no backend change is needed.

  ## Before / After
  
<img width="1728" height="1117" alt="before" src="https://github.com/user-attachments/assets/8cf2b6ff-455b-4df6-bd05-dddd4d76f73d" />


  **After:** 

<img width="1497" height="649" alt="after" src="https://github.com/user-attachments/assets/d676a0c7-9e67-4f8d-9b0b-85abc74b9127" />



  ## Changes

  - `directory/.../organizations/[id]/edit/page.tsx`: render the Tenant field read-only (current tenant name from the
  manage-view `tenantName` + helper note); drop the now-unused `TenantSelect` import.
  - `directory/i18n/{en,pl,de,es}.json`: add `directory.organizations.form.field.tenant.readonly`.

  ## Specification

  **Does a spec exist for this feature/module?**
  - [ ] Yes
  - [ ] No (created a new spec)
  - [x] N/A (minor change, no spec needed)

  **Spec file path:**
  N/A

  ## Testing

  - `yarn workspace @open-mercato/core build` → built successfully (no unused-import/type errors)
  - `yarn workspace @open-mercato/core test edit-submit` → 2/2 pass (submit still sends the original `tenantId`)
  - `yarn i18n:check` → passes (new key present in all 4 locales, used via `t()`, no hardcoded strings)
  - Manual (before/after above): as a superadmin, the Tenant field on the org edit page is now read-only text + note instead
  of an editable dropdown.

  ## Checklist

  - [x] This pull request targets `develop`.
  - [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
  - [x] I updated documentation, locales, or generators if the change requires it. (Added the new i18n key to all 4 locales.)
  - [ ] I added or adjusted tests that cover the change. — The change is a read-only render of a field inside `CrudForm`
  (mocked to `null` in the page's unit test), so there is no clean unit seam without un-mocking `CrudForm`; verified via
  build, i18n checks, the existing `edit-submit` test, and the manual before/after above.
  - [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). —
  Not required: UI-only read-only render, no new flow logic; the submit path is unchanged and already covered by
  `edit-submit`.
  - [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A.

  ### Design System Compliance
  - [x] No hardcoded status colors — uses the `text-muted-foreground` token.
  - [x] No arbitrary text sizes — uses `text-sm` / `text-xs`.
  - [x] Empty state handled — falls back to `—` when no tenant name.
  - [x] Loading state handled for async pages — unchanged (page already handles loading).
  - [x] `aria-label` on all icon-only buttons — no icon-only buttons added.
  - [x] Uses existing DS components — matches the file's existing read-only field pattern; no custom replacements.

  ## Linked issues

  Fixes #1217