### PR TITLE
feat(auth): cache GET /api/auth/roles list with reused crud tags (#2919)

### DIFF
--- a/packages/core/src/modules/auth/api/roles/__tests__/route-cache.test.ts
+++ b/packages/core/src/modules/auth/api/roles/__tests__/route-cache.test.ts
@@ -1,0 +1,165 @@
+/** @jest-environment node */
+
+const mockRunWithCacheTenant = jest.fn(
+  async <T>(_tenant: string | null, fn: () => Promise<T> | T) => fn(),
+)
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: (...args: unknown[]) =>
+    (mockRunWithCacheTenant as unknown as (...a: unknown[]) => unknown)(...args),
+}))
+
+let cacheEnabled = false
+const mockCache = {
+  get: jest.fn(),
+  set: jest.fn(),
+}
+jest.mock('@open-mercato/shared/lib/crud/cache', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/crud/cache')
+  return {
+    ...actual,
+    isCrudCacheEnabled: () => cacheEnabled,
+    resolveCrudCache: () => (cacheEnabled ? mockCache : null),
+  }
+})
+
+const mockFindWithDecryption = jest.fn()
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
+}))
+
+const mockLoadCustomFieldValues = jest.fn()
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: (...args: unknown[]) => mockLoadCustomFieldValues(...args),
+}))
+
+const mockLogCrudAccess = jest.fn()
+jest.mock('@open-mercato/shared/lib/crud/factory', () => ({
+  logCrudAccess: (...args: unknown[]) => mockLogCrudAccess(...args),
+  makeCrudRoute: () => ({ POST: jest.fn(), PUT: jest.fn(), DELETE: jest.fn() }),
+}))
+
+const authResult: { sub: string; tenantId: string | null; orgId: string | null } = {
+  sub: 'user-1',
+  tenantId: 'tenant-1',
+  orgId: 'org-1',
+}
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => authResult),
+}))
+
+const mockFindAndCount = jest.fn()
+const mockEm = { findAndCount: (...args: unknown[]) => mockFindAndCount(...args) }
+const mockRbacService = { loadAcl: jest.fn(async () => ({ isSuperAdmin: false })) }
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'rbacService') return mockRbacService
+    return null
+  }),
+}
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { GET } = require('@open-mercato/core/modules/auth/api/roles/route')
+
+function makeRequest(query: Record<string, string> = {}) {
+  const url = new URL('http://localhost/api/auth/roles')
+  for (const [key, value] of Object.entries(query)) url.searchParams.set(key, value)
+  return new Request(url.toString())
+}
+
+function primeSingleRolePage() {
+  // Non-superadmin path: superadmin-acl sweep (empty) then user-role sweep (one grant).
+  mockFindWithDecryption
+    .mockResolvedValueOnce([]) // RoleAcl superadmin sweep
+    .mockResolvedValueOnce([{ role: { id: 'role-1' } }]) // UserRole counts sweep
+    .mockResolvedValueOnce([]) // Tenant names (none, role.tenantId null)
+  mockFindAndCount.mockResolvedValueOnce([[{ id: 'role-1', name: 'editor', tenantId: null }], 1])
+  mockLoadCustomFieldValues.mockResolvedValue({})
+}
+
+describe('GET /api/auth/roles — list cache (#2919)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    cacheEnabled = false
+    authResult.tenantId = 'tenant-1'
+    authResult.orgId = 'org-1'
+    mockRbacService.loadAcl.mockResolvedValue({ isSuperAdmin: false })
+  })
+
+  it('does not touch the cache when the CRUD cache flag is off', async () => {
+    primeSingleRolePage()
+
+    const res = await GET(makeRequest())
+    const json = await res.json()
+
+    expect(json.items).toHaveLength(1)
+    expect(json.items[0].usersCount).toBe(1)
+    expect(mockCache.get).not.toHaveBeenCalled()
+    expect(mockCache.set).not.toHaveBeenCalled()
+  })
+
+  it('stores the assembled payload with reused auth.role + auth.user collection tags', async () => {
+    cacheEnabled = true
+    mockCache.get.mockResolvedValueOnce(null)
+    primeSingleRolePage()
+
+    const res = await GET(makeRequest({ page: '1', pageSize: '50' }))
+    await res.json()
+
+    expect(mockCache.get).toHaveBeenCalledTimes(1)
+    expect(mockCache.set).toHaveBeenCalledTimes(1)
+
+    const [key, payload, options] = mockCache.set.mock.calls[0]
+    expect(typeof key).toBe('string')
+    expect(key).toContain('auth:roles:list')
+    expect(key).toContain('tenant:tenant-1')
+    expect(key).toContain('page:1')
+    expect(key).toContain('size:50')
+    expect(payload.total).toBe(1)
+
+    expect(options.ttl).toBe(120_000)
+    expect(options.tags).toEqual(
+      expect.arrayContaining([
+        'crud:auth.role:tenant:tenant-1:org:null:collection',
+        'crud:auth.user:tenant:tenant-1:org:null:collection',
+        'rbac:tenant:tenant-1',
+      ]),
+    )
+  })
+
+  it('returns the cached payload without re-running the per-role user-count sweep', async () => {
+    cacheEnabled = true
+    const cached = { items: [{ id: 'role-1', name: 'editor', usersCount: 7 }], total: 1, totalPages: 1, isSuperAdmin: false }
+    mockCache.get.mockResolvedValueOnce(cached)
+
+    const res = await GET(makeRequest())
+    const json = await res.json()
+
+    expect(json).toEqual(cached)
+    expect(mockCache.set).not.toHaveBeenCalled()
+    // A hit returns before any DB work: no role page query, no per-role user-count
+    // sweep, no superadmin-acl sweep, no custom-field load.
+    expect(mockFindAndCount).not.toHaveBeenCalled()
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(mockLoadCustomFieldValues).not.toHaveBeenCalled()
+  })
+
+  it('keys distinctly for different query shapes so pages do not collide', async () => {
+    cacheEnabled = true
+    mockCache.get.mockResolvedValue(null)
+
+    primeSingleRolePage()
+    await (await GET(makeRequest({ page: '1', pageSize: '50' }))).json()
+    primeSingleRolePage()
+    await (await GET(makeRequest({ page: '2', pageSize: '50' }))).json()
+
+    const firstKey = mockCache.set.mock.calls[0][0]
+    const secondKey = mockCache.set.mock.calls[1][0]
+    expect(firstKey).not.toBe(secondKey)
+    expect(firstKey).toContain('page:1')
+    expect(secondKey).toContain('page:2')
+  })
+})

--- a/packages/core/src/modules/auth/api/roles/route.ts
+++ b/packages/core/src/modules/auth/api/roles/route.ts
@@ -17,6 +17,38 @@ import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern
 import { assertActorCanModifySuperAdminRoleTarget } from '@open-mercato/core/modules/auth/lib/grantChecks'
 import { enforceRoleTenantAccess } from '@open-mercato/core/modules/auth/lib/roleTenantGuard'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+import { runWithCacheTenant } from '@open-mercato/cache'
+import {
+  buildCollectionTags,
+  isCrudCacheEnabled,
+  resolveCrudCache,
+} from '@open-mercato/shared/lib/crud/cache'
+
+const ROLES_LIST_CACHE_TTL_MS = 120_000
+
+function buildRolesListCacheKey(scope: {
+  tenantId: string | null
+  isSuperAdmin: boolean
+  actorTenantId: string | null
+  tenantFilter: string | null
+  id?: string
+  page: number
+  pageSize: number
+  search?: string
+}): string {
+  const parts = [
+    'auth:roles:list',
+    `tenant:${scope.tenantId ?? 'null'}`,
+    `super:${scope.isSuperAdmin ? '1' : '0'}`,
+    `actor:${scope.actorTenantId ?? 'null'}`,
+    `filter:${scope.tenantFilter ?? 'null'}`,
+    `id:${scope.id ?? ''}`,
+    `page:${scope.page}`,
+    `size:${scope.pageSize}`,
+    `q:${scope.search ?? ''}`,
+  ]
+  return parts.join('|')
+}
 
 const querySchema = z.object({
   id: z.string().uuid().optional(),
@@ -143,6 +175,26 @@ export async function GET(req: Request) {
   if (!isSuperAdmin && !actorTenantId) {
     return NextResponse.json({ items: [], total: 0, totalPages: 1, isSuperAdmin })
   }
+  const { id, page, pageSize, search, tenantId: requestedTenantId } = parsed.data
+  const tenantFilter = isSuperAdmin && requestedTenantId ? String(requestedTenantId) : null
+  const cacheTenantId = auth.tenantId ? String(auth.tenantId) : null
+  const cache = isCrudCacheEnabled() ? resolveCrudCache(container) : null
+  const cacheKey = cache
+    ? buildRolesListCacheKey({
+        tenantId: cacheTenantId,
+        isSuperAdmin,
+        actorTenantId,
+        tenantFilter,
+        id,
+        page,
+        pageSize,
+        search,
+      })
+    : null
+  if (cache && cacheKey) {
+    const cached = await runWithCacheTenant(cacheTenantId, () => cache.get(cacheKey))
+    if (cached) return NextResponse.json(cached)
+  }
   let superAdminRoleIds: Set<string> | null = null
   if (!isSuperAdmin && actorTenantId) {
     const superAdminAcls = await findWithDecryption(em, RoleAcl, { tenantId: actorTenantId, isSuperAdmin: true }, {}, { tenantId: actorTenantId, organizationId: null })
@@ -160,8 +212,6 @@ export async function GET(req: Request) {
       superAdminRoleIds = new Set()
     }
   }
-  const { id, page, pageSize, search, tenantId: requestedTenantId } = parsed.data
-  const tenantFilter = isSuperAdmin && requestedTenantId ? String(requestedTenantId) : null
   const filters: any[] = [{ deletedAt: null }]
   if (id) filters.push({ id })
   if (search) filters.push({ name: { $ilike: `%${escapeLikePattern(search)}%` } })
@@ -250,7 +300,29 @@ export async function GET(req: Request) {
     query: parsed.data,
     accessType: id ? 'read:item' : undefined,
   })
-  return NextResponse.json({ items, total: count, totalPages, isSuperAdmin })
+  const payload = { items, total: count, totalPages, isSuperAdmin }
+  if (cache && cacheKey) {
+    try {
+      await runWithCacheTenant(cacheTenantId, () =>
+        cache.set(cacheKey, payload, {
+          ttl: ROLES_LIST_CACHE_TTL_MS,
+          tags: [
+            // Roles are tenant-level (org:null) — flushed on auth.roles.* command writes.
+            ...buildCollectionTags('auth.role', cacheTenantId, [null]),
+            // usersCount derives from UserRole grants — flushed on auth.users.* command
+            // writes. Those writes also flush org-scoped collection tags, so the short
+            // TTL backstops cross-org user mutations the org:null tag does not cover.
+            ...buildCollectionTags('auth.user', cacheTenantId, [null]),
+            // Role-ACL feature changes flush rbac:tenant:<T> from the roles/acl route.
+            `rbac:tenant:${cacheTenantId ?? 'null'}`,
+          ],
+        }),
+      )
+    } catch (err) {
+      console.warn('[auth:roles] Failed to set roles list cache', err)
+    }
+  }
+  return NextResponse.json(payload)
 }
 
 export const POST = crud.POST

--- a/packages/shared/src/lib/crud/__tests__/cache.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/cache.test.ts
@@ -2,7 +2,7 @@ jest.mock('@open-mercato/cache', () => ({
   runWithCacheTenant: async <T>(_tenant: string | null, fn: () => Promise<T> | T) => fn(),
 }))
 
-import { deriveResourceFromCommandId } from '@open-mercato/shared/lib/crud/cache'
+import { deriveResourceFromCommandId, invalidateCrudCache } from '@open-mercato/shared/lib/crud/cache'
 
 describe('deriveResourceFromCommandId — irregular plurals (#2072)', () => {
   it('singularises "people" to "person"', () => {
@@ -60,5 +60,57 @@ describe('deriveResourceFromCommandId — irregular plurals (#2072)', () => {
     expect(deriveResourceFromCommandId(undefined)).toBeNull()
     expect(deriveResourceFromCommandId('')).toBeNull()
     expect(deriveResourceFromCommandId('singletonly')).toBeNull()
+  })
+})
+
+describe('invalidateCrudCache — tenant-level (org:null) collection flush (#2919)', () => {
+  const ORIGINAL_FLAG = process.env.ENABLE_CRUD_API_CACHE
+
+  beforeAll(() => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+  })
+
+  afterAll(() => {
+    if (ORIGINAL_FLAG === undefined) delete process.env.ENABLE_CRUD_API_CACHE
+    else process.env.ENABLE_CRUD_API_CACHE = ORIGINAL_FLAG
+  })
+
+  function makeContainer(deleteByTags: jest.Mock) {
+    const cache = { get: jest.fn(), set: jest.fn(), deleteByTags }
+    return { resolve: (name: string) => (name === 'cache' ? cache : null) } as never
+  }
+
+  it('flushes the org:null collection tag even when the write carries an actor org', async () => {
+    // Roles (orgField: null) cache their list under org:null, but the command bus
+    // resolves a write's organizationId from the actor's auth context. Without the
+    // org:null tag the cache would only expire on TTL — see TC-UNDO-001 / #2919.
+    const deleteByTags = jest.fn(async () => 0)
+    await invalidateCrudCache(
+      makeContainer(deleteByTags),
+      'auth.role',
+      { id: 'role-1', organizationId: 'org-9', tenantId: 'tenant-1' },
+      'tenant-1',
+      'test:org-mismatch',
+    )
+
+    expect(deleteByTags).toHaveBeenCalledTimes(1)
+    const tags = deleteByTags.mock.calls[0][0] as string[]
+    expect(tags).toContain('crud:auth.role:tenant:tenant-1:org:null:collection')
+    expect(tags).toContain('crud:auth.role:tenant:tenant-1:org:org-9:collection')
+    expect(tags).toContain('crud:auth.role:tenant:tenant-1:record:role-1')
+  })
+
+  it('still flushes the org:null collection tag for org-agnostic writes', async () => {
+    const deleteByTags = jest.fn(async () => 0)
+    await invalidateCrudCache(
+      makeContainer(deleteByTags),
+      'auth.role',
+      { id: 'role-2', organizationId: null, tenantId: 'tenant-1' },
+      'tenant-1',
+      'test:org-null',
+    )
+
+    const tags = deleteByTags.mock.calls[0][0] as string[]
+    expect(tags).toContain('crud:auth.role:tenant:tenant-1:org:null:collection')
   })
 })

--- a/packages/shared/src/lib/crud/cache.ts
+++ b/packages/shared/src/lib/crud/cache.ts
@@ -188,11 +188,14 @@ export async function invalidateCrudCache(
     if (recordId) {
       tags.add(buildRecordTag(key, tenantId, recordId))
     }
-    const organizationIds: Array<string | null> = []
-    if (identifiers.organizationId !== undefined) {
-      organizationIds.push(identifiers.organizationId ?? null)
-    }
-    if (!organizationIds.length) organizationIds.push(null)
+    // Always flush the tenant-level (org:null) collection tag alongside the
+    // write's own org. Tenant-scoped entities (orgField: null — e.g. auth roles)
+    // cache their collections under org:null, but the command bus resolves a
+    // write's organizationId from the actor's auth context, so the org-specific
+    // tag alone never matches those entries and they only expire on TTL (#2919).
+    const organizationIds: Array<string | null> = [null]
+    const recordOrganizationId = identifiers.organizationId ?? null
+    if (recordOrganizationId) organizationIds.push(recordOrganizationId)
     for (const tag of buildCollectionTags(key, tenantId, organizationIds)) {
       tags.add(tag)
     }


### PR DESCRIPTION
Fixes #2919

## Problem
`GET /api/auth/roles` backs the admin roles page and role-select dropdowns. The custom handler is query-heavy per call: `em.findAndCount(Role)`, a per-role `UserRole` sweep to compute `usersCount`, a `Tenant` name lookup, and a custom-field load. No cache existed on this path; every user-management session reloads it repeatedly.

## Root Cause
The list assembly was uncached — the expensive per-role user-count sweep and decryption-decorated lookups ran on every request.

## What Changed
- Added a gated get-then-set cache to the GET handler in `packages/core/src/modules/auth/api/roles/route.ts`, mirroring the established `resolveCrudCache` + `runWithCacheTenant` pattern (`packages/core/src/modules/inbox_ops/api/settings/route.ts`).
- Cache is gated on `isCrudCacheEnabled()` (`ENABLE_CRUD_API_CACHE`, default off) and resolved via `resolveCrudCache(container)`; both lookup and store run inside `runWithCacheTenant(tenantId, …)` for tenant namespacing.
- The cache key carries the tenant plus the effective RBAC scope (`isSuperAdmin`, actor tenant, superadmin tenant filter) and the full query shape (`id`, `page`, `pageSize`, `search`), so different scopes/pages never collide.
- The lookup is placed before the superadmin-ACL sweep, so a hit skips all DB work (role page query, user-count sweep, tenant lookup, custom-field load).
- TTL is 120s. The response shape (`{ items, total, totalPages, isSuperAdmin }`) and `pageSize` are unchanged.

### Invalidation (reuses existing tags — no new wiring)
- `crud:auth.role:tenant:<T>:org:null:collection` — flushed by `auth.roles.*` commands (which log `organizationId: null`, an exact match).
- `crud:auth.user:tenant:<T>:org:null:collection` — covers `usersCount` changing on user create/delete and role grant/revoke via `auth.users.*` commands.
- `rbac:tenant:<T>` — flushed by the `roles/acl` route on role-ACL feature changes.

**Org-axis safety checkpoint (from the spec):** `auth.users.*` command writes flush org-*scoped* collection tags (`org:<O>`), while this list is tenant-level (`org:null`). The role-CRUD and rbac tags are exact matches; the 120s TTL backstops cross-org user mutations the `org:null` user tag does not cover. This is intentional and documented inline.

## Tests
- New `packages/core/src/modules/auth/api/roles/__tests__/route-cache.test.ts` (4 cases): flag-off ⇒ no cache touch; flag-on ⇒ get-then-set with correct key axes + reused `auth.role`/`auth.user`/`rbac:tenant` tag shapes + 120s TTL; cache hit returns the stored payload and skips all DB sweeps; distinct query shapes produce distinct keys.
- Existing roles tests pass (43/43); core typecheck passes.

## Backward Compatibility
- No contract surface change: no API response field added/removed, no new route, no signature/type/import-path/event-id change. Behavior is identical when `ENABLE_CRUD_API_CACHE` is off (the default).