### PR TITLE
fix(auth): stop login feature-check refiring when tenant banner is cleared (#3128)

### DIFF
--- a/packages/core/src/modules/auth/__tests__/login-feature-check-once.test.tsx
+++ b/packages/core/src/modules/auth/__tests__/login-feature-check-once.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression coverage for GH #3128 — clicking "Clear" on the login tenant
+ * banner deletes the `tenant` query param and navigates, which used to change
+ * the `searchParams` object the mount feature-check effect depended on, firing
+ * a second (401) POST /api/auth/feature-check. The effect must only depend on
+ * the `redirect` param it actually reads, so unrelated query-param changes do
+ * not re-trigger the auth probe.
+ */
+import * as React from 'react'
+import { act, render, waitFor } from '@testing-library/react'
+import LoginPage from '../frontend/login'
+
+const mockTranslate = (_key: string, fallback?: string, params?: Record<string, string | number>) => {
+  if (!fallback) return _key
+  if (!params) return fallback
+  return Object.entries(params).reduce(
+    (acc, [name, value]) => acc.replace(`{${name}}`, String(value)),
+    fallback,
+  )
+}
+
+const mockReplace = jest.fn()
+const mockPush = jest.fn()
+// Next's useRouter returns a stable reference across renders; mirror that so the
+// effect's dependency array isn't invalidated by an unrelated new router object.
+const mockRouter = { replace: mockReplace, push: mockPush }
+const mockApiCall = jest.fn()
+let currentSearchParams = new URLSearchParams()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => mockRouter,
+  useSearchParams: () => currentSearchParams,
+}))
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => <img alt={String(props.alt ?? '')} />,
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, ...rest }: any) => <a href={typeof href === 'string' ? href : '#'} {...rest}>{children}</a>,
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/translate', () => ({
+  translateWithFallback: (_t: unknown, _key: string, fallback: string, params?: Record<string, string | number>) =>
+    mockTranslate(_key, fallback, params),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/operations/store', () => ({
+  clearAllOperations: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/AuthSessionGuard', () => ({
+  notifyAuthIdentityChange: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/InjectionSpot', () => ({
+  InjectionSpot: () => null,
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useRegisteredComponent', () => ({
+  useRegisteredComponent: (_handle: string, Fallback: any) => Fallback,
+}))
+
+beforeAll(() => {
+  ;(globalThis as any).fetch = jest.fn(async () => ({ ok: true, json: async () => ({}), text: async () => '' }))
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  currentSearchParams = new URLSearchParams()
+  window.localStorage.clear()
+  mockApiCall.mockImplementation(async (url: string) => {
+    if (typeof url === 'string' && url.startsWith('/api/directory/tenants/lookup')) {
+      return { result: { ok: true, tenant: { id: 'tenant-1', name: 'Acme Tenant' } } }
+    }
+    // Unauthenticated visitor: feature-check returns no userId.
+    return { result: {} }
+  })
+})
+
+const featureCheckCalls = () =>
+  mockApiCall.mock.calls.filter(([url]) => url === '/api/auth/feature-check').length
+
+describe('LoginPage — feature-check fires once (#3128)', () => {
+  it('does not re-issue POST /api/auth/feature-check when the tenant param is cleared', async () => {
+    currentSearchParams = new URLSearchParams({ redirect: '/backend', tenant: 'tenant-1' })
+
+    let rerender: (ui: React.ReactElement) => void
+    await act(async () => {
+      const view = render(<LoginPage />)
+      rerender = view.rerender
+    })
+    await waitFor(() => expect(featureCheckCalls()).toBe(1))
+
+    // Simulate "Clear": the tenant param is removed, the rest of the URL is unchanged.
+    currentSearchParams = new URLSearchParams({ redirect: '/backend' })
+    await act(async () => {
+      rerender(<LoginPage />)
+      await Promise.resolve()
+    })
+
+    expect(featureCheckCalls()).toBe(1)
+  })
+})

--- a/packages/core/src/modules/auth/frontend/login.tsx
+++ b/packages/core/src/modules/auth/frontend/login.tsx
@@ -102,6 +102,7 @@ export default function LoginPage() {
   const searchParams = useSearchParams()
   const requireRole = (searchParams.get('requireRole') || searchParams.get('role') || '').trim()
   const requireFeature = (searchParams.get('requireFeature') || '').trim()
+  const redirectParam = searchParams.get('redirect') || ''
   const requiredRoles = requireRole ? requireRole.split(',').map((value) => value.trim()).filter(Boolean) : []
   const requiredFeatures = requireFeature ? requireFeature.split(',').map((value) => value.trim()).filter(Boolean) : []
   const translatedRoles = requiredRoles.map((role) => translate(`auth.roles.${role}`, role))
@@ -148,7 +149,7 @@ export default function LoginPage() {
         // producing an infinite loop (see GH #2070). Stay on the login page so
         // the access-denied banner is visible.
         if (hasAclChallenge) return
-        const rawRedirect = searchParams.get('redirect') || ''
+        const rawRedirect = redirectParam
         let destination = '/backend'
         if (rawRedirect) {
           try {
@@ -170,7 +171,7 @@ export default function LoginPage() {
       }
     })()
     return () => { cancelled = true }
-  }, [router, searchParams, requiredFeatures.length, requiredRoles.length])
+  }, [router, redirectParam, requiredFeatures.length, requiredRoles.length])
 
   useEffect(() => {
     const tenantParam = (searchParams.get('tenant') || '').trim()


### PR DESCRIPTION
Fixes #3128

## Problem
On the login page, clicking **Clear** to dismiss the tenant-selection banner fired a second `POST /api/auth/feature-check` that returned `401`. Dismissing a UI banner should not cause a network request.

## Root Cause
The mount feature-check effect listed the entire `searchParams` object in its dependency array:
```ts
}, [router, searchParams, requiredFeatures.length, requiredRoles.length])
```
`handleClearTenant` deletes the `tenant` query param and calls `router.replace(...)`, which yields a **new** `searchParams` reference. React then re-ran the effect and issued another feature-check, even though nothing the effect cares about changed.

## What Changed
- The effect only ever reads the `redirect` param, so it now depends on that hoisted string value (`redirectParam`) instead of the whole `searchParams` object. Removing the unrelated `tenant` param no longer invalidates the dependency array, so the auth probe is not repeated. The authenticated-redirect and ACL-challenge (#2070) behavior is unchanged.

## Tests
- Added `packages/core/src/modules/auth/__tests__/login-feature-check-once.test.tsx`: renders the login page with a `tenant` param, then re-renders with it removed (what Clear does) and asserts `/api/auth/feature-check` is called exactly once. Verified it fails against the old dependency array (2 calls) and passes with the fix.
- Existing `login-acl-challenge.test.tsx` (#2070) still passes.
- core typecheck shows no errors referencing the touched file.

## Backward Compatibility
No contract surface changes — internal `useEffect` dependency adjustment in the login page only.

## QA note
Customer-facing login behavior — warrants manual QA (verify in DevTools that clicking *Clear* on the banner fires no `/api/auth/feature-check` request).