### PR TITLE
fix(auth): replace hardcoded banner colors with semantic DS tokens

### DIFF
--- a/packages/core/src/modules/auth/frontend/login.tsx
+++ b/packages/core/src/modules/auth/frontend/login.tsx
@@ -383,15 +383,15 @@ export default function LoginPage() {
                 </div>
               ) : null}
               {showTenantInvalid ? (
-                <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-center text-xs text-red-700">
+                <div className="rounded-md border border-status-error-border bg-status-error-bg px-3 py-2 text-center text-xs text-status-error-text">
                   <div className="font-medium">{translate('auth.login.errors.tenantInvalid', 'Tenant not found. Clear the tenant selection and try again.')}</div>
-                  <Button type="button" variant="outline" size="sm" className="mt-2 border-red-300 text-red-700" onClick={handleClearTenant}>
+                  <Button type="button" variant="outline" size="sm" className="mt-2 border-status-error-border text-status-error-text" onClick={handleClearTenant}>
                     <X className="mr-2 size-4" aria-hidden="true" />
                     {translate('auth.login.tenantClear', 'Clear')}
                   </Button>
                 </div>
               ) : tenantId ? (
-                <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-center text-xs text-emerald-900">
+                <div className="rounded-md border border-status-success-border bg-status-success-bg px-3 py-2 text-center text-xs text-status-success-text">
                   <div className="font-medium">
                     {tenantLoading
                       ? translate('auth.login.tenantLoading', 'Loading tenant details...')
@@ -399,14 +399,14 @@ export default function LoginPage() {
                           tenant: tenantName || tenantId,
                         })}
                   </div>
-                  <Button type="button" variant="outline" size="sm" className="mt-2 border-emerald-300 text-emerald-900" onClick={handleClearTenant}>
+                  <Button type="button" variant="outline" size="sm" className="mt-2 border-status-success-border text-status-success-text" onClick={handleClearTenant}>
                     <X className="mr-2 size-4" aria-hidden="true" />
                     {translate('auth.login.tenantClear', 'Clear')}
                   </Button>
                 </div>
               ) : null}
               {error && !showTenantInvalid && (
-                <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-center text-sm text-red-700" role="alert" aria-live="polite">
+                <div className="rounded-md border border-status-error-border bg-status-error-bg px-3 py-2 text-center text-sm text-status-error-text" role="alert" aria-live="polite">
                   {error}
                 </div>
               )}


### PR DESCRIPTION
Fixes #3129.

## Summary
The login page tenant banners and the Clear button used hardcoded Tailwind color shades (`red-*`, `emerald-*`) instead of semantic DS tokens. On dark mode hover, the `outline` button variant switches the background via `dark:hover:bg-input/50`, but the hardcoded text color stays fixed and becomes invisible against the new background.

This PR replaces all three banner elements (invalid-tenant, valid-tenant, general error) with semantic status tokens that are dark-mode-aware by design and resolve correctly in all states.

## Changes
- `packages/core/src/modules/auth/frontend/login.tsx:386–409` — replace hardcoded `border-red-*`, `bg-red-*`, `text-red-*`, `border-emerald-*`, `bg-emerald-*`, `text-emerald-*` with `border-status-error-border`, `bg-status-error-bg`, `text-status-error-text` and their `success` counterparts across all three banners. 5 className substitutions, no logic change.

## CI gate (local)
- ✅  `yarn workspace @open-mercato/core build` — pass
- ✅  `yarn typecheck` — pass

Closes #3129