### PR TITLE
fix: wire mutation guards for notification write routes (#3265)

### DIFF
--- a/packages/core/src/modules/notifications/__tests__/mutation-guard.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/mutation-guard.test.ts
@@ -1,0 +1,231 @@
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const notificationId = '44444444-4444-4444-8444-444444444444'
+const recipientUserId = '55555555-5555-4555-8555-555555555555'
+
+const container = { resolve: jest.fn() }
+
+const ctx = {
+  container,
+  auth: { tenantId, sub: userId },
+  selectedOrganizationId: organizationId,
+}
+
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+
+const serviceMock = {
+  create: jest.fn(),
+  createBatch: jest.fn(),
+  createForRole: jest.fn(),
+  createForFeature: jest.fn(),
+  markAsRead: jest.fn(),
+  dismiss: jest.fn(),
+  restoreDismissed: jest.fn(),
+  executeAction: jest.fn(),
+  markAllAsRead: jest.fn(),
+}
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/api/context', () => ({
+  resolveRequestContext: jest.fn(async () => ({ ctx })),
+}))
+
+jest.mock('../lib/notificationService', () => ({
+  resolveNotificationService: jest.fn(() => serviceMock),
+}))
+
+const saveNotificationDeliveryConfigMock = jest.fn()
+const resolveNotificationDeliveryConfigMock = jest.fn()
+
+jest.mock('../lib/deliveryConfig', () => ({
+  DEFAULT_NOTIFICATION_DELIVERY_CONFIG: { strategies: {} },
+  saveNotificationDeliveryConfig: (...args: unknown[]) => saveNotificationDeliveryConfigMock(...args),
+  resolveNotificationDeliveryConfig: (...args: unknown[]) => resolveNotificationDeliveryConfigMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ sub: userId, tenantId, orgId: organizationId })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    t: (_key: string, fallback?: string) => fallback ?? 'x',
+    translate: (_key: string, fallback?: string) => fallback ?? 'x',
+  })),
+}))
+
+import { POST as createNotification } from '../api/route'
+import { POST as createBatchNotifications } from '../api/batch/route'
+import { PUT as markNotificationRead } from '../api/[id]/read/route'
+import { PUT as restoreNotification } from '../api/[id]/restore/route'
+import { POST as executeNotificationAction } from '../api/[id]/action/route'
+import { PUT as markAllNotificationsRead } from '../api/mark-all-read/route'
+import { POST as updateNotificationSettings } from '../api/settings/route'
+
+const jsonRequest = (url: string, method: string, body?: unknown) =>
+  new Request(url, {
+    method,
+    headers: { 'content-type': 'application/json' },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  })
+
+const guardArgs = (overrides: Record<string, unknown>) =>
+  expect.objectContaining({
+    tenantId,
+    organizationId,
+    userId,
+    requestMethod: expect.any(String),
+    ...overrides,
+  })
+
+describe('notification write routes run the mutation guard lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    serviceMock.create.mockResolvedValue({ id: notificationId })
+    serviceMock.createBatch.mockResolvedValue([{ id: notificationId }])
+    serviceMock.markAsRead.mockResolvedValue(undefined)
+    serviceMock.restoreDismissed.mockResolvedValue(undefined)
+    serviceMock.executeAction.mockResolvedValue({
+      notification: { actionData: { actions: [{ id: 'do', href: '/go/{sourceEntityId}' }] }, sourceEntityId: 'src' },
+      result: { ok: true },
+    })
+    serviceMock.markAllAsRead.mockResolvedValue(3)
+    saveNotificationDeliveryConfigMock.mockResolvedValue(undefined)
+    resolveNotificationDeliveryConfigMock.mockResolvedValue({ strategies: {} })
+  })
+
+  it('guards create (POST /api/notifications)', async () => {
+    const response = await createNotification(
+      jsonRequest('http://localhost/api/notifications', 'POST', { type: 'test', title: 'Hi', recipientUserId }),
+    )
+
+    expect(response.status).toBe(201)
+    expect(serviceMock.create).toHaveBeenCalled()
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      guardArgs({ resourceKind: 'notifications.notification', resourceId: '', operation: 'create' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
+      container,
+      guardArgs({ resourceKind: 'notifications.notification', operation: 'create' }),
+    )
+  })
+
+  it('guards bulk create (POST /api/notifications/batch)', async () => {
+    const response = await createBatchNotifications(
+      jsonRequest('http://localhost/api/notifications/batch', 'POST', {
+        type: 'test',
+        title: 'Hi',
+        recipientUserIds: [recipientUserId],
+      }),
+    )
+
+    expect(response.status).toBe(201)
+    expect(serviceMock.createBatch).toHaveBeenCalled()
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      guardArgs({ resourceKind: 'notifications.notification', operation: 'create' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+  })
+
+  it('guards single-action update (PUT /api/notifications/[id]/read)', async () => {
+    const response = await markNotificationRead(
+      jsonRequest(`http://localhost/api/notifications/${notificationId}/read`, 'PUT'),
+      { params: Promise.resolve({ id: notificationId }) },
+    )
+
+    expect(response.status).toBe(200)
+    expect(serviceMock.markAsRead).toHaveBeenCalledWith(notificationId, expect.anything())
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      guardArgs({ resourceKind: 'notifications.notification', resourceId: notificationId, operation: 'update' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+  })
+
+  it('guards restore (PUT /api/notifications/[id]/restore)', async () => {
+    const response = await restoreNotification(
+      jsonRequest(`http://localhost/api/notifications/${notificationId}/restore`, 'PUT', { status: 'unread' }),
+      { params: Promise.resolve({ id: notificationId }) },
+    )
+
+    expect(response.status).toBe(200)
+    expect(serviceMock.restoreDismissed).toHaveBeenCalled()
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      guardArgs({ resourceKind: 'notifications.notification', resourceId: notificationId, operation: 'update' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+  })
+
+  it('guards execute action (POST /api/notifications/[id]/action)', async () => {
+    const response = await executeNotificationAction(
+      jsonRequest(`http://localhost/api/notifications/${notificationId}/action`, 'POST', { actionId: 'do' }),
+      { params: Promise.resolve({ id: notificationId }) },
+    )
+
+    expect(response.status).toBe(200)
+    expect(serviceMock.executeAction).toHaveBeenCalled()
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      guardArgs({ resourceKind: 'notifications.notification', resourceId: notificationId, operation: 'custom' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+  })
+
+  it('guards mark-all-read (PUT /api/notifications/mark-all-read)', async () => {
+    const response = await markAllNotificationsRead(
+      jsonRequest('http://localhost/api/notifications/mark-all-read', 'PUT'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(serviceMock.markAllAsRead).toHaveBeenCalled()
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      guardArgs({ resourceKind: 'notifications.notification', operation: 'update' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+  })
+
+  it('guards settings update (POST /api/notifications/settings)', async () => {
+    const response = await updateNotificationSettings(
+      jsonRequest('http://localhost/api/notifications/settings', 'POST', {
+        strategies: { database: { enabled: true } },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(saveNotificationDeliveryConfigMock).toHaveBeenCalled()
+    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
+      container,
+      guardArgs({ resourceKind: 'notifications.settings', operation: 'update' }),
+    )
+    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+  })
+
+  it('blocks the write and skips after-success hooks when the guard rejects', async () => {
+    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 409, body: { error: 'conflict' } })
+
+    const response = await markAllNotificationsRead(
+      jsonRequest('http://localhost/api/notifications/mark-all-read', 'PUT'),
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({ error: 'conflict' })
+    expect(serviceMock.markAllAsRead).not.toHaveBeenCalled()
+    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/notifications/api/[id]/action/route.ts
+++ b/packages/core/src/modules/notifications/api/[id]/action/route.ts
@@ -1,9 +1,11 @@
 import { executeActionSchema } from '../../../data/validators'
 import { actionResultResponseSchema, errorResponseSchema } from '../../openapi'
 import {
+  NOTIFICATION_RESOURCE_KIND,
   notificationCrudErrorResponse,
   notificationValidationErrorResponse,
   resolveNotificationContext,
+  runGuardedNotificationWrite,
 } from '../../../lib/routeHelpers'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 
@@ -13,7 +15,7 @@ export const metadata = {
 
 export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const { service, scope } = await resolveNotificationContext(req)
+  const { service, scope, ctx } = await resolveNotificationContext(req)
 
   const body = await req.json().catch(() => ({}))
   const parsed = executeActionSchema.safeParse(body)
@@ -23,7 +25,20 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
   const input = parsed.data
 
   try {
-    const { notification, result } = await service.executeAction(id, input, scope)
+    const guarded = await runGuardedNotificationWrite(
+      ctx.container,
+      scope,
+      req,
+      {
+        resourceKind: NOTIFICATION_RESOURCE_KIND,
+        resourceId: id,
+        operation: 'custom',
+        payload: input as Record<string, unknown>,
+      },
+      () => service.executeAction(id, input, scope),
+    )
+    if (!guarded.ok) return guarded.response
+    const { notification, result } = guarded.result
 
     const action = notification.actionData?.actions?.find((a) => a.id === input.actionId)
     const href = action?.href?.replace('{sourceEntityId}', notification.sourceEntityId ?? '')

--- a/packages/core/src/modules/notifications/api/[id]/restore/route.ts
+++ b/packages/core/src/modules/notifications/api/[id]/restore/route.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod'
 import { restoreNotificationSchema } from '../../../data/validators'
-import { resolveNotificationContext } from '../../../lib/routeHelpers'
+import {
+  NOTIFICATION_RESOURCE_KIND,
+  resolveNotificationContext,
+  runGuardedNotificationWrite,
+} from '../../../lib/routeHelpers'
 
 export const metadata = {
   PUT: { requireAuth: true },
@@ -8,12 +12,24 @@ export const metadata = {
 
 export async function PUT(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const { service, scope } = await resolveNotificationContext(req)
+  const { service, scope, ctx } = await resolveNotificationContext(req)
 
   const body = await req.json().catch(() => ({}))
   const input = restoreNotificationSchema.parse(body)
 
-  await service.restoreDismissed(id, input.status, scope)
+  const guarded = await runGuardedNotificationWrite(
+    ctx.container,
+    scope,
+    req,
+    {
+      resourceKind: NOTIFICATION_RESOURCE_KIND,
+      resourceId: id,
+      operation: 'update',
+      payload: input as Record<string, unknown>,
+    },
+    () => service.restoreDismissed(id, input.status, scope),
+  )
+  if (!guarded.ok) return guarded.response
 
   return Response.json({ ok: true })
 }

--- a/packages/core/src/modules/notifications/api/mark-all-read/route.ts
+++ b/packages/core/src/modules/notifications/api/mark-all-read/route.ts
@@ -1,16 +1,30 @@
 import { z } from 'zod'
-import { resolveNotificationContext } from '../../lib/routeHelpers'
+import {
+  NOTIFICATION_RESOURCE_KIND,
+  resolveNotificationContext,
+  runGuardedNotificationWrite,
+} from '../../lib/routeHelpers'
 
 export const metadata = {
   PUT: { requireAuth: true },
 }
 
 export async function PUT(req: Request) {
-  const { service, scope } = await resolveNotificationContext(req)
+  const { service, scope, ctx } = await resolveNotificationContext(req)
 
-  const count = await service.markAllAsRead(scope)
+  const guarded = await runGuardedNotificationWrite(
+    ctx.container,
+    scope,
+    req,
+    {
+      resourceKind: NOTIFICATION_RESOURCE_KIND,
+      operation: 'update',
+    },
+    () => service.markAllAsRead(scope),
+  )
+  if (!guarded.ok) return guarded.response
 
-  return Response.json({ ok: true, count })
+  return Response.json({ ok: true, count: guarded.result })
 }
 
 export const openApi = {

--- a/packages/core/src/modules/notifications/api/route.ts
+++ b/packages/core/src/modules/notifications/api/route.ts
@@ -4,9 +4,11 @@ import { Notification } from '../data/entities'
 import { listNotificationsSchema, createNotificationSchema } from '../data/validators'
 import { toNotificationDto } from '../lib/notificationMapper'
 import {
+  NOTIFICATION_RESOURCE_KIND,
   notificationCrudErrorResponse,
   notificationValidationErrorResponse,
   resolveNotificationContext,
+  runGuardedNotificationWrite,
 } from '../lib/routeHelpers'
 import {
   buildNotificationsCrudOpenApi,
@@ -74,7 +76,7 @@ export async function GET(req: Request) {
 }
 
 export async function POST(req: Request) {
-  const { service, scope } = await resolveNotificationContext(req)
+  const { service, scope, ctx } = await resolveNotificationContext(req)
 
   const body = await req.json().catch(() => ({}))
   const parsed = createNotificationSchema.safeParse(body)
@@ -83,9 +85,20 @@ export async function POST(req: Request) {
   }
 
   try {
-    const notification = await service.create(parsed.data, scope)
+    const guarded = await runGuardedNotificationWrite(
+      ctx.container,
+      scope,
+      req,
+      {
+        resourceKind: NOTIFICATION_RESOURCE_KIND,
+        operation: 'create',
+        payload: parsed.data as Record<string, unknown>,
+      },
+      () => service.create(parsed.data, scope),
+    )
+    if (!guarded.ok) return guarded.response
 
-    return Response.json({ id: notification.id }, { status: 201 })
+    return Response.json({ id: guarded.result.id }, { status: 201 })
   } catch (error) {
     const errorResponse = notificationCrudErrorResponse(error)
     if (errorResponse) return errorResponse

--- a/packages/core/src/modules/notifications/api/settings/route.ts
+++ b/packages/core/src/modules/notifications/api/settings/route.ts
@@ -13,6 +13,10 @@ import {
   resolveNotificationDeliveryConfig,
   saveNotificationDeliveryConfig,
 } from '../../lib/deliveryConfig'
+import {
+  NOTIFICATION_SETTINGS_RESOURCE_KIND,
+  runGuardedNotificationWrite,
+} from '../../lib/routeHelpers'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['notifications.manage'] },
@@ -67,11 +71,28 @@ export async function POST(req: Request) {
 
   const container = await createRequestContainer()
   try {
-    await saveNotificationDeliveryConfig(container, parsed.data)
-    const settings = await resolveNotificationDeliveryConfig(container, {
-      defaultValue: DEFAULT_NOTIFICATION_DELIVERY_CONFIG,
-    })
-    return NextResponse.json({ ok: true, settings })
+    const guarded = await runGuardedNotificationWrite(
+      container,
+      {
+        tenantId: auth.tenantId ?? '',
+        organizationId: auth.orgId ?? null,
+        userId: auth.sub ?? null,
+      },
+      req,
+      {
+        resourceKind: NOTIFICATION_SETTINGS_RESOURCE_KIND,
+        operation: 'update',
+        payload: parsed.data as Record<string, unknown>,
+      },
+      async () => {
+        await saveNotificationDeliveryConfig(container, parsed.data)
+        return resolveNotificationDeliveryConfig(container, {
+          defaultValue: DEFAULT_NOTIFICATION_DELIVERY_CONFIG,
+        })
+      },
+    )
+    if (!guarded.ok) return guarded.response
+    return NextResponse.json({ ok: true, settings: guarded.result })
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : t('api.errors.internal', 'Internal error') },

--- a/packages/core/src/modules/notifications/lib/routeHelpers.ts
+++ b/packages/core/src/modules/notifications/lib/routeHelpers.ts
@@ -1,8 +1,23 @@
 import { z } from 'zod'
+import type { AwilixContainer } from 'awilix'
 import { resolveRequestContext } from '@open-mercato/shared/lib/api/context'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveNotificationService, type NotificationService } from './notificationService'
+
+/**
+ * Mutation-guard resource kind for notification rows.
+ */
+export const NOTIFICATION_RESOURCE_KIND = 'notifications.notification'
+
+/**
+ * Mutation-guard resource kind for notification delivery settings.
+ */
+export const NOTIFICATION_SETTINGS_RESOURCE_KIND = 'notifications.settings'
 
 /**
  * Notification scope context for service calls
@@ -64,6 +79,65 @@ export async function resolveNotificationContext(req: Request): Promise<Notifica
 }
 
 /**
+ * Mutation-guard options for a notification write.
+ */
+export interface NotificationMutationGuardOptions {
+  resourceKind: string
+  resourceId?: string | null
+  operation: 'create' | 'update' | 'delete' | 'custom'
+  payload?: Record<string, unknown> | null
+}
+
+export type GuardedNotificationWriteResult<T> =
+  | { ok: true; result: T }
+  | { ok: false; response: Response }
+
+/**
+ * Run a notification write through the mutation guard lifecycle.
+ * Validates before the mutation, performs the write, then runs after-success
+ * hooks only when the write succeeded and the guard requested them. Returns the
+ * guard's own block response when validation fails so authorization behavior and
+ * conflict shapes are preserved.
+ */
+export async function runGuardedNotificationWrite<T>(
+  container: AwilixContainer,
+  scope: NotificationScope,
+  req: Request,
+  options: NotificationMutationGuardOptions,
+  write: () => Promise<T>,
+): Promise<GuardedNotificationWriteResult<T>> {
+  const guardScope = {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: scope.userId ?? '',
+    resourceKind: options.resourceKind,
+    resourceId: options.resourceId ?? '',
+    operation: options.operation,
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+  }
+
+  const guardResult = await validateCrudMutationGuard(container, {
+    ...guardScope,
+    mutationPayload: options.payload ?? null,
+  })
+  if (guardResult && !guardResult.ok) {
+    return { ok: false, response: Response.json(guardResult.body, { status: guardResult.status }) }
+  }
+
+  const result = await write()
+
+  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+    await runCrudMutationGuardAfterSuccess(container, {
+      ...guardScope,
+      metadata: guardResult.metadata ?? null,
+    })
+  }
+
+  return { ok: true, result }
+}
+
+/**
  * Create a POST handler for bulk notification creation routes.
  * Used by batch, role, and feature notification endpoints.
  */
@@ -72,7 +146,7 @@ export function createBulkNotificationRoute<TSchema extends z.ZodTypeAny>(
   serviceMethod: 'createBatch' | 'createForRole' | 'createForFeature'
 ) {
   return async function POST(req: Request) {
-    const { service, scope } = await resolveNotificationContext(req)
+    const { service, scope, ctx } = await resolveNotificationContext(req)
 
     const body = await req.json().catch(() => ({}))
     const parsed = schema.safeParse(body)
@@ -81,7 +155,19 @@ export function createBulkNotificationRoute<TSchema extends z.ZodTypeAny>(
     }
 
     try {
-      const notifications = await service[serviceMethod](parsed.data as never, scope)
+      const guarded = await runGuardedNotificationWrite(
+        ctx.container,
+        scope,
+        req,
+        {
+          resourceKind: NOTIFICATION_RESOURCE_KIND,
+          operation: 'create',
+          payload: parsed.data as Record<string, unknown>,
+        },
+        () => service[serviceMethod](parsed.data as never, scope),
+      )
+      if (!guarded.ok) return guarded.response
+      const notifications = guarded.result
 
       return Response.json({
         ok: true,
@@ -144,10 +230,21 @@ export function createSingleNotificationActionRoute(
 ) {
   return async function PUT(req: Request, { params }: { params: Promise<{ id: string }> }) {
     const { id } = await params
-    const { service, scope } = await resolveNotificationContext(req)
+    const { service, scope, ctx } = await resolveNotificationContext(req)
 
     try {
-      await service[serviceMethod](id, scope)
+      const guarded = await runGuardedNotificationWrite(
+        ctx.container,
+        scope,
+        req,
+        {
+          resourceKind: NOTIFICATION_RESOURCE_KIND,
+          resourceId: id,
+          operation: 'update',
+        },
+        () => service[serviceMethod](id, scope),
+      )
+      if (!guarded.ok) return guarded.response
     } catch (error) {
       const errorResponse = notificationCrudErrorResponse(error)
       if (errorResponse) return errorResponse


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Notification custom write routes (the ones that do not use `makeCrudRoute`) were mutating
state without running the required mutation-guard lifecycle, violating the core contract in
`packages/core/AGENTS.md` ("Wire custom write routes through the mutation guard contract").
This wires `validateCrudMutationGuard` (before the write) and `runCrudMutationGuardAfterSuccess`
(after a successful write, only when requested) into every notification write route, centralized
through a single helper so authorization behavior and response shapes are preserved. In OSS (no
`crudMutationGuardService` registered) the guard returns `null` and behavior is unchanged; when a
guard service is present (e.g. enterprise record-locks) notification writes are now protected.

## Changes

- Add `runGuardedNotificationWrite()` to `lib/routeHelpers.ts` — runs validate → write → after-success, returns the guard's own block response on rejection — plus `NOTIFICATION_RESOURCE_KIND` (`notifications.notification`) and `NOTIFICATION_SETTINGS_RESOURCE_KIND` (`notifications.settings`).
- Wire the helper into the two route factories (`createBulkNotificationRoute` → batch/role/feature; `createSingleNotificationActionRoute` → read/dismiss).
- Wire the inline write routes: create (`api/route.ts`), restore, execute-action, mark-all-read, and settings update.
- Add `__tests__/mutation-guard.test.ts` covering all 7 write sites plus a guard-rejection case (write skipped, after-success not run).

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — bug fix that enforces an existing documented contract (`packages/core/AGENTS.md` → API Routes).


## Testing

List the tests or commands you ran to validate the change.

- `yarn workspace @open-mercato/core test -- modules/notifications/__tests__/mutation-guard.test` → 8/8 pass (proven red when wiring removed, then restored)
- `yarn workspace @open-mercato/core test -- modules/notifications` → 30/30 pass
- `yarn workspace @open-mercato/core test` → 742 suites / 6074 tests pass
- `yarn typecheck --filter=@open-mercato/core` → pass
- `yarn i18n:check-sync` → all locales in sync
- `yarn build:app` → pass

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no new auto-discovered files, no user-facing strings.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Covered by a per-route unit test mirroring the canonical `dictionaries` guard test; the guard service is enterprise-only (`record_locks`), so the guard *behavior* can't be exercised by an OSS integration run, while the *wiring* (validate-before / after-success-only) is fully asserted in the unit test.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — small bug fix.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). (`risk-high` — touches every notification write path / guard-and-auth-adjacent; kept from the issue.)
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`. (`needs-qa` — affects customer-facing notification write flows.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens — N/A — no UI
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` — N/A — no UI
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) — N/A — no UI
- [x] Loading state handled for async pages — N/A — no UI
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) — N/A — no UI
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements — N/A — no UI

## Linked issues

Fixes #3265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
