### PR TITLE
security(progress): scope job detail GET/PUT/DELETE by organizationId (#2930)

### DIFF
--- a/packages/core/src/modules/progress/__tests__/progressService.test.ts
+++ b/packages/core/src/modules/progress/__tests__/progressService.test.ts
@@ -443,6 +443,79 @@ describe('progress service', () => {
   })
 })
 
+describe('progress service — organization scoping (#2930)', () => {
+  const orgCtx = {
+    tenantId: '7f4c85ef-f8f7-4e53-9df1-42e95bd8d48e',
+    organizationId: 'b1d0c2a4-1111-4e53-9df1-42e95bd8d999',
+    userId: '2d4a4c33-9c4b-4e39-8e15-0a3cd9a7f432',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFindOneWithDecryption.mockReset()
+  })
+
+  it('getJob — scopes the lookup by organizationId when ctx provides one', async () => {
+    const em = buildEm()
+    const job = { id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId } as unknown as ProgressJob
+    em.findOne.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, { emit: jest.fn() })
+    await service.getJob('job-1', orgCtx)
+
+    expect(em.findOne).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId })
+    )
+  })
+
+  it('getJob — omits organizationId when ctx has none (superadmin/system)', async () => {
+    const em = buildEm()
+    em.findOne.mockResolvedValue(null)
+
+    const service = createProgressService(em as never, { emit: jest.fn() })
+    await service.getJob('job-1', { ...orgCtx, organizationId: null })
+
+    const filter = em.findOne.mock.calls[0][1]
+    expect(filter).not.toHaveProperty('organizationId')
+    expect(filter).toMatchObject({ id: 'job-1', tenantId: orgCtx.tenantId })
+  })
+
+  it('updateProgress — scopes the lookup by organizationId when ctx provides one', async () => {
+    const em = buildEm()
+    const job = { id: 'job-1', status: 'running', processedCount: 0, totalCount: null, startedAt: null, meta: null } as unknown as ProgressJob
+    em.findOneOrFail.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, { emit: jest.fn().mockResolvedValue(undefined) })
+    await service.updateProgress('job-1', { processedCount: 1 }, orgCtx)
+
+    expect(em.findOneOrFail).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId })
+    )
+  })
+
+  it('cancelJob — scopes the lookup by organizationId when ctx provides one', async () => {
+    const em = buildEm()
+    const job = { id: 'job-1', status: 'pending', cancellable: true } as unknown as ProgressJob
+    em.findOneOrFail.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, { emit: jest.fn().mockResolvedValue(undefined) })
+    await service.cancelJob('job-1', orgCtx)
+
+    expect(em.findOneOrFail).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        id: 'job-1',
+        tenantId: orgCtx.tenantId,
+        organizationId: orgCtx.organizationId,
+        cancellable: true,
+        status: { $in: ['pending', 'running'] },
+      })
+    )
+  })
+})
+
 describe('calculateProgressPercent', () => {
   it('returns correct percentage', () => {
     expect(calculateProgressPercent(50, 100)).toBe(50)

--- a/packages/core/src/modules/progress/api/jobs/[id]/route.ts
+++ b/packages/core/src/modules/progress/api/jobs/[id]/route.ts
@@ -26,6 +26,7 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
   const job = await em.findOne(ProgressJob, {
     id: params.id,
     tenantId: auth.tenantId,
+    ...(auth.orgId ? { organizationId: auth.orgId } : {}),
   })
 
   if (!job) {
@@ -74,7 +75,11 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
 
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
-  const existing = await em.findOne(ProgressJob, { id: params.id, tenantId: auth.tenantId })
+  const existing = await em.findOne(ProgressJob, {
+    id: params.id,
+    tenantId: auth.tenantId,
+    ...(auth.orgId ? { organizationId: auth.orgId } : {}),
+  })
   if (!existing) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }

--- a/packages/core/src/modules/progress/lib/progressServiceImpl.ts
+++ b/packages/core/src/modules/progress/lib/progressServiceImpl.ts
@@ -75,7 +75,11 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
     },
 
     async updateProgress(jobId, input, ctx) {
-      const job = await em.findOneOrFail(ProgressJob, { id: jobId, tenantId: ctx.tenantId })
+      const job = await em.findOneOrFail(ProgressJob, {
+        id: jobId,
+        tenantId: ctx.tenantId,
+        ...(ctx.organizationId ? { organizationId: ctx.organizationId } : {}),
+      })
       if (job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') {
         return job
       }
@@ -197,6 +201,7 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
       const job = await em.findOneOrFail(ProgressJob, {
         id: jobId,
         tenantId: ctx.tenantId,
+        ...(ctx.organizationId ? { organizationId: ctx.organizationId } : {}),
         cancellable: true,
         status: { $in: ['pending', 'running'] },
       })
@@ -279,6 +284,7 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
       return em.findOne(ProgressJob, {
         id: jobId,
         tenantId: ctx.tenantId,
+        ...(ctx.organizationId ? { organizationId: ctx.organizationId } : {}),
       })
     },
 


### PR DESCRIPTION
Fixes #2930

## Problem
The progress-job detail endpoints (`GET/PUT/DELETE /api/progress/jobs/{id}`) scoped their DB lookups by `tenantId` only. Because Open Mercato is multi-organization within a tenant, an authenticated user in organization A could read, update progress/heartbeat, or cancel progress jobs owned by organization B in the same tenant (cross-org information disclosure + integrity/DoS). The list endpoint already filtered by organization, so the detail routes were the inconsistency.

## Root Cause
- `api/jobs/[id]/route.ts` GET + PUT pre-check used `{ id, tenantId }`.
- `lib/progressServiceImpl.ts` `getJob` / `updateProgress` / `cancelJob` (called by GET/PUT/DELETE) resolved by `{ id, tenantId }` and ignored the `organizationId` already present in `ctx`.

## What Changed
- Added conditional `organizationId` scoping to every detail lookup, mirroring the existing list route and `getActiveJobs` pattern: `...(orgId ? { organizationId: orgId } : {})`.
  - Route GET `findOne` and PUT pre-check `findOne` now include `auth.orgId`.
  - Service `getJob`, `updateProgress`, `cancelJob` now apply `ctx.organizationId` to the WHERE clause.
- DELETE is covered transitively: `cancelJob` is now org-scoped, so a cross-org cancel resolves to no match and returns the existing `400`.
- Superadmin/system contexts with a null org scope are unaffected (the filter is omitted when no org is present), so workers and cross-org admin reads keep working.

## Tests
- New unit regression tests in `progressService.test.ts` assert the `organizationId` filter is applied to `getJob` / `updateProgress` / `cancelJob` when `ctx` provides an org, and omitted when it does not.
- `yarn workspace @open-mercato/core test src/modules/progress/__tests__/` → 30 passed.
- `yarn workspace @open-mercato/core typecheck` → clean.

## Security impact
- **Authorization / access control**: closes a cross-organization (within-tenant) read/update/cancel on progress jobs. No change to authentication, secrets, encryption, logging, or audit trails. Behavior change is intentional and additive (tighter scoping); no API response fields, routes, event IDs, DI names, or ACL features changed.

## Backward Compatibility
- No contract-surface changes. Service method signatures unchanged. The only behavioral change is that cross-org detail access is now denied, which is the fix.