### PR TITLE
fix(feature_toggles): align override list OpenAPI schema with live response (#3243)

### DIFF
--- a/packages/core/src/modules/feature_toggles/api/__tests__/override-list-openapi-schema.test.ts
+++ b/packages/core/src/modules/feature_toggles/api/__tests__/override-list-openapi-schema.test.ts
@@ -1,0 +1,98 @@
+import { EntityManager } from '@mikro-orm/postgresql'
+import { getOverrides } from '../../lib/queries'
+import { FeatureToggle, FeatureToggleOverride } from '../../data/entities'
+import { Tenant } from '@open-mercato/core/modules/directory/data/entities'
+import {
+  featureToggleOverrideSchema,
+  featureToggleOverrideListResponseSchema,
+} from '../openapi'
+
+describe('feature toggle override list OpenAPI schema', () => {
+  let em: EntityManager
+
+  const tenant = { id: '11111111-1111-4111-8111-111111111111', name: 'Tenant 1' } as Tenant
+
+  const overriddenToggle = {
+    id: '22222222-2222-4222-8222-222222222222',
+    identifier: 'toggle.overridden',
+    name: 'Overridden Toggle',
+    category: 'cat1',
+    defaultValue: false,
+    type: 'boolean',
+    failMode: 'fail_closed',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as unknown as FeatureToggle
+
+  const inheritedToggle = {
+    id: '33333333-3333-4333-8333-333333333333',
+    identifier: 'toggle.inherited',
+    name: 'Inherited Toggle',
+    category: 'cat2',
+    defaultValue: false,
+    type: 'boolean',
+    failMode: 'fail_closed',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as unknown as FeatureToggle
+
+  const override = {
+    id: '44444444-4444-4444-8444-444444444444',
+    toggle: { id: overriddenToggle.id },
+    tenantId: tenant.id,
+    value: undefined,
+  } as unknown as FeatureToggleOverride
+
+  beforeEach(() => {
+    em = {
+      find: jest.fn(),
+    } as unknown as EntityManager
+  })
+
+  it('documents the live response shape for both override and inherited rows', async () => {
+    (em.find as jest.Mock).mockResolvedValueOnce([overriddenToggle, inheritedToggle]);
+    (em.find as jest.Mock).mockResolvedValueOnce([override])
+
+    const result = await getOverrides(em, tenant, { page: 1, pageSize: 25 })
+
+    const overrideRow = result.items.find((item) => item.toggleId === overriddenToggle.id)
+    const inheritedRow = result.items.find((item) => item.toggleId === inheritedToggle.id)
+
+    expect(overrideRow).toMatchObject({ id: override.id, isOverride: true })
+    expect(inheritedRow).toMatchObject({ id: '', isOverride: false })
+
+    // Each live row must validate against the documented OpenAPI row schema,
+    // including the inherited empty-string `id` sentinel.
+    for (const row of result.items) {
+      expect(featureToggleOverrideSchema.safeParse(row).success).toBe(true)
+    }
+
+    const listResponse = {
+      items: result.items,
+      total: result.total,
+      totalPages: result.totalPages,
+      page: result.page,
+      pageSize: result.pageSize,
+      isSuperAdmin: false,
+    }
+
+    expect(featureToggleOverrideListResponseSchema.safeParse(listResponse).success).toBe(true)
+  })
+
+  it('rejects the previously documented but never-returned fields', () => {
+    const staleRow = {
+      id: '55555555-5555-4555-8555-555555555555',
+      toggleId: '66666666-6666-4666-8666-666666666666',
+      overrideState: 'enabled',
+      defaultState: true,
+      identifier: 'toggle.stale',
+      name: 'Stale Toggle',
+      category: 'cat3',
+      tenantName: 'Tenant 1',
+      tenantId: '11111111-1111-4111-8111-111111111111',
+    }
+
+    // The stale row omits the live `isOverride` field the schema now requires.
+    expect(featureToggleOverrideSchema.safeParse(staleRow).success).toBe(false)
+  })
+})

--- a/packages/core/src/modules/feature_toggles/api/openapi.ts
+++ b/packages/core/src/modules/feature_toggles/api/openapi.ts
@@ -7,6 +7,7 @@ import {
     overrideListQuerySchema,
     getToggleOverrideQuerySchema,
     featureToggleOverrideResponseSchema,
+    overrideRowIdSchema,
 } from '../data/validators'
 
 export const featureTogglesTag = 'Feature Toggles'
@@ -42,16 +43,20 @@ export const featureToggleListResponseSchema = z.object({
 
 export { toggleCreateSchema, toggleUpdateSchema }
 
+// Documents the actual override-list row shape returned by GET /api/feature_toggles/overrides
+// (see lib/queries.ts → getOverrides). Each row reports whether the tenant has a
+// per-tenant override via `isOverride`; inherited rows (no override) carry an
+// empty-string `id` sentinel instead of a UUID, hence `overrideRowIdSchema`.
 export const featureToggleOverrideSchema = z
     .object({
-        id: z.string().uuid(),
+        id: overrideRowIdSchema,
         toggleId: z.string().uuid(),
-        overrideState: z.enum(['enabled', 'disabled', 'inherit']),
+        tenantName: z.string(),
+        tenantId: z.string().uuid(),
         identifier: z.string(),
         name: z.string(),
-        category: z.string().nullable().optional(),
-        defaultState: z.boolean(),
-        tenantName: z.string().nullable().optional(),
+        category: z.string(),
+        isOverride: z.boolean(),
     })
     .passthrough()
 

--- a/packages/core/src/modules/feature_toggles/data/validators.ts
+++ b/packages/core/src/modules/feature_toggles/data/validators.ts
@@ -90,8 +90,13 @@ export const featureToggleSchema = z.object({
   updatedAt: z.string().optional(),
 })
 
+// Inherited rows (no per-tenant override) intentionally carry an empty-string
+// `id` sentinel instead of a UUID, so the row id must accept both a UUID (real
+// override rows) and the empty inherited sentinel. See lib/queries.ts.
+export const overrideRowIdSchema = z.union([z.string().uuid(), z.literal('')])
+
 export const overrideListResponseSchema = z.object({
-  id: z.string().uuid(),
+  id: overrideRowIdSchema,
   toggleId: z.string().uuid(),
   tenantName: z.string(),
   tenantId: z.string().uuid(),


### PR DESCRIPTION
Fixes #3243

## Problem
The OpenAPI schema for the feature-toggle override list (`GET /api/feature_toggles/overrides`) did not match the live response. The documented row schema advertised `overrideState`, `defaultState`, and a strict UUID `id`, while the route actually returns rows with `isOverride` and an empty-string `id` sentinel for inherited rows. Generated docs/clients could therefore expect fields that never arrive, reject valid inherited rows, or miss the actual `isOverride` field the UI consumes.

## Root Cause
- `api/openapi.ts` `featureToggleOverrideSchema` documented `overrideState`/`defaultState` (never returned) and required `id` as a UUID.
- `data/validators.ts` `overrideListResponseSchema` required `id: z.string().uuid()`, which rejects the empty-string inherited sentinel produced by `lib/queries.ts` `getOverrides`.

## What Changed
- Rewrote the OpenAPI `featureToggleOverrideSchema` to match the live row shape: `id`, `toggleId`, `tenantName`, `tenantId`, `identifier`, `name`, `category`, `isOverride`. Dropped the never-returned `overrideState`/`defaultState`.
- Added `overrideRowIdSchema = z.union([z.string().uuid(), z.literal('')])` in `data/validators.ts` and applied it to both the live `overrideListResponseSchema` and the documented OpenAPI schema, so inherited rows (`id: ''`) validate while real override rows keep UUID `id`.

## Tests
- New `api/__tests__/override-list-openapi-schema.test.ts` runs `getOverrides` with a mixed override + inherited dataset and asserts every live row plus the full list envelope validate against the documented OpenAPI schemas (including the inherited `id: ''` sentinel). It also asserts the previously-documented stale shape (missing `isOverride`) is rejected.
- Full `feature_toggles` unit suite green (57 tests). `yarn typecheck` passes across all packages.

## Backward Compatibility
- No runtime API behavior change: the route already returned this shape; only the documentation/validator schema is corrected to match it.
- The `id` change is strictly more permissive (UUID *or* empty string), so no existing valid consumer is broken.
- Removed schema fields (`overrideState`, `defaultState`) were never present in the live response, so no client could have relied on them with real data. The schema retains `.passthrough()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)