### PR TITLE
fix(ui): CrudForm group field-injection honors placement and renders label once (#3047)

### DIFF
--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -102,6 +102,7 @@ import { SortableGroupHandleProvider, type SortableGroupHandleProps } from './cr
 import { useGroupOrder } from './crud/useGroupOrder'
 import { InjectedField } from './injection/InjectedField'
 import type { InjectionFieldDefinition, FieldContext } from '@open-mercato/shared/modules/widgets/injection'
+import { insertByInjectionPlacement } from '@open-mercato/shared/modules/widgets/injection-position'
 import { evaluateInjectedVisibility } from './injection/visibility-utils'
 import { ComponentReplacementHandles } from '@open-mercato/shared/modules/widgets/component-registry'
 import { RichEditor, type RichEditorLabels } from '../primitives/rich-editor'
@@ -1740,21 +1741,27 @@ export function CrudForm<TValues extends Record<string, unknown>>({
   )
 
   const injectedCrudFields = React.useMemo<CrudField[]>(() => {
-    return injectedFieldDefinitions.map((definition) => ({
-      id: definition.id,
-      label: definition.label,
-      type: 'custom',
-      readOnly: definition.readOnly,
-      component: ({ value, setValue, values: formValues }) => (
-        <InjectedField
-          field={definition}
-          value={value}
-          onChange={(_, nextValue) => setValue(nextValue)}
-          context={injectedFieldContext}
-          formData={(formValues ?? values) as Record<string, unknown>}
-        />
-      ),
-    }))
+    return injectedFieldDefinitions.map((definition) => {
+      // InjectedField renders its own i18n-resolved <Label> for every field type
+      // except a custom component (type 'custom' + customComponent). Suppress the
+      // CrudForm row label in those cases so it is not rendered twice (#3047).
+      const injectedFieldRendersOwnLabel = !(definition.type === 'custom' && definition.customComponent)
+      return {
+        id: definition.id,
+        label: injectedFieldRendersOwnLabel ? '' : definition.label,
+        type: 'custom',
+        readOnly: definition.readOnly,
+        component: ({ value, setValue, values: formValues }) => (
+          <InjectedField
+            field={definition}
+            value={value}
+            onChange={(_, nextValue) => setValue(nextValue)}
+            context={injectedFieldContext}
+            formData={(formValues ?? values) as Record<string, unknown>}
+          />
+        ),
+      }
+    })
   }, [injectedFieldContext, injectedFieldDefinitions, values])
 
   const allFields = React.useMemo(() => {
@@ -1975,10 +1982,18 @@ export function CrudForm<TValues extends Record<string, unknown>>({
       }
       if (index < 0) continue
       const fieldEntries = cloned[index].fields ?? []
-      if (!fieldEntries.some((entry) => typeof entry === 'string' && entry === definition.id)) {
-        fieldEntries.push(definition.id)
-      }
-      cloned[index].fields = fieldEntries
+      const alreadyPresent = fieldEntries.some((entry) => {
+        const entryId = typeof entry === 'string' ? entry : entry.id
+        return entryId === definition.id
+      })
+      cloned[index].fields = alreadyPresent
+        ? fieldEntries
+        : insertByInjectionPlacement(
+            fieldEntries,
+            definition.id,
+            definition.placement,
+            (entry) => (typeof entry === 'string' ? entry : entry.id),
+          )
     }
     return cloned
   }, [groups, injectedFieldDefinitions])

--- a/packages/ui/src/backend/__tests__/CrudForm.fieldInjection.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.fieldInjection.test.tsx
@@ -1,0 +1,134 @@
+/** @jest-environment jsdom */
+jest.setTimeout(15000)
+
+// Injected field definitions for the CrudForm `:fields` injection spot. The
+// hook is mocked so the test drives `injectedFieldDefinitions` directly without
+// standing up the full injection registry/bootstrap. See issue #3047.
+let injectedFieldWidgets: Array<{ fields: unknown[] }> = []
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: () => {} }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}))
+jest.mock('remark-gfm', () => ({ __esModule: true, default: {} }))
+jest.mock('../injection/InjectionSpot', () => ({
+  __esModule: true,
+  InjectionSpot: () => null,
+  useInjectionWidgets: () => ({ widgets: [], loading: false, error: null }),
+  useInjectionSpotEvents: () => ({ triggerEvent: jest.fn(async () => ({ ok: true, data: {} })) }),
+}))
+jest.mock('../injection/useInjectionDataWidgets', () => ({
+  __esModule: true,
+  useInjectionDataWidgets: () => ({ widgets: injectedFieldWidgets, isLoading: false, error: null }),
+}))
+
+import * as React from 'react'
+import { waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { CrudForm, type CrudField, type CrudFormGroup } from '../CrudForm'
+import { InjectionPosition } from '@open-mercato/shared/modules/widgets/injection-position'
+
+const baseFields: CrudField[] = [
+  { id: 'firstName', label: 'First name', type: 'text' },
+  { id: 'lastName', label: 'Last name', type: 'text' },
+  // A trailing field so that "after lastName" is distinct from "end of group":
+  // the buggy unconditional push would land the injected field after `email`.
+  { id: 'email', label: 'Email', type: 'text' },
+]
+
+const groups: CrudFormGroup[] = [
+  { id: 'personalData', label: 'Personal data', fields: ['firstName', 'lastName', 'email'] },
+]
+
+function orderedFieldIds(container: HTMLElement): string[] {
+  const seen: string[] = []
+  container.querySelectorAll('[data-crud-field-id]').forEach((node) => {
+    const id = node.getAttribute('data-crud-field-id')
+    if (id && !seen.includes(id)) seen.push(id)
+  })
+  return seen
+}
+
+describe('CrudForm group field injection (#3047)', () => {
+  afterEach(() => {
+    injectedFieldWidgets = []
+  })
+
+  it('honors placement when injecting a field into an existing group', async () => {
+    injectedFieldWidgets = [
+      {
+        fields: [
+          {
+            id: 'cf:middle_name',
+            label: 'Middle name',
+            type: 'text',
+            group: 'personalData',
+            placement: { position: InjectionPosition.After, relativeTo: 'lastName' },
+          },
+        ],
+      },
+    ]
+
+    const { container } = renderWithProviders(
+      React.createElement(CrudForm as any, {
+        title: 'Form',
+        entityId: 'customers:person',
+        fields: baseFields,
+        groups,
+        onSubmit: () => {},
+      }),
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-crud-field-id="cf:middle_name"]')).toBeTruthy()
+    })
+
+    const ids = orderedFieldIds(container)
+    const lastNameIdx = ids.indexOf('lastName')
+    const middleIdx = ids.indexOf('cf:middle_name')
+    const firstNameIdx = ids.indexOf('firstName')
+    const emailIdx = ids.indexOf('email')
+    expect(firstNameIdx).toBeGreaterThanOrEqual(0)
+    expect(lastNameIdx).toBeGreaterThan(firstNameIdx)
+    // Injected field lands directly after `lastName` (placement honored), not at
+    // the end of the group after `email` (the pre-fix append behavior).
+    expect(middleIdx).toBe(lastNameIdx + 1)
+    expect(emailIdx).toBe(middleIdx + 1)
+  })
+
+  it('renders the injected field label exactly once', async () => {
+    injectedFieldWidgets = [
+      {
+        fields: [
+          {
+            id: 'cf:middle_name',
+            label: 'Middle name',
+            type: 'text',
+            group: 'personalData',
+            placement: { position: InjectionPosition.After, relativeTo: 'lastName' },
+          },
+        ],
+      },
+    ]
+
+    const { container } = renderWithProviders(
+      React.createElement(CrudForm as any, {
+        title: 'Form',
+        entityId: 'customers:person',
+        fields: baseFields,
+        groups,
+        onSubmit: () => {},
+      }),
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-crud-field-id="cf:middle_name"]')).toBeTruthy()
+    })
+
+    const labelMatches = Array.from(container.querySelectorAll('label')).filter(
+      (node) => node.textContent?.trim() === 'Middle name',
+    )
+    expect(labelMatches).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Fixes #3047

## Problem
When a module injects a form field into an **existing** CrudForm group via the `:fields` injection spot (an `InjectionFieldDefinition` whose `group` targets an existing group id):

1. **`placement` was ignored** — the injected field always landed at the **end** of the target group regardless of `placement.position` / `relativeTo`.
2. **The label rendered twice** — both the CrudForm field row and `InjectedField` rendered the field's label.

## Root Cause
Both defects live in `packages/ui/src/backend/CrudForm.tsx`:

- `groupsWithInjectedFields` unconditionally did `fieldEntries.push(definition.id)`, never consulting `definition.placement` or the existing `insertByInjectionPlacement` helper.
- `injectedCrudFields` mapped each definition to a `{ type: 'custom', label: definition.label, … }` row, while `InjectedField` already renders its own i18n-resolved `<Label>` for `text` / `textarea` / `select` / `boolean` (and the default input branch) — so the label appeared once from the row and once from `InjectedField`.

## What Changed
- `groupsWithInjectedFields` now routes insertion through `insertByInjectionPlacement(fieldEntries, definition.id, definition.placement, getId)`, honoring `before` / `after` / `first` / `last` relative to `relativeTo`. The duplicate-guard was also tightened to match object field entries by `id`, not just string entries.
- `injectedCrudFields` suppresses the CrudForm row `label` for every field type that `InjectedField` labels itself, and keeps `definition.label` only for custom-component fields (`type: 'custom'` + `customComponent`), which render no label of their own — so the label always renders exactly once and never loses i18n resolution.

## Tests
- New `packages/ui/src/backend/__tests__/CrudForm.fieldInjection.test.tsx`:
  - asserts an injected field with `placement: { position: After, relativeTo: 'lastName' }` lands directly after `lastName` (and before a trailing `email` field, so the assertion distinguishes the fix from the old append-to-end behavior).
  - asserts the injected field's label renders exactly once.
- Both tests were verified to **fail** against the pre-fix code and **pass** after the fix.
- `yarn workspace @open-mercato/ui test` — all 13 CrudForm suites (76 tests) green; full UI suite green except a pre-existing, environment-locale-dependent `format.test.ts` currency assertion unrelated to this change.
- `yarn build:packages` + `yarn typecheck` — green (21/21).

## Backward Compatibility
No contract surface changes. The fix is internal to `CrudForm` rendering/layout; no types, signatures, import paths, event IDs, widget spot IDs, API routes, DI keys, or ACL features were changed. The new `insertByInjectionPlacement` usage consumes an already-public shared helper.
