### PR TITLE
fix(customers): replace raw detail and config controls with shared UI primitives (#3204)

### DIFF
--- a/packages/core/src/modules/customers/backend/config/customers/pipeline-stages/__tests__/page.test.tsx
+++ b/packages/core/src/modules/customers/backend/config/customers/pipeline-stages/__tests__/page.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import PipelineStagesPage from '../page'
+
+const apiCallMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+  withScopedApiRequestHeaders: (_header: unknown, run: () => unknown) => run(),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+describe('PipelineStagesPage controls', () => {
+  beforeEach(() => {
+    apiCallMock.mockReset()
+    apiCallMock.mockImplementation((url: string) => {
+      if (url === '/api/customers/pipelines') {
+        return Promise.resolve({
+          ok: true,
+          result: { items: [{ id: 'pipeline-1', name: 'Sales', isDefault: true, updatedAt: '2026-06-01T00:00:00.000Z' }] },
+        })
+      }
+      if (url.startsWith('/api/customers/pipeline-stages')) {
+        return Promise.resolve({
+          ok: true,
+          result: {
+            items: [
+              { id: 'stage-1', pipelineId: 'pipeline-1', label: 'Qualification', order: 0, color: null, icon: null },
+              { id: 'stage-2', pipelineId: 'pipeline-1', label: 'Proposal', order: 1, color: null, icon: null },
+            ],
+          },
+        })
+      }
+      return Promise.resolve({ ok: true, result: { items: [] } })
+    })
+  })
+
+  it('renders stage reorder controls through the shared IconButton primitive (no raw <button>)', async () => {
+    await act(async () => {
+      renderWithProviders(<PipelineStagesPage />)
+    })
+
+    await waitFor(() => expect(screen.getByText('Qualification')).toBeInTheDocument())
+
+    const moveUpButtons = screen.getAllByRole('button', { name: 'Move up' })
+    const moveDownButtons = screen.getAllByRole('button', { name: 'Move down' })
+    expect(moveUpButtons.length).toBe(2)
+    expect(moveDownButtons.length).toBe(2)
+    moveUpButtons.forEach((node) => expect(node).toHaveAttribute('data-slot', 'icon-button'))
+    moveDownButtons.forEach((node) => expect(node).toHaveAttribute('data-slot', 'icon-button'))
+
+    // First stage can't move up; last stage can't move down.
+    expect(moveUpButtons[0]).toBeDisabled()
+    expect(moveDownButtons[1]).toBeDisabled()
+  })
+
+  it('renders the default-pipeline toggle as a shared Checkbox primitive (no raw checkbox input)', async () => {
+    await act(async () => {
+      renderWithProviders(<PipelineStagesPage />)
+    })
+
+    await waitFor(() => expect(screen.getByText('Qualification')).toBeInTheDocument())
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '+ Add pipeline' }))
+    })
+
+    await waitFor(() => expect(screen.getByText('Set as default pipeline')).toBeInTheDocument())
+    const checkbox = screen.getByRole('checkbox')
+    expect(checkbox).toHaveAttribute('id', 'pipeline-is-default')
+  })
+})

--- a/packages/core/src/modules/customers/backend/config/customers/pipeline-stages/page.tsx
+++ b/packages/core/src/modules/customers/backend/config/customers/pipeline-stages/page.tsx
@@ -1,12 +1,15 @@
 'use client'
 
 import * as React from 'react'
+import { ChevronDown, ChevronUp } from 'lucide-react'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { Button } from '@open-mercato/ui/primitives/button'
+import { Checkbox } from '@open-mercato/ui/primitives/checkbox'
+import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import { Input } from '@open-mercato/ui/primitives/input'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@open-mercato/ui/primitives/dialog'
 import {
@@ -409,24 +412,28 @@ export default function PipelineStagesPage() {
                       {stages.map((stage, index) => (
                         <div key={stage.id} className="flex items-center gap-3 px-4 py-3">
                           <div className="flex flex-col gap-1">
-                            <button
+                            <IconButton
                               type="button"
-                              className="text-muted-foreground hover:text-foreground disabled:opacity-50"
+                              variant="ghost"
+                              size="xs"
+                              className="text-muted-foreground hover:text-foreground"
                               onClick={() => moveStage(index, 'up')}
                               disabled={index === 0}
                               aria-label={t('customers.config.pipelineStages.moveUp', 'Move up')}
                             >
-                              ↑
-                            </button>
-                            <button
+                              <ChevronUp className="size-4" />
+                            </IconButton>
+                            <IconButton
                               type="button"
-                              className="text-muted-foreground hover:text-foreground disabled:opacity-50"
+                              variant="ghost"
+                              size="xs"
+                              className="text-muted-foreground hover:text-foreground"
                               onClick={() => moveStage(index, 'down')}
                               disabled={index === stages.length - 1}
                               aria-label={t('customers.config.pipelineStages.moveDown', 'Move down')}
                             >
-                              ↓
-                            </button>
+                              <ChevronDown className="size-4" />
+                            </IconButton>
                           </div>
                           <span className="flex-1 text-sm flex items-center gap-2">
                             {stage.color ? renderDictionaryColor(stage.color) : null}
@@ -476,11 +483,11 @@ export default function PipelineStagesPage() {
                   autoFocus
                 />
               </div>
-              <label className="flex items-center gap-2 text-sm cursor-pointer">
-                <input
-                  type="checkbox"
+              <label htmlFor="pipeline-is-default" className="flex items-center gap-2 text-sm cursor-pointer">
+                <Checkbox
+                  id="pipeline-is-default"
                   checked={pipelineIsDefault}
-                  onChange={(e) => setPipelineIsDefault(e.target.checked)}
+                  onCheckedChange={(checked) => setPipelineIsDefault(checked === true)}
                 />
                 {t('customers.config.pipelineStages.setAsDefault', 'Set as default pipeline')}
               </label>

--- a/packages/core/src/modules/customers/components/detail/ActivitiesAddNewMenu.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivitiesAddNewMenu.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { Check, Phone, Mail, Users, CheckSquare } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { Button } from '@open-mercato/ui/primitives/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@open-mercato/ui/primitives/popover'
 
 export type ActivityKind = 'meeting' | 'call' | 'task' | 'email'
@@ -34,28 +35,29 @@ export function ActivitiesAddNewMenu({ onSelect, disabled }: ActivitiesAddNewMen
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <button
+        <Button
           type="button"
           disabled={disabled}
           aria-label={t('customers.activities.addNew', 'Add new')}
-          className="inline-flex items-center gap-1.5 overflow-hidden rounded-md bg-foreground pl-3 pr-3.5 py-2 text-xs font-semibold text-background transition-colors hover:bg-foreground/90 disabled:opacity-60"
+          className="gap-1.5 overflow-hidden rounded-md bg-foreground pl-3 pr-3.5 py-2 text-xs font-semibold text-background hover:bg-foreground/90 disabled:opacity-60"
         >
           <Check className="size-3.5" />
           {t('customers.activities.addNew', 'Add new')}
-        </button>
+        </Button>
       </PopoverTrigger>
       <PopoverContent align="end" className="w-[180px] p-1">
         <ul className="flex flex-col">
           {MENU_ITEMS.map(({ kind, icon: Icon, key, fallback }) => (
             <li key={kind}>
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 onClick={() => handleSelect(kind)}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-accent/40"
+                className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-sm font-normal text-foreground hover:bg-accent/40"
               >
                 <Icon className="size-4 text-muted-foreground" />
                 {t(key, fallback)}
-              </button>
+              </Button>
             </li>
           ))}
         </ul>

--- a/packages/core/src/modules/customers/components/detail/AiActionChips.tsx
+++ b/packages/core/src/modules/customers/components/detail/AiActionChips.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { AiIcon } from '@open-mercato/ui/ai/AiIcon'
+import { Button } from '@open-mercato/ui/primitives/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@open-mercato/ui/primitives/tooltip'
 import { AI_TIMELINE_ACTIONS_BY_TYPE, resolveAiActions } from './aiActionCatalog'
 
@@ -23,13 +24,15 @@ export function AiActionChips({ activityType }: AiActionChipsProps) {
         {actions.map((action) => (
           <Tooltip key={action.key}>
             <TooltipTrigger asChild>
-              <button
+              <Button
                 type="button"
-                className="inline-flex items-center gap-1 rounded-[4px] border border-dashed border-border bg-card pl-1.5 pr-[7px] py-[3px] text-[9px] font-medium text-muted-foreground/70 transition-colors hover:border-muted-foreground hover:text-foreground"
+                variant="outline"
+                size="sm"
+                className="h-auto gap-1 rounded-[4px] border-dashed bg-card pl-1.5 pr-[7px] py-[3px] text-[9px] font-medium text-muted-foreground/70 shadow-none hover:border-muted-foreground hover:text-foreground"
               >
                 <AiIcon className="size-2.5 shrink-0" />
                 {t(action.i18nKey, action.fallback)}
-              </button>
+              </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom" className="text-xs">
               {t('customers.ai.comingSoon', 'Coming soon')}

--- a/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesAddNewMenu.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesAddNewMenu.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { ActivitiesAddNewMenu } from '../ActivitiesAddNewMenu'
+
+describe('ActivitiesAddNewMenu', () => {
+  it('renders the trigger and menu options through the shared Button primitive (no raw <button>)', async () => {
+    await act(async () => {
+      renderWithProviders(<ActivitiesAddNewMenu onSelect={jest.fn()} />)
+    })
+
+    const trigger = screen.getByRole('button', { name: 'Add new' })
+    expect(trigger).toHaveAttribute('data-slot', 'button')
+
+    await act(async () => {
+      fireEvent.click(trigger)
+    })
+
+    await waitFor(() => expect(screen.getByText('New meeting')).toBeInTheDocument())
+    const optionButtons = screen
+      .getAllByRole('button')
+      .filter((node) => node.getAttribute('data-slot') === 'button')
+    expect(optionButtons.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('invokes onSelect with the chosen activity kind and closes the menu', async () => {
+    const onSelect = jest.fn()
+    await act(async () => {
+      renderWithProviders(<ActivitiesAddNewMenu onSelect={onSelect} />)
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Add new' }))
+    })
+    await waitFor(() => expect(screen.getByText('Log call')).toBeInTheDocument())
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Log call'))
+    })
+
+    expect(onSelect).toHaveBeenCalledWith('call')
+  })
+
+  it('disables the trigger when disabled', async () => {
+    await act(async () => {
+      renderWithProviders(<ActivitiesAddNewMenu onSelect={jest.fn()} disabled />)
+    })
+    expect(screen.getByRole('button', { name: 'Add new' })).toBeDisabled()
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/__tests__/AiActionChips.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/AiActionChips.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { act, screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { AiActionChips } from '../AiActionChips'
+import { AI_TIMELINE_ACTIONS_BY_TYPE, resolveAiActions } from '../aiActionCatalog'
+
+describe('AiActionChips', () => {
+  it('renders each action chip through the shared Button primitive (no raw <button>)', async () => {
+    const expectedActions = resolveAiActions('meeting', AI_TIMELINE_ACTIONS_BY_TYPE)
+    expect(expectedActions.length).toBeGreaterThan(0)
+
+    await act(async () => {
+      renderWithProviders(<AiActionChips activityType="meeting" />)
+    })
+
+    const chipButtons = screen
+      .getAllByRole('button')
+      .filter((node) => node.getAttribute('data-slot') === 'button')
+    expect(chipButtons.length).toBe(expectedActions.length)
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/schedule/ParticipantsField.tsx
+++ b/packages/core/src/modules/customers/components/detail/schedule/ParticipantsField.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import * as React from 'react'
-import { Users, Search, X, Clock, CheckCircle2, XCircle } from 'lucide-react'
+import { Users, X, Clock, CheckCircle2, XCircle } from 'lucide-react'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
+import { Checkbox } from '@open-mercato/ui/primitives/checkbox'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import { Popover, PopoverContent, PopoverTrigger } from '@open-mercato/ui/primitives/popover'
+import { SearchInput } from '@open-mercato/ui/primitives/search-input'
 import { fetchAssignableStaffMembersPage } from '../assignableStaff'
 import type { ActivityType, ScheduleFieldId } from './fieldConfig'
 import { isVisible, getFieldLabel } from './fieldConfig'
@@ -84,17 +86,13 @@ function ParticipantSearchPopover({
         </Button>
       </PopoverTrigger>
       <PopoverContent align="start" className="w-72 p-2">
-        <div className="flex items-center gap-2 rounded-md border bg-background px-2 py-1.5 mb-2">
-          <Search className="size-3.5 text-muted-foreground shrink-0" />
-          <input
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder={t('customers.schedule.searchParticipant', 'Search team members...')}
-            className="flex-1 bg-transparent text-sm focus:outline-none"
-            autoFocus
-          />
-        </div>
+        <SearchInput
+          value={query}
+          onChange={setQuery}
+          placeholder={t('customers.schedule.searchParticipant', 'Search team members...')}
+          className="mb-2"
+          autoFocus
+        />
         {selectableResults.length ? (
           <div className="mb-2">
             <Button
@@ -228,16 +226,16 @@ export function ParticipantsField({
       {participants.length > 0 && (
         <div className="mt-3 flex flex-wrap items-center gap-x-[16px] gap-y-[6px] text-xs">
           <span className="font-medium text-muted-foreground">{t('customers.schedule.guestPermissions', 'Guest permissions:')}</span>
-          <label className="flex items-center gap-1.5 cursor-pointer">
-            <input type="checkbox" checked={guestPermissions.canInviteOthers} onChange={(e) => setGuestPermissions((p) => ({ ...p, canInviteOthers: e.target.checked }))} className="rounded" />
+          <label htmlFor="guest-perm-invite" className="flex items-center gap-1.5 cursor-pointer">
+            <Checkbox id="guest-perm-invite" checked={guestPermissions.canInviteOthers} onCheckedChange={(checked) => setGuestPermissions((p) => ({ ...p, canInviteOthers: checked === true }))} />
             {t('customers.schedule.guestPerm.invite', 'Invite others')}
           </label>
-          <label className="flex items-center gap-1.5 cursor-pointer">
-            <input type="checkbox" checked={guestPermissions.canModify} onChange={(e) => setGuestPermissions((p) => ({ ...p, canModify: e.target.checked }))} className="rounded" />
+          <label htmlFor="guest-perm-modify" className="flex items-center gap-1.5 cursor-pointer">
+            <Checkbox id="guest-perm-modify" checked={guestPermissions.canModify} onCheckedChange={(checked) => setGuestPermissions((p) => ({ ...p, canModify: checked === true }))} />
             {t('customers.schedule.guestPerm.modify', 'Modify')}
           </label>
-          <label className="flex items-center gap-1.5 cursor-pointer">
-            <input type="checkbox" checked={guestPermissions.canSeeList} onChange={(e) => setGuestPermissions((p) => ({ ...p, canSeeList: e.target.checked }))} className="rounded" />
+          <label htmlFor="guest-perm-see-list" className="flex items-center gap-1.5 cursor-pointer">
+            <Checkbox id="guest-perm-see-list" checked={guestPermissions.canSeeList} onCheckedChange={(checked) => setGuestPermissions((p) => ({ ...p, canSeeList: checked === true }))} />
             {t('customers.schedule.guestPerm.seeList', 'See list')}
           </label>
         </div>

--- a/packages/core/src/modules/customers/components/detail/schedule/__tests__/ParticipantsField.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/schedule/__tests__/ParticipantsField.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { ParticipantsField } from '../ParticipantsField'
+import type { Participant } from '../useScheduleFormState'
+
+jest.mock('../../assignableStaff', () => ({
+  fetchAssignableStaffMembersPage: jest.fn().mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 20 }),
+}))
+
+const baseGuestPermissions = { canInviteOthers: false, canModify: false, canSeeList: false }
+
+function renderField(overrides?: {
+  participants?: Participant[]
+  setGuestPermissions?: jest.Mock
+  guestPermissions?: typeof baseGuestPermissions
+}) {
+  const setGuestPermissions = overrides?.setGuestPermissions ?? jest.fn()
+  renderWithProviders(
+    <ParticipantsField
+      visible={new Set(['participants'])}
+      activityType="meeting"
+      participants={overrides?.participants ?? []}
+      setParticipants={jest.fn()}
+      removeParticipant={jest.fn()}
+      guestPermissions={overrides?.guestPermissions ?? baseGuestPermissions}
+      setGuestPermissions={setGuestPermissions}
+    />,
+  )
+  return { setGuestPermissions }
+}
+
+const sampleParticipant: Participant = {
+  userId: 'user-1',
+  name: 'Jan Kowalski',
+  email: 'jan@example.com',
+  color: 'bg-primary',
+  status: 'pending',
+}
+
+describe('ParticipantsField', () => {
+  it('renders the participant search through the shared SearchInput primitive (no raw <input>)', async () => {
+    await act(async () => {
+      renderField()
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Add participant' }))
+    })
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('Search team members...')).toBeInTheDocument(),
+    )
+    const searchInput = screen.getByPlaceholderText('Search team members...')
+    expect(searchInput).toHaveAttribute('type', 'search')
+  })
+
+  it('renders guest-permission toggles as shared Checkbox primitives and reports changes', async () => {
+    const setGuestPermissions = jest.fn()
+    await act(async () => {
+      renderField({ participants: [sampleParticipant], setGuestPermissions })
+    })
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes.length).toBe(3)
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Invite others'))
+    })
+
+    expect(setGuestPermissions).toHaveBeenCalledTimes(1)
+    const updater = setGuestPermissions.mock.calls[0][0] as (prev: typeof baseGuestPermissions) => typeof baseGuestPermissions
+    expect(updater(baseGuestPermissions)).toEqual({ ...baseGuestPermissions, canInviteOthers: true })
+  })
+})


### PR DESCRIPTION
Fixes #3204

## Problem
Several customers detail/config surfaces rendered raw HTML controls (`<button>`, `<input type="checkbox">`, a raw search input) instead of the shared `@open-mercato/ui` primitives required by the backend UI guidance. Because `customers` is the reference CRUD module, these raw controls make the local patterns harder to trust for new module work, and they miss the accessibility/styling contract the primitives provide.

## Root Cause
These components predate (or skipped) the shared-primitive rule in `packages/ui/AGENTS.md` / `packages/ui/src/backend/AGENTS.md` ("never use raw `<button>`, raw checkbox inputs"). They hand-rolled markup instead of using `Button`/`IconButton`/`Checkbox`/`SearchInput`.

## What Changed
Focused, behavior-preserving swaps to shared primitives (same callbacks, layout, i18n keys, and aria-labels):

- **`backend/config/customers/pipeline-stages/page.tsx`**
  - Stage move-up/move-down controls → `IconButton` (ghost, `ChevronUp`/`ChevronDown` icons) instead of raw `<button>` with `↑`/`↓` glyphs.
  - Default-pipeline toggle → `Checkbox` (with `htmlFor`-linked label) instead of raw `<input type="checkbox">`.
- **`components/detail/ActivitiesAddNewMenu.tsx`** — popover trigger and menu options → `Button` (trigger keeps the dark pill styling; options use `variant="ghost"`).
- **`components/detail/schedule/ParticipantsField.tsx`** — participant search → `SearchInput`; guest-permission toggles → `Checkbox` (`onCheckedChange`, `htmlFor`-linked labels).
- **`components/detail/AiActionChips.tsx`** — tooltip chips → `Button` (`variant="outline"`, dashed override) instead of raw `<button>`.

## Tests
- `components/detail/__tests__/ActivitiesAddNewMenu.test.tsx` — trigger/options render via shared `Button` (`data-slot="button"`), `onSelect` fires with the chosen kind, disabled state honored.
- `components/detail/__tests__/AiActionChips.test.tsx` — every action chip renders via shared `Button`.
- `components/detail/schedule/__tests__/ParticipantsField.test.tsx` — search renders via `SearchInput` (`type="search"`); guest-permission toggles render via `Checkbox` (role=checkbox) and report changes.
- `backend/config/customers/pipeline-stages/__tests__/page.test.tsx` — reorder controls render via `IconButton` (`data-slot="icon-button"`) with correct disabled edges; default-pipeline toggle renders via `Checkbox`.

Checks run: core `typecheck` (clean), ESLint on changed files (clean), `i18n:check-sync` (in sync) + `i18n:check-usage` (advisory only), 8/8 new tests passing, packages build + generate.

## Backward Compatibility
No contract surface changes. No public component props, API routes, types, event/widget/ACL/DI identifiers, or DB schema touched — purely presentational primitive swaps in the customers module.