### PR TITLE
fix(directory): harden organization branding PUT with mutation guards and optimistic locking (#3222)

### DIFF
--- a/packages/core/src/modules/directory/api/organization-branding/__tests__/route.test.ts
+++ b/packages/core/src/modules/directory/api/organization-branding/__tests__/route.test.ts
@@ -2,15 +2,21 @@
 
 const tenantId = '11111111-1111-4111-8111-111111111111'
 const organizationId = '22222222-2222-4222-8222-222222222222'
+const currentUpdatedAt = '2026-06-18T10:00:00.000Z'
+const staleUpdatedAt = '2026-06-17T10:00:00.000Z'
+const OPTIMISTIC_LOCK_HEADER = 'x-om-ext-optimistic-lock-expected-updated-at'
 
 const deleteByTags = jest.fn(async () => {})
 const commandBusExecute = jest.fn()
 const runWithCacheTenantMock = jest.fn(async (_tenantId: string | null, fn: () => unknown) => await fn())
+const validateMutation = jest.fn(async () => ({ ok: true, shouldRunAfterSuccess: false, metadata: null }))
+const afterMutationSuccess = jest.fn(async () => {})
 const container = {
   resolve: jest.fn((name: string) => {
     if (name === 'em') return {}
     if (name === 'cache') return { deleteByTags }
     if (name === 'commandBus') return { execute: commandBusExecute }
+    if (name === 'crudMutationGuardService') return { validateMutation, afterMutationSuccess }
     throw new Error(`Unexpected container resolve: ${name}`)
   }),
 }
@@ -63,6 +69,7 @@ function makeOrganization(overrides: Record<string, unknown> = {}) {
     id: organizationId,
     name: 'Acme',
     logoUrl: '/api/attachments/image/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/acme.png?width=320&height=320',
+    updatedAt: new Date(currentUpdatedAt),
     ...overrides,
   }
 }
@@ -78,6 +85,8 @@ beforeEach(() => {
   })
   findOneWithDecryptionMock.mockResolvedValue(makeOrganization())
   commandBusExecute.mockResolvedValue({ result: makeOrganization({ logoUrl: 'https://example.com/logo.svg' }) })
+  validateMutation.mockResolvedValue({ ok: true, shouldRunAfterSuccess: false, metadata: null })
+  afterMutationSuccess.mockResolvedValue(undefined)
 })
 
 describe('/api/directory/organization-branding', () => {
@@ -90,6 +99,7 @@ describe('/api/directory/organization-branding', () => {
       organizationName: 'Acme',
       tenantId,
       logoUrl: '/api/attachments/image/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/acme.png?width=320&height=320',
+      updatedAt: currentUpdatedAt,
     })
     expect(findOneWithDecryptionMock).toHaveBeenCalledWith(
       expect.anything(),
@@ -144,6 +154,7 @@ describe('/api/directory/organization-branding', () => {
       organizationName: 'Acme',
       tenantId,
       logoUrl: 'https://example.com/logo.svg',
+      updatedAt: currentUpdatedAt,
     })
   })
 
@@ -172,6 +183,7 @@ describe('/api/directory/organization-branding', () => {
       organizationName: 'Acme',
       tenantId,
       logoUrl,
+      updatedAt: currentUpdatedAt,
     })
   })
 
@@ -199,6 +211,7 @@ describe('/api/directory/organization-branding', () => {
       organizationName: 'Acme',
       tenantId,
       logoUrl: null,
+      updatedAt: currentUpdatedAt,
     })
   })
 
@@ -236,5 +249,74 @@ describe('/api/directory/organization-branding', () => {
     expect(commandBusExecute).not.toHaveBeenCalled()
     const body = await response.json() as { error?: string }
     expect(body.error).toBe('Enter a valid image URL.')
+  })
+
+  it('rejects a stale branding update with a 409 optimistic-lock conflict', async () => {
+    const response = await PUT(new Request('http://localhost/api/directory/organization-branding', {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        [OPTIMISTIC_LOCK_HEADER]: staleUpdatedAt,
+      },
+      body: JSON.stringify({ logoUrl: 'https://example.com/logo.svg' }),
+    }))
+
+    expect(response.status).toBe(409)
+    expect(commandBusExecute).not.toHaveBeenCalled()
+    expect(deleteByTags).not.toHaveBeenCalled()
+    const body = await response.json() as { code?: string; currentUpdatedAt?: string; expectedUpdatedAt?: string }
+    expect(body.code).toBe('optimistic_lock_conflict')
+    expect(body.currentUpdatedAt).toBe(currentUpdatedAt)
+    expect(body.expectedUpdatedAt).toBe(staleUpdatedAt)
+  })
+
+  it('updates branding when the expected version matches the current one', async () => {
+    const response = await PUT(new Request('http://localhost/api/directory/organization-branding', {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        [OPTIMISTIC_LOCK_HEADER]: currentUpdatedAt,
+      },
+      body: JSON.stringify({ logoUrl: 'https://example.com/logo.svg' }),
+    }))
+
+    expect(response.status).toBe(200)
+    expect(commandBusExecute).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks the branding update when the mutation guard denies it', async () => {
+    validateMutation.mockResolvedValue({ ok: false, status: 423, body: { error: 'Record is locked' } })
+
+    const response = await PUT(new Request('http://localhost/api/directory/organization-branding', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ logoUrl: 'https://example.com/logo.svg' }),
+    }))
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecute).not.toHaveBeenCalled()
+    expect(deleteByTags).not.toHaveBeenCalled()
+    const body = await response.json() as { error?: string }
+    expect(body.error).toBe('Record is locked')
+  })
+
+  it('runs the mutation-guard after-success hook when requested', async () => {
+    validateMutation.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { reason: 'test' } })
+
+    const response = await PUT(new Request('http://localhost/api/directory/organization-branding', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ logoUrl: 'https://example.com/logo.svg' }),
+    }))
+
+    expect(response.status).toBe(200)
+    expect(afterMutationSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceKind: 'directory.organization',
+        resourceId: organizationId,
+        operation: 'update',
+        metadata: { reason: 'test' },
+      }),
+    )
   })
 })

--- a/packages/core/src/modules/directory/api/organization-branding/route.ts
+++ b/packages/core/src/modules/directory/api/organization-branding/route.ts
@@ -7,6 +7,11 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
+import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { Organization } from '@open-mercato/core/modules/directory/data/entities'
@@ -24,6 +29,7 @@ const brandingResponseSchema = z.object({
   organizationName: z.string(),
   tenantId: z.string().uuid(),
   logoUrl: z.string().nullable(),
+  updatedAt: z.string().nullable(),
 })
 
 const brandingUpdateSchema = z.object({
@@ -105,12 +111,25 @@ async function resolveCurrentOrganization(req: Request) {
   return { auth, container, organization, organizationId, tenantId, translate }
 }
 
+function toIsoOrNull(value: Date | string | null | undefined): string | null {
+  if (value == null) return null
+  if (value instanceof Date) {
+    const ms = value.getTime()
+    return Number.isFinite(ms) ? new Date(ms).toISOString() : null
+  }
+  const trimmed = String(value).trim()
+  if (!trimmed) return null
+  const parsed = new Date(trimmed)
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null
+}
+
 function toResponsePayload(organization: Organization, tenantId: string) {
   return {
     organizationId: String(organization.id),
     organizationName: organization.name,
     tenantId,
     logoUrl: organization.logoUrl ?? null,
+    updatedAt: toIsoOrNull(organization.updatedAt),
   }
 }
 
@@ -169,6 +188,32 @@ export async function PUT(req: Request) {
   }
 
   try {
+    // Refuse a stale overwrite when two tabs edit the same organization branding.
+    // Strictly additive — a no-op when the client omits the expected-version header.
+    enforceCommandOptimisticLock({
+      resourceKind: 'directory.organization',
+      resourceId: resolved.organizationId,
+      current: resolved.organization.updatedAt ?? null,
+      request: req,
+    })
+
+    // Mutation-guard contract for custom write routes: validate before the write,
+    // then run the after-success hook once the command persists.
+    const guardResult = await validateCrudMutationGuard(resolved.container, {
+      tenantId: resolved.tenantId,
+      organizationId: resolved.organizationId,
+      userId: resolved.auth.sub,
+      resourceKind: 'directory.organization',
+      resourceId: resolved.organizationId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: { logoUrl: parsed.data.logoUrl ?? null },
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     const commandBus = resolved.container.resolve('commandBus') as CommandBus
     const ctx = buildCommandContext(
       resolved.container,
@@ -188,6 +233,21 @@ export async function PUT(req: Request) {
         ctx,
       },
     )
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(resolved.container, {
+        tenantId: resolved.tenantId,
+        organizationId: resolved.organizationId,
+        userId: resolved.auth.sub,
+        resourceKind: 'directory.organization',
+        resourceId: resolved.organizationId,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
+
     await invalidateSidebarBrandingCache(resolved.container, resolved.organizationId, resolved.tenantId)
     return NextResponse.json(toResponsePayload(result, resolved.tenantId))
   } catch (err) {
@@ -231,6 +291,7 @@ export const openApi: OpenApiRouteDoc = {
       errors: [
         { status: 400, description: 'Save failed', schema: errorSchema },
         { status: 401, description: 'Unauthorized', schema: errorSchema },
+        { status: 409, description: 'Organization branding changed since it was loaded', schema: errorSchema },
         { status: 422, description: 'Invalid logo URL', schema: errorSchema },
       ],
     },

--- a/packages/core/src/modules/directory/backend/directory/branding/page.tsx
+++ b/packages/core/src/modules/directory/backend/directory/branding/page.tsx
@@ -7,7 +7,9 @@ import { Page, PageBody, PageHeader } from '@open-mercato/ui/backend/Page'
 import { LoadingMessage, ErrorMessage } from '@open-mercato/ui/backend/detail'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
-import { apiCallOrThrow, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { apiCallOrThrow, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
+import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Input } from '@open-mercato/ui/primitives/input'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -17,6 +19,7 @@ type BrandingPayload = {
   organizationName: string
   tenantId: string
   logoUrl: string | null
+  updatedAt: string | null
 }
 
 type UploadPayload = {
@@ -98,15 +101,17 @@ export default function OrganizationBrandingPage() {
         operation: async () => {
           const uploadedLogoUrl = shouldUpload ? await uploadLogo(data.organizationId) : null
           const resolvedLogoUrl = uploadedLogoUrl ?? nextLogoUrl ?? logoUrl.trim()
-          // optimistic-lock-exempt: selected organization branding uses a scoped command endpoint without an exposed updatedAt token.
-          const response = await apiCallOrThrow<BrandingPayload>(
-            BRANDING_API,
-            {
-              method: 'PUT',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ logoUrl: resolvedLogoUrl || null }),
-            },
-            { errorMessage: t('directory.branding.errors.save', 'Failed to update organization branding') },
+          const response = await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(data.updatedAt),
+            () => apiCallOrThrow<BrandingPayload>(
+              BRANDING_API,
+              {
+                method: 'PUT',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ logoUrl: resolvedLogoUrl || null }),
+              },
+              { errorMessage: t('directory.branding.errors.save', 'Failed to update organization branding') },
+            ),
           )
           return response.result
         },
@@ -127,6 +132,7 @@ export default function OrganizationBrandingPage() {
       if (fileInputRef.current) fileInputRef.current.value = ''
       flash(t('directory.branding.flash.saved', 'Organization branding updated'), 'success')
     } catch (err: unknown) {
+      if (surfaceRecordConflict(err, t)) return
       const fallback = t('directory.branding.errors.save', 'Failed to update organization branding')
       const message = err instanceof Error ? err.message : fallback
       flash(message, 'error')


### PR DESCRIPTION
Fixes #3222

## Problem
`PUT /api/directory/organization-branding` updated the selected organization's `logoUrl` through a direct command-bus call without running the custom-route mutation-guard lifecycle, and the branding UI explicitly opted out of optimistic locking (`optimistic-lock-exempt`). That left this command/action endpoint outside the protections required by root/core AGENTS: custom write routes must validate mutation guards before the write and run the after-success hook after the command succeeds, and command/action endpoints must enforce optimistic locking for user-editable records.

## Root Cause
The route was authored as a custom `PUT` handler that resolved `commandBus` and executed `directory.organizations.update` directly, with no `enforceCommandOptimisticLock`, `validateCrudMutationGuard`, or `runCrudMutationGuardAfterSuccess` calls. The UI never sent an `If-Match`/expected-version token because the response did not expose `updatedAt`.

## What Changed
- **Route** (`api/organization-branding/route.ts`):
  - Enforce command-level optimistic locking against the organization's `updatedAt` via `enforceCommandOptimisticLock` (default ON; strictly additive — no-op without the header). Stale writes now return the standard structured `409 optimistic_lock_conflict`.
  - Expose `updatedAt` (ISO string) in the GET/PUT branding response so the client has a version token.
  - Run `validateCrudMutationGuard` before the write and `runCrudMutationGuardAfterSuccess` after the command succeeds, mirroring the `customers.settings` reference route.
  - Document the new `409` response in the OpenAPI spec.
- **UI** (`backend/directory/branding/page.tsx`):
  - Send the expected-version header via `withScopedApiRequestHeaders(buildOptimisticLockHeader(data.updatedAt), …)` and remove the `optimistic-lock-exempt` marker.
  - Surface 409s through `surfaceRecordConflict(err, t)` (the shared conflict bar) before the generic flash error.

## Tests
- Added route tests: stale update → `409` with `optimistic_lock_conflict` body, matching-version update succeeds, mutation-guard denial propagates its status/body, and the after-success hook runs with the right metadata when requested. Existing tests updated to assert `updatedAt` in the payload.
- `yarn workspace @open-mercato/core test -- organization-branding` → 12 passed.
- Optimistic-lock guard suites pass (`optimistic-lock-ui-coverage`, `optimistic-lock-editable-entities`) — the branding UI is now covered, not exempt.
- `yarn typecheck` (21/21), `yarn i18n:check-sync` (in sync), full `directory` suite (90 passed).

## Backward Compatibility
- Additive only: the response gains an `updatedAt` field; no fields removed. Optimistic locking is a no-op when the client omits the header, so existing API consumers are unaffected. No event ID / DI key / ACL / import-path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)