### PR TITLE
fix(customer_accounts): guard role ACL updates with optimistic locking and mutation guard (#3194)

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/admin/roles/[id]/__tests__/acl.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/roles/[id]/__tests__/acl.test.ts
@@ -1,0 +1,175 @@
+/** @jest-environment node */
+
+/**
+ * Optimistic-lock + mutation-guard coverage for the customer role ACL route (#3194).
+ *
+ * The ACL `PUT` mutates customer-portal permissions for the role aggregate. It
+ * must guard against stale overwrites (two admins editing the same role) with
+ * the same structured 409 the role route returns, run the generic mutation
+ * guard before/after the write, bump the role's `updatedAt` so a stale role-edit
+ * screen cannot save old permission arrays, and invalidate the RBAC cache.
+ */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const roleId = '44444444-4444-4444-8444-444444444444'
+const aclRowId = '55555555-5555-4555-8555-555555555555'
+
+const CURRENT_VERSION = '2026-06-18T08:42:20.999Z'
+const STALE_VERSION = '2026-06-18T08:42:18.123Z'
+
+import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+
+class CustomerRoleStub {}
+class CustomerRoleAclStub {}
+
+const em = {
+  findOne: jest.fn(),
+  nativeUpdate: jest.fn(async () => 1),
+  create: jest.fn((_entity: unknown, data: Record<string, unknown>) => ({ id: aclRowId, ...data })),
+  persist: jest.fn(),
+  flush: jest.fn(async () => undefined),
+}
+
+const rbacService = {
+  userHasAllFeatures: jest.fn(async () => true),
+}
+
+const invalidateRoleCacheMock = jest.fn(async () => undefined)
+const customerRbacService = {
+  invalidateRoleCache: invalidateRoleCacheMock,
+}
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'rbacService') return rbacService
+    if (name === 'customerRbacService') return customerRbacService
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const validateCrudMutationGuardMock = jest.fn(async () => null as unknown)
+const runCrudMutationGuardAfterSuccessMock = jest.fn(async () => undefined)
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: userId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/data/entities', () => ({
+  CustomerRole: CustomerRoleStub,
+  CustomerRoleAcl: CustomerRoleAclStub,
+}))
+
+jest.mock('@open-mercato/core/modules/auth/services/rbacService', () => ({ RbacService: class {} }))
+jest.mock('@open-mercato/core/modules/customer_accounts/services/customerRbacService', () => ({ CustomerRbacService: class {} }))
+
+import { PUT } from '../acl'
+
+function makeRequest(features: string[], expectedVersion: string | null): Request {
+  const headers = new Headers({ 'content-type': 'application/json' })
+  if (expectedVersion != null) headers.set(OPTIMISTIC_LOCK_HEADER_NAME, expectedVersion)
+  return new Request(`https://example.test/api/customer_accounts/admin/roles/${roleId}/acl`, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify({ features }),
+  })
+}
+
+describe('customer role ACL PUT — optimistic locking + mutation guard (#3194)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.OM_OPTIMISTIC_LOCK = 'all'
+    em.findOne.mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerRoleStub) {
+        return { id: roleId, tenantId, updatedAt: new Date(CURRENT_VERSION), name: 'Buyer' }
+      }
+      if (entity === CustomerRoleAclStub) {
+        return { id: aclRowId, tenantId, featuresJson: ['portal.profile.view'], isPortalAdmin: false }
+      }
+      return null
+    })
+    validateCrudMutationGuardMock.mockResolvedValue(null)
+  })
+
+  afterAll(() => {
+    delete process.env.OM_OPTIMISTIC_LOCK
+  })
+
+  it('returns the structured 409 conflict body when the expected version is stale', async () => {
+    const res = await PUT(makeRequest(['portal.orders.view'], STALE_VERSION), { params: { id: roleId } })
+    expect(res.status).toBe(409)
+    const body = await res.json()
+    expect(body.code).toBe('optimistic_lock_conflict')
+    expect(body.currentUpdatedAt).toBe(CURRENT_VERSION)
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+    expect(invalidateRoleCacheMock).not.toHaveBeenCalled()
+  })
+
+  it('writes the ACL, bumps the role version, invalidates the cache, and returns the new updatedAt on a matching version', async () => {
+    const res = await PUT(makeRequest(['portal.orders.view'], CURRENT_VERSION), { params: { id: roleId } })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(typeof body.updatedAt).toBe('string')
+    expect(body.updatedAt).not.toBe(CURRENT_VERSION)
+
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      CustomerRoleAclStub,
+      { id: aclRowId },
+      expect.objectContaining({ featuresJson: ['portal.orders.view'] }),
+    )
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      CustomerRoleStub,
+      { id: roleId },
+      expect.objectContaining({ updatedAt: expect.any(Date) }),
+    )
+    expect(invalidateRoleCacheMock).toHaveBeenCalledWith(roleId)
+  })
+
+  it('succeeds without a version header (strictly additive — plain API consumers keep working)', async () => {
+    const res = await PUT(makeRequest(['portal.orders.view'], null), { params: { id: roleId } })
+    expect(res.status).toBe(200)
+    expect(invalidateRoleCacheMock).toHaveBeenCalledWith(roleId)
+  })
+
+  it('blocks the write when the generic mutation guard rejects it', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+    const res = await PUT(makeRequest(['portal.orders.view'], CURRENT_VERSION), { params: { id: roleId } })
+    expect(res.status).toBe(423)
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+    expect(invalidateRoleCacheMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the mutation-guard after-success hook when the guard requests it', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: true, shouldRunAfterSuccess: true, metadata: { trace: 'x' } })
+    const res = await PUT(makeRequest(['portal.orders.view'], CURRENT_VERSION), { params: { id: roleId } })
+    expect(res.status).toBe(200)
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        resourceKind: 'customer_accounts.role',
+        resourceId: roleId,
+        operation: 'update',
+        metadata: { trace: 'x' },
+      }),
+    )
+  })
+
+  it('returns 404 when the role does not exist', async () => {
+    em.findOne.mockImplementation(async () => null)
+    const res = await PUT(makeRequest(['portal.orders.view'], CURRENT_VERSION), { params: { id: roleId } })
+    expect(res.status).toBe(404)
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/admin/roles/[id]/acl.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/roles/[id]/acl.ts
@@ -7,18 +7,27 @@ import { RbacService } from '@open-mercato/core/modules/auth/services/rbacServic
 import { CustomerRole, CustomerRoleAcl } from '@open-mercato/core/modules/customer_accounts/data/entities'
 import { CustomerRbacService } from '@open-mercato/core/modules/customer_accounts/services/customerRbacService'
 import { updateRoleAclSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
+import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 
 export const metadata = {}
 
+const ROLE_RESOURCE_KIND = 'customer_accounts.role'
+
 export async function PUT(req: Request, { params }: { params: { id: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth) {
+  if (!auth || !auth.tenantId) {
     return NextResponse.json({ ok: false, error: 'Authentication required' }, { status: 401 })
   }
+  const tenantId = auth.tenantId
 
   const container = await createRequestContainer()
   const rbacService = container.resolve('rbacService') as RbacService
-  const hasAccess = await rbacService.userHasAllFeatures(auth.sub, ['customer_accounts.roles.manage'], { tenantId: auth.tenantId, organizationId: auth.orgId })
+  const hasAccess = await rbacService.userHasAllFeatures(auth.sub, ['customer_accounts.roles.manage'], { tenantId, organizationId: auth.orgId })
   if (!hasAccess) {
     return NextResponse.json({ ok: false, error: 'Insufficient permissions' }, { status: 403 })
   }
@@ -39,16 +48,48 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
 
   const role = await em.findOne(CustomerRole, {
     id: params.id,
-    tenantId: auth.tenantId,
+    tenantId,
     deletedAt: null,
   })
   if (!role) {
     return NextResponse.json({ ok: false, error: 'Role not found' }, { status: 404 })
   }
 
+  // The ACL is part of the role aggregate: the role-edit screen loads and saves
+  // the role and its permissions together. Guard the write against the parent
+  // role's `updatedAt` so two admins editing the same role cannot silently
+  // overwrite each other's permission changes (#3194). Strictly additive — when
+  // the client sends no expected-version header the helper is a no-op.
+  try {
+    enforceCommandOptimisticLock({
+      resourceKind: ROLE_RESOURCE_KIND,
+      resourceId: role.id,
+      current: role.updatedAt ?? null,
+      request: req,
+    })
+  } catch (err) {
+    if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
+    throw err
+  }
+
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId,
+    organizationId: auth.orgId,
+    userId: auth.sub,
+    resourceKind: ROLE_RESOURCE_KIND,
+    resourceId: role.id,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: parsed.data,
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
   const acl = await em.findOne(CustomerRoleAcl, {
     role: role.id as any,
-    tenantId: auth.tenantId,
+    tenantId,
   })
 
   if (acl) {
@@ -59,7 +100,7 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
   } else {
     const newAcl = em.create(CustomerRoleAcl, {
       role,
-      tenantId: auth.tenantId,
+      tenantId,
       featuresJson: parsed.data.features,
       isPortalAdmin: parsed.data.isPortalAdmin ?? false,
       createdAt: new Date(),
@@ -68,13 +109,33 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
     await em.flush()
   }
 
+  // Bump the aggregate version so a stale role-edit screen (which holds the role's
+  // pre-edit `updatedAt`) cannot save old permission arrays afterwards. `nativeUpdate`
+  // bypasses MikroORM's `onUpdate` hook, so set it explicitly.
+  const nextUpdatedAt = new Date()
+  await em.nativeUpdate(CustomerRole, { id: role.id }, { updatedAt: nextUpdatedAt })
+
   const customerRbacService = container.resolve('customerRbacService') as CustomerRbacService
   await customerRbacService.invalidateRoleCache(role.id)
 
-  return NextResponse.json({ ok: true })
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId,
+      organizationId: auth.orgId,
+      userId: auth.sub,
+      resourceKind: ROLE_RESOURCE_KIND,
+      resourceId: role.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
+
+  return NextResponse.json({ ok: true, updatedAt: nextUpdatedAt.toISOString() })
 }
 
-const successSchema = z.object({ ok: z.literal(true) })
+const successSchema = z.object({ ok: z.literal(true), updatedAt: z.string().datetime() })
 const errorSchema = z.object({ ok: z.literal(false), error: z.string() })
 
 const methodDoc: OpenApiMethodDoc = {
@@ -88,6 +149,7 @@ const methodDoc: OpenApiMethodDoc = {
     { status: 401, description: 'Not authenticated', schema: errorSchema },
     { status: 403, description: 'Insufficient permissions', schema: errorSchema },
     { status: 404, description: 'Role not found', schema: errorSchema },
+    { status: 409, description: 'Stale ACL write (optimistic-lock conflict)', schema: errorSchema },
   ],
 }
 

--- a/packages/core/src/modules/customer_accounts/backend/customer_accounts/roles/[id]/page.tsx
+++ b/packages/core/src/modules/customer_accounts/backend/customer_accounts/roles/[id]/page.tsx
@@ -273,15 +273,23 @@ export default function CustomerRoleDetailPage({ params }: { params?: { id?: str
       return
     }
     const features = Array.isArray(values.features) ? values.features : []
-    const aclCall = await apiCall(
-      `/api/customer_accounts/admin/roles/${encodeURIComponent(id)}/acl`,
-      {
-        method: 'PUT',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ features }),
-      },
-    )
+    // The role PUT just bumped the aggregate's `updatedAt`; the ACL write guards
+    // the SAME role aggregate, so send its NEW version (not the stale pre-edit one)
+    // to avoid a false 409 while still blocking a concurrent overwrite (#3194).
+    const roleResult = (roleCall.result ?? null) as { updatedAt?: string | null } | null
+    const aclHeaders = buildOptimisticLockHeader(roleResult?.updatedAt ?? data?.updatedAt ?? data?.updated_at ?? null)
+    const aclCall = await withScopedApiRequestHeaders(aclHeaders, () => (
+      apiCall(
+        `/api/customer_accounts/admin/roles/${encodeURIComponent(id)}/acl`,
+        {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ features }),
+        },
+      )
+    ))
     if (!aclCall.ok) {
+      if (surfaceRecordConflict({ status: aclCall.status, body: aclCall.result }, t)) return
       flash(t('customer_accounts.admin.roleDetail.error.saveAcl', 'Failed to save permissions'), 'error')
       return
     }


### PR DESCRIPTION
Fixes #3194

## Problem
`PUT /api/customer_accounts/admin/roles/[id]/acl` updated customer-portal permissions directly, with no optimistic-lock command guard and no generic mutation-guard contract. Two admins editing the same role could silently overwrite each other's permission changes, and global mutation injections could neither observe nor block the ACL write. The sibling role `PUT` path was already protected, so the ACL sub-route was the inconsistent gap.

## Root Cause
The ACL handler loaded the role, then wrote `CustomerRoleAcl` (and the new-row case) without `enforceCommandOptimisticLock`, `validateCrudMutationGuard`, or `runCrudMutationGuardAfterSuccess`, and never advanced any aggregate version — so a stale role-edit screen's later ACL save was always accepted.

## What Changed
- `api/admin/roles/[id]/acl.ts`: treat the role as the aggregate root.
  - Enforce the command-level optimistic lock against the parent role's `updatedAt` (structured 409 conflict body on mismatch; strictly additive — no header => no-op).
  - Run `validateCrudMutationGuard` before the write and `runCrudMutationGuardAfterSuccess` after a successful write when the guard requests it.
  - Bump the role's `updatedAt` after the ACL write so a stale role-edit screen cannot save old permission arrays; return the new `updatedAt`.
  - Keep the existing RBAC cache invalidation (`invalidateRoleCache`).
- `backend/.../roles/[id]/page.tsx`: the role-edit form's `onSubmit` now sends the role PUT's newly-bumped `updatedAt` as the ACL call's expected-version header (per-child override) to avoid a false 409, and surfaces a real ACL conflict through the unified conflict bar (`surfaceRecordConflict`).

## Tests
- New `api/admin/roles/[id]/__tests__/acl.test.ts` (6 cases): stale write returns the structured `optimistic_lock_conflict` 409 (no mutation, no cache invalidation); matching version writes the ACL, bumps the role version, invalidates the cache, and returns a new `updatedAt`; no-header write still succeeds (additive); mutation-guard rejection blocks the write; after-success hook runs when requested; 404 when the role is absent.
- Existing `customer_accounts` suite (40 suites / 323 tests) and the `optimistic-lock-ui-coverage` guard pass.
- Full `yarn typecheck` green; `yarn i18n:check-sync` in sync.

## Backward Compatibility
No contract surface removed. Additive only: success response gains `updatedAt`, a new 409 status is documented, and the lock/guard are no-ops when the client sends no expected-version header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)