### PR TITLE
feat(dictionaries): cache GET /api/dictionaries/[id]/entries (reuse crud:dictionaries.entry tags) (#2917)

### DIFF
--- a/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/__tests__/cache.test.ts
+++ b/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/__tests__/cache.test.ts
@@ -1,0 +1,178 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const dictionaryId = '44444444-4444-4444-8444-444444444444'
+const entryId = '55555555-5555-4555-8555-555555555555'
+
+const em = {
+  fork: jest.fn(),
+  findOne: jest.fn(),
+  find: jest.fn(),
+}
+
+const cache = {
+  get: jest.fn(),
+  set: jest.fn(),
+} as { get: jest.Mock; set: jest.Mock }
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'cache') return cache
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const context = {
+  container,
+  ctx: {
+    container,
+    auth: { tenantId, sub: userId },
+    organizationScope: null,
+    selectedOrganizationId: organizationId,
+    organizationIds: [organizationId],
+    request: null,
+  },
+  auth: { tenantId, sub: userId },
+  em,
+  organizationId,
+  tenantId,
+  readableOrganizationIds: [organizationId],
+  translate: (_key: string, fallback?: string) => fallback ?? 'error',
+}
+
+jest.mock('@open-mercato/core/modules/dictionaries/api/context', () => ({
+  resolveDictionariesRouteContext: jest.fn(async () => context),
+  resolveDictionaryActorId: jest.fn(() => userId),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (emInstance: typeof em, entity: unknown, filters: unknown, opts?: Record<string, unknown>) => {
+    const hasOpts = opts && Object.keys(opts).length > 0
+    return hasOpts ? emInstance.find(entity, filters, opts) : emInstance.find(entity, filters)
+  },
+  findOneWithDecryption: (emInstance: typeof em, entity: unknown, filters: unknown, opts?: Record<string, unknown>) => {
+    const hasOpts = opts && Object.keys(opts).length > 0
+    return hasOpts ? emInstance.findOne(entity, filters, opts) : emInstance.findOne(entity, filters)
+  },
+}))
+
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: jest.fn((_tenantId: string, fn: () => unknown) => fn()),
+}))
+
+const makeEntry = (value: string, label: string, position: number) => ({
+  id: `${value}-id`,
+  value,
+  label,
+  color: null,
+  icon: null,
+  position,
+  isDefault: false,
+  createdAt: new Date('2026-04-11T08:00:00.000Z'),
+  updatedAt: new Date('2026-04-11T08:00:00.000Z'),
+})
+
+const ORIGINAL_ENV = { ...process.env }
+
+const loadRoute = async () => {
+  jest.resetModules()
+  return import('../route')
+}
+
+const makeRequest = () =>
+  new Request(`http://localhost/api/dictionaries/${dictionaryId}/entries`)
+
+describe('GET /api/dictionaries/[dictionaryId]/entries caching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+    em.fork.mockReturnValue(em)
+    em.findOne.mockResolvedValue({
+      id: dictionaryId,
+      organizationId,
+      tenantId,
+      deletedAt: null,
+      entrySortMode: 'label_asc',
+    })
+    em.find.mockResolvedValue([
+      makeEntry('a', 'Alpha', 0),
+      makeEntry('b', 'Beta', 1),
+    ])
+  })
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('caches the entries payload with command-bus-compatible tags', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+
+    const res = await GET(makeRequest(), { params: { dictionaryId } })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: { value: string }[] }
+    expect(body.items.map((item) => item.value)).toEqual(['a', 'b'])
+
+    expect(cache.get).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+    const [key, value, opts] = cache.set.mock.calls[0]
+    expect(key).toBe(`dictionaries:entries:${dictionaryId}:org=${organizationId}:sort=label_asc`)
+    expect((value as { items: unknown[] }).items).toHaveLength(2)
+    expect(opts.ttl).toBe(5 * 60_000)
+    expect(opts.tags).toEqual([
+      `crud:dictionaries.entry:tenant:${tenantId}:org:${organizationId}:collection`,
+      `crud:dictionaries.dictionary:tenant:${tenantId}:record:${dictionaryId}`,
+    ])
+  })
+
+  it('serves the cached payload without querying entries on a cache hit', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    const cachedPayload = { items: [{ id: entryId, value: 'cached', label: 'Cached' }] }
+    cache.get.mockResolvedValue(cachedPayload)
+
+    const res = await GET(makeRequest(), { params: { dictionaryId } })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual(cachedPayload)
+    expect(em.find).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('does not touch the cache when the crud cache flag is off', async () => {
+    delete process.env.ENABLE_CRUD_API_CACHE
+    const { GET } = await loadRoute()
+
+    const res = await GET(makeRequest(), { params: { dictionaryId } })
+
+    expect(res.status).toBe(200)
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+    expect(em.find).toHaveBeenCalledTimes(1)
+  })
+
+  it('keys the cache by the dictionary sort mode', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    em.findOne.mockResolvedValue({
+      id: dictionaryId,
+      organizationId,
+      tenantId,
+      deletedAt: null,
+      entrySortMode: 'value_asc',
+    })
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+
+    await GET(makeRequest(), { params: { dictionaryId } })
+
+    expect(cache.set).toHaveBeenCalledTimes(1)
+    const [key] = cache.set.mock.calls[0]
+    expect(key).toBe(`dictionaries:entries:${dictionaryId}:org=${organizationId}:sort=value_asc`)
+  })
+})

--- a/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/route.ts
+++ b/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
+import { runWithCacheTenant } from '@open-mercato/cache'
 import { Dictionary, DictionaryEntry } from '@open-mercato/core/modules/dictionaries/data/entities'
 import { resolveDictionariesRouteContext } from '@open-mercato/core/modules/dictionaries/api/context'
 import { createDictionaryEntrySchema } from '@open-mercato/core/modules/dictionaries/data/validators'
@@ -17,11 +18,29 @@ import {
 } from '../../openapi'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import {
+  buildCollectionTags,
+  buildRecordTag,
+  isCrudCacheEnabled,
+  resolveCrudCache,
+} from '@open-mercato/shared/lib/crud/cache'
+import {
   resolveDictionaryEntrySortMode,
   sortDictionaryEntries,
 } from '@open-mercato/core/modules/dictionaries/lib/entrySort'
 
 const paramsSchema = z.object({ dictionaryId: z.string().uuid() })
+
+const DICTIONARY_ENTRY_RESOURCE = 'dictionaries.entry'
+const DICTIONARY_DEFINITION_RESOURCE = 'dictionaries.dictionary'
+const DICTIONARY_ENTRIES_TTL_MS = 5 * 60_000
+
+function buildEntriesCacheKey(params: {
+  dictionaryId: string
+  organizationId: string | null
+  sortMode: string
+}): string {
+  return `dictionaries:entries:${params.dictionaryId}:org=${params.organizationId ?? 'null'}:sort=${params.sortMode}`
+}
 
 async function loadDictionary(
   context: Awaited<ReturnType<typeof resolveDictionariesRouteContext>>,
@@ -68,6 +87,26 @@ export async function GET(req: Request, ctx: { params?: { dictionaryId?: string 
     }
     const { dictionaryId } = paramsSchema.parse({ dictionaryId: ctx.params?.dictionaryId })
     const dictionary = await loadDictionary(context, dictionaryId, { allowInherited: true })
+    const dictionaryTenantId = dictionary.tenantId
+    const dictionaryOrgId = dictionary.organizationId ?? null
+    const sortMode = resolveDictionaryEntrySortMode(dictionary.entrySortMode)
+
+    // Dictionary CF selects hit this on every CrudForm open, so cache the
+    // decrypted+sorted options payload. The entry writes flow through the
+    // command bus (resourceKind dictionaries.entry), which already flushes the
+    // matching collection tag post-commit — no new invalidation wiring needed.
+    const cache = isCrudCacheEnabled() ? resolveCrudCache(context.container) : null
+    const cacheKey = cache
+      ? buildEntriesCacheKey({ dictionaryId, organizationId: dictionaryOrgId, sortMode })
+      : null
+
+    if (cache && cacheKey) {
+      const cached = await runWithCacheTenant(dictionaryTenantId, () => cache.get(cacheKey))
+      if (cached) {
+        return NextResponse.json(cached)
+      }
+    }
+
     const entries = await findWithDecryption(
       context.em,
       DictionaryEntry,
@@ -79,9 +118,9 @@ export async function GET(req: Request, ctx: { params?: { dictionaryId?: string 
       {},
       { tenantId: dictionary.tenantId, organizationId: dictionary.organizationId },
     )
-    const sortedEntries = sortDictionaryEntries(entries, resolveDictionaryEntrySortMode(dictionary.entrySortMode))
+    const sortedEntries = sortDictionaryEntries(entries, sortMode)
 
-    return NextResponse.json({
+    const payload = {
       items: sortedEntries.map((entry) => ({
         id: entry.id,
         value: entry.value,
@@ -93,7 +132,23 @@ export async function GET(req: Request, ctx: { params?: { dictionaryId?: string 
         createdAt: entry.createdAt,
         updatedAt: entry.updatedAt,
       })),
-    })
+    }
+
+    if (cache && cacheKey) {
+      try {
+        await runWithCacheTenant(dictionaryTenantId, () =>
+          cache.set(cacheKey, payload, {
+            ttl: DICTIONARY_ENTRIES_TTL_MS,
+            tags: [
+              ...buildCollectionTags(DICTIONARY_ENTRY_RESOURCE, dictionaryTenantId, [dictionaryOrgId]),
+              buildRecordTag(DICTIONARY_DEFINITION_RESOURCE, dictionaryTenantId, dictionaryId),
+            ],
+          }),
+        )
+      } catch {}
+    }
+
+    return NextResponse.json(payload)
   } catch (err) {
     if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })


### PR DESCRIPTION
Fixes #2917

## Problem
Every dictionary-backed custom field renders a select whose options come from `GET /api/dictionaries/[dictionaryId]/entries` (wired via `entities/api/definitions.ts` `optionsUrl`). It fires on form bootstrap for every dictionary CF across all modules — often several times per CrudForm open — and each call runs a per-row-decrypting `findWithDecryption(DictionaryEntry, …)` plus a sort pass. Extreme read:write ratio (entries are admin-curated), no caching today.

## What Changed
- `packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/route.ts` GET now caches the decrypted+sorted options payload behind the opt-in CRUD API cache:
  - gated on `isCrudCacheEnabled()` + `resolveCrudCache(context.container)` (no-op when the flag is off or no cache service)
  - tenant-namespaced via `runWithCacheTenant(dictionary.tenantId, …)`
  - key: `dictionaries:entries:<dictionaryId>:org=<resolvedOrg>:sort=<sortMode>` — mirrors the route's actual filter axes (the dictionary is resolved across readable orgs, then entries are scoped to the dictionary's own org, so the tag/key use `dictionary.organizationId`)
  - TTL 5 min
- Tags reuse the existing command-bus flush — **no new invalidation wiring**:
  - `crud:dictionaries.entry:tenant:<T>:org:<O>:collection` — flushed post-commit by the command bus on every entry create/update/delete/undo (`resourceKind: dictionaries.entry`)
  - `crud:dictionaries.dictionary:tenant:<T>:record:<dictionaryId>` — forward-compat record tag for definition writes
- Definition PATCH/DELETE are plain `em.flush()` routes, so definition rename / `entrySortMode` / soft-delete converge via the 5-minute TTL (acceptable for admin-curated metadata; the entries' option values themselves are unchanged by a parent rename).
- `set` failures are swallowed; 401/404/500 branches are never cached; response shape unchanged.

## Tests
- New `packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/__tests__/cache.test.ts` (mirrors the currencies/auth/messages cache-test siblings):
  - caches the payload with command-bus-compatible collection + definition record tags, TTL, and the exact key
  - serves a cache hit without querying entries and without re-setting
  - does not touch the cache when `ENABLE_CRUD_API_CACHE` is off
  - keys the cache by the dictionary sort mode
- Full dictionaries entries suite: 9 passed.
- `yarn typecheck`: passed.
- `yarn workspace @open-mercato/core test`: 5995 passed; the single unrelated failure (`customers/.../DealsKpiStrip.test.tsx`) is pre-existing on `develop` and untouched by this change.

## Backward Compatibility
No contract surface changes. The endpoint, response shape, and ACL guards are unchanged; caching is purely additive and disabled by default (opt-in via `ENABLE_CRUD_API_CACHE`).