### PR TITLE
test(core): widen Alert duplicate-icon guard scan to all packages/*/src (#3027)

### DIFF
--- a/packages/core/src/__tests__/alert-duplicate-icon-coverage.test.ts
+++ b/packages/core/src/__tests__/alert-duplicate-icon-coverage.test.ts
@@ -2,7 +2,7 @@ import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, relative, sep } from 'node:path'
 
 /**
- * Alert duplicate-icon regression audit (#2759).
+ * Alert duplicate-icon regression audit (#2759, scope hardening #3027).
  *
  * The redesigned `Alert` primitive (`packages/ui/src/primitives/alert.tsx`)
  * renders its own leading status icon automatically (`showIcon` defaults to
@@ -14,22 +14,58 @@ import { join, relative, sep } from 'node:path'
  * This audit flags any `<Alert …>` whose first JSX child on the next line
  * is a self-closing, icon-shaped component (capitalized tag whose className
  * carries a bare sizing utility such as `size-4` or `h-4 w-4`).
+ *
+ * Scan scope is derived from a per-package `src` discovery walk so any
+ * package that renders `<Alert>` is covered automatically, including future
+ * ones. A few roots outside that walk (the app modules and the create-app
+ * template) are appended explicitly.
  */
 
-const SCAN_ROOTS = [
-  'packages/core/src/modules',
-  'packages/ui/src',
-  'packages/webhooks/src',
-  'packages/enterprise/src',
+const repoRoot = join(__dirname, '..', '..', '..', '..')
+
+const EXTRA_SCAN_ROOTS = [
   'apps/mercato/src/modules',
   'packages/create-app/template/src/modules',
 ]
+
+function discoverPackageSrcRoots(): string[] {
+  const roots: string[] = []
+  let packages: string[]
+  try {
+    packages = readdirSync(join(repoRoot, 'packages'))
+  } catch {
+    return roots
+  }
+  for (const name of packages.sort()) {
+    const srcDir = join(repoRoot, 'packages', name, 'src')
+    try {
+      if (statSync(srcDir).isDirectory()) {
+        roots.push(`packages/${name}/src`)
+      }
+    } catch {
+      // package without a src directory — skip
+    }
+  }
+  return roots
+}
+
+const SCAN_ROOTS = [...discoverPackageSrcRoots(), ...EXTRA_SCAN_ROOTS]
 
 const ALERT_OPEN = /<Alert\b[^>]*>$/
 const ICON_CHILD =
   /^<[A-Z][A-Za-z0-9]*\s[^>]*className="[^"]*(?:\bsize-\d|\bh-\d+(?:\.\d+)?\s+w-\d+(?:\.\d+)?|\bw-\d+(?:\.\d+)?\s+h-\d+(?:\.\d+)?)[^"]*"[^>]*\/>$/
 
-const repoRoot = join(__dirname, '..', '..', '..', '..')
+function findDuplicateIconLines(source: string): number[] {
+  if (!source.includes('<Alert')) return []
+  const hits: number[] = []
+  const lines = source.split('\n')
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    if (!ALERT_OPEN.test(lines[index].trimEnd())) continue
+    const child = lines[index + 1].trim()
+    if (ICON_CHILD.test(child)) hits.push(index + 2)
+  }
+  return hits
+}
 
 function collectTsx(dir: string, acc: string[]): void {
   let entries: string[]
@@ -50,7 +86,7 @@ function collectTsx(dir: string, acc: string[]): void {
   }
 }
 
-describe('Alert callouts do not double the leading icon (#2759)', () => {
+describe('Alert callouts do not double the leading icon (#2759, #3027)', () => {
   const files: string[] = []
   for (const root of SCAN_ROOTS) {
     collectTsx(join(repoRoot, root), files)
@@ -60,19 +96,34 @@ describe('Alert callouts do not double the leading icon (#2759)', () => {
     expect(files.length).toBeGreaterThan(100)
   })
 
+  it('covers the package src roots that render <Alert> (incl. #3027 follow-up packages)', () => {
+    for (const expected of [
+      'packages/core/src',
+      'packages/ui/src',
+      'packages/webhooks/src',
+      'packages/enterprise/src',
+      'packages/checkout/src',
+      'packages/scheduler/src',
+      'packages/sync-akeneo/src',
+      'packages/ai-assistant/src',
+    ]) {
+      expect(SCAN_ROOTS).toContain(expected)
+    }
+  })
+
+  it('detects an icon element passed as the Alert first child', () => {
+    const planted = ['<Alert variant="info">', '  <Info className="size-4" />', '</Alert>'].join('\n')
+    expect(findDuplicateIconLines(planted)).toEqual([2])
+    expect(findDuplicateIconLines('<Alert variant="info">\n  <p>Plain banner</p>\n</Alert>')).toEqual([])
+  })
+
   it('no <Alert> passes an icon element as its first child — use the icon prop instead', () => {
     const violations: string[] = []
     for (const full of files) {
       const source = readFileSync(full, 'utf8')
-      if (!source.includes('<Alert')) continue
-      const lines = source.split('\n')
-      for (let index = 0; index < lines.length - 1; index += 1) {
-        if (!ALERT_OPEN.test(lines[index].trimEnd())) continue
-        const child = lines[index + 1].trim()
-        if (ICON_CHILD.test(child)) {
-          const rel = relative(repoRoot, full).split(sep).join('/')
-          violations.push(`${rel}:${index + 2} → ${child}`)
-        }
+      for (const line of findDuplicateIconLines(source)) {
+        const rel = relative(repoRoot, full).split(sep).join('/')
+        violations.push(`${rel}:${line}`)
       }
     }
     expect(violations).toEqual([])


### PR DESCRIPTION
Fixes #3027

## Problem
The `#2759` Alert duplicate-icon regression guard (`packages/core/src/__tests__/alert-duplicate-icon-coverage.test.ts`) hardcoded six `SCAN_ROOTS`. Several packages that also render `<Alert>` were never scanned, so a future icon-as-first-child regression introduced there would go uncaught:
- `packages/checkout`
- `packages/scheduler`
- `packages/sync-akeneo`
- `packages/ai-assistant`

(All confirmed clean today — this is preventive coverage, not a live bug.)

## Root Cause
`SCAN_ROOTS` was a fixed list. Any package added after the guard was written — or simply omitted from the list — escapes the scan.

## What Changed
- Derive the package scan roots from a `packages/*/src` discovery walk, so every current **and future** package that ships a `src` tree is covered automatically.
- Keep the two roots outside that walk explicit: `apps/mercato/src/modules` and `packages/create-app/template/src/modules`.
- Extract the detection logic into a pure `findDuplicateIconLines(source)` helper so it is directly testable.
- The detector regex and recursion behavior are unchanged — only the scope widened.

## Tests
All in `alert-duplicate-icon-coverage.test.ts` (`yarn workspace @open-mercato/core test --testPathPatterns alert-duplicate-icon-coverage` → 4 passed):
- existing "discovered tsx files to scan" guard retained;
- new assertion that the discovered roots include `checkout`, `scheduler`, `sync-akeneo`, and `ai-assistant` `src` (plus the original four);
- new detector sanity test proving `findDuplicateIconLines` flags an icon-as-first-child and ignores a plain banner;
- the full-scan guard still passes clean on `develop` (no new violations).

Acceptance-criteria sanity check (item 3): a deliberately planted `<Alert><Info className="size-4" /></Alert>` in `packages/checkout/src` made the full scan fail, then was reverted.

## Backward Compatibility
- No contract surface changes — test-only. No production code, types, events, DI, ACL, or API routes touched.

Related: #2759, #2763