### PR TITLE
fix(customers): guard custom command routes with mutation guard (#3200)

### DIFF
--- a/packages/core/src/modules/customers/api/pipeline-stages/__tests__/route.guard.test.ts
+++ b/packages/core/src/modules/customers/api/pipeline-stages/__tests__/route.guard.test.ts
@@ -1,0 +1,117 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const stageId = '55555555-5555-4555-8555-555555555555'
+const pipelineId = '44444444-4444-4444-8444-444444444444'
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const commandBusExecuteMock = jest.fn()
+
+const commandBus = { execute: commandBusExecuteMock }
+const container = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'commandBus') return commandBus
+    if (token === 'em') return {}
+    return {}
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: userId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({
+    selectedId: organizationId,
+    filterIds: [organizationId],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+import { POST, PUT, DELETE } from '../route'
+
+const jsonRequest = (method: string, body: unknown) =>
+  new Request('http://localhost/api/customers/pipeline-stages', {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+describe('customers pipeline-stages route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    commandBusExecuteMock.mockResolvedValue({ result: { stageId }, logEntry: null })
+  })
+
+  it('runs the guard before create and the after-success hook on success', async () => {
+    const response = await POST(jsonRequest('POST', { pipelineId, label: 'Lead' }))
+
+    expect(response.status).toBe(201)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'customers.pipelineStage',
+        operation: 'create',
+      }),
+    )
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('customers.pipeline-stages.create', expect.anything())
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'customers.pipelineStage', resourceId: stageId, operation: 'create' }),
+    )
+  })
+
+  it('short-circuits create when the guard blocks the mutation', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await POST(jsonRequest('POST', { pipelineId, label: 'Lead' }))
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('guards update with the stage id as the resource', async () => {
+    commandBusExecuteMock.mockResolvedValueOnce({ logEntry: null })
+
+    const response = await PUT(jsonRequest('PUT', { id: stageId, label: 'Renamed' }))
+
+    expect(response.status).toBe(200)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'customers.pipelineStage', resourceId: stageId, operation: 'update' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+  })
+
+  it('short-circuits delete when the guard blocks the mutation', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await DELETE(jsonRequest('DELETE', { id: stageId }))
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/pipeline-stages/reorder/__tests__/route.guard.test.ts
+++ b/packages/core/src/modules/customers/api/pipeline-stages/reorder/__tests__/route.guard.test.ts
@@ -1,0 +1,91 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const stageId = '55555555-5555-4555-8555-555555555555'
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const commandBusExecuteMock = jest.fn()
+
+const commandBus = { execute: commandBusExecuteMock }
+const container = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'commandBus') return commandBus
+    return {}
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: userId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({
+    selectedId: organizationId,
+    filterIds: [organizationId],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+import { POST } from '../route'
+
+const reorderRequest = () =>
+  new Request('http://localhost/api/customers/pipeline-stages/reorder', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ stages: [{ id: stageId, order: 0 }] }),
+  })
+
+describe('customers pipeline-stages reorder route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    commandBusExecuteMock.mockResolvedValue(undefined)
+  })
+
+  it('runs the guard before reorder and the after-success hook on success', async () => {
+    const response = await POST(reorderRequest())
+
+    expect(response.status).toBe(200)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'customers.pipelineStage',
+        resourceId: organizationId,
+        operation: 'custom',
+      }),
+    )
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('customers.pipeline-stages.reorder', expect.anything())
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+  })
+
+  it('short-circuits the reorder command when the guard blocks the mutation', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await POST(reorderRequest())
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/pipeline-stages/reorder/route.ts
+++ b/packages/core/src/modules/customers/api/pipeline-stages/reorder/route.ts
@@ -38,7 +38,7 @@ export async function POST(req: Request) {
     const organizationId = scope?.selectedId ?? auth.orgId ?? null
     const tenantId = auth.tenantId ?? null
     if (!organizationId || !tenantId) {
-      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+      return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
 
     const body = await req.json().catch(() => ({}))

--- a/packages/core/src/modules/customers/api/pipeline-stages/reorder/route.ts
+++ b/packages/core/src/modules/customers/api/pipeline-stages/reorder/route.ts
@@ -8,7 +8,13 @@ import { pipelineStageReorderSchema, type PipelineStageReorderInput } from '../.
 import { withScopedPayload } from '../../utils'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+const PIPELINE_STAGE_RESOURCE_KIND = 'customers.pipelineStage'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['customers.pipelines.manage'] },
@@ -29,15 +35,49 @@ export async function POST(req: Request) {
       organizationIds: scope?.filterIds ?? (auth.orgId ? [auth.orgId] : null),
       request: req,
     }
+    const organizationId = scope?.selectedId ?? auth.orgId ?? null
+    const tenantId = auth.tenantId ?? null
+    if (!organizationId || !tenantId) {
+      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+    }
 
     const body = await req.json().catch(() => ({}))
     const scoped = withScopedPayload(body, ctx, translate)
+    const input = pipelineStageReorderSchema.parse(scoped)
+
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId,
+      organizationId,
+      userId: auth.sub,
+      resourceKind: PIPELINE_STAGE_RESOURCE_KIND,
+      resourceId: organizationId,
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     await commandBus.execute<PipelineStageReorderInput, void>(
       'customers.pipeline-stages.reorder',
-      { input: pipelineStageReorderSchema.parse(scoped), ctx },
+      { input, ctx },
     )
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId,
+        userId: auth.sub,
+        resourceKind: PIPELINE_STAGE_RESOURCE_KIND,
+        resourceId: organizationId,
+        operation: 'custom',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
     return NextResponse.json({ ok: true })
   } catch (err) {
     if (isCrudHttpError(err)) {

--- a/packages/core/src/modules/customers/api/pipeline-stages/route.ts
+++ b/packages/core/src/modules/customers/api/pipeline-stages/route.ts
@@ -18,7 +18,13 @@ import { withScopedPayload } from '../utils'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+const PIPELINE_STAGE_RESOURCE_KIND = 'customers.pipelineStage'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.pipelines.view'] },
@@ -102,16 +108,48 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { ctx } = await buildContext(req)
+    const { ctx, organizationId, tenantId } = await buildContext(req)
+    if (!organizationId || !tenantId) {
+      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+    }
     const body = await req.json().catch(() => ({}))
     const { translate } = await resolveTranslations()
     const scoped = withScopedPayload(body, ctx, translate)
+    const input = pipelineStageCreateSchema.parse(scoped)
+
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId,
+      organizationId,
+      userId: ctx.auth!.sub,
+      resourceKind: PIPELINE_STAGE_RESOURCE_KIND,
+      resourceId: organizationId,
+      operation: 'create',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { result, logEntry } = await commandBus.execute<PipelineStageCreateInput, { stageId: string }>(
       'customers.pipeline-stages.create',
-      { input: pipelineStageCreateSchema.parse(scoped), ctx },
+      { input, ctx },
     )
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId,
+        userId: ctx.auth!.sub,
+        resourceKind: PIPELINE_STAGE_RESOURCE_KIND,
+        resourceId: result?.stageId ?? organizationId,
+        operation: 'create',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
     const response = NextResponse.json({ id: result?.stageId ?? null }, { status: 201 })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(
@@ -139,16 +177,48 @@ export async function POST(req: Request) {
 
 export async function PUT(req: Request) {
   try {
-    const { ctx } = await buildContext(req)
+    const { ctx, organizationId, tenantId } = await buildContext(req)
+    if (!organizationId || !tenantId) {
+      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+    }
     const body = await req.json().catch(() => ({}))
     const { translate } = await resolveTranslations()
     const scoped = withScopedPayload(body, ctx, translate)
+    const input = pipelineStageUpdateSchema.parse(scoped)
+
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId,
+      organizationId,
+      userId: ctx.auth!.sub,
+      resourceKind: PIPELINE_STAGE_RESOURCE_KIND,
+      resourceId: input.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { logEntry } = await commandBus.execute<PipelineStageUpdateInput, void>(
       'customers.pipeline-stages.update',
-      { input: pipelineStageUpdateSchema.parse(scoped), ctx },
+      { input, ctx },
     )
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId,
+        userId: ctx.auth!.sub,
+        resourceKind: PIPELINE_STAGE_RESOURCE_KIND,
+        resourceId: input.id,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
     const response = NextResponse.json({ ok: true })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(
@@ -176,16 +246,48 @@ export async function PUT(req: Request) {
 
 export async function DELETE(req: Request) {
   try {
-    const { ctx } = await buildContext(req)
+    const { ctx, organizationId, tenantId } = await buildContext(req)
+    if (!organizationId || !tenantId) {
+      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+    }
     const body = await req.json().catch(() => ({}))
     const { translate } = await resolveTranslations()
     const scoped = withScopedPayload(body, ctx, translate)
+    const input = pipelineStageDeleteSchema.parse(scoped)
+
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId,
+      organizationId,
+      userId: ctx.auth!.sub,
+      resourceKind: PIPELINE_STAGE_RESOURCE_KIND,
+      resourceId: input.id,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     await commandBus.execute<PipelineStageDeleteInput, void>(
       'customers.pipeline-stages.delete',
-      { input: pipelineStageDeleteSchema.parse(scoped), ctx },
+      { input, ctx },
     )
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId,
+        userId: ctx.auth!.sub,
+        resourceKind: PIPELINE_STAGE_RESOURCE_KIND,
+        resourceId: input.id,
+        operation: 'delete',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
     return NextResponse.json({ ok: true })
   } catch (err) {
     if (isCrudHttpError(err)) {

--- a/packages/core/src/modules/customers/api/pipeline-stages/route.ts
+++ b/packages/core/src/modules/customers/api/pipeline-stages/route.ts
@@ -35,7 +35,7 @@ export const metadata = {
 
 async function buildContext(
   req: Request
-): Promise<{ ctx: CommandRuntimeContext; organizationId: string | null; tenantId: string | null }> {
+): Promise<{ ctx: CommandRuntimeContext; organizationId: string | null; tenantId: string | null; translate: (key: string, fallback?: string) => string }> {
   const container = await createRequestContainer()
   const auth = await getAuthFromRequest(req)
   const { translate } = await resolveTranslations()
@@ -51,14 +51,14 @@ async function buildContext(
   }
   const organizationId = scope?.selectedId ?? auth.orgId ?? null
   const tenantId = auth.tenantId ?? null
-  return { ctx, organizationId, tenantId }
+  return { ctx, organizationId, tenantId, translate }
 }
 
 export async function GET(req: Request) {
   try {
-    const { ctx, organizationId, tenantId } = await buildContext(req)
+    const { ctx, organizationId, tenantId, translate } = await buildContext(req)
     if (!organizationId || !tenantId) {
-      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+      return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
     const url = new URL(req.url)
     const pipelineId = url.searchParams.get('pipelineId')
@@ -108,12 +108,11 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { ctx, organizationId, tenantId } = await buildContext(req)
+    const { ctx, organizationId, tenantId, translate } = await buildContext(req)
     if (!organizationId || !tenantId) {
-      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+      return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
     const body = await req.json().catch(() => ({}))
-    const { translate } = await resolveTranslations()
     const scoped = withScopedPayload(body, ctx, translate)
     const input = pipelineStageCreateSchema.parse(scoped)
 
@@ -177,12 +176,11 @@ export async function POST(req: Request) {
 
 export async function PUT(req: Request) {
   try {
-    const { ctx, organizationId, tenantId } = await buildContext(req)
+    const { ctx, organizationId, tenantId, translate } = await buildContext(req)
     if (!organizationId || !tenantId) {
-      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+      return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
     const body = await req.json().catch(() => ({}))
-    const { translate } = await resolveTranslations()
     const scoped = withScopedPayload(body, ctx, translate)
     const input = pipelineStageUpdateSchema.parse(scoped)
 
@@ -246,12 +244,11 @@ export async function PUT(req: Request) {
 
 export async function DELETE(req: Request) {
   try {
-    const { ctx, organizationId, tenantId } = await buildContext(req)
+    const { ctx, organizationId, tenantId, translate } = await buildContext(req)
     if (!organizationId || !tenantId) {
-      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+      return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
     const body = await req.json().catch(() => ({}))
-    const { translate } = await resolveTranslations()
     const scoped = withScopedPayload(body, ctx, translate)
     const input = pipelineStageDeleteSchema.parse(scoped)
 

--- a/packages/core/src/modules/customers/api/pipelines/__tests__/route.guard.test.ts
+++ b/packages/core/src/modules/customers/api/pipelines/__tests__/route.guard.test.ts
@@ -1,0 +1,119 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const pipelineId = '44444444-4444-4444-8444-444444444444'
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const commandBusExecuteMock = jest.fn()
+
+const commandBus = { execute: commandBusExecuteMock }
+const container = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'commandBus') return commandBus
+    if (token === 'em') return {}
+    return {}
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: userId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({
+    selectedId: organizationId,
+    filterIds: [organizationId],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+import { POST, PUT, DELETE } from '../route'
+
+const jsonRequest = (method: string, body: unknown) =>
+  new Request('http://localhost/api/customers/pipelines', {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+describe('customers pipelines route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    commandBusExecuteMock.mockResolvedValue({ result: { pipelineId }, logEntry: null })
+  })
+
+  it('runs the guard before create and the after-success hook on success', async () => {
+    const response = await POST(jsonRequest('POST', { name: 'Sales' }))
+
+    expect(response.status).toBe(201)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'customers.pipeline',
+        operation: 'create',
+        mutationPayload: expect.objectContaining({ name: 'Sales' }),
+      }),
+    )
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('customers.pipelines.create', expect.anything())
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'customers.pipeline', resourceId: pipelineId, operation: 'create' }),
+    )
+  })
+
+  it('short-circuits create when the guard blocks the mutation', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await POST(jsonRequest('POST', { name: 'Sales' }))
+
+    expect(response.status).toBe(423)
+    expect(await response.json()).toEqual({ error: 'locked' })
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('guards update with the pipeline id as the resource', async () => {
+    commandBusExecuteMock.mockResolvedValueOnce({ logEntry: null })
+
+    const response = await PUT(jsonRequest('PUT', { id: pipelineId, name: 'Renamed' }))
+
+    expect(response.status).toBe(200)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'customers.pipeline', resourceId: pipelineId, operation: 'update' }),
+    )
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('customers.pipelines.update', expect.anything())
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+  })
+
+  it('short-circuits delete when the guard blocks the mutation', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await DELETE(jsonRequest('DELETE', { id: pipelineId }))
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/pipelines/route.ts
+++ b/packages/core/src/modules/customers/api/pipelines/route.ts
@@ -35,7 +35,7 @@ export const metadata = {
 
 async function buildContext(
   req: Request
-): Promise<{ ctx: CommandRuntimeContext; organizationId: string | null; tenantId: string | null }> {
+): Promise<{ ctx: CommandRuntimeContext; organizationId: string | null; tenantId: string | null; translate: (key: string, fallback?: string) => string }> {
   const container = await createRequestContainer()
   const auth = await getAuthFromRequest(req)
   const { translate } = await resolveTranslations()
@@ -51,14 +51,14 @@ async function buildContext(
   }
   const organizationId = scope?.selectedId ?? auth.orgId ?? null
   const tenantId = auth.tenantId ?? null
-  return { ctx, organizationId, tenantId }
+  return { ctx, organizationId, tenantId, translate }
 }
 
 export async function GET(req: Request) {
   try {
-    const { ctx, organizationId, tenantId } = await buildContext(req)
+    const { ctx, organizationId, tenantId, translate } = await buildContext(req)
     if (!organizationId || !tenantId) {
-      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+      return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
     const url = new URL(req.url)
     const isDefaultParam = url.searchParams.get('isDefault')
@@ -90,12 +90,11 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { ctx, organizationId, tenantId } = await buildContext(req)
+    const { ctx, organizationId, tenantId, translate } = await buildContext(req)
     if (!organizationId || !tenantId) {
-      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+      return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
     const body = await req.json().catch(() => ({}))
-    const { translate } = await resolveTranslations()
     const scoped = withScopedPayload(body, ctx, translate)
     const input = pipelineCreateSchema.parse(scoped)
 
@@ -159,12 +158,11 @@ export async function POST(req: Request) {
 
 export async function PUT(req: Request) {
   try {
-    const { ctx, organizationId, tenantId } = await buildContext(req)
+    const { ctx, organizationId, tenantId, translate } = await buildContext(req)
     if (!organizationId || !tenantId) {
-      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+      return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
     const body = await req.json().catch(() => ({}))
-    const { translate } = await resolveTranslations()
     const scoped = withScopedPayload(body, ctx, translate)
     const input = pipelineUpdateSchema.parse(scoped)
 
@@ -228,12 +226,11 @@ export async function PUT(req: Request) {
 
 export async function DELETE(req: Request) {
   try {
-    const { ctx, organizationId, tenantId } = await buildContext(req)
+    const { ctx, organizationId, tenantId, translate } = await buildContext(req)
     if (!organizationId || !tenantId) {
-      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+      return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
     const body = await req.json().catch(() => ({}))
-    const { translate } = await resolveTranslations()
     const scoped = withScopedPayload(body, ctx, translate)
     const input = pipelineDeleteSchema.parse(scoped)
 

--- a/packages/core/src/modules/customers/api/pipelines/route.ts
+++ b/packages/core/src/modules/customers/api/pipelines/route.ts
@@ -18,7 +18,13 @@ import { withScopedPayload } from '../utils'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+const PIPELINE_RESOURCE_KIND = 'customers.pipeline'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.pipelines.view'] },
@@ -84,16 +90,48 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { ctx } = await buildContext(req)
+    const { ctx, organizationId, tenantId } = await buildContext(req)
+    if (!organizationId || !tenantId) {
+      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+    }
     const body = await req.json().catch(() => ({}))
     const { translate } = await resolveTranslations()
     const scoped = withScopedPayload(body, ctx, translate)
+    const input = pipelineCreateSchema.parse(scoped)
+
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId,
+      organizationId,
+      userId: ctx.auth!.sub,
+      resourceKind: PIPELINE_RESOURCE_KIND,
+      resourceId: organizationId,
+      operation: 'create',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { result, logEntry } = await commandBus.execute<PipelineCreateInput, { pipelineId: string }>(
       'customers.pipelines.create',
-      { input: pipelineCreateSchema.parse(scoped), ctx },
+      { input, ctx },
     )
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId,
+        userId: ctx.auth!.sub,
+        resourceKind: PIPELINE_RESOURCE_KIND,
+        resourceId: result?.pipelineId ?? organizationId,
+        operation: 'create',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
     const response = NextResponse.json({ id: result?.pipelineId ?? null }, { status: 201 })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(
@@ -121,16 +159,48 @@ export async function POST(req: Request) {
 
 export async function PUT(req: Request) {
   try {
-    const { ctx } = await buildContext(req)
+    const { ctx, organizationId, tenantId } = await buildContext(req)
+    if (!organizationId || !tenantId) {
+      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+    }
     const body = await req.json().catch(() => ({}))
     const { translate } = await resolveTranslations()
     const scoped = withScopedPayload(body, ctx, translate)
+    const input = pipelineUpdateSchema.parse(scoped)
+
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId,
+      organizationId,
+      userId: ctx.auth!.sub,
+      resourceKind: PIPELINE_RESOURCE_KIND,
+      resourceId: input.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { logEntry } = await commandBus.execute<PipelineUpdateInput, void>(
       'customers.pipelines.update',
-      { input: pipelineUpdateSchema.parse(scoped), ctx },
+      { input, ctx },
     )
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId,
+        userId: ctx.auth!.sub,
+        resourceKind: PIPELINE_RESOURCE_KIND,
+        resourceId: input.id,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
     const response = NextResponse.json({ ok: true })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(
@@ -158,16 +228,48 @@ export async function PUT(req: Request) {
 
 export async function DELETE(req: Request) {
   try {
-    const { ctx } = await buildContext(req)
+    const { ctx, organizationId, tenantId } = await buildContext(req)
+    if (!organizationId || !tenantId) {
+      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+    }
     const body = await req.json().catch(() => ({}))
     const { translate } = await resolveTranslations()
     const scoped = withScopedPayload(body, ctx, translate)
+    const input = pipelineDeleteSchema.parse(scoped)
+
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId,
+      organizationId,
+      userId: ctx.auth!.sub,
+      resourceKind: PIPELINE_RESOURCE_KIND,
+      resourceId: input.id,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     await commandBus.execute<PipelineDeleteInput, void>(
       'customers.pipelines.delete',
-      { input: pipelineDeleteSchema.parse(scoped), ctx },
+      { input, ctx },
     )
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId,
+        userId: ctx.auth!.sub,
+        resourceKind: PIPELINE_RESOURCE_KIND,
+        resourceId: input.id,
+        operation: 'delete',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
     return NextResponse.json({ ok: true })
   } catch (err) {
     if (isCrudHttpError(err)) {

--- a/packages/core/src/modules/customers/api/settings/address-format/__tests__/route.guard.test.ts
+++ b/packages/core/src/modules/customers/api/settings/address-format/__tests__/route.guard.test.ts
@@ -1,0 +1,101 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const settingsId = '99999999-9999-4999-8999-999999999999'
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const commandBusExecuteMock = jest.fn()
+const loadCustomerSettingsMock = jest.fn()
+
+const commandBus = { execute: commandBusExecuteMock }
+const container = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'commandBus') return commandBus
+    if (token === 'em') return {}
+    return {}
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: userId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({
+    selectedId: organizationId,
+    filterIds: [organizationId],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+jest.mock('../../../../commands/settings', () => ({
+  loadCustomerSettings: (...args: unknown[]) => loadCustomerSettingsMock(...args),
+}))
+
+import { PUT } from '../route'
+
+const putRequest = () =>
+  new Request('http://localhost/api/customers/settings/address-format', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ addressFormat: 'street_first' }),
+  })
+
+describe('customers settings address-format route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    commandBusExecuteMock.mockResolvedValue({ result: { settingsId, addressFormat: 'street_first' } })
+    loadCustomerSettingsMock.mockResolvedValue(null)
+  })
+
+  it('runs the guard before save and the after-success hook on success', async () => {
+    const response = await PUT(putRequest())
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ addressFormat: 'street_first' })
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'customers.settings',
+        resourceId: organizationId,
+        operation: 'update',
+        mutationPayload: expect.objectContaining({ addressFormat: 'street_first' }),
+      }),
+    )
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('customers.settings.save', expect.anything())
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+  })
+
+  it('short-circuits save when the guard blocks the mutation', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await PUT(putRequest())
+
+    expect(response.status).toBe(423)
+    expect(await response.json()).toEqual({ error: 'locked' })
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/settings/address-format/route.ts
+++ b/packages/core/src/modules/customers/api/settings/address-format/route.ts
@@ -7,11 +7,17 @@ import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { customerSettingsUpsertSchema, type CustomerSettingsUpsertInput } from '../../../data/validators'
 import { loadCustomerSettings } from '../../../commands/settings'
 import type { CustomerAddressFormat } from '../../../data/entities'
 import { withScopedPayload } from '../../utils'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+const SETTINGS_RESOURCE_KIND = 'customers.settings'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.settings.manage'] },
@@ -78,16 +84,45 @@ export async function GET(req: Request) {
 
 export async function PUT(req: Request) {
   try {
-    const { ctx, translate } = await resolveSettingsContext(req)
+    const { ctx, tenantId, organizationId, translate } = await resolveSettingsContext(req)
     const payload = await req.json().catch(() => ({}))
     const scoped = withScopedPayload(payload, ctx, translate)
     const input = customerSettingsUpsertSchema.parse(scoped)
+
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId,
+      organizationId,
+      userId: ctx.auth!.sub,
+      resourceKind: SETTINGS_RESOURCE_KIND,
+      resourceId: organizationId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { result } = await commandBus.execute<CustomerSettingsUpsertInput, { settingsId: string; addressFormat: CustomerAddressFormat }>(
       'customers.settings.save',
       { input, ctx },
     )
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId,
+        userId: ctx.auth!.sub,
+        resourceKind: SETTINGS_RESOURCE_KIND,
+        resourceId: organizationId,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     return NextResponse.json({
       addressFormat: result?.addressFormat ?? input.addressFormat,

--- a/packages/core/src/modules/customers/api/tags/assign/__tests__/route.guard.test.ts
+++ b/packages/core/src/modules/customers/api/tags/assign/__tests__/route.guard.test.ts
@@ -1,0 +1,93 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const entityId = '66666666-6666-4666-8666-666666666666'
+const tagId = '77777777-7777-4777-8777-777777777777'
+const assignmentId = '88888888-8888-4888-8888-888888888888'
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const commandBusExecuteMock = jest.fn()
+
+const commandBus = { execute: commandBusExecuteMock }
+const container = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'commandBus') return commandBus
+    return {}
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: userId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({
+    selectedId: organizationId,
+    filterIds: [organizationId],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+import { POST } from '../route'
+
+const assignRequest = () =>
+  new Request('http://localhost/api/customers/tags/assign', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ tagId, entityId }),
+  })
+
+describe('customers tags assign route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    commandBusExecuteMock.mockResolvedValue({ result: { assignmentId }, logEntry: null })
+  })
+
+  it('runs the guard before assign and the after-success hook on success', async () => {
+    const response = await POST(assignRequest())
+
+    expect(response.status).toBe(201)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'customers.tagAssignment',
+        resourceId: entityId,
+        operation: 'custom',
+      }),
+    )
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('customers.tags.assign', expect.anything())
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+  })
+
+  it('short-circuits assign when the guard blocks the mutation', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await POST(assignRequest())
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/tags/assign/route.ts
+++ b/packages/core/src/modules/customers/api/tags/assign/route.ts
@@ -46,7 +46,7 @@ export async function POST(req: Request) {
     const tenantId = auth!.tenantId
     const organizationId = ctx.selectedOrganizationId
     if (!tenantId || !organizationId) {
-      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+      return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
     const body = await req.json().catch(() => ({}))
     const scoped = withScopedPayload(body, ctx, translate)

--- a/packages/core/src/modules/customers/api/tags/assign/route.ts
+++ b/packages/core/src/modules/customers/api/tags/assign/route.ts
@@ -9,7 +9,13 @@ import { tagAssignmentSchema, type TagAssignmentInput } from '../../../data/vali
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { withScopedPayload } from '../../utils'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+const TAG_ASSIGNMENT_RESOURCE_KIND = 'customers.tagAssignment'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['customers.activities.manage'] },
@@ -37,15 +43,48 @@ async function buildContext(
 export async function POST(req: Request) {
   try {
     const { ctx, auth, translate } = await buildContext(req)
+    const tenantId = auth!.tenantId
+    const organizationId = ctx.selectedOrganizationId
+    if (!tenantId || !organizationId) {
+      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+    }
     const body = await req.json().catch(() => ({}))
     const scoped = withScopedPayload(body, ctx, translate)
     const input = tagAssignmentSchema.parse(scoped)
+
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId,
+      organizationId,
+      userId: auth!.sub,
+      resourceKind: TAG_ASSIGNMENT_RESOURCE_KIND,
+      resourceId: input.entityId,
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { result, logEntry } = await commandBus.execute<TagAssignmentInput, { assignmentId: string }>(
     'customers.tags.assign',
     { input, ctx },
   )
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId,
+        userId: auth!.sub,
+        resourceKind: TAG_ASSIGNMENT_RESOURCE_KIND,
+        resourceId: input.entityId,
+        operation: 'custom',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
     const response = NextResponse.json({ id: result?.assignmentId ?? null }, { status: 201 })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(

--- a/packages/core/src/modules/customers/api/tags/unassign/__tests__/route.guard.test.ts
+++ b/packages/core/src/modules/customers/api/tags/unassign/__tests__/route.guard.test.ts
@@ -1,0 +1,93 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const entityId = '66666666-6666-4666-8666-666666666666'
+const tagId = '77777777-7777-4777-8777-777777777777'
+const assignmentId = '88888888-8888-4888-8888-888888888888'
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const commandBusExecuteMock = jest.fn()
+
+const commandBus = { execute: commandBusExecuteMock }
+const container = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'commandBus') return commandBus
+    return {}
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: userId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({
+    selectedId: organizationId,
+    filterIds: [organizationId],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+import { POST } from '../route'
+
+const unassignRequest = () =>
+  new Request('http://localhost/api/customers/tags/unassign', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ tagId, entityId }),
+  })
+
+describe('customers tags unassign route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    commandBusExecuteMock.mockResolvedValue({ result: { assignmentId }, logEntry: null })
+  })
+
+  it('runs the guard before unassign and the after-success hook on success', async () => {
+    const response = await POST(unassignRequest())
+
+    expect(response.status).toBe(200)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'customers.tagAssignment',
+        resourceId: entityId,
+        operation: 'custom',
+      }),
+    )
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('customers.tags.unassign', expect.anything())
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+  })
+
+  it('short-circuits unassign when the guard blocks the mutation', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await POST(unassignRequest())
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/tags/unassign/route.ts
+++ b/packages/core/src/modules/customers/api/tags/unassign/route.ts
@@ -46,7 +46,7 @@ export async function POST(req: Request) {
     const tenantId = auth!.tenantId
     const organizationId = ctx.selectedOrganizationId
     if (!tenantId || !organizationId) {
-      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+      return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
     const body = await req.json().catch(() => ({}))
     const scoped = withScopedPayload(body, ctx, translate)

--- a/packages/core/src/modules/customers/api/tags/unassign/route.ts
+++ b/packages/core/src/modules/customers/api/tags/unassign/route.ts
@@ -9,7 +9,13 @@ import { tagAssignmentSchema, type TagAssignmentInput } from '../../../data/vali
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { withScopedPayload } from '../../utils'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+const TAG_ASSIGNMENT_RESOURCE_KIND = 'customers.tagAssignment'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['customers.activities.manage'] },
@@ -37,15 +43,48 @@ async function buildContext(
 export async function POST(req: Request) {
   try {
     const { ctx, auth, translate } = await buildContext(req)
+    const tenantId = auth!.tenantId
+    const organizationId = ctx.selectedOrganizationId
+    if (!tenantId || !organizationId) {
+      return NextResponse.json({ error: 'Organization and tenant context required' }, { status: 400 })
+    }
     const body = await req.json().catch(() => ({}))
     const scoped = withScopedPayload(body, ctx, translate)
     const input = tagAssignmentSchema.parse(scoped)
+
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId,
+      organizationId,
+      userId: auth!.sub,
+      resourceKind: TAG_ASSIGNMENT_RESOURCE_KIND,
+      resourceId: input.entityId,
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { result, logEntry } = await commandBus.execute<TagAssignmentInput, { assignmentId: string | null }>(
     'customers.tags.unassign',
     { input, ctx },
   )
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId,
+        userId: auth!.sub,
+        resourceKind: TAG_ASSIGNMENT_RESOURCE_KIND,
+        resourceId: input.entityId,
+        operation: 'custom',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
     const response = NextResponse.json({ id: result?.assignmentId ?? null })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(

--- a/packages/core/src/modules/customers/i18n/de.json
+++ b/packages/core/src/modules/customers/i18n/de.json
@@ -1306,6 +1306,7 @@
   "customers.errors.company_not_found": "Unternehmen nicht gefunden",
   "customers.errors.company_people_load_failed": "Verknüpfte Personen konnten nicht geladen werden",
   "customers.errors.company_required": "Unternehmens-ID ist erforderlich",
+  "customers.errors.context_required": "Organisations- und Mandantenkontext erforderlich",
   "customers.errors.customer_label_tables_missing": "Kundenlabel-Tabellen fehlen. Führen Sie yarn db:migrate aus.",
   "customers.errors.customer_not_found": "Kunde nicht gefunden",
   "customers.errors.deal_companies_load_failed": "Verknüpfte Unternehmen konnten nicht geladen werden",

--- a/packages/core/src/modules/customers/i18n/en.json
+++ b/packages/core/src/modules/customers/i18n/en.json
@@ -1306,6 +1306,7 @@
   "customers.errors.company_not_found": "Company not found",
   "customers.errors.company_people_load_failed": "Failed to load linked people",
   "customers.errors.company_required": "Company id is required",
+  "customers.errors.context_required": "Organization and tenant context required",
   "customers.errors.customer_label_tables_missing": "Customer label tables are missing. Run yarn db:migrate.",
   "customers.errors.customer_not_found": "Customer not found",
   "customers.errors.deal_companies_load_failed": "Failed to load linked companies",

--- a/packages/core/src/modules/customers/i18n/es.json
+++ b/packages/core/src/modules/customers/i18n/es.json
@@ -1306,6 +1306,7 @@
   "customers.errors.company_not_found": "Empresa no encontrada",
   "customers.errors.company_people_load_failed": "No se pudieron cargar las personas vinculadas",
   "customers.errors.company_required": "Se requiere el ID de la empresa",
+  "customers.errors.context_required": "Se requiere contexto de organización e inquilino",
   "customers.errors.customer_label_tables_missing": "Faltan las tablas de etiquetas de cliente. Ejecute yarn db:migrate.",
   "customers.errors.customer_not_found": "Cliente no encontrado",
   "customers.errors.deal_companies_load_failed": "No se pudieron cargar las empresas vinculadas",

--- a/packages/core/src/modules/customers/i18n/pl.json
+++ b/packages/core/src/modules/customers/i18n/pl.json
@@ -1306,6 +1306,7 @@
   "customers.errors.company_not_found": "Nie znaleziono firmy",
   "customers.errors.company_people_load_failed": "Nie udało się załadować powiązanych osób",
   "customers.errors.company_required": "Wymagany identyfikator firmy",
+  "customers.errors.context_required": "Wymagany jest kontekst organizacji i najemcy",
   "customers.errors.customer_label_tables_missing": "Brakuje tabel etykiet klientów. Uruchom yarn db:migrate.",
   "customers.errors.customer_not_found": "Nie znaleziono klienta",
   "customers.errors.deal_companies_load_failed": "Nie udało się załadować powiązanych firm",


### PR DESCRIPTION
Fixes #3200

## Problem
Several customers custom command routes executed writes through `commandBus.execute` without the generic CRUD mutation guard (`validateCrudMutationGuard` before the write, `runCrudMutationGuardAfterSuccess` after success). That bypassed the mutation lifecycle used by global write guards, mutation injections, record-lock integrations, and other side effects — inconsistent with neighboring routes (`labels/assign`, `settings/stuck-threshold`) that already wire the contract.

## Root Cause
The affected handlers called the command bus directly and never invoked the mutation-guard contract:
- `api/pipelines/route.ts` (create/update/delete)
- `api/pipeline-stages/route.ts` (create/update/delete)
- `api/pipeline-stages/reorder/route.ts` (reorder)
- `api/tags/assign/route.ts` and `api/tags/unassign/route.ts`
- `api/settings/address-format/route.ts` (save)

## What Changed
- Added `validateCrudMutationGuard` before each command write and `runCrudMutationGuardAfterSuccess` after successful execution, mirroring the reference routes.
- Blocked guard results short-circuit the command and return the structured guard body/status; successful writes run the after-success hook when requested.
- Used stable `resourceKind` / `resourceId` per resource:
  - pipelines → `customers.pipeline` (resourceId: pipeline id; create uses the organization id)
  - pipeline stages → `customers.pipelineStage` (resourceId: stage id; create/reorder use the organization id)
  - tag assign/unassign → `customers.tagAssignment`, operation `custom`, resourceId = target entity id
  - address-format settings → `customers.settings`, operation `update`, resourceId = organization id
- Added a tenant/organization context guard (400) on the mutating handlers that previously lacked one, consistent with the GET handlers in the same files.

## Tests
- New focused API tests for each route proving (a) a blocked guard short-circuits the command and skips the after-success hook, and (b) a successful write invokes the after-success hook:
  - `api/pipelines/__tests__/route.guard.test.ts`
  - `api/pipeline-stages/__tests__/route.guard.test.ts`
  - `api/pipeline-stages/reorder/__tests__/route.guard.test.ts`
  - `api/tags/assign/__tests__/route.guard.test.ts`
  - `api/tags/unassign/__tests__/route.guard.test.ts`
  - `api/settings/address-format/__tests__/route.guard.test.ts`
- `yarn workspace @open-mercato/core test --testPathPattern customers/api` — 43 suites / 183 tests pass.
- `yarn typecheck` (full monorepo) passes.
- `yarn i18n:check-sync` clean.

## Backward Compatibility
No contract surface changes — no API response fields, event IDs, DI keys, ACL features, or import paths altered. Guard `resourceKind` values are new internal identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)