### PR TITLE
feat(messages): cache GET /api/messages/unread-count (reuse crud:messages.message tags) (#2915)

### DIFF
--- a/packages/core/src/modules/messages/api/unread-count/__tests__/cache.test.ts
+++ b/packages/core/src/modules/messages/api/unread-count/__tests__/cache.test.ts
@@ -1,0 +1,134 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+
+const executeTakeFirst = jest.fn()
+
+const cache = {
+  get: jest.fn(),
+  set: jest.fn(),
+} as { get: jest.Mock; set: jest.Mock }
+
+const em = {
+  getKysely: () => {
+    const chain: any = {}
+    chain.innerJoin = jest.fn(() => chain)
+    chain.where = jest.fn(() => chain)
+    chain.select = jest.fn(() => chain)
+    chain.executeTakeFirst = executeTakeFirst
+    return { selectFrom: () => chain }
+  },
+}
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'cache') return cache
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const resolveMessageContextMock = jest.fn(async () => ({
+  ctx: { container },
+  scope: { userId, tenantId, organizationId: orgId },
+}))
+
+jest.mock('@open-mercato/core/modules/messages/lib/routeHelpers', () => ({
+  resolveMessageContext: (...args: unknown[]) => resolveMessageContextMock(...args),
+}))
+
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: jest.fn((_tenantId: string, fn: () => unknown) => fn()),
+}))
+
+const ORIGINAL_ENV = { ...process.env }
+
+const loadRoute = async () => {
+  jest.resetModules()
+  return import('../route')
+}
+
+describe('GET /api/messages/unread-count caching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+    resolveMessageContextMock.mockResolvedValue({
+      ctx: { container },
+      scope: { userId, tenantId, organizationId: orgId },
+    })
+  })
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('caches the count with command-bus-compatible collection tags keyed by user + org', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+    executeTakeFirst.mockResolvedValue({ count: '7' })
+
+    const res = await GET(new Request('http://localhost/api/messages/unread-count'))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ unreadCount: 7 })
+
+    expect(cache.get).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+    const [key, value, opts] = cache.set.mock.calls[0]
+    expect(key).toBe(`messages:unread-count:u=${userId}:org=${orgId}`)
+    expect(value).toBe(7)
+    expect(opts.ttl).toBe(10_000)
+    expect(opts.tags).toEqual([
+      `crud:messages.message:tenant:${tenantId}:org:${orgId}:collection`,
+    ])
+  })
+
+  it('serves the cached count without querying the database on a cache hit', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(4)
+
+    const res = await GET(new Request('http://localhost/api/messages/unread-count'))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ unreadCount: 4 })
+    expect(executeTakeFirst).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('uses the org=null axis in the key and tags when scope has no organization', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    resolveMessageContextMock.mockResolvedValue({
+      ctx: { container },
+      scope: { userId, tenantId, organizationId: null },
+    })
+    cache.get.mockResolvedValue(null)
+    executeTakeFirst.mockResolvedValue({ count: '2' })
+
+    const res = await GET(new Request('http://localhost/api/messages/unread-count'))
+
+    expect(res.status).toBe(200)
+    const [key, , opts] = cache.set.mock.calls[0]
+    expect(key).toBe(`messages:unread-count:u=${userId}:org=null`)
+    expect(opts.tags).toEqual([
+      `crud:messages.message:tenant:${tenantId}:org:null:collection`,
+    ])
+  })
+
+  it('does not cache when the crud cache flag is off', async () => {
+    delete process.env.ENABLE_CRUD_API_CACHE
+    const { GET } = await loadRoute()
+    executeTakeFirst.mockResolvedValue({ count: '5' })
+
+    const res = await GET(new Request('http://localhost/api/messages/unread-count'))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ unreadCount: 5 })
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/messages/api/unread-count/route.ts
+++ b/packages/core/src/modules/messages/api/unread-count/route.ts
@@ -1,11 +1,27 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { type Kysely, sql } from 'kysely'
+import { runWithCacheTenant } from '@open-mercato/cache'
+import {
+  buildCollectionTags,
+  isCrudCacheEnabled,
+  resolveCrudCache,
+} from '@open-mercato/shared/lib/crud/cache'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi/types'
 import { resolveMessageContext } from '../../lib/routeHelpers'
 import { unreadCountResponseSchema } from '../openapi'
 
 export const metadata = {
   GET: { requireAuth: true },
+}
+
+const UNREAD_COUNT_RESOURCE = 'messages.message'
+const UNREAD_COUNT_TTL_MS = 10_000
+
+function buildUnreadCountCacheKey(params: {
+  userId: string
+  orgId: string | null
+}): string {
+  return `messages:unread-count:u=${params.userId}:org=${params.orgId ?? 'null'}`
 }
 
 function getDb(em: EntityManager): Kysely<any> {
@@ -16,6 +32,19 @@ export async function GET(req: Request) {
   const { ctx, scope } = await resolveMessageContext(req)
   const em = ctx.container.resolve('em') as EntityManager
   const db = getDb(em) as any
+
+  const orgId = scope.organizationId ?? null
+  const cache = isCrudCacheEnabled() ? resolveCrudCache(ctx.container) : null
+  const cacheKey = cache
+    ? buildUnreadCountCacheKey({ userId: scope.userId, orgId })
+    : null
+
+  if (cache && cacheKey) {
+    const cached = await runWithCacheTenant(scope.tenantId, () => cache.get(cacheKey))
+    if (typeof cached === 'number') {
+      return Response.json({ unreadCount: cached })
+    }
+  }
 
   let query = db
     .selectFrom('message_recipients as r')
@@ -37,6 +66,17 @@ export async function GET(req: Request) {
     .select(sql<number>`count(*)`.as('count'))
     .executeTakeFirst() as { count: string | number } | undefined
   const count = Number(row?.count ?? 0)
+
+  if (cache && cacheKey) {
+    try {
+      await runWithCacheTenant(scope.tenantId, () =>
+        cache.set(cacheKey, count, {
+          ttl: UNREAD_COUNT_TTL_MS,
+          tags: buildCollectionTags(UNREAD_COUNT_RESOURCE, scope.tenantId, [orgId]),
+        }),
+      )
+    } catch {}
+  }
 
   return Response.json({ unreadCount: count })
 }


### PR DESCRIPTION
Fixes #2915

## Problem
- The unread-message badge polls `GET /api/messages/unread-count` every 5s (`POLL_INTERVAL = 5000` in `useMessagesPoll.ts`) from the app shell. Each tick runs an indexed Kysely `COUNT(*)` joining `message_recipients × messages` with 7 filter conditions, independent of activity — extreme aggregate cost across tabs/users.

## Root Cause
- The route had no caching, so every poll hit the database directly.

## What Changed
- Added a gated get-then-set cache to `packages/core/src/modules/messages/api/unread-count/route.ts`, mirroring the established sibling pattern (PR #3142 currencies options, PR #3143 auth roles):
  - `isCrudCacheEnabled()` flag gate + `resolveCrudCache(ctx.container)` — no-op when the flag is off or no cache service resolves (today's behavior preserved).
  - Tenant-scoped via `runWithCacheTenant(scope.tenantId, …)`.
  - Per-user **and** per-org cache key (`messages:unread-count:u=<userId>:org=<orgId|null>`) — this count is org-scoped, so both axes are in the key; no cross-user/cross-org bleed.
  - 10s TTL (two poll ticks) — appropriate for a badge.
  - Reuses the already-flushed `crud:messages.message:tenant:<T>:org:<O>:collection` tags via `buildCollectionTags(...)`. Every message command (send / mark read|unread / archive / delete / action, plus undo/redo) already flushes these tags through the command bus post-commit — **zero new invalidation wiring**.
  - Cache `set` failures are swallowed; the response is always returned.
- Response shape is unchanged (`{ unreadCount: number }`).

## Tests
- New focused unit test `api/unread-count/__tests__/cache.test.ts` (mirrors the sibling cache tests): caches with correct key/TTL/tags keyed by user+org; serves cache hit without touching the DB; uses the `org=null` axis when scope has no organization; does not cache when the flag is off.
- Existing `api/unread-count/__tests__/route.test.ts` still passes (flag off ⇒ uncached path).
- Full messages module suite: 49 suites / 232 tests passing. `yarn build:packages` and core typecheck pass.

## Backward Compatibility
- No contract-surface changes. No removed API fields, event IDs, ACL IDs, DI names, or import paths. Reuses existing CRUD cache tags; no new flush wiring.