### PR TITLE
fix(dictionaries): use Checkbox primitive and DS status tokens in field editor (#3221)

### DIFF
--- a/packages/core/src/modules/dictionaries/fields/__tests__/dictionary.test.tsx
+++ b/packages/core/src/modules/dictionaries/fields/__tests__/dictionary.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FieldRegistry } from '@open-mercato/ui/backend/fields/registry'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useDictionaryEntries } from '../../components/hooks/useDictionaryEntries'
+import '../dictionary'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/i18n/context')
+  return {
+    ...actual,
+    useT: () => (key: string, fallback?: string) => fallback ?? key,
+  }
+})
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+}))
+
+jest.mock('../../components/hooks/useDictionaryEntries', () => ({
+  useDictionaryEntries: jest.fn(),
+  ensureDictionaryEntries: jest.fn(),
+  invalidateDictionaryEntries: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/primitives/select', () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
+  return {
+    Select: Passthrough,
+    SelectContent: Passthrough,
+    SelectItem: Passthrough,
+    SelectTrigger: Passthrough,
+    SelectValue: () => null,
+  }
+})
+
+const apiCallMock = apiCall as unknown as jest.Mock
+const useDictionaryEntriesMock = useDictionaryEntries as unknown as jest.Mock
+
+function renderEditor(def: unknown, onChange: (patch: unknown) => void = jest.fn()) {
+  const defEditor = FieldRegistry.getDefEditor('dictionary')
+  if (!defEditor) throw new Error('dictionary field defEditor not registered')
+  render(<>{defEditor({ def, onChange })}</>)
+  return { onChange }
+}
+
+describe('dictionary field defEditor', () => {
+  beforeEach(() => {
+    apiCallMock.mockReset()
+    useDictionaryEntriesMock.mockReset()
+    apiCallMock.mockResolvedValue({ ok: true, result: { items: [] } })
+    useDictionaryEntriesMock.mockReturnValue({ data: { entries: [] }, isLoading: false })
+  })
+
+  it('renders the shared Checkbox primitive instead of a native checkbox input', async () => {
+    renderEditor({ configJson: { dictionaryId: 'dict-1', dictionaryInlineCreate: true } })
+
+    const checkbox = await screen.findByRole('checkbox')
+    expect(checkbox.tagName).toBe('BUTTON')
+    expect(checkbox).toHaveAttribute('data-state', 'checked')
+  })
+
+  it('toggles dictionaryInlineCreate through the Checkbox primitive', async () => {
+    const onChange = jest.fn()
+    renderEditor({ configJson: { dictionaryId: 'dict-1', dictionaryInlineCreate: true } }, onChange)
+
+    const checkbox = await screen.findByRole('checkbox')
+    fireEvent.click(checkbox)
+    expect(onChange).toHaveBeenCalledWith({ dictionaryInlineCreate: false })
+  })
+
+  it('disables the inline-create checkbox until a dictionary is selected', async () => {
+    renderEditor({ configJson: {} })
+
+    const checkbox = await screen.findByRole('checkbox')
+    expect(checkbox).toBeDisabled()
+  })
+
+  it('uses the design-system error token (not text-red-600) for load failures', async () => {
+    apiCallMock.mockResolvedValue({ ok: false, result: { error: 'boom' } })
+    renderEditor({ configJson: {} })
+
+    const message = await screen.findByText(/Failed to load dictionaries/)
+    expect(message).toHaveClass('text-status-error-text')
+    expect(message).not.toHaveClass('text-red-600')
+  })
+
+  it('uses the design-system warning token (not text-amber-600) for a stale default value', async () => {
+    useDictionaryEntriesMock.mockReturnValue({
+      data: { entries: [{ value: 'a', label: 'A' }] },
+      isLoading: false,
+    })
+    renderEditor({ configJson: { dictionaryId: 'dict-1', defaultValue: 'missing' } })
+
+    const message = await screen.findByText(/Default entry not found/)
+    expect(message).toHaveClass('text-status-warning-text')
+    expect(message).not.toHaveClass('text-amber-600')
+  })
+})

--- a/packages/core/src/modules/dictionaries/fields/dictionary.tsx
+++ b/packages/core/src/modules/dictionaries/fields/dictionary.tsx
@@ -5,6 +5,7 @@ import type { CrudCustomFieldRenderProps } from '@open-mercato/ui/backend/CrudFo
 import { FieldRegistry } from '@open-mercato/ui/backend/fields/registry'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { Checkbox } from '@open-mercato/ui/primitives/checkbox'
 import {
   Select,
   SelectContent,
@@ -70,7 +71,7 @@ function DictionaryDefaultSelector({
         </p>
       ) : null}
       {isStale ? (
-        <p className="text-xs text-amber-600">
+        <p className="text-xs text-status-warning-text">
           {t('dictionaries.customFields.defaultValueStale', 'Default entry not found — it may have been deleted or renamed.')}
         </p>
       ) : null}
@@ -83,6 +84,7 @@ function DictionaryFieldDefEditor({ def, onChange }: { def: { configJson?: Dicti
   const [items, setItems] = React.useState<DictionarySummary[]>([])
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
+  const inlineCreateId = React.useId()
   const selectedId = typeof def?.configJson?.dictionaryId === 'string' ? def?.configJson?.dictionaryId : ''
   const inlineCreate = def?.configJson?.dictionaryInlineCreate !== false
 
@@ -157,7 +159,7 @@ function DictionaryFieldDefEditor({ def, onChange }: { def: { configJson?: Dicti
             {t('dictionaries.customFields.loading', 'Loading dictionaries…')}
           </p>
         ) : null}
-        {error ? <p className="text-xs text-red-600">{error}</p> : null}
+        {error ? <p className="text-xs text-status-error-text">{error}</p> : null}
         {!loading && !error && items.length === 0 ? (
           <p className="text-xs text-muted-foreground">
             {t('dictionaries.customFields.empty', 'No dictionaries available yet. Create one first.')}
@@ -172,15 +174,20 @@ function DictionaryFieldDefEditor({ def, onChange }: { def: { configJson?: Dicti
           </a>
         </div>
       ) : null}
-      <label className="inline-flex items-center gap-2 text-xs">
-        <input
-          type="checkbox"
+      <div className="inline-flex items-center gap-2 text-xs">
+        <Checkbox
+          id={inlineCreateId}
           checked={inlineCreate}
-          onChange={(event) => onChange({ dictionaryInlineCreate: event.target.checked })}
+          onCheckedChange={(checked) => onChange({ dictionaryInlineCreate: checked === true })}
           disabled={!selectedId}
         />
-        {t('dictionaries.customFields.allowInlineCreate', 'Allow inline creation inside forms')}
-      </label>
+        <label
+          htmlFor={inlineCreateId}
+          className={selectedId ? 'cursor-pointer select-none' : 'cursor-not-allowed opacity-60'}
+        >
+          {t('dictionaries.customFields.allowInlineCreate', 'Allow inline creation inside forms')}
+        </label>
+      </div>
       {selectedId ? (
         <DictionaryDefaultSelector
           dictionaryId={selectedId}


### PR DESCRIPTION
Fixes #3221

## Problem
The dictionary custom-field definition editor (`packages/core/src/modules/dictionaries/fields/dictionary.tsx`) used a native `<input type="checkbox">` and hard-coded Tailwind status colors (`text-amber-600`, `text-red-600`), violating the UI package guidelines that require shared primitives and design-system status tokens.

## Root Cause
The editor predates the shared `Checkbox` primitive and the `{property}-status-{status}-{role}` token convention, so it rendered a raw checkbox and inline status-color classes.

## What Changed
- Replaced the raw `<input type="checkbox">` with the shared `Checkbox` primitive from `@open-mercato/ui/primitives/checkbox`, wiring an accessible `<label htmlFor>` via a `React.useId()`-generated id (the same pattern `CheckboxField`/`EncryptionManager` use). Behavior is preserved: checked state, `disabled` until a dictionary is selected, and the `dictionaryInlineCreate` toggle payload.
- Migrated the stale-default warning text from `text-amber-600` → `text-status-warning-text`.
- Migrated the load-error text from `text-red-600` → `text-status-error-text`.

The field-editor behavior is unchanged — this is a primitive/token swap only.

## Tests
- New jsdom regression suite `packages/core/src/modules/dictionaries/fields/__tests__/dictionary.test.tsx` (5 tests):
  - renders the shared `Checkbox` primitive (a `<button role="checkbox">`) rather than a native input
  - toggling fires `onChange({ dictionaryInlineCreate: false })`
  - the checkbox is disabled until a dictionary is selected (behavior preserved)
  - the load-error message uses `text-status-error-text`, not `text-red-600`
  - the stale-default message uses `text-status-warning-text`, not `text-amber-600`
  - Verified the three issue-specific assertions fail against the pre-fix source and pass after the fix.
- Checks run: `yarn build:packages`, `yarn generate`, and `@open-mercato/core` `typecheck` all pass.
- `build:app` and local `lint` were skipped as disproportionate for an isolated, behavior-preserving client-component change (local ESLint has a known plugin/ESLint-10 incompatibility on this machine; CI lint applies). i18n checks are not triggered — no translation keys or user-facing strings changed.

## Backward Compatibility
No contract surface changes. `dictionary.tsx` is an internal `FieldRegistry`-registered renderer; the `'dictionary'` registration key, the `def`/`onChange` shapes, and the `dictionaryInlineCreate` config semantics are all unchanged. No exports, public types, API routes, event IDs, widget spot IDs, DI keys, ACL features, or DB schema affected.

## Suggested labels (could not be applied from a fork without triage rights)
`review`, `bug`, `priority-low`, `risk-low`. This is a visible (behavior-preserving) backoffice UI change, so a maintainer may optionally add `needs-qa` for a quick visual check of the checkbox/colors.
