### PR TITLE
feat(currencies): cache GET /api/currencies/options (reuse crud:currencies.currency tags) (#2918)

### DIFF
--- a/packages/core/src/modules/currencies/api/currencies/options/__tests__/cache.test.ts
+++ b/packages/core/src/modules/currencies/api/currencies/options/__tests__/cache.test.ts
@@ -1,0 +1,147 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+
+const em = {
+  find: jest.fn(),
+} as { find: jest.Mock }
+
+const cache = {
+  get: jest.fn(),
+  set: jest.fn(),
+} as { get: jest.Mock; set: jest.Mock }
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'cache') return cache
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    sub: 'user-1',
+    tenantId,
+    orgId,
+  })),
+}))
+
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: jest.fn((_tenantId: string, fn: () => unknown) => fn()),
+}))
+
+const makeRow = (code: string, name: string) => ({
+  id: `00000000-0000-4000-8000-${code.padEnd(12, '0')}`,
+  organizationId: orgId,
+  tenantId,
+  code,
+  name,
+  symbol: null,
+  isActive: true,
+})
+
+const ORIGINAL_ENV = { ...process.env }
+
+const loadRoute = async () => {
+  jest.resetModules()
+  return import('../route')
+}
+
+describe('GET /api/currencies/options caching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('caches the option payload with command-bus-compatible collection tags', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+    em.find.mockResolvedValue([makeRow('USD', 'US Dollar'), makeRow('EUR', 'Euro')])
+
+    const res = await GET(new Request('http://localhost/api/currencies/options'))
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: { value: string; label: string }[] }
+    expect(body.items).toEqual([
+      { value: 'USD', label: 'USD - US Dollar' },
+      { value: 'EUR', label: 'EUR - Euro' },
+    ])
+
+    expect(cache.get).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+    const [key, value, opts] = cache.set.mock.calls[0]
+    expect(key).toBe('currencies:options:org=22222222-2222-4222-8222-222222222222:active=active:limit=50')
+    expect(value).toEqual({ items: body.items })
+    expect(opts.ttl).toBe(5 * 60_000)
+    expect(opts.tags).toEqual([
+      `crud:currencies.currency:tenant:${tenantId}:org:${orgId}:collection`,
+    ])
+  })
+
+  it('serves the cached payload without hitting the database on a cache hit', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    const cachedPayload = { items: [{ value: 'GBP', label: 'GBP - British Pound' }] }
+    cache.get.mockResolvedValue(cachedPayload)
+
+    const res = await GET(new Request('http://localhost/api/currencies/options'))
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual(cachedPayload)
+    expect(em.find).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('does not cache when the crud cache flag is off', async () => {
+    delete process.env.ENABLE_CRUD_API_CACHE
+    const { GET } = await loadRoute()
+    em.find.mockResolvedValue([makeRow('USD', 'US Dollar')])
+
+    const res = await GET(new Request('http://localhost/api/currencies/options'))
+
+    expect(res.status).toBe(200)
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+    expect(em.find).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the cache entirely when a search term is present', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    em.find.mockResolvedValue([makeRow('USD', 'US Dollar')])
+
+    const res = await GET(new Request('http://localhost/api/currencies/options?q=us'))
+
+    expect(res.status).toBe(200)
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+    expect(em.find).toHaveBeenCalledTimes(1)
+  })
+
+  it('keys the cache by includeInactive and limit axes', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+    em.find.mockResolvedValue([])
+
+    await GET(
+      new Request('http://localhost/api/currencies/options?includeInactive=true&limit=10'),
+    )
+
+    expect(cache.set).toHaveBeenCalledTimes(1)
+    const [key] = cache.set.mock.calls[0]
+    expect(key).toBe('currencies:options:org=22222222-2222-4222-8222-222222222222:active=all:limit=10')
+  })
+})

--- a/packages/core/src/modules/currencies/api/currencies/options/route.ts
+++ b/packages/core/src/modules/currencies/api/currencies/options/route.ts
@@ -1,14 +1,31 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
+import { runWithCacheTenant } from '@open-mercato/cache'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import {
+  buildCollectionTags,
+  isCrudCacheEnabled,
+  resolveCrudCache,
+} from '@open-mercato/shared/lib/crud/cache'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { Currency } from '../../../data/entities'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['currencies.view'] },
+}
+
+const CURRENCY_OPTIONS_RESOURCE = 'currencies.currency'
+const CURRENCY_OPTIONS_TTL_MS = 5 * 60_000
+
+function buildOptionsCacheKey(params: {
+  orgId: string | null
+  includeInactive: boolean
+  limit: number
+}): string {
+  return `currencies:options:org=${params.orgId ?? 'null'}:active=${params.includeInactive ? 'all' : 'active'}:limit=${params.limit}`
 }
 
 const optionsQuerySchema = z.object({
@@ -47,15 +64,35 @@ export async function GET(req: Request) {
 
   const { q, query, search, includeInactive, limit } = parsed.data
   const searchTerm = (q ?? query ?? search ?? '').trim()
-  const filter: any = {
-    tenantId: auth.tenantId,
-    deletedAt: null,
-  }
-  if (auth.orgId) {
-    filter.organizationId = auth.orgId
+  const tenantId = auth.tenantId
+  const orgId = auth.orgId ?? null
+  const includeInactiveFlag = includeInactive === 'true'
+
+  // Only the unfiltered bootstrap call (no ILIKE search term) is the hot path
+  // worth caching; search variants would multiply key cardinality with little
+  // hit-rate benefit, so they always read straight through.
+  const cache =
+    isCrudCacheEnabled() && !searchTerm ? resolveCrudCache(container) : null
+  const cacheKey = cache
+    ? buildOptionsCacheKey({ orgId, includeInactive: includeInactiveFlag, limit })
+    : null
+
+  if (cache && cacheKey) {
+    const cached = await runWithCacheTenant(tenantId, () => cache.get(cacheKey))
+    if (cached) {
+      return NextResponse.json(cached)
+    }
   }
 
-  if (includeInactive !== 'true') {
+  const filter: any = {
+    tenantId,
+    deletedAt: null,
+  }
+  if (orgId) {
+    filter.organizationId = orgId
+  }
+
+  if (!includeInactiveFlag) {
     filter.isActive = true
   }
 
@@ -77,7 +114,20 @@ export async function GET(req: Request) {
     label: `${currency.code} - ${currency.name}`,
   }))
 
-  return NextResponse.json({ items })
+  const payload = { items }
+
+  if (cache && cacheKey) {
+    try {
+      await runWithCacheTenant(tenantId, () =>
+        cache.set(cacheKey, payload, {
+          ttl: CURRENCY_OPTIONS_TTL_MS,
+          tags: buildCollectionTags(CURRENCY_OPTIONS_RESOURCE, tenantId, [orgId]),
+        }),
+      )
+    } catch {}
+  }
+
+  return NextResponse.json(payload)
 }
 
 const optionsResponseSchema = z.object({


### PR DESCRIPTION
Fixes #2918

## Problem
- `GET /api/currencies/options` ran an org-scoped `em.find(Currency, …)` plus response mapping on every form open. Currency option lists back every money-field select (pricing, sales documents, product forms), and currencies are near-static reference data — the endpoint was uncached.

## Root Cause
- The custom GET handler had no module cache, so each call re-queried and re-mapped near-static reference data.

## What Changed
- Added a gated get-then-set cache to `packages/core/src/modules/currencies/api/currencies/options/route.ts`:
  - Gated on `isCrudCacheEnabled()` (`ENABLE_CRUD_API_CACHE`); no-op without the flag or a resolvable cache service.
  - Resolves the cache via DI (`resolveCrudCache`) — no raw Redis/SQLite.
  - Tenant-scoped through `runWithCacheTenant`; org axis carried in both the cache key and the tags.
  - Tags reuse `buildCollectionTags('currencies.currency', tenantId, [orgId])`, producing `crud:currencies.currency:tenant:<T>:org:<O>:collection` — the exact tag the command bus already flushes post-commit on every `currencies.currency` create/update/delete (and undo). **Zero new flush wiring.**
  - 5-minute TTL; skips caching entirely when an ILIKE search term is present to cap key cardinality (the unfiltered bootstrap call is the hot path); never caches the 401/400 branches.
- Response shape (`{ items }`) and `pageSize`/behavior are unchanged.

## Tests
- New unit suite `__tests__/cache.test.ts` (5 cases): set with command-bus-compatible tags + TTL, cache-hit serves payload and bypasses the DB, flag-off ⇒ no caching, search-term ⇒ cache bypass, and `includeInactive`/`limit` key axes.
- Full currencies suite green (102 tests); core typecheck clean.

## Backward Compatibility
- No contract surface changes. Additive imports only; the endpoint behaves identically when the cache flag is off. No API response fields removed; no event IDs, DI names, ACL IDs, or import paths changed.

## Labels (intended — fork lacks upstream write)
- `review`, `feature`, `performance`, `priority-low`, `risk-low`, `skip-qa`
