### PR TITLE
security(entities): cap definitions.batch array to 1000 entries (#2924)

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/definitions.batch.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/definitions.batch.test.ts
@@ -109,3 +109,46 @@ describe('entities/definitions.batch POST (issue #1399)', () => {
     expect(mockEm.flush).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('entities/definitions.batch POST array bounds (issue #2924)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm.find.mockResolvedValue([] as unknown[])
+  })
+
+  it('rejects an oversized definitions array with 400 before any ORM work', async () => {
+    const body = {
+      entityId: 'test:entity',
+      definitions: Array.from({ length: 1001 }, (_, idx) => ({ key: `field_${idx}`, kind: 'text' })),
+    }
+
+    const response = await POST(makeRequest(body))
+
+    expect(response.status).toBe(400)
+    expect(mockEm.begin).not.toHaveBeenCalled()
+    expect(mockEm.find).not.toHaveBeenCalled()
+    expect(mockEm.persist).not.toHaveBeenCalled()
+    expect(mockEm.flush).not.toHaveBeenCalled()
+  })
+
+  it('accepts a batch at the maximum size', async () => {
+    const body = {
+      entityId: 'test:entity',
+      definitions: Array.from({ length: 1000 }, (_, idx) => ({ key: `field_${idx}`, kind: 'text' })),
+    }
+
+    const response = await POST(makeRequest(body))
+
+    expect(response.status).toBe(200)
+    expect(mockEm.persist).toHaveBeenCalledTimes(1000)
+  })
+
+  it('still accepts an empty definitions array (fieldset-only save path)', async () => {
+    const body = { entityId: 'test:entity', definitions: [] }
+
+    const response = await POST(makeRequest(body))
+
+    expect(response.status).toBe(200)
+    expect(mockEm.persist).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/entities/api/definitions.batch.ts
+++ b/packages/core/src/modules/entities/api/definitions.batch.ts
@@ -13,16 +13,20 @@ export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['entities.definitions.manage'] },
 }
 
+const MAX_DEFINITIONS_PER_BATCH = 1000
+
 const batchSchema = z
   .object({
     entityId: z.string().regex(/^[a-z0-9_]+:[a-z0-9_]+$/),
-    definitions: z.array(
-      upsertCustomFieldDefSchema
-        .omit({ entityId: true })
-        .extend({
-          configJson: z.any().optional(),
-        })
-    ),
+    definitions: z
+      .array(
+        upsertCustomFieldDefSchema
+          .omit({ entityId: true })
+          .extend({
+            configJson: z.any().optional(),
+          })
+      )
+      .max(MAX_DEFINITIONS_PER_BATCH),
   })
   .extend(customFieldEntityConfigSchema.shape)
 


### PR DESCRIPTION
Fixes #2924

## Problem
- `POST /api/entities/definitions.batch` validated its payload with an unbounded `definitions: z.array(...)`, then persisted every entry in an ORM loop. An authenticated user holding `entities.definitions.manage` could submit tens of thousands of definitions in a single request, holding a DB connection while minting that many `custom_field_def` rows — a resource-exhaustion DoS. Sibling collections on the same surface are already bounded (`fieldsets` capped at 20, bulk-delete capped at 10,000), making this endpoint the outlier.

## Root Cause
- `batchSchema.definitions` in `packages/core/src/modules/entities/api/definitions.batch.ts` had no `.max()` bound, so Zod validated each entry but never rejected on count, and the handler looped/persisted all of them.

## What Changed
- Added a `MAX_DEFINITIONS_PER_BATCH = 1000` cap (`.max(...)`) to the `definitions` array schema, so oversized batches are rejected with `400` before any ORM work.
- Deliberately did **not** add `.min(1)`: the combined entity+fieldset save path (`backend/entities/user/[entityId]/page.tsx`) legitimately posts an empty `definitions` array when an entity carries only fieldset config. The empty-array case is preserved.

## Tests
- Added regression tests in `definitions.batch.test.ts`:
  - oversized array (1001) → `400`, no `begin`/`find`/`persist`/`flush`
  - max-size array (1000) → `200`, persists all 1000
  - empty array → still `200` (fieldset-only save path preserved)
- `yarn workspace @open-mercato/core test definitions.batch` → 5/5 pass
- `yarn turbo run typecheck --filter=@open-mercato/core` → pass

## Backward Compatibility
- No contract-surface changes: route URL, response shape, ACL feature, and DI/event IDs are unchanged. The only behavioral change is rejecting batches larger than 1000 definitions, which is the intended hardening and far above any realistic legitimate batch size.

## Security impact
- Closes an authenticated resource-exhaustion (DoS) / storage-abuse vector by bounding the batch size before any DB work. Same hardening class as #2676.