### PR TITLE
fix: 2933 redact 500 error stack

### DIFF
--- a/packages/core/src/modules/data_sync/api/__tests__/run.test.ts
+++ b/packages/core/src/modules/data_sync/api/__tests__/run.test.ts
@@ -127,4 +127,23 @@ describe('data_sync run route', () => {
     })
     expect(mockStartDataSyncRun).toHaveBeenCalled()
   })
+
+  it('does not leak the error message or stack in the 500 response (CWE-209)', async () => {
+    const internalDetail = '/srv/app/internal at customers_pkey; connection tenant_secret'
+    mockStartDataSyncRun.mockRejectedValueOnce(new Error(internalDetail))
+
+    const response = await postHandler(new Request('http://localhost/api/data_sync/run', {
+      method: 'POST',
+      body: JSON.stringify({
+        integrationId: 'generic_sync',
+        entityType: 'customers.person',
+        direction: 'import',
+      }),
+    }))
+
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body).toEqual({ error: 'Failed to start data sync run.' })
+    expect(JSON.stringify(body)).not.toContain(internalDetail)
+  })
 })

--- a/packages/core/src/modules/data_sync/api/run.ts
+++ b/packages/core/src/modules/data_sync/api/run.ts
@@ -107,7 +107,7 @@ export async function POST(req: Request) {
     const stack = error instanceof Error ? error.stack : undefined
     console.error('[data_sync.run] unhandled error', { message, stack })
     return NextResponse.json(
-      { error: 'Failed to start data sync run.', message, stack },
+      { error: 'Failed to start data sync run.' },
       { status: 500 },
     )
   }

--- a/packages/core/src/modules/progress/api/jobs/__tests__/route.test.ts
+++ b/packages/core/src/modules/progress/api/jobs/__tests__/route.test.ts
@@ -1,0 +1,66 @@
+/** @jest-environment node */
+
+const mockGetAuthFromRequest = jest.fn()
+const mockCreateRequestContainer = jest.fn()
+const mockCreateJob = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(() => mockCreateRequestContainer()),
+}))
+
+type RouteModule = typeof import('../route')
+let postHandler: RouteModule['POST']
+
+beforeAll(async () => {
+  const routeModule = await import('../route')
+  postHandler = routeModule.POST
+})
+
+describe('progress jobs route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+    })
+    mockCreateRequestContainer.mockResolvedValue({
+      resolve: (token: string) => {
+        if (token === 'progressService') return { createJob: mockCreateJob }
+        throw new Error(`Unexpected token: ${token}`)
+      },
+    })
+    mockCreateJob.mockResolvedValue({ id: '11111111-1111-4111-8111-111111111111' })
+  })
+
+  it('creates a progress job', async () => {
+    const response = await postHandler(new Request('http://localhost/api/progress/jobs', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jobType: 'export', name: 'Export job' }),
+    }))
+
+    expect(response.status).toBe(201)
+    await expect(response.json()).resolves.toEqual({ id: '11111111-1111-4111-8111-111111111111' })
+  })
+
+  it('does not leak the error message or stack in the 500 response (CWE-209)', async () => {
+    const internalDetail = '/srv/app/internal at progress_jobs_pkey; connection tenant_secret'
+    mockCreateJob.mockRejectedValueOnce(new Error(internalDetail))
+
+    const response = await postHandler(new Request('http://localhost/api/progress/jobs', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jobType: 'export', name: 'Export job' }),
+    }))
+
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body).toEqual({ error: 'Failed to create progress job.' })
+    expect(JSON.stringify(body)).not.toContain(internalDetail)
+  })
+})

--- a/packages/core/src/modules/progress/api/jobs/route.ts
+++ b/packages/core/src/modules/progress/api/jobs/route.ts
@@ -165,7 +165,7 @@ export async function POST(req: Request) {
     const stack = error instanceof Error ? error.stack : undefined
     console.error('[progress.jobs.create] unhandled error', { message, stack })
     return NextResponse.json(
-      { error: 'Failed to create progress job.', message, stack },
+      { error: 'Failed to create progress job.' },
       { status: 500 },
     )
   }

--- a/packages/core/src/modules/sync_excel/api/import/__tests__/route.test.ts
+++ b/packages/core/src/modules/sync_excel/api/import/__tests__/route.test.ts
@@ -230,4 +230,20 @@ describe('sync_excel import route', () => {
 
     expect(response.status).toBe(404)
   })
+
+  it('does not leak the error message or stack in the 500 response (CWE-209)', async () => {
+    const internalDetail = '/srv/app/internal at sync_runs_pkey; connection tenant_secret'
+    mockStartDataSyncRun.mockRejectedValueOnce(new Error(internalDetail))
+
+    const response = await postHandler(new Request('http://localhost/api/sync_excel/import', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ok: true }),
+    }))
+
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body).toEqual({ error: 'Failed to start sync_excel import.' })
+    expect(JSON.stringify(body)).not.toContain(internalDetail)
+  })
 })

--- a/packages/core/src/modules/sync_excel/api/import/route.ts
+++ b/packages/core/src/modules/sync_excel/api/import/route.ts
@@ -190,7 +190,7 @@ export async function POST(request: Request) {
     const stack = error instanceof Error ? error.stack : undefined
     console.error('[sync_excel.import] unhandled error', { message, stack })
     return NextResponse.json(
-      { error: 'Failed to start sync_excel import.', message, stack },
+      { error: 'Failed to start sync_excel import.' },
       { status: 500 },
     )
   }


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Three authenticated POST endpoints (`data_sync.run`, `sync_excel.run`, `progress.create`)
returned the raw JavaScript error `message` and `stack` trace in their HTTP 500 JSON
response body — a CWE-209 information-disclosure weakness. The stack exposes absolute
server file paths, ORM/driver internals, and can echo SQL/constraint fragments or
secrets embedded in an exception message to any authenticated tenant user.

Each handler already logged the full `{ message, stack }` via `console.error`. This PR
drops `message`/`stack` from the response object only, so the client receives a generic
error while server-side observability is fully preserved.

## Changes

- `data_sync/api/run.ts`: 500 body now returns `{ error: 'Failed to start data sync run.' }` (was `{ error, message, stack }`)
- `sync_excel/api/import/route.ts`: 500 body now returns `{ error: 'Failed to start sync_excel import.' }`
- `progress/api/jobs/route.ts`: 500 body now returns `{ error: 'Failed to create progress job.' }`
- `console.error('[...] unhandled error', { message, stack })` retained unchanged in all three (no loss of server logs)
- Added CWE-209 regression tests for all three routes asserting the 500 body is `{ error }` only and never contains the thrown internal detail
- Audited the rest of `packages/` for the same `{ ..., message, stack }` client-leak shape: the only occurrences were these three. Other `stack` references are server-side logging or intentional stored-error-log admin viewers (out of scope)

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — targeted security bug fix.

## Testing

All run locally from the worktree (every step exit 0):
- `yarn workspace @open-mercato/core test <the 3 route test files>` → 10 passed (3 new CWE-209 tests + 7 existing). Verified RED on the pre-fix code (500 body contained `message` + full stack), GREEN after.
- `yarn turbo run typecheck --filter=@open-mercato/core` → 1 successful
- `yarn turbo run test --filter=@open-mercato/core` → 703 suites / 5788 tests passed
- `yarn i18n:check-sync` → all locales in sync
- `yarn build:packages` → ok · `yarn generate` → ok · `yarn build:app` → compiled successfully

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no new user-facing strings, no generator-discovered files, no docs surface.)
- [x] I added or adjusted tests that cover the change. (3 route-handler regression tests.)
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (N/A — backend error-response redaction with no UI flow; deterministically forcing an unhandled 500 in a live env is impractical, so coverage is at the route-handler unit level.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled — N/A, no UI
- [x] Loading state handled — N/A, no UI
- [x] `aria-label` on icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #2933