### PR TITLE
Fix deals list consistency for base-table entities

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-013.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-013.spec.ts
@@ -90,4 +90,96 @@ test.describe('TC-CRM-013: Pipeline View Navigation', () => {
       await deleteEntityByBody(request, token, '/api/customers/pipelines', pipelineId);
     }
   });
+
+  test('keeps aggregate counts, paginated list totals, and Show more aligned', async ({ page, request }) => {
+    test.slow();
+
+    let token: string | null = null;
+    let pipelineId: string | null = null;
+    let stageId: string | null = null;
+    let laterStageId: string | null = null;
+    const dealIds: string[] = [];
+
+    const timestamp = Date.now();
+    const pipelineName = `QA TC-CRM-013 Pagination Pipeline ${timestamp}`;
+    const stageName = 'Qualified';
+    const laterStageName = 'Review';
+    const titlePrefix = `QA TC-CRM-013 Page Deal ${timestamp}`;
+
+    try {
+      token = await getAuthToken(request);
+      pipelineId = await createPipelineFixture(request, token, { name: pipelineName });
+      stageId = await createPipelineStageFixture(request, token, { pipelineId, label: stageName, order: 0 });
+      laterStageId = await createPipelineStageFixture(request, token, { pipelineId, label: laterStageName, order: 1 });
+
+      for (let index = 1; index <= 27; index += 1) {
+        const dealId = await createDealFixture(request, token, {
+          title: `${titlePrefix} ${String(index).padStart(2, '0')}`,
+          pipelineId: pipelineId!,
+          pipelineStageId: stageId!,
+          valueAmount: 1000 + index,
+          valueCurrency: 'USD',
+        });
+        dealIds.push(dealId);
+      }
+
+      const aggregateResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/customers/deals/aggregate?pipelineId=${encodeURIComponent(pipelineId!)}`,
+        { token },
+      );
+      expect(aggregateResponse.ok(), `GET aggregate failed: ${aggregateResponse.status()}`).toBeTruthy();
+      const aggregateBody = (await aggregateResponse.json()) as {
+        perStage?: Array<{ stageId?: string; count?: number }>;
+      };
+      const aggregateStage = (aggregateBody.perStage ?? []).find((row) => row.stageId === stageId);
+      expect(aggregateStage?.count).toBe(27);
+
+      const pageOneResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/customers/deals?pipelineId=${encodeURIComponent(pipelineId!)}&pipelineStageId=${encodeURIComponent(stageId!)}&page=1&pageSize=25&sortField=updatedAt&sortDir=desc`,
+        { token },
+      );
+      expect(pageOneResponse.ok(), `GET deals page 1 failed: ${pageOneResponse.status()}`).toBeTruthy();
+      const pageOneBody = (await pageOneResponse.json()) as { items?: Array<Record<string, unknown>>; total?: number };
+      expect(pageOneBody.items ?? []).toHaveLength(25);
+      expect(pageOneBody.total).toBe(27);
+
+      const pageTwoResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/customers/deals?pipelineId=${encodeURIComponent(pipelineId!)}&pipelineStageId=${encodeURIComponent(stageId!)}&page=2&pageSize=25&sortField=updatedAt&sortDir=desc`,
+        { token },
+      );
+      expect(pageTwoResponse.ok(), `GET deals page 2 failed: ${pageTwoResponse.status()}`).toBeTruthy();
+      const pageTwoBody = (await pageTwoResponse.json()) as { items?: Array<Record<string, unknown>>; total?: number };
+      expect(pageTwoBody.items ?? []).toHaveLength(2);
+      expect(pageTwoBody.total).toBe(27);
+
+      await login(page, 'admin');
+      await page.goto('/backend/customers/deals/pipeline');
+      const pipelineChip = page.getByRole('button', { name: /^Pipeline:/ });
+      await expect(pipelineChip).toBeVisible({ timeout: 10_000 });
+      await pipelineChip.click();
+      const pipelinePopover = page.getByRole('dialog').last();
+      await pipelinePopover.getByRole('radio', { name: pipelineName, exact: true }).click();
+      await pipelinePopover.getByRole('button', { name: 'Apply', exact: true }).click();
+
+      await expect(page.getByText(stageName, { exact: true })).toBeVisible();
+      await expect(page.locator(`[aria-label="Deal: ${titlePrefix} 27"]`)).toBeVisible();
+      await expect(page.locator(`[aria-label="Deal: ${titlePrefix} 01"]`)).not.toBeVisible();
+
+      await page.getByRole('button', { name: new RegExp(`Load more deals in ${stageName}`) }).click();
+      await expect(page.locator(`[aria-label="Deal: ${titlePrefix} 01"]`)).toBeVisible();
+    } finally {
+      for (const dealId of dealIds) {
+        await deleteEntityIfExists(request, token, '/api/customers/deals', dealId);
+      }
+      await deleteEntityByBody(request, token, '/api/customers/pipeline-stages', laterStageId);
+      await deleteEntityByBody(request, token, '/api/customers/pipeline-stages', stageId);
+      await deleteEntityByBody(request, token, '/api/customers/pipelines', pipelineId);
+    }
+  });
 });

--- a/packages/core/src/modules/customers/api/deals/aggregate/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/deals/aggregate/__tests__/route.test.ts
@@ -79,6 +79,23 @@ describe('customers deals aggregate route', () => {
     expect(values).toContain(dealId)
   })
 
+  it('applies the valueCurrency filter used by kanban lane list requests', async () => {
+    const response = await GET(
+      new Request(
+        `http://localhost/api/customers/deals/aggregate?pipelineId=${pipelineId}&valueCurrency=gbp`,
+      ),
+    )
+
+    expect(response.status).toBe(200)
+
+    const aggregateCall = executeMock.mock.calls[1]
+    const sql = String(aggregateCall[0])
+    const values = aggregateCall[1] as string[]
+
+    expect(sql).toContain('UPPER(value_currency) = ?')
+    expect(values).toContain('GBP')
+  })
+
   it('collapses to zero rows when token lookup has no matches and encryption is enabled (default)', async () => {
     // `customers:customer_deal.title` and `.description` are encrypted at rest, so
     // the ILIKE fallback would silently match nothing on the ciphertext. The route

--- a/packages/core/src/modules/customers/api/deals/aggregate/route.ts
+++ b/packages/core/src/modules/customers/api/deals/aggregate/route.ts
@@ -26,6 +26,7 @@ const querySchema = z.object({
   ownerUserId: z.array(z.string().uuid()).optional(),
   personId: z.array(z.string().uuid()).optional(),
   companyId: z.array(z.string().uuid()).optional(),
+  valueCurrency: z.string().optional(),
   isStuck: z.preprocess((value) => {
     const parsed = parseBooleanFromUnknown(value)
     return parsed === null ? value : parsed
@@ -149,6 +150,7 @@ export async function GET(req: Request) {
     ownerUserId: readArrayParam(params, 'ownerUserId') ?? undefined,
     personId: readArrayParam(params, 'personId') ?? undefined,
     companyId: readArrayParam(params, 'companyId') ?? undefined,
+    valueCurrency: params.get('valueCurrency') ?? undefined,
     isStuck: params.get('isStuck') ?? undefined,
     isOverdue: params.get('isOverdue') ?? undefined,
     expectedCloseAtFrom: params.get('expectedCloseAtFrom') ?? undefined,
@@ -199,6 +201,11 @@ export async function GET(req: Request) {
   if (parsed.data.pipelineId) {
     where.push('pipeline_id = ?')
     values.push(parsed.data.pipelineId)
+  }
+  const valueCurrency = parsed.data.valueCurrency?.trim().toUpperCase()
+  if (valueCurrency) {
+    where.push('UPPER(value_currency) = ?')
+    values.push(valueCurrency)
   }
   const search = parsed.data.search?.trim()
   if (search) {

--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/components/Lane.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/components/Lane.tsx
@@ -35,6 +35,8 @@ type LaneProps = {
   deals: DealCardData[]
   /** Server-side aggregate for accurate counts/totals across all deals in this stage, not just loaded ones */
   aggregate?: LaneAggregateProp | null
+  /** Total reported by the list endpoint for this lane; used for pagination decisions */
+  listTotal?: number | null
   selectedDealIds: Set<string>
   buildMenuItems: (deal: DealCardData) => RowActionItem[]
   activeDragDealId?: string | null
@@ -185,6 +187,7 @@ function LaneImpl({
   stage,
   deals,
   aggregate,
+  listTotal,
   selectedDealIds,
   buildMenuItems,
   activeDragDealId,
@@ -221,7 +224,10 @@ function LaneImpl({
     : null
   const visibleCount = deals.length
   const totalCount = stats.count
-  const hasMoreDeals = totalCount > visibleCount
+  const paginationTotal = typeof listTotal === 'number' && Number.isFinite(listTotal)
+    ? listTotal
+    : totalCount
+  const hasMoreDeals = paginationTotal > visibleCount
   const accentClass = getAccentClass(stage.tone)
   const countBadgeClass = getCountBadgeClass(stage.tone)
 
@@ -345,7 +351,7 @@ function LaneImpl({
                   t,
                   'customers.deals.kanban.lane.loadMore',
                   'Show more ({remaining})',
-                  { remaining: totalCount - visibleCount },
+                  { remaining: paginationTotal - visibleCount },
                 )}
           </DashedTileButton>
         ) : null}
@@ -367,6 +373,7 @@ export const Lane = React.memo(LaneImpl, (prev, next) => {
   if (prev.stage !== next.stage) return false
   if (prev.deals !== next.deals) return false
   if (prev.aggregate !== next.aggregate) return false
+  if (prev.listTotal !== next.listTotal) return false
   if (prev.selectedDealIds !== next.selectedDealIds) return false
   if (prev.buildMenuItems !== next.buildMenuItems) return false
   if (prev.activeDragDealId !== next.activeDragDealId) return false

--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx
@@ -625,6 +625,7 @@ export default function DealsKanbanPage(): React.ReactElement {
       `people:${filterSignature.people}`,
       `companies:${filterSignature.companies}`,
       `close:${filterSignature.closeFrom}-${filterSignature.closeTo}`,
+      `currency:${filterSignature.currency}`,
     ],
     enabled: !!selectedPipelineId,
     staleTime: 30_000,
@@ -639,6 +640,7 @@ export default function DealsKanbanPage(): React.ReactElement {
       for (const companyId of companyFilters) params.append('companyId', companyId)
       if (closeDateFilter.from) params.set('expectedCloseAtFrom', closeDateFilter.from)
       if (closeDateFilter.to) params.set('expectedCloseAtTo', closeDateFilter.to)
+      if (currencyFilter) params.set('valueCurrency', currencyFilter)
       const call = await apiCall<StageAggregateResponse>(
         `/api/customers/deals/aggregate?${params.toString()}`,
       )
@@ -747,6 +749,7 @@ export default function DealsKanbanPage(): React.ReactElement {
 
   const laneState = React.useMemo(() => {
     const dealsByStage = new Map<string, DealCardData[]>()
+    const listTotalsByStage = new Map<string, number>()
     const stageIdByDealId = new Map<string, string>()
     const allDeals: DealCardData[] = []
     let total = 0
@@ -754,6 +757,7 @@ export default function DealsKanbanPage(): React.ReactElement {
       const stage = lanes[idx]
       if (!stage) return
       const firstPage = query.data?.items ?? []
+      listTotalsByStage.set(stage.id, query.data?.total ?? firstPage.length)
       const extra = extraCardsByStage[stage.id] ?? []
       // Merge first page + appended pages, deduping by id (in case of races/optimistic moves)
       const seen = new Set<string>()
@@ -778,7 +782,7 @@ export default function DealsKanbanPage(): React.ReactElement {
       dealsByStage.set(stage.id, list)
       total += list.length
     })
-    return { dealsByStage, stageIdByDealId, allDeals, total }
+    return { dealsByStage, listTotalsByStage, stageIdByDealId, allDeals, total }
   }, [laneQueries, lanes, fallbackTitle, extraCardsByStage])
 
   const rawDeals = laneState.allDeals
@@ -2822,6 +2826,7 @@ export default function DealsKanbanPage(): React.ReactElement {
                         stage={stage}
                         deals={laneDeals}
                         aggregate={aggregateByStage.get(stage.id) ?? null}
+                        listTotal={laneState.listTotalsByStage.get(stage.id) ?? null}
                         selectedDealIds={selectedDealIds}
                         buildMenuItems={buildMenuItems}
                         activeDragDealId={activeDragDealId}

--- a/packages/core/src/modules/customers/components/detail/DealLostSummaryDialog.tsx
+++ b/packages/core/src/modules/customers/components/detail/DealLostSummaryDialog.tsx
@@ -128,7 +128,7 @@ export function DealLostSummaryDialog({
             {lossNotes ? (
               <div className="rounded-xl bg-primary/15 px-4 py-4 text-left">
                 <div className="text-overline font-bold uppercase tracking-[0.16em] text-foreground">
-                  {t('customers.deals.detail.lost.nextHeading', "What's next")}
+                  {t('customers.deals.detail.lost.nextHeading', 'Loss notes')}
                 </div>
                 <div className="mt-2 text-xs leading-5 text-muted-foreground">{lossNotes}</div>
               </div>

--- a/packages/core/src/modules/customers/components/detail/__tests__/DealLostSummaryDialog.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/DealLostSummaryDialog.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { DealLostSummaryDialog } from '../DealLostSummaryDialog'
+
+jest.mock('@open-mercato/ui/primitives/dialog', () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div data-testid="dialog-content" className={className}>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+describe('DealLostSummaryDialog', () => {
+  it('shows entered loss notes under the loss notes heading', () => {
+    renderWithProviders(
+      <DealLostSummaryDialog
+        open
+        onClose={() => undefined}
+        dealTitle="Enterprise renewal"
+        lossNotes="Budget owner chose a cheaper vendor."
+        stats={{
+          dealValue: 12000,
+          dealCurrency: 'USD',
+          closureOutcome: 'lost',
+          closedAt: '2026-04-26T10:00:00.000Z',
+          pipelineName: 'Enterprise',
+          dealsClosedThisPeriod: 3,
+          salesCycleDays: 42,
+          dealRankInQuarter: 2,
+          lossReason: 'Price',
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Loss notes')).toBeVisible()
+    expect(screen.queryByText("What's next")).not.toBeInTheDocument()
+    expect(screen.getByText('Budget owner chose a cheaper vendor.')).toBeVisible()
+  })
+})

--- a/packages/core/src/modules/customers/i18n/de.json
+++ b/packages/core/src/modules/customers/i18n/de.json
@@ -778,7 +778,7 @@
   "customers.deals.detail.lost.dealsThisWeek": "Lost this week",
   "customers.deals.detail.lost.followUpFallbackTitle": "Revisit closed deal",
   "customers.deals.detail.lost.followUpTitle": "Revisit {{title}}",
-  "customers.deals.detail.lost.nextHeading": "What's next",
+  "customers.deals.detail.lost.nextHeading": "Verlustnotizen",
   "customers.deals.detail.lost.notesLabel": "Loss notes (optional)",
   "customers.deals.detail.lost.notesPlaceholder": "Additional context about the loss...",
   "customers.deals.detail.lost.popupSubtitle": "Even great teams miss a shot sometimes",

--- a/packages/core/src/modules/customers/i18n/en.json
+++ b/packages/core/src/modules/customers/i18n/en.json
@@ -778,7 +778,7 @@
   "customers.deals.detail.lost.dealsThisWeek": "Lost this week",
   "customers.deals.detail.lost.followUpFallbackTitle": "Revisit closed deal",
   "customers.deals.detail.lost.followUpTitle": "Revisit {{title}}",
-  "customers.deals.detail.lost.nextHeading": "What's next",
+  "customers.deals.detail.lost.nextHeading": "Loss notes",
   "customers.deals.detail.lost.notesLabel": "Loss notes (optional)",
   "customers.deals.detail.lost.notesPlaceholder": "Additional context about the loss...",
   "customers.deals.detail.lost.popupSubtitle": "Even great teams miss a shot sometimes",

--- a/packages/core/src/modules/customers/i18n/es.json
+++ b/packages/core/src/modules/customers/i18n/es.json
@@ -778,7 +778,7 @@
   "customers.deals.detail.lost.dealsThisWeek": "Lost this week",
   "customers.deals.detail.lost.followUpFallbackTitle": "Revisit closed deal",
   "customers.deals.detail.lost.followUpTitle": "Revisit {{title}}",
-  "customers.deals.detail.lost.nextHeading": "What's next",
+  "customers.deals.detail.lost.nextHeading": "Notas de pérdida",
   "customers.deals.detail.lost.notesLabel": "Loss notes (optional)",
   "customers.deals.detail.lost.notesPlaceholder": "Additional context about the loss...",
   "customers.deals.detail.lost.popupSubtitle": "Even great teams miss a shot sometimes",

--- a/packages/core/src/modules/customers/i18n/pl.json
+++ b/packages/core/src/modules/customers/i18n/pl.json
@@ -778,7 +778,7 @@
   "customers.deals.detail.lost.dealsThisWeek": "Lost this week",
   "customers.deals.detail.lost.followUpFallbackTitle": "Revisit closed deal",
   "customers.deals.detail.lost.followUpTitle": "Revisit {{title}}",
-  "customers.deals.detail.lost.nextHeading": "What's next",
+  "customers.deals.detail.lost.nextHeading": "Notatki o stracie",
   "customers.deals.detail.lost.notesLabel": "Loss notes (optional)",
   "customers.deals.detail.lost.notesPlaceholder": "Additional context about the loss...",
   "customers.deals.detail.lost.popupSubtitle": "Even great teams miss a shot sometimes",

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -8,6 +8,7 @@ type KyselyMockConfig = {
   indexCount: number
   coverageRefreshedAt?: Date | string | null
   customFieldKeys?: Record<string, string[]>
+  customEntityIds?: string[]
   rows?: Record<string, Array<Record<string, unknown>>>
   /** If provided, returned for information_schema.columns lookups. */
   columns?: Array<{ table_name: string; column_name: string }>
@@ -126,11 +127,20 @@ function resolveFirstRow(
   customFieldKeys: Record<string, string[]>,
 ): any {
   if (table === 'information_schema.tables') {
-    const lookingFor = log.wheres
-      .flatMap((entry: any[]) => entry)
-      .find((arg: any) => typeof arg === 'string')
-    // Any table_name lookup is satisfied if it matches baseTable or is our service table.
-    return lookingFor ? { one: 1 } : undefined
+    const args = log.wheres.flatMap((entry: any[]) => entry)
+    const tableName = args[args.indexOf('table_name') + 2] as string | undefined
+    const serviceTables = new Set([
+      'custom_entities',
+      'custom_entities_storage',
+      'custom_field_defs',
+      'entity_indexes',
+      'entity_index_coverage',
+      'search_tokens',
+    ])
+    if (tableName === config.baseTable || serviceTables.has(tableName ?? '') || config.rows?.[tableName ?? '']) {
+      return { one: 1 }
+    }
+    return undefined
   }
   if (table === 'information_schema.columns') {
     // Collect column/table names from the captured wheres to match the requested pair.
@@ -175,6 +185,9 @@ function resolveFirstRow(
     return config.hasIndexAny ? { entity_id: 'x' } : undefined
   }
   if (table === 'custom_entities') {
+    const args = log.wheres.flatMap((entry: any[]) => entry)
+    const entityId = args[args.indexOf('entity_id') + 2] as string | undefined
+    if (entityId && config.customEntityIds?.includes(entityId)) return { id: entityId }
     return undefined
   }
   return undefined
@@ -529,6 +542,42 @@ describe('HybridQueryEngine', () => {
       expect.objectContaining({ entity: 'example:todo', total: 10, fallbackTotal: 10 }),
     )
     warnSpy.mockRestore()
+  })
+
+  test('uses the base table when a core entity also has a custom entity registry row', async () => {
+    const db = createFakeKysely({
+      baseTable: 'todos',
+      hasIndexAny: true,
+      baseCount: 1,
+      indexCount: 1,
+      customEntityIds: ['example:todo'],
+      rows: {
+        todos: [{ id: 'todo-1', title: 'Core row' }],
+      },
+      columns: [
+        { table_name: 'todos', column_name: 'id' },
+        { table_name: 'todos', column_name: 'tenant_id' },
+        { table_name: 'todos', column_name: 'organization_id' },
+        { table_name: 'todos', column_name: 'deleted_at' },
+        { table_name: 'todos', column_name: 'title' },
+      ],
+    })
+    const engine = new HybridQueryEngine(buildEm(db), { query: jest.fn() } as any)
+    ;(engine as any).parseCount = jest.fn().mockReturnValue(1)
+
+    const result = await engine.query('example:todo', {
+      fields: ['id', 'title'],
+      filters: {
+        title: { $eq: 'Core row' },
+      },
+      organizationId: 'org1',
+      tenantId: 't1',
+      page: { page: 1, pageSize: 25 },
+    })
+
+    expect(result.items).toEqual([{ id: 'todo-1', title: 'Core row' }])
+    expect(result.total).toBe(1)
+    expect((db._chains as ChainLog[]).some((chain) => chain.table === 'custom_entities_storage')).toBe(false)
   })
 
   test('skips partial coverage warning when entity has no custom fields', async () => {
@@ -924,7 +973,6 @@ describe('HybridQueryEngine custom-entity classification (#2939)', () => {
 
     await engine.query('customers:customer_deal', {
       fields: ['id', 'title', 'pipeline_stage_id'],
-      includeCustomFields: true,
       organizationIds: ['org1'],
       tenantId: 't1',
     })

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -481,6 +481,56 @@ describe('HybridQueryEngine', () => {
     warnSpy.mockRestore()
   })
 
+  test('falls back when hybrid count finds rows but data page is empty for a filtered list', async () => {
+    const db = createFakeKysely({
+      baseTable: 'todos',
+      hasIndexAny: true,
+      baseCount: 10,
+      indexCount: 10,
+      customFieldKeys: {
+        'example:todo': ['priority'],
+      },
+      columns: [
+        { table_name: 'todos', column_name: 'id' },
+        { table_name: 'todos', column_name: 'tenant_id' },
+        { table_name: 'todos', column_name: 'organization_id' },
+        { table_name: 'todos', column_name: 'deleted_at' },
+        { table_name: 'todos', column_name: 'pipeline_id' },
+        { table_name: 'todos', column_name: 'pipeline_stage_id' },
+        { table_name: 'todos', column_name: 'updated_at' },
+      ],
+    })
+    const em = buildEm(db)
+    const fallback = {
+      query: jest.fn().mockResolvedValue({ items: [{ id: 'todo-1' }], page: 1, pageSize: 25, total: 10 }),
+    }
+    const engine = new HybridQueryEngine(em, fallback as any)
+    ;(engine as any).parseCount = jest.fn().mockReturnValue(10)
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await engine.query('example:todo', {
+      fields: ['id', 'pipeline_id', 'pipeline_stage_id', 'updated_at'],
+      includeCustomFields: true,
+      filters: {
+        pipeline_id: { $eq: 'pipeline-1' },
+        pipeline_stage_id: { $eq: 'stage-1' },
+      },
+      sort: [{ field: 'updated_at', dir: SortDir.Desc }],
+      organizationId: 'org1',
+      tenantId: 't1',
+      page: { page: 1, pageSize: 25 },
+    })
+
+    expect(fallback.query).toHaveBeenCalled()
+    expect(result.items).toEqual([{ id: 'todo-1' }])
+    expect(result.total).toBe(10)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Hybrid query returned an empty page'),
+      expect.objectContaining({ entity: 'example:todo', total: 10, fallbackTotal: 10 }),
+    )
+    warnSpy.mockRestore()
+  })
+
   test('skips partial coverage warning when entity has no custom fields', async () => {
     const db = createFakeKysely({
       baseTable: 'todos', hasIndexAny: true, baseCount: 8, indexCount: 2, customFieldKeys: {},

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -360,6 +360,36 @@ describe('HybridQueryEngine', () => {
     warnSpy.mockRestore()
   })
 
+  test('falls back on partial coverage when includeCustomFields is boolean true', async () => {
+    process.env.FORCE_QUERY_INDEX_ON_PARTIAL_INDEXES = 'false'
+    const db = createFakeKysely({ baseTable: 'todos', hasIndexAny: true, baseCount: 26, indexCount: 1 })
+    const em = buildEm(db)
+    const fallback = {
+      query: jest.fn().mockResolvedValue({ items: [{ id: 'todo-1' }], page: 1, pageSize: 25, total: 26 }),
+    }
+    const emitEvent = jest.fn().mockResolvedValue(undefined)
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent }))
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await engine.query('example:todo', {
+      fields: ['id', 'title'],
+      includeCustomFields: true,
+      organizationId: 'org1',
+      tenantId: 't1',
+      page: { page: 1, pageSize: 25 },
+    })
+
+    expect(fallback.query).toHaveBeenCalled()
+    expect(result.items).toEqual([{ id: 'todo-1' }])
+    expect(result.total).toBe(26)
+    expect(result.meta?.partialIndexWarning).toEqual(expect.objectContaining({
+      entity: 'example:todo',
+      baseCount: 26,
+      indexedCount: 1,
+    }))
+    warnSpy.mockRestore()
+  })
+
   test('skips partial coverage warning when entity has no custom fields', async () => {
     const db = createFakeKysely({
       baseTable: 'todos', hasIndexAny: true, baseCount: 8, indexCount: 2, customFieldKeys: {},
@@ -408,7 +438,7 @@ describe('HybridQueryEngine', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
 
     await engine.query('example:todo', {
-      fields: ['id'], includeCustomFields: true, organizationId: 'org1', tenantId: 't1',
+      fields: ['id'], organizationId: 'org1', tenantId: 't1',
     })
 
     expect(fallback.query).not.toHaveBeenCalled()

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -390,6 +390,46 @@ describe('HybridQueryEngine', () => {
     warnSpy.mockRestore()
   })
 
+  test('falls back when hybrid base query returns a false zero for includeCustomFields list queries', async () => {
+    const db = createFakeKysely({
+      baseTable: 'todos',
+      hasIndexAny: true,
+      baseCount: 0,
+      indexCount: 0,
+      customFieldKeys: {
+        'example:todo': ['priority'],
+      },
+    })
+    const em = buildEm(db)
+    const fallback = {
+      query: jest.fn().mockResolvedValue({ items: [{ id: 'todo-1' }], page: 1, pageSize: 25, total: 10 }),
+    }
+    const emitEvent = jest.fn().mockResolvedValue(undefined)
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent }))
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await engine.query('example:todo', {
+      fields: ['id', 'title'],
+      includeCustomFields: true,
+      filters: {
+        pipeline_id: { $eq: 'pipeline-1' },
+        pipeline_stage_id: { $eq: 'stage-1' },
+      },
+      organizationId: 'org1',
+      tenantId: 't1',
+      page: { page: 1, pageSize: 25 },
+    })
+
+    expect(fallback.query).toHaveBeenCalled()
+    expect(result.items).toEqual([{ id: 'todo-1' }])
+    expect(result.total).toBe(10)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Hybrid query returned zero rows'),
+      expect.objectContaining({ entity: 'example:todo', fallbackTotal: 10 }),
+    )
+    warnSpy.mockRestore()
+  })
+
   test('skips partial coverage warning when entity has no custom fields', async () => {
     const db = createFakeKysely({
       baseTable: 'todos', hasIndexAny: true, baseCount: 8, indexCount: 2, customFieldKeys: {},

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -430,6 +430,57 @@ describe('HybridQueryEngine', () => {
     warnSpy.mockRestore()
   })
 
+  test('falls back from false zero even when partial index forcing is enabled', async () => {
+    process.env.FORCE_QUERY_INDEX_ON_PARTIAL_INDEXES = 'true'
+    const db = createFakeKysely({
+      baseTable: 'todos',
+      hasIndexAny: true,
+      baseCount: 10,
+      indexCount: 0,
+      customFieldKeys: {
+        'example:todo': ['priority'],
+      },
+      columns: [
+        { table_name: 'todos', column_name: 'id' },
+        { table_name: 'todos', column_name: 'tenant_id' },
+        { table_name: 'todos', column_name: 'organization_id' },
+        { table_name: 'todos', column_name: 'deleted_at' },
+        { table_name: 'todos', column_name: 'pipeline_id' },
+        { table_name: 'todos', column_name: 'pipeline_stage_id' },
+        { table_name: 'todos', column_name: 'updated_at' },
+      ],
+    })
+    const em = buildEm(db)
+    const fallback = {
+      query: jest.fn().mockResolvedValue({ items: [{ id: 'todo-1' }], page: 1, pageSize: 25, total: 10 }),
+    }
+    const emitEvent = jest.fn().mockResolvedValue(undefined)
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent }))
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await engine.query('example:todo', {
+      fields: ['id', 'pipeline_id', 'pipeline_stage_id', 'updated_at'],
+      includeCustomFields: true,
+      filters: {
+        pipeline_id: { $eq: 'pipeline-1' },
+        pipeline_stage_id: { $eq: 'stage-1' },
+      },
+      sort: [{ field: 'updated_at', dir: SortDir.Desc }],
+      organizationId: 'org1',
+      tenantId: 't1',
+      page: { page: 1, pageSize: 25 },
+    })
+
+    expect(fallback.query).toHaveBeenCalled()
+    expect(result.items).toEqual([{ id: 'todo-1' }])
+    expect(result.total).toBe(10)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Hybrid query returned zero rows'),
+      expect.objectContaining({ entity: 'example:todo', fallbackTotal: 10 }),
+    )
+    warnSpy.mockRestore()
+  })
+
   test('skips partial coverage warning when entity has no custom fields', async () => {
     const db = createFakeKysely({
       baseTable: 'todos', hasIndexAny: true, baseCount: 8, indexCount: 2, customFieldKeys: {},

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -266,6 +266,7 @@ export class HybridQueryEngine implements QueryEngine {
       const wantsCf = (
         (opts.fields || []).some((field) => typeof field === 'string' && (field.startsWith('cf:') || field.startsWith('l10n:'))) ||
         cfFilters.length > 0 ||
+        opts.includeCustomFields === true ||
         (Array.isArray(opts.includeCustomFields) && opts.includeCustomFields.length > 0)
       )
 

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -889,6 +889,35 @@ export class HybridQueryEngine implements QueryEngine {
         total = this.parseCount(countRow)
       }
 
+      if (
+        total === 0 &&
+        wantsCf &&
+        normalizedFilters.length > 0 &&
+        cfFilters.length === 0 &&
+        searchFilters.length === 0 &&
+        !partialIndexWarning
+      ) {
+        const fallbackResult = await this.fallback.query<T>(entity, opts)
+        const fallbackTotal = typeof fallbackResult?.total === 'number'
+          ? fallbackResult.total
+          : Array.isArray(fallbackResult?.items)
+            ? fallbackResult.items.length
+            : 0
+        if (fallbackTotal > 0) {
+          console.warn('[HybridQueryEngine] Hybrid query returned zero rows while fallback found matches; falling back to basic engine:', {
+            entity,
+            fallbackTotal,
+          })
+          if (debugEnabled) this.debug('query:fallback:false-zero', { entity, fallbackTotal })
+          finishProfile({
+            result: 'fallback',
+            reason: 'hybrid_false_zero',
+            total: fallbackTotal,
+          })
+          return await applyAfterExtensions(fallbackResult)
+        }
+      }
+
       const dataRoot = db.selectFrom(`${baseTable} as b` as any)
       let dataBuilder = await applyQueryShape(dataRoot)
       dataBuilder = applySelection(dataBuilder)

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -2,7 +2,7 @@ import type { QueryEngine, QueryOptions, QueryResult, FilterOp, Filter, QueryCus
 import { SortDir } from '@open-mercato/shared/lib/query/types'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { BasicQueryEngine, resolveEntityTableName, resolveRegisteredEntityTableName } from '@open-mercato/shared/lib/query/engine'
+import { BasicQueryEngine, resolveEntityTableName } from '@open-mercato/shared/lib/query/engine'
 import { type Kysely, sql, type RawBuilder } from 'kysely'
 import type { EventBus } from '@open-mercato/events'
 import { readCoverageSnapshot, refreshCoverageSnapshot } from './coverage'
@@ -1061,17 +1061,9 @@ export class HybridQueryEngine implements QueryEngine {
     if (cached !== undefined) return cached
     let result = false
     try {
-      const db = this.getDb() as any
-      const row = await db
-        .selectFrom('custom_entities')
-        .select('id')
-        .where('entity_id', '=', entity)
-        .where('is_active', '=', true)
-        .executeTakeFirst()
-      if (row) {
-        result = true
-      } else if (resolveRegisteredEntityTableName(this.em, entity) !== null) {
-        // An id backed by a registered ORM table is never doc-storage-backed by
+      const baseTable = resolveEntityTableName(this.em as EntityManager, entity as EntityId)
+      if (baseTable && await this.tableExists(baseTable)) {
+        // An id backed by a real base table is never doc-storage-backed by
         // inference: stray `custom_entities_storage` rows for such an id (e.g. written
         // through the generic entities data engine) must not hijack every list/detail
         // read for the whole entity type away from its base table (#2939). Surfaces
@@ -1079,14 +1071,25 @@ export class HybridQueryEngine implements QueryEngine {
         // `forceCustomEntityStorage` in QueryOptions instead.
         result = false
       } else {
-        // Read/write symmetry. Records written through the entities data engine
-        // (`de.createCustomEntityRecord`) always land in `custom_entities_storage`,
-        // even for module-declared custom entities whose id is also a frozen system
-        // id — those are NEVER registered in `custom_entities` (install treats a
-        // system id as non-registrable). Without this fallback the query routes to
-        // the empty ORM/index path and those records are write-only (created with
-        // 200 but unreadable on the edit form).
-        result = await this.hasCustomEntityStorageRows(entity)
+        const db = this.getDb() as any
+        const row = await db
+          .selectFrom('custom_entities')
+          .select('id')
+          .where('entity_id', '=', entity)
+          .where('is_active', '=', true)
+          .executeTakeFirst()
+        if (row) {
+          result = true
+        } else {
+          // Read/write symmetry. Records written through the entities data engine
+          // (`de.createCustomEntityRecord`) always land in `custom_entities_storage`,
+          // even for module-declared custom entities whose id is also a frozen system
+          // id — those are NEVER registered in `custom_entities` (install treats a
+          // system id as non-registrable). Without this fallback the query routes to
+          // the empty ORM/index path and those records are write-only (created with
+          // 200 but unreadable on the edit form).
+          result = await this.hasCustomEntityStorageRows(entity)
+        }
       }
     } catch {
       result = false

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -889,13 +889,17 @@ export class HybridQueryEngine implements QueryEngine {
         total = this.parseCount(countRow)
       }
 
+      const hasFilterInput = normalizedFilters.length > 0 || (
+        !!opts.filters &&
+        typeof opts.filters === 'object' &&
+        (!Array.isArray(opts.filters) || opts.filters.length > 0) &&
+        (Array.isArray(opts.filters) || Object.keys(opts.filters as Record<string, unknown>).length > 0)
+      )
       if (
         total === 0 &&
-        wantsCf &&
-        normalizedFilters.length > 0 &&
+        hasFilterInput &&
         cfFilters.length === 0 &&
-        searchFilters.length === 0 &&
-        !partialIndexWarning
+        searchFilters.length === 0
       ) {
         const fallbackResult = await this.fallback.query<T>(entity, opts)
         const fallbackTotal = typeof fallbackResult?.total === 'number'

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -939,6 +939,37 @@ export class HybridQueryEngine implements QueryEngine {
         () => dataBuilder.execute(),
         { page, pageSize }, profiler,
       )
+      const expectedPageHasRows = total > 0 && (page - 1) * pageSize < total
+      if (
+        expectedPageHasRows &&
+        Array.isArray(itemsRaw) &&
+        itemsRaw.length === 0 &&
+        hasFilterInput &&
+        cfFilters.length === 0 &&
+        searchFilters.length === 0
+      ) {
+        const fallbackResult = await this.fallback.query<T>(entity, opts)
+        const fallbackItems = Array.isArray(fallbackResult?.items) ? fallbackResult.items.length : 0
+        const fallbackTotal = typeof fallbackResult?.total === 'number'
+          ? fallbackResult.total
+          : fallbackItems
+        if (fallbackItems > 0 || fallbackTotal > 0) {
+          console.warn('[HybridQueryEngine] Hybrid query returned an empty page while fallback found matches; falling back to basic engine:', {
+            entity,
+            total,
+            fallbackTotal,
+            page,
+            pageSize,
+          })
+          if (debugEnabled) this.debug('query:fallback:false-empty-page', { entity, total, fallbackTotal, page, pageSize })
+          finishProfile({
+            result: 'fallback',
+            reason: 'hybrid_false_empty_page',
+            total: fallbackTotal,
+          })
+          return await applyAfterExtensions(fallbackResult)
+        }
+      }
       if (debugEnabled) this.debug('query:complete', { entity, total, items: Array.isArray(itemsRaw) ? itemsRaw.length : 0 })
 
       let items = itemsRaw as any[]


### PR DESCRIPTION
## Summary

Fixes a deals pipeline/list consistency issue where a base-table entity can be misclassified as doc-storage-backed when stray custom entity registry/storage rows exist for the same entity id. In that state, aggregate counts can still be correct while list/card reads return empty pages because they are routed through custom entity storage instead of the entity base table.

Also tightens the deals kanban pagination contract and updates the lost-deal summary heading so saved loss notes are shown under a matching label.

## Root cause

`HybridQueryEngine.isCustomEntity()` could treat an entity id as custom-storage-backed before proving that a real base table exists for that id. For table-backed entities, that allowed unrelated custom entity registry/storage rows to hijack standard list/detail queries.

## User impact

Users could see non-zero pipeline totals while lane cards or paginated list results appeared empty. In the lost-deal flow, saved loss notes could be displayed under a generic heading that did not match the form label.

## Changes

- Prefer an existing base table over custom entity registry/storage inference in `HybridQueryEngine`.
- Keep fallback coverage for false-zero and false-empty hybrid query pages.
- Add regression coverage for aggregate-vs-list consistency and paginated pipeline-stage reads.
- Keep kanban lane first page and `Show more` on the same filter semantics.
- Rename the lost-deal notes summary heading in locale files and cover it with a component test.

## Backward compatibility

Additive/behavioral fix only. No API paths, events, ACL ids, import paths, database columns, or persisted schemas are renamed or removed. `forceCustomEntityStorage` remains the explicit path for surfaces that intentionally read doc-storage records for dual-declared ids.

## Verification

Passed:

```bash
corepack yarn workspace @open-mercato/core test \
  packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts \
  packages/core/src/modules/customers/api/deals/aggregate/__tests__/route.test.ts \
  packages/core/src/modules/customers/api/deals/__tests__/route.filters.test.ts \
  packages/core/src/modules/customers/components/detail/__tests__/DealLostSummaryDialog.test.tsx \
  packages/core/src/modules/customers/components/detail/__tests__/ConfirmDealLostDialog.test.tsx
```

Result: 5 suites passed, 50 tests passed.

Additional check:

```bash
corepack yarn workspace @open-mercato/core typecheck
```

This currently stops before type-checking changed code with `tsconfig.json(7,27): error TS5103: Invalid value for '--ignoreDeprecations'.`
