### PR TITLE
fix(query): bound encrypted-field sort with two-phase fetch + chunked decrypt

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -166,9 +166,11 @@ function resolveFirstRow(
     // Existence probe used by isCustomEntity/hasCustomEntityStorageRows.
     return (config.rows?.custom_entities_storage ?? []).length ? { one: 1 } : undefined
   }
-  // Count subquery / data reads: look for `count` alias in selects.
+  // Count subquery / data reads: look for `count` alias in selects. Kysely's
+  // `AliasedRawBuilderImpl` exposes the alias via a getter named `alias`
+  // (not `name`), and never re-exposes `.as`.
   const hasCount = log.selects.some((s: any) => {
-    try { return String(s?.name ?? s) === 'count' || typeof s?.as === 'function' } catch { return false }
+    try { return String(s?.alias ?? s) === 'count' } catch { return false }
   })
   if (hasCount) return { count: String(table === 'entity_indexes' ? config.indexCount : config.baseCount) }
   if (table === 'entity_indexes') {
@@ -593,7 +595,9 @@ describe('HybridQueryEngine', () => {
     )
 
     const result = await engine.query('customers:customer_entity', {
-      fields: ['id', 'display_name'],
+      // `tenant_id` is requested for output but is not a sort field, so phase 1
+      // (id + sort columns only) should select fewer columns than phase 2 (full row).
+      fields: ['id', 'display_name', 'tenant_id'],
       organizationId: 'org1',
       tenantId: 't1',
       sort: [{ field: 'display_name', dir: SortDir.Asc }],
@@ -602,12 +606,191 @@ describe('HybridQueryEngine', () => {
 
     expect(fallback.query).not.toHaveBeenCalled()
     expect(result.items.map((item: any) => item.display_name)).toEqual(['Charlie', 'Dave'])
-    const dataRead = db._chains
-      .filter((chain: ChainLog) => chain.table === 'customer_entities')
-      .at(-1)
-    expect(dataRead?.orderBys).toEqual([])
-    expect(dataRead?.limit).toBeNull()
-    expect(dataRead?.offset).toBeNull()
+    const customerEntityChains = db._chains.filter((chain: ChainLog) => chain.table === 'customer_entities')
+    // count (optimized path), phase 1 (slim id+sort-column scan), phase 2 (full fetch).
+    expect(customerEntityChains.length).toBe(3)
+    const [phase1Chain, phase2Chain] = customerEntityChains.slice(-2)
+    // Phase 1: no SQL order/limit — the full candidate set is fetched, decrypted,
+    // and sorted in memory.
+    expect(phase1Chain.orderBys).toEqual([])
+    expect(phase1Chain.limit).toBeNull()
+    expect(phase1Chain.selects.length).toBeLessThan(phase2Chain.selects.length)
+    // Phase 2: filtered by `id in [...]`, no SQL order/limit needed since the id
+    // list already bounds it to the page.
+    expect(phase2Chain.orderBys).toEqual([])
+    expect(phase2Chain.limit).toBeNull()
+    expect(phase2Chain.offset).toBeNull()
+    expect(phase2Chain.wheres.some((args: any[]) => args.includes('in'))).toBe(true)
+  })
+
+  test('paginates encrypted-sorted results correctly on page 1 and the tail page', async () => {
+    const db = createFakeKysely({
+      baseTable: 'customer_entities',
+      hasIndexAny: true,
+      baseCount: 5,
+      indexCount: 5,
+      columns: [
+        { table_name: 'customer_entities', column_name: 'id' },
+        { table_name: 'customer_entities', column_name: 'tenant_id' },
+        { table_name: 'customer_entities', column_name: 'organization_id' },
+        { table_name: 'customer_entities', column_name: 'deleted_at' },
+        { table_name: 'customer_entities', column_name: 'display_name' },
+      ],
+      rows: {
+        customer_entities: [
+          { id: '3', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-c' },
+          { id: '1', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-a' },
+          { id: '5', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-e' },
+          { id: '2', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-b' },
+          { id: '4', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-d' },
+        ],
+      },
+    })
+    const namesById: Record<string, string> = {
+      '1': 'Alice', '2': 'Bob', '3': 'Charlie', '4': 'Dave', '5': 'Eve',
+    }
+    const em = buildEm(db)
+    const fallback = { query: jest.fn() }
+    const emitEvent = jest.fn().mockResolvedValue(undefined)
+    const engine = new HybridQueryEngine(
+      em,
+      fallback as any,
+      () => ({ emitEvent }),
+      undefined,
+      () => ({
+        isEnabled: () => true,
+        getEncryptedFieldNames: async () => ['display_name'],
+        decryptEntityPayload: async (_entityId, payload) => ({
+          display_name: namesById[String(payload.id)],
+        }),
+      }),
+    )
+
+    const page1 = await engine.query('customers:customer_entity', {
+      fields: ['id', 'display_name'],
+      organizationId: 'org1',
+      tenantId: 't1',
+      sort: [{ field: 'display_name', dir: SortDir.Asc }],
+      page: { page: 1, pageSize: 2 },
+    })
+    expect(page1.items.map((item: any) => item.display_name)).toEqual(['Alice', 'Bob'])
+
+    const page3 = await engine.query('customers:customer_entity', {
+      fields: ['id', 'display_name'],
+      organizationId: 'org1',
+      tenantId: 't1',
+      sort: [{ field: 'display_name', dir: SortDir.Asc }],
+      page: { page: 3, pageSize: 2 },
+    })
+    expect(page3.items.map((item: any) => item.display_name)).toEqual(['Eve'])
+  })
+
+  describe('OM_ENCRYPTED_SORT_MAX_ROWS cap', () => {
+    const originalEnv = process.env.OM_ENCRYPTED_SORT_MAX_ROWS
+
+    afterEach(() => {
+      if (originalEnv === undefined) delete process.env.OM_ENCRYPTED_SORT_MAX_ROWS
+      else process.env.OM_ENCRYPTED_SORT_MAX_ROWS = originalEnv
+    })
+
+    function buildFixture() {
+      const db = createFakeKysely({
+        baseTable: 'customer_entities',
+        hasIndexAny: true,
+        baseCount: 5,
+        indexCount: 5,
+        columns: [
+          { table_name: 'customer_entities', column_name: 'id' },
+          { table_name: 'customer_entities', column_name: 'tenant_id' },
+          { table_name: 'customer_entities', column_name: 'organization_id' },
+          { table_name: 'customer_entities', column_name: 'deleted_at' },
+          { table_name: 'customer_entities', column_name: 'display_name' },
+        ],
+        rows: {
+          customer_entities: [
+            { id: '3', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-c' },
+            { id: '1', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-a' },
+            { id: '5', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-e' },
+            { id: '2', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-b' },
+            { id: '4', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-d' },
+          ],
+        },
+      })
+      const namesById: Record<string, string> = {
+        '1': 'Alice', '2': 'Bob', '3': 'Charlie', '4': 'Dave', '5': 'Eve',
+      }
+      const em = buildEm(db)
+      const fallback = { query: jest.fn() }
+      const emitEvent = jest.fn().mockResolvedValue(undefined)
+      const engine = new HybridQueryEngine(
+        em,
+        fallback as any,
+        () => ({ emitEvent }),
+        undefined,
+        () => ({
+          isEnabled: () => true,
+          getEncryptedFieldNames: async () => ['display_name'],
+          decryptEntityPayload: async (_entityId, payload) => ({
+            display_name: namesById[String(payload.id)],
+          }),
+        }),
+      )
+      return { db, engine }
+    }
+
+    test('unset: no limit on the phase-1 scan, no warning', async () => {
+      delete process.env.OM_ENCRYPTED_SORT_MAX_ROWS
+      const { db, engine } = buildFixture()
+      const result = await engine.query('customers:customer_entity', {
+        fields: ['id', 'display_name'],
+        organizationId: 'org1',
+        tenantId: 't1',
+        sort: [{ field: 'display_name', dir: SortDir.Asc }],
+        page: { page: 1, pageSize: 2 },
+      })
+      expect(result.meta?.encryptedSortRowCapWarning).toBeUndefined()
+      const [phase1Chain] = db._chains
+        .filter((chain: ChainLog) => chain.table === 'customer_entities')
+        .slice(-2)
+      expect(phase1Chain.limit).toBeNull()
+    })
+
+    test('set but not exceeded: no warning, identical results to uncapped', async () => {
+      process.env.OM_ENCRYPTED_SORT_MAX_ROWS = '10'
+      const { engine } = buildFixture()
+      const result = await engine.query('customers:customer_entity', {
+        fields: ['id', 'display_name'],
+        organizationId: 'org1',
+        tenantId: 't1',
+        sort: [{ field: 'display_name', dir: SortDir.Asc }],
+        page: { page: 1, pageSize: 2 },
+      })
+      expect(result.meta?.encryptedSortRowCapWarning).toBeUndefined()
+      expect(result.items.map((item: any) => item.display_name)).toEqual(['Alice', 'Bob'])
+    })
+
+    test('set and exceeded: caps + orders the phase-1 scan and attaches a warning', async () => {
+      process.env.OM_ENCRYPTED_SORT_MAX_ROWS = '3'
+      const { db, engine } = buildFixture()
+      const result = await engine.query('customers:customer_entity', {
+        fields: ['id', 'display_name'],
+        organizationId: 'org1',
+        tenantId: 't1',
+        sort: [{ field: 'display_name', dir: SortDir.Asc }],
+        page: { page: 1, pageSize: 2 },
+      })
+      expect(result.meta?.encryptedSortRowCapWarning).toEqual({
+        entity: 'customers:customer_entity',
+        sortFields: ['display_name'],
+        maxRows: 3,
+        totalMatched: 5,
+      })
+      const [phase1Chain] = db._chains
+        .filter((chain: ChainLog) => chain.table === 'customer_entities')
+        .slice(-2)
+      expect(phase1Chain.limit).toBe(3)
+      expect(phase1Chain.orderBys).toEqual([['b.id', 'asc']])
+    })
   })
 
   test('joins entity index aliases for customFieldSources', async () => {

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -1,4 +1,4 @@
-import type { QueryEngine, QueryOptions, QueryResult, FilterOp, Filter, QueryCustomFieldSource, PartialIndexWarning, QueryExtensionsConfig, Sort } from '@open-mercato/shared/lib/query/types'
+import type { QueryEngine, QueryOptions, QueryResult, QueryResultMeta, EncryptedSortRowCapWarning, FilterOp, Filter, QueryCustomFieldSource, PartialIndexWarning, QueryExtensionsConfig, Sort } from '@open-mercato/shared/lib/query/types'
 import { SortDir } from '@open-mercato/shared/lib/query/types'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { EntityManager } from '@mikro-orm/postgresql'
@@ -21,7 +21,10 @@ import {
 import { resolveSearchConfig, type SearchConfig } from '@open-mercato/shared/lib/search/config'
 import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
 import { runBeforeQueryPipeline, runAfterQueryPipeline, type QueryExtensionContext } from '@open-mercato/shared/lib/query/query-extension-runner'
-import { resolveEncryptedSortFields, sortRowsInMemory } from '@open-mercato/shared/lib/query/encrypted-sort'
+import { resolveEncryptedSortFields, resolveEncryptedSortMaxRows, sortRowsInMemory } from '@open-mercato/shared/lib/query/encrypted-sort'
+import { mapWithConcurrency } from '@open-mercato/shared/lib/query/bounded-decrypt'
+
+const DECRYPT_CONCURRENCY = 8
 
 function buildFilterableCustomFieldJoins(
   sources: QueryCustomFieldSource[] | undefined,
@@ -795,9 +798,10 @@ export class HybridQueryEngine implements QueryEngine {
       }
       const selectFields = Array.from(selectFieldSet)
 
-      const applySelection = (q: AnyBuilder): AnyBuilder => {
+      const applySelection = (q: AnyBuilder, fieldsOverride?: string[]): AnyBuilder => {
         let next = q
-        for (const field of selectFields) {
+        const fields = fieldsOverride ?? selectFields
+        for (const field of fields) {
           const fieldName = String(field)
           if (fieldName.startsWith('cf:')) {
             const alias = this.sanitize(fieldName)
@@ -888,71 +892,131 @@ export class HybridQueryEngine implements QueryEngine {
         total = this.parseCount(countRow)
       }
 
-      const dataRoot = db.selectFrom(`${baseTable} as b` as any)
-      let dataBuilder = await applyQueryShape(dataRoot)
-      dataBuilder = applySelection(dataBuilder)
-      dataBuilder = applySort(dataBuilder)
-      if (!requiresPlaintextSort) {
-        dataBuilder = dataBuilder.limit(pageSize).offset((page - 1) * pageSize)
-      }
-
-      if (debugEnabled && sqlDebugEnabled) {
-        const compiled = dataBuilder.compile()
-        this.debug('query:sql:data', { entity, sql: compiled.sql, bindings: compiled.parameters, page, pageSize })
-      }
-      const itemsRaw = await this.captureSqlTiming(
-        'query:sql:data', entity,
-        () => dataBuilder.execute(),
-        { page, pageSize }, profiler,
-      )
-      if (debugEnabled) this.debug('query:complete', { entity, total, items: Array.isArray(itemsRaw) ? itemsRaw.length : 0 })
-
-      let items = itemsRaw as any[]
       const dekKeyCache = new Map<string | null, string | null>()
-      if (encSvc?.decryptEntityPayload) {
-        const decrypt = encSvc.decryptEntityPayload.bind(encSvc) as (
-          entityId: EntityId, payload: Record<string, unknown>, tenantId: string | null, organizationId: string | null,
-        ) => Promise<Record<string, unknown>>
-        items = await Promise.all(
-          items.map(async (item) => {
-            try {
-              const decrypted = await decrypt(
-                entity, item,
-                item?.tenant_id ?? item?.tenantId ?? opts.tenantId ?? null,
-                item?.organization_id ?? item?.organizationId ?? fallbackOrgId ?? null,
-              )
-              return { ...item, ...decrypted }
-            } catch (err) {
-              console.error('Error decrypting entity payload', err)
-              return item
-            }
-          })
-        )
+
+      const decryptRow = async (item: Record<string, unknown>): Promise<Record<string, unknown>> => {
+        let next = item
+        if (encSvc?.decryptEntityPayload) {
+          const decrypt = encSvc.decryptEntityPayload.bind(encSvc) as (
+            entityId: EntityId, payload: Record<string, unknown>, tenantId: string | null, organizationId: string | null,
+          ) => Promise<Record<string, unknown>>
+          try {
+            const decrypted = await decrypt(
+              entity, next,
+              (next?.tenant_id ?? next?.tenantId ?? opts.tenantId ?? null) as string | null,
+              (next?.organization_id ?? next?.organizationId ?? fallbackOrgId ?? null) as string | null,
+            )
+            next = { ...next, ...decrypted }
+          } catch (err) {
+            console.error('Error decrypting entity payload', err)
+          }
+        }
+        if (encSvc) {
+          try {
+            next = await decryptIndexDocCustomFields(
+              next,
+              {
+                tenantId: (next?.tenant_id ?? next?.tenantId ?? opts.tenantId ?? null) as string | null,
+                organizationId: (next?.organization_id ?? next?.organizationId ?? null) as string | null,
+              },
+              encSvc as any, dekKeyCache,
+            )
+          } catch { /* keep next as-is */ }
+        }
+        return next
       }
-      if (encSvc) {
-        items = await Promise.all(
-          items.map(async (item) => {
-            try {
-              return await decryptIndexDocCustomFields(
-                item,
-                {
-                  tenantId: item?.tenant_id ?? item?.tenantId ?? opts.tenantId ?? null,
-                  organizationId: item?.organization_id ?? item?.organizationId ?? null,
-                },
-                encSvc as any, dekKeyCache,
-              )
-            } catch { return item }
-          }),
-        )
-      }
+
+      let items: Record<string, unknown>[]
+      let encryptedSortRowCapWarning: EncryptedSortRowCapWarning | undefined
+
       if (requiresPlaintextSort) {
-        items = sortRowsInMemory(items as Record<string, unknown>[], resolvedSorts)
+        // Phase 1: slim id+sort-columns candidate scan, bounded-concurrency decrypt,
+        // in-memory sort over the full candidate set, then slice to the page's ids.
+        const cap = resolveEncryptedSortMaxRows()
+        const phase1Root = db.selectFrom(`${baseTable} as b` as any)
+        let phase1 = await applyQueryShape(phase1Root)
+        const sortFieldNames = Array.from(new Set(['id', ...resolvedSorts.map((s) => String(s.field))]))
+        phase1 = applySelection(phase1, sortFieldNames)
+        if (cap !== null) {
+          phase1 = phase1.limit(cap).orderBy(qualify('id'), 'asc' as any)
+        }
+        if (debugEnabled && sqlDebugEnabled) {
+          const compiled = phase1.compile()
+          this.debug('query:sql:data:phase1', { entity, sql: compiled.sql, bindings: compiled.parameters })
+        }
+        const candidateRows = await this.captureSqlTiming(
+          'query:sql:data:phase1', entity,
+          () => phase1.execute(),
+          { phase: 1 }, profiler,
+        ) as Record<string, unknown>[]
+        const decryptedCandidates = await mapWithConcurrency(candidateRows, DECRYPT_CONCURRENCY, decryptRow)
+        const orderedCandidates = sortRowsInMemory(decryptedCandidates, resolvedSorts)
+        const pageIds = orderedCandidates
           .slice((page - 1) * pageSize, page * pageSize)
+          .map((row) => row.id)
+
+        if (cap !== null && total > cap) {
+          encryptedSortRowCapWarning = {
+            entity,
+            sortFields: resolvedSorts.map((s) => String(s.field)),
+            maxRows: cap,
+            totalMatched: total,
+          }
+        }
+
+        // Phase 2: fetch + decrypt full rows for just the page's ids, then reassemble
+        // in phase-1's order (SQL `WHERE id IN (...)` order is unspecified — never
+        // trust it for ordering).
+        if (pageIds.length === 0) {
+          items = []
+        } else {
+          const phase2Root = db.selectFrom(`${baseTable} as b` as any)
+          let phase2 = await applyQueryShape(phase2Root)
+          phase2 = applySelection(phase2)
+          phase2 = phase2.where(qualify('id'), 'in', pageIds)
+          if (debugEnabled && sqlDebugEnabled) {
+            const compiled = phase2.compile()
+            this.debug('query:sql:data:phase2', { entity, sql: compiled.sql, bindings: compiled.parameters })
+          }
+          const pageRowsRaw = await this.captureSqlTiming(
+            'query:sql:data:phase2', entity,
+            () => phase2.execute(),
+            { phase: 2 }, profiler,
+          ) as Record<string, unknown>[]
+          const decryptedPageRows = await mapWithConcurrency(pageRowsRaw, DECRYPT_CONCURRENCY, decryptRow)
+          const byId = new Map(decryptedPageRows.map((row) => [String(row.id), row]))
+          items = pageIds
+            .map((id) => byId.get(String(id)))
+            .filter((row): row is Record<string, unknown> => row != null)
+        }
+      } else {
+        const dataRoot = db.selectFrom(`${baseTable} as b` as any)
+        let dataBuilder = await applyQueryShape(dataRoot)
+        dataBuilder = applySelection(dataBuilder)
+        dataBuilder = applySort(dataBuilder)
+        dataBuilder = dataBuilder.limit(pageSize).offset((page - 1) * pageSize)
+
+        if (debugEnabled && sqlDebugEnabled) {
+          const compiled = dataBuilder.compile()
+          this.debug('query:sql:data', { entity, sql: compiled.sql, bindings: compiled.parameters, page, pageSize })
+        }
+        const itemsRaw = await this.captureSqlTiming(
+          'query:sql:data', entity,
+          () => dataBuilder.execute(),
+          { page, pageSize }, profiler,
+        ) as Record<string, unknown>[]
+        items = await mapWithConcurrency(itemsRaw, DECRYPT_CONCURRENCY, decryptRow)
       }
+      if (debugEnabled) this.debug('query:complete', { entity, total, items: items.length })
 
       const typedItems = items as unknown as T[]
       let result: QueryResult<T> = { items: typedItems, page, pageSize, total }
-      if (partialIndexWarning) result.meta = { partialIndexWarning }
+      if (partialIndexWarning || encryptedSortRowCapWarning) {
+        const meta: QueryResultMeta = {}
+        if (partialIndexWarning) meta.partialIndexWarning = partialIndexWarning
+        if (encryptedSortRowCapWarning) meta.encryptedSortRowCapWarning = encryptedSortRowCapWarning
+        result.meta = meta
+      }
 
       result = await applyAfterExtensions(result)
       finishProfile({

--- a/packages/shared/src/lib/query/__tests__/bounded-decrypt.test.ts
+++ b/packages/shared/src/lib/query/__tests__/bounded-decrypt.test.ts
@@ -1,0 +1,49 @@
+import { mapWithConcurrency } from '../bounded-decrypt'
+
+describe('mapWithConcurrency', () => {
+  test('preserves input order regardless of resolution order', async () => {
+    const items = [1, 2, 3, 4, 5]
+    const delays = [50, 10, 30, 5, 20]
+    const result = await mapWithConcurrency(items, 2, (item, index) =>
+      new Promise<number>((resolve) => setTimeout(() => resolve(item * 10), delays[index])),
+    )
+    expect(result).toEqual([10, 20, 30, 40, 50])
+  })
+
+  test('never runs more than `concurrency` mappers at once', async () => {
+    const items = Array.from({ length: 10 }, (_, i) => i)
+    let inFlight = 0
+    let maxInFlight = 0
+    await mapWithConcurrency(items, 3, async (item) => {
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      inFlight -= 1
+      return item
+    })
+    expect(maxInFlight).toBeLessThanOrEqual(3)
+  })
+
+  test('behaves like Promise.all when concurrency <= 0', async () => {
+    const items = [1, 2, 3]
+    const result = await mapWithConcurrency(items, 0, async (item) => item * 2)
+    expect(result).toEqual([2, 4, 6])
+  })
+
+  test('behaves like Promise.all when concurrency >= items.length', async () => {
+    const items = [1, 2, 3]
+    const result = await mapWithConcurrency(items, 10, async (item) => item * 2)
+    expect(result).toEqual([2, 4, 6])
+  })
+
+  test('returns an empty array for empty input', async () => {
+    const result = await mapWithConcurrency([], 4, async (item) => item)
+    expect(result).toEqual([])
+  })
+
+  test('passes the index to the mapper', async () => {
+    const items = ['a', 'b', 'c', 'd', 'e']
+    const result = await mapWithConcurrency(items, 2, async (item, index) => `${item}-${index}`)
+    expect(result).toEqual(['a-0', 'b-1', 'c-2', 'd-3', 'e-4'])
+  })
+})

--- a/packages/shared/src/lib/query/__tests__/engine.test.ts
+++ b/packages/shared/src/lib/query/__tests__/engine.test.ts
@@ -158,7 +158,7 @@ function createFakeKysely(overrides?: FakeData) {
           return infoRows.find((row: any) => !targetTable || row.table_name === targetTable)
         }
         if (localOps.selects.some((s: any) => s && typeof s === 'object' && (s.__isCount || String(s?.alias || '') === 'count'))) {
-          return { count: '0' }
+          return { count: String((data[localOps.table] || []).length) }
         }
         const rows = data[localOps.table] || []
         if (rows.length === 0) return { count: '0' }
@@ -642,9 +642,164 @@ describe('BasicQueryEngine (Kysely)', () => {
     })
 
     expect(result.items.map((item: any) => item.display_name)).toEqual(['Charlie', 'Dave'])
-    const baseCall = fakeDb._calls.find((call: any) => call._ops.table === 'customer_entities')
-    expect(baseCall._ops.orderBys).toEqual([])
-    expect(baseCall._ops.limits).toBe(0)
+    const baseCalls = fakeDb._calls.filter((call: any) => call._ops.table === 'customer_entities')
+    expect(baseCalls.length).toBe(2)
+    // qFull ('full' projection) is built first (used for count + phase 2);
+    // qSort ('sortKeys' projection) is built second (phase 1).
+    const [phase2Call, phase1Call] = baseCalls
+    // Phase 1 (slim id+sort-column scan): no SQL order/limit — the full candidate
+    // set is fetched, decrypted, and sorted in memory.
+    expect(phase1Call._ops.orderBys).toEqual([])
+    expect(phase1Call._ops.limits).toBe(0)
+    // Phase 2 (full-row fetch for the page's ids): filtered by `id in [...]`, no
+    // SQL order/limit needed since the id list already bounds it to the page.
+    expect(phase2Call._ops.orderBys).toEqual([])
+    expect(phase2Call._ops.limits).toBe(0)
+    expect(phase2Call._ops.wheres.some((w: any) => Array.isArray(w) && w[0] === 'customer_entities.id' && w[1] === 'in')).toBe(true)
+  })
+
+  test('paginates encrypted-sorted results correctly on page 1 and the tail page', async () => {
+    const fakeDb = createFakeKysely({
+      customer_entities: [
+        { id: '3', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-c' },
+        { id: '1', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-a' },
+        { id: '5', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-e' },
+        { id: '2', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-b' },
+        { id: '4', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-d' },
+      ],
+      'information_schema.columns': [
+        { table_name: 'customer_entities', column_name: 'id' },
+        { table_name: 'customer_entities', column_name: 'tenant_id' },
+        { table_name: 'customer_entities', column_name: 'organization_id' },
+        { table_name: 'customer_entities', column_name: 'deleted_at' },
+        { table_name: 'customer_entities', column_name: 'display_name' },
+      ],
+    })
+    const namesById: Record<string, string> = {
+      '1': 'Alice', '2': 'Bob', '3': 'Charlie', '4': 'Dave', '5': 'Eve',
+    }
+    const engine = new BasicQueryEngine(
+      {} as any,
+      () => fakeDb as any,
+      () => ({
+        isEnabled: () => true,
+        getEncryptedFieldNames: async () => ['display_name'],
+        decryptEntityPayload: async (_entityId, payload) => ({
+          display_name: namesById[String(payload.id)],
+        }),
+      }),
+    )
+
+    const page1 = await engine.query('customers:customer_entity', {
+      tenantId: 't1',
+      organizationId: 'org1',
+      fields: ['id', 'display_name'],
+      sort: [{ field: 'display_name', dir: SortDir.Asc }],
+      page: { page: 1, pageSize: 2 },
+    })
+    expect(page1.items.map((item: any) => item.display_name)).toEqual(['Alice', 'Bob'])
+
+    const page3 = await engine.query('customers:customer_entity', {
+      tenantId: 't1',
+      organizationId: 'org1',
+      fields: ['id', 'display_name'],
+      sort: [{ field: 'display_name', dir: SortDir.Asc }],
+      page: { page: 3, pageSize: 2 },
+    })
+    expect(page3.items.map((item: any) => item.display_name)).toEqual(['Eve'])
+  })
+
+  describe('OM_ENCRYPTED_SORT_MAX_ROWS cap', () => {
+    const originalEnv = process.env.OM_ENCRYPTED_SORT_MAX_ROWS
+
+    afterEach(() => {
+      if (originalEnv === undefined) delete process.env.OM_ENCRYPTED_SORT_MAX_ROWS
+      else process.env.OM_ENCRYPTED_SORT_MAX_ROWS = originalEnv
+    })
+
+    function buildFixture() {
+      const fakeDb = createFakeKysely({
+        customer_entities: [
+          { id: '3', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-c' },
+          { id: '1', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-a' },
+          { id: '5', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-e' },
+          { id: '2', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-b' },
+          { id: '4', tenant_id: 't1', organization_id: 'org1', display_name: 'cipher-d' },
+        ],
+        'information_schema.columns': [
+          { table_name: 'customer_entities', column_name: 'id' },
+          { table_name: 'customer_entities', column_name: 'tenant_id' },
+          { table_name: 'customer_entities', column_name: 'organization_id' },
+          { table_name: 'customer_entities', column_name: 'deleted_at' },
+          { table_name: 'customer_entities', column_name: 'display_name' },
+        ],
+      })
+      const namesById: Record<string, string> = {
+        '1': 'Alice', '2': 'Bob', '3': 'Charlie', '4': 'Dave', '5': 'Eve',
+      }
+      const engine = new BasicQueryEngine(
+        {} as any,
+        () => fakeDb as any,
+        () => ({
+          isEnabled: () => true,
+          getEncryptedFieldNames: async () => ['display_name'],
+          decryptEntityPayload: async (_entityId, payload) => ({
+            display_name: namesById[String(payload.id)],
+          }),
+        }),
+      )
+      return { fakeDb, engine }
+    }
+
+    test('unset: no limit on the phase-1 scan, no warning', async () => {
+      delete process.env.OM_ENCRYPTED_SORT_MAX_ROWS
+      const { fakeDb, engine } = buildFixture()
+      const result = await engine.query('customers:customer_entity', {
+        tenantId: 't1',
+        organizationId: 'org1',
+        fields: ['id', 'display_name'],
+        sort: [{ field: 'display_name', dir: SortDir.Asc }],
+        page: { page: 1, pageSize: 2 },
+      })
+      expect(result.meta?.encryptedSortRowCapWarning).toBeUndefined()
+      const [, phase1Call] = fakeDb._calls.filter((call: any) => call._ops.table === 'customer_entities')
+      expect(phase1Call._ops.limits).toBe(0)
+    })
+
+    test('set but not exceeded: no warning, identical results to uncapped', async () => {
+      process.env.OM_ENCRYPTED_SORT_MAX_ROWS = '10'
+      const { fakeDb, engine } = buildFixture()
+      const result = await engine.query('customers:customer_entity', {
+        tenantId: 't1',
+        organizationId: 'org1',
+        fields: ['id', 'display_name'],
+        sort: [{ field: 'display_name', dir: SortDir.Asc }],
+        page: { page: 1, pageSize: 2 },
+      })
+      expect(result.meta?.encryptedSortRowCapWarning).toBeUndefined()
+      expect(result.items.map((item: any) => item.display_name)).toEqual(['Alice', 'Bob'])
+    })
+
+    test('set and exceeded: caps + orders the phase-1 scan and attaches a warning', async () => {
+      process.env.OM_ENCRYPTED_SORT_MAX_ROWS = '3'
+      const { fakeDb, engine } = buildFixture()
+      const result = await engine.query('customers:customer_entity', {
+        tenantId: 't1',
+        organizationId: 'org1',
+        fields: ['id', 'display_name'],
+        sort: [{ field: 'display_name', dir: SortDir.Asc }],
+        page: { page: 1, pageSize: 2 },
+      })
+      expect(result.meta?.encryptedSortRowCapWarning).toEqual({
+        entity: 'customers:customer_entity',
+        sortFields: ['display_name'],
+        maxRows: 3,
+        totalMatched: 5,
+      })
+      const [, phase1Call] = fakeDb._calls.filter((call: any) => call._ops.table === 'customer_entities')
+      expect(phase1Call._ops.limits).toBe(3)
+      expect(phase1Call._ops.orderBys).toEqual([['customer_entities.id', 'asc']])
+    })
   })
 
   test('keeps SQL ordering and pagination for unencrypted base fields', async () => {

--- a/packages/shared/src/lib/query/bounded-decrypt.ts
+++ b/packages/shared/src/lib/query/bounded-decrypt.ts
@@ -1,0 +1,26 @@
+/**
+ * Maps `items` through `mapper` with at most `concurrency` calls in flight at
+ * once, preserving input order in the output. Chunks are processed
+ * sequentially; within a chunk, calls run in parallel via `Promise.all`.
+ *
+ * When `concurrency` is non-positive or `>= items.length`, this is
+ * equivalent to a plain `Promise.all(items.map(mapper))`.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (concurrency <= 0 || items.length <= concurrency) {
+    return Promise.all(items.map((item, index) => mapper(item, index)))
+  }
+  const results: R[] = new Array(items.length)
+  for (let start = 0; start < items.length; start += concurrency) {
+    const chunk = items.slice(start, start + concurrency)
+    const chunkResults = await Promise.all(
+      chunk.map((item, offset) => mapper(item, start + offset)),
+    )
+    for (let i = 0; i < chunkResults.length; i++) results[start + i] = chunkResults[i]
+  }
+  return results
+}

--- a/packages/shared/src/lib/query/encrypted-sort.ts
+++ b/packages/shared/src/lib/query/encrypted-sort.ts
@@ -24,6 +24,19 @@ export function fieldNameCandidates(field: string): string[] {
   return Array.from(new Set(candidates))
 }
 
+/**
+ * Opt-in cap on how many candidate rows the plaintext-sort path may fetch
+ * for sort-column decryption. Unset or invalid input means uncapped — the
+ * default must stay byte-identical to the pre-cap behavior.
+ */
+export function resolveEncryptedSortMaxRows(): number | null {
+  const raw = process.env.OM_ENCRYPTED_SORT_MAX_ROWS
+  if (raw === undefined || raw === '') return null
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return null
+  return Math.floor(parsed)
+}
+
 export async function resolveEncryptedSortFields(
   service: QueryEncryptionService | null | undefined,
   entity: EntityId,

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -1,4 +1,4 @@
-import type { QueryEngine, QueryOptions, QueryResult, QueryCustomFieldSource, QueryExtensionsConfig, Sort } from './types'
+import type { QueryEngine, QueryOptions, QueryResult, QueryResultMeta, EncryptedSortRowCapWarning, QueryCustomFieldSource, QueryExtensionsConfig, Sort } from './types'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { type Kysely, sql, type RawBuilder } from 'kysely'
@@ -20,7 +20,10 @@ import {
   type CustomFieldDefinitionRow,
   type ResolvedCustomFieldDefinitions,
 } from '../crud/custom-field-definition-index'
-import { resolveEncryptedSortFields, sortRowsInMemory } from './encrypted-sort'
+import { resolveEncryptedSortFields, resolveEncryptedSortMaxRows, sortRowsInMemory } from './encrypted-sort'
+import { mapWithConcurrency } from './bounded-decrypt'
+
+const DECRYPT_CONCURRENCY = 8
 
 type AnyDb = Kysely<any>
 type AnyBuilder = any
@@ -261,7 +264,6 @@ export class BasicQueryEngine implements QueryEngine {
     const table = resolveEntityTableName(this.em, entity)
     const db = this.getDb()
 
-    let q: AnyBuilder = db.selectFrom(table as any)
     const qualify = (col: string) => `${table}.${col}`
     const orgScope = this.resolveOrganizationScope(opts)
     this.searchAliasSeq = 0
@@ -274,18 +276,6 @@ export class BasicQueryEngine implements QueryEngine {
       )
     }
     const skipAutoScope = opts.omitAutomaticTenantOrgScope === true
-    // Optional organization filter (when present in schema)
-    if (!skipAutoScope && orgScope && await this.columnExists(table, 'organization_id')) {
-      q = this.applyOrganizationScope(q, qualify('organization_id'), orgScope)
-    }
-    // Tenant guard (required) when present in schema
-    if (!skipAutoScope && await this.columnExists(table, 'tenant_id')) {
-      q = q.where(qualify('tenant_id'), '=', opts.tenantId)
-    }
-    // Default soft-delete guard: exclude rows with deleted_at when column exists
-    if (!opts.withDeleted && await this.columnExists(table, 'deleted_at')) {
-      q = q.where(qualify('deleted_at'), 'is', null)
-    }
 
     const normalizedFilters = normalizeFilters(opts.filters)
     const resolvedJoins = resolveJoins(
@@ -428,65 +418,6 @@ export class BasicQueryEngine implements QueryEngine {
     const regularBaseFilters = baseFilters.filter((f) => !f.orGroup)
     const orGroupFilters = baseFilters.filter((f) => f.orGroup)
 
-    for (const filter of regularBaseFilters) {
-      const fieldName = String(filter.field)
-      let qualified = filter.qualified ?? null
-      if (!qualified) {
-        const column = await this.resolveBaseColumn(table, fieldName)
-        if (!column) {
-          q = this.applyIndexDocFilter(q, {
-            entity: String(entity),
-            field: fieldName,
-            op: filter.op,
-            value: filter.value,
-            recordIdColumn,
-            tenantId: opts.tenantId ?? null,
-            organizationScope: orgScope,
-            withDeleted: opts.withDeleted === true,
-            searchActive,
-            searchConfig,
-          })
-          continue
-        }
-        qualified = qualify(column)
-      }
-      q = applyFilterOp(q, qualified, filter.op, filter.value, fieldName)
-    }
-
-    // OR-grouped filters: AND within each group (one $or disjunct), OR between groups.
-    if (orGroupFilters.length > 0) {
-      const groups = new Map<string, typeof orGroupFilters>()
-      for (const f of orGroupFilters) {
-        const group = groups.get(f.orGroup!) ?? []
-        group.push(f)
-        groups.set(f.orGroup!, group)
-      }
-      const resolvedGroupFilters: Array<Array<{ qualified: string; op: string; value: unknown; fieldName: string }>> = []
-      for (const [, groupFilters] of groups) {
-        const resolved: Array<{ qualified: string; op: string; value: unknown; fieldName: string }> = []
-        for (const filter of groupFilters) {
-          const column = await this.resolveBaseColumn(table, String(filter.field))
-          if (column) {
-            resolved.push({
-              qualified: qualify(column),
-              op: filter.op,
-              value: filter.value,
-              fieldName: String(filter.field),
-            })
-          }
-        }
-        if (resolved.length > 0) resolvedGroupFilters.push(resolved)
-      }
-      if (resolvedGroupFilters.length > 0) {
-        q = q.where((eb: any) => eb.or(
-          resolvedGroupFilters.map((group) => {
-            const parts = group.map((rf) => this.buildColumnOpExpression(eb, rf.qualified, rf.op, rf.value))
-            return parts.length === 1 ? parts[0] : eb.and(parts)
-          })
-        ))
-      }
-    }
-
     const applyAliasScopes = async (builder: AnyBuilder, aliasName: string): Promise<AnyBuilder> => {
       const targetTable = aliasTables.get(aliasName)
       if (!targetTable) return builder
@@ -499,19 +430,6 @@ export class BasicQueryEngine implements QueryEngine {
       }
       return next
     }
-    q = await applyJoinFilters({
-      db,
-      baseTable: table,
-      builder: q,
-      joinMap,
-      joinFilters,
-      aliasTables,
-      qualifyBase: (column) => qualify(column),
-      applyAliasScope: (builder, alias) => applyAliasScopes(builder, alias),
-      applyFilterOp: (builder, column, op, value) => applyFilterOp(builder, column, op, value),
-      applyJoinFilterOp,
-      columnExists: (tbl, column) => this.columnExists(tbl, column),
-    })
 
     const fallbackOrgId =
       opts.organizationId
@@ -535,315 +453,439 @@ export class BasicQueryEngine implements QueryEngine {
     )
     const requiresPlaintextSort = encryptedSortFields.size > 0
 
-    // Selection (base columns only here; cf:* handled later)
-    if (opts.fields && opts.fields.length) {
-      const cols = new Set(opts.fields.filter((f) => !f.startsWith('cf:')))
-      if (requiresPlaintextSort) {
-        for (const field of encryptedSortFields) cols.add(field)
-      }
-      for (const c of cols) {
-        // Qualify and alias to base names to avoid ambiguity
-        q = q.select(sql.ref(qualify(c)).as(c))
-      }
-    } else {
-      // Default to selecting only base table columns to avoid ambiguity when joining
-      q = q.select(sql`${sql.ref(table)}.*`.as('__all'))
-    }
-
-    // Resolve which custom fields to include
     const tenantId = opts.tenantId
     const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9_]/g, '_')
-    const cfSourcesResult = this.configureCustomFieldSources(q, table, entity, db, opts, qualify)
-    q = cfSourcesResult.builder
-    const cfSources = cfSourcesResult.sources
-    const entityIdToSource = new Map<string, ResolvedCustomFieldSource>()
-    for (const source of cfSources) {
-      entityIdToSource.set(String(source.entityId), source)
+
+    type BuiltQuery = {
+      builder: AnyBuilder
+      hasJoinedAggregates: boolean
+      cfJsonAliases: Set<string>
+      cfMultiAliasByAlias: Map<string, string>
+      resolvedCustomFieldDefinitions: ResolvedCustomFieldDefinitions | undefined
     }
-    const requestedCustomFieldKeys = Array.isArray(opts.includeCustomFields)
-      ? opts.includeCustomFields.map((key) => String(key))
-      : []
-    const cfKeys = new Set<string>()
-    const keySource = new Map<string, ResolvedCustomFieldSource>()
-    // Custom-field definition index threaded onto the result so the CRUD factory
-    // can decorate list rows without reloading definitions from the DB (#2133).
-    let resolvedCustomFieldDefinitions: ResolvedCustomFieldDefinitions | undefined
-    // Explicit in fields/filters
-    for (const f of (opts.fields || [])) {
-      if (typeof f === 'string' && f.startsWith('cf:')) cfKeys.add(f.slice(3))
-    }
-    for (const f of cfFilters) {
-      if (typeof f.field === 'string' && f.field.startsWith('cf:')) cfKeys.add(f.field.slice(3))
-    }
-    if (opts.includeCustomFields === true) {
-      if (entityIdToSource.size > 0) {
-        const entityIdList = Array.from(entityIdToSource.keys())
-        const entityOrder = new Map<string, number>()
-        entityIdList.forEach((id, idx) => entityOrder.set(id, idx))
+
+    // Builds the fully-scoped query from a fresh root. `projection: 'full'` reproduces
+    // today's complete selection (base fields + CF projections + extension joins).
+    // `projection: 'sortKeys'` selects only `id` + the sort columns — the slim phase-1
+    // candidate scan used when `requiresPlaintextSort`. Re-running the WHERE/JOIN logic
+    // twice is cheap: every `columnExists`/`tableExists` check is memoized on
+    // `this.columnCache`/`this.tableCache`, so the second pass hits no extra DB calls.
+    const buildQuery = async (projection: 'full' | 'sortKeys'): Promise<BuiltQuery> => {
+      const isSortKeysProjection = projection === 'sortKeys'
+      let q: AnyBuilder = db.selectFrom(table as any)
+
+      // Tenant/org/soft-delete scope
+      if (!skipAutoScope && orgScope && await this.columnExists(table, 'organization_id')) {
+        q = this.applyOrganizationScope(q, qualify('organization_id'), orgScope)
+      }
+      if (!skipAutoScope && await this.columnExists(table, 'tenant_id')) {
+        q = q.where(qualify('tenant_id'), '=', opts.tenantId)
+      }
+      if (!opts.withDeleted && await this.columnExists(table, 'deleted_at')) {
+        q = q.where(qualify('deleted_at'), 'is', null)
+      }
+
+      for (const filter of regularBaseFilters) {
+        const fieldName = String(filter.field)
+        let qualified = filter.qualified ?? null
+        if (!qualified) {
+          const column = await this.resolveBaseColumn(table, fieldName)
+          if (!column) {
+            q = this.applyIndexDocFilter(q, {
+              entity: String(entity),
+              field: fieldName,
+              op: filter.op,
+              value: filter.value,
+              recordIdColumn,
+              tenantId: opts.tenantId ?? null,
+              organizationScope: orgScope,
+              withDeleted: opts.withDeleted === true,
+              searchActive,
+              searchConfig,
+            })
+            continue
+          }
+          qualified = qualify(column)
+        }
+        q = applyFilterOp(q, qualified, filter.op, filter.value, fieldName)
+      }
+
+      // OR-grouped filters: AND within each group (one $or disjunct), OR between groups.
+      if (orGroupFilters.length > 0) {
+        const groups = new Map<string, typeof orGroupFilters>()
+        for (const f of orGroupFilters) {
+          const group = groups.get(f.orGroup!) ?? []
+          group.push(f)
+          groups.set(f.orGroup!, group)
+        }
+        const resolvedGroupFilters: Array<Array<{ qualified: string; op: string; value: unknown; fieldName: string }>> = []
+        for (const [, groupFilters] of groups) {
+          const resolved: Array<{ qualified: string; op: string; value: unknown; fieldName: string }> = []
+          for (const filter of groupFilters) {
+            const column = await this.resolveBaseColumn(table, String(filter.field))
+            if (column) {
+              resolved.push({
+                qualified: qualify(column),
+                op: filter.op,
+                value: filter.value,
+                fieldName: String(filter.field),
+              })
+            }
+          }
+          if (resolved.length > 0) resolvedGroupFilters.push(resolved)
+        }
+        if (resolvedGroupFilters.length > 0) {
+          q = q.where((eb: any) => eb.or(
+            resolvedGroupFilters.map((group) => {
+              const parts = group.map((rf) => this.buildColumnOpExpression(eb, rf.qualified, rf.op, rf.value))
+              return parts.length === 1 ? parts[0] : eb.and(parts)
+            })
+          ))
+        }
+      }
+
+      q = await applyJoinFilters({
+        db,
+        baseTable: table,
+        builder: q,
+        joinMap,
+        joinFilters,
+        aliasTables,
+        qualifyBase: (column) => qualify(column),
+        applyAliasScope: (builder, alias) => applyAliasScopes(builder, alias),
+        applyFilterOp: (builder, column, op, value) => applyFilterOp(builder, column, op, value),
+        applyJoinFilterOp,
+        columnExists: (tbl, column) => this.columnExists(tbl, column),
+      })
+
+      // Selection (base columns only here; cf:* handled later)
+      if (isSortKeysProjection) {
+        q = q.select(sql.ref(qualify('id')).as('id'))
+        for (const s of resolvedSorts) {
+          if (!s.field.startsWith('cf:')) q = q.select(sql.ref(qualify(s.field)).as(s.field))
+        }
+      } else if (opts.fields && opts.fields.length) {
+        const cols = new Set(opts.fields.filter((f) => !f.startsWith('cf:')))
+        if (requiresPlaintextSort) {
+          for (const field of encryptedSortFields) cols.add(field)
+        }
+        for (const c of cols) {
+          // Qualify and alias to base names to avoid ambiguity
+          q = q.select(sql.ref(qualify(c)).as(c))
+        }
+      } else {
+        // Default to selecting only base table columns to avoid ambiguity when joining
+        q = q.select(sql`${sql.ref(table)}.*`.as('__all'))
+      }
+
+      // Resolve which custom fields to include
+      const cfSourcesResult = this.configureCustomFieldSources(q, table, entity, db, opts, qualify)
+      q = cfSourcesResult.builder
+      const cfSources = cfSourcesResult.sources
+      const entityIdToSource = new Map<string, ResolvedCustomFieldSource>()
+      for (const source of cfSources) {
+        entityIdToSource.set(String(source.entityId), source)
+      }
+      const requestedCustomFieldKeys = (!isSortKeysProjection && Array.isArray(opts.includeCustomFields))
+        ? opts.includeCustomFields.map((key) => String(key))
+        : []
+      const cfKeys = new Set<string>()
+      const keySource = new Map<string, ResolvedCustomFieldSource>()
+      // Custom-field definition index threaded onto the result so the CRUD factory
+      // can decorate list rows without reloading definitions from the DB (#2133).
+      // Output-only — never resolved for the slim sortKeys projection.
+      let resolvedCustomFieldDefinitions: ResolvedCustomFieldDefinitions | undefined
+      // Explicit in fields/filters
+      if (!isSortKeysProjection) {
+        for (const f of (opts.fields || [])) {
+          if (typeof f === 'string' && f.startsWith('cf:')) cfKeys.add(f.slice(3))
+        }
+      }
+      for (const f of cfFilters) {
+        if (typeof f.field === 'string' && f.field.startsWith('cf:')) cfKeys.add(f.field.slice(3))
+      }
+      if (!isSortKeysProjection && opts.includeCustomFields === true) {
+        if (entityIdToSource.size > 0) {
+          const entityIdList = Array.from(entityIdToSource.keys())
+          const entityOrder = new Map<string, number>()
+          entityIdList.forEach((id, idx) => entityOrder.set(id, idx))
+          const rows = await db
+            .selectFrom('custom_field_defs' as any)
+            .select([
+              'key' as any,
+              'entity_id' as any,
+              'config_json' as any,
+              'kind' as any,
+              'organization_id' as any,
+              'tenant_id' as any,
+              'updated_at' as any,
+              'deleted_at' as any,
+            ])
+            .where('entity_id' as any, 'in', entityIdList)
+            .where('is_active' as any, '=', true)
+            .where((eb: any) => eb.or([
+              eb('tenant_id' as any, '=', tenantId),
+              eb('tenant_id' as any, 'is', null),
+            ]))
+            .execute() as Array<{
+              key: string
+              entity_id: string
+              config_json: unknown
+              kind: string
+              organization_id: string | null
+              tenant_id: string | null
+              updated_at: Date | string | number | null
+              deleted_at: Date | string | number | null
+            }>
+          // Build the decoration index from the same rows, scoped exactly like the
+          // factory's loadCustomFieldDefinitionIndex (tenant + is_active already
+          // applied in SQL; org + soft-delete applied in the shared builder).
+          const orgCandidates = resolveCfDefIndexOrgCandidates(opts.organizationIds, opts.organizationId ?? null)
+          const definitionRows: CustomFieldDefinitionRow[] = rows.map((row) => ({
+            key: String(row.key),
+            entityId: String(row.entity_id),
+            kind: row.kind == null ? null : String(row.kind),
+            configJson: row.config_json,
+            organizationId: row.organization_id == null ? null : String(row.organization_id),
+            tenantId: row.tenant_id == null ? null : String(row.tenant_id),
+            deletedAt: row.deleted_at ?? null,
+            updatedAt: row.updated_at ?? null,
+          }))
+          resolvedCustomFieldDefinitions = {
+            index: buildCustomFieldDefinitionIndexFromRows(definitionRows, { organizationIds: orgCandidates }),
+            entityIds: entityIdList,
+            tenantId: tenantId ?? null,
+            organizationIds: orgCandidates,
+          }
+          type ScoredCustomFieldRow = {
+            key: string
+            entityId: string
+            kind: string
+            config: Record<string, unknown>
+          }
+          const sorted: ScoredCustomFieldRow[] = rows.map((row) => {
+            const raw = row.config_json
+            let cfg: Record<string, any> = {}
+            if (raw && typeof raw === 'string') {
+              try { cfg = JSON.parse(raw) } catch { cfg = {} }
+            } else if (raw && typeof raw === 'object') {
+              cfg = raw as Record<string, any>
+            }
+            return {
+              key: String(row.key),
+              entityId: String(row.entity_id),
+              kind: String(row.kind || ''),
+              config: cfg,
+            }
+          })
+          sorted.sort((a, b) => {
+            const ai = entityOrder.get(a.entityId) ?? Number.MAX_SAFE_INTEGER
+            const bi = entityOrder.get(b.entityId) ?? Number.MAX_SAFE_INTEGER
+            if (ai !== bi) return ai - bi
+            return a.key.localeCompare(b.key)
+          })
+          const selectedSources = new Map<string, { source: ResolvedCustomFieldSource; score: number; penalty: number; entityIndex: number }>()
+          for (const row of sorted) {
+            const source = entityIdToSource.get(row.entityId)
+            if (!source) continue
+            const cfg = row.config || {}
+            const entityIndex = entityOrder.get(row.entityId) ?? Number.MAX_SAFE_INTEGER
+            const scores = computeCustomFieldScore(cfg, row.kind, entityIndex)
+            const existing = selectedSources.get(row.key)
+            if (!existing || scores.base > existing.score || (scores.base === existing.score && (scores.penalty < existing.penalty || (scores.penalty === existing.penalty && scores.entityIndex < existing.entityIndex)))) {
+              selectedSources.set(row.key, { source, score: scores.base, penalty: scores.penalty, entityIndex: scores.entityIndex })
+            }
+            cfKeys.add(row.key)
+          }
+          for (const [key, entry] of selectedSources.entries()) {
+            keySource.set(key, entry.source)
+          }
+        }
+      } else if (!isSortKeysProjection && requestedCustomFieldKeys.length > 0) {
+        for (const key of requestedCustomFieldKeys) cfKeys.add(key)
+      }
+      const unresolvedKeys = Array.from(cfKeys).filter((key) => !keySource.has(key))
+      if (unresolvedKeys.length > 0 && entityIdToSource.size > 0) {
         const rows = await db
           .selectFrom('custom_field_defs' as any)
-          .select([
-            'key' as any,
-            'entity_id' as any,
-            'config_json' as any,
-            'kind' as any,
-            'organization_id' as any,
-            'tenant_id' as any,
-            'updated_at' as any,
-            'deleted_at' as any,
-          ])
-          .where('entity_id' as any, 'in', entityIdList)
+          .select(['key' as any, 'entity_id' as any])
+          .where('entity_id' as any, 'in', Array.from(entityIdToSource.keys()))
+          .where('key' as any, 'in', unresolvedKeys)
           .where('is_active' as any, '=', true)
           .where((eb: any) => eb.or([
             eb('tenant_id' as any, '=', tenantId),
             eb('tenant_id' as any, 'is', null),
           ]))
-          .execute() as Array<{
-            key: string
-            entity_id: string
-            config_json: unknown
-            kind: string
-            organization_id: string | null
-            tenant_id: string | null
-            updated_at: Date | string | number | null
-            deleted_at: Date | string | number | null
-          }>
-        // Build the decoration index from the same rows, scoped exactly like the
-        // factory's loadCustomFieldDefinitionIndex (tenant + is_active already
-        // applied in SQL; org + soft-delete applied in the shared builder).
-        const orgCandidates = resolveCfDefIndexOrgCandidates(opts.organizationIds, opts.organizationId ?? null)
-        const definitionRows: CustomFieldDefinitionRow[] = rows.map((row) => ({
-          key: String(row.key),
-          entityId: String(row.entity_id),
-          kind: row.kind == null ? null : String(row.kind),
-          configJson: row.config_json,
-          organizationId: row.organization_id == null ? null : String(row.organization_id),
-          tenantId: row.tenant_id == null ? null : String(row.tenant_id),
-          deletedAt: row.deleted_at ?? null,
-          updatedAt: row.updated_at ?? null,
-        }))
-        resolvedCustomFieldDefinitions = {
-          index: buildCustomFieldDefinitionIndexFromRows(definitionRows, { organizationIds: orgCandidates }),
-          entityIds: entityIdList,
-          tenantId: tenantId ?? null,
-          organizationIds: orgCandidates,
-        }
-        type ScoredCustomFieldRow = {
-          key: string
-          entityId: string
-          kind: string
-          config: Record<string, unknown>
-        }
-        const sorted: ScoredCustomFieldRow[] = rows.map((row) => {
-          const raw = row.config_json
-          let cfg: Record<string, any> = {}
-          if (raw && typeof raw === 'string') {
-            try { cfg = JSON.parse(raw) } catch { cfg = {} }
-          } else if (raw && typeof raw === 'object') {
-            cfg = raw as Record<string, any>
-          }
-          return {
-            key: String(row.key),
-            entityId: String(row.entity_id),
-            kind: String(row.kind || ''),
-            config: cfg,
-          }
-        })
-        sorted.sort((a, b) => {
-          const ai = entityOrder.get(a.entityId) ?? Number.MAX_SAFE_INTEGER
-          const bi = entityOrder.get(b.entityId) ?? Number.MAX_SAFE_INTEGER
-          if (ai !== bi) return ai - bi
-          return a.key.localeCompare(b.key)
-        })
-        const selectedSources = new Map<string, { source: ResolvedCustomFieldSource; score: number; penalty: number; entityIndex: number }>()
-        for (const row of sorted) {
-          const source = entityIdToSource.get(row.entityId)
+          .execute() as Array<{ key: string; entity_id: string }>
+        for (const row of rows) {
+          const source = entityIdToSource.get(String(row.entity_id))
           if (!source) continue
-          const cfg = row.config || {}
-          const entityIndex = entityOrder.get(row.entityId) ?? Number.MAX_SAFE_INTEGER
-          const scores = computeCustomFieldScore(cfg, row.kind, entityIndex)
-          const existing = selectedSources.get(row.key)
-          if (!existing || scores.base > existing.score || (scores.base === existing.score && (scores.penalty < existing.penalty || (scores.penalty === existing.penalty && scores.entityIndex < existing.entityIndex)))) {
-            selectedSources.set(row.key, { source, score: scores.base, penalty: scores.penalty, entityIndex: scores.entityIndex })
-          }
-          cfKeys.add(row.key)
-        }
-        for (const [key, entry] of selectedSources.entries()) {
-          keySource.set(key, entry.source)
+          if (!keySource.has(row.key)) keySource.set(row.key, source)
         }
       }
-    } else if (requestedCustomFieldKeys.length > 0) {
-      for (const key of requestedCustomFieldKeys) cfKeys.add(key)
-    }
-    const unresolvedKeys = Array.from(cfKeys).filter((key) => !keySource.has(key))
-    if (unresolvedKeys.length > 0 && entityIdToSource.size > 0) {
-      const rows = await db
-        .selectFrom('custom_field_defs' as any)
-        .select(['key' as any, 'entity_id' as any])
-        .where('entity_id' as any, 'in', Array.from(entityIdToSource.keys()))
-        .where('key' as any, 'in', unresolvedKeys)
-        .where('is_active' as any, '=', true)
-        .where((eb: any) => eb.or([
-          eb('tenant_id' as any, '=', tenantId),
-          eb('tenant_id' as any, 'is', null),
-        ]))
-        .execute() as Array<{ key: string; entity_id: string }>
-      for (const row of rows) {
-        const source = entityIdToSource.get(String(row.entity_id))
+
+      const cfValueExprByKey: Record<string, RawBuilder<string | null>> = {}
+      const cfSelectedAliases: string[] = []
+      const cfJsonAliases = new Set<string>()
+      const cfMultiAliasByAlias = new Map<string, string>()
+      for (const key of cfKeys) {
+        const source = keySource.get(key)
         if (!source) continue
-        if (!keySource.has(row.key)) keySource.set(row.key, source)
-      }
-    }
-
-    const cfValueExprByKey: Record<string, RawBuilder<string | null>> = {}
-    const cfSelectedAliases: string[] = []
-    const cfJsonAliases = new Set<string>()
-    const cfMultiAliasByAlias = new Map<string, string>()
-    for (const key of cfKeys) {
-      const source = keySource.get(key)
-      if (!source) continue
-      const entityIdForKey = source.entityId
-      const recordIdExpr = source.recordIdExpr
-      const sourceAliasSafe = sanitize(source.alias || 'src')
-      const keyAliasSafe = sanitize(key)
-      const defAlias = `cfd_${sourceAliasSafe}_${keyAliasSafe}`
-      const valAlias = `cfv_${sourceAliasSafe}_${keyAliasSafe}`
-      // Join definitions for kind resolution
-      q = q.leftJoin(`custom_field_defs as ${defAlias}` as any, (jb: any) =>
-        jb.on(`${defAlias}.entity_id`, '=', String(entityIdForKey))
-          .on(`${defAlias}.key`, '=', key)
-          .on(`${defAlias}.is_active`, '=', true)
-          .on((eb: any) => eb.or([
-            eb(`${defAlias}.tenant_id`, '=', tenantId),
-            eb(`${defAlias}.tenant_id`, 'is', null),
-          ]))
-      )
-      // Join values with record match
-      q = q.leftJoin(`custom_field_values as ${valAlias}` as any, (jb: any) =>
-        jb.on(`${valAlias}.entity_id`, '=', String(entityIdForKey))
-          .on(`${valAlias}.field_key`, '=', key)
-          .onRef(`${valAlias}.record_id`, '=', recordIdExpr as any)
-          .on((eb: any) => eb.or([
-            eb(`${valAlias}.tenant_id`, '=', tenantId),
-            eb(`${valAlias}.tenant_id`, 'is', null),
-          ]))
-      )
-      // Force a common SQL type across branches to avoid Postgres CASE type conflicts
-      const caseExpr = sql<string | null>`CASE ${sql.ref(`${defAlias}.kind`)}
-           WHEN 'integer' THEN (${sql.ref(`${valAlias}.value_int`)})::text
-           WHEN 'float' THEN (${sql.ref(`${valAlias}.value_float`)})::text
-           WHEN 'boolean' THEN (${sql.ref(`${valAlias}.value_bool`)})::text
-           WHEN 'multiline' THEN (${sql.ref(`${valAlias}.value_multiline`)})::text
-           ELSE (${sql.ref(`${valAlias}.value_text`)})::text
-         END`
-      cfValueExprByKey[key] = caseExpr
-      const alias = sanitize(`cf:${key}`)
-      // Project as aggregated to avoid duplicates when multi values exist
-      if ((opts.fields || []).includes(`cf:${key}`) || opts.includeCustomFields === true || (requestedCustomFieldKeys.length > 0 && requestedCustomFieldKeys.includes(key))) {
-        const multiAlias = `${alias}__is_multi`
-        const isMultiExpr = sql<boolean>`bool_or(coalesce((${sql.ref(`${defAlias}.config_json`)}->>'multi')::boolean, false))`
-        const aggregatedArray = sql<unknown>`array_remove(array_agg(DISTINCT ${caseExpr}), NULL)`
-        const projExpr = sql<unknown>`CASE WHEN ${isMultiExpr}
-                THEN to_jsonb(${aggregatedArray})
-                ELSE to_jsonb(max(${caseExpr}))
-           END`
-        q = q.select(projExpr.as(alias))
-        q = q.select(isMultiExpr.as(multiAlias))
-        cfSelectedAliases.push(alias)
-        cfJsonAliases.add(alias)
-        cfMultiAliasByAlias.set(alias, multiAlias)
-      }
-    }
-
-    // Apply cf:* filters (on raw expressions)
-    for (const f of cfFilters) {
-      if (!f.field.startsWith('cf:')) continue
-      const key = f.field.slice(3)
-      const expr = cfValueExprByKey[key]
-      if (!expr) continue
-      if ((f.op === 'like' || f.op === 'ilike') && searchActive && typeof f.value === 'string') {
-        const tokens = tokenizeText(String(f.value), searchConfig)
-        const hashes = tokens.hashes
-        if (hashes.length) {
-          const result = this.applySearchTokens(q, {
-            entity: String(entity),
-            field: f.field,
-            hashes,
-            recordIdColumn,
-            tenantId: opts.tenantId ?? null,
-            organizationScope: orgScope,
-            tokens: tokens.tokens,
-          })
-          this.logSearchDebug('search:cf-filter', {
-            entity: String(entity),
-            field: f.field,
-            tokens: tokens.tokens,
-            hashes,
-            applied: result.applied,
-            tenantId: opts.tenantId ?? null,
-            organizationScope: orgScope,
-          })
-          if (result.applied) {
-            q = result.builder
-            continue
-          }
-        } else {
-          this.logSearchDebug('search:cf-skip-empty-hashes', {
-            entity: String(entity),
-            field: f.field,
-            value: f.value,
-          })
-        }
-      }
-      q = this.applyColumnOp(q, expr, f.op, f.value)
-    }
-
-    // Entity extensions joins (no selection yet; enables future filters/projections)
-    if (opts.includeExtensions) {
-      const { getModules } = await import('@open-mercato/shared/lib/i18n/server')
-      const allMods = getModules() as any[]
-      const allExts = allMods.flatMap((m) => (m as any).entityExtensions || [])
-      const exts = allExts.filter((e: any) => e.base === entity)
-      const chosen = Array.isArray(opts.includeExtensions)
-        ? exts.filter((e: any) => (opts.includeExtensions as string[]).includes(e.extension))
-        : exts
-      for (const e of chosen) {
-        const [, extName] = (e.extension as string).split(':')
-        const extTable = extName.endsWith('s') ? extName : `${extName}s`
-        const alias = `ext_${sanitize(extName)}`
-        q = q.leftJoin(`${extTable} as ${alias}` as any, (jb: any) =>
-          jb.onRef(`${alias}.${e.join.extensionKey}`, '=', `${table}.${e.join.baseKey}`)
+        const entityIdForKey = source.entityId
+        const recordIdExpr = source.recordIdExpr
+        const sourceAliasSafe = sanitize(source.alias || 'src')
+        const keyAliasSafe = sanitize(key)
+        const defAlias = `cfd_${sourceAliasSafe}_${keyAliasSafe}`
+        const valAlias = `cfv_${sourceAliasSafe}_${keyAliasSafe}`
+        // Join definitions for kind resolution
+        q = q.leftJoin(`custom_field_defs as ${defAlias}` as any, (jb: any) =>
+          jb.on(`${defAlias}.entity_id`, '=', String(entityIdForKey))
+            .on(`${defAlias}.key`, '=', key)
+            .on(`${defAlias}.is_active`, '=', true)
+            .on((eb: any) => eb.or([
+              eb(`${defAlias}.tenant_id`, '=', tenantId),
+              eb(`${defAlias}.tenant_id`, 'is', null),
+            ]))
         )
-      }
-    }
-
-    // Sorting: base fields and cf:* (use aggregated alias for cf)
-    for (const s of resolvedSorts) {
-      if (s.field.startsWith('cf:')) {
-        const key = s.field.slice(3)
+        // Join values with record match
+        q = q.leftJoin(`custom_field_values as ${valAlias}` as any, (jb: any) =>
+          jb.on(`${valAlias}.entity_id`, '=', String(entityIdForKey))
+            .on(`${valAlias}.field_key`, '=', key)
+            .onRef(`${valAlias}.record_id`, '=', recordIdExpr as any)
+            .on((eb: any) => eb.or([
+              eb(`${valAlias}.tenant_id`, '=', tenantId),
+              eb(`${valAlias}.tenant_id`, 'is', null),
+            ]))
+        )
+        // Force a common SQL type across branches to avoid Postgres CASE type conflicts
+        const caseExpr = sql<string | null>`CASE ${sql.ref(`${defAlias}.kind`)}
+             WHEN 'integer' THEN (${sql.ref(`${valAlias}.value_int`)})::text
+             WHEN 'float' THEN (${sql.ref(`${valAlias}.value_float`)})::text
+             WHEN 'boolean' THEN (${sql.ref(`${valAlias}.value_bool`)})::text
+             WHEN 'multiline' THEN (${sql.ref(`${valAlias}.value_multiline`)})::text
+             ELSE (${sql.ref(`${valAlias}.value_text`)})::text
+           END`
+        cfValueExprByKey[key] = caseExpr
         const alias = sanitize(`cf:${key}`)
-        // Ensure included in projection to sort by
-        if (!cfSelectedAliases.includes(alias)) {
-          const expr = cfValueExprByKey[key]
-          if (expr) {
-            q = q.select(sql<string | null>`max(${expr})`.as(alias))
-            cfSelectedAliases.push(alias)
+        // Project as aggregated to avoid duplicates when multi values exist
+        if (!isSortKeysProjection && ((opts.fields || []).includes(`cf:${key}`) || opts.includeCustomFields === true || (requestedCustomFieldKeys.length > 0 && requestedCustomFieldKeys.includes(key)))) {
+          const multiAlias = `${alias}__is_multi`
+          const isMultiExpr = sql<boolean>`bool_or(coalesce((${sql.ref(`${defAlias}.config_json`)}->>'multi')::boolean, false))`
+          const aggregatedArray = sql<unknown>`array_remove(array_agg(DISTINCT ${caseExpr}), NULL)`
+          const projExpr = sql<unknown>`CASE WHEN ${isMultiExpr}
+                  THEN to_jsonb(${aggregatedArray})
+                  ELSE to_jsonb(max(${caseExpr}))
+             END`
+          q = q.select(projExpr.as(alias))
+          q = q.select(isMultiExpr.as(multiAlias))
+          cfSelectedAliases.push(alias)
+          cfJsonAliases.add(alias)
+          cfMultiAliasByAlias.set(alias, multiAlias)
+        }
+      }
+
+      // Apply cf:* filters (on raw expressions)
+      for (const f of cfFilters) {
+        if (!f.field.startsWith('cf:')) continue
+        const key = f.field.slice(3)
+        const expr = cfValueExprByKey[key]
+        if (!expr) continue
+        if ((f.op === 'like' || f.op === 'ilike') && searchActive && typeof f.value === 'string') {
+          const tokens = tokenizeText(String(f.value), searchConfig)
+          const hashes = tokens.hashes
+          if (hashes.length) {
+            const result = this.applySearchTokens(q, {
+              entity: String(entity),
+              field: f.field,
+              hashes,
+              recordIdColumn,
+              tenantId: opts.tenantId ?? null,
+              organizationScope: orgScope,
+              tokens: tokens.tokens,
+            })
+            this.logSearchDebug('search:cf-filter', {
+              entity: String(entity),
+              field: f.field,
+              tokens: tokens.tokens,
+              hashes,
+              applied: result.applied,
+              tenantId: opts.tenantId ?? null,
+              organizationScope: orgScope,
+            })
+            if (result.applied) {
+              q = result.builder
+              continue
+            }
+          } else {
+            this.logSearchDebug('search:cf-skip-empty-hashes', {
+              entity: String(entity),
+              field: f.field,
+              value: f.value,
+            })
           }
         }
-        if (!requiresPlaintextSort) q = q.orderBy(alias, (s.dir ?? 'asc') as any)
-      } else {
-        if (!requiresPlaintextSort) q = q.orderBy(qualify(s.field), (s.dir ?? 'asc') as any)
+        q = this.applyColumnOp(q, expr, f.op, f.value)
       }
+
+      // Entity extensions joins (no selection yet; enables future filters/projections)
+      if (opts.includeExtensions) {
+        const { getModules } = await import('@open-mercato/shared/lib/i18n/server')
+        const allMods = getModules() as any[]
+        const allExts = allMods.flatMap((m) => (m as any).entityExtensions || [])
+        const exts = allExts.filter((e: any) => e.base === entity)
+        const chosen = Array.isArray(opts.includeExtensions)
+          ? exts.filter((e: any) => (opts.includeExtensions as string[]).includes(e.extension))
+          : exts
+        for (const e of chosen) {
+          const [, extName] = (e.extension as string).split(':')
+          const extTable = extName.endsWith('s') ? extName : `${extName}s`
+          const alias = `ext_${sanitize(extName)}`
+          q = q.leftJoin(`${extTable} as ${alias}` as any, (jb: any) =>
+            jb.onRef(`${alias}.${e.join.extensionKey}`, '=', `${table}.${e.join.baseKey}`)
+          )
+        }
+      }
+
+      // Sorting: base fields and cf:* (use aggregated alias for cf)
+      for (const s of resolvedSorts) {
+        if (s.field.startsWith('cf:')) {
+          const key = s.field.slice(3)
+          const alias = sanitize(`cf:${key}`)
+          // Ensure included in projection to sort by
+          if (!cfSelectedAliases.includes(alias)) {
+            const expr = cfValueExprByKey[key]
+            if (expr) {
+              q = q.select(sql<string | null>`max(${expr})`.as(alias))
+              cfSelectedAliases.push(alias)
+            }
+          }
+          if (!requiresPlaintextSort) q = q.orderBy(alias, (s.dir ?? 'asc') as any)
+        } else {
+          if (!requiresPlaintextSort) q = q.orderBy(qualify(s.field), (s.dir ?? 'asc') as any)
+        }
+      }
+
+      // Deduplicate if we joined CFs or extensions by grouping on base id
+      const hasJoinedAggregates = (opts.includeExtensions && (Array.isArray(opts.includeExtensions) ? (opts.includeExtensions.length > 0) : true)) || Object.keys(cfValueExprByKey).length > 0
+      if (hasJoinedAggregates) {
+        q = q.groupBy(`${table}.id`)
+      }
+
+      return { builder: q, hasJoinedAggregates, cfJsonAliases, cfMultiAliasByAlias, resolvedCustomFieldDefinitions }
     }
 
     // Pagination
     const page = opts.page?.page ?? 1
     const pageSize = opts.page?.pageSize ?? 20
-    // Deduplicate if we joined CFs or extensions by grouping on base id
-    const hasJoinedAggregates = (opts.includeExtensions && (Array.isArray(opts.includeExtensions) ? (opts.includeExtensions.length > 0) : true)) || Object.keys(cfValueExprByKey).length > 0
-    if (hasJoinedAggregates) {
-      q = q.groupBy(`${table}.id`)
-    }
+
+    const {
+      builder: qFull,
+      hasJoinedAggregates,
+      cfJsonAliases,
+      cfMultiAliasByAlias,
+      resolvedCustomFieldDefinitions,
+    } = await buildQuery('full')
+
     // `count(distinct base.id)` is only required when a join can multiply base rows
     // (CF/extension aggregates, explicit relation joins, or custom-field sources).
     // Without such joins base.id is the unique PK, so `count(*)` is equivalent and
@@ -856,17 +898,41 @@ export class BasicQueryEngine implements QueryEngine {
       ? sql<string>`count(distinct ${sql.ref(`${table}.id`)})`
       : sql<string>`count(*)`
     const countBuilder = hasJoinedAggregates
-      ? q.clearSelect().clearOrderBy().clearGroupBy().select(countExpr.as('count'))
-      : q.clearSelect().clearOrderBy().select(countExpr.as('count'))
+      ? qFull.clearSelect().clearOrderBy().clearGroupBy().select(countExpr.as('count'))
+      : qFull.clearSelect().clearOrderBy().select(countExpr.as('count'))
     const countRow = await countBuilder.executeTakeFirst() as { count: unknown } | undefined
     const total = Number((countRow as any)?.count ?? 0)
-    const dataQuery = requiresPlaintextSort
-      ? q
-      : q.limit(pageSize).offset((page - 1) * pageSize)
-    const items = await dataQuery.execute() as any[]
 
-    if (cfJsonAliases.size > 0) {
-      for (const row of items) {
+    const svc = encryptionService
+    const decryptPayload =
+      svc?.decryptEntityPayload?.bind(svc) as
+        | ((
+            entityId: EntityId,
+            payload: Record<string, unknown>,
+            tenantId: string | null,
+            organizationId: string | null,
+          ) => Promise<Record<string, unknown>>)
+        | null
+
+    const decryptRow = async (item: ResultRow): Promise<ResultRow> => {
+      if (!decryptPayload) return item
+      try {
+        const decrypted = await decryptPayload(
+          entity,
+          item,
+          (item?.tenant_id ?? item?.tenantId ?? opts.tenantId ?? null) as string | null,
+          (item?.organization_id ?? item?.organizationId ?? fallbackOrgId ?? null) as string | null,
+        )
+        return { ...item, ...decrypted }
+      } catch (err) {
+        console.error('QueryEngine: error decrypting entity payload', err)
+        return item
+      }
+    }
+
+    const normalizeCfJsonAliases = (rows: ResultRow[]) => {
+      if (cfJsonAliases.size === 0) return
+      for (const row of rows) {
         for (const alias of cfJsonAliases) {
           const multiAlias = cfMultiAliasByAlias.get(alias)
           const isMulti = multiAlias ? Boolean(row[multiAlias]) : false
@@ -887,42 +953,66 @@ export class BasicQueryEngine implements QueryEngine {
       }
     }
 
-    const svc = encryptionService
-    const decryptPayload =
-      svc?.decryptEntityPayload?.bind(svc) as
-        | ((
-            entityId: EntityId,
-            payload: Record<string, unknown>,
-            tenantId: string | null,
-            organizationId: string | null,
-          ) => Promise<Record<string, unknown>>)
-        | null
-    let decryptedItems = items
-    if (decryptPayload) {
-      decryptedItems = await Promise.all(
-        (items as any[]).map(async (item) => {
-          try {
-            const decrypted = await decryptPayload(
-              entity,
-              item,
-              item?.tenant_id ?? item?.tenantId ?? opts.tenantId ?? null,
-              item?.organization_id ?? item?.organizationId ?? fallbackOrgId ?? null,
-            )
-            return { ...item, ...decrypted }
-          } catch (err) {
-            console.error('QueryEngine: error decrypting entity payload', err);
-            return item
-          }
-        })
-      )
+    let pagedItems: ResultRow[]
+    let encryptedSortRowCapWarning: EncryptedSortRowCapWarning | undefined
+
+    if (requiresPlaintextSort) {
+      // Phase 1: slim id+sort-columns candidate scan, bounded-concurrency decrypt,
+      // in-memory sort over the full candidate set, then slice to the page's ids.
+      const cap = resolveEncryptedSortMaxRows()
+      let qSort = (await buildQuery('sortKeys')).builder
+      if (cap !== null) {
+        qSort = qSort.limit(cap).orderBy(qualify('id'), 'asc' as any)
+      }
+      const candidateRows = await qSort.execute() as ResultRow[]
+      const decryptedCandidates = decryptPayload
+        ? await mapWithConcurrency(candidateRows, DECRYPT_CONCURRENCY, decryptRow)
+        : candidateRows
+      const orderedCandidates = sortRowsInMemory(decryptedCandidates, resolvedSorts)
+      const pageIds = orderedCandidates
+        .slice((page - 1) * pageSize, page * pageSize)
+        .map((row) => row.id)
+
+      if (cap !== null && total > cap) {
+        encryptedSortRowCapWarning = {
+          entity,
+          sortFields: resolvedSorts.map((s) => s.field),
+          maxRows: cap,
+          totalMatched: total,
+        }
+      }
+
+      // Phase 2: fetch + decrypt full rows for just the page's ids, then reassemble
+      // in phase-1's order (SQL `WHERE id IN (...)` order is unspecified — never
+      // trust it for ordering).
+      if (pageIds.length === 0) {
+        pagedItems = []
+      } else {
+        const pageRows = await qFull.where(qualify('id'), 'in', pageIds).execute() as ResultRow[]
+        normalizeCfJsonAliases(pageRows)
+        const decryptedPageRows = decryptPayload
+          ? await mapWithConcurrency(pageRows, DECRYPT_CONCURRENCY, decryptRow)
+          : pageRows
+        const byId = new Map(decryptedPageRows.map((row) => [String(row.id), row]))
+        pagedItems = pageIds
+          .map((id) => byId.get(String(id)))
+          .filter((row): row is ResultRow => row != null)
+      }
+    } else {
+      const dataQuery = qFull.limit(pageSize).offset((page - 1) * pageSize)
+      const items = await dataQuery.execute() as ResultRow[]
+      normalizeCfJsonAliases(items)
+      pagedItems = decryptPayload
+        ? await mapWithConcurrency(items, DECRYPT_CONCURRENCY, decryptRow)
+        : items
     }
 
-    const pagedItems = requiresPlaintextSort
-      ? sortRowsInMemory(decryptedItems as Record<string, unknown>[], resolvedSorts)
-          .slice((page - 1) * pageSize, page * pageSize)
-      : decryptedItems
+    let queryResult: QueryResult<T> = { items: pagedItems as unknown as T[], page, pageSize, total }
 
-    let queryResult: QueryResult<T> = { items: pagedItems, page, pageSize, total }
+    if (encryptedSortRowCapWarning) {
+      const meta: QueryResultMeta = { encryptedSortRowCapWarning }
+      queryResult.meta = meta
+    }
 
     // --- UMES query extension: after-query pipeline ---
     if (ext && extensionCtx) {

--- a/packages/shared/src/lib/query/types.ts
+++ b/packages/shared/src/lib/query/types.ts
@@ -148,8 +148,16 @@ export type PartialIndexWarning = {
   scope?: 'scoped' | 'global'
 }
 
+export type EncryptedSortRowCapWarning = {
+  entity: EntityId
+  sortFields: string[]
+  maxRows: number
+  totalMatched: number
+}
+
 export type QueryResultMeta = {
   partialIndexWarning?: PartialIndexWarning
+  encryptedSortRowCapWarning?: EncryptedSortRowCapWarning
 }
 
 export type QueryResult<T = any> = {


### PR DESCRIPTION
## Summary

Sorting by a tenant-encrypted column (e.g. `display_name`, `primary_email` on the customers list) made both query engines abandon SQL pagination entirely: they loaded the full scoped/filtered result set, decrypted every row with one unbounded `Promise.all`, sorted in memory, and only then sliced to the requested page. `pageSize <= 100` was completely defeated — this is reachable from the stock customers list, not a crafted query.

Fix: split the encrypted-sort path into two phases. Phase 1 fetches only `id` + sort columns for the full candidate set, decrypts them with bounded concurrency, sorts in memory, and determines the page's ids. Phase 2 fetches full rows for just those ids and reassembles them in phase-1's order. An opt-in `OM_ENCRYPTED_SORT_MAX_ROWS` cap bounds phase 1 for very large tables and surfaces a new `QueryResultMeta.encryptedSortRowCapWarning` when the candidate set is truncated.

## Changes

* `packages/shared/src/lib/query/bounded-decrypt.ts` (new): `mapWithConcurrency` — chunked, order-preserving bounded-concurrency helper, no new dependency. Replaces the unbounded `Promise.all` decrypt loops in both engines.
* `packages/shared/src/lib/query/encrypted-sort.ts`: `resolveEncryptedSortMaxRows()` — opt-in `OM_ENCRYPTED_SORT_MAX_ROWS` cap resolver (unset/invalid → uncapped, same pattern as `resolveCfDefIndexCacheTtlMs`).
* `packages/shared/src/lib/query/types.ts`: new `EncryptedSortRowCapWarning` on `QueryResultMeta`, kept separate from `partialIndexWarning` (different concern; both can coexist).
* `packages/shared/src/lib/query/engine.ts` (`BasicQueryEngine`): two-phase fetch for the encrypted-sort path; `!requiresPlaintextSort` path is behavior-identical (only the `Promise.all` → `mapWithConcurrency` swap).
* `packages/core/src/modules/query_index/lib/engine.ts` (`HybridQueryEngine`): same two-phase fetch, sharing one `dekKeyCache` across both phases; `encryptedSortRowCapWarning` can coexist with an independently-triggered `partialIndexWarning`.
* Test updates/additions in both engines' `__tests__/` plus a new `bounded-decrypt.test.ts`.

## Specification

**Does a spec exist for this feature/module?**

* [ ] Yes
* [x] No (created a new spec)
* [ ] N/A (minor change, no spec needed)

**Spec file path:**

N/A — contained bug fix to existing query-engine internals (no new API/contract surface, no schema change); scoped via plan mode rather than a committed spec. Happy to write one in `.ai/specs/` if a reviewer wants it on record.

## Testing

* `yarn workspace @open-mercato/shared test` — 1230/1230 passed (9 pre-existing, unrelated suite-resolution failures for `@open-mercato/cache`, unchanged before/after this change).
* `yarn workspace @open-mercato/core test` — 5424/5424 passed (36 pre-existing, unrelated suite-resolution failures, unchanged before/after).
* `yarn workspace @open-mercato/shared build` / `yarn workspace @open-mercato/core build` — both clean.
* `tsc --noEmit` — clean for `shared`; clean for `core` (confirmed once on this exact code; later re-runs hit sandbox OOM unrelated to the change).
* New: `packages/shared/src/lib/query/__tests__/bounded-decrypt.test.ts` (order preservation, concurrency bound, `Promise.all` fallback at the edges).
* Updated: `engine.test.ts` (shared) and `hybrid-engine.test.ts` (core) — page 1/tail-page pagination on the encrypted-sort path, phase-1/phase-2 query-shape assertions, `OM_ENCRYPTED_SORT_MAX_ROWS` unset/not-exceeded/exceeded incl. the `encryptedSortRowCapWarning` shape.
* No API route or UI surface changed, so no `.ai/qa/tests/` integration spec was added — covered by the unit tests above.

## Checklist

* [x] This pull request targets `develop`.
* [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
* [ ] I updated documentation, locales, or generators if the change requires it.
* [x] I added or adjusted tests that cover the change.
* [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- documented above: no API/UI surface change -->
* [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
* [ ] Priority set: this PR carries exactly one `priority-*` label. <!-- suggest priority-high, tracked issue is bug/performance/priority-high -->
* [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). <!-- suggest risk-medium: hot path in both query engines, behavior-preserving outside the encrypted-sort case -->
* [ ] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs). <!-- suggest needs-qa: affects customer-facing sort behavior (e.g. customers list sorted by name/email) -->

## Linked issues

Fixes #2969.
