### PR TITLE
perf(query_index,auth): add missing hot-path indexes — search_tokens(tenant_id, token_hash) and user_roles(user_id)/(role_id) (#2966)

### DIFF
--- a/packages/core/src/__tests__/hot-path-indexes.test.ts
+++ b/packages/core/src/__tests__/hot-path-indexes.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Hot-path index guard (#2966).
+ *
+ * Two of the platform's hottest read paths used to run sequential scans:
+ * TokenSearchStrategy filters search_tokens by (token_hash IN ..., tenant_id)
+ * on every keystroke, and RBAC scans user_roles by user_id on every ACL cache
+ * miss and by role_id on user-list/role-mutation paths — Postgres does not
+ * auto-index FK columns.
+ *
+ * This test pins the fix at all three declaration sites so a refactor cannot
+ * silently drop one of them: the entity `@Index` decorator, the migration SQL,
+ * and the module's `.snapshot-open-mercato.json` (which keeps `yarn db:generate`
+ * from re-emitting the diff).
+ */
+
+const modulesRoot = join(__dirname, '..', 'modules')
+
+function readEntities(module: string): string {
+  return readFileSync(join(modulesRoot, module, 'data', 'entities.ts'), 'utf8')
+}
+
+function readSnapshotIndexNames(module: string, table: string): string[] {
+  const snapshotPath = join(modulesRoot, module, 'migrations', '.snapshot-open-mercato.json')
+  const snapshot = JSON.parse(readFileSync(snapshotPath, 'utf8')) as {
+    tables: Array<{ name: string; indexes: Array<{ keyName: string }> }>
+  }
+  const tableSnapshot = snapshot.tables.find((candidate) => candidate.name === table)
+  expect(tableSnapshot).toBeDefined()
+  return tableSnapshot!.indexes.map((index) => index.keyName)
+}
+
+function readAllMigrationSql(module: string): string {
+  const migrationsDir = join(modulesRoot, module, 'migrations')
+  return readdirSync(migrationsDir)
+    .filter((file) => file.endsWith('.ts'))
+    .map((file) => readFileSync(join(migrationsDir, file), 'utf8'))
+    .join('\n')
+}
+
+describe('hot-path indexes (#2966)', () => {
+  describe('search_tokens (tenant_id, token_hash)', () => {
+    it('declares the index on the SearchToken entity', () => {
+      const source = readEntities('query_index')
+      expect(source).toContain(
+        "@Index({ name: 'search_tokens_tenant_token_hash_idx', properties: ['tenantId', 'tokenHash'] })",
+      )
+    })
+
+    it('creates the index concurrently in a query_index migration', () => {
+      const sql = readAllMigrationSql('query_index')
+      expect(sql).toContain(
+        'create index concurrently if not exists "search_tokens_tenant_token_hash_idx" on "search_tokens" ("tenant_id", "token_hash")',
+      )
+    })
+
+    it('records the index in the query_index schema snapshot', () => {
+      expect(readSnapshotIndexNames('query_index', 'search_tokens')).toContain(
+        'search_tokens_tenant_token_hash_idx',
+      )
+    })
+  })
+
+  describe('user_roles (user_id) and (role_id)', () => {
+    it('declares both FK indexes on the UserRole entity', () => {
+      const source = readEntities('auth')
+      expect(source).toContain("@Index({ name: 'user_roles_user_id_idx', properties: ['user'] })")
+      expect(source).toContain("@Index({ name: 'user_roles_role_id_idx', properties: ['role'] })")
+    })
+
+    it('creates both indexes in an auth migration', () => {
+      const sql = readAllMigrationSql('auth')
+      expect(sql).toContain('create index if not exists "user_roles_user_id_idx" on "user_roles" ("user_id")')
+      expect(sql).toContain('create index if not exists "user_roles_role_id_idx" on "user_roles" ("role_id")')
+    })
+
+    it('records both indexes in the auth schema snapshot', () => {
+      const indexNames = readSnapshotIndexNames('auth', 'user_roles')
+      expect(indexNames).toContain('user_roles_user_id_idx')
+      expect(indexNames).toContain('user_roles_role_id_idx')
+    })
+  })
+})

--- a/packages/core/src/modules/auth/data/entities.ts
+++ b/packages/core/src/modules/auth/data/entities.ts
@@ -178,6 +178,8 @@ export class SidebarVariant {
 }
 
 @Entity({ tableName: 'user_roles' })
+@Index({ name: 'user_roles_user_id_idx', properties: ['user'] })
+@Index({ name: 'user_roles_role_id_idx', properties: ['role'] })
 export class UserRole {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string

--- a/packages/core/src/modules/auth/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/auth/migrations/.snapshot-open-mercato.json
@@ -1733,6 +1733,26 @@
       },
       "indexes": [
         {
+          "keyName": "user_roles_user_id_idx",
+          "columnNames": [
+            "user_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "user_roles_role_id_idx",
+          "columnNames": [
+            "role_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
           "keyName": "user_roles_pkey",
           "columnNames": [
             "id"

--- a/packages/core/src/modules/auth/migrations/Migration20260611103000.ts
+++ b/packages/core/src/modules/auth/migrations/Migration20260611103000.ts
@@ -1,0 +1,21 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// #2966: user_roles carries only its FK constraints and Postgres does not
+// auto-index FK columns, so RBAC scans it sequentially by user_id on every
+// ACL cache miss (rbacService super-admin check + ACL aggregation) and by
+// role_id on user-list filtering and role rename/delete guards. Index both
+// FK columns so these hot paths become index scans. The table is small
+// relative to search_tokens, so a plain (transactional) build is safe.
+export class Migration20260611103000 extends Migration {
+
+  override up(): void | Promise<void> {
+    this.addSql(`create index if not exists "user_roles_user_id_idx" on "user_roles" ("user_id");`);
+    this.addSql(`create index if not exists "user_roles_role_id_idx" on "user_roles" ("role_id");`);
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`drop index if exists "user_roles_user_id_idx";`);
+    this.addSql(`drop index if exists "user_roles_role_id_idx";`);
+  }
+
+}

--- a/packages/core/src/modules/query_index/data/entities.ts
+++ b/packages/core/src/modules/query_index/data/entities.ts
@@ -254,6 +254,7 @@ export class IndexerStatusLog {
 @Entity({ tableName: 'search_tokens' })
 @Index({ name: 'search_tokens_lookup_idx', properties: ['entityType', 'field', 'tokenHash', 'tenantId', 'organizationId'] })
 @Index({ name: 'search_tokens_entity_idx', properties: ['entityType', 'entityId'] })
+@Index({ name: 'search_tokens_tenant_token_hash_idx', properties: ['tenantId', 'tokenHash'] })
 export class SearchToken {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string

--- a/packages/core/src/modules/query_index/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/query_index/migrations/.snapshot-open-mercato.json
@@ -1356,6 +1356,17 @@
         },
         {
           "columnNames": [
+            "tenant_id",
+            "token_hash"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "search_tokens_tenant_token_hash_idx",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
             "id"
           ],
           "composite": false,

--- a/packages/core/src/modules/query_index/migrations/Migration20260611103000_query_index.ts
+++ b/packages/core/src/modules/query_index/migrations/Migration20260611103000_query_index.ts
@@ -1,0 +1,29 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// #2966: TokenSearchStrategy — the always-available global-search fallback —
+// filters search_tokens by token_hash IN (...) AND tenant_id on every
+// keystroke, but both existing indexes lead with entity_type (and the lookup
+// index interposes field, which the query never filters), so the per-keystroke
+// lookup degrades to a sequential scan as the table grows. Add a
+// (tenant_id, token_hash)-leading index so it becomes an index scan.
+//
+// search_tokens is high-churn (rows scale with records × tokens), so the
+// index is built CONCURRENTLY to avoid blocking writes during the build.
+// CREATE INDEX CONCURRENTLY cannot run inside a transaction, hence
+// isTransactional() => false; the migration runner applies migrations
+// one-by-one, so this opt-out is safe.
+export class Migration20260611103000_query_index extends Migration {
+
+  override isTransactional(): boolean {
+    return false;
+  }
+
+  override up(): void | Promise<void> {
+    this.addSql(`create index concurrently if not exists "search_tokens_tenant_token_hash_idx" on "search_tokens" ("tenant_id", "token_hash");`);
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`drop index if exists "search_tokens_tenant_token_hash_idx";`);
+  }
+
+}


### PR DESCRIPTION
Fixes #2966

## Problem
Two of the platform's hottest read paths run sequential scans:
- `TokenSearchStrategy` (the always-available global-search fallback, and the only strategy without Meilisearch) filters `search_tokens` by `token_hash IN (...) AND tenant_id` **on every keystroke**, but both existing indexes lead with `entity_type` — and `search_tokens_lookup_idx` interposes `field`, which the query never filters — so the lookup degrades to a full-table scan + `GROUP BY`/`HAVING` as the table grows (rows scale with `records × tokens`).
- `user_roles` has **zero secondary indexes** (Postgres does not auto-index FK columns), yet RBAC scans it by `user_id` on every ACL cache miss (`rbacService.ts` super-admin check + ACL aggregation) and by `role_id` on user-list filtering and role rename/delete guards.

## What Changed
Three additive indexes, each declared at all three sites (entity `@Index` → migration SQL → `.snapshot-open-mercato.json`, so `yarn db:generate` stays quiet):

| Index | Migration | Build |
|---|---|---|
| `search_tokens_tenant_token_hash_idx (tenant_id, token_hash)` | `query_index/migrations/Migration20260611103000_query_index.ts` | `CREATE INDEX CONCURRENTLY` in a **non-transactional** migration (`isTransactional() => false`; the runner applies migrations one-by-one, so the opt-out is safe) — `search_tokens` is high-churn and must not block writes |
| `user_roles_user_id_idx (user_id)` | `auth/migrations/Migration20260611103000.ts` | plain transactional — small table |
| `user_roles_role_id_idx (role_id)` | same | plain transactional |

**Deliberately not shipped:** the audit's optional fourth candidate (composite on `entity_indexes`) — the issue itself requires EXPLAIN verification on a representative multi-org dataset first, and the per-row hybrid join is already served by the existing coalesced unique constraint.

## Tests
- New guard `packages/core/src/__tests__/hot-path-indexes.test.ts` (6 tests) pinning all three declaration sites per index, so a refactor can't silently drop the entity decorator, the migration SQL, or the snapshot entry.
- Full gate: `build:packages` → `generate` → `build:packages`, `yarn typecheck` (21/21), `yarn workspace @open-mercato/core test` (5852/5853 — the single failure is the pre-existing locale-dependent `DealsKpiStrip` compact-number test, untouched by this change), `yarn build:app` ✅.

## Backward Compatibility
Additive indexes only — explicitly permitted by `BACKWARD_COMPATIBILITY.md` §8 ("MAY add new indexes freely"). No types, routes, DI keys, event IDs, or response shapes change. `down()` migrations drop the indexes cleanly.

## Deployment note
The `search_tokens` index builds `CONCURRENTLY`, so the migration does not take a write-blocking lock; on very large tables it will simply take a while. As the issue suggests, confirming index pickup with `EXPLAIN (ANALYZE)` on seeded data before closing the regression is recommended.