### PR TITLE
fix(query_index): classify ORM-backed ids before the custom_entities probe (#2939 hardening)

### DIFF
--- a/.ai/specs/2026-06-15-query-index-orm-backed-classification-hardening.md
+++ b/.ai/specs/2026-06-15-query-index-orm-backed-classification-hardening.md
@@ -1,0 +1,85 @@
+# SPEC: Harden HybridQueryEngine custom-entity classification — ORM-backed ids before the `custom_entities` probe
+
+- Status: **Implemented** on this branch (`packages/core/src/modules/query_index/lib/engine.ts`); proposed for upstream contribution.
+- Date: 2026-06-15
+- Area: `query_index` module (`HybridQueryEngine` read-path storage classifier)
+- Severity: **High** — a single active `custom_entities` row for an ORM-backed system entity silently re-routes *every* list/detail read of that whole entity type to the (empty) doc-storage table. This is the #2939 read-path-poisoning failure mode, reachable through a door the existing guards do not cover.
+- Related: #2939 / #2942 (doc-storage rows poisoning read classification) and the doc-storage write seam `assertCustomEntityStorageEntityId`. Prerequisite for a planned follow-up that allows a presentation-metadata overlay on system entities (separate PR).
+
+## 1. Problem
+
+`HybridQueryEngine.isCustomEntity(entity)` is the platform-wide read-path classifier that decides whether `query()` reads an entity from its base ORM table (+ query index) or from doc storage (`custom_entities_storage`). It is **row-first**: it probes `custom_entities` for an active registration **before** considering whether the id is backed by a registered ORM table.
+
+```ts
+// BEFORE (packages/core/src/modules/query_index/lib/engine.ts)
+const row = await db.selectFrom('custom_entities').select('id')
+  .where('entity_id', '=', entity).where('is_active', '=', true).executeTakeFirst()
+if (row) {
+  result = true                                                   // custom => doc storage
+} else if (resolveRegisteredEntityTableName(this.em, entity) !== null) {
+  result = false                                                  // ORM-backed => base table (#2939 guard)
+} else {
+  result = await this.hasCustomEntityStorageRows(entity)
+}
+```
+
+The `else if` ORM-backed guard (added for #2939, so that *stray* `custom_entities_storage` rows cannot hijack reads) is only reached **when no active `custom_entities` row exists**. If an active `custom_entities` row exists for an ORM-backed system id (e.g. `customers:customer_person_profile` → `CustomerPersonProfile`, or `customers:customer_deal` → `CustomerDeal`), branch 1 fires and the id is classified as doc-storage-backed — so `query()` routes the entire entity type to the empty `custom_entities_storage` table and every list/detail read returns nothing.
+
+This is the exact asymmetry that makes the system-entity metadata-overlay use case unsafe: the records API (`classifyRecordsEntity`, `records.ts`) and the doc-storage write guard (`assertCustomEntityStorageEntityId`, `@open-mercato/shared/lib/data/engine`) both check `isOrmBackedSystemEntityId` **first**, but the read classifier trusted an active registration row over ORM-table resolution.
+
+## 2. Root cause
+
+Branch ordering. For an ORM-backed system entity, storage classification must be driven by the ORM-table resolution (`isOrmBackedSystemEntityId` = registry membership **and** `resolveRegisteredEntityTableName`), never by the mere existence of a `custom_entities` row. The read classifier was the only one of the three classification seams that did not enforce this ordering.
+
+## 3. Fix (implemented)
+
+Short-circuit ORM-backed system ids to `false` (base table) **before** probing `custom_entities`, mirroring the records API and the write guard:
+
+```ts
+// AFTER
+if (isOrmBackedSystemEntityId(this.em, entity)) {
+  result = false                                                  // ORM-backed => base table, ignore any custom_entities/storage rows (#2939)
+} else {
+  const row = await db.selectFrom('custom_entities').select('id')
+    .where('entity_id', '=', entity).where('is_active', '=', true).executeTakeFirst()
+  if (row) {
+    result = true
+  } else if (resolveRegisteredEntityTableName(this.em, entity) !== null) {
+    // Non-registry id whose entity segment collides with an ORM class name (e.g. `user:todo`
+    // vs the example module's `Todo`): resolves to a table but is NOT a system entity. Stray
+    // storage rows still must not hijack reads. (Behavior preserved exactly.)
+    result = false
+  } else {
+    result = await this.hasCustomEntityStorageRows(entity)        // read/write symmetry (behavior preserved)
+  }
+}
+```
+
+`isOrmBackedSystemEntityId` is imported from `@open-mercato/shared/lib/data/engine` (already used by the `entities` API and the records API — no new dependency direction).
+
+**Why this is minimal and safe:** the only classification that changes is "ORM-backed system id **with** an active `custom_entities` row": previously `true` (poison) → now `false` (correct, base table). Every other case is byte-for-byte preserved:
+- ORM-backed id with no row → already `false` (was via the `else if`, now via the short-circuit).
+- Non-ORM-backed collision id (`user:todo`) with/without a row → unchanged (`else` branch keeps the `resolveRegisteredEntityTableName` collision guard and the `hasCustomEntityStorageRows` fallback).
+- Genuinely custom entity (no ORM table) with an active row → still `true` (doc storage).
+
+Surfaces that intentionally read doc records for a dual-declared id keep using `forceCustomEntityStorage` in `QueryOptions` (unchanged; bypasses `isCustomEntity` entirely).
+
+## 4. Affected files
+- `packages/core/src/modules/query_index/lib/engine.ts` — `isCustomEntity` reorder + import of `isOrmBackedSystemEntityId`. **The fix.**
+- `packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts` — fake-Kysely `custom_entities` row support + two regression tests.
+- No change to `@open-mercato/shared/lib/data/engine` (`isOrmBackedSystemEntityId`, `assertCustomEntityStorageEntityId`), `records.ts` (`classifyRecordsEntity`), or any migration/schema.
+
+## 5. Test plan
+
+Unit (`hybrid-engine.test.ts`, extends the existing `#2939` classification suite):
+- **New, red→green:** an active `custom_entities` row for an ORM-backed entity (`customers:customer_deal`) → `isCustomEntity` returns `false` and `query()` reads `customer_deals`, not `custom_entities_storage`. (Verified to FAIL on the unpatched classifier with `Expected: false, Received: true`, and PASS after the fix.)
+- **New, over-reach guard:** a genuinely custom entity with no ORM table but an active registration row → still classifies as `true` (doc storage).
+- **Kept green:** existing #2939 stray-doc-row test, read/write-symmetry test, `forceCustomEntityStorage` test, and all coverage/sort/decrypt tests (24/24 in the suite; 62/62 across `query_index`; 48/48 across `entities` API).
+
+## 6. Backward compatibility
+- No public contract change: `QueryEngine.query` URL/types/response shapes unchanged. `isCustomEntity` is private. The change only **corrects** classification for ORM-backed ids carrying an active registration row — a state that today only produces broken (empty) reads.
+- No DB or schema change. No new ACL/feature, event, or DI surface.
+- Per `BACKWARD_COMPATIBILITY.md`: behavioral fix within the existing contract; no deprecation bridge required.
+
+## 7. Follow-up (separate PR)
+With the read classifier hardened, an active `custom_entities` overlay row for an ORM-backed system entity is inert for storage classification. That unblocks safely persisting a presentation-metadata overlay (label/description/defaultEditor) for system entities from the full “Edit Definitions” editor — tracked separately and stacked on this PR.

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -175,7 +175,10 @@ function resolveFirstRow(
     return config.hasIndexAny ? { entity_id: 'x' } : undefined
   }
   if (table === 'custom_entities') {
-    return undefined
+    // Active-registration probe used by isCustomEntity. Returns a row only when the
+    // fixture explicitly seeds `rows.custom_entities` (simulating an active overlay /
+    // registration row); existing fixtures that omit it keep the unregistered behavior.
+    return (config.rows?.custom_entities ?? []).length ? (config.rows!.custom_entities[0]) : undefined
   }
   return undefined
 }
@@ -760,6 +763,60 @@ describe('HybridQueryEngine custom-entity classification (#2939)', () => {
 
     const chains = db._chains as ChainLog[]
     expect(chains.some((chain) => chain.table === 'customer_deals')).toBe(true)
+  })
+
+  test('an active custom_entities registration row must not reroute a table-backed ORM entity away from its base table', async () => {
+    // Regression for the read-path asymmetry: isCustomEntity used to probe `custom_entities`
+    // FIRST and treat any active row as "doc storage", AHEAD of ORM-table resolution. An
+    // active overlay/registration row for an ORM-backed system id therefore hijacked every
+    // list/detail read of the whole entity type into the (empty) doc-storage table — the
+    // #2939 failure mode reachable via a metadata overlay alone. The ORM-backed guard now
+    // runs first, so the row is ignored for classification.
+    const db = createFakeKysely({
+      baseTable: 'customer_deals',
+      hasIndexAny: false,
+      baseCount: 282,
+      indexCount: 0,
+      customFieldKeys: {},
+      rows: {
+        custom_entities: [{ id: 'overlay-1' }],
+        custom_entities_storage: [{ entity_id: 'stray-doc-record' }],
+      },
+    })
+    const em = buildEmWithOrmMetadata(db, { CustomerDeal: 'customer_deals' })
+    const fallback = { query: jest.fn() }
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent: jest.fn() }))
+
+    await expect((engine as any).isCustomEntity('customers:customer_deal')).resolves.toBe(false)
+
+    await engine.query('customers:customer_deal', {
+      fields: ['id', 'title', 'pipeline_stage_id'],
+      includeCustomFields: true,
+      organizationIds: ['org1'],
+      tenantId: 't1',
+    })
+
+    const chains = db._chains as ChainLog[]
+    expect(chains.some((chain) => chain.table === 'customer_deals')).toBe(true)
+    expect(chains.some((chain) => chain.table === 'custom_entities_storage' && chain.selects.length > 0)).toBe(false)
+  })
+
+  test('a genuinely custom entity (no ORM table) with an active registration still routes to doc storage', async () => {
+    // Guards against the reorder over-reaching: an id that is NOT ORM-backed must still
+    // classify as custom when it has an active `custom_entities` registration row.
+    const db = createFakeKysely({
+      baseTable: 'unused',
+      hasIndexAny: false,
+      baseCount: 0,
+      indexCount: 0,
+      customFieldKeys: {},
+      rows: { custom_entities: [{ id: 'reg-1' }] },
+    })
+    const em = buildEmWithOrmMetadata(db, {})
+    const fallback = { query: jest.fn() }
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent: jest.fn() }))
+
+    await expect((engine as any).isCustomEntity('example:custom_thing')).resolves.toBe(true)
   })
 
   test('module-declared custom entities without an ORM table keep doc-storage routing (read/write symmetry)', async () => {

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -3,6 +3,7 @@ import { SortDir } from '@open-mercato/shared/lib/query/types'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { BasicQueryEngine, resolveEntityTableName, resolveRegisteredEntityTableName } from '@open-mercato/shared/lib/query/engine'
+import { isOrmBackedSystemEntityId } from '@open-mercato/shared/lib/data/engine'
 import { type Kysely, sql, type RawBuilder } from 'kysely'
 import type { EventBus } from '@open-mercato/events'
 import { readCoverageSnapshot, refreshCoverageSnapshot } from './coverage'
@@ -996,32 +997,44 @@ export class HybridQueryEngine implements QueryEngine {
     if (cached !== undefined) return cached
     let result = false
     try {
-      const db = this.getDb() as any
-      const row = await db
-        .selectFrom('custom_entities')
-        .select('id')
-        .where('entity_id', '=', entity)
-        .where('is_active', '=', true)
-        .executeTakeFirst()
-      if (row) {
-        result = true
-      } else if (resolveRegisteredEntityTableName(this.em, entity) !== null) {
-        // An id backed by a registered ORM table is never doc-storage-backed by
-        // inference: stray `custom_entities_storage` rows for such an id (e.g. written
-        // through the generic entities data engine) must not hijack every list/detail
-        // read for the whole entity type away from its base table (#2939). Surfaces
-        // that intentionally read doc records for a dual-declared id pass
-        // `forceCustomEntityStorage` in QueryOptions instead.
+      if (isOrmBackedSystemEntityId(this.em, entity)) {
+        // An id backed by a registered ORM table is never doc-storage-backed. Classify it
+        // as its base table BEFORE probing `custom_entities`, so neither a stray
+        // `custom_entities_storage` row nor an active `custom_entities` row (e.g. a
+        // presentation-metadata overlay for a system entity) can hijack every list/detail
+        // read for the whole entity type away from its base table (#2939). This mirrors the
+        // ORM-backed-first ordering already used by the records API (`classifyRecordsEntity`)
+        // and the doc-storage write guard (`assertCustomEntityStorageEntityId`); without it
+        // the read classifier alone trusted an active registration row over ORM-table
+        // resolution. Surfaces that intentionally read doc records for a dual-declared id
+        // pass `forceCustomEntityStorage` in QueryOptions instead.
         result = false
       } else {
-        // Read/write symmetry. Records written through the entities data engine
-        // (`de.createCustomEntityRecord`) always land in `custom_entities_storage`,
-        // even for module-declared custom entities whose id is also a frozen system
-        // id — those are NEVER registered in `custom_entities` (install treats a
-        // system id as non-registrable). Without this fallback the query routes to
-        // the empty ORM/index path and those records are write-only (created with
-        // 200 but unreadable on the edit form).
-        result = await this.hasCustomEntityStorageRows(entity)
+        const db = this.getDb() as any
+        const row = await db
+          .selectFrom('custom_entities')
+          .select('id')
+          .where('entity_id', '=', entity)
+          .where('is_active', '=', true)
+          .executeTakeFirst()
+        if (row) {
+          result = true
+        } else if (resolveRegisteredEntityTableName(this.em, entity) !== null) {
+          // A non-registry id whose entity segment collides with an ORM class name (e.g.
+          // `user:todo` vs the example module's `Todo`) resolves to a table but is NOT an
+          // ORM-backed system entity, so it is not short-circuited above. Stray
+          // `custom_entities_storage` rows for such an id must not hijack reads either.
+          result = false
+        } else {
+          // Read/write symmetry. Records written through the entities data engine
+          // (`de.createCustomEntityRecord`) always land in `custom_entities_storage`,
+          // even for module-declared custom entities whose id is also a frozen system
+          // id — those are NEVER registered in `custom_entities` (install treats a
+          // system id as non-registrable). Without this fallback the query routes to
+          // the empty ORM/index path and those records are write-only (created with
+          // 200 but unreadable on the edit form).
+          result = await this.hasCustomEntityStorageRows(entity)
+        }
       }
     } catch {
       result = false


### PR DESCRIPTION
## Summary
`HybridQueryEngine.isCustomEntity` — the platform-wide read-path storage classifier — probed `custom_entities` for an active registration row **before** checking ORM-table resolution. So a single active `custom_entities` row for an ORM-backed system entity (e.g. `customers:customer_person_profile`, `customers:customer_deal`) re-routed **every** list/detail read of that whole entity type to the empty `custom_entities_storage` table — the #2939 read-path-poisoning failure mode, reachable through a door the other classifiers already close.

## The asymmetry
Three seams decide custom (doc-storage) vs ORM-backed; only the read path was row-first:
- records API `classifyRecordsEntity` → `isOrmBackedSystemEntityId` **first** ✅
- doc-storage write guard `assertCustomEntityStorageEntityId` → `isOrmBackedSystemEntityId` **first** ✅
- read classifier `isCustomEntity` → active `custom_entities` row **first** ❌

```ts
// before
if (row) result = true                                              // any active row => doc storage
else if (resolveRegisteredEntityTableName(...) !== null) result = false  // only reached when NO row
else result = await this.hasCustomEntityStorageRows(entity)
```

## Fix
Short-circuit ORM-backed system ids to their base table **before** the `custom_entities` probe, mirroring the other two seams:

```ts
if (isOrmBackedSystemEntityId(this.em, entity)) {
  result = false
} else {
  // unchanged: active-row probe, collision-id guard, read/write-symmetry fallback
}
```

The collision-id guard (`resolveRegisteredEntityTableName`, for ids like `user:todo` whose segment collides with an ORM class name) and the `hasCustomEntityStorageRows` fallback are preserved **exactly**. The only classification that changes is "ORM-backed id + active registration row": `true` (poison) → `false` (correct). `forceCustomEntityStorage` still bypasses the classifier for surfaces that intentionally read doc rows for a dual-declared id.

## Tests
`packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts` (extends the existing `#2939` suite):
- **red→green:** an active `custom_entities` row for `customers:customer_deal` → `isCustomEntity` returns `false`; `query()` reads `customer_deals`, not `custom_entities_storage`. (Verified to FAIL on the unpatched classifier: `Expected: false, Received: true`.)
- **over-reach guard:** a genuinely custom entity (no ORM table) with an active registration row still classifies as `true` (doc storage).
- Existing tests stay green: 24/24 in the suite, 62/62 across `query_index`, 48/48 across `entities` API. Core typecheck clean.

## Backward compatibility
No public contract change (`isCustomEntity` is private; `QueryEngine.query` unchanged). No DB/schema change. The change only corrects classification for an ORM-backed id carrying an active registration row — a state that today only yields broken (empty) reads. Per `BACKWARD_COMPATIBILITY.md`: behavioral fix within the existing contract; no deprecation bridge required.

Full write-up: `.ai/specs/2026-06-15-query-index-orm-backed-classification-hardening.md` (included in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
