### PR TITLE
feat(entities): allow metadata overlay for system entities in full editor (stacked on #3106)

### DIFF
--- a/.ai/specs/2026-06-15-query-index-orm-backed-classification-hardening.md
+++ b/.ai/specs/2026-06-15-query-index-orm-backed-classification-hardening.md
@@ -1,0 +1,85 @@
+# SPEC: Harden HybridQueryEngine custom-entity classification — ORM-backed ids before the `custom_entities` probe
+
+- Status: **Implemented** on this branch (`packages/core/src/modules/query_index/lib/engine.ts`); proposed for upstream contribution.
+- Date: 2026-06-15
+- Area: `query_index` module (`HybridQueryEngine` read-path storage classifier)
+- Severity: **High** — a single active `custom_entities` row for an ORM-backed system entity silently re-routes *every* list/detail read of that whole entity type to the (empty) doc-storage table. This is the #2939 read-path-poisoning failure mode, reachable through a door the existing guards do not cover.
+- Related: #2939 / #2942 (doc-storage rows poisoning read classification) and the doc-storage write seam `assertCustomEntityStorageEntityId`. Prerequisite for a planned follow-up that allows a presentation-metadata overlay on system entities (separate PR).
+
+## 1. Problem
+
+`HybridQueryEngine.isCustomEntity(entity)` is the platform-wide read-path classifier that decides whether `query()` reads an entity from its base ORM table (+ query index) or from doc storage (`custom_entities_storage`). It is **row-first**: it probes `custom_entities` for an active registration **before** considering whether the id is backed by a registered ORM table.
+
+```ts
+// BEFORE (packages/core/src/modules/query_index/lib/engine.ts)
+const row = await db.selectFrom('custom_entities').select('id')
+  .where('entity_id', '=', entity).where('is_active', '=', true).executeTakeFirst()
+if (row) {
+  result = true                                                   // custom => doc storage
+} else if (resolveRegisteredEntityTableName(this.em, entity) !== null) {
+  result = false                                                  // ORM-backed => base table (#2939 guard)
+} else {
+  result = await this.hasCustomEntityStorageRows(entity)
+}
+```
+
+The `else if` ORM-backed guard (added for #2939, so that *stray* `custom_entities_storage` rows cannot hijack reads) is only reached **when no active `custom_entities` row exists**. If an active `custom_entities` row exists for an ORM-backed system id (e.g. `customers:customer_person_profile` → `CustomerPersonProfile`, or `customers:customer_deal` → `CustomerDeal`), branch 1 fires and the id is classified as doc-storage-backed — so `query()` routes the entire entity type to the empty `custom_entities_storage` table and every list/detail read returns nothing.
+
+This is the exact asymmetry that makes the system-entity metadata-overlay use case unsafe: the records API (`classifyRecordsEntity`, `records.ts`) and the doc-storage write guard (`assertCustomEntityStorageEntityId`, `@open-mercato/shared/lib/data/engine`) both check `isOrmBackedSystemEntityId` **first**, but the read classifier trusted an active registration row over ORM-table resolution.
+
+## 2. Root cause
+
+Branch ordering. For an ORM-backed system entity, storage classification must be driven by the ORM-table resolution (`isOrmBackedSystemEntityId` = registry membership **and** `resolveRegisteredEntityTableName`), never by the mere existence of a `custom_entities` row. The read classifier was the only one of the three classification seams that did not enforce this ordering.
+
+## 3. Fix (implemented)
+
+Short-circuit ORM-backed system ids to `false` (base table) **before** probing `custom_entities`, mirroring the records API and the write guard:
+
+```ts
+// AFTER
+if (isOrmBackedSystemEntityId(this.em, entity)) {
+  result = false                                                  // ORM-backed => base table, ignore any custom_entities/storage rows (#2939)
+} else {
+  const row = await db.selectFrom('custom_entities').select('id')
+    .where('entity_id', '=', entity).where('is_active', '=', true).executeTakeFirst()
+  if (row) {
+    result = true
+  } else if (resolveRegisteredEntityTableName(this.em, entity) !== null) {
+    // Non-registry id whose entity segment collides with an ORM class name (e.g. `user:todo`
+    // vs the example module's `Todo`): resolves to a table but is NOT a system entity. Stray
+    // storage rows still must not hijack reads. (Behavior preserved exactly.)
+    result = false
+  } else {
+    result = await this.hasCustomEntityStorageRows(entity)        // read/write symmetry (behavior preserved)
+  }
+}
+```
+
+`isOrmBackedSystemEntityId` is imported from `@open-mercato/shared/lib/data/engine` (already used by the `entities` API and the records API — no new dependency direction).
+
+**Why this is minimal and safe:** the only classification that changes is "ORM-backed system id **with** an active `custom_entities` row": previously `true` (poison) → now `false` (correct, base table). Every other case is byte-for-byte preserved:
+- ORM-backed id with no row → already `false` (was via the `else if`, now via the short-circuit).
+- Non-ORM-backed collision id (`user:todo`) with/without a row → unchanged (`else` branch keeps the `resolveRegisteredEntityTableName` collision guard and the `hasCustomEntityStorageRows` fallback).
+- Genuinely custom entity (no ORM table) with an active row → still `true` (doc storage).
+
+Surfaces that intentionally read doc records for a dual-declared id keep using `forceCustomEntityStorage` in `QueryOptions` (unchanged; bypasses `isCustomEntity` entirely).
+
+## 4. Affected files
+- `packages/core/src/modules/query_index/lib/engine.ts` — `isCustomEntity` reorder + import of `isOrmBackedSystemEntityId`. **The fix.**
+- `packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts` — fake-Kysely `custom_entities` row support + two regression tests.
+- No change to `@open-mercato/shared/lib/data/engine` (`isOrmBackedSystemEntityId`, `assertCustomEntityStorageEntityId`), `records.ts` (`classifyRecordsEntity`), or any migration/schema.
+
+## 5. Test plan
+
+Unit (`hybrid-engine.test.ts`, extends the existing `#2939` classification suite):
+- **New, red→green:** an active `custom_entities` row for an ORM-backed entity (`customers:customer_deal`) → `isCustomEntity` returns `false` and `query()` reads `customer_deals`, not `custom_entities_storage`. (Verified to FAIL on the unpatched classifier with `Expected: false, Received: true`, and PASS after the fix.)
+- **New, over-reach guard:** a genuinely custom entity with no ORM table but an active registration row → still classifies as `true` (doc storage).
+- **Kept green:** existing #2939 stray-doc-row test, read/write-symmetry test, `forceCustomEntityStorage` test, and all coverage/sort/decrypt tests (24/24 in the suite; 62/62 across `query_index`; 48/48 across `entities` API).
+
+## 6. Backward compatibility
+- No public contract change: `QueryEngine.query` URL/types/response shapes unchanged. `isCustomEntity` is private. The change only **corrects** classification for ORM-backed ids carrying an active registration row — a state that today only produces broken (empty) reads.
+- No DB or schema change. No new ACL/feature, event, or DI surface.
+- Per `BACKWARD_COMPATIBILITY.md`: behavioral fix within the existing contract; no deprecation bridge required.
+
+## 7. Follow-up (separate PR)
+With the read classifier hardened, an active `custom_entities` overlay row for an ORM-backed system entity is inert for storage classification. That unblocks safely persisting a presentation-metadata overlay (label/description/defaultEditor) for system entities from the full “Edit Definitions” editor — tracked separately and stacked on this PR.

--- a/.ai/specs/2026-06-15-system-entity-full-editor-custom-fields.md
+++ b/.ai/specs/2026-06-15-system-entity-full-editor-custom-fields.md
@@ -1,0 +1,127 @@
+# SPEC: System-entity full-editor save fails with "System entities cannot be registered as custom entities"
+
+- Status: **Implemented** across two stacked PRs — read-classifier hardening (#3106, see
+  `2026-06-15-query-index-orm-backed-classification-hardening.md`) and this metadata-overlay change
+  (`packages/core/src/modules/entities/api/entities.ts`). Proposed for upstream contribution.
+- Date: 2026-06-15
+- Area: `entities` module (custom entities / custom fields, EAV) + `query_index` (read classifier, via #3106)
+- Severity: High (blocks editing field definitions + metadata for any system entity via the full editor)
+- Related history: #2411 (`7bf54b807`) introduced system-entity metadata persistence; #2939 (`c5fa98eaa`) introduced the guard that broke it; #3106 hardens the read classifier this fix depends on.
+
+## 1. Problem
+
+When a user opens the full "Edit Definitions" editor for a **system** entity (source `code`), e.g.
+`customers:customer_person_profile`, at:
+
+- Page: `packages/core/src/modules/entities/backend/entities/system/[entityId]/page.tsx`
+  (a thin re-export of `.../entities/user/[entityId]/page.tsx`)
+- Route: `/backend/entities/system/<entityId>`
+
+clicking **Save** failed with HTTP 400:
+
+```json
+{ "error": "System entities cannot be registered as custom entities",
+  "code": "system_entity_records_blocked", "entityId": "customers:customer_person_profile" }
+```
+
+The **inline** "Edit custom fields" dialog (which POSTs only to `/api/entities/definitions.batch`)
+saved the **same** field definitions for the **same** system entity with no error. Both surfaces are
+supposed to let an operator attach custom **field definitions** to a system entity; only the full
+editor was broken.
+
+## 2. Root cause
+
+### 2.1 The full editor makes two calls; the first trips the guard
+
+`handleCrudFormSubmit` (`.../entities/user/[entityId]/page.tsx`) makes two API calls on every save,
+regardless of `entitySource`:
+
+1. `POST /api/entities/entities` — upserts a `CustomEntity` row carrying entity-level metadata
+   (`label`, `description`, `defaultEditor`; `showInSidebar` only for custom). For `code`-sourced
+   entities `buildEntityMetadataPayload('code', …)` returns a metadata-only payload
+   (`label`/`description`/`defaultEditor`).
+2. `POST /api/entities/definitions.batch` — writes the field **definitions** (only `CustomFieldDef` /
+   `CustomFieldEntityConfig`; never a `CustomEntity` row; never calls the system-entity guard).
+
+The first call is unconditional (by design from #2411, whose goal was to persist label/description/
+defaultEditor for system entities via a `CustomEntity` overlay, with the GET merge pinning
+`source: 'code'`). The `isOrmBackedSystemEntityId` guard added in #2939 rejected that call outright,
+so the full-editor Save 400s while the inline dialog (call #2 only) succeeds.
+
+### 2.2 Why the broad guard existed — and why a naive re-allow was unsafe
+
+#2939 added the guard to stop a `CustomEntity` registration from flipping query-engine storage
+classification to doc storage for an ORM-backed entity (the #2939/#2942 read-poisoning failure).
+A first proposal ("Option A: just write a metadata-only overlay and return ok") was **verified
+unsafe**: the read-path classifier `HybridQueryEngine.isCustomEntity` probed `custom_entities` for an
+active row **before** checking ORM-table resolution, so an active overlay row for an ORM-backed system
+entity would re-route every list/detail read of the whole type to the empty `custom_entities_storage`
+table — re-opening #2939 through metadata alone. `showInSidebar=false` and the GET `source:'code'` pin
+do not help (the classifier consults neither).
+
+The asymmetry: the records API (`classifyRecordsEntity`) and the doc-storage write guard
+(`assertCustomEntityStorageEntityId`) both key off `isOrmBackedSystemEntityId` **first**; only the read
+classifier was row-first.
+
+## 3. Fix (implemented, two stacked PRs)
+
+**PR-1 — read-classifier hardening (#3106).** Reorder `HybridQueryEngine.isCustomEntity` to
+short-circuit `isOrmBackedSystemEntityId(em, entity) → base table` **before** the `custom_entities`
+probe, mirroring the records API and the write guard. After this, an active `custom_entities` overlay
+row for an ORM-backed system entity is inert for storage classification. (Full write-up:
+`2026-06-15-query-index-orm-backed-classification-hardening.md`.)
+
+**PR-2 — metadata overlay (this change).** In `POST /api/entities/entities`
+(`packages/core/src/modules/entities/api/entities.ts`), replace the unconditional 400 for ORM-backed
+system entities with a **metadata-only overlay** write:
+
+- Persist only `label` / `description` / `defaultEditor`.
+- Force `showInSidebar = false` and leave `labelField` untouched, so the overlay can neither surface a
+  records UI nor relabel the system entity's record routing.
+- Return `ok`. Genuine (non-ORM-backed) custom entities keep their full behavior, including
+  `showInSidebar` / `labelField`.
+
+The doc-storage **write** guards are unchanged and still fire: `assertCustomEntityStorageEntityId`
+(create/update/delete record) and `classifyRecordsEntity` (records API) keep rejecting doc-storage
+writes / records-UI access for ORM-backed system entities. So an operator can edit a system entity's
+label/description/defaultEditor and its field definitions, but cannot create doc-storage records for it.
+
+## 4. Affected files
+- `packages/core/src/modules/query_index/lib/engine.ts` — `isCustomEntity` reorder (**PR-1 / #3106**).
+- `packages/core/src/modules/entities/api/entities.ts` — `POST` metadata-overlay branch; dropped the
+  now-unused `SYSTEM_ENTITY_RECORDS_BLOCKED_CODE` import (**PR-2 / this change**).
+- `packages/core/src/modules/entities/api/__tests__/entities.api.test.ts` — POST overlay tests (PR-2).
+- `packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts` — classifier tests (PR-1).
+- No change to `@open-mercato/shared/lib/data/engine`, `records.ts`, the editor page, or any migration.
+  No client gate needed in the editor: it already posts a metadata-only payload for `code` source, so
+  the server change alone makes Save succeed.
+
+## 5. Test plan
+
+Unit (Jest):
+- `entities.api.test.ts` (PR-2): POST for an ORM-backed system entity persists a metadata-only overlay
+  (`showInSidebar` forced false, `labelField` ignored) and returns 200 — verified red→green
+  (`Expected 200, Received 400` on the pre-fix handler). POST for a genuine custom entity still persists
+  full fields. GET overlay-merge tests stay green (`source: 'code'` preserved).
+- `hybrid-engine.test.ts` (PR-1): active `custom_entities` row for an ORM-backed id no longer reroutes
+  reads to doc storage (red→green); genuinely custom entity with a row still routes to doc storage.
+- `definitions.batch` tests stay green (system-entity definitions unaffected).
+- Suite results: `query_index` 62/62, `entities` API 50/50; core typecheck clean.
+
+Integration / manual (matches the repro):
+- System full editor: edit + Save `customers:customer_person_profile` → no 400, redirect to
+  `/backend/entities/system?flash=Definitions saved&type=success`; metadata + definitions persist.
+- Regression: list/detail reads of `customers:customer_person_profile` (and other ORM-backed system
+  entities) still resolve against their ORM tables — the #2939/#2942 scenario stays closed.
+
+## 6. Backward compatibility
+- `POST /api/entities/entities` keeps its URL, request schema (`upsertCustomEntitySchema`), and
+  200/400 response shapes. The change only **narrows** the inputs that 400 (system-entity metadata
+  overlays now succeed). The `system_entity_records_blocked` rejection stays in force for the genuine
+  doc-storage paths (`assertCustomEntityStorageEntityId`, `classifyRecordsEntity`).
+- No DB/schema change; the overlay uses the existing `CustomEntity` columns from #2411.
+- Per `BACKWARD_COMPATIBILITY.md`: behavioral change within the existing contract; no deprecation bridge.
+
+## 7. Changelog
+- 2026-06-15: Verified Option A unsafe without classifier hardening; split into PR-1 (#3106 read
+  classifier) + PR-2 (metadata overlay). Implemented both; added red→green regression tests for each.

--- a/packages/core/src/modules/entities/api/__tests__/entities.api.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/entities.api.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment node */
-import { GET } from '../entities'
+import { GET, POST } from '../entities'
+import { isOrmBackedSystemEntityId } from '@open-mercato/shared/lib/data/engine'
 
 const mockEm = {
   find: jest.fn(),
@@ -35,6 +36,10 @@ jest.mock('@open-mercato/shared/lib/encryption/entityIds', () => ({
 
 jest.mock('@open-mercato/shared/lib/entities/system-entities', () => ({
   isSystemEntitySelectable: (id: string) => id === 'customers:customer_person',
+}))
+
+jest.mock('@open-mercato/shared/lib/data/engine', () => ({
+  isOrmBackedSystemEntityId: jest.fn(),
 }))
 
 describe('GET /api/entities/entities — overlay merge', () => {
@@ -81,5 +86,67 @@ describe('GET /api/entities/entities — overlay merge', () => {
     const item = json.items.find((i: { entityId: string }) => i.entityId === 'customers:customer_person')
     expect(item).toBeDefined()
     expect(item.source).toBe('code')
+  })
+})
+
+describe('POST /api/entities/entities — system-entity metadata overlay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm.findOne.mockResolvedValue(null)
+    mockEm.create.mockImplementation((_cls: unknown, data: Record<string, unknown>) => ({ ...data }))
+  })
+
+  const post = (body: Record<string, unknown>) =>
+    POST(new Request('http://x/api/entities/entities', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }))
+
+  it('persists a metadata-only overlay for an ORM-backed system entity instead of returning 400', async () => {
+    // Pre-#3106 this returned 400 "System entities cannot be registered as custom entities";
+    // with the read classifier hardened, the overlay row is inert for storage and is allowed.
+    ;(isOrmBackedSystemEntityId as jest.Mock).mockReturnValue(true)
+
+    const response = await post({
+      entityId: 'customers:customer_person_profile',
+      label: 'Person profile',
+      description: 'Overlay description',
+      defaultEditor: 'markdown',
+      // Both of the following MUST be ignored/forced for a system entity:
+      labelField: 'should_be_ignored',
+      showInSidebar: true,
+    })
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.ok).toBe(true)
+    expect(mockEm.flush).toHaveBeenCalled()
+
+    const persisted = mockEm.persist.mock.calls[0][0]
+    expect(persisted.label).toBe('Person profile')
+    expect(persisted.description).toBe('Overlay description')
+    expect(persisted.defaultEditor).toBe('markdown')
+    // System overlays never surface a sidebar entry and never relabel record routing.
+    expect(persisted.showInSidebar).toBe(false)
+    expect(persisted.labelField ?? null).toBeNull()
+  })
+
+  it('persists full fields (incl. showInSidebar/labelField) for a genuine custom entity', async () => {
+    ;(isOrmBackedSystemEntityId as jest.Mock).mockReturnValue(false)
+
+    const response = await post({
+      entityId: 'my_module:thing',
+      label: 'Thing',
+      defaultEditor: 'htmlRichText',
+      labelField: 'name',
+      showInSidebar: true,
+    })
+
+    expect(response.status).toBe(200)
+    const persisted = mockEm.persist.mock.calls[0][0]
+    expect(persisted.showInSidebar).toBe(true)
+    expect(persisted.labelField).toBe('name')
+    expect(persisted.defaultEditor).toBe('htmlRichText')
   })
 })

--- a/packages/core/src/modules/entities/api/entities.ts
+++ b/packages/core/src/modules/entities/api/entities.ts
@@ -7,7 +7,7 @@ import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import { upsertCustomEntitySchema } from '@open-mercato/core/modules/entities/data/validators'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { isSystemEntitySelectable } from '@open-mercato/shared/lib/entities/system-entities'
-import { SYSTEM_ENTITY_RECORDS_BLOCKED_CODE, isOrmBackedSystemEntityId } from '@open-mercato/shared/lib/data/engine'
+import { isOrmBackedSystemEntityId } from '@open-mercato/shared/lib/data/engine'
 
 export const metadata = {
   GET: { requireAuth: true },
@@ -108,15 +108,18 @@ export async function POST(req: Request) {
   const { resolve } = await createRequestContainer()
   const em = resolve('em') as any
 
-  // A registration for a module-declared, table-backed system entity would flip
-  // query-engine classification to doc storage for the whole entity type (#2939's
-  // failure mode via another door) — refuse to create one.
-  if (isOrmBackedSystemEntityId(em, input.entityId)) {
-    return NextResponse.json(
-      { error: 'System entities cannot be registered as custom entities', code: SYSTEM_ENTITY_RECORDS_BLOCKED_CODE, entityId: input.entityId },
-      { status: 400 },
-    )
-  }
+  // For a module-declared, ORM-backed system entity we persist ONLY a presentation-metadata
+  // overlay (label/description/defaultEditor) — never a record-bearing custom-entity registration.
+  // Such an entity's records always live in its own ORM table; the overlay row is inert for
+  // storage classification because every seam keys off isOrmBackedSystemEntityId, not the row:
+  // the records API (classifyRecordsEntity) and the doc-storage write guard
+  // (assertCustomEntityStorageEntityId) check it first, and the read classifier
+  // (HybridQueryEngine.isCustomEntity) was hardened to do the same (#3106). So the overlay cannot
+  // reopen #2939. We force showInSidebar off and leave labelField untouched so the overlay can
+  // neither surface a records UI nor relabel the system entity's record routing. The full
+  // "Edit Definitions" editor relies on this to persist label/description/defaultEditor for a
+  // system entity (restoring the capability the broad #2939 guard had removed).
+  const isSystemEntity = isOrmBackedSystemEntityId(em, input.entityId)
 
   const where: any = { entityId: input.entityId, organizationId: auth.orgId ?? null, tenantId: auth.tenantId ?? null }
   let ent = await em.findOne(CustomEntity, where)
@@ -124,9 +127,13 @@ export async function POST(req: Request) {
   ent.label = input.label
   ent.description = input.description ?? null
   ent.isActive = input.isActive ?? true
-  ent.labelField = input.labelField ?? ent.labelField ?? null
   ent.defaultEditor = input.defaultEditor ?? ent.defaultEditor ?? null
-  ent.showInSidebar = input.showInSidebar ?? ent.showInSidebar ?? false
+  if (isSystemEntity) {
+    ent.showInSidebar = false
+  } else {
+    ent.labelField = input.labelField ?? ent.labelField ?? null
+    ent.showInSidebar = input.showInSidebar ?? ent.showInSidebar ?? false
+  }
   ent.updatedAt = new Date()
   em.persist(ent)
   await em.flush()

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -175,7 +175,10 @@ function resolveFirstRow(
     return config.hasIndexAny ? { entity_id: 'x' } : undefined
   }
   if (table === 'custom_entities') {
-    return undefined
+    // Active-registration probe used by isCustomEntity. Returns a row only when the
+    // fixture explicitly seeds `rows.custom_entities` (simulating an active overlay /
+    // registration row); existing fixtures that omit it keep the unregistered behavior.
+    return (config.rows?.custom_entities ?? []).length ? (config.rows!.custom_entities[0]) : undefined
   }
   return undefined
 }
@@ -760,6 +763,60 @@ describe('HybridQueryEngine custom-entity classification (#2939)', () => {
 
     const chains = db._chains as ChainLog[]
     expect(chains.some((chain) => chain.table === 'customer_deals')).toBe(true)
+  })
+
+  test('an active custom_entities registration row must not reroute a table-backed ORM entity away from its base table', async () => {
+    // Regression for the read-path asymmetry: isCustomEntity used to probe `custom_entities`
+    // FIRST and treat any active row as "doc storage", AHEAD of ORM-table resolution. An
+    // active overlay/registration row for an ORM-backed system id therefore hijacked every
+    // list/detail read of the whole entity type into the (empty) doc-storage table — the
+    // #2939 failure mode reachable via a metadata overlay alone. The ORM-backed guard now
+    // runs first, so the row is ignored for classification.
+    const db = createFakeKysely({
+      baseTable: 'customer_deals',
+      hasIndexAny: false,
+      baseCount: 282,
+      indexCount: 0,
+      customFieldKeys: {},
+      rows: {
+        custom_entities: [{ id: 'overlay-1' }],
+        custom_entities_storage: [{ entity_id: 'stray-doc-record' }],
+      },
+    })
+    const em = buildEmWithOrmMetadata(db, { CustomerDeal: 'customer_deals' })
+    const fallback = { query: jest.fn() }
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent: jest.fn() }))
+
+    await expect((engine as any).isCustomEntity('customers:customer_deal')).resolves.toBe(false)
+
+    await engine.query('customers:customer_deal', {
+      fields: ['id', 'title', 'pipeline_stage_id'],
+      includeCustomFields: true,
+      organizationIds: ['org1'],
+      tenantId: 't1',
+    })
+
+    const chains = db._chains as ChainLog[]
+    expect(chains.some((chain) => chain.table === 'customer_deals')).toBe(true)
+    expect(chains.some((chain) => chain.table === 'custom_entities_storage' && chain.selects.length > 0)).toBe(false)
+  })
+
+  test('a genuinely custom entity (no ORM table) with an active registration still routes to doc storage', async () => {
+    // Guards against the reorder over-reaching: an id that is NOT ORM-backed must still
+    // classify as custom when it has an active `custom_entities` registration row.
+    const db = createFakeKysely({
+      baseTable: 'unused',
+      hasIndexAny: false,
+      baseCount: 0,
+      indexCount: 0,
+      customFieldKeys: {},
+      rows: { custom_entities: [{ id: 'reg-1' }] },
+    })
+    const em = buildEmWithOrmMetadata(db, {})
+    const fallback = { query: jest.fn() }
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent: jest.fn() }))
+
+    await expect((engine as any).isCustomEntity('example:custom_thing')).resolves.toBe(true)
   })
 
   test('module-declared custom entities without an ORM table keep doc-storage routing (read/write symmetry)', async () => {

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -3,6 +3,7 @@ import { SortDir } from '@open-mercato/shared/lib/query/types'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { BasicQueryEngine, resolveEntityTableName, resolveRegisteredEntityTableName } from '@open-mercato/shared/lib/query/engine'
+import { isOrmBackedSystemEntityId } from '@open-mercato/shared/lib/data/engine'
 import { type Kysely, sql, type RawBuilder } from 'kysely'
 import type { EventBus } from '@open-mercato/events'
 import { readCoverageSnapshot, refreshCoverageSnapshot } from './coverage'
@@ -996,32 +997,44 @@ export class HybridQueryEngine implements QueryEngine {
     if (cached !== undefined) return cached
     let result = false
     try {
-      const db = this.getDb() as any
-      const row = await db
-        .selectFrom('custom_entities')
-        .select('id')
-        .where('entity_id', '=', entity)
-        .where('is_active', '=', true)
-        .executeTakeFirst()
-      if (row) {
-        result = true
-      } else if (resolveRegisteredEntityTableName(this.em, entity) !== null) {
-        // An id backed by a registered ORM table is never doc-storage-backed by
-        // inference: stray `custom_entities_storage` rows for such an id (e.g. written
-        // through the generic entities data engine) must not hijack every list/detail
-        // read for the whole entity type away from its base table (#2939). Surfaces
-        // that intentionally read doc records for a dual-declared id pass
-        // `forceCustomEntityStorage` in QueryOptions instead.
+      if (isOrmBackedSystemEntityId(this.em, entity)) {
+        // An id backed by a registered ORM table is never doc-storage-backed. Classify it
+        // as its base table BEFORE probing `custom_entities`, so neither a stray
+        // `custom_entities_storage` row nor an active `custom_entities` row (e.g. a
+        // presentation-metadata overlay for a system entity) can hijack every list/detail
+        // read for the whole entity type away from its base table (#2939). This mirrors the
+        // ORM-backed-first ordering already used by the records API (`classifyRecordsEntity`)
+        // and the doc-storage write guard (`assertCustomEntityStorageEntityId`); without it
+        // the read classifier alone trusted an active registration row over ORM-table
+        // resolution. Surfaces that intentionally read doc records for a dual-declared id
+        // pass `forceCustomEntityStorage` in QueryOptions instead.
         result = false
       } else {
-        // Read/write symmetry. Records written through the entities data engine
-        // (`de.createCustomEntityRecord`) always land in `custom_entities_storage`,
-        // even for module-declared custom entities whose id is also a frozen system
-        // id — those are NEVER registered in `custom_entities` (install treats a
-        // system id as non-registrable). Without this fallback the query routes to
-        // the empty ORM/index path and those records are write-only (created with
-        // 200 but unreadable on the edit form).
-        result = await this.hasCustomEntityStorageRows(entity)
+        const db = this.getDb() as any
+        const row = await db
+          .selectFrom('custom_entities')
+          .select('id')
+          .where('entity_id', '=', entity)
+          .where('is_active', '=', true)
+          .executeTakeFirst()
+        if (row) {
+          result = true
+        } else if (resolveRegisteredEntityTableName(this.em, entity) !== null) {
+          // A non-registry id whose entity segment collides with an ORM class name (e.g.
+          // `user:todo` vs the example module's `Todo`) resolves to a table but is NOT an
+          // ORM-backed system entity, so it is not short-circuited above. Stray
+          // `custom_entities_storage` rows for such an id must not hijack reads either.
+          result = false
+        } else {
+          // Read/write symmetry. Records written through the entities data engine
+          // (`de.createCustomEntityRecord`) always land in `custom_entities_storage`,
+          // even for module-declared custom entities whose id is also a frozen system
+          // id — those are NEVER registered in `custom_entities` (install treats a
+          // system id as non-registrable). Without this fallback the query routes to
+          // the empty ORM/index path and those records are write-only (created with
+          // 200 but unreadable on the edit form).
+          result = await this.hasCustomEntityStorageRows(entity)
+        }
       }
     } catch {
       result = false


### PR DESCRIPTION
> ⚠️ **Stacked on #3106.** This PR branches off #3106, so its diff currently also shows that commit (`fix(query_index): classify ORM-backed ids …`). Review/merge **after #3106 lands**; I'll rebase onto `main` then, leaving only the `entities` change. Kept as **draft** until #3106 merges.

## Summary
The full "Edit Definitions" editor for a **system** entity (`/backend/entities/system/<id>`) failed on **Save** with HTTP 400 `System entities cannot be registered as custom entities`. The editor unconditionally `POST`s `/api/entities/entities` to persist entity metadata (label/description/defaultEditor), and the #2939 guard rejected that for ORM-backed system entities. Field-definition edits (via `definitions.batch`) were unaffected — only the full-editor Save broke. The inline "Edit custom fields" dialog (which only calls `definitions.batch`) worked.

## Fix
Replace the unconditional 400 in `POST /api/entities/entities` with a **metadata-only overlay** for ORM-backed system entities: persist `label`/`description`/`defaultEditor`, force `showInSidebar=false`, leave `labelField` untouched, return `ok`. Genuine (non-ORM-backed) custom entities keep full behavior including `showInSidebar`/`labelField`.

This is safe **only because of #3106**: the read classifier now resolves ORM-backed ids to their base table *before* the `custom_entities` probe, so the overlay row is inert for storage classification. The doc-storage **write** guards are unchanged and still fire — `assertCustomEntityStorageEntityId` (record writes) and `classifyRecordsEntity` (records API) keep rejecting doc-storage records / the records UI for system entities. Net: you can edit a system entity's metadata + field definitions, but cannot create doc-storage records for it.

No editor change needed — the client already sends a metadata-only payload for `code` source, so the server change alone makes Save succeed.

## Tests
`packages/core/src/modules/entities/api/__tests__/entities.api.test.ts`:
- POST for an ORM-backed system entity → **200**, persists overlay with `showInSidebar=false` and `labelField` ignored (verified red→green: `Expected 200, Received 400` on the pre-fix handler).
- POST for a genuine custom entity → still persists full fields (`showInSidebar`/`labelField`).
- Existing GET overlay-merge tests (`source: 'code'` pin) stay green.
- `entities` API 50/50, `query_index` 62/62, core typecheck clean.

## Backward compatibility
`POST /api/entities/entities` keeps its URL, request schema, and 200/400 response shapes; the change only **narrows** the inputs that 400. `system_entity_records_blocked` stays in force for the genuine doc-storage paths. No DB/schema change. Per `BACKWARD_COMPATIBILITY.md`: behavioral change within the existing contract; no deprecation bridge.

Full write-up: `.ai/specs/2026-06-15-system-entity-full-editor-custom-fields.md` (in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
