### PR TITLE
perf(feature_toggles): paginate override list in the database and avoid O(n²) merge (#3242)

### DIFF
--- a/packages/core/src/modules/feature_toggles/lib/__tests__/queries.test.ts
+++ b/packages/core/src/modules/feature_toggles/lib/__tests__/queries.test.ts
@@ -9,29 +9,20 @@ describe('getOverrides', () => {
 
     const mockTenant1 = { id: 'tenant-1', name: 'Tenant 1' } as Tenant
 
-    const mockToggle1 = {
+    const makeToggle = (overrides: Partial<FeatureToggle>): FeatureToggle => ({
         id: 'toggle-1',
         identifier: 'toggle.one',
         name: 'Toggle One',
         category: 'cat1',
         defaultValue: false,
         type: 'boolean',
-        failMode: 'fail_closed',
         createdAt: new Date(),
         updatedAt: new Date(),
-    } as unknown as FeatureToggle
+        ...overrides,
+    } as unknown as FeatureToggle)
 
-    const mockToggle2 = {
-        id: 'toggle-2',
-        identifier: 'toggle.two',
-        name: 'Toggle Two',
-        category: 'cat2',
-        defaultValue: false,
-        type: 'boolean',
-        failMode: 'fail_closed',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-    } as unknown as FeatureToggle
+    const mockToggle1 = makeToggle({ id: 'toggle-1', identifier: 'toggle.one', name: 'Toggle One', category: 'cat1' })
+    const mockToggle2 = makeToggle({ id: 'toggle-2', identifier: 'toggle.two', name: 'Toggle Two', category: 'cat2' })
 
     const mockOverride1 = {
         id: 'override-1',
@@ -43,10 +34,12 @@ describe('getOverrides', () => {
     beforeEach(() => {
         em = {
             find: jest.fn(),
+            count: jest.fn(),
         } as unknown as EntityManager
     })
 
-    it('should return combined toggles and overrides with inheritance', async () => {
+    it('should map toggles to overrides using an O(1) lookup map', async () => {
+        (em.count as jest.Mock).mockResolvedValueOnce(2);
         (em.find as jest.Mock).mockResolvedValueOnce([mockToggle1, mockToggle2]);
         (em.find as jest.Mock).mockResolvedValueOnce([mockOverride1]);
 
@@ -56,21 +49,25 @@ describe('getOverrides', () => {
 
         const item1 = result.items.find((i) => i.toggleId === 'toggle-1')
         expect(item1).toMatchObject({
+            id: 'override-1',
             toggleId: 'toggle-1',
             tenantId: 'tenant-1',
+            isOverride: true,
         })
 
         const item2 = result.items.find((i) => i.toggleId === 'toggle-2')
         expect(item2).toMatchObject({
+            id: '',
             toggleId: 'toggle-2',
             tenantId: 'tenant-1',
+            isOverride: false,
         })
 
         expect(result.total).toBe(2)
     })
 
-    it('should apply filters to global toggles query', async () => {
-        (em.find as jest.Mock).mockResolvedValueOnce([]);
+    it('should apply filters to both the count and the toggle page query', async () => {
+        (em.count as jest.Mock).mockResolvedValueOnce(0);
         (em.find as jest.Mock).mockResolvedValueOnce([]);
 
         const query: GetOverridesQuery = {
@@ -82,51 +79,82 @@ describe('getOverrides', () => {
 
         await getOverrides(em, mockTenant1, query)
 
-        const findCalls = (em.find as jest.Mock).mock.calls
-        const toggleFilter = findCalls[0][1] as Record<string, unknown>
-
-        expect(toggleFilter).toEqual({
+        const expectedFilter = {
             deletedAt: null,
             category: { $ilike: '%cat1%' },
             name: { $ilike: '%One%' },
-        })
+        }
+
+        const countCall = (em.count as jest.Mock).mock.calls[0]
+        expect(countCall[1]).toEqual(expectedFilter)
+
+        const findCall = (em.find as jest.Mock).mock.calls[0]
+        expect(findCall[1]).toEqual(expectedFilter)
     })
 
-    it('should paginate results', async () => {
-        const manyToggles = Array.from({ length: 30 }).map((_, i) => ({
-            id: `t-${i}`,
-            identifier: `t.${i}`,
-            defaultValue: false,
-            type: 'boolean',
-            failMode: 'fail_closed',
-            createdAt: new Date(),
-            updatedAt: new Date(),
-        } as unknown as FeatureToggle));
+    it('should not query overrides when the toggle page is empty', async () => {
+        (em.count as jest.Mock).mockResolvedValueOnce(0);
+        (em.find as jest.Mock).mockResolvedValueOnce([]);
 
-        (em.find as jest.Mock).mockResolvedValueOnce(manyToggles);
+        const result = await getOverrides(em, mockTenant1, { page: 1, pageSize: 25 })
+
+        expect(result.items).toHaveLength(0)
+        expect(em.find as jest.Mock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should push pagination into the database (limit + offset)', async () => {
+        const pageToggles = Array.from({ length: 10 }).map((_, i) =>
+            makeToggle({ id: `t-${i + 10}`, identifier: `t.${i + 10}`, name: `T ${i + 10}` }),
+        );
+
+        (em.count as jest.Mock).mockResolvedValueOnce(30);
+        (em.find as jest.Mock).mockResolvedValueOnce(pageToggles);
         (em.find as jest.Mock).mockResolvedValueOnce([]);
 
         const result = await getOverrides(em, mockTenant1, { page: 2, pageSize: 10 })
 
         expect(result.total).toBe(30)
-        expect(result.items).toHaveLength(10)
+        expect(result.totalPages).toBe(3)
         expect(result.page).toBe(2)
-        expect(result.items[0].toggleId).toBe('t-10')
+        expect(result.items).toHaveLength(10)
+
+        const findOptions = (em.find as jest.Mock).mock.calls[0][2]
+        expect(findOptions).toMatchObject({ limit: 10, offset: 10 })
     })
 
-
-    it('should sort results locally', async () => {
-        (em.find as jest.Mock).mockResolvedValueOnce([mockToggle1, mockToggle2]);
-        (em.find as jest.Mock).mockResolvedValueOnce([]);
-        (em.find as jest.Mock).mockResolvedValueOnce([mockToggle1, mockToggle2]);
+    it('should return correct totals independent of the current page size', async () => {
+        (em.count as jest.Mock).mockResolvedValueOnce(95);
+        (em.find as jest.Mock).mockResolvedValueOnce([mockToggle1]);
         (em.find as jest.Mock).mockResolvedValueOnce([]);
 
-        const resultAsc = await getOverrides(em, mockTenant1, { sortField: 'name', sortDir: 'asc', page: 1, pageSize: 25 })
-        expect(resultAsc.items[0].name).toBe('Toggle One')
-        expect(resultAsc.items[1].name).toBe('Toggle Two')
+        const result = await getOverrides(em, mockTenant1, { page: 4, pageSize: 25 })
 
-        const resultDesc = await getOverrides(em, mockTenant1, { sortField: 'name', sortDir: 'desc', page: 1, pageSize: 25 })
-        expect(resultDesc.items[0].name).toBe('Toggle Two')
-        expect(resultDesc.items[1].name).toBe('Toggle One')
+        expect(result.total).toBe(95)
+        expect(result.totalPages).toBe(4)
+    })
+
+    it('should push sorting into the database with a deterministic id tiebreaker', async () => {
+        (em.count as jest.Mock).mockResolvedValueOnce(0);
+        (em.find as jest.Mock).mockResolvedValueOnce([]);
+
+        await getOverrides(em, mockTenant1, { sortField: 'name', sortDir: 'desc', page: 1, pageSize: 25 })
+
+        const findOptions = (em.find as jest.Mock).mock.calls[0][2]
+        expect(findOptions.orderBy).toEqual({ name: 'DESC', id: 'ASC' })
+    })
+
+    it('should ignore non-sortable sort fields but keep the id tiebreaker', async () => {
+        (em.count as jest.Mock).mockResolvedValueOnce(0);
+        (em.find as jest.Mock).mockResolvedValueOnce([]);
+
+        await getOverrides(em, mockTenant1, {
+            sortField: 'overrideState',
+            sortDir: 'asc',
+            page: 1,
+            pageSize: 25,
+        } as unknown as GetOverridesQuery)
+
+        const findOptions = (em.find as jest.Mock).mock.calls[0][2]
+        expect(findOptions.orderBy).toEqual({ id: 'ASC' })
     })
 })

--- a/packages/core/src/modules/feature_toggles/lib/queries.ts
+++ b/packages/core/src/modules/feature_toggles/lib/queries.ts
@@ -1,4 +1,4 @@
-import { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
+import { EntityManager, FilterQuery, QueryOrder } from '@mikro-orm/postgresql'
 import { FeatureToggle, FeatureToggleOverride } from '../data/entities'
 import { Tenant } from '@open-mercato/core/modules/directory/data/entities'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
@@ -28,6 +28,8 @@ export type GetOverridesQuery = {
     pageSize?: number
 }
 
+const SORTABLE_FIELDS = new Set<keyof FeatureToggle>(['identifier', 'name', 'category'])
+
 type GetOverridesResult = {
     items: OverrideListResponse[]
     total: number
@@ -56,76 +58,55 @@ export async function getOverrides(
         filters.identifier = { $ilike: `%${escapeLikePattern(query.identifier)}%` }
     }
 
-    const globalToggles = await em.find(FeatureToggle, filters)
+    const page = query.page ?? 1
+    const pageSize = query.pageSize ?? 25
+    const offset = (page - 1) * pageSize
 
-    const overrides = await em.find(FeatureToggleOverride, {
-        tenantId: tenant.id,
-        toggle: { id: { $in: globalToggles.map((toggle) => toggle.id) } },
+    const direction = query.sortDir === 'desc' ? QueryOrder.DESC : QueryOrder.ASC
+    const orderBy: Partial<Record<keyof FeatureToggle, QueryOrder>> = {}
+    if (query.sortField && SORTABLE_FIELDS.has(query.sortField as keyof FeatureToggle)) {
+        orderBy[query.sortField as keyof FeatureToggle] = direction
+    }
+    orderBy.id = QueryOrder.ASC
+
+    const totalItems = await em.count(FeatureToggle, filters)
+
+    const globalToggles = await em.find(FeatureToggle, filters, {
+        orderBy,
+        limit: pageSize,
+        offset,
     })
 
-    const response: OverrideListResponse[] = []
+    const overrides = globalToggles.length
+        ? await em.find(FeatureToggleOverride, {
+              tenantId: tenant.id,
+              toggle: { id: { $in: globalToggles.map((toggle) => toggle.id) } },
+          })
+        : []
 
-    globalToggles.forEach((toggle) => {
-        const override = overrides.find((o) => o.toggle.id === toggle.id)
-        if (override) {
-            response.push({
-                id: override?.id ?? '',
-                toggleId: toggle.id,
-                tenantName: tenant.name,
-                tenantId: tenant.id,
-                identifier: toggle.identifier,
-                name: toggle.name,
-                category: toggle.category ?? '',
-                isOverride: true,
-            })
-        } else {
-            response.push({
-                id: '',
-                toggleId: toggle.id,
-                tenantName: tenant.name,
-                tenantId: tenant.id,
-                identifier: toggle.identifier,
-                name: toggle.name,
-                category: toggle.category ?? '',
-                isOverride: false,
-            })
+    const overridesByToggleId = new Map<string, FeatureToggleOverride>()
+    for (const override of overrides) {
+        overridesByToggleId.set(override.toggle.id, override)
+    }
+
+    const items: OverrideListResponse[] = globalToggles.map((toggle) => {
+        const override = overridesByToggleId.get(toggle.id)
+        return {
+            id: override?.id ?? '',
+            toggleId: toggle.id,
+            tenantName: tenant.name,
+            tenantId: tenant.id,
+            identifier: toggle.identifier,
+            name: toggle.name,
+            category: toggle.category ?? '',
+            isOverride: Boolean(override),
         }
     })
 
-    if (query.sortField && query.sortDir) {
-        const sortField = query.sortField
-        const sortDir = query.sortDir
-
-        response.sort((a, b) => {
-            let aValue: any = a[sortField as keyof typeof a]
-            let bValue: any = b[sortField as keyof typeof b]
-
-
-
-            if (typeof aValue === 'string' && typeof bValue === 'string') {
-                const comparison = aValue.localeCompare(bValue)
-                return sortDir === 'asc' ? comparison : -comparison
-            }
-
-            if (typeof aValue === 'number' && typeof bValue === 'number') {
-                return sortDir === 'asc' ? aValue - bValue : bValue - aValue
-            }
-
-            return 0
-        })
-    }
-
-    const totalItems = response.length
-    const page = query.page ?? 1
-    const pageSize = query.pageSize ?? 25
     const totalPages = Math.ceil(totalItems / pageSize)
-    const startIndex = (page - 1) * pageSize
-    const endIndex = startIndex + pageSize
-
-    const paginatedItems = response.slice(startIndex, endIndex)
 
     return {
-        items: paginatedItems,
+        items,
         total: totalItems,
         totalPages,
         page,


### PR DESCRIPTION
Fixes #3242

## Problem
The feature-toggle override list (`getOverrides` in `packages/core/src/modules/feature_toggles/lib/queries.ts`) loaded every matching global toggle and every matching tenant override, merged them in memory with a repeated `.find()` inside the toggle loop, then sorted and paginated the assembled array in process. This does not scale: every page request paid for the full matching dataset, the merge was O(toggles × overrides), and pagination happened after the expensive work rather than in the database.

## Root Cause
- All matching `FeatureToggle` rows were loaded with `em.find` (no `limit`/`offset`).
- All matching overrides were loaded, then `overrides.find(...)` ran once per toggle (O(n²)).
- The full response array was sorted in memory and sliced for pagination.

## What Changed
- Push the total count (`em.count`), ordering, `limit`, and `offset` into the database. `FeatureToggle` is the driving table and owns every filter/sort field (`identifier`, `name`, `category`).
- Fetch overrides only for the current page of toggle ids, and build an override lookup `Map` keyed by toggle id so the merge is O(n) with O(1) lookups.
- Skip the overrides query entirely when the toggle page is empty.
- Add a deterministic `id` tiebreaker to `orderBy` so pagination is stable across pages even when the sort key has duplicate/null values (the old code applied no ordering when no sort field was given, which made paging non-deterministic).
- Response contract (`items`, `total`, `totalPages`, `page`, `pageSize`, `raw`) is unchanged.

## Tests
- Rewrote `packages/core/src/modules/feature_toggles/lib/__tests__/queries.test.ts` to cover: override-map merge correctness, filters applied to both the count and the page query, no overrides query on an empty page, DB-pushed pagination (`limit`/`offset` and totals spanning multiple pages), totals independent of page size, sort pushdown with the `id` tiebreaker, and non-sortable sort fields being ignored.
- `yarn workspace @open-mercato/core test src/modules/feature_toggles/` — 58/58 pass.
- `yarn workspace @open-mercato/core typecheck` — clean.
- `yarn i18n:check-sync` — in sync. ESLint on the changed files — clean.

## Backward Compatibility
- No contract surface changes: `getOverrides` signature and return type are unchanged, the API response shape is unchanged, and tenant scoping on overrides is preserved.
- Behavioral note: with no explicit sort, results are now deterministically ordered by `id`; explicit sorting now uses database collation ordering instead of JS `localeCompare`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)