### PR TITLE
fix(ui): refresh settings pages on tenant/org scope change (#3234)

### DIFF
--- a/packages/ui/src/backend/AppShell.tsx
+++ b/packages/ui/src/backend/AppShell.tsx
@@ -29,6 +29,7 @@ import { dismissRecordConflict } from './conflicts/store'
 import { ProgressTopBar } from './progress/ProgressTopBar'
 import { UpgradeActionBanner } from './upgrades/UpgradeActionBanner'
 import { PartialIndexBanner } from './indexes/PartialIndexBanner'
+import { OrganizationScopeBoundary } from './OrganizationScopeBoundary'
 import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import { slugifySidebarId } from '@open-mercato/shared/modules/navigation/sidebarPreferences'
 import { cloneSidebarGroups } from './sidebar/customization-helpers'
@@ -1375,7 +1376,9 @@ function AppShellBody({ productName, logo, email, canManageUpgradeActions = fals
             context={injectionContext}
           />
           <div id="om-top-banners" className="mb-3 space-y-2" />
-          {children}
+          <OrganizationScopeBoundary active={isOnSettingsPath}>
+            {children}
+          </OrganizationScopeBoundary>
           <InjectionSpot spotId={BACKEND_LAYOUT_FOOTER_INJECTION_SPOT_ID} context={injectionContext} />
         </main>
         <footer className="border-t bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/80 px-4 py-3 flex flex-wrap items-center justify-end gap-4">

--- a/packages/ui/src/backend/OrganizationScopeBoundary.tsx
+++ b/packages/ui/src/backend/OrganizationScopeBoundary.tsx
@@ -1,0 +1,54 @@
+'use client'
+import * as React from 'react'
+import {
+  subscribeOrganizationScopeChanged,
+  type OrganizationScopeChangedDetail,
+} from '@open-mercato/shared/lib/frontend/organizationEvents'
+
+export type OrganizationScopeBoundaryProps = {
+  active: boolean
+  children: React.ReactNode
+}
+
+/**
+ * Remounts its children whenever the active organization/tenant scope changes.
+ *
+ * The org/tenant switcher already calls `router.refresh()` on a scope change,
+ * which re-runs server components but does NOT remount client components — so
+ * settings pages that fetch their data once in a mount `useEffect` keep showing
+ * the previous scope's values until a manual reload. Wrapping those pages here
+ * forces a fresh mount (and therefore a refetch) on a real scope change.
+ *
+ * Gated by `active` so only the settings surface remounts; list/CRUD pages keep
+ * relying on the smoother `router.refresh()` path that preserves table state.
+ */
+export function OrganizationScopeBoundary({ active, children }: OrganizationScopeBoundaryProps) {
+  const [scopeKey, setScopeKey] = React.useState(0)
+  const lastScopeRef = React.useRef<OrganizationScopeChangedDetail | null>(null)
+  const hasInitializedScopeRef = React.useRef(false)
+
+  React.useEffect(() => {
+    return subscribeOrganizationScopeChanged((detail) => {
+      const prev = lastScopeRef.current
+      lastScopeRef.current = detail
+      if (!hasInitializedScopeRef.current) {
+        hasInitializedScopeRef.current = true
+        return
+      }
+      if (
+        prev &&
+        prev.organizationId === detail.organizationId &&
+        prev.tenantId === detail.tenantId
+      ) {
+        return
+      }
+      setScopeKey((current) => current + 1)
+    })
+  }, [])
+
+  if (!active) {
+    return <>{children}</>
+  }
+
+  return <React.Fragment key={scopeKey}>{children}</React.Fragment>
+}

--- a/packages/ui/src/backend/__tests__/OrganizationScopeBoundary.test.tsx
+++ b/packages/ui/src/backend/__tests__/OrganizationScopeBoundary.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { act, render } from '@testing-library/react'
+import { emitOrganizationScopeChanged } from '@open-mercato/shared/lib/frontend/organizationEvents'
+import { OrganizationScopeBoundary } from '../OrganizationScopeBoundary'
+
+let mountCount = 0
+
+function MountCounter() {
+  React.useEffect(() => {
+    mountCount += 1
+  }, [])
+  return <span data-testid="child">child</span>
+}
+
+describe('<OrganizationScopeBoundary>', () => {
+  beforeEach(() => {
+    mountCount = 0
+  })
+
+  it('remounts children on a real scope change when active', () => {
+    render(
+      <OrganizationScopeBoundary active>
+        <MountCounter />
+      </OrganizationScopeBoundary>,
+    )
+    expect(mountCount).toBe(1)
+
+    // First scope event after mount only establishes the baseline.
+    act(() => {
+      emitOrganizationScopeChanged({ organizationId: 'org-a', tenantId: 'tenant-a' })
+    })
+    expect(mountCount).toBe(1)
+
+    // A genuine change remounts the subtree, re-running mount effects.
+    act(() => {
+      emitOrganizationScopeChanged({ organizationId: 'org-b', tenantId: 'tenant-a' })
+    })
+    expect(mountCount).toBe(2)
+  })
+
+  it('does not remount children when the scope is unchanged', () => {
+    render(
+      <OrganizationScopeBoundary active>
+        <MountCounter />
+      </OrganizationScopeBoundary>,
+    )
+    act(() => {
+      emitOrganizationScopeChanged({ organizationId: 'org-c', tenantId: 'tenant-c' })
+    })
+    act(() => {
+      emitOrganizationScopeChanged({ organizationId: 'org-c', tenantId: 'tenant-c' })
+    })
+    expect(mountCount).toBe(1)
+  })
+
+  it('does not remount children on a scope change when inactive', () => {
+    render(
+      <OrganizationScopeBoundary active={false}>
+        <MountCounter />
+      </OrganizationScopeBoundary>,
+    )
+    act(() => {
+      emitOrganizationScopeChanged({ organizationId: 'org-d', tenantId: 'tenant-d' })
+    })
+    act(() => {
+      emitOrganizationScopeChanged({ organizationId: 'org-e', tenantId: 'tenant-e' })
+    })
+    expect(mountCount).toBe(1)
+  })
+})


### PR DESCRIPTION
Fixes #3234

## Problem
Switching the active tenant/organization did not refresh data on settings pages — the page kept showing the previously-selected scope's values until a manual browser reload. Noticed on `/backend/config/search` (Vector Search) but the root cause was generic across settings pages.

## Root Cause
The org/tenant switcher (`apps/mercato/src/components/OrganizationSwitcher.tsx`) **already** emits the central scope-change event *and* calls `router.refresh()` on a switch. But `router.refresh()` only re-fetches/re-renders **server** components — it does **not** remount client components, so their mount `useEffect` data fetches do not re-run.

Settings/config pages (`SearchSettingsPageClient` and every other `pageContext: 'settings'` page) load their data once in client mount effects, so they retained the previous scope's state. List/CRUD pages avoid this because their data is RSC-driven / `DataTable` re-fetches via its own scope subscription — those intentionally rely on `router.refresh()` and keep table/filter state.

## What Changed
- New internal client component `packages/ui/src/backend/OrganizationScopeBoundary.tsx` that remounts its children on a **real** org/tenant scope change (subscribing to `subscribeOrganizationScopeChanged`, with the same dedup + first-event init-skip guard that `DataTable` uses).
- Wired it into `AppShell` around the page `{children}`, gated by the **existing** `isOnSettingsPath` signal. This makes the fix:
  - **Central & general** — automatically covers every settings/config page (`pageContext: 'settings'`), not just search.
  - **Low blast radius** — non-settings pages get an unchanged passthrough; list/CRUD pages stay on the smoother `router.refresh()` path that preserves their table/filter state.
- No change to the locale-switch reload behavior.

## Tests
- New `OrganizationScopeBoundary.test.tsx`:
  - remounts children on a real scope change when active
  - does **not** remount on an unchanged scope
  - does **not** remount on a scope change when inactive (non-settings pages)
- Existing `AppShell.test.tsx` (14 tests) still green.
- Full `@open-mercato/ui` suite green (the single `formatCurrency` failure is a pre-existing machine-locale artifact under `LANG=pl_PL`; passes under `en_US`, green in CI).
- `yarn build:packages`, `yarn generate`, `yarn typecheck` all pass.

## Backward Compatibility
No contract surface changes. Purely additive: one new internal component (not exported from the package index) plus a two-line `AppShell` wrap. AppShell's public props are unchanged.

## Suggested labels
`bug`, `review`, `priority-medium`, `risk-medium` (single-module UI fix shipped with tests). _Note: this PR is opened from a fork without upstream triage permissions, so labels/assignees could not be applied programmatically._