### PR TITLE
fix(configs): make cache manage UI gating wildcard-aware (#3187)

### DIFF
--- a/packages/core/src/modules/configs/components/CachePanel.tsx
+++ b/packages/core/src/modules/configs/components/CachePanel.tsx
@@ -7,6 +7,9 @@ import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
+import { hasFeature } from '@open-mercato/shared/security/features'
+
+const MANAGE_FEATURE = 'configs.cache.manage'
 
 const API_PATH = '/api/configs/cache'
 
@@ -68,7 +71,7 @@ export function CachePanel() {
           {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ features: ['configs.cache.manage'] }),
+            body: JSON.stringify({ features: [MANAGE_FEATURE] }),
           },
           {
             errorMessage: t('configs.cache.loadError', 'Failed to load cache statistics.'),
@@ -79,8 +82,8 @@ export function CachePanel() {
         const granted = Array.isArray(payload?.granted)
           ? (payload.granted as unknown[]).filter((feature) => typeof feature === 'string') as string[]
           : []
-        const hasFeature = payload?.ok === true || granted.includes('configs.cache.manage')
-        setCanManage(hasFeature)
+        const canManageFeature = payload?.ok === true || hasFeature(granted, MANAGE_FEATURE)
+        setCanManage(canManageFeature)
       } catch {
         if (!cancelled) setCanManage(false)
       } finally {

--- a/packages/core/src/modules/configs/components/__tests__/CachePanel.test.tsx
+++ b/packages/core/src/modules/configs/components/__tests__/CachePanel.test.tsx
@@ -4,7 +4,7 @@
 
 import '@testing-library/jest-dom'
 import * as React from 'react'
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { CachePanel } from '../CachePanel'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
@@ -88,6 +88,46 @@ describe('CachePanel', () => {
       expect(screen.getByText('users.list')).toBeInTheDocument()
     })
     expect(screen.getByRole('button', { name: 'Purge all cache' })).toBeInTheDocument()
+  })
+
+  // `ok: false` is a synthetic shape that isolates the raw-`granted` fallback branch.
+  // The real /api/auth/feature-check returns ok:true for a `*`/`configs.*` holder, but the
+  // fallback must still be wildcard-aware so the manage controls are never hidden by an exact check.
+  it.each(['configs.cache.manage', 'configs.*', '*'])(
+    'keeps manage controls visible for the wildcard-equivalent grant %s on the fallback path',
+    async (grant) => {
+      ;(readApiResultOrThrow as jest.Mock)
+        .mockResolvedValueOnce(statsPayload) // stats
+        .mockResolvedValueOnce({ ok: false, granted: [grant] }) // feature check fallback path
+
+      renderWithProviders(<CachePanel />, { dict })
+
+      await waitFor(() => {
+        expect(screen.getByText('users.list')).toBeInTheDocument()
+      })
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Purge all cache' })).toBeInTheDocument()
+      })
+    },
+  )
+
+  it('hides manage controls when only an unrelated grant is present on the fallback path', async () => {
+    ;(readApiResultOrThrow as jest.Mock)
+      .mockResolvedValueOnce(statsPayload) // stats
+      .mockResolvedValueOnce({ ok: false, granted: ['unrelated_module.*'] }) // feature check fallback path
+
+    renderWithProviders(<CachePanel />, { dict })
+
+    await waitFor(() => {
+      expect(screen.getByText('users.list')).toBeInTheDocument()
+    })
+    await waitFor(() => {
+      expect(readApiResultOrThrow).toHaveBeenCalledTimes(2)
+    })
+    await act(async () => {})
+
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Purge all cache' })).not.toBeInTheDocument()
   })
 
   it('purges a segment when user confirms', async () => {


### PR DESCRIPTION
## Summary

`CachePanel`'s cache-manage permission gate fell back to an exact-string check —
`granted.includes('configs.cache.manage')` — against the raw feature array from
`/api/auth/feature-check`. Open Mercato ACL grants support wildcards (`configs.*`, `*`),
and the core/ui/shared AGENTS.md contracts forbid exact checks against raw feature arrays
when wildcard grants apply. As a result, a user with a wildcard grant could have the cache
management controls hidden whenever the gate took the fallback path. The server route still
enforces `configs.cache.manage`, so this is a UI-visibility bug, not a privilege escalation.

This makes the fallback wildcard-aware by using the shared `hasFeature` matcher.

## Changes

- `CachePanel.tsx`: import `hasFeature` from `@open-mercato/shared/security/features`; replace
  `granted.includes('configs.cache.manage')` with `hasFeature(granted, MANAGE_FEATURE)`; extract
  the feature id into a `MANAGE_FEATURE` constant shared by the feature-check request and the gate.
- `CachePanel.test.tsx`: add a parameterized test covering `configs.cache.manage`, `configs.*`,
  and `*` (manage controls stay visible on the fallback path) plus a negative guard that an
  unrelated wildcard grant keeps the controls hidden.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — isolated bug fix to an existing component gate.

## Testing

- `yarn workspace @open-mercato/core test -- --testPathPattern CachePanel` — 7 passed (the two
  wildcard cases are red before the fix, green after).
- `yarn workspace @open-mercato/core test -- --testPathPattern modules/configs` — 40 passed.
- `yarn typecheck` — 21/21 turbo tasks successful.
- `yarn workspace @open-mercato/core build` — built successfully.
- `yarn i18n:check-sync` — all 4 locales in sync (no new strings).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no new strings, schema, or generated files.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Not required: the defect is not reproducible through the live `/api/auth/feature-check` endpoint (the server returns `ok:true` for wildcard holders, masking the fallback branch), so it is only observable via the added render tests, which pin the exact gate behavior.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A, no spec.
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-low` — UI-only gate, no contract/schema/auth-server change, inherited from the issue.)
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. — `skip-qa`: admin-only gating change, `risk-low`, not manually reproducible (server already returns `ok:true` for wildcard holders), fully covered by deterministic render tests.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no DS-affecting markup changed (only the permission-gate boolean).
- [x] No arbitrary text sizes — N/A, no markup changed.
- [x] Empty state handled for list/data pages — N/A, no UI structure changed.
- [x] Loading state handled for async pages — N/A, unchanged.
- [x] `aria-label` on all icon-only buttons — N/A, no buttons added/changed.
- [x] Uses existing DS components — N/A, no components added/changed.

## Linked issues

Fixes #3187
