### PR TITLE
fix(data_sync): guard custom write routes with mutation guard (#3212)

### DIFF
--- a/packages/core/src/modules/data_sync/api/__tests__/run.test.ts
+++ b/packages/core/src/modules/data_sync/api/__tests__/run.test.ts
@@ -17,6 +17,11 @@ const mockIntegrationStateService = {
   isEnabled: jest.fn(),
 }
 
+const mockCrudMutationGuardService = {
+  validateMutation: jest.fn(),
+  afterMutationSuccess: jest.fn(),
+}
+
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
 }))
@@ -62,9 +67,12 @@ describe('data_sync run route', () => {
         if (token === 'dataSyncRunService') return mockSyncRunService
         if (token === 'progressService') return mockProgressService
         if (token === 'integrationStateService') return mockIntegrationStateService
+        if (token === 'crudMutationGuardService') return mockCrudMutationGuardService
         throw new Error(`Unexpected token: ${token}`)
       },
     })
+    mockCrudMutationGuardService.validateMutation.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: null })
+    mockCrudMutationGuardService.afterMutationSuccess.mockResolvedValue(undefined)
     mockGetIntegration.mockReturnValue({
       id: 'sync_excel',
       providerKey: 'excel',
@@ -126,6 +134,57 @@ describe('data_sync run route', () => {
       progressJobId: '22222222-2222-4222-8222-222222222222',
     })
     expect(mockStartDataSyncRun).toHaveBeenCalled()
+    expect(mockCrudMutationGuardService.validateMutation).toHaveBeenCalledWith(expect.objectContaining({
+      resourceKind: 'data_sync.run',
+      operation: 'custom',
+    }))
+    expect(mockCrudMutationGuardService.afterMutationSuccess).toHaveBeenCalledWith(expect.objectContaining({
+      resourceKind: 'data_sync.run',
+      resourceId: '11111111-1111-4111-8111-111111111111',
+    }))
+  })
+
+  it('short-circuits the run when the mutation guard blocks it', async () => {
+    mockCrudMutationGuardService.validateMutation.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      body: { error: 'Blocked by guard' },
+    })
+
+    const response = await postHandler(new Request('http://localhost/api/data_sync/run', {
+      method: 'POST',
+      body: JSON.stringify({
+        integrationId: 'generic_sync',
+        entityType: 'customers.person',
+        direction: 'import',
+      }),
+    }))
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: 'Blocked by guard' })
+    expect(mockStartDataSyncRun).not.toHaveBeenCalled()
+    expect(mockCrudMutationGuardService.afterMutationSuccess).not.toHaveBeenCalled()
+  })
+
+  it('does not run the after-success hook when the guard opts out', async () => {
+    mockCrudMutationGuardService.validateMutation.mockResolvedValueOnce({
+      ok: true,
+      shouldRunAfterSuccess: false,
+      metadata: null,
+    })
+
+    const response = await postHandler(new Request('http://localhost/api/data_sync/run', {
+      method: 'POST',
+      body: JSON.stringify({
+        integrationId: 'generic_sync',
+        entityType: 'customers.person',
+        direction: 'import',
+      }),
+    }))
+
+    expect(response.status).toBe(201)
+    expect(mockStartDataSyncRun).toHaveBeenCalled()
+    expect(mockCrudMutationGuardService.afterMutationSuccess).not.toHaveBeenCalled()
   })
 
   it('does not leak the error message or stack in the 500 response (CWE-209)', async () => {

--- a/packages/core/src/modules/data_sync/api/mappings/[id]/route.ts
+++ b/packages/core/src/modules/data_sync/api/mappings/[id]/route.ts
@@ -5,6 +5,10 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { SyncMapping } from '@open-mercato/core/modules/data_sync/data/entities'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 
 const idParamsSchema = z.object({ id: z.string().uuid() })
 
@@ -108,8 +112,37 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
     return NextResponse.json({ error: 'Mapping not found' }, { status: 404 })
   }
 
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: auth.sub,
+    resourceKind: 'data_sync.mapping',
+    resourceId: mapping.id,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: parsedBody.data,
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
   mapping.mapping = parsedBody.data.mapping
   await em.flush()
+
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: auth.sub,
+      resourceKind: 'data_sync.mapping',
+      resourceId: mapping.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
 
   return NextResponse.json({
     id: mapping.id,
@@ -151,8 +184,38 @@ export async function DELETE(req: Request, ctx: { params?: Promise<{ id?: string
     return NextResponse.json({ error: 'Mapping not found' }, { status: 404 })
   }
 
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: auth.sub,
+    resourceKind: 'data_sync.mapping',
+    resourceId: mapping.id,
+    operation: 'delete',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: null,
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
+  const mappingId = mapping.id
   em.remove(mapping)
   await em.flush()
+
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: auth.sub,
+      resourceKind: 'data_sync.mapping',
+      resourceId: mappingId,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
 
   return NextResponse.json({ deleted: true })
 }

--- a/packages/core/src/modules/data_sync/api/mappings/__tests__/mutation-guard.test.ts
+++ b/packages/core/src/modules/data_sync/api/mappings/__tests__/mutation-guard.test.ts
@@ -1,0 +1,122 @@
+/** @jest-environment node */
+
+const MAPPING_ID = '123e4567-e89b-12d3-a456-426614174099'
+const INTEGRATION_ID = 'demo-provider'
+
+const mockGetAuthFromRequest = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+
+const mockEm = {
+  create: jest.fn(),
+  persist: jest.fn(() => ({ flush: jest.fn(async () => undefined) })),
+  flush: jest.fn(async () => undefined),
+}
+
+const mockCrudMutationGuardService = {
+  validateMutation: jest.fn(),
+  afterMutationSuccess: jest.fn(),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+  findAndCountWithDecryption: jest.fn(async () => [[], 0]),
+}))
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'crudMutationGuardService') return mockCrudMutationGuardService
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+import { POST } from '../route'
+
+function request() {
+  return new Request('http://localhost/api/data_sync/mappings', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      integrationId: INTEGRATION_ID,
+      entityType: 'products',
+      mapping: { foo: 'bar' },
+    }),
+  })
+}
+
+describe('data_sync mapping create mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1' })
+    mockFindOneWithDecryption.mockResolvedValue(null)
+    mockEm.create.mockReturnValue({
+      id: MAPPING_ID,
+      integrationId: INTEGRATION_ID,
+      entityType: 'products',
+      mapping: { foo: 'bar' },
+    })
+    mockCrudMutationGuardService.validateMutation.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: null })
+    mockCrudMutationGuardService.afterMutationSuccess.mockResolvedValue(undefined)
+  })
+
+  it('runs the guard before the create write and the after-success hook after persistence', async () => {
+    const res = await POST(request())
+    expect(res.status).toBe(201)
+    expect(mockCrudMutationGuardService.validateMutation).toHaveBeenCalledWith(expect.objectContaining({
+      resourceKind: 'data_sync.mapping',
+      operation: 'create',
+    }))
+    expect(mockEm.persist).toHaveBeenCalled()
+    expect(mockCrudMutationGuardService.afterMutationSuccess).toHaveBeenCalledWith(expect.objectContaining({
+      resourceKind: 'data_sync.mapping',
+      resourceId: MAPPING_ID,
+      operation: 'create',
+    }))
+  })
+
+  it('short-circuits the create when the guard blocks the mutation', async () => {
+    mockCrudMutationGuardService.validateMutation.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      body: { error: 'Blocked by guard' },
+    })
+
+    const res = await POST(request())
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: 'Blocked by guard' })
+    expect(mockEm.create).not.toHaveBeenCalled()
+    expect(mockEm.persist).not.toHaveBeenCalled()
+    expect(mockCrudMutationGuardService.afterMutationSuccess).not.toHaveBeenCalled()
+  })
+
+  it('uses the update operation when a mapping already exists', async () => {
+    mockFindOneWithDecryption.mockResolvedValueOnce({
+      id: MAPPING_ID,
+      integrationId: INTEGRATION_ID,
+      entityType: 'products',
+      mapping: { old: 'value' },
+    })
+
+    const res = await POST(request())
+    expect(res.status).toBe(200)
+    expect(mockCrudMutationGuardService.validateMutation).toHaveBeenCalledWith(expect.objectContaining({
+      resourceKind: 'data_sync.mapping',
+      resourceId: MAPPING_ID,
+      operation: 'update',
+    }))
+    expect(mockEm.flush).toHaveBeenCalled()
+    expect(mockCrudMutationGuardService.afterMutationSuccess).toHaveBeenCalledWith(expect.objectContaining({
+      resourceKind: 'data_sync.mapping',
+      resourceId: MAPPING_ID,
+      operation: 'update',
+    }))
+  })
+})

--- a/packages/core/src/modules/data_sync/api/mappings/route.ts
+++ b/packages/core/src/modules/data_sync/api/mappings/route.ts
@@ -5,6 +5,10 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { findAndCountWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { SyncMapping } from '@open-mercato/core/modules/data_sync/data/entities'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 
 const listMappingsQuerySchema = z.object({
   integrationId: z.string().min(1).optional(),
@@ -115,9 +119,39 @@ export async function POST(req: Request) {
     scope,
   )
 
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: auth.sub,
+    resourceKind: 'data_sync.mapping',
+    resourceId: existing?.id ?? scope.organizationId,
+    operation: existing ? 'update' : 'create',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: parsed.data,
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
   if (existing) {
     existing.mapping = parsed.data.mapping
     await em.flush()
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(container, {
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        userId: auth.sub,
+        resourceKind: 'data_sync.mapping',
+        resourceId: existing.id,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
+
     return NextResponse.json({
       id: existing.id,
       integrationId: existing.integrationId,
@@ -134,6 +168,20 @@ export async function POST(req: Request) {
     tenantId: scope.tenantId,
   })
   await em.persist(created).flush()
+
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: auth.sub,
+      resourceKind: 'data_sync.mapping',
+      resourceId: created.id,
+      operation: 'create',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
 
   return NextResponse.json({
     id: created.id,

--- a/packages/core/src/modules/data_sync/api/run.ts
+++ b/packages/core/src/modules/data_sync/api/run.ts
@@ -9,6 +9,10 @@ import type { SyncRunService } from '../lib/sync-run-service'
 import { runSyncSchema } from '../data/validators'
 import { startDataSyncRun } from '../lib/start-run'
 import { getDataSyncAdapter } from '../lib/adapter-registry'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['data_sync.run'] },
@@ -80,6 +84,21 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'A sync run is already in progress for this integration and entity direction' }, { status: 409 })
     }
 
+    const guardResult = await validateCrudMutationGuard(container, {
+      tenantId: auth.tenantId,
+      organizationId: scope.organizationId,
+      userId: auth.sub,
+      resourceKind: 'data_sync.run',
+      resourceId: parsed.data.integrationId,
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: parsed.data,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     const cursor = parsed.data.fullSync
       ? null
       : await syncRunService.resolveCursor(parsed.data.integrationId, parsed.data.entityType, parsed.data.direction, scope)
@@ -100,6 +119,20 @@ export async function POST(req: Request) {
         batchSize: parsed.data.batchSize,
       },
     })
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(container, {
+        tenantId: auth.tenantId,
+        organizationId: scope.organizationId,
+        userId: auth.sub,
+        resourceKind: 'data_sync.run',
+        resourceId: run.id,
+        operation: 'custom',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     return NextResponse.json({ id: run.id, progressJobId: progressJob?.id ?? null }, { status: 201 })
   } catch (error) {

--- a/packages/core/src/modules/data_sync/api/runs/[id]/__tests__/cancel.test.ts
+++ b/packages/core/src/modules/data_sync/api/runs/[id]/__tests__/cancel.test.ts
@@ -22,6 +22,11 @@ const mockIntegrationLogService = {
   write: jest.fn(),
 }
 
+const mockCrudMutationGuardService = {
+  validateMutation: jest.fn(),
+  afterMutationSuccess: jest.fn(),
+}
+
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
 }))
@@ -52,9 +57,12 @@ describe('data_sync cancel run route', () => {
         if (token === 'progressService') return mockProgressService
         if (token === 'integrationStateService') return mockIntegrationStateService
         if (token === 'integrationLogService') return mockIntegrationLogService
+        if (token === 'crudMutationGuardService') return mockCrudMutationGuardService
         throw new Error(`Unexpected token: ${token}`)
       },
     })
+    mockCrudMutationGuardService.validateMutation.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: null })
+    mockCrudMutationGuardService.afterMutationSuccess.mockResolvedValue(undefined)
     mockSyncRunService.getRun.mockResolvedValue({
       id: '11111111-1111-4111-8111-111111111111',
       integrationId: 'sync_excel',
@@ -114,5 +122,33 @@ describe('data_sync cancel run route', () => {
       organizationId: 'org-1',
       tenantId: 'tenant-1',
     })
+    expect(mockCrudMutationGuardService.validateMutation).toHaveBeenCalledWith(expect.objectContaining({
+      resourceKind: 'data_sync.run',
+      resourceId: '11111111-1111-4111-8111-111111111111',
+      operation: 'custom',
+    }))
+    expect(mockCrudMutationGuardService.afterMutationSuccess).toHaveBeenCalledWith(expect.objectContaining({
+      resourceKind: 'data_sync.run',
+      resourceId: '11111111-1111-4111-8111-111111111111',
+    }))
+  })
+
+  it('short-circuits the cancellation when the mutation guard blocks it', async () => {
+    mockCrudMutationGuardService.validateMutation.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      body: { error: 'Blocked by guard' },
+    })
+
+    const response = await postHandler(
+      new Request('http://localhost/api/data_sync/runs/11111111-1111-4111-8111-111111111111/cancel', { method: 'POST' }),
+      { params: { id: '11111111-1111-4111-8111-111111111111' } },
+    )
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: 'Blocked by guard' })
+    expect(mockSyncRunService.markStatus).not.toHaveBeenCalled()
+    expect(mockProgressService.markCancelled).not.toHaveBeenCalled()
+    expect(mockCrudMutationGuardService.afterMutationSuccess).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/data_sync/api/runs/[id]/cancel.ts
+++ b/packages/core/src/modules/data_sync/api/runs/[id]/cancel.ts
@@ -6,6 +6,10 @@ import type { IntegrationLogService } from '../../../../integrations/lib/log-ser
 import type { IntegrationStateService } from '../../../../integrations/lib/state-service'
 import type { ProgressService } from '../../../../progress/lib/progressService'
 import type { SyncRunService } from '../../../lib/sync-run-service'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 
 const paramsSchema = z.object({ id: z.string().uuid() })
 
@@ -48,6 +52,21 @@ export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }
     return NextResponse.json({ error: 'Only pending or running runs can be cancelled' }, { status: 409 })
   }
 
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: auth.tenantId,
+    organizationId: scope.organizationId,
+    userId: auth.sub,
+    resourceKind: 'data_sync.run',
+    resourceId: run.id,
+    operation: 'custom',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: { action: 'cancel' },
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
   const progressCtx = {
     tenantId: auth.tenantId,
     organizationId: auth.orgId,
@@ -84,5 +103,20 @@ export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }
       summary: 'The sync run was cancelled before completion.',
     },
   }, scope)
+
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: auth.tenantId,
+      organizationId: scope.organizationId,
+      userId: auth.sub,
+      resourceKind: 'data_sync.run',
+      resourceId: run.id,
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
+
   return NextResponse.json({ ok: true })
 }

--- a/packages/core/src/modules/data_sync/api/runs/[id]/retry.ts
+++ b/packages/core/src/modules/data_sync/api/runs/[id]/retry.ts
@@ -7,6 +7,10 @@ import type { ProgressService } from '../../../../progress/lib/progressService'
 import type { SyncRunService } from '../../../lib/sync-run-service'
 import { retrySyncSchema } from '../../../data/validators'
 import { startDataSyncRun } from '../../../lib/start-run'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 
 const paramsSchema = z.object({ id: z.string().uuid() })
 
@@ -63,6 +67,21 @@ export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }
     return NextResponse.json({ error: 'A sync run is already in progress for this integration and entity direction' }, { status: 409 })
   }
 
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: auth.tenantId,
+    organizationId: scope.organizationId,
+    userId: auth.sub,
+    resourceKind: 'data_sync.run',
+    resourceId: previous.id,
+    operation: 'custom',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: { action: 'retry', ...parsedBody.data },
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
   const cursor = parsedBody.data.fromBeginning
     ? null
     : previous.cursor ?? await syncRunService.resolveCursor(previous.integrationId, previous.entityType, previous.direction, scope)
@@ -86,6 +105,20 @@ export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }
       },
     },
   })
+
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: auth.tenantId,
+      organizationId: scope.organizationId,
+      userId: auth.sub,
+      resourceKind: 'data_sync.run',
+      resourceId: run.id,
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
 
   return NextResponse.json({ id: run.id, progressJobId: progressJob?.id ?? null }, { status: 201 })
 }

--- a/packages/core/src/modules/data_sync/api/schedules/[id]/route.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/[id]/route.ts
@@ -6,6 +6,10 @@ import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { updateSyncScheduleSchema } from '../../../data/validators'
 import type { SyncScheduleService } from '../../../lib/sync-schedule-service'
 import { serializeSchedule } from '../serialize'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 
 const paramsSchema = z.object({
   id: z.string().uuid(),
@@ -81,6 +85,21 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
     return NextResponse.json({ error: 'Schedule not found' }, { status: 404 })
   }
 
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: auth.tenantId,
+    organizationId: scope.organizationId,
+    userId: auth.sub,
+    resourceKind: 'data_sync.schedule',
+    resourceId: current.id,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: parsed.data,
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
   try {
     const schedule = await scheduleService.saveSchedule({
       id: current.id,
@@ -93,6 +112,21 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
       fullSync: parsed.data.fullSync ?? current.fullSync,
       isEnabled: parsed.data.isEnabled ?? current.isEnabled,
     }, scope)
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(container, {
+        tenantId: auth.tenantId,
+        organizationId: scope.organizationId,
+        userId: auth.sub,
+        resourceKind: 'data_sync.schedule',
+        resourceId: schedule.id,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
+
     return NextResponse.json(serializeSchedule(schedule))
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to update sync schedule'
@@ -117,13 +151,41 @@ export async function DELETE(req: Request, ctx: { params?: Promise<{ id?: string
 
   const container = await createRequestContainer()
   const scheduleService = container.resolve('dataSyncScheduleService') as SyncScheduleService
-  const deleted = await scheduleService.deleteSchedule(parsedParams.data.id, {
-    organizationId: auth.orgId as string,
+  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+
+  const guardResult = await validateCrudMutationGuard(container, {
     tenantId: auth.tenantId,
+    organizationId: scope.organizationId,
+    userId: auth.sub,
+    resourceKind: 'data_sync.schedule',
+    resourceId: parsedParams.data.id,
+    operation: 'delete',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: null,
   })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
+  const deleted = await scheduleService.deleteSchedule(parsedParams.data.id, scope)
 
   if (!deleted) {
     return NextResponse.json({ error: 'Schedule not found' }, { status: 404 })
+  }
+
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: auth.tenantId,
+      organizationId: scope.organizationId,
+      userId: auth.sub,
+      resourceKind: 'data_sync.schedule',
+      resourceId: parsedParams.data.id,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
   }
 
   return NextResponse.json({ deleted: true })

--- a/packages/core/src/modules/data_sync/api/schedules/__tests__/mutation-guard.test.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/__tests__/mutation-guard.test.ts
@@ -1,0 +1,109 @@
+/** @jest-environment node */
+
+const SCHEDULE_ID = '123e4567-e89b-12d3-a456-426614174070'
+const INTEGRATION_ID = 'demo-provider'
+
+const mockGetAuthFromRequest = jest.fn()
+
+const mockScheduleService = {
+  saveSchedule: jest.fn(),
+}
+
+const mockCrudMutationGuardService = {
+  validateMutation: jest.fn(),
+  afterMutationSuccess: jest.fn(),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/http/readJsonSafe', () => ({
+  readJsonSafe: jest.fn((req: Request) => req.json()),
+}))
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'dataSyncScheduleService') return mockScheduleService
+    if (token === 'crudMutationGuardService') return mockCrudMutationGuardService
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+import { POST } from '../route'
+
+function request() {
+  return new Request('http://localhost/api/data_sync/schedules', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      integrationId: INTEGRATION_ID,
+      entityType: 'products',
+      direction: 'import',
+      scheduleType: 'cron',
+      scheduleValue: '0 * * * *',
+      timezone: 'UTC',
+      fullSync: false,
+      isEnabled: true,
+    }),
+  })
+}
+
+describe('data_sync schedule create mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1' })
+    mockScheduleService.saveSchedule.mockResolvedValue({
+      id: SCHEDULE_ID,
+      integrationId: INTEGRATION_ID,
+      entityType: 'products',
+      direction: 'import',
+      scheduleType: 'cron',
+      scheduleValue: '0 * * * *',
+      timezone: 'UTC',
+      fullSync: false,
+      isEnabled: true,
+      scheduledJobId: SCHEDULE_ID,
+      lastRunAt: null,
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      createdAt: new Date('2026-05-01T10:00:00.000Z'),
+      updatedAt: new Date('2026-06-01T10:00:00.000Z'),
+      deletedAt: null,
+    })
+    mockCrudMutationGuardService.validateMutation.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: null })
+    mockCrudMutationGuardService.afterMutationSuccess.mockResolvedValue(undefined)
+  })
+
+  it('runs the guard before the write and the after-success hook after it', async () => {
+    const res = await POST(request())
+    expect(res.status).toBe(201)
+    expect(mockCrudMutationGuardService.validateMutation).toHaveBeenCalledWith(expect.objectContaining({
+      resourceKind: 'data_sync.schedule',
+      operation: 'create',
+    }))
+    expect(mockScheduleService.saveSchedule).toHaveBeenCalled()
+    expect(mockCrudMutationGuardService.afterMutationSuccess).toHaveBeenCalledWith(expect.objectContaining({
+      resourceKind: 'data_sync.schedule',
+      resourceId: SCHEDULE_ID,
+    }))
+  })
+
+  it('short-circuits the write when the guard blocks the mutation', async () => {
+    mockCrudMutationGuardService.validateMutation.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      body: { error: 'Blocked by guard' },
+    })
+
+    const res = await POST(request())
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: 'Blocked by guard' })
+    expect(mockScheduleService.saveSchedule).not.toHaveBeenCalled()
+    expect(mockCrudMutationGuardService.afterMutationSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/data_sync/api/schedules/route.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/route.ts
@@ -7,6 +7,10 @@ import type { SyncScheduleService } from '../../lib/sync-schedule-service'
 import { serializeSchedule } from './serialize'
 import { readOptimisticLockExpected } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['data_sync.configure'] },
@@ -65,15 +69,43 @@ export async function POST(req: Request) {
 
   const container = await createRequestContainer()
   const scheduleService = container.resolve('dataSyncScheduleService') as SyncScheduleService
+  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: auth.tenantId,
+    organizationId: scope.organizationId,
+    userId: auth.sub,
+    resourceKind: 'data_sync.schedule',
+    resourceId: scope.organizationId,
+    operation: 'create',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: parsed.data,
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
 
   try {
     const schedule = await scheduleService.saveSchedule({
       ...parsed.data,
       expectedUpdatedAt: readOptimisticLockExpected(req),
-    }, {
-      organizationId: auth.orgId as string,
-      tenantId: auth.tenantId,
-    })
+    }, scope)
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(container, {
+        tenantId: auth.tenantId,
+        organizationId: scope.organizationId,
+        userId: auth.sub,
+        resourceKind: 'data_sync.schedule',
+        resourceId: schedule.id,
+        operation: 'create',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
+
     return NextResponse.json(serializeSchedule(schedule), { status: 201 })
   } catch (error) {
     if (isCrudHttpError(error)) {


### PR DESCRIPTION
Fixes #3212

## Problem
Several custom `data_sync` write routes performed or triggered mutations without running the generic CRUD mutation guard before the write or the after-success hook after a successful mutation. That bypassed the mutation lifecycle used by global write guards, mutation injections, record-lock integrations, and other side effects on protected custom routes.

## Root Cause
These custom (non-`makeCrudRoute`) write handlers never called `validateCrudMutationGuard` / `runCrudMutationGuardAfterSuccess`, which `packages/core/AGENTS.md` requires for custom write routes.

## What Changed
Wired the mutation-guard contract (`validateCrudMutationGuard` before mutation logic, `runCrudMutationGuardAfterSuccess` after successful persistence/enqueue, with blocked guard results short-circuiting the write) into:

- `api/run.ts` — start sync run (`data_sync.run`, custom)
- `api/schedules/route.ts` — create schedule (`data_sync.schedule`, create)
- `api/schedules/[id]/route.ts` — update + delete schedule (`data_sync.schedule`, update/delete)
- `api/mappings/route.ts` — create/update mapping (`data_sync.mapping`, create/update)
- `api/mappings/[id]/route.ts` — update + delete mapping (`data_sync.mapping`, update/delete)
- `api/runs/[id]/cancel.ts` — cancel run (`data_sync.run`, custom)
- `api/runs/[id]/retry.ts` — retry run (`data_sync.run`, custom)

Resource kinds reuse the stable `data_sync.schedule` value already used by `sync-schedule-service.ts`, plus `data_sync.run` and `data_sync.mapping`. Each route passes `tenantId`/`organizationId`/`userId` scope, the request method/headers, and the parsed payload to the guard.

## Tests
- Extended `api/__tests__/run.test.ts`: guard runs before start, after-success fires on success, blocked guard short-circuits (no `startDataSyncRun`), and `shouldRunAfterSuccess: false` skips the hook.
- Extended `api/runs/[id]/__tests__/cancel.test.ts`: guard + after-success on success, blocked guard short-circuits (no `markStatus`/`markCancelled`).
- Added `api/schedules/__tests__/mutation-guard.test.ts`: guard before write + after-success on create, blocked guard short-circuits the save.
- Added `api/mappings/__tests__/mutation-guard.test.ts`: guard for create + update operations, after-success on success, blocked guard short-circuits persistence.
- Full `data_sync` suite: 10 suites / 32 tests passing.
- `yarn typecheck` passes repo-wide.

## Backward Compatibility
No contract surface changes — additive guard wiring only. API request/response shapes are unchanged; the guard is a no-op when no `crudMutationGuardService` is registered (the existing schedules optimistic-lock test still passes unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)