### PR TITLE
feat(create-app): add --agents flag for non-interactive agentic setup

### DIFF
--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -14,7 +14,7 @@ import {
 } from './lib/ready-apps.js'
 import { applyStarterPreset } from './lib/apply-starter-preset.js'
 import { DEFAULT_PRESET_ID, VALID_PRESET_IDS } from './lib/starter-presets.js'
-import { runAgenticSetup } from './setup/wizard.js'
+import { runAgenticSetup, parseAgentsValue } from './setup/wizard.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -27,11 +27,18 @@ interface Options {
   preset?: string
   registry?: string
   initGit?: boolean
+  agents?: string
   skipAgenticSetup: boolean
   verdaccio: boolean
   help: boolean
   version: boolean
 }
+
+/** Resolved agentic-setup intent after combining --agents and --skip-agentic-setup. */
+type AgentSelection =
+  | { mode: 'skip' }
+  | { mode: 'tools'; tools: string[] }
+  | { mode: 'interactive' }
 
 function showHelp(): void {
   console.log(`
@@ -49,7 +56,9 @@ ${pc.bold('Options:')}
   --preset <id>      Starter preset: classic, empty, or crm (omit to choose interactively)
   --init-git         Initialize a local Git repository after scaffolding
   --no-init-git      Do not prompt for or initialize a local Git repository
-  --skip-agentic-setup  Skip the interactive agentic setup wizard
+  --agents <list>    Set up agent tooling non-interactively (skips the wizard):
+                     comma-separated claude-code,codex,cursor — or 'all' / 'none'
+  --skip-agentic-setup  Skip the agentic setup wizard (alias for --agents none)
   --registry <url>   Custom npm registry URL
   --verdaccio        Use local Verdaccio registry (http://localhost:4873)
   --help, -h         Show help
@@ -61,6 +70,9 @@ ${pc.bold('Examples:')}
   npx create-mercato-app my-store --preset empty
   npx create-mercato-app my-store --preset crm
   npx create-mercato-app my-store --init-git
+  npx create-mercato-app my-store --agents claude-code,codex
+  npx create-mercato-app my-store --agents all
+  npx create-mercato-app my-store --agents none
   npx create-mercato-app my-prm --app prm
   npx create-mercato-app my-marketplace --app-url https://github.com/some-agency/ready-app-marketplace
   npx create-mercato-app my-store --verdaccio
@@ -88,6 +100,7 @@ function parseArgs(args: string[]): { appName: string | null; options: Options }
     preset: undefined,
     registry: undefined,
     initGit: undefined,
+    agents: undefined,
     skipAgenticSetup: false,
     verdaccio: false,
     help: false,
@@ -102,6 +115,9 @@ function parseArgs(args: string[]): { appName: string | null; options: Options }
       options.help = true
     } else if (arg === '--version' || arg === '-v') {
       options.version = true
+    } else if (arg === '--agents') {
+      options.agents = requireOptionValue(args, index, arg)
+      index += 1
     } else if (arg === '--skip-agentic-setup') {
       options.skipAgenticSetup = true
     } else if (arg === '--init-git') {
@@ -419,9 +435,31 @@ async function scaffoldImportedReadyApp(targetDir: string, source: ReadyAppSourc
   ensureGeneratedCssPlaceholder(targetDir)
 }
 
-async function maybeRunAgenticSetup(targetDir: string, skipAgenticSetup: boolean): Promise<void> {
-  if (skipAgenticSetup) {
+// Combine --agents (validated) and --skip-agentic-setup into a single intent.
+// `--agents none` == `--skip-agentic-setup`; a non-empty --agents list together
+// with --skip-agentic-setup is contradictory and rejected.
+function resolveAgentSelection(options: Options): AgentSelection {
+  if (options.agents === undefined) {
+    return options.skipAgenticSetup ? { mode: 'skip' } : { mode: 'interactive' }
+  }
+  const parsed = parseAgentsValue(options.agents)
+  if (parsed.skip) {
+    return { mode: 'skip' }
+  }
+  if (options.skipAgenticSetup) {
+    throw new Error('--skip-agentic-setup cannot be combined with --agents <tools>. Use --agents none to skip.')
+  }
+  return { mode: 'tools', tools: parsed.tools }
+}
+
+async function maybeRunAgenticSetup(targetDir: string, selection: AgentSelection): Promise<void> {
+  if (selection.mode === 'skip') {
     await runAgenticSetup(targetDir, async () => '', { tool: 'skip' })
+    return
+  }
+
+  if (selection.mode === 'tools') {
+    await runAgenticSetup(targetDir, async () => '', { tool: selection.tools.join(',') })
     return
   }
 
@@ -529,6 +567,16 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 
   const readyAppSource = resolveReadyAppSource(options, PACKAGE_VERSION)
 
+  if (options.agents !== undefined && readyAppSource) {
+    throw new Error(
+      '--agents is not supported with --app/--app-url. Imported ready apps manage their own agentic tooling; run `yarn mercato agentic:init` inside the app instead.',
+    )
+  }
+
+  // Resolve (and validate) the agentic selection up front so a bad --agents
+  // value fails before any scaffolding work happens.
+  const agentSelection = resolveAgentSelection(options)
+
   const presetId = await resolveStarterPresetId(options, readyAppSource)
 
   const registryConfig = options.verdaccio
@@ -560,7 +608,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   console.log('')
 
   if (!readyAppSource) {
-    await maybeRunAgenticSetup(targetDir, options.skipAgenticSetup)
+    await maybeRunAgenticSetup(targetDir, agentSelection)
   }
 
   const gitResult = await maybeInitializeGitRepository(targetDir, options)

--- a/packages/create-app/src/setup/wizard.test.ts
+++ b/packages/create-app/src/setup/wizard.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { AGENT_TOOL_IDS, parseAgentsValue } from './wizard.js'
+
+test('parseAgentsValue: single tool', () => {
+  assert.deepEqual(parseAgentsValue('claude-code'), { skip: false, tools: ['claude-code'] })
+})
+
+test('parseAgentsValue: comma-separated list (trim + lowercase + dedupe)', () => {
+  assert.deepEqual(parseAgentsValue(' Claude-Code , codex ,codex'), {
+    skip: false,
+    tools: ['claude-code', 'codex'],
+  })
+})
+
+test('parseAgentsValue: all expands to every selectable tool', () => {
+  assert.deepEqual(parseAgentsValue('all'), { skip: false, tools: [...AGENT_TOOL_IDS] })
+})
+
+test('parseAgentsValue: none / skip request a skip', () => {
+  assert.deepEqual(parseAgentsValue('none'), { skip: true, tools: [] })
+  assert.deepEqual(parseAgentsValue('skip'), { skip: true, tools: [] })
+})
+
+test('parseAgentsValue: unknown id throws with the valid set', () => {
+  assert.throws(() => parseAgentsValue('claude-code,foo'), /Unknown agent "foo"\. Valid: .*all, none/)
+})
+
+test('parseAgentsValue: empty value throws', () => {
+  assert.throws(() => parseAgentsValue('   '), /requires at least one value/)
+})
+
+test('parseAgentsValue: none cannot combine with a tool', () => {
+  assert.throws(() => parseAgentsValue('none,codex'), /cannot be combined/)
+})
+
+test('parseAgentsValue: all cannot combine with a tool', () => {
+  assert.throws(() => parseAgentsValue('all,codex'), /cannot be combined with individual agents/)
+})

--- a/packages/create-app/src/setup/wizard.ts
+++ b/packages/create-app/src/setup/wizard.ts
@@ -26,6 +26,56 @@ const TOOLS = [
 
 const SELECTABLE_TOOLS = TOOLS.filter((t) => t.id !== 'multiple' && t.id !== 'skip')
 
+/** Concrete agent tool ids accepted by the `--agents` CLI flag. */
+export const AGENT_TOOL_IDS: readonly string[] = SELECTABLE_TOOLS.map((t) => t.id)
+
+export interface ParsedAgentsArg {
+  /** True when the value asked to skip agentic setup (`none`/`skip`). */
+  skip: boolean
+  /** Concrete tool ids to set up (empty when `skip`). */
+  tools: string[]
+}
+
+/**
+ * Parse the `--agents` value into a validated selection. Accepts a
+ * comma-separated list of tool ids plus the aliases `all` and `none`/`skip`.
+ * Throws (with the valid set) on unknown ids or contradictory combinations so
+ * the CLI fails fast instead of doing a silent half-setup.
+ */
+export function parseAgentsValue(raw: string): ParsedAgentsArg {
+  const validList = `${AGENT_TOOL_IDS.join(', ')}, all, none`
+  const tokens = raw
+    .split(',')
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean)
+  if (tokens.length === 0) {
+    throw new Error(`--agents requires at least one value (e.g. ${validList})`)
+  }
+
+  const hasSkip = tokens.some((t) => t === 'none' || t === 'skip')
+  const hasAll = tokens.some((t) => t === 'all')
+  const toolTokens = tokens.filter((t) => t !== 'none' && t !== 'skip' && t !== 'all')
+
+  const unknown = toolTokens.filter((t) => !AGENT_TOOL_IDS.includes(t))
+  if (unknown.length > 0) {
+    throw new Error(`Unknown agent ${unknown.map((u) => `"${u}"`).join(', ')}. Valid: ${validList}`)
+  }
+
+  if (hasSkip) {
+    if (hasAll || toolTokens.length > 0) {
+      throw new Error('--agents none cannot be combined with other agents')
+    }
+    return { skip: true, tools: [] }
+  }
+  if (hasAll) {
+    if (toolTokens.length > 0) {
+      throw new Error('--agents all cannot be combined with individual agents')
+    }
+    return { skip: false, tools: [...AGENT_TOOL_IDS] }
+  }
+  return { skip: false, tools: [...new Set(toolTokens)] }
+}
+
 async function promptSelection(ask: AskFn): Promise<string[]> {
   console.log('')
   console.log('🤖  Agentic workflow setup')


### PR DESCRIPTION
## Summary

Adds a `--agents <list>` argument to `create-mercato-app` so agentic tooling can be configured from the CLI instead of the interactive wizard — useful for CI, evals, and scripted scaffolding.

```bash
npx create-mercato-app my-store --agents claude-code,codex
npx create-mercato-app my-store --agents all
npx create-mercato-app my-store --agents none
```

## Behavior

| Input | Result |
|---|---|
| `--agents claude-code,codex` | sets those up, skips the wizard |
| `--agents all` | claude-code + codex + cursor |
| `--agents none` / `skip` | skip (equivalent to `--skip-agentic-setup`) |
| `--agents foo` | errors: `Unknown agent "foo". Valid: claude-code, codex, cursor, all, none` |
| `--skip-agentic-setup --agents codex` | errors (contradictory) |
| `--app … --agents …` | errors (imported ready apps manage their own tooling) |

Values are normalized (trim, lowercase, dedupe). Validation happens up front, before any scaffolding, so a bad value fails fast and CI never gets a silent half-setup.

## Implementation

- `setup/wizard.ts` — exported `AGENT_TOOL_IDS` and a validated `parseAgentsValue()` parser.
- `index.ts` — `--agents` flag parsing, an `AgentSelection` resolver combining `--agents`/`--skip-agentic-setup`, rewired `maybeRunAgenticSetup`, updated `--help` + examples, ready-app guard.
- Reuses the existing `runAgenticSetup({ tool })` plumbing — no change to how agentic files are generated. Purely additive (no existing flag behavior changes).

## Tests

`setup/wizard.test.ts` — 8 `node:test` cases for `parseAgentsValue` (single/list/all/none, dedupe+normalize, unknown-id error, empty error, contradictory combos). All green.

## Notes

- The fresh worktree needs `yarn install` before `yarn typecheck` / `yarn build:packages` run; the unit tests pass via the root `tsx`.
- `--help` is the source of truth for flags (updated); no docs flag-table to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)