### PR TITLE
fix(customers): bounded encrypted-sort for interactions + labels (P1 of #3386)

### DIFF
--- a/packages/core/src/modules/customers/api/interactions/__tests__/encryptedSortBranch.test.ts
+++ b/packages/core/src/modules/customers/api/interactions/__tests__/encryptedSortBranch.test.ts
@@ -1,0 +1,110 @@
+import {
+  Kysely,
+  PostgresAdapter,
+  PostgresQueryCompiler,
+  PostgresIntrospector,
+  DummyDriver,
+  type CompiledQuery,
+} from 'kysely'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+
+const recordedQueries: CompiledQuery[] = []
+
+function createRecordingKysely(): Kysely<any> {
+  const db = new Kysely<any>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+      createIntrospector: (instance: Kysely<any>) => new PostgresIntrospector(instance),
+    },
+  })
+  ;(db.getExecutor() as any).executeQuery = async (compiledQuery: CompiledQuery) => {
+    recordedQueries.push(compiledQuery)
+    return { rows: [] }
+  }
+  return db
+}
+
+const fakeEm = {
+  fork() {
+    return {
+      getKysely: () => createRecordingKysely(),
+    }
+  },
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (token: string) => {
+      if (token === 'em') return fakeEm
+      return undefined
+    },
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: async () => ({
+    tenantId,
+    orgId,
+    sub: null,
+    isApiKey: true,
+  }),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: async () => ({ filterIds: [orgId], selectedId: orgId }),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({ translate: (_key: string, fallback: string) => fallback }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/enricher-runner', () => ({
+  applyResponseEnrichers: async (items: unknown[]) => ({ items }),
+}))
+
+const mockGetEncryptedFieldNames = jest.fn(async () => ['title'])
+jest.mock('@open-mercato/shared/lib/encryption/customFieldValues', () => ({
+  resolveTenantEncryptionService: () => ({
+    isEnabled: () => true,
+    getEncryptedFieldNames: (...args: unknown[]) => mockGetEncryptedFieldNames(...args),
+    decryptEntityPayload: async (_entityId: string, payload: Record<string, unknown>) => payload,
+  }),
+}))
+
+import { GET } from '../route'
+
+const interactionQueries = () => recordedQueries.filter((entry) => entry.sql.includes('customer_interactions'))
+
+beforeEach(() => {
+  recordedQueries.length = 0
+  mockGetEncryptedFieldNames.mockClear()
+  mockGetEncryptedFieldNames.mockImplementation(async () => ['title'])
+})
+
+function makeRequest(qs: string) {
+  return new Request(`http://localhost/api/customers/interactions?${qs}`)
+}
+
+describe('interactions list — encrypted-sort branch routing (#3386)', () => {
+  test('sorting by an encrypted field (title) takes the bounded candidate-scan path, not the SQL ORDER BY/keyset path', async () => {
+    const res = await GET(makeRequest('sortField=title'))
+    expect(res.status).toBe(200)
+
+    const queries = interactionQueries()
+    expect(queries.length).toBeGreaterThan(0)
+    expect(queries.some((q) => /order by/i.test(q.sql))).toBe(false)
+  })
+
+  test('sorting by a non-encrypted field (status) keeps the SQL ORDER BY/keyset path', async () => {
+    mockGetEncryptedFieldNames.mockResolvedValueOnce([])
+    const res = await GET(makeRequest('sortField=status'))
+    expect(res.status).toBe(200)
+
+    const queries = interactionQueries()
+    expect(queries.some((q) => /order by/i.test(q.sql))).toBe(true)
+  })
+})

--- a/packages/core/src/modules/customers/api/interactions/__tests__/encryptedSortPage.test.ts
+++ b/packages/core/src/modules/customers/api/interactions/__tests__/encryptedSortPage.test.ts
@@ -1,0 +1,128 @@
+import { resolveEncryptedSortPage } from '../encryptedSortPage'
+
+const namesById: Record<string, string> = {
+  '1': 'cipher-a', '2': 'cipher-b', '3': 'cipher-c', '4': 'cipher-d', '5': 'cipher-e',
+}
+const plaintextById: Record<string, string> = {
+  '1': 'Alice', '2': 'Bob', '3': 'Charlie', '4': 'Dave', '5': 'Eve',
+}
+
+function makeCandidates() {
+  return [
+    { id: '3', title: namesById['3'] },
+    { id: '1', title: namesById['1'] },
+    { id: '5', title: namesById['5'] },
+    { id: '2', title: namesById['2'] },
+    { id: '4', title: namesById['4'] },
+  ]
+}
+
+async function decryptRow<T extends { id: string }>(row: T): Promise<T> {
+  return { ...row, title: plaintextById[row.id] }
+}
+
+describe('resolveEncryptedSortPage', () => {
+  test('sorts by decrypted plaintext, not ciphertext, on page 1', async () => {
+    const { pageIds, hasMore } = await resolveEncryptedSortPage({
+      candidates: makeCandidates(),
+      decryptRow,
+      sortField: 'title',
+      sortDir: 'asc',
+      cursorId: null,
+      limit: 2,
+    })
+    // Alphabetical by plaintext: Alice(1), Bob(2), Charlie(3), Dave(4), Eve(5)
+    expect(pageIds).toEqual(['1', '2'])
+    expect(hasMore).toBe(true)
+  })
+
+  test('resumes correctly at the tail page via cursorId', async () => {
+    const { pageIds, hasMore } = await resolveEncryptedSortPage({
+      candidates: makeCandidates(),
+      decryptRow,
+      sortField: 'title',
+      sortDir: 'asc',
+      cursorId: '4', // after Dave -> only Eve left
+      limit: 2,
+    })
+    expect(pageIds).toEqual(['5'])
+    expect(hasMore).toBe(false)
+  })
+
+  test('walks every page without skipping or duplicating rows', async () => {
+    const seen: string[] = []
+    let cursorId: string | null = null
+    for (let i = 0; i < 10; i++) {
+      const { pageIds, hasMore } = await resolveEncryptedSortPage({
+        candidates: makeCandidates(),
+        decryptRow,
+        sortField: 'title',
+        sortDir: 'asc',
+        cursorId,
+        limit: 2,
+      })
+      seen.push(...pageIds)
+      if (!hasMore) break
+      cursorId = pageIds[pageIds.length - 1]
+    }
+    expect(seen).toEqual(['1', '2', '3', '4', '5'])
+  })
+
+  test('respects descending sort direction', async () => {
+    const { pageIds } = await resolveEncryptedSortPage({
+      candidates: makeCandidates(),
+      decryptRow,
+      sortField: 'title',
+      sortDir: 'desc',
+      cursorId: null,
+      limit: 2,
+    })
+    expect(pageIds).toEqual(['5', '4']) // Eve, Dave
+  })
+
+  test('falls back to page 1 when the cursor id is not found among candidates', async () => {
+    const { pageIds } = await resolveEncryptedSortPage({
+      candidates: makeCandidates(),
+      decryptRow,
+      sortField: 'title',
+      sortDir: 'asc',
+      cursorId: 'does-not-exist',
+      limit: 2,
+    })
+    expect(pageIds).toEqual(['1', '2'])
+  })
+
+  test('never decrypts more than 8 candidates concurrently', async () => {
+    const candidates = Array.from({ length: 20 }, (_, i) => ({ id: String(i), title: `cipher-${i}` }))
+    let inFlight = 0
+    let maxInFlight = 0
+    await resolveEncryptedSortPage({
+      candidates,
+      decryptRow: async (row) => {
+        inFlight += 1
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await new Promise((resolve) => setTimeout(resolve, 1))
+        inFlight -= 1
+        return { ...row, title: `plain-${row.id}` }
+      },
+      sortField: 'title',
+      sortDir: 'asc',
+      cursorId: null,
+      limit: 5,
+    })
+    expect(maxInFlight).toBeLessThanOrEqual(8)
+  })
+
+  test('returns no ids and hasMore=false for an empty candidate set', async () => {
+    const { pageIds, hasMore } = await resolveEncryptedSortPage({
+      candidates: [],
+      decryptRow,
+      sortField: 'title',
+      sortDir: 'asc',
+      cursorId: null,
+      limit: 2,
+    })
+    expect(pageIds).toEqual([])
+    expect(hasMore).toBe(false)
+  })
+})

--- a/packages/core/src/modules/customers/api/interactions/encryptedSortPage.ts
+++ b/packages/core/src/modules/customers/api/interactions/encryptedSortPage.ts
@@ -1,0 +1,34 @@
+import { mapWithConcurrency } from '@open-mercato/shared/lib/query/bounded-decrypt'
+import { sortRowsInMemory } from '@open-mercato/shared/lib/query/encrypted-sort'
+import { SortDir } from '@open-mercato/shared/lib/query/types'
+
+const DECRYPT_CONCURRENCY = 8
+
+export type EncryptedSortCandidate = { id: string } & Record<string, unknown>
+
+// Re-sorts the bounded candidate set by plaintext on every call and resumes
+// from the cursor's id position — SQL keyset comparison against ciphertext
+// is meaningless for ordering.
+export async function resolveEncryptedSortPage<T extends EncryptedSortCandidate>(params: {
+  candidates: readonly T[]
+  decryptRow: (row: T) => Promise<T>
+  sortField: string
+  sortDir: 'asc' | 'desc'
+  cursorId: string | null
+  limit: number
+}): Promise<{ pageIds: string[]; hasMore: boolean }> {
+  const decrypted = await mapWithConcurrency(params.candidates, DECRYPT_CONCURRENCY, params.decryptRow)
+  const ordered = sortRowsInMemory(decrypted, [
+    { field: params.sortField, dir: params.sortDir === 'desc' ? SortDir.Desc : SortDir.Asc },
+  ])
+  let start = 0
+  if (params.cursorId) {
+    const idx = ordered.findIndex((row) => row.id === params.cursorId)
+    start = idx >= 0 ? idx + 1 : 0
+  }
+  const page = ordered.slice(start, start + params.limit)
+  return {
+    pageIds: page.map((row) => row.id),
+    hasMore: start + params.limit < ordered.length,
+  }
+}

--- a/packages/core/src/modules/customers/api/interactions/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/route.ts
@@ -9,6 +9,8 @@ import { normalizeCustomFieldResponse } from '@open-mercato/shared/lib/custom-fi
 import { applyResponseEnrichers } from '@open-mercato/shared/lib/crud/enricher-runner'
 import type { EnricherContext } from '@open-mercato/shared/lib/crud/response-enricher'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { resolveTenantEncryptionService } from '@open-mercato/shared/lib/encryption/customFieldValues'
+import { resolveEncryptedSortFields, resolveEncryptedSortMaxRows } from '@open-mercato/shared/lib/query/encrypted-sort'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
@@ -24,6 +26,7 @@ import {
 } from '../openapi'
 import { CUSTOMER_INTERACTION_ENTITY_ID } from '../../lib/interactionCompatibility'
 import { applyEmailVisibilityFilter } from '../../lib/visibilityFilter'
+import { resolveEncryptedSortPage } from './encryptedSortPage'
 import { resolveCanonicalActivityTargetId } from '../../lib/legacyActivityBridge'
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 
@@ -284,6 +287,85 @@ function buildSortSql(
   return `coalesce(${config.column}, ${sentinel})`
 }
 
+const INTERACTION_LIST_COLUMNS = [
+  'id',
+  'entity_id',
+  'deal_id',
+  'interaction_type',
+  'title',
+  'body',
+  'status',
+  'scheduled_at',
+  'occurred_at',
+  'priority',
+  'author_user_id',
+  'owner_user_id',
+  'appearance_icon',
+  'appearance_color',
+  'source',
+  'duration_minutes',
+  'location',
+  'all_day',
+  'recurrence_rule',
+  'recurrence_end',
+  'participants',
+  'reminder_minutes',
+  'visibility',
+  'linked_entities',
+  'guest_permissions',
+  'pinned',
+  'organization_id',
+  'tenant_id',
+  'created_at',
+  'updated_at',
+] as const
+
+// Shared by both the SQL keyset path and the encrypted-sort candidate scan
+// so the two paths never drift on which rows are in scope.
+function applyInteractionListFilters(
+  baseQuery: any,
+  params: {
+    tenantId: string
+    organizationIds: string[]
+    query: z.infer<typeof listSchema>
+  },
+): any {
+  let q = baseQuery.where('deleted_at', 'is', null).where('tenant_id', '=', params.tenantId)
+  if (params.organizationIds.length > 0) q = q.where('organization_id', 'in', params.organizationIds)
+  const { query } = params
+  if (query.entityId) q = q.where('entity_id', '=', query.entityId)
+  if (query.dealId) q = q.where('deal_id', '=', query.dealId)
+  if (query.status) q = q.where('status', '=', query.status)
+  if (query.interactionType) q = q.where('interaction_type', '=', query.interactionType)
+  if (query.type) {
+    const types = query.type.split(',').map((t) => t.trim()).filter(Boolean)
+    if (types.length > 0) q = q.where('interaction_type', 'in', types)
+  }
+  if (query.pinned === 'true') {
+    q = q.where('pinned', '=', true)
+  } else if (query.pinned === 'false') {
+    q = q.where('pinned', '=', false)
+  }
+  if (query.excludeInteractionType) q = q.where('interaction_type', '!=', query.excludeInteractionType)
+  if (query.search) {
+    // NOTE: for tenants with data encryption enabled, `title`/`body` are
+    // ciphertext at rest (see encryption.ts), so this ILIKE matches encrypted
+    // bytes and returns no rows — substring search over encrypted free-text
+    // columns is unsupported, the same documented limitation as
+    // customer_activity / customer_comment. The returned page's title/body are
+    // still decrypted for display further below.
+    const searchTerm = `%${escapeLikePattern(query.search)}%`
+    q = q.where(sql<boolean>`coalesce(title, '') ilike ${searchTerm} or coalesce(body, '') ilike ${searchTerm}`)
+  }
+  if (query.from) {
+    q = q.where(sql<boolean>`coalesce(occurred_at, scheduled_at, created_at) >= ${query.from}`)
+  }
+  if (query.to) {
+    q = q.where(sql<boolean>`coalesce(occurred_at, scheduled_at, created_at) <= ${query.to}`)
+  }
+  return q
+}
+
 async function resolveUserFeatures(
   container: { resolve: (name: string) => unknown },
   userId: string,
@@ -366,94 +448,6 @@ export async function GET(req: Request) {
       })
     }
 
-    let rowsQuery = db
-      .selectFrom('customer_interactions')
-      .select([
-        'id',
-        'entity_id',
-        'deal_id',
-        'interaction_type',
-        'title',
-        'body',
-        'status',
-        'scheduled_at',
-        'occurred_at',
-        'priority',
-        'author_user_id',
-        'owner_user_id',
-        'appearance_icon',
-        'appearance_color',
-        'source',
-        'duration_minutes',
-        'location',
-        'all_day',
-        'recurrence_rule',
-        'recurrence_end',
-        'participants',
-        'reminder_minutes',
-        'visibility',
-        'linked_entities',
-        'guest_permissions',
-        'pinned',
-        'organization_id',
-        'tenant_id',
-        'created_at',
-        'updated_at',
-        sql`${sql.raw(sortSql)}`.as('__sort_value'),
-      ])
-      .where('deleted_at', 'is', null)
-      .where('tenant_id', '=', auth.tenantId)
-      .limit(query.limit + 1)
-
-    if (organizationIds.length > 0) {
-      rowsQuery = rowsQuery.where('organization_id', 'in', organizationIds)
-    }
-    if (query.entityId) rowsQuery = rowsQuery.where('entity_id', '=', query.entityId)
-    if (query.dealId) rowsQuery = rowsQuery.where('deal_id', '=', query.dealId)
-    if (query.status) rowsQuery = rowsQuery.where('status', '=', query.status)
-    if (query.interactionType) rowsQuery = rowsQuery.where('interaction_type', '=', query.interactionType)
-    if (query.type) {
-      const types = query.type.split(',').map((t) => t.trim()).filter(Boolean)
-      if (types.length > 0) {
-        rowsQuery = rowsQuery.where('interaction_type', 'in', types)
-      }
-    }
-    if (query.pinned === 'true') {
-      rowsQuery = rowsQuery.where('pinned', '=', true)
-    } else if (query.pinned === 'false') {
-      rowsQuery = rowsQuery.where('pinned', '=', false)
-    }
-    if (query.excludeInteractionType) rowsQuery = rowsQuery.where('interaction_type', '!=', query.excludeInteractionType)
-    if (query.search) {
-      // NOTE: for tenants with data encryption enabled, `title`/`body` are
-      // ciphertext at rest (see encryption.ts), so this ILIKE matches encrypted
-      // bytes and returns no rows — substring search over encrypted free-text
-      // columns is unsupported, the same documented limitation as
-      // customer_activity / customer_comment. The returned page's title/body are
-      // still decrypted for display further below.
-      const searchTerm = `%${escapeLikePattern(query.search)}%`
-      rowsQuery = rowsQuery.where(sql<boolean>`coalesce(title, '') ilike ${searchTerm} or coalesce(body, '') ilike ${searchTerm}`)
-    }
-    if (query.from) {
-      rowsQuery = rowsQuery.where(sql<boolean>`coalesce(occurred_at, scheduled_at, created_at) >= ${query.from}`)
-    }
-    if (query.to) {
-      rowsQuery = rowsQuery.where(sql<boolean>`coalesce(occurred_at, scheduled_at, created_at) <= ${query.to}`)
-    }
-
-    if (cursor) {
-      const op = sortDir === 'asc' ? '>' : '<'
-      const opRaw = sql.raw(op)
-      const sortRaw = sql.raw(sortSql)
-      rowsQuery = rowsQuery.where((eb: any) => eb.or([
-        sql<boolean>`${sortRaw} ${opRaw} ${cursor.sortValue}`,
-        eb.and([
-          sql<boolean>`${sortRaw} = ${cursor.sortValue}`,
-          eb('id', op, cursor.id),
-        ]),
-      ]))
-    }
-
     // ── Email visibility filter (2026-05-27) ──────────────────────────────
     // Non-email interactions pass through; email rows with visibility='private'
     // are filtered out unless the caller is the author or has admin bypass.
@@ -461,19 +455,121 @@ export async function GET(req: Request) {
     // viewer to null so they never gain the author bypass and only see shared
     // emails (fail-closed). Mirrors counts/people/activities routes.
     const viewerUserId = auth.isApiKey ? null : (auth.sub ?? null)
-    const callerUserFeatures = viewerUserId
-      ? await resolveUserFeatures(container, viewerUserId, auth.tenantId ?? null, selectedOrganizationId)
-      : undefined
-    rowsQuery = applyEmailVisibilityFilter(rowsQuery as any, {
-      currentUserId: viewerUserId,
-      userFeatures: callerUserFeatures,
-    })
+    const encryptionService = resolveTenantEncryptionService(em)
+    // Encrypted sort columns can't use SQL keyset ordering on ciphertext, so an
+    // encrypted sort field takes a bounded candidate-scan + in-memory-sort path
+    // instead of the SQL path below. Resolved alongside the independent
+    // visibility-feature lookup rather than after it.
+    const [callerUserFeatures, encryptedSortFields] = await Promise.all([
+      viewerUserId
+        ? resolveUserFeatures(container, viewerUserId, auth.tenantId ?? null, selectedOrganizationId)
+        : Promise.resolve(undefined),
+      resolveEncryptedSortFields(
+        encryptionService,
+        CUSTOMER_INTERACTION_ENTITY_ID,
+        [sortConfig.column],
+        auth.tenantId,
+        selectedOrganizationId,
+      ),
+    ])
+    const sortFieldIsEncrypted = encryptedSortFields.has(sortConfig.column)
 
-    rowsQuery = rowsQuery.orderBy(sql`${sql.raw(sortSql)} ${sql.raw(sortDir)}`).orderBy('id', sortDir)
+    let pageRows: InteractionListRow[]
+    let hasMore: boolean
 
-    const rows = await rowsQuery.execute() as InteractionListRow[]
-    const pageRows = rows.slice(0, query.limit)
-    const hasMore = rows.length > query.limit
+    if (sortFieldIsEncrypted) {
+      let candidateQuery = applyInteractionListFilters(
+        db.selectFrom('customer_interactions').select(['id', sortConfig.column]),
+        { tenantId: auth.tenantId, organizationIds, query },
+      )
+      candidateQuery = applyEmailVisibilityFilter(candidateQuery as any, {
+        currentUserId: viewerUserId,
+        userFeatures: callerUserFeatures,
+      })
+      const cap = resolveEncryptedSortMaxRows()
+      if (cap !== null) {
+        candidateQuery = candidateQuery.limit(cap).orderBy('id', 'asc')
+      }
+      const candidateRows = await candidateQuery.execute() as Array<{ id: string } & Record<string, unknown>>
+      if (cap !== null && candidateRows.length >= cap) {
+        console.warn('[customers/interactions.GET] encrypted sort candidate scan hit OM_ENCRYPTED_SORT_MAX_ROWS cap; results may be incomplete', {
+          cap,
+          sortField: sortConfig.column,
+          tenantId: auth.tenantId,
+        })
+      }
+
+      const decryptPayload = encryptionService?.decryptEntityPayload?.bind(encryptionService)
+      const { pageIds, hasMore: encryptedHasMore } = await resolveEncryptedSortPage({
+        candidates: candidateRows,
+        decryptRow: async (row) => {
+          if (!decryptPayload) return row
+          try {
+            const decrypted = await decryptPayload(CUSTOMER_INTERACTION_ENTITY_ID, row, auth.tenantId, selectedOrganizationId)
+            return { ...row, ...decrypted }
+          } catch (err) {
+            console.error('[customers/interactions.GET] error decrypting sort candidate', err)
+            return row
+          }
+        },
+        sortField: sortConfig.column,
+        sortDir,
+        cursorId: cursor?.id ?? null,
+        limit: query.limit,
+      })
+      hasMore = encryptedHasMore
+
+      if (pageIds.length === 0) {
+        pageRows = []
+      } else {
+        let pageQuery = applyInteractionListFilters(
+          db.selectFrom('customer_interactions').select([...INTERACTION_LIST_COLUMNS, sql`${sql.raw(sortSql)}`.as('__sort_value')]),
+          { tenantId: auth.tenantId, organizationIds, query },
+        )
+        pageQuery = applyEmailVisibilityFilter(pageQuery as any, {
+          currentUserId: viewerUserId,
+          userFeatures: callerUserFeatures,
+        })
+        pageQuery = pageQuery.where('id', 'in', pageIds)
+        const rawPageRows = await pageQuery.execute() as InteractionListRow[]
+        const byId = new Map(rawPageRows.map((row) => [row.id, row]))
+        pageRows = pageIds
+          .map((id) => byId.get(id))
+          .filter((row): row is InteractionListRow => row != null)
+      }
+    } else {
+      let rowsQuery = applyInteractionListFilters(
+        db
+          .selectFrom('customer_interactions')
+          .select([...INTERACTION_LIST_COLUMNS, sql`${sql.raw(sortSql)}`.as('__sort_value')])
+          .limit(query.limit + 1),
+        { tenantId: auth.tenantId, organizationIds, query },
+      )
+
+      if (cursor) {
+        const op = sortDir === 'asc' ? '>' : '<'
+        const opRaw = sql.raw(op)
+        const sortRaw = sql.raw(sortSql)
+        rowsQuery = rowsQuery.where((eb: any) => eb.or([
+          sql<boolean>`${sortRaw} ${opRaw} ${cursor.sortValue}`,
+          eb.and([
+            sql<boolean>`${sortRaw} = ${cursor.sortValue}`,
+            eb('id', op, cursor.id),
+          ]),
+        ]))
+      }
+
+      rowsQuery = applyEmailVisibilityFilter(rowsQuery as any, {
+        currentUserId: viewerUserId,
+        userFeatures: callerUserFeatures,
+      })
+
+      rowsQuery = rowsQuery.orderBy(sql`${sql.raw(sortSql)} ${sql.raw(sortDir)}`).orderBy('id', sortDir)
+
+      const rows = await rowsQuery.execute() as InteractionListRow[]
+      pageRows = rows.slice(0, query.limit)
+      hasMore = rows.length > query.limit
+    }
 
     const authorIds = Array.from(
       new Set(

--- a/packages/core/src/modules/customers/api/labels/__tests__/labels-encrypted-sort.test.ts
+++ b/packages/core/src/modules/customers/api/labels/__tests__/labels-encrypted-sort.test.ts
@@ -1,0 +1,147 @@
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+const actorId = '33333333-3333-4333-8333-333333333333'
+
+const mockEmFind = jest.fn()
+const mockEm: any = { find: mockEmFind }
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+const mockGetAuthFromRequest = jest.fn()
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({ filterIds: [orgId], selectedId: orgId })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({ translate: (_key: string, fallback: string) => fallback })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(async () => []),
+  findOneWithDecryption: jest.fn(async () => null),
+}))
+
+const mockDecrypt = jest.fn(async (label: any) => {
+  if (typeof label.label === 'string') label.label = label.label.replace(/^cipher:/, '')
+})
+jest.mock('@open-mercato/shared/lib/encryption/subscriber', () => ({
+  decryptEntitiesWithFallbackScope: jest.fn((...args: unknown[]) => mockDecrypt(...args)),
+}))
+
+import { GET } from '../route'
+
+function makeLabel(id: string, plaintext: string) {
+  return { id, slug: plaintext.toLowerCase(), label: `cipher:${plaintext}`, tenantId, organizationId: orgId, userId: actorId }
+}
+
+function makeRequest(qs = '') {
+  return new Request(`http://localhost/api/customers/labels${qs ? `?${qs}` : ''}`)
+}
+
+const originalEnv = process.env
+
+describe('GET /api/customers/labels — bounded candidate scan + decrypt + in-memory sort (#3386)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv, OM_ENCRYPTED_SORT_MAX_ROWS: undefined }
+    mockGetAuthFromRequest.mockResolvedValue({ sub: actorId, tenantId, orgId })
+    mockDecrypt.mockImplementation(async (label: any) => {
+      if (typeof label.label === 'string') label.label = label.label.replace(/^cipher:/, '')
+    })
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  test('sorts decrypted labels alphabetically, not by ciphertext/insertion order', async () => {
+    mockEmFind.mockResolvedValueOnce([
+      makeLabel('1', 'Charlie'),
+      makeLabel('2', 'alpha'),
+      makeLabel('3', 'Bravo'),
+    ])
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items.map((item: any) => item.label)).toEqual(['alpha', 'Bravo', 'Charlie'])
+  })
+
+  test('decrypts every candidate label before sorting/paginating', async () => {
+    mockEmFind.mockResolvedValueOnce([
+      makeLabel('1', 'Charlie'),
+      makeLabel('2', 'alpha'),
+      makeLabel('3', 'Bravo'),
+    ])
+
+    await GET(makeRequest())
+    expect(mockDecrypt).toHaveBeenCalledTimes(3)
+  })
+
+  test('passes a limit+id-order clause to em.find when OM_ENCRYPTED_SORT_MAX_ROWS is set', async () => {
+    process.env.OM_ENCRYPTED_SORT_MAX_ROWS = '5'
+    mockEmFind.mockResolvedValueOnce([])
+
+    await GET(makeRequest())
+
+    const [, , options] = mockEmFind.mock.calls[0]
+    expect(options).toEqual({ limit: 5, orderBy: { id: 'asc' } })
+  })
+
+  test('does not cap em.find when OM_ENCRYPTED_SORT_MAX_ROWS is unset', async () => {
+    mockEmFind.mockResolvedValueOnce([])
+
+    await GET(makeRequest())
+
+    const [, , options] = mockEmFind.mock.calls[0]
+    expect(options).toEqual({})
+  })
+
+  test('scopes the candidate query to tenant, organization, and actor user', async () => {
+    mockEmFind.mockResolvedValueOnce([])
+
+    await GET(makeRequest())
+
+    const [, where] = mockEmFind.mock.calls[0]
+    expect(where).toEqual({ tenantId, organizationId: orgId, userId: actorId })
+  })
+
+  test('filters by plaintext search after decryption', async () => {
+    mockEmFind.mockResolvedValueOnce([
+      makeLabel('1', 'Charlie'),
+      makeLabel('2', 'alpha'),
+      makeLabel('3', 'Bravo'),
+    ])
+
+    const res = await GET(makeRequest('search=bra'))
+    const body = await res.json()
+    expect(body.items.map((item: any) => item.label)).toEqual(['Bravo'])
+  })
+
+  test('paginates the sorted, decrypted list', async () => {
+    mockEmFind.mockResolvedValueOnce([
+      makeLabel('1', 'Charlie'),
+      makeLabel('2', 'alpha'),
+      makeLabel('3', 'Bravo'),
+    ])
+
+    const res = await GET(makeRequest('pageSize=2&page=2'))
+    const body = await res.json()
+    expect(body.items.map((item: any) => item.label)).toEqual(['Charlie'])
+    expect(body.total).toBe(3)
+    expect(body.totalPages).toBe(2)
+  })
+})

--- a/packages/core/src/modules/customers/api/labels/route.ts
+++ b/packages/core/src/modules/customers/api/labels/route.ts
@@ -11,6 +11,10 @@ import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { decryptEntitiesWithFallbackScope } from '@open-mercato/shared/lib/encryption/subscriber'
+import { mapWithConcurrency } from '@open-mercato/shared/lib/query/bounded-decrypt'
+import { resolveEncryptedSortMaxRows, sortRowsInMemory } from '@open-mercato/shared/lib/query/encrypted-sort'
+import { SortDir } from '@open-mercato/shared/lib/query/types'
 import { resolveLabelActorUserId } from './auth'
 import {
   runCrudMutationGuardAfterSuccess,
@@ -27,6 +31,8 @@ export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.people.view'] },
   POST: { requireAuth: true, requireFeatures: ['customers.people.manage'] },
 }
+
+const DECRYPT_CONCURRENCY = 8
 
 const querySchema = z.object({
   entityId: z.string().uuid().optional(),
@@ -72,12 +78,30 @@ export async function GET(req: Request) {
       throw new CrudHttpError(400, { error: translate('customers.errors.organization_required', 'Organization context is required') })
     }
 
-    // Load all labels for this user
-    const labels = await findWithDecryption(em, CustomerLabel, {
+    // `label` is encrypted at rest; SQL can't sort it meaningfully, so the
+    // candidate set is decrypted and sorted in memory below.
+    const cap = resolveEncryptedSortMaxRows()
+    const candidateLabels = await em.find(CustomerLabel, {
       tenantId: auth.tenantId,
       organizationId,
       userId: actorUserId,
-    }, { orderBy: { label: 'asc' } }, { tenantId: auth.tenantId, organizationId })
+    } as FilterQuery<CustomerLabel>, cap !== null ? { limit: cap, orderBy: { id: 'asc' } } : {})
+    if (cap !== null && candidateLabels.length >= cap) {
+      console.warn('[customers/labels.GET] encrypted sort candidate scan hit OM_ENCRYPTED_SORT_MAX_ROWS cap; results may be incomplete', {
+        cap,
+        tenantId: auth.tenantId,
+        organizationId,
+      })
+    }
+
+    await mapWithConcurrency(candidateLabels, DECRYPT_CONCURRENCY, (label) =>
+      decryptEntitiesWithFallbackScope(label, { em, tenantId: auth.tenantId, organizationId }),
+    )
+
+    const labels = sortRowsInMemory(
+      candidateLabels as unknown as Record<string, unknown>[],
+      [{ field: 'label', dir: SortDir.Asc }],
+    ) as unknown as CustomerLabel[]
 
     // If entityId provided, also load assignments for that entity
     let assignedLabelIds: string[] = []


### PR DESCRIPTION
## Summary

Issue #3386 asked for the bounded two-phase encrypted-sort pattern from PR #3278 (shared query engine fix) to be rolled out to custom list handlers that bypass that engine. This PR covers **Phase 1 only**: `customers/api/interactions/route.ts` and `customers/api/labels/route.ts`.

Research turned up a more serious picture than the issue text: `title` is already an encrypted + sortable field for `customer_interactions` today, and the route builds its `ORDER BY`/keyset-cursor predicate directly against that ciphertext column — so sorting interactions by title in an encryption-enabled tenant returns ciphertext order, not alphabetical, **right now**, not hypothetically. `labels/route.ts` had a separate, more severe issue: it loaded *every* label for a user with no limit, decrypted them one at a time sequentially, then sorted on the ciphertext `label` column SQL-side before slicing in JS.

## Changes

* `customers/api/interactions/route.ts`: extracted the WHERE-predicate building shared by both query paths into `applyInteractionListFilters` so they can't drift. Added detection of whether the requested sort field is currently encrypted (`resolveEncryptedSortFields`); when it is, takes a bounded candidate-scan → bounded-concurrency decrypt → in-memory sort → phase-2 id-based fetch path instead of the SQL keyset path. Non-encrypted sort fields (7 of 8) are untouched. Logs a warning if `OM_ENCRYPTED_SORT_MAX_ROWS` truncates the candidate set.
* `customers/api/interactions/encryptedSortPage.ts` (new): pure, DB-agnostic helper (`resolveEncryptedSortPage`) implementing the decrypt + sort + cursor-resume-by-id logic, directly unit-testable without mocking Kysely.
* `customers/api/labels/route.ts`: replaced the unbounded `findWithDecryption(..., { orderBy: { label: 'asc' } })` call with a capped `em.find` + `mapWithConcurrency`-based bounded-concurrency decrypt + `sortRowsInMemory` plaintext sort. Same cap-truncation warning.
* Both reuse the existing shared primitives from PR #3278 (`mapWithConcurrency`, `resolveEncryptedSortFields`, `resolveEncryptedSortMaxRows`, `sortRowsInMemory`) rather than introducing a new shared module, matching how the query engine itself composes them.

## Specification

**Does a spec exist for this feature/module?**

* [ ] Yes
* [x] N/A (bug fix scoped to issue #3386, no new spec)

## Testing

```bash
yarn workspace @open-mercato/core test interactions labels encryptedSortPage listSearchAndDates
yarn workspace @open-mercato/core build
```

11 test suites / 57 tests passing, including:

* `encryptedSortPage.test.ts` — plaintext sort order (not ciphertext), cursor resume across page boundaries, descending sort, unknown-cursor fallback, decrypt concurrency bound (≤8), empty candidate set.
* `encryptedSortBranch.test.ts` — confirms `sortField=title` takes the candidate-scan path (no SQL `ORDER BY`) while `sortField=status` keeps the SQL keyset path.
* `labels-encrypted-sort.test.ts` — decrypted alphabetical ordering, every candidate decrypted, cap/no-cap `em.find` options, tenant/org/user scoping, search-after-decrypt, pagination over the sorted list.

Manually verified: a tenant with `TENANT_DATA_ENCRYPTION` enabled, sorting interactions by title across a page boundary, returns alphabetically ordered titles and pages forward without skipping/duplicating rows.

## Checklist

* [x] This pull request targets `develop`.
* [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
* [ ] I updated documentation, locales, or generators if the change requires it. *(no user-facing strings/docs changed)*
* [x] I added or adjusted tests that cover the change.
* [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Reason: unit coverage on the extracted pure helpers + route-level mocked tests already exercises the bug directly (ciphertext vs plaintext ordering); no new UI surface to integration-test.
* [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A, no spec for this issue.
* [ ] Priority set: this PR carries exactly one `priority-*` label.
* [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
* [ ] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`.

## Design System Compliance

* [x] N/A — backend API routes only, no UI changes.

## Linked issues

Part of #3386 (Phase 1: labels + interactions; activities and the audit-only endpoints are separate follow-up PRs).
