### PR TITLE
fix(events): memoize persistent-events BullMQ producer process-wide to stop per-request Redis connection leaks (#2959)

### DIFF
--- a/packages/events/src/__tests__/shared-producer.test.ts
+++ b/packages/events/src/__tests__/shared-producer.test.ts
@@ -1,0 +1,97 @@
+const createQueueMock = jest.fn()
+
+jest.mock('@open-mercato/queue', () => ({
+  createQueue: (...args: unknown[]) => createQueueMock(...args),
+}))
+
+import { createEventBus } from '@open-mercato/events/index'
+
+const PRODUCER_QUEUE_KEY = '__openMercatoEventsProducerQueues__'
+const PRODUCER_SHUTDOWN_KEY = '__openMercatoEventsProducerShutdown__'
+
+function makeFakeQueue(id: number) {
+  return {
+    id,
+    name: 'events',
+    strategy: 'async' as const,
+    enqueue: jest.fn(async () => `job-${id}`),
+    clear: jest.fn(async () => ({ removed: 0 })),
+    close: jest.fn(async () => {}),
+    process: jest.fn(),
+    getJobCounts: jest.fn(),
+  }
+}
+
+describe('persistent-events producer memoization (#2959)', () => {
+  const resolve = ((name: string) => name) as never
+
+  beforeEach(() => {
+    createQueueMock.mockReset()
+    let created = 0
+    createQueueMock.mockImplementation(() => makeFakeQueue(created++))
+    delete (globalThis as Record<string, unknown>)[PRODUCER_QUEUE_KEY]
+    delete (globalThis as Record<string, unknown>)[PRODUCER_SHUTDOWN_KEY]
+    process.env.REDIS_URL = 'redis://localhost:6379'
+    delete process.env.OM_EVENTS_SHARED_PRODUCER
+  })
+
+  afterEach(() => {
+    delete process.env.REDIS_URL
+    delete process.env.OM_EVENTS_SHARED_PRODUCER
+    delete (globalThis as Record<string, unknown>)[PRODUCER_QUEUE_KEY]
+    delete (globalThis as Record<string, unknown>)[PRODUCER_SHUTDOWN_KEY]
+  })
+
+  test('async strategy reuses a single process-wide producer across buses', async () => {
+    const busA = createEventBus({ resolve, queueStrategy: 'async' })
+    const busB = createEventBus({ resolve, queueStrategy: 'async' })
+
+    await busA.emit('demo.event.happened', { id: 1 }, { persistent: true })
+    await busB.emit('demo.event.happened', { id: 2 }, { persistent: true })
+
+    // The leak fix: only one producer queue (one Redis connection) is created
+    // even though two separate request-scoped buses emitted persistent events.
+    expect(createQueueMock).toHaveBeenCalledTimes(1)
+
+    const registry = (globalThis as Record<string, unknown>)[PRODUCER_QUEUE_KEY] as Map<string, { enqueue: jest.Mock }>
+    expect(registry.size).toBe(1)
+    const shared = [...registry.values()][0]
+    expect(shared.enqueue).toHaveBeenCalledTimes(2)
+  })
+
+  test('kill switch OM_EVENTS_SHARED_PRODUCER=0 restores per-bus producers', async () => {
+    process.env.OM_EVENTS_SHARED_PRODUCER = '0'
+    const busA = createEventBus({ resolve, queueStrategy: 'async' })
+    const busB = createEventBus({ resolve, queueStrategy: 'async' })
+
+    await busA.emit('demo.event.happened', { id: 1 }, { persistent: true })
+    await busB.emit('demo.event.happened', { id: 2 }, { persistent: true })
+
+    expect(createQueueMock).toHaveBeenCalledTimes(2)
+    expect((globalThis as Record<string, unknown>)[PRODUCER_QUEUE_KEY]).toBeUndefined()
+  })
+
+  test('separate Redis URLs get separate producers', async () => {
+    const busA = createEventBus({ resolve, queueStrategy: 'async' })
+    await busA.emit('demo.event.happened', { id: 1 }, { persistent: true })
+
+    process.env.REDIS_URL = 'redis://other-host:6379'
+    const busB = createEventBus({ resolve, queueStrategy: 'async' })
+    await busB.emit('demo.event.happened', { id: 2 }, { persistent: true })
+
+    expect(createQueueMock).toHaveBeenCalledTimes(2)
+    const registry = (globalThis as Record<string, unknown>)[PRODUCER_QUEUE_KEY] as Map<string, unknown>
+    expect(registry.size).toBe(2)
+  })
+
+  test('local strategy is not memoized (no pooled connection to share)', async () => {
+    const busA = createEventBus({ resolve, queueStrategy: 'local' })
+    const busB = createEventBus({ resolve, queueStrategy: 'local' })
+
+    await busA.emit('demo.event.happened', { id: 1 }, { persistent: true })
+    await busB.emit('demo.event.happened', { id: 2 }, { persistent: true })
+
+    expect(createQueueMock).toHaveBeenCalledTimes(2)
+    expect((globalThis as Record<string, unknown>)[PRODUCER_QUEUE_KEY]).toBeUndefined()
+  })
+})

--- a/packages/events/src/bus.ts
+++ b/packages/events/src/bus.ts
@@ -1,5 +1,6 @@
 import { createQueue } from '@open-mercato/queue'
 import type { Queue } from '@open-mercato/queue'
+import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import { matchEventPattern } from '@open-mercato/shared/lib/events/patterns'
 import { getRedisUrlOrThrow } from '@open-mercato/shared/lib/redis/connection'
 import { isBroadcastEvent } from '@open-mercato/shared/modules/events'
@@ -50,6 +51,46 @@ type EventJobData = {
   options?: EmitOptions
 }
 
+// Process-wide cache of the async (BullMQ) persistent-events producer queue.
+// Each authenticated request builds a fresh DI container and event bus, so a
+// per-bus producer queue opened a new ioredis connection per write request that
+// was never closed — leaking one Redis connection per request until maxclients
+// exhaustion. Memoizing the producer on `globalThis` (keyed by Redis URL, so a
+// reconfigured URL still gets its own queue) keeps it at one connection per
+// process, mirroring the `GLOBAL_EVENT_TAPS_KEY` and `getCachedRateLimiterService`
+// patterns. The local (file-based) strategy holds no pooled connection and its
+// base dir is cwd-relative, so it stays per-bus.
+const EVENTS_PRODUCER_QUEUE_KEY = '__openMercatoEventsProducerQueues__'
+const EVENTS_PRODUCER_SHUTDOWN_KEY = '__openMercatoEventsProducerShutdown__'
+
+function isSharedProducerEnabled(): boolean {
+  return parseBooleanWithDefault(process.env.OM_EVENTS_SHARED_PRODUCER, true)
+}
+
+function getProducerQueueRegistry(): Map<string, Queue<EventJobData>> {
+  const existing = (globalThis as Record<string, unknown>)[EVENTS_PRODUCER_QUEUE_KEY]
+  if (existing instanceof Map) {
+    return existing as Map<string, Queue<EventJobData>>
+  }
+  const created = new Map<string, Queue<EventJobData>>()
+  ;(globalThis as Record<string, unknown>)[EVENTS_PRODUCER_QUEUE_KEY] = created
+  return created
+}
+
+function registerProducerShutdownHook(): void {
+  if ((globalThis as Record<string, unknown>)[EVENTS_PRODUCER_SHUTDOWN_KEY]) return
+  const shutdown = () => {
+    const registry = getProducerQueueRegistry()
+    for (const sharedQueue of registry.values()) {
+      Promise.resolve(sharedQueue.close()).catch(() => {})
+    }
+    registry.clear()
+  }
+  process.once('SIGTERM', shutdown)
+  process.once('SIGINT', shutdown)
+  ;(globalThis as Record<string, unknown>)[EVENTS_PRODUCER_SHUTDOWN_KEY] = true
+}
+
 /**
  * Creates an event bus instance.
  *
@@ -93,16 +134,36 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
 
   /**
    * Gets or creates the queue instance for persistent events.
+   *
+   * The async (BullMQ) producer is memoized process-wide so the per-request
+   * event bus reuses one Redis connection instead of leaking one per write
+   * request. The local strategy stays per-bus (no pooled connection, cwd-relative
+   * base dir). Set `OM_EVENTS_SHARED_PRODUCER=0` to fall back to per-bus producers.
    */
   function getQueue(): Queue<EventJobData> {
-    if (!queue) {
-      queue = queueStrategy === 'async'
-        ? createQueue<EventJobData>(EVENTS_QUEUE_NAME, 'async', {
-            connection: { url: getRedisUrlOrThrow('QUEUE') },
-          })
-        : createQueue<EventJobData>(EVENTS_QUEUE_NAME, 'local')
+    if (queueStrategy !== 'async' || !isSharedProducerEnabled()) {
+      if (!queue) {
+        queue = queueStrategy === 'async'
+          ? createQueue<EventJobData>(EVENTS_QUEUE_NAME, 'async', {
+              connection: { url: getRedisUrlOrThrow('QUEUE') },
+            })
+          : createQueue<EventJobData>(EVENTS_QUEUE_NAME, 'local')
+      }
+      return queue
     }
-    return queue
+
+    const redisUrl = getRedisUrlOrThrow('QUEUE')
+    const registry = getProducerQueueRegistry()
+    const cacheKey = `async:${redisUrl}`
+    let shared = registry.get(cacheKey)
+    if (!shared) {
+      shared = createQueue<EventJobData>(EVENTS_QUEUE_NAME, 'async', {
+        connection: { url: redisUrl },
+      })
+      registry.set(cacheKey, shared)
+      registerProducerShutdownHook()
+    }
+    return shared
   }
 
   /**


### PR DESCRIPTION
Fixes #2959

## Problem
With `QUEUE_STRATEGY=async` (what Railway deploys bake in), every authenticated request builds a fresh DI container and runs `bootstrap()` (the Phase-5 bootstrap cache is default OFF), which constructs a brand-new event bus per request. The bus cached its persistent-events BullMQ `Queue` only in a per-instance closure (`packages/events/src/bus.ts:92`), so the first persistent emit on each request opened a new ioredis connection that was never closed. Because nearly every CRUD and custom-field write emits a persistent event, the process leaked one Redis connection per write request until `maxclients`/FD exhaustion took down the queue, cache, and rate limiter together.

## Root Cause
The producer `Queue` lifetime was bound to the per-request bus instead of the process. There was no `close()` on the bus and no process-wide memoization, so the connection could never be released and a new one was created on each request.

## What Changed
- `packages/events/src/bus.ts`: memoize the **async** producer `Queue` on `globalThis`, keyed by `async:<redisUrl>` (so a reconfigured Redis URL still gets its own queue), mirroring the existing `GLOBAL_EVENT_TAPS_KEY` and `getCachedRateLimiterService()` patterns — including a once-registered `SIGTERM`/`SIGINT` hook that closes the shared producer(s) on shutdown.
- The **local** (file-based) strategy is intentionally left per-bus: it holds no pooled connection and its base dir is cwd-relative, so sharing it would be wrong (and would break the cwd-isolated local tests).
- Gated behind `OM_EVENTS_SHARED_PRODUCER` (default **on**; set to `0`/`off`/`false`/`no` to restore the previous per-bus behavior as a fast escape hatch).
- Per the issue, `createAsyncQueue` is **not** memoized wholesale (the worker runner reuses that factory and manages queue lifecycle); only the events producer in `bus.ts` is shared. The search-indexing producer queues are an explicit optional follow-up and are not touched here.

## Tests
- New `packages/events/src/__tests__/shared-producer.test.ts` (4 tests): async strategy reuses a single process-wide producer across two request-scoped buses (createQueue called once, not twice); the `OM_EVENTS_SHARED_PRODUCER=0` kill switch restores per-bus producers; distinct Redis URLs get distinct producers; the local strategy is not memoized.
- Full events suite: 36/36 pass. Full repo `yarn typecheck`: 21/21 pass. `yarn generate` + `yarn build:packages`: pass. (The full monorepo `yarn test` / `yarn build:app` were not run end-to-end; the change is isolated to `packages/events`, additive, and behind a kill switch.)

## Backward Compatibility
- No contract surface changes: no DI key, event id, route, schema, import path, or signature change; the `EventBus` shape is untouched. `getQueue()` simply returns a process-shared instance instead of a per-bus one. The new env var is additive.

## Security impact
- No change to authentication/authorization/secrets/encryption. The fix prevents a Redis connection-exhaustion DoS condition (availability hardening) by bounding producer connections to one per process; the `SIGTERM`/`SIGINT` hook releases them on shutdown.