### PR TITLE
fix: wire mutation guards into messages write routes (#3259)

### DIFF
--- a/packages/core/src/modules/messages/api/[id]/actions/[actionId]/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/actions/[actionId]/route.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import type { CommandBus } from '@open-mercato/shared/lib/commands/command-bus'
 import { attachOperationMetadataHeader, type OperationLogEntryLike } from '../../../../lib/operationMetadata'
 import { resolveMessageContext } from '../../../../lib/routeHelpers'
+import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from '../../../guards'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi/types'
 import { actionResultResponseSchema } from '../../../openapi'
 
@@ -20,6 +21,29 @@ export async function POST(
   const body = (typeof rawBody === 'object' && rawBody && !Array.isArray(rawBody)
     ? rawBody
     : {}) as Record<string, unknown>
+
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: params.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: body,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
+
   try {
     const commandResult = await commandBus.execute('messages.actions.execute', {
       input: {
@@ -54,6 +78,16 @@ export async function POST(
     attachOperationMetadataHeader(response, result.operationLogEntry ?? null, {
       resourceKind: 'messages.message',
       resourceId: params.id,
+    })
+    await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: params.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
     })
     return response
   } catch (error) {

--- a/packages/core/src/modules/messages/api/[id]/archive/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/archive/route.ts
@@ -5,6 +5,7 @@ import { Message, MessageRecipient } from '../../../data/entities'
 import { attachOperationMetadataHeader } from '../../../lib/operationMetadata'
 import { hasOrganizationAccess, resolveMessageContext } from '../../../lib/routeHelpers'
 import type { MessageScope } from '../../../lib/routeHelpers'
+import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from '../../guards'
 import { errorResponseSchema, okResponseSchema } from '../../openapi'
 
 export const metadata = {
@@ -56,6 +57,27 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
   if ('response' in context) return context.response
   const { ctx, scope } = context
   const commandBus = ctx.container.resolve('commandBus') as CommandBus
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: params.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: null,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
   const { logEntry } = await commandBus.execute('messages.recipients.archive', {
     input: {
       messageId: params.id,
@@ -78,6 +100,16 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
     resourceKind: 'messages.message',
     resourceId: params.id,
   })
+  await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: scope.userId,
+    resourceKind: 'messages.message',
+    resourceId: params.id,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+  })
   return response
 }
 
@@ -86,6 +118,27 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
   if ('response' in context) return context.response
   const { ctx, scope } = context
   const commandBus = ctx.container.resolve('commandBus') as CommandBus
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: params.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: null,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
   const { logEntry } = await commandBus.execute('messages.recipients.unarchive', {
     input: {
       messageId: params.id,
@@ -107,6 +160,16 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
   attachOperationMetadataHeader(response, logEntry, {
     resourceKind: 'messages.message',
     resourceId: params.id,
+  })
+  await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: scope.userId,
+    resourceKind: 'messages.message',
+    resourceId: params.id,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
   })
   return response
 }

--- a/packages/core/src/modules/messages/api/[id]/attachments/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/attachments/route.ts
@@ -7,6 +7,7 @@ import { attachmentIdsPayloadSchema, unlinkAttachmentPayloadSchema } from '../..
 import { getMessageAttachments, linkAttachmentsToMessage } from '../../../lib/attachments'
 import { attachOperationMetadataHeader } from '../../../lib/operationMetadata'
 import { resolveMessageContext } from '../../../lib/routeHelpers'
+import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from '../../guards'
 import {
   attachmentIdsPayloadSchema as attachmentIdsOpenApiSchema,
   errorResponseSchema,
@@ -95,6 +96,27 @@ export async function POST(req: Request, { params }: { params: { id: string } })
   }
 
   const commandBus = ctx.container.resolve('commandBus') as CommandBus
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: message.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input as Record<string, unknown>,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
   const { logEntry } = await commandBus.execute('messages.attachments.link_to_draft', {
     input: {
       messageId: message.id,
@@ -117,6 +139,16 @@ export async function POST(req: Request, { params }: { params: { id: string } })
   attachOperationMetadataHeader(response, logEntry, {
     resourceKind: 'messages.message',
     resourceId: params.id,
+  })
+  await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: scope.userId,
+    resourceKind: 'messages.message',
+    resourceId: message.id,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
   })
   return response
 }
@@ -150,6 +182,27 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
   }
 
   const commandBus = ctx.container.resolve('commandBus') as CommandBus
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: message.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input as Record<string, unknown>,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
   const { logEntry } = await commandBus.execute('messages.attachments.unlink_from_draft', {
     input: {
       messageId: message.id,
@@ -172,6 +225,16 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
   attachOperationMetadataHeader(response, logEntry, {
     resourceKind: 'messages.message',
     resourceId: params.id,
+  })
+  await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: scope.userId,
+    resourceKind: 'messages.message',
+    resourceId: message.id,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
   })
   return response
 }

--- a/packages/core/src/modules/messages/api/[id]/conversation/archive/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/conversation/archive/route.ts
@@ -2,6 +2,7 @@ import type { CommandBus } from '@open-mercato/shared/lib/commands/command-bus'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi/types'
 import { attachOperationMetadataHeader } from '../../../../lib/operationMetadata'
 import { resolveMessageContext } from '../../../../lib/routeHelpers'
+import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from '../../../guards'
 import {
   conversationMutationResponseSchema,
   errorResponseSchema,
@@ -14,6 +15,28 @@ export const metadata = {
 export async function PUT(req: Request, { params }: { params: { id: string } }) {
   const { ctx, scope } = await resolveMessageContext(req)
   const commandBus = ctx.container.resolve('commandBus') as CommandBus
+
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.conversation',
+      resourceId: params.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: null,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
 
   try {
     const { result, logEntry } = await commandBus.execute('messages.conversation.archive_for_actor', {
@@ -37,6 +60,16 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
     attachOperationMetadataHeader(response, logEntry, {
       resourceKind: 'messages.conversation',
       resourceId: params.id,
+    })
+    await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.conversation',
+      resourceId: params.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
     })
     return response
   } catch (error) {

--- a/packages/core/src/modules/messages/api/[id]/conversation/read/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/conversation/read/route.ts
@@ -2,6 +2,7 @@ import type { CommandBus } from '@open-mercato/shared/lib/commands/command-bus'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi/types'
 import { attachOperationMetadataHeader } from '../../../../lib/operationMetadata'
 import { resolveMessageContext } from '../../../../lib/routeHelpers'
+import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from '../../../guards'
 import {
   conversationMutationResponseSchema,
   errorResponseSchema,
@@ -14,6 +15,28 @@ export const metadata = {
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   const { ctx, scope } = await resolveMessageContext(req)
   const commandBus = ctx.container.resolve('commandBus') as CommandBus
+
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.conversation',
+      resourceId: params.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: null,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
 
   try {
     const { result, logEntry } = await commandBus.execute('messages.conversation.mark_unread_for_actor', {
@@ -37,6 +60,16 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
     attachOperationMetadataHeader(response, logEntry, {
       resourceKind: 'messages.conversation',
       resourceId: params.id,
+    })
+    await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.conversation',
+      resourceId: params.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
     })
     return response
   } catch (error) {

--- a/packages/core/src/modules/messages/api/[id]/conversation/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/conversation/route.ts
@@ -2,6 +2,7 @@ import type { CommandBus } from '@open-mercato/shared/lib/commands/command-bus'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi/types'
 import { attachOperationMetadataHeader } from '../../../lib/operationMetadata'
 import { resolveMessageContext } from '../../../lib/routeHelpers'
+import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from '../../guards'
 import {
   conversationMutationResponseSchema,
   errorResponseSchema,
@@ -14,6 +15,28 @@ export const metadata = {
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   const { ctx, scope } = await resolveMessageContext(req)
   const commandBus = ctx.container.resolve('commandBus') as CommandBus
+
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.conversation',
+      resourceId: params.id,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: null,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
 
   try {
     const { result, logEntry } = await commandBus.execute('messages.conversation.delete_for_actor', {
@@ -37,6 +60,16 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
     attachOperationMetadataHeader(response, logEntry, {
       resourceKind: 'messages.conversation',
       resourceId: params.id,
+    })
+    await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.conversation',
+      resourceId: params.id,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
     })
     return response
   } catch (error) {

--- a/packages/core/src/modules/messages/api/[id]/forward/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/forward/route.ts
@@ -2,6 +2,7 @@ import type { CommandBus } from '@open-mercato/shared/lib/commands/command-bus'
 import { forwardMessageSchema } from '../../../data/validators'
 import { attachOperationMetadataHeader, OperationLogEntryLike } from '../../../lib/operationMetadata'
 import { canUseMessageEmailFeature, parseRequestBodySafe, resolveMessageContext } from '../../../lib/routeHelpers'
+import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from '../../guards'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi/types'
 import { forwardResponseSchema, forwardMessageSchema as forwardSchema } from '../../openapi'
 import { MessageCommandExecuteResult } from '../../../commands/shared'
@@ -17,6 +18,28 @@ export async function POST(req: Request, { params }: { params: { id: string } })
   const input = forwardMessageSchema.parse(body)
   if (input.sendViaEmail && !(await canUseMessageEmailFeature(ctx, scope))) {
     return Response.json({ error: 'Missing feature: messages.email' }, { status: 403 })
+  }
+
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: null,
+      operation: 'create',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input as Record<string, unknown>,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
   }
 
   let commandResult: { result: MessageCommandExecuteResult; logEntry: unknown }
@@ -61,6 +84,16 @@ export async function POST(req: Request, { params }: { params: { id: string } })
   attachOperationMetadataHeader(response, commandResult.logEntry as OperationLogEntryLike, {
     resourceKind: 'messages.message',
     resourceId: newMessageId,
+  })
+  await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: scope.userId,
+    resourceKind: 'messages.message',
+    resourceId: newMessageId,
+    operation: 'create',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
   })
   return response
 }

--- a/packages/core/src/modules/messages/api/[id]/read/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/read/route.ts
@@ -5,6 +5,7 @@ import { Message, MessageRecipient } from '../../../data/entities'
 import { attachOperationMetadataHeader } from '../../../lib/operationMetadata'
 import { hasOrganizationAccess, resolveMessageContext } from '../../../lib/routeHelpers'
 import type { MessageScope } from '../../../lib/routeHelpers'
+import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from '../../guards'
 import { errorResponseSchema, okResponseSchema } from '../../openapi'
 
 export const metadata = {
@@ -56,6 +57,27 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
   if ('response' in context) return context.response
   const { ctx, scope } = context
   const commandBus = ctx.container.resolve('commandBus') as CommandBus
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: params.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: null,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
   const { logEntry } = await commandBus.execute('messages.recipients.mark_read', {
     input: {
       messageId: params.id,
@@ -78,6 +100,16 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
     resourceKind: 'messages.message',
     resourceId: params.id,
   })
+  await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: scope.userId,
+    resourceKind: 'messages.message',
+    resourceId: params.id,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
+  })
   return response
 }
 
@@ -86,6 +118,27 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
   if ('response' in context) return context.response
   const { ctx, scope } = context
   const commandBus = ctx.container.resolve('commandBus') as CommandBus
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: params.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: null,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
   const { logEntry } = await commandBus.execute('messages.recipients.mark_unread', {
     input: {
       messageId: params.id,
@@ -107,6 +160,16 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
   attachOperationMetadataHeader(response, logEntry, {
     resourceKind: 'messages.message',
     resourceId: params.id,
+  })
+  await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: scope.userId,
+    resourceKind: 'messages.message',
+    resourceId: params.id,
+    operation: 'update',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
   })
   return response
 }

--- a/packages/core/src/modules/messages/api/[id]/reply/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/reply/route.ts
@@ -3,6 +3,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi/types'
 import { replyMessageSchema } from '../../../data/validators'
 import { attachOperationMetadataHeader } from '../../../lib/operationMetadata'
 import { canUseMessageEmailFeature, resolveMessageContext } from '../../../lib/routeHelpers'
+import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from '../../guards'
 import {
   errorResponseSchema,
   forwardResponseSchema,
@@ -21,6 +22,28 @@ export async function POST(req: Request, { params }: { params: { id: string } })
   const input = replyMessageSchema.parse(body)
   if (input.sendViaEmail && !(await canUseMessageEmailFeature(ctx, scope))) {
     return Response.json({ error: 'Missing feature: messages.email' }, { status: 403 })
+  }
+
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: null,
+      operation: 'create',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input as Record<string, unknown>,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
   }
 
   let commandResult
@@ -65,6 +88,16 @@ export async function POST(req: Request, { params }: { params: { id: string } })
   attachOperationMetadataHeader(response, commandResult.logEntry, {
     resourceKind: 'messages.message',
     resourceId: messageId,
+  })
+  await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: scope.userId,
+    resourceKind: 'messages.message',
+    resourceId: messageId,
+    operation: 'create',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
   })
   return response
 }

--- a/packages/core/src/modules/messages/api/[id]/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/route.ts
@@ -10,6 +10,7 @@ import { getMessageObjectType } from '../../lib/message-objects-registry'
 import { getMessageTypeOrDefault } from '../../lib/message-types-registry'
 import { attachOperationMetadataHeader } from '../../lib/operationMetadata'
 import { hasOrganizationAccess, resolveMessageContext } from '../../lib/routeHelpers'
+import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from '../guards'
 import {
   errorResponseSchema,
   messageDetailResponseSchema,
@@ -275,6 +276,28 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     return Response.json({ error: 'Only draft messages can be edited' }, { status: 409 })
   }
 
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: message.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input as Record<string, unknown>,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
+
   try {
     const { logEntry } = await commandBus.execute('messages.messages.update_draft', {
       input: {
@@ -298,6 +321,16 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     attachOperationMetadataHeader(response, logEntry, {
       resourceKind: 'messages.message',
       resourceId: message.id,
+    })
+    await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: message.id,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
     })
     return response
   } catch (error) {
@@ -336,6 +369,28 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
     return Response.json({ error: 'Access denied' }, { status: 403 })
   }
 
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: params.id,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: null,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
+
   try {
     const { logEntry } = await commandBus.execute('messages.messages.delete_for_actor', {
       input: {
@@ -358,6 +413,16 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
     attachOperationMetadataHeader(response, logEntry, {
       resourceKind: 'messages.message',
       resourceId: params.id,
+    })
+    await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: params.id,
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
     })
     return response
   } catch (error) {

--- a/packages/core/src/modules/messages/api/__tests__/mutation-guard-wiring.test.ts
+++ b/packages/core/src/modules/messages/api/__tests__/mutation-guard-wiring.test.ts
@@ -1,0 +1,369 @@
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const messageId = '44444444-4444-4444-8444-444444444444'
+const actionId = '55555555-5555-4555-8555-555555555555'
+
+const callOrder: string[] = []
+
+const em = {
+  fork: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+}
+
+const commandBusExecuteMock = jest.fn()
+const commandBus = {
+  execute: (...args: unknown[]) => commandBusExecuteMock(...args),
+}
+
+const rbacService = {
+  loadAcl: jest.fn(async () => ({ features: [], isSuperAdmin: false })),
+}
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'commandBus') return commandBus
+    if (name === 'rbacService') return rbacService
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const runMessageMutationGuardsMock = jest.fn()
+const runMessageMutationGuardAfterSuccessMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    sub: userId,
+    tenantId,
+    orgId: organizationId,
+    features: ['messages.compose', 'messages.view', 'messages.actions', 'messages.attach_files'],
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (key: string, fallback: string) => fallback,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (emInstance: typeof em, entity: unknown, filters: unknown) => emInstance.find(entity, filters),
+  findOneWithDecryption: (emInstance: typeof em, entity: unknown, filters: unknown) => emInstance.findOne(entity, filters),
+}))
+
+jest.mock('../guards', () => ({
+  resolveUserFeatures: jest.fn(() => []),
+  runMessageMutationGuards: (...args: unknown[]) => runMessageMutationGuardsMock(...args),
+  runMessageMutationGuardAfterSuccess: (...args: unknown[]) => runMessageMutationGuardAfterSuccessMock(...args),
+}))
+
+import { POST as composeMessage } from '../route'
+import { PATCH as updateDraft, DELETE as deleteMessage } from '../[id]/route'
+import { PUT as markRead } from '../[id]/read/route'
+import { POST as executeAction } from '../[id]/actions/[actionId]/route'
+import { POST as replyMessage } from '../[id]/reply/route'
+import { DELETE as deleteConversation } from '../[id]/conversation/route'
+
+const REJECTION = {
+  ok: false as const,
+  errorStatus: 423,
+  errorBody: { error: 'Record locked', guardId: 'record_locks.lock-check' },
+  afterSuccessCallbacks: [],
+}
+
+function allowGuard() {
+  runMessageMutationGuardsMock.mockImplementation(async () => {
+    callOrder.push('guard:validate')
+    return {
+      ok: true,
+      afterSuccessCallbacks: [{ guard: { id: 'g' }, metadata: { token: 'guard' } }],
+    }
+  })
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  callOrder.length = 0
+  em.fork.mockReturnValue(em)
+  em.find.mockResolvedValue([])
+  em.findOne.mockResolvedValue(null)
+  commandBusExecuteMock.mockImplementation(async () => {
+    callOrder.push('command')
+    return { result: { id: messageId, threadId: 'thread-1', ok: true, actionId, result: {}, operationLogEntry: null }, logEntry: null }
+  })
+  runMessageMutationGuardsMock.mockImplementation(async () => {
+    callOrder.push('guard:validate')
+    return { ok: true, afterSuccessCallbacks: [] }
+  })
+  runMessageMutationGuardAfterSuccessMock.mockImplementation(async () => {
+    callOrder.push('guard:after')
+  })
+})
+
+function composeRequest() {
+  return new Request('http://localhost/api/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ isDraft: true }),
+  })
+}
+
+function draftMessage() {
+  return { id: messageId, organizationId, senderUserId: userId, isDraft: true }
+}
+
+describe('messages compose route mutation guard wiring', () => {
+  it('blocks the command when the guard rejects', async () => {
+    runMessageMutationGuardsMock.mockResolvedValue(REJECTION)
+
+    const response = await composeMessage(composeRequest())
+
+    expect(response.status).toBe(423)
+    expect(await response.json()).toEqual(REJECTION.errorBody)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+
+  it('validates before dispatching and runs after-success only after the command', async () => {
+    allowGuard()
+
+    const response = await composeMessage(composeRequest())
+
+    expect(response.status).toBe(201)
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('messages.messages.compose', expect.anything())
+    expect(runMessageMutationGuardsMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'messages.message', operation: 'create' }),
+      expect.anything(),
+    )
+    expect(runMessageMutationGuardAfterSuccessMock).toHaveBeenCalledTimes(1)
+    expect(callOrder).toEqual(['guard:validate', 'command', 'guard:after'])
+  })
+})
+
+describe('messages update-draft route mutation guard wiring', () => {
+  it('blocks the command when the guard rejects', async () => {
+    em.findOne.mockResolvedValue(draftMessage())
+    runMessageMutationGuardsMock.mockResolvedValue(REJECTION)
+
+    const response = await updateDraft(
+      new Request('http://localhost/api/messages/x', { method: 'PATCH', body: JSON.stringify({ subject: 'edit' }) }),
+      { params: { id: messageId } },
+    )
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+
+  it('validates before dispatching and runs after-success only after the command', async () => {
+    em.findOne.mockResolvedValue(draftMessage())
+    allowGuard()
+
+    const response = await updateDraft(
+      new Request('http://localhost/api/messages/x', { method: 'PATCH', body: JSON.stringify({ subject: 'edit' }) }),
+      { params: { id: messageId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('messages.messages.update_draft', expect.anything())
+    expect(runMessageMutationGuardsMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'messages.message', resourceId: messageId, operation: 'update' }),
+      expect.anything(),
+    )
+    expect(callOrder).toEqual(['guard:validate', 'command', 'guard:after'])
+  })
+})
+
+describe('messages delete route mutation guard wiring', () => {
+  it('blocks the command when the guard rejects', async () => {
+    em.findOne.mockResolvedValue({ id: messageId, organizationId })
+    runMessageMutationGuardsMock.mockResolvedValue(REJECTION)
+
+    const response = await deleteMessage(
+      new Request('http://localhost/api/messages/x', { method: 'DELETE' }),
+      { params: { id: messageId } },
+    )
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+
+  it('validates before dispatching and runs after-success only after the command', async () => {
+    em.findOne.mockResolvedValue({ id: messageId, organizationId })
+    allowGuard()
+
+    const response = await deleteMessage(
+      new Request('http://localhost/api/messages/x', { method: 'DELETE' }),
+      { params: { id: messageId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('messages.messages.delete_for_actor', expect.anything())
+    expect(runMessageMutationGuardsMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'messages.message', resourceId: messageId, operation: 'delete' }),
+      expect.anything(),
+    )
+    expect(callOrder).toEqual(['guard:validate', 'command', 'guard:after'])
+  })
+
+  it('does not run after-success when the command throws', async () => {
+    em.findOne.mockResolvedValue({ id: messageId, organizationId })
+    allowGuard()
+    commandBusExecuteMock.mockImplementation(async () => {
+      callOrder.push('command')
+      throw new Error('command boom')
+    })
+
+    await expect(
+      deleteMessage(
+        new Request('http://localhost/api/messages/x', { method: 'DELETE' }),
+        { params: { id: messageId } },
+      ),
+    ).rejects.toThrow('command boom')
+
+    expect(runMessageMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('messages mark-read route mutation guard wiring', () => {
+  it('blocks the command when the guard rejects', async () => {
+    em.findOne
+      .mockResolvedValueOnce({ id: messageId, organizationId })
+      .mockResolvedValueOnce({ id: 'recipient-1', messageId, recipientUserId: userId })
+    runMessageMutationGuardsMock.mockResolvedValue(REJECTION)
+
+    const response = await markRead(
+      new Request('http://localhost/api/messages/x/read', { method: 'PUT' }),
+      { params: { id: messageId } },
+    )
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+
+  it('validates before dispatching and runs after-success only after the command', async () => {
+    em.findOne
+      .mockResolvedValueOnce({ id: messageId, organizationId })
+      .mockResolvedValueOnce({ id: 'recipient-1', messageId, recipientUserId: userId })
+    allowGuard()
+
+    const response = await markRead(
+      new Request('http://localhost/api/messages/x/read', { method: 'PUT' }),
+      { params: { id: messageId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('messages.recipients.mark_read', expect.anything())
+    expect(runMessageMutationGuardsMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'messages.message', resourceId: messageId, operation: 'update' }),
+      expect.anything(),
+    )
+    expect(callOrder).toEqual(['guard:validate', 'command', 'guard:after'])
+  })
+})
+
+describe('messages reply route mutation guard wiring', () => {
+  function replyRequest() {
+    return new Request('http://localhost/api/messages/x/reply', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ body: 'reply text' }),
+    })
+  }
+
+  it('blocks the command when the guard rejects', async () => {
+    runMessageMutationGuardsMock.mockResolvedValue(REJECTION)
+
+    const response = await replyMessage(replyRequest(), { params: { id: messageId } })
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+
+  it('validates before dispatching and runs after-success only after the command', async () => {
+    allowGuard()
+
+    const response = await replyMessage(replyRequest(), { params: { id: messageId } })
+
+    expect(response.status).toBe(201)
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('messages.messages.reply', expect.anything())
+    expect(runMessageMutationGuardsMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'messages.message', operation: 'create' }),
+      expect.anything(),
+    )
+    expect(callOrder).toEqual(['guard:validate', 'command', 'guard:after'])
+  })
+})
+
+describe('messages conversation-delete route mutation guard wiring', () => {
+  it('blocks the command when the guard rejects', async () => {
+    runMessageMutationGuardsMock.mockResolvedValue(REJECTION)
+
+    const response = await deleteConversation(
+      new Request('http://localhost/api/messages/x/conversation', { method: 'DELETE' }),
+      { params: { id: messageId } },
+    )
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+
+  it('validates before dispatching and runs after-success only after the command', async () => {
+    allowGuard()
+
+    const response = await deleteConversation(
+      new Request('http://localhost/api/messages/x/conversation', { method: 'DELETE' }),
+      { params: { id: messageId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('messages.conversation.delete_for_actor', expect.anything())
+    expect(runMessageMutationGuardsMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'messages.conversation', resourceId: messageId, operation: 'delete' }),
+      expect.anything(),
+    )
+    expect(callOrder).toEqual(['guard:validate', 'command', 'guard:after'])
+  })
+})
+
+describe('messages action-execute route mutation guard wiring', () => {
+  it('blocks the command when the guard rejects', async () => {
+    runMessageMutationGuardsMock.mockResolvedValue(REJECTION)
+
+    const response = await executeAction(
+      new Request('http://localhost/api/messages/x/actions/y', { method: 'POST', body: JSON.stringify({}) }),
+      { params: { id: messageId, actionId } },
+    )
+
+    expect(response.status).toBe(423)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+
+  it('validates before dispatching and runs after-success only after the command', async () => {
+    allowGuard()
+
+    const response = await executeAction(
+      new Request('http://localhost/api/messages/x/actions/y', { method: 'POST', body: JSON.stringify({}) }),
+      { params: { id: messageId, actionId } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(commandBusExecuteMock).toHaveBeenCalledWith('messages.actions.execute', expect.anything())
+    expect(runMessageMutationGuardsMock).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({ resourceKind: 'messages.message', resourceId: messageId, operation: 'update' }),
+      expect.anything(),
+    )
+    expect(callOrder).toEqual(['guard:validate', 'command', 'guard:after'])
+  })
+})

--- a/packages/core/src/modules/messages/api/guards.ts
+++ b/packages/core/src/modules/messages/api/guards.ts
@@ -1,0 +1,59 @@
+import type { AwilixContainer } from 'awilix'
+import {
+  bridgeLegacyGuard,
+  runMutationGuards,
+  type MutationGuard,
+  type MutationGuardInput,
+} from '@open-mercato/shared/lib/crud/mutation-guard-registry'
+
+type GuardAfterCallback = {
+  guard: MutationGuard
+  metadata: Record<string, unknown> | null
+}
+
+export function resolveUserFeatures(auth: unknown): string[] {
+  const features = (auth as { features?: unknown })?.features
+  if (!Array.isArray(features)) return []
+  return features.filter((value): value is string => typeof value === 'string')
+}
+
+export async function runMessageMutationGuards(
+  container: AwilixContainer,
+  input: MutationGuardInput,
+  userFeatures: string[],
+): Promise<{
+  ok: boolean
+  errorBody?: Record<string, unknown>
+  errorStatus?: number
+  modifiedPayload?: Record<string, unknown>
+  afterSuccessCallbacks: GuardAfterCallback[]
+}> {
+  const legacyGuard = bridgeLegacyGuard(container)
+  if (!legacyGuard) {
+    return { ok: true, afterSuccessCallbacks: [] }
+  }
+
+  return runMutationGuards([legacyGuard], input, { userFeatures })
+}
+
+export async function runMessageMutationGuardAfterSuccess(
+  callbacks: GuardAfterCallback[],
+  input: {
+    tenantId: string
+    organizationId: string | null
+    userId: string
+    resourceKind: string
+    resourceId: string
+    operation: 'create' | 'update' | 'delete'
+    requestMethod: string
+    requestHeaders: Headers
+  },
+): Promise<void> {
+  for (const callback of callbacks) {
+    if (!callback.guard.afterSuccess) continue
+    await callback.guard.afterSuccess({
+      ...input,
+      metadata: callback.metadata ?? null,
+    })
+  }
+}

--- a/packages/core/src/modules/messages/api/route.ts
+++ b/packages/core/src/modules/messages/api/route.ts
@@ -13,6 +13,7 @@ import { getMessageType } from '../lib/message-types-registry'
 import { validateMessageObjectsForType } from '../lib/object-validation'
 import { attachOperationMetadataHeader } from '../lib/operationMetadata'
 import { canUseMessageEmailFeature, resolveMessageContext } from '../lib/routeHelpers'
+import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from './guards'
 import { findMessageIdsBySearchTokens } from '../lib/searchLookup'
 import { MessageCommandExecuteResult } from '../commands/shared'
 import {
@@ -351,6 +352,28 @@ export async function POST(req: Request) {
     }
   }
 
+  const guardResult = await runMessageMutationGuards(
+    ctx.container,
+    {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      userId: scope.userId,
+      resourceKind: 'messages.message',
+      resourceId: null,
+      operation: 'create',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input as Record<string, unknown>,
+    },
+    resolveUserFeatures(ctx.auth),
+  )
+  if (!guardResult.ok) {
+    return Response.json(
+      guardResult.errorBody ?? { error: 'Operation blocked by guard' },
+      { status: guardResult.errorStatus ?? 422 },
+    )
+  }
+
   const { result, logEntry } = await commandBus.execute('messages.messages.compose', {
     input: {
       ...input,
@@ -374,6 +397,16 @@ export async function POST(req: Request) {
   attachOperationMetadataHeader(response, logEntry, {
     resourceKind: 'messages.message',
     resourceId: messageId,
+  })
+  await runMessageMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    userId: scope.userId,
+    resourceKind: 'messages.message',
+    resourceId: messageId,
+    operation: 'create',
+    requestMethod: req.method,
+    requestHeaders: req.headers,
   })
   return response
 }


### PR DESCRIPTION
## Summary

Custom message write routes dispatched their commands directly without running the CRUD mutation-guard lifecycle that `packages/core/AGENTS.md` requires for non-`makeCrudRoute` `POST`/`PUT`/`PATCH`/`DELETE` routes. As a result, registered mutation guards (e.g. the enterprise record-lock guard) never ran on the messages write surface, unlike `integrations`/`staff`/`sales`. This wires a `messages/api/guards.ts` helper (faithful copy of the `integrations`/`staff` pattern, using the non-deprecated `runMutationGuards` registry + `bridgeLegacyGuard`) into every message write route: validation runs before command dispatch, the after-success hook runs only after a successful command, and a guard rejection returns the guard's status/body and blocks the command. Auth, feature metadata, operation-metadata headers, response shapes, and command-bus behavior are unchanged; when no guard service is registered the helper no-ops, so existing behavior is preserved.

## Changes

- Add `packages/core/src/modules/messages/api/guards.ts` (`runMessageMutationGuards`, `runMessageMutationGuardAfterSuccess`, `resolveUserFeatures`).
- Wire the guard lifecycle into all 15 command-dispatching message write handlers across 11 route files: compose; update_draft; delete_for_actor; recipient mark_read/mark_unread; archive/unarchive; action execute; attachment link/unlink; reply; forward; and the `conversation` delete_for_actor/archive_for_actor/mark_unread_for_actor routes.
- Operation mapping: create (compose/reply/forward), update (edits & recipient/conversation state & attachments), delete (delete_for_actor, conversation delete). `resourceKind` `messages.message` for message-level routes, `messages.conversation` for conversation routes.
- Add `packages/core/src/modules/messages/api/__tests__/mutation-guard-wiring.test.ts` (15 route tests).

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — bug fix bringing routes into compliance with the existing documented mutation-guard contract (`packages/core/AGENTS.md` → API Routes; `packages/shared/src/lib/crud/mutation-guard-registry.ts`). No contract change.

## Testing

- `yarn workspace @open-mercato/core test --testPathPatterns="mutation-guard-wiring"` → 15/15 passed (red → green; verified red on base by confirming the command ran despite a guard rejection and after-success never fired).
- `yarn workspace @open-mercato/core test` → 742 suites / 6081 tests passed (no regressions).
- `yarn typecheck` → pass (21 packages).
- `yarn i18n:check-sync` → all locales in sync.
- `TURBO_FORCE=1 yarn build:app` → pass.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — no new contract/locale/generator surface; behavior-preserving guard wiring.)
- [x] I added or adjusted tests that cover the change. (`mutation-guard-wiring.test.ts`, 15 tests.)
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required — the issue's Validation section asks for route-level tests, which are provided as jest route tests; no new UI/E2E surface and the guard path is unit-coverable.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — compliance fix against an existing contract.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-high`, inherited — touches the write-surface contract across a whole module.)
- [x] QA routing set: `needs-qa` (risk-high write-surface change; maintainer may downgrade to `skip-qa` given it is backend-only, no-UI, fully unit-covered, and no-ops when no guard service is registered).

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI in this change.
- [x] No arbitrary text sizes — N/A, no UI in this change.
- [x] Empty state handled for list/data pages — N/A, no UI in this change.
- [x] Loading state handled for async pages — N/A, no UI in this change.
- [x] `aria-label` on all icon-only buttons — N/A, no UI in this change.
- [x] Uses existing DS components — N/A, no UI in this change.

## Linked issues

Fixes #3259

🤖 Generated with [Claude Code](https://claude.com/claude-code)
