### PR TITLE
fix: route DataTable perspective writes through useGuardedMutation (#3273)

### DIFF
--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -34,7 +34,7 @@ import { resolveInjectedIcon } from './injection/resolveInjectedIcon'
 import { serializeExport, defaultExportFilename, type PreparedExport } from '@open-mercato/shared/lib/crud/exporters'
 import { apiCall, withScopedApiRequestHeaders } from './utils/apiCall'
 import { buildOptimisticLockHeader } from './utils/optimisticLock'
-import { surfaceRecordConflict } from './conflicts'
+import { useGuardedMutation } from './injection/useGuardedMutation'
 import { raiseCrudError } from './utils/serverErrors'
 import { PerspectiveSidebar } from './PerspectiveSidebar'
 import { Popover, PopoverTrigger, PopoverContent } from '../primitives/popover'
@@ -1711,6 +1711,27 @@ export function DataTable<T>({
   }
 
   const perspectiveQueryKey: [string, string | null] = ['table-perspectives', perspectiveTableId]
+
+  type PerspectiveMutationContext = {
+    formId: string
+    resourceKind: 'perspective'
+    retryLastMutation: () => Promise<boolean>
+  }
+  const perspectiveMutationContextId = `data-table-perspectives:${perspectiveTableId ?? 'unknown'}`
+  const { runMutation: runPerspectiveMutation, retryLastMutation: retryPerspectiveMutation } =
+    useGuardedMutation<PerspectiveMutationContext>({
+      contextId: perspectiveMutationContextId,
+      blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+    })
+  const perspectiveMutationContext = React.useMemo<PerspectiveMutationContext>(
+    () => ({
+      formId: perspectiveMutationContextId,
+      resourceKind: 'perspective',
+      retryLastMutation: retryPerspectiveMutation,
+    }),
+    [perspectiveMutationContextId, retryPerspectiveMutation],
+  )
+
   const savePerspectiveMutation = useMutation<PerspectiveSaveResponse, Error, SavePerspectivePayload>({
     mutationFn: async (input) => {
       if (!perspectiveTableId) throw new Error('Missing table id')
@@ -1729,26 +1750,32 @@ export function DataTable<T>({
       const existing = input.perspectiveId
         ? perspectiveData?.perspectives.find((p) => p.id === input.perspectiveId) ?? null
         : null
-      const call = await withScopedApiRequestHeaders(
-        buildOptimisticLockHeader(existing?.updatedAt ?? null),
-        () => apiCall<PerspectiveSaveResponse>(
-          `/api/perspectives/${encodeURIComponent(perspectiveTableId)}`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-          },
-        ),
-      )
-      if (call.status === 404) {
-        throw new Error(t('ui.dataTable.perspectives.error.apiUnavailable', 'Perspectives API is not available. Run `yarn generate` to regenerate module routes and restart the dev server.'))
-      }
-      if (!call.ok) {
-        await raiseCrudError(call.response, t('ui.dataTable.perspectives.error.save', 'Failed to save perspective'))
-      }
-      const result = call.result
-      if (!result) throw new Error(t('ui.dataTable.perspectives.error.save', 'Failed to save perspective'))
-      return result
+      return runPerspectiveMutation({
+        operation: async () => {
+          const call = await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(existing?.updatedAt ?? null),
+            () => apiCall<PerspectiveSaveResponse>(
+              `/api/perspectives/${encodeURIComponent(perspectiveTableId)}`,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+              },
+            ),
+          )
+          if (call.status === 404) {
+            throw new Error(t('ui.dataTable.perspectives.error.apiUnavailable', 'Perspectives API is not available. Run `yarn generate` to regenerate module routes and restart the dev server.'))
+          }
+          if (!call.ok) {
+            await raiseCrudError(call.response, t('ui.dataTable.perspectives.error.save', 'Failed to save perspective'))
+          }
+          const result = call.result
+          if (!result) throw new Error(t('ui.dataTable.perspectives.error.save', 'Failed to save perspective'))
+          return result
+        },
+        context: perspectiveMutationContext,
+        mutationPayload: payload,
+      })
     },
     onSuccess: (data) => {
       if (perspectiveTableId) {
@@ -1758,11 +1785,12 @@ export function DataTable<T>({
         applyPerspectiveSettings(data.perspective.settings, data.perspective.id)
       }
     },
-    onError: (error) => {
+    onError: () => {
+      // Conflict surfacing is handled inside `runPerspectiveMutation`
+      // (surfaceRecordConflict); only the cache refresh remains here.
       if (perspectiveTableId) {
         void queryClient.invalidateQueries({ queryKey: perspectiveQueryKey })
       }
-      surfaceRecordConflict(error, t)
     },
   })
 
@@ -1786,14 +1814,20 @@ export function DataTable<T>({
   const deletePerspectiveMutation = useMutation<void, Error, { perspectiveId: string }>({
     mutationFn: async ({ perspectiveId }) => {
       if (!perspectiveTableId) throw new Error('Missing table id')
-      const call = await apiCall(
-        `/api/perspectives/${encodeURIComponent(perspectiveTableId)}/${encodeURIComponent(perspectiveId)}`,
-        { method: 'DELETE' },
-      )
-      if (call.status === 404) throw new Error(t('ui.dataTable.perspectives.error.apiUnavailable', 'Perspectives API is not available. Run `yarn generate` and restart the dev server.'))
-      if (!call.ok) {
-        await raiseCrudError(call.response, t('ui.dataTable.perspectives.error.delete', 'Failed to delete perspective'))
-      }
+      await runPerspectiveMutation({
+        operation: async () => {
+          const call = await apiCall(
+            `/api/perspectives/${encodeURIComponent(perspectiveTableId)}/${encodeURIComponent(perspectiveId)}`,
+            { method: 'DELETE' },
+          )
+          if (call.status === 404) throw new Error(t('ui.dataTable.perspectives.error.apiUnavailable', 'Perspectives API is not available. Run `yarn generate` and restart the dev server.'))
+          if (!call.ok) {
+            await raiseCrudError(call.response, t('ui.dataTable.perspectives.error.delete', 'Failed to delete perspective'))
+          }
+        },
+        context: perspectiveMutationContext,
+        mutationPayload: { perspectiveId },
+      })
     },
     onMutate: ({ perspectiveId }) => {
       setDeletingIds((prev) => prev.includes(perspectiveId) ? prev : [...prev, perspectiveId])
@@ -1822,14 +1856,20 @@ export function DataTable<T>({
   const clearRoleMutation = useMutation<void, Error, { roleId: string }>({
     mutationFn: async ({ roleId }) => {
       if (!perspectiveTableId) throw new Error('Missing table id')
-      const call = await apiCall(
-        `/api/perspectives/${encodeURIComponent(perspectiveTableId)}/roles/${encodeURIComponent(roleId)}`,
-        { method: 'DELETE' },
-      )
-      if (call.status === 404) throw new Error(t('ui.dataTable.perspectives.error.apiUnavailable', 'Perspectives API is not available. Run `yarn generate` and restart the dev server.'))
-      if (!call.ok) {
-        await raiseCrudError(call.response, t('ui.dataTable.perspectives.error.clearRoles', 'Failed to clear role perspectives'))
-      }
+      await runPerspectiveMutation({
+        operation: async () => {
+          const call = await apiCall(
+            `/api/perspectives/${encodeURIComponent(perspectiveTableId)}/roles/${encodeURIComponent(roleId)}`,
+            { method: 'DELETE' },
+          )
+          if (call.status === 404) throw new Error(t('ui.dataTable.perspectives.error.apiUnavailable', 'Perspectives API is not available. Run `yarn generate` and restart the dev server.'))
+          if (!call.ok) {
+            await raiseCrudError(call.response, t('ui.dataTable.perspectives.error.clearRoles', 'Failed to clear role perspectives'))
+          }
+        },
+        context: perspectiveMutationContext,
+        mutationPayload: { roleId },
+      })
     },
     onMutate: ({ roleId }) => {
       setRoleClearingIds((prev) => prev.includes(roleId) ? prev : [...prev, roleId])

--- a/packages/ui/src/backend/__tests__/DataTable.perspectiveGuardedMutation.test.tsx
+++ b/packages/ui/src/backend/__tests__/DataTable.perspectiveGuardedMutation.test.tsx
@@ -1,0 +1,263 @@
+/** @jest-environment jsdom */
+import * as React from 'react'
+import { DataTable } from '../DataTable'
+import type { ColumnDef } from '@tanstack/react-table'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+import { render, fireEvent, waitFor, screen } from '@testing-library/react'
+import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+import type { PerspectivesIndexResponse } from '@open-mercato/shared/modules/perspectives/types'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+}))
+
+jest.mock('../injection/useInjectionDataWidgets', () => ({
+  useInjectionDataWidgets: () => ({ widgets: [], isLoading: false }),
+}))
+
+// The guarded-mutation hook is the contract under test: every perspective write
+// must be routed through `runMutation` so global mutation injections, record
+// locks, and conflict handling participate consistently.
+const mockRunMutation = jest.fn(
+  async ({ operation }: { operation: () => Promise<unknown> }) => operation(),
+)
+const mockRetryLastMutation = jest.fn(async () => false)
+jest.mock('../injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: mockRunMutation,
+    retryLastMutation: mockRetryLastMutation,
+  }),
+}))
+
+// Capture the optimistic-lock headers attached to writes while keeping the call
+// flow real: `apiCall` is recorded, `withScopedApiRequestHeaders` records the
+// header bag and still runs the wrapped operation.
+const mockScopedHeaderCalls: Array<Record<string, string>> = []
+const mockApiCall = jest.fn(async (input: unknown, init?: { method?: string }) => {
+  const url = String(input)
+  const method = (init?.method ?? 'GET').toUpperCase()
+  const ok = (result: unknown) => ({
+    ok: true,
+    status: 200,
+    result,
+    response: { ok: true, status: 200 } as Response,
+    cacheStatus: null as const,
+  })
+  if (url.includes('/api/perspectives/') && method === 'POST') {
+    return ok({
+      perspective: {
+        id: 'persp-1',
+        name: 'My view',
+        tableId: 'test-table',
+        settings: {},
+        isDefault: false,
+        createdAt: 'now',
+        updatedAt: '2026-06-19T00:00:00.000Z',
+      },
+      rolePerspectives: [],
+      clearedRoleIds: [],
+    })
+  }
+  return ok(undefined)
+})
+jest.mock('../utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...(args as [unknown, { method?: string }?])),
+  withScopedApiRequestHeaders: async (
+    headers: Record<string, string>,
+    run: () => Promise<unknown>,
+  ) => {
+    mockScopedHeaderCalls.push(headers)
+    return run()
+  },
+}))
+
+type SidebarProps = {
+  onSave: (input: {
+    name: string
+    isDefault: boolean
+    applyToRoles: string[]
+    setRoleDefault: boolean
+    perspectiveId?: string | null
+    settings?: unknown
+  }) => void | Promise<void>
+  onDeletePerspective: (perspectiveId: string) => void | Promise<void>
+  onClearRole: (roleId: string) => void | Promise<void>
+}
+
+// Replace the heavy drawer UI with a stub exposing the three write handlers as
+// buttons, so the test drives the mutations without rendering the full sidebar.
+jest.mock('../PerspectiveSidebar', () => ({
+  PerspectiveSidebar: (props: SidebarProps) => (
+    <div>
+      <button
+        type="button"
+        data-testid="save-perspective"
+        onClick={() => {
+          void props.onSave({
+            name: 'My view',
+            isDefault: false,
+            applyToRoles: [],
+            setRoleDefault: false,
+            perspectiveId: 'persp-1',
+            settings: {
+              columnOrder: [],
+              columnVisibility: {},
+              filters: {},
+              sorting: [],
+              pageSize: 20,
+              searchValue: '',
+            },
+          })
+        }}
+      >
+        save
+      </button>
+      <button
+        type="button"
+        data-testid="delete-perspective"
+        onClick={() => {
+          void props.onDeletePerspective('persp-1')
+        }}
+      >
+        delete
+      </button>
+      <button
+        type="button"
+        data-testid="clear-role"
+        onClick={() => {
+          void props.onClearRole('role-1')
+        }}
+      >
+        clear
+      </button>
+    </div>
+  ),
+}))
+
+type Row = { id: string; name: string }
+
+const INDEX_RESPONSE: PerspectivesIndexResponse = {
+  tableId: 'test-table',
+  perspectives: [
+    {
+      id: 'persp-1',
+      name: 'My view',
+      tableId: 'test-table',
+      settings: {},
+      isDefault: false,
+      createdAt: 'now',
+      updatedAt: '2026-06-19T00:00:00.000Z',
+    },
+  ],
+  defaultPerspectiveId: null,
+  rolePerspectives: [],
+  roles: [{ id: 'role-1', name: 'Role 1', hasPerspective: false, hasDefault: false }],
+  canApplyToRoles: true,
+}
+
+function renderTable() {
+  const columns: ColumnDef<Row>[] = [{ accessorKey: 'name', header: 'Name' }]
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { staleTime: Infinity, gcTime: Infinity, retry: false },
+      mutations: { retry: false },
+    },
+  })
+  // Seed both perspective queries so the component renders the (mocked) sidebar
+  // without issuing any network fetch for them.
+  queryClient.setQueryData(['feature-check', 'perspectives'], { use: true, roleDefaults: true })
+  queryClient.setQueryData(['table-perspectives', 'test-table'], INDEX_RESPONSE)
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <I18nProvider locale="en" dict={{}}>
+        <DataTable
+          columns={columns}
+          data={[]}
+          perspective={{ tableId: 'test-table' }}
+        />
+      </I18nProvider>
+    </QueryClientProvider>,
+  )
+  return { ...utils, queryClient }
+}
+
+describe('DataTable perspective writes go through useGuardedMutation', () => {
+  beforeEach(() => {
+    mockRunMutation.mockClear()
+    mockRetryLastMutation.mockClear()
+    mockApiCall.mockClear()
+    mockScopedHeaderCalls.length = 0
+  })
+
+  it('routes perspective save through runMutation and keeps the optimistic-lock header', async () => {
+    const { queryClient } = renderTable()
+    try {
+      fireEvent.click(screen.getByTestId('save-perspective'))
+      await waitFor(() => expect(mockRunMutation).toHaveBeenCalledTimes(1))
+
+      const call = mockRunMutation.mock.calls[0][0] as {
+        operation: () => Promise<unknown>
+        context: Record<string, unknown>
+        mutationPayload?: Record<string, unknown>
+      }
+      expect(call.context.resourceKind).toBe('perspective')
+      expect(typeof call.context.retryLastMutation).toBe('function')
+
+      await waitFor(() =>
+        expect(mockApiCall).toHaveBeenCalledWith(
+          expect.stringContaining('/api/perspectives/test-table'),
+          expect.objectContaining({ method: 'POST' }),
+        ),
+      )
+      // The save still attaches the optimistic-lock header for the edited record.
+      expect(mockScopedHeaderCalls).toContainEqual({
+        [OPTIMISTIC_LOCK_HEADER_NAME]: '2026-06-19T00:00:00.000Z',
+      })
+    } finally {
+      queryClient.clear()
+    }
+  })
+
+  it('routes perspective delete through runMutation', async () => {
+    const { queryClient } = renderTable()
+    try {
+      fireEvent.click(screen.getByTestId('delete-perspective'))
+      await waitFor(() => expect(mockRunMutation).toHaveBeenCalledTimes(1))
+
+      const call = mockRunMutation.mock.calls[0][0] as { context: Record<string, unknown> }
+      expect(call.context.resourceKind).toBe('perspective')
+      expect(typeof call.context.retryLastMutation).toBe('function')
+
+      await waitFor(() =>
+        expect(mockApiCall).toHaveBeenCalledWith(
+          expect.stringContaining('/api/perspectives/test-table/persp-1'),
+          expect.objectContaining({ method: 'DELETE' }),
+        ),
+      )
+    } finally {
+      queryClient.clear()
+    }
+  })
+
+  it('routes role-clear through runMutation', async () => {
+    const { queryClient } = renderTable()
+    try {
+      fireEvent.click(screen.getByTestId('clear-role'))
+      await waitFor(() => expect(mockRunMutation).toHaveBeenCalledTimes(1))
+
+      const call = mockRunMutation.mock.calls[0][0] as { context: Record<string, unknown> }
+      expect(call.context.resourceKind).toBe('perspective')
+      expect(typeof call.context.retryLastMutation).toBe('function')
+
+      await waitFor(() =>
+        expect(mockApiCall).toHaveBeenCalledWith(
+          expect.stringContaining('/api/perspectives/test-table/roles/role-1'),
+          expect.objectContaining({ method: 'DELETE' }),
+        ),
+      )
+    } finally {
+      queryClient.clear()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

The saved-Views (perspectives) write flows in `DataTable` issued their `POST`/`DELETE` calls directly through React Query `useMutation`, bypassing `useGuardedMutation`. Per `packages/ui/AGENTS.md`, every non-`CrudForm` write must run through `useGuardedMutation(...).runMutation(...)` so global mutation injections, record locks, conflict handling, and future guards participate consistently. This routes perspective **save**, **delete**, and **role-clear** through the guard with a stable mutation context, while preserving all existing query-invalidation, active-view cleanup, and optimistic-lock behavior.

## Changes

- `packages/ui/src/backend/DataTable.tsx`:
  - Added a `useGuardedMutation` hook + a memoized, stable `perspectiveMutationContext` (`{ formId, resourceKind: 'perspective', retryLastMutation }`, keyed by `data-table-perspectives:<tableId>`).
  - Routed the network operation of `savePerspectiveMutation`, `deletePerspectiveMutation`, and `clearRoleMutation` through `runPerspectiveMutation({ operation, context, mutationPayload })`. React Query lifecycle (`onMutate`/`onSettled`/`onSuccess` — deleting/clearing state, active-view cleanup, query invalidation) is unchanged.
  - Kept the save's optimistic-lock header (`withScopedApiRequestHeaders(buildOptimisticLockHeader(existing?.updatedAt), …)`) inside the operation.
  - Removed the now-redundant `surfaceRecordConflict(error, t)` from the save's `onError` (the guard surfaces 409 conflicts exactly once) and dropped the now-unused `surfaceRecordConflict` import.
- `packages/ui/src/backend/__tests__/DataTable.perspectiveGuardedMutation.test.tsx` (new): interaction test proving all three writes route through `runMutation` with the correct context, and that the save still attaches the optimistic-lock header.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — contract-compliance remediation aligning one component with the existing `useGuardedMutation` rule (`packages/ui/AGENTS.md`); part of the guarded-mutation remediation campaign.

## Testing

List the tests or commands you ran to validate the change.

- `yarn workspace @open-mercato/ui jest src/backend/__tests__/DataTable.perspectiveGuardedMutation.test.tsx` → **3 passed** (red before the fix: `runMutation` called 0 times).
- `yarn workspace @open-mercato/ui jest` → **1520 tests passed**. (7 suite-load failures are pre-existing and unrelated — `Cannot find module '@open-mercato/ai-assistant/…'` in `AiChat.*` suites, from the optional ai-assistant submodule not being installed in a fresh worktree.)
- `tsc --noEmit` (ui package) → clean.
- `yarn i18n:check-sync` → all locales in sync (no new keys; reuses the existing `ui.forms.flash.saveBlocked`).
- `yarn build:packages` → success.
- `yarn build:app` → Compiled successfully + TypeScript passed.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No new locale keys, docs, or generators required — reuses existing keys.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required: behavior-preserving internal mutation-routing refactor with no API/UX change; covered by the new jsdom interaction test.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (Not applicable — no spec for this remediation.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium`: shared `DataTable` component, but the change is internal to the perspectives feature, behavior-preserving, and test-covered — no public-contract change.)
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. (`needs-qa`: touches saved-Views write flows; manual click-through of save/delete/clear confirms no regression.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI/markup change (logic-only refactor)
- [x] No arbitrary text sizes — N/A, no UI/markup change
- [x] Empty state handled for list/data pages — N/A, no UI/markup change
- [x] Loading state handled for async pages — N/A, no UI/markup change
- [x] `aria-label` on all icon-only buttons — N/A, no UI/markup change
- [x] Uses existing DS components — N/A, no UI/markup change

## Linked issues

Fixes #3273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
