### PR TITLE
fix(ui): parallelize independent tag create/assign operations (#3291)

### DIFF
--- a/packages/core/src/modules/resources/backend/resources/resources/[id]/page.tsx
+++ b/packages/core/src/modules/resources/backend/resources/resources/[id]/page.tsx
@@ -396,12 +396,10 @@ export default function ResourcesResourceDetailPage({ params }: { params?: { id?
   const handleTagsSave = React.useCallback(
     async ({ next, added, removed }: { next: TagOption[]; added: TagOption[]; removed: TagOption[] }) => {
       if (!resourceId) return
-      for (const tag of added) {
-        await assignTag(tag.id)
-      }
-      for (const tag of removed) {
-        await unassignTag(tag.id)
-      }
+      await Promise.all([
+        ...added.map((tag) => assignTag(tag.id)),
+        ...removed.map((tag) => unassignTag(tag.id)),
+      ])
       setTags(next)
       flash(t('resources.resources.tags.success', 'Tags updated.'), 'success')
     },

--- a/packages/ui/src/backend/__tests__/TagsSection.parallel.test.tsx
+++ b/packages/ui/src/backend/__tests__/TagsSection.parallel.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+import { TagsSection, type TagOption, type TagsSectionLabels } from '../detail/TagsSection'
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+const labels: TagsSectionLabels = {
+  loading: 'Loading…',
+  placeholder: 'Add tag',
+  empty: 'No tags',
+  loadError: 'Load failed',
+  createError: 'Create failed',
+  updateError: 'Update failed',
+  labelRequired: 'Label required',
+  saveShortcut: 'Save',
+  cancelShortcut: 'Cancel',
+  edit: 'Edit',
+  cancel: 'Cancel',
+  success: 'Tags updated',
+}
+
+type Deferred = { resolve: () => void; promise: Promise<void> }
+
+function createDeferred(): Deferred {
+  let resolve!: () => void
+  const promise = new Promise<void>((res) => {
+    resolve = () => res()
+  })
+  return { resolve, promise }
+}
+
+function renderSection(overrides: Partial<React.ComponentProps<typeof TagsSection>> = {}) {
+  const props: React.ComponentProps<typeof TagsSection> = {
+    title: 'Tags',
+    tags: [],
+    loadOptions: jest.fn(async () => [] as TagOption[]),
+    createTag: jest.fn(async (label: string) => ({ id: `id-${label}`, label })),
+    onSave: jest.fn(async () => {}),
+    labels,
+    ...overrides,
+  }
+  render(
+    <I18nProvider locale="en" dict={{}}>
+      <TagsSection {...props} />
+    </I18nProvider>,
+  )
+  return props
+}
+
+async function startEditingAndAddTags(tags: string[]) {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+  })
+  const input = await screen.findByPlaceholderText('Add tag')
+  for (const tag of tags) {
+    await act(async () => {
+      fireEvent.change(input, { target: { value: tag } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+    })
+  }
+  return input
+}
+
+describe('TagsSection — parallel tag creation (issue #3291)', () => {
+  it('dispatches createTag for all new tags concurrently instead of waiting for each to settle', async () => {
+    const deferreds: Deferred[] = []
+    let inFlight = 0
+    let maxConcurrent = 0
+    const createTag = jest.fn(async (label: string) => {
+      inFlight += 1
+      maxConcurrent = Math.max(maxConcurrent, inFlight)
+      const deferred = createDeferred()
+      deferreds.push(deferred)
+      await deferred.promise
+      inFlight -= 1
+      return { id: `id-${label}`, label }
+    })
+    const onSave = jest.fn(async () => {})
+
+    renderSection({ createTag, onSave })
+    await startEditingAndAddTags(['alpha', 'beta', 'gamma'])
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    })
+
+    await waitFor(() => expect(createTag).toHaveBeenCalledTimes(3))
+    // With the sequential implementation only one createTag would be in flight at a
+    // time (maxConcurrent === 1); the parallel implementation keeps all three pending.
+    expect(maxConcurrent).toBe(3)
+
+    await act(async () => {
+      deferreds.forEach((deferred) => deferred.resolve())
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
+    const saveArgs = onSave.mock.calls[0][0] as { added: TagOption[] }
+    expect(saveArgs.added.map((tag) => tag.label).sort()).toEqual(['alpha', 'beta', 'gamma'])
+  })
+})

--- a/packages/ui/src/backend/detail/TagsSection.tsx
+++ b/packages/ui/src/backend/detail/TagsSection.tsx
@@ -209,22 +209,19 @@ function TagsSectionImpl({
     const task = (async () => {
       const currentTags = savedTagsRef.current
       const currentIds = new Set(currentTags.map((tag) => tag.id))
-      const finalTagOptions: TagOption[] = []
       const submittedDraftKey = buildTagLabelKey(trimmed)
 
       setSaving(true)
       setError(null)
       try {
-        for (const normalized of uniqueLabels) {
-          const existing = optionsRef.current.get(normalized)
-          if (existing) {
-            finalTagOptions.push(existing)
-            continue
-          }
-          const matchingLabel = trimmed.find((label) => label.toLowerCase() === normalized) ?? normalized
-          const created = await ensureTagOption(matchingLabel)
-          finalTagOptions.push(created)
-        }
+        const finalTagOptions = await Promise.all(
+          uniqueLabels.map((normalized) => {
+            const existing = optionsRef.current.get(normalized)
+            if (existing) return existing
+            const matchingLabel = trimmed.find((label) => label.toLowerCase() === normalized) ?? normalized
+            return ensureTagOption(matchingLabel)
+          }),
+        )
 
         const finalIds = new Set(finalTagOptions.map((tag) => tag.id))
         const added = finalTagOptions.filter((tag) => !currentIds.has(tag.id))


### PR DESCRIPTION
Fixes #3291

## Problem
Resource tag saves serialized independent async work into client-side waterfalls. When a user added or removed several tags at once:
- `TagsSection` created each missing tag one at a time (`for ... await ensureTagOption(...)`), and
- the resources detail page assigned/unassigned each tag sequentially (`for ... await assignTag/unassignTag`).

This violates the `async-parallel` guidance — independent async operations should run concurrently.

## Root Cause
Two sequential `for ... await` loops over independent operations:
- `packages/ui/src/backend/detail/TagsSection.tsx` — tag creation loop.
- `packages/core/src/modules/resources/backend/resources/resources/[id]/page.tsx` — assign/unassign loops.

## What Changed
- `TagsSection`: replaced the sequential tag-creation loop with `Promise.all` over `uniqueLabels`. Already-known options resolve immediately; missing ones call `ensureTagOption` concurrently. `Promise.all` preserves input order, so the resulting `finalTagOptions` (and the redrawn draft) keep their original order.
- Resources detail page: replaced the two sequential loops with a single `Promise.all` over all `assignTag`/`unassignTag` calls.
- Behavior preserved: duplicate/conflict handling (`ensureTagOption` still dedupes via the options cache; `uniqueLabels` is already de-duplicated) and user-facing error surfacing (the surrounding `try/catch` still flashes the first rejection) are unchanged.

## Tests
- Added `packages/ui/src/backend/__tests__/TagsSection.parallel.test.tsx`: renders `TagsSection`, adds three new tags, saves, and asserts all three `createTag` calls are in flight concurrently (`maxConcurrent === 3`). Verified it **fails** against the previous sequential code (only 1 call in flight) and passes with the fix.
- `yarn workspace @open-mercato/ui test` — 1554 passing (the single pre-existing `format.test.ts` failure is an environment locale quirk, unrelated to this change).
- `yarn typecheck` (ui + core) — clean.
- `yarn build:packages`, `yarn generate` — clean.
- `yarn i18n:check-sync` — in sync; `eslint` on changed files — clean.

## Backward Compatibility
No contract surface changes — internal control flow only. No changes to types, signatures, import paths, event IDs, API routes, DI keys, ACL features, or DB schema.