### PR TITLE
fix: 2934 tenant scoped user email

### DIFF
--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-047-cross-tenant-email.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-047-cross-tenant-email.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  deleteGeneralEntityIfExists,
+  expectId,
+  getTokenContext,
+  readJsonSafe,
+} from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+
+type CreateResponse = { id?: string }
+
+async function apiRequestWithCookie(
+  request: APIRequestContext,
+  method: string,
+  path: string,
+  options: { token: string; cookie: string; data?: unknown },
+) {
+  return request.fetch(path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${options.token}`,
+      'Content-Type': 'application/json',
+      Cookie: options.cookie,
+    },
+    data: options.data,
+  })
+}
+
+function scopeCookie(tenantId: string, organizationId: string | null): string {
+  return [
+    `om_selected_tenant=${encodeURIComponent(tenantId)}`,
+    `om_selected_org=${encodeURIComponent(organizationId ?? '__all__')}`,
+  ].join('; ')
+}
+
+async function createTenant(request: APIRequestContext, token: string, name: string): Promise<string> {
+  const response = await apiRequest(request, 'POST', '/api/directory/tenants', { token, data: { name } })
+  expect(response.status(), 'POST /api/directory/tenants should return 201').toBe(201)
+  const body = await readJsonSafe<CreateResponse>(response)
+  return expectId(body?.id, 'Tenant create response should contain an id')
+}
+
+async function createOrganization(
+  request: APIRequestContext,
+  token: string,
+  cookie: string,
+  tenantId: string,
+  name: string,
+): Promise<string> {
+  const response = await apiRequestWithCookie(request, 'POST', '/api/directory/organizations', {
+    token,
+    cookie,
+    data: { name, tenantId },
+  })
+  expect(response.status(), 'POST /api/directory/organizations should return 201').toBe(201)
+  const body = await readJsonSafe<CreateResponse>(response)
+  return expectId(body?.id, 'Organization create response should contain an id')
+}
+
+function createUser(request: APIRequestContext, token: string, organizationId: string, email: string) {
+  return apiRequest(request, 'POST', '/api/auth/users', {
+    token,
+    data: { email, password: 'StrongSecret123!', organizationId },
+  })
+}
+
+/**
+ * TC-AUTH-047: User email uniqueness is scoped per-tenant, not globally (#2934).
+ *
+ * Before the fix the `users_email_unique` global constraint (and a globally-scoped
+ * application duplicate check) let one tenant's email registration block any other tenant
+ * from using the same address and leaked cross-tenant account existence. The same email must
+ * now be usable across tenants, while remaining unique within a single tenant.
+ *
+ * Covers: POST /api/auth/users (create command duplicate-email handling + DB constraint).
+ */
+test.describe('TC-AUTH-047: Per-tenant user email uniqueness', () => {
+  test('allows the same email in different tenants but rejects duplicates within a tenant', async ({ request }) => {
+    const stamp = Date.now()
+    const token = await getAuthToken(request, 'superadmin')
+    const { tenantId: actorTenantId, organizationId: actorOrganizationId } = getTokenContext(token)
+    const actorCookie = scopeCookie(actorTenantId, actorOrganizationId || null)
+    const sharedEmail = `qa-auth-047-${stamp}@example.com`
+
+    let tenantA: string | null = null
+    let tenantB: string | null = null
+    let organizationA: string | null = null
+    let organizationB: string | null = null
+    let userAId: string | null = null
+    let userBId: string | null = null
+
+    try {
+      tenantA = await createTenant(request, token, `QA AUTH 047 Tenant A ${stamp}`)
+      tenantB = await createTenant(request, token, `QA AUTH 047 Tenant B ${stamp}`)
+      organizationA = await createOrganization(request, token, actorCookie, tenantA, `QA AUTH 047 Org A ${stamp}`)
+      organizationB = await createOrganization(request, token, actorCookie, tenantB, `QA AUTH 047 Org B ${stamp}`)
+
+      // 1) Create the user in tenant A.
+      const firstResponse = await createUser(request, token, organizationA, sharedEmail)
+      expect(firstResponse.status(), 'first user create in tenant A should succeed').toBe(201)
+      userAId = expectId((await readJsonSafe<CreateResponse>(firstResponse))?.id, 'first user id')
+
+      // 2) The SAME email in a DIFFERENT tenant must succeed (the #2934 fix). Before the fix
+      //    this returned 400 (global app check) or 500 (global unique constraint).
+      const crossTenantResponse = await createUser(request, token, organizationB, sharedEmail)
+      expect(
+        crossTenantResponse.status(),
+        'same email in a separate tenant should succeed under per-tenant uniqueness',
+      ).toBe(201)
+      userBId = expectId((await readJsonSafe<CreateResponse>(crossTenantResponse))?.id, 'second user id')
+
+      // 3) Reusing the email a second time WITHIN tenant A must still be rejected.
+      const sameTenantDuplicate = await createUser(request, token, organizationA, sharedEmail)
+      expect(
+        sameTenantDuplicate.status(),
+        'duplicate email within the same tenant should be rejected',
+      ).toBe(400)
+    } finally {
+      await deleteGeneralEntityIfExists(request, token, '/api/auth/users', userAId)
+      await deleteGeneralEntityIfExists(request, token, '/api/auth/users', userBId)
+      await deleteGeneralEntityIfExists(request, token, '/api/directory/organizations', organizationA)
+      await deleteGeneralEntityIfExists(request, token, '/api/directory/organizations', organizationB)
+      await deleteGeneralEntityIfExists(request, token, '/api/directory/tenants', tenantA)
+      await deleteGeneralEntityIfExists(request, token, '/api/directory/tenants', tenantB)
+    }
+  })
+})

--- a/packages/core/src/modules/auth/commands/__tests__/users.tenant-scoped-email.test.ts
+++ b/packages/core/src/modules/auth/commands/__tests__/users.tenant-scoped-email.test.ts
@@ -1,0 +1,170 @@
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    auth: { user: 'auth:user', role: 'auth:role' },
+    directory: { organization: 'directory:organization' },
+  },
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/email/send', () => ({
+  sendEmail: jest.fn(async () => undefined),
+}))
+
+jest.mock('@open-mercato/core/modules/auth/emails/InviteUserEmail', () => ({
+  __esModule: true,
+  default: jest.fn(() => '<email />'),
+}))
+
+const mockFindOneWithDecryption = jest.fn()
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+  findWithDecryption: jest.fn(async () => []),
+}))
+
+import '@open-mercato/core/modules/auth/commands/users'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import type { CommandHandler, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
+import { User } from '@open-mercato/core/modules/auth/data/entities'
+
+const orgId = 'e0e0e0e0-e0e0-4e0e-8e0e-e0e0e0e0e0e0'
+const tenantId = 'a0a0a0a0-a0a0-4a0a-8a0a-a0a0a0a0a0a0'
+const targetUserId = 'b0b0b0b0-b0b0-4b0b-8b0b-b0b0b0b0b0b0'
+
+function buildContext() {
+  const createdUser = {
+    id: 'c0c0c0c0-c0c0-4c0c-8c0c-c0c0c0c0c0c0',
+    email: 'new-user@example.com',
+    emailHash: 'hash',
+    passwordHash: 'pw',
+    isConfirmed: true,
+    organizationId: orgId,
+    tenantId,
+    name: null,
+  } as unknown as User
+
+  const em: any = {
+    findOne: jest.fn(async () => null),
+    find: jest.fn(async () => []),
+    create: jest.fn((_entity: unknown, data: unknown) => data),
+    flush: jest.fn(async () => undefined),
+    remove: jest.fn(function remove(this: any) { return this }),
+    persist: jest.fn(function persist(this: any) { return this }),
+    nativeDelete: jest.fn(async () => 0),
+    fork: jest.fn(() => em),
+  }
+
+  const dataEngine = {
+    createOrmEntity: jest.fn(async () => createdUser) as any,
+    setCustomFields: jest.fn(async () => undefined) as DataEngine['setCustomFields'],
+    emitOrmEntityEvent: (async () => undefined) as DataEngine['emitOrmEntityEvent'],
+    markOrmEntityChange: jest.fn() as any,
+    flushOrmEntityChanges: (async () => undefined) as DataEngine['flushOrmEntityChanges'],
+  }
+
+  const container = {
+    resolve: (token: string) => {
+      switch (token) {
+        case 'dataEngine': return dataEngine
+        case 'em': return em
+        case 'rbacService': return { invalidateUserCache: jest.fn(async () => {}) }
+        case 'cache': return { deleteByTags: jest.fn(async () => {}) }
+        case 'notificationService': return { create: jest.fn(async () => ({})) }
+        default: throw new Error(`Unexpected dependency: ${token}`)
+      }
+    },
+  }
+
+  const ctx: CommandRuntimeContext = {
+    container: container as any,
+    auth: { sub: 'd0d0d0d0-d0d0-4d0d-8d0d-d0d0d0d0d0d0', tenantId, orgId } as any,
+    organizationScope: null,
+    selectedOrganizationId: null,
+    organizationIds: null,
+    request: undefined as any,
+  }
+
+  return { em, dataEngine, ctx }
+}
+
+// Returns the where clause of the User duplicate-email lookup (the call carrying `$or`),
+// distinguishing it from the plain existing-user lookup the update path also performs.
+function findDuplicateCheckWhere(): Record<string, unknown> | undefined {
+  const call = mockFindOneWithDecryption.mock.calls.find(
+    (args) => args[1] === User && (args[2] as { $or?: unknown })?.$or !== undefined,
+  )
+  return call?.[2] as Record<string, unknown> | undefined
+}
+
+describe('auth.users.create — email uniqueness is scoped to the org tenant (#2934)', () => {
+  const handler = commandRegistry.get<Record<string, unknown>, { user: User }>('auth.users.create') as CommandHandler<Record<string, unknown>, { user: User }>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('scopes the duplicate-email check to the target tenant and allows the create when no same-tenant match exists', async () => {
+    const { dataEngine, ctx } = buildContext()
+    mockFindOneWithDecryption
+      .mockResolvedValueOnce({ id: orgId, tenant: { id: tenantId } }) // organization lookup
+      .mockResolvedValueOnce(null) // duplicate check: no live user with this email in this tenant
+
+    await handler.execute({
+      email: 'new-user@example.com',
+      password: 'StrongSecret123!',
+      organizationId: orgId,
+    }, ctx)
+
+    const where = findDuplicateCheckWhere()
+    expect(where).toBeDefined()
+    // The defect: the check used to run globally ({ tenantId: null }). It must now be scoped
+    // to the org's tenant so an identical email in another tenant is invisible to it.
+    expect(where).toMatchObject({ tenantId, deletedAt: null })
+    expect(where!.$or).toBeDefined()
+    expect(dataEngine.createOrmEntity).toHaveBeenCalledTimes(1)
+  })
+
+  it('still rejects a duplicate email that already exists within the same tenant', async () => {
+    const { ctx } = buildContext()
+    mockFindOneWithDecryption
+      .mockResolvedValueOnce({ id: orgId, tenant: { id: tenantId } }) // organization lookup
+      .mockResolvedValueOnce({ id: 'existing-same-tenant', tenantId, email: 'dup@example.com' }) // same-tenant duplicate
+
+    await expect(handler.execute({
+      email: 'dup@example.com',
+      password: 'StrongSecret123!',
+      organizationId: orgId,
+    }, ctx)).rejects.toMatchObject({ status: 400 })
+
+    expect(findDuplicateCheckWhere()).toMatchObject({ tenantId })
+  })
+})
+
+describe('auth.users.update — email uniqueness is scoped to the user tenant (#2934)', () => {
+  const handler = commandRegistry.get<Record<string, unknown>, User>('auth.users.update') as CommandHandler<Record<string, unknown>, User>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('scopes the duplicate-email check to the user existing tenant when the organization is unchanged', async () => {
+    const { ctx } = buildContext()
+    mockFindOneWithDecryption
+      .mockResolvedValueOnce({ id: targetUserId, tenantId, organizationId: orgId, deletedAt: null }) // resolveUserTenantId
+      .mockResolvedValueOnce({ id: 'someone-else', tenantId }) // same-tenant duplicate → throws
+
+    await expect(handler.execute({
+      id: targetUserId,
+      email: 'dup@example.com',
+    }, ctx)).rejects.toMatchObject({ status: 400 })
+
+    const where = findDuplicateCheckWhere()
+    expect(where).toBeDefined()
+    expect(where).toMatchObject({ tenantId, id: { $ne: targetUserId } })
+  })
+})

--- a/packages/core/src/modules/auth/commands/users.ts
+++ b/packages/core/src/modules/auth/commands/users.ts
@@ -204,9 +204,14 @@ const createUserCommand: CommandHandler<Record<string, unknown>, CreateUserResul
       { tenantId: null, organizationId: parsed.organizationId },
     )
     if (!organization) throw new CrudHttpError(400, { error: 'Organization not found' })
+    const tenantId = organization.tenant?.id ? String(organization.tenant.id) : null
 
     const emailHash = computeEmailHash(parsed.email)
-    const duplicate = await findOneWithDecryption(em, User, { $or: [{ email: parsed.email }, { emailHash: { $in: emailHashLookupValues(parsed.email) } }], deletedAt: null } as any, {}, { tenantId: null, organizationId: null })
+    // Email is unique per-tenant, not globally (see Migration20260610120000:
+    // users_tenant_email_hash_uniq). Scope the duplicate check to the target tenant so the same
+    // email may legitimately exist in other tenants without blocking creation or leaking
+    // cross-tenant account existence (#2934).
+    const duplicate = await findOneWithDecryption(em, User, { $or: [{ email: parsed.email }, { emailHash: { $in: emailHashLookupValues(parsed.email) } }], deletedAt: null, tenantId } as any, {}, { tenantId: null, organizationId: null })
     if (duplicate) await throwDuplicateEmailError()
 
     let passwordHash: string | null = null
@@ -214,7 +219,6 @@ const createUserCommand: CommandHandler<Record<string, unknown>, CreateUserResul
       const { hash } = await import('bcryptjs')
       passwordHash = await hash(parsed.password, 10)
     }
-    const tenantId = organization.tenant?.id ? String(organization.tenant.id) : null
 
     const de = (ctx.container.resolve('dataEngine') as DataEngine)
     let user: User
@@ -518,13 +522,34 @@ const updateUserCommand: CommandHandler<Record<string, unknown>, User> = {
       ? await loadUserRoleNames(em, parsed.id)
       : null
 
+    // Resolve the tenant the user will belong to after this update first, so the email
+    // duplicate check below can be scoped to it. Email is unique per-tenant, not globally
+    // (see Migration20260610120000: users_tenant_email_hash_uniq) — a matching email in another
+    // tenant must not block the update or leak cross-tenant account existence (#2934).
+    let tenantId: string | null | undefined
+    if (parsed.organizationId !== undefined) {
+      const organization = await findOneWithDecryption(
+        em,
+        Organization,
+        { id: parsed.organizationId },
+        { populate: ['tenant'] },
+        { tenantId: null, organizationId: parsed.organizationId ?? null },
+      )
+      if (!organization) throw new CrudHttpError(400, { error: 'Organization not found' })
+      tenantId = organization.tenant?.id ? String(organization.tenant.id) : null
+    }
+
     if (parsed.email !== undefined) {
+      const targetTenantId = tenantId !== undefined
+        ? tenantId
+        : await resolveUserTenantId(em, parsed.id)
       const duplicate = await findOneWithDecryption(
         em,
         User,
         {
           $or: [{ email: parsed.email }, { emailHash: { $in: emailHashLookupValues(parsed.email) } }],
           deletedAt: null,
+          tenantId: targetTenantId,
           id: { $ne: parsed.id } as any,
         } as FilterQuery<User>,
         {},
@@ -541,19 +566,6 @@ const updateUserCommand: CommandHandler<Record<string, unknown>, User> = {
     }
     if (parsed.email !== undefined) {
       emailHash = computeEmailHash(parsed.email)
-    }
-
-    let tenantId: string | null | undefined
-    if (parsed.organizationId !== undefined) {
-      const organization = await findOneWithDecryption(
-        em,
-        Organization,
-        { id: parsed.organizationId },
-        { populate: ['tenant'] },
-        { tenantId: null, organizationId: parsed.organizationId ?? null },
-      )
-      if (!organization) throw new CrudHttpError(400, { error: 'Organization not found' })
-      tenantId = organization.tenant?.id ? String(organization.tenant.id) : null
     }
 
     const actorTenantScope = resolveActorTenantScope(ctx)
@@ -1067,6 +1079,11 @@ function arrayEquals(left: string[] | undefined, right: string[]): boolean {
   if (!left) return false
   if (left.length !== right.length) return false
   return left.every((value, idx) => value === right[idx])
+}
+
+async function resolveUserTenantId(em: EntityManager, id: string): Promise<string | null> {
+  const existing = await findOneWithDecryption(em, User, { id, deletedAt: null }, {}, { tenantId: null, organizationId: null })
+  return existing?.tenantId ? String(existing.tenantId) : null
 }
 
 async function throwDuplicateEmailError(): Promise<never> {

--- a/packages/core/src/modules/auth/data/entities.ts
+++ b/packages/core/src/modules/auth/data/entities.ts
@@ -1,6 +1,16 @@
 import { Entity, Index, ManyToOne, PrimaryKey, Property, Unique } from '@mikro-orm/decorators/legacy'
 
 @Entity({ tableName: 'users' })
+// Email uniqueness is per-tenant, enforced by a partial unique index
+// (`users_tenant_email_hash_uniq`) on `(tenant_id, email_hash)` over live rows
+// (`WHERE deleted_at IS NULL AND email_hash IS NOT NULL`), owned by raw SQL in
+// Migration20260610120000. It keys on the deterministic `email_hash`, not `email`, because
+// `email` is encrypted at rest with a per-row IV (see encryption.ts) — its ciphertext is
+// non-deterministic, so a unique index on it would not detect duplicates. A `@Unique`
+// decorator can't express a partial, tenant-scoped index, so the entity omits it — the
+// migration is the source of truth. A global unique constraint contradicts the multi-tenant
+// login flow and leaks cross-tenant account existence (#2934). Mirrors
+// `customer_users_tenant_email_hash_uniq`.
 export class User {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string
@@ -11,7 +21,7 @@ export class User {
   @Property({ name: 'organization_id', type: 'uuid', nullable: true })
   organizationId?: string | null
 
-  @Property({ type: 'text', unique: true })
+  @Property({ type: 'text' })
   email!: string
 
   @Property({ name: 'email_hash', type: 'text', nullable: true })

--- a/packages/core/src/modules/auth/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/auth/migrations/.snapshot-open-mercato.json
@@ -670,16 +670,6 @@
       "indexes": [
         {
           "columnNames": [
-            "email"
-          ],
-          "composite": false,
-          "keyName": "users_email_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "columnNames": [
             "email_hash"
           ],
           "composite": false,

--- a/packages/core/src/modules/auth/migrations/Migration20260610120000.ts
+++ b/packages/core/src/modules/auth/migrations/Migration20260610120000.ts
@@ -1,0 +1,53 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// #2934: User email uniqueness must be per-tenant, not global. The original
+// `users_email_unique` constraint (unique on `email` across all tenants) contradicts the
+// multi-tenant login flow — which resolves the same email across tenants via
+// `findUsersByEmail` — and leaks cross-tenant account existence / enables registration
+// squatting. Replace it with a partial unique index scoped per-tenant over live rows.
+//
+// The index is keyed on `email_hash`, NOT `email`: `email` is encrypted at rest with a
+// per-row IV (auth/encryption.ts -> shared aes.ts), so its ciphertext is non-deterministic
+// and a unique index on it would never detect duplicates under the default (encryption-on)
+// configuration. `email_hash` is the deterministic lookup hash the application already
+// de-dupes on, so the constraint is effective in both encryption-on and encryption-off
+// modes. This mirrors `customer_users_tenant_email_hash_uniq` in customer_accounts.
+//
+// `WHERE deleted_at IS NULL` lets a soft-deleted user's email be reused (the old non-partial
+// constraint blocked this); `AND email_hash IS NOT NULL` skips the rare legacy/bootstrap rows
+// that predate hash population (encryption-off `setup-app` users) — those remain protected by
+// the tenant-scoped application duplicate check.
+//
+// Before creating the index, soft-delete any pre-existing duplicate live rows per
+// (tenant_id, email_hash), keeping the most-recently-updated one. Under encryption the old
+// `email` constraint never fired, so same-tenant duplicates were only blocked by the
+// application check and a historical race could have slipped one through; the dedupe makes
+// the index creation safe on such data (no-op when there are none).
+export class Migration20260610120000 extends Migration {
+
+  override up(): void | Promise<void> {
+    this.addSql(`
+      with ranked as (
+        select id,
+               row_number() over (
+                 partition by tenant_id, email_hash
+                 order by coalesce(updated_at, created_at) desc, created_at desc, id desc
+               ) as rn
+        from users
+        where deleted_at is null and email_hash is not null
+      )
+      update users
+      set deleted_at = now()
+      from ranked
+      where users.id = ranked.id and ranked.rn > 1;
+    `);
+    this.addSql(`alter table "users" drop constraint if exists "users_email_unique";`);
+    this.addSql(`create unique index if not exists "users_tenant_email_hash_uniq" on "users" ("tenant_id", "email_hash") where "deleted_at" is null and "email_hash" is not null;`);
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`drop index if exists "users_tenant_email_hash_uniq";`);
+    this.addSql(`alter table "users" add constraint "users_email_unique" unique ("email");`);
+  }
+
+}


### PR DESCRIPTION
## Summary

`User.email` carried a **global** unique constraint (`users_email_unique`) and the user create/update commands de-duplicated email **globally**, which contradicts Open Mercato's multi-tenant login flow (`findUsersByEmail` resolves the same email across tenants). This let a user in tenant A permanently block tenant B from registering the same real email, and leaked cross-tenant account existence via the "email already in use" path (enumeration / squatting). This change makes email uniqueness **per-tenant** at both the database and application layers.

Note: `User.email` is encrypted at rest with a per-row IV, so its ciphertext is non-deterministic — a unique index on `email` is inert under the default (encryption-on) config. The constraint is therefore keyed on the deterministic `email_hash` column (mirroring `customer_users_tenant_email_hash_uniq`), which enforces correctly in both encryption modes.

## Changes

- Drop the global `users_email_unique` constraint; replace with a partial unique index `users_tenant_email_hash_uniq` on `(tenant_id, email_hash) WHERE deleted_at IS NULL AND email_hash IS NOT NULL` (`Migration20260610120000`), with a defensive dedupe of any pre-existing same-tenant duplicate rows and a faithful `down()`. Snapshot updated.
- Remove `unique: true` from `User.email` and document the migration-owned partial index on the entity.
- Scope the duplicate-email check in `auth.users.create` and `auth.users.update` to the resolved tenant (resolve org→tenant before the check; add `resolveUserTenantId` for unchanged-org updates) so the app check matches the new constraint and never blocks/leaks across tenants.
- Add a unit test (app-level tenant scoping) and an integration test (`TC-AUTH-047`, end-to-end cross-tenant create allowed + within-tenant duplicate rejected).

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — targeted security bug fix to an existing constraint; no module-level spec change required.

## Testing

- `yarn workspace @open-mercato/core test` — 703 suites / 5787 tests pass (incl. new `users.tenant-scoped-email.test.ts`; reverting the fix makes it fail for the right reason).
- `yarn turbo run typecheck --filter=@open-mercato/core` — pass (covers the migration and the new integration spec).
- `yarn db:generate` — `auth: no changes` (entity ↔ snapshot ↔ migration consistent).
- `yarn i18n:check-sync` — all locales in sync.
- `yarn build:packages` (21/21) and `yarn build:app` — pass.
- DB-level red→green proof on a throwaway database: old `email` index is inert under encryption (allows same-tenant duplicate); new `email_hash` index rejects within-tenant duplicates, allows the same email across tenants, the dedupe makes index creation safe, soft-deleted emails are reusable, and null-hash rows are tolerated.
- Integration test `TC-AUTH-047` (Playwright): superadmin creates two tenants, same email succeeds in both, and a second same-tenant create returns 400.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No new user-facing strings — reuses `auth.users.errors.emailExists`; migration + snapshot included; `db:generate` reports no further changes.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Added `TC-AUTH-047` in the module-local `__integration__/` directory, where `TC-AUTH-*` specs live.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — minor security fix, no spec.)

### Design System Compliance
- [x] No hardcoded status colors — **N/A, no UI changes** (backend: entity, command, migration).
- [x] No arbitrary text sizes — **N/A, no UI changes.**
- [x] Empty state handled for list/data pages — **N/A, no UI changes.**
- [x] Loading state handled for async pages — **N/A, no UI changes.**
- [x] `aria-label` on all icon-only buttons — **N/A, no UI changes.**
- [x] Uses existing DS components — **N/A, no UI changes.**

## Linked issues

Fixes #2934