### PR TITLE
fix(integrations): wrap marketplace and bundle writes in useGuardedMutation (#3255)

### DIFF
--- a/packages/core/src/modules/integrations/backend/integrations/__tests__/marketplace-guarded-mutation.test.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/__tests__/marketplace-guarded-mutation.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+
+const runMutationMock = jest.fn()
+const apiCallMock = jest.fn()
+const flashMock = jest.fn()
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}))
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PageBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/card', () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, asChild, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }) => (
+    <button {...props}>{children}</button>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/primitives/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+jest.mock('@open-mercato/ui/primitives/spinner', () => ({
+  Spinner: () => <div>loading</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/FilterBar', () => ({
+  FilterBar: () => <div>filter-bar</div>,
+}))
+
+jest.mock('lucide-react', () => new Proxy({}, {
+  get: () => () => null,
+}))
+
+jest.mock('@open-mercato/ui/primitives/switch', () => ({
+  Switch: ({ checked, disabled, onCheckedChange }: { checked: boolean; disabled?: boolean; onCheckedChange: (checked: boolean) => void }) => (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+    >
+      toggle
+    </button>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+  withScopedApiRequestHeaders: <T,>(_headers: Record<string, string>, run: () => Promise<T>) => run(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: (...args: unknown[]) => runMutationMock(...args),
+    retryLastMutation: jest.fn(),
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: (...args: unknown[]) => flashMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 0,
+}))
+
+import IntegrationsMarketplacePage from '../page'
+
+const standaloneIntegration = {
+  id: 'gateway_stripe',
+  title: 'Stripe',
+  description: 'Payments',
+  category: 'payment',
+  isEnabled: false,
+  hasCredentials: true,
+  healthStatus: 'healthy' as const,
+  analytics: { lastActivityAt: null, totalCount: 0, errorCount: 0, errorRate: 0, dailyCounts: [0, 0, 0] },
+  updatedAt: '2026-06-01T00:00:00.000Z',
+}
+
+const listResponse = {
+  items: [standaloneIntegration],
+  bundles: [],
+  total: 1,
+  page: 1,
+  pageSize: 100,
+  totalPages: 1,
+}
+
+describe('Integrations marketplace — guarded mutation wiring', () => {
+  beforeEach(() => {
+    runMutationMock.mockReset()
+    apiCallMock.mockReset()
+    flashMock.mockReset()
+    apiCallMock.mockResolvedValue({ ok: true, result: listResponse })
+  })
+
+  it('routes the integration toggle through runMutation and updates local state on success', async () => {
+    runMutationMock.mockResolvedValue({ ok: true, result: null })
+
+    renderWithProviders(<IntegrationsMarketplacePage />)
+
+    const toggle = await screen.findByRole('switch')
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+
+    fireEvent.click(toggle)
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalledTimes(1))
+    const runArgs = runMutationMock.mock.calls[0][0]
+    expect(runArgs.mutationPayload).toMatchObject({ integrationId: 'gateway_stripe', isEnabled: true })
+    expect(runArgs.context).toMatchObject({ actionId: 'toggle-state', resourceId: 'gateway_stripe' })
+    expect(typeof runArgs.operation).toBe('function')
+
+    await waitFor(() => expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true'))
+    expect(flashMock).not.toHaveBeenCalled()
+  })
+
+  it('flashes an error and leaves local state unchanged when the guarded mutation reports failure', async () => {
+    runMutationMock.mockResolvedValue({ ok: false, result: null })
+
+    renderWithProviders(<IntegrationsMarketplacePage />)
+
+    const toggle = await screen.findByRole('switch')
+    fireEvent.click(toggle)
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(flashMock).toHaveBeenCalledWith('integrations.detail.stateError', 'error'))
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false')
+  })
+})

--- a/packages/core/src/modules/integrations/backend/integrations/bundle/[id]/__tests__/bundle-guarded-mutation.test.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/bundle/[id]/__tests__/bundle-guarded-mutation.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+
+const runMutationMock = jest.fn()
+const apiCallMock = jest.fn()
+const flashMock = jest.fn()
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}))
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/backend/integrations/bundle/payments_bundle',
+}))
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PageBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/detail', () => ({
+  LoadingMessage: ({ label }: { label: string }) => <div>{label}</div>,
+  ErrorMessage: ({ label }: { label: string }) => <div>{label}</div>,
+  RecordNotFoundState: ({ label }: { label: string }) => <div>{label}</div>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/switch', () => ({
+  Switch: ({ checked, disabled, onCheckedChange }: { checked: boolean; disabled?: boolean; onCheckedChange: (checked: boolean) => void }) => (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+    >
+      toggle
+    </button>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+  withScopedApiRequestHeaders: <T,>(_headers: Record<string, string>, run: () => Promise<T>) => run(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: (...args: unknown[]) => runMutationMock(...args),
+    retryLastMutation: jest.fn(),
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: (...args: unknown[]) => flashMock(...args),
+}))
+
+import BundleConfigPage from '../page'
+
+const bundleDetail = {
+  integration: { id: 'payments_bundle', title: 'Payments bundle', bundleId: 'payments_bundle' },
+  bundle: {
+    id: 'payments_bundle',
+    title: 'Payments bundle',
+    description: 'Shared payment credentials',
+    credentials: { fields: [{ key: 'apiKey', label: 'API Key', type: 'text', required: true }] },
+  },
+  bundleIntegrations: [
+    { id: 'gateway_stripe', title: 'Stripe', category: 'payment', isEnabled: false },
+  ],
+  state: { isEnabled: true },
+  hasCredentials: true,
+}
+
+function mockLoadResponses() {
+  apiCallMock.mockImplementation((url: string) => {
+    if (typeof url === 'string' && url.endsWith('/credentials')) {
+      return Promise.resolve({ ok: true, result: { credentials: { apiKey: 'existing' } } })
+    }
+    return Promise.resolve({ ok: true, result: bundleDetail })
+  })
+}
+
+describe('Integrations bundle — guarded mutation wiring', () => {
+  beforeEach(() => {
+    runMutationMock.mockReset()
+    apiCallMock.mockReset()
+    flashMock.mockReset()
+    mockLoadResponses()
+  })
+
+  it('routes the child integration toggle through runMutation and updates local state on success', async () => {
+    runMutationMock.mockResolvedValue({ ok: true, result: null })
+
+    renderWithProviders(<BundleConfigPage params={{ id: 'payments_bundle' }} />)
+
+    const toggle = await screen.findByRole('switch')
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+
+    fireEvent.click(toggle)
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalled())
+    const runArgs = runMutationMock.mock.calls[0][0]
+    expect(runArgs.mutationPayload).toMatchObject({ integrationId: 'gateway_stripe', isEnabled: true })
+    expect(runArgs.context).toMatchObject({ actionId: 'toggle-state', resourceId: 'gateway_stripe' })
+    expect(typeof runArgs.operation).toBe('function')
+
+    await waitFor(() => expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true'))
+  })
+
+  it('routes the shared credentials save through runMutation and flashes success', async () => {
+    runMutationMock.mockResolvedValue({ ok: true, result: null })
+
+    renderWithProviders(<BundleConfigPage params={{ id: 'payments_bundle' }} />)
+
+    const saveButton = await screen.findByText('integrations.detail.credentials.save')
+    fireEvent.click(saveButton)
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalled())
+    const saveCall = runMutationMock.mock.calls.find((call) => call[0]?.context?.actionId === 'save-credentials')
+    expect(saveCall).toBeTruthy()
+    expect(saveCall[0].mutationPayload).toMatchObject({ bundleId: 'payments_bundle' })
+    expect(typeof saveCall[0].operation).toBe('function')
+
+    await waitFor(() => expect(flashMock).toHaveBeenCalledWith('integrations.detail.credentials.saved', 'success'))
+  })
+})

--- a/packages/core/src/modules/integrations/backend/integrations/bundle/[id]/page.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/bundle/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type { CredentialFieldType, IntegrationCredentialField } from '@open-mercato/shared/modules/integrations/types'
@@ -88,6 +89,14 @@ export default function BundleConfigPage({ params }: BundleConfigPageProps) {
   const [isSavingCreds, setIsSavingCreds] = React.useState(false)
   const [togglingIds, setTogglingIds] = React.useState<Set<string>>(new Set())
 
+  const mutationContextId = React.useMemo(
+    () => `integrations.bundle:${bundleId ?? 'unknown'}`,
+    [bundleId],
+  )
+  const { runMutation, retryLastMutation } = useGuardedMutation<Record<string, unknown>>({
+    contextId: mutationContextId,
+  })
+
   const resolveCurrentBundleId = React.useCallback(() => {
     return bundleId ?? (
       typeof window !== 'undefined'
@@ -147,49 +156,83 @@ export default function BundleConfigPage({ params }: BundleConfigPageProps) {
     const currentBundleId = resolveCurrentBundleId()
     if (!currentBundleId) return
     setIsSavingCreds(true)
-    // TODO(#2373-B): thread updatedAt — integration detail/state response does not expose a record version yet
-    const call = await withScopedApiRequestHeaders(
-      buildOptimisticLockHeader(undefined),
-      () => apiCall(`/api/integrations/${encodeURIComponent(currentBundleId)}/credentials`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ credentials: credValues }),
-      }, { fallback: null }),
-    )
-    if (call.ok) {
-      flash(t('integrations.detail.credentials.saved'), 'success')
-    } else {
+    try {
+      const call = await runMutation({
+        mutationPayload: { bundleId: currentBundleId, credentials: credValues },
+        context: {
+          formId: mutationContextId,
+          operation: 'update',
+          actionId: 'save-credentials',
+          resourceKind: 'integrations.bundle',
+          resourceId: currentBundleId,
+          bundleId: currentBundleId,
+          retryLastMutation,
+        },
+        // TODO(#2373-B): thread updatedAt — integration detail/state response does not expose a record version yet
+        operation: () => withScopedApiRequestHeaders(
+          buildOptimisticLockHeader(undefined),
+          () => apiCall(`/api/integrations/${encodeURIComponent(currentBundleId)}/credentials`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ credentials: credValues }),
+          }, { fallback: null }),
+        ),
+      })
+      if (call.ok) {
+        flash(t('integrations.detail.credentials.saved'), 'success')
+      } else {
+        flash(t('integrations.detail.credentials.saveError'), 'error')
+      }
+    } catch {
       flash(t('integrations.detail.credentials.saveError'), 'error')
+    } finally {
+      setIsSavingCreds(false)
     }
-    setIsSavingCreds(false)
-  }, [resolveCurrentBundleId, credValues, t])
+  }, [resolveCurrentBundleId, runMutation, mutationContextId, retryLastMutation, credValues, t])
 
   const handleToggle = React.useCallback(async (integrationId: string, enabled: boolean) => {
     setTogglingIds((prev) => new Set(prev).add(integrationId))
-    // TODO(#2373-B): thread updatedAt — integration detail/state response does not expose a record version yet
-    const call = await withScopedApiRequestHeaders(
-      buildOptimisticLockHeader(undefined),
-      () => apiCall(`/api/integrations/${encodeURIComponent(integrationId)}/state`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ isEnabled: enabled }),
-      }, { fallback: null }),
-    )
-    if (call.ok) {
-      setDetail((prev) => {
-        if (!prev) return prev
-        return {
-          ...prev,
-          bundleIntegrations: prev.bundleIntegrations.map((item) =>
-            item.id === integrationId ? { ...item, isEnabled: enabled } : item,
-          ),
-        }
+    try {
+      const call = await runMutation({
+        mutationPayload: { integrationId, isEnabled: enabled },
+        context: {
+          formId: mutationContextId,
+          operation: 'update',
+          actionId: 'toggle-state',
+          resourceKind: 'integrations.integration',
+          resourceId: integrationId,
+          integrationId,
+          retryLastMutation,
+        },
+        // TODO(#2373-B): thread updatedAt — integration detail/state response does not expose a record version yet
+        operation: () => withScopedApiRequestHeaders(
+          buildOptimisticLockHeader(undefined),
+          () => apiCall(`/api/integrations/${encodeURIComponent(integrationId)}/state`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ isEnabled: enabled }),
+          }, { fallback: null }),
+        ),
       })
-    } else {
+      if (call.ok) {
+        setDetail((prev) => {
+          if (!prev) return prev
+          return {
+            ...prev,
+            bundleIntegrations: prev.bundleIntegrations.map((item) =>
+              item.id === integrationId ? { ...item, isEnabled: enabled } : item,
+            ),
+          }
+        })
+      } else {
+        flash(t('integrations.detail.stateError'), 'error')
+      }
+    } catch {
       flash(t('integrations.detail.stateError'), 'error')
+    } finally {
+      setTogglingIds((prev) => { const next = new Set(prev); next.delete(integrationId); return next })
     }
-    setTogglingIds((prev) => { const next = new Set(prev); next.delete(integrationId); return next })
-  }, [t])
+  }, [runMutation, mutationContextId, retryLastMutation, t])
 
   const handleBulkToggle = React.useCallback(async (enabled: boolean) => {
     if (!detail) return

--- a/packages/core/src/modules/integrations/backend/integrations/page.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/page.tsx
@@ -9,6 +9,7 @@ import { Input } from '@open-mercato/ui/primitives/input'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -145,6 +146,9 @@ export default function IntegrationsMarketplacePage() {
   const [togglingIds, setTogglingIds] = React.useState<Set<string>>(new Set())
   const scopeVersion = useOrganizationScopeVersion()
   const t = useT()
+  const { runMutation, retryLastMutation } = useGuardedMutation<Record<string, unknown>>({
+    contextId: 'integrations.marketplace',
+  })
 
   React.useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(searchInput.trim()), 300)
@@ -202,30 +206,47 @@ export default function IntegrationsMarketplacePage() {
 
   const handleToggle = React.useCallback(async (integrationId: string, enabled: boolean, updatedAt?: string | null) => {
     setTogglingIds((prev) => new Set(prev).add(integrationId))
-    const call = await withScopedApiRequestHeaders(
-      buildOptimisticLockHeader(updatedAt),
-      () => apiCall(`/api/integrations/${encodeURIComponent(integrationId)}/state`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ isEnabled: enabled }),
-      }, { fallback: null }),
-    )
-
-    if (!call.ok) {
-      flash(t('integrations.detail.stateError'), 'error')
-    } else {
-      setData((prev) => {
-        if (!prev) return prev
-        return {
-          ...prev,
-          items: prev.items.map((item) =>
-            item.id === integrationId ? { ...item, isEnabled: enabled } : item,
-          ),
-        }
+    try {
+      const call = await runMutation({
+        mutationPayload: { integrationId, isEnabled: enabled },
+        context: {
+          formId: 'integrations.marketplace',
+          operation: 'update',
+          actionId: 'toggle-state',
+          resourceKind: 'integrations.integration',
+          resourceId: integrationId,
+          integrationId,
+          retryLastMutation,
+        },
+        operation: () => withScopedApiRequestHeaders(
+          buildOptimisticLockHeader(updatedAt),
+          () => apiCall(`/api/integrations/${encodeURIComponent(integrationId)}/state`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ isEnabled: enabled }),
+          }, { fallback: null }),
+        ),
       })
+
+      if (!call.ok) {
+        flash(t('integrations.detail.stateError'), 'error')
+      } else {
+        setData((prev) => {
+          if (!prev) return prev
+          return {
+            ...prev,
+            items: prev.items.map((item) =>
+              item.id === integrationId ? { ...item, isEnabled: enabled } : item,
+            ),
+          }
+        })
+      }
+    } catch {
+      flash(t('integrations.detail.stateError'), 'error')
+    } finally {
+      setTogglingIds((prev) => { const next = new Set(prev); next.delete(integrationId); return next })
     }
-    setTogglingIds((prev) => { const next = new Set(prev); next.delete(integrationId); return next })
-  }, [t])
+  }, [retryLastMutation, runMutation, t])
 
   const grouped = React.useMemo(() => {
     if (!data) return { bundles: [] as Array<BundleItem & { integrations: IntegrationItem[] }>, standalone: [] as IntegrationItem[] }


### PR DESCRIPTION
Fixes #3255

## Problem
The integrations **marketplace** (`backend/integrations/page.tsx`) and **bundle config** (`backend/integrations/bundle/[id]/page.tsx`) backend pages performed mutating `PUT` writes (integration state toggle, bundle credential save, child integration toggle) through a direct `withScopedApiRequestHeaders(... apiCall(... method: 'PUT'))` path. This bypasses the global mutation injection contract that `packages/ui/src/backend/AGENTS.md` requires for every non-`CrudForm` `POST`/`PUT`/`PATCH`/`DELETE` flow — so record locks, the unified conflict UI, and future mutation guards did not run for these flows. The sibling integration **detail** page already uses `useGuardedMutation`, so the expected pattern was available in-module.

## Root Cause
The marketplace/bundle write handlers never participated in `useGuardedMutation().runMutation(...)`; they called `apiCall` directly, so the `onBeforeSave`/`onAfterSave` injection lifecycle (record-lock conflict handling, scoped request headers, consistent error surfacing) was skipped.

## What Changed
- `backend/integrations/page.tsx`: added a `useGuardedMutation` wrapper (`contextId: 'integrations.marketplace'`) and routed the integration state toggle through `runMutation`, passing `mutationPayload` and a `context` with `resourceKind`/`resourceId`/`actionId` + `retryLastMutation`.
- `backend/integrations/bundle/[id]/page.tsx`: added a `useGuardedMutation` wrapper (`contextId: integrations.bundle:<id>`) and routed both the shared-credentials save and the child-integration toggle through `runMutation`.
- The existing optimistic-lock headers (`withScopedApiRequestHeaders(buildOptimisticLockHeader(...))`), local loading state (`togglingIds`/`isSavingCreds`), flash messages, and API endpoints are all preserved — the guarded wrapper now owns the call while the version header still ships on the inner operation.
- Each handler now wraps its body in `try/catch/finally` so the loading spinner clears and an error flash is shown even if the guarded mutation is blocked/throws.

## Tests
- `__tests__/marketplace-guarded-mutation.test.tsx` — proves the marketplace toggle invokes `runMutation` (with the expected payload/context) and updates local switch state on success; flashes an error and leaves state unchanged on failure.
- `bundle/[id]/__tests__/bundle-guarded-mutation.test.tsx` — proves the bundle child-toggle and shared-credentials save both invoke `runMutation` and update local state / flash success.
- Existing guard `optimistic-lock-ui-coverage.test.ts` still passes (both files remain version-header covered).
- Full integrations module suite (47 tests) green; `yarn typecheck` green; `yarn i18n:check-sync` clean; changed files lint clean.

## Backward Compatibility
No contract-surface changes. No API routes, types, event IDs, widget spot IDs, DI keys, or ACL features were altered. Behavior is preserved (same endpoints, headers, optimistic locking, and messaging); the writes now additionally flow through the standard mutation-injection lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
