### PR TITLE
fix: make shipping tracking GET read-only; add guarded POST /tracking/refresh (#3295)

### DIFF
--- a/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-016.spec.ts
+++ b/packages/core/src/modules/shipping_carriers/__integration__/TC-SHIP-016.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  createRoleFixture,
+  deleteRoleIfExists,
+  createUserFixture,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import { deleteUserAclInDb } from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import { createShipment, getTracking } from './helpers/fixtures'
+import {
+  setCarrierShipmentStatusInDb,
+  getCarrierShipmentRowFromDb,
+  deleteCarrierShipmentInDb,
+} from './helpers/db'
+
+/**
+ * TC-SHIP-016: Tracking reads do not mutate; refresh is a guarded write (issue #3295).
+ *
+ * `GET /api/shipping-carriers/tracking` previously persisted shipment status,
+ * tracking events, and `last_polled_at` inside a read request, violating GET
+ * semantics and skipping the write-path guard and status events. The fix makes
+ * the GET read-only and moves persistence behind `POST /tracking/refresh`
+ * (`shipping_carriers.manage`), which validates the transition and emits events.
+ *
+ * Non-`label_created` states are only reachable via async carrier events, so the
+ * fixture sets `carrier_shipments.unified_status` directly to keep the test
+ * deterministic.
+ *
+ * ENVIRONMENT: mixes API fixtures with DB-level fixtures (raw `pg` against
+ * `DATABASE_URL`). Run under a coherent app+DB stack (the `yarn test:integration`
+ * / `yarn test:integration:ephemeral` harness) where the app server and these
+ * fixtures share the same database.
+ */
+test.describe('TC-SHIP-016: tracking GET is read-only; refresh is a guarded write', () => {
+  test('GET tracking does not persist status or polling metadata', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    let shipmentId: string | null = null
+    try {
+      const shipment = await createShipment(request, token, { providerKey: 'mock_carrier' })
+      shipmentId = shipment.shipmentId
+
+      // Simulate a shipment that already advanced to in_transit via async events.
+      await setCarrierShipmentStatusInDb(shipmentId, 'in_transit')
+
+      const tracking = await getTracking(request, token, {
+        providerKey: 'mock_carrier',
+        shipmentId,
+      })
+      expect(tracking.status, 'GET still returns provider tracking data').toBeTruthy()
+
+      const row = await getCarrierShipmentRowFromDb(shipmentId)
+      expect(row?.unifiedStatus, 'GET must not overwrite the persisted status').toBe('in_transit')
+      expect(row?.lastPolledAt, 'GET must not stamp last_polled_at').toBeNull()
+    } finally {
+      await deleteCarrierShipmentInDb(shipmentId).catch(() => undefined)
+    }
+  })
+
+  test('POST /tracking/refresh persists polling metadata', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    let shipmentId: string | null = null
+    try {
+      const shipment = await createShipment(request, token, { providerKey: 'mock_carrier' })
+      shipmentId = shipment.shipmentId
+
+      const before = await getCarrierShipmentRowFromDb(shipmentId)
+      expect(before?.lastPolledAt, 'a freshly created shipment has never been polled').toBeNull()
+
+      const response = await apiRequest(request, 'POST', '/api/shipping-carriers/tracking/refresh', {
+        token,
+        data: { providerKey: 'mock_carrier', shipmentId },
+      })
+      expect(response.status(), 'refresh succeeds for a manage user').toBe(200)
+      const body = await readJsonSafe<{ status?: string; trackingNumber?: string }>(response)
+      expect(body?.status, 'refresh returns provider tracking data').toBeTruthy()
+
+      const after = await getCarrierShipmentRowFromDb(shipmentId)
+      expect(after?.lastPolledAt, 'refresh persists last_polled_at').not.toBeNull()
+    } finally {
+      await deleteCarrierShipmentInDb(shipmentId).catch(() => undefined)
+    }
+  })
+
+  test('POST /tracking/refresh requires shipping_carriers.manage', async ({ request }) => {
+    const stamp = Date.now()
+    const password = 'Secret123!'
+    const userEmail = `tc-ship-016-${stamp}@example.com`
+
+    let adminToken: string | null = null
+    let roleId: string | null = null
+    let userId: string | null = null
+    let shipmentId: string | null = null
+    try {
+      adminToken = await getAuthToken(request, 'admin')
+      const { organizationId, tenantId } = getTokenScope(adminToken)
+      expect(organizationId, 'admin token should carry an organization id').toBeTruthy()
+      expect(tenantId, 'admin token should carry a tenant id').toBeTruthy()
+
+      const shipment = await createShipment(request, adminToken, { providerKey: 'mock_carrier' })
+      shipmentId = shipment.shipmentId
+
+      roleId = await createRoleFixture(request, adminToken, { name: `TC-SHIP-016 View-Only Role ${stamp}` })
+      userId = await createUserFixture(request, adminToken, {
+        email: userEmail,
+        password,
+        organizationId,
+        roles: [roleId],
+      })
+      await setUserAclVisibility(request, adminToken, {
+        userId,
+        features: ['shipping_carriers.view'],
+        organizations: null,
+      })
+
+      const userToken = await getAuthToken(request, userEmail, password)
+
+      const refreshResponse = await apiRequest(request, 'POST', '/api/shipping-carriers/tracking/refresh', {
+        token: userToken,
+        data: { providerKey: 'mock_carrier', shipmentId },
+      })
+      expect(refreshResponse.status(), 'refresh must be forbidden without shipping_carriers.manage').toBe(403)
+      const refreshBody = await readJsonSafe<{ requiredFeatures?: string[] }>(refreshResponse)
+      expect(
+        refreshBody?.requiredFeatures,
+        'forbidden response should name the missing feature',
+      ).toContain('shipping_carriers.manage')
+
+      // The denial happens at the feature gate, before any persistence.
+      const row = await getCarrierShipmentRowFromDb(shipmentId)
+      expect(row?.lastPolledAt, 'a forbidden refresh must not persist polling metadata').toBeNull()
+    } finally {
+      await deleteUserAclInDb(userId ?? '').catch(() => undefined)
+      await deleteUserIfExists(request, adminToken, userId)
+      await deleteRoleIfExists(request, adminToken, roleId)
+      await deleteCarrierShipmentInDb(shipmentId).catch(() => undefined)
+    }
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/__integration__/helpers/db.ts
+++ b/packages/core/src/modules/shipping_carriers/__integration__/helpers/db.ts
@@ -60,6 +60,7 @@ export type CarrierShipmentRow = {
   unifiedStatus: string
   trackingNumber: string
   labelUrl: string | null
+  lastPolledAt: string | null
   organizationId: string
   tenantId: string
 }
@@ -81,10 +82,11 @@ export async function getCarrierShipmentRowFromDb(shipmentId: string): Promise<C
       unified_status: string
       tracking_number: string
       label_url: string | null
+      last_polled_at: string | null
       organization_id: string
       tenant_id: string
     }>(
-      `select unified_status, tracking_number, label_url, organization_id, tenant_id
+      `select unified_status, tracking_number, label_url, last_polled_at, organization_id, tenant_id
          from carrier_shipments
         where id = $1
         limit 1`,
@@ -96,6 +98,7 @@ export async function getCarrierShipmentRowFromDb(shipmentId: string): Promise<C
       unifiedStatus: row.unified_status,
       trackingNumber: row.tracking_number,
       labelUrl: row.label_url,
+      lastPolledAt: row.last_polled_at,
       organizationId: row.organization_id,
       tenantId: row.tenant_id,
     }

--- a/packages/core/src/modules/shipping_carriers/api/tracking/refresh/route.ts
+++ b/packages/core/src/modules/shipping_carriers/api/tracking/refresh/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import type { ShippingCarrierService } from '../../../lib/shipping-service'
+import { trackingRefreshSchema } from '../../../data/validators'
+import { shippingCarriersTag } from '../../openapi'
+
+export const metadata = {
+  path: '/shipping-carriers/tracking/refresh',
+  POST: { requireAuth: true, requireFeatures: ['shipping_carriers.manage'] },
+}
+
+export async function POST(req: Request) {
+  const auth = await getAuthFromRequest(req)
+  if (!auth?.tenantId || !auth.orgId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const payload = await readJsonSafe<unknown>(req)
+  const parsed = trackingRefreshSchema.safeParse(payload)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid payload', details: parsed.error.flatten() }, { status: 422 })
+  }
+  const container = await createRequestContainer()
+  const service = container.resolve('shippingCarrierService') as ShippingCarrierService
+  try {
+    const tracking = await service.refreshTracking({
+      ...parsed.data,
+      organizationId: auth.orgId as string,
+      tenantId: auth.tenantId,
+    })
+    return NextResponse.json(tracking)
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to refresh tracking'
+    return NextResponse.json({ error: message }, { status: 502 })
+  }
+}
+
+export const openApi = {
+  tags: [shippingCarriersTag],
+  summary: 'Refresh tracking',
+  methods: {
+    POST: {
+      summary: 'Refresh tracking and persist the latest shipment status',
+      tags: [shippingCarriersTag],
+      responses: [
+        { status: 200, description: 'Tracking refreshed and shipment status persisted' },
+        { status: 422, description: 'Validation failed' },
+        { status: 502, description: 'Provider upstream error' },
+      ],
+    },
+  },
+}

--- a/packages/core/src/modules/shipping_carriers/data/validators.ts
+++ b/packages/core/src/modules/shipping_carriers/data/validators.ts
@@ -55,6 +55,11 @@ export const trackingQuerySchema = z.object({
   path: ['shipmentId'],
 })
 
+export const trackingRefreshSchema = z.object({
+  providerKey: z.string().min(1),
+  shipmentId: z.string().uuid(),
+})
+
 export const cancelShipmentSchema = z.object({
   providerKey: z.string().min(1),
   shipmentId: z.string().uuid(),

--- a/packages/core/src/modules/shipping_carriers/lib/__tests__/shipping-service-tracking.test.ts
+++ b/packages/core/src/modules/shipping_carriers/lib/__tests__/shipping-service-tracking.test.ts
@@ -1,0 +1,198 @@
+import Chance from 'chance'
+import { createShippingCarrierService } from '../shipping-service'
+
+const chance = new Chance()
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+}))
+
+jest.mock('../adapter-registry', () => ({
+  getShippingAdapter: jest.fn(),
+}))
+
+jest.mock('../../events', () => ({
+  emitShippingEvent: jest.fn(),
+}))
+
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { getShippingAdapter } from '../adapter-registry'
+import { emitShippingEvent } from '../../events'
+
+const mockFindOne = findOneWithDecryption as jest.MockedFunction<typeof findOneWithDecryption>
+const mockGetAdapter = getShippingAdapter as jest.MockedFunction<typeof getShippingAdapter>
+const mockEmitEvent = emitShippingEvent as jest.MockedFunction<typeof emitShippingEvent>
+
+const makeScope = () => ({
+  organizationId: chance.guid(),
+  tenantId: chance.guid(),
+})
+
+const makeShipment = (overrides: Record<string, unknown> = {}) => ({
+  id: chance.guid(),
+  carrierShipmentId: chance.guid(),
+  trackingNumber: chance.string(),
+  unifiedStatus: 'label_created',
+  trackingEvents: null as unknown,
+  lastPolledAt: null as unknown,
+  organizationId: chance.guid(),
+  tenantId: chance.guid(),
+  ...overrides,
+})
+
+const makeTracking = (status = 'in_transit') => ({
+  trackingNumber: chance.string(),
+  status,
+  events: [{ status, occurredAt: new Date('2026-01-01').toISOString(), location: chance.city() }],
+})
+
+const makeAdapter = (tracking = makeTracking()) => ({
+  calculateRates: jest.fn(),
+  createShipment: jest.fn(),
+  getTracking: jest.fn().mockResolvedValue(tracking),
+  cancelShipment: jest.fn(),
+})
+
+const makeCredentialsService = () => ({
+  resolve: jest.fn().mockResolvedValue({}),
+})
+
+const makeEm = () => ({
+  flush: jest.fn().mockResolvedValue(undefined),
+})
+
+const makeInput = (overrides: Record<string, unknown> = {}) => ({
+  providerKey: chance.word(),
+  shipmentId: chance.guid(),
+  ...overrides,
+})
+
+describe('ShippingCarrierService.getTracking is read-only', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('does not flush, mutate the shipment, or emit events on a read', async () => {
+    const scope = makeScope()
+    const shipment = makeShipment({ unifiedStatus: 'label_created', ...scope })
+    mockFindOne.mockResolvedValueOnce(shipment as any)
+    mockGetAdapter.mockReturnValueOnce(makeAdapter(makeTracking('in_transit')) as any)
+
+    const em = makeEm()
+    const service = createShippingCarrierService({
+      em: em as any,
+      integrationCredentialsService: makeCredentialsService() as any,
+    })
+
+    const tracking = await service.getTracking({ ...makeInput(), ...scope })
+
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(mockEmitEvent).not.toHaveBeenCalled()
+    expect(shipment.unifiedStatus).toBe('label_created')
+    expect(shipment.trackingEvents).toBeNull()
+    expect(shipment.lastPolledAt).toBeNull()
+    expect(tracking.status).toBe('in_transit')
+  })
+
+  it('still returns provider tracking when no shipment row exists (tracking-number lookup)', async () => {
+    const scope = makeScope()
+    // No shipmentId, so the service never queries the shipment row.
+    mockGetAdapter.mockReturnValueOnce(makeAdapter(makeTracking('delivered')) as any)
+
+    const em = makeEm()
+    const service = createShippingCarrierService({
+      em: em as any,
+      integrationCredentialsService: makeCredentialsService() as any,
+    })
+
+    const tracking = await service.getTracking({
+      providerKey: chance.word(),
+      trackingNumber: chance.string(),
+      ...scope,
+    })
+
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(tracking.status).toBe('delivered')
+  })
+})
+
+describe('ShippingCarrierService.refreshTracking is the guarded write path', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('persists polling metadata, advances a valid status, and emits status_changed', async () => {
+    const scope = makeScope()
+    const shipment = makeShipment({ unifiedStatus: 'label_created', ...scope })
+    mockFindOne.mockResolvedValueOnce(shipment as any)
+    const tracking = makeTracking('in_transit')
+    mockGetAdapter.mockReturnValueOnce(makeAdapter(tracking) as any)
+
+    const em = makeEm()
+    const service = createShippingCarrierService({
+      em: em as any,
+      integrationCredentialsService: makeCredentialsService() as any,
+    })
+
+    const result = await service.refreshTracking({ ...makeInput(), ...scope })
+
+    expect(em.flush).toHaveBeenCalledTimes(1)
+    expect(shipment.unifiedStatus).toBe('in_transit')
+    expect(shipment.trackingEvents).toBe(tracking.events)
+    expect(shipment.lastPolledAt).toBeInstanceOf(Date)
+    expect(mockEmitEvent).toHaveBeenCalledTimes(1)
+    expect(mockEmitEvent).toHaveBeenCalledWith(
+      'shipping_carriers.shipment.status_changed',
+      expect.objectContaining({ shipmentId: shipment.id, previousStatus: 'label_created', newStatus: 'in_transit' }),
+    )
+    expect(result.status).toBe('in_transit')
+  })
+
+  it('emits the terminal event in addition to status_changed when the status is terminal', async () => {
+    const scope = makeScope()
+    const shipment = makeShipment({ unifiedStatus: 'out_for_delivery', ...scope })
+    mockFindOne.mockResolvedValueOnce(shipment as any)
+    mockGetAdapter.mockReturnValueOnce(makeAdapter(makeTracking('delivered')) as any)
+
+    const service = createShippingCarrierService({
+      em: makeEm() as any,
+      integrationCredentialsService: makeCredentialsService() as any,
+    })
+
+    await service.refreshTracking({ ...makeInput(), ...scope })
+
+    expect(mockEmitEvent).toHaveBeenCalledTimes(2)
+    expect(mockEmitEvent).toHaveBeenCalledWith('shipping_carriers.shipment.status_changed', expect.anything())
+    expect(mockEmitEvent).toHaveBeenCalledWith('shipping_carriers.shipment.delivered', expect.anything())
+  })
+
+  it('does not emit or regress the status on an invalid transition, but still records the poll', async () => {
+    const scope = makeScope()
+    const shipment = makeShipment({ unifiedStatus: 'delivered', ...scope })
+    mockFindOne.mockResolvedValueOnce(shipment as any)
+    const tracking = makeTracking('in_transit')
+    mockGetAdapter.mockReturnValueOnce(makeAdapter(tracking) as any)
+
+    const em = makeEm()
+    const service = createShippingCarrierService({
+      em: em as any,
+      integrationCredentialsService: makeCredentialsService() as any,
+    })
+
+    await service.refreshTracking({ ...makeInput(), ...scope })
+
+    expect(shipment.unifiedStatus).toBe('delivered')
+    expect(shipment.lastPolledAt).toBeInstanceOf(Date)
+    expect(shipment.trackingEvents).toBe(tracking.events)
+    expect(em.flush).toHaveBeenCalledTimes(1)
+    expect(mockEmitEvent).not.toHaveBeenCalled()
+  })
+
+  it('throws when the shipment cannot be found', async () => {
+    const scope = makeScope()
+    mockFindOne.mockResolvedValueOnce(null as any)
+
+    const service = createShippingCarrierService({
+      em: makeEm() as any,
+      integrationCredentialsService: makeCredentialsService() as any,
+    })
+
+    await expect(service.refreshTracking({ ...makeInput(), ...scope })).rejects.toThrow('Shipment not found')
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/lib/shipping-service.ts
+++ b/packages/core/src/modules/shipping_carriers/lib/shipping-service.ts
@@ -5,7 +5,13 @@ import { CarrierShipment } from '../data/entities'
 import { emitShippingEvent } from '../events'
 import { getShippingAdapter } from './adapter-registry'
 import type { UnifiedShipmentStatus } from './adapter'
-import { isValidShippingTransition, ShipmentCancelNotAllowedError } from './status-sync'
+import {
+  getTerminalShippingEvent,
+  isValidShippingTransition,
+  ShipmentCancelNotAllowedError,
+  syncShipmentStatus,
+  TERMINAL_SHIPPING_STATUSES,
+} from './status-sync'
 
 export function createShippingCarrierService(deps: {
   em: EntityManager
@@ -160,16 +166,46 @@ export function createShippingCarrierService(deps: {
           },
         )
         : null
-      const tracking = await adapter.getTracking({
+      return adapter.getTracking({
         shipmentId: shipment?.carrierShipmentId ?? input.shipmentId,
         trackingNumber: input.trackingNumber ?? shipment?.trackingNumber,
         credentials,
       })
-      if (shipment) {
-        shipment.unifiedStatus = tracking.status
-        shipment.trackingEvents = tracking.events
-        shipment.lastPolledAt = new Date()
-        await em.flush()
+    },
+
+    async refreshTracking(input: {
+      providerKey: string
+      shipmentId: string
+      organizationId: string
+      tenantId: string
+    }) {
+      const scope = { organizationId: input.organizationId, tenantId: input.tenantId }
+      const shipment = await findShipmentOrThrow(input.shipmentId, scope)
+      const { adapter, credentials } = await resolveAdapter(input.providerKey, scope)
+      const tracking = await adapter.getTracking({
+        shipmentId: shipment.carrierShipmentId,
+        trackingNumber: shipment.trackingNumber,
+        credentials,
+      })
+      const previousStatus = shipment.unifiedStatus
+      shipment.trackingEvents = tracking.events
+      shipment.lastPolledAt = new Date()
+      const transitionApplied = syncShipmentStatus(shipment, tracking.status)
+      await em.flush()
+      if (transitionApplied) {
+        const eventPayload = {
+          shipmentId: shipment.id,
+          providerKey: input.providerKey,
+          previousStatus,
+          newStatus: tracking.status,
+          organizationId: input.organizationId,
+          tenantId: input.tenantId,
+        }
+        await emitShippingEvent('shipping_carriers.shipment.status_changed', eventPayload)
+        if (TERMINAL_SHIPPING_STATUSES.has(tracking.status)) {
+          const terminalEvent = getTerminalShippingEvent(tracking.status)
+          if (terminalEvent) await emitShippingEvent(terminalEvent, eventPayload)
+        }
       }
       return tracking
     },

--- a/packages/core/src/modules/shipping_carriers/workers/status-poller.ts
+++ b/packages/core/src/modules/shipping_carriers/workers/status-poller.ts
@@ -23,7 +23,7 @@ export const metadata: WorkerMeta = {
 export default async function handle(job: QueuedJob<PollerJobPayload>, ctx: HandlerContext): Promise<void> {
   const service = ctx.resolve<ShippingCarrierService>('shippingCarrierService')
   for (const shipmentId of job.payload.shipmentIds) {
-    await service.getTracking({
+    await service.refreshTracking({
       providerKey: job.payload.providerKey,
       shipmentId,
       organizationId: job.payload.scope.organizationId,


### PR DESCRIPTION
## Summary

`GET /api/shipping-carriers/tracking` performed persistent writes: it updated `shipment.unifiedStatus`, `trackingEvents`, and `lastPolledAt` and flushed inside the read handler, violating GET semantics, bypassing the module's write-path guard, and skipping shipment status events. This makes the GET read-only and moves status refresh/persistence behind an explicit guarded write path (`POST /tracking/refresh`, `shipping_carriers.manage`) that validates the transition and emits consistent events — mirroring the existing `webhook-processor` pattern. Fixes #3295.

## Changes

- `lib/shipping-service.ts`: `getTracking` is now strictly read-only (resolves adapter + optional shipment lookup, returns provider tracking — no mutation, no `em.flush()`, no events). Added a guarded `refreshTracking(...)` that loads the tenant-scoped shipment, fetches tracking, persists `trackingEvents`/`lastPolledAt`, applies the status via the shared `syncShipmentStatus` (transition-validated), flushes, and emits `shipping_carriers.shipment.status_changed` plus terminal events only on a real transition.
- `api/tracking/refresh/route.ts` (new): `POST /shipping-carriers/tracking/refresh` guarded by `shipping_carriers.manage`, mirroring `api/cancel/route.ts`; exports `openApi`.
- `data/validators.ts`: added `trackingRefreshSchema` (`providerKey` + `shipmentId`).
- `workers/status-poller.ts`: repointed from `getTracking` to `refreshTracking`, so the background poller keeps persisting status and now also emits the previously-missing status events.
- Tests: `lib/__tests__/shipping-service-tracking.test.ts` (GET read-only; `refreshTracking` persist/validate/emit/terminal/invalid-transition/not-found) and `__integration__/TC-SHIP-016.spec.ts` (GET does not persist; refresh persists `last_polled_at`; refresh requires `shipping_carriers.manage`). `__integration__/helpers/db.ts` now exposes `lastPolledAt`.

No new ACL features, event IDs, DB columns, migrations, or DI keys — the `last_polled_at` column already existed; backward compatibility preserved (GET wire-shape unchanged; new route is additive).

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — targeted bug fix following existing `shipping_carriers` write conventions; no shipping/tracking spec exists in `.ai/specs/`.

## Testing

- `yarn build:packages` → `yarn generate` → `yarn build:packages` — ✓ (new route registered in generated registries)
- `yarn i18n:check-sync` — ✓ (4 locales in sync)
- `yarn typecheck` — ✓ 21/21 packages
- `yarn test` — ✓ all tasks; core 741 suites / 6061 tests pass, including the new `shipping-service-tracking.test.ts` (red→green) and the untouched `shipping-service-cancel.test.ts`
- `yarn build:app` — ✓ compiled successfully
- Integration `TC-SHIP-016` authored + typechecked; executes in CI's ephemeral-integration job

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (`yarn generate` re-ran for the new route; OpenAPI auto-generated from the route's `openApi` export; no locale changes needed.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Added `__integration__/TC-SHIP-016.spec.ts` — module-local per the current `__integration__/TC-*.spec.ts` convention.)
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — minor bug fix, no spec.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-high`, inherited — write-path + new API surface.)
- [x] QA routing set: `needs-qa` (risk-high write-path change with a new API endpoint; comprehensive unit + integration coverage attached for the QA reviewer to confirm).

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI in this change.
- [x] No arbitrary text sizes — N/A, no UI in this change.
- [x] Empty state handled for list/data pages — N/A, no UI in this change.
- [x] Loading state handled for async pages — N/A, no UI in this change.
- [x] `aria-label` on all icon-only buttons — N/A, no UI in this change.
- [x] Uses existing DS components — N/A, no UI in this change.

## Linked issues

Fixes #3295
