### PR TITLE
fix(query_index): batch status coverage reads, drop inline refresh on polls (#3285)

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/status-coverage-waterfall.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/status-coverage-waterfall.test.ts
@@ -1,0 +1,170 @@
+const mockGetAuthFromRequest = jest.fn()
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+const mockCreateRequestContainer = jest.fn()
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => mockCreateRequestContainer(...args),
+}))
+
+const mockGetEntityIds = jest.fn()
+jest.mock('@open-mercato/shared/lib/encryption/entityIds', () => ({
+  getEntityIds: (...args: unknown[]) => mockGetEntityIds(...args),
+}))
+
+const mockFlattenSystemEntityIds = jest.fn()
+jest.mock('@open-mercato/shared/lib/entities/system-entities', () => ({
+  flattenSystemEntityIds: (...args: unknown[]) => mockFlattenSystemEntityIds(...args),
+}))
+
+const mockResolveOrganizationScopeForRequest = jest.fn()
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: (...args: unknown[]) => mockResolveOrganizationScopeForRequest(...args),
+}))
+
+const mockReadCoverageSnapshot = jest.fn()
+const mockReadCoverageSnapshots = jest.fn()
+const mockRefreshCoverageSnapshot = jest.fn()
+jest.mock('../lib/coverage', () => ({
+  readCoverageSnapshot: (...args: unknown[]) => mockReadCoverageSnapshot(...args),
+  readCoverageSnapshots: (...args: unknown[]) => mockReadCoverageSnapshots(...args),
+  refreshCoverageSnapshot: (...args: unknown[]) => mockRefreshCoverageSnapshot(...args),
+}))
+
+import { GET } from '../api/status'
+
+const ENTITY_A = 'catalog:catalog_product'
+const ENTITY_B = 'customers:person'
+
+function staleSnapshot() {
+  const refreshedAt = new Date(Date.now() - 5 * 60_000)
+  return {
+    base_count: 5,
+    indexed_count: 5,
+    vector_indexed_count: 0,
+    refreshed_at: refreshedAt,
+    baseCount: 5,
+    indexedCount: 5,
+    vectorIndexedCount: 0,
+  }
+}
+
+function makeFakeDb(tableRows: Record<string, unknown[]>) {
+  const build = (table: string) => {
+    const rows = tableRows[String(table)] ?? []
+    const chain: Record<string, unknown> = {}
+    const passthrough = () => chain
+    for (const method of ['select', 'selectAll', 'distinct', 'where', 'orderBy', 'limit']) {
+      chain[method] = passthrough
+    }
+    chain.execute = async () => rows
+    chain.executeTakeFirst = async () => rows[0]
+    return chain
+  }
+  return { selectFrom: (table: string) => build(table) }
+}
+
+function makeRequest(query = '') {
+  return new Request(`http://localhost/api/query_index/status${query}`)
+}
+
+describe('query_index status route — coverage waterfall (#3285)', () => {
+  const emitEvent = jest.fn(async () => undefined)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({ tenantId: 'tenant-1', orgId: 'org-1', sub: 'user-1' })
+    mockGetEntityIds.mockReturnValue({ catalog: { product: ENTITY_A }, customers: { person: ENTITY_B } })
+    mockFlattenSystemEntityIds.mockReturnValue([ENTITY_A, ENTITY_B])
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: 'org-1',
+      filterIds: ['org-1'],
+      allowedIds: ['org-1'],
+      tenantId: 'tenant-1',
+    })
+    mockReadCoverageSnapshot.mockResolvedValue(staleSnapshot())
+    mockReadCoverageSnapshots.mockImplementation(async (_db: unknown, batch: { entityTypes: string[] }) => {
+      const map = new Map<string, unknown>()
+      for (const entityType of batch.entityTypes) map.set(entityType, staleSnapshot())
+      return map
+    })
+    mockRefreshCoverageSnapshot.mockResolvedValue(undefined)
+
+    const db = makeFakeDb({
+      custom_field_defs: [{ entity_id: ENTITY_A }, { entity_id: ENTITY_B }],
+      entity_index_jobs: [],
+      indexer_error_logs: [],
+      indexer_status_logs: [],
+    })
+    const em = { getKysely: () => db }
+    mockCreateRequestContainer.mockResolvedValue({
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        if (name === 'eventBus') return { emitEvent }
+        if (name === 'searchModuleConfigs') return []
+        if (name === 'searchStrategies') return []
+        throw new Error(`Unexpected token: ${name}`)
+      },
+    })
+  })
+
+  it('stays read-cheap on a normal poll: no inline coverage refresh', async () => {
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    expect(mockRefreshCoverageSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('reads every entity snapshot via a single batched query', async () => {
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    expect(mockReadCoverageSnapshots).toHaveBeenCalledTimes(1)
+    expect(mockReadCoverageSnapshots).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ entityTypes: expect.arrayContaining([ENTITY_A, ENTITY_B]) }),
+    )
+    // The per-entity serial read must not be used by the polling path.
+    expect(mockReadCoverageSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('queues stale entities for the async coverage.refresh event path', async () => {
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const refreshEvents = emitEvent.mock.calls.filter(([eventId]) => eventId === 'query_index.coverage.refresh')
+    const refreshedEntities = refreshEvents.map(([, payload]) => (payload as { entityType: string }).entityType)
+    expect(refreshedEntities).toEqual(expect.arrayContaining([ENTITY_A, ENTITY_B]))
+    expect(mockRefreshCoverageSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('still blocks on a refresh when an explicit ?refresh action is requested', async () => {
+    const res = await GET(makeRequest('?refresh=1'))
+    expect(res.status).toBe(200)
+    expect(mockRefreshCoverageSnapshot).toHaveBeenCalledTimes(2)
+    const refreshedScopes = mockRefreshCoverageSnapshot.mock.calls.map(([, scope]) => (scope as { entityType: string }).entityType)
+    expect(refreshedScopes).toEqual(expect.arrayContaining([ENTITY_A, ENTITY_B]))
+  })
+
+  it('does not raise a partial-index warning when coverage is not yet computed', async () => {
+    mockReadCoverageSnapshots.mockResolvedValue(new Map())
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-om-partial-index')).toBeNull()
+  })
+
+  it('still raises a partial-index warning when base and index counts diverge', async () => {
+    mockReadCoverageSnapshots.mockImplementation(async (_db: unknown, batch: { entityTypes: string[] }) => {
+      const map = new Map<string, unknown>()
+      for (const entityType of batch.entityTypes) {
+        map.set(entityType, { ...staleSnapshot(), base_count: 10, indexed_count: 3, baseCount: 10, indexedCount: 3 })
+      }
+      return map
+    })
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const header = res.headers.get('x-om-partial-index')
+    expect(header).toBeTruthy()
+    const parsed = JSON.parse(header as string)
+    expect(parsed.type).toBe('partial_index')
+    expect([ENTITY_A, ENTITY_B]).toContain(parsed.entity)
+  })
+})

--- a/packages/core/src/modules/query_index/api/status.ts
+++ b/packages/core/src/modules/query_index/api/status.ts
@@ -4,7 +4,8 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { sql } from 'kysely'
-import { readCoverageSnapshot, refreshCoverageSnapshot } from '../lib/coverage'
+import { readCoverageSnapshots, refreshCoverageSnapshot } from '../lib/coverage'
+import { mapWithConcurrency } from '@open-mercato/shared/lib/query/bounded-decrypt'
 import type { FullTextSearchStrategy } from '@open-mercato/search/strategies'
 import type { SearchModuleConfig } from '@open-mercato/shared/modules/search'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -146,6 +147,7 @@ export async function GET(req: Request) {
 
   const HEARTBEAT_STALE_MS = 60_000
   const COVERAGE_STALE_MS = 60_000
+  const COVERAGE_REFRESH_CONCURRENCY = 8
 
   async function fetchJobSummary(entityType: string, tenantIdParam: string | null, organizationIdParam: string | null) {
     try {
@@ -288,39 +290,30 @@ export async function GET(req: Request) {
     return Number.isFinite(parsed) ? parsed : null
   }
 
-  const coverageSnapshots: Array<Awaited<ReturnType<typeof readCoverageSnapshot>>> = []
+  const coverageScope = {
+    tenantId: tenantId ?? null,
+    organizationId,
+    withDeleted: false,
+  } as const
   const entitiesNeedingRefresh = new Set<string>()
-  for (const entityId of entityIds) {
-    const scope = {
-      entityType: entityId,
-      tenantId: tenantId ?? null,
-      organizationId,
-      withDeleted: false,
-    } as const
-    const ensureSnapshot = async () => {
-      let snapshot = await readCoverageSnapshot(db, scope)
-      const refreshedAt = snapshot?.refreshed_at instanceof Date
-        ? snapshot.refreshed_at
-        : snapshot?.refreshed_at
-          ? new Date(snapshot.refreshed_at)
-          : null
-      const stale = !snapshot || !refreshedAt || (Date.now() - refreshedAt.getTime() > COVERAGE_STALE_MS)
-      if (forceRefresh || stale) {
-        await refreshCoverageSnapshot(em, scope).catch(() => undefined)
-        snapshot = await readCoverageSnapshot(db, scope)
-      }
-      const finalRefreshed = snapshot?.refreshed_at instanceof Date
-        ? snapshot.refreshed_at
-        : snapshot?.refreshed_at
-          ? new Date(snapshot.refreshed_at)
-          : null
-      if (!snapshot || !finalRefreshed || (Date.now() - finalRefreshed.getTime() > COVERAGE_STALE_MS)) {
-        entitiesNeedingRefresh.add(entityId)
-      }
-      return snapshot
-    }
-    coverageSnapshots.push(await ensureSnapshot())
+
+  // Read every entity's coverage snapshot in a single batched query. This endpoint is
+  // polled by the status table every few seconds, so the poll path must stay read-cheap:
+  // stale snapshots are refreshed asynchronously via the query_index.coverage.refresh
+  // event emitted below, never inline per entity.
+  const snapshotByEntity = await readCoverageSnapshots(db, { entityTypes: entityIds, ...coverageScope })
+
+  // An explicit refresh action (?refresh) is allowed to block: recompute every entity's
+  // coverage with bounded concurrency, then re-read the freshly written snapshots.
+  if (forceRefresh && entityIds.length > 0) {
+    await mapWithConcurrency(entityIds, COVERAGE_REFRESH_CONCURRENCY, (entityId) =>
+      refreshCoverageSnapshot(em, { entityType: entityId, ...coverageScope }).catch(() => undefined),
+    )
+    const refreshed = await readCoverageSnapshots(db, { entityTypes: entityIds, ...coverageScope })
+    for (const [entityId, snapshot] of refreshed) snapshotByEntity.set(entityId, snapshot)
   }
+
+  const coverageSnapshots = entityIds.map((entityId) => snapshotByEntity.get(entityId) ?? null)
 
   const jobs = await Promise.all(entityIds.map((eid) => fetchJobSummary(eid, tenantId, organizationId)))
 
@@ -467,6 +460,9 @@ export async function GET(req: Request) {
 
   const response = NextResponse.json({ items, errors, logs })
   const partial = items.find((item) => {
+    // Coverage not computed yet (no snapshot) — pending an async refresh, not a partial
+    // index. Do not raise the partial-index warning while counts are still unknown.
+    if (item.baseCount == null && item.indexCount == null) return false
     if (item.baseCount == null || item.indexCount == null) return true
     return item.baseCount !== item.indexCount
   })

--- a/packages/core/src/modules/query_index/lib/coverage.ts
+++ b/packages/core/src/modules/query_index/lib/coverage.ts
@@ -16,6 +16,19 @@ type CoverageRow = {
   refreshed_at: Date | string | null
 }
 
+export type CoverageSnapshot = CoverageRow & {
+  baseCount: number
+  indexedCount: number
+  vectorIndexedCount: number
+}
+
+export type CoverageBatchScope = {
+  entityTypes: readonly string[]
+  tenantId?: string | null
+  organizationId?: string | null
+  withDeleted?: boolean
+}
+
 export type CoverageAdjustment = {
   entityType: string
   tenantId: string | null
@@ -184,6 +197,56 @@ export async function readCoverageSnapshot(
     indexedCount: toCount(row.indexed_count),
     vectorIndexedCount: toCount(row.vector_indexed_count),
   }
+}
+
+export async function readCoverageSnapshots(
+  db: Kysely<any>,
+  batch: CoverageBatchScope
+): Promise<Map<string, CoverageSnapshot>> {
+  const entityTypes = Array.from(
+    new Set((batch.entityTypes ?? []).map((id) => String(id || '')).filter((id) => id.length > 0))
+  )
+  const result = new Map<string, CoverageSnapshot>()
+  if (entityTypes.length === 0) return result
+
+  const withDeleted = batch.withDeleted === true
+  let query = db
+    .selectFrom('entity_index_coverage' as any)
+    .select([
+      'entity_type' as any,
+      'base_count' as any,
+      'indexed_count' as any,
+      'vector_indexed_count' as any,
+      'refreshed_at' as any,
+      'organization_id' as any,
+    ])
+    .where('entity_type' as any, 'in', entityTypes)
+    .where('with_deleted' as any, '=', withDeleted)
+    .orderBy('refreshed_at' as any, 'desc')
+  query = batch.tenantId == null
+    ? query.where('tenant_id' as any, 'is', null as any)
+    : query.where('tenant_id' as any, '=', batch.tenantId)
+  query = applyOrganizationCondition(query as any, 'organization_id', batch.organizationId ?? null)
+
+  const rows = await query.execute() as Array<CoverageRow & { entity_type: string }>
+  for (const row of rows ?? []) {
+    const entityType = String(row.entity_type || '')
+    // Rows are ordered by refreshed_at desc, so the first row seen per entity is the latest.
+    if (!entityType || result.has(entityType)) continue
+    const refreshedAt = row.refreshed_at instanceof Date
+      ? row.refreshed_at
+      : (row.refreshed_at ? new Date(row.refreshed_at) : null)
+    result.set(entityType, {
+      base_count: row.base_count,
+      indexed_count: row.indexed_count,
+      vector_indexed_count: row.vector_indexed_count,
+      refreshed_at: refreshedAt ?? null,
+      baseCount: toCount(row.base_count),
+      indexedCount: toCount(row.indexed_count),
+      vectorIndexedCount: toCount(row.vector_indexed_count),
+    })
+  }
+  return result
 }
 
 export async function applyCoverageAdjustments(


### PR DESCRIPTION
## Summary

`/api/query_index/status` is polled every 4 seconds by the admin Query Indexes table, but the route serialized per-entity coverage work: it read each entity's coverage snapshot one-by-one and ran an expensive inline `refreshCoverageSnapshot` (several `COUNT(*)` queries plus a write) whenever a snapshot was older than 60s — i.e. during routine polling — creating a request-time waterfall on a hot endpoint.

This makes per-entity coverage work independent: snapshots are read in a single batched query, inline refreshes are removed from the polling path (stale entities are refreshed asynchronously via the already-wired `query_index.coverage.refresh` event), and an explicit `?refresh` action is the only path that blocks on a refresh — now parallelized with bounded concurrency.

Related but not duplicate: #2401 (coverage TTL cache) and #2968 (TTL thundering herd). This issue is specifically the admin status endpoint's per-entity serial waterfall under 4s polling.

## Changes

- `lib/coverage.ts`: add `readCoverageSnapshots(db, { entityTypes, tenantId, organizationId, withDeleted })` — one `entity_type IN (…)` query returning a `Map`, mirroring `readCoverageSnapshot`'s org-placeholder handling and latest-`refreshed_at`-wins tie-break for duplicate rows.
- `api/status.ts`: replace the serial per-entity loop with the batched read; only run `refreshCoverageSnapshot` inline for an explicit `?refresh` (bounded concurrency of 8 via the shared `mapWithConcurrency`), then re-read; normal polls queue stale entities to the existing `query_index.coverage.refresh` event instead of refreshing inline.
- `api/status.ts`: do not raise the `x-om-partial-index` warning when a snapshot has not been computed yet (both counts `null`) — that is a pending async refresh, not a partial index.
- Tests: add `__tests__/status-coverage-waterfall.test.ts` covering read-cheap polling, single-batched-query reads, event-path queuing, the blocking `?refresh` path, and the cold-start partial-banner guard.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — focused performance bug fix; related context in #2401 (coverage TTL cache) and #2968 (TTL thundering herd), neither duplicated here.

## Testing

- `tsc --noEmit` (packages/core) — passes, 0 errors
- `yarn jest src/modules/query_index/__tests__/status-coverage-waterfall.test.ts` (packages/core) — 6/6 pass (red → green)
- `yarn jest src/modules/query_index/__tests__` (packages/core) — 14 suites / 73 tests pass
- `yarn workspace @open-mercato/core build` — built successfully

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- none required: no new user-facing strings, generated files, or entity changes -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- route-level jest test added; pure read-path optimization with an unchanged API contract — no new Playwright flow required -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — minor perf fix, no spec -->
- [x] Priority set: this PR carries exactly one `priority-*` label. <!-- priority-medium (ordinary perf bug fix) -->
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. <!-- risk-medium (single-module read-path change, additive export, ships with tests) -->
- [x] QA routing set. <!-- needs-qa — admin-visible behavior (Query Indexes status table + partial-index banner). QA: confirm the table still renders coverage and no spurious "partial index" banner appears for a fresh tenant. -->

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #3285

🤖 Generated with [Claude Code](https://claude.com/claude-code)
