### PR TITLE
fix: 2939 deals list misroute

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-2939-deals-list-stray-doc-rows.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-2939-deals-list-stray-doc-rows.spec.ts
@@ -1,22 +1,28 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 import { createDealFixture, deleteEntityIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
 import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
 import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+import { withClient } from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures';
 
 /**
  * TC-CRM-2939: deals list keeps reading customer_deals when stray doc-storage rows exist
  * Source: https://github.com/open-mercato/open-mercato/issues/2939
  *
  * `customers:customer_deal` is a table-backed ORM entity that is ALSO declared as a
- * module custom entity in ce.ts (for its custom-field set). Writing a record through
- * the generic entities records API stores a doc in `custom_entities_storage` for that
- * entity type. Before the fix, HybridQueryEngine re-classified the whole entity type as
- * doc-storage-backed as soon as one such row existed, so `/api/customers/deals` (list,
- * kanban lanes, MCP) returned only the stray doc rows while the aggregate endpoint kept
+ * module custom entity in ce.ts (for its custom-field set). Before the fix, a single
+ * `custom_entities_storage` row for that entity type made HybridQueryEngine re-classify
+ * the whole entity type as doc-storage-backed, so `/api/customers/deals` (list, kanban
+ * lanes, MCP) returned only the stray doc rows while the aggregate endpoint kept
  * counting the real table rows.
+ *
+ * The write path is now gated too (#2942 hardening): `/api/entities/records` rejects
+ * system entity ids, so the stray row is seeded directly in the database — exactly the
+ * state of an environment poisoned before the gate existed (e.g. on v0.6.4). The engine
+ * guard must keep the deals list on the base table even then.
  */
 test.describe('TC-CRM-2939: deals list ignores stray doc-storage rows', () => {
-  test('GET /api/customers/deals returns table-backed deals despite custom_entities_storage rows', async ({ request }) => {
+  test('records API rejects system entity writes and the deals list stays table-backed despite legacy stray rows', async ({ request }) => {
     let token: string | null = null;
     let dealId: string | null = null;
     let strayRecordId: string | null = null;
@@ -26,17 +32,29 @@ test.describe('TC-CRM-2939: deals list ignores stray doc-storage rows', () => {
       token = await getAuthToken(request);
       dealId = await createDealFixture(request, token, { title: dealTitle });
 
-      const strayResponse = await apiRequest(request, 'POST', '/api/entities/records', {
+      // 1) The poison path is closed: generic record writes for a table-backed
+      //    system entity are rejected outright.
+      const strayWrite = await apiRequest(request, 'POST', '/api/entities/records', {
         token,
         data: {
           entityId: 'customers:customer_deal',
           values: { competitive_risk: 'high' },
         },
       });
-      expect(strayResponse.status(), `POST /api/entities/records returned ${strayResponse.status()}`).toBe(200);
-      const strayPayload = (await readJsonSafe(strayResponse)) as { item?: { recordId?: string } } | null;
-      strayRecordId = strayPayload?.item?.recordId ?? null;
-      expect(strayRecordId, 'Expected stray doc record id in records response').toBeTruthy();
+      expect(strayWrite.status(), `POST /api/entities/records for customers:customer_deal returned ${strayWrite.status()}`).toBe(400);
+      const strayWriteBody = (await readJsonSafe(strayWrite)) as { code?: string } | null;
+      expect(strayWriteBody?.code, 'system-entity rejection code').toBe('system_entity_records_blocked');
+
+      // 2) Defense in depth for environments poisoned BEFORE the gate existed:
+      //    seed the stray doc row directly and assert the deals list ignores it.
+      strayRecordId = randomUUID();
+      await withClient(async (client) => {
+        await client.query(
+          `INSERT INTO custom_entities_storage (entity_type, entity_id, organization_id, tenant_id, doc, created_at, updated_at)
+           VALUES ($1, $2, NULL, NULL, $3::jsonb, now(), now())`,
+          ['customers:customer_deal', strayRecordId, JSON.stringify({ id: strayRecordId, title: 'TC-CRM-2939 stray doc row' })],
+        );
+      });
 
       const listResponse = await apiRequest(request, 'GET', '/api/customers/deals?pageSize=100&sortField=createdAt&sortDir=desc', { token });
       expect(listResponse.status(), `GET /api/customers/deals returned ${listResponse.status()}`).toBe(200);
@@ -48,8 +66,10 @@ test.describe('TC-CRM-2939: deals list ignores stray doc-storage rows', () => {
       expect(listedIds, 'table-backed deal must stay visible in the deals list').toContain(dealId);
       expect(listedIds, 'stray doc-storage record must not surface in the deals list').not.toContain(strayRecordId);
     } finally {
-      if (token && strayRecordId) {
-        await apiRequest(request, 'DELETE', `/api/entities/records?entityId=customers:customer_deal&recordId=${strayRecordId}`, { token }).catch(() => undefined);
+      if (strayRecordId) {
+        await withClient(async (client) => {
+          await client.query('DELETE FROM custom_entities_storage WHERE entity_id = $1 AND entity_type = $2', [strayRecordId, 'customers:customer_deal']);
+        }).catch(() => undefined);
       }
       await deleteEntityIfExists(request, token, '/api/customers/deals', dealId);
     }

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-2939-deals-list-stray-doc-rows.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-2939-deals-list-stray-doc-rows.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+import { createDealFixture, deleteEntityIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+/**
+ * TC-CRM-2939: deals list keeps reading customer_deals when stray doc-storage rows exist
+ * Source: https://github.com/open-mercato/open-mercato/issues/2939
+ *
+ * `customers:customer_deal` is a table-backed ORM entity that is ALSO declared as a
+ * module custom entity in ce.ts (for its custom-field set). Writing a record through
+ * the generic entities records API stores a doc in `custom_entities_storage` for that
+ * entity type. Before the fix, HybridQueryEngine re-classified the whole entity type as
+ * doc-storage-backed as soon as one such row existed, so `/api/customers/deals` (list,
+ * kanban lanes, MCP) returned only the stray doc rows while the aggregate endpoint kept
+ * counting the real table rows.
+ */
+test.describe('TC-CRM-2939: deals list ignores stray doc-storage rows', () => {
+  test('GET /api/customers/deals returns table-backed deals despite custom_entities_storage rows', async ({ request }) => {
+    let token: string | null = null;
+    let dealId: string | null = null;
+    let strayRecordId: string | null = null;
+    const dealTitle = `QA TC-CRM-2939 Deal ${Date.now()}`;
+
+    try {
+      token = await getAuthToken(request);
+      dealId = await createDealFixture(request, token, { title: dealTitle });
+
+      const strayResponse = await apiRequest(request, 'POST', '/api/entities/records', {
+        token,
+        data: {
+          entityId: 'customers:customer_deal',
+          values: { competitive_risk: 'high' },
+        },
+      });
+      expect(strayResponse.status(), `POST /api/entities/records returned ${strayResponse.status()}`).toBe(200);
+      const strayPayload = (await readJsonSafe(strayResponse)) as { item?: { recordId?: string } } | null;
+      strayRecordId = strayPayload?.item?.recordId ?? null;
+      expect(strayRecordId, 'Expected stray doc record id in records response').toBeTruthy();
+
+      const listResponse = await apiRequest(request, 'GET', '/api/customers/deals?pageSize=100&sortField=createdAt&sortDir=desc', { token });
+      expect(listResponse.status(), `GET /api/customers/deals returned ${listResponse.status()}`).toBe(200);
+      const listPayload = (await readJsonSafe(listResponse)) as { items?: Array<{ id?: string }>; total?: number } | null;
+      const listedIds = (listPayload?.items ?? [])
+        .map((item) => item?.id)
+        .filter((value): value is string => typeof value === 'string');
+
+      expect(listedIds, 'table-backed deal must stay visible in the deals list').toContain(dealId);
+      expect(listedIds, 'stray doc-storage record must not surface in the deals list').not.toContain(strayRecordId);
+    } finally {
+      if (token && strayRecordId) {
+        await apiRequest(request, 'DELETE', `/api/entities/records?entityId=customers:customer_deal&recordId=${strayRecordId}`, { token }).catch(() => undefined);
+      }
+      await deleteEntityIfExists(request, token, '/api/customers/deals', dealId);
+    }
+  });
+});

--- a/packages/core/src/modules/entities/__integration__/TC-ENT-2055-RECORD-READBACK.spec.ts
+++ b/packages/core/src/modules/entities/__integration__/TC-ENT-2055-RECORD-READBACK.spec.ts
@@ -2,37 +2,51 @@ import { expect, test, type APIRequestContext } from '@playwright/test';
 import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
 
 /**
- * TC-ENT-2055-RECORD-READBACK: a custom-entity record written through
- * `/api/entities/records` MUST be readable back with all of its values —
- * including multi-select (array) custom fields.
+ * TC-ENT-2055-RECORD-READBACK: the records surface serves CUSTOM entities only,
+ * and a custom-entity record written through `/api/entities/records` MUST be
+ * readable back with all of its values — including multi-select (array) fields.
  *
- * Root cause this guards (found while QA-sweeping CrudForm persistence for
- * #2333/#2055): the records GET reads through the query engine, which only
- * routed an entity to the `custom_entities_storage` (doc-storage) reader when
- * the entity had an ACTIVE row in `custom_entities`. A module-declared custom
- * entity whose id is also a frozen system id (e.g. `example:todo`, registered
- * in entities.ids.generated.ts) is NEVER registered in `custom_entities`
- * (install treats a system id as non-registrable), yet POST/PUT still write its
- * records to `custom_entities_storage`. So the write returned 200 but the GET
- * routed to the empty ORM/index path → list + by-id both returned total:0 and
- * the edit form loaded blank (multi-select showed nothing selected).
+ * History: the original #2055 fix made reads follow writes for ids that landed in
+ * `custom_entities_storage` without a `custom_entities` registration. That
+ * classification-by-storage-rows let a stray doc record written for a TABLE-backed
+ * system id (e.g. `customers:customer_deal`) reroute the whole module's list reads
+ * to doc storage (#2939). The hardened contract (#2942): ids backed by a registered
+ * ORM table are rejected by `/api/entities/records` outright — doc storage is for
+ * custom entities only — while genuine custom entities keep full read/write symmetry.
  *
- * The fix makes read/write symmetric: `HybridQueryEngine.isCustomEntity` and the
- * records route both treat an entity as doc-storage-backed when it has rows in
- * `custom_entities_storage`, even without a `custom_entities` registration.
+ * Part 1 — system entities are rejected (400, code `system_entity_records_blocked`)
+ * on both read and write: `example:todo` (ORM table `todos`) and
+ * `customers:customer_deal` (ORM table `customer_deals`).
+ *
+ * Part 2 — round-trip parity on a runtime-defined custom entity: integer,
+ * single-select, boolean, multi tags, multi-select listbox (the field that
+ * displayed empty pre-#2055), and multiline values all read back with bare keys.
  *
  * Endpoints covered:
- *   - POST   /api/entities/records                         (create)
- *   - GET    /api/entities/records?entityId=               (list — must include it)
- *   - GET    /api/entities/records?entityId=&id=<recordId> (by-id — edit-form read)
- *   - DELETE /api/entities/records?entityId=&recordId=     (cleanup)
- *
- * Asserts the record round-trips with: integer (priority), single-select
- * (severity), boolean (blocked), multi tags (labels), and the multi-select
- * listbox (assignee) — the exact field that displayed empty pre-fix.
+ *   - POST   /api/entities/entities                          (runtime entity)
+ *   - POST   /api/entities/definitions                       (runtime field defs)
+ *   - POST   /api/entities/records                           (create + rejection)
+ *   - GET    /api/entities/records?entityId=                 (list + rejection)
+ *   - GET    /api/entities/records?entityId=&id=<recordId>   (by-id read)
+ *   - DELETE /api/entities/records?entityId=&recordId=       (cleanup)
+ *   - DELETE /api/entities/entities                          (cleanup)
  */
 
-const ENTITY_ID = 'example:todo';
+const SYSTEM_ENTITY_CASES: Array<{ entityId: string; values: Record<string, unknown> }> = [
+  { entityId: 'example:todo', values: { priority: 2 } },
+  { entityId: 'customers:customer_deal', values: { competitive_risk: 'high' } },
+];
+
+const RUNTIME_ENTITY_ID = `qa_ent2055:readback_${Date.now()}`;
+
+const RUNTIME_FIELD_DEFS: Array<{ key: string; kind: string; configJson: Record<string, unknown> }> = [
+  { key: 'priority', kind: 'integer', configJson: { label: 'Priority', formEditable: true } },
+  { key: 'severity', kind: 'select', configJson: { label: 'Severity', options: ['low', 'medium', 'high'], formEditable: true } },
+  { key: 'blocked', kind: 'boolean', configJson: { label: 'Blocked', formEditable: true } },
+  { key: 'labels', kind: 'text', configJson: { label: 'Labels', multi: true, input: 'tags', formEditable: true } },
+  { key: 'assignee', kind: 'select', configJson: { label: 'Assignees', options: ['alice', 'bob', 'charlie'], multi: true, input: 'listbox', formEditable: true } },
+  { key: 'description', kind: 'multiline', configJson: { label: 'Description', formEditable: true } },
+];
 
 async function readById(
   request: APIRequestContext,
@@ -42,7 +56,7 @@ async function readById(
   const res = await apiRequest(
     request,
     'GET',
-    `/api/entities/records?entityId=${encodeURIComponent(ENTITY_ID)}&page=1&pageSize=1&sortField=id&sortDir=asc&id=${encodeURIComponent(recordId)}`,
+    `/api/entities/records?entityId=${encodeURIComponent(RUNTIME_ENTITY_ID)}&page=1&pageSize=1&sortField=id&sortDir=asc&id=${encodeURIComponent(recordId)}`,
     { token },
   );
   expect(res.status(), 'by-id GET 200').toBe(200);
@@ -51,63 +65,119 @@ async function readById(
   return items.find((it) => String(it.id) === String(recordId)) ?? null;
 }
 
-test('TC-ENT-2055-RECORD-READBACK: a custom-entity record reads back all values incl. multi-select', async ({ request }) => {
-  const token = await getAuthToken(request, 'admin');
-  let recordId: string | null = null;
+test.describe('TC-ENT-2055-RECORD-READBACK', () => {
+  test('system (table-backed) entity ids are rejected by the records API', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
 
-  try {
-    const create = await apiRequest(request, 'POST', '/api/entities/records', {
-      token,
-      data: {
-        entityId: ENTITY_ID,
-        values: {
-          priority: 2,
-          severity: 'low',
-          blocked: true,
-          labels: ['ops'],
-          assignee: ['charlie'],
-          description: 'TC-ENT-2055 round-trip',
-        },
-      },
-    });
-    expect(create.status(), `create 200: ${create.status()}`).toBe(200);
-    const created = (await create.json()) as { ok?: boolean; item?: { recordId?: string } };
-    recordId = created.item?.recordId ?? null;
-    expect(typeof recordId, 'recordId present').toBe('string');
+    for (const { entityId, values } of SYSTEM_ENTITY_CASES) {
+      const create = await apiRequest(request, 'POST', '/api/entities/records', {
+        token,
+        data: { entityId, values },
+      });
+      expect(create.status(), `POST records for ${entityId} is rejected`).toBe(400);
+      const createBody = (await create.json()) as { code?: string };
+      expect(createBody.code, `rejection code for ${entityId}`).toBe('system_entity_records_blocked');
 
-    // 1) The just-created live record MUST appear in the list (pre-fix: total 0).
-    const list = await apiRequest(
-      request,
-      'GET',
-      `/api/entities/records?entityId=${encodeURIComponent(ENTITY_ID)}&page=1&pageSize=100&sortField=id&sortDir=asc`,
-      { token },
-    );
-    expect(list.status(), 'list GET 200').toBe(200);
-    const listBody = (await list.json()) as { items?: Array<Record<string, unknown>>; total?: number };
-    expect((listBody.total ?? 0), 'list total includes the new record').toBeGreaterThanOrEqual(1);
-    expect(
-      (listBody.items ?? []).some((it) => String(it.id) === String(recordId)),
-      'created record present in list',
-    ).toBe(true);
-
-    // 2) The by-id read (what the edit form fetches) MUST return every value,
-    //    custom-field keys normalized to bare names (no cf_ prefix).
-    const detail = await readById(request, token, recordId as string);
-    expect(detail, 'by-id detail returned (not blank)').toBeTruthy();
-    expect(detail!.priority, 'integer field').toBe(2);
-    expect(detail!.severity, 'single-select field').toBe('low');
-    expect(detail!.blocked, 'boolean field').toBe(true);
-    expect(detail!.labels, 'multi tags field').toEqual(['ops']);
-    expect(detail!.assignee, 'multi-select listbox field (the pre-fix-empty one)').toEqual(['charlie']);
-    expect(detail!.description, 'multiline field').toBe('TC-ENT-2055 round-trip');
-  } finally {
-    if (recordId) {
-      await apiRequest(
+      const list = await apiRequest(
         request,
-        'DELETE',
-        `/api/entities/records?entityId=${encodeURIComponent(ENTITY_ID)}&recordId=${encodeURIComponent(recordId)}`,
+        'GET',
+        `/api/entities/records?entityId=${encodeURIComponent(entityId)}&page=1&pageSize=1`,
         { token },
-      ).catch(() => {});
+      );
+      expect(list.status(), `GET records for ${entityId} is rejected`).toBe(400);
+      const listBody = (await list.json()) as { code?: string };
+      expect(listBody.code, `rejection code for ${entityId} list`).toBe('system_entity_records_blocked');
+
+      const register = await apiRequest(request, 'POST', '/api/entities/entities', {
+        token,
+        data: { entityId, label: 'QA rogue system-entity registration' },
+      });
+      expect(register.status(), `registering ${entityId} as a custom entity is rejected`).toBe(400);
+      const registerBody = (await register.json()) as { code?: string };
+      expect(registerBody.code, `registration rejection code for ${entityId}`).toBe('system_entity_records_blocked');
     }
-  }
+  });
+
+  test('a custom-entity record reads back all values incl. multi-select', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    let recordId: string | null = null;
+    let entityCreated = false;
+
+    try {
+      const createEntity = await apiRequest(request, 'POST', '/api/entities/entities', {
+        token,
+        data: { entityId: RUNTIME_ENTITY_ID, label: 'QA ENT-2055 Readback Item', description: 'Runtime entity for record readback parity' },
+      });
+      expect(createEntity.status(), `runtime entity upsert 200: ${createEntity.status()}`).toBe(200);
+      entityCreated = true;
+
+      for (const def of RUNTIME_FIELD_DEFS) {
+        const res = await apiRequest(request, 'POST', '/api/entities/definitions', {
+          token,
+          data: { entityId: RUNTIME_ENTITY_ID, key: def.key, kind: def.kind, configJson: def.configJson },
+        });
+        expect(res.status(), `field def ${def.key} upsert 200: ${res.status()}`).toBe(200);
+      }
+
+      const create = await apiRequest(request, 'POST', '/api/entities/records', {
+        token,
+        data: {
+          entityId: RUNTIME_ENTITY_ID,
+          values: {
+            priority: 2,
+            severity: 'low',
+            blocked: true,
+            labels: ['ops'],
+            assignee: ['charlie'],
+            description: 'TC-ENT-2055 round-trip',
+          },
+        },
+      });
+      expect(create.status(), `create 200: ${create.status()}`).toBe(200);
+      const created = (await create.json()) as { ok?: boolean; item?: { recordId?: string } };
+      recordId = created.item?.recordId ?? null;
+      expect(typeof recordId, 'recordId present').toBe('string');
+
+      // 1) The just-created live record MUST appear in the list.
+      const list = await apiRequest(
+        request,
+        'GET',
+        `/api/entities/records?entityId=${encodeURIComponent(RUNTIME_ENTITY_ID)}&page=1&pageSize=100&sortField=id&sortDir=asc`,
+        { token },
+      );
+      expect(list.status(), 'list GET 200').toBe(200);
+      const listBody = (await list.json()) as { items?: Array<Record<string, unknown>>; total?: number };
+      expect((listBody.total ?? 0), 'list total includes the new record').toBeGreaterThanOrEqual(1);
+      expect(
+        (listBody.items ?? []).some((it) => String(it.id) === String(recordId)),
+        'created record present in list',
+      ).toBe(true);
+
+      // 2) The by-id read (what the edit form fetches) MUST return every value,
+      //    custom-field keys normalized to bare names (no cf_ prefix).
+      const detail = await readById(request, token, recordId as string);
+      expect(detail, 'by-id detail returned (not blank)').toBeTruthy();
+      expect(detail!.priority, 'integer field').toBe(2);
+      expect(detail!.severity, 'single-select field').toBe('low');
+      expect(detail!.blocked, 'boolean field').toBe(true);
+      expect(detail!.labels, 'multi tags field').toEqual(['ops']);
+      expect(detail!.assignee, 'multi-select listbox field').toEqual(['charlie']);
+      expect(detail!.description, 'multiline field').toBe('TC-ENT-2055 round-trip');
+    } finally {
+      if (recordId) {
+        await apiRequest(
+          request,
+          'DELETE',
+          `/api/entities/records?entityId=${encodeURIComponent(RUNTIME_ENTITY_ID)}&recordId=${encodeURIComponent(recordId)}`,
+          { token },
+        ).catch(() => {});
+      }
+      if (entityCreated) {
+        await apiRequest(request, 'DELETE', '/api/entities/entities', {
+          token,
+          data: { entityId: RUNTIME_ENTITY_ID },
+        }).catch(() => {});
+      }
+    }
+  });
 });

--- a/packages/core/src/modules/entities/__integration__/TC-ENTITIES-006.spec.ts
+++ b/packages/core/src/modules/entities/__integration__/TC-ENTITIES-006.spec.ts
@@ -22,10 +22,11 @@ import {
  * Verified behavior note (corrects the issue's premise):
  *   The issue expected records to disappear after deleting the entity definition.
  *   In reality, records live in `custom_entities_storage` independently of the
- *   `custom_entities` definition row, and the records endpoint detects the entity
- *   from its storage rows — so the entity-definition soft delete is metadata-only
- *   and its stored records REMAIN queryable. This spec asserts the true invariant:
- *   the entity vanishes from the entity list while its records persist.
+ *   `custom_entities` definition row, and the records endpoint classifies the entity
+ *   from its registration row (active OR soft-deleted) — so the entity-definition
+ *   soft delete is metadata-only and its stored records REMAIN queryable. This spec
+ *   asserts the true invariant: the entity vanishes from the entity list while its
+ *   records persist.
  */
 test.describe('TC-ENTITIES-006: Soft-deleting a custom entity hides it from the list', () => {
   test('removes the entity from the default list; stored records persist', async ({ request }) => {

--- a/packages/core/src/modules/entities/api/entities.ts
+++ b/packages/core/src/modules/entities/api/entities.ts
@@ -7,6 +7,7 @@ import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import { upsertCustomEntitySchema } from '@open-mercato/core/modules/entities/data/validators'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { isSystemEntitySelectable } from '@open-mercato/shared/lib/entities/system-entities'
+import { SYSTEM_ENTITY_RECORDS_BLOCKED_CODE, isOrmBackedSystemEntityId } from '@open-mercato/shared/lib/data/engine'
 
 export const metadata = {
   GET: { requireAuth: true },
@@ -106,6 +107,16 @@ export async function POST(req: Request) {
 
   const { resolve } = await createRequestContainer()
   const em = resolve('em') as any
+
+  // A registration for a module-declared, table-backed system entity would flip
+  // query-engine classification to doc storage for the whole entity type (#2939's
+  // failure mode via another door) — refuse to create one.
+  if (isOrmBackedSystemEntityId(em, input.entityId)) {
+    return NextResponse.json(
+      { error: 'System entities cannot be registered as custom entities', code: SYSTEM_ENTITY_RECORDS_BLOCKED_CODE, entityId: input.entityId },
+      { status: 400 },
+    )
+  }
 
   const where: any = { entityId: input.entityId, organizationId: auth.orgId ?? null, tenantId: auth.tenantId ?? null }
   let ent = await em.findOne(CustomEntity, where)

--- a/packages/core/src/modules/entities/api/records.ts
+++ b/packages/core/src/modules/entities/api/records.ts
@@ -6,6 +6,7 @@ import type { QueryEngine, QueryOptions, Where, Sort } from '@open-mercato/share
 import { normalizeExportFormat, serializeExport, defaultExportFilename, ensureColumns } from '@open-mercato/shared/lib/crud/exporters'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { resolveOrganizationScope, getSelectedOrganizationFromRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { SYSTEM_ENTITY_RECORDS_BLOCKED_CODE, isOrmBackedSystemEntityId } from '@open-mercato/shared/lib/data/engine'
 import { parseBooleanToken, parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import { setRecordCustomFields } from '../lib/helpers'
 import { CustomFieldValue } from '../data/entities'
@@ -36,24 +37,31 @@ function isDeclaredCustomEntity(entityId: string): boolean {
 
 const CUSTOM_ENTITY_RECORD_RESOURCE_KIND = 'entities.record'
 
-async function detectCustomEntity(em: any, entityId: string): Promise<boolean> {
-  if (isDeclaredCustomEntity(entityId)) return true
+type RecordsEntityKind = 'system' | 'custom' | 'unknown'
+
+// This surface manages doc-storage records, which exist for CUSTOM entities only.
+// Module-declared ids backed by a registered ORM table are system entities — their
+// records live in their own module tables/APIs, and stray doc rows for them poisoned
+// read-path classification platform-wide (#2939) — so they are rejected outright. The
+// previous fallback that classified an entity by the mere presence of
+// `custom_entities_storage` rows is gone: within the allowed set, declaration (ce.ts)
+// or an active `custom_entities` registration is authoritative.
+async function classifyRecordsEntity(em: any, entityId: string): Promise<RecordsEntityKind> {
+  if (isOrmBackedSystemEntityId(em, entityId)) return 'system'
+  if (isDeclaredCustomEntity(entityId)) return 'custom'
   try {
     const { CustomEntity } = await import('../data/entities')
     const found = await em.findOne(CustomEntity as any, { entityId, isActive: true })
-    if (found) return true
+    if (found) return 'custom'
   } catch {}
-  try {
-    const db = em.getKysely()
-    const row = await db
-      .selectFrom('custom_entities_storage' as any)
-      .select(['entity_id' as any])
-      .where('entity_type' as any, '=', entityId)
-      .limit(1)
-      .executeTakeFirst()
-    return !!row
-  } catch {}
-  return false
+  return 'unknown'
+}
+
+function systemEntityRecordsRejection(entityId: string) {
+  return NextResponse.json(
+    { error: 'Records are available for custom entities only', code: SYSTEM_ENTITY_RECORDS_BLOCKED_CODE, entityId },
+    { status: 400 },
+  )
 }
 
 async function readCustomEntityRecordUpdatedAt(
@@ -148,13 +156,13 @@ export async function GET(req: Request) {
     const rbac = resolve('rbacService') as RbacService
     const scope = await resolveOrganizationScope({ em, rbac, auth, selectedId: getSelectedOrganizationFromRequest(req) })
     let organizationIds: string[] | null = scope.filterIds
-    // Read/write symmetry: this endpoint writes every record to custom_entities_storage
-    // via the data engine, including module-declared custom entities whose id is a
-    // frozen system id and therefore never registered in `custom_entities`. detectCustomEntity
-    // covers the declared-entity registry plus the custom_entities / doc-storage fallbacks
-    // (mirrors HybridQueryEngine.isCustomEntity) so mapRow strips the cf_ prefix and the edit
-    // form can read back saved values.
-    const isCustomEntity = await detectCustomEntity(em, entityId)
+    // Module-declared custom entities (ce.ts) carry frozen system-style ids and are never
+    // registered in `custom_entities`, so classification checks the declared registry plus
+    // active registrations. System (table-backed) ids are rejected above; for the allowed
+    // set `isCustomEntity` drives mapRow's cf_ stripping so the edit form reads back values.
+    const entityKind = await classifyRecordsEntity(em, entityId)
+    if (entityKind === 'system') return systemEntityRecordsRejection(entityId)
+    const isCustomEntity = entityKind === 'custom'
     await assertEntityAclForRequest({ auth, entityId, action: 'view', isCustomEntity, rbac })
     if (organizationIds && organizationIds.length === 0) {
       return NextResponse.json({ items: [], total: 0, page, pageSize, totalPages: 0 })
@@ -230,9 +238,9 @@ export async function GET(req: Request) {
     if (organizationIds && organizationIds.length) {
       qopts.organizationIds = organizationIds
     }
-    // Dual-declared ids (module-declared custom entity + registered ORM table, e.g.
-    // `example:todo`) auto-classify to their base table since #2939 — this surface
-    // manages doc records, so direct the engine to doc storage explicitly.
+    // Allowed entities are doc-storage-backed by definition (system ids were rejected
+    // above) — direct the engine to doc storage explicitly so reads stay deterministic
+    // even before the first record exists.
     if (isCustomEntity) qopts.forceCustomEntityStorage = true
     for (const [k, v] of qpEntries) buildFilter(k, v, isCustomEntity)
     const res = await qe.query(entityId as any, qopts)
@@ -367,7 +375,9 @@ export async function POST(req: Request) {
     const scope = await resolveOrganizationScope({ em, rbac, auth, selectedId: getSelectedOrganizationFromRequest(req) })
     const targetOrgId = scope.selectedId ?? auth.orgId
     if (!targetOrgId) return NextResponse.json({ error: 'Organization context is required' }, { status: 400 })
-    const isCustomEntity = await detectCustomEntity(em, entityId)
+    const entityKind = await classifyRecordsEntity(em, entityId)
+    if (entityKind === 'system') return systemEntityRecordsRejection(entityId)
+    const isCustomEntity = entityKind === 'custom'
     await assertEntityAclForRequest({ auth, entityId, action: 'manage', isCustomEntity, rbac })
     const norm = normalizeValues(values)
 
@@ -431,7 +441,9 @@ export async function PUT(req: Request) {
     const scope = await resolveOrganizationScope({ em, rbac, auth, selectedId: getSelectedOrganizationFromRequest(req) })
     const targetOrgId = scope.selectedId ?? auth.orgId
     if (!targetOrgId) return NextResponse.json({ error: 'Organization context is required' }, { status: 400 })
-    const isCustomEntity = await detectCustomEntity(em, entityId)
+    const entityKind = await classifyRecordsEntity(em, entityId)
+    if (entityKind === 'system') return systemEntityRecordsRejection(entityId)
+    const isCustomEntity = entityKind === 'custom'
     await assertEntityAclForRequest({ auth, entityId, action: 'manage', isCustomEntity, rbac })
     const norm = normalizeValues(values)
 
@@ -520,7 +532,9 @@ export async function DELETE(req: Request) {
     const scope = await resolveOrganizationScope({ em, rbac, auth, selectedId: getSelectedOrganizationFromRequest(req) })
     const targetOrgId = scope.selectedId ?? auth.orgId
     if (!targetOrgId) return NextResponse.json({ error: 'Organization context is required' }, { status: 400 })
-    const isCustomEntity = await detectCustomEntity(em, entityId)
+    const entityKind = await classifyRecordsEntity(em, entityId)
+    if (entityKind === 'system') return systemEntityRecordsRejection(entityId)
+    const isCustomEntity = entityKind === 'custom'
     await assertEntityAclForRequest({ auth, entityId, action: 'manage', isCustomEntity, rbac })
     await de.deleteCustomEntityRecord({ entityId, recordId, organizationId: targetOrgId, tenantId: auth.tenantId!, soft: true })
     return NextResponse.json({ ok: true })

--- a/packages/core/src/modules/entities/api/records.ts
+++ b/packages/core/src/modules/entities/api/records.ts
@@ -51,7 +51,10 @@ async function classifyRecordsEntity(em: any, entityId: string): Promise<Records
   if (isDeclaredCustomEntity(entityId)) return 'custom'
   try {
     const { CustomEntity } = await import('../data/entities')
-    const found = await em.findOne(CustomEntity as any, { entityId, isActive: true })
+    // Any registration row — active or soft-deleted — proves the id is a custom
+    // entity. Records persist beyond the definition's soft delete (TC-ENTITIES-006)
+    // and must stay readable/deletable, e.g. for the restore flow and cleanup.
+    const found = await em.findOne(CustomEntity as any, { entityId })
     if (found) return 'custom'
   } catch {}
   return 'unknown'

--- a/packages/core/src/modules/entities/api/records.ts
+++ b/packages/core/src/modules/entities/api/records.ts
@@ -230,6 +230,10 @@ export async function GET(req: Request) {
     if (organizationIds && organizationIds.length) {
       qopts.organizationIds = organizationIds
     }
+    // Dual-declared ids (module-declared custom entity + registered ORM table, e.g.
+    // `example:todo`) auto-classify to their base table since #2939 — this surface
+    // manages doc records, so direct the engine to doc storage explicitly.
+    if (isCustomEntity) qopts.forceCustomEntityStorage = true
     for (const [k, v] of qpEntries) buildFilter(k, v, isCustomEntity)
     const res = await qe.query(entityId as any, qopts)
     const rawItems = res.items || []

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/[recordId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/[recordId]/page.tsx
@@ -6,6 +6,8 @@ import { z } from 'zod'
 import { apiCall, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { updateCrud } from '@open-mercato/ui/backend/utils/crud'
 import { createCrudFormError, raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
+import { ErrorMessage, LoadingMessage } from '@open-mercato/ui/backend/detail'
+import { useRecordsEntityGuard } from '@open-mercato/core/modules/entities/components/useRecordsEntityGuard'
 
 type UpdateRecordRequest = (payload: { entityId: string; recordId: string; values: Record<string, unknown> }) => Promise<void>
 
@@ -38,6 +40,19 @@ export async function submitCustomEntityRecordUpdate(options: {
 type RecordsResponse = { items: any[] }
 
 export default function EditRecordPage({ params }: { params: { entityId?: string; recordId?: string } }) {
+  const t = useT()
+  const entityId = decodeURIComponent(params?.entityId || '')
+  const guard = useRecordsEntityGuard(entityId)
+  if (guard === 'blocked') {
+    return <ErrorMessage label={t('entities.userEntities.records.errors.systemEntity', 'This entity is system-managed. Records are available for custom entities only.')} />
+  }
+  if (guard === 'checking') {
+    return <LoadingMessage label={t('entities.userEntities.records.loading', 'Loading records...')} />
+  }
+  return <EditRecordPageInner params={params} />
+}
+
+function EditRecordPageInner({ params }: { params: { entityId?: string; recordId?: string } }) {
   const t = useT()
   const entityId = decodeURIComponent(params?.entityId || '')
   const recordId = decodeURIComponent(params?.recordId || '')

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/create/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/create/page.tsx
@@ -6,6 +6,8 @@ import { CrudForm, type CrudField } from '@open-mercato/ui/backend/CrudForm'
 import { z } from 'zod'
 import { createCrud } from '@open-mercato/ui/backend/utils/crud'
 import { createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors'
+import { ErrorMessage, LoadingMessage } from '@open-mercato/ui/backend/detail'
+import { useRecordsEntityGuard } from '@open-mercato/core/modules/entities/components/useRecordsEntityGuard'
 
 type CreateRecordRequest = (payload: { entityId: string; values: Record<string, unknown> }) => Promise<void>
 
@@ -30,6 +32,19 @@ export async function submitCustomEntityRecord(options: {
 }
 
 export default function CreateRecordPage({ params }: { params: { entityId?: string } }) {
+  const t = useT()
+  const entityId = decodeURIComponent(params?.entityId || '')
+  const guard = useRecordsEntityGuard(entityId)
+  if (guard === 'blocked') {
+    return <ErrorMessage label={t('entities.userEntities.records.errors.systemEntity', 'This entity is system-managed. Records are available for custom entities only.')} />
+  }
+  if (guard === 'checking') {
+    return <LoadingMessage label={t('entities.userEntities.records.loading', 'Loading records...')} />
+  }
+  return <CreateRecordPageInner params={params} />
+}
+
+function CreateRecordPageInner({ params }: { params: { entityId?: string } }) {
   const t = useT()
   const router = useRouter()
   const entityId = decodeURIComponent(params?.entityId || '')

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/page.tsx
@@ -17,6 +17,9 @@ import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
+import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { ErrorMessage, LoadingMessage } from '@open-mercato/ui/backend/detail'
+import { useRecordsEntityGuard } from '@open-mercato/core/modules/entities/components/useRecordsEntityGuard'
 
 type RecordsResponse = {
   items: any[]
@@ -44,6 +47,26 @@ function normalizeCell(v: any): string {
 }
 
 export default function RecordsPage({ params }: { params: { entityId?: string } }) {
+  const t = useT()
+  const entityId = decodeURIComponent(params?.entityId || '')
+  const guard = useRecordsEntityGuard(entityId)
+  if (guard !== 'allowed') {
+    return (
+      <Page>
+        <PageBody>
+          {guard === 'blocked' ? (
+            <ErrorMessage label={t('entities.userEntities.records.errors.systemEntity', 'This entity is system-managed. Records are available for custom entities only.')} />
+          ) : (
+            <LoadingMessage label={t('entities.userEntities.records.loading', 'Loading records...')} />
+          )}
+        </PageBody>
+      </Page>
+    )
+  }
+  return <RecordsPageInner params={params} />
+}
+
+function RecordsPageInner({ params }: { params: { entityId?: string } }) {
   const entityId = decodeURIComponent(params?.entityId || '')
   const [sorting, setSorting] = React.useState<SortingState>([{ id: 'id', desc: false }])
   const [page, setPage] = React.useState(1)

--- a/packages/core/src/modules/entities/components/useRecordsEntityGuard.ts
+++ b/packages/core/src/modules/entities/components/useRecordsEntityGuard.ts
@@ -1,0 +1,41 @@
+"use client"
+import * as React from 'react'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+
+export type RecordsEntityGuardState = 'checking' | 'blocked' | 'allowed'
+
+// Mirrors SYSTEM_ENTITY_RECORDS_BLOCKED_CODE from @open-mercato/shared/lib/data/engine —
+// kept as a literal so client bundles do not pull the server-side data engine in.
+const SYSTEM_ENTITY_RECORDS_BLOCKED_CODE = 'system_entity_records_blocked'
+
+/**
+ * The records surface serves custom entities only; the API rejects system
+ * (table-backed) entity ids with 400 + `system_entity_records_blocked` (#2939
+ * hardening). Records pages are URL-addressable for any entity id, so they probe
+ * once and render a dedicated error state instead of a broken table/form.
+ * Fails open on transport errors — the page's own data calls surface those.
+ */
+export function useRecordsEntityGuard(entityId: string): RecordsEntityGuardState {
+  const [state, setState] = React.useState<RecordsEntityGuardState>(entityId ? 'checking' : 'allowed')
+  React.useEffect(() => {
+    if (!entityId) {
+      setState('allowed')
+      return
+    }
+    let cancelled = false
+    setState('checking')
+    apiCall<{ code?: string }>(`/api/entities/records?entityId=${encodeURIComponent(entityId)}&page=1&pageSize=1`)
+      .then((res) => {
+        if (cancelled) return
+        const blocked = res.status === 400 && res.result?.code === SYSTEM_ENTITY_RECORDS_BLOCKED_CODE
+        setState(blocked ? 'blocked' : 'allowed')
+      })
+      .catch(() => {
+        if (!cancelled) setState('allowed')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [entityId])
+  return state
+}

--- a/packages/core/src/modules/entities/i18n/de.json
+++ b/packages/core/src/modules/entities/i18n/de.json
@@ -82,6 +82,7 @@
   "entities.userEntities.records.errors.deleteFailed": "Datensatz konnte nicht gelöscht werden",
   "entities.userEntities.records.errors.entityIdRequired": "Entitätskennung ist erforderlich",
   "entities.userEntities.records.errors.recordIdRequired": "Datensatzkennung ist erforderlich",
+  "entities.userEntities.records.errors.systemEntity": "Diese Entität wird vom System verwaltet. Datensätze sind nur für benutzerdefinierte Entitäten verfügbar.",
   "entities.userEntities.records.form.createTitle": "Datensatz erstellen",
   "entities.userEntities.records.form.editTitle": "Datensatz bearbeiten",
   "entities.userEntities.records.form.submitCreate": "Erstellen",

--- a/packages/core/src/modules/entities/i18n/en.json
+++ b/packages/core/src/modules/entities/i18n/en.json
@@ -82,6 +82,7 @@
   "entities.userEntities.records.errors.deleteFailed": "Failed to delete record",
   "entities.userEntities.records.errors.entityIdRequired": "Entity identifier is required",
   "entities.userEntities.records.errors.recordIdRequired": "Record identifier is required",
+  "entities.userEntities.records.errors.systemEntity": "This entity is system-managed. Records are available for custom entities only.",
   "entities.userEntities.records.form.createTitle": "Create record",
   "entities.userEntities.records.form.editTitle": "Edit record",
   "entities.userEntities.records.form.submitCreate": "Create",

--- a/packages/core/src/modules/entities/i18n/es.json
+++ b/packages/core/src/modules/entities/i18n/es.json
@@ -82,6 +82,7 @@
   "entities.userEntities.records.errors.deleteFailed": "No se pudo eliminar el registro",
   "entities.userEntities.records.errors.entityIdRequired": "Se requiere el identificador de la entidad",
   "entities.userEntities.records.errors.recordIdRequired": "Se requiere el identificador del registro",
+  "entities.userEntities.records.errors.systemEntity": "Esta entidad está gestionada por el sistema. Los registros solo están disponibles para entidades personalizadas.",
   "entities.userEntities.records.form.createTitle": "Crear registro",
   "entities.userEntities.records.form.editTitle": "Editar registro",
   "entities.userEntities.records.form.submitCreate": "Crear",

--- a/packages/core/src/modules/entities/i18n/pl.json
+++ b/packages/core/src/modules/entities/i18n/pl.json
@@ -82,6 +82,7 @@
   "entities.userEntities.records.errors.deleteFailed": "Nie udało się usunąć rekordu",
   "entities.userEntities.records.errors.entityIdRequired": "Wymagany jest identyfikator encji",
   "entities.userEntities.records.errors.recordIdRequired": "Wymagany jest identyfikator rekordu",
+  "entities.userEntities.records.errors.systemEntity": "Ta encja jest zarządzana systemowo. Rekordy są dostępne wyłącznie dla encji niestandardowych.",
   "entities.userEntities.records.form.createTitle": "Utwórz rekord",
   "entities.userEntities.records.form.editTitle": "Edytuj rekord",
   "entities.userEntities.records.form.submitCreate": "Utwórz",

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -162,6 +162,10 @@ function resolveFirstRow(
       organization_id: null,
     }
   }
+  if (table === 'custom_entities_storage' && log.limit === 1) {
+    // Existence probe used by isCustomEntity/hasCustomEntityStorageRows.
+    return (config.rows?.custom_entities_storage ?? []).length ? { one: 1 } : undefined
+  }
   // Count subquery / data reads: look for `count` alias in selects.
   const hasCount = log.selects.some((s: any) => {
     try { return String(s?.name ?? s) === 'count' || typeof s?.as === 'function' } catch { return false }
@@ -216,6 +220,16 @@ function resolveRows(
 
 function buildEm(db: any): any {
   return { getKysely: () => db }
+}
+
+function buildEmWithOrmMetadata(db: any, classTables: Record<string, string>): any {
+  return {
+    getKysely: () => db,
+    getMetadata: () => ({
+      find: (className: string) => (classTables[className] ? { tableName: classTables[className] } : undefined),
+      getAll: () => Object.values(classTables).map((tableName) => ({ tableName })),
+    }),
+  }
 }
 
 describe('HybridQueryEngine', () => {
@@ -718,5 +732,74 @@ describe('sort direction coercion (#2704)', () => {
     const serialized = serializeOrderBys(db)
     expect(serialized).not.toContain('pg_sleep')
     expect(serialized).not.toContain('vault')
+  })
+})
+
+describe('HybridQueryEngine custom-entity classification (#2939)', () => {
+  test('stray doc-storage rows must not reroute a table-backed ORM entity away from its base table', async () => {
+    const db = createFakeKysely({
+      baseTable: 'customer_deals',
+      hasIndexAny: false,
+      baseCount: 282,
+      indexCount: 0,
+      customFieldKeys: {},
+      rows: { custom_entities_storage: [{ entity_id: 'stray-doc-record' }] },
+    })
+    const em = buildEmWithOrmMetadata(db, { CustomerDeal: 'customer_deals' })
+    const fallback = { query: jest.fn() }
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent: jest.fn() }))
+
+    await expect((engine as any).isCustomEntity('customers:customer_deal')).resolves.toBe(false)
+
+    await engine.query('customers:customer_deal', {
+      fields: ['id', 'title', 'pipeline_stage_id'],
+      includeCustomFields: true,
+      organizationIds: ['org1'],
+      tenantId: 't1',
+    })
+
+    const chains = db._chains as ChainLog[]
+    expect(chains.some((chain) => chain.table === 'customer_deals')).toBe(true)
+  })
+
+  test('module-declared custom entities without an ORM table keep doc-storage routing (read/write symmetry)', async () => {
+    const db = createFakeKysely({
+      baseTable: 'unused',
+      hasIndexAny: false,
+      baseCount: 0,
+      indexCount: 0,
+      customFieldKeys: {},
+      rows: { custom_entities_storage: [{ entity_id: 'calendar-record' }] },
+    })
+    const em = buildEmWithOrmMetadata(db, {})
+    const fallback = { query: jest.fn() }
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent: jest.fn() }))
+
+    await expect((engine as any).isCustomEntity('example:calendar_entity')).resolves.toBe(true)
+  })
+
+  test('forceCustomEntityStorage routes a dual-declared id to doc storage (entities records surface)', async () => {
+    const db = createFakeKysely({
+      baseTable: 'todos',
+      hasIndexAny: false,
+      baseCount: 0,
+      indexCount: 0,
+      customFieldKeys: {},
+      rows: { custom_entities_storage: [{ entity_id: 'todo-doc-record' }] },
+    })
+    const em = buildEmWithOrmMetadata(db, { Todo: 'todos' })
+    const fallback = { query: jest.fn() }
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent: jest.fn() }))
+
+    await engine.query('example:todo', {
+      fields: ['id', 'title'],
+      organizationIds: ['org1'],
+      tenantId: 't1',
+      forceCustomEntityStorage: true,
+    })
+
+    const chains = db._chains as ChainLog[]
+    expect(chains.some((chain) => chain.table === 'custom_entities_storage' && chain.selects.length > 0)).toBe(true)
+    expect(chains.some((chain) => chain.table === 'todos')).toBe(false)
   })
 })

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -2,7 +2,7 @@ import type { QueryEngine, QueryOptions, QueryResult, FilterOp, Filter, QueryCus
 import { SortDir } from '@open-mercato/shared/lib/query/types'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { BasicQueryEngine, resolveEntityTableName } from '@open-mercato/shared/lib/query/engine'
+import { BasicQueryEngine, resolveEntityTableName, resolveRegisteredEntityTableName } from '@open-mercato/shared/lib/query/engine'
 import { type Kysely, sql, type RawBuilder } from 'kysely'
 import type { EventBus } from '@open-mercato/events'
 import { readCoverageSnapshot, refreshCoverageSnapshot } from './coverage'
@@ -219,7 +219,7 @@ export class HybridQueryEngine implements QueryEngine {
       const debugEnabled = this.isDebugVerbosity()
       if (debugEnabled) this.debug('query:start', { entity })
 
-      const isCustom = await this.isCustomEntity(entity)
+      const isCustom = opts.forceCustomEntityStorage === true || await this.isCustomEntity(entity)
       if (isCustom) {
         if (debugEnabled) this.debug('query:custom-entity', { entity })
         const section = profiler.section('custom_entity')
@@ -1005,6 +1005,14 @@ export class HybridQueryEngine implements QueryEngine {
         .executeTakeFirst()
       if (row) {
         result = true
+      } else if (resolveRegisteredEntityTableName(this.em, entity) !== null) {
+        // An id backed by a registered ORM table is never doc-storage-backed by
+        // inference: stray `custom_entities_storage` rows for such an id (e.g. written
+        // through the generic entities data engine) must not hijack every list/detail
+        // read for the whole entity type away from its base table (#2939). Surfaces
+        // that intentionally read doc records for a dual-declared id pass
+        // `forceCustomEntityStorage` in QueryOptions instead.
+        result = false
       } else {
         // Read/write symmetry. Records written through the entities data engine
         // (`de.createCustomEntityRecord`) always land in `custom_entities_storage`,
@@ -1012,9 +1020,7 @@ export class HybridQueryEngine implements QueryEngine {
         // id — those are NEVER registered in `custom_entities` (install treats a
         // system id as non-registrable). Without this fallback the query routes to
         // the empty ORM/index path and those records are write-only (created with
-        // 200 but unreadable on the edit form). A real ORM entity never writes rows
-        // to `custom_entities_storage`, so this can only ever re-classify genuine
-        // doc-storage entities — it cannot misroute table-backed entities.
+        // 200 but unreadable on the edit form).
         result = await this.hasCustomEntityStorageRows(entity)
       }
     } catch {

--- a/packages/shared/src/lib/data/__tests__/engine.custom-entity-storage-guard.test.ts
+++ b/packages/shared/src/lib/data/__tests__/engine.custom-entity-storage-guard.test.ts
@@ -1,0 +1,78 @@
+import { DefaultDataEngine, assertCustomEntityStorageEntityId } from '../engine'
+import { isCrudHttpError } from '../../crud/errors'
+import { registerEntityIds } from '../../encryption/entityIds'
+
+function buildEm(classTables: Record<string, string>): any {
+  return {
+    getKysely: () => {
+      throw new Error('[internal] storage must not be touched for rejected entity ids')
+    },
+    getMetadata: () => ({
+      find: (className: string) => (classTables[className] ? { tableName: classTables[className] } : undefined),
+      getAll: () => Object.values(classTables).map((tableName) => ({ tableName })),
+    }),
+  }
+}
+
+function expectSystemEntityRejection(err: unknown) {
+  expect(isCrudHttpError(err)).toBe(true)
+  const httpError = err as { status: number; body: { code?: string } }
+  expect(httpError.status).toBe(400)
+  expect(httpError.body.code).toBe('system_entity_records_blocked')
+}
+
+describe('custom-entity storage guard (#2939 hardening)', () => {
+  beforeEach(() => {
+    registerEntityIds({
+      customers: { customer_deal: 'customers:customer_deal' },
+      example: { todo: 'example:todo', calendar_entity: 'example:calendar_entity' },
+    })
+  })
+
+  afterEach(() => {
+    registerEntityIds({})
+  })
+
+  test('assertCustomEntityStorageEntityId rejects module-declared ids backed by a registered ORM table', () => {
+    const em = buildEm({ CustomerDeal: 'customer_deals' })
+    try {
+      assertCustomEntityStorageEntityId(em, 'customers:customer_deal')
+      throw new Error('[internal] expected the guard to throw')
+    } catch (err) {
+      expectSystemEntityRejection(err)
+    }
+  })
+
+  test('assertCustomEntityStorageEntityId allows module-declared ids without a registered ORM table', () => {
+    const em = buildEm({})
+    expect(() => assertCustomEntityStorageEntityId(em, 'example:calendar_entity')).not.toThrow()
+  })
+
+  test('a runtime entity whose name collides with an ORM class name is NOT classified as system', () => {
+    const em = buildEm({ Todo: 'todos' })
+    expect(() => assertCustomEntityStorageEntityId(em, 'user:todo')).not.toThrow()
+  })
+
+  test('falls back to the ORM-table check when the entity-id registry is not populated', () => {
+    registerEntityIds({})
+    const em = buildEm({ CustomerDeal: 'customer_deals' })
+    try {
+      assertCustomEntityStorageEntityId(em, 'customers:customer_deal')
+      throw new Error('[internal] expected the guard to throw')
+    } catch (err) {
+      expectSystemEntityRejection(err)
+    }
+  })
+
+  test.each([
+    ['createCustomEntityRecord', (engine: DefaultDataEngine) => engine.createCustomEntityRecord({ entityId: 'customers:customer_deal', values: {} })],
+    ['updateCustomEntityRecord', (engine: DefaultDataEngine) => engine.updateCustomEntityRecord({ entityId: 'customers:customer_deal', recordId: '11111111-1111-4111-8111-111111111111', values: {} })],
+    ['deleteCustomEntityRecord', (engine: DefaultDataEngine) => engine.deleteCustomEntityRecord({ entityId: 'customers:customer_deal', recordId: '11111111-1111-4111-8111-111111111111' })],
+  ])('%s rejects a table-backed system entity id before touching storage', async (_name, run) => {
+    const engine = new DefaultDataEngine(buildEm({ CustomerDeal: 'customer_deals' }) as any, {} as any)
+    await expect(run(engine)).rejects.toMatchObject({
+      status: 400,
+      body: { code: 'system_entity_records_blocked' },
+    })
+  })
+})

--- a/packages/shared/src/lib/data/engine.ts
+++ b/packages/shared/src/lib/data/engine.ts
@@ -13,6 +13,8 @@ import type {
   CrudEntityIdentifiers,
 } from '../crud/types'
 import { CrudHttpError } from '../crud/errors'
+import { resolveRegisteredEntityTableName } from '../query/engine'
+import { getEntityIds } from '../encryption/entityIds'
 import { normalizeCustomFieldValues } from '../custom-fields/normalize'
 import { parseBooleanToken } from '../boolean'
 import { isEventDeclared } from '../../modules/events'
@@ -136,6 +138,41 @@ export interface DataEngine {
   flushOrmEntityChanges(): Promise<void>
 }
 
+export const SYSTEM_ENTITY_RECORDS_BLOCKED_CODE = 'system_entity_records_blocked'
+
+/**
+ * A system entity for doc-storage purposes is an id that modules declare in the
+ * generated entity-id registry AND that resolves to a registered ORM table. Both
+ * conditions matter: `resolveRegisteredEntityTableName` matches class-name candidates
+ * from the entity segment alone, so a runtime-registered custom entity whose name
+ * happens to collide with some ORM class (e.g. `user:todo` vs the example module's
+ * `Todo`) must never be classified as system. When the registry is not populated
+ * (exotic bootstraps, unit harnesses) the check conservatively falls back to the
+ * ORM-table match alone so the #2939 protection never switches off.
+ */
+export function isOrmBackedSystemEntityId(em: EntityManager, entityId: string): boolean {
+  const registry = getEntityIds(false)
+  const moduleIds = Object.values(registry).flatMap((moduleEntities) => Object.values(moduleEntities ?? {}))
+  if (moduleIds.length > 0 && !moduleIds.includes(entityId)) return false
+  return resolveRegisteredEntityTableName(em, entityId) !== null
+}
+
+/**
+ * Doc storage (`custom_entities_storage`) is for custom entities only. A system
+ * entity's records live in its own module tables/APIs — writing doc rows for it
+ * poisons read-path classification (#2939) and must be rejected at the deepest
+ * seam so no caller (API, AI tool, workflow) can do it.
+ */
+export function assertCustomEntityStorageEntityId(em: EntityManager, entityId: string): void {
+  if (isOrmBackedSystemEntityId(em, entityId)) {
+    throw new CrudHttpError(400, {
+      error: 'Records are available for custom entities only',
+      code: SYSTEM_ENTITY_RECORDS_BLOCKED_CODE,
+      entityId,
+    })
+  }
+}
+
 export class DefaultDataEngine implements DataEngine {
   private pendingSideEffects = new Map<string, QueuedCrudSideEffect>()
   constructor(private em: EntityManager, private container: AwilixContainer) {}
@@ -254,6 +291,7 @@ export class DefaultDataEngine implements DataEngine {
   }
 
   async createCustomEntityRecord(opts: Parameters<DataEngine['createCustomEntityRecord']>[0]): Promise<{ id: string }> {
+    assertCustomEntityStorageEntityId(this.em, opts.entityId)
     const db = this.getKysely()
     await this.ensureStorageTableExists()
     const sanitizedValues = await sanitizeCustomFieldHtmlRichTextValuesServer(this.em, {
@@ -345,6 +383,7 @@ export class DefaultDataEngine implements DataEngine {
   }
 
   async updateCustomEntityRecord(opts: Parameters<DataEngine['updateCustomEntityRecord']>[0]): Promise<void> {
+    assertCustomEntityStorageEntityId(this.em, opts.entityId)
     const db = this.getKysely()
     const sanitizedValues = await sanitizeCustomFieldHtmlRichTextValuesServer(this.em, {
       entityId: opts.entityId,
@@ -410,6 +449,7 @@ export class DefaultDataEngine implements DataEngine {
   }
 
   async deleteCustomEntityRecord(opts: Parameters<DataEngine['deleteCustomEntityRecord']>[0]): Promise<void> {
+    assertCustomEntityStorageEntityId(this.em, opts.entityId)
     const db = this.getKysely()
     const id = String(opts.recordId)
     const orgId = opts.organizationId ?? null

--- a/packages/shared/src/lib/query/types.ts
+++ b/packages/shared/src/lib/query/types.ts
@@ -125,6 +125,16 @@ export type QueryOptions = {
   // Used by the search indexing pipeline to prevent feedback loops where indexing triggers
   // re-indexing indefinitely.
   skipAutoReindex?: boolean
+  /**
+   * Force routing this query to custom-entity doc storage (`custom_entities_storage`)
+   * instead of classifying the entity automatically. Automatic classification routes
+   * ids backed by a registered ORM table to that base table, so surfaces that manage
+   * doc records for ids that are ALSO table-backed (e.g. the entities records browser
+   * reading a module-declared custom entity such as `example:todo`) must set this flag.
+   * Honored by the hybrid query engine only; `BasicQueryEngine` has no doc-storage
+   * reader and ignores it.
+   */
+  forceCustomEntityStorage?: boolean
   // Optional UMES query extensions context. When provided, the engine will
   // emit sync lifecycle events and apply query-level enrichers.
   extensions?: QueryExtensionsConfig


### PR DESCRIPTION
## Summary

`GET /api/customers/deals` — backing the deals list, every kanban lane, and the MCP deals tool — returned only a handful of stray placeholder rows while `/api/customers/deals/aggregate` kept counting all real deals (#2939). Cause: the read/write-symmetry fallback introduced in #2055 (`9e20d3307`) classifies an entity as doc-storage-backed whenever any `custom_entities_storage` row exists for its entity type. `customers:customer_deal` is a table-backed ORM entity that is also declared in `ce.ts` for its custom-field set, so a single stray doc record (creatable via the generic `POST /api/entities/records`) rerouted the entire deals read path to doc storage. This PR makes ORM-table-backed ids immune to that inference while preserving #2055's fix for genuine doc-storage entities via an explicit opt-in used by the entities records surface.

## Changes

- `packages/core/src/modules/query_index/lib/engine.ts`: `isCustomEntity` checks `resolveRegisteredEntityTableName` before the doc-rows fallback — a registered ORM table always wins; `query()` honors the new `forceCustomEntityStorage` option.
- `packages/shared/src/lib/query/types.ts`: additive optional `QueryOptions.forceCustomEntityStorage` (hybrid-engine-only, documented).
- `packages/core/src/modules/entities/api/records.ts`: the records browser GET passes `forceCustomEntityStorage` when its own `detectCustomEntity` says doc-backed, so dual-declared ids (e.g. `example:todo`) keep reading doc records (TC-ENT-2055 stays green). Release note: for dual-declared table-backed ids this surface now consistently lists doc records instead of being state-dependent.
- `packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts`: repro (fails pre-fix) + guards for doc-only entities and the explicit opt-in.
- `packages/core/src/modules/customers/__integration__/TC-CRM-2939-deals-list-stray-doc-rows.spec.ts`: e2e regression — plants a stray doc row via `/api/entities/records`, asserts `/api/customers/deals` still returns table-backed deals and not the stray record.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
n/a — regression fix; root-cause analysis documented in #2939.

## Testing

- `yarn workspace @open-mercato/core test __tests__/hybrid-engine` — 22/22 (repro verified red on pre-fix code: 1 failed / 21 passed)
- `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn typecheck` — green
- `yarn test` — 702 suites / 5787 tests passed
- `yarn build:app` — green
- Ephemeral integration env: `BASE_URL=http://127.0.0.1:5001 npx playwright test --config .ai/qa/tests/playwright.config.ts TC-CRM-2939 TC-ENT-2055 --retries=0` — 2 passed
- `yarn lint` — fails on develop too (pre-existing ESLint 10 × eslint-plugin-react rule-loading crash on `next.config.ts`, unrelated to this diff)

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No user-facing strings or generated registries affected; new option documented via JSDoc on the shared type.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (module-local `__integration__/TC-CRM-2939-…` per current convention; discovered by the shared Playwright config).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (Not applicable — bug fix.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI changes
- [x] No arbitrary text sizes — N/A, no UI changes
- [x] Empty state handled for list/data pages — N/A, no UI changes
- [x] Loading state handled for async pages — N/A, no UI changes
- [x] `aria-label` on all icon-only buttons — N/A, no UI changes
- [x] Uses existing DS components — N/A, no UI changes

## Linked issues

Fixes #2939