### PR TITLE
docs(customers): spec — configurable CRM interaction (task) statuses

### DIFF
--- a/.ai/specs/2026-06-18-configurable-crm-interaction-statuses.md
+++ b/.ai/specs/2026-06-18-configurable-crm-interaction-statuses.md
@@ -1,0 +1,411 @@
+# Configurable CRM interaction (task) statuses
+
+> Status: DRAFT (ready for review)
+> Scope: OSS · Module: `customers` (`packages/core`)
+> Date: 2026-06-18
+
+## TLDR
+
+CRM tasks are `customer_interactions`. Their `status` is today a hardcoded enum
+`interactionStatusValues = ['planned', 'done', 'canceled']`
+(`packages/core/src/modules/customers/data/validators.ts:381`) wired into `z.enum(...)`. Tenants
+cannot add or rename statuses. This spec makes interaction statuses **dictionary-backed and
+UI-configurable per tenant**, reusing the existing `deal-statuses` mechanism — **Option A**: the
+editable list lives in a dictionary; the behaviorally-significant **open/terminal semantics** stay
+in code, centralized in one helper. The default seeded set grows from three to five: `planned`,
+`in_progress`, `waiting`, `done`, `canceled`.
+
+The non-obvious work is not the dictionary — that pattern already exists for deals. It is closing
+the **"open" semantic gap**: the codebase holds two competing definitions of an open interaction
+(`status NOT IN (terminal)` in the enricher vs. `status = 'planned'` in several other call sites).
+Adding `in_progress`/`waiting` means the positive `= 'planned'` filters would silently drop them.
+
+## Overview
+
+Deal statuses in the same module already flow through the `dictionaries` mechanism: a seeded
+`deal-statuses` dictionary, a management UI section, per-tenant editing, and lenient validation
+(`status: z.string().max(50)`). Interaction (task) statuses never received that treatment and remain
+a fixed enum. This spec brings interactions to parity with deals using the identical mechanism, and
+does the extra correctness work that interactions specifically require: a single open/terminal
+semantics helper and an audit of every call site that branches on interaction status.
+
+No new entity, no DB migration, no new ACL feature, no new event ID. The change is additive to a
+contract surface (`interactionStatusValues`) and is handled with a deprecation bridge.
+
+## Resolved decisions
+
+- **Q1 — Seeded set.** `planned, in_progress, waiting, done, canceled`. "Waiting / blocked" is a
+  single status (`value: waiting`, label "Waiting / blocked").
+- **Q2 — Unknown/custom status bucket.** A status not known to code counts as **open /
+  non-terminal** (appears in the open-activities badge, never auto-treated as completed). This is
+  the safe default and matches the enricher's existing exclusion filter.
+- **Q3 — Complete target.** `complete_task` / the UI "Complete" action keeps mapping to the single
+  canonical terminal-success status `done`. No change to the MCP, no per-status complete picker.
+- **Validation is lenient**, mirroring `deal_status` (`validators.ts:147`,
+  `status: z.string().max(50).optional()`). The `interaction-statuses` dictionary drives the UI
+  dropdown only; the API accepts any string ≤50 chars (no strict 422). Keeps BC for existing rows /
+  external writers and keeps the `dispatch-crm` MCP working unchanged.
+
+## Problem statement
+
+`customer_interactions.status` is a fixed three-value enum. Operators who run follow-ups through the
+CRM cannot model an in-progress or waiting-on-customer task; every task is either open (`planned`) or
+closed (`done`/`canceled`). Statuses are not editable from the UI, unlike deal statuses. Extending
+the enum in code would not make it configurable and would still require a redeploy per change.
+
+## Proposed solution (Option A)
+
+Introduce an `interaction-statuses` dictionary, identical in mechanism to `deal-statuses`:
+
+- Storage kind `interaction_status` (underscore), route/UI kind `interaction-statuses` (hyphen),
+  bridged in `KIND_MAP` (`api/dictionaries/context.ts:48`). No new entity or migration — dictionary
+  `kind` is a free-text column on the reused `customer_dictionary_entries` table.
+- Seed defaults via `INTERACTION_STATUS_DEFAULTS` consumed inside `seedCustomerDictionaries`
+  (`cli.ts:1101`), exactly like `DEAL_STATUS_DEFAULTS` (`cli.ts:56`).
+- Validators stop using `z.enum(...)` and become lenient `z.string().max(50)`.
+- Open/terminal semantics move out of the private enricher constant into one shared helper
+  (`lib/interactionStatus.ts`) that every call site reads. The enricher's existing
+  `status NOT IN (terminal)` already does the right thing for unknown statuses; the gap is the
+  positive `= 'planned'` call sites, which broaden to the shared "open" predicate.
+- `complete` still sets `done`, `cancel` still sets `canceled`, undo still reverts to the snapshot
+  (`planned`). Unchanged.
+- The deal-style management UI section ("Interaction statuses") is added to `DictionarySettings` and
+  `DictionarySortSettings`, gated by the existing `customers.settings.manage` feature (no new ACL).
+
+This is intentionally a thin feature: it reuses the dictionary CRUD, routes, cache, hook, and
+management components wholesale. The spec documents only the parts unique to interactions.
+
+## Architecture
+
+- **Module isolation.** Everything lives inside `customers`. No cross-module ORM relation, no
+  cross-module import. The dictionary is the same `customer_dictionary_entries` table already used
+  for deal statuses, scoped by `(organization_id, tenant_id, kind)`.
+- **DI / commands.** No new service and no new command. Interaction writes keep going through the
+  existing undoable commands (`customers.interactions.{create,update,complete,cancel,delete}`); the
+  dictionary writes keep going through the existing `customers.dictionaryEntries.{create,update,delete}`
+  commands. This spec only changes which `kind` they accept and the validator on the `status` field.
+- **Semantics boundary.** The one piece of genuinely new logic — "which status means open vs
+  closed" — is isolated in `lib/interactionStatus.ts` so there is a single source of truth rather
+  than the current scatter of literals.
+
+## Data model
+
+No schema change. Reused tables (`data/entities.ts`):
+
+- `customer_dictionary_entries` (`entities.ts:888`) — stores `(kind='interaction_status', value,
+  label, color, icon)` per `(organizationId, tenantId)`. Unique on
+  `(organizationId, tenantId, kind, normalizedValue)`.
+- `customer_dictionary_kind_settings` (`entities.ts:1060`) — optional per-kind sort/selection
+  settings, created on demand (not seeded), same as deals.
+- `customer_interactions.status` (`entities.ts:599`) — unchanged `text default 'planned'` column.
+  It already accepts arbitrary strings at the DB level; only the application validator changes.
+
+## API contracts
+
+No new route files. Affected/reused contracts:
+
+- **Dictionary CRUD (reused as-is).**
+  `GET/POST /api/customers/dictionaries/interaction-statuses` and
+  `PATCH/DELETE /api/customers/dictionaries/interaction-statuses/{id}`. Served by the existing
+  `api/dictionaries/[kind]/route.ts` once the kind is registered (`BUILTIN_DICTIONARY_ROUTE_KINDS`,
+  `KIND_MAP`, `DICTIONARY_KINDS`, `CUSTOMER_DICTIONARY_KINDS`). Guards unchanged: `GET` requires
+  `customers.people.view`, writes require `customers.settings.manage`. `openApi` already exported by
+  that route. Response shape unchanged (`{ sortMode, items: [{ id, value, label, color, icon, … }] }`).
+- **Interaction create/update (validator widened).**
+  `POST/PUT /api/customers/interactions` — `status` validator goes from
+  `z.enum(interactionStatusValues)` to `z.string().max(50)` (`validators.ts:424` keeps
+  `.default('planned')`; `:491` stays optional). Widening only; no request/response shape change.
+- **Complete / cancel (unchanged).** `POST /api/customers/interactions/complete` → `done`;
+  `…/cancel` → `canceled`. No contract change.
+- **Counts (param reframed, BC-preserving).** `GET /api/customers/interactions/counts` — the
+  `status` query param (`route.ts:15`, today `z.enum(['done','planned'])`) gains an `open` value
+  meaning "not terminal"; `planned` is retained as an accepted alias.
+
+## Status semantics — single source of truth
+
+New module file `packages/core/src/modules/customers/lib/interactionStatus.ts`:
+
+```ts
+// Built-in interaction status values known to code. Tenants may add more via the
+// `interaction-statuses` dictionary; unknown values are treated as OPEN (Q2).
+export const INTERACTION_STATUS_COMPLETED = 'done' as const   // canonical terminal-success
+export const INTERACTION_STATUS_CANCELED = 'canceled' as const
+export const INTERACTION_STATUS_PLANNED = 'planned' as const
+
+// Terminal = closed. 'completed' is a legacy spelling accepted defensively (see enrichers.ts:25).
+const TERMINAL_INTERACTION_STATUSES = new Set(['done', 'canceled', 'completed'])
+
+export function isTerminalInteractionStatus(value: string | null | undefined): boolean {
+  return value != null && TERMINAL_INTERACTION_STATUSES.has(value)
+}
+export function isOpenInteractionStatus(value: string | null | undefined): boolean {
+  return !isTerminalInteractionStatus(value)
+}
+export const TERMINAL_INTERACTION_STATUS_LIST = [...TERMINAL_INTERACTION_STATUSES]
+```
+
+`data/enrichers.ts:27` deletes its private `TERMINAL_INTERACTION_STATUSES` and imports
+`TERMINAL_INTERACTION_STATUS_LIST` for its `status NOT IN (...)` query (`enrichers.ts:66`).
+`isStuck`/`isOverdue` are unaffected (they never read interaction status).
+
+## The "open" call-site decision table
+
+Every site that encodes open-vs-terminal is reviewed. SQL `= 'planned'` that means "open" broadens
+to "not terminal"; truly-planned-only intent stays.
+
+| Call site | Today | Decision |
+|---|---|---|
+| `data/enrichers.ts:66` (open-activities badge) | `status NOT IN ('done','canceled','completed')` | Keep; source the list from the helper. Already correct for new/custom statuses. |
+| `lib/interactionProjection.ts:35` (next-interaction projection → search/denormalized) | `status = 'planned'` | **Broaden to open** — a started/blocked task is still the next step. |
+| `api/interactions/conflicts/route.ts:103` (scheduling conflicts) | `status = 'planned'` | **Broaden to open** — an in-progress/waiting scheduled item still conflicts. |
+| `api/people/[id]/route.ts:560`, `api/companies/[id]/route.ts:528` (upcoming non-task activities) | `status === 'planned' && type !== 'task'` | **Broaden to open** non-task activities. |
+| `api/interactions/counts/route.ts:15` (count param `z.enum(['done','planned'])`) | planned vs done | Reframe param to `open` vs `done`; `open` counts non-terminal. Keep `planned` as an accepted alias for BC. |
+| UI "Mark done" affordance: `ActivityTimeline.tsx:86`, `ActivityCard.tsx:200`, `TasksSection.tsx`, `PlannedActivitiesSection.tsx`, `NextStepCard.tsx`, `OpenTasksWidget.tsx` | show when `status === 'planned'` | **Broaden to `isOpenInteractionStatus`** so in_progress/waiting tasks can still be completed. |
+| `ActivitiesCard.tsx:71,256` overdue predicate (`status !== 'done'`) | not-done + past schedule | Switch the `!== 'done'` half to `isOpenInteractionStatus` for canceled-correctness. |
+| `commands/interactions.ts:922` (`'done'`), `:1062` (`'canceled'`) | hardcoded transitions | Keep; reference helper constants instead of literals. |
+| `lib/link-channel-message-handler.ts:488` (`status:'done'` for logged emails) | hardcoded | Keep; reference `INTERACTION_STATUS_COMPLETED`. |
+
+## Dictionary wiring (mirror of deal-statuses)
+
+1. `cli.ts` — add `INTERACTION_STATUS_DEFAULTS` and a seed loop in `seedCustomerDictionaries`
+   (storage kind `interaction_status`):
+   ```ts
+   export const INTERACTION_STATUS_DEFAULTS: DictionaryDefault[] = [
+     { value: 'planned',     label: 'Planned',           color: '#2563eb', icon: 'lucide:circle' },
+     { value: 'in_progress', label: 'In progress',       color: '#f59e0b', icon: 'lucide:activity' },
+     { value: 'waiting',     label: 'Waiting / blocked', color: '#a855f7', icon: 'lucide:pause-circle' },
+     { value: 'done',        label: 'Done',              color: '#22c55e', icon: 'lucide:check-circle' },
+     { value: 'canceled',    label: 'Canceled',          color: '#6b7280', icon: 'lucide:x-circle' },
+   ]
+   ```
+   (`color` is dictionary data stored in the DB and mapped to a DS tone at render via
+   `mapDictionaryColorToTone`, exactly like `DEAL_STATUS_DEFAULTS` — it is not a Tailwind class.)
+2. `commands/shared.ts:142-155` — add `'interaction_status'` to the `DICTIONARY_KINDS` allow-set so
+   `ensureDictionaryEntry` and the CRUD commands accept it.
+3. `api/dictionaries/context.ts` — add `'interaction-statuses'` to `BUILTIN_DICTIONARY_ROUTE_KINDS`
+   (`:12`) and `'interaction-statuses': 'interaction_status'` to `KIND_MAP` (`:42`).
+4. `lib/dictionaries.ts:14` — add `'interaction-statuses'` to `CUSTOMER_DICTIONARY_KINDS`.
+5. `components/DictionarySettings.tsx:52` and `components/DictionarySortSettings.tsx:46` — add the
+   `{ kind: 'interaction-statuses', title, description }` section objects + i18n keys.
+
+## UI rendering
+
+Switch interaction/task status rendering from the three flat i18n keys + inline conditionals to the
+dictionary map, mirroring deals (`createDictionarySelectLabels('deal-statuses')`, `StatusBadge` with
+`mapDictionaryColorToTone`). Surfaces: `TasksSection.tsx`, `ActivityCard.tsx`, `ActivityTimeline.tsx`,
+and any task list/detail that shows a status. The task create/edit form (a `CrudForm`) gains a status
+`<select>` populated from the fetched dictionary options (today there is no status picker for tasks).
+DS: `StatusBadge` + semantic tones only, no hardcoded status colors; the form is a `CrudForm`, so
+`Cmd/Ctrl+Enter` submit and `Escape` cancel are inherited.
+
+The legacy flat keys `customers.interactions.status.{planned,done,canceled}` stay as fallback labels
+for any surface not yet dictionary-driven; the stored, tenant-editable dictionary label takes
+precedence when present, same as deals.
+
+## AI tool pack
+
+`ai-tools/activities-tasks-pack.ts:241` filters interactions by `z.enum(['open','done','cancelled'])`
+and maps `open → planned`, `done → 'completed'`. With the open-set redefinition, `open` maps to "not
+terminal" (now including `in_progress`/`waiting`); the enum may additionally accept `in_progress`/
+`waiting` as explicit filters. This also fixes a pre-existing spelling divergence (the pack writes
+`'completed'`/`'cancelled'` while rows store `'done'`/`'canceled'`). Additive.
+
+## MCP follow-up (out of scope for code)
+
+The `dispatch-crm` MCP server lives in a separate repo. `create_task` (→ `planned`) and
+`complete_task` (→ `done`) keep working unchanged. Setting `in_progress`/`waiting`/`canceled` from
+the agent needs new `update_task`/`set_task_status` tools there — tracked as a follow-up in that
+repo, not delivered here.
+
+## Backward compatibility & migration
+
+- **`interactionStatusValues` / `InteractionStatus` export** (`validators.ts:381-382`) — STABLE
+  contract surface. **Keep contents unchanged (3 values)** and mark `@deprecated` with a pointer to
+  the new helper + dictionary. Do not repurpose it as the validation source; do not expand its
+  members (avoids breaking exhaustive `switch`/union consumers). New code uses
+  `lib/interactionStatus.ts` and the dictionary.
+- **Validators** switch `z.enum(interactionStatusValues)` → `z.string().max(50)` at
+  `validators.ts:424` (keep `.default('planned')`) and `:491`. Widening — non-breaking.
+- **Existing rows** already hold `planned`/`done`/`canceled`, equal to seeded dictionary values — no
+  row rewrite required for the common case.
+- **Legacy `completed` rows** (the spelling the enricher tolerates): optional one-time backfill
+  `completed → done`. The helper keeps tolerating `completed` regardless, so this is cleanup, not a
+  correctness requirement.
+- **Existing tenants** need the new dictionary seeded. Add an idempotent upgrade action in
+  `configs/lib/upgrade-actions.ts` (per `packages/core/AGENTS.md` → Upgrade Actions) that runs the
+  same `ensureDictionaryEntry` seed for `interaction_status` across tenants. New tenants get it via
+  `seedDefaults`.
+- **No DB migration**, no new ACL feature, no event-ID change.
+
+## Phasing
+
+Each phase leaves the app working and shippable.
+
+**Phase 1 — Semantics helper + enricher refactor (no behavior change).** Introduce
+`lib/interactionStatus.ts`; replace the private enricher constant and the hardcoded transition
+literals in commands / link-channel handler with helper references. Pure refactor, covered by
+existing tests.
+
+**Phase 2 — Close the open-set gap.** Broaden the `= 'planned'` call sites per the decision table to
+`isOpenInteractionStatus` / `NOT IN terminal`. This is the behavior change that makes
+`in_progress`/`waiting` first-class once they exist. Add coverage for "in-progress task still appears
+as next step / open count / mark-done affordance".
+
+**Phase 3 — Dictionary + seed + validators.** Add `INTERACTION_STATUS_DEFAULTS`, the seed loop, the
+`DICTIONARY_KINDS`/`KIND_MAP`/`BUILTIN_DICTIONARY_ROUTE_KINDS`/`CUSTOMER_DICTIONARY_KINDS` entries,
+and switch validators to lenient. After this, the five statuses are selectable and the API accepts
+them.
+
+**Phase 4 — Management UI + task status picker + rendering.** Add the "Interaction statuses"
+sections to `DictionarySettings`/`DictionarySortSettings`, add the status `<select>` to the task
+form, switch task/activity status rendering to the dictionary map + `StatusBadge`. i18n keys for the
+new section titles.
+
+**Phase 5 — Existing-tenant backfill + AI tool + deprecation.** Upgrade action to seed the dictionary
+for existing tenants; optional `completed → done` cleanup; widen + spelling-align the AI tool status
+filter; add `@deprecated` to `interactionStatusValues`.
+
+## Implementation plan
+
+> Format: step → verify.
+
+### Phase 1
+1. Create `lib/interactionStatus.ts` with the helper + constants → unit test
+   `isTerminalInteractionStatus`/`isOpenInteractionStatus` for all five seeded + an unknown value.
+2. Refactor `data/enrichers.ts` to import `TERMINAL_INTERACTION_STATUS_LIST` → existing enricher
+   tests pass; `yarn workspace @open-mercato/core test`.
+3. Replace literal `'done'`/`'canceled'`/`'planned'` in `commands/interactions.ts:393,922,1062` and
+   `lib/link-channel-message-handler.ts:488` with helper constants → TC-UNDO-001 still green.
+
+### Phase 2
+4. Broaden `lib/interactionProjection.ts:35`, `api/interactions/conflicts/route.ts:103`,
+   `api/people/[id]/route.ts:560`, `api/companies/[id]/route.ts:528` to the open predicate → unit
+   tests asserting an `in_progress` row is included.
+5. Broaden the count param in `api/interactions/counts/route.ts:15` (`open` bucket = non-terminal,
+   `planned` alias retained) → route test.
+6. Broaden UI "mark done" predicates to `isOpenInteractionStatus` → component/render test.
+
+### Phase 3
+7. Add `INTERACTION_STATUS_DEFAULTS` + seed loop in `cli.ts` → seed test asserts five entries under
+   kind `interaction_status` (extend `seedDictionaryScope.test.ts`).
+8. Register the kind in `commands/shared.ts`, `api/dictionaries/context.ts`, `lib/dictionaries.ts`
+   → `GET /api/customers/dictionaries/interaction-statuses` returns the five entries (integration).
+9. Switch `validators.ts:424,491` to `z.string().max(50)` → validator unit test accepts
+   `in_progress`; create/update integration test sets and reads back `in_progress`.
+
+### Phase 4
+10. Add management sections to `DictionarySettings.tsx` + `DictionarySortSettings.tsx` + i18n keys →
+    settings page renders an editable "Interaction statuses" list.
+11. Add a status `<select>` (dictionary options) to the task create/edit form → create a task as
+    `waiting` from the UI, integration test.
+12. Render task/activity status via the dictionary map + `StatusBadge` → ds-guardian pass, no
+    hardcoded status colors.
+
+### Phase 5
+13. Upgrade action in `configs/lib/upgrade-actions.ts` seeding `interaction_status` for existing
+    tenants (idempotent) → run twice, second run is a no-op.
+14. Optional backfill `completed → done`; widen + spelling-align the AI tool filter; add
+    `@deprecated` JSDoc to `interactionStatusValues` → typecheck, i18n check.
+
+## Integration & test coverage
+
+Per-feature coverage is mandatory (root `AGENTS.md`). New/updated tests, self-contained (create
+fixtures via API, clean up in teardown):
+
+- **API paths**
+  - `GET /api/customers/dictionaries/interaction-statuses` → five seeded entries; create/update/
+    delete a custom status via `POST/PATCH/DELETE`.
+  - `POST/PUT /api/customers/interactions` → set and read back `in_progress` and a custom status.
+  - `POST /api/customers/interactions/complete` → `done`; `…/cancel` → `canceled`; undo reverts to
+    `planned` (extend **TC-UNDO-001**).
+  - `GET /api/customers/interactions/counts` → `open` bucket includes an `in_progress` row.
+  - Deal open-activities enricher: a deal with one `in_progress` interaction shows
+    `openActivitiesCount = 1`.
+- **UI paths**
+  - Task create form: create a `waiting` task; status badge renders the dictionary label/color.
+  - "Mark done" affordance present on an `in_progress` task and completes it to `done`.
+  - Settings: "Interaction statuses" section lists and edits entries.
+- **Unit**
+  - `lib/interactionStatus.ts` predicates; seed defaults; validator widening.
+
+## Risks & Impact Review
+
+| # | Scenario | Severity | Affected area | Mitigation | Residual |
+|---|----------|----------|---------------|------------|----------|
+| R1 | Split-brain "open" definitions: `in_progress`/`waiting` counted open by the enricher but dropped by a `= 'planned'` filter, so a started task vanishes from "next step" / conflicts / mark-done. | High (correctness) | enricher badge, next-step projection, scheduling conflicts, task UI affordances | Single helper as source of truth; Phase 2 audits every site via the decision table; a unit test enumerates the seeded set so any future built-in addition forces a conscious open/terminal classification. | Low — custom statuses default to open (safe). |
+| R2 | Lenient validation lets a typo (`donee`) persist as a status. | Low | data quality | Dictionary dropdown is the practical UI guard; a typo counts as open, so it stays visible rather than silently closing. Matches deal-status behavior. | Low (accepted, parity with deals). |
+| R3 | Existing tenant has no seeded `interaction_status` dictionary → empty status dropdown until the upgrade action runs. | Medium (UX) | settings + task form for existing tenants | Phase 5 idempotent upgrade action seeds all tenants; lenient validation keeps the API working meanwhile; helper defaults keep open/terminal correct regardless of dictionary presence. | Low. |
+| R4 | AI tool status filter spelling divergence (`'completed'`/`'cancelled'` double-L vs stored `'done'`/`'canceled'`) — pre-existing. | Low | AI agent task filtering | Phase 5 widens and spelling-aligns the filter; the terminal helper tolerates `'completed'`. | Low (pre-existing, not introduced here). |
+| R5 | Legacy `completed` rows misclassified. | Low | a small number of legacy rows | Helper treats `completed` as terminal; optional one-time backfill to `done`. | Negligible. |
+
+**Blast radius.** Confined to the `customers` module. No DB migration, no cross-module contract
+change beyond the deprecated `interactionStatusValues` export. **Operational detection.** Existing
+enricher + TC-UNDO-001 tests plus the new unit/integration tests; TypeScript surfaces any
+helper/validator drift at build time.
+
+## Out of scope
+
+- `dispatch-crm` MCP tools for arbitrary status transitions (separate repo; follow-up).
+- Per-status semantic metadata editable by tenants (that was Option B; rejected for cost).
+- Workflow/automation triggers on specific interaction statuses.
+
+## Final Compliance Report — 2026-06-18
+
+### AGENTS.md files reviewed
+- `AGENTS.md` (root)
+- `packages/core/AGENTS.md`
+- `packages/core/src/modules/customers/AGENTS.md`
+- `packages/ui/AGENTS.md`
+- `.ai/ds-rules.md` + `.ai/ui-components.md`
+- `.ai/specs/AGENTS.md`
+
+### Compliance Matrix
+
+| Rule Source | Rule | Status | Notes |
+|-------------|------|--------|-------|
+| root AGENTS.md | No direct ORM relationships between modules | Compliant | All changes within `customers`; dictionary is same-module. |
+| root AGENTS.md | Filter by `organization_id` | Compliant | Dictionary entries and the enricher query are org/tenant scoped (unchanged). |
+| root AGENTS.md | Optimistic locking on new user-editable entities | N/A | No new entity; status is a column on the existing interaction. |
+| root AGENTS.md (Design System) | No hardcoded status colors / arbitrary sizes; semantic tokens | Compliant | Render via `StatusBadge` + `mapDictionaryColorToTone`. Seeded hex `color`s are dictionary data (DB), not Tailwind classes — same as `DEAL_STATUS_DEFAULTS`. |
+| `.ai/ds-rules.md` + `.ai/ui-components.md` | Shared primitives; dialog `Cmd/Ctrl+Enter`+`Escape`; `aria-label` | Compliant | Status badge via `StatusBadge`; status picker is in a `CrudForm` (inherits dialog keys). |
+| packages/core/AGENTS.md → API Routes | CRUD routes use `makeCrudRoute` + `indexer`; routes export `openApi` | Compliant | No new routes. Interactions route already uses `makeCrudRoute` + `indexer`; dictionary `[kind]` route already exports `openApi`. |
+| packages/core/AGENTS.md → Encryption | Sensitive/GDPR fields use `encryption.ts` + `findWithDecryption` | N/A | `status` is not PII; no new sensitive column. |
+| packages/core/AGENTS.md → Commands/Undo | Mutations via commands; undo specified | Compliant | Reuses existing undoable interaction + dictionary commands; no new mutation. |
+| packages/ui/AGENTS.md | Forms use `CrudForm`; HTTP via `apiCall`; non-`CrudForm` writes use `useGuardedMutation` | Compliant | Status select added to existing `CrudForm`; reads via existing dictionary hook/`apiCall`. No raw `fetch`. |
+| packages/cache/AGENTS.md | Cache via DI; tenant-scoped tags | Compliant | Reuses the existing dictionary read cache (tenant-tagged); no new cache path. |
+| packages/events/AGENTS.md | Cross-module side effects via `createModuleEvents` | N/A / Compliant | No new cross-module effect; existing interaction events unchanged. |
+| BACKWARD_COMPATIBILITY.md | Contract-surface changes follow deprecation protocol | Compliant | `interactionStatusValues` kept + `@deprecated`; validator widening is non-breaking; counts param keeps `planned` alias. |
+| om-spec-writing heuristic #9 | Frontend Architecture Contract for app/** / heavy widgets | N/A | Reuses existing client components (dictionary select, `StatusBadge`); no new provider, bundle, or heavy widget. |
+| `.ai/specs/AGENTS.md` | `{date}-{title}.md`, no `SPEC-*` prefix, required sections | Compliant | Filename `2026-06-18-configurable-crm-interaction-statuses.md`; required sections present. |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Data models match API contracts | Pass | No schema change; lenient validator matches the "accept any string" contract. |
+| API contracts match UI/UX section | Pass | Status `<select>` and badge both read the dictionary map. |
+| Risks cover all write operations | Pass | create/update/complete/cancel covered; lenient-write risk noted (R2). |
+| Commands defined for all mutations | Pass | Reuses existing interaction + dictionary commands; no new mutation. |
+| Cache strategy covers all read APIs | Pass | Dictionary reads reuse existing tenant-tagged cache; enricher query unchanged. |
+
+### Non-Compliant Items
+None.
+
+### Verdict
+**Fully compliant — approved for implementation.** Recommend running `om-pre-implement-spec` (BC
+audit + gap analysis) before Phase 1, given the contract-surface touch on `interactionStatusValues`.
+
+## Changelog
+
+- **2026-06-18** — Spec drafted (Option A: dictionary-backed interaction statuses). Open Questions
+  gate resolved: Q1 single `waiting`; Q2 unknown→open; Q3 complete→`done`; lenient validation per
+  the deal-status precedent.
+
+### Review — 2026-06-18
+- **Reviewer**: Agent
+- **Security**: Passed (no new auth surface; reuses `customers.settings.manage`; status not PII)
+- **Performance**: Passed (reuses indexed dictionary reads + the existing enricher query; no new N+1)
+- **Cache**: Passed (reuses the existing tenant-tagged dictionary cache)
+- **Commands**: Passed (no new mutation; reuses existing undoable commands)
+- **Risks**: Passed (split-brain open-definition is the tracked primary risk R1, mitigated by Phase 2 + the helper)
+- **Verdict**: Approved — ready for implementation (recommend `om-pre-implement-spec` first)

--- a/.ai/specs/2026-06-18-configurable-crm-interaction-statuses.md
+++ b/.ai/specs/2026-06-18-configurable-crm-interaction-statuses.md
@@ -281,6 +281,15 @@ filter; add `@deprecated` to `interactionStatusValues`.
 4. Broaden `lib/interactionProjection.ts:35`, `api/interactions/conflicts/route.ts:103`,
    `api/people/[id]/route.ts:560`, `api/companies/[id]/route.ts:528` to the open predicate → unit
    tests asserting an `in_progress` row is included.
+   - **Query-index consistency (R6):** broadening the next-interaction projection changes the
+     denormalized `next_interaction_*` fields on `customer_entities` (query-indexed). The path MUST
+     keep emitting `query_index.upsert_one` for affected entities so global search / token filters do
+     not go stale (per `.ai/lessons.md` → "Projection updates that change indexed parent fields must
+     emit query-index upserts"). Add an integration assertion that an `in_progress` interaction
+     updates the indexed `next_interaction_*`.
+   - **Ordering (R7):** define the "next step" ordering explicitly now that non-scheduled open
+     statuses (in_progress/waiting) can enter the projection — the projection orders by `scheduledAt`,
+     so decide scheduled-first then `createdAt`, and unit-test the mixed (NULL `scheduledAt`) case.
 5. Broaden the count param in `api/interactions/counts/route.ts:15` (`open` bucket = non-terminal,
    `planned` alias retained) → route test.
 6. Broaden UI "mark done" predicates to `isOpenInteractionStatus` → component/render test.
@@ -337,6 +346,8 @@ fixtures via API, clean up in teardown):
 | R3 | Existing tenant has no seeded `interaction_status` dictionary → empty status dropdown until the upgrade action runs. | Medium (UX) | settings + task form for existing tenants | Phase 5 idempotent upgrade action seeds all tenants; lenient validation keeps the API working meanwhile; helper defaults keep open/terminal correct regardless of dictionary presence. | Low. |
 | R4 | AI tool status filter spelling divergence (`'completed'`/`'cancelled'` double-L vs stored `'done'`/`'canceled'`) — pre-existing. | Low | AI agent task filtering | Phase 5 widens and spelling-aligns the filter; the terminal helper tolerates `'completed'`. | Low (pre-existing, not introduced here). |
 | R5 | Legacy `completed` rows misclassified. | Low | a small number of legacy rows | Helper treats `completed` as terminal; optional one-time backfill to `done`. | Negligible. |
+| R6 | Broadening the next-interaction projection (Phase 2) changes query-indexed `next_interaction_*` on `customer_entities` without an index upsert → grids show fresh values but global search / token filters stay stale. | Medium (search/list consistency) | `customer_entities` next-step fields, search/token index | Emit `query_index.upsert_one` for affected entities in the same path (per `.ai/lessons.md`); integration-assert that an in_progress interaction updates the indexed fields. | Low. |
+| R7 | Next-interaction ordering when in_progress/waiting lack `scheduledAt` (projection orders by `scheduledAt`). | Low | "next step" selection on contacts | Define ordering explicitly (scheduled-first, then `createdAt`); unit-test the NULL-`scheduledAt` case. | Low. |
 
 **Blast radius.** Confined to the `customers` module. No DB migration, no cross-module contract
 change beyond the deprecated `interactionStatusValues` export. **Operational detection.** Existing
@@ -400,6 +411,10 @@ audit + gap analysis) before Phase 1, given the contract-surface touch on `inter
 - **2026-06-18** — Spec drafted (Option A: dictionary-backed interaction statuses). Open Questions
   gate resolved: Q1 single `waiting`; Q2 unknown→open; Q3 complete→`done`; lenient validation per
   the deal-status precedent.
+- **2026-06-18** — Pre-implementation analysis run (see
+  `.ai/specs/analysis/ANALYSIS-2026-06-18-configurable-crm-interaction-statuses.md`): verdict **ready
+  to implement**, no BC blockers, no test breakage. Folded R6 (query-index upsert on projection
+  broadening) and R7 (next-interaction ordering) into Phase 2 and the risk table.
 
 ### Review — 2026-06-18
 - **Reviewer**: Agent

--- a/.ai/specs/analysis/ANALYSIS-2026-06-18-configurable-crm-interaction-statuses.md
+++ b/.ai/specs/analysis/ANALYSIS-2026-06-18-configurable-crm-interaction-statuses.md
@@ -1,0 +1,132 @@
+# Pre-Implementation Analysis: Configurable CRM interaction (task) statuses
+
+> Spec: `.ai/specs/2026-06-18-configurable-crm-interaction-statuses.md`
+> PR #3231 · Issue #3230 · Date: 2026-06-18 · Scope: `customers` (`packages/core`)
+
+## Executive Summary
+
+**Ready to implement.** No backward-compatibility blockers and **no existing test breaks** from any
+of the four mechanical changes (validator widening, counts-param reframe, new dictionary kind,
+open-set broadening). The single highest-value front-loaded item is a query-index consistency
+requirement on the Phase 2 projection broadening (from `.ai/lessons.md`): when the next-interaction
+projection starts including `in_progress`/`waiting`, it must keep emitting `query_index.upsert_one`
+for the affected `customer_entities`, or search/token filters go stale. Recommendation: fold three
+implementation notes into the spec, then proceed.
+
+## Backward Compatibility
+
+All 13 contract surfaces checked. Only one surface is touched, and the spec already handles it.
+
+### Violations Found
+| # | Surface | Issue | Severity | Proposed Fix |
+|---|---------|-------|----------|-------------|
+| 1 | (2) Type definitions | `interactionStatusValues` / `InteractionStatus` (validators.ts:381-382) stop being the validation source | Warning | **Already in spec** — keep both exported, add `@deprecated`, do not remove or change contents. Compliant with the deprecation protocol. |
+| 2 | (1) `data/validators.ts` "MUST NOT remove or narrow existing schemas" | `status` goes `z.enum(...)` → `z.string().max(50)` | None (allowed) | This is a **widening** (accepts a superset). The rule forbids *narrowing*; widening is non-breaking and explicitly allowed. |
+| 3 | (7) API routes | `counts` route `status` param adds `open` | None (additive) | Keep `planned`/`done` accepted; add `open`. Additive per the API-route rules. `openApi` already exported (counts/route.ts:34). |
+| 4 | (8) DB schema | none | None | No column/table change; `status` stays `text`. |
+| 5 | (10) ACL feature IDs | none | None | Reuses `customers.settings.manage`; no new feature ID. |
+
+### Missing BC Section
+None. The spec has a "Backward compatibility & migration" section covering the deprecation bridge,
+the widening, row handling, the existing-tenant upgrade action, and "no DB migration / no new ACL".
+
+## Spec Completeness
+
+All required sections present (TLDR, Overview, Problem, Proposed Solution, Architecture, Data model,
+API contracts, Risks & Impact Review, Phasing, Implementation Plan, Integration Test Coverage, Final
+Compliance Report, Changelog).
+
+### Incomplete Sections
+| Section | Gap | Recommendation |
+|---------|-----|---------------|
+| Implementation Plan — Phase 2, step 4 | Broadening `interactionProjection.ts` changes which interactions feed the denormalized `next_interaction_*` fields on `customer_entities` (query-indexed). The step does not mention re-emitting the query index upsert. | Add: "preserve/verify `query_index.upsert_one` emission for affected `customer_entities` when the projection set changes (per `.ai/lessons.md` → 'Projection updates that change indexed parent fields must emit query-index upserts'). Verify ordering / NULL-`scheduledAt` handling now that non-scheduled open statuses (in_progress/waiting) can enter the projection." |
+| Risks & Impact Review | Two implementation-specific risks below are not yet listed (R6, R7). | Add them. |
+
+## AGENTS.md Compliance
+
+No violations. Spot checks:
+- **Canonical primitives** — reuses `makeCrudRoute` (interactions route already does), the existing
+  dictionary CRUD route/commands, `CrudForm` for the status picker, `StatusBadge` for rendering,
+  `apiCall` via the existing dictionary hook. No DIY substitutes.
+- **No raw writes** — the task status picker lives in `CrudForm`; per `.ai/lessons.md` → "Detail
+  sections must route writes through page-level guarded mutations", any non-`CrudForm` status write
+  from a detail section MUST use `useGuardedMutation`. Flag for the implementer (no current spec step
+  proposes a raw write).
+- **i18n** — new `<select>` option labels and the management-section titles must use `useT()` keys.
+  The hardcoded-string checker is advisory (exit 0) and excludes tests/i18n dirs, so it will not
+  fail CI, but house convention requires keys. Note in Phase 4.
+- **Design System** — `StatusBadge` + `mapDictionaryColorToTone`; seeded hex `color`s are dictionary
+  data (DB), not Tailwind classes — same as `DEAL_STATUS_DEFAULTS`. Compliant.
+- **Encryption** — N/A; `status` is not PII.
+- **Events / commands** — reuses existing undoable interaction commands and existing interaction
+  events (`completed`/`canceled`/`reverted`); no new event ID, no new mutation.
+
+## Risk Assessment
+
+### High Risks
+None.
+
+### Medium Risks
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| **R6 — Query-index staleness on projection broadening.** Broadening `interactionProjection.ts` to include in_progress/waiting changes `next_interaction_*` on `customer_entities` without an index upsert → grids show fresh values but global search / token filters stay stale (the exact failure in `.ai/lessons.md`). | Search/list inconsistency for the next-step fields. | Emit `query_index.upsert_one` for affected entities in the same path; add an integration assertion that an in_progress interaction updates the indexed `next_interaction_*`. |
+| **R3 — Existing tenants without the seeded dictionary** (already in spec) | Empty status dropdown until the upgrade action runs. | Phase 5 idempotent upgrade action; lenient validation keeps the API working meanwhile. |
+
+### Low Risks
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| **R7 — Next-interaction ordering when in_progress/waiting lack `scheduledAt`.** The projection orders by `scheduledAt`; non-scheduled open tasks may sort oddly or surface NULL. | "Next step" may pick an unscheduled in_progress task over a scheduled planned one, or vice-versa. | Decide ordering explicitly (e.g. scheduled-first, then by createdAt); add a unit test for the mixed case. |
+| **R1 — Split-brain open definitions** (already the spec's tracked primary risk) | Started task vanishes from a positive `= 'planned'` filter. | Single helper + Phase 2 call-site audit + enumerating unit test. |
+
+## Gap Analysis
+
+### Critical Gaps (block implementation)
+None.
+
+### Important Gaps (should address — fold into spec before Phase 2)
+- **Query-index upsert on projection broadening** (R6) — see Incomplete Sections.
+- **Projection ordering / NULL `scheduledAt`** (R7) — define the intended "next step" ordering once
+  in_progress/waiting are eligible.
+
+### Nice-to-Have Gaps
+- **Positive test coverage** for the widened `z.string()` status and the new `open` counts bucket.
+  The two status-coupled test files (`data/__tests__/interactionSchemas.test.ts`,
+  `__tests__/validators.test.ts`) currently pass through unchanged; add cases there.
+- **AI tool spelling fix** — `ai-tools/activities-tasks-pack.ts:241` maps done→`'completed'` and uses
+  `'cancelled'` (double-L) vs stored `'done'`/`'canceled'`; Phase 5 should align spelling, not just
+  widen the enum. (Pre-existing latent mismatch, not introduced here.)
+
+## Test-Impact Findings (verified against the codebase)
+
+- **Nothing breaks.** No test asserts interaction-status rejection; none pins `interactionStatusValues`
+  contents/length; the counts tests never pass `status`; `seedDictionaryScope.test.ts` does not assert
+  the seeded-kind set; no test pins `KIND_MAP` / `BUILTIN_DICTIONARY_ROUTE_KINDS` membership.
+- `interactionParticipantSchema.status` is already `z.string().trim().max(50)` (validators.ts:388) —
+  unaffected by the interaction-level widening; do not confuse the two.
+- `ActivityHistorySection.test.tsx:63` asserts `status` is null on the **list** route (already
+  `z.string().optional()`), not the counts route — unaffected by the counts reframe.
+- `enrichers.test.ts` operates on a pre-computed count map and never asserts the status list —
+  changing the terminal set does not break it.
+- `openApi` confirmed on both `api/interactions/route.ts:680` and `api/interactions/counts/route.ts:34`.
+
+## Remediation Plan
+
+### Before implementation (must do)
+1. Fold R6 (query-index upsert on projection broadening) into Phase 2 step 4 of the spec.
+2. Fold R7 (projection ordering / NULL `scheduledAt`) decision into the spec.
+
+### During implementation (add to spec / honour)
+1. Add positive test cases for widened status + `open` counts bucket in the two status-coupled test files.
+2. Keep the task status picker in `CrudForm`; if any detail section writes status directly, use `useGuardedMutation`.
+3. Phase 5: align AI tool status spelling (`completed`→`done`, `cancelled`→`canceled`) while widening.
+
+### Post-implementation (follow up)
+1. `dispatch-crm` MCP (separate repo): add `update_task` / `set_task_status` so the agent can set in_progress/waiting/canceled.
+2. Optional backfill of legacy `completed` rows → `done`.
+
+## Recommendation
+
+**Ready to implement** after folding R6 and R7 into the spec (both are small, additive notes — done
+in this prep pass). No major revision needed. Implement with `om-implement-spec` or
+`om-auto-fix-github 3230`; Phase order as written. The contract-surface touch is limited to the
+already-bridged `interactionStatusValues` export.


### PR DESCRIPTION
## What

Adds an OSS spec — `.ai/specs/2026-06-18-configurable-crm-interaction-statuses.md`.

Makes CRM task (`customer_interactions`) statuses **dictionary-backed and UI-configurable per tenant**, reusing the existing `deal-statuses` mechanism (Option A). Default set grows from `planned/done/canceled` to `planned/in_progress/waiting/done/canceled`.

## Why

Interaction statuses are a hardcoded enum (`interactionStatusValues`, `validators.ts:381`); tenants can't add or rename them, unlike deal statuses. This brings interactions to parity.

## Key design point

The codebase holds two competing definitions of "open" — `status NOT IN (terminal)` (enricher) vs `status = 'planned'` (next-step, conflicts, mark-done). Adding `in_progress`/`waiting` would make the positive filters silently drop them. The spec centralizes open/terminal semantics in one helper and dedicates **Phase 2** to auditing every call site (decision table included).

## Scope

- **Spec only — no code.** Implementation is phased (5 phases) and deferred to #3230.
- Backward compatible: `interactionStatusValues` kept + `@deprecated`; validator widening is non-breaking; no DB migration, no new ACL.
- `dispatch-crm` MCP (separate repo) `update_task` follow-up noted, out of scope here.

Includes a Final Compliance Report (fully compliant) and recommends `om-pre-implement-spec` before implementation.

Tracking issue: #3230

🤖 Generated with [Claude Code](https://claude.com/claude-code)