### PR TITLE
fix(entities): skip system-entity registration POST so custom-field edit works (#3115)

### DIFF
--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
@@ -473,7 +473,11 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
       flash('Please fix validation errors in field definitions', 'error')
       throw createCrudFormError('Please fix validation errors in field definitions')
     }
-    {
+    // Code-declared system entities are not registered as custom entities — their
+    // metadata is owned by code and `POST /api/entities/entities` is fail-closed for
+    // ORM-backed system ids (#3115). Only their field definitions are user-editable, so
+    // skip the registration call and persist definitions below.
+    if (shouldRegisterEntityMetadata(entitySource)) {
       const entityPayload = buildEntityMetadataPayload(entitySource, vals)
       if (!entityPayload) throw createCrudFormError('Validation failed')
       const callEntity = await apiCall('/api/entities/entities', {
@@ -595,6 +599,10 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
       </Dialog>
     </Page>
   )
+}
+
+export function shouldRegisterEntityMetadata(entitySource: 'code' | 'custom'): boolean {
+  return entitySource === 'custom'
 }
 
 export function buildEntityMetadataPayload(

--- a/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-page-submit.test.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-page-submit.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import EditDefinitionsPage from '../[entityId]/page'
+import { apiCall, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+
+const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}))
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: any) => <div>{children}</div>,
+  PageBody: ({ children }: any) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
+  CrudForm: (props: any) => (
+    <div data-testid="crud-form-mock">
+      <div data-testid="crud-form-loading">{String(props.isLoading)}</div>
+      <button data-testid="submit-button" onClick={() => { void props.onSubmit?.(props.initialValues) }}>
+        {props.submitLabel}
+      </button>
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/custom-fields/FieldDefinitionsEditor', () => ({
+  FieldDefinitionsEditor: () => <div data-testid="field-definitions-editor" />,
+}))
+
+jest.mock('@open-mercato/core/modules/translations/components/TranslationManager', () => ({
+  TranslationManager: () => null,
+}))
+
+jest.mock('@open-mercato/ui/backend/fields/registry', () => ({
+  loadGeneratedFieldRegistrations: jest.fn(() => Promise.resolve()),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/customFieldDefs', () => ({
+  invalidateCustomFieldDefs: jest.fn(() => Promise.resolve()),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/serverErrors', () => ({
+  createCrudFormError: (message: string) => new Error(message),
+  raiseCrudError: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+  readApiResultOrThrow: jest.fn(),
+}))
+
+const apiCallMock = apiCall as jest.Mock
+const readApiResultOrThrowMock = readApiResultOrThrow as jest.Mock
+
+function mockLoad(entityId: string, source: 'code' | 'custom') {
+  readApiResultOrThrowMock.mockImplementation((url: string) => {
+    if (url.startsWith('/api/entities/entities')) {
+      return Promise.resolve({ items: [{ entityId, label: entityId, description: '', source }] })
+    }
+    return Promise.resolve({ items: [], deletedKeys: [], fieldsets: [], settings: {} })
+  })
+  apiCallMock.mockResolvedValue({ ok: true, response: {} })
+}
+
+function calledUrls(): string[] {
+  return apiCallMock.mock.calls.map((call) => call[0] as string)
+}
+
+describe('EditDefinitionsPage submit (#3115)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('skips entity registration for code-declared system entities and still saves definitions', async () => {
+    const entityId = 'workflows:workflow_instance'
+    mockLoad(entityId, 'code')
+
+    render(<EditDefinitionsPage params={{ entityId }} />)
+    await waitFor(() => expect(screen.getByTestId('crud-form-loading')).toHaveTextContent('false'))
+
+    fireEvent.click(screen.getByTestId('submit-button'))
+
+    await waitFor(() => expect(calledUrls()).toContain('/api/entities/definitions.batch'))
+    expect(calledUrls()).not.toContain('/api/entities/entities')
+  })
+
+  it('still registers entity metadata for custom (user-defined) entities', async () => {
+    const entityId = 'demo:thing'
+    mockLoad(entityId, 'custom')
+
+    render(<EditDefinitionsPage params={{ entityId }} />)
+    await waitFor(() => expect(screen.getByTestId('crud-form-loading')).toHaveTextContent('false'))
+
+    fireEvent.click(screen.getByTestId('submit-button'))
+
+    await waitFor(() => expect(calledUrls()).toContain('/api/entities/definitions.batch'))
+    expect(calledUrls()).toContain('/api/entities/entities')
+  })
+})

--- a/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts
+++ b/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts
@@ -2,7 +2,17 @@ jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
   CrudForm: () => null,
 }))
 
-import { buildEntityMetadataPayload } from '../[entityId]/page'
+import { buildEntityMetadataPayload, shouldRegisterEntityMetadata } from '../[entityId]/page'
+
+describe('shouldRegisterEntityMetadata', () => {
+  it('registers metadata for custom (user-defined) entities', () => {
+    expect(shouldRegisterEntityMetadata('custom')).toBe(true)
+  })
+
+  it('does not register metadata for code-declared system entities (#3115)', () => {
+    expect(shouldRegisterEntityMetadata('code')).toBe(false)
+  })
+})
 
 describe('buildEntityMetadataPayload', () => {
   describe('code-sourced (system) entities', () => {


### PR DESCRIPTION
Fixes #3115

## Problem
The System Entities admin page advertises *"Use Edit to define custom fields for a system entity"*, but clicking **Save** on any system entity always failed with `400 {"error":"System entities cannot be registered as custom entities","code":"system_entity_records_blocked"}`. The advertised feature was completely non-functional — no custom field definition could be saved for any system entity.

## Root Cause
`handleCrudFormSubmit` in the entity edit page (`backend/entities/user/[entityId]/page.tsx`) unconditionally called `POST /api/entities/entities` for both user (`entitySource === 'custom'`) and code-declared (`entitySource === 'code'`) entities. That endpoint is fail-closed for ORM-backed system entity ids (the `isOrmBackedSystemEntityId` guard added for #2939), so the call threw for system entities and the follow-up `POST /api/entities/definitions.batch` — the one that actually saves field definitions — never fired.

System entities own their metadata in code and do not need to be "registered" as custom entities; only their field definitions are user-editable.

## What Changed
- Added a small exported helper `shouldRegisterEntityMetadata(entitySource)` (returns `true` only for `'custom'`).
- Gated the `POST /api/entities/entities` registration call behind it. Code-sourced (system) entities now skip registration and persist their field definitions directly via `definitions.batch`; custom entities keep registering exactly as before.

`definitions.batch` has no system-entity guard, so the definitions save now succeeds for system entities.

## Tests
- `edit-entity-submit.test.ts`: unit coverage for `shouldRegisterEntityMetadata` (`'custom'` → true, `'code'` → false).
- `edit-entity-page-submit.test.tsx` (new): renders the page and submits — asserts that for a code-sourced entity the submit does **not** call `/api/entities/entities` but **does** call `/api/entities/definitions.batch`, and that custom entities still call both. Verified the render test fails when the registration call is left unconditional.
- Full entities test suite: 22 suites / 122 tests pass. Root `tsc --noEmit` typecheck passes.

## Backward Compatibility
No contract surface changes. The only new export is the additive `shouldRegisterEntityMetadata` helper. No API routes, types, event IDs, DI keys, or ACL features changed; no response fields removed.

Note: the *Entity Settings* (label/description/defaultEditor) fields are code-owned for system entities and are not persisted from this form (they never could be — registration was blocked by design). Making those fields read-only for system entities would be a reasonable follow-up.
