### PR TITLE
security(sales): remove raw acceptance-token fallback in public quote endpoints (#2929)

### DIFF
--- a/packages/core/src/modules/sales/api/__tests__/quotes.acceptance.test.ts
+++ b/packages/core/src/modules/sales/api/__tests__/quotes.acceptance.test.ts
@@ -135,38 +135,76 @@ describe('quote send + accept flow', () => {
     expect(mockEm.persist).toHaveBeenCalledWith(quote)
   })
 
-  test('accept falls back to raw token lookup for quotes sent before hashing rollout', async () => {
-    const LEGACY_RAW_TOKEN = '77777777-7777-4777-8777-777777777777'
-    const legacyQuote = {
+  test('accept never matches a raw (unhashed) stored token — hashed lookup only (#2929)', async () => {
+    const RAW_STORED_TOKEN = '77777777-7777-4777-8777-777777777777'
+    const rawStoredQuote = {
       id: '66666666-6666-4666-8666-666666666666',
       tenantId: '00000000-0000-4000-8000-000000000000',
       organizationId: '11111111-1111-4111-8111-111111111111',
-      quoteNumber: 'SQ-LEGACY',
+      quoteNumber: 'SQ-RAW',
       status: 'sent',
       statusEntryId: null,
       validUntil: new Date(Date.now() + 60_000),
       updatedAt: new Date(),
-      acceptanceToken: LEGACY_RAW_TOKEN,
+      acceptanceToken: RAW_STORED_TOKEN,
     }
 
     const seenWhereTokens: Array<string | undefined> = []
     mockEm.findOne.mockImplementation(async (cls: any, where: any) => {
       if (cls === SalesQuote) {
         seenWhereTokens.push(where?.acceptanceToken)
-        return where?.acceptanceToken === LEGACY_RAW_TOKEN ? legacyQuote : null
+        return where?.acceptanceToken === RAW_STORED_TOKEN ? rawStoredQuote : null
       }
       if (cls === Dictionary) return { id: 'dict-1' }
       if (cls === DictionaryEntry) return { id: 'entry-confirmed' }
-      if (cls === SalesOrder) return { id: 'order-legacy', orderNumber: 'SO-LEGACY', deletedAt: null }
+      if (cls === SalesOrder) return { id: 'order-raw', orderNumber: 'SO-RAW', deletedAt: null }
       return null
     })
-    mockCommandBus.execute.mockResolvedValue({ result: { orderId: 'order-legacy' } })
 
-    const res = await acceptQuote(makeAcceptRequest({ token: LEGACY_RAW_TOKEN }))
-    expect(res.status).toBe(200)
-    expect(seenWhereTokens[0]).toBe(hashAuthToken(LEGACY_RAW_TOKEN))
-    expect(seenWhereTokens[1]).toBe(LEGACY_RAW_TOKEN)
-    expect(legacyQuote.status).toBe('confirmed')
+    const res = await acceptQuote(makeAcceptRequest({ token: RAW_STORED_TOKEN }))
+    expect(res.status).toBe(404)
+    expect(seenWhereTokens).toEqual([hashAuthToken(RAW_STORED_TOKEN)])
+    expect(seenWhereTokens).not.toContain(RAW_STORED_TOKEN)
+    expect(mockCommandBus.execute).not.toHaveBeenCalled()
+    expect(rawStoredQuote.status).toBe('sent')
+  })
+
+  test('public view never matches a raw (unhashed) stored token — hashed lookup only (#2929)', async () => {
+    const RAW_STORED_TOKEN = '99999999-9999-4999-8999-999999999999'
+    const rawStoredQuote = {
+      id: 'q-raw-public',
+      tenantId: '00000000-0000-4000-8000-000000000000',
+      quoteNumber: 'SQ-RAW-PUB',
+      currencyCode: 'USD',
+      status: 'sent',
+      validFrom: null,
+      validUntil: null,
+      subtotalNetAmount: '0',
+      subtotalGrossAmount: '0',
+      discountTotalAmount: '0',
+      taxTotalAmount: '0',
+      grandTotalNetAmount: '0',
+      grandTotalGrossAmount: '0',
+      acceptanceToken: RAW_STORED_TOKEN,
+    }
+
+    const seenWhereTokens: Array<string | undefined> = []
+    mockEm.findOne.mockImplementation(async (cls: any, where: any) => {
+      if (cls === SalesQuote) {
+        seenWhereTokens.push(where?.acceptanceToken)
+        return where?.acceptanceToken === RAW_STORED_TOKEN ? rawStoredQuote : null
+      }
+      return null
+    })
+    mockEm.find.mockResolvedValue([])
+
+    const res = await getPublicQuote(
+      new Request(`http://localhost/api/sales/quotes/public/${RAW_STORED_TOKEN}`),
+      { params: { token: RAW_STORED_TOKEN } } as any,
+    )
+    expect(res.status).toBe(404)
+    expect(seenWhereTokens).toEqual([hashAuthToken(RAW_STORED_TOKEN)])
+    expect(seenWhereTokens).not.toContain(RAW_STORED_TOKEN)
   })
 
   test('public view returns expired flag', async () => {
@@ -356,11 +394,11 @@ describe('accept - tenant isolation (fix: tenantId scoped in lookup + encryption
       validUntil: new Date(Date.now() + 60_000),
       updatedAt: new Date(),
     }
-    // Simulate DB: honour tenantId in where clause (cross-tenant lookup returns null)
+    // Simulate DB: token stored hashed at rest; honour tenantId in where clause (cross-tenant lookup returns null)
     mockEm.findOne.mockImplementation(async (cls: any, where: any) => {
       if (cls === SalesQuote) {
         if (where?.tenantId && where.tenantId !== TENANT_ID) return null
-        return where?.acceptanceToken === ACCEPTANCE_TOKEN ? quote : null
+        return where?.acceptanceToken === hashAuthToken(ACCEPTANCE_TOKEN) ? quote : null
       }
       if (cls === Dictionary) return { id: 'dict-1' }
       if (cls === DictionaryEntry) return { id: 'entry-confirmed' }
@@ -406,7 +444,7 @@ describe('accept - tenant isolation (fix: tenantId scoped in lookup + encryption
     mockEm.findOne.mockImplementation(async (cls: any, where: any) => {
       if (cls === SalesQuote) {
         capturedWhere = where
-        return where?.acceptanceToken === ACCEPTANCE_TOKEN ? quote : null
+        return where?.acceptanceToken === hashAuthToken(ACCEPTANCE_TOKEN) ? quote : null
       }
       if (cls === Dictionary) return { id: 'dict-1' }
       if (cls === DictionaryEntry) return { id: 'entry-confirmed' }

--- a/packages/core/src/modules/sales/api/quotes/accept/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/accept/route.ts
@@ -88,7 +88,7 @@ export async function POST(req: Request) {
           { lockMode: LockMode.PESSIMISTIC_WRITE },
           tenantScope,
         )
-      const quote = (await findQuoteByToken(hashedToken)) ?? (await findQuoteByToken(token))
+      const quote = await findQuoteByToken(hashedToken)
       if (!quote) {
         throw new CrudHttpError(404, { error: translate('sales.quotes.accept.notFound', 'Quote not found.') })
       }

--- a/packages/core/src/modules/sales/api/quotes/public/[token]/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/public/[token]/route.ts
@@ -29,15 +29,10 @@ export async function GET(req: Request, ctx: { params: { token: string } }) {
     const container = await createRequestContainer();
     const em = container.resolve("em") as EntityManager;
     const hashedToken = hashAuthToken(token);
-    const quote =
-      (await findOneWithDecryption(em, SalesQuote, {
-        acceptanceToken: hashedToken,
-        deletedAt: null,
-      })) ??
-      (await findOneWithDecryption(em, SalesQuote, {
-        acceptanceToken: token,
-        deletedAt: null,
-      }));
+    const quote = await findOneWithDecryption(em, SalesQuote, {
+      acceptanceToken: hashedToken,
+      deletedAt: null,
+    });
     const { translate } = await resolveTranslations();
     if (!quote) {
       throw new CrudHttpError(404, {


### PR DESCRIPTION
Fixes #2929

## Problem
- The two unauthenticated public quote endpoints looked up the quote by `hashAuthToken(token)` and, on a miss, **fell back to matching the raw, unhashed token** against the stored `acceptanceToken` column:
  - `GET /api/sales/quotes/public/[token]`
  - `POST /api/sales/quotes/accept`
- This defeats hashing at rest: anyone able to read the column (backup leak, replica snapshot, log/dump, SQL injection elsewhere) could present the stored value directly to disclose full quote contents or accept the quote and convert it to an order.

## Root Cause
- The raw-token fallback was added as a transition bridge when token hashing was introduced (#1486) and never removed. It is the same at-rest-hashing-defeating pattern already fixed for auth session/reset tokens (#2691 → PR #2807) and message access tokens (#2702 → PR #2800).

## What Changed
- `packages/core/src/modules/sales/api/quotes/public/[token]/route.ts` — removed the raw-token fallback lookup; only `hashAuthToken(token)` is matched.
- `packages/core/src/modules/sales/api/quotes/accept/route.ts` — removed `?? findQuoteByToken(token)`; only the hashed lookup remains (still inside the pessimistic-lock transaction).
- No new raw-comparison path is retained, mirroring the approach accepted in #2691/#2702.

## Tests
- Replaced the test that asserted the legacy raw-token fallback with two regression tests proving a raw stored token never resolves a quote (`accept` → 404, no conversion command executed; `public view` → 404) and that the lookup queries **only** the hashed token.
- Updated tenant-isolation test mocks to simulate hashed-at-rest storage (they previously relied on the raw fallback).
- Verified the new regression tests fail on the unfixed routes and pass with the fix (22/22 in `quotes.acceptance.test.ts`).
- Full gate: `yarn generate`, `yarn build:packages`, `yarn typecheck`, `yarn test`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn build:app` — all green. (One pre-existing, unrelated `@open-mercato/ui` `formatCurrency` test failure on my machine is caused by a non-English system locale; it passes with `LANG=en_US.UTF-8`.)

## Backward Compatibility
- No contract surface changes: API URLs, request/response shapes, event IDs, ACL features, and DI keys are untouched.
- Behavior change is the security fix itself: quote rows whose `acceptanceToken` is still stored raw (only possible for quotes sent before the hashing rollout in #1486) no longer resolve. Remediation is to re-send the quote, which mints and stores a fresh hashed token. Same BC stance as #2691/#2702.

## Security impact
- Removes a weaker authentication path on two unauthenticated endpoints; the stored token column is no longer a usable credential, restoring the at-rest hashing guarantee for quote acceptance tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)