### PR TITLE
fix(translations): wire custom write routes through mutation guards (#3315)

### DIFF
--- a/packages/core/src/modules/translations/api/[entityType]/[entityId]/__tests__/mutation-guard.test.ts
+++ b/packages/core/src/modules/translations/api/[entityType]/[entityId]/__tests__/mutation-guard.test.ts
@@ -1,0 +1,177 @@
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const entityType = 'catalog:product'
+const entityId = '44444444-4444-4444-8444-444444444444'
+const rowId = '55555555-5555-4555-8555-555555555555'
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const commandBusExecuteMock = jest.fn()
+
+const db = {
+  selectFrom: jest.fn().mockReturnThis(),
+  selectAll: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  executeTakeFirst: jest.fn(),
+}
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'commandBus') return { execute: (...args: unknown[]) => commandBusExecuteMock(...args) }
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const context = {
+  container,
+  auth: { tenantId, sub: userId },
+  db,
+  organizationId,
+  tenantId,
+  commandCtx: {
+    container,
+    auth: { tenantId, sub: userId },
+    organizationScope: null,
+    selectedOrganizationId: organizationId,
+    organizationIds: [organizationId],
+    request: null,
+  },
+}
+
+jest.mock('@open-mercato/core/modules/translations/api/context', () => ({
+  resolveTranslationsRouteContext: jest.fn(async () => context),
+  requireTranslationFeatures: jest.fn(async () => undefined),
+  resolveTranslationsActorId: jest.fn(() => userId),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+import { PUT, DELETE } from '../route'
+
+const makePutRequest = () =>
+  new Request(`http://localhost/api/translations/${entityType}/${entityId}`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ en: { title: 'Hello' } }),
+  })
+
+const makeDeleteRequest = () =>
+  new Request(`http://localhost/api/translations/${entityType}/${entityId}`, {
+    method: 'DELETE',
+    headers: { 'content-type': 'application/json' },
+  })
+
+const routeParams = { params: { entityType, entityId } }
+
+describe('translations entity write routes mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    db.selectFrom.mockReturnThis()
+    db.selectAll.mockReturnThis()
+    db.where.mockReturnThis()
+    db.executeTakeFirst.mockResolvedValue({
+      id: rowId,
+      entity_type: entityType,
+      entity_id: entityId,
+      translations: { en: { title: 'Hello' } },
+      created_at: new Date('2026-04-11T08:00:00.000Z'),
+      updated_at: new Date('2026-04-11T08:00:00.000Z'),
+    })
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    commandBusExecuteMock.mockResolvedValue({ result: { rowId }, logEntry: null })
+  })
+
+  it('runs the mutation guard and after-success hook when saving translations (PUT)', async () => {
+    const response = await PUT(makePutRequest(), routeParams)
+
+    expect(response.status).toBe(200)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'translations.translation',
+        resourceId: `${entityType}:${entityId}`,
+        operation: 'update',
+        requestMethod: 'PUT',
+      }),
+    )
+    expect(commandBusExecuteMock).toHaveBeenCalledTimes(1)
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'translations.translation',
+        resourceId: `${entityType}:${entityId}`,
+        operation: 'update',
+        metadata: { token: 'guard' },
+      }),
+    )
+  })
+
+  it('skips the after-success hook when the guard does not request it (PUT)', async () => {
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: false, metadata: null })
+
+    const response = await PUT(makePutRequest(), routeParams)
+
+    expect(response.status).toBe(200)
+    expect(commandBusExecuteMock).toHaveBeenCalledTimes(1)
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('aborts the save before mutating when the guard blocks the write (PUT)', async () => {
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: false, status: 409, body: { error: 'Conflict' } })
+
+    const response = await PUT(makePutRequest(), routeParams)
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({ error: 'Conflict' })
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the mutation guard and after-success hook when deleting translations (DELETE)', async () => {
+    const response = await DELETE(makeDeleteRequest(), routeParams)
+
+    expect(response.status).toBe(204)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'translations.translation',
+        resourceId: `${entityType}:${entityId}`,
+        operation: 'delete',
+        requestMethod: 'DELETE',
+      }),
+    )
+    expect(commandBusExecuteMock).toHaveBeenCalledTimes(1)
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        resourceKind: 'translations.translation',
+        resourceId: `${entityType}:${entityId}`,
+        operation: 'delete',
+      }),
+    )
+  })
+
+  it('aborts the delete before mutating when the guard blocks the write (DELETE)', async () => {
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: false, status: 409, body: { error: 'Conflict' } })
+
+    const response = await DELETE(makeDeleteRequest(), routeParams)
+
+    expect(response.status).toBe(409)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/translations/api/[entityType]/[entityId]/route.ts
+++ b/packages/core/src/modules/translations/api/[entityType]/[entityId]/route.ts
@@ -1,9 +1,13 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { sql } from 'kysely'
-import { resolveTranslationsRouteContext, requireTranslationFeatures } from '@open-mercato/core/modules/translations/api/context'
+import { resolveTranslationsRouteContext, requireTranslationFeatures, resolveTranslationsActorId } from '@open-mercato/core/modules/translations/api/context'
 import { translationBodySchema, entityTypeParamSchema, entityIdParamSchema } from '@open-mercato/core/modules/translations/data/validators'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { CommandBus } from '@open-mercato/shared/lib/commands'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -80,6 +84,22 @@ export async function PUT(req: Request, ctx: { params?: { entityType?: string; e
     }
     const translations = translationBodySchema.parse(rawBody)
 
+    const guardUserId = resolveTranslationsActorId(context.auth)
+    const guardResult = await validateCrudMutationGuard(context.container, {
+      tenantId: context.tenantId,
+      organizationId: context.organizationId,
+      userId: guardUserId,
+      resourceKind: 'translations.translation',
+      resourceId: `${entityType}:${entityId}`,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: { entityType, entityId, translations },
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     const commandBus = context.container.resolve('commandBus') as CommandBus
     const { result, logEntry } = await commandBus.execute<
       { entityType: string; entityId: string; translations: typeof translations; organizationId: string | null; tenantId: string },
@@ -94,6 +114,20 @@ export async function PUT(req: Request, ctx: { params?: { entityType?: string; e
       },
       ctx: context.commandCtx,
     })
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(context.container, {
+        tenantId: context.tenantId,
+        organizationId: context.organizationId,
+        userId: guardUserId,
+        resourceKind: 'translations.translation',
+        resourceId: `${entityType}:${entityId}`,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     const row = await (context.db as any)
       .selectFrom('entity_translations')
@@ -150,6 +184,22 @@ export async function DELETE(req: Request, ctx: { params?: { entityType?: string
       entityId: ctx.params?.entityId,
     })
 
+    const guardUserId = resolveTranslationsActorId(context.auth)
+    const guardResult = await validateCrudMutationGuard(context.container, {
+      tenantId: context.tenantId,
+      organizationId: context.organizationId,
+      userId: guardUserId,
+      resourceKind: 'translations.translation',
+      resourceId: `${entityType}:${entityId}`,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: null,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     const commandBus = context.container.resolve('commandBus') as CommandBus
     const { logEntry } = await commandBus.execute<
       { entityType: string; entityId: string; organizationId: string | null; tenantId: string },
@@ -163,6 +213,20 @@ export async function DELETE(req: Request, ctx: { params?: { entityType?: string
       },
       ctx: context.commandCtx,
     })
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(context.container, {
+        tenantId: context.tenantId,
+        organizationId: context.organizationId,
+        userId: guardUserId,
+        resourceKind: 'translations.translation',
+        resourceId: `${entityType}:${entityId}`,
+        operation: 'delete',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     const response = new NextResponse(null, { status: 204 })
 

--- a/packages/core/src/modules/translations/api/context.ts
+++ b/packages/core/src/modules/translations/api/context.ts
@@ -17,6 +17,13 @@ export type TranslationsRouteContext = {
   commandCtx: CommandRuntimeContext
 }
 
+export function resolveTranslationsActorId(auth: TranslationsRouteContext['auth']): string {
+  if (typeof auth.sub === 'string' && auth.sub.trim().length > 0) return auth.sub
+  if (typeof auth.userId === 'string' && auth.userId.trim().length > 0) return auth.userId
+  if (typeof auth.keyId === 'string' && auth.keyId.trim().length > 0) return auth.keyId
+  return 'system'
+}
+
 export async function resolveTranslationsRouteContext(req: Request): Promise<TranslationsRouteContext> {
   const container = await createRequestContainer()
   const auth = await getAuthFromRequest(req)

--- a/packages/core/src/modules/translations/api/put/__tests__/locales-mutation-guard.test.ts
+++ b/packages/core/src/modules/translations/api/put/__tests__/locales-mutation-guard.test.ts
@@ -1,0 +1,87 @@
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const setValueMock = jest.fn()
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'moduleConfigService') return { setValue: (...args: unknown[]) => setValueMock(...args) }
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const context = {
+  container,
+  auth: { tenantId, sub: userId },
+  organizationId,
+  tenantId,
+}
+
+jest.mock('@open-mercato/core/modules/translations/api/context', () => ({
+  resolveTranslationsRouteContext: jest.fn(async () => context),
+  requireTranslationFeatures: jest.fn(async () => undefined),
+  resolveTranslationsActorId: jest.fn(() => userId),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+import PUT from '../locales'
+
+const makeRequest = () =>
+  new Request('http://localhost/api/translations/locales', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ locales: ['en', 'fr'] }),
+  })
+
+describe('translations locales route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    setValueMock.mockResolvedValue(undefined)
+  })
+
+  it('runs the mutation guard and after-success hook when updating supported locales', async () => {
+    const response = await PUT(makeRequest())
+
+    expect(response.status).toBe(200)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'translations.locales',
+        operation: 'custom',
+        requestMethod: 'PUT',
+      }),
+    )
+    expect(setValueMock).toHaveBeenCalledWith('translations', 'supported_locales', ['en', 'fr'])
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        resourceKind: 'translations.locales',
+        operation: 'custom',
+        metadata: { token: 'guard' },
+      }),
+    )
+  })
+
+  it('aborts the locale update before persisting when the guard blocks the write', async () => {
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: false, status: 409, body: { error: 'Conflict' } })
+
+    const response = await PUT(makeRequest())
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({ error: 'Conflict' })
+    expect(setValueMock).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/translations/api/put/locales.ts
+++ b/packages/core/src/modules/translations/api/put/locales.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
-import { resolveTranslationsRouteContext } from '@open-mercato/core/modules/translations/api/context'
+import { resolveTranslationsRouteContext, resolveTranslationsActorId } from '@open-mercato/core/modules/translations/api/context'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { isValidIso639 } from '@open-mercato/shared/lib/i18n/iso639'
 import type { ModuleConfigService } from '@open-mercato/core/modules/configs/lib/module-config-service'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -23,8 +27,38 @@ async function PUT(req: Request) {
     const body = bodySchema.parse(await req.json())
     const uniqueLocales = [...new Set(body.locales.map((l) => l.toLowerCase().trim()))]
 
+    const guardUserId = resolveTranslationsActorId(context.auth)
+    const guardResult = await validateCrudMutationGuard(context.container, {
+      tenantId: context.tenantId,
+      organizationId: context.organizationId,
+      userId: guardUserId,
+      resourceKind: 'translations.locales',
+      resourceId: 'supported_locales',
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: { locales: uniqueLocales },
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     const configService = context.container.resolve('moduleConfigService') as ModuleConfigService
     await configService.setValue('translations', 'supported_locales', uniqueLocales)
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(context.container, {
+        tenantId: context.tenantId,
+        organizationId: context.organizationId,
+        userId: guardUserId,
+        resourceKind: 'translations.locales',
+        resourceId: 'supported_locales',
+        operation: 'custom',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     return NextResponse.json({ locales: uniqueLocales })
   } catch (err) {


### PR DESCRIPTION
## Summary

The `translations` module's three custom write routes mutated translation/locale state without running the mutation-guard lifecycle that every non-`makeCrudRoute` write route must wire (`packages/core/AGENTS.md` → API Routes). This left translation save/delete and supported-locale updates outside the optimistic-locking / mutation-guard contract used everywhere else. This PR wires all three handlers through `validateCrudMutationGuard` (before the write) and `runCrudMutationGuardAfterSuccess` (after success, when requested), mirroring the sanctioned reference (`dictionaries/.../set-default`).

## Changes

- `translations/api/context.ts`: add `resolveTranslationsActorId` (resolves the actor id via `sub → userId → keyId → 'system'`, mirroring `resolveDictionaryActorId`; handles API-key auth where `sub` is absent).
- `translations/api/[entityType]/[entityId]/route.ts`: wire the mutation guard into `PUT` (`operation: 'update'`) and `DELETE` (`operation: 'delete'`) — `resourceKind: 'translations.translation'`, `resourceId: ${entityType}:${entityId}`; validate before the command bus, run after-success only when `guardResult.ok && guardResult.shouldRunAfterSuccess`.
- `translations/api/put/locales.ts`: wire the mutation guard into `PUT` (`resourceKind: 'translations.locales'`, `resourceId: 'supported_locales'`, `operation: 'custom'`) around the supported-locales config write.
- Tests: add focused jest route tests for all three handlers proving (a) a blocked guard aborts before any mutation and returns the guard's status, (b) the after-success hook runs on success, and (c) after-success is skipped when `shouldRunAfterSuccess` is false.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A for this fix. Governing contract: `packages/core/AGENTS.md` → API Routes (mutation guard contract); related umbrella spec `.ai/specs/2026-05-28-optimistic-locking-coverage-completion.md`.

## Testing

- `yarn workspace @open-mercato/core test modules/translations` → 10 suites, 193 tests pass (incl. 7 new guard tests; red before the fix for the right reason — the guard was never invoked)
- `tsc --noEmit -p packages/core/tsconfig.json` → exit 0
- `yarn build:packages` (×2, around `yarn generate`) → success
- `yarn i18n:check-sync` → all locales in sync
- `yarn build:app` → success

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no new user-facing strings, no auto-discovered files added; the contract is already documented in `packages/core/AGENTS.md`.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required — mutation-guard wiring is a DI seam best exercised with mocked guard results at the route-unit level, exactly as the canonical `dictionaries` reference does; no end-user-visible behavior change for current callers, so no Playwright E2E is warranted.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — bug fix applying an existing documented contract.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — contained, additive, backward-compatible single-module wiring with tests; see the label comment.)
- [x] QA routing set. (`skip-qa` — backend-only infra wiring, no UI/customer-facing behavior change for current callers; the guard no-ops unless a guard service is registered.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, backend-only (no UI)
- [x] No arbitrary text sizes — N/A, backend-only (no UI)
- [x] Empty state handled — N/A, backend-only (no UI)
- [x] Loading state handled — N/A, backend-only (no UI)
- [x] `aria-label` on icon-only buttons — N/A, backend-only (no UI)
- [x] Uses existing DS components — N/A, backend-only (no UI)

## Linked issues

Fixes #3315
