### PR TITLE
fix(cli): copy om-integration-builder STANDALONE.md in agentic:init scaffolder

### DIFF
--- a/.ai/runs/2026-06-19-cli-agentic-init-integration-builder-standalone.md
+++ b/.ai/runs/2026-06-19-cli-agentic-init-integration-builder-standalone.md
@@ -30,5 +30,5 @@ Make the CLI agentic scaffolder (`mercato agentic:init` → `packages/cli/src/li
 
 ### Phase 1: Fix scaffolder + verify
 
-- [ ] 1.1 Add conditional STANDALONE.md copy for om-integration-builder in agentic-setup.ts
-- [ ] 1.2 Build CLI package and run affected unit + integration tests, typecheck
+- [x] 1.1 Add conditional STANDALONE.md copy for om-integration-builder in agentic-setup.ts — 0699704b4
+- [x] 1.2 Build CLI package and run affected unit + integration tests, typecheck — 0699704b4 (agentic-init.test.ts 12/12, TC-INT-008 passing, cli typecheck clean)

--- a/.ai/runs/2026-06-19-cli-agentic-init-integration-builder-standalone.md
+++ b/.ai/runs/2026-06-19-cli-agentic-init-integration-builder-standalone.md
@@ -1,0 +1,34 @@
+# Execution Plan: copy om-integration-builder STANDALONE.md in agentic:init scaffolder
+
+## Goal
+
+Make the CLI agentic scaffolder (`mercato agentic:init` → `packages/cli/src/lib/agentic-setup.ts`) copy `ai/skills/om-integration-builder/STANDALONE.md` into scaffolded apps, so the integration test `TC-INT-008` passes again on `develop`.
+
+## Scope
+
+- `packages/cli/src/lib/agentic-setup.ts` — add a conditional copy of the `om-integration-builder` `STANDALONE.md` next to the existing `SKILL.md` / `references/adapter-contracts.md` copies.
+
+### Non-goals
+
+- No change to the create-app wizard scaffolder (`packages/create-app/src/setup/tools/shared.ts`) — it already copies this file (PR #3088).
+- No change to `TC-INT-008.spec.ts` — the test is correct; the scaffolder is the defect.
+- No change to the source skill files.
+
+## Root cause (pre-diagnosed)
+
+- PR #3085 added `packages/create-app/agentic/shared/ai/skills/om-integration-builder/STANDALONE.md` but taught neither scaffolder to copy it.
+- PR #3088 patched only the create-app wizard scaffolder (`shared.ts`), missing the CLI scaffolder (`agentic-setup.ts`).
+- `TC-INT-008` enumerates every file under `packages/create-app/agentic/shared` and asserts the CLI scaffolder copies each one; the uncopied STANDALONE.md makes `missingPaths` non-empty → deterministic failure on shard `ephemeral-integration (3/15)`, blocking unrelated PRs (#3338, #3334).
+
+## Risks
+
+- Very low. One-file, additive copy mirroring an already-shipped pattern. No contract surface touched.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Fix scaffolder + verify
+
+- [ ] 1.1 Add conditional STANDALONE.md copy for om-integration-builder in agentic-setup.ts
+- [ ] 1.2 Build CLI package and run affected unit + integration tests, typecheck

--- a/packages/cli/src/lib/agentic-setup.ts
+++ b/packages/cli/src/lib/agentic-setup.ts
@@ -109,6 +109,13 @@ function generateShared(config: AgenticConfig): void {
     'ai/skills/om-integration-builder/references/adapter-contracts.md',
     join(targetDir, '.ai', 'skills', 'om-integration-builder', 'references', 'adapter-contracts.md'),
   )
+  if (existsSync(join(srcDir, 'ai', 'skills', 'om-integration-builder', 'STANDALONE.md'))) {
+    copyFile(
+      srcDir,
+      'ai/skills/om-integration-builder/STANDALONE.md',
+      join(targetDir, '.ai', 'skills', 'om-integration-builder', 'STANDALONE.md'),
+    )
+  }
 
   copyFile(
     srcDir,


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-19-cli-agentic-init-integration-builder-standalone.md
Status: complete

## Goal
- Make `mercato agentic:init` (`packages/cli/src/lib/agentic-setup.ts`) copy `ai/skills/om-integration-builder/STANDALONE.md` into scaffolded apps, fixing the deterministic failure of integration test `TC-INT-008` on `develop`.

## Root cause
- PR #3085 added `packages/create-app/agentic/shared/ai/skills/om-integration-builder/STANDALONE.md` to the agentic source tree but taught neither scaffolder to copy it.
- PR #3088 patched only the create-app **wizard** scaffolder (`packages/create-app/src/setup/tools/shared.ts:88-92`) — it missed the **CLI** scaffolder (`packages/cli/src/lib/agentic-setup.ts`), which is the exact code path `TC-INT-008` exercises.
- `TC-INT-008` enumerates every file under `packages/create-app/agentic/shared` and asserts the CLI scaffolder copies each one. The uncopied STANDALONE.md left `missingPaths` non-empty, failing shard `ephemeral-integration (3/15)` and blocking unrelated PRs (#3338, #3334) that happened to land on that shard.

## What Changed
- `packages/cli/src/lib/agentic-setup.ts`: after copying the `om-integration-builder` `SKILL.md` and `references/adapter-contracts.md`, added a conditional copy of `STANDALONE.md` (guarded by `existsSync`), mirroring exactly the copy the create-app wizard scaffolder already performs.

## Tests
- `TC-INT-008.spec.ts` — now **passing** (was failing before the change).
- `packages/cli/src/lib/__tests__/agentic-init.test.ts` — 12/12 passing.
- Full CLI unit suite — 983/983 passing.
- `yarn workspace @open-mercato/cli typecheck` — clean.
- `yarn build:packages` — clean.

## Backward Compatibility
- No contract surface changes. Internal CLI scaffolding logic only; the change is purely additive (copies one additional file when present). No types, signatures, import paths, event IDs, API routes, DI keys, ACL features, or DB schema touched.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-19-cli-agentic-init-integration-builder-standalone.md#progress).
