### PR TITLE
fix(staff): atomic start-timer command so timer start can't orphan an entry (#3311)

### DIFF
--- a/packages/core/src/modules/staff/api/timesheets/time-entries/start-timer/route.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/start-timer/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
+import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { staffTimeEntryStartTimerSchema, type StaffTimeEntryStartTimerInput } from '../../../../data/validators'
+
+export const metadata = {
+  POST: { requireAuth: true, requireFeatures: ['staff.timesheets.manage_own'] },
+}
+
+async function buildContext(
+  req: Request
+): Promise<{ ctx: CommandRuntimeContext; translate: (key: string, fallback?: string) => string }> {
+  const container = await createRequestContainer()
+  const auth = await getAuthFromRequest(req)
+  const { translate } = await resolveTranslations()
+  if (!auth) throw new CrudHttpError(401, { error: translate('staff.errors.unauthorized', 'Unauthorized') })
+  const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
+  const ctx: CommandRuntimeContext = {
+    container,
+    auth,
+    organizationScope: scope,
+    selectedOrganizationId: scope?.selectedId ?? auth.orgId ?? null,
+    organizationIds: scope?.filterIds ?? (auth.orgId ? [auth.orgId] : null),
+    request: req,
+  }
+  return { ctx, translate }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { ctx, translate } = await buildContext(req)
+    const body = await req.json().catch(() => ({}))
+    const input = parseScopedCommandInput(staffTimeEntryStartTimerSchema, body, ctx, translate)
+    const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
+    const { result, logEntry } = await commandBus.execute<StaffTimeEntryStartTimerInput, { timeEntryId: string }>(
+      'staff.timesheets.time_entries.start_timer',
+      { input, ctx },
+    )
+    const response = NextResponse.json({ ok: true, id: result?.timeEntryId ?? null }, { status: 201 })
+    if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
+      response.headers.set(
+        'x-om-operation',
+        serializeOperationMetadata({
+          id: logEntry.id,
+          undoToken: logEntry.undoToken,
+          commandId: logEntry.commandId,
+          actionLabel: logEntry.actionLabel ?? null,
+          resourceKind: logEntry.resourceKind ?? 'staff.timesheets.time_entry',
+          resourceId: logEntry.resourceId ?? result?.timeEntryId ?? null,
+          executedAt: logEntry.createdAt instanceof Date ? logEntry.createdAt.toISOString() : undefined,
+        }),
+      )
+    }
+    return response
+  } catch (err) {
+    if (isCrudHttpError(err)) {
+      return NextResponse.json(err.body, { status: err.status })
+    }
+    const { translate } = await resolveTranslations()
+    console.error('staff.timesheets.time-entries.start-timer failed', err)
+    return NextResponse.json(
+      { error: translate('staff.timesheets.errors.timerStart', 'Failed to start timer.') },
+      { status: 400 },
+    )
+  }
+}
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'Staff',
+  summary: 'Start a timesheet timer',
+  methods: {
+    POST: {
+      summary: 'Start a timesheet timer',
+      description:
+        'Atomically creates a timer-sourced time entry and starts it (sets startedAt and creates the initial work segment) in a single transaction, so a partial failure cannot leave an orphaned, unstarted entry.',
+      requestBody: {
+        contentType: 'application/json',
+        schema: staffTimeEntryStartTimerSchema,
+      },
+      responses: [
+        {
+          status: 201,
+          description: 'Timer started',
+          schema: z.object({ ok: z.literal(true), id: z.string().uuid().nullable() }),
+        },
+        { status: 400, description: 'Invalid payload', schema: z.object({ error: z.string() }) },
+        { status: 401, description: 'Unauthorized', schema: z.object({ error: z.string() }) },
+        { status: 403, description: 'Forbidden', schema: z.object({ error: z.string() }) },
+        {
+          status: 409,
+          description: 'Another timer is already running for this staff member',
+          schema: z.object({ error: z.string() }),
+        },
+        {
+          status: 422,
+          description: 'Referenced time project not found or out of scope',
+          schema: z.object({ error: z.string() }),
+        },
+      ],
+    },
+  },
+}

--- a/packages/core/src/modules/staff/commands/__tests__/timesheets-start-timer.test.ts
+++ b/packages/core/src/modules/staff/commands/__tests__/timesheets-start-timer.test.ts
@@ -1,0 +1,178 @@
+/** @jest-environment node */
+// Regression coverage for issue #3311: starting a timesheet timer must be a
+// single atomic command (create the timer entry AND start it in one
+// transaction) so a partial failure can no longer leave an orphaned,
+// never-started timer entry. The legacy flow issued two independent client
+// requests (POST time-entries to create a `source:'timer'` row, then
+// POST /timer-start); if the second request failed or the browser navigated
+// between them, the created entry persisted unstarted. This test pins the
+// atomic `staff.timesheets.time_entries.start_timer` command and proves that a
+// rejected start (single-active-timer invariant, #2855) persists no orphan.
+import type { AwilixContainer } from 'awilix'
+
+const mockFindOneWithDecryption = jest.fn()
+const mockEmitStaffEvent = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/commands/helpers')
+  return {
+    ...actual,
+    emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+    emitCrudUndoSideEffects: jest.fn().mockResolvedValue(undefined),
+  }
+})
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn().mockResolvedValue({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('@open-mercato/core/modules/staff/events', () => ({
+  emitStaffEvent: jest.fn((...args: unknown[]) => mockEmitStaffEvent(...args)),
+}))
+
+type RegisteredCommand = {
+  execute: (input: unknown, ctx: unknown) => Promise<unknown>
+}
+
+const TENANT_ID = '11111111-1111-4111-8111-111111111111'
+const ORG_ID = '22222222-2222-4222-8222-222222222222'
+const STAFF_MEMBER_ID = '33333333-3333-4333-8333-333333333333'
+const PROJECT_ID = '44444444-4444-4444-8444-444444444444'
+
+type LoadedCommand = {
+  command: RegisteredCommand
+  StaffTimeEntry: unknown
+  StaffTimeEntrySegment: unknown
+}
+
+// Re-import the entity classes from the *same* freshly-reset module registry the
+// command uses (jest.resetModules() makes a stale top-level import a different
+// class object), so identity comparisons in the em.create mock line up.
+async function loadStartTimerCommand(): Promise<LoadedCommand> {
+  jest.resetModules()
+  const { commandRegistry } = await import('@open-mercato/shared/lib/commands')
+  commandRegistry.clear()
+  await import('../timesheets-entries')
+  const entities = await import('../../data/entities')
+  return {
+    command: commandRegistry.get('staff.timesheets.time_entries.start_timer') as RegisteredCommand,
+    StaffTimeEntry: entities.StaffTimeEntry,
+    StaffTimeEntrySegment: entities.StaffTimeEntrySegment,
+  }
+}
+
+type CreateCall = { cls: unknown; data: Record<string, unknown> }
+
+function makeEm(createCalls: CreateCall[], StaffTimeEntry: unknown, StaffTimeEntrySegment: unknown) {
+  let entrySeq = 0
+  const em: Record<string, jest.Mock> = {
+    fork: jest.fn(),
+    // assertTimeProjectInScope() resolves the referenced project as in-scope.
+    findOne: jest.fn(async () => ({ id: PROJECT_ID })),
+    create: jest.fn((cls: unknown, data: Record<string, unknown>) => {
+      createCalls.push({ cls, data })
+      const created: Record<string, unknown> = { ...data }
+      if (cls === StaffTimeEntry) created.id = `entry-${++entrySeq}`
+      else if (cls === StaffTimeEntrySegment) created.id = 'segment-1'
+      return created
+    }),
+    flush: jest.fn(async () => {}),
+    transactional: jest.fn(async (cb: (trx: unknown) => Promise<unknown>) => cb(em)),
+  }
+  em.fork.mockReturnValue(em)
+  return em
+}
+
+function createCtx(em: unknown) {
+  return {
+    auth: { sub: 'user-1', tenantId: TENANT_ID, orgId: ORG_ID },
+    container: {
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        if (name === 'dataEngine') return null
+        if (name === 'rbacService') return { userHasAllFeatures: async () => true }
+        return null
+      },
+    } as unknown as AwilixContainer,
+    selectedOrganizationId: null,
+    organizationScope: null,
+    organizationIds: null,
+  }
+}
+
+function startInput() {
+  return {
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    staffMemberId: STAFF_MEMBER_ID,
+    date: '2026-01-01',
+    timeProjectId: PROJECT_ID,
+    notes: 'Working',
+  }
+}
+
+describe('staff timesheets atomic start-timer (#3311)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFindOneWithDecryption.mockResolvedValue(null)
+    mockEmitStaffEvent.mockResolvedValue(undefined)
+  })
+
+  it('creates and starts the timer entry inside a single transaction', async () => {
+    const { command, StaffTimeEntry, StaffTimeEntrySegment } = await loadStartTimerCommand()
+    expect(command).toBeTruthy()
+    const createCalls: CreateCall[] = []
+    const em = makeEm(createCalls, StaffTimeEntry, StaffTimeEntrySegment)
+
+    const result = (await command.execute(startInput(), createCtx(em))) as { timeEntryId: string }
+
+    expect(result.timeEntryId).toBeTruthy()
+    expect(em.transactional).toHaveBeenCalledTimes(1)
+
+    const entryCreate = createCalls.find((call) => call.cls === StaffTimeEntry)
+    const segmentCreate = createCalls.find((call) => call.cls === StaffTimeEntrySegment)
+    expect(entryCreate?.data).toMatchObject({
+      source: 'timer',
+      durationMinutes: 0,
+      staffMemberId: STAFF_MEMBER_ID,
+      timeProjectId: PROJECT_ID,
+    })
+    expect(entryCreate?.data.startedAt).toBeInstanceOf(Date)
+    expect(segmentCreate?.data).toMatchObject({
+      segmentType: 'work',
+      timeEntryId: result.timeEntryId,
+    })
+    expect(mockEmitStaffEvent).toHaveBeenCalledWith(
+      'staff.timesheets.time_entry.timer_started',
+      expect.objectContaining({ id: result.timeEntryId, staffMemberId: STAFF_MEMBER_ID }),
+      expect.objectContaining({ persistent: true }),
+    )
+  })
+
+  it('rejects with 409 and persists no orphan entry when another timer is already running (#2855)', async () => {
+    const { command, StaffTimeEntry, StaffTimeEntrySegment } = await loadStartTimerCommand()
+    const createCalls: CreateCall[] = []
+    const em = makeEm(createCalls, StaffTimeEntry, StaffTimeEntrySegment)
+    // Single-active-timer invariant: the staff member already has a running entry.
+    mockFindOneWithDecryption.mockResolvedValue({
+      id: 'other-running',
+      staffMemberId: STAFF_MEMBER_ID,
+      startedAt: new Date('2026-01-01T07:00:00.000Z'),
+      endedAt: null,
+    })
+
+    await expect(command.execute(startInput(), createCtx(em))).rejects.toMatchObject({ status: 409 })
+
+    // The invariant check runs before any create inside the same transaction, so
+    // a rejected start leaves no orphaned entry or segment behind — the bug.
+    expect(createCalls).toHaveLength(0)
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(mockEmitStaffEvent).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/staff/commands/timesheets-entries.ts
+++ b/packages/core/src/modules/staff/commands/timesheets-entries.ts
@@ -7,15 +7,18 @@ import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { buildChanges, emitCrudSideEffects, emitCrudUndoSideEffects } from '@open-mercato/shared/lib/commands/helpers'
 import { makeCreateRedo } from '@open-mercato/shared/lib/commands/redo'
 import type { CrudIndexerConfig } from '@open-mercato/shared/lib/crud/types'
-import { StaffTimeEntry, StaffTimeProject, type StaffTimeEntrySource } from '../data/entities'
+import { StaffTimeEntry, StaffTimeEntrySegment, StaffTimeProject, type StaffTimeEntrySource } from '../data/entities'
+import { emitStaffEvent } from '../events'
 
 const timeEntryCrudIndexer: CrudIndexerConfig<StaffTimeEntry> = {
   entityType: 'staff:staff_time_entry',
 }
 import {
   staffTimeEntryCreateSchema,
+  staffTimeEntryStartTimerSchema,
   staffTimeEntryUpdateSchema,
   type StaffTimeEntryCreateInput,
+  type StaffTimeEntryStartTimerInput,
   type StaffTimeEntryUpdateInput,
 } from '../data/validators'
 import { staffTimeEntryCrudEvents } from '../lib/crud'
@@ -281,6 +284,167 @@ const createTimeEntryCommand: CommandHandler<StaffTimeEntryCreateInput, { timeEn
   }),
 }
 
+const startTimerCommand: CommandHandler<StaffTimeEntryStartTimerInput, { timeEntryId: string }> = {
+  id: 'staff.timesheets.time_entries.start_timer',
+  async execute(rawInput, ctx) {
+    const parsed = staffTimeEntryStartTimerSchema.parse(rawInput)
+    ensureTenantScope(ctx, parsed.tenantId)
+    ensureOrganizationScope(ctx, parsed.organizationId)
+
+    const em = (ctx.container.resolve('em') as EntityManager).fork()
+
+    // Ownership enforcement mirrors createTimeEntryCommand: callers without
+    // `staff.timesheets.manage_all` can only start their own timer, so the
+    // request body's staffMemberId can't start a timer under a colleague's id.
+    let effectiveStaffMemberId = parsed.staffMemberId
+    if (!(await callerHasManageAll(ctx))) {
+      const callerStaffMemberId = await resolveCallerStaffMemberId(em, ctx)
+      if (!callerStaffMemberId) {
+        const { translate } = await resolveTranslations()
+        throw new CrudHttpError(403, {
+          error: translate('staff.timesheets.errors.noStaffMember', 'No staff member linked to your account.'),
+        })
+      }
+      effectiveStaffMemberId = callerStaffMemberId
+    }
+
+    await assertTimeProjectInScope(em, parsed.timeProjectId ?? null, parsed.tenantId, parsed.organizationId)
+
+    const scopeCtx = { tenantId: parsed.tenantId, organizationId: parsed.organizationId }
+
+    // Create the timer entry AND start it inside a single transaction so a
+    // partial failure can never leave an orphaned, never-started timer entry
+    // (issue #3311 — the legacy two-request create-then-start flow). The
+    // single-active-timer invariant (#2855) is re-checked here so a second
+    // surface cannot create a parallel running timer for the same staff member.
+    const { entry, startedAt } = await em.transactional(async (trx) => {
+      const otherRunningEntry = await findOneWithDecryption(
+        trx,
+        StaffTimeEntry,
+        {
+          tenantId: parsed.tenantId,
+          organizationId: parsed.organizationId,
+          staffMemberId: effectiveStaffMemberId,
+          startedAt: { $ne: null },
+          endedAt: null,
+          deletedAt: null,
+        },
+        {},
+        scopeCtx,
+      )
+      if (otherRunningEntry) {
+        const { translate } = await resolveTranslations()
+        throw new CrudHttpError(409, {
+          error: translate(
+            'staff.timesheets.errors.timerAlreadyRunning',
+            'Another timer is already running. Stop it before starting a new one.',
+          ),
+        })
+      }
+
+      const startedAt = new Date()
+      const entry = trx.create(StaffTimeEntry, {
+        tenantId: parsed.tenantId,
+        organizationId: parsed.organizationId,
+        staffMemberId: effectiveStaffMemberId,
+        date: parsed.date,
+        durationMinutes: 0,
+        startedAt,
+        endedAt: null,
+        notes: parsed.notes ?? null,
+        timeProjectId: parsed.timeProjectId ?? null,
+        customerId: null,
+        dealId: null,
+        orderId: null,
+        source: 'timer',
+        createdAt: startedAt,
+        updatedAt: startedAt,
+        deletedAt: null,
+      })
+      // Flush so the DB-generated id is populated before the work segment
+      // references it; both writes commit together when the transaction closes.
+      await trx.flush()
+
+      const segmentData = {
+        tenantId: parsed.tenantId,
+        organizationId: parsed.organizationId,
+        timeEntryId: entry.id,
+        startedAt,
+        segmentType: 'work' as const,
+      }
+      trx.create(StaffTimeEntrySegment, segmentData as never)
+      await trx.flush()
+
+      return { entry, startedAt }
+    })
+
+    await emitCrudSideEffects({
+      dataEngine: ctx.container.resolve('dataEngine'),
+      action: 'created',
+      entity: entry,
+      identifiers: { id: entry.id, organizationId: entry.organizationId, tenantId: entry.tenantId },
+      events: staffTimeEntryCrudEvents,
+      indexer: timeEntryCrudIndexer,
+    })
+
+    void emitStaffEvent('staff.timesheets.time_entry.timer_started', {
+      id: entry.id,
+      staffMemberId: effectiveStaffMemberId,
+      tenantId: parsed.tenantId,
+      organizationId: parsed.organizationId,
+      startedAt: startedAt.toISOString(),
+    }, { persistent: true }).catch((err) => {
+      console.error('[staff.timesheets] emit timer_started failed', err)
+    })
+
+    return { timeEntryId: entry.id }
+  },
+  captureAfter: async (_input, result, ctx) => {
+    const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const snapshot = await loadTimeEntrySnapshot(em, result.timeEntryId)
+    if (!snapshot) return null
+    return { snapshot }
+  },
+  buildLog: async ({ result, ctx }) => {
+    const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const snapshot = await loadTimeEntrySnapshot(em, result.timeEntryId)
+    if (!snapshot) return null
+    const { translate } = await resolveTranslations()
+    return {
+      actionLabel: translate('staff.audit.timesheets.time_entries.startTimer', 'Start timer'),
+      resourceKind: 'staff.timesheets.time_entry',
+      resourceId: snapshot.id,
+      tenantId: snapshot.tenantId,
+      organizationId: snapshot.organizationId,
+      snapshotAfter: snapshot,
+      payload: {
+        undo: {
+          after: snapshot,
+        } satisfies TimeEntryUndoPayload,
+      },
+    }
+  },
+  undo: async ({ logEntry, ctx }) => {
+    const payload = extractUndoPayload<TimeEntryUndoPayload>(logEntry)
+    const after = payload?.after
+    if (!after) return
+    const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const entry = await em.findOne(StaffTimeEntry, { id: after.id })
+    if (entry) {
+      entry.deletedAt = new Date()
+      await em.flush()
+
+      await emitCrudUndoSideEffects({
+        dataEngine: ctx.container.resolve('dataEngine'),
+        action: 'deleted',
+        entity: entry,
+        identifiers: { id: entry.id, organizationId: entry.organizationId, tenantId: entry.tenantId },
+        events: staffTimeEntryCrudEvents,
+      })
+    }
+  },
+}
+
 const updateTimeEntryCommand: CommandHandler<StaffTimeEntryUpdateInput, { timeEntryId: string }> = {
   id: 'staff.timesheets.time_entries.update',
   async prepare(rawInput, ctx) {
@@ -531,5 +695,6 @@ const deleteTimeEntryCommand: CommandHandler<{ id?: string }, { timeEntryId: str
 }
 
 registerCommand(createTimeEntryCommand)
+registerCommand(startTimerCommand)
 registerCommand(updateTimeEntryCommand)
 registerCommand(deleteTimeEntryCommand)

--- a/packages/core/src/modules/staff/data/validators.ts
+++ b/packages/core/src/modules/staff/data/validators.ts
@@ -291,6 +291,14 @@ export const staffTimeEntryUpdateSchema = z.object({
   notes: z.string().max(2000).optional().nullable(),
 })
 
+export const staffTimeEntryStartTimerSchema = z.object({
+  ...scopedCreateFields,
+  staffMemberId: z.string().uuid(),
+  date: z.coerce.date(),
+  timeProjectId: z.string().uuid().optional().nullable(),
+  notes: z.string().max(2000).optional().nullable(),
+})
+
 export const staffTimeEntryBulkItemSchema = z.object({
   id: z.string().uuid().optional().nullable(),
   date: z.coerce.date(),
@@ -369,6 +377,7 @@ export const staffMyProjectVisibilityUpdateSchema = z.object({
 
 export type StaffTimeEntryCreateInput = z.infer<typeof staffTimeEntryCreateSchema>
 export type StaffTimeEntryUpdateInput = z.infer<typeof staffTimeEntryUpdateSchema>
+export type StaffTimeEntryStartTimerInput = z.infer<typeof staffTimeEntryStartTimerSchema>
 export type StaffTimeEntryBulkSaveInput = z.infer<typeof staffTimeEntryBulkSaveSchema>
 export type StaffTimeEntrySegmentCreateInput = z.infer<typeof staffTimeEntrySegmentCreateSchema>
 export type StaffTimeEntrySegmentUpdateInput = z.infer<typeof staffTimeEntrySegmentUpdateSchema>

--- a/packages/core/src/modules/staff/i18n/de.json
+++ b/packages/core/src/modules/staff/i18n/de.json
@@ -120,6 +120,7 @@
   "staff.audit.teams.update": "Team aktualisieren",
   "staff.audit.timesheets.time_entries.create": "Zeiteintrag erstellen",
   "staff.audit.timesheets.time_entries.delete": "Zeiteintrag löschen",
+  "staff.audit.timesheets.time_entries.startTimer": "Timer starten",
   "staff.audit.timesheets.time_entries.update": "Zeiteintrag aktualisieren",
   "staff.audit.timesheets.time_project_members.assign": "Zeitprojektmitglied zuweisen",
   "staff.audit.timesheets.time_project_members.unassign": "Zeitprojektmitglied entfernen",

--- a/packages/core/src/modules/staff/i18n/en.json
+++ b/packages/core/src/modules/staff/i18n/en.json
@@ -120,6 +120,7 @@
   "staff.audit.teams.update": "Update team",
   "staff.audit.timesheets.time_entries.create": "Create time entry",
   "staff.audit.timesheets.time_entries.delete": "Delete time entry",
+  "staff.audit.timesheets.time_entries.startTimer": "Start timer",
   "staff.audit.timesheets.time_entries.update": "Update time entry",
   "staff.audit.timesheets.time_project_members.assign": "Assign time project member",
   "staff.audit.timesheets.time_project_members.unassign": "Unassign time project member",

--- a/packages/core/src/modules/staff/i18n/es.json
+++ b/packages/core/src/modules/staff/i18n/es.json
@@ -120,6 +120,7 @@
   "staff.audit.teams.update": "Actualizar equipo",
   "staff.audit.timesheets.time_entries.create": "Crear registro de tiempo",
   "staff.audit.timesheets.time_entries.delete": "Eliminar registro de tiempo",
+  "staff.audit.timesheets.time_entries.startTimer": "Iniciar temporizador",
   "staff.audit.timesheets.time_entries.update": "Actualizar registro de tiempo",
   "staff.audit.timesheets.time_project_members.assign": "Asignar miembro del proyecto de tiempo",
   "staff.audit.timesheets.time_project_members.unassign": "Desasignar miembro del proyecto de tiempo",

--- a/packages/core/src/modules/staff/i18n/pl.json
+++ b/packages/core/src/modules/staff/i18n/pl.json
@@ -120,6 +120,7 @@
   "staff.audit.teams.update": "Zaktualizuj zespół",
   "staff.audit.timesheets.time_entries.create": "Utwórz wpis czasu",
   "staff.audit.timesheets.time_entries.delete": "Usuń wpis czasu",
+  "staff.audit.timesheets.time_entries.startTimer": "Uruchom licznik czasu",
   "staff.audit.timesheets.time_entries.update": "Zaktualizuj wpis czasu",
   "staff.audit.timesheets.time_project_members.assign": "Przypisz członka projektu czasu",
   "staff.audit.timesheets.time_project_members.unassign": "Usuń przypisanie członka projektu czasu",

--- a/packages/core/src/modules/staff/lib/timesheets-ui/TimerBar.tsx
+++ b/packages/core/src/modules/staff/lib/timesheets-ui/TimerBar.tsx
@@ -8,6 +8,7 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { ProjectColorDot } from './ProjectColorDot'
+import { startTimerEntry } from './startTimer'
 
 type ProjectOption = {
   id: string
@@ -140,31 +141,14 @@ export function TimerBar({ projects, staffMemberId, onTimerStopped }: TimerBarPr
     setIsStarting(true)
     try {
       const today = getToday()
-      const createResponse = await apiCallOrThrow(
-        '/api/staff/timesheets/time-entries',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            staffMemberId,
-            timeProjectId: selectedProjectId,
-            date: today,
-            durationMinutes: 0,
-            source: 'timer',
-            notes: description || null,
-          }),
-        },
-      )
+      const { id: entryId } = await startTimerEntry({
+        staffMemberId,
+        timeProjectId: selectedProjectId,
+        date: today,
+        notes: description || null,
+      })
 
-      const created = createResponse.result as Record<string, unknown> | null
-      const entryId = created?.id as string | undefined
-
-      await apiCallOrThrow(
-        `/api/staff/timesheets/time-entries/${entryId}/timer-start`,
-        { method: 'POST' },
-      )
-
-      setActiveEntryId(entryId ?? null)
+      setActiveEntryId(entryId)
       setActiveProjectId(selectedProjectId)
       startElapsedCounter(new Date().toISOString())
     } catch {

--- a/packages/core/src/modules/staff/lib/timesheets-ui/startTimer.ts
+++ b/packages/core/src/modules/staff/lib/timesheets-ui/startTimer.ts
@@ -1,0 +1,40 @@
+import { apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+
+export type StartTimerEntryInput = {
+  staffMemberId: string
+  timeProjectId: string
+  date: string
+  notes?: string | null
+}
+
+export type StartedTimerEntry = {
+  id: string | null
+}
+
+/**
+ * Starts a timesheet timer through the single atomic server endpoint
+ * (`/api/staff/timesheets/time-entries/start-timer`), which creates the
+ * timer-sourced entry AND starts it in one transaction. This replaces the
+ * legacy create-then-start two-request sequence so a partial failure (a failed
+ * second request, or the browser navigating between the two calls) can no
+ * longer leave an orphaned, never-started timer entry (issue #3311). Both the
+ * TimerBar and the dashboard time-reporting widget call this helper so they
+ * share error handling and refresh semantics.
+ */
+export async function startTimerEntry(input: StartTimerEntryInput): Promise<StartedTimerEntry> {
+  const response = await apiCallOrThrow<Record<string, unknown>>(
+    '/api/staff/timesheets/time-entries/start-timer',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        staffMemberId: input.staffMemberId,
+        timeProjectId: input.timeProjectId,
+        date: input.date,
+        notes: input.notes ?? null,
+      }),
+    },
+  )
+  const result = response.result as Record<string, unknown> | null
+  return { id: (result?.id as string | undefined) ?? null }
+}

--- a/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/widget.client.tsx
+++ b/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/widget.client.tsx
@@ -6,6 +6,7 @@ import { apiCall, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/ap
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Input } from '@open-mercato/ui/primitives/input'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { startTimerEntry } from '../../../lib/timesheets-ui/startTimer'
 import { DEFAULT_SETTINGS, hydrateSettings, type TimeReportingSettings } from './config'
 
 type ProjectOption = { id: string; name: string; code: string | null }
@@ -138,25 +139,15 @@ const TimeReportingWidget: React.FC<DashboardWidgetComponentProps<TimeReportingS
     setActionLoading(true)
     try {
       const today = new Date().toISOString().slice(0, 10)
-      // Create entry + start timer
-      const createRes = await apiCall<Record<string, unknown>>('/api/staff/timesheets/time-entries', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          staffMemberId,
-          date: today,
-          timeProjectId: selectedProjectId,
-          durationMinutes: 0,
-          notes: notes.trim() || null,
-          source: 'timer',
-        }),
+      // Single atomic create+start request (issue #3311): a partial failure can
+      // no longer leave an orphaned, unstarted timer entry, and a rejected start
+      // now surfaces here instead of being silently ignored.
+      await startTimerEntry({
+        staffMemberId,
+        timeProjectId: selectedProjectId,
+        date: today,
+        notes: notes.trim() || null,
       })
-      if (!createRes.ok) throw new Error('Failed to create entry')
-      const body = createRes.result as Record<string, unknown> | null
-      const entryId = String(body?.id ?? (body?.item as Record<string, unknown> | undefined)?.id ?? '')
-      if (!entryId) throw new Error('Failed to extract entry ID')
-
-      await apiCall(`/api/staff/timesheets/time-entries/${entryId}/timer-start`, { method: 'POST' })
 
       onSettingsChange({ ...hydrated, lastProjectId: selectedProjectId })
       await loadState()


### PR DESCRIPTION
## Summary

Starting a staff timesheet timer was implemented as two independent client requests — create a zero-duration `source:'timer'` entry, then `POST /timer-start` on it. If the second request failed, or the browser navigated between the two calls, an unstarted timer entry was orphaned (it represented neither a manual entry nor a running timer). The dashboard widget additionally ignored the `timer-start` response, so a failed start orphaned silently.

This adds a single guarded server path — the `staff.timesheets.time_entries.start_timer` command behind `POST /api/staff/timesheets/time-entries/start-timer` — that creates the timer entry **and** starts it (sets `startedAt`, creates the initial work segment) inside one transaction, re-checking the single-active-timer invariant (#2855) before creating anything, so a rejected start persists no orphan. Both `TimerBar` and the dashboard time-reporting widget now call one shared client helper (`startTimerEntry`) so they share error handling and refresh semantics. The legacy per-id `timer-start` route is unchanged (still used by entries created on the timesheet grid).

## Changes

- Add `staff.timesheets.time_entries.start_timer` command (atomic create+start in one `em.transactional`, single-active-timer guard, emits `created` side-effects + `timer_started` after commit, with audit/undo parity).
- Add `POST /api/staff/timesheets/time-entries/start-timer` route dispatching via `commandBus` (mirrors `leave-requests/accept`), with `openApi`.
- Add `staffTimeEntryStartTimerSchema` validator (additive).
- Add shared client helper `lib/timesheets-ui/startTimer.ts`; adopt it in `TimerBar.tsx` and the dashboard `widget.client.tsx` (the widget now surfaces start failures instead of swallowing them).
- Add `staff.audit.timesheets.time_entries.startTimer` to en/de/es/pl locales.
- Add command unit test covering atomic create+start and no-orphan-on-409.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — bug fix; the existing timesheets behavior/spec is unchanged.

## Testing

- `yarn workspace @open-mercato/core test` — 741 suites / 6057 tests pass (incl. new `timesheets-start-timer.test.ts`; existing #2416/#2855 timer suite still green)
- `yarn typecheck` — pass (21/21 packages)
- `yarn i18n:check-sync` — in sync (en/pl/es/de); `yarn i18n:check-hardcoded` — no new hardcoded strings
- `yarn build:app` — pass
- Fresh-context adversarial code review — PASS, 0 blockers

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (locales: en/de/es/pl)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Documented: covered by the command-level no-orphan unit test; the orphan failure mode cannot be reproduced in a happy-path integration flow now that start is a single atomic request. The `needs-qa` manual pass exercises the UI flow.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A, no spec change.
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium`)
- [x] QA routing set: `needs-qa` (customer-facing timesheets timer flow).

### Design System Compliance
- [x] No hardcoded status colors — none introduced (logic-only edits to the two client files)
- [x] No arbitrary text sizes — none introduced
- [x] Empty state handled for list/data pages — N/A (no list/data page added; existing states untouched)
- [x] Loading state handled for async pages — existing `isStarting`/`actionLoading` guards preserved around the new single call
- [x] `aria-label` on all icon-only buttons — N/A (no buttons added/changed)
- [x] Uses existing DS components — no custom replacements added

## Linked issues

Fixes #3311

🤖 Generated with [Claude Code](https://claude.com/claude-code)
