### PR TITLE
refactor(cache): gate tenant-aware stats() base.stats() call to memory backends (#3146)

### DIFF
--- a/packages/cache/src/__tests__/service.test.ts
+++ b/packages/cache/src/__tests__/service.test.ts
@@ -2,6 +2,9 @@ import { createCacheService, CacheService } from '../service'
 import fs from 'node:fs'
 import path from 'node:path'
 import { DEFAULT_JSON_FILE_CACHE_PATH, DEFAULT_SQLITE_CACHE_PATH } from '../defaults'
+import type { CacheStrategy } from '../types'
+import * as memoryStrategyModule from '../strategies/memory'
+import * as sqliteStrategyModule from '../strategies/sqlite'
 
 describe('Cache Service', () => {
   afterEach(() => {
@@ -234,5 +237,65 @@ describe('Cache Service', () => {
       expect(stats.size).toBe(30)
       expect(stats.evictions).toBe(0)
     })
+  })
+})
+
+describe('Cache Service stats() counter gating', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const createFakeStrategy = (stats: CacheStrategy['stats']): CacheStrategy => ({
+    get: jest.fn(async () => null),
+    set: jest.fn(async () => {}),
+    has: jest.fn(async () => false),
+    delete: jest.fn(async () => false),
+    deleteByTags: jest.fn(async () => 0),
+    clear: jest.fn(async () => 0),
+    keys: jest.fn(async () => []),
+    stats,
+  })
+
+  it('skips the extra base.stats() call for non-memory backends', async () => {
+    const baseStats = jest.fn(async () => ({ size: 5, expired: 1 }))
+    jest
+      .spyOn(sqliteStrategyModule, 'createSqliteStrategy')
+      .mockReturnValue(createFakeStrategy(baseStats))
+
+    const cache = createCacheService({ strategy: 'sqlite' })
+    const stats = await cache.stats()
+
+    // The cold-path counter harvest is gated to memory-backed strategies, so a
+    // redis/sqlite/jsonfile backend never incurs the extra base.stats() round-trip.
+    expect(baseStats).not.toHaveBeenCalled()
+    expect(stats).toEqual({ size: 0, expired: 0 })
+    expect(stats.evictions).toBeUndefined()
+    expect(stats.sweeps).toBeUndefined()
+    expect(stats.lastSweepReclaimed).toBeUndefined()
+  })
+
+  it('still harvests bound counters via base.stats() for the memory backend', async () => {
+    const baseStats = jest.fn(async () => ({
+      size: 99,
+      expired: 99,
+      evictions: 7,
+      sweeps: 2,
+      lastSweepReclaimed: 3,
+    }))
+    jest
+      .spyOn(memoryStrategyModule, 'createMemoryStrategy')
+      .mockReturnValue(createFakeStrategy(baseStats))
+
+    const cache = createCacheService({ strategy: 'memory' })
+    const stats = await cache.stats()
+
+    // size/expired stay tenant-scoped (computed by the wrapper), while the
+    // process-global counters come from a single base.stats() call.
+    expect(baseStats).toHaveBeenCalledTimes(1)
+    expect(stats.size).toBe(0)
+    expect(stats.expired).toBe(0)
+    expect(stats.evictions).toBe(7)
+    expect(stats.sweeps).toBe(2)
+    expect(stats.lastSweepReclaimed).toBe(3)
   })
 })

--- a/packages/cache/src/service.ts
+++ b/packages/cache/src/service.ts
@@ -84,7 +84,7 @@ function buildTagSet(tags: string[] | undefined, prefixes: TenantPrefixes, inclu
   return Array.from(scoped)
 }
 
-function createTenantAwareWrapper(base: CacheStrategy): CacheStrategy {
+function createTenantAwareWrapper(base: CacheStrategy, reportsBoundedCounters: boolean): CacheStrategy {
   function normalizeDeletionCount(raw: number): number {
     if (!raw) return raw
     if (!Number.isFinite(raw)) return raw
@@ -170,9 +170,15 @@ function createTenantAwareWrapper(base: CacheStrategy): CacheStrategy {
       const expiresAt = metadata?.expiresAt ?? null
       if (expiresAt !== null && expiresAt <= now) expired++
     }
-    // size/expired stay tenant-scoped (derived from this tenant's meta keys);
-    // surface the underlying strategy's process-global bound counters too so
-    // operators reading the DI cacheService can see LRU/sweep activity.
+    // size/expired stay tenant-scoped (derived from this tenant's meta keys).
+    // Only memory-backed strategies track the process-global bound counters, so
+    // skip the extra base.stats() round-trip for redis/sqlite/jsonfile and omit
+    // the optional fields (the stats() contract marks them optional). Keyed off
+    // the configured strategy: a backend degraded to the memory fallback
+    // intentionally does not surface these diagnostics.
+    if (!reportsBoundedCounters) {
+      return { size, expired }
+    }
     const { evictions, sweeps, lastSweepReclaimed } = await base.stats()
     return { size, expired, evictions, sweeps, lastSweepReclaimed }
   }
@@ -235,8 +241,9 @@ export function createCacheService(options?: CacheServiceOptions): CacheStrategy
 
   const baseStrategy = createStrategyForType(strategyType, options, defaultTtl, maxEntries)
   const resilientStrategy = withDependencyFallback(baseStrategy, strategyType, defaultTtl, maxEntries)
+  const reportsBoundedCounters = strategyType === 'memory'
 
-  return createTenantAwareWrapper(resilientStrategy)
+  return createTenantAwareWrapper(resilientStrategy, reportsBoundedCounters)
 }
 
 /**


### PR DESCRIPTION
Fixes #3146

## Problem
The tenant-aware cache wrapper's `stats()` (in `packages/cache/src/service.ts`) unconditionally called `await base.stats()` to harvest the process-global `evictions`/`sweeps`/`lastSweepReclaimed` counters — even for redis/sqlite/jsonfile backends that don't track them and return `undefined`. `stats()` is a diagnostic/observability method, so this is a cold-path inefficiency (the Low finding carried forward from the approving review on #3091).

## Root Cause
Only the memory strategy tracks the bounded LRU/sweep counters; the other strategies return `{ size, expired }` only. The wrapper harvested the counters from `base.stats()` regardless of backend, making the extra call pure overhead for non-memory backends.

## What Changed
- `createTenantAwareWrapper` now takes a `reportsBoundedCounters` flag, computed once in `createCacheService` as `strategyType === 'memory'`.
- The wrapper's `stats()` only performs the extra `await base.stats()` round-trip when the backend is memory-backed; redis/sqlite/jsonfile return just `{ size, expired }` and omit the optional counter fields.
- This matches the documented contract ("Other backends omit these fields" — `packages/cache/AGENTS.md`). The optional `stats()` fields are unchanged; memory-backed behavior is identical.

## Tests
- Added `Cache Service stats() counter gating` suite in `packages/cache/src/__tests__/service.test.ts`:
  - non-memory backend (`sqlite`) no longer calls `base.stats()` (spy asserts 0 calls) and omits the counter fields.
  - memory backend still harvests the counters via a single `base.stats()` call.
  - Verified the gating test fails against the pre-fix (unconditional) behavior, so it genuinely anchors the regression.
- `yarn workspace @open-mercato/cache test` — 55 passed.
- `yarn workspace @open-mercato/cache build`, repo-wide `yarn build:packages` + `yarn generate` + `yarn typecheck` — all green.

## Backward Compatibility
- No contract-surface changes. `createCacheService`, the `CacheService` class, and the `CacheStrategy.stats()` return type are unchanged; the counter fields remain optional. `createTenantAwareWrapper` is an internal (non-exported) helper.
- Behavior note: non-memory backends now omit the optional counter keys rather than returning them as `undefined`, which aligns with the documented contract. A backend that has degraded to the in-memory fallback intentionally does not surface these diagnostics (gating is keyed off the configured strategy).

## Security impact
None — this only changes which diagnostic counters a cold-path `stats()` call returns. No auth, secrets, encryption, logging, audit, or access-control surfaces are touched.