### PR TITLE
fix(planner): wire availability bulk POST routes through mutation guard lifecycle (#3280)

### DIFF
--- a/packages/core/src/modules/planner/api/__tests__/availability-mutation-guard.test.ts
+++ b/packages/core/src/modules/planner/api/__tests__/availability-mutation-guard.test.ts
@@ -1,0 +1,180 @@
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const subjectId = '33333333-3333-4333-8333-333333333333'
+const actorId = '44444444-4444-4444-8444-444444444444'
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const commandBusExecuteMock = jest.fn()
+const assertAvailabilityWriteAccessMock = jest.fn()
+const parseScopedCommandInputMock = jest.fn()
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'commandBus') return { execute: (...args: unknown[]) => commandBusExecuteMock(...args) }
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: actorId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({ selectedId: organizationId, filterIds: [organizationId] })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({ translate: (_key: string, fallback?: string) => fallback ?? 'error' })),
+}))
+
+jest.mock('@open-mercato/shared/lib/api/scoped', () => ({
+  parseScopedCommandInput: (...args: unknown[]) => parseScopedCommandInputMock(...args),
+}))
+
+jest.mock('../access', () => {
+  const actual = jest.requireActual('../access')
+  return {
+    ...actual,
+    assertAvailabilityWriteAccess: (...args: unknown[]) => assertAvailabilityWriteAccessMock(...args),
+  }
+})
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+import { POST as replaceWeekly } from '../availability-weekly'
+import { POST as replaceDateSpecific } from '../availability-date-specific'
+
+const weeklyInput = {
+  tenantId,
+  organizationId,
+  subjectType: 'member' as const,
+  subjectId,
+  timezone: 'UTC',
+  windows: [],
+}
+
+const dateSpecificInput = {
+  tenantId,
+  organizationId,
+  subjectType: 'member' as const,
+  subjectId,
+  timezone: 'UTC',
+  date: '2026-04-11',
+  dates: ['2026-04-11'],
+  windows: [],
+  isAvailable: true,
+}
+
+const expectedGuardInput = {
+  tenantId,
+  organizationId,
+  userId: actorId,
+  resourceKind: 'planner.availability',
+  resourceId: subjectId,
+  operation: 'custom',
+}
+
+function makeRequest(path: string, body: unknown): Request {
+  return new Request(`http://localhost/api/planner/${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('planner availability bulk replace routes — mutation guard lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    assertAvailabilityWriteAccessMock.mockResolvedValue({
+      canManageAll: true,
+      canManageSelf: true,
+      canManageUnavailability: true,
+      memberId: subjectId,
+      tenantId,
+      organizationId,
+    })
+    commandBusExecuteMock.mockResolvedValue({ logEntry: null })
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+  })
+
+  describe('weekly availability replace', () => {
+    beforeEach(() => {
+      parseScopedCommandInputMock.mockReturnValue(weeklyInput)
+    })
+
+    it('runs the mutation guard before and after a successful replace', async () => {
+      const response = await replaceWeekly(makeRequest('availability-weekly', { subjectType: 'member', subjectId, windows: [] }))
+
+      expect(response.status).toBe(200)
+      expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining(expectedGuardInput),
+      )
+      expect(commandBusExecuteMock).toHaveBeenCalledWith('planner.availability.weekly.replace', expect.anything())
+      expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({ ...expectedGuardInput, metadata: { token: 'guard' } }),
+      )
+    })
+
+    it('blocks the replace when a registered guard rejects it', async () => {
+      validateCrudMutationGuardMock.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        body: { error: { code: 'RECORD_LOCKED' } },
+      })
+
+      const response = await replaceWeekly(makeRequest('availability-weekly', { subjectType: 'member', subjectId, windows: [] }))
+
+      expect(response.status).toBe(409)
+      await expect(response.json()).resolves.toMatchObject({ error: { code: 'RECORD_LOCKED' } })
+      expect(commandBusExecuteMock).not.toHaveBeenCalled()
+      expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('date-specific availability replace', () => {
+    beforeEach(() => {
+      parseScopedCommandInputMock.mockReturnValue(dateSpecificInput)
+    })
+
+    it('runs the mutation guard before and after a successful replace', async () => {
+      const response = await replaceDateSpecific(makeRequest('availability-date-specific', { subjectType: 'member', subjectId, date: '2026-04-11', windows: [] }))
+
+      expect(response.status).toBe(200)
+      expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining(expectedGuardInput),
+      )
+      expect(commandBusExecuteMock).toHaveBeenCalledWith('planner.availability.date-specific.replace', expect.anything())
+      expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+        container,
+        expect.objectContaining({ ...expectedGuardInput, metadata: { token: 'guard' } }),
+      )
+    })
+
+    it('blocks the replace when a registered guard rejects it', async () => {
+      validateCrudMutationGuardMock.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        body: { error: { code: 'RECORD_LOCKED' } },
+      })
+
+      const response = await replaceDateSpecific(makeRequest('availability-date-specific', { subjectType: 'member', subjectId, date: '2026-04-11', windows: [] }))
+
+      expect(response.status).toBe(409)
+      await expect(response.json()).resolves.toMatchObject({ error: { code: 'RECORD_LOCKED' } })
+      expect(commandBusExecuteMock).not.toHaveBeenCalled()
+      expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/modules/planner/api/access.ts
+++ b/packages/core/src/modules/planner/api/access.ts
@@ -79,3 +79,12 @@ export async function assertAvailabilityWriteAccess(
   }
   return access
 }
+
+export function resolveAvailabilityActorId(auth: AuthContext): string {
+  if (auth) {
+    if (typeof auth.sub === 'string' && auth.sub.trim().length > 0) return auth.sub
+    if (typeof auth.userId === 'string' && auth.userId.trim().length > 0) return auth.userId
+    if (typeof auth.keyId === 'string' && auth.keyId.trim().length > 0) return auth.keyId
+  }
+  return 'system'
+}

--- a/packages/core/src/modules/planner/api/availability-date-specific.ts
+++ b/packages/core/src/modules/planner/api/availability-date-specific.ts
@@ -11,9 +11,13 @@ import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { plannerAvailabilityDateSpecificReplaceSchema } from '../data/validators'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { PlannerAvailabilityRule } from '../data/entities'
 import { parseAvailabilityRuleWindow } from '../lib/availabilitySchedule'
-import { assertAvailabilityWriteAccess } from './access'
+import { assertAvailabilityWriteAccess, resolveAvailabilityActorId } from './access'
 
 export const metadata = {
   POST: { requireAuth: true },
@@ -93,8 +97,25 @@ export async function POST(req: Request) {
         }
       }
     }
+    const guardInput = {
+      tenantId: input.tenantId,
+      organizationId: input.organizationId,
+      userId: resolveAvailabilityActorId(ctx.auth),
+      resourceKind: 'planner.availability',
+      resourceId: input.subjectId,
+      operation: 'custom' as const,
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+    }
+    const guardResult = await validateCrudMutationGuard(ctx.container, { ...guardInput, mutationPayload: input })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
     const commandBus = ctx.container.resolve('commandBus') as CommandBus
     const { logEntry } = await commandBus.execute('planner.availability.date-specific.replace', { input, ctx })
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, { ...guardInput, metadata: guardResult.metadata ?? null })
+    }
     const response = NextResponse.json({ ok: true })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(

--- a/packages/core/src/modules/planner/api/availability-weekly.ts
+++ b/packages/core/src/modules/planner/api/availability-weekly.ts
@@ -9,7 +9,11 @@ import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/er
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import { plannerAvailabilityWeeklyReplaceSchema } from '../data/validators'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
-import { assertAvailabilityWriteAccess } from './access'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
+import { assertAvailabilityWriteAccess, resolveAvailabilityActorId } from './access'
 
 export const metadata = {
   POST: { requireAuth: true },
@@ -55,8 +59,25 @@ export async function POST(req: Request) {
     const payload = await req.json().catch(() => ({}))
     const input = parseScopedCommandInput(plannerAvailabilityWeeklyReplaceSchema, payload, ctx, translate)
     await assertAvailabilityWriteAccess(ctx, { subjectType: input.subjectType, subjectId: input.subjectId }, translate)
+    const guardInput = {
+      tenantId: input.tenantId,
+      organizationId: input.organizationId,
+      userId: resolveAvailabilityActorId(ctx.auth),
+      resourceKind: 'planner.availability',
+      resourceId: input.subjectId,
+      operation: 'custom' as const,
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+    }
+    const guardResult = await validateCrudMutationGuard(ctx.container, { ...guardInput, mutationPayload: input })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
     const commandBus = ctx.container.resolve('commandBus') as CommandBus
     const { logEntry } = await commandBus.execute('planner.availability.weekly.replace', { input, ctx })
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, { ...guardInput, metadata: guardResult.metadata ?? null })
+    }
     const response = NextResponse.json({ ok: true })
     if (logEntry?.undoToken && logEntry?.id && logEntry?.commandId) {
       response.headers.set(


### PR DESCRIPTION
## Summary

The planner bulk availability write routes are custom command-bus `POST` handlers (not `makeCrudRoute` routes), and they never ran the shared mutation-guard lifecycle. That bypassed the platform extension point used for cross-cutting write policies — record locks and other module-provided mutation guards — violating the `packages/core/AGENTS.md` → API Routes contract and SPEC-035. This wires both routes through `validateCrudMutationGuard` (before command execution) and `runCrudMutationGuardAfterSuccess` (after success, when validation requested it), mirroring the canonical `customers/api/interactions/complete/route.ts` pattern.

## Changes

- `packages/core/src/modules/planner/api/availability-weekly.ts`: call `validateCrudMutationGuard` before `commandBus.execute('planner.availability.weekly.replace', …)`; on rejection return the guard's status/body (command skipped); call `runCrudMutationGuardAfterSuccess` after success when `shouldRunAfterSuccess`.
- `packages/core/src/modules/planner/api/availability-date-specific.ts`: identical guard wiring around `planner.availability.date-specific.replace`.
- `packages/core/src/modules/planner/api/access.ts`: add `resolveAvailabilityActorId(auth)` helper (resolves the guard actor id as `sub → userId → keyId → 'system'`), shared by both routes. No shared actor-id helper exists, so this avoids a cross-module import (the customers/dictionaries modules each keep their own local copy).
- `packages/core/src/modules/planner/api/__tests__/availability-mutation-guard.test.ts`: new coverage proving a registered guard can block weekly and date-specific replacements (409 returned, command not executed) and that validate + after-success run on the success path — for both routes.

Guard arguments: `resourceKind: 'planner.availability'`, `operation: 'custom'`, `resourceId: input.subjectId`, `tenantId`/`organizationId` from the validated scoped input — consistent between the validate and after-success calls.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/implemented/SPEC-035-2026-02-22-mutation-guard-mechanism.md` (existing — defines the mutation-guard contract; this is a compliance bug fix bringing two routes in line, so no spec change was needed)

## Testing

- `yarn workspace @open-mercato/core test --testPathPatterns availability-mutation-guard` — 4/4 pass (was RED before the fix: `validateCrudMutationGuard` never called, block path returned 200 instead of 409)
- `yarn workspace @open-mercato/core test --testPathPatterns planner` — 33/33 pass (no regression)
- `yarn turbo run typecheck --filter=@open-mercato/core` — pass
- `yarn i18n:check-sync` — all locales in sync
- `yarn build:packages` — 21/21
- `yarn build:app` — success

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No new user-facing strings or generator inputs — none required.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (N/A — internal write-policy wiring with no new API/UI surface and no default-config behavior change; the new route-handler unit test fully exercises the guard lifecycle on both routes.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (Not applicable — existing implemented SPEC-035 already defines the contract; this is a compliance fix.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — single-module fix with tests; default-config behavior unchanged when no guard is registered.)
- [x] QA routing set. (`skip-qa` — backend-only, non-customer-facing infra; no observable behavior change in default config, fully unit-covered.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI.
- [x] No arbitrary text sizes — N/A, no UI.
- [x] Empty state handled for list/data pages — N/A, no UI.
- [x] Loading state handled for async pages — N/A, no UI.
- [x] `aria-label` on all icon-only buttons — N/A, no UI.
- [x] Uses existing DS components — N/A, no UI.

## Linked issues

Fixes #3280
