### PR TITLE
fix(currencies): harden options cache — log set failures + defensive get fallback (#3301)

### DIFF
--- a/packages/core/src/modules/currencies/api/currencies/options/__tests__/cache.test.ts
+++ b/packages/core/src/modules/currencies/api/currencies/options/__tests__/cache.test.ts
@@ -144,4 +144,42 @@ describe('GET /api/currencies/options caching', () => {
     const [key] = cache.set.mock.calls[0]
     expect(key).toBe('currencies:options:org=22222222-2222-4222-8222-222222222222:active=all:limit=10')
   })
+
+  it('falls back to the database when the cache read throws', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockRejectedValue(new Error('cache backend down'))
+    em.find.mockResolvedValue([makeRow('USD', 'US Dollar')])
+
+    const res = await GET(new Request('http://localhost/api/currencies/options'))
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: { value: string; label: string }[] }
+    expect(body.items).toEqual([{ value: 'USD', label: 'USD - US Dollar' }])
+    expect(em.find).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs the failure without throwing when the cache write fails', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    process.env.QUERY_ENGINE_DEBUG_SQL = 'true'
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+    cache.set.mockRejectedValue(new Error('cache write failed'))
+    em.find.mockResolvedValue([makeRow('USD', 'US Dollar')])
+
+    const res = await GET(new Request('http://localhost/api/currencies/options'))
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: { value: string; label: string }[] }
+    expect(body.items).toEqual([{ value: 'USD', label: 'USD - US Dollar' }])
+    expect(cache.set).toHaveBeenCalledTimes(1)
+    expect(debugSpy).toHaveBeenCalledWith(
+      '[crud][cache]',
+      'store',
+      expect.objectContaining({ error: 'cache write failed' }),
+    )
+    debugSpy.mockRestore()
+  })
 })

--- a/packages/core/src/modules/currencies/api/currencies/options/route.ts
+++ b/packages/core/src/modules/currencies/api/currencies/options/route.ts
@@ -7,6 +7,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import {
   buildCollectionTags,
+  debugCrudCache,
   isCrudCacheEnabled,
   resolveCrudCache,
 } from '@open-mercato/shared/lib/crud/cache'
@@ -78,9 +79,18 @@ export async function GET(req: Request) {
     : null
 
   if (cache && cacheKey) {
-    const cached = await runWithCacheTenant(tenantId, () => cache.get(cacheKey))
-    if (cached) {
-      return NextResponse.json(cached)
+    try {
+      const cached = await runWithCacheTenant(tenantId, () => cache.get(cacheKey))
+      if (cached) {
+        return NextResponse.json(cached)
+      }
+    } catch (err) {
+      // A cache-backend read error must degrade to a fresh DB read, never a 500.
+      debugCrudCache('get', {
+        resource: CURRENCY_OPTIONS_RESOURCE,
+        key: cacheKey,
+        error: err instanceof Error ? err.message : String(err),
+      })
     }
   }
 
@@ -124,7 +134,15 @@ export async function GET(req: Request) {
           tags: buildCollectionTags(CURRENCY_OPTIONS_RESOURCE, tenantId, [orgId]),
         }),
       )
-    } catch {}
+    } catch (err) {
+      // A cache write must never break the request; log it for observability
+      // instead of swallowing the failure silently (matches the CRUD factory).
+      debugCrudCache('store', {
+        resource: CURRENCY_OPTIONS_RESOURCE,
+        key: cacheKey,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
   }
 
   return NextResponse.json(payload)


### PR DESCRIPTION
Fixes #3301

## Problem
The flag-gated get-then-set cache added to `packages/core/src/modules/currencies/api/currencies/options/route.ts` (PR #3142) had two resilience/observability gaps flagged in review:
- `catch {}` around `cache.set` silently swallowed write failures (no observability).
- `cache.get` was not wrapped in try/catch, so a cache-backend read error would surface as a 500 instead of degrading to a DB read.

## Root Cause
The hot-path caching was written for the happy path only — cache write/read errors were either swallowed without a trace or allowed to propagate as request failures, instead of being treated as non-fatal degradations of an optional optimization.

## What Changed
- Route the `cache.set` failure through `debugCrudCache('store', { resource, key, error })` (the same shape the CRUD factory uses) so write failures are observable under `QUERY_ENGINE_DEBUG_SQL` instead of silent.
- Wrap `cache.get` in try/catch; on a backend read error, log via `debugCrudCache('get', …)` and fall through to the fresh DB query so the request still succeeds.
- No other behavior change: the cache stays a no-op when `ENABLE_CRUD_API_CACHE` is off or no cache service resolves, search variants still read straight through, and the `{ items }` response shape / `limit` are preserved.

## Tests
- Extended `packages/core/src/modules/currencies/api/currencies/options/__tests__/cache.test.ts` with two regression tests:
  - `cache.get` throwing → falls back to the DB and returns 200 (verified to fail before the fix).
  - `cache.set` failing → logged via `debugCrudCache`, request still returns 200 (verified to fail before the fix).
- `yarn workspace @open-mercato/core test -- currencies` → 16 suites / 104 tests pass.
- `yarn build:packages`, `yarn generate`, and full `yarn typecheck` (21/21) pass.

## Backward Compatibility
No contract-surface changes. Imports only an already-exported helper (`debugCrudCache`); no API response fields, event IDs, DI names, ACL features, or import paths changed. Tenant scoping (`runWithCacheTenant(tenantId, …)`) is preserved on both cache reads and writes.

Related: #3142, #2918