### PR TITLE
fix(dashboards): wrap widget visibility saves in useGuardedMutation (#3206)

### DIFF
--- a/packages/core/src/modules/dashboards/components/WidgetVisibilityEditor.tsx
+++ b/packages/core/src/modules/dashboards/components/WidgetVisibilityEditor.tsx
@@ -6,8 +6,11 @@ import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { RadioGroup } from '@open-mercato/ui/primitives/radio'
 import { RadioField } from '@open-mercato/ui/primitives/radio-field'
 import { apiCallOrThrow, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+
+const WIDGET_VISIBILITY_CONTEXT_ID = 'dashboards-widget-visibility:save'
 
 type WidgetCatalogItem = {
   id: string
@@ -94,6 +97,13 @@ export const WidgetVisibilityEditor = React.forwardRef<WidgetVisibilityEditorHan
     [t],
   )
   const { kind, targetId, tenantId, organizationId, preserveOnTenantChange = false } = props
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: WIDGET_VISIBILITY_CONTEXT_ID,
+  })
   const [catalog, setCatalog] = React.useState<WidgetCatalogItem[]>([])
   const [loading, setLoading] = React.useState(true)
   const [saving, setSaving] = React.useState(false)
@@ -243,11 +253,20 @@ export const WidgetVisibilityEditor = React.forwardRef<WidgetVisibilityEditorHan
           widgetIds: selected,
         }
         // optimistic-lock-exempt: per-role widget visibility preference
-        await apiCallOrThrow('/api/dashboards/roles/widgets', {
-          method: 'PUT',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify(payload),
-        }, { errorMessage: saveError })
+        await runMutation({
+          operation: () =>
+            apiCallOrThrow('/api/dashboards/roles/widgets', {
+              method: 'PUT',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(payload),
+            }, { errorMessage: saveError }),
+          context: {
+            formId: WIDGET_VISIBILITY_CONTEXT_ID,
+            resourceKind: 'dashboards.role_widget_visibility',
+            retryLastMutation,
+          },
+          mutationPayload: payload,
+        })
         setOriginal(selected)
         setOriginalMode('override')
         setEffective(selected)
@@ -260,11 +279,20 @@ export const WidgetVisibilityEditor = React.forwardRef<WidgetVisibilityEditorHan
           widgetIds: selected,
         }
         // optimistic-lock-exempt: per-user widget visibility preference
-        await apiCallOrThrow('/api/dashboards/users/widgets', {
-          method: 'PUT',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify(payload),
-        }, { errorMessage: saveError })
+        await runMutation({
+          operation: () =>
+            apiCallOrThrow('/api/dashboards/users/widgets', {
+              method: 'PUT',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(payload),
+            }, { errorMessage: saveError }),
+          context: {
+            formId: WIDGET_VISIBILITY_CONTEXT_ID,
+            resourceKind: 'dashboards.user_widget_visibility',
+            retryLastMutation,
+          },
+          mutationPayload: payload,
+        })
         setOriginal(selected)
         if (mode === 'inherit') {
           const refreshed = await readApiResultOrThrow<UserResponse>(
@@ -286,7 +314,7 @@ export const WidgetVisibilityEditor = React.forwardRef<WidgetVisibilityEditorHan
     } finally {
       setSaving(false)
     }
-  }, [catalog.length, dirty, error, kind, loading, mode, organizationId, selected, t, targetId, tenantId])
+  }, [catalog.length, dirty, error, kind, loading, mode, organizationId, retryLastMutation, runMutation, selected, t, targetId, tenantId])
 
   React.useImperativeHandle(ref, () => ({ save }), [save])
 

--- a/packages/core/src/modules/dashboards/components/__tests__/WidgetVisibilityEditor.guardedMutation.test.tsx
+++ b/packages/core/src/modules/dashboards/components/__tests__/WidgetVisibilityEditor.guardedMutation.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression for #3206 — `WidgetVisibilityEditor` must route both the role and
+ * user widget-visibility saves through `useGuardedMutation().runMutation(...)`
+ * instead of calling `apiCallOrThrow` directly, so non-`CrudForm` writes still
+ * pass through shared mutation handling (injection `onBeforeSave`/`onAfterSave`,
+ * conflict surfacing, scoped headers) per `packages/ui/AGENTS.md`.
+ */
+import * as React from 'react'
+import { act, render, waitFor } from '@testing-library/react'
+
+const apiCallOrThrowMock = jest.fn()
+const readApiResultOrThrowMock = jest.fn()
+const runMutationMock = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+const retryLastMutationMock = jest.fn(async () => false)
+const flashMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCallOrThrow: (...args: unknown[]) => apiCallOrThrowMock(...args),
+  readApiResultOrThrow: (...args: unknown[]) => readApiResultOrThrowMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: (options: { contextId: string }) => {
+    useGuardedMutationOptions = options
+    return { runMutation: runMutationMock, retryLastMutation: retryLastMutationMock }
+  },
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: (...args: unknown[]) => flashMock(...args),
+}))
+
+let useGuardedMutationOptions: { contextId: string } | null = null
+
+import { WidgetVisibilityEditor, type WidgetVisibilityEditorHandle } from '../WidgetVisibilityEditor'
+
+const CATALOG = {
+  items: [
+    { id: 'example.dashboard.notes', title: 'Notes', description: 'Quick notes' },
+    { id: 'example.dashboard.tasks', title: 'Tasks', description: 'Task list' },
+  ],
+}
+
+function primeRoleLoad() {
+  readApiResultOrThrowMock.mockReset()
+  readApiResultOrThrowMock.mockImplementation(async (url: string) => {
+    if (url.startsWith('/api/dashboards/widgets/catalog')) return CATALOG
+    if (url.startsWith('/api/dashboards/roles/widgets')) {
+      return { widgetIds: ['example.dashboard.notes'], hasCustom: true, scope: { tenantId: null, organizationId: null } }
+    }
+    if (url.startsWith('/api/dashboards/users/widgets')) {
+      return {
+        mode: 'override',
+        widgetIds: ['example.dashboard.notes'],
+        hasCustom: true,
+        effectiveWidgetIds: ['example.dashboard.notes'],
+        scope: { tenantId: null, organizationId: null },
+      }
+    }
+    return {}
+  })
+}
+
+describe('WidgetVisibilityEditor — guarded mutation wiring (#3206)', () => {
+  beforeEach(() => {
+    apiCallOrThrowMock.mockReset()
+    apiCallOrThrowMock.mockResolvedValue({ ok: true })
+    runMutationMock.mockClear()
+    retryLastMutationMock.mockClear()
+    flashMock.mockClear()
+    useGuardedMutationOptions = null
+    primeRoleLoad()
+  })
+
+  it('uses a stable guarded-mutation contextId', async () => {
+    const ref = React.createRef<WidgetVisibilityEditorHandle>()
+    await act(async () => {
+      render(<WidgetVisibilityEditor ref={ref} kind="role" targetId="role-1" />)
+    })
+    expect(useGuardedMutationOptions?.contextId).toBe('dashboards-widget-visibility:save')
+  })
+
+  it('routes the role save through runMutation, not a raw apiCallOrThrow', async () => {
+    const ref = React.createRef<WidgetVisibilityEditorHandle>()
+    await act(async () => {
+      render(<WidgetVisibilityEditor ref={ref} kind="role" targetId="role-1" />)
+    })
+
+    await waitFor(() => expect(readApiResultOrThrowMock).toHaveBeenCalled())
+
+    const checkbox = document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')[1]
+    await act(async () => {
+      checkbox.click()
+    })
+
+    await act(async () => {
+      await ref.current!.save()
+    })
+
+    expect(runMutationMock).toHaveBeenCalledTimes(1)
+    const call = runMutationMock.mock.calls[0][0]
+    expect(typeof call.operation).toBe('function')
+    expect(call.context.resourceKind).toBe('dashboards.role_widget_visibility')
+    expect(call.context.retryLastMutation).toBe(retryLastMutationMock)
+
+    const putCall = apiCallOrThrowMock.mock.calls.find(([url]) => url === '/api/dashboards/roles/widgets')
+    expect(putCall).toBeDefined()
+    expect(putCall![1].method).toBe('PUT')
+    expect(flashMock).toHaveBeenCalledWith('Dashboard widgets updated', 'success')
+  })
+
+  it('routes the user save through runMutation, not a raw apiCallOrThrow', async () => {
+    const ref = React.createRef<WidgetVisibilityEditorHandle>()
+    await act(async () => {
+      render(<WidgetVisibilityEditor ref={ref} kind="user" targetId="user-1" />)
+    })
+
+    await waitFor(() => expect(readApiResultOrThrowMock).toHaveBeenCalled())
+
+    const checkbox = document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')[1]
+    await act(async () => {
+      checkbox.click()
+    })
+
+    await act(async () => {
+      await ref.current!.save()
+    })
+
+    expect(runMutationMock).toHaveBeenCalledTimes(1)
+    const call = runMutationMock.mock.calls[0][0]
+    expect(call.context.resourceKind).toBe('dashboards.user_widget_visibility')
+
+    const putCall = apiCallOrThrowMock.mock.calls.find(([url]) => url === '/api/dashboards/users/widgets')
+    expect(putCall).toBeDefined()
+    expect(putCall![1].method).toBe('PUT')
+  })
+})


### PR DESCRIPTION
Fixes #3206

## Problem
`WidgetVisibilityEditor` saved role and user dashboard-widget visibility preferences through raw `apiCallOrThrow` PUT calls instead of the shared guarded mutation path. `packages/ui/AGENTS.md` requires `useGuardedMutation` for every non-`CrudForm` write so UI writes consistently pass through shared mutation handling, conflict/error behavior, and guard integrations (`onBeforeSave`/`onAfterSave`, scoped request headers, unified conflict surfacing).

## Root Cause
The component called `apiCallOrThrow('/api/dashboards/roles/widgets', { method: 'PUT', ... })` and `apiCallOrThrow('/api/dashboards/users/widgets', { method: 'PUT', ... })` directly, never importing or using `useGuardedMutation`. The optimistic-lock exemption was intentional (per-role / per-user preference rows), but the non-lock guard behavior was being bypassed.

## What Changed
- `packages/core/src/modules/dashboards/components/WidgetVisibilityEditor.tsx`
  - Imported `useGuardedMutation` and added a stable `contextId` (`dashboards-widget-visibility:save`).
  - Wrapped both the role and user save PUTs in `runMutation({ operation, context, mutationPayload })`, passing `retryLastMutation` in the injection context.
  - Preserved the existing payloads, `flash` success messaging, post-save local state updates, and the intentional `optimistic-lock-exempt` markers.

## Tests
- Added `packages/core/src/modules/dashboards/components/__tests__/WidgetVisibilityEditor.guardedMutation.test.tsx` (jsdom): asserts both the role and user saves route through `runMutation` (not a raw `apiCallOrThrow`), use the stable `contextId`, carry the correct `resourceKind` + `retryLastMutation` context, and still issue the PUT and flash success. Verified the test fails against the pre-fix source and passes after the fix.
- `yarn workspace @open-mercato/core test` for the new test plus `optimistic-lock-ui-coverage` guard — both green.
- `yarn typecheck` (full repo) — 21/21 successful.

## Backward Compatibility
- No contract surface changes. UI-only change; no API routes, event IDs, DI keys, types, or generated files modified. Optimistic-lock exemption for these preference writes is preserved intentionally.