### PR TITLE
fix(messages): wrap detail-page writes in useGuardedMutation (#3258)

### DIFF
--- a/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetailsActions.test.tsx
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetailsActions.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react'
+import type { UseQueryResult } from '@tanstack/react-query'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
+import { useMessageDetailsActions } from '../useMessageDetailsActions'
+import type { MessageAction, MessageDetail } from '../../types'
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+const mockRunMutation = jest.fn()
+const mockRetryLastMutation = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: jest.fn(() => ({
+    runMutation: mockRunMutation,
+    retryLastMutation: mockRetryLastMutation,
+  })),
+}))
+
+const mockApiCall = apiCall as jest.MockedFunction<typeof apiCall>
+const mockFlash = flash as jest.MockedFunction<typeof flash>
+const mockUseGuardedMutation = useGuardedMutation as jest.MockedFunction<typeof useGuardedMutation>
+
+const translate = ((key: string, fallback?: string) => fallback ?? key) as never
+
+function okResult<T>(result: T) {
+  return { ok: true, status: 200, result, response: {} as Response, cacheStatus: null }
+}
+
+function setup(detailOverrides: Partial<MessageDetail> = {}) {
+  const refetch = jest.fn().mockResolvedValue(null)
+  const refreshDetailWithoutAutoMarkRead = jest.fn().mockResolvedValue(null)
+  const onDeleted = jest.fn()
+  const detailQuery = { refetch } as unknown as UseQueryResult<MessageDetail | null, Error>
+  const detail = {
+    id: 'message-1',
+    isRead: false,
+    actionTaken: null,
+    ...detailOverrides,
+  } as MessageDetail
+
+  const view = renderHook(() => useMessageDetailsActions({
+    id: 'message-1',
+    t: translate,
+    detail,
+    detailQuery,
+    attachments: [],
+    isArchived: false,
+    onDeleted,
+    refreshDetailWithoutAutoMarkRead,
+  }))
+
+  return { ...view, refetch, refreshDetailWithoutAutoMarkRead, onDeleted }
+}
+
+describe('useMessageDetailsActions guarded writes (#3258)', () => {
+  beforeEach(() => {
+    mockApiCall.mockReset()
+    mockFlash.mockReset()
+    mockRunMutation.mockReset()
+    mockRetryLastMutation.mockReset()
+    mockUseGuardedMutation.mockClear()
+    // Pass-through guard so the wrapped operation still runs and we can assert
+    // the underlying apiCall/refetch/success behavior is preserved.
+    mockRunMutation.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+    mockApiCall.mockResolvedValue(okResult({ ok: true }))
+  })
+
+  it('routes message read toggle through runMutation and refetches', async () => {
+    const { result, refetch } = setup({ isRead: false })
+
+    await act(async () => {
+      await result.current.toggleRead()
+    })
+
+    expect(mockRunMutation).toHaveBeenCalledTimes(1)
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({
+        resourceKind: 'message',
+        messageId: 'message-1',
+        retryLastMutation: mockRetryLastMutation,
+      }),
+    }))
+    expect(mockApiCall).toHaveBeenCalledWith('/api/messages/message-1/read', { method: 'PUT' })
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes message archive toggle through runMutation', async () => {
+    const { result } = setup()
+
+    await act(async () => {
+      await result.current.toggleArchive()
+    })
+
+    expect(mockRunMutation).toHaveBeenCalledTimes(1)
+    expect(mockApiCall).toHaveBeenCalledWith('/api/messages/message-1/archive', { method: 'PUT' })
+  })
+
+  it('routes message delete through runMutation and preserves success navigation', async () => {
+    const { result, onDeleted } = setup()
+
+    await act(async () => {
+      await result.current.handleDelete()
+    })
+
+    expect(mockRunMutation).toHaveBeenCalledTimes(1)
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({ resourceKind: 'message', action: 'delete' }),
+    }))
+    expect(mockApiCall).toHaveBeenCalledWith('/api/messages/message-1', { method: 'DELETE' })
+    expect(onDeleted).toHaveBeenCalledTimes(1)
+    expect(mockFlash).toHaveBeenCalledWith('Message deleted.', 'success')
+  })
+
+  it('routes conversation archive through runMutation with a conversation resource kind', async () => {
+    const { result } = setup()
+
+    await act(async () => {
+      await result.current.archiveConversation()
+    })
+
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({ resourceKind: 'conversation', action: 'archiveConversation' }),
+    }))
+    expect(mockApiCall).toHaveBeenCalledWith('/api/messages/message-1/conversation/archive', { method: 'PUT' })
+  })
+
+  it('routes conversation delete through runMutation and preserves navigation', async () => {
+    const { result, onDeleted } = setup()
+
+    await act(async () => {
+      await result.current.deleteConversation()
+    })
+
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({ resourceKind: 'conversation', action: 'deleteConversation' }),
+    }))
+    expect(mockApiCall).toHaveBeenCalledWith('/api/messages/message-1/conversation', { method: 'DELETE' })
+    expect(onDeleted).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes message action execution through runMutation and refetches', async () => {
+    mockApiCall.mockResolvedValue(okResult({ ok: true, result: {} }))
+    const { result, refetch } = setup()
+    const action: MessageAction = { id: 'approve', label: 'Approve' }
+
+    await act(async () => {
+      await result.current.handleExecuteAction(action)
+    })
+
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({ resourceKind: 'message', action: 'execute-action' }),
+    }))
+    expect(mockApiCall).toHaveBeenCalledWith(
+      '/api/messages/message-1/actions/approve',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces failures through the guarded path (conflict / error)', async () => {
+    mockApiCall.mockResolvedValue({
+      ok: false,
+      status: 409,
+      result: {
+        code: 'optimistic_lock_conflict',
+        error: 'record_modified',
+        currentUpdatedAt: '2026-06-19T00:00:00.000Z',
+        expectedUpdatedAt: '2026-06-18T00:00:00.000Z',
+      },
+      response: {} as Response,
+      cacheStatus: null,
+    })
+
+    const { result, onDeleted } = setup()
+
+    await act(async () => {
+      await result.current.handleDelete()
+    })
+
+    // The mutation still flows through the guard (which owns conflict
+    // surfacing), and the failure is reported via flash rather than navigation.
+    expect(mockRunMutation).toHaveBeenCalledTimes(1)
+    expect(onDeleted).not.toHaveBeenCalled()
+    expect(mockFlash).toHaveBeenCalledWith(expect.any(String), 'error')
+  })
+})

--- a/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsActions.ts
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsActions.ts
@@ -5,6 +5,7 @@ import type { UseQueryResult } from '@tanstack/react-query'
 import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
 import type { MessageActionsProps, MessageContentProps } from '@open-mercato/shared/modules/messages/types'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import type {
   ActionResult,
@@ -20,6 +21,13 @@ type RequestAndRefreshOptions = {
 }
 
 type ConversationActionKind = 'archiveConversation' | 'deleteConversation' | 'markAllUnread'
+
+type MessageDetailMutationContext = {
+  resourceKind: 'message' | 'conversation'
+  messageId: string
+  action: string
+  retryLastMutation: () => Promise<boolean>
+}
 
 type UseMessageDetailsActionsInput = {
   id: string
@@ -51,6 +59,10 @@ export function useMessageDetailsActions({
   const [deleteConfirmationOpen, setDeleteConfirmationOpen] = React.useState(false)
   const [activeConversationAction, setActiveConversationAction] = React.useState<ConversationActionKind | null>(null)
 
+  const { runMutation, retryLastMutation } = useGuardedMutation<MessageDetailMutationContext>({
+    contextId: 'messages-detail-actions',
+  })
+
   const requestAndRefresh = React.useCallback(async (
     url: string,
     method: 'PUT' | 'DELETE',
@@ -58,18 +70,24 @@ export function useMessageDetailsActions({
   ) => {
     setUpdatingState(true)
     try {
-      const call = await apiCall<{ ok?: boolean }>(url, { method })
-      if (!call.ok) {
-        throw new Error(
-          toErrorMessage(call.result)
-          ?? t('messages.errors.stateChangeFailed', 'Failed to update message state.'),
-        )
-      }
-      if (options?.skipDetailAutoMarkRead) {
-        await refreshDetailWithoutAutoMarkRead()
-      } else {
-        await detailQuery.refetch()
-      }
+      await runMutation({
+        operation: async () => {
+          const call = await apiCall<{ ok?: boolean }>(url, { method })
+          if (!call.ok) {
+            throw new Error(
+              toErrorMessage(call.result)
+              ?? t('messages.errors.stateChangeFailed', 'Failed to update message state.'),
+            )
+          }
+          if (options?.skipDetailAutoMarkRead) {
+            await refreshDetailWithoutAutoMarkRead()
+          } else {
+            await detailQuery.refetch()
+          }
+        },
+        context: { resourceKind: 'message', messageId: id, action: 'state-change', retryLastMutation },
+        mutationPayload: { messageId: id, action: 'state-change', url, method },
+      })
     } catch (err) {
       flash(
         err instanceof Error
@@ -80,17 +98,23 @@ export function useMessageDetailsActions({
     } finally {
       setUpdatingState(false)
     }
-  }, [detailQuery, refreshDetailWithoutAutoMarkRead, t])
+  }, [detailQuery, id, refreshDetailWithoutAutoMarkRead, retryLastMutation, runMutation, t])
 
   const handleDelete = React.useCallback(async () => {
     setUpdatingState(true)
     try {
-      const call = await apiCall<{ ok?: boolean }>(`/api/messages/${encodeURIComponent(id)}`, {
-        method: 'DELETE',
+      await runMutation({
+        operation: async () => {
+          const call = await apiCall<{ ok?: boolean }>(`/api/messages/${encodeURIComponent(id)}`, {
+            method: 'DELETE',
+          })
+          if (!call.ok) {
+            throw new Error(toErrorMessage(call.result) ?? t('messages.errors.deleteFailed', 'Failed to delete message.'))
+          }
+        },
+        context: { resourceKind: 'message', messageId: id, action: 'delete', retryLastMutation },
+        mutationPayload: { messageId: id, action: 'delete' },
       })
-      if (!call.ok) {
-        throw new Error(toErrorMessage(call.result) ?? t('messages.errors.deleteFailed', 'Failed to delete message.'))
-      }
       flash(t('messages.flash.deleted', 'Message deleted.'), 'success')
       onDeleted()
     } catch (err) {
@@ -103,7 +127,7 @@ export function useMessageDetailsActions({
     } finally {
       setUpdatingState(false)
     }
-  }, [id, onDeleted, t])
+  }, [id, onDeleted, retryLastMutation, runMutation, t])
 
   const runConversationAction = React.useCallback(async (
     action: ConversationActionKind,
@@ -117,13 +141,19 @@ export function useMessageDetailsActions({
   ) => {
     setActiveConversationAction(action)
     try {
-      const call = await apiCall<{ ok?: boolean; affectedCount?: number }>(options.url, { method: options.method })
-      if (!call.ok) {
-        throw new Error(
-          toErrorMessage(call.result)
-          ?? t('messages.errors.conversationActionFailed', 'Failed to update conversation.'),
-        )
-      }
+      await runMutation({
+        operation: async () => {
+          const call = await apiCall<{ ok?: boolean; affectedCount?: number }>(options.url, { method: options.method })
+          if (!call.ok) {
+            throw new Error(
+              toErrorMessage(call.result)
+              ?? t('messages.errors.conversationActionFailed', 'Failed to update conversation.'),
+            )
+          }
+        },
+        context: { resourceKind: 'conversation', messageId: id, action, retryLastMutation },
+        mutationPayload: { messageId: id, action, url: options.url, method: options.method },
+      })
 
       flash(options.successMessage, 'success')
 
@@ -147,7 +177,7 @@ export function useMessageDetailsActions({
     } finally {
       setActiveConversationAction(null)
     }
-  }, [detailQuery, refreshDetailWithoutAutoMarkRead, t])
+  }, [detailQuery, id, refreshDetailWithoutAutoMarkRead, retryLastMutation, runMutation, t])
 
   const archiveConversation = React.useCallback(async (messageId?: string) => {
     const targetMessageId = messageId ?? id
@@ -194,21 +224,29 @@ export function useMessageDetailsActions({
   const executeAction = React.useCallback(async (action: MessageAction, payload?: Record<string, unknown>) => {
     setExecutingActionId(action.id)
     try {
-      const call = await apiCall<ActionResult>(
-        `/api/messages/${encodeURIComponent(id)}/actions/${encodeURIComponent(action.id)}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload ?? {}),
-        },
-      )
+      const call = await runMutation({
+        operation: async () => {
+          const result = await apiCall<ActionResult>(
+            `/api/messages/${encodeURIComponent(id)}/actions/${encodeURIComponent(action.id)}`,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload ?? {}),
+            },
+          )
 
-      if (!call.ok) {
-        throw new Error(
-          toErrorMessage(call.result)
-          ?? t('messages.errors.actionFailed', 'Failed to execute action.'),
-        )
-      }
+          if (!result.ok) {
+            throw new Error(
+              toErrorMessage(result.result)
+              ?? t('messages.errors.actionFailed', 'Failed to execute action.'),
+            )
+          }
+
+          return result
+        },
+        context: { resourceKind: 'message', messageId: id, action: 'execute-action', retryLastMutation },
+        mutationPayload: { messageId: id, action: 'execute-action', actionId: action.id },
+      })
 
       flash(t('messages.flash.actionSuccess', 'Action completed.'), 'success')
 
@@ -233,7 +271,7 @@ export function useMessageDetailsActions({
     } finally {
       setExecutingActionId(null)
     }
-  }, [detailQuery, id, t])
+  }, [detailQuery, id, retryLastMutation, runMutation, t])
 
   const handleExecuteAction = React.useCallback(async (action: MessageAction, payload?: Record<string, unknown>) => {
     if (executingActionId || detail?.actionTaken) return


### PR DESCRIPTION
## Summary

The message detail page issued all of its durable write operations through raw `apiCall`, bypassing the global mutation-injection pipeline. As a result record-lock header attachment, the unified conflict UI, and `onBeforeSave`/`onAfterSave` guards did not run on these user-facing actions. This routes every detail-page write through `useGuardedMutation(...).runMutation(...)`, matching the pattern the module already uses for bulk inbox actions.

## Changes

- `packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsActions.ts`: import `useGuardedMutation`, add a typed `MessageDetailMutationContext`, and wrap all four write surfaces — state toggle (`requestAndRefresh` → read/archive PUT/DELETE), message delete (`handleDelete`), conversation archive/delete/mark-unread (`runConversationAction`), and message action execution (`executeAction`) — in `runMutation({ operation, context, mutationPayload })`. Each context carries `resourceKind`, `messageId`, `action`, and `retryLastMutation`. The existing `apiCall`, `!ok` throw, flash messaging, refetch/refresh selection, delete navigation, and action redirect behavior are preserved unchanged; `useCallback` dependency arrays updated accordingly.
- `packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetailsActions.test.tsx`: new jsdom hook test proving each write invokes `runMutation` (with a pass-through guard mock) and still performs the same API call / refetch / success-navigation behavior, plus a failure-path case asserting failures flow through the guard rather than navigating.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — per-module bug fix in the guarded-mutation remediation campaign; no spec change required.

## Testing

List the tests or commands you ran to validate the change.

- `yarn workspace @open-mercato/core test --testPathPattern useMessageDetailsActions` → 7/7 pass (red before fix)
- `yarn workspace @open-mercato/core test --testPathPattern modules/messages` → 49 suites / 235 tests pass
- `yarn turbo run typecheck --filter=@open-mercato/core --force` → pass
- `yarn i18n:check-sync` → all locales in sync
- `yarn build:packages` → 21/21
- `yarn build:app` → compiled + typechecked successfully

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no new user-facing strings or generated files.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required — behavior-preserving UI-hook wiring with no new API surface; the issue's validation calls for component/hook tests, which are included.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-high`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). (`risk-high`, inherited from the issue — touches the mutation/conflict pipeline.)
- [x] QA routing set: `needs-qa` (customer-facing message detail-page write actions). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — N/A, logic-only hook (no JSX/markup).
- [x] No arbitrary text sizes (`text-[Npx]`) — N/A, no UI markup.
- [x] Empty state handled for list/data pages — N/A, no list/data page in this change.
- [x] Loading state handled for async pages — N/A; existing `updatingState`/`executingActionId`/`activeConversationAction` flags preserved.
- [x] `aria-label` on all icon-only buttons — N/A, no buttons changed.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — N/A, no UI components changed.

## Linked issues

Fixes #3258
