### PR TITLE
fix(dictionaries): avoid refetching dictionary list when selection changes (#3220)

### DIFF
--- a/packages/core/src/modules/dictionaries/components/DictionariesManager.tsx
+++ b/packages/core/src/modules/dictionaries/components/DictionariesManager.tsx
@@ -121,16 +121,19 @@ export function DictionariesManager() {
         : []
       const filtered = list.filter((dictionary: DictionarySummary) => dictionary.managerVisibility !== 'hidden')
       setItems(filtered)
-      if (!filtered.find((dict: DictionarySummary) => dict.id === selectedId)) {
-        setSelectedId(filtered.length ? filtered[0].id : null)
-      }
+      setSelectedId((current) => {
+        if (current && filtered.some((dict: DictionarySummary) => dict.id === current)) {
+          return current
+        }
+        return filtered.length ? filtered[0].id : null
+      })
     } catch (err) {
       console.error('Failed to load dictionaries', err)
       flash(t('dictionaries.config.error.load', 'Failed to load dictionaries.'), 'error')
     } finally {
       setLoading(false)
     }
-  }, [selectedId, t])
+  }, [t])
 
   React.useEffect(() => {
     loadDictionaries().catch(() => {})

--- a/packages/core/src/modules/dictionaries/components/__tests__/DictionariesManager.test.tsx
+++ b/packages/core/src/modules/dictionaries/components/__tests__/DictionariesManager.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { DictionariesManager } from '../DictionariesManager'
+
+const apiCall = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCall(...args),
+  withScopedApiRequestHeaders: (_header: unknown, fn: () => unknown) => fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/conflicts', () => ({
+  surfaceRecordConflict: () => false,
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({ confirm: jest.fn(async () => false), ConfirmDialogElement: null }),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => {
+  const translate = (key: string, fallback?: unknown) =>
+    typeof fallback === 'string' ? fallback : key
+  return { useT: () => translate }
+})
+
+jest.mock('@open-mercato/ui/primitives/empty-state', () => ({
+  EmptyState: ({ title }: { title?: React.ReactNode }) => <div>{title}</div>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/primitives/spinner', () => ({
+  Spinner: () => <span data-testid="spinner" />,
+}))
+
+jest.mock('@open-mercato/ui/primitives/dialog', () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/select', () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+}))
+
+jest.mock('../DictionaryEntriesEditor', () => ({
+  DictionaryEntriesEditor: ({ dictionaryId }: { dictionaryId: string }) => (
+    <div data-testid="entries-editor">{dictionaryId}</div>
+  ),
+}))
+
+const dictionaries = [
+  {
+    id: 'dict-colors',
+    key: 'colors',
+    name: 'Colors',
+    description: null,
+    isSystem: false,
+    isActive: true,
+    entrySortMode: 'label_asc',
+    organizationId: 'org-1',
+    isInherited: false,
+    managerVisibility: 'default',
+    updatedAt: '2026-06-18T00:00:00.000Z',
+  },
+  {
+    id: 'dict-sizes',
+    key: 'sizes',
+    name: 'Sizes',
+    description: null,
+    isSystem: false,
+    isActive: true,
+    entrySortMode: 'label_asc',
+    organizationId: 'org-1',
+    isInherited: false,
+    managerVisibility: 'default',
+    updatedAt: '2026-06-18T00:00:00.000Z',
+  },
+]
+
+function listFetchCount() {
+  return apiCall.mock.calls.filter(([url]) => url === '/api/dictionaries').length
+}
+
+describe('DictionariesManager', () => {
+  beforeEach(() => {
+    apiCall.mockReset()
+    apiCall.mockImplementation(async (url: string) => {
+      if (url === '/api/dictionaries') {
+        return { ok: true, result: { items: dictionaries } }
+      }
+      return { ok: true, result: {} }
+    })
+  })
+
+  it('does not refetch the dictionaries list when the selection changes', async () => {
+    render(<DictionariesManager />)
+
+    // Initial load auto-selects the first dictionary and fetches the list exactly once.
+    await waitFor(() => expect(screen.getByTestId('entries-editor')).toHaveTextContent('dict-colors'))
+    expect(listFetchCount()).toBe(1)
+
+    // Selecting another dictionary must update the editor without refetching the list.
+    fireEvent.click(screen.getByText('Sizes'))
+    await waitFor(() => expect(screen.getByTestId('entries-editor')).toHaveTextContent('dict-sizes'))
+    expect(listFetchCount()).toBe(1)
+  })
+})


### PR DESCRIPTION
Fixes #3220

## Problem
Selecting a dictionary in the manager refetched the entire `/api/dictionaries` list. The list fetch callback (`loadDictionaries`) read `selectedId` and listed it as a dependency, and the load effect depended on that callback — so a pure selection change recreated the callback and reran the fetch effect. It also fired a second redundant fetch on mount, right after the first load auto-selected the first dictionary.

## Root Cause
`loadDictionaries` reconciled the current selection by reading `selectedId` directly:

```ts
if (!filtered.find((dict) => dict.id === selectedId)) {
  setSelectedId(filtered.length ? filtered[0].id : null)
}
// deps: [selectedId, t]  ->  React.useEffect(() => { loadDictionaries() }, [loadDictionaries])
```

Because `selectedId` was a dependency, every selection change produced a new callback identity, which retriggered the `loadDictionaries()` effect.

## What Changed
- `packages/core/src/modules/dictionaries/components/DictionariesManager.tsx`: reconcile the selection inside `loadDictionaries` via a **functional** `setSelectedId` updater (`current => current is still present ? current : first/null`) instead of reading `selectedId`, and drop `selectedId` from the callback dependency list (`[selectedId, t]` → `[t]`).
- The callback is now stable across selection changes. The list is fetched only on mount and on explicit refresh / save / delete; selection changes no longer hit `/api/dictionaries`. Selection-reconciliation behavior is unchanged (keep the current dictionary when it still exists, otherwise fall back to the first or none).

## Tests
- Added `packages/core/src/modules/dictionaries/components/__tests__/DictionariesManager.test.tsx`: renders the manager, asserts exactly one `/api/dictionaries` fetch after the initial load, clicks a different dictionary, and asserts the editor switches **without** a second list fetch. Verified it fails on the pre-fix code (`Received: 2`) and passes after the fix.
- `yarn workspace @open-mercato/core test -- src/modules/dictionaries` → 6 suites / 17 tests pass.
- Optimistic-lock guards (`optimistic-lock-ui-coverage`, `optimistic-lock-editable-entities`) pass — no new mutating UI calls were introduced.
- `@open-mercato/core` typecheck passes; `yarn build:packages` + `yarn generate` succeed.

## Backward Compatibility
- No contract surface changes. No exported types, signatures, API routes, event IDs, or DB schema touched. Purely an internal client-component fix in one module.