### PR TITLE
fix(ai_assistant): declare active-participants partial index to stop spurious drop-index migration (#3025)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/data/__tests__/schema-unique-indexes.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/data/__tests__/schema-unique-indexes.test.ts
@@ -38,6 +38,45 @@ describe('AI assistant nullable organization unique indexes', () => {
     },
   )
 
+  it('declares every snapshot expression index on the participants entity (no snapshot/entity drift)', () => {
+    const snapshot = JSON.parse(
+      readFileSync(
+        new URL('../../migrations/.snapshot-open-mercato.json', import.meta.url),
+        'utf8',
+      ),
+    ) as {
+      tables: Array<{ name: string; indexes?: Array<{ keyName: string; expression?: string }> }>
+    }
+
+    const participants = snapshot.tables.find(
+      (table) => table.name === 'ai_chat_conversation_participants',
+    )
+    expect(participants).toBeDefined()
+
+    const entitySource = readFileSync(
+      new URL('../entities.ts', import.meta.url),
+      'utf8',
+    )
+
+    const expressionIndexes = (participants?.indexes ?? []).filter((index) => index.expression)
+    expect(expressionIndexes.length).toBeGreaterThan(0)
+
+    for (const index of expressionIndexes) {
+      expect(entitySource).toContain(index.keyName)
+    }
+  })
+
+  it('keeps the active-participants partial index declared on the entity', () => {
+    const entitySource = readFileSync(
+      new URL('../entities.ts', import.meta.url),
+      'utf8',
+    )
+
+    expect(entitySource).toContain(
+      'create index "ai_chat_conv_participants_active_conv_user_idx" on "ai_chat_conversation_participants" ("tenant_id", "organization_id", "conversation_id", "user_id") where "deleted_at" is null',
+    )
+  })
+
   it('keeps the module snapshot aligned with partial unique indexes', () => {
     const snapshot = JSON.parse(
       readFileSync(

--- a/packages/ai-assistant/src/modules/ai_assistant/data/entities.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/data/entities.ts
@@ -790,6 +790,11 @@ export class AiChatConversation {
     'create unique index "ai_chat_conv_participants_tenant_conv_user_null_org_uq" on "ai_chat_conversation_participants" ("tenant_id", "conversation_id", "user_id") where "organization_id" is null',
 })
 @Index({
+  name: 'ai_chat_conv_participants_active_conv_user_idx',
+  expression:
+    'create index "ai_chat_conv_participants_active_conv_user_idx" on "ai_chat_conversation_participants" ("tenant_id", "organization_id", "conversation_id", "user_id") where "deleted_at" is null',
+})
+@Index({
   name: 'ai_chat_conv_participants_tenant_org_user_conv_idx',
   properties: ['tenantId', 'organizationId', 'userId', 'conversationId'],
 })


### PR DESCRIPTION
Fixes #3025

## Problem
On a clean checkout, `yarn db:generate` — without touching the `ai_assistant` module — emits a phantom migration that drops the partial index `ai_chat_conv_participants_active_conv_user_idx` on `ai_chat_conversation_participants`. The drop reappears on every run.

## Root Cause
Snapshot/entity drift. PR #1969/#2023 hand-wrote `Migration20260522120000_ai_assistant` (which adds the `deleted_at` column and creates the active-rows partial index) and updated `migrations/.snapshot-open-mercato.json` to record the index — but the matching `@Index` decorator was never added to the `AiChatConversationParticipant` entity. The index has therefore never existed in the entity metadata in git history, so the generator diffs the entity against the snapshot and produces a spurious "drop index" migration for an otherwise-unmodified module.

## What Changed
- Re-declared the `ai_chat_conv_participants_active_conv_user_idx` partial index on the `AiChatConversationParticipant` entity using the **exact** expression string already stored in the snapshot, so entity ↔ snapshot ↔ deployed schema all agree.
- This is a **declaration-only** fix: the index already exists in every migrated database (created by `Migration20260522120000`) and in the snapshot, so there is no schema change and no new migration — the change simply stops the generator from emitting the phantom drop.

## Tests
- Extended `data/__tests__/schema-unique-indexes.test.ts` with two cases:
  - asserts the entity source declares **every** expression-based snapshot index for `ai_chat_conversation_participants` (guards this drift class generally);
  - asserts the active-participants partial index expression is present on the entity.
- Verified both tests **fail without the fix** and pass with it.
- Full `@open-mercato/ai-assistant` suite green: **1247 passed / 88 suites**. Package builds successfully.
- Note: a live `yarn db:generate` could not be exercised in this environment (no database configured). Correctness rests on the decorator's `expression` being byte-identical to the snapshot entry — MikroORM's expression-index diff compares those strings, so the diff is empty by construction — backed by the regression test.

## Backward Compatibility
No contract surface changes. No API response fields, event IDs, widget spot IDs, ACL features, DI names, or import paths affected. No DB schema change (the index already exists everywhere); no migration added.
