### PR TITLE
Avoid duplicate runtime Next output layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,8 @@ COPY --from=builder /app/apps/mercato/tsconfig.json ./apps/mercato/
 COPY --from=builder /app/apps/mercato/postcss.config.mjs ./apps/mercato/
 
 # Copy generated files and other runtime necessities
-COPY --from=builder /app/apps/mercato/.mercato ./apps/mercato/.mercato
+COPY --from=builder /app/apps/mercato/.mercato/generated ./apps/mercato/.mercato/generated
+COPY --from=builder /app/apps/mercato/.mercato/queue ./apps/mercato/.mercato/queue
 COPY --from=builder /app/apps/mercato/src ./apps/mercato/src
 COPY --from=builder /app/apps/mercato/types ./apps/mercato/types
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,6 @@ COPY --from=builder /app/apps/mercato/postcss.config.mjs ./apps/mercato/
 
 # Copy generated files and other runtime necessities
 COPY --from=builder /app/apps/mercato/.mercato/generated ./apps/mercato/.mercato/generated
-COPY --from=builder /app/apps/mercato/.mercato/queue ./apps/mercato/.mercato/queue
 COPY --from=builder /app/apps/mercato/src ./apps/mercato/src
 COPY --from=builder /app/apps/mercato/types ./apps/mercato/types
 

--- a/scripts/__tests__/dockerfile-runtime-copy.test.mjs
+++ b/scripts/__tests__/dockerfile-runtime-copy.test.mjs
@@ -13,10 +13,6 @@ test('production Dockerfile avoids duplicating the generated Next output layer',
     dockerfile,
     /COPY --from=builder \/app\/apps\/mercato\/\.mercato\/generated \.\/apps\/mercato\/\.mercato\/generated/,
   )
-  assert.match(
-    dockerfile,
-    /COPY --from=builder \/app\/apps\/mercato\/\.mercato\/queue \.\/apps\/mercato\/\.mercato\/queue/,
-  )
   assert.doesNotMatch(
     dockerfile,
     /COPY --from=builder \/app\/apps\/mercato\/\.mercato \.\/apps\/mercato\/\.mercato/,

--- a/scripts/__tests__/dockerfile-runtime-copy.test.mjs
+++ b/scripts/__tests__/dockerfile-runtime-copy.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+
+test('production Dockerfile avoids duplicating the generated Next output layer', async () => {
+  const dockerfile = await readFile(new URL('../../Dockerfile', import.meta.url), 'utf8')
+
+  assert.match(
+    dockerfile,
+    /COPY --from=builder \/app\/apps\/mercato\/\.mercato\/next \.\/apps\/mercato\/\.mercato\/next/,
+  )
+  assert.match(
+    dockerfile,
+    /COPY --from=builder \/app\/apps\/mercato\/\.mercato\/generated \.\/apps\/mercato\/\.mercato\/generated/,
+  )
+  assert.match(
+    dockerfile,
+    /COPY --from=builder \/app\/apps\/mercato\/\.mercato\/queue \.\/apps\/mercato\/\.mercato\/queue/,
+  )
+  assert.doesNotMatch(
+    dockerfile,
+    /COPY --from=builder \/app\/apps\/mercato\/\.mercato \.\/apps\/mercato\/\.mercato/,
+  )
+})


### PR DESCRIPTION
## Summary
- copy only `.mercato/generated` after the standalone Next output instead of copying the full `.mercato` directory into the runtime image
- add a small Dockerfile guard test so the duplicated runtime layer does not regress

## Why
The runtime image already copies `apps/mercato/.mercato/next`. Copying the full `.mercato` directory afterwards duplicates the largest build output and can make Docker layer export/unpack much slower on deployment hosts.

## Checks
- `node --test scripts/__tests__/dockerfile-runtime-copy.test.mjs`
- `docker build --check .`