### PR TITLE
fix(dashboards): skip role visibility lookups when user override selects widgets (#3209)

### DIFF
--- a/packages/core/src/modules/dashboards/lib/__tests__/access.test.ts
+++ b/packages/core/src/modules/dashboards/lib/__tests__/access.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment node
+ */
+import type { EntityManager } from '@mikro-orm/postgresql'
+
+const mockFindWithDecryption = jest.fn()
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
+}))
+
+import { resolveAllowedWidgetIds } from '../access'
+
+type WidgetInput = { metadata: { id: string; features?: string[] } }
+
+function widget(id: string, features?: string[]): WidgetInput {
+  return { metadata: { id, ...(features ? { features } : {}) } }
+}
+
+const baseCtx = {
+  userId: 'user-1',
+  tenantId: 'tenant-1',
+  organizationId: 'org-1',
+  features: [] as string[],
+  isSuperAdmin: false,
+}
+
+type EmStub = {
+  findOne: jest.Mock
+  find: jest.Mock
+}
+
+function makeEm(options: { userRecord?: unknown; roleRecords?: unknown[] }): EmStub {
+  return {
+    findOne: jest.fn(async () => options.userRecord ?? null),
+    find: jest.fn(async () => options.roleRecords ?? []),
+  }
+}
+
+beforeEach(() => {
+  mockFindWithDecryption.mockReset()
+  mockFindWithDecryption.mockResolvedValue([])
+})
+
+describe('resolveAllowedWidgetIds', () => {
+  test('non-empty user override wins and skips role-level lookups', async () => {
+    const em = makeEm({ userRecord: { mode: 'override', widgetIdsJson: ['a', 'b'] } })
+    const widgets = [widget('a'), widget('b'), widget('c')]
+
+    const result = await resolveAllowedWidgetIds(em as unknown as EntityManager, baseCtx, widgets)
+
+    expect(result).toEqual(['a', 'b'])
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(em.find).not.toHaveBeenCalled()
+  })
+
+  test('empty user override returns no widgets without role lookups', async () => {
+    const em = makeEm({ userRecord: { mode: 'override', widgetIdsJson: [] } })
+    const widgets = [widget('a'), widget('b')]
+
+    const result = await resolveAllowedWidgetIds(em as unknown as EntityManager, baseCtx, widgets)
+
+    expect(result).toEqual([])
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(em.find).not.toHaveBeenCalled()
+  })
+
+  test('feature gating still applies to a user override selection', async () => {
+    const em = makeEm({ userRecord: { mode: 'override', widgetIdsJson: ['a', 'b'] } })
+    const widgets = [widget('a'), widget('b', ['dashboards.secret'])]
+
+    const result = await resolveAllowedWidgetIds(em as unknown as EntityManager, baseCtx, widgets)
+
+    expect(result).toEqual(['a'])
+    expect(em.find).not.toHaveBeenCalled()
+  })
+
+  test('inherited mode aggregates role widgets', async () => {
+    mockFindWithDecryption.mockResolvedValue([{ role: { id: 'role-1' } }])
+    const em = makeEm({
+      userRecord: { mode: 'inherit', widgetIdsJson: ['a'] },
+      roleRecords: [{ roleId: 'role-1', tenantId: null, organizationId: null, widgetIdsJson: ['b'] }],
+    })
+    const widgets = [widget('a'), widget('b'), widget('c')]
+
+    const result = await resolveAllowedWidgetIds(em as unknown as EntityManager, baseCtx, widgets)
+
+    expect(result).toEqual(['b'])
+    expect(mockFindWithDecryption).toHaveBeenCalledTimes(1)
+    expect(em.find).toHaveBeenCalledTimes(1)
+  })
+
+  test('falls back to all widgets when there is no override and no role records', async () => {
+    mockFindWithDecryption.mockResolvedValue([])
+    const em = makeEm({ userRecord: null, roleRecords: [] })
+    const widgets = [widget('a'), widget('b')]
+
+    const result = await resolveAllowedWidgetIds(em as unknown as EntityManager, baseCtx, widgets)
+
+    expect(result).toEqual(['a', 'b'])
+    expect(mockFindWithDecryption).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/dashboards/lib/access.ts
+++ b/packages/core/src/modules/dashboards/lib/access.ts
@@ -50,50 +50,47 @@ export async function resolveAllowedWidgetIds(
     }
   }
 
-  if (allowedByUser && allowedByUser.size === 0) {
-    return Array.from(allowedByUser)
-  }
-
-  // Aggregate role-level settings
-  const userRoles = await findWithDecryption(
-    em,
-    UserRole,
-    { user: ctx.userId as any, deletedAt: null },
-    { populate: ['role'] },
-    { tenantId: ctx.tenantId, organizationId: ctx.organizationId },
-  )
-  const roleRecords = await em.find(DashboardRoleWidgets, {
-    roleId: { $in: userRoles.map((ur) => String(ur.role?.id || ur.role)) },
-    deletedAt: null,
-  })
-
-  const byRole = new Map<string, DashboardRoleWidgets>()
-  for (const record of roleRecords) {
-    const role = String(record.roleId)
-    if (record.tenantId && ctx.tenantId && record.tenantId !== ctx.tenantId) continue
-    if (record.tenantId && !ctx.tenantId) continue
-    if (record.organizationId && ctx.organizationId && record.organizationId !== ctx.organizationId) continue
-    if (record.organizationId && !ctx.organizationId) continue
-    const current = byRole.get(role)
-    if (!current || specificity(record) > specificity(current)) {
-      byRole.set(role, record)
-    }
-  }
-
-  const allowedByRole = new Set<string>()
-  for (const record of byRole.values()) {
-    for (const id of record.widgetIdsJson) {
-      if (allWidgetIds.includes(id)) allowedByRole.add(id)
-    }
-  }
-
   let baseSet: Set<string>
   if (allowedByUser) {
+    // A user override fully determines visibility, so role-level lookups would
+    // be discarded — skip them entirely. An empty override is handled by the
+    // shared `baseSet.size === 0` guard below.
     baseSet = allowedByUser
-  } else if (allowedByRole.size > 0) {
-    baseSet = allowedByRole
   } else {
-    baseSet = new Set(allWidgetIds)
+    // No user override: aggregate role-level settings.
+    const userRoles = await findWithDecryption(
+      em,
+      UserRole,
+      { user: ctx.userId as any, deletedAt: null },
+      { populate: ['role'] },
+      { tenantId: ctx.tenantId, organizationId: ctx.organizationId },
+    )
+    const roleRecords = await em.find(DashboardRoleWidgets, {
+      roleId: { $in: userRoles.map((ur) => String(ur.role?.id || ur.role)) },
+      deletedAt: null,
+    })
+
+    const byRole = new Map<string, DashboardRoleWidgets>()
+    for (const record of roleRecords) {
+      const role = String(record.roleId)
+      if (record.tenantId && ctx.tenantId && record.tenantId !== ctx.tenantId) continue
+      if (record.tenantId && !ctx.tenantId) continue
+      if (record.organizationId && ctx.organizationId && record.organizationId !== ctx.organizationId) continue
+      if (record.organizationId && !ctx.organizationId) continue
+      const current = byRole.get(role)
+      if (!current || specificity(record) > specificity(current)) {
+        byRole.set(role, record)
+      }
+    }
+
+    const allowedByRole = new Set<string>()
+    for (const record of byRole.values()) {
+      for (const id of record.widgetIdsJson) {
+        if (allWidgetIds.includes(id)) allowedByRole.add(id)
+      }
+    }
+
+    baseSet = allowedByRole.size > 0 ? allowedByRole : new Set(allWidgetIds)
   }
 
   if (baseSet.size === 0) return []


### PR DESCRIPTION
Fixes #3209

## Problem
`resolveAllowedWidgetIds` still loaded role assignments (the decrypted `UserRole` lookup) and `DashboardRoleWidgets` settings after finding a non-empty user-level override, even though that role work was discarded when the user override was selected as the base widget set. For users with explicit dashboard-widget overrides, every dashboard layout/access resolution paid for those extra queries.

## Root Cause
The role-level aggregation ran unconditionally between the user-override resolution and the final `baseSet` selection. The `if (allowedByUser) baseSet = allowedByUser` branch then ignored the role results entirely.

## What Changed
- `packages/core/src/modules/dashboards/lib/access.ts`: moved the role-level aggregation (`findWithDecryption(UserRole)` + `em.find(DashboardRoleWidgets)` + the specificity merge) into the `else` branch that runs only when there is **no** user override. A present non-empty override now short-circuits both queries.
- Folded the previous empty-override early `return` into the shared `baseSet.size === 0` guard, so the empty-override path also skips role lookups and returns `[]` — identical output.
- Inherited mode, the default-all fallback, and feature filtering are unchanged; feature gating still applies to the user-selected set.

## Tests
- New `packages/core/src/modules/dashboards/lib/__tests__/access.test.ts` covering all four paths the issue requested — empty override, non-empty override (the **regression guard**: asserts `findWithDecryption` and `em.find` are not called), role-inherited aggregation, default-all fallback — plus feature gating on an override selection.
- Verified the new test **fails against the pre-fix code** (role lookups ran → 2 failing assertions) and **passes after the fix**.
- `yarn workspace @open-mercato/core test src/modules/dashboards` → 84 passed (6 suites).
- `tsc --noEmit` on `@open-mercato/core` → 0 errors.
- `yarn build:packages` and `yarn build:app` → green.

## Backward Compatibility
- No contract surface changes. `resolveAllowedWidgetIds` keeps its signature and `Promise<string[]>` return; outputs are identical for every path. Internal `lib` helper only — not an exported/public API.

## Notes
- The dashboard-owned tables (`DashboardUserWidgets`, `DashboardRoleWidgets`) are **not** encrypted (the module ships no `encryption.ts`); the whole module reads them with raw `em.find`/`em.findOne`, and only the cross-module `UserRole` read uses `findWithDecryption`. The relocated `em.find(DashboardRoleWidgets)` keeps that established pattern — no new raw read of an encrypted entity is introduced.

## Suggested triage
Low-risk, behavior-preserving backend perf refactor with full unit coverage. Recommended labels (carried from the issue): `priority-low`, `risk-low`, `performance`, `skip-qa`.
