### PR TITLE
Fix customer dictionary manage links

### DIFF
--- a/packages/core/src/modules/customers/components/DictionarySettings.tsx
+++ b/packages/core/src/modules/customers/components/DictionarySettings.tsx
@@ -13,7 +13,10 @@ import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimi
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
-import type { CustomerDictionaryKind } from '../lib/dictionaries'
+import {
+  getCustomerDictionarySettingsSectionId,
+  type CustomerDictionaryKind,
+} from '../lib/dictionaries'
 import { ICON_SUGGESTIONS } from '@open-mercato/core/modules/dictionaries/components/dictionaryAppearance'
 import {
   DictionaryForm,
@@ -359,7 +362,10 @@ function CustomerDictionarySection({ kind, title, description }: CustomerDiction
   }), [dialog, t])
 
   return (
-    <section className="rounded border bg-card text-card-foreground shadow-sm">
+    <section
+      id={getCustomerDictionarySettingsSectionId(kind)}
+      className="scroll-mt-24 rounded border bg-card text-card-foreground shadow-sm"
+    >
       <div className="border-b px-6 py-4 space-y-1">
         <h2 className="text-lg font-medium">{title}</h2>
         <p className="text-sm text-muted-foreground">{description}</p>

--- a/packages/core/src/modules/customers/components/DictionarySettings.tsx
+++ b/packages/core/src/modules/customers/components/DictionarySettings.tsx
@@ -49,6 +49,19 @@ const DEFAULT_FORM_VALUES: DictionaryFormValues = {
   icon: null,
 }
 
+const DICTIONARY_HASH_SCROLL_RETRY_DELAYS_MS = [100, 350, 1000] as const
+
+function getCurrentDictionaryHashTarget(): HTMLElement | null {
+  if (typeof window === 'undefined') return null
+  const hash = window.location.hash
+  if (!hash.startsWith('#customer-dictionary-')) return null
+  try {
+    return document.getElementById(decodeURIComponent(hash.slice(1)))
+  } catch {
+    return document.getElementById(hash.slice(1))
+  }
+}
+
 export default function DictionarySettings() {
   const t = useT()
 
@@ -99,6 +112,45 @@ export default function DictionarySettings() {
       description: t('customers.config.dictionaries.sections.addressTypes.description', 'Define the available address types.'),
     },
   ], [t])
+
+  React.useEffect(() => {
+    const timeoutIds: number[] = []
+    let frameId: number | null = null
+
+    const clearScheduledScrolls = () => {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId)
+        frameId = null
+      }
+      while (timeoutIds.length > 0) {
+        const timeoutId = timeoutIds.pop()
+        if (timeoutId !== undefined) window.clearTimeout(timeoutId)
+      }
+    }
+
+    const scrollToHashTarget = () => {
+      getCurrentDictionaryHashTarget()?.scrollIntoView({ block: 'start' })
+    }
+
+    const scheduleHashScroll = () => {
+      clearScheduledScrolls()
+      if (!window.location.hash.startsWith('#customer-dictionary-')) return
+      scrollToHashTarget()
+      if (typeof window.requestAnimationFrame === 'function') {
+        frameId = window.requestAnimationFrame(scrollToHashTarget)
+      }
+      DICTIONARY_HASH_SCROLL_RETRY_DELAYS_MS.forEach((delay) => {
+        timeoutIds.push(window.setTimeout(scrollToHashTarget, delay))
+      })
+    }
+
+    scheduleHashScroll()
+    window.addEventListener('hashchange', scheduleHashScroll)
+    return () => {
+      window.removeEventListener('hashchange', scheduleHashScroll)
+      clearScheduledScrolls()
+    }
+  }, [])
 
   return (
     <div className="space-y-8">

--- a/packages/core/src/modules/customers/components/__tests__/DictionarySelectField.test.tsx
+++ b/packages/core/src/modules/customers/components/__tests__/DictionarySelectField.test.tsx
@@ -1,0 +1,87 @@
+/** @jest-environment jsdom */
+
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import {
+  CUSTOMER_DICTIONARIES_MANAGE_HREF,
+  DictionarySelectField,
+} from '../formConfig'
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({}),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 'test-scope',
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+}))
+
+jest.mock('@open-mercato/core/modules/dictionaries/components/DictionaryEntrySelect', () => ({
+  DictionaryEntrySelect: ({ manageHref }: { manageHref?: string }) => (
+    <a data-testid="manage-link" href={manageHref}>
+      Manage
+    </a>
+  ),
+}))
+
+jest.mock('../AddressTiles', () => ({
+  CustomerAddressTiles: () => null,
+}))
+
+jest.mock('../detail/RolesSection', () => ({
+  RolesSection: () => null,
+}))
+
+const labels = {
+  placeholder: 'Select a job title',
+  addLabel: 'Add job title',
+  dialogTitle: 'Add job title',
+  valueLabel: 'Value',
+  valuePlaceholder: 'Value',
+  labelLabel: 'Label',
+  labelPlaceholder: 'Display name shown in UI',
+  emptyError: 'Value is required',
+  cancelLabel: 'Cancel',
+  saveLabel: 'Save',
+  errorLoad: 'Failed to load options',
+  errorSave: 'Failed to save option',
+  loadingLabel: 'Loading',
+  manageTitle: 'Manage dictionary',
+}
+
+describe('DictionarySelectField', () => {
+  it('links customer dictionaries to the customers configuration page by default', () => {
+    render(
+      <DictionarySelectField
+        kind="job-titles"
+        value={undefined}
+        onChange={() => {}}
+        labels={labels}
+        showManage
+      />,
+    )
+
+    expect(screen.getByTestId('manage-link')).toHaveAttribute(
+      'href',
+      CUSTOMER_DICTIONARIES_MANAGE_HREF,
+    )
+  })
+
+  it('keeps explicit manage links when a caller provides one', () => {
+    render(
+      <DictionarySelectField
+        kind="job-titles"
+        value={undefined}
+        onChange={() => {}}
+        labels={labels}
+        manageHref="/custom/manage"
+        showManage
+      />,
+    )
+
+    expect(screen.getByTestId('manage-link')).toHaveAttribute('href', '/custom/manage')
+  })
+})

--- a/packages/core/src/modules/customers/components/__tests__/DictionarySelectField.test.tsx
+++ b/packages/core/src/modules/customers/components/__tests__/DictionarySelectField.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/react'
 import {
   CUSTOMER_DICTIONARIES_MANAGE_HREF,
   DictionarySelectField,
+  getCustomerDictionaryManageHref,
 } from '../formConfig'
 
 jest.mock('@tanstack/react-query', () => ({
@@ -53,7 +54,7 @@ const labels = {
 }
 
 describe('DictionarySelectField', () => {
-  it('links customer dictionaries to the customers configuration page by default', () => {
+  it('links customer dictionaries to their configuration section by default', () => {
     render(
       <DictionarySelectField
         kind="job-titles"
@@ -66,7 +67,27 @@ describe('DictionarySelectField', () => {
 
     expect(screen.getByTestId('manage-link')).toHaveAttribute(
       'href',
+      getCustomerDictionaryManageHref('job-titles'),
+    )
+  })
+
+  it('keeps customer dictionary manage links on the customers configuration page', () => {
+    render(
+      <DictionarySelectField
+        kind="industries"
+        value={undefined}
+        onChange={() => {}}
+        labels={labels}
+        showManage
+      />,
+    )
+
+    expect(screen.getByTestId('manage-link').getAttribute('href')).toContain(
       CUSTOMER_DICTIONARIES_MANAGE_HREF,
+    )
+    expect(screen.getByTestId('manage-link')).toHaveAttribute(
+      'href',
+      getCustomerDictionaryManageHref('industries'),
     )
   })
 

--- a/packages/core/src/modules/customers/components/__tests__/DictionarySettings.test.tsx
+++ b/packages/core/src/modules/customers/components/__tests__/DictionarySettings.test.tsx
@@ -59,8 +59,12 @@ jest.mock('@open-mercato/core/modules/dictionaries/components/DictionaryTable', 
 }))
 
 describe('DictionarySettings', () => {
+  const originalHash = window.location.hash
+  const originalScrollIntoView = Element.prototype.scrollIntoView
+
   beforeEach(() => {
     jest.clearAllMocks()
+    window.location.hash = originalHash
     confirmMock.mockResolvedValue(false)
     readApiResultOrThrowMock.mockImplementation(async (path: string) => {
       if (path === '/api/customers/dictionaries/person-company-roles') {
@@ -77,6 +81,15 @@ describe('DictionarySettings', () => {
       }
       return { items: [] }
     })
+  })
+
+  afterEach(() => {
+    window.location.hash = originalHash
+    if (originalScrollIntoView) {
+      Element.prototype.scrollIntoView = originalScrollIntoView
+    } else {
+      delete (Element.prototype as Partial<Element>).scrollIntoView
+    }
   })
 
   it('blocks deleting role types that are already in use before sending the request', async () => {
@@ -100,5 +113,21 @@ describe('DictionarySettings', () => {
       }),
     )
     expect(apiCallOrThrowMock).not.toHaveBeenCalled()
+  })
+
+  it('scrolls the linked customer dictionary section after rendering', async () => {
+    const scrollIntoView = jest.fn()
+    Element.prototype.scrollIntoView = scrollIntoView
+    window.location.hash = '#customer-dictionary-job-titles'
+
+    renderWithProviders(<DictionarySettings />)
+
+    const target = document.getElementById('customer-dictionary-job-titles')
+    expect(target).toBeTruthy()
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start' })
+    })
+    expect(scrollIntoView.mock.contexts).toContain(target)
   })
 })

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -51,7 +51,11 @@ import {
   ensureCustomerDictionary,
   invalidateCustomerDictionary,
 } from './detail/hooks/useCustomerDictionary'
-import type { CustomerDictionaryKind } from '../lib/dictionaries'
+import {
+  CUSTOMER_DICTIONARIES_MANAGE_HREF,
+  getCustomerDictionaryManageHref,
+  type CustomerDictionaryKind,
+} from '../lib/dictionaries'
 import { normalizeCustomFieldSubmitValue } from './detail/customFieldUtils'
 import { CUSTOMER_PHONE_INVALID_MESSAGE_KEY } from '../data/validators'
 
@@ -116,7 +120,7 @@ type DictionarySelectFieldProps = {
   showActiveAppearance?: boolean
 }
 
-export const CUSTOMER_DICTIONARIES_MANAGE_HREF = '/backend/config/customers'
+export { CUSTOMER_DICTIONARIES_MANAGE_HREF, getCustomerDictionaryManageHref }
 
 const emailValidationSchema = z.string().email()
 const EMAIL_CHECK_DEBOUNCE_MS = 350
@@ -139,7 +143,7 @@ export function DictionarySelectField({
   onChange,
   labels,
   selectClassName,
-  manageHref = CUSTOMER_DICTIONARIES_MANAGE_HREF,
+  manageHref,
   allowInlineCreate = false,
   allowAppearance = false,
   showManage = false,
@@ -235,7 +239,7 @@ export function DictionarySelectField({
       fetchOptions={fetchOptions}
       createOption={createOption}
       labels={labels}
-      manageHref={manageHref}
+      manageHref={manageHref ?? getCustomerDictionaryManageHref(kind)}
       selectClassName={selectClassName}
       allowInlineCreate={allowInlineCreate}
       allowAppearance={allowAppearance}

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -116,6 +116,8 @@ type DictionarySelectFieldProps = {
   showActiveAppearance?: boolean
 }
 
+export const CUSTOMER_DICTIONARIES_MANAGE_HREF = '/backend/config/customers'
+
 const emailValidationSchema = z.string().email()
 const EMAIL_CHECK_DEBOUNCE_MS = 350
 
@@ -137,7 +139,7 @@ export function DictionarySelectField({
   onChange,
   labels,
   selectClassName,
-  manageHref,
+  manageHref = CUSTOMER_DICTIONARIES_MANAGE_HREF,
   allowInlineCreate = false,
   allowAppearance = false,
   showManage = false,

--- a/packages/core/src/modules/customers/lib/dictionaries.ts
+++ b/packages/core/src/modules/customers/lib/dictionaries.ts
@@ -30,6 +30,16 @@ export type CustomerDictionaryKind = typeof CUSTOMER_DICTIONARY_KINDS[number]
 export type CustomerDictionaryDisplayEntry = DictionaryDisplayEntry
 export type CustomerDictionaryMap = DictionaryMap
 
+export const CUSTOMER_DICTIONARIES_MANAGE_HREF = '/backend/config/customers'
+
+export function getCustomerDictionarySettingsSectionId(kind: CustomerDictionaryKind) {
+  return `customer-dictionary-${kind}`
+}
+
+export function getCustomerDictionaryManageHref(kind: CustomerDictionaryKind) {
+  return `${CUSTOMER_DICTIONARIES_MANAGE_HREF}#${getCustomerDictionarySettingsSectionId(kind)}`
+}
+
 export function createEmptyCustomerDictionaryMaps(): Record<CustomerDictionaryKind, CustomerDictionaryMap> {
   return CUSTOMER_DICTIONARY_KINDS.reduce<Record<CustomerDictionaryKind, CustomerDictionaryMap>>(
     (acc, kind) => {


### PR DESCRIPTION
## Summary

Customer dictionary selectors can expose a manage action for module-owned dictionary values. This change routes those manage links to the customer configuration page by default and deep-links them to the relevant dictionary section, while preserving explicit `manageHref` overrides for callers that need a different destination.

## Changes

- Added shared customer dictionary management href helpers.
- Added stable section anchors to customer dictionary settings.
- Defaulted customer `DictionarySelectField` manage links to section-specific `/backend/config/customers#...` URLs.
- Re-applied the current dictionary hash after render so async-loaded dictionary tables do not leave the target section below the viewport.
- Preserved explicit `manageHref` overrides for custom callers.
- Added focused regression coverage for the default link, explicit override behavior, and customer dictionary section hash scrolling.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

N/A

## Testing

- `corepack yarn workspace @open-mercato/core test src/modules/customers/components/__tests__/DictionarySettings.test.tsx src/modules/customers/components/__tests__/DictionarySelectField.test.tsx src/modules/customers/components/__tests__/formConfig.test.ts --runInBand`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). Component-level coverage is sufficient because this changes the destination passed to an existing link component and verifies the settings page honors section hashes after render; it does not add a new API or end-to-end flow.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

N/A

