### PR TITLE
perf(audit_logs): throttle access_logs rotation and index created_at (#2965)

### DIFF
--- a/apps/docs/docs/user-guide/audit-logs.mdx
+++ b/apps/docs/docs/user-guide/audit-logs.mdx
@@ -40,5 +40,6 @@ Access log retention is automatic and environment-configurable:
 
 - **Core resources** (`auth.user`, `auth.role`) are retained for **7 days** by default. Override with `AUDIT_LOGS_CORE_RETENTION_DAYS`.
 - **All other resources** rotate after **8 hours** by default. Override with `AUDIT_LOGS_NON_CORE_RETENTION_HOURS`.
+- **Rotation frequency** is throttled to at most one sweep per **60 seconds** per process. Override with `AUDIT_LOGS_ROTATE_INTERVAL_MS`; setting it to `0` runs the sweep after every write.
 
 Configure these in your `.env` file to keep the volume of access logs under control while preserving critical trails for longer investigations.

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -228,6 +228,8 @@ DB_POOL_ACQUIRE_TIMEOUT=10000
 AUDIT_LOGS_CORE_RETENTION_DAYS=7
 # Non-core reads rotate aggressively to limit storage.
 AUDIT_LOGS_NON_CORE_RETENTION_HOURS=8
+# Minimum gap between retention sweeps per process. 0 rotates on every write.
+AUDIT_LOGS_ROTATE_INTERVAL_MS=60000
 
 # Tenant data encryption (enabled by default)
 TENANT_DATA_ENCRYPTION=yes

--- a/packages/core/src/modules/audit_logs/data/entities.ts
+++ b/packages/core/src/modules/audit_logs/data/entities.ts
@@ -96,6 +96,7 @@ export class ActionLog {
 @Entity({ tableName: 'access_logs' })
 @Index({ name: 'access_logs_tenant_idx', properties: ['tenantId', 'createdAt'] })
 @Index({ name: 'access_logs_actor_idx', properties: ['actorUserId', 'createdAt'] })
+@Index({ name: 'access_logs_created_at_idx', properties: ['createdAt'] })
 export class AccessLog {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string

--- a/packages/core/src/modules/audit_logs/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/audit_logs/migrations/.snapshot-open-mercato.json
@@ -209,6 +209,16 @@
           "unique": false
         },
         {
+          "keyName": "access_logs_created_at_idx",
+          "columnNames": [
+            "created_at"
+          ],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
           "keyName": "access_logs_pkey",
           "columnNames": [
             "id"

--- a/packages/core/src/modules/audit_logs/migrations/Migration20260611104500.ts
+++ b/packages/core/src/modules/audit_logs/migrations/Migration20260611104500.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260611104500 extends Migration {
+
+  override up(): void | Promise<void> {
+    this.addSql(`create index "access_logs_created_at_idx" on "access_logs" ("created_at");`);
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`drop index "access_logs_created_at_idx";`);
+  }
+
+}

--- a/packages/core/src/modules/audit_logs/services/__tests__/accessLogService.rotation.test.ts
+++ b/packages/core/src/modules/audit_logs/services/__tests__/accessLogService.rotation.test.ts
@@ -1,0 +1,112 @@
+jest.mock('@open-mercato/shared/lib/encryption/customFieldValues', () => ({
+  resolveTenantEncryptionService: jest.fn(() => null),
+}))
+
+type ServiceModule = typeof import('../accessLogService')
+
+const ROTATE_INTERVAL_ENV = 'AUDIT_LOGS_ROTATE_INTERVAL_MS'
+
+function loadServiceModule(intervalMs: string | undefined): ServiceModule {
+  let mod: ServiceModule | undefined
+  jest.isolateModules(() => {
+    if (intervalMs === undefined) delete process.env[ROTATE_INTERVAL_ENV]
+    else process.env[ROTATE_INTERVAL_ENV] = intervalMs
+    mod = require('../accessLogService') as ServiceModule
+  })
+  if (!mod) throw new Error('[internal] failed to load accessLogService module')
+  return mod
+}
+
+function makeFakeEm() {
+  const nativeDeleteCalls: unknown[] = []
+  const fork = {
+    getConnection: () => ({
+      execute: jest.fn(async () => [{ id: '00000000-0000-4000-8000-000000000001' }]),
+    }),
+    nativeDelete: jest.fn(async (_entity: unknown, where: unknown) => {
+      nativeDeleteCalls.push(where)
+      return 0
+    }),
+    create: jest.fn((_entity: unknown, data: Record<string, unknown>) => data),
+  }
+  const em = {
+    fork: jest.fn(() => fork),
+  }
+  return { em, nativeDeleteCalls }
+}
+
+function payload(idx: number) {
+  return {
+    tenantId: '11111111-1111-4111-8111-111111111111',
+    organizationId: '22222222-2222-4222-8222-222222222222',
+    actorUserId: '33333333-3333-4333-8333-333333333333',
+    resourceKind: 'example.todo',
+    resourceId: `00000000-0000-4000-8000-${String(idx).padStart(12, '0')}`,
+    accessType: 'read:list',
+    fields: ['id', 'title'],
+    context: { resultCount: 50 },
+  }
+}
+
+const originalRotateInterval = process.env[ROTATE_INTERVAL_ENV]
+
+afterEach(() => {
+  if (originalRotateInterval === undefined) delete process.env[ROTATE_INTERVAL_ENV]
+  else process.env[ROTATE_INTERVAL_ENV] = originalRotateInterval
+  jest.restoreAllMocks()
+})
+
+describe('access log rotation throttling', () => {
+  it('rotates once per interval instead of on every write (default interval)', async () => {
+    const { AccessLogService } = loadServiceModule(undefined)
+    const { em, nativeDeleteCalls } = makeFakeEm()
+    const service = new AccessLogService(em as never)
+
+    await service.log(payload(0))
+    expect(nativeDeleteCalls).toHaveLength(2)
+
+    await service.log(payload(1))
+    await service.logMany([payload(2), payload(3)])
+    expect(nativeDeleteCalls).toHaveLength(2)
+  })
+
+  it('rotates again once the configured interval has elapsed', async () => {
+    const { AccessLogService } = loadServiceModule('60000')
+    const { em, nativeDeleteCalls } = makeFakeEm()
+    const service = new AccessLogService(em as never)
+
+    const baseTime = 1_750_000_000_000
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTime)
+    await service.log(payload(0))
+    expect(nativeDeleteCalls).toHaveLength(2)
+
+    nowSpy.mockReturnValue(baseTime + 59_999)
+    await service.log(payload(1))
+    expect(nativeDeleteCalls).toHaveLength(2)
+
+    nowSpy.mockReturnValue(baseTime + 60_000)
+    await service.log(payload(2))
+    expect(nativeDeleteCalls).toHaveLength(4)
+  })
+
+  it('rotates on every write when the interval is 0', async () => {
+    const { AccessLogService } = loadServiceModule('0')
+    const { em, nativeDeleteCalls } = makeFakeEm()
+    const service = new AccessLogService(em as never)
+
+    await service.log(payload(0))
+    await service.log(payload(1))
+    await service.logMany([payload(2), payload(3)])
+    expect(nativeDeleteCalls).toHaveLength(6)
+  })
+
+  it('falls back to the throttled default for invalid interval values', async () => {
+    const { AccessLogService } = loadServiceModule('not-a-number')
+    const { em, nativeDeleteCalls } = makeFakeEm()
+    const service = new AccessLogService(em as never)
+
+    await service.log(payload(0))
+    await service.log(payload(1))
+    expect(nativeDeleteCalls).toHaveLength(2)
+  })
+})

--- a/packages/core/src/modules/audit_logs/services/accessLogService.ts
+++ b/packages/core/src/modules/audit_logs/services/accessLogService.ts
@@ -20,10 +20,23 @@ function toPositiveNumber(value: string | undefined, fallback: number): number {
   return parsed
 }
 
+function toNonNegativeNumber(value: string | undefined, fallback: number): number {
+  if (value === undefined || value === '') return fallback
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback
+  return parsed
+}
+
 const CORE_RETENTION_DAYS = toPositiveNumber(process.env.AUDIT_LOGS_CORE_RETENTION_DAYS, 7)
 const NON_CORE_RETENTION_HOURS = toPositiveNumber(process.env.AUDIT_LOGS_NON_CORE_RETENTION_HOURS, 8)
 const CORE_RETENTION_MS = CORE_RETENTION_DAYS * 24 * 60 * 60 * 1000
 const NON_CORE_RETENTION_MS = NON_CORE_RETENTION_HOURS * 60 * 60 * 1000
+// Rotation runs after every successful write; without a gate that means two
+// DELETE statements per CRUD GET. Amortize to one rotation per interval per
+// process — `0` opts back into rotate-on-every-write (test harnesses).
+const ROTATE_INTERVAL_MS = toNonNegativeNumber(process.env.AUDIT_LOGS_ROTATE_INTERVAL_MS, 60_000)
+
+let lastRotatedAt: number | null = null
 const UUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/
 // Postgres has a hard limit of 65k bind parameters per statement. Each access
 // log row uses 10 bind values (see INSERT below), so 500 rows × 10 = 5 000
@@ -380,6 +393,8 @@ export class AccessLogService {
 
   private async rotate(fork: EntityManager) {
     const now = Date.now()
+    if (ROTATE_INTERVAL_MS > 0 && lastRotatedAt !== null && now - lastRotatedAt < ROTATE_INTERVAL_MS) return
+    lastRotatedAt = now
     const coreCutoff = new Date(now - CORE_RETENTION_MS)
     const nonCoreCutoff = new Date(now - NON_CORE_RETENTION_MS)
     try {

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -218,6 +218,8 @@ DB_POOL_ACQUIRE_TIMEOUT=60000
 AUDIT_LOGS_CORE_RETENTION_DAYS=7
 # Non-core reads rotate aggressively to limit storage.
 AUDIT_LOGS_NON_CORE_RETENTION_HOURS=8
+# Minimum gap between retention sweeps per process. 0 rotates on every write.
+AUDIT_LOGS_ROTATE_INTERVAL_MS=60000
 
 # Tenant data encryption (enabled by default)
 TENANT_DATA_ENCRYPTION=yes


### PR DESCRIPTION
Fixes #2965

## Problem
- Every authenticated CRUD list/detail GET writes access logs, and each `AccessLogService` write path ends by awaiting `rotate()`, which fires two `nativeDelete` statements on `access_logs`. With no index leading on `created_at`, both DELETEs sequential-scan a high-churn table, twice per request, with no throttling.

## Root Cause
- `rotate()` has no time gate — it is the sole retention mechanism and runs after every successful write (`logInternal` and `logManyInternal`).
- `access_logs` only has `(tenant_id, created_at)` and `(actor_user_id, created_at)` indexes; the rotation DELETEs filter on `resource_kind` + `created_at`, and the `$nin` predicate cannot use any `resource_kind`-prefixed index, so neither DELETE is index-driven.

## What Changed
- `packages/core/src/modules/audit_logs/services/accessLogService.ts` — rotation is now gated by a module-level `lastRotatedAt` guard keyed off a new `AUDIT_LOGS_ROTATE_INTERVAL_MS` env (default 60 000 ms; `0` restores rotate-on-every-write for test harnesses; invalid values fall back to the default). This cuts rotation DELETEs from 2/request to 2/interval/process while keeping `rotate()` as the sole retention mechanism. The guard check-and-set is synchronous, so concurrent fire-and-forget writes cannot double-rotate within a tick; per-process state means an N-instance fleet rotates at most N times per interval — still a large reduction, and each instance stays self-healing without coordination.
- `packages/core/src/modules/audit_logs/data/entities.ts` — additive `access_logs_created_at_idx` on `created_at` (chosen over `(resource_kind, created_at)` because the `$nin` DELETE cannot use a `resource_kind` prefix).
- `packages/core/src/modules/audit_logs/migrations/Migration20260611104500.ts` — additive `create index` migration, plus the matching `.snapshot-open-mercato.json` update.
- `apps/mercato/.env.example`, `packages/create-app/template/.env.example`, `apps/docs/docs/user-guide/audit-logs.mdx` — document the new knob alongside the existing `AUDIT_LOGS_*` retention envs.

## Tests
- New `accessLogService.rotation.test.ts` (4 cases): default interval rotates once then skips subsequent `log`/`logMany` writes; rotation resumes once the interval elapses (`Date.now` spied); `AUDIT_LOGS_ROTATE_INTERVAL_MS=0` rotates on every write; invalid values fall back to the throttled default. 3 of 4 fail without the fix (the `0` case pins the preserved legacy behavior).
- Full gate run: `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app` — all green except one pre-existing, environment-only failure in `@open-mercato/ui` `format.test.ts` (`formatCurrency` expects en-US formatting; this machine runs a Polish locale — the same test passes with `LC_ALL=en_US.UTF-8` and the diff touches nothing in `packages/ui`).

## Backward Compatibility
- No contract surface changes: no response shape, DI key, event ID, ACL feature, or API route touched. The env knob and index are additive; adding an index is explicitly permitted by `BACKWARD_COMPATIBILITY.md` §8. Retention semantics are preserved — the high-water mark grows by at most one interval (60 s) against existing 8 h / 7 d retention budgets.
