### PR TITLE
fix: notifications do not update local state after failed API writes (#3264)

### DIFF
--- a/packages/ui/src/backend/notifications/__tests__/useNotificationActions.failedWrites.test.tsx
+++ b/packages/ui/src/backend/notifications/__tests__/useNotificationActions.failedWrites.test.tsx
@@ -1,0 +1,119 @@
+jest.mock('../../utils/api', () => ({
+  apiFetch: jest.fn(),
+}))
+
+import { act, renderHook } from '@testing-library/react'
+import * as React from 'react'
+import type { NotificationDto } from '@open-mercato/shared/modules/notifications/types'
+import { apiFetch } from '../../utils/api'
+import { useNotificationActions } from '../useNotificationActions'
+
+function makeNotification(id: string): NotificationDto {
+  return {
+    id,
+    type: 'example.test',
+    title: `title-${id}`,
+    severity: 'info',
+    status: 'unread',
+    actions: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+  }
+}
+
+function mockResponse(status: number): Response {
+  const ok = status >= 200 && status < 300
+  const body = ok ? '{}' : JSON.stringify({ error: 'boom' })
+  return {
+    ok,
+    status,
+    headers: new Map<string, string>(),
+    text: jest.fn(async () => body),
+    clone: () => mockResponse(status),
+  } as unknown as Response
+}
+
+function setFetchResult(status: number) {
+  ;(apiFetch as jest.Mock).mockResolvedValue(mockResponse(status))
+}
+
+function renderActions(notifications: NotificationDto[]) {
+  const setNotifications = jest.fn()
+  const setUnreadCount = jest.fn()
+  const hook = renderHook(() =>
+    useNotificationActions(notifications, setNotifications, setUnreadCount),
+  )
+  return { hook, setNotifications, setUnreadCount }
+}
+
+async function callAndCaptureRejection(run: () => Promise<unknown>): Promise<boolean> {
+  let rejected = false
+  await act(async () => {
+    try {
+      await run()
+    } catch {
+      rejected = true
+    }
+  })
+  return rejected
+}
+
+describe('useNotificationActions — failed API writes leave local state unchanged', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('markAsRead surfaces the error and does not mutate state when the write fails', async () => {
+    setFetchResult(500)
+    const { hook, setNotifications, setUnreadCount } = renderActions([makeNotification('n1')])
+
+    const rejected = await callAndCaptureRejection(() => hook.result.current.markAsRead('n1'))
+
+    expect(rejected).toBe(true)
+    expect(setNotifications).not.toHaveBeenCalled()
+    expect(setUnreadCount).not.toHaveBeenCalled()
+  })
+
+  it('dismiss surfaces the error and does not mutate state when the write fails', async () => {
+    setFetchResult(500)
+    const { hook, setNotifications, setUnreadCount } = renderActions([makeNotification('n1')])
+
+    const rejected = await callAndCaptureRejection(() => hook.result.current.dismiss('n1'))
+
+    expect(rejected).toBe(true)
+    expect(setNotifications).not.toHaveBeenCalled()
+    expect(setUnreadCount).not.toHaveBeenCalled()
+    expect(hook.result.current.dismissUndo).toBeNull()
+  })
+
+  it('undoDismiss (restore) surfaces the error and preserves the undo banner when the write fails', async () => {
+    const { hook, setNotifications, setUnreadCount } = renderActions([makeNotification('n1')])
+
+    setFetchResult(200)
+    await act(async () => {
+      await hook.result.current.dismiss('n1')
+    })
+    expect(hook.result.current.dismissUndo).not.toBeNull()
+
+    setNotifications.mockClear()
+    setUnreadCount.mockClear()
+    setFetchResult(500)
+
+    const rejected = await callAndCaptureRejection(() => hook.result.current.undoDismiss())
+
+    expect(rejected).toBe(true)
+    expect(setNotifications).not.toHaveBeenCalled()
+    expect(setUnreadCount).not.toHaveBeenCalled()
+    expect(hook.result.current.dismissUndo).not.toBeNull()
+  })
+
+  it('markAllRead surfaces the error and does not mutate state when the write fails', async () => {
+    setFetchResult(500)
+    const { hook, setNotifications, setUnreadCount } = renderActions([makeNotification('n1')])
+
+    const rejected = await callAndCaptureRejection(() => hook.result.current.markAllRead())
+
+    expect(rejected).toBe(true)
+    expect(setNotifications).not.toHaveBeenCalled()
+    expect(setUnreadCount).not.toHaveBeenCalled()
+  })
+})

--- a/packages/ui/src/backend/notifications/useNotificationActions.ts
+++ b/packages/ui/src/backend/notifications/useNotificationActions.ts
@@ -1,6 +1,6 @@
 "use client"
 import * as React from 'react'
-import { apiCall } from '../utils/apiCall'
+import { apiCall, apiCallOrThrow } from '../utils/apiCall'
 import type { NotificationDto } from '@open-mercato/shared/modules/notifications/types'
 
 export type NotificationDismissUndoState = {
@@ -32,7 +32,7 @@ export function useNotificationActions(
   const dismissUndoTimerRef = React.useRef<number | null>(null)
 
   const markAsRead = React.useCallback(async (id: string) => {
-    await apiCall(`/api/notifications/${id}/read`, { method: 'PUT' })
+    await apiCallOrThrow(`/api/notifications/${id}/read`, { method: 'PUT' })
     setNotifications((prev) =>
       prev.map((n) =>
         n.id === id ? { ...n, status: 'read', readAt: new Date().toISOString() } : n,
@@ -69,7 +69,7 @@ export function useNotificationActions(
 
   const dismiss = React.useCallback(
     async (id: string) => {
-      await apiCall(`/api/notifications/${id}/dismiss`, { method: 'PUT' })
+      await apiCallOrThrow(`/api/notifications/${id}/dismiss`, { method: 'PUT' })
       const notification = notifications.find((n) => n.id === id)
       setNotifications((prev) => prev.filter((n) => n.id !== id))
       if (notification?.status === 'unread') {
@@ -95,7 +95,7 @@ export function useNotificationActions(
 
   const undoDismiss = React.useCallback(async () => {
     if (!dismissUndo) return
-    await apiCall(`/api/notifications/${dismissUndo.notification.id}/restore`, {
+    await apiCallOrThrow(`/api/notifications/${dismissUndo.notification.id}/restore`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ status: dismissUndo.previousStatus }),
@@ -129,7 +129,7 @@ export function useNotificationActions(
   }, [dismissUndo, setNotifications, setUnreadCount])
 
   const markAllRead = React.useCallback(async () => {
-    await apiCall('/api/notifications/mark-all-read', { method: 'PUT' })
+    await apiCallOrThrow('/api/notifications/mark-all-read', { method: 'PUT' })
     setNotifications((prev) =>
       prev.map((n) =>
         n.status === 'unread'


### PR DESCRIPTION
## Summary

Notification actions updated local React state even when the API write failed, because `apiCall` is a non-throwing helper that returns `{ ok, status, result }`. A failed mark-read / dismiss / restore / mark-all-read still mutated the UI, diverging the client from the server. This switches those four writes to the throwing helper `apiCallOrThrow`, so a failed write surfaces an error and leaves local notification state unchanged.

## Changes

- `packages/ui/src/backend/notifications/useNotificationActions.ts`: `markAsRead`, `dismiss`, `undoDismiss` (restore), and `markAllRead` now `await apiCallOrThrow(...)` instead of `apiCall(...)`. On a non-2xx response the call throws before any `setNotifications`/`setUnreadCount`/`setDismissUndo`/timer mutation, so local state is unchanged and the undo banner survives a failed restore. `executeAction` is unchanged — it already guards on `result.ok`.
- `packages/ui/src/backend/notifications/__tests__/useNotificationActions.failedWrites.test.tsx`: new focused tests asserting that a failed read, dismiss, restore, and mark-all-read each reject and do not mutate local state.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — focused bug fix, no spec required.

## Testing

- `yarn workspace @open-mercato/ui test --testPathPatterns 'useNotificationActions.failedWrites'` → 4/4 pass (verified red on un-fixed code first)
- `yarn workspace @open-mercato/ui test` → 183 suites / 1561 tests pass
- `yarn workspace @open-mercato/ui build` → typecheck/build OK
- `yarn i18n:check-sync` → all 4 locales in sync

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No new strings/generators; none required.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — N/A: the bug is a client-side React-hook error-handling guard whose failure path requires injecting a non-2xx API response; that is exercised by the new focused unit tests (mocking `apiFetch`), which is the appropriate level. Playwright cannot reliably force a mid-flow API failure here.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A (no spec).
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium`, inherited from the issue — single-module hook change with tests.)
- [x] QA routing set: `needs-qa` (touches customer-facing notification action flows). Note: the failure path is only observable by forcing a non-2xx API response; the success path is visually unchanged.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI/markup changed (logic-only hook change).
- [x] No arbitrary text sizes — N/A, no UI/markup changed.
- [x] Empty state handled for list/data pages — N/A, no page changed.
- [x] Loading state handled for async pages — N/A, no page changed.
- [x] `aria-label` on all icon-only buttons — N/A, no buttons changed.
- [x] Uses existing DS components — N/A, no components changed.

## Linked issues

Fixes #3264
