### PR TITLE
refactor(ui): standardize browser storage state with versioned envelopes (#3174)

### DIFF
--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -35,6 +35,7 @@ yarn workspace @open-mercato/shared build
 | `api/` | When building scoped API payloads | `@open-mercato/shared/lib/api/scoped` |
 | `auth/` | When you need wildcard-aware feature matching or shared auth helpers | `@open-mercato/shared/lib/auth/featureMatch` |
 | `boolean/` | When parsing boolean strings from env/query params | `@open-mercato/shared/lib/boolean` |
+| `browser/` | When persisting client UI state to `localStorage` — use the safe wrappers and the versioned-envelope helper instead of raw `localStorage` reads/writes | `@open-mercato/shared/lib/browser/safeLocalStorage`, `@open-mercato/shared/lib/browser/versionedPreference` |
 | `commands/` | When implementing undo/redo command pattern | `@open-mercato/shared/lib/commands` |
 | `commands/flush` | When a command mutates entities across multiple phases (scalar + relation syncs) — wraps phases in a single atomic flush | `@open-mercato/shared/lib/commands/flush` — `withAtomicFlush(em, phases, { transaction? })` |
 | `commands/runCrudCommandWrite` | When a command writes an entity + custom fields + CRUD/index side effects in one logical operation — composes fork → atomic flush → custom-field write → side-effect queue in the only correct order. **Prefer this over composing the primitives by hand for new commands.** | `@open-mercato/shared/lib/commands/runCrudCommandWrite` — `runCrudCommandWrite({ ctx, entityId, action, scope, phases, customFields?, events?, indexer?, sideEffect })` |
@@ -90,6 +91,24 @@ const results = await findWithDecryption(em, 'Entity', filter, { tenantId, organ
 ```typescript
 import { parseBooleanToken, parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 ```
+
+### Browser Storage — use the shared helpers instead of raw `localStorage`
+
+Persisted client UI state MUST go through the shared `browser/` helpers, never raw `window.localStorage` reads/writes scattered per component:
+
+```typescript
+import { readJsonFromLocalStorage, writeJsonToLocalStorage } from '@open-mercato/shared/lib/browser/safeLocalStorage'
+import { readVersionedPreference, writeVersionedPreference, clearVersionedPreference } from '@open-mercato/shared/lib/browser/versionedPreference'
+```
+
+- `safeLocalStorage` — SSR-safe, error-swallowing JSON get/set/remove. Use for raw values.
+- `versionedPreference` — wraps a value in a `{ v, data }` envelope so schema changes can migrate or safely discard stale data. `readVersionedPreference(key, version, isValid, fallback, { legacyIsValid })` validates the envelope, discards version-mismatched or malformed data, and (when `legacyIsValid` is supplied) migrates a pre-envelope bare value forward on the next write. `readVersionedIdSet`/`writeVersionedIdSet` are convenience wrappers for the common "set of ids" shape.
+
+**Versioning threshold** — when to reach for `versionedPreference` vs. a raw scalar:
+
+- **Trivial scalar flags** (a single boolean/number/string with no schema to evolve, e.g. `om:sidebarCollapsed`, `om:progress:expanded`) MAY stay raw via `safeLocalStorage` (or a plain `'1'`/`'0'`). Add a one-line comment noting the deliberate choice.
+- **Structured values** (objects, records, arrays of objects — anything whose shape can change incompatibly, e.g. a perspective snapshot, a model-picker selection, a sessions cache) MUST use a versioned envelope so a future shape change can migrate or discard old data instead of crashing or silently corrupting state.
+- A slot that already carries its own inline version discriminator (e.g. `{ v, ... }` checked on read) is already migratable and need not be re-wrapped — re-wrapping changes the on-disk format and discards existing user data.
 
 ### i18n — MUST use for all user-facing strings
 

--- a/packages/shared/src/lib/browser/__tests__/versionedPreference.test.ts
+++ b/packages/shared/src/lib/browser/__tests__/versionedPreference.test.ts
@@ -1,0 +1,81 @@
+/** @jest-environment jsdom */
+import {
+  readVersionedPreference,
+  writeVersionedPreference,
+  clearVersionedPreference,
+  readVersionedIdSet,
+  writeVersionedIdSet,
+} from '../versionedPreference'
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+    && Object.values(value as Record<string, unknown>).every((v) => typeof v === 'string')
+}
+
+describe('versionedPreference', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('round-trips a value through write then read', () => {
+    writeVersionedPreference('test:a', 1, { foo: 'bar' })
+    expect(readVersionedPreference('test:a', 1, isStringRecord, {})).toEqual({ foo: 'bar' })
+  })
+
+  it('discards data on version mismatch', () => {
+    writeVersionedPreference('test:b', 1, { foo: 'bar' })
+    expect(readVersionedPreference('test:b', 2, isStringRecord, {})).toEqual({})
+  })
+
+  it('discards malformed/invalid envelope data', () => {
+    localStorage.setItem('test:c', JSON.stringify({ v: 1, data: { foo: 42 } }))
+    expect(readVersionedPreference('test:c', 1, isStringRecord, {})).toEqual({})
+  })
+
+  it('migrates a legacy bare (unversioned) value and upgrades it on next write', () => {
+    localStorage.setItem('test:d', JSON.stringify({ foo: 'legacy' }))
+    const value = readVersionedPreference('test:d', 1, isStringRecord, {}, { legacyIsValid: isStringRecord })
+    expect(value).toEqual({ foo: 'legacy' })
+
+    writeVersionedPreference('test:d', 1, value)
+    expect(JSON.parse(localStorage.getItem('test:d')!)).toEqual({ v: 1, data: { foo: 'legacy' } })
+  })
+
+  it('treats a legacy record with a literal "v" key as legacy data, not a malformed envelope', () => {
+    localStorage.setItem('test:legacy-v-key', JSON.stringify({ v: 250, other: 300 }))
+    function isNumberRecord(value: unknown): value is Record<string, number> {
+      return !!value && typeof value === 'object' && !Array.isArray(value)
+        && Object.values(value as Record<string, unknown>).every((v) => typeof v === 'number')
+    }
+    expect(readVersionedPreference('test:legacy-v-key', 1, isNumberRecord, {}, { legacyIsValid: isNumberRecord }))
+      .toEqual({ v: 250, other: 300 })
+  })
+
+  it('does not migrate a legacy value when legacyIsValid is not provided', () => {
+    localStorage.setItem('test:e', JSON.stringify({ foo: 'legacy' }))
+    expect(readVersionedPreference('test:e', 1, isStringRecord, {})).toEqual({})
+  })
+
+  it('clearVersionedPreference removes the key', () => {
+    writeVersionedPreference('test:f', 1, { foo: 'bar' })
+    clearVersionedPreference('test:f')
+    expect(localStorage.getItem('test:f')).toBeNull()
+  })
+
+  describe('readVersionedIdSet / writeVersionedIdSet', () => {
+    it('round-trips a set of ids', () => {
+      writeVersionedIdSet('test:ids', 1, new Set(['a', 'b']))
+      expect(readVersionedIdSet('test:ids', 1)).toEqual(new Set(['a', 'b']))
+    })
+
+    it('migrates a legacy bare string[] array', () => {
+      localStorage.setItem('test:ids-legacy', JSON.stringify(['x', 'y']))
+      expect(readVersionedIdSet('test:ids-legacy', 1)).toEqual(new Set(['x', 'y']))
+    })
+
+    it('falls back to an empty set for malformed entries', () => {
+      localStorage.setItem('test:ids-bad', JSON.stringify({ v: 1, data: [1, 2, 3] }))
+      expect(readVersionedIdSet('test:ids-bad', 1)).toEqual(new Set())
+    })
+  })
+})

--- a/packages/shared/src/lib/browser/versionedPreference.ts
+++ b/packages/shared/src/lib/browser/versionedPreference.ts
@@ -1,0 +1,40 @@
+import { readJsonFromLocalStorage, writeJsonToLocalStorage, removeLocalStorageKey, type JsonSerializable } from './safeLocalStorage'
+
+type VersionedEnvelope<T> = { v: number; data: T }
+
+export function readVersionedPreference<T>(
+  key: string,
+  version: number,
+  isValid: (value: unknown) => value is T,
+  fallback: T,
+  options?: { legacyIsValid?: (value: unknown) => value is T },
+): T {
+  const raw = readJsonFromLocalStorage<JsonSerializable>(key, null)
+  if (raw && typeof raw === 'object' && !Array.isArray(raw) && 'v' in raw && 'data' in raw) {
+    const envelope = raw as { v?: unknown; data?: unknown }
+    return envelope.v === version && isValid(envelope.data) ? envelope.data : fallback
+  }
+  if (options?.legacyIsValid && options.legacyIsValid(raw)) return raw
+  return fallback
+}
+
+export function writeVersionedPreference<T>(key: string, version: number, data: T): void {
+  writeJsonToLocalStorage(key, { v: version, data } satisfies VersionedEnvelope<T>)
+}
+
+export function clearVersionedPreference(key: string): void {
+  removeLocalStorageKey(key)
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}
+
+/** Convenience pair for the common "set of ids" preference shape, with legacy bare-array migration. */
+export function readVersionedIdSet(key: string, version: number): Set<string> {
+  return new Set(readVersionedPreference<string[]>(key, version, isStringArray, [], { legacyIsValid: isStringArray }))
+}
+
+export function writeVersionedIdSet(key: string, version: number, ids: Set<string>): void {
+  writeVersionedPreference(key, version, Array.from(ids))
+}

--- a/packages/ui/src/ai/AiChat.tsx
+++ b/packages/ui/src/ai/AiChat.tsx
@@ -76,49 +76,13 @@ import { useAiChatUpload } from './useAiChatUpload'
 import { useAiShortcuts } from './useAiShortcuts'
 import { LoopTracePanel, type LoopTracePanelTrace } from './LoopTracePanel'
 import { AiIcon } from './AiIcon'
+import { readModelPickerValue, writeModelPickerValue } from './modelPickerStorage'
 
 // Cap inline previews so we do not blow past localStorage quota (~5MB on most
 // browsers). Images larger than this still upload + send to the LLM as inline
 // base64 server-side; only the in-chat preview is dropped on reload.
 const PREVIEW_DATA_URL_MAX_BYTES = 2 * 1024 * 1024
 const COMPACT_FOOTER_MAX_WIDTH = 640
-
-const MODEL_PICKER_STORAGE_PREFIX = 'om-ai-model-picker:'
-
-function readModelPickerValue(agentId: string): ModelPickerValue | null {
-  if (typeof window === 'undefined') return null
-  try {
-    const raw = window.localStorage.getItem(`${MODEL_PICKER_STORAGE_PREFIX}${agentId}`)
-    if (!raw) return null
-    const parsed = JSON.parse(raw) as unknown
-    if (
-      parsed &&
-      typeof parsed === 'object' &&
-      typeof (parsed as Record<string, unknown>).providerId === 'string' &&
-      typeof (parsed as Record<string, unknown>).modelId === 'string'
-    ) {
-      const value = parsed as ModelPickerValue
-      return { providerId: value.providerId, modelId: value.modelId }
-    }
-    return null
-  } catch {
-    return null
-  }
-}
-
-function writeModelPickerValue(agentId: string, value: ModelPickerValue | null): void {
-  if (typeof window === 'undefined') return
-  try {
-    const key = `${MODEL_PICKER_STORAGE_PREFIX}${agentId}`
-    if (value === null) {
-      window.localStorage.removeItem(key)
-    } else {
-      window.localStorage.setItem(key, JSON.stringify({ providerId: value.providerId, modelId: value.modelId }))
-    }
-  } catch {
-    // Quota exceeded / privacy mode — silently ignore.
-  }
-}
 
 interface ModelsApiResponse {
   agentId: string

--- a/packages/ui/src/ai/AiChatSessions.tsx
+++ b/packages/ui/src/ai/AiChatSessions.tsx
@@ -24,6 +24,7 @@ import {
   getCurrentOrganizationScope,
   subscribeOrganizationScopeChanged,
 } from '@open-mercato/shared/lib/frontend/organizationEvents'
+import { readVersionedPreference, writeVersionedPreference } from '@open-mercato/shared/lib/browser/versionedPreference'
 import {
   createAiServerConversation,
   listAiServerConversations,
@@ -108,57 +109,62 @@ function makeId(): string {
   return `${Date.now().toString(16)}-${rand()}-${rand()}`
 }
 
-function readPersisted(storageKey: string): AiChatSessionsState {
-  if (typeof window === 'undefined') return { sessions: [], activeByAgent: {} }
-  try {
-    const raw = window.localStorage.getItem(storageKey)
-    if (!raw) return { sessions: [], activeByAgent: {} }
-    const parsed = JSON.parse(raw) as Partial<AiChatSessionsState> | null
-    const sessions = Array.isArray(parsed?.sessions)
-      ? (parsed!.sessions as unknown[])
-          .filter((entry): entry is AiChatSession => {
-            if (!entry || typeof entry !== 'object') return false
-            const value = entry as Record<string, unknown>
-            return (
-              typeof value.id === 'string' &&
-              typeof value.agentId === 'string' &&
-              typeof value.conversationId === 'string' &&
-              typeof value.createdAt === 'number' &&
-              typeof value.lastUsedAt === 'number' &&
-              (value.status === 'open' || value.status === 'closed')
-            )
-          })
-          .map((entry) => {
-            const value = entry as unknown as Record<string, unknown>
-            const candidate = value.name
-            return {
-              ...entry,
-              name: typeof candidate === 'string' ? candidate : undefined,
-            }
-          })
-      : []
-    const activeByAgent =
-      parsed?.activeByAgent && typeof parsed.activeByAgent === 'object'
-        ? Object.fromEntries(
-            Object.entries(parsed.activeByAgent as Record<string, unknown>).filter(
-              (entry): entry is [string, string] =>
-                typeof entry[0] === 'string' && typeof entry[1] === 'string',
-            ),
-          )
-        : {}
-    return { sessions, activeByAgent }
-  } catch {
-    return { sessions: [], activeByAgent: {} }
-  }
+// Versioned-envelope discriminator for the persisted sessions cache. Bump when
+// the stored shape changes incompatibly; legacy bare `{ sessions, activeByAgent }`
+// values are migrated forward on the next write. See
+// `@open-mercato/shared/lib/browser/versionedPreference`.
+const AI_CHAT_SESSIONS_VERSION = 1
+
+function isPersistedSessionsShape(value: unknown): value is Partial<AiChatSessionsState> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
-function writePersisted(storageKey: string, state: AiChatSessionsState): void {
-  if (typeof window === 'undefined') return
-  try {
-    window.localStorage.setItem(storageKey, JSON.stringify(state))
-  } catch {
-    /* quota / privacy mode — drop silently */
-  }
+export function readPersisted(storageKey: string): AiChatSessionsState {
+  const parsed = readVersionedPreference<Partial<AiChatSessionsState> | null>(
+    storageKey,
+    AI_CHAT_SESSIONS_VERSION,
+    (value): value is Partial<AiChatSessionsState> | null => isPersistedSessionsShape(value),
+    null,
+    { legacyIsValid: (value): value is Partial<AiChatSessionsState> | null => isPersistedSessionsShape(value) },
+  )
+  if (!parsed) return { sessions: [], activeByAgent: {} }
+  const sessions = Array.isArray(parsed.sessions)
+    ? (parsed.sessions as unknown[])
+        .filter((entry): entry is AiChatSession => {
+          if (!entry || typeof entry !== 'object') return false
+          const value = entry as Record<string, unknown>
+          return (
+            typeof value.id === 'string' &&
+            typeof value.agentId === 'string' &&
+            typeof value.conversationId === 'string' &&
+            typeof value.createdAt === 'number' &&
+            typeof value.lastUsedAt === 'number' &&
+            (value.status === 'open' || value.status === 'closed')
+          )
+        })
+        .map((entry) => {
+          const value = entry as unknown as Record<string, unknown>
+          const candidate = value.name
+          return {
+            ...entry,
+            name: typeof candidate === 'string' ? candidate : undefined,
+          }
+        })
+    : []
+  const activeByAgent =
+    parsed.activeByAgent && typeof parsed.activeByAgent === 'object'
+      ? Object.fromEntries(
+          Object.entries(parsed.activeByAgent as Record<string, unknown>).filter(
+            (entry): entry is [string, string] =>
+              typeof entry[0] === 'string' && typeof entry[1] === 'string',
+          ),
+        )
+      : {}
+  return { sessions, activeByAgent }
+}
+
+export function writePersisted(storageKey: string, state: AiChatSessionsState): void {
+  writeVersionedPreference(storageKey, AI_CHAT_SESSIONS_VERSION, state)
 }
 
 function serverConversationToSession(

--- a/packages/ui/src/ai/__tests__/AiChat.modelPickerStorage.test.ts
+++ b/packages/ui/src/ai/__tests__/AiChat.modelPickerStorage.test.ts
@@ -1,0 +1,40 @@
+/** @jest-environment jsdom */
+import { readModelPickerValue, writeModelPickerValue } from '../modelPickerStorage'
+
+const PREFIX = 'om-ai-model-picker:'
+
+describe('AiChat model-picker storage (versioned envelope)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('writes a versioned envelope and reads it back', () => {
+    writeModelPickerValue('agent1', { providerId: 'openai', modelId: 'gpt' })
+    expect(JSON.parse(localStorage.getItem(`${PREFIX}agent1`)!)).toEqual({
+      v: 1,
+      data: { providerId: 'openai', modelId: 'gpt' },
+    })
+    expect(readModelPickerValue('agent1')).toEqual({ providerId: 'openai', modelId: 'gpt' })
+  })
+
+  it('migrates a legacy bare (pre-envelope) value on read', () => {
+    localStorage.setItem(`${PREFIX}agent2`, JSON.stringify({ providerId: 'anthropic', modelId: 'opus' }))
+    expect(readModelPickerValue('agent2')).toEqual({ providerId: 'anthropic', modelId: 'opus' })
+  })
+
+  it('discards a version-mismatched envelope', () => {
+    localStorage.setItem(`${PREFIX}agent3`, JSON.stringify({ v: 2, data: { providerId: 'x', modelId: 'y' } }))
+    expect(readModelPickerValue('agent3')).toBeNull()
+  })
+
+  it('returns null for malformed data', () => {
+    localStorage.setItem(`${PREFIX}agent4`, JSON.stringify({ providerId: 123 }))
+    expect(readModelPickerValue('agent4')).toBeNull()
+  })
+
+  it('clears the slot when writing null', () => {
+    writeModelPickerValue('agent5', { providerId: 'a', modelId: 'b' })
+    writeModelPickerValue('agent5', null)
+    expect(localStorage.getItem(`${PREFIX}agent5`)).toBeNull()
+  })
+})

--- a/packages/ui/src/ai/__tests__/AiChatSessions.storage.test.ts
+++ b/packages/ui/src/ai/__tests__/AiChatSessions.storage.test.ts
@@ -1,0 +1,42 @@
+/** @jest-environment jsdom */
+import { readPersisted, writePersisted } from '../AiChatSessions'
+
+const KEY = 'om-ai-chat-sessions-v1:t1:o1'
+const session = {
+  id: 's1',
+  agentId: 'a1',
+  conversationId: 'c1',
+  createdAt: 1,
+  lastUsedAt: 2,
+  status: 'open' as const,
+}
+
+describe('AiChatSessions persisted cache (versioned envelope)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('writes a versioned envelope and reads it back', () => {
+    const state = { sessions: [session], activeByAgent: { a1: 's1' } }
+    writePersisted(KEY, state)
+    const stored = JSON.parse(localStorage.getItem(KEY)!)
+    expect(stored.v).toBe(1)
+    expect(stored.data).toEqual(state)
+    expect(readPersisted(KEY)).toEqual(state)
+  })
+
+  it('migrates a legacy bare (pre-envelope) cache on read', () => {
+    const legacy = { sessions: [session], activeByAgent: { a1: 's1' } }
+    localStorage.setItem(KEY, JSON.stringify(legacy))
+    expect(readPersisted(KEY)).toEqual(legacy)
+  })
+
+  it('discards a version-mismatched envelope', () => {
+    localStorage.setItem(KEY, JSON.stringify({ v: 99, data: { sessions: [session], activeByAgent: { a1: 's1' } } }))
+    expect(readPersisted(KEY)).toEqual({ sessions: [], activeByAgent: {} })
+  })
+
+  it('returns empty state for missing data', () => {
+    expect(readPersisted(KEY)).toEqual({ sessions: [], activeByAgent: {} })
+  })
+})

--- a/packages/ui/src/ai/__tests__/AiChatSessions.test.tsx
+++ b/packages/ui/src/ai/__tests__/AiChatSessions.test.tsx
@@ -120,9 +120,10 @@ describe('<AiChatSessionsProvider> — tenant/org scope isolation', () => {
 
     const scoped = window.localStorage.getItem(scopedKey('T1', 'O1'))
     expect(scoped).not.toBeNull()
-    const parsed = JSON.parse(scoped!) as { sessions: Array<{ agentId: string }> }
-    expect(parsed.sessions).toHaveLength(1)
-    expect(parsed.sessions[0].agentId).toBe('assistant')
+    const parsed = JSON.parse(scoped!) as { v: number; data: { sessions: Array<{ agentId: string }> } }
+    expect(parsed.v).toBe(1)
+    expect(parsed.data.sessions).toHaveLength(1)
+    expect(parsed.data.sessions[0].agentId).toBe('assistant')
 
     expect(window.localStorage.getItem(scopedKey('T2', 'O2'))).toBeNull()
   })
@@ -185,11 +186,14 @@ describe('<AiChatSessionsProvider> — tenant/org scope isolation', () => {
       expect(screen.getByTestId('session-count').textContent).toBe('1')
     })
 
-    // T1/O1 bucket must remain untouched after the swap.
+    // T1/O1 bucket must retain its 2 sessions after the swap. The legacy bare
+    // value seeded above is migrated forward to the versioned `{ v, data }`
+    // envelope on mount, so read the sessions from `data`.
     const t1Raw = window.localStorage.getItem(scopedKey('T1', 'O1'))
     expect(t1Raw).not.toBeNull()
-    const t1Parsed = JSON.parse(t1Raw!) as { sessions: unknown[] }
-    expect(t1Parsed.sessions).toHaveLength(2)
+    const t1Parsed = JSON.parse(t1Raw!) as { v: number; data: { sessions: unknown[] } }
+    expect(t1Parsed.v).toBe(1)
+    expect(t1Parsed.data.sessions).toHaveLength(2)
   })
 
   it('refires the server conversation list on scope change', async () => {

--- a/packages/ui/src/ai/modelPickerStorage.ts
+++ b/packages/ui/src/ai/modelPickerStorage.ts
@@ -1,0 +1,40 @@
+import { readVersionedPreference, writeVersionedPreference, clearVersionedPreference } from '@open-mercato/shared/lib/browser/versionedPreference'
+import type { ModelPickerValue } from './ModelPicker'
+
+const MODEL_PICKER_STORAGE_PREFIX = 'om-ai-model-picker:'
+
+// Versioned-envelope discriminator for the persisted model-picker selection.
+// Bump when the stored shape changes incompatibly; legacy bare `{ providerId,
+// modelId }` values are migrated forward on the next write. See
+// `@open-mercato/shared/lib/browser/versionedPreference`.
+const MODEL_PICKER_VERSION = 1
+
+function isModelPickerValue(value: unknown): value is ModelPickerValue {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).providerId === 'string' &&
+    typeof (value as Record<string, unknown>).modelId === 'string'
+  )
+}
+
+export function readModelPickerValue(agentId: string): ModelPickerValue | null {
+  const value = readVersionedPreference<ModelPickerValue | null>(
+    `${MODEL_PICKER_STORAGE_PREFIX}${agentId}`,
+    MODEL_PICKER_VERSION,
+    (candidate): candidate is ModelPickerValue | null => isModelPickerValue(candidate),
+    null,
+    { legacyIsValid: (candidate): candidate is ModelPickerValue | null => isModelPickerValue(candidate) },
+  )
+  return value ? { providerId: value.providerId, modelId: value.modelId } : null
+}
+
+export function writeModelPickerValue(agentId: string, value: ModelPickerValue | null): void {
+  const key = `${MODEL_PICKER_STORAGE_PREFIX}${agentId}`
+  if (value === null) {
+    clearVersionedPreference(key)
+    return
+  }
+  writeVersionedPreference(key, MODEL_PICKER_VERSION, { providerId: value.providerId, modelId: value.modelId })
+}

--- a/packages/ui/src/ai/useAiChat.ts
+++ b/packages/ui/src/ai/useAiChat.ts
@@ -195,6 +195,13 @@ const SESSION_UPDATED_EVENT = 'om-ai-chat-session-updated'
 const SESSION_STREAM_STATE_EVENT = 'om-ai-chat-session-stream-state'
 const activeSessionStreams = new Set<string>()
 
+// This slot already implements its own versioned, migratable shape: the inline
+// `v` discriminator is checked on read and the value is discarded on mismatch
+// (see `readPersistedSession`). It is intentionally NOT migrated to the generic
+// `{ v, data }` envelope from `@open-mercato/shared/lib/browser/versionedPreference`
+// — doing so would change the on-disk format and discard users' in-progress
+// sessions, and the write path needs bespoke transient-blob-URL stripping that
+// the generic helper does not express.
 interface PersistedAiChatSession {
   v: number
   conversationId: string

--- a/packages/ui/src/backend/AppShell.tsx
+++ b/packages/ui/src/backend/AppShell.tsx
@@ -31,6 +31,7 @@ import { UpgradeActionBanner } from './upgrades/UpgradeActionBanner'
 import { PartialIndexBanner } from './indexes/PartialIndexBanner'
 import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import { slugifySidebarId } from '@open-mercato/shared/modules/navigation/sidebarPreferences'
+import { readVersionedPreference, writeVersionedPreference } from '@open-mercato/shared/lib/browser/versionedPreference'
 import { cloneSidebarGroups } from './sidebar/customization-helpers'
 import type { SectionNavGroup } from './section-page/types'
 import { InjectionSpot } from './injection/InjectionSpot'
@@ -58,6 +59,25 @@ import {
   GLOBAL_HEADER_STATUS_INDICATORS_INJECTION_SPOT_ID,
   GLOBAL_SIDEBAR_STATUS_BADGES_INJECTION_SPOT_ID,
 } from './injection/spotIds'
+
+// Versioned-envelope discriminator for the persisted sidebar open/closed group
+// map. This is a structured value (a record), so it carries a version so future
+// shape changes can migrate or safely discard stale data; legacy bare
+// `Record<string, boolean>` values are migrated forward on the next write. The
+// neighbouring `om:sidebarCollapsed` / `om:progress:expanded` flags are trivial
+// scalar booleans and deliberately stay raw (see their write sites). See
+// `@open-mercato/shared/lib/browser/versionedPreference`.
+const SIDEBAR_OPEN_GROUPS_KEY = 'om:sidebarOpenGroups'
+const SIDEBAR_OPEN_GROUPS_VERSION = 1
+
+function isBooleanRecord(value: unknown): value is Record<string, boolean> {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.values(value as Record<string, unknown>).every((entry) => typeof entry === 'boolean')
+  )
+}
 
 export type ShellLogo = {
   src: string
@@ -605,22 +625,23 @@ function AppShellBody({ productName, logo, email, canManageUpgradeActions = fals
   }, [mobileOpen])
 
   React.useEffect(() => {
-    try {
-      const savedOpen = typeof window !== 'undefined' ? localStorage.getItem('om:sidebarOpenGroups') : null
-      if (!savedOpen) return
-      const parsed = JSON.parse(savedOpen) as Record<string, boolean>
-      setOpenGroups((prev) => {
-        const next = { ...prev }
-        for (const group of resolvedGroups) {
-          const key = resolveGroupKey(group)
-          if (key in parsed) next[key] = !!parsed[key]
-          else if (group.name in parsed) next[key] = !!parsed[group.name]
-        }
-        return next
-      })
-    } catch {
-      // ignore localStorage errors to avoid breaking hydration
-    }
+    const parsed = readVersionedPreference<Record<string, boolean>>(
+      SIDEBAR_OPEN_GROUPS_KEY,
+      SIDEBAR_OPEN_GROUPS_VERSION,
+      isBooleanRecord,
+      {},
+      { legacyIsValid: isBooleanRecord },
+    )
+    if (Object.keys(parsed).length === 0) return
+    setOpenGroups((prev) => {
+      const next = { ...prev }
+      for (const group of resolvedGroups) {
+        const key = resolveGroupKey(group)
+        if (key in parsed) next[key] = !!parsed[key]
+        else if (group.name in parsed) next[key] = !!parsed[group.name]
+      }
+      return next
+    })
   }, [resolvedGroups])
 
   const toggleGroup = (groupId: string) => setOpenGroups((prev) => ({ ...prev, [groupId]: prev[groupId] === false }))
@@ -633,6 +654,9 @@ function AppShellBody({ productName, logo, email, canManageUpgradeActions = fals
   // private/incognito mode (storage blocked) or when cookies are disabled —
   // the persisted preference is purely a UX nice-to-have, never functional, so
   // swallow the failure and let the component fall back to the default state.
+  // This is a trivial scalar flag ('1' | '0') with no schema to evolve, so it is
+  // intentionally kept raw rather than wrapped in a versioned envelope (the
+  // versioning threshold lives in `@open-mercato/shared/lib/browser/versionedPreference`).
   React.useEffect(() => {
     try { localStorage.setItem('om:sidebarCollapsed', collapsed ? '1' : '0') } catch { /* localStorage blocked (private mode) — non-critical */ }
     try {
@@ -659,7 +683,7 @@ function AppShellBody({ productName, logo, email, canManageUpgradeActions = fals
     previousSidebarModeRef.current = sidebarMode
   }, [sidebarMode, collapsed])
   React.useEffect(() => {
-    try { localStorage.setItem('om:sidebarOpenGroups', JSON.stringify(openGroups)) } catch { /* localStorage blocked (private mode) — non-critical */ }
+    writeVersionedPreference(SIDEBAR_OPEN_GROUPS_KEY, SIDEBAR_OPEN_GROUPS_VERSION, openGroups)
   }, [openGroups])
 
   // Ensure current route's group is expanded on load

--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -40,6 +40,7 @@ import { PerspectiveSidebar } from './PerspectiveSidebar'
 import { Popover, PopoverTrigger, PopoverContent } from '../primitives/popover'
 import { formatWithPublicDateFormat, normalizeDateFormatPattern } from '../primitives/date-format'
 import { cn } from '@open-mercato/shared/lib/utils'
+import { readVersionedPreference, writeVersionedPreference, clearVersionedPreference } from '@open-mercato/shared/lib/browser/versionedPreference'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { flash } from './FlashMessages'
 import { useConfirmDialog } from './confirm-dialog'
@@ -484,6 +485,19 @@ type PerspectiveSnapshot = {
   updatedAt: number
 }
 
+// Versioned-envelope discriminator for the persisted perspective snapshot. Bump
+// when the snapshot shape changes incompatibly and add a read-old migration
+// branch; see `@open-mercato/shared/lib/browser/versionedPreference`.
+const PERSPECTIVE_SNAPSHOT_VERSION = 1
+
+type StoredPerspectiveSnapshot = { perspectiveId?: unknown; settings?: unknown; updatedAt?: unknown }
+
+function isStoredPerspectiveSnapshot(value: unknown): value is StoredPerspectiveSnapshot {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const settings = (value as Record<string, unknown>).settings
+  return typeof settings === 'object' && settings !== null
+}
+
 function readPerspectiveCookie(tableId: string): string | null {
   if (typeof document === 'undefined') return null
   const key = `${PERSPECTIVE_COOKIE_PREFIX}:${tableId}`
@@ -500,40 +514,31 @@ function writePerspectiveCookie(tableId: string, perspectiveId: string | null): 
   document.cookie = `${key}=${value}; Path=/; ${expires}; SameSite=Lax`
 }
 
-function readPerspectiveSnapshot(tableId: string): PerspectiveSnapshot | null {
-  if (typeof window === 'undefined') return null
-  try {
-    const raw = window.localStorage.getItem(`${PERSPECTIVE_STORAGE_PREFIX}:${tableId}`)
-    if (!raw) return null
-    const parsed = JSON.parse(raw)
-    if (!parsed || typeof parsed !== 'object') return null
-    const perspectiveId =
-      typeof parsed.perspectiveId === 'string' && parsed.perspectiveId.trim().length > 0
-        ? parsed.perspectiveId
-        : null
-    const settings = typeof parsed.settings === 'object' && parsed.settings !== null
-      ? parsed.settings as PerspectiveSettings
+export function readPerspectiveSnapshot(tableId: string): PerspectiveSnapshot | null {
+  const parsed = readVersionedPreference<StoredPerspectiveSnapshot | null>(
+    `${PERSPECTIVE_STORAGE_PREFIX}:${tableId}`,
+    PERSPECTIVE_SNAPSHOT_VERSION,
+    (value): value is StoredPerspectiveSnapshot | null => isStoredPerspectiveSnapshot(value),
+    null,
+    { legacyIsValid: (value): value is StoredPerspectiveSnapshot | null => isStoredPerspectiveSnapshot(value) },
+  )
+  if (!parsed) return null
+  const perspectiveId =
+    typeof parsed.perspectiveId === 'string' && parsed.perspectiveId.trim().length > 0
+      ? parsed.perspectiveId
       : null
-    const updatedAt = typeof parsed.updatedAt === 'number' ? parsed.updatedAt : Date.now()
-    if (!settings) return null
-    return { perspectiveId, settings, updatedAt }
-  } catch {
-    return null
-  }
+  const settings = parsed.settings as PerspectiveSettings
+  const updatedAt = typeof parsed.updatedAt === 'number' ? parsed.updatedAt : Date.now()
+  return { perspectiveId, settings, updatedAt }
 }
 
-function writePerspectiveSnapshot(tableId: string, snapshot: PerspectiveSnapshot | null) {
-  if (typeof window === 'undefined') return
+export function writePerspectiveSnapshot(tableId: string, snapshot: PerspectiveSnapshot | null) {
   const key = `${PERSPECTIVE_STORAGE_PREFIX}:${tableId}`
-  try {
-    if (!snapshot) {
-      window.localStorage.removeItem(key)
-      return
-    }
-    window.localStorage.setItem(key, JSON.stringify(snapshot))
-  } catch {
-    // ignore storage errors
+  if (!snapshot) {
+    clearVersionedPreference(key)
+    return
   }
+  writeVersionedPreference(key, PERSPECTIVE_SNAPSHOT_VERSION, snapshot)
 }
 
 function sanitizePerspectiveSettings(source?: PerspectiveSettings | null): PerspectiveSettings | null {

--- a/packages/ui/src/backend/__tests__/DataTable.perspectiveStorage.test.ts
+++ b/packages/ui/src/backend/__tests__/DataTable.perspectiveStorage.test.ts
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+import { readPerspectiveSnapshot, writePerspectiveSnapshot } from '../DataTable'
+
+const PREFIX = 'om_table_perspective_snapshot'
+
+describe('DataTable perspective snapshot storage (versioned envelope)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('writes a versioned envelope and reads it back', () => {
+    const snapshot = { perspectiveId: 'p1', settings: { columnOrder: ['a', 'b'] }, updatedAt: 123 }
+    writePerspectiveSnapshot('tbl', snapshot)
+    const stored = JSON.parse(localStorage.getItem(`${PREFIX}:tbl`)!)
+    expect(stored.v).toBe(1)
+    expect(stored.data).toEqual(snapshot)
+    expect(readPerspectiveSnapshot('tbl')).toEqual(snapshot)
+  })
+
+  it('migrates a legacy bare (pre-envelope) snapshot on read', () => {
+    const legacy = { perspectiveId: 'p2', settings: { columnOrder: ['x'] }, updatedAt: 7 }
+    localStorage.setItem(`${PREFIX}:tbl2`, JSON.stringify(legacy))
+    expect(readPerspectiveSnapshot('tbl2')).toEqual(legacy)
+  })
+
+  it('discards a version-mismatched envelope', () => {
+    localStorage.setItem(
+      `${PREFIX}:tbl3`,
+      JSON.stringify({ v: 99, data: { perspectiveId: null, settings: {}, updatedAt: 1 } }),
+    )
+    expect(readPerspectiveSnapshot('tbl3')).toBeNull()
+  })
+
+  it('returns null for a malformed value (no settings object)', () => {
+    localStorage.setItem(`${PREFIX}:tbl4`, JSON.stringify({ foo: 'bar' }))
+    expect(readPerspectiveSnapshot('tbl4')).toBeNull()
+  })
+
+  it('clears the slot when writing null', () => {
+    writePerspectiveSnapshot('tbl5', { perspectiveId: null, settings: { columnOrder: ['z'] }, updatedAt: 1 })
+    writePerspectiveSnapshot('tbl5', null)
+    expect(localStorage.getItem(`${PREFIX}:tbl5`)).toBeNull()
+  })
+})

--- a/packages/ui/src/backend/progress/ProgressTopBar.tsx
+++ b/packages/ui/src/backend/progress/ProgressTopBar.tsx
@@ -26,6 +26,10 @@ export function ProgressTopBar({ className, t, completedAutoHideMs }: ProgressTo
   const visibleCompleted = useAutoHideCompletedJobs(recentlyCompleted, completedAutoHideMs)
   const [expanded, setExpanded] = React.useState(false)
 
+  // `om:progress:expanded` is a trivial scalar flag ('true' | 'false') with no
+  // schema to evolve, so it is intentionally kept raw rather than wrapped in a
+  // versioned envelope (the versioning threshold for structured persisted state
+  // lives in `@open-mercato/shared/lib/browser/versionedPreference`).
   React.useEffect(() => {
     const saved = localStorage.getItem('om:progress:expanded')
     if (saved === 'true') setExpanded(true)


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Several shared UI surfaces persisted browser state with ad hoc `localStorage` keys and unversioned JSON shapes, with per-component parsing and no migration/discard story when a schema changes. This standardizes them behind a small shared versioned-envelope helper so structured persisted state can migrate or be safely discarded, while trivial scalar flags stay simple.

> Coordinates with open PR #3393 (issue #3178), which introduces the same `packages/shared/src/lib/browser/versionedPreference.ts` helper for the *customers* module surfaces. This PR is the *shared-UI + AI-chat* half of the same audit. The helper + its unit test are mirrored byte-for-byte here so this branch builds standalone on `develop`; whichever of #3174/#3393 merges second simply drops its identical copy of those two shared files (trivial add/add). The net contribution here is the UI-package migrations.

## Changes

- Added `packages/shared/src/lib/browser/versionedPreference.ts` (mirrors #3393): `readVersionedPreference`/`writeVersionedPreference`/`clearVersionedPreference` (generic `{ v, data }` envelope built on the existing `safeLocalStorage` helpers) plus `readVersionedIdSet`/`writeVersionedIdSet`. Invalid/version-mismatched data is safely discarded; a legacy pre-envelope value is migrated forward via an optional `legacyIsValid` guard.
- Documented the helper and the **versioning threshold** (trivial scalar flags may stay raw; structured values must use a versioned envelope; an already-inline-versioned slot need not be re-wrapped) in `packages/shared/AGENTS.md`, plus a `browser/` row in the library table.
- Migrated `DataTable.tsx` perspective snapshots, `AiChatSessions.tsx` sessions cache, the AI model-picker selection (extracted to a new `packages/ui/src/ai/modelPickerStorage.ts`), and `AppShell.tsx` `om:sidebarOpenGroups` onto the versioned envelope, preserving each surface's prior read coercion/field-filtering and keeping the storage keys unchanged so existing values migrate forward.
- Kept the trivial scalar flags `om:sidebarCollapsed` (AppShell) and `om:progress:expanded` (ProgressTopBar) raw, each with a documented reason referencing the versioning threshold.
- Left `useAiChat.ts` session persistence as-is (it already carries its own inline `v` discriminator with discard-on-mismatch) and documented why it is intentionally not re-wrapped (would change the on-disk format and discard users' in-progress sessions; its write needs bespoke transient-blob-URL stripping).

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- N/A — client-side storage refactor, no behavior/contract change -->


## Testing

- `yarn workspace @open-mercato/shared test versionedPreference` — 10/10 (round-trip, version-mismatch discard, malformed discard, legacy migration incl. literal-`v`-key edge case, id-set round-trip/migration/malformed).
- `yarn workspace @open-mercato/ui test` — 185 suites / 1571 tests pass, including the 3 new per-surface storage tests (perspective snapshot, model picker, sessions cache: each asserts envelope write + legacy migration + version-mismatch/malformed discard) and the updated `AiChatSessions.test.tsx` envelope assertions.
- `yarn workspace @open-mercato/shared test` — 121 suites / 1288 tests pass.
- `yarn typecheck` — 21/21 packages pass.
- `yarn i18n:check-sync` — all locales in sync (no new user-facing strings).
- `TURBO_FORCE=1 yarn build:app` — succeeds.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. *(Added the Browser Storage guidance + library row to `packages/shared/AGENTS.md`; no locales/generators affected.)*
- [x] I added or adjusted tests that cover the change. *(Helper unit tests + 3 new per-surface storage tests + updated `AiChatSessions.test.tsx`.)*
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). *(Not required — this is a client-side `localStorage` refactor with no API/server surface; it is fully covered by unit + component (jsdom) tests that exercise the real read/write functions and the real session provider.)*
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). *(N/A — minor refactor, no spec; matches sibling PR #3393.)*
- [x] Priority set: this PR carries exactly one `priority-*` label. *(`priority-low`, inherited from the issue.)*
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. *(`risk-medium`, inherited from the issue — touches shared UI + AI chat surfaces, behavior preserved.)*
- [x] QA routing set. *(`needs-qa` — touches customer-facing shared UI surfaces; behavior is preserved and fully test-covered, so a light smoke (reload persistence on a DataTable perspective, sidebar groups, AI model picker / chat sessions) suffices.)*

### Design System Compliance
- [x] No hardcoded status colors — *N/A, no markup/className changed (storage mechanics only)*
- [x] No arbitrary text sizes — *N/A, no markup changed*
- [x] Empty state handled for list/data pages — *N/A, no rendering changed*
- [x] Loading state handled for async pages — *N/A, no rendering changed*
- [x] `aria-label` on all icon-only buttons — *N/A, no markup changed*
- [x] Uses existing DS components — *N/A, no components added/changed*

## Linked issues

Fixes #3174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
