### PR TITLE
security(ai_assistant): fail closed when MCP stdio server has no auth context (#2673)

### DIFF
--- a/packages/ai-assistant/AGENTS.md
+++ b/packages/ai-assistant/AGENTS.md
@@ -1464,6 +1464,18 @@ Agents that need multi-step tool loops configure the `loop` block on `AiAgentDef
 
 ## Changelog
 
+### 2026-06-11 - MCP stdio server fails closed without auth (#2673)
+
+**What changed**:
+- `createMcpServer` / `runMcpServer` (`lib/mcp-server.ts`) no longer silently grant `isSuperAdmin = true` when no auth is supplied. The two fail-open branches (a `context` without a `userId`, and neither `apiKeySecret` nor `context`) now **throw** instead of escalating to an unscoped superadmin.
+- `apiKeySecret` is normalized — an empty / whitespace-only string is treated as missing instead of falling through to the unauthenticated branch.
+- Added an explicit, loud opt-in `McpServerOptions.allowUnauthenticatedSuperadmin` (default off) for local dev/testing. When enabled the server runs as superadmin with a startup `WARNING` log; when off and unauthenticated it refuses to start.
+- `mcp:serve` CLI: `--user` is now effectively required alongside `--tenant`; the legacy "no user → superadmin" behavior is preserved only behind the new `--allow-unauthenticated-superadmin` flag (documented in `--help`).
+
+**Files modified**: `lib/mcp-server.ts`, `lib/types.ts`, `cli.ts`. Regression test: `lib/__tests__/mcp-server-auth-fail-closed.test.ts`.
+
+**Backward compatibility**: `allowUnauthenticatedSuperadmin` is an additive optional field. The only behavior change is that a previously fail-open misconfiguration now fails closed — callers that relied on auth-less superadmin must pass the explicit opt-in.
+
 ### 2026-05-13 - Remove dead `indexApiEndpoints` from MCP boot (#1876)
 
 **What changed**:

--- a/packages/ai-assistant/src/modules/ai_assistant/cli.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/cli.ts
@@ -52,6 +52,9 @@ const mcpServe: ModuleCli = {
     const organizationId = String(args.org ?? args.organizationId ?? '') || null
     const userId = String(args.user ?? args.userId ?? '') || null
     const debug = args.debug === true || args.debug === 'true'
+    const allowUnauthenticatedSuperadmin =
+      args['allow-unauthenticated-superadmin'] === true ||
+      args['allow-unauthenticated-superadmin'] === 'true'
 
     // Either API key or tenant is required
     if (!apiKey && !tenantId) {
@@ -63,14 +66,18 @@ const mcpServe: ModuleCli = {
       console.error('')
       console.error('Options (with --tenant):')
       console.error('  --org <id>           Organization ID (optional)')
-      console.error('  --user <id>          User ID for ACL (optional, uses superadmin if not set)')
+      console.error('  --user <id>          User ID for ACL (required unless --allow-unauthenticated-superadmin is set)')
       console.error('')
       console.error('Common options:')
       console.error('  --debug              Enable debug logging')
+      console.error('  --allow-unauthenticated-superadmin')
+      console.error('                       DEV/TEST ONLY: run as superadmin with no per-user ACL when')
+      console.error('                       no --user (and no --api-key) is supplied. Never use in production.')
       console.error('')
       console.error('Examples:')
       console.error('  mercato ai_assistant mcp:serve --api-key omk_xxxx.yyyy...')
-      console.error('  mercato ai_assistant mcp:serve --tenant 123e4567-e89b-12d3-a456-426614174000')
+      console.error('  mercato ai_assistant mcp:serve --tenant 123e4567-e89b-12d3-a456-426614174000 --user <user-id>')
+      console.error('  mercato ai_assistant mcp:serve --tenant 123e4567-e89b-12d3-a456-426614174000 --allow-unauthenticated-superadmin')
       return
     }
 
@@ -102,6 +109,7 @@ const mcpServe: ModuleCli = {
           organizationId,
           userId,
         },
+        allowUnauthenticatedSuperadmin,
       })
     }
   },

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-server-auth-fail-closed.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-server-auth-fail-closed.test.ts
@@ -1,0 +1,133 @@
+import { createMcpServer } from '../mcp-server'
+import type { McpServerOptions } from '../types'
+
+jest.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
+  Server: class {
+    setRequestHandler() {}
+  },
+}))
+jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: class {},
+}))
+jest.mock('@modelcontextprotocol/sdk/types.js', () => ({
+  ListToolsRequestSchema: {},
+  CallToolRequestSchema: {},
+}))
+jest.mock('../tool-registry', () => ({
+  getToolRegistry: () => ({
+    getTools: () => new Map(),
+    listToolNames: () => [],
+  }),
+}))
+jest.mock('../tool-executor', () => ({ executeTool: jest.fn() }))
+jest.mock('../tool-loader', () => ({
+  loadAllModuleTools: jest.fn(),
+  indexToolsForSearch: jest.fn(),
+}))
+
+const authenticateMcpRequest = jest.fn()
+jest.mock('../auth', () => ({
+  authenticateMcpRequest: (...args: unknown[]) => authenticateMcpRequest(...args),
+  hasRequiredFeatures: jest.fn(() => true),
+}))
+
+const loadAcl = jest.fn()
+
+function makeContainer() {
+  return {
+    resolve: (name: string) => {
+      if (name === 'rbacService') return { loadAcl }
+      return {}
+    },
+  } as unknown as McpServerOptions['container']
+}
+
+function baseOptions(overrides: Partial<McpServerOptions>): McpServerOptions {
+  return {
+    config: { name: 'test-mcp', version: '0.0.0', debug: false },
+    container: makeContainer(),
+    ...overrides,
+  } as McpServerOptions
+}
+
+describe('issue #2673 — MCP stdio server must fail closed without auth', () => {
+  beforeEach(() => {
+    authenticateMcpRequest.mockReset()
+    loadAcl.mockReset()
+    loadAcl.mockResolvedValue({ isSuperAdmin: false, features: ['ai_assistant.view'] })
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('throws when neither apiKeySecret nor context is supplied', async () => {
+    await expect(createMcpServer(baseOptions({}))).rejects.toThrow(
+      /refused to start: no authentication/i,
+    )
+    expect(loadAcl).not.toHaveBeenCalled()
+  })
+
+  it('throws when context lacks a userId (the mcp:serve --tenant-without-user path)', async () => {
+    await expect(
+      createMcpServer(
+        baseOptions({ context: { tenantId: 't1', organizationId: 'o1', userId: null } }),
+      ),
+    ).rejects.toThrow(/refused to start: no authentication/i)
+    expect(loadAcl).not.toHaveBeenCalled()
+  })
+
+  it('treats an empty-string apiKeySecret as missing and fails closed', async () => {
+    await expect(createMcpServer(baseOptions({ apiKeySecret: '' }))).rejects.toThrow(
+      /refused to start: no authentication/i,
+    )
+    expect(authenticateMcpRequest).not.toHaveBeenCalled()
+  })
+
+  it('treats a whitespace-only apiKeySecret as missing and fails closed', async () => {
+    await expect(createMcpServer(baseOptions({ apiKeySecret: '   ' }))).rejects.toThrow(
+      /refused to start: no authentication/i,
+    )
+    expect(authenticateMcpRequest).not.toHaveBeenCalled()
+  })
+
+  it('loads the real user ACL when context carries a non-empty userId', async () => {
+    const server = await createMcpServer(
+      baseOptions({ context: { tenantId: 't1', organizationId: 'o1', userId: 'u1' } }),
+    )
+    expect(server).toBeDefined()
+    expect(loadAcl).toHaveBeenCalledWith('u1', { tenantId: 't1', organizationId: 'o1' })
+  })
+
+  it('allows unauthenticated superadmin only behind the explicit opt-in, without loading an ACL', async () => {
+    const server = await createMcpServer(
+      baseOptions({
+        context: { tenantId: 't1', organizationId: 'o1', userId: null },
+        allowUnauthenticatedSuperadmin: true,
+      }),
+    )
+    expect(server).toBeDefined()
+    expect(loadAcl).not.toHaveBeenCalled()
+  })
+
+  it('allows fully unauthenticated superadmin behind the opt-in with no context', async () => {
+    const server = await createMcpServer(baseOptions({ allowUnauthenticatedSuperadmin: true }))
+    expect(server).toBeDefined()
+  })
+
+  it('still authenticates via a valid apiKeySecret', async () => {
+    authenticateMcpRequest.mockResolvedValue({
+      success: true,
+      tenantId: 't1',
+      organizationId: 'o1',
+      userId: 'u1',
+      features: ['ai_assistant.view'],
+      isSuperAdmin: false,
+      keyName: 'test-key',
+    })
+    const server = await createMcpServer(baseOptions({ apiKeySecret: 'omk_valid.secret' }))
+    expect(server).toBeDefined()
+    expect(authenticateMcpRequest).toHaveBeenCalledWith('omk_valid.secret', expect.anything())
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-server.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-server.ts
@@ -17,7 +17,14 @@ import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacS
  * Create and configure an MCP server instance.
  */
 export async function createMcpServer(options: McpServerOptions): Promise<Server> {
-  const { config, container, context, apiKeySecret } = options
+  const { config, container, context, allowUnauthenticatedSuperadmin } = options
+
+  // Treat empty / whitespace-only secrets as missing so a blank api key cannot
+  // fall through into an unauthenticated branch.
+  const apiKeySecret =
+    typeof options.apiKeySecret === 'string' && options.apiKeySecret.trim().length > 0
+      ? options.apiKeySecret
+      : undefined
 
   let tenantId: string | null = null
   let organizationId: string | null = null
@@ -37,41 +44,48 @@ export async function createMcpServer(options: McpServerOptions): Promise<Server
     userFeatures = authResult.features
     isSuperAdmin = authResult.isSuperAdmin
     console.error(`[MCP Server] Authenticated via API key: ${authResult.keyName}`)
-  } else if (context) {
-    // Manual context provided
+  } else if (context && context.userId) {
+    // Manual context with a real user — load that user's ACL.
     tenantId = context.tenantId
     organizationId = context.organizationId
     userId = context.userId
 
-    if (userId) {
-      try {
-        const rbacService = container.resolve('rbacService') as {
-          loadAcl: (
-            userId: string,
-            scope: { tenantId: string | null; organizationId: string | null }
-          ) => Promise<{
-            isSuperAdmin: boolean
-            features: string[]
-          }>
-        }
-        const acl = await rbacService.loadAcl(userId, {
-          tenantId,
-          organizationId,
-        })
-        userFeatures = acl.features
-        isSuperAdmin = acl.isSuperAdmin
-      } catch (error) {
-        console.error('[MCP Server] Failed to load user ACL:', error)
+    try {
+      const rbacService = container.resolve('rbacService') as {
+        loadAcl: (
+          userId: string,
+          scope: { tenantId: string | null; organizationId: string | null }
+        ) => Promise<{
+          isSuperAdmin: boolean
+          features: string[]
+        }>
       }
-    } else {
-      // No user specified - grant superadmin access for development/testing
-      isSuperAdmin = true
-      console.error('[MCP Server] No user specified, running with superadmin access')
+      const acl = await rbacService.loadAcl(userId, {
+        tenantId,
+        organizationId,
+      })
+      userFeatures = acl.features
+      isSuperAdmin = acl.isSuperAdmin
+    } catch (error) {
+      console.error('[MCP Server] Failed to load user ACL:', error)
     }
-  } else {
-    // No context and no API key - superadmin for dev/testing
+  } else if (allowUnauthenticatedSuperadmin) {
+    // Explicit, loud dev/testing opt-in. Without a user there is no ACL to load,
+    // so the server runs as superadmin with no tenant scoping beyond whatever the
+    // caller pinned via `context`. NEVER enable this in production.
+    if (context) {
+      tenantId = context.tenantId
+      organizationId = context.organizationId
+    }
     isSuperAdmin = true
-    console.error('[MCP Server] No auth context, running with superadmin access')
+    console.error(
+      '[MCP Server] WARNING: allowUnauthenticatedSuperadmin is enabled — running with UNAUTHENTICATED SUPERADMIN access and no per-user ACL. Do not use this outside local development/testing.'
+    )
+  } else {
+    // Fail closed: refuse to start rather than silently escalating to superadmin.
+    throw new Error(
+      '[internal] MCP server refused to start: no authentication provided. Supply a valid apiKeySecret, a context with a non-empty userId, or explicitly set allowUnauthenticatedSuperadmin: true for local development.'
+    )
   }
 
   const toolContext: McpToolContext = {
@@ -200,14 +214,14 @@ export async function runMcpServer(options: McpServerOptions): Promise<void> {
 
   console.error(`[MCP Server] Starting ${options.config.name} v${options.config.version}`)
 
-  if (options.apiKeySecret) {
+  if (options.apiKeySecret && options.apiKeySecret.trim().length > 0) {
     console.error(`[MCP Server] Authentication: API key`)
-  } else if (options.context) {
+  } else if (options.context && options.context.userId) {
     console.error(`[MCP Server] Tenant: ${options.context.tenantId ?? '(none)'}`)
     console.error(`[MCP Server] Organization: ${options.context.organizationId ?? '(none)'}`)
-    console.error(`[MCP Server] User: ${options.context.userId ?? '(superadmin)'}`)
+    console.error(`[MCP Server] User: ${options.context.userId}`)
   } else {
-    console.error(`[MCP Server] Authentication: none (superadmin mode)`)
+    console.error(`[MCP Server] Authentication: none (unauthenticated superadmin opt-in)`)
   }
 
   console.error(`[MCP Server] Tools registered: ${toolCount}`)

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/types.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/types.ts
@@ -217,6 +217,13 @@ export interface McpServerOptions {
   }
   /** API key secret for authentication (alternative to manual context) */
   apiKeySecret?: string
+  /**
+   * Explicit, loud opt-in for running without authentication as a superadmin
+   * (development/testing only). When false/unset and no `apiKeySecret` or
+   * `context.userId` is supplied, the server fails closed and refuses to start
+   * instead of silently escalating to superadmin. NEVER enable in production.
+   */
+  allowUnauthenticatedSuperadmin?: boolean
 }
 
 /**


### PR DESCRIPTION
Fixes #2673

## Problem
`createMcpServer` / `runMcpServer` (`packages/ai-assistant/src/modules/ai_assistant/lib/mcp-server.ts`) silently granted `isSuperAdmin = true` with an empty feature set and no tenant scoping in three fail-open paths:
- a `context` supplied without a `userId` (e.g. `mcp:serve --tenant <id>` without `--user`, which passes `userId: null`);
- neither `apiKeySecret` nor `context` supplied;
- `apiKeySecret = ''` (the truthiness guard let an empty string fall through to the fail-open branch).

Because `runMcpServer` is public package API, a misconfigured/auth-less invocation escalated to superadmin and exposed every registered tool with no tenant/organization scoping (`isSuperAdmin` short-circuits the per-tool ACL filter).

## Root Cause
Fail-open auth design: the `else` branches defaulted to superadmin instead of refusing to start.

## What Changed
- **Fail closed by default**: throw an explicit error unless a valid `apiKeySecret` or a `context` with a non-empty `userId` is supplied.
- **Normalize `apiKeySecret`**: empty / whitespace-only is treated as missing instead of falling through.
- **Explicit dev/test opt-in**: new additive optional `McpServerOptions.allowUnauthenticatedSuperadmin` (default off) re-enables unauthenticated-superadmin mode with a loud startup `WARNING` log.
- **CLI**: `mcp:serve` now effectively requires `--user` with `--tenant`; the legacy auth-less superadmin behavior is preserved only behind a new `--allow-unauthenticated-superadmin` flag (documented in `--help`).
- Updated the module AGENTS.md changelog.

## Tests
- New `lib/__tests__/mcp-server-auth-fail-closed.test.ts` (8 cases): throws on no-auth, on `userId: null` context, on empty / whitespace `apiKeySecret`; loads the real ACL for a non-empty `userId`; allows superadmin only behind the opt-in (with/without context) and without calling `loadAcl`; still authenticates a valid `apiKeySecret`.
- Full `ai_assistant` lib suite green (50 suites / 763 tests). Package build green.

## Security impact
Closes a privilege-escalation / missing-tenant-scoping fail-open in a public package API. Default behavior is now fail-closed; unauthenticated superadmin requires an explicit, logged opt-in. No data migration; the only behavioral change is that a previously fail-open misconfiguration now refuses to start.

## Backward Compatibility
`allowUnauthenticatedSuperadmin` is an additive optional field — no contract surface removed. Callers that relied on auth-less superadmin must pass the explicit opt-in (or `--allow-unauthenticated-superadmin`).