### PR TITLE
security(search): escape LIKE wildcards in list-search $ilike patterns (#2932)

### DIFF
--- a/apps/mercato/src/modules/example/api/todos/route.ts
+++ b/apps/mercato/src/modules/example/api/todos/route.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod'
 import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { Todo } from '../../data/entities'
 
 const ENTITY_ID = 'example:todo' as const
@@ -105,7 +106,7 @@ export const { metadata, GET, POST, PUT, DELETE } = makeCrudRoute({
         if (ids.length > 0) F.id = { $in: ids }
       }
       if (q.id) F.id = q.id
-      if (q.title) F.title = { $ilike: `%${q.title}%` }
+      if (q.title) F.title = { $ilike: `%${escapeLikePattern(q.title)}%` }
       if (q.isDone !== undefined) F.is_done = q.isDone as any
       if (q.organizationId) F.organization_id = q.organizationId
       if (q.createdFrom || q.createdTo) {

--- a/packages/checkout/src/modules/checkout/api/links/route.ts
+++ b/packages/checkout/src/modules/checkout/api/links/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { FilterQuery } from '@mikro-orm/postgresql'
 import { findAndCountWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { CheckoutLink } from '../../data/entities'
 import { serializeLinkRecord } from '../../commands/links'
 import {
@@ -35,9 +36,9 @@ export async function GET(req: Request) {
     const pricingMode = url.searchParams.get('pricingMode')
     if (search) {
       where.$or = [
-        { name: { $ilike: `%${search}%` } },
-        { title: { $ilike: `%${search}%` } },
-        { slug: { $ilike: `%${search}%` } },
+        { name: { $ilike: `%${escapeLikePattern(search)}%` } },
+        { title: { $ilike: `%${escapeLikePattern(search)}%` } },
+        { slug: { $ilike: `%${escapeLikePattern(search)}%` } },
       ]
     }
     if (templateId) where.templateId = templateId

--- a/packages/checkout/src/modules/checkout/api/templates/route.ts
+++ b/packages/checkout/src/modules/checkout/api/templates/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { FilterQuery } from '@mikro-orm/postgresql'
 import { findAndCountWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { CheckoutLinkTemplate } from '../../data/entities'
 import { checkoutTag } from '../openapi'
 import {
@@ -33,8 +34,8 @@ export async function GET(req: Request) {
     }
     if (search) {
       where.$or = [
-        { name: { $ilike: `%${search}%` } },
-        { title: { $ilike: `%${search}%` } },
+        { name: { $ilike: `%${escapeLikePattern(search)}%` } },
+        { title: { $ilike: `%${escapeLikePattern(search)}%` } },
       ]
     }
     if (pricingMode === 'fixed' || pricingMode === 'custom_amount' || pricingMode === 'price_list') where.pricingMode = pricingMode

--- a/packages/checkout/src/modules/checkout/api/transactions/route.ts
+++ b/packages/checkout/src/modules/checkout/api/transactions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { findAndCountWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { CheckoutLink, CheckoutTransaction } from '../../data/entities'
 import { handleCheckoutRouteError, requireAdminContext, userHasCheckoutFeature } from '../helpers'
 import { checkoutTag } from '../openapi'
@@ -27,10 +28,10 @@ export async function GET(req: Request) {
     if (linkId) where.linkId = linkId
     if (status) where.status = status
     if (search) where.$or = [
-      { email: { $ilike: `%${search}%` } },
-      { firstName: { $ilike: `%${search}%` } },
-      { lastName: { $ilike: `%${search}%` } },
-      { id: { $ilike: `%${search}%` } },
+      { email: { $ilike: `%${escapeLikePattern(search)}%` } },
+      { firstName: { $ilike: `%${escapeLikePattern(search)}%` } },
+      { lastName: { $ilike: `%${escapeLikePattern(search)}%` } },
+      { id: { $ilike: `%${escapeLikePattern(search)}%` } },
     ]
     const [items, total] = await findAndCountWithDecryption(
       em,

--- a/packages/core/src/modules/currencies/api/currencies/route.ts
+++ b/packages/core/src/modules/currencies/api/currencies/route.ts
@@ -6,6 +6,7 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import type { FilterQuery } from '@mikro-orm/core'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { currencyCreateSchema, currencyUpdateSchema } from '../../data/validators'
 import {
   createCurrenciesCrudOpenApi,
@@ -148,9 +149,9 @@ export async function GET(req: Request) {
   if (code) filter.code = code
   if (search) {
     filter.$or = [
-      { code: { $ilike: `%${search}%` } },
-      { name: { $ilike: `%${search}%` } },
-      { symbol: { $ilike: `%${search}%` } },
+      { code: { $ilike: `%${escapeLikePattern(search)}%` } },
+      { name: { $ilike: `%${escapeLikePattern(search)}%` } },
+      { symbol: { $ilike: `%${escapeLikePattern(search)}%` } },
     ]
   }
   if (isBase === 'true') filter.isBase = true

--- a/packages/core/src/modules/customer_accounts/api/admin/roles.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/roles.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc, OpenApiMethodDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { CustomerRole, CustomerRoleAcl } from '@open-mercato/core/modules/customer_accounts/data/entities'
 import { createRoleSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
@@ -37,7 +38,7 @@ export async function GET(req: Request) {
   }
 
   if (search) {
-    const escapedSearch = search.replace(/[%_\\]/g, '\\$&')
+    const escapedSearch = escapeLikePattern(search)
     where.$or = [
       { name: { $ilike: `%${escapedSearch}%` } },
       { slug: { $ilike: `%${escapedSearch}%` } },

--- a/packages/core/src/modules/workflows/api/definitions/route.ts
+++ b/packages/core/src/modules/workflows/api/definitions/route.ts
@@ -9,6 +9,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
@@ -93,8 +94,8 @@ export async function GET(request: NextRequest) {
 
     if (search) {
       where.$or = [
-        { workflowId: { $ilike: `%${search}%` } },
-        { workflowName: { $ilike: `%${search}%` } },
+        { workflowId: { $ilike: `%${escapeLikePattern(search)}%` } },
+        { workflowName: { $ilike: `%${escapeLikePattern(search)}%` } },
       ]
     }
 

--- a/packages/create-app/template/src/modules/example/api/todos/route.ts
+++ b/packages/create-app/template/src/modules/example/api/todos/route.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod'
 import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { Todo } from '../../data/entities'
 
 const ENTITY_ID = 'example:todo' as const
@@ -105,7 +106,7 @@ export const { metadata, GET, POST, PUT, DELETE } = makeCrudRoute({
         if (ids.length > 0) F.id = { $in: ids }
       }
       if (q.id) F.id = q.id
-      if (q.title) F.title = { $ilike: `%${q.title}%` }
+      if (q.title) F.title = { $ilike: `%${escapeLikePattern(q.title)}%` }
       if (q.isDone !== undefined) F.is_done = q.isDone as any
       if (q.organizationId) F.organization_id = q.organizationId
       if (q.createdFrom || q.createdTo) {

--- a/packages/shared/src/lib/db/__tests__/escapeLikePattern.test.ts
+++ b/packages/shared/src/lib/db/__tests__/escapeLikePattern.test.ts
@@ -1,0 +1,123 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative, sep } from 'node:path'
+import { escapeLikePattern } from '../escapeLikePattern'
+
+describe('escapeLikePattern', () => {
+  it('escapes LIKE wildcards and the escape character', () => {
+    expect(escapeLikePattern('%')).toBe('\\%')
+    expect(escapeLikePattern('_')).toBe('\\_')
+    expect(escapeLikePattern('\\')).toBe('\\\\')
+    expect(escapeLikePattern('a%b_c')).toBe('a\\%b\\_c')
+  })
+
+  it('escapes the backslash before the wildcards so the escape itself is literal', () => {
+    expect(escapeLikePattern('100%\\_')).toBe('100\\%\\\\\\_')
+  })
+
+  it('leaves ordinary input untouched', () => {
+    expect(escapeLikePattern('hello world')).toBe('hello world')
+    expect(escapeLikePattern('')).toBe('')
+  })
+})
+
+/**
+ * Regression guard for #2932 (and the earlier #2734 fix).
+ *
+ * Every user-supplied value interpolated into a MikroORM `$ilike` pattern under
+ * any module's `api/**` tree MUST flow through `escapeLikePattern`, otherwise a
+ * caller can inject LIKE metacharacters (`%`, `_`, `\`) to broaden predicates or
+ * force pathological full scans. This scans the whole monorepo so a NEW unescaped
+ * `$ilike` interpolation in any package or app fails the build.
+ */
+function findRepoRoot(start: string): string {
+  let current = start
+  for (let depth = 0; depth < 12; depth += 1) {
+    if (existsSync(join(current, 'packages')) && existsSync(join(current, 'apps'))) {
+      return current
+    }
+    const parent = dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+  throw new Error('[internal] could not locate monorepo root for $ilike guard')
+}
+
+const SKIP_DIRS = new Set(['node_modules', '__tests__', 'generated', 'dist', '.next', '.mercato'])
+
+function collectApiSourceFiles(dir: string, acc: string[]): void {
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return
+  }
+  for (const name of entries) {
+    const full = join(dir, name)
+    let stat
+    try {
+      stat = statSync(full)
+    } catch {
+      continue
+    }
+    if (stat.isDirectory()) {
+      if (SKIP_DIRS.has(name)) continue
+      collectApiSourceFiles(full, acc)
+    } else if (
+      (name.endsWith('.ts') || name.endsWith('.tsx')) &&
+      !name.endsWith('.test.ts') &&
+      !name.endsWith('.test.tsx') &&
+      full.split(sep).includes('api')
+    ) {
+      acc.push(full)
+    }
+  }
+}
+
+const BARE_IDENTIFIER = /^[A-Za-z_$][\w$]*$/
+
+function isPreEscapedVariable(expr: string, source: string): boolean {
+  if (!BARE_IDENTIFIER.test(expr)) return false
+  const assignedFromEscape = new RegExp(`\\b${expr}\\s*=\\s*escapeLikePattern\\(`)
+  return assignedFromEscape.test(source)
+}
+
+function findUnescapedIlikeInterpolations(source: string): string[] {
+  const ilikeTemplate = /\$ilike:\s*`([^`]*)`/g
+  const interpolation = /\$\{([^}]*)\}/g
+  const offenders: string[] = []
+  let templateMatch: RegExpExecArray | null
+  while ((templateMatch = ilikeTemplate.exec(source)) !== null) {
+    const literal = templateMatch[1]
+    let exprMatch: RegExpExecArray | null
+    while ((exprMatch = interpolation.exec(literal)) !== null) {
+      const expr = exprMatch[1].trim()
+      if (expr.startsWith('escapeLikePattern(')) continue
+      if (isPreEscapedVariable(expr, source)) continue
+      offenders.push(`\`${templateMatch[1]}\``)
+    }
+  }
+  return offenders
+}
+
+describe('$ilike user input must be escaped under api/** (#2932)', () => {
+  const repoRoot = findRepoRoot(__dirname)
+  const roots = [join(repoRoot, 'packages'), join(repoRoot, 'apps')]
+  const files: string[] = []
+  for (const root of roots) collectApiSourceFiles(root, files)
+
+  it('discovered api source files to scan', () => {
+    expect(files.length).toBeGreaterThan(20)
+  })
+
+  it('every $ilike pattern interpolating a variable uses escapeLikePattern', () => {
+    const violations: string[] = []
+    for (const full of files) {
+      const source = readFileSync(full, 'utf8')
+      const offenders = findUnescapedIlikeInterpolations(source)
+      if (offenders.length === 0) continue
+      const rel = relative(repoRoot, full).split(sep).join('/')
+      for (const offender of offenders) violations.push(`${rel}: ${offender}`)
+    }
+    expect(violations).toEqual([])
+  })
+})


### PR DESCRIPTION
Fixes #2932

## Problem
Several list/search endpoints interpolated the user-supplied `search` term directly into a MikroORM `$ilike` pattern (`` `%${search}%` ``) without escaping LIKE metacharacters. An authenticated caller could inject `%`/`_`/`\` to broaden predicates (enumerate records more efficiently than intended) or force pathological leading-wildcard full scans (mild DoS) within their own tenant/org scope. Same defect class the team already fixed in #2734.

## Root Cause
The shared `escapeLikePattern` helper (`@open-mercato/shared/lib/db/escapeLikePattern`) was applied in some routes (customers, `currencies/options`, `progress/jobs`) but missed on others. No guard existed to enforce its use across `api/**`.

## What Changed
Wrapped every unescaped interpolation in `escapeLikePattern`:
- `packages/core/src/modules/currencies/api/currencies/route.ts` — `code`, `name`, `symbol`
- `packages/core/src/modules/workflows/api/definitions/route.ts` — `workflowId`, `workflowName`
- `packages/checkout/src/modules/checkout/api/transactions/route.ts` — `email`, `firstName`, `lastName`, `id`
- `packages/checkout/src/modules/checkout/api/links/route.ts` — `name`, `title`, `slug`
- `packages/checkout/src/modules/checkout/api/templates/route.ts` — `name`, `title`
- `apps/mercato/src/modules/example/api/todos/route.ts` (+ the `create-app` template copy, kept in sync) — `title`

Also switched `packages/core/src/modules/customer_accounts/api/admin/roles.ts` from a divergent inline escape regex to the shared helper for consistency (behavior-preserving — both produce identical escaping).

## Tests
- New `packages/shared/src/lib/db/__tests__/escapeLikePattern.test.ts`:
  - Unit tests for `escapeLikePattern` (wildcards + escape char).
  - A repo-wide **regression guard** that scans every `api/**` source file across all packages and apps and fails if any `$ilike` template interpolates a value that does not flow through `escapeLikePattern` (recognizes both direct calls and values pre-escaped into a variable). Verified it fails when a raw `%${search}%` is reintroduced.
- Ran `yarn build:packages` → `yarn generate` → `yarn build:packages`, `yarn typecheck` (shared, checkout, core, app), and `yarn test` (shared, checkout, core: 5784 passing).

## Backward Compatibility
No contract surface changes. Pure input-escaping hardening — API request/response shapes, event IDs, and DI names are unchanged.

## Security impact
Hardens authorization-adjacent input handling: prevents LIKE-metacharacter injection into search predicates (over-broad matching / scan-based probing) on the listed list endpoints. No change to authentication, encryption, logging, or access control; tenant/org scoping is unchanged.