### PR TITLE
fix: send optimistic-lock header when toggling workflow definition enabled state (#3333)

### DIFF
--- a/packages/core/src/modules/workflows/backend/definitions/__tests__/page.toggleEnabled.optimisticLock.test.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/__tests__/page.toggleEnabled.optimisticLock.test.tsx
@@ -1,0 +1,160 @@
+/** @jest-environment jsdom */
+
+import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+
+/**
+ * Regression for #3333 — the workflow definitions list toggles a definition's
+ * enabled state with a raw `PUT /api/workflows/definitions/:id` row action. The
+ * API enforces command-level optimistic locking, but treats a *missing*
+ * expected-version header as a no-op lock, so without the header this row action
+ * can silently overwrite a newer definition update.
+ *
+ * Both toggle entry points (the enabled badge and the row-action menu item) MUST
+ * send `buildOptimisticLockHeader(row.original.updatedAt)` via
+ * `withScopedApiRequestHeaders`, exactly like the delete and visual-editor update
+ * paths already do.
+ */
+
+const apiCallMock = jest.fn()
+const surfaceRecordConflictMock = jest.fn<boolean, [unknown, unknown]>(() => false)
+const flashMock = jest.fn()
+const scopedHeaderCalls: Array<Record<string, string>> = []
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+  withScopedApiRequestHeaders: <T,>(headers: Record<string, string>, run: () => Promise<T>) => {
+    scopedHeaderCalls.push(headers)
+    return run()
+  },
+}))
+
+jest.mock('@open-mercato/ui/backend/conflicts', () => ({
+  surfaceRecordConflict: (...args: [unknown, unknown]) => surfaceRecordConflictMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({ flash: (...args: unknown[]) => flashMock(...args) }))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallback?: string) => fallback ?? key,
+}))
+
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }))
+
+jest.mock('next/link', () => ({ children, href }: { children: React.ReactNode; href: string }) => (
+  <a href={href}>{children}</a>
+))
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: [], isLoading: false, error: null }),
+  useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}))
+
+let capturedColumns: Array<{ id?: string; cell?: (ctx: unknown) => React.ReactNode }> = []
+
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  DataTable: (props: { columns: Array<{ id?: string; cell?: (ctx: unknown) => React.ReactNode }> }) => {
+    capturedColumns = props.columns
+    return <div data-testid="data-table-mock" />
+  },
+}))
+
+jest.mock('@open-mercato/ui/backend/RowActions', () => ({
+  RowActions: ({ items }: { items: Array<{ id: string; label: string; onSelect?: () => void }> }) => (
+    <div>
+      {items.map((item) => (
+        <button key={item.id} data-testid={`row-action-${item.id}`} onClick={() => item.onSelect?.()}>
+          {item.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+import * as React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import WorkflowDefinitionsListPage from '../page'
+
+const UPDATED_AT = '2026-06-19T08:42:18.123Z'
+
+function buildDefinition(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'def-1',
+    workflowId: 'wf_demo',
+    workflowName: 'Demo workflow',
+    description: null,
+    version: 1,
+    definition: {},
+    enabled: true,
+    effectiveFrom: null,
+    effectiveTo: null,
+    metadata: null,
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    createdAt: '2026-06-19T08:00:00.000Z',
+    updatedAt: UPDATED_AT,
+    createdBy: null,
+    source: 'user',
+    ...overrides,
+  }
+}
+
+function renderColumns() {
+  capturedColumns = []
+  render(<WorkflowDefinitionsListPage />)
+  return capturedColumns
+}
+
+describe('WorkflowDefinitionsListPage — toggle enabled sends optimistic-lock header (#3333)', () => {
+  beforeEach(() => {
+    apiCallMock.mockReset().mockResolvedValue({ ok: true })
+    surfaceRecordConflictMock.mockReset().mockReturnValue(false)
+    flashMock.mockReset()
+    scopedHeaderCalls.length = 0
+  })
+
+  it('sends the expected updated_at header when toggling via the enabled badge', async () => {
+    const columns = renderColumns()
+    const enabledColumn = columns.find((col) => col.id === 'enabled')
+    expect(enabledColumn?.cell).toBeTruthy()
+
+    render(enabledColumn!.cell!({ row: { original: buildDefinition() } }) as React.ReactElement)
+    fireEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => expect(apiCallMock).toHaveBeenCalledTimes(1))
+    expect(apiCallMock.mock.calls[0][0]).toBe('/api/workflows/definitions/def-1')
+    expect(apiCallMock.mock.calls[0][1]).toMatchObject({ method: 'PUT' })
+    expect(scopedHeaderCalls).toContainEqual({ [OPTIMISTIC_LOCK_HEADER_NAME]: UPDATED_AT })
+  })
+
+  it('sends the expected updated_at header when toggling via the row action', async () => {
+    const columns = renderColumns()
+    const actionsColumn = columns.find((col) => col.id === 'actions')
+    expect(actionsColumn?.cell).toBeTruthy()
+
+    render(actionsColumn!.cell!({ row: { original: buildDefinition({ enabled: true }) } }) as React.ReactElement)
+    fireEvent.click(screen.getByTestId('row-action-disable'))
+
+    await waitFor(() => expect(apiCallMock).toHaveBeenCalledTimes(1))
+    expect(apiCallMock.mock.calls[0][0]).toBe('/api/workflows/definitions/def-1')
+    expect(apiCallMock.mock.calls[0][1]).toMatchObject({ method: 'PUT' })
+    expect(scopedHeaderCalls).toContainEqual({ [OPTIMISTIC_LOCK_HEADER_NAME]: UPDATED_AT })
+  })
+
+  it('surfaces a 409 conflict via surfaceRecordConflict instead of a generic error flash', async () => {
+    apiCallMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      result: { code: 'optimistic_lock_conflict', currentUpdatedAt: '2026-06-19T09:00:00.000Z', expectedUpdatedAt: UPDATED_AT },
+    })
+    surfaceRecordConflictMock.mockReturnValue(true)
+
+    const columns = renderColumns()
+    const enabledColumn = columns.find((col) => col.id === 'enabled')
+    render(enabledColumn!.cell!({ row: { original: buildDefinition() } }) as React.ReactElement)
+    fireEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => expect(surfaceRecordConflictMock).toHaveBeenCalledTimes(1))
+    expect(surfaceRecordConflictMock.mock.calls[0][0]).toMatchObject({ status: 409, code: 'optimistic_lock_conflict' })
+    expect(flashMock).not.toHaveBeenCalledWith(expect.anything(), 'error')
+  })
+})

--- a/packages/core/src/modules/workflows/backend/definitions/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/page.tsx
@@ -153,20 +153,29 @@ export default function WorkflowDefinitionsListPage() {
     setDeleteTarget(null)
   }
 
-  const handleToggleEnabled = async (id: string, currentEnabled: boolean) => {
-    const result = await apiCall(`/api/workflows/definitions/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        enabled: !currentEnabled,
+  const handleToggleEnabled = async (id: string, currentEnabled: boolean, updatedAt: string | null) => {
+    const result = await withScopedApiRequestHeaders(
+      buildOptimisticLockHeader(updatedAt),
+      () => apiCall(`/api/workflows/definitions/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          enabled: !currentEnabled,
+        }),
       }),
-    })
+    )
 
     if (result.ok) {
       flash(t('workflows.messages.updated'), 'success')
       queryClient.invalidateQueries({ queryKey: ['workflow-definitions'] })
     } else {
-      flash(t('workflows.messages.updateFailed'), 'error')
+      const conflictError = Object.assign(new Error(t('workflows.messages.updateFailed')), {
+        status: result.status,
+        ...(result.result && typeof result.result === 'object' ? result.result : {}),
+      })
+      if (!surfaceRecordConflict(conflictError, t)) {
+        flash(t('workflows.messages.updateFailed'), 'error')
+      }
     }
   }
 
@@ -296,7 +305,7 @@ export default function WorkflowDefinitionsListPage() {
       accessorKey: 'enabled',
       cell: ({ row }) => (
         <button
-          onClick={() => handleToggleEnabled(row.original.id, row.original.enabled)}
+          onClick={() => handleToggleEnabled(row.original.id, row.original.enabled, row.original.updatedAt)}
           className={`inline-flex items-center px-2 py-1 rounded text-xs font-medium cursor-pointer ${
             row.original.enabled
               ? 'bg-status-success-bg text-status-success-text hover:bg-status-success-border'
@@ -356,7 +365,7 @@ export default function WorkflowDefinitionsListPage() {
           ...(!isCodeOnly ? [{
             id: row.original.enabled ? 'disable' : 'enable',
             label: row.original.enabled ? t('common.disable') : t('common.enable'),
-            onSelect: () => handleToggleEnabled(row.original.id, row.original.enabled),
+            onSelect: () => handleToggleEnabled(row.original.id, row.original.enabled, row.original.updatedAt),
           }] : []),
           ...(!isCodeOnly ? [{
             id: 'duplicate',


### PR DESCRIPTION
## Summary

The workflow definitions list lets users toggle a definition's enabled state via a row action, but that mutation sent a raw `PUT /api/workflows/definitions/:id` with no optimistic-lock header. The definition API enforces command-level optimistic locking yet treats a *missing* expected-version header as no-conflict, so the toggle could silently overwrite a newer definition update (lost update). This wires the toggle to send `buildOptimisticLockHeader(row.updatedAt)` and surface 409 conflicts — exactly like the delete and visual-editor update paths already do.

## Changes

- `packages/core/src/modules/workflows/backend/definitions/page.tsx`: `handleToggleEnabled` now takes `updatedAt`, wraps the `PUT` in `withScopedApiRequestHeaders(buildOptimisticLockHeader(updatedAt), …)`, and surfaces 409s via `surfaceRecordConflict(err, t)` (falling back to the generic error flash). Both call sites (the enabled badge cell and the row-action menu item) now pass `row.original.updatedAt`.
- Added `packages/core/src/modules/workflows/backend/definitions/__tests__/page.toggleEnabled.optimisticLock.test.tsx`: a render/interaction regression that asserts the optimistic-lock header is sent for both toggle entry points and that a 409 routes to `surfaceRecordConflict` instead of a generic error flash.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
Related (not modified): `.ai/specs/2026-05-28-optimistic-locking-coverage-completion.md` — this is a single missed call site within the already-shipped optimistic-locking pattern, not a new spec surface.

## Testing

- `yarn workspace @open-mercato/core test page.toggleEnabled.optimisticLock` — red before fix → **3 passed** after.
- `yarn typecheck --filter=@open-mercato/core` — pass.
- `yarn workspace @open-mercato/core test optimistic-lock-ui-coverage optimistic-lock-editable-entities "modules/workflows/"` — **32 suites / 583 tests passed** (both lock guards green).
- `yarn i18n:check-sync` — all 4 locales in sync.
- `yarn build:app` — compiled successfully.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No new locale keys/docs/generators — reuses existing `workflows.messages.*`.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Covered by a unit/render test; the server-side 409 enforcement already has API-level coverage in `api/definitions/[id]/__tests__/optimistic-lock.test.ts`, and a concurrent-edit race is impractical to drive in Playwright for a header-only change.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A for this single-call-site fix.
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-low` — isolated single-module UI fix with tests.)
- [x] QA routing set: `needs-qa` (customer-facing UI behavior change). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no markup changed (existing toggle button already uses `status-*` tokens).
- [x] No arbitrary text sizes — N/A, no markup changed.
- [x] Empty state handled for list/data pages — already handled (`DataTable emptyState`), unchanged.
- [x] Loading state handled for async pages — already handled (`useQuery` loading/error), unchanged.
- [x] `aria-label` on all icon-only buttons — N/A, no new icon-only buttons (toggle button has text).
- [x] Uses existing DS components — N/A, no new components.

## Linked issues

Fixes #3333

🤖 Generated with [Claude Code](https://claude.com/claude-code)
