### PR TITLE
fix(notifications): guard cache.get read failure in unread-count route (#3300)

### DIFF
--- a/packages/core/src/modules/notifications/api/unread-count/__tests__/cache.test.ts
+++ b/packages/core/src/modules/notifications/api/unread-count/__tests__/cache.test.ts
@@ -92,6 +92,20 @@ describe('GET /api/notifications/unread-count caching', () => {
     expect(cache.set).not.toHaveBeenCalled()
   })
 
+  it('falls back to the database count when the cache read throws', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockRejectedValue(new Error('cache backend unavailable'))
+    count.mockResolvedValue(9)
+
+    const res = await GET(new Request('http://localhost/api/notifications/unread-count'))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ unreadCount: 9 })
+    expect(cache.get).toHaveBeenCalledTimes(1)
+    expect(count).toHaveBeenCalledTimes(1)
+  })
+
   it('uses a user-only key that ignores the organization axis', async () => {
     process.env.ENABLE_CRUD_API_CACHE = 'true'
     const { GET } = await loadRoute()

--- a/packages/core/src/modules/notifications/api/unread-count/route.ts
+++ b/packages/core/src/modules/notifications/api/unread-count/route.ts
@@ -29,10 +29,12 @@ export async function GET(req: Request) {
   const cacheKey = cache && userId ? buildUnreadCountCacheKey(userId) : null
 
   if (cache && cacheKey) {
-    const cached = await runWithCacheTenant(scope.tenantId, () => cache.get(cacheKey))
-    if (typeof cached === 'number') {
-      return Response.json({ unreadCount: cached })
-    }
+    try {
+      const cached = await runWithCacheTenant(scope.tenantId, () => cache.get(cacheKey))
+      if (typeof cached === 'number') {
+        return Response.json({ unreadCount: cached })
+      }
+    } catch {}
   }
 
   const count = await em.count(Notification, {


### PR DESCRIPTION
Fixes #3300

## Problem
The notifications unread-count endpoint (`GET /api/notifications/unread-count`) wrapped its `cache.set` write in `try/catch` but awaited `cache.get(...)` **unguarded**. A cache-backend read error (e.g. a Redis hiccup) would surface as a `500` instead of degrading to the database COUNT — an asymmetric-resilience follow-up flagged in code review on #3157.

## Root Cause
`packages/core/src/modules/notifications/api/unread-count/route.ts` had the read path:
```ts
const cached = await runWithCacheTenant(scope.tenantId, () => cache.get(cacheKey))
```
with no error handling, while the write path below it already swallowed failures in a `try/catch`.

## What Changed
- **L1**: Wrapped the `cache.get(...)` read in `try/catch`, mirroring the existing `cache.set` write path. A cache-read failure now falls through to `em.count(...)` and returns the live DB count instead of a 500.
- Added a regression test (`falls back to the database count when the cache read throws`) to the existing `cache.test.ts`, proving the read-failure → DB-fallback path. Confirmed it **fails** on `develop` and **passes** with the fix.

## Acceptance criteria
- [x] **L1** — `cache.get` read guarded so a backend read error degrades to the DB COUNT.
- [x] Unit test covering the cache-read-failure → DB-fallback path (extends `cache.test.ts`; 6/6 pass).
- [x] **L2** — accepted as-is: the intentionally-added `buildCollectionTags(..., [null])` invalidation hook is a benign, inert future-v2 hook (nothing flushes that tag today). No code change; documented here as the desired v1 deviation.
- [x] **Sibling messages route (#3155)** — checked: `packages/core/src/modules/messages/api/unread-count/route.ts` uses **no cache at all** (direct Kysely COUNT), so it does not share the asymmetry — nothing to guard there.

## Tests
- Extended `packages/core/src/modules/notifications/api/unread-count/__tests__/cache.test.ts` — 6/6 pass; full notifications module suite 23/23 pass.
- `tsc --noEmit` (core) clean.
- `yarn build:packages` + `yarn generate` clean.

## Backward Compatibility
- No contract-surface changes. Response shape `{ unreadCount }`, route path, and behavior on the happy path are unchanged; only the failure mode is improved (degrade instead of 500).