### PR TITLE
fix(sales): route non-CrudForm sales config writes through useGuardedMutation (#3293)

### DIFF
--- a/packages/core/src/modules/sales/backend/sales/channels/offers/page.tsx
+++ b/packages/core/src/modules/sales/backend/sales/channels/offers/page.tsx
@@ -14,6 +14,7 @@ import { readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { deleteCrud } from '@open-mercato/ui/backend/utils/crud'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { mapOfferRow, renderOfferPriceSummary, type OfferRow } from '@open-mercato/core/modules/sales/components/channels/offerTableUtils'
@@ -26,9 +27,27 @@ type OffersResponse = {
 
 const PAGE_SIZE = 25
 
+const SAVE_CONTEXT_ID = 'sales-channel-offers-list'
+
 export default function SalesChannelOffersListPage() {
   const t = useT()
   const router = useRouter()
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: SAVE_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const mutationContext = React.useMemo(
+    () => ({
+      formId: SAVE_CONTEXT_ID,
+      resourceKind: 'sales.channels.offers',
+      retryLastMutation,
+    }),
+    [retryLastMutation],
+  )
   const scopeVersion = useOrganizationScopeVersion()
   const channelOptionsRef = React.useRef<Map<string, FilterOption>>(new Map())
   const [rows, setRows] = React.useState<OfferRow[]>([])
@@ -282,19 +301,24 @@ export default function SalesChannelOffersListPage() {
 
   const handleDelete = React.useCallback(async (row: OfferRow) => {
     try {
-      await withScopedApiRequestHeaders(
-        buildOptimisticLockHeader(row.updatedAt),
-        () => deleteCrud('catalog/offers', row.id, {
-          errorMessage: t('sales.channels.offers.errors.delete', 'Failed to delete offer.'),
-        }),
-      )
+      await runMutation({
+        operation: () =>
+          withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(row.updatedAt),
+            () => deleteCrud('catalog/offers', row.id, {
+              errorMessage: t('sales.channels.offers.errors.delete', 'Failed to delete offer.'),
+            }),
+          ),
+        context: mutationContext,
+        mutationPayload: { action: 'delete', id: row.id },
+      })
       flash(t('sales.channels.offers.messages.deleted', 'Offer deleted.'), 'success')
       handleRefresh()
     } catch (err) {
       if (surfaceRecordConflict(err, t)) { handleRefresh(); return }
       console.error('sales.channels.offers.delete', err)
     }
-  }, [handleRefresh, t])
+  }, [handleRefresh, mutationContext, runMutation, t])
 
   const tableTitle = (
     <div className="flex flex-col gap-1">

--- a/packages/core/src/modules/sales/backend/sales/channels/page.tsx
+++ b/packages/core/src/modules/sales/backend/sales/channels/page.tsx
@@ -13,6 +13,7 @@ import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { buildOptimisticLockHeader, extractOptimisticLockConflict } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 
@@ -34,9 +35,27 @@ type ChannelsResponse = {
 
 const PAGE_SIZE = 25
 
+const SAVE_CONTEXT_ID = 'sales-channels-list'
+
 export default function SalesChannelsPage() {
   const t = useT()
   const router = useRouter()
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: SAVE_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const mutationContext = React.useMemo(
+    () => ({
+      formId: SAVE_CONTEXT_ID,
+      resourceKind: 'sales.channels',
+      retryLastMutation,
+    }),
+    [retryLastMutation],
+  )
   const scopeVersion = useOrganizationScopeVersion()
   const [rows, setRows] = React.useState<ChannelRow[]>([])
   const [page, setPage] = React.useState(1)
@@ -139,12 +158,17 @@ export default function SalesChannelsPage() {
 
   const handleDelete = React.useCallback(async (row: ChannelRow) => {
     try {
-      await withScopedApiRequestHeaders(
-        buildOptimisticLockHeader(row.updatedAt),
-        () => deleteCrud('sales/channels', row.id, {
-          errorMessage: t('sales.channels.table.errors.delete', 'Failed to delete channel.'),
-        }),
-      )
+      await runMutation({
+        operation: () =>
+          withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(row.updatedAt),
+            () => deleteCrud('sales/channels', row.id, {
+              errorMessage: t('sales.channels.table.errors.delete', 'Failed to delete channel.'),
+            }),
+          ),
+        context: mutationContext,
+        mutationPayload: { action: 'delete', id: row.id },
+      })
       flash(t('sales.channels.table.messages.deleted', 'Channel deleted.'), 'success')
       handleRefresh()
     } catch (err) {
@@ -161,7 +185,7 @@ export default function SalesChannelsPage() {
       }
       console.error('sales.channels.delete', err)
     }
-  }, [handleRefresh, t])
+  }, [handleRefresh, mutationContext, runMutation, t])
 
   return (
     <Page>

--- a/packages/core/src/modules/sales/components/AdjustmentKindSettings.tsx
+++ b/packages/core/src/modules/sales/components/AdjustmentKindSettings.tsx
@@ -18,6 +18,7 @@ import { Label } from '@open-mercato/ui/primitives/label'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { apiCall, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 import { AppearanceSelector } from '@open-mercato/core/modules/dictionaries/components/AppearanceSelector'
@@ -75,10 +76,28 @@ const normalizeEntry = (raw: any): AdjustmentKind | null => {
   }
 }
 
+const SAVE_CONTEXT_ID = 'sales-adjustment-kind-settings'
+
 export function AdjustmentKindSettings() {
   const t = useT()
   const scopeVersion = useOrganizationScopeVersion()
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: SAVE_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const mutationContext = React.useMemo(
+    () => ({
+      formId: SAVE_CONTEXT_ID,
+      resourceKind: 'sales.adjustmentKinds',
+      retryLastMutation,
+    }),
+    [retryLastMutation],
+  )
   const [items, setItems] = React.useState<AdjustmentKind[]>([])
   const [search, setSearch] = React.useState('')
   const [loading, setLoading] = React.useState(false)
@@ -222,16 +241,26 @@ export function AdjustmentKindSettings() {
 
       const lockHeader =
         dialog.mode === 'edit' ? buildOptimisticLockHeader(dialog.entry.updatedAt) : {}
-      const call = await withScopedApiRequestHeaders(lockHeader, () =>
-        apiCall('/api/sales/adjustment-kinds', {
-          method,
-          headers: { 'content-type': 'application/json' },
-          body,
-        })
-      )
-      if (!call.ok) {
-        await raiseCrudError(call.response, labels.saveError)
-      }
+      await runMutation({
+        operation: async () => {
+          const call = await withScopedApiRequestHeaders(lockHeader, () =>
+            apiCall('/api/sales/adjustment-kinds', {
+              method,
+              headers: { 'content-type': 'application/json' },
+              body,
+            })
+          )
+          if (!call.ok) {
+            await raiseCrudError(call.response, labels.saveError)
+          }
+          return call
+        },
+        context: mutationContext,
+        mutationPayload:
+          dialog.mode === 'create'
+            ? { action: 'create', ...payload }
+            : { action: 'update', id: dialog.entry.id, ...payload },
+      })
       flash(dialog.mode === 'create' ? labels.created : labels.updated, 'success')
       closeDialog()
       await loadItems()
@@ -242,7 +271,7 @@ export function AdjustmentKindSettings() {
     } finally {
       setSubmitting(false)
     }
-  }, [closeDialog, dialog, form.color, form.icon, form.label, form.value, labels, loadItems])
+  }, [closeDialog, dialog, form.color, form.icon, form.label, form.value, labels, loadItems, mutationContext, runMutation])
 
   const handleDelete = React.useCallback(
     async (entry: AdjustmentKind) => {
@@ -253,18 +282,25 @@ export function AdjustmentKindSettings() {
       })
       if (!confirmed) return
       try {
-        const call = await withScopedApiRequestHeaders(
-          buildOptimisticLockHeader(entry.updatedAt),
-          () =>
-            apiCall('/api/sales/adjustment-kinds', {
-              method: 'DELETE',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ id: entry.id }),
-            })
-        )
-        if (!call.ok) {
-          await raiseCrudError(call.response, labels.deleteError)
-        }
+        await runMutation({
+          operation: async () => {
+            const call = await withScopedApiRequestHeaders(
+              buildOptimisticLockHeader(entry.updatedAt),
+              () =>
+                apiCall('/api/sales/adjustment-kinds', {
+                  method: 'DELETE',
+                  headers: { 'content-type': 'application/json' },
+                  body: JSON.stringify({ id: entry.id }),
+                })
+            )
+            if (!call.ok) {
+              await raiseCrudError(call.response, labels.deleteError)
+            }
+            return call
+          },
+          context: mutationContext,
+          mutationPayload: { action: 'delete', id: entry.id },
+        })
         flash(labels.deleted, 'success')
         await loadItems()
       } catch (err) {
@@ -273,7 +309,7 @@ export function AdjustmentKindSettings() {
         flash(message, 'error')
       }
     },
-    [confirm, labels, loadItems]
+    [confirm, labels, loadItems, mutationContext, runMutation]
   )
 
   const formKeyHandler = React.useCallback(

--- a/packages/core/src/modules/sales/components/DocumentNumberSettings.tsx
+++ b/packages/core/src/modules/sales/components/DocumentNumberSettings.tsx
@@ -6,6 +6,7 @@ import { Button } from '@open-mercato/ui/primitives/button'
 import { Input } from '@open-mercato/ui/primitives/input'
 import { Badge } from '@open-mercato/ui/primitives/badge'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -56,6 +57,8 @@ const normalizeState = (payload?: Partial<SettingsResponse> | null): FormState =
       : '1',
 })
 
+const SAVE_CONTEXT_ID = 'sales-document-number-settings'
+
 export function DocumentNumberSettings() {
   const t = useT()
   const scopeVersion = useOrganizationScopeVersion()
@@ -63,6 +66,15 @@ export function DocumentNumberSettings() {
   const [loading, setLoading] = React.useState(false)
   const [saving, setSaving] = React.useState(false)
   const [tokens, setTokens] = React.useState(DOCUMENT_NUMBER_TOKENS)
+
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: SAVE_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
 
   const translations = React.useMemo(() => ({
     title: t('sales.config.numbering.title', 'Document numbers'),
@@ -128,16 +140,26 @@ export function DocumentNumberSettings() {
         orderNextNumber: Number.parseInt(formState.orderNextNumber, 10) || undefined,
         quoteNextNumber: Number.parseInt(formState.quoteNextNumber, 10) || undefined,
       }
-      // optimistic-lock-exempt: single-row tenant numbering settings blob — no per-record version / concurrent record edit
-      const call = await apiCall<SettingsResponse>('/api/sales/settings/document-numbers', {
-        method: 'PUT',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(payload),
+      const call = await runMutation({
+        // optimistic-lock-exempt: single-row tenant numbering settings blob — no per-record version / concurrent record edit
+        operation: async () => {
+          const response = await apiCall<SettingsResponse>('/api/sales/settings/document-numbers', {
+            method: 'PUT',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(payload),
+          })
+          if (!response.ok) {
+            throw new Error(translations.errors.save)
+          }
+          return response
+        },
+        context: {
+          formId: SAVE_CONTEXT_ID,
+          resourceKind: 'sales.settings',
+          retryLastMutation,
+        },
+        mutationPayload: payload,
       })
-      if (!call.ok) {
-        flash(translations.errors.save, 'error')
-        return
-      }
       setFormState(normalizeState(call.result))
       setTokens(Array.isArray(call.result?.tokens) && call.result.tokens.length ? call.result.tokens : DOCUMENT_NUMBER_TOKENS)
       flash(translations.messages.saved, 'success')
@@ -147,7 +169,7 @@ export function DocumentNumberSettings() {
     } finally {
       setSaving(false)
     }
-  }, [formState.orderNextNumber, formState.orderNumberFormat, formState.quoteNextNumber, formState.quoteNumberFormat, translations.errors.save, translations.messages.saved])
+  }, [formState.orderNextNumber, formState.orderNumberFormat, formState.quoteNextNumber, formState.quoteNumberFormat, retryLastMutation, runMutation, translations.errors.save, translations.messages.saved])
 
   const handleReset = React.useCallback(() => {
     setFormState(DEFAULT_STATE)

--- a/packages/core/src/modules/sales/components/OrderEditingSettings.tsx
+++ b/packages/core/src/modules/sales/components/OrderEditingSettings.tsx
@@ -6,6 +6,7 @@ import { Button } from '@open-mercato/ui/primitives/button'
 import { Switch } from '@open-mercato/ui/primitives/switch'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 
@@ -35,6 +36,8 @@ const normalizeStatusList = (list: unknown): string[] | null => {
   return Array.from(set)
 }
 
+const SAVE_CONTEXT_ID = 'sales-order-editing-settings'
+
 export function OrderEditingSettings() {
   const t = useT()
   const scopeVersion = useOrganizationScopeVersion()
@@ -43,6 +46,15 @@ export function OrderEditingSettings() {
   const [options, setOptions] = React.useState<OrderStatusOption[]>([])
   const [customerStatuses, setCustomerStatuses] = React.useState<string[] | null>(null)
   const [addressStatuses, setAddressStatuses] = React.useState<string[] | null>(null)
+
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: SAVE_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
 
   const translations = React.useMemo(
     () => ({
@@ -121,16 +133,26 @@ export function OrderEditingSettings() {
         orderCustomerEditableStatuses: customerStatuses,
         orderAddressEditableStatuses: addressStatuses,
       }
-      // optimistic-lock-exempt: single-row tenant order-editing settings blob — no per-record version / concurrent record edit
-      const call = await apiCall<SettingsResponse>('/api/sales/settings/order-editing', {
-        method: 'PUT',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(payload),
+      const call = await runMutation({
+        // optimistic-lock-exempt: single-row tenant order-editing settings blob — no per-record version / concurrent record edit
+        operation: async () => {
+          const response = await apiCall<SettingsResponse>('/api/sales/settings/order-editing', {
+            method: 'PUT',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(payload),
+          })
+          if (!response.ok) {
+            throw new Error(translations.messages.saveError)
+          }
+          return response
+        },
+        context: {
+          formId: SAVE_CONTEXT_ID,
+          resourceKind: 'sales.settings',
+          retryLastMutation,
+        },
+        mutationPayload: payload,
       })
-      if (!call.ok) {
-        flash(translations.messages.saveError, 'error')
-        return
-      }
       setCustomerStatuses(normalizeStatusList(call.result?.orderCustomerEditableStatuses))
       setAddressStatuses(normalizeStatusList(call.result?.orderAddressEditableStatuses))
       setOptions(Array.isArray(call.result?.orderStatuses) ? call.result.orderStatuses : [])
@@ -141,7 +163,7 @@ export function OrderEditingSettings() {
     } finally {
       setSaving(false)
     }
-  }, [addressStatuses, customerStatuses, translations.messages.saveError, translations.messages.saved])
+  }, [addressStatuses, customerStatuses, retryLastMutation, runMutation, translations.messages.saveError, translations.messages.saved])
 
   const renderStatusList = React.useCallback(
     (kind: 'customer' | 'address', values: string[] | null, label: string) => {

--- a/packages/core/src/modules/sales/components/StatusSettings.tsx
+++ b/packages/core/src/modules/sales/components/StatusSettings.tsx
@@ -10,6 +10,7 @@ import {
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { apiCall, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
@@ -43,6 +44,8 @@ const DEFAULT_FORM_VALUES: DictionaryFormValues = {
   icon: null,
 }
 
+const SAVE_CONTEXT_ID = 'sales-status-settings'
+
 export function StatusSettings() {
   const t = useT()
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
@@ -50,6 +53,23 @@ export function StatusSettings() {
     const value = t(key)
     return value === key ? fallback : value
   }, [t])
+
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: SAVE_CONTEXT_ID,
+    blockedMessage: translate('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const mutationContext = React.useMemo(
+    () => ({
+      formId: SAVE_CONTEXT_ID,
+      resourceKind: 'sales.statuses',
+      retryLastMutation,
+    }),
+    [retryLastMutation],
+  )
 
   const sections = React.useMemo<SectionDefinition[]>(() => [
     {
@@ -198,18 +218,25 @@ export function StatusSettings() {
     })
     if (!confirmed) return
     try {
-      const call = await withScopedApiRequestHeaders(
-        buildOptimisticLockHeader(entry.updatedAt),
-        () =>
-          apiCall(apiPaths[kind], {
-            method: 'DELETE',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ id: entry.id }),
-          })
-      )
-      if (!call.ok) {
-        await raiseCrudError(call.response, translate('sales.config.statuses.error.delete', 'Failed to delete status.'))
-      }
+      await runMutation({
+        operation: async () => {
+          const call = await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(entry.updatedAt),
+            () =>
+              apiCall(apiPaths[kind], {
+                method: 'DELETE',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ id: entry.id }),
+              })
+          )
+          if (!call.ok) {
+            await raiseCrudError(call.response, translate('sales.config.statuses.error.delete', 'Failed to delete status.'))
+          }
+          return call
+        },
+        context: mutationContext,
+        mutationPayload: { action: 'delete', kind, id: entry.id },
+      })
       flash(translate('sales.config.statuses.success.delete', 'Status deleted.'), 'success')
       await loadEntries(kind)
     } catch (err) {
@@ -217,7 +244,7 @@ export function StatusSettings() {
       const message = err instanceof Error ? err.message : translate('sales.config.statuses.error.delete', 'Failed to delete status.')
       flash(message, 'error')
     }
-  }, [apiPaths, confirm, loadEntries, translate])
+  }, [apiPaths, confirm, loadEntries, mutationContext, runMutation, translate])
 
   const submitForm = React.useCallback(async (values: DictionaryFormValues) => {
     if (!dialog) return
@@ -225,14 +252,21 @@ export function StatusSettings() {
     setSubmitting(true)
     try {
       if (dialog.mode === 'create') {
-        const call = await apiCall(path, {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify(values),
+        await runMutation({
+          operation: async () => {
+            const call = await apiCall(path, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(values),
+            })
+            if (!call.ok) {
+              await raiseCrudError(call.response, translate('sales.config.statuses.error.save', 'Failed to save status.'))
+            }
+            return call
+          },
+          context: mutationContext,
+          mutationPayload: { action: 'create', kind: dialog.kind, ...values },
         })
-        if (!call.ok) {
-          await raiseCrudError(call.response, translate('sales.config.statuses.error.save', 'Failed to save status.'))
-        }
         flash(translate('sales.config.statuses.success.save', 'Status saved.'), 'success')
       } else if (dialog.mode === 'edit') {
         const entry = dialog.entry
@@ -243,18 +277,25 @@ export function StatusSettings() {
         if (nextColor !== (entry.color ?? null)) body.color = nextColor
         const nextIcon = values.icon ?? null
         if (nextIcon !== (entry.icon ?? null)) body.icon = nextIcon
-        const call = await withScopedApiRequestHeaders(
-          buildOptimisticLockHeader(entry.updatedAt),
-          () =>
-            apiCall(path, {
-              method: 'PUT',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify(body),
-            })
-        )
-        if (!call.ok) {
-          await raiseCrudError(call.response, translate('sales.config.statuses.error.save', 'Failed to save status.'))
-        }
+        await runMutation({
+          operation: async () => {
+            const call = await withScopedApiRequestHeaders(
+              buildOptimisticLockHeader(entry.updatedAt),
+              () =>
+                apiCall(path, {
+                  method: 'PUT',
+                  headers: { 'content-type': 'application/json' },
+                  body: JSON.stringify(body),
+                })
+            )
+            if (!call.ok) {
+              await raiseCrudError(call.response, translate('sales.config.statuses.error.save', 'Failed to save status.'))
+            }
+            return call
+          },
+          context: mutationContext,
+          mutationPayload: { action: 'update', kind: dialog.kind, ...body },
+        })
         flash(translate('sales.config.statuses.success.save', 'Status saved.'), 'success')
       }
       closeDialog()
@@ -267,7 +308,7 @@ export function StatusSettings() {
     } finally {
       setSubmitting(false)
     }
-  }, [apiPaths, closeDialog, dialog, loadEntries, translate])
+  }, [apiPaths, closeDialog, dialog, loadEntries, mutationContext, runMutation, translate])
 
   const currentValues = React.useMemo<DictionaryFormValues>(() => {
     if (dialog && dialog.mode === 'edit') {

--- a/packages/core/src/modules/sales/components/__tests__/salesConfigGuardedMutation.test.tsx
+++ b/packages/core/src/modules/sales/components/__tests__/salesConfigGuardedMutation.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { DocumentNumberSettings } from '../DocumentNumberSettings'
+import { OrderEditingSettings } from '../OrderEditingSettings'
+
+/**
+ * Regression for #3293: non-CrudForm sales config writes must route through
+ * `useGuardedMutation().runMutation(...)` so the global mutation injection
+ * hooks (onBeforeSave/onAfterSave), scoped headers, retry, and unified 409
+ * conflict surfacing run. `useGuardedMutation` is mocked to a pass-through so
+ * the assertion is purely "the write went through the guarded runner" — before
+ * the fix these components called `apiCall` directly and `runMutation` was
+ * never invoked.
+ */
+
+const apiCallMock = jest.fn()
+const runMutationMock = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+const retryLastMutationMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+  withScopedApiRequestHeaders: (_headers: unknown, fn: () => unknown) => fn(),
+  readApiResultOrThrow: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: (...args: unknown[]) => runMutationMock(...(args as [{ operation: () => Promise<unknown> }])),
+    retryLastMutation: retryLastMutationMock,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 1,
+}))
+
+describe('sales config writes route through useGuardedMutation (#3293)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    runMutationMock.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+    apiCallMock.mockImplementation(async (_path: string, init?: { method?: string }) => {
+      if (!init || !init.method) {
+        return {
+          ok: true,
+          result: {
+            orderNumberFormat: 'ORD-{seq}',
+            quoteNumberFormat: 'QUO-{seq}',
+            nextOrderNumber: 1,
+            nextQuoteNumber: 1,
+            tokens: [],
+            orderStatuses: [],
+            orderCustomerEditableStatuses: null,
+            orderAddressEditableStatuses: null,
+          },
+        }
+      }
+      return { ok: true, result: {} }
+    })
+  })
+
+  it('DocumentNumberSettings: saving routes the PUT through runMutation', async () => {
+    renderWithProviders(<DocumentNumberSettings />)
+    await waitFor(() => expect(apiCallMock).toHaveBeenCalledWith('/api/sales/settings/document-numbers'))
+
+    const saveButton = await screen.findByRole('button', { name: /save settings/i })
+    await waitFor(() => expect(saveButton).toBeEnabled())
+    fireEvent.click(saveButton)
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalledTimes(1))
+    expect(runMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          resourceKind: 'sales.settings',
+          retryLastMutation: expect.any(Function),
+        }),
+        mutationPayload: expect.objectContaining({ orderNumberFormat: expect.any(String) }),
+      }),
+    )
+    expect(apiCallMock).toHaveBeenCalledWith(
+      '/api/sales/settings/document-numbers',
+      expect.objectContaining({ method: 'PUT' }),
+    )
+  })
+
+  it('OrderEditingSettings: saving routes the PUT through runMutation', async () => {
+    renderWithProviders(<OrderEditingSettings />)
+    await waitFor(() => expect(apiCallMock).toHaveBeenCalledWith('/api/sales/settings/order-editing'))
+
+    const saveButton = await screen.findByRole('button', { name: /save settings/i })
+    await waitFor(() => expect(saveButton).toBeEnabled())
+    fireEvent.click(saveButton)
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalledTimes(1))
+    expect(runMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          resourceKind: 'sales.settings',
+          retryLastMutation: expect.any(Function),
+        }),
+      }),
+    )
+    expect(apiCallMock).toHaveBeenCalledWith(
+      '/api/sales/settings/order-editing',
+      expect.objectContaining({ method: 'PUT' }),
+    )
+  })
+})

--- a/packages/core/src/modules/sales/components/channels/SalesChannelOffersPanel.tsx
+++ b/packages/core/src/modules/sales/components/channels/SalesChannelOffersPanel.tsx
@@ -13,6 +13,7 @@ import { readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { mapOfferRow, renderOfferPriceSummary, type OfferRow } from './offerTableUtils'
 
@@ -24,9 +25,27 @@ type OffersResponse = {
 
 const PAGE_SIZE = 25
 
+const SAVE_CONTEXT_ID = 'sales-channel-offers-panel'
+
 export function SalesChannelOffersPanel({ channelId, channelName }: { channelId: string; channelName?: string }) {
   const t = useT()
   const router = useRouter()
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: SAVE_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const mutationContext = React.useMemo(
+    () => ({
+      formId: SAVE_CONTEXT_ID,
+      resourceKind: 'sales.channels.offers',
+      retryLastMutation,
+    }),
+    [retryLastMutation],
+  )
   const [rows, setRows] = React.useState<OfferRow[]>([])
   const [page, setPage] = React.useState(1)
   const [total, setTotal] = React.useState(0)
@@ -125,11 +144,16 @@ export function SalesChannelOffersPanel({ channelId, channelName }: { channelId:
 
   const handleDelete = React.useCallback(async (row: OfferRow) => {
     try {
-      await withScopedApiRequestHeaders(buildOptimisticLockHeader(row.updatedAt), () =>
-        deleteCrud('catalog/offers', row.id, {
-          errorMessage: t('sales.channels.offers.errors.delete', 'Failed to delete offer.'),
-        }),
-      )
+      await runMutation({
+        operation: () =>
+          withScopedApiRequestHeaders(buildOptimisticLockHeader(row.updatedAt), () =>
+            deleteCrud('catalog/offers', row.id, {
+              errorMessage: t('sales.channels.offers.errors.delete', 'Failed to delete offer.'),
+            }),
+          ),
+        context: mutationContext,
+        mutationPayload: { action: 'delete', id: row.id },
+      })
       flash(t('sales.channels.offers.messages.deleted', 'Offer deleted.'), 'success')
       setReloadToken((token) => token + 1)
     } catch (err) {
@@ -137,7 +161,7 @@ export function SalesChannelOffersPanel({ channelId, channelName }: { channelId:
       console.error('sales.channels.offers.delete', err)
       flash(t('sales.channels.offers.errors.delete', 'Failed to delete offer.'), 'error')
     }
-  }, [t])
+  }, [mutationContext, runMutation, t])
 
   const handleSearchChange = React.useCallback((value: string) => {
     setSearch(value)


### PR DESCRIPTION
## Summary

Several sales config/admin/channel UI write handlers performed raw `apiCall`/`deleteCrud` mutations (some with `withScopedApiRequestHeaders` for optimistic-lock headers) instead of going through `useGuardedMutation().runMutation(...)`. As a result the global UMES mutation injection hooks (`onBeforeSave`/`onAfterSave`), unified guarded retry, and the conflict-banner path never ran for those writes. This wraps every non-`CrudForm` mutating write in the enumerated sales components in `runMutation(...)`, keeping optimistic-lock headers inside the guarded callback and passing `retryLastMutation` in the mutation context.

Fixes #3293

## Changes

- `DocumentNumberSettings.tsx` / `OrderEditingSettings.tsx`: wrap the settings-save PUT in `runMutation` (kept the `optimistic-lock-exempt` single-row markers).
- `StatusSettings.tsx`: wrap status create (POST), edit (PUT), and delete (DELETE) — lock headers kept inside the guarded `operation`.
- `AdjustmentKindSettings.tsx`: wrap create/edit (POST/PUT) and delete (DELETE).
- `channels/SalesChannelOffersPanel.tsx`, `backend/sales/channels/page.tsx`, `backend/sales/channels/offers/page.tsx`: wrap the channel/offer row-action `deleteCrud` deletes; preserved existing `surfaceRecordConflict`/`extractOptimisticLockConflict` handling.
- Added behavioral regression test `components/__tests__/salesConfigGuardedMutation.test.tsx` asserting the writes route through the guarded runner.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — follows the established `packages/ui/AGENTS.md` rule ("use `useGuardedMutation` for every write that cannot use `CrudForm`") and the optimistic-locking spec lineage (`.ai/specs/implemented/2026-05-25-oss-optimistic-locking.md`); part of the per-module guarded-mutation remediation campaign (#3195–#3316).

## Testing

- `yarn workspace @open-mercato/core test -- salesConfigGuardedMutation` — new repro (verified red before fix: `runMutation` called 0 times; green after).
- `yarn workspace @open-mercato/core typecheck` — pass.
- `yarn workspace @open-mercato/core test` — 742 suites / 6068 tests pass (incl. existing `salesComponentsRender` rendering the changed components with the real hook, and `optimistic-lock-ui-coverage`).
- `yarn i18n:check-sync` — all locales in sync.
- `yarn build:packages` and `yarn build:app` — pass.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — reused existing i18n keys; no module-discovery files changed.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (N/A — logic-only reroute of existing writes through an existing hook; covered by a behavioral render test + the file-level `optimistic-lock-ui-coverage` guard; no new API/endpoint behavior to integration-test.)
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec change.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — single-module UI-layer change, ships with tests.)
- [x] QA routing set. (`needs-qa` — admin UI write/conflict behavior change.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no new markup/colors (logic-only reroute of write calls).
- [x] No arbitrary text sizes — N/A, no markup changes.
- [x] Empty state handled for list/data pages — unchanged (pre-existing).
- [x] Loading state handled for async pages — unchanged (pre-existing).
- [x] `aria-label` on all icon-only buttons — unchanged (pre-existing).
- [x] Uses existing DS components — N/A, no new components.

## Linked issues

Fixes #3293

🤖 Generated with [Claude Code](https://claude.com/claude-code)
