### PR TITLE
perf(customers): parallelize people and company detail API enrichment (#3203)

### DIFF
--- a/packages/core/src/modules/customers/api/companies/[id]/__tests__/route.parallel.test.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/__tests__/route.parallel.test.ts
@@ -1,0 +1,167 @@
+/** @jest-environment node */
+
+// Regression coverage for issue #3203: the company detail route must dispatch its
+// independent enrichment reads in parallel instead of awaiting them one after
+// another. The test makes findWithDecryption hang until two calls are in flight,
+// which can only resolve if the route started them concurrently.
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+const mockResolveCustomerInteractionFeatureFlags = jest.fn()
+const mockLoadCustomFieldValues = jest.fn()
+const mockResolveCompanyCustomFieldRouting = jest.fn()
+const mockMergeCompanyCustomFieldValues = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+
+const mockEm = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  count: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'queryEngine') return { query: jest.fn(async () => ({ items: [] })) }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScopeForRequest(args)),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScopeGuard', () => ({
+  isOrganizationReadAccessAllowed: jest.fn(() => true),
+}))
+
+jest.mock('../../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn((...args: unknown[]) => mockResolveCustomerInteractionFeatureFlags(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn((args: unknown) => mockLoadCustomFieldValues(args)),
+}))
+
+jest.mock('../../../../lib/customFieldRouting', () => ({
+  resolveCompanyCustomFieldRouting: jest.fn((...args: unknown[]) => mockResolveCompanyCustomFieldRouting(...args)),
+  mergeCompanyCustomFieldValues: jest.fn((...args: unknown[]) => mockMergeCompanyCustomFieldValues(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('../../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async () => []),
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    customers: {
+      customer_entity: 'customer_entity',
+      customer_company_profile: 'customer_company_profile',
+    },
+  },
+}), { virtual: true })
+
+const COMPANY_ID = '2408107d-0000-4000-8000-000000000020'
+
+function buildCompany() {
+  const createdAt = new Date('2026-04-10T08:00:00.000Z')
+  return {
+    id: COMPANY_ID,
+    kind: 'company',
+    deletedAt: null,
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    companyProfile: null,
+    displayName: 'Acme Corp',
+    description: null,
+    ownerUserId: null,
+    primaryEmail: null,
+    primaryPhone: null,
+    status: null,
+    lifecycleStage: null,
+    source: null,
+    nextInteractionAt: null,
+    nextInteractionName: null,
+    nextInteractionRefId: null,
+    nextInteractionIcon: null,
+    nextInteractionColor: null,
+    isActive: true,
+    temperature: null,
+    renewalQuarter: null,
+    createdAt,
+    updatedAt: createdAt,
+  }
+}
+
+describe('GET /api/customers/companies/[id] — parallel enrichment (issue #3203)', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    mockGetAuthFromRequest.mockReset()
+    mockResolveOrganizationScopeForRequest.mockReset()
+    mockResolveCustomerInteractionFeatureFlags.mockReset()
+    mockLoadCustomFieldValues.mockReset()
+    mockResolveCompanyCustomFieldRouting.mockReset()
+    mockMergeCompanyCustomFieldValues.mockReset()
+    mockFindWithDecryption.mockReset()
+    mockFindOneWithDecryption.mockReset()
+    mockEm.findOne.mockReset()
+    mockEm.find.mockReset()
+    mockEm.count.mockReset()
+    mockEm.count.mockResolvedValue(0)
+    mockContainer.resolve.mockClear()
+
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1', isApiKey: false })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({ filterIds: ['org-1'], selectedId: 'org-1', tenantId: 'tenant-1' })
+    mockResolveCustomerInteractionFeatureFlags.mockResolvedValue({ unified: false })
+    mockLoadCustomFieldValues.mockResolvedValue({})
+    mockResolveCompanyCustomFieldRouting.mockResolvedValue(new Map())
+    mockMergeCompanyCustomFieldValues.mockReturnValue({})
+    mockFindOneWithDecryption
+      .mockResolvedValueOnce(buildCompany())
+      .mockResolvedValue(null)
+    mockFindWithDecryption.mockResolvedValue([])
+  })
+
+  it('dispatches the independent tag/label/interaction reads concurrently', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    let releaseGate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve
+    })
+
+    mockFindWithDecryption.mockImplementation(async () => {
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      if (maxInFlight >= 2) releaseGate()
+      await gate
+      inFlight -= 1
+      return []
+    })
+
+    const { GET } = await import('../route')
+    const response = await GET(
+      new Request(`http://localhost/api/customers/companies/${COMPANY_ID}?include=comments,interactions`),
+      { params: { id: COMPANY_ID } },
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.company.id).toBe(COMPANY_ID)
+    expect(maxInFlight).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/core/src/modules/customers/api/companies/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/route.ts
@@ -414,102 +414,106 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
     userFeatures: undefined,
   })
 
-  const profile = company.companyProfile
-    ? await findOneWithDecryption(
-        em,
-        CustomerCompanyProfile,
-        {
-          id: company.companyProfile.id,
-          tenantId: company.tenantId,
-          organizationId: company.organizationId,
-        },
-        {},
-        companyScope,
-      )
-    : await findOneWithDecryption(
-        em,
-        CustomerCompanyProfile,
-        {
-          entity: company,
-          tenantId: company.tenantId,
-          organizationId: company.organizationId,
-        },
-        {},
-        companyScope,
-      )
-
-  const addresses = includeAddresses
-    ? await findWithDecryption(
-        em,
-        CustomerAddress,
-        {
-          entity: company.id,
-          tenantId: company.tenantId,
-          organizationId: company.organizationId,
-        },
-        { orderBy: { isPrimary: 'desc', createdAt: 'desc' } },
-        companyScope,
-      )
-    : []
-  const tagAssignments = await findWithDecryption(
-    em,
-    CustomerTagAssignment,
-    {
-      entity: company.id,
-      tenantId: company.tenantId,
-      organizationId: company.organizationId,
-    },
-    { populate: ['tag'] },
-    companyScope,
-  )
-  const labelAssignments = await findWithDecryption(
-    em,
-    CustomerLabelAssignment,
-    {
-      entity: company.id,
-      tenantId: company.tenantId,
-      organizationId: company.organizationId,
-    },
-    { populate: ['label'] },
-    companyScope,
-  )
-
-  const comments = includeComments
-    ? await findWithDecryption(
-        em,
-        CustomerComment,
-        {
-          entity: company.id,
-          tenantId: company.tenantId,
-          organizationId: company.organizationId,
-        },
-        { orderBy: { createdAt: 'desc' }, limit: 50 },
-        companyScope,
-      )
-    : []
   const shouldLoadCanonicalInteractions = includeInteractions || includeActivities || includeTodos
-  const canonicalInteractionRows = shouldLoadCanonicalInteractions
-    ? await findWithDecryption(
-        em,
-        CustomerInteraction,
-        interactionFlags.unified
-          ? {
-              entity: company.id,
-              tenantId: company.tenantId,
-              organizationId: company.organizationId,
-              deletedAt: null,
-              ...emailVisibilityFilter,
-            }
-          : {
-              entity: company.id,
-              tenantId: company.tenantId,
-              organizationId: company.organizationId,
-              ...emailVisibilityFilter,
-            },
-        { orderBy: { scheduledAt: 'asc', createdAt: 'desc' }, limit: 100 },
-        companyScope,
-      )
-    : []
+
+  // These reads only depend on the resolved company + scope + email visibility
+  // filter, so dispatch them together to avoid a server-side request waterfall
+  // before the detail surface can render (issue #3203).
+  const [profile, addresses, tagAssignments, labelAssignments, comments, canonicalInteractionRows] = await Promise.all([
+    company.companyProfile
+      ? findOneWithDecryption(
+          em,
+          CustomerCompanyProfile,
+          {
+            id: company.companyProfile.id,
+            tenantId: company.tenantId,
+            organizationId: company.organizationId,
+          },
+          {},
+          companyScope,
+        )
+      : findOneWithDecryption(
+          em,
+          CustomerCompanyProfile,
+          {
+            entity: company,
+            tenantId: company.tenantId,
+            organizationId: company.organizationId,
+          },
+          {},
+          companyScope,
+        ),
+    includeAddresses
+      ? findWithDecryption(
+          em,
+          CustomerAddress,
+          {
+            entity: company.id,
+            tenantId: company.tenantId,
+            organizationId: company.organizationId,
+          },
+          { orderBy: { isPrimary: 'desc', createdAt: 'desc' } },
+          companyScope,
+        )
+      : Promise.resolve<CustomerAddress[]>([]),
+    findWithDecryption(
+      em,
+      CustomerTagAssignment,
+      {
+        entity: company.id,
+        tenantId: company.tenantId,
+        organizationId: company.organizationId,
+      },
+      { populate: ['tag'] },
+      companyScope,
+    ),
+    findWithDecryption(
+      em,
+      CustomerLabelAssignment,
+      {
+        entity: company.id,
+        tenantId: company.tenantId,
+        organizationId: company.organizationId,
+      },
+      { populate: ['label'] },
+      companyScope,
+    ),
+    includeComments
+      ? findWithDecryption(
+          em,
+          CustomerComment,
+          {
+            entity: company.id,
+            tenantId: company.tenantId,
+            organizationId: company.organizationId,
+          },
+          { orderBy: { createdAt: 'desc' }, limit: 50 },
+          companyScope,
+        )
+      : Promise.resolve<CustomerComment[]>([]),
+    shouldLoadCanonicalInteractions
+      ? findWithDecryption(
+          em,
+          CustomerInteraction,
+          interactionFlags.unified
+            ? {
+                entity: company.id,
+                tenantId: company.tenantId,
+                organizationId: company.organizationId,
+                deletedAt: null,
+                ...emailVisibilityFilter,
+              }
+            : {
+                entity: company.id,
+                tenantId: company.tenantId,
+                organizationId: company.organizationId,
+                ...emailVisibilityFilter,
+              },
+          { orderBy: { scheduledAt: 'asc', createdAt: 'desc' }, limit: 100 },
+          companyScope,
+        )
+      : Promise.resolve<CustomerInteraction[]>([]),
+  ])
   const canonicalActiveInteractions = canonicalInteractionRows.filter((interaction) => !interaction.deletedAt)
   const canonicalInteractions = shouldLoadCanonicalInteractions
     ? await hydrateCanonicalInteractions({
@@ -775,32 +779,35 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
     relatedPeople = Array.from(relatedPeopleById.values())
   }
 
-  const entityCustomFieldValues = await loadCustomFieldValues({
-    em,
-    entityId: E.customers.customer_entity,
-    recordIds: [company.id],
-    tenantIdByRecord: { [company.id]: company.tenantId ?? null },
-    organizationIdByRecord: { [company.id]: company.organizationId ?? null },
-    tenantFallbacks: [
-      company.tenantId ?? auth.tenantId ?? null,
-    ].filter((v): v is string => !!v),
-  })
-  let profileCustomFieldValues: Record<string, Record<string, unknown>> = {}
+  // Entity custom fields, profile custom fields, and the routing lookup do not
+  // depend on each other (profileId is already resolved above), so load them in
+  // parallel instead of three sequential awaits (issue #3203).
   const profileId = profile?.id ?? null
-  if (profileId) {
-    profileCustomFieldValues = await loadCustomFieldValues({
+  const [entityCustomFieldValues, profileCustomFieldValues, routing] = await Promise.all([
+    loadCustomFieldValues({
       em,
-      entityId: E.customers.customer_company_profile,
-      recordIds: [profileId],
-      tenantIdByRecord: { [profileId]: profile?.tenantId ?? null },
-      organizationIdByRecord: { [profileId]: profile?.organizationId ?? null },
+      entityId: E.customers.customer_entity,
+      recordIds: [company.id],
+      tenantIdByRecord: { [company.id]: company.tenantId ?? null },
+      organizationIdByRecord: { [company.id]: company.organizationId ?? null },
       tenantFallbacks: [
-        profile?.tenantId ?? company.tenantId ?? auth.tenantId ?? null,
+        company.tenantId ?? auth.tenantId ?? null,
       ].filter((v): v is string => !!v),
-    })
-  }
-
-  const routing = await resolveCompanyCustomFieldRouting(em, company.tenantId ?? null, company.organizationId ?? null)
+    }),
+    profileId
+      ? loadCustomFieldValues({
+          em,
+          entityId: E.customers.customer_company_profile,
+          recordIds: [profileId],
+          tenantIdByRecord: { [profileId]: profile?.tenantId ?? null },
+          organizationIdByRecord: { [profileId]: profile?.organizationId ?? null },
+          tenantFallbacks: [
+            profile?.tenantId ?? company.tenantId ?? auth.tenantId ?? null,
+          ].filter((v): v is string => !!v),
+        })
+      : Promise.resolve<Record<string, Record<string, unknown>>>({}),
+    resolveCompanyCustomFieldRouting(em, company.tenantId ?? null, company.organizationId ?? null),
+  ])
   const customFields = normalizeCustomerDetailCustomFields(
     mergeCompanyCustomFieldValues(
       routing,
@@ -809,85 +816,103 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
     ),
   )
 
-  const activityCount = await em.count(CustomerInteraction, {
-    entity: company.id,
-    organizationId: company.organizationId,
-    tenantId: company.tenantId,
-    deletedAt: null,
-    interactionType: { $ne: 'task' },
-    ...emailVisibilityFilter,
-  })
-  const interactionCount = await em.count(CustomerInteraction, {
-    entity: company.id,
-    organizationId: company.organizationId,
-    tenantId: company.tenantId,
-    deletedAt: null,
-    ...emailVisibilityFilter,
-  })
-  const todoCount = interactionFlags.unified
-    ? await em.count(CustomerInteraction, {
-        entity: company.id,
-        organizationId: company.organizationId,
-        tenantId: company.tenantId,
-        deletedAt: null,
-        interactionType: 'task',
-      })
-    : await em.count(CustomerTodoLink, {
-        entity: company.id,
-        organizationId: company.organizationId,
-        tenantId: company.tenantId,
-      })
-  const commentsCount = includeComments
-    ? comments.length
-    : await em.count(CustomerComment, {
-        entity: company.id,
-        organizationId: company.organizationId,
-        tenantId: company.tenantId,
-      })
-  const addressesCount = includeAddresses
-    ? addresses.length
-    : await em.count(CustomerAddress, {
-        entity: company.id,
-        organizationId: company.organizationId,
-        tenantId: company.tenantId,
-      })
-  const peopleCount = includePeople
-    ? relatedPeople.length
-    : filterActivePersonCompanyLinks(
-        await findWithDecryption(
+  // The count queries, related-people fallback, and KPI interaction fallback are
+  // all independent of each other; dispatch them together rather than awaiting
+  // each inline so the response counts/KPIs are assembled in one parallel round
+  // instead of a waterfall (issue #3203).
+  const peopleCountQuery = includePeople
+    ? Promise.resolve(relatedPeople.length)
+    : (async () => {
+        const peopleLinkWhere = await withActiveCustomerPersonCompanyLinkFilter(
           em,
-          CustomerPersonCompanyLink,
-          await withActiveCustomerPersonCompanyLinkFilter(
+          {
+            company: company.id,
+            organizationId: company.organizationId,
+            tenantId: company.tenantId,
+          },
+          'customers.companies.GET',
+        )
+        return filterActivePersonCompanyLinks(
+          await findWithDecryption(
             em,
-            {
-              company: company.id,
-              organizationId: company.organizationId,
-              tenantId: company.tenantId,
-            },
-            'customers.companies.GET',
+            CustomerPersonCompanyLink,
+            peopleLinkWhere,
+            {},
+            { tenantId: company.tenantId, organizationId: company.organizationId },
           ),
-          {},
-          { tenantId: company.tenantId, organizationId: company.organizationId },
-        ),
-      ).length
-  const kpiInteractionRows = canonicalActiveInteractions.length
-    ? canonicalActiveInteractions
-    : await findWithDecryption(
-        em,
-        CustomerInteraction,
-        {
+        ).length
+      })()
+  const [
+    activityCount,
+    interactionCount,
+    todoCount,
+    commentsCount,
+    addressesCount,
+    peopleCount,
+    kpiInteractionRows,
+  ] = await Promise.all([
+    em.count(CustomerInteraction, {
+      entity: company.id,
+      organizationId: company.organizationId,
+      tenantId: company.tenantId,
+      deletedAt: null,
+      interactionType: { $ne: 'task' },
+      ...emailVisibilityFilter,
+    }),
+    em.count(CustomerInteraction, {
+      entity: company.id,
+      organizationId: company.organizationId,
+      tenantId: company.tenantId,
+      deletedAt: null,
+      ...emailVisibilityFilter,
+    }),
+    interactionFlags.unified
+      ? em.count(CustomerInteraction, {
           entity: company.id,
           organizationId: company.organizationId,
           tenantId: company.tenantId,
           deletedAt: null,
-          ...emailVisibilityFilter,
-        },
-        {
-          fields: ['id', 'occurredAt', 'scheduledAt', 'createdAt'],
-          orderBy: { createdAt: 'DESC' },
-        },
-        { tenantId: company.tenantId, organizationId: company.organizationId },
-      )
+          interactionType: 'task',
+        })
+      : em.count(CustomerTodoLink, {
+          entity: company.id,
+          organizationId: company.organizationId,
+          tenantId: company.tenantId,
+        }),
+    includeComments
+      ? Promise.resolve(comments.length)
+      : em.count(CustomerComment, {
+          entity: company.id,
+          organizationId: company.organizationId,
+          tenantId: company.tenantId,
+        }),
+    includeAddresses
+      ? Promise.resolve(addresses.length)
+      : em.count(CustomerAddress, {
+          entity: company.id,
+          organizationId: company.organizationId,
+          tenantId: company.tenantId,
+        }),
+    peopleCountQuery,
+    canonicalActiveInteractions.length
+      ? Promise.resolve(canonicalActiveInteractions)
+      : findWithDecryption(
+          em,
+          CustomerInteraction,
+          {
+            entity: company.id,
+            organizationId: company.organizationId,
+            tenantId: company.tenantId,
+            deletedAt: null,
+            ...emailVisibilityFilter,
+          },
+          {
+            fields: ['id', 'occurredAt', 'scheduledAt', 'createdAt'],
+            orderBy: { createdAt: 'DESC' },
+          },
+          { tenantId: company.tenantId, organizationId: company.organizationId },
+        ),
+  ])
   const activityTrend = computeActivityTrend(
     kpiInteractionRows
       .map((interaction) => interaction.occurredAt ?? interaction.scheduledAt ?? interaction.createdAt)

--- a/packages/core/src/modules/customers/api/people/[id]/__tests__/route.parallel.test.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/__tests__/route.parallel.test.ts
@@ -1,0 +1,179 @@
+/** @jest-environment node */
+
+// Regression coverage for issue #3203: the people detail route must dispatch its
+// independent enrichment reads in parallel instead of awaiting them one after
+// another. The test makes findWithDecryption hang until all expected calls are
+// in flight, which can only resolve if the route started them concurrently.
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+const mockResolveCustomerInteractionFeatureFlags = jest.fn()
+const mockLoadCustomFieldValues = jest.fn()
+const mockResolvePersonCustomFieldRouting = jest.fn()
+const mockMergePersonCustomFieldValues = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+const mockLoadPersonCompanyLinks = jest.fn()
+
+const mockEm = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  count: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'queryEngine') return { query: jest.fn(async () => ({ items: [] })) }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScopeForRequest(args)),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScopeGuard', () => ({
+  isOrganizationReadAccessAllowed: jest.fn(() => true),
+}))
+
+jest.mock('../../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn((...args: unknown[]) => mockResolveCustomerInteractionFeatureFlags(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn((args: unknown) => mockLoadCustomFieldValues(args)),
+}))
+
+jest.mock('../../../../lib/customFieldRouting', () => ({
+  resolvePersonCustomFieldRouting: jest.fn((...args: unknown[]) => mockResolvePersonCustomFieldRouting(...args)),
+  mergePersonCustomFieldValues: jest.fn((...args: unknown[]) => mockMergePersonCustomFieldValues(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('../../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async () => []),
+}))
+
+jest.mock('../../../../lib/personCompanies', () => ({
+  loadPersonCompanyLinks: jest.fn((...args: unknown[]) => mockLoadPersonCompanyLinks(...args)),
+  summarizePersonCompanies: jest.fn(() => []),
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    customers: {
+      customer_entity: 'customer_entity',
+      customer_person_profile: 'customer_person_profile',
+    },
+  },
+}), { virtual: true })
+
+const PERSON_ID = '2408107d-0000-4000-8000-000000000010'
+
+function buildPerson() {
+  const createdAt = new Date('2026-04-10T08:00:00.000Z')
+  return {
+    id: PERSON_ID,
+    kind: 'person',
+    deletedAt: null,
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    displayName: 'Ada Lovelace',
+    description: null,
+    ownerUserId: null,
+    primaryEmail: null,
+    primaryPhone: null,
+    status: null,
+    lifecycleStage: null,
+    source: null,
+    temperature: null,
+    renewalQuarter: null,
+    nextInteractionAt: null,
+    nextInteractionName: null,
+    nextInteractionRefId: null,
+    nextInteractionIcon: null,
+    nextInteractionColor: null,
+    isActive: true,
+    createdAt,
+    updatedAt: createdAt,
+  }
+}
+
+describe('GET /api/customers/people/[id] — parallel enrichment (issue #3203)', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    mockGetAuthFromRequest.mockReset()
+    mockResolveOrganizationScopeForRequest.mockReset()
+    mockResolveCustomerInteractionFeatureFlags.mockReset()
+    mockLoadCustomFieldValues.mockReset()
+    mockResolvePersonCustomFieldRouting.mockReset()
+    mockMergePersonCustomFieldValues.mockReset()
+    mockFindWithDecryption.mockReset()
+    mockFindOneWithDecryption.mockReset()
+    mockLoadPersonCompanyLinks.mockReset()
+    mockEm.findOne.mockReset()
+    mockEm.find.mockReset()
+    mockEm.count.mockReset()
+    mockEm.count.mockResolvedValue(0)
+    mockContainer.resolve.mockClear()
+
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1', isApiKey: false })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({ filterIds: ['org-1'], selectedId: 'org-1', tenantId: 'tenant-1' })
+    mockResolveCustomerInteractionFeatureFlags.mockResolvedValue({ unified: false })
+    mockLoadCustomFieldValues.mockResolvedValue({})
+    mockResolvePersonCustomFieldRouting.mockResolvedValue(new Map())
+    mockMergePersonCustomFieldValues.mockReturnValue({})
+    mockLoadPersonCompanyLinks.mockResolvedValue([])
+    mockFindOneWithDecryption
+      .mockResolvedValueOnce(buildPerson())
+      .mockResolvedValue(null)
+    mockFindWithDecryption.mockResolvedValue([])
+  })
+
+  it('dispatches the independent tag/label/interaction reads concurrently', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    let releaseGate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve
+    })
+
+    // The first batch of independent reads (tags, labels, and — with the include
+    // flags below — comments + canonical interactions) all run through
+    // findWithDecryption. Hold the first few open simultaneously: if the route
+    // awaited them serially, only one would ever be in flight at a time and the
+    // gate (released once two are concurrent) would never trip, hanging the test.
+    mockFindWithDecryption.mockImplementation(async () => {
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      if (maxInFlight >= 2) releaseGate()
+      await gate
+      inFlight -= 1
+      return []
+    })
+
+    const { GET } = await import('../route')
+    const response = await GET(
+      new Request(`http://localhost/api/customers/people/${PERSON_ID}?include=comments,interactions`),
+      { params: { id: PERSON_ID } },
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.person.id).toBe(PERSON_ID)
+    expect(maxInFlight).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/core/src/modules/customers/api/people/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/route.ts
@@ -485,37 +485,13 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
       return forbidden('Access denied')
     }
 
-    profile = await findOneWithDecryption(em, CustomerPersonProfile, { entity: person }, { populate: ['company'] }, { tenantId: person.tenantId ?? auth.tenantId ?? null, organizationId: person.organizationId ?? auth.orgId ?? null })
+    const [profileResult, personCompanyLinks] = await Promise.all([
+      findOneWithDecryption(em, CustomerPersonProfile, { entity: person }, { populate: ['company'] }, { tenantId: person.tenantId ?? auth.tenantId ?? null, organizationId: person.organizationId ?? auth.orgId ?? null }),
+      loadPersonCompanyLinks(em, person),
+    ])
+    profile = profileResult
     profiler.mark('profile_loaded', { found: !!profile })
-    companies = summarizePersonCompanies(profile, await loadPersonCompanyLinks(em, person))
-
-    if (includeAddresses) {
-      addresses = await findWithDecryption(em, CustomerAddress, { entity: person.id }, { orderBy: { isPrimary: 'desc', createdAt: 'desc' } }, { tenantId: person.tenantId ?? auth.tenantId ?? null, organizationId: person.organizationId ?? auth.orgId ?? null })
-      profiler.mark('addresses_loaded', { count: addresses.length })
-    }
-
-    tagAssignments = await findWithDecryption(
-      em,
-      CustomerTagAssignment,
-      { entity: person.id },
-      { populate: ['tag'] },
-      { tenantId: person.tenantId ?? auth.tenantId ?? null, organizationId: person.organizationId ?? auth.orgId ?? null },
-    )
-    profiler.mark('tags_loaded', { count: tagAssignments.length })
-
-    const labelAssignments = await findWithDecryption(
-      em,
-      CustomerLabelAssignment,
-      { entity: person.id },
-      { populate: ['label'] },
-      { tenantId: person.tenantId ?? auth.tenantId ?? null, organizationId: person.organizationId ?? auth.orgId ?? null },
-    )
-    profiler.mark('labels_loaded', { count: labelAssignments.length })
-
-    if (includeComments) {
-      comments = await findWithDecryption(em, CustomerComment, { entity: person.id }, { orderBy: { createdAt: 'desc' }, limit: 50 }, { tenantId: person.tenantId ?? auth.tenantId ?? null, organizationId: person.organizationId ?? auth.orgId ?? null })
-      profiler.mark('comments_loaded', { count: comments.length })
-    }
+    companies = summarizePersonCompanies(profile, personCompanyLinks)
 
     // Per-user email privacy (CRM email integration spec, "Layer 1 — DB filter"):
     // exclude private email interactions owned by other users from every read
@@ -528,18 +504,46 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
       userFeatures: undefined,
     })
 
+    const personScope = { tenantId: person.tenantId ?? auth.tenantId ?? null, organizationId: person.organizationId ?? auth.orgId ?? null }
     const shouldLoadCanonicalInteractions = includeInteractions || includeActivities || includeTodos
-    const canonicalInteractionRows = shouldLoadCanonicalInteractions
-      ? await findWithDecryption(
-          em,
-          CustomerInteraction,
-          interactionFlags.unified
-            ? { entity: person.id, deletedAt: null, ...emailVisibilityFilter }
-            : { entity: person.id, ...emailVisibilityFilter },
-          { orderBy: { scheduledAt: 'asc', createdAt: 'desc' }, limit: 100 },
-          { tenantId: person.tenantId ?? auth.tenantId ?? null, organizationId: person.organizationId ?? auth.orgId ?? null },
-        )
-      : []
+
+    // These reads only depend on the resolved person + scope + email visibility
+    // filter, so dispatch them together to avoid a server-side request waterfall
+    // before the detail surface can render (issue #3203).
+    const [
+      addressesResult,
+      tagAssignmentsResult,
+      labelAssignments,
+      commentsResult,
+      canonicalInteractionRows,
+    ] = await Promise.all([
+      includeAddresses
+        ? findWithDecryption(em, CustomerAddress, { entity: person.id }, { orderBy: { isPrimary: 'desc', createdAt: 'desc' } }, personScope)
+        : Promise.resolve<CustomerAddress[]>([]),
+      findWithDecryption(em, CustomerTagAssignment, { entity: person.id }, { populate: ['tag'] }, personScope),
+      findWithDecryption(em, CustomerLabelAssignment, { entity: person.id }, { populate: ['label'] }, personScope),
+      includeComments
+        ? findWithDecryption(em, CustomerComment, { entity: person.id }, { orderBy: { createdAt: 'desc' }, limit: 50 }, personScope)
+        : Promise.resolve<CustomerComment[]>([]),
+      shouldLoadCanonicalInteractions
+        ? findWithDecryption(
+            em,
+            CustomerInteraction,
+            interactionFlags.unified
+              ? { entity: person.id, deletedAt: null, ...emailVisibilityFilter }
+              : { entity: person.id, ...emailVisibilityFilter },
+            { orderBy: { scheduledAt: 'asc', createdAt: 'desc' }, limit: 100 },
+            personScope,
+          )
+        : Promise.resolve<CustomerInteraction[]>([]),
+    ])
+    addresses = addressesResult
+    tagAssignments = tagAssignmentsResult
+    comments = commentsResult
+    profiler.mark('addresses_loaded', { count: addresses.length })
+    profiler.mark('tags_loaded', { count: tagAssignments.length })
+    profiler.mark('labels_loaded', { count: labelAssignments.length })
+    profiler.mark('comments_loaded', { count: comments.length })
     profiler.mark('canonical_interactions_loaded', { count: canonicalInteractionRows.length })
     const canonicalActiveInteractions = canonicalInteractionRows.filter((interaction) => !interaction.deletedAt)
     const canonicalInteractions = shouldLoadCanonicalInteractions
@@ -676,35 +680,39 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
       profiler.mark('deals_loaded', { count: deals.length })
     }
 
-    const entityCustomFieldValues = await loadCustomFieldValues({
-      em,
-      entityId: E.customers.customer_entity,
-      recordIds: [person.id],
-      tenantIdByRecord: { [person.id]: person.tenantId ?? null },
-      organizationIdByRecord: { [person.id]: person.organizationId ?? null },
-      tenantFallbacks: [
-        person.tenantId ?? auth.tenantId ?? null,
-      ].filter((v): v is string => !!v),
-    })
-    profiler.mark('entity_custom_fields_loaded', { keys: Object.keys(entityCustomFieldValues?.[person.id] ?? {}).length })
-
-    let profileCustomFieldValues: Record<string, Record<string, unknown>> = {}
+    // Entity custom fields, profile custom fields, and the routing lookup do not
+    // depend on each other (profileId is already resolved above), so load them in
+    // parallel instead of three sequential awaits (issue #3203).
     const profileId = profile?.id ?? null
-    if (profileId) {
-      profileCustomFieldValues = await loadCustomFieldValues({
+    const [entityCustomFieldValues, profileCustomFieldValues, routing] = await Promise.all([
+      loadCustomFieldValues({
         em,
-        entityId: E.customers.customer_person_profile,
-        recordIds: [profileId],
-        tenantIdByRecord: { [profileId]: profile?.tenantId ?? null },
-        organizationIdByRecord: { [profileId]: profile?.organizationId ?? null },
+        entityId: E.customers.customer_entity,
+        recordIds: [person.id],
+        tenantIdByRecord: { [person.id]: person.tenantId ?? null },
+        organizationIdByRecord: { [person.id]: person.organizationId ?? null },
         tenantFallbacks: [
-          profile?.tenantId ?? person.tenantId ?? auth.tenantId ?? null,
+          person.tenantId ?? auth.tenantId ?? null,
         ].filter((v): v is string => !!v),
-      })
+      }),
+      profileId
+        ? loadCustomFieldValues({
+            em,
+            entityId: E.customers.customer_person_profile,
+            recordIds: [profileId],
+            tenantIdByRecord: { [profileId]: profile?.tenantId ?? null },
+            organizationIdByRecord: { [profileId]: profile?.organizationId ?? null },
+            tenantFallbacks: [
+              profile?.tenantId ?? person.tenantId ?? auth.tenantId ?? null,
+            ].filter((v): v is string => !!v),
+          })
+        : Promise.resolve<Record<string, Record<string, unknown>>>({}),
+      resolvePersonCustomFieldRouting(em, person.tenantId ?? null, person.organizationId ?? null),
+    ])
+    profiler.mark('entity_custom_fields_loaded', { keys: Object.keys(entityCustomFieldValues?.[person.id] ?? {}).length })
+    if (profileId) {
       profiler.mark('profile_custom_fields_loaded', { keys: Object.keys(profileCustomFieldValues?.[profileId] ?? {}).length })
     }
-
-    const routing = await resolvePersonCustomFieldRouting(em, person.tenantId ?? null, person.organizationId ?? null)
     profiler.mark('custom_field_routing_resolved', { keys: routing.size })
     customFields = normalizeCustomerDetailCustomFields(
       mergePersonCustomFieldValues(
@@ -716,16 +724,25 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
     profiler.mark('custom_fields_merged', { keys: Object.keys(customFields).length })
 
     const viewerUserIdFinal = viewerUserId
-    const counts = {
-      tags: tagAssignments.length + labelAssignments.length,
-      comments: includeComments
-        ? comments.length
-        : await em.count(CustomerComment, {
+    // The count fields are independent of each other; dispatch them together so
+    // the response counts object is assembled in one round of parallel queries
+    // instead of an inline await waterfall (issue #3203).
+    const [
+      commentsCount,
+      activitiesCount,
+      interactionsCount,
+      todosCount,
+      addressesCount,
+      dealsCount,
+    ] = await Promise.all([
+      includeComments
+        ? Promise.resolve(comments.length)
+        : em.count(CustomerComment, {
             entity: person.id,
             organizationId: person.organizationId,
             tenantId: person.tenantId,
           }),
-      activities: await em.count(CustomerInteraction, {
+      em.count(CustomerInteraction, {
         entity: person.id,
         organizationId: person.organizationId,
         tenantId: person.tenantId,
@@ -733,38 +750,47 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
         interactionType: { $ne: 'task' },
         ...emailVisibilityFilter,
       }),
-      interactions: await em.count(CustomerInteraction, {
+      em.count(CustomerInteraction, {
         entity: person.id,
         organizationId: person.organizationId,
         tenantId: person.tenantId,
         deletedAt: null,
         ...emailVisibilityFilter,
       }),
-      todos: interactionFlags.unified
-        ? await em.count(CustomerInteraction, {
+      interactionFlags.unified
+        ? em.count(CustomerInteraction, {
             entity: person.id,
             organizationId: person.organizationId,
             tenantId: person.tenantId,
             deletedAt: null,
             interactionType: 'task',
           })
-        : await em.count(CustomerTodoLink, {
+        : em.count(CustomerTodoLink, {
             entity: person.id,
             organizationId: person.organizationId,
             tenantId: person.tenantId,
           }),
-      addresses: includeAddresses
-        ? addresses.length
-        : await em.count(CustomerAddress, {
+      includeAddresses
+        ? Promise.resolve(addresses.length)
+        : em.count(CustomerAddress, {
             entity: person.id,
             organizationId: person.organizationId,
             tenantId: person.tenantId,
           }),
-      deals: includeDeals
-        ? deals.length
-        : await em.count(CustomerDealPersonLink, {
+      includeDeals
+        ? Promise.resolve(deals.length)
+        : em.count(CustomerDealPersonLink, {
             person: person.id,
           }),
+    ])
+    const counts = {
+      tags: tagAssignments.length + labelAssignments.length,
+      comments: commentsCount,
+      activities: activitiesCount,
+      interactions: interactionsCount,
+      todos: todosCount,
+      addresses: addressesCount,
+      deals: dealsCount,
       companies: companies.length,
     }
 


### PR DESCRIPTION
Fixes #3203

## Problem
The customers people and company detail GET routes loaded their independent enrichment blocks sequentially after the target record and scope were resolved. Serializing tags, labels, comments, interactions, related records, custom fields, and counts inflated server response time before the React detail surface could render — an avoidable server-side request waterfall.

## Root Cause
Each enrichment read (`addresses`, `tagAssignments`, `labelAssignments`, `comments`, canonical interactions, custom fields, routing, and the per-field `em.count` calls) was awaited inline one after another, even though most of them only depend on the already-resolved entity + organization scope + email-visibility filter.

## What Changed
Grouped the genuinely independent reads into `Promise.all` batches in both routes:

- **people** (`api/people/[id]/route.ts`):
  - profile + person-company links
  - addresses / tags / labels / comments / canonical interaction rows
  - entity custom fields + profile custom fields + custom-field routing
  - the response `counts` queries
- **companies** (`api/companies/[id]/route.ts`):
  - profile / addresses / tags / labels / comments / canonical interaction rows
  - entity custom fields + profile custom fields + routing
  - the count queries + related-people fallback + KPI interaction fallback

True dependencies stay ordered: canonical hydration runs after the rows load, profile custom fields after `profileId` resolution, and planned previews are still derived from the canonical interaction rows. Tenant/organization scoping, the per-user email visibility filter, all route-profiler marks, and existing fallback behavior are preserved. Parallel reads on the shared request-scoped `EntityManager` follow the established pattern already used across the customers list/interactions/activities routes.

## Tests
- New `api/people/[id]/__tests__/route.parallel.test.ts` and `api/companies/[id]/__tests__/route.parallel.test.ts`: hold `findWithDecryption` open until two calls are concurrently in flight; they hang (time out) against the old sequential code and pass once the reads run in parallel. Verified both fail pre-fix and pass post-fix.
- Full customers module suite: 149 suites / 830 tests pass.
- `tsc --noEmit` on `@open-mercato/core`: clean.
- ESLint on the changed routes: clean.

## Backward Compatibility
No contract surface changes. Response shapes, field names, ordering of returned arrays, status codes, scoping, and profiler output are all unchanged — only the internal await ordering of independent reads was parallelized.