### PR TITLE
fix(customers): wrap config writes in useGuardedMutation (#3201)

### DIFF
--- a/packages/core/src/modules/customers/backend/config/customers/pipeline-stages/page.tsx
+++ b/packages/core/src/modules/customers/backend/config/customers/pipeline-stages/page.tsx
@@ -5,6 +5,7 @@ import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Input } from '@open-mercato/ui/primitives/input'
@@ -65,6 +66,31 @@ export default function PipelineStagesPage() {
   const [stageColor, setStageColor] = React.useState<string | null>(null)
   const [stageIcon, setStageIcon] = React.useState<string | null>(null)
   const [saving, setSaving] = React.useState(false)
+
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: 'customers-pipeline-stages-page',
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const pipelineMutationContext = React.useMemo(
+    () => ({
+      formId: 'customers-pipeline-stages-page',
+      resourceKind: 'customers.pipeline',
+      retryLastMutation,
+    }),
+    [retryLastMutation],
+  )
+  const stageMutationContext = React.useMemo(
+    () => ({
+      formId: 'customers-pipeline-stages-page',
+      resourceKind: 'customers.pipeline_stage',
+      retryLastMutation,
+    }),
+    [retryLastMutation],
+  )
 
   const selectedPipeline = React.useMemo(
     () => pipelines.find((p) => p.id === selectedPipelineId) ?? null,
@@ -135,30 +161,54 @@ export default function PipelineStagesPage() {
     setSaving(true)
     try {
       if (pipelineDialog?.mode === 'create') {
-        const result = await apiCall<{ id: string }>('/api/customers/pipelines', {
-          method: 'POST',
-          body: JSON.stringify({ name: pipelineName.trim(), isDefault: pipelineIsDefault }),
-          headers: { 'Content-Type': 'application/json' },
-        })
-        if (!result.ok) {
-          flash(t('customers.config.pipelineStages.errorCreatePipeline', 'Failed to create pipeline'), 'error')
+        let newId: string | null = null
+        try {
+          await runMutation({
+            operation: async () => {
+              const result = await apiCall<{ id: string }>('/api/customers/pipelines', {
+                method: 'POST',
+                body: JSON.stringify({ name: pipelineName.trim(), isDefault: pipelineIsDefault }),
+                headers: { 'Content-Type': 'application/json' },
+              })
+              if (!result.ok) {
+                throw new Error(t('customers.config.pipelineStages.errorCreatePipeline', 'Failed to create pipeline'))
+              }
+              newId = result.result?.id ?? null
+            },
+            context: pipelineMutationContext,
+            mutationPayload: { action: 'create', name: pipelineName.trim(), isDefault: pipelineIsDefault },
+          })
+        } catch (err) {
+          const msg = err instanceof Error && err.message ? err.message : t('customers.config.pipelineStages.errorCreatePipeline', 'Failed to create pipeline')
+          flash(msg, 'error')
           return
         }
         flash(t('customers.config.pipelineStages.createdPipeline', 'Pipeline created'), 'success')
-        const newId = result.result?.id ?? null
         await loadPipelines()
         if (newId) setSelectedPipelineId(newId)
       } else if (pipelineDialog?.mode === 'edit') {
-        const result = await withScopedApiRequestHeaders(
-          buildOptimisticLockHeader(pipelineDialog.pipeline.updatedAt),
-          () => apiCall('/api/customers/pipelines', {
-            method: 'PUT',
-            body: JSON.stringify({ id: pipelineDialog.pipeline.id, name: pipelineName.trim(), isDefault: pipelineIsDefault }),
-            headers: { 'Content-Type': 'application/json' },
-          }),
-        )
-        if (!result.ok) {
-          flash(t('customers.config.pipelineStages.errorUpdatePipeline', 'Failed to update pipeline'), 'error')
+        const targetPipeline = pipelineDialog.pipeline
+        try {
+          await runMutation({
+            operation: async () => {
+              const result = await withScopedApiRequestHeaders(
+                buildOptimisticLockHeader(targetPipeline.updatedAt),
+                () => apiCall('/api/customers/pipelines', {
+                  method: 'PUT',
+                  body: JSON.stringify({ id: targetPipeline.id, name: pipelineName.trim(), isDefault: pipelineIsDefault }),
+                  headers: { 'Content-Type': 'application/json' },
+                }),
+              )
+              if (!result.ok) {
+                throw new Error(t('customers.config.pipelineStages.errorUpdatePipeline', 'Failed to update pipeline'))
+              }
+            },
+            context: pipelineMutationContext,
+            mutationPayload: { action: 'update', id: targetPipeline.id, name: pipelineName.trim(), isDefault: pipelineIsDefault },
+          })
+        } catch (err) {
+          const msg = err instanceof Error && err.message ? err.message : t('customers.config.pipelineStages.errorUpdatePipeline', 'Failed to update pipeline')
+          flash(msg, 'error')
           return
         }
         flash(t('customers.config.pipelineStages.updatedPipeline', 'Pipeline updated'), 'success')
@@ -181,17 +231,28 @@ export default function PipelineStagesPage() {
       variant: 'destructive',
     })
     if (!confirmed) return
-    const result = await withScopedApiRequestHeaders(
-      buildOptimisticLockHeader(pipeline.updatedAt),
-      () => apiCall('/api/customers/pipelines', {
-        method: 'DELETE',
-        body: JSON.stringify({ id: pipeline.id }),
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
-    if (!result.ok) {
-      const error = (result.result as { error?: string })?.error
-      flash(error ?? t('customers.config.pipelineStages.errorDeletePipeline', 'Failed to delete pipeline'), 'error')
+    try {
+      await runMutation({
+        operation: async () => {
+          const result = await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(pipeline.updatedAt),
+            () => apiCall('/api/customers/pipelines', {
+              method: 'DELETE',
+              body: JSON.stringify({ id: pipeline.id }),
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          )
+          if (!result.ok) {
+            const error = (result.result as { error?: string })?.error
+            throw new Error(error ?? t('customers.config.pipelineStages.errorDeletePipeline', 'Failed to delete pipeline'))
+          }
+        },
+        context: pipelineMutationContext,
+        mutationPayload: { action: 'delete', id: pipeline.id },
+      })
+    } catch (err) {
+      const msg = err instanceof Error && err.message ? err.message : t('customers.config.pipelineStages.errorDeletePipeline', 'Failed to delete pipeline')
+      flash(msg, 'error')
       return
     }
     flash(t('customers.config.pipelineStages.deletedPipeline', 'Pipeline deleted'), 'success')
@@ -222,27 +283,50 @@ export default function PipelineStagesPage() {
           ...(stageColor !== null ? { color: stageColor } : {}),
           ...(stageIcon !== null ? { icon: stageIcon } : {}),
         }
-        const result = await apiCall('/api/customers/pipeline-stages', {
-          method: 'POST',
-          body: JSON.stringify({ pipelineId: selectedPipelineId, label: stageName.trim(), ...appearancePayload }),
-          headers: { 'Content-Type': 'application/json' },
-        })
-        if (!result.ok) {
-          flash(t('customers.config.pipelineStages.errorCreateStage', 'Failed to create stage'), 'error')
+        try {
+          await runMutation({
+            operation: async () => {
+              const result = await apiCall('/api/customers/pipeline-stages', {
+                method: 'POST',
+                body: JSON.stringify({ pipelineId: selectedPipelineId, label: stageName.trim(), ...appearancePayload }),
+                headers: { 'Content-Type': 'application/json' },
+              })
+              if (!result.ok) {
+                throw new Error(t('customers.config.pipelineStages.errorCreateStage', 'Failed to create stage'))
+              }
+            },
+            context: stageMutationContext,
+            mutationPayload: { action: 'create', pipelineId: selectedPipelineId, label: stageName.trim(), ...appearancePayload },
+          })
+        } catch (err) {
+          const msg = err instanceof Error && err.message ? err.message : t('customers.config.pipelineStages.errorCreateStage', 'Failed to create stage')
+          flash(msg, 'error')
           return
         }
         flash(t('customers.config.pipelineStages.createdStage', 'Stage created'), 'success')
       } else if (stageDialog?.mode === 'edit') {
-        const result = await withScopedApiRequestHeaders(
-          buildOptimisticLockHeader(stageDialog.stage.updatedAt),
-          () => apiCall('/api/customers/pipeline-stages', {
-            method: 'PUT',
-            body: JSON.stringify({ id: stageDialog.stage.id, label: stageName.trim(), color: stageColor, icon: stageIcon }),
-            headers: { 'Content-Type': 'application/json' },
-          }),
-        )
-        if (!result.ok) {
-          flash(t('customers.config.pipelineStages.errorUpdateStage', 'Failed to update stage'), 'error')
+        const targetStage = stageDialog.stage
+        try {
+          await runMutation({
+            operation: async () => {
+              const result = await withScopedApiRequestHeaders(
+                buildOptimisticLockHeader(targetStage.updatedAt),
+                () => apiCall('/api/customers/pipeline-stages', {
+                  method: 'PUT',
+                  body: JSON.stringify({ id: targetStage.id, label: stageName.trim(), color: stageColor, icon: stageIcon }),
+                  headers: { 'Content-Type': 'application/json' },
+                }),
+              )
+              if (!result.ok) {
+                throw new Error(t('customers.config.pipelineStages.errorUpdateStage', 'Failed to update stage'))
+              }
+            },
+            context: stageMutationContext,
+            mutationPayload: { action: 'update', id: targetStage.id, label: stageName.trim(), color: stageColor, icon: stageIcon },
+          })
+        } catch (err) {
+          const msg = err instanceof Error && err.message ? err.message : t('customers.config.pipelineStages.errorUpdateStage', 'Failed to update stage')
+          flash(msg, 'error')
           return
         }
         flash(t('customers.config.pipelineStages.updatedStage', 'Stage updated'), 'success')
@@ -265,17 +349,28 @@ export default function PipelineStagesPage() {
       variant: 'destructive',
     })
     if (!confirmed) return
-    const result = await withScopedApiRequestHeaders(
-      buildOptimisticLockHeader(stage.updatedAt),
-      () => apiCall('/api/customers/pipeline-stages', {
-        method: 'DELETE',
-        body: JSON.stringify({ id: stage.id }),
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
-    if (!result.ok) {
-      const error = (result.result as { error?: string })?.error
-      flash(error ?? t('customers.config.pipelineStages.errorDeleteStage', 'Failed to delete stage'), 'error')
+    try {
+      await runMutation({
+        operation: async () => {
+          const result = await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(stage.updatedAt),
+            () => apiCall('/api/customers/pipeline-stages', {
+              method: 'DELETE',
+              body: JSON.stringify({ id: stage.id }),
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          )
+          if (!result.ok) {
+            const error = (result.result as { error?: string })?.error
+            throw new Error(error ?? t('customers.config.pipelineStages.errorDeleteStage', 'Failed to delete stage'))
+          }
+        },
+        context: stageMutationContext,
+        mutationPayload: { action: 'delete', id: stage.id },
+      })
+    } catch (err) {
+      const msg = err instanceof Error && err.message ? err.message : t('customers.config.pipelineStages.errorDeleteStage', 'Failed to delete stage')
+      flash(msg, 'error')
       return
     }
     flash(t('customers.config.pipelineStages.deletedStage', 'Stage deleted'), 'success')
@@ -293,13 +388,25 @@ export default function PipelineStagesPage() {
     const updated = reordered.map((stage, i) => ({ ...stage, order: i }))
     setStages(updated)
 
-    const result = await apiCall('/api/customers/pipeline-stages/reorder', {
-      method: 'POST',
-      body: JSON.stringify({ stages: updated.map((s) => ({ id: s.id, order: s.order })) }),
-      headers: { 'Content-Type': 'application/json' },
-    })
-    if (!result.ok) {
-      flash(t('customers.config.pipelineStages.errorReorder', 'Failed to reorder stages'), 'error')
+    const orderedStages = updated.map((s) => ({ id: s.id, order: s.order }))
+    try {
+      await runMutation({
+        operation: async () => {
+          const result = await apiCall('/api/customers/pipeline-stages/reorder', {
+            method: 'POST',
+            body: JSON.stringify({ stages: orderedStages }),
+            headers: { 'Content-Type': 'application/json' },
+          })
+          if (!result.ok) {
+            throw new Error(t('customers.config.pipelineStages.errorReorder', 'Failed to reorder stages'))
+          }
+        },
+        context: stageMutationContext,
+        mutationPayload: { action: 'reorder', stages: orderedStages },
+      })
+    } catch (err) {
+      const msg = err instanceof Error && err.message ? err.message : t('customers.config.pipelineStages.errorReorder', 'Failed to reorder stages')
+      flash(msg, 'error')
       if (selectedPipelineId) await loadStages(selectedPipelineId)
     }
   }

--- a/packages/core/src/modules/customers/components/AddressFormatSettings.tsx
+++ b/packages/core/src/modules/customers/components/AddressFormatSettings.tsx
@@ -5,8 +5,11 @@ import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { RadioGroup, Radio } from '@open-mercato/ui/primitives/radio'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type { AddressFormatStrategy } from '../utils/addressFormat'
+
+const SAVE_CONTEXT_ID = 'customers-address-format-settings'
 
 type Option = {
   id: AddressFormatStrategy
@@ -20,6 +23,15 @@ export function AddressFormatSettings() {
   const [loading, setLoading] = React.useState(true)
   const [pending, setPending] = React.useState<AddressFormatStrategy | null>(null)
   const [error, setError] = React.useState<string | null>(null)
+
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: SAVE_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
 
   const options = React.useMemo<Option[]>(
     () => [
@@ -87,25 +99,33 @@ export function AddressFormatSettings() {
       setPending(next)
       setError(null)
       try {
-        // optimistic-lock-exempt: single-row tenant address-format preference toggle — no per-record version / concurrent record edit
-        const call = await apiCall<Record<string, unknown>>(
-          '/api/customers/settings/address-format',
-          {
-            method: 'PUT',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ addressFormat: next }),
+        await runMutation({
+          // optimistic-lock-exempt: single-row tenant address-format preference toggle — no per-record version / concurrent record edit
+          operation: async () => {
+            const call = await apiCall<Record<string, unknown>>(
+              '/api/customers/settings/address-format',
+              {
+                method: 'PUT',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ addressFormat: next }),
+              },
+            )
+            const payload = call.result ?? {}
+            if (!call.ok) {
+              const message =
+                typeof payload?.error === 'string'
+                  ? payload.error
+                  : t('customers.config.addressFormat.errorSave', 'Failed to update address settings')
+              throw new Error(message)
+            }
           },
-        )
-        const payload = call.result ?? {}
-        if (!call.ok) {
-          const message =
-            typeof payload?.error === 'string'
-              ? payload.error
-              : t('customers.config.addressFormat.errorSave', 'Failed to update address settings')
-          setError(message)
-          flash(message, 'error')
-          return
-        }
+          context: {
+            formId: SAVE_CONTEXT_ID,
+            resourceKind: 'customers.settings',
+            retryLastMutation,
+          },
+          mutationPayload: { addressFormat: next },
+        })
         setFormat(next)
         flash(t('customers.config.addressFormat.success', 'Address format updated'), 'success')
       } catch (err) {
@@ -119,7 +139,7 @@ export function AddressFormatSettings() {
         setPending(null)
       }
     },
-    [format, t]
+    [format, retryLastMutation, runMutation, t]
   )
 
   return (

--- a/packages/core/src/modules/customers/components/DictionarySettings.tsx
+++ b/packages/core/src/modules/customers/components/DictionarySettings.tsx
@@ -10,6 +10,7 @@ import {
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { apiCallOrThrow, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
@@ -128,6 +129,24 @@ function CustomerDictionarySection({ kind, title, description }: CustomerDiction
   const [dialog, setDialog] = React.useState<DialogState | null>(null)
   const [submitting, setSubmitting] = React.useState(false)
 
+  const saveContextId = `customers-dictionary-${kind}`
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: saveContextId,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const mutationContext = React.useMemo(
+    () => ({
+      formId: saveContextId,
+      resourceKind: 'customers.dictionary',
+      retryLastMutation,
+    }),
+    [retryLastMutation, saveContextId],
+  )
+
   const inheritedActionBlocked = t('customers.config.dictionaries.inherited.blocked', 'Inherited entries can only be edited from the parent organization.')
   const inheritedTooltip = t('customers.config.dictionaries.inherited.tooltip', 'Managed in parent organization')
   const inheritedLabel = t('customers.config.dictionaries.inherited.label', 'Inherited')
@@ -221,13 +240,18 @@ function CustomerDictionarySection({ kind, title, description }: CustomerDiction
     })
     if (!confirmed) return
     try {
-      await withScopedApiRequestHeaders(buildOptimisticLockHeader(entry.updatedAt), () =>
-        apiCallOrThrow(
-          `/api/customers/dictionaries/${kind}/${encodeURIComponent(entry.id)}`,
-          { method: 'DELETE' },
-          { errorMessage: errorDelete },
-        ),
-      )
+      await runMutation({
+        operation: () =>
+          withScopedApiRequestHeaders(buildOptimisticLockHeader(entry.updatedAt), () =>
+            apiCallOrThrow(
+              `/api/customers/dictionaries/${kind}/${encodeURIComponent(entry.id)}`,
+              { method: 'DELETE' },
+              { errorMessage: errorDelete },
+            ),
+          ),
+        context: mutationContext,
+        mutationPayload: { action: 'delete', id: entry.id, kind },
+      })
       flash(successDelete, 'success')
       await loadEntries()
     } catch (err) {
@@ -245,7 +269,7 @@ function CustomerDictionarySection({ kind, title, description }: CustomerDiction
       const messageValue = err instanceof Error ? err.message : errorDelete
       flash(messageValue, 'error')
     }
-  }, [confirm, deleteConfirmTemplate, errorDelete, formatCountMessage, inheritedActionBlocked, kind, loadEntries, roleTypeDeleteBlockedText, roleTypeDeleteBlockedTitle, successDelete, t])
+  }, [confirm, deleteConfirmTemplate, errorDelete, formatCountMessage, inheritedActionBlocked, kind, loadEntries, mutationContext, roleTypeDeleteBlockedText, roleTypeDeleteBlockedTitle, runMutation, successDelete, t])
 
   const submitForm = React.useCallback(async (values: DictionaryFormValues) => {
     const payload = {
@@ -257,15 +281,20 @@ function CustomerDictionarySection({ kind, title, description }: CustomerDiction
     setSubmitting(true)
     try {
       if (!dialog || dialog.mode === 'create') {
-        await apiCallOrThrow(
-          `/api/customers/dictionaries/${kind}`,
-          {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify(payload),
-          },
-          { errorMessage: errorSave },
-        )
+        await runMutation({
+          operation: () =>
+            apiCallOrThrow(
+              `/api/customers/dictionaries/${kind}`,
+              {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify(payload),
+              },
+              { errorMessage: errorSave },
+            ),
+          context: mutationContext,
+          mutationPayload: { action: 'create', kind, ...payload },
+        })
         flash(successSave, 'success')
       } else if (dialog.mode === 'edit') {
         const target = dialog.entry
@@ -284,17 +313,22 @@ function CustomerDictionarySection({ kind, title, description }: CustomerDiction
           closeDialog()
           return
         }
-        await withScopedApiRequestHeaders(buildOptimisticLockHeader(target.updatedAt), () =>
-          apiCallOrThrow(
-            `/api/customers/dictionaries/${kind}/${encodeURIComponent(target.id)}`,
-            {
-              method: 'PATCH',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify(body),
-            },
-            { errorMessage: errorSave },
-          ),
-        )
+        await runMutation({
+          operation: () =>
+            withScopedApiRequestHeaders(buildOptimisticLockHeader(target.updatedAt), () =>
+              apiCallOrThrow(
+                `/api/customers/dictionaries/${kind}/${encodeURIComponent(target.id)}`,
+                {
+                  method: 'PATCH',
+                  headers: { 'content-type': 'application/json' },
+                  body: JSON.stringify(body),
+                },
+                { errorMessage: errorSave },
+              ),
+            ),
+          context: mutationContext,
+          mutationPayload: { action: 'update', id: target.id, kind, ...body },
+        })
         flash(successSave, 'success')
       }
       closeDialog()
@@ -305,7 +339,7 @@ function CustomerDictionarySection({ kind, title, description }: CustomerDiction
     } finally {
       setSubmitting(false)
     }
-  }, [closeDialog, dialog, errorSave, inheritedActionBlocked, kind, loadEntries, successSave])
+  }, [closeDialog, dialog, errorSave, inheritedActionBlocked, kind, loadEntries, mutationContext, runMutation, successSave])
 
   const currentValues = React.useMemo<DictionaryFormValues>(() => {
     if (dialog && dialog.mode === 'edit') {

--- a/packages/core/src/modules/customers/components/PipelineSettings.tsx
+++ b/packages/core/src/modules/customers/components/PipelineSettings.tsx
@@ -16,6 +16,7 @@ import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { apiCall, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
@@ -103,6 +104,31 @@ export default function PipelineSettings(): React.ReactElement {
   const [stageForm, setStageForm] = React.useState({ label: '', color: null as string | null, icon: null as string | null })
   const [submittingStage, setSubmittingStage] = React.useState(false)
 
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: 'customers-pipeline-settings',
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const pipelineMutationContext = React.useMemo(
+    () => ({
+      formId: 'customers-pipeline-settings',
+      resourceKind: 'customers.pipeline',
+      retryLastMutation,
+    }),
+    [retryLastMutation],
+  )
+  const stageMutationContext = React.useMemo(
+    () => ({
+      formId: 'customers-pipeline-settings',
+      resourceKind: 'customers.pipeline_stage',
+      retryLastMutation,
+    }),
+    [retryLastMutation],
+  )
+
   const loadPipelines = React.useCallback(async () => {
     setLoadingPipelines(true)
     try {
@@ -165,38 +191,50 @@ export default function PipelineSettings(): React.ReactElement {
     setSubmittingPipeline(true)
     try {
       if (pipelineDialog?.mode === 'create') {
-        const res = await apiCall('/api/customers/pipelines', {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ name: pipelineForm.name.trim(), isDefault: pipelineForm.isDefault }),
+        await runMutation({
+          operation: async () => {
+            const res = await apiCall('/api/customers/pipelines', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ name: pipelineForm.name.trim(), isDefault: pipelineForm.isDefault }),
+            })
+            if (!res.ok) {
+              await raiseCrudError(res.response, t('customers.pipelines.errors.createFailed', 'Failed to create pipeline'))
+            }
+          },
+          context: pipelineMutationContext,
+          mutationPayload: { action: 'create', name: pipelineForm.name.trim(), isDefault: pipelineForm.isDefault },
         })
-        if (!res.ok) {
-          await raiseCrudError(res.response, t('customers.pipelines.errors.createFailed', 'Failed to create pipeline'))
-          return
-        }
         flash(t('customers.pipelines.flash.created', 'Pipeline created'), 'success')
       } else if (pipelineDialog?.mode === 'edit') {
-        const res = await withScopedApiRequestHeaders(
-          buildOptimisticLockHeader(pipelineDialog.entry.updatedAt),
-          () =>
-            apiCall('/api/customers/pipelines', {
-              method: 'PUT',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ id: pipelineDialog.entry.id, name: pipelineForm.name.trim(), isDefault: pipelineForm.isDefault }),
-            }),
-        )
-        if (!res.ok) {
-          await raiseCrudError(res.response, t('customers.pipelines.errors.updateFailed', 'Failed to update pipeline'))
-          return
-        }
+        await runMutation({
+          operation: async () => {
+            const res = await withScopedApiRequestHeaders(
+              buildOptimisticLockHeader(pipelineDialog.entry.updatedAt),
+              () =>
+                apiCall('/api/customers/pipelines', {
+                  method: 'PUT',
+                  headers: { 'content-type': 'application/json' },
+                  body: JSON.stringify({ id: pipelineDialog.entry.id, name: pipelineForm.name.trim(), isDefault: pipelineForm.isDefault }),
+                }),
+            )
+            if (!res.ok) {
+              await raiseCrudError(res.response, t('customers.pipelines.errors.updateFailed', 'Failed to update pipeline'))
+            }
+          },
+          context: pipelineMutationContext,
+          mutationPayload: { action: 'update', id: pipelineDialog.entry.id, name: pipelineForm.name.trim(), isDefault: pipelineForm.isDefault },
+        })
         flash(t('customers.pipelines.flash.updated', 'Pipeline updated'), 'success')
       }
       setPipelineDialog(null)
       await loadPipelines()
+    } catch {
+      return
     } finally {
       setSubmittingPipeline(false)
     }
-  }, [pipelineDialog, pipelineForm, loadPipelines, t])
+  }, [pipelineDialog, pipelineForm, loadPipelines, pipelineMutationContext, runMutation, t])
 
   const handleDeletePipeline = React.useCallback(async (pipeline: Pipeline) => {
     const confirmed = await confirm({
@@ -206,25 +244,36 @@ export default function PipelineSettings(): React.ReactElement {
       variant: 'destructive',
     })
     if (!confirmed) return
-    const res = await withScopedApiRequestHeaders(
-      buildOptimisticLockHeader(pipeline.updatedAt),
-      () =>
-        apiCall('/api/customers/pipelines', {
-          method: 'DELETE',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ id: pipeline.id }),
-        }),
-    )
-    if (!res.ok) {
-      const body = (res.result ?? {}) as Record<string, unknown>
-      const msg = typeof body.error === 'string' ? body.error : t('customers.pipelines.errors.deleteFailed', 'Failed to delete pipeline')
+    try {
+      await runMutation({
+        operation: async () => {
+          const res = await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(pipeline.updatedAt),
+            () =>
+              apiCall('/api/customers/pipelines', {
+                method: 'DELETE',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ id: pipeline.id }),
+              }),
+          )
+          if (!res.ok) {
+            const body = (res.result ?? {}) as Record<string, unknown>
+            const msg = typeof body.error === 'string' ? body.error : t('customers.pipelines.errors.deleteFailed', 'Failed to delete pipeline')
+            throw new Error(msg)
+          }
+        },
+        context: pipelineMutationContext,
+        mutationPayload: { action: 'delete', id: pipeline.id },
+      })
+    } catch (err) {
+      const msg = err instanceof Error && err.message ? err.message : t('customers.pipelines.errors.deleteFailed', 'Failed to delete pipeline')
       flash(msg, 'error')
       return
     }
     flash(t('customers.pipelines.flash.deleted', 'Pipeline deleted'), 'success')
     if (expandedPipelineId === pipeline.id) setExpandedPipelineId(null)
     await loadPipelines()
-  }, [confirm, expandedPipelineId, loadPipelines, t])
+  }, [confirm, expandedPipelineId, loadPipelines, pipelineMutationContext, runMutation, t])
 
   const openCreateStage = React.useCallback((pipelineId: string) => {
     setStageForm({ label: '', color: null, icon: null })
@@ -249,39 +298,53 @@ export default function PipelineSettings(): React.ReactElement {
       if (stageForm.icon) appearance.icon = stageForm.icon
 
       if (stageDialog?.mode === 'create') {
-        const res = await apiCall('/api/customers/pipeline-stages', {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ pipelineId: stageDialog.pipelineId, label: stageForm.label.trim(), ...appearance }),
-        })
-        if (!res.ok) {
-          await raiseCrudError(res.response, t('customers.pipelines.errors.stageCreateFailed', 'Failed to create stage'))
-          return
-        }
-        flash(t('customers.pipelines.flash.stageCreated', 'Stage created'), 'success')
-        await loadStages(stageDialog.pipelineId)
-      } else if (stageDialog?.mode === 'edit') {
-        const res = await withScopedApiRequestHeaders(
-          buildOptimisticLockHeader(stageDialog.entry.updatedAt),
-          () =>
-            apiCall('/api/customers/pipeline-stages', {
-              method: 'PUT',
+        const targetPipelineId = stageDialog.pipelineId
+        await runMutation({
+          operation: async () => {
+            const res = await apiCall('/api/customers/pipeline-stages', {
+              method: 'POST',
               headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ id: stageDialog.entry.id, label: stageForm.label.trim(), ...appearance }),
-            }),
-        )
-        if (!res.ok) {
-          await raiseCrudError(res.response, t('customers.pipelines.errors.stageUpdateFailed', 'Failed to update stage'))
-          return
-        }
+              body: JSON.stringify({ pipelineId: targetPipelineId, label: stageForm.label.trim(), ...appearance }),
+            })
+            if (!res.ok) {
+              await raiseCrudError(res.response, t('customers.pipelines.errors.stageCreateFailed', 'Failed to create stage'))
+            }
+          },
+          context: stageMutationContext,
+          mutationPayload: { action: 'create', pipelineId: targetPipelineId, label: stageForm.label.trim(), ...appearance },
+        })
+        flash(t('customers.pipelines.flash.stageCreated', 'Stage created'), 'success')
+        await loadStages(targetPipelineId)
+      } else if (stageDialog?.mode === 'edit') {
+        const targetStage = stageDialog.entry
+        await runMutation({
+          operation: async () => {
+            const res = await withScopedApiRequestHeaders(
+              buildOptimisticLockHeader(targetStage.updatedAt),
+              () =>
+                apiCall('/api/customers/pipeline-stages', {
+                  method: 'PUT',
+                  headers: { 'content-type': 'application/json' },
+                  body: JSON.stringify({ id: targetStage.id, label: stageForm.label.trim(), ...appearance }),
+                }),
+            )
+            if (!res.ok) {
+              await raiseCrudError(res.response, t('customers.pipelines.errors.stageUpdateFailed', 'Failed to update stage'))
+            }
+          },
+          context: stageMutationContext,
+          mutationPayload: { action: 'update', id: targetStage.id, label: stageForm.label.trim(), ...appearance },
+        })
         flash(t('customers.pipelines.flash.stageUpdated', 'Stage updated'), 'success')
-        await loadStages(stageDialog.entry.pipelineId)
+        await loadStages(targetStage.pipelineId)
       }
       setStageDialog(null)
+    } catch {
+      return
     } finally {
       setSubmittingStage(false)
     }
-  }, [stageDialog, stageForm, loadStages, t])
+  }, [stageDialog, stageForm, loadStages, runMutation, stageMutationContext, t])
 
   const handleDeleteStage = React.useCallback(async (stage: PipelineStage) => {
     const confirmed = await confirm({
@@ -291,24 +354,35 @@ export default function PipelineSettings(): React.ReactElement {
       variant: 'destructive',
     })
     if (!confirmed) return
-    const res = await withScopedApiRequestHeaders(
-      buildOptimisticLockHeader(stage.updatedAt),
-      () =>
-        apiCall('/api/customers/pipeline-stages', {
-          method: 'DELETE',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ id: stage.id }),
-        }),
-    )
-    if (!res.ok) {
-      const body = (res.result ?? {}) as Record<string, unknown>
-      const msg = typeof body.error === 'string' ? body.error : t('customers.pipelines.errors.stageDeleteFailed', 'Failed to delete stage')
+    try {
+      await runMutation({
+        operation: async () => {
+          const res = await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(stage.updatedAt),
+            () =>
+              apiCall('/api/customers/pipeline-stages', {
+                method: 'DELETE',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ id: stage.id }),
+              }),
+          )
+          if (!res.ok) {
+            const body = (res.result ?? {}) as Record<string, unknown>
+            const msg = typeof body.error === 'string' ? body.error : t('customers.pipelines.errors.stageDeleteFailed', 'Failed to delete stage')
+            throw new Error(msg)
+          }
+        },
+        context: stageMutationContext,
+        mutationPayload: { action: 'delete', id: stage.id },
+      })
+    } catch (err) {
+      const msg = err instanceof Error && err.message ? err.message : t('customers.pipelines.errors.stageDeleteFailed', 'Failed to delete stage')
       flash(msg, 'error')
       return
     }
     flash(t('customers.pipelines.flash.stageDeleted', 'Stage deleted'), 'success')
     await loadStages(stage.pipelineId)
-  }, [confirm, loadStages, t])
+  }, [confirm, loadStages, runMutation, stageMutationContext, t])
 
   const handleMoveStage = React.useCallback(async (stage: PipelineStage, direction: 'up' | 'down') => {
     const pipelineStages = stages[stage.pipelineId] ?? []
@@ -323,17 +397,28 @@ export default function PipelineSettings(): React.ReactElement {
     reordered[swapIdx] = temp
 
     const orderedStages = reordered.map((s, i) => ({ id: s.id, order: i }))
-    const res = await apiCall('/api/customers/pipeline-stages/reorder', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ stages: orderedStages }),
-    })
-    if (!res.ok) {
-      flash(t('customers.pipelines.errors.reorderFailed', 'Failed to reorder stages'), 'error')
+    try {
+      await runMutation({
+        operation: async () => {
+          const res = await apiCall('/api/customers/pipeline-stages/reorder', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ stages: orderedStages }),
+          })
+          if (!res.ok) {
+            throw new Error(t('customers.pipelines.errors.reorderFailed', 'Failed to reorder stages'))
+          }
+        },
+        context: stageMutationContext,
+        mutationPayload: { action: 'reorder', stages: orderedStages },
+      })
+    } catch (err) {
+      const msg = err instanceof Error && err.message ? err.message : t('customers.pipelines.errors.reorderFailed', 'Failed to reorder stages')
+      flash(msg, 'error')
       return
     }
     await loadStages(stage.pipelineId)
-  }, [stages, loadStages, t])
+  }, [stages, loadStages, runMutation, stageMutationContext, t])
 
   const handleKeyDown = React.useCallback(
     (handler: () => void) => (e: React.KeyboardEvent) => {

--- a/packages/core/src/modules/customers/components/__tests__/AddressFormatSettings.test.tsx
+++ b/packages/core/src/modules/customers/components/__tests__/AddressFormatSettings.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import AddressFormatSettings from '../AddressFormatSettings'
+
+const apiCallMock = jest.fn()
+const runMutationMock = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: (...args: unknown[]) => runMutationMock(...(args as [{ operation: () => Promise<unknown> }])),
+    retryLastMutation: jest.fn(),
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+describe('AddressFormatSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    apiCallMock.mockImplementation(async (path: string, init?: { method?: string }) => {
+      if (!init || !init.method) {
+        return { ok: true, result: { addressFormat: 'line_first' } }
+      }
+      return { ok: true, result: {} }
+    })
+  })
+
+  it('routes the address-format toggle through the guarded mutation runner', async () => {
+    renderWithProviders(<AddressFormatSettings />)
+
+    await waitFor(() => {
+      expect(apiCallMock).toHaveBeenCalledWith('/api/customers/settings/address-format')
+    })
+
+    fireEvent.click(await screen.findByLabelText(/Street-first/i))
+
+    await waitFor(() => {
+      expect(runMutationMock).toHaveBeenCalledTimes(1)
+    })
+    expect(runMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          resourceKind: 'customers.settings',
+          retryLastMutation: expect.any(Function),
+        }),
+        mutationPayload: { addressFormat: 'street_first' },
+      }),
+    )
+    expect(apiCallMock).toHaveBeenCalledWith(
+      '/api/customers/settings/address-format',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ addressFormat: 'street_first' }),
+      }),
+    )
+  })
+})

--- a/packages/core/src/modules/customers/components/__tests__/DictionarySettings.test.tsx
+++ b/packages/core/src/modules/customers/components/__tests__/DictionarySettings.test.tsx
@@ -9,10 +9,23 @@ import DictionarySettings from '../DictionarySettings'
 const apiCallOrThrowMock = jest.fn()
 const readApiResultOrThrowMock = jest.fn()
 const confirmMock = jest.fn()
+const runMutationMock = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
 
 jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
   apiCallOrThrow: (...args: unknown[]) => apiCallOrThrowMock(...args),
   readApiResultOrThrow: (...args: unknown[]) => readApiResultOrThrowMock(...args),
+  withScopedApiRequestHeaders: (_headers: unknown, fn: () => Promise<unknown>) => fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: (...args: unknown[]) => runMutationMock(...(args as [{ operation: () => Promise<unknown> }])),
+    retryLastMutation: jest.fn(),
+  }),
 }))
 
 jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
@@ -100,5 +113,47 @@ describe('DictionarySettings', () => {
       }),
     )
     expect(apiCallOrThrowMock).not.toHaveBeenCalled()
+  })
+
+  it('routes a confirmed dictionary delete through the guarded mutation runner', async () => {
+    confirmMock.mockResolvedValue(true)
+    apiCallOrThrowMock.mockResolvedValue(undefined)
+    readApiResultOrThrowMock.mockImplementation(async (path: string) => {
+      if (path === '/api/customers/dictionaries/statuses') {
+        return {
+          items: [
+            {
+              id: 'status-1',
+              value: 'active',
+              label: 'Active',
+              updatedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }
+      }
+      return { items: [] }
+    })
+
+    renderWithProviders(<DictionarySettings />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'delete-Statuses' }))
+
+    await waitFor(() => {
+      expect(runMutationMock).toHaveBeenCalledTimes(1)
+    })
+    expect(runMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          resourceKind: 'customers.dictionary',
+          retryLastMutation: expect.any(Function),
+        }),
+        mutationPayload: expect.objectContaining({ action: 'delete', id: 'status-1', kind: 'statuses' }),
+      }),
+    )
+    expect(apiCallOrThrowMock).toHaveBeenCalledWith(
+      '/api/customers/dictionaries/statuses/status-1',
+      { method: 'DELETE' },
+      expect.any(Object),
+    )
   })
 })

--- a/packages/core/src/modules/customers/components/__tests__/PipelineSettings.test.tsx
+++ b/packages/core/src/modules/customers/components/__tests__/PipelineSettings.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import PipelineSettings from '../PipelineSettings'
+
+const apiCallMock = jest.fn()
+const readApiResultOrThrowMock = jest.fn()
+const runMutationMock = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+  readApiResultOrThrow: (...args: unknown[]) => readApiResultOrThrowMock(...args),
+  withScopedApiRequestHeaders: (_headers: unknown, fn: () => Promise<unknown>) => fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/serverErrors', () => ({
+  raiseCrudError: jest.fn(async () => {
+    throw new Error('[internal] crud error')
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: (...args: unknown[]) => runMutationMock(...(args as [{ operation: () => Promise<unknown> }])),
+    retryLastMutation: jest.fn(),
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 0,
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({
+    confirm: jest.fn().mockResolvedValue(true),
+    ConfirmDialogElement: null,
+  }),
+}))
+
+jest.mock('@open-mercato/core/modules/dictionaries/components/AppearanceSelector', () => ({
+  AppearanceSelector: () => null,
+}))
+
+jest.mock('@open-mercato/core/modules/dictionaries/components/dictionaryAppearance', () => ({
+  renderDictionaryColor: () => null,
+  renderDictionaryIcon: () => null,
+}))
+
+describe('PipelineSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    readApiResultOrThrowMock.mockResolvedValue({ items: [] })
+    apiCallMock.mockResolvedValue({ ok: true, result: {}, response: { ok: true } })
+  })
+
+  it('routes a pipeline create through the guarded mutation runner', async () => {
+    renderWithProviders(<PipelineSettings />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add pipeline' }))
+
+    const nameInput = await screen.findByPlaceholderText('e.g. New Business')
+    fireEvent.change(nameInput, { target: { value: 'New Business' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(runMutationMock).toHaveBeenCalledTimes(1)
+    })
+    expect(runMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          resourceKind: 'customers.pipeline',
+          retryLastMutation: expect.any(Function),
+        }),
+        mutationPayload: expect.objectContaining({ action: 'create', name: 'New Business' }),
+      }),
+    )
+    expect(apiCallMock).toHaveBeenCalledWith(
+      '/api/customers/pipelines',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+})


### PR DESCRIPTION
Fixes #3201

## Problem
Several customers config/settings components performed non-`CrudForm` writes directly with `apiCall` / `apiCallOrThrow` instead of routing them through `useGuardedMutation`. That bypasses the shared backend UI mutation lifecycle used for record locks, conflict UI, retry context, and global mutation injections — which the customers module treats as a local rule (backend writes outside `CrudForm` MUST use `useGuardedMutation` and provide retry/mutation context).

## Root Cause
These components predate / never adopted the `useGuardedMutation` wrapper that the reference `DictionarySortSettings` already uses. They sent raw mutating requests directly.

## What Changed
Wrapped every remaining non-`CrudForm` write in `useGuardedMutation(...).runMutation(...)`, passing a stable `contextId`, a `context` with `resourceKind` + `retryLastMutation`, and a `mutationPayload`:

- `components/AddressFormatSettings.tsx` — address-format `PUT` toggle.
- `components/DictionarySettings.tsx` — dictionary entry create (`POST`), update (`PATCH`), delete (`DELETE`).
- `components/PipelineSettings.tsx` — pipeline + stage create/update/delete and stage reorder.
- `backend/config/customers/pipeline-stages/page.tsx` — same coverage for the standalone settings page.

Existing optimistic-lock headers (`buildOptimisticLockHeader` + `withScopedApiRequestHeaders`), `optimistic-lock-exempt` markers, and all flash/error/early-return behavior are preserved. `runMutation` now also surfaces 409 record-lock conflicts via the unified conflict bar automatically.

## Tests
- `components/__tests__/AddressFormatSettings.test.tsx` (new) — asserts the toggle routes through `runMutation` with the correct context/payload and issues the `PUT`.
- `components/__tests__/PipelineSettings.test.tsx` (new) — asserts pipeline create routes through `runMutation` and issues the `POST`.
- `components/__tests__/DictionarySettings.test.tsx` (extended) — asserts a confirmed delete routes through `runMutation` and issues the `DELETE`; keeps the existing role-in-use guard test.
- Verified `optimistic-lock-ui-coverage` guard still passes.
- Full `yarn typecheck` green; `yarn i18n:check-sync` in sync; all 60 customers component suites pass.

## Backward Compatibility
No contract surface changes — UI-only refactor reusing existing API routes, i18n keys, and lock primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)