### PR TITLE
fix(search): propagate strategy index/delete/purge failures so the queue retries (#3103)

### DIFF
--- a/packages/queue/src/strategies/local.ts
+++ b/packages/queue/src/strategies/local.ts
@@ -32,7 +32,10 @@ const fsp = fs.promises
  * **Limitations:**
  * - Jobs are processed sequentially (concurrency option is for logging/compatibility only)
  * - Not suitable for production or multi-process environments
- * - No retry mechanism for failed jobs
+ *
+ * Failed jobs are retried up to `DEFAULT_MAX_ATTEMPTS` times with exponential
+ * backoff and moved to a dead-letter store once attempts are exhausted (see the
+ * retry handling in `process()` below).
  *
  * All file I/O is asynchronous (`fs.promises.*`) so queue operations do not
  * block the Node.js event loop. A per-queue promise chain serializes

--- a/packages/search/src/__tests__/service.test.ts
+++ b/packages/search/src/__tests__/service.test.ts
@@ -355,6 +355,52 @@ describe('SearchService', () => {
       expect(availableStrategy.index).toHaveBeenCalled()
       expect(unavailableStrategy.index).not.toHaveBeenCalled()
     })
+
+    // issue #3103: a strategy index failure must surface to the caller so the
+    // queue worker re-throws and the job is retried instead of silently completing.
+    it('should reject when a strategy index fails (so the queue can retry)', async () => {
+      const strategy = createMockStrategy({
+        id: 'vector',
+        index: jest.fn().mockRejectedValue(new Error('sorry, too many clients already')),
+      })
+      const service = new SearchService({ strategies: [strategy] })
+
+      await expect(service.index(createMockRecord())).rejects.toThrow(
+        'Search index failed for 1 strategy(ies): vector (sorry, too many clients already)'
+      )
+    })
+
+    it('should still reject when only one of several strategies fails', async () => {
+      const ok = createMockStrategy({ id: 'tokens', index: jest.fn().mockResolvedValue(undefined) })
+      const failing = createMockStrategy({
+        id: 'vector',
+        index: jest.fn().mockRejectedValue(new Error('embedding provider blip')),
+      })
+      const service = new SearchService({ strategies: [ok, failing] })
+
+      await expect(service.index(createMockRecord())).rejects.toThrow(
+        'Search index failed for 1 strategy(ies): vector (embedding provider blip)'
+      )
+      // Successful strategies still commit their work.
+      expect(ok.index).toHaveBeenCalled()
+    })
+
+    it('should preserve the original strategy errors on the thrown AggregateError', async () => {
+      const cause = new Error('sorry, too many clients already')
+      const strategy = createMockStrategy({ id: 'vector', index: jest.fn().mockRejectedValue(cause) })
+      const service = new SearchService({ strategies: [strategy] })
+
+      await expect(service.index(createMockRecord())).rejects.toMatchObject({
+        errors: [cause],
+      })
+    })
+
+    it('should resolve when all strategies succeed', async () => {
+      const strategy = createMockStrategy({ id: 'tokens', index: jest.fn().mockResolvedValue(undefined) })
+      const service = new SearchService({ strategies: [strategy] })
+
+      await expect(service.index(createMockRecord())).resolves.toBeUndefined()
+    })
   })
 
   describe('bulkIndex', () => {
@@ -439,6 +485,19 @@ describe('SearchService', () => {
       expect(strategy1.delete).toHaveBeenCalledWith('test:entity', 'rec-123', 'tenant-123')
       expect(strategy2.delete).toHaveBeenCalledWith('test:entity', 'rec-123', 'tenant-123')
     })
+
+    // issue #3103: deletes must also surface failures so removals are retried.
+    it('should reject when a strategy delete fails (so the queue can retry)', async () => {
+      const strategy = createMockStrategy({
+        id: 'fulltext',
+        delete: jest.fn().mockRejectedValue(new Error('connection reset')),
+      })
+      const service = new SearchService({ strategies: [strategy] })
+
+      await expect(service.delete('test:entity', 'rec-123', 'tenant-123')).rejects.toThrow(
+        'Search delete failed for 1 strategy(ies): fulltext (connection reset)'
+      )
+    })
   })
 
   describe('purge', () => {
@@ -459,6 +518,19 @@ describe('SearchService', () => {
 
       // organizationId is forwarded as undefined for a tenant-wide purge (issue #2935)
       expect(strategyWithPurge.purge).toHaveBeenCalledWith('test:entity', 'tenant-123', undefined)
+    })
+
+    // issue #3103: purge failures must surface so the reindex job is retried.
+    it('should reject when a strategy purge fails (so the queue can retry)', async () => {
+      const strategy = createMockStrategy({
+        id: 'tokens',
+        purge: jest.fn().mockRejectedValue(new Error('sorry, too many clients already')),
+      })
+      const service = new SearchService({ strategies: [strategy] })
+
+      await expect(service.purge('test:entity', 'tenant-123')).rejects.toThrow(
+        'Search purge failed for 1 strategy(ies): tokens (sorry, too many clients already)'
+      )
     })
   })
 

--- a/packages/search/src/service.ts
+++ b/packages/search/src/service.ts
@@ -202,19 +202,10 @@ export class SearchService {
       strategies.map((strategy) => this.executeStrategyIndex(strategy, record)),
     )
 
-    // Log any failures
-    for (let i = 0; i < results.length; i++) {
-      const result = results[i]
-      if (result.status === 'rejected') {
-        const strategy = strategies[i]
-        searchError('SearchService', 'Strategy index failed', {
-          strategyId: strategy?.id,
-          entityId: record.entityId,
-          recordId: record.recordId,
-          error: result.reason instanceof Error ? result.reason.message : result.reason,
-        })
-      }
-    }
+    this.throwOnStrategyFailures('index', strategies, results, {
+      entityId: record.entityId,
+      recordId: record.recordId,
+    })
   }
 
   /**
@@ -231,19 +222,7 @@ export class SearchService {
       strategies.map((strategy) => this.executeStrategyDelete(strategy, entityId, recordId, tenantId)),
     )
 
-    // Log any failures
-    for (let i = 0; i < results.length; i++) {
-      const result = results[i]
-      if (result.status === 'rejected') {
-        const strategy = strategies[i]
-        searchError('SearchService', 'Strategy delete failed', {
-          strategyId: strategy?.id,
-          entityId,
-          recordId,
-          error: result.reason instanceof Error ? result.reason.message : result.reason,
-        })
-      }
-    }
+    this.throwOnStrategyFailures('delete', strategies, results, { entityId, recordId })
   }
 
   /**
@@ -312,18 +291,54 @@ export class SearchService {
       }),
     )
 
-    // Log any failures
+    this.throwOnStrategyFailures('purge', strategies, results, { entityId })
+  }
+
+  /**
+   * Inspect the settled results of a per-strategy write operation, log every
+   * rejection, and re-throw an aggregated error when any strategy failed.
+   *
+   * Write operations (index/delete/purge) must surface failures to the caller
+   * so the queue worker re-throws and the job is retried. Swallowing rejections
+   * here causes silent, permanent index gaps on transient failures such as
+   * Postgres connection-pool exhaustion (issue #3103). Successful strategies
+   * still commit their work; only the aggregated failure propagates.
+   */
+  private throwOnStrategyFailures(
+    operation: 'index' | 'delete' | 'purge',
+    strategies: SearchStrategy[],
+    results: PromiseSettledResult<unknown>[],
+    context: { entityId: string; recordId?: string },
+  ): void {
+    const failures: Array<{ strategyId: string; reason: unknown }> = []
+
     for (let i = 0; i < results.length; i++) {
       const result = results[i]
       if (result.status === 'rejected') {
         const strategy = strategies[i]
-        searchError('SearchService', 'Strategy purge failed', {
+        failures.push({ strategyId: strategy?.id || 'unknown', reason: result.reason })
+        searchError('SearchService', `Strategy ${operation} failed`, {
           strategyId: strategy?.id,
-          entityId,
+          entityId: context.entityId,
+          recordId: context.recordId,
           error: result.reason instanceof Error ? result.reason.message : result.reason,
         })
       }
     }
+
+    if (failures.length === 0) return
+
+    const summary = `Search ${operation} failed for ${failures.length} strategy(ies): ${failures
+      .map((failure) => {
+        const message = failure.reason instanceof Error ? failure.reason.message : String(failure.reason)
+        return `${failure.strategyId} (${message})`
+      })
+      .join(', ')}`
+
+    throw new AggregateError(
+      failures.map((failure) => failure.reason),
+      summary,
+    )
   }
 
   /**


### PR DESCRIPTION
Fixes #3103

## Problem
Search index jobs were reported as **completed** even when a strategy failed, so the queue's retry mechanism never fired for transient failures like Postgres connection-pool exhaustion (`sorry, too many clients already`). The record was silently dropped from the index — no retry, no dead-letter.

## Root Cause
`SearchService.index()` (and the `delete`/`purge` siblings) ran strategies through `Promise.allSettled` and **only logged** rejections — they never re-threw. The call chain `*-index.worker` → `SearchIndexer.indexRecordById()` → `indexRecord()` → `SearchService.index()` therefore returned normally even when a strategy threw, so the worker's own `throw error` retry path was never exercised and the queue marked the job completed.

## What Changed
- `SearchService.index/delete/purge` now aggregate rejected strategies and re-throw an `AggregateError` (mirroring the already-throwing `bulkIndex`), so the worker re-throws and the queue retries. Successful strategies still commit their work; only the aggregated failure propagates. The original strategy errors are preserved on `AggregateError.errors` so downstream code can still classify transient vs permanent.
- Failure logging is preserved (each rejected strategy is still logged via `searchError`) and centralized in a private `throwOnStrategyFailures` helper.
- The single-record indexing workers already re-throw in their `catch` block, so the failure now reaches the queue (`async`/BullMQ `attempts: 3` + backoff; `local` `DEFAULT_MAX_ATTEMPTS = 3` + backoff + dead-letter). The reindex/batch paths already wrap these calls in try/catch and are unaffected.
- Corrected the stale `No retry mechanism for failed jobs` comment in the `local` queue strategy (local *does* retry + dead-letter).

The success path is unchanged: when every strategy succeeds the methods still resolve to `void`.

## Tests
- New unit tests in `packages/search/src/__tests__/service.test.ts`:
  - `index()` rejects when a strategy throws (`too many clients already`)
  - partial failure (one of several strategies) still rejects, successful strategies still run
  - thrown `AggregateError` preserves the original strategy errors
  - all-success path still resolves
  - `delete()` and `purge()` reject when a strategy fails
- `yarn workspace @open-mercato/search test` — 215 passed
- `yarn workspace @open-mercato/queue test` — 51 passed
- `yarn build:packages`, `yarn generate`, typecheck of search/queue all green

## Acceptance criteria (issue #3103)
- [x] A strategy index failure causes the queue job to fail and retry (worker re-throws → `local` and `async` both retry).
- [x] After retries are exhausted the failure is visible (dead-letter / surfaced error) instead of silently completed.
- [x] Unit test: `SearchService.index()` rejects when a strategy throws.

## Backward Compatibility
No contract-surface changes — method signatures and return types (`Promise<void>`) are unchanged. The behavioral change (rejecting on failure instead of silently resolving) is the intended fix and is consistent with the existing `bulkIndex` contract; the only production callers (`SearchIndexer` reindex/batch paths) already wrap these calls in try/catch.

## Intended labels (fork lacks upstream write)
`review`, `bug`, `priority-high` (inherited), `risk-high` (inherited — event-reliability / silent data-loss class), `needs-qa` (reliability behavior change to indexing/retry; exercise an index job that fails transiently and confirm it retries).
