### PR TITLE
fix(entities): enforce stale-delete protection for custom entity records (#3227)

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/records.crud.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/records.crud.test.ts
@@ -2,9 +2,21 @@
 import { POST, PUT, DELETE } from '@open-mercato/core/modules/entities/api/records'
 import { UNKNOWN_CUSTOM_FIELD_ERROR } from '@open-mercato/shared/modules/entities/validation'
 
+let mockRecordUpdatedAt: string | null = null
+
+function makeKyselyStub() {
+  const builder: any = {
+    select: () => builder,
+    where: () => builder,
+    executeTakeFirst: async () => (mockRecordUpdatedAt == null ? undefined : { updated_at: mockRecordUpdatedAt }),
+  }
+  return { selectFrom: () => builder }
+}
+
 const mockEm = {
   find: jest.fn(async () => [] as Array<Record<string, unknown>>),
   findOne: jest.fn(async () => null),
+  getKysely: jest.fn(() => makeKyselyStub()),
 }
 
 function mockActiveCustomFieldDefs(keys: string[]) {
@@ -55,7 +67,10 @@ jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => 
 }))
 
 describe('Records API CRUD operations', () => {
-  beforeEach(() => { jest.clearAllMocks() })
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRecordUpdatedAt = null
+  })
 
   describe('POST /api/entities/records', () => {
     it('creates a record and returns entityId + recordId', async () => {
@@ -245,6 +260,53 @@ describe('Records API CRUD operations', () => {
       })
       const res = await DELETE(req)
       expect(res.status).toBe(400)
+    })
+
+    it('rejects a stale delete with 409 when the expected version does not match (#3227)', async () => {
+      mockRecordUpdatedAt = '2026-05-01T00:00:00.000Z'
+      const recordId = '123e4567-e89b-12d3-a456-426614174000'
+      const req = new Request(
+        `http://x/api/entities/records?entityId=user:qa_entity&recordId=${recordId}`,
+        {
+          method: 'DELETE',
+          headers: { 'x-om-ext-optimistic-lock-expected-updated-at': '2026-04-01T00:00:00.000Z' },
+        },
+      )
+      const res = await DELETE(req)
+      expect(res.status).toBe(409)
+      const json = await res.json()
+      expect(json.code).toBe('optimistic_lock_conflict')
+      expect(json.currentUpdatedAt).toBe('2026-05-01T00:00:00.000Z')
+      expect(mockDataEngine.deleteCustomEntityRecord).not.toHaveBeenCalled()
+    })
+
+    it('allows the delete when the expected version matches the current version (#3227)', async () => {
+      mockRecordUpdatedAt = '2026-05-01T00:00:00.000Z'
+      const recordId = '123e4567-e89b-12d3-a456-426614174000'
+      const req = new Request(
+        `http://x/api/entities/records?entityId=user:qa_entity&recordId=${recordId}`,
+        {
+          method: 'DELETE',
+          headers: { 'x-om-ext-optimistic-lock-expected-updated-at': '2026-05-01T00:00:00.000Z' },
+        },
+      )
+      const res = await DELETE(req)
+      expect(res.status).toBe(200)
+      expect(mockDataEngine.deleteCustomEntityRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ recordId, soft: true }),
+      )
+    })
+
+    it('deletes without a conflict when the client sends no expected version (#3227)', async () => {
+      mockRecordUpdatedAt = '2026-05-01T00:00:00.000Z'
+      const recordId = '123e4567-e89b-12d3-a456-426614174000'
+      const req = new Request(
+        `http://x/api/entities/records?entityId=user:qa_entity&recordId=${recordId}`,
+        { method: 'DELETE' },
+      )
+      const res = await DELETE(req)
+      expect(res.status).toBe(200)
+      expect(mockDataEngine.deleteCustomEntityRecord).toHaveBeenCalled()
     })
   })
 })

--- a/packages/core/src/modules/entities/api/records.ts
+++ b/packages/core/src/modules/entities/api/records.ts
@@ -539,6 +539,26 @@ export async function DELETE(req: Request) {
     if (entityKind === 'system') return systemEntityRecordsRejection(entityId)
     const isCustomEntity = entityKind === 'custom'
     await assertEntityAclForRequest({ auth, entityId, action: 'manage', isCustomEntity, rbac })
+
+    try {
+      const currentUpdatedAt = await readCustomEntityRecordUpdatedAt(em, {
+        entityType: entityId,
+        entityId: recordId,
+        organizationId: targetOrgId,
+      })
+      enforceCommandOptimisticLock({
+        resourceKind: CUSTOM_ENTITY_RECORD_RESOURCE_KIND,
+        resourceId: recordId,
+        current: currentUpdatedAt,
+        request: req,
+      })
+    } catch (lockError) {
+      if (isCrudHttpError(lockError)) {
+        return NextResponse.json(lockError.body, { status: lockError.status })
+      }
+      throw lockError
+    }
+
     await de.deleteCustomEntityRecord({ entityId, recordId, organizationId: targetOrgId, tenantId: auth.tenantId!, soft: true })
     return NextResponse.json({ ok: true })
   } catch (e) {

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/page.tsx
@@ -17,6 +17,7 @@ import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { ErrorMessage, LoadingMessage } from '@open-mercato/ui/backend/detail'
 import { useRecordsEntityGuard } from '@open-mercato/core/modules/entities/components/useRecordsEntityGuard'
@@ -67,6 +68,7 @@ export default function RecordsPage({ params }: { params: { entityId?: string } 
 }
 
 function RecordsPageInner({ params }: { params: { entityId?: string } }) {
+  const t = useT()
   const entityId = decodeURIComponent(params?.entityId || '')
   const [sorting, setSorting] = React.useState<SortingState>([{ id: 'id', desc: false }])
   const [page, setPage] = React.useState(1)
@@ -80,6 +82,16 @@ function RecordsPageInner({ params }: { params: { entityId?: string } }) {
   const [loading, setLoading] = React.useState(false)
   const scopeVersion = useOrganizationScopeVersion()
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
+  const deleteMutationContextId = `entities.user.records.${entityId}:single-delete`
+  const { runMutation: runDeleteMutation, retryLastMutation: retryDeleteMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    resourceId: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: deleteMutationContextId,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
   const { data: cfDefs = [] } = useCustomFieldDefs(entityId, {
     enabled: Boolean(entityId),
     keyExtras: [scopeVersion],
@@ -367,22 +379,33 @@ export RECORD_ID="<record uuid>"`}</code></pre>
               items={[
                 { id: 'edit', label: 'Edit', href: `/backend/entities/user/${encodeURIComponent(entityId)}/records/${encodeURIComponent(String((row as any).id))}` },
                 { id: 'delete', label: 'Delete', destructive: true, onSelect: async () => {
+                  const recordId = String((row as any).id)
                   try {
                     const confirmed = await confirm({
                       title: 'Delete this record?',
                       variant: 'destructive',
                     })
                     if (!confirmed) return
-                    const deleteCall = await withScopedApiRequestHeaders(
-                      buildOptimisticLockHeader((row as any).updatedAt),
-                      () => apiCall(
-                        `/api/entities/records?entityId=${encodeURIComponent(entityId)}&recordId=${encodeURIComponent(String((row as any).id))}`,
-                        { method: 'DELETE' },
-                      ),
-                    )
-                    if (!deleteCall.ok) {
-                      await raiseCrudError(deleteCall.response, 'Failed to delete record')
-                    }
+                    await runDeleteMutation({
+                      operation: async () => {
+                        const deleteCall = await withScopedApiRequestHeaders(
+                          buildOptimisticLockHeader((row as any).updatedAt),
+                          () => apiCall(
+                            `/api/entities/records?entityId=${encodeURIComponent(entityId)}&recordId=${encodeURIComponent(recordId)}`,
+                            { method: 'DELETE' },
+                          ),
+                        )
+                        if (!deleteCall.ok) {
+                          await raiseCrudError(deleteCall.response, 'Failed to delete record')
+                        }
+                      },
+                      context: {
+                        formId: deleteMutationContextId,
+                        resourceKind: 'entities.record',
+                        resourceId: recordId,
+                        retryLastMutation: retryDeleteMutation,
+                      },
+                    })
                     const j = await readApiResultOrThrow<RecordsResponse>(
                       `/api/entities/records?entityId=${encodeURIComponent(entityId)}&page=${page}&pageSize=${pageSize}`,
                       undefined,


### PR DESCRIPTION
Fixes #3227

## Problem
Custom entity record updates enforced command optimistic locking, but custom record **deletes** did not. The records table also performed its delete through a raw `apiCall` path instead of `useGuardedMutation`, so the delete flow was not protected consistently end to end. A stale tab could delete a custom entity record after another user had changed it, violating the default optimistic-locking rule for user-editable entities and edit/delete flows.

## Root Cause
`packages/core/src/modules/entities/api/records.ts` `DELETE` called `deleteCustomEntityRecord` without any version check, even though:
- the `PUT` route already enforced `enforceCommandOptimisticLock`, and
- the records list UI already sent the `x-om-ext-optimistic-lock-expected-updated-at` header (derived from each row's `updatedAt`).

The header was sent but silently ignored on delete.

## What Changed
- **Server (`api/records.ts` `DELETE`)**: read the record's current `updated_at` via the existing `readCustomEntityRecordUpdatedAt` helper and call `enforceCommandOptimisticLock` (same `entities.record` resource kind and pattern as `PUT`) before deleting. On a version mismatch it returns the standard structured `409` conflict body; strictly additive (no header ⇒ no-op, so plain API consumers are unaffected).
- **UI (`backend/.../records/page.tsx`)**: routed the table row delete through `useGuardedMutation(...).runMutation(...)` (passing `retryLastMutation` in the injection context) while keeping the existing `withScopedApiRequestHeaders(buildOptimisticLockHeader(row.updatedAt), …)` header. A stale delete now surfaces on the unified conflict bar via `surfaceRecordConflict` (invoked automatically by `useGuardedMutation`) instead of a transient flash.

## Tests
- `api/__tests__/records.crud.test.ts`: added focused `DELETE` coverage — (1) stale version ⇒ `409` with `code: optimistic_lock_conflict` and no delete call, (2) matching version ⇒ `200` + soft delete, (3) no expected-version header ⇒ `200` (additive no-op). Added a Kysely stub to `mockEm` so `readCustomEntityRecordUpdatedAt` resolves a current version.
- Verified the `optimistic-lock-ui-coverage` guard still passes for the records page.
- `yarn typecheck`, targeted `yarn workspace @open-mercato/core test`, and `yarn i18n:check-sync` all pass.

## Backward Compatibility
- No contract surface changes. The new `409` only fires when the client supplies the expected-version header (existing behavior for `PUT`); API consumers that don't send it keep their prior `200` behavior. No API response fields removed, no event/DI/ACL/route changes.