### PR TITLE
feat(create-app): collaborative proposal skills + installer skill-package selection

### DIFF
--- a/.ai/runs/2026-06-15-collaborative-proposal-skills.md
+++ b/.ai/runs/2026-06-15-collaborative-proposal-skills.md
@@ -35,10 +35,14 @@ Ship a new group of agentic skills for **collaborative pre-spec ideation** — `
 
 ### Phase 1: Skills + contract + optional intake
 
-- [ ] 1.1 Proposal file contract (`om-proposal/references/proposal-template.md`)
-- [ ] 1.2 `om-proposal` SKILL.md (scan → defer-aware question gate → method → append → ready/move)
-- [ ] 1.3 `om-brainstorm` SKILL.md + `references/methods.md` (BMAD attribution)
-- [ ] 1.4 `om-spec-writing` optional intake (`references/proposal-intake.md` + guarded step, both copies)
-- [ ] 1.5 Monorepo wiring (`om-help` catalog + sequences §0; root `AGENTS.md` Task Router row)
-- [ ] 1.6 Standalone wiring (mirror skills; `generateShared()` copies + intake; shipped `om-help` refs)
-- [ ] 1.7 Tests (`shared.test.ts` asserts ship + wiring)
+- [x] 1.1 Proposal file contract (`om-proposal/references/proposal-template.md`) — cf672ccee
+- [x] 1.2 `om-proposal` SKILL.md (scan → defer-aware question gate → method → append → ready/move) — cf672ccee
+- [x] 1.3 `om-brainstorm` SKILL.md + `references/methods.md` (BMAD attribution) — cf672ccee
+- [x] 1.4 `om-spec-writing` optional intake (`references/proposal-intake.md` + guarded step, both copies) — cf672ccee
+- [x] 1.5 Monorepo wiring (`om-help` catalog + sequences §0; root `AGENTS.md` Task Router row) — cf672ccee
+- [x] 1.6 Standalone wiring (mirror skills; `generateShared()` copies + intake; shipped `om-help` refs) — cf672ccee
+- [x] 1.7 Tests (`shared.test.ts` asserts ship + wiring) — cf672ccee
+
+## Changelog
+
+- 2026-06-15 — Phase 1 implemented and verified (create-app `shared.test.ts` 6/6, typecheck clean, `node build.mjs` copies new skills into `dist/agentic`). PR opened on fork.

--- a/.ai/runs/2026-06-15-collaborative-proposal-skills.md
+++ b/.ai/runs/2026-06-15-collaborative-proposal-skills.md
@@ -1,0 +1,44 @@
+# Execution Plan — Collaborative Proposal Skills (Phase 1)
+
+Source spec: .ai/specs/2026-06-15-collaborative-proposal-skills.md
+
+## Goal
+
+Ship a new group of agentic skills for **collaborative pre-spec ideation** — `om-proposal`
+(async, file-based proposals in `.ai/proposals/`) and `om-brainstorm` (party mode / Socratic /
+5-whys / yes-and) — plus an optional `om-spec-writing` intake hook, wired into both the monorepo
+`.ai/skills/` and the standalone `create-mercato-app` generator.
+
+## Scope
+
+- New skills `om-proposal` + `om-brainstorm` (monorepo source + create-app mirror).
+- Optional `om-spec-writing/references/proposal-intake.md` + guarded SKILL.md step (both copies).
+- `generateShared()` copy-list extension + `shared.test.ts` coverage.
+- `om-help` catalog/sequences (both locations) + root `AGENTS.md` Task Router row.
+
+## Non-goals
+
+- Phase 2 installer "skill package" selection (separate spec).
+- Codex/Cursor parity for the new skills.
+- Real-time multi-human collaboration.
+
+## Risks
+
+- Source-level wiring only; standalone delivery additionally needs `yarn build` in
+  `packages/create-app` (esbuild + `build.mjs` copies `agentic/ → dist/agentic/`).
+- Fork PR: per project fork workflow there are no upstream pipeline labels / review bots, so the
+  label-normalization and `auto-review-pr` ceremony are reduced for this run.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Skills + contract + optional intake
+
+- [ ] 1.1 Proposal file contract (`om-proposal/references/proposal-template.md`)
+- [ ] 1.2 `om-proposal` SKILL.md (scan → defer-aware question gate → method → append → ready/move)
+- [ ] 1.3 `om-brainstorm` SKILL.md + `references/methods.md` (BMAD attribution)
+- [ ] 1.4 `om-spec-writing` optional intake (`references/proposal-intake.md` + guarded step, both copies)
+- [ ] 1.5 Monorepo wiring (`om-help` catalog + sequences §0; root `AGENTS.md` Task Router row)
+- [ ] 1.6 Standalone wiring (mirror skills; `generateShared()` copies + intake; shipped `om-help` refs)
+- [ ] 1.7 Tests (`shared.test.ts` asserts ship + wiring)

--- a/.ai/skills/om-brainstorm/SKILL.md
+++ b/.ai/skills/om-brainstorm/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: om-brainstorm
+description: >
+  Facilitation methods for exploring an idea — party mode (an AI panel of personas), Socratic
+  questioning, 5-whys, yes-and, and more. Use when ideating on a feature, stress-testing an
+  approach, or when invoked by om-proposal to explore a proposal. Methods adapted from
+  BMAD-METHOD. Single-user facilitation: personas are simulated, not real teammates.
+---
+
+# om-brainstorm — Idea Facilitation Methods
+
+A toolbox of brainstorming methods to explore and pressure-test an idea. Usually invoked by
+`om-proposal` against an active proposal, but works standalone too. This is **single-user
+facilitation** — when a method uses multiple voices (e.g. party mode), the skill simulates those
+personas; it is not a real-time multi-human session. Real teammate collaboration happens
+asynchronously through the proposal file (see `om-proposal`).
+
+Method details and prompts live in [methods.md](references/methods.md). Attribution:
+methods are adapted from [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD) core-skills.
+
+## Workflow
+
+1. **Pick a method** — ask the user which method fits, or recommend one:
+   - **Party mode** — convene a panel of personas (architect, PM, skeptic, end-user, …) that
+     debate the idea from their angles. Best for surfacing blind spots and trade-offs.
+   - **Socratic** — interrogate the idea with probing questions to expose hidden assumptions.
+     Best when the idea feels obvious but untested.
+   - **5 Whys** — drill from symptom to root cause. Best for problem framing.
+   - **Yes-and** — divergent expansion without judgement. Best early, to widen the option space.
+2. **Run the method** following its recipe in `methods.md`. Stay in the method until it converges
+   or the user stops it.
+3. **Distil** — summarise decisions, trade-offs, and any new questions the session raised.
+4. **Return** the distilled output to the caller. When invoked by `om-proposal`, the output is
+   written into the proposal's `## Findings`, and new questions into `## Open Questions`.
+
+## Rules
+
+- MUST keep persona panels balanced — always include at least one skeptic/critic voice so party
+  mode does not become an echo chamber.
+- MUST end every method with a distillation (decisions + open questions), not just a transcript.
+- MUST credit BMAD-METHOD when the user asks where the methods come from.
+- MUST NOT invent consensus — if personas/questions expose an unresolved trade-off, record it as
+  an open question rather than papering over it.

--- a/.ai/skills/om-brainstorm/references/methods.md
+++ b/.ai/skills/om-brainstorm/references/methods.md
@@ -1,0 +1,70 @@
+# Brainstorming Methods
+
+Recipes for the facilitation methods offered by `om-brainstorm`. Adapted from
+[BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD) core-skills.
+
+Every method ends with a **distillation**: the decisions reached + the new open questions raised.
+That distillation is what flows back to `om-proposal`'s `## Findings` / `## Open Questions`.
+
+---
+
+## Party Mode
+
+Convene a panel of personas and let them debate the idea. The skill role-plays each persona in
+turn; the user is the moderator.
+
+**Default panel** (adapt to the domain): **Architect** (feasibility, system fit), **Product
+Manager** (user value, scope, priorities), **Skeptic** (risks, failure modes, "why this won't
+work"), **End User** (real-world workflow, friction), and optionally a **Domain Expert**.
+
+**Recipe**
+1. State the idea in one sentence and confirm it with the user.
+2. Go round the panel: each persona reacts in 2-4 sentences from its angle. Label every turn with
+   the persona name.
+3. Let personas respond to each other where they disagree — surface the trade-off, do not resolve
+   it artificially.
+4. Run 2-3 rounds, or until the discussion converges.
+5. **Distil**: agreed points, live trade-offs (→ open questions), and a recommended direction.
+
+**Rule**: the Skeptic must always speak — party mode without dissent is an echo chamber.
+
+---
+
+## Socratic
+
+Interrogate the idea with successive probing questions to expose assumptions the user has not
+examined.
+
+**Recipe**
+1. Restate the user's claim/idea.
+2. Ask one probing question at a time (e.g. "What must be true for this to work?", "What's the
+   simplest case where this breaks?", "What evidence would change your mind?").
+3. Follow each answer with a deeper question. Do not lecture — only ask.
+4. Stop when an assumption is exposed as load-bearing-and-untested, or the idea is well-grounded.
+5. **Distil**: the assumptions found, which are validated vs unvalidated (→ open questions).
+
+---
+
+## 5 Whys
+
+Drill from a symptom to its root cause to make sure the proposal solves the right problem.
+
+**Recipe**
+1. State the problem/symptom.
+2. Ask "why does this happen?" Take the answer, ask "why?" again. Repeat ~5 times.
+3. Stop when you hit a root cause that is actionable.
+4. **Distil**: the root cause and whether the proposed idea actually addresses it (→ open question
+   if it only treats a symptom).
+
+---
+
+## Yes-And
+
+Divergent expansion for the early, generative phase — widen the option space before judging.
+
+**Recipe**
+1. Take the seed idea. Each turn adds "yes, and …" — building, never blocking.
+2. Defer all criticism; capture every branch, even unlikely ones.
+3. After divergence, cluster the branches and let the user pick which to keep.
+4. **Distil**: the option clusters and the user's shortlist (→ open questions for the dropped ones
+   worth revisiting).

--- a/.ai/skills/om-help/references/skills-catalog.md
+++ b/.ai/skills/om-help/references/skills-catalog.md
@@ -19,7 +19,9 @@ Default tier — installed by `yarn install-skills`.
 | Skill | Trigger phrase / When to use | Preceded by | Followed by |
 |-------|------------------------------|-------------|-------------|
 | `om-help` | "what now?", "next steps?", "which skill?", "how do I X in OM?", orientation questions | — | any |
-| `om-spec-writing` | New feature (3+ files), architectural change, new module | — | `om-pre-implement-spec` |
+| `om-proposal` | Collaborative pre-spec ideation — capture/refine an idea in `.ai/proposals/`, surface teammates' open questions (async, file-based) | — | `om-brainstorm` then `om-spec-writing` |
+| `om-brainstorm` | Facilitate ideation — party mode (persona panel), Socratic, 5-whys, yes-and | `om-proposal` | `om-proposal` (writes findings back) |
+| `om-spec-writing` | New feature (3+ files), architectural change, new module | `om-proposal` (optional) | `om-pre-implement-spec` |
 | `om-pre-implement-spec` | Before implementing a spec — BC audit, gap analysis, readiness report | `om-spec-writing` | `om-implement-spec` |
 | `om-implement-spec` | Execute an existing spec phase by phase | `om-pre-implement-spec` | `om-code-review` |
 | `om-code-review` | Review before merge — architecture, security, DS, conventions | `om-implement-spec` | `om-check-and-commit` |

--- a/.ai/skills/om-help/references/workflow-sequences.md
+++ b/.ai/skills/om-help/references/workflow-sequences.md
@@ -5,6 +5,7 @@
 
 ## Table of Contents
 
+- [Ideate Before a Spec (Collaborative)](#0-ideate-before-a-spec-collaborative)
 - [New Feature](#1-new-feature)
 - [Bug Fix](#2-bug-fix)
 - [UI / Design System Change](#3-ui--design-system-change)
@@ -17,6 +18,28 @@
 - [AI Agent / MCP Tool](#10-ai-agent--mcp-tool)
 - [Spec Fix / Rename](#11-spec-fix--rename)
 - [Choosing the Right Sequence](#choosing-the-right-sequence)
+
+---
+
+## 0. Ideate Before a Spec (Collaborative)
+
+**Use when:** A feature/module is still a rough idea and the team should weigh in before a spec is
+locked. Collaboration is asynchronous and file-based via `.ai/proposals/` (committed to git).
+
+```
+om-proposal        (open/refine a proposal; surface teammates' open questions; defer or answer)
+  → om-brainstorm  (party mode, Socratic, 5-whys, yes-and — findings flow back to the proposal)
+  → om-proposal    (mark ready; moves to .ai/proposals/ready/)
+  → om-spec-writing (consumes the proposal's "For the spec" brief + carried-forward questions)
+```
+
+**Rationale per step:**
+1. `om-proposal` — capture the idea and pull in unanswered questions teammates left behind.
+2. `om-brainstorm` — explore with a facilitation method; every method ends with a distillation.
+3. `om-proposal` — when the team agrees, mark `ready` and hand off.
+4. `om-spec-writing` — auto-consumes the brief when its proposal-intake hook is installed.
+
+> Optional pre-spec layer. For a solo quick feature, skip straight to `om-spec-writing`.
 
 ---
 

--- a/.ai/skills/om-proposal/SKILL.md
+++ b/.ai/skills/om-proposal/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: om-proposal
+description: >
+  Collaborative pre-spec ideation. Turn a loose idea into a structured proposal that becomes
+  the input to om-spec-writing. Use when a team wants to ideate before a spec exists, when you
+  hear "let's brainstorm a feature", "capture an idea", "open a proposal", "what should we
+  build", "I have a rough idea", "gather the team's thoughts", or before writing a spec for a
+  non-trivial feature/module. Collaboration is asynchronous and file-based via `.ai/proposals/`.
+---
+
+# om-proposal — Collaborative Pre-Spec Proposals
+
+Proposals are the ideation layer **before** a spec. They live as markdown under
+`.ai/proposals/`, committed to git, so teammates contribute **asynchronously**: each person runs
+this skill, it surfaces teammates' unanswered questions, and appends new thoughts and answers.
+A finished proposal hands off to `om-spec-writing`.
+
+This skill manages the proposal file and the question gate. It delegates the actual idea
+exploration to `om-brainstorm` (party mode, Socratic, …).
+
+## File Contract — `.ai/proposals/<YYYY-MM-DD>-<slug>.md`
+
+See [proposal-template.md](references/proposal-template.md) for the exact shape. The headings are
+a **stable contract** — `om-brainstorm` and the `om-spec-writing` intake hook depend on them:
+
+- Frontmatter: `title`, `status: open | ready | deferred`, `contributors`, `created`, `updated`.
+- `## Idea / Context` — the problem and motivation.
+- `## Open Questions` — checklist; each item names an asker and a status `open | answered | deferred`.
+- `## Findings` — answers and distilled brainstorm output.
+- `## For the spec` — the brief `om-spec-writing` consumes.
+
+A `ready` proposal is moved to `.ai/proposals/ready/`; `deferred` and `open` proposals stay in the
+root folder.
+
+## Workflow
+
+### Step 1 — Scan existing proposals
+
+Read every file under `.ai/proposals/` (including `ready/`). Build a list of all
+**unanswered (`open`) and `deferred`** questions across proposals, noting which proposal and who
+asked each one. If `.ai/proposals/` does not exist yet, create it.
+
+### Step 2 — Surface teammates' open questions
+
+Present the outstanding questions from other proposals to the user, grouped by proposal. For each,
+the user may **answer** it (write the answer to `## Findings`, flip the item to `answered`) or
+**defer** it. **Always offer "defer" explicitly** — a deferred question is written back with
+`status: deferred` and is **never deleted**. Do not pressure the user to answer; deferral is a
+first-class outcome.
+
+### Step 3 — Capture what the user wants to add
+
+Ask what the user wants to contribute and to **which** proposal (existing, or a new one — then ask
+for a title and derive the `<slug>`). Create the file from the template if new, adding the user to
+`contributors` and stamping `updated`.
+
+### Step 4 — Choose a method and explore
+
+Ask which facilitation method to use, then **delegate to `om-brainstorm`** (party mode, Socratic,
+5-whys, …). Write the method's output into `## Findings`. New questions raised during exploration
+are added to `## Open Questions` as `open`.
+
+### Step 5 — Handoff
+
+When the team considers the proposal complete:
+- Ensure `## For the spec` holds a coherent brief and any still-`deferred` questions are listed
+  there (so `om-spec-writing` can seed its own Open Questions from them).
+- Set `status: ready`, **move the file to `.ai/proposals/ready/`**, and point the user at
+  `om-spec-writing` (which will detect and consume the proposal when its intake hook is installed).
+
+## Rules
+
+- MUST offer "defer" for every question; deferred questions persist and are never deleted.
+- MUST preserve the section headings exactly — they are the contract the other skills read.
+- MUST append, never silently overwrite another contributor's content; update `updated` and
+  `contributors` on every edit.
+- MUST keep proposals free of secrets/credentials/customer data (they are committed to git).
+- MUST NOT write the spec here — that is `om-spec-writing`'s job. This skill only produces the brief.
+- Derive `<slug>` as kebab-case from the title; date is `YYYY-MM-DD`.

--- a/.ai/skills/om-proposal/references/proposal-template.md
+++ b/.ai/skills/om-proposal/references/proposal-template.md
@@ -1,0 +1,31 @@
+---
+title: <human-readable title>
+status: open
+contributors: [<your-name>]
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+---
+
+## Idea / Context
+
+<What problem are we exploring? Why now? Who is it for? Keep it short — this is ideation,
+not a spec. Link related proposals or specs if relevant.>
+
+## Open Questions
+
+> Each item: `[ ]` open · `[~]` deferred · `[x]` answered. Name the asker. Deferred questions
+> are never deleted — they carry forward into `om-spec-writing`'s Open Questions gate.
+
+- [ ] (asked by <name>) <question> — status: open
+- [~] (asked by <name>) <question> — status: deferred
+
+## Findings
+
+<Answers to questions, decisions reached, and the distilled output of brainstorming sessions
+(party mode panels, Socratic threads, …). Attribute non-obvious points to a contributor.>
+
+## For the spec
+
+<The brief `om-spec-writing` will consume as its starting point: the agreed problem, the chosen
+direction, constraints, and the list of still-deferred questions it must turn into its own
+Open Questions. This section is the handoff contract.>

--- a/.ai/skills/om-spec-writing/SKILL.md
+++ b/.ai/skills/om-spec-writing/SKILL.md
@@ -10,6 +10,7 @@ Design and review specifications (SPECs) against Open Mercato's architecture, na
 ## Workflow
 
 1.  **Load Context**: Load initial context, take user provided context prompt, and load related files using the Task-Routing table from root `AGENTS.md`.
+    - **Proposal intake (optional)**: if `references/proposal-intake.md` is present, follow it before initializing the spec file — a matching `.ai/proposals/**/<slug>.md` may supply the starting brief and carry-forward Open Questions. If the file is absent, skip this and proceed normally.
 2.  **Initialize**: Create an empty file with the correct naming convention for scope:
     - OSS scope: `{date}-{title}.md` in `.ai/specs/`
     - Enterprise scope: `{date}-{title}.md` in `.ai/specs/enterprise/`

--- a/.ai/skills/om-spec-writing/references/proposal-intake.md
+++ b/.ai/skills/om-spec-writing/references/proposal-intake.md
@@ -1,0 +1,29 @@
+# Proposal Intake (optional)
+
+> This file is present only when the collaborative proposal skills (`om-proposal` /
+> `om-brainstorm`) are installed. When present, `om-spec-writing` consumes a matching proposal as
+> the starting brief. When absent, spec-writing proceeds normally — the guarded step is a no-op.
+
+## When to apply
+
+Before initializing the spec file (Workflow Step "Load Context" / "Initialize"), check whether the
+work being spec'd already has a proposal.
+
+## Procedure
+
+1. **Locate** a matching proposal under `.ai/proposals/**/<slug>.md` (check both the root folder
+   and `.ai/proposals/ready/`). Match by topic/slug; if several look relevant, ask the user which.
+   If none exists, skip the rest of this procedure.
+2. **Read** the proposal's `## For the spec` (the agreed brief) and `## Findings` (decisions and
+   rationale). Use them to seed the spec's TLDR, Problem Statement, and Proposed Solution instead
+   of starting from scratch.
+3. **Carry forward open questions**: any item in the proposal's `## Open Questions` still marked
+   `open` or `deferred` becomes a candidate for the spec's **Open Questions** gate (Skeleton step).
+   Do not silently assume answers the proposal explicitly deferred.
+4. **Reference** the proposal in the spec (e.g. "Derived from `.ai/proposals/ready/<slug>.md`") so
+   the ideation trail is traceable.
+
+## Rules
+
+- MUST NOT resolve a question the proposal left `deferred` — surface it in the spec's Open Questions.
+- MUST keep the proposal as the source of *intent*; the spec remains the source of *design*.

--- a/.ai/skills/tiers.json
+++ b/.ai/skills/tiers.json
@@ -9,6 +9,8 @@
         "om-ds-guardian",
         "om-backend-ui-design",
         "om-check-and-commit",
+        "om-proposal",
+        "om-brainstorm",
         "om-spec-writing",
         "om-implement-spec",
         "om-pre-implement-spec",

--- a/.ai/specs/2026-06-15-collaborative-proposal-skills.md
+++ b/.ai/specs/2026-06-15-collaborative-proposal-skills.md
@@ -1,0 +1,180 @@
+# Collaborative Proposal Skills (pre-spec ideation)
+
+> Status: **DRAFT — ready for implementation review**
+> Scope: OSS · agentic skills (monorepo `.ai/skills/` + `packages/create-app` standalone shipment)
+
+## TLDR
+
+Add a new group of agentic skills — **collaborative / creative skills** — that let a team
+ideate on a feature or module *before* a spec is written. They turn a loose idea into a
+structured **proposal** that becomes the input to `om-spec-writing`. Collaboration between
+teammates is **asynchronous and file-based**: proposals live as markdown under `.ai/proposals/`,
+committed to git; each teammate runs the skill, the skill surfaces teammates' unanswered
+questions, and appends new thoughts/answers. "Party mode" and similar methods are
+**AI-persona facilitation for a single user**, not real-time multi-human sessions.
+
+This spec (Phase 1) ships the two skills, the proposal file contract, and an **optional**
+intake hook inside `om-spec-writing`. Installer-level "skill package" selection is **Phase 2**
+(separate spec).
+
+## Resolved decisions (Open Questions gate)
+
+- **Q1 → both.** Skills live in the monorepo `.ai/skills/` *and* are shipped to standalone apps
+  via `packages/create-app/agentic/shared/ai/skills/` + `generateShared()`.
+- **Q2 → two skills.** `om-proposal` (proposal file + question gate + handoff) delegates to
+  `om-brainstorm` (facilitation methods).
+- **Q3 → yes, but optional.** `om-spec-writing` consumes a proposal **only when the proposal
+  skills are installed**. Mechanism: a `references/proposal-intake.md` fragment that is copied
+  into `om-spec-writing` *only* when the proposals group is installed; the SKILL.md step is
+  guarded on the presence of that file, so an install without proposals is a clean no-op.
+- **Q4 → move to subfolder.** A `ready` proposal is moved to `.ai/proposals/ready/`
+  (lifecycle-folder pattern, mirroring `.ai/specs/`), with `status: ready` in frontmatter.
+
+## Problem Statement
+
+The current agentic flow jumps straight from "I have an idea" to `om-spec-writing`. There is no
+structured ideation/collaboration phase where multiple teammates can contribute thoughts, raise
+doubts, and have open questions tracked and answered before a spec is locked. BMAD-style
+facilitation methods (party mode, Socratic questioning, etc.) are unavailable. The result: specs
+start from one person's framing, with team doubts surfacing late (during review or QA) instead
+of during ideation.
+
+## Proposed Solution
+
+### 1. Proposal file contract — `.ai/proposals/<YYYY-MM-DD>-<slug>.md`
+
+Frontmatter:
+
+```yaml
+---
+title: <human title>
+status: open | ready | deferred
+contributors: [<name>, ...]
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+---
+```
+
+Body sections (stable contract — the skills and the intake hook depend on these headings):
+
+- `## Idea / Context` — the problem and motivation.
+- `## Open Questions` — checklist; each item carries an asker and a status
+  (`open` / `answered` / `deferred`). Deferred questions persist; they are never deleted.
+- `## Findings` — answers and the distilled output of brainstorming sessions.
+- `## For the spec` — the brief `om-spec-writing` consumes as its starting point.
+
+Lifecycle: a proposal starts `open`. When the team marks it `ready`, `om-proposal` moves the
+file to `.ai/proposals/ready/` and sets `status: ready`. `deferred` proposals stay in the root
+folder.
+
+### 2. `om-proposal` skill
+
+Behaviour on invocation:
+
+1. **Scan** `.ai/proposals/*.md` (and `ready/`), surfacing **unanswered/deferred questions** from
+   teammates across all open proposals.
+2. **Ask** the user those questions one at a time, **always offering "defer"** — a deferred
+   question is written back with `status: deferred` and is never lost.
+3. **Ask** what the user wants to add and **which method** to use, then delegate facilitation to
+   `om-brainstorm`.
+4. **Append** new thoughts/answers/findings to the proposal file (creating it if new), updating
+   `updated` and `contributors`.
+5. **Handoff**: when the proposal is `ready`, move it to `.ai/proposals/ready/` and point the
+   user at `om-spec-writing`.
+
+### 3. `om-brainstorm` skill
+
+Facilitation methods, adapted from [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD)
+core-skills (attribution in `references/`):
+
+- **Party mode** — AI role-plays a panel of personas (architect, PM, skeptic, end-user, …) that
+  debate the idea. Single user; the personas are simulated, not real teammates.
+- **Socratic** — the skill interrogates the idea with probing questions to expose assumptions.
+- Additional lightweight methods (e.g. "5 whys", "yes-and") as `references/methods.md` entries.
+
+Output of any method is written back into the active proposal's `## Findings` by `om-proposal`.
+
+### 4. Optional intake hook in `om-spec-writing`
+
+- Add `om-spec-writing/references/proposal-intake.md` describing: detect a matching
+  `.ai/proposals/**/<slug>.md`, read its `## For the spec` + resolved `## Open Questions`, and use
+  it as the starting brief (seeding the spec's own Open Questions from any still-`deferred` items).
+- Add one guarded line to `om-spec-writing/SKILL.md` Workflow Step 1:
+  *"Proposal intake (optional): if `references/proposal-intake.md` is present, follow it before
+  initializing the spec file."*
+- The reference file is copied by `generateShared()` **only** when the proposals group ships.
+  Absent file ⇒ the guarded step is a no-op ⇒ zero behaviour change for installs without proposals.
+
+### 5. Wiring
+
+- **Monorepo**: create both skills under `.ai/skills/om-proposal/` and `.ai/skills/om-brainstorm/`;
+  add the `references/proposal-intake.md` to `.ai/skills/om-spec-writing/` and the guarded SKILL.md
+  step. Register in `.ai/skills/om-help/references/skills-catalog.md` and `workflow-sequences.md`
+  with the chain **proposal → spec → implement**. Add a Task Router row in root `AGENTS.md`.
+- **Standalone**: mirror both skills into
+  `packages/create-app/agentic/shared/ai/skills/{om-proposal,om-brainstorm}/`, add the intake
+  fragment to the create-app `om-spec-writing`, and extend `generateShared()` in
+  `packages/create-app/src/setup/tools/shared.ts` to copy them (flat list, Phase 1) plus the
+  guarded intake reference. Update `om-help` references shipped to standalone.
+
+## Phasing
+
+### Phase 1 — Skills + contract + optional intake (this spec)
+
+| Step | Deliverable |
+|------|-------------|
+| 1.1 | Proposal file contract documented (frontmatter + sections) — captured in `om-proposal/references/proposal-template.md`. |
+| 1.2 | `om-proposal` SKILL.md (scan → question gate w/ defer → method choice → append → ready-handoff/move). |
+| 1.3 | `om-brainstorm` SKILL.md + `references/methods.md` (party mode, Socratic, +light methods) with BMAD attribution. |
+| 1.4 | `om-spec-writing` optional intake: `references/proposal-intake.md` + guarded SKILL.md step (both monorepo + create-app copies). |
+| 1.5 | Monorepo wiring: `om-help` catalog + workflow-sequences entries; root `AGENTS.md` Task Router row. |
+| 1.6 | Standalone wiring: mirror skills into `agentic/shared/ai/skills/`; extend `generateShared()` copy list + intake fragment; update shipped `om-help` references. |
+| 1.7 | Tests: extend `packages/create-app/src/setup/tools/shared.test.ts` to assert the new skills + intake fragment are generated. |
+
+### Phase 2 — Installer skill-package selection (deferred, separate spec)
+
+Refactor `generateShared()` from a flat copy list to a **group manifest**, add a wizard prompt
+(`wizard.ts`) asking which skill packages to install, and gate the proposals group (and its
+`om-spec-writing` intake fragment) on that selection. Out of scope here.
+
+## Backward Compatibility
+
+- **Additive only.** New skills + new reference files. No existing skill is removed or renamed.
+- The `om-spec-writing` change is a single guarded step keyed on an optional file; installs
+  without the proposals group are byte-for-byte unaffected in behaviour.
+- `generateShared()` gains copies; existing copied skills are untouched. No contract-surface
+  removal (see `BACKWARD_COMPATIBILITY.md` — auto-discovery / CLI surfaces unchanged).
+
+## Testing & Verification
+
+- `packages/create-app/src/setup/tools/shared.test.ts`: assert `om-proposal`, `om-brainstorm`,
+  and `om-spec-writing/references/proposal-intake.md` are written to the target dir.
+- Manual: run `om-proposal` in a scratch repo — verify it creates `.ai/proposals/<date>-<slug>.md`,
+  surfaces a seeded deferred question, defers correctly, and moves to `ready/` on completion.
+- Manual: run `om-spec-writing` with and without the intake fragment present — confirm it consumes
+  the proposal when present and is a no-op when absent.
+- `yarn test:create-app` smoke (skills present in scaffold).
+
+## Out of Scope
+
+- Real-time multi-human collaboration (out of model for Claude skills).
+- Installer package-selection mechanism (Phase 2, separate spec).
+- Cross-tool parity for Codex/Cursor of the new skills (skills are Claude-oriented; revisit if needed).
+
+## Implementation Status
+
+| Phase | Status | Date | Notes |
+|-------|--------|------|-------|
+| Phase 1 — Skills + contract + optional intake | Done | 2026-06-15 | All steps 1.1–1.7 implemented; `shared.test.ts` 6/6 green; create-app typecheck clean. |
+| Phase 2 — Installer skill-package selection | Not Started | — | Deferred to a separate spec. |
+
+### Phase 1 — Detailed Progress
+- [x] 1.1 Proposal file contract — `.ai/skills/om-proposal/references/proposal-template.md`
+- [x] 1.2 `om-proposal` SKILL.md (scan → defer-aware question gate → method → append → ready/move)
+- [x] 1.3 `om-brainstorm` SKILL.md + `references/methods.md` (party mode, Socratic, 5-whys, yes-and; BMAD attribution)
+- [x] 1.4 `om-spec-writing` optional intake: `references/proposal-intake.md` + guarded SKILL.md step (monorepo + create-app)
+- [x] 1.5 Monorepo wiring: `om-help` skills-catalog + workflow-sequences (§0); root `AGENTS.md` Task Router row
+- [x] 1.6 Standalone wiring: mirrored skills into `agentic/shared/ai/skills/`; `generateShared()` copy calls + intake; shipped `om-help` references updated
+- [x] 1.7 Tests: `shared.test.ts` asserts new skills + intake ship and are wired into `generateShared()`
+
+> Note: standalone delivery also requires `yarn build` in `packages/create-app` (esbuild + `build.mjs` copies `agentic/` → `dist/agentic/`) before publishing; source-level wiring + tests are green.

--- a/.ai/specs/2026-06-15-collaborative-proposal-skills.md
+++ b/.ai/specs/2026-06-15-collaborative-proposal-skills.md
@@ -166,7 +166,7 @@ Refactor `generateShared()` from a flat copy list to a **group manifest**, add a
 | Phase | Status | Date | Notes |
 |-------|--------|------|-------|
 | Phase 1 — Skills + contract + optional intake | Done | 2026-06-15 | All steps 1.1–1.7 implemented; `shared.test.ts` 6/6 green; create-app typecheck clean. |
-| Phase 2 — Installer skill-package selection | Not Started | — | Deferred to a separate spec. |
+| Phase 2 — Installer skill-package selection | Done | 2026-06-15 | Implemented in `.ai/specs/2026-06-15-installer-skill-packages.md`. The ideation skills became the opt-in `creative` package — the **default scaffold no longer ships `om-proposal`/`om-brainstorm`** unless the user selects `creative` (or passes `--skill-packages …,creative`). |
 
 ### Phase 1 — Detailed Progress
 - [x] 1.1 Proposal file contract — `.ai/skills/om-proposal/references/proposal-template.md`

--- a/.ai/specs/2026-06-15-installer-skill-packages.md
+++ b/.ai/specs/2026-06-15-installer-skill-packages.md
@@ -1,0 +1,167 @@
+# Installer Skill Packages (Phase 2 of collaborative proposal skills)
+
+> Status: **DRAFT — ready for implementation review**
+> Scope: OSS · `packages/create-app` agentic installer (`wizard.ts` + `generateShared()`)
+> Builds on: `.ai/specs/2026-06-15-collaborative-proposal-skills.md` (Phase 1, shipped)
+
+## TLDR
+
+Give the `create-mercato-app` agentic installer a **skill-package selection** step. Today
+`generateShared()` copies a single hardcoded flat list of skills; the wizard only asks which AI
+tool to use. Phase 2 introduces a **package manifest** (`packages.json`, mirroring the monorepo
+`tiers.json`), refactors `generateShared()` to copy skills from that manifest, and adds a wizard
+prompt — *"Which skill packages do you want to install?"* — shown for every tool. The
+collaborative ideation skills (`om-proposal`, `om-brainstorm`) form a new opt-in **`creative`**
+package, realizing the original `wsad.md` ask. Accept-defaults / non-interactive runs install
+today's full set (so nothing regresses); only `creative` is newly opt-in.
+
+## Resolved decisions (Open Questions gate)
+
+- **Q1 → JSON manifest.** A `packages.json` under `agentic/shared/ai/skills/` in the `tiers.json`
+  shape (`{ default: [...], packages: { name: { description, skills: [...], extraFiles?: [...] } } }`).
+- **Q2 → opt-in, named `creative`.** The ideation skills live in a `creative` package, **default OFF**.
+- **Q3 → always.** The package prompt is shown regardless of the selected tool (Codex/Cursor also get `.ai/skills/`).
+- **Q4 → `--skill-packages` flag + today's set as default.** Accept-defaults, non-TTY, and
+  `--skip-agentic-setup` install the default set (= every package currently shipped, i.e. all
+  except `creative`). A `--skill-packages <csv>` CLI flag overrides for scripted scaffolds/tests.
+
+## Problem Statement
+
+`generateShared()` (`packages/create-app/src/setup/tools/shared.ts`) is a flat, hardcoded copy
+list: every standalone app gets every shipped skill, with no way to choose, and the list is getting
+long and hard to maintain. `wsad.md` explicitly asked for an installer question selecting which
+skill *packages* to install, with the collaborative ideation skills as one package. The standalone
+installer has no grouping abstraction today — even though the monorepo already groups skills via
+`.ai/skills/tiers.json` + `install-skills.sh`.
+
+## Design
+
+### 1. Package manifest — `agentic/shared/ai/skills/packages.json`
+
+Mirrors the monorepo `tiers.json` schema, with an optional `extraFiles` for non-skill fragments a
+package owns (e.g. an optional reference inside an otherwise-core skill):
+
+```json
+{
+  "$schema": "./packages.schema.json",
+  "default": ["core", "automation", "integrations", "migration"],
+  "packages": {
+    "core":         { "description": "Daily-driver skills (always installed).", "skills": ["om-spec-writing", "om-implement-spec", "om-code-review", "om-backend-ui-design", "om-data-model-design", "om-module-scaffold", "om-integration-tests", "om-troubleshooter", "om-help", "om-system-extension", "om-eject-and-customize"] },
+    "automation":   { "description": "PR/issue automation.", "skills": ["om-auto-create-pr", "om-auto-continue-pr", "om-auto-create-pr-loop", "om-auto-continue-pr-loop", "om-auto-review-pr", "om-auto-fix-github", "om-prepare-issue", "om-trim-unused-modules"] },
+    "integrations": { "description": "Integration provider builder.", "skills": ["om-integration-builder"] },
+    "migration":    { "description": "Version-pinned upgrade helpers.", "skills": ["om-auto-upgrade-0.4.10-to-0.5.0"] },
+    "creative":     { "description": "Collaborative pre-spec ideation (proposals + brainstorming).", "skills": ["om-proposal", "om-brainstorm"], "extraFiles": ["om-spec-writing/references/proposal-intake.md"] }
+  }
+}
+```
+
+- `core` is **forced** — always installed even if not selected.
+- `default` lists what an accept-defaults run installs (everything except `creative`).
+- `extraFiles` are package-owned files that live under a skill not in this package (here: the
+  optional `proposal-intake.md` fragment of the core `om-spec-writing`). They ship only when the
+  owning package is selected — realizing the Phase-1 Q3 gating.
+
+### 2. `generateShared()` refactor
+
+Replace the flat skill-copy block with manifest-driven copying. Non-skill assets (`AGENTS.md.template`,
+`.ai/specs/`, `.ai/qa/`, package guides) are unchanged.
+
+- Extract a **pure resolver** `resolveSkillFiles(selectedPackages, manifest)` → ordered list of
+  relative paths to copy (skill dirs of `core` ∪ selected packages, plus their `extraFiles`),
+  deduped, `core` always included. This is unit-testable without the filesystem.
+- For each resolved skill folder, copy `SKILL.md` + everything under `references/` recursively.
+  Apply `{{PROJECT_NAME}}` substitution to every copied text file (a no-op when no placeholder),
+  collapsing the current `writeTemplate`-vs-`copyFile` split into one placeholder-safe copy path.
+- `generateShared` receives `config.skillPackages: string[]`.
+
+### 3. Wizard + CLI
+
+- **`wizard.ts`**: after tool selection, always run a package prompt. Multi-select (comma-separated
+  numbers like the tool prompt); `core` shown as forced/always-on; empty input → `default` set.
+  Honor `config.skillPackages` when provided (skip the prompt). Non-TTY → `default` set.
+- **`index.ts`**: parse `--skill-packages <csv>` (validated against manifest package names; unknown
+  name → friendly error listing valid packages) and thread it into `AgenticConfig.skillPackages`.
+  Add usage text. `--skip-agentic-setup` and non-TTY keep installing the default set.
+
+### 4. Validation + tests
+
+- Manifest coverage guard in `shared.test.ts`: parse `packages.json`; assert every skill folder
+  under `agentic/shared/ai/skills/` is assigned to **exactly one** package, every `default` entry
+  names a real package, and every `extraFiles` path exists on disk.
+- Resolver unit tests: `core` always present; `creative` selected ⇒ `om-proposal`/`om-brainstorm` +
+  `proposal-intake.md`; `creative` absent ⇒ none of those; default set = today's full set.
+- Wizard parsing tests: empty → default; explicit csv → that set + forced `core`; invalid name → error.
+
+## Phasing
+
+### Phase 1 — Manifest + coverage guard
+
+| Step | Deliverable |
+|------|-------------|
+| 1.1 | Author `agentic/shared/ai/skills/packages.json` (+ `packages.schema.json`) with the taxonomy above. |
+| 1.2 | `shared.test.ts` coverage guard: every skill folder in exactly one package; `default`/`extraFiles` valid. |
+
+### Phase 2 — generateShared refactor (manifest-driven)
+
+| Step | Deliverable |
+|------|-------------|
+| 2.1 | Extract pure `resolveSkillFiles(selected, manifest)` (core forced, dedupe, extraFiles) + unit tests. |
+| 2.2 | Refactor `generateShared()` skill-copy block to drive from resolver; unify on placeholder-safe copy; keep non-skill assets unchanged. |
+| 2.3 | Gate `creative` `extraFiles` (`proposal-intake.md`) on selection (subsumed by resolver). |
+
+### Phase 3 — Wizard + CLI flag
+
+| Step | Deliverable |
+|------|-------------|
+| 3.1 | `--skill-packages <csv>` parsing + validation + usage text in `index.ts`; thread into `AgenticConfig`. |
+| 3.2 | Wizard package prompt (always; multi-select; `core` forced; empty→default; honor override; non-TTY→default). |
+| 3.3 | Wizard/parsing unit tests (default / explicit / invalid / core-forced). |
+
+### Phase 4 — Docs + alignment
+
+| Step | Deliverable |
+|------|-------------|
+| 4.1 | Update create-app `AGENTS.md` (Agentic Setup Maintenance) to document `packages.json` + the prompt. |
+| 4.2 | Update Phase-1 spec cross-ref; note `creative` is now opt-in (default scaffold no longer ships proposal/brainstorm unless selected). |
+
+## Backward Compatibility
+
+- The flat-list → manifest refactor is internal to `generateShared()`; an accept-defaults run ships
+  the same set as today **except** the newly opt-in `creative` package (Phase 1 had shipped
+  proposal/brainstorm unconditionally; that release has not gone out, so the default change is safe
+  and intentional). No other skill is dropped.
+- Additive wizard step + additive CLI flag. `--skip-agentic-setup` and non-TTY paths preserved.
+- Monorepo `tiers.json` / `install-skills.sh` untouched; the standalone `packages.json` is an
+  independent, conceptually-aligned file.
+
+## Testing & Verification
+
+- `cd packages/create-app && node --test --import tsx src/setup/tools/shared.test.ts` (coverage guard + resolver + wizard parsing).
+- Manual: `node dist/index.js /tmp/app --skill-packages core,creative` → only core + creative skills + `proposal-intake.md`; `node dist/index.js /tmp/app2` (defaults) → today's set, no `creative`.
+- Manual interactive: run the wizard, confirm the package prompt appears for each tool and `core` cannot be deselected.
+- `yarn test:create-app` smoke (default scaffold still complete).
+
+## Out of Scope
+
+- Changing the monorepo `install-skills.sh` / `tiers.json` mechanism.
+- Per-skill (vs per-package) selection granularity.
+- Codex/Cursor-specific skill formats beyond what already ships.
+
+## Implementation Status
+
+| Phase | Status | Date | Notes |
+|-------|--------|------|-------|
+| Phase 1 — Manifest + coverage guard | Done | 2026-06-15 | `packages.json` + `packages.schema.json`; `shared.test.ts` coverage guards (folder↔package 1:1, default/extraFiles valid, creative opt-in). |
+| Phase 2 — generateShared refactor | Done | 2026-06-15 | Pure `resolveSkillSelection` + `loadSkillManifest` + recursive placeholder-safe `copySkillTree`; flat list removed; gated extraFiles. |
+| Phase 3 — Wizard + CLI flag | Done | 2026-06-15 | `--skill-packages <csv>` (validated) + `AgenticConfig.skillPackages`; always-shown package prompt; non-TTY/CI degrade to `default`. |
+| Phase 4 — Docs + alignment | Done | 2026-06-15 | create-app `AGENTS.md` Skill Packages section; Phase-1 spec cross-ref updated (creative now opt-in). |
+
+### Verification
+- `node --test --import tsx 'src/**/*.test.ts'` → 53/53 green (incl. resolver, parsing, manifest coverage guards).
+- create-app typecheck clean; `node build.mjs` ok.
+- End-to-end scaffolds: defaults → 21 skills, no `creative`; `--skill-packages core,creative` → 13 skills + `proposal-intake.md`, no `automation`; invalid package → error + exit 1; non-TTY without flag → `default` set (no prompt-starvation regression).
+
+### Notes / deviations
+- **BC default change (intended):** the default scaffold no longer ships `om-proposal`/`om-brainstorm` (now opt-in `creative`). Phase 1 had shipped them unconditionally but was unreleased, so the change is safe.
+- **Non-TTY fix:** adding a second wizard prompt risked starving on EOF under piped stdin; non-interactive runs now resolve packages to the manifest `default` (mirrors the starter-preset / git prompts), so CI and `printf`-driven scaffolds don't regress.
+- `migration` kept in `default` to preserve today's shipped set; moving it to opt-in is a possible future refinement.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ IMPORTANT: Before any research or coding, match the task to the root `AGENTS.md`
 | **Testing** | |
 | Integration testing, creating/running Playwright tests, converting markdown test cases to TypeScript, CI test pipeline | `.ai/qa/AGENTS.md` + `.ai/skills/om-integration-tests/SKILL.md` |
 | **Spec & PR Automation** | |
+| Collaborative pre-spec ideation (capture an idea, brainstorm with party mode / Socratic, surface teammates' open questions before a spec exists) — async, file-based via `.ai/proposals/` | Browse `.ai/skills/{om-proposal,om-brainstorm}/SKILL.md`; hands off to `om-spec-writing` via its optional `references/proposal-intake.md`. Spec: `.ai/specs/2026-06-15-collaborative-proposal-skills.md` |
 | Spec lifecycle (pre-implement → implement → write/update), code review, DS review | Browse `.ai/skills/{om-spec-writing,om-pre-implement-spec,om-implement-spec,om-code-review,om-ds-guardian}/SKILL.md` + `.ai/specs/AGENTS.md` + `.ai/ds-rules.md` |
 | PR/issue automation (one-shot auto-PR, resumable loop variants, review/merge-buddy, post-merge sync, changelog). **Default for one-off bug fixes / small features:** `om-auto-create-pr` | Browse `.ai/skills/{om-auto-create-pr,om-auto-continue-pr,om-auto-create-pr-loop,om-auto-continue-pr-loop,om-auto-review-pr,om-merge-buddy,om-review-prs,om-sync-merged-pr-issues,om-auto-update-changelog}/SKILL.md` |
 

--- a/packages/create-app/AGENTS.md
+++ b/packages/create-app/AGENTS.md
@@ -155,6 +155,7 @@ The `agentic/` directory contains standalone-app-specific AI coding tool configu
 packages/create-app/agentic/
 ├── shared/                      # Always generated (AGENTS.md, .ai/ structure)
 │   ├── AGENTS.md.template       # {{PROJECT_NAME}} placeholder substitution
+│   ├── ai/skills/               # Skill folders + packages.json manifest (see Skill Packages below)
 │   └── ai/specs/                # Spec templates for standalone apps
 ├── claude-code/                 # Claude Code tool config
 │   ├── CLAUDE.md.template       # {{PROJECT_NAME}} placeholder substitution
@@ -177,6 +178,15 @@ packages/create-app/agentic/
 - When adding new auto-discovery paths or module files
 - When changing CLI commands that standalone apps use
 - When the entity-migration hook logic needs adjustment
+- **When adding or removing a skill** under `agentic/shared/ai/skills/`: assign it to exactly one package in `agentic/shared/ai/skills/packages.json`. The `shared.test.ts` coverage guard fails if a skill folder is orphaned or listed-but-missing.
+
+### Skill Packages (`packages.json`)
+
+`generateShared()` copies skills from `agentic/shared/ai/skills/packages.json` (shape mirrors the monorepo `.ai/skills/tiers.json`): `{ default, packages: { name: { description, skills[], extraFiles? } } }`.
+
+- `core` is always installed; `default` lists packages shipped on an accept-defaults / non-interactive run; other packages are opt-in.
+- The wizard asks which packages to install (shown for every tool). Non-TTY / CI runs skip the prompt and use `default`; `--skill-packages <csv>` overrides non-interactively (validated against the manifest).
+- `extraFiles` are package-owned files living under a skill in another package (e.g. `creative` owns `om-spec-writing/references/proposal-intake.md`). They are gated: skipped during folder copy unless their package is selected. See `src/setup/tools/skill-packages.ts` (pure resolver) and `loadSkillManifest()` in `shared.ts`.
 
 ### Key Constraints
 

--- a/packages/create-app/agentic/shared/ai/skills/om-brainstorm/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-brainstorm/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: om-brainstorm
+description: >
+  Facilitation methods for exploring an idea — party mode (an AI panel of personas), Socratic
+  questioning, 5-whys, yes-and, and more. Use when ideating on a feature, stress-testing an
+  approach, or when invoked by om-proposal to explore a proposal. Methods adapted from
+  BMAD-METHOD. Single-user facilitation: personas are simulated, not real teammates.
+---
+
+# om-brainstorm — Idea Facilitation Methods
+
+A toolbox of brainstorming methods to explore and pressure-test an idea. Usually invoked by
+`om-proposal` against an active proposal, but works standalone too. This is **single-user
+facilitation** — when a method uses multiple voices (e.g. party mode), the skill simulates those
+personas; it is not a real-time multi-human session. Real teammate collaboration happens
+asynchronously through the proposal file (see `om-proposal`).
+
+Method details and prompts live in [methods.md](references/methods.md). Attribution:
+methods are adapted from [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD) core-skills.
+
+## Workflow
+
+1. **Pick a method** — ask the user which method fits, or recommend one:
+   - **Party mode** — convene a panel of personas (architect, PM, skeptic, end-user, …) that
+     debate the idea from their angles. Best for surfacing blind spots and trade-offs.
+   - **Socratic** — interrogate the idea with probing questions to expose hidden assumptions.
+     Best when the idea feels obvious but untested.
+   - **5 Whys** — drill from symptom to root cause. Best for problem framing.
+   - **Yes-and** — divergent expansion without judgement. Best early, to widen the option space.
+2. **Run the method** following its recipe in `methods.md`. Stay in the method until it converges
+   or the user stops it.
+3. **Distil** — summarise decisions, trade-offs, and any new questions the session raised.
+4. **Return** the distilled output to the caller. When invoked by `om-proposal`, the output is
+   written into the proposal's `## Findings`, and new questions into `## Open Questions`.
+
+## Rules
+
+- MUST keep persona panels balanced — always include at least one skeptic/critic voice so party
+  mode does not become an echo chamber.
+- MUST end every method with a distillation (decisions + open questions), not just a transcript.
+- MUST credit BMAD-METHOD when the user asks where the methods come from.
+- MUST NOT invent consensus — if personas/questions expose an unresolved trade-off, record it as
+  an open question rather than papering over it.

--- a/packages/create-app/agentic/shared/ai/skills/om-brainstorm/references/methods.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-brainstorm/references/methods.md
@@ -1,0 +1,70 @@
+# Brainstorming Methods
+
+Recipes for the facilitation methods offered by `om-brainstorm`. Adapted from
+[BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD) core-skills.
+
+Every method ends with a **distillation**: the decisions reached + the new open questions raised.
+That distillation is what flows back to `om-proposal`'s `## Findings` / `## Open Questions`.
+
+---
+
+## Party Mode
+
+Convene a panel of personas and let them debate the idea. The skill role-plays each persona in
+turn; the user is the moderator.
+
+**Default panel** (adapt to the domain): **Architect** (feasibility, system fit), **Product
+Manager** (user value, scope, priorities), **Skeptic** (risks, failure modes, "why this won't
+work"), **End User** (real-world workflow, friction), and optionally a **Domain Expert**.
+
+**Recipe**
+1. State the idea in one sentence and confirm it with the user.
+2. Go round the panel: each persona reacts in 2-4 sentences from its angle. Label every turn with
+   the persona name.
+3. Let personas respond to each other where they disagree — surface the trade-off, do not resolve
+   it artificially.
+4. Run 2-3 rounds, or until the discussion converges.
+5. **Distil**: agreed points, live trade-offs (→ open questions), and a recommended direction.
+
+**Rule**: the Skeptic must always speak — party mode without dissent is an echo chamber.
+
+---
+
+## Socratic
+
+Interrogate the idea with successive probing questions to expose assumptions the user has not
+examined.
+
+**Recipe**
+1. Restate the user's claim/idea.
+2. Ask one probing question at a time (e.g. "What must be true for this to work?", "What's the
+   simplest case where this breaks?", "What evidence would change your mind?").
+3. Follow each answer with a deeper question. Do not lecture — only ask.
+4. Stop when an assumption is exposed as load-bearing-and-untested, or the idea is well-grounded.
+5. **Distil**: the assumptions found, which are validated vs unvalidated (→ open questions).
+
+---
+
+## 5 Whys
+
+Drill from a symptom to its root cause to make sure the proposal solves the right problem.
+
+**Recipe**
+1. State the problem/symptom.
+2. Ask "why does this happen?" Take the answer, ask "why?" again. Repeat ~5 times.
+3. Stop when you hit a root cause that is actionable.
+4. **Distil**: the root cause and whether the proposed idea actually addresses it (→ open question
+   if it only treats a symptom).
+
+---
+
+## Yes-And
+
+Divergent expansion for the early, generative phase — widen the option space before judging.
+
+**Recipe**
+1. Take the seed idea. Each turn adds "yes, and …" — building, never blocking.
+2. Defer all criticism; capture every branch, even unlikely ones.
+3. After divergence, cluster the branches and let the user pick which to keep.
+4. **Distil**: the option clusters and the user's shortlist (→ open questions for the dropped ones
+   worth revisiting).

--- a/packages/create-app/agentic/shared/ai/skills/om-help/references/skills-catalog.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-help/references/skills-catalog.md
@@ -20,6 +20,8 @@ Skills for creating new functionality in your standalone Open Mercato applicatio
 | Skill | Trigger / When to use | Preceded by | Followed by |
 |-------|----------------------|-------------|-------------|
 | `om-help` | "what now?", "which skill?", "next steps?", "how do I X?", orientation | — | any |
+| `om-proposal` | Capture/refine a pre-spec idea collaboratively (async, file-based in `.ai/proposals/`); surface teammates' open questions | — | `om-brainstorm` then `om-spec-writing` |
+| `om-brainstorm` | Facilitate ideation — party mode (persona panel), Socratic, 5-whys, yes-and | `om-proposal` | `om-proposal` (writes findings back) |
 | `om-data-model-design` | Designing entities, relationships, migrations, encryption maps for PII | — | `om-spec-writing` or `om-module-scaffold` |
 | `om-spec-writing` | Writing a spec before building a non-trivial feature | `om-data-model-design` | `om-module-scaffold` or `om-implement-spec` |
 | `om-module-scaffold` | Creating a new module with entity, routes, pages, ACL, DI | `om-spec-writing` or `om-data-model-design` | `om-integration-tests` |

--- a/packages/create-app/agentic/shared/ai/skills/om-help/references/workflow-sequences.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-help/references/workflow-sequences.md
@@ -5,6 +5,7 @@
 
 ## Table of Contents
 
+- [Ideate Before a Spec (Collaborative)](#0-ideate-before-a-spec-collaborative)
 - [New Module](#1-new-module)
 - [New Feature in Existing Module](#2-new-feature-in-existing-module)
 - [Extend an Existing Module](#3-extend-an-existing-module)
@@ -15,6 +16,28 @@
 - [Slim Down the App](#8-slim-down-the-app)
 - [Upgrade Open Mercato](#9-upgrade-open-mercato)
 - [Choosing the Right Sequence](#choosing-the-right-sequence)
+
+---
+
+## 0. Ideate Before a Spec (Collaborative)
+
+**Use when:** A feature/module is still a rough idea and you want the team to weigh in before a
+spec is locked. Collaboration is asynchronous and file-based via `.ai/proposals/`.
+
+```
+om-proposal        (open/refine a proposal; surface teammates' open questions; defer or answer)
+  → om-brainstorm  (party mode, Socratic, 5-whys, yes-and — findings flow back to the proposal)
+  → om-proposal    (mark ready; moves to .ai/proposals/ready/)
+  → om-spec-writing (consumes the proposal's "For the spec" brief + carried-forward questions)
+```
+
+**Rationale per step:**
+1. `om-proposal` — capture the idea, pull in unanswered questions other teammates left behind.
+2. `om-brainstorm` — explore with a facilitation method; every method ends with a distillation.
+3. `om-proposal` — when the team agrees, mark `ready` and hand off.
+4. `om-spec-writing` — picks up the brief automatically when its proposal-intake hook is installed.
+
+> Optional layer. For a solo quick feature, skip straight to `om-spec-writing` (or `om-module-scaffold`).
 
 ---
 

--- a/packages/create-app/agentic/shared/ai/skills/om-proposal/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-proposal/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: om-proposal
+description: >
+  Collaborative pre-spec ideation. Turn a loose idea into a structured proposal that becomes
+  the input to om-spec-writing. Use when a team wants to ideate before a spec exists, when you
+  hear "let's brainstorm a feature", "capture an idea", "open a proposal", "what should we
+  build", "I have a rough idea", "gather the team's thoughts", or before writing a spec for a
+  non-trivial feature/module. Collaboration is asynchronous and file-based via `.ai/proposals/`.
+---
+
+# om-proposal — Collaborative Pre-Spec Proposals
+
+Proposals are the ideation layer **before** a spec. They live as markdown under
+`.ai/proposals/`, committed to git, so teammates contribute **asynchronously**: each person runs
+this skill, it surfaces teammates' unanswered questions, and appends new thoughts and answers.
+A finished proposal hands off to `om-spec-writing`.
+
+This skill manages the proposal file and the question gate. It delegates the actual idea
+exploration to `om-brainstorm` (party mode, Socratic, …).
+
+## File Contract — `.ai/proposals/<YYYY-MM-DD>-<slug>.md`
+
+See [proposal-template.md](references/proposal-template.md) for the exact shape. The headings are
+a **stable contract** — `om-brainstorm` and the `om-spec-writing` intake hook depend on them:
+
+- Frontmatter: `title`, `status: open | ready | deferred`, `contributors`, `created`, `updated`.
+- `## Idea / Context` — the problem and motivation.
+- `## Open Questions` — checklist; each item names an asker and a status `open | answered | deferred`.
+- `## Findings` — answers and distilled brainstorm output.
+- `## For the spec` — the brief `om-spec-writing` consumes.
+
+A `ready` proposal is moved to `.ai/proposals/ready/`; `deferred` and `open` proposals stay in the
+root folder.
+
+## Workflow
+
+### Step 1 — Scan existing proposals
+
+Read every file under `.ai/proposals/` (including `ready/`). Build a list of all
+**unanswered (`open`) and `deferred`** questions across proposals, noting which proposal and who
+asked each one. If `.ai/proposals/` does not exist yet, create it.
+
+### Step 2 — Surface teammates' open questions
+
+Present the outstanding questions from other proposals to the user, grouped by proposal. For each,
+the user may **answer** it (write the answer to `## Findings`, flip the item to `answered`) or
+**defer** it. **Always offer "defer" explicitly** — a deferred question is written back with
+`status: deferred` and is **never deleted**. Do not pressure the user to answer; deferral is a
+first-class outcome.
+
+### Step 3 — Capture what the user wants to add
+
+Ask what the user wants to contribute and to **which** proposal (existing, or a new one — then ask
+for a title and derive the `<slug>`). Create the file from the template if new, adding the user to
+`contributors` and stamping `updated`.
+
+### Step 4 — Choose a method and explore
+
+Ask which facilitation method to use, then **delegate to `om-brainstorm`** (party mode, Socratic,
+5-whys, …). Write the method's output into `## Findings`. New questions raised during exploration
+are added to `## Open Questions` as `open`.
+
+### Step 5 — Handoff
+
+When the team considers the proposal complete:
+- Ensure `## For the spec` holds a coherent brief and any still-`deferred` questions are listed
+  there (so `om-spec-writing` can seed its own Open Questions from them).
+- Set `status: ready`, **move the file to `.ai/proposals/ready/`**, and point the user at
+  `om-spec-writing` (which will detect and consume the proposal when its intake hook is installed).
+
+## Rules
+
+- MUST offer "defer" for every question; deferred questions persist and are never deleted.
+- MUST preserve the section headings exactly — they are the contract the other skills read.
+- MUST append, never silently overwrite another contributor's content; update `updated` and
+  `contributors` on every edit.
+- MUST keep proposals free of secrets/credentials/customer data (they are committed to git).
+- MUST NOT write the spec here — that is `om-spec-writing`'s job. This skill only produces the brief.
+- Derive `<slug>` as kebab-case from the title; date is `YYYY-MM-DD`.

--- a/packages/create-app/agentic/shared/ai/skills/om-proposal/references/proposal-template.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-proposal/references/proposal-template.md
@@ -1,0 +1,31 @@
+---
+title: <human-readable title>
+status: open
+contributors: [<your-name>]
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+---
+
+## Idea / Context
+
+<What problem are we exploring? Why now? Who is it for? Keep it short — this is ideation,
+not a spec. Link related proposals or specs if relevant.>
+
+## Open Questions
+
+> Each item: `[ ]` open · `[~]` deferred · `[x]` answered. Name the asker. Deferred questions
+> are never deleted — they carry forward into `om-spec-writing`'s Open Questions gate.
+
+- [ ] (asked by <name>) <question> — status: open
+- [~] (asked by <name>) <question> — status: deferred
+
+## Findings
+
+<Answers to questions, decisions reached, and the distilled output of brainstorming sessions
+(party mode panels, Socratic threads, …). Attribute non-obvious points to a contributor.>
+
+## For the spec
+
+<The brief `om-spec-writing` will consume as its starting point: the agreed problem, the chosen
+direction, constraints, and the list of still-deferred questions it must turn into its own
+Open Questions. This section is the handoff contract.>

--- a/packages/create-app/agentic/shared/ai/skills/om-spec-writing/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-spec-writing/SKILL.md
@@ -10,6 +10,7 @@ Design and review specifications (SPECs) against Open Mercato architecture and q
 ## Workflow
 
 1. **Load Context**: Read `AGENTS.md` for module conventions and `.ai/specs/` for existing specs.
+   - **Proposal intake (optional)**: if `references/proposal-intake.md` is present, follow it before initializing the spec file — a matching `.ai/proposals/**/<slug>.md` may supply the starting brief and carry-forward Open Questions. If the file is absent, skip this and proceed normally.
 2. **Initialize**: Create `{date}-{title}.md` in `.ai/specs/`.
 3. **Start Minimal**: Write a Skeleton Spec (TLDR + 2-3 key sections). Do NOT write the full spec in one pass.
    - Scan for **critical unknowns** — decisions that block data model, scope, or architecture.

--- a/packages/create-app/agentic/shared/ai/skills/om-spec-writing/references/proposal-intake.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-spec-writing/references/proposal-intake.md
@@ -1,0 +1,29 @@
+# Proposal Intake (optional)
+
+> This file is present only when the collaborative proposal skills (`om-proposal` /
+> `om-brainstorm`) are installed. When present, `om-spec-writing` consumes a matching proposal as
+> the starting brief. When absent, spec-writing proceeds normally — the guarded step is a no-op.
+
+## When to apply
+
+Before initializing the spec file (Workflow Step "Load Context" / "Initialize"), check whether the
+work being spec'd already has a proposal.
+
+## Procedure
+
+1. **Locate** a matching proposal under `.ai/proposals/**/<slug>.md` (check both the root folder
+   and `.ai/proposals/ready/`). Match by topic/slug; if several look relevant, ask the user which.
+   If none exists, skip the rest of this procedure.
+2. **Read** the proposal's `## For the spec` (the agreed brief) and `## Findings` (decisions and
+   rationale). Use them to seed the spec's TLDR, Problem Statement, and Proposed Solution instead
+   of starting from scratch.
+3. **Carry forward open questions**: any item in the proposal's `## Open Questions` still marked
+   `open` or `deferred` becomes a candidate for the spec's **Open Questions** gate (Skeleton step).
+   Do not silently assume answers the proposal explicitly deferred.
+4. **Reference** the proposal in the spec (e.g. "Derived from `.ai/proposals/ready/<slug>.md`") so
+   the ideation trail is traceable.
+
+## Rules
+
+- MUST NOT resolve a question the proposal left `deferred` — surface it in the spec's Open Questions.
+- MUST keep the proposal as the source of *intent*; the spec remains the source of *design*.

--- a/packages/create-app/agentic/shared/ai/skills/packages.json
+++ b/packages/create-app/agentic/shared/ai/skills/packages.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "./packages.schema.json",
+  "default": ["core", "automation", "integrations", "migration"],
+  "packages": {
+    "core": {
+      "description": "Daily-driver skills. Always installed (cannot be deselected).",
+      "skills": [
+        "om-spec-writing",
+        "om-implement-spec",
+        "om-code-review",
+        "om-backend-ui-design",
+        "om-data-model-design",
+        "om-module-scaffold",
+        "om-integration-tests",
+        "om-troubleshooter",
+        "om-help",
+        "om-system-extension",
+        "om-eject-and-customize"
+      ]
+    },
+    "automation": {
+      "description": "PR and issue automation (auto-create-pr, review, fix, slimdown).",
+      "skills": [
+        "om-auto-create-pr",
+        "om-auto-continue-pr",
+        "om-auto-create-pr-loop",
+        "om-auto-continue-pr-loop",
+        "om-auto-review-pr",
+        "om-auto-fix-github",
+        "om-prepare-issue",
+        "om-trim-unused-modules"
+      ]
+    },
+    "integrations": {
+      "description": "Integration provider builder (payment, shipping, data-sync).",
+      "skills": ["om-integration-builder"]
+    },
+    "migration": {
+      "description": "Version-pinned upgrade helpers.",
+      "skills": ["om-auto-upgrade-0.4.10-to-0.5.0"]
+    },
+    "creative": {
+      "description": "Collaborative pre-spec ideation — proposals and brainstorming (party mode, Socratic).",
+      "skills": ["om-proposal", "om-brainstorm"],
+      "extraFiles": ["om-spec-writing/references/proposal-intake.md"]
+    }
+  }
+}

--- a/packages/create-app/agentic/shared/ai/skills/packages.schema.json
+++ b/packages/create-app/agentic/shared/ai/skills/packages.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Standalone skill packages manifest",
+  "description": "Groups the standalone agentic skills into named packages the create-mercato-app installer can offer. The 'core' package is always installed; 'default' lists packages installed on an accept-defaults run.",
+  "type": "object",
+  "required": ["default", "packages"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "default": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1,
+      "description": "Package names installed when the user accepts defaults / runs non-interactively."
+    },
+    "packages": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["description", "skills"],
+        "additionalProperties": false,
+        "properties": {
+          "description": { "type": "string" },
+          "skills": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Skill folder names (under .ai/skills/) belonging to this package."
+          },
+          "extraFiles": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Package-owned files living under a skill not in this package (paths relative to .ai/skills/). Shipped only when this package is selected."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -15,6 +15,8 @@ import {
 import { applyStarterPreset } from './lib/apply-starter-preset.js'
 import { DEFAULT_PRESET_ID, VALID_PRESET_IDS } from './lib/starter-presets.js'
 import { runAgenticSetup } from './setup/wizard.js'
+import { loadSkillManifest } from './setup/tools/shared.js'
+import { findUnknownPackages, parseSkillPackagesInput } from './setup/tools/skill-packages.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -28,6 +30,7 @@ interface Options {
   registry?: string
   initGit?: boolean
   skipAgenticSetup: boolean
+  skillPackages?: string[]
   verdaccio: boolean
   help: boolean
   version: boolean
@@ -50,6 +53,7 @@ ${pc.bold('Options:')}
   --init-git         Initialize a local Git repository after scaffolding
   --no-init-git      Do not prompt for or initialize a local Git repository
   --skip-agentic-setup  Skip the interactive agentic setup wizard
+  --skill-packages <csv>  Skill packages to install (e.g. core,creative); skips the package prompt
   --registry <url>   Custom npm registry URL
   --verdaccio        Use local Verdaccio registry (http://localhost:4873)
   --help, -h         Show help
@@ -65,6 +69,7 @@ ${pc.bold('Examples:')}
   npx create-mercato-app my-marketplace --app-url https://github.com/some-agency/ready-app-marketplace
   npx create-mercato-app my-store --verdaccio
   npx create-mercato-app my-store --registry http://localhost:4873
+  npx create-mercato-app my-store --skill-packages core,creative
 `)
 }
 
@@ -104,6 +109,9 @@ function parseArgs(args: string[]): { appName: string | null; options: Options }
       options.version = true
     } else if (arg === '--skip-agentic-setup') {
       options.skipAgenticSetup = true
+    } else if (arg === '--skill-packages') {
+      options.skillPackages = parseSkillPackagesInput(requireOptionValue(args, index, arg))
+      index += 1
     } else if (arg === '--init-git') {
       options.initGit = true
     } else if (arg === '--no-init-git') {
@@ -419,10 +427,30 @@ async function scaffoldImportedReadyApp(targetDir: string, source: ReadyAppSourc
   ensureGeneratedCssPlaceholder(targetDir)
 }
 
-async function maybeRunAgenticSetup(targetDir: string, skipAgenticSetup: boolean): Promise<void> {
+async function maybeRunAgenticSetup(
+  targetDir: string,
+  skipAgenticSetup: boolean,
+  skillPackages?: string[],
+): Promise<void> {
   if (skipAgenticSetup) {
     await runAgenticSetup(targetDir, async () => '', { tool: 'skip' })
     return
+  }
+
+  let resolvedPackages = skillPackages
+  if (resolvedPackages && resolvedPackages.length > 0) {
+    const manifest = loadSkillManifest()
+    const unknown = findUnknownPackages(resolvedPackages, manifest)
+    if (unknown.length > 0) {
+      console.error(pc.red(`Unknown skill package(s): ${unknown.join(', ')}`))
+      console.error(`   Valid packages: ${Object.keys(manifest.packages).join(', ')}`)
+      process.exit(1)
+    }
+  } else if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    // Non-interactive (CI / piped stdin): can't prompt for packages — a follow-up
+    // readline question would starve on EOF and abandon setup. Use the manifest default,
+    // matching how the starter-preset and git prompts degrade without a TTY.
+    resolvedPackages = loadSkillManifest().default
   }
 
   const rl = createInterface({ input: process.stdin, output: process.stdout })
@@ -430,7 +458,7 @@ async function maybeRunAgenticSetup(targetDir: string, skipAgenticSetup: boolean
     new Promise<string>((resolveAnswer) => rl.question(question, (answer) => resolveAnswer(answer.trim())))
 
   try {
-    await runAgenticSetup(targetDir, ask)
+    await runAgenticSetup(targetDir, ask, { skillPackages: resolvedPackages })
   } finally {
     rl.close()
   }
@@ -560,7 +588,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   console.log('')
 
   if (!readyAppSource) {
-    await maybeRunAgenticSetup(targetDir, options.skipAgenticSetup)
+    await maybeRunAgenticSetup(targetDir, options.skipAgenticSetup, options.skillPackages)
   }
 
   const gitResult = await maybeInitializeGitRepository(targetDir, options)

--- a/packages/create-app/src/setup/tools/shared.test.ts
+++ b/packages/create-app/src/setup/tools/shared.test.ts
@@ -34,6 +34,33 @@ const POLYFILL_PATTERNS = {
 // regression at PR time instead of at customer install time.
 const TRACKED_TEMPLATES = ['ai/qa/tests/playwright.config.ts']
 
+// Collaborative pre-spec ideation skills shipped to standalone apps. Each must
+// exist under agentic/shared AND be wired into generateShared()'s copy list, or
+// a `create-mercato-app` user gets a broken/partial proposal workflow.
+const PROPOSAL_SKILL_FILES = [
+  'ai/skills/om-proposal/SKILL.md',
+  'ai/skills/om-proposal/references/proposal-template.md',
+  'ai/skills/om-brainstorm/SKILL.md',
+  'ai/skills/om-brainstorm/references/methods.md',
+  'ai/skills/om-spec-writing/references/proposal-intake.md',
+]
+
+const SHARED_GENERATOR_SOURCE = readFileSync(join(__dirname, 'shared.ts'), 'utf8')
+
+for (const relativePath of PROPOSAL_SKILL_FILES) {
+  test(`proposal skill "${relativePath}" ships and is wired into generateShared()`, () => {
+    const fullPath = join(AGENTIC_SHARED_DIR, relativePath)
+    assert.doesNotThrow(
+      () => readFileSync(fullPath, 'utf8'),
+      `${relativePath} is missing from agentic/shared — standalone apps would not receive it.`,
+    )
+    assert.ok(
+      SHARED_GENERATOR_SOURCE.includes(`'${relativePath}'`),
+      `${relativePath} exists but generateShared() does not copy it — add a copyFile() call in shared.ts.`,
+    )
+  })
+}
+
 for (const relativePath of TRACKED_TEMPLATES) {
   test(`agentic/shared template "${relativePath}" is ESM-safe`, () => {
     const fullPath = join(AGENTIC_SHARED_DIR, relativePath)

--- a/packages/create-app/src/setup/tools/shared.test.ts
+++ b/packages/create-app/src/setup/tools/shared.test.ts
@@ -1,8 +1,9 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import type { SkillPackageManifest } from './skill-packages.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -34,32 +35,62 @@ const POLYFILL_PATTERNS = {
 // regression at PR time instead of at customer install time.
 const TRACKED_TEMPLATES = ['ai/qa/tests/playwright.config.ts']
 
-// Collaborative pre-spec ideation skills shipped to standalone apps. Each must
-// exist under agentic/shared AND be wired into generateShared()'s copy list, or
-// a `create-mercato-app` user gets a broken/partial proposal workflow.
-const PROPOSAL_SKILL_FILES = [
-  'ai/skills/om-proposal/SKILL.md',
-  'ai/skills/om-proposal/references/proposal-template.md',
-  'ai/skills/om-brainstorm/SKILL.md',
-  'ai/skills/om-brainstorm/references/methods.md',
-  'ai/skills/om-spec-writing/references/proposal-intake.md',
-]
+// Skill packages: generateShared() copies skills from packages.json. The
+// manifest must stay in lockstep with the skill folders on disk, or a
+// `create-mercato-app` user gets an orphaned (never-installed) or dangling
+// (listed-but-missing) skill. These guards catch drift at PR time.
+const SKILLS_DIR = join(AGENTIC_SHARED_DIR, 'ai', 'skills')
+const MANIFEST = JSON.parse(readFileSync(join(SKILLS_DIR, 'packages.json'), 'utf8')) as SkillPackageManifest
 
-const SHARED_GENERATOR_SOURCE = readFileSync(join(__dirname, 'shared.ts'), 'utf8')
-
-for (const relativePath of PROPOSAL_SKILL_FILES) {
-  test(`proposal skill "${relativePath}" ships and is wired into generateShared()`, () => {
-    const fullPath = join(AGENTIC_SHARED_DIR, relativePath)
-    assert.doesNotThrow(
-      () => readFileSync(fullPath, 'utf8'),
-      `${relativePath} is missing from agentic/shared — standalone apps would not receive it.`,
-    )
-    assert.ok(
-      SHARED_GENERATOR_SOURCE.includes(`'${relativePath}'`),
-      `${relativePath} exists but generateShared() does not copy it — add a copyFile() call in shared.ts.`,
-    )
-  })
+function skillFoldersOnDisk(): string[] {
+  return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(join(SKILLS_DIR, entry.name, 'SKILL.md')))
+    .map((entry) => entry.name)
 }
+
+test('every skill folder on disk is assigned to exactly one package', () => {
+  const assignment = new Map<string, string[]>()
+  for (const [pkgName, pkg] of Object.entries(MANIFEST.packages)) {
+    for (const skill of pkg.skills) {
+      assignment.set(skill, [...(assignment.get(skill) ?? []), pkgName])
+    }
+  }
+  for (const skill of skillFoldersOnDisk()) {
+    const owners = assignment.get(skill) ?? []
+    assert.equal(owners.length, 1, `${skill} is in ${owners.length} packages (${owners.join(', ') || 'none'}); expected exactly 1.`)
+  }
+})
+
+test('every skill listed in the manifest exists on disk', () => {
+  const onDisk = new Set(skillFoldersOnDisk())
+  for (const pkg of Object.values(MANIFEST.packages)) {
+    for (const skill of pkg.skills) {
+      assert.ok(onDisk.has(skill), `manifest lists "${skill}" but it has no folder with SKILL.md on disk.`)
+    }
+  }
+})
+
+test('every default entry names a defined package', () => {
+  for (const name of MANIFEST.default) {
+    assert.ok(MANIFEST.packages[name], `default lists "${name}" which is not a defined package.`)
+  }
+})
+
+test('every extraFiles path exists on disk', () => {
+  for (const pkg of Object.values(MANIFEST.packages)) {
+    for (const extra of pkg.extraFiles ?? []) {
+      assert.ok(existsSync(join(SKILLS_DIR, ...extra.split('/'))), `extraFiles path "${extra}" does not exist on disk.`)
+    }
+  }
+})
+
+test('creative package owns the ideation skills and the proposal-intake fragment', () => {
+  const creative = MANIFEST.packages.creative
+  assert.ok(creative, 'creative package is missing from the manifest.')
+  assert.ok(creative.skills.includes('om-proposal') && creative.skills.includes('om-brainstorm'))
+  assert.ok((creative.extraFiles ?? []).includes('om-spec-writing/references/proposal-intake.md'))
+  assert.ok(!MANIFEST.default.includes('creative'), 'creative must stay opt-in (not in default).')
+})
 
 for (const relativePath of TRACKED_TEMPLATES) {
   test(`agentic/shared template "${relativePath}" is ESM-safe`, () => {

--- a/packages/create-app/src/setup/tools/shared.ts
+++ b/packages/create-app/src/setup/tools/shared.ts
@@ -58,6 +58,30 @@ export function generateShared(config: AgenticConfig): void {
     'ai/skills/om-spec-writing/references/spec-checklist.md',
     join(targetDir, '.ai', 'skills', 'om-spec-writing', 'references', 'spec-checklist.md'),
   )
+  // Optional proposal intake — present so om-spec-writing can consume a `.ai/proposals/` brief.
+  // The guarded SKILL.md step is a no-op when this file is absent.
+  copyFile(
+    'ai/skills/om-spec-writing/references/proposal-intake.md',
+    join(targetDir, '.ai', 'skills', 'om-spec-writing', 'references', 'proposal-intake.md'),
+  )
+
+  // Collaborative pre-spec ideation skills (proposal -> spec -> implement).
+  copyFile(
+    'ai/skills/om-proposal/SKILL.md',
+    join(targetDir, '.ai', 'skills', 'om-proposal', 'SKILL.md'),
+  )
+  copyFile(
+    'ai/skills/om-proposal/references/proposal-template.md',
+    join(targetDir, '.ai', 'skills', 'om-proposal', 'references', 'proposal-template.md'),
+  )
+  copyFile(
+    'ai/skills/om-brainstorm/SKILL.md',
+    join(targetDir, '.ai', 'skills', 'om-brainstorm', 'SKILL.md'),
+  )
+  copyFile(
+    'ai/skills/om-brainstorm/references/methods.md',
+    join(targetDir, '.ai', 'skills', 'om-brainstorm', 'references', 'methods.md'),
+  )
 
   copyFile(
     'ai/skills/om-backend-ui-design/SKILL.md',

--- a/packages/create-app/src/setup/tools/shared.ts
+++ b/packages/create-app/src/setup/tools/shared.ts
@@ -2,12 +2,14 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, readd
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { AgenticConfig } from '../wizard.js'
+import { resolveSkillSelection, type SkillPackageManifest } from './skill-packages.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 // In the bundled output (dist/index.js), __dirname is dist/.
 // agentic/ is copied to dist/agentic/ by build.mjs.
 const AGENTIC_DIR = join(__dirname, 'agentic', 'shared')
 const GUIDES_DIR = join(__dirname, 'agentic', 'guides')
+const SKILLS_REL = 'ai/skills'
 
 function resolvePlaceholders(content: string, config: AgenticConfig): string {
   return content.replace(/\{\{PROJECT_NAME\}\}/g, config.projectName)
@@ -33,6 +35,50 @@ function copyFile(srcRelative: string, destPath: string): void {
   copyFileSync(srcPath, destPath)
 }
 
+/** Read and minimally validate the standalone skill-package manifest (packages.json). */
+export function loadSkillManifest(): SkillPackageManifest {
+  const manifestPath = join(AGENTIC_DIR, SKILLS_REL, 'packages.json')
+  const parsed = JSON.parse(readFileSync(manifestPath, 'utf-8')) as SkillPackageManifest
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    !Array.isArray(parsed.default) ||
+    typeof parsed.packages !== 'object' ||
+    parsed.packages === null
+  ) {
+    throw new Error(`Invalid skill package manifest at ${manifestPath}`)
+  }
+  return parsed
+}
+
+/**
+ * Recursively copy a skill folder into the target app, applying {{PROJECT_NAME}}
+ * substitution to every file. Files whose `<skill>/<relative>` path is gated
+ * (owned by an unselected package) are skipped.
+ */
+function copySkillTree(skillName: string, config: AgenticConfig, gatedFiles: Set<string>): void {
+  const srcRoot = join(AGENTIC_DIR, SKILLS_REL, skillName)
+  if (!existsSync(srcRoot)) return
+
+  const walk = (relDir: string): void => {
+    const absDir = relDir ? join(srcRoot, relDir) : srcRoot
+    for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+      const relPath = relDir ? `${relDir}/${entry.name}` : entry.name
+      if (entry.isDirectory()) {
+        walk(relPath)
+        continue
+      }
+      if (gatedFiles.has(`${skillName}/${relPath}`)) continue
+      const destPath = join(config.targetDir, '.ai', 'skills', skillName, ...relPath.split('/'))
+      const content = readFileSync(join(absDir, entry.name), 'utf-8')
+      ensureDir(destPath)
+      writeFileSync(destPath, resolvePlaceholders(content, config))
+    }
+  }
+
+  walk('')
+}
+
 export function generateShared(config: AgenticConfig): void {
   const { targetDir } = config
 
@@ -44,188 +90,21 @@ export function generateShared(config: AgenticConfig): void {
   copyFile('ai/specs/SPEC-000-template.md', join(targetDir, '.ai', 'specs', 'SPEC-000-template.md'))
   copyFile('ai/lessons.md', join(targetDir, '.ai', 'lessons.md'))
 
-  // .ai/skills/
-  writeTemplate(
-    'ai/skills/om-spec-writing/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-spec-writing', 'SKILL.md'),
-    config,
-  )
-  copyFile(
-    'ai/skills/om-spec-writing/references/spec-template.md',
-    join(targetDir, '.ai', 'skills', 'om-spec-writing', 'references', 'spec-template.md'),
-  )
-  copyFile(
-    'ai/skills/om-spec-writing/references/spec-checklist.md',
-    join(targetDir, '.ai', 'skills', 'om-spec-writing', 'references', 'spec-checklist.md'),
-  )
-  // Optional proposal intake — present so om-spec-writing can consume a `.ai/proposals/` brief.
-  // The guarded SKILL.md step is a no-op when this file is absent.
-  copyFile(
-    'ai/skills/om-spec-writing/references/proposal-intake.md',
-    join(targetDir, '.ai', 'skills', 'om-spec-writing', 'references', 'proposal-intake.md'),
-  )
-
-  // Collaborative pre-spec ideation skills (proposal -> spec -> implement).
-  copyFile(
-    'ai/skills/om-proposal/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-proposal', 'SKILL.md'),
-  )
-  copyFile(
-    'ai/skills/om-proposal/references/proposal-template.md',
-    join(targetDir, '.ai', 'skills', 'om-proposal', 'references', 'proposal-template.md'),
-  )
-  copyFile(
-    'ai/skills/om-brainstorm/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-brainstorm', 'SKILL.md'),
-  )
-  copyFile(
-    'ai/skills/om-brainstorm/references/methods.md',
-    join(targetDir, '.ai', 'skills', 'om-brainstorm', 'references', 'methods.md'),
-  )
-
-  copyFile(
-    'ai/skills/om-backend-ui-design/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-backend-ui-design', 'SKILL.md'),
-  )
-  copyFile(
-    'ai/skills/om-backend-ui-design/references/ui-components.md',
-    join(targetDir, '.ai', 'skills', 'om-backend-ui-design', 'references', 'ui-components.md'),
-  )
-
-  copyFile(
-    'ai/skills/om-code-review/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-code-review', 'SKILL.md'),
-  )
-  copyFile(
-    'ai/skills/om-code-review/references/review-checklist.md',
-    join(targetDir, '.ai', 'skills', 'om-code-review', 'references', 'review-checklist.md'),
-  )
-
-  copyFile(
-    'ai/skills/om-integration-builder/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-integration-builder', 'SKILL.md'),
-  )
-  copyFile(
-    'ai/skills/om-integration-builder/references/adapter-contracts.md',
-    join(targetDir, '.ai', 'skills', 'om-integration-builder', 'references', 'adapter-contracts.md'),
-  )
-
-  // system-extension skill
-  copyFile(
-    'ai/skills/om-system-extension/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-system-extension', 'SKILL.md'),
-  )
-  copyFile(
-    'ai/skills/om-system-extension/references/extension-contracts.md',
-    join(targetDir, '.ai', 'skills', 'om-system-extension', 'references', 'extension-contracts.md'),
-  )
-
-  // module-scaffold skill
-  copyFile(
-    'ai/skills/om-module-scaffold/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-module-scaffold', 'SKILL.md'),
-  )
-  copyFile(
-    'ai/skills/om-module-scaffold/references/naming-conventions.md',
-    join(targetDir, '.ai', 'skills', 'om-module-scaffold', 'references', 'naming-conventions.md'),
-  )
-  copyFile(
-    'ai/skills/om-module-scaffold/references/navigation-patterns.md',
-    join(targetDir, '.ai', 'skills', 'om-module-scaffold', 'references', 'navigation-patterns.md'),
-  )
-
-  // troubleshooter skill
-  copyFile(
-    'ai/skills/om-troubleshooter/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-troubleshooter', 'SKILL.md'),
-  )
-  copyFile(
-    'ai/skills/om-troubleshooter/references/diagnostic-commands.md',
-    join(targetDir, '.ai', 'skills', 'om-troubleshooter', 'references', 'diagnostic-commands.md'),
-  )
-
-  // eject-and-customize skill
-  copyFile(
-    'ai/skills/om-eject-and-customize/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-eject-and-customize', 'SKILL.md'),
-  )
-
-  // data-model-design skill
-  copyFile(
-    'ai/skills/om-data-model-design/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-data-model-design', 'SKILL.md'),
-  )
-  copyFile(
-    'ai/skills/om-data-model-design/references/mikro-orm-cheatsheet.md',
-    join(targetDir, '.ai', 'skills', 'om-data-model-design', 'references', 'mikro-orm-cheatsheet.md'),
-  )
-
-  // implement-spec skill
-  copyFile(
-    'ai/skills/om-implement-spec/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-implement-spec', 'SKILL.md'),
-  )
-
-  // integration-tests skill
-  copyFile(
-    'ai/skills/om-integration-tests/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-integration-tests', 'SKILL.md'),
-  )
-
-  // help / workflow navigator skill
-  copyFile(
-    'ai/skills/om-help/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-help', 'SKILL.md'),
-  )
-  copyFile(
-    'ai/skills/om-help/references/skills-catalog.md',
-    join(targetDir, '.ai', 'skills', 'om-help', 'references', 'skills-catalog.md'),
-  )
-  copyFile(
-    'ai/skills/om-help/references/workflow-sequences.md',
-    join(targetDir, '.ai', 'skills', 'om-help', 'references', 'workflow-sequences.md'),
-  )
-
-  // 0.4.10 -> 0.5.0 upgrade companion skill
-  copyFile(
-    'ai/skills/om-auto-upgrade-0.4.10-to-0.5.0/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-auto-upgrade-0.4.10-to-0.5.0', 'SKILL.md'),
-  )
-
-  // Agent automation / auto-* skills. Some skills also ship with a
-  // STANDALONE.md portability override that adjusts the workflow for use in
-  // standalone apps (default-branch discovery, opt-in pipeline labels,
-  // probe-before-run validation gate, src/modules/... file layout).
-  for (const autoSkill of [
-    'om-auto-create-pr',
-    'om-auto-continue-pr',
-    'om-auto-create-pr-loop',
-    'om-auto-continue-pr-loop',
-    'om-auto-review-pr',
-    'om-auto-fix-github',
-    'om-prepare-issue',
-  ]) {
-    if (!existsSync(join(AGENTIC_DIR, 'ai', 'skills', autoSkill, 'SKILL.md'))) {
-      continue
-    }
-    copyFile(
-      `ai/skills/${autoSkill}/SKILL.md`,
-      join(targetDir, '.ai', 'skills', autoSkill, 'SKILL.md'),
-    )
-    if (existsSync(join(AGENTIC_DIR, 'ai', 'skills', autoSkill, 'STANDALONE.md'))) {
-      copyFile(
-        `ai/skills/${autoSkill}/STANDALONE.md`,
-        join(targetDir, '.ai', 'skills', autoSkill, 'STANDALONE.md'),
-      )
-    }
+  // .ai/skills/ — manifest-driven (packages.json). `core` is always installed;
+  // other packages ship only when selected. Package-owned `extraFiles` (e.g. the
+  // om-spec-writing proposal-intake fragment owned by `creative`) are gated: skipped
+  // during folder copy, then re-added only for the selected packages.
+  const manifest = loadSkillManifest()
+  const requested =
+    config.skillPackages && config.skillPackages.length > 0 ? config.skillPackages : manifest.default
+  const selection = resolveSkillSelection(requested, manifest)
+  const gatedFiles = new Set(selection.gatedFiles)
+  for (const skill of selection.skills) {
+    copySkillTree(skill, config, gatedFiles)
   }
-
-  // Classic-mode slimdown skill — offered after the user adds a new module
-  // so unused built-in modules can be disabled from src/modules.ts.
-  copyFile(
-    'ai/skills/om-trim-unused-modules/SKILL.md',
-    join(targetDir, '.ai', 'skills', 'om-trim-unused-modules', 'SKILL.md'),
-  )
+  for (const extra of selection.includeExtraFiles) {
+    writeTemplate(`${SKILLS_REL}/${extra}`, join(targetDir, '.ai', 'skills', ...extra.split('/')), config)
+  }
 
   // .ai/qa/tests/ — Playwright config for integration tests
   copyFile('ai/qa/tests/playwright.config.ts', join(targetDir, '.ai', 'qa', 'tests', 'playwright.config.ts'))

--- a/packages/create-app/src/setup/tools/skill-packages.test.ts
+++ b/packages/create-app/src/setup/tools/skill-packages.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  CORE_PACKAGE,
+  findUnknownPackages,
+  parseSkillPackagesInput,
+  resolveSkillSelection,
+  type SkillPackageManifest,
+} from './skill-packages.js'
+
+const MANIFEST: SkillPackageManifest = {
+  default: ['core', 'automation'],
+  packages: {
+    core: { description: 'core', skills: ['om-spec-writing', 'om-help'] },
+    automation: { description: 'automation', skills: ['om-auto-create-pr'] },
+    creative: {
+      description: 'creative',
+      skills: ['om-proposal', 'om-brainstorm'],
+      extraFiles: ['om-spec-writing/references/proposal-intake.md'],
+    },
+  },
+}
+
+test('resolveSkillSelection always includes core, even when not requested', () => {
+  const result = resolveSkillSelection(['automation'], MANIFEST)
+  assert.deepEqual(result.packages, ['core', 'automation'])
+  assert.ok(result.skills.includes('om-spec-writing'))
+  assert.ok(result.skills.includes('om-auto-create-pr'))
+})
+
+test('creative selected ships its skills and includes the gated extra file', () => {
+  const result = resolveSkillSelection(['creative'], MANIFEST)
+  assert.ok(result.skills.includes('om-proposal'))
+  assert.ok(result.skills.includes('om-brainstorm'))
+  assert.deepEqual(result.includeExtraFiles, ['om-spec-writing/references/proposal-intake.md'])
+})
+
+test('creative NOT selected: proposal-intake stays gated and is not included', () => {
+  const result = resolveSkillSelection(['automation'], MANIFEST)
+  assert.ok(!result.skills.includes('om-proposal'))
+  assert.deepEqual(result.includeExtraFiles, [])
+  // gatedFiles always lists every package's extraFiles so folder copy skips them.
+  assert.ok(result.gatedFiles.includes('om-spec-writing/references/proposal-intake.md'))
+})
+
+test('unknown package names are ignored by the resolver', () => {
+  const result = resolveSkillSelection(['does-not-exist'], MANIFEST)
+  assert.deepEqual(result.packages, ['core'])
+})
+
+test('parseSkillPackagesInput trims, lowercases, dedupes, drops empties', () => {
+  assert.deepEqual(parseSkillPackagesInput(' Core, creative ,,CREATIVE'), ['core', 'creative'])
+  assert.deepEqual(parseSkillPackagesInput(''), [])
+})
+
+test('findUnknownPackages reports only undefined names', () => {
+  assert.deepEqual(findUnknownPackages(['core', 'nope'], MANIFEST), ['nope'])
+  assert.deepEqual(findUnknownPackages(['core', 'creative'], MANIFEST), [])
+})
+
+test('CORE_PACKAGE constant matches manifest core key', () => {
+  assert.equal(CORE_PACKAGE, 'core')
+})

--- a/packages/create-app/src/setup/tools/skill-packages.ts
+++ b/packages/create-app/src/setup/tools/skill-packages.ts
@@ -1,0 +1,79 @@
+// Pure helpers for the standalone skill-package manifest (packages.json).
+// No filesystem access here — the loader lives in shared.ts. Keeping selection
+// logic pure makes it unit-testable without scaffolding a temp app.
+
+export const CORE_PACKAGE = 'core'
+
+export interface SkillPackage {
+  description: string
+  skills: string[]
+  extraFiles?: string[]
+}
+
+export interface SkillPackageManifest {
+  default: string[]
+  packages: Record<string, SkillPackage>
+}
+
+export interface ResolvedSkillSelection {
+  /** Effective package names: core forced first, then the valid requested ones, deduped. */
+  packages: string[]
+  /** Skill folder names to copy (under .ai/skills/). */
+  skills: string[]
+  /** Package-owned extra files to ship for the selected packages (relative to .ai/skills/). */
+  includeExtraFiles: string[]
+  /** Every package's extra files — skipped during folder copy unless explicitly included. */
+  gatedFiles: string[]
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)]
+}
+
+/** Normalize raw CSV / user input into clean, deduped, lower-cased package names. */
+export function parseSkillPackagesInput(raw: string): string[] {
+  return unique(
+    raw
+      .split(',')
+      .map((token) => token.trim().toLowerCase())
+      .filter((token) => token.length > 0),
+  )
+}
+
+/** Return the requested names that are not defined in the manifest (for friendly CLI errors). */
+export function findUnknownPackages(requested: string[], manifest: SkillPackageManifest): string[] {
+  const known = new Set(Object.keys(manifest.packages))
+  return requested.filter((name) => !known.has(name))
+}
+
+/**
+ * Resolve which skill folders and extra files to ship.
+ * `core` is always included. Unknown names are ignored (validate upstream for errors).
+ */
+export function resolveSkillSelection(
+  requested: string[],
+  manifest: SkillPackageManifest,
+): ResolvedSkillSelection {
+  const known = manifest.packages
+  const effective = unique([CORE_PACKAGE, ...requested]).filter((name) => name in known)
+
+  const skills: string[] = []
+  const includeExtraFiles: string[] = []
+  for (const name of effective) {
+    const pkg = known[name]
+    skills.push(...pkg.skills)
+    if (pkg.extraFiles) includeExtraFiles.push(...pkg.extraFiles)
+  }
+
+  const gatedFiles: string[] = []
+  for (const pkg of Object.values(known)) {
+    if (pkg.extraFiles) gatedFiles.push(...pkg.extraFiles)
+  }
+
+  return {
+    packages: effective,
+    skills: unique(skills),
+    includeExtraFiles: unique(includeExtraFiles),
+    gatedFiles: unique(gatedFiles),
+  }
+}

--- a/packages/create-app/src/setup/wizard.ts
+++ b/packages/create-app/src/setup/wizard.ts
@@ -1,19 +1,24 @@
 import { basename } from 'node:path'
-import { generateShared } from './tools/shared.js'
+import { generateShared, loadSkillManifest } from './tools/shared.js'
 import { generateClaudeCode } from './tools/claude-code.js'
 import { generateCodex } from './tools/codex.js'
 import { generateCursor } from './tools/cursor.js'
+import { CORE_PACKAGE } from './tools/skill-packages.js'
 
 export type AskFn = (question: string) => Promise<string>
 
 export interface AgenticSetupOptions {
   tool?: string
   force?: boolean
+  /** Pre-resolved skill packages (from --skill-packages); skips the package prompt. */
+  skillPackages?: string[]
 }
 
 export interface AgenticConfig {
   projectName: string
   targetDir: string
+  /** Selected skill packages. When empty/undefined, generateShared falls back to the manifest default. */
+  skillPackages?: string[]
 }
 
 const TOOLS = [
@@ -67,6 +72,34 @@ async function promptSelection(ask: AskFn): Promise<string[]> {
   return ids.length > 0 ? ids : ['skip']
 }
 
+// Ask which skill packages to install. Shown for every tool (skills live under
+// .ai/skills/ regardless of tool). `core` is always installed and not offered.
+// Empty input selects the manifest's recommended default set.
+async function promptSkillPackages(ask: AskFn): Promise<string[]> {
+  const manifest = loadSkillManifest()
+  const selectable = Object.keys(manifest.packages).filter((name) => name !== CORE_PACKAGE)
+
+  console.log('')
+  console.log('   Which skill packages do you want to install?')
+  console.log('')
+  const coreDescription = manifest.packages[CORE_PACKAGE]?.description ?? 'always installed'
+  console.log(`   • core — ${coreDescription} (always on)`)
+  selectable.forEach((name, index) => {
+    const suffix = manifest.default.includes(name) ? ' [recommended]' : ''
+    console.log(`   ${index + 1}. ${name} — ${manifest.packages[name].description}${suffix}`)
+  })
+  console.log('')
+
+  const answer = (await ask('   Enter number(s) separated by comma, or Enter for the recommended set: ')).trim()
+  if (!answer) return manifest.default
+
+  const chosen = answer
+    .split(',')
+    .map((token) => selectable[Number(token.trim()) - 1])
+    .filter((name): name is string => Boolean(name))
+  return chosen.length > 0 ? chosen : manifest.default
+}
+
 export async function runAgenticSetup(
   targetDir: string,
   ask: AskFn,
@@ -87,9 +120,15 @@ export async function runAgenticSetup(
     return
   }
 
+  const skillPackages =
+    options?.skillPackages && options.skillPackages.length > 0
+      ? options.skillPackages
+      : await promptSkillPackages(ask)
+
   const config: AgenticConfig = {
     projectName: basename(targetDir),
     targetDir,
+    skillPackages,
   }
 
   // Order matters — codex patches AGENTS.md created by shared
@@ -98,10 +137,10 @@ export async function runAgenticSetup(
   if (selectedIds.includes('codex')) generateCodex(config)
   if (selectedIds.includes('cursor')) generateCursor(config)
 
-  printSummary(selectedIds)
+  printSummary(selectedIds, skillPackages)
 }
 
-function printSummary(selectedIds: string[]): void {
+function printSummary(selectedIds: string[], skillPackages: string[]): void {
   console.log('')
   console.log('   Agentic setup complete:')
 
@@ -115,7 +154,9 @@ function printSummary(selectedIds: string[]): void {
     console.log('   ✓ Cursor — .cursor/rules/, .cursor/hooks/, .cursor/mcp.json.example')
   }
 
-  if (selectedIds.includes('claude-code')) {
+  console.log(`   ✓ Skill packages — core, ${skillPackages.filter((name) => name !== CORE_PACKAGE).join(', ') || '(core only)'}`)
+
+  if (selectedIds.includes('claude-code') && skillPackages.includes('automation')) {
     console.log('')
     console.log('   ⚡ Autonomous skills shipped under .ai/skills/:')
     console.log('      /om-auto-create-pr  <task>    — delegate a whole task end-to-end as a PR')
@@ -126,6 +167,13 @@ function printSummary(selectedIds: string[]): void {
     console.log('      /om-trim-unused-modules       — slim classic-mode defaults after adding your own module')
     console.log('      See .ai/skills/om-auto-create-pr/STANDALONE.md for portability notes')
     console.log('      (base-branch discovery, opt-in pipeline labels, script probing).')
+  }
+
+  if (selectedIds.includes('claude-code') && skillPackages.includes('creative')) {
+    console.log('')
+    console.log('   🎨 Creative collaboration skills shipped under .ai/skills/:')
+    console.log('      /om-proposal   — capture/refine a pre-spec idea collaboratively in .ai/proposals/')
+    console.log('      /om-brainstorm — facilitate ideation (party mode, Socratic, 5-whys, yes-and)')
   }
 
   console.log('')


### PR DESCRIPTION
## Goal
Add a collaborative pre-spec ideation skill group for standalone (`create-mercato-app`) projects, and let the installer choose which **skill packages** to install.

## What changed

**Phase 1 — collaborative proposal skills** (`.ai/specs/2026-06-15-collaborative-proposal-skills.md`)
- `om-proposal` — async, file-based pre-spec proposals in `.ai/proposals/` with a defer-aware open-questions gate and a `ready/` handoff.
- `om-brainstorm` — facilitation methods (party mode, Socratic, 5-whys, yes-and), adapted from BMAD-METHOD with attribution.
- `om-spec-writing` optional `proposal-intake.md` hook + guarded SKILL.md step (no-op when the fragment is absent).
- Mirrored into both the monorepo `.ai/skills/` and the standalone `create-app` agentic set; `om-help` catalog/sequences + root `AGENTS.md` Task Router updated; registered in `.ai/skills/tiers.json` (core).

**Phase 2 — installer skill packages** (`.ai/specs/2026-06-15-installer-skill-packages.md`)
- `agentic/shared/ai/skills/packages.json` manifest groups skills into core (forced) / automation / integrations / migration / **creative** (opt-in).
- `generateShared()` is now manifest-driven (pure `resolveSkillSelection` + recursive placeholder-safe `copySkillTree`); the flat copy list is removed; package-owned `extraFiles` are gated.
- Wizard package prompt (shown for every tool; `core` forced; empty → recommended default) + `--skill-packages <csv>` CLI flag (validated); non-TTY/CI runs degrade to the default set.

## Tests
- `packages/create-app`: 53/53 unit tests (manifest coverage guard + resolver/parsing + ESM-safety), typecheck clean, `node build.mjs` ok.
- End-to-end scaffolds: defaults → 21 skills, no `creative`; `--skill-packages core,creative` → 13 skills + `proposal-intake.md`, no automation; invalid package → exit 1; non-TTY without flag → default set.

## Backward compatibility
- Additive: no skill removed/renamed; `generateShared()` signature unchanged (`AgenticConfig.skillPackages` optional); CLI flag and wizard step additive.
- Intentional default change: the ideation skills are the opt-in `creative` package, so the default scaffold no longer ships `om-proposal`/`om-brainstorm` unless selected. Phase 1 was unreleased, so this is safe.

## How to verify
- `cd packages/create-app && node --test --import tsx 'src/**/*.test.ts'`
- `node packages/create-app/dist/index.js /tmp/demo --skill-packages core,creative` then inspect `/tmp/demo/.ai/skills/`.

