### PR TITLE
fix(staff): route timesheet timer writes through guards

### DIFF
--- a/packages/core/src/modules/staff/lib/timesheets-ui/TimerBar.tsx
+++ b/packages/core/src/modules/staff/lib/timesheets-ui/TimerBar.tsx
@@ -7,6 +7,7 @@ import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { ProjectColorDot } from './ProjectColorDot'
 
 type ProjectOption = {
@@ -20,6 +21,17 @@ type TimerBarProps = {
   projects: ProjectOption[]
   staffMemberId: string | null
   onTimerStopped: () => void
+}
+
+const TIMER_MUTATION_CONTEXT_ID = 'staff-timesheets-timer-bar'
+
+type TimerMutationContext = {
+  formId: string
+  resourceKind: string
+  resourceId: string
+  staffMemberId: string | null
+  action: 'timer-create' | 'timer-start' | 'timer-stop'
+  retryLastMutation: () => Promise<boolean>
 }
 
 function formatElapsed(seconds: number): string {
@@ -39,6 +51,10 @@ function getToday(): string {
 
 export function TimerBar({ projects, staffMemberId, onTimerStopped }: TimerBarProps) {
   const t = useT()
+  const { runMutation, retryLastMutation } = useGuardedMutation<TimerMutationContext>({
+    contextId: TIMER_MUTATION_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
 
   const [activeEntryId, setActiveEntryId] = useState<string | null>(null)
   const [activeProjectId, setActiveProjectId] = useState<string | null>(null)
@@ -140,31 +156,62 @@ export function TimerBar({ projects, staffMemberId, onTimerStopped }: TimerBarPr
     setIsStarting(true)
     try {
       const today = getToday()
-      const createResponse = await apiCallOrThrow(
-        '/api/staff/timesheets/time-entries',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            staffMemberId,
-            timeProjectId: selectedProjectId,
-            date: today,
-            durationMinutes: 0,
-            source: 'timer',
-            notes: description || null,
-          }),
+      const createPayload = {
+        staffMemberId,
+        timeProjectId: selectedProjectId,
+        date: today,
+        durationMinutes: 0,
+        source: 'timer',
+        notes: description || null,
+      }
+      const createResponse = await runMutation({
+        operation: () =>
+          apiCallOrThrow(
+            '/api/staff/timesheets/time-entries',
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(createPayload),
+            },
+          ),
+        context: {
+          formId: TIMER_MUTATION_CONTEXT_ID,
+          resourceKind: 'staff.timesheets.time_entry',
+          resourceId: staffMemberId,
+          staffMemberId,
+          action: 'timer-create',
+          retryLastMutation,
         },
-      )
+        mutationPayload: createPayload,
+      })
 
       const created = createResponse.result as Record<string, unknown> | null
       const entryId = created?.id as string | undefined
+      if (!entryId) throw new Error('Failed to extract entry ID')
 
-      await apiCallOrThrow(
-        `/api/staff/timesheets/time-entries/${entryId}/timer-start`,
-        { method: 'POST' },
-      )
+      const startPayload = {
+        id: entryId,
+        action: 'timer-start',
+        staffMemberId,
+      }
+      await runMutation({
+        operation: () =>
+          apiCallOrThrow(
+            `/api/staff/timesheets/time-entries/${entryId}/timer-start`,
+            { method: 'POST' },
+          ),
+        context: {
+          formId: TIMER_MUTATION_CONTEXT_ID,
+          resourceKind: 'staff.timesheets.time_entry',
+          resourceId: entryId,
+          staffMemberId,
+          action: 'timer-start',
+          retryLastMutation,
+        },
+        mutationPayload: startPayload,
+      })
 
-      setActiveEntryId(entryId ?? null)
+      setActiveEntryId(entryId)
       setActiveProjectId(selectedProjectId)
       startElapsedCounter(new Date().toISOString())
     } catch {
@@ -182,10 +229,27 @@ export function TimerBar({ projects, staffMemberId, onTimerStopped }: TimerBarPr
 
     setIsStopping(true)
     try {
-      await apiCallOrThrow(
-        `/api/staff/timesheets/time-entries/${activeEntryId}/timer-stop`,
-        { method: 'POST' },
-      )
+      const stopPayload = {
+        id: activeEntryId,
+        action: 'timer-stop',
+        staffMemberId,
+      }
+      await runMutation({
+        operation: () =>
+          apiCallOrThrow(
+            `/api/staff/timesheets/time-entries/${activeEntryId}/timer-stop`,
+            { method: 'POST' },
+          ),
+        context: {
+          formId: TIMER_MUTATION_CONTEXT_ID,
+          resourceKind: 'staff.timesheets.time_entry',
+          resourceId: activeEntryId,
+          staffMemberId,
+          action: 'timer-stop',
+          retryLastMutation,
+        },
+        mutationPayload: stopPayload,
+      })
 
       setActiveEntryId(null)
       setActiveProjectId(null)

--- a/packages/core/src/modules/staff/lib/timesheets-ui/__tests__/TimerBar.guardedMutation.test.tsx
+++ b/packages/core/src/modules/staff/lib/timesheets-ui/__tests__/TimerBar.guardedMutation.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { TimerBar } from '../TimerBar'
+import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+
+const mockRunMutation = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+const mockRetryLastMutation = jest.fn(async () => true)
+const mockTranslate = (_key: string, fallback?: string) => fallback ?? ''
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: mockRunMutation,
+    retryLastMutation: mockRetryLastMutation,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+  apiCallOrThrow: jest.fn(),
+}))
+
+const mockApiCall = apiCall as jest.MockedFunction<typeof apiCall>
+const mockApiCallOrThrow = apiCallOrThrow as jest.MockedFunction<typeof apiCallOrThrow>
+
+const projects = [
+  { id: 'project-1', name: 'Build', code: 'BLD', color: null },
+]
+
+describe('TimerBar guarded mutations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRunMutation.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+    mockApiCall.mockResolvedValue({ ok: true, result: { items: [] } } as any)
+    mockApiCallOrThrow.mockResolvedValue({ result: { id: 'entry-1' } } as any)
+  })
+
+  it('routes timer create and start through guarded mutation context', async () => {
+    render(<TimerBar projects={projects} staffMemberId="staff-1" onTimerStopped={jest.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Project' }))
+    fireEvent.click(screen.getByRole('button', { name: /Build/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Start timer' }))
+
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalledTimes(2))
+    expect(mockRunMutation).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      context: expect.objectContaining({
+        resourceKind: 'staff.timesheets.time_entry',
+        resourceId: 'staff-1',
+        staffMemberId: 'staff-1',
+        retryLastMutation: mockRetryLastMutation,
+      }),
+      mutationPayload: expect.objectContaining({
+        staffMemberId: 'staff-1',
+        timeProjectId: 'project-1',
+        source: 'timer',
+      }),
+    }))
+    expect(mockRunMutation).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      context: expect.objectContaining({
+        resourceKind: 'staff.timesheets.time_entry',
+        resourceId: 'entry-1',
+        staffMemberId: 'staff-1',
+        retryLastMutation: mockRetryLastMutation,
+      }),
+      mutationPayload: {
+        id: 'entry-1',
+        action: 'timer-start',
+        staffMemberId: 'staff-1',
+      },
+    }))
+  })
+
+  it('routes timer stop through guarded mutation context', async () => {
+    mockApiCall.mockResolvedValue({
+      ok: true,
+      result: {
+        items: [{
+          id: 'entry-1',
+          time_project_id: 'project-1',
+          notes: 'Build task',
+          started_at: new Date().toISOString(),
+          ended_at: null,
+        }],
+      },
+    } as any)
+
+    render(<TimerBar projects={projects} staffMemberId="staff-1" onTimerStopped={jest.fn()} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Stop timer' }))
+
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalledTimes(1))
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({
+        resourceKind: 'staff.timesheets.time_entry',
+        resourceId: 'entry-1',
+        staffMemberId: 'staff-1',
+        retryLastMutation: mockRetryLastMutation,
+      }),
+      mutationPayload: {
+        id: 'entry-1',
+        action: 'timer-stop',
+        staffMemberId: 'staff-1',
+      },
+    }))
+  })
+})

--- a/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/__tests__/widget.client.guardedMutation.test.tsx
+++ b/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/__tests__/widget.client.guardedMutation.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import TimeReportingWidget from '../widget.client'
+import { apiCall, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+
+const mockRunMutation = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+const mockRetryLastMutation = jest.fn(async () => true)
+const mockOnSettingsChange = jest.fn()
+const mockTranslate = (_key: string, fallback?: string) => fallback ?? ''
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: mockRunMutation,
+    retryLastMutation: mockRetryLastMutation,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+  readApiResultOrThrow: jest.fn(),
+}))
+
+const mockApiCall = apiCall as jest.MockedFunction<typeof apiCall>
+const mockReadApiResultOrThrow = readApiResultOrThrow as jest.MockedFunction<typeof readApiResultOrThrow>
+
+function renderWidget() {
+  render(
+    <TimeReportingWidget
+      {...({
+        mode: 'view',
+        settings: {},
+        onSettingsChange: mockOnSettingsChange,
+      } as any)}
+    />,
+  )
+}
+
+function mockWidgetReads({ running }: { running: boolean }) {
+  mockReadApiResultOrThrow.mockImplementation(async (path: string) => {
+    if (path === '/api/staff/timesheets/my-projects?pageSize=100') {
+      return { items: [{ time_project_id: 'project-1' }] } as any
+    }
+    if (path === '/api/staff/timesheets/time-projects?ids=project-1&pageSize=100') {
+      return { items: [{ id: 'project-1', name: 'Build', code: 'BLD' }] } as any
+    }
+    if (path === '/api/staff/team-members/self') {
+      return { member: { id: 'staff-1' } } as any
+    }
+    if (path.startsWith('/api/staff/timesheets/time-entries?')) {
+      return {
+        items: running
+          ? [{
+            id: 'entry-1',
+            started_at: new Date().toISOString(),
+            ended_at: null,
+            time_project_id: 'project-1',
+          }]
+          : [],
+      } as any
+    }
+    return { items: [] } as any
+  })
+}
+
+describe('TimeReportingWidget guarded mutations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRunMutation.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+    mockApiCall.mockResolvedValue({ ok: true, result: { id: 'entry-1' } } as any)
+  })
+
+  it('routes timer create and start through guarded mutation context', async () => {
+    mockWidgetReads({ running: false })
+    renderWidget()
+
+    fireEvent.change(await screen.findByLabelText('Project'), { target: { value: 'project-1' } })
+    fireEvent.change(screen.getByLabelText('Task / Note'), { target: { value: 'Build task' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Start Timer' }))
+
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalledTimes(2))
+    expect(mockRunMutation).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      context: expect.objectContaining({
+        resourceKind: 'staff.timesheets.time_entry',
+        resourceId: 'staff-1',
+        staffMemberId: 'staff-1',
+        retryLastMutation: mockRetryLastMutation,
+      }),
+      mutationPayload: expect.objectContaining({
+        staffMemberId: 'staff-1',
+        timeProjectId: 'project-1',
+        source: 'timer',
+        notes: 'Build task',
+      }),
+    }))
+    expect(mockRunMutation).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      context: expect.objectContaining({
+        resourceKind: 'staff.timesheets.time_entry',
+        resourceId: 'entry-1',
+        staffMemberId: 'staff-1',
+        retryLastMutation: mockRetryLastMutation,
+      }),
+      mutationPayload: {
+        id: 'entry-1',
+        action: 'timer-start',
+        staffMemberId: 'staff-1',
+      },
+    }))
+  })
+
+  it('routes timer stop through guarded mutation context', async () => {
+    mockWidgetReads({ running: true })
+    renderWidget()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Stop Timer' }))
+
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalledTimes(1))
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({
+        resourceKind: 'staff.timesheets.time_entry',
+        resourceId: 'entry-1',
+        staffMemberId: 'staff-1',
+        retryLastMutation: mockRetryLastMutation,
+      }),
+      mutationPayload: {
+        id: 'entry-1',
+        action: 'timer-stop',
+        staffMemberId: 'staff-1',
+      },
+    }))
+  })
+})

--- a/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/widget.client.tsx
+++ b/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/widget.client.tsx
@@ -6,6 +6,7 @@ import { apiCall, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/ap
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Input } from '@open-mercato/ui/primitives/input'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { DEFAULT_SETTINGS, hydrateSettings, type TimeReportingSettings } from './config'
 
 type ProjectOption = { id: string; name: string; code: string | null }
@@ -15,6 +16,17 @@ type TimerState = {
   running: boolean
   startedAt: string | null
   projectId: string | null
+}
+
+const TIMER_WIDGET_MUTATION_CONTEXT_ID = 'staff-timesheets-time-reporting-widget'
+
+type TimerWidgetMutationContext = {
+  formId: string
+  resourceKind: string
+  resourceId: string
+  staffMemberId: string
+  action: 'timer-create' | 'timer-start' | 'timer-stop'
+  retryLastMutation: () => Promise<boolean>
 }
 
 function formatElapsed(startedAt: string): string {
@@ -34,6 +46,10 @@ const TimeReportingWidget: React.FC<DashboardWidgetComponentProps<TimeReportingS
   onRefreshStateChange,
 }) => {
   const t = useT()
+  const { runMutation, retryLastMutation } = useGuardedMutation<TimerWidgetMutationContext>({
+    contextId: TIMER_WIDGET_MUTATION_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
 
   const [projects, setProjects] = React.useState<ProjectOption[]>([])
@@ -138,25 +154,54 @@ const TimeReportingWidget: React.FC<DashboardWidgetComponentProps<TimeReportingS
     setActionLoading(true)
     try {
       const today = new Date().toISOString().slice(0, 10)
-      // Create entry + start timer
-      const createRes = await apiCall<Record<string, unknown>>('/api/staff/timesheets/time-entries', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
+      const createPayload = {
+        staffMemberId,
+        date: today,
+        timeProjectId: selectedProjectId,
+        durationMinutes: 0,
+        notes: notes.trim() || null,
+        source: 'timer',
+      }
+      const createRes = await runMutation({
+        operation: () =>
+          apiCall<Record<string, unknown>>('/api/staff/timesheets/time-entries', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(createPayload),
+          }),
+        context: {
+          formId: TIMER_WIDGET_MUTATION_CONTEXT_ID,
+          resourceKind: 'staff.timesheets.time_entry',
+          resourceId: staffMemberId,
           staffMemberId,
-          date: today,
-          timeProjectId: selectedProjectId,
-          durationMinutes: 0,
-          notes: notes.trim() || null,
-          source: 'timer',
-        }),
+          action: 'timer-create',
+          retryLastMutation,
+        },
+        mutationPayload: createPayload,
       })
       if (!createRes.ok) throw new Error('Failed to create entry')
       const body = createRes.result as Record<string, unknown> | null
       const entryId = String(body?.id ?? (body?.item as Record<string, unknown> | undefined)?.id ?? '')
       if (!entryId) throw new Error('Failed to extract entry ID')
 
-      await apiCall(`/api/staff/timesheets/time-entries/${entryId}/timer-start`, { method: 'POST' })
+      const startPayload = {
+        id: entryId,
+        action: 'timer-start',
+        staffMemberId,
+      }
+      await runMutation({
+        operation: () =>
+          apiCall(`/api/staff/timesheets/time-entries/${entryId}/timer-start`, { method: 'POST' }),
+        context: {
+          formId: TIMER_WIDGET_MUTATION_CONTEXT_ID,
+          resourceKind: 'staff.timesheets.time_entry',
+          resourceId: entryId,
+          staffMemberId,
+          action: 'timer-start',
+          retryLastMutation,
+        },
+        mutationPayload: startPayload,
+      })
 
       onSettingsChange({ ...hydrated, lastProjectId: selectedProjectId })
       await loadState()
@@ -166,13 +211,30 @@ const TimeReportingWidget: React.FC<DashboardWidgetComponentProps<TimeReportingS
     } finally {
       setActionLoading(false)
     }
-  }, [selectedProjectId, staffMemberId, timer.running, notes, hydrated, onSettingsChange, loadState, t])
+  }, [selectedProjectId, staffMemberId, timer.running, notes, hydrated, onSettingsChange, loadState, runMutation, retryLastMutation, t])
 
   const handleStop = React.useCallback(async () => {
-    if (!timer.entryId) return
+    if (!timer.entryId || !staffMemberId) return
     setActionLoading(true)
     try {
-      await apiCall(`/api/staff/timesheets/time-entries/${timer.entryId}/timer-stop`, { method: 'POST' })
+      const stopPayload = {
+        id: timer.entryId,
+        action: 'timer-stop',
+        staffMemberId,
+      }
+      await runMutation({
+        operation: () =>
+          apiCall(`/api/staff/timesheets/time-entries/${timer.entryId}/timer-stop`, { method: 'POST' }),
+        context: {
+          formId: TIMER_WIDGET_MUTATION_CONTEXT_ID,
+          resourceKind: 'staff.timesheets.time_entry',
+          resourceId: timer.entryId,
+          staffMemberId,
+          action: 'timer-stop',
+          retryLastMutation,
+        },
+        mutationPayload: stopPayload,
+      })
       await loadState()
     } catch (err) {
       console.error('staff.timesheets.timeReporting.stop', err)
@@ -180,7 +242,7 @@ const TimeReportingWidget: React.FC<DashboardWidgetComponentProps<TimeReportingS
     } finally {
       setActionLoading(false)
     }
-  }, [timer.entryId, loadState, t])
+  }, [timer.entryId, staffMemberId, loadState, runMutation, retryLastMutation, t])
 
   if (mode === 'settings') {
     return (


### PR DESCRIPTION
## Summary

Fixes #3308.

Routes staff timesheet timer create/start/stop writes through the guarded mutation flow so mutation guards and blocked-save handling apply consistently in both the timer bar and dashboard time-reporting widget.

## Changes

- Wrap `TimerBar` timer create/start/stop mutations with `useGuardedMutation`.
- Wrap dashboard time-reporting widget timer create/start/stop mutations with `useGuardedMutation`.
- Add focused jsdom regression tests that prove each timer write path uses the guarded mutation runner.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- `cd packages/core && yarn exec jest --config jest.config.cjs --runTestsByPath src/modules/staff/lib/timesheets-ui/__tests__/TimerBar.guardedMutation.test.tsx src/modules/staff/widgets/dashboard/timesheets-time-reporting/__tests__/widget.client.guardedMutation.test.tsx --runInBand`
- `yarn build:packages`
- `yarn generate`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- `yarn exec eslint packages/core/src/modules/staff/lib/timesheets-ui/TimerBar.tsx packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/widget.client.tsx packages/core/src/modules/staff/lib/timesheets-ui/__tests__/TimerBar.guardedMutation.test.tsx packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/__tests__/widget.client.guardedMutation.test.tsx`
- `git diff --cached --check`

Note: full `yarn lint` is blocked by unrelated pre-existing hook-order errors in `apps/mercato/src/components/OrganizationSwitcher.tsx`.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3308
