### PR TITLE
refactor(sync-akeneo,channel-gmail): consolidate HTTP clients onto shared fetchWithTimeout (#3068)

### DIFF
--- a/packages/channel-gmail/src/modules/channel_gmail/lib/__tests__/gmail-client.test.ts
+++ b/packages/channel-gmail/src/modules/channel_gmail/lib/__tests__/gmail-client.test.ts
@@ -1,3 +1,4 @@
+import { FetchTimeoutError } from '@open-mercato/shared/lib/http/fetchWithTimeout'
 import { decodeBase64Url, encodeBase64Url, getGmailApiClient, GmailApiError, setGmailApiClient } from '../gmail-client'
 
 describe('base64url encoding helpers', () => {
@@ -53,6 +54,10 @@ function fakeResponse(init: FakeResponseInit): Response {
 }
 
 describe('FetchGmailApiClient.requestJson retry/backoff', () => {
+  // Mirrors GMAIL_DEFAULT_REQUEST_TIMEOUT_MS in gmail-client.ts: the per-request
+  // timeout `fetchWithTimeout` schedules when no OM_CHANNEL_GMAIL_REQUEST_TIMEOUT_MS
+  // override is set (none of these tests set it).
+  const GMAIL_DEFAULT_REQUEST_TIMEOUT_MS = 30_000
   const originalFetch = globalThis.fetch
   const originalSetTimeout = globalThis.setTimeout
   const originalRandom = Math.random
@@ -65,8 +70,15 @@ describe('FetchGmailApiClient.requestJson retry/backoff', () => {
     capturedDelays = []
     // Replace the backoff sleep with a synchronous no-wait shim that records the
     // requested delay and fires the callback immediately, so the retry loop runs
-    // without real timers while we assert the computed wait durations.
+    // without real timers while we assert the computed wait durations. The
+    // shared `fetchWithTimeout` helper also schedules a per-request timeout timer
+    // (`GMAIL_DEFAULT_REQUEST_TIMEOUT_MS`); delegate that one to the real timer —
+    // the helper clears it in its `finally` before the mocked fetch resolves, so
+    // it never fires and never pollutes the recorded backoff delays.
     globalThis.setTimeout = ((callback: () => void, ms?: number) => {
+      if (ms === GMAIL_DEFAULT_REQUEST_TIMEOUT_MS) {
+        return originalSetTimeout(callback, ms)
+      }
       capturedDelays.push(typeof ms === 'number' ? ms : 0)
       callback()
       return 0 as unknown as ReturnType<typeof setTimeout>
@@ -241,6 +253,29 @@ describe('FetchGmailApiClient.requestJson retry/backoff', () => {
     expect(calls).toBe(2)
     expect(profile.historyId).toBe('5')
     // computeBackoff(0) = 500ms (jitter stripped) — the timeout took the retry path.
+    expect(capturedDelays).toEqual([500])
+  })
+
+  it('treats a shared-helper FetchTimeoutError as transient and retries it (issue #3068)', async () => {
+    Math.random = () => 0
+    let calls = 0
+    globalThis.fetch = (() => {
+      calls += 1
+      if (calls === 1) {
+        // After consolidating onto `fetchWithTimeout`, an elapsed per-request
+        // timeout surfaces as `FetchTimeoutError` (a real Error subclass), not a
+        // `TimeoutError` DOMException — exercise that production failure shape.
+        return Promise.reject(new FetchTimeoutError('https://gmail.googleapis.com/gmail/v1/users/me/profile', 30_000))
+      }
+      return Promise.resolve(
+        fakeResponse({ status: 200, statusText: 'OK', body: JSON.stringify({ emailAddress: 'a@gmail.com', historyId: '11' }) }),
+      )
+    }) as unknown as typeof globalThis.fetch
+
+    const profile = await getGmailApiClient().getProfile({ accessToken: 'token' })
+
+    expect(calls).toBe(2)
+    expect(profile.historyId).toBe('11')
     expect(capturedDelays).toEqual([500])
   })
 

--- a/packages/channel-gmail/src/modules/channel_gmail/lib/gmail-client.ts
+++ b/packages/channel-gmail/src/modules/channel_gmail/lib/gmail-client.ts
@@ -14,6 +14,8 @@
  *   - deleteMessage    → gmail.users.messages.trash (move to trash; matches `deleteMessage: true` capability)
  */
 
+import { fetchWithTimeout, FetchTimeoutError } from '@open-mercato/shared/lib/http/fetchWithTimeout'
+
 const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1'
 
 export interface GmailApiAuth {
@@ -198,23 +200,23 @@ class FetchGmailApiClient implements GmailApiClient {
     while (attempt <= GMAIL_MAX_RETRIES) {
       let res: Response
       try {
-        res = await fetch(url.toString(), {
+        res = await fetchWithTimeout(url.toString(), {
           method,
           headers,
           body: payload,
           // Bound each attempt so a stalled connection fails fast instead of
           // hanging on undici's multi-minute default and pinning the worker slot.
-          signal: AbortSignal.timeout(resolveGmailRequestTimeoutMs()),
+          timeoutMs: resolveGmailRequestTimeoutMs(),
         })
       } catch (err) {
         // A timed-out/aborted connection is transient — let the bounded retry
-        // loop retry it rather than propagating a raw error. `AbortSignal.timeout`
-        // rejects fetch with a `TimeoutError` DOMException; an externally-aborted
-        // request surfaces as `AbortError`. Match on the `name` field (not
-        // `instanceof Error`, since DOMException does not subclass Error across
-        // realms) — treat both as transient.
+        // loop retry it rather than propagating a raw error. `fetchWithTimeout`
+        // surfaces an elapsed timeout as `FetchTimeoutError`; an externally-aborted
+        // request still surfaces as an `AbortError` DOMException. Match the
+        // `FetchTimeoutError` type and the abort `name` field (DOMException does
+        // not subclass Error across realms) — treat both as transient.
         const errName = (err as { name?: unknown } | null)?.name
-        const aborted = errName === 'TimeoutError' || errName === 'AbortError'
+        const aborted = err instanceof FetchTimeoutError || errName === 'TimeoutError' || errName === 'AbortError'
         if (!aborted) throw err
         const timeoutError = new GmailApiError(
           `Gmail API ${method} ${url.pathname} timed out`,

--- a/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts
@@ -1,3 +1,4 @@
+import { FetchTimeoutError } from '@open-mercato/shared/lib/http/fetchWithTimeout'
 import { createAkeneoClient, encodeAkeneoPathParam, normalizeAkeneoDateTime, sanitizeAkeneoProductNextUrl, validateAkeneoApiUrl } from '../lib/client'
 
 const validCredentials = {
@@ -222,6 +223,10 @@ describe('akeneo client security', () => {
 })
 
 describe('akeneo client resilience (issue #2976)', () => {
+  // Mirrors DEFAULT_AKENEO_REQUEST_TIMEOUT_MS in client.ts: the per-request
+  // timeout `fetchWithTimeout` schedules when no
+  // OM_INTEGRATION_AKENEO_REQUEST_TIMEOUT_MS override is set (none of these tests set it).
+  const AKENEO_DEFAULT_REQUEST_TIMEOUT_MS = 30_000
   const originalFetch = global.fetch
   const originalSetTimeout = global.setTimeout
   const originalMaxRetries = process.env.OM_INTEGRATION_AKENEO_MAX_RATE_LIMIT_RETRIES
@@ -236,8 +241,15 @@ describe('akeneo client resilience (issue #2976)', () => {
     global.fetch = jest.fn() as typeof fetch
     capturedDelays = []
     // Fire backoff/retry-after sleeps synchronously so the retry loop runs
-    // without real timers while we assert the requested wait durations.
+    // without real timers while we assert the requested wait durations. The
+    // shared `fetchWithTimeout` helper also schedules a per-request timeout timer
+    // (`AKENEO_DEFAULT_REQUEST_TIMEOUT_MS`); delegate that one to the real timer —
+    // the helper clears it in its `finally` before the mocked fetch resolves, so
+    // it never fires and never pollutes the recorded backoff delays.
     global.setTimeout = ((callback: () => void, ms?: number) => {
+      if (ms === AKENEO_DEFAULT_REQUEST_TIMEOUT_MS) {
+        return originalSetTimeout(callback, ms)
+      }
       capturedDelays.push(typeof ms === 'number' ? ms : 0)
       callback()
       return 0 as unknown as ReturnType<typeof setTimeout>
@@ -304,5 +316,15 @@ describe('akeneo client resilience (issue #2976)', () => {
     const requestInit = fetchMock.mock.calls[1][1] as RequestInit
     expect(tokenInit.signal).toBeInstanceOf(AbortSignal)
     expect(requestInit.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('surfaces the shared-helper FetchTimeoutError when an authenticated request times out (issue #3068)', async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse())
+      .mockRejectedValueOnce(new FetchTimeoutError('https://tenant.cloud.akeneo.com/api/rest/v1/channels', 30_000))
+
+    const client = createAkeneoClient(validCredentials)
+    await expect(client.listChannels()).rejects.toBeInstanceOf(FetchTimeoutError)
   })
 })

--- a/packages/sync-akeneo/src/modules/sync_akeneo/lib/client.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/lib/client.ts
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from '@open-mercato/shared/lib/http/fetchWithTimeout'
 import { dedupeStrings, labelFromLocalizedRecord, safeRecord, type AkeneoAttribute, type AkeneoAttributeOption, type AkeneoCategory, type AkeneoChannel, type AkeneoCredentialShape, type AkeneoFamily, type AkeneoFamilyVariant, type AkeneoLocale, type AkeneoProduct, type AkeneoProductModel } from './shared'
 
 type TokenState = {
@@ -250,9 +251,9 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
   }
 
   async function acquirePasswordGrantToken(): Promise<TokenState> {
-    const response = await fetch(tokenEndpointUrl, {
+    const response = await fetchWithTimeout(tokenEndpointUrl, {
       method: 'POST',
-      signal: AbortSignal.timeout(resolveAkeneoRequestTimeoutMs()),
+      timeoutMs: resolveAkeneoRequestTimeoutMs(),
       headers: {
         accept: 'application/json',
         'content-type': 'application/json',
@@ -289,9 +290,9 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
 
   async function refreshAccessToken(current: TokenState): Promise<TokenState> {
     if (!current.refreshToken) return acquirePasswordGrantToken()
-    const response = await fetch(tokenEndpointUrl, {
+    const response = await fetchWithTimeout(tokenEndpointUrl, {
       method: 'POST',
-      signal: AbortSignal.timeout(resolveAkeneoRequestTimeoutMs()),
+      timeoutMs: resolveAkeneoRequestTimeoutMs(),
       headers: {
         accept: 'application/json',
         'content-type': 'application/json',
@@ -338,9 +339,9 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
     const url = resolveAkeneoRequestUrl(pathOrUrl)
     const token = await ensureToken()
 
-    const response = await fetch(url, {
+    const response = await fetchWithTimeout(url, {
       ...init,
-      signal: init.signal ?? AbortSignal.timeout(resolveAkeneoRequestTimeoutMs()),
+      timeoutMs: resolveAkeneoRequestTimeoutMs(),
       headers: {
         accept: 'application/json',
         authorization: `Bearer ${token}`,
@@ -387,9 +388,9 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
     const url = resolveAkeneoRequestUrl(pathOrUrl)
     const token = await ensureToken()
 
-    const response = await fetch(url, {
+    const response = await fetchWithTimeout(url, {
       ...init,
-      signal: init.signal ?? AbortSignal.timeout(resolveAkeneoRequestTimeoutMs()),
+      timeoutMs: resolveAkeneoRequestTimeoutMs(),
       headers: {
         authorization: `Bearer ${token}`,
         ...init.headers,


### PR DESCRIPTION
Fixes #3068

## Problem
PR #3014 hardened the Akeneo and Gmail external HTTP clients against remote-controlled hangs, but both clients hand-rolled their own `AbortSignal.timeout(...)` plumbing. The `#3014` review raised a Low finding: this duplicated wiring is exactly what `@open-mercato/shared/lib/http/fetchWithTimeout` already provides, and the hand-rolled `AbortSignal.timeout()` is what produced the `TimeoutError`-vs-`AbortError` foot-gun fixed earlier in that PR.

## Root Cause
Both clients re-implemented timeout plumbing instead of reusing the shared helper (`AGENTS.md`: "re-use common utilities via `src/lib/`"). `AbortSignal.timeout()` rejects with a `TimeoutError` DOMException, which does not subclass `Error` across realms — a recurring foot-gun the shared `fetchWithTimeout` avoids by throwing a real `FetchTimeoutError`.

## What Changed
- `packages/sync-akeneo/.../lib/client.ts`: replaced all four `fetch(..., { signal: AbortSignal.timeout(...) })` sites (password-grant token, refresh token, `request`, `requestBinary`) with `fetchWithTimeout(..., { timeoutMs })`.
- `packages/channel-gmail/.../lib/gmail-client.ts`: replaced the `requestJson` `fetch(..., { signal: AbortSignal.timeout(...) })` with `fetchWithTimeout(..., { timeoutMs })`, and extended the transient-error guard to also treat the helper's `FetchTimeoutError` as transient (alongside the externally-aborted `AbortError`).

Behavior preserved: env-overridable timeout/retry defaults (`OM_INTEGRATION_AKENEO_REQUEST_TIMEOUT_MS`, `OM_CHANNEL_GMAIL_REQUEST_TIMEOUT_MS`), retry-as-transient semantics, and error shapes (`Akeneo request failed (<status>)`, `GmailApiError`) all stay intact.

## Tests
- Updated the Akeneo + Gmail resilience suites' fake-timer shims to delegate the helper's per-request timeout timer to the real timer (it is cleared in `finally` before the mocked fetch resolves), so it no longer pollutes the asserted backoff delays.
- Added a Gmail test: a shared-helper `FetchTimeoutError` is treated as transient and retried.
- Added an Akeneo test: a `FetchTimeoutError` from an authenticated request propagates unchanged.
- `packages/sync-akeneo` jest: 8 suites / 50 tests green. `packages/channel-gmail` jest: 6 suites / 78 tests green.
- `tsc --noEmit` clean for both packages; `yarn build:packages` (21 packages) and `yarn generate` succeed.

## Backward Compatibility
No contract surface changes. Imports are additive, public signatures and error shapes are unchanged. Pure internal refactor.