### PR TITLE
fix(events,onboarding): default-on single-delivery with worker guard; stop onboarding waiting on inline reindex

### DIFF
--- a/packages/cli/src/__tests__/mercato.test.ts
+++ b/packages/cli/src/__tests__/mercato.test.ts
@@ -642,6 +642,8 @@ describe('server dev managed process exits', () => {
   const originalLazy = process.env.OM_AUTO_SPAWN_WORKERS_LAZY
   const originalLazyScheduler = process.env.OM_AUTO_SPAWN_SCHEDULER_LAZY
   const originalGenerateWatchMode = process.env.OM_DEV_GENERATE_WATCH_MODE
+  const originalSingleDelivery = process.env.OM_EVENTS_SINGLE_DELIVERY
+  const originalExternalWorker = process.env.OM_EVENTS_EXTERNAL_WORKER
 
   beforeEach(() => {
     jest.restoreAllMocks()
@@ -650,6 +652,12 @@ describe('server dev managed process exits', () => {
     process.env.AUTO_SPAWN_WORKERS = 'true'
     delete process.env.OM_AUTO_SPAWN_WORKERS_LAZY
     delete process.env.OM_AUTO_SPAWN_SCHEDULER_LAZY
+    // These tests toggle AUTO_SPAWN_WORKERS to exercise scheduler/Next exits, not
+    // the events single-delivery guard. Acknowledge an external events worker so
+    // the (default-on) guard stays quiet, and start each test from a clean
+    // single-delivery env since the guard rewrites it in place.
+    delete process.env.OM_EVENTS_SINGLE_DELIVERY
+    process.env.OM_EVENTS_EXTERNAL_WORKER = 'true'
     // These tests stub the resolver to an empty object; the in-process
     // generate watcher's default checksum function would error on the
     // missing methods. Force the legacy out-of-process mode so the
@@ -680,6 +688,10 @@ describe('server dev managed process exits', () => {
     else process.env.OM_AUTO_SPAWN_WORKERS_LAZY = originalLazy
     if (originalLazyScheduler === undefined) delete process.env.OM_AUTO_SPAWN_SCHEDULER_LAZY
     else process.env.OM_AUTO_SPAWN_SCHEDULER_LAZY = originalLazyScheduler
+    if (originalSingleDelivery === undefined) delete process.env.OM_EVENTS_SINGLE_DELIVERY
+    else process.env.OM_EVENTS_SINGLE_DELIVERY = originalSingleDelivery
+    if (originalExternalWorker === undefined) delete process.env.OM_EVENTS_EXTERNAL_WORKER
+    else process.env.OM_EVENTS_EXTERNAL_WORKER = originalExternalWorker
   })
 
   it('skips scheduler auto-start when the module is not enabled', async () => {
@@ -909,6 +921,8 @@ describe('server start managed process exits', () => {
   const originalAutoSpawnWorkers = process.env.AUTO_SPAWN_WORKERS
   const originalLazy = process.env.OM_AUTO_SPAWN_WORKERS_LAZY
   const originalLazyScheduler = process.env.OM_AUTO_SPAWN_SCHEDULER_LAZY
+  const originalSingleDelivery = process.env.OM_EVENTS_SINGLE_DELIVERY
+  const originalExternalWorker = process.env.OM_EVENTS_EXTERNAL_WORKER
 
   beforeEach(() => {
     jest.restoreAllMocks()
@@ -917,6 +931,11 @@ describe('server start managed process exits', () => {
     process.env.AUTO_SPAWN_WORKERS = 'true'
     delete process.env.OM_AUTO_SPAWN_WORKERS_LAZY
     delete process.env.OM_AUTO_SPAWN_SCHEDULER_LAZY
+    // Not exercising the events single-delivery guard here — acknowledge an
+    // external worker so the default-on guard stays quiet, and reset the
+    // guard-rewritten single-delivery env between tests.
+    delete process.env.OM_EVENTS_SINGLE_DELIVERY
+    process.env.OM_EVENTS_EXTERNAL_WORKER = 'true'
   })
 
   afterEach(() => {
@@ -938,6 +957,10 @@ describe('server start managed process exits', () => {
     else process.env.OM_AUTO_SPAWN_WORKERS_LAZY = originalLazy
     if (originalLazyScheduler === undefined) delete process.env.OM_AUTO_SPAWN_SCHEDULER_LAZY
     else process.env.OM_AUTO_SPAWN_SCHEDULER_LAZY = originalLazyScheduler
+    if (originalSingleDelivery === undefined) delete process.env.OM_EVENTS_SINGLE_DELIVERY
+    else process.env.OM_EVENTS_SINGLE_DELIVERY = originalSingleDelivery
+    if (originalExternalWorker === undefined) delete process.env.OM_EVENTS_EXTERNAL_WORKER
+    else process.env.OM_EVENTS_EXTERNAL_WORKER = originalExternalWorker
   })
 
   it('skips scheduler auto-start when the module is not enabled', async () => {

--- a/packages/cli/src/lib/__tests__/events-single-delivery.test.ts
+++ b/packages/cli/src/lib/__tests__/events-single-delivery.test.ts
@@ -1,0 +1,68 @@
+import {
+  applyEventsSingleDeliveryGuard,
+  reconcileEventsSingleDelivery,
+} from '../events-single-delivery'
+
+describe('reconcileEventsSingleDelivery', () => {
+  it('keeps single-delivery on when workers auto-spawn (default request)', () => {
+    expect(reconcileEventsSingleDelivery({}, 'eager')).toEqual({ effective: true })
+    expect(reconcileEventsSingleDelivery({}, 'lazy')).toEqual({ effective: true })
+  })
+
+  it('falls back to inline dual-dispatch (with a warning) when no worker runs', () => {
+    const result = reconcileEventsSingleDelivery({}, 'off')
+    expect(result.effective).toBe(false)
+    expect(result.warning).toContain('OM_EVENTS_SINGLE_DELIVERY')
+    expect(result.warning).toContain('OM_EVENTS_EXTERNAL_WORKER')
+  })
+
+  it('keeps single-delivery on with no auto-spawn when an external worker is acknowledged', () => {
+    expect(
+      reconcileEventsSingleDelivery({ OM_EVENTS_EXTERNAL_WORKER: 'true' }, 'off'),
+    ).toEqual({ effective: true })
+  })
+
+  it('respects an explicit legacy opt-out regardless of worker availability', () => {
+    expect(
+      reconcileEventsSingleDelivery({ OM_EVENTS_SINGLE_DELIVERY: 'false' }, 'eager'),
+    ).toEqual({ effective: false })
+  })
+})
+
+describe('applyEventsSingleDeliveryGuard', () => {
+  it('writes the reconciled value into both process and runtime env', () => {
+    const processEnv: NodeJS.ProcessEnv = {}
+    const runtimeEnv: NodeJS.ProcessEnv = {}
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    const result = applyEventsSingleDeliveryGuard({
+      processEnv,
+      runtimeEnv,
+      autoSpawnWorkersMode: 'off',
+    })
+
+    expect(result.effective).toBe(false)
+    expect(processEnv.OM_EVENTS_SINGLE_DELIVERY).toBe('false')
+    expect(runtimeEnv.OM_EVENTS_SINGLE_DELIVERY).toBe('false')
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    errorSpy.mockRestore()
+  })
+
+  it('writes true (and stays quiet) when workers are available', () => {
+    const processEnv: NodeJS.ProcessEnv = {}
+    const runtimeEnv: NodeJS.ProcessEnv = {}
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    const result = applyEventsSingleDeliveryGuard({
+      processEnv,
+      runtimeEnv,
+      autoSpawnWorkersMode: 'eager',
+    })
+
+    expect(result.effective).toBe(true)
+    expect(processEnv.OM_EVENTS_SINGLE_DELIVERY).toBe('true')
+    expect(runtimeEnv.OM_EVENTS_SINGLE_DELIVERY).toBe('true')
+    expect(errorSpy).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+})

--- a/packages/cli/src/lib/events-single-delivery.ts
+++ b/packages/cli/src/lib/events-single-delivery.ts
@@ -1,0 +1,69 @@
+import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
+import type { AutoSpawnWorkersMode } from './auto-spawn-workers'
+
+// Keep these env names in sync with the runtime source of truth,
+// `@open-mercato/events/single-delivery`. The CLI cannot import the events
+// package (no dependency edge), so the reconcile logic is mirrored here for the
+// server-bootstrap guard only; the bus and worker own the runtime behavior.
+const EVENTS_SINGLE_DELIVERY_ENV = 'OM_EVENTS_SINGLE_DELIVERY'
+const EVENTS_EXTERNAL_WORKER_ENV = 'OM_EVENTS_EXTERNAL_WORKER'
+
+type EnvSource = NodeJS.ProcessEnv | Record<string, string | undefined>
+
+export type SingleDeliveryReconciliation = {
+  effective: boolean
+  warning?: string
+}
+
+/**
+ * Server-bootstrap guard for the default-on single-delivery dispatch.
+ *
+ * With single-delivery on, persistent subscribers are skipped inline and ONLY
+ * the events worker dispatches them. A process that runs NO events worker
+ * (auto-spawn off and no acknowledged external worker) would skip those
+ * subscribers with nothing to drain the queue — silently dropping notifications,
+ * queued emails, and indexing. This fails safe by disabling single-delivery for
+ * such a process (back to inline dual-dispatch) and returning a loud warning.
+ *
+ * Transient worker downtime is NOT this guard's concern: the durable queue holds
+ * the job until a worker returns. Only the "no worker at all" config is guarded.
+ */
+export function reconcileEventsSingleDelivery(
+  env: EnvSource,
+  autoSpawnWorkersMode: AutoSpawnWorkersMode,
+): SingleDeliveryReconciliation {
+  const requested = parseBooleanWithDefault(env[EVENTS_SINGLE_DELIVERY_ENV], true)
+  if (!requested) return { effective: false }
+  const externalWorker = parseBooleanWithDefault(env[EVENTS_EXTERNAL_WORKER_ENV], false)
+  const workersAvailable = autoSpawnWorkersMode !== 'off' || externalWorker
+  if (workersAvailable) return { effective: true }
+  return {
+    effective: false,
+    warning:
+      `[events] ${EVENTS_SINGLE_DELIVERY_ENV} is on (default) but this process auto-spawns no events worker ` +
+      `(AUTO_SPAWN_WORKERS=off) and ${EVENTS_EXTERNAL_WORKER_ENV} is not set. Persistent subscribers would be ` +
+      `skipped inline with nothing to drain the queue, silently dropping notifications, queued emails, and ` +
+      `indexing. Falling back to legacy inline dual-dispatch for safety. To keep single-delivery, run an events ` +
+      `worker (\`mercato queue worker events\`) and set ${EVENTS_EXTERNAL_WORKER_ENV}=true, or enable ` +
+      `AUTO_SPAWN_WORKERS.`,
+  }
+}
+
+/**
+ * Applies {@link reconcileEventsSingleDelivery} and writes the effective value
+ * into both the current process env (for the in-process app/bus) and the spawned
+ * worker/child env (so a child worker reads the same value the bus does). Logs
+ * the warning once when single-delivery is disabled for safety.
+ */
+export function applyEventsSingleDeliveryGuard(args: {
+  processEnv: NodeJS.ProcessEnv
+  runtimeEnv: NodeJS.ProcessEnv
+  autoSpawnWorkersMode: AutoSpawnWorkersMode
+}): SingleDeliveryReconciliation {
+  const result = reconcileEventsSingleDelivery(args.processEnv, args.autoSpawnWorkersMode)
+  if (result.warning) console.error(result.warning)
+  const value = result.effective ? 'true' : 'false'
+  args.processEnv[EVENTS_SINGLE_DELIVERY_ENV] = value
+  args.runtimeEnv[EVENTS_SINGLE_DELIVERY_ENV] = value
+  return result
+}

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -15,6 +15,7 @@ import {
   resolveLazyRestart,
 } from './lib/auto-spawn-workers'
 import { startLazyWorkerSupervisor } from './lib/queue-worker-supervisor'
+import { applyEventsSingleDeliveryGuard } from './lib/events-single-delivery'
 import { createPerJobWorkerHandler } from './lib/worker-job-handler'
 import {
   planWorkerConcurrency,
@@ -2061,6 +2062,12 @@ export async function run(argv = process.argv) {
               envReloader.reload()
               const runtimeEnv = buildServerProcessEnvironment(process.env)
               const autoSpawnWorkersMode = resolveAutoSpawnWorkersMode(process.env)
+              // Guard the default-on events single-delivery: if this process runs
+              // no events worker, fall back to safe inline dual-dispatch so
+              // persistent side effects are never silently dropped. Mutates both
+              // process.env (in-process bus) and runtimeEnv (spawned workers) so
+              // they agree.
+              applyEventsSingleDeliveryGuard({ processEnv: process.env, runtimeEnv, autoSpawnWorkersMode })
               const autoSpawnSchedulerMode = resolveAutoSpawnSchedulerMode(process.env)
               const queueStrategy = process.env.QUEUE_STRATEGY || 'local'
               const schedulerCommand = lookupModuleCommand(getCliModules(), 'scheduler', 'start')
@@ -2214,6 +2221,10 @@ export async function run(argv = process.argv) {
           const autoSpawnSchedulerMode = resolveAutoSpawnSchedulerMode(process.env)
           const queueStrategy = process.env.QUEUE_STRATEGY || 'local'
           const runtimeEnv = buildServerProcessEnvironment(process.env)
+          // Guard the default-on events single-delivery (see the dev `server`
+          // command): fall back to safe inline dual-dispatch when this process
+          // runs no events worker, keeping process.env and runtimeEnv in sync.
+          applyEventsSingleDeliveryGuard({ processEnv: process.env, runtimeEnv, autoSpawnWorkersMode })
           // Throws on single-instance strategies under a multi-instance topology,
           // aborting before the start lock is acquired or any process is spawned.
           assertSingleInstanceStrategies(runtimeEnv)

--- a/packages/core/src/modules/query_index/__tests__/api-queue-only.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/api-queue-only.test.ts
@@ -1,0 +1,74 @@
+const mockGetAuthFromRequest = jest.fn()
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+const mockCreateRequestContainer = jest.fn()
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => mockCreateRequestContainer(...args),
+}))
+
+const mockRecordIndexerLog = jest.fn(async () => undefined)
+jest.mock('@open-mercato/shared/lib/indexers/status-log', () => ({
+  recordIndexerLog: (...args: unknown[]) => mockRecordIndexerLog(...args),
+}))
+
+import { POST as reindexPost } from '../api/reindex'
+import { POST as purgePost } from '../api/purge'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/query_index', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+describe('query_index API persistent job dispatch', () => {
+  const emitEvent = jest.fn(async () => undefined)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      sub: 'user-1',
+    })
+    mockCreateRequestContainer.mockResolvedValue({
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return { em: true }
+        if (name === 'eventBus') return { emitEvent }
+        throw new Error(`Unexpected token: ${name}`)
+      }),
+    })
+  })
+
+  it('queues reindex without inline delivery', async () => {
+    const res = await reindexPost(makeRequest({ entityType: 'catalog:catalog_product' }))
+
+    expect(res.status).toBe(200)
+    expect(emitEvent).toHaveBeenCalledWith(
+      'query_index.reindex',
+      expect.objectContaining({
+        entityType: 'catalog:catalog_product',
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+      }),
+      { persistent: true, deliverInline: false },
+    )
+  })
+
+  it('queues purge without inline delivery', async () => {
+    const res = await purgePost(makeRequest({ entityType: 'catalog:catalog_product' }))
+
+    expect(res.status).toBe(200)
+    expect(emitEvent).toHaveBeenCalledWith(
+      'query_index.purge',
+      {
+        entityType: 'catalog:catalog_product',
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+      },
+      { persistent: true, deliverInline: false },
+    )
+  })
+})

--- a/packages/core/src/modules/query_index/__tests__/reindex-subscriber.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/reindex-subscriber.test.ts
@@ -1,0 +1,70 @@
+const mockRecordIndexerError = jest.fn(async () => undefined)
+const mockRecordIndexerLog = jest.fn(async () => undefined)
+const mockReindexEntity = jest.fn(async () => ({
+  processed: 0,
+  total: 0,
+  tenantScopes: [],
+  scopes: [],
+}))
+
+jest.mock('@open-mercato/shared/lib/indexers/error-log', () => ({
+  recordIndexerError: (...args: unknown[]) => mockRecordIndexerError(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/indexers/status-log', () => ({
+  recordIndexerLog: (...args: unknown[]) => mockRecordIndexerLog(...args),
+}))
+
+jest.mock('../lib/reindexer', () => ({
+  reindexEntity: (...args: unknown[]) => mockReindexEntity(...args),
+}))
+
+import handleReindex from '../subscribers/reindex'
+
+describe('query_index reindex subscriber', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('uses a fresh EntityManager fork for reindex work', async () => {
+    const forkedEm = { id: 'forked-em' }
+    const sourceEm = {
+      id: 'source-em',
+      fork: jest.fn(() => forkedEm),
+    }
+    const eventBus = { emitEvent: jest.fn(async () => undefined) }
+    const ctx = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return sourceEm
+        if (name === 'eventBus') return eventBus
+        throw new Error(`Unexpected token: ${name}`)
+      }),
+    }
+
+    await handleReindex({
+      entityType: 'checkout:checkout_transaction',
+      tenantId: 'tenant-1',
+      organizationId: null,
+      force: true,
+    }, ctx)
+
+    expect(sourceEm.fork).toHaveBeenCalledWith({
+      clear: true,
+      freshEventManager: true,
+      useContext: false,
+    })
+    expect(mockReindexEntity).toHaveBeenCalledWith(forkedEm, expect.objectContaining({
+      entityType: 'checkout:checkout_transaction',
+      tenantId: 'tenant-1',
+      organizationId: null,
+    }))
+    expect(mockRecordIndexerLog).toHaveBeenCalledWith(
+      { em: forkedEm },
+      expect.objectContaining({
+        source: 'query_index',
+        handler: 'event:query_index.reindex',
+        message: 'Reindex started for checkout:checkout_transaction',
+      }),
+    )
+  })
+})

--- a/packages/core/src/modules/query_index/api/purge.ts
+++ b/packages/core/src/modules/query_index/api/purge.ts
@@ -34,7 +34,11 @@ export async function POST(req: Request) {
     },
   ).catch(() => undefined)
   try {
-    await bus.emitEvent('query_index.purge', { entityType, organizationId: auth.orgId, tenantId: auth.tenantId }, { persistent: true })
+    await bus.emitEvent(
+      'query_index.purge',
+      { entityType, organizationId: auth.orgId, tenantId: auth.tenantId },
+      { persistent: true, deliverInline: false },
+    )
     await recordIndexerLog(
       { em: em ?? undefined },
       {

--- a/packages/core/src/modules/query_index/api/reindex.ts
+++ b/packages/core/src/modules/query_index/api/reindex.ts
@@ -81,7 +81,7 @@ export async function POST(req: Request) {
         return bus.emitEvent(
           'query_index.reindex',
           payload,
-          { persistent: true },
+          { persistent: true, deliverInline: false },
         )
       }),
     )

--- a/packages/core/src/modules/query_index/components/QueryIndexesTable.tsx
+++ b/packages/core/src/modules/query_index/components/QueryIndexesTable.tsx
@@ -6,6 +6,7 @@ import { DataTable } from '@open-mercato/ui/backend/DataTable'
 import { RowActions } from '@open-mercato/ui/backend/RowActions'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { apiCallOrThrow, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
@@ -262,11 +263,12 @@ export default function QueryIndexesTable() {
           body: JSON.stringify(body),
         }, { errorMessage })
       } catch (err) {
-        console.error('query_index.table.trigger', err)
-        if (typeof window !== 'undefined') {
-          const message = err instanceof Error ? err.message : errorMessage
-          window.alert(message)
-        }
+        // Expected operational failures (e.g. a 503 when a search backend is not
+        // configured) — surface a flash toast, not an alert or an error-level
+        // stack dump that reads like an unhandled exception.
+        const message = err instanceof Error && err.message ? err.message : errorMessage
+        console.warn('[query_index] index action failed', message)
+        flash(message, 'error')
       }
       qc.invalidateQueries({ queryKey: ['query-index-status'] })
     },
@@ -297,11 +299,9 @@ export default function QueryIndexesTable() {
           }),
         }, { errorMessage })
       } catch (err) {
-        console.error('query_index.table.vectorAction', err)
-        if (typeof window !== 'undefined') {
-          const message = err instanceof Error ? err.message : errorMessage
-          window.alert(message)
-        }
+        const message = err instanceof Error && err.message ? err.message : errorMessage
+        console.warn('[query_index] vector action failed', message)
+        flash(message, 'error')
       }
       qc.invalidateQueries({ queryKey: ['query-index-status'] })
     },
@@ -332,11 +332,9 @@ export default function QueryIndexesTable() {
           }),
         }, { errorMessage })
       } catch (err) {
-        console.error('query_index.table.fulltextAction', err)
-        if (typeof window !== 'undefined') {
-          const message = err instanceof Error ? err.message : errorMessage
-          window.alert(message)
-        }
+        const message = err instanceof Error && err.message ? err.message : errorMessage
+        console.warn('[query_index] fulltext action failed', message)
+        flash(message, 'error')
       }
       qc.invalidateQueries({ queryKey: ['query-index-status'] })
     },

--- a/packages/core/src/modules/query_index/subscribers/reindex.ts
+++ b/packages/core/src/modules/query_index/subscribers/reindex.ts
@@ -8,8 +8,14 @@ import { resolveQueryIndexReindexScope } from '../lib/subscriber-scope'
 
 export const metadata = { event: 'query_index.reindex', persistent: true }
 
+function forkReindexEntityManager(em: EntityManager): EntityManager {
+  const fork = (em as unknown as { fork?: (options?: Record<string, unknown>) => EntityManager }).fork
+  if (typeof fork !== 'function') return em
+  return fork.call(em, { clear: true, freshEventManager: true, useContext: false })
+}
+
 export default async function handle(payload: any, ctx: { resolve: <T=any>(name: string) => T }) {
-  const em = ctx.resolve<EntityManager>('em')
+  const em = forkReindexEntityManager(ctx.resolve<EntityManager>('em'))
   const eventBus = ctx.resolve<any>('eventBus')
   let vectorService: VectorIndexService | null = null
   try {

--- a/packages/events/AGENTS.md
+++ b/packages/events/AGENTS.md
@@ -76,15 +76,18 @@ export default async function handler(payload, ctx) { /* ... */ }
 - When `QUEUE_STRATEGY=local`, persistent events process from `.mercato/queue/` (or `QUEUE_BASE_DIR`)
 - Ephemeral subscribers always run in-process regardless of queue strategy
 
-### Persistent delivery: legacy vs single-delivery (`OM_EVENTS_SINGLE_DELIVERY`)
+### Persistent delivery: single-delivery (`OM_EVENTS_SINGLE_DELIVERY`, default ON)
 
-By default (`OM_EVENTS_SINGLE_DELIVERY` unset/false) a persistent emit is delivered on **both** paths: inline to every matching in-memory subscriber **and** through the events worker (exact-match). This double-dispatches exact-match subscribers and never reaches wildcard (`event: '*'`) persistent subscribers in the worker.
+Single-delivery is the default. A persistent emit is delivered on exactly one path:
 
-Set `OM_EVENTS_SINGLE_DELIVERY=true` to make persistent delivery single-path:
-- the bus skips inline delivery of **persistent-marked** subscribers on a persistent emit (ephemeral subscribers still run inline);
-- the events worker dispatches **persistent** subscribers via `matchEventPattern`, so wildcard persistent subscribers are finally reached.
+- the bus skips inline delivery of **persistent-marked** subscribers on a persistent emit (ephemeral subscribers still run inline — read-your-writes paths like `query_index.upsert_one` are `persistent: false` and are unaffected);
+- the events worker dispatches **persistent** subscribers via `matchEventPattern`, so wildcard (`event: '*'`) persistent subscribers (workflow triggers, business-rules CRUD trigger, webhook outbound dispatch) are reached.
 
-Both halves are gated by the same flag and MUST move together. When enabling it, ensure the events worker runs (default `AUTO_SPAWN_WORKERS=true`) and validate under both `QUEUE_STRATEGY=local` and `=async` so no persistent subscriber is dropped. This is the "Ask First: changing persistent delivery semantics" gate — the flag defaults off to preserve today's behavior.
+This avoids the legacy dual-dispatch (set `OM_EVENTS_SINGLE_DELIVERY=false` to opt back in) where persistent emits ran inline **and** in the worker — double-running exact-match persistent subscribers (duplicate notifications/emails) and never reaching wildcard persistent subscribers in the worker. Both halves read the same env var and MUST agree within a process.
+
+**Worker guard (silent-loss protection).** With single-delivery on, persistent subscribers run ONLY in the worker. The server bootstrap (`mercato server`/`start`) reconciles the flag against worker availability: if a process auto-spawns no events worker (`AUTO_SPAWN_WORKERS=off`) and `OM_EVENTS_EXTERNAL_WORKER` is not set, it logs a loud warning and falls back to inline dual-dispatch so persistent side effects are never silently dropped. Run an events worker out-of-process and set `OM_EVENTS_EXTERNAL_WORKER=true` to keep single-delivery without auto-spawn. Transient worker downtime is not a concern — the durable queue holds jobs until a worker returns; the guard only catches the "no worker at all" misconfiguration. Reconcile logic: `reconcileSingleDelivery` in `@open-mercato/events/single-delivery` (mirrored for the CLI in `packages/cli/src/lib/events-single-delivery.ts`).
+
+**Enqueue-only emits.** Pass `{ persistent: true, deliverInline: false }` to hand a heavy persistent job (e.g. a full query-index rebuild) to the durable queue without ANY inline delivery, independent of the single-delivery flag. Only use it when every subscriber to the event is `persistent: true`. This is the "Ask First: changing persistent delivery semantics" surface — coordinate before altering these defaults.
 
 ## Queue Integration
 

--- a/packages/events/src/__tests__/single-delivery-reconcile.test.ts
+++ b/packages/events/src/__tests__/single-delivery-reconcile.test.ts
@@ -1,0 +1,44 @@
+import {
+  isSingleDeliveryRequested,
+  isExternalWorkerAcknowledged,
+  reconcileSingleDelivery,
+} from '@open-mercato/events/single-delivery'
+
+describe('isSingleDeliveryRequested', () => {
+  it('defaults ON when unset', () => {
+    expect(isSingleDeliveryRequested({})).toBe(true)
+  })
+
+  it('honors an explicit false token', () => {
+    expect(isSingleDeliveryRequested({ OM_EVENTS_SINGLE_DELIVERY: 'false' })).toBe(false)
+    expect(isSingleDeliveryRequested({ OM_EVENTS_SINGLE_DELIVERY: '0' })).toBe(false)
+  })
+})
+
+describe('isExternalWorkerAcknowledged', () => {
+  it('defaults off and reads truthy tokens', () => {
+    expect(isExternalWorkerAcknowledged({})).toBe(false)
+    expect(isExternalWorkerAcknowledged({ OM_EVENTS_EXTERNAL_WORKER: 'true' })).toBe(true)
+  })
+})
+
+describe('reconcileSingleDelivery', () => {
+  it('stays on when a worker is available', () => {
+    expect(reconcileSingleDelivery({ requested: true, workersAvailable: true })).toEqual({
+      effective: true,
+    })
+  })
+
+  it('falls back to inline with a warning when no worker is available', () => {
+    const result = reconcileSingleDelivery({ requested: true, workersAvailable: false })
+    expect(result.effective).toBe(false)
+    expect(result.warning).toContain('OM_EVENTS_SINGLE_DELIVERY')
+    expect(result.warning).toContain('OM_EVENTS_EXTERNAL_WORKER')
+  })
+
+  it('stays off (no warning) when not requested', () => {
+    expect(reconcileSingleDelivery({ requested: false, workersAvailable: false })).toEqual({
+      effective: false,
+    })
+  })
+})

--- a/packages/events/src/__tests__/single-delivery.test.ts
+++ b/packages/events/src/__tests__/single-delivery.test.ts
@@ -38,15 +38,31 @@ describe('Event bus single-delivery (OM_EVENTS_SINGLE_DELIVERY)', () => {
     return { id, event, persistent, handler: () => { sink.push(id) } }
   }
 
-  test('flag OFF (default): a persistent subscriber still runs inline on a persistent emit', async () => {
+  test('default (unset): a persistent subscriber is skipped inline (single-delivery is default-on)', async () => {
     delete process.env.OM_EVENTS_SINGLE_DELIVERY
+    const calls: string[] = []
+    const bus = createEventBus({ resolve: ((name: string) => name) as never })
+    bus.registerModuleSubscribers([
+      makeSub('persistent-sub', 'demo', true, calls),
+      makeSub('ephemeral-sub', 'demo', false, calls),
+    ])
+
+    await bus.emit('demo', { a: 1 }, { persistent: true })
+
+    // Default-on: the persistent subscriber is deferred to the worker; only the
+    // ephemeral subscriber runs inline.
+    expect(calls).toEqual(['ephemeral-sub'])
+  })
+
+  test('flag explicitly OFF (legacy opt-out): a persistent subscriber still runs inline', async () => {
+    process.env.OM_EVENTS_SINGLE_DELIVERY = 'false'
     const calls: string[] = []
     const bus = createEventBus({ resolve: ((name: string) => name) as never })
     bus.registerModuleSubscribers([makeSub('persistent-sub', 'demo', true, calls)])
 
     await bus.emit('demo', { a: 1 }, { persistent: true })
 
-    // Legacy dual-dispatch: inline delivery is preserved when the flag is off.
+    // Legacy dual-dispatch: inline delivery is preserved when explicitly opted out.
     expect(calls).toEqual(['persistent-sub'])
   })
 
@@ -91,5 +107,81 @@ describe('Event bus single-delivery (OM_EVENTS_SINGLE_DELIVERY)', () => {
     const list = JSON.parse(fs.readFileSync(queuePath, 'utf8'))
     expect(Array.isArray(list)).toBe(true)
     expect(list.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+/**
+ * Regression coverage for the onboarding stall: `enqueueQueryIndexRebuild` emits
+ * a persistent `query_index.reindex` with `deliverInline: false` so the heavy
+ * rebuild runs solely in the events worker, never inline in the onboarding
+ * request. A bare `{ persistent: true }` dual-dispatches and ran the reindex
+ * inline (reusing the request's committed em), which is exactly the bug.
+ */
+describe('Event bus enqueue-only persistent emit (deliverInline: false)', () => {
+  const origCwd = process.cwd()
+  const origFlag = process.env.OM_EVENTS_SINGLE_DELIVERY
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'events-enqueue-only-'))
+    process.chdir(tmp)
+    delete process.env.QUEUE_STRATEGY
+    delete process.env.EVENTS_STRATEGY
+    // Prove the skip is driven by deliverInline, not the single-delivery flag.
+    delete process.env.OM_EVENTS_SINGLE_DELIVERY
+  })
+
+  afterEach(() => {
+    process.chdir(origCwd)
+    if (origFlag === undefined) delete process.env.OM_EVENTS_SINGLE_DELIVERY
+    else process.env.OM_EVENTS_SINGLE_DELIVERY = origFlag
+    try { fs.rmSync(tmp, { recursive: true, force: true }) } catch {}
+  })
+
+  function pushHandler(id: string, event: string, persistent: boolean, sink: string[]): SubscriberDescriptor {
+    return { id, event, persistent, handler: () => { sink.push(id) } }
+  }
+
+  test('skips inline delivery of every subscriber but still enqueues for the worker', async () => {
+    const queuePath = path.join(path.resolve('.mercato/queue', 'events'), 'queue.json')
+    const calls: string[] = []
+    const bus = createEventBus({ resolve: ((name: string) => name) as never })
+    bus.registerModuleSubscribers([
+      pushHandler('persistent-sub', 'query_index.reindex', true, calls),
+      pushHandler('ephemeral-sub', 'query_index.reindex', false, calls),
+    ])
+
+    await bus.emit('query_index.reindex', { entityType: 'catalog:product' }, { persistent: true, deliverInline: false })
+
+    // Nothing ran inline — the worker is the sole dispatcher.
+    expect(calls).toEqual([])
+    const list = JSON.parse(fs.readFileSync(queuePath, 'utf8'))
+    expect(Array.isArray(list)).toBe(true)
+    expect(list.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test('deliverInline: false has no effect on a non-persistent emit', async () => {
+    const calls: string[] = []
+    const bus = createEventBus({ resolve: ((name: string) => name) as never })
+    bus.registerModuleSubscribers([pushHandler('sub', 'demo', false, calls)])
+
+    // Not persistent → nothing is enqueued, so inline is the only path and runs.
+    await bus.emit('demo', { a: 1 }, { deliverInline: false })
+
+    expect(calls).toEqual(['sub'])
+  })
+
+  test('deliverInline unset under legacy opt-out preserves inline dual-dispatch', async () => {
+    // Isolate the deliverInline default from the single-delivery default by
+    // explicitly opting out: a persistent emit with deliverInline unset still
+    // runs inline (legacy dual-dispatch).
+    process.env.OM_EVENTS_SINGLE_DELIVERY = 'false'
+    const calls: string[] = []
+    const bus = createEventBus({ resolve: ((name: string) => name) as never })
+    bus.registerModuleSubscribers([pushHandler('persistent-sub', 'demo', true, calls)])
+
+    await bus.emit('demo', { a: 1 }, { persistent: true })
+
+    expect(calls).toEqual(['persistent-sub'])
   })
 })

--- a/packages/events/src/bus.ts
+++ b/packages/events/src/bus.ts
@@ -1,6 +1,7 @@
 import { createQueue } from '@open-mercato/queue'
 import type { Queue } from '@open-mercato/queue'
 import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
+import { isSingleDeliveryRequested } from './single-delivery'
 import { matchEventPattern } from '@open-mercato/shared/lib/events/patterns'
 import { getRedisUrlOrThrow } from '@open-mercato/shared/lib/redis/connection'
 import { isBroadcastEvent } from '@open-mercato/shared/modules/events'
@@ -22,12 +23,13 @@ const EVENTS_QUEUE_NAME = 'events'
  * When enabled, a persistent emit delivers each subscriber on exactly one path:
  * persistent-marked subscribers are skipped inline (the events worker dispatches
  * them via pattern match, so wildcard persistent subscribers are reached), while
- * ephemeral subscribers keep running inline. Default off preserves the legacy
- * dual-dispatch behavior. Both this flag and the worker MUST agree, so the worker
- * reads the same env var.
+ * ephemeral subscribers keep running inline. Defaults ON; the server bootstrap
+ * reconciles the env against worker availability (and may rewrite it to `false`
+ * for a worker-less process). Both the bus and the events worker read the same
+ * (possibly reconciled) env var, so they always agree within a process.
  */
 function isSingleDeliveryEnabled(): boolean {
-  return parseBooleanWithDefault(process.env.OM_EVENTS_SINGLE_DELIVERY, false)
+  return isSingleDeliveryRequested()
 }
 
 type GlobalEventTap = (event: string, payload: EventPayload, options?: EmitOptions) => void | Promise<void>
@@ -259,8 +261,17 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
     // Deliver to in-memory handlers first. Under single-delivery, persistent
     // subscribers are skipped inline on a persistent emit because the events
     // worker will dispatch them from the queue.
-    const skipPersistentInline = Boolean(options?.persistent) && isSingleDeliveryEnabled()
-    await deliver(event, payload, options, skipPersistentInline)
+    //
+    // `deliverInline: false` on a persistent emit is enqueue-only: skip inline
+    // delivery entirely so a heavy persistent job runs solely in the events
+    // worker, off the caller's request path (the queued enqueue below still
+    // happens). Without this, a persistent emit dual-dispatches by default and
+    // runs the subscriber inline in the caller's request too.
+    const enqueueOnly = Boolean(options?.persistent) && options?.deliverInline === false
+    if (!enqueueOnly) {
+      const skipPersistentInline = Boolean(options?.persistent) && isSingleDeliveryEnabled()
+      await deliver(event, payload, options, skipPersistentInline)
+    }
 
     if (isBroadcastEvent(event) && hasTenantScope(payload)) {
       try {

--- a/packages/events/src/modules/events/workers/__tests__/events.worker.test.ts
+++ b/packages/events/src/modules/events/workers/__tests__/events.worker.test.ts
@@ -33,6 +33,19 @@ describe('Events Worker', () => {
   })
 
   describe('handle', () => {
+    // These tests exercise the legacy exact-match dispatch (the worker runs every
+    // matching subscriber, persistent or not). Single-delivery (now default-on)
+    // dispatches only persistent subscribers in the worker, so pin the legacy
+    // path here; single-delivery semantics are covered in the sibling describe.
+    const ORIG_SINGLE_DELIVERY = process.env.OM_EVENTS_SINGLE_DELIVERY
+    beforeEach(() => {
+      process.env.OM_EVENTS_SINGLE_DELIVERY = 'false'
+    })
+    afterEach(() => {
+      if (ORIG_SINGLE_DELIVERY === undefined) delete process.env.OM_EVENTS_SINGLE_DELIVERY
+      else process.env.OM_EVENTS_SINGLE_DELIVERY = ORIG_SINGLE_DELIVERY
+    })
+
     const createMockJob = (
       event: string,
       payload: unknown,
@@ -486,8 +499,27 @@ describe('Events Worker', () => {
       expect(calls).toEqual(['p'])
     })
 
-    it('flag OFF (default): preserves legacy exact-match dispatch and never reaches wildcards', async () => {
+    it('default (unset): dispatches wildcard persistent subscribers (single-delivery is default-on)', async () => {
       delete process.env.OM_EVENTS_SINGLE_DELIVERY
+      clearListenerCache()
+      const calls: string[] = []
+      registerCliModules([{
+        id: 'm',
+        subscribers: [
+          { id: 'p', event: 'user.created', persistent: true, handler: () => { calls.push('p') } },
+          { id: 'w', event: '*', persistent: true, handler: () => { calls.push('w') } },
+        ],
+      }])
+
+      await handle(createMockJob('user.created', {}), createMockContext())
+
+      // Default-on: pattern dispatch reaches both the exact-match and the wildcard
+      // persistent subscriber.
+      expect(calls.sort()).toEqual(['p', 'w'])
+    })
+
+    it('flag explicitly OFF (legacy opt-out): preserves exact-match dispatch and never reaches wildcards', async () => {
+      process.env.OM_EVENTS_SINGLE_DELIVERY = 'false'
       clearListenerCache()
       const calls: string[] = []
       registerCliModules([{

--- a/packages/events/src/modules/events/workers/events.worker.ts
+++ b/packages/events/src/modules/events/workers/events.worker.ts
@@ -1,7 +1,7 @@
 import type { QueuedJob, JobContext, WorkerMeta } from '@open-mercato/queue'
 import { getCliModules } from '@open-mercato/shared/modules/registry'
 import { matchEventPattern } from '@open-mercato/shared/lib/events/patterns'
-import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
+import { isSingleDeliveryRequested } from '../../../single-delivery'
 
 export const EVENTS_QUEUE_NAME = 'events'
 
@@ -38,11 +38,12 @@ type SubscriberEntry = {
 /**
  * Mirror of the event bus single-delivery flag. When enabled, the worker owns
  * dispatch of every persistent subscriber and matches by pattern so wildcard
- * (`event: '*'`) persistent subscribers are finally reached. Default off keeps
- * the legacy exact-match dispatch of all subscribers.
+ * (`event: '*'`) persistent subscribers are finally reached. Defaults ON;
+ * reconciled by the server bootstrap against worker availability and read from
+ * the same env var as the bus so the two always agree within a process.
  */
 function isSingleDeliveryEnabled(): boolean {
-  return parseBooleanWithDefault(process.env.OM_EVENTS_SINGLE_DELIVERY, false)
+  return isSingleDeliveryRequested()
 }
 
 /**

--- a/packages/events/src/single-delivery.ts
+++ b/packages/events/src/single-delivery.ts
@@ -1,0 +1,75 @@
+import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
+
+/** Env var that toggles single-path persistent delivery. Defaults ON (see below). */
+export const EVENTS_SINGLE_DELIVERY_ENV = 'OM_EVENTS_SINGLE_DELIVERY'
+/**
+ * Operator acknowledgment that an events worker runs OUT OF PROCESS (separate
+ * `mercato queue worker` container/process), so the server bootstrap must not
+ * disable single-delivery just because it does not auto-spawn workers itself.
+ */
+export const EVENTS_EXTERNAL_WORKER_ENV = 'OM_EVENTS_EXTERNAL_WORKER'
+
+type EnvSource = Record<string, string | undefined>
+
+/**
+ * Whether single-path persistent delivery is requested.
+ *
+ * Default ON: a persistent emit is delivered on exactly one path — persistent
+ * subscribers run in the events worker (matched by pattern, so wildcard
+ * persistent subscribers are reached), ephemeral subscribers still run inline.
+ * This is the correct behavior; the legacy dual-dispatch (inline AND worker)
+ * double-ran exact-match persistent subscribers and never reached wildcard
+ * persistent subscribers in the worker. Set the env to a false token to opt back
+ * into legacy dual-dispatch.
+ *
+ * The server bootstrap reconciles this against worker availability (see
+ * {@link reconcileSingleDelivery}) and may rewrite the env to `false` for a
+ * process that would otherwise skip inline delivery with no worker to drain the
+ * queue. The bus and the events worker both read the (possibly reconciled) env,
+ * so they always agree within a process.
+ */
+export function isSingleDeliveryRequested(env: EnvSource = process.env): boolean {
+  return parseBooleanWithDefault(env[EVENTS_SINGLE_DELIVERY_ENV], true)
+}
+
+export function isExternalWorkerAcknowledged(env: EnvSource = process.env): boolean {
+  return parseBooleanWithDefault(env[EVENTS_EXTERNAL_WORKER_ENV], false)
+}
+
+export type SingleDeliveryReconciliation = {
+  /** The value the process should actually use. */
+  effective: boolean
+  /** Set when single-delivery was requested but disabled for safety. */
+  warning?: string
+}
+
+/**
+ * Guards the default-on single-delivery against the silent-loss failure mode:
+ * with single-delivery on, persistent subscribers are skipped inline and ONLY
+ * the events worker dispatches them. If no worker drains the queue, those
+ * persistent side effects (notifications, queued emails, indexing) never run.
+ *
+ * The durable queue already covers transient worker downtime — a job persists
+ * and drains when a worker returns. The dangerous case is a process configured
+ * to run with NO events worker at all (auto-spawn off and no external worker).
+ * For that case this fails safe: it disables single-delivery so persistent
+ * subscribers run inline (dual-dispatch) and side effects are never dropped,
+ * and surfaces a loud warning telling the operator how to opt back in.
+ */
+export function reconcileSingleDelivery(input: {
+  requested: boolean
+  workersAvailable: boolean
+}): SingleDeliveryReconciliation {
+  if (!input.requested) return { effective: false }
+  if (input.workersAvailable) return { effective: true }
+  return {
+    effective: false,
+    warning:
+      `[events] ${EVENTS_SINGLE_DELIVERY_ENV} is on (default) but this process auto-spawns no events worker ` +
+      `(AUTO_SPAWN_WORKERS=off) and ${EVENTS_EXTERNAL_WORKER_ENV} is not set. Persistent subscribers would be ` +
+      `skipped inline with nothing to drain the queue, silently dropping notifications, queued emails, and ` +
+      `indexing. Falling back to legacy inline dual-dispatch for safety. To keep single-delivery, run an events ` +
+      `worker (\`mercato queue worker events\`) and set ${EVENTS_EXTERNAL_WORKER_ENV}=true, or enable ` +
+      `AUTO_SPAWN_WORKERS.`,
+  }
+}

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -61,6 +61,19 @@ export type SubscriberDescriptor = {
 export type EmitOptions = {
   /** If true, the event will be persisted to a queue for async processing */
   persistent?: boolean
+  /**
+   * Controls inline in-memory delivery on a persistent emit. Defaults to `true`,
+   * which preserves the legacy dual-dispatch behavior (subscribers run inline AND
+   * the event is enqueued for the worker). Set to `false` to ENQUEUE-ONLY: inline
+   * delivery is skipped entirely and the events worker is the sole dispatcher.
+   *
+   * Use this to hand a heavy persistent job (e.g. a full query-index rebuild) to
+   * the durable queue without running it on the caller's request path. Has no
+   * effect unless `persistent: true`. Ephemeral subscribers to the event will not
+   * run inline either, so only use it for events whose subscribers are all
+   * worker-dispatched (`persistent: true`).
+   */
+  deliverInline?: boolean
   /** Trusted tenant scope for subscribers that must not rely on payload scope */
   tenantId?: string | null
   /** Trusted organization scope for subscribers that must not rely on payload scope */

--- a/packages/onboarding/src/__tests__/deferred-provisioning.test.ts
+++ b/packages/onboarding/src/__tests__/deferred-provisioning.test.ts
@@ -189,10 +189,14 @@ describe('runDeferredProvisioning single-flight claim', () => {
         tenantId: RUN_ARGS.tenantId,
         force: true,
       })
+      // deliverInline: false makes the persistent emit enqueue-only — the heavy
+      // reindex runs solely in the events worker, never inline in this request.
+      // A bare { persistent: true } would dual-dispatch and re-introduce the
+      // onboarding stall, so the exact options shape is asserted here.
       expect(emitEvent).toHaveBeenCalledWith(
         'query_index.reindex',
         expect.objectContaining({ entityType }),
-        { persistent: true },
+        { persistent: true, deliverInline: false },
       )
     }
     expect(markPreparationCompleted).toHaveBeenCalledTimes(1)

--- a/packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts
@@ -113,7 +113,11 @@ async function enqueueVectorReindex(args: {
 }
 
 type PersistentEventBus = {
-  emitEvent: (event: string, payload: unknown, options?: { persistent?: boolean }) => Promise<void>
+  emitEvent: (
+    event: string,
+    payload: unknown,
+    options?: { persistent?: boolean; deliverInline?: boolean },
+  ) => Promise<void>
 }
 
 async function enqueueQueryIndexRebuild(args: {
@@ -143,6 +147,13 @@ async function enqueueQueryIndexRebuild(args: {
   const entityIds = flattenSystemEntityIds(getEntityIds())
   for (const entityType of entityIds) {
     try {
+      // deliverInline: false is load-bearing here. A bare `{ persistent: true }`
+      // emit dual-dispatches: the events worker drains the queued job AND the
+      // subscriber runs inline in THIS request — so the multi-minute force
+      // reindex of every system entity would still block onboarding (and reuse
+      // the request's already-committed em, spamming "Transaction is already
+      // committed" from the vector-purge status-log prune). Enqueue-only hands
+      // the rebuild to the worker and returns immediately.
       await eventBus.emitEvent(
         'query_index.reindex',
         {
@@ -150,7 +161,7 @@ async function enqueueQueryIndexRebuild(args: {
           tenantId: args.tenantId,
           force: true,
         },
-        { persistent: true },
+        { persistent: true, deliverInline: false },
       )
     } catch (error) {
       console.error('[onboarding.verify] failed to enqueue query index rebuild', {

--- a/packages/search/src/__tests__/workers.test.ts
+++ b/packages/search/src/__tests__/workers.test.ts
@@ -14,8 +14,7 @@ jest.mock('@open-mercato/shared/lib/indexers/status-log', () => ({
 }))
 
 jest.mock('@open-mercato/core/modules/query_index/lib/coverage', () => ({
-  applyCoverageAdjustments: jest.fn().mockResolvedValue(undefined),
-  createCoverageAdjustments: jest.fn().mockReturnValue([]),
+  refreshCoverageSnapshot: jest.fn().mockResolvedValue(undefined),
 }))
 
 jest.mock('../vector/lib/vector-logs', () => ({
@@ -36,13 +35,15 @@ jest.mock('../modules/search/lib/reindex-lock', () => ({
 }))
 
 jest.mock('../modules/search/lib/reindex-progress', () => ({
+  hasActiveReindexProgress: jest.fn().mockResolvedValue(true),
   incrementReindexProgress: jest.fn().mockResolvedValue(true),
 }))
 
 import { handleVectorIndexJob } from '../modules/search/workers/vector-index.worker'
 import { handleFulltextIndexJob } from '../modules/search/workers/fulltext-index.worker'
 import { updateReindexProgress, clearReindexLock } from '../modules/search/lib/reindex-lock'
-import { incrementReindexProgress } from '../modules/search/lib/reindex-progress'
+import { hasActiveReindexProgress, incrementReindexProgress } from '../modules/search/lib/reindex-progress'
+import { refreshCoverageSnapshot } from '@open-mercato/core/modules/query_index/lib/coverage'
 
 /**
  * Create a mock job context
@@ -104,6 +105,7 @@ describe('Vector Index Worker', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    ;(hasActiveReindexProgress as jest.Mock).mockResolvedValue(true)
     mockEmbeddingService.available = true
     mockEmbeddingService.dimension = 1536
     mockEmbeddingService.createEmbedding.mockResolvedValue([0.1, 0.2, 0.3])
@@ -143,6 +145,39 @@ describe('Vector Index Worker', () => {
       tenantId: 'tenant-123',
       organizationId: 'org-456',
     })
+  })
+
+  it('refreshes vector coverage from storage after indexing instead of incrementing it blindly', async () => {
+    const mockEventBus = { emitEvent: jest.fn().mockResolvedValue(undefined) }
+    const containerWithEventBus: HandlerContext = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'searchIndexer') return mockSearchIndexer
+        if (name === 'em') return null
+        if (name === 'eventBus') return mockEventBus
+        if (name === 'vectorEmbeddingService') return mockEmbeddingService
+        if (name === 'vectorDrivers') return [mockPgvectorDriver]
+        throw new Error(`Unknown service: ${name}`)
+      }) as HandlerContext['resolve'],
+    }
+    const job = createMockJob<VectorIndexJobPayload>({
+      jobType: 'index',
+      entityType: 'customers:customer_person_profile',
+      recordId: 'rec-123',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+    })
+
+    await handleVectorIndexJob(job, createMockJobContext(), containerWithEventBus)
+
+    expect(mockSearchIndexer.indexRecordById).toHaveBeenCalledTimes(1)
+    expect(mockEventBus.emitEvent).toHaveBeenCalledWith('query_index.coverage.refresh', {
+      entityType: 'customers:customer_person_profile',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      withDeleted: false,
+      delayMs: 1000,
+    })
+    expect(refreshCoverageSnapshot).not.toHaveBeenCalled()
   })
 
   it('should delete record when jobType is delete', async () => {
@@ -266,6 +301,75 @@ describe('Vector Index Worker', () => {
     warnSpy.mockRestore()
   })
 
+  it('counts handled-but-skipped batch records as processed so progress can complete', async () => {
+    mockSearchIndexer.indexRecordById
+      .mockResolvedValueOnce({ action: 'skipped' })
+      .mockResolvedValueOnce({ action: 'skipped' })
+    const mockDb = { kysely: true }
+    const mockBatchEm = { getKysely: () => mockDb }
+    const containerWithProgress: HandlerContext = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'searchIndexer') return mockSearchIndexer
+        if (name === 'em') return mockBatchEm
+        if (name === 'progressService') return { id: 'progress' }
+        if (name === 'vectorEmbeddingService') return mockEmbeddingService
+        if (name === 'vectorDrivers') return [mockPgvectorDriver]
+        throw new Error(`Unknown service: ${name}`)
+      }) as HandlerContext['resolve'],
+    }
+    const job = createMockJob<VectorIndexJobPayload>({
+      jobType: 'batch-index',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      records: [
+        { entityId: 'test:entity', recordId: 'rec-1' },
+        { entityId: 'test:entity', recordId: 'rec-2' },
+      ],
+    })
+
+    await handleVectorIndexJob(job, createMockJobContext(), containerWithProgress)
+
+    expect(mockSearchIndexer.indexRecordById).toHaveBeenCalledTimes(2)
+    expect(updateReindexProgress).toHaveBeenCalledWith(mockDb, 'tenant-123', 'vector', 2, 'org-456')
+    expect(incrementReindexProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'vector', tenantId: 'tenant-123', delta: 2 }),
+    )
+    expect(clearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'vector', 'org-456')
+    expect(refreshCoverageSnapshot).toHaveBeenCalledWith(mockBatchEm, expect.objectContaining({
+      entityType: 'test:entity',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+    }))
+  })
+
+  it('clears an orphaned reindex lock instead of recreating it when no progress job is active', async () => {
+    ;(hasActiveReindexProgress as jest.Mock).mockResolvedValueOnce(false)
+    const mockDb = { kysely: true }
+    const containerWithProgress: HandlerContext = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'searchIndexer') return mockSearchIndexer
+        if (name === 'em') return { getKysely: () => mockDb }
+        if (name === 'progressService') return { id: 'progress' }
+        if (name === 'vectorEmbeddingService') return mockEmbeddingService
+        if (name === 'vectorDrivers') return [mockPgvectorDriver]
+        throw new Error(`Unknown service: ${name}`)
+      }) as HandlerContext['resolve'],
+    }
+    const job = createMockJob<VectorIndexJobPayload>({
+      jobType: 'batch-index',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      records: [{ entityId: 'test:entity', recordId: 'rec-1' }],
+    })
+
+    await handleVectorIndexJob(job, createMockJobContext(), containerWithProgress)
+
+    expect(mockSearchIndexer.indexRecordById).toHaveBeenCalledTimes(1)
+    expect(updateReindexProgress).not.toHaveBeenCalled()
+    expect(incrementReindexProgress).not.toHaveBeenCalled()
+    expect(clearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'vector', 'org-456')
+  })
+
   it('should skip a single-record index on dimension mismatch without indexing or embedding', async () => {
     mockTableDimension = 768
     mockEmbeddingService.dimension = 1536
@@ -352,6 +456,9 @@ describe('Fulltext Index Worker', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    ;(hasActiveReindexProgress as jest.Mock).mockResolvedValue(true)
+    mockFulltextStrategy.isAvailable.mockResolvedValue(true)
+    mockSearchIndexer.indexRecordById.mockResolvedValue({ action: 'indexed', created: true })
   })
 
   it('should skip job with missing tenantId', async () => {
@@ -396,6 +503,67 @@ describe('Fulltext Index Worker', () => {
       tenantId: 'tenant-123',
       organizationId: undefined,
     })
+  })
+
+  it('counts handled fulltext batch records as processed so progress can complete', async () => {
+    mockSearchIndexer.indexRecordById
+      .mockResolvedValueOnce({ action: 'skipped' })
+      .mockResolvedValueOnce({ action: 'skipped' })
+    const records = [
+      { entityId: 'test:entity', recordId: 'rec-1' },
+      { entityId: 'test:entity', recordId: 'rec-2' },
+    ]
+    const containerWithProgress: HandlerContext = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'searchStrategies') return [mockFulltextStrategy]
+        if (name === 'em') return mockEm
+        if (name === 'searchIndexer') return mockSearchIndexer
+        if (name === 'progressService') return { id: 'progress' }
+        throw new Error(`Unknown service: ${name}`)
+      }) as HandlerContext['resolve'],
+    }
+    const job = createMockJob<FulltextIndexJobPayload>({
+      jobType: 'batch-index',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      records,
+    })
+
+    await handleFulltextIndexJob(job, createMockJobContext(), containerWithProgress)
+
+    expect(mockSearchIndexer.indexRecordById).toHaveBeenCalledTimes(2)
+    expect(updateReindexProgress).toHaveBeenCalledWith(mockDb, 'tenant-123', 'fulltext', 2, 'org-456')
+    expect(incrementReindexProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'fulltext', tenantId: 'tenant-123', delta: 2 }),
+    )
+    expect(clearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'fulltext', 'org-456')
+  })
+
+  it('clears an orphaned fulltext reindex lock instead of recreating it when no progress job is active', async () => {
+    ;(hasActiveReindexProgress as jest.Mock).mockResolvedValueOnce(false)
+    const records = [{ entityId: 'test:entity', recordId: 'rec-1' }]
+    const containerWithProgress: HandlerContext = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'searchStrategies') return [mockFulltextStrategy]
+        if (name === 'em') return mockEm
+        if (name === 'searchIndexer') return mockSearchIndexer
+        if (name === 'progressService') return { id: 'progress' }
+        throw new Error(`Unknown service: ${name}`)
+      }) as HandlerContext['resolve'],
+    }
+    const job = createMockJob<FulltextIndexJobPayload>({
+      jobType: 'batch-index',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      records,
+    })
+
+    await handleFulltextIndexJob(job, createMockJobContext(), containerWithProgress)
+
+    expect(mockSearchIndexer.indexRecordById).toHaveBeenCalledTimes(1)
+    expect(updateReindexProgress).not.toHaveBeenCalled()
+    expect(incrementReindexProgress).not.toHaveBeenCalled()
+    expect(clearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'fulltext', 'org-456')
   })
 
   it('should skip batch-index with empty records', async () => {

--- a/packages/search/src/modules/search/api/__tests__/embeddings-reindex.routes.test.ts
+++ b/packages/search/src/modules/search/api/__tests__/embeddings-reindex.routes.test.ts
@@ -1,0 +1,130 @@
+const mockGetAuthFromRequest = jest.fn()
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+const mockCreateRequestContainer = jest.fn()
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => mockCreateRequestContainer(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+jest.mock('../../lib/embedding-config', () => ({
+  resolveEmbeddingConfig: jest.fn().mockResolvedValue(null),
+}))
+
+const mockRecordIndexerLog = jest.fn().mockResolvedValue(undefined)
+jest.mock('@open-mercato/shared/lib/indexers/status-log', () => ({
+  recordIndexerLog: (...args: unknown[]) => mockRecordIndexerLog(...args),
+}))
+
+const mockGetReindexLockStatus = jest.fn().mockResolvedValue(null)
+const mockAcquireReindexLock = jest.fn().mockResolvedValue({ acquired: true })
+const mockClearReindexLock = jest.fn().mockResolvedValue(undefined)
+jest.mock('../../lib/reindex-lock', () => ({
+  getReindexLockStatus: (...args: unknown[]) => mockGetReindexLockStatus(...args),
+  acquireReindexLock: (...args: unknown[]) => mockAcquireReindexLock(...args),
+  clearReindexLock: (...args: unknown[]) => mockClearReindexLock(...args),
+}))
+
+const mockEnsureReindexProgressJob = jest.fn().mockResolvedValue('progress-1')
+const mockCompleteReindexProgress = jest.fn().mockResolvedValue(undefined)
+const mockFailReindexProgress = jest.fn().mockResolvedValue(undefined)
+jest.mock('../../lib/reindex-progress', () => ({
+  ensureReindexProgressJob: (...args: unknown[]) => mockEnsureReindexProgressJob(...args),
+  completeReindexProgress: (...args: unknown[]) => mockCompleteReindexProgress(...args),
+  failReindexProgress: (...args: unknown[]) => mockFailReindexProgress(...args),
+}))
+
+import { POST as vectorReindexPost } from '../embeddings/reindex/route'
+
+describe('POST /api/search/embeddings/reindex', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetReindexLockStatus.mockResolvedValue(null)
+    mockAcquireReindexLock.mockResolvedValue({ acquired: true })
+  })
+
+  test('finishes progress and clears the lock when no vector jobs are queued', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({
+      tenantId: 'tenant-123',
+      orgId: 'org-456',
+      sub: 'user-789',
+    })
+
+    const mockDb = { db: true }
+    const mockEm = { getKysely: jest.fn(() => mockDb) }
+    const mockProgressService = { progress: true }
+    const mockSearchIndexer = {
+      reindexEntityToVector: jest.fn().mockResolvedValue({
+        success: true,
+        entitiesProcessed: 1,
+        recordsIndexed: 0,
+        recordsDropped: 0,
+        jobsEnqueued: 0,
+        errors: [],
+      }),
+    }
+    const mockContainer = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return mockEm
+        if (name === 'progressService') return mockProgressService
+        if (name === 'searchIndexer') return mockSearchIndexer
+        throw new Error(`Unknown service: ${name}`)
+      }),
+      dispose: jest.fn().mockResolvedValue(undefined),
+    }
+    mockCreateRequestContainer.mockResolvedValue(mockContainer)
+
+    const req = new Request('http://localhost/api/search/embeddings/reindex', {
+      method: 'POST',
+      body: JSON.stringify({ entityId: 'catalog:catalog_product_variant' }),
+    })
+
+    const res = await vectorReindexPost(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual(expect.objectContaining({
+      ok: true,
+      recordsIndexed: 0,
+      jobsEnqueued: 0,
+      entitiesProcessed: 1,
+    }))
+    expect(mockSearchIndexer.reindexEntityToVector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityId: 'catalog:catalog_product_variant',
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+        useQueue: true,
+      }),
+    )
+    expect(mockEnsureReindexProgressJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totalCount: 0,
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+      }),
+    )
+    expect(mockCompleteReindexProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+        resultSummary: expect.objectContaining({
+          entitiesProcessed: 1,
+          recordsIndexed: 0,
+          jobsEnqueued: 0,
+          errors: 0,
+        }),
+      }),
+    )
+    expect(mockFailReindexProgress).not.toHaveBeenCalled()
+    expect(mockClearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'vector', 'org-456')
+    expect(mockContainer.dispose).toHaveBeenCalled()
+  })
+})

--- a/packages/search/src/modules/search/api/__tests__/reindex.routes.test.ts
+++ b/packages/search/src/modules/search/api/__tests__/reindex.routes.test.ts
@@ -1,0 +1,165 @@
+const mockGetAuthFromRequest = jest.fn()
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+const mockCreateRequestContainer = jest.fn()
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => mockCreateRequestContainer(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+const mockRecordIndexerLog = jest.fn().mockResolvedValue(undefined)
+const mockRecordIndexerError = jest.fn().mockResolvedValue(undefined)
+jest.mock('@open-mercato/shared/lib/indexers/status-log', () => ({
+  recordIndexerLog: (...args: unknown[]) => mockRecordIndexerLog(...args),
+}))
+jest.mock('@open-mercato/shared/lib/indexers/error-log', () => ({
+  recordIndexerError: (...args: unknown[]) => mockRecordIndexerError(...args),
+}))
+
+const mockGetReindexLockStatus = jest.fn().mockResolvedValue(null)
+const mockAcquireReindexLock = jest.fn().mockResolvedValue({ acquired: true })
+const mockClearReindexLock = jest.fn().mockResolvedValue(undefined)
+jest.mock('../../lib/reindex-lock', () => ({
+  getReindexLockStatus: (...args: unknown[]) => mockGetReindexLockStatus(...args),
+  acquireReindexLock: (...args: unknown[]) => mockAcquireReindexLock(...args),
+  clearReindexLock: (...args: unknown[]) => mockClearReindexLock(...args),
+}))
+
+const mockEnsureReindexProgressJob = jest.fn().mockResolvedValue('progress-1')
+const mockCompleteReindexProgress = jest.fn().mockResolvedValue(undefined)
+const mockFailReindexProgress = jest.fn().mockResolvedValue(undefined)
+jest.mock('../../lib/reindex-progress', () => ({
+  ensureReindexProgressJob: (...args: unknown[]) => mockEnsureReindexProgressJob(...args),
+  completeReindexProgress: (...args: unknown[]) => mockCompleteReindexProgress(...args),
+  failReindexProgress: (...args: unknown[]) => mockFailReindexProgress(...args),
+}))
+
+import { POST as fulltextReindexPost } from '../reindex/route'
+
+function mockAuth() {
+  mockGetAuthFromRequest.mockResolvedValue({
+    tenantId: 'tenant-123',
+    orgId: 'org-456',
+    sub: 'user-789',
+  })
+}
+
+function makeRequest(body: Record<string, unknown> = {}) {
+  return new Request('http://localhost/api/search/reindex', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/search/reindex', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockAuth()
+    mockGetReindexLockStatus.mockResolvedValue(null)
+    mockAcquireReindexLock.mockResolvedValue({ acquired: true })
+  })
+
+  test('clears the fulltext lock when no indexable strategy is configured', async () => {
+    const mockDb = { db: true }
+    const mockEm = { getKysely: jest.fn(() => mockDb) }
+    const mockContainer = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return mockEm
+        if (name === 'progressService') return { progress: true }
+        if (name === 'searchStrategies') return []
+        throw new Error(`Unknown service: ${name}`)
+      }),
+      dispose: jest.fn().mockResolvedValue(undefined),
+    }
+    mockCreateRequestContainer.mockResolvedValue(mockContainer)
+
+    const res = await fulltextReindexPost(makeRequest({ action: 'reindex' }))
+    const body = await res.json()
+
+    expect(res.status).toBe(503)
+    expect(body.error).toBe('No indexable search strategy is configured')
+    expect(mockClearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'fulltext', 'org-456')
+    expect(mockContainer.dispose).toHaveBeenCalled()
+  })
+
+  test('finishes progress and clears the fulltext lock when queued reindex enqueues no jobs', async () => {
+    const mockDb = { db: true }
+    const mockEm = { getKysely: jest.fn(() => mockDb) }
+    const mockStrategy = {
+      id: 'fulltext',
+      isAvailable: jest.fn().mockResolvedValue(true),
+      recreateIndex: jest.fn().mockResolvedValue(undefined),
+    }
+    const mockSearchIndexer = {
+      listEnabledEntities: jest.fn(() => ['catalog:catalog_product']),
+      reindexEntityToFulltext: jest.fn().mockResolvedValue({
+        success: true,
+        recordsIndexed: 0,
+        jobsEnqueued: 0,
+        errors: [],
+      }),
+    }
+    const mockContainer = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return mockEm
+        if (name === 'progressService') return { progress: true }
+        if (name === 'searchStrategies') return [mockStrategy]
+        if (name === 'searchIndexer') return mockSearchIndexer
+        throw new Error(`Unknown service: ${name}`)
+      }),
+      dispose: jest.fn().mockResolvedValue(undefined),
+    }
+    mockCreateRequestContainer.mockResolvedValue(mockContainer)
+
+    const res = await fulltextReindexPost(makeRequest({
+      action: 'reindex',
+      entityId: 'catalog:catalog_product',
+    }))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual(expect.objectContaining({
+      ok: true,
+      action: 'reindex',
+      entityId: 'catalog:catalog_product',
+      useQueue: true,
+    }))
+    expect(mockSearchIndexer.reindexEntityToFulltext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityId: 'catalog:catalog_product',
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+        useQueue: true,
+      }),
+    )
+    expect(mockEnsureReindexProgressJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'fulltext',
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+        totalCount: 0,
+      }),
+    )
+    expect(mockCompleteReindexProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'fulltext',
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+        resultSummary: expect.objectContaining({
+          recordsIndexed: 0,
+          jobsEnqueued: 0,
+          errors: 0,
+        }),
+      }),
+    )
+    expect(mockClearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'fulltext', 'org-456')
+    expect(mockContainer.dispose).toHaveBeenCalled()
+  })
+})

--- a/packages/search/src/modules/search/api/embeddings/reindex/route.ts
+++ b/packages/search/src/modules/search/api/embeddings/reindex/route.ts
@@ -14,6 +14,7 @@ import type { EntityId } from '@open-mercato/shared/modules/entities'
 import { searchDebug, searchDebugWarn, searchError } from '../../../../../lib/debug'
 import { acquireReindexLock, clearReindexLock, getReindexLockStatus } from '../../../lib/reindex-lock'
 import {
+  completeReindexProgress,
   ensureReindexProgressJob,
   failReindexProgress,
 } from '../../../lib/reindex-progress'
@@ -164,6 +165,34 @@ export async function POST(req: Request) {
         ? `Vector reindex ${entityId} (queued)`
         : 'Vector reindex all entities (queued)',
     })
+
+    if ((result.jobsEnqueued ?? 0) === 0) {
+      if (result.success) {
+        await completeReindexProgress({
+          em,
+          progressService,
+          type: 'vector',
+          tenantId: auth.tenantId,
+          organizationId: auth.orgId ?? null,
+          resultSummary: {
+            entitiesProcessed: result.entitiesProcessed,
+            recordsIndexed: result.recordsIndexed,
+            jobsEnqueued: result.jobsEnqueued ?? 0,
+            errors: result.errors.length,
+          },
+        })
+      } else {
+        await failReindexProgress({
+          em,
+          progressService,
+          type: 'vector',
+          tenantId: auth.tenantId,
+          organizationId: auth.orgId ?? null,
+          errorMessage: result.errors[0]?.error ?? 'Vector reindex failed before queueing work',
+        })
+      }
+      await clearReindexLock(db, auth.tenantId, 'vector', auth.orgId ?? null)
+    }
 
     await recordIndexerLog(
       { em: em ?? undefined },

--- a/packages/search/src/modules/search/api/reindex/route.ts
+++ b/packages/search/src/modules/search/api/reindex/route.ts
@@ -87,6 +87,7 @@ export async function POST(req: Request) {
   const entityId = typeof payload.entityId === 'string' ? payload.entityId : undefined
   // Use queue by default (requires queue workers to be running), can be disabled with useQueue: false
   const useQueue = payload.useQueue !== false
+  let keepLockForQueuedWorkers = false
 
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
@@ -320,7 +321,8 @@ export async function POST(req: Request) {
           ? `Reindex ${entityId} (${useQueue ? 'queued' : 'sync'})`
           : `Reindex all entities (${useQueue ? 'queued' : 'sync'})`,
       })
-      if (!useQueue) {
+      const jobsEnqueued = result.jobsEnqueued ?? 0
+      if (!useQueue || jobsEnqueued === 0) {
         await completeReindexProgress({
           em,
           progressService,
@@ -334,6 +336,8 @@ export async function POST(req: Request) {
             errors: result.errors.length,
           },
         })
+      } else {
+        keepLockForQueuedWorkers = true
       }
 
       // Get updated stats from all strategies
@@ -452,7 +456,7 @@ export async function POST(req: Request) {
   } finally {
     // Only clear lock immediately if NOT using queue mode
     // When using queue mode, workers update heartbeat and stale detection handles cleanup
-    if (!useQueue) {
+    if (!keepLockForQueuedWorkers) {
       await clearReindexLock(db, tenantId, 'fulltext', auth.orgId ?? null)
     }
 

--- a/packages/search/src/modules/search/frontend/components/SearchSettingsPageClient.tsx
+++ b/packages/search/src/modules/search/frontend/components/SearchSettingsPageClient.tsx
@@ -213,6 +213,17 @@ export function SearchSettingsPageClient() {
     }
   }, [])
 
+  const hasActiveReindexLock = Boolean(settings?.fulltextReindexLock || settings?.vectorReindexLock)
+  React.useEffect(() => {
+    if (!hasActiveReindexLock) return
+
+    const interval = setInterval(() => {
+      void refreshStatsOnly()
+    }, 5000)
+
+    return () => clearInterval(interval)
+  }, [hasActiveReindexLock, refreshStatsOnly])
+
   // Lightweight embedding stats refresh
   const refreshEmbeddingStatsOnly = React.useCallback(async () => {
     try {

--- a/packages/search/src/modules/search/lib/reindex-progress.ts
+++ b/packages/search/src/modules/search/lib/reindex-progress.ts
@@ -139,6 +139,15 @@ export async function incrementReindexProgress(params: {
   return false
 }
 
+export async function hasActiveReindexProgress(params: {
+  em: EntityManager
+  type: ReindexProgressType
+  tenantId: string
+  organizationId?: string | null
+}): Promise<boolean> {
+  return (await findActiveJob(params.em, params.type, params.tenantId, params.organizationId)) != null
+}
+
 export async function completeReindexProgress(params: {
   em: EntityManager
   progressService: ProgressService

--- a/packages/search/src/modules/search/workers/fulltext-index.worker.ts
+++ b/packages/search/src/modules/search/workers/fulltext-index.worker.ts
@@ -11,7 +11,7 @@ import { recordIndexerError } from '@open-mercato/shared/lib/indexers/error-log'
 import type { ProgressService } from '@open-mercato/core/modules/progress/lib/progressService'
 import { searchDebug, searchDebugWarn, searchError } from '../../../lib/debug'
 import { clearReindexLock, updateReindexProgress } from '../lib/reindex-lock'
-import { incrementReindexProgress } from '../lib/reindex-progress'
+import { hasActiveReindexProgress, incrementReindexProgress } from '../lib/reindex-progress'
 
 // Worker metadata for auto-discovery
 const DEFAULT_CONCURRENCY = 2
@@ -23,6 +23,54 @@ export const metadata: WorkerMeta = {
 }
 
 type HandlerContext = { resolve: <T = unknown>(name: string) => T }
+
+async function advanceFulltextReindexProgress(params: {
+  db: Kysely<any> | null
+  em: EntityManager | null
+  progressService: ProgressService | null
+  tenantId: string
+  organizationId?: string | null
+  delta: number
+}): Promise<void> {
+  if (!Number.isFinite(params.delta) || params.delta <= 0) return
+
+  if (params.progressService && params.em) {
+    const hasActiveProgress = await hasActiveReindexProgress({
+      em: params.em,
+      type: 'fulltext',
+      tenantId: params.tenantId,
+      organizationId: params.organizationId ?? null,
+    })
+
+    if (!hasActiveProgress) {
+      if (params.db) {
+        await clearReindexLock(params.db, params.tenantId, 'fulltext', params.organizationId ?? null)
+      }
+      return
+    }
+
+    if (params.db) {
+      await updateReindexProgress(params.db, params.tenantId, 'fulltext', params.delta, params.organizationId ?? null)
+    }
+
+    const completed = await incrementReindexProgress({
+      em: params.em,
+      progressService: params.progressService,
+      type: 'fulltext',
+      tenantId: params.tenantId,
+      organizationId: params.organizationId ?? null,
+      delta: params.delta,
+    })
+    if (completed && params.db) {
+      await clearReindexLock(params.db, params.tenantId, 'fulltext', params.organizationId ?? null)
+    }
+    return
+  }
+
+  if (params.db) {
+    await updateReindexProgress(params.db, params.tenantId, 'fulltext', params.delta, params.organizationId ?? null)
+  }
+}
 
 /**
  * Process a fulltext indexing job.
@@ -193,23 +241,14 @@ export async function handleFulltextIndexJob(
         }
       }
 
-      // Update heartbeat to signal worker is still processing
-      if (db && records.length > 0) {
-        await updateReindexProgress(db, tenantId, 'fulltext', successCount, organizationId ?? null)
-      }
-      if (progressService && em && records.length > 0) {
-        const completed = await incrementReindexProgress({
-          em,
-          progressService,
-          type: 'fulltext',
-          tenantId,
-          organizationId: organizationId ?? null,
-          delta: successCount,
-        })
-        if (completed && db) {
-          await clearReindexLock(db, tenantId, 'fulltext', organizationId ?? null)
-        }
-      }
+      await advanceFulltextReindexProgress({
+        db,
+        em,
+        progressService,
+        tenantId,
+        organizationId: organizationId ?? null,
+        delta: records.length,
+      })
 
       searchDebug('fulltext-index.worker', 'Batch indexed to fulltext', {
         jobId: jobCtx.jobId,

--- a/packages/search/src/modules/search/workers/vector-index.worker.ts
+++ b/packages/search/src/modules/search/workers/vector-index.worker.ts
@@ -7,14 +7,14 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 
 import type { ProgressService } from '@open-mercato/core/modules/progress/lib/progressService'
 import { recordIndexerError } from '@open-mercato/shared/lib/indexers/error-log'
-import { applyCoverageAdjustments, createCoverageAdjustments } from '@open-mercato/core/modules/query_index/lib/coverage'
+import { refreshCoverageSnapshot } from '@open-mercato/core/modules/query_index/lib/coverage'
 import { logVectorOperation } from '../../../vector/lib/vector-logs'
 import { resolveAutoIndexingEnabled } from '../lib/auto-indexing'
 import { resolveEmbeddingConfig } from '../lib/embedding-config'
 import { searchDebugWarn, searchWarn } from '../../../lib/debug'
 import { evaluateVectorPreflight, type VectorPreflightResult } from '../../../vector/lib/preflight'
 import { clearReindexLock, updateReindexProgress } from '../lib/reindex-lock'
-import { incrementReindexProgress } from '../lib/reindex-progress'
+import { hasActiveReindexProgress, incrementReindexProgress } from '../lib/reindex-progress'
 
 // Worker metadata for auto-discovery
 const DEFAULT_CONCURRENCY = 2
@@ -26,6 +26,52 @@ export const metadata: WorkerMeta = {
 }
 
 type HandlerContext = { resolve: <T = unknown>(name: string) => T }
+type CoverageEventBus = { emitEvent(event: string, payload: unknown, options?: unknown): Promise<void> }
+
+async function refreshVectorCoverage(params: {
+  em: EntityManager | null
+  eventBus: CoverageEventBus | null
+  entityType: string
+  tenantId: string
+  organizationId?: string | null
+  delayMs?: number
+}): Promise<void> {
+  if (!params.entityType || !params.tenantId) return
+
+  if (params.eventBus) {
+    try {
+      await params.eventBus.emitEvent('query_index.coverage.refresh', {
+        entityType: params.entityType,
+        tenantId: params.tenantId,
+        organizationId: params.organizationId ?? null,
+        withDeleted: false,
+        delayMs: params.delayMs ?? 1000,
+      })
+      return
+    } catch (emitError) {
+      searchDebugWarn('vector-index.worker', 'Failed to enqueue vector coverage refresh', {
+        entityType: params.entityType,
+        error: emitError instanceof Error ? emitError.message : emitError,
+      })
+    }
+  }
+
+  if (params.em) {
+    try {
+      await refreshCoverageSnapshot(params.em, {
+        entityType: params.entityType,
+        tenantId: params.tenantId,
+        organizationId: params.organizationId ?? null,
+        withDeleted: false,
+      })
+    } catch (coverageError) {
+      searchDebugWarn('vector-index.worker', 'Failed to refresh vector coverage', {
+        entityType: params.entityType,
+        error: coverageError instanceof Error ? coverageError.message : coverageError,
+      })
+    }
+  }
+}
 
 /**
  * Decide once per job whether vector work can succeed, so the worker can skip a
@@ -66,6 +112,54 @@ async function runVectorPreflight(
     tableDimension,
     probe: options.withProbe ? () => service.createEmbedding('preflight') : undefined,
   })
+}
+
+async function advanceVectorReindexProgress(params: {
+  db: Kysely<any> | null
+  em: EntityManager | null
+  progressService: ProgressService | null
+  tenantId: string
+  organizationId?: string | null
+  delta: number
+}): Promise<void> {
+  if (!Number.isFinite(params.delta) || params.delta <= 0) return
+
+  if (params.progressService && params.em) {
+    const hasActiveProgress = await hasActiveReindexProgress({
+      em: params.em,
+      type: 'vector',
+      tenantId: params.tenantId,
+      organizationId: params.organizationId ?? null,
+    })
+
+    if (!hasActiveProgress) {
+      if (params.db) {
+        await clearReindexLock(params.db, params.tenantId, 'vector', params.organizationId ?? null)
+      }
+      return
+    }
+
+    if (params.db) {
+      await updateReindexProgress(params.db, params.tenantId, 'vector', params.delta, params.organizationId ?? null)
+    }
+
+    const completed = await incrementReindexProgress({
+      em: params.em,
+      progressService: params.progressService,
+      type: 'vector',
+      tenantId: params.tenantId,
+      organizationId: params.organizationId ?? null,
+      delta: params.delta,
+    })
+    if (completed && params.db) {
+      await clearReindexLock(params.db, params.tenantId, 'vector', params.organizationId ?? null)
+    }
+    return
+  }
+
+  if (params.db) {
+    await updateReindexProgress(params.db, params.tenantId, 'vector', params.delta, params.organizationId ?? null)
+  }
 }
 
 /**
@@ -122,6 +216,13 @@ export async function handleVectorIndexJob(
       progressService = null
     }
 
+    let eventBus: CoverageEventBus | null = null
+    try {
+      eventBus = ctx.resolve<CoverageEventBus>('eventBus')
+    } catch {
+      eventBus = null
+    }
+
     // Load saved embedding config to use the correct provider/model
     try {
       const embeddingConfig = await resolveEmbeddingConfig(ctx, { defaultValue: null })
@@ -147,22 +248,14 @@ export async function handleVectorIndexJob(
         totalRecords: records.length,
         tenantId,
       })
-      if (db && records.length > 0) {
-        await updateReindexProgress(db, tenantId, 'vector', records.length, organizationId ?? null)
-      }
-      if (progressService && em && records.length > 0) {
-        const completed = await incrementReindexProgress({
-          em,
-          progressService,
-          type: 'vector',
-          tenantId,
-          organizationId: organizationId ?? null,
-          delta: records.length,
-        })
-        if (completed && db) {
-          await clearReindexLock(db, tenantId, 'vector', organizationId ?? null)
-        }
-      }
+      await advanceVectorReindexProgress({
+        db,
+        em,
+        progressService,
+        tenantId,
+        organizationId,
+        delta: records.length,
+      })
       return
     }
 
@@ -191,22 +284,27 @@ export async function handleVectorIndexJob(
     }
 
     // Update heartbeat to signal worker is still processing
-    if (db && records.length > 0) {
-      await updateReindexProgress(db, tenantId, 'vector', successCount, organizationId ?? null)
-    }
-    if (progressService && em && records.length > 0) {
-      const completed = await incrementReindexProgress({
-        em,
-        progressService,
-        type: 'vector',
-        tenantId,
-        organizationId: organizationId ?? null,
-        delta: successCount,
-      })
-      if (completed && db) {
-        await clearReindexLock(db, tenantId, 'vector', organizationId ?? null)
-      }
-    }
+    await advanceVectorReindexProgress({
+      db,
+      em,
+      progressService,
+      tenantId,
+      organizationId,
+      delta: records.length,
+    })
+
+    const touchedEntities = new Set(records.map((record) => record.entityId).filter(Boolean))
+    await Promise.all(
+      Array.from(touchedEntities).map((touchedEntity) =>
+        refreshVectorCoverage({
+          em,
+          eventBus,
+          entityType: touchedEntity,
+          tenantId,
+          organizationId,
+        }),
+      ),
+    )
 
     searchDebugWarn('vector-index.worker', 'Batch-index job completed', {
       jobId: jobCtx.jobId,
@@ -284,9 +382,9 @@ export async function handleVectorIndexJob(
     em = null
   }
 
-  let eventBus: { emitEvent(event: string, payload: unknown, options?: unknown): Promise<void> } | null = null
+  let eventBus: CoverageEventBus | null = null
   try {
-    eventBus = ctx.resolve('eventBus')
+    eventBus = ctx.resolve<CoverageEventBus>('eventBus')
   } catch {
     eventBus = null
   }
@@ -321,43 +419,13 @@ export async function handleVectorIndexJob(
     }
 
     if (delta !== 0) {
-      let adjustmentsApplied = false
-      if (em) {
-        try {
-          const adjustments = createCoverageAdjustments({
-            entityType,
-            tenantId,
-            organizationId,
-            baseDelta: 0,
-            indexDelta: 0,
-            vectorDelta: delta,
-          })
-          if (adjustments.length) {
-            await applyCoverageAdjustments(em, adjustments)
-            adjustmentsApplied = true
-          }
-        } catch (coverageError) {
-          searchDebugWarn('vector-index.worker', 'Failed to adjust vector coverage', {
-            error: coverageError instanceof Error ? coverageError.message : coverageError,
-          })
-        }
-      }
-
-      if (!adjustmentsApplied && eventBus) {
-        try {
-          await eventBus.emitEvent('query_index.coverage.refresh', {
-            entityType,
-            tenantId,
-            organizationId,
-            withDeleted: false,
-            delayMs: 1000,
-          })
-        } catch (emitError) {
-          searchDebugWarn('vector-index.worker', 'Failed to enqueue coverage refresh', {
-            error: emitError instanceof Error ? emitError.message : emitError,
-          })
-        }
-      }
+      await refreshVectorCoverage({
+        em,
+        eventBus,
+        entityType,
+        tenantId,
+        organizationId,
+      })
     }
 
     await logVectorOperation({

--- a/packages/shared/src/lib/indexers/__tests__/status-log.test.ts
+++ b/packages/shared/src/lib/indexers/__tests__/status-log.test.ts
@@ -1,0 +1,94 @@
+import { recordIndexerLog } from '../status-log'
+
+type Behaviors = {
+  insert?: () => unknown
+  select?: () => unknown
+  delete?: () => unknown
+}
+
+function makeBuilder(op: keyof Behaviors, behaviors: Behaviors): any {
+  const builder: any = {}
+  for (const method of ['values', 'select', 'where', 'orderBy', 'offset', 'limit']) {
+    builder[method] = () => builder
+  }
+  builder.execute = async () => {
+    const behavior = behaviors[op]
+    return behavior ? behavior() : []
+  }
+  return builder
+}
+
+function makeDb(behaviors: Behaviors): any {
+  return {
+    insertInto: () => makeBuilder('insert', behaviors),
+    selectFrom: () => makeBuilder('select', behaviors),
+    deleteFrom: () => makeBuilder('delete', behaviors),
+  }
+}
+
+const INPUT = { source: 'vector' as const, handler: 'event:test', message: 'hi' }
+
+describe('recordIndexerLog — inactive-transaction de-noising', () => {
+  let errorSpy: jest.SpyInstance
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+    warnSpy.mockRestore()
+  })
+
+  it('skips quietly when the insert hits an already-committed transaction', async () => {
+    const db = makeDb({
+      insert: () => {
+        throw new Error('Transaction is already committed')
+      },
+    })
+
+    await recordIndexerLog({ db }, INPUT)
+
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('still logs an unexpected insert failure', async () => {
+    const db = makeDb({
+      insert: () => {
+        throw new Error('connection refused')
+      },
+    })
+
+    await recordIndexerLog({ db }, INPUT)
+
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips quietly when the prune hits a rolled-back transaction', async () => {
+    const db = makeDb({
+      insert: () => undefined,
+      select: () => {
+        throw new Error('Transaction is already rolled back')
+      },
+    })
+
+    await recordIndexerLog({ db }, INPUT)
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('still warns on an unexpected prune failure', async () => {
+    const db = makeDb({
+      insert: () => undefined,
+      select: () => {
+        throw new Error('deadlock detected')
+      },
+    })
+
+    await recordIndexerLog({ db }, INPUT)
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/shared/src/lib/indexers/status-log.ts
+++ b/packages/shared/src/lib/indexers/status-log.ts
@@ -55,6 +55,21 @@ function pickDb(deps: RecordIndexerLogDeps): Kysely<any> | null {
   return null
 }
 
+/**
+ * Indexer status logging is best-effort observability and must never ride on —
+ * or be noisy about — the caller's transaction lifecycle. When index maintenance
+ * runs inline on a request `em` (e.g. an inline force reindex that emits the
+ * vector-purge subscriber), the captured Kysely can be a transaction handle that
+ * has already committed/rolled back, so a follow-up read/write throws
+ * "Transaction is already committed". Treat that class of error as a quiet skip
+ * rather than an error the operator must triage. A fresh-EM path (the events
+ * worker) never hits this; this guard only de-noises the inline path.
+ */
+function isInactiveTransactionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  return /transaction is already (committed|rolled back)/i.test(message)
+}
+
 async function pruneExcessLogs(db: Kysely<any>, source: IndexerErrorSource): Promise<void> {
   const rows = await db
     .selectFrom('indexer_status_logs' as any)
@@ -110,13 +125,19 @@ export async function recordIndexerLog(
       } as any)
       .execute()
   } catch (error) {
-    console.error('[indexers] Failed to persist indexer log', error)
+    // A committed/rolled-back caller transaction is an expected, harmless
+    // condition for best-effort logging — skip quietly instead of surfacing it.
+    if (!isInactiveTransactionError(error)) {
+      console.error('[indexers] Failed to persist indexer log', error)
+    }
     return
   }
 
   try {
     await pruneExcessLogs(db, input.source)
   } catch (pruneError) {
-    console.warn('[indexers] Failed to prune indexer logs', pruneError)
+    if (!isInactiveTransactionError(pruneError)) {
+      console.warn('[indexers] Failed to prune indexer logs', pruneError)
+    }
   }
 }

--- a/packages/ui/src/backend/__tests__/useProgressSse.test.tsx
+++ b/packages/ui/src/backend/__tests__/useProgressSse.test.tsx
@@ -1,0 +1,105 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ProgressJobDto } from '../progress/useProgressPoll'
+
+const mockApiCall = jest.fn()
+jest.mock('../utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+}))
+
+const mockAppEventHandlers = new Map<string, Array<(event: { payload?: unknown }) => void>>()
+jest.mock('../injection/useAppEvent', () => ({
+  useAppEvent: (eventId: string, handler: (event: { payload?: unknown }) => void) => {
+    const handlers = mockAppEventHandlers.get(eventId) ?? []
+    handlers.push(handler)
+    mockAppEventHandlers.set(eventId, handlers)
+  },
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/progressEvents', () => ({
+  subscribeProgressUpdate: jest.fn(() => jest.fn()),
+}))
+
+import { useProgressSse } from '../progress/useProgressSse'
+
+const runningJob: ProgressJobDto = {
+  id: 'job-1',
+  jobType: 'search.reindex.vector',
+  name: 'Search vector reindex',
+  description: 'Vector reindex catalog:catalog_product_variant (queued)',
+  status: 'running',
+  progressPercent: 0,
+  processedCount: 0,
+  totalCount: 0,
+  cancellable: true,
+  startedAt: '2026-06-15T16:37:01.382Z',
+  finishedAt: null,
+  errorMessage: null,
+}
+
+const completedJob: ProgressJobDto = {
+  ...runningJob,
+  status: 'completed',
+  progressPercent: 100,
+  finishedAt: '2026-06-15T16:37:01.391Z',
+}
+
+function mockProgressResponse(active: ProgressJobDto[], recentlyCompleted: ProgressJobDto[] = []) {
+  return {
+    ok: true,
+    result: {
+      active,
+      recentlyCompleted,
+    },
+  }
+}
+
+describe('useProgressSse', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.clearAllMocks()
+    mockAppEventHandlers.clear()
+  })
+
+  it('removes a job from activeJobs when an SSE update carries a terminal status', async () => {
+    mockApiCall.mockResolvedValue(mockProgressResponse([runningJob]))
+    const { result } = renderHook(() => useProgressSse())
+
+    await waitFor(() => expect(result.current.activeJobs).toHaveLength(1))
+
+    act(() => {
+      for (const handler of mockAppEventHandlers.get('progress.job.updated') ?? []) {
+        handler({ payload: { ...completedJob, jobId: completedJob.id } })
+      }
+    })
+
+    expect(result.current.activeJobs).toHaveLength(0)
+    expect(result.current.recentlyCompleted[0]).toEqual(expect.objectContaining({
+      id: 'job-1',
+      status: 'completed',
+    }))
+  })
+
+  it('periodically reconciles active jobs in SSE mode when completion events are missed', async () => {
+    jest.useFakeTimers()
+    mockApiCall
+      .mockResolvedValueOnce(mockProgressResponse([runningJob]))
+      .mockResolvedValueOnce(mockProgressResponse([], [completedJob]))
+
+    const { result } = renderHook(() => useProgressSse())
+
+    await waitFor(() => expect(result.current.activeJobs).toHaveLength(1))
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(result.current.activeJobs).toHaveLength(0)
+      expect(result.current.recentlyCompleted[0]).toEqual(expect.objectContaining({
+        id: 'job-1',
+        status: 'completed',
+      }))
+    })
+  })
+})

--- a/packages/ui/src/backend/progress/useProgressSse.ts
+++ b/packages/ui/src/backend/progress/useProgressSse.ts
@@ -6,8 +6,18 @@ import { subscribeProgressUpdate } from '@open-mercato/shared/lib/frontend/progr
 import type { ProgressJobDto, UseProgressPollResult } from './useProgressPoll'
 import { applyLocalProgressUpdate, isLocalProgressJob } from './useProgressPoll'
 
+const SSE_PROGRESS_SYNC_INTERVAL = 5000
+
 function isVisibleProgressJob(job: ProgressJobDto): boolean {
   return job.meta?.hiddenFromTopBar !== true
+}
+
+function isActiveStatus(status: ProgressJobDto['status']): boolean {
+  return status === 'pending' || status === 'running'
+}
+
+function isTerminalStatus(status: ProgressJobDto['status']): boolean {
+  return status === 'completed' || status === 'failed' || status === 'cancelled'
 }
 
 function upsertJob(list: ProgressJobDto[], job: ProgressJobDto): ProgressJobDto[] {
@@ -35,11 +45,11 @@ export function useProgressSse(): UseProgressPollResult {
       )
       if (result.ok && result.result) {
         setActiveJobs((prev) => [
-          ...prev.filter((job) => isLocalProgressJob(job) && (job.status === 'pending' || job.status === 'running')),
+          ...prev.filter((job) => isLocalProgressJob(job) && isActiveStatus(job.status)),
           ...result.result!.active.filter(isVisibleProgressJob),
         ])
         setRecentlyCompleted((prev) => [
-          ...prev.filter((job) => isLocalProgressJob(job) && (job.status === 'completed' || job.status === 'failed')),
+          ...prev.filter((job) => isLocalProgressJob(job) && isTerminalStatus(job.status)),
           ...result.result!.recentlyCompleted.filter(isVisibleProgressJob),
         ].slice(0, 10))
         setError(null)
@@ -60,6 +70,33 @@ export function useProgressSse(): UseProgressPollResult {
   }, [fetchJobs])
 
   React.useEffect(() => {
+    let interval: ReturnType<typeof setInterval> | null = setInterval(() => {
+      void fetchJobs()
+    }, SSE_PROGRESS_SYNC_INTERVAL)
+
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        if (interval) {
+          clearInterval(interval)
+          interval = null
+        }
+      } else {
+        void fetchJobs()
+        if (interval) clearInterval(interval)
+        interval = setInterval(() => {
+          void fetchJobs()
+        }, SSE_PROGRESS_SYNC_INTERVAL)
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => {
+      if (interval) clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [fetchJobs])
+
+  React.useEffect(() => {
     return subscribeProgressUpdate((detail) => {
       applyLocalProgressUpdate(detail, setActiveJobs, setRecentlyCompleted)
     })
@@ -74,23 +111,32 @@ export function useProgressSse(): UseProgressPollResult {
         void fetchJobs()
         return
       }
+      const status = (payload.status as ProgressJobDto['status']) ?? 'running'
+      const job: ProgressJobDto = {
+        id: jobId,
+        jobType: payload.jobType ?? 'progress',
+        name: payload.name ?? payload.jobType ?? 'Progress job',
+        description: payload.description ?? null,
+        meta: (payload.meta && typeof payload.meta === 'object') ? payload.meta as Record<string, unknown> : null,
+        status,
+        progressPercent: payload.progressPercent ?? 0,
+        processedCount: payload.processedCount ?? 0,
+        totalCount: payload.totalCount ?? null,
+        etaSeconds: payload.etaSeconds ?? null,
+        cancellable: payload.cancellable ?? false,
+        startedAt: payload.startedAt ?? null,
+        finishedAt: payload.finishedAt ?? null,
+        errorMessage: payload.errorMessage ?? null,
+      }
+
+      if (isTerminalStatus(status)) {
+        setActiveJobs((prev) => prev.filter((item) => item.id !== jobId))
+        setRecentlyCompleted((prev) => upsertJob(prev, job).slice(0, 10))
+        return
+      }
+
       setActiveJobs((prev) =>
-        upsertJob(prev, {
-          id: jobId,
-          jobType: payload.jobType ?? 'progress',
-          name: payload.name ?? payload.jobType ?? 'Progress job',
-          description: payload.description ?? null,
-          meta: (payload.meta && typeof payload.meta === 'object') ? payload.meta as Record<string, unknown> : null,
-          status: (payload.status as ProgressJobDto['status']) ?? 'running',
-          progressPercent: payload.progressPercent ?? 0,
-          processedCount: payload.processedCount ?? 0,
-          totalCount: payload.totalCount ?? null,
-          etaSeconds: payload.etaSeconds ?? null,
-          cancellable: payload.cancellable ?? false,
-          startedAt: payload.startedAt ?? null,
-          finishedAt: payload.finishedAt ?? null,
-          errorMessage: payload.errorMessage ?? null,
-        }),
+        upsertJob(prev, job),
       )
     },
     [fetchJobs],


### PR DESCRIPTION
## Problem

Onboarding's "preparing your workspace" page still stalled after #3095. The status route returned `completed` but `ready:false` forever, and the logs filled with `Transaction is already committed`.

Root cause: a **persistent emit dual-dispatches by default**. `bus.emit(..., { persistent: true })` runs every matching subscriber **inline** *and* enqueues it for the events worker. So `enqueueQueryIndexRebuild` ran the multi-minute force reindex of every system entity **inline in the onboarding request** (the exact thing #3095 tried to remove), and reused that request's already-committed `em` — so the inline vector-purge subscriber's status-log prune threw `Transaction is already committed` on every entity.

#3095 assumed `{ persistent: true }` only enqueues. It only does under `OM_EVENTS_SINGLE_DELIVERY=true`, which was default-off.

## What changed

### Events delivery (the enabling change)
- **`EmitOptions.deliverInline`** (additive, defaults `true`). `{ persistent: true, deliverInline: false }` is *enqueue-only*: skip all inline delivery, let the events worker dispatch the job off the caller's request path.
- **`OM_EVENTS_SINGLE_DELIVERY` flipped to default-ON** (bus + worker). Persistent emits stop double-running exact-match subscribers (duplicate notifications/emails), and wildcard (`event: '*'`) persistent subscribers — workflow triggers, business-rules CRUD trigger, webhook outbound dispatch — finally reach the worker with real queue/retry semantics. Set `OM_EVENTS_SINGLE_DELIVERY=false` to opt back into legacy dual-dispatch.
- **Worker guard (silent-loss protection).** With single-delivery on, persistent subscribers run *only* in the worker. The server bootstrap reconciles the flag against worker availability: a process that auto-spawns no events worker and has not set `OM_EVENTS_EXTERNAL_WORKER` logs a loud warning and **falls back to inline dual-dispatch** so persistent side effects are never silently dropped. Transient downtime is not a concern — the durable queue holds jobs until a worker returns; the guard only catches the "no worker at all" misconfiguration.

### Onboarding
- `enqueueQueryIndexRebuild` now emits `{ persistent: true, deliverInline: false }`, so the rebuild runs solely in the worker and the workspace is marked ready in seconds.

### query_index + search: fully queue-only reindex/purge with worker progress
- query_index reindex/purge API routes emit enqueue-only; the `query_index.reindex` subscriber runs on a **forked EntityManager** (fresh identity map + UnitOfWork), so reindex DB work can never ride on — or commit — a caller's transaction. This fixes `Transaction is already committed` **at its source**.
- search vector/fulltext + embeddings reindex routes are queue-aware: they keep the reindex lock for queued workers and complete/fail the progress job from the worker tail, or finalize inline when nothing is enqueued. Workers report progress via the shared reindex-progress helpers.

### Indexer status log (defense in depth)
- A committed/rolled-back-transaction Kysely is now a quiet skip instead of an error/warn stack dump — best-effort observability must not ride on, or be noisy about, a caller's transaction.

### UI
- `QueryIndexesTable` index/vector/fulltext actions surface failures (e.g. a 503 when a search backend isn't configured) via a `flash` toast instead of `window.alert` + an error-level `console.error` that read like an unhandled exception.
- `useProgressSse` hardening for the worker-driven progress stream.

## Read-your-writes is safe

Per-record indexing (`query_index.upsert_one` / `delete_one` / coverage) is `persistent: false` (ephemeral) and **always runs inline** — the projection row is written synchronously on a forked EM and the data engine awaits it. Single-delivery only changes `persistent: true` subscribers, so normal CRUD visibility is unchanged. Only the bulk `reindex`/`purge` sweeps are persistent.

## Backward compatibility

- `EmitOptions.deliverInline` and `OM_EVENTS_EXTERNAL_WORKER` are additive optionals; `deliverInline` defaults to today's behavior.
- The single-delivery *default* flip is a behavior change, gated by the worker guard and reversible via `OM_EVENTS_SINGLE_DELIVERY=false`. This is the events `AGENTS.md` "Ask First: persistent delivery semantics" surface — documented there.
- No event IDs, DI keys, routes, or schema touched.

## Tests

- Events bus: enqueue-only skips inline but enqueues; default-on skips persistent inline; explicit legacy opt-out preserves dual-dispatch.
- Events worker: default-on reaches wildcard persistent subscribers; legacy opt-out preserves exact-match.
- Reconcile guard (events + CLI mirror): stays on with a worker, falls back with a warning when none, honors external-worker ack and explicit opt-out.
- Status-log: committed/rolled-back transaction is a quiet skip; unexpected errors still log.
- query_index: api-queue-only + reindex-subscriber fork coverage. search: reindex/embeddings route + worker tests. ui: useProgressSse.
- Onboarding: asserts the enqueue-only options shape and ready-before-reindex ordering.
- Green: events 54, shared 1266, cli 974, onboarding 87, search 170, core query_index 63, ui useProgressSse; repo typecheck 21/21.

## Operator notes

- Already-stuck tenants don't self-heal: `UPDATE onboarding_requests SET preparation_completed_at = now() WHERE preparation_completed_at IS NULL;`
- If web and events workers run as **separate processes** with `AUTO_SPAWN_WORKERS=off`, set `OM_EVENTS_EXTERNAL_WORKER=true` on the web process to keep single-delivery (otherwise it falls back to dual-dispatch with a warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
