### PR TITLE
fix(customers,sales): show addresses on person v2 detail + decrypt address snapshots (#3038)

### DIFF
--- a/packages/core/src/modules/customers/backend/customers/people-v2/[id]/__tests__/page.test.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people-v2/[id]/__tests__/page.test.tsx
@@ -109,12 +109,16 @@ jest.mock('../../../../../components/detail/PersonDetailHeader', () => ({
 
 jest.mock('../../../../../components/detail/PersonDetailTabs', () => ({
   resolveLegacyTab: (tab?: string | null) => {
-    if (tab === 'activities' || tab === 'companies' || tab === 'tasks' || tab === 'deals' || tab === 'files' || tab === 'changelog') {
+    if (tab === 'activities' || tab === 'companies' || tab === 'tasks' || tab === 'deals' || tab === 'files' || tab === 'changelog' || tab === 'addresses') {
       return tab
     }
     return 'activities'
   },
   PersonDetailTabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('../../../../../components/detail/AddressesSection', () => ({
+  AddressesSection: () => <div>addresses-section</div>,
 }))
 
 jest.mock('../../../../../components/detail/ActivitiesSection', () => ({
@@ -214,5 +218,12 @@ describe('PersonDetailV2Page', () => {
     expect(scopedDeleteHeaderCalls).toContainEqual({
       [OPTIMISTIC_LOCK_HEADER_NAME]: '2026-05-28T09:45:00.000Z',
     })
+  })
+
+  it('renders the AddressesSection when the addresses tab is active', async () => {
+    activeTabParam = 'addresses'
+    renderWithProviders(<PersonDetailV2Page params={{ id: 'person-123' }} />)
+
+    await waitFor(() => expect(screen.getByText('addresses-section')).toBeInTheDocument())
   })
 })

--- a/packages/core/src/modules/customers/backend/customers/people-v2/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people-v2/[id]/page.tsx
@@ -37,6 +37,7 @@ import { ScheduleActivityDialog, type ScheduleActivityEditData } from '../../../
 import { PersonDetailHeader } from '../../../../components/detail/PersonDetailHeader'
 import { ChangelogTab } from '../../../../components/detail/ChangelogTab'
 import { PersonDetailTabs, resolveLegacyTab, type PersonTabId } from '../../../../components/detail/PersonDetailTabs'
+import { AddressesSection } from '../../../../components/detail/AddressesSection'
 import { PersonCompaniesSection } from '../../../../components/detail/PersonCompaniesSection'
 import { MobilePersonDetail } from '../../../../components/detail/MobilePersonDetail'
 import type { TagsSectionController } from '@open-mercato/ui/backend/detail'
@@ -541,6 +542,7 @@ export default function PersonDetailV2Page({ params }: { params?: { id?: string 
                 activitiesCount={interactionCount}
                 dealsCount={dealCount}
                 companiesCount={companyCount}
+                addressesCount={data?.counts?.addresses ?? 0}
                 tasksCount={todoCount}
                 sectionAction={sectionAction}
               >
@@ -615,6 +617,22 @@ export default function PersonDetailV2Page({ params }: { params?: { id?: string 
                         initialLinkedCompanies={data?.companies ?? []}
                         onChanged={loadData}
                         runGuardedMutation={runMutationWithContext}
+                      />
+                    )
+                  }
+
+                  if (activeTab === 'addresses') {
+                    return (
+                      <AddressesSection
+                        entityId={personId}
+                        emptyLabel={t('customers.people.detail.empty.addresses', 'No addresses linked to this person.')}
+                        addActionLabel={t('customers.people.detail.addresses.add', 'Add address')}
+                        emptyState={{
+                          title: t('customers.people.detail.emptyState.addresses.title', 'No addresses yet'),
+                          actionLabel: t('customers.people.detail.emptyState.addresses.action', 'Add address'),
+                        }}
+                        onActionChange={handleSectionActionChange}
+                        translator={detailTranslator}
                       />
                     )
                   }

--- a/packages/core/src/modules/customers/components/detail/PersonDetailTabs.tsx
+++ b/packages/core/src/modules/customers/components/detail/PersonDetailTabs.tsx
@@ -13,6 +13,7 @@ import {
   History,
   Paperclip,
   Plus,
+  MapPin,
 } from 'lucide-react'
 import type { SectionAction } from '@open-mercato/ui/backend/detail'
 
@@ -21,6 +22,7 @@ export type PersonTabId =
   | 'emails'
   | 'deals'
   | 'companies'
+  | 'addresses'
   | 'tasks'
   | 'changelog'
   | 'files'
@@ -40,13 +42,14 @@ type PersonDetailTabsProps = {
   activitiesCount?: number
   dealsCount?: number
   companiesCount?: number
+  addressesCount?: number
   tasksCount?: number
   filesCount?: number
   sectionAction?: SectionAction | null
   children: React.ReactNode
 }
 
-const SUPPORTED_TAB_IDS = new Set<PersonTabId>(['activities', 'emails', 'deals', 'companies', 'tasks', 'changelog', 'files'])
+const SUPPORTED_TAB_IDS = new Set<PersonTabId>(['activities', 'emails', 'deals', 'companies', 'addresses', 'tasks', 'changelog', 'files'])
 
 export function resolveLegacyTab(tab: string | null | undefined): PersonTabId {
   if (!tab) return 'activities'
@@ -77,6 +80,7 @@ export function PersonDetailTabs({
   activitiesCount = 0,
   dealsCount = 0,
   companiesCount = 0,
+  addressesCount = 0,
   tasksCount = 0,
   filesCount = 0,
   sectionAction = null,
@@ -110,6 +114,12 @@ export function PersonDetailTabs({
         badge: <CountBadge count={companiesCount} />,
       },
       {
+        id: 'addresses',
+        label: t('customers.people.detail.tabs.addresses', 'Addresses'),
+        icon: <MapPin className="size-4" />,
+        badge: <CountBadge count={addressesCount} />,
+      },
+      {
         id: 'tasks',
         label: t('customers.people.detail.tabs.tasks', 'Tasks'),
         icon: <Check className="size-4" />,
@@ -128,7 +138,7 @@ export function PersonDetailTabs({
         badge: <CountBadge count={filesCount} />,
       },
     ],
-    [t, activitiesCount, dealsCount, companiesCount, tasksCount, filesCount],
+    [t, activitiesCount, dealsCount, companiesCount, addressesCount, tasksCount, filesCount],
   )
 
   const allTabs: TabDef[] = React.useMemo(

--- a/packages/core/src/modules/customers/components/detail/__tests__/PersonDetailTabs.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/PersonDetailTabs.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { PersonDetailTabs } from '../PersonDetailTabs'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallback?: string) => fallback ?? key,
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}))
+
+describe('PersonDetailTabs', () => {
+  it('renders an Addresses tab', () => {
+    render(
+      <PersonDetailTabs activeTab="activities" onTabChange={() => {}}>
+        <div>content</div>
+      </PersonDetailTabs>,
+    )
+    expect(screen.getByRole('tab', { name: /address/i })).toBeInTheDocument()
+  })
+})

--- a/packages/core/src/modules/sales/commands/__tests__/documents.address-decryption.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/documents.address-decryption.test.ts
@@ -1,0 +1,201 @@
+/** @jest-environment node */
+
+/**
+ * Repro for #3038 (Part 2): when a saved customer address is chosen as a sales
+ * document shipping (or billing) address, the address must be DECRYPTED before
+ * its values are snapshotted onto the document.
+ *
+ * CustomerAddress fields (address_line1, city, postal_code, ...) are encrypted
+ * at rest (see customers/encryption.ts). `resolveAddressSnapshot` read the row
+ * with a raw `em.findOne(CustomerAddress, ...)`, copying the still-encrypted
+ * ciphertext into `shipping_address_snapshot` (an encrypted JSON column on the
+ * order/quote). On read the outer JSON decrypts but the inner per-field values
+ * stay garbled — exactly the `XQ4Q6eh...:...:...` strings in the issue. The fix
+ * reads CustomerAddress through `findOneWithDecryption` (the platform rule for
+ * every encrypted entity), so the snapshot carries plaintext.
+ *
+ * Driven through `sales.quotes.update` (the lightest command that reaches
+ * `resolveAddressSnapshot`); the same `resolveAddressSnapshot` serves order +
+ * quote create/update and billing + shipping, so one fix covers them all.
+ */
+
+import { asValue, createContainer, InjectionMode } from 'awilix'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { CustomerAddress } from '@open-mercato/core/modules/customers/data/entities'
+import { SalesQuote } from '../../data/entities'
+import type { DocumentUpdateInput } from '../documents'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/cache', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/crud/cache')
+  return { ...actual, invalidateCrudCache: jest.fn() }
+})
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(async () => []),
+  findOneWithDecryption: jest.fn(),
+}))
+
+const ORG_ID = '33333333-3333-4333-8333-333333333333'
+const TENANT_ID = '44444444-4444-4444-8444-444444444444'
+const QUOTE_ID = '11111111-1111-4111-8111-111111111111'
+const ADDRESS_ID = '55555555-5555-4555-8555-555555555555'
+
+// Values as a RAW em.findOne would return them (encrypted at rest).
+const CIPHERTEXT_LINE1 = 'XQ4Q6ehKAbJLHwl7:mRmR22kYhzylaQ==:dWcC'
+const CIPHERTEXT_CITY = 'AVddsCP0zDPqZefv:BPyaBLUnVx0=:7hfU9abgRlU'
+// Values as findOneWithDecryption would return them (decrypted).
+const PLAIN_LINE1 = 'Dmowskiego 4r'
+const PLAIN_CITY = 'Wroclaw'
+const PLAIN_POSTAL = '55-556'
+const PLAIN_COUNTRY = 'PL'
+
+function makeCustomerAddress(overrides: Record<string, unknown>) {
+  return {
+    id: ADDRESS_ID,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    name: null,
+    purpose: null,
+    companyName: null,
+    addressLine1: 'OVERRIDE_ME',
+    addressLine2: null,
+    buildingNumber: null,
+    flatNumber: null,
+    city: null,
+    region: null,
+    postalCode: null,
+    country: null,
+    latitude: null,
+    longitude: null,
+    isPrimary: true,
+    ...overrides,
+  }
+}
+
+const cipherAddress = makeCustomerAddress({
+  addressLine1: CIPHERTEXT_LINE1,
+  city: CIPHERTEXT_CITY,
+  postalCode: 'CIPHER_PC',
+  country: 'CIPHER_C',
+})
+
+const plainAddress = makeCustomerAddress({
+  addressLine1: PLAIN_LINE1,
+  city: PLAIN_CITY,
+  postalCode: PLAIN_POSTAL,
+  country: PLAIN_COUNTRY,
+})
+
+function makeQuote() {
+  return {
+    id: QUOTE_ID,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    quoteNumber: 'Q-1',
+    status: null,
+    statusEntryId: null,
+    customerEntityId: null,
+    customerContactId: null,
+    customerSnapshot: null,
+    billingAddressId: null,
+    shippingAddressId: null,
+    billingAddressSnapshot: null,
+    shippingAddressSnapshot: null,
+    currencyCode: 'USD',
+    shippingMethodId: null,
+    shippingMethodCode: null,
+    shippingMethodSnapshot: null,
+    paymentMethodId: null,
+    paymentMethodCode: null,
+    paymentMethodSnapshot: null,
+    metadata: null,
+  } as Record<string, any>
+}
+
+function makeEm(quote: Record<string, any>) {
+  const em: any = {
+    // Raw reads return ciphertext (encrypted at rest).
+    findOne: jest.fn(async (entityClass: unknown) => {
+      if (entityClass === SalesQuote) return quote
+      if (entityClass === CustomerAddress) return cipherAddress
+      return null
+    }),
+    find: jest.fn(async () => []),
+    flush: jest.fn(async () => {}),
+    begin: jest.fn(async () => {}),
+    commit: jest.fn(async () => {}),
+    rollback: jest.fn(async () => {}),
+    fork() {
+      return this
+    },
+  }
+  return em
+}
+
+describe('#3038 — sales document shipping address is decrypted before snapshot', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../documents')
+  })
+
+  beforeEach(() => {
+    jest.mocked(findWithDecryption).mockClear()
+    // findOneWithDecryption returns the DECRYPTED address for CustomerAddress;
+    // for every other entity it transparently delegates to the raw em read so
+    // the rest of the command (quote load, snapshots) behaves normally.
+    jest.mocked(findOneWithDecryption).mockReset()
+    jest.mocked(findOneWithDecryption).mockImplementation(
+      async (em: any, entityClass: unknown, where: unknown) => {
+        if (entityClass === CustomerAddress) return plainAddress as any
+        return em.findOne(entityClass, where)
+      },
+    )
+  })
+
+  it('snapshots decrypted values (not encrypted ciphertext) when shippingAddressId is a saved customer address', async () => {
+    const quote = makeQuote()
+    const em = makeEm(quote)
+    const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+    container.register({ em: asValue(em) })
+    const ctx: any = {
+      container,
+      auth: { tenantId: TENANT_ID, orgId: ORG_ID, sub: 'user-1' },
+      selectedOrganizationId: ORG_ID,
+      organizationScope: null,
+      organizationIds: null,
+    }
+
+    const handler = commandRegistry.get<DocumentUpdateInput, { quote: SalesQuote }>('sales.quotes.update')
+    expect(handler).toBeTruthy()
+
+    await handler?.execute({ id: QUOTE_ID, shippingAddressId: ADDRESS_ID }, ctx)
+
+    const snapshot = quote.shippingAddressSnapshot as Record<string, unknown> | null
+    expect(snapshot).toBeTruthy()
+    // The reported symptom: ciphertext leaking into the snapshot.
+    expect(snapshot?.addressLine1).toBe(PLAIN_LINE1)
+    expect(snapshot?.city).toBe(PLAIN_CITY)
+    expect(snapshot?.postalCode).toBe(PLAIN_POSTAL)
+    expect(JSON.stringify(snapshot)).not.toContain(CIPHERTEXT_LINE1)
+
+    // The encrypted entity must be read through the decryption helper with the
+    // document's tenant/org scope (the platform rule for encrypted reads).
+    expect(jest.mocked(findOneWithDecryption)).toHaveBeenCalledWith(
+      em,
+      CustomerAddress,
+      expect.objectContaining({ id: ADDRESS_ID }),
+      undefined,
+      expect.objectContaining({ tenantId: TENANT_ID, organizationId: ORG_ID }),
+    )
+  })
+})

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -719,11 +719,13 @@ async function resolveAddressSnapshot(
   addressId?: string | null,
 ): Promise<Record<string, unknown> | null> {
   if (!addressId) return null;
-  const address = await em.findOne(CustomerAddress, {
-    id: addressId,
-    organizationId,
-    tenantId,
-  });
+  const address = await findOneWithDecryption(
+    em,
+    CustomerAddress,
+    { id: addressId, organizationId, tenantId },
+    undefined,
+    { tenantId, organizationId },
+  );
   if (!address) return null;
 
   return {


### PR DESCRIPTION
## Summary

Fixes two related customer-address bugs reported in #3038.

1. **Address invisible after person creation.** An address entered while creating a Person (Customers → People) was persisted but never shown on the People **v2** detail/edit page — the v2 redesign dropped the Addresses tab that v1 has. The v2 page now renders the Addresses section.
2. **Garbled (encrypted) shipping address on orders.** `customer_address` fields are encrypted at rest. When a saved customer address was chosen as a sales document's shipping/billing address, `resolveAddressSnapshot` read it with a raw `em.findOne` and copied the encrypted ciphertext into the order's `*_address_snapshot`, rendering as `XQ4Q6eh…:…:…`. It now reads via `findOneWithDecryption`, so the snapshot carries decrypted values. One chokepoint covers order+quote × create+update × shipping+billing.

## Changes

- `sales/commands/documents.ts` — `resolveAddressSnapshot` reads `CustomerAddress` via `findOneWithDecryption(em, …, undefined, { tenantId, organizationId })` instead of raw `em.findOne` (the platform encrypted-read rule).
- `customers/components/detail/PersonDetailTabs.tsx` — additive: `addresses` added to `PersonTabId`, `SUPPORTED_TAB_IDS`, optional `addressesCount` prop, and a new Addresses tab (MapPin icon + count badge).
- `customers/backend/customers/people-v2/[id]/page.tsx` — renders `<AddressesSection>` on the addresses tab (mirrors the v1 page) and passes `addressesCount`.
- Tests: new `documents.address-decryption.test.ts` (Part 2, asserts the snapshot is decrypted, not ciphertext), new `PersonDetailTabs.test.tsx`, and an extended people-v2 `page.test.tsx` (Part 1, asserts the Addresses tab/section renders).

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — bug fix.

## Testing

- `documents.address-decryption.test.ts` — reproduced red (snapshot received the exact issue ciphertext) → green after the fix.
- `PersonDetailTabs.test.tsx` + people-v2 `page.test.tsx` — reproduced red (no Addresses tab/section) → green.
- `yarn typecheck` ✅ (21 packages) · `yarn workspace @open-mercato/core test` ✅ (714 suites / 5854 tests) · `yarn i18n:check-sync` ✅ · `yarn build:packages` ✅ · `yarn build:app` ✅.
- `yarn lint` is pre-broken repo-wide (eslint 10.4.1 vs eslint-config-next plugins) on `apps/mercato`; `packages/core` has no lint script — unrelated to this change.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. <!-- reused existing i18n keys; no new generators/docs required -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- Covered by faithful command-level + UI jest repros (red→green); no Playwright spec added to avoid shipping unverified integration coverage. Existing ephemeral-integration suite still runs. -->
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — bug fix -->

### Design System Compliance
- [x] No hardcoded status colors — none added; reuses existing tab/badge styling
- [x] No arbitrary text sizes — icon uses DS `size-4` (matches sibling tabs)
- [x] Empty state handled — `AddressesSection` `emptyState` prop passed
- [x] Loading state handled — `AddressesSection` handles its own loading; page has `LoadingMessage`
- [x] `aria-label` on icon-only buttons — N/A (tab buttons have text labels)
- [x] Uses existing DS components (AddressesSection, CountBadge, Button) — no custom replacements

## Linked issues

Fixes #3038
