### PR TITLE
security(webhooks): prevent custom headers from overriding Standard Webhooks signature headers (#2922)

### DIFF
--- a/packages/webhooks/src/modules/webhooks/data/__tests__/validators.test.ts
+++ b/packages/webhooks/src/modules/webhooks/data/__tests__/validators.test.ts
@@ -87,3 +87,29 @@ describe('webhookCreateSchema — URL safety', () => {
     expect(webhookCreateSchema.safeParse(baseInput({ url: 'https://user:pass@localhost/webhooks' })).success).toBe(false)
   })
 })
+
+describe('webhookCreateSchema — reserved custom headers', () => {
+  it('rejects custom headers that shadow Standard Webhooks signature headers', () => {
+    const result = webhookCreateSchema.safeParse(baseInput({ customHeaders: { 'webhook-signature': 'forged' } }))
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/reserved/i)
+    }
+  })
+
+  it('rejects reserved header names case-insensitively', () => {
+    expect(webhookCreateSchema.safeParse(baseInput({ customHeaders: { 'Webhook-Id': 'constant' } })).success).toBe(false)
+    expect(webhookCreateSchema.safeParse(baseInput({ customHeaders: { 'WEBHOOK-TIMESTAMP': '0' } })).success).toBe(false)
+    expect(webhookCreateSchema.safeParse(baseInput({ customHeaders: { 'Content-Type': 'text/plain' } })).success).toBe(false)
+  })
+
+  it('rejects reserved headers on update', () => {
+    const result = webhookUpdateSchema.safeParse({ customHeaders: { 'webhook-signature': 'forged' } })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts non-reserved custom headers', () => {
+    expect(webhookCreateSchema.safeParse(baseInput({ customHeaders: { 'x-api-key': 'value', authorization: 'Bearer token' } })).success).toBe(true)
+    expect(webhookUpdateSchema.safeParse({ customHeaders: { 'x-api-key': 'value' } }).success).toBe(true)
+  })
+})

--- a/packages/webhooks/src/modules/webhooks/data/validators.ts
+++ b/packages/webhooks/src/modules/webhooks/data/validators.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { assertStaticallySafeWebhookUrl, UnsafeWebhookUrlError } from '../lib/url-safety'
+import { isReservedWebhookCustomHeader } from '../lib/custom-headers'
 
 const safeWebhookUrl = z.string().url().superRefine((value, ctx) => {
   try {
@@ -12,13 +13,25 @@ const safeWebhookUrl = z.string().url().superRefine((value, ctx) => {
   }
 })
 
+const webhookCustomHeaders = z.record(z.string(), z.string()).superRefine((value, ctx) => {
+  for (const name of Object.keys(value)) {
+    if (isReservedWebhookCustomHeader(name)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Header "${name}" is reserved for webhook signing and cannot be overridden`,
+        path: [name],
+      })
+    }
+  }
+})
+
 export const webhookCreateSchema = z.object({
   name: z.string().min(1).max(255),
   description: z.string().max(1000).optional().nullable(),
   url: safeWebhookUrl,
   subscribedEvents: z.array(z.string().min(1)).min(1),
   httpMethod: z.enum(['POST', 'PUT', 'PATCH'] as const).default('POST'),
-  customHeaders: z.record(z.string(), z.string()).optional().nullable(),
+  customHeaders: webhookCustomHeaders.optional().nullable(),
   deliveryStrategy: z.literal('http').default('http'),
   strategyConfig: z.record(z.string(), z.unknown()).optional().nullable(),
   maxRetries: z.number().int().min(0).max(30).default(10),

--- a/packages/webhooks/src/modules/webhooks/lib/__tests__/delivery-custom-headers.test.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/__tests__/delivery-custom-headers.test.ts
@@ -1,0 +1,169 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { processWebhookDeliveryJob } from '../delivery'
+import { isReservedWebhookCustomHeader, sanitizeWebhookCustomHeaders } from '../custom-headers'
+
+jest.mock('../../events', () => ({
+  emitWebhooksEvent: jest.fn(async () => undefined),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+}))
+
+jest.mock('../integration-state', () => ({
+  isWebhookIntegrationEnabled: jest.fn(async () => true),
+  WEBHOOK_INTEGRATION_DISABLED_MESSAGE: 'disabled',
+}))
+
+jest.mock('@open-mercato/shared/lib/webhooks', () => ({
+  buildWebhookHeaders: jest.fn(() => ({
+    'webhook-id': 'msg-1',
+    'webhook-timestamp': '1700000000',
+    'webhook-signature': 'v1,legitimate-signature',
+  })),
+  generateMessageId: jest.fn(() => 'msg-1'),
+}))
+
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+
+const findOneWithDecryptionMock = findOneWithDecryption as jest.MockedFunction<typeof findOneWithDecryption>
+
+describe('isReservedWebhookCustomHeader', () => {
+  it('reserves webhook-* and content-type case-insensitively', () => {
+    expect(isReservedWebhookCustomHeader('webhook-signature')).toBe(true)
+    expect(isReservedWebhookCustomHeader('Webhook-Id')).toBe(true)
+    expect(isReservedWebhookCustomHeader('WEBHOOK-TIMESTAMP')).toBe(true)
+    expect(isReservedWebhookCustomHeader(' webhook-signature ')).toBe(true)
+    expect(isReservedWebhookCustomHeader('Content-Type')).toBe(true)
+    expect(isReservedWebhookCustomHeader('x-custom-header')).toBe(false)
+    expect(isReservedWebhookCustomHeader('authorization')).toBe(false)
+  })
+})
+
+describe('sanitizeWebhookCustomHeaders', () => {
+  it('strips reserved headers and keeps the rest', () => {
+    expect(sanitizeWebhookCustomHeaders({
+      'Webhook-Signature': 'forged',
+      'webhook-id': 'constant',
+      'Content-Type': 'text/plain',
+      'x-api-key': 'value',
+    })).toEqual({ 'x-api-key': 'value' })
+  })
+
+  it('returns an empty object for null or undefined', () => {
+    expect(sanitizeWebhookCustomHeaders(null)).toEqual({})
+    expect(sanitizeWebhookCustomHeaders(undefined)).toEqual({})
+  })
+})
+
+describe('processWebhookDeliveryJob — custom headers cannot override signed headers', () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS = '1'
+    globalThis.fetch = jest.fn(async () => new Response('ok', { status: 200 })) as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    delete process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS
+  })
+
+  function buildDelivery() {
+    return {
+      id: 'delivery-1',
+      tenantId: 't',
+      organizationId: 'o',
+      webhookId: 'w-1',
+      status: 'pending',
+      payload: { type: 'x', timestamp: new Date().toISOString(), data: {} },
+      enqueuedAt: new Date(),
+      eventType: 'x',
+      maxAttempts: 3,
+      attemptNumber: 0,
+      messageId: 'msg-1',
+      responseBody: null,
+      responseHeaders: null,
+      responseStatus: null,
+      nextRetryAt: null,
+      errorMessage: null,
+      lastAttemptAt: null,
+      deliveredAt: null,
+      durationMs: null,
+    }
+  }
+
+  function buildWebhook(customHeaders: Record<string, string> | null) {
+    return {
+      id: 'w-1',
+      url: 'http://127.0.0.1:3001/hook',
+      isActive: true,
+      timeoutMs: 1000,
+      httpMethod: 'POST',
+      customHeaders,
+      consecutiveFailures: 0,
+      lastFailureAt: null,
+      lastSuccessAt: null,
+      autoDisableThreshold: 0,
+      maxRetries: 3,
+      secret: 'secret',
+      previousSecret: null,
+      tenantId: 't',
+      organizationId: 'o',
+    }
+  }
+
+  function buildEm(delivery: Record<string, unknown>) {
+    return {
+      findOne: jest.fn(async () => delivery),
+      flush: jest.fn(async () => undefined),
+    } as unknown as EntityManager
+  }
+
+  it('sends signed headers even when customHeaders tries to override them', async () => {
+    const delivery = buildDelivery()
+    const webhook = buildWebhook({
+      'webhook-signature': 'forged-signature',
+      'Webhook-Id': 'pinned-id',
+      'WEBHOOK-TIMESTAMP': '0',
+      'content-type': 'text/plain',
+      'x-api-key': 'tenant-value',
+    })
+    findOneWithDecryptionMock.mockResolvedValueOnce(webhook as never)
+
+    const em = buildEm(delivery)
+    const result = await processWebhookDeliveryJob(em, {
+      deliveryId: 'delivery-1',
+      tenantId: 't',
+      organizationId: 'o',
+    }, { scheduleRetries: false })
+
+    expect(result?.status).toBe('delivered')
+    expect((globalThis.fetch as jest.Mock).mock.calls).toHaveLength(1)
+    const sentHeaders = new Headers((globalThis.fetch as jest.Mock).mock.calls[0][1].headers)
+    expect(sentHeaders.get('webhook-signature')).toBe('v1,legitimate-signature')
+    expect(sentHeaders.get('webhook-id')).toBe('msg-1')
+    expect(sentHeaders.get('webhook-timestamp')).toBe('1700000000')
+    expect(sentHeaders.get('content-type')).toBe('application/json')
+    expect(sentHeaders.get('x-api-key')).toBe('tenant-value')
+  })
+
+  it('still applies non-reserved custom headers', async () => {
+    const delivery = buildDelivery()
+    const webhook = buildWebhook({ authorization: 'Bearer receiver-token' })
+    findOneWithDecryptionMock.mockResolvedValueOnce(webhook as never)
+
+    const em = buildEm(delivery)
+    const result = await processWebhookDeliveryJob(em, {
+      deliveryId: 'delivery-1',
+      tenantId: 't',
+      organizationId: 'o',
+    }, { scheduleRetries: false })
+
+    expect(result?.status).toBe('delivered')
+    const sentHeaders = new Headers((globalThis.fetch as jest.Mock).mock.calls[0][1].headers)
+    expect(sentHeaders.get('authorization')).toBe('Bearer receiver-token')
+    expect(sentHeaders.get('webhook-signature')).toBe('v1,legitimate-signature')
+  })
+})

--- a/packages/webhooks/src/modules/webhooks/lib/custom-headers.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/custom-headers.ts
@@ -1,0 +1,16 @@
+const RESERVED_HEADER_PREFIX = 'webhook-'
+const RESERVED_HEADER_NAMES = new Set(['content-type'])
+
+export function isReservedWebhookCustomHeader(name: string): boolean {
+  const normalized = name.trim().toLowerCase()
+  return normalized.startsWith(RESERVED_HEADER_PREFIX) || RESERVED_HEADER_NAMES.has(normalized)
+}
+
+export function sanitizeWebhookCustomHeaders(
+  customHeaders: Record<string, string> | null | undefined,
+): Record<string, string> {
+  if (!customHeaders) return {}
+  return Object.fromEntries(
+    Object.entries(customHeaders).filter(([name]) => !isReservedWebhookCustomHeader(name)),
+  )
+}

--- a/packages/webhooks/src/modules/webhooks/lib/delivery.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/delivery.ts
@@ -5,6 +5,7 @@ import { WebhookDeliveryEntity, WebhookEntity } from '../data/entities'
 import { emitWebhooksEvent } from '../events'
 import { enqueueWebhookDelivery } from './queue'
 import { isWebhookIntegrationEnabled, WEBHOOK_INTEGRATION_DISABLED_MESSAGE } from './integration-state'
+import { sanitizeWebhookCustomHeaders } from './custom-headers'
 import {
   assertSafeWebhookDeliveryUrl,
   safeWebhookFetch,
@@ -165,8 +166,8 @@ export async function processWebhookDeliveryJob(
         redirect: 'manual',
         headers: {
           'content-type': 'application/json',
+          ...sanitizeWebhookCustomHeaders(webhook.customHeaders),
           ...headers,
-          ...(webhook.customHeaders ?? {}),
         },
         body,
         signal: controller.signal,


### PR DESCRIPTION
Fixes #2922

## Problem
- The outbound webhook delivery worker built the HTTP request as `{ 'content-type': ..., ...signedHeaders, ...webhook.customHeaders }`. Object spread is last-write-wins, so a custom header named `webhook-signature`, `webhook-id`, `webhook-timestamp`, or `content-type` silently replaced the cryptographically signed value. Any user with `webhooks.manage` could subvert the signing guarantee (forge/break signatures, pin `webhook-id` for covert dedup-based event suppression, defeat replay-window checks) without ever holding the endpoint secret.

## Root Cause
- `processWebhookDeliveryJob` spread `webhook.customHeaders` **after** the signed Standard Webhooks headers, and `customHeaders` validation (`z.record(z.string(), z.string())`) accepted arbitrary key names with no reserved-name filtering.

## What Changed
- New `lib/custom-headers.ts`: `isReservedWebhookCustomHeader` (any `webhook-*` prefix plus `content-type`, case-insensitive, trimmed) and `sanitizeWebhookCustomHeaders` (strips reserved keys).
- `lib/delivery.ts`: custom headers are now sanitized and spread **before** the signed headers, so signed values always win — this also neutralizes reserved headers already persisted by existing webhooks.
- `data/validators.ts`: `webhookCreateSchema`/`webhookUpdateSchema` reject reserved header names with a per-key validation issue (HTTP 400), covering both the `makeCrudRoute` surface and the `PUT /api/webhooks/[id]` handler, which share these schemas.

## Tests
- `lib/__tests__/delivery-custom-headers.test.ts` (new): unit coverage for the reserved-name predicate and sanitizer, plus two `processWebhookDeliveryJob` tests asserting the outbound request carries the signed `webhook-id`/`webhook-timestamp`/`webhook-signature` and `content-type: application/json` even when `customHeaders` tries to override them (mixed-case included), while non-reserved headers still apply.
- `data/__tests__/validators.test.ts`: create/update schemas reject `webhook-signature`, `Webhook-Id`, `WEBHOOK-TIMESTAMP`, `Content-Type` and accept `x-api-key`/`authorization`.
- Verified the regression tests fail on unfixed code (4 failures) and pass with the fix (105/105 in `@open-mercato/webhooks`).
- Full gate run: `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app` — all green except one pre-existing locale-dependent failure (`ui/src/utils/__tests__/format.test.ts › formatCurrency`) that fails on clean develop under `pl_PL` locale and passes under `en_US`; unrelated to this change.

## Security impact
- Restores the Standard Webhooks signing integrity contract for outbound deliveries: `webhook-id`, `webhook-timestamp`, `webhook-signature`, and `content-type` can no longer be spoofed via tenant-configurable custom headers, at both the validation layer (reject) and the delivery layer (defense in depth for already-persisted data). No changes to authentication, authorization scopes, or secret handling.

## Backward Compatibility
- No contract surface removals. Input validation is deliberately tightened: payloads that set reserved header names — previously accepted but actively harmful — now return 400 with a field-level message. Existing webhooks with persisted reserved headers keep working; the reserved keys are simply ignored at send time and partial updates that don't touch `customHeaders` still validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)