### PR TITLE
security(audit_logs): harden redo endpoint scope guard (#2931)

### DIFF
--- a/packages/core/src/modules/audit_logs/api/__tests__/redo.route.test.ts
+++ b/packages/core/src/modules/audit_logs/api/__tests__/redo.route.test.ts
@@ -167,4 +167,73 @@ describe('POST /api/audit_logs/audit-logs/actions/redo', () => {
       organizationId: null,
     })
   })
+
+  // Regression for issue #2931 — a caller with a null tenantId (tenant-less global
+  // account or unscoped API key) must NOT redo a tenant-scoped row. The old guard
+  // (`log.tenantId && auth.tenantId && ...`) short-circuited to "allow" whenever
+  // auth.tenantId was null, mirroring the pre-#2685 undo defect.
+  it('rejects a tenant-less caller redoing a tenant-scoped row', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: null,
+      orgId: null,
+    })
+    const log = {
+      id: 'log-1',
+      commandId: 'demo.command',
+      actorUserId: 'user-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      resourceKind: 'auth.user',
+      resourceId: 'user-42',
+      executionState: 'undone',
+      commandPayload: { __redoInput: {} },
+      contextJson: null,
+    }
+    mockLogs.findById.mockResolvedValue(log)
+    mockLogs.latestUndoneForActor.mockResolvedValue(log)
+
+    const res = await POST(makeRequest({ logId: 'log-1' }))
+    expect(res.status).toBe(400)
+    expect(mockCommandBus.execute).not.toHaveBeenCalled()
+  })
+
+  // Regression for issue #2931 — a regular caller (no audit_logs.redo_tenant) whose
+  // organization scope resolves to null must NOT redo an org-scoped row. The old org
+  // guard (`log.organizationId && scopedOrgId && ...`) skipped rejection when
+  // scopedOrgId was null; only tenant-level redoers may legitimately leave org null.
+  it('rejects a regular caller with null org scope redoing an org-scoped row', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    const { resolveFeatureCheckContext } = await import('@open-mercato/core/modules/directory/utils/organizationScope')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: null,
+    })
+    ;(resolveFeatureCheckContext as jest.Mock).mockResolvedValue({
+      organizationId: null,
+      scope: { allowedIds: null },
+    })
+    mockRbac.userHasAllFeatures.mockResolvedValue(false)
+
+    const log = {
+      id: 'log-2',
+      commandId: 'demo.command',
+      actorUserId: 'user-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      resourceKind: 'auth.user',
+      resourceId: 'user-42',
+      executionState: 'undone',
+      commandPayload: { __redoInput: {} },
+      contextJson: null,
+    }
+    mockLogs.findById.mockResolvedValue(log)
+    mockLogs.latestUndoneForActor.mockResolvedValue(log)
+
+    const res = await POST(makeRequest({ logId: 'log-2' }))
+    expect(res.status).toBe(400)
+    expect(mockCommandBus.execute).not.toHaveBeenCalled()
+  })
 })

--- a/packages/core/src/modules/audit_logs/api/audit-logs/actions/redo/route.ts
+++ b/packages/core/src/modules/audit_logs/api/audit-logs/actions/redo/route.ts
@@ -70,10 +70,22 @@ export async function POST(req: Request) {
   if (log.actorUserId && log.actorUserId !== auth.sub && !canRedoTenant) {
     return NextResponse.json({ error: 'Redo target not available' }, { status: 400 })
   }
-  if (log.tenantId && auth.tenantId && log.tenantId !== auth.tenantId) {
+  // Fail closed on tenant scope: `audit_logs.redo_tenant` only widens scope WITHIN a
+  // tenant, never across tenants, so a tenant-scoped target always requires a caller
+  // bound to that same tenant. A caller whose tenantId is null (tenant-less global
+  // account or unscoped API key) must never redo a tenant-scoped row. Mirrors the
+  // hardened undo route (issue #2685, ported in #2931).
+  if (log.tenantId && log.tenantId !== (auth.tenantId ?? null)) {
     return NextResponse.json({ error: 'Redo target not available' }, { status: 400 })
   }
-  if (log.organizationId && scopedOrgId && log.organizationId !== scopedOrgId) {
+  // Tenant-level redoers may redo across organizations within the tenant, so an
+  // unresolved (null) caller org is allowed and only an explicit mismatch is rejected.
+  // Every other caller must resolve to the target's own organization — a null caller
+  // org must not bypass an org-scoped target (issue #2685, ported in #2931).
+  const orgScopeMismatch = canRedoTenant
+    ? Boolean(log.organizationId && scopedOrgId && log.organizationId !== scopedOrgId)
+    : Boolean(log.organizationId && log.organizationId !== scopedOrgId)
+  if (orgScopeMismatch) {
     return NextResponse.json({ error: 'Redo target not available' }, { status: 400 })
   }
 


### PR DESCRIPTION
Fixes #2931

## Problem
The audit-log **redo** endpoint guarded its tenant and organization scope with the pre-#2685 "both operands must be truthy" comparison pattern. The matching fix was applied to the **undo** endpoint in #2685 but never ported to its redo mirror, so the redo scope guard fails open for a tenant-less / org-less caller (it relies on a transitive downstream `latestUndoneForActor` re-check to stay safe).

## Root Cause
`packages/core/src/modules/audit_logs/api/audit-logs/actions/redo/route.ts`:
- `if (log.tenantId && auth.tenantId && log.tenantId !== auth.tenantId)` — the `&& auth.tenantId` gate short-circuits to "allow" when the caller's `tenantId` is null.
- `if (log.organizationId && scopedOrgId && log.organizationId !== scopedOrgId)` — the `&& scopedOrgId` gate skips rejection when the caller's resolved org is null, even for a regular (non-`redo_tenant`) caller.

## What Changed
Ported the #2685 fail-closed guards verbatim from the undo route:
- **Tenant:** `if (log.tenantId && log.tenantId !== (auth.tenantId ?? null))` — a null-tenant caller can no longer redo a tenant-scoped row.
- **Org:** `canRedoTenant ? Boolean(log.organizationId && scopedOrgId && log.organizationId !== scopedOrgId) : Boolean(log.organizationId && log.organizationId !== scopedOrgId)` — only tenant-level redoers may leave the caller org null; every other caller must match the target's organization.

## Tests
Added two regression tests in `redo.route.test.ts` mirroring the undo #2685 cases (verified failing against the old guards, passing with the fix):
- tenant-less caller redoing a tenant-scoped row → 400 at the guard
- regular caller with null org scope redoing an org-scoped row → 400 at the guard

Checks run: `yarn workspace @open-mercato/core test -- audit_logs` (47 passed), `yarn build:packages`, `yarn generate`, core `tsc --noEmit` (clean).

## Security impact
Hardens an authorization guard on a sensitive operation (re-executing a previously-undone command). The guard now fails closed on null caller tenant/org scope instead of depending on a transitive secondary lookup. No API path, response shape, or ACL feature changed; the change only rejects cases that were never intended to be authorized.

## Backward Compatibility
No contract surface changes — route path, request/response schema, and ACL features are unchanged. Behavior change is strictly a tightening of an internal scope guard, matching the already-accepted #2685 hardening on the undo mirror.