### PR TITLE
perf(dashboards): fetch comparison widget data in parallel with primary query (#3208)

### DIFF
--- a/packages/core/src/modules/dashboards/services/__tests__/widgetDataService.test.ts
+++ b/packages/core/src/modules/dashboards/services/__tests__/widgetDataService.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment node
+ */
+import type { EntityManager } from '@mikro-orm/postgresql'
+import {
+  WidgetDataService,
+  type WidgetDataRequest,
+} from '../widgetDataService'
+import type { AnalyticsRegistry } from '../analyticsRegistry'
+
+jest.mock('../../lib/aggregations', () => ({
+  ...jest.requireActual('../../lib/aggregations'),
+  buildAggregationQuery: jest.fn(() => ({ sql: 'SELECT 1', params: [] })),
+}))
+
+type ExecuteResult = Array<Record<string, unknown>>
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+function createRegistry(): AnalyticsRegistry {
+  return {
+    getAllEntityConfigs: () => [],
+    getEntityConfig: () => null,
+    isValidEntityType: () => true,
+    getEntityTypeConfig: () => null,
+    getFieldMapping: () => ({ dbColumn: 'total', type: 'number' }),
+    getRequiredFeatures: () => null,
+    getLabelResolverConfig: () => null,
+    getAllFieldMappings: () => null,
+  }
+}
+
+function createService(execute: (sql: string, params: unknown[]) => Promise<ExecuteResult>) {
+  const em = {
+    getConnection: () => ({ execute }),
+  } as unknown as EntityManager
+  return new WidgetDataService({
+    em,
+    scope: { tenantId: 'tenant-1' },
+    registry: createRegistry(),
+  })
+}
+
+const comparisonRequest: WidgetDataRequest = {
+  entityType: 'sales:orders',
+  metric: { field: 'total', aggregate: 'sum' },
+  dateRange: { field: 'created_at', preset: 'this_month' },
+  comparison: { type: 'previous_period' },
+}
+
+describe('WidgetDataService comparison fetching', () => {
+  test('runs the primary and comparison queries in parallel', async () => {
+    const deferreds = [createDeferred<ExecuteResult>(), createDeferred<ExecuteResult>()]
+    let started = 0
+    const execute = jest.fn(async () => {
+      const deferred = deferreds[started]
+      started += 1
+      return deferred.promise
+    })
+
+    const service = createService(execute)
+    const pending = service.fetchWidgetData(comparisonRequest)
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(execute).toHaveBeenCalledTimes(2)
+
+    deferreds[0].resolve([{ value: 200 }])
+    deferreds[1].resolve([{ value: 100 }])
+
+    const response = await pending
+    expect(response.value).toBe(200)
+    expect(response.comparison).toEqual({
+      value: 100,
+      change: 100,
+      direction: 'up',
+    })
+  })
+
+  test('preserves the comparison response shape and math', async () => {
+    const execute = jest.fn(async (_sql: string, _params: unknown[]): Promise<ExecuteResult> => {
+      const call = execute.mock.calls.length
+      return call === 1 ? [{ value: 80 }] : [{ value: 100 }]
+    })
+
+    const service = createService(execute)
+    const response = await service.fetchWidgetData(comparisonRequest)
+
+    expect(execute).toHaveBeenCalledTimes(2)
+    expect(response.value).toBe(80)
+    expect(response.data).toEqual([])
+    expect(response.metadata.recordCount).toBe(1)
+    expect(response.comparison).toEqual({
+      value: 100,
+      change: -20,
+      direction: 'down',
+    })
+  })
+
+  test('runs a single query and omits comparison when none is requested', async () => {
+    const execute = jest.fn(async (): Promise<ExecuteResult> => [{ value: 42 }])
+    const service = createService(execute)
+
+    const response = await service.fetchWidgetData({
+      entityType: 'sales:orders',
+      metric: { field: 'total', aggregate: 'sum' },
+      dateRange: { field: 'created_at', preset: 'this_month' },
+    })
+
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(response.value).toBe(42)
+    expect(response.comparison).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/dashboards/services/widgetDataService.ts
+++ b/packages/core/src/modules/dashboards/services/widgetDataService.ts
@@ -145,12 +145,14 @@ export class WidgetDataService {
       }
     }
 
-    const mainResult = await this.executeQuery(request, dateRangeResolved)
+    const shouldFetchComparison = Boolean(comparisonRange && request.dateRange)
 
-    let comparisonResult: { value: number | null; data: WidgetDataItem[] } | undefined
-    if (comparisonRange && request.dateRange) {
-      comparisonResult = await this.executeQuery(request, comparisonRange)
-    }
+    const [mainResult, comparisonResult] = await Promise.all([
+      this.executeQuery(request, dateRangeResolved),
+      shouldFetchComparison && comparisonRange
+        ? this.executeQuery(request, comparisonRange)
+        : Promise.resolve<{ value: number | null; data: WidgetDataItem[] } | undefined>(undefined),
+    ])
 
     const response: WidgetDataResponse = {
       value: mainResult.value,


### PR DESCRIPTION
Fixes #3208

## Problem
Dashboard widget data with period-over-period comparison ran the primary aggregation query and the comparison aggregation query sequentially. Both date ranges are resolved before either query starts and the two queries are independent, so awaiting them serially added avoidable latency to every KPI and chart widget that requests comparison data.

## Root Cause
`WidgetDataService.fetchWidgetData` awaited `executeQuery(request, dateRangeResolved)` for the primary result, then awaited `executeQuery(request, comparisonRange)` for the comparison result. The comparison result is only combined with the main result after both exist, so the second `await` blocked needlessly on the first.

## What Changed
- `packages/core/src/modules/dashboards/services/widgetDataService.ts`: start the primary and (when requested) comparison `executeQuery` calls together via `Promise.all`, resolving the comparison slot to `undefined` when no comparison is requested. Response shape, cache behavior, request validation, and comparison math are unchanged.

## Tests
- New `packages/core/src/modules/dashboards/services/__tests__/widgetDataService.test.ts`:
  - proves both queries are in flight simultaneously when a comparison is requested (would fail under the previous serial implementation)
  - asserts the comparison response shape and percentage-change/direction math are unchanged
  - confirms a single query runs and no `comparison` block is emitted when no comparison is requested
- `yarn workspace @open-mercato/core test --testPathPatterns dashboards` (87 passed)
- `yarn workspace @open-mercato/core typecheck` (clean)

## Backward Compatibility
- No contract surface changes — public method signature, `WidgetDataResponse` shape, cache keys/tags, and comparison semantics are identical. Only query execution order changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)