### PR TITLE
fix(entities): add optimistic locking to entity definition edit form (#3117)

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/entities.api.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/entities.api.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment node */
-import { GET } from '../entities'
+import { GET, POST } from '../entities'
+import { OPTIMISTIC_LOCK_HEADER_NAME, OPTIMISTIC_LOCK_CONFLICT_CODE } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
 
 const mockEm = {
   find: jest.fn(),
@@ -35,6 +36,11 @@ jest.mock('@open-mercato/shared/lib/encryption/entityIds', () => ({
 
 jest.mock('@open-mercato/shared/lib/entities/system-entities', () => ({
   isSystemEntitySelectable: (id: string) => id === 'customers:customer_person',
+}))
+
+jest.mock('@open-mercato/shared/lib/data/engine', () => ({
+  SYSTEM_ENTITY_RECORDS_BLOCKED_CODE: 'system_entity_records_blocked',
+  isOrmBackedSystemEntityId: () => false,
 }))
 
 describe('GET /api/entities/entities — overlay merge', () => {
@@ -81,5 +87,83 @@ describe('GET /api/entities/entities — overlay merge', () => {
     const item = json.items.find((i: { entityId: string }) => i.entityId === 'customers:customer_person')
     expect(item).toBeDefined()
     expect(item.source).toBe('code')
+  })
+
+  it('returns updatedAt (ISO string) for a custom entity so the form can derive the lock header', async () => {
+    const updatedAt = new Date('2026-06-16T08:00:00.000Z')
+    mockEm.find.mockResolvedValueOnce([
+      {
+        entityId: 'customers:customer_person',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        label: 'Custom Label',
+        description: 'desc',
+        isActive: true,
+        updatedAt,
+      },
+    ])
+
+    const response = await GET(new Request('http://x/api/entities/entities'))
+    expect(response.status).toBe(200)
+
+    const json = await response.json()
+    const item = json.items.find((i: { entityId: string }) => i.entityId === 'customers:customer_person')
+    expect(item).toBeDefined()
+    expect(item.updatedAt).toBe('2026-06-16T08:00:00.000Z')
+  })
+})
+
+describe('POST /api/entities/entities — optimistic locking', () => {
+  const entityId = 'example:calendar_entity'
+  const currentUpdatedAt = new Date('2026-06-16T08:00:00.000Z')
+
+  function buildRequest(expectedHeader?: string): Request {
+    const headers: Record<string, string> = { 'content-type': 'application/json' }
+    if (expectedHeader) headers[OPTIMISTIC_LOCK_HEADER_NAME] = expectedHeader
+    return new Request('http://x/api/entities/entities', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ entityId, label: 'Updated label', description: 'Version B' }),
+    })
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    delete process.env.OM_OPTIMISTIC_LOCK
+    mockEm.findOne.mockResolvedValue({
+      id: 'ent-1',
+      entityId,
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      label: 'Old label',
+      description: 'Version A',
+      isActive: true,
+      updatedAt: currentUpdatedAt,
+    })
+  })
+
+  it('returns 409 with the conflict code when a stale lock header is sent', async () => {
+    const response = await POST(buildRequest('2026-06-16T07:00:00.000Z'))
+    expect(response.status).toBe(409)
+    const json = await response.json()
+    expect(json.code).toBe(OPTIMISTIC_LOCK_CONFLICT_CODE)
+    // Stale save must not persist the overwrite
+    expect(mockEm.flush).not.toHaveBeenCalled()
+  })
+
+  it('saves when the lock header matches the current version', async () => {
+    const response = await POST(buildRequest('2026-06-16T08:00:00.000Z'))
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.ok).toBe(true)
+    expect(mockEm.flush).toHaveBeenCalled()
+  })
+
+  it('saves when no lock header is present (strictly additive — legacy clients)', async () => {
+    const response = await POST(buildRequest())
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.ok).toBe(true)
+    expect(mockEm.flush).toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/entities/api/entities.ts
+++ b/packages/core/src/modules/entities/api/entities.ts
@@ -8,6 +8,10 @@ import { upsertCustomEntitySchema } from '@open-mercato/core/modules/entities/da
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { isSystemEntitySelectable } from '@open-mercato/shared/lib/entities/system-entities'
 import { SYSTEM_ENTITY_RECORDS_BLOCKED_CODE, isOrmBackedSystemEntityId } from '@open-mercato/shared/lib/data/engine'
+import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+
+const CUSTOM_ENTITY_DEFINITION_RESOURCE_KIND = 'entities.entity'
 
 export const metadata = {
   GET: { requireAuth: true },
@@ -60,6 +64,7 @@ export async function GET(req: Request) {
       labelField: (c as any).labelField ?? undefined,
       defaultEditor: (c as any).defaultEditor ?? undefined,
       showInSidebar: (c as any).showInSidebar ?? false,
+      updatedAt: c.updatedAt instanceof Date ? c.updatedAt.toISOString() : (c.updatedAt ?? undefined),
     }))
 
   const byId = new Map<string, any>()
@@ -120,6 +125,21 @@ export async function POST(req: Request) {
 
   const where: any = { entityId: input.entityId, organizationId: auth.orgId ?? null, tenantId: auth.tenantId ?? null }
   let ent = await em.findOne(CustomEntity, where)
+  if (ent) {
+    try {
+      enforceCommandOptimisticLock({
+        resourceKind: CUSTOM_ENTITY_DEFINITION_RESOURCE_KIND,
+        resourceId: ent.id,
+        current: ent.updatedAt ?? null,
+        request: req,
+      })
+    } catch (lockError) {
+      if (isCrudHttpError(lockError)) {
+        return NextResponse.json(lockError.body, { status: lockError.status })
+      }
+      throw lockError
+    }
+  }
   if (!ent) ent = em.create(CustomEntity, { ...where, createdAt: new Date() })
   ent.label = input.label
   ent.description = input.description ?? null
@@ -177,6 +197,7 @@ const entitySummarySchema = z.object({
   labelField: z.string().optional(),
   defaultEditor: z.string().optional(),
   showInSidebar: z.boolean().optional(),
+  updatedAt: z.string().optional(),
   count: z.number(),
 })
 

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
@@ -45,7 +45,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
   const [label, setLabel] = useState('')
   const [entitySource, setEntitySource] = useState<'code'|'custom'>('custom')
   const [entityFormLoading, setEntityFormLoading] = useState(true)
-  const [entityInitial, setEntityInitial] = useState<{ label?: string; description?: string; labelField?: string; defaultEditor?: string; showInSidebar?: boolean }>({})
+  const [entityInitial, setEntityInitial] = useState<{ label?: string; description?: string; labelField?: string; defaultEditor?: string; showInSidebar?: boolean; updatedAt?: string }>({})
   const [defs, setDefs] = useState<Def[]>([])
   const [orderDirty, setOrderDirty] = useState(false)
   const [orderSaving, setOrderSaving] = useState(false)
@@ -171,6 +171,8 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
           const defaultEditorValue =
             typeof record?.defaultEditor === 'string' ? record.defaultEditor : ''
           const showInSidebarValue = record?.showInSidebar === true
+          const updatedAtValue =
+            typeof record?.updatedAt === 'string' && record.updatedAt.length > 0 ? record.updatedAt : undefined
           setLabel(labelValue)
           if (record?.source === 'code' || record?.source === 'custom') setEntitySource(record.source)
           setEntityInitial({
@@ -179,6 +181,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
             labelField: labelFieldValue,
             defaultEditor: defaultEditorValue,
             showInSidebar: showInSidebarValue,
+            updatedAt: updatedAtValue,
           })
           setEntityFormLoading(false)
         }


### PR DESCRIPTION
Fixes #3117

## Problem
Two users editing the same custom entity **definition** (label, description, custom-field definitions) at `/backend/entities/user/<entityId>` both get a "Definitions saved" toast — the last save silently overwrites the first. No 409, no conflict bar. This is distinct from entity *record* editing, which already locks.

## Root Cause
The `CustomEntity` row has an `updated_at` column, but the three pieces that activate optimistic locking were all missing across the API → form → header chain:
1. `GET /api/entities/entities` never returned `updatedAt`.
2. The edit page never passed `updatedAt` into `CrudForm` `initialValues`, so the auto-derived `x-om-ext-optimistic-lock-expected-updated-at` header was never sent.
3. `POST /api/entities/entities` set `updatedAt = new Date()` on every save without comparing an expected version.

## What Changed
- **GET** `api/entities.ts`: include `updatedAt` (ISO string) on each custom-entity item, plus `updatedAt` in the OpenAPI response schema.
- **Page** `backend/entities/user/[entityId]/page.tsx`: read `record.updatedAt` and wire it into `entityInitial`. `CrudForm` auto-derives the lock header and scopes it onto the custom `onSubmit`'s `apiCall` via `withScopedApiRequestHeaders`.
- **POST** `api/entities.ts`: when the target row exists, call `enforceCommandOptimisticLock` (resourceKind `entities.entity`) against `ent.updatedAt` before mutating; on mismatch return the structured 409 conflict body. The unified conflict bar then renders client-side.

Strictly additive — clients that omit the header still save (legacy/API consumers). Code entities and first-time overlays (no existing row) skip the check, so no false 409s. The sibling `definitions.batch` call in the same submit does not enforce locking, so the shared header cannot produce a false conflict there.

## Tests
- `entities.api.test.ts`: GET returns `updatedAt` for a custom entity; POST returns 409 + conflict code on a stale header (and does not flush); POST saves when the header matches; POST saves when no header is present (additive).
- Full `modules/entities/api/__tests__` suite green (49 tests); `@open-mercato/core` package build green.

## Backward Compatibility
- Additive only: new optional `updatedAt` field on the entities list response; new no-op-on-absent-header guard on POST. No contract surface removed or changed.