### PR TITLE
test(core): migrate core integration specs to public helper imports (#3189)

### DIFF
--- a/packages/core/src/modules/core/__integration__/__tests__/helper-import-convention.test.ts
+++ b/packages/core/src/modules/core/__integration__/__tests__/helper-import-convention.test.ts
@@ -1,0 +1,38 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const integrationRoot = join(__dirname, '..')
+
+const legacyAliasPattern =
+  /from\s+['"]@open-mercato\/core\/modules\/core\/__integration__\/helpers\//
+const legacyRelativePattern = /from\s+['"](?:\.{1,2}\/)+helpers\/(?!integration\/)/
+
+function collectSpecFiles(dir: string): string[] {
+  const collected: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry)
+    if (statSync(fullPath).isDirectory()) {
+      collected.push(...collectSpecFiles(fullPath))
+    } else if (entry.endsWith('.spec.ts')) {
+      collected.push(fullPath)
+    }
+  }
+  return collected
+}
+
+describe('core integration specs use the public helper import path', () => {
+  const specFiles = collectSpecFiles(integrationRoot)
+
+  it('discovers core integration specs (guards against a broken scan)', () => {
+    expect(specFiles.length).toBeGreaterThan(0)
+  })
+
+  it.each(specFiles.map((filePath) => [relative(integrationRoot, filePath), filePath]))(
+    '%s imports helpers from @open-mercato/core/helpers/integration/* only',
+    (_label, filePath) => {
+      const source = readFileSync(filePath, 'utf8')
+      expect(source).not.toMatch(legacyAliasPattern)
+      expect(source).not.toMatch(legacyRelativePattern)
+    },
+  )
+})

--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-001.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-001.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
-import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { login } from '@open-mercato/core/helpers/integration/auth';
+import { getAuthToken, apiRequest } from '@open-mercato/core/helpers/integration/api';
 
 /**
  * TC-ADMIN-001: Create API Key

--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-002.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-002.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
-import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
-import { createApiKeyFixture } from '@open-mercato/core/modules/core/__integration__/helpers/apiKeysFixtures';
+import { login } from '@open-mercato/core/helpers/integration/auth';
+import { getAuthToken, apiRequest } from '@open-mercato/core/helpers/integration/api';
+import { createApiKeyFixture } from '@open-mercato/core/helpers/integration/apiKeysFixtures';
 
 type Page = import('@playwright/test').Page;
 type Locator = import('@playwright/test').Locator;

--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-003.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-003.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+import { login } from '@open-mercato/core/helpers/integration/auth';
 
 /**
  * TC-ADMIN-003: View and Filter Audit Logs

--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-004.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-004.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
-import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { login } from '@open-mercato/core/helpers/integration/auth';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
 
 /**
  * TC-ADMIN-004: Manage Dictionary Entries

--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-005.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-005.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+import { login } from '@open-mercato/core/helpers/integration/auth';
 
 /**
  * TC-ADMIN-005: Feature Toggles Management

--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-006.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-006.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+import { login } from '@open-mercato/core/helpers/integration/auth';
 
 /**
  * TC-ADMIN-006: Feature Toggle Overrides

--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-007.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-007.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+import { login } from '@open-mercato/core/helpers/integration/auth';
 
 /**
  * TC-ADMIN-007: Custom Entity Creation

--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-009.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-009.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+import { login } from '@open-mercato/core/helpers/integration/auth';
 
 /**
  * TC-ADMIN-009: View System Status Dashboard

--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-010.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-010.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+import { login } from '@open-mercato/core/helpers/integration/auth';
 
 /**
  * TC-ADMIN-010: Cache Management

--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-011.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-011.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
-import { login } from '../helpers/auth';
-import { apiRequest, getAuthToken } from '../helpers/api';
+import { login } from '@open-mercato/core/helpers/integration/auth';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
 
 type DashboardLayoutItem = {
   id: string;

--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-012.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-012.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
-import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
-import { deleteGeneralEntityIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { deleteGeneralEntityIfExists } from '@open-mercato/core/helpers/integration/generalFixtures';
 
 /**
  * TC-ADMIN-012: API Key CRUD via API

--- a/packages/core/src/modules/core/__integration__/integration/TC-INT-001.spec.ts
+++ b/packages/core/src/modules/core/__integration__/integration/TC-INT-001.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
-import { addCustomLine, addPayment, addShipment, createSalesDocument } from '@open-mercato/core/modules/core/__integration__/helpers/salesUi';
+import { login } from '@open-mercato/core/helpers/integration/auth';
+import { addCustomLine, addPayment, addShipment, createSalesDocument } from '@open-mercato/core/helpers/integration/salesUi';
 
 /**
  * TC-INT-001: Quote to Order to Invoice to Payment

--- a/packages/core/src/modules/core/__integration__/integration/TC-INT-002.spec.ts
+++ b/packages/core/src/modules/core/__integration__/integration/TC-INT-002.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
-import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
-import { createPipelineFixture, createPipelineStageFixture, deleteEntityIfExists, deleteEntityByBody } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
-import { createSalesDocument } from '@open-mercato/core/modules/core/__integration__/helpers/salesUi';
+import { login } from '@open-mercato/core/helpers/integration/auth';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { createPipelineFixture, createPipelineStageFixture, deleteEntityIfExists, deleteEntityByBody } from '@open-mercato/core/helpers/integration/crmFixtures';
+import { createSalesDocument } from '@open-mercato/core/helpers/integration/salesUi';
 
 /**
  * TC-INT-002: Customer to Deal to Quote to Order Flow

--- a/packages/core/src/modules/core/__integration__/integration/TC-INT-003.spec.ts
+++ b/packages/core/src/modules/core/__integration__/integration/TC-INT-003.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
-import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { login } from '@open-mercato/core/helpers/integration/auth';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
 import {
   createProductFixture,
   deleteCatalogProductIfExists,
-} from '@open-mercato/core/modules/core/__integration__/helpers/catalogFixtures';
-import { createSalesDocument } from '@open-mercato/core/modules/core/__integration__/helpers/salesUi';
+} from '@open-mercato/core/helpers/integration/catalogFixtures';
+import { createSalesDocument } from '@open-mercato/core/helpers/integration/salesUi';
 
 /**
  * TC-INT-003: Product Creation to Sales Channel to Order

--- a/packages/core/src/modules/core/__integration__/integration/TC-INT-004.spec.ts
+++ b/packages/core/src/modules/core/__integration__/integration/TC-INT-004.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type BrowserContext } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
-import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
-import { createUserViaUi } from '@open-mercato/core/modules/core/__integration__/helpers/authUi';
+import { login } from '@open-mercato/core/helpers/integration/auth';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { createUserViaUi } from '@open-mercato/core/helpers/integration/authUi';
 
 /**
  * TC-INT-004: User to Role to Permission to Access Verification

--- a/packages/core/src/modules/core/__integration__/integration/TC-INT-005.spec.ts
+++ b/packages/core/src/modules/core/__integration__/integration/TC-INT-005.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
-import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
-import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
-import { addCustomLine, addPayment, addShipment, createSalesDocument } from '@open-mercato/core/modules/core/__integration__/helpers/salesUi';
+import { login } from '@open-mercato/core/helpers/integration/auth';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { addCustomLine, addPayment, addShipment, createSalesDocument } from '@open-mercato/core/helpers/integration/salesUi';
 
 /**
  * TC-INT-005: Order to Shipment to Invoice to Credit Memo


### PR DESCRIPTION
Fixes #3189

## Problem
The central `core` integration specs imported reusable test helpers through the legacy, monorepo-only re-export paths — both the alias `@open-mercato/core/modules/core/__integration__/helpers/*` and sibling `../helpers/*` shims. Per `.ai/qa/AGENTS.md`, that path is not available from npm; new code should use the public helper path `@open-mercato/core/helpers/integration/*` so the test surface stays aligned with standalone app/package consumption.

## Root Cause
The shipped core specs were never migrated when the public helper path (`packages/core/src/helpers/integration/*`, exported as `@open-mercato/core/helpers/integration/*`) was introduced. They kept relying on the module-local re-export shims, which only resolve inside the monorepo.

## What Changed
- Migrated all 16 core integration specs (11 under `admin/`, 5 under `integration/`) to import helpers directly from `@open-mercato/core/helpers/integration/*`.
  - Covers both the legacy alias and the relative `../helpers/*` form (TC-ADMIN-011).
- The migration is symbol-identical and behavior-preserving: the legacy module-local helper files are 1:1 `export *` re-exports of the public modules.
- **Backward compatibility:** the module-local helper re-export shims are intentionally **retained** (no removal), and the legacy tsconfig path alias is untouched, so any other in-repo specs or third-party consumers still on the legacy path keep working. This change only migrates the shipped core specs, as the issue scopes it.

## Tests
- Added a jest guard `packages/core/src/modules/core/__integration__/__tests__/helper-import-convention.test.ts` that scans every core integration spec and fails if any reintroduces the legacy module-local helper import path (alias or relative). It includes a discovery-sanity assertion so a broken scan can't pass vacuously.
  - Verified it **fails before** the migration (16 failing specs) and **passes after** (17/17).
- `tsc --noEmit` on `@open-mercato/core`: no new errors attributable to this change (the only diagnostics are pre-existing `#generated/*` module-resolution noise from a `--mode=skip-build` install with no `yarn generate`; none reference the migrated specs or the helper path).
- Playwright discovery for the migrated subset passes:
  `npx playwright test --config .ai/qa/tests/playwright.config.ts --list packages/core/src/modules/core/__integration__` → `Total: 16 tests in 16 files`, exit 0.

## Backward Compatibility
- No contract surface changes. The legacy helper re-export shims and their tsconfig alias are retained; the public `@open-mercato/core/helpers/integration/*` path is unchanged. No public types, event IDs, ACL IDs, DI names, API routes, or DB schema touched.
