### PR TITLE
fix(auth): drop redundant tenant descriptor from login banner (#3127)

### DIFF
--- a/packages/core/src/modules/auth/__tests__/login-tenant-banner-i18n.test.ts
+++ b/packages/core/src/modules/auth/__tests__/login-tenant-banner-i18n.test.ts
@@ -1,0 +1,34 @@
+import { createTranslator } from '@open-mercato/shared/lib/i18n/translate'
+import en from '../i18n/en.json'
+import es from '../i18n/es.json'
+import pl from '../i18n/pl.json'
+import de from '../i18n/de.json'
+
+const locales: Record<string, Record<string, string>> = { en, es, pl, de }
+
+const BANNER_KEY = 'auth.login.tenantBanner'
+
+describe('login tenant banner i18n (#3127)', () => {
+  it('keeps the {tenant} placeholder in every locale', () => {
+    for (const [locale, dict] of Object.entries(locales)) {
+      expect(dict[BANNER_KEY]).toContain('{tenant}')
+    }
+  })
+
+  it('does not duplicate the word "tenant" when the tenant name already carries the provisioned " Tenant" suffix', () => {
+    // Provisioning names tenants `${orgName} Tenant` (auth/lib/setup-app.ts, auth/cli.ts),
+    // so the banner must not append its own generic "tenant" descriptor on top of that name.
+    const provisionedTenantName = 'Acme Tenant'
+    for (const [locale, dict] of Object.entries(locales)) {
+      const translate = createTranslator(dict)
+      const rendered = translate(BANNER_KEY, { tenant: provisionedTenantName })
+      expect(rendered).toContain(provisionedTenantName)
+      expect(rendered).not.toMatch(/tenant\s+tenant/i)
+    }
+  })
+
+  it('renders the English banner as the tenant name only, with no trailing descriptor', () => {
+    const translate = createTranslator(en)
+    expect(translate(BANNER_KEY, { tenant: 'Qacorpo' })).toBe("You're logging in to Qacorpo.")
+  })
+})

--- a/packages/core/src/modules/auth/frontend/login.tsx
+++ b/packages/core/src/modules/auth/frontend/login.tsx
@@ -395,7 +395,7 @@ export default function LoginPage() {
                   <div className="font-medium">
                     {tenantLoading
                       ? translate('auth.login.tenantLoading', 'Loading tenant details...')
-                      : translate('auth.login.tenantBanner', "You're logging in to {tenant} tenant.", {
+                      : translate('auth.login.tenantBanner', "You're logging in to {tenant}.", {
                           tenant: tenantName || tenantId,
                         })}
                   </div>

--- a/packages/core/src/modules/auth/i18n/de.json
+++ b/packages/core/src/modules/auth/i18n/de.json
@@ -51,7 +51,7 @@
   "auth.login.requireRoleMessage": "Für den Zugriff ist die folgende Rolle erforderlich: {roles}",
   "auth.login.requireRolesMessage": "Für den Zugriff ist eine der folgenden Rollen erforderlich: {roles}",
   "auth.login.subtitle": "Greife auf deinen Arbeitsbereich zu",
-  "auth.login.tenantBanner": "Du meldest dich beim Tenant {tenant} an.",
+  "auth.login.tenantBanner": "Du meldest dich bei {tenant} an.",
   "auth.login.tenantClear": "Zurücksetzen",
   "auth.login.tenantLoading": "Tenant-Daten werden geladen...",
   "auth.manageAuthSettings": "Verwalte die Authentifizierungseinstellungen.",

--- a/packages/core/src/modules/auth/i18n/en.json
+++ b/packages/core/src/modules/auth/i18n/en.json
@@ -51,7 +51,7 @@
   "auth.login.requireRoleMessage": "Access requires role: {roles}",
   "auth.login.requireRolesMessage": "Access requires one of the following roles: {roles}",
   "auth.login.subtitle": "Access your workspace",
-  "auth.login.tenantBanner": "You're logging in to {tenant} tenant.",
+  "auth.login.tenantBanner": "You're logging in to {tenant}.",
   "auth.login.tenantClear": "Clear",
   "auth.login.tenantLoading": "Loading tenant details...",
   "auth.manageAuthSettings": "Manage authentication settings.",

--- a/packages/core/src/modules/auth/i18n/es.json
+++ b/packages/core/src/modules/auth/i18n/es.json
@@ -51,7 +51,7 @@
   "auth.login.requireRoleMessage": "El acceso requiere el rol: {roles}",
   "auth.login.requireRolesMessage": "El acceso requiere uno de los siguientes roles: {roles}",
   "auth.login.subtitle": "Accede a tu espacio de trabajo",
-  "auth.login.tenantBanner": "Estás iniciando sesión en el inquilino {tenant}.",
+  "auth.login.tenantBanner": "Estás iniciando sesión en {tenant}.",
   "auth.login.tenantClear": "Borrar",
   "auth.login.tenantLoading": "Cargando detalles del inquilino...",
   "auth.manageAuthSettings": "Administra la configuración de autenticación.",

--- a/packages/core/src/modules/auth/i18n/pl.json
+++ b/packages/core/src/modules/auth/i18n/pl.json
@@ -51,7 +51,7 @@
   "auth.login.requireRoleMessage": "Dostęp wymaga roli: {roles}",
   "auth.login.requireRolesMessage": "Dostęp wymaga jednej z następujących ról: {roles}",
   "auth.login.subtitle": "Uzyskaj dostęp do swojego środowiska",
-  "auth.login.tenantBanner": "Logujesz się do najemcy {tenant}.",
+  "auth.login.tenantBanner": "Logujesz się do {tenant}.",
   "auth.login.tenantClear": "Wyczyść",
   "auth.login.tenantLoading": "Ładowanie szczegółów najemcy...",
   "auth.manageAuthSettings": "Zarządzaj ustawieniami uwierzytelniania.",


### PR DESCRIPTION
Fixes #3127

## Problem
After self-service onboarding the login banner read "You're logging in to **Qacorpo Tenant tenant**." — the word *tenant* appeared twice and the org name was buried.

## Root Cause
Two layers compounded:
1. Provisioning names every tenant `${orgName} Tenant` (`auth/lib/setup-app.ts`, `auth/cli.ts`) → tenant name "Qacorpo Tenant".
2. The banner i18n string appended its own generic descriptor after the name: `"You're logging in to {tenant} tenant."` (and the localized equivalents *inquilino* / *najemcy* / *Tenant*).

With a name that already ends in "Tenant", the descriptor became redundant/duplicated.

## What Changed
- Display the tenant's own name on its own in the banner, dropping the trailing descriptor, across all four locales (en/es/pl/de) and the inline fallback in `login.tsx`. English now reads "You're logging in to Qacorpo Tenant." (single, accurate) and a bare-name tenant reads "You're logging in to Qacorpo.".
- The data-model `${orgName} Tenant` provisioning suffix is intentionally left untouched — the reporter flagged the tenant-vs-organization naming only as "worth discussing", and changing stored tenant names has wider blast radius across admin lists. This PR fixes the user-visible duplication at the display layer only.

## Tests
- Added `packages/core/src/modules/auth/__tests__/login-tenant-banner-i18n.test.ts`: asserts the `{tenant}` placeholder is preserved in every locale, that rendering with a provisioned " Tenant"-suffixed name never produces a duplicated descriptor (`/tenant\s+tenant/i`), and that the English banner renders as the tenant name only.
- `yarn i18n:check-sync` ✅ (locales in sync) · `yarn i18n:check-usage` ✅ · core typecheck shows no errors referencing the touched files.

## Backward Compatibility
No contract surface changes — only translation copy and one inline fallback string. The i18n key `auth.login.tenantBanner` is unchanged.