### PR TITLE
perf(dev): replace eager react-markdown in AttachmentContentPreview with lazy MarkdownContent (#2850)

### DIFF
--- a/packages/core/src/modules/attachments/components/AttachmentContentPreview.tsx
+++ b/packages/core/src/modules/attachments/components/AttachmentContentPreview.tsx
@@ -93,9 +93,12 @@ export function AttachmentContentPreview({
           id={previewPanelId}
           aria-labelledby={previewTabId}
           data-testid="markdown-preview"
-          className="text-sm text-muted-foreground [&>*]:mb-2 [&>*:last-child]:mb-0 [&_ul]:ml-4 [&_ul]:list-disc [&_ol]:ml-4 [&_ol]:list-decimal [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_pre]:rounded-md [&_pre]:bg-muted [&_pre]:p-3 [&_pre]:text-xs"
         >
-          <MarkdownContent body={text} format="markdown" />
+          <MarkdownContent
+            body={text}
+            format="markdown"
+            className="text-sm text-muted-foreground [&>*]:mb-2 [&>*:last-child]:mb-0 [&_ul]:ml-4 [&_ul]:list-disc [&_ol]:ml-4 [&_ol]:list-decimal [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_pre]:rounded-md [&_pre]:bg-muted [&_pre]:p-3 [&_pre]:text-xs"
+          />
         </div>
       )}
 

--- a/packages/core/src/modules/attachments/components/AttachmentContentPreview.tsx
+++ b/packages/core/src/modules/attachments/components/AttachmentContentPreview.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
-import type { PluggableList } from 'unified'
+import { MarkdownContent } from '@open-mercato/ui/backend/markdown'
 import { Button } from '@open-mercato/ui/primitives/button'
 
 type Props = {
@@ -26,7 +24,6 @@ export function AttachmentContentPreview({
   const [expanded, setExpanded] = React.useState(false)
   const [tab, setTab] = React.useState<'source' | 'preview'>('source')
   const text = (content ?? '').trim()
-  const markdownPlugins = React.useMemo<PluggableList>(() => [remarkGfm], [])
 
   // ARIA IDs for accessibility
   const sourceTabId = 'attachment-content-preview-tab-source'
@@ -98,7 +95,7 @@ export function AttachmentContentPreview({
           data-testid="markdown-preview"
           className="text-sm text-muted-foreground [&>*]:mb-2 [&>*:last-child]:mb-0 [&_ul]:ml-4 [&_ul]:list-disc [&_ol]:ml-4 [&_ol]:list-decimal [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_pre]:rounded-md [&_pre]:bg-muted [&_pre]:p-3 [&_pre]:text-xs"
         >
-          <ReactMarkdown remarkPlugins={markdownPlugins}>{text}</ReactMarkdown>
+          <MarkdownContent body={text} format="markdown" />
         </div>
       )}
 

--- a/packages/core/src/modules/attachments/components/__tests__/AttachmentContentPreview.test.tsx
+++ b/packages/core/src/modules/attachments/components/__tests__/AttachmentContentPreview.test.tsx
@@ -1,18 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-jest.mock('react-markdown', () => ({
-  __esModule: true,
-  default: (props: any) => <div data-testid="markdown-preview">{props.children}</div>,
-}))
-
-jest.mock('remark-gfm', () => ({
-  __esModule: true,
-  default: 'remark-gfm',
-}))
-
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { AttachmentContentPreview } from '../AttachmentContentPreview'
+
 describe('AttachmentContentPreview', () => {
   it('shows placeholder when content is missing', () => {
     render(<AttachmentContentPreview content={null} />)
@@ -45,11 +36,13 @@ describe('AttachmentContentPreview', () => {
     expect(preview.textContent).toContain(longText.trim())
   })
 
-  it('renders markdown preview when tab is selected', () => {
+  it('renders markdown preview when tab is selected', async () => {
     const { container } = render(<AttachmentContentPreview content="**bold** text" />)
     const previewTab = screen.getByRole('tab', { name: /preview/i })
     fireEvent.click(previewTab)
     expect(previewTab).toHaveAttribute('aria-selected', 'true')
-    expect(container.querySelector('[data-testid="markdown-preview"]')?.textContent).toContain('bold')
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="markdown-preview"]')?.textContent).toContain('bold')
+    })
   })
 })

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -74,6 +74,10 @@
       "types": "./src/backend/forms/index.ts",
       "default": "./dist/backend/forms/index.js"
     },
+    "./backend/markdown": {
+      "types": "./src/backend/markdown/index.ts",
+      "default": "./dist/backend/markdown/index.js"
+    },
     "./backend/messages": {
       "types": "./src/backend/messages/index.ts",
       "default": "./dist/backend/messages/index.js"

--- a/packages/ui/src/backend/__tests__/lazy-heavy-libraries.test.ts
+++ b/packages/ui/src/backend/__tests__/lazy-heavy-libraries.test.ts
@@ -123,4 +123,12 @@ describe('heavy libraries are lazy-loaded', () => {
     const source = read('packages/ui/src/backend/schedule/ScheduleCalendar.tsx')
     expect(source).toMatch(/import\s+['"]react-big-calendar\/lib\/css\/react-big-calendar\.css['"]/)
   })
+
+  it('AttachmentContentPreview does not statically import react-markdown or remark-gfm', () => {
+    const source = read(
+      'packages/core/src/modules/attachments/components/AttachmentContentPreview.tsx',
+    )
+    expect(source).not.toMatch(/from\s+['"]react-markdown['"]/)
+    expect(source).not.toMatch(/from\s+['"]remark-gfm['"]/)
+  })
 })


### PR DESCRIPTION
## Summary

`AttachmentContentPreview` imported `react-markdown` and `remark-gfm` statically, pulling them into the synchronous module graph. This PR replaces those imports with the already-lazy `MarkdownContent` wrapper from `@open-mercato/ui/backend/markdown`, which defers the `react-markdown` load to a dynamic `import()` the first time the Preview tab is opened.

## Changes

- Replace `ReactMarkdown` + `remark-gfm` static imports in `AttachmentContentPreview` with `MarkdownContent` from `@open-mercato/ui/backend/markdown`
- Remove `PluggableList` type import and `markdownPlugins` useMemo — no longer needed
- Remove `jest.mock('react-markdown')` and `jest.mock('remark-gfm')` stubs from the component test; the stub now lives inside `MarkdownContent`'s own test environment
- Wrap the async markdown render assertion in `waitFor`
- Add guard test asserting `AttachmentContentPreview` does not statically import `react-markdown` or `remark-gfm`

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

## Testing

- `yarn workspace @open-mercato/core test -- AttachmentContentPreview` — 6 tests pass
- `yarn workspace @open-mercato/ui test -- lazy-heavy-libraries` — 18 tests pass

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Closes #2850 (partial — candidate #2 of 5)