### PR TITLE
fix(translations): replace native fetch access probe (#3317)

### DIFF
--- a/packages/core/src/modules/translations/widgets/injection/translation-manager/__tests__/widget.client.test.tsx
+++ b/packages/core/src/modules/translations/widgets/injection/translation-manager/__tests__/widget.client.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+
+jest.mock('next/navigation', () => ({
+  useParams: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+}))
+
+jest.mock('../../../../components/TranslationManager', () => ({
+  TranslationManager: () => null,
+}))
+
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import TranslationWidget from '../widget.client'
+
+const mockedApiCall = apiCall as jest.MockedFunction<typeof apiCall>
+type ApiResult = Awaited<ReturnType<typeof apiCall>>
+
+function featureCheckResult(granted: string[]): ApiResult {
+  return {
+    ok: true,
+    status: 200,
+    result: { ok: granted.length > 0, granted, userId: 'user-1' },
+    cacheStatus: null,
+  } as unknown as ApiResult
+}
+
+const widgetContext = { entityId: 'customers:person', recordId: 'record-1' }
+const widgetData = { id: 'record-1' }
+
+function renderWidget() {
+  return renderWithProviders(
+    <TranslationWidget context={widgetContext} data={widgetData} />,
+  )
+}
+
+describe('TranslationWidget — access probe', () => {
+  beforeEach(() => {
+    mockedApiCall.mockReset()
+  })
+
+  it('probes access through apiCall/feature-check (no native fetch) and shows the trigger when granted', async () => {
+    mockedApiCall.mockResolvedValue(featureCheckResult(['translations.view']))
+    renderWidget()
+
+    expect(await screen.findByRole('button', { name: 'Translation manager' })).toBeInTheDocument()
+
+    expect(mockedApiCall).toHaveBeenCalledTimes(1)
+    const [url, init] = mockedApiCall.mock.calls[0]
+    expect(url).toBe('/api/auth/feature-check')
+    expect(init?.method).toBe('POST')
+    expect(JSON.parse(String(init?.body))).toEqual({ features: ['translations.view'] })
+  })
+
+  it('hides the widget when the user lacks translations.view', async () => {
+    mockedApiCall.mockResolvedValue(featureCheckResult([]))
+    renderWidget()
+
+    await waitFor(() => expect(mockedApiCall).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: 'Translation manager' })).not.toBeInTheDocument()
+  })
+
+  it('hides gracefully on a forbidden response without throwing or redirecting', async () => {
+    // apiCall throws ForbiddenError on a 403 now that the redirect-on-403 behavior is gone.
+    // The probe must swallow it (retry: false) and keep the widget hidden.
+    mockedApiCall.mockRejectedValue(new Error('Forbidden'))
+    renderWidget()
+
+    await waitFor(() => expect(mockedApiCall).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: 'Translation manager' })).not.toBeInTheDocument()
+  })
+
+  it('dedupes the access probe across multiple injected widget instances', async () => {
+    mockedApiCall.mockResolvedValue(featureCheckResult(['translations.view']))
+    renderWithProviders(
+      <>
+        <TranslationWidget context={widgetContext} data={widgetData} />
+        <TranslationWidget context={widgetContext} data={widgetData} />
+      </>,
+    )
+
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: 'Translation manager' })).toHaveLength(2),
+    )
+    expect(mockedApiCall).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/translations/widgets/injection/translation-manager/widget.client.tsx
+++ b/packages/core/src/modules/translations/widgets/injection/translation-manager/widget.client.tsx
@@ -3,9 +3,12 @@
 import * as React from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
+import { useQuery } from '@tanstack/react-query'
 import { ExternalLink, Languages } from 'lucide-react'
 import type { InjectionWidgetComponentProps } from '@open-mercato/shared/modules/widgets/injection'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { hasAllFeatures } from '@open-mercato/shared/lib/auth/featureMatch'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { Button } from '@open-mercato/ui/primitives/button'
 import {
   Drawer,
@@ -21,20 +24,34 @@ import { extractRecordId } from '../../../lib/extract-record-id'
 type WidgetContext = { entityId?: string; recordId?: string }
 type WidgetData = Record<string, unknown> & { id?: string | number }
 
+type FeatureCheckResponse = {
+  ok: boolean
+  granted: string[]
+  userId: string
+}
+
+const TRANSLATION_ACCESS_FEATURES = ['translations.view']
+
+// Probe access through the shared apiCall/React Query path so multiple injected
+// widget instances dedupe a single request via the query key. feature-check
+// always answers 200 with the granted feature list, so a user without
+// translations.view is hidden gracefully — no login redirect, no forbidden flash.
 function useTranslationAccess(): boolean {
-  const [hasAccess, setHasAccess] = React.useState(false)
-  React.useEffect(() => {
-    let mounted = true
-    // Use the original fetch to bypass the global apiFetch wrapper
-    // that redirects to login on 403. This lets us gracefully hide the widget
-    // when the user lacks translations.view instead of crashing the page.
-    const nativeFetch = ((window as any).__omOriginalFetch as typeof fetch) || fetch
-    nativeFetch('/api/translations/locales', { credentials: 'include' })
-      .then((res) => { if (mounted) setHasAccess(res.ok) })
-      .catch(() => { if (mounted) setHasAccess(false) })
-    return () => { mounted = false }
-  }, [])
-  return hasAccess
+  const { data } = useQuery<boolean>({
+    queryKey: ['translations', 'widget-access', ...TRANSLATION_ACCESS_FEATURES],
+    queryFn: async () => {
+      const res = await apiCall<FeatureCheckResponse>('/api/auth/feature-check', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ features: TRANSLATION_ACCESS_FEATURES }),
+      })
+      if (!res.ok) return false
+      return hasAllFeatures(TRANSLATION_ACCESS_FEATURES, res.result?.granted ?? [])
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  })
+  return data === true
 }
 
 export default function TranslationWidget({ context, data }: InjectionWidgetComponentProps<WidgetContext, WidgetData>) {


### PR DESCRIPTION
Fixes #3317

## Problem
The translation-manager injection widget (`packages/core/src/modules/translations/widgets/injection/translation-manager/widget.client.tsx`) probed access with a raw `window.__omOriginalFetch` (native `fetch`) call to `/api/translations/locales`. This was a workaround for the old redirect-on-403 behavior and bypassed the shared `apiCall` / React Query data path, so repeated injected widget instances could not dedupe or share the request.

## Root Cause
- The probe used native fetch to dodge the global `apiFetch` wrapper that used to redirect to login on 403.
- The coherent-access-denied-ux spec (`.ai/specs/2026-03-25-coherent-access-denied-ux.md:108`) removed redirect-on-403 and explicitly calls for removing direct `nativeFetch` 403 workarounds.
- `packages/ui/AGENTS.md` forbids raw `fetch` in UI data flows where `apiCall` is available.

## What Changed
- Replaced the `useEffect` + native-fetch probe with a React Query (`useQuery`) probe over `apiCall` against the existing org/tenant-aware `POST /api/auth/feature-check` endpoint, checking `translations.view` (the same feature the locales endpoint required). This mirrors the established `useAuditPermissions` pattern.
- `feature-check` answers `200` with the granted feature list, so a user lacking `translations.view` is hidden gracefully — no login redirect and no "forbidden" flash banner.
- A stable query key (`['translations', 'widget-access', 'translations.view']`) dedupes the probe across multiple injected widget instances.
- Removed the `window.__omOriginalFetch` / native-`fetch` workaround entirely.

## Tests
- New `widget.client.test.tsx` regression test (fails before the fix, passes after):
  - probes via `apiCall`/`feature-check` (not native fetch) and shows the trigger when granted
  - hides the widget when the user lacks `translations.view`
  - hides gracefully on a forbidden/throwing response without redirecting (`retry: false`)
  - dedupes the access probe across multiple injected widget instances (single `apiCall`)
- Full translations module unit tests pass (171 tests). Typecheck shows no errors attributable to the change.

## Backward Compatibility
- No contract surface changes. The widget's default export signature is unchanged; no exported types, API routes, event/widget IDs, DI names, or ACL features were modified. The change only swaps which existing endpoint the internal access probe calls.