### PR TITLE
perf(customers): parallelize tag dialog option loading (#3202)

### DIFF
--- a/packages/core/src/modules/customers/components/detail/EntityTagsDialog.tsx
+++ b/packages/core/src/modules/customers/components/detail/EntityTagsDialog.tsx
@@ -438,53 +438,49 @@ export function EntityTagsDialog({
   const loadData = React.useCallback(async () => {
     setLoading(true)
     try {
-      let kindSettings: KindSetting[] = []
       const scopedQuery = new URLSearchParams()
       if (entityOrganizationId) {
         scopedQuery.set('organizationId', entityOrganizationId)
       }
-      try {
-        const settingsCall = await apiCall<{ items?: KindSetting[] }>(
-          `/api/customers/dictionaries/kind-settings${scopedQuery.size ? `?${scopedQuery.toString()}` : ''}`,
-          { cache: 'no-store', headers: { 'x-om-unauthorized-redirect': '0' } },
-        )
-        if (settingsCall.ok && settingsCall.result?.items) {
-          kindSettings = settingsCall.result.items
+
+      const loadKindSettings = async (): Promise<KindSetting[]> => {
+        try {
+          const settingsCall = await apiCall<{ items?: KindSetting[] }>(
+            `/api/customers/dictionaries/kind-settings${scopedQuery.size ? `?${scopedQuery.toString()}` : ''}`,
+            { cache: 'no-store', headers: { 'x-om-unauthorized-redirect': '0' } },
+          )
+          if (settingsCall.ok && settingsCall.result?.items) {
+            return settingsCall.result.items
+          }
+        } catch {
+          // Default category order works without explicit settings rows.
         }
-      } catch {
-        // Default category order works without explicit settings rows.
+        return []
       }
 
-      const settingsMap = new Map(kindSettings.map((setting) => [setting.kind, setting]))
-
-      const selectedTagEntries = Array.isArray(entityData.tags)
-        ? entityData.tags.map((tag) => ({
-            id: tag.id,
-            value: tag.id,
-            label: tag.label,
-            color: tag.color ?? null,
-          }))
-        : []
-
-      let assignedLabelIds: string[] = []
-      let selectedLabelEntries: CategoryOption[] = []
-      try {
-        const labelsQuery = new URLSearchParams()
-        labelsQuery.set('entityId', entityId)
-        labelsQuery.set('pageSize', '1')
-        if (entityOrganizationId) {
-          labelsQuery.set('organizationId', entityOrganizationId)
-        }
-        const labelsCall = await apiCall<{
-          items?: LabelItem[]
-          assignedIds?: string[]
-        }>(`/api/customers/labels?${labelsQuery.toString()}`, {
-          cache: 'no-store',
-          headers: { 'x-om-unauthorized-redirect': '0' },
-        })
-        const labelsData = labelsCall.ok ? labelsCall.result : null
-        assignedLabelIds = labelsData?.assignedIds ?? []
-        if (assignedLabelIds.length > 0) {
+      const loadLabelData = async (): Promise<{
+        assignedLabelIds: string[]
+        selectedLabelEntries: CategoryOption[]
+      }> => {
+        try {
+          const labelsQuery = new URLSearchParams()
+          labelsQuery.set('entityId', entityId)
+          labelsQuery.set('pageSize', '1')
+          if (entityOrganizationId) {
+            labelsQuery.set('organizationId', entityOrganizationId)
+          }
+          const labelsCall = await apiCall<{
+            items?: LabelItem[]
+            assignedIds?: string[]
+          }>(`/api/customers/labels?${labelsQuery.toString()}`, {
+            cache: 'no-store',
+            headers: { 'x-om-unauthorized-redirect': '0' },
+          })
+          const labelsData = labelsCall.ok ? labelsCall.result : null
+          const assignedLabelIds = labelsData?.assignedIds ?? []
+          if (assignedLabelIds.length === 0) {
+            return { assignedLabelIds, selectedLabelEntries: [] }
+          }
           const detailQuery = new URLSearchParams({
             ids: assignedLabelIds.join(','),
             pageSize: String(Math.min(assignedLabelIds.length, 100)),
@@ -500,44 +496,36 @@ export function EntityTagsDialog({
             },
           )
           const selectedLabels = selectedLabelsCall.ok ? selectedLabelsCall.result?.items ?? [] : []
-          selectedLabelEntries = selectedLabels.map((label) => ({
+          const selectedLabelEntries = selectedLabels.map((label) => ({
             id: label.id,
             value: label.id,
             label: label.label,
             color: null,
           }))
+          return { assignedLabelIds, selectedLabelEntries }
+        } catch {
+          return { assignedLabelIds: [], selectedLabelEntries: [] }
         }
-      } catch {
-        assignedLabelIds = []
-        selectedLabelEntries = []
       }
 
+      const selectedTagEntries = Array.isArray(entityData.tags)
+        ? entityData.tags.map((tag) => ({
+            id: tag.id,
+            value: tag.id,
+            label: tag.label,
+            color: tag.color ?? null,
+          }))
+        : []
+
+      // The label chain is independent of kind settings and the dictionary
+      // fan-out, so kick it off immediately and let it resolve in parallel.
+      const labelDataPromise = loadLabelData()
+
+      const kindSettings = await loadKindSettings()
+      const settingsMap = new Map(kindSettings.map((setting) => [setting.kind, setting]))
       const categoryDefs = buildApplicableCategories(entityType, kindSettings)
-      const loadedCategories: CategorySection[] = []
 
-      for (const categoryDef of categoryDefs) {
-        if (categoryDef.source === 'tags') {
-          loadedCategories.push({
-            ...categoryDef,
-            label: t(categoryDef.labelKey, categoryDef.labelFallback),
-            description: t(categoryDef.descriptionKey, categoryDef.descriptionFallback),
-            entries: sortOptions(selectedTagEntries),
-            selectionMode: categoryDef.selectionMode ?? 'multi',
-          })
-          continue
-        }
-
-        if (categoryDef.source === 'labels') {
-          loadedCategories.push({
-            ...categoryDef,
-            label: t(categoryDef.labelKey, categoryDef.labelFallback),
-            description: t(categoryDef.descriptionKey, categoryDef.descriptionFallback),
-            entries: sortOptions(selectedLabelEntries),
-            selectionMode: categoryDef.selectionMode ?? 'multi',
-          })
-          continue
-        }
-
+      const loadDictionaryCategory = async (categoryDef: CategoryDef): Promise<CategorySection> => {
         try {
           const dictionaryUrl = new URL(`/api/customers/dictionaries/${categoryDef.routeKind}`, 'http://localhost')
           if (entityOrganizationId) {
@@ -568,7 +556,7 @@ export function EntityTagsDialog({
               color: null,
             })
           })
-          loadedCategories.push({
+          return {
             ...categoryDef,
             label: categoryDef.labelKey
               ? t(categoryDef.labelKey, categoryDef.labelFallback)
@@ -582,7 +570,7 @@ export function EntityTagsDialog({
               : categoryDef.descriptionFallback,
             entries: sortOptions(entries),
             selectionMode,
-          })
+          }
         } catch {
           const setting = categoryDef.settingKind
             ? settingsMap.get(categoryDef.settingKind)
@@ -594,7 +582,7 @@ export function EntityTagsDialog({
             label: value,
             color: null,
           }))
-          loadedCategories.push({
+          return {
             ...categoryDef,
             label: categoryDef.labelKey
               ? t(categoryDef.labelKey, categoryDef.labelFallback)
@@ -608,9 +596,39 @@ export function EntityTagsDialog({
               : categoryDef.descriptionFallback,
             entries: fallbackEntries,
             selectionMode,
-          })
+          }
         }
       }
+
+      // Independent dictionary requests fan out together instead of awaiting
+      // each one sequentially; Promise.all preserves categoryDefs order so the
+      // subsequent sort and selection initialization stay stable.
+      const loadedCategories = await Promise.all(
+        categoryDefs.map(async (categoryDef): Promise<CategorySection> => {
+          if (categoryDef.source === 'tags') {
+            return {
+              ...categoryDef,
+              label: t(categoryDef.labelKey, categoryDef.labelFallback),
+              description: t(categoryDef.descriptionKey, categoryDef.descriptionFallback),
+              entries: sortOptions(selectedTagEntries),
+              selectionMode: categoryDef.selectionMode ?? 'multi',
+            }
+          }
+          if (categoryDef.source === 'labels') {
+            const { selectedLabelEntries } = await labelDataPromise
+            return {
+              ...categoryDef,
+              label: t(categoryDef.labelKey, categoryDef.labelFallback),
+              description: t(categoryDef.descriptionKey, categoryDef.descriptionFallback),
+              entries: sortOptions(selectedLabelEntries),
+              selectionMode: categoryDef.selectionMode ?? 'multi',
+            }
+          }
+          return loadDictionaryCategory(categoryDef)
+        }),
+      )
+
+      const { assignedLabelIds, selectedLabelEntries } = await labelDataPromise
 
       loadedCategories.sort((left, right) => {
         const leftSortOrder =

--- a/packages/core/src/modules/customers/components/detail/__tests__/EntityTagsDialog.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/EntityTagsDialog.test.tsx
@@ -268,4 +268,102 @@ describe('EntityTagsDialog', () => {
 
     expect(screen.getByText('Champion')).toBeInTheDocument()
   })
+
+  it('fans out independent dictionary requests in parallel instead of waterfalling', async () => {
+    const requestedDictionaries = new Set<string>()
+    let releaseDictionaries: () => void = () => {}
+    const dictionaryGate = new Promise<void>((resolve) => {
+      releaseDictionaries = resolve
+    })
+
+    apiCallMock.mockImplementation((url: string) => {
+      if (url.startsWith('/api/customers/dictionaries/kind-settings')) {
+        return Promise.resolve({ ok: true, result: { items: [] } })
+      }
+      if (url.startsWith('/api/customers/labels?')) {
+        return Promise.resolve({ ok: true, result: { items: [], assignedIds: [], totalPages: 1 } })
+      }
+      if (url.startsWith('/api/customers/dictionaries/')) {
+        requestedDictionaries.add(new URL(url, 'http://localhost').pathname)
+        return dictionaryGate.then(() => ({ ok: true, result: { items: [] } }))
+      }
+      return Promise.resolve({ ok: true, result: { items: [] } })
+    })
+
+    await act(async () => {
+      renderWithProviders(
+        <EntityTagsDialog
+          open
+          onClose={jest.fn()}
+          entityId="person-1"
+          entityType="person"
+          entityOrganizationId="org-1"
+          entityData={{}}
+        />,
+      )
+    })
+
+    // The previous sequential loop awaited each dictionary in turn, so while the
+    // gate is held only the first request would have been issued. The parallel
+    // fan-out issues every person dictionary category before any resolves.
+    await waitFor(() => {
+      expect(requestedDictionaries).toEqual(
+        new Set([
+          '/api/customers/dictionaries/statuses',
+          '/api/customers/dictionaries/lifecycle-stages',
+          '/api/customers/dictionaries/sources',
+          '/api/customers/dictionaries/temperature',
+          '/api/customers/dictionaries/renewal-quarters',
+          '/api/customers/dictionaries/job-titles',
+        ]),
+      )
+    })
+
+    await act(async () => {
+      releaseDictionaries()
+    })
+  })
+
+  it('keeps unrelated categories working and falls back when one dictionary request fails', async () => {
+    apiCallMock.mockImplementation((url: string) => {
+      if (url.startsWith('/api/customers/dictionaries/kind-settings')) {
+        return Promise.resolve({ ok: true, result: { items: [] } })
+      }
+      if (url.startsWith('/api/customers/labels?')) {
+        return Promise.resolve({ ok: true, result: { items: [], assignedIds: [], totalPages: 1 } })
+      }
+      if (url.startsWith('/api/customers/dictionaries/sources')) {
+        return Promise.reject(new Error('network down'))
+      }
+      if (url.startsWith('/api/customers/dictionaries/statuses')) {
+        return Promise.resolve({
+          ok: true,
+          result: { items: [{ id: 'status-1', value: 'active', label: 'Active', color: null }] },
+        })
+      }
+      return Promise.resolve({ ok: true, result: { items: [] } })
+    })
+
+    await act(async () => {
+      renderWithProviders(
+        <EntityTagsDialog
+          open
+          onClose={jest.fn()}
+          entityId="person-1"
+          entityType="person"
+          entityOrganizationId="org-1"
+          entityData={{ source: 'outbound_campaign', status: 'active' }}
+        />,
+      )
+    })
+
+    // The failed Source dictionary still produces a fallback entry for the
+    // record's current value, scoped to that category only.
+    fireEvent.click(screen.getByRole('button', { name: /^Source\b/ }))
+    expect(screen.getByText('outbound_campaign')).toBeInTheDocument()
+
+    // Unrelated categories resolved by their own requests are unaffected.
+    fireEvent.click(screen.getByRole('button', { name: /^Status\b/ }))
+    expect(screen.getByText('Active')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Fixes #3202

## Problem
`EntityTagsDialog.loadData` serialized several independent requests before the dialog could render editable categories. Opening the tag/category dialog awaited kind settings, then the label-assignment + selected-label-detail chain, then **each** dictionary-backed category one after another. Most of that work is independent once the category definitions are known, so the modal paid for an avoidable client-side request waterfall (6 sequential dictionary fetches for a person).

## Root Cause
`loadData` used `await` for every request in sequence and a `for … of` loop that awaited each dictionary fetch individually (`EntityTagsDialog.tsx`, the kind-settings fetch → label chain → per-category dictionary loop).

## What Changed
- The label chain (assigned-id lookup + selected-label detail) now starts immediately and resolves **in parallel** with the kind-settings request and the dictionary fan-out.
- Dictionary-backed categories are fetched together via `Promise.all` instead of a sequential `for` loop. Dictionary fetches still depend on kind settings (needed to compute the applicable category definitions), but no longer on each other.
- `Promise.all` preserves `categoryDefs` order, so the existing category **sort** and **selection initialization** are unchanged.

Best-effort behavior is preserved exactly:
- missing kind settings fall back to the default category order,
- label failures degrade to empty (tag editing still works),
- an individual dictionary failure still yields a fallback entry for **that category only** (each dictionary load keeps its own try/catch, so one rejection never breaks the dialog).

## Tests
- `fans out independent dictionary requests in parallel instead of waterfalling` — holds a gate open over the dictionary responses and asserts all six person dictionary categories are requested before any resolves. **Fails against the previous sequential loop** (which would only issue the first request) and passes with the parallel fan-out.
- `keeps unrelated categories working and falls back when one dictionary request fails` — one dictionary request rejects; the affected category still shows a fallback entry for the record's current value and unrelated categories load normally.
- Full `EntityTagsDialog` suite (7) and the customers components suite (58 suites / 214 tests) pass.
- `yarn build:packages`, `yarn generate`, and `@open-mercato/core` typecheck are green.

## Backward Compatibility
No contract-surface changes. `EntityTagsDialog`'s props/exports are unchanged; this is an internal restructuring of a client component's data loading. No API routes, types, event IDs, DI keys, ACL features, or import paths were touched.

## Labels (fork note)
This PR is opened from a fork without upstream label/assignee permissions. Suggested labels (please apply on merge-in): `review`, `refactor`, `performance`, `priority-low`, `risk-low`. The change is behavior-preserving and unit-covered.