### PR TITLE
feat: support dictionary custom field multiselect

### DIFF
--- a/.ai/specs/2026-06-19-dictionary-custom-field-multiselect.md
+++ b/.ai/specs/2026-06-19-dictionary-custom-field-multiselect.md
@@ -1,0 +1,75 @@
+# Dictionary Custom Field Multiselect
+
+## TLDR
+
+Dictionary-backed custom fields can opt into multiple values by setting `multi: true`. Generated `CrudForm` custom-field sections render those fields as built-in multi-select listboxes backed by the existing dictionary entries endpoint, and values round-trip as arrays through the existing custom-field EAV storage.
+
+## Overview
+
+The custom-field system already supports multi-value fields and array persistence for user-editable custom fields. Dictionary custom fields, however, were wired to a specialized single-value dictionary selector so generated forms could only choose one entry even when the definition carried `multi: true`.
+
+This change makes dictionary multi-value support a form-generation concern. Single-value dictionary fields keep using the existing registered dictionary control, including inline entry creation. Multi-value dictionary fields use the generic `CrudForm` select/listbox behavior and load options from `/api/dictionaries/:id/entries`.
+
+## Problem Statement
+
+Users defining dictionary custom fields need a way to select more than one dictionary entry in generated create/edit forms. The previous generated form path treated dictionary fields as scalar custom controls, so records could not be edited naturally with multiple dictionary values even though custom-field storage can already persist arrays.
+
+The change must not introduce a new storage model, widen `CustomFieldDefinition.defaultValue`, or change dictionary entry APIs.
+
+## Proposed Solution
+
+- Extend custom-field form mapping so `kind: "dictionary"` plus `multi: true` returns a built-in `select` field with `multiple: true`, `listbox: true`, empty initial options, and async `loadOptions`.
+- Resolve options from `def.optionsUrl` when supplied, otherwise from `/api/dictionaries/:dictionaryId/entries`.
+- Preserve existing registered dictionary custom input behavior for single-value dictionary fields.
+- Add a `Multiple values` toggle to the dictionary custom-field definition editor.
+- Hide and clear the single-value default selector when multiple values are enabled.
+- Keep `dictionaryInlineCreate` scoped to single-value dictionary fields; multi inline-create is intentionally out of scope.
+
+## Architecture
+
+The implementation touches two form surfaces:
+
+- `packages/ui/src/backend/utils/customFieldForms.ts` owns generated `CrudForm` field definitions. It now branches dictionary fields by `multi`.
+- `packages/core/src/modules/dictionaries/fields/dictionary.tsx` owns dictionary-specific custom-field definition editing. It exposes the multi toggle and hides scalar-only controls when enabled.
+
+No server route needs to change. Custom-field definition payloads already carry `multi`, `dictionaryId`, and `optionsUrl`, and entity record writes already accept array values for multi fields.
+
+## Data Models
+
+No database migration is required.
+
+- `CustomFieldDefinition.defaultValue` remains scalar.
+- Multi dictionary record values are stored using the existing custom-field EAV array handling.
+- Dictionary entry values remain the persisted token values returned by the existing entries API.
+
+## API Contracts
+
+No new endpoints or route contracts are introduced.
+
+Covered existing APIs:
+
+- `GET /api/dictionaries/:id/entries` for option loading.
+- `POST /api/entities/definitions` for dictionary custom-field definitions with `multi: true`.
+- `POST /api/entities/records` and `PUT /api/entities/records` for array custom-field values.
+- `GET /api/entities/records` for list/detail readback.
+
+## Risks & Impact Review
+
+| Risk | Severity | Affected Area | Mitigation | Residual Risk |
+| --- | --- | --- | --- | --- |
+| Single-value dictionary behavior regresses | Medium | Generated CRUD forms | Unit coverage asserts single dictionary fields remain custom registered inputs. | Low |
+| Multi dictionary option loading diverges from dictionary APIs | Medium | Generated CRUD forms | Reuses the existing dictionary entries endpoint and shared remote-option loader. | Low |
+| Array values fail to round-trip | High | Custom entities and records | Integration coverage creates, updates, and reads back multi dictionary values. | Low |
+| Scalar default values accidentally become arrays | Medium | Custom-field definitions | Multi default values stay out of scope and the editor clears scalar defaults when multi is enabled. | Low |
+
+## Final Compliance Report
+
+- Tenant and organization scoping is unchanged.
+- No database schema, migration, or dictionary entry API changes are introduced.
+- Single-value dictionary fields keep their current inline-create flow.
+- Multi-value defaults and multi inline-create are deferred by design.
+- The feature is covered by focused UI helper tests and custom-entity API readback coverage.
+
+## Changelog
+
+- 2026-06-19: Added dictionary multi-select support for generated custom-field forms and dictionary field-definition editing.

--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -99,6 +99,7 @@ Specs awaiting implementation or partially complete. Focus here for actionable w
 | [Sales Payments Tenant Scope](implemented/2026-06-06-sales-recompute-order-payment-totals-tenant-scope.md) | 2026-06-06 | sales(payments): scope `recomputeOrderPaymentTotals` order lookups by tenant/organization | Defence-in-depth scope filter + `ensureSameScope` on 7 `findOne(SalesOrder, …)` sites in `payments.ts` (#2111) |
 | [Checkout Cookie sessionVersion](implemented/2026-06-06-checkout-access-cookie-non-reversible-session-version.md) | 2026-06-06 | Derive checkout access cookie sessionVersion | Non-reversible HMAC-SHA256 derivation of the embedded `sessionVersion` so the bcrypt `passwordHash` never appears in the client-readable cookie payload (#2675) |
 | [Organization Sidebar Logo](2026-06-08-organization-sidebar-logo.md) | 2026-06-08 | Organization Sidebar Logo | Organization-level backend sidebar logo branding with additive `organizations.logo_url`, branding API, Directory settings UI, and admin nav brand payload |
+| [Dictionary Custom Field Multiselect](2026-06-19-dictionary-custom-field-multiselect.md) | 2026-06-19 | Dictionary Custom Field Multiselect | Dictionary-backed custom fields can opt into multi-select CRUD form rendering while reusing existing EAV array persistence |
 
 ### Implemented Specifications
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+# Unreleased
+
+## ✨ Features
+- ✨ Entities: dictionary custom fields can now opt into multi-value CRUD form rendering backed by existing dictionary entries and custom-field array persistence.
+
 # 0.6.5 (2026-06-15)
 
 ## Highlights

--- a/packages/core/src/modules/dictionaries/fields/__tests__/dictionary.test.tsx
+++ b/packages/core/src/modules/dictionaries/fields/__tests__/dictionary.test.tsx
@@ -58,7 +58,7 @@ describe('dictionary field defEditor', () => {
   it('renders the shared Checkbox primitive instead of a native checkbox input', async () => {
     renderEditor({ configJson: { dictionaryId: 'dict-1', dictionaryInlineCreate: true } })
 
-    const checkbox = await screen.findByRole('checkbox')
+    const checkbox = await screen.findByLabelText('Allow inline creation inside forms')
     expect(checkbox.tagName).toBe('BUTTON')
     expect(checkbox).toHaveAttribute('data-state', 'checked')
   })
@@ -67,7 +67,7 @@ describe('dictionary field defEditor', () => {
     const onChange = jest.fn()
     renderEditor({ configJson: { dictionaryId: 'dict-1', dictionaryInlineCreate: true } }, onChange)
 
-    const checkbox = await screen.findByRole('checkbox')
+    const checkbox = await screen.findByLabelText('Allow inline creation inside forms')
     fireEvent.click(checkbox)
     expect(onChange).toHaveBeenCalledWith({ dictionaryInlineCreate: false })
   })
@@ -75,8 +75,19 @@ describe('dictionary field defEditor', () => {
   it('disables the inline-create checkbox until a dictionary is selected', async () => {
     renderEditor({ configJson: {} })
 
-    const checkbox = await screen.findByRole('checkbox')
+    const checkbox = await screen.findByLabelText('Allow inline creation inside forms')
     expect(checkbox).toBeDisabled()
+  })
+
+  it('toggles multi-value dictionary fields and clears scalar defaults', async () => {
+    const onChange = jest.fn()
+    renderEditor({ configJson: { dictionaryId: 'dict-1', defaultValue: 'north' } }, onChange)
+
+    const checkbox = await screen.findByLabelText('Allow selecting multiple entries')
+    expect(checkbox).toHaveAttribute('data-state', 'unchecked')
+
+    fireEvent.click(checkbox)
+    expect(onChange).toHaveBeenCalledWith({ multi: true, defaultValue: undefined })
   })
 
   it('uses the design-system error token (not text-red-600) for load failures', async () => {

--- a/packages/core/src/modules/dictionaries/fields/dictionary.tsx
+++ b/packages/core/src/modules/dictionaries/fields/dictionary.tsx
@@ -19,6 +19,7 @@ import { useDictionaryEntries } from '../components/hooks/useDictionaryEntries'
 type DictionaryFieldDefinition = {
   dictionaryId?: string
   dictionaryInlineCreate?: boolean
+  multi?: boolean
   defaultValue?: string
 }
 
@@ -84,9 +85,12 @@ function DictionaryFieldDefEditor({ def, onChange }: { def: { configJson?: Dicti
   const [items, setItems] = React.useState<DictionarySummary[]>([])
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
+  const multiId = React.useId()
   const inlineCreateId = React.useId()
   const selectedId = typeof def?.configJson?.dictionaryId === 'string' ? def?.configJson?.dictionaryId : ''
   const inlineCreate = def?.configJson?.dictionaryInlineCreate !== false
+  const isMulti = def?.configJson?.multi === true
+  const errorLoadLabel = t('dictionaries.customFields.errorLoad', 'Failed to load dictionaries.')
 
   React.useEffect(() => {
     let cancelled = false
@@ -116,7 +120,7 @@ function DictionaryFieldDefEditor({ def, onChange }: { def: { configJson?: Dicti
       } catch (err) {
         if (!cancelled) {
           console.error('Failed to load dictionaries list', err)
-          setError(t('dictionaries.customFields.errorLoad', 'Failed to load dictionaries.'))
+          setError(errorLoadLabel)
         }
       } finally {
         if (!cancelled) {
@@ -128,7 +132,7 @@ function DictionaryFieldDefEditor({ def, onChange }: { def: { configJson?: Dicti
     return () => {
       cancelled = true
     }
-  }, [t])
+  }, [errorLoadLabel])
 
   const manageHref = '/backend/config/dictionaries'
 
@@ -176,19 +180,38 @@ function DictionaryFieldDefEditor({ def, onChange }: { def: { configJson?: Dicti
       ) : null}
       <div className="inline-flex items-center gap-2 text-xs">
         <Checkbox
-          id={inlineCreateId}
-          checked={inlineCreate}
-          onCheckedChange={(checked) => onChange({ dictionaryInlineCreate: checked === true })}
+          id={multiId}
+          checked={isMulti}
+          onCheckedChange={(checked) => {
+            const enabled = checked === true
+            onChange({ multi: enabled, defaultValue: enabled ? undefined : def?.configJson?.defaultValue })
+          }}
           disabled={!selectedId}
         />
         <label
-          htmlFor={inlineCreateId}
+          htmlFor={multiId}
           className={selectedId ? 'cursor-pointer select-none' : 'cursor-not-allowed opacity-60'}
         >
-          {t('dictionaries.customFields.allowInlineCreate', 'Allow inline creation inside forms')}
+          {t('dictionaries.customFields.allowMultiple', 'Allow selecting multiple entries')}
         </label>
       </div>
-      {selectedId ? (
+      {!isMulti ? (
+        <div className="inline-flex items-center gap-2 text-xs">
+          <Checkbox
+            id={inlineCreateId}
+            checked={inlineCreate}
+            onCheckedChange={(checked) => onChange({ dictionaryInlineCreate: checked === true })}
+            disabled={!selectedId}
+          />
+          <label
+            htmlFor={inlineCreateId}
+            className={selectedId ? 'cursor-pointer select-none' : 'cursor-not-allowed opacity-60'}
+          >
+            {t('dictionaries.customFields.allowInlineCreate', 'Allow inline creation inside forms')}
+          </label>
+        </div>
+      ) : null}
+      {selectedId && !isMulti ? (
         <DictionaryDefaultSelector
           dictionaryId={selectedId}
           defaultValue={typeof def?.configJson?.defaultValue === 'string' ? def.configJson.defaultValue : ''}

--- a/packages/core/src/modules/dictionaries/i18n/de.json
+++ b/packages/core/src/modules/dictionaries/i18n/de.json
@@ -80,6 +80,7 @@
   "dictionaries.config.success.delete": "Wörterbuch gelöscht.",
   "dictionaries.config.success.update": "Wörterbuch aktualisiert.",
   "dictionaries.customFields.allowInlineCreate": "Inline-Erstellung in Formularen erlauben",
+  "dictionaries.customFields.allowMultiple": "Mehrere Einträge auswählen erlauben",
   "dictionaries.customFields.defaultValue": "Standardwert",
   "dictionaries.customFields.defaultValueNone": "Kein Standardwert",
   "dictionaries.customFields.defaultValueStale": "Standardeintrag nicht gefunden — er wurde möglicherweise gelöscht oder umbenannt.",

--- a/packages/core/src/modules/dictionaries/i18n/en.json
+++ b/packages/core/src/modules/dictionaries/i18n/en.json
@@ -80,6 +80,7 @@
   "dictionaries.config.success.delete": "Dictionary deleted.",
   "dictionaries.config.success.update": "Dictionary updated.",
   "dictionaries.customFields.allowInlineCreate": "Allow inline creation inside forms",
+  "dictionaries.customFields.allowMultiple": "Allow selecting multiple entries",
   "dictionaries.customFields.defaultValue": "Default value",
   "dictionaries.customFields.defaultValueNone": "No default",
   "dictionaries.customFields.defaultValueStale": "Default entry not found — it may have been deleted or renamed.",

--- a/packages/core/src/modules/dictionaries/i18n/es.json
+++ b/packages/core/src/modules/dictionaries/i18n/es.json
@@ -80,6 +80,7 @@
   "dictionaries.config.success.delete": "Diccionario eliminado.",
   "dictionaries.config.success.update": "Diccionario actualizado.",
   "dictionaries.customFields.allowInlineCreate": "Permitir creación en línea dentro de los formularios",
+  "dictionaries.customFields.allowMultiple": "Permitir seleccionar varias entradas",
   "dictionaries.customFields.defaultValue": "Valor predeterminado",
   "dictionaries.customFields.defaultValueNone": "Sin valor predeterminado",
   "dictionaries.customFields.defaultValueStale": "No se encontró la entrada predeterminada; puede haber sido eliminada o renombrada.",

--- a/packages/core/src/modules/dictionaries/i18n/pl.json
+++ b/packages/core/src/modules/dictionaries/i18n/pl.json
@@ -80,6 +80,7 @@
   "dictionaries.config.success.delete": "Słownik został usunięty.",
   "dictionaries.config.success.update": "Słownik został zaktualizowany.",
   "dictionaries.customFields.allowInlineCreate": "Zezwól na tworzenie w formularzach",
+  "dictionaries.customFields.allowMultiple": "Zezwól na wybór wielu wpisów",
   "dictionaries.customFields.defaultValue": "Wartość domyślna",
   "dictionaries.customFields.defaultValueNone": "Brak wartości domyślnej",
   "dictionaries.customFields.defaultValueStale": "Nie znaleziono domyślnego wpisu — mógł zostać usunięty albo przemianowany.",

--- a/packages/core/src/modules/entities/__integration__/TC-ENT-2055-RECORD-READBACK.spec.ts
+++ b/packages/core/src/modules/entities/__integration__/TC-ENT-2055-RECORD-READBACK.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type APIRequestContext } from '@playwright/test';
 import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { createDictionaryFixture } from '@open-mercato/core/helpers/integration/dictionariesFixtures';
 
 /**
  * TC-ENT-2055-RECORD-READBACK: the records surface serves CUSTOM entities only,
@@ -39,14 +40,36 @@ const SYSTEM_ENTITY_CASES: Array<{ entityId: string; values: Record<string, unkn
 
 const RUNTIME_ENTITY_ID = `qa_ent2055:readback_${Date.now()}`;
 
-const RUNTIME_FIELD_DEFS: Array<{ key: string; kind: string; configJson: Record<string, unknown> }> = [
-  { key: 'priority', kind: 'integer', configJson: { label: 'Priority', formEditable: true } },
-  { key: 'severity', kind: 'select', configJson: { label: 'Severity', options: ['low', 'medium', 'high'], formEditable: true } },
-  { key: 'blocked', kind: 'boolean', configJson: { label: 'Blocked', formEditable: true } },
-  { key: 'labels', kind: 'text', configJson: { label: 'Labels', multi: true, input: 'tags', formEditable: true } },
-  { key: 'assignee', kind: 'select', configJson: { label: 'Assignees', options: ['alice', 'bob', 'charlie'], multi: true, input: 'listbox', formEditable: true } },
-  { key: 'description', kind: 'multiline', configJson: { label: 'Description', formEditable: true } },
-];
+function buildRuntimeFieldDefs(dictionaryId: string): Array<{ key: string; kind: string; configJson: Record<string, unknown> }> {
+  return [
+    { key: 'priority', kind: 'integer', configJson: { label: 'Priority', formEditable: true } },
+    { key: 'severity', kind: 'select', configJson: { label: 'Severity', options: ['low', 'medium', 'high'], formEditable: true } },
+    { key: 'blocked', kind: 'boolean', configJson: { label: 'Blocked', formEditable: true } },
+    { key: 'labels', kind: 'text', configJson: { label: 'Labels', multi: true, input: 'tags', formEditable: true } },
+    { key: 'assignee', kind: 'select', configJson: { label: 'Assignees', options: ['alice', 'bob', 'charlie'], multi: true, input: 'listbox', formEditable: true } },
+    { key: 'regions', kind: 'dictionary', configJson: { label: 'Regions', dictionaryId, multi: true, formEditable: true, filterable: true } },
+    { key: 'description', kind: 'multiline', configJson: { label: 'Description', formEditable: true } },
+  ];
+}
+
+async function createDictionaryEntry(
+  request: APIRequestContext,
+  token: string,
+  dictionaryId: string,
+  value: string,
+  label: string,
+): Promise<string> {
+  const response = await apiRequest(
+    request,
+    'POST',
+    `/api/dictionaries/${encodeURIComponent(dictionaryId)}/entries`,
+    { token, data: { value, label } },
+  );
+  expect(response.status(), `dictionary entry ${value} create 201`).toBe(201);
+  const body = (await response.json()) as { id?: string };
+  expect(typeof body.id, `dictionary entry ${value} id`).toBe('string');
+  return body.id as string;
+}
 
 async function readById(
   request: APIRequestContext,
@@ -102,8 +125,19 @@ test.describe('TC-ENT-2055-RECORD-READBACK', () => {
     const token = await getAuthToken(request, 'admin');
     let recordId: string | null = null;
     let entityCreated = false;
+    let dictionaryId: string | null = null;
+    const dictionaryEntryIds: string[] = [];
 
     try {
+      dictionaryId = await createDictionaryFixture(request, token, {
+        key: `qa_ent2055_regions_${Date.now()}`,
+        name: 'QA ENT-2055 Regions',
+      });
+      dictionaryEntryIds.push(
+        await createDictionaryEntry(request, token, dictionaryId, 'north', 'North'),
+        await createDictionaryEntry(request, token, dictionaryId, 'south', 'South'),
+      );
+
       const createEntity = await apiRequest(request, 'POST', '/api/entities/entities', {
         token,
         data: { entityId: RUNTIME_ENTITY_ID, label: 'QA ENT-2055 Readback Item', description: 'Runtime entity for record readback parity' },
@@ -111,7 +145,7 @@ test.describe('TC-ENT-2055-RECORD-READBACK', () => {
       expect(createEntity.status(), `runtime entity upsert 200: ${createEntity.status()}`).toBe(200);
       entityCreated = true;
 
-      for (const def of RUNTIME_FIELD_DEFS) {
+      for (const def of buildRuntimeFieldDefs(dictionaryId)) {
         const res = await apiRequest(request, 'POST', '/api/entities/definitions', {
           token,
           data: { entityId: RUNTIME_ENTITY_ID, key: def.key, kind: def.kind, configJson: def.configJson },
@@ -129,6 +163,7 @@ test.describe('TC-ENT-2055-RECORD-READBACK', () => {
             blocked: true,
             labels: ['ops'],
             assignee: ['charlie'],
+            regions: ['north', 'south'],
             description: 'TC-ENT-2055 round-trip',
           },
         },
@@ -162,7 +197,35 @@ test.describe('TC-ENT-2055-RECORD-READBACK', () => {
       expect(detail!.blocked, 'boolean field').toBe(true);
       expect(detail!.labels, 'multi tags field').toEqual(['ops']);
       expect(detail!.assignee, 'multi-select listbox field').toEqual(['charlie']);
+      expect(detail!.regions, 'multi dictionary field').toEqual(['north', 'south']);
       expect(detail!.description, 'multiline field').toBe('TC-ENT-2055 round-trip');
+
+      const update = await apiRequest(request, 'PUT', '/api/entities/records', {
+        token,
+        data: {
+          entityId: RUNTIME_ENTITY_ID,
+          recordId,
+          values: {
+            priority: 3,
+            severity: 'medium',
+            blocked: false,
+            labels: ['ops', 'qa'],
+            assignee: ['alice', 'bob'],
+            regions: ['south'],
+            description: 'TC-ENT-2055 updated round-trip',
+          },
+        },
+      });
+      expect(update.status(), `update 200: ${update.status()}`).toBe(200);
+      const updatedDetail = await readById(request, token, recordId as string);
+      expect(updatedDetail, 'updated by-id detail returned').toBeTruthy();
+      expect(updatedDetail!.priority, 'updated integer field').toBe(3);
+      expect(updatedDetail!.severity, 'updated single-select field').toBe('medium');
+      expect(updatedDetail!.blocked, 'updated boolean field').toBe(false);
+      expect(updatedDetail!.labels, 'updated multi tags field').toEqual(['ops', 'qa']);
+      expect(updatedDetail!.assignee, 'updated multi-select listbox field').toEqual(['alice', 'bob']);
+      expect(updatedDetail!.regions, 'updated multi dictionary field').toEqual(['south']);
+      expect(updatedDetail!.description, 'updated multiline field').toBe('TC-ENT-2055 updated round-trip');
     } finally {
       if (recordId) {
         await apiRequest(
@@ -177,6 +240,24 @@ test.describe('TC-ENT-2055-RECORD-READBACK', () => {
           token,
           data: { entityId: RUNTIME_ENTITY_ID },
         }).catch(() => {});
+      }
+      if (dictionaryId) {
+        for (const entryId of dictionaryEntryIds) {
+          await apiRequest(
+            request,
+            'DELETE',
+            `/api/dictionaries/${encodeURIComponent(dictionaryId)}/entries/${encodeURIComponent(entryId)}`,
+            { token },
+          ).catch(() => {});
+        }
+      }
+      if (dictionaryId) {
+        await apiRequest(
+          request,
+          'DELETE',
+          `/api/dictionaries/${encodeURIComponent(dictionaryId)}`,
+          { token },
+        ).catch(() => {});
       }
     }
   });

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -2689,6 +2689,12 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     for (const injectedId of injectedFieldIdSet) {
       delete coreValues[injectedId]
     }
+    if (customEntity) {
+      const allowedKeys = new Set(cfDefinitions.map((definition) => definition.key).filter(Boolean))
+      for (const key of Object.keys(coreValues)) {
+        if (!allowedKeys.has(key)) delete coreValues[key]
+      }
+    }
 
     let parsedValues: TValues
     if (schema) {
@@ -2721,6 +2727,12 @@ export function CrudForm<TValues extends Record<string, unknown>>({
           const projectedCoreValues = { ...(result.data as Record<string, unknown>) }
           for (const injectedId of injectedFieldIdSet) {
             delete projectedCoreValues[injectedId]
+          }
+          if (customEntity) {
+            const allowedKeys = new Set(cfDefinitions.map((definition) => definition.key).filter(Boolean))
+            for (const key of Object.keys(projectedCoreValues)) {
+              if (!allowedKeys.has(key)) delete projectedCoreValues[key]
+            }
           }
           coreSubmitValues = schema
             ? schema.parse(collapseDotPathFields(projectedCoreValues, dotPathBaseFieldIds))

--- a/packages/ui/src/backend/__tests__/CrudForm.custom-fields.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.custom-fields.test.tsx
@@ -275,6 +275,73 @@ describe('CrudForm custom field loading', () => {
     expect(container.querySelector('[data-crud-field-id="cf_renewal_quarter"]')?.textContent).toContain('Q3')
   })
 
+  it('submits custom entity values without loaded record metadata', async () => {
+    const handleSubmit = jest.fn().mockResolvedValue(undefined)
+
+    buildFormFieldFromCustomFieldDefMock.mockImplementation((definition: any) => ({
+      id: definition.key,
+      label: definition.label ?? definition.key,
+      type: 'select',
+      multiple: true,
+      listbox: true,
+      options: [
+        { value: 'north', label: 'North' },
+        { value: 'south', label: 'South' },
+      ],
+    }))
+    fetchCustomFieldFormStructureMock.mockResolvedValue({
+      fields: [],
+      definitions: [
+        {
+          entityId: 'user:qa_entity',
+          key: 'regions',
+          label: 'Regions',
+          kind: 'dictionary',
+          multi: true,
+        },
+      ],
+      metadata: {
+        items: [],
+        fieldsetsByEntity: {},
+        entitySettings: {},
+      },
+    })
+
+    renderWithProviders(
+      <CrudForm
+        title="Form"
+        entityId="user:qa_entity"
+        fields={[]}
+        customEntity
+        initialValues={{
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          regions: ['north', 'south'],
+          updatedAt: '2026-06-19T10:00:00.000Z',
+          createdAt: '2026-06-19T09:00:00.000Z',
+        }}
+        onSubmit={handleSubmit}
+      />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+        },
+      },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('North')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[0]!)
+    })
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledTimes(1)
+    })
+    expect(handleSubmit).toHaveBeenCalledWith({ regions: ['north', 'south'] }, expect.any(Object))
+  })
+
   it('opens the field manager without submitting the parent form', async () => {
     const handleSubmit = jest.fn().mockResolvedValue(undefined)
 

--- a/packages/ui/src/backend/__tests__/custom-field-filters.test.ts
+++ b/packages/ui/src/backend/__tests__/custom-field-filters.test.ts
@@ -24,6 +24,13 @@ describe('buildFilterDefsFromCustomFields', () => {
         ],
         multi: true,
       },
+      {
+        key: 'regions',
+        kind: 'dictionary',
+        filterable: true,
+        optionsUrl: '/api/dictionaries/dictionary-1/entries',
+        multi: true,
+      },
       { key: 'notes', kind: 'multiline', filterable: true },
       { key: 'hidden', kind: 'text', filterable: false },
     ]
@@ -44,6 +51,11 @@ describe('buildFilterDefsFromCustomFields', () => {
     if (labels.type !== 'select') throw new Error('expected select')
     expect(labels.multiple).toBe(true)
     expect((labels.options || []).map((o) => o.value)).toEqual(['bug','feature'])
+    const regions = out.find(f => f.id === 'cf_regionsIn')!
+    expect(regions.type).toBe('select')
+    if (regions.type !== 'select') throw new Error('expected select')
+    expect(regions.multiple).toBe(true)
+    expect(typeof regions.loadOptions).toBe('function')
     // text-like (multiline) => text
     expect(out.find(f => f.id === 'cf_notes')!.type).toBe('text')
     // non-filterable omitted

--- a/packages/ui/src/backend/__tests__/custom-field-forms.test.ts
+++ b/packages/ui/src/backend/__tests__/custom-field-forms.test.ts
@@ -1,7 +1,12 @@
 import { buildFormFieldsFromCustomFields } from '../utils/customFieldForms'
 import type { CustomFieldDefDto } from '../utils/customFieldFilters'
+import { FieldRegistry } from '../fields/registry'
 
 describe('buildFormFieldsFromCustomFields', () => {
+  beforeAll(() => {
+    FieldRegistry.register('dictionary', { input: () => null })
+  })
+
   it('maps kinds to CrudField and filters by formEditable', () => {
     const defs: CustomFieldDefDto[] = [
       { key: 'blocked', kind: 'boolean', filterable: true, formEditable: true },
@@ -31,6 +36,23 @@ describe('buildFormFieldsFromCustomFields', () => {
       { key: 'notes', kind: 'multiline', filterable: false, formEditable: true },
       // text with editor hint should render richtext
       { key: 'desc', kind: 'text', filterable: false, formEditable: true, editor: 'htmlRichText' },
+      {
+        key: 'region',
+        kind: 'dictionary',
+        dictionaryId: 'dictionary-1',
+        optionsUrl: '/api/dictionaries/dictionary-1/entries',
+        filterable: true,
+        formEditable: true,
+      },
+      {
+        key: 'regions',
+        kind: 'dictionary',
+        dictionaryId: 'dictionary-1',
+        optionsUrl: '/api/dictionaries/dictionary-1/entries',
+        multi: true,
+        filterable: true,
+        formEditable: true,
+      },
       { key: 'hidden', kind: 'text', filterable: true, formEditable: false },
     ]
 
@@ -48,6 +70,13 @@ describe('buildFormFieldsFromCustomFields', () => {
     expect(byId['cf_desc']?.type).toBe('richtext')
     if (byId['cf_desc']?.type === 'richtext') {
       expect(byId['cf_desc'].editor).toBe('html')
+    }
+    expect(byId['cf_region']?.type).toBe('custom')
+    expect(byId['cf_regions']?.type).toBe('select')
+    if (byId['cf_regions']?.type === 'select') {
+      expect(byId['cf_regions'].multiple).toBe(true)
+      expect(byId['cf_regions'].listbox).toBe(true)
+      expect(typeof byId['cf_regions'].loadOptions).toBe('function')
     }
     expect(byId['cf_hidden']).toBeUndefined()
   })

--- a/packages/ui/src/backend/utils/customFieldForms.ts
+++ b/packages/ui/src/backend/utils/customFieldForms.ts
@@ -120,6 +120,40 @@ export function buildFormFieldFromCustomFieldDef(
           : {}),
         ...(def.multi && def.input === 'listbox' ? ({ listbox: true } as any) : {}),
       }
+    case 'dictionary': {
+      if (!def.multi) {
+        const input = FieldRegistry.getInput(def.kind)
+        if (input) {
+          return {
+            id,
+            label,
+            type: 'custom',
+            ...baseProps,
+            component: (props) => input({ ...props, def }),
+          }
+        }
+        return { id, label, type: 'text', ...baseProps }
+      }
+      const optionsUrl = def.optionsUrl || (def.dictionaryId ? `/api/dictionaries/${def.dictionaryId}/entries` : undefined)
+      return {
+        id,
+        label,
+        type: 'select',
+        description: def.description,
+        required,
+        options: [],
+        multiple: true,
+        listbox: true,
+        ...(optionsUrl
+          ? {
+              loadOptions: async (query?: string) => {
+                const url = buildOptionsUrl(optionsUrl, query)
+                return loadRemoteOptions(url)
+              },
+            }
+          : {}),
+      }
+    }
     default: {
       if (def.kind === 'text' && def.multi) {
         const base: any = { id, label, type: 'tags', ...baseProps }


### PR DESCRIPTION
## Summary

Adds multi-value support for dictionary custom fields in generated Open Mercato forms. Dictionary fields marked as multi-value render through the built-in multi-select/listbox path, persist arrays through the existing custom-field EAV storage, and read back selected values from list/detail APIs.

## Changes

- Map dictionary custom fields with `multi: true` to built-in select/listbox fields with `multiple: true` and dictionary-entry option loading.
- Preserve the existing registered dictionary selector and inline-create behavior for single-value dictionary fields.
- Add a dictionary definition-editor toggle for multiple values and hide scalar-only default/inline-create controls when multi-value mode is enabled.
- Project custom-entity form submits to known custom-field keys so generated edit forms do not forward record metadata into strict custom-entity APIs.
- Add UI helper tests, dictionary editor tests, custom-entity submit coverage, and entity API readback integration coverage.
- Add an OSS spec, spec index entry, locale strings, and changelog entry.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [x] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/2026-06-19-dictionary-custom-field-multiselect.md`

## Testing

- `corepack yarn workspace @open-mercato/ui test --runTestsByPath src/backend/__tests__/custom-field-forms.test.ts src/backend/__tests__/custom-field-filters.test.ts src/backend/__tests__/CrudForm.custom-fields.test.tsx`
- `corepack yarn workspace @open-mercato/core test --runTestsByPath src/modules/dictionaries/fields/__tests__/dictionary.test.tsx`
- `corepack yarn test:integration packages/core/src/modules/entities/__integration__/TC-ENT-2055-RECORD-READBACK.spec.ts`
- `corepack yarn build:packages`
- `corepack yarn generate`
- `corepack yarn workspace @open-mercato/ui test`
- `corepack yarn workspace @open-mercato/core test`
- `corepack yarn typecheck`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). Integration coverage is in `packages/core/src/modules/entities/__integration__/TC-ENT-2055-RECORD-READBACK.spec.ts` because this is generated form/API behavior rather than a separate user journey document.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

N/A
