### PR TITLE
fix(inbox_ops): reload counts and settings when organization scope changes (#3251)

### DIFF
--- a/packages/core/src/modules/inbox_ops/backend/inbox-ops/__tests__/page.scope-reload.test.tsx
+++ b/packages/core/src/modules/inbox_ops/backend/inbox-ops/__tests__/page.scope-reload.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { act, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { emitOrganizationScopeChanged } from '@open-mercato/shared/lib/frontend/organizationEvents'
+import InboxOpsProposalsPage from '../page'
+
+type ApiResult<T> = { ok: boolean; result: T }
+
+const apiCallMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: async ({ operation }: { operation: () => Promise<unknown> }) => operation(),
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({
+    confirm: jest.fn(async () => true),
+    ConfirmDialogElement: null,
+  }),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+
+function okResult<T>(result: T): ApiResult<T> {
+  return { ok: true, result }
+}
+
+function configureApi(scope: { inboxAddress: string; pending: number }) {
+  apiCallMock.mockImplementation(async (url: string) => {
+    if (url.startsWith('/api/inbox_ops/proposals/counts')) {
+      return okResult({ pending: scope.pending, partial: 0, accepted: 0, rejected: 0 })
+    }
+    if (url.startsWith('/api/inbox_ops/settings')) {
+      return okResult({ settings: { inboxAddress: scope.inboxAddress } })
+    }
+    if (url.startsWith('/api/inbox_ops/proposals')) {
+      return okResult({ items: [], total: 0, page: 1, totalPages: 1 })
+    }
+    return okResult({})
+  })
+}
+
+beforeEach(() => {
+  apiCallMock.mockReset()
+})
+
+describe('InboxOpsProposalsPage scope reload', () => {
+  it('reloads counts and settings when the organization scope changes', async () => {
+    configureApi({ inboxAddress: 'org-a@inbox.example.com', pending: 0 })
+
+    renderWithProviders(<InboxOpsProposalsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('org-a@inbox.example.com')).toBeTruthy()
+    })
+
+    const countsCallsBefore = apiCallMock.mock.calls.filter(([url]) =>
+      typeof url === 'string' && url.startsWith('/api/inbox_ops/proposals/counts'),
+    ).length
+    const settingsCallsBefore = apiCallMock.mock.calls.filter(([url]) =>
+      typeof url === 'string' && url.startsWith('/api/inbox_ops/settings'),
+    ).length
+
+    configureApi({ inboxAddress: 'org-b@inbox.example.com', pending: 0 })
+
+    act(() => {
+      emitOrganizationScopeChanged({
+        organizationId: 'org-b',
+        tenantId: 'tenant-b',
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('org-b@inbox.example.com')).toBeTruthy()
+    })
+    expect(screen.queryByText('org-a@inbox.example.com')).toBeNull()
+
+    const countsCallsAfter = apiCallMock.mock.calls.filter(([url]) =>
+      typeof url === 'string' && url.startsWith('/api/inbox_ops/proposals/counts'),
+    ).length
+    const settingsCallsAfter = apiCallMock.mock.calls.filter(([url]) =>
+      typeof url === 'string' && url.startsWith('/api/inbox_ops/settings'),
+    ).length
+
+    expect(countsCallsAfter).toBeGreaterThan(countsCallsBefore)
+    expect(settingsCallsAfter).toBeGreaterThan(settingsCallsBefore)
+  })
+})

--- a/packages/core/src/modules/inbox_ops/backend/inbox-ops/page.tsx
+++ b/packages/core/src/modules/inbox_ops/backend/inbox-ops/page.tsx
@@ -148,6 +148,13 @@ export default function InboxOpsProposalsPage() {
     if (initialLoadComplete) loadProposals()
   }, [page, statusFilter, categoryFilter, search, scopeVersion]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  React.useEffect(() => {
+    if (initialLoadComplete) {
+      loadCounts()
+      loadSettings()
+    }
+  }, [scopeVersion]) // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleCopyAddress = React.useCallback(() => {
     if (settings?.inboxAddress) {
       navigator.clipboard.writeText(settings.inboxAddress)


### PR DESCRIPTION
Fixes #3251

## Problem
The InboxOps proposal list (`packages/core/src/modules/inbox_ops/backend/inbox-ops/page.tsx`) reloaded proposals when the organization scope changed, but left status counts and settings from the previous scope on screen. After switching scope the user could see stale status counts and the wrong inbox address.

## Root Cause
- The initial-load effect ran `Promise.all([loadProposals(), loadCounts(), loadSettings()])` once with an empty dependency array.
- The scope-reactive effect depended on `scopeVersion` but only called `loadProposals()`.
- `loadCounts` / `loadSettings` were scope-aware callbacks (they listed `scopeVersion` in their deps) but no effect re-invoked them when `scopeVersion` changed, so counts and the inbox address never refreshed for the new scope.

## What Changed
- Added a dedicated effect that reruns `loadCounts()` and `loadSettings()` whenever `scopeVersion` changes (gated on `initialLoadComplete`, mirroring the existing proposals effect). Each scope-dependent request now refreshes its own state, so visible counts and the inbox address update after a scope switch.

## Tests
- Added `packages/core/src/modules/inbox_ops/backend/inbox-ops/__tests__/page.scope-reload.test.tsx`: a jsdom React Testing Library test that renders the page, drives a real organization-scope change via `emitOrganizationScopeChanged`, and asserts the inbox address (settings) and the counts endpoint refresh for the new scope. Verified the test fails on the pre-fix code and passes with the fix.
- `yarn typecheck` (core) clean; lint clean (0 errors); inbox_ops backend test suite green.

## Backward Compatibility
- No contract surface changes. UI-only behavior fix in a single page component; no API routes, types, event IDs, DI keys, ACL features, DB schema, or generated files touched.