### PR TITLE
fix(devcontainer): add jq to Dockerfile apt-get dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ruby ruby-dev \
     build-essential \
     ca-certificates openssl \
-    git curl bash zsh sudo \
+    git curl bash zsh sudo jq \
     postgresql-client \
     procps file \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

`install-skills.sh` requires `jq` and hard-exits with code 1 if it is absent — causing the entire `postCreateCommand` to fail on every fresh Dev Container build. The base `node:24-slim` image does not include `jq`, and Homebrew (present in the image) does not help because its PATH is only wired into interactive shell profiles (`.bashrc`/`.profile`), which are not sourced during the non-interactive `postCreateCommand` and `postStartCommand` hooks where the script runs on every container create and restart.

Thanks to @yaotzin1 for the report (#3429) — this kind of issue is invisible to CI (GitHub Actions runners ship with `jq` preinstalled) and only surfaces to someone going through the Dev Container onboarding path for the first time.

## Changes

- `.devcontainer/Dockerfile` — add `jq` to the `apt-get install -y` list

## Specification

- [x] N/A (minor infrastructure fix, no spec needed)

## Testing

Manual QA in Dev Container:

```bash
devcontainer up --workspace-folder . --remove-existing-container
```

Expected: step `[3/7] Installing skills ...` completes without `jq is required but not installed` error.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] No documentation, locales, or generators require updating.
- [x] No unit tests applicable (infrastructure/Docker change).
- [x] Priority set: `priority-medium`
- [x] Risk set: `risk-low`
- [x] QA routing set: `needs-qa`

### Design System Compliance

N/A — infrastructure change only.

## Linked issues

Fixes #3429