### PR TITLE
fix(directory): bound tenant custom-field filters before pagination (#3225)

### DIFF
--- a/packages/core/src/modules/directory/api/tenants/__tests__/list-pagination.test.ts
+++ b/packages/core/src/modules/directory/api/tenants/__tests__/list-pagination.test.ts
@@ -82,27 +82,61 @@ describe('GET /api/directory/tenants pagination', () => {
     expect(options.offset).toBe(0)
   })
 
-  it('falls back to fetch-all + JS slice when a custom-field filter must be matched in memory', async () => {
-    // Custom-field values live in a separate store and are matched in JS, so the
-    // full set must be loaded before filtering — pagination cannot be pushed down.
+  it('resolves custom-field filters via a bounded id query and pushes pagination to findAndCount', async () => {
+    // Custom-field values live in a separate store. The route must resolve the
+    // matching tenant ids from that store, then push pagination to the database
+    // instead of loading the whole tenant table and slicing in memory.
     buildCustomFieldFiltersFromQuery.mockResolvedValue({ 'cf:tier': { $in: ['gold'] } })
     const gold1 = makeTenant(1)
     const gold2 = makeTenant(2)
-    const silver = makeTenant(3)
-    em.find.mockResolvedValue([gold1, gold2, silver])
+
+    em.find.mockImplementation(async (entity: { name: string }) => {
+      if (entity.name === 'CustomFieldDef') return [{ key: 'tier', kind: 'text' }]
+      if (entity.name === 'CustomFieldValue') {
+        return [{ recordId: gold1.id }, { recordId: gold2.id }]
+      }
+      throw new Error(`Unexpected em.find for entity ${entity.name}`)
+    })
+    em.findAndCount.mockResolvedValue([[gold1, gold2], 2])
     loadCustomFieldValues.mockResolvedValue({
       [gold1.id]: { cf_tier: 'gold' },
       [gold2.id]: { cf_tier: 'gold' },
-      [silver.id]: { cf_tier: 'silver' },
     })
 
     const res = await GET(new Request('http://localhost/api/directory/tenants?page=1&pageSize=50&cf_tier=gold'))
 
-    expect(em.findAndCount).not.toHaveBeenCalled()
-    expect(em.find).toHaveBeenCalledTimes(1)
+    // The whole tenant table is never loaded: only the custom-field store is
+    // queried via em.find; the tenant page goes through findAndCount.
+    const tenantFinds = em.find.mock.calls.filter(([entity]) => entity?.name === 'Tenant')
+    expect(tenantFinds).toHaveLength(0)
+    expect(em.findAndCount).toHaveBeenCalledTimes(1)
+    const [, where, options] = em.findAndCount.mock.calls[0]
+    expect(where.id).toEqual({ $in: [gold1.id, gold2.id] })
+    expect(options).toEqual(expect.objectContaining({ limit: 50, offset: 0 }))
+
     expect(res.status).toBe(200)
     const body = (await res.json()) as { items: { id: string }[]; total: number }
     expect(body.total).toBe(2)
     expect(body.items.map((it) => it.id)).toEqual([gold1.id, gold2.id])
+  })
+
+  it('short-circuits without loading any tenants when a custom-field filter matches nothing', async () => {
+    buildCustomFieldFiltersFromQuery.mockResolvedValue({ 'cf:tier': { $in: ['platinum'] } })
+    em.find.mockImplementation(async (entity: { name: string }) => {
+      if (entity.name === 'CustomFieldDef') return [{ key: 'tier', kind: 'text' }]
+      if (entity.name === 'CustomFieldValue') return []
+      throw new Error(`Unexpected em.find for entity ${entity.name}`)
+    })
+
+    const res = await GET(new Request('http://localhost/api/directory/tenants?page=1&pageSize=50&cf_tier=platinum'))
+
+    expect(em.findAndCount).not.toHaveBeenCalled()
+    const tenantFinds = em.find.mock.calls.filter(([entity]) => entity?.name === 'Tenant')
+    expect(tenantFinds).toHaveLength(0)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: unknown[]; total: number; totalPages: number }
+    expect(body.items).toHaveLength(0)
+    expect(body.total).toBe(0)
+    expect(body.totalPages).toBe(1)
   })
 })

--- a/packages/core/src/modules/directory/api/tenants/__tests__/tenant-cf-filter.test.ts
+++ b/packages/core/src/modules/directory/api/tenants/__tests__/tenant-cf-filter.test.ts
@@ -1,0 +1,127 @@
+/** @jest-environment node */
+
+import { resolveRecordIdsForCustomFieldFilters } from '../tenant-cf-filter'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const entityId = 'directory:tenant'
+
+type FindCall = { entity: { name: string }; where: Record<string, unknown> }
+
+const makeEm = (handlers: {
+  defs: { key: string; kind: string }[]
+  valuesByCall: Record<string, { recordId: string }[]>
+}) => {
+  const calls: FindCall[] = []
+  const find = jest.fn(async (entity: { name: string }, where: Record<string, unknown>) => {
+    calls.push({ entity, where })
+    if (entity.name === 'CustomFieldDef') return handlers.defs
+    if (entity.name === 'CustomFieldValue') {
+      const key = String((where as { fieldKey?: string }).fieldKey)
+      return handlers.valuesByCall[key] ?? []
+    }
+    throw new Error(`Unexpected entity ${entity.name}`)
+  })
+  return { em: { find } as never, calls, find }
+}
+
+describe('resolveRecordIdsForCustomFieldFilters', () => {
+  it('returns an empty set when there are no filters', async () => {
+    const { em, find } = makeEm({ defs: [], valuesByCall: {} })
+    const ids = await resolveRecordIdsForCustomFieldFilters({ em, entityId, tenantId, filters: [] })
+    expect(ids.size).toBe(0)
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('selects the value column from the field definition kind', async () => {
+    const { em, calls } = makeEm({
+      defs: [{ key: 'score', kind: 'integer' }],
+      valuesByCall: { score: [{ recordId: 'a' }] },
+    })
+    const ids = await resolveRecordIdsForCustomFieldFilters({
+      em,
+      entityId,
+      tenantId,
+      filters: [['score', { $in: [10] }]],
+    })
+    expect(Array.from(ids)).toEqual(['a'])
+    const valueCall = calls.find((call) => call.entity.name === 'CustomFieldValue')!
+    expect(valueCall.where).toMatchObject({ fieldKey: 'score', valueInt: { $in: [10] } })
+    expect(valueCall.where).not.toHaveProperty('valueText')
+  })
+
+  it('falls back to the text column for unknown/text kinds', async () => {
+    const { em, calls } = makeEm({
+      defs: [{ key: 'tier', kind: 'text' }],
+      valuesByCall: { tier: [{ recordId: 'a' }] },
+    })
+    await resolveRecordIdsForCustomFieldFilters({
+      em,
+      entityId,
+      tenantId,
+      filters: [['tier', 'gold']],
+    })
+    const valueCall = calls.find((call) => call.entity.name === 'CustomFieldValue')!
+    expect(valueCall.where).toMatchObject({ fieldKey: 'tier', valueText: { $in: ['gold'] } })
+  })
+
+  it('intersects record ids across multiple filters (AND semantics)', async () => {
+    const { em } = makeEm({
+      defs: [
+        { key: 'tier', kind: 'text' },
+        { key: 'region', kind: 'text' },
+      ],
+      valuesByCall: {
+        tier: [{ recordId: 'a' }, { recordId: 'b' }],
+        region: [{ recordId: 'b' }, { recordId: 'c' }],
+      },
+    })
+    const ids = await resolveRecordIdsForCustomFieldFilters({
+      em,
+      entityId,
+      tenantId,
+      filters: [
+        ['tier', 'gold'],
+        ['region', 'eu'],
+      ],
+    })
+    expect(Array.from(ids)).toEqual(['b'])
+  })
+
+  it('short-circuits to an empty set when an earlier filter matches nothing', async () => {
+    const { em, find } = makeEm({
+      defs: [
+        { key: 'tier', kind: 'text' },
+        { key: 'region', kind: 'text' },
+      ],
+      valuesByCall: { tier: [], region: [{ recordId: 'b' }] },
+    })
+    const ids = await resolveRecordIdsForCustomFieldFilters({
+      em,
+      entityId,
+      tenantId,
+      filters: [
+        ['tier', 'gold'],
+        ['region', 'eu'],
+      ],
+    })
+    expect(ids.size).toBe(0)
+    const valueCalls = find.mock.calls.filter(([entity]) => entity.name === 'CustomFieldValue')
+    expect(valueCalls).toHaveLength(1)
+  })
+
+  it('scopes definition and value queries to the tenant or global rows', async () => {
+    const { em, calls } = makeEm({
+      defs: [{ key: 'tier', kind: 'text' }],
+      valuesByCall: { tier: [{ recordId: 'a' }] },
+    })
+    await resolveRecordIdsForCustomFieldFilters({
+      em,
+      entityId,
+      tenantId,
+      filters: [['tier', 'gold']],
+    })
+    for (const call of calls) {
+      expect(call.where.tenantId).toEqual({ $in: [tenantId, null] })
+    }
+  })
+})

--- a/packages/core/src/modules/directory/api/tenants/route.ts
+++ b/packages/core/src/modules/directory/api/tenants/route.ts
@@ -6,6 +6,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { Tenant } from '@open-mercato/core/modules/directory/data/entities'
 import { tenantCreateSchema, tenantUpdateSchema } from '@open-mercato/core/modules/directory/data/validators'
 import { loadCustomFieldValues, buildCustomFieldFiltersFromQuery } from '@open-mercato/shared/lib/crud/custom-fields'
+import { resolveRecordIdsForCustomFieldFilters } from './tenant-cf-filter'
 import { E } from '#generated/entities.ids.generated'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import type { EntityManager } from '@mikro-orm/postgresql'
@@ -86,11 +87,6 @@ const toRow = (tenant: Tenant, cf: Record<string, unknown>): TenantRow => ({
   updatedAt: tenant.updatedAt ? tenant.updatedAt.toISOString() : null,
   ...cf,
 })
-
-const matchesValue = (current: unknown, expected: unknown): boolean => {
-  if (Array.isArray(current)) return current.some((item) => item === expected)
-  return current === expected
-}
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
@@ -180,28 +176,31 @@ export async function GET(req: Request) {
   let cfValues: Record<string, Record<string, unknown>>
 
   if (cfFilterEntries.length) {
-    // Custom-field filters are matched in JS against separately-loaded values,
-    // so the full result set must be fetched before filtering and paging.
-    const all = await em.find(Tenant, where, { orderBy })
-    cfValues = await loadCfValues(all)
-    const filtered = all.filter((tenant) => {
-      const rid = String(tenant.id)
-      const payload = cfValues[rid] ?? {}
-      return cfFilterEntries.every(([key, expected]) => {
-        const value = payload[`cf_${key}`]
-        if (expected && typeof expected === 'object' && !Array.isArray(expected)) {
-          const maybeIn = (expected as { $in?: unknown[] }).$in
-          if (Array.isArray(maybeIn)) {
-            if (value === undefined || value === null) return false
-            if (Array.isArray(value)) return value.some((val) => maybeIn.includes(val))
-            return maybeIn.includes(value)
-          }
-        }
-        return matchesValue(value, expected)
-      })
+    // Custom-field values live in a separate store, so first resolve the bounded
+    // set of matching tenant ids from that store, then push pagination to the
+    // database via findAndCount instead of loading the whole tenant table.
+    const matchedIds = await resolveRecordIdsForCustomFieldFilters({
+      em,
+      entityId: E.directory.tenant,
+      tenantId: auth.tenantId ?? null,
+      filters: cfFilterEntries,
     })
-    total = filtered.length
-    pageTenants = filtered.slice(start, start + pageSize)
+    const existingId = where.id
+    const idFilter = typeof existingId === 'string'
+      ? (matchedIds.has(existingId) ? [existingId] : [])
+      : Array.from(matchedIds)
+
+    if (!idFilter.length) {
+      total = 0
+      pageTenants = []
+      cfValues = {}
+    } else {
+      where.id = { $in: idFilter }
+      const [rows, count] = await em.findAndCount(Tenant, where, { orderBy, limit: pageSize, offset: start })
+      total = count
+      pageTenants = rows
+      cfValues = await loadCfValues(rows)
+    }
   } else {
     // No JS-side filtering applies, so pagination is pushed to the database
     // instead of fetching the whole table and slicing in memory.

--- a/packages/core/src/modules/directory/api/tenants/tenant-cf-filter.ts
+++ b/packages/core/src/modules/directory/api/tenants/tenant-cf-filter.ts
@@ -1,0 +1,97 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { FilterQuery } from '@mikro-orm/core'
+import type { EntityId } from '@open-mercato/shared/modules/entities'
+import { CustomFieldDef, CustomFieldValue } from '@open-mercato/core/modules/entities/data/entities'
+
+export type CustomFieldFilterEntry = readonly [string, unknown]
+
+type ValueColumn = 'valueText' | 'valueMultiline' | 'valueInt' | 'valueFloat' | 'valueBool'
+
+const valueColumnForKind = (kind: string | null | undefined): ValueColumn => {
+  switch (kind) {
+    case 'integer':
+      return 'valueInt'
+    case 'float':
+      return 'valueFloat'
+    case 'boolean':
+      return 'valueBool'
+    case 'multiline':
+      return 'valueMultiline'
+    default:
+      return 'valueText'
+  }
+}
+
+const expectedValuesFor = (condition: unknown): unknown[] => {
+  if (condition && typeof condition === 'object' && !Array.isArray(condition)) {
+    const maybeIn = (condition as { $in?: unknown[] }).$in
+    if (Array.isArray(maybeIn)) return maybeIn
+  }
+  return [condition]
+}
+
+const intersect = (current: Set<string> | null, next: Set<string>): Set<string> => {
+  if (current === null) return next
+  const result = new Set<string>()
+  for (const id of next) {
+    if (current.has(id)) result.add(id)
+  }
+  return result
+}
+
+/**
+ * Resolve the bounded set of record ids that satisfy the given custom-field
+ * filters by querying the custom-field value store directly, instead of loading
+ * every entity row and matching the values in memory. Filters are combined with
+ * AND semantics. Returns an empty set when any filter matches nothing.
+ */
+export async function resolveRecordIdsForCustomFieldFilters(opts: {
+  em: EntityManager
+  entityId: EntityId
+  tenantId: string | null
+  filters: CustomFieldFilterEntry[]
+}): Promise<Set<string>> {
+  const { em, entityId, tenantId, filters } = opts
+  if (!filters.length) return new Set<string>()
+
+  const keys = Array.from(new Set(filters.map(([key]) => key)))
+  const tenantScope: Record<string, unknown> = tenantId
+    ? { tenantId: { $in: [tenantId, null] } }
+    : { tenantId: null }
+
+  const defs = await em.find(CustomFieldDef, {
+    entityId: String(entityId),
+    key: { $in: keys },
+    isActive: true,
+    deletedAt: null,
+    ...tenantScope,
+  } as FilterQuery<CustomFieldDef>)
+  const kindByKey = new Map<string, string>()
+  for (const def of defs) {
+    if (!kindByKey.has(def.key)) kindByKey.set(def.key, def.kind)
+  }
+
+  let matched: Set<string> | null = null
+  for (const [key, condition] of filters) {
+    const column = valueColumnForKind(kindByKey.get(key))
+    const expectedValues = expectedValuesFor(condition).filter((value) => value !== undefined && value !== null)
+    if (!expectedValues.length) return new Set<string>()
+
+    const rows = await em.find(
+      CustomFieldValue,
+      {
+        entityId: String(entityId),
+        fieldKey: key,
+        deletedAt: null,
+        [column]: { $in: expectedValues },
+        ...tenantScope,
+      } as FilterQuery<CustomFieldValue>,
+      { fields: ['recordId'] },
+    )
+    const ids = new Set<string>(rows.map((row) => String(row.recordId)))
+    matched = intersect(matched, ids)
+    if (matched.size === 0) return matched
+  }
+
+  return matched ?? new Set<string>()
+}


### PR DESCRIPTION
Fixes #3225

## Problem
`GET /api/directory/tenants` pushed pagination to the database for normal list requests, but as soon as a custom-field filter was present it loaded **every** matching tenant row, loaded custom-field values for all of them, filtered in JavaScript, and only then sliced the page. Custom-field filtering scaled with the full tenant table instead of the requested page — an unbounded in-memory scan.

## Root Cause
The custom-field branch used `em.find(Tenant, where, { orderBy })` (no limit/offset) + `loadCustomFieldValues(all)` + `Array.slice`, because custom-field values live in a separate store and were matched in JS.

## What Changed
- Added `resolveRecordIdsForCustomFieldFilters` (`packages/core/src/modules/directory/api/tenants/tenant-cf-filter.ts`): a bounded two-phase resolver that queries the custom-field value store directly (`CustomFieldValue`, selecting the value column from the field-definition kind), intersects matching record ids across filters with AND semantics, and short-circuits to empty when any filter matches nothing.
- Reworked the custom-field branch in `route.ts` to resolve the bounded id set, intersect it with any existing `id` filter, then push pagination to the database via `findAndCount` with `limit`/`offset` — the same path the non-custom-field branch already used.
- Removed the now-unused in-memory `matchesValue` helper.

Response shape (`items/total/page/pageSize/totalPages`) and sorting semantics are unchanged.

## Tests
- Updated `list-pagination.test.ts`: the custom-field path now resolves ids via the value store and pushes pagination to `findAndCount` (asserts the whole `Tenant` table is never loaded, `where.id` is the bounded `$in`, and limit/offset are applied); added a no-match short-circuit case.
- Added `tenant-cf-filter.test.ts` covering kind→column selection, text fallback, AND intersection, early short-circuit, and tenant/global scoping.
- Full `@open-mercato/core` suite green (6062 tests); `yarn typecheck`, `yarn i18n:check-sync`, `yarn i18n:check-usage` pass. (Pre-existing, unrelated `react-hooks/rules-of-hooks` lint errors in `apps/mercato/src/modules/example` also present on `develop`.)

## Backward Compatibility
No contract surface changes — same route, response shape, sorting, types, events, and DI. The new helper is module-internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)