### PR TITLE
fix(onboarding): queue workspace preparation

### DIFF
--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -69,9 +69,11 @@
     }
   },
   "peerDependencies": {
+    "@open-mercato/queue": "workspace:*",
     "@open-mercato/shared": "workspace:*"
   },
   "devDependencies": {
+    "@open-mercato/queue": "workspace:*",
     "@open-mercato/shared": "workspace:*",
     "@types/jest": "^30.0.0",
     "jest": "^30.4.2",

--- a/packages/onboarding/src/__tests__/prepare-workspace-worker.test.ts
+++ b/packages/onboarding/src/__tests__/prepare-workspace-worker.test.ts
@@ -1,0 +1,97 @@
+const fork = jest.fn()
+const resolve = jest.fn()
+const findById = jest.fn()
+const runDeferredProvisioning = jest.fn()
+
+jest.mock('@open-mercato/onboarding/modules/onboarding/lib/service', () => ({
+  OnboardingService: jest.fn().mockImplementation(() => ({
+    findById,
+  })),
+}))
+
+jest.mock('@open-mercato/onboarding/modules/onboarding/lib/deferred-provisioning', () => ({
+  runDeferredProvisioning: (...args: unknown[]) => runDeferredProvisioning(...args),
+}))
+
+import handle, { metadata } from '../modules/onboarding/workers/prepare-workspace'
+import {
+  ONBOARDING_PREPARATION_QUEUE,
+  ONBOARDING_PREPARATION_WORKER_ID,
+  type OnboardingPreparationJobPayload,
+} from '../modules/onboarding/lib/preparation-queue'
+import type { JobContext, QueuedJob } from '@open-mercato/queue'
+
+function makeJob(
+  payload: Partial<OnboardingPreparationJobPayload> = {},
+): QueuedJob<OnboardingPreparationJobPayload> {
+  return {
+    id: 'job-1',
+    payload: {
+      requestId: 'req-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      ...payload,
+    },
+    createdAt: new Date().toISOString(),
+  }
+}
+
+function makeCtx(): JobContext & { resolve: <T = unknown>(name: string) => T } {
+  const em = { fork }
+  fork.mockReturnValue(em)
+  resolve.mockImplementation((name: string) => {
+    if (name === 'em') return em
+    throw new Error(`unexpected resolve(${name})`)
+  })
+  return {
+    jobId: 'job-1',
+    queueName: ONBOARDING_PREPARATION_QUEUE,
+    attemptNumber: 1,
+    resolve,
+  }
+}
+
+describe('onboarding prepare-workspace worker', () => {
+  beforeEach(() => {
+    fork.mockReset()
+    resolve.mockReset()
+    findById.mockReset()
+    runDeferredProvisioning.mockReset()
+  })
+
+  it('declares the onboarding preparation queue metadata', () => {
+    expect(metadata).toEqual({
+      queue: ONBOARDING_PREPARATION_QUEUE,
+      id: ONBOARDING_PREPARATION_WORKER_ID,
+      concurrency: 1,
+    })
+  })
+
+  it('runs deferred provisioning for an unfinished request', async () => {
+    findById.mockResolvedValue({ id: 'req-1', preparationCompletedAt: null })
+
+    await handle(makeJob(), makeCtx())
+
+    expect(runDeferredProvisioning).toHaveBeenCalledWith({
+      requestId: 'req-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+  })
+
+  it('skips jobs whose request already completed preparation', async () => {
+    findById.mockResolvedValue({ id: 'req-1', preparationCompletedAt: new Date() })
+
+    await handle(makeJob(), makeCtx())
+
+    expect(runDeferredProvisioning).not.toHaveBeenCalled()
+  })
+
+  it('skips jobs when the onboarding request no longer exists', async () => {
+    findById.mockResolvedValue(null)
+
+    await handle(makeJob(), makeCtx())
+
+    expect(runDeferredProvisioning).not.toHaveBeenCalled()
+  })
+})

--- a/packages/onboarding/src/__tests__/service.test.ts
+++ b/packages/onboarding/src/__tests__/service.test.ts
@@ -308,5 +308,29 @@ describe('OnboardingService', () => {
       expect(renewed).toBe(true)
       expect(dbRow.processingStartedAt).toBe(renewedAt)
     })
+
+    it('releases a preparation lease after enqueue failure', async () => {
+      const startedAt = new Date()
+      const dbRow: DbRow = {
+        id: 'req-1',
+        status: 'completed',
+        processingStartedAt: startedAt,
+        preparationCompletedAt: null,
+      }
+      const request = makeRequest({
+        id: 'req-1',
+        status: 'completed',
+        processingStartedAt: startedAt,
+        preparationCompletedAt: null,
+      })
+      const em = createRowBackedEm(dbRow)
+      const service = new OnboardingService(em)
+
+      const released = await service.releasePreparationLease(request, startedAt)
+
+      expect(released).toBe(true)
+      expect(dbRow.processingStartedAt).toBeNull()
+      expect(request.processingStartedAt).toBeNull()
+    })
   })
 })

--- a/packages/onboarding/src/__tests__/service.test.ts
+++ b/packages/onboarding/src/__tests__/service.test.ts
@@ -75,7 +75,12 @@ function createMockEm(overrides: Record<string, unknown> = {}): MockEm {
   } as unknown as MockEm
 }
 
-type DbRow = { id: string; status: string; processingStartedAt: Date | null }
+type DbRow = {
+  id: string
+  status: string
+  processingStartedAt: Date | null
+  preparationCompletedAt?: Date | null
+}
 
 // EntityManager mock backed by a single persisted row. `nativeUpdate` honours the
 // status guard in its WHERE clause (so it returns 0 when the row has already moved
@@ -89,12 +94,43 @@ function createRowBackedEm(dbRow: DbRow, trackedEntity?: OnboardingRequest): Ent
   })
   const nativeUpdate = jest.fn(
     async (_entity: unknown, where: Record<string, unknown>, data: Record<string, unknown>) => {
-      const matches = Object.entries(where).every(
-        ([key, value]) => (dbRow as unknown as Record<string, unknown>)[key] === value,
-      )
+      const matches = Object.entries(where).every(([key, value]) => {
+        if (key === '$or' && Array.isArray(value)) {
+          return value.some((candidate) =>
+            Object.entries(candidate as Record<string, unknown>).every(([candidateKey, candidateValue]) => {
+              const rowValue = (dbRow as unknown as Record<string, unknown>)[candidateKey]
+              if (
+                candidateValue
+                && typeof candidateValue === 'object'
+                && '$lt' in (candidateValue as Record<string, unknown>)
+              ) {
+                const threshold = (candidateValue as { $lt: Date }).$lt
+                return rowValue instanceof Date && rowValue.getTime() < threshold.getTime()
+              }
+              if (
+                candidateValue
+                && typeof candidateValue === 'object'
+                && '$ne' in (candidateValue as Record<string, unknown>)
+              ) {
+                return rowValue !== (candidateValue as { $ne: unknown }).$ne
+              }
+              return rowValue === candidateValue
+            }),
+          )
+        }
+        if (
+          value
+          && typeof value === 'object'
+          && '$ne' in (value as Record<string, unknown>)
+        ) {
+          return (dbRow as unknown as Record<string, unknown>)[key] !== (value as { $ne: unknown }).$ne
+        }
+        return (dbRow as unknown as Record<string, unknown>)[key] === value
+      })
       if (!matches) return 0
       if ('status' in data) dbRow.status = data.status as string
       if ('processingStartedAt' in data) dbRow.processingStartedAt = (data.processingStartedAt as Date | null) ?? null
+      if ('preparationCompletedAt' in data) dbRow.preparationCompletedAt = (data.preparationCompletedAt as Date | null) ?? null
       return 1
     },
   )
@@ -206,6 +242,71 @@ describe('OnboardingService', () => {
       expect(reverted).toBe(true)
       expect(dbRow.status).toBe('pending')
       expect(dbRow.processingStartedAt).toBeNull()
+    })
+  })
+
+  describe('claimPreparation', () => {
+    it('lets only one status poll claim deferred preparation for a completed request', async () => {
+      const dbRow: DbRow = {
+        id: 'req-1',
+        status: 'completed',
+        processingStartedAt: null,
+        preparationCompletedAt: null,
+      }
+      const em = createRowBackedEm(dbRow)
+      const service = new OnboardingService(em)
+      const requestA = makeRequest({ id: 'req-1', status: 'completed', preparationCompletedAt: null })
+      const requestB = makeRequest({ id: 'req-1', status: 'completed', preparationCompletedAt: null })
+      const startedAt = new Date()
+      const staleBefore = new Date(startedAt.getTime() - 15 * 60 * 1000)
+
+      const claimedA = await service.claimPreparation(requestA, startedAt, staleBefore)
+      const claimedB = await service.claimPreparation(requestB, new Date(startedAt.getTime() + 1000), staleBefore)
+
+      expect(claimedA).toBe(true)
+      expect(claimedB).toBe(false)
+      expect(dbRow.processingStartedAt).toBe(startedAt)
+    })
+
+    it('reclaims stale deferred preparation work', async () => {
+      const oldStartedAt = new Date(Date.now() - 20 * 60 * 1000)
+      const newStartedAt = new Date()
+      const dbRow: DbRow = {
+        id: 'req-1',
+        status: 'completed',
+        processingStartedAt: oldStartedAt,
+        preparationCompletedAt: null,
+      }
+      const em = createRowBackedEm(dbRow)
+      const service = new OnboardingService(em)
+      const request = makeRequest({ id: 'req-1', status: 'completed', preparationCompletedAt: null })
+
+      const claimed = await service.claimPreparation(
+        request,
+        newStartedAt,
+        new Date(newStartedAt.getTime() - 15 * 60 * 1000),
+      )
+
+      expect(claimed).toBe(true)
+      expect(dbRow.processingStartedAt).toBe(newStartedAt)
+    })
+
+    it('renews an active preparation lease', async () => {
+      const oldStartedAt = new Date(Date.now() - 5 * 60 * 1000)
+      const renewedAt = new Date()
+      const dbRow: DbRow = {
+        id: 'req-1',
+        status: 'completed',
+        processingStartedAt: oldStartedAt,
+        preparationCompletedAt: null,
+      }
+      const em = createRowBackedEm(dbRow)
+      const service = new OnboardingService(em)
+
+      const renewed = await service.renewPreparationLease('req-1', renewedAt)
+
+      expect(renewed).toBe(true)
+      expect(dbRow.processingStartedAt).toBe(renewedAt)
     })
   })
 })

--- a/packages/onboarding/src/__tests__/status-endpoint-auth.test.ts
+++ b/packages/onboarding/src/__tests__/status-endpoint-auth.test.ts
@@ -5,7 +5,8 @@ const sendWorkspaceReadyEmail = jest.fn()
 const assertAllowedAppOrigin = jest.fn()
 const markCompleted = jest.fn()
 const claimPreparation = jest.fn()
-const runDeferredProvisioning = jest.fn()
+const releasePreparationLease = jest.fn()
+const enqueueOnboardingPreparation = jest.fn()
 
 jest.mock('next/server', () => {
   const actual = jest.requireActual('next/server')
@@ -41,6 +42,7 @@ jest.mock('@open-mercato/onboarding/modules/onboarding/lib/service', () => ({
     findLatestByTenantId,
     markCompleted,
     claimPreparation,
+    releasePreparationLease,
   })),
 }))
 
@@ -57,7 +59,10 @@ jest.mock('@open-mercato/onboarding/modules/onboarding/lib/deferred-provisioning
       userId: request.userId,
     }
   },
-  runDeferredProvisioning: (...args: unknown[]) => runDeferredProvisioning(...args),
+}))
+
+jest.mock('@open-mercato/onboarding/modules/onboarding/lib/preparation-queue', () => ({
+  enqueueOnboardingPreparation: (...args: unknown[]) => enqueueOnboardingPreparation(...args),
 }))
 
 import { GET } from '../modules/onboarding/api/get/onboarding/status'
@@ -92,7 +97,8 @@ describe('onboarding status endpoint authorization', () => {
     assertAllowedAppOrigin.mockReset()
     markCompleted.mockReset()
     claimPreparation.mockReset()
-    runDeferredProvisioning.mockReset()
+    releasePreparationLease.mockReset()
+    enqueueOnboardingPreparation.mockReset()
     markCompleted.mockImplementation(async (request: OnboardingRequest, data: {
       tenantId: string
       organizationId: string
@@ -109,6 +115,11 @@ describe('onboarding status endpoint authorization', () => {
       request.processingStartedAt = startedAt
       return true
     })
+    releasePreparationLease.mockImplementation(async (request: OnboardingRequest) => {
+      request.processingStartedAt = null
+      return true
+    })
+    enqueueOnboardingPreparation.mockResolvedValue('job-1')
     findLatestByTenantId.mockResolvedValue(makeRequest())
   })
 
@@ -200,7 +211,7 @@ describe('onboarding status endpoint authorization', () => {
     expect(body.ready).toBe(false)
     expect(markCompleted).not.toHaveBeenCalled()
     expect(claimPreparation).not.toHaveBeenCalled()
-    expect(runDeferredProvisioning).not.toHaveBeenCalled()
+    expect(enqueueOnboardingPreparation).not.toHaveBeenCalled()
   })
 
   it('recovers an interrupted stale processing request that already has provisioned ids', async () => {
@@ -231,7 +242,7 @@ describe('onboarding status endpoint authorization', () => {
     })
   })
 
-  it('claims deferred preparation before scheduling it from a status poll', async () => {
+  it('claims deferred preparation before enqueueing it from a status poll', async () => {
     const request = makeRequest({
       tenantId: TENANT_ID,
       organizationId: '44444444-4444-4444-8444-444444444444',
@@ -247,8 +258,8 @@ describe('onboarding status endpoint authorization', () => {
 
     expect(res.status).toBe(200)
     expect(claimPreparation).toHaveBeenCalledTimes(1)
-    expect(runDeferredProvisioning).toHaveBeenCalledTimes(1)
-    expect(runDeferredProvisioning).toHaveBeenCalledWith({
+    expect(enqueueOnboardingPreparation).toHaveBeenCalledTimes(1)
+    expect(enqueueOnboardingPreparation).toHaveBeenCalledWith({
       requestId: request.id,
       tenantId: TENANT_ID,
       organizationId: '44444444-4444-4444-8444-444444444444',
@@ -273,6 +284,26 @@ describe('onboarding status endpoint authorization', () => {
 
     expect(res.status).toBe(200)
     expect(claimPreparation).toHaveBeenCalledTimes(1)
-    expect(runDeferredProvisioning).not.toHaveBeenCalled()
+    expect(enqueueOnboardingPreparation).not.toHaveBeenCalled()
+  })
+
+  it('releases the preparation claim when queue enqueue fails', async () => {
+    enqueueOnboardingPreparation.mockRejectedValue(new Error('queue unavailable'))
+    const request = makeRequest({
+      tenantId: TENANT_ID,
+      organizationId: '44444444-4444-4444-8444-444444444444',
+      userId: '55555555-5555-4555-8555-555555555555',
+      preparationCompletedAt: null,
+      processingStartedAt: null,
+    })
+    findLatestByTenantId.mockResolvedValue(request)
+
+    await expect(
+      GET(buildRequest({ tenantId: TENANT_ID, cookie: `om_login_tenant=${TENANT_ID}` })),
+    ).rejects.toThrow('queue unavailable')
+
+    expect(claimPreparation).toHaveBeenCalledTimes(1)
+    expect(releasePreparationLease).toHaveBeenCalledTimes(1)
+    expect(releasePreparationLease.mock.calls[0][0]).toBe(request)
   })
 })

--- a/packages/onboarding/src/__tests__/status-endpoint-auth.test.ts
+++ b/packages/onboarding/src/__tests__/status-endpoint-auth.test.ts
@@ -4,6 +4,7 @@ const findLatestByTenantId = jest.fn()
 const sendWorkspaceReadyEmail = jest.fn()
 const assertAllowedAppOrigin = jest.fn()
 const markCompleted = jest.fn()
+const claimPreparation = jest.fn()
 const runDeferredProvisioning = jest.fn()
 
 jest.mock('next/server', () => {
@@ -39,6 +40,7 @@ jest.mock('@open-mercato/onboarding/modules/onboarding/lib/service', () => ({
   OnboardingService: jest.fn().mockImplementation(() => ({
     findLatestByTenantId,
     markCompleted,
+    claimPreparation,
   })),
 }))
 
@@ -89,6 +91,7 @@ describe('onboarding status endpoint authorization', () => {
     sendWorkspaceReadyEmail.mockReset()
     assertAllowedAppOrigin.mockReset()
     markCompleted.mockReset()
+    claimPreparation.mockReset()
     runDeferredProvisioning.mockReset()
     markCompleted.mockImplementation(async (request: OnboardingRequest, data: {
       tenantId: string
@@ -101,6 +104,10 @@ describe('onboarding status endpoint authorization', () => {
       request.userId = data.userId
       request.completedAt = new Date()
       request.processingStartedAt = null
+    })
+    claimPreparation.mockImplementation(async (request: OnboardingRequest, startedAt: Date) => {
+      request.processingStartedAt = startedAt
+      return true
     })
     findLatestByTenantId.mockResolvedValue(makeRequest())
   })
@@ -170,7 +177,7 @@ describe('onboarding status endpoint authorization', () => {
     expect(res.status).toBe(404)
   })
 
-  it('recovers an interrupted processing request that already has provisioned ids', async () => {
+  it('leaves a fresh processing request owned by the active verifier', async () => {
     const request = makeRequest({
       status: 'processing',
       tenantId: TENANT_ID,
@@ -189,6 +196,32 @@ describe('onboarding status endpoint authorization', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.ok).toBe(true)
+    expect(body.status).toBe('processing')
+    expect(body.ready).toBe(false)
+    expect(markCompleted).not.toHaveBeenCalled()
+    expect(claimPreparation).not.toHaveBeenCalled()
+    expect(runDeferredProvisioning).not.toHaveBeenCalled()
+  })
+
+  it('recovers an interrupted stale processing request that already has provisioned ids', async () => {
+    const request = makeRequest({
+      status: 'processing',
+      tenantId: TENANT_ID,
+      organizationId: '44444444-4444-4444-8444-444444444444',
+      userId: '55555555-5555-4555-8555-555555555555',
+      completedAt: null,
+      preparationCompletedAt: null,
+      processingStartedAt: new Date(Date.now() - 20 * 60 * 1000),
+    })
+    findLatestByTenantId.mockResolvedValue(request)
+
+    const res = await GET(
+      buildRequest({ tenantId: TENANT_ID, cookie: `om_login_tenant=${TENANT_ID}` }),
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
     expect(body.status).toBe('completed')
     expect(body.ready).toBe(false)
     expect(markCompleted).toHaveBeenCalledWith(request, {
@@ -196,5 +229,50 @@ describe('onboarding status endpoint authorization', () => {
       organizationId: '44444444-4444-4444-8444-444444444444',
       userId: '55555555-5555-4555-8555-555555555555',
     })
+  })
+
+  it('claims deferred preparation before scheduling it from a status poll', async () => {
+    const request = makeRequest({
+      tenantId: TENANT_ID,
+      organizationId: '44444444-4444-4444-8444-444444444444',
+      userId: '55555555-5555-4555-8555-555555555555',
+      preparationCompletedAt: null,
+      processingStartedAt: null,
+    })
+    findLatestByTenantId.mockResolvedValue(request)
+
+    const res = await GET(
+      buildRequest({ tenantId: TENANT_ID, cookie: `om_login_tenant=${TENANT_ID}` }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(claimPreparation).toHaveBeenCalledTimes(1)
+    expect(runDeferredProvisioning).toHaveBeenCalledTimes(1)
+    expect(runDeferredProvisioning).toHaveBeenCalledWith({
+      requestId: request.id,
+      tenantId: TENANT_ID,
+      organizationId: '44444444-4444-4444-8444-444444444444',
+    })
+  })
+
+  it('does not schedule deferred preparation when another poll already owns the claim', async () => {
+    claimPreparation.mockResolvedValue(false)
+    findLatestByTenantId.mockResolvedValue(
+      makeRequest({
+        tenantId: TENANT_ID,
+        organizationId: '44444444-4444-4444-8444-444444444444',
+        userId: '55555555-5555-4555-8555-555555555555',
+        preparationCompletedAt: null,
+        processingStartedAt: new Date(),
+      }),
+    )
+
+    const res = await GET(
+      buildRequest({ tenantId: TENANT_ID, cookie: `om_login_tenant=${TENANT_ID}` }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(claimPreparation).toHaveBeenCalledTimes(1)
+    expect(runDeferredProvisioning).not.toHaveBeenCalled()
   })
 })

--- a/packages/onboarding/src/modules/onboarding/__integration__/TC-ONB-002-multi-tenant-parallel-login.spec.ts
+++ b/packages/onboarding/src/modules/onboarding/__integration__/TC-ONB-002-multi-tenant-parallel-login.spec.ts
@@ -1,0 +1,192 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { expect, test, type APIRequestContext, type Browser, type BrowserContext, type Page } from '@playwright/test';
+import { withClient } from '@open-mercato/core/helpers/integration/dbFixtures';
+
+export const integrationMeta = {
+  dependsOnModules: ['onboarding'],
+  requiredEnvVars: ['SELF_SERVICE_ONBOARDING_ENABLED'],
+  requiredAnyEnvVars: ['CONSENT_INTEGRITY_SECRET', 'AUTH_SECRET', 'NEXTAUTH_SECRET', 'JWT_SECRET'],
+};
+
+type OnboardingTenant = {
+  email: string;
+  organizationName: string;
+  token: string;
+  requestId?: string;
+  tenantId?: string;
+};
+
+type BrowserTenantSession = {
+  context: BrowserContext;
+  page: Page;
+  refreshRequests: string[];
+};
+
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000';
+const ONBOARDING_PASSWORD = 'ParallelPass123!';
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+async function replaceVerificationToken(email: string, token: string): Promise<string> {
+  return withClient(async (client) => {
+    const result = await client.query<{ id: string }>(
+      `update onboarding_requests
+         set token_hash = $2,
+             expires_at = now() + interval '24 hours',
+             updated_at = now()
+       where email = $1
+       returning id`,
+      [email, hashToken(token)],
+    );
+    expect(result.rowCount, `onboarding request should exist for ${email}`).toBe(1);
+    return result.rows[0].id;
+  });
+}
+
+async function readPreparationState(requestId: string): Promise<{
+  preparation_completed_at: Date | null;
+  processing_started_at: Date | null;
+}> {
+  return withClient(async (client) => {
+    const result = await client.query<{
+      preparation_completed_at: Date | null;
+      processing_started_at: Date | null;
+    }>(
+      `select preparation_completed_at, processing_started_at
+         from onboarding_requests
+        where id = $1`,
+      [requestId],
+    );
+    expect(result.rowCount, `onboarding request ${requestId} should remain queryable`).toBe(1);
+    return result.rows[0];
+  });
+}
+
+async function waitForPreparationComplete(requestId: string): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  let lastState: Awaited<ReturnType<typeof readPreparationState>> | null = null;
+  while (Date.now() < deadline) {
+    lastState = await readPreparationState(requestId);
+    if (lastState.preparation_completed_at && !lastState.processing_started_at) return;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  expect(lastState?.processing_started_at, 'deferred preparation lease should be cleared after completion').toBeNull();
+  expect(lastState?.preparation_completed_at, 'workspace preparation should complete').toBeTruthy();
+}
+
+async function submitOnboarding(request: APIRequestContext, tenant: OnboardingTenant): Promise<void> {
+  const response = await request.post(`${BASE_URL}/api/onboarding/onboarding`, {
+    data: {
+      email: tenant.email,
+      firstName: 'Parallel',
+      lastName: 'Login',
+      organizationName: tenant.organizationName,
+      password: ONBOARDING_PASSWORD,
+      confirmPassword: ONBOARDING_PASSWORD,
+      termsAccepted: true,
+      marketingConsent: true,
+      locale: 'en',
+    },
+  });
+  expect(response.status(), `onboarding start should succeed for ${tenant.email}`).toBe(200);
+}
+
+async function verifyTenantInBrowser(browser: Browser, token: string): Promise<BrowserTenantSession & { tenantId: string }> {
+  const context = await browser.newContext({ baseURL: BASE_URL });
+  const page = await context.newPage();
+  const refreshRequests: string[] = [];
+  page.on('request', (browserRequest) => {
+    const url = browserRequest.url();
+    if (url.includes('/api/auth/session/refresh')) refreshRequests.push(url);
+  });
+
+  await page.goto(`/api/onboarding/onboarding/verify?token=${encodeURIComponent(token)}`);
+  await expect(page).toHaveURL(/\/onboarding\/preparing\?tenant=[0-9a-f-]+/);
+  await expect(page.getByText('We are preparing your workspace')).toBeVisible();
+  const tenantId = new URL(page.url()).searchParams.get('tenant');
+  expect(tenantId, 'verify redirect should include tenant id').toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+  );
+  return { context, page, refreshRequests, tenantId: tenantId! };
+}
+
+async function pollOnboardingStatus(request: APIRequestContext, tenantId: string) {
+  return request.get(`${BASE_URL}/api/onboarding/onboarding/status?tenantId=${encodeURIComponent(tenantId)}`, {
+    headers: {
+      Cookie: `om_login_tenant=${encodeURIComponent(tenantId)}`,
+    },
+  });
+}
+
+async function loginAndAssertBackend(session: BrowserTenantSession, tenant: OnboardingTenant): Promise<void> {
+  expect(tenant.tenantId, `tenant id should exist for ${tenant.email}`).toBeTruthy();
+  await expect(session.page).toHaveURL(new RegExp(`/login\\?tenant=${tenant.tenantId}`));
+  await expect(session.page.locator('form[data-auth-ready="1"]')).toBeVisible();
+  await session.page.getByLabel('Email').fill(tenant.email);
+  await session.page.getByLabel('Password', { exact: true }).fill(ONBOARDING_PASSWORD);
+  await session.page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(session.page, `browser login should land ${tenant.email} in the backend`).toHaveURL(/\/backend(?:\/.*)?$/);
+  await expect(session.page.getByText(/Session expired/i)).toHaveCount(0);
+
+  const profileResult = await session.page.evaluate(async () => {
+    const response = await fetch('/api/auth/profile', { credentials: 'include' });
+    const body = await response.json().catch(() => null);
+    return { status: response.status, body };
+  });
+  expect(profileResult.status, `browser page should keep ${tenant.email} authenticated`).toBe(200);
+  const profile = profileResult.body;
+  expect(profile.email).toBe(tenant.email);
+  expect(profile.roles).toContain('admin');
+
+  await session.page.goto('/backend');
+  await expect(session.page).toHaveURL(/\/backend(?:\/.*)?$/);
+  expect(session.refreshRequests, `backend should not bounce ${tenant.email} through session refresh`).toHaveLength(0);
+}
+
+test.describe('TC-ONB-002: multi-tenant onboarding parallel login', () => {
+  test('creates two self-service tenants, handles repeated status polling, and keeps both logins authenticated', async ({
+    browser,
+    request,
+  }) => {
+    const unique = randomUUID().slice(0, 8);
+    const tenants: OnboardingTenant[] = [1, 2].map((index) => ({
+      email: `qa-onboarding-parallel-${unique}-${index}@example.test`,
+      organizationName: `QA Onboarding Parallel ${unique} ${index}`,
+      token: `integration-parallel-${index}-${randomUUID().replace(/-/g, '')}`,
+    }));
+
+    await Promise.all(tenants.map((tenant) => submitOnboarding(request, tenant)));
+
+    for (const tenant of tenants) {
+      tenant.requestId = await replaceVerificationToken(tenant.email, tenant.token);
+    }
+
+    const browserSessions = await Promise.all(
+      tenants.map(async (tenant) => {
+        const session = await verifyTenantInBrowser(browser, tenant.token);
+        tenant.tenantId = session.tenantId;
+        return session;
+      }),
+    );
+
+    try {
+      const statusResponses = await Promise.all(
+        tenants.flatMap((tenant) =>
+          Array.from({ length: 6 }, () => pollOnboardingStatus(request, tenant.tenantId!)),
+        ),
+      );
+      for (const response of statusResponses) {
+        expect(response.status(), 'status polling should not exhaust the app DB pool').toBe(200);
+      }
+
+      await Promise.all(tenants.map((tenant) => waitForPreparationComplete(tenant.requestId!)));
+      await Promise.all(
+        tenants.map((tenant, index) => loginAndAssertBackend(browserSessions[index], tenant)),
+      );
+    } finally {
+      await Promise.all(browserSessions.map((session) => session.context.close()));
+    }
+  });
+});

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
@@ -5,10 +5,11 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { assertAllowedAppOrigin, mapSecurityEmailUrlError } from '@open-mercato/shared/lib/url'
 import { OnboardingService } from '@open-mercato/onboarding/modules/onboarding/lib/service'
 import { sendWorkspaceReadyEmail } from '@open-mercato/onboarding/modules/onboarding/lib/ready-email'
+import type { OnboardingRequest } from '@open-mercato/onboarding/modules/onboarding/data/entities'
 import {
   resolveProvisioningIds,
-  runDeferredProvisioning,
 } from '@open-mercato/onboarding/modules/onboarding/lib/deferred-provisioning'
+import { enqueueOnboardingPreparation } from '@open-mercato/onboarding/modules/onboarding/lib/preparation-queue'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 
 export const metadata = {
@@ -50,20 +51,33 @@ function isProcessingFresh(request: { status: string; processingStartedAt?: Date
 }
 
 async function scheduleDeferredProvisioning(args: {
+  service: OnboardingService
+  request: OnboardingRequest
   requestId: string
   tenantId: string
   organizationId: string
+  claimedAt: Date
   claim: () => Promise<boolean>
 }) {
   const claimed = await args.claim()
   if (!claimed) return
-  after(async () => {
-    await runDeferredProvisioning({
+  try {
+    await enqueueOnboardingPreparation({
       requestId: args.requestId,
       tenantId: args.tenantId,
       organizationId: args.organizationId,
     })
-  })
+  } catch (error) {
+    await args.service.releasePreparationLease(args.request, args.claimedAt).catch((releaseError) => {
+      console.error('[onboarding.status] failed to release preparation claim after enqueue failure', {
+        requestId: args.requestId,
+        tenantId: args.tenantId,
+        organizationId: args.organizationId,
+        error: releaseError,
+      })
+    })
+    throw error
+  }
 }
 
 export async function GET(req: Request) {
@@ -106,9 +120,12 @@ export async function GET(req: Request) {
     const now = new Date()
     const staleBefore = new Date(now.getTime() - PREPARATION_LEASE_MS)
     await scheduleDeferredProvisioning({
+      service,
+      request,
       requestId: request.id,
       tenantId: provisioningIds.tenantId,
       organizationId: provisioningIds.organizationId,
+      claimedAt: now,
       claim: () => service.claimPreparation(request, now, staleBefore),
     })
   }

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
@@ -19,6 +19,8 @@ export const metadata = {
 }
 
 const ONBOARDING_LOGIN_TENANT_COOKIE = 'om_login_tenant'
+const PROCESSING_LEASE_MS = 15 * 60 * 1000
+const PREPARATION_LEASE_MS = 15 * 60 * 1000
 
 const onboardingStatusQuerySchema = z.object({
   tenantId: z.string().uuid(),
@@ -40,6 +42,28 @@ function readCookie(req: Request, name: string): string | null {
     }
   }
   return null
+}
+
+function isProcessingFresh(request: { status: string; processingStartedAt?: Date | null }, now = Date.now()) {
+  const processingStartedAt = request.processingStartedAt?.getTime() ?? 0
+  return request.status === 'processing' && processingStartedAt > now - PROCESSING_LEASE_MS
+}
+
+async function scheduleDeferredProvisioning(args: {
+  requestId: string
+  tenantId: string
+  organizationId: string
+  claim: () => Promise<boolean>
+}) {
+  const claimed = await args.claim()
+  if (!claimed) return
+  after(async () => {
+    await runDeferredProvisioning({
+      requestId: args.requestId,
+      tenantId: args.tenantId,
+      organizationId: args.organizationId,
+    })
+  })
 }
 
 export async function GET(req: Request) {
@@ -75,16 +99,17 @@ export async function GET(req: Request) {
   }
 
   const provisioningIds = resolveProvisioningIds(request)
-  if (provisioningIds && request.status === 'processing') {
+  if (provisioningIds && request.status === 'processing' && !isProcessingFresh(request)) {
     await service.markCompleted(request, provisioningIds)
   }
   if (provisioningIds && request.status === 'completed' && !request.preparationCompletedAt) {
-    after(async () => {
-      await runDeferredProvisioning({
-        requestId: request.id,
-        tenantId: provisioningIds.tenantId,
-        organizationId: provisioningIds.organizationId,
-      })
+    const now = new Date()
+    const staleBefore = new Date(now.getTime() - PREPARATION_LEASE_MS)
+    await scheduleDeferredProvisioning({
+      requestId: request.id,
+      tenantId: provisioningIds.tenantId,
+      organizationId: provisioningIds.organizationId,
+      claim: () => service.claimPreparation(request, now, staleBefore),
     })
   }
 

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
@@ -14,8 +14,8 @@ import {
 import { resolveVerifyRedirectBaseUrl } from '@open-mercato/onboarding/modules/onboarding/lib/verify-base-url'
 import {
   resolveProvisioningIds,
-  runDeferredProvisioning,
 } from '@open-mercato/onboarding/modules/onboarding/lib/deferred-provisioning'
+import { enqueueOnboardingPreparation } from '@open-mercato/onboarding/modules/onboarding/lib/preparation-queue'
 import { setupInitialTenant } from '@open-mercato/core/modules/auth/lib/setup-app'
 import { UserConsent } from '@open-mercato/core/modules/auth/data/entities'
 import { computeConsentIntegrityHash } from '@open-mercato/core/modules/auth/lib/consentIntegrity'
@@ -114,13 +114,23 @@ async function scheduleDeferredProvisioning(
   const staleBefore = new Date(now.getTime() - PREPARATION_LEASE_MS)
   const claimed = await service.claimPreparation(request, now, staleBefore)
   if (!claimed) return
-  after(async () => {
-    await runDeferredProvisioning({
+  try {
+    await enqueueOnboardingPreparation({
       requestId: request.id,
       tenantId: ids.tenantId,
       organizationId: ids.organizationId,
     })
-  })
+  } catch (error) {
+    await service.releasePreparationLease(request, now).catch((releaseError) => {
+      console.error('[onboarding.verify] failed to release preparation claim after enqueue failure', {
+        requestId: request.id,
+        tenantId: ids.tenantId,
+        organizationId: ids.organizationId,
+        error: releaseError,
+      })
+    })
+    throw error
+  }
 }
 
 export async function GET(req: Request) {

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
@@ -33,6 +33,8 @@ export const metadata = {
 }
 
 const SEED_DEFAULTS_TIMEOUT_MS = 15_000
+const PROCESSING_LEASE_MS = 15 * 60 * 1000
+const PREPARATION_LEASE_MS = 15 * 60 * 1000
 
 function createTimeoutPromise(label: string, timeoutMs: number): Promise<never> {
   return new Promise((_, reject) => {
@@ -93,14 +95,32 @@ async function completeProvisionedRequest(args: {
   const ids = resolveProvisioningIds(args.request)
   if (!ids) return null
   await args.service.markCompleted(args.request, ids)
+  await scheduleDeferredProvisioning(args.service, args.request, ids)
+  return ids
+}
+
+function isProcessingFresh(request: OnboardingRequest, now = Date.now()) {
+  const processingStartedAt = request.processingStartedAt?.getTime() ?? 0
+  return request.status === 'processing' && processingStartedAt > now - PROCESSING_LEASE_MS
+}
+
+async function scheduleDeferredProvisioning(
+  service: OnboardingService,
+  request: OnboardingRequest,
+  ids: { tenantId: string; organizationId: string },
+) {
+  if (request.preparationCompletedAt) return
+  const now = new Date()
+  const staleBefore = new Date(now.getTime() - PREPARATION_LEASE_MS)
+  const claimed = await service.claimPreparation(request, now, staleBefore)
+  if (!claimed) return
   after(async () => {
     await runDeferredProvisioning({
-      requestId: args.request.id,
+      requestId: request.id,
       tenantId: ids.tenantId,
       organizationId: ids.organizationId,
     })
   })
-  return ids
 }
 
 export async function GET(req: Request) {
@@ -153,15 +173,10 @@ export async function GET(req: Request) {
     }
     return redirectToLogin(baseUrl, request.tenantId)
   }
-  const lockWindowMs = 15 * 60 * 1000
-  const processingStartedAt = request.processingStartedAt?.getTime() ?? 0
-  const processingFresh = request.status === 'processing' && processingStartedAt > Date.now() - lockWindowMs
-  if (processingFresh) {
-    const recovered = await completeProvisionedRequest({ service, request })
-    if (recovered) return redirectToPreparing(baseUrl, recovered.tenantId)
+  if (isProcessingFresh(request)) {
     return redirectToPreparing(baseUrl, request.tenantId ?? null)
   }
-  if (request.status === 'processing' && !processingFresh) {
+  if (request.status === 'processing') {
     const recovered = await completeProvisionedRequest({ service, request })
     if (recovered) return redirectToPreparing(baseUrl, recovered.tenantId)
     await service.resetProcessing(request)
@@ -183,8 +198,10 @@ export async function GET(req: Request) {
         : redirectToPreparing(baseUrl, current.tenantId)
     }
     if (current?.status === 'processing') {
-      const recovered = await completeProvisionedRequest({ service: currentService, request: current })
-      if (recovered) return redirectToPreparing(baseUrl, recovered.tenantId)
+      if (!isProcessingFresh(current)) {
+        const recovered = await completeProvisionedRequest({ service: currentService, request: current })
+        if (recovered) return redirectToPreparing(baseUrl, recovered.tenantId)
+      }
     }
     return redirectToPreparing(baseUrl, current?.tenantId ?? request.tenantId ?? null)
   }
@@ -300,12 +317,9 @@ export async function GET(req: Request) {
     })
     // TODO: Move deferred provisioning into a durable job keyed by request id so process restarts can resume
     // seedExamples/index rebuild/email dispatch instead of leaving completed requests stuck on preparing.
-    after(async () => {
-      await runDeferredProvisioning({
-        requestId: request.id,
-        tenantId: resolvedTenantId,
-        organizationId: resolvedOrganizationId,
-      })
+    await scheduleDeferredProvisioning(service, request, {
+      tenantId: resolvedTenantId,
+      organizationId: resolvedOrganizationId,
     })
     return redirectToPreparing(baseUrl, resolvedTenantId)
   } catch (error) {

--- a/packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts
@@ -78,12 +78,15 @@ async function runModuleSetupHook(args: {
   }
 }
 
+async function renewPreparationLease(service: OnboardingService, requestId: string) {
+  await service.renewPreparationLease(requestId, new Date())
+}
+
 async function markWorkspaceReady(args: {
   requestId: string
+  service: OnboardingService
 }) {
-  const container = await createRequestContainer()
-  const em = container.resolve('em') as EntityManager
-  const service = new OnboardingService(em)
+  const service = args.service
   const request = await service.findById(args.requestId)
   if (!request || request.preparationCompletedAt) return
   await service.markPreparationCompleted(request, new Date())
@@ -187,10 +190,12 @@ export async function runDeferredProvisioning(args: {
 }) {
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
+  const service = new OnboardingService(em)
   const modules = getModules()
 
   for (const mod of modules) {
     if (!mod.setup?.seedExamples) continue
+    await renewPreparationLease(service, args.requestId)
     try {
       await runModuleSetupHook({
         moduleId: mod.id,
@@ -223,6 +228,7 @@ export async function runDeferredProvisioning(args: {
 
   await markWorkspaceReady({
     requestId: args.requestId,
+    service,
   })
 
   await sendWorkspaceReadyEmail({

--- a/packages/onboarding/src/modules/onboarding/lib/preparation-queue.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/preparation-queue.ts
@@ -1,0 +1,26 @@
+import { createModuleQueue, type Queue } from '@open-mercato/queue'
+
+export const ONBOARDING_PREPARATION_QUEUE = 'onboarding-preparation'
+export const ONBOARDING_PREPARATION_WORKER_ID = 'onboarding:preparation'
+
+export type OnboardingPreparationJobPayload = {
+  requestId: string
+  tenantId: string
+  organizationId: string
+}
+
+let queue: Queue<OnboardingPreparationJobPayload> | null = null
+
+export function getOnboardingPreparationQueue(): Queue<OnboardingPreparationJobPayload> {
+  if (queue) return queue
+  queue = createModuleQueue<OnboardingPreparationJobPayload>(ONBOARDING_PREPARATION_QUEUE, {
+    concurrency: 1,
+  })
+  return queue
+}
+
+export async function enqueueOnboardingPreparation(
+  payload: OnboardingPreparationJobPayload,
+): Promise<string> {
+  return getOnboardingPreparationQueue().enqueue(payload)
+}

--- a/packages/onboarding/src/modules/onboarding/lib/service.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/service.ts
@@ -139,6 +139,39 @@ export class OnboardingService {
     await this.em.flush()
   }
 
+  async claimPreparation(request: OnboardingRequest, startedAt: Date, staleBefore: Date): Promise<boolean> {
+    const claimedRows = await this.em.nativeUpdate(
+      OnboardingRequest,
+      {
+        id: request.id,
+        status: 'completed',
+        preparationCompletedAt: null,
+        $or: [
+          { processingStartedAt: null },
+          { processingStartedAt: { $lt: staleBefore } as any },
+        ],
+      } as any,
+      { processingStartedAt: startedAt, updatedAt: new Date() },
+    )
+    if (claimedRows === 0) return false
+    request.processingStartedAt = startedAt
+    return true
+  }
+
+  async renewPreparationLease(requestId: string, renewedAt: Date): Promise<boolean> {
+    const renewedRows = await this.em.nativeUpdate(
+      OnboardingRequest,
+      {
+        id: requestId,
+        status: 'completed',
+        preparationCompletedAt: null,
+        processingStartedAt: { $ne: null } as any,
+      } as any,
+      { processingStartedAt: renewedAt, updatedAt: new Date() },
+    )
+    return renewedRows > 0
+  }
+
   async markReadyEmailSent(request: OnboardingRequest, sentAt: Date) {
     request.readyEmailSentAt = sentAt
     await this.em.flush()
@@ -146,6 +179,7 @@ export class OnboardingService {
 
   async markPreparationCompleted(request: OnboardingRequest, completedAt: Date) {
     request.preparationCompletedAt = completedAt
+    request.processingStartedAt = null
     await this.em.flush()
   }
 }

--- a/packages/onboarding/src/modules/onboarding/lib/service.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/service.ts
@@ -172,6 +172,22 @@ export class OnboardingService {
     return renewedRows > 0
   }
 
+  async releasePreparationLease(request: OnboardingRequest, startedAt: Date): Promise<boolean> {
+    const releasedRows = await this.em.nativeUpdate(
+      OnboardingRequest,
+      {
+        id: request.id,
+        status: 'completed',
+        preparationCompletedAt: null,
+        processingStartedAt: startedAt,
+      },
+      { processingStartedAt: null, updatedAt: new Date() },
+    )
+    if (releasedRows === 0) return false
+    request.processingStartedAt = null
+    return true
+  }
+
   async markReadyEmailSent(request: OnboardingRequest, sentAt: Date) {
     request.readyEmailSentAt = sentAt
     await this.em.flush()

--- a/packages/onboarding/src/modules/onboarding/workers/prepare-workspace.ts
+++ b/packages/onboarding/src/modules/onboarding/workers/prepare-workspace.ts
@@ -1,0 +1,35 @@
+import type { JobContext, QueuedJob, WorkerMeta } from '@open-mercato/queue'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { OnboardingService } from '@open-mercato/onboarding/modules/onboarding/lib/service'
+import { runDeferredProvisioning } from '@open-mercato/onboarding/modules/onboarding/lib/deferred-provisioning'
+import {
+  ONBOARDING_PREPARATION_QUEUE,
+  ONBOARDING_PREPARATION_WORKER_ID,
+  type OnboardingPreparationJobPayload,
+} from '@open-mercato/onboarding/modules/onboarding/lib/preparation-queue'
+
+export const metadata: WorkerMeta = {
+  queue: ONBOARDING_PREPARATION_QUEUE,
+  id: ONBOARDING_PREPARATION_WORKER_ID,
+  concurrency: 1,
+}
+
+type HandlerContext = JobContext & {
+  resolve: <T = unknown>(name: string) => T
+}
+
+export default async function handle(
+  job: QueuedJob<OnboardingPreparationJobPayload>,
+  ctx: HandlerContext,
+): Promise<void> {
+  const em = (ctx.resolve('em') as EntityManager).fork()
+  const service = new OnboardingService(em)
+  const request = await service.findById(job.payload.requestId)
+  if (!request || request.preparationCompletedAt) return
+
+  await runDeferredProvisioning({
+    requestId: job.payload.requestId,
+    tenantId: job.payload.tenantId,
+    organizationId: job.payload.organizationId,
+  })
+}


### PR DESCRIPTION
## Root cause

The preparing page polls `/api/onboarding/onboarding/status` every few seconds. The previous post-provisioning flow scheduled expensive `seedExamples`, ready-email, query index rebuild, and vector enqueue work from request/Next `after()` execution while `preparationCompletedAt` was still null. A few users clicking or polling at once could therefore create overlapping preparation runs, absorb app DB connections, and make tenant lookup/login degrade into the observed session-expired/login bounce in multi-tenant environments.

Supersedes #3007 by keeping the atomic preparation lease fix and moving the expensive preparation work to the queue worker contract.

## Fix

- Keep the atomic preparation claim so repeated status polls can enqueue at most one active preparation job per onboarding request.
- Treat fresh `processing` requests as owned by the verifier; only stale processing rows can be recovered.
- Add `onboarding-preparation` queue helper using `createModuleQueue`, local in dev and Redis/BullMQ when `QUEUE_STRATEGY=async`.
- Add `workers/prepare-workspace.ts` with concurrency 1 and idempotent skip behavior when the request is missing or already prepared.
- Enqueue workspace preparation from verify/status instead of running deferred provisioning in request `after()` callbacks.
- Release the preparation lease if enqueue fails so later polls can retry promptly.
- Keep lease renewal/clearing in the deferred provisioning path so active work is not reclaimed mid-run and stale work can recover later.

## Auth/index-change audit

I rechecked the suspected #2952 tenant-scoped email index impact across login, JWT/session refresh, `getAuthFromRequest`, RBAC/ACL loading, tenant access, and feature guards. The login/session/authorization paths remain user-id/session-id based after login and focused auth tests pass.

Separate follow-up risks from duplicate tenant-scoped emails remain outside this outage fix:

- Password reset still chooses one global user by email.
- `setupInitialTenant` can globally reuse an existing email outside an explicit tenant context.
- `mercato auth set-password` is ambiguous when the same email exists in multiple tenants.
- The `(tenant_id, email_hash)` unique index does not constrain duplicate `NULL` tenant rows on PostgreSQL.

## Validation

- `yarn generate`
- `yarn workspace @open-mercato/onboarding test --runInBand`
- `./node_modules/.bin/tsc --noEmit -p packages/onboarding/tsconfig.json`
- `yarn workspace @open-mercato/onboarding build`
- `yarn workspace @open-mercato/core test --runInBand packages/core/src/modules/auth/commands/__tests__/users.tenant-scoped-email.test.ts packages/core/src/modules/auth/api/__tests__/login.test.ts packages/core/src/modules/auth/services/__tests__/authService.test.ts packages/core/src/modules/auth/lib/__tests__/sessionIntegrity.test.ts packages/core/src/modules/auth/services/__tests__/rbacService.test.ts packages/core/src/modules/auth/lib/__tests__/tenantAccess.test.ts`
- `yarn test:integration:ephemeral --no-reuse-env --force-rebuild packages/onboarding/src/modules/onboarding/__integration__/TC-ONB-002-multi-tenant-parallel-login.spec.ts`
- `git diff --check`

Note: the focused core auth Jest run passed, then emitted the existing "Jest did not exit one second after the test run has completed" open-handle warning.
