### PR TITLE
fix(sales): pin orders/quotes number column on horizontal scroll (#3039)

### DIFF
--- a/packages/core/src/modules/sales/components/documents/SalesDocumentsTable.tsx
+++ b/packages/core/src/modules/sales/components/documents/SalesDocumentsTable.tsx
@@ -667,6 +667,7 @@ export function SalesDocumentsTable({ kind }: { kind: SalesDocumentKind }) {
     <Page>
       <PageBody>
         <DataTable<SalesDocumentRow>
+          stickyFirstColumn
           stickyActionsColumn
           title={(
             <div className="flex flex-col">

--- a/packages/core/src/modules/sales/components/documents/__tests__/SalesDocumentsTable.stickyColumn.test.tsx
+++ b/packages/core/src/modules/sales/components/documents/__tests__/SalesDocumentsTable.stickyColumn.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, act } from '@testing-library/react'
+import { SalesDocumentsTable } from '../SalesDocumentsTable'
+
+// Capture the props handed to DataTable so we can assert the sticky-column wiring.
+const mockDataTable = jest.fn()
+const mockApiCall = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  withDataTableNamespaces: (mappedRow: Record<string, unknown>) => mappedRow,
+  DataTable: (props: any) => {
+    mockDataTable(props)
+    return null
+  },
+}))
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: any) => <div>{children}</div>,
+  PageBody: ({ children }: any) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/RowActions', () => ({
+  RowActions: ({ children }: any) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: any[]) => mockApiCall(...args),
+  withScopedApiRequestHeaders: (_header: unknown, callback: any) => callback?.(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  buildCrudExportUrl: () => '/export.csv',
+  deleteCrud: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({ confirm: jest.fn(), ConfirmDialogElement: null }),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 1,
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => {
+  // Stable reference: the real useT() is memoized. Returning a fresh function
+  // each render would re-create the data-load callback and loop the effect.
+  const translate = (key: string, fallback?: string) => fallback ?? key
+  return { useT: () => translate }
+})
+
+jest.mock('@open-mercato/core/modules/dictionaries/components/dictionaryAppearance', () => ({
+  DictionaryValue: ({ value }: any) => <span>{value}</span>,
+  createDictionaryMap: () => ({}),
+  normalizeDictionaryEntries: () => [],
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), refresh: jest.fn() }),
+}))
+
+describe('SalesDocumentsTable sticky number column (issue #3039)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockApiCall.mockResolvedValue({ ok: true, result: { items: [] } })
+  })
+
+  it.each(['order', 'quote'] as const)(
+    'pins the %s number column by passing stickyFirstColumn to DataTable',
+    async (kind) => {
+      await act(async () => {
+        render(<SalesDocumentsTable kind={kind} />)
+      })
+
+      expect(mockDataTable).toHaveBeenCalled()
+      const props = mockDataTable.mock.calls.at(-1)?.[0]
+
+      // The number column must be the first data column for stickyFirstColumn to pin it.
+      expect(props?.columns?.[0]?.id).toBe('number')
+      // Regression for #3039: DataTable applies position: sticky to the first column
+      // only when stickyFirstColumn is set; meta.sticky alone is inert.
+      expect(props?.stickyFirstColumn).toBe(true)
+    },
+  )
+})


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The orders/quotes list number column is declared sticky via `meta: { sticky: true }`, but `DataTable` ignores that property — it pins the first column only when the `stickyFirstColumn` prop is set, which `SalesDocumentsTable` never passed. So on horizontal scroll the "Order"/"Quote" number column scrolled away instead of staying pinned. This adds `stickyFirstColumn` to the table's existing `<DataTable>` call (it already passes `stickyActionsColumn`), matching the customers deals/people/companies list pages.

## Changes

- `packages/core/src/modules/sales/components/documents/SalesDocumentsTable.tsx`: pass `stickyFirstColumn` to `<DataTable>` so the first data column (the order/quote number) is pinned during horizontal scroll.
- `packages/core/src/modules/sales/components/documents/__tests__/SalesDocumentsTable.stickyColumn.test.tsx`: new render test (orders + quotes) asserting the number column is `columns[0]` and that `stickyFirstColumn: true` is handed to `DataTable` — a regression guard for the missing prop.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — one-line UI prop fix.

## Testing

- `yarn workspace @open-mercato/core test SalesDocumentsTable.stickyColumn` → 2/2 pass (verified red before the fix, green after)
- `yarn workspace @open-mercato/core test sales` → 43 suites / 311 tests pass (no regressions)
- `yarn workspace @open-mercato/ui test DataTable` → 3 suites / 15 tests pass
- `tsc -p packages/core/tsconfig.json --noEmit` → clean
- `yarn i18n:check-sync` → all locales in sync
- `yarn build:packages && yarn generate && yarn build:app` → success

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — no new strings, generators, or docs affected; i18n sync verified.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Covered by a focused render test; live sticky-scroll behavior is a manual-QA step — needs a seeded env + narrow viewport to force horizontal scroll.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — minor fix.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) (N/A — no icon-only buttons added)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3039
