### PR TITLE
fix(resources): guard tag assignment routes (#3289)

### DIFF
--- a/packages/core/src/modules/resources/api/resources/tags/__tests__/route.test.ts
+++ b/packages/core/src/modules/resources/api/resources/tags/__tests__/route.test.ts
@@ -1,0 +1,145 @@
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const tagId = '44444444-4444-4444-8444-444444444444'
+const resourceId = '55555555-5555-4555-8555-555555555555'
+const assignmentId = '66666666-6666-4666-8666-666666666666'
+
+const commandBusExecuteMock = jest.fn()
+const commandBus = {
+  execute: (...args: unknown[]) => commandBusExecuteMock(...args),
+}
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'commandBus') return commandBus
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    sub: userId,
+    tenantId,
+    orgId: organizationId,
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({
+    tenantId,
+    selectedId: organizationId,
+    filterIds: [organizationId],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+import { POST as assignResourceTag } from '../assign/route'
+import { POST as unassignResourceTag } from '../unassign/route'
+
+function buildTagRequest(path: string) {
+  return new Request(`http://localhost${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-om-test-lock': 'expected-version',
+    },
+    body: JSON.stringify({ tagId, resourceId }),
+  })
+}
+
+describe('resources resource tag assignment routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    validateCrudMutationGuardMock.mockResolvedValue({
+      ok: true,
+      shouldRunAfterSuccess: true,
+      metadata: { lockToken: 'guard-token' },
+    })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    commandBusExecuteMock.mockResolvedValue({
+      result: { assignmentId },
+      logEntry: null,
+    })
+  })
+
+  it('blocks resource tag assignment before executing the command when the mutation guard rejects it', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      body: { error: 'Resource is locked' },
+    })
+
+    const response = await assignResourceTag(buildTagRequest('/api/resources/resources/tags/assign'))
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({ error: 'Resource is locked' })
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'resources.resourceTagAssignment',
+        resourceId,
+        operation: 'custom',
+        requestMethod: 'POST',
+        mutationPayload: expect.objectContaining({
+          tenantId,
+          organizationId,
+          tagId,
+          resourceId,
+        }),
+      }),
+    )
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the mutation guard after-success hook after resource tag unassignment succeeds', async () => {
+    const response = await unassignResourceTag(buildTagRequest('/api/resources/resources/tags/unassign'))
+
+    expect(response.status).toBe(200)
+    expect(commandBusExecuteMock).toHaveBeenCalledWith(
+      'resources.resourceTags.unassign',
+      expect.objectContaining({
+        input: expect.objectContaining({
+          tenantId,
+          organizationId,
+          tagId,
+          resourceId,
+        }),
+      }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'resources.resourceTagAssignment',
+        resourceId,
+        operation: 'custom',
+        requestMethod: 'POST',
+        metadata: { lockToken: 'guard-token' },
+      }),
+    )
+  })
+})

--- a/packages/core/src/modules/resources/api/resources/tags/assign/route.ts
+++ b/packages/core/src/modules/resources/api/resources/tags/assign/route.ts
@@ -10,6 +10,10 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
+import {
   resourcesResourceTagAssignmentSchema,
   type ResourcesResourceTagAssignmentInput,
 } from '../../../../data/validators'
@@ -37,16 +41,54 @@ async function buildContext(
   return { ctx, translate }
 }
 
+function resolveActorId(ctx: CommandRuntimeContext): string {
+  const auth = ctx.auth
+  if (auth && typeof auth.sub === 'string' && auth.sub.trim().length > 0) return auth.sub
+  if (auth && typeof auth.userId === 'string' && auth.userId.trim().length > 0) return auth.userId
+  if (auth && typeof auth.keyId === 'string' && auth.keyId.trim().length > 0) return auth.keyId
+  return 'system'
+}
+
 export async function POST(req: Request) {
   try {
     const { ctx, translate } = await buildContext(req)
     const body = await req.json().catch(() => ({}))
     const input = parseScopedCommandInput(resourcesResourceTagAssignmentSchema, body, ctx, translate)
+    const actorId = resolveActorId(ctx)
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId: input.tenantId,
+      organizationId: input.organizationId,
+      userId: actorId,
+      resourceKind: 'resources.resourceTagAssignment',
+      resourceId: input.resourceId,
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { result, logEntry } = await commandBus.execute<ResourcesResourceTagAssignmentInput, { assignmentId: string }>(
       'resources.resourceTags.assign',
       { input, ctx },
     )
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId: input.tenantId,
+        organizationId: input.organizationId,
+        userId: actorId,
+        resourceKind: 'resources.resourceTagAssignment',
+        resourceId: input.resourceId,
+        operation: 'custom',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
+
     const response = NextResponse.json({ id: result?.assignmentId ?? null }, { status: 201 })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(

--- a/packages/core/src/modules/resources/api/resources/tags/unassign/route.ts
+++ b/packages/core/src/modules/resources/api/resources/tags/unassign/route.ts
@@ -10,6 +10,10 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
+import {
   resourcesResourceTagAssignmentSchema,
   type ResourcesResourceTagAssignmentInput,
 } from '../../../../data/validators'
@@ -37,16 +41,54 @@ async function buildContext(
   return { ctx, translate }
 }
 
+function resolveActorId(ctx: CommandRuntimeContext): string {
+  const auth = ctx.auth
+  if (auth && typeof auth.sub === 'string' && auth.sub.trim().length > 0) return auth.sub
+  if (auth && typeof auth.userId === 'string' && auth.userId.trim().length > 0) return auth.userId
+  if (auth && typeof auth.keyId === 'string' && auth.keyId.trim().length > 0) return auth.keyId
+  return 'system'
+}
+
 export async function POST(req: Request) {
   try {
     const { ctx, translate } = await buildContext(req)
     const body = await req.json().catch(() => ({}))
     const input = parseScopedCommandInput(resourcesResourceTagAssignmentSchema, body, ctx, translate)
+    const actorId = resolveActorId(ctx)
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId: input.tenantId,
+      organizationId: input.organizationId,
+      userId: actorId,
+      resourceKind: 'resources.resourceTagAssignment',
+      resourceId: input.resourceId,
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { result, logEntry } = await commandBus.execute<ResourcesResourceTagAssignmentInput, { assignmentId: string | null }>(
       'resources.resourceTags.unassign',
       { input, ctx },
     )
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId: input.tenantId,
+        organizationId: input.organizationId,
+        userId: actorId,
+        resourceKind: 'resources.resourceTagAssignment',
+        resourceId: input.resourceId,
+        operation: 'custom',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
+
     const response = NextResponse.json({ id: result?.assignmentId ?? null })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(


### PR DESCRIPTION
## Summary

Fixes resources tag assignment custom POST routes so assign/unassign writes run the platform mutation guard lifecycle.

## Changes

- Wire `/api/resources/resources/tags/assign` through `validateCrudMutationGuard` before command execution and `runCrudMutationGuardAfterSuccess` after success.
- Wire `/api/resources/resources/tags/unassign` through the same lifecycle.
- Add focused route tests proving guard rejection blocks the command and after-success hooks run after successful unassignment.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — minor bug fix for an existing custom-route convention.

## Testing

- `yarn workspace @open-mercato/core test src/modules/resources/api/resources/tags/__tests__/route.test.ts --runInBand --no-cache` — PASS
- `yarn build:packages` — PASS
- `yarn generate` — PASS
- `yarn build:packages` — PASS
- `yarn i18n:check-sync` — PASS
- `yarn i18n:check-usage` — PASS with existing advisory unused-key report
- `yarn typecheck` — PASS
- `yarn test` — PASS
- `yarn build:app` — PASS
- `yarn lint` — FAILS on pre-existing untouched app-shell hook-order errors in `apps/mercato/src/components/OrganizationSwitcher.tsx`; staged touched files pass direct ESLint.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3289