### PR TITLE
fix(ui): stop InjectionSpot remounting widgets on context-identity changes (#2986)

### DIFF
--- a/packages/ui/src/backend/injection/InjectionSpot.tsx
+++ b/packages/ui/src/backend/injection/InjectionSpot.tsx
@@ -76,6 +76,15 @@ export function useInjectionWidgets<TContext = unknown>(
   const [error, setError] = React.useState<string | null>(null)
   const [registryVersion, setRegistryVersion] = React.useState(() => getInjectionRegistryVersion())
   const loadedRef = React.useRef(false)
+  const contextRef = React.useRef(options?.context)
+  const triggerOnLoadRef = React.useRef(options?.triggerOnLoad)
+  const onEventRef = React.useRef(options?.onEvent)
+
+  React.useEffect(() => {
+    contextRef.current = options?.context
+    triggerOnLoadRef.current = options?.triggerOnLoad
+    onEventRef.current = options?.onEvent
+  })
 
   React.useEffect(() => {
     return subscribeToInjectionRegistryChanges(() => {
@@ -105,16 +114,16 @@ export function useInjectionWidgets<TContext = unknown>(
           placement: w.placement,
         }))
         setWidgets(widgetList)
-        
+
         // Trigger onLoad for all widgets
-        if (!loadedRef.current && options?.triggerOnLoad) {
+        if (!loadedRef.current && triggerOnLoadRef.current) {
           loadedRef.current = true
           for (const widget of widgetList) {
             if (widget.module.eventHandlers?.onLoad) {
               try {
-                const widgetContext = injectSharedStateIntoContext(options.context as TContext, widget.moduleId)
+                const widgetContext = injectSharedStateIntoContext(contextRef.current as TContext, widget.moduleId)
                 await widget.module.eventHandlers.onLoad(widgetContext)
-                options.onEvent?.('onLoad', widget.widgetId)
+                onEventRef.current?.('onLoad', widget.widgetId)
               } catch (err) {
                 console.error(`[InjectionSpot] Error in onLoad for widget ${widget.widgetId}:`, err)
               }
@@ -133,7 +142,9 @@ export function useInjectionWidgets<TContext = unknown>(
     return () => {
       mounted = false
     }
-  }, [spotId, options?.context, options?.triggerOnLoad, options?.onEvent, registryVersion])
+    // context/triggerOnLoad/onEvent are read from refs so only a real registry-version bump reloads the spot
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [spotId, registryVersion])
 
   return { widgets, loading, error }
 }
@@ -148,16 +159,25 @@ export function InjectionSpot<TContext = unknown, TData = unknown>({
   widgetsOverride,
 }: InjectionSpotProps<TContext, TData>) {
   const useSpotId = widgetsOverride ? null : spotId
+  const onEventRef = React.useRef(onEvent)
+  React.useEffect(() => {
+    onEventRef.current = onEvent
+  })
+  const hasOnEvent = Boolean(onEvent)
+  const stableOnEvent = React.useMemo(
+    () => (hasOnEvent ? (event: 'onLoad', id: string) => onEventRef.current?.(event, id) : undefined),
+    [hasOnEvent],
+  )
   const { widgets, loading, error } = useInjectionWidgets<TContext>(useSpotId, {
     context,
     triggerOnLoad: !widgetsOverride,
-    onEvent: onEvent ? (event, id) => onEvent(event, id) : undefined,
+    onEvent: stableOnEvent,
   })
   const effectiveWidgets = widgetsOverride ?? widgets
   const effectiveLoading = widgetsOverride ? false : loading
   const effectiveError = widgetsOverride ? null : error
 
-  if (effectiveLoading) {
+  if (effectiveLoading && effectiveWidgets.length === 0) {
     return null
   }
 

--- a/packages/ui/src/backend/injection/__tests__/InjectionSpot.remount.test.tsx
+++ b/packages/ui/src/backend/injection/__tests__/InjectionSpot.remount.test.tsx
@@ -1,0 +1,140 @@
+/** @jest-environment jsdom */
+
+import * as React from 'react'
+import { act, render, waitFor } from '@testing-library/react'
+
+const mockState: { registryVersion: number; listener: null | (() => void) } = {
+  registryVersion: 0,
+  listener: null,
+}
+const mockLoadSpy = jest.fn()
+
+jest.mock('@open-mercato/shared/modules/widgets/injection-loader', () => ({
+  getInjectionRegistryVersion: () => mockState.registryVersion,
+  subscribeToInjectionRegistryChanges: (listener: () => void) => {
+    mockState.listener = listener
+    return () => {
+      mockState.listener = null
+    }
+  },
+  loadInjectionWidgetsForSpot: (...args: unknown[]) => mockLoadSpy(...args),
+}))
+
+jest.mock('../WidgetSharedState', () => ({
+  getWidgetSharedState: () => ({}),
+}))
+
+import { InjectionSpot } from '../InjectionSpot'
+
+const SPOT_ID = 'data-table:test.products:toolbar'
+const widgetMountSpy = jest.fn()
+const onLoadSpy = jest.fn()
+
+function makeWidget(id: string) {
+  return {
+    metadata: { id },
+    moduleId: 'test_module',
+    key: id,
+    placement: undefined,
+    eventHandlers: { onLoad: onLoadSpy },
+    Widget: ({ context }: { context: unknown }) => {
+      React.useEffect(() => {
+        widgetMountSpy()
+      }, [])
+      const label = (context as { label?: string } | null)?.label ?? ''
+      return <div data-testid="injected-widget">{label}</div>
+    },
+  }
+}
+
+function Harness({ tick, onEvent }: { tick: number; onEvent?: (event: 'onLoad', id: string) => void }) {
+  // Fresh context identity on every render — mirrors hosts that feed a useMemo/closure
+  // context whose identity changes on routine interactions (e.g. row-selection toggles).
+  const context = { label: 'ctx', tick }
+  return <InjectionSpot spotId={SPOT_ID} context={context} onEvent={onEvent} />
+}
+
+describe('InjectionSpot — context identity changes do not remount injected widgets', () => {
+  beforeEach(() => {
+    mockState.registryVersion = 0
+    mockState.listener = null
+    mockLoadSpy.mockReset()
+    mockLoadSpy.mockResolvedValue([makeWidget('test_module:hello')])
+    widgetMountSpy.mockClear()
+    onLoadSpy.mockClear()
+  })
+
+  it('renders the injected widget and loads the spot exactly once', async () => {
+    const { findByTestId } = render(<Harness tick={0} />)
+    await findByTestId('injected-widget')
+    expect(mockLoadSpy).toHaveBeenCalledTimes(1)
+    expect(widgetMountSpy).toHaveBeenCalledTimes(1)
+    expect(onLoadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT reload or remount when only the context identity changes', async () => {
+    const { rerender, findByTestId } = render(<Harness tick={0} />)
+    await findByTestId('injected-widget')
+    expect(mockLoadSpy).toHaveBeenCalledTimes(1)
+    expect(widgetMountSpy).toHaveBeenCalledTimes(1)
+
+    for (let next = 1; next <= 3; next += 1) {
+      rerender(<Harness tick={next} />)
+      // flush effects for this render
+      await act(async () => {})
+    }
+
+    expect(mockLoadSpy).toHaveBeenCalledTimes(1)
+    expect(widgetMountSpy).toHaveBeenCalledTimes(1)
+    expect(onLoadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT reload when a fresh onEvent closure is passed on every render', async () => {
+    const { rerender, findByTestId } = render(<Harness tick={0} onEvent={() => {}} />)
+    await findByTestId('injected-widget')
+    expect(mockLoadSpy).toHaveBeenCalledTimes(1)
+
+    rerender(<Harness tick={1} onEvent={() => {}} />)
+    await act(async () => {})
+
+    expect(mockLoadSpy).toHaveBeenCalledTimes(1)
+    expect(widgetMountSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('DOES reload when the injection registry version actually bumps', async () => {
+    const { findByTestId } = render(<Harness tick={0} />)
+    await findByTestId('injected-widget')
+    expect(mockLoadSpy).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      mockState.registryVersion += 1
+      mockState.listener?.()
+    })
+
+    await waitFor(() => expect(mockLoadSpy).toHaveBeenCalledTimes(2))
+  })
+
+  it('keeps the previously-rendered widget mounted during a registry reload', async () => {
+    const { findByTestId } = render(<Harness tick={0} />)
+    await findByTestId('injected-widget')
+
+    let resolveReload: (value: ReturnType<typeof makeWidget>[]) => void = () => {}
+    mockLoadSpy.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveReload = resolve }),
+    )
+
+    await act(async () => {
+      mockState.registryVersion += 1
+      mockState.listener?.()
+    })
+
+    // Reload is in-flight (loading === true) but the existing widget stays mounted.
+    expect(await findByTestId('injected-widget')).toBeTruthy()
+
+    await act(async () => {
+      resolveReload([makeWidget('test_module:hello')])
+    })
+
+    await findByTestId('injected-widget')
+  })
+})


### PR DESCRIPTION
Fixes #2986

## Problem
On any backend table with injected bulk actions, ticking a single row checkbox unmounted and remounted every widget in all four `DataTable` chrome spots and refired their async loads; on `CrudForm`, every submit remounted header-spot widgets. This discarded in-widget state (e.g. closed an open Merchandising Assistant sheet) and triggered redundant fetch-on-mount calls on the hottest backend surfaces.

## Root Cause
`useInjectionWidgets` keyed its widget-loading effect on `options?.context` and `options?.onEvent` (`InjectionSpot.tsx:136`). Hosts feed the spot a `useMemo`/closure context whose identity changes on routine interactions (DataTable `resolvedInjectionContext` depends on `rowSelection`; CrudForm `injectionContext` depends on `isLoading`/`pending`/`operation`). Each identity change reran the effect, set `loading=true`, and `InjectionSpot` returned `null` while loading — unmounting and remounting all injected widgets even though fresh context already reaches mounted widgets through per-render props. `InjectionSpot` also recreated its `onEvent` closure every render, so any spot given `onEvent` reloaded on every parent render.

## What Changed
- `useInjectionWidgets`: carry `context`, `triggerOnLoad`, and `onEvent` in refs; key the load effect on `[spotId, registryVersion]` only. A real registry-version bump remains the sole reload trigger; fresh context still reaches mounted widgets via the existing per-render props, and `onLoad` keeps its one-shot `loadedRef` guard.
- `InjectionSpot`: stabilize the `onEvent` closure (ref + `useMemo` keyed on presence) so unstable parent handlers no longer churn the spot.
- Keep previously-rendered widgets mounted during a genuine registry-version reload (`effectiveLoading && effectiveWidgets.length === 0` guard) instead of returning `null`, preserving widget state across legitimate reloads too.

## Tests
- New `InjectionSpot.remount.test.tsx` (5 cases): asserts a single load + mount on first render; **no** reload/remount when context identity changes; **no** reload when a fresh `onEvent` closure is passed each render; reload **does** happen on a registry-version bump; the existing widget stays mounted during an in-flight reload.
- Verified the 3 fix-specific cases fail on the unpatched code and pass after the fix; behavior-preserving cases pass both ways.
- `@open-mercato/ui` typecheck passes; full UI suite green except pre-existing, unrelated failures (locale `format.test.ts`, AiChat suites) that also fail on a clean `develop` checkout.

## Backward Compatibility
- No contract-surface changes. Exported `useInjectionWidgets` / `InjectionSpot` signatures, `InjectionWidgetModule` props, and all spot IDs are unchanged (internal-only refactor). The only behavior change is the intended one: context changes no longer force a widget reload, exactly as the repro cases (DataTable bulk-action spots, CrudForm header spot) want.