### PR TITLE
fix(integration): inline persistent event delivery in the ephemeral env to de-flake TC-CRM-028 & TC-WF-008

### DIFF
--- a/packages/cli/src/lib/testing/integration.ts
+++ b/packages/cli/src/lib/testing/integration.ts
@@ -1671,6 +1671,11 @@ function buildReusableEnvironment(
     // not have to call flushPendingCrudAccessLogs() explicitly.
     OM_CRUD_ACCESS_LOG_BLOCKING: process.env.OM_CRUD_ACCESS_LOG_BLOCKING ?? '1',
     OM_WEBHOOKS_ALLOW_PRIVATE_URLS: process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS ?? '1',
+    // Keep the bus in the Playwright process (used by in-test queue-drain helpers)
+    // on the same delivery mode as the app server it drives: inline persistent
+    // delivery so event side effects are deterministic for assertions. See the
+    // matching OM_EVENTS_SINGLE_DELIVERY note on the app server environment below.
+    OM_EVENTS_SINGLE_DELIVERY: process.env.OM_EVENTS_SINGLE_DELIVERY ?? 'false',
     ENABLE_CRUD_API_CACHE: 'true',
     MOCK_GATEWAY_WEBHOOK_SECRET: 'open-mercato-mock-dev-webhook-secret',
     MOCK_CARRIER_WEBHOOK_SECRET: 'open-mercato-mock-dev-carrier-webhook-secret',
@@ -2987,6 +2992,18 @@ export async function startEphemeralEnvironment(options: EphemeralRuntimeOptions
       CI: 'true',
       TENANT_DATA_ENCRYPTION_FALLBACK_KEY: process.env.TENANT_DATA_ENCRYPTION_FALLBACK_KEY ?? 'om-ephemeral-integration-fallback-key',
       AUTO_SPAWN_WORKERS: process.env.AUTO_SPAWN_WORKERS ?? 'true',
+      // Process persistent event subscribers INLINE in the request that emits
+      // the event (legacy dual-dispatch), rather than the production default of
+      // worker-only single delivery. Integration specs assert event side effects
+      // (sync mappings, workflow-trigger instances, notifications) immediately
+      // after the emitting API call and poll for them on short budgets; routing
+      // those subscribers through the async events worker makes the side effect
+      // race the poll under the 15-shard CI load, which surfaced as flaky
+      // timeouts in TC-CRM-028 (inbound sync mapping) and TC-WF-008 (event-
+      // triggered workflow) once single-delivery became default-ON. Inline
+      // delivery makes the side effects deterministic for tests; production keeps
+      // the single-delivery default. Honor an explicit override if the caller set one.
+      OM_EVENTS_SINGLE_DELIVERY: process.env.OM_EVENTS_SINGLE_DELIVERY ?? 'false',
       AUTO_SPAWN_SCHEDULER: 'false',
       // Hide the demo feedback floating action button — it lives at
       // `fixed bottom-6 right-6 z-banner` and consistently intercepts pointer


### PR DESCRIPTION
## Why

Today's flip of `OM_EVENTS_SINGLE_DELIVERY` to **default-ON** (#3101) moved persistent event subscribers off the inline request path — they now run **only** when the events worker drains the queue. The ephemeral integration runtime auto-spawns that worker, so delivery still happens, but it now **races** specs that assert event side effects immediately after the emitting API call and poll for them on short budgets. Under the 15-shard CI load the worker lags the poll, surfacing as flaky timeouts on the first develop run with the new default:

| Spec | Failure |
|------|---------|
| `TC-CRM-028` › *creates a canonical interaction when a linked example todo is created* | `waitForMapping()` never saw the inbound sync mapping within 15s — `expect(received).not.toBeNull()` → `Received: null` |
| `TC-WF-008` › *creates a triggered workflow, fires the event through CRM UI, and sees the instance execute* | the wildcard workflow-trigger subscriber's instance never reached `COMPLETED` within the 90s poll |

Root cause is the **delivery-timing change, not the assertions** — the whole suite was green under the prior dual-dispatch default, where these persistent subscribers ran inline (synchronously) in the emitting request. The events worker *does* run in the ephemeral env (`[queue:events] Job … completed` appears in the logs); it simply can't keep the side effect ahead of the poll under parallel load.

## What

Force `OM_EVENTS_SINGLE_DELIVERY=false` in the **ephemeral integration environment only** (the app server it boots *and* the in-test queue-drain process), so persistent subscribers run inline again and event side effects are deterministic for the specs.

- Scoped to the test harness (`packages/cli/src/lib/testing/integration.ts`) — **production keeps the single-delivery default.**
- An explicit `OM_EVENTS_SINGLE_DELIVERY` override is still honored (`?? 'false'`).
- Restores the exact delivery mode the integration suite was validated under before #3101.

## Verification

- `yarn workspace @open-mercato/cli typecheck` → clean
- `yarn workspace @open-mercato/cli test` → 974 passed / 55 suites
- CI `ephemeral-integration` shards re-exercise TC-CRM-028 + TC-WF-008 under the new env.

## Context

Discovered while waiting on develop/main CI. The companion failure from the same investigation — main's red `audit` job (high-severity `ws`/`protobufjs` CVEs) — was already resolved on develop by #3107 (byte-identical to the fix I had staged), so this PR carries only the integration-flake fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
