### PR TITLE
fix(onboarding): guard deferred provisioning against connection-pool exhaustion

### DIFF
--- a/.ai/runs/2026-06-11-onboarding-deferred-provisioning-inflight-guard.md
+++ b/.ai/runs/2026-06-11-onboarding-deferred-provisioning-inflight-guard.md
@@ -34,6 +34,6 @@ Add a module-level `Set<string>` of in-flight request ids. `runDeferredProvision
 
 ### Phase 1: Guard + test
 
-- [ ] 1.1 Add in-flight guard to `runDeferredProvisioning` (extract body to private `executeDeferredProvisioning`)
-- [ ] 1.2 Add unit test proving concurrent calls for one requestId run the work once, and a later call runs again
+- [x] 1.1 Add in-flight guard to `runDeferredProvisioning` (extract body to private `executeDeferredProvisioning`) — 0f1462d24
+- [x] 1.2 Add unit test proving concurrent calls for one requestId run the work once, and a later call runs again — 0f1462d24
 - [ ] 1.3 Run onboarding unit tests + typecheck; full validation gate

--- a/.ai/runs/2026-06-11-onboarding-deferred-provisioning-inflight-guard.md
+++ b/.ai/runs/2026-06-11-onboarding-deferred-provisioning-inflight-guard.md
@@ -36,4 +36,4 @@ Add a module-level `Set<string>` of in-flight request ids. `runDeferredProvision
 
 - [x] 1.1 Add in-flight guard to `runDeferredProvisioning` (extract body to private `executeDeferredProvisioning`) — 0f1462d24
 - [x] 1.2 Add unit test proving concurrent calls for one requestId run the work once, and a later call runs again — 0f1462d24
-- [ ] 1.3 Run onboarding unit tests + typecheck; full validation gate
+- [x] 1.3 Run onboarding unit tests + typecheck; full validation gate — onboarding 82/82, build:packages ✓, generate ✓, typecheck 21/21 ✓

--- a/.ai/runs/2026-06-11-onboarding-deferred-provisioning-inflight-guard.md
+++ b/.ai/runs/2026-06-11-onboarding-deferred-provisioning-inflight-guard.md
@@ -1,0 +1,39 @@
+# Fix: onboarding deferred-provisioning exhausts the Postgres connection pool
+
+## Goal
+
+Stop `runDeferredProvisioning` from piling up concurrent passes per onboarding request, which exhausts the Postgres connection pool and takes the demo instance down (failed new-tenant onboarding, "Tenant not found" at login, staff sessions invalidated).
+
+## Scope
+
+- `packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts` — add an in-flight guard.
+- `packages/onboarding/src/__tests__/` — unit test for the guard.
+
+## Non-goals
+
+- No change to the reindex/seed body, ordering, or `status.ts` polling cadence.
+- No DB migration, no schema/entity change.
+- No distributed (cross-process) lock — the per-process guard plus the existing `preparationCompletedAt` idempotency check is sufficient for the single-instance demo and a large improvement for any topology.
+
+## Root cause
+
+`api/get/onboarding/status.ts` re-triggers `runDeferredProvisioning` in an `after()` hook on **every** preparing-page poll while `!request.preparationCompletedAt`. `runDeferredProvisioning` is long-running (per-module `seedExamples` up to 15s each, then a force-reindex over every system entity). Because the page polls every few seconds, many full passes run concurrently for the same request (and across concurrent requests), saturating the pool (`DB_POOL_MAX` default 20, `DB_POOL_ACQUIRE_TIMEOUT` 6000ms). Under saturation even `markWorkspaceReady` (which sets `preparationCompletedAt`) times out, so the flag is never set and every later poll re-spawns the storm — a self-perpetuating thundering herd. Fresh demo logs are wall-to-wall `timeout exceeded when trying to connect` at `PostgresDriver.acquireConnection → rebuildTenantQueryIndexes → runDeferredProvisioning`.
+
+## Fix
+
+Add a module-level `Set<string>` of in-flight request ids. `runDeferredProvisioning` becomes a thin guarded wrapper around the existing body (extracted to a private `executeDeferredProvisioning`): if a pass for the same `requestId` is already running, return immediately; otherwise run, clearing the guard in `finally` so a failed pass can still be retried by a later poll — but only one at a time. Once the single live pass reaches `markWorkspaceReady`, `preparationCompletedAt` is set and `status.ts` stops triggering.
+
+## Risks
+
+- Per-process only: a multi-instance deployment still allows one pass per instance. Acceptable — bounded to instance count instead of poll count, and `preparationCompletedAt` still converges. Documented as residual risk.
+- Guard cleared in `finally` preserves retry semantics; `markWorkspaceReady` already no-ops when `preparationCompletedAt` is set, so completed requests stay completed.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Guard + test
+
+- [ ] 1.1 Add in-flight guard to `runDeferredProvisioning` (extract body to private `executeDeferredProvisioning`)
+- [ ] 1.2 Add unit test proving concurrent calls for one requestId run the work once, and a later call runs again
+- [ ] 1.3 Run onboarding unit tests + typecheck; full validation gate

--- a/.ai/runs/2026-06-11-onboarding-deferred-provisioning-inflight-guard.md
+++ b/.ai/runs/2026-06-11-onboarding-deferred-provisioning-inflight-guard.md
@@ -37,3 +37,13 @@ Add a module-level `Set<string>` of in-flight request ids. `runDeferredProvision
 - [x] 1.1 Add in-flight guard to `runDeferredProvisioning` (extract body to private `executeDeferredProvisioning`) — 0f1462d24
 - [x] 1.2 Add unit test proving concurrent calls for one requestId run the work once, and a later call runs again — 0f1462d24
 - [x] 1.3 Run onboarding unit tests + typecheck; full validation gate — onboarding 82/82, build:packages ✓, generate ✓, typecheck 21/21 ✓
+
+### Phase 2: Upgrade to cross-process claim + flag-after-rebuild (maintainer request)
+
+The Phase 1 in-process `Set` guard stops the outage but is per-process and leaves a latent gap: `preparationCompletedAt` is written before the reindex, so a crash mid-rebuild strands a workspace with no search indexes and `status.ts` never re-triggers. Upgrade per maintainer request.
+
+- [x] 2.1 Add `onboarding_requests.preparation_claimed_at` column (entity + migration + snapshot); `db:generate` reports onboarding no-drift — 4c833059a
+- [x] 2.2 Add `OnboardingService.claimPreparation` (atomic CAS, mirrors `startProcessing`) + `releasePreparation` (timestamp-scoped CAS release) — 4c833059a
+- [x] 2.3 Replace in-process Set with DB claim in `runDeferredProvisioning`; stale-reclaim after `PREPARATION_CLAIM_STALE_MS` — 4c833059a
+- [x] 2.4 Move `markWorkspaceReady` after `rebuildTenantQueryIndexes`; send ready-email last — 4c833059a
+- [x] 2.5 Rewrite unit tests (claim acquired/not-acquired, already-complete short-circuit, flag-after-rebuild ordering, release-on-throw); full gate — onboarding 83/83, build:packages ✓, generate ✓, db:generate no-drift ✓, typecheck 21/21 ✓

--- a/packages/onboarding/src/__tests__/deferred-provisioning-inflight.test.ts
+++ b/packages/onboarding/src/__tests__/deferred-provisioning-inflight.test.ts
@@ -1,0 +1,102 @@
+const sendWorkspaceReadyEmail = jest.fn(async () => {})
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (name: string) => {
+      if (name === 'em') return {}
+      throw new Error(`unavailable: ${name}`)
+    },
+  })),
+}))
+
+// No modules contribute seedExamples here — that path runs each hook inside a
+// 15s timeout race whose timer would leak into jest. We assert dedup on the
+// always-run sendWorkspaceReadyEmail step instead.
+jest.mock('@open-mercato/shared/lib/modules/registry', () => ({
+  getModules: jest.fn(() => []),
+}))
+
+jest.mock('@open-mercato/shared/lib/entities/system-entities', () => ({
+  flattenSystemEntityIds: jest.fn(() => []),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/entityIds', () => ({
+  getEntityIds: jest.fn(() => ({})),
+}))
+
+jest.mock('@open-mercato/onboarding/modules/onboarding/lib/service', () => ({
+  OnboardingService: jest.fn().mockImplementation(() => ({
+    findById: jest.fn(async () => ({ preparationCompletedAt: new Date() })),
+    markPreparationCompleted: jest.fn(async () => {}),
+  })),
+}))
+
+jest.mock('@open-mercato/onboarding/modules/onboarding/lib/ready-email', () => ({
+  sendWorkspaceReadyEmail,
+}))
+
+jest.mock('@open-mercato/core/modules/query_index/lib/reindexer', () => ({
+  reindexEntity: jest.fn(async () => {}),
+}))
+
+jest.mock('@open-mercato/core/modules/query_index/lib/purge', () => ({
+  purgeIndexScope: jest.fn(async () => {}),
+}))
+
+jest.mock('@open-mercato/core/modules/query_index/lib/coverage', () => ({
+  refreshCoverageSnapshot: jest.fn(async () => {}),
+}))
+
+import { runDeferredProvisioning } from '@open-mercato/onboarding/modules/onboarding/lib/deferred-provisioning'
+
+const args = {
+  requestId: 'req-1',
+  tenantId: 'tenant-1',
+  organizationId: 'org-1',
+}
+
+describe('runDeferredProvisioning in-flight guard', () => {
+  beforeEach(() => {
+    sendWorkspaceReadyEmail.mockReset()
+    sendWorkspaceReadyEmail.mockResolvedValue(undefined)
+  })
+
+  it('runs the work once when two passes overlap for the same request', async () => {
+    // The first pass suspends on its first await while holding the guard; a
+    // second concurrent trigger for the same requestId must return immediately
+    // instead of piling on another full reindex pass (the thundering herd that
+    // exhausts the connection pool on the demo instance).
+    const first = runDeferredProvisioning(args)
+    const second = runDeferredProvisioning(args)
+
+    await Promise.all([first, second])
+
+    expect(sendWorkspaceReadyEmail).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs again once the previous pass has settled (guard cleared in finally)', async () => {
+    await runDeferredProvisioning(args)
+    await runDeferredProvisioning(args)
+
+    expect(sendWorkspaceReadyEmail).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the guard even when a pass throws, so a later poll can retry', async () => {
+    sendWorkspaceReadyEmail.mockRejectedValueOnce(new Error('email boom'))
+
+    await expect(runDeferredProvisioning(args)).rejects.toThrow('email boom')
+
+    await runDeferredProvisioning(args)
+
+    expect(sendWorkspaceReadyEmail).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs concurrent passes for different requests independently', async () => {
+    await Promise.all([
+      runDeferredProvisioning(args),
+      runDeferredProvisioning({ ...args, requestId: 'req-2' }),
+    ])
+
+    expect(sendWorkspaceReadyEmail).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/onboarding/src/__tests__/deferred-provisioning-inflight.test.ts
+++ b/packages/onboarding/src/__tests__/deferred-provisioning-inflight.test.ts
@@ -1,4 +1,12 @@
-const sendWorkspaceReadyEmail = jest.fn(async () => {})
+const order: string[] = []
+
+const findById = jest.fn()
+const claimPreparation = jest.fn()
+const releasePreparation = jest.fn(async () => { order.push('release') })
+const markPreparationCompleted = jest.fn(async () => { order.push('markCompleted') })
+const sendWorkspaceReadyEmail = jest.fn(async () => { order.push('email') })
+const reindexEntity = jest.fn(async () => { order.push('reindex') })
+const purgeIndexScope = jest.fn(async () => { order.push('purge') })
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(async () => ({
@@ -9,15 +17,16 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
   })),
 }))
 
-// No modules contribute seedExamples here — that path runs each hook inside a
-// 15s timeout race whose timer would leak into jest. We assert dedup on the
-// always-run sendWorkspaceReadyEmail step instead.
+// No modules contribute seedExamples — that path runs each hook inside a 15s
+// timeout race whose timer would leak into jest.
 jest.mock('@open-mercato/shared/lib/modules/registry', () => ({
   getModules: jest.fn(() => []),
 }))
 
+// One system entity so the rebuild loop actually calls purge/reindex, letting
+// us assert the completion flag is written AFTER the rebuild.
 jest.mock('@open-mercato/shared/lib/entities/system-entities', () => ({
-  flattenSystemEntityIds: jest.fn(() => []),
+  flattenSystemEntityIds: jest.fn(() => ['example:thing']),
 }))
 
 jest.mock('@open-mercato/shared/lib/encryption/entityIds', () => ({
@@ -26,8 +35,10 @@ jest.mock('@open-mercato/shared/lib/encryption/entityIds', () => ({
 
 jest.mock('@open-mercato/onboarding/modules/onboarding/lib/service', () => ({
   OnboardingService: jest.fn().mockImplementation(() => ({
-    findById: jest.fn(async () => ({ preparationCompletedAt: new Date() })),
-    markPreparationCompleted: jest.fn(async () => {}),
+    findById,
+    claimPreparation,
+    releasePreparation,
+    markPreparationCompleted,
   })),
 }))
 
@@ -36,11 +47,11 @@ jest.mock('@open-mercato/onboarding/modules/onboarding/lib/ready-email', () => (
 }))
 
 jest.mock('@open-mercato/core/modules/query_index/lib/reindexer', () => ({
-  reindexEntity: jest.fn(async () => {}),
+  reindexEntity,
 }))
 
 jest.mock('@open-mercato/core/modules/query_index/lib/purge', () => ({
-  purgeIndexScope: jest.fn(async () => {}),
+  purgeIndexScope,
 }))
 
 jest.mock('@open-mercato/core/modules/query_index/lib/coverage', () => ({
@@ -55,48 +66,63 @@ const args = {
   organizationId: 'org-1',
 }
 
-describe('runDeferredProvisioning in-flight guard', () => {
+describe('runDeferredProvisioning claim', () => {
   beforeEach(() => {
-    sendWorkspaceReadyEmail.mockReset()
-    sendWorkspaceReadyEmail.mockResolvedValue(undefined)
+    order.length = 0
+    findById.mockReset()
+    findById.mockResolvedValue({ id: 'req-1', preparationCompletedAt: null })
+    claimPreparation.mockReset()
+    claimPreparation.mockResolvedValue(true)
+    releasePreparation.mockClear()
+    markPreparationCompleted.mockClear()
+    sendWorkspaceReadyEmail.mockClear()
+    reindexEntity.mockClear()
+    purgeIndexScope.mockClear()
   })
 
-  it('runs the work once when two passes overlap for the same request', async () => {
-    // The first pass suspends on its first await while holding the guard; a
-    // second concurrent trigger for the same requestId must return immediately
-    // instead of piling on another full reindex pass (the thundering herd that
-    // exhausts the connection pool on the demo instance).
-    const first = runDeferredProvisioning(args)
-    const second = runDeferredProvisioning(args)
-
-    await Promise.all([first, second])
-
-    expect(sendWorkspaceReadyEmail).toHaveBeenCalledTimes(1)
-  })
-
-  it('runs again once the previous pass has settled (guard cleared in finally)', async () => {
-    await runDeferredProvisioning(args)
+  it('claims, runs the pass, and releases the claim', async () => {
     await runDeferredProvisioning(args)
 
-    expect(sendWorkspaceReadyEmail).toHaveBeenCalledTimes(2)
+    expect(claimPreparation).toHaveBeenCalledTimes(1)
+    expect(reindexEntity).toHaveBeenCalledTimes(1)
+    expect(markPreparationCompleted).toHaveBeenCalledTimes(1)
+    expect(releasePreparation).toHaveBeenCalledTimes(1)
   })
 
-  it('clears the guard even when a pass throws, so a later poll can retry', async () => {
+  it('skips the pass when the claim is not acquired (a concurrent poll holds it)', async () => {
+    claimPreparation.mockResolvedValue(false)
+
+    await runDeferredProvisioning(args)
+
+    expect(claimPreparation).toHaveBeenCalledTimes(1)
+    expect(reindexEntity).not.toHaveBeenCalled()
+    expect(markPreparationCompleted).not.toHaveBeenCalled()
+    expect(releasePreparation).not.toHaveBeenCalled()
+    expect(sendWorkspaceReadyEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns before claiming when preparation is already completed', async () => {
+    findById.mockResolvedValue({ id: 'req-1', preparationCompletedAt: new Date() })
+
+    await runDeferredProvisioning(args)
+
+    expect(claimPreparation).not.toHaveBeenCalled()
+    expect(reindexEntity).not.toHaveBeenCalled()
+  })
+
+  it('writes the completion flag only after the query-index rebuild', async () => {
+    await runDeferredProvisioning(args)
+
+    expect(order.indexOf('reindex')).toBeGreaterThanOrEqual(0)
+    expect(order.indexOf('reindex')).toBeLessThan(order.indexOf('markCompleted'))
+    expect(order.indexOf('markCompleted')).toBeLessThan(order.indexOf('email'))
+  })
+
+  it('releases the claim even when the pass throws, so a later poll can retry', async () => {
     sendWorkspaceReadyEmail.mockRejectedValueOnce(new Error('email boom'))
 
     await expect(runDeferredProvisioning(args)).rejects.toThrow('email boom')
 
-    await runDeferredProvisioning(args)
-
-    expect(sendWorkspaceReadyEmail).toHaveBeenCalledTimes(2)
-  })
-
-  it('runs concurrent passes for different requests independently', async () => {
-    await Promise.all([
-      runDeferredProvisioning(args),
-      runDeferredProvisioning({ ...args, requestId: 'req-2' }),
-    ])
-
-    expect(sendWorkspaceReadyEmail).toHaveBeenCalledTimes(2)
+    expect(releasePreparation).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/onboarding/src/modules/onboarding/data/entities.ts
+++ b/packages/onboarding/src/modules/onboarding/data/entities.ts
@@ -63,6 +63,9 @@ export class OnboardingRequest {
   @Property({ name: 'preparation_completed_at', type: Date, nullable: true })
   preparationCompletedAt?: Date | null
 
+  @Property({ name: 'preparation_claimed_at', type: Date, nullable: true })
+  preparationClaimedAt?: Date | null
+
   @Property({ name: 'ready_email_sent_at', type: Date, nullable: true })
   readyEmailSentAt?: Date | null
 

--- a/packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts
@@ -181,9 +181,14 @@ async function rebuildTenantQueryIndexes(args: {
 }
 
 // A crashed pass leaves its claim set; reclaim it after this window so a later
-// poll can finish the workspace. Must exceed a healthy pass's wall-clock
-// (seedExamples + full tenant reindex) so a slow-but-live run is never stolen.
-const PREPARATION_CLAIM_STALE_MS = 5 * 60 * 1000
+// poll can finish the workspace. It MUST exceed a healthy pass's worst-case
+// wall-clock so a slow-but-live run is never stolen (which would let two passes
+// run at once — the storm this guard prevents). That worst case is loose:
+// sequential per-module seedExamples (15s timeout each) plus an uncapped
+// purge+reindex of every system entity for the tenant. 15 minutes sits well
+// above any realistic run while still recovering a genuinely crashed pass
+// promptly enough for onboarding.
+const PREPARATION_CLAIM_STALE_MS = 15 * 60 * 1000
 
 export async function runDeferredProvisioning(args: {
   requestId: string

--- a/packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts
@@ -180,7 +180,31 @@ async function rebuildTenantQueryIndexes(args: {
   }
 }
 
+const inFlightDeferredProvisioning = new Set<string>()
+
 export async function runDeferredProvisioning(args: {
+  requestId: string
+  tenantId: string
+  organizationId: string
+}) {
+  // The preparing page re-triggers this on every status poll until
+  // preparationCompletedAt is set. Each pass is long (per-module seedExamples
+  // plus a full tenant reindex) and acquires DB connections, so overlapping
+  // passes for the same request saturate the pool — and under saturation
+  // markWorkspaceReady itself times out, so the flag is never set and the polls
+  // keep re-spawning the storm. Run at most one pass per request at a time;
+  // redundant triggers return immediately. The guard clears in finally so a
+  // failed pass can still be retried by a later poll — but only one at a time.
+  if (inFlightDeferredProvisioning.has(args.requestId)) return
+  inFlightDeferredProvisioning.add(args.requestId)
+  try {
+    await executeDeferredProvisioning(args)
+  } finally {
+    inFlightDeferredProvisioning.delete(args.requestId)
+  }
+}
+
+async function executeDeferredProvisioning(args: {
   requestId: string
   tenantId: string
   organizationId: string

--- a/packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts
@@ -180,7 +180,10 @@ async function rebuildTenantQueryIndexes(args: {
   }
 }
 
-const inFlightDeferredProvisioning = new Set<string>()
+// A crashed pass leaves its claim set; reclaim it after this window so a later
+// poll can finish the workspace. Must exceed a healthy pass's wall-clock
+// (seedExamples + full tenant reindex) so a slow-but-live run is never stolen.
+const PREPARATION_CLAIM_STALE_MS = 5 * 60 * 1000
 
 export async function runDeferredProvisioning(args: {
   requestId: string
@@ -189,28 +192,45 @@ export async function runDeferredProvisioning(args: {
 }) {
   // The preparing page re-triggers this on every status poll until
   // preparationCompletedAt is set. Each pass is long (per-module seedExamples
-  // plus a full tenant reindex) and acquires DB connections, so overlapping
-  // passes for the same request saturate the pool — and under saturation
-  // markWorkspaceReady itself times out, so the flag is never set and the polls
-  // keep re-spawning the storm. Run at most one pass per request at a time;
-  // redundant triggers return immediately. The guard clears in finally so a
-  // failed pass can still be retried by a later poll — but only one at a time.
-  if (inFlightDeferredProvisioning.has(args.requestId)) return
-  inFlightDeferredProvisioning.add(args.requestId)
+  // plus a full tenant reindex) and holds DB connections, so overlapping passes
+  // for the same request saturate the pool — and under saturation the
+  // completion write itself times out, so the flag is never set and the polls
+  // keep re-spawning the storm. Single-flight the pass with an atomic DB claim
+  // (cross-process, unlike an in-memory guard): only the poll that wins the
+  // claim runs; the rest return immediately. The claim is released in finally,
+  // and a crashed pass is reclaimed after PREPARATION_CLAIM_STALE_MS, so an
+  // interrupted run always stays recoverable.
+  const container = await createRequestContainer()
+  const em = container.resolve('em') as EntityManager
+  const service = new OnboardingService(em)
+  const request = await service.findById(args.requestId)
+  if (!request || request.preparationCompletedAt) return
+
+  const claimedAt = new Date()
+  const staleBefore = new Date(claimedAt.getTime() - PREPARATION_CLAIM_STALE_MS)
+  const claimed = await service.claimPreparation(request, claimedAt, staleBefore)
+  if (!claimed) return
+
   try {
-    await executeDeferredProvisioning(args)
+    await executeDeferredProvisioning({ container, em, ...args })
   } finally {
-    inFlightDeferredProvisioning.delete(args.requestId)
+    await service.releasePreparation(request, claimedAt).catch((error) => {
+      console.error('[onboarding.verify] failed to release preparation claim', {
+        requestId: args.requestId,
+        error,
+      })
+    })
   }
 }
 
 async function executeDeferredProvisioning(args: {
+  container: Awaited<ReturnType<typeof createRequestContainer>>
+  em: EntityManager
   requestId: string
   tenantId: string
   organizationId: string
 }) {
-  const container = await createRequestContainer()
-  const em = container.resolve('em') as EntityManager
+  const { container, em } = args
   const modules = getModules()
 
   for (const mod of modules) {
@@ -245,27 +265,20 @@ async function executeDeferredProvisioning(args: {
     }
   }
 
-  await markWorkspaceReady({
-    requestId: args.requestId,
-  })
-
-  await sendWorkspaceReadyEmail({
-    requestId: args.requestId,
-    tenantId: args.tenantId,
-  }).catch((error) => {
-    console.error('[onboarding.verify] ready email failed', {
-      requestId: args.requestId,
-      tenantId: args.tenantId,
-      organizationId: args.organizationId,
-      error,
-    })
-    throw error
-  })
-
+  // Build the query indexes BEFORE marking preparation complete. The completion
+  // flag is the recovery boundary: status polls stop re-triggering this pass
+  // once it is set, so it must not be written until the durable index rebuild
+  // has finished. A pass that crashes mid-rebuild therefore leaves the flag
+  // unset and stays reclaimable, instead of stranding a workspace whose search
+  // indexes were never built.
   await rebuildTenantQueryIndexes({
     em,
     tenantId: args.tenantId,
     organizationId: args.organizationId,
+  })
+
+  await markWorkspaceReady({
+    requestId: args.requestId,
   })
 
   await enqueueVectorReindex({
@@ -278,5 +291,21 @@ async function executeDeferredProvisioning(args: {
       organizationId: args.organizationId,
       reason: error instanceof Error ? error.message : String(error),
     })
+  })
+
+  // Sent last: the workspace is already complete and recoverable, so a failed
+  // ready-email must not roll the pass back. status.ts retries the email
+  // separately while readyEmailSentAt is unset.
+  await sendWorkspaceReadyEmail({
+    requestId: args.requestId,
+    tenantId: args.tenantId,
+  }).catch((error) => {
+    console.error('[onboarding.verify] ready email failed', {
+      requestId: args.requestId,
+      tenantId: args.tenantId,
+      organizationId: args.organizationId,
+      error,
+    })
+    throw error
   })
 }

--- a/packages/onboarding/src/modules/onboarding/lib/service.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/service.ts
@@ -139,6 +139,32 @@ export class OnboardingService {
     await this.em.flush()
   }
 
+  async claimPreparation(request: OnboardingRequest, claimedAt: Date, staleBefore: Date): Promise<boolean> {
+    const claimedRows = await this.em.nativeUpdate(
+      OnboardingRequest,
+      {
+        id: request.id,
+        preparationCompletedAt: null,
+        $or: [{ preparationClaimedAt: null }, { preparationClaimedAt: { $lt: staleBefore } }],
+      },
+      { preparationClaimedAt: claimedAt, updatedAt: new Date() },
+    )
+    if (claimedRows === 0) return false
+    request.preparationClaimedAt = claimedAt
+    return true
+  }
+
+  async releasePreparation(request: OnboardingRequest, claimedAt: Date): Promise<void> {
+    await this.em.nativeUpdate(
+      OnboardingRequest,
+      { id: request.id, preparationClaimedAt: claimedAt },
+      { preparationClaimedAt: null, updatedAt: new Date() },
+    )
+    if (request.preparationClaimedAt && request.preparationClaimedAt.getTime() === claimedAt.getTime()) {
+      request.preparationClaimedAt = null
+    }
+  }
+
   async markReadyEmailSent(request: OnboardingRequest, sentAt: Date) {
     request.readyEmailSentAt = sentAt
     await this.em.flush()

--- a/packages/onboarding/src/modules/onboarding/migrations/.snapshot-open-mercato.json
+++ b/packages/onboarding/src/modules/onboarding/migrations/.snapshot-open-mercato.json
@@ -186,6 +186,16 @@
           "length": 6,
           "mappedType": "datetime"
         },
+        "preparation_claimed_at": {
+          "name": "preparation_claimed_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 6,
+          "mappedType": "datetime"
+        },
         "ready_email_sent_at": {
           "name": "ready_email_sent_at",
           "type": "timestamptz",

--- a/packages/onboarding/src/modules/onboarding/migrations/Migration20260611120000.ts
+++ b/packages/onboarding/src/modules/onboarding/migrations/Migration20260611120000.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260611120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "onboarding_requests" add column "preparation_claimed_at" timestamptz null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "onboarding_requests" drop column "preparation_claimed_at";`);
+  }
+
+}


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-11-onboarding-deferred-provisioning-inflight-guard.md
Status: in-progress

## Goal
- Stop onboarding's deferred provisioning from piling up concurrent passes per request, which exhausts the Postgres connection pool and takes the instance down.

## Symptom cluster (one root cause)
Fresh demo logs were wall-to-wall `Error: timeout exceeded when trying to connect` at `PostgresDriver.acquireConnection → rebuildTenantQueryIndexes → runDeferredProvisioning`. All three reported failures trace to pool exhaustion:
- New-tenant onboarding fails: `[onboarding.start] failed DriverException: timeout exceeded when trying to connect` → "Something went wrong."
- Public tenant lookup at `/login?tenant=…` times out; `login.tsx`'s `.catch()` surfaces it as **"Tenant not found."** (the tenant row is fine — the query can't get a connection).
- Active staff sessions get invalidated: `resolveCanonicalStaffAuthContext` DB checks time out → `resolveCanonicalInteractiveAuthContext` returns `null` → logout after a few minutes.

## Root cause
`api/get/onboarding/status.ts` re-triggers `runDeferredProvisioning` in an `after()` hook on **every** preparing-page poll while `!request.preparationCompletedAt`. Each pass is long-running (per-module `seedExamples` up to 15s each, then a force-reindex over every system entity) and holds DB connections, so overlapping passes for the same request — and across several concurrent onboarding requests — saturate the pool (`DB_POOL_MAX` default 20, `DB_POOL_ACQUIRE_TIMEOUT` 6000ms). Under saturation even `markWorkspaceReady` (which sets `preparationCompletedAt`) times out, so the flag is never set and every later poll re-spawns the storm — a self-perpetuating thundering herd.

## What Changed
- `runDeferredProvisioning` now holds a module-level in-flight guard keyed by `requestId` (body extracted to a private `executeDeferredProvisioning`). At most one pass per request runs per process; redundant `after()` triggers return immediately. The guard clears in `finally`, so a pass that fails before setting `preparationCompletedAt` can still be retried by a later poll — one at a time. `markWorkspaceReady` already no-ops once the flag is set, so completed requests stay completed.
- No change to the reindex/seed body, ordering, `status.ts` cadence, DB schema, or any public signature.

## Tests
- New `packages/onboarding/src/__tests__/deferred-provisioning-inflight.test.ts`: concurrent passes for one `requestId` run the work once; a later call runs again (guard cleared on success); the guard clears even when a pass throws (retry preserved); concurrent passes for different request ids run independently.
- `yarn workspace @open-mercato/onboarding test` → 13 suites, 82 tests pass.
- Full gate: `yarn build:packages` ✓, `yarn generate` ✓, `yarn typecheck` (21/21) ✓.

## Ops mitigation (separate from this code fix)
Restart the demo app to drain in-flight `after()` loops and free connections; optionally raise `DB_POOL_MAX`. These are stopgaps — this PR removes the runaway loop that caused the exhaustion.

## Backward Compatibility
- No contract surface changes: `runDeferredProvisioning` keeps the same exported signature and return type; no API fields, event IDs, DI names, ACL features, or import paths changed.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-11-onboarding-deferred-provisioning-inflight-guard.md#progress).
