### PR TITLE
fix: enforce optimistic lock on planner date-specific availability replace (#3279)

### DIFF
--- a/packages/core/src/modules/planner/__integration__/TC-LOCK-OSS-038.spec.ts
+++ b/packages/core/src/modules/planner/__integration__/TC-LOCK-OSS-038.spec.ts
@@ -43,11 +43,21 @@ import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optim
  * API-level assertion (PLN-03 API) also proves the server refuses a stale DELETE
  * with the 409 optimistic-lock conflict body the false toast was masking.
  *
+ * PLN-04 (API, regression for issue #3279): the date-specific bulk replace
+ * endpoint `POST /api/planner/availability-date-specific` soft-deletes the
+ * one-off rules for a subject/date and recreates them via the command bus,
+ * bypassing the CRUD guard. Without a command-level optimistic-lock check two
+ * users editing the same subject/date silently last-write-wins. A header-
+ * carrying replace with a stale token must now be refused with the 409
+ * optimistic-lock conflict body, and a correctly-versioned replace must still
+ * succeed (no false positive).
+ *
  * See `packages/core/src/modules/sales/__integration__/__concurrent_edit_pattern.md`.
  */
 
 const RULE_SET_API = '/api/planner/availability-rule-sets'
 const AVAILABILITY_API = '/api/planner/availability'
+const DATE_SPECIFIC_API = '/api/planner/availability-date-specific'
 
 test.describe('TC-LOCK-OSS-038: planner availability lock (rule set + per-rule)', () => {
   test('PLN-01: stale availability rule set edit shows the conflict bar', async ({ page }) => {
@@ -224,6 +234,87 @@ test.describe('TC-LOCK-OSS-038: planner availability lock (rule set + per-rule)'
       await expectConflictBody(staleResponse)
     } finally {
       await deleteAvailabilityRuleIfExists(page.request, token, ruleId)
+      await deleteAvailabilityRuleSetIfExists(page.request, token, ruleSetId)
+    }
+  })
+
+  test('PLN-04: stale date-specific replace is refused with a 409 conflict body', async ({ page }) => {
+    const token = await getAuthToken(page.request, 'admin')
+    const stamp = Date.now()
+    const date = '2026-06-15'
+    let ruleSetId: string | null = null
+
+    const listOnceRuleIds = async (): Promise<string[]> => {
+      const response = await apiRequest(
+        page.request,
+        'GET',
+        `${AVAILABILITY_API}?subjectType=ruleset&subjectIds=${encodeURIComponent(ruleSetId as string)}`,
+        { token },
+      )
+      if (response.status() !== 200) return []
+      const body = await readJsonSafe<{ items?: Array<{ id?: string }> }>(response)
+      return (body?.items ?? []).map((item) => item.id).filter((id): id is string => typeof id === 'string')
+    }
+
+    const replaceDateSpecific = (lockValue?: string) =>
+      page.request.fetch(DATE_SPECIFIC_API, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          ...(lockValue !== undefined ? { [OPTIMISTIC_LOCK_HEADER_NAME]: lockValue } : {}),
+        },
+        data: {
+          subjectType: 'ruleset',
+          subjectId: ruleSetId,
+          timezone: 'UTC',
+          dates: [date],
+          windows: [{ start: '09:00', end: '17:00' }],
+          kind: 'availability',
+        },
+      })
+
+    try {
+      ruleSetId = await createAvailabilityRuleSetFixture(page.request, token, {
+        name: `QA Lock 038 PLN04 ${stamp}`,
+        timezone: 'UTC',
+      })
+
+      // Seed the subject/date aggregate via the real endpoint (header-less, additive).
+      const seed = await replaceDateSpecific()
+      expect(seed.status(), 'seeding the date-specific aggregate should succeed').toBe(200)
+
+      // Read the current aggregate version (the one-off rule's updated_at).
+      const listResponse = await apiRequest(
+        page.request,
+        'GET',
+        `${AVAILABILITY_API}?subjectType=ruleset&subjectIds=${encodeURIComponent(ruleSetId)}`,
+        { token },
+      )
+      expect(listResponse.status(), 'GET /api/planner/availability should return 200').toBe(200)
+      const listBody = await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(listResponse)
+      const seeded = listBody?.items?.[0]
+      expect(seeded, 'the seeded one-off availability rule should be listed for its subject').toBeTruthy()
+      const currentUpdatedAt = (seeded?.updated_at ?? seeded?.updatedAt) as string | undefined
+      expect(typeof currentUpdatedAt, 'availability rule should expose updated_at').toBe('string')
+
+      // A replace carrying a deliberately stale token must 409 and NOT mutate.
+      const staleIso = new Date(Date.parse(currentUpdatedAt as string) - 60_000).toISOString()
+      const staleResponse = await replaceDateSpecific(staleIso)
+      await expectConflictBody(staleResponse)
+
+      // The correctly-versioned token must still succeed (no false positive).
+      const freshResponse = await replaceDateSpecific(new Date(Date.parse(currentUpdatedAt as string)).toISOString())
+      expect(
+        freshResponse.status(),
+        `a current-version date-specific replace should succeed, got ${freshResponse.status()}`,
+      ).toBe(200)
+    } finally {
+      if (ruleSetId) {
+        for (const id of await listOnceRuleIds()) {
+          await deleteAvailabilityRuleIfExists(page.request, token, id)
+        }
+      }
       await deleteAvailabilityRuleSetIfExists(page.request, token, ruleSetId)
     }
   })

--- a/packages/core/src/modules/planner/api/availability-date-specific.ts
+++ b/packages/core/src/modules/planner/api/availability-date-specific.ts
@@ -140,6 +140,16 @@ export const openApi = {
         { status: 400, description: 'Invalid payload', schema: z.object({ error: z.string() }) },
         { status: 401, description: 'Unauthorized', schema: z.object({ error: z.string() }) },
         { status: 403, description: 'Forbidden', schema: z.object({ error: z.string() }) },
+        {
+          status: 409,
+          description: 'Conflict — the subject/date availability was modified by another edit',
+          schema: z.object({
+            error: z.string(),
+            code: z.string(),
+            currentUpdatedAt: z.string(),
+            expectedUpdatedAt: z.string(),
+          }),
+        },
       ],
     },
   },

--- a/packages/core/src/modules/planner/commands/__tests__/availability-date-specific.optimistic-lock.test.ts
+++ b/packages/core/src/modules/planner/commands/__tests__/availability-date-specific.optimistic-lock.test.ts
@@ -1,0 +1,166 @@
+/** @jest-environment node */
+
+/**
+ * Aggregate optimistic locking for the planner date-specific availability
+ * replace command (issue #3279).
+ *
+ * `planner.availability.date-specific.replace` soft-deletes the active one-off
+ * rules for the targeted subject/date(s) and creates replacements. It is a
+ * Command-pattern write that never reaches the CRUD guard, so without a
+ * command-level check two users editing the same subject/date silently
+ * last-write-wins. The aggregate has no single parent row, so the version is
+ * derived from the max `updated_at` of the one-off rules being replaced; the
+ * client sends that token via the optimistic-lock extension header. On mismatch
+ * the command throws the structured 409 BEFORE replacing any rows. Strictly
+ * additive: no header → no 409.
+ */
+
+import { createContainer, asValue, InjectionMode } from 'awilix'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (key: string) => key,
+  }),
+}))
+
+const ORG_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const TENANT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const SUBJECT_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const RULE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+
+const DATE = '2026-06-15'
+const CURRENT = '2026-05-25T08:42:20.999Z'
+const STALE = '2026-05-25T08:42:18.123Z'
+
+// Mirror the command's own DTSTART builder so the rule round-trips to the same
+// local calendar day under `parseAvailabilityRuleWindow` + `formatDateKey`
+// regardless of the host timezone (local noon is stable across all offsets).
+function buildOnceRrule(date: string, time = '12:00'): string {
+  const [year, month, day] = date.split('-').map((part) => Number(part))
+  const [hours, minutes] = time.split(':').map((part) => Number(part))
+  const start = new Date(year, month - 1, day, hours, minutes, 0, 0)
+  const dtStart = start.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z'
+  return `DTSTART:${dtStart}\nDURATION:PT1H\nRRULE:FREQ=DAILY;COUNT=1`
+}
+
+function makeExistingRule(updatedAt: string) {
+  return {
+    id: RULE_ID,
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    subjectType: 'ruleset',
+    subjectId: SUBJECT_ID,
+    timezone: 'UTC',
+    rrule: buildOnceRrule(DATE),
+    exdates: [],
+    kind: 'availability',
+    note: null,
+    unavailabilityReasonEntryId: null,
+    unavailabilityReasonValue: null,
+    createdAt: new Date(CURRENT),
+    updatedAt: new Date(updatedAt),
+    deletedAt: null,
+  }
+}
+
+function makeEm(existing: unknown[]) {
+  const em: Record<string, unknown> = {
+    find: jest.fn(async () => existing),
+    create: jest.fn((_cls: unknown, data: Record<string, unknown>) => ({ ...data })),
+    persist: jest.fn(() => undefined),
+    flush: jest.fn(async () => undefined),
+    transactional: jest.fn(async (cb: (trx: unknown) => Promise<void>) => {
+      await cb(em)
+    }),
+    fork() {
+      return this
+    },
+  }
+  return em
+}
+
+function makeRequest(headerValue: string | null): Request {
+  const headers = new Headers()
+  if (headerValue != null) headers.set(OPTIMISTIC_LOCK_HEADER_NAME, headerValue)
+  return new Request('https://example.test/api/planner/availability-date-specific', {
+    method: 'POST',
+    headers,
+  })
+}
+
+function makeCtx(em: unknown, request: Request) {
+  const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+  container.register({ em: asValue(em) })
+  return {
+    container,
+    auth: { tenantId: TENANT_ID, orgId: ORG_ID, sub: 'user-1' },
+    selectedOrganizationId: ORG_ID,
+    organizationScope: null,
+    organizationIds: null,
+    request,
+  }
+}
+
+const baseInput = {
+  tenantId: TENANT_ID,
+  organizationId: ORG_ID,
+  subjectType: 'ruleset',
+  subjectId: SUBJECT_ID,
+  timezone: 'UTC',
+  dates: [DATE],
+  windows: [{ start: '09:00', end: '17:00' }],
+  kind: 'availability',
+}
+
+describe('planner.availability.date-specific.replace — aggregate optimistic lock', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../availability-date-specific')
+  })
+
+  it('rejects a stale aggregate version with a 409 before replacing rows', async () => {
+    const em = makeEm([makeExistingRule(CURRENT)])
+    const ctx = makeCtx(em, makeRequest(STALE))
+    const handler = commandRegistry.get('planner.availability.date-specific.replace')
+    expect(handler).toBeTruthy()
+
+    let caught: unknown
+    try {
+      await handler!.execute(baseInput, ctx as never)
+    } catch (err) {
+      caught = err
+    }
+    expect(isCrudHttpError(caught)).toBe(true)
+    expect((caught as CrudHttpError).status).toBe(409)
+    expect((caught as CrudHttpError).body).toMatchObject({
+      code: 'optimistic_lock_conflict',
+      currentUpdatedAt: CURRENT,
+      expectedUpdatedAt: STALE,
+    })
+    // Proves the check fires before mutation: no replacement rows were created.
+    expect(em.create).not.toHaveBeenCalled()
+  })
+
+  it('passes when the header matches the aggregate version', async () => {
+    const em = makeEm([makeExistingRule(CURRENT)])
+    const ctx = makeCtx(em, makeRequest(CURRENT))
+    const handler = commandRegistry.get('planner.availability.date-specific.replace')
+
+    await expect(handler!.execute(baseInput, ctx as never)).resolves.toEqual({ ok: true })
+    expect(em.flush).toHaveBeenCalled()
+  })
+
+  it('is a no-op (no 409) when the client sends no header — strictly additive', async () => {
+    const em = makeEm([makeExistingRule(CURRENT)])
+    const ctx = makeCtx(em, makeRequest(null))
+    const handler = commandRegistry.get('planner.availability.date-specific.replace')
+
+    await expect(handler!.execute(baseInput, ctx as never)).resolves.toEqual({ ok: true })
+  })
+})

--- a/packages/core/src/modules/planner/commands/availability-date-specific.ts
+++ b/packages/core/src/modules/planner/commands/availability-date-specific.ts
@@ -9,9 +9,27 @@ import {
   type PlannerAvailabilityDateSpecificReplaceInput,
 } from '../data/validators'
 import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import type { PlannerAvailabilityKind, PlannerAvailabilitySubjectType } from '../data/entities'
 
 const AVAILABILITY_RULE_RESOURCE_KIND = 'planner.availability.rule'
+
+/**
+ * The date-specific aggregate (the one-off rules for a subject/date) has no
+ * single parent row, so its optimistic-lock version is the latest `updated_at`
+ * of the rules being replaced. The editor sends that token via the extension
+ * header; an empty set means "nothing to clobber" → no current version → the
+ * guard is a no-op (strictly additive, fail-open).
+ */
+function resolveAggregateLockVersion(rules: PlannerAvailabilityRule[]): Date | null {
+  let latest: Date | null = null
+  for (const rule of rules) {
+    const value = rule.updatedAt
+    if (!value || Number.isNaN(value.getTime())) continue
+    if (!latest || value.getTime() > latest.getTime()) latest = value
+  }
+  return latest
+}
 
 type AvailabilityRuleSnapshot = {
   id: string
@@ -206,6 +224,12 @@ const replaceDateSpecificAvailabilityCommand: CommandHandler<PlannerAvailability
           const window = parseAvailabilityRuleWindow(rule)
           if (window.repeat !== 'once') return false
           return dates.has(formatDateKey(window.startAt))
+        })
+        enforceCommandOptimisticLock({
+          resourceKind: AVAILABILITY_RULE_RESOURCE_KIND,
+          resourceId: `${parsed.subjectType}:${parsed.subjectId}`,
+          current: resolveAggregateLockVersion(toDelete),
+          request: ctx.request ?? null,
         })
         toDelete.forEach((rule) => {
           rule.deletedAt = now

--- a/packages/core/src/modules/planner/components/AvailabilityRulesEditor.tsx
+++ b/packages/core/src/modules/planner/components/AvailabilityRulesEditor.tsx
@@ -29,6 +29,7 @@ import {
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 import { normalizeCrudServerError } from '@open-mercato/ui/backend/utils/serverErrors'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { parseAvailabilityRuleWindow } from '@open-mercato/core/modules/planner/lib/availabilitySchedule'
 import { deleteAvailabilityRuleSet } from '@open-mercato/core/modules/planner/lib/deleteAvailabilityRuleSet'
 import { CrudForm, type CrudField } from '@open-mercato/ui/backend/CrudForm'
@@ -106,6 +107,30 @@ function withOptimisticLockForRule<T>(rule: AvailabilityRule, mutation: () => Pr
 
 function withOptimisticLockForRuleSet<T>(ruleSet: AvailabilityRuleSet | null | undefined, mutation: () => Promise<T>): Promise<T> {
   return withScopedApiRequestHeaders(buildOptimisticLockHeader(ruleSet?.updatedAt ?? ruleSet?.updated_at ?? null), mutation)
+}
+
+/**
+ * The date-specific replace endpoint mutates a subject/date aggregate that has
+ * no single parent row, so its lock version is the latest `updated_at` of the
+ * one-off rules being replaced (mirrors the command-side derivation). Returns
+ * null when no existing rules back the date so the header is omitted (additive).
+ */
+function resolveDateSpecificLockToken(rules: AvailabilityRule[]): string | null {
+  let latestMs = Number.NEGATIVE_INFINITY
+  let latestIso: string | null = null
+  for (const rule of rules) {
+    const raw = rule.updatedAt ?? rule.updated_at ?? null
+    if (!raw) continue
+    const ms = Date.parse(raw)
+    if (!Number.isFinite(ms) || ms <= latestMs) continue
+    latestMs = ms
+    latestIso = raw
+  }
+  return latestIso
+}
+
+function withOptimisticLockForDateSpecific<T>(rules: AvailabilityRule[], mutation: () => Promise<T>): Promise<T> {
+  return withScopedApiRequestHeaders(buildOptimisticLockHeader(resolveDateSpecificLockToken(rules)), mutation)
 }
 
 const DAY_LABELS = [
@@ -1299,11 +1324,11 @@ export function AvailabilityRulesEditor({
           unavailabilityReasonEntryId: editorUnavailable ? reasonEntryId : null,
           unavailabilityReasonValue: editorUnavailable ? reasonValue : null,
         }
-        await apiCallOrThrow('/api/planner/availability-date-specific', {
+        await withOptimisticLockForDateSpecific(editorRules, () => apiCallOrThrow('/api/planner/availability-date-specific', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
-        }, { errorMessage: listLabels.saveDateError })
+        }, { errorMessage: listLabels.saveDateError }))
       } else {
         const rulesToDelete = editorRules
         const uniqueRulesById = new Map(rulesToDelete.map((rule) => [rule.id, rule]))
@@ -1338,6 +1363,7 @@ export function AvailabilityRulesEditor({
       await refreshAvailability()
       await refreshRuleSetRules()
     } catch (error) {
+      if (surfaceRecordConflict(error, t)) return
       const message = error instanceof Error ? error.message : listLabels.saveDateError
       flash(message, 'error')
     }
@@ -1364,6 +1390,7 @@ export function AvailabilityRulesEditor({
     usingRuleSet,
     canManageUnavailability,
     isReadOnly,
+    t,
   ])
 
   const handleSlotClick = React.useCallback((slot: ScheduleSlot) => {


### PR DESCRIPTION
## Summary

`POST /api/planner/availability-date-specific` replaces a subject/date availability aggregate by soft-deleting the matching one-off rules and recreating them through the command bus, bypassing the `makeCrudRoute` optimistic-lock guard. The command enforced no version check and the editor sent no expected-version header, so two users editing the same subject/date got last-write-wins instead of a 409 conflict.

This adds command-level optimistic locking for the date-specific aggregate (version derived from the latest `updated_at` of the one-off rules being replaced), makes the editor send that token and surface 409s through the unified conflict bar, and adds regression coverage. Strictly additive: clients that send no lock header are unaffected.

## Changes

- `commands/availability-date-specific.ts`: enforce `enforceCommandOptimisticLock` for the `planner.availability.rule` aggregate (resourceId `subjectType:subjectId`) before soft-deleting/creating, using `max(updatedAt)` of the rules being replaced as the current version (mirrors `sales` `enforceSalesDocumentOptimisticLock`). Empty set → no current version → no-op.
- `api/availability-date-specific.ts`: document the `409` optimistic-lock conflict response in `openApi` (the route's existing `isCrudHttpError` catch already returns the structured body).
- `components/AvailabilityRulesEditor.tsx`: new `withOptimisticLockForDateSpecific(...)` attaches the loaded rules' latest `updated_at` as the `x-om-ext-optimistic-lock-expected-updated-at` header on the date-specific POST; the submit catch now calls `surfaceRecordConflict(error, t)` so a 409 shows the unified conflict bar instead of a generic flash.
- Tests: new jest command test (stale → 409 before mutation / match → ok / no-header → additive) and `TC-LOCK-OSS-038` PLN-04 integration regression for stale `POST /api/planner/availability-date-specific`.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/2026-05-28-optimistic-locking-coverage-completion.md` (command-level / coverage-completion). This PR closes the date-specific bulk-replace gap that spec scopes; the spec document itself was not modified.

## Testing

- `yarn workspace @open-mercato/core test --testPathPattern "availability-date-specific.optimistic-lock"` — red on pre-fix code (no 409 thrown), green after the fix; 3/3.
- `yarn workspace @open-mercato/core test --testPathPattern planner` — 32/32 passed (7 suites).
- `yarn typecheck` — pass (core recompiled clean, including the edited `__integration__` spec).
- `yarn build:packages` — pass (21/21).
- `yarn i18n:check-sync` — pass (en/de/es/pl in sync).
- `yarn build:app` — pass (Next.js compiled + TypeScript clean).
- `TC-LOCK-OSS-038` PLN-04 (Playwright) added and typechecks; exercised in CI's integration pipeline.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (openApi 409 documented; no new locale keys — reuses the existing `ui.forms.flash.recordModified`.)
- [x] I added or adjusted tests that cover the change. (jest command test, red→green.)
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Module-local `__integration__/TC-LOCK-OSS-038.spec.ts` PLN-04, per the repo's module-local convention.)
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (Existing coverage spec already scopes this gap; spec doc not modified.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — single-module change with tests, additive.)
- [x] QA routing set: `needs-qa` (customer-facing concurrent-edit conflict surfacing in the availability editor).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — no new color classes added (conflict UI is the existing shared `RecordConflictBanner`).
- [x] No arbitrary text sizes (`text-[Npx]`) — none added.
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) — N/A (no new list/data page).
- [x] Loading state handled for async pages — N/A (no new async page).
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) — N/A (no new icon-only buttons).
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — reuses the shared conflict bar via `surfaceRecordConflict`; no custom replacements.

## Linked issues

Fixes #3279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
