### PR TITLE
bug(resources): route raw writes through guarded mutations

### DIFF
--- a/packages/core/src/modules/resources/backend/resources/__tests__/guarded-mutations.test.tsx
+++ b/packages/core/src/modules/resources/backend/resources/__tests__/guarded-mutations.test.tsx
@@ -1,0 +1,477 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import ResourcesResourceTypesPage from '../resource-types/page'
+import ResourcesResourcesPage from '../resources/page'
+import ResourcesResourceDetailPage from '../resources/[id]/page'
+
+const mockPush = jest.fn()
+const mockReplace = jest.fn()
+const mockRefresh = jest.fn()
+let mockSearchParams = new URLSearchParams()
+
+const mockApiCall = jest.fn()
+const mockApiCallOrThrow = jest.fn()
+const mockReadApiResultOrThrow = jest.fn()
+const mockWithScopedApiRequestHeaders = jest.fn((_headers: Record<string, string>, run: () => unknown) => run())
+const mockCreateCrud = jest.fn()
+const mockUpdateCrud = jest.fn()
+const mockDeleteCrud = jest.fn()
+const mockRunMutation = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+const mockRetryLastMutation = jest.fn(async () => false)
+const mockResolveFieldsetCode = jest.fn(() => 'resources_resource_default')
+const mockTranslate = (_key: string, fallback?: string) => fallback ?? _key
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/backend/resources/resources',
+  useRouter: () => ({ push: mockPush, replace: mockReplace, refresh: mockRefresh }),
+  useSearchParams: () => mockSearchParams,
+}))
+
+jest.mock('next/link', () => ({ children, href }: { children: React.ReactNode; href: string }) => (
+  <a href={href}>{children}</a>
+))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/translate', () => ({
+  createTranslatorWithFallback: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 1,
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    resources: {
+      resources_resource: 'resources:resources_resource',
+      resources_resource_activity: 'resources:resources_resource_activity',
+    },
+  },
+}), { virtual: true })
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PageBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/forms', () => ({
+  FormHeader: ({ title }: { title: React.ReactNode }) => <h1>{title}</h1>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, asChild: _asChild, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }) => (
+    <button {...props}>{children}</button>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  DataTable: (props: { data?: Array<Record<string, unknown>>; rowActions?: (row: Record<string, unknown>) => React.ReactNode }) => (
+    <div>
+      {(props.data ?? []).map((row, index) => (
+        <div key={String(row.id ?? index)} data-testid={`row-${String(row.id ?? index)}`}>
+          {props.rowActions?.(row)}
+        </div>
+      ))}
+    </div>
+  ),
+  withDataTableNamespaces: (row: Record<string, unknown>) => row,
+}))
+
+jest.mock('@open-mercato/ui/backend/RowActions', () => ({
+  RowActions: ({ items }: { items: Array<{ id: string; label: string; onSelect?: () => void }> }) => (
+    <div>
+      {items.map((item) => (
+        <button key={item.id} type="button" data-testid={`row-action-${item.id}`} onClick={() => item.onSelect?.()}>
+          {item.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({
+    confirm: jest.fn(async () => true),
+    ConfirmDialogElement: null,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+  apiCallOrThrow: (...args: unknown[]) => mockApiCallOrThrow(...args),
+  readApiResultOrThrow: (...args: unknown[]) => mockReadApiResultOrThrow(...args),
+  withScopedApiRequestHeaders: (...args: [Record<string, string>, () => unknown]) =>
+    mockWithScopedApiRequestHeaders(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  createCrud: (...args: unknown[]) => mockCreateCrud(...args),
+  updateCrud: (...args: unknown[]) => mockUpdateCrud(...args),
+  deleteCrud: (...args: unknown[]) => mockDeleteCrud(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: (updatedAt?: string | null) =>
+    updatedAt ? { 'x-om-ext-optimistic-lock-expected-updated-at': updatedAt } : {},
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: mockRunMutation,
+    retryLastMutation: mockRetryLastMutation,
+  }),
+}))
+
+jest.mock('@open-mercato/core/modules/dictionaries/components/dictionaryAppearance', () => ({
+  ICON_SUGGESTIONS: [],
+  renderDictionaryColor: (color: string) => <span>{color}</span>,
+  renderDictionaryIcon: (icon: string) => <span>{icon}</span>,
+}))
+
+jest.mock('@open-mercato/ui/backend/ValueIcons', () => ({
+  BooleanIcon: ({ value }: { value: boolean }) => <span>{String(value)}</span>,
+}))
+
+jest.mock('@open-mercato/ui/backend/version-history', () => ({
+  VersionHistoryAction: () => null,
+}))
+
+jest.mock('@open-mercato/ui/backend/messages', () => ({
+  SendObjectMessageDialog: () => null,
+}))
+
+jest.mock('@open-mercato/core/modules/resources/components/detail/dictionaries', () => ({
+  createResourceDictionaryEntry: jest.fn(async (_dictionary: string, input: Record<string, unknown>) => ({
+    id: 'activity-type-2',
+    ...input,
+  })),
+  loadResourceDictionary: jest.fn(async () => ({ dictionary: { id: 'activity-types' }, entries: [] })),
+}))
+
+jest.mock('@open-mercato/core/modules/planner/components/AvailabilityRulesEditor', () => ({
+  AvailabilityRulesEditor: ({ onRulesetChange }: { onRulesetChange: (nextId: string | null) => Promise<void> }) => (
+    <button type="button" data-testid="change-ruleset" onClick={() => { void onRulesetChange('ruleset-2') }}>
+      change ruleset
+    </button>
+  ),
+}))
+
+jest.mock('@open-mercato/core/modules/resources/components/ResourceCrudForm', () => ({
+  ResourcesResourceForm: ({
+    formConfig,
+    onDelete,
+  }: {
+    formConfig: { tagsSection?: { createTag: (label: string) => Promise<unknown>; onSave: (payload: unknown) => Promise<void> } }
+    onDelete?: () => Promise<void>
+  }) => (
+    <div>
+      <button type="button" data-testid="detail-delete" onClick={() => { void onDelete?.() }}>
+        delete resource
+      </button>
+      <button type="button" data-testid="create-tag" onClick={() => { void formConfig.tagsSection?.createTag('Urgent') }}>
+        create tag
+      </button>
+      <button
+        type="button"
+        data-testid="save-tags"
+        onClick={() => {
+          void formConfig.tagsSection?.onSave({
+            next: [{ id: 'tag-new', label: 'New tag', color: null }],
+            added: [{ id: 'tag-new', label: 'New tag', color: null }],
+            removed: [{ id: 'tag-old', label: 'Old tag', color: null }],
+          })
+        }}
+      >
+        save tags
+      </button>
+    </div>
+  ),
+  useResourcesResourceFormConfig: ({ tagsSection }: { tagsSection?: unknown }) => ({
+    fields: [],
+    groups: [],
+    resourceTypesLoaded: true,
+    resolveFieldsetCode: mockResolveFieldsetCode,
+    tagsSection,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/detail', () => ({
+  ActivitiesSection: ({ dataAdapter }: { dataAdapter: { create: (payload: unknown) => Promise<void>; update: (payload: unknown) => Promise<void>; delete: (payload: unknown) => Promise<void> } }) => (
+    <div>
+      <button
+        type="button"
+        data-testid="activity-create"
+        onClick={() => {
+          void dataAdapter.create({
+            entityId: 'resource-1',
+            activityType: 'meeting',
+            subject: 'Visit',
+            body: 'Checked room',
+            occurredAt: '2026-06-19T10:00:00.000Z',
+          })
+        }}
+      >
+        create activity
+      </button>
+      <button
+        type="button"
+        data-testid="activity-update"
+        onClick={() => { void dataAdapter.update({ id: 'activity-1', patch: { subject: 'Updated' } }) }}
+      >
+        update activity
+      </button>
+      <button
+        type="button"
+        data-testid="activity-delete"
+        onClick={() => { void dataAdapter.delete({ id: 'activity-1' }) }}
+      >
+        delete activity
+      </button>
+    </div>
+  ),
+  NotesSection: ({ dataAdapter }: { dataAdapter: { create: (payload: unknown) => Promise<unknown>; update: (payload: unknown) => Promise<void>; delete: (payload: unknown) => Promise<void> } }) => (
+    <div>
+      <button
+        type="button"
+        data-testid="note-create"
+        onClick={() => {
+          void dataAdapter.create({
+            entityId: 'resource-1',
+            body: 'Needs cleaning',
+            appearanceIcon: null,
+            appearanceColor: null,
+          })
+        }}
+      >
+        create note
+      </button>
+      <button
+        type="button"
+        data-testid="note-update"
+        onClick={() => { void dataAdapter.update({ id: 'note-1', patch: { body: 'Updated note' } }) }}
+      >
+        update note
+      </button>
+      <button
+        type="button"
+        data-testid="note-delete"
+        onClick={() => { void dataAdapter.delete({ id: 'note-1' }) }}
+      >
+        delete note
+      </button>
+    </div>
+  ),
+  RecordNotFoundState: () => <div>not found</div>,
+}))
+
+jest.mock('lucide-react', () => new Proxy({}, { get: () => () => null }))
+
+function apiResult(result: Record<string, unknown>) {
+  return { ok: true, result }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockSearchParams = new URLSearchParams()
+  mockRunMutation.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+  mockRetryLastMutation.mockResolvedValue(false)
+  mockCreateCrud.mockResolvedValue(undefined)
+  mockUpdateCrud.mockResolvedValue(undefined)
+  mockDeleteCrud.mockResolvedValue(undefined)
+  mockApiCallOrThrow.mockImplementation(async (url: string) => {
+    if (url === '/api/resources/tags') {
+      return { result: { id: 'tag-created', label: 'Urgent', color: null } }
+    }
+    return { result: {} }
+  })
+  mockApiCall.mockImplementation(async (url: string) => {
+    if (url === '/api/auth/feature-check') {
+      return apiResult({ ok: true, granted: ['resources.manage_resources'] })
+    }
+    if (url.startsWith('/api/resources/resource-types')) {
+      return apiResult({
+        items: [{ id: 'type-1', name: 'Room', appearanceIcon: null, appearanceColor: null }],
+        total: 1,
+        page: 1,
+        totalPages: 1,
+      })
+    }
+    if (url.startsWith('/api/resources/resources')) {
+      return apiResult({
+        items: [
+          {
+            id: 'resource-1',
+            name: 'Room 1',
+            resourceTypeId: null,
+            capacity: 1,
+            tags: [],
+            isActive: true,
+            updatedAt: '2026-06-19T10:00:00.000Z',
+          },
+        ],
+        total: 1,
+        page: 1,
+        totalPages: 1,
+      })
+    }
+    return apiResult({ items: [] })
+  })
+  mockReadApiResultOrThrow.mockImplementation(async (url: string) => {
+    if (url.startsWith('/api/resources/resource-types')) {
+      return {
+        items: [
+          {
+            id: 'resource-type-1',
+            name: 'Room',
+            description: null,
+            appearanceIcon: null,
+            appearanceColor: null,
+            updatedAt: '2026-06-19T10:00:00.000Z',
+            resourceCount: 0,
+          },
+        ],
+        total: 1,
+        totalPages: 1,
+      }
+    }
+    if (url.startsWith('/api/resources/resources')) {
+      return {
+        items: [
+          {
+            id: 'resource-1',
+            name: 'Room 1',
+            resourceTypeId: null,
+            capacity: 1,
+            tags: [{ id: 'tag-old', label: 'Old tag', color: null }],
+            isActive: true,
+            updatedAt: '2026-06-19T10:00:00.000Z',
+            availabilityRuleSetId: 'ruleset-1',
+          },
+        ],
+        total: 1,
+        totalPages: 1,
+      }
+    }
+    return { items: [] }
+  })
+})
+
+it('wraps resource list deletes in the guarded mutation path', async () => {
+  render(<ResourcesResourcesPage />)
+
+  fireEvent.click(await screen.findByTestId('row-action-delete'))
+
+  await waitFor(() => {
+    expect(mockDeleteCrud).toHaveBeenCalledWith('resources/resources', 'resource-1', expect.any(Object))
+  })
+  expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+    context: expect.objectContaining({
+      formId: 'resources.resources.list',
+      resourceKind: 'resources.resource',
+      resourceId: 'resource-1',
+      retryLastMutation: mockRetryLastMutation,
+    }),
+    mutationPayload: expect.objectContaining({ operation: 'deleteResource', id: 'resource-1' }),
+  }))
+})
+
+it('wraps resource type list deletes in the guarded mutation path', async () => {
+  render(<ResourcesResourceTypesPage />)
+
+  fireEvent.click(await screen.findByTestId('row-action-delete'))
+
+  await waitFor(() => {
+    expect(mockDeleteCrud).toHaveBeenCalledWith('resources/resource-types', 'resource-type-1', expect.any(Object))
+  })
+  expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+    context: expect.objectContaining({
+      formId: 'resources.resource-types.list',
+      resourceKind: 'resources.resourceType',
+      resourceId: 'resource-type-1',
+      retryLastMutation: mockRetryLastMutation,
+    }),
+    mutationPayload: expect.objectContaining({ operation: 'deleteResourceType', id: 'resource-type-1' }),
+  }))
+})
+
+it('wraps resource detail tag writes and delete in the guarded mutation path', async () => {
+  render(<ResourcesResourceDetailPage params={{ id: 'resource-1' }} />)
+
+  fireEvent.click(await screen.findByTestId('create-tag'))
+  fireEvent.click(await screen.findByTestId('save-tags'))
+  fireEvent.click(await screen.findByTestId('detail-delete'))
+
+  await waitFor(() => {
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      mutationPayload: expect.objectContaining({ operation: 'createTag', label: 'Urgent' }),
+    }))
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      mutationPayload: expect.objectContaining({ operation: 'assignTag', resourceId: 'resource-1', tagId: 'tag-new' }),
+    }))
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      mutationPayload: expect.objectContaining({ operation: 'unassignTag', resourceId: 'resource-1', tagId: 'tag-old' }),
+    }))
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      mutationPayload: expect.objectContaining({ operation: 'deleteResource', id: 'resource-1' }),
+    }))
+  })
+})
+
+it('wraps resource availability ruleset updates in the guarded mutation path', async () => {
+  render(<ResourcesResourceDetailPage params={{ id: 'resource-1' }} />)
+
+  fireEvent.click(await screen.findByRole('tab', { name: 'Availability' }))
+  fireEvent.click(await screen.findByTestId('change-ruleset'))
+
+  await waitFor(() => {
+    expect(mockUpdateCrud).toHaveBeenCalledWith(
+      'resources/resources',
+      { id: 'resource-1', availabilityRuleSetId: 'ruleset-2' },
+      expect.any(Object),
+    )
+  })
+  expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+    context: expect.objectContaining({
+      formId: 'resources.resource:resource-1',
+      resourceKind: 'resources.resource',
+      resourceId: 'resource-1',
+      retryLastMutation: mockRetryLastMutation,
+    }),
+    mutationPayload: expect.objectContaining({
+      operation: 'updateAvailabilityRuleSet',
+      id: 'resource-1',
+      availabilityRuleSetId: 'ruleset-2',
+    }),
+  }))
+})
+
+it('wraps resource notes and activities adapter writes in the guarded mutation path', async () => {
+  render(<ResourcesResourceDetailPage params={{ id: 'resource-1' }} />)
+
+  fireEvent.click(await screen.findByTestId('note-create'))
+  fireEvent.click(await screen.findByTestId('note-update'))
+  fireEvent.click(await screen.findByTestId('note-delete'))
+
+  fireEvent.click(screen.getByRole('button', { name: 'Activities' }))
+  fireEvent.click(await screen.findByTestId('activity-create'))
+  fireEvent.click(await screen.findByTestId('activity-update'))
+  fireEvent.click(await screen.findByTestId('activity-delete'))
+
+  await waitFor(() => {
+    for (const operation of ['createNote', 'updateNote', 'deleteNote', 'createActivity', 'updateActivity', 'deleteActivity']) {
+      expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+        mutationPayload: expect.objectContaining({ operation }),
+      }))
+    }
+  })
+})

--- a/packages/core/src/modules/resources/backend/resources/resource-types/page.tsx
+++ b/packages/core/src/modules/resources/backend/resources/resource-types/page.tsx
@@ -13,6 +13,7 @@ import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { renderDictionaryColor, renderDictionaryIcon } from '@open-mercato/core/modules/dictionaries/components/dictionaryAppearance'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 import { Package } from 'lucide-react'
@@ -23,6 +24,7 @@ import { formatDateTime } from '@open-mercato/shared/lib/time'
 const PAGE_SIZE = 50
 const DESCRIPTION_CLASSNAME = 'line-clamp-3 whitespace-pre-line text-sm text-foreground'
 const SUBTEXT_CLASSNAME = 'line-clamp-2 text-xs text-muted-foreground'
+const RESOURCE_TYPES_MUTATION_CONTEXT_ID = 'resources.resource-types.list'
 
 type ResourceTypeRow = {
   id: string
@@ -40,6 +42,13 @@ type ResourceTypesResponse = {
   totalPages?: number
 }
 
+type ResourceTypesMutationContext = {
+  formId: string
+  resourceKind: string
+  resourceId?: string
+  retryLastMutation: () => Promise<boolean>
+}
+
 export default function ResourcesResourceTypesPage() {
   const translate = useT()
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
@@ -53,6 +62,27 @@ export default function ResourcesResourceTypesPage() {
   const [search, setSearch] = React.useState('')
   const [isLoading, setIsLoading] = React.useState(true)
   const [reloadToken, setReloadToken] = React.useState(0)
+  const { runMutation, retryLastMutation } = useGuardedMutation<ResourceTypesMutationContext>({
+    contextId: RESOURCE_TYPES_MUTATION_CONTEXT_ID,
+    blockedMessage: translate('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const runResourceTypeMutation = React.useCallback(
+    async <T,>(
+      operation: () => Promise<T>,
+      mutationPayload: Record<string, unknown>,
+      resourceId?: string,
+    ): Promise<T> => runMutation({
+      operation,
+      mutationPayload,
+      context: {
+        formId: RESOURCE_TYPES_MUTATION_CONTEXT_ID,
+        resourceKind: 'resources.resourceType',
+        resourceId,
+        retryLastMutation,
+      },
+    }),
+    [retryLastMutation, runMutation],
+  )
 
   const translations = React.useMemo(() => ({
     title: translate('resources.resourceTypes.page.title', 'Resource types'),
@@ -230,16 +260,20 @@ export default function ResourcesResourceTypesPage() {
     if (!confirmed) return
     try {
       const headers = buildOptimisticLockHeader(entry.updatedAt)
-      await withScopedApiRequestHeaders(headers, () => (
-        deleteCrud('resources/resource-types', entry.id, { errorMessage: translations.errors.delete })
-      ))
+      await runResourceTypeMutation(
+        () => withScopedApiRequestHeaders(headers, () => (
+          deleteCrud('resources/resource-types', entry.id, { errorMessage: translations.errors.delete })
+        )),
+        { operation: 'deleteResourceType', id: entry.id, updatedAt: entry.updatedAt ?? null },
+        entry.id,
+      )
       flash(translations.messages.deleted, 'success')
       handleRefresh()
     } catch (error) {
       console.error('resources.resource-types.delete', error)
       flash(translations.errors.delete, 'error')
     }
-  }, [confirm, handleRefresh, translations.actions.deleteConfirm, translations.errors.delete, translations.errors.deleteAssigned, translations.messages.deleted])
+  }, [confirm, handleRefresh, runResourceTypeMutation, translations.actions.deleteConfirm, translations.errors.delete, translations.errors.deleteAssigned, translations.messages.deleted])
 
   return (
     <Page>

--- a/packages/core/src/modules/resources/backend/resources/resources/[id]/page.tsx
+++ b/packages/core/src/modules/resources/backend/resources/resources/[id]/page.tsx
@@ -12,6 +12,7 @@ import { createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors
 import { updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { ActivitiesSection, NotesSection, RecordNotFoundState, type SectionAction, type TagOption } from '@open-mercato/ui/backend/detail'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { VersionHistoryAction } from '@open-mercato/ui/backend/version-history'
 import { SendObjectMessageDialog } from '@open-mercato/ui/backend/messages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -62,6 +63,14 @@ type ResourceResponse = {
   items: ResourceRecord[]
 }
 
+type ResourceDetailMutationContext = {
+  formId: string
+  resourceKind: string
+  resourceId?: string
+  data: Record<string, unknown> | null
+  retryLastMutation: () => Promise<boolean>
+}
+
 function normalizeResourceRecord(record: ResourceRecord): ResourceRecord {
   return {
     ...record,
@@ -95,8 +104,42 @@ export default function ResourcesResourceDetailPage({ params }: { params?: { id?
   const flashShownRef = React.useRef(false)
 
   const availabilityMode = 'availability'
-  const notesAdapter = React.useMemo(() => createResourceNotesAdapter(detailTranslator), [detailTranslator])
-  const activitiesAdapter = React.useMemo(() => createResourceActivitiesAdapter(detailTranslator), [detailTranslator])
+  const mutationContextId = React.useMemo(
+    () => (resourceId ? `resources.resource:${resourceId}` : 'resources.resource:pending'),
+    [resourceId],
+  )
+  const { runMutation, retryLastMutation } = useGuardedMutation<ResourceDetailMutationContext>({
+    contextId: mutationContextId,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const mutationContext = React.useMemo<ResourceDetailMutationContext>(
+    () => ({
+      formId: mutationContextId,
+      resourceKind: 'resources.resource',
+      resourceId,
+      data: initialValues,
+      retryLastMutation,
+    }),
+    [initialValues, mutationContextId, resourceId, retryLastMutation],
+  )
+  const runMutationWithContext = React.useCallback(
+    async <T,>(operation: () => Promise<T>, mutationPayload?: Record<string, unknown>): Promise<T> => (
+      runMutation({
+        operation,
+        mutationPayload,
+        context: mutationContext,
+      })
+    ),
+    [mutationContext, runMutation],
+  )
+  const notesAdapter = React.useMemo(
+    () => createResourceNotesAdapter(detailTranslator, { runMutation: runMutationWithContext }),
+    [detailTranslator, runMutationWithContext],
+  )
+  const activitiesAdapter = React.useMemo(
+    () => createResourceActivitiesAdapter(detailTranslator, { runMutation: runMutationWithContext }),
+    [detailTranslator, runMutationWithContext],
+  )
 
   const activityTypeLabels = React.useMemo<DictionarySelectLabels>(() => ({
     placeholder: t('resources.resources.detail.activities.dictionary.placeholder', 'Select an activity type'),
@@ -329,14 +372,18 @@ export default function ResourcesResourceDetailPage({ params }: { params?: { id?
       if (!trimmed.length) {
         throw new Error(t('resources.resources.tags.labelRequired', 'Tag name is required.'))
       }
-      const response = await apiCallOrThrow<Record<string, unknown>>(
-        '/api/resources/tags',
-        {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ label: trimmed }),
-        },
-        { errorMessage: t('resources.resources.tags.createError', 'Failed to create tag.') },
+      const requestBody = { label: trimmed }
+      const response = await runMutationWithContext(
+        () => apiCallOrThrow<Record<string, unknown>>(
+          '/api/resources/tags',
+          {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(requestBody),
+          },
+          { errorMessage: t('resources.resources.tags.createError', 'Failed to create tag.') },
+        ),
+        { operation: 'createTag', label: trimmed },
       )
       const payload = response.result ?? {}
       const id =
@@ -351,34 +398,42 @@ export default function ResourcesResourceDetailPage({ params }: { params?: { id?
         : null
       return { id, label: trimmed, color }
     },
-    [t],
+    [runMutationWithContext, t],
   )
 
   const assignTag = React.useCallback(async (tagId: string) => {
     if (!resourceId) return
-    await apiCallOrThrow(
-      '/api/resources/resources/tags/assign',
-      {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ tagId, resourceId }),
-      },
-      { errorMessage: t('resources.resources.tags.updateError', 'Failed to update tags.') },
+    const requestBody = { tagId, resourceId }
+    await runMutationWithContext(
+      () => apiCallOrThrow(
+        '/api/resources/resources/tags/assign',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(requestBody),
+        },
+        { errorMessage: t('resources.resources.tags.updateError', 'Failed to update tags.') },
+      ),
+      { operation: 'assignTag', resourceId, tagId },
     )
-  }, [resourceId, t])
+  }, [resourceId, runMutationWithContext, t])
 
   const unassignTag = React.useCallback(async (tagId: string) => {
     if (!resourceId) return
-    await apiCallOrThrow(
-      '/api/resources/resources/tags/unassign',
-      {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ tagId, resourceId }),
-      },
-      { errorMessage: t('resources.resources.tags.updateError', 'Failed to update tags.') },
+    const requestBody = { tagId, resourceId }
+    await runMutationWithContext(
+      () => apiCallOrThrow(
+        '/api/resources/resources/tags/unassign',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(requestBody),
+        },
+        { errorMessage: t('resources.resources.tags.updateError', 'Failed to update tags.') },
+      ),
+      { operation: 'unassignTag', resourceId, tagId },
     )
-  }, [resourceId, t])
+  }, [resourceId, runMutationWithContext, t])
 
   const handleTagsSave = React.useCallback(
     async ({ next, added, removed }: { next: TagOption[]; added: TagOption[]; removed: TagOption[] }) => {
@@ -470,12 +525,21 @@ export default function ResourcesResourceDetailPage({ params }: { params?: { id?
 
   const handleDelete = React.useCallback(async () => {
     if (!resourceId) return
-    await deleteCrud('resources/resources', resourceId, {
+    const resourceOptimisticLockHeader = buildOptimisticLockHeader(
+      typeof initialValues?.updatedAt === 'string' ? initialValues.updatedAt : null,
+    )
+    const deleteResource = () => deleteCrud('resources/resources', resourceId, {
       errorMessage: t('resources.resources.form.errors.delete', 'Failed to delete resource.'),
     })
+    await runMutationWithContext(
+      () => Object.keys(resourceOptimisticLockHeader).length > 0
+        ? withScopedApiRequestHeaders(resourceOptimisticLockHeader, deleteResource)
+        : deleteResource(),
+      { operation: 'deleteResource', id: resourceId, updatedAt: initialValues?.updatedAt ?? null },
+    )
     flash(t('resources.resources.form.flash.deleted', 'Resource deleted.'), 'success')
     router.push('/backend/resources/resources')
-  }, [resourceId, router, t])
+  }, [initialValues?.updatedAt, resourceId, router, runMutationWithContext, t])
 
   const handleRulesetChange = React.useCallback(async (nextId: string | null) => {
     if (!resourceId) return
@@ -485,14 +549,15 @@ export default function ResourcesResourceDetailPage({ params }: { params?: { id?
     const resourceOptimisticLockHeader = buildOptimisticLockHeader(
       typeof initialValues?.updatedAt === 'string' ? initialValues.updatedAt : null,
     )
-    if (Object.keys(resourceOptimisticLockHeader).length > 0) {
-      await withScopedApiRequestHeaders(resourceOptimisticLockHeader, updateSchedule)
-    } else {
-      await updateSchedule()
-    }
+    await runMutationWithContext(
+      () => Object.keys(resourceOptimisticLockHeader).length > 0
+        ? withScopedApiRequestHeaders(resourceOptimisticLockHeader, updateSchedule)
+        : updateSchedule(),
+      { operation: 'updateAvailabilityRuleSet', id: resourceId, availabilityRuleSetId: nextId },
+    )
     setAvailabilityRuleSetId(nextId)
     flash(t('resources.resources.availability.ruleset.updateSuccess', 'Schedule updated.'), 'success')
-  }, [initialValues?.updatedAt, resourceId, t])
+  }, [initialValues?.updatedAt, resourceId, runMutationWithContext, t])
 
   const resourceTitle =
     typeof initialValues?.name === 'string' && initialValues.name.trim().length > 0

--- a/packages/core/src/modules/resources/backend/resources/resources/page.tsx
+++ b/packages/core/src/modules/resources/backend/resources/resources/page.tsx
@@ -15,6 +15,7 @@ import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimi
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import type { FilterDef, FilterOption, FilterValues } from '@open-mercato/ui/backend/FilterOverlay'
 import type { TagOption } from '@open-mercato/ui/backend/detail'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { renderDictionaryColor, renderDictionaryIcon } from '@open-mercato/core/modules/dictionaries/components/dictionaryAppearance'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -22,6 +23,7 @@ import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 import { Pencil } from 'lucide-react'
 
 const PAGE_SIZE = 20
+const RESOURCE_LIST_MUTATION_CONTEXT_ID = 'resources.resources.list'
 
 type ResourceRow = {
   id: string
@@ -65,6 +67,13 @@ type ResourceTypesResponse = {
   items: Array<Record<string, unknown>>
 }
 
+type ResourceListMutationContext = {
+  formId: string
+  resourceKind: string
+  resourceId?: string
+  retryLastMutation: () => Promise<boolean>
+}
+
 export default function ResourcesResourcesPage() {
   const [rows, setRows] = React.useState<ResourceRow[]>([])
   const [page, setPage] = React.useState(1)
@@ -86,6 +95,27 @@ export default function ResourcesResourcesPage() {
   const selectedResourceTypeId = typeof filterValues.resourceTypeId === 'string'
     ? filterValues.resourceTypeId
     : resourceTypeFilter
+  const { runMutation, retryLastMutation } = useGuardedMutation<ResourceListMutationContext>({
+    contextId: RESOURCE_LIST_MUTATION_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const runResourceMutation = React.useCallback(
+    async <T,>(
+      operation: () => Promise<T>,
+      mutationPayload: Record<string, unknown>,
+      resourceId?: string,
+    ): Promise<T> => runMutation({
+      operation,
+      mutationPayload,
+      context: {
+        formId: RESOURCE_LIST_MUTATION_CONTEXT_ID,
+        resourceKind: 'resources.resource',
+        resourceId,
+        retryLastMutation,
+      },
+    }),
+    [retryLastMutation, runMutation],
+  )
 
   React.useEffect(() => {
     setPage(1)
@@ -352,11 +382,15 @@ export default function ResourcesResourcesPage() {
     if (!confirmed) return
     try {
       const headers = buildOptimisticLockHeader(row.updatedAt)
-      await withScopedApiRequestHeaders(headers, () => (
-        deleteCrud('resources/resources', row.id, {
-          errorMessage: t('resources.resources.list.error.delete', 'Failed to delete resource.'),
-        })
-      ))
+      await runResourceMutation(
+        () => withScopedApiRequestHeaders(headers, () => (
+          deleteCrud('resources/resources', row.id, {
+            errorMessage: t('resources.resources.list.error.delete', 'Failed to delete resource.'),
+          })
+        )),
+        { operation: 'deleteResource', id: row.id, updatedAt: row.updatedAt ?? null },
+        row.id,
+      )
       flash(t('resources.resources.list.flash.deleted', 'Resource deleted.'), 'success')
       setPage(1)
       router.refresh()
@@ -364,7 +398,7 @@ export default function ResourcesResourcesPage() {
       const message = error instanceof Error ? error.message : t('resources.resources.list.error.delete', 'Failed to delete resource.')
       flash(message, 'error')
     }
-  }, [confirm, router, t])
+  }, [confirm, router, runResourceMutation, t])
 
   const columns = React.useMemo<ColumnDef<ResourceTableRow>[]>(() => [
     {

--- a/packages/core/src/modules/resources/components/detail/activitiesAdapter.ts
+++ b/packages/core/src/modules/resources/components/detail/activitiesAdapter.ts
@@ -6,7 +6,29 @@ import type { ActivitiesDataAdapter, ActivitySummary } from '@open-mercato/ui/ba
 
 type Translator = (key: string, fallback?: string, params?: Record<string, string | number>) => string
 
-export function createResourceActivitiesAdapter(translator: Translator): ActivitiesDataAdapter {
+export type ResourceActivitiesGuardedMutation = <T>(
+  runner: () => Promise<T>,
+  payload?: Record<string, unknown>,
+) => Promise<T>
+
+export type CreateResourceActivitiesAdapterOptions = {
+  runMutation?: ResourceActivitiesGuardedMutation
+}
+
+export function createResourceActivitiesAdapter(
+  translator: Translator,
+  options: CreateResourceActivitiesAdapterOptions = {},
+): ActivitiesDataAdapter {
+  const runWrite = async <T,>(
+    runner: () => Promise<T>,
+    payload: Record<string, unknown>,
+  ): Promise<T> => {
+    if (options.runMutation) {
+      return options.runMutation(runner, payload)
+    }
+    return runner()
+  }
+
   return {
     list: async ({ entityId }) => {
       const params = new URLSearchParams({
@@ -23,19 +45,23 @@ export function createResourceActivitiesAdapter(translator: Translator): Activit
       return Array.isArray(payload?.items) ? (payload.items as ActivitySummary[]) : []
     },
     create: async ({ entityId, activityType, subject, body, occurredAt, customFields }) => {
-      await createCrud('resources/activities', {
+      const payload = {
         entityId,
         activityType,
         subject: subject ?? undefined,
         body: body ?? undefined,
         occurredAt: occurredAt ?? undefined,
         ...(customFields ? { customFields } : {}),
-      }, {
-        errorMessage: translator('resources.resources.detail.activities.error', 'Failed to save activity'),
-      })
+      }
+      await runWrite(
+        () => createCrud('resources/activities', payload, {
+          errorMessage: translator('resources.resources.detail.activities.error', 'Failed to save activity'),
+        }),
+        { operation: 'createActivity', entityId, activityType },
+      )
     },
     update: async ({ id, patch }) => {
-      await updateCrud('resources/activities', {
+      const payload = {
         id,
         entityId: patch.entityId,
         activityType: patch.activityType,
@@ -43,15 +69,22 @@ export function createResourceActivitiesAdapter(translator: Translator): Activit
         body: patch.body ?? undefined,
         occurredAt: patch.occurredAt ?? undefined,
         ...(patch.customFields ? { customFields: patch.customFields } : {}),
-      }, {
-        errorMessage: translator('resources.resources.detail.activities.error', 'Failed to save activity'),
-      })
+      }
+      await runWrite(
+        () => updateCrud('resources/activities', payload, {
+          errorMessage: translator('resources.resources.detail.activities.error', 'Failed to save activity'),
+        }),
+        { operation: 'updateActivity', id },
+      )
     },
     delete: async ({ id }) => {
-      await deleteCrud('resources/activities', {
-        id,
-        errorMessage: translator('resources.resources.detail.activities.deleteError', 'Failed to delete activity.'),
-      })
+      await runWrite(
+        () => deleteCrud('resources/activities', {
+          id,
+          errorMessage: translator('resources.resources.detail.activities.deleteError', 'Failed to delete activity.'),
+        }),
+        { operation: 'deleteActivity', id },
+      )
     },
   }
 }

--- a/packages/core/src/modules/resources/components/detail/notesAdapter.ts
+++ b/packages/core/src/modules/resources/components/detail/notesAdapter.ts
@@ -5,7 +5,29 @@ import { mapCommentSummary, type NotesDataAdapter } from '@open-mercato/ui/backe
 
 type Translator = (key: string, fallback?: string, params?: Record<string, string | number>) => string
 
-export function createResourceNotesAdapter(translator: Translator): NotesDataAdapter {
+export type ResourceNotesGuardedMutation = <T>(
+  runner: () => Promise<T>,
+  payload?: Record<string, unknown>,
+) => Promise<T>
+
+export type CreateResourceNotesAdapterOptions = {
+  runMutation?: ResourceNotesGuardedMutation
+}
+
+export function createResourceNotesAdapter(
+  translator: Translator,
+  options: CreateResourceNotesAdapterOptions = {},
+): NotesDataAdapter {
+  const runWrite = async <T,>(
+    runner: () => Promise<T>,
+    payload: Record<string, unknown>,
+  ): Promise<T> => {
+    if (options.runMutation) {
+      return options.runMutation(runner, payload)
+    }
+    return runner()
+  }
+
   return {
     list: async ({ entityId }) => {
       const params = new URLSearchParams()
@@ -19,19 +41,23 @@ export function createResourceNotesAdapter(translator: Translator): NotesDataAda
       return items.map(mapCommentSummary)
     },
     create: async ({ entityId, body, appearanceIcon, appearanceColor }) => {
-      const response = await apiCallOrThrow<Record<string, unknown>>(
-        '/api/resources/comments',
-        {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({
-            entityId,
-            body,
-            appearanceIcon: appearanceIcon ?? undefined,
-            appearanceColor: appearanceColor ?? undefined,
-          }),
-        },
-        { errorMessage: translator('resources.resources.detail.notes.error', 'Failed to save note.') },
+      const requestBody = {
+        entityId,
+        body,
+        appearanceIcon: appearanceIcon ?? undefined,
+        appearanceColor: appearanceColor ?? undefined,
+      }
+      const response = await runWrite(
+        () => apiCallOrThrow<Record<string, unknown>>(
+          '/api/resources/comments',
+          {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(requestBody),
+          },
+          { errorMessage: translator('resources.resources.detail.notes.error', 'Failed to save note.') },
+        ),
+        { operation: 'createNote', entityId },
       )
       return response.result ?? {}
     },
@@ -40,24 +66,30 @@ export function createResourceNotesAdapter(translator: Translator): NotesDataAda
       if (patch.body !== undefined) payload.body = patch.body
       if (patch.appearanceIcon !== undefined) payload.appearanceIcon = patch.appearanceIcon
       if (patch.appearanceColor !== undefined) payload.appearanceColor = patch.appearanceColor
-      await apiCallOrThrow(
-        '/api/resources/comments',
-        {
-          method: 'PUT',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify(payload),
-        },
-        { errorMessage: translator('resources.resources.detail.notes.updateError', 'Failed to update note.') },
+      await runWrite(
+        () => apiCallOrThrow(
+          '/api/resources/comments',
+          {
+            method: 'PUT',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(payload),
+          },
+          { errorMessage: translator('resources.resources.detail.notes.updateError', 'Failed to update note.') },
+        ),
+        { operation: 'updateNote', id },
       )
     },
     delete: async ({ id }) => {
-      await apiCallOrThrow(
-        `/api/resources/comments?id=${encodeURIComponent(id)}`,
-        {
-          method: 'DELETE',
-          headers: { 'content-type': 'application/json' },
-        },
-        { errorMessage: translator('resources.resources.detail.notes.deleteError', 'Failed to delete note') },
+      await runWrite(
+        () => apiCallOrThrow(
+          `/api/resources/comments?id=${encodeURIComponent(id)}`,
+          {
+            method: 'DELETE',
+            headers: { 'content-type': 'application/json' },
+          },
+          { errorMessage: translator('resources.resources.detail.notes.deleteError', 'Failed to delete note') },
+        ),
+        { operation: 'deleteNote', id },
       )
     },
   }


### PR DESCRIPTION
## Summary

Fix resources-module raw UI mutations that bypassed the guarded mutation path.

## Changes

- Wrapped resource list delete and resource type list delete in guarded mutation runners.
- Wrapped resource detail tag writes, detail delete, and availability ruleset updates in the guarded mutation path.
- Added optional guarded mutation injection to resource notes and activities adapters while preserving existing call signatures.
- Added regression coverage for every resources raw mutating path listed in #3288.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- `yarn workspace @open-mercato/core test src/modules/resources/backend/resources/__tests__/guarded-mutations.test.tsx --runInBand`
- `yarn build:packages`
- `yarn generate`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- `yarn i18n:check-sync`
- `git diff --staged --check`

Known unrelated blockers:
- `yarn lint` fails before this diff is linted due the existing ESLint/plugin incompatibility in `apps/mercato/next.config.ts`.
- `yarn i18n:check-usage` reports pre-existing missing/unused keys outside touched resources files.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3288
