### PR TITLE
fix(dictionaries): add mutation guard lifecycle to custom write routes (#3217)

### DIFF
--- a/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/[entryId]/route.ts
+++ b/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/[entryId]/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { Dictionary, DictionaryEntry } from '@open-mercato/core/modules/dictionaries/data/entities'
-import { resolveDictionariesRouteContext } from '@open-mercato/core/modules/dictionaries/api/context'
+import { resolveDictionariesRouteContext, resolveDictionaryActorId } from '@open-mercato/core/modules/dictionaries/api/context'
 import { updateDictionaryEntrySchema } from '@open-mercato/core/modules/dictionaries/data/validators'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -80,6 +84,21 @@ export async function PATCH(req: Request, ctx: { params?: { dictionaryId?: strin
     })
     const rawBody = await req.json().catch(() => ({}))
     const payload = updateDictionaryEntrySchema.parse(rawBody)
+    const guardUserId = resolveDictionaryActorId(context.auth)
+    const guardResult = await validateCrudMutationGuard(context.container, {
+      tenantId: context.tenantId,
+      organizationId: context.organizationId,
+      userId: guardUserId,
+      resourceKind: 'dictionaries.entry',
+      resourceId: entry.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: payload,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
     // These nested routes don't use the CRUD factory, so invoke the command bus explicitly.
     const commandBus = (context.container.resolve('commandBus') as CommandBus)
     const input = { ...(payload as Record<string, unknown>), id: entryId }
@@ -91,6 +110,19 @@ export async function PATCH(req: Request, ctx: { params?: { dictionaryId?: strin
     const updatedEntryId = typeof updateResult.entryId === 'string' ? updateResult.entryId : null
     if (!updatedEntryId) {
       throw new CrudHttpError(500, { error: context.translate('dictionaries.errors.entry_update_failed', 'Failed to update dictionary entry') })
+    }
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(context.container, {
+        tenantId: context.tenantId,
+        organizationId: context.organizationId,
+        userId: guardUserId,
+        resourceKind: 'dictionaries.entry',
+        resourceId: updatedEntryId,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
     }
     const updated = await findOneWithDecryption(
       context.em.fork(),
@@ -146,11 +178,39 @@ export async function DELETE(req: Request, ctx: { params?: { dictionaryId?: stri
     })
     const dictionary = await loadDictionary(context, dictionaryId)
     const entry = await loadEntry(context, dictionary, entryId)
+    const guardUserId = resolveDictionaryActorId(context.auth)
+    const guardResult = await validateCrudMutationGuard(context.container, {
+      tenantId: context.tenantId,
+      organizationId: context.organizationId,
+      userId: guardUserId,
+      resourceKind: 'dictionaries.entry',
+      resourceId: entry.id,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: null,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
     const commandBus = (context.container.resolve('commandBus') as CommandBus)
     const { logEntry } = await commandBus.execute('dictionaries.entries.delete', {
       input: { body: { id: entry.id } },
       ctx: context.ctx,
     })
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(context.container, {
+        tenantId: context.tenantId,
+        organizationId: context.organizationId,
+        userId: guardUserId,
+        resourceKind: 'dictionaries.entry',
+        resourceId: entry.id,
+        operation: 'delete',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
     const response = NextResponse.json({ ok: true })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(

--- a/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/__tests__/entry-write-mutation-guard.test.ts
+++ b/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/__tests__/entry-write-mutation-guard.test.ts
@@ -1,0 +1,205 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const dictionaryId = '44444444-4444-4444-8444-444444444444'
+const entryId = '55555555-5555-4555-8555-555555555555'
+
+const dictionaryRecord = {
+  id: dictionaryId,
+  organizationId,
+  tenantId,
+  deletedAt: null as Date | null,
+}
+
+const entryRecord = {
+  id: entryId,
+  value: 'red',
+  label: 'Red',
+  color: null,
+  icon: null,
+  position: 0,
+  isDefault: false,
+  organizationId,
+  tenantId,
+  createdAt: new Date('2026-05-01T10:00:00.000Z'),
+  updatedAt: new Date('2026-06-01T10:00:00.000Z'),
+}
+
+const em = {
+  findOne: jest.fn(),
+  fork: jest.fn(),
+}
+
+const commandBusExecuteMock = jest.fn()
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'commandBus') return { execute: (...args: unknown[]) => commandBusExecuteMock(...args) }
+    return null
+  }),
+}
+
+const context = {
+  container,
+  ctx: {
+    container,
+    auth: { tenantId, sub: userId },
+    organizationScope: null,
+    selectedOrganizationId: organizationId,
+    organizationIds: [organizationId],
+    request: null,
+  },
+  auth: { tenantId, sub: userId, orgId: organizationId },
+  em,
+  organizationId,
+  tenantId,
+  readableOrganizationIds: [organizationId],
+  translate: (_key: string, fallback?: string) => fallback ?? 'error',
+}
+
+jest.mock('@open-mercato/core/modules/dictionaries/api/context', () => ({
+  resolveDictionariesRouteContext: jest.fn(async () => context),
+  resolveDictionaryActorId: jest.fn(() => userId),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(async () => ({ ...entryRecord, dictionary: dictionaryRecord })),
+  findWithDecryption: jest.fn(async () => []),
+}))
+
+import { POST as createEntry } from '../route'
+import { PATCH as updateEntry, DELETE as deleteEntry } from '../[entryId]/route'
+
+const entryParams = { params: { dictionaryId, entryId } }
+
+describe('dictionary entry write routes mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    em.fork.mockReturnValue(em)
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    commandBusExecuteMock.mockResolvedValue({ result: { entryId }, logEntry: null })
+  })
+
+  it('runs the mutation guard lifecycle when creating an entry', async () => {
+    const response = await createEntry(
+      new Request(`http://localhost/api/dictionaries/${dictionaryId}/entries`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ value: 'red', label: 'Red' }),
+      }),
+      { params: { dictionaryId } },
+    )
+
+    expect(response.status).toBe(201)
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('dictionaries.entries.create', expect.anything())
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dictionaries.entry', operation: 'create' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dictionaries.entry', resourceId: entryId, operation: 'create' }),
+    )
+  })
+
+  it('blocks entry creation when the guard rejects the mutation', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await createEntry(
+      new Request(`http://localhost/api/dictionaries/${dictionaryId}/entries`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ value: 'red', label: 'Red' }),
+      }),
+      { params: { dictionaryId } },
+    )
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the mutation guard lifecycle when updating an entry', async () => {
+    em.findOne.mockResolvedValueOnce(dictionaryRecord).mockResolvedValueOnce(entryRecord)
+
+    const response = await updateEntry(
+      new Request(`http://localhost/api/dictionaries/${dictionaryId}/entries/${entryId}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ label: 'Renamed' }),
+      }),
+      entryParams,
+    )
+
+    expect(response.status).toBe(200)
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('dictionaries.entries.update', expect.anything())
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dictionaries.entry', resourceId: entryId, operation: 'update' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dictionaries.entry', resourceId: entryId, operation: 'update' }),
+    )
+  })
+
+  it('blocks entry update when the guard rejects the mutation', async () => {
+    em.findOne.mockResolvedValueOnce(dictionaryRecord).mockResolvedValueOnce(entryRecord)
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await updateEntry(
+      new Request(`http://localhost/api/dictionaries/${dictionaryId}/entries/${entryId}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ label: 'Renamed' }),
+      }),
+      entryParams,
+    )
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the mutation guard lifecycle when deleting an entry', async () => {
+    em.findOne.mockResolvedValueOnce(dictionaryRecord).mockResolvedValueOnce(entryRecord)
+
+    const response = await deleteEntry(
+      new Request(`http://localhost/api/dictionaries/${dictionaryId}/entries/${entryId}`, { method: 'DELETE' }),
+      entryParams,
+    )
+
+    expect(response.status).toBe(200)
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('dictionaries.entries.delete', expect.anything())
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dictionaries.entry', resourceId: entryId, operation: 'delete' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dictionaries.entry', resourceId: entryId, operation: 'delete' }),
+    )
+  })
+
+  it('blocks entry deletion when the guard rejects the mutation', async () => {
+    em.findOne.mockResolvedValueOnce(dictionaryRecord).mockResolvedValueOnce(entryRecord)
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await deleteEntry(
+      new Request(`http://localhost/api/dictionaries/${dictionaryId}/entries/${entryId}`, { method: 'DELETE' }),
+      entryParams,
+    )
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/route.ts
+++ b/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/route.ts
@@ -2,9 +2,13 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { runWithCacheTenant } from '@open-mercato/cache'
 import { Dictionary, DictionaryEntry } from '@open-mercato/core/modules/dictionaries/data/entities'
-import { resolveDictionariesRouteContext } from '@open-mercato/core/modules/dictionaries/api/context'
+import { resolveDictionariesRouteContext, resolveDictionaryActorId } from '@open-mercato/core/modules/dictionaries/api/context'
 import { createDictionaryEntrySchema } from '@open-mercato/core/modules/dictionaries/data/validators'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -166,6 +170,21 @@ export async function POST(req: Request, ctx: { params?: { dictionaryId?: string
     }
     const { dictionaryId } = paramsSchema.parse({ dictionaryId: ctx.params?.dictionaryId })
     const payload = createDictionaryEntrySchema.parse(await req.json().catch(() => ({})))
+    const guardUserId = resolveDictionaryActorId(context.auth)
+    const guardResult = await validateCrudMutationGuard(context.container, {
+      tenantId: context.tenantId,
+      organizationId: context.organizationId,
+      userId: guardUserId,
+      resourceKind: DICTIONARY_ENTRY_RESOURCE,
+      resourceId: dictionaryId,
+      operation: 'create',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: payload,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
     // These nested routes do not use makeCrudRoute, so we invoke the command bus directly.
     const commandBus = (context.container.resolve('commandBus') as CommandBus)
     const { result, logEntry } = await commandBus.execute('dictionaries.entries.create', {
@@ -176,6 +195,19 @@ export async function POST(req: Request, ctx: { params?: { dictionaryId?: string
     const createdEntryId = typeof createResult.entryId === 'string' ? createResult.entryId : null
     if (!createdEntryId) {
       throw new CrudHttpError(500, { error: context.translate('dictionaries.errors.entry_create_failed', 'Failed to create dictionary entry') })
+    }
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(context.container, {
+        tenantId: context.tenantId,
+        organizationId: context.organizationId,
+        userId: guardUserId,
+        resourceKind: DICTIONARY_ENTRY_RESOURCE,
+        resourceId: createdEntryId,
+        operation: 'create',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
     }
     const entry = await findOneWithDecryption(
       context.em.fork(),

--- a/packages/core/src/modules/dictionaries/api/[dictionaryId]/route.ts
+++ b/packages/core/src/modules/dictionaries/api/[dictionaryId]/route.ts
@@ -1,9 +1,13 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { Dictionary } from '@open-mercato/core/modules/dictionaries/data/entities'
-import { resolveDictionariesRouteContext } from '@open-mercato/core/modules/dictionaries/api/context'
+import { resolveDictionariesRouteContext, resolveDictionaryActorId } from '@open-mercato/core/modules/dictionaries/api/context'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
   resolveDictionaryEntrySortMode,
@@ -118,6 +122,22 @@ export async function PATCH(req: Request, ctx: { params?: { dictionaryId?: strin
       request: req,
     })
 
+    const guardUserId = resolveDictionaryActorId(context.auth)
+    const guardResult = await validateCrudMutationGuard(context.container, {
+      tenantId: context.tenantId,
+      organizationId: context.organizationId,
+      userId: guardUserId,
+      resourceKind: 'dictionaries.dictionary',
+      resourceId: dictionary.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: payload,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     if (isProtectedCurrencyDictionary(dictionary)) {
       if (payload.key && payload.key.trim().toLowerCase() !== dictionary.key) {
         throw new CrudHttpError(400, { error: context.translate('dictionaries.errors.currency_protected', 'The currency dictionary cannot be modified or deleted.') })
@@ -172,6 +192,20 @@ export async function PATCH(req: Request, ctx: { params?: { dictionaryId?: strin
     dictionary.updatedAt = new Date()
     await context.em.flush()
 
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(context.container, {
+        tenantId: context.tenantId,
+        organizationId: context.organizationId,
+        userId: guardUserId,
+        resourceKind: 'dictionaries.dictionary',
+        resourceId: dictionary.id,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
+
     return NextResponse.json({
       id: dictionary.id,
       key: dictionary.key,
@@ -202,6 +236,22 @@ export async function DELETE(req: Request, ctx: { params?: { dictionaryId?: stri
     const { dictionaryId } = paramsSchema.parse({ dictionaryId: ctx.params?.dictionaryId })
     const dictionary = await loadDictionary(context, dictionaryId)
 
+    const guardUserId = resolveDictionaryActorId(context.auth)
+    const guardResult = await validateCrudMutationGuard(context.container, {
+      tenantId: context.tenantId,
+      organizationId: context.organizationId,
+      userId: guardUserId,
+      resourceKind: 'dictionaries.dictionary',
+      resourceId: dictionary.id,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: null,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     if (isProtectedCurrencyDictionary(dictionary)) {
       throw new CrudHttpError(400, { error: context.translate('dictionaries.errors.currency_protected', 'The currency dictionary cannot be modified or deleted.') })
     }
@@ -209,6 +259,20 @@ export async function DELETE(req: Request, ctx: { params?: { dictionaryId?: stri
     dictionary.isActive = false
     dictionary.deletedAt = dictionary.deletedAt ?? new Date()
     await context.em.flush()
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(context.container, {
+        tenantId: context.tenantId,
+        organizationId: context.organizationId,
+        userId: guardUserId,
+        resourceKind: 'dictionaries.dictionary',
+        resourceId: dictionary.id,
+        operation: 'delete',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     return NextResponse.json({ ok: true })
   } catch (err) {

--- a/packages/core/src/modules/dictionaries/api/__tests__/mutation-guard.test.ts
+++ b/packages/core/src/modules/dictionaries/api/__tests__/mutation-guard.test.ts
@@ -1,0 +1,208 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const dictionaryId = '44444444-4444-4444-8444-444444444444'
+
+const em = {
+  fork: jest.fn(),
+  findOne: jest.fn(),
+  find: jest.fn(),
+  create: jest.fn(),
+  persist: jest.fn(),
+  flush: jest.fn(),
+}
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const context = {
+  container,
+  ctx: {
+    container,
+    auth: { tenantId, sub: userId },
+    organizationScope: null,
+    selectedOrganizationId: organizationId,
+    organizationIds: [organizationId],
+    request: null,
+  },
+  auth: { tenantId, sub: userId, orgId: organizationId },
+  em,
+  organizationId,
+  tenantId,
+  readableOrganizationIds: [organizationId],
+  translate: (_key: string, fallback?: string) => fallback ?? 'error',
+}
+
+jest.mock('@open-mercato/core/modules/dictionaries/api/context', () => ({
+  resolveDictionariesRouteContext: jest.fn(async () => context),
+  resolveDictionaryActorId: jest.fn(() => userId),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+import { POST as createDictionary } from '../route'
+import { PATCH as updateDictionary, DELETE as deleteDictionary } from '../[dictionaryId]/route'
+
+function makeDictionaryRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: dictionaryId,
+    key: 'colors',
+    name: 'Colors',
+    description: null,
+    isSystem: false,
+    isActive: true,
+    managerVisibility: 'all',
+    entrySortMode: 'label_asc',
+    organizationId,
+    tenantId,
+    deletedAt: null as Date | null,
+    createdAt: new Date('2026-05-01T10:00:00.000Z'),
+    updatedAt: new Date('2026-06-01T10:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+describe('dictionary custom write routes mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    em.fork.mockReturnValue(em)
+    em.flush.mockResolvedValue(undefined)
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+  })
+
+  it('runs the mutation guard lifecycle when creating a dictionary', async () => {
+    em.findOne.mockResolvedValueOnce(null)
+    em.create.mockImplementation((_entity: unknown, data: Record<string, unknown>) => ({ id: dictionaryId, ...data }))
+
+    const response = await createDictionary(
+      new Request('http://localhost/api/dictionaries', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ key: 'colors', name: 'Colors' }),
+      }),
+    )
+
+    expect(response.status).toBe(201)
+    expect(em.persist).toHaveBeenCalled()
+    expect(em.flush).toHaveBeenCalled()
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'dictionaries.dictionary',
+        operation: 'create',
+      }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dictionaries.dictionary', operation: 'create' }),
+    )
+  })
+
+  it('blocks dictionary creation when the guard rejects the mutation', async () => {
+    em.findOne.mockResolvedValueOnce(null)
+    em.create.mockImplementation((_entity: unknown, data: Record<string, unknown>) => ({ id: dictionaryId, ...data }))
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await createDictionary(
+      new Request('http://localhost/api/dictionaries', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ key: 'colors', name: 'Colors' }),
+      }),
+    )
+
+    expect(response.status).toBe(423)
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the mutation guard lifecycle when updating a dictionary', async () => {
+    em.findOne.mockResolvedValueOnce(makeDictionaryRecord())
+
+    const response = await updateDictionary(
+      new Request(`http://localhost/api/dictionaries/${dictionaryId}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed' }),
+      }),
+      { params: { dictionaryId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(em.flush).toHaveBeenCalled()
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dictionaries.dictionary', resourceId: dictionaryId, operation: 'update' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dictionaries.dictionary', resourceId: dictionaryId, operation: 'update' }),
+    )
+  })
+
+  it('blocks dictionary update when the guard rejects the mutation', async () => {
+    em.findOne.mockResolvedValueOnce(makeDictionaryRecord())
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await updateDictionary(
+      new Request(`http://localhost/api/dictionaries/${dictionaryId}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed' }),
+      }),
+      { params: { dictionaryId } },
+    )
+
+    expect(response.status).toBe(423)
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('runs the mutation guard lifecycle when deleting a dictionary', async () => {
+    em.findOne.mockResolvedValueOnce(makeDictionaryRecord())
+
+    const response = await deleteDictionary(
+      new Request(`http://localhost/api/dictionaries/${dictionaryId}`, { method: 'DELETE' }),
+      { params: { dictionaryId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(em.flush).toHaveBeenCalled()
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dictionaries.dictionary', resourceId: dictionaryId, operation: 'delete' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'dictionaries.dictionary', resourceId: dictionaryId, operation: 'delete' }),
+    )
+  })
+
+  it('blocks dictionary deletion when the guard rejects the mutation', async () => {
+    em.findOne.mockResolvedValueOnce(makeDictionaryRecord())
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 423, body: { error: 'locked' } })
+
+    const response = await deleteDictionary(
+      new Request(`http://localhost/api/dictionaries/${dictionaryId}`, { method: 'DELETE' }),
+      { params: { dictionaryId } },
+    )
+
+    expect(response.status).toBe(423)
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/dictionaries/api/route.ts
+++ b/packages/core/src/modules/dictionaries/api/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server'
 import { Dictionary } from '@open-mercato/core/modules/dictionaries/data/entities'
-import { resolveDictionariesRouteContext } from '@open-mercato/core/modules/dictionaries/api/context'
+import { resolveDictionariesRouteContext, resolveDictionaryActorId } from '@open-mercato/core/modules/dictionaries/api/context'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
   DEFAULT_DICTIONARY_ENTRY_SORT_MODE,
@@ -100,8 +104,39 @@ export async function POST(req: Request) {
       createdAt: new Date(),
       updatedAt: new Date(),
     })
+
+    const guardUserId = resolveDictionaryActorId(context.auth)
+    const guardResult = await validateCrudMutationGuard(context.container, {
+      tenantId: context.tenantId,
+      organizationId: context.organizationId,
+      userId: guardUserId,
+      resourceKind: 'dictionaries.dictionary',
+      resourceId: dictionary.id,
+      operation: 'create',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: payload,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     context.em.persist(dictionary)
     await context.em.flush()
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(context.container, {
+        tenantId: context.tenantId,
+        organizationId: context.organizationId,
+        userId: guardUserId,
+        resourceKind: 'dictionaries.dictionary',
+        resourceId: dictionary.id,
+        operation: 'create',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     return NextResponse.json({
       id: dictionary.id,


### PR DESCRIPTION
Fixes #3217

## Problem
Several custom `dictionaries` write routes bypassed the CRUD mutation guard lifecycle required by `packages/core/AGENTS.md`. Global mutation hooks, record-lock integrations, and future write guards did not run consistently for dictionary writes. By contrast, the reorder and set-default routes already wired the guard, so the gap was route-specific.

## Root Cause
The non-`makeCrudRoute` write routes persisted directly (via `em.persist`/`em.flush`) or through the command bus without calling `validateCrudMutationGuard` / `runCrudMutationGuardAfterSuccess`.

## What Changed
Wired the standard mutation guard lifecycle into every affected route — `validateCrudMutationGuard` before the write (returning the guard rejection body/status when it blocks), and `runCrudMutationGuardAfterSuccess` after a successful write when requested:

- `POST /api/dictionaries` (create dictionary) — `dictionaries.dictionary`, `create`
- `PATCH /api/dictionaries/[dictionaryId]` (update) — `dictionaries.dictionary`, `update`
- `DELETE /api/dictionaries/[dictionaryId]` (delete) — `dictionaries.dictionary`, `delete`
- `POST /api/dictionaries/[dictionaryId]/entries` (create entry) — `dictionaries.entry`, `create`
- `PATCH /api/dictionaries/[dictionaryId]/entries/[entryId]` (update entry) — `dictionaries.entry`, `update`
- `DELETE /api/dictionaries/[dictionaryId]/entries/[entryId]` (delete entry) — `dictionaries.entry`, `delete`

The actor id is resolved with the existing `resolveDictionaryActorId`, mirroring the reorder/set-default routes. No optimistic-locking behavior was changed.

## Tests
- `api/__tests__/mutation-guard.test.ts` — covers dictionary create/update/delete: asserts the guard validate + after-success lifecycle runs, and that a guard rejection blocks the flush.
- `api/[dictionaryId]/entries/__tests__/entry-write-mutation-guard.test.ts` — covers entry create/update/delete with the same assertions against the command bus.
- Full dictionaries API suite: 6 suites / 26 tests pass (including the pre-existing reorder/set-default guard and optimistic-lock tests).
- `tsc --noEmit` reports zero errors across the dictionaries module.

## Backward Compatibility
No contract surface changes. The guard is a no-op when no `crudMutationGuardService` is registered (OSS default), so existing API consumers are unaffected.