### PR TITLE
fix(sales): reject zero-value Return adjustments to protect the Returns flow (#3037)

### DIFF
--- a/packages/core/src/modules/sales/components/documents/AdjustmentDialog.tsx
+++ b/packages/core/src/modules/sales/components/documents/AdjustmentDialog.tsx
@@ -698,6 +698,22 @@ export function AdjustmentDialog({
           )
         }
       }
+      const resolvedKind =
+        typeof values.kind === 'string' && values.kind.trim().length ? values.kind.trim() : 'custom'
+      if (resolvedKind === 'return') {
+        const hasNonZeroValue =
+          calculationMode === 'rate'
+            ? Number.isFinite(percentageRate) && percentageRate !== 0
+            : (Number.isFinite(amountNet) && amountNet !== 0) ||
+              (Number.isFinite(amountGross) && amountGross !== 0)
+        if (!hasNonZeroValue) {
+          const message = t(
+            'sales.documents.adjustments.errorReturnZero',
+            'Return adjustments must use a non-zero amount. Create the return through the Returns tab instead.'
+          )
+          throw createCrudFormError(message, { amountNet: message })
+        }
+      }
       const customFields = collectCustomFieldValues(values, {
         transform: (value) => normalizeCustomFieldSubmitValue(value),
       })

--- a/packages/core/src/modules/sales/data/__tests__/validators.adjustment-sign.test.ts
+++ b/packages/core/src/modules/sales/data/__tests__/validators.adjustment-sign.test.ts
@@ -4,6 +4,7 @@ import {
   DISCOUNT_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
   RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE,
   RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE,
+  RETURN_ADJUSTMENT_ZERO_MESSAGE,
   SHIPPING_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
   SHIPPING_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
   SURCHARGE_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
@@ -80,14 +81,54 @@ describe('enforceAdjustmentSign — return adjustments', () => {
     expect(result.success).toBe(true)
   })
 
-  it('accepts zero amounts for kind="return"', () => {
+  it('rejects zero amounts for kind="return" (issue #3037)', () => {
     const result = orderUpsertSchema.safeParse({
       ...base,
       kind: 'return',
       amountNet: 0,
       amountGross: 0,
     })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain(RETURN_ADJUSTMENT_ZERO_MESSAGE)
+    }
+  })
+
+  it('rejects a return with no amounts supplied (issue #3037)', () => {
+    const result = orderUpsertSchema.safeParse({
+      ...base,
+      kind: 'return',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain(RETURN_ADJUSTMENT_ZERO_MESSAGE)
+    }
+  })
+
+  it('accepts a return when only one negative amount is supplied', () => {
+    const result = orderUpsertSchema.safeParse({
+      ...base,
+      kind: 'return',
+      amountGross: -5,
+    })
     expect(result.success).toBe(true)
+  })
+
+  it('does not flag a positive return as zero-valued', () => {
+    const result = orderUpsertSchema.safeParse({
+      ...base,
+      kind: 'return',
+      amountNet: 5,
+      amountGross: 5,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain(RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE)
+      expect(messages).not.toContain(RETURN_ADJUSTMENT_ZERO_MESSAGE)
+    }
   })
 
   it('accepts positive amounts for non-return adjustments', () => {
@@ -257,5 +298,19 @@ describe('enforceAdjustmentSign — quote adjustments retain return behavior', (
       amountGross: -7.5,
     })
     expect(result.success).toBe(true)
+  })
+
+  it('rejects zero amounts for kind="return" on quote adjustments (issue #3037)', () => {
+    const result = quoteUpsertSchema.safeParse({
+      ...base,
+      kind: 'return',
+      amountNet: 0,
+      amountGross: 0,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain(RETURN_ADJUSTMENT_ZERO_MESSAGE)
+    }
   })
 })

--- a/packages/core/src/modules/sales/data/validators.ts
+++ b/packages/core/src/modules/sales/data/validators.ts
@@ -434,6 +434,8 @@ export const RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE =
   'Return adjustments must use a non-positive amountNet (returns reduce the total).'
 export const RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE =
   'Return adjustments must use a non-positive amountGross (returns reduce the total).'
+export const RETURN_ADJUSTMENT_ZERO_MESSAGE =
+  'Return adjustments must use a non-zero amount. Create the return through the Returns tab instead of recording a zero-value Return adjustment.'
 export const DISCOUNT_ADJUSTMENT_NEGATIVE_NET_MESSAGE =
   'Discount adjustments must use a non-negative amountNet (discounts reduce the total).'
 export const DISCOUNT_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE =
@@ -482,19 +484,32 @@ export const enforceAdjustmentSign = (
 ) => {
   if (!value.kind) return
   if (value.kind === 'return') {
-    if (typeof value.amountNet === 'number' && value.amountNet > 0) {
+    const netIsPositive = typeof value.amountNet === 'number' && value.amountNet > 0
+    const grossIsPositive = typeof value.amountGross === 'number' && value.amountGross > 0
+    if (netIsPositive) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE,
         path: ['amountNet'],
       })
     }
-    if (typeof value.amountGross === 'number' && value.amountGross > 0) {
+    if (grossIsPositive) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE,
         path: ['amountGross'],
       })
+    }
+    if (!netIsPositive && !grossIsPositive) {
+      const netIsNegative = typeof value.amountNet === 'number' && value.amountNet < 0
+      const grossIsNegative = typeof value.amountGross === 'number' && value.amountGross < 0
+      if (!netIsNegative && !grossIsNegative) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: RETURN_ADJUSTMENT_ZERO_MESSAGE,
+          path: ['amountNet'],
+        })
+      }
     }
     return
   }

--- a/packages/core/src/modules/sales/i18n/de.json
+++ b/packages/core/src/modules/sales/i18n/de.json
@@ -461,6 +461,7 @@
   "sales.documents.adjustments.errorDelete": "Anpassung konnte nicht gelöscht werden.",
   "sales.documents.adjustments.errorLoad": "Anpassungen konnten nicht geladen werden.",
   "sales.documents.adjustments.errorRate": "Geben Sie einen Prozentsatz ein.",
+  "sales.documents.adjustments.errorReturnZero": "Rückgabe-Anpassungen müssen einen Betrag ungleich null verwenden. Erstellen Sie die Rückgabe über den Tab „Rückgaben“, anstatt eine Rückgabe-Anpassung mit dem Wert null zu erfassen.",
   "sales.documents.adjustments.errorSave": "Anpassung konnte nicht gespeichert werden.",
   "sales.documents.adjustments.errorScope": "Organisation und Mandant sind erforderlich.",
   "sales.documents.adjustments.kind": "Typ",

--- a/packages/core/src/modules/sales/i18n/en.json
+++ b/packages/core/src/modules/sales/i18n/en.json
@@ -461,6 +461,7 @@
   "sales.documents.adjustments.errorDelete": "Failed to delete adjustment.",
   "sales.documents.adjustments.errorLoad": "Failed to load adjustments.",
   "sales.documents.adjustments.errorRate": "Enter a percentage rate.",
+  "sales.documents.adjustments.errorReturnZero": "Return adjustments must use a non-zero amount. Create the return through the Returns tab instead.",
   "sales.documents.adjustments.errorSave": "Failed to save adjustment.",
   "sales.documents.adjustments.errorScope": "Organization and tenant are required.",
   "sales.documents.adjustments.kind": "Kind",

--- a/packages/core/src/modules/sales/i18n/es.json
+++ b/packages/core/src/modules/sales/i18n/es.json
@@ -461,6 +461,7 @@
   "sales.documents.adjustments.errorDelete": "No se pudo eliminar el ajuste.",
   "sales.documents.adjustments.errorLoad": "No se pudieron cargar los ajustes.",
   "sales.documents.adjustments.errorRate": "Introduce un porcentaje.",
+  "sales.documents.adjustments.errorReturnZero": "Los ajustes de devolución deben usar un importe distinto de cero. Crea la devolución desde la pestaña Devoluciones en lugar de registrar un ajuste de devolución con valor cero.",
   "sales.documents.adjustments.errorSave": "No se pudo guardar el ajuste.",
   "sales.documents.adjustments.errorScope": "Se requieren organización y arrendatario.",
   "sales.documents.adjustments.kind": "Tipo",

--- a/packages/core/src/modules/sales/i18n/pl.json
+++ b/packages/core/src/modules/sales/i18n/pl.json
@@ -461,6 +461,7 @@
   "sales.documents.adjustments.errorDelete": "Nie udało się usunąć korekty.",
   "sales.documents.adjustments.errorLoad": "Nie udało się wczytać korekt.",
   "sales.documents.adjustments.errorRate": "Wprowadź stawkę procentową.",
+  "sales.documents.adjustments.errorReturnZero": "Korekty zwrotu muszą mieć kwotę różną od zera. Utwórz zwrot na karcie Zwroty zamiast dodawać korektę zwrotu o wartości zero.",
   "sales.documents.adjustments.errorSave": "Nie udało się zapisać korekty.",
   "sales.documents.adjustments.errorScope": "Wymagane są identyfikatory organizacji i dzierżawcy.",
   "sales.documents.adjustments.kind": "Typ",


### PR DESCRIPTION
Fixes #3037

## Problem
In the order **Adjustments** tab, a user could manually create an adjustment with `Kind: Return` and an amount of `0 USD`. The record saved with no validation error and appeared in the Adjustments list, even though no corresponding return existed in the Returns tab. This let arbitrary Return-type financial entries be injected outside the Returns workflow, and created a Returns-vs-Adjustments inconsistency.

## Root Cause
`enforceAdjustmentSign` (used by both the order- and quote-adjustment upsert schemas, on the API route and in the command) only rejected *positive* amounts for `kind: 'return'`. A zero amount passed every layer, so a meaningless zero-value Return adjustment was accepted.

## What Changed
- **`packages/core/src/modules/sales/data/validators.ts`** — `enforceAdjustmentSign` now requires a return adjustment to carry a strictly **negative** amount. Zero or absent net/gross amounts are rejected with the new `RETURN_ADJUSTMENT_ZERO_MESSAGE`. Positive amounts still raise the existing positive-amount errors (no double-reporting). Other kinds are unchanged.
- **`AdjustmentDialog.tsx`** — mirrors the guard client-side for immediate feedback (`sales.documents.adjustments.errorReturnZero`), covering both fixed-amount and percentage modes.
- **i18n** — added `sales.documents.adjustments.errorReturnZero` to en/pl/de/es (in sync).

The legitimate Returns flow (`sales.return.create`) creates its line-level return adjustments via direct persistence, **not** through this schema, so real returns (always non-zero) are unaffected.

## Tests
- `validators.adjustment-sign.test.ts`: flipped the prior "accepts zero amounts for return" case to **rejects**, plus new cases — no-amounts-supplied rejected, single negative amount accepted, positive return not mis-flagged as zero, and a quote-side zero rejection. `30 passed`.
- Confirmed `validators.return-adjustment-remaining` (unchanged validator) still green.
- `yarn i18n:check-sync` ✓, `yarn build:packages` ✓, `yarn typecheck` ✓ (all 21 tasks).

## Scope note
This implements the reporter's "at minimum require a non-zero amount" suggestion. Fully excluding `Kind: Return` from the manual form (or requiring a linked return record) is a larger adjustment-kind semantics change and was intentionally left out per the module's "Ask First" guidance.

## Backward Compatibility
No contract surface changes — only a stricter validation rule for zero-value Return adjustments (additive exported constant `RETURN_ADJUSTMENT_ZERO_MESSAGE`). No API response fields, event IDs, DI names, ACL IDs, or import paths removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
