### PR TITLE
perf(cache): hoist the cache service to a process-wide singleton in bootstrap (#2961)

### DIFF
--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -201,6 +201,16 @@ CACHE_STRATEGY=sqlite
 # Default TTL in milliseconds (optional)
 CACHE_TTL=300000
 
+# Max entries retained by the in-memory cache strategy before LRU eviction
+# (default: 50000). Bounds memory for the process-wide cache singleton. A
+# non-positive value disables the cap (unbounded — not recommended).
+#CACHE_MEMORY_MAX_ENTRIES=50000
+
+# The cache service is shared process-wide (a singleton) so cross-request
+# caches actually hit. Set to off/false to fall back to a per-request cache
+# instance (legacy behavior). Default: on.
+#OM_CACHE_SINGLETON=on
+
 # Redis Configuration
 #REDIS_PORT=6379
 # Memory ceiling for the Redis container in Docker Compose (default: 512mb).

--- a/packages/cache/src/__tests__/memory.strategy.test.ts
+++ b/packages/cache/src/__tests__/memory.strategy.test.ts
@@ -259,4 +259,55 @@ describe('Memory Cache Strategy', () => {
       expect(stats.expired).toBe(1)
     })
   })
+
+  describe('LRU bounding (maxEntries)', () => {
+    it('evicts the least-recently-used entry once the cap is exceeded', async () => {
+      const bounded = createMemoryStrategy({ maxEntries: 3 })
+      await bounded.set('a', 1)
+      await bounded.set('b', 2)
+      await bounded.set('c', 3)
+      // Inserting a 4th entry evicts the oldest (a)
+      await bounded.set('d', 4)
+
+      expect(await bounded.get('a')).toBeNull()
+      expect(await bounded.get('b')).toBe(2)
+      expect(await bounded.get('c')).toBe(3)
+      expect(await bounded.get('d')).toBe(4)
+      expect((await bounded.stats()).size).toBe(3)
+    })
+
+    it('keeps recently-read entries alive (reads refresh LRU position)', async () => {
+      const bounded = createMemoryStrategy({ maxEntries: 3 })
+      await bounded.set('a', 1)
+      await bounded.set('b', 2)
+      await bounded.set('c', 3)
+      // Touch 'a' so it becomes most-recently-used; 'b' is now the oldest
+      expect(await bounded.get('a')).toBe(1)
+      await bounded.set('d', 4)
+
+      expect(await bounded.get('a')).toBe(1)
+      expect(await bounded.get('b')).toBeNull()
+      expect(await bounded.get('c')).toBe(3)
+      expect(await bounded.get('d')).toBe(4)
+    })
+
+    it('drops evicted keys from the tag index so deleteByTags stays consistent', async () => {
+      const bounded = createMemoryStrategy({ maxEntries: 2 })
+      await bounded.set('a', 1, { tags: ['shared'] })
+      await bounded.set('b', 2, { tags: ['shared'] })
+      await bounded.set('c', 3, { tags: ['shared'] }) // evicts 'a'
+
+      const removed = await bounded.deleteByTags(['shared'])
+      expect(removed).toBe(2)
+      expect((await bounded.stats()).size).toBe(0)
+    })
+
+    it('treats a non-positive cap as unbounded', async () => {
+      const unbounded = createMemoryStrategy({ maxEntries: 0 })
+      for (let index = 0; index < 100; index += 1) {
+        await unbounded.set(`key${index}`, index)
+      }
+      expect((await unbounded.stats()).size).toBe(100)
+    })
+  })
 })

--- a/packages/cache/src/service.ts
+++ b/packages/cache/src/service.ts
@@ -225,8 +225,12 @@ export function createCacheService(options?: CacheServiceOptions): CacheStrategy
   const parsedEnvTtl = envTtl ? Number.parseInt(envTtl, 10) : undefined
   const defaultTtl = options?.defaultTtl ?? (typeof parsedEnvTtl === 'number' && Number.isFinite(parsedEnvTtl) ? parsedEnvTtl : undefined)
 
-  const baseStrategy = createStrategyForType(strategyType, options, defaultTtl)
-  const resilientStrategy = withDependencyFallback(baseStrategy, strategyType, defaultTtl)
+  const envMaxEntries = process.env.CACHE_MEMORY_MAX_ENTRIES
+  const parsedEnvMaxEntries = envMaxEntries ? Number.parseInt(envMaxEntries, 10) : undefined
+  const maxEntries = options?.maxEntries ?? (typeof parsedEnvMaxEntries === 'number' && Number.isFinite(parsedEnvMaxEntries) ? parsedEnvMaxEntries : undefined)
+
+  const baseStrategy = createStrategyForType(strategyType, options, defaultTtl, maxEntries)
+  const resilientStrategy = withDependencyFallback(baseStrategy, strategyType, defaultTtl, maxEntries)
 
   return createTenantAwareWrapper(resilientStrategy)
 }
@@ -288,7 +292,7 @@ export class CacheService implements CacheStrategy {
   }
 }
 
-function createStrategyForType(strategyType: CacheStrategyName, options?: CacheServiceOptions, defaultTtl?: number): CacheStrategy {
+function createStrategyForType(strategyType: CacheStrategyName, options?: CacheServiceOptions, defaultTtl?: number, maxEntries?: number): CacheStrategy {
   switch (strategyType) {
     case 'redis':
       return createRedisStrategy(options?.redisUrl, { defaultTtl })
@@ -298,7 +302,7 @@ function createStrategyForType(strategyType: CacheStrategyName, options?: CacheS
       return createJsonFileStrategy(options?.jsonFilePath, { defaultTtl })
     case 'memory':
     default:
-      return createMemoryStrategy({ defaultTtl })
+      return createMemoryStrategy({ defaultTtl, maxEntries })
   }
 }
 
@@ -324,7 +328,7 @@ function describeDependencyFailure(error: CacheDependencyUnavailableError): stri
   return `${error.dependency} failed to load`
 }
 
-function withDependencyFallback(strategy: CacheStrategy, strategyType: CacheStrategyName, defaultTtl?: number): CacheStrategy {
+function withDependencyFallback(strategy: CacheStrategy, strategyType: CacheStrategyName, defaultTtl?: number, maxEntries?: number): CacheStrategy {
   if (strategyType === 'memory') return strategy
 
   let activeStrategy = strategy
@@ -333,7 +337,7 @@ function withDependencyFallback(strategy: CacheStrategy, strategyType: CacheStra
 
   const ensureFallback = (error: CacheDependencyUnavailableError) => {
     if (!fallbackStrategy) {
-      fallbackStrategy = createMemoryStrategy({ defaultTtl })
+      fallbackStrategy = createMemoryStrategy({ defaultTtl, maxEntries })
     }
     if (!warned) {
       const dependencyMessage = error.dependency

--- a/packages/cache/src/strategies/memory.ts
+++ b/packages/cache/src/strategies/memory.ts
@@ -2,17 +2,53 @@ import type { CacheStrategy, CacheEntry, CacheGetOptions, CacheSetOptions, Cache
 import { matchCacheKeyPattern } from '../patterns'
 
 /**
+ * Default upper bound on the number of entries a memory cache retains.
+ * Bounds memory for long-lived (process-wide) instances; LRU eviction drops
+ * the least-recently-used entries once the cap is exceeded. Override via the
+ * `maxEntries` option (or `CACHE_MEMORY_MAX_ENTRIES`); a non-positive value
+ * disables the cap (unbounded — only safe for short-lived instances).
+ */
+export const DEFAULT_MEMORY_MAX_ENTRIES = 50_000
+
+function normalizeMaxEntries(raw?: number): number {
+  if (raw === undefined) return DEFAULT_MEMORY_MAX_ENTRIES
+  if (!Number.isFinite(raw) || raw <= 0) return Number.POSITIVE_INFINITY
+  return Math.floor(raw)
+}
+
+/**
  * In-memory cache strategy with tag support
  * Fast but data is lost when process restarts
  */
-export function createMemoryStrategy(options?: { defaultTtl?: number }): CacheStrategy {
+export function createMemoryStrategy(options?: { defaultTtl?: number; maxEntries?: number }): CacheStrategy {
   const store = new Map<string, CacheEntry>()
   const tagIndex = new Map<string, Set<string>>() // tag -> Set of keys
   const defaultTtl = options?.defaultTtl
+  const maxEntries = normalizeMaxEntries(options?.maxEntries)
 
   function isExpired(entry: CacheEntry): boolean {
     if (entry.expiresAt === null) return false
     return Date.now() > entry.expiresAt
+  }
+
+  // LRU bookkeeping: re-insert on read so the most-recently-used entry moves
+  // to the tail (Map preserves insertion order), mirroring the rbacDefaultCache
+  // precedent; evictIfNeeded then drops from the head (least-recently-used).
+  function touchKey(key: string, entry: CacheEntry): void {
+    if (maxEntries === Number.POSITIVE_INFINITY) return
+    store.delete(key)
+    store.set(key, entry)
+  }
+
+  function evictIfNeeded(): void {
+    if (maxEntries === Number.POSITIVE_INFINITY) return
+    while (store.size > maxEntries) {
+      const oldest = store.keys().next().value
+      if (typeof oldest !== 'string') break
+      const entry = store.get(oldest)
+      store.delete(oldest)
+      if (entry) removeFromTagIndex(oldest, entry.tags)
+    }
   }
 
   function cleanupExpiredEntry(key: string, entry: CacheEntry): void {
@@ -62,6 +98,7 @@ export function createMemoryStrategy(options?: { defaultTtl?: number }): CacheSt
       return null
     }
 
+    touchKey(key, entry)
     return entry.value
   }
 
@@ -86,6 +123,7 @@ export function createMemoryStrategy(options?: { defaultTtl?: number }): CacheSt
 
     store.set(key, entry)
     addToTagIndex(key, tags)
+    evictIfNeeded()
   }
 
   const has = async (key: string): Promise<boolean> => {

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -102,4 +102,12 @@ export type CacheServiceOptions = {
   sqlitePath?: string
   jsonFilePath?: string
   defaultTtl?: number
+  /**
+   * Upper bound on retained entries for the in-memory strategy (including the
+   * memory fallback used when a native dependency is unavailable). Bounds
+   * memory for process-wide instances via LRU eviction. Falls back to
+   * `CACHE_MEMORY_MAX_ENTRIES` then a built-in default; a non-positive value
+   * disables the cap.
+   */
+  maxEntries?: number
 }

--- a/packages/core/src/__tests__/cacheSingleton.test.ts
+++ b/packages/core/src/__tests__/cacheSingleton.test.ts
@@ -1,0 +1,58 @@
+// bootstrap.ts pulls in sibling packages that have no jest module mapping in
+// this workspace; getCachedCacheService only needs the real @open-mercato/cache,
+// so stub the rest to keep the unit test focused and resolvable.
+jest.mock('@open-mercato/events/index', () => ({ createEventBus: jest.fn() }), { virtual: true })
+jest.mock('@open-mercato/search', () => ({
+  registerSearchModule: jest.fn(),
+  createSearchDeleteSubscriber: jest.fn(),
+  searchDeleteMetadata: {},
+}), { virtual: true })
+
+import { getCachedCacheService } from '../bootstrap'
+
+const CACHE_GLOBAL_KEY = '__openMercatoCacheService__'
+const CACHE_SHUTDOWN_KEY = '__openMercatoCacheShutdown__'
+
+describe('getCachedCacheService', () => {
+  const originalSingletonEnv = process.env.OM_CACHE_SINGLETON
+  const originalStrategy = process.env.CACHE_STRATEGY
+
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>)[CACHE_GLOBAL_KEY]
+    delete (globalThis as Record<string, unknown>)[CACHE_SHUTDOWN_KEY]
+    delete process.env.OM_CACHE_SINGLETON
+    process.env.CACHE_STRATEGY = 'memory'
+  })
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>)[CACHE_GLOBAL_KEY]
+    delete (globalThis as Record<string, unknown>)[CACHE_SHUTDOWN_KEY]
+    if (originalSingletonEnv === undefined) delete process.env.OM_CACHE_SINGLETON
+    else process.env.OM_CACHE_SINGLETON = originalSingletonEnv
+    if (originalStrategy === undefined) delete process.env.CACHE_STRATEGY
+    else process.env.CACHE_STRATEGY = originalStrategy
+  })
+
+  it('returns the same instance across calls so caches survive request containers', () => {
+    const first = getCachedCacheService()
+    const second = getCachedCacheService()
+    expect(first).not.toBeNull()
+    expect(second).toBe(first)
+  })
+
+  it('returns a working cache strategy', async () => {
+    const cache = getCachedCacheService()
+    expect(cache).not.toBeNull()
+    await cache!.set('singleton-key', 'singleton-value')
+    expect(await cache!.get('singleton-key')).toBe('singleton-value')
+  })
+
+  it('returns null when disabled via the OM_CACHE_SINGLETON escape hatch', () => {
+    process.env.OM_CACHE_SINGLETON = 'off'
+    expect(getCachedCacheService()).toBeNull()
+  })
+
+  it('treats an unset OM_CACHE_SINGLETON as enabled', () => {
+    expect(getCachedCacheService()).not.toBeNull()
+  })
+})

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -3,6 +3,7 @@ import { asValue } from 'awilix'
 import { createEventBus } from '@open-mercato/events/index'
 import { setGlobalEventBus } from '@open-mercato/shared/modules/events'
 import { createCacheService } from '@open-mercato/cache'
+import type { CacheStrategy } from '@open-mercato/cache'
 import { createKmsService } from '@open-mercato/shared/lib/encryption/kms'
 import { TenantDataEncryptionService } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
 import { registerTenantEncryptionSubscriber } from '@open-mercato/shared/lib/encryption/subscriber'
@@ -20,6 +21,59 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 // Use globalThis to survive tsx/webpack module duplication (same pattern as container.ts DI registrars)
 const RL_GLOBAL_KEY = '__openMercatoRateLimiterService__'
 const RL_SHUTDOWN_KEY = '__openMercatoRateLimiterShutdown__'
+
+const CACHE_GLOBAL_KEY = '__openMercatoCacheService__'
+const CACHE_SHUTDOWN_KEY = '__openMercatoCacheShutdown__'
+
+// Escape hatch: set OM_CACHE_SINGLETON=off to fall back to the legacy
+// per-request cache instance (e.g. to isolate a regression). Default ON.
+function isCacheSingletonEnabled(): boolean {
+  const raw = process.env.OM_CACHE_SINGLETON
+  if (raw === undefined) return true
+  const normalized = raw.trim().toLowerCase()
+  if (!normalized.length) return true
+  return !(normalized === '0' || normalized === 'off' || normalized === 'false' || normalized === 'no')
+}
+
+/**
+ * Process-wide cache service singleton, mirroring getCachedRateLimiterService.
+ *
+ * bootstrap() previously built a fresh cache per request container, so under
+ * the default memory strategy every cross-request cache was a no-op (each
+ * instance is process-local) and under sqlite each request leaked a native
+ * handle. Reusing one instance is safe by construction: tenant scope resolves
+ * per-call via AsyncLocalStorage (packages/cache/src/tenantContext.ts), so the
+ * service holds no request-bound state.
+ *
+ * Returns null when disabled via the escape hatch or when creation fails, so
+ * the caller falls back to a per-request instance.
+ */
+export function getCachedCacheService(): CacheStrategy | null {
+  if (!isCacheSingletonEnabled()) return null
+  let service = (globalThis as any)[CACHE_GLOBAL_KEY] as CacheStrategy | null ?? null
+  if (!service) {
+    try {
+      try {
+        service = createCacheService()
+      } catch (err) {
+        console.warn('Cache service initialization failed; falling back to memory strategy:', (err as Error)?.message || err)
+        service = createCacheService({ strategy: 'memory' })
+      }
+      ;(globalThis as any)[CACHE_GLOBAL_KEY] = service
+
+      // Register shutdown hook once to close persistent handles (sqlite/redis) on process exit
+      if (!(globalThis as any)[CACHE_SHUTDOWN_KEY]) {
+        const shutdown = () => { service?.close?.().catch(() => {}) }
+        process.once('SIGTERM', shutdown)
+        process.once('SIGINT', shutdown)
+        ;(globalThis as any)[CACHE_SHUTDOWN_KEY] = true
+      }
+    } catch (err) {
+      console.warn('[cache] Failed to create cache service:', (err as Error)?.message || err)
+    }
+  }
+  return service
+}
 
 export function getCachedRateLimiterService(): RateLimiterService | null {
   let service = (globalThis as any)[RL_GLOBAL_KEY] as RateLimiterService | null ?? null
@@ -50,13 +104,17 @@ export function getCachedRateLimiterService(): RateLimiterService | null {
 }
 
 export async function bootstrap(container: AwilixContainer) {
-  // Create and register the cache service
-  let cache: any
-  try {
-    cache = createCacheService()
-  } catch (err: any) {
-    console.warn('Cache service initialization failed; falling back to memory strategy:', err?.message || err)
-    cache = createCacheService({ strategy: 'memory' })
+  // Register the cache service. Prefer the process-wide singleton so caches
+  // survive across request containers; fall back to a per-request instance
+  // when the singleton is disabled or fails to build.
+  let cache: any = getCachedCacheService()
+  if (!cache) {
+    try {
+      cache = createCacheService()
+    } catch (err: any) {
+      console.warn('Cache service initialization failed; falling back to memory strategy:', err?.message || err)
+      cache = createCacheService({ strategy: 'memory' })
+    }
   }
   container.register({ cache: asValue(cache) })
 

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -194,6 +194,16 @@ CACHE_STRATEGY=sqlite
 # Default TTL in milliseconds (optional)
 CACHE_TTL=300000
 
+# Max entries retained by the in-memory cache strategy before LRU eviction
+# (default: 50000). Bounds memory for the process-wide cache singleton. A
+# non-positive value disables the cap (unbounded — not recommended).
+#CACHE_MEMORY_MAX_ENTRIES=50000
+
+# The cache service is shared process-wide (a singleton) so cross-request
+# caches actually hit. Set to off/false to fall back to a per-request cache
+# instance (legacy behavior). Default: on.
+#OM_CACHE_SINGLETON=on
+
 # Redis Configuration
 #REDIS_PORT=6379
 


### PR DESCRIPTION
Fixes #2961

## Problem
`bootstrap()` rebuilt the cache service with `createCacheService()` on every request container, and an authenticated request constructs 2–3 containers. Under the default memory strategy each instance is process-local, so every cross-request cache was effectively a no-op — RBAC's 5-minute ACL cache, nav, org-scope, business-rules, and the ~42 other `resolve('cache')` consumers re-ran their full query chains on each request. Under the shipped `CACHE_STRATEGY=sqlite` default, each container opened a fresh `better-sqlite3` handle (PRAGMA + DDL churn) and never closed it, so handle count grew with request volume.

## Root Cause
The cache was constructed per request container instead of once per process — unlike the rate limiter (`getCachedRateLimiterService`), which is already a `globalThis` singleton with a SIGTERM/SIGINT close hook.

## What Changed
- **`getCachedCacheService()` in `packages/core/src/bootstrap.ts`** — mirrors `getCachedRateLimiterService` exactly: same DI key `cache`, a `globalThis` key to survive module duplication, a once-registered SIGTERM/SIGINT `close()` hook (closes persistent sqlite/redis handles on exit), and an `OM_CACHE_SINGLETON` escape hatch (default ON). It returns `null` when disabled or when creation fails, so `bootstrap()` falls back to the legacy per-request instance.
- **`bootstrap()`** now registers the shared singleton, falling back to a per-request instance only when the singleton is disabled/unavailable.
- **LRU cap on `createMemoryStrategy` (hard prerequisite)** — added a `maxEntries` cap (default `50000`, configurable via `CACHE_MEMORY_MAX_ENTRIES`; a non-positive value disables it), porting the `rbacDefaultCache` Map-reinsertion LRU precedent, so a now-process-lifetime memory cache can't grow unbounded. Threaded through `CacheServiceOptions` and the memory-fallback path.
- Documented `CACHE_MEMORY_MAX_ENTRIES` and `OM_CACHE_SINGLETON` in `apps/mercato/.env.example` and the create-app template `.env.example`.

It is safe by construction: tenant scope resolves per-call through `AsyncLocalStorage` (`packages/cache/src/tenantContext.ts`) and the service carries no request state, so this targeted hoist does not require the default-OFF `OM_BOOTSTRAP_CACHE` replay.

## Tests
- `packages/cache/src/__tests__/memory.strategy.test.ts` — LRU eviction at the cap, read-refreshes-LRU-position, tag-index consistency on eviction, and non-positive-cap = unbounded.
- `packages/core/src/__tests__/cacheSingleton.test.ts` — singleton identity across calls, working get/set through the shared instance, and the `OM_CACHE_SINGLETON` escape hatch returning `null`.
- Verified: `@open-mercato/cache` 47/47 pass; `@open-mercato/core` 5854 pass (1 pre-existing locale-dependent failure in `DealsKpiStrip.test.tsx`, unrelated — the component formats via `Intl.NumberFormat(undefined, …)` and the test asserts the `en` output `'1K'`; this box's default locale is `pl-PL`). Typecheck green for both packages.

## Backward Compatibility
No contract surface removed or changed. Additions only: optional `maxEntries` on `CacheServiceOptions`/`createMemoryStrategy`, new exported `DEFAULT_MEMORY_MAX_ENTRIES`, and new `getCachedCacheService`. DI key `cache`, the `CacheStrategy` shape, and fallback-to-memory behavior are unchanged. Behavior changes (intentional, per the issue): the cache is now process-shared by default, and the memory strategy now applies a default LRU cap — both gated by env escape hatches (`OM_CACHE_SINGLETON`, `CACHE_MEMORY_MAX_ENTRIES`).

## Security impact
Touches the access-control-adjacent cache path (RBAC's 5-minute ACL cache resolves `cache`). The ACL cache TTL (5 min) and tag-based invalidation are unchanged; the cache simply now persists across requests as originally intended rather than being rebuilt per request. Tenant/organization isolation is preserved — scoping resolves per-call via `AsyncLocalStorage` and the shared service holds no request-bound state, so no cross-tenant leakage is introduced. The new LRU cap can only evict entries (causing a cache miss → fresh authoritative query), never serve another tenant's data. The SIGTERM/SIGINT hook closes persistent cache handles on shutdown.
