### PR TITLE
perf(catalog): parallelize product-list filter prequeries (#3179)

### DIFF
--- a/packages/core/src/modules/catalog/api/__tests__/products.route.test.ts
+++ b/packages/core/src/modules/catalog/api/__tests__/products.route.test.ts
@@ -86,6 +86,67 @@ describe('catalog products route helpers', () => {
     expect((filters as any).custom).toEqual({ $eq: 'value' })
   })
 
+  it('dispatches independent filter prequeries concurrently and intersects them (issue #3179)', async () => {
+    const expectedConcurrent = 4
+    let dispatched = 0
+    let releaseBarrier: () => void = () => {}
+    const barrier = new Promise<void>((resolve) => {
+      releaseBarrier = resolve
+    })
+
+    const rowsForWhere = (where: any) => {
+      if (where?.$or) return [{ id: 'p1' }, { id: 'p2' }, { id: 'p3' }]
+      if (where?.channelId) return [{ id: 'o2', product: 'p2' }, { id: 'o3', product: 'p3' }, { id: 'o4', product: 'p4' }]
+      if (where?.category) return [{ id: 'a2', product: 'p2' }, { id: 'a3', product: 'p3' }]
+      if (where?.tag) return [{ id: 't3', product: { id: 'p3' } }]
+      return []
+    }
+
+    // Each query parks on a shared barrier that only releases once every
+    // independent prequery has been dispatched. Sequential awaits can never
+    // reach that count, so this resolves only when they run concurrently.
+    const find = jest.fn().mockImplementation(async (_entity: unknown, where: any) => {
+      dispatched += 1
+      if (dispatched >= expectedConcurrent) releaseBarrier()
+      await barrier
+      return rowsForWhere(where)
+    })
+    const forkedEm = { find }
+    const em = { fork: () => forkedEm }
+    const container = { resolve: jest.fn().mockReturnValue(em) }
+    ;(buildCustomFieldFiltersFromQuery as jest.Mock).mockResolvedValueOnce({})
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const guard = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error('filter prequeries were awaited sequentially, not dispatched concurrently')),
+        1000,
+      )
+    })
+
+    try {
+      const filters = await Promise.race([
+        buildProductFilters(
+          {
+            search: 'widget',
+            channelIds: '11111111-1111-4111-8111-111111111111',
+            categoryIds: '22222222-2222-4222-8222-222222222222',
+            tagIds: '33333333-3333-4333-8333-333333333333',
+          } as any,
+          { container, auth: { tenantId: 'tenant-1' } } as any,
+        ),
+        guard,
+      ])
+
+      expect(find).toHaveBeenCalledTimes(expectedConcurrent)
+      // search {p1,p2,p3} ∩ channel {p2,p3,p4} ∩ category {p2,p3} ∩ tag {p3} = {p3}
+      expect(filters.id).toEqual({ $eq: 'p3' })
+    } finally {
+      if (timer) clearTimeout(timer)
+      releaseBarrier()
+    }
+  })
+
   it('falls back to sentinel id when restricted products exclude the requested record', async () => {
     const forkedEm = {
       find: jest.fn().mockResolvedValue([{ product: 'prod-allowed' }]),

--- a/packages/core/src/modules/catalog/api/products/route.ts
+++ b/packages/core/src/modules/catalog/api/products/route.ts
@@ -184,7 +184,24 @@ export async function buildProductFilters(
     tenantId: ctx.auth?.tenantId ?? null,
   };
   const term = sanitizeSearchTerm(query.search);
-  if (term) {
+  const channelFilterIds = parseIdList(query.channelIds);
+  const categoryFilterIds = parseIdList(query.categoryIds);
+  const tagFilterIds = parseIdList(query.tagIds);
+  const customFieldset =
+    typeof query.customFieldset === "string" &&
+    query.customFieldset.trim().length
+      ? query.customFieldset.trim()
+      : null;
+  const tenantId = ctx.auth?.tenantId ?? null;
+
+  // These prequeries are independent — each only feeds the final product-id
+  // intersection, none depends on another's result — so dispatch them together
+  // instead of awaiting one after another (#3179). A task returns null when its
+  // filter is inactive (intersection skipped) or the matched product-id list
+  // (possibly empty) when active, preserving the "active filter with no matches
+  // => empty result" behavior.
+  const searchTask = async (): Promise<string[] | null> => {
+    if (!term) return null;
     const like = `%${escapeLikePattern(term)}%`;
     const searchMatches = await findWithDecryption(
       em,
@@ -203,14 +220,13 @@ export async function buildProductFilters(
       { fields: ["id"] },
       scope,
     );
-    const productIds = searchMatches
+    return searchMatches
       .map((product) => product.id)
       .filter((id): id is string => typeof id === "string" && id.length > 0);
-    intersectProductIds(productIds);
-  }
+  };
 
-  const channelFilterIds = parseIdList(query.channelIds);
-  if (channelFilterIds.length) {
+  const channelTask = async (): Promise<string[] | null> => {
+    if (!channelFilterIds.length) return null;
     const offerRows = await findWithDecryption(
       em,
       CatalogOffer,
@@ -222,18 +238,17 @@ export async function buildProductFilters(
       { fields: ["id", "product"] },
       scope,
     );
-    const productIds = offerRows
+    return offerRows
       .map((offer) =>
         typeof offer.product === "string"
           ? offer.product
           : (offer.product?.id ?? null),
       )
       .filter((id): id is string => !!id);
-    intersectProductIds(productIds);
-  }
+  };
 
-  const categoryFilterIds = parseIdList(query.categoryIds);
-  if (categoryFilterIds.length) {
+  const categoryTask = async (): Promise<string[] | null> => {
+    if (!categoryFilterIds.length) return null;
     const assignments = await findWithDecryption(
       em,
       CatalogProductCategoryAssignment,
@@ -241,18 +256,17 @@ export async function buildProductFilters(
       { fields: ["id", "product"] },
       scope,
     );
-    const productIds = assignments
+    return assignments
       .map((assignment) =>
         typeof assignment.product === "string"
           ? assignment.product
           : (assignment.product?.id ?? null),
       )
       .filter((id): id is string => !!id);
-    intersectProductIds(productIds);
-  }
+  };
 
-  const tagFilterIds = parseIdList(query.tagIds);
-  if (tagFilterIds.length) {
+  const tagTask = async (): Promise<string[] | null> => {
+    if (!tagFilterIds.length) return null;
     const assignments = await findWithDecryption(
       em,
       CatalogProductTagAssignment,
@@ -260,36 +274,49 @@ export async function buildProductFilters(
       { fields: ["id", "product"] },
       scope,
     );
-    const productIds = assignments
+    return assignments
       .map((assignment) =>
         typeof assignment.product === "string"
           ? assignment.product
           : (assignment.product?.id ?? null),
       )
       .filter((id): id is string => !!id);
-    intersectProductIds(productIds);
+  };
+
+  const customFieldTask = async (): Promise<Record<string, unknown>> => {
+    try {
+      const scopedEm = ctx.container.resolve("em") as EntityManager;
+      return await buildCustomFieldFiltersFromQuery({
+        entityIds: [E.catalog.catalog_product],
+        query,
+        em: scopedEm,
+        tenantId,
+        fieldset: customFieldset ?? undefined,
+      });
+    } catch (err) {
+      // Custom field filter parsing may fail for non-existent or misconfigured fields.
+      // Fall back to base filters to avoid blocking the product listing.
+      if (process.env.NODE_ENV === 'development') console.warn('[catalog:products] custom field filter error', err);
+      return {};
+    }
+  };
+
+  const [searchIds, channelIds, categoryIds, tagIds, cfFilters] =
+    await Promise.all([
+      searchTask(),
+      channelTask(),
+      categoryTask(),
+      tagTask(),
+      customFieldTask(),
+    ]);
+
+  // Apply intersections in the original order; intersection is commutative, so
+  // the result is identical to the previous sequential pass. An empty array is
+  // still intersected (active filter that matched nothing); null is skipped.
+  for (const productIds of [searchIds, channelIds, categoryIds, tagIds]) {
+    if (productIds) intersectProductIds(productIds);
   }
-  const customFieldset =
-    typeof query.customFieldset === "string" &&
-    query.customFieldset.trim().length
-      ? query.customFieldset.trim()
-      : null;
-  const tenantId = ctx.auth?.tenantId ?? null;
-  try {
-    const scopedEm = ctx.container.resolve("em") as EntityManager;
-    const cfFilters = await buildCustomFieldFiltersFromQuery({
-      entityIds: [E.catalog.catalog_product],
-      query,
-      em: scopedEm,
-      tenantId,
-      fieldset: customFieldset ?? undefined,
-    });
-    Object.assign(filters, cfFilters);
-  } catch (err) {
-    // Custom field filter parsing may fail for non-existent or misconfigured fields.
-    // Fall back to base filters to avoid blocking the product listing.
-    if (process.env.NODE_ENV === 'development') console.warn('[catalog:products] custom field filter error', err);
-  }
+  Object.assign(filters, cfFilters);
   applyRestrictedProducts();
   return filters;
 }


### PR DESCRIPTION
## Summary

`GET /api/catalog/products` ran a pre-list waterfall: `buildProductFilters` awaited the
search-match, channel-offer, category-assignment, tag-assignment, and custom-field
prequeries one after another, even though none depends on another's result — each only
contributes to the final product-id intersection. This change dispatches the independent
prequeries together with `Promise.all`, cutting the pre-list latency from the sum of the
queries to the slowest single one. It is a behavior-preserving refactor (separate from
#2230, which tracks the `decorateProductsAfterList` afterList waterfall).

## Changes

- `packages/core/src/modules/catalog/api/products/route.ts`: refactor `buildProductFilters`
  so the four product-id prequeries plus the custom-field build run via `Promise.all`.
  Each task returns `null` when its filter is inactive (intersection skipped) or the matched
  product-id list — possibly empty — when active, preserving the "active filter with no
  matches ⇒ empty result" semantic. Intersections are then applied in the original order
  (intersection is commutative, so the result is identical to the prior sequential pass).
  Tenant/organization scoping, the custom-field parsing try/catch fallback (still on the
  non-forked `scopedEm`), and the `applyRestrictedProducts` sentinel behavior are unchanged.
- `packages/core/src/modules/catalog/api/__tests__/products.route.test.ts`: add a focused
  combined-filter test that proves the prequeries are dispatched concurrently (a shared
  barrier that only releases once all four queries are in flight — sequential awaits
  deadlock) and that the four-way intersection still collapses to the correct product id.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — behavior-preserving performance refactor scoped to a single function; tracked by issue #3179.

## Testing

- `yarn workspace @open-mercato/core test` — 741 suites / 6067 tests passed (includes the new repro + the existing `buildProductFilters` suite).
- New test red→green: fails on the sequential code with "filter prequeries were awaited sequentially, not dispatched concurrently"; passes after the refactor.
- `yarn typecheck` — all 21 packages pass.
- `yarn i18n:check-sync` — all 4 locales (en/pl/es/de) in sync.
- `yarn build:packages` (after `yarn generate`) + `yarn build:app` — Next.js app builds successfully.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no new strings, schema, or generator-discovered files.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required — behavior-preserving internal refactor with no contract/UI change; the issue asked for focused route/unit coverage, which is added, and the existing product-list endpoint coverage is unchanged.)
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — single-module, behavior-preserving, shipped with tests.)
- [x] QA routing set: `skip-qa` — behavior-preserving backend perf refactor, no UI/contract/schema change, fully covered by unit tests including a combined-filter intersection guard. (Switch to `needs-qa` if you'd prefer a manual smoke of combined product-list filters.)

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI in this change
- [x] No arbitrary text sizes — N/A, no UI in this change
- [x] Empty state handled for list/data pages — N/A, no UI in this change
- [x] Loading state handled for async pages — N/A, no UI in this change
- [x] `aria-label` on all icon-only buttons — N/A, no UI in this change
- [x] Uses existing DS components — N/A, no UI in this change

## Linked issues

Fixes #3179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
