### PR TITLE
fix(sales): reject future return dates on create & edit (#3100)

### DIFF
--- a/packages/core/src/modules/sales/components/documents/ReturnEditDialog.tsx
+++ b/packages/core/src/modules/sales/components/documents/ReturnEditDialog.tsx
@@ -79,6 +79,7 @@ export function ReturnEditDialog({
         id: 'returnedAt',
         label: t('sales.returns.returnedAt', 'Returned at'),
         type: 'date',
+        maxDate: new Date(),
       },
       {
         id: 'notes',

--- a/packages/core/src/modules/sales/data/__tests__/validators.return-date.test.ts
+++ b/packages/core/src/modules/sales/data/__tests__/validators.return-date.test.ts
@@ -1,0 +1,74 @@
+import {
+  RETURN_DATE_IN_FUTURE_MESSAGE,
+  returnCreateSchema,
+  returnUpdateSchema,
+} from '../validators'
+
+const ORGANIZATION_ID = '11111111-1111-4111-8111-111111111111'
+const TENANT_ID = '22222222-2222-4222-8222-222222222222'
+const ORDER_ID = '33333333-3333-4333-8333-333333333333'
+const ORDER_LINE_ID = '44444444-4444-4444-8444-444444444444'
+const RETURN_ID = '55555555-5555-4555-8555-555555555555'
+
+const futureDate = () => {
+  const date = new Date()
+  date.setFullYear(date.getFullYear() + 1)
+  return date.toISOString()
+}
+
+const createInput = (returnedAt?: string) => ({
+  organizationId: ORGANIZATION_ID,
+  tenantId: TENANT_ID,
+  orderId: ORDER_ID,
+  lines: [{ orderLineId: ORDER_LINE_ID, quantity: 1 }],
+  ...(returnedAt ? { returnedAt } : {}),
+})
+
+const updateInput = (returnedAt?: string) => ({
+  organizationId: ORGANIZATION_ID,
+  tenantId: TENANT_ID,
+  id: RETURN_ID,
+  orderId: ORDER_ID,
+  ...(returnedAt ? { returnedAt } : {}),
+})
+
+const expectFutureRejection = (result: ReturnType<typeof returnCreateSchema.safeParse>) => {
+  expect(result.success).toBe(false)
+  if (result.success) return
+  const issue = result.error.issues.find((entry) => entry.path.includes('returnedAt'))
+  expect(issue?.message).toBe(RETURN_DATE_IN_FUTURE_MESSAGE)
+}
+
+describe('return date validation — issue #3100', () => {
+  describe('returnCreateSchema', () => {
+    it('rejects a returnedAt in the future', () => {
+      expectFutureRejection(returnCreateSchema.safeParse(createInput(futureDate())))
+    })
+
+    it('accepts a returnedAt in the past', () => {
+      expect(returnCreateSchema.safeParse(createInput('2020-01-01')).success).toBe(true)
+    })
+
+    it('accepts an omitted returnedAt', () => {
+      expect(returnCreateSchema.safeParse(createInput()).success).toBe(true)
+    })
+
+    it('accepts the current moment', () => {
+      expect(returnCreateSchema.safeParse(createInput(new Date().toISOString())).success).toBe(true)
+    })
+  })
+
+  describe('returnUpdateSchema', () => {
+    it('rejects a returnedAt in the future', () => {
+      expectFutureRejection(returnUpdateSchema.safeParse(updateInput(futureDate())))
+    })
+
+    it('accepts a returnedAt in the past', () => {
+      expect(returnUpdateSchema.safeParse(updateInput('2020-01-01')).success).toBe(true)
+    })
+
+    it('accepts an omitted returnedAt', () => {
+      expect(returnUpdateSchema.safeParse(updateInput()).success).toBe(true)
+    })
+  })
+})

--- a/packages/core/src/modules/sales/data/validators.ts
+++ b/packages/core/src/modules/sales/data/validators.ts
@@ -803,11 +803,23 @@ const returnLineQuantitySchema = z.coerce
   .min(1, 'Return quantity must be at least 1.')
   .max(MAX_QUANTITY, 'Quantity is too large.')
 
+export const RETURN_DATE_IN_FUTURE_MESSAGE = 'Return date cannot be in the future.'
+
+// A return records when goods physically came back to the seller, so a future
+// date is not yet a fact. Evaluate "now" at parse time (not module-load time)
+// so a long-running server never rejects legitimate same-day returns.
+const returnedAtSchema = z.coerce
+  .date()
+  .refine((value) => value.getTime() <= Date.now(), {
+    message: RETURN_DATE_IN_FUTURE_MESSAGE,
+  })
+  .optional()
+
 export const returnCreateSchema = scoped.extend({
   orderId: uuid(),
   reason: z.string().trim().max(4000).optional(),
   notes: z.string().trim().max(4000).optional(),
-  returnedAt: z.coerce.date().optional(),
+  returnedAt: returnedAtSchema,
   lines: z
     .array(
       z.object({
@@ -823,7 +835,7 @@ export const returnUpdateSchema = scoped.extend({
   orderId: uuid(),
   reason: z.string().trim().max(4000).optional(),
   notes: z.string().trim().max(4000).optional(),
-  returnedAt: z.coerce.date().optional(),
+  returnedAt: returnedAtSchema,
 })
 
 export const returnDeleteSchema = scoped.extend({


### PR DESCRIPTION
Fixes #3100

## Problem
The **Returned at** date on the return create and edit flows accepted any future date. The save succeeded (HTTP 200) and the credit adjustment was applied to the order totals immediately — recording a return that has not physically happened yet.

## Root Cause
`returnCreateSchema` and `returnUpdateSchema` in `packages/core/src/modules/sales/data/validators.ts` declared `returnedAt: z.coerce.date().optional()` with no upper bound, so both `POST /api/sales/returns` and `PUT /api/sales/returns` accepted future dates.

## What Changed
- Added a shared `returnedAt` schema that rejects any date after the current moment, applied to both `returnCreateSchema` and `returnUpdateSchema`. The bound is evaluated at parse time via `.refine()` rather than a literal `.max(new Date())` — a literal would freeze "now" at module-load time and wrongly reject legitimate same-day returns on a long-running server.
- Exported `RETURN_DATE_IN_FUTURE_MESSAGE` for reuse/testing.
- Restricted the edit dialog's calendar picker to today or earlier (`maxDate: new Date()`) as UI defense-in-depth. (The create dialog does not expose a date field; the server validation covers the API path.)

## Tests
- New unit test `validators.return-date.test.ts`: both schemas reject a future `returnedAt` with the expected message, and accept past / current / omitted values (7 cases).
- Full sales `data`/`commands` suite (147 tests) green; existing return integration test unaffected (it uses a past date).
- `yarn build:packages`, `yarn generate`, and `yarn typecheck` all pass.

## Backward Compatibility
No contract surface changes — inferred schema types are unchanged (`Date | undefined`); the only additions are a tightened runtime validation and an additive exported message constant.