### PR TITLE
fix: parallelize legacy activity timeline fallback page fetches (#3176)

### DIFF
--- a/packages/core/src/modules/customers/components/detail/ActivitiesSection.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivitiesSection.tsx
@@ -204,21 +204,29 @@ export function ActivitiesSection({
         return
       }
 
-      // In legacy mode, also fetch legacy activities and merge with canonical
+      // In legacy mode, also fetch legacy activities and merge with canonical.
+      // Legacy pages use known page numbers, so once loadedPages is fixed we can request
+      // every page concurrently instead of awaiting them one at a time.
+      const legacyPayloads = await Promise.all(
+        Array.from({ length: loadedPages }, (_unused, index) => {
+          const legacyParams = new URLSearchParams({
+            entityId,
+            page: String(index + 1),
+            pageSize: '50',
+            sortField: 'occurredAt',
+            sortDir: 'desc',
+          })
+          if (dealId) legacyParams.set('dealId', dealId)
+          return readApiResultOrThrow<{ items?: ActivitySummary[]; totalPages?: number }>(
+            `/api/customers/activities?${legacyParams.toString()}`,
+          ).catch(() => ({ items: [] as ActivitySummary[], totalPages: 1 }))
+        }),
+      )
+
+      // Consume payloads in page order so merge/dedup ordering stays stable.
       const legacyItems: InteractionSummary[] = []
       let legacyTotalPages = 1
-      for (let legacyPage = 1; legacyPage <= loadedPages; legacyPage += 1) {
-        const legacyParams = new URLSearchParams({
-          entityId,
-          page: String(legacyPage),
-          pageSize: '50',
-          sortField: 'occurredAt',
-          sortDir: 'desc',
-        })
-        if (dealId) legacyParams.set('dealId', dealId)
-        const legacyPayload = await readApiResultOrThrow<{ items?: ActivitySummary[]; totalPages?: number }>(
-          `/api/customers/activities?${legacyParams.toString()}`,
-        ).catch(() => ({ items: [] as ActivitySummary[], totalPages: 1 }))
+      for (const legacyPayload of legacyPayloads) {
         legacyItems.push(...(Array.isArray(legacyPayload?.items) ? legacyPayload.items.map(normalizeLegacyActivity) : []))
         legacyTotalPages = typeof legacyPayload?.totalPages === 'number' ? legacyPayload.totalPages : legacyTotalPages
       }

--- a/packages/core/src/modules/customers/components/detail/ActivityHistorySection.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivityHistorySection.tsx
@@ -265,17 +265,24 @@ export function ActivityHistorySection({
       let combined = canonicalItems
 
       if (!useCanonicalInteractions) {
+        // Legacy pages use known page numbers, so once loadedPages is fixed we can request
+        // every page concurrently instead of awaiting them one at a time.
+        const legacyPayloads = await Promise.all(
+          Array.from({ length: loadedPages }, (_unused, index) =>
+            readApiResultOrThrow<{ items?: ActivitySummary[]; totalPages?: number }>(
+              `/api/customers/activities?entityId=${encodeURIComponent(entityId)}&page=${index + 1}&pageSize=20&sortField=occurredAt&sortDir=desc`,
+              { signal },
+            ).catch(() => ({ items: [] as ActivitySummary[], totalPages: 1 })),
+          ),
+        )
+        if (isStale()) return
+
+        // Consume payloads in page order so merge/dedup ordering stays stable.
         const legacyItems: InteractionSummary[] = []
         let legacyTotalPages = 1
-        for (let legacyPage = 1; legacyPage <= loadedPages; legacyPage += 1) {
-          const legacyPayload = await readApiResultOrThrow<{ items?: ActivitySummary[]; totalPages?: number }>(
-            `/api/customers/activities?entityId=${encodeURIComponent(entityId)}&page=${legacyPage}&pageSize=20&sortField=occurredAt&sortDir=desc`,
-            { signal },
-          ).catch(() => ({ items: [] as ActivitySummary[], totalPages: 1 }))
-          if (isStale()) return
+        for (const legacyPayload of legacyPayloads) {
           legacyItems.push(...(Array.isArray(legacyPayload.items) ? legacyPayload.items.map(normalizeLegacyActivity) : []))
           legacyTotalPages = typeof legacyPayload.totalPages === 'number' ? legacyPayload.totalPages : legacyTotalPages
-          if (legacyPage >= legacyTotalPages) break
         }
         const rangeStartDate = computeRangeStart(dateRange)
         const filteredLegacy = legacyItems.filter((item) => {

--- a/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesSection.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesSection.test.tsx
@@ -324,4 +324,57 @@ describe('Customer ActivitiesSection wrapper', () => {
     fireEvent.keyDown(window, { key: '1', metaKey: true })
     expect(document.activeElement).not.toBe(searchInput)
   })
+
+  it('dispatches legacy fallback pages in parallel once the page count is known', async () => {
+    const legacyDispatchedPages: string[] = []
+    let firstLegacyPageResolved = false
+    readApiResultOrThrowMock.mockImplementation((url: string) => {
+      if (url.includes('/api/customers/interactions?')) {
+        return Promise.resolve({ items: [] })
+      }
+      if (url.includes('/api/customers/activities?')) {
+        const page = new URL(url, 'http://localhost').searchParams.get('page') ?? ''
+        legacyDispatchedPages.push(page)
+        // First page-1 fetch resolves so a second page exists ("Load more" appears);
+        // every later legacy fetch hangs so sequential code would block before page 2.
+        if (page === '1' && !firstLegacyPageResolved) {
+          firstLegacyPageResolved = true
+          return Promise.resolve({
+            items: [
+              {
+                id: 'legacy-1',
+                activityType: 'note',
+                subject: 'Legacy note',
+                occurredAt: '2026-06-15T10:00:00.000Z',
+                createdAt: '2026-06-15T10:00:00.000Z',
+              },
+            ],
+            totalPages: 3,
+          })
+        }
+        return new Promise(() => {})
+      }
+      return Promise.resolve({ items: [] })
+    })
+
+    renderWithProviders(
+      <CustomerActivitiesSection
+        entityId="company-123"
+        addActionLabel="Log activity"
+        emptyState={{ title: 'No activities logged yet', actionLabel: 'Log activity' }}
+      />,
+    )
+
+    const loadMore = await screen.findByRole('button', { name: 'Load more' })
+    legacyDispatchedPages.length = 0
+    fireEvent.click(loadMore)
+
+    // After "Load more" the component fetches legacy pages 1 and 2. With a parallel
+    // dispatch both are requested even though page 1 is still pending; sequential code
+    // would await the hanging page-1 fetch and never reach page 2.
+    await waitFor(() => {
+      expect(legacyDispatchedPages).toContain('2')
+    })
+    expect(legacyDispatchedPages).toContain('1')
+  })
 })

--- a/packages/core/src/modules/customers/components/detail/__tests__/ActivityHistorySection.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ActivityHistorySection.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import * as React from 'react'
-import { act, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { ActivityHistorySection } from '../ActivityHistorySection'
 
@@ -71,5 +71,63 @@ describe('ActivityHistorySection', () => {
 
     expect(diffDays).toBeGreaterThanOrEqual(89)
     expect(diffDays).toBeLessThanOrEqual(91)
+  })
+})
+
+describe('ActivityHistorySection legacy fallback parallelization', () => {
+  beforeEach(() => {
+    jest.useRealTimers()
+    readApiResultOrThrowMock.mockReset()
+  })
+
+  it('dispatches legacy fallback pages in parallel once the page count is known', async () => {
+    const legacyDispatchedPages: string[] = []
+    let firstLegacyPageResolved = false
+    readApiResultOrThrowMock.mockImplementation((url: string) => {
+      if (url.startsWith('/api/customers/interactions/counts?')) {
+        return Promise.resolve({ result: { call: 0, email: 0, meeting: 0, note: 0, task: 0, total: 0 } })
+      }
+      if (url.startsWith('/api/customers/interactions?')) {
+        return Promise.resolve({
+          items: [
+            {
+              id: 'canon-1',
+              interactionType: 'note',
+              status: 'done',
+              occurredAt: '2026-06-15T10:00:00.000Z',
+              scheduledAt: null,
+              createdAt: '2026-06-15T10:00:00.000Z',
+              updatedAt: '2026-06-15T10:00:00.000Z',
+            },
+          ],
+        })
+      }
+      if (url.startsWith('/api/customers/activities?')) {
+        const page = new URL(url, 'http://localhost').searchParams.get('page') ?? ''
+        legacyDispatchedPages.push(page)
+        // First page-1 fetch resolves so a second page exists ("Load more" appears);
+        // every later legacy fetch hangs so sequential code would block before page 2.
+        if (page === '1' && !firstLegacyPageResolved) {
+          firstLegacyPageResolved = true
+          return Promise.resolve({ items: [], totalPages: 3 })
+        }
+        return new Promise(() => {})
+      }
+      return Promise.resolve({})
+    })
+
+    renderWithProviders(<ActivityHistorySection entityId="company-123" />)
+
+    const loadMore = await screen.findByRole('button', { name: 'Load more' })
+    legacyDispatchedPages.length = 0
+    fireEvent.click(loadMore)
+
+    // After "Load more" the component fetches legacy pages 1 and 2. With a parallel
+    // dispatch both are requested even though page 1 is still pending; sequential code
+    // would await the hanging page-1 fetch and never reach page 2.
+    await waitFor(() => {
+      expect(legacyDispatchedPages).toContain('2')
+    })
+    expect(legacyDispatchedPages).toContain('1')
   })
 })


### PR DESCRIPTION
## Summary

The customer activity-timeline components (`ActivitiesSection`, `ActivityHistorySection`) fetched their legacy fallback pages one at a time — a sequential `for` loop that awaited each `/api/customers/activities?page=N` request before issuing the next. Cursor-based canonical pagination must stay sequential (each cursor depends on the previous response), but the legacy fallback uses known page numbers and can be issued together once the requested page count is known. This serialization slowed activity/history rendering whenever more than one page was loaded.

This PR parallelizes only the legacy fallback fetches with `Promise.all`, leaving canonical cursor pagination, ordering, filtering, dedup, and abort/stale guards unchanged.

## Changes

- `ActivitiesSection.tsx`: replace the sequential legacy `for` loop with `Promise.all` over `Array.from({ length: loadedPages })`; consume the resolved payloads in page-index order so merge/dedup ordering stays stable. Canonical cursor loop and per-request `.catch(...)` fallback unchanged.
- `ActivityHistorySection.tsx`: same parallelization; move the `isStale()` abort/stale guard to immediately after `Promise.all` (before any state consumption); drop the now-redundant `if (legacyPage >= legacyTotalPages) break` early-exit (safe — `loadedPages` only grows via "Load more", which renders only while more pages remain).
- Tests: add a deferred-promise parallel-dispatch regression test to each component's existing render-test suite. Each fails on the old sequential code (page 2 is never dispatched while page 1 is pending) and passes on the parallel implementation.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — localized client-side performance refactor, no contract surface affected.

## Testing

- `yarn jest` (core) on both files — 9 passed (2 new parallel-dispatch tests + 7 existing): red on the sequential code, green on the fix.
- `yarn build:packages` → `yarn generate` → `yarn build:packages` → green
- `yarn turbo run typecheck --filter=@open-mercato/core` → green
- `yarn i18n:check-sync` → all locales in sync (no new strings)
- `yarn build:app` → green

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no new strings/keys; `i18n:check-sync` green.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required — this is a client-side fetch-concurrency refactor with no new/changed API path; covered deterministically by the jsdom render tests that drive load → "Load more" → merged timeline.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — minor refactor.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — single-module UI change shipping with tests; no auth/money/schema/contract surface.)
- [x] QA routing set: `needs-qa` (customer-facing activity timeline). Behavior is preserved and render-test-covered, so `skip-qa` is also defensible — maintainer's call.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no `className`/styling changed
- [x] No arbitrary text sizes — N/A, no `className`/styling changed
- [x] Empty state handled for list/data pages — unchanged (pre-existing empty states preserved)
- [x] Loading state handled for async pages — unchanged (pre-existing loading states preserved)
- [x] `aria-label` on all icon-only buttons — N/A, no markup changed
- [x] Uses existing DS components — N/A, no components changed

## Linked issues

Fixes #3176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
