### PR TITLE
fix(inbox_ops): wire proposal and email custom write routes through mutation guards (#3249)

### DIFF
--- a/packages/core/src/modules/inbox_ops/api/__tests__/mutation-guards.test.ts
+++ b/packages/core/src/modules/inbox_ops/api/__tests__/mutation-guards.test.ts
@@ -1,0 +1,276 @@
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const proposalId = '44444444-4444-4444-8444-444444444444'
+const actionId = '55555555-5555-4555-8555-555555555555'
+const emailId = '66666666-6666-4666-8666-666666666666'
+
+const flushMock = jest.fn()
+const nativeUpdateMock = jest.fn()
+
+const container = { resolve: jest.fn() }
+
+const ctx = {
+  auth: { sub: userId, tenantId, orgId: organizationId },
+  userId,
+  tenantId,
+  organizationId,
+  scope: { tenantId, organizationId },
+  em: { flush: flushMock, nativeUpdate: nativeUpdateMock },
+  container,
+  eventBus: null,
+}
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+
+const resolveProposalMock = jest.fn()
+const resolveActionAndProposalMock = jest.fn()
+const extractPathSegmentMock = jest.fn()
+const acceptAllActionsMock = jest.fn()
+const emitInboxOpsEventMock = jest.fn()
+const findOneWithDecryptionMock = jest.fn()
+
+class UnauthorizedError extends Error {}
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: async (_tenant: string, fn: () => unknown) => fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: (...args: unknown[]) => findOneWithDecryptionMock(...args),
+}))
+
+jest.mock('../routeHelpers', () => ({
+  resolveRequestContext: jest.fn(async () => ctx),
+  resolveProposal: (...args: unknown[]) => resolveProposalMock(...args),
+  resolveActionAndProposal: (...args: unknown[]) => resolveActionAndProposalMock(...args),
+  resolveCrossModuleEntities: jest.fn(() => ({})),
+  toExecutionContext: jest.fn(() => ({})),
+  extractPathSegment: (...args: unknown[]) => extractPathSegmentMock(...args),
+  handleRouteError: jest.fn((err: unknown, label: string) => {
+    const { NextResponse } = require('next/server')
+    return NextResponse.json({ error: `Failed to ${label}` }, { status: 500 })
+  }),
+  isErrorResponse: jest.fn((value: unknown) => {
+    const { NextResponse } = require('next/server')
+    return value instanceof NextResponse
+  }),
+  UnauthorizedError,
+}))
+
+jest.mock('../../lib/cache', () => ({
+  resolveCache: jest.fn(() => ({})),
+  invalidateCountsCache: jest.fn(async () => undefined),
+}))
+
+jest.mock('../../lib/executionEngine', () => ({
+  acceptAllActions: (...args: unknown[]) => acceptAllActionsMock(...args),
+}))
+
+jest.mock('../../events', () => ({
+  emitInboxOpsEvent: (...args: unknown[]) => emitInboxOpsEventMock(...args),
+}))
+
+import { POST as categorizePost } from '../proposals/[id]/categorize/route'
+import { PATCH as actionPatch } from '../proposals/[id]/actions/[actionId]/route'
+import { POST as acceptAllPost } from '../proposals/[id]/accept-all/route'
+import { DELETE as emailDelete } from '../emails/[id]/route'
+
+const guardAllow = { ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } }
+const guardDeny = { ok: false, status: 423, body: { error: 'locked' } }
+
+function jsonRequest(url: string, method: string, body?: unknown): Request {
+  return new Request(url, {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+}
+
+describe('inbox_ops custom write routes wire the mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    validateCrudMutationGuardMock.mockResolvedValue(guardAllow)
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    flushMock.mockResolvedValue(undefined)
+    nativeUpdateMock.mockResolvedValue(1)
+    resolveProposalMock.mockResolvedValue({ id: proposalId, category: 'inquiry' })
+    resolveActionAndProposalMock.mockResolvedValue({
+      action: { id: actionId, proposalId, status: 'pending', actionType: 'unknown_type', payload: {} },
+      proposal: { id: proposalId },
+    })
+    extractPathSegmentMock.mockReturnValue(emailId)
+    acceptAllActionsMock.mockResolvedValue({ results: [{ success: true }], stoppedOnFailure: false })
+    emitInboxOpsEventMock.mockResolvedValue(undefined)
+  })
+
+  describe('categorize proposal', () => {
+    it('validates the guard before mutating and runs the after-success hook', async () => {
+      const response = await categorizePost(
+        jsonRequest(`http://localhost/api/inbox_ops/proposals/${proposalId}/categorize`, 'POST', { category: 'order' }),
+      )
+
+      expect(response.status).toBe(200)
+      const validateOrder = validateCrudMutationGuardMock.mock.invocationCallOrder[0]
+      const flushOrder = flushMock.mock.invocationCallOrder[0]
+      expect(validateOrder).toBeLessThan(flushOrder)
+      expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({
+          tenantId,
+          organizationId,
+          userId,
+          resourceKind: 'inbox_ops:inbox_proposal',
+          resourceId: proposalId,
+          operation: 'update',
+        }),
+      )
+      expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({ resourceKind: 'inbox_ops:inbox_proposal', resourceId: proposalId }),
+      )
+    })
+
+    it('returns the guard rejection and does not mutate', async () => {
+      validateCrudMutationGuardMock.mockResolvedValue(guardDeny)
+
+      const response = await categorizePost(
+        jsonRequest(`http://localhost/api/inbox_ops/proposals/${proposalId}/categorize`, 'POST', { category: 'order' }),
+      )
+
+      expect(response.status).toBe(423)
+      expect(flushMock).not.toHaveBeenCalled()
+      expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('edit action payload', () => {
+    it('validates the guard before mutating and runs the after-success hook', async () => {
+      const response = await actionPatch(
+        jsonRequest(
+          `http://localhost/api/inbox_ops/proposals/${proposalId}/actions/${actionId}`,
+          'PATCH',
+          { payload: { note: 'updated' } },
+        ),
+      )
+
+      expect(response.status).toBe(200)
+      const validateOrder = validateCrudMutationGuardMock.mock.invocationCallOrder[0]
+      const flushOrder = flushMock.mock.invocationCallOrder[0]
+      expect(validateOrder).toBeLessThan(flushOrder)
+      expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({
+          resourceKind: 'inbox_ops:inbox_proposal_action',
+          resourceId: actionId,
+          operation: 'update',
+        }),
+      )
+      expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({ resourceKind: 'inbox_ops:inbox_proposal_action', resourceId: actionId }),
+      )
+    })
+
+    it('returns the guard rejection and does not mutate', async () => {
+      validateCrudMutationGuardMock.mockResolvedValue(guardDeny)
+
+      const response = await actionPatch(
+        jsonRequest(
+          `http://localhost/api/inbox_ops/proposals/${proposalId}/actions/${actionId}`,
+          'PATCH',
+          { payload: { note: 'updated' } },
+        ),
+      )
+
+      expect(response.status).toBe(423)
+      expect(flushMock).not.toHaveBeenCalled()
+      expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('accept all actions', () => {
+    it('validates the guard before executing and runs the after-success hook', async () => {
+      const response = await acceptAllPost(
+        jsonRequest(`http://localhost/api/inbox_ops/proposals/${proposalId}/accept-all`, 'POST'),
+      )
+
+      expect(response.status).toBe(200)
+      const validateOrder = validateCrudMutationGuardMock.mock.invocationCallOrder[0]
+      const executeOrder = acceptAllActionsMock.mock.invocationCallOrder[0]
+      expect(validateOrder).toBeLessThan(executeOrder)
+      expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({
+          resourceKind: 'inbox_ops:inbox_proposal',
+          resourceId: proposalId,
+          operation: 'custom',
+        }),
+      )
+      expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    })
+
+    it('returns the guard rejection and does not execute actions', async () => {
+      validateCrudMutationGuardMock.mockResolvedValue(guardDeny)
+
+      const response = await acceptAllPost(
+        jsonRequest(`http://localhost/api/inbox_ops/proposals/${proposalId}/accept-all`, 'POST'),
+      )
+
+      expect(response.status).toBe(423)
+      expect(acceptAllActionsMock).not.toHaveBeenCalled()
+      expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('delete email', () => {
+    it('validates the guard before deleting and runs the after-success hook', async () => {
+      const response = await emailDelete(
+        jsonRequest(`http://localhost/api/inbox_ops/emails/${emailId}`, 'DELETE'),
+      )
+
+      expect(response.status).toBe(200)
+      const validateOrder = validateCrudMutationGuardMock.mock.invocationCallOrder[0]
+      const updateOrder = nativeUpdateMock.mock.invocationCallOrder[0]
+      expect(validateOrder).toBeLessThan(updateOrder)
+      expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({
+          resourceKind: 'inbox_ops:inbox_email',
+          resourceId: emailId,
+          operation: 'delete',
+        }),
+      )
+      expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    })
+
+    it('returns the guard rejection and does not delete', async () => {
+      validateCrudMutationGuardMock.mockResolvedValue(guardDeny)
+
+      const response = await emailDelete(
+        jsonRequest(`http://localhost/api/inbox_ops/emails/${emailId}`, 'DELETE'),
+      )
+
+      expect(response.status).toBe(423)
+      expect(nativeUpdateMock).not.toHaveBeenCalled()
+      expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+    })
+
+    it('does not run the after-success hook when the email was already deleted', async () => {
+      nativeUpdateMock.mockResolvedValue(0)
+
+      const response = await emailDelete(
+        jsonRequest(`http://localhost/api/inbox_ops/emails/${emailId}`, 'DELETE'),
+      )
+
+      expect(response.status).toBe(404)
+      expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/modules/inbox_ops/api/emails/[id]/route.ts
+++ b/packages/core/src/modules/inbox_ops/api/emails/[id]/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { InboxEmail } from '../../../data/entities'
 import {
   resolveRequestContext,
@@ -62,6 +66,20 @@ export async function DELETE(req: Request) {
 
     const ctx = await resolveRequestContext(req)
 
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId: ctx.tenantId,
+      organizationId: ctx.organizationId,
+      userId: ctx.userId,
+      resourceKind: 'inbox_ops:inbox_email',
+      resourceId: id,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     const updated = await ctx.em.nativeUpdate(
       InboxEmail,
       {
@@ -75,6 +93,20 @@ export async function DELETE(req: Request) {
 
     if (updated === 0) {
       return NextResponse.json({ error: 'Email not found' }, { status: 404 })
+    }
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId: ctx.tenantId,
+        organizationId: ctx.organizationId,
+        userId: ctx.userId,
+        resourceKind: 'inbox_ops:inbox_email',
+        resourceId: id,
+        operation: 'delete',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
     }
 
     return NextResponse.json({ ok: true })

--- a/packages/core/src/modules/inbox_ops/api/proposals/[id]/accept-all/route.ts
+++ b/packages/core/src/modules/inbox_ops/api/proposals/[id]/accept-all/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { runWithCacheTenant } from '@open-mercato/cache'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { acceptAllActions } from '../../../../lib/executionEngine'
 import { resolveCache, invalidateCountsCache } from '../../../../lib/cache'
 import {
@@ -22,6 +26,20 @@ export async function POST(req: Request) {
     const proposal = await resolveProposal(new URL(req.url), ctx)
     if (isErrorResponse(proposal)) return proposal
 
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId: ctx.tenantId,
+      organizationId: ctx.organizationId,
+      userId: ctx.userId,
+      resourceKind: 'inbox_ops:inbox_proposal',
+      resourceId: proposal.id,
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     const entities = resolveCrossModuleEntities(ctx.container)
     const { results, stoppedOnFailure } = await acceptAllActions(
       proposal.id,
@@ -30,6 +48,20 @@ export async function POST(req: Request) {
 
     const succeeded = results.filter((r) => r.success).length
     const failed = results.filter((r) => !r.success).length
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId: ctx.tenantId,
+        organizationId: ctx.organizationId,
+        userId: ctx.userId,
+        resourceKind: 'inbox_ops:inbox_proposal',
+        resourceId: proposal.id,
+        operation: 'custom',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     const cache = resolveCache(ctx.container)
     await runWithCacheTenant(ctx.tenantId, () => invalidateCountsCache(cache, ctx.tenantId))

--- a/packages/core/src/modules/inbox_ops/api/proposals/[id]/actions/[actionId]/route.ts
+++ b/packages/core/src/modules/inbox_ops/api/proposals/[id]/actions/[actionId]/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { runWithCacheTenant } from '@open-mercato/cache'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { actionEditSchema, validateActionPayloadForType } from '../../../../../data/validators'
 import { emitInboxOpsEvent } from '../../../../../events'
 import { resolveCache, invalidateCountsCache } from '../../../../../lib/cache'
@@ -39,8 +43,37 @@ export async function PATCH(req: Request) {
       return NextResponse.json({ error: payloadValidation.error }, { status: 400 })
     }
 
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId: ctx.tenantId,
+      organizationId: ctx.organizationId,
+      userId: ctx.userId,
+      resourceKind: 'inbox_ops:inbox_proposal_action',
+      resourceId: action.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: parsed.data,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     action.payload = mergedPayload
     await ctx.em.flush()
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId: ctx.tenantId,
+        organizationId: ctx.organizationId,
+        userId: ctx.userId,
+        resourceKind: 'inbox_ops:inbox_proposal_action',
+        resourceId: action.id,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     const cache = resolveCache(ctx.container)
     await runWithCacheTenant(ctx.tenantId, () => invalidateCountsCache(cache, ctx.tenantId))

--- a/packages/core/src/modules/inbox_ops/api/proposals/[id]/categorize/route.ts
+++ b/packages/core/src/modules/inbox_ops/api/proposals/[id]/categorize/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { runWithCacheTenant } from '@open-mercato/cache'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { categorizeProposalSchema } from '../../../../data/validators'
 import { resolveCache, invalidateCountsCache } from '../../../../lib/cache'
 import {
@@ -27,9 +31,38 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: `Invalid category: ${issues}` }, { status: 400 })
     }
 
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId: ctx.tenantId,
+      organizationId: ctx.organizationId,
+      userId: ctx.userId,
+      resourceKind: 'inbox_ops:inbox_proposal',
+      resourceId: proposal.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: parsed.data,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     const previousCategory = proposal.category || null
     proposal.category = parsed.data.category
     await ctx.em.flush()
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId: ctx.tenantId,
+        organizationId: ctx.organizationId,
+        userId: ctx.userId,
+        resourceKind: 'inbox_ops:inbox_proposal',
+        resourceId: proposal.id,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     const cache = resolveCache(ctx.container)
     await runWithCacheTenant(ctx.tenantId, () => invalidateCountsCache(cache, ctx.tenantId))


### PR DESCRIPTION
Fixes #3249

## Problem
`inbox_ops` had custom mutating API routes that did not wire the repo mutation guard lifecycle required by `packages/core/AGENTS.md` for custom `POST`/`PUT`/`PATCH`/`DELETE` routes that do not use `makeCrudRoute`. These endpoints execute AI-proposed actions, mutate proposal review state, or delete email records, so they were invisible to the mutation guard contract that protects other custom writes.

## Root Cause
The four affected routes mutated state and flushed (or executed actions) without calling `validateCrudMutationGuard` before the mutation and `runCrudMutationGuardAfterSuccess` after a successful write.

## What Changed
Wired the mutation guard lifecycle into the four custom write routes, preserving existing authorization, tenant/organization scoping, cache invalidation, and event-emission order:

- `api/proposals/[id]/categorize/route.ts` (POST) — `inbox_ops:inbox_proposal`, `update`
- `api/proposals/[id]/actions/[actionId]/route.ts` (PATCH) — `inbox_ops:inbox_proposal_action`, `update`
- `api/proposals/[id]/accept-all/route.ts` (POST) — `inbox_ops:inbox_proposal`, `custom`
- `api/emails/[id]/route.ts` (DELETE) — `inbox_ops:inbox_email`, `delete`

For each route the guard is validated **before** the mutation (returns the structured rejection body/status when the guard denies) and the after-success hook runs **only** after a confirmed successful write (e.g. the email DELETE skips the hook when `nativeUpdate` affected 0 rows). The guard helpers are no-ops when no `crudMutationGuardService` is registered, so behavior is unchanged where the guard is absent.

## Tests
- New `api/__tests__/mutation-guards.test.ts` (9 cases) proves, for all four routes, that the guard is validated before mutation, the after-success hook runs only after a successful write, a guard rejection returns its status and skips the mutation, and the already-deleted email path skips the after-success hook.
- Full `inbox_ops` suite: 30 suites / 367 tests pass.
- `yarn typecheck` passes.

## Backward Compatibility
No contract surface changes. Routes, response shapes, ACL features, and event IDs are unchanged; the guard hooks are additive and degrade to no-ops when the guard service is not registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)