### PR TITLE
fix(feature_toggles): show falsy defaults and call useT unconditionally (#3241)

### DIFF
--- a/packages/core/src/modules/feature_toggles/components/FeatureToggleDetailsCard.tsx
+++ b/packages/core/src/modules/feature_toggles/components/FeatureToggleDetailsCard.tsx
@@ -7,30 +7,32 @@ type FeatureToggleDetailsCardProps = {
 }
 
 function DefaultValueDisplay({ featureToggleItem }: { featureToggleItem?: FeatureToggle }) {
+  const t = useT()
 
-  if (!featureToggleItem?.defaultValue) {
+  const defaultValue = featureToggleItem?.defaultValue
+  if (defaultValue === null || defaultValue === undefined) {
     return <p className="text-base text-muted-foreground">-</p>
   }
 
-  switch (featureToggleItem.type) {
+  switch (featureToggleItem?.type) {
     case 'boolean':
       return (
         <p className="text-base font-semibold text-foreground">
-          {featureToggleItem.defaultValue ? useT()('feature_toggles.values.true', 'True') : useT()('feature_toggles.values.false', 'False')}
+          {defaultValue ? t('feature_toggles.values.true', 'True') : t('feature_toggles.values.false', 'False')}
         </p>
       )
 
     case 'string':
       return (
         <p className="text-base font-semibold text-foreground">
-          {featureToggleItem.defaultValue}
+          {defaultValue}
         </p>
       )
 
     case 'number':
       return (
         <p className="text-base font-semibold text-foreground">
-          {featureToggleItem.defaultValue}
+          {defaultValue}
         </p>
       )
 
@@ -38,9 +40,9 @@ function DefaultValueDisplay({ featureToggleItem }: { featureToggleItem?: Featur
       return (
         <div className="text-base font-semibold text-foreground">
           <pre className="bg-muted/30 p-2 rounded text-sm font-mono overflow-x-auto whitespace-pre-wrap">
-            {typeof featureToggleItem.defaultValue === 'object'
-              ? JSON.stringify(featureToggleItem.defaultValue, null, 2)
-              : featureToggleItem.defaultValue}
+            {typeof defaultValue === 'object'
+              ? JSON.stringify(defaultValue, null, 2)
+              : defaultValue}
           </pre>
         </div>
       )

--- a/packages/core/src/modules/feature_toggles/components/__tests__/FeatureToggleDetailsCard.test.tsx
+++ b/packages/core/src/modules/feature_toggles/components/__tests__/FeatureToggleDetailsCard.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { FeatureToggleDetailsCard } from '@open-mercato/core/modules/feature_toggles/components/FeatureToggleDetailsCard'
+import type { FeatureToggle } from '@open-mercato/core/modules/feature_toggles/data/validators'
+
+const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+function baseToggle(overrides: Partial<FeatureToggle>): FeatureToggle {
+  return {
+    identifier: 'sample_flag',
+    name: 'Sample flag',
+    description: 'A sample flag',
+    category: 'ui',
+    type: 'string',
+    defaultValue: 'value',
+    ...overrides,
+  } as FeatureToggle
+}
+
+describe('FeatureToggleDetailsCard — default value rendering (#3241)', () => {
+  it('renders boolean false default as "False", not "-"', () => {
+    render(<FeatureToggleDetailsCard featureToggleItem={baseToggle({ type: 'boolean', defaultValue: false })} />)
+    expect(screen.getByText('False')).toBeInTheDocument()
+    expect(screen.queryByText('-')).toBeNull()
+  })
+
+  it('renders boolean true default as "True"', () => {
+    render(<FeatureToggleDetailsCard featureToggleItem={baseToggle({ type: 'boolean', defaultValue: true })} />)
+    expect(screen.getByText('True')).toBeInTheDocument()
+  })
+
+  it('renders numeric 0 default as "0", not "-"', () => {
+    render(<FeatureToggleDetailsCard featureToggleItem={baseToggle({ type: 'number', defaultValue: 0 })} />)
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('renders empty string default as an empty value, not "-"', () => {
+    const { container } = render(
+      <FeatureToggleDetailsCard featureToggleItem={baseToggle({ type: 'string', defaultValue: '' })} />,
+    )
+    // The default-value paragraph exists but is empty; it must not fall back to "-".
+    expect(screen.queryByText('-')).toBeNull()
+    expect(container.querySelector('.font-semibold')).not.toBeNull()
+  })
+
+  it('renders JSON object default as formatted JSON', () => {
+    render(
+      <FeatureToggleDetailsCard
+        featureToggleItem={baseToggle({ type: 'json', defaultValue: { enabled: true } })}
+      />,
+    )
+    expect(screen.getByText(/"enabled": true/)).toBeInTheDocument()
+  })
+
+  it('renders "-" only when the default value is missing (null/undefined)', () => {
+    const { rerender } = render(
+      <FeatureToggleDetailsCard featureToggleItem={baseToggle({ type: 'string', defaultValue: null })} />,
+    )
+    expect(screen.getByText('-')).toBeInTheDocument()
+
+    rerender(
+      <FeatureToggleDetailsCard featureToggleItem={baseToggle({ type: 'string', defaultValue: undefined })} />,
+    )
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+
+  it('does not change hook order when re-rendering from no data to a boolean toggle', () => {
+    // Reproduces the conditional-useT() hook-order failure: first render with no
+    // record (card renders "-" via the early return), then a re-render with a
+    // truthy boolean toggle. A conditional hook would throw on this transition.
+    const { rerender } = render(<FeatureToggleDetailsCard featureToggleItem={undefined} />)
+    expect(screen.getAllByText('-').length).toBeGreaterThan(0)
+
+    expect(() => {
+      rerender(
+        <FeatureToggleDetailsCard featureToggleItem={baseToggle({ type: 'boolean', defaultValue: true })} />,
+      )
+    }).not.toThrow()
+    expect(screen.getByText('True')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #3241

## Problem
- The feature toggle details card treated every falsy `defaultValue` (`false`, `0`, `''`) as missing and rendered `-`, so valid defaults displayed incorrectly.
- `DefaultValueDisplay` called `useT()` inside the boolean `switch` branch, after an early `return`. That conditional hook violates React's rules-of-hooks when the card first renders without data and later re-renders with a boolean toggle (the detail page mounts the card before `useFeatureToggleItem` has loaded), risking a hook-order runtime failure.

## Root Cause
- `if (!featureToggleItem?.defaultValue)` is truthiness-based, so falsy-but-valid values fall into the "missing" branch.
- `useT()` was invoked inside a conditional render path instead of unconditionally at the top of the component.

## What Changed
- `packages/core/src/modules/feature_toggles/components/FeatureToggleDetailsCard.tsx`:
  - Hoisted `const t = useT()` to the top of `DefaultValueDisplay` (single unconditional hook call) and replaced the inline `useT()` calls in the boolean branch with `t`.
  - Gated the empty state on `defaultValue === null || defaultValue === undefined` only, so `false`, `0`, and `''` render their real values.
  - Switched the string/number/json branches to the locally-bound `defaultValue`.

## Tests
- Added `packages/core/src/modules/feature_toggles/components/__tests__/FeatureToggleDetailsCard.test.tsx` covering boolean `false`/`true`, numeric `0`, empty string, JSON object defaults, the missing (`null`/`undefined`) case, and a no-data → boolean-toggle re-render to guard hook ordering.
- Verified the new tests fail against the pre-fix component (3 falsy-default cases) and pass after the fix.
- `yarn workspace @open-mercato/core test --testPathPattern feature_toggles` → 62 passed.
- `yarn workspace @open-mercato/core typecheck` → clean.

## Backward Compatibility
- No contract surface changes. No API, type, event ID, DI, ACL, or import-path changes. i18n keys (`feature_toggles.values.true|false`) already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)