### PR TITLE
fix(customer_accounts): emit invitation-created events from admin and portal invite routes (#3196)

### DIFF
--- a/packages/core/src/modules/customer_accounts/AGENTS.md
+++ b/packages/core/src/modules/customer_accounts/AGENTS.md
@@ -262,6 +262,7 @@ Declared in `events.ts` via `createModuleEvents`. Emit with `emitCustomerAccount
 | `customer_accounts.role.created` | crud | No |
 | `customer_accounts.role.updated` | crud | No |
 | `customer_accounts.role.deleted` | crud | No |
+| `customer_accounts.user.invited` | lifecycle | Yes |
 | `customer_accounts.invitation.accepted` | lifecycle | Yes |
 
 ## Subscribers

--- a/packages/core/src/modules/customer_accounts/api/__tests__/users-invite-events.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/__tests__/users-invite-events.test.ts
@@ -1,0 +1,214 @@
+/** @jest-environment node */
+
+import { NextResponse } from 'next/server'
+import type { RateLimitConfig } from '@open-mercato/shared/lib/ratelimit/types'
+
+const inviteIpConfig: RateLimitConfig = { points: 20, duration: 60, blockDuration: 120, keyPrefix: 'customer-invite-ip' }
+const inviteCompoundConfig: RateLimitConfig = { points: 5, duration: 60, blockDuration: 120, keyPrefix: 'customer-invite' }
+
+const mockCheckAuthRateLimit = jest.fn()
+const mockCreateInvitation = jest.fn()
+const mockUserHasAllFeatures = jest.fn()
+const mockGetAuthFromRequest = jest.fn()
+const mockGetCustomerAuthFromRequest = jest.fn()
+const mockRequireCustomerFeature = jest.fn()
+const mockEmit = jest.fn(async () => undefined)
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/rateLimiter', () => ({
+  checkAuthRateLimit: (...args: unknown[]) => mockCheckAuthRateLimit(...args),
+  customerInviteIpRateLimitConfig: inviteIpConfig,
+  customerInviteRateLimitConfig: inviteCompoundConfig,
+}))
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'rbacService') return { userHasAllFeatures: mockUserHasAllFeatures }
+    if (token === 'customerRbacService') return {}
+    if (token === 'customerInvitationService') return { createInvitation: mockCreateInvitation }
+    if (token === 'em') return { find: jest.fn() }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuth', () => ({
+  getCustomerAuthFromRequest: (...args: unknown[]) => mockGetCustomerAuthFromRequest(...args),
+  requireCustomerFeature: (...args: unknown[]) => mockRequireCustomerFeature(...args),
+}))
+
+const mockFindWithDecryption = jest.fn(async () => [] as unknown[])
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
+  findOneWithDecryption: jest.fn(async () => null),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/events', () => ({
+  emitCustomerAccountsEvent: (...args: unknown[]) => mockEmit(...args),
+}))
+
+const tenantId = '22222222-2222-4222-8222-222222222222'
+const organizationId = '33333333-3333-4333-8333-333333333333'
+const customerEntityId = '44444444-4444-4444-8444-444444444444'
+const invitationId = '55555555-5555-4555-8555-555555555555'
+const roleId = '11111111-1111-4111-8111-111111111111'
+
+function makeInviteRequest(path: string, body: Record<string, unknown>): Request {
+  return new Request(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function rateLimitResponse(): NextResponse {
+  return NextResponse.json({ error: 'Too many requests' }, { status: 429 })
+}
+
+function invitedEvents(): unknown[][] {
+  return mockEmit.mock.calls.filter((call: unknown[]) => call[0] === 'customer_accounts.user.invited')
+}
+
+describe('customer invitation endpoints — invitation-created event', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCheckAuthRateLimit.mockResolvedValue({ error: null, compoundKey: null })
+    mockUserHasAllFeatures.mockResolvedValue(true)
+    mockRequireCustomerFeature.mockResolvedValue(undefined)
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'staff-1', tenantId, orgId: organizationId })
+    mockGetCustomerAuthFromRequest.mockResolvedValue({
+      sub: 'portal-1',
+      tenantId,
+      orgId: organizationId,
+      customerEntityId,
+    })
+    mockCreateInvitation.mockResolvedValue({
+      invitation: {
+        id: invitationId,
+        email: 'buyer@example.com',
+        customerEntityId,
+        expiresAt: new Date().toISOString(),
+      },
+      rawToken: 'raw-secret-token',
+    })
+    mockEmit.mockResolvedValue(undefined)
+    mockFindWithDecryption.mockResolvedValue([{ id: roleId, name: 'Buyer', customerAssignable: true }])
+  })
+
+  it('admin route emits the invitation-created event once with staff context and no raw token', async () => {
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(
+      makeInviteRequest('/api/customer_accounts/admin/users-invite', { email: 'buyer@example.com', roleIds: [roleId] }),
+    )
+
+    expect(res.status).toBe(201)
+    const events = invitedEvents()
+    expect(events).toHaveLength(1)
+    expect(events[0][1]).toEqual({
+      invitationId,
+      email: 'buyer@example.com',
+      customerEntityId,
+      invitedByType: 'staff',
+      tenantId,
+      organizationId,
+    })
+    expect(JSON.stringify(events[0][1])).not.toContain('raw-secret-token')
+  })
+
+  it('portal route emits the invitation-created event once with portal context', async () => {
+    const { POST } = await import('../portal/users-invite')
+    const res = await POST(
+      makeInviteRequest('/api/customer_accounts/portal/users-invite', { email: 'buyer@example.com', roleIds: [roleId] }),
+    )
+
+    expect(res.status).toBe(201)
+    const events = invitedEvents()
+    expect(events).toHaveLength(1)
+    expect(events[0][1]).toEqual({
+      invitationId,
+      email: 'buyer@example.com',
+      customerEntityId,
+      invitedByType: 'portal',
+      tenantId,
+      organizationId,
+    })
+  })
+
+  it('admin route does NOT emit when unauthenticated', async () => {
+    mockGetAuthFromRequest.mockResolvedValue(null)
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(
+      makeInviteRequest('/api/customer_accounts/admin/users-invite', { email: 'buyer@example.com', roleIds: [roleId] }),
+    )
+
+    expect(res.status).toBe(401)
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
+    expect(invitedEvents()).toHaveLength(0)
+  })
+
+  it('admin route does NOT emit when the caller lacks customer_accounts.invite', async () => {
+    mockUserHasAllFeatures.mockResolvedValue(false)
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(
+      makeInviteRequest('/api/customer_accounts/admin/users-invite', { email: 'buyer@example.com', roleIds: [roleId] }),
+    )
+
+    expect(res.status).toBe(403)
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
+    expect(invitedEvents()).toHaveLength(0)
+  })
+
+  it('admin route does NOT emit when validation fails', async () => {
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(
+      makeInviteRequest('/api/customer_accounts/admin/users-invite', { email: 'not-an-email', roleIds: [roleId] }),
+    )
+
+    expect(res.status).toBe(400)
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
+    expect(invitedEvents()).toHaveLength(0)
+  })
+
+  it('admin route does NOT emit when rate limited', async () => {
+    mockCheckAuthRateLimit.mockResolvedValue({ error: rateLimitResponse(), compoundKey: null })
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(
+      makeInviteRequest('/api/customer_accounts/admin/users-invite', { email: 'buyer@example.com', roleIds: [roleId] }),
+    )
+
+    expect(res.status).toBe(429)
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
+    expect(invitedEvents()).toHaveLength(0)
+  })
+
+  it('portal route does NOT emit when the portal feature check rejects', async () => {
+    mockRequireCustomerFeature.mockRejectedValue(NextResponse.json({ ok: false, error: 'Insufficient permissions' }, { status: 403 }))
+    const { POST } = await import('../portal/users-invite')
+    const res = await POST(
+      makeInviteRequest('/api/customer_accounts/portal/users-invite', { email: 'buyer@example.com', roleIds: [] }),
+    )
+
+    expect(res.status).toBe(403)
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
+    expect(invitedEvents()).toHaveLength(0)
+  })
+
+  it('portal route does NOT emit when rate limited', async () => {
+    mockCheckAuthRateLimit.mockResolvedValue({ error: rateLimitResponse(), compoundKey: null })
+    const { POST } = await import('../portal/users-invite')
+    const res = await POST(
+      makeInviteRequest('/api/customer_accounts/portal/users-invite', { email: 'buyer@example.com', roleIds: [] }),
+    )
+
+    expect(res.status).toBe(429)
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
+    expect(invitedEvents()).toHaveLength(0)
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/admin/users-invite.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users-invite.ts
@@ -5,6 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { CustomerInvitationService } from '@open-mercato/core/modules/customer_accounts/services/customerInvitationService'
+import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 import { inviteUserSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
 import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
 import {
@@ -62,6 +63,15 @@ export async function POST(req: Request) {
       displayName: parsed.data.displayName || null,
     },
   )
+
+  void emitCustomerAccountsEvent('customer_accounts.user.invited', {
+    invitationId: invitation.id,
+    email: invitation.email,
+    customerEntityId: invitation.customerEntityId || null,
+    invitedByType: 'staff',
+    tenantId: auth.tenantId!,
+    organizationId: auth.orgId!,
+  }).catch(() => undefined)
 
   return NextResponse.json({
     ok: true,

--- a/packages/core/src/modules/customer_accounts/api/portal/users-invite.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/users-invite.ts
@@ -4,6 +4,7 @@ import type { OpenApiRouteDoc, OpenApiMethodDoc } from '@open-mercato/shared/lib
 import { getCustomerAuthFromRequest, requireCustomerFeature } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { CustomerInvitationService } from '@open-mercato/core/modules/customer_accounts/services/customerInvitationService'
+import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 import { CustomerRbacService } from '@open-mercato/core/modules/customer_accounts/services/customerRbacService'
 import { CustomerRole } from '@open-mercato/core/modules/customer_accounts/data/entities'
 import { inviteUserSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
@@ -94,6 +95,15 @@ export async function POST(req: Request) {
       displayName: parsed.data.displayName || null,
     },
   )
+
+  void emitCustomerAccountsEvent('customer_accounts.user.invited', {
+    invitationId: invitation.id,
+    email: invitation.email,
+    customerEntityId: invitation.customerEntityId || null,
+    invitedByType: 'portal',
+    tenantId: auth.tenantId,
+    organizationId: auth.orgId,
+  }).catch(() => undefined)
 
   return NextResponse.json({
     ok: true,

--- a/packages/core/src/modules/customer_accounts/events.ts
+++ b/packages/core/src/modules/customer_accounts/events.ts
@@ -16,6 +16,7 @@ const events = [
   { id: 'customer_accounts.role.created', label: 'Customer Role Created', entity: 'role', category: 'crud' },
   { id: 'customer_accounts.role.updated', label: 'Customer Role Updated', entity: 'role', category: 'crud', portalBroadcast: true },
   { id: 'customer_accounts.role.deleted', label: 'Customer Role Deleted', entity: 'role', category: 'crud' },
+  { id: 'customer_accounts.user.invited', label: 'Customer User Invited', entity: 'user', category: 'lifecycle', clientBroadcast: true },
   { id: 'customer_accounts.invitation.accepted', label: 'Customer Invitation Accepted', category: 'lifecycle', clientBroadcast: true },
   { id: 'customer_accounts.password_reset.requested', label: 'Customer Password Reset Requested', category: 'lifecycle' },
   // Custom domain mapping lifecycle (see .ai/specs/implemented/2026-04-08-portal-custom-domain-routing.md)


### PR DESCRIPTION
Fixes #3196

## Problem
Both the staff/admin (`POST /api/customer_accounts/admin/users-invite`) and portal-admin (`POST /api/customer_accounts/portal/users-invite`) invite routes create `CustomerUserInvitation` records and return success, but neither emitted the `customer_accounts.user.invited` event declared by the original customer identity contract (SPEC-060). That left notification, automation, audit, and integration subscribers without the invitation-created signal.

## Root Cause
- `events.ts` declared many `customer_accounts` events but not `customer_accounts.user.invited`.
- Neither invite route called `emitCustomerAccountsEvent` after `createInvitation`.

## What Changed
- Added the `customer_accounts.user.invited` event definition (`lifecycle`, `clientBroadcast: true`, consistent with `customer_accounts.invitation.accepted`) in `packages/core/src/modules/customer_accounts/events.ts`.
- Emit the event from both invite routes after a successful invitation is created, using the established `void emit(...).catch(() => undefined)` pattern (non-blocking, fail-soft).
- Payload follows the spec (`{ invitationId, email, customerEntityId, invitedByType }`) and additionally carries `tenantId`/`organizationId` context. `invitedByType` is `'staff'` for the admin route and `'portal'` for the portal route so subscribers can distinguish the two paths. The raw invitation token is never included.
- Documented the new event in the module `AGENTS.md` events table.

## Tests
- New `api/__tests__/users-invite-events.test.ts`:
  - Asserts the event is emitted exactly once per successful invite (admin = staff context, portal = portal context) with the expected payload, and that the raw token is not present in the payload.
  - Asserts the event is NOT emitted on auth failure (401), RBAC/feature failure (403), validation failure (400), or rate-limit (429) — for both routes.
- `yarn workspace @open-mercato/core test --testPathPatterns customer_accounts` → 325 passed.
- `yarn typecheck` → all packages pass.
- `yarn i18n:check-sync` → in sync; `yarn i18n:check-usage` → no new violations (no locale changes).

## Backward Compatibility
Additive only. A new event id is added to the ADDITIVE-ONLY event-id contract surface; no existing event id, API response field, DI name, import path, or ACL feature is removed or changed. Route response shapes are unchanged.