### PR TITLE
fix(ui): replace raw NotificationPanel buttons with primitives (#3267)

### DIFF
--- a/packages/ui/src/backend/notifications/NotificationPanel.tsx
+++ b/packages/ui/src/backend/notifications/NotificationPanel.tsx
@@ -5,6 +5,7 @@ import { ArrowDown, ArrowUp, Bell, Loader2, RotateCcw, Settings2, X } from 'luci
 import { Button } from '../../primitives/button'
 import { IconButton } from '../../primitives/icon-button'
 import { Sheet, SheetContent, SheetTitle } from '../../primitives/sheet'
+import { Tabs, TabsList, TabsTrigger } from '../../primitives/tabs'
 import { NotificationItem } from './NotificationItem'
 import type { NotificationDto, NotificationRendererProps } from '@open-mercato/shared/modules/notifications/types'
 import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
@@ -97,6 +98,12 @@ export function NotificationPanel({
     }
   }
 
+  const handleFilterChange = React.useCallback((next: string) => {
+    if (next === 'all' || next === 'unread' || next === 'action') {
+      setFilter(next)
+    }
+  }, [])
+
   // Preserve the body scroll lock contract that consumers (and integration
   // tests) rely on. Radix Dialog locks scroll via react-remove-scroll which
   // does not set `document.body.style.overflow` — we set it ourselves so the
@@ -124,15 +131,17 @@ export function NotificationPanel({
           </SheetTitle>
           <div className="flex items-center gap-1">
             {unreadCount > 0 ? (
-              <button
+              <Button
                 type="button"
+                variant="link"
+                size="sm"
                 onClick={handleMarkAllRead}
                 disabled={markingAllRead}
-                className="inline-flex items-center gap-1 rounded-md px-1 text-sm font-medium leading-5 text-accent-indigo transition-colors hover:text-accent-indigo/80 disabled:opacity-50"
+                className="gap-1 px-1 text-accent-indigo hover:text-accent-indigo/80 hover:no-underline"
               >
                 {markingAllRead ? <Loader2 className="size-3.5 animate-spin" /> : null}
                 {t('notifications.markAllRead', 'Mark all read')}
-              </button>
+              </Button>
             ) : null}
             <IconButton
               type="button"
@@ -146,41 +155,29 @@ export function NotificationPanel({
           </div>
         </div>
 
-        <div role="tablist" className="flex items-center gap-5 border-b px-5 py-3.5">
-          {(['all', 'unread', 'action'] as const).map((value) => {
-            const isActive = filter === value
-            const label =
-              value === 'all'
-                ? t('notifications.filters.all', 'All')
-                : value === 'unread'
-                  ? t('notifications.filters.unread', 'Unread')
-                  : t('notifications.filters.actionRequired', 'Action Required')
-            return (
-              <button
-                key={value}
-                type="button"
-                role="tab"
-                aria-selected={isActive}
-                onClick={() => setFilter(value)}
-                className="relative inline-flex items-center gap-1.5 pb-2 text-sm font-medium leading-5 tracking-tight transition-colors focus:outline-none focus-visible:text-foreground data-[active=true]:text-foreground data-[active=false]:text-muted-foreground hover:text-foreground"
-                data-active={isActive}
-              >
-                <span>{label}</span>
-                {value === 'unread' && unreadCount > 0 ? (
-                  <span className="inline-flex min-w-4 items-center justify-center rounded-full bg-accent-indigo px-1 text-overline font-medium text-accent-indigo-foreground">
-                    {unreadCount > 99 ? '99+' : unreadCount}
-                  </span>
-                ) : null}
-                {isActive ? (
-                  <span
-                    className="absolute bottom-[-14px] left-0 right-0 h-0.5 bg-foreground"
-                    aria-hidden="true"
-                  />
-                ) : null}
-              </button>
-            )
-          })}
-        </div>
+        <Tabs value={filter} onValueChange={handleFilterChange} variant="underline">
+          <TabsList className="flex w-full px-5">
+            {(['all', 'unread', 'action'] as const).map((value) => {
+              const label =
+                value === 'all'
+                  ? t('notifications.filters.all', 'All')
+                  : value === 'unread'
+                    ? t('notifications.filters.unread', 'Unread')
+                    : t('notifications.filters.actionRequired', 'Action Required')
+              const count =
+                value === 'unread' && unreadCount > 0
+                  ? unreadCount > 99
+                    ? '99+'
+                    : unreadCount
+                  : undefined
+              return (
+                <TabsTrigger key={value} value={value} count={count}>
+                  {label}
+                </TabsTrigger>
+              )
+            })}
+          </TabsList>
+        </Tabs>
 
         {dismissUndo && onUndoDismiss && (
           <div className="border-b bg-muted/50 px-4 py-2 text-sm">

--- a/packages/ui/src/backend/notifications/__tests__/NotificationPanel.test.tsx
+++ b/packages/ui/src/backend/notifications/__tests__/NotificationPanel.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { render, screen, fireEvent, within, act } from '@testing-library/react'
+import { NotificationPanel } from '../NotificationPanel'
+import type { NotificationDto } from '@open-mercato/shared/modules/notifications/types'
+import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
+
+// NotificationItem (rendered per row) calls next/navigation's useRouter, which
+// throws outside an App Router provider. Stub it so the panel can render rows.
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    refresh: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+  }),
+}))
+
+const t = ((key: string, fallback?: unknown) =>
+  typeof fallback === 'string' ? fallback : key) as TranslateFn
+
+function buildNotification(overrides: Partial<NotificationDto>): NotificationDto {
+  return {
+    id: 'n',
+    type: 'system.generic',
+    title: 'Title',
+    severity: 'info',
+    status: 'unread',
+    actions: [],
+    createdAt: '2026-06-18T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function buildProps(overrides: Partial<React.ComponentProps<typeof NotificationPanel>> = {}) {
+  return {
+    open: true,
+    onOpenChange: jest.fn(),
+    notifications: [] as NotificationDto[],
+    unreadCount: 0,
+    onMarkAsRead: jest.fn().mockResolvedValue(undefined),
+    onExecuteAction: jest.fn().mockResolvedValue({}),
+    onDismiss: jest.fn().mockResolvedValue(undefined),
+    onMarkAllRead: jest.fn().mockResolvedValue(undefined),
+    t,
+    ...overrides,
+  } satisfies React.ComponentProps<typeof NotificationPanel>
+}
+
+describe('NotificationPanel controls use shared primitives', () => {
+  it('renders the filter tabs through the Tabs primitive, not raw buttons', () => {
+    render(<NotificationPanel {...buildProps()} />)
+
+    const tablist = screen.getByRole('tablist')
+    const tabs = within(tablist).getAllByRole('tab')
+
+    expect(tabs).toHaveLength(3)
+    // The Tabs primitive stamps data-slot on every trigger; a raw <button>
+    // would not, so this guards against regressing back to hand-rolled markup.
+    tabs.forEach((tab) => expect(tab).toHaveAttribute('data-slot', 'tabs-trigger'))
+  })
+
+  it('marks the active filter with aria-selected and switches on click', () => {
+    render(<NotificationPanel {...buildProps()} />)
+
+    const allTab = screen.getByRole('tab', { name: /All/i })
+    const unreadTab = screen.getByRole('tab', { name: /Unread/i })
+
+    expect(allTab).toHaveAttribute('aria-selected', 'true')
+    expect(unreadTab).toHaveAttribute('aria-selected', 'false')
+
+    fireEvent.click(unreadTab)
+
+    expect(unreadTab).toHaveAttribute('aria-selected', 'true')
+    expect(allTab).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('shows the unread count badge on the Unread tab and caps it at 99+', () => {
+    const { rerender } = render(<NotificationPanel {...buildProps({ unreadCount: 5 })} />)
+    expect(within(screen.getByRole('tab', { name: /Unread/i })).getByText('5')).toBeInTheDocument()
+
+    rerender(<NotificationPanel {...buildProps({ unreadCount: 150 })} />)
+    expect(within(screen.getByRole('tab', { name: /Unread/i })).getByText('99+')).toBeInTheDocument()
+  })
+
+  it('renders Mark all read as a Button primitive and invokes the handler', async () => {
+    const onMarkAllRead = jest.fn().mockResolvedValue(undefined)
+    render(<NotificationPanel {...buildProps({ unreadCount: 3, onMarkAllRead })} />)
+
+    const markAllButton = screen.getByRole('button', { name: /Mark all read/i })
+    expect(markAllButton).toHaveAttribute('data-slot', 'button')
+
+    await act(async () => {
+      fireEvent.click(markAllButton)
+    })
+    expect(onMarkAllRead).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides Mark all read when there are no unread notifications', () => {
+    render(<NotificationPanel {...buildProps({ unreadCount: 0 })} />)
+    expect(screen.queryByRole('button', { name: /Mark all read/i })).toBeNull()
+  })
+
+  it('keeps filtering behavior when switching tabs', () => {
+    const notifications = [
+      buildNotification({ id: 'a', title: 'Unread one', status: 'unread' }),
+      buildNotification({ id: 'b', title: 'Read one', status: 'read' }),
+    ]
+    render(<NotificationPanel {...buildProps({ notifications, unreadCount: 1 })} />)
+
+    expect(screen.getByText('Unread one')).toBeInTheDocument()
+    expect(screen.getByText('Read one')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: /Unread/i }))
+
+    expect(screen.getByText('Unread one')).toBeInTheDocument()
+    expect(screen.queryByText('Read one')).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #3267

## Problem
The notification panel rendered two controls as raw `<button>` elements, contrary to the UI package guidance that backend interactions must use the shared primitives so styling, states, accessibility, and design-system behavior stay consistent:
- the **mark-all-read** control (`NotificationPanel.tsx:127`)
- the **filter tabs** (`NotificationPanel.tsx:159`)

These were left behind by the earlier raw-button cleanup (#611).

## Root Cause
The controls predate / were missed by the primitive migration and were styled with bespoke Tailwind classes (including an arbitrary `bottom-[-14px]` value) instead of composing the shared `Button` / `Tabs` primitives.

## What Changed
- **Mark all read** → `Button` primitive (`variant="link"`, `size="sm"`). Keeps the panel's indigo accent and the flat (no-underline) hover, the leading spinner, and the disabled-while-pending behavior.
- **Filter tabs** → `Tabs` / `TabsList` / `TabsTrigger` underline primitive. The `role="tablist"` / `role="tab"` / `aria-selected` semantics, active-tab indicator, and the unread count badge (with the `99+` cap) are now provided by the shared primitive. Tab selection is narrowed to the `'all' | 'unread' | 'action'` union via a typed handler (no `any`/cast).
- Scoped strictly to these two controls — the header close button and the Undo action already used `IconButton`/`Button`.

### Visual note
Because the fix adopts the canonical DS primitives (as the issue requested — "appropriate tab/segmented primitives"), the active-tab underline now uses the `accent-indigo` accent already present in the panel (unread badge, mark-all-read), and the unread badge uses the DS soft-indigo count style rather than a bespoke solid pill. Behavior, accessibility, and disabled states are unchanged.

## Tests
- New `packages/ui/src/backend/notifications/__tests__/NotificationPanel.test.tsx` (6 cases):
  - filter tabs render through the `Tabs` primitive (`role="tablist"`/`tab`, `data-slot="tabs-trigger"` — guards against regressing to raw markup)
  - active filter tracks `aria-selected` and switches on click
  - unread badge shows the count and caps at `99+`
  - mark-all-read renders as the `Button` primitive (`data-slot="button"`) and invokes the handler
  - mark-all-read is hidden when there are no unread notifications
  - filtering behavior is preserved when switching tabs
- `yarn jest` (UI package): **1559 passing** (incl. `tabs.test.tsx`). The only failing test, `src/utils/__tests__/format.test.ts`, is a pre-existing locale-sensitivity issue (`Intl` currency formatting on a non-en locale) unrelated to this change.
- `tsc --noEmit` for `@open-mercato/ui`: clean.

## Backward Compatibility
- No contract-surface change. `NotificationPanel`'s export and `NotificationPanelProps` signature are untouched; only the internal rendering of the two controls changed.