### PR TITLE
fix: wire mutation guards for payment gateway write routes (#3270)

### DIFF
--- a/packages/core/src/modules/payment_gateways/api/__tests__/guarded-routes.test.ts
+++ b/packages/core/src/modules/payment_gateways/api/__tests__/guarded-routes.test.ts
@@ -1,0 +1,195 @@
+/** @jest-environment node */
+
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import {
+  runPaymentGatewayMutationGuardAfterSuccess,
+  runPaymentGatewayMutationGuards,
+} from '../guards'
+import { POST as createSession } from '../sessions/route'
+import { POST as capturePayment } from '../capture/route'
+import { POST as refundPayment } from '../refund/route'
+import { POST as cancelPayment } from '../cancel/route'
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(),
+}))
+
+jest.mock('../guards', () => ({
+  resolveUserFeatures: jest.fn(() => []),
+  runPaymentGatewayMutationGuards: jest.fn(),
+  runPaymentGatewayMutationGuardAfterSuccess: jest.fn(),
+}))
+
+const TXN_ID = '11111111-1111-4111-8111-111111111111'
+const RESOURCE_KIND = 'payment_gateways.gateway_transaction'
+
+const service = {
+  createPaymentSession: jest.fn(),
+  capturePayment: jest.fn(),
+  refundPayment: jest.fn(),
+  cancelPayment: jest.fn(),
+}
+
+function buildRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/payment_gateways', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ tenantId: 't1', orgId: 'o1', sub: 'u1', features: [] })
+  ;(createRequestContainer as jest.Mock).mockResolvedValue({
+    resolve: (key: string) => {
+      if (key === 'paymentGatewayService') return service
+      throw new Error(`unexpected resolve(${key})`)
+    },
+  })
+  ;(runPaymentGatewayMutationGuards as jest.Mock).mockResolvedValue({ ok: true, afterSuccessCallbacks: [] })
+  service.createPaymentSession.mockResolvedValue({
+    transaction: { id: 'txn_created', providerKey: 'stripe', paymentId: 'pay_1' },
+    session: { sessionId: 'sess_1', status: 'pending', clientSecret: null, providerData: null, clientSession: null },
+  })
+  service.capturePayment.mockResolvedValue({ ok: true })
+  service.refundPayment.mockResolvedValue({ ok: true })
+  service.cancelPayment.mockResolvedValue({ ok: true })
+})
+
+describe('payment gateway write routes wire the mutation guard lifecycle', () => {
+  describe('POST /payment_gateways/sessions (create)', () => {
+    const body = { providerKey: 'stripe', amount: 10, currencyCode: 'USD' }
+
+    it('runs the mutation guard with a create operation before mutating', async () => {
+      await createSession(buildRequest(body))
+      expect(runPaymentGatewayMutationGuards).toHaveBeenCalledTimes(1)
+      expect(runPaymentGatewayMutationGuards).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ resourceKind: RESOURCE_KIND, operation: 'create' }),
+        [],
+      )
+    })
+
+    it('returns the guard rejection and does not create the session when blocked', async () => {
+      ;(runPaymentGatewayMutationGuards as jest.Mock).mockResolvedValue({
+        ok: false,
+        errorStatus: 423,
+        errorBody: { error: 'Record is locked', code: 'record_locked' },
+        afterSuccessCallbacks: [],
+      })
+      const response = await createSession(buildRequest(body))
+      expect(response.status).toBe(423)
+      expect(await response.json()).toEqual({ error: 'Record is locked', code: 'record_locked' })
+      expect(service.createPaymentSession).not.toHaveBeenCalled()
+    })
+
+    it('runs after-success hooks once the session is created', async () => {
+      const response = await createSession(buildRequest(body))
+      expect(response.status).toBe(201)
+      expect(service.createPaymentSession).toHaveBeenCalledTimes(1)
+      expect(runPaymentGatewayMutationGuardAfterSuccess).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('POST /payment_gateways/capture (update)', () => {
+    const body = { transactionId: TXN_ID }
+
+    it('runs the mutation guard with an update operation scoped to the transaction', async () => {
+      await capturePayment(buildRequest(body))
+      expect(runPaymentGatewayMutationGuards).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ resourceKind: RESOURCE_KIND, operation: 'update', resourceId: TXN_ID }),
+        [],
+      )
+    })
+
+    it('returns the guard rejection and does not capture when blocked', async () => {
+      ;(runPaymentGatewayMutationGuards as jest.Mock).mockResolvedValue({
+        ok: false,
+        errorStatus: 423,
+        errorBody: { error: 'Record is locked', code: 'record_locked' },
+        afterSuccessCallbacks: [],
+      })
+      const response = await capturePayment(buildRequest(body))
+      expect(response.status).toBe(423)
+      expect(service.capturePayment).not.toHaveBeenCalled()
+    })
+
+    it('runs after-success hooks once the capture succeeds', async () => {
+      const response = await capturePayment(buildRequest(body))
+      expect(response.status).toBe(200)
+      expect(service.capturePayment).toHaveBeenCalledTimes(1)
+      expect(runPaymentGatewayMutationGuardAfterSuccess).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('POST /payment_gateways/refund (update)', () => {
+    const body = { transactionId: TXN_ID }
+
+    it('runs the mutation guard with an update operation scoped to the transaction', async () => {
+      await refundPayment(buildRequest(body))
+      expect(runPaymentGatewayMutationGuards).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ resourceKind: RESOURCE_KIND, operation: 'update', resourceId: TXN_ID }),
+        [],
+      )
+    })
+
+    it('returns the guard rejection and does not refund when blocked', async () => {
+      ;(runPaymentGatewayMutationGuards as jest.Mock).mockResolvedValue({
+        ok: false,
+        errorStatus: 423,
+        errorBody: { error: 'Record is locked', code: 'record_locked' },
+        afterSuccessCallbacks: [],
+      })
+      const response = await refundPayment(buildRequest(body))
+      expect(response.status).toBe(423)
+      expect(service.refundPayment).not.toHaveBeenCalled()
+    })
+
+    it('runs after-success hooks once the refund succeeds', async () => {
+      const response = await refundPayment(buildRequest(body))
+      expect(response.status).toBe(200)
+      expect(service.refundPayment).toHaveBeenCalledTimes(1)
+      expect(runPaymentGatewayMutationGuardAfterSuccess).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('POST /payment_gateways/cancel (update)', () => {
+    const body = { transactionId: TXN_ID }
+
+    it('runs the mutation guard with an update operation scoped to the transaction', async () => {
+      await cancelPayment(buildRequest(body))
+      expect(runPaymentGatewayMutationGuards).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ resourceKind: RESOURCE_KIND, operation: 'update', resourceId: TXN_ID }),
+        [],
+      )
+    })
+
+    it('returns the guard rejection and does not cancel when blocked', async () => {
+      ;(runPaymentGatewayMutationGuards as jest.Mock).mockResolvedValue({
+        ok: false,
+        errorStatus: 423,
+        errorBody: { error: 'Record is locked', code: 'record_locked' },
+        afterSuccessCallbacks: [],
+      })
+      const response = await cancelPayment(buildRequest(body))
+      expect(response.status).toBe(423)
+      expect(service.cancelPayment).not.toHaveBeenCalled()
+    })
+
+    it('runs after-success hooks once the cancel succeeds', async () => {
+      const response = await cancelPayment(buildRequest(body))
+      expect(response.status).toBe(200)
+      expect(service.cancelPayment).toHaveBeenCalledTimes(1)
+      expect(runPaymentGatewayMutationGuardAfterSuccess).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/core/src/modules/payment_gateways/api/cancel/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/cancel/route.ts
@@ -5,6 +5,13 @@ import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { cancelSchema } from '../../data/validators'
 import type { PaymentGatewayService } from '../../lib/gateway-service'
 import { paymentGatewaysTag } from '../openapi'
+import {
+  resolveUserFeatures,
+  runPaymentGatewayMutationGuardAfterSuccess,
+  runPaymentGatewayMutationGuards,
+} from '../guards'
+
+const gatewayTransactionResourceKind = 'payment_gateways.gateway_transaction'
 
 export const metadata = {
   path: '/payment_gateways/cancel',
@@ -24,6 +31,28 @@ export async function POST(req: Request) {
   }
 
   const container = await createRequestContainer()
+  const guardResult = await runPaymentGatewayMutationGuards(
+    container,
+    {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+      userId: auth.sub ?? '',
+      resourceKind: gatewayTransactionResourceKind,
+      resourceId: parsed.data.transactionId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: parsed.data as Record<string, unknown>,
+    },
+    resolveUserFeatures(auth),
+  )
+  if (!guardResult.ok) {
+    return NextResponse.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
+
   const service = container.resolve('paymentGatewayService') as PaymentGatewayService
 
   try {
@@ -32,6 +61,16 @@ export async function POST(req: Request) {
       parsed.data.reason,
       { organizationId: auth.orgId as string, tenantId: auth.tenantId },
     )
+    await runPaymentGatewayMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+      userId: auth.sub ?? '',
+      resourceKind: gatewayTransactionResourceKind,
+      resourceId: parsed.data.transactionId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+    })
     return NextResponse.json(result)
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Cancel failed'

--- a/packages/core/src/modules/payment_gateways/api/capture/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/capture/route.ts
@@ -5,6 +5,13 @@ import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { captureSchema } from '../../data/validators'
 import type { PaymentGatewayService } from '../../lib/gateway-service'
 import { paymentGatewaysTag } from '../openapi'
+import {
+  resolveUserFeatures,
+  runPaymentGatewayMutationGuardAfterSuccess,
+  runPaymentGatewayMutationGuards,
+} from '../guards'
+
+const gatewayTransactionResourceKind = 'payment_gateways.gateway_transaction'
 
 export const metadata = {
   path: '/payment_gateways/capture',
@@ -24,6 +31,28 @@ export async function POST(req: Request) {
   }
 
   const container = await createRequestContainer()
+  const guardResult = await runPaymentGatewayMutationGuards(
+    container,
+    {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+      userId: auth.sub ?? '',
+      resourceKind: gatewayTransactionResourceKind,
+      resourceId: parsed.data.transactionId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: parsed.data as Record<string, unknown>,
+    },
+    resolveUserFeatures(auth),
+  )
+  if (!guardResult.ok) {
+    return NextResponse.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
+
   const service = container.resolve('paymentGatewayService') as PaymentGatewayService
 
   try {
@@ -32,6 +61,16 @@ export async function POST(req: Request) {
       parsed.data.amount,
       { organizationId: auth.orgId as string, tenantId: auth.tenantId },
     )
+    await runPaymentGatewayMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+      userId: auth.sub ?? '',
+      resourceKind: gatewayTransactionResourceKind,
+      resourceId: parsed.data.transactionId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+    })
     return NextResponse.json(result)
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Capture failed'

--- a/packages/core/src/modules/payment_gateways/api/guards.ts
+++ b/packages/core/src/modules/payment_gateways/api/guards.ts
@@ -1,0 +1,59 @@
+import type { AwilixContainer } from 'awilix'
+import {
+  bridgeLegacyGuard,
+  runMutationGuards,
+  type MutationGuard,
+  type MutationGuardInput,
+} from '@open-mercato/shared/lib/crud/mutation-guard-registry'
+
+type GuardAfterCallback = {
+  guard: MutationGuard
+  metadata: Record<string, unknown> | null
+}
+
+export function resolveUserFeatures(auth: unknown): string[] {
+  const features = (auth as { features?: unknown })?.features
+  if (!Array.isArray(features)) return []
+  return features.filter((value): value is string => typeof value === 'string')
+}
+
+export async function runPaymentGatewayMutationGuards(
+  container: AwilixContainer,
+  input: MutationGuardInput,
+  userFeatures: string[],
+): Promise<{
+  ok: boolean
+  errorBody?: Record<string, unknown>
+  errorStatus?: number
+  modifiedPayload?: Record<string, unknown>
+  afterSuccessCallbacks: GuardAfterCallback[]
+}> {
+  const legacyGuard = bridgeLegacyGuard(container)
+  if (!legacyGuard) {
+    return { ok: true, afterSuccessCallbacks: [] }
+  }
+
+  return runMutationGuards([legacyGuard], input, { userFeatures })
+}
+
+export async function runPaymentGatewayMutationGuardAfterSuccess(
+  callbacks: GuardAfterCallback[],
+  input: {
+    tenantId: string
+    organizationId: string | null
+    userId: string
+    resourceKind: string
+    resourceId: string
+    operation: 'create' | 'update' | 'delete'
+    requestMethod: string
+    requestHeaders: Headers
+  },
+): Promise<void> {
+  for (const callback of callbacks) {
+    if (!callback.guard.afterSuccess) continue
+    await callback.guard.afterSuccess({
+      ...input,
+      metadata: callback.metadata ?? null,
+    })
+  }
+}

--- a/packages/core/src/modules/payment_gateways/api/refund/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/refund/route.ts
@@ -5,6 +5,13 @@ import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { refundSchema } from '../../data/validators'
 import type { PaymentGatewayService } from '../../lib/gateway-service'
 import { paymentGatewaysTag } from '../openapi'
+import {
+  resolveUserFeatures,
+  runPaymentGatewayMutationGuardAfterSuccess,
+  runPaymentGatewayMutationGuards,
+} from '../guards'
+
+const gatewayTransactionResourceKind = 'payment_gateways.gateway_transaction'
 
 export const metadata = {
   path: '/payment_gateways/refund',
@@ -24,6 +31,28 @@ export async function POST(req: Request) {
   }
 
   const container = await createRequestContainer()
+  const guardResult = await runPaymentGatewayMutationGuards(
+    container,
+    {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+      userId: auth.sub ?? '',
+      resourceKind: gatewayTransactionResourceKind,
+      resourceId: parsed.data.transactionId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: parsed.data as Record<string, unknown>,
+    },
+    resolveUserFeatures(auth),
+  )
+  if (!guardResult.ok) {
+    return NextResponse.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
+
   const service = container.resolve('paymentGatewayService') as PaymentGatewayService
 
   try {
@@ -33,6 +62,16 @@ export async function POST(req: Request) {
       parsed.data.reason,
       { organizationId: auth.orgId as string, tenantId: auth.tenantId },
     )
+    await runPaymentGatewayMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+      userId: auth.sub ?? '',
+      resourceKind: gatewayTransactionResourceKind,
+      resourceId: parsed.data.transactionId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+    })
     return NextResponse.json(result)
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Refund failed'

--- a/packages/core/src/modules/payment_gateways/api/sessions/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/sessions/route.ts
@@ -5,6 +5,13 @@ import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { createSessionSchema } from '../../data/validators'
 import type { PaymentGatewayService } from '../../lib/gateway-service'
 import { paymentGatewaysTag } from '../openapi'
+import {
+  resolveUserFeatures,
+  runPaymentGatewayMutationGuardAfterSuccess,
+  runPaymentGatewayMutationGuards,
+} from '../guards'
+
+const gatewayTransactionResourceKind = 'payment_gateways.gateway_transaction'
 
 export const metadata = {
   path: '/payment_gateways/sessions',
@@ -24,6 +31,28 @@ export async function POST(req: Request) {
   }
 
   const container = await createRequestContainer()
+  const guardResult = await runPaymentGatewayMutationGuards(
+    container,
+    {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+      userId: auth.sub ?? '',
+      resourceKind: gatewayTransactionResourceKind,
+      resourceId: null,
+      operation: 'create',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: parsed.data as Record<string, unknown>,
+    },
+    resolveUserFeatures(auth),
+  )
+  if (!guardResult.ok) {
+    return NextResponse.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
+
   const service = container.resolve('paymentGatewayService') as PaymentGatewayService
 
   try {
@@ -45,6 +74,17 @@ export async function POST(req: Request) {
 
     const redirectUrl = session.redirectUrl
       ?? (session.clientSession?.type === 'redirect' ? session.clientSession.redirectUrl : null)
+
+    await runPaymentGatewayMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+      userId: auth.sub ?? '',
+      resourceKind: gatewayTransactionResourceKind,
+      resourceId: transaction.id,
+      operation: 'create',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+    })
 
     return NextResponse.json({
       transactionId: transaction.id,


### PR DESCRIPTION
## Summary

Payment gateway custom write routes mutated money-related state without running the
mutation-guard lifecycle that core guidance mandates for every custom (non-`makeCrudRoute`)
write route. This wires `validate-before-mutate` + `after-success` hooks into all four
gateway write routes, so record-locks and any registered mutation guards now apply to
payment session creation, capture, refund, and cancel. RBAC, request/response shapes,
provider error mapping, and integration logging are unchanged.

## Changes

- Add `packages/core/src/modules/payment_gateways/api/guards.ts` — module-local helper
  (`resolveUserFeatures`, `runPaymentGatewayMutationGuards`,
  `runPaymentGatewayMutationGuardAfterSuccess`) mirroring the canonical
  `integrations`/`staff` guard helpers, using the current `bridgeLegacyGuard` +
  `runMutationGuards` path (not the deprecated `validateCrudMutationGuard`).
- `api/sessions/route.ts`: run the guard (`operation: 'create'`) before
  `createPaymentSession`; run after-success hooks (`resourceId: transaction.id`) on success.
- `api/capture/route.ts`, `api/refund/route.ts`, `api/cancel/route.ts`: run the guard
  (`operation: 'update'`, `resourceId: transactionId`) before the mutating service call;
  run after-success hooks on success. A blocked guard returns its status/body and the
  service is never called.
- Add `api/__tests__/guarded-routes.test.ts` covering the lifecycle for all four routes.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — focused bug fix wiring an existing contract (`packages/core/AGENTS.md` → API Routes
→ "Wire custom write routes through the mutation guard contract").

## Testing

- `yarn workspace @open-mercato/core test -- --testPathPattern "payment_gateways/api/__tests__/guarded-routes"` — 12/12 (red → green)
- `yarn workspace @open-mercato/core test -- --testPathPattern "payment_gateways"` — 20/20
- `yarn workspace @open-mercato/core test` — 742 suites / 6078 tests pass
- `yarn typecheck` — 21/21 pass
- `yarn i18n:check-sync` — pass
- `yarn build:packages` (around `yarn generate`) + `yarn build:app` — pass

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — no new locales/generators; behavior wires an existing contract.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Documented: the guard-lifecycle wiring is exercised by jest route tests (`api/__tests__/guarded-routes.test.ts`), matching how the sibling `integrations`/`staff` guard wiring is tested (`integrations/api/__tests__/credentials-route.test.ts`). The block path only manifests when a record-lock/mutation guard actively targets payment transactions, which the shared integration env does not seed; no new external API surface to drive end-to-end.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec.)
- [x] Priority set: this PR carries exactly one `priority-*` label. — `priority-high` (inherited from the issue).
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. — `risk-high` (touches money-mutation routes).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. — `needs-qa`: backend-only with no UI/response-shape change, but it sits on payment-mutation paths and can now return a guard block (423/409) where it previously always proceeded; conservative QA on a money path.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #3270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
