### PR TITLE
fix(cli,search): bulkhead background workers against DB connection-pool exhaustion

### DIFF
--- a/.ai/runs/2026-06-15-harden-indexing-db-pool-exhaustion.md
+++ b/.ai/runs/2026-06-15-harden-indexing-db-pool-exhaustion.md
@@ -96,8 +96,8 @@ pin connections.
 
 ### Phase 1: Worker connection-budget bulkhead
 
-- [ ] 1.1 Pure `resolveWorkerConcurrencyBudget()` helper + unit tests
-- [ ] 1.2 Apply budget in `worker --all` / single-queue + startup logging
+- [x] 1.1 Pure `resolveWorkerConcurrencyBudget()` helper + unit tests — ad6580b8f
+- [x] 1.2 Apply budget in `worker --all` / single-queue + startup logging — 5ff4dca3b
 
 ### Phase 2: Abort the embedding fetch on timeout
 

--- a/.ai/runs/2026-06-15-harden-indexing-db-pool-exhaustion.md
+++ b/.ai/runs/2026-06-15-harden-indexing-db-pool-exhaustion.md
@@ -1,0 +1,108 @@
+# Harden background indexing against DB connection-pool exhaustion
+
+## Overview
+
+Onboarding on the demo seeds fully but never sets `preparationCompletedAt` — the
+preparing page polls forever. Root-cause analysis traced this to **DB connection
+starvation of the request/onboarding path by background worker jobs**, newly
+exposed by #3011.
+
+Causal chain:
+
+1. **#3011** made `worker --all` build a fresh request container (own
+   `EntityManager` = own pooled DB connection) **per job**, instead of sharing one
+   EM across all concurrent jobs. Peak worker DB-connection demand is now
+   `Σ(per-queue concurrency)` — but nothing bounds that sum against the DB pool
+   (`DB_POOL_MAX`, default 20) or the database's global `max_connections`.
+2. A misconfigured embedding stack on the demo (768-dim Ollama column vs 1536-dim
+   OpenAI output, plus an unreachable `OLLAMA_BASE_URL`) produces a storm of
+   failing vector/fulltext indexing jobs.
+3. Each failing job holds its connection while the embedding call runs. The await
+   is already bounded to ~3s by an existing `Promise.race` timeout, but the
+   underlying `embed()` fetch is **not actually aborted**, so orphaned requests
+   linger and the worker stays maximally busy.
+4. Under that load the unbounded `Σconcurrency` over-subscribes connections —
+   inside the worker (acquire-timeout thrash) and, against `max_connections`,
+   across the worker + web processes — starving onboarding's completion write.
+
+This is a hardening change: make background work unable to exhaust the connection
+budget the request path depends on, regardless of which subsystem misbehaves.
+
+### External References
+
+None (no `--skill-url` provided).
+
+## Goal
+
+Background/indexing workers must never consume the DB connections the
+request/onboarding path needs, and a misconfigured embedding provider must not
+pin connections.
+
+## Scope
+
+- `packages/cli/src/lib/worker-connection-budget.ts` (new, pure, testable) — derive
+  a per-queue effective-concurrency plan bounded by a DB connection budget.
+- `packages/cli/src/mercato.ts` — apply the budget in `worker --all` (and clamp a
+  single-queue run to the budget), log the resolved plan, warn on over-subscription.
+- `packages/search/src/vector/services/embedding.ts` — pass a real `AbortSignal`
+  to `embed()` and abort it on timeout so a dead provider releases sockets/the
+  connection promptly.
+- `packages/queue/AGENTS.md` + `packages/shared/AGENTS.md` — document the invariant
+  `web_pool_max + worker_pool_max + overhead ≤ pg_max_connections` and the new knobs.
+
+## Non-goals
+
+- Not fixing the demo's embedding misconfiguration (ops/config, separate).
+- Not changing onboarding's deferred-provisioning flow or completion semantics.
+- Not introducing a separate ORM/pool instance for the worker (out of scope;
+  documented as an ops concern instead).
+- Not raising default concurrency or pool sizes.
+
+## Risks
+
+- Clamping `Σconcurrency` to the pool budget changes worker scheduling. Mitigation:
+  the budget defaults to the resolved `DB_POOL_MAX`, so the clamp only bites when
+  workers were already over-subscribed (jobs beyond `poolMax` were blocking on
+  connection acquire anyway) — effective throughput is unchanged, only the
+  thrash is removed. Override via `OM_WORKERS_DB_CONNECTION_BUDGET`; a floor of 1
+  per queue guarantees no queue is starved.
+- `queue/AGENTS.md` says "Ask before changing worker concurrency limits" — this is
+  the user's explicit request; behavior change is surfaced in the PR + `needs-qa`.
+- Aborting `embed()` changes the error surface on timeout. Mitigation: preserve the
+  existing timeout error message; tests assert message + that a signal is passed.
+
+## Implementation Plan
+
+### Phase 1: Worker connection-budget bulkhead
+
+- 1.1 Add pure `resolveWorkerConcurrencyBudget()` helper + unit tests (proportional
+  scale-down to budget, floor 1, metadata for logging).
+- 1.2 Wire it into `worker --all` and the single-queue path in `mercato.ts`; log the
+  resolved budget/plan and warn when over-subscribed.
+
+### Phase 2: Abort the embedding fetch on timeout
+
+- 2.1 Pass an `AbortController` signal to `embed()` and abort on timeout in
+  `createEmbedding`; preserve the timeout error message. Extend embedding tests.
+
+### Phase 3: Document the connection-budget invariant
+
+- 3.1 Add a "Connection Budget" section to `packages/queue/AGENTS.md` and a DB-pool
+  note to `packages/shared/AGENTS.md` covering the invariant and new env knobs.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Worker connection-budget bulkhead
+
+- [ ] 1.1 Pure `resolveWorkerConcurrencyBudget()` helper + unit tests
+- [ ] 1.2 Apply budget in `worker --all` / single-queue + startup logging
+
+### Phase 2: Abort the embedding fetch on timeout
+
+- [ ] 2.1 AbortSignal cancellation in `createEmbedding` + tests
+
+### Phase 3: Document the connection-budget invariant
+
+- [ ] 3.1 Document invariant + env knobs in queue/shared AGENTS.md

--- a/.ai/runs/2026-06-15-harden-indexing-db-pool-exhaustion.md
+++ b/.ai/runs/2026-06-15-harden-indexing-db-pool-exhaustion.md
@@ -105,4 +105,4 @@ pin connections.
 
 ### Phase 3: Document the connection-budget invariant
 
-- [ ] 3.1 Document invariant + env knobs in queue/shared AGENTS.md
+- [x] 3.1 Document invariant + env knobs in queue/shared AGENTS.md — 2fe735233

--- a/.ai/runs/2026-06-15-harden-indexing-db-pool-exhaustion.md
+++ b/.ai/runs/2026-06-15-harden-indexing-db-pool-exhaustion.md
@@ -2,6 +2,8 @@
 
 ## Overview
 
+> Shipped as PR #3089 (against `develop`).
+
 Onboarding on the demo seeds fully but never sets `preparationCompletedAt` — the
 preparing page polls forever. Root-cause analysis traced this to **DB connection
 starvation of the request/onboarding path by background worker jobs**, newly

--- a/.ai/runs/2026-06-15-harden-indexing-db-pool-exhaustion.md
+++ b/.ai/runs/2026-06-15-harden-indexing-db-pool-exhaustion.md
@@ -101,7 +101,7 @@ pin connections.
 
 ### Phase 2: Abort the embedding fetch on timeout
 
-- [ ] 2.1 AbortSignal cancellation in `createEmbedding` + tests
+- [x] 2.1 AbortSignal cancellation in `createEmbedding` + tests — 1b36cde42
 
 ### Phase 3: Document the connection-budget invariant
 

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -239,6 +239,11 @@ DB_POOL_ACQUIRE_TIMEOUT=10000
 # queries / lock waits so they cannot exhaust the pool. Recommended in production.
 #DB_STATEMENT_TIMEOUT_MS=30000
 #DB_LOCK_TIMEOUT_MS=10000
+# Background-worker DB connection budget. `mercato queue worker --all` fits the sum of
+# per-queue concurrency to this budget (one pooled connection per in-flight job) so workers
+# cannot starve the request path. Defaults to DB_POOL_MAX. Keep
+# web_pool_max + worker_pool_max + overhead <= Postgres max_connections.
+#OM_WORKERS_DB_CONNECTION_BUDGET=20
 
 # Audit log retention windows
 # Core resources (users, roles) keep access history longer to support investigations.

--- a/packages/cli/src/lib/__tests__/worker-connection-budget.test.ts
+++ b/packages/cli/src/lib/__tests__/worker-connection-budget.test.ts
@@ -1,0 +1,115 @@
+import {
+  planWorkerConcurrency,
+  resolveWorkerConnectionBudget,
+} from '../worker-connection-budget'
+
+describe('resolveWorkerConnectionBudget', () => {
+  it('defaults to the pool max when no override is set', () => {
+    expect(resolveWorkerConnectionBudget({} as NodeJS.ProcessEnv, 20)).toBe(20)
+  })
+
+  it('honors a positive OM_WORKERS_DB_CONNECTION_BUDGET override', () => {
+    expect(
+      resolveWorkerConnectionBudget(
+        { OM_WORKERS_DB_CONNECTION_BUDGET: '8' } as unknown as NodeJS.ProcessEnv,
+        20,
+      ),
+    ).toBe(8)
+  })
+
+  it('falls back to the pool max for non-numeric or non-positive overrides', () => {
+    for (const value of ['0', '-3', 'abc', '']) {
+      expect(
+        resolveWorkerConnectionBudget(
+          { OM_WORKERS_DB_CONNECTION_BUDGET: value } as unknown as NodeJS.ProcessEnv,
+          16,
+        ),
+      ).toBe(16)
+    }
+  })
+
+  it('clamps an invalid pool max to at least 1', () => {
+    expect(resolveWorkerConnectionBudget({} as NodeJS.ProcessEnv, 0)).toBe(1)
+    expect(resolveWorkerConnectionBudget({} as NodeJS.ProcessEnv, Number.NaN)).toBe(1)
+  })
+})
+
+describe('planWorkerConcurrency', () => {
+  it('passes concurrency through untouched when it fits the budget', () => {
+    const plan = planWorkerConcurrency(
+      [
+        { queue: 'events', concurrency: 5 },
+        { queue: 'vector-indexing', concurrency: 2 },
+        { queue: 'fulltext-indexing', concurrency: 2 },
+      ],
+      20,
+    )
+    expect(plan.clamped).toBe(false)
+    expect(plan.totalEffective).toBe(9)
+    expect(plan.entries.map((entry) => entry.effective)).toEqual([5, 2, 2])
+  })
+
+  it('scales down to exactly the budget when over-subscribed', () => {
+    const plan = planWorkerConcurrency(
+      [
+        { queue: 'events', concurrency: 10 },
+        { queue: 'vector-indexing', concurrency: 10 },
+        { queue: 'fulltext-indexing', concurrency: 10 },
+      ],
+      12,
+    )
+    expect(plan.clamped).toBe(true)
+    expect(plan.belowQueueFloor).toBe(false)
+    expect(plan.totalEffective).toBe(12)
+    for (const entry of plan.entries) {
+      expect(entry.effective).toBeGreaterThanOrEqual(1)
+      expect(entry.effective).toBeLessThanOrEqual(entry.requested)
+    }
+  })
+
+  it('keeps a floor of 1 per queue and never exceeds the request', () => {
+    const plan = planWorkerConcurrency(
+      [
+        { queue: 'events', concurrency: 16 },
+        { queue: 'vector-indexing', concurrency: 2 },
+        { queue: 'fulltext-indexing', concurrency: 2 },
+      ],
+      6,
+    )
+    const byQueue = Object.fromEntries(plan.entries.map((entry) => [entry.queue, entry.effective]))
+    expect(byQueue['vector-indexing']).toBeGreaterThanOrEqual(1)
+    expect(byQueue['fulltext-indexing']).toBeGreaterThanOrEqual(1)
+    // The largest requester absorbs most of the remaining budget.
+    expect(byQueue['events']).toBeGreaterThan(byQueue['vector-indexing'])
+    expect(plan.totalEffective).toBe(6)
+  })
+
+  it('flags belowQueueFloor when the budget is smaller than the queue count', () => {
+    const plan = planWorkerConcurrency(
+      [
+        { queue: 'a', concurrency: 4 },
+        { queue: 'b', concurrency: 4 },
+        { queue: 'c', concurrency: 4 },
+      ],
+      2,
+    )
+    expect(plan.clamped).toBe(true)
+    expect(plan.belowQueueFloor).toBe(true)
+    // Floor of 1 wins even though it exceeds the budget.
+    expect(plan.entries.every((entry) => entry.effective === 1)).toBe(true)
+    expect(plan.totalEffective).toBe(3)
+  })
+
+  it('treats zero/negative requested concurrency as a floor of 1', () => {
+    const plan = planWorkerConcurrency(
+      [
+        { queue: 'events', concurrency: 0 },
+        { queue: 'vector-indexing', concurrency: -5 },
+      ],
+      20,
+    )
+    expect(plan.entries.map((entry) => entry.requested)).toEqual([1, 1])
+    expect(plan.totalEffective).toBe(2)
+    expect(plan.clamped).toBe(false)
+  })
+})

--- a/packages/cli/src/lib/worker-connection-budget.ts
+++ b/packages/cli/src/lib/worker-connection-budget.ts
@@ -1,0 +1,131 @@
+/**
+ * Bound the DB-connection demand of background queue workers.
+ *
+ * Since #2970/#3011 each worker job builds its own request container, so its own
+ * `EntityManager` checks out a dedicated pooled DB connection for the job's
+ * duration. The peak connection demand of `worker --all` is therefore the sum of
+ * every queue's concurrency. Nothing previously bounded that sum against the DB
+ * pool (`DB_POOL_MAX`) or the database's global `max_connections`, so a storm of
+ * slow/failing jobs could over-subscribe connections — thrashing on the worker's
+ * own acquire timeout and, across the worker + web processes, starving the
+ * request/onboarding path that shares the same database.
+ *
+ * These helpers derive a per-queue effective-concurrency plan whose total never
+ * exceeds a connection budget (defaulting to the resolved pool max), while
+ * guaranteeing every queue keeps at least one worker.
+ */
+
+export type WorkerQueueConcurrency = {
+  queue: string
+  concurrency: number
+}
+
+export type WorkerConcurrencyPlanEntry = {
+  queue: string
+  requested: number
+  effective: number
+}
+
+export type WorkerConcurrencyPlan = {
+  /** Connection budget the plan was fitted to. */
+  budget: number
+  /** Sum of requested concurrency across all queues. */
+  totalRequested: number
+  /** Sum of effective concurrency the plan grants. */
+  totalEffective: number
+  /** True when any queue's concurrency was reduced to fit the budget. */
+  clamped: boolean
+  /**
+   * True when the budget is smaller than the number of queues, so the per-queue
+   * floor of 1 forces the total above the budget. The caller should surface this
+   * as a misconfiguration (raise `DB_POOL_MAX` or the budget).
+   */
+  belowQueueFloor: boolean
+  entries: WorkerConcurrencyPlanEntry[]
+}
+
+function toPositiveInt(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback
+  const floored = Math.floor(value)
+  return floored > 0 ? floored : fallback
+}
+
+/**
+ * Resolve the connection budget for background workers. Defaults to the resolved
+ * DB pool max so the worker never tries to use more connections than its own pool
+ * can hand out; override with `OM_WORKERS_DB_CONNECTION_BUDGET` (positive int).
+ */
+export function resolveWorkerConnectionBudget(
+  env: NodeJS.ProcessEnv,
+  poolMax: number,
+): number {
+  const safePoolMax = toPositiveInt(poolMax, 1)
+  const raw = env.OM_WORKERS_DB_CONNECTION_BUDGET
+  if (!raw) return safePoolMax
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : safePoolMax
+}
+
+/**
+ * Fit per-queue concurrency to a connection budget.
+ *
+ * - Every queue keeps a floor of 1 worker (no queue is starved).
+ * - No queue exceeds its requested concurrency.
+ * - When the sum exceeds the budget, leftover capacity is distributed greedily to
+ *   the queues furthest below their request, so the total matches the budget
+ *   exactly (when `budget >= queueCount`) and the allocation is deterministic.
+ */
+export function planWorkerConcurrency(
+  queues: WorkerQueueConcurrency[],
+  budget: number,
+): WorkerConcurrencyPlan {
+  const safeBudget = toPositiveInt(budget, 1)
+  const requested = queues.map((entry) => ({
+    queue: entry.queue,
+    requested: toPositiveInt(entry.concurrency, 1),
+  }))
+  const totalRequested = requested.reduce((sum, entry) => sum + entry.requested, 0)
+
+  if (totalRequested <= safeBudget) {
+    return {
+      budget: safeBudget,
+      totalRequested,
+      totalEffective: totalRequested,
+      clamped: false,
+      belowQueueFloor: false,
+      entries: requested.map((entry) => ({ ...entry, effective: entry.requested })),
+    }
+  }
+
+  // Floor every queue at 1, then water-fill the remaining budget to the queues
+  // with the largest unmet request first.
+  const effective = requested.map(() => 1)
+  let used = effective.length
+  while (used < safeBudget) {
+    let bestIndex = -1
+    let bestDeficit = 0
+    for (let index = 0; index < requested.length; index += 1) {
+      const deficit = requested[index].requested - effective[index]
+      if (deficit > bestDeficit) {
+        bestDeficit = deficit
+        bestIndex = index
+      }
+    }
+    if (bestIndex === -1) break
+    effective[bestIndex] += 1
+    used += 1
+  }
+
+  const totalEffective = effective.reduce((sum, value) => sum + value, 0)
+  return {
+    budget: safeBudget,
+    totalRequested,
+    totalEffective,
+    clamped: true,
+    belowQueueFloor: requested.length > safeBudget,
+    entries: requested.map((entry, index) => ({
+      ...entry,
+      effective: effective[index],
+    })),
+  }
+}

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -17,6 +17,11 @@ import {
 import { startLazyWorkerSupervisor } from './lib/queue-worker-supervisor'
 import { createPerJobWorkerHandler } from './lib/worker-job-handler'
 import {
+  planWorkerConcurrency,
+  resolveWorkerConnectionBudget,
+  type WorkerConcurrencyPlan,
+} from './lib/worker-connection-budget'
+import {
   resolveAutoSpawnSchedulerMode,
   resolveLazySchedulerPollMs,
   resolveLazySchedulerRestart,
@@ -523,6 +528,46 @@ function formatQueueWorkerLabel(queueNames: string[]): string {
   const sorted = [...queueNames].sort((a, b) => a.localeCompare(b))
   const preview = sorted.length > 4 ? `${sorted.slice(0, 4).join(', ')}, +${sorted.length - 4} more` : sorted.join(', ')
   return `Queue worker (${preview})`
+}
+
+/**
+ * Fit the requested per-queue worker concurrency to the worker process's DB
+ * connection budget and log the resolved plan. Since each job runs in its own
+ * request container (one pooled connection per in-flight job), the sum of worker
+ * concurrency is the worker's peak connection demand — it MUST stay within the
+ * pool so background jobs cannot starve the request/onboarding path that shares
+ * the same database.
+ */
+async function resolveWorkerBudgetPlan(
+  requestedByQueue: { queue: string; concurrency: number }[],
+): Promise<WorkerConcurrencyPlan> {
+  const { resolvePoolConfig } = await import('@open-mercato/shared/lib/db/mikro')
+  const poolMax = resolvePoolConfig(process.env).poolMax
+  const budget = resolveWorkerConnectionBudget(process.env, poolMax)
+  const plan = planWorkerConcurrency(requestedByQueue, budget)
+
+  console.log(
+    `[worker] DB connection budget: ${plan.budget} (pool max ${poolMax}); ` +
+      `requested Σconcurrency ${plan.totalRequested}, effective ${plan.totalEffective}`,
+  )
+  if (plan.clamped) {
+    const perQueue = plan.entries
+      .map((entry) => `${entry.queue}=${entry.effective}/${entry.requested}`)
+      .join(', ')
+    console.warn(
+      `[worker] Worker concurrency clamped to fit the DB connection budget (${plan.budget}): ${perQueue}. ` +
+        `Raise DB_POOL_MAX or set OM_WORKERS_DB_CONNECTION_BUDGET to change this. ` +
+        `Keep web_pool_max + worker_pool_max + overhead <= Postgres max_connections.`,
+    )
+  }
+  if (plan.belowQueueFloor) {
+    console.warn(
+      `[worker] DB connection budget (${plan.budget}) is smaller than the number of queues ` +
+        `(${requestedByQueue.length}); every queue runs at concurrency 1 and total demand ` +
+        `(${plan.totalEffective}) still exceeds the budget. Raise DB_POOL_MAX.`,
+    )
+  }
+  return plan
 }
 
 function lookupModuleCommand(
@@ -1520,12 +1565,31 @@ export async function run(argv = process.argv) {
             }
 
             const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
+
+            // Fit Σconcurrency to the worker's DB connection budget before
+            // starting any worker, so the per-job containers (one connection each)
+            // can never over-subscribe the pool the request path shares.
+            const requestedByQueue = discoveredQueues.map((queue) => {
+              const queueWorkers = allWorkers.filter((w) => w.queue === queue)
+              return {
+                queue,
+                concurrency: concurrencyOverride ?? Math.max(...queueWorkers.map((w) => w.concurrency), 1),
+              }
+            })
+            const budgetPlan = await resolveWorkerBudgetPlan(requestedByQueue)
+            const effectiveByQueue = new Map(
+              budgetPlan.entries.map((entry) => [entry.queue, entry.effective]),
+            )
+
             console.log(`[worker] Starting workers for all queues: ${discoveredQueues.join(', ')}`)
 
             // Start all queue workers in background mode
             const workerPromises = discoveredQueues.map(async (queue) => {
               const queueWorkers = allWorkers.filter((w) => w.queue === queue)
-              const concurrency = concurrencyOverride ?? Math.max(...queueWorkers.map((w) => w.concurrency), 1)
+              const concurrency =
+                effectiveByQueue.get(queue) ??
+                concurrencyOverride ??
+                Math.max(...queueWorkers.map((w) => w.concurrency), 1)
 
               console.log(`[worker] Starting "${queue}" with ${queueWorkers.length} handler(s), concurrency: ${concurrency}`)
 
@@ -1552,7 +1616,11 @@ export async function run(argv = process.argv) {
             if (queueWorkers.length > 0) {
               // Use discovered workers
               const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
-              const concurrency = concurrencyOverride ?? Math.max(...queueWorkers.map((w) => w.concurrency), 1)
+              const requested = concurrencyOverride ?? Math.max(...queueWorkers.map((w) => w.concurrency), 1)
+              // Bound a single-queue run to the connection budget too, so it can
+              // never check out more pooled connections than the worker pool holds.
+              const budgetPlan = await resolveWorkerBudgetPlan([{ queue: queueName!, concurrency: requested }])
+              const concurrency = budgetPlan.entries[0]?.effective ?? requested
 
               console.log(`[worker] Found ${queueWorkers.length} worker(s) for queue "${queueName}"`)
 

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -229,6 +229,11 @@ DB_POOL_ACQUIRE_TIMEOUT=60000
 # queries / lock waits so they cannot exhaust the pool. Recommended in production.
 #DB_STATEMENT_TIMEOUT_MS=30000
 #DB_LOCK_TIMEOUT_MS=10000
+# Background-worker DB connection budget. `mercato queue worker --all` fits the sum of
+# per-queue concurrency to this budget (one pooled connection per in-flight job) so workers
+# cannot starve the request path. Defaults to DB_POOL_MAX. Keep
+# web_pool_max + worker_pool_max + overhead <= Postgres max_connections.
+#OM_WORKERS_DB_CONNECTION_BUDGET=20
 
 # Audit log retention windows
 # Core resources (users, roles) keep access history longer to support investigations.

--- a/packages/queue/AGENTS.md
+++ b/packages/queue/AGENTS.md
@@ -42,6 +42,21 @@ yarn workspace @open-mercato/queue build
 | CPU-bound (calculations, parsing) | 1–2 | Avoid blocking the event loop |
 | Database-heavy (bulk writes) | 3–5 | Balance throughput with connection pool |
 
+## Connection Budget (MUST keep workers within the DB pool)
+
+Since each worker job runs in its own request container (one `EntityManager`, so
+one pooled DB connection checked out for the job's duration), the peak DB
+connection demand of `worker --all` is **`Σ(per-queue concurrency)`**. That sum
+MUST stay within the database's connection budget, or background jobs starve the
+connections the request/onboarding path needs — the failure mode behind the
+2026-06 onboarding stall.
+
+- **Invariant:** `web_pool_max + worker_pool_max + scheduler/overhead ≤ Postgres max_connections` (leave headroom). `*_pool_max` is each process's `DB_POOL_MAX` (default 20).
+- `worker --all` fits `Σconcurrency` to the worker's connection budget at startup and logs the resolved plan (`[worker] DB connection budget: …`). The budget defaults to the resolved `DB_POOL_MAX`; override with `OM_WORKERS_DB_CONNECTION_BUDGET`. Every queue keeps a floor of 1, and no queue exceeds its declared concurrency — so clamping only removes over-subscription, never real throughput.
+- When you change a worker's `concurrency`, add a queue, or raise a pool size, re-check the invariant. A change that multiplies per-job resource usage (e.g. moving to per-job containers) MUST state and verify the new connection ceiling.
+- Give long-running background processes (the worker) a **smaller** `DB_POOL_MAX` than the web process when they share one database, so a worker storm can never consume the web pool's share of `max_connections`.
+- Workers that call external services MUST bound those calls with a timeout (e.g. `VECTOR_EMBEDDING_TIMEOUT_MS` for embeddings) so a dead dependency releases its connection promptly instead of pinning pool capacity.
+
 ## Adding a New Worker
 
 1. Create worker file in `src/modules/<module>/workers/<worker-name>.ts`

--- a/packages/search/src/__tests__/embedding.test.ts
+++ b/packages/search/src/__tests__/embedding.test.ts
@@ -38,6 +38,29 @@ describe('EmbeddingService', () => {
     )
   })
 
+  it('aborts the in-flight request when it times out', async () => {
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
+    process.env.VECTOR_EMBEDDING_TIMEOUT_MS = '5'
+    let capturedSignal: AbortSignal | undefined
+    mockedEmbed.mockImplementation((options) => {
+      capturedSignal = (options as { abortSignal?: AbortSignal }).abortSignal
+      return new Promise(() => undefined)
+    })
+
+    const service = new EmbeddingService({
+      config: {
+        providerId: 'ollama',
+        model: 'nomic-embed-text',
+        dimension: 768,
+        updatedAt: new Date().toISOString(),
+      },
+    })
+
+    await expect(service.createEmbedding('test input')).rejects.toThrow('timed out')
+    expect(capturedSignal).toBeInstanceOf(AbortSignal)
+    expect(capturedSignal?.aborted).toBe(true)
+  })
+
   it('returns embeddings when provider responds before the timeout', async () => {
     process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
     process.env.VECTOR_EMBEDDING_TIMEOUT_MS = '100'

--- a/packages/search/src/vector/services/embedding.ts
+++ b/packages/search/src/vector/services/embedding.ts
@@ -234,17 +234,26 @@ export class EmbeddingService {
     const providerOptions = this.getProviderOptions()
     const timeoutMs = resolveEmbeddingTimeoutMs()
 
+    const abortController = new AbortController()
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null
     try {
       const result = await Promise.race([
         embed({
           model,
           value: merged,
+          abortSignal: abortController.signal,
           ...(providerOptions && { providerOptions }),
         }),
         new Promise<never>((_, reject) => {
           timeoutHandle = setTimeout(
-            () => reject(timeoutError(this.config.providerId, timeoutMs)),
+            () => {
+              // Abort the in-flight request so a dead/unreachable provider releases
+              // its socket — and, in a worker, the per-job DB connection held while
+              // this awaits — promptly, instead of lingering until the platform's
+              // default network timeout and pinning pool capacity under a storm.
+              abortController.abort()
+              reject(timeoutError(this.config.providerId, timeoutMs))
+            },
             timeoutMs,
           )
         }),

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -41,6 +41,7 @@ yarn workspace @open-mercato/shared build
 | `crud/` | When building CRUD routes | `@open-mercato/shared/lib/crud` |
 | `custom-fields/` | When handling custom field payloads | `@open-mercato/shared/lib/custom-fields` |
 | `data/` | When you need `DataEngine` or `QueryEngine` types | `@open-mercato/shared/lib/data/engine` |
+| `db/` | When resolving the ORM/connection-pool config (`resolvePoolConfig`, pool/timeout env knobs) | `@open-mercato/shared/lib/db/mikro` |
 | `di/` | When setting up dependency injection (Awilix) | `@open-mercato/shared/lib/di` |
 | `encryption/` | When querying encrypted entities (MUST use instead of raw `em.find`) | `@open-mercato/shared/lib/encryption/find` |
 | `i18n/` | When translating strings — `useT()` client-side, `resolveTranslations()` server-side | `@open-mercato/shared/lib/i18n/context` or `/server` |
@@ -65,6 +66,17 @@ When you need shared type definitions, import from these:
 | Module-level overrides (`ModuleOverrides`, dispatcher, per-domain compose helpers) | `@open-mercato/shared/modules/overrides` |
 
 ## Key Patterns
+
+### Database Connection Pool — MUST keep total demand under `max_connections`
+
+The MikroORM pool is configured from env via `resolvePoolConfig(process.env)` in
+`@open-mercato/shared/lib/db/mikro` (pure and unit-testable). Each process gets
+its own pool (`DB_POOL_MAX`, default 20). Because background worker jobs each run
+in their own request container (one pooled connection per in-flight job), the
+peak connection demand of all processes against one database is additive.
+
+- **Invariant:** `web_pool_max + worker_pool_max + scheduler/overhead ≤ Postgres max_connections` (with headroom). Violating it lets background work starve the request/onboarding path — see `packages/queue/AGENTS.md` → Connection Budget.
+- Tune per process with `DB_POOL_MAX` (and the opt-in `DB_STATEMENT_TIMEOUT_MS` / `DB_LOCK_TIMEOUT_MS`; `idle_in_transaction` defaults to a finite 120s). Bound the worker's job concurrency with `OM_WORKERS_DB_CONNECTION_BUDGET`.
 
 ### Encryption — MUST use instead of raw ORM queries
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-15-harden-indexing-db-pool-exhaustion.md
Status: complete

## Goal
- Stop background/indexing workers from exhausting the DB connection pool the request/onboarding path shares — the root cause of demo onboarding seeding fully but never setting `preparationCompletedAt`, newly exposed by #3011.

## What Changed
- **Worker connection-budget bulkhead (`packages/cli`)**: new pure `worker-connection-budget.ts` planner fits `Σ(per-queue concurrency)` to a DB connection budget (default `DB_POOL_MAX`, override `OM_WORKERS_DB_CONNECTION_BUDGET`). `mercato queue worker --all` (and single-queue) now apply it and log the resolved budget/plan, warning on over-subscription. Floors every queue at 1; never exceeds requested concurrency — so it only removes over-subscription, not real throughput.
- **Abort the embedding fetch on timeout (`packages/search`)**: the timeout was a `Promise.race` that abandoned the await but left the underlying `embed()` fetch running, so a dead/unreachable provider lingered and held the worker's per-job DB connection. Now passes an `AbortSignal` to `embed()` and aborts it on timeout; the existing timeout error message is preserved.
- **Docs**: documented the invariant `web_pool_max + worker_pool_max + overhead ≤ Postgres max_connections` in `packages/queue/AGENTS.md` (Connection Budget) and `packages/shared/AGENTS.md` (DB pool key pattern), plus the `OM_WORKERS_DB_CONNECTION_BUDGET` knob in both `.env.example` files.

## Tests
- New `packages/cli/src/lib/__tests__/worker-connection-budget.test.ts` (9 cases): budget resolution, proportional clamp to exactly the budget, per-queue floor of 1, never-exceed-requested, below-queue-floor flag, zero/negative normalization.
- Extended `packages/search/src/__tests__/embedding.test.ts`: asserts the in-flight request is aborted (`signal.aborted === true`) on timeout.
- Full gate: `build:packages` ✓, `generate` ✓, `build:packages` (post-generate) ✓, `i18n:check-sync` ✓, `i18n:check-usage` ✓, `typecheck` ✓, `test` ✓ (all suites; 5895 core tests), `build:app` ✓.

## Backward Compatibility
- No contract surface changes. CLI command contract (`worker`, `--all`, `--concurrency=`) unchanged. `EmbeddingService.createEmbedding` signature and timeout error message unchanged. `OM_WORKERS_DB_CONNECTION_BUDGET` is additive and defaults to `DB_POOL_MAX`, so concurrency only changes when workers were already over-subscribing the pool (excess jobs were blocking on connection acquire anyway).

## Progress
See [Progress section in the plan](.ai/runs/2026-06-15-harden-indexing-db-pool-exhaustion.md#progress).
