### PR TITLE
fix: enforce optimistic locking on currency fetch-config updates (#3190)

### DIFF
--- a/packages/core/src/modules/currencies/api/fetch-configs/__tests__/optimistic-lock.test.ts
+++ b/packages/core/src/modules/currencies/api/fetch-configs/__tests__/optimistic-lock.test.ts
@@ -1,0 +1,144 @@
+/** @jest-environment node */
+// Regression coverage for #3190: the custom PUT/DELETE /api/currencies/fetch-configs
+// route never enforced the optimistic-lock header the UI sends, so a stale provider
+// edit silently overwrote a concurrent change. The route must load the current
+// config, compare its updated_at against the client's expected version, and return
+// the standard structured 409 conflict body (no-op when the header is absent).
+
+import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+
+const TENANT_ID = '123e4567-e89b-12d3-a456-426614174001'
+const ORG_ID = '123e4567-e89b-12d3-a456-426614174002'
+const CONFIG_ID = '123e4567-e89b-12d3-a456-426614174050'
+const CURRENT_VERSION = '2026-06-01T10:00:00.000Z'
+const STALE_VERSION = '2026-06-01T09:00:00.000Z'
+
+const configRecord = {
+  id: CONFIG_ID,
+  provider: 'ecb',
+  organizationId: ORG_ID,
+  tenantId: TENANT_ID,
+  isEnabled: true,
+  updatedAt: new Date(CURRENT_VERSION),
+}
+
+const mockEm = {
+  findOne: jest.fn(async () => configRecord),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => (token === 'em' ? mockEm : null)),
+  dispose: jest.fn(async () => undefined),
+}
+
+const mockGetAuthFromRequest = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/core/modules/currencies/data/entities', () => ({
+  CurrencyFetchConfig: class CurrencyFetchConfig {},
+}))
+
+jest.mock('@open-mercato/core/modules/currencies/commands/fetch-configs', () => ({
+  createFetchConfig: jest.fn(),
+  updateFetchConfig: jest.fn(async () => configRecord),
+  deleteFetchConfig: jest.fn(async () => undefined),
+}))
+
+import { PUT, DELETE } from '@open-mercato/core/modules/currencies/api/fetch-configs/route'
+import {
+  updateFetchConfig,
+  deleteFetchConfig,
+} from '@open-mercato/core/modules/currencies/commands/fetch-configs'
+
+function putRequest(headerVersion: string | null, body: unknown) {
+  const headers: Record<string, string> = { 'content-type': 'application/json' }
+  if (headerVersion) headers[OPTIMISTIC_LOCK_HEADER_NAME] = headerVersion
+  return new Request('http://localhost/api/currencies/fetch-configs', {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+function deleteRequest(headerVersion: string | null) {
+  const headers: Record<string, string> = {}
+  if (headerVersion) headers[OPTIMISTIC_LOCK_HEADER_NAME] = headerVersion
+  return new Request(`http://localhost/api/currencies/fetch-configs?id=${CONFIG_ID}`, {
+    method: 'DELETE',
+    headers,
+  })
+}
+
+describe('currencies fetch-configs optimistic locking', () => {
+  const originalEnv = process.env.OM_OPTIMISTIC_LOCK
+
+  beforeAll(() => {
+    process.env.OM_OPTIMISTIC_LOCK = 'all'
+  })
+
+  afterAll(() => {
+    if (originalEnv === undefined) delete process.env.OM_OPTIMISTIC_LOCK
+    else process.env.OM_OPTIMISTIC_LOCK = originalEnv
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: TENANT_ID, orgId: ORG_ID })
+    mockEm.findOne.mockResolvedValue(configRecord)
+  })
+
+  describe('PUT', () => {
+    it('returns 409 with the structured conflict body when the expected version is stale', async () => {
+      const res = await PUT(putRequest(STALE_VERSION, { id: CONFIG_ID, isEnabled: false }) as never)
+      expect(res.status).toBe(409)
+      const body = await res.json()
+      expect(body.code).toBe('optimistic_lock_conflict')
+      expect(body.currentUpdatedAt).toBe(CURRENT_VERSION)
+      expect(body.expectedUpdatedAt).toBe(STALE_VERSION)
+      expect(updateFetchConfig).not.toHaveBeenCalled()
+    })
+
+    it('updates when the expected version matches', async () => {
+      const res = await PUT(putRequest(CURRENT_VERSION, { id: CONFIG_ID, isEnabled: false }) as never)
+      expect(res.status).toBe(200)
+      expect(updateFetchConfig).toHaveBeenCalledTimes(1)
+    })
+
+    it('is a no-op (no 409) when the client sends no expected-version header', async () => {
+      const res = await PUT(putRequest(null, { id: CONFIG_ID, isEnabled: false }) as never)
+      expect(res.status).toBe(200)
+      expect(updateFetchConfig).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('DELETE', () => {
+    it('returns 409 with the structured conflict body when the expected version is stale', async () => {
+      const res = await DELETE(deleteRequest(STALE_VERSION) as never)
+      expect(res.status).toBe(409)
+      const body = await res.json()
+      expect(body.code).toBe('optimistic_lock_conflict')
+      expect(body.currentUpdatedAt).toBe(CURRENT_VERSION)
+      expect(body.expectedUpdatedAt).toBe(STALE_VERSION)
+      expect(deleteFetchConfig).not.toHaveBeenCalled()
+    })
+
+    it('deletes when the expected version matches', async () => {
+      const res = await DELETE(deleteRequest(CURRENT_VERSION) as never)
+      expect(res.status).toBe(200)
+      expect(deleteFetchConfig).toHaveBeenCalledTimes(1)
+    })
+
+    it('is a no-op (no 409) when the client sends no expected-version header', async () => {
+      const res = await DELETE(deleteRequest(null) as never)
+      expect(res.status).toBe(200)
+      expect(deleteFetchConfig).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/core/src/modules/currencies/api/fetch-configs/route.ts
+++ b/packages/core/src/modules/currencies/api/fetch-configs/route.ts
@@ -4,6 +4,8 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { CurrencyFetchConfig } from '../../data/entities'
 import {
   createFetchConfig,
@@ -107,6 +109,20 @@ export async function PUT(req: NextRequest) {
       return NextResponse.json({ error: 'ID required' }, { status: 400 })
     }
 
+    const existing = await em.findOne(CurrencyFetchConfig, {
+      id,
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+    })
+    if (existing) {
+      enforceCommandOptimisticLock({
+        resourceKind: 'currencies.currency_fetch_config',
+        resourceId: existing.id,
+        current: existing.updatedAt ?? null,
+        request: req,
+      })
+    }
+
     const config = await updateFetchConfig(em, id, data, {
       tenantId: auth.tenantId,
       organizationId: auth.orgId,
@@ -115,6 +131,9 @@ export async function PUT(req: NextRequest) {
 
     return NextResponse.json({ config })
   } catch (err: any) {
+    if (isCrudHttpError(err)) {
+      return NextResponse.json(err.body, { status: err.status })
+    }
     return NextResponse.json({ error: err.message }, { status: 400 })
   } finally {
     await (container as any).dispose?.()
@@ -138,6 +157,20 @@ export async function DELETE(req: NextRequest) {
       return NextResponse.json({ error: 'ID required' }, { status: 400 })
     }
 
+    const existing = await em.findOne(CurrencyFetchConfig, {
+      id,
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+    })
+    if (existing) {
+      enforceCommandOptimisticLock({
+        resourceKind: 'currencies.currency_fetch_config',
+        resourceId: existing.id,
+        current: existing.updatedAt ?? null,
+        request: req,
+      })
+    }
+
     await deleteFetchConfig(em, id, {
       tenantId: auth.tenantId,
       organizationId: auth.orgId,
@@ -146,6 +179,9 @@ export async function DELETE(req: NextRequest) {
 
     return NextResponse.json({ success: true })
   } catch (err: any) {
+    if (isCrudHttpError(err)) {
+      return NextResponse.json(err.body, { status: err.status })
+    }
     return NextResponse.json({ error: err.message }, { status: 400 })
   } finally {
     await (container as any).dispose?.()


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The custom `PUT`/`DELETE /api/currencies/fetch-configs` route is a Command-pattern write (not `makeCrudRoute`), so it never honored the `x-om-ext-optimistic-lock-expected-updated-at` header the `CurrencyFetchingConfig` UI already sends. Two admins editing the same provider config would have the later write silently win, and the handler's catch-all collapsed any error to `400`. This change enforces the optimistic-lock check in the route (mirroring the `business_rules`/`feature_toggles` command-lock idiom) and returns the standard structured `409` conflict body so the unified conflict bar fires.

## Changes

- `packages/core/src/modules/currencies/api/fetch-configs/route.ts`: in `PUT` and `DELETE`, load the tenant/org-scoped `CurrencyFetchConfig` and call `enforceCommandOptimisticLock({ resourceKind: 'currencies.currency_fetch_config', current: existing.updatedAt, request: req })` before dispatching the mutating command; pass `CrudHttpError` through via `isCrudHttpError(err)` so the structured `409` is not flattened to `400`.
- `packages/core/src/modules/currencies/api/fetch-configs/__tests__/optimistic-lock.test.ts`: new route-level coverage for stale (→ 409 + structured body), matching (→ 200), and no-header (→ no-op) on both verbs.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
Covered by the existing optimistic-locking specs — `.ai/specs/implemented/2026-05-25-oss-optimistic-locking.md` (§ command-level checks) and `.ai/specs/2026-05-28-optimistic-locking-coverage-completion.md` (Phase 4). This is a coverage-gap fix for one command-pattern route, not a new spec.

## Testing

- `yarn workspace @open-mercato/core test src/modules/currencies/api/fetch-configs/__tests__/optimistic-lock.test.ts` → 6/6 pass (2 RED before the fix)
- `yarn workspace @open-mercato/core test` → 742 suites / 6072 tests pass
- `yarn build:packages` → `yarn generate` → core rebuild → `yarn typecheck` (all 21 packages) → pass
- `yarn i18n:check-sync` → all locales in sync
- `yarn build:app` → builds successfully

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No new user-facing strings or generated registries — conflict body comes from the shared helper.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Documented: this command-lock route is covered with route-level unit tests, matching the established pattern for `business_rules`/`workflows`/`feature_toggles` `optimistic-lock.test.ts`; the existing currencies Playwright lock specs cover the `makeCrudRoute` surfaces.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — coverage-gap fix under existing optimistic-locking specs.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — ordinary single-module bug fix shipped with tests, strictly additive.)
- [x] QA routing set: `needs-qa` — alters customer-facing conflict behavior in the currency fetch-config admin flow (a stale save now surfaces the conflict bar). An engineer may self-QA by opening the fetch-config in two tabs, saving one, then saving the stale tab and confirming the conflict bar appears.

### Design System Compliance
_N/A — backend-only change, no UI files touched._
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #3190
