### PR TITLE
fix(inbox_ops): make draft reply sends idempotent before calling Resend (#3248)

### DIFF
--- a/packages/core/src/modules/inbox_ops/api/proposals/[id]/replies/[replyId]/send/__tests__/route.test.ts
+++ b/packages/core/src/modules/inbox_ops/api/proposals/[id]/replies/[replyId]/send/__tests__/route.test.ts
@@ -22,6 +22,7 @@ jest.mock('@open-mercato/shared/lib/auth/server', () => ({
 const mockEm = {
   fork: jest.fn(),
   flush: jest.fn(),
+  nativeUpdate: jest.fn(),
 }
 
 const mockContainer = {
@@ -106,6 +107,7 @@ describe('POST /api/inbox_ops/proposals/[id]/replies/[replyId]/send', () => {
     jest.clearAllMocks()
     mockEm.fork.mockReturnValue(mockEm)
     mockEm.flush.mockResolvedValue(undefined)
+    mockEm.nativeUpdate.mockResolvedValue(1)
     mockEmitInboxOpsEvent.mockResolvedValue(undefined)
     mockCreateMessageRecordForReply.mockResolvedValue(null)
     process.env = {
@@ -269,6 +271,32 @@ describe('POST /api/inbox_ops/proposals/[id]/replies/[replyId]/send', () => {
     expect(mockResendSend).not.toHaveBeenCalled()
   })
 
+  it('claims the send before calling Resend so a concurrent request cannot double-send', async () => {
+    setupHappyPath()
+
+    const response = await POST(makeRequest())
+
+    expect(response.status).toBe(200)
+    expect(mockEm.nativeUpdate).toHaveBeenCalled()
+    // The claim must be issued before the external email provider is invoked.
+    expect(mockEm.nativeUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      mockResendSend.mock.invocationCallOrder[0],
+    )
+  })
+
+  it('returns 409 without calling Resend when the send is already claimed by a concurrent request', async () => {
+    setupHappyPath()
+    mockEm.nativeUpdate.mockResolvedValueOnce(0)
+
+    const response = await POST(makeRequest())
+    const payload = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(payload.error).toContain('already in progress')
+    expect(mockResendSend).not.toHaveBeenCalled()
+    expect(mockEm.flush).not.toHaveBeenCalled()
+  })
+
   it('returns 502 when Resend fails', async () => {
     setupHappyPath()
     mockResendSend.mockResolvedValueOnce({
@@ -281,6 +309,20 @@ describe('POST /api/inbox_ops/proposals/[id]/replies/[replyId]/send', () => {
 
     expect(response.status).toBe(502)
     expect(payload.error).toContain('Failed to send email')
+  })
+
+  it('releases the send claim when Resend fails so the reply can be retried', async () => {
+    setupHappyPath()
+    mockResendSend.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'Invalid API key' },
+    })
+
+    const response = await POST(makeRequest())
+
+    expect(response.status).toBe(502)
+    // The claim (nativeUpdate #1) plus the release (nativeUpdate #2) must both run.
+    expect(mockEm.nativeUpdate).toHaveBeenCalledTimes(2)
   })
 
   it('returns 401 when not authenticated', async () => {

--- a/packages/core/src/modules/inbox_ops/api/proposals/[id]/replies/[replyId]/send/route.ts
+++ b/packages/core/src/modules/inbox_ops/api/proposals/[id]/replies/[replyId]/send/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { raw } from '@mikro-orm/core'
 import { Resend } from 'resend'
 import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import { resolveDefaultEmailFromAddress } from '@open-mercato/shared/lib/email/config'
@@ -111,6 +112,57 @@ export async function POST(req: Request) {
       headers['References'] = references.join(' ')
     }
 
+    // Atomically claim the send right before calling the external email provider so
+    // two concurrent requests cannot both deliver the same reply. The claim only
+    // succeeds when neither replySentAt nor replySendClaimedAt is already set in the
+    // metadata; a losing request gets 0 rows back and is rejected with 409.
+    const sendClaimedAt = new Date().toISOString()
+    const claimed = await ctx.em.nativeUpdate(
+      InboxProposalAction,
+      {
+        id: action.id,
+        proposalId: proposal.id,
+        actionType: 'draft_reply',
+        organizationId: ctx.organizationId,
+        tenantId: ctx.tenantId,
+        deletedAt: null,
+        status: 'executed',
+        [raw(`coalesce("metadata"->>'replySentAt', '')`)]: '',
+        [raw(`coalesce("metadata"->>'replySendClaimedAt', '')`)]: '',
+      },
+      {
+        metadata: raw(
+          `coalesce("metadata", '{}'::jsonb) || jsonb_build_object('replySendClaimedAt', ?::text)`,
+          [sendClaimedAt],
+        ),
+      },
+    )
+
+    if (claimed === 0) {
+      return NextResponse.json(
+        { error: 'Reply send is already in progress or has been sent for this action' },
+        { status: 409 },
+      )
+    }
+
+    const releaseSendClaim = async () => {
+      try {
+        await ctx.em.nativeUpdate(
+          InboxProposalAction,
+          {
+            id: action.id,
+            organizationId: ctx.organizationId,
+            tenantId: ctx.tenantId,
+            [raw(`coalesce("metadata"->>'replySentAt', '')`)]: '',
+            [raw(`("metadata"->>'replySendClaimedAt')`)]: sendClaimedAt,
+          },
+          { metadata: raw(`"metadata" - 'replySendClaimedAt'`) },
+        )
+      } catch (releaseError) {
+        console.error('[inbox_ops:reply:send] Failed to release send claim:', releaseError)
+      }
+    }
+
     const resend = new Resend(apiKey)
     const { data: sendData, error: sendError } = await resend.emails.send({
       to: toAddress,
@@ -121,6 +173,7 @@ export async function POST(req: Request) {
     })
 
     if (sendError) {
+      await releaseSendClaim()
       const errorMessage = sendError.message || 'Unknown error'
       return NextResponse.json({ error: `Failed to send email: ${errorMessage}` }, { status: 502 })
     }
@@ -182,7 +235,7 @@ export const openApi: OpenApiRouteDoc = {
         { status: 200, description: 'Reply sent successfully' },
         { status: 400, description: 'Missing required payload fields' },
         { status: 404, description: 'Reply action not found' },
-        { status: 409, description: 'Action in invalid state for sending' },
+        { status: 409, description: 'Action in invalid state for sending, or a send is already in progress / completed for this reply' },
         { status: 502, description: 'Email delivery failed' },
         { status: 503, description: 'Email service not configured or disabled' },
       ],


### PR DESCRIPTION
Fixes #3248

## Problem
Sending a draft reply was not idempotent before the external Resend call. Two concurrent POSTs could both pass the `replySentAt` pre-check and deliver the same email before either request recorded the sent metadata.

## Root Cause
The handler only read `action.metadata.replySentAt` (a non-atomic in-memory check), then called `resend.emails.send(...)`, and only persisted `replySentAt` after Resend succeeded. Nothing reserved the send between the check and the external call, leaving a TOCTOU race where duplicate requests both delivered email.

## What Changed
- `packages/core/src/modules/inbox_ops/api/proposals/[id]/replies/[replyId]/send/route.ts`
  - Added an **atomic single-flight claim** immediately before the Resend call using `em.nativeUpdate(...)` (matching the existing claim pattern in `inbox_ops/lib/executionEngine.ts` and `subscribers/extractionWorker.ts`). The guarded update writes a `replySendClaimedAt` marker into the `jsonb` metadata **only when** neither `replySentAt` nor `replySendClaimedAt` is already set. The losing request gets `0` rows back and is rejected with `409` before any email is sent.
  - The claim is **released** (marker removed) when Resend reports an error, so a genuine failure can be retried.
  - On success the existing `replySentAt` / `sentMessageId` metadata behavior is preserved (the final flush overwrites the claim marker with the authoritative sent metadata). After a real delivery the claim is intentionally retained even if a later step throws, so a duplicate send can never occur.
  - Updated the `409` OpenAPI description to cover the in-progress/already-sent case.
- The claim filter is tenant/organization-scoped (`tenantId`, `organizationId`, `deletedAt: null`, `status: 'executed'`).

## Tests
- `packages/core/src/modules/inbox_ops/api/proposals/[id]/replies/[replyId]/send/__tests__/route.test.ts`
  - claim is issued before Resend is invoked (ordering assertion)
  - a concurrent request whose claim returns `0` gets `409` and never calls Resend or flushes
  - the claim is released (second `nativeUpdate`) when Resend fails
- Full `@open-mercato/core` suite: 740 suites / 6058 tests passing. `yarn workspace @open-mercato/core typecheck` clean. `yarn i18n:check-sync` clean.

## Backward Compatibility
- No contract surface changes. Same route, request, and success response shape. The `409` response simply covers an additional concurrency case (additive). No event IDs, DI names, ACL features, or DB schema changed (the claim reuses the existing `metadata` jsonb column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)