### PR TITLE
fix(feature_toggles): route override saves through mutation guard lifecycle (#3240)

### DIFF
--- a/packages/core/src/modules/feature_toggles/api/overrides/__tests__/mutation-guard.test.ts
+++ b/packages/core/src/modules/feature_toggles/api/overrides/__tests__/mutation-guard.test.ts
@@ -1,0 +1,134 @@
+/** @jest-environment node */
+
+import { PUT } from '../route'
+
+const TENANT_ID = '123e4567-e89b-12d3-a456-426614174001'
+const ORG_ID = '123e4567-e89b-12d3-a456-426614174002'
+const TOGGLE_ID = '123e4567-e89b-12d3-a456-426614174090'
+const OVERRIDE_ID = '123e4567-e89b-12d3-a456-426614174099'
+const USER_ID = 'user-1'
+
+const mockExecute = jest.fn(async () => ({ result: { overrideToggleId: OVERRIDE_ID }, logEntry: null }))
+const mockFindOne = jest.fn()
+const mockValidateMutation = jest.fn()
+const mockAfterMutationSuccess = jest.fn(async () => {})
+
+const mockEm = { findOne: jest.fn((...args: unknown[]) => mockFindOne(...args)) }
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'commandBus') return { execute: mockExecute }
+    if (token === 'crudMutationGuardService') {
+      return {
+        validateMutation: mockValidateMutation,
+        afterMutationSuccess: mockAfterMutationSuccess,
+      }
+    }
+    return null
+  }),
+}
+
+jest.mock('../../../lib/utils', () => ({
+  buildContext: jest.fn(async () => ({
+    ctx: { container: mockContainer, auth: { sub: USER_ID, tenantId: TENANT_ID } },
+    auth: { sub: USER_ID, tenantId: TENANT_ID },
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveFeatureCheckContext: jest.fn(async () => ({ scope: { tenantId: TENANT_ID }, organizationId: ORG_ID })),
+}))
+
+jest.mock('../../../lib/queries', () => ({ getOverrides: jest.fn() }))
+
+function putRequest() {
+  return new Request('http://localhost/api/feature_toggles/overrides', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ toggleId: TOGGLE_ID, isOverride: true, overrideValue: true }),
+  })
+}
+
+describe('feature_toggles override mutation guard lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    delete process.env.OM_OPTIMISTIC_LOCK
+    mockFindOne.mockResolvedValue(null)
+  })
+
+  it('blocks the command when the mutation guard denies the write', async () => {
+    mockValidateMutation.mockResolvedValue({ ok: false, status: 403, body: { error: 'blocked-by-guard' } })
+
+    const res = await PUT(putRequest())
+
+    expect(res.status).toBe(403)
+    const body = await res.json()
+    expect(body.error).toBe('blocked-by-guard')
+    expect(mockValidateMutation).toHaveBeenCalledTimes(1)
+    expect(mockExecute).not.toHaveBeenCalled()
+    expect(mockAfterMutationSuccess).not.toHaveBeenCalled()
+  })
+
+  it('passes stable resource metadata to the guard validation call', async () => {
+    mockValidateMutation.mockResolvedValue({ ok: true, shouldRunAfterSuccess: false })
+
+    const res = await PUT(putRequest())
+
+    expect(res.status).toBe(200)
+    expect(mockValidateMutation).toHaveBeenCalledTimes(1)
+    const input = mockValidateMutation.mock.calls[0][0]
+    expect(input).toMatchObject({
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      resourceKind: 'feature_toggles.feature_toggle_override',
+      resourceId: TOGGLE_ID,
+      operation: 'update',
+      requestMethod: 'PUT',
+    })
+    expect(mockExecute).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs the after-success hook after a successful override write', async () => {
+    mockValidateMutation.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { rule: 'x' } })
+
+    const res = await PUT(putRequest())
+
+    expect(res.status).toBe(200)
+    expect(mockExecute).toHaveBeenCalledTimes(1)
+    expect(mockAfterMutationSuccess).toHaveBeenCalledTimes(1)
+    const input = mockAfterMutationSuccess.mock.calls[0][0]
+    expect(input).toMatchObject({
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      resourceKind: 'feature_toggles.feature_toggle_override',
+      resourceId: OVERRIDE_ID,
+      operation: 'update',
+      requestMethod: 'PUT',
+      metadata: { rule: 'x' },
+    })
+  })
+
+  it('does not run the after-success hook when the guard opts out', async () => {
+    mockValidateMutation.mockResolvedValue({ ok: true, shouldRunAfterSuccess: false })
+
+    const res = await PUT(putRequest())
+
+    expect(res.status).toBe(200)
+    expect(mockExecute).toHaveBeenCalledTimes(1)
+    expect(mockAfterMutationSuccess).not.toHaveBeenCalled()
+  })
+
+  it('uses the existing override id as the guard resource id when a row exists', async () => {
+    mockFindOne.mockResolvedValue({ id: OVERRIDE_ID, updatedAt: new Date('2026-06-01T10:00:00.000Z') })
+    mockValidateMutation.mockResolvedValue({ ok: true, shouldRunAfterSuccess: false })
+
+    const res = await PUT(putRequest())
+
+    expect(res.status).toBe(200)
+    const input = mockValidateMutation.mock.calls[0][0]
+    expect(input.resourceId).toBe(OVERRIDE_ID)
+  })
+})

--- a/packages/core/src/modules/feature_toggles/api/overrides/route.ts
+++ b/packages/core/src/modules/feature_toggles/api/overrides/route.ts
@@ -6,6 +6,10 @@ import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/op
 import { getOverrides } from '../../lib/queries'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { logCrudAccess } from '@open-mercato/shared/lib/crud/factory'
 import { FeatureToggleOverride } from '../../data/entities'
 import { buildContext } from '../../lib/utils'
@@ -75,7 +79,7 @@ export async function PUT(req: Request) {
       return NextResponse.json({ error: 'Invalid payload', details: parsed.error.flatten() }, { status: 400 })
     }
 
-    const { scope } = await resolveFeatureCheckContext({
+    const { scope, organizationId } = await resolveFeatureCheckContext({
       container: ctx.container,
       auth: ctx.auth,
       request: req
@@ -104,6 +108,31 @@ export async function PUT(req: Request) {
       })
     }
 
+    // Run the CRUD mutation guard lifecycle so this custom write route honors
+    // module-level guard injections (and after-success hooks) like every other
+    // mutating endpoint. The override either updates an existing row or creates a
+    // new one, so the resource id falls back to the toggle id when no row exists.
+    const guardUserId = ctx.auth?.userId ?? ctx.auth?.sub ?? null
+    if (!guardUserId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const guardResourceKind = 'feature_toggles.feature_toggle_override'
+    const guardResourceId = existingOverride?.id ?? parsed.data.toggleId
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId: scope.tenantId,
+      organizationId: organizationId ?? null,
+      userId: guardUserId,
+      resourceKind: guardResourceKind,
+      resourceId: guardResourceId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: parsed.data,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     const commandBus = ctx.container.resolve('commandBus') as CommandBus
     const { result, logEntry } = await commandBus.execute<ProcessedChangeOverrideStateInput, { overrideToggleId: string | null }>('feature_toggles.overrides.changeState', {
       input: {
@@ -114,6 +143,20 @@ export async function PUT(req: Request) {
       },
       ctx,
     })
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId: scope.tenantId,
+        organizationId: organizationId ?? null,
+        userId: guardUserId,
+        resourceKind: guardResourceKind,
+        resourceId: result?.overrideToggleId ?? guardResourceId,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     const response = NextResponse.json({
       ok: true,


### PR DESCRIPTION
Fixes #3240

## Problem
`PUT /api/feature_toggles/overrides` is a custom write route that executed the override command directly. It enforced optimistic locking for existing override rows but never ran the CRUD mutation guard lifecycle required for custom write routes, leaving feature-toggle override changes outside module-level mutation guard injections and after-success hooks.

## Root Cause
The handler called `validateCrudMutationGuard` / `runCrudMutationGuardAfterSuccess` nowhere; it jumped straight from the optimistic-lock check to `commandBus.execute(...)`.

## What Changed
- `packages/core/src/modules/feature_toggles/api/overrides/route.ts`:
  - Call `validateCrudMutationGuard` before executing the override command; return the structured guard body/status when the guard denies the write (the command never runs).
  - Call `runCrudMutationGuardAfterSuccess` after a successful write when the guard requests it, with stable `resourceKind` (`feature_toggles.feature_toggle_override`), `resourceId` (existing override id, else the toggle id), and `operation: 'update'` metadata.
  - Derive the actor `userId` from `ctx.auth` (`userId ?? sub`).
- Existing optimistic-lock enforcement and conflict-bar coverage are preserved. The guard is additive and a no-op when no `crudMutationGuardService` is registered, so the UI save path (FeatureToggleOverrideCard) is unchanged and still receives the structured guard response on denial.

## Tests
- New `api/overrides/__tests__/mutation-guard.test.ts`:
  - A blocking guard prevents the command and skips the after-success hook (403).
  - Successful write runs the after-success hook with the expected metadata.
  - Guard validation receives stable resource kind/id/operation.
  - After-success hook is skipped when the guard opts out.
  - Existing override row id is used as the guard resource id.
- Existing `api/overrides/__tests__/optimistic-lock.test.ts` still passes (no regression).
- `yarn workspace @open-mercato/core test` (feature_toggles): 60 passed.
- `yarn typecheck`: 21/21 successful.

## Backward Compatibility
- No contract surface changes. Route URL, method, response shape, and event/DI/ACL identifiers are unchanged. The mutation guard wiring is additive and degrades to a no-op when no guard service is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
