### PR TITLE
security(shared/encryption): self-heal HashicorpVaultKmsService instead of staying unhealthy for the instance lifetime (#2661)

### DIFF
--- a/packages/shared/src/lib/encryption/__tests__/kms.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/kms.test.ts
@@ -126,3 +126,83 @@ describe('kms timeout handling', () => {
     expect(dek?.key).toBeTruthy()
   })
 })
+
+describe('kms self-healing circuit breaker (#2661)', () => {
+  const vaultAddr = 'http://vault.test'
+  const vaultToken = 'token'
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    jest.restoreAllMocks()
+  })
+
+  it('re-probes Vault and recovers after the cooldown window instead of staying unhealthy forever', async () => {
+    let clock = 1_000_000
+    jest.spyOn(Date, 'now').mockImplementation(() => clock)
+
+    let calls = 0
+    const fetchMock = jest.fn(() => {
+      calls += 1
+      if (calls === 1) {
+        // First read hits a transient 5xx (Vault hiccup) → breaker opens.
+        return Promise.resolve({ ok: false, status: 503, json: async () => ({}) })
+      }
+      // Vault is back: subsequent reads succeed.
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ data: { data: { key: 'recovered-key' } } }) })
+    })
+    ;(globalThis as { fetch?: typeof fetch }).fetch = fetchMock as typeof fetch
+
+    const service = new HashicorpVaultKmsService({ vaultAddr, vaultToken, recoveryCooldownMs: 5_000 })
+
+    // Transient failure flips the instance unhealthy.
+    await expect(service.getTenantDek('tenant-1')).resolves.toBeNull()
+    expect(service.isHealthy()).toBe(false)
+
+    // Still within the cooldown: the breaker stays open.
+    clock += 4_000
+    expect(service.isHealthy()).toBe(false)
+
+    // Past the cooldown: half-open — report healthy so the next call re-probes.
+    clock += 2_000
+    expect(service.isHealthy()).toBe(true)
+
+    // The re-probe succeeds and the breaker fully closes (the never-recover bug).
+    const dek = await service.getTenantDek('tenant-1')
+    expect(dek?.key).toBe('recovered-key')
+    expect(service.isHealthy()).toBe(true)
+  })
+
+  it('treats missing VAULT_ADDR/VAULT_TOKEN as a terminal failure that never self-heals', () => {
+    let clock = 2_000_000
+    jest.spyOn(Date, 'now').mockImplementation(() => clock)
+
+    const service = new HashicorpVaultKmsService({ vaultAddr: '', vaultToken: '', recoveryCooldownMs: 5_000 })
+    expect(service.isHealthy()).toBe(false)
+
+    // No cooldown re-probe should ever revive a misconfigured instance.
+    clock += 10_000_000
+    expect(service.isHealthy()).toBe(false)
+  })
+
+  it('keeps Vault healthy on a 404 read so read-before-write DEK creation can proceed', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(3_000_000)
+
+    const fetchMock = jest.fn((_url: string, init?: RequestInit) => {
+      const method = (init?.method || 'GET').toUpperCase()
+      if (method === 'GET') {
+        // KV v2 returns 404 for a not-yet-created tenant key — Vault is reachable.
+        return Promise.resolve({ ok: false, status: 404, json: async () => ({}) })
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({}) })
+    })
+    ;(globalThis as { fetch?: typeof fetch }).fetch = fetchMock as typeof fetch
+
+    const service = new HashicorpVaultKmsService({ vaultAddr, vaultToken })
+
+    const dek = await service.createTenantDek('tenant-2')
+    expect(typeof dek?.key).toBe('string')
+    expect(dek?.key).toBeTruthy()
+    expect(service.isHealthy()).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2) // 404 read probe + the write
+  })
+})

--- a/packages/shared/src/lib/encryption/kms.ts
+++ b/packages/shared/src/lib/encryption/kms.ts
@@ -5,11 +5,18 @@ import { parseBooleanToken } from '../boolean'
 import { fetchWithTimeout, resolveTimeoutMs } from '../http/fetchWithTimeout'
 
 const DEFAULT_VAULT_REQUEST_TIMEOUT_MS = 1_000
+const DEFAULT_VAULT_RECOVERY_COOLDOWN_MS = 30_000
 
 function resolveVaultRequestTimeoutMs(): number {
   const raw = process.env.VAULT_REQUEST_TIMEOUT_MS
   const parsed = raw ? Number.parseInt(raw, 10) : undefined
   return resolveTimeoutMs(parsed, DEFAULT_VAULT_REQUEST_TIMEOUT_MS)
+}
+
+function resolveVaultRecoveryCooldownMs(): number {
+  const raw = process.env.VAULT_RECOVERY_COOLDOWN_MS
+  const parsed = raw ? Number.parseInt(raw, 10) : undefined
+  return resolveTimeoutMs(parsed, DEFAULT_VAULT_RECOVERY_COOLDOWN_MS)
 }
 
 export type TenantDek = {
@@ -90,6 +97,7 @@ type VaultClientOpts = {
   mountPath?: string
   ttlMs?: number
   requestTimeoutMs?: number
+  recoveryCooldownMs?: number
 }
 
 type VaultReadResponse = {
@@ -166,7 +174,16 @@ export class HashicorpVaultKmsService implements KmsService {
   private readonly mountPath: string
   private readonly ttlMs: number
   private readonly requestTimeoutMs: number
+  private readonly recoveryCooldownMs: number
   private healthy = true
+  // Sticky terminal failure (missing VAULT_ADDR/VAULT_TOKEN): no amount of
+  // re-probing fixes a misconfiguration, so this never self-heals — only a
+  // restart with corrected config does.
+  private misconfigured = false
+  // Timestamp of the last transient failure (timeout / network blip / 5xx).
+  // Drives the half-open circuit breaker in isHealthy(): after the cooldown the
+  // instance reports healthy again so the next call re-probes Vault.
+  private lastTransientFailureAt: number | null = null
   private readonly debugEnabled: boolean
   private static loggedInit = false
 
@@ -176,9 +193,11 @@ export class HashicorpVaultKmsService implements KmsService {
     this.mountPath = (opts.mountPath || process.env.VAULT_KV_PATH || 'secret/data').replace(/\/+$/, '')
     this.ttlMs = opts.ttlMs ?? 15 * 60 * 1000
     this.requestTimeoutMs = resolveTimeoutMs(opts.requestTimeoutMs, resolveVaultRequestTimeoutMs())
+    this.recoveryCooldownMs = resolveTimeoutMs(opts.recoveryCooldownMs, resolveVaultRecoveryCooldownMs())
     this.debugEnabled = isEncryptionDebugEnabled()
     if (!this.vaultAddr || !this.vaultToken) {
       this.healthy = false
+      this.misconfigured = true
       if (this.debugEnabled) {
         console.warn('⚠️ [encryption][kms] Vault misconfigured (missing VAULT_ADDR or VAULT_TOKEN)')
       }
@@ -192,11 +211,32 @@ export class HashicorpVaultKmsService implements KmsService {
   }
 
   isHealthy(): boolean {
-    return this.healthy
+    // A missing-config failure is terminal — never report healthy again.
+    if (this.misconfigured) return false
+    if (this.healthy) return true
+    // Half-open circuit breaker: once the cooldown since the last transient
+    // failure has elapsed, report healthy so the next read/write re-probes
+    // Vault. A successful probe flips `healthy` back on; a failing one records a
+    // fresh failure timestamp and re-opens the breaker for another cooldown.
+    if (this.lastTransientFailureAt === null) return false
+    return this.now() - this.lastTransientFailureAt >= this.recoveryCooldownMs
   }
 
   private now(): number {
     return Date.now()
+  }
+
+  // Vault responded successfully (or is provably reachable): close the breaker.
+  private markHealthy(): void {
+    this.healthy = true
+    this.lastTransientFailureAt = null
+  }
+
+  // Transient infra failure (timeout / network blip / 5xx): open the breaker and
+  // start the recovery cooldown so a later call can re-probe and self-heal.
+  private markTransientFailure(): void {
+    this.healthy = false
+    this.lastTransientFailureAt = this.now()
   }
 
   private cacheHit(tenantId: string): TenantDek | null {
@@ -212,6 +252,7 @@ export class HashicorpVaultKmsService implements KmsService {
   private async readVault(path: string): Promise<VaultReadResponse | null> {
     if (!this.vaultAddr || !this.vaultToken) {
       this.healthy = false
+      this.misconfigured = true
       return null
     }
     try {
@@ -221,16 +262,21 @@ export class HashicorpVaultKmsService implements KmsService {
         timeoutMs: this.requestTimeoutMs,
       })
       if (!res.ok) {
-        this.healthy = res.status < 500
+        // 5xx = Vault down/erroring (transient). <500 (auth/not-found/etc.) means
+        // Vault is reachable and answered, so keep it healthy — a 404 for a
+        // not-yet-created tenant DEK is the normal read-before-write path.
+        if (res.status >= 500) this.markTransientFailure()
+        else this.markHealthy()
         console.warn('⚠️ [encryption][kms] Vault read failed', { path, status: res.status })
         return null
       }
+      this.markHealthy()
       if (this.debugEnabled) {
         console.info('🔍 [encryption][kms] Vault read ok', { path })
       }
       return (await res.json()) as VaultReadResponse
     } catch (err) {
-      this.healthy = false
+      this.markTransientFailure()
       console.warn('⚠️ [encryption][kms] Vault read error', {
         path,
         error: (err as Error)?.message || String(err),
@@ -243,6 +289,7 @@ export class HashicorpVaultKmsService implements KmsService {
   private async writeVault(path: string, key: string, opts?: { cas?: number }): Promise<VaultWriteOutcome> {
     if (!this.vaultAddr || !this.vaultToken) {
       this.healthy = false
+      this.misconfigured = true
       return 'error'
     }
     const body: { data: { key: string }; options?: { cas: number } } = { data: { key } }
@@ -258,21 +305,22 @@ export class HashicorpVaultKmsService implements KmsService {
         timeoutMs: this.requestTimeoutMs,
       })
       if (res.ok) {
-        this.healthy = true
+        this.markHealthy()
         return 'ok'
       }
       // KV v2 returns 400 when a check-and-set write loses to a concurrent
       // writer (path already at a newer version). That is a normal race outcome,
-      // not an unhealthy Vault — don't flip `healthy`.
+      // not an unhealthy Vault — Vault is reachable, so close the breaker.
       if (typeof opts?.cas === 'number' && res.status === 400) {
+        this.markHealthy()
         console.warn('⚠️ [encryption][kms] Vault write CAS conflict (concurrent DEK create)', { path, status: res.status })
         return 'conflict'
       }
-      this.healthy = false
+      this.markTransientFailure()
       console.warn('⚠️ [encryption][kms] Vault write failed', { path, status: res.status })
       return 'error'
     } catch (err) {
-      this.healthy = false
+      this.markTransientFailure()
       console.warn('⚠️ [encryption][kms] Vault write error', {
         path,
         error: (err as Error)?.message || String(err),


### PR DESCRIPTION
Fixes #2661

## Problem
`HashicorpVaultKmsService` set `this.healthy = false` on the first Vault error (throw / timeout / network blip / 5xx) with **no resurrection mechanism** — it never re-probed, retried, or reset back to `true`. Combined with the fail-open encryption path (`encryptEntityPayload` returns plaintext when `!isEnabled()`, and `isEnabled()` ANDs `kms.isHealthy()`), a single transient Vault hiccup silently downgraded **all new writes for the lifetime of that KMS instance** to plaintext, with only one `console.warn` as the signal. Long-lived workers/subscribers with reused EMs made this especially damaging.

## Root Cause
`isHealthy()` only read the `healthy` field; nothing ever re-probed Vault or reset it. There was no distinction between a *transient* failure (recoverable) and a *terminal* misconfiguration (missing `VAULT_ADDR`/`VAULT_TOKEN`), and successful reads never restored health.

## What Changed
`packages/shared/src/lib/encryption/kms.ts` — added a half-open circuit breaker to `HashicorpVaultKmsService`:

- **Distinguish terminal vs transient.** Missing `VAULT_ADDR`/`VAULT_TOKEN` sets a sticky `misconfigured` flag that never self-heals (only a restart with corrected config fixes it). Timeout / network / 5xx are treated as transient.
- **Self-heal after a cooldown.** A transient failure records `lastTransientFailureAt`. Once `VAULT_RECOVERY_COOLDOWN_MS` (default 30s, env-overridable) elapses, `isHealthy()` reports healthy again so the next read/write re-probes Vault. A successful probe fully closes the breaker; a failing one re-opens it for another cooldown.
- **Reads and reachable responses heal too.** A successful read — and a CAS-conflict write (400), which proves Vault is reachable — now close the breaker. A 404 read (not-yet-created tenant DEK) keeps Vault healthy so the read-before-write DEK creation path still works.

This bounds the plaintext-downgrade window from the entire instance lifetime down to a single cooldown interval, and lets long-lived processes recover without a restart.

### Scope note
This fixes the never-recover root cause named in the issue title (recommendations #1 and #2). Recommendation #3 — converting the broader fail-open encryption path to **fail-closed** and adding durable alerting (audit row / metric / error-level log on every skipped encryption) — is a separate behavioral/contract change with wider blast radius and is intentionally left as a follow-up rather than bundled here.

## Tests
`packages/shared/src/lib/encryption/__tests__/kms.test.ts`:
- **re-probes and recovers after the cooldown window** — drives a transient 5xx → unhealthy, asserts still-unhealthy before cooldown, half-open (healthy) after cooldown, and full recovery on the next successful read. **Fails on the pre-fix code, passes after.**
- **terminal misconfig never self-heals** — missing addr/token stays unhealthy even after a long cooldown.
- **404 read keeps Vault healthy** — locks in the read-before-write DEK creation path.
- Existing `marks Vault unhealthy after a timed out write` still holds (cooldown not yet elapsed).

Checks run: full encryption suite (60 tests) green; all 1223 shared unit tests pass; `tsc --noEmit` on `@open-mercato/shared` → 0 errors.

## Backward Compatibility
Additive only. New optional internal constructor opt (`recoveryCooldownMs`) and new optional env var `VAULT_RECOVERY_COOLDOWN_MS` (default 30s). No exported type, method signature, event ID, DI name, or import path changed. The only behavior change is the intended one: the KMS instance now self-heals from transient failures instead of staying unhealthy forever.