### PR TITLE
fix(customer_accounts): align demo credential copy with seeded password (#3198)

### DIFF
--- a/packages/core/src/modules/customer_accounts/__tests__/demoCredentialsCopy.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/demoCredentialsCopy.test.ts
@@ -1,0 +1,58 @@
+/** @jest-environment node */
+
+import path from 'path'
+import fs from 'fs'
+
+type LocaleMap = Record<string, string>
+
+const LOCALES = ['en', 'pl', 'de', 'es'] as const
+
+const moduleDir = path.join(__dirname, '..')
+
+function loadLocale(locale: string): LocaleMap {
+  const file = path.join(moduleDir, 'i18n', `${locale}.json`)
+  return JSON.parse(fs.readFileSync(file, 'utf8')) as LocaleMap
+}
+
+function readSeededAliceCredential(): { email: string; password: string } {
+  const setup = fs.readFileSync(path.join(moduleDir, 'setup.ts'), 'utf8')
+  const match = setup.match(
+    /email:\s*'(alice\.johnson@example\.com)'[^}]*password:\s*'([^']+)'/,
+  )
+  if (!match) {
+    throw new Error('Unable to locate seeded alice.johnson example credential in setup.ts')
+  }
+  return { email: match[1], password: match[2] }
+}
+
+describe('customer_accounts demo credential copy (regression for issue #3198)', () => {
+  const seeded = readSeededAliceCredential()
+
+  it('seeded example password uses the expected casing', () => {
+    expect(seeded.password).toBe('Password123!')
+  })
+
+  describe.each(LOCALES)('locale: %s', (locale) => {
+    it('portalInfo.credentials matches the seeded example password', () => {
+      const localeMap = loadLocale(locale)
+      const credentials = localeMap['customer_accounts.admin.portalInfo.credentials']
+      expect(credentials).toBeTruthy()
+      expect(credentials).toContain(seeded.email)
+      expect(credentials).toContain(seeded.password)
+    })
+  })
+
+  it('users page banner fallback copy matches the seeded example password', () => {
+    const page = fs.readFileSync(
+      path.join(moduleDir, 'backend', 'customer_accounts', 'users', 'page.tsx'),
+      'utf8',
+    )
+    const match = page.match(
+      /customer_accounts\.admin\.portalInfo\.credentials',\s*'([^']+)'/,
+    )
+    expect(match).toBeTruthy()
+    const fallback = match![1]
+    expect(fallback).toContain(seeded.email)
+    expect(fallback).toContain(seeded.password)
+  })
+})

--- a/packages/core/src/modules/customer_accounts/backend/customer_accounts/users/page.tsx
+++ b/packages/core/src/modules/customer_accounts/backend/customer_accounts/users/page.tsx
@@ -500,7 +500,7 @@ export default function CustomerAccountsPage() {
                 })}
               </p>
               <p className="mt-0.5 text-xs text-status-info-text">
-                {t('customer_accounts.admin.portalInfo.credentials', 'Demo credentials: alice.johnson@example.com / password123')}
+                {t('customer_accounts.admin.portalInfo.credentials', 'Demo credentials: alice.johnson@example.com / Password123!')}
               </p>
             </div>
             <div className="flex shrink-0 flex-col gap-2">

--- a/packages/core/src/modules/customer_accounts/i18n/de.json
+++ b/packages/core/src/modules/customer_accounts/i18n/de.json
@@ -121,7 +121,7 @@
   "customer_accounts.admin.portalFeatures.users.invite": "Invite team members",
   "customer_accounts.admin.portalFeatures.users.manage": "Manage team members",
   "customer_accounts.admin.portalFeatures.users.view": "View team members",
-  "customer_accounts.admin.portalInfo.credentials": "Demo credentials: alice.johnson@example.com / password123",
+  "customer_accounts.admin.portalInfo.credentials": "Demo credentials: alice.johnson@example.com / Password123!",
   "customer_accounts.admin.portalInfo.description": "Manage customer portal accounts. Customers can self-register, log in, and access orders, quotes, and invoices through the portal.",
   "customer_accounts.admin.portalInfo.open": "Open Portal",
   "customer_accounts.admin.portalInfo.openConfiguration": "Open Configuration",

--- a/packages/core/src/modules/customer_accounts/i18n/en.json
+++ b/packages/core/src/modules/customer_accounts/i18n/en.json
@@ -121,7 +121,7 @@
   "customer_accounts.admin.portalFeatures.users.invite": "Invite team members",
   "customer_accounts.admin.portalFeatures.users.manage": "Manage team members",
   "customer_accounts.admin.portalFeatures.users.view": "View team members",
-  "customer_accounts.admin.portalInfo.credentials": "Demo credentials: alice.johnson@example.com / password123",
+  "customer_accounts.admin.portalInfo.credentials": "Demo credentials: alice.johnson@example.com / Password123!",
   "customer_accounts.admin.portalInfo.description": "Manage customer portal accounts. Customers can self-register, log in, and access orders, quotes, and invoices through the portal.",
   "customer_accounts.admin.portalInfo.open": "Open Portal",
   "customer_accounts.admin.portalInfo.openConfiguration": "Open Configuration",

--- a/packages/core/src/modules/customer_accounts/i18n/es.json
+++ b/packages/core/src/modules/customer_accounts/i18n/es.json
@@ -121,7 +121,7 @@
   "customer_accounts.admin.portalFeatures.users.invite": "Invite team members",
   "customer_accounts.admin.portalFeatures.users.manage": "Manage team members",
   "customer_accounts.admin.portalFeatures.users.view": "View team members",
-  "customer_accounts.admin.portalInfo.credentials": "Demo credentials: alice.johnson@example.com / password123",
+  "customer_accounts.admin.portalInfo.credentials": "Demo credentials: alice.johnson@example.com / Password123!",
   "customer_accounts.admin.portalInfo.description": "Manage customer portal accounts. Customers can self-register, log in, and access orders, quotes, and invoices through the portal.",
   "customer_accounts.admin.portalInfo.open": "Open Portal",
   "customer_accounts.admin.portalInfo.openConfiguration": "Open Configuration",

--- a/packages/core/src/modules/customer_accounts/i18n/pl.json
+++ b/packages/core/src/modules/customer_accounts/i18n/pl.json
@@ -121,7 +121,7 @@
   "customer_accounts.admin.portalFeatures.users.invite": "Invite team members",
   "customer_accounts.admin.portalFeatures.users.manage": "Manage team members",
   "customer_accounts.admin.portalFeatures.users.view": "View team members",
-  "customer_accounts.admin.portalInfo.credentials": "Demo credentials: alice.johnson@example.com / password123",
+  "customer_accounts.admin.portalInfo.credentials": "Demo credentials: alice.johnson@example.com / Password123!",
   "customer_accounts.admin.portalInfo.description": "Manage customer portal accounts. Customers can self-register, log in, and access orders, quotes, and invoices through the portal.",
   "customer_accounts.admin.portalInfo.open": "Open Portal",
   "customer_accounts.admin.portalInfo.openConfiguration": "Open Configuration",


### PR DESCRIPTION
Fixes #3198

## Problem
- The customer user list banner and its translations displayed `Demo credentials: alice.johnson@example.com / password123`, but seeded example customer accounts and the dedicated settings page use `Password123!`. The shown credential was therefore unusable and inconsistent.

## Root Cause
- The banner fallback string in the users page and the `customer_accounts.admin.portalInfo.credentials` key across all four locale files carried the stale lowercase `password123`, while `setup.ts` `seedExamples` and the settings page `DEMO_CREDENTIALS` use `Password123!`.

## What Changed
- Updated the users page banner fallback string to `Password123!`.
- Updated `customer_accounts.admin.portalInfo.credentials` in `en`, `de`, `es`, and `pl` locale files to `Password123!`.
- Added `demoCredentialsCopy.test.ts` regression test that reads the seeded example password from `setup.ts` and asserts every locale credential string and the page fallback stay in sync (guards against future casing drift).

## Tests
- New unit test `packages/core/src/modules/customer_accounts/__tests__/demoCredentialsCopy.test.ts` (6 cases) — verified it fails on the old `password123` value and passes after the fix.
- `yarn i18n:check-sync` — all locales in sync.
- `yarn workspace @open-mercato/core typecheck` — passes.
- Sibling `navigationLabels.test.ts` still green.

## Backward Compatibility
- No contract surface changes. Same i18n key, same component, no API/event/ACL/DI changes. Copy-only fix plus a test.