### PR TITLE
perf(communication_channels): aggregate channel health counts in the database (#3184)

### DIFF
--- a/packages/core/src/modules/communication_channels/api/get/channels/[id]/health/__tests__/route.test.ts
+++ b/packages/core/src/modules/communication_channels/api/get/channels/[id]/health/__tests__/route.test.ts
@@ -1,0 +1,223 @@
+/** @jest-environment node */
+
+// Regression for https://github.com/open-mercato/open-mercato/issues/3184 —
+// the channel health endpoint used to materialize every last-24h
+// `message_channel_links` row into memory and count delivery statuses in JS.
+// It now computes the counts with a grouped database aggregate, so the response
+// stays a small fixed shape regardless of channel volume. These tests pin the
+// aggregate response shape and confirm channel access + tenant scoping still
+// hold.
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const channelId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const conversationId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+const findOneWithDecryptionMock = jest.fn()
+const findWithDecryptionMock = jest.fn()
+const loadAclMock = jest.fn()
+const assertCanAccessChannelMock = jest.fn()
+const getAuthFromRequestMock = jest.fn()
+
+class ChannelAccessDeniedErrorMock extends Error {}
+
+const kyselySelectFromMock = jest.fn()
+const kyselyWhereMock = jest.fn()
+const kyselyGroupByMock = jest.fn()
+const kyselyExecuteMock = jest.fn()
+const getKyselyMock = jest.fn()
+
+const kyselyBuilder = {
+  selectFrom: (...args: unknown[]) => {
+    kyselySelectFromMock(...args)
+    return kyselyBuilder
+  },
+  select: () => kyselyBuilder,
+  where: (...args: unknown[]) => {
+    kyselyWhereMock(...args)
+    return kyselyBuilder
+  },
+  groupBy: (...args: unknown[]) => {
+    kyselyGroupByMock(...args)
+    return kyselyBuilder
+  },
+  execute: (...args: unknown[]) => kyselyExecuteMock(...args),
+}
+
+const em = {
+  fork: () => em,
+  getKysely: (...args: unknown[]) => getKyselyMock(...args),
+}
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'rbacService') return { loadAcl: loadAclMock }
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => getAuthFromRequestMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: (...args: unknown[]) => findOneWithDecryptionMock(...args),
+  findWithDecryption: (...args: unknown[]) => findWithDecryptionMock(...args),
+}))
+
+jest.mock('../../../../../../lib/access-control', () => ({
+  ChannelAccessDeniedError: ChannelAccessDeniedErrorMock,
+  assertCanAccessChannel: (...args: unknown[]) => assertCanAccessChannelMock(...args),
+}))
+
+import { GET } from '../route'
+
+const failedLink = {
+  id: 'fail-1',
+  messageId: 'msg-1',
+  direction: 'outbound',
+  createdAt: new Date('2026-06-20T00:00:00.000Z'),
+  channelMetadata: { lastError: 'SMTP 550', transient: false },
+}
+
+function buildRequest() {
+  return new Request(`http://localhost/api/communication_channels/channels/${channelId}/health`)
+}
+
+function invoke() {
+  return GET(buildRequest(), { params: { id: channelId } })
+}
+
+describe('communication_channels channel health route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getAuthFromRequestMock.mockResolvedValue({ sub: userId, tenantId, orgId: organizationId })
+    loadAclMock.mockResolvedValue({ isSuperAdmin: true, features: ['*'], organizations: null })
+    assertCanAccessChannelMock.mockImplementation(() => {})
+    findOneWithDecryptionMock.mockResolvedValue({
+      id: channelId,
+      providerKey: 'imap',
+      channelType: 'email',
+    })
+    // Conversations lookup returns one conversation; the bounded recent-failures
+    // query returns a single failed link. The unbounded "load all links" query
+    // that the old code issued for counts must never be made — return [] for any
+    // unexpected link read so a regression surfaces as zeroed counts.
+    findWithDecryptionMock.mockImplementation(async (_em, _entity, filter: Record<string, unknown>) => {
+      if (filter && 'channelId' in filter) return [{ id: conversationId }]
+      if (filter && filter.deliveryStatus === 'failed') return [failedLink]
+      return []
+    })
+    getKyselyMock.mockReturnValue(kyselyBuilder)
+    kyselyExecuteMock.mockResolvedValue([
+      { delivery_status: 'sent', count: 3 },
+      { delivery_status: 'failed', count: '2' },
+      { delivery_status: 'pending', count: 1 },
+      { delivery_status: 'bounced', count: 4 },
+    ])
+  })
+
+  it('computes delivery-status counts with a grouped DB aggregate, not an in-memory scan', async () => {
+    const response = await invoke()
+    expect(response.status).toBe(200)
+
+    const body = (await response.json()) as {
+      channelId: string
+      counts: Record<string, number>
+      totalsLast24h: number
+      recentFailures: Array<Record<string, unknown>>
+    }
+
+    // Counts come from the aggregate rows; an unknown status ('bounced') folds
+    // into `other`, and totals are the sum across all groups.
+    expect(body.channelId).toBe(channelId)
+    expect(body.counts).toEqual({
+      sent: 3,
+      delivered: 0,
+      read: 0,
+      failed: 2,
+      pending: 1,
+      queued: 0,
+      other: 4,
+    })
+    expect(body.totalsLast24h).toBe(10)
+
+    // The aggregate runs in the database, grouped by delivery_status and scoped
+    // to this channel's conversations, tenant, and 24h window.
+    expect(getKyselyMock).toHaveBeenCalledTimes(1)
+    expect(kyselySelectFromMock).toHaveBeenCalledWith('message_channel_links')
+    expect(kyselyGroupByMock).toHaveBeenCalledWith('delivery_status')
+    const whereColumns = kyselyWhereMock.mock.calls.map((call) => call[0])
+    expect(whereColumns).toEqual(
+      expect.arrayContaining(['external_conversation_id', 'tenant_id', 'created_at']),
+    )
+
+    // The unbounded "load every last-24h link" query is gone: the only
+    // message_channel_links read is the bounded recent-failures query.
+    const unboundedCountsLoad = findWithDecryptionMock.mock.calls.find((call) => {
+      const filter = call[2] as Record<string, unknown> | undefined
+      const options = call[3] as { limit?: number } | undefined
+      return (
+        !!filter &&
+        'createdAt' in filter &&
+        filter.deliveryStatus === undefined &&
+        (!options || options.limit === undefined)
+      )
+    })
+    expect(unboundedCountsLoad).toBeUndefined()
+
+    // Recent failures stay bounded and carry last-error context.
+    expect(body.recentFailures).toHaveLength(1)
+    expect(body.recentFailures[0]).toMatchObject({ id: 'fail-1', lastError: 'SMTP 550' })
+  })
+
+  it('returns zeroed counts without querying when the channel has no conversations', async () => {
+    findWithDecryptionMock.mockImplementation(async () => [])
+
+    const response = await invoke()
+    expect(response.status).toBe(200)
+
+    const body = (await response.json()) as { counts: Record<string, number>; totalsLast24h: number }
+    expect(body.totalsLast24h).toBe(0)
+    expect(Object.values(body.counts).every((n) => n === 0)).toBe(true)
+    // No conversations → no aggregate query at all.
+    expect(getKyselyMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid channel id with 400', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/communication_channels/channels/not-a-uuid/health'),
+      { params: { id: 'not-a-uuid' } },
+    )
+    expect(response.status).toBe(400)
+  })
+
+  it('returns 401 when the request has no tenant', async () => {
+    getAuthFromRequestMock.mockResolvedValue(null)
+    const response = await invoke()
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 404 when the channel is not found for the tenant', async () => {
+    findOneWithDecryptionMock.mockResolvedValue(null)
+    const response = await invoke()
+    expect(response.status).toBe(404)
+    expect(getKyselyMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 (not 403) when channel access is denied', async () => {
+    assertCanAccessChannelMock.mockImplementation(() => {
+      throw new ChannelAccessDeniedErrorMock('denied')
+    })
+    const response = await invoke()
+    expect(response.status).toBe(404)
+    // Access is denied before any health aggregate runs.
+    expect(getKyselyMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/communication_channels/api/get/channels/[id]/health/route.ts
+++ b/packages/core/src/modules/communication_channels/api/get/channels/[id]/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
+import { sql } from 'kysely'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { EntityManager } from '@mikro-orm/postgresql'
@@ -100,21 +101,36 @@ export async function GET(req: Request, context: RouteContext): Promise<Response
   )
   const conversationIds = conversations.map((c) => c.id).filter(Boolean) as string[]
 
-  let links: MessageChannelLink[] = []
+  const counts = { sent: 0, delivered: 0, read: 0, failed: 0, pending: 0, queued: 0, other: 0 }
+  let totalsLast24h = 0
   let recentFailures: MessageChannelLink[] = []
   if (conversationIds.length > 0) {
     const since = new Date(Date.now() - WINDOW_HOURS * 60 * 60 * 1000)
-    links = await findWithDecryption(
-      em,
-      MessageChannelLink,
-      {
-        externalConversationId: { $in: conversationIds },
-        tenantId: auth.tenantId,
-        createdAt: { $gte: since },
-      },
-      undefined,
-      dscope,
-    )
+
+    // Aggregate the delivery-status counts in the database so the response stays
+    // a small fixed shape regardless of how much traffic the channel saw in the
+    // window. `delivery_status`, `external_conversation_id`, `tenant_id` and
+    // `created_at` are plaintext columns (see encryption.ts — only
+    // `channel_ingest_dead_letter.raw_body` is encrypted on this module), so a
+    // grouped count is safe without the decryption helpers.
+    const db = em.getKysely<any>() as any
+    const statusRows = (await db
+      .selectFrom('message_channel_links')
+      .select(['delivery_status', sql<string>`count(*)`.as('count')])
+      .where('external_conversation_id', 'in', conversationIds)
+      .where('tenant_id', '=', auth.tenantId)
+      .where('created_at', '>=', since)
+      .groupBy('delivery_status')
+      .execute()) as Array<{ delivery_status: string | null; count: string | number }>
+
+    for (const row of statusRows) {
+      const value = Number(row.count) || 0
+      totalsLast24h += value
+      const key = row.delivery_status as keyof typeof counts
+      if (key && key in counts) counts[key] += value
+      else counts.other += value
+    }
+
     recentFailures = await findWithDecryption(
       em,
       MessageChannelLink,
@@ -128,20 +144,13 @@ export async function GET(req: Request, context: RouteContext): Promise<Response
     )
   }
 
-  const counts = { sent: 0, delivered: 0, read: 0, failed: 0, pending: 0, queued: 0, other: 0 }
-  for (const link of links) {
-    const key = link.deliveryStatus as keyof typeof counts
-    if (key in counts) counts[key] += 1
-    else counts.other += 1
-  }
-
   return NextResponse.json({
     channelId: channel.id,
     providerKey: channel.providerKey,
     channelType: channel.channelType,
     windowHours: WINDOW_HOURS,
     counts,
-    totalsLast24h: links.length,
+    totalsLast24h,
     recentFailures: recentFailures.map((link) => ({
       id: link.id,
       messageId: link.messageId,


### PR DESCRIPTION
## Summary

The channel health endpoint (`GET /communication_channels/channels/[id]/health`) returns a small fixed shape — delivery-status counts plus a bounded recent-failure sample — but it materialized **every** last-24h `message_channel_links` row for the channel into memory just to tally statuses in JavaScript, so a high-volume channel made the endpoint's work scale with all recent traffic. This replaces the in-memory scan with a grouped database aggregate (`GROUP BY delivery_status`), keeping the recent-failures query bounded by `RECENT_FAILURES_LIMIT` and the response shape unchanged.

## Changes

- `communication_channels/api/get/channels/[id]/health/route.ts`: compute `deliveryStatus` counts with a Kysely `GROUP BY delivery_status` aggregate via `em.getKysely()`, scoped to the same channel conversations / tenant / 24h window as before; derive `totalsLast24h` from the sum of group counts; drop the unbounded link load and the JS count loop. The bounded recent-failures query, channel-access checks, tenant scoping, response shape, and OpenAPI doc are unchanged. (`delivery_status` is a plaintext column — see `encryption.ts` — so a grouped count needs no decryption helpers.)
- `communication_channels/api/.../health/__tests__/route.test.ts` (new): route-level coverage for the aggregate response shape (incl. unknown-status `other` folding and bigint→number coercion), the empty-conversations no-query path, channel-access (404 before any aggregate) and tenant scoping (400/401/404), plus a regression assertion that the old unbounded link materialization is never issued.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — minimal performance refactor of an existing route; behavior and wire contract unchanged.

## Testing

- New unit test `communication_channels/api/get/channels/[id]/health/__tests__/route.test.ts` — verified RED against the previous in-memory implementation (counts returned all-zero) and GREEN after the fix.
- `jest --config jest.config.cjs` for the `communication_channels` module — all tests pass (544), including the 6 new cases.
- `tsc --noEmit` (`@open-mercato/core`) — no type errors in the changed files.
- Existing real-DB integration spec `__integration__/TC-CHANNEL-API-003.spec.ts` continues to cover the endpoint end-to-end (seeds an inbound message, asserts numeric counts and `totalsLast24h >= 1`), exercising the new aggregate path and tenant scoping.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- none required: no user-facing strings, no generator-discovered files changed -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- endpoint already covered by module-local __integration__/TC-CHANNEL-API-003.spec.ts; perf refactor preserves its contract and adds route unit coverage -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — minor refactor, no spec -->
- [x] Priority set: this PR carries exactly one `priority-*` label. <!-- priority-medium (inherited from #3184) -->
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). <!-- risk-medium (inherited from #3184) -->
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. <!-- skip-qa: backend-only counting optimization, identical wire output, no customer-facing behavior change -->

### Design System Compliance
<!-- N/A — backend API route only, no UI surface. -->
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens <!-- N/A — no UI -->
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` <!-- N/A — no UI -->
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) <!-- N/A — no UI -->
- [x] Loading state handled for async pages <!-- N/A — no UI -->
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) <!-- N/A — no UI -->
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements <!-- N/A — no UI -->

## Linked issues

Fixes #3184

🤖 Generated with [Claude Code](https://claude.com/claude-code)
