### PR TITLE
fix(staff): wire command-backed POST routes through mutation guards (#3310)

### DIFF
--- a/packages/core/src/modules/staff/api/leave-requests/accept/__tests__/route.test.ts
+++ b/packages/core/src/modules/staff/api/leave-requests/accept/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+/** @jest-environment node */
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScope = jest.fn()
+const mockParseScopedCommandInput = jest.fn()
+const mockExecute = jest.fn()
+const mockRunStaffMutationGuards = jest.fn()
+const mockRunStaffMutationGuardAfterSuccess = jest.fn()
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'commandBus') return { execute: mockExecute }
+    return undefined
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScope(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({ translate: (_key: string, fallback?: string) => fallback ?? _key })),
+}))
+
+jest.mock('@open-mercato/shared/lib/api/scoped', () => ({
+  parseScopedCommandInput: jest.fn((...args: unknown[]) => mockParseScopedCommandInput(...args)),
+}))
+
+jest.mock('../../../guards', () => ({
+  resolveUserFeatures: jest.fn(() => ['staff.leave_requests.manage']),
+  runStaffMutationGuards: jest.fn((...args: unknown[]) => mockRunStaffMutationGuards(...args)),
+  runStaffMutationGuardAfterSuccess: jest.fn((...args: unknown[]) => mockRunStaffMutationGuardAfterSuccess(...args)),
+}))
+
+type RouteModule = typeof import('../route')
+let postHandler: RouteModule['POST']
+
+beforeAll(async () => {
+  postHandler = (await import('../route')).POST
+})
+
+const buildRequest = () =>
+  new Request('http://localhost/api/staff/leave-requests/accept', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ id: 'leave-1' }),
+  })
+
+describe('staff leave-requests accept route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      features: ['staff.leave_requests.manage'],
+    })
+    mockResolveOrganizationScope.mockResolvedValue({ tenantId: 'tenant-1', selectedId: 'org-1', filterIds: ['org-1'] })
+    mockParseScopedCommandInput.mockReturnValue({ id: 'leave-1', decisionComment: null })
+    mockExecute.mockResolvedValue({ result: { requestId: 'leave-1' }, logEntry: null })
+    mockRunStaffMutationGuards.mockResolvedValue({ ok: true, afterSuccessCallbacks: [] })
+  })
+
+  it('blocks the decision when the mutation guard denies the request', async () => {
+    mockRunStaffMutationGuards.mockResolvedValueOnce({
+      ok: false,
+      errorStatus: 423,
+      errorBody: { error: 'Locked' },
+      afterSuccessCallbacks: [],
+    })
+
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(423)
+    await expect(response.json()).resolves.toEqual({ error: 'Locked' })
+    expect(mockRunStaffMutationGuards).toHaveBeenCalledWith(
+      mockContainer,
+      expect.objectContaining({
+        resourceKind: 'staff.leave_request',
+        resourceId: 'leave-1',
+        operation: 'update',
+        requestMethod: 'POST',
+      }),
+      expect.any(Array),
+    )
+    expect(mockExecute).not.toHaveBeenCalled()
+    expect(mockRunStaffMutationGuardAfterSuccess).not.toHaveBeenCalled()
+  })
+
+  it('runs the after-success hook when the guard requests it', async () => {
+    mockRunStaffMutationGuards.mockResolvedValueOnce({
+      ok: true,
+      afterSuccessCallbacks: [{ guard: {}, metadata: { lock: 'token' } }],
+    })
+
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(200)
+    expect(mockExecute).toHaveBeenCalledWith('staff.leave-requests.accept', expect.anything())
+    expect(mockRunStaffMutationGuardAfterSuccess).toHaveBeenCalledWith(
+      [{ guard: {}, metadata: { lock: 'token' } }],
+      expect.objectContaining({
+        resourceKind: 'staff.leave_request',
+        resourceId: 'leave-1',
+        operation: 'update',
+      }),
+    )
+  })
+
+  it('does not run the after-success hook when the guard does not request it', async () => {
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(200)
+    expect(mockExecute).toHaveBeenCalled()
+    expect(mockRunStaffMutationGuardAfterSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/staff/api/leave-requests/accept/route.ts
+++ b/packages/core/src/modules/staff/api/leave-requests/accept/route.ts
@@ -10,6 +10,11 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { staffLeaveRequestDecisionSchema, type StaffLeaveRequestDecisionInput } from '../../../data/validators'
+import {
+  resolveUserFeatures,
+  runStaffMutationGuardAfterSuccess,
+  runStaffMutationGuards,
+} from '../../guards'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['staff.leave_requests.manage'] },
@@ -39,11 +44,51 @@ export async function POST(req: Request) {
     const { ctx, translate } = await buildContext(req)
     const body = await req.json().catch(() => ({}))
     const input = parseScopedCommandInput(staffLeaveRequestDecisionSchema, body, ctx, translate)
+
+    const auth = ctx.auth
+    const tenantId = auth?.tenantId ?? ''
+    const organizationId = ctx.selectedOrganizationId ?? null
+    const guardResult = await runStaffMutationGuards(
+      ctx.container,
+      {
+        tenantId,
+        organizationId,
+        userId: auth?.sub ?? '',
+        resourceKind: 'staff.leave_request',
+        resourceId: input.id,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        mutationPayload: input,
+      },
+      resolveUserFeatures(auth),
+    )
+    if (!guardResult.ok) {
+      return NextResponse.json(
+        guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+        { status: guardResult.errorStatus ?? 422 },
+      )
+    }
+
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { result, logEntry } = await commandBus.execute<StaffLeaveRequestDecisionInput, { requestId: string }>(
       'staff.leave-requests.accept',
       { input, ctx },
     )
+
+    if (guardResult.afterSuccessCallbacks.length) {
+      await runStaffMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+        tenantId,
+        organizationId,
+        userId: auth?.sub ?? '',
+        resourceKind: 'staff.leave_request',
+        resourceId: result?.requestId ?? input.id,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+      })
+    }
+
     const response = NextResponse.json({ ok: true, id: result?.requestId ?? null }, { status: 200 })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(

--- a/packages/core/src/modules/staff/api/leave-requests/reject/__tests__/route.test.ts
+++ b/packages/core/src/modules/staff/api/leave-requests/reject/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+/** @jest-environment node */
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScope = jest.fn()
+const mockParseScopedCommandInput = jest.fn()
+const mockExecute = jest.fn()
+const mockRunStaffMutationGuards = jest.fn()
+const mockRunStaffMutationGuardAfterSuccess = jest.fn()
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'commandBus') return { execute: mockExecute }
+    return undefined
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScope(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({ translate: (_key: string, fallback?: string) => fallback ?? _key })),
+}))
+
+jest.mock('@open-mercato/shared/lib/api/scoped', () => ({
+  parseScopedCommandInput: jest.fn((...args: unknown[]) => mockParseScopedCommandInput(...args)),
+}))
+
+jest.mock('../../../guards', () => ({
+  resolveUserFeatures: jest.fn(() => ['staff.leave_requests.manage']),
+  runStaffMutationGuards: jest.fn((...args: unknown[]) => mockRunStaffMutationGuards(...args)),
+  runStaffMutationGuardAfterSuccess: jest.fn((...args: unknown[]) => mockRunStaffMutationGuardAfterSuccess(...args)),
+}))
+
+type RouteModule = typeof import('../route')
+let postHandler: RouteModule['POST']
+
+beforeAll(async () => {
+  postHandler = (await import('../route')).POST
+})
+
+const buildRequest = () =>
+  new Request('http://localhost/api/staff/leave-requests/reject', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ id: 'leave-1' }),
+  })
+
+describe('staff leave-requests reject route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      features: ['staff.leave_requests.manage'],
+    })
+    mockResolveOrganizationScope.mockResolvedValue({ tenantId: 'tenant-1', selectedId: 'org-1', filterIds: ['org-1'] })
+    mockParseScopedCommandInput.mockReturnValue({ id: 'leave-1', decisionComment: null })
+    mockExecute.mockResolvedValue({ result: { requestId: 'leave-1' }, logEntry: null })
+    mockRunStaffMutationGuards.mockResolvedValue({ ok: true, afterSuccessCallbacks: [] })
+  })
+
+  it('blocks the decision when the mutation guard denies the request', async () => {
+    mockRunStaffMutationGuards.mockResolvedValueOnce({
+      ok: false,
+      errorStatus: 423,
+      errorBody: { error: 'Locked' },
+      afterSuccessCallbacks: [],
+    })
+
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(423)
+    await expect(response.json()).resolves.toEqual({ error: 'Locked' })
+    expect(mockRunStaffMutationGuards).toHaveBeenCalledWith(
+      mockContainer,
+      expect.objectContaining({
+        resourceKind: 'staff.leave_request',
+        resourceId: 'leave-1',
+        operation: 'update',
+        requestMethod: 'POST',
+      }),
+      expect.any(Array),
+    )
+    expect(mockExecute).not.toHaveBeenCalled()
+    expect(mockRunStaffMutationGuardAfterSuccess).not.toHaveBeenCalled()
+  })
+
+  it('runs the after-success hook when the guard requests it', async () => {
+    mockRunStaffMutationGuards.mockResolvedValueOnce({
+      ok: true,
+      afterSuccessCallbacks: [{ guard: {}, metadata: { lock: 'token' } }],
+    })
+
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(200)
+    expect(mockExecute).toHaveBeenCalledWith('staff.leave-requests.reject', expect.anything())
+    expect(mockRunStaffMutationGuardAfterSuccess).toHaveBeenCalledWith(
+      [{ guard: {}, metadata: { lock: 'token' } }],
+      expect.objectContaining({
+        resourceKind: 'staff.leave_request',
+        resourceId: 'leave-1',
+        operation: 'update',
+      }),
+    )
+  })
+
+  it('does not run the after-success hook when the guard does not request it', async () => {
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(200)
+    expect(mockExecute).toHaveBeenCalled()
+    expect(mockRunStaffMutationGuardAfterSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/staff/api/leave-requests/reject/route.ts
+++ b/packages/core/src/modules/staff/api/leave-requests/reject/route.ts
@@ -10,6 +10,11 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { staffLeaveRequestDecisionSchema, type StaffLeaveRequestDecisionInput } from '../../../data/validators'
+import {
+  resolveUserFeatures,
+  runStaffMutationGuardAfterSuccess,
+  runStaffMutationGuards,
+} from '../../guards'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['staff.leave_requests.manage'] },
@@ -39,11 +44,51 @@ export async function POST(req: Request) {
     const { ctx, translate } = await buildContext(req)
     const body = await req.json().catch(() => ({}))
     const input = parseScopedCommandInput(staffLeaveRequestDecisionSchema, body, ctx, translate)
+
+    const auth = ctx.auth
+    const tenantId = auth?.tenantId ?? ''
+    const organizationId = ctx.selectedOrganizationId ?? null
+    const guardResult = await runStaffMutationGuards(
+      ctx.container,
+      {
+        tenantId,
+        organizationId,
+        userId: auth?.sub ?? '',
+        resourceKind: 'staff.leave_request',
+        resourceId: input.id,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        mutationPayload: input,
+      },
+      resolveUserFeatures(auth),
+    )
+    if (!guardResult.ok) {
+      return NextResponse.json(
+        guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+        { status: guardResult.errorStatus ?? 422 },
+      )
+    }
+
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { result, logEntry } = await commandBus.execute<StaffLeaveRequestDecisionInput, { requestId: string }>(
       'staff.leave-requests.reject',
       { input, ctx },
     )
+
+    if (guardResult.afterSuccessCallbacks.length) {
+      await runStaffMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+        tenantId,
+        organizationId,
+        userId: auth?.sub ?? '',
+        resourceKind: 'staff.leave_request',
+        resourceId: result?.requestId ?? input.id,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+      })
+    }
+
     const response = NextResponse.json({ ok: true, id: result?.requestId ?? null }, { status: 200 })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(

--- a/packages/core/src/modules/staff/api/team-members/self/__tests__/route.test.ts
+++ b/packages/core/src/modules/staff/api/team-members/self/__tests__/route.test.ts
@@ -1,0 +1,131 @@
+/** @jest-environment node */
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScope = jest.fn()
+const mockParseScopedCommandInput = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+const mockExecute = jest.fn()
+const mockRunStaffMutationGuards = jest.fn()
+const mockRunStaffMutationGuardAfterSuccess = jest.fn()
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'commandBus') return { execute: mockExecute }
+    if (token === 'em') return {}
+    return undefined
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScope(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({ translate: (_key: string, fallback?: string) => fallback ?? _key })),
+}))
+
+jest.mock('@open-mercato/shared/lib/api/scoped', () => ({
+  parseScopedCommandInput: jest.fn((...args: unknown[]) => mockParseScopedCommandInput(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('../../../guards', () => ({
+  resolveUserFeatures: jest.fn(() => ['staff.leave_requests.send']),
+  runStaffMutationGuards: jest.fn((...args: unknown[]) => mockRunStaffMutationGuards(...args)),
+  runStaffMutationGuardAfterSuccess: jest.fn((...args: unknown[]) => mockRunStaffMutationGuardAfterSuccess(...args)),
+}))
+
+type RouteModule = typeof import('../route')
+let postHandler: RouteModule['POST']
+
+beforeAll(async () => {
+  postHandler = (await import('../route')).POST
+})
+
+const buildRequest = () =>
+  new Request('http://localhost/api/staff/team-members/self', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ displayName: 'Ada Lovelace' }),
+  })
+
+describe('staff team-members self route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      features: ['staff.leave_requests.send'],
+    })
+    mockResolveOrganizationScope.mockResolvedValue({ tenantId: 'tenant-1', selectedId: 'org-1', filterIds: ['org-1'] })
+    mockParseScopedCommandInput.mockReturnValue({ displayName: 'Ada Lovelace' })
+    mockFindOneWithDecryption.mockResolvedValue(null)
+    mockExecute.mockResolvedValue({ result: { memberId: 'member-1' }, logEntry: null })
+    mockRunStaffMutationGuards.mockResolvedValue({ ok: true, afterSuccessCallbacks: [] })
+  })
+
+  it('blocks self-profile creation when the mutation guard denies the request', async () => {
+    mockRunStaffMutationGuards.mockResolvedValueOnce({
+      ok: false,
+      errorStatus: 423,
+      errorBody: { error: 'Locked' },
+      afterSuccessCallbacks: [],
+    })
+
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(423)
+    await expect(response.json()).resolves.toEqual({ error: 'Locked' })
+    expect(mockRunStaffMutationGuards).toHaveBeenCalledWith(
+      mockContainer,
+      expect.objectContaining({
+        resourceKind: 'staff.team_member',
+        operation: 'create',
+        requestMethod: 'POST',
+      }),
+      expect.any(Array),
+    )
+    expect(mockExecute).not.toHaveBeenCalled()
+    expect(mockRunStaffMutationGuardAfterSuccess).not.toHaveBeenCalled()
+  })
+
+  it('runs the after-success hook when the guard requests it', async () => {
+    mockRunStaffMutationGuards.mockResolvedValueOnce({
+      ok: true,
+      afterSuccessCallbacks: [{ guard: {}, metadata: { lock: 'token' } }],
+    })
+
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(201)
+    expect(mockExecute).toHaveBeenCalledWith('staff.team-members.create', expect.anything())
+    expect(mockRunStaffMutationGuardAfterSuccess).toHaveBeenCalledWith(
+      [{ guard: {}, metadata: { lock: 'token' } }],
+      expect.objectContaining({
+        resourceKind: 'staff.team_member',
+        resourceId: 'member-1',
+        operation: 'create',
+      }),
+    )
+  })
+
+  it('does not run the after-success hook when the guard does not request it', async () => {
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(201)
+    expect(mockExecute).toHaveBeenCalled()
+    expect(mockRunStaffMutationGuardAfterSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/staff/api/team-members/self/route.ts
+++ b/packages/core/src/modules/staff/api/team-members/self/route.ts
@@ -16,6 +16,11 @@ import {
   type StaffTeamMemberSelfCreateInput,
   type StaffTeamMemberCreateInput,
 } from '../../../data/validators'
+import {
+  resolveUserFeatures,
+  runStaffMutationGuardAfterSuccess,
+  runStaffMutationGuards,
+} from '../../guards'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['staff.leave_requests.send'] },
@@ -102,6 +107,30 @@ export async function POST(req: Request) {
       throw new CrudHttpError(409, { error: translate('staff.teamMembers.self.exists', 'Team member profile already exists.') })
     }
 
+    const tenantId = auth.tenantId ?? ''
+    const organizationId = ctx.selectedOrganizationId ?? null
+    const guardResult = await runStaffMutationGuards(
+      ctx.container,
+      {
+        tenantId,
+        organizationId,
+        userId: auth.sub,
+        resourceKind: 'staff.team_member',
+        resourceId: auth.sub,
+        operation: 'create',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        mutationPayload: parsed,
+      },
+      resolveUserFeatures(auth),
+    )
+    if (!guardResult.ok) {
+      return NextResponse.json(
+        guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+        { status: guardResult.errorStatus ?? 422 },
+      )
+    }
+
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const selfInput: StaffTeamMemberCreateInput = {
       ...parsed,
@@ -119,6 +148,20 @@ export async function POST(req: Request) {
         ctx,
       },
     )
+
+    if (guardResult.afterSuccessCallbacks.length) {
+      await runStaffMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+        tenantId,
+        organizationId,
+        userId: auth.sub,
+        resourceKind: 'staff.team_member',
+        resourceId: result?.memberId ?? auth.sub,
+        operation: 'create',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+      })
+    }
+
     const response = NextResponse.json({ id: result?.memberId ?? null }, { status: 201 })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(

--- a/packages/core/src/modules/staff/api/team-members/tags/assign/__tests__/route.test.ts
+++ b/packages/core/src/modules/staff/api/team-members/tags/assign/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+/** @jest-environment node */
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScope = jest.fn()
+const mockParseScopedCommandInput = jest.fn()
+const mockExecute = jest.fn()
+const mockRunStaffMutationGuards = jest.fn()
+const mockRunStaffMutationGuardAfterSuccess = jest.fn()
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'commandBus') return { execute: mockExecute }
+    return undefined
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScope(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({ translate: (_key: string, fallback?: string) => fallback ?? _key })),
+}))
+
+jest.mock('@open-mercato/shared/lib/api/scoped', () => ({
+  parseScopedCommandInput: jest.fn((...args: unknown[]) => mockParseScopedCommandInput(...args)),
+}))
+
+jest.mock('../../../../guards', () => ({
+  resolveUserFeatures: jest.fn(() => ['staff.manage_team']),
+  runStaffMutationGuards: jest.fn((...args: unknown[]) => mockRunStaffMutationGuards(...args)),
+  runStaffMutationGuardAfterSuccess: jest.fn((...args: unknown[]) => mockRunStaffMutationGuardAfterSuccess(...args)),
+}))
+
+type RouteModule = typeof import('../route')
+let postHandler: RouteModule['POST']
+
+beforeAll(async () => {
+  postHandler = (await import('../route')).POST
+})
+
+const buildRequest = () =>
+  new Request('http://localhost/api/staff/team-members/tags/assign', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ memberId: 'member-1', tag: 'vip' }),
+  })
+
+describe('staff team-members tags assign route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      features: ['staff.manage_team'],
+    })
+    mockResolveOrganizationScope.mockResolvedValue({ tenantId: 'tenant-1', selectedId: 'org-1', filterIds: ['org-1'] })
+    mockParseScopedCommandInput.mockReturnValue({ memberId: 'member-1', tag: 'vip' })
+    mockExecute.mockResolvedValue({ result: { memberId: 'member-1' }, logEntry: null })
+    mockRunStaffMutationGuards.mockResolvedValue({ ok: true, afterSuccessCallbacks: [] })
+  })
+
+  it('blocks the tag assignment when the mutation guard denies the request', async () => {
+    mockRunStaffMutationGuards.mockResolvedValueOnce({
+      ok: false,
+      errorStatus: 423,
+      errorBody: { error: 'Locked' },
+      afterSuccessCallbacks: [],
+    })
+
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(423)
+    await expect(response.json()).resolves.toEqual({ error: 'Locked' })
+    expect(mockRunStaffMutationGuards).toHaveBeenCalledWith(
+      mockContainer,
+      expect.objectContaining({
+        resourceKind: 'staff.team_member',
+        resourceId: 'member-1',
+        operation: 'create',
+        requestMethod: 'POST',
+      }),
+      expect.any(Array),
+    )
+    expect(mockExecute).not.toHaveBeenCalled()
+    expect(mockRunStaffMutationGuardAfterSuccess).not.toHaveBeenCalled()
+  })
+
+  it('runs the after-success hook when the guard requests it', async () => {
+    mockRunStaffMutationGuards.mockResolvedValueOnce({
+      ok: true,
+      afterSuccessCallbacks: [{ guard: {}, metadata: { lock: 'token' } }],
+    })
+
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(201)
+    expect(mockExecute).toHaveBeenCalledWith('staff.team-members.tags.assign', expect.anything())
+    expect(mockRunStaffMutationGuardAfterSuccess).toHaveBeenCalledWith(
+      [{ guard: {}, metadata: { lock: 'token' } }],
+      expect.objectContaining({
+        resourceKind: 'staff.team_member',
+        resourceId: 'member-1',
+        operation: 'create',
+      }),
+    )
+  })
+
+  it('does not run the after-success hook when the guard does not request it', async () => {
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(201)
+    expect(mockExecute).toHaveBeenCalled()
+    expect(mockRunStaffMutationGuardAfterSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/staff/api/team-members/tags/assign/route.ts
+++ b/packages/core/src/modules/staff/api/team-members/tags/assign/route.ts
@@ -13,6 +13,11 @@ import {
   staffTeamMemberTagAssignmentSchema,
   type StaffTeamMemberTagAssignmentInput,
 } from '../../../../data/validators'
+import {
+  resolveUserFeatures,
+  runStaffMutationGuardAfterSuccess,
+  runStaffMutationGuards,
+} from '../../../guards'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['staff.manage_team'] },
@@ -42,11 +47,51 @@ export async function POST(req: Request) {
     const { ctx, translate } = await buildContext(req)
     const body = await req.json().catch(() => ({}))
     const input = parseScopedCommandInput(staffTeamMemberTagAssignmentSchema, body, ctx, translate)
+
+    const auth = ctx.auth
+    const tenantId = auth?.tenantId ?? ''
+    const organizationId = ctx.selectedOrganizationId ?? null
+    const guardResult = await runStaffMutationGuards(
+      ctx.container,
+      {
+        tenantId,
+        organizationId,
+        userId: auth?.sub ?? '',
+        resourceKind: 'staff.team_member',
+        resourceId: input.memberId,
+        operation: 'create',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        mutationPayload: input,
+      },
+      resolveUserFeatures(auth),
+    )
+    if (!guardResult.ok) {
+      return NextResponse.json(
+        guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+        { status: guardResult.errorStatus ?? 422 },
+      )
+    }
+
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { result, logEntry } = await commandBus.execute<StaffTeamMemberTagAssignmentInput, { memberId: string }>(
       'staff.team-members.tags.assign',
       { input, ctx },
     )
+
+    if (guardResult.afterSuccessCallbacks.length) {
+      await runStaffMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+        tenantId,
+        organizationId,
+        userId: auth?.sub ?? '',
+        resourceKind: 'staff.team_member',
+        resourceId: result?.memberId ?? input.memberId,
+        operation: 'create',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+      })
+    }
+
     const response = NextResponse.json({ id: result?.memberId ?? null }, { status: 201 })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(

--- a/packages/core/src/modules/staff/api/team-members/tags/unassign/__tests__/route.test.ts
+++ b/packages/core/src/modules/staff/api/team-members/tags/unassign/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+/** @jest-environment node */
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScope = jest.fn()
+const mockParseScopedCommandInput = jest.fn()
+const mockExecute = jest.fn()
+const mockRunStaffMutationGuards = jest.fn()
+const mockRunStaffMutationGuardAfterSuccess = jest.fn()
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'commandBus') return { execute: mockExecute }
+    return undefined
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScope(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({ translate: (_key: string, fallback?: string) => fallback ?? _key })),
+}))
+
+jest.mock('@open-mercato/shared/lib/api/scoped', () => ({
+  parseScopedCommandInput: jest.fn((...args: unknown[]) => mockParseScopedCommandInput(...args)),
+}))
+
+jest.mock('../../../../guards', () => ({
+  resolveUserFeatures: jest.fn(() => ['staff.manage_team']),
+  runStaffMutationGuards: jest.fn((...args: unknown[]) => mockRunStaffMutationGuards(...args)),
+  runStaffMutationGuardAfterSuccess: jest.fn((...args: unknown[]) => mockRunStaffMutationGuardAfterSuccess(...args)),
+}))
+
+type RouteModule = typeof import('../route')
+let postHandler: RouteModule['POST']
+
+beforeAll(async () => {
+  postHandler = (await import('../route')).POST
+})
+
+const buildRequest = () =>
+  new Request('http://localhost/api/staff/team-members/tags/unassign', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ memberId: 'member-1', tag: 'vip' }),
+  })
+
+describe('staff team-members tags unassign route mutation guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      features: ['staff.manage_team'],
+    })
+    mockResolveOrganizationScope.mockResolvedValue({ tenantId: 'tenant-1', selectedId: 'org-1', filterIds: ['org-1'] })
+    mockParseScopedCommandInput.mockReturnValue({ memberId: 'member-1', tag: 'vip' })
+    mockExecute.mockResolvedValue({ result: { memberId: 'member-1' }, logEntry: null })
+    mockRunStaffMutationGuards.mockResolvedValue({ ok: true, afterSuccessCallbacks: [] })
+  })
+
+  it('blocks the tag removal when the mutation guard denies the request', async () => {
+    mockRunStaffMutationGuards.mockResolvedValueOnce({
+      ok: false,
+      errorStatus: 423,
+      errorBody: { error: 'Locked' },
+      afterSuccessCallbacks: [],
+    })
+
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(423)
+    await expect(response.json()).resolves.toEqual({ error: 'Locked' })
+    expect(mockRunStaffMutationGuards).toHaveBeenCalledWith(
+      mockContainer,
+      expect.objectContaining({
+        resourceKind: 'staff.team_member',
+        resourceId: 'member-1',
+        operation: 'delete',
+        requestMethod: 'POST',
+      }),
+      expect.any(Array),
+    )
+    expect(mockExecute).not.toHaveBeenCalled()
+    expect(mockRunStaffMutationGuardAfterSuccess).not.toHaveBeenCalled()
+  })
+
+  it('runs the after-success hook when the guard requests it', async () => {
+    mockRunStaffMutationGuards.mockResolvedValueOnce({
+      ok: true,
+      afterSuccessCallbacks: [{ guard: {}, metadata: { lock: 'token' } }],
+    })
+
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(200)
+    expect(mockExecute).toHaveBeenCalledWith('staff.team-members.tags.unassign', expect.anything())
+    expect(mockRunStaffMutationGuardAfterSuccess).toHaveBeenCalledWith(
+      [{ guard: {}, metadata: { lock: 'token' } }],
+      expect.objectContaining({
+        resourceKind: 'staff.team_member',
+        resourceId: 'member-1',
+        operation: 'delete',
+      }),
+    )
+  })
+
+  it('does not run the after-success hook when the guard does not request it', async () => {
+    const response = await postHandler(buildRequest())
+
+    expect(response.status).toBe(200)
+    expect(mockExecute).toHaveBeenCalled()
+    expect(mockRunStaffMutationGuardAfterSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/staff/api/team-members/tags/unassign/route.ts
+++ b/packages/core/src/modules/staff/api/team-members/tags/unassign/route.ts
@@ -13,6 +13,11 @@ import {
   staffTeamMemberTagAssignmentSchema,
   type StaffTeamMemberTagAssignmentInput,
 } from '../../../../data/validators'
+import {
+  resolveUserFeatures,
+  runStaffMutationGuardAfterSuccess,
+  runStaffMutationGuards,
+} from '../../../guards'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['staff.manage_team'] },
@@ -42,11 +47,51 @@ export async function POST(req: Request) {
     const { ctx, translate } = await buildContext(req)
     const body = await req.json().catch(() => ({}))
     const input = parseScopedCommandInput(staffTeamMemberTagAssignmentSchema, body, ctx, translate)
+
+    const auth = ctx.auth
+    const tenantId = auth?.tenantId ?? ''
+    const organizationId = ctx.selectedOrganizationId ?? null
+    const guardResult = await runStaffMutationGuards(
+      ctx.container,
+      {
+        tenantId,
+        organizationId,
+        userId: auth?.sub ?? '',
+        resourceKind: 'staff.team_member',
+        resourceId: input.memberId,
+        operation: 'delete',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        mutationPayload: input,
+      },
+      resolveUserFeatures(auth),
+    )
+    if (!guardResult.ok) {
+      return NextResponse.json(
+        guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+        { status: guardResult.errorStatus ?? 422 },
+      )
+    }
+
     const commandBus = (ctx.container.resolve('commandBus') as CommandBus)
     const { result, logEntry } = await commandBus.execute<StaffTeamMemberTagAssignmentInput, { memberId: string }>(
       'staff.team-members.tags.unassign',
       { input, ctx },
     )
+
+    if (guardResult.afterSuccessCallbacks.length) {
+      await runStaffMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+        tenantId,
+        organizationId,
+        userId: auth?.sub ?? '',
+        resourceKind: 'staff.team_member',
+        resourceId: result?.memberId ?? input.memberId,
+        operation: 'delete',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+      })
+    }
+
     const response = NextResponse.json({ id: result?.memberId ?? null })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Several command-backed staff POST routes executed domain mutations without the
staff module's mutation-guard lifecycle that `packages/core/AGENTS.md` requires
for custom (non-`makeCrudRoute`) write routes. The timesheet custom routes already
use `runStaffMutationGuards` / `runStaffMutationGuardAfterSuccess`, but the leave-request
decision routes, self-profile creation, and tag assign/unassign routes skipped that
contract — bypassing the seam mutation guards (record-locks, rate-limiting, integrity
checks) plug into.

All five routes are now wired through the same guard lifecycle the timesheet routes use.

## Changes

- `staff/api/leave-requests/accept/route.ts`: guard before `commandBus.execute` (`resourceKind: 'staff.leave_request'`, `resourceId: input.id`, `operation: 'update'`); abort on denial; after-success hook on success.
- `staff/api/leave-requests/reject/route.ts`: same wiring for the reject decision.
- `staff/api/team-members/self/route.ts`: guard after the 409 existence check (`resourceKind: 'staff.team_member'`, `operation: 'create'`); after-success uses the created `memberId`.
- `staff/api/team-members/tags/assign/route.ts`: guard before assign (`operation: 'create'`, `resourceId: input.memberId`).
- `staff/api/team-members/tags/unassign/route.ts`: guard before unassign (`operation: 'delete'`, `resourceId: input.memberId`).
- Added 5 colocated route test files (15 tests) proving the guard blocks the write before command execution and the after-success hook runs only on success when requested.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — wiring an existing contract surface (mutation guards) into routes that omitted it.

## Testing

- `yarn workspace @open-mercato/core test "modules/staff/"` → 18 suites / 98 tests pass (incl. 15 new guard tests; the 10 block/after-success tests fail on base, pass after the fix).
- `yarn build:packages` → 21/21
- `yarn generate` → ok
- `yarn typecheck` → 21/21
- `yarn i18n:check-sync` → all 4 locales in sync
- `yarn build:app` → compiled + TypeScript checked

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no contract/locale/generator surface changed.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Guard denial requires injecting a guard service into the request container, which is not feasible against a live ephemeral server; the wiring is fully covered by the route unit tests, and the default OSS guard already has integration coverage (`staff/__integration__` + `workflows/__integration__/TC-LOCK-OSS-044`).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A, see Specification.
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, carried from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — single-module, additive, ships with tests, and no-ops when no guard service is registered; carried down from the issue's `risk-high` since the change is narrowly scoped and backward-compatible.)
- [x] QA routing set: `skip-qa` — backend-only, no customer-facing UI change, fully covered by unit tests.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI.
- [x] No arbitrary text sizes — N/A, no UI.
- [x] Empty state handled for list/data pages — N/A, no UI.
- [x] Loading state handled for async pages — N/A, no UI.
- [x] `aria-label` on all icon-only buttons — N/A, no UI.
- [x] Uses existing DS components — N/A, no UI.

## Linked issues

Fixes #3310

🤖 Generated with [Claude Code](https://claude.com/claude-code)
