### PR TITLE
fix(entities): guard encryption map saves and reject stale writes (#3228)

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/encryption.api.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/encryption.api.test.ts
@@ -2,9 +2,17 @@
 import { GET, POST } from '@open-mercato/core/modules/entities/api/encryption'
 import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
 
+// Deterministic version instants. The optimistic-lock check is a pure ISO-string
+// equality compare of two version tokens (see optimistic-lock-command.ts) — it
+// never reads the wall clock — so only the relative ordering (older < newer)
+// matters, never the absolute calendar value. Anchored to a fixed historical
+// instant so these can never read as a near-future "timebomb" date.
+const CURRENT_VERSION = new Date('2020-01-02T12:00:00.000Z')
+const STALE_VERSION = new Date('2020-01-01T08:00:00.000Z')
+
 const mockMapRepo = {
   findOne: jest.fn(),
-  create: jest.fn((data) => ({ ...data, updatedAt: new Date('2026-06-01T00:00:00.000Z') })),
+  create: jest.fn((data) => ({ ...data, updatedAt: CURRENT_VERSION })),
 }
 const persistFlush = jest.fn(async () => {})
 const mockEm = {
@@ -53,7 +61,7 @@ describe('entities/encryption API', () => {
   })
 
   it('returns the map version token from the read path', async () => {
-    const updatedAt = new Date('2026-06-15T10:00:00.000Z')
+    const updatedAt = CURRENT_VERSION
     mockMapRepo.findOne.mockResolvedValueOnce({
       id: 'm-1',
       fieldsJson: [{ field: 'email', hashField: 'email_hash' }],
@@ -82,14 +90,14 @@ describe('entities/encryption API', () => {
   })
 
   it('rejects a stale write to an existing map with a 409 conflict', async () => {
-    const current = new Date('2026-06-15T12:00:00.000Z')
+    const current = CURRENT_VERSION
     mockMapRepo.findOne.mockResolvedValue({
       id: 'm-1',
       fieldsJson: [],
       isActive: true,
       updatedAt: current,
     })
-    const stale = new Date('2026-06-10T08:00:00.000Z').toISOString()
+    const stale = STALE_VERSION.toISOString()
     const payload = { entityId: 'auth:user', fields: [{ field: 'email', hashField: null }] }
     const res = await POST(new Request('http://x/api/entities/encryption', {
       method: 'POST',
@@ -112,7 +120,7 @@ describe('entities/encryption API', () => {
   })
 
   it('persists when the expected version matches the current map version', async () => {
-    const current = new Date('2026-06-15T12:00:00.000Z')
+    const current = CURRENT_VERSION
     const existing = { id: 'm-1', fieldsJson: [], isActive: true, updatedAt: current }
     mockMapRepo.findOne.mockResolvedValue(existing)
     const payload = { entityId: 'auth:user', fields: [{ field: 'email', hashField: null }] }

--- a/packages/core/src/modules/entities/api/__tests__/encryption.api.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/encryption.api.test.ts
@@ -1,9 +1,10 @@
 /** @jest-environment node */
 import { GET, POST } from '@open-mercato/core/modules/entities/api/encryption'
+import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
 
 const mockMapRepo = {
   findOne: jest.fn(),
-  create: jest.fn((data) => data),
+  create: jest.fn((data) => ({ ...data, updatedAt: new Date('2026-06-01T00:00:00.000Z') })),
 }
 const persistFlush = jest.fn(async () => {})
 const mockEm = {
@@ -16,23 +17,31 @@ const mockEncSvc = {
   invalidateMap: jest.fn(async () => {}),
 }
 
+let mockGuardService: any = null
+
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: async () => ({
     resolve: (k: string) => {
       if (k === 'em') return mockEm
       if (k === 'tenantEncryptionService') return mockEncSvc
+      if (k === 'crudMutationGuardService') {
+        if (!mockGuardService) throw new Error('not registered')
+        return mockGuardService
+      }
       return null
     },
   }),
 }))
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
-  getAuthFromRequest: () => ({ tenantId: 't-1', orgId: 'o-1', roles: ['admin'] }),
+  getAuthFromRequest: () => ({ sub: 'u-1', tenantId: 't-1', orgId: 'o-1', roles: ['admin'] }),
 }))
 
 describe('entities/encryption API', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockGuardService = null
+    delete process.env.OM_OPTIMISTIC_LOCK
   })
 
   it('returns empty map when none exists', async () => {
@@ -40,7 +49,21 @@ describe('entities/encryption API', () => {
     const res = await GET(new Request('http://x/api/entities/encryption?entityId=auth:user'))
     expect(res.status).toBe(200)
     const json = await res.json()
-    expect(json).toMatchObject({ entityId: 'auth:user', fields: [] })
+    expect(json).toMatchObject({ entityId: 'auth:user', fields: [], updatedAt: null })
+  })
+
+  it('returns the map version token from the read path', async () => {
+    const updatedAt = new Date('2026-06-15T10:00:00.000Z')
+    mockMapRepo.findOne.mockResolvedValueOnce({
+      id: 'm-1',
+      fieldsJson: [{ field: 'email', hashField: 'email_hash' }],
+      isActive: true,
+      updatedAt,
+    })
+    const res = await GET(new Request('http://x/api/entities/encryption?entityId=auth:user'))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.updatedAt).toBe(updatedAt.toISOString())
   })
 
   it('creates map on POST and invalidates cache', async () => {
@@ -56,5 +79,102 @@ describe('entities/encryption API', () => {
     expect(mockEm.persist).toHaveBeenCalled()
     expect(persistFlush).toHaveBeenCalled()
     expect(mockEncSvc.invalidateMap).toHaveBeenCalledWith('auth:user', 't-1', 'o-1')
+  })
+
+  it('rejects a stale write to an existing map with a 409 conflict', async () => {
+    const current = new Date('2026-06-15T12:00:00.000Z')
+    mockMapRepo.findOne.mockResolvedValue({
+      id: 'm-1',
+      fieldsJson: [],
+      isActive: true,
+      updatedAt: current,
+    })
+    const stale = new Date('2026-06-10T08:00:00.000Z').toISOString()
+    const payload = { entityId: 'auth:user', fields: [{ field: 'email', hashField: null }] }
+    const res = await POST(new Request('http://x/api/entities/encryption', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: {
+        'content-type': 'application/json',
+        [OPTIMISTIC_LOCK_HEADER_NAME]: stale,
+      },
+    }))
+    expect(res.status).toBe(409)
+    const json = await res.json()
+    expect(json).toMatchObject({
+      code: 'optimistic_lock_conflict',
+      currentUpdatedAt: current.toISOString(),
+      expectedUpdatedAt: stale,
+    })
+    // Stale write must not persist.
+    expect(persistFlush).not.toHaveBeenCalled()
+    expect(mockEncSvc.invalidateMap).not.toHaveBeenCalled()
+  })
+
+  it('persists when the expected version matches the current map version', async () => {
+    const current = new Date('2026-06-15T12:00:00.000Z')
+    const existing = { id: 'm-1', fieldsJson: [], isActive: true, updatedAt: current }
+    mockMapRepo.findOne.mockResolvedValue(existing)
+    const payload = { entityId: 'auth:user', fields: [{ field: 'email', hashField: null }] }
+    const res = await POST(new Request('http://x/api/entities/encryption', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: {
+        'content-type': 'application/json',
+        [OPTIMISTIC_LOCK_HEADER_NAME]: current.toISOString(),
+      },
+    }))
+    expect(res.status).toBe(200)
+    expect(persistFlush).toHaveBeenCalled()
+    expect(existing.fieldsJson).toEqual(payload.fields)
+  })
+
+  it('blocks the write when the mutation guard rejects it', async () => {
+    mockGuardService = {
+      validateMutation: jest.fn(async () => ({ ok: false, status: 403, body: { error: 'blocked' } })),
+      afterMutationSuccess: jest.fn(async () => {}),
+    }
+    mockMapRepo.findOne.mockResolvedValue(null)
+    const payload = { entityId: 'auth:user', fields: [{ field: 'email', hashField: null }] }
+    const res = await POST(new Request('http://x/api/entities/encryption', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'content-type': 'application/json' },
+    }))
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json).toMatchObject({ error: 'blocked' })
+    expect(mockGuardService.validateMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceKind: 'entities.encryption_map',
+        operation: 'create',
+        userId: 'u-1',
+      }),
+    )
+    // Guard-blocked write must not persist.
+    expect(persistFlush).not.toHaveBeenCalled()
+    expect(mockEncSvc.invalidateMap).not.toHaveBeenCalled()
+  })
+
+  it('runs the mutation-guard after-success hook on a successful write', async () => {
+    mockGuardService = {
+      validateMutation: jest.fn(async () => ({ ok: true, shouldRunAfterSuccess: true, metadata: { trace: 'x' } })),
+      afterMutationSuccess: jest.fn(async () => {}),
+    }
+    mockMapRepo.findOne.mockResolvedValue(null)
+    const payload = { entityId: 'auth:user', fields: [{ field: 'email', hashField: null }] }
+    const res = await POST(new Request('http://x/api/entities/encryption', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'content-type': 'application/json' },
+    }))
+    expect(res.status).toBe(200)
+    expect(mockGuardService.afterMutationSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceKind: 'entities.encryption_map',
+        operation: 'create',
+        metadata: { trace: 'x' },
+      }),
+    )
   })
 })

--- a/packages/core/src/modules/entities/api/encryption.ts
+++ b/packages/core/src/modules/entities/api/encryption.ts
@@ -4,7 +4,15 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { EncryptionMap } from '@open-mercato/core/modules/entities/data/entities'
 import { upsertEncryptionMapSchema } from '@open-mercato/core/modules/entities/data/validators'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+const ENCRYPTION_MAP_RESOURCE_KIND = 'entities.encryption_map'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['entities.definitions.manage'] },
@@ -18,6 +26,16 @@ function resolveScope(auth: { tenantId?: string | null; orgId?: string | null })
   }
 }
 
+function toIsoOrNull(value: Date | string | null | undefined): string | null {
+  if (value == null) return null
+  if (value instanceof Date) {
+    const ms = value.getTime()
+    return Number.isFinite(ms) ? new Date(ms).toISOString() : null
+  }
+  const trimmed = String(value).trim()
+  return trimmed.length ? trimmed : null
+}
+
 export async function GET(req: Request) {
   const url = new URL(req.url)
   const entityId = url.searchParams.get('entityId') || ''
@@ -26,8 +44,8 @@ export async function GET(req: Request) {
   if (!auth?.tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { tenantId, organizationId } = resolveScope(auth)
 
-  const { resolve } = await createRequestContainer()
-  const em = resolve('em') as any
+  const container = await createRequestContainer()
+  const em = container.resolve('em') as any
   const repo = em.getRepository(EncryptionMap)
   // Prefer tenant+org, then tenant-global, then global
   const candidates = [
@@ -51,51 +69,113 @@ export async function GET(req: Request) {
     organizationId,
     fields: record?.fieldsJson ?? [],
     isActive: record?.isActive ?? true,
+    updatedAt: toIsoOrNull(record?.updatedAt),
   })
 }
 
 export async function POST(req: Request) {
-  const body = await req.json().catch(() => ({}))
-  const parsed = upsertEncryptionMapSchema.safeParse(body)
-  if (!parsed.success) {
-    return NextResponse.json({ error: 'Invalid payload', details: parsed.error.flatten() }, { status: 400 })
-  }
-  const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const scope = resolveScope(auth)
-  const payload = parsed.data
-  const tenantId = scope.tenantId
-  const organizationId = scope.organizationId
+  try {
+    const body = await req.json().catch(() => ({}))
+    const parsed = upsertEncryptionMapSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid payload', details: parsed.error.flatten() }, { status: 400 })
+    }
+    const auth = await getAuthFromRequest(req)
+    if (!auth?.tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    const scope = resolveScope(auth)
+    const payload = parsed.data
+    const tenantId: string = auth.tenantId
+    const organizationId = scope.organizationId
 
-  const { resolve } = await createRequestContainer()
-  const em = resolve('em') as any
-  const repo = em.getRepository(EncryptionMap)
-  const existing = await repo.findOne({ entityId: payload.entityId, tenantId, organizationId, deletedAt: null })
-  if (existing) {
-    existing.fieldsJson = payload.fields
-    existing.isActive = payload.isActive ?? true
-    existing.updatedAt = new Date()
-    await em.persist(existing).flush()
-  } else {
-    const map = repo.create({
-      entityId: payload.entityId,
+    const container = await createRequestContainer()
+    const em = container.resolve('em') as any
+    const repo = em.getRepository(EncryptionMap)
+    const existing = await repo.findOne({ entityId: payload.entityId, tenantId, organizationId, deletedAt: null })
+
+    // Reject stale writes: a save started from an older tab must not silently
+    // overwrite a newer encryption configuration. No-op when the client did not
+    // send the expected-version header (strictly additive).
+    if (existing) {
+      enforceCommandOptimisticLock({
+        resourceKind: ENCRYPTION_MAP_RESOURCE_KIND,
+        resourceId: existing.id,
+        current: existing.updatedAt,
+        request: req,
+      })
+    }
+
+    // Mutation-guard contract for custom write routes. The resource is the
+    // encryption map for this entity scoped to the tenant/organization.
+    const guardResult = await validateCrudMutationGuard(container, {
       tenantId,
       organizationId,
-      fieldsJson: payload.fields,
-      isActive: payload.isActive ?? true,
+      userId: auth.sub,
+      resourceKind: ENCRYPTION_MAP_RESOURCE_KIND,
+      resourceId: existing?.id ?? payload.entityId,
+      operation: existing ? 'update' : 'create',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: payload,
     })
-    await em.persist(map).flush()
-  }
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
-  try {
-    const svc = resolve('tenantEncryptionService') as { invalidateMap?: (e: string, t: string | null, o: string | null) => Promise<void> }
-    await svc?.invalidateMap?.(payload.entityId, tenantId, organizationId)
-  } catch {
-    // best-effort cache bust
-  }
+    let saved: any
+    if (existing) {
+      existing.fieldsJson = payload.fields
+      existing.isActive = payload.isActive ?? true
+      existing.updatedAt = new Date()
+      await em.persist(existing).flush()
+      saved = existing
+    } else {
+      const map = repo.create({
+        entityId: payload.entityId,
+        tenantId,
+        organizationId,
+        fieldsJson: payload.fields,
+        isActive: payload.isActive ?? true,
+      })
+      await em.persist(map).flush()
+      saved = map
+    }
 
-  return NextResponse.json({ ok: true })
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(container, {
+        tenantId,
+        organizationId,
+        userId: auth.sub,
+        resourceKind: ENCRYPTION_MAP_RESOURCE_KIND,
+        resourceId: saved?.id ?? payload.entityId,
+        operation: existing ? 'update' : 'create',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
+
+    try {
+      const svc = container.resolve('tenantEncryptionService') as { invalidateMap?: (e: string, t: string | null, o: string | null) => Promise<void> }
+      await svc?.invalidateMap?.(payload.entityId, tenantId, organizationId)
+    } catch {
+      // best-effort cache bust
+    }
+
+    return NextResponse.json({ ok: true, updatedAt: toIsoOrNull(saved?.updatedAt) })
+  } catch (err) {
+    if (isCrudHttpError(err)) {
+      return NextResponse.json(err.body, { status: err.status })
+    }
+    throw err
+  }
 }
+
+const conflictResponseSchema = z.object({
+  error: z.string(),
+  code: z.string(),
+  currentUpdatedAt: z.string(),
+  expectedUpdatedAt: z.string(),
+})
 
 export const openApi: OpenApiRouteDoc = {
   tag: 'Entities',
@@ -105,13 +185,16 @@ export const openApi: OpenApiRouteDoc = {
       summary: 'Fetch encryption map',
       description: 'Returns the encrypted field map for the current tenant/organization scope.',
       query: z.object({ entityId: z.string() }),
-      responses: [{ status: 200, description: 'Map', schema: z.object({ entityId: z.string(), fields: z.array(z.object({ field: z.string(), hashField: z.string().nullable().optional() })), isActive: z.boolean().optional() }) }],
+      responses: [{ status: 200, description: 'Map', schema: z.object({ entityId: z.string(), fields: z.array(z.object({ field: z.string(), hashField: z.string().nullable().optional() })), isActive: z.boolean().optional(), updatedAt: z.string().nullable().optional() }) }],
     },
     POST: {
       summary: 'Upsert encryption map',
-      description: 'Creates or updates the encryption map for the current tenant/organization scope.',
+      description: 'Creates or updates the encryption map for the current tenant/organization scope. Enforces optimistic locking when the caller sends the expected version header.',
       requestBody: { contentType: 'application/json', schema: upsertEncryptionMapSchema },
-      responses: [{ status: 200, description: 'Saved', schema: z.object({ ok: z.boolean() }) }],
+      responses: [
+        { status: 200, description: 'Saved', schema: z.object({ ok: z.boolean(), updatedAt: z.string().nullable().optional() }) },
+        { status: 409, description: 'Optimistic-lock conflict (stale write)', schema: conflictResponseSchema },
+      ],
     },
   },
 }

--- a/packages/core/src/modules/entities/components/EncryptionManager.tsx
+++ b/packages/core/src/modules/entities/components/EncryptionManager.tsx
@@ -13,8 +13,10 @@ import {
 } from '@open-mercato/ui/primitives/select'
 import { LoadingMessage, ErrorMessage } from '@open-mercato/ui/backend/detail'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
-import { apiCall, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { apiCall, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
+import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { useCustomFieldDefs, type CustomFieldDefDto } from '@open-mercato/ui/backend/utils/customFieldDefs'
 import { Plus, Save, Trash2 } from 'lucide-react'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
@@ -34,6 +36,7 @@ type EncryptionMapResponse = {
   entityId: string
   fields?: Array<{ field: string; hashField?: string | null }>
   isActive?: boolean
+  updatedAt?: string | null
 }
 
 type CanonicalOption = { value: string; label?: string }
@@ -225,6 +228,8 @@ export function EncryptionManager() {
     lastMapSignatureRef.current = signature
   }, [mapSignature, map, canonicalOptions, hasUserEdited])
 
+  const { runMutation } = useGuardedMutation({ contextId: 'entities.encryption-map' })
+
   const mutation = useMutation({
     mutationFn: async () => {
       const trimmed = fields
@@ -243,15 +248,29 @@ export function EncryptionManager() {
       if (!trimmed.length) {
         throw new Error(t('entities.encryption.errors.noFields', 'Add at least one field to encrypt'))
       }
-      const res = await apiCall('/api/entities/encryption', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ entityId: selectedEntityId, fields: trimmed, isActive }),
+      const payload = { entityId: selectedEntityId, fields: trimmed, isActive }
+      // Route the write through the guarded mutation helper so global injection
+      // modules (mutation guard, record-lock conflict handling) can run, and send
+      // the loaded map's version so a stale tab cannot silently overwrite a newer
+      // encryption configuration (the server rejects mismatches with a 409).
+      return runMutation({
+        operation: async () => {
+          const res = await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(map?.updatedAt ?? null),
+            () => apiCall('/api/entities/encryption', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(payload),
+            }),
+          )
+          if (!res.ok) {
+            await raiseCrudError(res.response, t('entities.encryption.errors.save', 'Failed to save encryption map'))
+          }
+          return true
+        },
+        context: {},
+        mutationPayload: payload,
       })
-      if (!res.ok) {
-        await raiseCrudError(res.response, t('entities.encryption.errors.save', 'Failed to save encryption map'))
-      }
-      return true
     },
     onSuccess: () => {
       flash(t('entities.encryption.flash.saved', 'Encryption map saved'), 'success')


### PR DESCRIPTION
Fixes #3228

## Problem
The entity encryption settings UI and `POST /api/entities/encryption` persisted encryption maps through custom paths that bypassed guarded UI mutations, the mutation guard lifecycle, and optimistic locking. A stale save from an older tab could silently overwrite a newer encryption configuration (which fields are encrypted), and module mutation guards could not block or audit the write.

## Root Cause
- `EncryptionManager.tsx` posted directly to `/api/entities/encryption` via a raw `useMutation` + `apiCall`, never routing through `useGuardedMutation` and never sending the optimistic-lock version header.
- `POST /api/entities/encryption` neither exposed nor enforced an `updatedAt` version token, and never called the mutation-guard lifecycle hooks.

## What Changed
- `api/encryption.ts`:
  - `GET` now returns the map's current version token (`updatedAt`).
  - `POST` enforces optimistic locking on an existing map via `enforceCommandOptimisticLock` before mutating it — strictly additive (no-op when the client omits the `x-om-ext-optimistic-lock-expected-updated-at` header), returning the unified structured `409` conflict body on mismatch.
  - `POST` wires the mutation-guard contract (`validateCrudMutationGuard` before the write, `runCrudMutationGuardAfterSuccess` after) so guards can block/audit encryption-map writes.
  - `POST` returns `updatedAt`; `CrudHttpError`s (incl. the 409) are mapped to their HTTP status; `openApi` documents the 409 and the `updatedAt` fields.
- `components/EncryptionManager.tsx`:
  - Tracks the loaded map's `updatedAt` and routes the save through `useGuardedMutation(...).runMutation(...)`, attaching the version via `withScopedApiRequestHeaders(buildOptimisticLockHeader(map.updatedAt), …)`. Conflicts now surface on the shared record-conflict bar.

## Tests
- Extended `api/__tests__/encryption.api.test.ts`:
  - `GET` returns the version token.
  - Stale write to an existing map → `409` with `code: 'optimistic_lock_conflict'`, and the write does **not** persist or bust cache.
  - Matching expected version → persists.
  - Mutation guard rejection blocks the write (no persist/cache bust); after-success hook fires on a successful write.
- `yarn workspace @open-mercato/core test -- encryption.api` → 7/7 pass.
- `yarn workspace @open-mercato/core test -- optimistic-lock` → 88/88 pass (incl. the UI-coverage guard that requires new raw mutating UI calls to send the header).
- `yarn build:packages`, `yarn generate`, `yarn typecheck`, `yarn i18n:check-sync`/`check-usage` all green. (Pre-existing lint errors on `develop` in `apps/mercato/src/components/OrganizationSwitcher.tsx` and `apps/mercato/src/modules/example/*` are unrelated to this change.)

## Backward Compatibility
- Additive only. The new `updatedAt` response field is additive; the optimistic-lock check is a no-op for callers that do not send the header, so existing API consumers keep working.
- No event IDs, widget spot IDs, ACL IDs, DI names, or import paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)