### PR TITLE
fix(customer_accounts): wrap remaining non-CrudForm writes in useGuardedMutation (#3195)

### DIFF
--- a/packages/core/src/modules/customer_accounts/__tests__/guarded-mutation-coverage.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/guarded-mutation-coverage.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Regression coverage for #3195 — the remaining customer_accounts non-CrudForm
+ * write paths must route through `useGuardedMutation` so the shared mutation
+ * injection lifecycle (record locks, conflict UI, global write guards) runs
+ * instead of calling `apiCall` directly.
+ *
+ * These two UI surfaces are not `CrudForm` hosts, so they need the guard wired
+ * by hand. This test fails if either drops the wiring.
+ */
+const moduleRoot = join(__dirname, '..')
+
+const GUARDED_WRITE_FILES = [
+  'backend/customer_accounts/roles/page.tsx',
+  'widgets/injection/account-status/widget.client.tsx',
+]
+
+describe('customer_accounts non-CrudForm writes route through useGuardedMutation (#3195)', () => {
+  it.each(GUARDED_WRITE_FILES)('%s imports and invokes useGuardedMutation', (relativePath) => {
+    const source = readFileSync(join(moduleRoot, relativePath), 'utf8')
+    expect(source).toContain("from '@open-mercato/ui/backend/injection/useGuardedMutation'")
+    expect(source).toContain('useGuardedMutation')
+    expect(source).toContain('runMutation')
+  })
+})

--- a/packages/core/src/modules/customer_accounts/backend/customer_accounts/roles/page.tsx
+++ b/packages/core/src/modules/customer_accounts/backend/customer_accounts/roles/page.tsx
@@ -14,6 +14,7 @@ import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimi
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { ListEmptyState } from '@open-mercato/ui/backend/filters/ListEmptyState'
 
 type RoleRow = {
@@ -46,6 +47,21 @@ export default function CustomerRolesPage() {
   const [search, setSearch] = React.useState('')
   const [isLoading, setIsLoading] = React.useState(true)
   const [reloadToken, setReloadToken] = React.useState(0)
+
+  const { runMutation } = useGuardedMutation<{ entityType: string }>({
+    contextId: 'customer_accounts:roles-list',
+  })
+
+  const runMutationWithContext = React.useCallback(
+    async <T,>(operation: () => Promise<T>, mutationPayload?: Record<string, unknown>): Promise<T> => {
+      return runMutation({
+        operation,
+        mutationPayload,
+        context: { entityType: 'customer_accounts:role' },
+      })
+    },
+    [runMutation],
+  )
 
   const queryParams = React.useMemo(() => {
     const params = new URLSearchParams()
@@ -95,24 +111,26 @@ export default function CustomerRolesPage() {
     })
     if (!confirmed) return
     try {
-      const call = await withScopedApiRequestHeaders(
-        buildOptimisticLockHeader(role.updatedAt),
-        () => apiCall(
-          `/api/customer_accounts/admin/roles/${encodeURIComponent(role.id)}`,
-          { method: 'DELETE' },
-        ),
-      )
-      if (!call.ok) {
-        flash(t('customer_accounts.admin.roles.error.delete', 'Failed to delete role'), 'error')
-        return
-      }
-      flash(t('customer_accounts.admin.roles.flash.deleted', 'Role deleted'), 'success')
-      setReloadToken((token) => token + 1)
+      await runMutationWithContext(async () => {
+        const call = await withScopedApiRequestHeaders(
+          buildOptimisticLockHeader(role.updatedAt),
+          () => apiCall(
+            `/api/customer_accounts/admin/roles/${encodeURIComponent(role.id)}`,
+            { method: 'DELETE' },
+          ),
+        )
+        if (!call.ok) {
+          flash(t('customer_accounts.admin.roles.error.delete', 'Failed to delete role'), 'error')
+          return
+        }
+        flash(t('customer_accounts.admin.roles.flash.deleted', 'Role deleted'), 'success')
+        setReloadToken((token) => token + 1)
+      }, { id: role.id })
     } catch (err) {
       const message = err instanceof Error ? err.message : t('customer_accounts.admin.roles.error.delete', 'Failed to delete role')
       flash(message, 'error')
     }
-  }, [confirm, t])
+  }, [confirm, runMutationWithContext, t])
 
   const columns = React.useMemo<ColumnDef<RoleRow>[]>(() => [
     {

--- a/packages/core/src/modules/customer_accounts/widgets/injection/account-status/__tests__/widget.client.test.tsx
+++ b/packages/core/src/modules/customer_accounts/widgets/injection/account-status/__tests__/widget.client.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression coverage for #3195 — the account-status invite form must route its
+ * invitation POST through `useGuardedMutation.runMutation` so the shared mutation
+ * injection lifecycle (record locks, conflict UI, global write guards) runs,
+ * instead of calling `apiCall` directly.
+ */
+import * as React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import AccountStatusWidget from '../widget.client'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+
+const mockRunMutation = jest.fn(
+  async ({ operation }: { operation: () => Promise<unknown> }) => operation(),
+)
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback: string) => fallback || _key,
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: jest.fn(() => ({ runMutation: mockRunMutation })),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+}))
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: null, isLoading: false }),
+  useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}))
+
+const mockApiCall = apiCall as jest.MockedFunction<typeof apiCall>
+
+describe('customer_accounts AccountStatusWidget invite form (#3195)', () => {
+  beforeEach(() => {
+    mockRunMutation.mockClear()
+    mockApiCall.mockReset()
+    mockApiCall.mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/api/customers/people/')) {
+        return { ok: true, status: 200, result: { person: null, profile: null } } as never
+      }
+      if (typeof url === 'string' && url.includes('/api/customer_accounts/admin/roles')) {
+        return {
+          ok: true,
+          status: 200,
+          result: { items: [{ id: 'role-1', name: 'Buyer' }] },
+        } as never
+      }
+      // users-invite POST
+      return { ok: true, status: 200, result: { ok: true } } as never
+    })
+  })
+
+  async function openInviteForm() {
+    render(<AccountStatusWidget context={{ recordId: 'person-entity-1' }} />)
+    fireEvent.click(await screen.findByRole('button', { name: /invite to portal/i }))
+    return screen.findByRole('button', { name: /send invitation/i })
+  }
+
+  it('routes the invitation POST through useGuardedMutation.runMutation', async () => {
+    const submitButton = await openInviteForm()
+
+    fireEvent.change(await screen.findByLabelText(/email/i), {
+      target: { value: 'buyer@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Buyer' }))
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockRunMutation).toHaveBeenCalledTimes(1)
+    })
+
+    const runArgs = mockRunMutation.mock.calls[0][0] as {
+      context: { entityType: string }
+      mutationPayload: Record<string, unknown>
+    }
+    expect(runArgs.context.entityType).toBe('customer_accounts:user')
+    expect(runArgs.mutationPayload.customerEntityId).toBe('person-entity-1')
+
+    await waitFor(() => {
+      const inviteCall = mockApiCall.mock.calls.find(
+        ([url]) => typeof url === 'string' && url.includes('/api/customer_accounts/admin/users-invite'),
+      )
+      expect(inviteCall).toBeTruthy()
+      expect((inviteCall?.[1] as RequestInit | undefined)?.method).toBe('POST')
+    })
+  })
+})

--- a/packages/core/src/modules/customer_accounts/widgets/injection/account-status/widget.client.tsx
+++ b/packages/core/src/modules/customer_accounts/widgets/injection/account-status/widget.client.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Input } from '@open-mercato/ui/primitives/input'
@@ -49,6 +50,10 @@ function InviteForm({ personEntityId, onSuccess }: { personEntityId: string; onS
   const [availableRoles, setAvailableRoles] = React.useState<RoleOption[]>([])
   const [isLoadingRoles, setIsLoadingRoles] = React.useState(true)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
+
+  const { runMutation } = useGuardedMutation<{ entityType: string }>({
+    contextId: 'customer_accounts:account-status-invite',
+  })
 
   React.useEffect(() => {
     let cancelled = false
@@ -124,28 +129,35 @@ function InviteForm({ personEntityId, onSuccess }: { personEntityId: string; onS
 
     setIsSubmitting(true)
     try {
-      const call = await apiCall<{ ok: boolean; error?: string }>(
-        '/api/customer_accounts/admin/users-invite',
-        {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({
-            email: trimmedEmail,
-            roleIds: selectedRoleIds,
-            displayName: displayName.trim() || undefined,
-            customerEntityId: personEntityId,
-          }),
+      await runMutation({
+        context: { entityType: 'customer_accounts:user' },
+        mutationPayload: { customerEntityId: personEntityId, roleIds: selectedRoleIds },
+        operation: async () => {
+          // optimistic-lock-exempt: creates a new portal invitation, not a concurrent record edit
+          const call = await apiCall<{ ok: boolean; error?: string }>(
+            '/api/customer_accounts/admin/users-invite',
+            {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                email: trimmedEmail,
+                roleIds: selectedRoleIds,
+                displayName: displayName.trim() || undefined,
+                customerEntityId: personEntityId,
+              }),
+            },
+          )
+
+          if (!call.ok) {
+            const errorMessage = (call.result as Record<string, unknown> | null)?.error as string | undefined
+            flash(errorMessage || t('customer_accounts.widgets.invite.error.failed', 'Failed to send invitation'), 'error')
+            return
+          }
+
+          flash(t('customer_accounts.widgets.invite.success', 'Invitation sent successfully'), 'success')
+          onSuccess()
         },
-      )
-
-      if (!call.ok) {
-        const errorMessage = (call.result as Record<string, unknown> | null)?.error as string | undefined
-        flash(errorMessage || t('customer_accounts.widgets.invite.error.failed', 'Failed to send invitation'), 'error')
-        return
-      }
-
-      flash(t('customer_accounts.widgets.invite.success', 'Invitation sent successfully'), 'success')
-      onSuccess()
+      })
     } catch {
       flash(t('customer_accounts.widgets.invite.error.failed', 'Failed to send invitation'), 'error')
     } finally {


### PR DESCRIPTION
Fixes #3195

## Problem
A few `customer_accounts` backend/injected UI write paths called `apiCall` directly instead of routing through `useGuardedMutation`, bypassing the shared mutation injection lifecycle used for record locks, conflict UI, and global write guards on non-`CrudForm` actions.

## Root Cause
- `backend/customer_accounts/roles/page.tsx` deleted roles with `withScopedApiRequestHeaders(... apiCall(... DELETE ...))` but did not wrap it in `useGuardedMutation`.
- `widgets/injection/account-status/widget.client.tsx` posted invitations to `/api/customer_accounts/admin/users-invite` directly from the injected widget.

Both surfaces are not `CrudForm` hosts, so the guard must be wired by hand (as the sibling domain-settings page and users list already do).

## What Changed
- Roles list row delete now calls `runMutation` around the scoped `DELETE`, keeping optimistic-lock conflict handling (`buildOptimisticLockHeader`) intact. `contextId: customer_accounts:roles-list`, `context.entityType: customer_accounts:role`.
- Account-status injection invite form now calls `runMutation` around the invite `POST` with `context.entityType: customer_accounts:user` and a mutation payload so global hooks can classify the write. The POST is a create, so it carries an inline `optimistic-lock-exempt` note.

## Tests
- New component test `widgets/injection/account-status/__tests__/widget.client.test.tsx` asserts the invite POST routes through `useGuardedMutation.runMutation` with the expected context/payload and still issues the POST.
- New source-coverage guard `__tests__/guarded-mutation-coverage.test.ts` fails if either non-`CrudForm` write file drops the `useGuardedMutation` wiring.
- Full `@open-mercato/core` suite green (742 suites / 6058 tests); `optimistic-lock-ui-coverage` guard still passes; full `yarn typecheck` and `yarn i18n:check-sync` pass.

## Backward Compatibility
- No contract surface changes (UI internals only; no API/event/widget-spot/DI/ACL/import-path changes). No new user-facing strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)