### PR TITLE
docs(enterprise): Service Detail + coverage + time-limited sandboxes (follow-up to #3140)

### DIFF
--- a/.ai/specs/enterprise/README.md
+++ b/.ai/specs/enterprise/README.md
@@ -18,7 +18,7 @@ Specs awaiting implementation or in design phase.
 | --- | --- | --- | --- |
 | [Health Endpoints](SPEC-ENT-002-2026-02-17-mercato-health-endpoints.md) | 2026-02-17 | Enterprise Health Endpoints | Liveness (`/api/health/live`) and readiness (`/api/health/ready`) endpoints for deployment orchestration |
 | [Usage Telemetry / Phone Home](2026-06-04-usage-telemetry-phone-home.md) | 2026-06-04 | Usage Telemetry & "Phone Home" Verification | OSS telemetry client + separate-repo central admin module reporting aggregate usage counts for transparent billing verification; fail-safe 100 ms beacon, daily worker, dual OSS/enterprise modes |
-| [Sandboxes](Sandboxes.md) | — | Sandboxes | One-click cloud dev/build environments (OM + coding agents) + optional managed dev/test infrastructure |
+| [Sandboxes](Sandboxes.md) | — | Sandboxes | One-click cloud dev/build environments with Open Mercato and coding agents preinstalled |
 | [Password Change](CONSIDERATION-password-change-integration-2026-03-05.md) | 2026-03-05 | Password Change Integration (Consideration) | Design decision for enterprise password change flow without modifying core |
 
 ## Implemented Specifications

--- a/.ai/specs/enterprise/Sandboxes.md
+++ b/.ai/specs/enterprise/Sandboxes.md
@@ -1,7 +1,5 @@
 # Open Mercato — Sandboxes
 
-## Sandboxes
-
 Open Mercato Sandboxes are pre-provisioned cloud environments with Open Mercato pre-installed (in dev mode) and AI coding agents wired in — for learning and building on Open Mercato with no local setup. A sandbox boots in about 30 seconds and provides:
 
 - The full Open Mercato framework in dev mode (entities, modules, generators, hot reload) on an industry-standard stack (TypeScript, React, Next.js, Postgres) — no proprietary lock-in, so skills transfer to real work.
@@ -10,9 +8,3 @@ Open Mercato Sandboxes are pre-provisioned cloud environments with Open Mercato 
 - Per-sandbox lifecycle (create, pause/resume, delete) with persistent volumes, backups, and restore up to 7 days back.
 
 Build and learn in the sandbox, then move the application to your own infrastructure. This unified trial-and-build path in the cloud replaces ad-hoc demos. Public waitlist: https://sandboxes.openmercato.com.
-
-## Developer Sandbox Cloud
-
-Developer Sandbox Cloud is an optional, fully managed dev/test infrastructure offering for clients who would rather Open Mercato own setup, monitoring and maintenance than self-host. It is based on a reference self-hosted deployment (Dokploy + parallel queue processing) and can run on Open Mercato-provided or client-owned infrastructure.
-
-Scope and commercial terms are agreed per engagement.

--- a/.ai/specs/enterprise/Sandboxes.md
+++ b/.ai/specs/enterprise/Sandboxes.md
@@ -1,10 +1,15 @@
 # Open Mercato — Sandboxes
 
-Open Mercato Sandboxes are pre-provisioned cloud environments with Open Mercato pre-installed (in dev mode) and AI coding agents wired in — for learning and building on Open Mercato with no local setup. A sandbox boots in about 30 seconds and provides:
+Open Mercato Sandboxes are pre-provisioned cloud environments with Open Mercato pre-installed (in dev mode) and AI coding agents wired in — for learning and building on Open Mercato with no local setup. A sandbox boots in about 30 seconds.
 
 - The full Open Mercato framework in dev mode (entities, modules, generators, hot reload) on an industry-standard stack (TypeScript, React, Next.js, Postgres) — no proprietary lock-in, so skills transfer to real work.
-- A browser workspace: a terminal with coding agents (Claude Code, Codex) available from a quick menu, plus live preview, and an IDE-with-chat variant.
-- Start from a ready-made template (e.g. a CRM app) or an empty project, with full GitHub integration and shareable preview URLs.
-- Per-sandbox lifecycle (create, pause/resume, delete) with persistent volumes, backups, and restore up to 7 days back.
+- Start from a template (a CRM app, a classic project, or empty), with full GitHub integration and shareable preview URLs.
+- A browser workspace: a terminal whose menu drops you into a plain shell or pairs you with a coding agent (Claude Code or Codex), with tmux session resume — plus a live preview and an IDE-with-chat variant.
+- A dashboard to manage your sandboxes — status, resources, and quick create / pause / resume / delete, within your plan's quota.
+- Persistent volumes: code, database, and state survive pause/resume; backups with restore up to 7 days back.
 
-Build and learn in the sandbox, then move the application to your own infrastructure. This unified trial-and-build path in the cloud replaces ad-hoc demos. Public waitlist: https://sandboxes.openmercato.com.
+Build and learn in the sandbox, then move the application to your own infrastructure. This unified trial-and-build path in the cloud replaces ad-hoc demos.
+
+Within the Enterprise Subscription, project sandboxes are included as a time-limited offer.
+
+Public waitlist: https://sandboxes.openmercato.com.

--- a/packages/enterprise/README.md
+++ b/packages/enterprise/README.md
@@ -49,6 +49,7 @@ Three tiers scale the level of service with company size. Every tier includes th
 | Unlimited users & servers (per project / monorepo) | Included | Included | Included |
 | Project sandboxes — *time-limited offer* (dev/staging + prod env, CI/CD, AI SDLC pipeline, 7-day restore) | 1 active project | 3 active projects | 10 active projects |
 | Priority support (AI-assisted helpdesk, issue triage) | up to 5 accounts | up to 10 accounts, Discord | unlimited accounts, Discord |
+| Support & review coverage | Open Mercato core (open-source) | core + custom code | core + custom code |
 | Software updates | self-serve | assisted | managed for you |
 | Pre-deployment Architecture Audit | — | Included | Included |
 | Monthly Security / Performance / Custom-code Reviews | — | optional | Included |
@@ -69,7 +70,7 @@ Startups below $5M in annual revenue can request a startup discount via [info@op
 
 **Monthly Custom Module Code Review (up to 4h/mo).** Alignment with Open Mercato best practices, code quality and maintainability, agent-friendly architecture patterns, and upgrade safety.
 
-**Priority Technical Support.** Priority helpdesk (Slack / Discord or ticketing) for architecture and development questions, handled with AI assistance within tier limits. Advisory only — it does not include custom software development.
+**Priority Technical Support.** Priority helpdesk (Slack / Discord or ticketing) for architecture and development questions, handled with AI assistance within tier limits. Advisory only — it does not include custom software development. Coverage: Basic covers the Open Mercato core (open-source libraries); Medium and Enterprise also cover your custom code.
 
 **Dedicated Customer Success Manager (pre-go-live).** A CSM supports the Product Owner and technical team until launch: one 1-hour online meeting per month, ongoing ticketing support, and rollout-readiness guidance.
 

--- a/packages/enterprise/README.md
+++ b/packages/enterprise/README.md
@@ -129,7 +129,7 @@ Agencies operate on the front line; Open Mercato stands behind system quality.
 
 ## Contact
 
-- Enterprise licensing and program details: [info@catchthetornado.com](mailto:info@catchthetornado.com)
+- Enterprise licensing and program details: [info@openmercato.com](mailto:info@openmercato.com)
 - Certified agency partnership: [mat@openmercato.com](mailto:mat@openmercato.com)
 
 ## Important

--- a/packages/enterprise/README.md
+++ b/packages/enterprise/README.md
@@ -59,6 +59,26 @@ Three tiers scale the level of service with company size. Every tier includes th
 
 Startups below $5M in annual revenue can request a startup discount via [info@openmercato.com](mailto:info@openmercato.com).
 
+## Service Detail
+
+**Pre-deployment Architecture Audit.** A structured architecture review before production deployment: overall system architecture, identification of structural risks, and recommendations for production readiness.
+
+**Monthly Security Review (up to 4h/mo).** Application code review, infrastructure and environment configuration review, identification of security risks, and remediation guidance.
+
+**Monthly Performance Review — custom code (up to 4h/mo).** Detection of performance bottlenecks, review of scalability risks, and optimization recommendations.
+
+**Monthly Custom Module Code Review (up to 4h/mo).** Alignment with Open Mercato best practices, code quality and maintainability, agent-friendly architecture patterns, and upgrade safety.
+
+**Priority Technical Support.** Priority helpdesk (Slack / Discord or ticketing) for architecture and development questions, handled with AI assistance within tier limits. Advisory only — it does not include custom software development.
+
+**Dedicated Customer Success Manager (pre-go-live).** A CSM supports the Product Owner and technical team until launch: one 1-hour online meeting per month, ongoing ticketing support, and rollout-readiness guidance.
+
+**Software Updates.** Security patches, new platform features, and partner-ready upgrade packages with documented risks and upgrade procedures. Basic: update packages are provided and applied by the customer independently. Medium: update packages with support and guidance from our team during the upgrade. Enterprise: managed upgrades — planning, validation, and application by our team. Customers may continue using the software after license expiration, but new updates, security patches, and platform enhancements require an active license.
+
+**Production Approval (Homologation).** A formal production-readiness assessment before go-live: production approval report, risk summary, and go-live recommendation.
+
+**Production Hosting Reference.** A reference self-hosted deployment setup (including Dokploy and parallel queue processing), with an optional fully managed Developer Sandbox Cloud offering for development and testing environments.
+
 ## Enterprise Software Package
 
 The `@open-mercato/enterprise` package delivers the proprietary modules included with every subscription — not available in the open-source distribution:

--- a/packages/enterprise/README.md
+++ b/packages/enterprise/README.md
@@ -47,7 +47,7 @@ Three tiers scale the level of service with company size. Every tier includes th
 | Company revenue band | below $25M | $25M–$250M | above $250M |
 | Enterprise software modules (MFA, SSO & Directory Sync, Record Locking) | Included | Included | Included |
 | Unlimited users & servers (per project / monorepo) | Included | Included | Included |
-| Project sandboxes (dev/staging + prod env, CI/CD, AI SDLC pipeline, 7-day restore) | 1 active project | 3 active projects | 10 active projects |
+| Project sandboxes — *time-limited offer* (dev/staging + prod env, CI/CD, AI SDLC pipeline, 7-day restore) | 1 active project | 3 active projects | 10 active projects |
 | Priority support (AI-assisted helpdesk, issue triage) | up to 5 accounts | up to 10 accounts, Discord | unlimited accounts, Discord |
 | Software updates | self-serve | assisted | managed for you |
 | Pre-deployment Architecture Audit | — | Included | Included |
@@ -99,9 +99,9 @@ Open Mercato Sandboxes are pre-provisioned cloud environments with Open Mercato 
 
 Build and learn in the sandbox, then move the application to your own infrastructure. This unified trial-and-build path replaces ad-hoc demos — start immediately, without first clearing a security review.
 
-Pre-launch (waitlist): [sandboxes.openmercato.com](https://sandboxes.openmercato.com)
+Within the Enterprise Subscription, project sandboxes are included as a time-limited offer. Sandboxes are for building and learning; production still runs the certification and homologation path above.
 
-Sandboxes are for building and learning. Production still runs the certification and homologation path above.
+More detail: [Sandboxes spec](../../.ai/specs/enterprise/Sandboxes.md) · pre-launch waitlist: [sandboxes.openmercato.com](https://sandboxes.openmercato.com)
 
 ## Open Mercato Partnership Program
 


### PR DESCRIPTION
Follow-up to #3140, which was merged before these five changes landed on the branch.

Lands on top of the merged Enterprise Subscription README:

- **Service Detail** section under the tiers table — describes the table line-items per v2 §05 (architecture audit, monthly reviews, priority support, CSM, software updates per tier, homologation, production hosting reference).
- **Support & review coverage** tier row — Basic covers the Open Mercato core; Medium / Enterprise also cover custom code.
- Project sandboxes marked as a **time-limited offer** (per v2), with a link from the README to the Sandboxes spec.
- Licensing contact set to **info@openmercato.com**.
- **Sandboxes spec** (`.ai/specs/enterprise/Sandboxes.md`): dropped the optional Developer Sandbox Cloud section (it is an optional add-on, not bundled in any tier, and the near-identical name was confusing) and fleshed out the product detail (templates, terminal auto-menu + tmux, manage dashboard, persistent volumes).

No pricing or internal infrastructure detail added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
