### PR TITLE
fix(sales): widen orders/quotes number column to fit standard document numbers (#2947)

### DIFF
--- a/packages/core/src/modules/sales/components/documents/SalesDocumentsTable.tsx
+++ b/packages/core/src/modules/sales/components/documents/SalesDocumentsTable.tsx
@@ -23,6 +23,7 @@ import {
   createDictionaryMap,
   normalizeDictionaryEntries,
 } from '@open-mercato/core/modules/dictionaries/components/dictionaryAppearance'
+import { SALES_DOCUMENT_NUMBER_COLUMN_META } from './salesDocumentsColumns'
 
 type SalesDocumentKind = 'order' | 'quote'
 
@@ -594,7 +595,7 @@ export function SalesDocumentsTable({ kind }: { kind: SalesDocumentKind }) {
           ) : null}
         </div>
       ),
-      meta: { sticky: true },
+      meta: SALES_DOCUMENT_NUMBER_COLUMN_META,
     },
     {
       accessorKey: 'customerName',

--- a/packages/core/src/modules/sales/components/documents/__tests__/salesDocumentsColumns.test.ts
+++ b/packages/core/src/modules/sales/components/documents/__tests__/salesDocumentsColumns.test.ts
@@ -1,0 +1,38 @@
+import {
+  SALES_DOCUMENT_NUMBER_COLUMN_MAX_WIDTH,
+  SALES_DOCUMENT_NUMBER_COLUMN_META,
+} from '../salesDocumentsColumns'
+import {
+  DEFAULT_ORDER_NUMBER_FORMAT,
+  DEFAULT_QUOTE_NUMBER_FORMAT,
+} from '../../../lib/documentNumberTokens'
+
+const DATA_TABLE_DEFAULT_MAX_WIDTH_PX = 150
+
+const parsePx = (value: string): number => Number.parseInt(value.replace('px', ''), 10)
+
+const renderSampleNumber = (format: string): string =>
+  format
+    .replace('{yyyy}', '2026')
+    .replace('{mm}', '06')
+    .replace('{dd}', '10')
+    .replace('{seq:5}', '00123')
+
+describe('sales documents number column width (issue #2947)', () => {
+  it('keeps the column sticky', () => {
+    expect(SALES_DOCUMENT_NUMBER_COLUMN_META.sticky).toBe(true)
+  })
+
+  it('declares an explicit maxWidth so it does not fall back to the DataTable default', () => {
+    expect(SALES_DOCUMENT_NUMBER_COLUMN_META.maxWidth).toBe(SALES_DOCUMENT_NUMBER_COLUMN_MAX_WIDTH)
+    expect(parsePx(SALES_DOCUMENT_NUMBER_COLUMN_MAX_WIDTH)).toBeGreaterThan(DATA_TABLE_DEFAULT_MAX_WIDTH_PX)
+  })
+
+  it.each([
+    ['order', DEFAULT_ORDER_NUMBER_FORMAT],
+    ['quote', DEFAULT_QUOTE_NUMBER_FORMAT],
+  ])('reserves enough width for the default %s number format', (_kind, format) => {
+    const sampleNumber = renderSampleNumber(format)
+    expect(parsePx(SALES_DOCUMENT_NUMBER_COLUMN_MAX_WIDTH)).toBeGreaterThanOrEqual(sampleNumber.length * 9)
+  })
+})

--- a/packages/core/src/modules/sales/components/documents/salesDocumentsColumns.ts
+++ b/packages/core/src/modules/sales/components/documents/salesDocumentsColumns.ts
@@ -1,0 +1,6 @@
+export const SALES_DOCUMENT_NUMBER_COLUMN_MAX_WIDTH = '220px'
+
+export const SALES_DOCUMENT_NUMBER_COLUMN_META = {
+  sticky: true,
+  maxWidth: SALES_DOCUMENT_NUMBER_COLUMN_MAX_WIDTH,
+} as const


### PR DESCRIPTION
Fixes #2947

## Problem
On the backend Orders/Quotes list, the first column (order/quote number) truncates standard-format numbers (e.g. `ORDER-20260610-00123`) with an ellipsis.

## Root Cause
The number column definition only set `meta: { sticky: true }` and provided no `maxWidth`, so it fell through to the DataTable default of `maxWidth: '150px'` with `truncate: true` (`getColumnTruncateConfig` in `packages/ui/src/backend/DataTable.tsx`). 150px is too narrow for the ~20-char default format `ORDER-{yyyy}{mm}{dd}-{seq:5}`.

## What Changed
- Added `packages/core/src/modules/sales/components/documents/salesDocumentsColumns.ts` exporting `SALES_DOCUMENT_NUMBER_COLUMN_META` (`sticky: true`, `maxWidth: '220px'`).
- `SalesDocumentsTable.tsx` now uses that meta for the number column instead of the inline `{ sticky: true }`.
- Width is comfortably above the 150px default and fits both default order and quote number formats. Affects orders and quotes (shared table).

## Tests
- New unit test `__tests__/salesDocumentsColumns.test.ts`: asserts the column stays sticky, declares an explicit `maxWidth` greater than the 150px DataTable default, and reserves enough width for the default order/quote number formats (derived from `documentNumberTokens`). 4 tests pass.
- `yarn typecheck` (all 21 packages incl. `@open-mercato/app`) passes.

## Backward Compatibility
- No contract surface changes. New file/exports are additive; the only behavioral change is a wider column width.
