### PR TITLE
fix(shared): sync CustomFieldKind with runtime kinds + add cf.date/cf.datetime (#3042)

### DIFF
--- a/packages/shared/src/modules/__tests__/dsl.test.ts
+++ b/packages/shared/src/modules/__tests__/dsl.test.ts
@@ -1,4 +1,6 @@
 import { defineLink, entityId, linkable, defineFields, cf } from '../../modules/dsl'
+import { CUSTOM_FIELD_KINDS } from '../../modules/entities/kinds'
+import type { CustomFieldDefinition, CustomFieldKind } from '../../modules/entities'
 
 describe('DSL helpers', () => {
   test('defineLink + entityId', () => {
@@ -30,6 +32,23 @@ describe('DSL helpers', () => {
     expect(set.fields[1]).toMatchObject({ key: 'vip', kind: 'boolean' })
     expect(set.fields[2]).toMatchObject({ key: 'priority', kind: 'integer' })
     expect(set.source).toBe('my_module')
+  })
+
+  test('cf.date / cf.datetime helpers produce date kinds (#3042)', () => {
+    expect(cf.date('birth_date', { label: 'Birth date' })).toMatchObject({ key: 'birth_date', kind: 'date', label: 'Birth date' })
+    expect(cf.datetime('seen_at')).toMatchObject({ key: 'seen_at', kind: 'datetime' })
+  })
+
+  test('CustomFieldKind type stays in sync with the runtime kinds list (#3042)', () => {
+    // The CustomFieldKind type is derived from CUSTOM_FIELD_KINDS, so declaring a
+    // field with any runtime kind — including date/datetime — must type-check.
+    const dateField: CustomFieldDefinition = { key: 'birth_date', kind: 'date' }
+    const dateTimeField: CustomFieldDefinition = { key: 'seen_at', kind: 'datetime' }
+    expect(dateField.kind).toBe('date')
+    expect(dateTimeField.kind).toBe('datetime')
+    const everyRuntimeKind: CustomFieldKind[] = [...CUSTOM_FIELD_KINDS]
+    expect(everyRuntimeKind).toContain('date')
+    expect(everyRuntimeKind).toContain('datetime')
   })
 })
 

--- a/packages/shared/src/modules/dsl.ts
+++ b/packages/shared/src/modules/dsl.ts
@@ -24,6 +24,8 @@ export const cf = {
   boolean: (key: string, opts: Omit<CustomFieldDefinition, 'key' | 'kind'> = {}): CustomFieldDefinition => ({ key, kind: 'boolean', ...opts }),
   select: (key: string, options: string[], opts: Omit<CustomFieldDefinition, 'key' | 'kind' | 'options'> = {}): CustomFieldDefinition => ({ key, kind: 'select', options, ...opts }),
   currency: (key: string, opts: Omit<CustomFieldDefinition, 'key' | 'kind'> = {}): CustomFieldDefinition => ({ key, kind: 'currency', ...opts }),
+  date: (key: string, opts: Omit<CustomFieldDefinition, 'key' | 'kind'> = {}): CustomFieldDefinition => ({ key, kind: 'date', ...opts }),
+  datetime: (key: string, opts: Omit<CustomFieldDefinition, 'key' | 'kind'> = {}): CustomFieldDefinition => ({ key, kind: 'datetime', ...opts }),
   dictionary: (key: string, dictionaryId: string, opts: Omit<CustomFieldDefinition, 'key' | 'kind' | 'dictionaryId'> = {}): CustomFieldDefinition => ({ key, kind: 'dictionary', dictionaryId, ...opts }),
 }
 

--- a/packages/shared/src/modules/entities.ts
+++ b/packages/shared/src/modules/entities.ts
@@ -1,5 +1,12 @@
 // Shared entity/extension/custom-field types used by generators and DI
 
+// Single source of truth: CustomFieldKind is derived from the runtime
+// CUSTOM_FIELD_KINDS list so the type can never drift behind the kinds the admin
+// UI and runtime already accept (e.g. 'date', 'datetime'). Add new kinds in
+// ./entities/kinds.ts only.
+import type { CustomFieldKind } from './entities/kinds'
+export type { CustomFieldKind }
+
 export type EntityId = string // format: '<module>:<entity>' e.g., 'auth:user'
 
 export type EntityExtension = {
@@ -17,18 +24,6 @@ export type EntityExtension = {
   required?: boolean
   description?: string
 }
-
-export type CustomFieldKind =
-  | 'text'
-  | 'multiline'
-  | 'integer'
-  | 'float'
-  | 'boolean'
-  | 'select'
-  | 'currency'
-  | 'relation'
-  | 'attachment'
-  | 'dictionary'
 
 export type CustomFieldDefinition = {
   id?: string // stable id; generated if omitted


### PR DESCRIPTION
Fixes #3042

## Problem
`CustomFieldKind` (the type used by `CustomFieldDefinition.kind`) was narrower than the runtime `CUSTOM_FIELD_KINDS` list. The admin UI and runtime both support `date` and `datetime` custom-field kinds, but declaring one in code raised `TS2322: Type '"date"' is not assignable to type 'CustomFieldKind'`. The `cf` DSL also lacked `cf.date` / `cf.datetime` helpers.

## Root Cause
Two diverging definitions:
- `CustomFieldKind` in `packages/shared/src/modules/entities.ts` — hand-maintained 10-kind union (no `date`/`datetime`)
- `CUSTOM_FIELD_KINDS` in `packages/shared/src/modules/entities/kinds.ts` — 12-kind runtime list (includes `date`/`datetime`)

The hand-maintained union drifted behind the runtime list.

## What Changed
- `entities.ts`: removed the hand-maintained `CustomFieldKind` union and re-export the type from `entities/kinds.ts`, making the runtime `CUSTOM_FIELD_KINDS` the single source of truth (the type can no longer drift). The exported name and import path are unchanged.
- `dsl.ts`: added `cf.date` and `cf.datetime` helpers, mirroring the existing `cf.*` helpers.

## Tests
- Extended `packages/shared/src/modules/__tests__/dsl.test.ts`:
  - `cf.date` / `cf.datetime` produce the correct `date`/`datetime` kinds (runtime guard — fails before the fix because the helpers did not exist).
  - declaring `CustomFieldDefinition` with `kind: 'date' | 'datetime'` type-checks, and the runtime kinds list contains both (compile-time guard via typecheck).
- Full `@open-mercato/shared` suite green (1264 tests). `yarn typecheck` green across all 21 packages.

## Backward Compatibility
- No contract surface broken. `CustomFieldKind` is only **broadened** (adds `date`, `datetime`); the prior 10 members remain. Exported type name and import path are unchanged — additive, no deprecation needed.

## Notes
- Repo-wide `yarn lint` currently fails in `@open-mercato/app` with an environment-level ESLint/`eslint-plugin-react` version incompatibility (`contextOrFilename.getFilename is not a function` while linting `apps/mercato/next.config.ts`), unrelated to this change — this diff only touches `packages/shared`.