### PR TITLE
fix(onboarding): recover a crashed deferred-provisioning runner in seconds, not 10 minutes (TC-ONB-002)

### DIFF
--- a/packages/onboarding/src/__tests__/preparation-claim.test.ts
+++ b/packages/onboarding/src/__tests__/preparation-claim.test.ts
@@ -1,0 +1,31 @@
+import {
+  PREPARATION_CLAIM_STALE_MS,
+  isPreparationClaimActive,
+} from '@open-mercato/onboarding/modules/onboarding/lib/preparation-claim'
+
+describe('preparation claim staleness', () => {
+  const now = new Date('2026-06-15T12:00:00.000Z')
+
+  it('treats a null lease as inactive (reclaimable)', () => {
+    expect(isPreparationClaimActive(null, now)).toBe(false)
+    expect(isPreparationClaimActive(undefined, now)).toBe(false)
+  })
+
+  it('treats a freshly-renewed lease as active', () => {
+    const justRenewed = new Date(now.getTime() - 1_000)
+    expect(isPreparationClaimActive(justRenewed, now)).toBe(true)
+  })
+
+  it('treats a lease older than the stale window as reclaimable', () => {
+    const crashedRunner = new Date(now.getTime() - PREPARATION_CLAIM_STALE_MS - 1)
+    expect(isPreparationClaimActive(crashedRunner, now)).toBe(false)
+  })
+
+  it('keeps the stale window short enough for status-poll recovery', () => {
+    // The preparing page polls status every ~1s and recovers a crashed runner by
+    // re-scheduling deferred provisioning once the lease goes stale. A multi-
+    // minute window (the historical 10 minutes) stranded the workspace on
+    // "preparing". Guard against regressing back to a long window.
+    expect(PREPARATION_CLAIM_STALE_MS).toBeLessThanOrEqual(60_000);
+  })
+})

--- a/packages/onboarding/src/modules/onboarding/__integration__/TC-ONB-002-multi-tenant-parallel-login.spec.ts
+++ b/packages/onboarding/src/modules/onboarding/__integration__/TC-ONB-002-multi-tenant-parallel-login.spec.ts
@@ -67,11 +67,19 @@ async function readPreparationState(requestId: string): Promise<{
   });
 }
 
-async function waitForPreparationComplete(requestId: string): Promise<void> {
+async function waitForPreparationComplete(
+  request: APIRequestContext,
+  tenant: OnboardingTenant,
+): Promise<void> {
   const deadline = Date.now() + 60_000;
   let lastState: Awaited<ReturnType<typeof readPreparationState>> | null = null;
   while (Date.now() < deadline) {
-    lastState = await readPreparationState(requestId);
+    // Drive the same recovery the real preparing page provides: it polls the
+    // status endpoint every ~1s, and each poll re-schedules deferred
+    // provisioning when no fresh claim is held. Watching only the DB would never
+    // recover a deferred runner that crashed after claiming its lease.
+    await pollOnboardingStatus(request, tenant.tenantId!).catch(() => undefined);
+    lastState = await readPreparationState(tenant.requestId!);
     if (lastState.preparation_completed_at && !lastState.preparation_started_at) return;
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
@@ -187,7 +195,7 @@ test.describe('TC-ONB-002: multi-tenant onboarding parallel login', () => {
         expect(response.status(), 'status polling should not exhaust the app DB pool').toBe(200);
       }
 
-      await Promise.all(tenants.map((tenant) => waitForPreparationComplete(tenant.requestId!)));
+      await Promise.all(tenants.map((tenant) => waitForPreparationComplete(request, tenant)));
       await Promise.all(
         tenants.map((tenant, index) => loginAndAssertBackend(browserSessions[index], tenant)),
       );

--- a/packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/deferred-provisioning.ts
@@ -12,6 +12,10 @@ import { PREPARATION_CLAIM_STALE_MS } from '@open-mercato/onboarding/modules/onb
 
 const VECTOR_REINDEX_ENQUEUE_TIMEOUT_MS = 5_000
 const SEED_EXAMPLES_TIMEOUT_MS = 15_000
+// Steady lease-renewal cadence while the chain works. Must stay well below
+// PREPARATION_CLAIM_STALE_MS so a live runner is never mistaken for a crashed
+// one, regardless of how long any single module's seedExamples takes.
+const PREPARATION_HEARTBEAT_MS = 5_000
 
 export function resolveProvisioningIds(request: OnboardingRequest) {
   if (!request.tenantId || !request.organizationId || !request.userId) return null
@@ -202,60 +206,82 @@ export async function runDeferredProvisioning(args: {
     return
   }
 
-  const modules = getModules()
+  // Steady heartbeat on a SEPARATE EntityManager (own connection) so renewal can
+  // never interleave with the chain's own DB work on `em`. This keeps the lease
+  // fresh on a fixed cadence independent of how long any single module's
+  // seedExamples takes, which is what lets PREPARATION_CLAIM_STALE_MS stay short:
+  // a runner that actually crashes stops renewing and is reclaimable in seconds,
+  // while a genuinely-working one is never falsely reclaimed. renewPreparation is
+  // a no-op once the request is completed, so a late tick can't resurrect a
+  // finished lease.
+  const heartbeatEm = typeof (em as { fork?: () => EntityManager }).fork === 'function'
+    ? em.fork()
+    : em
+  const heartbeatService = new OnboardingService(heartbeatEm)
+  const heartbeat = setInterval(() => {
+    void heartbeatService.renewPreparation(args.requestId, new Date()).catch(() => {})
+  }, PREPARATION_HEARTBEAT_MS)
+  if (typeof heartbeat.unref === 'function') heartbeat.unref()
 
-  for (const mod of modules) {
-    if (!mod.setup?.seedExamples) continue
-    // Heartbeat: keep the lease fresh while legitimately working so a slow run
-    // (many modules × 15s seed timeout + rebuild) can never look stale and get
-    // double-claimed by a later poll.
-    await service.renewPreparation(args.requestId, new Date()).catch(() => {})
-    try {
-      await runModuleSetupHook({
-        moduleId: mod.id,
-        phase: 'seedExamples',
-        timeoutMs: SEED_EXAMPLES_TIMEOUT_MS,
-        run: () => mod.setup!.seedExamples!({
-          em,
-          tenantId: args.tenantId,
-          organizationId: args.organizationId,
-          container,
-        }),
-      })
-    } catch (error) {
-      if (isUniqueViolation(error)) {
-        console.info('[onboarding.verify] deferred seedExamples skipped (already applied)', {
+  try {
+    const modules = getModules()
+
+    for (const mod of modules) {
+      if (!mod.setup?.seedExamples) continue
+      // Renew immediately before each module too, so even a long-running module
+      // starts from a fresh lease in addition to the steady heartbeat above.
+      await service.renewPreparation(args.requestId, new Date()).catch(() => {})
+      try {
+        await runModuleSetupHook({
           moduleId: mod.id,
-          tenantId: args.tenantId,
-          organizationId: args.organizationId,
+          phase: 'seedExamples',
+          timeoutMs: SEED_EXAMPLES_TIMEOUT_MS,
+          run: () => mod.setup!.seedExamples!({
+            em,
+            tenantId: args.tenantId,
+            organizationId: args.organizationId,
+            container,
+          }),
         })
-      } else {
-        console.error('[onboarding.verify] deferred seedExamples failed', {
-          moduleId: mod.id,
-          tenantId: args.tenantId,
-          organizationId: args.organizationId,
-          error,
-        })
+      } catch (error) {
+        if (isUniqueViolation(error)) {
+          console.info('[onboarding.verify] deferred seedExamples skipped (already applied)', {
+            moduleId: mod.id,
+            tenantId: args.tenantId,
+            organizationId: args.organizationId,
+          })
+        } else {
+          console.error('[onboarding.verify] deferred seedExamples failed', {
+            moduleId: mod.id,
+            tenantId: args.tenantId,
+            organizationId: args.organizationId,
+            error,
+          })
+        }
       }
     }
+
+    // The query-index rebuild is ENQUEUED before the completion flag, not run
+    // inline: preparationCompletedAt is the terminal gate for both the
+    // status-route scheduling and claimPreparation, so a runner that dies before
+    // the jobs are queued must leave the flag unset — the stale claim then makes
+    // the chain reclaimable and re-enqueues (a repeated force reindex is
+    // harmless). Enqueuing is fast, so the workspace is marked ready in seconds
+    // while the actual reindex runs in the background workers.
+    await enqueueQueryIndexRebuild({
+      container,
+      tenantId: args.tenantId,
+    })
+
+    await markWorkspaceReady({
+      requestId: args.requestId,
+      service,
+    })
+  } finally {
+    // Stop renewing as soon as the chain finishes (or throws): a crashed runner
+    // must let the lease go stale so a status poll can reclaim it.
+    clearInterval(heartbeat)
   }
-
-  // The query-index rebuild is ENQUEUED before the completion flag, not run
-  // inline: preparationCompletedAt is the terminal gate for both the
-  // status-route scheduling and claimPreparation, so a runner that dies before
-  // the jobs are queued must leave the flag unset — the stale claim then makes
-  // the chain reclaimable and re-enqueues (a repeated force reindex is
-  // harmless). Enqueuing is fast, so the workspace is marked ready in seconds
-  // while the actual reindex runs in the background workers.
-  await enqueueQueryIndexRebuild({
-    container,
-    tenantId: args.tenantId,
-  })
-
-  await markWorkspaceReady({
-    requestId: args.requestId,
-    service,
-  })
 
   // Non-fatal (#2954 contract): an email failure must not abort the chain.
   // The status endpoint retries the ready email on later polls while

--- a/packages/onboarding/src/modules/onboarding/lib/preparation-claim.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/preparation-claim.ts
@@ -1,4 +1,10 @@
-export const PREPARATION_CLAIM_STALE_MS = 10 * 60 * 1000
+// A claimed-but-crashed deferred-provisioning runner must become reclaimable
+// fast enough that the preparing page's ~1s status polling can recover it within
+// seconds — not strand the workspace on "preparing" for minutes. A live runner
+// renews its lease on a steady PREPARATION_HEARTBEAT_MS cadence (see
+// deferred-provisioning.ts), so this window only needs comfortable headroom over
+// that heartbeat (here 6×) to never reclaim a runner that is genuinely working.
+export const PREPARATION_CLAIM_STALE_MS = 30 * 1000
 
 export function isPreparationClaimActive(startedAt: Date | null | undefined, now: Date = new Date()): boolean {
   if (!startedAt) return false


### PR DESCRIPTION
## Problem

`TC-ONB-002` failed in CI ([run](https://github.com/open-mercato/open-mercato/actions/runs/27560296601/job/81471437208)) on both the initial attempt and the retry:

```
Error: deferred preparation lease should be cleared after completion
expect(preparation_started_at).toBeNull()   // never cleared within the wait
```

## Root cause

Deferred provisioning runs as a fire-and-forget Next.js `after()` chain guarded by a single-flight lease (`preparation_started_at`). If that one chain **crashes after claiming the lease** — a transient DB/connection hiccup is enough under two parallel onboardings on a loaded CI box — the lease stayed "active" for `PREPARATION_CLAIM_STALE_MS = 10 minutes`. During that window every status poll skips re-scheduling (`isPreparationClaimActive` → true), so nothing re-runs the chain. The workspace is stranded on "preparing" — exactly the failure the `verify.ts` TODO calls out.

The heartbeat that keeps a *live* lease fresh was coupled to the per-module `seedExamples` loop (up to 15s between renewals), which is what forced such a long stale window in the first place.

The single-delivery default-on change already removed the *inline reindex* stall, so the chain itself is fast now — the remaining failure is purely **slow recovery from a transient crash**.

## Fix (root cause)

- **Steady heartbeat on a separate (forked) EntityManager** renews the lease every `PREPARATION_HEARTBEAT_MS` (5s), independent of how long any module's `seedExamples` takes, cleared in a `finally` when the chain ends or throws. A crashed runner stops renewing immediately. The forked EM means renewal can't interleave with the chain's own DB work, and `renewPreparation` is a no-op once the request is completed, so a late tick can't resurrect a finished lease.
- **`PREPARATION_CLAIM_STALE_MS` 10 min → 30s** (6× the heartbeat). Never reclaims a genuinely-working runner, but lets a status poll reclaim a crashed one within seconds — matching the preparing page's ~1s polling. This also fixes the real **UX bug**: a hiccup no longer strands a real user on "preparing" for ten minutes.

## Test

- `TC-ONB-002`'s wait loop now **polls the status endpoint** while waiting (as the real preparing page does), so the poll-driven recovery is actually exercised instead of passively watching the DB.
- New `preparation-claim` unit test guards the short stale window (prevents regressing to a multi-minute value) and the fresh/stale classification.

## Verification

- `@open-mercato/onboarding` unit suite green (91 tests); repo typecheck 21/21.
- The integration fix targets the exact assertion that failed; recovery now completes well inside the per-tenant wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
