### PR TITLE
security(perspectives): scope assigned role lookup to the current tenant

### DIFF
--- a/packages/core/src/modules/perspectives/api/[tableId]/route.ts
+++ b/packages/core/src/modules/perspectives/api/[tableId]/route.ts
@@ -71,9 +71,10 @@ export async function GET(_req: Request, ctx: { params: { tableId: string } }) {
   const assignedRoleNames = Array.isArray(auth.roles)
     ? Array.from(new Set(auth.roles.filter((role): role is string => typeof role === 'string' && role.trim().length > 0)))
     : []
-  const assignedRoles = assignedRoleNames.length
+  const assignedRoles = assignedRoleNames.length && auth.tenantId
     ? await em.find(Role, {
         name: { $in: assignedRoleNames as any },
+        tenantId: auth.tenantId,
         deletedAt: null,
       } as any, { orderBy: { name: 'asc' } })
     : []

--- a/packages/core/src/modules/perspectives/api/__tests__/tableId-route.test.ts
+++ b/packages/core/src/modules/perspectives/api/__tests__/tableId-route.test.ts
@@ -1,0 +1,110 @@
+import { GET } from '@open-mercato/core/modules/perspectives/api/[tableId]/route'
+
+const mockGetAuthFromRequest = jest.fn()
+const mockUserHasAllFeatures = jest.fn()
+const mockLoadPerspectivesState = jest.fn()
+
+const tenantA = 'a0a0a0a0-a0a0-4a0a-8a0a-a0a0a0a0a0a0'
+const tenantB = 'b0b0b0b0-b0b0-4b0b-8b0b-b0b0b0b0b0b0'
+const userId = 'c0c0c0c0-c0c0-4c0c-8c0c-c0c0c0c0c0c0'
+const orgId = 'e0e0e0e0-e0e0-4e0e-8e0e-e0e0e0e0e0e0'
+
+const roleTenantA = { id: 'role-1-tenant-a', name: 'Manager', tenantId: tenantA, deletedAt: null }
+const roleTenantB = { id: 'role-2-tenant-b', name: 'Manager', tenantId: tenantB, deletedAt: null }
+let roleRows: Array<typeof roleTenantA> = [roleTenantA, roleTenantB]
+
+function matchesRoleWhere(row: Record<string, unknown>, where: Record<string, unknown>): boolean {
+  if ('deletedAt' in where && row.deletedAt !== where.deletedAt) return false
+  if ('tenantId' in where && row.tenantId !== where.tenantId) return false
+  const nameFilter = where.name as { $in?: string[] } | undefined
+  if (nameFilter?.$in && !nameFilter.$in.includes(row.name as string)) return false
+  return true
+}
+
+const mockEm = {
+  find: jest.fn(async (_entity: unknown, where: Record<string, unknown>) =>
+    roleRows.filter((row) => matchesRoleWhere(row, where)),
+  ),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'rbacService') return { userHasAllFeatures: mockUserHasAllFeatures }
+    if (token === 'cache') return null
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/perspectives/services/perspectiveService', () => ({
+  loadPerspectivesState: jest.fn((...args: unknown[]) => mockLoadPerspectivesState(...args)),
+  saveUserPerspective: jest.fn(),
+  saveRolePerspectives: jest.fn(),
+  clearRolePerspectives: jest.fn(),
+}))
+
+function makeRequest() {
+  return new Request('http://localhost/api/perspectives/orders', { method: 'GET' })
+}
+
+describe('GET /api/perspectives/[tableId] (issue #3276)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    roleRows = [roleTenantA, roleTenantB]
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: userId,
+      tenantId: tenantA,
+      orgId,
+      roles: ['Manager'],
+    })
+    mockUserHasAllFeatures.mockResolvedValue(false)
+    mockLoadPerspectivesState.mockResolvedValue({
+      tableId: 'orders',
+      personal: [],
+      personalDefaultId: null,
+      rolePerspectives: [],
+    })
+  })
+
+  test('scopes the assigned-role lookup to the caller tenant', async () => {
+    const res = await GET(makeRequest(), { params: { tableId: 'orders' } })
+    expect(res.status).toBe(200)
+
+    const whereArg = mockEm.find.mock.calls[0]?.[1] as Record<string, unknown>
+    expect(whereArg.tenantId).toBe(tenantA)
+  })
+
+  test('does not return a same-named role belonging to another tenant', async () => {
+    const res = await GET(makeRequest(), { params: { tableId: 'orders' } })
+    const body = await res.json()
+
+    expect(body.roles).toHaveLength(1)
+    expect(body.roles[0].id).toBe(roleTenantA.id)
+    expect(body.roles.find((role: { id: string }) => role.id === roleTenantB.id)).toBeUndefined()
+  })
+
+  test('never passes the foreign role id into role-perspective resolution', async () => {
+    await GET(makeRequest(), { params: { tableId: 'orders' } })
+
+    const stateOptions = mockLoadPerspectivesState.mock.calls[0]?.[2] as { roleIds: string[] }
+    expect(stateOptions.roleIds).toEqual([roleTenantA.id])
+    expect(stateOptions.roleIds).not.toContain(roleTenantB.id)
+  })
+
+  test('returns no assigned roles when only another tenant has the matching role name', async () => {
+    roleRows = [roleTenantB]
+
+    const res = await GET(makeRequest(), { params: { tableId: 'orders' } })
+    const body = await res.json()
+
+    expect(body.roles).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

The perspectives index (`GET /api/perspectives/[tableId]`) resolved the caller's assigned roles from `auth.roles` by matching `Role.name` only, with no `tenantId` predicate — even though `Role` is tenant-scoped and unique on `(tenantId, name)`. A role with the same name in a different tenant was pulled into the response's `roles` list and into the `roleIds` passed to role-perspective resolution.

## Changes

* `packages/core/src/modules/perspectives/api/[tableId]/route.ts`: the `assignedRoles` lookup now filters by `tenantId: auth.tenantId` (and skips the query entirely when there's no tenant context), matching the already-correct scoping used elsewhere in the same file (`roleScope` for `availableRoles`/role-default validation in `POST`).

## Specification

**Does a spec exist for this feature/module?**

* [ ] Yes
* [ ] No (created a new spec)
* [x] N/A (minor change, no spec needed)

**Spec file path:**

## Testing

* `yarn workspace @open-mercato/core test tableId-route` — 4 new regression tests: query is scoped to the caller's tenant, a same-named foreign-tenant role is excluded from `roles`, the foreign role ID never reaches `loadPerspectivesState`'s `roleIds`, and zero roles are returned when only the foreign tenant has the matching name.
* Verified the regression tests actually catch the bug: reverted the one-line fix locally and confirmed all 4 tests fail with the exact leak described in the issue, then restored the fix and confirmed they pass.
* `yarn workspace @open-mercato/core build` — succeeds.

## Checklist

* [x] This pull request targets `develop`.
* [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
* [x] I updated documentation, locales, or generators if the change requires it. *(not required — query-predicate fix only)*
* [x] I added or adjusted tests that cover the change.
* [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). *(not added — the cross-tenant leak is fully and precisely covered by the route-level unit tests above, which mock the DB layer to prove the exact predicate; a full Playwright integration test would need to provision two real tenants with colliding role names for the same assertion)*
* [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). *(N/A — no spec)*

### Design System Compliance

* [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
* [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
* [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
* [x] Loading state handled for async pages
* [x] `aria-label` on all icon-only buttons (`<IconButton>`)
* [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

*(No UI was touched — backend query-scoping fix only.)*

## Linked issues

Fixes #3276