### PR TITLE
fix: route currencies non-CrudForm UI writes through guarded mutations (#3191)

### DIFF
--- a/packages/core/src/modules/currencies/backend/currencies/[id]/page.tsx
+++ b/packages/core/src/modules/currencies/backend/currencies/[id]/page.tsx
@@ -8,7 +8,8 @@ import { updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
-import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { buildOptimisticLockHeader, extractOptimisticLockConflict } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { SendObjectMessageDialog } from '@open-mercato/ui/backend/messages'
 import { DataLoader } from '@open-mercato/ui/primitives/DataLoader'
@@ -35,6 +36,16 @@ export default function EditCurrencyPage({ params }: { params?: { id?: string } 
   const t = useT()
   const router = useRouter()
   const { confirm: confirmDialog, ConfirmDialogElement } = useConfirmDialog()
+  const mutationContextId = 'currencies-edit:delete'
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    resourceId: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: mutationContextId,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
 
   const [currency, setCurrency] = React.useState<CurrencyData | null>(null)
   const [loading, setLoading] = React.useState(true)
@@ -144,21 +155,40 @@ export default function EditCurrencyPage({ params }: { params?: { id?: string } 
     if (!confirmed) return
 
     try {
-      const headers = buildOptimisticLockHeader(currency.updatedAt ?? currency.updated_at ?? null)
-      await withScopedApiRequestHeaders(headers, () => (
-        apiCall('/api/currencies/currencies', {
-          method: 'DELETE',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: currency.id, organizationId: currency.organizationId, tenantId: currency.tenantId }),
-        })
-      ))
+      await runMutation({
+        operation: async () => {
+          const headers = buildOptimisticLockHeader(currency.updatedAt ?? currency.updated_at ?? null)
+          const call = await withScopedApiRequestHeaders(headers, () => (
+            apiCall('/api/currencies/currencies', {
+              method: 'DELETE',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ id: currency.id, organizationId: currency.organizationId, tenantId: currency.tenantId }),
+            })
+          ))
+          if (!call.ok) {
+            throw Object.assign(new Error('[internal] currencies.delete failed'), {
+              status: call.status,
+              ...((call.result as Record<string, unknown> | null) ?? {}),
+            })
+          }
+          return call
+        },
+        context: {
+          formId: mutationContextId,
+          resourceKind: 'currencies.currency',
+          resourceId: currency.id,
+          retryLastMutation,
+        },
+        mutationPayload: { id: currency.id },
+      })
 
       flash(t('currencies.flash.deleted'), 'success')
       router.push('/backend/currencies')
     } catch (error) {
+      if (extractOptimisticLockConflict(error)) return
       flash(t('currencies.flash.deleteError'), 'error')
     }
-  }, [currency, t, router, confirmDialog])
+  }, [currency, t, router, confirmDialog, mutationContextId, retryLastMutation, runMutation])
 
   if (loading) {
     return (

--- a/packages/core/src/modules/currencies/backend/currencies/__tests__/CurrenciesPage.test.tsx
+++ b/packages/core/src/modules/currencies/backend/currencies/__tests__/CurrenciesPage.test.tsx
@@ -8,9 +8,15 @@ import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 
 const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+const mockRunMutation = jest.fn(({ operation }: { operation: () => unknown }) => operation())
+const mockRetryLastMutation = jest.fn()
 
 jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
   useT: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({ runMutation: mockRunMutation, retryLastMutation: mockRetryLastMutation }),
 }))
 
 jest.mock('next/link', () => ({ children, href }: any) => <a href={href}>{children}</a>)
@@ -176,5 +182,32 @@ describe('CurrenciesPage', () => {
       expect(deleteCall).toBeDefined()
       expect(deleteCall[0]).toBe('/api/currencies/currencies')
     })
+  })
+
+  // Regression for #3191: every non-CrudForm write must route through the
+  // guarded mutation so global injections, scoped headers, and the unified
+  // optimistic-lock conflict handling run consistently.
+  it('routes set-base through the guarded mutation', async () => {
+    render(<CurrenciesPage />)
+    await waitFor(() => expect(apiCall).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByTestId('row-action-set-base'))
+
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalled())
+    const ctx = mockRunMutation.mock.calls.at(-1)?.[0]?.context
+    expect(ctx?.resourceKind).toBe('currencies.currency')
+    expect(typeof ctx?.retryLastMutation).toBe('function')
+  })
+
+  it('routes delete through the guarded mutation', async () => {
+    render(<CurrenciesPage />)
+    await waitFor(() => expect(apiCall).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByTestId('row-action-delete'))
+
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalled())
+    const ctx = mockRunMutation.mock.calls.at(-1)?.[0]?.context
+    expect(ctx?.resourceKind).toBe('currencies.currency')
+    expect(typeof ctx?.retryLastMutation).toBe('function')
   })
 })

--- a/packages/core/src/modules/currencies/backend/currencies/page.tsx
+++ b/packages/core/src/modules/currencies/backend/currencies/page.tsx
@@ -13,7 +13,8 @@ import { BooleanIcon } from '@open-mercato/ui/backend/ValueIcons'
 import { Plus, Star } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
-import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { buildOptimisticLockHeader, extractOptimisticLockConflict } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
@@ -52,6 +53,16 @@ export default function CurrenciesPage() {
   const [isLoading, setIsLoading] = React.useState(true)
   const [reloadToken, setReloadToken] = React.useState(0)
   const scopeVersion = useOrganizationScopeVersion()
+  const mutationContextId = 'currencies-list:mutation'
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    resourceId: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: mutationContextId,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
 
   React.useEffect(() => {
     let cancelled = false
@@ -101,27 +112,41 @@ export default function CurrenciesPage() {
   const handleSetBase = React.useCallback(
     async (row: CurrencyRow) => {
       try {
-        const call = await withScopedApiRequestHeaders(
-          buildOptimisticLockHeader(row.updatedAt),
-          () => apiCall('/api/currencies/currencies', {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ id: row.id, isBase: true }),
-          }),
-        )
-
-        if (!call.ok) {
-          flash(t('currencies.flash.baseSetError'), 'error')
-          return
-        }
+        await runMutation({
+          operation: async () => {
+            const call = await withScopedApiRequestHeaders(
+              buildOptimisticLockHeader(row.updatedAt),
+              () => apiCall('/api/currencies/currencies', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ id: row.id, isBase: true }),
+              }),
+            )
+            if (!call.ok) {
+              throw Object.assign(new Error('[internal] currencies.setBase failed'), {
+                status: call.status,
+                ...((call.result as Record<string, unknown> | null) ?? {}),
+              })
+            }
+            return call
+          },
+          context: {
+            formId: mutationContextId,
+            resourceKind: 'currencies.currency',
+            resourceId: row.id,
+            retryLastMutation,
+          },
+          mutationPayload: { id: row.id, isBase: true },
+        })
 
         flash(t('currencies.flash.baseSet'), 'success')
         setReloadToken((token) => token + 1)
       } catch (error) {
+        if (extractOptimisticLockConflict(error)) return
         flash(t('currencies.flash.baseSetError'), 'error')
       }
     },
-    [t]
+    [mutationContextId, retryLastMutation, runMutation, t]
   )
 
   const handleDelete = React.useCallback(
@@ -133,27 +158,41 @@ export default function CurrenciesPage() {
       if (!confirmed) return
 
       try {
-        const call = await withScopedApiRequestHeaders(
-          buildOptimisticLockHeader(row.updatedAt),
-          () => apiCall(`/api/currencies/currencies`, {
-            method: 'DELETE',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ id: row.id, organizationId: row.organizationId, tenantId: row.tenantId }),
-          }),
-        )
-
-        if (!call.ok) {
-          flash(t('currencies.flash.deleteError'), 'error')
-          return
-        }
+        await runMutation({
+          operation: async () => {
+            const call = await withScopedApiRequestHeaders(
+              buildOptimisticLockHeader(row.updatedAt),
+              () => apiCall(`/api/currencies/currencies`, {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ id: row.id, organizationId: row.organizationId, tenantId: row.tenantId }),
+              }),
+            )
+            if (!call.ok) {
+              throw Object.assign(new Error('[internal] currencies.delete failed'), {
+                status: call.status,
+                ...((call.result as Record<string, unknown> | null) ?? {}),
+              })
+            }
+            return call
+          },
+          context: {
+            formId: mutationContextId,
+            resourceKind: 'currencies.currency',
+            resourceId: row.id,
+            retryLastMutation,
+          },
+          mutationPayload: { id: row.id },
+        })
 
         flash(t('currencies.flash.deleted'), 'success')
         setReloadToken((token) => token + 1)
       } catch (error) {
+        if (extractOptimisticLockConflict(error)) return
         flash(t('currencies.flash.deleteError'), 'error')
       }
     },
-    [t, confirmDialog]
+    [t, confirmDialog, mutationContextId, retryLastMutation, runMutation]
   )
 
   const columns = React.useMemo<ColumnDef<CurrencyRow>[]>(

--- a/packages/core/src/modules/currencies/backend/exchange-rates/__tests__/ExchangeRatesPage.test.tsx
+++ b/packages/core/src/modules/currencies/backend/exchange-rates/__tests__/ExchangeRatesPage.test.tsx
@@ -8,9 +8,15 @@ import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 
 const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+const mockRunMutation = jest.fn(({ operation }: { operation: () => unknown }) => operation())
+const mockRetryLastMutation = jest.fn()
 
 jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
   useT: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({ runMutation: mockRunMutation, retryLastMutation: mockRetryLastMutation }),
 }))
 
 jest.mock('next/link', () => ({ children, href }: any) => <a href={href}>{children}</a>)
@@ -131,5 +137,18 @@ describe('ExchangeRatesPage', () => {
       expect(deleteCall).toBeDefined()
       expect(deleteCall[0]).toBe('/api/currencies/exchange-rates')
     })
+  })
+
+  // Regression for #3191: the delete write must route through the guarded mutation.
+  it('routes delete through the guarded mutation', async () => {
+    render(<ExchangeRatesPage />)
+    await waitFor(() => expect(apiCall).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByTestId('row-action-delete'))
+
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalled())
+    const ctx = mockRunMutation.mock.calls.at(-1)?.[0]?.context
+    expect(ctx?.resourceKind).toBe('currencies.exchange_rate')
+    expect(typeof ctx?.retryLastMutation).toBe('function')
   })
 })

--- a/packages/core/src/modules/currencies/backend/exchange-rates/page.tsx
+++ b/packages/core/src/modules/currencies/backend/exchange-rates/page.tsx
@@ -13,7 +13,8 @@ import { BooleanIcon } from '@open-mercato/ui/backend/ValueIcons'
 import { Plus } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
-import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { buildOptimisticLockHeader, extractOptimisticLockConflict } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
@@ -53,6 +54,16 @@ export default function ExchangeRatesPage() {
   const [isLoading, setIsLoading] = React.useState(true)
   const [reloadToken, setReloadToken] = React.useState(0)
   const scopeVersion = useOrganizationScopeVersion()
+  const mutationContextId = 'currencies-exchange-rates-list:mutation'
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    resourceId: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: mutationContextId,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
 
   React.useEffect(() => {
     let cancelled = false
@@ -111,27 +122,41 @@ export default function ExchangeRatesPage() {
       if (!confirmed) return
 
       try {
-        const call = await withScopedApiRequestHeaders(
-          buildOptimisticLockHeader(row.updatedAt),
-          () => apiCall(`/api/currencies/exchange-rates`, {
-            method: 'DELETE',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ id: row.id, organizationId: row.organizationId, tenantId: row.tenantId }),
-          }),
-        )
-
-        if (!call.ok) {
-          flash(t('exchangeRates.flash.deleteError'), 'error')
-          return
-        }
+        await runMutation({
+          operation: async () => {
+            const call = await withScopedApiRequestHeaders(
+              buildOptimisticLockHeader(row.updatedAt),
+              () => apiCall(`/api/currencies/exchange-rates`, {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ id: row.id, organizationId: row.organizationId, tenantId: row.tenantId }),
+              }),
+            )
+            if (!call.ok) {
+              throw Object.assign(new Error('[internal] currencies.exchangeRate.delete failed'), {
+                status: call.status,
+                ...((call.result as Record<string, unknown> | null) ?? {}),
+              })
+            }
+            return call
+          },
+          context: {
+            formId: mutationContextId,
+            resourceKind: 'currencies.exchange_rate',
+            resourceId: row.id,
+            retryLastMutation,
+          },
+          mutationPayload: { id: row.id },
+        })
 
         flash(t('exchangeRates.flash.deleted'), 'success')
         setReloadToken((token) => token + 1)
       } catch (error) {
+        if (extractOptimisticLockConflict(error)) return
         flash(t('exchangeRates.flash.deleteError'), 'error')
       }
     },
-    [t, confirmDialog]
+    [t, confirmDialog, mutationContextId, retryLastMutation, runMutation]
   )
 
   const columns = React.useMemo<ColumnDef<ExchangeRateRow>[]>(

--- a/packages/core/src/modules/currencies/components/CurrencyFetchingConfig.tsx
+++ b/packages/core/src/modules/currencies/components/CurrencyFetchingConfig.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
-import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { buildOptimisticLockHeader, extractOptimisticLockConflict } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { Switch } from '@open-mercato/ui/primitives/switch'
@@ -31,16 +32,35 @@ export default function CurrencyFetchingConfig() {
   // Available providers that should be configured
   const availableProviders = useMemo(() => ['NBP', 'Raiffeisen Bank Polska'], [])
 
+  const mutationContextId = 'currencies-fetch-configs:mutation'
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    resourceId?: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: mutationContextId,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+
   const createProviderConfig = useCallback(async (provider: string) => {
     try {
-      await apiCall('/api/currencies/fetch-configs', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          provider,
-          isEnabled: false,
-          syncTime: '09:00',
+      await runMutation({
+        operation: () => apiCall('/api/currencies/fetch-configs', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            provider,
+            isEnabled: false,
+            syncTime: '09:00',
+          }),
         }),
+        context: {
+          formId: mutationContextId,
+          resourceKind: 'currencies.fetch_config',
+          retryLastMutation,
+        },
+        mutationPayload: { provider, isEnabled: false, syncTime: '09:00' },
       })
     } catch (err: any) {
       // Ignore errors for duplicate providers
@@ -48,7 +68,7 @@ export default function CurrencyFetchingConfig() {
         throw err
       }
     }
-  }, [])
+  }, [mutationContextId, retryLastMutation, runMutation])
 
   const initializeMissingProviders = useCallback(async (providers: string[]) => {
     setInitializing(true)
@@ -96,19 +116,38 @@ export default function CurrencyFetchingConfig() {
 
   const toggleEnabled = useCallback(async (configId: string, currentValue: boolean, updatedAt?: string | null) => {
     try {
-      const { result } = await withScopedApiRequestHeaders(
-        buildOptimisticLockHeader(updatedAt),
-        () =>
-          apiCall('/api/currencies/fetch-configs', {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              id: configId,
-              isEnabled: !currentValue,
-            }),
-          }),
-      )
+      const call = await runMutation({
+        operation: async () => {
+          const response = await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(updatedAt),
+            () =>
+              apiCall('/api/currencies/fetch-configs', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  id: configId,
+                  isEnabled: !currentValue,
+                }),
+              }),
+          )
+          if (!response.ok) {
+            throw Object.assign(new Error('[internal] currencies.fetchConfig.toggle failed'), {
+              status: response.status,
+              ...((response.result as Record<string, unknown> | null) ?? {}),
+            })
+          }
+          return response
+        },
+        context: {
+          formId: mutationContextId,
+          resourceKind: 'currencies.fetch_config',
+          resourceId: configId,
+          retryLastMutation,
+        },
+        mutationPayload: { id: configId, isEnabled: !currentValue },
+      })
 
+      const result = call.result as { config?: FetchConfig } | null
       if (result?.config) {
         setConfigs((prev) =>
           prev.map((c) => (c.id === configId ? (result.config as FetchConfig) : c))
@@ -121,47 +160,77 @@ export default function CurrencyFetchingConfig() {
         )
       }
     } catch (err: any) {
+      if (extractOptimisticLockConflict(err)) return
       flash(err.message || t('currencies.fetch.error_update_config'), 'error')
     }
-  }, [t])
+  }, [mutationContextId, retryLastMutation, runMutation, t])
 
   const updateSyncTime = useCallback(async (configId: string, syncTime: string, updatedAt?: string | null) => {
     try {
-      const { result } = await withScopedApiRequestHeaders(
-        buildOptimisticLockHeader(updatedAt),
-        () =>
-          apiCall('/api/currencies/fetch-configs', {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              id: configId,
-              syncTime: syncTime || null,
-            }),
-          }),
-      )
+      const call = await runMutation({
+        operation: async () => {
+          const response = await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(updatedAt),
+            () =>
+              apiCall('/api/currencies/fetch-configs', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  id: configId,
+                  syncTime: syncTime || null,
+                }),
+              }),
+          )
+          if (!response.ok) {
+            throw Object.assign(new Error('[internal] currencies.fetchConfig.updateSyncTime failed'), {
+              status: response.status,
+              ...((response.result as Record<string, unknown> | null) ?? {}),
+            })
+          }
+          return response
+        },
+        context: {
+          formId: mutationContextId,
+          resourceKind: 'currencies.fetch_config',
+          resourceId: configId,
+          retryLastMutation,
+        },
+        mutationPayload: { id: configId, syncTime: syncTime || null },
+      })
 
+      const result = call.result as { config?: FetchConfig } | null
       if (result?.config) {
         setConfigs((prev) =>
           prev.map((c) => (c.id === configId ? (result.config as FetchConfig) : c))
         )
       }
     } catch (err: any) {
+      if (extractOptimisticLockConflict(err)) return
       flash(err.message || t('currencies.fetch.error_update_sync_time'), 'error')
     }
-  }, [t])
+  }, [mutationContextId, retryLastMutation, runMutation, t])
 
   const fetchNow = useCallback(async (provider: string) => {
     setFetching(provider)
 
     try {
-      const { result } = await apiCall('/api/currencies/fetch-rates', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          providers: [provider],
+      const call = await runMutation({
+        operation: () => apiCall('/api/currencies/fetch-rates', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            providers: [provider],
+          }),
         }),
+        context: {
+          formId: mutationContextId,
+          resourceKind: 'currencies.fetch_rates',
+          retryLastMutation,
+        },
+        mutationPayload: { providers: [provider] },
       })
 
+      const result = call.result as { byProvider?: Record<string, { count: number; errors?: string[] }> } | null
       if (result) {
         const byProvider = result.byProvider as Record<string, { count: number; errors?: string[] }>
         const count = byProvider?.[provider]?.count || 0
@@ -178,7 +247,7 @@ export default function CurrencyFetchingConfig() {
     } finally {
       setFetching(null)
     }
-  }, [t, loadConfigs])
+  }, [mutationContextId, retryLastMutation, runMutation, t, loadConfigs])
 
   useEffect(() => {
     loadConfigs()

--- a/packages/core/src/modules/currencies/components/__tests__/CurrencyFetchingConfig.test.tsx
+++ b/packages/core/src/modules/currencies/components/__tests__/CurrencyFetchingConfig.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment jsdom
+ */
+import type React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import CurrencyFetchingConfig from '../CurrencyFetchingConfig'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+
+const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+const mockRunMutation = jest.fn(({ operation }: { operation: () => unknown }) => operation())
+const mockRetryLastMutation = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({ runMutation: mockRunMutation, retryLastMutation: mockRetryLastMutation }),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+  withScopedApiRequestHeaders: (_headers: unknown, run: () => unknown) => run(),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, onClick, disabled }: any) => (
+    <button data-testid="fetch-button" onClick={onClick} disabled={disabled}>{children}</button>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/primitives/spinner', () => ({
+  Spinner: () => null,
+}))
+
+jest.mock('@open-mercato/ui/primitives/switch', () => ({
+  Switch: ({ onCheckedChange }: any) => (
+    <button data-testid="switch" onClick={() => onCheckedChange?.()}>switch</button>
+  ),
+}))
+
+const enabledNbp = {
+  id: 'cfg-nbp',
+  provider: 'NBP',
+  isEnabled: true,
+  syncTime: '09:00',
+  lastSyncAt: null,
+  lastSyncStatus: null,
+  lastSyncMessage: null,
+  lastSyncCount: null,
+  updatedAt: '2024-01-01',
+}
+const disabledRaiffeisen = {
+  id: 'cfg-raif',
+  provider: 'Raiffeisen Bank Polska',
+  isEnabled: false,
+  syncTime: '09:00',
+  lastSyncAt: null,
+  lastSyncStatus: null,
+  lastSyncMessage: null,
+  lastSyncCount: null,
+  updatedAt: '2024-01-01',
+}
+
+describe('CurrencyFetchingConfig — guarded mutations (#3191)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('routes toggle, sync-time, and fetch-now through the guarded mutation', async () => {
+    ;(apiCall as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      result: { configs: [enabledNbp, disabledRaiffeisen] },
+    })
+
+    const { container } = render(<CurrencyFetchingConfig />)
+    await waitFor(() => expect(screen.getAllByTestId('switch').length).toBeGreaterThan(0))
+
+    // toggle (PUT)
+    fireEvent.click(screen.getAllByTestId('switch')[0])
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalled())
+    expect(mockRunMutation.mock.calls.at(-1)?.[0]?.context?.resourceKind).toBe('currencies.fetch_config')
+
+    // sync-time (PUT)
+    mockRunMutation.mockClear()
+    const timeInput = container.querySelector('input[type="time"]') as HTMLInputElement
+    expect(timeInput).toBeTruthy()
+    fireEvent.change(timeInput, { target: { value: '10:30' } })
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalled())
+    expect(mockRunMutation.mock.calls.at(-1)?.[0]?.context?.resourceKind).toBe('currencies.fetch_config')
+
+    // fetch-now (POST)
+    mockRunMutation.mockClear()
+    fireEvent.click(screen.getByTestId('fetch-button'))
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalled())
+    expect(mockRunMutation.mock.calls.at(-1)?.[0]?.context?.resourceKind).toBe('currencies.fetch_rates')
+  })
+
+  it('routes auto-initialized provider creation through the guarded mutation', async () => {
+    ;(apiCall as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      result: { configs: [] },
+    })
+
+    render(<CurrencyFetchingConfig />)
+
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalled())
+    expect(mockRunMutation.mock.calls.at(-1)?.[0]?.context?.resourceKind).toBe('currencies.fetch_config')
+  })
+})


### PR DESCRIPTION
## Summary

Several `currencies` backend UI writes bypassed `useGuardedMutation` and called
`apiCall` directly, violating the `packages/ui/AGENTS.md` contract that every
non-`CrudForm` write (`POST`/`PUT`/`PATCH`/`DELETE`) must run through
`useGuardedMutation(...).runMutation(...)` so global mutation injections, scoped
headers, unified optimistic-lock conflict handling, and future guards run
consistently. This routes all eight currencies write paths through the guard
while preserving confirmation dialogs, flash messages, optimistic-lock
semantics, and reload behavior, and surfaces 409 conflicts via the shared
conflict UI instead of a generic flash.

## Changes

- `backend/currencies/page.tsx`: route `handleSetBase` (PUT) and `handleDelete` (DELETE) through `runMutation`; keep the optimistic-lock header inside the `operation`; throw a conflict-shaped error on `!ok` so the guard surfaces 409, and suppress the generic flash only on conflict via `extractOptimisticLockConflict`.
- `backend/exchange-rates/page.tsx`: route `handleDelete` (DELETE) through `runMutation` (same pattern).
- `backend/currencies/[id]/page.tsx`: route the custom `handleDelete` (DELETE) through `runMutation`.
- `components/CurrencyFetchingConfig.tsx`: route `createProviderConfig` (POST), `toggleEnabled` (PUT), `updateSyncTime` (PUT), and `fetchNow` (POST) through `runMutation`; the lock-bearing PUTs surface 409 via the guard, while the POST create (duplicate-swallow) and fetch-now keep their original non-throwing behavior.
- Tests: extended `CurrenciesPage`/`ExchangeRatesPage` suites and added `CurrencyFetchingConfig.test.tsx` to assert every write routes through `runMutation` with stable `resourceKind`/`retryLastMutation` context.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — bug fix following the existing guarded-mutation remediation pattern.

## Testing

- `yarn workspace @open-mercato/core test -- --testPathPattern "(CurrenciesPage|ExchangeRatesPage|CurrencyFetchingConfig|EditCurrencyPage)"` → 13 passed (5 new routing tests red→green).
- `yarn workspace @open-mercato/core test -- --testPathPattern "modules/currencies|optimistic-lock"` → 195 passed (incl. optimistic-lock-ui-coverage guard).
- `tsc -p packages/core/tsconfig.json --noEmit` → 0 errors.
- `yarn workspace @open-mercato/core build` → built successfully.
- `yarn i18n:check-sync` → all locales in sync.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No new keys; reuses existing `ui.forms.flash.saveBlocked` and `currencies.*` keys.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Not required: no API contract change; this is a client-side write-routing refactor verified by jsdom render tests.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A.
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — single-module UI change with tests.)
- [x] QA routing set: `needs-qa` (UI change to mutating currency/exchange-rate/config flows). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors — none introduced on changed lines (pre-existing ones in `getStatusBadge` are on untouched lines).
- [x] No arbitrary text sizes (`text-[Npx]`) — none introduced.
- [x] Empty state handled for list/data pages — unchanged (existing `emptyState`/empty-config UX preserved).
- [x] Loading state handled for async pages — unchanged.
- [x] `aria-label` on all icon-only buttons — N/A, no icon-only buttons added.
- [x] Uses existing DS components — no custom replacements added.

## Linked issues

Fixes #3191

🤖 Generated with [Claude Code](https://claude.com/claude-code)
