### PR TITLE
fix(queue): worker --all isolates each job in its own request container (#2970)

### DIFF
--- a/packages/cli/src/lib/__tests__/worker-job-handler.test.ts
+++ b/packages/cli/src/lib/__tests__/worker-job-handler.test.ts
@@ -1,0 +1,135 @@
+import type { ModuleWorker } from '@open-mercato/shared/modules/registry'
+import { createPerJobWorkerHandler, type WorkerJobContainer } from '../worker-job-handler'
+
+type FakeContainer = WorkerJobContainer & {
+  id: number
+  em: { clear: jest.Mock }
+}
+
+function makeContainerFactory() {
+  const containers: FakeContainer[] = []
+  let nextId = 0
+  const factory = jest.fn(async (): Promise<WorkerJobContainer> => {
+    const em = { clear: jest.fn() }
+    const container: FakeContainer = {
+      id: nextId++,
+      em,
+      resolve: <T = unknown>(name: string): T => {
+        if (name === 'em') return em as unknown as T
+        return undefined as unknown as T
+      },
+    }
+    containers.push(container)
+    return container
+  })
+  return { factory, containers }
+}
+
+function makeWorker(id: string, handler: ModuleWorker['handler']): ModuleWorker {
+  return { id, queue: 'test', concurrency: 1, handler }
+}
+
+const baseCtx = { jobId: 'job-1', attemptNumber: 1, queueName: 'test' }
+
+describe('createPerJobWorkerHandler', () => {
+  it('creates a fresh container for every job invocation', async () => {
+    const { factory } = makeContainerFactory()
+    const worker = makeWorker('w', jest.fn())
+    const handler = createPerJobWorkerHandler([worker], factory)
+
+    await handler({ id: 'a' }, { ...baseCtx, jobId: 'a' })
+    await handler({ id: 'b' }, { ...baseCtx, jobId: 'b' })
+
+    expect(factory).toHaveBeenCalledTimes(2)
+  })
+
+  it('passes each worker a resolve bound to that job container', async () => {
+    const { factory, containers } = makeContainerFactory()
+    const seenEms: unknown[] = []
+    const worker = makeWorker('w', (_job, ctx) => {
+      const resolve = (ctx as { resolve: (name: string) => unknown }).resolve
+      seenEms.push(resolve('em'))
+    })
+    const handler = createPerJobWorkerHandler([worker], factory)
+
+    await handler({ id: 'a' }, { ...baseCtx, jobId: 'a' })
+    await handler({ id: 'b' }, { ...baseCtx, jobId: 'b' })
+
+    expect(seenEms).toHaveLength(2)
+    expect(seenEms[0]).toBe(containers[0].em)
+    expect(seenEms[1]).toBe(containers[1].em)
+    expect(seenEms[0]).not.toBe(seenEms[1])
+  })
+
+  it('isolates concurrent jobs in distinct containers (no shared EntityManager)', async () => {
+    const { factory, containers } = makeContainerFactory()
+    let release: (() => void) | null = null
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const resolvedEms: unknown[] = []
+    let firstEntered = false
+    const worker = makeWorker('w', async (_job, ctx) => {
+      const resolve = (ctx as { resolve: (name: string) => unknown }).resolve
+      resolvedEms.push(resolve('em'))
+      if (!firstEntered) {
+        firstEntered = true
+        // Hold the first job open so the second job starts concurrently.
+        await gate
+      }
+    })
+    const handler = createPerJobWorkerHandler([worker], factory)
+
+    const first = handler({ id: 'a' }, { ...baseCtx, jobId: 'a' })
+    const second = handler({ id: 'b' }, { ...baseCtx, jobId: 'b' })
+    release?.()
+    await Promise.all([first, second])
+
+    expect(factory).toHaveBeenCalledTimes(2)
+    expect(resolvedEms[0]).toBe(containers[0].em)
+    expect(resolvedEms[1]).toBe(containers[1].em)
+    expect(resolvedEms[0]).not.toBe(resolvedEms[1])
+  })
+
+  it('runs every worker for the queue against the same per-job container', async () => {
+    const { factory, containers } = makeContainerFactory()
+    const seen: unknown[] = []
+    const record = (_job: unknown, ctx: unknown) => {
+      seen.push((ctx as { resolve: (name: string) => unknown }).resolve('em'))
+    }
+    const handler = createPerJobWorkerHandler(
+      [makeWorker('w1', record), makeWorker('w2', record)],
+      factory,
+    )
+
+    await handler({ id: 'a' }, baseCtx)
+
+    expect(factory).toHaveBeenCalledTimes(1)
+    expect(seen).toHaveLength(2)
+    expect(seen[0]).toBe(containers[0].em)
+    expect(seen[1]).toBe(containers[0].em)
+  })
+
+  it('clears the job container EntityManager after the job completes', async () => {
+    const { factory, containers } = makeContainerFactory()
+    const handler = createPerJobWorkerHandler([makeWorker('w', jest.fn())], factory)
+
+    await handler({ id: 'a' }, baseCtx)
+
+    expect(containers[0].em.clear).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the EntityManager and rethrows when a worker fails', async () => {
+    const { factory, containers } = makeContainerFactory()
+    const boom = new Error('worker failed')
+    const handler = createPerJobWorkerHandler(
+      [makeWorker('w', () => {
+        throw boom
+      })],
+      factory,
+    )
+
+    await expect(handler({ id: 'a' }, baseCtx)).rejects.toBe(boom)
+    expect(containers[0].em.clear).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/cli/src/lib/worker-job-handler.ts
+++ b/packages/cli/src/lib/worker-job-handler.ts
@@ -1,0 +1,45 @@
+import type { JobContext, JobHandler } from '@open-mercato/queue'
+import type { ModuleWorker } from '@open-mercato/shared/modules/registry'
+
+export type WorkerJobContainer = {
+  resolve: <T = unknown>(name: string) => T
+}
+
+export type WorkerJobContainerFactory = () => Promise<WorkerJobContainer>
+
+type ClearableEntityManager = {
+  clear?: () => void
+}
+
+/**
+ * Builds a queue job handler that isolates every job in its own request
+ * container, instead of sharing a single process-wide `EntityManager` fork
+ * across all concurrent jobs.
+ *
+ * Under the async (BullMQ) strategy jobs run with real concurrency, so a
+ * shared EM would interleave unit-of-work flushes between unrelated jobs and
+ * never release its identity map. Creating one container per job removes both
+ * the cross-job flush race and the unbounded identity-map growth, while
+ * keeping the `ctx.resolve` contract and DI keys unchanged. See issue #2970.
+ */
+export function createPerJobWorkerHandler(
+  workers: ModuleWorker[],
+  createContainer: WorkerJobContainerFactory,
+): JobHandler {
+  return async (job, ctx: JobContext) => {
+    const container = await createContainer()
+    try {
+      for (const worker of workers) {
+        await worker.handler(job, { ...ctx, resolve: container.resolve.bind(container) })
+      }
+    } finally {
+      try {
+        const em = container.resolve('em') as ClearableEntityManager | null
+        em?.clear?.()
+      } catch {
+        // Best-effort: clearing the identity map is a memory optimization and
+        // must never mask a job's own outcome.
+      }
+    }
+  }
+}

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -15,6 +15,7 @@ import {
   resolveLazyRestart,
 } from './lib/auto-spawn-workers'
 import { startLazyWorkerSupervisor } from './lib/queue-worker-supervisor'
+import { createPerJobWorkerHandler } from './lib/worker-job-handler'
 import {
   resolveAutoSpawnSchedulerMode,
   resolveLazySchedulerPollMs,
@@ -1518,7 +1519,6 @@ export async function run(argv = process.argv) {
             }
 
             const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
-            const container = await createRequestContainer()
             console.log(`[worker] Starting workers for all queues: ${discoveredQueues.join(', ')}`)
 
             // Start all queue workers in background mode
@@ -1534,11 +1534,7 @@ export async function run(argv = process.argv) {
                 connection: queueRedisUrl ? { url: queueRedisUrl } : undefined,
                 concurrency,
                 background: true,
-                handler: async (job, ctx) => {
-                  for (const worker of queueWorkers) {
-                    await worker.handler(job, { ...ctx, resolve: container.resolve.bind(container) })
-                  }
-                },
+                handler: createPerJobWorkerHandler(queueWorkers, createRequestContainer),
               })
             })
 
@@ -1555,7 +1551,6 @@ export async function run(argv = process.argv) {
             if (queueWorkers.length > 0) {
               // Use discovered workers
               const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
-              const container = await createRequestContainer()
               const concurrency = concurrencyOverride ?? Math.max(...queueWorkers.map((w) => w.concurrency), 1)
 
               console.log(`[worker] Found ${queueWorkers.length} worker(s) for queue "${queueName}"`)
@@ -1565,11 +1560,7 @@ export async function run(argv = process.argv) {
                 queueName: queueName!,
                 connection: queueRedisUrl ? { url: queueRedisUrl } : undefined,
                 concurrency,
-                handler: async (job, ctx) => {
-                  for (const worker of queueWorkers) {
-                    await worker.handler(job, { ...ctx, resolve: container.resolve.bind(container) })
-                  }
-                },
+                handler: createPerJobWorkerHandler(queueWorkers, createRequestContainer),
               })
             } else {
               console.error(`No workers found for queue "${queueName}"`)


### PR DESCRIPTION
Fixes #2970

## Problem
`mercato queue worker --all` (auto-spawned by `app start`) built a single `createRequestContainer()` once at startup and handed the same `container.resolve.bind(container)` to every job of every queue. The single-queue path had the same shape. Because `em` is registered as `asValue` of one shared `EntityManager` fork, every concurrent job in the process shared one EntityManager.

## Root Cause
Under `QUEUE_STRATEGY=async` (production) BullMQ runs handlers with real concurrency, so jobs interleaved unit-of-work flushes on the single shared EM — one job's `flush()` could commit another job's half-applied changes (silent cross-job write interleaving / lost updates on webhook + import runs). Independently, the identity map was never cleared between jobs, so a long-lived worker accumulated every entity it ever loaded (unbounded RSS growth). The local strategy is sequential per queue, so this only surfaced in production.

## What Changed
- Added `packages/cli/src/lib/worker-job-handler.ts` exporting `createPerJobWorkerHandler(workers, createContainer)`, which builds a **fresh request container per job** and clears that container's EntityManager in a `finally` block once the job completes.
- Rewired both worker paths in `packages/cli/src/mercato.ts` (`--all` and single-queue) to use the helper instead of a startup-time shared container; removed the now-unused startup `createRequestContainer()` calls.

This mirrors the proven per-job isolation pattern already used by `catalog-product-bulk-delete` and `deals-bulk-update-owner`, and is cheap because `bootstrap()` is process-cached. Per-job containers also correctly re-attach the tenant-encryption subscriber to the fresh EM.

## Tests
- New unit suite `packages/cli/src/lib/__tests__/worker-job-handler.test.ts` (6 tests) proving: a fresh container per job invocation; `ctx.resolve` bound to the per-job container; concurrent jobs get **distinct** EntityManagers (the core race fix); all workers of one queue share one per-job container; the EM is cleared after success; and the EM is cleared + error rethrown on worker failure.
- Full CLI suite: 948/948 pass. Full repo `yarn typecheck`: pass. `yarn build:packages` + `yarn generate`: pass.

## Backward Compatibility
- No contract surface changes. The `ctx.resolve` contract and DI keys are unchanged (BACKWARD_COMPATIBILITY.md §9); workers are contractually idempotent and must not rely on cross-job EM state.