### PR TITLE
fix: 2935 search index purge org scope

### DIFF
--- a/packages/search/src/__tests__/purge-org-scoping.test.ts
+++ b/packages/search/src/__tests__/purge-org-scoping.test.ts
@@ -1,0 +1,136 @@
+import { SearchService } from '../service'
+import { VectorSearchStrategy } from '../strategies/vector.strategy'
+import { FullTextSearchStrategy } from '../strategies/fulltext.strategy'
+import { TokenSearchStrategy } from '../strategies/token.strategy'
+
+/**
+ * Regression coverage for issue #2935: the search purge chain ignored
+ * organizationId and deleted index entries by (tenantId, entityType) only,
+ * letting a holder of search.embeddings.manage in one organization destroy
+ * another organization's entries within the same tenant. organizationId must
+ * now flow through SearchService.purge -> every strategy.purge -> the driver,
+ * and each store must scope the delete to that organization when provided
+ * (while preserving the tenant-wide purge when no organization is given).
+ */
+
+function fakeStrategy(id: string) {
+  return {
+    id,
+    name: id,
+    priority: 1,
+    isAvailable: jest.fn().mockResolvedValue(true),
+    search: jest.fn().mockResolvedValue([]),
+    index: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+    purge: jest.fn().mockResolvedValue(undefined),
+  }
+}
+
+describe('SearchService.purge organization scoping (issue #2935)', () => {
+  it('forwards organizationId to every available strategy', async () => {
+    const vector = fakeStrategy('vector')
+    const tokens = fakeStrategy('tokens')
+    const service = new SearchService({ strategies: [vector, tokens] as never })
+
+    await service.purge('demo:item', 'tenant-1', 'org-A')
+
+    expect(vector.purge).toHaveBeenCalledWith('demo:item', 'tenant-1', 'org-A')
+    expect(tokens.purge).toHaveBeenCalledWith('demo:item', 'tenant-1', 'org-A')
+  })
+
+  it('performs a tenant-wide purge (no organization) when organizationId is omitted', async () => {
+    const vector = fakeStrategy('vector')
+    const service = new SearchService({ strategies: [vector] as never })
+
+    await service.purge('demo:item', 'tenant-1')
+
+    expect(vector.purge).toHaveBeenCalledWith('demo:item', 'tenant-1', undefined)
+  })
+})
+
+describe('VectorSearchStrategy.purge organization scoping (issue #2935)', () => {
+  function createDriver() {
+    return {
+      id: 'pgvector' as const,
+      ensureReady: jest.fn().mockResolvedValue(undefined),
+      upsert: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn().mockResolvedValue([]),
+      getChecksum: jest.fn().mockResolvedValue(null),
+      purge: jest.fn().mockResolvedValue(undefined),
+    }
+  }
+
+  it('forwards organizationId to the vector driver', async () => {
+    const driver = createDriver()
+    const strategy = new VectorSearchStrategy({ available: true } as never, driver as never)
+
+    await strategy.purge('demo:item', 'tenant-1', 'org-A')
+
+    expect(driver.purge).toHaveBeenCalledWith('demo:item', 'tenant-1', 'org-A')
+  })
+
+  it('forwards an undefined organizationId for a tenant-wide purge', async () => {
+    const driver = createDriver()
+    const strategy = new VectorSearchStrategy({ available: true } as never, driver as never)
+
+    await strategy.purge('demo:item', 'tenant-1')
+
+    expect(driver.purge).toHaveBeenCalledWith('demo:item', 'tenant-1', undefined)
+  })
+})
+
+describe('FullTextSearchStrategy.purge organization scoping (issue #2935)', () => {
+  it('forwards organizationId to the fulltext driver', async () => {
+    const driver = {
+      ensureReady: jest.fn().mockResolvedValue(undefined),
+      isHealthy: jest.fn().mockResolvedValue(true),
+      search: jest.fn().mockResolvedValue([]),
+      index: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+      purge: jest.fn().mockResolvedValue(undefined),
+    }
+    const strategy = new FullTextSearchStrategy(driver as never)
+
+    await strategy.purge('demo:item', 'tenant-1', 'org-A')
+
+    expect(driver.purge).toHaveBeenCalledWith('demo:item', 'tenant-1', 'org-A')
+  })
+})
+
+describe('TokenSearchStrategy.purge organization scoping (issue #2935)', () => {
+  function createMockDb() {
+    const wheres: Array<[string, string, unknown]> = []
+    const builder: Record<string, unknown> = {
+      where: jest.fn((column: string, op: string, value: unknown) => {
+        wheres.push([column, op, value])
+        return builder
+      }),
+      execute: jest.fn().mockResolvedValue([]),
+    }
+    const db = { deleteFrom: jest.fn(() => builder) }
+    return { db, wheres }
+  }
+
+  it('adds an organization_id filter to the delete when an organization is provided', async () => {
+    const { db, wheres } = createMockDb()
+    const strategy = new TokenSearchStrategy(db as never)
+
+    await strategy.purge('demo:item', 'tenant-1', 'org-A')
+
+    expect(wheres).toContainEqual(['entity_type', '=', 'demo:item'])
+    expect(wheres).toContainEqual(['tenant_id', '=', 'tenant-1'])
+    expect(wheres).toContainEqual(['organization_id', '=', 'org-A'])
+  })
+
+  it('does NOT add an organization_id filter for a tenant-wide purge', async () => {
+    const { db, wheres } = createMockDb()
+    const strategy = new TokenSearchStrategy(db as never)
+
+    await strategy.purge('demo:item', 'tenant-1')
+
+    expect(wheres.map((entry) => entry[0])).not.toContain('organization_id')
+    expect(wheres).toContainEqual(['entity_type', '=', 'demo:item'])
+    expect(wheres).toContainEqual(['tenant_id', '=', 'tenant-1'])
+  })
+})

--- a/packages/search/src/__tests__/service.test.ts
+++ b/packages/search/src/__tests__/service.test.ts
@@ -457,7 +457,8 @@ describe('SearchService', () => {
 
       await service.purge('test:entity', 'tenant-123')
 
-      expect(strategyWithPurge.purge).toHaveBeenCalledWith('test:entity', 'tenant-123')
+      // organizationId is forwarded as undefined for a tenant-wide purge (issue #2935)
+      expect(strategyWithPurge.purge).toHaveBeenCalledWith('test:entity', 'tenant-123', undefined)
     })
   })
 

--- a/packages/search/src/fulltext/drivers/meilisearch/index.ts
+++ b/packages/search/src/fulltext/drivers/meilisearch/index.ts
@@ -296,14 +296,20 @@ export function createMeilisearchDriver(
       }
     },
 
-    async purge(entityId: EntityId, tenantId: string): Promise<void> {
+    async purge(entityId: EntityId, tenantId: string, organizationId?: string | null): Promise<void> {
       const meiliClient = getClient()
       const indexName = buildIndexName(tenantId)
+      const normalizedOrganizationId =
+        typeof organizationId === 'string' && organizationId.trim().length > 0 ? organizationId.trim() : null
+      const filter =
+        normalizedOrganizationId !== null
+          ? `_entityId = "${escapeFilterValue(entityId)}" AND _organizationId = "${escapeFilterValue(normalizedOrganizationId)}"`
+          : `_entityId = "${escapeFilterValue(entityId)}"`
 
       try {
         const index = meiliClient.index(indexName)
         await index.deleteDocuments({
-          filter: `_entityId = "${entityId}"`,
+          filter,
         })
       } catch (error: unknown) {
         const meilisearchError = error as { code?: string }

--- a/packages/search/src/fulltext/types.ts
+++ b/packages/search/src/fulltext/types.ts
@@ -99,7 +99,7 @@ export interface FullTextSearchDriver {
 
   // Batch operations (optional)
   bulkIndex?(docs: FullTextSearchDocument[]): Promise<void>
-  purge?(entityId: EntityId, tenantId: string): Promise<void>
+  purge?(entityId: EntityId, tenantId: string, organizationId?: string | null): Promise<void>
 
   // Index management (optional)
   clearIndex?(tenantId: string): Promise<void>

--- a/packages/search/src/indexer/search-indexer.ts
+++ b/packages/search/src/indexer/search-indexer.ts
@@ -48,6 +48,7 @@ export type DeleteRecordParams = {
 export type PurgeEntityParams = {
   entityId: EntityId
   tenantId: string
+  organizationId?: string | null
 }
 
 /**
@@ -352,7 +353,7 @@ export class SearchIndexer {
    * Purge all records of an entity type from the search index.
    */
   async purgeEntity(params: PurgeEntityParams): Promise<void> {
-    await this.searchService.purge(params.entityId, params.tenantId)
+    await this.searchService.purge(params.entityId, params.tenantId, params.organizationId)
   }
 
   /**
@@ -394,7 +395,7 @@ export class SearchIndexer {
     // Optionally purge first
     if (params.purgeFirst) {
       try {
-        await this.searchService.purge(params.entityId, params.tenantId)
+        await this.searchService.purge(params.entityId, params.tenantId, params.organizationId)
       } catch (error) {
         searchDebugWarn('SearchIndexer', 'Failed to purge entity before reindex', {
           entityId: params.entityId,
@@ -865,7 +866,7 @@ export class SearchIndexer {
       // Optionally purge vector index first
       if (params.purgeFirst) {
         try {
-          await this.searchService.purge(params.entityId, params.tenantId)
+          await this.searchService.purge(params.entityId, params.tenantId, params.organizationId)
         } catch (error) {
           searchDebugWarn('SearchIndexer', 'Failed to purge entity before vector reindex', {
             entityId: params.entityId,

--- a/packages/search/src/modules/search/api/__tests__/org-scoping.routes.test.ts
+++ b/packages/search/src/modules/search/api/__tests__/org-scoping.routes.test.ts
@@ -27,9 +27,19 @@ jest.mock('../../lib/global-search-config', () => ({
   resolveGlobalSearchStrategies: jest.fn().mockResolvedValue(['tokens']),
 }))
 
+const mockRecordIndexerLog = jest.fn().mockResolvedValue(undefined)
+jest.mock('@open-mercato/shared/lib/indexers/status-log', () => ({
+  recordIndexerLog: (...args: unknown[]) => mockRecordIndexerLog(...args),
+}))
+
+const mockWriteCoverageCounts = jest.fn().mockResolvedValue(undefined)
+jest.mock('@open-mercato/core/modules/query_index/lib/coverage', () => ({
+  writeCoverageCounts: (...args: unknown[]) => mockWriteCoverageCounts(...args),
+}))
+
 import { GET as hybridSearchGet } from '../search/route'
 import { GET as globalSearchGet } from '../search/global/route'
-import { GET as indexGet } from '../index/route'
+import { GET as indexGet, DELETE as indexDelete } from '../index/route'
 
 type MockOrganizationScope = {
   selectedId: string | null
@@ -159,5 +169,105 @@ describe('Search API organizationId scoping', () => {
     expect(vectorStrategy.listEntries).toHaveBeenCalledTimes(1)
     const passedOptions = (vectorStrategy.listEntries as jest.Mock).mock.calls[0][0] as Record<string, unknown>
     expect(passedOptions.organizationId).toEqual('org-A')
+  })
+})
+
+describe('Search API DELETE /api/search/index organizationId scoping (issue #2935)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  function setupContainer() {
+    const searchIndexer = {
+      listEnabledEntities: jest.fn().mockReturnValue(['demo:item', 'demo:other']),
+      purgeEntity: jest.fn().mockResolvedValue(undefined),
+    }
+    const container = {
+      resolve: jest.fn((name: string) => (name === 'searchIndexer' ? searchIndexer : undefined)),
+      dispose: jest.fn(),
+    }
+    mockCreateRequestContainer.mockResolvedValue(container)
+    return { searchIndexer, container }
+  }
+
+  test('scopes the purge to the caller selected organization (never tenant-wide)', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({ tenantId: 't1', orgId: 'org-A', sub: 'user-1', isSuperAdmin: false })
+    const { searchIndexer } = setupContainer()
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: 'org-A',
+      filterIds: ['org-A'],
+      allowedIds: ['org-A'],
+      tenantId: 't1',
+    } satisfies MockOrganizationScope)
+
+    const req = new Request('http://localhost/api/search/index?entityId=demo:item', { method: 'DELETE' })
+    const res = await indexDelete(req)
+
+    expect(res.status).toBe(200)
+    expect(mockResolveOrganizationScopeForRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ container: expect.anything(), auth: expect.anything(), request: req }),
+    )
+    expect(searchIndexer.purgeEntity).toHaveBeenCalledTimes(1)
+    expect(searchIndexer.purgeEntity).toHaveBeenCalledWith(
+      expect.objectContaining({ entityId: 'demo:item', tenantId: 't1', organizationId: 'org-A' }),
+    )
+  })
+
+  test('purges the full authorized org set (never tenant-wide) for a restricted user with no selected org', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({ tenantId: 't1', orgId: null, sub: 'user-1', isSuperAdmin: false })
+    const { searchIndexer } = setupContainer()
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: null,
+      filterIds: ['org-A', 'org-B'],
+      allowedIds: ['org-A', 'org-B'],
+      tenantId: 't1',
+    } satisfies MockOrganizationScope)
+
+    const req = new Request('http://localhost/api/search/index?entityId=demo:item', { method: 'DELETE' })
+    const res = await indexDelete(req)
+
+    expect(res.status).toBe(200)
+    const purgedOrgs = (searchIndexer.purgeEntity as jest.Mock).mock.calls.map(
+      (call) => (call[0] as { organizationId?: string | null }).organizationId,
+    )
+    expect(purgedOrgs).toEqual(expect.arrayContaining(['org-A', 'org-B']))
+    expect(purgedOrgs).not.toContain(undefined)
+    expect(purgedOrgs).not.toContain(null)
+  })
+
+  test('purges nothing when the caller has no accessible organizations', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({ tenantId: 't1', orgId: 'org-A', sub: 'user-1', isSuperAdmin: false })
+    const { searchIndexer } = setupContainer()
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: null,
+      filterIds: [],
+      allowedIds: [],
+      tenantId: 't1',
+    } satisfies MockOrganizationScope)
+
+    const req = new Request('http://localhost/api/search/index?entityId=demo:item', { method: 'DELETE' })
+    const res = await indexDelete(req)
+
+    expect(res.status).toBe(200)
+    expect(searchIndexer.purgeEntity).not.toHaveBeenCalled()
+  })
+
+  test('allows a tenant-wide purge for an unrestricted (super-admin) caller', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({ tenantId: 't1', orgId: null, sub: 'user-1', isSuperAdmin: true })
+    const { searchIndexer } = setupContainer()
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId: 't1',
+    } satisfies MockOrganizationScope)
+
+    const req = new Request('http://localhost/api/search/index?entityId=demo:item', { method: 'DELETE' })
+    const res = await indexDelete(req)
+
+    expect(res.status).toBe(200)
+    expect(searchIndexer.purgeEntity).toHaveBeenCalledTimes(1)
+    const arg = (searchIndexer.purgeEntity as jest.Mock).mock.calls[0][0] as { organizationId?: string | null }
+    expect(arg.organizationId).toBeUndefined()
   })
 })

--- a/packages/search/src/modules/search/api/index/route.ts
+++ b/packages/search/src/modules/search/api/index/route.ts
@@ -163,13 +163,36 @@ export async function DELETE(req: Request) {
       ? [entityIdParam]
       : searchIndexer.listEnabledEntities()
 
+    // Constrain the purge to the caller's authorized organization scope so a
+    // holder of search.embeddings.manage in one organization cannot destroy
+    // another organization's index entries within the same tenant (issue #2935).
+    const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
+    if (Array.isArray(scope.filterIds) && scope.filterIds.length === 0) {
+      return NextResponse.json({ ok: true })
+    }
+    const selectedOrganizationId =
+      typeof scope.selectedId === 'string' && scope.selectedId.trim().length > 0 ? scope.selectedId.trim() : null
+    // The single selected org, else the explicit authorized set, else
+    // (unrestricted/super-admin) a single tenant-wide purge.
+    const purgeOrganizationIds: Array<string | undefined> = selectedOrganizationId
+      ? [selectedOrganizationId]
+      : Array.isArray(scope.filterIds)
+        ? scope.filterIds
+        : [undefined]
+
     const scopes = new Set<string>()
-    const registerScope = (org: string | null) => {
+    const registerScope = (org: string | undefined) => {
       const key = org ?? '__null__'
       if (!scopes.has(key)) scopes.add(key)
     }
-    registerScope(null)
-    if (auth.orgId) registerScope(auth.orgId)
+    for (const organizationId of purgeOrganizationIds) {
+      if (organizationId === undefined) {
+        registerScope(undefined)
+        if (auth.orgId) registerScope(auth.orgId)
+      } else {
+        registerScope(organizationId)
+      }
+    }
 
     await recordIndexerLog(
       { em: em ?? undefined },
@@ -186,12 +209,17 @@ export async function DELETE(req: Request) {
       },
     ).catch(() => undefined)
 
-    // Purge each entity using SearchIndexer
+    // Purge each entity using SearchIndexer, scoped to the authorized
+    // organization(s). An undefined organizationId performs a tenant-wide purge
+    // and is only reachable for unrestricted (e.g. super-admin) callers.
     for (const entityId of entityIds) {
-      await searchIndexer.purgeEntity({
-        entityId: entityId as EntityId,
-        tenantId: auth.tenantId,
-      })
+      for (const organizationId of purgeOrganizationIds) {
+        await searchIndexer.purgeEntity({
+          entityId: entityId as EntityId,
+          tenantId: auth.tenantId,
+          organizationId,
+        })
+      }
     }
 
     // Update coverage counts

--- a/packages/search/src/modules/search/cli.ts
+++ b/packages/search/src/modules/search/cli.ts
@@ -577,7 +577,7 @@ async function reindexCommand(rest: string[]): Promise<void> {
       if (purgeFirst && tenantId) {
         try {
           console.log('  -> purging existing vector index rows...')
-          await searchIndexer.purgeEntity({ entityId: entityType as EntityId, tenantId })
+          await searchIndexer.purgeEntity({ entityId: entityType as EntityId, tenantId, organizationId })
           await resetVectorCoverageAfterPurge(baseEm, entityType, tenantId ?? null, organizationId ?? null)
           if (baseEventBus) {
             const scopes = new Set<string>()

--- a/packages/search/src/modules/search/subscribers/__tests__/vector_purge.test.ts
+++ b/packages/search/src/modules/search/subscribers/__tests__/vector_purge.test.ts
@@ -1,0 +1,55 @@
+jest.mock('@open-mercato/shared/lib/indexers/status-log', () => ({
+  recordIndexerLog: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('@open-mercato/shared/lib/indexers/error-log', () => ({
+  recordIndexerError: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('@open-mercato/core/modules/query_index/lib/coverage', () => ({
+  writeCoverageCounts: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('../../lib/embedding-config', () => ({
+  resolveEmbeddingConfig: jest.fn().mockResolvedValue(null),
+}))
+
+import handle from '../vector_purge'
+
+/**
+ * Regression coverage for issue #2935 (sibling of the DELETE endpoint fix):
+ * the query_index.vectorize_purge subscriber received an organizationId in the
+ * event payload but dropped it when calling purgeEntity, performing a
+ * tenant-wide purge that destroys other organizations' vector entries during an
+ * org-scoped force-reindex. organizationId must now flow into purgeEntity.
+ */
+function createCtx(purgeEntity: jest.Mock) {
+  return {
+    resolve: jest.fn((name: string) => {
+      if (name === 'searchIndexer') return { purgeEntity }
+      throw new Error(`not registered: ${name}`)
+    }),
+  }
+}
+
+describe('query_index.vectorize_purge subscriber organization scoping (issue #2935)', () => {
+  it('forwards the payload organizationId to purgeEntity (org-scoped purge)', async () => {
+    const purgeEntity = jest.fn().mockResolvedValue(undefined)
+
+    await handle(
+      { entityType: 'demo:item', tenantId: 'tenant-1', organizationId: 'org-A' },
+      createCtx(purgeEntity) as never,
+    )
+
+    expect(purgeEntity).toHaveBeenCalledTimes(1)
+    expect(purgeEntity).toHaveBeenCalledWith(
+      expect.objectContaining({ entityId: 'demo:item', tenantId: 'tenant-1', organizationId: 'org-A' }),
+    )
+  })
+
+  it('performs a tenant-wide purge (organizationId null) when the event carries no organization', async () => {
+    const purgeEntity = jest.fn().mockResolvedValue(undefined)
+
+    await handle({ entityType: 'demo:item', tenantId: 'tenant-1' }, createCtx(purgeEntity) as never)
+
+    expect(purgeEntity).toHaveBeenCalledTimes(1)
+    expect((purgeEntity.mock.calls[0][0] as { organizationId?: string | null }).organizationId).toBeNull()
+  })
+})

--- a/packages/search/src/modules/search/subscribers/vector_purge.ts
+++ b/packages/search/src/modules/search/subscribers/vector_purge.ts
@@ -73,6 +73,7 @@ export default async function handle(payload: Payload, ctx: HandlerContext) {
     await searchIndexer.purgeEntity({
       entityId: entityType as EntityId,
       tenantId,
+      organizationId,
     })
     if (em) {
       try {

--- a/packages/search/src/service.ts
+++ b/packages/search/src/service.ts
@@ -300,13 +300,13 @@ export class SearchService {
    * @param entityId - Entity type to purge
    * @param tenantId - Tenant for isolation
    */
-  async purge(entityId: string, tenantId: string): Promise<void> {
+  async purge(entityId: string, tenantId: string, organizationId?: string | null): Promise<void> {
     const strategies = await this.getAvailableStrategies()
 
     const results = await Promise.allSettled(
       strategies.map((strategy) => {
         if (strategy.purge) {
-          return strategy.purge(entityId, tenantId)
+          return strategy.purge(entityId, tenantId, organizationId)
         }
         return Promise.resolve()
       }),

--- a/packages/search/src/strategies/fulltext.strategy.ts
+++ b/packages/search/src/strategies/fulltext.strategy.ts
@@ -75,11 +75,11 @@ export class FullTextSearchStrategy implements SearchStrategy {
     return this.driver.bulkIndex(docs)
   }
 
-  async purge(entityId: EntityId, tenantId: string): Promise<void> {
+  async purge(entityId: EntityId, tenantId: string, organizationId?: string | null): Promise<void> {
     if (!this.driver.purge) {
       return
     }
-    return this.driver.purge(entityId, tenantId)
+    return this.driver.purge(entityId, tenantId, organizationId)
   }
 
   // Additional methods exposed for enrichment and admin purposes

--- a/packages/search/src/strategies/token.strategy.ts
+++ b/packages/search/src/strategies/token.strategy.ts
@@ -170,11 +170,16 @@ export class TokenSearchStrategy implements SearchStrategy {
     await replaceSearchTokensForBatch(this.db, payloads)
   }
 
-  async purge(entityId: EntityId, tenantId: string): Promise<void> {
-    await this.db
+  async purge(entityId: EntityId, tenantId: string, organizationId?: string | null): Promise<void> {
+    const normalizedOrganizationId =
+      typeof organizationId === 'string' && organizationId.trim().length > 0 ? organizationId.trim() : null
+    let query = this.db
       .deleteFrom('search_tokens' as any)
       .where('entity_type' as any, '=', entityId)
       .where('tenant_id' as any, '=', tenantId)
-      .execute()
+    if (normalizedOrganizationId !== null) {
+      query = query.where('organization_id' as any, '=', normalizedOrganizationId)
+    }
+    await query.execute()
   }
 }

--- a/packages/search/src/strategies/vector.strategy.ts
+++ b/packages/search/src/strategies/vector.strategy.ts
@@ -157,10 +157,10 @@ export class VectorSearchStrategy implements SearchStrategy {
     await this.vectorDriver.delete(entityId, recordId, tenantId)
   }
 
-  async purge(entityId: EntityId, tenantId: string): Promise<void> {
+  async purge(entityId: EntityId, tenantId: string, organizationId?: string | null): Promise<void> {
     await this.ensureReady()
     if (this.vectorDriver.purge) {
-      await this.vectorDriver.purge(entityId, tenantId)
+      await this.vectorDriver.purge(entityId, tenantId, organizationId)
     }
   }
 

--- a/packages/search/src/vector/drivers/pgvector/index.ts
+++ b/packages/search/src/vector/drivers/pgvector/index.ts
@@ -302,11 +302,19 @@ export function createPgVectorDriver(opts: PgVectorDriverOptions = {}): VectorDr
     return res.rowCount ? res.rows[0].checksum : null
   }
 
-  const purge = async (entityId: string, tenantId: string) => {
+  const purge = async (entityId: string, tenantId: string, organizationId?: string | null) => {
     await ensureReady()
+    const normalizedOrganizationId =
+      typeof organizationId === 'string' && organizationId.trim().length > 0 ? organizationId.trim() : null
+    const conditions = ['driver_id = $1', 'entity_id = $2', 'tenant_id = $3::uuid']
+    const values: any[] = [DRIVER_ID, entityId, tenantId]
+    if (normalizedOrganizationId !== null) {
+      conditions.push('organization_id = $4::uuid')
+      values.push(normalizedOrganizationId)
+    }
     await pool.query(
-      `DELETE FROM ${tableIdent} WHERE driver_id = $1 AND entity_id = $2 AND tenant_id = $3::uuid`,
-      [DRIVER_ID, entityId, tenantId],
+      `DELETE FROM ${tableIdent} WHERE ${conditions.join(' AND ')}`,
+      values,
     )
   }
 

--- a/packages/search/src/vector/services/vector-index.service.ts
+++ b/packages/search/src/vector/services/vector-index.service.ts
@@ -900,7 +900,7 @@ export class VectorIndexService {
 
     if (this.opts.eventBus) {
       if (shouldPurge && driver.purge && args.tenantId) {
-        await driver.purge(args.entityId, args.tenantId)
+        await driver.purge(args.entityId, args.tenantId, args.organizationId)
       } else if (shouldPurge && !args.tenantId) {
         searchDebugWarn('vector', 'Skipping purge for multi-tenant reindex (tenant not provided)')
       }
@@ -923,7 +923,7 @@ export class VectorIndexService {
     }
 
     if (shouldPurge && driver.purge) {
-      await driver.purge(args.entityId, args.tenantId)
+      await driver.purge(args.entityId, args.tenantId, args.organizationId)
     }
 
     const pageSize = 50

--- a/packages/search/src/vector/types.ts
+++ b/packages/search/src/vector/types.ts
@@ -103,7 +103,7 @@ export interface VectorDriver {
   delete(entityId: EntityId, recordId: string, tenantId: string): Promise<void>
   query(input: VectorDriverQuery): Promise<VectorDriverQueryResult[]>
   getChecksum(entityId: EntityId, recordId: string, tenantId: string): Promise<string | null>
-  purge?(entityId: EntityId, tenantId: string): Promise<void>
+  purge?(entityId: EntityId, tenantId: string, organizationId?: string | null): Promise<void>
   list?(params: VectorDriverListParams): Promise<VectorIndexEntry[]>
   count?(params: VectorDriverCountParams): Promise<number>
   removeOrphans?(params: VectorDriverRemoveOrphansParams): Promise<number | void>

--- a/packages/shared/src/modules/search.ts
+++ b/packages/shared/src/modules/search.ts
@@ -160,7 +160,7 @@ export interface SearchStrategy {
   bulkIndex?(records: IndexableRecord[]): Promise<void>
 
   /** Purge all records for an entity type (optional) */
-  purge?(entityId: EntityId, tenantId: string): Promise<void>
+  purge?(entityId: EntityId, tenantId: string, organizationId?: string | null): Promise<void>
 }
 
 // =============================================================================


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

`DELETE /api/search/index` (the vector-index purge endpoint, gated by `search.embeddings.manage`) resolved no organization scope and purged index entries by `(tenantId, entityType)` only. Because `purgeEntity` fans out to the **vector, fulltext, and token** stores — none of which filtered the delete by `organization_id` — a user holding `search.embeddings.manage` in organization A could destroy organization B's search index entries across the entire tenant (and, with `?confirmAll=true`, every enabled entity's entries). This is a cross-organization integrity/availability defect (recoverable via reindex, but performed without the other org's authorization).

This PR threads the caller's organization scope through the whole purge chain and constrains the endpoint to the caller's **authorized** organization(s), mirroring the GET handler. A tenant-wide purge is now reachable only for genuinely unrestricted (e.g. super-admin) callers; an org-scoped holder can never default to tenant-wide, and a caller with no accessible organizations purges nothing. The same org-blind `purgeEntity` call was also fixed at the reindex / event-subscriber / CLI sites that already had the organization in scope. All new `organizationId` parameters are **optional and additive** (backward compatible — existing callers passing no org keep tenant-wide behavior).

## Changes

- `DELETE /api/search/index` now resolves the caller's org scope via `resolveOrganizationScopeForRequest` and purges only the authorized org(s): single selected org → that org; restricted user with no single selection → each org in the authorized set; no accessible orgs → purge nothing; unrestricted (`filterIds === null`) → tenant-wide.
- Threaded optional `organizationId` through `SearchService.purge` → `SearchStrategy.purge` (vector/fulltext/token) → drivers; each store now scopes the delete by `organization_id` when provided: pgvector (`organization_id = $N::uuid`), token (`.where('organization_id','=',org)`), Meilisearch (escaped `_organizationId` filter). Omitting org preserves the tenant-wide purge.
- `PurgeEntityParams` gains optional `organizationId`; `SearchIndexer.purgeEntity`, both `reindexEntity*` `purgeFirst` calls, and `VectorIndexService.reindexEntity` now pass the org already in scope.
- Fixed the same org-blind `purgeEntity` call in the `query_index.vectorize_purge` subscriber and the `reindex --purgeFirst` CLI command (both forward their existing `organizationId`).
- Tests: 4 DELETE org-scoping cases (route), chain + token/driver SQL scoping, subscriber org-forwarding; updated one `service.test.ts` assertion for the additive third argument.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed) — targeted security bug fix in one module; no behavior change beyond closing the cross-org leak.

**Spec file path:**
N/A

## Testing

Ran the local gate (all green):
- `yarn build:packages` → 21/21
- `yarn generate`
- `yarn build:packages` (rebuild) → 21/21
- `yarn i18n:check-sync` → all locales in sync (no new strings)
- typecheck `@open-mercato/shared`, `@open-mercato/search`, `@open-mercato/core` → pass
- `yarn workspace @open-mercato/search test` → 15 suites, 150 tests pass (13 new). The new DELETE org-scoping tests were confirmed red against the pre-fix handler (purge ran tenant-wide), then green.
- `yarn build:app` (forced) → compiled successfully

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- none required: no new user-facing strings (i18n in sync), no generated-file or doc impact -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- Covered by deterministic jest route + chain + driver-SQL + subscriber tests that assert cross-org isolation. A Playwright cross-org-purge spec would require a configured embedding backend (otherwise skips, like TC-SEARCH-008) plus a second org and an org-scoped user; the unit/route coverage fully exercises the security contract. -->
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — bug fix, no spec -->

### Design System Compliance
<!-- N/A — backend-only change (API route, services, strategies, drivers, event subscriber, CLI); no UI. -->
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens <!-- N/A — no UI -->
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` <!-- N/A — no UI -->
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) <!-- N/A — no UI -->
- [x] Loading state handled for async pages <!-- N/A — no UI -->
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) <!-- N/A — no UI -->
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements <!-- N/A — no UI -->

## Linked issues

Fixes #2935