### PR TITLE
security(ai_assistant): mcp:dev bounds API-key lookup to project root and checks file permissions (#2671)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-dev-key-resolution.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-dev-key-resolution.test.ts
@@ -1,0 +1,92 @@
+import { resolve } from 'node:path'
+import { findProjectRoot, checkMcpConfigPermissions } from '../mcp-dev-key-resolution'
+
+describe('mcp:dev API key resolution (#2671)', () => {
+  describe('findProjectRoot', () => {
+    const projectRoot = resolve('/home/dev/project')
+    const launchDir = resolve('/home/dev/project/packages/ai-assistant')
+
+    it('returns the nearest ancestor containing a root marker', () => {
+      const exists = (path: string) => path === resolve(projectRoot, '.git')
+      expect(findProjectRoot(launchDir, exists)).toBe(projectRoot)
+    })
+
+    it('stops at the nearest marker and never picks a marker higher up the tree', () => {
+      // A marker exists both at the real project root and at a higher ancestor.
+      // Walking up from the launch dir must stop at the closest one, so an
+      // attacker planting a marker (and a sibling .mcp.json) higher up cannot
+      // shadow the real project root.
+      const higherAncestor = resolve('/home/dev')
+      const exists = (path: string) =>
+        path === resolve(projectRoot, '.git') || path === resolve(higherAncestor, '.git')
+      expect(findProjectRoot(launchDir, exists)).toBe(projectRoot)
+      expect(findProjectRoot(launchDir, exists)).not.toBe(higherAncestor)
+    })
+
+    it('falls back to the start directory (never the filesystem root) when no marker is found', () => {
+      const exists = () => false
+      expect(findProjectRoot(launchDir, exists)).toBe(launchDir)
+      expect(findProjectRoot(launchDir, exists)).not.toBe(resolve('/'))
+    })
+
+    it('recognises any of the supported root markers', () => {
+      const exists = (path: string) => path === resolve(projectRoot, 'yarn.lock')
+      expect(findProjectRoot(launchDir, exists)).toBe(projectRoot)
+    })
+  })
+
+  describe('checkMcpConfigPermissions', () => {
+    const configPath = '/home/dev/project/.mcp.json'
+
+    it('refuses to read a config owned by another user', () => {
+      const warnings: string[] = []
+      const result = checkMcpConfigPermissions(
+        configPath,
+        { uid: 4242, mode: 0o600 },
+        1000,
+        (message) => warnings.push(message),
+      )
+      expect(result.ok).toBe(false)
+      expect(result.reason).toContain('owned by uid 4242')
+      expect(warnings).toHaveLength(0)
+    })
+
+    it('warns loudly but allows when the config is group/world accessible', () => {
+      const warnings: string[] = []
+      const result = checkMcpConfigPermissions(
+        configPath,
+        { uid: 1000, mode: 0o644 },
+        1000,
+        (message) => warnings.push(message),
+      )
+      expect(result.ok).toBe(true)
+      expect(warnings).toHaveLength(1)
+      expect(warnings[0]).toContain('accessible to group/other')
+      expect(warnings[0]).toContain('chmod 600')
+    })
+
+    it('accepts an owner-only config without warning', () => {
+      const warnings: string[] = []
+      const result = checkMcpConfigPermissions(
+        configPath,
+        { uid: 1000, mode: 0o600 },
+        1000,
+        (message) => warnings.push(message),
+      )
+      expect(result.ok).toBe(true)
+      expect(warnings).toHaveLength(0)
+    })
+
+    it('skips ownership/permission checks when uid is unavailable (non-POSIX)', () => {
+      const warnings: string[] = []
+      const result = checkMcpConfigPermissions(
+        configPath,
+        { uid: 4242, mode: 0o644 },
+        null,
+        (message) => warnings.push(message),
+      )
+      expect(result.ok).toBe(true)
+      expect(warnings).toHaveLength(0)
+    })
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-dev-key-resolution.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-dev-key-resolution.ts
@@ -1,0 +1,107 @@
+import { resolve, dirname } from 'node:path'
+
+const MCP_CONFIG_FILENAME = '.mcp.json'
+
+// Markers that identify a project/repo root. The lookup stops at the first
+// ancestor that has one of these, so the secret is only ever read from the
+// project root — never from an unbounded walk up to the filesystem root.
+const PROJECT_ROOT_MARKERS = ['.git', 'yarn.lock', 'pnpm-lock.yaml', 'package-lock.json'] as const
+
+const log = (message: string, ...args: unknown[]) => {
+  console.error(`[MCP Dev] ${message}`, ...args)
+}
+
+type PermissionStat = { uid: number; mode: number }
+
+/**
+ * Resolve the project root by walking up from `startDir` to the nearest
+ * ancestor containing a project-root marker. Falls back to `startDir` (never
+ * the filesystem root) when no marker is found, so a planted `.mcp.json` in a
+ * writable ancestor such as `/tmp` can never be picked up.
+ */
+export function findProjectRoot(startDir: string, exists: (path: string) => boolean): string {
+  let dir = resolve(startDir)
+  while (true) {
+    for (const marker of PROJECT_ROOT_MARKERS) {
+      if (exists(resolve(dir, marker))) return dir
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return resolve(startDir)
+    dir = parent
+  }
+}
+
+/**
+ * Validate the ownership and permissions of `.mcp.json` before its secret is
+ * read. Refuses when the file is owned by another user (a planted/shadowed
+ * config) and warns loudly when it is accessible to group/other (the key is a
+ * live secret). POSIX-only: when `currentUid` is null (e.g. Windows) the checks
+ * are skipped.
+ */
+export function checkMcpConfigPermissions(
+  configPath: string,
+  fileStat: PermissionStat,
+  currentUid: number | null,
+  warn: (message: string) => void,
+): { ok: boolean; reason?: string } {
+  if (currentUid === null) return { ok: true }
+  if (fileStat.uid !== currentUid) {
+    return {
+      ok: false,
+      reason: `refusing to read ${configPath}: it is owned by uid ${fileStat.uid}, not the current user (uid ${currentUid})`,
+    }
+  }
+  if ((fileStat.mode & 0o077) !== 0) {
+    warn(
+      `${configPath} is accessible to group/other (mode ${(fileStat.mode & 0o777).toString(8)}); it contains a live API key — restrict it with: chmod 600 ${configPath}`,
+    )
+  }
+  return { ok: true }
+}
+
+/**
+ * Resolve the dev MCP server's API key.
+ *
+ * Priority: `OPEN_MERCATO_API_KEY` env var, then `headers.x-api-key` from a
+ * single `.mcp.json` read from the detected project root. The lookup is bounded
+ * to the project root (it never walks up to the filesystem root), and the file
+ * is ownership/permission-checked before its secret is read.
+ */
+export async function getApiKeyFromMcpJson(): Promise<string | undefined> {
+  const envKey = process.env.OPEN_MERCATO_API_KEY
+  if (envKey && envKey.trim().length > 0) {
+    return envKey.trim()
+  }
+
+  const { readFile, stat } = await import('node:fs/promises')
+  const { existsSync } = await import('node:fs')
+
+  try {
+    const projectRoot = findProjectRoot(process.cwd(), existsSync)
+    const mcpJsonPath = resolve(projectRoot, MCP_CONFIG_FILENAME)
+    if (!existsSync(mcpJsonPath)) {
+      return undefined
+    }
+
+    const fileStat = await stat(mcpJsonPath)
+    const currentUid = typeof process.getuid === 'function' ? process.getuid() : null
+    const permissionCheck = checkMcpConfigPermissions(
+      mcpJsonPath,
+      { uid: fileStat.uid, mode: fileStat.mode },
+      currentUid,
+      (message) => log(`Warning: ${message}`),
+    )
+    if (!permissionCheck.ok) {
+      log(`Error: ${permissionCheck.reason}`)
+      return undefined
+    }
+
+    const content = await readFile(mcpJsonPath, 'utf-8')
+    const config = JSON.parse(content)
+    const serverConfig = config?.mcpServers?.['open-mercato']
+
+    return serverConfig?.headers?.['x-api-key']
+  } catch {
+    return undefined
+  }
+}

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-dev-server.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-dev-server.ts
@@ -7,6 +7,7 @@ import { executeTool } from './tool-executor'
 import { loadAllModuleTools, indexToolsForSearch } from './tool-loader'
 import { authenticateMcpRequest, extractApiKeyFromHeaders, hasRequiredFeatures } from './auth'
 import { jsonSchemaToZod } from './schema-utils'
+import { getApiKeyFromMcpJson } from './mcp-dev-key-resolution'
 import type { McpToolContext } from './types'
 import type { SearchService } from '@open-mercato/search/service'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
@@ -15,42 +16,6 @@ const DEFAULT_PORT = 3001
 
 const log = (message: string, ...args: unknown[]) => {
   console.error(`[MCP Dev] ${message}`, ...args)
-}
-
-async function getApiKeyFromMcpJson(): Promise<string | undefined> {
-  const { readFile, access } = await import('node:fs/promises')
-  const { resolve, dirname } = await import('node:path')
-
-  // Search for .mcp.json starting from cwd and walking up to project root
-  const findMcpJson = async (startDir: string): Promise<string | null> => {
-    let dir = startDir
-    const root = resolve('/')
-    while (dir !== root) {
-      const candidate = resolve(dir, '.mcp.json')
-      try {
-        await access(candidate)
-        return candidate
-      } catch {
-        dir = dirname(dir)
-      }
-    }
-    return null
-  }
-
-  try {
-    const mcpJsonPath = await findMcpJson(process.cwd())
-    if (!mcpJsonPath) {
-      return undefined
-    }
-
-    const content = await readFile(mcpJsonPath, 'utf-8')
-    const config = JSON.parse(content)
-    const serverConfig = config?.mcpServers?.['open-mercato']
-
-    return serverConfig?.headers?.['x-api-key']
-  } catch {
-    return undefined
-  }
 }
 
 /**


### PR DESCRIPTION
Fixes #2671

## Problem
The dev MCP server (`yarn mcp:dev` / `runMcpDevServer`) resolved its API key by walking from `process.cwd()` all the way up to the filesystem root and reading the first `.mcp.json` it found (`packages/ai-assistant/src/modules/ai_assistant/lib/mcp-dev-server.ts:20-54`), with no project-root bound and no ownership/permission check.

On a shared/multi-user dev host this allowed two MEDIUM-severity issues:
- **Config shadowing**: starting the server from a subdirectory while an attacker controls a `.mcp.json` in a writable ancestor (e.g. `/tmp` or a shared workspace parent) caused the planted file — found first while walking up — to inject an attacker-controlled `x-api-key`.
- **Silent key exposure**: the file was read regardless of mode, so a world-readable `.mcp.json` leaked the live key to any local user without any warning.

## Root Cause
First-match-while-walking-up to `/` with no boundary and no `stat()` before reading the secret.

## What Changed
Extracted key resolution into a new SDK-free module `lib/mcp-dev-key-resolution.ts` and hardened it (`mcp-dev-server.ts` now imports `getApiKeyFromMcpJson` from there):

- **Honor `OPEN_MERCATO_API_KEY`** — already documented in `packages/ai-assistant/AGENTS.md` but never actually implemented; it now short-circuits before any file read.
- **Bound the lookup to the project root** — `findProjectRoot()` walks up to the *nearest* ancestor containing a root marker (`.git` / `yarn.lock` / `pnpm-lock.yaml` / `package-lock.json`) and reads `.mcp.json` only from there. It never walks to the filesystem root, and falls back to `cwd` (not `/`) when no marker exists, so a planted config in a writable ancestor can no longer be picked up. (`yarn mcp:dev` runs from `packages/ai-assistant` via turbo, with `.mcp.json` at the repo root — still resolved correctly.)
- **Ownership/permission check** — `checkMcpConfigPermissions()` stats the file before reading: it **refuses** when the file is owned by another user (a planted/shadowed config) and **warns loudly** (with a `chmod 600` hint) when it is group/world-accessible. POSIX-only — checks are skipped when `process.getuid` is unavailable (e.g. Windows).

## Tests
- New `lib/__tests__/mcp-dev-key-resolution.test.ts` (8 tests): `findProjectRoot` returns the nearest marker, **never a marker higher up the tree** (the shadowing-defeat property), falls back to the start dir rather than `/`, and recognises each marker; `checkMcpConfigPermissions` refuses on foreign ownership, warns-but-allows on group/world bits, accepts owner-only `0600` silently, and skips checks when uid is unavailable.
- Full `@open-mercato/ai-assistant` suite: 1253/1253 pass. Full repo `yarn typecheck`: 21/21 pass. `yarn generate` + `yarn build:packages`: pass.

## Backward Compatibility
- No contract surface changes: `runMcpDevServer` is unchanged; the new helpers live in the module's internal `lib/` path (not part of the documented developer contract). The `OPEN_MERCATO_API_KEY` env var is additive and was already documented.

## Security impact
- **Access control / secrets**: removes a dev-host privilege-escalation/secret-shadowing vector (planted `.mcp.json` in a writable ancestor) by bounding the lookup to the project root, and flags/blocks lax-permission or foreign-owned config files before the live API key is read. Ownership mismatch fails closed (refuse); lax permission bits warn loudly per the issue's guidance. `mcp:dev` is a developer-local tool, so refuse-on-foreign-ownership is the safe default; if a maintainer prefers warn-only there, it is a one-line change in `checkMcpConfigPermissions`.