### PR TITLE
refactor(cache): bound memory sweep, add eviction/sweep counters + env test (#3070)

### DIFF
--- a/packages/cache/AGENTS.md
+++ b/packages/cache/AGENTS.md
@@ -10,6 +10,15 @@ Use `@open-mercato/cache` for all caching needs. MUST NOT use raw Redis, SQLite,
 | SQLite | Use for single-server production deployments; local persistent convenience cache, tuned with WAL/`synchronous=NORMAL` | `CACHE_STRATEGY=sqlite` |
 | Redis | Use for multi-server production or latency-sensitive request paths with frequent cache writes | `CACHE_STRATEGY=redis` |
 
+## Memory Strategy Bounds
+
+The memory strategy is bounded so a process-shared instance (`OM_BOOTSTRAP_CACHE`, long-lived workers, memory-backed CRUD list cache) cannot grow without limit on user-controllable key cardinality.
+
+- **LRU cap** — at most `maxEntries` entries are retained (default `50000`). Reads refresh recency (Map re-insertion); the least-recently-used entries are evicted on write once the cap is exceeded.
+- **`CACHE_MEMORY_MAX_ENTRIES`** — env override for the cap, resolved in the cache service. `.env.example` carries a commented `#CACHE_MEMORY_MAX_ENTRIES=50000`. A non-positive value (or an unparseable one — which is ignored, falling back to the default) disables the cap (**unbounded** — only safe for short-lived per-request instances).
+- **Amortized expired-entry sweep** — expired entries are reclaimed by a budgeted sweep that runs every 256 writes (no per-instance timer, so the per-request default stays leak-free). Each pass scans a bounded slice from the LRU head, so it stays `O(budget)` rather than scanning the whole store. Expired entries beyond the budget are still reclaimed on access, by LRU eviction, or via an explicit `cleanup()`.
+- **Observability** — `stats()` on a memory-backed service surfaces `evictions`, `sweeps`, and `lastSweepReclaimed` (process-global counters) alongside the tenant-scoped `size`/`expired`, so operators can tell whether the bound is actively protecting the process. Other backends omit these fields.
+
 ## Always
 
 1. **MUST resolve via DI** — always use `container.resolve('cacheService')`, never instantiate cache directly

--- a/packages/cache/src/__tests__/memory.strategy.test.ts
+++ b/packages/cache/src/__tests__/memory.strategy.test.ts
@@ -251,10 +251,67 @@ describe('Memory Cache Strategy', () => {
           await bounded.set(`fresh:${i}`, i)
         }
         // The expired cohort was reclaimed; only the 60 fresh entries remain.
-        expect((await bounded.stats()).size).toBe(60)
+        const stats = await bounded.stats()
+        expect(stats.size).toBe(60)
+        // The firing pass reclaimed the whole 200-entry cohort (under budget).
+        expect(stats.sweeps).toBeGreaterThanOrEqual(1)
+        expect(stats.lastSweepReclaimed).toBe(200)
       } finally {
         jest.useRealTimers()
       }
+    })
+
+    it('bounds a single sweep pass instead of scanning the whole store', async () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2025-01-01T00:00:00.000Z'))
+      try {
+        // A cohort larger than the per-pass scan budget so one sweep cannot
+        // reclaim all of it. maxEntries default (50k) keeps LRU eviction out
+        // of the picture for this many entries.
+        const cohort = 1_200
+        const bounded = createMemoryStrategy()
+        for (let i = 0; i < cohort; i++) {
+          await bounded.set(`expiring:${i}`, i, { ttl: 50 })
+        }
+        await jest.advanceTimersByTimeAsync(100)
+
+        // Cross the sweep interval again with fresh (non-expiring) entries.
+        for (let i = 0; i < 256; i++) {
+          await bounded.set(`fresh:${i}`, i)
+        }
+
+        const stats = await bounded.stats()
+        // The budget caps the firing pass, so not every expired entry is gone
+        // and the reclaimed count is strictly below the full cohort.
+        expect(stats.lastSweepReclaimed).toBeGreaterThan(0)
+        expect(stats.lastSweepReclaimed).toBeLessThan(cohort)
+        expect(stats.size).toBeGreaterThan(256)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+  })
+
+  describe('Observability counters', () => {
+    it('counts LRU evictions via stats()', async () => {
+      const bounded = createMemoryStrategy({ maxEntries: 3 })
+      await bounded.set('a', 1)
+      await bounded.set('b', 2)
+      await bounded.set('c', 3)
+      expect((await bounded.stats()).evictions).toBe(0)
+
+      await bounded.set('d', 4) // evicts 'a'
+      await bounded.set('e', 5) // evicts 'b'
+      expect((await bounded.stats()).evictions).toBe(2)
+    })
+
+    it('reports zero counters for an idle bounded strategy', async () => {
+      const bounded = createMemoryStrategy({ maxEntries: 10 })
+      await bounded.set('a', 1)
+      const stats = await bounded.stats()
+      expect(stats.evictions).toBe(0)
+      expect(stats.sweeps).toBe(0)
+      expect(stats.lastSweepReclaimed).toBe(0)
     })
   })
 

--- a/packages/cache/src/__tests__/service.test.ts
+++ b/packages/cache/src/__tests__/service.test.ts
@@ -199,4 +199,40 @@ describe('Cache Service', () => {
       expect(stats.expired).toBe(0)
     })
   })
+
+  describe('Memory bound env resolution (CACHE_MEMORY_MAX_ENTRIES)', () => {
+    afterEach(() => {
+      delete process.env.CACHE_MEMORY_MAX_ENTRIES
+    })
+
+    it('bounds a memory-backed service when the env var is set', async () => {
+      process.env.CACHE_MEMORY_MAX_ENTRIES = '10'
+      const cache = createCacheService({ strategy: 'memory' })
+
+      for (let index = 0; index < 30; index += 1) {
+        await cache.set(`key:${index}`, index)
+      }
+
+      const stats = await cache.stats()
+      // The LRU cap kept the store far below the 30 logical writes and the
+      // surfaced eviction counter proves the bound was actively enforced.
+      expect(stats.size).toBeLessThan(30)
+      expect(stats.evictions).toBeGreaterThan(0)
+    })
+
+    it('ignores an invalid env value and stays unbounded by default', async () => {
+      process.env.CACHE_MEMORY_MAX_ENTRIES = 'not-a-number'
+      const cache = createCacheService({ strategy: 'memory' })
+
+      for (let index = 0; index < 30; index += 1) {
+        await cache.set(`key:${index}`, index)
+      }
+
+      const stats = await cache.stats()
+      // Invalid value parses to NaN, is discarded, and the default cap (50k)
+      // leaves all 30 entries resident with no evictions.
+      expect(stats.size).toBe(30)
+      expect(stats.evictions).toBe(0)
+    })
+  })
 })

--- a/packages/cache/src/service.ts
+++ b/packages/cache/src/service.ts
@@ -170,7 +170,11 @@ function createTenantAwareWrapper(base: CacheStrategy): CacheStrategy {
       const expiresAt = metadata?.expiresAt ?? null
       if (expiresAt !== null && expiresAt <= now) expired++
     }
-    return { size, expired }
+    // size/expired stay tenant-scoped (derived from this tenant's meta keys);
+    // surface the underlying strategy's process-global bound counters too so
+    // operators reading the DI cacheService can see LRU/sweep activity.
+    const { evictions, sweeps, lastSweepReclaimed } = await base.stats()
+    return { size, expired, evictions, sweeps, lastSweepReclaimed }
   }
 
   const cleanup = base.cleanup
@@ -274,7 +278,13 @@ export class CacheService implements CacheStrategy {
     return this.strategy.keys(pattern)
   }
 
-  async stats(): Promise<{ size: number; expired: number }> {
+  async stats(): Promise<{
+    size: number
+    expired: number
+    evictions?: number
+    sweeps?: number
+    lastSweepReclaimed?: number
+  }> {
     return this.strategy.stats()
   }
 

--- a/packages/cache/src/strategies/memory.ts
+++ b/packages/cache/src/strategies/memory.ts
@@ -4,6 +4,16 @@ import { matchCacheKeyPattern } from '../patterns'
 const EXPIRED_SWEEP_WRITE_INTERVAL = 256
 
 /**
+ * Upper bound on entries scanned by a single amortized sweep pass. Keeps the
+ * sweep O(budget) instead of O(store size) so a large, hot store never pays a
+ * full-store scan latency spike on the `set()` that crosses the sweep interval.
+ * The scan walks from the LRU head, where expired-and-cold entries accumulate;
+ * anything beyond the budget is reclaimed on a later sweep, on access, by LRU
+ * eviction once the cap is exceeded, or by an explicit `cleanup()`.
+ */
+const EXPIRED_SWEEP_MAX_SCAN = 1_000
+
+/**
  * Default upper bound on the number of entries a memory cache retains.
  * Bounds memory for long-lived (process-wide) instances; LRU eviction drops
  * the least-recently-used entries once the cap is exceeded. Override via the
@@ -38,6 +48,12 @@ export function createMemoryStrategy(options?: { defaultTtl?: number; maxEntries
   const defaultTtl = options?.defaultTtl
   const maxEntries = normalizeMaxEntries(options?.maxEntries)
   let writesSinceSweep = 0
+  // Lightweight observability counters so operators can tell whether the bound
+  // is actively protecting the process. Process-global for this instance, not
+  // tenant-scoped; surfaced via stats().
+  let evictions = 0
+  let sweeps = 0
+  let lastSweepReclaimed = 0
 
   function isExpired(entry: CacheEntry): boolean {
     if (entry.expiresAt === null) return false
@@ -61,6 +77,7 @@ export function createMemoryStrategy(options?: { defaultTtl?: number; maxEntries
       const entry = store.get(oldest)
       store.delete(oldest)
       if (entry) removeFromTagIndex(oldest, entry.tags)
+      evictions++
     }
   }
 
@@ -102,15 +119,24 @@ export function createMemoryStrategy(options?: { defaultTtl?: number; maxEntries
   // Amortized reclamation of already-expired entries. Runs every N writes
   // instead of on a timer, keeping the no-shared-state property that makes the
   // per-request default safe. Independent of the LRU cap so expired-but-cold
-  // entries are reclaimed even when the store stays under `maxEntries`.
+  // entries are reclaimed even when the store stays under `maxEntries`. The
+  // scan is budgeted (EXPIRED_SWEEP_MAX_SCAN entries from the LRU head per pass)
+  // so it stays O(budget) on large stores instead of scanning every entry.
   function sweepExpiredIfDue(): void {
     if (++writesSinceSweep < EXPIRED_SWEEP_WRITE_INTERVAL) return
     writesSinceSweep = 0
+    sweeps++
+    let scanned = 0
+    let reclaimed = 0
     for (const [key, entry] of store.entries()) {
+      if (scanned >= EXPIRED_SWEEP_MAX_SCAN) break
+      scanned++
       if (isExpired(entry)) {
         cleanupExpiredEntry(key, entry)
+        reclaimed++
       }
     }
+    lastSweepReclaimed = reclaimed
   }
 
   const get = async (key: string, options?: CacheGetOptions): Promise<CacheValue | null> => {
@@ -208,14 +234,20 @@ export function createMemoryStrategy(options?: { defaultTtl?: number; maxEntries
     return allKeys.filter((key) => matchCacheKeyPattern(key, pattern))
   }
 
-  const stats = async (): Promise<{ size: number; expired: number }> => {
+  const stats = async (): Promise<{
+    size: number
+    expired: number
+    evictions: number
+    sweeps: number
+    lastSweepReclaimed: number
+  }> => {
     let expired = 0
     for (const entry of store.values()) {
       if (isExpired(entry)) {
         expired++
       }
     }
-    return { size: store.size, expired }
+    return { size: store.size, expired, evictions, sweeps, lastSweepReclaimed }
   }
 
   const cleanup = async (): Promise<number> => {

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -5,6 +5,10 @@ export type CacheEntry = {
   value: CacheValue
   tags: string[]
   expiresAt: number | null
+  /**
+   * Wall-clock creation time. Informational/diagnostic only — LRU recency and
+   * eviction rely purely on Map insertion order, not on this field.
+   */
   createdAt: number
 }
 
@@ -77,6 +81,12 @@ export type CacheStrategy = {
   stats(): Promise<{
     size: number // Total number of entries
     expired: number // Number of expired entries
+    // Optional process-global counters surfaced by bounded strategies (memory)
+    // so operators can tell whether the LRU cap / sweep is actively protecting
+    // the process. Strategies that do not track them omit these fields.
+    evictions?: number // Entries dropped by LRU eviction since process start
+    sweeps?: number // Amortized expired-entry sweep passes run since process start
+    lastSweepReclaimed?: number // Entries reclaimed by the most recent sweep pass
   }>
 
   /**


### PR DESCRIPTION
Fixes #3070

## Problem
Follow-up to PR #2995 (bounded `createMemoryStrategy`). The issue tracks low-priority, non-blocking code-review nits on that work — none block merge; the bounded-cache behaviour and its coverage were already correct and green.

## What Changed
Addressed the clear-win findings:

- **#2 — Budgeted sweep.** The amortized expired-entry sweep no longer scans the whole store on the write that crosses the 256-write interval. It now scans up to `EXPIRED_SWEEP_MAX_SCAN` (1000) entries from the LRU head per pass, keeping it `O(budget)` instead of `O(store size)` and removing the periodic latency spike on a single `set()` for large, hot stores. Entries beyond the budget are still reclaimed on a later sweep, on access, by LRU eviction, or via `cleanup()`.
- **#6 — Observability.** `stats()` on the memory strategy now reports process-global `evictions`, `sweeps`, and `lastSweepReclaimed` counters so operators can tell whether the bound is actively protecting the process. These are **additive optional fields** on the `CacheStrategy.stats()` contract and are surfaced through the tenant-aware wrapper and `CacheService`. Non-memory backends omit them.
- **#1 — Missing test.** Added a service-layer test for the `CACHE_MEMORY_MAX_ENTRIES` env resolution path (bounds a memory-backed service; an invalid value is ignored and falls back to the default).
- **#4 — `createdAt`.** Documented as informational/diagnostic only (LRU recency relies on Map insertion order, not this field).
- **#7 — Docs.** Added a "Memory Strategy Bounds" section to `packages/cache/AGENTS.md` covering the LRU cap, `CACHE_MEMORY_MAX_ENTRIES`, the non-positive→unbounded escape hatch, the budgeted sweep, and the new counters.

### Deferred (per the issue's own "only if a real need appears" guidance)
- **#3** recency-on-read Map churn — mirrors the `rbacDefaultCache` precedent; revisit only if cache reads show up in a profile.
- **#5** env-tunable sweep interval — expose only if a concrete need appears.

## Tests
- New memory-strategy tests: budgeted sweep does not reclaim an over-budget expired cohort in a single pass; `lastSweepReclaimed`/`sweeps` update after a sweep; `evictions` counter increments on LRU eviction; idle counters report zero.
- New service tests: `CACHE_MEMORY_MAX_ENTRIES` bounds a memory service (eviction counter proves enforcement); invalid value ignored → unbounded default, no evictions.
- `yarn workspace @open-mercato/cache test` → 53 passed.
- `yarn typecheck` → 21/21 packages green.
- `yarn workspace @open-mercato/cache build` → clean.
- Note: one unrelated, pre-existing failure in `packages/ui` `format.test.ts` (`formatCurrency` is locale/`Intl`-dependent on the host) — outside this change's scope.

## Backward Compatibility
No contract surface broken. `stats()` return type gains **optional** fields only (additive); no fields removed, no signatures/event IDs/DI keys/import paths/API routes changed. The budgeted sweep changes an internal reclamation cadence, not any public behaviour (expired entries are still never returned).