### PR TITLE
fix(create-app): preserve module data in Railway uploads

### DIFF
--- a/.ai/runs/2026-06-15-railway-local-upload-data-ignore.md
+++ b/.ai/runs/2026-06-15-railway-local-upload-data-ignore.md
@@ -1,0 +1,64 @@
+# Fix Railway Local Upload Data Ignore
+
+## Goal
+
+Fix fresh `create-mercato-app` Railway local-source deployments so required app module `data/` source folders are uploaded and the remote build can resolve their imports.
+
+## Scope
+
+- Update the standalone template `.railwayignore` rule that currently excludes every directory named `data`.
+- Add a create-app regression test proving module `src/modules/*/data` files are not matched by the upload ignore contract.
+- Validate the focused create-app tests.
+
+## Non-goals
+
+- Do not change Railway authentication, token handling, resource provisioning, or deploy mode selection.
+- Do not change package dependencies or generated files.
+- Do not run a live Railway deployment.
+
+## Source Context
+
+- Source spec: `.ai/specs/2026-05-12-railway-one-command-deploy.md`
+- Deployment docs: `apps/docs/docs/deployment/railway.mdx`
+- Package guide: `packages/create-app/AGENTS.md`
+- CLI guide: `packages/cli/AGENTS.md`
+
+## Risks
+
+- The root runtime data directory must remain excluded from local uploads. Anchor only the runtime-state rule, and keep the existing safety preflight entries passing.
+
+## Implementation Plan
+
+### Phase 1: Reproduce and narrow root cause
+
+- Confirm the `@develop` scaffold ships `.railwayignore` with an unanchored `data/` rule.
+- Confirm required module source files under `src/modules/*/data` are present locally but matched by that rule.
+
+### Phase 2: Fix template and regression coverage
+
+- Anchor the Railway ignore runtime-state rule to `/data/`.
+- Add focused test coverage that fails if app module data source files would be excluded by the template Railway ignore file.
+
+### Phase 3: Validation and PR
+
+- Run focused create-app Railway template tests.
+- Run diff hygiene checks and open a PR against `develop`.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Reproduce and narrow root cause
+
+- [x] 1.1 Reproduce scaffold ignore mismatch locally
+- [ ] 1.2 Record root-cause evidence in PR summary
+
+### Phase 2: Fix template and regression coverage
+
+- [ ] 2.1 Anchor Railway runtime data ignore rule
+- [ ] 2.2 Add regression coverage for module data source files
+
+### Phase 3: Validation and PR
+
+- [ ] 3.1 Run focused create-app Railway template tests
+- [ ] 3.2 Open PR and summarize cause, fix, and workaround

--- a/.ai/runs/2026-06-15-railway-local-upload-data-ignore.md
+++ b/.ai/runs/2026-06-15-railway-local-upload-data-ignore.md
@@ -51,7 +51,7 @@ Fix fresh `create-mercato-app` Railway local-source deployments so required app 
 ### Phase 1: Reproduce and narrow root cause
 
 - [x] 1.1 Reproduce scaffold ignore mismatch locally
-- [ ] 1.2 Record root-cause evidence in PR summary
+- [x] 1.2 Record root-cause evidence in PR summary
 
 ### Phase 2: Fix template and regression coverage
 
@@ -61,4 +61,4 @@ Fix fresh `create-mercato-app` Railway local-source deployments so required app 
 ### Phase 3: Validation and PR
 
 - [x] 3.1 Run focused create-app Railway template tests
-- [ ] 3.2 Open PR and summarize cause, fix, and workaround
+- [x] 3.2 Open PR and summarize cause, fix, and workaround — PR #3072

--- a/.ai/runs/2026-06-15-railway-local-upload-data-ignore.md
+++ b/.ai/runs/2026-06-15-railway-local-upload-data-ignore.md
@@ -55,8 +55,8 @@ Fix fresh `create-mercato-app` Railway local-source deployments so required app 
 
 ### Phase 2: Fix template and regression coverage
 
-- [x] 2.1 Anchor Railway runtime data ignore rule — d52442e0b
-- [x] 2.2 Add regression coverage for module data source files — d52442e0b
+- [x] 2.1 Anchor Railway runtime data ignore rule — 5cdd2f7a4
+- [x] 2.2 Add regression coverage for module data source files — 5cdd2f7a4
 
 ### Phase 3: Validation and PR
 

--- a/.ai/runs/2026-06-15-railway-local-upload-data-ignore.md
+++ b/.ai/runs/2026-06-15-railway-local-upload-data-ignore.md
@@ -55,10 +55,10 @@ Fix fresh `create-mercato-app` Railway local-source deployments so required app 
 
 ### Phase 2: Fix template and regression coverage
 
-- [ ] 2.1 Anchor Railway runtime data ignore rule
-- [ ] 2.2 Add regression coverage for module data source files
+- [x] 2.1 Anchor Railway runtime data ignore rule — d52442e0b
+- [x] 2.2 Add regression coverage for module data source files — d52442e0b
 
 ### Phase 3: Validation and PR
 
-- [ ] 3.1 Run focused create-app Railway template tests
+- [x] 3.1 Run focused create-app Railway template tests
 - [ ] 3.2 Open PR and summarize cause, fix, and workaround

--- a/packages/create-app/src/lib/template-railway.test.ts
+++ b/packages/create-app/src/lib/template-railway.test.ts
@@ -6,6 +6,20 @@ import test from 'node:test'
 const templateRoot = resolve(import.meta.dirname, '../../template')
 const templateSyncScript = resolve(import.meta.dirname, '../../../../scripts/template-sync.ts')
 
+function matchesDirectoryIgnoreRule(rule: string, sourcePath: string): boolean {
+  const directoryRule = rule.endsWith('/')
+  if (!directoryRule || rule.startsWith('!')) return false
+
+  const normalizedRule = rule.replace(/^\/+|\/+$/g, '')
+  if (!normalizedRule) return false
+
+  if (rule.startsWith('/')) {
+    return sourcePath === normalizedRule || sourcePath.startsWith(`${normalizedRule}/`)
+  }
+
+  return sourcePath.split('/').includes(normalizedRule)
+}
+
 test('standalone template keeps app and worker Railway deploy contracts separate', () => {
   const appConfig = readFileSync(resolve(templateRoot, 'railway.toml'), 'utf8')
   const workerConfig = readFileSync(resolve(templateRoot, 'railway.worker.toml'), 'utf8')
@@ -35,6 +49,31 @@ test('standalone template excludes deployment secrets from local Railway uploads
   ]) {
     assert.match(ignore, new RegExp(requiredEntry.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
   }
+})
+
+test('standalone template does not exclude app module data source files from local Railway uploads', () => {
+  const ignoreLines = readFileSync(resolve(templateRoot, '.railwayignore'), 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'))
+
+  assert.ok(ignoreLines.includes('/data/'))
+  assert.ok(ignoreLines.includes('/storage/'))
+  assert.equal(ignoreLines.includes('data/'), false)
+  assert.equal(ignoreLines.includes('storage/'), false)
+
+  for (const sourceFile of [
+    'src/modules/example/data/entities.ts',
+    'src/modules/example/data/validators.ts',
+    'src/modules/example_customers_sync/data/entities.ts',
+    'src/modules/example_customers_sync/data/validators.ts',
+  ]) {
+    assert.doesNotThrow(() => readFileSync(resolve(templateRoot, sourceFile), 'utf8'))
+    assert.equal(ignoreLines.some((line) => matchesDirectoryIgnoreRule(line, sourceFile)), false, sourceFile)
+  }
+
+  assert.equal(ignoreLines.some((line) => matchesDirectoryIgnoreRule(line, 'data/local.db')), true)
+  assert.equal(ignoreLines.some((line) => matchesDirectoryIgnoreRule(line, 'storage/uploads/file.bin')), true)
 })
 
 test('template sync preserves Railway-only healthcheck routes', () => {

--- a/packages/create-app/template/.railwayignore
+++ b/packages/create-app/template/.railwayignore
@@ -9,8 +9,8 @@ node_modules/
 coverage/
 test-results/
 playwright-report/
-storage/
-data/
+/storage/
+/data/
 *.db
 *.db-shm
 *.db-wal


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-15-railway-local-upload-data-ignore.md
Status: complete

## Goal
- Fix fresh `create-mercato-app` Railway local-source deployments so app module `data/` source folders are uploaded and remote builds can resolve their imports.

## What Changed
- Anchored the standalone template Railway upload ignore rules for root runtime directories from `storage/` and `data/` to `/storage/` and `/data/`.
- Added a `create-mercato-app` regression test that verifies app module files such as `src/modules/example/data/entities.ts` are not excluded while root runtime `data/` and `storage/` still are.

## Root Cause
- `create-mercato-app@develop` scaffolds `.railwayignore` with an unanchored `data/` entry.
- In gitignore-style matching, `data/` matches any directory named `data`, including `src/modules/example/data` and `src/modules/example_customers_sync/data`.
- Local builds pass because the files exist locally; Railway local-source upload omits those files, so the remote Docker build fails with unresolved imports such as `../data/entities` and `../data/validators`.

## Workaround Until This Ships
- In a generated app, change `.railwayignore` entries from `data/` and `storage/` to `/data/` and `/storage/`, then redeploy.

## Tests
- `node --import tsx --test --test-timeout=120000 packages/create-app/src/lib/template-railway.test.ts`
- `yarn workspace create-mercato-app typecheck`
- `yarn workspace create-mercato-app test`
- `yarn workspace create-mercato-app build`
- `git diff --check origin/develop...HEAD`

## Backward Compatibility
- No public API, module auto-discovery, database, event, ACL, DI, import path, or CLI command contract is removed or renamed.
- The existing root runtime data/storage exclusions are preserved with anchored patterns.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-15-railway-local-upload-data-ignore.md#progress).

