### PR TITLE
fix(directory): route tenant and organization list deletes through useGuardedMutation (#3223)

### DIFF
--- a/packages/core/src/modules/directory/backend/directory/organizations/__tests__/page.test.tsx
+++ b/packages/core/src/modules/directory/backend/directory/organizations/__tests__/page.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment jsdom
+ */
+import type React from 'react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import DirectoryOrganizationsPage from '../page'
+import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
+
+const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  ...jest.requireActual('@open-mercato/shared/lib/i18n/context'),
+  useT: () => mockTranslate,
+}))
+
+jest.mock('next/link', () => ({ children, href }: any) => <a href={href}>{children}</a>)
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: any) => <div>{children}</div>,
+  PageBody: ({ children }: any) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  DataTable: (props: any) => (
+    <div data-testid="data-table-mock">
+      <div data-testid="data-table-title">{props.title}</div>
+      <div data-testid="row-actions">
+        {props.rowActions?.({
+          id: 'org-1',
+          name: 'Acme HQ',
+          depth: 0,
+          updatedAt: '2024-05-06T07:08:09.000Z',
+        })}
+      </div>
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/filters/ListEmptyState', () => ({
+  ListEmptyState: () => null,
+}))
+
+jest.mock('@open-mercato/ui/backend/RowActions', () => ({
+  RowActions: ({ items }: any) => (
+    <div>
+      {items.map((item: any) => (
+        <button key={item.id} data-testid={`row-action-${item.id}`} onClick={() => item.onSelect?.()}>
+          {item.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/ValueIcons', () => ({
+  BooleanIcon: ({ value }: { value: boolean }) => <span>{String(value)}</span>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, asChild, ...rest }: any) =>
+    asChild ? <span {...rest}>{children}</span> : <button {...rest}>{children}</button>,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+  apiCallOrThrow: jest.fn(),
+  readApiResultOrThrow: jest.fn(),
+  withScopedApiRequestHeaders: (_headers: unknown, run: () => unknown) => run(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: jest.fn(() => ({ 'x-expected-updated-at': 'header' })),
+}))
+
+const runMutationMock = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+const retryLastMutationMock = jest.fn(async () => true)
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: (input: { operation: () => Promise<unknown> }) => runMutationMock(input),
+    retryLastMutation: retryLastMutationMock,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/conflicts', () => ({
+  surfaceRecordConflict: jest.fn(() => false),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: jest.fn().mockReturnValue(1),
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({
+    confirm: jest.fn(() => Promise.resolve(true)),
+    ConfirmDialogElement: null,
+  }),
+}))
+
+const { readApiResultOrThrow } = jest.requireMock('@open-mercato/ui/backend/utils/apiCall') as {
+  readApiResultOrThrow: jest.Mock
+}
+
+describe('DirectoryOrganizationsPage delete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    runMutationMock.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+    ;(surfaceRecordConflict as jest.Mock).mockReturnValue(false)
+    ;(apiCall as jest.Mock).mockResolvedValue({ ok: true, result: { ok: true, granted: ['directory.organizations.manage'] } })
+    readApiResultOrThrow.mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 50, totalPages: 0 })
+    ;(apiCallOrThrow as jest.Mock).mockResolvedValue({ ok: true })
+  })
+
+  it('routes the delete through useGuardedMutation with stable context and the row lock header', async () => {
+    renderWithProviders(<DirectoryOrganizationsPage />)
+    const deleteButton = await screen.findByTestId('row-action-delete')
+
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalledTimes(1))
+    const input = runMutationMock.mock.calls[0][0]
+    expect(input.context).toEqual(
+      expect.objectContaining({
+        formId: 'directory-organizations-list:single-delete',
+        resourceKind: 'directory.organization',
+        resourceId: 'org-1',
+        retryLastMutation: retryLastMutationMock,
+      }),
+    )
+
+    await waitFor(() => expect(apiCallOrThrow).toHaveBeenCalled())
+    expect(buildOptimisticLockHeader).toHaveBeenCalledWith('2024-05-06T07:08:09.000Z')
+    const deleteCall = (apiCallOrThrow as jest.Mock).mock.calls[0]
+    expect(deleteCall[0]).toBe('/api/directory/organizations?id=org-1')
+    expect(deleteCall[1]).toEqual(expect.objectContaining({ method: 'DELETE' }))
+    expect(flash).toHaveBeenCalledWith('Organization deleted', 'success')
+  })
+
+  it('surfaces a stale-record 409 conflict through the shared conflict path and skips the generic flash', async () => {
+    const conflict = Object.assign(new Error('record_modified'), { status: 409 })
+    ;(apiCallOrThrow as jest.Mock).mockRejectedValue(conflict)
+    ;(surfaceRecordConflict as jest.Mock).mockReturnValue(true)
+
+    renderWithProviders(<DirectoryOrganizationsPage />)
+    const deleteButton = await screen.findByTestId('row-action-delete')
+
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => expect(surfaceRecordConflict).toHaveBeenCalledWith(conflict, expect.any(Function)))
+    expect(flash).not.toHaveBeenCalledWith('Organization deleted', 'success')
+    expect(flash).not.toHaveBeenCalledWith(expect.stringContaining('Failed'), 'error')
+  })
+
+  it('falls back to a generic error flash for non-conflict failures', async () => {
+    const failure = new Error('boom')
+    ;(apiCallOrThrow as jest.Mock).mockRejectedValue(failure)
+    ;(surfaceRecordConflict as jest.Mock).mockReturnValue(false)
+
+    renderWithProviders(<DirectoryOrganizationsPage />)
+    const deleteButton = await screen.findByTestId('row-action-delete')
+
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => expect(flash).toHaveBeenCalledWith('boom', 'error'))
+  })
+})

--- a/packages/core/src/modules/directory/backend/directory/organizations/page.tsx
+++ b/packages/core/src/modules/directory/backend/directory/organizations/page.tsx
@@ -13,6 +13,8 @@ import { Button } from '@open-mercato/ui/primitives/button'
 import { apiCall, apiCallOrThrow, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -177,6 +179,17 @@ export default function DirectoryOrganizationsPage() {
   const total = data?.total ?? 0
   const totalPages = data?.totalPages ?? 0
 
+  const deleteMutationContextId = 'directory-organizations-list:single-delete'
+  const { runMutation: runDeleteMutation, retryLastMutation: retryDeleteMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    resourceId: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: deleteMutationContextId,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+
   const handleDelete = React.useCallback(async (org: OrganizationRow) => {
     const confirmLabel = t('directory.organizations.list.confirmDelete', 'Archive organization "{{name}}"?', { name: org.name })
     const confirmed = await confirm({
@@ -187,22 +200,36 @@ export default function DirectoryOrganizationsPage() {
     if (!confirmed) return
 
     try {
-      await withScopedApiRequestHeaders(
-        buildOptimisticLockHeader(org.updatedAt),
-        () => apiCallOrThrow(
-          `/api/directory/organizations?id=${encodeURIComponent(org.id)}`,
-          { method: 'DELETE' },
-          { errorMessage: t('directory.organizations.list.error.delete', 'Failed to delete organization') },
+      await runDeleteMutation({
+        operation: () => withScopedApiRequestHeaders(
+          buildOptimisticLockHeader(org.updatedAt),
+          () => apiCallOrThrow(
+            `/api/directory/organizations?id=${encodeURIComponent(org.id)}`,
+            { method: 'DELETE' },
+            { errorMessage: t('directory.organizations.list.error.delete', 'Failed to delete organization') },
+          ),
         ),
-      )
+        context: {
+          formId: deleteMutationContextId,
+          resourceKind: 'directory.organization',
+          resourceId: org.id,
+          retryLastMutation: retryDeleteMutation,
+        },
+      })
       await queryClient.invalidateQueries({ queryKey: ['directory-organizations'] })
       flash(t('directory.organizations.flash.deleted', 'Organization deleted'), 'success')
     } catch (err: unknown) {
+      // A stale delete surfaces the unified conflict bar (via the guarded
+      // mutation) — skip the generic error flash to avoid a double message.
+      if (surfaceRecordConflict(err, t)) {
+        await queryClient.invalidateQueries({ queryKey: ['directory-organizations'] })
+        return
+      }
       const fallback = t('directory.organizations.list.error.delete', 'Failed to delete organization')
       const message = err instanceof Error ? err.message : fallback
       flash(message, 'error')
     }
-  }, [confirm, queryClient, t])
+  }, [confirm, deleteMutationContextId, queryClient, retryDeleteMutation, runDeleteMutation, t])
 
   return (
     <Page>

--- a/packages/core/src/modules/directory/backend/directory/tenants/__tests__/page.test.tsx
+++ b/packages/core/src/modules/directory/backend/directory/tenants/__tests__/page.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @jest-environment jsdom
+ */
+import type React from 'react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import DirectoryTenantsPage from '../page'
+import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
+
+const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  ...jest.requireActual('@open-mercato/shared/lib/i18n/context'),
+  useT: () => mockTranslate,
+}))
+
+jest.mock('next/link', () => ({ children, href }: any) => <a href={href}>{children}</a>)
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: any) => <div>{children}</div>,
+  PageBody: ({ children }: any) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  DataTable: (props: any) => (
+    <div data-testid="data-table-mock">
+      <div data-testid="data-table-title">{props.title}</div>
+      <div data-testid="row-actions">
+        {props.rowActions?.({
+          id: 'tenant-1',
+          name: 'Acme',
+          isActive: true,
+          createdAt: '2024-01-01',
+          updatedAt: '2024-01-02T03:04:05.000Z',
+        })}
+      </div>
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/filters/ListEmptyState', () => ({
+  ListEmptyState: () => null,
+}))
+
+jest.mock('@open-mercato/ui/backend/RowActions', () => ({
+  RowActions: ({ items }: any) => (
+    <div>
+      {items.map((item: any) => (
+        <button key={item.id} data-testid={`row-action-${item.id}`} onClick={() => item.onSelect?.()}>
+          {item.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/ValueIcons', () => ({
+  BooleanIcon: ({ value }: { value: boolean }) => <span>{String(value)}</span>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, asChild, ...rest }: any) =>
+    asChild ? <span {...rest}>{children}</span> : <button {...rest}>{children}</button>,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+  apiCallOrThrow: jest.fn(),
+  readApiResultOrThrow: jest.fn(),
+  withScopedApiRequestHeaders: (_headers: unknown, run: () => unknown) => run(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: jest.fn(() => ({ 'x-expected-updated-at': 'header' })),
+}))
+
+const runMutationMock = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+const retryLastMutationMock = jest.fn(async () => true)
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: (input: { operation: () => Promise<unknown> }) => runMutationMock(input),
+    retryLastMutation: retryLastMutationMock,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/conflicts', () => ({
+  surfaceRecordConflict: jest.fn(() => false),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: jest.fn().mockReturnValue(1),
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({
+    confirm: jest.fn(() => Promise.resolve(true)),
+    ConfirmDialogElement: null,
+  }),
+}))
+
+const { readApiResultOrThrow } = jest.requireMock('@open-mercato/ui/backend/utils/apiCall') as {
+  readApiResultOrThrow: jest.Mock
+}
+
+describe('DirectoryTenantsPage delete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    runMutationMock.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+    ;(surfaceRecordConflict as jest.Mock).mockReturnValue(false)
+    ;(apiCall as jest.Mock).mockResolvedValue({ ok: true, result: { ok: true, granted: ['directory.tenants.manage'] } })
+    readApiResultOrThrow.mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 20, totalPages: 0 })
+    ;(apiCallOrThrow as jest.Mock).mockResolvedValue({ ok: true })
+  })
+
+  it('routes the delete through useGuardedMutation with stable context and the row lock header', async () => {
+    renderWithProviders(<DirectoryTenantsPage />)
+    const deleteButton = await screen.findByTestId('row-action-delete')
+
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalledTimes(1))
+    const input = runMutationMock.mock.calls[0][0]
+    expect(input.context).toEqual(
+      expect.objectContaining({
+        formId: 'directory-tenants-list:single-delete',
+        resourceKind: 'directory.tenant',
+        resourceId: 'tenant-1',
+        retryLastMutation: retryLastMutationMock,
+      }),
+    )
+
+    await waitFor(() => expect(apiCallOrThrow).toHaveBeenCalled())
+    expect(buildOptimisticLockHeader).toHaveBeenCalledWith('2024-01-02T03:04:05.000Z')
+    const deleteCall = (apiCallOrThrow as jest.Mock).mock.calls[0]
+    expect(deleteCall[0]).toBe('/api/directory/tenants?id=tenant-1')
+    expect(deleteCall[1]).toEqual(expect.objectContaining({ method: 'DELETE' }))
+    expect(flash).toHaveBeenCalledWith('Tenant deleted', 'success')
+  })
+
+  it('surfaces a stale-record 409 conflict through the shared conflict path and skips the generic flash', async () => {
+    const conflict = Object.assign(new Error('record_modified'), { status: 409 })
+    ;(apiCallOrThrow as jest.Mock).mockRejectedValue(conflict)
+    ;(surfaceRecordConflict as jest.Mock).mockReturnValue(true)
+
+    renderWithProviders(<DirectoryTenantsPage />)
+    const deleteButton = await screen.findByTestId('row-action-delete')
+
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => expect(surfaceRecordConflict).toHaveBeenCalledWith(conflict, expect.any(Function)))
+    expect(flash).not.toHaveBeenCalledWith('Tenant deleted', 'success')
+    expect(flash).not.toHaveBeenCalledWith(expect.stringContaining('Failed'), 'error')
+  })
+
+  it('falls back to a generic error flash for non-conflict failures', async () => {
+    const failure = new Error('boom')
+    ;(apiCallOrThrow as jest.Mock).mockRejectedValue(failure)
+    ;(surfaceRecordConflict as jest.Mock).mockReturnValue(false)
+
+    renderWithProviders(<DirectoryTenantsPage />)
+    const deleteButton = await screen.findByTestId('row-action-delete')
+
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => expect(flash).toHaveBeenCalledWith('boom', 'error'))
+  })
+})

--- a/packages/core/src/modules/directory/backend/directory/tenants/page.tsx
+++ b/packages/core/src/modules/directory/backend/directory/tenants/page.tsx
@@ -10,10 +10,11 @@ import { RowActions } from '@open-mercato/ui/backend/RowActions'
 import { BooleanIcon } from '@open-mercato/ui/backend/ValueIcons'
 import type { FilterValues } from '@open-mercato/ui/backend/FilterBar'
 import { Button } from '@open-mercato/ui/primitives/button'
-import { apiCall, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
+import { apiCall, apiCallOrThrow, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
-import { raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -117,6 +118,17 @@ export default function DirectoryTenantsPage() {
   const total = data?.total ?? 0
   const totalPages = data?.totalPages ?? 0
 
+  const deleteMutationContextId = 'directory-tenants-list:single-delete'
+  const { runMutation: runDeleteMutation, retryLastMutation: retryDeleteMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    resourceId: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: deleteMutationContextId,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+
   const handleDelete = React.useCallback(async (tenant: TenantRow) => {
     const confirmMessage = t('directory.tenants.list.confirmDelete', 'Delete tenant "{{name}}"? This will archive it.').replace('{{name}}', tenant.name)
     const confirmed = await confirm({
@@ -127,23 +139,35 @@ export default function DirectoryTenantsPage() {
     if (!confirmed) return
 
     try {
-      const call = await withScopedApiRequestHeaders(
-        buildOptimisticLockHeader(tenant.updatedAt),
-        () => apiCall(
-          `/api/directory/tenants?id=${encodeURIComponent(tenant.id)}`,
-          { method: 'DELETE' },
+      await runDeleteMutation({
+        operation: () => withScopedApiRequestHeaders(
+          buildOptimisticLockHeader(tenant.updatedAt),
+          () => apiCallOrThrow(
+            `/api/directory/tenants?id=${encodeURIComponent(tenant.id)}`,
+            { method: 'DELETE' },
+            { errorMessage: t('directory.tenants.list.error.delete', 'Failed to delete tenant') },
+          ),
         ),
-      )
-      if (!call.ok) {
-        await raiseCrudError(call.response, t('directory.tenants.list.error.delete', 'Failed to delete tenant'))
-      }
+        context: {
+          formId: deleteMutationContextId,
+          resourceKind: 'directory.tenant',
+          resourceId: tenant.id,
+          retryLastMutation: retryDeleteMutation,
+        },
+      })
       await queryClient.invalidateQueries({ queryKey: ['directory-tenants'] })
       flash(t('directory.tenants.list.success.delete', 'Tenant deleted'), 'success')
-    } catch (err: any) {
+    } catch (err: unknown) {
+      // A stale delete surfaces the unified conflict bar (via the guarded
+      // mutation) — skip the generic error flash to avoid a double message.
+      if (surfaceRecordConflict(err, t)) {
+        await queryClient.invalidateQueries({ queryKey: ['directory-tenants'] })
+        return
+      }
       const message = err instanceof Error ? err.message : t('directory.tenants.list.error.delete', 'Failed to delete tenant')
       flash(message, 'error')
     }
-  }, [confirm, queryClient, t])
+  }, [confirm, deleteMutationContextId, queryClient, retryDeleteMutation, runDeleteMutation, t])
 
   return (
     <Page>


### PR DESCRIPTION
Fixes #3223

## Problem
The directory tenant and organization list pages performed row deletes manually with `apiCall`/`apiCallOrThrow`, bypassing `useGuardedMutation` and the unified conflict surfacing used for non-`CrudForm` mutating UI actions. Although the requests already sent optimistic-lock headers, routing them outside the guarded helper meant UI-level mutation guards and consistent 409 conflict handling could be skipped on these destructive row actions.

## Root Cause
Neither list page wired its delete flow through `useGuardedMutation`. The tenant page additionally used a raw `apiCall(..., { method: 'DELETE' })` + manual `raiseCrudError`, and both pages handled failures with a generic `flash(message, 'error')` that did not surface stale-record conflicts through the shared conflict bar.

## What Changed
- `tenants/page.tsx` and `organizations/page.tsx`: each row delete now runs inside `useGuardedMutation(...).runMutation(...)` with a stable `contextId` (`directory-tenants-list:single-delete` / `directory-organizations-list:single-delete`), entity metadata (`resourceKind`/`resourceId`), and `retryLastMutation` in the injection context.
- Preserved the per-row optimistic-lock header via `withScopedApiRequestHeaders(buildOptimisticLockHeader(row.updatedAt), …)` inside the guarded `operation`.
- On failure both handlers now call `surfaceRecordConflict(err, t)` first; a stale-record 409 surfaces the unified conflict bar and refreshes the list, skipping the generic error flash to avoid a double message. Non-conflict errors still flash a generic message.
- Tenant delete switched from `apiCall` + manual `raiseCrudError` to `apiCallOrThrow` for parity with the organizations page; removed the now-unused `raiseCrudError` import.

## Tests
- New `tenants/__tests__/page.test.tsx` and `organizations/__tests__/page.test.tsx`, each covering:
  - the delete is routed through `useGuardedMutation` with stable context/entity metadata and the row's optimistic-lock header is built for the selected row,
  - a stale-record (409) conflict is surfaced through `surfaceRecordConflict` and the generic flash is skipped,
  - non-conflict failures still fall back to a generic error flash.
- `optimistic-lock-ui-coverage` / `optimistic-lock-editable-entities` guard tests pass (both pages remain lock-covered).
- Full directory module suite green (17 suites / 92 tests). `yarn typecheck` and `yarn i18n:check-sync` pass.

## Backward Compatibility
- No contract surface changes (no API routes, types, event IDs, widget spot IDs, DI keys, or ACL features touched). Reuses the existing `ui.forms.flash.saveBlocked` translation key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)