### PR TITLE
fix(shipping_carriers): render tracking status via DS StatusBadge and translated labels (#3298)

### DIFF
--- a/packages/core/src/modules/shipping_carriers/i18n/de.json
+++ b/packages/core/src/modules/shipping_carriers/i18n/de.json
@@ -69,5 +69,14 @@
   "shipping_carriers.create.summary.to": "Nach",
   "shipping_carriers.create.title": "Sendung beim Transporteur erstellen",
   "shipping_carriers.feature.manage": "Versanddienstleister-Vorgaenge verwalten",
-  "shipping_carriers.feature.view": "Sendungen der Versanddienstleister anzeigen"
+  "shipping_carriers.feature.view": "Sendungen der Versanddienstleister anzeigen",
+  "shipping_carriers.status.cancelled": "Storniert",
+  "shipping_carriers.status.delivered": "Zugestellt",
+  "shipping_carriers.status.failed_delivery": "Zustellung fehlgeschlagen",
+  "shipping_carriers.status.in_transit": "Unterwegs",
+  "shipping_carriers.status.label_created": "Etikett erstellt",
+  "shipping_carriers.status.out_for_delivery": "In Zustellung",
+  "shipping_carriers.status.picked_up": "Abgeholt",
+  "shipping_carriers.status.returned": "Zurückgesendet",
+  "shipping_carriers.status.unknown": "Unbekannt"
 }

--- a/packages/core/src/modules/shipping_carriers/i18n/en.json
+++ b/packages/core/src/modules/shipping_carriers/i18n/en.json
@@ -69,5 +69,14 @@
   "shipping_carriers.create.summary.to": "To",
   "shipping_carriers.create.title": "Create carrier shipment",
   "shipping_carriers.feature.manage": "Manage shipping carrier operations",
-  "shipping_carriers.feature.view": "View shipping carrier shipments"
+  "shipping_carriers.feature.view": "View shipping carrier shipments",
+  "shipping_carriers.status.cancelled": "Cancelled",
+  "shipping_carriers.status.delivered": "Delivered",
+  "shipping_carriers.status.failed_delivery": "Delivery failed",
+  "shipping_carriers.status.in_transit": "In transit",
+  "shipping_carriers.status.label_created": "Label created",
+  "shipping_carriers.status.out_for_delivery": "Out for delivery",
+  "shipping_carriers.status.picked_up": "Picked up",
+  "shipping_carriers.status.returned": "Returned",
+  "shipping_carriers.status.unknown": "Unknown"
 }

--- a/packages/core/src/modules/shipping_carriers/i18n/es.json
+++ b/packages/core/src/modules/shipping_carriers/i18n/es.json
@@ -69,5 +69,14 @@
   "shipping_carriers.create.summary.to": "Hasta",
   "shipping_carriers.create.title": "Crear envio con transportista",
   "shipping_carriers.feature.manage": "Gestionar operaciones de transportistas",
-  "shipping_carriers.feature.view": "Ver envios de transportistas"
+  "shipping_carriers.feature.view": "Ver envios de transportistas",
+  "shipping_carriers.status.cancelled": "Cancelado",
+  "shipping_carriers.status.delivered": "Entregado",
+  "shipping_carriers.status.failed_delivery": "Entrega fallida",
+  "shipping_carriers.status.in_transit": "En transito",
+  "shipping_carriers.status.label_created": "Etiqueta creada",
+  "shipping_carriers.status.out_for_delivery": "En reparto",
+  "shipping_carriers.status.picked_up": "Recogido",
+  "shipping_carriers.status.returned": "Devuelto",
+  "shipping_carriers.status.unknown": "Desconocido"
 }

--- a/packages/core/src/modules/shipping_carriers/i18n/pl.json
+++ b/packages/core/src/modules/shipping_carriers/i18n/pl.json
@@ -69,5 +69,14 @@
   "shipping_carriers.create.summary.to": "Odbiór",
   "shipping_carriers.create.title": "Utwórz przesyłkę u przewoźnika",
   "shipping_carriers.feature.manage": "Zarzadzanie operacjami przewoznikow",
-  "shipping_carriers.feature.view": "Podglad przesylek przewoznikow"
+  "shipping_carriers.feature.view": "Podglad przesylek przewoznikow",
+  "shipping_carriers.status.cancelled": "Anulowano",
+  "shipping_carriers.status.delivered": "Dostarczono",
+  "shipping_carriers.status.failed_delivery": "Nieudana dostawa",
+  "shipping_carriers.status.in_transit": "W transporcie",
+  "shipping_carriers.status.label_created": "Utworzono etykietę",
+  "shipping_carriers.status.out_for_delivery": "W doręczeniu",
+  "shipping_carriers.status.picked_up": "Odebrano",
+  "shipping_carriers.status.returned": "Zwrócono",
+  "shipping_carriers.status.unknown": "Nieznany"
 }

--- a/packages/core/src/modules/shipping_carriers/widgets/injection/__tests__/tracking-status-badge.widget.test.tsx
+++ b/packages/core/src/modules/shipping_carriers/widgets/injection/__tests__/tracking-status-badge.widget.test.tsx
@@ -10,8 +10,14 @@ describe('tracking status badge widget', () => {
     expect(isValidElement(rendered)).toBe(true)
     expect(rendered).toMatchObject({
       props: {
-        children: 'in transit',
+        status: 'in_transit',
       },
     })
+  })
+
+  it('renders nothing for empty or non-string values', () => {
+    const cell = widget.columns[0]?.cell
+    expect(cell?.({ getValue: () => '' })).toBeNull()
+    expect(cell?.({ getValue: () => null })).toBeNull()
   })
 })

--- a/packages/core/src/modules/shipping_carriers/widgets/injection/tracking-status-badge/__tests__/widget.test.tsx
+++ b/packages/core/src/modules/shipping_carriers/widgets/injection/tracking-status-badge/__tests__/widget.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+import widget from '../widget'
+
+const STATUS_LABELS: Record<string, string> = {
+  label_created: 'Label created',
+  picked_up: 'Picked up',
+  in_transit: 'In transit',
+  out_for_delivery: 'Out for delivery',
+  delivered: 'Delivered',
+  failed_delivery: 'Delivery failed',
+  returned: 'Returned',
+  cancelled: 'Cancelled',
+  unknown: 'Unknown',
+}
+
+const STATUS_TOKEN: Record<string, string> = {
+  label_created: 'status-neutral',
+  picked_up: 'status-info',
+  in_transit: 'status-info',
+  out_for_delivery: 'status-info',
+  delivered: 'status-success',
+  failed_delivery: 'status-error',
+  returned: 'status-warning',
+  cancelled: 'status-error',
+  unknown: 'status-neutral',
+}
+
+const dict = Object.fromEntries(
+  Object.entries(STATUS_LABELS).map(([status, label]) => [`shipping_carriers.status.${status}`, label]),
+)
+
+function renderCell(value: unknown) {
+  const cell = widget.columns[0].cell
+  if (!cell) throw new Error('cell renderer missing')
+  return render(
+    <I18nProvider locale="en" dict={dict}>
+      {cell({ getValue: () => value })}
+    </I18nProvider>,
+  )
+}
+
+describe('shipping_carriers tracking-status-badge widget', () => {
+  it('renders translated status labels instead of raw underscore-formatted ids', () => {
+    for (const [status, label] of Object.entries(STATUS_LABELS)) {
+      const { container, unmount } = renderCell(status)
+      expect(container.textContent).toContain(label)
+      // Raw ids must never leak through (e.g. "out_for_delivery" or "out for delivery").
+      expect(container.textContent).not.toContain(status)
+      expect(container.textContent).not.toContain(status.replace(/_/g, ' '))
+      unmount()
+    }
+  })
+
+  it('maps each shipment status to its design-system status token, never a hard-coded Tailwind shade', () => {
+    const forbidden = /\b(?:bg|text|border)-(?:gray|slate|sky|blue|indigo|green|amber|red|orange)-\d{2,3}\b/
+    for (const [status, token] of Object.entries(STATUS_TOKEN)) {
+      const { container, unmount } = renderCell(status)
+      expect(container.innerHTML).toContain(token)
+      expect(container.innerHTML).not.toMatch(forbidden)
+      unmount()
+    }
+  })
+
+  it('falls back to the neutral token for unexpected status values', () => {
+    const { container } = renderCell('some_future_status')
+    expect(container.innerHTML).toContain('status-neutral')
+  })
+
+  it('renders nothing for empty or non-string values', () => {
+    expect(renderCell('').container.textContent).toBe('')
+    expect(renderCell(null).container.textContent).toBe('')
+    expect(renderCell(42).container.textContent).toBe('')
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/widgets/injection/tracking-status-badge/widget.tsx
+++ b/packages/core/src/modules/shipping_carriers/widgets/injection/tracking-status-badge/widget.tsx
@@ -1,19 +1,30 @@
-import type { InjectionColumnWidget } from '@open-mercato/shared/modules/widgets/injection'
+'use client'
 
-const SHIPPING_STATUS_COLORS: Record<string, string> = {
-  pending: 'bg-gray-100 text-gray-700',
-  label_created: 'bg-slate-100 text-slate-700',
-  picked_up: 'bg-sky-100 text-sky-700',
-  in_transit: 'bg-blue-100 text-blue-700',
-  out_for_delivery: 'bg-indigo-100 text-indigo-700',
-  delivered: 'bg-green-100 text-green-700',
-  returned: 'bg-amber-100 text-amber-700',
-  cancelled: 'bg-red-100 text-red-700',
-  failed_delivery: 'bg-orange-100 text-orange-700',
+import type { InjectionColumnWidget } from '@open-mercato/shared/modules/widgets/injection'
+import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { StatusBadge, type StatusMap } from '@open-mercato/ui/primitives/status-badge'
+import type { UnifiedShipmentStatus } from '../../../lib/adapter'
+
+const SHIPMENT_STATUS_VARIANTS: StatusMap<UnifiedShipmentStatus> = {
+  label_created: 'neutral',
+  picked_up: 'info',
+  in_transit: 'info',
+  out_for_delivery: 'info',
+  delivered: 'success',
+  failed_delivery: 'error',
+  returned: 'warning',
+  cancelled: 'error',
+  unknown: 'neutral',
 }
 
-function formatShippingStatusLabel(value: string): string {
-  return value.replace(/_/g, ' ')
+function TrackingStatusBadgeCell({ status }: { status: string }) {
+  const t = useT()
+  const variant = SHIPMENT_STATUS_VARIANTS[status as UnifiedShipmentStatus] ?? 'neutral'
+  return (
+    <StatusBadge variant={variant} dot>
+      {t(`shipping_carriers.status.${status}`, status)}
+    </StatusBadge>
+  )
 }
 
 const widget: InjectionColumnWidget = {
@@ -30,12 +41,7 @@ const widget: InjectionColumnWidget = {
       cell: ({ getValue }) => {
         const value = getValue()
         if (typeof value !== 'string' || value.length === 0) return null
-        const colors = SHIPPING_STATUS_COLORS[value] ?? 'bg-gray-100 text-gray-700'
-        return (
-          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colors}`}>
-            {formatShippingStatusLabel(value)}
-          </span>
-        )
+        return <TrackingStatusBadgeCell status={value} />
       },
     },
   ],


### PR DESCRIPTION
Fixes #3298

## Problem
The injected tracking status badge in `shipping_carriers` hard-coded Tailwind status colors (`bg-red-100 text-red-700`, `bg-green-100 …`, etc.) and derived its visible label by replacing underscores in the raw status ID. This violated two repo rules: **no hard-coded design-system status colors** and **no hard-coded user-facing strings**.

## Root Cause
`packages/core/src/modules/shipping_carriers/widgets/injection/tracking-status-badge/widget.tsx` used a local `SHIPPING_STATUS_COLORS` map of raw Tailwind shade classes and `formatShippingStatusLabel(value)` (`value.replace(/_/g, ' ')`) instead of the shared design-system status badge and module translations.

## What Changed
- Render shipment statuses through the shared **`StatusBadge`** primitive (`@open-mercato/ui/primitives/status-badge`), driven by a typed `StatusMap<UnifiedShipmentStatus>` → semantic variant map (`success`/`warning`/`error`/`info`/`neutral`). These map to `status-*` DS tokens that are dark-mode aware — no more hard-coded shades.
- Resolve labels via `t('shipping_carriers.status.<status>')` using a small client cell component (the `cell` render prop is not a React component, so the `useT()` hook must live in a rendered component). Unknown statuses fall back to the `neutral` variant and the raw value.
- Added `shipping_carriers.status.*` keys (9 canonical statuses) to `en`, `pl`, `es`, `de` locale files; `yarn i18n:check-sync` reports all locales in sync.

## Tests
- New `widget.test.tsx` (jsdom): asserts every status renders its DS `status-*` token (never a hard-coded `bg-*-100`/`text-*-700` shade), renders the translated label (not the underscore-formatted raw id), falls back to `neutral` for unexpected values, and renders nothing for empty/non-string values. Verified this test **fails on the pre-fix widget** and passes after.
- Updated the pre-existing `tracking-status-badge.widget.test.tsx` that asserted the old underscore-formatted output.
- `yarn build:packages` (×2) ✓, `yarn generate` ✓, core `tsc --noEmit` ✓ (0 errors), `shipping_carriers` jest (85 tests) ✓, `i18n:check-sync`/`check-usage`/`check-hardcoded` ✓, `yarn build:app` ✓.

## Backward Compatibility
No contract surface changes. Widget metadata id (`shipping_carriers.injection.tracking-status-badge`), column id (`carrier_status_badge`), header key, and `accessorKey` are unchanged. The removed helpers were file-local (not exported). New i18n keys are additive.
