### PR TITLE
ci(test): stabilize flaky markitdown install in the test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,11 +360,22 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/pip
-          key: pip-markitdown-v1
+          key: pip-markitdown-v2
           restore-keys: pip-markitdown-
 
+      - name: Upgrade pip
+        # Upgrade pip in its own invocation: the system pip (24.0) resolver
+        # backtracks through markitdown versions and dead-ends on markdownify
+        # (ResolutionImpossible). A combined `pip install --upgrade pip markitdown`
+        # does NOT help because the newer resolver only takes effect on the next
+        # invocation. Splitting the upgrade out lets the install below run on the
+        # modern resolver.
+        run: python3 -m pip install --upgrade pip
+
       - name: Install markitdown CLI
-        run: python3 -m pip install --upgrade pip markitdown
+        # Pin the version so resolution is deterministic and a future
+        # markitdown/markdownify release cannot break CI without an explicit bump.
+        run: python3 -m pip install 'markitdown==0.1.6'
 
       - name: Install dependencies
         if: steps.nm-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Problem

The `test` job in **CI for Develop&Main** intermittently fails while installing the markitdown CLI:

```
ERROR: Cannot install markitdown==0.0.1 … 0.1.6 because these package versions have conflicting dependencies.
    markitdown 0.1.6 depends on markdownify
ERROR: ResolutionImpossible
```

Observed on develop @ `384a97c7a`: two concurrent CI runs for the *same* SHA — one `test` job passed, the other failed. That non-determinism is the tell.

## Root cause

The step runs everything in one invocation:

```yaml
run: python3 -m pip install --upgrade pip markitdown
```

The resolution is performed by the **system pip (24.0)**, whose resolver backtracks through every markitdown version and dead-ends on `markdownify`. Upgrading pip *in the same command* doesn't help — the newer resolver only takes effect on the **next** invocation. The run that "passed" did so purely on pip-cache luck.

Verified locally: with an upgraded pip (26.x), `markitdown` resolves cleanly to `0.1.6` + `markdownify 1.2.2`.

## Fix

- **Upgrade pip in its own step** so the install below runs on the modern resolver.
- **Pin `markitdown==0.1.6`** so resolution is deterministic and a future markitdown/markdownify release can't silently break CI without an explicit bump.
- **Bump the pip cache key** (`v1` → `v2`) to discard the poisoned partial cache.

CI-only change; no app/runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)