### PR TITLE
fix(notifications): prevent repeated notification action execution (#3266)

### DIFF
--- a/packages/core/src/modules/notifications/__integration__/TC-NOTIF-010.spec.ts
+++ b/packages/core/src/modules/notifications/__integration__/TC-NOTIF-010.spec.ts
@@ -42,6 +42,21 @@ test.describe('TC-NOTIF-010: Notification action execution', () => {
       expect(body).toHaveProperty('result')
       expect(body?.result).toBeNull()
       expect(body?.href).toBe(`/backend/example/${sourceEntityId}`)
+
+      // A repeated/duplicate action must be rejected without re-running the side
+      // effect — the notification is already actioned.
+      const duplicate = await apiRequest(
+        request,
+        'POST',
+        `/api/notifications/${encodeURIComponent(notificationId)}/action`,
+        { token, data: { actionId: 'approve', payload: {} } },
+      )
+      expect(
+        duplicate.status(),
+        'a repeated POST /api/notifications/{id}/action should return 409',
+      ).toBe(409)
+      const duplicateBody = await readJsonSafe<{ ok?: boolean; error?: string }>(duplicate)
+      expect(duplicateBody?.ok).not.toBe(true)
     } finally {
       await dismissNotificationIfExists(request, token, notificationId)
     }

--- a/packages/core/src/modules/notifications/__tests__/notificationService.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/notificationService.test.ts
@@ -48,6 +48,15 @@ const buildEm = () => {
         where: () => ({ executeTakeFirst: async () => undefined, execute: async () => [] }),
       }),
     }),
+    updateTable: () => ({
+      set: () => {
+        const chain: any = {
+          where: () => chain,
+          executeTakeFirst: async () => ({ numUpdatedRows: BigInt(1) }),
+        }
+        return chain
+      },
+    }),
   })
   return em
 }
@@ -377,5 +386,91 @@ describe('notification service', () => {
         tenantId: baseCtx.tenantId,
       })
     )
+  })
+
+  it('rejects an already-actioned notification without dispatching the command', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+    const commandBus = { execute: jest.fn().mockResolvedValue({ result: { ok: true } }) }
+    const container = { resolve: jest.fn() }
+    const service = createNotificationService({ em, eventBus, commandBus, container })
+
+    const notification: Notification = {
+      id: 'note-actioned',
+      recipientUserId: baseCtx.userId ?? null,
+      tenantId: baseCtx.tenantId,
+      status: 'actioned',
+      readAt: new Date(),
+      sourceEntityId: '1f9d8d1c-319f-48d4-b803-77665b6b2510',
+      actionData: {
+        actions: [{ id: 'approve', label: 'Approve', commandId: 'sales.approve' }],
+        primaryActionId: 'approve',
+      },
+    } as Notification
+
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValue(notification)
+
+    await expect(
+      service.executeAction(notification.id, { actionId: 'approve', payload: {} }, baseCtx)
+    ).rejects.toMatchObject({ status: 409 })
+
+    expect(commandBus.execute).not.toHaveBeenCalled()
+  })
+
+  it('executes the target command at most once for duplicate concurrent requests', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+    const commandBus = { execute: jest.fn().mockResolvedValue({ result: { ok: true } }) }
+    const container = { resolve: jest.fn() }
+
+    // Both requests load the notification before either has actioned it, so the
+    // in-memory status guard cannot stop the race — only the atomic DB claim can.
+    const buildPending = (): Notification => ({
+      id: 'note-race',
+      recipientUserId: baseCtx.userId ?? null,
+      tenantId: baseCtx.tenantId,
+      status: 'unread',
+      readAt: null,
+      sourceEntityId: '1f9d8d1c-319f-48d4-b803-77665b6b2510',
+      actionData: {
+        actions: [{ id: 'approve', label: 'Approve', commandId: 'sales.approve' }],
+        primaryActionId: 'approve',
+      },
+    } as Notification)
+    ;(findOneWithDecryption as jest.Mock).mockImplementation(async () => buildPending())
+
+    // Atomic claim: the first conditional UPDATE wins (1 row), the second loses (0 rows).
+    let claims = 0
+    em.getKysely.mockReturnValue({
+      selectFrom: () => ({
+        select: () => ({
+          where: () => ({ executeTakeFirst: async () => undefined, execute: async () => [] }),
+        }),
+      }),
+      updateTable: () => ({
+        set: () => {
+          const chain: any = {
+            where: () => chain,
+            executeTakeFirst: async () => ({ numUpdatedRows: BigInt(claims++ === 0 ? 1 : 0) }),
+          }
+          return chain
+        },
+      }),
+    })
+
+    const service = createNotificationService({ em, eventBus, commandBus, container })
+    const input = { actionId: 'approve', payload: {} }
+
+    const outcomes = await Promise.allSettled([
+      service.executeAction('note-race', input, baseCtx),
+      service.executeAction('note-race', input, baseCtx),
+    ])
+
+    const fulfilled = outcomes.filter((o) => o.status === 'fulfilled')
+    const rejected = outcomes.filter((o) => o.status === 'rejected') as PromiseRejectedResult[]
+    expect(fulfilled).toHaveLength(1)
+    expect(rejected).toHaveLength(1)
+    expect(rejected[0].reason).toMatchObject({ status: 409 })
+    expect(commandBus.execute).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/src/modules/notifications/__tests__/notificationService.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/notificationService.test.ts
@@ -417,6 +417,67 @@ describe('notification service', () => {
     expect(commandBus.execute).not.toHaveBeenCalled()
   })
 
+  it('releases the claim when the dispatched command fails so the action can be retried', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+    const commandError = new Error('command exploded')
+    const commandBus = { execute: jest.fn().mockRejectedValue(commandError) }
+    const container = { resolve: jest.fn() }
+
+    // Capture every UPDATE ... SET payload so we can assert the claim is rolled back.
+    const setPayloads: Array<Record<string, unknown>> = []
+    em.getKysely.mockReturnValue({
+      selectFrom: () => ({
+        select: () => ({
+          where: () => ({ executeTakeFirst: async () => undefined, execute: async () => [] }),
+        }),
+      }),
+      updateTable: () => ({
+        set: (payload: Record<string, unknown>) => {
+          setPayloads.push(payload)
+          const chain: any = {
+            where: () => chain,
+            executeTakeFirst: async () => ({ numUpdatedRows: BigInt(1) }),
+          }
+          return chain
+        },
+      }),
+    })
+
+    const service = createNotificationService({ em, eventBus, commandBus, container })
+
+    const notification: Notification = {
+      id: 'note-retry',
+      recipientUserId: baseCtx.userId ?? null,
+      tenantId: baseCtx.tenantId,
+      status: 'unread',
+      readAt: null,
+      actionedAt: null,
+      actionTaken: null,
+      sourceEntityId: '1f9d8d1c-319f-48d4-b803-77665b6b2510',
+      actionData: {
+        actions: [{ id: 'approve', label: 'Approve', commandId: 'sales.approve' }],
+        primaryActionId: 'approve',
+      },
+    } as Notification
+
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValue(notification)
+
+    await expect(
+      service.executeAction(notification.id, { actionId: 'approve', payload: {} }, baseCtx)
+    ).rejects.toBe(commandError)
+
+    // First UPDATE claims the notification; the second releases it back to its
+    // prior, retryable state instead of leaving it locked as `actioned`.
+    expect(setPayloads).toHaveLength(2)
+    expect(setPayloads[0]).toMatchObject({ status: 'actioned', action_taken: 'approve' })
+    expect(setPayloads[1]).toMatchObject({ status: 'unread', actioned_at: null, action_taken: null })
+
+    // The failed action did not persist an actioned state or emit the actioned event.
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalledWith(NOTIFICATION_EVENTS.ACTIONED, expect.anything())
+  })
+
   it('executes the target command at most once for duplicate concurrent requests', async () => {
     const em = buildEm()
     const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }

--- a/packages/core/src/modules/notifications/lib/notificationService.ts
+++ b/packages/core/src/modules/notifications/lib/notificationService.ts
@@ -455,6 +455,9 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
       }
 
       const actionedAt = new Date()
+      const previousStatus = notification.status
+      const previousActionedAt = notification.actionedAt ?? null
+      const previousActionTaken = notification.actionTaken ?? null
 
       // Atomically claim the notification so only one concurrent request can run
       // the side-effecting command. The conditional UPDATE matches only while the
@@ -474,6 +477,26 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
 
       if (Number(claimResult?.numUpdatedRows ?? 0) === 0) {
         throw conflict('Notification action already executed')
+      }
+
+      // The claim is provisional: if the side-effecting command fails, the action
+      // never actually completed, so release the claim to its prior state. This
+      // lets the user retry the action instead of the notification being locked as
+      // `actioned` forever. Only release while we still own the claim
+      // (status = 'actioned'), so a concurrent winner's state is never clobbered.
+      const releaseClaim = async () => {
+        await getDb(em)
+          .updateTable('notifications' as any)
+          .set({
+            status: previousStatus,
+            actioned_at: previousActionedAt,
+            action_taken: previousActionTaken,
+          } as any)
+          .where('id' as any, '=', notification.id)
+          .where('recipient_user_id' as any, '=', ctx.userId as any)
+          .where('tenant_id' as any, '=', ctx.tenantId)
+          .where('status' as any, '=', 'actioned')
+          .executeTakeFirst()
       }
 
       let result: unknown = null
@@ -497,15 +520,27 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
           organizationIds: ctx.organizationId ? [ctx.organizationId] : null,
         }
 
-        const commandResult = await commandBus.execute(action.commandId, {
-          input: commandInput,
-          ctx: commandCtx,
-          metadata: {
-            tenantId: ctx.tenantId,
-            organizationId: ctx.organizationId,
-            resourceKind: 'notifications',
-          },
-        })
+        let commandResult: { result: unknown }
+        try {
+          commandResult = await commandBus.execute(action.commandId, {
+            input: commandInput,
+            ctx: commandCtx,
+            metadata: {
+              tenantId: ctx.tenantId,
+              organizationId: ctx.organizationId,
+              resourceKind: 'notifications',
+            },
+          })
+        } catch (err) {
+          // Never let a rollback failure mask the original command error — the
+          // caller needs the real failure to decide whether to retry.
+          try {
+            await releaseClaim()
+          } catch (releaseErr) {
+            debug('failed to release notification action claim', releaseErr)
+          }
+          throw err
+        }
 
         result = commandResult.result
       }

--- a/packages/core/src/modules/notifications/lib/notificationService.ts
+++ b/packages/core/src/modules/notifications/lib/notificationService.ts
@@ -1,6 +1,6 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { type Kysely, sql } from 'kysely'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, conflict } from '@open-mercato/shared/lib/crud/errors'
 import { Notification, type NotificationStatus } from '../data/entities'
 import type { CreateNotificationInput, CreateBatchNotificationInput, CreateRoleNotificationInput, CreateFeatureNotificationInput, ExecuteActionInput } from '../data/validators'
 import type { NotificationPollData } from '@open-mercato/shared/modules/notifications/types'
@@ -448,6 +448,34 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
         throw new Error('Action not found')
       }
 
+      // Reject an already-actioned notification before dispatching the command,
+      // so a retry or double-click cannot re-run the side effect.
+      if (notification.status === 'actioned') {
+        throw conflict('Notification action already executed')
+      }
+
+      const actionedAt = new Date()
+
+      // Atomically claim the notification so only one concurrent request can run
+      // the side-effecting command. The conditional UPDATE matches only while the
+      // notification has not been actioned yet; a losing request updates 0 rows.
+      const claimResult = (await getDb(em)
+        .updateTable('notifications' as any)
+        .set({
+          status: 'actioned',
+          actioned_at: actionedAt,
+          action_taken: input.actionId,
+        } as any)
+        .where('id' as any, '=', notification.id)
+        .where('recipient_user_id' as any, '=', ctx.userId as any)
+        .where('tenant_id' as any, '=', ctx.tenantId)
+        .where('status' as any, '!=', 'actioned')
+        .executeTakeFirst()) as { numUpdatedRows?: bigint | number } | undefined
+
+      if (Number(claimResult?.numUpdatedRows ?? 0) === 0) {
+        throw conflict('Notification action already executed')
+      }
+
       let result: unknown = null
 
       if (action.commandId && commandBus && container) {
@@ -483,7 +511,7 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
       }
 
       notification.status = 'actioned'
-      notification.actionedAt = new Date()
+      notification.actionedAt = actionedAt
       notification.actionTaken = input.actionId
       notification.actionResult = result as Record<string, unknown>
 


### PR DESCRIPTION
## Summary

Notification actions could be executed more than once. `executeAction` dispatched the target command before marking the notification `actioned` and never rejected an already-actioned notification, so a double-click, retry, or concurrent request could run the side-effecting command multiple times. This change rejects already-actioned notifications and adds an atomic claim so only one request can run the side effect; duplicate/concurrent losers get a stable `409` without dispatching the command.

## Changes

- `packages/core/src/modules/notifications/lib/notificationService.ts`: in `executeAction`, reject an already-actioned notification with a `409` (`conflict()`) before dispatch, then atomically claim the notification via a conditional Kysely `UPDATE … SET status='actioned' … WHERE status != 'actioned'` (mirrors the existing `markAllAsRead` update pattern); a request that updates 0 rows lost the race and returns `409` without running the command. Reuse a single `actionedAt` for the claim and the post-command flush.
- `packages/core/src/modules/notifications/__tests__/notificationService.test.ts`: add two unit tests (already-actioned rejection without command dispatch; concurrent-duplicate requests dispatch the command at most once) and extend the `buildEm` Kysely mock with an `updateTable` chain.
- `packages/core/src/modules/notifications/__integration__/TC-NOTIF-010.spec.ts`: assert a repeated `POST /api/notifications/{id}/action` returns `409` and does not re-run the action.
- **Retry-after-failure (review follow-up):** the claim is now treated as **provisional**. The command dispatch is wrapped in `try/catch`; if the side-effecting command throws, the claim is **released** back to the notification's prior `status` / `actioned_at` / `action_taken` via a conditional `UPDATE … WHERE status = 'actioned'` (so a concurrent winner is never clobbered), and the original error is re-thrown. This means a *failed* action no longer locks the notification as `actioned` forever — the user can retry it. A rollback that itself fails never masks the original command error. Added a unit test covering the rollback (claim → release, no actioned flush, no `ACTIONED` event).

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — targeted concurrency/idempotency bug fix in an existing module.


## Testing

- `yarn workspace @open-mercato/core test --testPathPatterns notifications/__tests__/notificationService` → 10/10 pass (2 new repro tests red before the fix, green after)
- `yarn workspace @open-mercato/core typecheck` → pass
- `yarn workspace @open-mercato/core test` (full) → 741 suites / 6068 tests pass
- `yarn i18n:check-sync` → all locales in sync
- `yarn build:app` → pass
- Integration: extended `TC-NOTIF-010.spec.ts` to assert a duplicate action POST returns `409`
- `yarn workspace @open-mercato/core test --testPathPatterns notifications/__tests__/notificationService` → 11/11 pass (added rollback-on-command-failure test)
- `yarn workspace @open-mercato/core build` (esbuild) → pass

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No locale/doc/generator change required; `conflict()` mirrors the existing `CrudHttpError(404)` pattern in the same file.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Extended the module integration spec `notifications/__integration__/TC-NOTIF-010.spec.ts`.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec for this bug fix.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). (`risk-high` — event/command-reliability seam, inherited from the issue.)
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. (`needs-qa` — affects notification action execution behavior; covered by automated unit + integration tests.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens — N/A, backend-only (no UI)
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` — N/A, backend-only (no UI)
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) — N/A, backend-only (no UI)
- [x] Loading state handled for async pages — N/A, backend-only (no UI)
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) — N/A, backend-only (no UI)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements — N/A, backend-only (no UI)

## Linked issues

Fixes #3266

🤖 Generated with [Claude Code](https://claude.com/claude-code)