### PR TITLE
fix(integrations): replace hardcoded external-id status colors with status tokens (#3257)

### DIFF
--- a/packages/core/src/modules/integrations/widgets/injection/external-ids/__tests__/widget.client.test.tsx
+++ b/packages/core/src/modules/integrations/widgets/injection/external-ids/__tests__/widget.client.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react'
+import ExternalIdsWidget from '../widget.client'
+import type { ExternalIdMapping } from '@open-mercato/shared/modules/integrations/types'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallback?: string) => fallback ?? key,
+}))
+
+const STATUS_DOT_TOKENS: Record<ExternalIdMapping['syncStatus'], string> = {
+  synced: 'bg-status-success-icon',
+  pending: 'bg-status-warning-icon',
+  error: 'bg-status-error-icon',
+  not_synced: 'bg-status-neutral-icon',
+}
+
+const LEGACY_STATUS_COLORS = ['bg-green-500', 'bg-yellow-500', 'bg-red-500', 'bg-gray-400']
+
+const ALL_STATUSES = Object.keys(STATUS_DOT_TOKENS) as ExternalIdMapping['syncStatus'][]
+
+function renderWidget(syncStatus: ExternalIdMapping['syncStatus']) {
+  const mappings: Record<string, ExternalIdMapping> = {
+    shopify: { externalId: 'ext-123', syncStatus },
+  }
+  const data: Record<string, unknown> = { _integrations: mappings }
+  return render(<ExternalIdsWidget context={undefined} data={data} />)
+}
+
+describe('ExternalIdsWidget sync status dots', () => {
+  it.each(ALL_STATUSES)('renders the semantic status token for %s', (status) => {
+    const { container } = renderWidget(status)
+    const dot = container.querySelector('span[aria-hidden="true"]')
+    expect(dot).not.toBeNull()
+    expect(dot?.className).toContain(STATUS_DOT_TOKENS[status])
+  })
+
+  it('never renders hardcoded Tailwind status colors', () => {
+    for (const status of ALL_STATUSES) {
+      const { container } = renderWidget(status)
+      for (const legacyColor of LEGACY_STATUS_COLORS) {
+        expect(container.innerHTML).not.toContain(legacyColor)
+      }
+    }
+  })
+})

--- a/packages/core/src/modules/integrations/widgets/injection/external-ids/widget.client.tsx
+++ b/packages/core/src/modules/integrations/widgets/injection/external-ids/widget.client.tsx
@@ -10,10 +10,10 @@ import { cn } from '@open-mercato/shared/lib/utils'
 type IntegrationsData = Record<string, ExternalIdMapping>
 
 const SYNC_STATUS_STYLES: Record<ExternalIdMapping['syncStatus'], { dot: string; label: string }> = {
-  synced: { dot: 'bg-green-500', label: 'integrations.syncStatus.synced' },
-  pending: { dot: 'bg-yellow-500', label: 'integrations.syncStatus.pending' },
-  error: { dot: 'bg-red-500', label: 'integrations.syncStatus.error' },
-  not_synced: { dot: 'bg-gray-400', label: 'integrations.syncStatus.notSynced' },
+  synced: { dot: 'bg-status-success-icon', label: 'integrations.syncStatus.synced' },
+  pending: { dot: 'bg-status-warning-icon', label: 'integrations.syncStatus.pending' },
+  error: { dot: 'bg-status-error-icon', label: 'integrations.syncStatus.error' },
+  not_synced: { dot: 'bg-status-neutral-icon', label: 'integrations.syncStatus.notSynced' },
 }
 
 function SyncStatusBadge({ status, lastSynced }: { status: ExternalIdMapping['syncStatus']; lastSynced?: string }) {


### PR DESCRIPTION
Fixes #3257

## Problem
The integrations **External IDs** injection widget mapped each sync-status dot to hardcoded Tailwind status colors (`bg-green-500`, `bg-yellow-500`, `bg-red-500`, `bg-gray-400`), violating the design-system rule against hardcoded status colors (`AGENTS.md` lines 32 & 317).

## Root Cause
`SYNC_STATUS_STYLES` in `packages/core/src/modules/integrations/widgets/injection/external-ids/widget.client.tsx` used raw Tailwind color shades for the status dots instead of semantic `{property}-status-{status}-{role}` tokens.

## What Changed
- Mapped each sync status to the canonical semantic dot token, mirroring the `StatusBadge` primitive's `dotColors` and the integrations detail page token usage:
  - `synced` → `bg-status-success-icon`
  - `pending` → `bg-status-warning-icon`
  - `error` → `bg-status-error-icon`
  - `not_synced` → `bg-status-neutral-icon`
- Dark mode / contrast are handled by the tokens, so no `dark:` overrides are needed.

## Tests
- Added `external-ids/__tests__/widget.client.test.tsx` — a focused component test (jsdom) asserting each status renders its semantic dot token and that the widget never emits the legacy hardcoded color classes. Verified the test **fails against the pre-fix widget** and **passes after the fix**.
- `yarn workspace @open-mercato/core test -- src/modules/integrations/` → 8 suites / 48 tests pass.
- `tsc --noEmit` reports zero errors in the changed files (remaining repo errors are the missing-`#generated`-files artifact of a fresh worktree, unrelated to this diff).

## Backward Compatibility
- No contract surface changes — widget spot id, metadata, features, props, and types are unchanged. Visual-token-only change.