### PR TITLE
fix: adjust labels tenant #3127

### DIFF
--- a/packages/core/src/modules/auth/frontend/login.tsx
+++ b/packages/core/src/modules/auth/frontend/login.tsx
@@ -395,7 +395,7 @@ export default function LoginPage() {
                   <div className="font-medium">
                     {tenantLoading
                       ? translate('auth.login.tenantLoading', 'Loading tenant details...')
-                      : translate('auth.login.tenantBanner', "You're logging in to {tenant} tenant.", {
+                      : translate('auth.login.tenantBanner', "You're logging in to {tenant}.", {
                           tenant: tenantName || tenantId,
                         })}
                   </div>

--- a/packages/core/src/modules/auth/i18n/de.json
+++ b/packages/core/src/modules/auth/i18n/de.json
@@ -51,7 +51,7 @@
   "auth.login.requireRoleMessage": "Für den Zugriff ist die folgende Rolle erforderlich: {roles}",
   "auth.login.requireRolesMessage": "Für den Zugriff ist eine der folgenden Rollen erforderlich: {roles}",
   "auth.login.subtitle": "Greife auf deinen Arbeitsbereich zu",
-  "auth.login.tenantBanner": "Du meldest dich beim Tenant {tenant} an.",
+  "auth.login.tenantBanner": "Du meldest dich bei {tenant} an.",
   "auth.login.tenantClear": "Zurücksetzen",
   "auth.login.tenantLoading": "Tenant-Daten werden geladen...",
   "auth.manageAuthSettings": "Verwalte die Authentifizierungseinstellungen.",

--- a/packages/core/src/modules/auth/i18n/en.json
+++ b/packages/core/src/modules/auth/i18n/en.json
@@ -51,7 +51,7 @@
   "auth.login.requireRoleMessage": "Access requires role: {roles}",
   "auth.login.requireRolesMessage": "Access requires one of the following roles: {roles}",
   "auth.login.subtitle": "Access your workspace",
-  "auth.login.tenantBanner": "You're logging in to {tenant} tenant.",
+  "auth.login.tenantBanner": "You're logging in to {tenant}.",
   "auth.login.tenantClear": "Clear",
   "auth.login.tenantLoading": "Loading tenant details...",
   "auth.manageAuthSettings": "Manage authentication settings.",

--- a/packages/core/src/modules/auth/i18n/es.json
+++ b/packages/core/src/modules/auth/i18n/es.json
@@ -51,7 +51,7 @@
   "auth.login.requireRoleMessage": "El acceso requiere el rol: {roles}",
   "auth.login.requireRolesMessage": "El acceso requiere uno de los siguientes roles: {roles}",
   "auth.login.subtitle": "Accede a tu espacio de trabajo",
-  "auth.login.tenantBanner": "Estás iniciando sesión en el inquilino {tenant}.",
+  "auth.login.tenantBanner": "Estás iniciando sesión en {tenant}.",
   "auth.login.tenantClear": "Borrar",
   "auth.login.tenantLoading": "Cargando detalles del inquilino...",
   "auth.manageAuthSettings": "Administra la configuración de autenticación.",

--- a/packages/core/src/modules/auth/i18n/pl.json
+++ b/packages/core/src/modules/auth/i18n/pl.json
@@ -51,7 +51,7 @@
   "auth.login.requireRoleMessage": "Dostęp wymaga roli: {roles}",
   "auth.login.requireRolesMessage": "Dostęp wymaga jednej z następujących ról: {roles}",
   "auth.login.subtitle": "Uzyskaj dostęp do swojego środowiska",
-  "auth.login.tenantBanner": "Logujesz się do najemcy {tenant}.",
+  "auth.login.tenantBanner": "Logujesz się do {tenant}.",
   "auth.login.tenantClear": "Wyczyść",
   "auth.login.tenantLoading": "Ładowanie szczegółów najemcy...",
   "auth.manageAuthSettings": "Zarządzaj ustawieniami uwierzytelniania.",

--- a/packages/core/src/modules/auth/lib/setup-app.ts
+++ b/packages/core/src/modules/auth/lib/setup-app.ts
@@ -300,7 +300,7 @@ export async function setupInitialTenant(
 
     await em.transactional(async (tem) => {
       const tenant = tem.create(Tenant, {
-        name: `${options.orgName} Tenant`,
+        name: options.orgName,
         isActive: true,
         createdAt: new Date(),
         updatedAt: new Date(),


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Provide a concise description of the problem and the proposed solution.

## Changes

- bullet the key code or documentation updates

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [ ] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [ ] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [ ] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [ ] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [ ] Loading state handled for async pages
- [ ] `aria-label` on all icon-only buttons (`<IconButton>`)
- [ ] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
