### PR TITLE
fix(entities): make custom record search pagination-aware (#3229)

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/records.get.search.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/records.get.search.test.ts
@@ -1,0 +1,83 @@
+/** @jest-environment node */
+import { GET } from '@open-mercato/core/modules/entities/api/records'
+
+const mockQE = {
+  query: jest.fn(async (_entityId: string, _options: { filters?: Record<string, unknown> }) => ({
+    items: [
+      { id: 'rec-1', cf_title: 'Berlin Conference', created_at: '2024-10-03T00:00:00Z' },
+    ],
+    total: 1,
+    page: 1,
+    pageSize: 50,
+  })),
+}
+
+const mockEm = {
+  findOne: jest.fn(async () => ({ id: 'ce-1', entityId: 'example:custom' })),
+  getKysely: () => ({
+    selectFrom: () => ({ select: () => ({ where: () => ({ where: () => ({ execute: async () => [] }) }) }) }),
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({ resolve: (k: string) => (k === 'queryEngine' ? mockQE : mockEm) }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({ getAuthFromRequest: () => ({ orgId: 'org', tenantId: 't1', roles: ['admin'] }) }))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScope: async () => ({ selectedId: 'org', filterIds: ['org'] }),
+  getSelectedOrganizationFromRequest: () => 'org',
+}))
+
+describe('GET /api/entities/records server-side search', () => {
+  beforeEach(() => { jest.clearAllMocks() })
+
+  it('passes an OR of ilike clauses across requested searchFields to the query engine', async () => {
+    const url = 'http://x/api/entities/records?entityId=example:custom&page=1&pageSize=50&search=Berlin&searchFields=id,title,location'
+    const req = new Request(url)
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+
+    expect(mockQE.query).toHaveBeenCalled()
+    const [, opts] = mockQE.query.mock.calls[0] as [string, { filters?: Record<string, unknown> }]
+    const orClauses = (opts?.filters as any)?.$or as Array<Record<string, unknown>>
+    expect(Array.isArray(orClauses)).toBe(true)
+    expect(orClauses).toEqual([
+      { id: { $ilike: '%Berlin%' } },
+      { title: { $ilike: '%Berlin%' } },
+      { location: { $ilike: '%Berlin%' } },
+    ])
+  })
+
+  it('defaults to searching the id field when no searchFields are provided', async () => {
+    const url = 'http://x/api/entities/records?entityId=example:custom&page=1&pageSize=50&search=abc'
+    const req = new Request(url)
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+
+    const [, opts] = mockQE.query.mock.calls[0] as [string, { filters?: Record<string, unknown> }]
+    expect((opts?.filters as any)?.$or).toEqual([{ id: { $ilike: '%abc%' } }])
+  })
+
+  it('does not add a search filter when the term is blank', async () => {
+    const url = 'http://x/api/entities/records?entityId=example:custom&page=1&pageSize=50&search=%20%20&searchFields=title'
+    const req = new Request(url)
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+
+    const [, opts] = mockQE.query.mock.calls[0] as [string, { filters?: Record<string, unknown> }]
+    expect((opts?.filters as any)?.$or).toBeUndefined()
+  })
+
+  it('does not treat search/searchFields as record filters', async () => {
+    const url = 'http://x/api/entities/records?entityId=example:custom&page=1&pageSize=50&search=Berlin&searchFields=title'
+    const req = new Request(url)
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+
+    const [, opts] = mockQE.query.mock.calls[0] as [string, { filters?: Record<string, unknown> }]
+    expect((opts?.filters as any)?.search).toBeUndefined()
+    expect((opts?.filters as any)?.searchFields).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/entities/api/records.ts
+++ b/packages/core/src/modules/entities/api/records.ts
@@ -107,6 +107,8 @@ const listRecordsQuerySchema = z
     pageSize: z.coerce.number().int().min(1).max(100).optional(),
     sortField: z.string().optional(),
     sortDir: z.enum(['asc', 'desc']).optional(),
+    search: z.string().optional(),
+    searchFields: z.string().optional(),
     withDeleted: z.coerce.boolean().optional(),
     format: z.enum(['csv', 'json', 'xml', 'markdown']).optional(),
     exportScope: z.enum(['full']).optional(),
@@ -145,10 +147,15 @@ export async function GET(req: Request) {
   const sortField = url.searchParams.get('sortField') || 'id'
   const sortDir = (url.searchParams.get('sortDir') || 'asc').toLowerCase() === 'desc' ? 'desc' : 'asc'
   const withDeleted = parseBooleanWithDefault(url.searchParams.get('withDeleted'), false)
+  const searchTerm = (url.searchParams.get('search') || '').trim()
+  const searchFields = (url.searchParams.get('searchFields') || '')
+    .split(',')
+    .map((field) => field.trim())
+    .filter(Boolean)
 
   const qpEntries: Array<[string, string]> = []
   for (const [key, val] of url.searchParams.entries()) {
-    if (['entityId','page','pageSize','sortField','sortDir','withDeleted','format','exportScope','export_scope','all','full'].includes(key)) continue
+    if (['entityId','page','pageSize','sortField','sortDir','withDeleted','format','exportScope','export_scope','all','full','search','searchFields'].includes(key)) continue
     qpEntries.push([key, val])
   }
 
@@ -246,6 +253,15 @@ export async function GET(req: Request) {
     // even before the first record exists.
     if (isCustomEntity) qopts.forceCustomEntityStorage = true
     for (const [k, v] of qpEntries) buildFilter(k, v, isCustomEntity)
+    // Server-side full-result search: match the term against the requested fields
+    // (defaults to `id`) before pagination so totals/exports stay consistent with
+    // the active search instead of filtering only the current client page (#3229).
+    if (searchTerm) {
+      const fields = searchFields.length ? searchFields : ['id']
+      const pattern = `%${searchTerm}%`
+      const orClauses = fields.map((field) => ({ [field]: { $ilike: pattern } }))
+      ;(filtersObj as any).$or = orClauses
+    }
     const res = await qe.query(entityId as any, qopts)
     const rawItems = res.items || []
     const viewPageItems = rawItems.map(mapRow)

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/page.tsx
@@ -85,7 +85,16 @@ function RecordsPageInner({ params }: { params: { entityId?: string } }) {
     keyExtras: [scopeVersion],
   })
 
-  // Fetch records whenever paging/sorting/filters change (do NOT refetch on cfDefs/search changes)
+  // Fields searched server-side: every visible column plus the base `id`.
+  const searchableFields = React.useMemo(() => {
+    const fields = (columns || [])
+      .map((col) => (col as any).accessorKey)
+      .filter((key): key is string => typeof key === 'string' && key.length > 0)
+    return Array.from(new Set(['id', ...fields]))
+  }, [columns])
+
+  // Fetch records whenever paging/sorting/filters/search change. Search is applied
+  // server-side (before pagination) so totals and exports stay consistent (#3229).
   React.useEffect(() => {
     let cancelled = false
     const run = async () => {
@@ -95,6 +104,11 @@ function RecordsPageInner({ params }: { params: { entityId?: string } }) {
         params.set('entityId', entityId)
         params.set('page', String(page))
         params.set('pageSize', String(pageSize))
+        const trimmedSearch = search.trim()
+        if (trimmedSearch) {
+          params.set('search', trimmedSearch)
+          if (searchableFields.length) params.set('searchFields', searchableFields.join(','))
+        }
         const s = sorting?.[0]
         if (s?.id) {
           params.set('sortField', String(s.id))
@@ -142,7 +156,7 @@ function RecordsPageInner({ params }: { params: { entityId?: string } }) {
     }
     if (entityId) run()
     return () => { cancelled = true }
-  }, [entityId, page, pageSize, sorting, filterValues, scopeVersion])
+  }, [entityId, page, pageSize, sorting, filterValues, scopeVersion, search, searchableFields])
 
   // Build columns from custom field definitions only (no data round-trip)
   React.useEffect(() => {
@@ -163,15 +177,9 @@ function RecordsPageInner({ params }: { params: { entityId?: string } }) {
     setColumns(cols)
   }, [cfDefs])
 
-  // Client-side quick search filtering without triggering server refetch
-  const data = React.useMemo(() => {
-    if (!search.trim()) return rawData
-    const q = search.trim().toLowerCase()
-    return (rawData || []).filter((row: any) => {
-      const values = Object.values(row || {})
-      return values.some((v) => normalizeCell(v).toLowerCase().includes(q))
-    })
-  }, [rawData, search])
+  // Search is server-side (see fetch effect); render the fetched page as-is so
+  // pagination totals and exports stay consistent with the active search (#3229).
+  const data = rawData
 
   const viewExportColumns = React.useMemo(() => {
     return (columns || [])
@@ -201,8 +209,13 @@ function RecordsPageInner({ params }: { params: { entityId?: string } }) {
       qp.set('sortField', String(sort.id))
       qp.set('sortDir', sort.desc ? 'desc' : 'asc')
     }
+    const trimmedSearch = search.trim()
+    if (trimmedSearch) {
+      qp.set('search', trimmedSearch)
+      if (searchableFields.length) qp.set('searchFields', searchableFields.join(','))
+    }
     return `/api/entities/records?${qp.toString()}`
-  }, [entityId, sorting])
+  }, [entityId, sorting, search, searchableFields])
 
   const exportConfig = React.useMemo(() => {
     const safeEntityId = entityId.replace(/[^a-z0-9_-]/gi, '_') || 'records'

--- a/packages/shared/src/lib/query/__tests__/records-search-filter.test.ts
+++ b/packages/shared/src/lib/query/__tests__/records-search-filter.test.ts
@@ -1,0 +1,58 @@
+/** @jest-environment node */
+import { normalizeFilters } from '../join-utils'
+
+/**
+ * The custom-entity records API builds a pagination-aware server-side search as a
+ * top-level `$or` of `$ilike` clauses (one per searchable field) ANDed with the
+ * tenant/org scope (#3229). This verifies the filter shape it produces normalizes
+ * into the orGroup disjuncts + lifted common clause that the query engine consumes,
+ * so the search applies before pagination instead of only on the current page.
+ */
+describe('records server-side search filter normalization', () => {
+  it('expands an $or of $ilike clauses into orGroup-tagged disjuncts', () => {
+    const filters = {
+      $or: [
+        { id: { $ilike: '%berlin%' } },
+        { title: { $ilike: '%berlin%' } },
+        { location: { $ilike: '%berlin%' } },
+      ],
+    }
+    const normalized = normalizeFilters(filters)
+    const groups = new Set(normalized.map((f) => f.orGroup))
+    expect(groups.size).toBe(3)
+    expect(normalized).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'id', op: 'ilike', value: '%berlin%' }),
+        expect.objectContaining({ field: 'title', op: 'ilike', value: '%berlin%' }),
+        expect.objectContaining({ field: 'location', op: 'ilike', value: '%berlin%' }),
+      ]),
+    )
+  })
+
+  it('lifts the ANDed org scope out of the search disjuncts as a common clause', () => {
+    const filters = {
+      organization_id: { $in: ['org-1'] },
+      $or: [
+        { title: { $ilike: '%abc%' } },
+        { location: { $ilike: '%abc%' } },
+      ],
+    }
+    const normalized = normalizeFilters(filters)
+    const common = normalized.filter((f) => !f.orGroup)
+    const disjuncts = normalized.filter((f) => f.orGroup)
+    expect(common).toEqual([
+      expect.objectContaining({ field: 'organization_id', op: 'in', value: ['org-1'] }),
+    ])
+    expect(new Set(disjuncts.map((f) => f.orGroup)).size).toBe(2)
+    expect(disjuncts.map((f) => f.field).sort()).toEqual(['location', 'title'])
+  })
+
+  it('keeps a single-field search as a plain AND clause (no orGroup)', () => {
+    const filters = { $or: [{ id: { $ilike: '%x%' } }] }
+    const normalized = normalizeFilters(filters)
+    expect(normalized).toEqual([
+      expect.objectContaining({ field: 'id', op: 'ilike', value: '%x%' }),
+    ])
+    expect(normalized.every((f) => !f.orGroup)).toBe(true)
+  })
+})

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -518,18 +518,21 @@ export class BasicQueryEngine implements QueryEngine {
           group.push(f)
           groups.set(f.orGroup!, group)
         }
-        const resolvedGroupFilters: Array<Array<{ qualified: string; op: string; value: unknown; fieldName: string }>> = []
+        type ResolvedOrClause =
+          | { kind: 'column'; qualified: string; op: NormalizedFilter['op']; value: unknown }
+          | { kind: 'doc'; field: string; op: NormalizedFilter['op']; value: unknown }
+        const resolvedGroupFilters: ResolvedOrClause[][] = []
         for (const [, groupFilters] of groups) {
-          const resolved: Array<{ qualified: string; op: string; value: unknown; fieldName: string }> = []
+          const resolved: ResolvedOrClause[] = []
           for (const filter of groupFilters) {
             const column = await this.resolveBaseColumn(table, String(filter.field))
             if (column) {
-              resolved.push({
-                qualified: qualify(column),
-                op: filter.op,
-                value: filter.value,
-                fieldName: String(filter.field),
-              })
+              resolved.push({ kind: 'column', qualified: qualify(column), op: filter.op, value: filter.value })
+            } else {
+              // Field is not a base column — for custom-entity records it lives in
+              // entity_indexes.doc. Build an EXISTS sub-filter so `$or` searches
+              // across doc fields resolve instead of being silently dropped (#3229).
+              resolved.push({ kind: 'doc', field: String(filter.field), op: filter.op, value: filter.value })
             }
           }
           if (resolved.length > 0) resolvedGroupFilters.push(resolved)
@@ -537,7 +540,18 @@ export class BasicQueryEngine implements QueryEngine {
         if (resolvedGroupFilters.length > 0) {
           q = q.where((eb: any) => eb.or(
             resolvedGroupFilters.map((group) => {
-              const parts = group.map((rf) => this.buildColumnOpExpression(eb, rf.qualified, rf.op, rf.value))
+              const parts = group.map((rf) => rf.kind === 'column'
+                ? this.buildColumnOpExpression(eb, rf.qualified, rf.op, rf.value)
+                : this.buildIndexDocOpExpression(eb, {
+                    entity: String(entity),
+                    field: rf.field,
+                    op: rf.op,
+                    value: rf.value,
+                    recordIdColumn,
+                    tenantId: opts.tenantId ?? null,
+                    organizationScope: orgScope,
+                    withDeleted: opts.withDeleted === true,
+                  }))
               return parts.length === 1 ? parts[0] : eb.and(parts)
             })
           ))
@@ -1270,9 +1284,29 @@ export class BasicQueryEngine implements QueryEngine {
       return q
     }
 
+    return q.where((eb: any) => this.buildIndexDocOpExpression(eb, opts))
+  }
+
+  // Builds the entity_indexes EXISTS expression for a single doc-field operator,
+  // shared by the regular doc-filter path (applyIndexDocFilter) and the OR-group
+  // path so `$or` queries over custom-entity doc fields resolve instead of being
+  // silently dropped (#3229).
+  private buildIndexDocOpExpression(
+    eb: any,
+    opts: {
+      entity: string
+      field: string
+      op: NormalizedFilter['op']
+      value: unknown
+      recordIdColumn: string
+      tenantId?: string | null
+      organizationScope?: { ids: string[]; includeNull: boolean } | null
+      withDeleted: boolean
+    }
+  ): any {
     const alias = `ei_${this.searchAliasSeq++}`
     const engine = this
-    return q.where((eb: any) => eb.exists((() => {
+    return eb.exists((() => {
       let sub: AnyBuilder = eb
         .selectFrom(`entity_indexes as ${alias}`)
         .select(sql<number>`1`.as('one'))
@@ -1325,7 +1359,7 @@ export class BasicQueryEngine implements QueryEngine {
           break
       }
       return sub
-    })()))
+    })())
   }
 
   private configureCustomFieldSources(


### PR DESCRIPTION
Fixes #3229

## Problem
The custom entity records table search filtered only the already-loaded page of records client-side. Records on other pages were missed, while pagination totals (and exports) still reflected the unsearched server result — making search incomplete and misleading for any custom entity larger than the current page size.

## Root Cause
- `records/page.tsx` stored the search value in local state and filtered only `rawData` (the current server page) client-side, never sending the term to `GET /api/entities/records`.
- The records list API had no `search` handling, so totals/exports ignored the term.
- The query engine's OR-group path dropped any clause whose field is not a base table column, so an `$or` over custom-entity **doc** fields (where custom field values live, in `entity_indexes.doc`) silently matched nothing.

## What Changed
- **API (`entities/api/records.ts`)**: accepts `search` (and `searchFields`) and builds a top-level `$or` of `$ilike` clauses (one per searchable field, defaulting to `id`) merged with the tenant/org scope. Applied **before** pagination, so `total`/`totalPages` and the full/view exports all respect the active search. `search`/`searchFields` are excluded from the generic record-filter pass-through and documented in `openApi`.
- **Page (`records/page.tsx`)**: sends the trimmed term plus the visible column keys to the API, refetches on search change (resetting to page 1), removes the client-side page-only filter (renders the fetched page directly), and forwards the term to the full-export URL.
- **Query engine (`shared/.../query/engine.ts`)**: OR-group clauses whose field is not a base column now build an `entity_indexes.doc ->> field` `EXISTS` sub-filter instead of being dropped. The existing index-doc filter SQL was extracted into a shared `buildIndexDocOpExpression` reused by both the regular and OR-group paths (behavior-preserving for the existing single-clause path).

## Tests
- `entities/api/__tests__/records.get.search.test.ts` — verifies the API passes an `$or` of `$ilike` clauses across the requested `searchFields`, defaults to `id`, no-ops on a blank term, and never leaks `search`/`searchFields` into record filters.
- `shared/.../query/__tests__/records-search-filter.test.ts` — verifies the filter shape normalizes into orGroup disjuncts with the ANDed org scope lifted as a common clause (single-field search stays a plain AND clause).
- Full shared query suite (156) and core records suite (33) pass. `yarn typecheck`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage` all green.

## Backward Compatibility
- Additive only: new optional `search`/`searchFields` query params; no API response fields removed; no event IDs / DI keys / ACL features / import paths changed. The engine change only affects OR-grouped queries with non-column fields, which previously returned nothing for those clauses (latent bug), so existing behavior is preserved or corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)