### PR TITLE
fix(data_sync): create ProgressJobs for scheduled sync runs (#3214)

### DIFF
--- a/packages/core/src/modules/data_sync/workers/__tests__/sync-scheduled.test.ts
+++ b/packages/core/src/modules/data_sync/workers/__tests__/sync-scheduled.test.ts
@@ -1,0 +1,212 @@
+/** @jest-environment node */
+
+const mockFindOneWithDecryption = jest.fn()
+const mockGetSyncQueue = jest.fn()
+
+const mockEnqueue = jest.fn()
+
+const mockSyncRunService = {
+  findRunningOverlap: jest.fn(),
+  resolveCursor: jest.fn(),
+  createRun: jest.fn(),
+}
+
+const mockProgressService = {
+  createJob: jest.fn(),
+}
+
+const mockIntegrationStateService = {
+  isEnabled: jest.fn(),
+}
+
+const mockEm = {
+  flush: jest.fn(),
+}
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...args),
+}))
+
+jest.mock('../../lib/queue', () => ({
+  getSyncQueue: (...args: unknown[]) => mockGetSyncQueue(...args),
+}))
+
+jest.mock('../../data/entities', () => ({
+  SyncSchedule: class SyncSchedule {},
+}))
+
+type WorkerModule = typeof import('../sync-scheduled')
+let handle: WorkerModule['default']
+
+const scope = { organizationId: 'org-1', tenantId: 'tenant-1' }
+
+function buildContext() {
+  return {
+    resolve: (token: string) => {
+      if (token === 'em') return mockEm
+      if (token === 'dataSyncRunService') return mockSyncRunService
+      if (token === 'progressService') return mockProgressService
+      if (token === 'integrationStateService') return mockIntegrationStateService
+      throw new Error(`Unexpected token: ${token}`)
+    },
+  } as never
+}
+
+function buildJob() {
+  return {
+    payload: {
+      scheduleId: 'schedule-1',
+      scope,
+    },
+  } as never
+}
+
+beforeAll(async () => {
+  const workerModule = await import('../sync-scheduled')
+  handle = workerModule.default
+})
+
+describe('data-sync scheduled worker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetSyncQueue.mockReturnValue({ enqueue: mockEnqueue })
+    mockIntegrationStateService.isEnabled.mockResolvedValue(true)
+    mockSyncRunService.findRunningOverlap.mockResolvedValue(null)
+    mockSyncRunService.resolveCursor.mockResolvedValue('cursor-1')
+    mockSyncRunService.createRun.mockImplementation(async (input: { progressJobId?: string | null }) => ({
+      id: 'run-1',
+      progressJobId: input.progressJobId ?? null,
+    }))
+    mockProgressService.createJob.mockResolvedValue({ id: 'progress-1' })
+    mockEm.flush.mockResolvedValue(undefined)
+  })
+
+  it('creates a ProgressJob and links it to the scheduled run', async () => {
+    mockFindOneWithDecryption.mockResolvedValue({
+      id: 'schedule-1',
+      integrationId: 'sync_excel',
+      entityType: 'customers.person',
+      direction: 'import',
+      isEnabled: true,
+      fullSync: false,
+    })
+
+    await handle(buildJob(), buildContext())
+
+    expect(mockProgressService.createJob).toHaveBeenCalledTimes(1)
+    expect(mockSyncRunService.createRun).toHaveBeenCalledTimes(1)
+    const createRunInput = mockSyncRunService.createRun.mock.calls[0][0]
+    expect(createRunInput.progressJobId).toBe('progress-1')
+    expect(createRunInput.triggeredBy).toBe('scheduler')
+    expect(createRunInput.cursor).toBe('cursor-1')
+  })
+
+  it('enqueues the import job with a tenant/organization-scoped payload', async () => {
+    mockFindOneWithDecryption.mockResolvedValue({
+      id: 'schedule-1',
+      integrationId: 'sync_excel',
+      entityType: 'customers.person',
+      direction: 'import',
+      isEnabled: true,
+      fullSync: false,
+    })
+
+    await handle(buildJob(), buildContext())
+
+    expect(mockGetSyncQueue).toHaveBeenCalledWith('data-sync-import')
+    expect(mockEnqueue).toHaveBeenCalledTimes(1)
+    const enqueuePayload = mockEnqueue.mock.calls[0][0]
+    expect(enqueuePayload.runId).toBe('run-1')
+    expect(enqueuePayload.scope.organizationId).toBe('org-1')
+    expect(enqueuePayload.scope.tenantId).toBe('tenant-1')
+  })
+
+  it('updates lastRunAt before enqueuing', async () => {
+    const schedule = {
+      id: 'schedule-1',
+      integrationId: 'sync_excel',
+      entityType: 'customers.person',
+      direction: 'import',
+      isEnabled: true,
+      fullSync: false,
+      lastRunAt: null as Date | null,
+    }
+    mockFindOneWithDecryption.mockResolvedValue(schedule)
+
+    await handle(buildJob(), buildContext())
+
+    expect(schedule.lastRunAt).toBeInstanceOf(Date)
+    expect(mockEm.flush).toHaveBeenCalled()
+  })
+
+  it('resolves a null cursor for full-sync schedules', async () => {
+    mockFindOneWithDecryption.mockResolvedValue({
+      id: 'schedule-1',
+      integrationId: 'sync_excel',
+      entityType: 'customers.person',
+      direction: 'export',
+      isEnabled: true,
+      fullSync: true,
+    })
+
+    await handle(buildJob(), buildContext())
+
+    expect(mockSyncRunService.resolveCursor).not.toHaveBeenCalled()
+    expect(mockGetSyncQueue).toHaveBeenCalledWith('data-sync-export')
+    const createRunInput = mockSyncRunService.createRun.mock.calls[0][0]
+    expect(createRunInput.cursor).toBeNull()
+  })
+
+  it('skips disabled schedules without creating a run', async () => {
+    mockFindOneWithDecryption.mockResolvedValue({
+      id: 'schedule-1',
+      integrationId: 'sync_excel',
+      entityType: 'customers.person',
+      direction: 'import',
+      isEnabled: false,
+      fullSync: false,
+    })
+
+    await handle(buildJob(), buildContext())
+
+    expect(mockProgressService.createJob).not.toHaveBeenCalled()
+    expect(mockSyncRunService.createRun).not.toHaveBeenCalled()
+    expect(mockEnqueue).not.toHaveBeenCalled()
+  })
+
+  it('skips when an overlapping run is already in progress', async () => {
+    mockFindOneWithDecryption.mockResolvedValue({
+      id: 'schedule-1',
+      integrationId: 'sync_excel',
+      entityType: 'customers.person',
+      direction: 'import',
+      isEnabled: true,
+      fullSync: false,
+    })
+    mockSyncRunService.findRunningOverlap.mockResolvedValue({ id: 'running-1' })
+
+    await handle(buildJob(), buildContext())
+
+    expect(mockProgressService.createJob).not.toHaveBeenCalled()
+    expect(mockSyncRunService.createRun).not.toHaveBeenCalled()
+    expect(mockEnqueue).not.toHaveBeenCalled()
+  })
+
+  it('skips when the integration is disabled', async () => {
+    mockFindOneWithDecryption.mockResolvedValue({
+      id: 'schedule-1',
+      integrationId: 'sync_excel',
+      entityType: 'customers.person',
+      direction: 'import',
+      isEnabled: true,
+      fullSync: false,
+    })
+    mockIntegrationStateService.isEnabled.mockResolvedValue(false)
+
+    await handle(buildJob(), buildContext())
+
+    expect(mockProgressService.createJob).not.toHaveBeenCalled()
+    expect(mockSyncRunService.createRun).not.toHaveBeenCalled()
+    expect(mockEnqueue).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/data_sync/workers/sync-scheduled.ts
+++ b/packages/core/src/modules/data_sync/workers/sync-scheduled.ts
@@ -2,9 +2,10 @@ import type { JobContext, QueuedJob, WorkerMeta } from '@open-mercato/queue'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { IntegrationStateService } from '../../integrations/lib/state-service'
+import type { ProgressService } from '../../progress/lib/progressService'
 import type { SyncRunService } from '../lib/sync-run-service'
 import { SyncSchedule } from '../data/entities'
-import { getSyncQueue } from '../lib/queue'
+import { startDataSyncRun } from '../lib/start-run'
 
 type ScheduledSyncPayload = {
   scheduleId: string
@@ -27,6 +28,7 @@ type HandlerContext = JobContext & {
 export default async function handle(job: QueuedJob<ScheduledSyncPayload>, ctx: HandlerContext): Promise<void> {
   const em = ctx.resolve<EntityManager>('em')
   const syncRunService = ctx.resolve<SyncRunService>('dataSyncRunService')
+  const progressService = ctx.resolve<ProgressService>('progressService')
   const integrationStateService = ctx.resolve<IntegrationStateService>('integrationStateService')
 
   const schedule = await findOneWithDecryption(
@@ -70,22 +72,19 @@ export default async function handle(job: QueuedJob<ScheduledSyncPayload>, ctx: 
         job.payload.scope,
       )
 
-  const run = await syncRunService.createRun({
-    integrationId: schedule.integrationId,
-    entityType: schedule.entityType,
-    direction: schedule.direction,
-    cursor,
-    triggeredBy: 'scheduler',
-  }, job.payload.scope)
-
   schedule.lastRunAt = new Date()
   await em.flush()
 
-  const queueName = schedule.direction === 'import' ? 'data-sync-import' : 'data-sync-export'
-  const queue = getSyncQueue(queueName)
-  await queue.enqueue({
-    runId: run.id,
-    batchSize: 100,
+  await startDataSyncRun({
+    syncRunService,
+    progressService,
     scope: job.payload.scope,
+    input: {
+      integrationId: schedule.integrationId,
+      entityType: schedule.entityType,
+      direction: schedule.direction,
+      cursor,
+      triggeredBy: 'scheduler',
+    },
   })
 }


### PR DESCRIPTION
Fixes #3214

## Problem
- Scheduled data-sync runs were created directly in the scheduled worker (`syncRunService.createRun(...)` + a manual `getSyncQueue().enqueue(...)`), so they never got a linked `ProgressJob`. Manual run (`api/run.ts`) and retry (`api/runs/[id]/retry.ts`) already route through `startDataSyncRun`, making scheduled runs the outlier without ProgressTopBar visibility, live progress, cancellation, or run-detail progress hydration.

## Root Cause
- `packages/core/src/modules/data_sync/workers/sync-scheduled.ts` bypassed the shared `startDataSyncRun` path, which is the only place that creates a `ProgressJob`, stores `progressJobId` on the `SyncRun`, and enqueues the worker job.

## What Changed
- `sync-scheduled.ts` now resolves `progressService` from the worker DI context and routes run creation through `startDataSyncRun`, so every scheduled run gets a `ProgressJob` and the same enqueue/progress contract as manual and retry runs.
- Preserved overlap detection, disabled-schedule and disabled-integration short-circuits, cursor resolution (incl. `fullSync` → null cursor), `triggeredBy: 'scheduler'`, the default batch size of 100, and the `lastRunAt` update + flush (now done before starting the run).

## Tests
- Added `packages/core/src/modules/data_sync/workers/__tests__/sync-scheduled.test.ts` (7 cases): asserts scheduled runs create a `ProgressJob` and link a non-null `progressJobId`, enqueue a tenant/organization-scoped payload to the correct direction queue, update `lastRunAt`, resolve a null cursor for full-sync schedules, and still skip on disabled schedule / disabled integration / overlapping run.
- `yarn workspace @open-mercato/core test src/modules/data_sync` — 31 passed.
- `yarn typecheck` — all packages pass.

## Backward Compatibility
- No contract surface changes. Worker queue id/metadata, run enqueue payload shape, and DI keys are unchanged; `progressService` is an existing DI key already used by sibling data_sync routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)