### PR TITLE
fix(cli): allow third-party module packages via --allow-third-party (#2940)

### DIFF
--- a/apps/docs/docs/cli/module-add.mdx
+++ b/apps/docs/docs/cli/module-add.mdx
@@ -4,7 +4,7 @@ sidebar_label: module add
 description: Installs and registers an official Open Mercato module package into your app.
 ---
 
-`yarn mercato module add` fetches an official module package from npm, auto-discovers the module it contains, registers it in your app's `src/modules.ts`, and runs the code generators. It is the primary command for adding pre-built modules published under the `@open-mercato/*` scope. If the package is already installed, [`mercato module enable`](./module-enable) supports the same optional `--eject` flow without reinstalling dependencies.
+`yarn mercato module add` fetches a module package from npm, auto-discovers the module it contains, registers it in your app's `src/modules.ts`, and runs the code generators. It is the primary command for adding pre-built modules published under the `@open-mercato/*` scope. Third-party packages that follow the same module conventions can be installed too by passing `--allow-third-party`. If the package is already installed, [`mercato module enable`](./module-enable) supports the same optional `--eject` flow without reinstalling dependencies.
 
 ## Usage
 
@@ -17,26 +17,30 @@ yarn mercato module add <packageSpec> --module <moduleId>
 
 # Copy module source into src/modules/<moduleId>/
 yarn mercato module add <packageSpec> --module <moduleId> --eject
+
+# Install a third-party (non-@open-mercato) module package
+yarn mercato module add <packageSpec> --allow-third-party
 ```
 
-`<packageSpec>` follows the standard npm package specifier format: `@open-mercato/<name>`, `@open-mercato/<name>@<version>`, or `@open-mercato/<name>@<tag>` (e.g., `@open-mercato/test-package@preview`).
+`<packageSpec>` follows the standard npm package specifier format: `<name>`, `<name>@<version>`, or `<name>@<tag>` (e.g., `@open-mercato/test-package@preview`, `@fast-white-cat/integration-ksef-direct@0.1.0`). Packages outside the `@open-mercato/*` scope require `--allow-third-party`.
 
 ## Options
 
 | Option | Description | Default |
 | --- | --- | --- |
-| `<packageSpec>` | npm package specifier for the official module to install. Must be scoped under `@open-mercato/*`. | — |
+| `<packageSpec>` | npm package specifier for the module to install. Scoped under `@open-mercato/*` by default; other scopes require `--allow-third-party`. | — |
 | `--module <moduleId>` | Select a specific module from a package that contains multiple modules. Required when the package exposes more than one module; omit for single-module packages. | auto |
 | `--eject` | Copy the module source into `src/modules/<moduleId>/` and load it as a local (`@app`) module. Cross-module imports inside the copied source are automatically rewritten to reference the originating package. Omit this flag to keep the module installed in `node_modules`. | `false` |
+| `--allow-third-party` | Allow installing a package outside the `@open-mercato/*` scope. The package must still pass the module-structure validation below. Required as an explicit opt-in for supply-chain safety. | `false` |
 
 ## Package Eligibility
 
 Only packages that satisfy all of the following criteria can be installed with this command:
 
-- Scoped under `@open-mercato/*`.
+- Scoped under `@open-mercato/*`, or any other scope when `--allow-third-party` is passed.
 - Contain at least one module directory under `src/modules/<moduleId>/` and `dist/modules/<moduleId>/`.
 
-Module identity and ejectability are read directly from each module's `src/modules/<moduleId>/index.ts` — no extra fields in `package.json` are required.
+Module identity and ejectability are read directly from each module's `src/modules/<moduleId>/index.ts` — no extra fields in `package.json` are required. The `@open-mercato/*` scope is **not** a hard requirement for the module to work; it only gates the implicit-trust default, which `--allow-third-party` overrides.
 
 ## What the Command Does
 
@@ -76,6 +80,12 @@ Install and copy the module source into your app for local ownership:
 yarn mercato module add @open-mercato/test-package --eject
 ```
 
+Install a third-party module package published under a different scope:
+
+```bash
+yarn mercato module add @fast-white-cat/integration-ksef-direct@0.1.0 --allow-third-party
+```
+
 ## Post-Install Steps
 
 ```bash
@@ -91,7 +101,8 @@ If you ran the command with **`--eject`**, the module source is now in `src/modu
 ## Troubleshooting
 
 - **Package not found** — verify the package name and tag against the npm registry. Ensure your npm authentication is configured if the package is private.
-- **No modules found** — the package has no `src/modules/` or `dist/modules/` directory. Only `@open-mercato/*` packages that expose at least one module directory are supported.
+- **No modules found** — the package has no `src/modules/` or `dist/modules/` directory. Only packages that expose at least one module directory are supported.
+- **Package is outside the @open-mercato/\* scope** — the package belongs to a different npm scope. Rerun with `--allow-third-party` to opt in to installing third-party module packages.
 - **Multiple modules, --module required** — the package contains more than one module. Rerun with `--module <moduleId>`. The error message lists the available IDs.
 - **Module already registered** — the module is already present in `src/modules.ts`. Remove the existing entry before re-installing, or use [`mercato module eject`](./eject) if you want to take local ownership instead.
 - **Destination directory already exists** (`--eject`) — remove `src/modules/<moduleId>/` before running the command again with `--eject`.

--- a/apps/docs/docs/cli/module-enable.mdx
+++ b/apps/docs/docs/cli/module-enable.mdx
@@ -19,17 +19,21 @@ yarn mercato module enable <packageName> --module <moduleId>
 
 # Copy the installed module source into src/modules/<moduleId>/
 yarn mercato module enable <packageName> --eject
+
+# Enable an already-installed third-party (non-@open-mercato) module package
+yarn mercato module enable <packageName> --allow-third-party
 ```
 
-`<packageName>` is the full npm package name (e.g., `@open-mercato/test-package`), without a version suffix.
+`<packageName>` is the full npm package name (e.g., `@open-mercato/test-package`), without a version suffix. Packages outside the `@open-mercato/*` scope require `--allow-third-party`.
 
 ## Options
 
 | Option | Description |
 | --- | --- |
-| `<packageName>` | Full npm package name of the already-installed official module. Must be scoped under `@open-mercato/*` and present in `node_modules`. |
+| `<packageName>` | Full npm package name of the already-installed module. Scoped under `@open-mercato/*` by default; other scopes require `--allow-third-party`. Must be present in `node_modules`. |
 | `--module <moduleId>` | Select a specific module from a package that contains multiple modules. Required when the package exposes more than one module; omit for single-module packages. |
 | `--eject` | Copy the selected module source into `src/modules/<moduleId>/`, rewrite cross-module imports to the origin package, and register it as `from: '@app'`. Omit this flag to keep loading the module from `node_modules`. |
+| `--allow-third-party` | Allow enabling a package outside the `@open-mercato/*` scope. The package must still pass module-structure validation. Required as an explicit opt-in for supply-chain safety. |
 
 ## When to Use `module enable` vs `module add`
 
@@ -86,7 +90,8 @@ yarn dev
 ## Troubleshooting
 
 - **Package not found in node_modules** — the package must already be installed. Run `yarn mercato module add <packageSpec>` to install and register in one step.
-- **No modules found** — the package has no `src/modules/` or `dist/modules/` directory. Only `@open-mercato/*` packages that expose at least one module directory are supported.
+- **No modules found** — the package has no `src/modules/` or `dist/modules/` directory. Only packages that expose at least one module directory are supported.
+- **Package is outside the @open-mercato/\* scope** — the package belongs to a different npm scope. Rerun with `--allow-third-party` to opt in to enabling third-party module packages.
 - **Multiple modules, --module required** — the package contains more than one module. Rerun with `--module <moduleId>`. The error message lists the available IDs.
 - **Module already registered** — the module is already present in `src/modules.ts` from the same source. Nothing to do — it is already active.
 - **Module registered from a different source** — the module exists in `src/modules.ts` but with a different `from` value. Remove the existing entry first, or use [`mercato module eject`](./eject) if the package-backed module is already enabled and you want to switch it to local ownership.

--- a/packages/cli/src/lib/__tests__/module-install-args.test.ts
+++ b/packages/cli/src/lib/__tests__/module-install-args.test.ts
@@ -32,4 +32,27 @@ describe('parseModuleInstallArgs', () => {
       'Unsupported option: --installed',
     )
   })
+
+  it('defaults allowThirdParty to false', () => {
+    expect(parseModuleInstallArgs(['@open-mercato/test-package'])).toMatchObject({
+      allowThirdParty: false,
+    })
+  })
+
+  it('accepts --allow-third-party as a boolean flag', () => {
+    expect(parseModuleInstallArgs(['@scope/pkg', '--allow-third-party'])).toMatchObject({
+      packageSpec: '@scope/pkg',
+      allowThirdParty: true,
+    })
+    expect(parseModuleInstallArgs(['--allow-third-party', '@scope/pkg'])).toMatchObject({
+      packageSpec: '@scope/pkg',
+      allowThirdParty: true,
+    })
+  })
+
+  it('rejects --allow-third-party values', () => {
+    expect(() => parseModuleInstallArgs(['@scope/pkg', '--allow-third-party=true'])).toThrow(
+      '--allow-third-party does not accept a value',
+    )
+  })
 })

--- a/packages/cli/src/lib/__tests__/module-install.test.ts
+++ b/packages/cli/src/lib/__tests__/module-install.test.ts
@@ -10,15 +10,17 @@ function buildPackageFixture(
   options?: {
     ejectable?: boolean
     extraSourceFiles?: Array<{ relativePath: string; content: string }>
+    packageName?: string
   },
 ): void {
   const ejectable = options?.ejectable ?? false
+  const packageName = options?.packageName ?? '@open-mercato/test-package'
   for (const base of ['src', 'dist']) {
     fs.mkdirSync(path.join(packageRoot, base, 'modules', moduleId), { recursive: true })
   }
   fs.writeFileSync(
     path.join(packageRoot, 'package.json'),
-    JSON.stringify({ name: '@open-mercato/test-package', version: '0.1.0' }),
+    JSON.stringify({ name: packageName, version: '0.1.0' }),
   )
   fs.writeFileSync(
     path.join(packageRoot, 'src', 'modules', moduleId, 'index.ts'),
@@ -234,5 +236,68 @@ describe('enableOfficialModule', () => {
     await expect(
       addOfficialModule(resolver, '@open-mercato/test-package@npm:evil', false),
     ).rejects.toThrow('Unsupported package spec suffix')
+  })
+})
+
+describe('third-party module packages', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'module-install-3p-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('rejects adding a non-@open-mercato package without --allow-third-party', async () => {
+    const packageRoot = path.join(tmpDir, 'node_modules', '@fast-white-cat', 'integration-ksef-direct')
+    const appDir = path.join(tmpDir, 'app')
+    buildPackageFixture(packageRoot, 'ksef_direct', {
+      packageName: '@fast-white-cat/integration-ksef-direct',
+    })
+
+    const resolver = buildResolver(appDir, packageRoot, 'export const enabledModules = []\n')
+
+    await expect(
+      addOfficialModule(resolver, '@fast-white-cat/integration-ksef-direct@0.1.0', false),
+    ).rejects.toThrow('Re-run with --allow-third-party')
+  })
+
+  it('rejects enabling a non-@open-mercato package without --allow-third-party', async () => {
+    const packageRoot = path.join(tmpDir, 'node_modules', '@fast-white-cat', 'integration-ksef-direct')
+    const appDir = path.join(tmpDir, 'app')
+    buildPackageFixture(packageRoot, 'ksef_direct', {
+      packageName: '@fast-white-cat/integration-ksef-direct',
+    })
+
+    const resolver = buildResolver(appDir, packageRoot, 'export const enabledModules = []\n')
+
+    await expect(
+      enableOfficialModule(resolver, '@fast-white-cat/integration-ksef-direct'),
+    ).rejects.toThrow('Re-run with --allow-third-party')
+  })
+
+  it('enables a non-@open-mercato package when --allow-third-party is set', async () => {
+    const packageRoot = path.join(tmpDir, 'node_modules', '@fast-white-cat', 'integration-ksef-direct')
+    const appDir = path.join(tmpDir, 'app')
+    buildPackageFixture(packageRoot, 'ksef_direct', {
+      packageName: '@fast-white-cat/integration-ksef-direct',
+    })
+
+    const resolver = buildResolver(appDir, packageRoot, 'export const enabledModules = []\n')
+
+    await expect(
+      enableOfficialModule(resolver, '@fast-white-cat/integration-ksef-direct', undefined, false, true),
+    ).resolves.toEqual({
+      moduleId: 'ksef_direct',
+      packageName: '@fast-white-cat/integration-ksef-direct',
+      from: '@fast-white-cat/integration-ksef-direct',
+      registrationChanged: true,
+    })
+
+    expect(fs.readFileSync(path.join(appDir, 'src', 'modules.ts'), 'utf8')).toContain(
+      "{ id: 'ksef_direct', from: '@fast-white-cat/integration-ksef-direct' }",
+    )
   })
 })

--- a/packages/cli/src/lib/__tests__/module-package.test.ts
+++ b/packages/cli/src/lib/__tests__/module-package.test.ts
@@ -57,6 +57,33 @@ describe('module-package', () => {
     expect(modulePackage.distModuleDir).toContain(path.join('dist', 'modules', 'test_package'))
   })
 
+  it('validates a third-party (non-@open-mercato) module package by structure', () => {
+    const packageRoot = path.join(tmpDir, 'node_modules', '@fast-white-cat', 'integration-ksef-direct')
+    for (const base of ['src', 'dist']) {
+      fs.mkdirSync(path.join(packageRoot, base, 'modules', 'ksef_direct'), { recursive: true })
+    }
+    fs.writeFileSync(
+      path.join(packageRoot, 'package.json'),
+      JSON.stringify({ name: '@fast-white-cat/integration-ksef-direct', version: '0.1.0' }),
+    )
+    fs.writeFileSync(
+      path.join(packageRoot, 'src', 'modules', 'ksef_direct', 'index.ts'),
+      "export const metadata = { title: 'KSeF Direct', ejectable: false }\n",
+    )
+    fs.writeFileSync(
+      path.join(packageRoot, 'dist', 'modules', 'ksef_direct', 'index.js'),
+      'exports.metadata = {};\n',
+    )
+
+    const modulePackage = readOfficialModulePackageFromRoot(
+      packageRoot,
+      '@fast-white-cat/integration-ksef-direct',
+    )
+
+    expect(modulePackage.packageName).toBe('@fast-white-cat/integration-ksef-direct')
+    expect(modulePackage.metadata.moduleId).toBe('ksef_direct')
+  })
+
   it('resolves a hoisted installed module package from a monorepo app', () => {
     const appDir = path.join(tmpDir, 'apps', 'mercato')
     const installedPackageRoot = path.join(tmpDir, 'node_modules', '@open-mercato', 'test-package')

--- a/packages/cli/src/lib/module-install-args.ts
+++ b/packages/cli/src/lib/module-install-args.ts
@@ -2,12 +2,14 @@ export type ParsedModuleInstallArgs = {
   packageSpec: string | null
   eject: boolean
   moduleId: string | null
+  allowThirdParty: boolean
 }
 
 export function parseModuleInstallArgs(args: string[]): ParsedModuleInstallArgs {
   let packageSpec: string | null = null
   let eject = false
   let moduleId: string | null = null
+  let allowThirdParty = false
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index]
@@ -20,6 +22,15 @@ export function parseModuleInstallArgs(args: string[]): ParsedModuleInstallArgs 
 
     if (arg.startsWith('--eject=')) {
       throw new Error('--eject does not accept a value')
+    }
+
+    if (arg === '--allow-third-party') {
+      allowThirdParty = true
+      continue
+    }
+
+    if (arg.startsWith('--allow-third-party=')) {
+      throw new Error('--allow-third-party does not accept a value')
     }
 
     if (arg === '--module') {
@@ -46,5 +57,5 @@ export function parseModuleInstallArgs(args: string[]): ParsedModuleInstallArgs 
     }
   }
 
-  return { packageSpec, eject, moduleId }
+  return { packageSpec, eject, moduleId, allowThirdParty }
 }

--- a/packages/cli/src/lib/module-install.ts
+++ b/packages/cli/src/lib/module-install.ts
@@ -24,7 +24,8 @@ type InstallTarget = {
   args: string[]
 }
 
-const SAFE_PACKAGE_SPEC_PATTERN = /^@open-mercato\/[a-z0-9][a-z0-9-]*(?:@.+)?$/i
+const OFFICIAL_PACKAGE_SCOPE = '@open-mercato/'
+const SAFE_PACKAGE_SPEC_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*(?:@.+)?$/i
 const SAFE_PACKAGE_TAG_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 const SAFE_PACKAGE_FILE_LOCATOR_PATTERN = /^file:[A-Za-z0-9_./: \\-]+$/
 
@@ -133,21 +134,36 @@ async function runGeneratorsWithRegistrationNotice(
   }
 }
 
+function isOfficialPackage(packageName: string): boolean {
+  return packageName.startsWith(OFFICIAL_PACKAGE_SCOPE)
+}
+
 function assertPackageName(packageName: string | null): asserts packageName is string {
-  if (!packageName || !packageName.startsWith('@open-mercato/')) {
-    throw new Error('Only @open-mercato/* package specs are supported by "mercato module add".')
+  if (!packageName) {
+    throw new Error('Could not determine a package name from the provided spec.')
   }
 }
 
-function assertSupportedPackageSpec(packageSpec: string): string {
+function assertThirdPartyAllowed(packageName: string, allowThirdParty: boolean): void {
+  if (isOfficialPackage(packageName) || allowThirdParty) {
+    return
+  }
+
+  throw new Error(
+    `Package "${packageName}" is outside the ${OFFICIAL_PACKAGE_SCOPE}* scope. Re-run with --allow-third-party to install third-party module packages.`,
+  )
+}
+
+function assertSupportedPackageSpec(packageSpec: string, allowThirdParty: boolean): string {
   const trimmed = packageSpec.trim()
 
   if (!SAFE_PACKAGE_SPEC_PATTERN.test(trimmed)) {
-    throw new Error('Unsupported package spec. Only direct @open-mercato/* package specs are allowed.')
+    throw new Error('Unsupported package spec. Provide a valid npm package name with an optional tag/version or file: locator.')
   }
 
   const packageName = parsePackageNameFromSpec(trimmed)
   assertPackageName(packageName)
+  assertThirdPartyAllowed(packageName, allowThirdParty)
 
   if (trimmed === packageName) {
     return trimmed
@@ -240,8 +256,9 @@ export async function addOfficialModule(
   packageSpec: string,
   eject: boolean,
   moduleId?: string,
+  allowThirdParty = false,
 ): Promise<ModuleCommandResult> {
-  const safePackageSpec = assertSupportedPackageSpec(packageSpec)
+  const safePackageSpec = assertSupportedPackageSpec(packageSpec, allowThirdParty)
   const packageName = parsePackageNameFromSpec(safePackageSpec)
   assertPackageName(packageName)
 
@@ -256,10 +273,9 @@ export async function enableOfficialModule(
   packageName: string,
   moduleId?: string,
   eject = false,
+  allowThirdParty = false,
 ): Promise<ModuleCommandResult> {
-  if (!packageName.startsWith('@open-mercato/')) {
-    throw new Error('Only @open-mercato/* packages can be enabled with "mercato module enable".')
-  }
+  assertThirdPartyAllowed(packageName, allowThirdParty)
 
   const modulePackage = resolveInstalledOfficialModulePackage(resolver, packageName, moduleId)
   return registerResolvedOfficialModule(resolver, modulePackage, packageName, eject)

--- a/packages/cli/src/lib/module-package.ts
+++ b/packages/cli/src/lib/module-package.ts
@@ -270,8 +270,8 @@ export function readOfficialModulePackageFromRoot(
 
   const packageJson = readPackageJson(packageJsonPath)
   const packageName = packageJson.name
-  if (!packageName || !packageName.startsWith('@open-mercato/')) {
-    throw new Error(`Package at ${packageRoot} is not under the @open-mercato scope.`)
+  if (!packageName) {
+    throw new Error(`Package manifest at ${packageJsonPath} is missing the "name" field.`)
   }
 
   if (expectedPackageName && packageName !== expectedPackageName) {

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -1282,8 +1282,8 @@ export async function run(argv = process.argv) {
 
       if (!subcommand || subcommand === 'help' || subcommand === '--help' || subcommand === '-h') {
         console.log('Usage: yarn mercato module <add|enable|eject> ...')
-        console.log('  yarn mercato module add <packageSpec> [--module <moduleId>] [--eject]')
-        console.log('  yarn mercato module enable <packageName> [--module <moduleId>] [--eject]')
+        console.log('  yarn mercato module add <packageSpec> [--module <moduleId>] [--eject] [--allow-third-party]')
+        console.log('  yarn mercato module enable <packageName> [--module <moduleId>] [--eject] [--allow-third-party]')
         console.log('  yarn mercato module eject <moduleId>')
         return 0
       }
@@ -1291,14 +1291,14 @@ export async function run(argv = process.argv) {
       if (subcommand === 'add') {
         const { createResolver } = await import('./lib/resolver')
         const { addOfficialModule } = await import('./lib/module-install')
-        const { packageSpec, eject, moduleId } = parseModuleInstallArgs(commandArgs)
+        const { packageSpec, eject, moduleId, allowThirdParty } = parseModuleInstallArgs(commandArgs)
 
         if (!packageSpec) {
-          console.error('Usage: yarn mercato module add <packageSpec> [--module <moduleId>] [--eject]')
+          console.error('Usage: yarn mercato module add <packageSpec> [--module <moduleId>] [--eject] [--allow-third-party]')
           return 1
         }
 
-        const result = await addOfficialModule(createResolver(), packageSpec, eject, moduleId ?? undefined)
+        const result = await addOfficialModule(createResolver(), packageSpec, eject, moduleId ?? undefined, allowThirdParty)
         console.log(`\n✅ Module "${result.moduleId}" enabled from ${result.from}.\n`)
         console.log('Next steps:')
         console.log('  1. Review generated files if needed: .mercato/generated/')
@@ -1309,14 +1309,14 @@ export async function run(argv = process.argv) {
       if (subcommand === 'enable') {
         const packageName = commandArgs.find((arg) => !arg.startsWith('-'))
         if (!packageName) {
-          console.error('Usage: yarn mercato module enable <packageName> [--module <moduleId>] [--eject]')
+          console.error('Usage: yarn mercato module enable <packageName> [--module <moduleId>] [--eject] [--allow-third-party]')
           return 1
         }
 
         const { createResolver } = await import('./lib/resolver')
         const { enableOfficialModule } = await import('./lib/module-install')
-        const { moduleId, eject } = parseModuleInstallArgs(commandArgs)
-        const result = await enableOfficialModule(createResolver(), packageName, moduleId ?? undefined, eject)
+        const { moduleId, eject, allowThirdParty } = parseModuleInstallArgs(commandArgs)
+        const result = await enableOfficialModule(createResolver(), packageName, moduleId ?? undefined, eject, allowThirdParty)
         console.log(`\n✅ Module "${result.moduleId}" enabled from ${result.from}.\n`)
         console.log('Next steps:')
         console.log('  1. Review generated files if needed: .mercato/generated/')


### PR DESCRIPTION
Fixes #2940

## Problem
`yarn mercato module add` / `module enable` hard-rejected any package spec outside the `@open-mercato/*` scope:

```
❌ Module command failed: Unsupported package spec. Only direct @open-mercato/* package specs are allowed.
```

Third-party packages that follow the exact Open Mercato module conventions (e.g. `@fast-white-cat/integration-ksef-direct`) could only be installed by hand-editing `src/modules.ts`, skipping the CLI's validation + generate flow — even though `ModuleEntry.from` is already typed to accept arbitrary sources.

## Root Cause
Three layered `@open-mercato/`-prefix guards in `@open-mercato/cli`:
- `SAFE_PACKAGE_SPEC_PATTERN` (regex matched only `@open-mercato/…`)
- `assertPackageName` in `module-install.ts`
- the scope check in `enableOfficialModule`
- plus the scope assertion in `readOfficialModulePackageFromRoot` (`module-package.ts`)

## What Changed
- Relaxed `SAFE_PACKAGE_SPEC_PATTERN` to accept any valid scoped/unscoped npm package name, keeping the existing tag/version + `file:` suffix validation.
- Replaced the hard scope prefix checks with structure-based validation — module identity is trusted from `src/modules/<id>/` + `dist/modules/<id>/` + a parseable `index.ts`, not from the npm scope.
- Added an explicit `--allow-third-party` opt-in (parsed in `module-install-args.ts`, threaded through `addOfficialModule` / `enableOfficialModule`). Packages outside `@open-mercato/*` require this flag; official packages keep working with no flag.
- Updated `mercato module add/enable` usage strings and the CLI docs (`module-add.mdx`, `module-enable.mdx`).

### Why the flag (supply-chain safety)
Rather than silently trusting any npm scope, non-official packages require a deliberate `--allow-third-party` opt-in — this unblocks the integrator use case while keeping a guardrail against accidental/typo-squat installs.

## Tests
- `module-install-args.test.ts` — `--allow-third-party` parsing + `=value` rejection + default `false`.
- `module-install.test.ts` — third-party package rejected without the flag (add + enable), and full registration succeeds with the flag (asserts the `from: '@fast-white-cat/…'` entry written to `modules.ts`).
- `module-package.test.ts` — `readOfficialModulePackageFromRoot` validates a non-`@open-mercato` package by structure.
- Existing official-package + suffix-rejection tests unchanged and green (30 targeted tests pass).
- `yarn typecheck` (full) green; `@open-mercato/cli` build green.
- Note: `dev-env-reload.test.ts` has one pre-existing flaky failure on clean `develop` (file-watcher timer race), unrelated to this change.

## Backward Compatibility
Additive only. Exported `addOfficialModule` / `enableOfficialModule` gained an optional trailing `allowThirdParty` param (default `false`); `ParsedModuleInstallArgs` gained an additive field; `readOfficialModulePackageFromRoot` accepts a superset of inputs. No exported symbol, signature shape, or behavior for existing `@open-mercato/*` callers changed.

> Note: this relaxes a `mercato module add/enable` CLI guard (an "Ask First" contract surface). It is the change requested in #2940; flagged here for maintainer sign-off.
