### PR TITLE
fix(sales): wire mutation guard lifecycle to sales settings PUT routes

### DIFF
--- a/packages/core/src/modules/sales/api/settings/document-numbers/route.ts
+++ b/packages/core/src/modules/sales/api/settings/document-numbers/route.ts
@@ -13,6 +13,11 @@ import { loadSalesSettings } from '../../../commands/settings'
 import { SalesDocumentNumberGenerator } from '../../../services/salesDocumentNumberGenerator'
 import { DOCUMENT_NUMBER_TOKENS, DEFAULT_ORDER_NUMBER_FORMAT, DEFAULT_QUOTE_NUMBER_FORMAT } from '../../../lib/documentNumberTokens'
 import { withScopedPayload } from '../../utils'
+import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['sales.settings.manage'] },
@@ -94,9 +99,24 @@ export async function GET(req: Request) {
 export async function PUT(req: Request) {
   try {
     const { ctx, translate, generator, organizationId, tenantId } = await resolveSettingsContext(req)
-    const payload = await req.json().catch(() => ({}))
+    const payload = await readJsonSafe(req, {})
     const scoped = withScopedPayload(payload, ctx, translate)
     const input = salesSettingsUpsertSchema.parse(scoped)
+
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId,
+      organizationId,
+      userId: ctx.auth!.sub,
+      resourceKind: 'sales.settings',
+      resourceId: organizationId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
     const commandBus = ctx.container.resolve('commandBus') as CommandBus
     const { result } = await commandBus.execute<
@@ -109,6 +129,20 @@ export async function PUT(req: Request) {
         nextQuoteNumber: number
       }
     >('sales.settings.save', { input, ctx })
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId,
+        userId: ctx.auth!.sub,
+        resourceKind: 'sales.settings',
+        resourceId: organizationId,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     const sequences = await generator.peekSequences({ organizationId, tenantId })
 

--- a/packages/core/src/modules/sales/api/settings/order-editing/route.ts
+++ b/packages/core/src/modules/sales/api/settings/order-editing/route.ts
@@ -12,6 +12,11 @@ import { salesEditingSettingsSchema, salesSettingsUpsertSchema } from '../../../
 import { loadSalesSettings } from '../../../commands/settings'
 import { DEFAULT_ORDER_NUMBER_FORMAT, DEFAULT_QUOTE_NUMBER_FORMAT } from '../../../lib/documentNumberTokens'
 import { withScopedPayload } from '../../utils'
+import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import {
+  runCrudMutationGuardAfterSuccess,
+  validateCrudMutationGuard,
+} from '@open-mercato/shared/lib/crud/mutation-guard'
 import { ensureSalesDictionary } from '../../../lib/dictionaries'
 import { DictionaryEntry } from '@open-mercato/core/modules/dictionaries/data/entities'
 
@@ -114,22 +119,51 @@ export async function GET(req: Request) {
 export async function PUT(req: Request) {
   try {
     const { ctx, translate, organizationId, tenantId, em } = await resolveSettingsContext(req)
-    const payload = await req.json().catch(() => ({}))
+    const payload = (await readJsonSafe<Record<string, unknown>>(req, {})) ?? {}
     const scoped = withScopedPayload(payload, ctx, translate)
     const parsed = salesEditingSettingsSchema.parse(scoped)
+
+    const guardResult = await validateCrudMutationGuard(ctx.container, {
+      tenantId,
+      organizationId,
+      userId: ctx.auth!.sub,
+      resourceKind: 'sales.settings',
+      resourceId: organizationId,
+      operation: 'update',
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: parsed,
+    })
+    if (guardResult && !guardResult.ok) {
+      return NextResponse.json(guardResult.body, { status: guardResult.status })
+    }
 
     const current = await loadSalesSettings(em, { tenantId, organizationId })
     const commandInput = salesSettingsUpsertSchema.parse({
       ...parsed,
       orderNumberFormat: parsed.orderNumberFormat ?? current?.orderNumberFormat ?? DEFAULT_ORDER_NUMBER_FORMAT,
       quoteNumberFormat: parsed.quoteNumberFormat ?? current?.quoteNumberFormat ?? DEFAULT_QUOTE_NUMBER_FORMAT,
-      orderNextNumber: payload?.orderNextNumber,
-      quoteNextNumber: payload?.quoteNextNumber,
+      orderNextNumber: payload.orderNextNumber,
+      quoteNextNumber: payload.quoteNextNumber,
     })
 
     const commandBus = ctx.container.resolve('commandBus') as CommandBus
     const response = await commandBus.execute('sales.settings.save', { input: commandInput, ctx })
     const result = (response as { result?: { orderCustomerEditableStatuses?: string[] | null; orderAddressEditableStatuses?: string[] | null } }).result
+
+    if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
+      await runCrudMutationGuardAfterSuccess(ctx.container, {
+        tenantId,
+        organizationId,
+        userId: ctx.auth!.sub,
+        resourceKind: 'sales.settings',
+        resourceId: organizationId,
+        operation: 'update',
+        requestMethod: req.method,
+        requestHeaders: req.headers,
+        metadata: guardResult.metadata ?? null,
+      })
+    }
 
     const orderStatuses = await loadStatusOptions(em, tenantId, organizationId)
 


### PR DESCRIPTION
## Summary

Wire the mutation guard contract to two sales settings PUT routes that were bypassing it, causing enterprise guard plugins to be silently skipped.

## Changes

* `api/settings/document-numbers/route.ts` — add `validateCrudMutationGuard` before and `runCrudMutationGuardAfterSuccess` after `commandBus.execute`; replace `req.json().catch()` with `readJsonSafe()`
* `api/settings/order-editing/route.ts` — same guard wiring and JSON fix

Pattern mirrors the reference implementation at `customers/api/settings/stuck-threshold/route.ts`.

## Specification

N/A — pure compliance fix, no new behavior.

## Testing

* `yarn workspace @open-mercato/core test --testPathPatterns="sales|optimistic-lock"` — 60 suites, 409 tests, all green
* `yarn workspace @open-mercato/core build` — built successfully

## Checklist

* [x] Code follows project conventions (mutation guard pattern from reference module)
* [x] No new user-facing strings
* [x] No database migrations required
* [x] No backward-incompatible contract changes
* [x] Defensive JSON parsing (`readJsonSafe`) applied

## Design System Compliance

N/A — backend-only change, no UI.

## Linked issues

Closes #3292