### PR TITLE
fix(events): add flag-gated single-delivery dispatch for persistent subscribers (#2960)

### DIFF
--- a/packages/events/AGENTS.md
+++ b/packages/events/AGENTS.md
@@ -76,6 +76,16 @@ export default async function handler(payload, ctx) { /* ... */ }
 - When `QUEUE_STRATEGY=local`, persistent events process from `.mercato/queue/` (or `QUEUE_BASE_DIR`)
 - Ephemeral subscribers always run in-process regardless of queue strategy
 
+### Persistent delivery: legacy vs single-delivery (`OM_EVENTS_SINGLE_DELIVERY`)
+
+By default (`OM_EVENTS_SINGLE_DELIVERY` unset/false) a persistent emit is delivered on **both** paths: inline to every matching in-memory subscriber **and** through the events worker (exact-match). This double-dispatches exact-match subscribers and never reaches wildcard (`event: '*'`) persistent subscribers in the worker.
+
+Set `OM_EVENTS_SINGLE_DELIVERY=true` to make persistent delivery single-path:
+- the bus skips inline delivery of **persistent-marked** subscribers on a persistent emit (ephemeral subscribers still run inline);
+- the events worker dispatches **persistent** subscribers via `matchEventPattern`, so wildcard persistent subscribers are finally reached.
+
+Both halves are gated by the same flag and MUST move together. When enabling it, ensure the events worker runs (default `AUTO_SPAWN_WORKERS=true`) and validate under both `QUEUE_STRATEGY=local` and `=async` so no persistent subscriber is dropped. This is the "Ask First: changing persistent delivery semantics" gate — the flag defaults off to preserve today's behavior.
+
 ## Queue Integration
 
 | Queue strategy | Ephemeral events | Persistent events |

--- a/packages/events/src/__tests__/single-delivery.test.ts
+++ b/packages/events/src/__tests__/single-delivery.test.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { createEventBus } from '@open-mercato/events/index'
+import type { SubscriberDescriptor } from '@open-mercato/events/types'
+
+/**
+ * Regression coverage for issue #2960: persistent subscribers must run on
+ * exactly one path under the OM_EVENTS_SINGLE_DELIVERY flag, and the default-off
+ * behavior must be preserved byte-for-byte.
+ */
+describe('Event bus single-delivery (OM_EVENTS_SINGLE_DELIVERY)', () => {
+  const origCwd = process.cwd()
+  const origFlag = process.env.OM_EVENTS_SINGLE_DELIVERY
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'events-single-delivery-'))
+    process.chdir(tmp)
+    delete process.env.QUEUE_STRATEGY
+    delete process.env.EVENTS_STRATEGY
+  })
+
+  afterEach(() => {
+    process.chdir(origCwd)
+    if (origFlag === undefined) delete process.env.OM_EVENTS_SINGLE_DELIVERY
+    else process.env.OM_EVENTS_SINGLE_DELIVERY = origFlag
+    try { fs.rmSync(tmp, { recursive: true, force: true }) } catch {}
+  })
+
+  function makeSub(
+    id: string,
+    event: string,
+    persistent: boolean,
+    sink: string[],
+  ): SubscriberDescriptor {
+    return { id, event, persistent, handler: () => { sink.push(id) } }
+  }
+
+  test('flag OFF (default): a persistent subscriber still runs inline on a persistent emit', async () => {
+    delete process.env.OM_EVENTS_SINGLE_DELIVERY
+    const calls: string[] = []
+    const bus = createEventBus({ resolve: ((name: string) => name) as never })
+    bus.registerModuleSubscribers([makeSub('persistent-sub', 'demo', true, calls)])
+
+    await bus.emit('demo', { a: 1 }, { persistent: true })
+
+    // Legacy dual-dispatch: inline delivery is preserved when the flag is off.
+    expect(calls).toEqual(['persistent-sub'])
+  })
+
+  test('flag ON: a persistent subscriber is skipped inline (deferred to the worker)', async () => {
+    process.env.OM_EVENTS_SINGLE_DELIVERY = 'true'
+    const calls: string[] = []
+    const bus = createEventBus({ resolve: ((name: string) => name) as never })
+    bus.registerModuleSubscribers([
+      makeSub('persistent-sub', 'demo', true, calls),
+      makeSub('ephemeral-sub', 'demo', false, calls),
+    ])
+
+    await bus.emit('demo', { a: 1 }, { persistent: true })
+
+    // Only the ephemeral subscriber runs inline; the persistent one is dispatched
+    // by the events worker from the queue, so it is skipped here.
+    expect(calls).toEqual(['ephemeral-sub'])
+  })
+
+  test('flag ON: a non-persistent emit still delivers persistent subscribers inline', async () => {
+    process.env.OM_EVENTS_SINGLE_DELIVERY = 'true'
+    const calls: string[] = []
+    const bus = createEventBus({ resolve: ((name: string) => name) as never })
+    bus.registerModuleSubscribers([makeSub('persistent-sub', 'demo', true, calls)])
+
+    // Non-persistent emit is never enqueued, so inline delivery is the only path.
+    await bus.emit('demo', { a: 1 })
+
+    expect(calls).toEqual(['persistent-sub'])
+  })
+
+  test('flag ON: persistent emit is still enqueued for the worker', async () => {
+    process.env.OM_EVENTS_SINGLE_DELIVERY = 'true'
+    const queuePath = path.join(path.resolve('.mercato/queue', 'events'), 'queue.json')
+    const calls: string[] = []
+    const bus = createEventBus({ resolve: ((name: string) => name) as never })
+    bus.registerModuleSubscribers([makeSub('persistent-sub', 'demo', true, calls)])
+
+    await bus.emit('demo', { a: 1 }, { persistent: true })
+
+    expect(calls).toEqual([])
+    const list = JSON.parse(fs.readFileSync(queuePath, 'utf8'))
+    expect(Array.isArray(list)).toBe(true)
+    expect(list.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/packages/events/src/bus.ts
+++ b/packages/events/src/bus.ts
@@ -1,6 +1,7 @@
 import { createQueue } from '@open-mercato/queue'
 import type { Queue } from '@open-mercato/queue'
 import { matchEventPattern } from '@open-mercato/shared/lib/events/patterns'
+import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import { getRedisUrlOrThrow } from '@open-mercato/shared/lib/redis/connection'
 import { isBroadcastEvent } from '@open-mercato/shared/modules/events'
 export { registerCrossProcessEventListener } from './bridge'
@@ -16,6 +17,18 @@ import type {
 
 /** Queue name for persistent events */
 const EVENTS_QUEUE_NAME = 'events'
+
+/**
+ * When enabled, a persistent emit delivers each subscriber on exactly one path:
+ * persistent-marked subscribers are skipped inline (the events worker dispatches
+ * them via pattern match, so wildcard persistent subscribers are reached), while
+ * ephemeral subscribers keep running inline. Default off preserves the legacy
+ * dual-dispatch behavior. Both this flag and the worker MUST agree, so the worker
+ * reads the same env var.
+ */
+function isSingleDeliveryEnabled(): boolean {
+  return parseBooleanWithDefault(process.env.OM_EVENTS_SINGLE_DELIVERY, false)
+}
 
 type GlobalEventTap = (event: string, payload: EventPayload, options?: EmitOptions) => void | Promise<void>
 const GLOBAL_EVENT_TAPS_KEY = '__openMercatoEventBusGlobalTaps__'
@@ -83,6 +96,9 @@ type EventJobData = {
 export function createEventBus(opts: CreateBusOptions): EventBus {
   // In-memory listeners for immediate event delivery
   const listeners = new Map<string, Set<SubscriberHandler>>()
+  // Handlers registered as persistent (worker-dispatched). Used by the
+  // single-delivery path to skip them inline on a persistent emit.
+  const persistentHandlers = new Set<SubscriberHandler>()
 
   // Determine queue strategy from options or environment
   const queueStrategy = opts.queueStrategy ??
@@ -109,13 +125,21 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
    * Delivers an event to all registered in-memory handlers.
    * Supports wildcard pattern matching for event patterns.
    */
-  async function deliver(event: string, payload: EventPayload, options?: EmitOptions): Promise<void> {
+  async function deliver(
+    event: string,
+    payload: EventPayload,
+    options?: EmitOptions,
+    skipPersistent = false,
+  ): Promise<void> {
     // Check all registered patterns (including wildcards)
     for (const [pattern, handlers] of listeners) {
       if (!matchEventPattern(event, pattern)) continue
       if (!handlers || handlers.size === 0) continue
 
       for (const handler of handlers) {
+        // Single-delivery: persistent subscribers are dispatched by the worker,
+        // so skip them inline to avoid double execution.
+        if (skipPersistent && persistentHandlers.has(handler)) continue
         try {
           // Pass eventName in context for wildcard handlers
           await Promise.resolve(handler(payload, {
@@ -134,11 +158,14 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
   /**
    * Registers a handler for an event.
    */
-  function on(event: string, handler: SubscriberHandler): void {
+  function on(event: string, handler: SubscriberHandler, options?: { persistent?: boolean }): void {
     if (!listeners.has(event)) {
       listeners.set(event, new Set())
     }
     listeners.get(event)!.add(handler)
+    if (options?.persistent) {
+      persistentHandlers.add(handler)
+    }
   }
 
   /**
@@ -146,7 +173,7 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
    */
   function registerModuleSubscribers(subs: SubscriberDescriptor[]): void {
     for (const sub of subs) {
-      on(sub.event, sub.handler)
+      on(sub.event, sub.handler, { persistent: sub.persistent })
     }
   }
 
@@ -169,8 +196,11 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
       }
     }
 
-    // Always deliver to in-memory handlers first
-    await deliver(event, payload, options)
+    // Deliver to in-memory handlers first. Under single-delivery, persistent
+    // subscribers are skipped inline on a persistent emit because the events
+    // worker will dispatch them from the queue.
+    const skipPersistentInline = Boolean(options?.persistent) && isSingleDeliveryEnabled()
+    await deliver(event, payload, options, skipPersistentInline)
 
     if (isBroadcastEvent(event) && hasTenantScope(payload)) {
       try {

--- a/packages/events/src/modules/events/workers/__tests__/events.worker.test.ts
+++ b/packages/events/src/modules/events/workers/__tests__/events.worker.test.ts
@@ -431,4 +431,77 @@ describe('Events Worker', () => {
       errorSpy.mockRestore()
     })
   })
+
+  describe('single-delivery dispatch (OM_EVENTS_SINGLE_DELIVERY) — issue #2960', () => {
+    const origFlag = process.env.OM_EVENTS_SINGLE_DELIVERY
+
+    afterEach(() => {
+      if (origFlag === undefined) delete process.env.OM_EVENTS_SINGLE_DELIVERY
+      else process.env.OM_EVENTS_SINGLE_DELIVERY = origFlag
+    })
+
+    const createMockJob = (event: string, payload: unknown): QueuedJob<{ event: string; payload: unknown }> => ({
+      id: 'test-job-id',
+      payload: { event, payload },
+      createdAt: new Date().toISOString(),
+    })
+
+    const createMockContext = (): JobContext & { resolve: <T = unknown>(name: string) => T } => ({
+      jobId: 'test-job-id',
+      attemptNumber: 1,
+      queueName: 'events',
+      resolve: <T = unknown>(name: string): T => { throw new Error(`No mock for ${name}`) },
+    })
+
+    it('flag ON: dispatches wildcard persistent subscribers that exact-match never reached', async () => {
+      process.env.OM_EVENTS_SINGLE_DELIVERY = 'true'
+      clearListenerCache()
+      const calls: string[] = []
+      registerCliModules([{
+        id: 'm',
+        subscribers: [
+          { id: 'wildcard:persistent', event: '*', persistent: true, handler: () => { calls.push('wild') } },
+        ],
+      }])
+
+      await handle(createMockJob('any.event', {}), createMockContext())
+
+      expect(calls).toEqual(['wild'])
+    })
+
+    it('flag ON: excludes non-persistent subscribers from worker dispatch', async () => {
+      process.env.OM_EVENTS_SINGLE_DELIVERY = 'true'
+      clearListenerCache()
+      const calls: string[] = []
+      registerCliModules([{
+        id: 'm',
+        subscribers: [
+          { id: 'p', event: 'user.created', persistent: true, handler: () => { calls.push('p') } },
+          { id: 'e', event: 'user.created', persistent: false, handler: () => { calls.push('e') } },
+        ],
+      }])
+
+      await handle(createMockJob('user.created', {}), createMockContext())
+
+      expect(calls).toEqual(['p'])
+    })
+
+    it('flag OFF (default): preserves legacy exact-match dispatch and never reaches wildcards', async () => {
+      delete process.env.OM_EVENTS_SINGLE_DELIVERY
+      clearListenerCache()
+      const calls: string[] = []
+      registerCliModules([{
+        id: 'm',
+        subscribers: [
+          { id: 'p', event: 'user.created', persistent: true, handler: () => { calls.push('p') } },
+          { id: 'w', event: '*', persistent: true, handler: () => { calls.push('w') } },
+        ],
+      }])
+
+      await handle(createMockJob('user.created', {}), createMockContext())
+
+      // Legacy behavior: exact-match only, so the wildcard subscriber is not reached here.
+      expect(calls).toEqual(['p'])
+    })
+  })
 })

--- a/packages/events/src/modules/events/workers/events.worker.ts
+++ b/packages/events/src/modules/events/workers/events.worker.ts
@@ -1,5 +1,7 @@
 import type { QueuedJob, JobContext, WorkerMeta } from '@open-mercato/queue'
 import { getCliModules } from '@open-mercato/shared/modules/registry'
+import { matchEventPattern } from '@open-mercato/shared/lib/events/patterns'
+import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 
 export const EVENTS_QUEUE_NAME = 'events'
 
@@ -29,7 +31,41 @@ type HandlerContext = {
 type SubscriberEntry = {
   id: string
   event: string
+  persistent?: boolean
   handler: (payload: unknown, ctx: unknown) => Promise<void> | void
+}
+
+/**
+ * Mirror of the event bus single-delivery flag. When enabled, the worker owns
+ * dispatch of every persistent subscriber and matches by pattern so wildcard
+ * (`event: '*'`) persistent subscribers are finally reached. Default off keeps
+ * the legacy exact-match dispatch of all subscribers.
+ */
+function isSingleDeliveryEnabled(): boolean {
+  return parseBooleanWithDefault(process.env.OM_EVENTS_SINGLE_DELIVERY, false)
+}
+
+/**
+ * Resolves the subscribers to run for a queued event.
+ * - Legacy (flag off): exact-match lookup of every subscriber for the event.
+ * - Single-delivery (flag on): persistent subscribers whose pattern matches the
+ *   event, including wildcards, so they run exactly once here instead of inline.
+ */
+function resolveSubscribers(
+  listeners: Map<string, SubscriberEntry[]>,
+  event: string,
+): SubscriberEntry[] {
+  if (!isSingleDeliveryEnabled()) {
+    return listeners.get(event) ?? []
+  }
+  const matched: SubscriberEntry[] = []
+  for (const [pattern, subs] of listeners) {
+    if (!matchEventPattern(event, pattern)) continue
+    for (const sub of subs) {
+      if (sub.persistent) matched.push(sub)
+    }
+  }
+  return matched
 }
 
 // Cached listener map - built once on first use
@@ -75,7 +111,7 @@ export default async function handle(
 ): Promise<void> {
   const { event, payload, options } = job.payload
   const listeners = getListenerMap()
-  const subscribers = listeners.get(event)
+  const subscribers = resolveSubscribers(listeners, event)
 
   if (!subscribers || subscribers.length === 0) return
 

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -43,6 +43,12 @@ export type SubscriberDescriptor = {
   id: string
   /** Event name to subscribe to */
   event: string
+  /**
+   * Whether this subscriber is dispatched through the persistent events queue
+   * (events worker) rather than inline. Consulted by the `OM_EVENTS_SINGLE_DELIVERY`
+   * single-delivery path to decide which subscribers run inline vs in the worker.
+   */
+  persistent?: boolean
   /** Handler function */
   handler: SubscriberHandler
 }
@@ -100,8 +106,10 @@ export interface EventBus {
    *
    * @param event - Event name to listen for
    * @param handler - Handler function
+   * @param options - Optional registration options. `persistent: true` marks the
+   *   handler as worker-dispatched so the single-delivery path skips it inline.
    */
-  on(event: string, handler: SubscriberHandler): void
+  on(event: string, handler: SubscriberHandler, options?: { persistent?: boolean }): void
 
   /**
    * Register multiple module subscribers at once.


### PR DESCRIPTION
Fixes #2960

## Problem
`bus.emit` delivers every event inline to all matching in-memory subscribers **and**, for a `persistent: true` emit, additionally enqueues it for the events worker, which re-dispatches through an exact-match listener map. Under the default `AUTO_SPAWN_WORKERS=true` this yields two compounding faults:
- **Exact-match persistent subscribers run twice** (once inline, once in the worker) — e.g. duplicate in-app notifications (`customers:deal-won-notification`) and duplicate queued emails (`messages:queue-email-delivery`).
- **Wildcard (`event: '*'`) persistent subscribers run only inline** — workflow event triggers, the business-rules CRUD trigger, and webhook outbound dispatch never reach the worker because `listeners.get(event)` never matches `'*'`, so they get no queue/retry semantics and run synchronously on the mutation request path.

## Root Cause
- `bus.ts` always delivers inline regardless of persistence, and separately enqueues persistent emits → dual dispatch.
- `registerModuleSubscribers` registered handlers keyed only by `event`, dropping the `persistent` flag.
- `events.worker.ts` `buildListenerMap` indexes by exact `sub.event` and `handle` resolves via `listeners.get(event)` with no persistent filter and no wildcard matching.

## What Changed
Behind a **default-off** `OM_EVENTS_SINGLE_DELIVERY` flag, persistent delivery becomes single-path:
- `packages/events/src/types.ts` — add optional `persistent` to `SubscriberDescriptor`; `EventBus.on` gains an optional `{ persistent? }` third argument (additive).
- `packages/events/src/bus.ts` — track persistent-registered handlers; on a persistent emit, skip them inline (ephemeral subscribers still run inline) while still enqueuing.
- `packages/events/src/modules/events/workers/events.worker.ts` — dispatch **persistent** subscribers via the shared `matchEventPattern`, so wildcard persistent subscribers are finally reached.

Both halves are gated by the same env var and move together. Default off preserves today's dual-dispatch behavior exactly.

## Tests
- **Bus** (`src/__tests__/single-delivery.test.ts`): flag-off persistent subscriber still inline; flag-on persistent subscriber skipped inline while ephemeral runs inline; flag-on non-persistent emit still delivers inline; flag-on persistent emit still enqueued.
- **Worker** (`events.worker.test.ts`): flag-on dispatches wildcard persistent subscribers; flag-on excludes non-persistent subscribers; flag-off preserves legacy exact-match dispatch (wildcards not reached).
- Full `@open-mercato/events` suite green (5 suites / 39 tests); `@open-mercato/webhooks` green (13 suites / 96 tests); full-repo `yarn typecheck` green (21/21).

## Backward Compatibility
No contract surface broken. The subscriber metadata shape `{ event, persistent?, id? }` is unchanged; `SubscriberDescriptor.persistent`, `EventBus.on`'s third arg, and the worker's `SubscriberEntry.persistent` are all additive optionals. No event IDs, DI keys, routes, or schema touched. The new flag defaults off, so existing behavior is preserved — this satisfies the events `AGENTS.md` "Ask First: changing persistent delivery semantics" gate.

**Note:** This is the prerequisite for, not the implementation of, the enterprise-spec P2.1 work — `query_index.upsert_one` stays `persistent: false` (intentionally synchronous for read-your-writes). When enabling the flag, ensure the events worker runs and validate under both `QUEUE_STRATEGY=local` and `=async` so no persistent subscriber is dropped.