### PR TITLE
chore(deps): bump undici resolution to 7.28.0 to clear high CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "flatted": "3.4.2",
     "socket.io-parser": "4.2.6",
     "tar": "7.5.16",
-    "undici": "7.24.0",
+    "undici": "7.28.0",
     "brace-expansion": "5.0.5",
     "handlebars": "4.7.9",
     "path-to-regexp": "0.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29391,10 +29391,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:7.24.0":
-  version: 7.24.0
-  resolution: "undici@npm:7.24.0"
-  checksum: 10/663f08fe940e6cea3633748c82a77e975ab61d7e1d3fd9951a13213c4ddbc5c8196f741b57b52d0df9d08a34092b6aa31eeaff8cd545a0a23cacd0523c21a398
+"undici@npm:7.28.0":
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10/154423b280d623278a61decb437f8a7e581fb18b8c95556ef956b32a58cd668eadbb812d28e20678cb2dc545a566f35a3afc0962307ca801da30f4741117986d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

The CI `audit` job (`yarn npm audit --all --recursive --severity high`) is failing **repo-wide — including on `develop`** — so it blocks the rest of the pipeline (`test`, `ephemeral-integration`, `merge-coverage` all `need: audit` and are skipped). One of the offending advisories is **undici**, pinned to `7.24.0` by the root `resolutions`, which falls in the vulnerable range `>=7.23.0 <7.28.0`:

- [GHSA-vmh5-mc38-953g](https://github.com/advisories/GHSA-vmh5-mc38-953g) — undici TLS certificate validation bypass via dropped `requestTls` in SOCKS5 ProxyAgent (severity: high).

## What

- `resolutions.undici`: `7.24.0` → `7.28.0` (first fixed release, same v7 line — low risk).
- Regenerated `yarn.lock`.

Verified locally: `yarn npm audit --all --recursive --severity high` no longer reports undici.

## Scope note

This is the **low-risk half** of the audit cleanup. The remaining high CVE is **nodemailer** (`<=9.0.0`, via `channel-imap`/`mailparser`), which needs a **major bump (8 → 9.0.1+/10.x)** and is intentionally left out of this PR. So `audit` will still fail on nodemailer until that is addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)