### PR TITLE
fix(deps): clear high-severity protobufjs & ws CVEs via patched resolutions

### DIFF
--- a/.ai/runs/2026-06-15-audit-high-severity-deps.md
+++ b/.ai/runs/2026-06-15-audit-high-severity-deps.md
@@ -1,0 +1,58 @@
+# Execution Plan: Fix high-severity `yarn npm audit` failures
+
+**Slug:** audit-high-severity-deps
+**Branch:** fix/audit-high-severity-deps
+**Base:** develop
+
+## Goal
+
+Make `yarn npm audit --all --recursive --severity high` (CI step `ci.yml:273`) pass
+again by forcing patched versions of three transitively-pulled, vulnerable packages.
+
+## Context
+
+CI `audit` job fails with three high-severity advisories:
+
+| Package | Advisory | Vulnerable | Pulled by | Patched target |
+|---------|----------|-----------|-----------|----------------|
+| `protobufjs` | GHSA-wcpc-wj8m-hjx6 (DoS via unbounded Any expansion) | `<=7.6.0` | `@grpc/proto-loader@0.8.1` (wants `^7.5.5`) | `7.6.4` |
+| `ws` (8.x) | GHSA-96hv-2xvq-fx4p (memory-exhaustion DoS) | `>=8.0.0 <8.21.0` | `engine.io@6.6.5`, `jsdom@26.1.0` (`^8.17.1`/`^8.18.0`/`~8.18.3`) | `8.21.0` |
+| `ws` (7.x) | GHSA-96hv-2xvq-fx4p (memory-exhaustion DoS) | `>=7.0.0 <7.5.11` | `webpack-bundle-analyzer@4.10.2` (`^7.3.1`) | `7.5.11` |
+
+Root `package.json` already pins `"protobufjs": "7.5.8"` in `resolutions` — that pin is
+itself the vulnerable version and must be bumped. `ws` has no resolution yet.
+
+`ws` 7.x consumer is kept on the 7.x line (`7.5.11`) to avoid the major-version API
+break that a blanket bump to 8.x would cause in `webpack-bundle-analyzer`.
+
+## Scope
+
+- `package.json` `resolutions` only.
+- `yarn.lock` regenerated to match.
+
+### Non-goals
+
+- No upgrade of the direct dependents themselves (`@grpc/proto-loader`, `jsdom`,
+  `engine.io`, `webpack-bundle-analyzer`) — out of scope and higher risk.
+- No source/code changes; no behavior change.
+
+## Risks
+
+- A blanket `ws` resolution could break `webpack-bundle-analyzer` (expects ws 7 API);
+  mitigated by scoping the 7.x descriptor to `7.5.11`.
+- `--immutable` install in CI requires the committed `yarn.lock` to be exactly
+  consistent with `package.json`; verified locally by re-running audit + a clean install.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Bump resolutions and regenerate lockfile
+
+- [ ] 1.1 Bump `protobufjs` resolution to `7.6.4` and add scoped `ws` resolutions (`^7.3.1`→`7.5.11`, 8.x→`8.21.0`)
+- [ ] 1.2 Run `yarn install` to regenerate `yarn.lock`; confirm resolved versions
+
+### Phase 2: Verify the audit gate
+
+- [ ] 2.1 Run `yarn npm audit --all --recursive --severity high` and confirm it passes
+- [ ] 2.2 Confirm `yarn install --immutable` is a no-op (lockfile consistent)

--- a/.ai/runs/2026-06-15-audit-high-severity-deps.md
+++ b/.ai/runs/2026-06-15-audit-high-severity-deps.md
@@ -49,10 +49,10 @@ break that a blanket bump to 8.x would cause in `webpack-bundle-analyzer`.
 
 ### Phase 1: Bump resolutions and regenerate lockfile
 
-- [ ] 1.1 Bump `protobufjs` resolution to `7.6.4` and add scoped `ws` resolutions (`^7.3.1`→`7.5.11`, 8.x→`8.21.0`)
-- [ ] 1.2 Run `yarn install` to regenerate `yarn.lock`; confirm resolved versions
+- [x] 1.1 Bump `protobufjs` resolution to `7.6.4` and add scoped `ws` resolutions (`^7.3.1`→`7.5.11`, 8.x→`8.21.0`) — b075665bf
+- [x] 1.2 Run `yarn install` to regenerate `yarn.lock`; confirm resolved versions (ws 7.5.11 + 8.21.0, protobufjs 7.6.4) — b075665bf
 
 ### Phase 2: Verify the audit gate
 
-- [ ] 2.1 Run `yarn npm audit --all --recursive --severity high` and confirm it passes
-- [ ] 2.2 Confirm `yarn install --immutable` is a no-op (lockfile consistent)
+- [x] 2.1 Run `yarn npm audit --all --recursive --severity high` and confirm it passes (exit 0, "No audit suggestions") — b075665bf
+- [x] 2.2 Confirm `yarn install --immutable` is a no-op (lockfile consistent) — b075665bf

--- a/package.json
+++ b/package.json
@@ -196,13 +196,17 @@
     "brace-expansion": "5.0.5",
     "handlebars": "4.7.9",
     "path-to-regexp": "0.1.13",
-    "protobufjs": "7.5.8",
+    "protobufjs": "7.6.4",
     "yaml": "2.8.3",
     "webpack": "5.104.1",
     "fast-xml-builder": "1.2.0",
     "shell-quote": "1.8.4",
     "dompurify": "3.4.9",
     "esbuild": "0.28.1",
-    "@grpc/grpc-js": "1.14.4"
+    "@grpc/grpc-js": "1.14.4",
+    "ws@npm:^7.3.1": "7.5.11",
+    "ws@npm:^8.17.1": "8.21.0",
+    "ws@npm:^8.18.0": "8.21.0",
+    "ws@npm:~8.18.3": "8.21.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8331,20 +8331,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/eventemitter@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/eventemitter@npm:1.1.0"
-  checksum: 10/03af3e99f17ad421283d054c88a06a30a615922a817741b43ca1b13e7c6b37820a37f6eba9980fb5150c54dba6e26cb6f7b64a6f7d8afa83596fafb3afa218c3
+"@protobufjs/eventemitter@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/eventemitter@npm:1.1.1"
+  checksum: 10/a54dc1aff4475ffad4fdf3235c71a553f5e40e3b4cf6a2e217151895a61cb4eb0be20d63791db22441ca25e594671f1021977133f9939540750231ff7d8e9dd6
   languageName: node
   linkType: hard
 
-"@protobufjs/fetch@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/fetch@npm:1.1.0"
+"@protobufjs/fetch@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/fetch@npm:1.1.1"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.1"
-    "@protobufjs/inquire": "npm:^1.1.0"
-  checksum: 10/67ae40572ad536e4ef94269199f252c024b66e3059850906bdaee161ca1d75c73d04d35cd56f147a8a5a079f5808e342b99e61942c1dae15604ff0600b09a958
+  checksum: 10/427cf2da8c69b494b0df3b2fb1f43c97f0f71ca2c8ef8232dac7e44f2527ad0cc9cecb243eda14a918e86018bfa6d54d92252240d2b37ed205b13adb5506fa1d
   languageName: node
   linkType: hard
 
@@ -8352,20 +8351,6 @@ __metadata:
   version: 1.0.2
   resolution: "@protobufjs/float@npm:1.0.2"
   checksum: 10/634c2c989da0ef2f4f19373d64187e2a79f598c5fb7991afb689d29a2ea17c14b796b29725945fa34b9493c17fb799e08ac0a7ccaae460ee1757d3083ed35187
-  languageName: node
-  linkType: hard
-
-"@protobufjs/inquire@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/inquire@npm:1.1.0"
-  checksum: 10/c09efa34a5465cb120775e1a482136f2340a58b4abce7e93d72b8b5a9324a0e879275016ef9fcd73d72a4731639c54f2bb755bb82f916e4a78892d1d840bb3d2
-  languageName: node
-  linkType: hard
-
-"@protobufjs/inquire@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@protobufjs/inquire@npm:1.1.1"
-  checksum: 10/504740e8ac348f70b33bcf6a20c83d5b9679901654c1a96b18c0491ec2f2f7ac580e74019b6d1bce16113bfb9746bc6e7dfd4e12a717deed699675b7f230ce9e
   languageName: node
   linkType: hard
 
@@ -21267,7 +21252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:^5.0.0":
+"long@npm:^5.0.0, long@npm:^5.3.2":
   version: 5.3.2
   resolution: "long@npm:5.3.2"
   checksum: 10/b6b55ddae56fcce2864d37119d6b02fe28f6dd6d9e44fd22705f86a9254b9321bd69e9ffe35263b4846d54aba197c64882adcb8c543f2383c1e41284b321ea64
@@ -25481,23 +25466,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:7.5.8":
-  version: 7.5.8
-  resolution: "protobufjs@npm:7.5.8"
+"protobufjs@npm:7.6.4":
+  version: 7.6.4
+  resolution: "protobufjs@npm:7.6.4"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
     "@protobufjs/codegen": "npm:^2.0.5"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/eventemitter": "npm:^1.1.1"
+    "@protobufjs/fetch": "npm:^1.1.1"
     "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.1"
     "@protobufjs/path": "npm:^1.1.2"
     "@protobufjs/pool": "npm:^1.1.0"
     "@protobufjs/utf8": "npm:^1.1.1"
     "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10/2beb69b88a5c0a8420d0d5934f2358d417ecd6446f4c0d7c8a9ba5fc0e62ec1631938c0ab083258c14f15b87d39d559b49b398779638df57b2f3a3238cc0be1c
+    long: "npm:^5.3.2"
+  checksum: 10/eb6898f3a128ba8622509c89b274b9cf899fbe9ecdea4a94e68a608b3c82f45161f78ee32ea650695976a06a7af217e3bffec387ae244b8e8aab23287a971ea9
   languageName: node
   linkType: hard
 
@@ -30334,9 +30318,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^7.3.1":
-  version: 7.5.10
-  resolution: "ws@npm:7.5.10"
+"ws@npm:7.5.11":
+  version: 7.5.11
+  resolution: "ws@npm:7.5.11"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -30345,13 +30329,13 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/9c796b84ba80ffc2c2adcdfc9c8e9a219ba99caa435c9a8d45f9ac593bba325563b3f83edc5eb067cc6d21b9a6bf2c930adf76dd40af5f58a5ca6859e81858f0
+  checksum: 10/486141e4a01bb75883f9ba39317309c2427e24db1cb75e340fad6e5886b65c03d994a34209f0e4ba06dd6cb9ec95dd1b6a09c52c05eed9a34d6376f4fbbf617c
   languageName: node
   linkType: hard
 
-"ws@npm:^8.17.1, ws@npm:^8.18.0":
-  version: 8.19.0
-  resolution: "ws@npm:8.19.0"
+"ws@npm:8.21.0":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -30360,22 +30344,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/26e4901e93abaf73af9f26a93707c95b4845e91a7a347ec8c569e6e9be7f9df066f6c2b817b2d685544e208207898a750b78461e6e8d810c11a370771450c31b
-  languageName: node
-  linkType: hard
-
-"ws@npm:~8.18.3":
-  version: 8.18.3
-  resolution: "ws@npm:8.18.3"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10/725964438d752f0ab0de582cd48d6eeada58d1511c3f613485b5598a83680bedac6187c765b0fe082e2d8cc4341fc57707c813ae780feee82d0c5efe6a4c61b6
+  checksum: 10/088411956432c8f876158409d5a285cb9ad1382f593391f51d3a599bd0a5b277f876609ebd00fc3596321c4a4c9064d6fffe1ebad960e8ea7fd9ae25324f35c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-15-audit-high-severity-deps.md
Status: complete

## Goal
- Make the CI `audit` step (`yarn npm audit --all --recursive --severity high`, `ci.yml:273`) pass by forcing patched versions of three transitively-pulled, high-severity-vulnerable packages.

## What Changed
Root `package.json` `resolutions` only (plus the regenerated `yarn.lock`):

| Package | Advisory | Was | Now |
|---------|----------|-----|-----|
| `protobufjs` | [GHSA-wcpc-wj8m-hjx6](https://github.com/advisories/GHSA-wcpc-wj8m-hjx6) — DoS via unbounded `Any` expansion (`<=7.6.0`) | `7.5.8` (pinned-vulnerable) | `7.6.4` |
| `ws` (8.x) | [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) — memory-exhaustion DoS (`>=8.0.0 <8.21.0`) | `8.18.3` / `8.19.0` | `8.21.0` |
| `ws` (7.x) | [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) — memory-exhaustion DoS (`>=7.0.0 <7.5.11`) | `7.5.10` | `7.5.11` |

- `protobufjs` is pulled by `@grpc/proto-loader@0.8.1` (wants `^7.5.5`; `7.6.4` satisfies it).
- `ws` 8.x is pulled by `engine.io@6.6.5` and `jsdom@26.1.0`.
- `ws` 7.x is pulled by `webpack-bundle-analyzer@4.10.2`; the `^7.3.1` consumer is deliberately kept on the 7.x line (`7.5.11`) to avoid the major-version API break a blanket bump to 8.x would cause.

## Tests
- No source changed, so there are no unit tests to add — this is a dependency-resolution-only change. The meaningful verification is the audit gate itself:
  - `yarn npm audit --all --recursive --severity high` → exit 0, "No audit suggestions".
  - `yarn install --immutable` → no lockfile changes (CI uses `--immutable`).
  - `yarn build:packages` → all 21 packages build successfully with the new dependency versions.

## Backward Compatibility
- No contract surface changes. Only `resolutions` were edited; bumps are patch/minor within the same major versions, with no public-API changes in `protobufjs` or `ws`.

## ⚠️ Pre-existing unrelated CI blocker
- `yarn typecheck` fails in `packages/events/src/bus.ts` with `TS2300: Duplicate identifier 'parseBooleanWithDefault'` (duplicate import at lines 3 and 5). This **pre-exists on `develop`** (introduced by the merge of #3017/#3018) and is **not** touched by this PR — the diff is limited to `package.json`, `yarn.lock`, and the run plan. It should be fixed in a separate one-line PR.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-15-audit-high-severity-deps.md#progress).
