### PR TITLE
fix(messages): make terminal actions concurrency-safe before executing target commands (#3261)

### DIFF
--- a/packages/core/src/modules/messages/__integration__/TC-API-MSG-004.spec.ts
+++ b/packages/core/src/modules/messages/__integration__/TC-API-MSG-004.spec.ts
@@ -86,4 +86,52 @@ test.describe('TC-API-MSG-004: Terminal Action Can Be Executed Once', () => {
     const detailBody = (await detailResponse.json()) as { actionTaken?: unknown };
     expect(detailBody.actionTaken).toBe('ack');
   });
+
+  test('executes the terminal action at most once under concurrent requests', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin@acme.com', 'secret');
+    const employeeToken = await getAuthToken(request, 'employee@acme.com', 'secret');
+    const employeeId = decodeJwtSubject(employeeToken);
+
+    const subject = `QA TC-API-MSG-004 concurrent ${Date.now()}`;
+    const messageId = await composeActionMessage(request, adminToken, employeeId, subject);
+
+    // Fire two requests at the same terminal action simultaneously. Exactly one
+    // must execute the target and succeed; the other must lose the atomic claim
+    // and receive the existing "Action already taken" 409 response.
+    const [first, second] = await Promise.all([
+      apiRequest(request, 'POST', `/api/messages/${messageId}/actions/ack`, {
+        token: employeeToken,
+        data: {},
+      }),
+      apiRequest(request, 'POST', `/api/messages/${messageId}/actions/ack`, {
+        token: employeeToken,
+        data: {},
+      }),
+    ]);
+
+    const statuses = [first.status(), second.status()].sort();
+    expect(statuses).toEqual([200, 409]);
+
+    const okResponse = first.status() === 200 ? first : second;
+    const conflictResponse = first.status() === 409 ? first : second;
+
+    expect((await okResponse.json()) as { ok?: unknown; actionId?: unknown }).toMatchObject({
+      ok: true,
+      actionId: 'ack',
+    });
+
+    const conflictBody = (await conflictResponse.json()) as {
+      error?: unknown;
+      actionTaken?: unknown;
+    };
+    expect(conflictBody.error).toBe('Action already taken');
+    expect(conflictBody.actionTaken).toBe('ack');
+
+    const detailResponse = await apiRequest(request, 'GET', `/api/messages/${messageId}`, {
+      token: employeeToken,
+    });
+    expect(detailResponse.status()).toBe(200);
+    const detailBody = (await detailResponse.json()) as { actionTaken?: unknown };
+    expect(detailBody.actionTaken).toBe('ack');
+  });
 });

--- a/packages/core/src/modules/messages/commands/__tests__/actions.test.ts
+++ b/packages/core/src/modules/messages/commands/__tests__/actions.test.ts
@@ -47,6 +47,7 @@ describe('messages.actions.execute command', () => {
         if (entity === MessageObject) return []
         return []
       }),
+      nativeUpdate: jest.fn(async () => 1),
     }
 
     const terminalLogEntry = {
@@ -106,5 +107,101 @@ describe('messages.actions.execute command', () => {
         }),
       }),
     )
+  })
+
+  it('does not run the target command when the terminal action is claimed concurrently', async () => {
+    const command = commandRegistry.get('messages.actions.execute')
+    expect(command).toBeTruthy()
+
+    const message = {
+      id: '11111111-1111-4111-8111-111111111111',
+      type: 'default',
+      sourceEntityId: '22222222-2222-4222-8222-222222222222',
+      tenantId: '55555555-5555-4555-8555-555555555555',
+      organizationId: '66666666-6666-4666-8666-666666666666',
+      threadId: null,
+      parentMessageId: null,
+      sentAt: new Date('2026-03-01T12:00:00.000Z'),
+      deletedAt: null,
+      actionTaken: null,
+      actionData: {
+        actions: [
+          {
+            id: 'approve',
+            label: 'Approve',
+            commandId: 'demo.approve',
+            isTerminal: true,
+          },
+        ],
+      },
+    }
+
+    // Simulate a concurrent request that wins the atomic claim between our read
+    // and our own claim attempt: the compare-and-set UPDATE then matches 0 rows.
+    let winnerClaimed = false
+    const emFork = {
+      findOne: jest.fn(async (entity: unknown) => {
+        if (entity === Message) {
+          return winnerClaimed
+            ? { ...message, actionTaken: 'approve', actionTakenByUserId: 'other-user' }
+            : message
+        }
+        if (entity === MessageRecipient) {
+          return {
+            id: '33333333-3333-4333-8333-333333333333',
+            messageId: message.id,
+            recipientUserId: '44444444-4444-4444-8444-444444444444',
+            deletedAt: null,
+          }
+        }
+        return null
+      }),
+      find: jest.fn(async (entity: unknown) => {
+        if (entity === MessageObject) return []
+        return []
+      }),
+      nativeUpdate: jest.fn(async () => {
+        winnerClaimed = true
+        return 0
+      }),
+    }
+
+    const nestedCommandBus = {
+      execute: jest.fn(async () => ({ result: { ok: true }, logEntry: null })),
+    }
+
+    await expect(
+      command!.execute(
+        {
+          messageId: message.id,
+          actionId: 'approve',
+          tenantId: '55555555-5555-4555-8555-555555555555',
+          organizationId: '66666666-6666-4666-8666-666666666666',
+          userId: '44444444-4444-4444-8444-444444444444',
+        },
+        {
+          container: {
+            resolve: (name: string) => {
+              if (name === 'em') return { fork: () => emFork }
+              if (name === 'commandBus') return nestedCommandBus
+              return null
+            },
+          } as never,
+          auth: {
+            sub: '44444444-4444-4444-8444-444444444444',
+            tenantId: '55555555-5555-4555-8555-555555555555',
+            orgId: '66666666-6666-4666-8666-666666666666',
+          } as never,
+          organizationScope: null,
+          selectedOrganizationId: '66666666-6666-4666-8666-666666666666',
+          organizationIds: ['66666666-6666-4666-8666-666666666666'],
+        },
+      ),
+    ).rejects.toThrow('Action already taken')
+
+    // The atomic claim must run before the target command...
+    expect(emFork.nativeUpdate).toHaveBeenCalledTimes(1)
+    // ...and because the claim lost the race, the target command never executed.
+    expect(nestedCommandBus.execute).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/messages/commands/actions.ts
+++ b/packages/core/src/modules/messages/commands/actions.ts
@@ -15,6 +15,13 @@ import {
 import { getMessageType } from '../lib/message-types-registry'
 import { assertOrganizationAccess, type MessageScopeInput } from './shared'
 
+const actionStateSnapshotSchema = z.object({
+  actionTaken: z.string().nullable(),
+  actionTakenByUserId: z.string().nullable(),
+  actionTakenAt: z.string().nullable(),
+  actionResult: z.record(z.string(), z.unknown()).nullable(),
+})
+
 const recordTerminalActionSchema = z.object({
   messageId: z.string().uuid(),
   actionId: z.string().min(1),
@@ -22,6 +29,10 @@ const recordTerminalActionSchema = z.object({
   tenantId: z.string().uuid(),
   organizationId: z.string().uuid().nullable(),
   userId: z.string().uuid(),
+  // Optional pre-claim snapshot supplied by `messages.actions.execute` so the
+  // undo log records the true (un-taken) state even though the terminal action
+  // was atomically claimed before this finalizer runs.
+  previousState: actionStateSnapshotSchema.optional(),
 })
 
 type RecordTerminalActionInput = z.infer<typeof recordTerminalActionSchema>
@@ -121,12 +132,35 @@ const recordTerminalActionCommand: CommandHandler<unknown, { ok: true }> = {
     const input = recordTerminalActionSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const message = await requireActionTarget(em, input)
-    if (message.actionTaken) {
-      throw new Error('Action already taken')
+    const claimedByCaller =
+      message.actionTaken === input.actionId && message.actionTakenByUserId === input.userId
+    if (!claimedByCaller) {
+      if (message.actionTaken) {
+        throw new Error('Action already taken')
+      }
+      // Atomic compare-and-set: only one concurrent request transitions the
+      // message out of the un-taken state. nativeUpdate runs as a single
+      // `UPDATE ... WHERE action_taken IS NULL` so the loser matches 0 rows.
+      const claimedRows = await em.nativeUpdate(
+        Message,
+        { id: input.messageId, tenantId: input.tenantId, actionTaken: null, deletedAt: null },
+        {
+          actionTaken: input.actionId,
+          actionTakenByUserId: input.userId,
+          actionTakenAt: new Date(),
+        },
+      )
+      if (claimedRows === 0) {
+        throw new Error('Action already taken')
+      }
+      message.actionTaken = input.actionId
+      message.actionTakenByUserId = input.userId
     }
-    message.actionTaken = input.actionId
-    message.actionTakenByUserId = input.userId
-    message.actionTakenAt = new Date()
+    if (!message.actionTakenAt) {
+      message.actionTakenAt = new Date()
+    }
+    // action_result is an encrypted column, so it must be written through the
+    // flush path (the encryption subscriber) rather than nativeUpdate.
     message.actionResult = input.result
     await em.flush()
     return { ok: true }
@@ -139,6 +173,13 @@ const recordTerminalActionCommand: CommandHandler<unknown, { ok: true }> = {
   },
   buildLog: async ({ input, snapshots }) => {
     const parsed = recordTerminalActionSchema.parse(input)
+    // When the action was pre-claimed by `messages.actions.execute`, the
+    // prepare-captured snapshot already reflects the claimed state, so prefer
+    // the explicit pre-claim snapshot for the undo baseline.
+    const before =
+      (parsed.previousState as ActionStateSnapshot | undefined) ??
+      (snapshots.before as ActionStateSnapshot | undefined) ??
+      null
     return {
       actionLabel: 'Execute message terminal action',
       resourceKind: 'messages.message',
@@ -147,11 +188,11 @@ const recordTerminalActionCommand: CommandHandler<unknown, { ok: true }> = {
       organizationId: parsed.organizationId,
       payload: {
         undo: {
-          before: (snapshots.before as ActionStateSnapshot | undefined) ?? null,
+          before,
           after: (snapshots.after as ActionStateSnapshot | undefined) ?? null,
         } satisfies UndoPayload<ActionStateSnapshot>,
       },
-      snapshotBefore: snapshots.before ?? null,
+      snapshotBefore: before,
       snapshotAfter: snapshots.after ?? null,
     }
   },
@@ -209,6 +250,52 @@ const executeActionCommand: CommandHandler<
       }
     }
 
+    // Capture the un-taken state for the undo log before reserving the action.
+    const previousState = snapshotActionState(message)
+    let claimedTerminal = false
+    const releaseTerminalClaim = async () => {
+      if (!claimedTerminal) return
+      claimedTerminal = false
+      await em.nativeUpdate(
+        Message,
+        {
+          id: message.id,
+          tenantId: input.tenantId,
+          actionTaken: action.id,
+          actionTakenByUserId: input.userId,
+        },
+        { actionTaken: null, actionTakenByUserId: null, actionTakenAt: null },
+      )
+    }
+
+    if (shouldRecordActionTaken) {
+      // Atomically reserve the terminal action BEFORE running the target
+      // command so concurrent requests cannot both execute it. The losing
+      // request matches 0 rows and surfaces the existing 409 response.
+      const claimedRows = await em.nativeUpdate(
+        Message,
+        { id: message.id, tenantId: input.tenantId, actionTaken: null, deletedAt: null },
+        {
+          actionTaken: action.id,
+          actionTakenByUserId: input.userId,
+          actionTakenAt: new Date(),
+        },
+      )
+      if (claimedRows === 0) {
+        const current = await findOneWithDecryption(
+          em,
+          Message,
+          { id: message.id, tenantId: input.tenantId, deletedAt: null },
+          undefined,
+          { tenantId: input.tenantId, organizationId: input.organizationId },
+        )
+        throw Object.assign(new Error('Action already taken'), {
+          actionTaken: current?.actionTaken ?? message.actionTaken ?? action.id,
+        })
+      }
+      claimedTerminal = true
+    }
+
     const commandBus = ctx.container.resolve('commandBus') as {
       execute: (
         commandId: string,
@@ -263,6 +350,9 @@ const executeActionCommand: CommandHandler<
         operationLogEntry = commandResult.logEntry ?? null
       } catch (err) {
         console.error('[messages] executeActionCommand sub-command failed', err)
+        // The target command never completed — release the reservation so the
+        // action stays retryable, matching the pre-claim failure semantics.
+        await releaseTerminalClaim()
         throw new Error('Action failed')
       }
     } else if (action.href) {
@@ -272,10 +362,12 @@ const executeActionCommand: CommandHandler<
         userId: input.userId,
       })
       if (!safeRedirect) {
+        await releaseTerminalClaim()
         throw new Error('Action has an unsafe redirect target')
       }
       result = { redirect: safeRedirect }
     } else {
+      await releaseTerminalClaim()
       throw new Error('Action has no executable target')
     }
 
@@ -288,6 +380,7 @@ const executeActionCommand: CommandHandler<
           tenantId: input.tenantId,
           organizationId: input.organizationId,
           userId: input.userId,
+          previousState,
         },
         ctx: {
           container: ctx.container,


### PR DESCRIPTION
## Summary

Terminal message actions recorded `actionTaken` only *after* executing the target command, so two concurrent `POST /api/messages/[id]/actions/[actionId]` requests could both pass the read-time `actionTaken` check and both run the target command (duplicate side effects) before either recorded the terminal state. This makes the terminal-action transition an atomic compare-and-set performed **before** the target command runs, so only one request ever executes it; the loser receives the existing `Action already taken` 409.

## Changes

- `executeActionCommand.execute` (`packages/core/src/modules/messages/commands/actions.ts`): atomically reserve the terminal action with `em.nativeUpdate(Message, { …, actionTaken: null, deletedAt: null }, {…})` (single `UPDATE … WHERE action_taken IS NULL`) **before** running the target command; the losing request matches 0 rows, re-reads the message (tenant-scoped) and throws the existing `Action already taken` → 409.
- Release the reservation if the target command itself fails (unsafe-redirect / no-target / sub-command error) so the action stays retryable, matching prior semantics; never released after a successful target.
- `recordTerminalActionCommand.execute`: converted the non-atomic read-then-write guard into an atomic claim-or-finalize. The encrypted `action_result` column is written via `em.flush()` (encryption subscriber), never via `nativeUpdate`.
- Preserve undo correctness: `executeActionCommand` passes a pre-claim `previousState` snapshot, and `buildLog` uses it for the undo baseline so undo restores the truly un-taken state. Added an optional `previousState` field to the `record_terminal` zod schema (additive/backward-compatible).
- Tests: deterministic unit repro proving the target command never runs when the claim is lost; concurrent `Promise.all` integration test in `TC-API-MSG-004` asserting exactly one `200` + one `409`.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — root-cause concurrency fix in an existing module (reference spec: `.ai/specs/SPEC-002-2026-01-23-messages-module.md`); no contract/schema change beyond an additive optional command-input field.

## Testing

- `yarn workspace @open-mercato/core test src/modules/messages/commands/__tests__/actions.test.ts` — new concurrency repro red → green; existing tests pass.
- `yarn workspace @open-mercato/core test src/modules/messages` — 48 suites / 229 tests pass.
- `yarn workspace @open-mercato/core test` — 741 suites / 6067 tests pass (no cross-module regression).
- `yarn workspace @open-mercato/core build` — tsc typecheck passes (incl. the `__integration__` Playwright spec).
- `yarn i18n:check-sync` — all locales in sync.
- Added `TC-API-MSG-004` concurrent integration test (`Promise.all` → exactly one 200 + one 409).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no new user-facing strings, schema, or generated files.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Added to the module's `__integration__/TC-API-MSG-004.spec.ts`, matching this repo's module-integration-test convention.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — minor root-cause fix, no spec change.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-high`, inherited — concurrency/event-reliability surface.)
- [x] QA routing set: `needs-qa` (customer-facing message-action flow; concurrency contract). A `needs-qa` PR cannot merge until QA adds `qa-approved`.

### Design System Compliance
- [x] No hardcoded status colors — N/A (no UI in this change)
- [x] No arbitrary text sizes — N/A (no UI)
- [x] Empty state handled for list/data pages — N/A (no UI)
- [x] Loading state handled for async pages — N/A (no UI)
- [x] `aria-label` on all icon-only buttons — N/A (no UI)
- [x] Uses existing DS components — N/A (no UI)

## Linked issues

Fixes #3261
