### PR TITLE
fix(data_sync): replace raw checkboxes and hardcoded status colors in admin UI (#3216)

### DIFF
--- a/packages/core/src/modules/data_sync/backend/data-sync/page.tsx
+++ b/packages/core/src/modules/data_sync/backend/data-sync/page.tsx
@@ -7,7 +7,8 @@ import { DataTable } from '@open-mercato/ui/backend/DataTable'
 import type { ColumnDef } from '@tanstack/react-table'
 import type { FilterDef, FilterValues } from '@open-mercato/ui/backend/FilterBar'
 import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
-import { Badge, type BadgeProps } from '@open-mercato/ui/primitives/badge'
+import { Badge } from '@open-mercato/ui/primitives/badge'
+import { StatusBadge } from '@open-mercato/ui/primitives/status-badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@open-mercato/ui/primitives/card'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Input } from '@open-mercato/ui/primitives/input'
@@ -40,6 +41,7 @@ import {
   Settings2,
   ShieldCheck,
 } from 'lucide-react'
+import { getSyncRunStatusVariant, getSyncSummaryVariant } from '../../lib/syncRunStatus'
 
 type SyncRunRow = {
   id: string
@@ -107,56 +109,7 @@ type SyncScheduleEditorState = {
   updatedAt?: string | null
 }
 
-const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-gray-100 text-gray-800',
-  running: 'bg-blue-100 text-blue-800',
-  completed: 'bg-green-100 text-green-800',
-  failed: 'bg-red-100 text-red-800',
-  cancelled: 'bg-yellow-100 text-yellow-800',
-  paused: 'bg-orange-100 text-orange-800',
-}
-
 const DEFAULT_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
-
-type SummaryBadgeStyle = {
-  variant: BadgeProps['variant']
-  className?: string
-}
-
-function getSummaryBadgeStyle(kind: 'enabled' | 'disabled' | 'ready' | 'missing' | 'scheduled' | 'paused' | 'none'): SummaryBadgeStyle {
-  if (kind === 'enabled' || kind === 'ready') {
-    return {
-      variant: 'outline',
-      className: 'border-emerald-500/30 bg-emerald-500/15 text-emerald-200',
-    }
-  }
-
-  if (kind === 'disabled' || kind === 'missing') {
-    return {
-      variant: 'outline',
-      className: 'border-red-500/30 bg-red-500/15 text-red-200',
-    }
-  }
-
-  if (kind === 'paused') {
-    return {
-      variant: 'outline',
-      className: 'border-amber-500/30 bg-amber-500/15 text-amber-200',
-    }
-  }
-
-  if (kind === 'scheduled') {
-    return {
-      variant: 'outline',
-      className: 'border-sky-500/30 bg-sky-500/15 text-sky-200',
-    }
-  }
-
-  return {
-    variant: 'outline',
-    className: 'border-muted-foreground/20 bg-muted/50 text-muted-foreground',
-  }
-}
 
 function formatEntityTypeLabel(entityType: string): string {
   return entityType
@@ -589,9 +542,9 @@ export default function SyncRunsDashboardPage() {
       accessorKey: 'status',
       header: t('data_sync.dashboard.columns.status'),
       cell: ({ row }) => (
-        <Badge variant="secondary" className={STATUS_STYLES[row.original.status] ?? ''}>
+        <StatusBadge variant={getSyncRunStatusVariant(row.original.status)}>
           {t(`data_sync.dashboard.status.${row.original.status}`)}
-        </Badge>
+        </StatusBadge>
       ),
     },
     {
@@ -622,9 +575,9 @@ export default function SyncRunsDashboardPage() {
   )
   const hasSavedSchedule = Boolean(scheduleEditor.id)
   const selectedEntityLabel = selectedEntityType ? formatEntityTypeLabel(selectedEntityType) : t('data_sync.dashboard.columns.entityType')
-  const integrationStateBadge = getSummaryBadgeStyle(selectedIntegration?.isEnabled ? 'enabled' : 'disabled')
-  const credentialsBadge = getSummaryBadgeStyle(selectedIntegration?.hasCredentials ? 'ready' : 'missing')
-  const scheduleBadge = getSummaryBadgeStyle(
+  const integrationStateVariant = getSyncSummaryVariant(selectedIntegration?.isEnabled ? 'enabled' : 'disabled')
+  const credentialsVariant = getSyncSummaryVariant(selectedIntegration?.hasCredentials ? 'ready' : 'missing')
+  const scheduleVariant = getSyncSummaryVariant(
     hasSavedSchedule
       ? (scheduleEditor.isEnabled ? 'scheduled' : 'paused')
       : 'none',
@@ -668,19 +621,19 @@ export default function SyncRunsDashboardPage() {
                   <ArrowRightLeft className="size-3.5" />
                   {t(`data_sync.dashboard.direction.${selectedDirection}`)}
                 </Badge>
-                <Badge variant={integrationStateBadge.variant} className={`gap-1.5 ${integrationStateBadge.className ?? ''}`}>
+                <Badge variant={integrationStateVariant} className="gap-1.5">
                   <ShieldCheck className="size-3.5" />
                   {selectedIntegration.isEnabled
                     ? t('data_sync.dashboard.start.status.enabled', 'Integration enabled')
                     : t('data_sync.dashboard.start.status.disabled', 'Integration disabled')}
                 </Badge>
-                <Badge variant={credentialsBadge.variant} className={`gap-1.5 ${credentialsBadge.className ?? ''}`}>
+                <Badge variant={credentialsVariant} className="gap-1.5">
                   <PlugZap className="size-3.5" />
                   {selectedIntegration.hasCredentials
                     ? t('data_sync.dashboard.start.status.credentialsReady', 'Credentials ready')
                     : t('data_sync.dashboard.start.status.credentialsMissing', 'Credentials missing')}
                 </Badge>
-                <Badge variant={scheduleBadge.variant} className={`gap-1.5 ${scheduleBadge.className ?? ''}`}>
+                <Badge variant={scheduleVariant} className="gap-1.5">
                   <CalendarClock className="size-3.5" />
                   {hasSavedSchedule
                     ? (scheduleEditor.isEnabled

--- a/packages/core/src/modules/data_sync/backend/data-sync/runs/[id]/page.tsx
+++ b/packages/core/src/modules/data_sync/backend/data-sync/runs/[id]/page.tsx
@@ -5,6 +5,7 @@ import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { FormHeader } from '@open-mercato/ui/backend/forms'
 import { Card, CardHeader, CardTitle, CardContent } from '@open-mercato/ui/primitives/card'
 import { Badge } from '@open-mercato/ui/primitives/badge'
+import { StatusBadge } from '@open-mercato/ui/primitives/status-badge'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { LogList, type LogListEntry } from '@open-mercato/ui/backend/LogList'
 import { Progress } from '@open-mercato/ui/primitives/progress'
@@ -15,6 +16,7 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { LoadingMessage, ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { useAppEvent } from '@open-mercato/ui/backend/injection/useAppEvent'
 import { RotateCcw, XCircle } from 'lucide-react'
+import { getSyncRunStatusVariant } from '../../../../lib/syncRunStatus'
 
 type SyncRunDetail = {
   id: string
@@ -67,15 +69,6 @@ function formatEtaSeconds(seconds: number): string {
   const hours = Math.floor(seconds / 3600)
   const minutes = Math.ceil((seconds % 3600) / 60)
   return `${hours}h ${minutes}m`
-}
-
-const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-gray-100 text-gray-800',
-  running: 'bg-blue-100 text-blue-800',
-  completed: 'bg-green-100 text-green-800',
-  failed: 'bg-red-100 text-red-800',
-  cancelled: 'bg-yellow-100 text-yellow-800',
-  paused: 'bg-orange-100 text-orange-800',
 }
 
 type SyncRunDetailPageProps = {
@@ -284,9 +277,9 @@ export default function SyncRunDetailPage({ params }: SyncRunDetailPageProps) {
           statusBadge={(
             <div className="mt-2 flex flex-wrap gap-2">
               <Badge variant="outline">{t(`data_sync.dashboard.direction.${run.direction}`)}</Badge>
-              <Badge variant="secondary" className={STATUS_STYLES[run.status] ?? ''}>
+              <StatusBadge variant={getSyncRunStatusVariant(run.status)}>
                 {t(`data_sync.dashboard.status.${run.status}`)}
-              </Badge>
+              </StatusBadge>
               {run.triggeredBy ? <Badge variant="outline">{run.triggeredBy}</Badge> : null}
             </div>
           )}
@@ -312,9 +305,9 @@ export default function SyncRunDetailPage({ params }: SyncRunDetailPageProps) {
           <CardHeader>
             <div className="flex items-center justify-between gap-3">
               <CardTitle>{t('data_sync.runs.detail.progress')}</CardTitle>
-              <Badge variant="secondary" className={STATUS_STYLES[progressStatus] ?? ''}>
+              <StatusBadge variant={getSyncRunStatusVariant(progressStatus)}>
                 {t(`data_sync.dashboard.status.${progressStatus}`)}
-              </Badge>
+              </StatusBadge>
             </div>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -355,37 +348,37 @@ export default function SyncRunDetailPage({ params }: SyncRunDetailPageProps) {
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           <Card>
             <CardContent className="pt-6 text-center">
-              <div className="text-2xl font-bold text-green-600">{run.createdCount}</div>
+              <div className="text-2xl font-bold text-status-success-text">{run.createdCount}</div>
               <p className="text-sm text-muted-foreground">{t('data_sync.runs.detail.counters.created')}</p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="pt-6 text-center">
-              <div className="text-2xl font-bold text-blue-600">{run.updatedCount}</div>
+              <div className="text-2xl font-bold text-status-info-text">{run.updatedCount}</div>
               <p className="text-sm text-muted-foreground">{t('data_sync.runs.detail.counters.updated')}</p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="pt-6 text-center">
-              <div className="text-2xl font-bold text-gray-600">{run.skippedCount}</div>
+              <div className="text-2xl font-bold text-muted-foreground">{run.skippedCount}</div>
               <p className="text-sm text-muted-foreground">{t('data_sync.runs.detail.counters.skipped')}</p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="pt-6 text-center">
-              <div className="text-2xl font-bold text-red-600">{run.failedCount}</div>
+              <div className="text-2xl font-bold text-status-error-text">{run.failedCount}</div>
               <p className="text-sm text-muted-foreground">{t('data_sync.runs.detail.counters.failed')}</p>
             </CardContent>
           </Card>
         </div>
 
         {run.lastError && (
-          <Card className="border-red-200 bg-red-50">
+          <Card className="border-status-error-border bg-status-error-bg">
             <CardHeader>
-              <CardTitle className="text-red-800">{t('data_sync.runs.detail.error')}</CardTitle>
+              <CardTitle className="text-status-error-text">{t('data_sync.runs.detail.error')}</CardTitle>
             </CardHeader>
             <CardContent>
-              <pre className="text-sm text-red-700 whitespace-pre-wrap">{run.lastError}</pre>
+              <pre className="text-sm text-status-error-text whitespace-pre-wrap">{run.lastError}</pre>
             </CardContent>
           </Card>
         )}

--- a/packages/core/src/modules/data_sync/components/IntegrationScheduleTab.tsx
+++ b/packages/core/src/modules/data_sync/components/IntegrationScheduleTab.tsx
@@ -18,8 +18,10 @@ import {
   SelectValue,
 } from '@open-mercato/ui/primitives/select'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
+import { Switch } from '@open-mercato/ui/primitives/switch'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { getSyncSummaryVariant } from '../lib/syncRunStatus'
 import {
   CalendarClock,
   Play,
@@ -360,13 +362,13 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="space-y-2">
           <div className="flex flex-wrap items-center gap-2">
-            <Badge variant="outline" className={props.isEnabled ? 'border-emerald-300 text-emerald-700' : 'border-amber-300 text-amber-700'}>
+            <Badge variant={getSyncSummaryVariant(props.isEnabled ? 'enabled' : 'disabled')}>
               {props.isEnabled ? <ShieldCheck className="mr-2 h-3.5 w-3.5" /> : <ShieldAlert className="mr-2 h-3.5 w-3.5" />}
               {props.isEnabled
                 ? t('data_sync.dashboard.start.status.enabled', 'Integration enabled')
                 : t('data_sync.dashboard.start.status.disabled', 'Integration disabled')}
             </Badge>
-            <Badge variant="outline" className={props.hasCredentials ? 'border-sky-300 text-sky-700' : 'border-amber-300 text-amber-700'}>
+            <Badge variant={getSyncSummaryVariant(props.hasCredentials ? 'ready' : 'missing')}>
               <CalendarClock className="mr-2 h-3.5 w-3.5" />
               {props.hasCredentials
                 ? t('data_sync.dashboard.start.status.credentialsReady', 'Credentials ready')
@@ -477,22 +479,22 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
                     </td>
                     <td className="px-3 py-3">
                       <label className="flex min-h-10 items-center gap-2 text-sm">
-                        <input
-                          type="checkbox"
+                        <Switch
                           checked={scheduleState.fullSync}
-                          onChange={(event) => updateScheduleEditor(row.key, { fullSync: event.target.checked }, row.entityType)}
+                          onCheckedChange={(checked) => updateScheduleEditor(row.key, { fullSync: checked }, row.entityType)}
                           disabled={controlsDisabled}
+                          aria-label={t('data_sync.dashboard.start.fullSync', 'Run as full sync')}
                         />
                         <span>{t('data_sync.integrationTab.fullSyncShort', 'Full')}</span>
                       </label>
                     </td>
                     <td className="px-3 py-3">
                       <label className="flex min-h-10 items-center gap-2 text-sm">
-                        <input
-                          type="checkbox"
+                        <Switch
                           checked={scheduleState.isEnabled}
-                          onChange={(event) => updateScheduleEditor(row.key, { isEnabled: event.target.checked }, row.entityType)}
+                          onCheckedChange={(checked) => updateScheduleEditor(row.key, { isEnabled: checked }, row.entityType)}
                           disabled={controlsDisabled}
+                          aria-label={t('data_sync.dashboard.schedule.enabled', 'Schedule enabled')}
                         />
                         <span>{scheduleState.isEnabled ? t('data_sync.dashboard.schedule.status.shortEnabled', 'Scheduled') : t('data_sync.dashboard.schedule.status.shortDisabled', 'Paused')}</span>
                       </label>

--- a/packages/core/src/modules/data_sync/lib/__tests__/syncRunStatus.test.tsx
+++ b/packages/core/src/modules/data_sync/lib/__tests__/syncRunStatus.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import { StatusBadge } from '@open-mercato/ui/primitives/status-badge'
+import {
+  getSyncRunStatusVariant,
+  getSyncSummaryVariant,
+  syncRunStatusVariants,
+  syncSummaryVariants,
+} from '../syncRunStatus'
+
+const HARDCODED_STATUS_COLOR = /(bg|text|border)-(green|red|blue|gray|yellow|orange|emerald|amber|sky|rose|slate)-\d{2,3}/
+
+describe('data_sync syncRunStatus helper', () => {
+  it('maps every run status to a semantic design-system variant', () => {
+    expect(syncRunStatusVariants).toEqual({
+      pending: 'neutral',
+      running: 'info',
+      completed: 'success',
+      failed: 'error',
+      cancelled: 'warning',
+      paused: 'warning',
+    })
+  })
+
+  it('falls back to neutral for unknown run statuses', () => {
+    expect(getSyncRunStatusVariant('something-else')).toBe('neutral')
+  })
+
+  it('maps summary kinds to semantic variants', () => {
+    expect(syncSummaryVariants).toEqual({
+      enabled: 'success',
+      ready: 'success',
+      disabled: 'neutral',
+      missing: 'warning',
+      scheduled: 'info',
+      paused: 'warning',
+      none: 'neutral',
+    })
+    expect(getSyncSummaryVariant('enabled')).toBe('success')
+    expect(getSyncSummaryVariant('missing')).toBe('warning')
+  })
+
+  it('renders run-status badges with semantic status tokens, never raw Tailwind colors', () => {
+    for (const status of Object.keys(syncRunStatusVariants)) {
+      const { container, unmount } = render(
+        <StatusBadge variant={getSyncRunStatusVariant(status)}>{status}</StatusBadge>,
+      )
+      const badge = container.querySelector('[data-slot="badge"]')
+      expect(badge).not.toBeNull()
+      expect(badge?.className).toContain('-status-')
+      expect(badge?.className ?? '').not.toMatch(HARDCODED_STATUS_COLOR)
+      unmount()
+    }
+  })
+})

--- a/packages/core/src/modules/data_sync/lib/syncRunStatus.ts
+++ b/packages/core/src/modules/data_sync/lib/syncRunStatus.ts
@@ -1,0 +1,39 @@
+import type { StatusBadgeVariant, StatusMap } from '@open-mercato/ui/primitives/status-badge'
+
+export type SyncRunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'paused'
+
+export const syncRunStatusVariants: StatusMap<SyncRunStatus> = {
+  pending: 'neutral',
+  running: 'info',
+  completed: 'success',
+  failed: 'error',
+  cancelled: 'warning',
+  paused: 'warning',
+}
+
+export function getSyncRunStatusVariant(status: string): StatusBadgeVariant {
+  return syncRunStatusVariants[status as SyncRunStatus] ?? 'neutral'
+}
+
+export type SyncSummaryKind =
+  | 'enabled'
+  | 'disabled'
+  | 'ready'
+  | 'missing'
+  | 'scheduled'
+  | 'paused'
+  | 'none'
+
+export const syncSummaryVariants: Record<SyncSummaryKind, StatusBadgeVariant> = {
+  enabled: 'success',
+  ready: 'success',
+  disabled: 'neutral',
+  missing: 'warning',
+  scheduled: 'info',
+  paused: 'warning',
+  none: 'neutral',
+}
+
+export function getSyncSummaryVariant(kind: SyncSummaryKind): StatusBadgeVariant {
+  return syncSummaryVariants[kind] ?? 'neutral'
+}


### PR DESCRIPTION
Fixes #3216

## Problem
The `data_sync` admin UI used raw `<input type=checkbox>` controls and hard-coded Tailwind status colors instead of shared UI primitives and design-system status tokens, violating `packages/ui/AGENTS.md` and the DS rules (no raw checkboxes, no hard-coded status colors for backend UI).

## Root Cause
The dashboard (`backend/data-sync/page.tsx`), run-detail page (`backend/data-sync/runs/[id]/page.tsx`), and `components/IntegrationScheduleTab.tsx` predate the shared `StatusBadge`/`Switch` primitives, so they carried local `STATUS_STYLES` color maps, an inline `getSummaryBadgeStyle` color map, ad-hoc `emerald/amber/sky` badge classes, and raw checkbox inputs.

## What Changed
- **Centralized helper** `data_sync/lib/syncRunStatus.ts` — maps sync run statuses and integration/schedule summary kinds to semantic `StatusBadge` variants (design-system status tokens only, no hard-coded colors).
- **Status maps removed** — both `STATUS_STYLES` maps replaced with `StatusBadge` + `getSyncRunStatusVariant` (dashboard table + run detail status & progress badges).
- **Summary badges** — `getSummaryBadgeStyle` and the inline `emerald/amber/sky` badge classes replaced with semantic `Badge` variants via `getSyncSummaryVariant` (dashboard header + schedule tab).
- **Boy Scout** — remaining hard-coded counter colors (`text-green-600`, `text-blue-600`, `text-gray-600`, `text-red-600`) and the error card (`border-red-200 bg-red-50`, `text-red-800/700`) on the run-detail page migrated to `status-*` / `muted-foreground` tokens.
- **Raw checkboxes → `Switch`** — the full-sync and schedule-enabled checkboxes in `IntegrationScheduleTab` now use the shared `Switch` primitive (with `aria-label`s), matching the dashboard's existing toggles for the same fields.

No behavior change beyond the primitive/token swaps; status mappings were unified across the dashboard and schedule tab (they previously disagreed: `disabled`→neutral, `missing`→warning).

## Tests
- New render test `data_sync/lib/__tests__/syncRunStatus.test.tsx` — asserts every run status maps to a semantic variant and that rendered badges use `-status-` tokens and contain **no** raw Tailwind color shades (fails before this change, since the helper did not exist).
- `@open-mercato/core` `data_sync` suite: 9 suites / 28 tests pass.
- `optimistic-lock-ui-coverage` guard passes (no new raw mutating UI calls).
- Full gate: `build:packages` → `generate` → `build:packages`, `typecheck` (21/21), `i18n:check-sync` (in sync), `i18n:check-usage` (advisory only), `build:app` — all green.

## Backward Compatibility
No contract-surface changes. Removed symbols (`STATUS_STYLES`, `getSummaryBadgeStyle`, `SummaryBadgeStyle`) were module-local and unexported; the new `syncRunStatus.ts` helper is additive. No API responses, event IDs, DI keys, ACL features, DB schema, or import paths changed.

## Self-review note
Opened from a fork without upstream triage permission, so labels/assignees and the formal review verdict cannot be applied from here. Intended labels: `review`, `bug`, `needs-qa` (interactive admin UI change), `priority-low` (inherited), `risk-low` (inherited). A documented self code-review + BC review was performed against `om-code-review` and `BACKWARD_COMPATIBILITY.md`.