### PR TITLE
fix(sync_excel): replace hardcoded run status badge colors with StatusBadge (#3313)

### DIFF
--- a/packages/core/src/modules/sync_excel/widgets/injection/upload-config/__tests__/RunStatusBadge.test.tsx
+++ b/packages/core/src/modules/sync_excel/widgets/injection/upload-config/__tests__/RunStatusBadge.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
+import { RunStatusBadge, RUN_STATUS_BADGE_VARIANTS } from '../widget.client'
+
+const translate: TranslateFn = (key, fallbackOrParams) =>
+  typeof fallbackOrParams === 'string' ? fallbackOrParams : key
+
+const HARDCODED_STATUS_COLOR = /(emerald|zinc-\d|blue-500|red-300|red-500)/
+
+const statusCases: Array<{
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'idle'
+  variant: string
+  label: string
+}> = [
+  { status: 'completed', variant: 'success', label: 'Completed' },
+  { status: 'failed', variant: 'error', label: 'Failed' },
+  { status: 'cancelled', variant: 'neutral', label: 'Cancelled' },
+  { status: 'pending', variant: 'info', label: 'Pending' },
+  { status: 'running', variant: 'info', label: 'Running' },
+  { status: 'idle', variant: 'neutral', label: 'Idle' },
+]
+
+describe('RunStatusBadge — semantic status tokens', () => {
+  it.each(statusCases)(
+    'renders $status with the $variant StatusBadge variant and no hardcoded status colors',
+    ({ status, variant, label }) => {
+      const { container, getByText } = render(<RunStatusBadge status={status} t={translate} />)
+
+      const badge = container.querySelector('[data-slot="badge"]') as HTMLElement | null
+      expect(badge).not.toBeNull()
+      expect(badge?.getAttribute('data-variant')).toBe(variant)
+      expect(badge?.className).not.toMatch(HARDCODED_STATUS_COLOR)
+      expect(getByText(label)).toBeTruthy()
+    },
+  )
+
+  it('maps every run status to a semantic variant', () => {
+    expect(RUN_STATUS_BADGE_VARIANTS).toEqual({
+      completed: 'success',
+      failed: 'error',
+      cancelled: 'neutral',
+      pending: 'info',
+      running: 'info',
+      idle: 'neutral',
+    })
+  })
+})

--- a/packages/core/src/modules/sync_excel/widgets/injection/upload-config/widget.client.tsx
+++ b/packages/core/src/modules/sync_excel/widgets/injection/upload-config/widget.client.tsx
@@ -12,6 +12,7 @@ import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { useCustomFieldDefs } from '@open-mercato/ui/backend/utils/customFieldDefs'
 import { Alert, AlertDescription, AlertTitle } from '@open-mercato/ui/primitives/alert'
 import { Badge } from '@open-mercato/ui/primitives/badge'
+import { StatusBadge, type StatusMap } from '@open-mercato/ui/primitives/status-badge'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@open-mercato/ui/primitives/card'
 import { Input } from '@open-mercato/ui/primitives/input'
@@ -1171,54 +1172,67 @@ function MetricCard({ label, value }: { label: string; value: string }) {
   )
 }
 
-function RunStatusBadge({
+type RunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'idle'
+
+export const RUN_STATUS_BADGE_VARIANTS: StatusMap<RunStatus> = {
+  completed: 'success',
+  failed: 'error',
+  cancelled: 'neutral',
+  pending: 'info',
+  running: 'info',
+  idle: 'neutral',
+}
+
+export function RunStatusBadge({
   status,
   t,
 }: {
-  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'idle'
+  status: RunStatus
   t: ReturnType<typeof useT>
 }) {
+  const variant = RUN_STATUS_BADGE_VARIANTS[status] ?? 'neutral'
+
   if (status === 'completed') {
     return (
-      <Badge variant="outline" className="gap-1.5 border-emerald-500/30 bg-emerald-500/10 text-emerald-300">
+      <StatusBadge variant={variant} className="gap-1.5">
         <CheckCircle2 className="size-3.5" />
         {t('sync_excel.widget.run.status.completed', 'Completed')}
-      </Badge>
+      </StatusBadge>
     )
   }
 
   if (status === 'failed') {
     return (
-      <Badge variant="outline" className="gap-1.5 border-red-500/30 bg-red-500/10 text-red-300">
+      <StatusBadge variant={variant} className="gap-1.5">
         <AlertTriangle className="size-3.5" />
         {t('sync_excel.widget.run.status.failed', 'Failed')}
-      </Badge>
+      </StatusBadge>
     )
   }
 
   if (status === 'cancelled') {
     return (
-      <Badge variant="outline" className="gap-1.5 border-zinc-500/30 bg-zinc-500/10 text-zinc-300">
+      <StatusBadge variant={variant} className="gap-1.5">
         <XCircle className="size-3.5" />
         {t('sync_excel.widget.run.status.cancelled', 'Cancelled')}
-      </Badge>
+      </StatusBadge>
     )
   }
 
   if (status === 'pending' || status === 'running') {
     return (
-      <Badge variant="outline" className="gap-1.5 border-blue-500/30 bg-blue-500/10 text-blue-300">
+      <StatusBadge variant={variant} className="gap-1.5">
         <RefreshCw className={cn('size-3.5', status === 'running' ? 'animate-spin' : '')} />
         {status === 'pending'
           ? t('sync_excel.widget.run.status.pending', 'Pending')
           : t('sync_excel.widget.run.status.running', 'Running')}
-      </Badge>
+      </StatusBadge>
     )
   }
 
   return (
-    <Badge variant="outline" className="gap-1.5 border-zinc-500/30 bg-zinc-500/10 text-zinc-300">
+    <StatusBadge variant={variant}>
       {t('sync_excel.widget.run.status.idle', 'Idle')}
-    </Badge>
+    </StatusBadge>
   )
 }


### PR DESCRIPTION
Fixes #3313

## Problem
The `sync_excel` injected upload/import widget rendered import-run statuses with `Badge variant="outline"` plus hardcoded Tailwind status colors (`border-emerald-500/30`, `bg-red-500/10`, `text-blue-300`, `border-zinc-500/30`, …). This bypasses the design-system status tokens and makes the status UI impossible to theme consistently — it violates `.ai/ds-rules.md` (use `StatusBadge`, never hardcode status colors on `Badge`) and `packages/ui/AGENTS.md` (static badges are not for system status display).

## Root Cause
`RunStatusBadge` in `packages/core/src/modules/sync_excel/widgets/injection/upload-config/widget.client.tsx` was built directly on top of `Badge` with per-status hardcoded color classes instead of the shared semantic `StatusBadge` primitive.

## What Changed
- Replaced the hardcoded-color `Badge` rendering in `RunStatusBadge` with `StatusBadge` from `@open-mercato/ui/primitives/status-badge`, driven by a local `RUN_STATUS_BADGE_VARIANTS` status→variant map:
  - `completed` → `success`
  - `failed` → `error`
  - `cancelled` → `neutral`
  - `pending` / `running` → `info`
  - `idle` → `neutral`
- Preserved the existing translated labels and status icons (incl. the spinning `RefreshCw` for `running`).
- No remaining hardcoded Tailwind status colors in `RunStatusBadge`. Other plain info badges in the file (filename, row count, file size, job id) are intentionally left as-is — they are not system-status displays and are outside this issue's scope.

## Tests
- Added `__tests__/RunStatusBadge.test.tsx`: renders every run status and asserts the rendered badge carries the correct semantic `data-variant`, contains no hardcoded status color classes, and keeps its translated label; also locks the status→variant map.
- Existing `widget.client.test.tsx` suite still passes.
- Ran: full `sync_excel` test suite (12 suites / 52 tests, all green), `@open-mercato/core` `tsc --noEmit` (0 errors after `yarn generate`), `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync` (in sync), `yarn i18n:check-usage` (advisory only).

## Backward Compatibility
- No contract-surface changes. Change is additive only: `RunStatusBadge` (and a `RUN_STATUS_BADGE_VARIANTS` map) are now exported from the widget client file for testing; the default export and widget registration are unchanged. No types removed, no API/event/DI/ACL/route surfaces touched.