### PR TITLE
security(onboarding): rate-limit unauthenticated onboarding submissions (#2923)

### DIFF
--- a/packages/onboarding/src/__tests__/onboarding-submit-rate-limit.test.ts
+++ b/packages/onboarding/src/__tests__/onboarding-submit-rate-limit.test.ts
@@ -1,0 +1,22 @@
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(),
+}))
+
+import { metadata, openApi } from '../modules/onboarding/api/post/onboarding'
+
+describe('onboarding submission rate limiting', () => {
+  it('declares an IP rate limit so the API dispatcher throttles unauthenticated submissions', () => {
+    expect(metadata.POST.requireAuth).toBe(false)
+    expect(metadata.POST.rateLimit).toEqual({
+      points: 10,
+      duration: 60,
+      blockDuration: 60,
+      keyPrefix: 'onboarding',
+    })
+  })
+
+  it('documents the 429 response in the OpenAPI doc', () => {
+    const errors = openApi.methods?.POST?.errors ?? []
+    expect(errors.some((entry) => entry.status === 429)).toBe(true)
+  })
+})

--- a/packages/onboarding/src/modules/onboarding/api/post/onboarding.ts
+++ b/packages/onboarding/src/modules/onboarding/api/post/onboarding.ts
@@ -15,11 +15,19 @@ import { User } from '@open-mercato/core/modules/auth/data/entities'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { formatPasswordRequirements, getPasswordPolicy } from '@open-mercato/shared/lib/auth/passwordPolicy'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/config'
+import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
 
 export const metadata = {
   path: '/onboarding/onboarding',
   POST: {
     requireAuth: false,
+    rateLimit: readEndpointRateLimitConfig('ONBOARDING', {
+      points: 10,
+      duration: 60,
+      blockDuration: 60,
+      keyPrefix: 'onboarding',
+    }),
   },
 }
 
@@ -242,6 +250,7 @@ const onboardingPostDoc: OpenApiMethodDoc = {
     { status: 400, description: 'Validation failed', schema: onboardingErrorSchema },
     { status: 404, description: 'Self-service onboarding disabled', schema: onboardingErrorSchema },
     { status: 409, description: 'Existing account or pending request', schema: onboardingErrorSchema },
+    { status: 429, description: 'Too many onboarding submissions from this IP', schema: rateLimitErrorSchema },
     { status: 500, description: 'Unexpected server error', schema: onboardingErrorSchema },
   ],
 }


### PR DESCRIPTION
Fixes #2923

## Problem
- `POST /api/onboarding/onboarding` is unauthenticated and sends a verification email per request, but declared no `rateLimit` in its route metadata, so the API dispatcher applied no IP-level throttle. The only guard was a per-email 10-minute cooldown, which is useless when an attacker fans out across unique addresses — enabling email-bombing, provider quota exhaustion, sender-reputation damage, and unbounded `onboarding_request` row growth from a single IP.

## Root Cause
- The dispatcher (`apps/mercato/src/app/api/[...slug]/route.ts`) only enforces rate limiting when `methodMetadata.rateLimit` is present. The onboarding submission route's metadata was `{ requireAuth: false }` with no `rateLimit` — an inconsistency with sibling unauthenticated email-sending endpoints (password reset, customer invitations fixed in #2692).

## What Changed
- `packages/onboarding/src/modules/onboarding/api/post/onboarding.ts`: declared `rateLimit` in the POST metadata via `readEndpointRateLimitConfig('ONBOARDING', { points: 10, duration: 60, blockDuration: 60, keyPrefix: 'onboarding' })` — enforced per client IP by the dispatcher, overridable through `RATE_LIMIT_ONBOARDING_POINTS` / `_DURATION` / `_BLOCK_DURATION` env vars (same pattern as the password-reset endpoint).
- Documented the `429` response in the route's OpenAPI doc using the shared `rateLimitErrorSchema`.

## Tests
- New `packages/onboarding/src/__tests__/onboarding-submit-rate-limit.test.ts`: asserts the POST metadata declares the IP rate limit (fails on develop, passes with the fix) and that the OpenAPI doc includes the 429 response.
- Ran: `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app` — all green. (One pre-existing locale-sensitive `@open-mercato/ui` `formatCurrency` test fails only under a non-en-US system locale; passes with `LC_ALL=en_US.UTF-8`; unrelated to this change.)

## Backward Compatibility
- Purely additive: new optional metadata field, new OpenAPI error entry, new optional env-var overrides. No contract surfaces removed or altered.

## Security impact
- Hardens an unauthenticated, email-sending endpoint against abuse: per-IP throttle (10/min, 60s block) closes the email-bombing / quota-exhaustion vector described in #2923. No changes to authentication, authorization, or data access semantics — requests under the limit behave exactly as before.