### PR TITLE
fix(directory): load all tenants in TenantSelect via pagination (#3224)

### DIFF
--- a/packages/core/src/modules/directory/components/TenantSelect.tsx
+++ b/packages/core/src/modules/directory/components/TenantSelect.tsx
@@ -57,21 +57,11 @@ function filterTenantsByStatus(list: TenantRecord[], status: 'all' | 'active' | 
   return list
 }
 
-async function fetchDirectoryTenants(status: 'all' | 'active' | 'inactive', errorMessage: string): Promise<TenantRecord[]> {
-  const search = new URLSearchParams()
-  search.set('page', '1')
-  search.set('pageSize', '100')
-  search.set('sortField', 'name')
-  search.set('sortDir', 'asc')
-  if (status === 'active') search.set('isActive', 'true')
-  if (status === 'inactive') search.set('isActive', 'false')
-  const json = await readApiResultOrThrow<{ items?: unknown[] }>(
-    `/api/directory/tenants?${search.toString()}`,
-    undefined,
-    { errorMessage, allowNullResult: true },
-  )
-  const items = Array.isArray(json?.items) ? json.items : []
-  const normalized = items
+const DIRECTORY_TENANTS_PAGE_SIZE = 100
+const DIRECTORY_TENANTS_MAX_PAGES = 200
+
+function normalizeTenantItems(items: unknown[]): TenantRecord[] {
+  return items
     .map((item: unknown): TenantRecord | null => {
       if (!item || typeof item !== 'object') return null
       const entry = item as Record<string, unknown>
@@ -84,7 +74,34 @@ async function fetchDirectoryTenants(status: 'all' | 'active' | 'inactive', erro
       return { id, name, isActive }
     })
     .filter((tenant: TenantRecord | null): tenant is TenantRecord => tenant !== null)
-  return mergeTenantLists(filterTenantsByStatus(normalized, status))
+}
+
+async function fetchDirectoryTenants(status: 'all' | 'active' | 'inactive', errorMessage: string): Promise<TenantRecord[]> {
+  const collected: TenantRecord[] = []
+  let page = 1
+  let totalPages = 1
+  do {
+    const search = new URLSearchParams()
+    search.set('page', String(page))
+    search.set('pageSize', String(DIRECTORY_TENANTS_PAGE_SIZE))
+    search.set('sortField', 'name')
+    search.set('sortDir', 'asc')
+    if (status === 'active') search.set('isActive', 'true')
+    if (status === 'inactive') search.set('isActive', 'false')
+    const json = await readApiResultOrThrow<{ items?: unknown[]; totalPages?: unknown }>(
+      `/api/directory/tenants?${search.toString()}`,
+      undefined,
+      { errorMessage, allowNullResult: true },
+    )
+    const items = Array.isArray(json?.items) ? json.items : []
+    collected.push(...normalizeTenantItems(items))
+    totalPages = typeof json?.totalPages === 'number' && Number.isFinite(json.totalPages)
+      ? Math.max(1, Math.floor(json.totalPages))
+      : 1
+    if (items.length < DIRECTORY_TENANTS_PAGE_SIZE) break
+    page += 1
+  } while (page <= totalPages && page <= DIRECTORY_TENANTS_MAX_PAGES)
+  return mergeTenantLists(filterTenantsByStatus(collected, status))
 }
 
 async function fetchTenantsFromOrganizationSwitcher(status: 'all' | 'active' | 'inactive', errorMessage: string): Promise<TenantRecord[]> {

--- a/packages/core/src/modules/directory/components/__tests__/TenantSelect.test.tsx
+++ b/packages/core/src/modules/directory/components/__tests__/TenantSelect.test.tsx
@@ -61,11 +61,11 @@ describe('TenantSelect', () => {
     })
   })
 
-  it('requests pageSize=100 from the directory tenants endpoint', async () => {
-    let capturedUrl: string | undefined
-    ;(readApiResultOrThrow as jest.Mock).mockImplementationOnce(async (url: string) => {
-      capturedUrl = url
-      return { items: [{ id: 't-100', name: 'Tenant A', isActive: true }] }
+  it('requests only one page when the first page is not full', async () => {
+    const capturedUrls: string[] = []
+    ;(readApiResultOrThrow as jest.Mock).mockImplementation(async (url: string) => {
+      capturedUrls.push(url)
+      return { items: [{ id: 't-100', name: 'Tenant A', isActive: true }], totalPages: 1 }
     })
 
     renderWithProviders(<TenantSelect />, { dict })
@@ -74,8 +74,36 @@ describe('TenantSelect', () => {
       expect(screen.getByRole('option', { name: 'Tenant A' })).toBeInTheDocument()
     })
 
-    expect(capturedUrl).toContain('pageSize=100')
-    expect(capturedUrl).not.toContain('pageSize=200')
+    expect(capturedUrls).toHaveLength(1)
+    expect(capturedUrls[0]).toContain('page=1')
+    expect(capturedUrls[0]).toContain('pageSize=100')
+  })
+
+  it('pages through every tenant when more than one page exists', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      id: `t-${String(index).padStart(3, '0')}`,
+      name: `Tenant ${String(index).padStart(3, '0')}`,
+      isActive: true,
+    }))
+    const secondPage = [{ id: 't-extra', name: 'Tenant Beyond First Page', isActive: true }]
+    const capturedUrls: string[] = []
+    ;(readApiResultOrThrow as jest.Mock).mockImplementation(async (url: string) => {
+      capturedUrls.push(url)
+      if (url.includes('page=2')) {
+        return { items: secondPage, totalPages: 2 }
+      }
+      return { items: firstPage, totalPages: 2 }
+    })
+
+    renderWithProviders(<TenantSelect includeEmptyOption />, { dict })
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Tenant Beyond First Page' })).toBeInTheDocument()
+    })
+
+    expect(capturedUrls.some((url) => url.includes('page=1'))).toBe(true)
+    expect(capturedUrls.some((url) => url.includes('page=2'))).toBe(true)
+    expect(screen.getByRole('option', { name: 'Tenant 000' })).toBeInTheDocument()
   })
 
   it('auto-selects first tenant when value is null and includeEmptyOption is false', async () => {


### PR DESCRIPTION
Fixes #3224

## Problem
`TenantSelect` only fetched the first 100 tenants from `/api/directory/tenants` and rendered that bounded result as the complete option list. In deployments with more than 100 tenants, superadmins could not select tenants beyond the first page in the directory organization create/edit flows — a correctness bug that can block assigning or moving an organization to a valid tenant.

## Root Cause
`fetchDirectoryTenants` issued a single request hard-coded to `page=1&pageSize=100` and used that one page as the full tenant list. The `/api/directory/tenants` endpoint caps `pageSize` at 100, so a single request can never return more than 100 records.

## What Changed
- `packages/core/src/modules/directory/components/TenantSelect.tsx`: `fetchDirectoryTenants` now pages through the endpoint at the API's max `pageSize=100` until the server reports no further pages, accumulating every selectable tenant. It uses the response `totalPages` plus a defensive short-page break, and a hard `DIRECTORY_TENANTS_MAX_PAGES` cap (200 pages) to guarantee termination even if the API misreports paging.
- Extracted the per-item normalization into a `normalizeTenantItems` helper reused across pages.
- The per-request shape is unchanged (`pageSize=100`); the organization-switcher fallback path is unchanged.

## Tests
- Updated `packages/core/src/modules/directory/components/__tests__/TenantSelect.test.tsx`:
  - Replaced the test that pinned first-page-only behavior with one asserting a single request when the first page is not full.
  - Added a regression test that returns a full first page plus a second page and asserts the component pages through and renders a tenant that only exists on page 2 (fails against the old single-page implementation).
- `yarn workspace @open-mercato/core test -- TenantSelect`: 9 passed.
- `yarn workspace @open-mercato/core typecheck`: clean (after `yarn build:packages` + `yarn generate`).

## Backward Compatibility
- No contract surface changes. `TenantSelect` props, the API route, and the request parameters are unchanged; only the client now consumes all pages instead of one.