### PR TITLE
fix: route cache purge UI writes through guarded mutations (#3186)

### DIFF
--- a/packages/core/src/modules/configs/api/cache/route.ts
+++ b/packages/core/src/modules/configs/api/cache/route.ts
@@ -6,6 +6,11 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { runWithCacheTenant, type CacheStrategy } from '@open-mercato/cache'
 import { collectCrudCacheStats, purgeCrudCacheSegment } from '@open-mercato/shared/lib/crud/cache-stats'
 import {
+  bridgeLegacyGuard,
+  runMutationGuards,
+  type MutationGuardInput,
+} from '@open-mercato/shared/lib/crud/mutation-guard-registry'
+import {
   configsTag,
   cacheStatsResponseSchema,
   cachePurgeRequestSchema,
@@ -18,6 +23,11 @@ export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['configs.cache.view'] },
   POST: { requireAuth: true, requireFeatures: ['configs.cache.manage'] },
 } as const
+
+function resolveUserFeatures(auth: unknown): string[] {
+  const features = (auth as { features?: unknown } | null)?.features
+  return Array.isArray(features) ? features.filter((value): value is string => typeof value === 'string') : []
+}
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
@@ -79,22 +89,74 @@ export async function POST(req: Request) {
     }
     const tenantScope = auth.tenantId ?? null
 
-    if (action === 'purgeSegment') {
-      const segment = typeof body?.segment === 'string' ? body.segment.trim() : ''
-      if (!segment) {
-        return NextResponse.json(
-          { error: translate('configs.cache.purgeError', 'Failed to purge cache segment.') },
-          { status: 400 },
-        )
-      }
-      const result = await runWithCacheTenant(tenantScope, () => purgeCrudCacheSegment(cache, segment))
-      const stats = await runWithCacheTenant(tenantScope, () => collectCrudCacheStats(cache))
-      return NextResponse.json({ action: 'purgeSegment', segment, deleted: result.deleted, stats })
+    const segment =
+      action === 'purgeSegment'
+        ? (typeof body?.segment === 'string' ? body.segment.trim() : '')
+        : null
+    if (action === 'purgeSegment' && !segment) {
+      return NextResponse.json(
+        { error: translate('configs.cache.purgeError', 'Failed to purge cache segment.') },
+        { status: 400 },
+      )
     }
 
-    await runWithCacheTenant(tenantScope, () => cache.clear())
-    const stats = await runWithCacheTenant(tenantScope, () => collectCrudCacheStats(cache))
-    return NextResponse.json({ action: 'purgeAll', stats })
+    // Mutation-guard contract for this custom write route (packages/core/AGENTS.md
+    // → API Routes). A cache purge carries no per-record optimistic-lock version, so
+    // the default OSS guard short-circuits; wiring it keeps the route on the shared
+    // write-guard interception path for any tenant-registered guard.
+    const guardInput: MutationGuardInput = {
+      tenantId: tenantScope ?? '',
+      organizationId: auth.orgId ?? null,
+      userId: auth.sub,
+      resourceKind: 'configs.cache',
+      resourceId: segment ?? tenantScope ?? 'all',
+      operation: 'delete',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: { action, ...(segment ? { segment } : {}) },
+    }
+    const guard = bridgeLegacyGuard(container)
+    let afterSuccessCallbacks: Awaited<ReturnType<typeof runMutationGuards>>['afterSuccessCallbacks'] = []
+    if (guard) {
+      const guardResult = await runMutationGuards([guard], guardInput, {
+        userFeatures: resolveUserFeatures(auth),
+      })
+      if (!guardResult.ok) {
+        return NextResponse.json(
+          guardResult.errorBody ?? { error: translate('configs.cache.purgeError', 'Failed to purge cache segment.') },
+          { status: guardResult.errorStatus ?? 422 },
+        )
+      }
+      afterSuccessCallbacks = guardResult.afterSuccessCallbacks
+    }
+
+    let responseBody: Record<string, unknown>
+    if (action === 'purgeSegment') {
+      const result = await runWithCacheTenant(tenantScope, () => purgeCrudCacheSegment(cache, segment!))
+      const stats = await runWithCacheTenant(tenantScope, () => collectCrudCacheStats(cache))
+      responseBody = { action: 'purgeSegment', segment, deleted: result.deleted, stats }
+    } else {
+      await runWithCacheTenant(tenantScope, () => cache.clear())
+      const stats = await runWithCacheTenant(tenantScope, () => collectCrudCacheStats(cache))
+      responseBody = { action: 'purgeAll', stats }
+    }
+
+    for (const callback of afterSuccessCallbacks) {
+      if (!callback.guard.afterSuccess) continue
+      await callback.guard.afterSuccess({
+        tenantId: tenantScope ?? '',
+        organizationId: auth.orgId ?? null,
+        userId: auth.sub,
+        resourceKind: 'configs.cache',
+        resourceId: segment ?? tenantScope ?? 'all',
+        operation: 'delete',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: callback.metadata ?? null,
+      })
+    }
+
+    return NextResponse.json(responseBody)
   } catch (error) {
     console.error('[configs.cache] failed to purge cache', error)
     return NextResponse.json(

--- a/packages/core/src/modules/configs/components/CachePanel.tsx
+++ b/packages/core/src/modules/configs/components/CachePanel.tsx
@@ -4,11 +4,13 @@ import * as React from 'react'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 
 const API_PATH = '/api/configs/cache'
+const CACHE_MUTATION_CONTEXT_ID = 'configs-cache-panel'
 
 type CrudCacheSegment = {
   segment: string
@@ -38,6 +40,23 @@ export function CachePanel() {
   const [checkingFeature, setCheckingFeature] = React.useState(true)
   const [purgingAll, setPurgingAll] = React.useState(false)
   const [segmentPurges, setSegmentPurges] = React.useState<Record<string, boolean>>({})
+
+  const { runMutation, retryLastMutation } = useGuardedMutation<{
+    formId: string
+    resourceKind: string
+    retryLastMutation: () => Promise<boolean>
+  }>({
+    contextId: CACHE_MUTATION_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
+  const cacheMutationContext = React.useMemo(
+    () => ({
+      formId: CACHE_MUTATION_CONTEXT_ID,
+      resourceKind: 'configs.cache',
+      retryLastMutation,
+    }),
+    [retryLastMutation],
+  )
 
   const loadStats = React.useCallback(async () => {
     setState((current) => ({ ...current, loading: true, error: null }))
@@ -106,18 +125,23 @@ export function CachePanel() {
     if (!confirmed) return
     setPurgingAll(true)
     try {
-      const payload = await readApiResultOrThrow<{ stats?: CrudCacheStats }>(
-        API_PATH,
-        {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ action: 'purgeAll' }),
-        },
-        {
-          errorMessage: t('configs.cache.purgeError', 'Failed to purge cache segment.'),
-          allowNullResult: true,
-        },
-      )
+      const payload = await runMutation({
+        operation: () =>
+          readApiResultOrThrow<{ stats?: CrudCacheStats }>(
+            API_PATH,
+            {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ action: 'purgeAll' }),
+            },
+            {
+              errorMessage: t('configs.cache.purgeError', 'Failed to purge cache segment.'),
+              allowNullResult: true,
+            },
+          ),
+        context: cacheMutationContext,
+        mutationPayload: { action: 'purgeAll' },
+      })
       const stats = payload?.stats
       if (stats) {
         setState({ loading: false, error: null, stats })
@@ -135,7 +159,7 @@ export function CachePanel() {
     } finally {
       setPurgingAll(false)
     }
-  }, [canManage, confirm, purgingAll, t, handleRefresh]);
+  }, [canManage, confirm, purgingAll, t, handleRefresh, runMutation, cacheMutationContext]);
 
 
   const handlePurgeSegment = React.useCallback(async (segment: string) => {
@@ -147,18 +171,23 @@ export function CachePanel() {
     if (!confirmed) return
     setSegmentPurges((prev) => ({ ...prev, [segment]: true }))
     try {
-      const payload = await readApiResultOrThrow<{ stats?: CrudCacheStats; deleted?: number }>(
-        API_PATH,
-        {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ action: 'purgeSegment', segment }),
-        },
-        {
-          errorMessage: t('configs.cache.purgeError', 'Failed to purge cache segment.'),
-          allowNullResult: true,
-        },
-      )
+      const payload = await runMutation({
+        operation: () =>
+          readApiResultOrThrow<{ stats?: CrudCacheStats; deleted?: number }>(
+            API_PATH,
+            {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ action: 'purgeSegment', segment }),
+            },
+            {
+              errorMessage: t('configs.cache.purgeError', 'Failed to purge cache segment.'),
+              allowNullResult: true,
+            },
+          ),
+        context: cacheMutationContext,
+        mutationPayload: { action: 'purgeSegment', segment },
+      })
       const stats = payload?.stats
       if (stats) {
         setState({ loading: false, error: null, stats })
@@ -186,7 +215,7 @@ export function CachePanel() {
         return next
       })
     }
-  }, [canManage, confirm, segmentPurges, t, handleRefresh]);
+  }, [canManage, confirm, segmentPurges, t, handleRefresh, runMutation, cacheMutationContext]);
 
   if (state.loading) {
     return (
@@ -220,7 +249,7 @@ export function CachePanel() {
           {state.error}
         </div>
         <div className="flex flex-wrap gap-2">
-          <Button variant="outline" onClick={handleRefresh}>
+          <Button variant="outline" type="button" onClick={handleRefresh}>
             {t('configs.cache.retry', 'Retry')}
           </Button>
         </div>
@@ -259,11 +288,11 @@ export function CachePanel() {
           ) : null}
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={handleRefresh}>
+          <Button variant="outline" type="button" onClick={handleRefresh}>
             {t('configs.cache.refresh', 'Refresh')}
           </Button>
           {canShowActions ? (
-            <Button variant="destructive" disabled={purgingAll} onClick={() => { void handlePurgeAll() }}>
+            <Button variant="destructive" type="button" disabled={purgingAll} onClick={() => { void handlePurgeAll() }}>
               {purgingAll
                 ? t('configs.cache.purgeAllLoading', 'Purging…')
                 : t('configs.cache.purgeAll', 'Purge all cache')}
@@ -327,6 +356,7 @@ export function CachePanel() {
                           <Button
                             variant="outline"
                             size="sm"
+                            type="button"
                             disabled={isPurging}
                             onClick={() => { void handlePurgeSegment(segment.segment) }}
                           >

--- a/packages/core/src/modules/configs/components/__tests__/CachePanel.test.tsx
+++ b/packages/core/src/modules/configs/components/__tests__/CachePanel.test.tsx
@@ -10,8 +10,17 @@ import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWith
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 
+const runMutationMock = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+
 jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
   readApiResultOrThrow: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: (...args: unknown[]) => runMutationMock(...(args as [{ operation: () => Promise<unknown> }])),
+    retryLastMutation: jest.fn(),
+  }),
 }))
 
 jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
@@ -72,15 +81,25 @@ const statsPayload = {
   ],
 }
 
+function mockManageEnabled() {
+  ;(readApiResultOrThrow as jest.Mock)
+    .mockResolvedValueOnce(statsPayload) // stats
+    .mockResolvedValueOnce({ ok: true, granted: ['configs.cache.manage'] }) // feature check
+}
+
+async function confirmDialog() {
+  const confirmButtons = screen.getAllByText('Confirm')
+  fireEvent.click(confirmButtons[confirmButtons.length - 1])
+}
+
 describe('CachePanel', () => {
   beforeEach(() => {
     jest.resetAllMocks()
+    runMutationMock.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
   })
 
   it('renders cache statistics and management actions', async () => {
-    ;(readApiResultOrThrow as jest.Mock)
-      .mockResolvedValueOnce(statsPayload) // stats
-      .mockResolvedValueOnce({ ok: true, granted: ['configs.cache.manage'] }) // feature check
+    mockManageEnabled()
 
     renderWithProviders(<CachePanel />, { dict })
 
@@ -91,13 +110,11 @@ describe('CachePanel', () => {
   })
 
   it('purges a segment when user confirms', async () => {
-    ;(readApiResultOrThrow as jest.Mock)
-      .mockResolvedValueOnce(statsPayload)
-      .mockResolvedValueOnce({ ok: true, granted: ['configs.cache.manage'] })
-      .mockResolvedValueOnce({
-        stats: statsPayload,
-        deleted: 1,
-      })
+    mockManageEnabled()
+    ;(readApiResultOrThrow as jest.Mock).mockResolvedValueOnce({
+      stats: statsPayload,
+      deleted: 1,
+    })
 
     renderWithProviders(<CachePanel />, { dict })
 
@@ -105,17 +122,13 @@ describe('CachePanel', () => {
       expect(screen.getByText('users.list')).toBeInTheDocument()
     })
 
-    // Click purge segment button
     fireEvent.click(screen.getByRole('button', { name: 'Purge segment' }))
 
-    // Wait for confirm dialog to appear (dialog title)
     await waitFor(() => {
       expect(screen.getByText('Confirm segment purge?')).toBeInTheDocument()
     })
 
-    // Click confirm button by text (inside dialog)
-    const confirmButtons = screen.getAllByText('Confirm')
-    fireEvent.click(confirmButtons[confirmButtons.length - 1])
+    await confirmDialog()
 
     await waitFor(() => {
       expect(flash).toHaveBeenCalledWith('Purged users.list (1)', 'success')
@@ -130,5 +143,86 @@ describe('CachePanel', () => {
     await waitFor(() => {
       expect(screen.getByText('boom')).toBeInTheDocument()
     })
+
+    // The retry control is a non-submit action and MUST declare type="button".
+    expect(screen.getByRole('button', { name: 'Retry' })).toHaveAttribute('type', 'button')
+  })
+
+  it('routes the purge-all write through the guarded mutation runner', async () => {
+    mockManageEnabled()
+    ;(readApiResultOrThrow as jest.Mock).mockResolvedValueOnce({ stats: statsPayload })
+
+    renderWithProviders(<CachePanel />, { dict })
+
+    await waitFor(() => {
+      expect(screen.getByText('users.list')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Purge all cache' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Confirm all purge?')).toBeInTheDocument()
+    })
+
+    await confirmDialog()
+
+    await waitFor(() => {
+      expect(runMutationMock).toHaveBeenCalledTimes(1)
+    })
+    expect(runMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          resourceKind: 'configs.cache',
+          retryLastMutation: expect.any(Function),
+        }),
+        mutationPayload: { action: 'purgeAll' },
+      }),
+    )
+  })
+
+  it('routes the purge-segment write through the guarded mutation runner', async () => {
+    mockManageEnabled()
+    ;(readApiResultOrThrow as jest.Mock).mockResolvedValueOnce({ stats: statsPayload, deleted: 1 })
+
+    renderWithProviders(<CachePanel />, { dict })
+
+    await waitFor(() => {
+      expect(screen.getByText('users.list')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Purge segment' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Confirm segment purge?')).toBeInTheDocument()
+    })
+
+    await confirmDialog()
+
+    await waitFor(() => {
+      expect(runMutationMock).toHaveBeenCalledTimes(1)
+    })
+    expect(runMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          resourceKind: 'configs.cache',
+          retryLastMutation: expect.any(Function),
+        }),
+        mutationPayload: { action: 'purgeSegment', segment: 'users.list' },
+      }),
+    )
+  })
+
+  it('declares explicit type="button" on the non-submit action buttons', async () => {
+    mockManageEnabled()
+
+    renderWithProviders(<CachePanel />, { dict })
+
+    await waitFor(() => {
+      expect(screen.getByText('users.list')).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('button', { name: 'Refresh' })).toHaveAttribute('type', 'button')
+    expect(screen.getByRole('button', { name: 'Purge all cache' })).toHaveAttribute('type', 'button')
+    expect(screen.getByRole('button', { name: 'Purge segment' })).toHaveAttribute('type', 'button')
   })
 })


### PR DESCRIPTION
## Summary

`CachePanel` sent its cache-purge writes (`purgeAll`, `purgeSegment`) directly through `readApiResultOrThrow`, bypassing the backend UI mutation-guard path that `packages/ui/src/backend/AGENTS.md` mandates for every non-`CrudForm` write — so global mutation injections, conflict handling, and scoped headers never ran. The same panel rendered several non-submit `Button`s without an explicit `type="button"`, violating the backend button contract. This routes both writes through `useGuardedMutation(...).runMutation(...)`, adds the missing button types, and (per the issue's follow-up question) wires the custom-write mutation-guard contract on the `POST /api/configs/cache` route as `packages/core/AGENTS.md` requires.

## Changes

- `packages/core/src/modules/configs/components/CachePanel.tsx`: wrap `handlePurgeAll` and `handlePurgeSegment` POSTs in `runMutation({ operation, context, mutationPayload })` (contextId `configs-cache-panel`, resourceKind `configs.cache`, includes `retryLastMutation`); the throwing `readApiResultOrThrow` call stays inside `operation`, and the existing try/catch/flash is unchanged. Add explicit `type="button"` to the Retry, Refresh, Purge-all, and Purge-segment buttons.
- `packages/core/src/modules/configs/api/cache/route.ts`: wire the mutation-guard contract via `bridgeLegacyGuard` + `runMutationGuards` (non-deprecated registry API, `operation: 'delete'`, resourceKind `configs.cache`). The default OSS optimistic-lock guard short-circuits for a header-less cache purge, so the route's response shapes and the empty-segment→400 are preserved exactly.
- `packages/core/src/modules/configs/components/__tests__/CachePanel.test.tsx`: add regression tests asserting both writes route through `runMutation` with the correct context/payload and that the non-submit buttons declare `type="button"`.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — bug fix bringing an existing component/route into compliance with the documented UI and mutation-guard contracts (part of the per-module guarded-mutation remediation campaign).

## Testing

- `yarn workspace @open-mercato/core test CachePanel` — 6/6 pass (the new guarded-mutation routing + button-type cases fail before the fix, pass after)
- `yarn workspace @open-mercato/core test configs` — 44/44 pass
- `tsc --noEmit` (core) — clean
- `yarn build:packages` — 21/21 (core rebuilt clean)
- `yarn i18n:check-sync` — all locales in sync
- Server route is a verified no-op pass-through for header-less purges, so existing integration tests TC-CONF-003 (purge all), TC-CONF-004 (purge segment incl. empty-segment→400), and TC-CONF-005 (RBAC) keep their behavior.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No new user-facing strings — reused existing `configs.cache.*` and `ui.forms.flash.saveBlocked` keys.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — The client guarded-mutation routing is covered by the jsdom unit test (the campaign's canonical pattern, as in sibling fixes); the server route's externally observable behavior is unchanged and already covered by the existing TC-CONF-003/004/005 integration specs, so no new integration test is required.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A, contract-compliance bug fix.
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — single-module bug fix shipping with tests; the API-route change is additive and behavior-preserving.)
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. — `skip-qa`: internal admin cache-settings panel, no observable UX change, fully unit-tested, server behavior preserved under existing integration tests.

### Design System Compliance
- [x] No hardcoded status colors — *this change introduces none*; it adds `type="button"` to existing buttons. (A pre-existing hardcoded-red error box on an untouched line is flagged separately, out of scope.)
- [x] No arbitrary text sizes — none introduced.
- [x] Empty state handled for list/data pages — N/A (unchanged; panel already handles empty/loading/error states).
- [x] Loading state handled for async pages — unchanged (existing `Spinner`/loading state preserved).
- [x] `aria-label` on all icon-only buttons — N/A (no icon-only buttons; all touched buttons are text buttons).
- [x] Uses existing DS components — yes (`Button` primitive; no custom replacements added).

## Linked issues

Fixes #3186

🤖 Generated with [Claude Code](https://claude.com/claude-code)
