### PR TITLE
perf(currencies): parallelize independent provider fetches in rate fetching (#3193)

### DIFF
--- a/packages/core/src/modules/currencies/services/__tests__/rateFetchingService.concurrency.test.ts
+++ b/packages/core/src/modules/currencies/services/__tests__/rateFetchingService.concurrency.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals'
+import { RateFetchingService } from '../rateFetchingService'
+import type { RateProvider } from '../providers/base'
+import {
+  createMockEntityManager,
+  createMockProvider,
+  createTestCurrency,
+  createTestRate,
+  TEST_SCOPE,
+  TEST_DATE,
+} from './rateFetchingService.setup'
+
+describe('RateFetchingService - Concurrent provider fetching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('dispatches all provider fetches concurrently instead of in a sequential waterfall', async () => {
+    const currencies = [
+      createTestCurrency({ code: 'USD' }),
+      createTestCurrency({ code: 'EUR' }),
+    ]
+    const { em } = createMockEntityManager({ currencies })
+    const service = new RateFetchingService(em)
+
+    let releaseSlow: (() => void) | undefined
+    const slowGate = new Promise<void>((resolve) => {
+      releaseSlow = resolve
+    })
+
+    let slowStarted = false
+    let fastStartedWhileSlowPending = false
+
+    // SLOW blocks on a gate so the fetch stays in flight; sequential code would
+    // never reach FAST while SLOW is pending, so FAST.fetchRates would not be called.
+    const slowProvider: RateProvider = {
+      source: 'SLOW',
+      name: 'SLOW',
+      isAvailable: () => true,
+      fetchRates: jest.fn(async () => {
+        slowStarted = true
+        await slowGate
+        return [createTestRate({ fromCurrencyCode: 'USD', toCurrencyCode: 'EUR', source: 'SLOW' })]
+      }),
+    }
+
+    const fastProvider: RateProvider = {
+      source: 'FAST',
+      name: 'FAST',
+      isAvailable: () => true,
+      fetchRates: jest.fn(async () => {
+        if (slowStarted) fastStartedWhileSlowPending = true
+        return [createTestRate({ fromCurrencyCode: 'EUR', toCurrencyCode: 'USD', source: 'FAST' })]
+      }),
+    }
+
+    service.registerProvider(slowProvider)
+    service.registerProvider(fastProvider)
+
+    const pending = service.fetchRatesForDate(TEST_DATE, TEST_SCOPE)
+
+    try {
+      // Let queued microtasks/timers run while SLOW is still gated.
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      expect(slowProvider.fetchRates).toHaveBeenCalled()
+      expect(fastProvider.fetchRates).toHaveBeenCalled()
+      expect(fastStartedWhileSlowPending).toBe(true)
+    } finally {
+      releaseSlow?.()
+    }
+
+    const result = await pending
+    expect(result.totalFetched).toBe(2)
+    expect(result.byProvider['SLOW']).toEqual({ count: 1 })
+    expect(result.byProvider['FAST']).toEqual({ count: 1 })
+    expect(result.errors).toEqual([])
+  })
+
+  it('isolates a provider failure while still persisting the successful provider', async () => {
+    const currencies = [
+      createTestCurrency({ code: 'USD' }),
+      createTestCurrency({ code: 'EUR' }),
+    ]
+    const { em } = createMockEntityManager({ currencies })
+    const service = new RateFetchingService(em)
+
+    const failingProvider = createMockProvider({
+      source: 'FAILING',
+      error: new Error('Network timeout'),
+    })
+    const successProvider = createMockProvider({
+      source: 'SUCCESS',
+      rates: [createTestRate({ fromCurrencyCode: 'USD', toCurrencyCode: 'EUR', source: 'SUCCESS' })],
+    })
+
+    service.registerProvider(failingProvider)
+    service.registerProvider(successProvider)
+
+    const result = await service.fetchRatesForDate(TEST_DATE, TEST_SCOPE)
+
+    expect(failingProvider.fetchRates).toHaveBeenCalled()
+    expect(successProvider.fetchRates).toHaveBeenCalled()
+    expect(result.totalFetched).toBe(1)
+    expect(result.byProvider['SUCCESS']).toEqual({ count: 1 })
+    expect(result.byProvider['FAILING']).toEqual({ count: 0, errors: ['Network timeout'] })
+    expect(result.errors).toContain('FAILING: Network timeout')
+  })
+
+  it('persists provider results in stable provider order regardless of fetch completion order', async () => {
+    const currencies = [
+      createTestCurrency({ code: 'USD' }),
+      createTestCurrency({ code: 'EUR' }),
+    ]
+    const { em } = createMockEntityManager({ currencies })
+    const service = new RateFetchingService(em)
+
+    // ALPHA resolves AFTER BETA, but must still appear first in byProvider.
+    const alphaProvider: RateProvider = {
+      source: 'ALPHA',
+      name: 'ALPHA',
+      isAvailable: () => true,
+      fetchRates: jest.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        return [createTestRate({ fromCurrencyCode: 'USD', toCurrencyCode: 'EUR', source: 'ALPHA' })]
+      }),
+    }
+    const betaProvider: RateProvider = {
+      source: 'BETA',
+      name: 'BETA',
+      isAvailable: () => true,
+      fetchRates: jest.fn(async () =>
+        [createTestRate({ fromCurrencyCode: 'EUR', toCurrencyCode: 'USD', source: 'BETA' })]
+      ),
+    }
+
+    service.registerProvider(alphaProvider)
+    service.registerProvider(betaProvider)
+
+    const result = await service.fetchRatesForDate(TEST_DATE, TEST_SCOPE)
+
+    expect(Object.keys(result.byProvider)).toEqual(['ALPHA', 'BETA'])
+    expect(result.totalFetched).toBe(2)
+  })
+})

--- a/packages/core/src/modules/currencies/services/rateFetchingService.ts
+++ b/packages/core/src/modules/currencies/services/rateFetchingService.ts
@@ -13,6 +13,11 @@ export interface FetchOptions {
   forceUpdate?: boolean
 }
 
+type ProviderFetchOutcome =
+  | { kind: 'skipped'; providerSource: string; error: string }
+  | { kind: 'failed'; providerSource: string; error: string }
+  | { kind: 'fetched'; providerSource: string; rates: RateProviderResult[] }
+
 const exchangeRateKey = (
   fromCurrencyCode: string,
   toCurrencyCode: string,
@@ -54,44 +59,76 @@ export class RateFetchingService {
       ? options.providers
       : Array.from(this.providers.keys())
 
-    for (const providerSource of providerList) {
-      const provider = this.providers.get(providerSource)
+    // Fetch every provider concurrently: provider calls are independent network I/O,
+    // so overlapping them caps total latency at the slowest provider instead of the sum
+    // of all provider timeouts. Each provider is isolated in its own try/catch so a
+    // single failure never rejects the batch.
+    const outcomes = await Promise.all(
+      providerList.map((providerSource) =>
+        this.fetchFromProvider(providerSource, date, scope, currencyCodeSet)
+      )
+    )
 
-      if (!provider) {
-        result.errors.push(`Unknown provider: ${providerSource}`)
+    // Persist sequentially in provider order: a single EntityManager is not safe for
+    // concurrent transactions, and stable ordering keeps DB writes and the byProvider
+    // response shape deterministic regardless of which fetch resolved first.
+    for (const outcome of outcomes) {
+      if (outcome.kind === 'skipped') {
+        result.errors.push(outcome.error)
         continue
       }
 
-      if (!provider.isAvailable()) {
-        result.errors.push(`Provider not available: ${providerSource}`)
+      if (outcome.kind === 'failed') {
+        result.errors.push(`${outcome.providerSource}: ${outcome.error}`)
+        result.byProvider[outcome.providerSource] = { count: 0, errors: [outcome.error] }
         continue
       }
 
       try {
-        const rates = await provider.fetchRates(date, scope, currencyCodeSet)
-
-        // Filter: only currencies that exist in both directions
-        const validRates = rates.filter(
-          (r) =>
-            currencyCodeSet.has(r.fromCurrencyCode) &&
-            currencyCodeSet.has(r.toCurrencyCode)
-        )
-
-        const stored = await this.storeRates(validRates, scope)
-
-        result.byProvider[providerSource] = { count: stored }
+        const stored = await this.storeRates(outcome.rates, scope)
+        result.byProvider[outcome.providerSource] = { count: stored }
         result.totalFetched += stored
-      } catch (err: any) {
-        const errorMsg = `${providerSource}: ${err.message}`
-        result.errors.push(errorMsg)
-        result.byProvider[providerSource] = {
-          count: 0,
-          errors: [err.message],
-        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        result.errors.push(`${outcome.providerSource}: ${message}`)
+        result.byProvider[outcome.providerSource] = { count: 0, errors: [message] }
       }
     }
 
     return result
+  }
+
+  private async fetchFromProvider(
+    providerSource: string,
+    date: Date,
+    scope: { tenantId: string; organizationId: string },
+    currencyCodeSet: Set<string>
+  ): Promise<ProviderFetchOutcome> {
+    const provider = this.providers.get(providerSource)
+
+    if (!provider) {
+      return { kind: 'skipped', providerSource, error: `Unknown provider: ${providerSource}` }
+    }
+
+    if (!provider.isAvailable()) {
+      return { kind: 'skipped', providerSource, error: `Provider not available: ${providerSource}` }
+    }
+
+    try {
+      const rates = await provider.fetchRates(date, scope, currencyCodeSet)
+
+      // Filter: only currencies that exist in both directions
+      const validRates = rates.filter(
+        (r) =>
+          currencyCodeSet.has(r.fromCurrencyCode) &&
+          currencyCodeSet.has(r.toCurrencyCode)
+      )
+
+      return { kind: 'fetched', providerSource, rates: validRates }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return { kind: 'failed', providerSource, error: message }
+    }
   }
 
   private async getExistingCurrencies(scope: {


### PR DESCRIPTION
## Summary

`RateFetchingService.fetchRatesForDate` fetched each configured external rate provider sequentially. Provider calls are independent network I/O, each with a 15s default timeout, so the user-triggered `POST /api/currencies/fetch-rates` path waited for the **sum** of provider latency/timeouts instead of the slowest provider. This parallelizes the independent provider fetches while keeping DB writes deterministic and safe.

## Changes

- `packages/core/src/modules/currencies/services/rateFetchingService.ts`: fetch all providers concurrently with `Promise.all` (each provider isolated in a new private `fetchFromProvider` helper that returns a typed `ProviderFetchOutcome`, so a single provider failure never rejects the batch), then persist results sequentially in provider order. The single `EntityManager` is never used for concurrent transactions, and `byProvider` key order / `errors[]` order stay deterministic regardless of which fetch resolves first. Per-provider error isolation, the `storeRates` transaction-error handling, and the `FetchResult` response shape are unchanged.
- `packages/core/src/modules/currencies/services/__tests__/rateFetchingService.concurrency.test.ts` (new): focused service tests — concurrent dispatch (red→green reproduction), partial provider failure preserving `byProvider` counts/errors, and stable provider-order persistence regardless of fetch completion order.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — internal performance refactor with no contract/behavior change; covered by focused service unit tests.

## Testing

- `yarn workspace @open-mercato/core test -- --testPathPattern 'rateFetchingService'` — 5 suites / 40 tests pass (new concurrency suite goes red on the pre-fix sequential code, green after).
- `yarn workspace @open-mercato/core test -- --testPathPattern 'modules/currencies/.*(test)\.(ts|tsx)$'` — 17 suites / 105 tests pass.
- `yarn turbo run typecheck --filter=@open-mercato/core` — pass.
- `yarn turbo run build --filter=@open-mercato/core` — pass.
- `yarn i18n:check-sync` — all locales in sync (no new strings introduced).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — no user-facing strings, generators, or docs affected.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — N/A: the issue requested focused *service* tests (added); this is an internal orchestration refactor with no change to API behavior or response shape, so no new Playwright coverage is required.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — minor refactor.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium`, inherited from the issue — single-module change, no contract/schema surface touched.)
- [x] QA routing set: `skip-qa` — backend-only internal refactor, externally observable behavior and `FetchResult` response shape are identical and fully unit-covered; no customer-facing behavior to exercise manually. (A reviewer may escalate to `needs-qa` if they want the `fetch-rates` flow exercised live.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #3193

🤖 Generated with [Claude Code](https://claude.com/claude-code)
