### PR TITLE
fix: derive checkout demo current step during render (#3172)

### DIFF
--- a/packages/core/src/modules/workflows/frontend/checkout-demo/__tests__/deriveCurrentStep.test.ts
+++ b/packages/core/src/modules/workflows/frontend/checkout-demo/__tests__/deriveCurrentStep.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Regression tests for the checkout demo current-step derivation.
+ *
+ * The checkout demo page used to mirror `currentStep` into React state and keep
+ * it in sync with an effect. This pins the derivation semantics that effect
+ * produced so the render-time computation stays behavior-identical (#3172).
+ */
+
+import { describe, test, expect } from '@jest/globals'
+import { deriveCurrentStep } from '../deriveCurrentStep'
+
+const steps = [
+  { stepId: 'start', stepName: 'Start', stepType: 'START' },
+  { stepId: 'customer_info', stepName: 'Customer Information', stepType: 'USER_TASK' },
+  { stepId: 'end', stepName: 'Complete', stepType: 'END' },
+]
+
+describe('deriveCurrentStep', () => {
+  test('returns the matching step when currentStepId resolves to a known step', () => {
+    expect(deriveCurrentStep('customer_info', steps)).toBe(steps[1])
+  })
+
+  test('returns null when there is no current step id (initial / reset state)', () => {
+    expect(deriveCurrentStep(undefined, steps)).toBeNull()
+  })
+
+  test('returns null when currentStepId does not match any known step', () => {
+    expect(deriveCurrentStep('unknown_step', steps)).toBeNull()
+  })
+
+  test('preserves the resolved step object so callers can read its stepType', () => {
+    expect(deriveCurrentStep('end', steps)?.stepType).toBe('END')
+  })
+
+  test('is a pure derivation that never throws on an empty step list', () => {
+    expect(deriveCurrentStep('customer_info', [])).toBeNull()
+  })
+})

--- a/packages/core/src/modules/workflows/frontend/checkout-demo/deriveCurrentStep.ts
+++ b/packages/core/src/modules/workflows/frontend/checkout-demo/deriveCurrentStep.ts
@@ -1,0 +1,12 @@
+/**
+ * Derives the current workflow step from the running instance's `currentStepId`
+ * and the available workflow steps. This is a pure function of its inputs so the
+ * checkout demo can compute it during render instead of mirroring it into state.
+ */
+export function deriveCurrentStep<TStep extends { stepId: string }>(
+  currentStepId: string | undefined,
+  steps: TStep[],
+): TStep | null {
+  if (!currentStepId) return null
+  return steps.find((step) => step.stepId === currentStepId) ?? null
+}

--- a/packages/core/src/modules/workflows/frontend/checkout-demo/page.tsx
+++ b/packages/core/src/modules/workflows/frontend/checkout-demo/page.tsx
@@ -14,6 +14,7 @@ import {
 import Link from 'next/link'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { deriveCurrentStep } from './deriveCurrentStep'
 
 interface CartItem {
   id: string // Product UUID
@@ -62,8 +63,6 @@ export default function CheckoutDemoPage() {
   const [advancing, setAdvancing] = useState(false)
   const [result, setResult] = useState<WorkflowResult | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [currentStep, setCurrentStep] = useState<StepInfo | null>(null)
-  const [availableSteps, setAvailableSteps] = useState<StepInfo[]>([])
   const [formData, setFormData] = useState<Record<string, any>>({})
   const [submittingTask, setSubmittingTask] = useState(false)
   const [taskError, setTaskError] = useState<string | null>(null)
@@ -270,21 +269,8 @@ export default function CheckoutDemoPage() {
     { stepId: 'end', stepName: 'Complete', stepType: 'END', description: 'Checkout completed' },
   ]
 
-  // Update current step and available steps when result changes
-  useEffect(() => {
-    if (result?.currentStepId) {
-      const current = workflowSteps.find(s => s.stepId === result.currentStepId)
-      setCurrentStep(current || null)
-
-      // Find next available steps (simple - just show next step)
-      const currentIndex = workflowSteps.findIndex(s => s.stepId === result.currentStepId)
-      if (currentIndex >= 0 && currentIndex < workflowSteps.length - 1) {
-        setAvailableSteps([workflowSteps[currentIndex + 1]])
-      } else {
-        setAvailableSteps([])
-      }
-    }
-  }, [result])
+  // Current step derived from the running instance and the workflow steps
+  const currentStep = deriveCurrentStep(result?.currentStepId, workflowSteps)
 
   // Add initial delay before polling for user tasks when workflow becomes PAUSED
   // This reduces race condition where API returns before background execution completes
@@ -1490,8 +1476,6 @@ export default function CheckoutDemoPage() {
                     onClick={() => {
                       setResult(null)
                       setError(null)
-                      setCurrentStep(null)
-                      setAvailableSteps([])
                     }}
                     variant="outline"
                     className="w-full"
@@ -1515,8 +1499,6 @@ export default function CheckoutDemoPage() {
                   onClick={() => {
                     setResult(null)
                     setError(null)
-                    setCurrentStep(null)
-                    setAvailableSteps([])
                   }}
                   className="w-full mt-6"
                 >
@@ -1773,8 +1755,6 @@ export default function CheckoutDemoPage() {
                     onClick={() => {
                       setResult(null)
                       setError(null)
-                      setCurrentStep(null)
-                      setAvailableSteps([])
                     }}
                     variant="outline"
                     className="w-full"


### PR DESCRIPTION
## Summary

The workflow checkout demo stored `currentStep` and `availableSteps` in React state and kept them in sync with a `useEffect`, even though both are deterministic derivations of `result.currentStepId` and `workflowSteps`. This refactor computes `currentStep` during render and removes the effect plus the redundant derived-state resets. `availableSteps` was write-only dead state (set but read nowhere) and is removed entirely. Behavior is unchanged.

## Changes

- Remove the `currentStep` / `availableSteps` `useState` declarations and the `useEffect` that synchronized them from `packages/core/src/modules/workflows/frontend/checkout-demo/page.tsx`.
- Derive `currentStep` at render time via a small pure helper, `deriveCurrentStep(result?.currentStepId, workflowSteps)`.
- Add `packages/core/src/modules/workflows/frontend/checkout-demo/deriveCurrentStep.ts` (pure, generic, tested seam).
- Drop the now-redundant `setCurrentStep(null)` / `setAvailableSteps([])` clears from the three reset/start handlers (Start New Order, Try Again, Start New Checkout).
- Add a regression unit test pinning the derivation semantics the old effect produced.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — behavior-preserving local refactor of a demo page.

## Testing

List the tests or commands you ran to validate the change.

- `yarn workspace @open-mercato/core test -- --runTestsByPath src/modules/workflows/frontend/checkout-demo/__tests__/deriveCurrentStep.test.ts` → red (pre-fix, module missing) → **green, 5/5** (post-fix)
- `yarn workspace @open-mercato/core test -- --testPathPattern modules/workflows` → **30 suites / 550 tests pass**
- `yarn turbo run typecheck --filter=@open-mercato/core --force` → **pass**
- `yarn i18n:check-sync` → **all locales in sync**
- `yarn build:packages` → **21/21 success**
- `yarn build:app` → **✓ Compiled successfully**

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. <!-- none required: no strings, schema, or generator inputs changed -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- N/A — behavior-preserving refactor; no new API/UI path; covered by the new unit test -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — minor refactor -->
- [x] Priority set: this PR carries exactly one `priority-*` label. <!-- priority-low (inherited from issue) -->
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). <!-- risk-low (inherited from issue) -->
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. <!-- skip-qa: behavior-preserving risk-low refactor, proven value-identical at the only consumption site; no manual exercise needed -->

### Design System Compliance
- [x] No hardcoded status colors — use semantic tokens <!-- N/A — no markup/styling lines changed; refactor only removes derived React state -->
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` <!-- N/A — no styling changed -->
- [x] Empty state handled for list/data pages <!-- N/A — no list/data UI changed -->
- [x] Loading state handled for async pages <!-- N/A — unchanged -->
- [x] `aria-label` on all icon-only buttons <!-- N/A — no buttons added/changed -->
- [x] Uses existing DS components — no custom replacements <!-- N/A — no components added -->

## Linked issues

Fixes #3172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
