### PR TITLE
perf(customers): parallelize deal detail API enrichment reads (#3175)

### DIFF
--- a/packages/core/src/modules/customers/api/deals/[id]/__tests__/route.parallel.test.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/__tests__/route.parallel.test.ts
@@ -1,0 +1,175 @@
+/** @jest-environment node */
+
+// Regression coverage for issue #3175 (deals slice): the deal detail route must
+// dispatch its independent post-access enrichment reads in parallel instead of
+// awaiting them one after another. The test holds findWithDecryption open until
+// two calls are concurrently in flight; the linked person + company reads can
+// only both be in flight if the route started them concurrently. A safety timer
+// releases the gate so a still-sequential route fails the assertion fast instead
+// of hanging on the jest timeout.
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+const mockLoadCustomFieldValues = jest.fn()
+const mockNormalizeCustomFieldResponse = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+const mockDecryptEntitiesWithFallbackScope = jest.fn()
+
+const mockEm = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  count: jest.fn(),
+}
+
+const mockRbac = {
+  userHasAllFeatures: jest.fn(async () => true),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'rbacService') return mockRbac
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScopeForRequest(args)),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScopeGuard', () => ({
+  isOrganizationReadAccessAllowed: jest.fn(() => true),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn((args: unknown) => mockLoadCustomFieldValues(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/custom-fields/normalize', () => ({
+  normalizeCustomFieldResponse: jest.fn((...args: unknown[]) => mockNormalizeCustomFieldResponse(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/subscriber', () => ({
+  decryptEntitiesWithFallbackScope: jest.fn((...args: unknown[]) => mockDecryptEntitiesWithFallbackScope(...args)),
+}))
+
+jest.mock('../../../../lib/dealStageTransitionTable', () => ({
+  isMissingDealStageTransitionTable: jest.fn(() => false),
+  warnMissingDealStageTransitionTable: jest.fn(),
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    customers: {
+      customer_deal: 'customer_deal',
+    },
+  },
+}), { virtual: true })
+
+const DEAL_ID = '2408107d-0000-4000-8000-000000000020'
+
+function buildDeal() {
+  const createdAt = new Date('2026-04-10T08:00:00.000Z')
+  return {
+    id: DEAL_ID,
+    deletedAt: null,
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    title: 'Acme expansion',
+    description: null,
+    status: 'open',
+    pipelineStage: null,
+    pipelineId: null,
+    pipelineStageId: null,
+    valueAmount: null,
+    valueCurrency: null,
+    probability: null,
+    expectedCloseAt: null,
+    ownerUserId: null,
+    source: null,
+    closureOutcome: null,
+    lossReasonId: null,
+    lossNotes: null,
+    createdAt,
+    updatedAt: createdAt,
+  }
+}
+
+describe('GET /api/customers/deals/[id] — parallel enrichment (issue #3175)', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    mockGetAuthFromRequest.mockReset()
+    mockResolveOrganizationScopeForRequest.mockReset()
+    mockLoadCustomFieldValues.mockReset()
+    mockNormalizeCustomFieldResponse.mockReset()
+    mockFindWithDecryption.mockReset()
+    mockFindOneWithDecryption.mockReset()
+    mockDecryptEntitiesWithFallbackScope.mockReset()
+    mockEm.findOne.mockReset()
+    mockEm.find.mockReset()
+    mockEm.count.mockReset()
+    mockRbac.userHasAllFeatures.mockReset()
+    mockContainer.resolve.mockClear()
+
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1', isApiKey: false, email: null })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({ filterIds: ['org-1'], selectedId: 'org-1', tenantId: 'tenant-1' })
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+    mockLoadCustomFieldValues.mockResolvedValue({})
+    mockNormalizeCustomFieldResponse.mockReturnValue({})
+    mockDecryptEntitiesWithFallbackScope.mockResolvedValue(undefined)
+    // First findOneWithDecryption resolves the deal; later ones (viewer/owner) are null.
+    mockFindOneWithDecryption
+      .mockResolvedValueOnce(buildDeal())
+      .mockResolvedValue(null)
+    mockFindWithDecryption.mockResolvedValue([])
+  })
+
+  it('dispatches the independent person/company link reads concurrently', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    let releaseGate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve
+    })
+
+    // The linked person + company reads both go through findWithDecryption and are
+    // independent of each other. Hold every findWithDecryption open: if the route
+    // awaits them serially only one is ever in flight, so the gate never trips and
+    // the safety timer below releases it, leaving maxInFlight at 1 (assertion fails).
+    mockFindWithDecryption.mockImplementation(async () => {
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      if (maxInFlight >= 2) releaseGate()
+      await gate
+      inFlight -= 1
+      return []
+    })
+    const safety = setTimeout(() => releaseGate(), 1500)
+
+    const { GET } = await import('../route')
+    const response = await GET(
+      new Request(`http://localhost/api/customers/deals/${DEAL_ID}`),
+      { params: { id: DEAL_ID } },
+    )
+    clearTimeout(safety)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.deal.id).toBe(DEAL_ID)
+    expect(maxInFlight).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/core/src/modules/customers/api/deals/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/route.ts
@@ -386,103 +386,119 @@ export async function GET(request: Request, context: { params?: Record<string, u
     tenantId: deal.tenantId ?? auth.tenantId ?? null,
     organizationId: deal.organizationId ?? auth.orgId ?? null,
   }
-  let linkedPersonIds: string[] = []
-  let linkedCompanyIds: string[] = []
-  let people: DealAssociation[] = []
-  let companies: DealAssociation[] = []
-
-  if (liteView) {
-    const personLinkRows = await findWithDecryption(
-      em,
-      CustomerDealPersonLink,
-      { deal: deal.id },
-      { orderBy: { createdAt: 'ASC' } },
-      decryptionScope,
-    )
-    const companyLinkRows = await findWithDecryption(
-      em,
-      CustomerDealCompanyLink,
-      { deal: deal.id },
-      { orderBy: { createdAt: 'ASC' } },
-      decryptionScope,
-    )
-
-    linkedPersonIds = Array.from(
-      new Set(
-        personLinkRows
-          .map((link) => {
-            const personRef = link.person
-            if (!personRef) return null
-            if (typeof personRef === 'string') return personRef
-            const personIdValue = personRef.id
-            return typeof personIdValue === 'string' ? personIdValue : null
-          })
-          .filter((value): value is string => typeof value === 'string' && value.trim().length > 0),
-      ),
-    )
-    linkedCompanyIds = Array.from(
-      new Set(
-        companyLinkRows
-          .map((link) => {
-            const companyRef = link.company
-            if (!companyRef) return null
-            if (typeof companyRef === 'string') return companyRef
-            const companyIdValue = companyRef.id
-            return typeof companyIdValue === 'string' ? companyIdValue : null
-          })
-          .filter((value): value is string => typeof value === 'string' && value.trim().length > 0),
-      ),
-    )
-
-    const previewPeople = linkedPersonIds.length
-      ? await findWithDecryption(
+  // Issue #3175: the reads below only depend on the already-resolved deal +
+  // organization scope + decryption scope, so they are grouped into Promise.all
+  // batches instead of being awaited one after another. True dependencies stay
+  // ordered: preview/decrypt run after their link rows, pipeline reads after the
+  // effective stage is known, and the appearance map / audit fallback after the
+  // pipeline stages load. This mirrors the parallel-read pattern already used
+  // across the customers list/interactions/activities routes.
+  const resolveAssociations = async (): Promise<{
+    people: DealAssociation[]
+    companies: DealAssociation[]
+    linkedPersonIds: string[]
+    linkedCompanyIds: string[]
+  }> => {
+    if (liteView) {
+      const [personLinkRows, companyLinkRows] = await Promise.all([
+        findWithDecryption(
           em,
-          CustomerEntity,
-          { id: { $in: linkedPersonIds.slice(0, 3) } },
-          { populate: ['personProfile'] },
+          CustomerDealPersonLink,
+          { deal: deal.id },
+          { orderBy: { createdAt: 'ASC' } },
           decryptionScope,
-        )
-      : []
-    const previewCompanies = linkedCompanyIds.length
-      ? await findWithDecryption(
+        ),
+        findWithDecryption(
           em,
-          CustomerEntity,
-          { id: { $in: linkedCompanyIds.slice(0, 3) } },
-          { populate: ['companyProfile'] },
+          CustomerDealCompanyLink,
+          { deal: deal.id },
+          { orderBy: { createdAt: 'ASC' } },
           decryptionScope,
-        )
-      : []
-    const previewPeopleMap = new Map(previewPeople.map((entity) => [entity.id, entity]))
-    const previewCompaniesMap = new Map(previewCompanies.map((entity) => [entity.id, entity]))
-    people = linkedPersonIds.slice(0, 3).reduce<DealAssociation[]>((acc, personId) => {
-      const entity = previewPeopleMap.get(personId) ?? null
-      if (!entity || entity.deletedAt) return acc
-      const { label, subtitle } = normalizePersonAssociation(entity)
-      acc.push({ id: entity.id, label, subtitle, kind: 'person' })
-      return acc
-    }, [])
-    companies = linkedCompanyIds.slice(0, 3).reduce<DealAssociation[]>((acc, companyId) => {
-      const entity = previewCompaniesMap.get(companyId) ?? null
-      if (!entity || entity.deletedAt) return acc
-      const { label, subtitle } = normalizeCompanyAssociation(entity)
-      acc.push({ id: entity.id, label, subtitle, kind: 'company' })
-      return acc
-    }, [])
-  } else {
-    const personLinks = await findWithDecryption(
-      em,
-      CustomerDealPersonLink,
-      { deal: deal.id },
-      { populate: ['person', 'person.personProfile'] },
-      decryptionScope,
-    )
-    const companyLinks = await findWithDecryption(
-      em,
-      CustomerDealCompanyLink,
-      { deal: deal.id },
-      { populate: ['company', 'company.companyProfile'] },
-      decryptionScope,
-    )
+        ),
+      ])
+
+      const linkedPersonIds = Array.from(
+        new Set(
+          personLinkRows
+            .map((link) => {
+              const personRef = link.person
+              if (!personRef) return null
+              if (typeof personRef === 'string') return personRef
+              const personIdValue = personRef.id
+              return typeof personIdValue === 'string' ? personIdValue : null
+            })
+            .filter((value): value is string => typeof value === 'string' && value.trim().length > 0),
+        ),
+      )
+      const linkedCompanyIds = Array.from(
+        new Set(
+          companyLinkRows
+            .map((link) => {
+              const companyRef = link.company
+              if (!companyRef) return null
+              if (typeof companyRef === 'string') return companyRef
+              const companyIdValue = companyRef.id
+              return typeof companyIdValue === 'string' ? companyIdValue : null
+            })
+            .filter((value): value is string => typeof value === 'string' && value.trim().length > 0),
+        ),
+      )
+
+      const [previewPeople, previewCompanies] = await Promise.all([
+        linkedPersonIds.length
+          ? findWithDecryption(
+              em,
+              CustomerEntity,
+              { id: { $in: linkedPersonIds.slice(0, 3) } },
+              { populate: ['personProfile'] },
+              decryptionScope,
+            )
+          : [],
+        linkedCompanyIds.length
+          ? findWithDecryption(
+              em,
+              CustomerEntity,
+              { id: { $in: linkedCompanyIds.slice(0, 3) } },
+              { populate: ['companyProfile'] },
+              decryptionScope,
+            )
+          : [],
+      ])
+      const previewPeopleMap = new Map(previewPeople.map((entity) => [entity.id, entity]))
+      const previewCompaniesMap = new Map(previewCompanies.map((entity) => [entity.id, entity]))
+      const people = linkedPersonIds.slice(0, 3).reduce<DealAssociation[]>((acc, personId) => {
+        const entity = previewPeopleMap.get(personId) ?? null
+        if (!entity || entity.deletedAt) return acc
+        const { label, subtitle } = normalizePersonAssociation(entity)
+        acc.push({ id: entity.id, label, subtitle, kind: 'person' })
+        return acc
+      }, [])
+      const companies = linkedCompanyIds.slice(0, 3).reduce<DealAssociation[]>((acc, companyId) => {
+        const entity = previewCompaniesMap.get(companyId) ?? null
+        if (!entity || entity.deletedAt) return acc
+        const { label, subtitle } = normalizeCompanyAssociation(entity)
+        acc.push({ id: entity.id, label, subtitle, kind: 'company' })
+        return acc
+      }, [])
+      return { people, companies, linkedPersonIds, linkedCompanyIds }
+    }
+
+    const [personLinks, companyLinks] = await Promise.all([
+      findWithDecryption(
+        em,
+        CustomerDealPersonLink,
+        { deal: deal.id },
+        { populate: ['person', 'person.personProfile'] },
+        decryptionScope,
+      ),
+      findWithDecryption(
+        em,
+        CustomerDealCompanyLink,
+        { deal: deal.id },
+        { populate: ['company', 'company.companyProfile'] },
+        decryptionScope,
+      ),
+    ])
     const fallbackTenantId = deal.tenantId ?? auth.tenantId ?? null
     const fallbackOrgId = deal.organizationId ?? auth.orgId ?? null
     await decryptEntitiesWithFallbackScope(personLinks, {
@@ -496,7 +512,7 @@ export async function GET(request: Request, context: { params?: Record<string, u
       organizationId: fallbackOrgId,
     })
 
-    people = personLinks.reduce<DealAssociation[]>((acc, link) => {
+    const people = personLinks.reduce<DealAssociation[]>((acc, link) => {
       const entity = link.person as CustomerEntity | null
       if (!entity || entity.deletedAt) return acc
       const { label, subtitle } = normalizePersonAssociation(entity)
@@ -504,103 +520,54 @@ export async function GET(request: Request, context: { params?: Record<string, u
       return acc
     }, [])
 
-    companies = companyLinks.reduce<DealAssociation[]>((acc, link) => {
+    const companies = companyLinks.reduce<DealAssociation[]>((acc, link) => {
       const entity = link.company as CustomerEntity | null
       if (!entity || entity.deletedAt) return acc
       const { label, subtitle } = normalizeCompanyAssociation(entity)
       acc.push({ id: entity.id, label, subtitle, kind: 'company' })
       return acc
     }, [])
-    linkedPersonIds = people.map((entry) => entry.id)
-    linkedCompanyIds = companies.map((entry) => entry.id)
+    return {
+      people,
+      companies,
+      linkedPersonIds: people.map((entry) => entry.id),
+      linkedCompanyIds: companies.map((entry) => entry.id),
+    }
   }
 
-  const customFieldValues = await loadCustomFieldValues({
-    em,
-    entityId: E.customers.customer_deal,
-    recordIds: [deal.id],
-    tenantIdByRecord: { [deal.id]: deal.tenantId ?? null },
-    organizationIdByRecord: { [deal.id]: deal.organizationId ?? null },
-    tenantFallbacks: [deal.tenantId ?? auth.tenantId ?? null].filter((value): value is string => !!value),
-  })
-  const customFields = normalizeCustomFieldResponse(customFieldValues[deal.id]) ?? {}
-
   const viewerUserId = auth.isApiKey ? null : auth.sub ?? null
-  let viewerName: string | null = null
-  let viewerEmail: string | null = auth.email ?? null
-  if (viewerUserId) {
-    const viewerScope = {
-      tenantId: auth.tenantId ?? null,
-      organizationId: auth.orgId ?? null,
+  const resolveViewer = async (): Promise<{ name: string | null; email: string | null }> => {
+    if (!viewerUserId) {
+      return { name: null, email: auth.email ?? null }
     }
     const viewer = await findOneWithDecryption(
       em,
       User,
       { id: viewerUserId, tenantId: auth.tenantId ?? null },
       {},
-      viewerScope,
+      { tenantId: auth.tenantId ?? null, organizationId: auth.orgId ?? null },
     )
-    viewerName = viewer?.name ?? null
-    viewerEmail = viewer?.email ?? viewerEmail ?? null
+    return {
+      name: viewer?.name ?? null,
+      email: viewer?.email ?? auth.email ?? null,
+    }
   }
 
-  const owner = deal.ownerUserId
-    ? await findOneWithDecryption(
-      em,
-      User,
-      { id: deal.ownerUserId, tenantId: deal.tenantId ?? auth.tenantId ?? null },
-      {},
-      decryptionScope,
-    )
-    : null
-  const ownerPayload = owner
-    ? {
-      id: owner.id,
-      name: owner.name ?? owner.email ?? owner.id,
-      email: owner.email ?? '',
-    }
-    : null
+  const resolveOwner = async () =>
+    deal.ownerUserId
+      ? await findOneWithDecryption(
+        em,
+        User,
+        { id: deal.ownerUserId, tenantId: deal.tenantId ?? auth.tenantId ?? null },
+        {},
+        decryptionScope,
+      )
+      : null
 
-  const effectiveStage = includeStages
-    ? await resolveEffectivePipelineStage(em, deal, decryptionScope)
-    : null
-  const effectivePipelineId = deal.pipelineId ?? effectiveStage?.pipelineId ?? null
-  const effectivePipelineStageId = deal.pipelineStageId ?? effectiveStage?.id ?? null
-  const effectivePipelineStageLabel = deal.pipelineStage ?? effectiveStage?.label ?? null
-
-  const pipelineStages = includeStages && effectivePipelineId
-    ? await findWithDecryption(
-      em,
-      CustomerPipelineStage,
-      {
-        pipelineId: effectivePipelineId,
-        organizationId: deal.organizationId,
-        tenantId: deal.tenantId,
-      },
-      { orderBy: { order: 'ASC' } },
-      decryptionScope,
-    )
-    : []
-  const pipeline = effectivePipelineId
-    ? await findOneWithDecryption(
-      em,
-      CustomerPipeline,
-      {
-        id: effectivePipelineId,
-        organizationId: deal.organizationId,
-        tenantId: deal.tenantId,
-      },
-      {},
-      decryptionScope,
-    )
-    : null
-  const pipelineStageAppearanceMap = pipelineStages.length
-    ? await loadPipelineStageAppearanceMap(em, pipelineStages, deal.organizationId, deal.tenantId)
-    : new Map<string, CustomerDictionaryEntry>()
-  let stageTransitions: CustomerDealStageTransition[] = []
-  if (includeStages) {
+  const resolveStageTransitions = async (): Promise<CustomerDealStageTransition[]> => {
+    if (!includeStages) return []
     try {
-      stageTransitions = await findWithDecryption(
+      return await findWithDecryption(
         em,
         CustomerDealStageTransition,
         { deal: deal.id, deletedAt: null },
@@ -612,18 +579,85 @@ export async function GET(request: Request, context: { params?: Record<string, u
         throw error
       }
       warnMissingDealStageTransitionTable('customers.api.deals.detail.GET')
-      stageTransitions = []
+      return []
     }
   }
+
+  const [associations, customFieldValues, viewerInfo, owner, effectiveStage, stageTransitions] = await Promise.all([
+    resolveAssociations(),
+    loadCustomFieldValues({
+      em,
+      entityId: E.customers.customer_deal,
+      recordIds: [deal.id],
+      tenantIdByRecord: { [deal.id]: deal.tenantId ?? null },
+      organizationIdByRecord: { [deal.id]: deal.organizationId ?? null },
+      tenantFallbacks: [deal.tenantId ?? auth.tenantId ?? null].filter((value): value is string => !!value),
+    }),
+    resolveViewer(),
+    resolveOwner(),
+    includeStages ? resolveEffectivePipelineStage(em, deal, decryptionScope) : Promise.resolve(null),
+    resolveStageTransitions(),
+  ])
+
+  const { people, companies, linkedPersonIds, linkedCompanyIds } = associations
+  const customFields = normalizeCustomFieldResponse(customFieldValues[deal.id]) ?? {}
+  const viewerName = viewerInfo.name
+  const viewerEmail = viewerInfo.email
+  const ownerPayload = owner
+    ? {
+      id: owner.id,
+      name: owner.name ?? owner.email ?? owner.id,
+      email: owner.email ?? '',
+    }
+    : null
+
+  const effectivePipelineId = deal.pipelineId ?? effectiveStage?.pipelineId ?? null
+  const effectivePipelineStageId = deal.pipelineStageId ?? effectiveStage?.id ?? null
+  const effectivePipelineStageLabel = deal.pipelineStage ?? effectiveStage?.label ?? null
+
+  const [pipelineStages, pipeline] = await Promise.all([
+    includeStages && effectivePipelineId
+      ? findWithDecryption(
+        em,
+        CustomerPipelineStage,
+        {
+          pipelineId: effectivePipelineId,
+          organizationId: deal.organizationId,
+          tenantId: deal.tenantId,
+        },
+        { orderBy: { order: 'ASC' } },
+        decryptionScope,
+      )
+      : [],
+    effectivePipelineId
+      ? findOneWithDecryption(
+        em,
+        CustomerPipeline,
+        {
+          id: effectivePipelineId,
+          organizationId: deal.organizationId,
+          tenantId: deal.tenantId,
+        },
+        {},
+        decryptionScope,
+      )
+      : null,
+  ])
+
   const persistedStageTransitions = stageTransitions.map((transition) => ({
     stageId: transition.stageId,
     stageLabel: transition.stageLabel,
     stageOrder: transition.stageOrder,
     transitionedAt: transition.transitionedAt.toISOString(),
   }))
-  const recoveredStageTransitions = includeStages && persistedStageTransitions.length === 0
-    ? await loadAuditStageTransitionsFallback({ container, deal, pipelineStages })
-    : []
+  const [pipelineStageAppearanceMap, recoveredStageTransitions] = await Promise.all([
+    pipelineStages.length
+      ? loadPipelineStageAppearanceMap(em, pipelineStages, deal.organizationId, deal.tenantId)
+      : new Map<string, CustomerDictionaryEntry>(),
+    includeStages && persistedStageTransitions.length === 0
+      ? loadAuditStageTransitionsFallback({ container, deal, pipelineStages })
+      : [],
+  ])
   const effectiveCurrentStage = (() => {
     if (!effectivePipelineStageId) return null
     const matchingStage = pipelineStages.find((stage) => stage.id === effectivePipelineStageId)


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The customer **deal detail** GET route (`api/customers/deals/[id]`) loaded its independent enrichment blocks sequentially after the target deal and scope were resolved. Serializing the linked person/company reads, custom fields, viewer/owner lookups, pipeline-stage resolution, and stage-transition reads inflated server response time before the React deal-detail surface could render — an avoidable server-side request waterfall.

This is the **deals slice** of #3175. The people + company routes from the same issue are already handled by the in-flight PR #3352 (Fixes #3203); this PR deliberately touches only the deals route so the two do not conflict.

## Changes

- `api/deals/[id]/route.ts`: grouped the genuinely independent post-access reads into `Promise.all` batches:
  - **Batch 1** (deal + scope deps only): person/company links (now concurrent, with lite-view previews concurrent too), custom fields, viewer lookup, owner lookup, effective pipeline stage, and stage transitions.
  - **Batch 2** (after the effective stage is known): pipeline stages + pipeline.
  - **Batch 3** (after pipeline stages load): pipeline-stage appearance map + audit-log stage-transition fallback.
- True dependencies stay ordered: preview/decrypt after link rows, pipeline reads after `effectivePipelineId`, appearance/fallback after pipeline stages, and the audit fallback after `persistedStageTransitions`. Auth, tenant scope, feature flags, and entity-access checks remain entirely before enrichment.
- Added `api/deals/[id]/__tests__/route.parallel.test.ts`: holds `findWithDecryption` open until two reads are concurrently in flight; it fails (gate never trips, `maxInFlight` stays 1) against the old sequential code and passes once the reads run in parallel.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — behavior-preserving perf refactor of a single route; mirrors the pattern of #3203/#3352.

## Testing

- `npx jest deals/[id]/__tests__/route.parallel` — RED pre-fix (`expected >= 2, received 1`), GREEN post-fix.
- `tsc --noEmit` on `@open-mercato/core`: clean (0 errors).
- ESLint on the two changed files: clean.
- `yarn workspace @open-mercato/core build`: built successfully.
- Full customers module suite (`jest modules/customers`): 148 suites / 829 tests pass.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. <!-- N/A — no user-facing strings, generators, or docs affected -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- N/A — byte-identical response (no observable behavior change); covered by the focused concurrency unit test + the existing customers route suite -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — minor behavior-preserving refactor -->
- [x] Priority set: this PR carries exactly one `priority-*` label. <!-- priority-medium (inherited from issue) -->
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. <!-- risk-medium — single-module API refactor, ships with tests -->
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. <!-- needs-qa: customer-facing deal-detail surface (response is provably unchanged, so QA is a quick smoke of the deal detail page) -->

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Refs #3175 (deals slice; people + companies covered by #3352 / #3203). Recommend closing #3175 as a duplicate of #3203 once both this PR and #3352 land.
