### PR TITLE
perf(customers): parallelize legacy activity timeline fallback page fetches (#3176)

### DIFF
--- a/packages/core/src/modules/customers/components/detail/ActivitiesSection.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivitiesSection.tsx
@@ -204,21 +204,30 @@ export function ActivitiesSection({
         return
       }
 
-      // In legacy mode, also fetch legacy activities and merge with canonical
+      // In legacy mode, also fetch legacy activities and merge with canonical.
+      // Legacy fallback uses known page numbers, so request every page up front
+      // and resolve them together instead of awaiting each one sequentially.
+      const legacyPageNumbers = Array.from({ length: loadedPages }, (_, index) => index + 1)
+      const legacyPayloads = await Promise.all(
+        legacyPageNumbers.map((legacyPage) => {
+          const legacyParams = new URLSearchParams({
+            entityId,
+            page: String(legacyPage),
+            pageSize: '50',
+            sortField: 'occurredAt',
+            sortDir: 'desc',
+          })
+          if (dealId) legacyParams.set('dealId', dealId)
+          return readApiResultOrThrow<{ items?: ActivitySummary[]; totalPages?: number }>(
+            `/api/customers/activities?${legacyParams.toString()}`,
+          ).catch(() => ({ items: [] as ActivitySummary[], totalPages: 1 }))
+        }),
+      )
+      // Merge in page order so timeline ordering stays stable regardless of
+      // which request settles first.
       const legacyItems: InteractionSummary[] = []
       let legacyTotalPages = 1
-      for (let legacyPage = 1; legacyPage <= loadedPages; legacyPage += 1) {
-        const legacyParams = new URLSearchParams({
-          entityId,
-          page: String(legacyPage),
-          pageSize: '50',
-          sortField: 'occurredAt',
-          sortDir: 'desc',
-        })
-        if (dealId) legacyParams.set('dealId', dealId)
-        const legacyPayload = await readApiResultOrThrow<{ items?: ActivitySummary[]; totalPages?: number }>(
-          `/api/customers/activities?${legacyParams.toString()}`,
-        ).catch(() => ({ items: [] as ActivitySummary[], totalPages: 1 }))
+      for (const legacyPayload of legacyPayloads) {
         legacyItems.push(...(Array.isArray(legacyPayload?.items) ? legacyPayload.items.map(normalizeLegacyActivity) : []))
         legacyTotalPages = typeof legacyPayload?.totalPages === 'number' ? legacyPayload.totalPages : legacyTotalPages
       }

--- a/packages/core/src/modules/customers/components/detail/ActivityHistorySection.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivityHistorySection.tsx
@@ -265,17 +265,23 @@ export function ActivityHistorySection({
       let combined = canonicalItems
 
       if (!useCanonicalInteractions) {
+        // Legacy fallback uses known page numbers, so request every page in
+        // parallel (sharing the abort signal) and merge them in page order.
+        const legacyPageNumbers = Array.from({ length: loadedPages }, (_, index) => index + 1)
+        const legacyPayloads = await Promise.all(
+          legacyPageNumbers.map((legacyPage) =>
+            readApiResultOrThrow<{ items?: ActivitySummary[]; totalPages?: number }>(
+              `/api/customers/activities?entityId=${encodeURIComponent(entityId)}&page=${legacyPage}&pageSize=20&sortField=occurredAt&sortDir=desc`,
+              { signal },
+            ).catch(() => ({ items: [] as ActivitySummary[], totalPages: 1 })),
+          ),
+        )
+        if (isStale()) return
         const legacyItems: InteractionSummary[] = []
         let legacyTotalPages = 1
-        for (let legacyPage = 1; legacyPage <= loadedPages; legacyPage += 1) {
-          const legacyPayload = await readApiResultOrThrow<{ items?: ActivitySummary[]; totalPages?: number }>(
-            `/api/customers/activities?entityId=${encodeURIComponent(entityId)}&page=${legacyPage}&pageSize=20&sortField=occurredAt&sortDir=desc`,
-            { signal },
-          ).catch(() => ({ items: [] as ActivitySummary[], totalPages: 1 }))
-          if (isStale()) return
+        for (const legacyPayload of legacyPayloads) {
           legacyItems.push(...(Array.isArray(legacyPayload.items) ? legacyPayload.items.map(normalizeLegacyActivity) : []))
           legacyTotalPages = typeof legacyPayload.totalPages === 'number' ? legacyPayload.totalPages : legacyTotalPages
-          if (legacyPage >= legacyTotalPages) break
         }
         const rangeStartDate = computeRangeStart(dateRange)
         const filteredLegacy = legacyItems.filter((item) => {

--- a/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesSection.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesSection.test.tsx
@@ -324,4 +324,53 @@ describe('Customer ActivitiesSection wrapper', () => {
     fireEvent.keyDown(window, { key: '1', metaKey: true })
     expect(document.activeElement).not.toBe(searchInput)
   })
+
+  it('fetches legacy fallback pages in parallel rather than one at a time', async () => {
+    let legacyInFlight = 0
+    let legacyMaxInFlight = 0
+    const legacyPagesRequested: number[] = []
+    readApiResultOrThrowMock.mockImplementation((url: string) => {
+      if (url.startsWith('/api/customers/interactions?')) {
+        if (url.includes('cursor=cursor-2')) {
+          return Promise.resolve({
+            items: [sampleActivity({ id: 'canonical-2', interactionType: 'email' })],
+          })
+        }
+        return Promise.resolve({
+          items: [sampleActivity({ id: 'canonical-1', interactionType: 'call' })],
+          nextCursor: 'cursor-2',
+        })
+      }
+      if (url.startsWith('/api/customers/activities?')) {
+        const page = Number(new URL(url, 'http://localhost').searchParams.get('page'))
+        legacyPagesRequested.push(page)
+        legacyInFlight += 1
+        legacyMaxInFlight = Math.max(legacyMaxInFlight, legacyInFlight)
+        return Promise.resolve({ items: [], totalPages: 5 }).finally(() => {
+          legacyInFlight -= 1
+        })
+      }
+      return Promise.resolve({})
+    })
+
+    renderWithProviders(
+      <CustomerActivitiesSection
+        entityId="company-123"
+        useCanonicalInteractions={false}
+        addActionLabel="Log activity"
+        emptyState={{ title: 'No activities logged yet', actionLabel: 'Log activity' }}
+      />,
+    )
+
+    // First load (loadedPages=1) must finish and reveal the "Load more" control.
+    const loadMore = await screen.findByRole('button', { name: 'Load more' })
+    fireEvent.click(loadMore)
+
+    // Loading a second page requests legacy page 2 in both the old and new code…
+    await waitFor(() => {
+      expect(legacyPagesRequested.filter((page) => page === 2)).toHaveLength(1)
+    })
+    // …but the two legacy page fetches must overlap (parallel), not run one-at-a-time.
+    expect(legacyMaxInFlight).toBeGreaterThanOrEqual(2)
+  })
 })

--- a/packages/core/src/modules/customers/components/detail/__tests__/ActivityHistorySection.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ActivityHistorySection.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import * as React from 'react'
-import { act, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { ActivityHistorySection } from '../ActivityHistorySection'
 
@@ -71,5 +71,60 @@ describe('ActivityHistorySection', () => {
 
     expect(diffDays).toBeGreaterThanOrEqual(89)
     expect(diffDays).toBeLessThanOrEqual(91)
+  })
+
+  it('fetches legacy fallback pages in parallel rather than one at a time', async () => {
+    jest.useRealTimers()
+    let legacyInFlight = 0
+    let legacyMaxInFlight = 0
+    const legacyPagesRequested: number[] = []
+    readApiResultOrThrowMock.mockReset()
+    readApiResultOrThrowMock.mockImplementation((url: string) => {
+      if (url.startsWith('/api/customers/interactions/counts?')) {
+        return Promise.resolve({ result: { call: 0, email: 0, meeting: 0, note: 0, task: 0, total: 0 } })
+      }
+      if (url.startsWith('/api/customers/interactions?')) {
+        if (url.includes('cursor=cursor-2')) {
+          return Promise.resolve({ items: [] })
+        }
+        return Promise.resolve({
+          items: [
+            {
+              id: 'canonical-1',
+              interactionType: 'call',
+              status: 'done',
+              occurredAt: '2026-04-10T09:00:00.000Z',
+              scheduledAt: null,
+              createdAt: '2026-04-10T09:00:00.000Z',
+              updatedAt: '2026-04-10T09:00:00.000Z',
+            },
+          ],
+          nextCursor: 'cursor-2',
+        })
+      }
+      if (url.startsWith('/api/customers/activities?')) {
+        const page = Number(new URL(url, 'http://localhost').searchParams.get('page'))
+        legacyPagesRequested.push(page)
+        legacyInFlight += 1
+        legacyMaxInFlight = Math.max(legacyMaxInFlight, legacyInFlight)
+        return Promise.resolve({ items: [], totalPages: 5 }).finally(() => {
+          legacyInFlight -= 1
+        })
+      }
+      return Promise.resolve({})
+    })
+
+    renderWithProviders(<ActivityHistorySection entityId="company-123" />)
+
+    // First load (loadedPages=1) must finish and reveal the "Load more" control.
+    const loadMore = await screen.findByRole('button', { name: 'Load more' })
+    fireEvent.click(loadMore)
+
+    // Loading a second page requests legacy page 2 in both the old and new code…
+    await waitFor(() => {
+      expect(legacyPagesRequested.filter((page) => page === 2)).toHaveLength(1)
+    })
+    // …but the two legacy page fetches must overlap (parallel), not run one-at-a-time.
+    expect(legacyMaxInFlight).toBeGreaterThanOrEqual(2)
   })
 })


### PR DESCRIPTION
## Summary

The customer activity-timeline components fetched legacy fallback pages one at a time: each `readApiResultOrThrow` was `await`ed before the next page request was issued, so rendering N pages of history cost N sequential round-trips. Because legacy mode is still the default path, this slowed activity/history loading whenever more than one page was loaded. The fix fires the legacy fallback page requests in parallel (the page numbers are all known once `loadedPages` is fixed) while keeping canonical cursor pagination sequential.

## Changes

- `ActivitiesSection.tsx` (`loadActivities`): replaced the sequential legacy `for/await` loop with `Promise.all` over the known page numbers, then merge the resolved payloads in page-index order. Canonical cursor pagination is unchanged (still sequential).
- `ActivityHistorySection.tsx` (`loadHistory`): same parallelization, sharing the existing abort `signal`; the `isStale()` abort/stale guard is preserved (checked once after the batch resolves, before any state write); the per-page `.catch` fallback is preserved. The sequential-only `if (legacyPage >= legacyTotalPages) break` early-exit is removed (it cannot apply once all pages are requested up front; `totalPages` is page-independent so `hasMore` is unaffected).
- Added a regression test to each component's test file asserting the legacy fallback pages overlap in-flight (max concurrent ≥ 2) — fails on the old sequential code, passes on the parallel implementation.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — localized performance refactor of existing component code.

## Testing

- `yarn workspace @open-mercato/core test --testPathPatterns 'detail/__tests__/(ActivitiesSection|ActivityHistorySection)'` → 2 suites / 9 tests passed (new concurrency tests red on old code, green on fix).
- `yarn typecheck` → 21/21 packages pass.
- `yarn i18n:check-sync` → all locales in sync.
- `yarn workspace @open-mercato/core test` (full) → 741 suites / 6068 tests pass.
- `yarn build:app` → Next.js app builds successfully.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no new strings, routes, or generated surfaces.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Not required: a frontend fetch-scheduling refactor with no API/route/flow change; fully covered by component-level concurrency unit tests.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A, no spec.
- [x] Priority set: this PR carries exactly one `priority-*` label. — `priority-medium` (inherited from the issue).
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. — `risk-medium` (single-module frontend refactor shipped with tests; inherited from the issue).
- [x] QA routing set. — `needs-qa` (operator-facing activity-timeline behavior); manually exercise the "Load more" flow on a record with multiple pages of legacy activities.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI markup changed (fetch-scheduling refactor only)
- [x] No arbitrary text sizes — N/A, no UI markup changed
- [x] Empty state handled for list/data pages — N/A, existing states untouched
- [x] Loading state handled for async pages — N/A, existing states untouched
- [x] `aria-label` on all icon-only buttons — N/A, no buttons changed
- [x] Uses existing DS components — N/A, no components added/replaced

## Linked issues

Fixes #3176
