### PR TITLE
fix(sales): credit return net total when a line has a zeroed stored net (#3036)

### DIFF
--- a/packages/core/src/modules/sales/commands/__tests__/returns.net-total.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/returns.net-total.test.ts
@@ -1,0 +1,249 @@
+/** @jest-environment node */
+
+// Regression coverage for #3036 / #3521: the order net total must keep
+// recalculating on every return WITHOUT over-crediting genuinely free lines.
+//
+// A line persisted with a zeroed stored net total (but a valid gross) used to
+// credit only the gross side of a return, freezing the net grand total while
+// gross kept decreasing (#3036). `total_net_amount = 0` while `gross > 0` is not
+// a representable priced state (gross = net * (1 + taxRate) ⇒ net = 0 ⇒ gross = 0),
+// so the return reconstructs the missing net from the line's gross + tax rate via
+// `deriveLineNetFromGross` rather than the discount-ignoring unit price. A truly
+// free line (gross = 0, e.g. a 100% discount / comp) keeps net 0 and must NOT be
+// refunded at the full catalog price (#3521).
+
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { DefaultSalesCalculationService } from '../../services/salesCalculationService'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+const state: { order: any; lines: any[]; adjustments: any[]; shipments: any[]; shipmentItems: any[] } = {
+  order: null,
+  lines: [],
+  adjustments: [],
+  shipments: [],
+  shipmentItems: [],
+}
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(async (_em: any, entity: any) => {
+    if (entity?.name === 'SalesOrder') return state.order
+    return null
+  }),
+  findWithDecryption: jest.fn(async (_em: any, entity: any) => {
+    // Return copies so command-local mutation/persist never feeds back into the
+    // already-resolved query results within the same command call.
+    if (entity?.name === 'SalesOrderLine') return [...state.lines]
+    if (entity?.name === 'SalesOrderAdjustment') return [...state.adjustments]
+    // Returns now require the items to have been shipped first: the command caps
+    // the available return quantity at the shipped quantity per line.
+    if (entity?.name === 'SalesShipment') return [...state.shipments]
+    if (entity?.name === 'SalesShipmentItem') return [...state.shipmentItems]
+    return []
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => ({
+  emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+}))
+
+let mockReturnNumberCounter = 0
+jest.mock('../../services/salesDocumentNumberGenerator', () => ({
+  SalesDocumentNumberGenerator: class {
+    async generate() {
+      mockReturnNumberCounter += 1
+      return { number: `RET-TEST-${mockReturnNumberCounter}` }
+    }
+  },
+}))
+
+const TEST_TENANT_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+const TEST_ORG_ID = 'bbbbbbbb-bbbb-4bbb-abbb-bbbbbbbbbbbb'
+const TEST_ORDER_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const LINE_A_ID = 'dddddddd-dddd-4ddd-9ddd-dddddddddddd'
+const LINE_B_ID = 'eeeeeeee-eeee-4eee-aeee-eeeeeeeeeeee'
+
+function num(value: any): number {
+  return Number(value ?? 0)
+}
+
+function buildTx() {
+  return {
+    create: (_entity: any, data: Record<string, unknown>) => ({ ...data }),
+    persist: (entity: any) => {
+      // Return credit adjustments must survive into the next command call so a
+      // second return sees the first return's adjustment.
+      if (entity && entity.kind === 'return' && entity.scope === 'line') {
+        state.adjustments.push(entity)
+      }
+    },
+    remove: jest.fn(),
+    flush: jest.fn().mockResolvedValue(undefined),
+    getReference: (_entity: any, id: unknown) => ({ id }),
+  }
+}
+
+function buildCtx() {
+  const calc = new DefaultSalesCalculationService(null)
+  const container = {
+    resolve: (name: string) => {
+      if (name === 'em') {
+        return {
+          fork: () => ({
+            transactional: async (cb: (tx: any) => Promise<any>) => cb(buildTx()),
+          }),
+        }
+      }
+      if (name === 'salesCalculationService') return calc
+      if (name === 'dataEngine') return {}
+      return {}
+    },
+  }
+  return {
+    container,
+    auth: { tenantId: TEST_TENANT_ID, orgId: TEST_ORG_ID },
+    selectedOrganizationId: TEST_ORG_ID,
+    organizationIds: [TEST_ORG_ID],
+    request: null,
+    organizationScope: null,
+  }
+}
+
+function buildLine(overrides: Record<string, unknown>) {
+  return {
+    lineNumber: 1,
+    kind: 'product',
+    currencyCode: 'USD',
+    discountAmount: '0',
+    discountPercent: '0',
+    taxRate: '10',
+    returnedQuantity: '0',
+    ...overrides,
+  }
+}
+
+function seed(lines: any[], adjustments: any[] = []) {
+  state.order = {
+    id: TEST_ORDER_ID,
+    tenantId: TEST_TENANT_ID,
+    organizationId: TEST_ORG_ID,
+    currencyCode: 'USD',
+    shippingMethodSnapshot: null,
+    paymentMethodSnapshot: null,
+    paidTotalAmount: '0',
+    refundedTotalAmount: '0',
+    grandTotalNetAmount: '0',
+    grandTotalGrossAmount: '0',
+    updatedAt: new Date(),
+  }
+  state.lines = lines
+  state.adjustments = adjustments
+  // Fully ship every seeded line so the shipped-quantity gate allows the returns
+  // under test (the returns flow caps the returnable quantity at shipped).
+  state.shipments = [{ id: 'ffffffff-ffff-4fff-8fff-ffffffffffff' }]
+  state.shipmentItems = lines.map((line) => ({
+    shipment: { id: 'ffffffff-ffff-4fff-8fff-ffffffffffff' },
+    orderLine: { id: line.id },
+    quantity: line.quantity,
+  }))
+}
+
+async function createReturn(lineId: string, quantity: number) {
+  const execute = commandRegistry.get('sales.returns.create')?.execute as any
+  expect(execute).toBeInstanceOf(Function)
+  await execute(
+    { tenantId: TEST_TENANT_ID, organizationId: TEST_ORG_ID, orderId: TEST_ORDER_ID, lines: [{ orderLineId: lineId, quantity }] },
+    buildCtx(),
+  )
+  return {
+    net: num(state.order.grandTotalNetAmount),
+    gross: num(state.order.grandTotalGrossAmount),
+  }
+}
+
+function lastReturnAdjustment() {
+  const returns = state.adjustments.filter((adj) => adj.kind === 'return' && adj.scope === 'line')
+  return returns[returns.length - 1]
+}
+
+describe('sales.returns.create — net total recalculation across returns (#3036 / #3521)', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../returns')
+  })
+
+  it('credits the net total on a second return even when the line has a zeroed stored net total', async () => {
+    seed([
+      buildLine({ id: LINE_A_ID, quantity: '1', unitPriceNet: '100', unitPriceGross: '110', totalNetAmount: '100', totalGrossAmount: '110' }),
+      // Line persisted without a computed net total: total_net_amount defaults to
+      // '0' while the gross side is populated. Returning it must still credit net,
+      // reconstructed from gross (220) and taxRate (10%) → 200.
+      buildLine({ id: LINE_B_ID, quantity: '1', unitPriceNet: '200', unitPriceGross: '220', totalNetAmount: '0', totalGrossAmount: '220' }),
+    ])
+
+    const afterFirst = await createReturn(LINE_A_ID, 1)
+    expect(afterFirst.net).toBeLessThan(num('200') + num('100')) // sanity: net dropped from full
+    expect(afterFirst.net).toBeGreaterThan(0)
+
+    const afterSecond = await createReturn(LINE_B_ID, 1)
+
+    // The second return must reduce BOTH net and gross, not freeze the net total.
+    expect(afterSecond.gross).toBeLessThan(afterFirst.gross)
+    expect(afterSecond.net).toBeLessThan(afterFirst.net)
+
+    // The second return's credit adjustment must carry a non-zero net amount,
+    // reconstructed from gross / taxRate (220 / 1.1 = 200), not the raw 0.
+    const secondReturn = lastReturnAdjustment()
+    expect(num(secondReturn.amountNet)).toBeCloseTo(-200, 4)
+    expect(num(secondReturn.amountGross)).toBeCloseTo(-220, 4)
+  })
+
+  it('does not over-credit a genuinely free line (gross = 0, 100% discount / comp)', async () => {
+    // A fully discounted line is legitimately zero on BOTH sides. The earlier
+    // unit-price fallback would have refunded the full catalog price (200 / 220),
+    // exceeding what the customer was ever charged. The reconstruction must keep a
+    // gross = 0 line at net 0, so the return credits nothing (#3521).
+    seed([
+      buildLine({
+        id: LINE_A_ID,
+        quantity: '1',
+        unitPriceNet: '200',
+        unitPriceGross: '220',
+        discountPercent: '100',
+        discountAmount: '200',
+        totalNetAmount: '0',
+        totalGrossAmount: '0',
+      }),
+    ])
+
+    const afterReturn = await createReturn(LINE_A_ID, 1)
+
+    // No money moves: a free line credits nothing on either side.
+    expect(afterReturn.net).toBe(0)
+    expect(afterReturn.gross).toBe(0)
+
+    const credit = lastReturnAdjustment()
+    expect(num(credit.amountNet)).toBe(0)
+    expect(num(credit.amountGross)).toBe(0)
+  })
+
+  it('reduces both net and gross totals on each sequential return for normally-priced lines', async () => {
+    seed([
+      buildLine({ id: LINE_A_ID, lineNumber: 1, quantity: '1', unitPriceNet: '640', unitPriceGross: '704', totalNetAmount: '640', totalGrossAmount: '704' }),
+      buildLine({ id: LINE_B_ID, lineNumber: 2, quantity: '3', unitPriceNet: '85', unitPriceGross: '93.5', discountAmount: '4.25', discountPercent: '5', totalNetAmount: '242.25', totalGrossAmount: '266.475' }),
+    ])
+
+    const afterFirst = await createReturn(LINE_A_ID, 1)
+    const afterSecond = await createReturn(LINE_B_ID, 3)
+
+    expect(afterSecond.net).toBeLessThan(afterFirst.net)
+    expect(afterSecond.gross).toBeLessThan(afterFirst.gross)
+  })
+})

--- a/packages/core/src/modules/sales/commands/returns.ts
+++ b/packages/core/src/modules/sales/commands/returns.ts
@@ -12,7 +12,7 @@ import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/
 import { SalesDocumentNumberGenerator } from '../services/salesDocumentNumberGenerator'
 import type { SalesCalculationService } from '../services/salesCalculationService'
 import type { SalesAdjustmentDraft, SalesLineSnapshot, SalesDocumentCalculationResult } from '../lib/types'
-import { cloneJson, ensureOrganizationScope, ensureSameScope, ensureTenantScope, extractUndoPayload, toNumericString, enforceSalesDocumentOptimisticLock, SALES_RESOURCE_KIND_ORDER, SALES_RESOURCE_KIND_RETURN } from './shared'
+import { cloneJson, deriveLineNetFromGross, ensureOrganizationScope, ensureSameScope, ensureTenantScope, extractUndoPayload, toNumericString, enforceSalesDocumentOptimisticLock, SALES_RESOURCE_KIND_ORDER, SALES_RESOURCE_KIND_RETURN } from './shared'
 import { resolveRedoSnapshot } from '@open-mercato/shared/lib/commands/redo'
 import { SalesOrder, SalesOrderAdjustment, SalesOrderLine, SalesReturn, SalesReturnLine, SalesShipment, SalesShipmentItem } from '../data/entities'
 import { coerceShipmentQuantity } from '../lib/shipments/snapshots'
@@ -683,7 +683,15 @@ const createReturnCommand: CommandHandler<ReturnCreateInput, { returnId: string 
         if (!line) return
         const quantity = lineInput.quantity
         const lineQuantity = Math.max(toNumeric(line.quantity), 0)
-        const unitNet = lineQuantity > 0 ? toNumeric(line.totalNetAmount) / lineQuantity : toNumeric(line.unitPriceNet)
+        // `total_net_amount = 0` while `total_gross_amount > 0` is not a representable
+        // priced state (gross = net * (1 + taxRate) ⇒ net = 0 ⇒ gross = 0). When a line
+        // carries a positive gross but a zeroed/missing net, reconstruct the net from the
+        // line's gross and tax rate so the return credits both sides and the order's net
+        // grand total moves in lockstep with gross (#3036). A genuinely free line
+        // (gross = 0, e.g. a 100% discount / comp) keeps net 0, so the return is not
+        // over-credited at the discount-ignoring unit price (#3521).
+        const lineTotalNet = deriveLineNetFromGross(line.totalNetAmount, line.totalGrossAmount, line.taxRate)
+        const unitNet = lineQuantity > 0 ? lineTotalNet / lineQuantity : toNumeric(line.unitPriceNet)
         const unitGross = lineQuantity > 0 ? toNumeric(line.totalGrossAmount) / lineQuantity : toNumeric(line.unitPriceGross)
         const totalNet = -round(Math.max(unitNet, 0) * quantity)
         const totalGross = -round(Math.max(unitGross, 0) * quantity)


### PR DESCRIPTION
Fixes #3036

## Problem
After the first return on an order the Grand Total (Net) updates correctly, but after a second return the net total stays frozen at the previous value while the Grand Total (Gross) keeps decreasing — net and gross diverge in the order Totals section.

## Root Cause
`sales.returns.create` derives a return line's per-unit credit independently for net and gross, and only fell back to the unit price when the line **quantity** was zero:

```ts
const unitNet = lineQuantity > 0 ? toNumeric(line.totalNetAmount) / lineQuantity : toNumeric(line.unitPriceNet)
```

`SalesOrderLine.totalNetAmount` defaults to `'0'`, so a line persisted with a zeroed stored net total (but a valid `totalGrossAmount`) produces a return credit of `amountNet = 0` while `amountGross` is correct. The line-scoped return adjustment then reduces the order's gross subtotal but not its net subtotal — so the net grand total freezes on that return while gross keeps moving. The downstream totals engine (`calculations.ts`) is fully symmetric; the asymmetry originates in this credit derivation.

The underlying data inconsistency (`net = 0` while `gross > 0` is not a representable priced state — `gross = net·(1+taxRate)` ⇒ `net = 0 ⇒ gross = 0`) was sealed at the source in **#3521 / #3558** (`reconcileLinePersistedTotals` + backfill migration). This PR hardens the **return-credit derivation** so the same skew can never produce a wrong refund even if an inconsistent line slips through.

## What Changed
- `packages/core/src/modules/sales/commands/returns.ts`: when a line carries a positive gross but a zeroed/missing net, **reconstruct the net from the line's own gross and tax rate** via the shared `deriveLineNetFromGross` helper (the canonical derivation introduced in #3558), instead of the discount-ignoring catalog `unitPriceNet`. This:
  - Fixes #3036: every return now credits net in lockstep with gross.
  - Avoids over-crediting: a genuinely free line (`gross = 0`, e.g. a 100%-discount / comp) stays at `net = 0`, so the return is **not** refunded at the full catalog price — addressing the money-correctness regression raised in code review.
  - Leaves normal lines (positive net) and the quantity-zero unit-price fallback unchanged.

## Tests
- `packages/core/src/modules/sales/commands/__tests__/returns.net-total.test.ts`:
  - **#3036 reproduction** — a second return on a line with a zeroed stored net total still credits net, reconstructed from gross/taxRate (220 / 1.1 = 200). Fails on the pre-fix derivation.
  - **#3521 over-credit guard** — a 100%-discounted line (`gross = 0`) credits **0** on a return, not the catalog unit price. Fails on the earlier unit-price fallback.
  - Guard: sequential returns on normally-priced lines reduce both net and gross each time.
  - Each seeded line is fully shipped in the fixture so the new shipped-quantity return gate is satisfied.
- Full sales `commands`/`lib` suites pass (21 suites, 128 tests); full `@open-mercato/core` jest run green except one pre-existing, develop-identical `messages` concurrency timing suite unrelated to this change.
- `yarn build:packages`, `yarn generate`, `yarn typecheck`, `yarn i18n:check-sync`, `yarn build:app` all succeed.

## Backward Compatibility
- No contract surface changes. Reuses an already-exported shared helper; no API, event, schema, or DI changes.