### PR TITLE
fix(entities): route custom entity definition writes through mutation guards (#3226)

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/definitions.mutation-guard.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/definitions.mutation-guard.test.ts
@@ -1,0 +1,255 @@
+/** @jest-environment node */
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+
+type Where = Record<string, unknown>
+
+const mockEm = {
+  begin: jest.fn(async () => {}),
+  commit: jest.fn(async () => {}),
+  rollback: jest.fn(async () => {}),
+  find: jest.fn(async (_entity: unknown, _where: Where) => [] as unknown[]),
+  findOne: jest.fn(async () => null),
+  create: jest.fn((_entity: unknown, data: Where) => ({ id: 'created-id', ...data })),
+  persist: jest.fn(),
+  flush: jest.fn(async () => {}),
+}
+
+const mockCache = {
+  get: jest.fn(async () => null),
+  set: jest.fn(async () => undefined),
+  deleteByTags: jest.fn(async () => undefined),
+}
+
+const container = {
+  resolve: (key: string) => {
+    if (key === 'em') return mockEm
+    if (key === 'cache') return mockCache
+    return null
+  },
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => container,
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: async () => ({
+    sub: 'user-1',
+    userId: 'user-1',
+    tenantId: 'tenant-1',
+    orgId: 'org-1',
+    roles: ['admin'],
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/entities/data/entities', () => ({
+  CustomEntity: 'CustomEntity',
+  CustomFieldDef: 'CustomFieldDef',
+  CustomFieldEntityConfig: 'CustomFieldEntityConfig',
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/entityIds', () => ({
+  getEntityIds: () => ({}),
+}))
+
+jest.mock('@open-mercato/shared/lib/entities/system-entities', () => ({
+  isSystemEntitySelectable: () => true,
+  filterSelectableSystemEntityIds: (ids: string[]) => ids,
+}))
+
+jest.mock('@open-mercato/shared/lib/data/engine', () => ({
+  SYSTEM_ENTITY_RECORDS_BLOCKED_CODE: 'SYSTEM_ENTITY_RECORDS_BLOCKED',
+  isOrmBackedSystemEntityId: () => false,
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: async () => ({ tenantId: 'tenant-1', selectedId: 'org-1' }),
+}))
+
+jest.mock('../definitions.cache', () => ({
+  invalidateDefinitionsCache: jest.fn(async () => undefined),
+  createDefinitionsCacheKey: () => 'key',
+  createDefinitionsCacheTags: () => [],
+  ENTITY_DEFINITIONS_CACHE_TTL_MS: 1000,
+}))
+
+jest.mock('../../lib/fieldsets', () => ({
+  loadEntityFieldsetConfigs: async () => new Map(),
+  CustomFieldsetDefinition: class {},
+  mergeEntityFieldsetConfig: (existing: unknown) => existing,
+  normalizeEntityFieldsetConfig: () => ({ fieldsets: [], singleFieldsetPerRecord: true }),
+}))
+
+jest.mock('../../lib/install-from-ce', () => ({
+  installCustomEntitiesFromModules: async () => ({}),
+}))
+
+import { POST as ENTITIES_POST, DELETE as ENTITIES_DELETE } from '../entities'
+import { POST as DEFINITIONS_POST, DELETE as DEFINITIONS_DELETE } from '../definitions'
+import { POST as DEFINITIONS_BATCH_POST } from '../definitions.batch'
+import { POST as DEFINITIONS_RESTORE_POST } from '../definitions.restore'
+
+const allow = () => validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+const block = () => validateCrudMutationGuardMock.mockResolvedValue({ ok: false, status: 423, body: { error: 'blocked by guard' } })
+
+const jsonRequest = (url: string, method: string, body: unknown) =>
+  new Request(url, {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+describe('entities write routes — mutation guard lifecycle (issue #3226)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm.find.mockResolvedValue([] as unknown[])
+    mockEm.findOne.mockResolvedValue(null)
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+  })
+
+  describe('POST /api/entities/entities', () => {
+    const body = { entityId: 'mod:thing', label: 'Thing' }
+
+    it('blocks persistence when the guard rejects the mutation', async () => {
+      block()
+      const response = await ENTITIES_POST(jsonRequest('http://x/api/entities/entities', 'POST', body))
+      expect(response.status).toBe(423)
+      expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({ resourceKind: 'entities.entity', operation: 'create', tenantId: 'tenant-1' }),
+      )
+      expect(mockEm.flush).not.toHaveBeenCalled()
+      expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+    })
+
+    it('runs the after-success hook once the write succeeds', async () => {
+      allow()
+      const response = await ENTITIES_POST(jsonRequest('http://x/api/entities/entities', 'POST', body))
+      expect(response.status).toBe(200)
+      expect(mockEm.flush).toHaveBeenCalled()
+      expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({ resourceKind: 'entities.entity', operation: 'create' }),
+      )
+    })
+  })
+
+  describe('DELETE /api/entities/entities', () => {
+    const body = { entityId: 'mod:thing' }
+
+    it('blocks deletion when the guard rejects the mutation', async () => {
+      block()
+      mockEm.findOne.mockResolvedValue({ id: 'ent-1', updatedAt: new Date() })
+      const response = await ENTITIES_DELETE(jsonRequest('http://x/api/entities/entities', 'DELETE', body))
+      expect(response.status).toBe(423)
+      expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({ resourceKind: 'entities.entity', operation: 'delete' }),
+      )
+      expect(mockEm.flush).not.toHaveBeenCalled()
+    })
+
+    it('runs the after-success hook once the soft delete succeeds', async () => {
+      allow()
+      mockEm.findOne.mockResolvedValue({ id: 'ent-1', updatedAt: new Date() })
+      const response = await ENTITIES_DELETE(jsonRequest('http://x/api/entities/entities', 'DELETE', body))
+      expect(response.status).toBe(200)
+      expect(mockEm.flush).toHaveBeenCalled()
+      expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /api/entities/definitions', () => {
+    const body = { entityId: 'mod:thing', key: 'color', kind: 'text', configJson: { label: 'Color' } }
+
+    it('blocks persistence when the guard rejects the mutation', async () => {
+      block()
+      const response = await DEFINITIONS_POST(jsonRequest('http://x/api/entities/definitions', 'POST', body))
+      expect(response.status).toBe(423)
+      expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({ resourceKind: 'entities.field_definition', operation: 'create' }),
+      )
+      expect(mockEm.flush).not.toHaveBeenCalled()
+    })
+
+    it('runs the after-success hook once the write succeeds', async () => {
+      allow()
+      const response = await DEFINITIONS_POST(jsonRequest('http://x/api/entities/definitions', 'POST', body))
+      expect(response.status).toBe(200)
+      expect(mockEm.flush).toHaveBeenCalled()
+      expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('DELETE /api/entities/definitions', () => {
+    const body = { entityId: 'mod:thing', key: 'color' }
+
+    it('blocks deletion when the guard rejects the mutation', async () => {
+      block()
+      mockEm.findOne.mockResolvedValue({ id: 'def-1', updatedAt: new Date() })
+      const response = await DEFINITIONS_DELETE(jsonRequest('http://x/api/entities/definitions', 'DELETE', body))
+      expect(response.status).toBe(423)
+      expect(mockEm.flush).not.toHaveBeenCalled()
+    })
+
+    it('runs the after-success hook once the soft delete succeeds', async () => {
+      allow()
+      mockEm.findOne.mockResolvedValue({ id: 'def-1', updatedAt: new Date() })
+      const response = await DEFINITIONS_DELETE(jsonRequest('http://x/api/entities/definitions', 'DELETE', body))
+      expect(response.status).toBe(200)
+      expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /api/entities/definitions/batch', () => {
+    const body = { entityId: 'mod:thing', definitions: [{ key: 'color', kind: 'text' }] }
+
+    it('blocks the batch before opening a transaction when the guard rejects', async () => {
+      block()
+      const response = await DEFINITIONS_BATCH_POST(jsonRequest('http://x/api/entities/definitions/batch', 'POST', body))
+      expect(response.status).toBe(423)
+      expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({ resourceKind: 'entities.field_definition', operation: 'custom' }),
+      )
+      expect(mockEm.begin).not.toHaveBeenCalled()
+      expect(mockEm.flush).not.toHaveBeenCalled()
+    })
+
+    it('runs the after-success hook once the batch commits', async () => {
+      allow()
+      const response = await DEFINITIONS_BATCH_POST(jsonRequest('http://x/api/entities/definitions/batch', 'POST', body))
+      expect(response.status).toBe(200)
+      expect(mockEm.commit).toHaveBeenCalled()
+      expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /api/entities/definitions/restore', () => {
+    const body = { entityId: 'mod:thing', key: 'color' }
+
+    it('blocks the restore when the guard rejects the mutation', async () => {
+      block()
+      mockEm.findOne.mockResolvedValue({ id: 'def-1', updatedAt: new Date() })
+      const response = await DEFINITIONS_RESTORE_POST(jsonRequest('http://x/api/entities/definitions/restore', 'POST', body))
+      expect(response.status).toBe(423)
+      expect(mockEm.flush).not.toHaveBeenCalled()
+    })
+
+    it('runs the after-success hook once the restore succeeds', async () => {
+      allow()
+      mockEm.findOne.mockResolvedValue({ id: 'def-1', updatedAt: new Date() })
+      const response = await DEFINITIONS_RESTORE_POST(jsonRequest('http://x/api/entities/definitions/restore', 'POST', body))
+      expect(response.status).toBe(200)
+      expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/modules/entities/api/definitions.batch.ts
+++ b/packages/core/src/modules/entities/api/definitions.batch.ts
@@ -8,6 +8,10 @@ import { z } from 'zod'
 import { invalidateDefinitionsCache } from './definitions.cache'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { mergeEntityFieldsetConfig, normalizeEntityFieldsetConfig } from '../lib/fieldsets'
+import {
+  beginEntitiesMutationGuard,
+  FIELD_DEFINITION_RESOURCE_KIND,
+} from './definitions.mutation-guard'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['entities.definitions.manage'] },
@@ -66,6 +70,17 @@ export async function POST(req: Request) {
   try {
     cache = resolve('cache') as CacheStrategy
   } catch {}
+
+  const guard = await beginEntitiesMutationGuard({
+    container,
+    auth,
+    req,
+    resourceKind: FIELD_DEFINITION_RESOURCE_KIND,
+    resourceId: entityId,
+    operation: 'custom',
+    mutationPayload: { entityId, definitionCount: definitions.length },
+  })
+  if (guard.blockedResponse) return guard.blockedResponse
 
   await em.begin()
   try {
@@ -133,6 +148,8 @@ export async function POST(req: Request) {
     try { await em.rollback() } catch {}
     return NextResponse.json({ error: 'Failed to save definitions batch' }, { status: 500 })
   }
+
+  await guard.runAfterSuccess()
 
   await invalidateDefinitionsCache(cache, {
     tenantId: auth.tenantId ?? null,

--- a/packages/core/src/modules/entities/api/definitions.mutation-guard.ts
+++ b/packages/core/src/modules/entities/api/definitions.mutation-guard.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from 'next/server'
+import type { AwilixContainer } from 'awilix'
+import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
+
+export const ENTITY_DEFINITION_RESOURCE_KIND = 'entities.entity'
+export const FIELD_DEFINITION_RESOURCE_KIND = 'entities.field_definition'
+
+type AuthenticatedContext = NonNullable<AuthContext>
+
+type GuardOperation = 'create' | 'update' | 'delete' | 'custom'
+
+type EntitiesMutationGuardContext = {
+  container: AwilixContainer
+  auth: AuthenticatedContext
+  req: Request
+  resourceKind: string
+  resourceId: string
+  operation: GuardOperation
+  mutationPayload?: Record<string, unknown> | null
+}
+
+type EntitiesMutationGuardHandle = {
+  blockedResponse: NextResponse | null
+  runAfterSuccess: () => Promise<void>
+}
+
+function resolveActorUserId(auth: AuthenticatedContext): string {
+  return auth.userId ?? auth.sub
+}
+
+export async function beginEntitiesMutationGuard(
+  ctx: EntitiesMutationGuardContext,
+): Promise<EntitiesMutationGuardHandle> {
+  const tenantId = ctx.auth.tenantId
+  const userId = resolveActorUserId(ctx.auth)
+  if (!tenantId) {
+    return { blockedResponse: null, runAfterSuccess: async () => undefined }
+  }
+
+  const guardResult = await validateCrudMutationGuard(ctx.container, {
+    tenantId,
+    organizationId: ctx.auth.orgId ?? null,
+    userId,
+    resourceKind: ctx.resourceKind,
+    resourceId: ctx.resourceId,
+    operation: ctx.operation,
+    requestMethod: ctx.req.method,
+    requestHeaders: ctx.req.headers,
+    mutationPayload: ctx.mutationPayload ?? null,
+  })
+
+  if (guardResult && !guardResult.ok) {
+    return {
+      blockedResponse: NextResponse.json(guardResult.body, { status: guardResult.status }),
+      runAfterSuccess: async () => undefined,
+    }
+  }
+
+  return {
+    blockedResponse: null,
+    runAfterSuccess: async () => {
+      if (!guardResult?.ok || !guardResult.shouldRunAfterSuccess) return
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId: ctx.auth.orgId ?? null,
+        userId,
+        resourceKind: ctx.resourceKind,
+        resourceId: ctx.resourceId,
+        operation: ctx.operation,
+        requestMethod: ctx.req.method,
+        requestHeaders: ctx.req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    },
+  }
+}

--- a/packages/core/src/modules/entities/api/definitions.restore.ts
+++ b/packages/core/src/modules/entities/api/definitions.restore.ts
@@ -6,6 +6,10 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { CustomFieldDef } from '@open-mercato/core/modules/entities/data/entities'
 import { invalidateDefinitionsCache } from './definitions.cache'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import {
+  beginEntitiesMutationGuard,
+  FIELD_DEFINITION_RESOURCE_KIND,
+} from './definitions.mutation-guard'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['entities.definitions.manage'] },
@@ -30,11 +34,24 @@ export async function POST(req: Request) {
   const where: any = { entityId, key, organizationId: auth.orgId ?? null, tenantId: auth.tenantId ?? null }
   const def = await em.findOne(CustomFieldDef, where)
   if (!def) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const guard = await beginEntitiesMutationGuard({
+    container,
+    auth,
+    req,
+    resourceKind: FIELD_DEFINITION_RESOURCE_KIND,
+    resourceId: def.id,
+    operation: 'custom',
+    mutationPayload: { entityId, key },
+  })
+  if (guard.blockedResponse) return guard.blockedResponse
+
   ;(def as any).deletedAt = null
   ;(def as any).isActive = true
   ;(def as any).updatedAt = new Date()
   em.persist(def)
   await em.flush()
+  await guard.runAfterSuccess()
   await invalidateDefinitionsCache(cache, {
     tenantId: auth.tenantId ?? null,
     organizationId: auth.orgId ?? null,

--- a/packages/core/src/modules/entities/api/definitions.ts
+++ b/packages/core/src/modules/entities/api/definitions.ts
@@ -20,6 +20,10 @@ import { installCustomEntitiesFromModules } from '../lib/install-from-ce'
 import { normalizeCustomFieldOptions } from '@open-mercato/shared/modules/entities/options'
 import { CURRENCY_OPTIONS_URL } from '@open-mercato/shared/modules/entities/kinds'
 import type { EntityManager } from '@mikro-orm/postgresql'
+import {
+  beginEntitiesMutationGuard,
+  FIELD_DEFINITION_RESOURCE_KIND,
+} from './definitions.mutation-guard'
 
 /**
  * Validate defaultValue against the field kind. Returns an error message string
@@ -473,6 +477,18 @@ export async function POST(req: Request) {
 
   const where: any = { entityId: input.entityId, key: input.key, organizationId: auth.orgId ?? null, tenantId: auth.tenantId ?? null }
   let def = await em.findOne(CustomFieldDef, where)
+
+  const guard = await beginEntitiesMutationGuard({
+    container,
+    auth,
+    req,
+    resourceKind: FIELD_DEFINITION_RESOURCE_KIND,
+    resourceId: def ? def.id : `${input.entityId}:${input.key}`,
+    operation: def ? 'update' : 'create',
+    mutationPayload: input as unknown as Record<string, unknown>,
+  })
+  if (guard.blockedResponse) return guard.blockedResponse
+
   if (!def) def = em.create(CustomFieldDef, { ...where, createdAt: new Date() })
   def.kind = input.kind
   const inCfg = (input as any).configJson ?? {}
@@ -508,6 +524,7 @@ export async function POST(req: Request) {
   def.updatedAt = new Date()
   em.persist(def)
   await em.flush()
+  await guard.runAfterSuccess()
   await invalidateDefinitionsCache(cache, {
     tenantId: auth.tenantId ?? null,
     organizationId: auth.orgId ?? null,
@@ -535,11 +552,24 @@ export async function DELETE(req: Request) {
   const where: any = { entityId, key, organizationId: auth.orgId ?? null, tenantId: auth.tenantId ?? null }
   const def = await em.findOne(CustomFieldDef, where)
   if (!def) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const guard = await beginEntitiesMutationGuard({
+    container,
+    auth,
+    req,
+    resourceKind: FIELD_DEFINITION_RESOURCE_KIND,
+    resourceId: def.id,
+    operation: 'delete',
+    mutationPayload: { entityId, key },
+  })
+  if (guard.blockedResponse) return guard.blockedResponse
+
   def.isActive = false
   def.updatedAt = new Date()
   def.deletedAt = def.deletedAt ?? new Date()
   em.persist(def)
   await em.flush()
+  await guard.runAfterSuccess()
   await invalidateDefinitionsCache(cache, {
     tenantId: auth.tenantId ?? null,
     organizationId: auth.orgId ?? null,

--- a/packages/core/src/modules/entities/api/entities.ts
+++ b/packages/core/src/modules/entities/api/entities.ts
@@ -10,8 +10,12 @@ import { isSystemEntitySelectable } from '@open-mercato/shared/lib/entities/syst
 import { SYSTEM_ENTITY_RECORDS_BLOCKED_CODE, isOrmBackedSystemEntityId } from '@open-mercato/shared/lib/data/engine'
 import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import {
+  beginEntitiesMutationGuard,
+  ENTITY_DEFINITION_RESOURCE_KIND,
+} from './definitions.mutation-guard'
 
-const CUSTOM_ENTITY_DEFINITION_RESOURCE_KIND = 'entities.entity'
+const CUSTOM_ENTITY_DEFINITION_RESOURCE_KIND = ENTITY_DEFINITION_RESOURCE_KIND
 
 export const metadata = {
   GET: { requireAuth: true },
@@ -110,7 +114,8 @@ export async function POST(req: Request) {
   }
   const input = parsed.data
 
-  const { resolve } = await createRequestContainer()
+  const container = await createRequestContainer()
+  const { resolve } = container
   const em = resolve('em') as any
 
   // A registration for a module-declared, table-backed system entity would flip
@@ -140,6 +145,18 @@ export async function POST(req: Request) {
       throw lockError
     }
   }
+
+  const guard = await beginEntitiesMutationGuard({
+    container,
+    auth,
+    req,
+    resourceKind: ENTITY_DEFINITION_RESOURCE_KIND,
+    resourceId: ent ? ent.id : input.entityId,
+    operation: ent ? 'update' : 'create',
+    mutationPayload: input as unknown as Record<string, unknown>,
+  })
+  if (guard.blockedResponse) return guard.blockedResponse
+
   if (!ent) ent = em.create(CustomEntity, { ...where, createdAt: new Date() })
   ent.label = input.label
   ent.description = input.description ?? null
@@ -150,6 +167,7 @@ export async function POST(req: Request) {
   ent.updatedAt = new Date()
   em.persist(ent)
   await em.flush()
+  await guard.runAfterSuccess()
   // Invalidate sidebar/nav cache for tenant scope (also when tenantId is null)
   try {
     const cache = (await createRequestContainer()).resolve('cache') as any
@@ -168,17 +186,31 @@ export async function DELETE(req: Request) {
   const entityId = body?.entityId
   if (!entityId) return NextResponse.json({ error: 'entityId is required' }, { status: 400 })
 
-  const { resolve } = await createRequestContainer()
+  const container = await createRequestContainer()
+  const { resolve } = container
   const em = resolve('em') as any
 
   const where: any = { entityId, organizationId: auth.orgId ?? null, tenantId: auth.tenantId ?? null }
   const ent = await em.findOne(CustomEntity, where)
   if (!ent) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const guard = await beginEntitiesMutationGuard({
+    container,
+    auth,
+    req,
+    resourceKind: ENTITY_DEFINITION_RESOURCE_KIND,
+    resourceId: ent.id,
+    operation: 'delete',
+    mutationPayload: { entityId },
+  })
+  if (guard.blockedResponse) return guard.blockedResponse
+
   ent.isActive = false
   ent.updatedAt = new Date()
   ent.deletedAt = ent.deletedAt ?? new Date()
   em.persist(ent)
   await em.flush()
+  await guard.runAfterSuccess()
   // Invalidate sidebar/nav cache for tenant scope (also when tenantId is null)
   try {
     const cache = (await createRequestContainer()).resolve('cache') as any


### PR DESCRIPTION
Fixes #3226

## Problem
Custom entity metadata and field-definition write routes mutated entities directly without running the CRUD mutation guard lifecycle that root/core AGENTS require for custom `POST`/`PUT`/`PATCH`/`DELETE` handlers. That left schema-changing writes (which affect every record form/table built from those definitions) outside module-level mutation controls.

## Root Cause
None of the entities-module write routes called `validateCrudMutationGuard` / `runCrudMutationGuardAfterSuccess`. Issue #3152 added optimistic locking to the entity definition edit form but did not cover the mutation-guard lifecycle for these custom routes.

## What Changed
Added a shared helper `packages/core/src/modules/entities/api/definitions.mutation-guard.ts` (`beginEntitiesMutationGuard`) that runs the guard before mutation and exposes a `runAfterSuccess()` callback, with stable resource kinds `entities.entity` and `entities.field_definition`. Wired it into every write route:

- `api/entities.ts` — `POST` (create/update) and `DELETE`
- `api/definitions.ts` — `POST` (create/update) and `DELETE`
- `api/definitions.batch.ts` — `POST` (custom; guard runs before the transaction opens)
- `api/definitions.restore.ts` — `POST` (custom)

Blocked guards short-circuit before any persistence; the after-success hook only fires once the write/commit succeeds. Existing optimistic-lock behavior on the entity `POST` (from #3152) is preserved, and #3152's form-level stale-write scope is not duplicated.

## Tests
- New `api/__tests__/definitions.mutation-guard.test.ts` (12 cases): for each of the six write paths it proves a rejecting guard prevents persistence (no `flush`/`begin`) and an allowing guard runs the after-success hook on success.
- Full entities module suite green: 138 tests across 23 suites.
- `yarn typecheck` (core) clean; `yarn i18n:check-sync` / `yarn i18n:check-usage` clean (no new user-facing strings).

## Backward Compatibility
No contract-surface changes. When no `crudMutationGuardService` is registered, `validateCrudMutationGuard` returns `null` and route behavior is unchanged. No API response fields, event IDs, ACL/DI names, or import paths were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
