### PR TITLE
fix(payment_gateways): make status refresh a guarded write instead of a mutating GET (#3269)

### DIFF
--- a/apps/mercato/src/modules/example/backend/payments/page.tsx
+++ b/apps/mercato/src/modules/example/backend/payments/page.tsx
@@ -327,7 +327,10 @@ export default function PaymentGatewayDemoPage() {
   async function refreshStatus(transactionId = transaction?.transactionId) {
     if (!transactionId) return
     try {
-      const response = await apiCall(`/api/payment_gateways/status?transactionId=${encodeURIComponent(transactionId)}`)
+      const response = await apiCall('/api/payment_gateways/status', {
+        method: 'POST',
+        body: JSON.stringify({ transactionId }),
+      })
       if (response.ok) {
         const data = response.result as { status?: string } | null
         setTransaction((prev) => prev ? { ...prev, status: data?.status ?? prev.status } : prev)

--- a/packages/core/src/modules/payment_gateways/api/__tests__/status-route.test.ts
+++ b/packages/core/src/modules/payment_gateways/api/__tests__/status-route.test.ts
@@ -1,0 +1,151 @@
+/** @jest-environment node */
+import { GET, POST } from '../status/route'
+
+const mockResolve = jest.fn()
+const mockGetAuth = jest.fn()
+const mockValidateGuard = jest.fn()
+const mockRunGuardAfter = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({ resolve: mockResolve })),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuth(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => mockValidateGuard(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => mockRunGuardAfter(...args),
+}))
+
+const TRANSACTION_ID = '11111111-1111-4111-8111-111111111111'
+
+function makeTransaction() {
+  return {
+    id: TRANSACTION_ID,
+    paymentId: '22222222-2222-4222-8222-222222222222',
+    providerKey: 'stripe',
+    providerSessionId: 'sess_123',
+    unifiedStatus: 'authorized',
+    gatewayStatus: 'requires_capture',
+    amount: '100.0000',
+    currencyCode: 'USD',
+    redirectUrl: null,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+  }
+}
+
+function makeService() {
+  return {
+    findTransaction: jest.fn().mockResolvedValue(makeTransaction()),
+    getPaymentStatus: jest.fn().mockResolvedValue({
+      status: 'captured',
+      amount: 100,
+      amountReceived: 100,
+      currencyCode: 'USD',
+      providerData: {},
+    }),
+  }
+}
+
+function getRequest(transactionId: string = TRANSACTION_ID): Request {
+  return {
+    method: 'GET',
+    url: `http://localhost/api/payment_gateways/status?transactionId=${transactionId}`,
+    headers: new Headers(),
+  } as unknown as Request
+}
+
+function postRequest(body: unknown): Request {
+  return {
+    method: 'POST',
+    url: 'http://localhost/api/payment_gateways/status',
+    headers: new Headers({ 'content-type': 'application/json' }),
+    text: jest.fn(async () => JSON.stringify(body)),
+  } as unknown as Request
+}
+
+describe('payment_gateways status route', () => {
+  let service: ReturnType<typeof makeService>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    service = makeService()
+    mockGetAuth.mockResolvedValue({
+      sub: '33333333-3333-4333-8333-333333333333',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+    })
+    mockResolve.mockImplementation((token: string) => {
+      if (token === 'paymentGatewayService') return service
+      throw new Error(`Unexpected token: ${token}`)
+    })
+    mockValidateGuard.mockResolvedValue(null)
+    mockRunGuardAfter.mockResolvedValue(undefined)
+  })
+
+  describe('GET (read-only)', () => {
+    it('returns stored status WITHOUT polling the provider (a read must not mutate)', async () => {
+      const res = await GET(getRequest())
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      // Regression for #3269: the GET handler must not invoke the mutating provider poller.
+      expect(service.getPaymentStatus).not.toHaveBeenCalled()
+      expect(service.findTransaction).toHaveBeenCalledTimes(1)
+      // Response reflects the stored transaction state, not a freshly polled value.
+      expect(body.status).toBe('authorized')
+      expect(body.amount).toBe(100)
+    })
+
+    it('returns 404 when the transaction is missing', async () => {
+      service.findTransaction.mockResolvedValue(null)
+      const res = await GET(getRequest())
+      expect(res.status).toBe(404)
+      expect(service.getPaymentStatus).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('POST (guarded refresh)', () => {
+    it('polls the provider and routes the write through the mutation guard lifecycle', async () => {
+      const res = await POST(postRequest({ transactionId: TRANSACTION_ID }))
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(service.getPaymentStatus).toHaveBeenCalledTimes(1)
+      expect(service.getPaymentStatus).toHaveBeenCalledWith(TRANSACTION_ID, {
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+      })
+      expect(mockValidateGuard).toHaveBeenCalledTimes(1)
+      const guardInput = mockValidateGuard.mock.calls[0][1]
+      expect(guardInput).toMatchObject({
+        resourceKind: 'payment_gateways:gateway_transaction',
+        resourceId: TRANSACTION_ID,
+        operation: 'custom',
+        requestMethod: 'POST',
+      })
+      expect(body.status).toBe('captured')
+    })
+
+    it('blocks the write when the mutation guard denies it', async () => {
+      mockValidateGuard.mockResolvedValue({ ok: false, status: 409, body: { error: 'locked' } })
+      const res = await POST(postRequest({ transactionId: TRANSACTION_ID }))
+      expect(res.status).toBe(409)
+      expect(service.getPaymentStatus).not.toHaveBeenCalled()
+    })
+
+    it('rejects an invalid payload with 422', async () => {
+      const res = await POST(postRequest({ transactionId: 'not-a-uuid' }))
+      expect(res.status).toBe(422)
+      expect(service.getPaymentStatus).not.toHaveBeenCalled()
+    })
+
+    it('returns 404 when the transaction is missing', async () => {
+      service.findTransaction.mockResolvedValue(null)
+      const res = await POST(postRequest({ transactionId: TRANSACTION_ID }))
+      expect(res.status).toBe(404)
+      expect(service.getPaymentStatus).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/modules/payment_gateways/api/status/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/status/route.ts
@@ -1,13 +1,21 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { getStatusSchema } from '../../data/validators'
 import type { PaymentGatewayService } from '../../lib/gateway-service'
 import { paymentGatewaysTag } from '../openapi'
 
+const gatewayTransactionResourceKind = 'payment_gateways:gateway_transaction'
+
 export const metadata = {
   path: '/payment_gateways/status',
   GET: { requireAuth: true, requireFeatures: ['payment_gateways.view'] },
+  POST: { requireAuth: true, requireFeatures: ['payment_gateways.manage'] },
 }
 
 export async function GET(req: Request) {
@@ -36,7 +44,80 @@ export async function GET(req: Request) {
       return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
     }
 
+    return NextResponse.json({
+      transactionId: transaction.id,
+      paymentId: transaction.paymentId,
+      providerKey: transaction.providerKey,
+      sessionId: transaction.providerSessionId,
+      status: transaction.unifiedStatus,
+      gatewayStatus: transaction.gatewayStatus,
+      amount: Number(transaction.amount),
+      amountReceived: null,
+      currencyCode: transaction.currencyCode,
+      redirectUrl: transaction.redirectUrl,
+      createdAt: transaction.createdAt.toISOString(),
+      updatedAt: transaction.updatedAt.toISOString(),
+    })
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Failed to get status'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  const auth = await getAuthFromRequest(req)
+  if (!auth?.tenantId || !auth.orgId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const payload = await readJsonSafe<unknown>(req)
+  const parsed = getStatusSchema.safeParse(payload)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid payload', details: parsed.error.flatten() }, { status: 422 })
+  }
+
+  const container = await createRequestContainer()
+  const service = container.resolve('paymentGatewayService') as PaymentGatewayService
+  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const actorUserId = auth.userId ?? auth.sub
+  const { transactionId } = parsed.data
+
+  try {
+    const transaction = await service.findTransaction(transactionId, scope)
+    if (!transaction) {
+      return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
+    }
+
+    const guardResult = await validateCrudMutationGuard(container, {
+      tenantId: auth.tenantId,
+      organizationId: scope.organizationId,
+      userId: actorUserId,
+      resourceKind: gatewayTransactionResourceKind,
+      resourceId: transactionId,
+      operation: 'custom',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: parsed.data,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
+
     const status = await service.getPaymentStatus(transactionId, scope)
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(container, {
+        tenantId: auth.tenantId,
+        organizationId: scope.organizationId,
+        userId: actorUserId,
+        resourceKind: gatewayTransactionResourceKind,
+        resourceId: transactionId,
+        operation: 'custom',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     return NextResponse.json({
       transactionId: transaction.id,
@@ -53,22 +134,33 @@ export async function GET(req: Request) {
       updatedAt: transaction.updatedAt.toISOString(),
     })
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : 'Failed to get status'
-    return NextResponse.json({ error: message }, { status: 500 })
+    const message = err instanceof Error ? err.message : 'Failed to refresh status'
+    return NextResponse.json({ error: message }, { status: 502 })
   }
 }
 
 export const openApi = {
   tags: [paymentGatewaysTag],
-  summary: 'Get payment transaction status',
+  summary: 'Payment transaction status',
   methods: {
     GET: {
-      summary: 'Get transaction status',
+      summary: 'Get stored transaction status',
       tags: [paymentGatewaysTag],
       responses: [
-        { status: 200, description: 'Transaction status' },
+        { status: 200, description: 'Stored transaction status' },
         { status: 400, description: 'Missing or malformed transactionId' },
         { status: 404, description: 'Transaction not found' },
+      ],
+    },
+    POST: {
+      summary: 'Refresh transaction status from the provider',
+      tags: [paymentGatewaysTag],
+      responses: [
+        { status: 200, description: 'Refreshed transaction status' },
+        { status: 401, description: 'Unauthorized' },
+        { status: 404, description: 'Transaction not found' },
+        { status: 422, description: 'Missing or malformed payload' },
+        { status: 502, description: 'Gateway provider error' },
       ],
     },
   },

--- a/packages/core/src/modules/payment_gateways/backend/payment-gateways/page.tsx
+++ b/packages/core/src/modules/payment_gateways/backend/payment-gateways/page.tsx
@@ -290,19 +290,35 @@ export default function PaymentTransactionsPage() {
   const handleRefreshStatus = React.useCallback(async () => {
     if (!selectedId) return
     setIsRefreshingStatus(true)
-    const call = await apiCall(`/api/payment_gateways/status?transactionId=${encodeURIComponent(selectedId)}`, undefined, { fallback: null })
-    if (!call.ok) {
-      flash(t('payment_gateways.transactions.error.refreshStatus', 'Failed to refresh transaction status'), 'error')
+    try {
+      await runMutation({
+        operation: async () => {
+          await apiCallOrThrow('/api/payment_gateways/status', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ transactionId: selectedId }),
+          })
+        },
+        context: {
+          entityType: 'payment_gateways:gateway_transaction',
+          entityId: selectedId,
+        },
+        mutationPayload: { transactionId: selectedId },
+      })
+      await Promise.all([
+        loadRows(),
+        loadDetail(selectedId),
+      ])
+      flash(t('payment_gateways.transactions.success.refreshStatus', 'Transaction status refreshed'), 'success')
+    } catch (error) {
+      const message = error instanceof Error && error.message
+        ? error.message
+        : t('payment_gateways.transactions.error.refreshStatus', 'Failed to refresh transaction status')
+      flash(message, 'error')
+    } finally {
       setIsRefreshingStatus(false)
-      return
     }
-    await Promise.all([
-      loadRows(),
-      loadDetail(selectedId),
-    ])
-    flash(t('payment_gateways.transactions.success.refreshStatus', 'Transaction status refreshed'), 'success')
-    setIsRefreshingStatus(false)
-  }, [loadDetail, loadRows, selectedId, t])
+  }, [loadDetail, loadRows, runMutation, selectedId, t])
 
   const handleCapturePayment = React.useCallback(async () => {
     if (!selectedId) return

--- a/packages/create-app/template/src/modules/example/backend/payments/page.tsx
+++ b/packages/create-app/template/src/modules/example/backend/payments/page.tsx
@@ -327,7 +327,10 @@ export default function PaymentGatewayDemoPage() {
   async function refreshStatus(transactionId = transaction?.transactionId) {
     if (!transactionId) return
     try {
-      const response = await apiCall(`/api/payment_gateways/status?transactionId=${encodeURIComponent(transactionId)}`)
+      const response = await apiCall('/api/payment_gateways/status', {
+        method: 'POST',
+        body: JSON.stringify({ transactionId }),
+      })
       if (response.ok) {
         const data = response.result as { status?: string } | null
         setTransaction((prev) => prev ? { ...prev, status: data?.status ?? prev.status } : prev)


### PR DESCRIPTION
## Summary

`GET /api/payment_gateways/status` was a read route (gated by `payment_gateways.view`) but its handler called `getPaymentStatus()`, which polls the provider and mutates `GatewayTransaction` (DB write, event emission, integration log) — a mutating GET running outside the write-guard path. This makes the GET pure (stored state only) and moves the provider-polling refresh into a guarded `POST /api/payment_gateways/status` (`payment_gateways.manage`) routed through the mutation-guard lifecycle, with the backend page calling it via `useGuardedMutation`.

## Changes

- `payment_gateways/api/status/route.ts`: `GET` returns stored transaction state only (no poll/mutation); new guarded `POST` performs the provider refresh, wired with `validateCrudMutationGuard` (before) + `runCrudMutationGuardAfterSuccess` (after); `openApi` documents both methods.
- `payment_gateways/backend/payment-gateways/page.tsx`: refresh button now POSTs via `useGuardedMutation().runMutation(...)` (mirrors the existing `handleCapturePayment`).
- `example/backend/payments/page.tsx` (app + create-app template): `refreshStatus` switched GET→POST so it re-polls via the guarded write (the endpoint contract change applied to all call sites).
- Added route-level regression test `payment_gateways/api/__tests__/status-route.test.ts`.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — security/correctness bug fix scoped to one route + its call sites.

## Testing

- `yarn workspace @open-mercato/core test status-route.test` → 6/6 pass (verified RED on the pre-fix mutating GET: the GET test fails at `expect(getPaymentStatus).not.toHaveBeenCalled()`)
- `yarn workspace @open-mercato/core test payment_gateways` → 14/14 pass
- `yarn workspace @open-mercato/core` typecheck (`tsc --noEmit`) → 0 errors
- `apps/mercato` typecheck (`tsc --noEmit`) → 0 errors
- `yarn generate` → success; `yarn i18n:check-sync` → in sync; `yarn workspace @open-mercato/core build` → success

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (ran `yarn generate`; no locale/doc changes needed)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Documented: behavior is at the API-contract level and fully covered by the deterministic route-level test; an end-to-end refresh would require a live provider session/transaction fixture, so dedicated `.ai/qa/tests/` coverage is not required.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A (no spec).
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-high` — payment/money + API contract surface + cross-module call sites)
- [x] QA routing set: `needs-qa` (payment-related backend UI/flow change).

### Design System Compliance
- [x] No hardcoded status colors — UI edits are logic-only (no color tokens added).
- [x] No arbitrary text sizes — none added.
- [x] Empty state handled for list/data pages — existing handling unchanged.
- [x] Loading state handled for async pages — `isRefreshingStatus` retained.
- [x] `aria-label` on all icon-only buttons — no buttons added/changed.
- [x] Uses existing DS components — `flash`, `Button`, `runMutation`; no custom replacements.

## Linked issues

Fixes #3269

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
