### PR TITLE
fix(ui): render profile dropdown in a body portal so it clears sticky table columns (#2941)

### DIFF
--- a/packages/ui/src/backend/ProfileDropdown.tsx
+++ b/packages/ui/src/backend/ProfileDropdown.tsx
@@ -1,5 +1,6 @@
 'use client'
 import * as React from 'react'
+import { createPortal } from 'react-dom'
 import Link from 'next/link'
 import { User, LogOut, Bell, Moon, Sun, Globe, Key, Check, ChevronRight } from 'lucide-react'
 import { useT, useLocale } from '@open-mercato/shared/lib/i18n/context'
@@ -20,6 +21,8 @@ export type ProfileDropdownProps = {
   changePasswordHref?: string
   notificationsHref?: string
 }
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect
 
 const localeLabels: Record<Locale, string> = {
   en: 'English',
@@ -42,11 +45,38 @@ export function ProfileDropdown({
   const [mounted, setMounted] = React.useState(false)
   const buttonRef = React.useRef<HTMLButtonElement>(null)
   const menuRef = React.useRef<HTMLDivElement>(null)
+  const [menuPosition, setMenuPosition] = React.useState<{ top: number; right: number } | null>(null)
   const { items: injectedItems } = useInjectedMenuItems('menu:topbar:profile-dropdown')
 
   React.useEffect(() => {
     setMounted(true)
   }, [])
+
+  // Position the portaled menu under the trigger. Rendering the menu in a body
+  // portal keeps it out of the sticky header's backdrop-blur stacking context so
+  // it always paints above page content such as the DataTable sticky Actions column.
+  useIsomorphicLayoutEffect(() => {
+    if (!open) {
+      setMenuPosition(null)
+      return
+    }
+    const updatePosition = () => {
+      const trigger = buttonRef.current
+      if (!trigger) return
+      const rect = trigger.getBoundingClientRect()
+      setMenuPosition({
+        top: rect.bottom + 8,
+        right: Math.max(0, window.innerWidth - rect.right),
+      })
+    }
+    updatePosition()
+    window.addEventListener('resize', updatePosition)
+    window.addEventListener('scroll', updatePosition, true)
+    return () => {
+      window.removeEventListener('resize', updatePosition)
+      window.removeEventListener('scroll', updatePosition, true)
+    }
+  }, [open])
 
   const isDark = resolvedTheme === 'dark'
 
@@ -336,10 +366,11 @@ export function ProfileDropdown({
         <User className="size-4" />
       </IconButton>
 
-      {open && (
+      {open && menuPosition && typeof document !== 'undefined' && createPortal(
         <div
           ref={menuRef}
-          className="absolute right-0 top-full z-popover mt-2 w-64 overflow-hidden rounded-lg border bg-popover p-0 shadow-lg"
+          className="fixed z-popover w-64 overflow-hidden rounded-lg border bg-popover p-0 shadow-lg"
+          style={{ top: menuPosition.top, right: menuPosition.right }}
           role="menu"
           data-testid="profile-dropdown"
         >
@@ -384,7 +415,8 @@ export function ProfileDropdown({
               context={injectionContext}
             />
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   )

--- a/packages/ui/src/backend/__tests__/ProfileDropdown.test.tsx
+++ b/packages/ui/src/backend/__tests__/ProfileDropdown.test.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+
+jest.mock('next/link', () => {
+  const MockLink = ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...rest}>{children}</a>
+  )
+  MockLink.displayName = 'MockLink'
+  return MockLink
+})
+
+jest.mock('../injection/InjectionSpot', () => ({
+  InjectionSpot: () => null,
+}))
+
+jest.mock('../injection/useInjectedMenuItems', () => ({
+  useInjectedMenuItems: () => ({ items: [], isLoading: false }),
+}))
+
+jest.mock('@open-mercato/ui/theme', () => ({
+  useTheme: () => ({ theme: 'light', resolvedTheme: 'light', setTheme: jest.fn() }),
+}))
+
+import { ProfileDropdown } from '../ProfileDropdown'
+
+describe('ProfileDropdown', () => {
+  it('does not render the menu until the trigger is clicked', () => {
+    renderWithProviders(<ProfileDropdown email="user@example.com" />)
+    expect(screen.queryByTestId('profile-dropdown')).not.toBeInTheDocument()
+  })
+
+  it('renders the open menu in a body portal so it escapes the header stacking context', () => {
+    renderWithProviders(<ProfileDropdown email="user@example.com" />)
+
+    fireEvent.click(screen.getByTestId('profile-dropdown-trigger'))
+
+    const menu = screen.getByTestId('profile-dropdown')
+    expect(menu).toBeInTheDocument()
+    // createPortal mounts the menu directly under document.body, outside the
+    // sticky header's backdrop-blur stacking context (regression: issue #2941).
+    expect(menu.parentElement).toBe(document.body)
+    // It must use fixed positioning + the popover layer rather than being
+    // absolutely positioned inside the header.
+    expect(menu.className).toContain('fixed')
+    expect(menu.className).toContain('z-popover')
+    expect(menu.className).not.toContain('absolute')
+  })
+
+  it('closes the menu (unmounting the portal) on Escape', () => {
+    renderWithProviders(<ProfileDropdown email="user@example.com" />)
+
+    fireEvent.click(screen.getByTestId('profile-dropdown-trigger'))
+    expect(screen.getByTestId('profile-dropdown')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('profile-dropdown')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #2941

## Problem
The user/profile dropdown (top-right person icon) renders **behind** the DataTable's sticky **Actions** column. With the dropdown open over a list page that has a sticky right-hand Actions column (e.g. Customers → Companies), the "Actions" header label and the `…` row-action buttons bleed through and overlap the menu.

## Root Cause
A cross-stacking-context issue, not a numeric z-index problem:

- The AppShell header (`AppShell.tsx`) is `sticky top-0 z-sticky` **with `backdrop-blur`**, which establishes its own stacking context. The dropdown was anchored inside that header (`absolute … z-popover`), so its `z-popover` (45) only orders it *within the header's context*; relative to the page the entire header sits at `z-sticky` (10).
- The DataTable sticky Actions column cells (`DataTable.tsx`: header `z-dropdown`/20, body `z-sticky`/10) live in the main content area, which is **not** a stacking context, so they bubble up and paint above the header — and therefore above the dropdown — despite the lower numeric z-index.

## What Changed
- `packages/ui/src/backend/ProfileDropdown.tsx`: render the open menu through a React portal to `document.body` with `fixed` positioning derived from the trigger's bounding rect. This takes the menu out of the header's `backdrop-blur` stacking context entirely, so `z-popover` reliably wins against page content (including sticky table columns).
- Position is computed on open and recomputed on `resize`/`scroll` (capture) while open; listeners are torn down on close.
- Existing behavior preserved: click-outside close, `Escape` close, language submenu, theme toggle, injected menu items, and the `profile-dropdown` / `profile-dropdown-trigger` test ids.

This follows the issue's recommended primary fix (portal the dropdown) rather than bumping sticky-cell z-indexes, which the report notes can cause sticky columns to cover other overlays.

## Tests
- New `packages/ui/src/backend/__tests__/ProfileDropdown.test.tsx`:
  - menu is not rendered until the trigger is clicked;
  - when open, the menu is mounted directly under `document.body` (portal) and uses `fixed` + `z-popover` (not `absolute`) — the regression assertion;
  - `Escape` unmounts the portal.
- `yarn workspace @open-mercato/ui test` — 176 suites / 1522 tests pass.
- `yarn turbo run typecheck --filter=@open-mercato/ui` — passes.

## Backward Compatibility
No contract surface changes. `ProfileDropdown` props, exports, injection spot (`menu:topbar:profile-dropdown`), and test ids are unchanged; only the menu's DOM mount location and positioning strategy changed.