### PR TITLE
security(ai_assistant): pass MCP API key via env var, not command-line argv (#2669)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/__tests__/cli-mcp-serve-key.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/__tests__/cli-mcp-serve-key.test.ts
@@ -1,0 +1,63 @@
+import type { ModuleCli } from '@open-mercato/shared/modules/registry'
+import cliCommands from '../cli'
+
+const mockRunMcpServer = jest.fn(async () => undefined)
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({})),
+  getDiRegistrars: jest.fn(() => []),
+}))
+
+jest.mock('../lib/mcp-server', () => ({
+  runMcpServer: (...args: unknown[]) => mockRunMcpServer(...args),
+}))
+
+function getMcpServe(): ModuleCli {
+  const cmd = (cliCommands as ModuleCli[]).find((c) => c.command === 'mcp:serve')
+  if (!cmd) throw new Error('mcp:serve command not found')
+  return cmd
+}
+
+describe('mcp:serve API key resolution (issue #2669)', () => {
+  const originalEnv = process.env.OPEN_MERCATO_API_KEY
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    delete process.env.OPEN_MERCATO_API_KEY
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.OPEN_MERCATO_API_KEY
+    else process.env.OPEN_MERCATO_API_KEY = originalEnv
+  })
+
+  it('reads the key from OPEN_MERCATO_API_KEY when --api-key is absent', async () => {
+    process.env.OPEN_MERCATO_API_KEY = 'omk_env.secret'
+
+    await getMcpServe().run([])
+
+    expect(mockRunMcpServer).toHaveBeenCalledTimes(1)
+    expect(mockRunMcpServer).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKeySecret: 'omk_env.secret' }),
+    )
+  })
+
+  it('still accepts the --api-key flag and prefers it over the env var', async () => {
+    process.env.OPEN_MERCATO_API_KEY = 'omk_env.secret'
+
+    await getMcpServe().run(['--api-key', 'omk_flag.secret'])
+
+    expect(mockRunMcpServer).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKeySecret: 'omk_flag.secret' }),
+    )
+  })
+
+  it('prints usage and does not start the server when neither key nor tenant is provided', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    await getMcpServe().run([])
+
+    expect(mockRunMcpServer).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/cli.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/cli.ts
@@ -47,7 +47,10 @@ const mcpServe: ModuleCli = {
   command: 'mcp:serve',
   async run(rest) {
     const args = parseArgs(rest)
-    const apiKey = String(args['api-key'] ?? args.apiKey ?? '') || null
+    // Prefer the OPEN_MERCATO_API_KEY env var so the secret never has to be
+    // placed on the command line (argv is world-readable via ps / /proc).
+    // The --api-key flag stays supported for backward compatibility.
+    const apiKey = String(args['api-key'] ?? args.apiKey ?? '') || process.env.OPEN_MERCATO_API_KEY || null
     const tenantId = String(args.tenant ?? args.tenantId ?? '') || null
     const organizationId = String(args.org ?? args.organizationId ?? '') || null
     const userId = String(args.user ?? args.userId ?? '') || null
@@ -58,8 +61,9 @@ const mcpServe: ModuleCli = {
       console.error('Usage: mercato ai_assistant mcp:serve [options]')
       console.error('')
       console.error('Authentication (choose one):')
-      console.error('  --api-key <secret>   API key secret for authentication (recommended)')
-      console.error('  --tenant <id>        Tenant ID (for manual context)')
+      console.error('  OPEN_MERCATO_API_KEY env   API key secret (recommended — keeps the secret off argv)')
+      console.error('  --api-key <secret>         API key secret for authentication (visible in process listings)')
+      console.error('  --tenant <id>              Tenant ID (for manual context)')
       console.error('')
       console.error('Options (with --tenant):')
       console.error('  --org <id>           Organization ID (optional)')
@@ -69,6 +73,7 @@ const mcpServe: ModuleCli = {
       console.error('  --debug              Enable debug logging')
       console.error('')
       console.error('Examples:')
+      console.error('  OPEN_MERCATO_API_KEY=omk_xxxx.yyyy... mercato ai_assistant mcp:serve')
       console.error('  mercato ai_assistant mcp:serve --api-key omk_xxxx.yyyy...')
       console.error('  mercato ai_assistant mcp:serve --tenant 123e4567-e89b-12d3-a456-426614174000')
       return

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/client-factory.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/client-factory.test.ts
@@ -1,0 +1,42 @@
+import { createMcpClient } from '../client-factory'
+
+const mockConnect = jest.fn(async () => ({ listTools: jest.fn(), callTool: jest.fn(), close: jest.fn() }))
+
+jest.mock('../mcp-client', () => ({
+  McpClient: {
+    connect: (...args: unknown[]) => mockConnect(...args),
+  },
+}))
+
+describe('createMcpClient stdio mode (issue #2669)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('never places the API key on the default argv', async () => {
+    await createMcpClient({ mode: 'stdio', apiKeySecret: 'omk_secret.value' })
+
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+    const options = mockConnect.mock.calls[0][0] as { apiKeySecret: string; args?: string[] }
+
+    // The secret is forwarded to McpClient.connect, which delivers it via env.
+    expect(options.apiKeySecret).toBe('omk_secret.value')
+
+    // The factory must not build default args that embed the secret. Leaving
+    // args undefined lets connectStdio use its secret-free default.
+    expect(options.args).toBeUndefined()
+    expect(JSON.stringify(options.args ?? [])).not.toContain('--api-key')
+    expect(JSON.stringify(options.args ?? [])).not.toContain('omk_secret.value')
+  })
+
+  it('honors explicitly provided stdio args without injecting the secret', async () => {
+    await createMcpClient({
+      mode: 'stdio',
+      apiKeySecret: 'omk_secret.value',
+      stdioArgs: ['node', 'custom-server.js'],
+    })
+
+    const options = mockConnect.mock.calls[0][0] as { args?: string[] }
+    expect(options.args).toEqual(['node', 'custom-server.js'])
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-client.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-client.test.ts
@@ -58,7 +58,7 @@ describe('McpClient stdio transport', () => {
       command: 'node',
       args: ['server.js'],
       cwd: '/tmp/open-mercato',
-      env: process.env,
+      env: { ...process.env, OPEN_MERCATO_API_KEY: 'test-secret' },
       stderr: 'pipe',
     })
     expect(mockClientConnect).toHaveBeenCalledTimes(1)
@@ -70,5 +70,24 @@ describe('McpClient stdio transport', () => {
     expect(mockClientClose).toHaveBeenCalledTimes(1)
     expect(mockTransportClose).toHaveBeenCalledTimes(1)
     expect(mockManualChildKill).not.toHaveBeenCalled()
+  })
+
+  it('passes the API key via OPEN_MERCATO_API_KEY env, never on argv (issue #2669)', async () => {
+    await McpClient.connect({
+      transport: 'stdio',
+      apiKeySecret: 'omk_secret.value',
+    })
+
+    expect(StdioClientTransport).toHaveBeenCalledTimes(1)
+    const transportArgs = (StdioClientTransport as jest.Mock).mock.calls[0][0]
+
+    // The secret must reach the child process exclusively through the env var.
+    expect(transportArgs.env.OPEN_MERCATO_API_KEY).toBe('omk_secret.value')
+
+    // It must NOT appear on argv (world-readable via ps / /proc/<pid>/cmdline).
+    expect(transportArgs.args).toEqual(['mercato', 'ai_assistant', 'mcp:serve'])
+    expect(transportArgs.args).not.toContain('--api-key')
+    expect(transportArgs.args).not.toContain('omk_secret.value')
+    expect(JSON.stringify(transportArgs.args)).not.toContain('omk_secret.value')
   })
 })

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/client-factory.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/client-factory.ts
@@ -93,16 +93,10 @@ export async function createMcpClient(options: CreateClientOptions): Promise<Mcp
 
       if (options.stdioArgs) {
         stdioOptions.args = options.stdioArgs
-      } else {
-        // Default args include the API key
-        stdioOptions.args = [
-          'mercato',
-          'ai_assistant',
-          'mcp:serve',
-          '--api-key',
-          apiKeySecret,
-        ]
       }
+      // Otherwise let McpClient.connectStdio apply its default args. The API key
+      // is delivered to the child via the OPEN_MERCATO_API_KEY env var, never on
+      // argv — command-line arguments are world-readable (ps / /proc/<pid>/cmdline).
 
       if (options.cwd) {
         stdioOptions.cwd = options.cwd

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-client.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-client.ts
@@ -8,11 +8,15 @@ import type { McpClientInterface, ToolInfo, ToolResult } from './types'
  */
 export type StdioClientOptions = {
   transport: 'stdio'
-  /** API key secret (passed to server via --api-key) */
+  /**
+   * API key secret. Delivered to the spawned server via the
+   * `OPEN_MERCATO_API_KEY` environment variable, never as a command-line
+   * argument (argv is world-readable via `ps`/`/proc/<pid>/cmdline`).
+   */
   apiKeySecret: string
   /** Command to run (default: 'yarn') */
   command?: string
-  /** Arguments for the command (default: mercato mcp:serve with api-key) */
+  /** Arguments for the command (default: mercato ai_assistant mcp:serve, no secret on argv) */
   args?: string[]
   /** Working directory (default: process.cwd()) */
   cwd?: string
@@ -72,12 +76,12 @@ export class McpClient implements McpClientInterface {
    */
   private static async connectStdio(options: StdioClientOptions): Promise<McpClient> {
     const command = options.command ?? 'yarn'
+    // The API key is passed via OPEN_MERCATO_API_KEY in the child env (below),
+    // never on argv — command-line arguments are readable by any local user.
     const args = options.args ?? [
       'mercato',
       'ai_assistant',
       'mcp:serve',
-      '--api-key',
-      options.apiKeySecret,
     ]
     const cwd = options.cwd ?? process.cwd()
 
@@ -85,7 +89,7 @@ export class McpClient implements McpClientInterface {
       command,
       args,
       cwd,
-      env: process.env as Record<string, string>,
+      env: { ...process.env, OPEN_MERCATO_API_KEY: options.apiKeySecret } as Record<string, string>,
       stderr: 'pipe',
     })
     transport.stderr?.on('data', (data) => {


### PR DESCRIPTION
Fixes #2669

## Problem
When the MCP client connects via stdio transport it spawned the server with the API key secret on the command line: `mercato ai_assistant mcp:serve --api-key <omk_xxx.yyy>`. Command-line arguments are not private — any local user can read them via `ps -ef`, `/proc/<pid>/cmdline`, auditd, process accounting, or observability agents. On a multi-user host or shared CI runner, a co-located account could lift the secret and fully impersonate the bound tenant/user (potentially super-admin).

## Root Cause
- `lib/mcp-client.ts` `connectStdio` built default args ending in `--api-key`, `options.apiKeySecret`.
- `lib/client-factory.ts` stdio mode built the same secret-bearing default args.
- `cli.ts` `mcp:serve` only accepted the key via the `--api-key` flag — no env fallback — so the secret was necessarily placed on argv.

## What Changed
Deliver the secret to the spawned server through the `OPEN_MERCATO_API_KEY` environment variable (the spawn already inherits the parent env) and remove it from argv:
- **`lib/mcp-client.ts`** — default args drop `--api-key <secret>`; the key is injected as `OPEN_MERCATO_API_KEY` in the child `env`.
- **`lib/client-factory.ts`** — stdio mode no longer builds default args embedding the key; it lets `connectStdio` apply its secret-free default and deliver the key via env.
- **`cli.ts`** — `mcp:serve` reads `OPEN_MERCATO_API_KEY` when `--api-key` is absent (the flag stays supported for backward compatibility); usage text updated to recommend the env var.

`OPEN_MERCATO_API_KEY` is already the established convention for `mcp:dev`, and this mirrors the `AbortController` + env-timeout pattern in `communication_channels`.

## Tests
- `lib/__tests__/mcp-client.test.ts` — asserts the secret reaches the child via `env.OPEN_MERCATO_API_KEY` and never appears on argv; existing spawn-delegation test updated for the new env shape.
- `lib/__tests__/client-factory.test.ts` (new) — asserts the default stdio path carries no `--api-key` and that explicit `stdioArgs` are honored.
- `__tests__/cli-mcp-serve-key.test.ts` (new) — asserts `mcp:serve` reads `OPEN_MERCATO_API_KEY`, that `--api-key` still works and wins when both are present, and that usage is printed when neither key nor tenant is given.
- Full `@open-mercato/ai-assistant` suite green (90 suites / 1251 tests), including the real-subprocess `mcp-client.integration.test.ts`. Full-repo `yarn typecheck` green (21/21).

## Backward Compatibility
No contract surface changes. The `--api-key` flag and `StdioClientOptions` / `CreateClientOptions` shapes are unchanged; `OPEN_MERCATO_API_KEY` is an additive, already-conventional env var. The default spawn argv change is internal behavior.

## Security impact
- **Affected areas:** secrets handling, authentication (MCP server API key → two-tier session-token issuance), credential exposure surface.
- **Fix:** removes a tenant/user-scoped API key from world-readable process argv; the secret now travels via an environment variable, readable only by the same user/root via `/proc/<pid>/environ` and not surfaced by `ps`/cmdline.
- **Residual considerations:** env vars are still visible to the same UID and root; this matches the platform's existing secret-delivery convention (`mcp:dev`, OAuth token timeouts). No secret is logged. The `--api-key` flag remains available for compatibility but is now documented as the less-safe option.