### PR TITLE
fix: inline timesheet description save handles failed API responses (#3309)

### DIFF
--- a/packages/core/src/modules/staff/i18n/de.json
+++ b/packages/core/src/modules/staff/i18n/de.json
@@ -976,6 +976,7 @@
   "staff.timesheets.my.errors.updateAssignment": "Failed to update projects.",
   "staff.timesheets.my.list.addDescription": "Add description",
   "staff.timesheets.my.list.noEntries": "No entries for this period.",
+  "staff.timesheets.my.list.saveError": "Beschreibung konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
   "staff.timesheets.my.list.today": "Today",
   "staff.timesheets.my.list.yesterday": "Yesterday",
   "staff.timesheets.my.loading": "Loading timesheets...",

--- a/packages/core/src/modules/staff/i18n/en.json
+++ b/packages/core/src/modules/staff/i18n/en.json
@@ -976,6 +976,7 @@
   "staff.timesheets.my.errors.updateAssignment": "Failed to update projects.",
   "staff.timesheets.my.list.addDescription": "Add description",
   "staff.timesheets.my.list.noEntries": "No entries for this period.",
+  "staff.timesheets.my.list.saveError": "Failed to save description. Please try again.",
   "staff.timesheets.my.list.today": "Today",
   "staff.timesheets.my.list.yesterday": "Yesterday",
   "staff.timesheets.my.loading": "Loading timesheets...",

--- a/packages/core/src/modules/staff/i18n/es.json
+++ b/packages/core/src/modules/staff/i18n/es.json
@@ -976,6 +976,7 @@
   "staff.timesheets.my.errors.updateAssignment": "Failed to update projects.",
   "staff.timesheets.my.list.addDescription": "Add description",
   "staff.timesheets.my.list.noEntries": "No entries for this period.",
+  "staff.timesheets.my.list.saveError": "No se pudo guardar la descripción. Inténtalo de nuevo.",
   "staff.timesheets.my.list.today": "Today",
   "staff.timesheets.my.list.yesterday": "Yesterday",
   "staff.timesheets.my.loading": "Loading timesheets...",

--- a/packages/core/src/modules/staff/i18n/pl.json
+++ b/packages/core/src/modules/staff/i18n/pl.json
@@ -976,6 +976,7 @@
   "staff.timesheets.my.errors.updateAssignment": "Failed to update projects.",
   "staff.timesheets.my.list.addDescription": "Add description",
   "staff.timesheets.my.list.noEntries": "No entries for this period.",
+  "staff.timesheets.my.list.saveError": "Nie udało się zapisać opisu. Spróbuj ponownie.",
   "staff.timesheets.my.list.today": "Today",
   "staff.timesheets.my.list.yesterday": "Yesterday",
   "staff.timesheets.my.loading": "Loading timesheets...",

--- a/packages/core/src/modules/staff/lib/timesheets-ui/ListView.tsx
+++ b/packages/core/src/modules/staff/lib/timesheets-ui/ListView.tsx
@@ -3,7 +3,9 @@
 import * as React from 'react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { ProjectColorDot } from './ProjectColorDot'
 
 type TimeEntry = {
@@ -86,6 +88,7 @@ function InlineDescription({
   placeholder: string
   onSaved?: () => void
 }) {
+  const t = useT()
   const [editing, setEditing] = React.useState(false)
   const [value, setValue] = React.useState(initialValue ?? '')
   const [saving, setSaving] = React.useState(false)
@@ -103,19 +106,24 @@ function InlineDescription({
     }
     setSaving(true)
     try {
-      await apiCall(`/api/staff/timesheets/time-entries`, {
+      await apiCallOrThrow(`/api/staff/timesheets/time-entries`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: entryId, notes: trimmed || null }),
       })
-      onSaved?.()
-    } catch {
-      // silent
-    } finally {
       setSaving(false)
       setEditing(false)
+      onSaved?.()
+    } catch (err) {
+      setSaving(false)
+      if (!surfaceRecordConflict(err, t)) {
+        flash(
+          t('staff.timesheets.my.list.saveError', 'Failed to save description. Please try again.'),
+          'error',
+        )
+      }
     }
-  }, [entryId, value, initialValue, onSaved])
+  }, [entryId, value, initialValue, onSaved, t])
 
   if (!editing) {
     return (

--- a/packages/core/src/modules/staff/lib/timesheets-ui/__tests__/ListView.save.test.tsx
+++ b/packages/core/src/modules/staff/lib/timesheets-ui/__tests__/ListView.save.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ListView } from '../ListView'
+import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(async () => ({ ok: false, status: 500, result: null, response: {} })),
+  apiCallOrThrow: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/conflicts', () => ({
+  surfaceRecordConflict: jest.fn(() => false),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+const apiCallOrThrowMock = apiCallOrThrow as unknown as jest.Mock
+const surfaceRecordConflictMock = surfaceRecordConflict as unknown as jest.Mock
+const flashMock = flash as unknown as jest.Mock
+
+const ENTRY = {
+  id: 'entry-1',
+  date: '2026-06-19',
+  durationMinutes: 60,
+  projectId: 'project-1',
+  projectName: 'Project One',
+  projectCode: null,
+  projectColor: null,
+  notes: null,
+  source: 'manual',
+  startedAt: null,
+  endedAt: null,
+}
+
+function startEditingAndSubmit(newValue: string) {
+  fireEvent.click(screen.getByRole('button', { name: 'Add description' }))
+  const input = screen.getByRole('textbox') as HTMLInputElement
+  fireEvent.change(input, { target: { value: newValue } })
+  fireEvent.keyDown(input, { key: 'Enter' })
+}
+
+describe('timesheet inline description save', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    surfaceRecordConflictMock.mockReturnValue(false)
+  })
+
+  it('does not treat a failed PUT as success: keeps the editor open, flashes an error, and never calls onEntryUpdated', async () => {
+    apiCallOrThrowMock.mockRejectedValue(Object.assign(new Error('Server error'), { status: 500 }))
+    const onEntryUpdated = jest.fn()
+
+    render(<ListView entries={[ENTRY]} onEntryUpdated={onEntryUpdated} />)
+    startEditingAndSubmit('Updated note')
+
+    await waitFor(() => {
+      expect(flashMock).toHaveBeenCalledWith(
+        'Failed to save description. Please try again.',
+        'error',
+      )
+    })
+    expect(onEntryUpdated).not.toHaveBeenCalled()
+    // Editor stays open so the user can retry — the input is still present.
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('treats a 2xx PUT as success: closes the editor and calls onEntryUpdated', async () => {
+    apiCallOrThrowMock.mockResolvedValue({ ok: true, status: 200, result: { ok: true }, response: {} })
+    const onEntryUpdated = jest.fn()
+
+    render(<ListView entries={[ENTRY]} onEntryUpdated={onEntryUpdated} />)
+    startEditingAndSubmit('Updated note')
+
+    await waitFor(() => {
+      expect(onEntryUpdated).toHaveBeenCalledTimes(1)
+    })
+    expect(flashMock).not.toHaveBeenCalled()
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+
+  it('surfaces the conflict bar on a 409 conflict instead of a generic error and does not call onEntryUpdated', async () => {
+    apiCallOrThrowMock.mockRejectedValue(Object.assign(new Error('Conflict'), { status: 409 }))
+    surfaceRecordConflictMock.mockReturnValue(true)
+    const onEntryUpdated = jest.fn()
+
+    render(<ListView entries={[ENTRY]} onEntryUpdated={onEntryUpdated} />)
+    startEditingAndSubmit('Updated note')
+
+    await waitFor(() => {
+      expect(surfaceRecordConflictMock).toHaveBeenCalledTimes(1)
+    })
+    expect(flashMock).not.toHaveBeenCalled()
+    expect(onEntryUpdated).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

The inline timesheet description editor (`InlineDescription` in the staff timesheets ListView) treated failed `PUT /api/staff/timesheets/time-entries` responses as successful saves. `apiCall` resolves `{ ok: false }` on handled HTTP failures instead of throwing, but the code only caught thrown exceptions, then called `onSaved?.()` and closed the editor in a `finally` — hiding validation, RBAC, conflict, and server errors from the user. This makes the save only succeed on a 2xx response; on failure it keeps the editor open and surfaces the error.

## Changes

- `packages/core/src/modules/staff/lib/timesheets-ui/ListView.tsx`: use `apiCallOrThrow` instead of `apiCall`; only call `onSaved?.()` and close the editor on a 2xx response; on failure keep the editor open (and the typed value) so the user can retry, surface a 409 optimistic-lock conflict via `surfaceRecordConflict`, otherwise show a translated `flash` error.
- `packages/core/src/modules/staff/i18n/{en,de,es,pl}.json`: add `staff.timesheets.my.list.saveError`.
- `packages/core/src/modules/staff/lib/timesheets-ui/__tests__/ListView.save.test.tsx`: new RTL test covering failure (editor stays open, error flashed, `onEntryUpdated` not called), success (editor closes, `onEntryUpdated` called), and 409 conflict (conflict bar surfaced, no generic flash).

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — isolated bug fix in one component.

## Testing

- `yarn workspace @open-mercato/core test ListView.save` → 3/3 pass (verified red on the pre-fix code: 2/3 failed for the right reason)
- `yarn workspace @open-mercato/core test src/modules/staff` → 86/86 pass
- `yarn workspace @open-mercato/core test optimistic-lock-ui-coverage` → pass
- `yarn i18n:check-sync` → all 4 locales in sync
- `yarn build:packages` → 21/21
- `yarn generate` && `yarn typecheck` → 21/21
- `build:app` deferred to CI `prepare` (compile covered by build:packages + typecheck).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (Added `saveError` to all 4 locale files.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — N/A: this is the failure path of an inline-edit save; forcing a deterministic non-2xx response isn't reproducible in the live Playwright flow. Covered by a component-level RTL test that renders the real component across success/failure/409.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A, no spec.
- [x] Priority set: this PR carries exactly one `priority-*` label (`priority-high`, inherited from the issue).
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-medium`, inherited from the issue).
- [x] QA routing set: `needs-qa` (customer-facing UI behavior). Note for QA: success path is easy to exercise; the failure path requires inducing a non-2xx PUT (e.g. throttled/offline) — on failure the inline editor must stay open and show an error.

### Design System Compliance
- [x] No hardcoded status colors — change adds none; error feedback routes through the DS `flash` and the shared conflict bar.
- [x] No arbitrary text sizes — none added.
- [x] Empty state handled for list/data pages — existing `noEntries` empty state unchanged.
- [x] Loading state handled for async pages — existing `saving` state preserved; input disabled while saving.
- [x] `aria-label` on all icon-only buttons — N/A, no icon-only buttons in this change.
- [x] Uses existing DS components — reuses `flash` (FlashMessages) and `surfaceRecordConflict` (conflict bar); no custom replacements.

## Linked issues

Fixes #3309
