### PR TITLE
security(attachments): harden attachment copy/clone scope against partial-null rows (#2879)

### DIFF
--- a/.ai/runs/2026-06-11-harden-attachment-copy-scope.md
+++ b/.ai/runs/2026-06-11-harden-attachment-copy-scope.md
@@ -1,0 +1,86 @@
+# Execution plan — harden attachment copy scope (follow-up to PR #2879 / #2109)
+
+## Goal
+
+Eliminate the partial-null `(tenant_id, organization_id)` attachment-row construction paths
+flagged in PR #2879 by deriving each copied/cloned attachment's scope pair **as a unit** from
+its source row, so a row with exactly one scope column set can no longer be created.
+
+## Context
+
+PR #2879 (#2109) added a read-time fail-closed guard (`isSameScope`) and a creation guard
+(`assertAttachmentScopeInvariant`) at the upload site, but explicitly left the cross-module
+copy paths unhardened. Its audit named `messages/lib/attachments.ts`
+(`copyAttachmentsForForwardMessages`) as the one path that can currently construct a
+partial-null row, because it applies a caller-supplied nullable `targetOrganizationId`
+alongside a non-null `tenantId` to every copy.
+
+A second independent-coalescing path exists at `catalog/commands/variants.ts`
+(`aggregateVariantMediaToProduct`), which sets
+`organizationId: source.organizationId ?? variant.organizationId ?? null` and
+`tenantId: source.tenantId ?? variant.tenantId ?? null` independently — these `??` chains
+can resolve to one-null/one-set.
+
+`sync_excel/lib/upload-storage.ts` and `sync-akeneo` pass a single scope object's
+`organizationId`/`tenantId` through atomically (both-or-neither preserved by the caller), so
+they are not partial-null construction sites and are left unchanged.
+
+The PR #2879 creation guard lives on its (still-open) branch, so this follow-up must be
+self-contained: it hardens structurally (derive the scope pair as a unit) rather than depend
+on an unmerged import. A new `attachments/lib/scope.ts` file avoids merge conflicts with
+#2879's edits to `attachments/lib/access.ts`.
+
+## Scope
+
+- New shared helper: `packages/core/src/modules/attachments/lib/scope.ts` —
+  `resolveAttachmentScopePair(...candidates)` returns the first candidate that forms a valid
+  both-or-neither pair (blank/whitespace normalized to null), else `null`.
+- `messages/lib/attachments.ts` — `copyAttachmentsForForwardMessages` (and the
+  `copyAttachmentsForForward` wrapper) derive each copy's scope from the **source attachment's
+  own pair**; partial-null source rows (legacy dead data) are skipped, not propagated. Drop the
+  now-meaningless `targetOrganizationId` parameter.
+- `messages/commands/messages.ts` — update the single caller to the new signature.
+- `catalog/commands/variants.ts` — `aggregateVariantMediaToProduct` resolves the clone's scope
+  pair atomically (source pair, else variant pair, else global).
+- Tests: new `attachments/lib/__tests__/scope.test.ts`; update messages attachments + forward
+  tests for the signature change and add partial-null-source coverage.
+
+## Non-goals
+
+- No DB schema / `NOT NULL` / `CHECK` migration (that is #2879's documented Option-B decision).
+- Do not touch `attachments/api/route.ts` (owned by #2879) or the sync_excel / sync-akeneo
+  upload sites (atomic scope, not partial-null sites).
+- No change to read-time access semantics (`checkAttachmentAccess` / `isSameScope`).
+
+## Risks
+
+- Signature change to `copyAttachmentsForForwardMessages` / `copyAttachmentsForForward`: these
+  are module-internal lib helpers (relative-import only), not a `BACKWARD_COMPATIBILITY.md`
+  contract surface. All callers (one command + tests) are updated in the same change.
+- Behavioral nuance: forwarded-attachment copies now inherit the **source** attachment's org
+  rather than the forward target's org. In practice a forward stays within the same thread/org,
+  so these match; the change only differs in the cross-org edge case, where inheriting the
+  source scope is the safer (invariant-preserving) choice per #2879's audit.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Shared scope helper
+
+- [x] 1.1 Add `attachments/lib/scope.ts` with `resolveAttachmentScopePair`
+- [x] 1.2 Add `attachments/lib/__tests__/scope.test.ts`
+
+### Phase 2: Harden messages forward copy
+
+- [x] 2.1 Refactor `copyAttachmentsForForwardMessages` to derive scope from source + skip partial-null; drop `targetOrganizationId`
+- [x] 2.2 Update caller in `messages/commands/messages.ts`
+- [x] 2.3 Update messages attachments + forward tests; add partial-null-source coverage
+
+### Phase 3: Harden catalog variant clone
+
+- [x] 3.1 Resolve clone scope pair atomically in `aggregateVariantMediaToProduct`
+
+### Phase 4: Validation
+
+- [x] 4.1 Targeted tests + typecheck for core; full gate

--- a/packages/core/src/modules/attachments/lib/__tests__/scope.test.ts
+++ b/packages/core/src/modules/attachments/lib/__tests__/scope.test.ts
@@ -1,0 +1,65 @@
+import {
+  isValidAttachmentScopePair,
+  resolveAttachmentScopePair,
+} from '../scope'
+
+describe('attachment scope invariant helpers', () => {
+  describe('isValidAttachmentScopePair', () => {
+    it('accepts a fully scoped pair', () => {
+      expect(isValidAttachmentScopePair({ organizationId: 'org-1', tenantId: 'tenant-1' })).toBe(true)
+    })
+
+    it('accepts a fully global pair (both null/undefined)', () => {
+      expect(isValidAttachmentScopePair({ organizationId: null, tenantId: null })).toBe(true)
+      expect(isValidAttachmentScopePair({})).toBe(true)
+    })
+
+    it('rejects partial-null pairs in both directions', () => {
+      expect(isValidAttachmentScopePair({ organizationId: 'org-1', tenantId: null })).toBe(false)
+      expect(isValidAttachmentScopePair({ organizationId: null, tenantId: 'tenant-1' })).toBe(false)
+    })
+
+    it('treats blank/whitespace as null', () => {
+      expect(isValidAttachmentScopePair({ organizationId: '   ', tenantId: 'tenant-1' })).toBe(false)
+      expect(isValidAttachmentScopePair({ organizationId: '   ', tenantId: '' })).toBe(true)
+    })
+  })
+
+  describe('resolveAttachmentScopePair', () => {
+    it('returns the first valid candidate as a normalized pair', () => {
+      expect(
+        resolveAttachmentScopePair({ organizationId: ' org-1 ', tenantId: ' tenant-1 ' }),
+      ).toEqual({ organizationId: 'org-1', tenantId: 'tenant-1' })
+    })
+
+    it('skips a partial-null candidate and falls back to the next valid one', () => {
+      expect(
+        resolveAttachmentScopePair(
+          { organizationId: 'org-1', tenantId: null },
+          { organizationId: 'org-2', tenantId: 'tenant-2' },
+        ),
+      ).toEqual({ organizationId: 'org-2', tenantId: 'tenant-2' })
+    })
+
+    it('returns a global pair when the first valid candidate is fully null', () => {
+      expect(
+        resolveAttachmentScopePair({ organizationId: null, tenantId: null }),
+      ).toEqual({ organizationId: null, tenantId: null })
+    })
+
+    it('ignores nullish candidates', () => {
+      expect(
+        resolveAttachmentScopePair(null, undefined, { organizationId: 'org-1', tenantId: 'tenant-1' }),
+      ).toEqual({ organizationId: 'org-1', tenantId: 'tenant-1' })
+    })
+
+    it('returns null when no candidate forms a valid pair', () => {
+      expect(
+        resolveAttachmentScopePair(
+          { organizationId: 'org-1', tenantId: null },
+          { organizationId: null, tenantId: 'tenant-2' },
+        ),
+      ).toBeNull()
+    })
+  })
+})

--- a/packages/core/src/modules/attachments/lib/scope.ts
+++ b/packages/core/src/modules/attachments/lib/scope.ts
@@ -1,0 +1,42 @@
+export type AttachmentScopePair = {
+  organizationId: string | null
+  tenantId: string | null
+}
+
+export type AttachmentScopeCandidate = {
+  organizationId?: string | null
+  tenantId?: string | null
+}
+
+function normalizeScopeValue(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return value ?? null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export function isValidAttachmentScopePair(candidate: AttachmentScopeCandidate): boolean {
+  const organizationId = normalizeScopeValue(candidate.organizationId)
+  const tenantId = normalizeScopeValue(candidate.tenantId)
+  return (organizationId === null) === (tenantId === null)
+}
+
+/**
+ * Returns the first candidate whose tenant/organization columns form a valid
+ * "both set or both null" scope pair (blank/whitespace treated as null), or
+ * `null` when no candidate satisfies the invariant. Copy/clone sites use this
+ * to carry a scope pair across as a unit instead of coalescing the two columns
+ * independently, which is what allows a partial-null row to be constructed.
+ */
+export function resolveAttachmentScopePair(
+  ...candidates: Array<AttachmentScopeCandidate | null | undefined>
+): AttachmentScopePair | null {
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    const organizationId = normalizeScopeValue(candidate.organizationId)
+    const tenantId = normalizeScopeValue(candidate.tenantId)
+    if ((organizationId === null) === (tenantId === null)) {
+      return { organizationId, tenantId }
+    }
+  }
+  return null
+}

--- a/packages/core/src/modules/catalog/commands/variants.ts
+++ b/packages/core/src/modules/catalog/commands/variants.ts
@@ -19,6 +19,7 @@ import {
 } from '../data/entities'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import { Attachment } from '@open-mercato/core/modules/attachments/data/entities'
+import { resolveAttachmentScopePair } from '@open-mercato/core/modules/attachments/lib/scope'
 import {
   variantCreateSchema,
   variantUpdateSchema,
@@ -550,11 +551,15 @@ async function aggregateVariantMediaToProduct(
   for (const source of attachments) {
     const key = buildKey(source)
     if (existingKeys.has(key)) continue
+    // Carry a scope pair across as a unit (source row first, else the variant
+    // scope, else global) so independent `??` coalescing can't produce a
+    // partial-null attachment row.
+    const scope = resolveAttachmentScopePair(source, variant) ?? { organizationId: null, tenantId: null }
     const clone = em.create(Attachment, {
       entityId: E.catalog.catalog_product,
       recordId: productId,
-      organizationId: source.organizationId ?? variant.organizationId ?? null,
-      tenantId: source.tenantId ?? variant.tenantId ?? null,
+      organizationId: scope.organizationId,
+      tenantId: scope.tenantId,
       partitionCode: source.partitionCode,
       fileName: source.fileName,
       mimeType: source.mimeType,

--- a/packages/core/src/modules/messages/commands/__tests__/messages.forward.test.ts
+++ b/packages/core/src/modules/messages/commands/__tests__/messages.forward.test.ts
@@ -339,7 +339,6 @@ describe('messages.messages.forward command', () => {
       trx,
       [rootMessageId, sourceMessageId],
       forwardedMessageId,
-      organizationId,
       tenantId,
     )
   })

--- a/packages/core/src/modules/messages/commands/messages.ts
+++ b/packages/core/src/modules/messages/commands/messages.ts
@@ -933,7 +933,6 @@ const forwardMessageCommand: CommandHandler<unknown, { id: string; externalEmail
           trx,
           forwardThreadSlice.map((item) => item.id),
           newMessage.id,
-          input.organizationId,
           input.tenantId,
         )
       }

--- a/packages/core/src/modules/messages/lib/__tests__/attachments.test.ts
+++ b/packages/core/src/modules/messages/lib/__tests__/attachments.test.ts
@@ -202,7 +202,6 @@ describe('messages attachments helpers', () => {
       em as never,
       'source-msg',
       'target-msg',
-      'org-1',
       'tenant-1',
     )
 
@@ -219,6 +218,76 @@ describe('messages attachments helpers', () => {
     )
     expect(em.persist).toHaveBeenCalledTimes(1)
     expect(em.flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('inherits the source attachment scope pair rather than a caller-supplied org', async () => {
+    const globalAttachment = {
+      id: 'att-global',
+      tenantId: null,
+      organizationId: null,
+      fileName: 'global.pdf',
+      mimeType: 'application/pdf',
+      fileSize: 12,
+      storageDriver: 'local',
+      storagePath: '/tmp/global.pdf',
+      storageMetadata: null,
+      url: '/f/global.pdf',
+      partitionCode: 'messages',
+    }
+
+    const em = createEm({
+      find: jest.fn(async () => [globalAttachment]),
+    })
+
+    const copiedCount = await copyAttachmentsForForward(
+      em as never,
+      'source-msg',
+      'target-msg',
+      'tenant-1',
+    )
+
+    expect(copiedCount).toBe(1)
+    expect(em.create).toHaveBeenCalledWith(
+      Attachment,
+      expect.objectContaining({
+        recordId: 'target-msg',
+        organizationId: null,
+        tenantId: null,
+        fileName: 'global.pdf',
+      }),
+    )
+  })
+
+  it('skips partial-null source rows instead of propagating an invalid scope', async () => {
+    const partialNullAttachment = {
+      id: 'att-bad',
+      tenantId: 'tenant-1',
+      organizationId: null,
+      fileName: 'orphan.pdf',
+      mimeType: 'application/pdf',
+      fileSize: 12,
+      storageDriver: 'local',
+      storagePath: '/tmp/orphan.pdf',
+      storageMetadata: null,
+      url: '/f/orphan.pdf',
+      partitionCode: 'messages',
+    }
+
+    const em = createEm({
+      find: jest.fn(async () => [partialNullAttachment]),
+    })
+
+    const copiedCount = await copyAttachmentsForForward(
+      em as never,
+      'source-msg',
+      'target-msg',
+      'tenant-1',
+    )
+
+    expect(copiedCount).toBe(0)
+    expect(em.create).not.toHaveBeenCalled()
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
   })
 
   it('copies and deduplicates attachments for forward across thread slice message ids', async () => {
@@ -256,7 +325,6 @@ describe('messages attachments helpers', () => {
       em as never,
       ['source-1', 'source-2'],
       'target-msg',
-      'org-1',
       'tenant-1',
     )
 

--- a/packages/core/src/modules/messages/lib/attachments.ts
+++ b/packages/core/src/modules/messages/lib/attachments.ts
@@ -1,4 +1,5 @@
 import type { EntityManager } from '@mikro-orm/core'
+import { resolveAttachmentScopePair } from '@open-mercato/core/modules/attachments/lib/scope'
 import { MESSAGE_ATTACHMENT_ENTITY_ID } from './constants'
 const LIBRARY_ATTACHMENT_ENTITY_ID = 'attachments:library'
 
@@ -135,14 +136,12 @@ export async function copyAttachmentsForForward(
   em: EntityManager,
   sourceMessageId: string,
   targetMessageId: string,
-  organizationId: string | null,
   tenantId: string,
 ): Promise<number> {
   return copyAttachmentsForForwardMessages(
     em,
     [sourceMessageId],
     targetMessageId,
-    organizationId,
     tenantId,
   )
 }
@@ -151,7 +150,6 @@ export async function copyAttachmentsForForwardMessages(
   em: EntityManager,
   sourceMessageIds: string[],
   targetMessageId: string,
-  targetOrganizationId: string | null,
   tenantId: string,
 ): Promise<number> {
   if (sourceMessageIds.length === 0) return 0
@@ -173,12 +171,19 @@ export async function copyAttachmentsForForwardMessages(
     }
   }
 
+  let copied = 0
   for (const sourceAttachment of dedupedById.values()) {
+    // Carry the source attachment's scope across as a unit so a forwarded copy
+    // can never become a partial-null row. Source rows that are themselves
+    // partial-null are unreadable dead data; skip rather than propagate them.
+    const scope = resolveAttachmentScopePair(sourceAttachment)
+    if (!scope) continue
+
     const copy = em.create(Attachment, {
       entityId: MESSAGE_ATTACHMENT_ENTITY_ID,
       recordId: targetMessageId,
-      organizationId: targetOrganizationId,
-      tenantId,
+      organizationId: scope.organizationId,
+      tenantId: scope.tenantId,
       fileName: sourceAttachment.fileName,
       mimeType: sourceAttachment.mimeType,
       fileSize: sourceAttachment.fileSize,
@@ -190,8 +195,11 @@ export async function copyAttachmentsForForwardMessages(
     })
 
     em.persist(copy)
+    copied += 1
   }
 
-  await em.flush()
-  return dedupedById.size
+  if (copied > 0) {
+    await em.flush()
+  }
+  return copied
 }


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-11-harden-attachment-copy-scope.md
Status: complete

Follow-up to #2879 / #2109.

## Goal
- Structurally prevent the partial-null `(tenant_id, organization_id)` attachment rows that PR #2879's audit flagged but left unfixed in the cross-module copy paths.

## Background
PR #2879 added a read-time fail-closed guard (`isSameScope`) and a creation guard at the upload site, but explicitly named `messages/lib/attachments.ts` (`copyAttachmentsForForwardMessages`) as the one path that can still construct a partial-null row: it applied a caller-supplied **nullable** `targetOrganizationId` alongside a **non-null** `tenantId` to every copy. A second independent-coalescing path exists in `catalog/commands/variants.ts`, where `organizationId: source.organizationId ?? variant.organizationId ?? null` and `tenantId: source.tenantId ?? variant.tenantId ?? null` are resolved separately and can land on one-set/one-null.

Since PR #2879's `assertAttachmentScopeInvariant` lives on its still-open branch, this follow-up hardens **structurally** (carry the scope pair across as a unit) instead of depending on an unmerged import. The new logic lives in a separate file to avoid merge conflicts with #2879's edits to `attachments/lib/access.ts`.

## What Changed
- **`attachments/lib/scope.ts`** (new) — `resolveAttachmentScopePair(...candidates)` returns the first candidate whose `(organizationId, tenantId)` form a valid both-set/both-null pair (blank/whitespace normalized to null), else `null`. Plus `isValidAttachmentScopePair`.
- **`messages/lib/attachments.ts`** — `copyAttachmentsForForwardMessages` (and the `copyAttachmentsForForward` wrapper) now inherit **each source attachment's own scope pair**; partial-null source rows (legacy dead data) are skipped rather than propagated. The now-meaningless `targetOrganizationId` parameter is dropped.
- **`messages/commands/messages.ts`** — caller updated to the new signature.
- **`catalog/commands/variants.ts`** — `aggregateVariantMediaToProduct` resolves the clone's scope pair atomically (source pair → variant pair → global).

`sync_excel` and `sync-akeneo` already pass a single scope object's columns through atomically, so they are not partial-null construction sites and are left unchanged. `attachments/api/route.ts` is owned by #2879 and is untouched here.

## Tests
- `attachments/lib/__tests__/scope.test.ts` (new) — valid/global/partial-null pairs, blank handling, fallback selection, all-invalid → null.
- `messages/lib/__tests__/attachments.test.ts` — updated for the signature change; added a "inherits source scope pair" case (global source → global copy) and a "skips partial-null source row" case.
- `messages/commands/__tests__/messages.forward.test.ts` — updated call-args expectation.
- Full gate: `yarn build:packages`, `yarn generate`, `yarn typecheck` (21 pkgs), `yarn test` (705 suites / 5808 tests), `yarn i18n:check-sync`, `yarn build:app` — all green.

## Backward Compatibility
No contract-surface change. `copyAttachmentsForForward(Messages)` are module-internal lib helpers (relative-import only, not part of `@open-mercato/core`'s public export map), and every caller is updated in the same change. No API response fields, event IDs, DI names, ACL IDs, import paths, or DB schema are affected. The new guard only refuses rows that were already unreadable dead data.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-11-harden-attachment-copy-scope.md#progress).
