### PR TITLE
fix: route TranslationManager writes through useGuardedMutation (#3316)

### DIFF
--- a/packages/core/src/modules/translations/components/TranslationManager.tsx
+++ b/packages/core/src/modules/translations/components/TranslationManager.tsx
@@ -9,6 +9,7 @@ import { LoadingMessage, ErrorMessage } from '@open-mercato/ui/backend/detail'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { apiCall, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useCustomFieldDefs } from '@open-mercato/ui/backend/utils/customFieldDefs'
 import { Save, Plus, X } from 'lucide-react'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
@@ -18,6 +19,9 @@ import { ISO_639_1, isValidIso639, getIso639Label } from '@open-mercato/shared/l
 import { formatEntityLabel, buildEntityListUrl, getRecordLabel, resolveBaseValue } from '../lib/helpers'
 import { resolveFieldList } from '../lib/resolve-field-list'
 import type { ResolvedField } from '../lib/resolve-field-list'
+
+const TRANSLATION_MUTATION_CONTEXT_ID = 'translations.entity-translations'
+const SUPPORTED_LOCALES_MUTATION_CONTEXT_ID = 'translations.supported-locales'
 
 type TranslationManagerProps = {
   entityType?: string
@@ -218,6 +222,16 @@ export function TranslationManager({
     }
   }, [translationSignature, translationData])
 
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    entityType: string
+    recordId: string
+    resourceKind: string
+    resourceId: string
+    data: TranslationsResponse | null
+    retryLastMutation: () => Promise<boolean>
+  }>({ contextId: TRANSLATION_MUTATION_CONTEXT_ID })
+
   const mutation = useMutation({
     mutationFn: async () => {
       if (!entityType || !recordId) {
@@ -239,21 +253,35 @@ export function TranslationManager({
         console.warn('[translations] Save skipped: payload is empty — no locale contains any non-empty field')
         throw new Error(t('translations.manager.errors.nothingToSave', 'Nothing to save — enter a translation first'))
       }
-      const res = await withScopedApiRequestHeaders(
-        buildOptimisticLockHeader(translationData?.updatedAt),
-        () => apiCall(
-          `/api/translations/${encodeURIComponent(entityType)}/${encodeURIComponent(recordId)}`,
-          {
-            method: 'PUT',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify(body),
-          },
-        ),
-      )
-      if (!res.ok) {
-        throw new Error(t('translations.manager.errors.save', 'Failed to save translations'))
-      }
-      return true
+      return runMutation({
+        operation: async () => {
+          const res = await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(translationData?.updatedAt),
+            () => apiCall(
+              `/api/translations/${encodeURIComponent(entityType)}/${encodeURIComponent(recordId)}`,
+              {
+                method: 'PUT',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify(body),
+              },
+            ),
+          )
+          if (!res.ok) {
+            throw new Error(t('translations.manager.errors.save', 'Failed to save translations'))
+          }
+          return true
+        },
+        context: {
+          formId: TRANSLATION_MUTATION_CONTEXT_ID,
+          entityType,
+          recordId,
+          resourceKind: 'translation',
+          resourceId: recordId,
+          data: translationData ?? null,
+          retryLastMutation,
+        },
+        mutationPayload: body,
+      })
     },
     onSuccess: () => {
       flash(t('translations.manager.flash.saved', 'Translations saved'), 'success')
@@ -541,16 +569,32 @@ export function LocaleManager() {
   const { data: locales = [], isLoading } = useTranslationLocales()
   const [newLocale, setNewLocale] = React.useState('')
 
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({ contextId: SUPPORTED_LOCALES_MUTATION_CONTEXT_ID })
+
   const mutation = useMutation({
     mutationFn: async (updatedLocales: string[]) => {
       // optimistic-lock-exempt: single-row tenant supported-locales settings list — no per-record version / concurrent record edit
-      const res = await apiCall<{ locales: string[] }>('/api/translations/locales', {
-        method: 'PUT',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ locales: updatedLocales }),
+      return runMutation({
+        operation: async () => {
+          const res = await apiCall<{ locales: string[] }>('/api/translations/locales', {
+            method: 'PUT',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ locales: updatedLocales }),
+          })
+          if (!res.ok) throw new Error('Failed to save locales')
+          return res.result?.locales ?? updatedLocales
+        },
+        context: {
+          formId: SUPPORTED_LOCALES_MUTATION_CONTEXT_ID,
+          resourceKind: 'translation-locales',
+          retryLastMutation,
+        },
+        mutationPayload: { locales: updatedLocales },
       })
-      if (!res.ok) throw new Error('Failed to save locales')
-      return res.result?.locales ?? updatedLocales
     },
     onSuccess: (result) => {
       queryClient.setQueryData(['translation-locales'], result)

--- a/packages/core/src/modules/translations/components/__tests__/TranslationManager.test.tsx
+++ b/packages/core/src/modules/translations/components/__tests__/TranslationManager.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { TranslationManager, LocaleManager } from '../TranslationManager'
+
+const apiCallMock = jest.fn()
+const withScopedApiRequestHeadersMock = jest.fn(
+  async (_headers: unknown, operation: () => Promise<unknown>) => operation(),
+)
+const buildOptimisticLockHeaderMock = jest.fn((updatedAt?: string) => ({
+  'x-om-ext-optimistic-lock-expected-updated-at': updatedAt ?? '',
+}))
+const runMutationMock = jest.fn(
+  async ({ operation }: { operation: () => Promise<unknown> }) => operation(),
+)
+const retryLastMutationMock = jest.fn(async () => true)
+const flashMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+  readApiResultOrThrow: jest.fn(async () => ({ items: [] })),
+  withScopedApiRequestHeaders: (...args: [unknown, () => Promise<unknown>]) =>
+    withScopedApiRequestHeadersMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: (...args: [string | undefined]) => buildOptimisticLockHeaderMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: runMutationMock,
+    retryLastMutation: retryLastMutationMock,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: (...args: unknown[]) => flashMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/customFieldDefs', () => ({
+  useCustomFieldDefs: () => ({ data: [], isLoading: false }),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 0,
+}))
+
+jest.mock('@open-mercato/ui/backend/inputs', () => ({
+  ComboboxInput: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string
+    onChange: (value: string) => void
+    placeholder?: string
+  }) => (
+    <input
+      aria-label="combobox"
+      value={value}
+      placeholder={placeholder}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}))
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  apiCallMock.mockImplementation(
+    async (url: string, init?: { method?: string; body?: string }) => {
+      if (!init?.method) {
+        if (url === '/api/translations/locales') {
+          return { ok: true, result: { locales: ['en', 'de'] } }
+        }
+        // entity-translation GET
+        return {
+          ok: true,
+          result: {
+            entityType: 'catalog:product',
+            entityId: 'rec-1',
+            translations: {},
+            updatedAt: '2026-01-02T00:00:00Z',
+          },
+        }
+      }
+      // mutating writes (PUT)
+      const parsed = init.body ? JSON.parse(init.body) : {}
+      return { ok: true, result: { locales: parsed.locales ?? [] } }
+    },
+  )
+})
+
+describe('TranslationManager guarded mutations (#3316)', () => {
+  it('routes the entity-translation save through useGuardedMutation, not a raw mutation', async () => {
+    renderWithProviders(
+      <TranslationManager
+        mode="embedded"
+        entityType="catalog:product"
+        recordId="rec-1"
+        baseValues={{ name: 'Base name' }}
+        translatableFields={['name']}
+      />,
+    )
+
+    const input = await screen.findByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Nazwa testowa' } })
+
+    fireEvent.click(screen.getByTestId('translations-save'))
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalledTimes(1))
+
+    const runInput = runMutationMock.mock.calls[0][0] as {
+      context: Record<string, unknown>
+      mutationPayload?: Record<string, unknown>
+    }
+    expect(runInput.context).toMatchObject({ entityType: 'catalog:product', recordId: 'rec-1' })
+    // the conflict-resolution retry handle MUST be carried in the injection context
+    expect(runInput.context.retryLastMutation).toBe(retryLastMutationMock)
+    expect(runInput.mutationPayload).toEqual({ en: { name: 'Nazwa testowa' } })
+
+    // optimistic-lock header is still built + applied on the guarded write
+    await waitFor(() =>
+      expect(buildOptimisticLockHeaderMock).toHaveBeenCalledWith('2026-01-02T00:00:00Z'),
+    )
+    expect(withScopedApiRequestHeadersMock).toHaveBeenCalled()
+    expect(apiCallMock).toHaveBeenCalledWith(
+      '/api/translations/catalog%3Aproduct/rec-1',
+      expect.objectContaining({ method: 'PUT' }),
+    )
+
+    // flash behavior preserved
+    await waitFor(() => expect(flashMock).toHaveBeenCalledWith('Translations saved', 'success'))
+  })
+})
+
+describe('LocaleManager guarded mutations (#3316)', () => {
+  it('routes the supported-locales save through useGuardedMutation, not a raw mutation', async () => {
+    renderWithProviders(<LocaleManager />)
+
+    await screen.findByRole('button', { name: 'Add' })
+
+    // click a locale remove "X" button -> removeLocale -> guarded save
+    const removeButton = screen
+      .getAllByRole('button')
+      .find((button) => !/add/i.test(button.textContent || ''))
+    expect(removeButton).toBeDefined()
+    fireEvent.click(removeButton as HTMLElement)
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalledTimes(1))
+
+    const runInput = runMutationMock.mock.calls[0][0] as {
+      context: Record<string, unknown>
+      mutationPayload?: Record<string, unknown>
+    }
+    expect(runInput.context.retryLastMutation).toBe(retryLastMutationMock)
+    expect(runInput.mutationPayload).toEqual({ locales: ['de'] })
+    expect(apiCallMock).toHaveBeenCalledWith(
+      '/api/translations/locales',
+      expect.objectContaining({ method: 'PUT' }),
+    )
+
+    // flash behavior preserved
+    await waitFor(() => expect(flashMock).toHaveBeenCalledWith('Locales updated', 'success'))
+  })
+})


### PR DESCRIPTION
## Summary

`TranslationManager` (entity-translation save) and `LocaleManager` (supported-locales save) performed their `PUT` writes through raw React Query `useMutation` → `apiCall`, bypassing the shared `useGuardedMutation` pipeline. That skipped `onBeforeSave`/`onAfterSave` injections, guard-supplied scoped headers, conflict surfacing, and the `retryLastMutation` retry context — violating the repo rule that every non-`CrudForm` backend write must go through `useGuardedMutation().runMutation(...)`. This routes both write paths through the guard while preserving all existing behavior (optimistic-lock header, flash, `isPending`/`Cmd+Enter`).

## Changes

- `packages/core/src/modules/translations/components/TranslationManager.tsx`: wrap both `useMutation` write paths inside `useGuardedMutation().runMutation({ operation, context, mutationPayload })`; carry `retryLastMutation` in each injection context; keep the optimistic-lock header (`buildOptimisticLockHeader` + `withScopedApiRequestHeaders`) on the translation save, now inside the guarded operation; preserve the `optimistic-lock-exempt` marker on the single-row locales save; retain the outer `useMutation` purely for lifecycle/flash state so the UI is unchanged.
- `packages/core/src/modules/translations/components/__tests__/TranslationManager.test.tsx`: new component test proving both write paths go through the guarded mutation wrapper (not a raw mutation), pass `retryLastMutation`, build+apply the optimistic-lock header, issue the `PUT`, and preserve flash.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — single-component bug fix; behavior preserved, no contract change.

## Testing

- `yarn workspace @open-mercato/core test --testPathPatterns=TranslationManager` → 2 passed (red→green; failed before the fix because writes bypassed `runMutation`)
- `yarn typecheck` → 21/21 packages pass
- `yarn i18n:check-sync` → all locales in sync
- `yarn build:packages` → 21/21 pass
- `yarn workspace @open-mercato/core test` → 742 suites / 6068 tests pass (incl. `optimistic-lock-ui-coverage` guard)
- `yarn build:app` → success

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — reuses existing i18n keys; no docs/generators affected.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required — internal mutation-plumbing refactor with no new API/UI flow; covered by the new component test; existing translations `__integration__` suites still pass.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — minor fix.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — single-module UI change shipped with tests.)
- [x] QA routing set: `needs-qa` (UI write-path change to the translations settings flow).

### Design System Compliance
- [x] No hardcoded status colors — no markup/styling changed (logic-only refactor).
- [x] No arbitrary text sizes — no markup/styling changed.
- [x] Empty state handled for list/data pages — unchanged; existing states preserved.
- [x] Loading state handled for async pages — unchanged; existing `LoadingMessage` preserved.
- [x] `aria-label` on all icon-only buttons — no icon-only buttons added or modified by this change.
- [x] Uses existing DS components — reuses the canonical `useGuardedMutation` helper; no custom replacements.

## Linked issues

Fixes #3316

🤖 Generated with [Claude Code](https://claude.com/claude-code)
