### PR TITLE
fix(sync-akeneo,channel-gmail): cap Akeneo 429 retries, clamp retry-after, add AbortSignal timeouts to external HTTP calls (#2976)

### DIFF
--- a/packages/channel-gmail/src/modules/channel_gmail/lib/__tests__/gmail-client.test.ts
+++ b/packages/channel-gmail/src/modules/channel_gmail/lib/__tests__/gmail-client.test.ts
@@ -221,15 +221,15 @@ describe('FetchGmailApiClient.requestJson retry/backoff', () => {
     expect(capturedSignal).toBeInstanceOf(AbortSignal)
   })
 
-  it('treats a timed-out (AbortError) fetch as transient and retries it (issue #2976)', async () => {
+  it('treats a timed-out (TimeoutError) fetch as transient and retries it (issue #2976)', async () => {
     Math.random = () => 0
     let calls = 0
     globalThis.fetch = (() => {
       calls += 1
       if (calls === 1) {
-        const abortError = new Error('The operation was aborted')
-        abortError.name = 'AbortError'
-        return Promise.reject(abortError)
+        // `AbortSignal.timeout()` rejects fetch with a `TimeoutError` DOMException,
+        // not an `AbortError` — exercise the real production failure shape.
+        return Promise.reject(new DOMException('The operation timed out', 'TimeoutError'))
       }
       return Promise.resolve(
         fakeResponse({ status: 200, statusText: 'OK', body: JSON.stringify({ emailAddress: 'a@gmail.com', historyId: '5' }) }),
@@ -240,18 +240,34 @@ describe('FetchGmailApiClient.requestJson retry/backoff', () => {
 
     expect(calls).toBe(2)
     expect(profile.historyId).toBe('5')
-    // computeBackoff(0) = 500ms (jitter stripped) — the abort took the retry path.
+    // computeBackoff(0) = 500ms (jitter stripped) — the timeout took the retry path.
     expect(capturedDelays).toEqual([500])
   })
 
-  it('throws a GmailApiError after AbortErrors exhaust the retry budget (issue #2976)', async () => {
+  it('also retries an externally-aborted (AbortError) fetch (issue #2976)', async () => {
     Math.random = () => 0
     let calls = 0
     globalThis.fetch = (() => {
       calls += 1
-      const abortError = new Error('The operation was aborted')
-      abortError.name = 'AbortError'
-      return Promise.reject(abortError)
+      if (calls === 1) return Promise.reject(new DOMException('The operation was aborted', 'AbortError'))
+      return Promise.resolve(
+        fakeResponse({ status: 200, statusText: 'OK', body: JSON.stringify({ emailAddress: 'a@gmail.com', historyId: '7' }) }),
+      )
+    }) as unknown as typeof globalThis.fetch
+
+    const profile = await getGmailApiClient().getProfile({ accessToken: 'token' })
+
+    expect(calls).toBe(2)
+    expect(profile.historyId).toBe('7')
+    expect(capturedDelays).toEqual([500])
+  })
+
+  it('throws a GmailApiError after timeouts exhaust the retry budget (issue #2976)', async () => {
+    Math.random = () => 0
+    let calls = 0
+    globalThis.fetch = (() => {
+      calls += 1
+      return Promise.reject(new DOMException('The operation timed out', 'TimeoutError'))
     }) as unknown as typeof globalThis.fetch
 
     const thrown = await getGmailApiClient()

--- a/packages/channel-gmail/src/modules/channel_gmail/lib/__tests__/gmail-client.test.ts
+++ b/packages/channel-gmail/src/modules/channel_gmail/lib/__tests__/gmail-client.test.ts
@@ -206,4 +206,62 @@ describe('FetchGmailApiClient.requestJson retry/backoff', () => {
     expect(calls).toBe(1)
     expect(capturedDelays).toEqual([])
   })
+
+  it('attaches an AbortSignal to each request so a stalled connection cannot hang the worker (issue #2976)', async () => {
+    let capturedSignal: unknown
+    globalThis.fetch = ((_url: string, init?: RequestInit) => {
+      capturedSignal = init?.signal
+      return Promise.resolve(
+        fakeResponse({ status: 200, statusText: 'OK', body: JSON.stringify({ emailAddress: 'a@gmail.com', historyId: '1' }) }),
+      )
+    }) as unknown as typeof globalThis.fetch
+
+    await getGmailApiClient().getProfile({ accessToken: 'token' })
+
+    expect(capturedSignal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('treats a timed-out (AbortError) fetch as transient and retries it (issue #2976)', async () => {
+    Math.random = () => 0
+    let calls = 0
+    globalThis.fetch = (() => {
+      calls += 1
+      if (calls === 1) {
+        const abortError = new Error('The operation was aborted')
+        abortError.name = 'AbortError'
+        return Promise.reject(abortError)
+      }
+      return Promise.resolve(
+        fakeResponse({ status: 200, statusText: 'OK', body: JSON.stringify({ emailAddress: 'a@gmail.com', historyId: '5' }) }),
+      )
+    }) as unknown as typeof globalThis.fetch
+
+    const profile = await getGmailApiClient().getProfile({ accessToken: 'token' })
+
+    expect(calls).toBe(2)
+    expect(profile.historyId).toBe('5')
+    // computeBackoff(0) = 500ms (jitter stripped) — the abort took the retry path.
+    expect(capturedDelays).toEqual([500])
+  })
+
+  it('throws a GmailApiError after AbortErrors exhaust the retry budget (issue #2976)', async () => {
+    Math.random = () => 0
+    let calls = 0
+    globalThis.fetch = (() => {
+      calls += 1
+      const abortError = new Error('The operation was aborted')
+      abortError.name = 'AbortError'
+      return Promise.reject(abortError)
+    }) as unknown as typeof globalThis.fetch
+
+    const thrown = await getGmailApiClient()
+      .getProfile({ accessToken: 'token' })
+      .catch((error: unknown) => error)
+
+    expect(thrown).toBeInstanceOf(GmailApiError)
+    expect((thrown as GmailApiError).status).toBe(599)
+    // 1 initial + 3 retries = 4 attempts; backoff fired on the first 3.
+    expect(calls).toBe(4)
+    expect(capturedDelays).toEqual([500, 1000, 2000])
+  })
 })

--- a/packages/channel-gmail/src/modules/channel_gmail/lib/gmail-client.ts
+++ b/packages/channel-gmail/src/modules/channel_gmail/lib/gmail-client.ts
@@ -116,6 +116,12 @@ export interface GmailApiClient {
 const GMAIL_MAX_RETRIES = 3
 const GMAIL_BACKOFF_BASE_MS = 500
 const GMAIL_BACKOFF_CAP_MS = 8_000
+const GMAIL_DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+
+function resolveGmailRequestTimeoutMs(): number {
+  const fromEnv = Number.parseInt(process.env.OM_CHANNEL_GMAIL_REQUEST_TIMEOUT_MS ?? '', 10)
+  return Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : GMAIL_DEFAULT_REQUEST_TIMEOUT_MS
+}
 
 class FetchGmailApiClient implements GmailApiClient {
   async listHistory(auth: GmailApiAuth, input: GmailHistoryListInput): Promise<GmailHistoryListResponse> {
@@ -190,7 +196,32 @@ class FetchGmailApiClient implements GmailApiClient {
     let attempt = 0
     let lastError: GmailApiError | null = null
     while (attempt <= GMAIL_MAX_RETRIES) {
-      const res = await fetch(url.toString(), { method, headers, body: payload })
+      let res: Response
+      try {
+        res = await fetch(url.toString(), {
+          method,
+          headers,
+          body: payload,
+          // Bound each attempt so a stalled connection fails fast instead of
+          // hanging on undici's multi-minute default and pinning the worker slot.
+          signal: AbortSignal.timeout(resolveGmailRequestTimeoutMs()),
+        })
+      } catch (err) {
+        // A timed-out/aborted connection is transient — let the bounded retry
+        // loop retry it rather than propagating a raw AbortError.
+        const aborted = err instanceof Error && err.name === 'AbortError'
+        if (!aborted) throw err
+        const timeoutError = new GmailApiError(
+          `Gmail API ${method} ${url.pathname} timed out`,
+          599,
+          'request timed out',
+        )
+        if (attempt === GMAIL_MAX_RETRIES) throw timeoutError
+        lastError = timeoutError
+        await sleep(computeBackoff(attempt))
+        attempt += 1
+        continue
+      }
       const text = await res.text()
       if (res.ok) {
         if (!text) return undefined as unknown as T

--- a/packages/channel-gmail/src/modules/channel_gmail/lib/gmail-client.ts
+++ b/packages/channel-gmail/src/modules/channel_gmail/lib/gmail-client.ts
@@ -208,8 +208,13 @@ class FetchGmailApiClient implements GmailApiClient {
         })
       } catch (err) {
         // A timed-out/aborted connection is transient — let the bounded retry
-        // loop retry it rather than propagating a raw AbortError.
-        const aborted = err instanceof Error && err.name === 'AbortError'
+        // loop retry it rather than propagating a raw error. `AbortSignal.timeout`
+        // rejects fetch with a `TimeoutError` DOMException; an externally-aborted
+        // request surfaces as `AbortError`. Match on the `name` field (not
+        // `instanceof Error`, since DOMException does not subclass Error across
+        // realms) — treat both as transient.
+        const errName = (err as { name?: unknown } | null)?.name
+        const aborted = errName === 'TimeoutError' || errName === 'AbortError'
         if (!aborted) throw err
         const timeoutError = new GmailApiError(
           `Gmail API ${method} ${url.pathname} timed out`,

--- a/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts
@@ -220,3 +220,89 @@ describe('akeneo client security', () => {
     }))
   })
 })
+
+describe('akeneo client resilience (issue #2976)', () => {
+  const originalFetch = global.fetch
+  const originalSetTimeout = global.setTimeout
+  const originalMaxRetries = process.env.OM_INTEGRATION_AKENEO_MAX_RATE_LIMIT_RETRIES
+  const originalRetryCap = process.env.OM_INTEGRATION_AKENEO_RETRY_AFTER_CAP_MS
+  let capturedDelays: number[]
+
+  function tokenResponse(): Response {
+    return jsonResponse({ access_token: 'token-123', expires_in: 3600 })
+  }
+
+  beforeEach(() => {
+    global.fetch = jest.fn() as typeof fetch
+    capturedDelays = []
+    // Fire backoff/retry-after sleeps synchronously so the retry loop runs
+    // without real timers while we assert the requested wait durations.
+    global.setTimeout = ((callback: () => void, ms?: number) => {
+      capturedDelays.push(typeof ms === 'number' ? ms : 0)
+      callback()
+      return 0 as unknown as ReturnType<typeof setTimeout>
+    }) as unknown as typeof global.setTimeout
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    global.setTimeout = originalSetTimeout
+    if (originalMaxRetries === undefined) delete process.env.OM_INTEGRATION_AKENEO_MAX_RATE_LIMIT_RETRIES
+    else process.env.OM_INTEGRATION_AKENEO_MAX_RATE_LIMIT_RETRIES = originalMaxRetries
+    if (originalRetryCap === undefined) delete process.env.OM_INTEGRATION_AKENEO_RETRY_AFTER_CAP_MS
+    else process.env.OM_INTEGRATION_AKENEO_RETRY_AFTER_CAP_MS = originalRetryCap
+    jest.restoreAllMocks()
+  })
+
+  it('caps 429 retries and surfaces the existing error shape instead of looping forever', async () => {
+    process.env.OM_INTEGRATION_AKENEO_MAX_RATE_LIMIT_RETRIES = '2'
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
+    fetchMock.mockImplementation(async (input) => {
+      if (String(input).endsWith('/api/oauth/v1/token')) return tokenResponse()
+      return new Response('rate limited', { status: 429, headers: { 'retry-after': '1' } })
+    })
+
+    const client = createAkeneoClient(validCredentials)
+    await expect(client.listChannels()).rejects.toThrow('Akeneo request failed (429)')
+
+    // 1 token + (maxRetries + 1) request attempts = 1 + 3 = 4 fetches; 2 sleeps.
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(capturedDelays).toHaveLength(2)
+  })
+
+  it('clamps a hostile retry-after header to the configured ceiling', async () => {
+    process.env.OM_INTEGRATION_AKENEO_RETRY_AFTER_CAP_MS = '60000'
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
+    let listCalls = 0
+    fetchMock.mockImplementation(async (input) => {
+      if (String(input).endsWith('/api/oauth/v1/token')) return tokenResponse()
+      listCalls += 1
+      if (listCalls === 1) {
+        // retry-after: ~31 years — must be clamped, not slept verbatim.
+        return new Response('', { status: 429, headers: { 'retry-after': '999999999' } })
+      }
+      return jsonResponse({ _embedded: { items: [{ code: 'web' }] }, _links: {}, items_count: 1 })
+    })
+
+    const client = createAkeneoClient(validCredentials)
+    const channels = await client.listChannels()
+
+    expect(channels).toHaveLength(1)
+    expect(capturedDelays).toEqual([60000])
+  })
+
+  it('attaches an AbortSignal timeout to authenticated requests', async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(jsonResponse({ _embedded: { items: [] }, _links: {}, items_count: 0 }))
+
+    const client = createAkeneoClient(validCredentials)
+    await client.listChannels()
+
+    const tokenInit = fetchMock.mock.calls[0][1] as RequestInit
+    const requestInit = fetchMock.mock.calls[1][1] as RequestInit
+    expect(tokenInit.signal).toBeInstanceOf(AbortSignal)
+    expect(requestInit.signal).toBeInstanceOf(AbortSignal)
+  })
+})

--- a/packages/sync-akeneo/src/modules/sync_akeneo/lib/client.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/lib/client.ts
@@ -200,6 +200,30 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+const DEFAULT_AKENEO_REQUEST_TIMEOUT_MS = 30_000
+const DEFAULT_AKENEO_MAX_RATE_LIMIT_RETRIES = 5
+const DEFAULT_AKENEO_RETRY_AFTER_CAP_MS = 60_000
+
+function resolvePositiveIntEnv(raw: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(raw ?? '', 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function resolveAkeneoRequestTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  return resolvePositiveIntEnv(env.OM_INTEGRATION_AKENEO_REQUEST_TIMEOUT_MS, DEFAULT_AKENEO_REQUEST_TIMEOUT_MS)
+}
+
+function resolveAkeneoMaxRateLimitRetries(env: NodeJS.ProcessEnv = process.env): number {
+  return resolvePositiveIntEnv(env.OM_INTEGRATION_AKENEO_MAX_RATE_LIMIT_RETRIES, DEFAULT_AKENEO_MAX_RATE_LIMIT_RETRIES)
+}
+
+function clampAkeneoRetryAfterMs(retryAfterHeader: string | null, env: NodeJS.ProcessEnv = process.env): number {
+  const retryAfter = Number(retryAfterHeader ?? '1')
+  const requestedMs = Number.isFinite(retryAfter) ? retryAfter * 1000 : 1000
+  const cap = resolvePositiveIntEnv(env.OM_INTEGRATION_AKENEO_RETRY_AFTER_CAP_MS, DEFAULT_AKENEO_RETRY_AFTER_CAP_MS)
+  return Math.min(Math.max(requestedMs, 0), cap)
+}
+
 export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
   const credentials = coerceCredentials(credentialsInput)
   const akeneoBaseUrl = new URL(`${credentials.apiUrl}/`)
@@ -228,6 +252,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
   async function acquirePasswordGrantToken(): Promise<TokenState> {
     const response = await fetch(tokenEndpointUrl, {
       method: 'POST',
+      signal: AbortSignal.timeout(resolveAkeneoRequestTimeoutMs()),
       headers: {
         accept: 'application/json',
         'content-type': 'application/json',
@@ -266,6 +291,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
     if (!current.refreshToken) return acquirePasswordGrantToken()
     const response = await fetch(tokenEndpointUrl, {
       method: 'POST',
+      signal: AbortSignal.timeout(resolveAkeneoRequestTimeoutMs()),
       headers: {
         accept: 'application/json',
         'content-type': 'application/json',
@@ -307,12 +333,14 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
     pathOrUrl: string,
     init: RequestInit = {},
     retried = false,
+    rateLimitAttempts = 0,
   ): Promise<T> {
     const url = resolveAkeneoRequestUrl(pathOrUrl)
     const token = await ensureToken()
 
     const response = await fetch(url, {
       ...init,
+      signal: init.signal ?? AbortSignal.timeout(resolveAkeneoRequestTimeoutMs()),
       headers: {
         accept: 'application/json',
         authorization: `Bearer ${token}`,
@@ -322,13 +350,16 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
 
     if (response.status === 401 && !retried) {
       await ensureToken(true)
-      return request<T>(pathOrUrl, init, true)
+      return request<T>(pathOrUrl, init, true, rateLimitAttempts)
     }
 
     if (response.status === 429) {
-      const retryAfter = Number(response.headers.get('retry-after') ?? '1')
-      await sleep(Number.isFinite(retryAfter) ? retryAfter * 1000 : 1000)
-      return request<T>(pathOrUrl, init, retried)
+      if (rateLimitAttempts >= resolveAkeneoMaxRateLimitRetries()) {
+        const body = await response.text()
+        throw new Error(`Akeneo request failed (429): ${body}`)
+      }
+      await sleep(clampAkeneoRetryAfterMs(response.headers.get('retry-after')))
+      return request<T>(pathOrUrl, init, retried, rateLimitAttempts + 1)
     }
 
     if (!response.ok) {
@@ -347,6 +378,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
     pathOrUrl: string,
     init: RequestInit = {},
     retried = false,
+    rateLimitAttempts = 0,
   ): Promise<{
     buffer: Buffer
     contentType: string | null
@@ -357,6 +389,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
 
     const response = await fetch(url, {
       ...init,
+      signal: init.signal ?? AbortSignal.timeout(resolveAkeneoRequestTimeoutMs()),
       headers: {
         authorization: `Bearer ${token}`,
         ...init.headers,
@@ -365,13 +398,16 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
 
     if (response.status === 401 && !retried) {
       await ensureToken(true)
-      return requestBinary(pathOrUrl, init, true)
+      return requestBinary(pathOrUrl, init, true, rateLimitAttempts)
     }
 
     if (response.status === 429) {
-      const retryAfter = Number(response.headers.get('retry-after') ?? '1')
-      await sleep(Number.isFinite(retryAfter) ? retryAfter * 1000 : 1000)
-      return requestBinary(pathOrUrl, init, retried)
+      if (rateLimitAttempts >= resolveAkeneoMaxRateLimitRetries()) {
+        const body = await response.text()
+        throw new Error(`Akeneo request failed (429): ${body}`)
+      }
+      await sleep(clampAkeneoRetryAfterMs(response.headers.get('retry-after')))
+      return requestBinary(pathOrUrl, init, retried, rateLimitAttempts + 1)
     }
 
     if (!response.ok) {


### PR DESCRIPTION
Fixes #2976

## Problem
Two external HTTP clients let a misbehaving remote server wedge background workers indefinitely:
- **Akeneo** (`packages/sync-akeneo/.../lib/client.ts`) retried `429` responses with **no ceiling** and slept the server-supplied `retry-after` value **unclamped** — a hostile `retry-after: 999999999` parks the worker for ~31 years.
- **Neither** the Akeneo client nor the **Gmail** client (`packages/channel-gmail/.../lib/gmail-client.ts`) attached an `AbortSignal`, so a stalled connection hangs to undici's multi-minute default.

On Akeneo's concurrency-1 first-import queue a single stalled call freezes the entire sync and leaves the run stuck in `running`, so `findRunningOverlap` rejects every subsequent run for that scope until the process restarts. On the Gmail side a stalled connection blocks a poll/history-sync worker slot for up to ~20 min instead of failing in seconds.

## Root Cause
- Akeneo `request()`/`requestBinary()` `429` branches recursed with the retry flag passed through unchanged (no counter) and slept `retryAfter * 1000` with no upper bound.
- All Akeneo `fetch` calls (token, request, binary) and the Gmail `requestJson` `fetch` carried no abort signal.

## What Changed
**Akeneo** (`packages/sync-akeneo/src/modules/sync_akeneo/lib/client.ts`):
- Thread a 429 retry counter through `request`/`requestBinary`; after the cap (default **5**) throw the existing `Akeneo request failed (429)` error.
- Clamp the `retry-after` sleep to a ceiling (default **60s**).
- Attach `AbortSignal.timeout(...)` (default **30s**) to the token, request, and binary fetches.
- All env-overridable: `OM_INTEGRATION_AKENEO_MAX_RATE_LIMIT_RETRIES`, `OM_INTEGRATION_AKENEO_RETRY_AFTER_CAP_MS`, `OM_INTEGRATION_AKENEO_REQUEST_TIMEOUT_MS`.

**Gmail** (`packages/channel-gmail/src/modules/channel_gmail/lib/gmail-client.ts`):
- Attach `AbortSignal.timeout(...)` (default **30s**, `OM_CHANNEL_GMAIL_REQUEST_TIMEOUT_MS`) per attempt.
- Treat `AbortError` as transient so the already-bounded `GMAIL_MAX_RETRIES` loop retries it instead of hanging.

Mirrors the `AbortController` + env-timeout shape already established in `communication_channels/lib/oauth-token.ts`.

## Tests
- **Akeneo** (`__tests__/client.test.ts`, new `resilience` suite): caps 429 retries and surfaces the existing error shape; clamps a hostile `retry-after: 999999999` header to the configured ceiling; attaches an `AbortSignal` to token + authenticated requests.
- **Gmail** (`lib/__tests__/gmail-client.test.ts`): attaches an `AbortSignal` to each request; retries a timed-out (`AbortError`) fetch then succeeds; throws `GmailApiError` after `AbortError`s exhaust the retry budget.
- Full package suites green: `@open-mercato/sync-akeneo` (8 suites / 49 tests), `@open-mercato/channel-gmail` (6 suites / 76 tests).
- Typecheck passes for both packages.

## Backward Compatibility
No contract surface changes. `request`/`requestBinary` are internal closures (additive optional param only); Gmail `requestJson` is private. Existing error shapes (`Akeneo request failed (<status>)`, `GmailApiError`) are reused. New env vars are additive.

## Security impact
Hardens against a remote-controlled denial-of-service: an unbounded retry loop and an attacker-supplied `retry-after` could previously stall a worker effectively forever (logging/throughput/availability impact on sync + inbound-mail workers). Clamping + the retry ceiling convert that into a normal failed run (retryable); per-attempt abort timeouts are operator-tunable via env.