### PR TITLE
Fix perspectives mutation guard lifecycle

### DIFF
--- a/packages/core/src/modules/perspectives/api/[tableId]/[perspectiveId]/route.ts
+++ b/packages/core/src/modules/perspectives/api/[tableId]/[perspectiveId]/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { deleteUserPerspective } from '@open-mercato/core/modules/perspectives/services/perspectiveService'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { perspectivesTag, perspectivesErrorSchema, perspectivesSuccessSchema } from '../../openapi'
@@ -40,7 +44,22 @@ export async function DELETE(req: Request, ctx: { params: { tableId: string; per
     }
   })()
 
-  await deleteUserPerspective(em, cache, {
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: auth.tenantId ?? '',
+    organizationId: auth.orgId ?? null,
+    userId: auth.sub,
+    resourceKind: 'perspectives.perspective',
+    resourceId: perspectiveId,
+    operation: 'delete',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: { tableId, perspectiveId },
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
+  const deleted = await deleteUserPerspective(em, cache, {
     scope: {
       userId: auth.sub,
       tenantId: auth.tenantId ?? null,
@@ -49,6 +68,20 @@ export async function DELETE(req: Request, ctx: { params: { tableId: string; per
     tableId,
     perspectiveId,
   })
+
+  if (deleted && guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: auth.tenantId ?? '',
+      organizationId: auth.orgId ?? null,
+      userId: auth.sub,
+      resourceKind: 'perspectives.perspective',
+      resourceId: perspectiveId,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
 
   return NextResponse.json({ success: true })
 }

--- a/packages/core/src/modules/perspectives/api/[tableId]/__tests__/mutation-guard.test.ts
+++ b/packages/core/src/modules/perspectives/api/[tableId]/__tests__/mutation-guard.test.ts
@@ -1,0 +1,425 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const perspectiveId = '44444444-4444-4444-8444-444444444444'
+const roleId = '55555555-5555-4555-8555-555555555555'
+const tableId = 'customers.deals'
+
+const em = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+}
+const cache = {}
+const rbacService = {
+  userHasAllFeatures: jest.fn(),
+}
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'cache') return cache
+    if (name === 'rbacService') return rbacService
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const withAtomicFlushMock = jest.fn(async (_em: unknown, phases: Array<() => unknown>) => {
+  for (const phase of phases) {
+    await phase()
+  }
+})
+const saveUserPerspectiveMock = jest.fn()
+const saveRolePerspectivesMock = jest.fn()
+const clearRolePerspectivesMock = jest.fn()
+const deleteUserPerspectiveMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    sub: userId,
+    tenantId,
+    orgId: organizationId,
+    roles: [],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/flush', () => ({
+  withAtomicFlush: (...args: unknown[]) => withAtomicFlushMock(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/perspectives/services/perspectiveService', () => ({
+  loadPerspectivesState: jest.fn(),
+  saveUserPerspective: (...args: unknown[]) => saveUserPerspectiveMock(...args),
+  saveRolePerspectives: (...args: unknown[]) => saveRolePerspectivesMock(...args),
+  clearRolePerspectives: (...args: unknown[]) => clearRolePerspectivesMock(...args),
+  deleteUserPerspective: (...args: unknown[]) => deleteUserPerspectiveMock(...args),
+}))
+
+import { POST } from '../route'
+import { DELETE as DELETE_PERSONAL } from '../[perspectiveId]/route'
+import { DELETE as DELETE_ROLE } from '../roles/[roleId]/route'
+
+describe('perspectives custom write mutation guards', () => {
+  beforeEach(() => {
+    container.resolve.mockClear()
+    validateCrudMutationGuardMock.mockReset()
+    runCrudMutationGuardAfterSuccessMock.mockReset()
+    withAtomicFlushMock.mockReset()
+    saveUserPerspectiveMock.mockReset()
+    saveRolePerspectivesMock.mockReset()
+    clearRolePerspectivesMock.mockReset()
+    deleteUserPerspectiveMock.mockReset()
+    rbacService.userHasAllFeatures.mockReset()
+    em.find.mockReset()
+    em.findOne.mockReset()
+    validateCrudMutationGuardMock.mockResolvedValue({
+      ok: true,
+      shouldRunAfterSuccess: true,
+      metadata: { token: 'guard' },
+    })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    withAtomicFlushMock.mockImplementation(async (_em: unknown, phases: Array<() => unknown>) => {
+      for (const phase of phases) {
+        await phase()
+      }
+    })
+    saveUserPerspectiveMock.mockResolvedValue({
+      id: perspectiveId,
+      tableId,
+      name: 'Pipeline',
+      settings: {},
+      isDefault: false,
+      createdAt: '2026-06-19T00:00:00.000Z',
+      updatedAt: '2026-06-19T00:00:00.000Z',
+    })
+    saveRolePerspectivesMock.mockResolvedValue([])
+    clearRolePerspectivesMock.mockResolvedValue(1)
+    deleteUserPerspectiveMock.mockResolvedValue(true)
+    rbacService.userHasAllFeatures.mockResolvedValue(false)
+    em.find.mockResolvedValue([])
+    em.findOne.mockResolvedValue({ id: roleId, tenantId, deletedAt: null })
+  })
+
+  it('wraps the save route with validation before the atomic write and after-success after commit', async () => {
+    const response = await POST(
+      new Request(`http://localhost/api/perspectives/${encodeURIComponent(tableId)}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          perspectiveId,
+          name: 'Pipeline',
+          settings: {},
+          isDefault: false,
+        }),
+      }),
+      { params: { tableId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'perspectives.perspective',
+        resourceId: perspectiveId,
+        operation: 'custom',
+        mutationPayload: expect.objectContaining({ perspectiveId, name: 'Pipeline' }),
+      }),
+    )
+    expect(withAtomicFlushMock).toHaveBeenCalledWith(em, expect.any(Array), { transaction: true })
+    expect(saveUserPerspectiveMock).toHaveBeenCalled()
+    expect(validateCrudMutationGuardMock.mock.invocationCallOrder[0]).toBeLessThan(
+      saveUserPerspectiveMock.mock.invocationCallOrder[0],
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'perspectives.perspective',
+        resourceId: perspectiveId,
+        operation: 'custom',
+        metadata: { token: 'guard' },
+      }),
+    )
+    expect(saveUserPerspectiveMock.mock.invocationCallOrder[0]).toBeLessThan(
+      runCrudMutationGuardAfterSuccessMock.mock.invocationCallOrder[0],
+    )
+  })
+
+  it('short-circuits the save route when the mutation guard rejects', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      body: { error: { code: 'RECORD_LOCKED' } },
+    })
+
+    const response = await POST(
+      new Request(`http://localhost/api/perspectives/${encodeURIComponent(tableId)}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          perspectiveId,
+          name: 'Pipeline',
+          settings: {},
+        }),
+      }),
+      { params: { tableId } },
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({ error: { code: 'RECORD_LOCKED' } })
+    expect(withAtomicFlushMock).not.toHaveBeenCalled()
+    expect(saveUserPerspectiveMock).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('wraps role perspective mutations from the save route with mutation guards', async () => {
+    rbacService.userHasAllFeatures.mockResolvedValueOnce(true)
+    em.find.mockResolvedValueOnce([{ id: roleId, tenantId, deletedAt: null }])
+
+    const response = await POST(
+      new Request(`http://localhost/api/perspectives/${encodeURIComponent(tableId)}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          perspectiveId,
+          name: 'Pipeline',
+          settings: {},
+          applyToRoles: [roleId],
+          setRoleDefault: true,
+        }),
+      }),
+      { params: { tableId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(validateCrudMutationGuardMock).toHaveBeenNthCalledWith(
+      2,
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'perspectives.role_perspective',
+        resourceId: roleId,
+        operation: 'custom',
+        mutationPayload: expect.objectContaining({ tableId, applyToRoles: [roleId] }),
+      }),
+    )
+    expect(saveRolePerspectivesMock).toHaveBeenCalledWith(em, cache, expect.objectContaining({
+      tableId,
+      tenantId,
+      organizationId,
+      input: expect.objectContaining({ roleIds: [roleId], setDefault: true }),
+    }))
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'perspectives.role_perspective',
+        resourceId: roleId,
+        operation: 'custom',
+        metadata: { token: 'guard' },
+      }),
+    )
+  })
+
+  it('short-circuits role perspective mutations from the save route when the role guard rejects', async () => {
+    rbacService.userHasAllFeatures.mockResolvedValueOnce(true)
+    em.find.mockResolvedValueOnce([{ id: roleId, tenantId, deletedAt: null }])
+    validateCrudMutationGuardMock
+      .mockResolvedValueOnce({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'personal' } })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        body: { error: { code: 'ROLE_PERSPECTIVE_LOCKED' } },
+      })
+
+    const response = await POST(
+      new Request(`http://localhost/api/perspectives/${encodeURIComponent(tableId)}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          perspectiveId,
+          name: 'Pipeline',
+          settings: {},
+          applyToRoles: [roleId],
+        }),
+      }),
+      { params: { tableId } },
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({ error: { code: 'ROLE_PERSPECTIVE_LOCKED' } })
+    expect(withAtomicFlushMock).not.toHaveBeenCalled()
+    expect(saveUserPerspectiveMock).not.toHaveBeenCalled()
+    expect(saveRolePerspectivesMock).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('does not run role after-success for clear-only save route no-ops', async () => {
+    rbacService.userHasAllFeatures.mockResolvedValueOnce(true)
+    em.find.mockResolvedValueOnce([{ id: roleId, tenantId, deletedAt: null }])
+    clearRolePerspectivesMock.mockResolvedValueOnce(0)
+
+    const response = await POST(
+      new Request(`http://localhost/api/perspectives/${encodeURIComponent(tableId)}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          perspectiveId,
+          name: 'Pipeline',
+          settings: {},
+          clearRoleIds: [roleId],
+        }),
+      }),
+      { params: { tableId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(clearRolePerspectivesMock).toHaveBeenCalledWith(em, cache, {
+      tableId,
+      tenantId,
+      organizationId,
+      roleIds: [roleId],
+    })
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledTimes(1)
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'perspectives.perspective' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'perspectives.role_perspective' }),
+    )
+  })
+
+  it('wraps personal perspective deletes with mutation guards', async () => {
+    const response = await DELETE_PERSONAL(
+      new Request(`http://localhost/api/perspectives/${encodeURIComponent(tableId)}/${perspectiveId}`, {
+        method: 'DELETE',
+      }),
+      { params: { tableId, perspectiveId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'perspectives.perspective',
+        resourceId: perspectiveId,
+        operation: 'delete',
+        mutationPayload: { tableId, perspectiveId },
+      }),
+    )
+    expect(deleteUserPerspectiveMock).toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'perspectives.perspective',
+        resourceId: perspectiveId,
+        operation: 'delete',
+        metadata: { token: 'guard' },
+      }),
+    )
+  })
+
+  it('does not run after-success for personal perspective delete no-ops', async () => {
+    deleteUserPerspectiveMock.mockResolvedValueOnce(false)
+
+    const response = await DELETE_PERSONAL(
+      new Request(`http://localhost/api/perspectives/${encodeURIComponent(tableId)}/${perspectiveId}`, {
+        method: 'DELETE',
+      }),
+      { params: { tableId, perspectiveId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(deleteUserPerspectiveMock).toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('wraps role perspective clears with mutation guards', async () => {
+    const response = await DELETE_ROLE(
+      new Request(`http://localhost/api/perspectives/${encodeURIComponent(tableId)}/roles/${roleId}`, {
+        method: 'DELETE',
+      }),
+      { params: { tableId, roleId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'perspectives.role_perspective',
+        resourceId: roleId,
+        operation: 'delete',
+        mutationPayload: { tableId, roleId },
+      }),
+    )
+    expect(clearRolePerspectivesMock).toHaveBeenCalledWith(em, cache, {
+      tableId,
+      tenantId,
+      organizationId,
+      roleIds: [roleId],
+    })
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        tenantId,
+        organizationId,
+        userId,
+        resourceKind: 'perspectives.role_perspective',
+        resourceId: roleId,
+        operation: 'delete',
+        metadata: { token: 'guard' },
+      }),
+    )
+  })
+
+  it('does not run after-success for role perspective clear no-ops', async () => {
+    clearRolePerspectivesMock.mockResolvedValueOnce(0)
+
+    const response = await DELETE_ROLE(
+      new Request(`http://localhost/api/perspectives/${encodeURIComponent(tableId)}/roles/${roleId}`, {
+        method: 'DELETE',
+      }),
+      { params: { tableId, roleId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(clearRolePerspectivesMock).toHaveBeenCalledWith(em, cache, {
+      tableId,
+      tenantId,
+      organizationId,
+      roleIds: [roleId],
+    })
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/perspectives/api/[tableId]/roles/[roleId]/route.ts
+++ b/packages/core/src/modules/perspectives/api/[tableId]/roles/[roleId]/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { clearRolePerspectives } from '@open-mercato/core/modules/perspectives/services/perspectiveService'
 import { Role } from '@open-mercato/core/modules/auth/data/entities'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -48,12 +52,41 @@ export async function DELETE(req: Request, ctx: { params: { tableId: string; rol
   const role = await em.findOne(Role, { id: roleId, deletedAt: null, ...(scope as any) } as any)
   if (!role) return NextResponse.json({ error: 'Role not found' }, { status: 404 })
 
-  await clearRolePerspectives(em, cache, {
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: auth.tenantId ?? '',
+    organizationId: auth.orgId ?? null,
+    userId: auth.sub,
+    resourceKind: 'perspectives.role_perspective',
+    resourceId: roleId,
+    operation: 'delete',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: { tableId, roleId },
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
+  const clearedCount = await clearRolePerspectives(em, cache, {
     tableId,
     tenantId: auth.tenantId ?? null,
     organizationId: auth.orgId ?? null,
     roleIds: [roleId],
   })
+
+  if (clearedCount > 0 && guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: auth.tenantId ?? '',
+      organizationId: auth.orgId ?? null,
+      userId: auth.sub,
+      resourceKind: 'perspectives.role_perspective',
+      resourceId: roleId,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
 
   return NextResponse.json({ success: true })
 }

--- a/packages/core/src/modules/perspectives/api/[tableId]/route.ts
+++ b/packages/core/src/modules/perspectives/api/[tableId]/route.ts
@@ -4,6 +4,10 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { perspectiveSaveSchema } from '@open-mercato/core/modules/perspectives/data/validators'
 import {
   loadPerspectivesState,
@@ -168,6 +172,7 @@ export async function POST(req: Request, ctx: { params: { tableId: string } }) {
   const applyToRoles = Array.from(new Set(parsed.data.applyToRoles ?? [])).filter((id) => id.trim().length > 0)
   const clearRoleIds = Array.from(new Set(parsed.data.clearRoleIds ?? [])).filter((id) => id.trim().length > 0)
   const hasRoleOps = applyToRoles.length > 0 || clearRoleIds.length > 0
+  const targetRoleIds = Array.from(new Set([...applyToRoles, ...clearRoleIds]))
 
   if (hasRoleOps) {
     const canApplyToRoles = await rbac.userHasAllFeatures?.(
@@ -183,7 +188,6 @@ export async function POST(req: Request, ctx: { params: { tableId: string } }) {
     const roleScope = auth.tenantId
       ? { $or: [{ tenantId: auth.tenantId }, { tenantId: null }] }
       : { tenantId: null }
-    const targetRoleIds = Array.from(new Set([...applyToRoles, ...clearRoleIds]))
     const roles = await em.find(Role, {
       id: { $in: targetRoleIds as any },
       ...(roleScope as any),
@@ -197,50 +201,121 @@ export async function POST(req: Request, ctx: { params: { tableId: string } }) {
     }
   }
 
+  const guardResourceId = parsed.data.perspectiveId ?? tableId
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: auth.tenantId ?? '',
+    organizationId: auth.orgId ?? null,
+    userId: auth.sub,
+    resourceKind: 'perspectives.perspective',
+    resourceId: guardResourceId,
+    operation: 'custom',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: { ...parsed.data, tableId },
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
+  let roleGuardResult: Awaited<ReturnType<typeof validateCrudMutationGuard>> | null = null
+  if (hasRoleOps) {
+    roleGuardResult = await validateCrudMutationGuard(container, {
+      tenantId: auth.tenantId ?? '',
+      organizationId: auth.orgId ?? null,
+      userId: auth.sub,
+      resourceKind: 'perspectives.role_perspective',
+      resourceId: targetRoleIds.join(','),
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: {
+        tableId,
+        applyToRoles,
+        clearRoleIds,
+        name: parsed.data.name,
+        settings: parsed.data.settings,
+        setRoleDefault: parsed.data.setRoleDefault ?? false,
+      },
+    })
+  }
+  if (roleGuardResult && !roleGuardResult.ok) {
+    return NextResponse.json(roleGuardResult.body, { status: roleGuardResult.status })
+  }
+
   let saved: Awaited<ReturnType<typeof saveUserPerspective>> | null = null
   let updatedRolePerspectives: Awaited<ReturnType<typeof saveRolePerspectives>> | null = null
+  let clearedRolePerspectiveCount = 0
 
   try {
     await withAtomicFlush(em, [
-    async () => {
-      saved = await saveUserPerspective(em, cache, {
-        scope,
-        tableId,
-        input: parsed.data,
-        request: req,
-      })
-    },
-    async () => {
-      if (applyToRoles.length) {
-        updatedRolePerspectives = await saveRolePerspectives(em, cache, {
+      async () => {
+        saved = await saveUserPerspective(em, cache, {
+          scope,
           tableId,
-          tenantId: auth.tenantId ?? null,
-          organizationId: auth.orgId ?? null,
-          input: {
-            roleIds: applyToRoles,
-            name: parsed.data.name,
-            settings: parsed.data.settings,
-            setDefault: parsed.data.setRoleDefault ?? false,
-          },
+          input: parsed.data,
+          request: req,
         })
-      }
-    },
-    async () => {
-      if (clearRoleIds.length) {
-        await clearRolePerspectives(em, cache, {
-          tableId,
-          tenantId: auth.tenantId ?? null,
-          organizationId: auth.orgId ?? null,
-          roleIds: clearRoleIds,
-        })
-      }
-    },
+      },
+      async () => {
+        if (applyToRoles.length) {
+          updatedRolePerspectives = await saveRolePerspectives(em, cache, {
+            tableId,
+            tenantId: auth.tenantId ?? null,
+            organizationId: auth.orgId ?? null,
+            input: {
+              roleIds: applyToRoles,
+              name: parsed.data.name,
+              settings: parsed.data.settings,
+              setDefault: parsed.data.setRoleDefault ?? false,
+            },
+          })
+        }
+      },
+      async () => {
+        if (clearRoleIds.length) {
+          clearedRolePerspectiveCount = await clearRolePerspectives(em, cache, {
+            tableId,
+            tenantId: auth.tenantId ?? null,
+            organizationId: auth.orgId ?? null,
+            roleIds: clearRoleIds,
+          })
+        }
+      },
     ], { transaction: true })
   } catch (err) {
     if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     throw err
+  }
+
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: auth.tenantId ?? '',
+      organizationId: auth.orgId ?? null,
+      userId: auth.sub,
+      resourceKind: 'perspectives.perspective',
+      resourceId: guardResourceId,
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
+
+  const didWriteRolePerspectives = applyToRoles.length > 0 || clearedRolePerspectiveCount > 0
+  if (didWriteRolePerspectives && roleGuardResult?.ok && roleGuardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      tenantId: auth.tenantId ?? '',
+      organizationId: auth.orgId ?? null,
+      userId: auth.sub,
+      resourceKind: 'perspectives.role_perspective',
+      resourceId: targetRoleIds.join(','),
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      metadata: roleGuardResult.metadata ?? null,
+    })
   }
 
   return NextResponse.json({

--- a/packages/core/src/modules/perspectives/services/__tests__/perspectiveService.batching.test.ts
+++ b/packages/core/src/modules/perspectives/services/__tests__/perspectiveService.batching.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals'
-import { saveRolePerspectives } from '../perspectiveService'
+import { clearRolePerspectives, deleteUserPerspective, saveRolePerspectives } from '../perspectiveService'
 
 type Where = Record<string, unknown>
 
@@ -71,5 +71,72 @@ describe('saveRolePerspectives (issue #1399)', () => {
     expect(em.create).toHaveBeenCalledTimes(1)
     expect(em.create.mock.calls[0][1]).toMatchObject({ roleId: roleB })
     expect(em.flush).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('perspective mutation affected-row reporting', () => {
+  const scope = { userId: 'user-1', tenantId: 'tenant-1', organizationId: 'org-1' }
+
+  it('reports whether a personal perspective was deleted', async () => {
+    const existing = { deletedAt: null, isDefault: true }
+    const em = {
+      findOne: jest.fn(async () => existing),
+      flush: jest.fn(async () => {}),
+    }
+    const cache = { deleteByTags: jest.fn(async () => {}) }
+
+    await expect(deleteUserPerspective(em as any, cache as any, {
+      scope,
+      tableId: 'orders',
+      perspectiveId: 'perspective-1',
+    })).resolves.toBe(true)
+
+    expect(existing.deletedAt).toBeInstanceOf(Date)
+    expect(existing.isDefault).toBe(false)
+    expect(em.flush).toHaveBeenCalledTimes(1)
+    expect(cache.deleteByTags).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns false for personal perspective delete misses', async () => {
+    const em = {
+      findOne: jest.fn(async () => null),
+      flush: jest.fn(async () => {}),
+    }
+    const cache = { deleteByTags: jest.fn(async () => {}) }
+
+    await expect(deleteUserPerspective(em as any, cache as any, {
+      scope,
+      tableId: 'orders',
+      perspectiveId: 'missing',
+    })).resolves.toBe(false)
+
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(cache.deleteByTags).not.toHaveBeenCalled()
+  })
+
+  it('returns the affected count for role perspective clears', async () => {
+    const em = createMockEm()
+    em.nativeUpdate.mockResolvedValueOnce(2)
+    const cache = { deleteByTags: jest.fn(async () => {}) }
+
+    await expect(clearRolePerspectives(em as any, cache as any, {
+      ...baseOptions,
+      roleIds: ['role-1', 'role-2'],
+    })).resolves.toBe(2)
+
+    expect(cache.deleteByTags).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves role perspective cache invalidation when nothing was cleared', async () => {
+    const em = createMockEm()
+    em.nativeUpdate.mockResolvedValueOnce(0)
+    const cache = { deleteByTags: jest.fn(async () => {}) }
+
+    await expect(clearRolePerspectives(em as any, cache as any, {
+      ...baseOptions,
+      roleIds: ['role-1'],
+    })).resolves.toBe(0)
+
+    expect(cache.deleteByTags).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/src/modules/perspectives/services/perspectiveService.ts
+++ b/packages/core/src/modules/perspectives/services/perspectiveService.ts
@@ -309,7 +309,7 @@ export async function deleteUserPerspective(
   em: EntityManager,
   cache: CacheStrategy | null | undefined,
   options: { scope: PerspectiveScope; tableId: string; perspectiveId: string },
-): Promise<void> {
+): Promise<boolean> {
   const { scope, tableId, perspectiveId } = options
   const tenantId = scope.tenantId ?? null
   const organizationId = scope.organizationId ?? null
@@ -322,7 +322,7 @@ export async function deleteUserPerspective(
     tableId,
     deletedAt: null,
   })
-  if (!existing) return
+  if (!existing) return false
 
   existing.deletedAt = new Date()
   existing.isDefault = false
@@ -331,6 +331,8 @@ export async function deleteUserPerspective(
   if (cache?.deleteByTags) {
     await cache.deleteByTags([userTag(scope, tableId)])
   }
+
+  return true
 }
 
 export async function saveRolePerspectives(
@@ -430,13 +432,13 @@ export async function clearRolePerspectives(
     organizationId?: string | null
     roleIds: string[]
   },
-): Promise<void> {
+): Promise<number> {
   const { tableId, roleIds } = options
   const tenantId = options.tenantId ?? null
   const organizationId = options.organizationId ?? null
-  if (!roleIds.length) return
+  if (!roleIds.length) return 0
 
-  await em.nativeUpdate(
+  const affected = await em.nativeUpdate(
     RolePerspective,
     {
       roleId: { $in: roleIds as any },
@@ -452,4 +454,6 @@ export async function clearRolePerspectives(
     const tags = roleIds.map((roleId) => roleTag(roleId, tableId, tenantId))
     await cache.deleteByTags(tags)
   }
+
+  return affected
 }


### PR DESCRIPTION
## Summary

Fixes perspectives custom write routes so mutation guards run before writes and after-success hooks only run after successful mutations.

## Changes

- Added mutation guard validation and after-success lifecycle calls to personal save, personal delete, and role clear routes.
- Added affected-row reporting for perspective delete/role clear services so no-op deletes do not trigger after-success hooks.
- Added focused regression tests for guard ordering, guard rejection, role operations, and no-op delete/clear behavior.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
.ai/specs/implemented/SPEC-035-2026-02-22-mutation-guard-mechanism.md

## Testing

- `yarn workspace @open-mercato/core test --runTestsByPath 'src/modules/perspectives/api/[tableId]/__tests__/mutation-guard.test.ts' 'src/modules/perspectives/services/__tests__/perspectiveService.batching.test.ts' --runInBand`
- `yarn build:packages`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- `yarn i18n:check-sync`

Not run: `yarn lint` is blocked by the existing repo ESLint rule API error (`contextOrFilename.getFilename is not a function`).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3274
