### PR TITLE
fix(dashboards): add mutation guards to custom dashboard write APIs (#3205)

### DIFF
--- a/packages/core/src/modules/dashboards/api/layout/[itemId]/__tests__/route.test.ts
+++ b/packages/core/src/modules/dashboards/api/layout/[itemId]/__tests__/route.test.ts
@@ -1,0 +1,87 @@
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const layoutItemId = '66666666-6666-4666-8666-666666666666'
+
+const em = {
+  fork: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  persist: jest.fn(),
+  flush: jest.fn(),
+}
+
+const rbac = { loadAcl: jest.fn() }
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'rbacService') return rbac
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: userId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+import { PATCH } from '../route'
+
+function buildRequest(): Request {
+  return new Request(`http://localhost/api/dashboards/layout/${layoutItemId}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ size: 'lg' }),
+  })
+}
+
+describe('dashboards layout item route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    em.flush.mockResolvedValue(undefined)
+    rbac.loadAcl.mockResolvedValue({ isSuperAdmin: true, features: [] })
+    em.findOne.mockResolvedValue({ layoutJson: [{ id: layoutItemId, widgetId: 'sales-summary', size: 'md' }] })
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+  })
+
+  it('short-circuits the write when the mutation guard blocks the request', async () => {
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: false, status: 409, body: { error: 'conflict' } })
+
+    const response = await PATCH(buildRequest(), { params: { itemId: layoutItemId } })
+
+    expect(response.status).toBe(409)
+    expect(await response.json()).toEqual({ error: 'conflict' })
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dashboards.layout', resourceId: layoutItemId, operation: 'update' }),
+    )
+    expect(em.findOne).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the after-success hook after a successful write', async () => {
+    const response = await PATCH(buildRequest(), { params: { itemId: layoutItemId } })
+
+    expect(response.status).toBe(200)
+    expect(em.flush).toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dashboards.layout', resourceId: layoutItemId, operation: 'update' }),
+    )
+  })
+})

--- a/packages/core/src/modules/dashboards/api/layout/[itemId]/route.ts
+++ b/packages/core/src/modules/dashboards/api/layout/[itemId]/route.ts
@@ -5,6 +5,10 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { DashboardLayout } from '@open-mercato/core/modules/dashboards/data/entities'
 import { dashboardLayoutItemPatchSchema } from '@open-mercato/core/modules/dashboards/data/validators'
 import { hasFeature } from '@open-mercato/shared/security/features'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
   dashboardsTag,
@@ -14,6 +18,7 @@ import {
 } from '../../openapi'
 
 const DEFAULT_SIZE = 'md'
+const RESOURCE_KIND = 'dashboards.layout'
 
 export const metadata = {
   PATCH: { requireAuth: true, requireFeatures: ['dashboards.configure'] },
@@ -39,7 +44,8 @@ export async function PATCH(req: Request, ctx: { params?: { itemId?: string } })
     return NextResponse.json({ error: 'Invalid payload', issues: parsed.error.issues }, { status: 400 })
   }
 
-  const { resolve } = await createRequestContainer()
+  const container = await createRequestContainer()
+  const { resolve } = container
   const em = resolve('em') as any
   const rbac = resolve('rbacService') as any
 
@@ -52,6 +58,21 @@ export async function PATCH(req: Request, ctx: { params?: { itemId?: string } })
   const acl = await rbac.loadAcl(scope.userId, { tenantId: scope.tenantId, organizationId: scope.organizationId })
   if (!acl.isSuperAdmin && !hasFeature(acl.features, 'dashboards.configure')) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: scope.tenantId ?? '',
+    organizationId: scope.organizationId,
+    userId: scope.userId,
+    resourceKind: RESOURCE_KIND,
+    resourceId: layoutItemId,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: { id: layoutItemId, size: parsed.data.size, settings: parsed.data.settings },
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
   }
 
   const layout = await em.findOne(DashboardLayout, {
@@ -76,6 +97,20 @@ export async function PATCH(req: Request, ctx: { params?: { itemId?: string } })
     settings: parsed.data.settings ?? current.settings,
   }
   await em.flush()
+
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: scope.tenantId ?? '',
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: RESOURCE_KIND,
+      resourceId: layoutItemId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
 
   return NextResponse.json({ ok: true })
 }

--- a/packages/core/src/modules/dashboards/api/layout/__tests__/route.test.ts
+++ b/packages/core/src/modules/dashboards/api/layout/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const layoutItemId = '66666666-6666-4666-8666-666666666666'
+
+const em = {
+  fork: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  persist: jest.fn(),
+  flush: jest.fn(),
+}
+
+const rbac = { loadAcl: jest.fn() }
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'rbacService') return rbac
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: userId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/dashboards/lib/widgets', () => ({
+  loadAllWidgets: jest.fn(async () => [{ metadata: { id: 'sales-summary' } }]),
+}))
+
+jest.mock('@open-mercato/core/modules/dashboards/lib/access', () => ({
+  resolveAllowedWidgetIds: jest.fn(async () => ['sales-summary']),
+}))
+
+import { PUT } from '../route'
+
+function buildRequest(): Request {
+  return new Request('http://localhost/api/dashboards/layout', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ items: [{ id: layoutItemId, widgetId: 'sales-summary', order: 0 }] }),
+  })
+}
+
+describe('dashboards layout route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    em.fork.mockReturnValue(em)
+    em.flush.mockResolvedValue(undefined)
+    em.create.mockImplementation((_entity: unknown, payload: Record<string, unknown>) => ({ id: 'rec', ...payload }))
+    em.findOne.mockResolvedValue(null)
+    rbac.loadAcl.mockResolvedValue({ isSuperAdmin: true, features: [] })
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+  })
+
+  it('short-circuits the write when the mutation guard blocks the request', async () => {
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: false, status: 409, body: { error: 'conflict' } })
+
+    const response = await PUT(buildRequest())
+
+    expect(response.status).toBe(409)
+    expect(await response.json()).toEqual({ error: 'conflict' })
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dashboards.layout', resourceId: userId, operation: 'update' }),
+    )
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the after-success hook after a successful write', async () => {
+    const response = await PUT(buildRequest())
+
+    expect(response.status).toBe(200)
+    expect(em.flush).toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dashboards.layout', resourceId: userId, operation: 'update' }),
+    )
+  })
+})

--- a/packages/core/src/modules/dashboards/api/layout/route.ts
+++ b/packages/core/src/modules/dashboards/api/layout/route.ts
@@ -9,6 +9,10 @@ import { resolveAllowedWidgetIds } from '@open-mercato/core/modules/dashboards/l
 import { hasFeature } from '@open-mercato/shared/security/features'
 import { User } from '@open-mercato/core/modules/auth/data/entities'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
   dashboardsTag,
@@ -18,6 +22,7 @@ import {
 } from '../openapi'
 
 const DEFAULT_SIZE = 'md'
+const RESOURCE_KIND = 'dashboards.layout'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['dashboards.view'] },
@@ -206,7 +211,8 @@ export async function PUT(req: Request) {
     return NextResponse.json({ error: 'Invalid layout payload', issues: parsed.error.issues }, { status: 400 })
   }
 
-  const { resolve } = await createRequestContainer()
+  const container = await createRequestContainer()
+  const { resolve } = container
   const em = (resolve('em') as any).fork({ clear: true, freshEventManager: true, useContext: true })
   const rbac = resolve('rbacService') as any
 
@@ -219,6 +225,21 @@ export async function PUT(req: Request) {
   const acl = await rbac.loadAcl(scope.userId, { tenantId: scope.tenantId, organizationId: scope.organizationId })
   if (!acl.isSuperAdmin && !hasFeature(acl.features, 'dashboards.configure')) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: scope.tenantId ?? '',
+    organizationId: scope.organizationId,
+    userId: scope.userId,
+    resourceKind: RESOURCE_KIND,
+    resourceId: scope.userId,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: { items: parsed.data.items },
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
   }
 
   const widgets = await loadAllWidgets()
@@ -265,6 +286,20 @@ export async function PUT(req: Request) {
     layout.layoutJson = sanitized
   }
   await em.flush()
+
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: scope.tenantId ?? '',
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: RESOURCE_KIND,
+      resourceId: scope.userId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
 
   return NextResponse.json({ ok: true })
 }

--- a/packages/core/src/modules/dashboards/api/roles/widgets/__tests__/route.test.ts
+++ b/packages/core/src/modules/dashboards/api/roles/widgets/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const roleId = '44444444-4444-4444-8444-444444444444'
+
+const em = {
+  fork: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  persist: jest.fn(),
+  remove: jest.fn(),
+  flush: jest.fn(),
+}
+
+const rbac = { loadAcl: jest.fn() }
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'rbacService') return rbac
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: userId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/dashboards/lib/widgets', () => ({
+  loadAllWidgets: jest.fn(async () => [{ metadata: { id: 'sales-summary' } }]),
+}))
+
+import { PUT } from '../route'
+
+function buildRequest(body: unknown): Request {
+  return new Request('http://localhost/api/dashboards/roles/widgets', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('dashboards role widgets route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    em.flush.mockResolvedValue(undefined)
+    em.remove.mockReturnValue({ flush: jest.fn().mockResolvedValue(undefined) })
+    em.create.mockImplementation((_entity: unknown, payload: Record<string, unknown>) => ({ id: 'rec', ...payload }))
+    rbac.loadAcl.mockResolvedValue({ isSuperAdmin: true, features: [] })
+    em.findOne.mockResolvedValue({ id: roleId, tenantId })
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+  })
+
+  it('short-circuits the write when the mutation guard blocks the request', async () => {
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: false, status: 409, body: { error: 'conflict' } })
+
+    const response = await PUT(buildRequest({ roleId, widgetIds: ['sales-summary'] }))
+
+    expect(response.status).toBe(409)
+    expect(await response.json()).toEqual({ error: 'conflict' })
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dashboards.roleWidgets', resourceId: roleId, operation: 'update' }),
+    )
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the after-success hook after a successful write', async () => {
+    em.findOne.mockResolvedValueOnce({ id: roleId, tenantId })
+    em.findOne.mockResolvedValueOnce(null)
+
+    const response = await PUT(buildRequest({ roleId, widgetIds: ['sales-summary'] }))
+
+    expect(response.status).toBe(200)
+    expect(em.flush).toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dashboards.roleWidgets', resourceId: roleId, operation: 'update' }),
+    )
+  })
+})

--- a/packages/core/src/modules/dashboards/api/roles/widgets/route.ts
+++ b/packages/core/src/modules/dashboards/api/roles/widgets/route.ts
@@ -8,6 +8,10 @@ import { roleWidgetSettingsSchema } from '@open-mercato/core/modules/dashboards/
 import { loadAllWidgets } from '@open-mercato/core/modules/dashboards/lib/widgets'
 import { resolveWidgetAssignmentReadScope } from '@open-mercato/core/modules/dashboards/lib/widgetAssignmentScope'
 import { hasFeature } from '@open-mercato/shared/security/features'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
   dashboardsTag,
@@ -17,6 +21,7 @@ import {
 } from '../../openapi'
 
 const FEATURE = 'dashboards.admin.assign-widgets'
+const RESOURCE_KIND = 'dashboards.roleWidgets'
 
 function pickBestRecord(records: DashboardRoleWidgets[], tenantId: string | null, organizationId: string | null): DashboardRoleWidgets | null {
   let best: DashboardRoleWidgets | null = null
@@ -99,7 +104,8 @@ export async function PUT(req: Request) {
     return NextResponse.json({ error: 'Invalid payload', issues: parsed.error.issues }, { status: 400 })
   }
 
-  const { resolve } = await createRequestContainer()
+  const container = await createRequestContainer()
+  const { resolve } = container
   const em = resolve('em') as any
   const rbac = resolve('rbacService') as any
   const acl = await rbac.loadAcl(auth.sub, { tenantId: auth.tenantId ?? null, organizationId: auth.orgId ?? null })
@@ -119,6 +125,21 @@ export async function PUT(req: Request) {
     return NextResponse.json({ error: 'Role not found' }, { status: 404 })
   }
 
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: tenantId ?? '',
+    organizationId,
+    userId: String(auth.sub),
+    resourceKind: RESOURCE_KIND,
+    resourceId: parsed.data.roleId,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: { roleId: parsed.data.roleId, widgetIds },
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
   let record = await em.findOne(DashboardRoleWidgets, {
     roleId: parsed.data.roleId,
     tenantId,
@@ -129,6 +150,19 @@ export async function PUT(req: Request) {
   if (!widgetIds.length) {
     if (record) {
       await em.remove(record).flush()
+    }
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(container, {
+        tenantId: tenantId ?? '',
+        organizationId,
+        userId: String(auth.sub),
+        resourceKind: RESOURCE_KIND,
+        resourceId: parsed.data.roleId,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
     }
     return NextResponse.json({ ok: true, widgetIds: [] })
   }
@@ -145,6 +179,20 @@ export async function PUT(req: Request) {
     record.widgetIdsJson = widgetIds
   }
   await em.flush()
+
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: tenantId ?? '',
+      organizationId,
+      userId: String(auth.sub),
+      resourceKind: RESOURCE_KIND,
+      resourceId: parsed.data.roleId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
 
   return NextResponse.json({ ok: true, widgetIds })
 }

--- a/packages/core/src/modules/dashboards/api/users/widgets/__tests__/route.test.ts
+++ b/packages/core/src/modules/dashboards/api/users/widgets/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const adminUserId = '33333333-3333-4333-8333-333333333333'
+const targetUserId = '55555555-5555-4555-8555-555555555555'
+
+const em = {
+  fork: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  persist: jest.fn(),
+  remove: jest.fn(),
+  flush: jest.fn(),
+}
+
+const rbac = { loadAcl: jest.fn() }
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'rbacService') return rbac
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: adminUserId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/dashboards/lib/widgets', () => ({
+  loadAllWidgets: jest.fn(async () => [{ metadata: { id: 'sales-summary' } }]),
+}))
+
+import { PUT } from '../route'
+
+function buildRequest(body: unknown): Request {
+  return new Request('http://localhost/api/dashboards/users/widgets', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('dashboards user widgets route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    em.flush.mockResolvedValue(undefined)
+    em.remove.mockReturnValue({ flush: jest.fn().mockResolvedValue(undefined) })
+    em.create.mockImplementation((_entity: unknown, payload: Record<string, unknown>) => ({ id: 'rec', ...payload }))
+    rbac.loadAcl.mockResolvedValue({ isSuperAdmin: true, features: [] })
+    em.findOne.mockResolvedValue({ id: targetUserId, tenantId })
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+  })
+
+  it('short-circuits the write when the mutation guard blocks the request', async () => {
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: false, status: 409, body: { error: 'conflict' } })
+
+    const response = await PUT(buildRequest({ userId: targetUserId, mode: 'override', widgetIds: ['sales-summary'] }))
+
+    expect(response.status).toBe(409)
+    expect(await response.json()).toEqual({ error: 'conflict' })
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dashboards.userWidgets', resourceId: targetUserId, operation: 'update' }),
+    )
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the after-success hook after a successful write', async () => {
+    em.findOne.mockResolvedValueOnce({ id: targetUserId, tenantId })
+    em.findOne.mockResolvedValueOnce(null)
+
+    const response = await PUT(buildRequest({ userId: targetUserId, mode: 'override', widgetIds: ['sales-summary'] }))
+
+    expect(response.status).toBe(200)
+    expect(em.flush).toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dashboards.userWidgets', resourceId: targetUserId, operation: 'update' }),
+    )
+  })
+})

--- a/packages/core/src/modules/dashboards/api/users/widgets/route.ts
+++ b/packages/core/src/modules/dashboards/api/users/widgets/route.ts
@@ -9,6 +9,10 @@ import { loadAllWidgets } from '@open-mercato/core/modules/dashboards/lib/widget
 import { resolveAllowedWidgetIds } from '@open-mercato/core/modules/dashboards/lib/access'
 import { resolveWidgetAssignmentReadScope } from '@open-mercato/core/modules/dashboards/lib/widgetAssignmentScope'
 import { hasFeature } from '@open-mercato/shared/security/features'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
   dashboardsTag,
@@ -18,6 +22,7 @@ import {
 } from '../../openapi'
 
 const FEATURE = 'dashboards.admin.assign-widgets'
+const RESOURCE_KIND = 'dashboards.userWidgets'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: [FEATURE] },
@@ -99,7 +104,8 @@ export async function PUT(req: Request) {
     return NextResponse.json({ error: 'Invalid payload', issues: parsed.error.issues }, { status: 400 })
   }
 
-  const { resolve } = await createRequestContainer()
+  const container = await createRequestContainer()
+  const { resolve } = container
   const em = resolve('em') as any
   const rbac = resolve('rbacService') as any
   const acl = await rbac.loadAcl(auth.sub, { tenantId: auth.tenantId ?? null, organizationId: auth.orgId ?? null })
@@ -119,6 +125,21 @@ export async function PUT(req: Request) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 })
   }
 
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: tenantId ?? '',
+    organizationId,
+    userId: String(auth.sub),
+    resourceKind: RESOURCE_KIND,
+    resourceId: parsed.data.userId,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: { userId: parsed.data.userId, mode: parsed.data.mode, widgetIds },
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
   let record = await em.findOne(DashboardUserWidgets, {
     userId: parsed.data.userId,
     tenantId,
@@ -129,6 +150,19 @@ export async function PUT(req: Request) {
   if (parsed.data.mode === 'inherit') {
     if (record) {
       await em.remove(record).flush()
+    }
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(container, {
+        tenantId: tenantId ?? '',
+        organizationId,
+        userId: String(auth.sub),
+        resourceKind: RESOURCE_KIND,
+        resourceId: parsed.data.userId,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
     }
     return NextResponse.json({ ok: true, mode: 'inherit', widgetIds: [] })
   }
@@ -147,6 +181,20 @@ export async function PUT(req: Request) {
     record.widgetIdsJson = widgetIds
   }
   await em.flush()
+
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: tenantId ?? '',
+      organizationId,
+      userId: String(auth.sub),
+      resourceKind: RESOURCE_KIND,
+      resourceId: parsed.data.userId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
 
   return NextResponse.json({ ok: true, mode: 'override', widgetIds })
 }


### PR DESCRIPTION
Fixes #3205

## Problem
Several custom dashboard write routes mutated dashboard records directly without running the generic CRUD mutation guard before the write or the after-success hook after a successful mutation, bypassing global write guards, mutation injections, and record-lock integrations that the core write-route contract requires.

Affected handlers:
- `PUT /api/dashboards/roles/widgets` (`DashboardRoleWidgets`)
- `PUT /api/dashboards/users/widgets` (`DashboardUserWidgets`)
- `PUT /api/dashboards/layout` (full `DashboardLayout` replacement)
- `PATCH /api/dashboards/layout/[itemId]` (item-level layout patch)

## Root Cause
These routes were hand-written custom write handlers (not `makeCrudRoute`) and never wired the `validateCrudMutationGuard` / `runCrudMutationGuardAfterSuccess` contract that `packages/core/AGENTS.md` mandates for custom `PUT`/`PATCH`/`DELETE` routes.

## What Changed
- Each write handler now keeps a reference to the request container and calls `validateCrudMutationGuard` before any persistence. A blocked guard result short-circuits the write and returns the guard's status/body.
- After a successful `flush`/remove, each handler calls `runCrudMutationGuardAfterSuccess` when `guardResult.shouldRunAfterSuccess` is set, forwarding the guard metadata.
- Stable `resourceKind` values: `dashboards.roleWidgets` (resourceId = roleId), `dashboards.userWidgets` (resourceId = userId), `dashboards.layout` (resourceId = userId for full replace, layout item id for the item patch). Each call passes the relevant mutation payload.
- Both the empty/inherit (delete) branch and the upsert branch of the widget routes run the after-success hook.

## Tests
- New focused route tests for all four handlers under `packages/core/src/modules/dashboards/api/**/__tests__/route.test.ts`, each proving:
  - a blocked guard response short-circuits the write (no `flush`, no after-success hook), and
  - a successful write runs the after-success hook with the expected `resourceKind`/`resourceId`/`operation`.
- `yarn workspace @open-mercato/core test --testPathPattern dashboards` (92 passed)
- `yarn typecheck` (full, green)
- `yarn i18n:check-sync` (in sync)

## Backward Compatibility
No contract surface changes. The wiring is purely additive — guard short-circuiting only fires when a registered mutation guard returns a failure; the default OSS optimistic-lock guard treats these unregistered resource kinds as a no-op, so existing behavior is preserved.