### PR TITLE
fix(ui): keep DataTable columns and pagination footer usable on mobile

### DIFF
--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -367,10 +367,14 @@ const EMPTY_FILTER_VALUES: FilterValues = Object.freeze({}) as FilterValues
 //   sticky right-0  → shadow falls to the LEFT  (use `before:` + `-left-2` + `to-l`)
 //   sticky left-0   → shadow falls to the RIGHT (use `after:`  + `-right-2` + `to-r`)
 // `foreground/8` matches the `--shadow-md` token opacity (8%) and is theme-aware.
+// Column pinning (and these shadows) is md-and-up only: below `md` the pinned
+// first column + actions column can be wider than the whole viewport, which
+// leaves the scrollable middle columns no visible window at all — narrow
+// screens fall back to plain horizontal scroll so every column stays reachable.
 const STICKY_RIGHT_SHADOW_CLASS =
-  'before:absolute before:inset-y-0 before:-left-2 before:w-2 before:bg-gradient-to-l before:from-foreground/8 before:to-transparent before:pointer-events-none'
+  'md:before:absolute md:before:inset-y-0 md:before:-left-2 md:before:w-2 md:before:bg-gradient-to-l md:before:from-foreground/8 md:before:to-transparent md:before:pointer-events-none'
 const STICKY_LEFT_SHADOW_CLASS =
-  'after:absolute after:inset-y-0 after:-right-2 after:w-2 after:bg-gradient-to-r after:from-foreground/8 after:to-transparent after:pointer-events-none'
+  'md:after:absolute md:after:inset-y-0 md:after:-right-2 md:after:w-2 md:after:bg-gradient-to-r md:after:from-foreground/8 md:after:to-transparent md:after:pointer-events-none'
 
 type BulkActionExecuteResult = {
   ok: boolean
@@ -2708,7 +2712,7 @@ export function DataTable<T>({
                   const columnMeta = (header.column.columnDef as any)?.meta
                   const priority = resolvePriority(header.column)
                   const isFirstDataColumn = headerIndex === 0
-                  const stickyClass = stickyFirstColumn && isFirstDataColumn ? ` sticky left-0 z-10 bg-background ${STICKY_LEFT_SHADOW_CLASS}` : ''
+                  const stickyClass = stickyFirstColumn && isFirstDataColumn ? ` md:sticky md:left-0 md:z-10 md:bg-background ${STICKY_LEFT_SHADOW_CLASS}` : ''
                   const headerCellContent = header.isPlaceholder ? null : (
                     <Button
                       variant="ghost"
@@ -2741,7 +2745,7 @@ export function DataTable<T>({
                   <TableHead
                     className={cn(
                       actionsColumnAlign === 'center' ? 'w-0 text-center' : 'w-0 text-right',
-                      stickyActionsColumn && `sticky right-0 z-20 bg-background ${STICKY_RIGHT_SHADOW_CLASS}`,
+                      stickyActionsColumn && `md:sticky md:right-0 md:z-20 md:bg-background ${STICKY_RIGHT_SHADOW_CLASS}`,
                     )}
                   >
                     {t('ui.dataTable.actionsColumn', 'Actions')}
@@ -2863,7 +2867,7 @@ export function DataTable<T>({
                       ) : content
 
                       return (
-                        <TableCell key={cell.id} className={responsiveClass(priority, columnMeta?.hidden) + (isStickyCell ? ` sticky left-0 z-10 bg-background ${STICKY_LEFT_SHADOW_CLASS}` : '')}>
+                        <TableCell key={cell.id} className={responsiveClass(priority, columnMeta?.hidden) + (isStickyCell ? ` md:sticky md:left-0 md:z-10 md:bg-background ${STICKY_LEFT_SHADOW_CLASS}` : '')}>
                           {wrappedContent}
                         </TableCell>
                       )
@@ -2872,7 +2876,7 @@ export function DataTable<T>({
                       <TableCell
                         className={cn(
                           actionsColumnAlign === 'center' ? 'text-center whitespace-nowrap' : 'text-right whitespace-nowrap',
-                          stickyActionsColumn && `sticky right-0 z-10 bg-background ${STICKY_RIGHT_SHADOW_CLASS}`,
+                          stickyActionsColumn && `md:sticky md:right-0 md:z-10 md:bg-background ${STICKY_RIGHT_SHADOW_CLASS}`,
                         )}
                         data-actions-cell
                       >

--- a/packages/ui/src/backend/__tests__/DataTable.stickyResponsive.test.tsx
+++ b/packages/ui/src/backend/__tests__/DataTable.stickyResponsive.test.tsx
@@ -1,0 +1,99 @@
+/** @jest-environment jsdom */
+import * as React from 'react'
+import { DataTable } from '../DataTable'
+import type { ColumnDef } from '@tanstack/react-table'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+import { render } from '@testing-library/react'
+import { RowActions } from '../RowActions'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+}))
+
+jest.mock('../injection/useInjectionDataWidgets', () => ({
+  useInjectionDataWidgets: () => ({ widgets: [], isLoading: false }),
+}))
+
+type Row = { id: string; title: string; status: string }
+
+const tokensOf = (el: Element | null): string[] =>
+  (el?.getAttribute('class') ?? '').split(/\s+/).filter(Boolean)
+
+// Pinned columns must never consume the viewport on phones: an unconditionally
+// `sticky` first column (often ~300px wide) plus a sticky actions column can
+// exceed a small screen entirely, leaving the middle columns scrolling
+// invisibly underneath with no reachable window. Pinning (position, offsets,
+// z-index, opaque background, edge shadows) must therefore apply only from the
+// `md` breakpoint up, so narrow viewports fall back to the documented plain
+// horizontal-scroll behavior where every column can be swiped into view.
+describe('DataTable sticky columns are viewport-gated', () => {
+  function renderStickyTable() {
+    const columns: ColumnDef<Row>[] = [
+      { accessorKey: 'title', header: 'Title' },
+      { accessorKey: 'status', header: 'Status' },
+    ]
+    const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+    const result = render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider locale="en" dict={{}}>
+          <DataTable
+            columns={columns}
+            data={[{ id: '1', title: 'Solar rollout', status: 'open' }]}
+            stickyFirstColumn
+            stickyActionsColumn
+            rowActions={() => (
+              <RowActions items={[{ id: 'edit', label: 'Edit', onSelect: () => {} }]} />
+            )}
+          />
+        </I18nProvider>
+      </QueryClientProvider>,
+    )
+    return { ...result, queryClient }
+  }
+
+  it('pins the first data column only from md up', () => {
+    const { container, queryClient } = renderStickyTable()
+    try {
+      const headerCells = container.querySelectorAll('thead th')
+      const firstHeader = headerCells[0]
+      const firstBodyCell = container.querySelector('tbody tr td')
+
+      for (const cell of [firstHeader, firstBodyCell]) {
+        const tokens = tokensOf(cell)
+        expect(tokens).toEqual(
+          expect.arrayContaining(['md:sticky', 'md:left-0', 'md:bg-background', 'md:after:absolute']),
+        )
+        expect(tokens).not.toContain('sticky')
+        expect(tokens).not.toContain('left-0')
+        expect(tokens).not.toContain('bg-background')
+        expect(tokens).not.toContain('after:absolute')
+      }
+    } finally {
+      queryClient.clear()
+    }
+  })
+
+  it('pins the actions column only from md up', () => {
+    const { container, queryClient } = renderStickyTable()
+    try {
+      const headerCells = container.querySelectorAll('thead th')
+      const actionsHeader = headerCells[headerCells.length - 1]
+      const actionsBodyCell = container.querySelector('tbody tr td[data-actions-cell]')
+      expect(actionsBodyCell).not.toBeNull()
+
+      for (const cell of [actionsHeader, actionsBodyCell]) {
+        const tokens = tokensOf(cell)
+        expect(tokens).toEqual(
+          expect.arrayContaining(['md:sticky', 'md:right-0', 'md:bg-background', 'md:before:absolute']),
+        )
+        expect(tokens).not.toContain('sticky')
+        expect(tokens).not.toContain('right-0')
+        expect(tokens).not.toContain('bg-background')
+        expect(tokens).not.toContain('before:absolute')
+      }
+    } finally {
+      queryClient.clear()
+    }
+  })
+})

--- a/packages/ui/src/primitives/__tests__/pagination.test.tsx
+++ b/packages/ui/src/primitives/__tests__/pagination.test.tsx
@@ -60,6 +60,37 @@ describe('Pagination', () => {
     expect(nav.getAttribute('aria-label')).toBe('Pagination')
   })
 
+  // The info text, page buttons, and page-size select together need ~600px of
+  // min-content (info and the select are shrink-0). Without flex-wrap the row
+  // cannot compress on a phone-width container, overflows its card, and drags
+  // the whole page into horizontal scroll. Every level that holds a fixed-width,
+  // shrink-0 button run must be allowed to wrap: the root row, the controls
+  // group (first/prev/pages/next/last ≈ 392px at 6 pages — wider than a phone
+  // on its own), and the page-number list itself (so a long run wraps instead
+  // of overflowing). Wrapping just the outer row leaves the ~392px controls
+  // group on a single unbreakable line that still overflows.
+  it('lets every fixed-width control row wrap on narrow containers', () => {
+    const { container } = render(
+      <Pagination
+        page={3}
+        pageSize={20}
+        total={120}
+        onPageChange={() => {}}
+        onPageSizeChange={() => {}}
+      />,
+    )
+    const tokensOf = (selector: string) => {
+      const el = container.querySelector(selector) as HTMLElement | null
+      expect(el).not.toBeNull()
+      return (el!.getAttribute('class') ?? '').split(/\s+/).filter(Boolean)
+    }
+    expect(tokensOf('[data-slot="pagination"]')).toEqual(
+      expect.arrayContaining(['flex-wrap', 'justify-between']),
+    )
+    expect(tokensOf('[data-slot="pagination-controls"]')).toContain('flex-wrap')
+    expect(tokensOf('[data-slot="pagination-pages"]')).toContain('flex-wrap')
+  })
+
   it('renders "Page X of Y" info by default', () => {
     const { container } = render(
       <Pagination page={2} pageSize={10} total={100} onPageChange={() => {}} />,

--- a/packages/ui/src/primitives/pagination.tsx
+++ b/packages/ui/src/primitives/pagination.tsx
@@ -235,7 +235,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
         ref={ref}
         data-slot="pagination"
         aria-label={props['aria-label'] ?? t('ui.pagination.landmark.ariaLabel', 'Pagination')}
-        className={cn('flex w-full items-center justify-between gap-6', className)}
+        className={cn('flex w-full flex-wrap items-center justify-between gap-x-6 gap-y-2', className)}
         {...props}
       >
         {showInfo ? (
@@ -251,7 +251,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
 
         <div
           data-slot="pagination-controls"
-          className="inline-flex items-center gap-2"
+          className="flex flex-wrap items-center justify-center gap-2"
         >
           {showFirstLast ? (
             <button
@@ -280,7 +280,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
 
           <ol
             data-slot="pagination-pages"
-            className="inline-flex items-center gap-2 list-none"
+            className="flex flex-wrap items-center justify-center gap-2 list-none"
           >
             {items.map((entry, index) => {
               if (entry === 'ellipsis-left' || entry === 'ellipsis-right') {


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The CRM deals list (reported from a mobile screenshot) — and every other page using the shared `DataTable` — was unusable on phones in two independent ways:

1. **Sticky column pinning.** With `stickyFirstColumn` (~300px) + `stickyActionsColumn` (~82px) + the bulk checkbox, the pinned columns are wider than a phone's scroll viewport, so the middle columns (status, stage, value, owner, custom fields, …) scrolled invisibly *underneath* the pinned edges with no reachable window. Only a truncated Title and the Actions kebab were visible, separated by a dead opaque band.
2. **Pagination footer overflow.** The footer's button rows were non-wrapping `inline-flex` with `shrink-0` buttons, so once the page-number run was wider than the viewport (~392px at 6 pages) it forced **page-level** horizontal scroll — deal titles slid off-screen and "20 per page" floated past the card edge into a black void.

Both are presentational; no data, API, or `DataTable`/`Pagination` prop contracts change.

## Changes

- `packages/ui/src/backend/DataTable.tsx`: `md:`-gate the first-column and actions-column pinning utilities (`sticky`, `left-0`/`right-0`, `z-10`/`z-20`, `bg-background`) and both sticky edge-shadow class constants. Below `md` the table falls back to plain horizontal scroll (every column reachable by swipe); at `md+` the pinning is pixel-identical to before.
- `packages/ui/src/primitives/pagination.tsx`: allow every fixed-width button row to wrap on narrow viewports — `flex-wrap` + `gap-x-6 gap-y-2` on the nav root row, and `inline-flex` → `flex flex-wrap justify-center` on the controls group and the page-number list. Prevents page-level horizontal scroll when the page-button run exceeds the viewport; desktop stays a single line.
- `packages/ui/src/backend/__tests__/DataTable.stickyResponsive.test.tsx` (new): asserts the pinning class contract is `md:`-gated for the header and body cells of both pinned columns.
- `packages/ui/src/primitives/__tests__/pagination.test.tsx`: adds a test asserting `flex-wrap` on all three levels (root row, controls group, pages list) so reverting any one fails.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->
N/A — presentational responsive fix to shared UI primitives.

## Testing

- New/strengthened regression tests, red→green (fail on the pre-fix classes, pass after): `yarn workspace @open-mercato/ui jest src/backend/__tests__/DataTable.stickyResponsive.test.tsx src/primitives/__tests__/pagination.test.tsx`
- `yarn build:packages` → `yarn generate` → `yarn build:packages` — pass
- `yarn i18n:check-sync` — pass
- `yarn typecheck` — pass
- `yarn test` — pass (all packages; `@open-mercato/ui` 1541 tests incl. both regression tests)
- `yarn build:app` — pass
- Manual preview on a seeded 6-page deals list: at 390px the page has zero horizontal overflow, table columns are swipe-reachable, and the footer wraps tidily; at 1280px the pinning and the single-line footer are unchanged.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — CSS-class-level change to existing components; no strings, APIs, or auto-discovery affected.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required: the responsive class contract is pinned deterministically by the two unit-level regression tests; the deals list page itself is already covered by `TC-CRM-082`/`083`. A Playwright viewport test would re-assert the same class contract less reliably. Behavior was additionally verified manually at 390px and 1280px.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — minor presentational fix.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens (only the semantic `bg-background` token, now `md:`-gated; status colors untouched)
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` (none added; only responsive `md:` and flex utilities)
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) (unchanged; the empty-state's own `sticky` centering is intentionally untouched)
- [x] Loading state handled for async pages (unchanged)
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) (unchanged; no buttons added)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements (only `DataTable` and `Pagination` primitives modified in place)

## Linked issues

No GitHub issue — fixed from a direct mobile bug report (screenshots of the CRM deals list). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
