### PR TITLE
fix(catalog): replace raw controls and hardcoded status colors in catalog injection widgets (#3181)

### DIFF
--- a/packages/core/src/modules/catalog/backend/catalog/products/MerchandisingAssistantSheet.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/MerchandisingAssistantSheet.tsx
@@ -428,12 +428,13 @@ export function MerchandisingAssistantSheet({
               </div>
               <div className="flex flex-col gap-0.5">
                 {agents.map((agent) => (
-                  <button
+                  <Button
                     key={agent.id}
                     type="button"
+                    variant="ghost"
                     onClick={() => handleSelectAgent(agent.id)}
                     data-ai-merchandising-agent-option={agent.id}
-                    className="flex items-start gap-2 rounded-sm px-2 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none"
+                    className="h-auto w-full items-start justify-start gap-2 whitespace-normal rounded-sm px-2 py-2 text-left text-sm font-normal"
                   >
                     <span className="mt-0.5 inline-flex size-6 items-center justify-center rounded-full bg-secondary text-secondary-foreground">
                       {agent.icon}
@@ -444,7 +445,7 @@ export function MerchandisingAssistantSheet({
                         {agent.description}
                       </span>
                     </span>
-                  </button>
+                  </Button>
                 ))}
               </div>
             </PopoverContent>

--- a/packages/core/src/modules/catalog/widgets/injection/product-seo/__tests__/widget.client.test.tsx
+++ b/packages/core/src/modules/catalog/widgets/injection/product-seo/__tests__/widget.client.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ *
+ * #3181 — The Product SEO injection widget must render its status states via
+ * shared design-system primitives (StatusBadge / Alert) and DS status tokens,
+ * never hardcoded Tailwind status colors (`text-red-*`, `bg-amber-*`,
+ * `bg-emerald-*`, ...). These assertions fail against the pre-fix widget that
+ * applied raw status color classes and custom pills.
+ */
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import ProductSeoWidget from '../widget.client'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback: string, vars?: Record<string, unknown>) => {
+    if (!fallback) return _key
+    if (!vars) return fallback
+    return fallback.replace(/\{\{(\w+)\}\}/g, (_match, name) =>
+      name in vars ? String((vars as Record<string, unknown>)[name]) : `{{${name}}}`,
+    )
+  },
+}))
+
+const FORBIDDEN_STATUS_CLASSES = [
+  'text-red-600',
+  'bg-red-50',
+  'border-red-200',
+  'text-amber-600',
+  'bg-amber-50',
+  'border-amber-200',
+  'text-amber-700',
+  'text-amber-900',
+  'text-green-600',
+  'bg-green-50',
+  'border-green-200',
+  'bg-emerald-50',
+  'text-emerald-700',
+  'text-emerald-800',
+  'border-emerald-200',
+]
+
+function renderWidget(data: { title?: string | null; name?: string | null; description?: string | null }) {
+  return render(<ProductSeoWidget context={{}} data={data} />)
+}
+
+describe('ProductSeoWidget — DS token compliance (#3181)', () => {
+  it('renders the needs-attention state without hardcoded status colors', () => {
+    const { container } = renderWidget({ title: '', description: '' })
+    const html = container.innerHTML
+    for (const cls of FORBIDDEN_STATUS_CLASSES) {
+      expect(html).not.toContain(cls)
+    }
+  })
+
+  it('renders the ready/good state without hardcoded status colors', () => {
+    const { container } = renderWidget({
+      title: 'A perfectly good product title',
+      description: 'A sufficiently long product description for good SEO ranking quality.',
+    })
+    const html = container.innerHTML
+    for (const cls of FORBIDDEN_STATUS_CLASSES) {
+      expect(html).not.toContain(cls)
+    }
+  })
+
+  it('drives the score indicators through shared DS status primitives (Badge tokens)', () => {
+    const { container } = renderWidget({ title: '', description: '' })
+    const badges = container.querySelectorAll('[data-slot="badge"]')
+    expect(badges.length).toBeGreaterThan(0)
+    expect(container.innerHTML).toContain('bg-status-error-bg')
+    expect(container.innerHTML).toContain('bg-status-warning-bg')
+  })
+
+  it('preserves the human-readable status text', () => {
+    const { getAllByText } = renderWidget({ title: '', description: '' })
+    expect(getAllByText('Missing').length).toBeGreaterThan(0)
+    expect(getAllByText('Needs attention').length).toBeGreaterThan(0)
+  })
+})

--- a/packages/core/src/modules/catalog/widgets/injection/product-seo/widget.client.tsx
+++ b/packages/core/src/modules/catalog/widgets/injection/product-seo/widget.client.tsx
@@ -3,6 +3,8 @@ import * as React from 'react'
 import type { InjectionWidgetComponentProps } from '@open-mercato/shared/modules/widgets/injection'
 import { subscribeProductSeoValidation } from './state'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { StatusBadge, type StatusBadgeVariant } from '@open-mercato/ui/primitives/status-badge'
+import { Alert } from '@open-mercato/ui/primitives/alert'
 
 type SeoData = {
   title?: string | null
@@ -13,6 +15,8 @@ type SeoData = {
 type ValidationState = { ok: boolean; issues: string[]; message?: string }
 
 type IssueKey = 'addTitle' | 'titleTooShort' | 'titleTooLong' | 'addDescription' | 'descriptionTooShort'
+
+type SeoScore = { text: string; variant: StatusBadgeVariant }
 
 function computeIssueKeys(title: string, description: string): IssueKey[] {
   const issues: IssueKey[] = []
@@ -51,27 +55,27 @@ export default function ProductSeoWidget({ data }: InjectionWidgetComponentProps
     })
   }, [])
 
-  const titleScore = React.useMemo(() => {
-    if (!title) return { text: t('catalog.products.create.seoWidget.missing', 'Missing'), color: 'text-red-600', bg: 'bg-red-50', border: 'border-red-200' }
-    if (title.length < 10) return { text: t('catalog.products.create.seoWidget.tooShort', 'Too short'), color: 'text-amber-600', bg: 'bg-amber-50', border: 'border-amber-200' }
-    if (title.length > 60) return { text: t('catalog.products.create.seoWidget.tooLong', 'Too long'), color: 'text-amber-600', bg: 'bg-amber-50', border: 'border-amber-200' }
-    return { text: t('catalog.products.create.seoWidget.good', 'Good'), color: 'text-green-600', bg: 'bg-green-50', border: 'border-green-200' }
+  const titleScore = React.useMemo<SeoScore>(() => {
+    if (!title) return { text: t('catalog.products.create.seoWidget.missing', 'Missing'), variant: 'error' }
+    if (title.length < 10) return { text: t('catalog.products.create.seoWidget.tooShort', 'Too short'), variant: 'warning' }
+    if (title.length > 60) return { text: t('catalog.products.create.seoWidget.tooLong', 'Too long'), variant: 'warning' }
+    return { text: t('catalog.products.create.seoWidget.good', 'Good'), variant: 'success' }
   }, [title, t])
 
-  const descScore = React.useMemo(() => {
-    if (!description) return { text: t('catalog.products.create.seoWidget.missing', 'Missing'), color: 'text-red-600', bg: 'bg-red-50', border: 'border-red-200' }
-    if (description.length < 50) return { text: t('catalog.products.create.seoWidget.tooShort', 'Too short'), color: 'text-amber-600', bg: 'bg-amber-50', border: 'border-amber-200' }
-    return { text: t('catalog.products.create.seoWidget.good', 'Good'), color: 'text-green-600', bg: 'bg-green-50', border: 'border-green-200' }
+  const descScore = React.useMemo<SeoScore>(() => {
+    if (!description) return { text: t('catalog.products.create.seoWidget.missing', 'Missing'), variant: 'error' }
+    if (description.length < 50) return { text: t('catalog.products.create.seoWidget.tooShort', 'Too short'), variant: 'warning' }
+    return { text: t('catalog.products.create.seoWidget.good', 'Good'), variant: 'success' }
   }, [description, t])
 
   const statusBadge = validation.ok ? (
-    <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 border border-emerald-200">
+    <StatusBadge variant="success">
       {t('catalog.products.create.seoWidget.ready', 'Ready')}
-    </span>
+    </StatusBadge>
   ) : (
-    <span className="rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 border border-amber-200">
+    <StatusBadge variant="warning">
       {t('catalog.products.create.seoWidget.needsAttention', 'Needs attention')}
-    </span>
+    </StatusBadge>
   )
 
   const translateIssue = (issueKey: string): string => {
@@ -89,7 +93,13 @@ export default function ProductSeoWidget({ data }: InjectionWidgetComponentProps
       </div>
 
       {validation.message || validation.issues.length ? (
-        <div className={`rounded-md border p-3 text-xs ${validation.ok ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-amber-200 bg-amber-50 text-amber-900'}`}>
+        <Alert
+          status={validation.ok ? 'success' : 'warning'}
+          style="lighter"
+          size="sm"
+          showIcon={false}
+          className="text-xs"
+        >
           {validation.message ? <div className="font-medium">{validation.message}</div> : null}
           {validation.issues.length ? (
             <ul className="ml-4 list-disc space-y-1 pt-1">
@@ -98,17 +108,17 @@ export default function ProductSeoWidget({ data }: InjectionWidgetComponentProps
               ))}
             </ul>
           ) : null}
-        </div>
+        </Alert>
       ) : null}
 
       <div className="rounded border bg-muted/30 p-3 text-sm">
         <div className="flex items-center justify-between">
           <span className="text-muted-foreground">{t('catalog.products.create.seoWidget.titleLabel', 'Title ({{count}} chars)', { count: title.length })}</span>
-          <span className={`font-medium ${titleScore.color}`}>{titleScore.text}</span>
+          <StatusBadge variant={titleScore.variant}>{titleScore.text}</StatusBadge>
         </div>
         <div className="mt-2 flex items-center justify-between">
           <span className="text-muted-foreground">{t('catalog.products.create.seoWidget.descriptionLabel', 'Description ({{count}} chars)', { count: description.length })}</span>
-          <span className={`font-medium ${descScore.color}`}>{descScore.text}</span>
+          <StatusBadge variant={descScore.variant}>{descScore.text}</StatusBadge>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Two catalog injection/widget UI surfaces drifted from the shared design-system contract: the Product SEO injection widget hardcoded red/amber/green Tailwind status colors and rendered custom status pills, and the merchandising agent-picker popover rendered each option as a raw `<button>`. This replaces both with DS-backed primitives while preserving all behavior, i18n keys, widget injection surfaces, and test data attributes.

## Changes

- `catalog/widgets/injection/product-seo/widget.client.tsx`: map SEO score states to a `StatusBadgeVariant` (`missing→error`, `tooShort`/`tooLong→warning`, `good→success`) rendered via `StatusBadge`; render the "Ready/Needs attention" header pill via `StatusBadge`; render the validation block via `Alert` (`status` success/warning, `style="lighter"`). Removes every hardcoded `text-red-*`/`bg-amber-*`/`bg-emerald-*`/`text-green-*` class. No i18n keys changed.
- `catalog/backend/catalog/products/MerchandisingAssistantSheet.tsx`: replace the raw `<button>` agent-picker options with `<Button variant="ghost">`, preserving the click handler, keyboard focus, and the `data-ai-merchandising-agent-option` attribute.
- `catalog/widgets/injection/product-seo/__tests__/widget.client.test.tsx` (new): regression test asserting the rendered SEO widget contains no hardcoded status colors and uses DS status-token primitives across both the needs-attention and ready states.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — isolated design-system token/primitive compliance fix.

## Testing

- `yarn workspace @open-mercato/core test -- "product-seo"` — new widget test red → green (4 tests).
- `yarn workspace @open-mercato/core test -- "catalog"` — 53 suites / 606 tests pass (incl. existing merchandising-assistant-trigger tests, unchanged).
- `tsc --noEmit -p packages/core/tsconfig.json` — exit 0, no type errors.
- `yarn i18n:check-sync` — all translation files in sync.
- `yarn workspace @open-mercato/core build` — built successfully.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- none required: all existing i18n keys preserved, no generator-discovered files changed -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- Not required: pure component-level DS rendering change; no API route or user flow behavior changed. Covered by a component render test. -->
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — minor change -->
- [x] Priority set: this PR carries exactly one `priority-*` label. <!-- priority-low (cosmetic DS cleanup) -->
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. <!-- risk-low (single-module, two UI files, ships with tests, no contract/schema/auth surface) -->
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. <!-- needs-qa (visible admin UI change) -->

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) <!-- N/A — not a list/data page -->
- [x] Loading state handled for async pages <!-- N/A — widget derives state synchronously from props -->
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) <!-- N/A — no new icon-only buttons; picker option Button has a visible text label -->
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3181
