### PR TITLE
feat(skills): add spec tracking-issue mode to om-followup-issue-from-pr

### DIFF
--- a/.ai/runs/2026-06-17-followup-issue-spec-tracking.md
+++ b/.ai/runs/2026-06-17-followup-issue-spec-tracking.md
@@ -1,0 +1,72 @@
+# Execution plan: spec-tracking-issue support in `om-followup-issue-from-pr`
+
+Tracking plan for an `om-auto-create-pr` run.
+
+## Goal
+
+Extend the `om-followup-issue-from-pr` skill so that, in addition to turning a review
+comment into a follow-up issue, it also detects when the target PR **adds/contains a
+spec file** (`.ai/specs/**.md`). When a spec is present, the skill checks whether a
+tracking issue for *implementing that spec* already exists and, if not, creates the
+tracking issue (using the repo's existing "Implement: …" tracking-issue conventions).
+
+## Scope
+
+- Edit only `.ai/skills/om-followup-issue-from-pr/SKILL.md` (docs/process automation).
+- No code changes. No new dependencies. No contract surfaces touched.
+
+### Non-goals
+
+- Not changing `om-prepare-issue`, `om-spec-writing`, or `om-implement-spec`.
+- Not auto-implementing specs; only opening the tracking issue.
+- Not altering the existing comment→issue behavior; spec handling is additive.
+
+## Conventions reused (from research)
+
+- Spec files: `.ai/specs/**.md` and `.ai/specs/enterprise/**.md`; new names are
+  `YYYY-MM-DD-<slug>.md` (legacy `SPEC-*` deprecated). `implemented/` subdirs = done.
+- Detect PR spec files: `gh pr view <num> --repo <owner>/<repo> --json files --jq …`.
+- Tracking-issue convention (from `om-prepare-issue`): title `Implement: <feature>`,
+  body has `## Spec` (spec path + spec PR) and `## How to implement` (run
+  `/om-implement-spec <path>` after the spec PR merges); labels `feature`
+  (+`enterprise` for enterprise specs); never pipeline labels on issues.
+- Existing-issue search: `gh issue list --state open --search "<slug> in:title,body"`.
+
+## Risks (brief)
+
+- False positives: a PR that only *edits* an already-implemented spec, or moves a spec
+  into `implemented/`, should not spawn a tracking issue. Mitigated by skipping
+  `implemented/` paths and de-duplicating against existing open issues.
+- Ambiguity when a PR carries both an actionable comment and a new spec: the skill must
+  handle both paths without forcing a choice. Mitigated by making spec handling an
+  additive branch with its own dedupe + confirmation.
+
+## Implementation Plan
+
+### Phase 1: Skill rewrite
+
+- 1.1 Update frontmatter `description` + intro so the skill advertises both modes
+  (comment→follow-up issue, and spec→tracking issue).
+- 1.2 Add a "Detect spec files in the PR" step and a dedicated "Spec tracking issue"
+  workflow (dedupe search, compose `Implement: …` issue, create, cross-link).
+- 1.3 Update Inputs (plain PR link now also triggers spec detection) and Rules
+  (dedupe, skip `implemented/`, additive behavior, label conventions).
+
+### Phase 2: Validation
+
+- 2.1 Re-read the diff for correctness, internal-link integrity, and consistency with
+  cited skills/conventions. Confirm frontmatter YAML is still valid.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Skill rewrite
+
+- [ ] 1.1 Update frontmatter description and intro for dual-mode
+- [ ] 1.2 Add spec-detection step and spec tracking-issue workflow
+- [ ] 1.3 Update Inputs and Rules sections
+
+### Phase 2: Validation
+
+- [ ] 2.1 Re-read diff; verify YAML frontmatter and internal references

--- a/.ai/runs/2026-06-17-followup-issue-spec-tracking.md
+++ b/.ai/runs/2026-06-17-followup-issue-spec-tracking.md
@@ -63,10 +63,10 @@ tracking issue (using the repo's existing "Implement: …" tracking-issue conven
 
 ### Phase 1: Skill rewrite
 
-- [ ] 1.1 Update frontmatter description and intro for dual-mode
-- [ ] 1.2 Add spec-detection step and spec tracking-issue workflow
-- [ ] 1.3 Update Inputs and Rules sections
+- [x] 1.1 Update frontmatter description and intro for dual-mode
+- [x] 1.2 Add spec-detection step and spec tracking-issue workflow
+- [x] 1.3 Update Inputs and Rules sections
 
 ### Phase 2: Validation
 
-- [ ] 2.1 Re-read diff; verify YAML frontmatter and internal references
+- [x] 2.1 Re-read diff; verify YAML frontmatter and internal references

--- a/.ai/skills/om-followup-issue-from-pr/SKILL.md
+++ b/.ai/skills/om-followup-issue-from-pr/SKILL.md
@@ -32,7 +32,28 @@ When a plain PR link is pasted, always run the spec check (step 2a) in addition 
    - **Plain PR link with no comment id:** list recent conversation comments
      (`gh api repos/<owner>/<repo>/issues/<num>/comments --jq '.[] | {id,user:.user.login,body}'`),
      identify the one with a concrete actionable ask, and confirm with the user if ambiguous.
+     If there is no actionable comment but the PR adds a spec, skip comment mode and proceed
+     with spec mode only (step 2a).
    - The comment body is the **source of the action** — preserve the user's actual words (quote them in the issue).
+
+2a. **Detect spec files in the PR (spec mode).** Always run this for plain PR links; for comment links, run it too so a new spec is never silently missed.
+   ```bash
+   gh pr view <num> --repo <owner>/<repo> --json files \
+     --jq '.files[].path | select(test("^\\.ai/specs/(enterprise/)?[^/]+\\.md$"))'
+   ```
+   - Keep only spec files **at the top level** of `.ai/specs/` or `.ai/specs/enterprise/`. **Skip** anything under an `implemented/` subdirectory — moving a spec to `implemented/` (or editing an already-implemented spec) is not new work to track.
+   - Prefer files the PR **added** (status `added`) over files it merely modified. A pure edit to an existing, still-pending spec usually already has a tracking issue; treat modified-only specs as a soft signal and confirm with the user before filing.
+   - If no qualifying spec file is found, spec mode is a no-op — continue with comment mode only.
+   - For each qualifying spec, derive its `<slug>`: strip the directory, the trailing `.md`, and any leading `YYYY-MM-DD-` date prefix (legacy `SPEC-*`/`SPEC-ENT-*` prefixes: strip the prefix too). Note whether the path is under `enterprise/`.
+
+2b. **Dedupe against existing tracking issues (spec mode).** Before creating anything, check for an open issue that already tracks implementing this spec:
+   ```bash
+   gh issue list --repo <owner>/<repo> --state open \
+     --search "<slug> in:title,body" --json number,title,url
+   ```
+   - A match is an open issue whose title is `Implement: …` for this feature **or** whose body references the spec path. Also scan the PR body for an explicit `Tracking issue: #<n>` line.
+   - If a tracking issue already exists, **do not** create a duplicate — instead report it, and (optionally, with the user's nod) add a one-line comment on that issue linking the spec PR.
+   - If none exists, create the tracking issue per step 6a.
 
 3. **Gather PR context** for a useful issue body:
    ```bash
@@ -65,13 +86,56 @@ When a plain PR link is pasted, always run the spec check (step 2a) in addition 
    ```
    - If the assignee can't be set (not a collaborator), create the issue anyway and report that assignment failed so the user can fix it.
 
-7. **Report** the new issue URL, who it's assigned to, and a one-line summary of the captured action.
+6a. **Create the spec tracking issue (spec mode).** Only when step 2a found a qualifying spec and step 2b found no existing tracking issue. Follow the `om-prepare-issue` tracking-issue convention so it interoperates with `/om-implement-spec` and `/om-auto-fix-github`:
+   - **Title:** `Implement: <feature title>` — derive the feature title from the spec's H1 / `<slug>`, not a date.
+   - **Body:**
+     ```markdown
+     ## Spec
+     - Implementation spec: `.ai/specs/<path>.md`
+     - Spec PR: <pr-url>
+
+     ## Summary
+     - 2–4 lines describing what the spec proposes (from the spec's overview/goal).
+
+     ## How to implement
+     - Once the spec PR merges, run `/om-implement-spec .ai/specs/<path>.md` or `/om-auto-fix-github <thisIssueNumber>`.
+     - Do not start implementation until the spec PR is merged into `develop`.
+
+     Related: #<num>
+     ```
+   - **Labels:** `feature` (or `refactor`/`bug` if the spec is clearly corrective). Add `enterprise` when the spec lives under `.ai/specs/enterprise/`. Optionally mirror priority/risk from the PR. **Never** apply pipeline labels (`review`, `qa`, `merge-queue`, …) — this is a tracking issue, not a PR. Only apply labels that already exist in the repo.
+   - **Assignee:** the spec PR author (`author.login`). A spec PR author is the natural owner of the implementation tracking issue; if they decline, the user can reassign.
+   - **Create:**
+     ```bash
+     gh issue create --repo <owner>/<repo> \
+       --title "Implement: <feature title>" \
+       --assignee <author-login> \
+       --label feature \
+       --body "<body>"
+     ```
+   - **Cross-link:** after creation, leave a one-line comment on the spec PR pointing at the tracking issue (e.g. `Tracking implementation in #<issue>`), so the spec and its tracking issue reference each other.
+
+7. **Report** each issue created (URL, assignee, one-line summary). Make clear which were follow-up issues (comment mode) and which were spec tracking issues (spec mode), and note any tracking issue that already existed and was reused.
 
 ## Rules
 
+### Comment mode
+
 - **Assignee:** an explicit @-mention in the comment wins; otherwise the PR author. Never the comment/reviewer author just because they wrote it (a reviewer files work for someone else to do).
 - Faithfully represent the comment — quote it; don't invent scope it didn't ask for.
-- One issue per invocation unless the user points at multiple comments.
+- One follow-up issue per invocation unless the user points at multiple comments.
 - If the comment is not actionable (praise, a question, "LGTM"), say so and ask the user what to file instead of inventing a task.
-- Always link back to the PR and any issue it `Fixes`.
+
+### Spec mode
+
+- Spec mode is **additive** — it never replaces comment mode. A single PR can produce both a follow-up issue and a spec tracking issue in one run.
+- Only treat top-level `.ai/specs/**.md` / `.ai/specs/enterprise/**.md` files as specs. **Skip** `implemented/` subdirectories — those are completed work, not new tracking work.
+- **Always dedupe first.** Never create a tracking issue when an open `Implement: …` issue (or a `Tracking issue: #<n>` line in the PR body) already covers the spec; report and reuse it instead.
+- Spec tracking issues follow the `om-prepare-issue` convention: title `Implement: <feature>`, body with `## Spec` + `## How to implement`, labelled `feature` (+`enterprise` for enterprise specs). **Never** put pipeline labels on an issue.
+- Assign the spec tracking issue to the spec PR author.
+- Cross-link the spec PR and the new tracking issue so they reference each other.
+
+### Both modes
+
+- Always link back to the PR and any issue it `Fixes`. Only apply labels that already exist in the repo.
 - Follows the Open Mercato PR/issue label conventions in `AGENTS.md` (category labels are additive: `bug`, `feature`, `refactor`, `security`, …).

--- a/.ai/skills/om-followup-issue-from-pr/SKILL.md
+++ b/.ai/skills/om-followup-issue-from-pr/SKILL.md
@@ -41,7 +41,7 @@ When a plain PR link is pasted, always run the spec check (step 2a) in addition 
    gh pr view <num> --repo <owner>/<repo> --json files \
      --jq '.files[].path | select(test("^\\.ai/specs/(enterprise/)?[^/]+\\.md$"))'
    ```
-   - Keep only spec files **at the top level** of `.ai/specs/` or `.ai/specs/enterprise/`. **Skip** anything under an `implemented/` subdirectory — moving a spec to `implemented/` (or editing an already-implemented spec) is not new work to track.
+   - Keep only spec files **at the top level** of `.ai/specs/` or `.ai/specs/enterprise/`. **Skip** anything under an `implemented/` subdirectory — moving a spec to `implemented/` (or editing an already-implemented spec) is not new work to track. **Skip** `AGENTS.md` and any other non-spec doc (a real spec is named `YYYY-MM-DD-<slug>.md`, or has a legacy `SPEC-*`/`SPEC-ENT-*` prefix).
    - Prefer files the PR **added** (status `added`) over files it merely modified. A pure edit to an existing, still-pending spec usually already has a tracking issue; treat modified-only specs as a soft signal and confirm with the user before filing.
    - If no qualifying spec file is found, spec mode is a no-op — continue with comment mode only.
    - For each qualifying spec, derive its `<slug>`: strip the directory, the trailing `.md`, and any leading `YYYY-MM-DD-` date prefix (legacy `SPEC-*`/`SPEC-ENT-*` prefixes: strip the prefix too). Note whether the path is under `enterprise/`.

--- a/.ai/skills/om-followup-issue-from-pr/SKILL.md
+++ b/.ai/skills/om-followup-issue-from-pr/SKILL.md
@@ -1,18 +1,23 @@
 ---
 name: om-followup-issue-from-pr
-description: Turn a review comment into a follow-up GitHub issue assigned to the PR author. Paste a link to a PR or a PR comment; the skill extracts the actionable ask from the comment, gathers PR context, and opens a tracking issue. Assignee is the comment's @-mention if present, otherwise the PR author. Use during code review when the user says "make a follow-up issue", "create an issue for this", "om-followup", or pastes a PR/comment link with that intent.
+description: Turn a PR into tracked follow-up work. Two modes (both can fire for one PR). (1) Comment mode — paste a PR or PR-comment link; the skill extracts the actionable ask, gathers PR context, and opens a follow-up issue assigned to the comment's @-mention if present, otherwise the PR author. (2) Spec mode — if the PR adds/contains a spec under `.ai/specs/`, the skill checks whether a tracking issue for implementing that spec already exists and, if not, opens an `Implement: …` tracking issue. Use during code review when the user says "make a follow-up issue", "create an issue for this", "om-followup", or pastes a PR/comment link with that intent.
 ---
 
-# Follow-up Issue from PR Comment
+# Follow-up Issue from PR
 
-Companion to the code-review process. The user pastes a link to a **PR** or a **specific PR comment** that contains an actionable request (usually written by the reviewer). This skill turns that request into a GitHub issue so the follow-up work is tracked, assigned to the right person.
+Companion to the code-review and spec-writing processes. The user pastes a link to a **PR** or a **specific PR comment**. This skill turns the PR into tracked follow-up work in up to two ways, and **both can apply to the same PR**:
+
+- **Comment mode** — the linked comment (or a comment chosen from a plain PR link) contains an actionable request (usually written by the reviewer). The skill turns that request into a GitHub issue, assigned to the right person.
+- **Spec mode** — the PR adds or contains a spec file under `.ai/specs/` (a spec PR). The skill checks whether a tracking issue for *implementing that spec* already exists and, if not, opens one following the repo's `Implement: …` tracking-issue convention.
+
+When a plain PR link is pasted, always run the spec check (step 2a) in addition to the comment handling. When a specific comment link is pasted, comment mode is the primary intent, but still surface any new spec in the PR so the user can opt into a tracking issue.
 
 ## Inputs
 
 - **A GitHub URL** (required), one of:
   - PR comment link: `…/pull/<num>#issuecomment-<id>`
   - Inline review comment link: `…/pull/<num>#discussion_r<id>`
-  - Plain PR link: `…/pull/<num>` — no specific comment; see step 2.
+  - Plain PR link: `…/pull/<num>` — no specific comment; runs spec detection (step 2a) and, if comments exist, comment selection (step 2).
 - The repo is parsed from the URL (`owner/repo`). Don't assume the current repo.
 
 ## Steps


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-17-followup-issue-spec-tracking.md
Status: complete

## Goal
- Extend `om-followup-issue-from-pr` so that when the target PR adds/contains a spec under `.ai/specs/`, the skill checks for an existing implementation tracking issue and, if none exists, opens an `Implement: …` tracking issue — additive to the existing comment→follow-up-issue behavior.

## What Changed
- Frontmatter `description` + intro now advertise two modes (comment mode + spec mode); both can fire for one PR.
- New **step 2a** detects top-level spec files in the PR via `gh pr view --json files` (skips `implemented/`, prefers added-over-modified, derives a slug).
- New **step 2b** dedupes against existing open `Implement: …` tracking issues / a `Tracking issue: #n` line before creating anything.
- New **step 6a** creates the spec tracking issue using the `om-prepare-issue` convention (title `Implement: …`, `## Spec` + `## How to implement` body, `feature`/`enterprise` labels, assigned to the spec PR author, cross-linked to the PR).
- Inputs, Report (step 7), and Rules sections updated for the dual-mode behavior.

## Tests
- Docs-only change to a single skill file — no unit tests apply.
- Verified: clean two-file diff vs `develop`, valid YAML frontmatter, internal step references resolve, conventions match `.ai/specs/AGENTS.md` + `om-prepare-issue`.

## Backward Compatibility
- No contract surface changes. Existing comment-mode behavior is preserved verbatim; spec mode is purely additive.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-17-followup-issue-spec-tracking.md#progress).
