### PR TITLE
fix(auth): stop login 500 when a UserRole has a null populated role

### DIFF
--- a/.ai/runs/2026-06-11-auth-getuserroles-null-role.md
+++ b/.ai/runs/2026-06-11-auth-getuserroles-null-role.md
@@ -78,5 +78,5 @@ reaches that code.
 
 ### Phase 1: Fix + tests
 
-- [ ] 1.1 Harden `AuthService.getUserRoles` to filter null roles / non-string names
-- [ ] 1.2 Add unit test reproducing the null-role NPE and asserting it is filtered
+- [x] 1.1 Harden `AuthService.getUserRoles` to filter null roles / non-string names — ce62ade5b
+- [x] 1.2 Add unit test reproducing the null-role NPE and asserting it is filtered — ce62ade5b

--- a/.ai/runs/2026-06-11-auth-getuserroles-null-role.md
+++ b/.ai/runs/2026-06-11-auth-getuserroles-null-role.md
@@ -1,0 +1,82 @@
+# Fix: login 500 — `getUserRoles` NPE on orphaned/soft-deleted role links
+
+## Goal
+
+Stop `POST /api/auth/login` from returning HTTP 500 after a successful password
+verification when the authenticating user has a `UserRole` whose populated `role`
+is `null` (orphaned link to a soft-deleted/re-seeded role). Make staff role
+resolution resilient, mirroring the existing defensive pattern already used in
+session-integrity validation.
+
+## Reproduction (live demo, v0.6.5)
+
+`POST https://demo.openmercato.com/api/auth/login` for a freshly onboarded tenant:
+
+- wrong password → `401`
+- nonexistent email → `401`
+- **correct credentials → `500` (empty body)** — an uncaught throw re-raised to
+  Next.js (API 500 stacks are redacted by #2950), reproducible for both
+  `application/x-www-form-urlencoded` and `multipart/form-data` and with
+  `remember` on/off.
+
+The `401` on a wrong password proves the user is found and the password is
+checked, so the throw is in the **post-verification** chain
+(`packages/core/src/modules/auth/api/login.ts:136-219`):
+`updateLastLoginAt → getUserRoles → createSession → signJwt → after-interceptors`.
+
+## Root cause
+
+`AuthService.getUserRoles` (`packages/core/src/modules/auth/services/authService.ts:63`)
+ends with:
+
+```ts
+return links.map((l) => l.role.name)
+```
+
+The query populates `role` and filters `role: { tenantId, deletedAt: null }`, but a
+populated `role` can still come back `null` when a `UserRole` references a role row
+that is soft-deleted (the Role soft-delete filter suppresses hydration). This is a
+known shape in this codebase: the parallel staff-session validator
+`resolveCanonicalStaffAuthContext`
+(`packages/core/src/modules/auth/lib/sessionIntegrity.ts:131-133`) already guards it:
+
+```ts
+const linkedRoles = links.map((link) => link.role).filter((role): role is Role => !!role)
+```
+
+`getUserRoles` has no such guard, so `l.role.name` throws `TypeError: Cannot read
+properties of null (reading 'name')` → uncaught → HTTP 500.
+
+A freshly created tenant is the trigger: recent onboarding work
+(`recover interrupted provisioning`, re-seed unique-collision handling) can leave an
+admin `UserRole` pointing at a role that a later re-seed soft-deleted, producing the
+orphaned link.
+
+`getUserRoles` is on the hot path for login (×2), `refreshFromSessionToken`, the
+profile route, and SSO — so the NPE also breaks session refresh, not just login.
+
+Note: PR #2883 (the user's initial suspect) is a red herring — it only gates
+**authenticated** requests; `/api/auth/login` is `requireAuth: false` and never
+reaches that code.
+
+## Scope
+
+- In scope: harden `getUserRoles` to drop links whose `role` is null and whose name
+  is not a non-empty string (mirrors `sessionIntegrity`). Add unit coverage.
+- Non-goals: changing the query/join semantics; the `updateLastLoginAt`
+  managed-entity re-encrypt side-effect (separate, defensive path — noted for
+  follow-up); cleaning up the orphaned data rows; touching `#2883`.
+
+## Risks
+
+- Filtering null roles can only ever remove a crash; a valid grant always has a
+  non-null populated `role`, so no real role is dropped. Low risk.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Fix + tests
+
+- [ ] 1.1 Harden `AuthService.getUserRoles` to filter null roles / non-string names
+- [ ] 1.2 Add unit test reproducing the null-role NPE and asserting it is filtered

--- a/packages/core/src/modules/auth/services/__tests__/authService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/authService.test.ts
@@ -3,10 +3,11 @@ import { Session } from '@open-mercato/core/modules/auth/data/entities'
 import { hashAuthToken } from '@open-mercato/core/modules/auth/lib/tokenHash'
 
 const mockFindOneWithDecryption = jest.fn()
+const mockFindWithDecryption = jest.fn().mockResolvedValue([])
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...args),
-  findWithDecryption: jest.fn().mockResolvedValue([]),
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
 }))
 
 function makeEm() {
@@ -49,6 +50,34 @@ describe('AuthService', () => {
     const row = persisted[0]
     expect(row.token).toBe(hashAuthToken(result.token))
     expect(row.token).not.toBe(result.token)
+  })
+
+  // -------------------------------------------------------------------------
+  // Regression: login 500 — getUserRoles must not throw on an orphaned UserRole
+  // whose populated role is null (link to a soft-deleted / re-seeded role).
+  // -------------------------------------------------------------------------
+
+  it('getUserRoles skips links whose populated role is null instead of throwing', async () => {
+    const { em } = makeEm()
+    mockFindWithDecryption.mockResolvedValueOnce([
+      { role: null },
+      { role: { name: 'admin' } },
+      { role: { name: '   ' } },
+      { role: { name: 'employee' } },
+    ])
+    const svc = new AuthService(em)
+    // @ts-expect-error partial user fixture is sufficient for this path
+    const roles = await svc.getUserRoles({ id: 'u1', tenantId: 't1', organizationId: 'o1' }, 't1')
+    expect(roles).toEqual(['admin', 'employee'])
+  })
+
+  it('getUserRoles returns an empty list (no throw) when the user has no role links', async () => {
+    const { em } = makeEm()
+    mockFindWithDecryption.mockResolvedValueOnce([])
+    const svc = new AuthService(em)
+    // @ts-expect-error partial user fixture is sufficient for this path
+    const roles = await svc.getUserRoles({ id: 'u1', tenantId: 't1', organizationId: 'o1' }, 't1')
+    expect(roles).toEqual([])
   })
 
   it('deleteSessionByToken deletes only by the hashed token', async () => {

--- a/packages/core/src/modules/auth/services/authService.ts
+++ b/packages/core/src/modules/auth/services/authService.ts
@@ -70,7 +70,16 @@ export class AuthService {
       { populate: ['role'] },
       { tenantId: resolvedTenantId, organizationId: user.organizationId ?? null },
     )
-    return links.map((l) => l.role.name)
+    // A populated `role` can still be null when the link points at a soft-deleted
+    // role (the Role soft-delete filter suppresses hydration), e.g. an admin link
+    // orphaned by a re-seed during interrupted-provisioning recovery. Dropping such
+    // links keeps role resolution from throwing on the login / session-refresh hot
+    // path, mirroring resolveCanonicalStaffAuthContext in lib/sessionIntegrity.ts.
+    return links
+      .map((l) => l.role)
+      .filter((role): role is Role => !!role)
+      .map((role) => role.name)
+      .filter((name): name is string => typeof name === 'string' && name.trim().length > 0)
   }
 
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-11-auth-getuserroles-null-role.md
Status: complete

## Goal
- Stop `POST /api/auth/login` returning **HTTP 500** (and breaking session refresh) for a freshly-onboarded tenant whose admin `UserRole` points at a null/soft-deleted role.

## Problem (reproduced on demo.openmercato.com, v0.6.5)
For a newly created tenant, login behaved like this:
- wrong password → `401`
- nonexistent email → `401`
- **correct credentials → `500`, empty body** (uncaught throw re-raised to Next; API 500 stacks are redacted by #2950)

The `401` on a wrong password proves the user is found and the password verifies, so the throw is in the **post-verification** chain (`auth/login.ts` → `getUserRoles → createSession → signJwt → after-interceptors`). The browser posts the same endpoint (`login.tsx:259`), so the user could not actually log in — it surfaces as “logged in, then session expired”.

## Root cause
`AuthService.getUserRoles` (`packages/core/src/modules/auth/services/authService.ts:63`) ended with:
```ts
return links.map((l) => l.role.name)
```
The query populates `role` and filters `role: { tenantId, deletedAt: null }`, but a populated `role` can still be **null** when the link references a soft-deleted role (the Role soft-delete filter suppresses hydration). This shape is already known in the codebase — the sibling staff-session validator `resolveCanonicalStaffAuthContext` (`lib/sessionIntegrity.ts:131-133`) explicitly guards it with `.filter((role): role is Role => !!role)`. `getUserRoles` had no guard, so `l.role.name` threw `TypeError: Cannot read properties of null (reading 'name')` → uncaught → 500.

A newly-created tenant is the trigger: recent onboarding work (recover-interrupted-provisioning + re-seed unique-collision handling) can leave an admin `UserRole` pointing at a role a later re-seed soft-deleted.

`getUserRoles` is on the hot path for login (×2), `refreshFromSessionToken`, the profile route, and SSO — so the NPE broke session refresh too.

> Note: PR #2883 (the initial suspect) is a **red herring** — it only gates *authenticated* requests; `/api/auth/login` is `requireAuth: false` and never reaches that code.

## What changed
- `getUserRoles` now drops links whose populated `role` is null and filters blank names, mirroring `resolveCanonicalStaffAuthContext`. No signature/contract change.

## Tests
- New unit tests in `authService.test.ts`: a user with a null-role link resolves to `['admin','employee']` (no throw); no links → `[]`.
- **Red→green proof**: against the pre-fix line the new test fails with the exact `TypeError: Cannot read properties of null (reading 'name')` at `authService.ts:73`; with the fix all 18 suite tests pass.
- Full auth module suite: **53 suites / 406 tests pass**.
- `@open-mercato/core` esbuild build passes. (`yarn typecheck` is blocked by an unrelated worktree env issue — `tsconfig --ignoreDeprecations` invalid under the locally-resolved typescript@6.0.3 — not introduced by this change.)

## Backward Compatibility
- No contract surface changes. Filtering null roles can only prevent a crash; a valid grant always has a non-null populated role, so no real role is dropped.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-11-auth-getuserroles-null-role.md#progress).
