### PR TITLE
feat(notifications): cache GET /api/notifications/unread-count (#2908)

### DIFF
--- a/packages/core/src/modules/notifications/api/unread-count/__tests__/cache.test.ts
+++ b/packages/core/src/modules/notifications/api/unread-count/__tests__/cache.test.ts
@@ -1,0 +1,144 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+
+const count = jest.fn()
+
+const cache = {
+  get: jest.fn(),
+  set: jest.fn(),
+} as { get: jest.Mock; set: jest.Mock }
+
+const em = {
+  count: (...args: unknown[]) => count(...args),
+}
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'cache') return cache
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const resolveNotificationContextMock = jest.fn(async () => ({
+  ctx: { container },
+  scope: { userId, tenantId, organizationId: orgId },
+}))
+
+jest.mock('@open-mercato/core/modules/notifications/lib/routeHelpers', () => ({
+  resolveNotificationContext: (...args: unknown[]) => resolveNotificationContextMock(...args),
+}))
+
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: jest.fn((_tenantId: string, fn: () => unknown) => fn()),
+}))
+
+const ORIGINAL_ENV = { ...process.env }
+
+const loadRoute = async () => {
+  jest.resetModules()
+  return import('../route')
+}
+
+describe('GET /api/notifications/unread-count caching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+    resolveNotificationContextMock.mockResolvedValue({
+      ctx: { container },
+      scope: { userId, tenantId, organizationId: orgId },
+    })
+  })
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('caches the count with an org-agnostic collection tag keyed per user', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+    count.mockResolvedValue(7)
+
+    const res = await GET(new Request('http://localhost/api/notifications/unread-count'))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ unreadCount: 7 })
+
+    expect(cache.get).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+    const [key, value, opts] = cache.set.mock.calls[0]
+    expect(key).toBe(`notifications:unread-count:u=${userId}`)
+    expect(value).toBe(7)
+    expect(opts.ttl).toBe(10_000)
+    expect(opts.tags).toEqual([
+      `crud:notifications.notification:tenant:${tenantId}:org:null:collection`,
+    ])
+  })
+
+  it('serves the cached count without querying the database on a cache hit', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(4)
+
+    const res = await GET(new Request('http://localhost/api/notifications/unread-count'))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ unreadCount: 4 })
+    expect(count).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('uses a user-only key that ignores the organization axis', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    resolveNotificationContextMock.mockResolvedValue({
+      ctx: { container },
+      scope: { userId, tenantId, organizationId: null },
+    })
+    cache.get.mockResolvedValue(null)
+    count.mockResolvedValue(2)
+
+    const res = await GET(new Request('http://localhost/api/notifications/unread-count'))
+
+    expect(res.status).toBe(200)
+    const [key, , opts] = cache.set.mock.calls[0]
+    expect(key).toBe(`notifications:unread-count:u=${userId}`)
+    expect(opts.tags).toEqual([
+      `crud:notifications.notification:tenant:${tenantId}:org:null:collection`,
+    ])
+  })
+
+  it('does not cache when the crud cache flag is off', async () => {
+    delete process.env.ENABLE_CRUD_API_CACHE
+    const { GET } = await loadRoute()
+    count.mockResolvedValue(5)
+
+    const res = await GET(new Request('http://localhost/api/notifications/unread-count'))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ unreadCount: 5 })
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('does not cache when there is no user in scope', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    resolveNotificationContextMock.mockResolvedValue({
+      ctx: { container },
+      scope: { userId: null, tenantId, organizationId: orgId },
+    })
+    count.mockResolvedValue(3)
+
+    const res = await GET(new Request('http://localhost/api/notifications/unread-count'))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ unreadCount: 3 })
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/notifications/api/unread-count/route.ts
+++ b/packages/core/src/modules/notifications/api/unread-count/route.ts
@@ -1,4 +1,10 @@
 import type { EntityManager } from '@mikro-orm/core'
+import { runWithCacheTenant } from '@open-mercato/cache'
+import {
+  buildCollectionTags,
+  isCrudCacheEnabled,
+  resolveCrudCache,
+} from '@open-mercato/shared/lib/crud/cache'
 import { Notification } from '../../data/entities'
 import { unreadCountResponseSchema } from '../openapi'
 import { resolveNotificationContext } from '../../lib/routeHelpers'
@@ -7,15 +13,44 @@ export const metadata = {
   GET: { requireAuth: true },
 }
 
+const UNREAD_COUNT_RESOURCE = 'notifications.notification'
+const UNREAD_COUNT_TTL_MS = 10_000
+
+function buildUnreadCountCacheKey(userId: string): string {
+  return `notifications:unread-count:u=${userId}`
+}
+
 export async function GET(req: Request) {
   const { scope, ctx } = await resolveNotificationContext(req)
   const em = ctx.container.resolve('em') as EntityManager
 
+  const userId = scope.userId
+  const cache = userId && isCrudCacheEnabled() ? resolveCrudCache(ctx.container) : null
+  const cacheKey = cache && userId ? buildUnreadCountCacheKey(userId) : null
+
+  if (cache && cacheKey) {
+    const cached = await runWithCacheTenant(scope.tenantId, () => cache.get(cacheKey))
+    if (typeof cached === 'number') {
+      return Response.json({ unreadCount: cached })
+    }
+  }
+
   const count = await em.count(Notification, {
-    recipientUserId: scope.userId,
+    recipientUserId: userId,
     tenantId: scope.tenantId,
     status: 'unread',
   })
+
+  if (cache && cacheKey) {
+    try {
+      await runWithCacheTenant(scope.tenantId, () =>
+        cache.set(cacheKey, count, {
+          ttl: UNREAD_COUNT_TTL_MS,
+          tags: buildCollectionTags(UNREAD_COUNT_RESOURCE, scope.tenantId, [null]),
+        }),
+      )
+    } catch {}
+  }
 
   return Response.json({ unreadCount: count })
 }


### PR DESCRIPTION
Fixes #2908

## Problem
The notification bell badge polls `GET /api/notifications/unread-count` every 5 seconds on every backoffice page (`useNotificationsPoll.ts`, `POLL_INTERVAL = 5000`). Each call runs an unconditional `em.count(Notification, { recipientUserId, tenantId, status: 'unread' })`, so every authenticated session issues ~12 COUNT queries/minute purely for the badge.

## Root Cause
The route had no caching, and it is not a `makeCrudRoute`, so the generic CRUD cache did not cover it.

## What Changed
- `packages/core/src/modules/notifications/api/unread-count/route.ts` — add a short-TTL (10s) cache around the COUNT, mirroring the messages unread-count cache (PR #3155):
  - gated on `isCrudCacheEnabled()` + `resolveCrudCache(ctx.container)` — a defensive no-op when caching is disabled or the cache service is unavailable, so behavior is byte-identical to today in that case;
  - tenant-scoped via `runWithCacheTenant(scope.tenantId, …)` so the key is tenant-namespaced without carrying the tenant literal;
  - **per-user key** `notifications:unread-count:u=<userId>` — the count filters on user + tenant + status only (it ignores `organizationId`), so the key deliberately omits the org axis to avoid org-switching inconsistencies; never caches when `userId` is empty;
  - reuses the `notifications.notification` collection tag via `buildCollectionTags(..., [null])` (org-null axis, matching the org-agnostic value) so that if notifications ever gain command-bus writes, invalidation works automatically — **no new invalidation wiring is added** in this PR;
  - swallows `cache.set` failures; never caches a non-200.
- Response shape (`{ unreadCount }`) is unchanged.

### Freshness / safety
Worst-case staleness is the deterministic 10s TTL (≤2 poll ticks) — there is no missed-invalidation failure mode. Notification writes flow through `createNotificationService` (not the command bus), so today no `crud:notifications.notification` collection tag is flushed; freshness is carried entirely by the short TTL, which is appropriate for a UI badge. SSE-enabled clients keep near-real-time pushes regardless. This is badge-only data (not money/stock/auth).

## Tests
- New `packages/core/src/modules/notifications/api/unread-count/__tests__/cache.test.ts` (mirrors PR #3155): caches with the org-null collection tag + 10s TTL keyed per user; serves a cache hit without querying the DB; org axis is ignored in the key; does not cache when the flag is off; does not cache when there is no user in scope. 5/5 pass.
- `yarn workspace @open-mercato/core test -- modules/notifications` → 22/22 pass (5 suites).
- `yarn typecheck` → 21/21 successful.
- `yarn generate` + `yarn build:packages` clean.

## Backward Compatibility
No contract surface changes. Additive caching behind the existing `ENABLE_CRUD_API_CACHE` flag; response shape unchanged; defensive no-op without a cache service.