### PR TITLE
fix: make resource-type counts opt-in to avoid full resources scan (#3290)

### DIFF
--- a/packages/core/src/modules/resources/__integration__/TC-RESO-003.spec.ts
+++ b/packages/core/src/modules/resources/__integration__/TC-RESO-003.spec.ts
@@ -58,14 +58,14 @@ test.describe('TC-RESO-003: Resource Types CRUD + referential delete guard', () 
       await expect
         .poll(
           async () => {
-            const items = await listResourceTypes(request, token, `?search=${encodeURIComponent(typeName)}&pageSize=50`);
+            const items = await listResourceTypes(request, token, `?search=${encodeURIComponent(typeName)}&pageSize=50&withResourceCounts=true`);
             return items.some((item) => item.id === typeId);
           },
           { timeout: 8000, message: 'created resource type should appear in search results' },
         )
         .toBe(true);
 
-      const created = (await listResourceTypes(request, token, `?search=${encodeURIComponent(typeName)}&pageSize=50`)).find(
+      const created = (await listResourceTypes(request, token, `?search=${encodeURIComponent(typeName)}&pageSize=50&withResourceCounts=true`)).find(
         (item) => item.id === typeId,
       );
       expect(created, 'created type present in search').toBeTruthy();
@@ -122,7 +122,7 @@ test.describe('TC-RESO-003: Resource Types CRUD + referential delete guard', () 
       await expect
         .poll(
           async () => {
-            const items = await listResourceTypes(request, token, `?ids=${encodeURIComponent(typeId!)}`);
+            const items = await listResourceTypes(request, token, `?ids=${encodeURIComponent(typeId!)}&withResourceCounts=true`);
             return items[0]?.resourceCount ?? null;
           },
           { timeout: 8000, message: 'type resourceCount should reflect the linked resource' },

--- a/packages/core/src/modules/resources/api/__tests__/resourceTypeCounts.test.ts
+++ b/packages/core/src/modules/resources/api/__tests__/resourceTypeCounts.test.ts
@@ -1,0 +1,76 @@
+/** @jest-environment node */
+
+import { attachResourceTypeCounts } from '../resourceTypeCounts'
+
+type ChainableBuilder = {
+  selectFrom: jest.Mock
+  select: jest.Mock
+  where: jest.Mock
+  groupBy: jest.Mock
+  execute: jest.Mock
+}
+
+function buildKysely(rows: Array<{ resource_type_id: string | null; count: string | number }>): ChainableBuilder {
+  const builder = {} as ChainableBuilder
+  const chain = () => builder
+  builder.selectFrom = jest.fn(chain)
+  builder.select = jest.fn(chain)
+  builder.where = jest.fn(chain)
+  builder.groupBy = jest.fn(chain)
+  builder.execute = jest.fn().mockResolvedValue(rows)
+  return builder
+}
+
+function buildCtx(builder: ChainableBuilder, withResourceCounts: unknown) {
+  const getKysely = jest.fn(() => builder)
+  const em = { getKysely }
+  const container = { resolve: jest.fn((name: string) => (name === 'em' ? em : {})) }
+  const ctx = {
+    container: container as never,
+    auth: { tenantId: 'tenant-1' } as never,
+    organizationScope: null,
+    organizationIds: ['org-1'],
+    selectedOrganizationId: 'org-1',
+    query: { withResourceCounts },
+  }
+  return { ctx, getKysely }
+}
+
+describe('attachResourceTypeCounts', () => {
+  test('does not scan resources when counts are not requested', async () => {
+    const builder = buildKysely([])
+    const { ctx, getKysely } = buildCtx(builder, undefined)
+    const items: Array<Record<string, unknown>> = [{ id: 'type-a' }, { id: 'type-b' }]
+
+    await attachResourceTypeCounts({ items }, ctx)
+
+    expect(getKysely).not.toHaveBeenCalled()
+    expect(builder.selectFrom).not.toHaveBeenCalled()
+    expect('resourceCount' in items[0]).toBe(false)
+    expect('resourceCount' in items[1]).toBe(false)
+  })
+
+  test('attaches accurate scoped counts with zero-fill when requested', async () => {
+    const builder = buildKysely([{ resource_type_id: 'type-a', count: '3' }])
+    const { ctx, getKysely } = buildCtx(builder, 'true')
+    const items: Array<Record<string, unknown>> = [{ id: 'type-a' }, { id: 'type-b' }]
+
+    await attachResourceTypeCounts({ items }, ctx)
+
+    expect(getKysely).toHaveBeenCalledTimes(1)
+    expect(builder.selectFrom).toHaveBeenCalledWith('resources_resources')
+    expect(builder.groupBy).toHaveBeenCalledWith('resource_type_id')
+    expect(builder.execute).toHaveBeenCalledTimes(1)
+    expect(items[0].resourceCount).toBe(3)
+    expect(items[1].resourceCount).toBe(0)
+  })
+
+  test('skips the query entirely when there are no items even if requested', async () => {
+    const builder = buildKysely([])
+    const { ctx, getKysely } = buildCtx(builder, 'true')
+
+    await attachResourceTypeCounts({ items: [] }, ctx)
+
+    expect(getKysely).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/resources/api/resource-types.ts
+++ b/packages/core/src/modules/resources/api/resource-types.ts
@@ -3,11 +3,10 @@ import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveCrudRecordId, parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
-import type { EntityManager } from '@mikro-orm/postgresql'
-import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-import { ResourcesResource, ResourcesResourceType } from '../data/entities'
+import { ResourcesResourceType } from '../data/entities'
 import { resourcesResourceTypeCreateSchema, resourcesResourceTypeUpdateSchema } from '../data/validators'
 import { sanitizeSearchTerm } from './helpers'
+import { attachResourceTypeCounts } from './resourceTypeCounts'
 import { E } from '#generated/entities.ids.generated'
 import { createResourcesCrudOpenApi, createPagedListResponseSchema, defaultOkResponseSchema } from './openapi'
 
@@ -47,6 +46,7 @@ const listSchema = z
     ids: z.string().optional(),
     sortField: z.string().optional(),
     sortDir: z.enum(['asc', 'desc']).optional(),
+    withResourceCounts: z.string().optional(),
   })
   .passthrough()
 
@@ -131,47 +131,7 @@ const crud = makeCrudRoute({
     },
   },
   hooks: {
-    afterList: async (payload, ctx) => {
-      const items: Array<Record<string, unknown>> = Array.isArray(payload?.items)
-        ? (payload.items as Array<Record<string, unknown>>)
-        : []
-      if (!items.length) return
-      const typeIds = items
-        .map((item) => (typeof item.id === 'string' ? item.id : null))
-        .filter((id): id is string => typeof id === 'string' && id.length > 0)
-      if (!typeIds.length) return
-      const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const tenantId = ctx.organizationScope?.tenantId ?? ctx.auth?.tenantId ?? null
-      const orgIds = ctx.organizationIds ?? ctx.organizationScope?.filterIds ?? null
-      const orgFilter =
-        Array.isArray(orgIds) && orgIds.length > 0
-          ? { $in: orgIds }
-          : ctx.selectedOrganizationId ?? ctx.organizationScope?.selectedId ?? null
-      const scope = { tenantId, organizationId: ctx.selectedOrganizationId ?? ctx.organizationScope?.selectedId ?? null }
-      const resources = await findWithDecryption(
-        em,
-        ResourcesResource,
-        {
-          resourceTypeId: { $in: typeIds },
-          deletedAt: null,
-          ...(tenantId ? { tenantId } : {}),
-          ...(orgFilter ? { organizationId: orgFilter } : {}),
-        },
-        { fields: ['id', 'resourceTypeId'] },
-        scope,
-      )
-      const countMap = new Map<string, number>()
-      resources.forEach((resource) => {
-        const typeId = resource.resourceTypeId ?? null
-        if (!typeId) return
-        countMap.set(typeId, (countMap.get(typeId) ?? 0) + 1)
-      })
-      items.forEach((item) => {
-        const id = typeof item.id === 'string' ? item.id : null
-        if (!id) return
-        item.resourceCount = countMap.get(id) ?? 0
-      })
-    },
+    afterList: (payload, ctx) => attachResourceTypeCounts(payload, ctx),
   },
 })
 

--- a/packages/core/src/modules/resources/api/resourceTypeCounts.ts
+++ b/packages/core/src/modules/resources/api/resourceTypeCounts.ts
@@ -1,0 +1,74 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { parseBooleanFromUnknown } from '@open-mercato/shared/lib/boolean'
+import type { CrudCtx } from '@open-mercato/shared/lib/crud/factory'
+
+type ResourceCountDatabase = {
+  resources_resources: {
+    resource_type_id: string | null
+    deleted_at: Date | null
+    tenant_id: string | null
+    organization_id: string | null
+  }
+}
+
+type KyselyCapableEntityManager = { getKysely: () => Kysely<ResourceCountDatabase> }
+
+type ResourceTypeCountContext = Pick<
+  CrudCtx,
+  'container' | 'auth' | 'organizationScope' | 'organizationIds' | 'selectedOrganizationId'
+> & { query?: { withResourceCounts?: unknown } }
+
+type ResourceTypeListPayload = { items?: unknown } | null | undefined
+
+type ResourceCountRow = { resource_type_id: string | null; count: string | number }
+
+export async function attachResourceTypeCounts(
+  payload: ResourceTypeListPayload,
+  ctx: ResourceTypeCountContext,
+): Promise<void> {
+  // Resource counts are opt-in: only callers that render the count (the
+  // resource-types admin table and its delete gate) pass `withResourceCounts`.
+  // Select/filter callers (resource dropdowns, group labels) skip the scan
+  // entirely so ordinary type lookups no longer pay an O(resources) cost.
+  if (!parseBooleanFromUnknown(ctx.query?.withResourceCounts)) return
+
+  const items = Array.isArray(payload?.items)
+    ? (payload!.items as Array<Record<string, unknown>>)
+    : []
+  if (!items.length) return
+
+  const typeIds = items
+    .map((item) => (typeof item.id === 'string' ? item.id : null))
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+  if (!typeIds.length) return
+
+  const tenantId = ctx.organizationScope?.tenantId ?? ctx.auth?.tenantId ?? null
+  const orgIds = ctx.organizationIds ?? ctx.organizationScope?.filterIds ?? null
+  const singleOrgId = ctx.selectedOrganizationId ?? ctx.organizationScope?.selectedId ?? null
+
+  const db = (ctx.container.resolve('em') as unknown as KyselyCapableEntityManager).getKysely()
+  let query = db
+    .selectFrom('resources_resources')
+    .select(['resource_type_id', sql<string>`count(*)`.as('count')])
+    .where('resource_type_id', 'in', typeIds)
+    .where('deleted_at', 'is', null)
+  if (tenantId) query = query.where('tenant_id', '=', tenantId)
+  if (Array.isArray(orgIds) && orgIds.length > 0) {
+    query = query.where('organization_id', 'in', orgIds)
+  } else if (singleOrgId) {
+    query = query.where('organization_id', '=', singleOrgId)
+  }
+  const rows = (await query.groupBy('resource_type_id').execute()) as ResourceCountRow[]
+
+  const countMap = new Map<string, number>()
+  for (const row of rows) {
+    if (typeof row.resource_type_id !== 'string') continue
+    const count = typeof row.count === 'string' ? Number.parseInt(row.count, 10) : Number(row.count)
+    countMap.set(row.resource_type_id, Number.isFinite(count) ? count : 0)
+  }
+  for (const item of items) {
+    if (typeof item.id !== 'string') continue
+    item.resourceCount = countMap.get(item.id) ?? 0
+  }
+}

--- a/packages/core/src/modules/resources/backend/resources/resource-types/[id]/edit/page.tsx
+++ b/packages/core/src/modules/resources/backend/resources/resource-types/[id]/edit/page.tsx
@@ -34,7 +34,7 @@ export default function ResourcesResourceTypeEditPage({ params }: { params?: { i
       setIsNotFound(false)
       try {
         const payload = await readApiResultOrThrow<ResourceTypesResponse>(
-          `/api/resources/resource-types?ids=${encodeURIComponent(resourceTypeId)}&page=1&pageSize=1`,
+          `/api/resources/resource-types?ids=${encodeURIComponent(resourceTypeId)}&page=1&pageSize=1&withResourceCounts=true`,
           undefined,
           { errorMessage: t('resources.resourceTypes.errors.load', 'Failed to load resource types.') },
         )

--- a/packages/core/src/modules/resources/backend/resources/resource-types/page.tsx
+++ b/packages/core/src/modules/resources/backend/resources/resource-types/page.tsx
@@ -178,6 +178,7 @@ export default function ResourcesResourceTypesPage() {
       const params = new URLSearchParams({
         page: String(page),
         pageSize: String(PAGE_SIZE),
+        withResourceCounts: 'true',
       })
       const sort = sorting[0]
       if (sort?.id) {


### PR DESCRIPTION
## Summary

The `/api/resources/resource-types` list endpoint enriched every response with `resourceCount` by loading all matching resources via `findWithDecryption` and counting them in JS — so ordinary resource-type dropdown/filter loads paid an O(number of resources) scan they never needed. This makes resource counts **opt-in** (`?withResourceCounts=true`) and, when requested, computes them with a single scoped `COUNT(*) … GROUP BY resource_type_id` aggregate instead of loading rows. Select/filter callers now stay on a zero-scan path; the resource-types admin table and its delete-gating edit page request counts explicitly and still get accurate, tenant/org-scoped values.

## Changes

- New `api/resourceTypeCounts.ts`: `attachResourceTypeCounts` — opt-in gate on `ctx.query.withResourceCounts`; scoped kysely grouped `COUNT(*)` by `resource_type_id` with zero-fill (no full resource scan, no JS counting, no needless decryption).
- `api/resource-types.ts`: added `withResourceCounts` to the list schema; replaced the unconditional inline `afterList` scan with the helper; removed the now-unused `findWithDecryption` / `ResourcesResource` / `EntityManager` imports.
- `backend/.../resource-types/page.tsx` and `backend/.../resource-types/[id]/edit/page.tsx`: pass `withResourceCounts=true` (the only callers that render the count / gate delete).
- `__integration__/TC-RESO-003.spec.ts`: count-asserting reads now request counts (assertions unchanged — still `0`, then `1`).
- New unit test `api/__tests__/resourceTypeCounts.test.ts`: proves no resources query when counts aren't requested, and accurate zero-filled scoped counts when they are.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — focused single-module performance fix.

## Testing

- `yarn workspace @open-mercato/core test resourceTypeCounts` — repro test red (no-scan-when-not-requested) → green after the opt-in gate.
- `yarn generate` — registries regenerated; no phantom route for the new helper file; `resource-types` route unchanged.
- `yarn turbo run typecheck --filter=@open-mercato/core` — pass.
- `yarn workspace @open-mercato/core build` — pass.
- `yarn workspace @open-mercato/core test` — 742 suites / 6069 tests pass.
- `yarn i18n:check-sync` — all locales in sync.
- `yarn build:app` — compiled successfully.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- no doc/locale changes required; `yarn generate` re-run with no committed diff -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- updated module integration test packages/core/src/modules/resources/__integration__/TC-RESO-003.spec.ts to the opt-in contract -->
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — minor perf fix -->
- [x] Priority set: this PR carries exactly one `priority-*` label. <!-- priority-medium, inherited from the issue -->
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). <!-- risk-medium: single-module API change, additive opt-in param, behavior-preserving, covered by unit + integration tests -->
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. <!-- needs-qa: touches the resource-types admin table + delete gating, though behavior is preserved and integration-covered -->

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI/markup changes (only added a query param to two existing fetches)
- [x] No arbitrary text sizes — N/A, no UI/markup changes
- [x] Empty state handled for list/data pages — N/A, no UI/markup changes
- [x] Loading state handled for async pages — N/A, no UI/markup changes
- [x] `aria-label` on all icon-only buttons — N/A, no UI/markup changes
- [x] Uses existing DS components — N/A, no UI/markup changes

## Linked issues

Fixes #3290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
