### PR TITLE
fix(integrations): guard manual health-check mutations (#3254)

### DIFF
--- a/packages/core/src/modules/integrations/api/[id]/health/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/health/route.ts
@@ -4,6 +4,11 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getIntegration } from '@open-mercato/shared/modules/integrations/types'
 import type { IntegrationHealthService } from '../../../lib/health-service'
+import {
+  resolveUserFeatures,
+  runIntegrationMutationGuardAfterSuccess,
+  runIntegrationMutationGuards,
+} from '../../guards'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -37,12 +42,42 @@ export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }
   }
 
   const container = await createRequestContainer()
+  const guardResult = await runIntegrationMutationGuards(
+    container,
+    {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+      userId: auth.sub ?? '',
+      resourceKind: 'integrations.integration',
+      resourceId: integration.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: { integrationId: integration.id },
+    },
+    resolveUserFeatures(auth),
+  )
+  if (!guardResult.ok) {
+    return NextResponse.json(guardResult.errorBody ?? { error: 'Operation blocked by guard' }, { status: guardResult.errorStatus ?? 422 })
+  }
+
   const healthService = container.resolve('integrationHealthService') as IntegrationHealthService
 
   const result = await healthService.runHealthCheck(
     integration.id,
     { organizationId: auth.orgId as string, tenantId: auth.tenantId },
   )
+
+  await runIntegrationMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+    tenantId: auth.tenantId,
+    organizationId: auth.orgId,
+    userId: auth.sub ?? '',
+    resourceKind: 'integrations.integration',
+    resourceId: integration.id,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+  })
 
   return NextResponse.json({
     status: result.status,

--- a/packages/core/src/modules/integrations/api/__tests__/health-route.test.ts
+++ b/packages/core/src/modules/integrations/api/__tests__/health-route.test.ts
@@ -1,0 +1,108 @@
+/** @jest-environment node */
+
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getIntegration } from '@open-mercato/shared/modules/integrations/types'
+import {
+  resolveUserFeatures,
+  runIntegrationMutationGuardAfterSuccess,
+  runIntegrationMutationGuards,
+} from '../guards'
+import { POST } from '../[id]/health/route'
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/modules/integrations/types', () => ({
+  ...jest.requireActual('@open-mercato/shared/modules/integrations/types'),
+  getIntegration: jest.fn(),
+}))
+
+jest.mock('../guards', () => ({
+  resolveUserFeatures: jest.fn(() => []),
+  runIntegrationMutationGuards: jest.fn(),
+  runIntegrationMutationGuardAfterSuccess: jest.fn(),
+}))
+
+function buildRequest(): Request {
+  return new Request('http://localhost/api/integrations/sync_akeneo/health', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('integrations health POST route — mutation guard contract', () => {
+  const runHealthCheckMock = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    runHealthCheckMock.mockReset()
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ tenantId: 't1', orgId: 'o1', sub: 'u1' })
+    ;(getIntegration as jest.Mock).mockReturnValue({ id: 'sync_akeneo', title: 'Akeneo PIM' })
+    ;(createRequestContainer as jest.Mock).mockResolvedValue({
+      resolve: (key: string) => {
+        if (key === 'integrationHealthService') {
+          return { runHealthCheck: runHealthCheckMock }
+        }
+        throw new Error(`unexpected resolve(${key})`)
+      },
+    })
+  })
+
+  it('blocks the health probe and after-success callbacks when a guard denies the mutation', async () => {
+    ;(runIntegrationMutationGuards as jest.Mock).mockResolvedValue({
+      ok: false,
+      errorStatus: 403,
+      errorBody: { error: 'Blocked by guard' },
+      afterSuccessCallbacks: [],
+    })
+
+    const response = await POST(buildRequest(), { params: { id: 'sync_akeneo' } })
+
+    expect(response.status).toBe(403)
+    const body = await response.json()
+    expect(body).toEqual({ error: 'Blocked by guard' })
+    expect(runHealthCheckMock).not.toHaveBeenCalled()
+    expect(runIntegrationMutationGuardAfterSuccess).not.toHaveBeenCalled()
+  })
+
+  it('runs the probe and after-success callbacks when guards pass', async () => {
+    const checkedAt = new Date('2026-06-19T00:00:00.000Z').toISOString()
+    ;(runIntegrationMutationGuards as jest.Mock).mockResolvedValue({
+      ok: true,
+      afterSuccessCallbacks: [{ guard: {}, metadata: null }],
+    })
+    runHealthCheckMock.mockResolvedValue({
+      status: 'healthy',
+      message: 'ok',
+      details: { foo: 'bar' },
+      latencyMs: 12,
+      checkedAt,
+    })
+
+    const response = await POST(buildRequest(), { params: { id: 'sync_akeneo' } })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toEqual({
+      status: 'healthy',
+      message: 'ok',
+      details: { foo: 'bar' },
+      latencyMs: 12,
+      checkedAt,
+    })
+    expect(runHealthCheckMock).toHaveBeenCalledWith('sync_akeneo', { organizationId: 'o1', tenantId: 't1' })
+
+    const guardCallOrder = (runIntegrationMutationGuards as jest.Mock).mock.invocationCallOrder[0]
+    const probeCallOrder = runHealthCheckMock.mock.invocationCallOrder[0]
+    const afterSuccessCallOrder = (runIntegrationMutationGuardAfterSuccess as jest.Mock).mock.invocationCallOrder[0]
+    expect(guardCallOrder).toBeLessThan(probeCallOrder)
+    expect(probeCallOrder).toBeLessThan(afterSuccessCallOrder)
+    expect(runIntegrationMutationGuardAfterSuccess).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Fixes #3254

## Problem
- The manual integration health-check API route (`POST /api/integrations/[id]/health`) mutates persisted integration state (`stateService.upsert`) and writes integration logs, but it bypassed the mutation guard lifecycle that every other integrations write route enforces.

## Root Cause
- `packages/core/src/modules/integrations/api/[id]/health/route.ts` called `healthService.runHealthCheck(...)` directly, without `runIntegrationMutationGuards` (before) or `runIntegrationMutationGuardAfterSuccess` (after). The neighboring `state`, `credentials`, and `version` routes all wire both.

## What Changed
- Wrapped the health-check route in the integrations mutation guard contract:
  - `runIntegrationMutationGuards(...)` runs **before** `runHealthCheck`; a blocked guard returns the guard's error body/status and the probe never runs.
  - `runIntegrationMutationGuardAfterSuccess(...)` runs **after** the probe (which performs the state/log writes) succeeds.
- The guard uses `operation: 'update'` and `resourceKind: 'integrations.integration'`, matching the sibling write routes.
- Auth (`integrations.manage`), tenant/organization scoping, the JSON response shape, and the health-check timeout behavior are all preserved — the change is purely additive guard wiring.

## Tests
- New `packages/core/src/modules/integrations/api/__tests__/health-route.test.ts`:
  - A denied guard returns the guard status/body, never calls `runHealthCheck`, and never runs after-success callbacks.
  - A passing guard runs the probe and after-success callbacks, returns the unchanged response shape, and enforces the guard → probe → after-success ordering.
- `yarn workspace @open-mercato/core test -- --testPathPattern "integrations/api/__tests__"` → 8 passed.
- `yarn workspace @open-mercato/core typecheck` → clean.

## Backward Compatibility
- No contract surface changes: API URL, response fields, ACL features, event IDs, DI names, and types are unchanged. Guard wiring is additive.