### PR TITLE
fix: route non-CrudForm planner availability writes through useGuardedMutation (#3281)

### DIFF
--- a/packages/core/src/modules/planner/backend/planner/availability-rulesets/__tests__/page.test.tsx
+++ b/packages/core/src/modules/planner/backend/planner/availability-rulesets/__tests__/page.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import PlannerAvailabilityRuleSetsPage from '../page'
+
+const runMutationMock = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+const retryLastMutationMock = jest.fn()
+const deleteCrudMock = jest.fn(async () => ({ ok: true }))
+const readApiResultOrThrowMock = jest.fn()
+const confirmMock = jest.fn(async () => true)
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: (...args: unknown[]) => runMutationMock(...(args as [{ operation: () => Promise<unknown> }])),
+    retryLastMutation: retryLastMutationMock,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  readApiResultOrThrow: (...args: unknown[]) => readApiResultOrThrowMock(...args),
+  withScopedApiRequestHeaders: (_headers: unknown, fn: () => Promise<unknown>) => fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  deleteCrud: (...args: unknown[]) => deleteCrudMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/serverErrors', () => ({
+  normalizeCrudServerError: (error: unknown) => ({ message: error instanceof Error ? error.message : null }),
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({
+    confirm: (...args: unknown[]) => confirmMock(...args),
+    ConfirmDialogElement: null,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 0,
+}))
+
+jest.mock('@open-mercato/shared/lib/time', () => ({
+  formatDateTime: (value: string) => value,
+}))
+
+jest.mock('@open-mercato/ui/backend/markdown/markdownToPlainText', () => ({
+  markdownToPlainText: (value: string) => value,
+}))
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PageBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('@open-mercato/ui/backend/RowActions', () => ({
+  RowActions: ({ items }: { items: Array<{ id: string; label: string; onSelect?: () => void }> }) => (
+    <>
+      {items.map((item) => (
+        <button key={item.id} type="button" onClick={item.onSelect} disabled={!item.onSelect}>
+          {item.label}
+        </button>
+      ))}
+    </>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  withDataTableNamespaces: (row: Record<string, unknown>) => row,
+  DataTable: ({
+    data,
+    rowActions,
+  }: {
+    data: Array<Record<string, unknown>>
+    rowActions?: (row: Record<string, unknown>) => React.ReactNode
+  }) => (
+    <div data-testid="data-table">
+      {(Array.isArray(data) ? data : []).map((row, index) => (
+        <div key={index}>{rowActions ? rowActions(row) : null}</div>
+      ))}
+    </div>
+  ),
+}))
+
+describe('PlannerAvailabilityRuleSetsPage — guarded mutation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    confirmMock.mockResolvedValue(true)
+    readApiResultOrThrowMock.mockResolvedValue({
+      items: [
+        {
+          id: 'rule-set-1',
+          name: 'Weekdays',
+          description: null,
+          timezone: 'Europe/Warsaw',
+          updatedAt: '2026-06-01T10:00:00.000Z',
+        },
+      ],
+      total: 1,
+      totalPages: 1,
+    })
+  })
+
+  it('routes the rule-set delete through useGuardedMutation with the optimistic-lock-aware operation', async () => {
+    renderWithProviders(<PlannerAvailabilityRuleSetsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalledTimes(1))
+
+    expect(runMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          resourceKind: 'planner.availability_rule_set',
+          retryLastMutation: expect.any(Function),
+        }),
+        mutationPayload: expect.objectContaining({ action: 'delete', id: 'rule-set-1' }),
+      }),
+    )
+
+    expect(deleteCrudMock).toHaveBeenCalledWith(
+      'planner/availability-rule-sets',
+      'rule-set-1',
+      expect.any(Object),
+    )
+  })
+})

--- a/packages/core/src/modules/planner/backend/planner/availability-rulesets/page.tsx
+++ b/packages/core/src/modules/planner/backend/planner/availability-rulesets/page.tsx
@@ -11,6 +11,7 @@ import { RowActions } from '@open-mercato/ui/backend/RowActions'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { deleteCrud } from '@open-mercato/ui/backend/utils/crud'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { normalizeCrudServerError } from '@open-mercato/ui/backend/utils/serverErrors'
@@ -41,6 +42,23 @@ export default function PlannerAvailabilityRuleSetsPage() {
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
   const router = useRouter()
   const scopeVersion = useOrganizationScopeVersion()
+  const mutationContextId = 'planner-availability-rule-sets'
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: mutationContextId,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const mutationContext = React.useMemo(
+    () => ({
+      formId: mutationContextId,
+      resourceKind: 'planner.availability_rule_set',
+      retryLastMutation,
+    }),
+    [mutationContextId, retryLastMutation],
+  )
   const [rows, setRows] = React.useState<RuleSetRow[]>([])
   const [page, setPage] = React.useState(1)
   const [total, setTotal] = React.useState(0)
@@ -127,10 +145,13 @@ export default function PlannerAvailabilityRuleSetsPage() {
     })
     if (!confirmed) return
     try {
-      const headers = buildOptimisticLockHeader(entry.updatedAt)
-      await withScopedApiRequestHeaders(headers, () => (
-        deleteCrud('planner/availability-rule-sets', entry.id, { errorMessage: labels.errors.delete })
-      ))
+      await runMutation({
+        operation: () => withScopedApiRequestHeaders(buildOptimisticLockHeader(entry.updatedAt), () => (
+          deleteCrud('planner/availability-rule-sets', entry.id, { errorMessage: labels.errors.delete })
+        )),
+        context: mutationContext,
+        mutationPayload: { action: 'delete', id: entry.id },
+      })
       flash(labels.messages.deleted, 'success')
       handleRefresh()
     } catch (error) {
@@ -138,7 +159,7 @@ export default function PlannerAvailabilityRuleSetsPage() {
       const normalized = normalizeCrudServerError(error)
       flash(normalized.message ?? labels.errors.delete, 'error')
     }
-  }, [confirm, handleRefresh, labels.actions.deleteConfirm, labels.errors.delete, labels.messages.deleted])
+  }, [confirm, handleRefresh, labels.actions.deleteConfirm, labels.errors.delete, labels.messages.deleted, mutationContext, runMutation])
 
   const columns = React.useMemo<ColumnDef<RuleSetRow>[]>(() => [
     {

--- a/packages/core/src/modules/planner/components/AvailabilityRulesEditor.tsx
+++ b/packages/core/src/modules/planner/components/AvailabilityRulesEditor.tsx
@@ -16,6 +16,7 @@ import {
 import { LoadingMessage, ErrorMessage } from '@open-mercato/ui/backend/detail'
 import { apiCall, apiCallOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { createCrud, deleteCrud, updateCrud } from '@open-mercato/ui/backend/utils/crud'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
@@ -381,6 +382,23 @@ export function AvailabilityRulesEditor({
 }: AvailabilityRulesEditorProps) {
   const t = useT()
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
+  const mutationContextId = 'planner-availability-rules-editor'
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: mutationContextId,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const mutationContext = React.useMemo(
+    () => ({
+      formId: mutationContextId,
+      resourceKind: 'planner.availability',
+      retryLastMutation,
+    }),
+    [mutationContextId, retryLastMutation],
+  )
   const isReadOnly = Boolean(readOnly)
   const canManageUnavailability = allowUnavailability ?? true
   const dialogRef = React.useRef<HTMLDivElement | null>(null)
@@ -818,16 +836,20 @@ export function AvailabilityRulesEditor({
     setIsWeeklyAutoSaving(options?.silentSuccess === true)
     try {
       const windows = buildWeeklyPayload(normalizeWeeklyWindows(weeklyWindowsRef.current))
-      await apiCallOrThrow('/api/planner/availability-weekly', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          subjectType: subjectForRules,
-          subjectId: subjectIdForRules,
-          timezone,
-          windows,
-        }),
-      }, { errorMessage: listLabels.saveWeeklyError })
+      await runMutation({
+        operation: () => apiCallOrThrow('/api/planner/availability-weekly', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            subjectType: subjectForRules,
+            subjectId: subjectIdForRules,
+            timezone,
+            windows,
+          }),
+        }, { errorMessage: listLabels.saveWeeklyError }),
+        context: mutationContext,
+        mutationPayload: { action: 'save-weekly', subjectType: subjectForRules, subjectId: subjectIdForRules },
+      })
       lastSavedWeeklyKeyRef.current = weeklyKey
       weeklyDirtyRef.current = false
       if (!options?.silentSuccess) {
@@ -856,6 +878,8 @@ export function AvailabilityRulesEditor({
     weeklyHasErrors,
     weeklyKey,
     isReadOnly,
+    mutationContext,
+    runMutation,
   ])
 
   React.useEffect(() => {
@@ -929,7 +953,11 @@ export function AvailabilityRulesEditor({
         )))
       }
       if (updates.length) {
-        await Promise.all(updates)
+        await runMutation({
+          operation: () => Promise.all(updates),
+          context: mutationContext,
+          mutationPayload: { action: 'update-timezone', timezone: trimmedTimezone },
+        })
         await refreshAvailability()
         await refreshRuleSetRules()
       }
@@ -951,6 +979,8 @@ export function AvailabilityRulesEditor({
     subjectId,
     subjectType,
     isReadOnly,
+    mutationContext,
+    runMutation,
   ])
 
   React.useEffect(() => {
@@ -990,14 +1020,18 @@ export function AvailabilityRulesEditor({
         kind: rule.kind ?? 'availability',
         note: rule.note ?? null,
       }))
-      await Promise.all(creations)
+      await runMutation({
+        operation: () => Promise.all(creations),
+        context: mutationContext,
+        mutationPayload: { action: 'customize', count: creations.length },
+      })
       setCustomOverridesEnabled(true)
       await refreshAvailability()
     } catch (error) {
       const message = error instanceof Error ? error.message : listLabels.saveWeeklyError
       flash(message, 'error')
     }
-  }, [effectiveRulesetId, listLabels.saveWeeklyError, refreshAvailability, rulesetRules, subjectId, subjectType, isReadOnly])
+  }, [effectiveRulesetId, listLabels.saveWeeklyError, refreshAvailability, rulesetRules, subjectId, subjectType, isReadOnly, mutationContext, runMutation])
 
   const handleResetToRuleSet = React.useCallback(async () => {
     if (isReadOnly) return
@@ -1012,21 +1046,25 @@ export function AvailabilityRulesEditor({
     try {
       const idsToDelete = selectCustomRuleIdsToDelete('reset', availabilityRules)
       const idsToDeleteSet = new Set(idsToDelete)
-      await Promise.all(
-        availabilityRules
-          .filter((rule) => idsToDeleteSet.has(rule.id))
-          .map((rule) => withOptimisticLockForRule(
-            rule,
-            () => deleteCrud('planner/availability', rule.id, { errorMessage: listLabels.saveWeeklyError }),
-          )),
-      )
+      await runMutation({
+        operation: () => Promise.all(
+          availabilityRules
+            .filter((rule) => idsToDeleteSet.has(rule.id))
+            .map((rule) => withOptimisticLockForRule(
+              rule,
+              () => deleteCrud('planner/availability', rule.id, { errorMessage: listLabels.saveWeeklyError }),
+            )),
+        ),
+        context: mutationContext,
+        mutationPayload: { action: 'reset-to-ruleset', ids: idsToDelete },
+      })
       setCustomOverridesEnabled(false)
       await refreshAvailability()
     } catch (error) {
       const message = error instanceof Error ? error.message : listLabels.saveWeeklyError
       flash(message, 'error')
     }
-  }, [availabilityRules, confirm, effectiveRulesetId, listLabels.ruleSetConfirm, listLabels.saveWeeklyError, refreshAvailability, isReadOnly])
+  }, [availabilityRules, confirm, effectiveRulesetId, listLabels.ruleSetConfirm, listLabels.saveWeeklyError, refreshAvailability, isReadOnly, mutationContext, runMutation])
 
   const handleRuleSetChange = React.useCallback(async (nextId: string | null) => {
     if (isReadOnly) return
@@ -1035,14 +1073,18 @@ export function AvailabilityRulesEditor({
     const idsToDelete = selectCustomRuleIdsToDelete('switch', availabilityRules)
     if (idsToDelete.length) {
       const idsToDeleteSet = new Set(idsToDelete)
-      await Promise.all(
-        availabilityRules
-          .filter((rule) => idsToDeleteSet.has(rule.id))
-          .map((rule) => withOptimisticLockForRule(
-            rule,
-            () => deleteCrud('planner/availability', rule.id, { errorMessage: listLabels.saveWeeklyError }),
-          )),
-      )
+      await runMutation({
+        operation: () => Promise.all(
+          availabilityRules
+            .filter((rule) => idsToDeleteSet.has(rule.id))
+            .map((rule) => withOptimisticLockForRule(
+              rule,
+              () => deleteCrud('planner/availability', rule.id, { errorMessage: listLabels.saveWeeklyError }),
+            )),
+        ),
+        context: mutationContext,
+        mutationPayload: { action: 'switch-ruleset', ids: idsToDelete },
+      })
     }
     setSelectedRulesetId(nextId)
     setCustomOverridesEnabled(false)
@@ -1060,6 +1102,8 @@ export function AvailabilityRulesEditor({
     onRulesetChange,
     refreshAvailability,
     isReadOnly,
+    mutationContext,
+    runMutation,
   ])
 
   const handleDeleteRuleSet = React.useCallback(async () => {
@@ -1076,9 +1120,13 @@ export function AvailabilityRulesEditor({
       deleteRuleSet: async (id) => {
         // Version-check the schedule delete (the list page already does; the editor
         // previously sent no header → last-write-wins on delete). #2055 round-5.
-        await withOptimisticLockForRuleSet(selected, () => (
-          deleteCrud('planner/availability-rule-sets', id, { errorMessage: listLabels.ruleSetDeleteError })
-        ))
+        await runMutation({
+          operation: () => withOptimisticLockForRuleSet(selected, () => (
+            deleteCrud('planner/availability-rule-sets', id, { errorMessage: listLabels.ruleSetDeleteError })
+          )),
+          context: mutationContext,
+          mutationPayload: { action: 'delete-ruleset', id },
+        })
       },
       clearAssignment: async () => {
         setCustomOverridesEnabled(false)
@@ -1105,6 +1153,8 @@ export function AvailabilityRulesEditor({
     refreshRuleSets,
     ruleSets,
     rulesetId,
+    mutationContext,
+    runMutation,
   ])
 
   const ruleSetFormSchema = React.useMemo(
@@ -1658,12 +1708,16 @@ export function AvailabilityRulesEditor({
                                 variant="outline"
                                 size="icon"
                                 onClick={async () => {
-                                  await Promise.all(
-                                    rules.map((rule) => withOptimisticLockForRule(
-                                      rule,
-                                      () => deleteCrud('planner/availability', rule.id),
-                                    )),
-                                  )
+                                  await runMutation({
+                                    operation: () => Promise.all(
+                                      rules.map((rule) => withOptimisticLockForRule(
+                                        rule,
+                                        () => deleteCrud('planner/availability', rule.id),
+                                      )),
+                                    ),
+                                    context: mutationContext,
+                                    mutationPayload: { action: 'delete-date-rules', count: rules.length },
+                                  })
                                   await refreshAvailability()
                                   await refreshRuleSetRules()
                                 }}


### PR DESCRIPTION
## Summary

Planner had several hand-built availability write paths that cannot use `CrudForm` but
called `apiCallOrThrow` / `createCrud` / `updateCrud` / `deleteCrud` directly, bypassing
`useGuardedMutation(...).runMutation(...)`. As a result the global mutation-injection path
(`onBeforeSave`/`onAfterSave`), the retry context (`retryLastMutation`), and the unified
optimistic-lock 409 conflict bar never ran for those writes. This routes every genuinely
non-`CrudForm` planner write through `runMutation`, while leaving `CrudForm`-hosted
`onSubmit`/`onDelete` handlers untouched (CrudForm already owns the lock header + conflict
surfacing — re-wrapping them would double-fire injection and conflict UX).

## Changes

- `AvailabilityRulesEditor.tsx`: add `useGuardedMutation` + a memoized mutation context, and
  route 7 non-CrudForm write sites through `runMutation` (weekly auto-save, timezone persist,
  customize, reset-to-ruleset, switch-ruleset, ruleset delete, inline date-row delete). Per-record
  `withOptimisticLockForRule`/`withOptimisticLockForRuleSet` headers stay inside each `operation`
  so each child keeps its own version; refreshes stay outside; `useCallback` deps updated.
- `backend/planner/availability-rulesets/page.tsx`: route the DataTable row delete through
  `runMutation`, with the optimistic-lock header inlined into the operation.
- Added a jsdom regression test asserting the rule-set delete goes through `runMutation` with the
  right context (`resourceKind` + `retryLastMutation`) and that `deleteCrud` fires inside it.
- Intentionally unchanged: editor CrudForm `onSubmit`s (`handleEditorSubmit`, `handleCreateRuleSet`)
  and `AvailabilitySchedule.tsx` — those are CrudForm-hosted writes already covered by CrudForm.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — per-module remediation bug fix in the guarded-mutation campaign; mirrors merged siblings
(e.g. #3201). Background context: `.ai/specs/implemented/2026-05-25-oss-optimistic-locking.md`.

## Testing

- `yarn workspace @open-mercato/core test` → 742 suites / 6067 tests pass (incl. the new
  `availability-rulesets/__tests__/page.test.tsx` and `optimistic-lock-ui-coverage.test.ts`).
- New repro test verified RED on pre-fix code (0 `runMutation` calls) → GREEN after the fix.
- `yarn workspace @open-mercato/core typecheck` → pass (21/21 packages).
- `yarn i18n:check-sync` → all 4 locales in sync.
- `yarn build:app` → compiled successfully (TypeScript pass).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no new locale keys or generated files; reuses the existing `ui.forms.flash.saveBlocked` key.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (N/A — no new API surface; the change is client mutation-wiring, covered by a jsdom render test; the guarded-mutation conflict UX is platform-level and already integration-covered.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — per-module campaign bug fix, no dedicated spec.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — single-module UI change shipping with tests.)
- [x] QA routing set: `needs-qa` (backend availability-editing UI behavior change). `skip-qa` is defensible (no visual change; conflict UX is platform-tested), but `needs-qa` is the safer default for a customer-facing backend flow.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI markup changed (mutation-wiring only).
- [x] No arbitrary text sizes — N/A, no UI markup changed.
- [x] Empty state handled for list/data pages — N/A, list rendering unchanged (page already has `emptyState`).
- [x] Loading state handled for async pages — N/A, already handled; unchanged.
- [x] `aria-label` on all icon-only buttons — N/A, the touched inline delete button already has `aria-label` (unchanged).
- [x] Uses existing DS components — N/A, no components added.

## Linked issues

Fixes #3281
