### PR TITLE
fix(query_index): route reindex/purge writes through mutation guard (#3286)

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/api-queue-only.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/api-queue-only.test.ts
@@ -25,6 +25,8 @@ function makeRequest(body: Record<string, unknown>) {
 
 describe('query_index API persistent job dispatch', () => {
   const emitEvent = jest.fn(async () => undefined)
+  const validateMutation = jest.fn()
+  const afterMutationSuccess = jest.fn(async () => undefined)
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -33,10 +35,12 @@ describe('query_index API persistent job dispatch', () => {
       orgId: 'org-1',
       sub: 'user-1',
     })
+    validateMutation.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { guard: true } })
     mockCreateRequestContainer.mockResolvedValue({
       resolve: jest.fn((name: string) => {
         if (name === 'em') return { em: true }
         if (name === 'eventBus') return { emitEvent }
+        if (name === 'crudMutationGuardService') return { validateMutation, afterMutationSuccess }
         throw new Error(`Unexpected token: ${name}`)
       }),
     })
@@ -70,5 +74,85 @@ describe('query_index API persistent job dispatch', () => {
       },
       { persistent: true, deliverInline: false },
     )
+  })
+
+  it('runs the mutation guard before and after a reindex write', async () => {
+    const res = await reindexPost(makeRequest({ entityType: 'catalog:catalog_product' }))
+
+    expect(res.status).toBe(200)
+    expect(validateMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        userId: 'user-1',
+        resourceKind: 'query_index',
+        resourceId: 'catalog:catalog_product',
+        operation: 'custom',
+        requestMethod: 'POST',
+        requestHeaders: expect.any(Headers),
+        mutationPayload: expect.objectContaining({ entityType: 'catalog:catalog_product' }),
+      }),
+    )
+    expect(afterMutationSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceKind: 'query_index',
+        resourceId: 'catalog:catalog_product',
+        operation: 'custom',
+        metadata: { guard: true },
+      }),
+    )
+    expect(validateMutation.mock.invocationCallOrder[0]).toBeLessThan(emitEvent.mock.invocationCallOrder[0])
+    expect(emitEvent.mock.invocationCallOrder[0]).toBeLessThan(afterMutationSuccess.mock.invocationCallOrder[0])
+  })
+
+  it('blocks a reindex write when the mutation guard rejects it', async () => {
+    validateMutation.mockResolvedValueOnce({ ok: false, status: 409, body: { error: 'blocked' } })
+
+    const res = await reindexPost(makeRequest({ entityType: 'catalog:catalog_product' }))
+
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toEqual({ error: 'blocked' })
+    expect(emitEvent).not.toHaveBeenCalled()
+    expect(afterMutationSuccess).not.toHaveBeenCalled()
+  })
+
+  it('runs the mutation guard before and after a purge write', async () => {
+    const res = await purgePost(makeRequest({ entityType: 'catalog:catalog_product' }))
+
+    expect(res.status).toBe(200)
+    expect(validateMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        userId: 'user-1',
+        resourceKind: 'query_index',
+        resourceId: 'catalog:catalog_product',
+        operation: 'custom',
+        requestMethod: 'POST',
+        requestHeaders: expect.any(Headers),
+        mutationPayload: expect.objectContaining({ entityType: 'catalog:catalog_product' }),
+      }),
+    )
+    expect(afterMutationSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceKind: 'query_index',
+        resourceId: 'catalog:catalog_product',
+        operation: 'custom',
+        metadata: { guard: true },
+      }),
+    )
+    expect(validateMutation.mock.invocationCallOrder[0]).toBeLessThan(emitEvent.mock.invocationCallOrder[0])
+    expect(emitEvent.mock.invocationCallOrder[0]).toBeLessThan(afterMutationSuccess.mock.invocationCallOrder[0])
+  })
+
+  it('blocks a purge write when the mutation guard rejects it', async () => {
+    validateMutation.mockResolvedValueOnce({ ok: false, status: 409, body: { error: 'blocked' } })
+
+    const res = await purgePost(makeRequest({ entityType: 'catalog:catalog_product' }))
+
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toEqual({ error: 'blocked' })
+    expect(emitEvent).not.toHaveBeenCalled()
+    expect(afterMutationSuccess).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/query_index/api/purge.ts
+++ b/packages/core/src/modules/query_index/api/purge.ts
@@ -4,6 +4,10 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { queryIndexTag, queryIndexErrorSchema, queryIndexOkSchema, queryIndexPurgeRequestSchema } from './openapi'
 import { recordIndexerLog } from '@open-mercato/shared/lib/indexers/status-log'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['query_index.purge'] },
@@ -16,12 +20,29 @@ export async function POST(req: Request) {
   const entityType = String(body?.entityType || '')
   if (!entityType) return NextResponse.json({ error: 'Missing entityType' }, { status: 400 })
 
-  const { resolve } = await createRequestContainer()
+  const container = await createRequestContainer()
   let em: any | null = null
   try {
-    em = resolve('em')
+    em = container.resolve('em')
   } catch {}
-  const bus = resolve('eventBus') as any
+  const bus = container.resolve('eventBus') as any
+
+  const guardUserId = typeof auth.sub === 'string' ? auth.sub : ''
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: auth.tenantId,
+    organizationId: auth.orgId,
+    userId: guardUserId,
+    resourceKind: 'query_index',
+    resourceId: entityType,
+    operation: 'custom',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: { entityType },
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
   await recordIndexerLog(
     { em: em ?? undefined },
     {
@@ -50,6 +71,19 @@ export async function POST(req: Request) {
         organizationId: auth.orgId ?? null,
       },
     ).catch(() => undefined)
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(container, {
+        tenantId: auth.tenantId,
+        organizationId: auth.orgId,
+        userId: guardUserId,
+        resourceKind: 'query_index',
+        resourceId: entityType,
+        operation: 'custom',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
   } catch (error) {
     await recordIndexerLog(
       { em: em ?? undefined },

--- a/packages/core/src/modules/query_index/api/reindex.ts
+++ b/packages/core/src/modules/query_index/api/reindex.ts
@@ -5,6 +5,10 @@ import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib
 import { queryIndexTag, queryIndexErrorSchema, queryIndexOkSchema, queryIndexReindexRequestSchema } from './openapi'
 import { recordIndexerLog } from '@open-mercato/shared/lib/indexers/status-log'
 import { isValidEntityIdShape } from '@open-mercato/shared/lib/query/engine'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['query_index.reindex'] },
@@ -31,16 +35,39 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'partitionIndex must be < partitionCount' }, { status: 400 })
   }
 
-  const { resolve } = await createRequestContainer()
+  const container = await createRequestContainer()
   let em: any | null = null
   try {
-    em = resolve('em')
+    em = container.resolve('em')
   } catch {}
-  const bus = resolve('eventBus') as any
+  const bus = container.resolve('eventBus') as any
   const partitions = partitionIndex !== undefined
     ? [partitionIndex]
     : Array.from({ length: partitionCount }, (_, idx) => idx)
   const firstPartition = partitions[0] ?? 0
+
+  const guardUserId = typeof auth.sub === 'string' ? auth.sub : ''
+  const guardResult = await validateCrudMutationGuard(container, {
+    tenantId: auth.tenantId,
+    organizationId: auth.orgId,
+    userId: guardUserId,
+    resourceKind: 'query_index',
+    resourceId: entityType,
+    operation: 'custom',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+    mutationPayload: {
+      entityType,
+      force,
+      batchSize: batchSize ?? null,
+      partitionCount,
+      partitionIndex: partitionIndex ?? null,
+    },
+  })
+  if (guardResult && !guardResult.ok) {
+    return NextResponse.json(guardResult.body, { status: guardResult.status })
+  }
+
   await recordIndexerLog(
     { em: em ?? undefined },
     {
@@ -102,6 +129,19 @@ export async function POST(req: Request) {
         },
       },
     ).catch(() => undefined)
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(container, {
+        tenantId: auth.tenantId,
+        organizationId: auth.orgId,
+        userId: guardUserId,
+        resourceKind: 'query_index',
+        resourceId: entityType,
+        operation: 'custom',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
   } catch (error) {
     await recordIndexerLog(
       { em: em ?? undefined },

--- a/packages/core/src/modules/query_index/components/QueryIndexesTable.tsx
+++ b/packages/core/src/modules/query_index/components/QueryIndexesTable.tsx
@@ -10,6 +10,9 @@ import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
+
+const MUTATION_CONTEXT_ID = 'query_index.status.list:actions'
 
 type Translator = (key: string, params?: Record<string, string | number>) => string
 
@@ -227,6 +230,15 @@ export default function QueryIndexesTable() {
   const t = useT()
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
   const columns = React.useMemo(() => createColumns(t), [t])
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    resourceId: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: MUTATION_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
 
   const { data, isLoading } = useQuery<Resp>({
     queryKey: ['query-index-status', scopeVersion, refreshSeq],
@@ -257,11 +269,21 @@ export default function QueryIndexesTable() {
         action === 'purge' ? t('query_index.table.actions.purge') : t('query_index.table.actions.reindex')
       const errorMessage = t('query_index.table.errors.actionFailed', { action: actionLabel })
       try {
-        await apiCallOrThrow(`/api/query_index/${action}`, {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify(body),
-        }, { errorMessage })
+        await runMutation({
+          operation: () =>
+            apiCallOrThrow(`/api/query_index/${action}`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(body),
+            }, { errorMessage }),
+          context: {
+            formId: MUTATION_CONTEXT_ID,
+            resourceKind: 'query_index',
+            resourceId: entityId,
+            retryLastMutation,
+          },
+          mutationPayload: { action, entityType: entityId, force: Boolean(opts?.force) },
+        })
       } catch (err) {
         // Expected operational failures (e.g. a 503 when a search backend is not
         // configured) — surface a flash toast, not an alert or an error-level
@@ -272,7 +294,7 @@ export default function QueryIndexesTable() {
       }
       qc.invalidateQueries({ queryKey: ['query-index-status'] })
     },
-    [qc, t],
+    [qc, t, runMutation, retryLastMutation],
   )
 
   const triggerVector = React.useCallback(
@@ -290,14 +312,24 @@ export default function QueryIndexesTable() {
         : t('query_index.table.actions.vectorReindex')
       const errorMessage = t('query_index.table.errors.actionFailed', { action: actionLabel })
       try {
-        await apiCallOrThrow('/api/search/embeddings/reindex', {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({
-            entityId,
-            purgeFirst: action === 'purge',
-          }),
-        }, { errorMessage })
+        await runMutation({
+          operation: () =>
+            apiCallOrThrow('/api/search/embeddings/reindex', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                entityId,
+                purgeFirst: action === 'purge',
+              }),
+            }, { errorMessage }),
+          context: {
+            formId: MUTATION_CONTEXT_ID,
+            resourceKind: 'query_index.vector',
+            resourceId: entityId,
+            retryLastMutation,
+          },
+          mutationPayload: { action, entityId, purgeFirst: action === 'purge' },
+        })
       } catch (err) {
         const message = err instanceof Error && err.message ? err.message : errorMessage
         console.warn('[query_index] vector action failed', message)
@@ -305,7 +337,7 @@ export default function QueryIndexesTable() {
       }
       qc.invalidateQueries({ queryKey: ['query-index-status'] })
     },
-    [confirm, qc, t],
+    [confirm, qc, t, runMutation, retryLastMutation],
   )
 
   const triggerFulltext = React.useCallback(
@@ -323,14 +355,24 @@ export default function QueryIndexesTable() {
         : t('query_index.table.actions.fulltextReindex')
       const errorMessage = t('query_index.table.errors.actionFailed', { action: actionLabel })
       try {
-        await apiCallOrThrow('/api/search/reindex', {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({
-            action: action === 'purge' ? 'clear' : 'reindex',
-            entityId,
-          }),
-        }, { errorMessage })
+        await runMutation({
+          operation: () =>
+            apiCallOrThrow('/api/search/reindex', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                action: action === 'purge' ? 'clear' : 'reindex',
+                entityId,
+              }),
+            }, { errorMessage }),
+          context: {
+            formId: MUTATION_CONTEXT_ID,
+            resourceKind: 'query_index.fulltext',
+            resourceId: entityId,
+            retryLastMutation,
+          },
+          mutationPayload: { action, entityId },
+        })
       } catch (err) {
         const message = err instanceof Error && err.message ? err.message : errorMessage
         console.warn('[query_index] fulltext action failed', message)
@@ -338,7 +380,7 @@ export default function QueryIndexesTable() {
       }
       qc.invalidateQueries({ queryKey: ['query-index-status'] })
     },
-    [confirm, qc, t],
+    [confirm, qc, t, runMutation, retryLastMutation],
   )
 
   return (

--- a/packages/core/src/modules/query_index/components/__tests__/QueryIndexesTable.guarded-mutation.test.tsx
+++ b/packages/core/src/modules/query_index/components/__tests__/QueryIndexesTable.guarded-mutation.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+
+const apiCallOrThrowMock = jest.fn()
+const readApiResultOrThrowMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCallOrThrow: (...args: unknown[]) => apiCallOrThrowMock(...args),
+  readApiResultOrThrow: (...args: unknown[]) => readApiResultOrThrowMock(...args),
+  withScopedApiRequestHeaders: (
+    _headers: Record<string, string>,
+    operation: () => Promise<unknown>,
+  ) => operation(),
+}))
+
+const flashMock = jest.fn()
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: (...args: unknown[]) => flashMock(...args),
+}))
+
+type RunMutationArgs = {
+  operation: () => Promise<unknown>
+  context: Record<string, unknown>
+  mutationPayload?: Record<string, unknown>
+}
+
+const runMutationMock = jest.fn(async ({ operation }: RunMutationArgs) => operation())
+const retryLastMutation = jest.fn(async () => true)
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({ runMutation: runMutationMock, retryLastMutation }),
+}))
+
+// Render the row actions as plain buttons so we can invoke them without
+// driving the RowActions dropdown — keeps the test focused on the guarded
+// mutation wiring rather than DataTable internals.
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  DataTable: ({ data, rowActions }: any) => (
+    <div>
+      {(data ?? []).map((row: any) => (
+        <div key={row.entityId}>{rowActions(row)}</div>
+      ))}
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/RowActions', () => ({
+  RowActions: ({ items }: any) => (
+    <div>
+      {(items ?? []).map((action: any) => (
+        <button key={action.id} data-action-id={action.id} onClick={() => action.onSelect()}>
+          {action.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+import QueryIndexesTable from '../QueryIndexesTable'
+
+async function findActionButton(actionId: string): Promise<HTMLButtonElement> {
+  return waitFor(() => {
+    const button = document.querySelector(`[data-action-id="${actionId}"]`)
+    if (!button) throw new Error(`row action "${actionId}" not rendered yet`)
+    return button as HTMLButtonElement
+  })
+}
+
+const statusRow = {
+  entityId: 'catalog:catalog_product',
+  label: 'Products',
+  vectorEnabled: false,
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  runMutationMock.mockImplementation(async ({ operation }: RunMutationArgs) => operation())
+  apiCallOrThrowMock.mockResolvedValue(undefined)
+  readApiResultOrThrowMock.mockResolvedValue({ items: [statusRow] })
+})
+
+describe('QueryIndexesTable guarded mutations', () => {
+  it('runs the reindex row action through the guarded mutation pipeline', async () => {
+    renderWithProviders(<QueryIndexesTable />)
+
+    const reindexButton = await findActionButton('reindex')
+
+    fireEvent.click(reindexButton)
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalledTimes(1))
+
+    const call = runMutationMock.mock.calls[0][0] as RunMutationArgs
+    expect(call.context).toEqual(
+      expect.objectContaining({
+        resourceKind: 'query_index',
+        resourceId: 'catalog:catalog_product',
+        retryLastMutation,
+      }),
+    )
+
+    await waitFor(() =>
+      expect(apiCallOrThrowMock).toHaveBeenCalledWith(
+        '/api/query_index/reindex',
+        expect.objectContaining({ method: 'POST' }),
+        expect.anything(),
+      ),
+    )
+  })
+
+  it('runs the purge row action through the guarded mutation pipeline', async () => {
+    renderWithProviders(<QueryIndexesTable />)
+
+    const purgeButton = await findActionButton('purge')
+
+    fireEvent.click(purgeButton)
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalledTimes(1))
+
+    const call = runMutationMock.mock.calls[0][0] as RunMutationArgs
+    expect(call.context).toEqual(
+      expect.objectContaining({
+        resourceKind: 'query_index',
+        resourceId: 'catalog:catalog_product',
+        retryLastMutation,
+      }),
+    )
+
+    await waitFor(() =>
+      expect(apiCallOrThrowMock).toHaveBeenCalledWith(
+        '/api/query_index/purge',
+        expect.objectContaining({ method: 'POST' }),
+        expect.anything(),
+      ),
+    )
+  })
+
+  it('routes the vector and fulltext reindex actions through guarded mutations', async () => {
+    readApiResultOrThrowMock.mockResolvedValue({
+      items: [{ ...statusRow, vectorEnabled: true, fulltextEnabled: true }],
+    })
+
+    renderWithProviders(<QueryIndexesTable />)
+
+    fireEvent.click(await findActionButton('vector-reindex'))
+    await waitFor(() =>
+      expect(apiCallOrThrowMock).toHaveBeenCalledWith(
+        '/api/search/embeddings/reindex',
+        expect.objectContaining({ method: 'POST' }),
+        expect.anything(),
+      ),
+    )
+    expect(runMutationMock.mock.calls.at(-1)?.[0].context).toEqual(
+      expect.objectContaining({ resourceKind: 'query_index.vector', retryLastMutation }),
+    )
+
+    fireEvent.click(await findActionButton('fulltext-reindex'))
+    await waitFor(() =>
+      expect(apiCallOrThrowMock).toHaveBeenCalledWith(
+        '/api/search/reindex',
+        expect.objectContaining({ method: 'POST' }),
+        expect.anything(),
+      ),
+    )
+    expect(runMutationMock.mock.calls.at(-1)?.[0].context).toEqual(
+      expect.objectContaining({ resourceKind: 'query_index.fulltext', retryLastMutation }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

The query index admin table started reindex/purge writes through raw API calls, and the custom `POST` routes (`api/reindex.ts`, `api/purge.ts`) never ran the mutation guard lifecycle. This bypassed the platform's global mutation injections for non-`CrudForm` writes, violating `packages/core/AGENTS.md` (custom write routes must call `validateCrudMutationGuard` / `runCrudMutationGuardAfterSuccess`) and `packages/ui/AGENTS.md` (non-`CrudForm` backend writes must go through `useGuardedMutation`). This routes all query-index reindex/purge writes through the guard lifecycle.

## Changes

- `components/QueryIndexesTable.tsx`: wrap the query-index, vector, and fulltext reindex/purge row actions in `useGuardedMutation(...).runMutation(...)`, passing `operation`, a `context` with `resourceKind`/`resourceId`/`retryLastMutation`, and a `mutationPayload`. Existing try/catch flash handling and the confirm-dialog flow are preserved.
- `api/reindex.ts`: call `validateCrudMutationGuard` before logging/queueing (returning the guard's status/body and skipping the write when rejected) and `runCrudMutationGuardAfterSuccess` after the event is accepted.
- `api/purge.ts`: same mutation-guard wiring.
- Tests: new `QueryIndexesTable.guarded-mutation.test.tsx` proving the UI row actions route through `runMutation`; extended `__tests__/api-queue-only.test.ts` proving both routes invoke the before/after guard hooks (ordered relative to the queued event) and that a rejecting guard blocks the write.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — bug fix within the ongoing guarded-mutation remediation campaign (one issue per module/surface); no spec file.

## Testing

- `yarn workspace @open-mercato/core test -- --testPathPattern "query_index/(__tests__/api-queue-only|components/__tests__/QueryIndexesTable.guarded-mutation)"` → 2 suites / 9 tests passed (red before fix, green after).
- `yarn workspace @open-mercato/core test -- --testPathPattern "query_index"` → 14 suites / 73 tests passed.
- `yarn i18n:check-sync` → all locales in sync.
- `yarn build:packages` → `yarn generate` → `yarn build:packages` → all succeeded.
- `yarn typecheck` → 21/21 packages clean.
- `yarn build:app` → Next.js build succeeded.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No new locale keys — reused the existing `ui.forms.flash.saveBlocked`; no generator/doc changes required.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — N/A: the issue's expected fix specifies UI + route unit tests proving the guard hooks; this is internal mutation-guard wiring with unchanged endpoints/payloads, so no new Playwright coverage is required.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A (campaign bug fix, no spec).
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium`, inherited from the issue.)
- [x] QA routing set: `needs-qa` (touches backend admin write actions). The endpoints/payloads are unchanged and unit-tested, so self-QA via clicking through the query-index reindex/purge actions is straightforward.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI markup/color classes added (behavior-preserving wiring change).
- [x] No arbitrary text sizes — N/A, no UI markup added.
- [x] Empty state handled for list/data pages — N/A, existing DataTable behavior preserved.
- [x] Loading state handled for async pages — N/A, existing `isLoading` preserved.
- [x] `aria-label` on all icon-only buttons — N/A, no new icon buttons.
- [x] Uses existing DS components — yes, no custom replacements (only wraps existing calls through `useGuardedMutation`).

## Linked issues

Fixes #3286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
