### PR TITLE
fix: enforce status-machine transitions on manual payment gateway actions (#3271)

### DIFF
--- a/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-009.spec.ts
+++ b/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-009.spec.ts
@@ -1,19 +1,23 @@
 import { expect, test } from '@playwright/test'
 import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api'
-import { createPaymentSession, capturePayment, getTransactionStatus } from './helpers/fixtures'
+import {
+  createPaymentSession,
+  capturePayment,
+  refundPayment,
+  getTransactionStatus,
+} from './helpers/fixtures'
 
 /**
- * TC-PGWY-009: Invalid state transition — double capture
+ * TC-PGWY-009: Manual gateway actions enforce the status machine (#3271)
  *
- * Creates a session with manual capture, captures it once, then attempts a
- * second capture. The gateway service delegates to the adapter without
- * pre-checking status transitions, so the mock adapter handles the call.
- * The test verifies the system behaves gracefully: either the second
- * capture is rejected with a 4xx/5xx error, or it succeeds idempotently
- * with status remaining `captured` and no corruption.
+ * Manual capture/refund/cancel no longer trust the adapter result blindly. The
+ * service pre-checks the current transaction status and validates the adapter
+ * result before persisting it, so a terminal transaction (cancelled, refunded,
+ * failed, expired) can never be moved back into an active or captured state.
+ * Same-status responses are treated as idempotent.
  */
-test.describe('TC-PGWY-009: Double capture — invalid state transition', () => {
-  test('should handle a second capture attempt without corrupting transaction state', async ({ request }) => {
+test.describe('TC-PGWY-009: Manual actions enforce status-machine transitions', () => {
+  test('treats a second capture as idempotent without corrupting transaction state', async ({ request }) => {
     const token = await getAuthToken(request)
 
     const session = await createPaymentSession(request, token, {
@@ -31,30 +35,21 @@ test.describe('TC-PGWY-009: Double capture — invalid state transition', () => 
     const statusAfterFirst = await getTransactionStatus(request, token, session.transactionId)
     expect(statusAfterFirst.status).toBe('captured')
 
-    // Attempt a second capture using raw apiRequest to inspect the response
+    // Second capture: current status is already `captured`, so the same-status
+    // adapter response is idempotent — 200 with status unchanged.
     const secondResponse = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
       token,
       data: { transactionId: session.transactionId },
     })
+    expect(secondResponse.ok()).toBe(true)
+    const secondCapture = await secondResponse.json()
+    expect(secondCapture.status).toBe('captured')
 
-    // The system may accept or reject the second capture — both are valid behaviors.
-    // If accepted (200), status must still be `captured` with no side effects.
-    // If rejected (4xx/5xx), status must remain `captured`.
-    const secondStatus = secondResponse.status()
-    if (secondResponse.ok()) {
-      const secondCapture = await secondResponse.json()
-      expect(secondCapture.status).toBe('captured')
-      expect(secondCapture.capturedAmount).toBe(80.00)
-    } else {
-      expect(secondStatus).toBeGreaterThanOrEqual(400)
-    }
-
-    // Regardless of the second capture outcome, the transaction must remain captured
     const finalStatus = await getTransactionStatus(request, token, session.transactionId)
     expect(finalStatus.status).toBe('captured')
   })
 
-  test('should reject capture on a cancelled payment', async ({ request }) => {
+  test('rejects capture on a cancelled payment and keeps it cancelled', async ({ request }) => {
     const token = await getAuthToken(request)
 
     const session = await createPaymentSession(request, token, {
@@ -65,7 +60,6 @@ test.describe('TC-PGWY-009: Double capture — invalid state transition', () => 
     })
     expect(session.status).toBe('authorized')
 
-    // Cancel first
     const cancelResponse = await apiRequest(request, 'POST', '/api/payment_gateways/cancel', {
       token,
       data: { transactionId: session.transactionId },
@@ -75,27 +69,56 @@ test.describe('TC-PGWY-009: Double capture — invalid state transition', () => 
     const statusAfterCancel = await getTransactionStatus(request, token, session.transactionId)
     expect(statusAfterCancel.status).toBe('cancelled')
 
-    // Attempt capture on a cancelled payment — should not produce a captured status
+    // Capture on a cancelled (terminal) transaction must be rejected by the
+    // service status-machine guard, regardless of the permissive mock adapter.
     const captureResponse = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
       token,
       data: { transactionId: session.transactionId },
     })
+    expect(captureResponse.ok()).toBe(false)
+    expect(captureResponse.status()).toBe(409)
 
-    // Whether it errors or silently succeeds at the adapter level,
-    // the final status must not revert to `captured` via the status machine
     const finalStatus = await getTransactionStatus(request, token, session.transactionId)
-    // cancelled is a terminal state — status should remain cancelled or the capture should fail
-    const validFinalStatuses = ['cancelled', 'captured']
-    expect(validFinalStatuses).toContain(finalStatus.status)
+    expect(finalStatus.status).toBe('cancelled')
+  })
 
-    // If the adapter accepted the capture, the service updates status to `captured`.
-    // The mock adapter does not validate status, so this documents current behavior.
-    // A real adapter would reject capture on a cancelled payment.
-    if (captureResponse.ok()) {
-      // Document that mock adapter allows this (no status machine guard in service)
-      expect(finalStatus.status).toBe('captured')
-    } else {
-      expect(finalStatus.status).toBe('cancelled')
-    }
+  test('rejects capture and cancel on a refunded payment and keeps it refunded', async ({ request }) => {
+    const token = await getAuthToken(request)
+
+    const session = await createPaymentSession(request, token, {
+      providerKey: 'mock',
+      amount: 60.00,
+      currencyCode: 'USD',
+      captureMethod: 'manual',
+    })
+    expect(session.status).toBe('authorized')
+
+    const capture = await capturePayment(request, token, session.transactionId)
+    expect(capture.status).toBe('captured')
+
+    const refund = await refundPayment(request, token, session.transactionId)
+    expect(refund.status).toBe('refunded')
+
+    const statusAfterRefund = await getTransactionStatus(request, token, session.transactionId)
+    expect(statusAfterRefund.status).toBe('refunded')
+
+    // Capture on a refunded (terminal) transaction must be rejected.
+    const captureResponse = await apiRequest(request, 'POST', '/api/payment_gateways/capture', {
+      token,
+      data: { transactionId: session.transactionId },
+    })
+    expect(captureResponse.ok()).toBe(false)
+    expect(captureResponse.status()).toBe(409)
+
+    // Cancel on a refunded (terminal) transaction must be rejected too.
+    const cancelResponse = await apiRequest(request, 'POST', '/api/payment_gateways/cancel', {
+      token,
+      data: { transactionId: session.transactionId },
+    })
+    expect(cancelResponse.ok()).toBe(false)
+    expect(cancelResponse.status()).toBe(409)
+
+    const finalStatus = await getTransactionStatus(request, token, session.transactionId)
+    expect(finalStatus.status).toBe('refunded')
   })
 })

--- a/packages/core/src/modules/payment_gateways/api/cancel/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/cancel/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { cancelSchema } from '../../data/validators'
 import type { PaymentGatewayService } from '../../lib/gateway-service'
 import { paymentGatewaysTag } from '../openapi'
@@ -34,6 +35,9 @@ export async function POST(req: Request) {
     )
     return NextResponse.json(result)
   } catch (err: unknown) {
+    if (isCrudHttpError(err)) {
+      return NextResponse.json(err.body, { status: err.status })
+    }
     const message = err instanceof Error ? err.message : 'Cancel failed'
     return NextResponse.json({ error: message }, { status: 502 })
   }
@@ -48,6 +52,7 @@ export const openApi = {
       tags: [paymentGatewaysTag],
       responses: [
         { status: 200, description: 'Payment cancelled' },
+        { status: 409, description: 'Invalid payment status transition' },
         { status: 422, description: 'Invalid payload' },
         { status: 502, description: 'Gateway provider error' },
       ],

--- a/packages/core/src/modules/payment_gateways/api/capture/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/capture/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { captureSchema } from '../../data/validators'
 import type { PaymentGatewayService } from '../../lib/gateway-service'
 import { paymentGatewaysTag } from '../openapi'
@@ -34,6 +35,9 @@ export async function POST(req: Request) {
     )
     return NextResponse.json(result)
   } catch (err: unknown) {
+    if (isCrudHttpError(err)) {
+      return NextResponse.json(err.body, { status: err.status })
+    }
     const message = err instanceof Error ? err.message : 'Capture failed'
     return NextResponse.json({ error: message }, { status: 502 })
   }
@@ -48,6 +52,7 @@ export const openApi = {
       tags: [paymentGatewaysTag],
       responses: [
         { status: 200, description: 'Payment captured' },
+        { status: 409, description: 'Invalid payment status transition' },
         { status: 422, description: 'Invalid payload' },
         { status: 502, description: 'Gateway provider error' },
       ],

--- a/packages/core/src/modules/payment_gateways/api/refund/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/refund/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { refundSchema } from '../../data/validators'
 import type { PaymentGatewayService } from '../../lib/gateway-service'
 import { paymentGatewaysTag } from '../openapi'
@@ -35,6 +36,9 @@ export async function POST(req: Request) {
     )
     return NextResponse.json(result)
   } catch (err: unknown) {
+    if (isCrudHttpError(err)) {
+      return NextResponse.json(err.body, { status: err.status })
+    }
     const message = err instanceof Error ? err.message : 'Refund failed'
     return NextResponse.json({ error: message }, { status: 502 })
   }
@@ -49,6 +53,7 @@ export const openApi = {
       tags: [paymentGatewaysTag],
       responses: [
         { status: 200, description: 'Payment refunded' },
+        { status: 409, description: 'Invalid payment status transition' },
         { status: 422, description: 'Invalid payload' },
         { status: 502, description: 'Gateway provider error' },
       ],

--- a/packages/core/src/modules/payment_gateways/lib/__tests__/gateway-service.test.ts
+++ b/packages/core/src/modules/payment_gateways/lib/__tests__/gateway-service.test.ts
@@ -1,0 +1,175 @@
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { setGlobalEventBus } from '@open-mercato/shared/modules/events'
+import {
+  registerGatewayAdapter,
+  clearGatewayAdapters,
+  type GatewayAdapter,
+  type UnifiedPaymentStatus,
+} from '@open-mercato/shared/modules/payment_gateways/types'
+import type { GatewayTransaction } from '../../data/entities'
+import { createPaymentGatewayService } from '../gateway-service'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn(),
+}))
+
+const findOneMock = findOneWithDecryption as jest.MockedFunction<typeof findOneWithDecryption>
+
+const PROVIDER_KEY = 'mock-unit'
+
+const scope = { organizationId: 'org_1', tenantId: 'tenant_1' }
+
+function makeTransaction(status: UnifiedPaymentStatus): GatewayTransaction {
+  return {
+    id: 'txn_1',
+    paymentId: 'pay_1',
+    providerKey: PROVIDER_KEY,
+    providerSessionId: 'sess_1',
+    unifiedStatus: status,
+    gatewayMetadata: {},
+    gatewayRefundId: null,
+    organizationId: scope.organizationId,
+    tenantId: scope.tenantId,
+  } as unknown as GatewayTransaction
+}
+
+type AdapterResults = {
+  capture?: { status: UnifiedPaymentStatus; capturedAmount: number }
+  refund?: { status: UnifiedPaymentStatus; refundedAmount: number; refundId: string }
+  cancel?: { status: UnifiedPaymentStatus }
+}
+
+function buildService(transaction: GatewayTransaction, results: AdapterResults) {
+  const captureFn = jest.fn(async () => results.capture ?? { status: 'captured' as UnifiedPaymentStatus, capturedAmount: 10 })
+  const refundFn = jest.fn(async () => results.refund ?? { status: 'refunded' as UnifiedPaymentStatus, refundedAmount: 10, refundId: 're_1' })
+  const cancelFn = jest.fn(async () => results.cancel ?? { status: 'cancelled' as UnifiedPaymentStatus })
+
+  const adapter: GatewayAdapter = {
+    providerKey: PROVIDER_KEY,
+    createSession: jest.fn(),
+    capture: captureFn as never,
+    refund: refundFn as never,
+    cancel: cancelFn as never,
+    getStatus: jest.fn(),
+    verifyWebhook: jest.fn(),
+    mapStatus: jest.fn(() => 'unknown' as UnifiedPaymentStatus),
+  } as unknown as GatewayAdapter
+  registerGatewayAdapter(adapter)
+
+  const flush = jest.fn(async () => {})
+  const em = { flush } as never
+  const integrationCredentialsService = { resolve: jest.fn(async () => ({})) } as never
+
+  findOneMock.mockResolvedValue(transaction)
+
+  const service = createPaymentGatewayService({ em, integrationCredentialsService })
+  return { service, captureFn, refundFn, cancelFn, flush }
+}
+
+describe('payment gateway service — status-machine guard (#3271)', () => {
+  beforeAll(() => {
+    setGlobalEventBus({ emit: async () => {} })
+  })
+
+  beforeEach(() => {
+    clearGatewayAdapters()
+    findOneMock.mockReset()
+  })
+
+  afterEach(() => {
+    clearGatewayAdapters()
+  })
+
+  it('rejects a capture on a cancelled (terminal) transaction without touching adapter or status', async () => {
+    const transaction = makeTransaction('cancelled')
+    const { service, captureFn, flush } = buildService(transaction, {
+      capture: { status: 'captured', capturedAmount: 45 },
+    })
+
+    await expect(service.capturePayment(transaction.id, undefined, scope)).rejects.toMatchObject({ status: 409 })
+
+    expect(captureFn).not.toHaveBeenCalled()
+    expect(transaction.unifiedStatus).toBe('cancelled')
+    expect(flush).not.toHaveBeenCalled()
+  })
+
+  it('rejects a refund on a pending transaction (no valid transition into refunded)', async () => {
+    const transaction = makeTransaction('pending')
+    const { service, refundFn, flush } = buildService(transaction, {
+      refund: { status: 'refunded', refundedAmount: 20, refundId: 're_x' },
+    })
+
+    await expect(service.refundPayment(transaction.id, undefined, undefined, scope)).rejects.toMatchObject({ status: 409 })
+
+    expect(refundFn).not.toHaveBeenCalled()
+    expect(transaction.unifiedStatus).toBe('pending')
+    expect(flush).not.toHaveBeenCalled()
+  })
+
+  it('rejects a cancel on a refunded (terminal) transaction', async () => {
+    const transaction = makeTransaction('refunded')
+    const { service, cancelFn, flush } = buildService(transaction, {
+      cancel: { status: 'cancelled' },
+    })
+
+    await expect(service.cancelPayment(transaction.id, undefined, scope)).rejects.toMatchObject({ status: 409 })
+
+    expect(cancelFn).not.toHaveBeenCalled()
+    expect(transaction.unifiedStatus).toBe('refunded')
+    expect(flush).not.toHaveBeenCalled()
+  })
+
+  it('rejects a refund on an already-refunded (terminal) transaction without re-calling the adapter', async () => {
+    const transaction = makeTransaction('refunded')
+    const { service, refundFn, flush } = buildService(transaction, {
+      refund: { status: 'refunded', refundedAmount: 10, refundId: 're_dup' },
+    })
+
+    await expect(service.refundPayment(transaction.id, undefined, undefined, scope)).rejects.toMatchObject({ status: 409 })
+
+    expect(refundFn).not.toHaveBeenCalled()
+    expect(transaction.unifiedStatus).toBe('refunded')
+    expect(flush).not.toHaveBeenCalled()
+  })
+
+  it('rejects an adapter result that is not a valid transition (permissive adapter returns refunded on capture)', async () => {
+    const transaction = makeTransaction('authorized')
+    const { service, captureFn, flush } = buildService(transaction, {
+      capture: { status: 'refunded' as UnifiedPaymentStatus, capturedAmount: 30 },
+    })
+
+    await expect(service.capturePayment(transaction.id, undefined, scope)).rejects.toMatchObject({ status: 409 })
+
+    expect(captureFn).toHaveBeenCalledTimes(1)
+    expect(transaction.unifiedStatus).toBe('authorized')
+    expect(flush).not.toHaveBeenCalled()
+  })
+
+  it('captures a valid authorized -> captured transition and persists', async () => {
+    const transaction = makeTransaction('authorized')
+    const { service, captureFn, flush } = buildService(transaction, {
+      capture: { status: 'captured', capturedAmount: 80 },
+    })
+
+    const result = await service.capturePayment(transaction.id, undefined, scope)
+
+    expect(captureFn).toHaveBeenCalledTimes(1)
+    expect(result.status).toBe('captured')
+    expect(transaction.unifiedStatus).toBe('captured')
+    expect(flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a same-status capture as idempotent (double capture stays captured)', async () => {
+    const transaction = makeTransaction('captured')
+    const { service, captureFn } = buildService(transaction, {
+      capture: { status: 'captured', capturedAmount: 80 },
+    })
+
+    const result = await service.capturePayment(transaction.id, undefined, scope)
+
+    expect(captureFn).toHaveBeenCalledTimes(1)
+    expect(result.status).toBe('captured')
+    expect(transaction.unifiedStatus).toBe('captured')
+  })
+})

--- a/packages/core/src/modules/payment_gateways/lib/gateway-service.ts
+++ b/packages/core/src/modules/payment_gateways/lib/gateway-service.ts
@@ -14,9 +14,33 @@ import {
 import type { CredentialsService } from '../../integrations/lib/credentials-service'
 import type { IntegrationStateService } from '../../integrations/lib/state-service'
 import type { IntegrationLogService } from '../../integrations/lib/log-service'
+import { conflict } from '@open-mercato/shared/lib/crud/errors'
 import { GatewayTransaction } from '../data/entities'
-import { isValidTransition } from './status-machine'
+import { canApplyManualAction, isValidTransition, type ManualGatewayAction } from './status-machine'
 import { emitPaymentGatewayEvent } from '../events'
+
+function assertManualActionAllowed(action: ManualGatewayAction, transaction: GatewayTransaction): void {
+  const current = transaction.unifiedStatus as UnifiedPaymentStatus
+  if (!canApplyManualAction(action, current)) {
+    throw conflict(`Cannot ${action} a payment in status "${current}"`)
+  }
+}
+
+function applyAdapterResultStatus(
+  action: ManualGatewayAction,
+  transaction: GatewayTransaction,
+  resultStatus: UnifiedPaymentStatus,
+): boolean {
+  const current = transaction.unifiedStatus as UnifiedPaymentStatus
+  if (resultStatus === current) return false
+  if (!isValidTransition(current, resultStatus)) {
+    throw conflict(
+      `Gateway returned status "${resultStatus}" which is not a valid transition from "${current}" for ${action}`,
+    )
+  }
+  transaction.unifiedStatus = resultStatus
+  return true
+}
 
 export interface PaymentGatewayServiceDeps {
   em: EntityManager
@@ -197,6 +221,7 @@ export function createPaymentGatewayService(deps: PaymentGatewayServiceDeps) {
 
     async capturePayment(transactionId: string, amount: number | undefined, scope: { organizationId: string; tenantId: string }): Promise<CaptureResult> {
       const transaction = await findTransactionOrThrow(transactionId, scope)
+      assertManualActionAllowed('capture', transaction)
       const { adapter, credentials } = await resolveAdapterAndCredentials(
         transaction.providerKey,
         { organizationId: transaction.organizationId, tenantId: transaction.tenantId },
@@ -208,16 +233,18 @@ export function createPaymentGatewayService(deps: PaymentGatewayServiceDeps) {
         credentials,
       })
 
-      transaction.unifiedStatus = result.status
+      const statusChanged = applyAdapterResultStatus('capture', transaction, result.status)
       transaction.gatewayMetadata = { ...transaction.gatewayMetadata, captureResult: result.providerData }
       await em.flush()
-      await emitStatusEvent(result.status, {
-        transactionId: transaction.id,
-        paymentId: transaction.paymentId,
-        providerKey: transaction.providerKey,
-        organizationId: transaction.organizationId,
-        tenantId: transaction.tenantId,
-      })
+      if (statusChanged) {
+        await emitStatusEvent(result.status, {
+          transactionId: transaction.id,
+          paymentId: transaction.paymentId,
+          providerKey: transaction.providerKey,
+          organizationId: transaction.organizationId,
+          tenantId: transaction.tenantId,
+        })
+      }
       await writeTransactionLog(
         transaction.providerKey,
         { organizationId: transaction.organizationId, tenantId: transaction.tenantId },
@@ -241,6 +268,7 @@ export function createPaymentGatewayService(deps: PaymentGatewayServiceDeps) {
       scope: { organizationId: string; tenantId: string },
     ): Promise<RefundResult> {
       const transaction = await findTransactionOrThrow(transactionId, scope)
+      assertManualActionAllowed('refund', transaction)
       const { adapter, credentials } = await resolveAdapterAndCredentials(
         transaction.providerKey,
         { organizationId: transaction.organizationId, tenantId: transaction.tenantId },
@@ -253,17 +281,19 @@ export function createPaymentGatewayService(deps: PaymentGatewayServiceDeps) {
         credentials,
       })
 
-      transaction.unifiedStatus = result.status
+      const statusChanged = applyAdapterResultStatus('refund', transaction, result.status)
       transaction.gatewayRefundId = result.refundId
       transaction.gatewayMetadata = { ...transaction.gatewayMetadata, refundResult: result.providerData }
       await em.flush()
-      await emitStatusEvent(result.status, {
-        transactionId: transaction.id,
-        paymentId: transaction.paymentId,
-        providerKey: transaction.providerKey,
-        organizationId: transaction.organizationId,
-        tenantId: transaction.tenantId,
-      })
+      if (statusChanged) {
+        await emitStatusEvent(result.status, {
+          transactionId: transaction.id,
+          paymentId: transaction.paymentId,
+          providerKey: transaction.providerKey,
+          organizationId: transaction.organizationId,
+          tenantId: transaction.tenantId,
+        })
+      }
       await writeTransactionLog(
         transaction.providerKey,
         { organizationId: transaction.organizationId, tenantId: transaction.tenantId },
@@ -287,6 +317,7 @@ export function createPaymentGatewayService(deps: PaymentGatewayServiceDeps) {
       scope: { organizationId: string; tenantId: string },
     ): Promise<CancelResult> {
       const transaction = await findTransactionOrThrow(transactionId, scope)
+      assertManualActionAllowed('cancel', transaction)
       const { adapter, credentials } = await resolveAdapterAndCredentials(
         transaction.providerKey,
         { organizationId: transaction.organizationId, tenantId: transaction.tenantId },
@@ -298,15 +329,17 @@ export function createPaymentGatewayService(deps: PaymentGatewayServiceDeps) {
         credentials,
       })
 
-      transaction.unifiedStatus = result.status
+      const statusChanged = applyAdapterResultStatus('cancel', transaction, result.status)
       await em.flush()
-      await emitStatusEvent(result.status, {
-        transactionId: transaction.id,
-        paymentId: transaction.paymentId,
-        providerKey: transaction.providerKey,
-        organizationId: transaction.organizationId,
-        tenantId: transaction.tenantId,
-      })
+      if (statusChanged) {
+        await emitStatusEvent(result.status, {
+          transactionId: transaction.id,
+          paymentId: transaction.paymentId,
+          providerKey: transaction.providerKey,
+          organizationId: transaction.organizationId,
+          tenantId: transaction.tenantId,
+        })
+      }
       await writeTransactionLog(
         transaction.providerKey,
         { organizationId: transaction.organizationId, tenantId: transaction.tenantId },

--- a/packages/core/src/modules/payment_gateways/lib/status-machine.ts
+++ b/packages/core/src/modules/payment_gateways/lib/status-machine.ts
@@ -26,3 +26,19 @@ export function isValidTransition(from: UnifiedPaymentStatus, to: UnifiedPayment
 export function isTerminalStatus(status: UnifiedPaymentStatus): boolean {
   return TERMINAL_STATUSES.has(status)
 }
+
+export type ManualGatewayAction = 'capture' | 'refund' | 'cancel'
+
+const MANUAL_ACTION_TARGET_STATUSES: Record<ManualGatewayAction, UnifiedPaymentStatus[]> = {
+  capture: ['captured', 'partially_captured'],
+  refund: ['refunded', 'partially_refunded'],
+  cancel: ['cancelled'],
+}
+
+export function canApplyManualAction(action: ManualGatewayAction, from: UnifiedPaymentStatus): boolean {
+  if (isTerminalStatus(from)) return false
+  const targets = MANUAL_ACTION_TARGET_STATUSES[action]
+  if (!targets) return false
+  if (targets.includes(from)) return true
+  return targets.some((target) => isValidTransition(from, target))
+}


### PR DESCRIPTION
## Summary

Manual capture/refund/cancel actions on payment gateway transactions bypassed the payment status machine: the service assigned the adapter's returned status directly to `transaction.unifiedStatus` with no pre-action state check and no validation of the returned status — unlike the poller (`getPaymentStatus`) and webhook sync (`syncTransactionStatus`), which both gate on `isValidTransition()`. A stale UI action or a permissive adapter could therefore move a terminal transaction (refunded/cancelled/failed/expired) back into an active or captured state.

This change enforces the status machine on the three manual actions: it pre-checks the current transaction status before calling the adapter, validates the adapter's result before persisting it, treats same-status responses as idempotent no-ops, and surfaces invalid transitions as a clean 409 Conflict.

## Changes

- `lib/status-machine.ts`: add `ManualGatewayAction` + `canApplyManualAction(action, from)` — rejects any manual action out of a terminal state, otherwise allows an idempotent re-issue on a non-terminal target (e.g. double capture) or a valid forward transition into the action's target. Reuses `isValidTransition`/`isTerminalStatus`.
- `lib/gateway-service.ts`: add `assertManualActionAllowed(...)` (pre-check before the adapter call) and `applyAdapterResultStatus(...)` (validate the adapter result before persisting; same-status = no-op, invalid transition → `conflict()` thrown before `em.flush()`). Wire into `capturePayment`/`refundPayment`/`cancelPayment`; emit the status event only when the status actually changes.
- `api/{capture,refund,cancel}/route.ts`: map `CrudHttpError` (via `isCrudHttpError`) to its real HTTP status (409 for invalid transitions) instead of collapsing every error into 502; keep the 502 fallback for genuine gateway errors; document the 409 response in `openApi`.
- `lib/__tests__/gateway-service.test.ts` (new): unit coverage for the service status-machine guard.
- `__integration__/TC-PGWY-009.spec.ts`: replace the test that documented the missing guard with assertions that cancelled/refunded transactions cannot be moved back into active/captured states (hard 409 + preserved terminal status), plus idempotent double-capture.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
.ai/specs/implemented/SPEC-044-2026-02-24-payment-gateway-integrations.md (targeted bug fix; the documented contract is unchanged, so no spec edit required)


## Testing

List the tests or commands you ran to validate the change.

- `yarn workspace @open-mercato/core test -- gateway-service.test` → 7/7 pass (4 were red for the right reason before the fix)
- `yarn workspace @open-mercato/core test` → 742 suites / 6073 tests pass (no regressions)
- `tsc -p packages/core/tsconfig.json --noEmit` → exit 0 (covers product code + the TC-PGWY-009 integration spec)
- `yarn workspace @open-mercato/core build` → built successfully
- `yarn i18n:check-sync` → all locales in sync
- Integration suite (Playwright/TC-PGWY-009): not executed locally (requires the ephemeral env); spec typechecks and the same service logic is fully covered by the jest suite.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- openApi 409 responses added; no locale/generator changes needed -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or adjusted integration tests (hardened `__integration__/TC-PGWY-009.spec.ts`; this module keeps its integration specs under the module's `__integration__/` dir).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — targeted bug fix, no contract change to SPEC-044 -->
- [x] Priority set: this PR carries exactly one `priority-*` label. <!-- priority-high (inherited from issue) -->
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. <!-- risk-high — payment/money state handling -->
- [x] QA routing set. <!-- needs-qa (payment/money, risk-high); automated coverage attached via jest + hardened integration spec -->

### Design System Compliance
- [x] No hardcoded status colors — N/A — no UI
- [x] No arbitrary text sizes — N/A — no UI
- [x] Empty state handled — N/A — no UI
- [x] Loading state handled — N/A — no UI
- [x] `aria-label` on icon-only buttons — N/A — no UI
- [x] Uses existing DS components — N/A — no UI

## Linked issues

Fixes #3271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
