### PR TITLE
perf(sales): hoist SalesDocumentForm custom render components out of the parent component (#3173)

### DIFF
--- a/packages/core/src/modules/sales/components/__tests__/salesDocumentFormHoistedRenderers.test.tsx
+++ b/packages/core/src/modules/sales/components/__tests__/salesDocumentFormHoistedRenderers.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression coverage for #3173: the sales document form's custom field/group
+ * renderers must be hoisted to module scope (stable component identity, hooks in
+ * real React component boundaries) rather than defined inside SalesDocumentForm.
+ *
+ * - The "structural" block fails while the renderers are nested and passes once
+ *   they are hoisted (the bug reproduction).
+ * - The "behavior" block exercises document-number, billing-address and
+ *   customer-selection rendering to prove the refactor preserves behavior.
+ */
+import * as React from 'react'
+import * as fs from 'fs'
+import * as path from 'path'
+import { render, screen, waitFor } from '@testing-library/react'
+
+jest.setTimeout(20000)
+
+const mockApiCall = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: any[]) => mockApiCall(...args),
+  apiCallOrThrow: jest.fn().mockResolvedValue({ items: [] }),
+  readApiResultOrThrow: jest.fn().mockResolvedValue({ items: [] }),
+}))
+
+// Render the captured field/group renderers so their behavior is exercised.
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
+  CrudForm: ({ fields, groups, initialValues }: any) => {
+    const docField = (fields ?? []).find((f: any) => f.id === 'documentNumber')
+    const billingField = (fields ?? []).find((f: any) => f.id === 'billingAddressSection')
+    const customerGroup = (groups ?? []).find((g: any) => g.id === 'customer')
+    const fieldProps = {
+      value: '',
+      setValue: () => {},
+      setFormValue: () => {},
+      values: initialValues ?? {},
+    }
+    return (
+      <div>
+        <div data-testid="doc-number">
+          {docField ? docField.component({ ...fieldProps, id: 'documentNumber' }) : null}
+        </div>
+        <div data-testid="billing">
+          {billingField ? billingField.component({ ...fieldProps, id: 'billingAddressSection' }) : null}
+        </div>
+        <div data-testid="customer">
+          {customerGroup?.component
+            ? customerGroup.component({ values: initialValues ?? {}, setValue: () => {}, errors: {} })
+            : null}
+        </div>
+      </div>
+    )
+  },
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  createCrud: jest.fn().mockResolvedValue({ ok: true }),
+  updateCrud: jest.fn().mockResolvedValue({ ok: true }),
+  deleteCrud: jest.fn().mockResolvedValue({ ok: true }),
+  buildCrudExportUrl: () => '/export.csv',
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({ flash: jest.fn() }))
+
+jest.mock('@open-mercato/ui/backend/inputs', () => ({
+  LookupSelect: () => <div data-testid="lookup-select" />,
+}))
+
+jest.mock('@open-mercato/ui/primitives/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}))
+
+jest.mock('@open-mercato/ui/primitives/email-input', () => ({
+  EmailInput: (props: any) => <input type="email" {...props} />,
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: any) => <span>{placeholder}</span>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/switch-field', () => ({
+  SwitchField: ({ label }: any) => <label>{label}</label>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/dialog', () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <p>{children}</p>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <h3>{children}</h3>,
+  DialogTrigger: ({ children }: any) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/customFieldValues', () => ({
+  collectCustomFieldValues: jest.fn().mockReturnValue({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/serverErrors', () => ({
+  raiseCrudError: jest.fn(),
+  createCrudFormError: (msg: string) => new Error(msg),
+  normalizeCrudServerError: (err: any) => ({ message: err?.message ?? 'error' }),
+}))
+
+jest.mock('@open-mercato/core/modules/dictionaries/components/DictionaryEntrySelect', () => ({
+  DictionaryEntrySelect: () => <select />,
+}))
+
+jest.mock('@open-mercato/core/modules/customers/components/detail/hooks/useCurrencyDictionary', () => ({
+  useCurrencyDictionary: () => ({ data: { entries: [] }, refetch: jest.fn() }),
+}))
+
+jest.mock('@open-mercato/core/modules/customers/backend/hooks/useEmailDuplicateCheck', () => ({
+  useEmailDuplicateCheck: () => ({ checking: false, duplicate: false, check: jest.fn() }),
+}))
+
+jest.mock('@open-mercato/core/modules/customers/components/formConfig', () => ({
+  createPersonFormFields: () => [],
+  createPersonFormGroups: () => [],
+  createPersonFormSchema: () => ({}),
+  createCompanyFormFields: () => [],
+  createCompanyFormGroups: () => [],
+  createCompanyFormSchema: () => ({}),
+  buildPersonPayload: jest.fn(),
+  buildCompanyPayload: jest.fn(),
+}))
+
+jest.mock('@open-mercato/core/modules/customers/components/AddressEditor', () => ({
+  AddressEditor: () => <div data-testid="address-editor" />,
+}))
+
+jest.mock('@open-mercato/core/modules/customers/utils/addressFormat', () => ({
+  formatAddressString: () => '',
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallback?: string) => fallback ?? key,
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 1,
+  useOrganizationScopeDetail: () => ({ organizationId: 'org', tenantId: 'tenant' }),
+}))
+
+jest.mock('@open-mercato/shared/lib/custom-fields/normalize', () => ({
+  normalizeCustomFieldResponse: (input: any) => input,
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    sales: { sales_quote: 'sales:sales_quote', sales_order: 'sales:sales_order' },
+    customers: { customer_entity: 'customers:customer_entity', customer_company_profile: 'customers:company' },
+  },
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn(), replace: jest.fn() }),
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}))
+
+jest.mock('lucide-react', () => ({
+  Building2: () => <span />,
+  Mail: () => <span />,
+  Plus: () => <span />,
+  Store: () => <span />,
+  UserRound: () => <span />,
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { SalesDocumentForm } = require('../documents/SalesDocumentForm')
+
+describe('SalesDocumentForm hoisted renderers — structural (#3173)', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'documents', 'SalesDocumentForm.tsx'),
+    'utf8',
+  )
+
+  it('declares DocumentNumberField at module scope, not nested in the form', () => {
+    expect(source).toMatch(/^function DocumentNumberField\b/m)
+    expect(source).not.toMatch(/\n[ \t]+function DocumentNumberField\b/)
+  })
+
+  it('declares BillingAddressSectionField at module scope, not as an inline renderer', () => {
+    expect(source).toMatch(/^function BillingAddressSectionField\b/m)
+    expect(source).not.toMatch(/component:\s*function BillingAddressSectionField\b/)
+  })
+
+  it('declares CustomerGroupComponent at module scope, not as an inline renderer', () => {
+    expect(source).toMatch(/^function CustomerGroupComponent\b/m)
+    expect(source).not.toMatch(/component:\s*function CustomerGroupComponent\b/)
+  })
+
+  it('passes the hoisted renderers to CrudForm as stable element references', () => {
+    expect(source).toMatch(/<DocumentNumberField\b/)
+    expect(source).toMatch(/<BillingAddressSectionField\b/)
+    expect(source).toMatch(/<CustomerGroupComponent\b/)
+  })
+})
+
+describe('SalesDocumentForm hoisted renderers — behavior (#3173)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockApiCall.mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/api/catalog/price-kinds')) {
+        return Promise.resolve({
+          ok: true,
+          result: {
+            items: [{ id: 'pk-1', code: 'regular', title: 'Regular', currency_code: 'EUR', is_promotion: false, is_active: true }],
+          },
+        })
+      }
+      return Promise.resolve({ ok: true, result: { items: [], number: 'ORD-001' } })
+    })
+  })
+
+  it('renders the document-number field and auto-requests a number on mount', async () => {
+    render(<SalesDocumentForm onCreated={jest.fn()} initialKind="order" />)
+
+    await waitFor(() => {
+      expect(mockApiCall).toHaveBeenCalledWith(
+        '/api/sales/document-numbers',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+
+  it('renders the billing address section', async () => {
+    render(<SalesDocumentForm onCreated={jest.fn()} initialKind="order" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Billing address')).toBeTruthy()
+    })
+  })
+
+  it('renders the customer selection group with its email input', async () => {
+    render(<SalesDocumentForm onCreated={jest.fn()} initialKind="order" />)
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Email used for the document')).toBeTruthy()
+    })
+  })
+})

--- a/packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx
+++ b/packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from 'react'
-import { CrudForm, type CrudCustomFieldRenderProps, type CrudField, type CrudFormGroup } from '@open-mercato/ui/backend/CrudForm'
+import { CrudForm, type CrudCustomFieldRenderProps, type CrudField, type CrudFormGroup, type CrudFormGroupComponentProps } from '@open-mercato/ui/backend/CrudForm'
 import { LookupSelect, type LookupSelectItem } from '@open-mercato/ui/backend/inputs'
 import { Input } from '@open-mercato/ui/primitives/input'
 import { EmailInput } from '@open-mercato/ui/primitives/email-input'
@@ -406,6 +406,353 @@ function normalizeAddressDraft(draft?: AddressDraft | null): Record<string, unkn
   return Object.keys(normalized).length ? normalized : null
 }
 
+type DocumentNumberFieldProps = CrudCustomFieldRenderProps & { t: Translator }
+
+type BillingAddressSectionFieldProps = CrudCustomFieldRenderProps & {
+  t: Translator
+  addressesLoading: boolean
+  addressOptions: AddressOption[]
+  addressFormat: AddressFormatStrategy
+}
+
+type CustomerGroupComponentProps = CrudFormGroupComponentProps & {
+  t: Translator
+  customers: CustomerOption[]
+  setCustomers: React.Dispatch<React.SetStateAction<CustomerOption[]>>
+  customerQuerySetter: React.MutableRefObject<((value: string) => void) | null>
+  loadAddresses: (customerId?: string | null) => Promise<AddressOption[]>
+  loadCustomers: (query?: string) => Promise<CustomerOption[]>
+  fetchCustomerEmail: (id: string, kindHint?: 'person' | 'company') => Promise<string | null>
+  resetAddressFormState: (updateValue: (key: string, value: unknown) => void) => void
+}
+
+function DocumentNumberField({ value, setValue, values, t }: DocumentNumberFieldProps) {
+  const formValues = (values ?? {}) as Partial<SalesDocumentFormValues>
+  const kind: DocumentKind = formValues.documentKind === 'order' ? 'order' : 'quote'
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const autoValueRef = React.useRef<string | null>(null)
+  const lastKindRef = React.useRef<DocumentKind | null>(null)
+
+  const requestNumber = React.useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const call = await apiCall<{ number?: string; error?: string }>('/api/sales/document-numbers', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ kind }),
+      })
+      const nextNumber = typeof call.result?.number === 'string' ? call.result.number : null
+      if (call.ok && nextNumber) {
+        autoValueRef.current = nextNumber
+        lastKindRef.current = kind
+        setValue(nextNumber)
+      } else {
+        setError(call.result?.error || t('sales.documents.form.errors.numberGenerate', 'Could not generate a document number.'))
+      }
+    } catch (err) {
+      console.error('sales.documents.generateNumber', err)
+      setError(t('sales.documents.form.errors.numberGenerate', 'Could not generate a document number.'))
+    } finally {
+      setLoading(false)
+    }
+  }, [kind, setValue, t])
+
+  React.useEffect(() => {
+    const current = typeof value === 'string' ? value.trim() : ''
+    if (!current.length && !lastKindRef.current) {
+      void requestNumber()
+    } else {
+      lastKindRef.current = kind
+    }
+  }, [kind, requestNumber, value])
+
+  return (
+    <div className="space-y-2">
+      <div className="flex w-full flex-col gap-2 md:flex-row md:items-center md:gap-3">
+        <Input
+          value={typeof value === 'string' ? value : ''}
+          onChange={(event) => setValue(event.target.value)}
+          disabled={loading}
+          spellCheck={false}
+          className="w-full md:flex-1"
+        />
+        <Button type="button" variant="outline" onClick={requestNumber} disabled={loading}>
+          {loading
+            ? t('sales.documents.form.numberLoading', 'Generating…')
+            : t('sales.documents.form.numberRefresh', 'Generate')}
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {kind === 'order'
+          ? t('sales.documents.form.numberHintOrder', 'Format applies to orders and uses the configured counter.')
+          : t('sales.documents.form.numberHintQuote', 'Format applies to quotes and uses the configured counter.')}
+      </p>
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  )
+}
+
+function BillingAddressSectionField({ values, setFormValue, t, addressesLoading, addressOptions, addressFormat }: BillingAddressSectionFieldProps) {
+  const formValues = (values ?? {}) as Partial<SalesDocumentFormValues>
+  const updateValue = setFormValue ?? (() => {})
+  const useCustom = formValues.useCustomBilling === true
+  const selectedId = typeof formValues.billingAddressId === 'string' ? formValues.billingAddressId : ''
+  const draft = (formValues.billingAddressDraft ?? {}) as AddressDraft
+  const customerRequired = !formValues.customerEntityId
+  const sameAsShipping = formValues.sameAsShipping !== false
+  const shippingId = typeof formValues.shippingAddressId === 'string' ? formValues.shippingAddressId : null
+  const shippingDraft = (formValues.shippingAddressDraft ?? {}) as AddressDraft
+  const shippingDraftKey = JSON.stringify(shippingDraft)
+  const billingDraftKey = JSON.stringify(draft)
+  const useCustomShipping = formValues.useCustomShipping === true
+
+  React.useEffect(() => {
+    if (!sameAsShipping) return
+    if ((formValues.billingAddressId ?? null) !== shippingId) {
+      updateValue('billingAddressId', shippingId)
+    }
+    if (useCustomShipping !== (formValues.useCustomBilling === true)) {
+      updateValue('useCustomBilling', useCustomShipping)
+    }
+    if (useCustomShipping && shippingDraftKey !== billingDraftKey) {
+      updateValue('billingAddressDraft', shippingDraft)
+    }
+  }, [
+    billingDraftKey,
+    sameAsShipping,
+    updateValue,
+    shippingDraft,
+    shippingDraftKey,
+    shippingId,
+    useCustomShipping,
+    formValues.billingAddressId,
+    formValues.useCustomBilling,
+  ])
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="text-base font-semibold">
+            {t('sales.documents.form.billing.title', 'Billing address')}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {sameAsShipping
+              ? t('sales.documents.form.address.sameAsShippingHint', 'Billing will mirror the shipping address. Uncheck to edit.')
+              : t('sales.documents.form.billing.hint', 'Select an address or define a new one.')}
+          </p>
+        </div>
+        <SwitchField
+          label={t('sales.documents.form.address.sameAsShipping', 'Same as shipping')}
+          flip
+          checked={sameAsShipping}
+          onCheckedChange={(checked) => {
+            updateValue('sameAsShipping', checked)
+            if (checked) {
+              updateValue('useCustomBilling', useCustomShipping)
+              updateValue('billingAddressId', shippingId)
+              updateValue('billingAddressDraft', shippingDraft)
+            }
+          }}
+        />
+      </div>
+
+      {!sameAsShipping ? (
+        <>
+          {!useCustom ? (
+            <Select
+              value={selectedId || undefined}
+              onValueChange={(value) => updateValue('billingAddressId', value || null)}
+              disabled={addressesLoading || customerRequired}
+            >
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={
+                    addressesLoading
+                      ? t('sales.documents.form.address.loading', 'Loading addresses…')
+                      : t('sales.documents.form.address.placeholder', 'Select address')
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {addressOptions.map((addr) => {
+                  const optionLabel = addr.summary ? `${addr.label} — ${addr.summary}` : addr.label
+                  return (
+                    <SelectItem key={addr.id} value={addr.id}>{optionLabel}</SelectItem>
+                  )
+                })}
+              </SelectContent>
+            </Select>
+          ) : null}
+
+          <SwitchField
+            label={t('sales.documents.form.shipping.custom', 'Define new address')}
+            flip
+            checked={useCustom}
+            onCheckedChange={(checked) => updateValue('useCustomBilling', checked)}
+            disabled={false}
+          />
+
+          {useCustom ? (
+            <div className="space-y-3">
+              <AddressEditor
+                value={draft}
+                format={addressFormat}
+                t={t}
+                onChange={(next) => updateValue('billingAddressDraft', next)}
+                hidePrimaryToggle
+              />
+              <SwitchField
+                containerClassName="col-span-2"
+                label={t('sales.documents.form.address.saveToCustomer', 'Save this address to the customer')}
+                flip
+                checked={formValues.saveBillingAddress === true}
+                onCheckedChange={(checked) => updateValue('saveBillingAddress', checked)}
+              />
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+function CustomerGroupComponent({ values, setValue, t, customers, setCustomers, customerQuerySetter, loadAddresses, loadCustomers, fetchCustomerEmail, resetAddressFormState }: CustomerGroupComponentProps) {
+  const emailValue = typeof values.customerEmail === 'string' ? values.customerEmail : ''
+  const { duplicate, checking } = useEmailDuplicateCheck(emailValue, {
+    disabled: false,
+    debounceMs: 400,
+    matchMode: 'prefix',
+  })
+  return (
+    <div className="space-y-4">
+      <div className="space-y-3">
+        <LookupSelect
+          value={typeof values.customerEntityId === 'string' ? values.customerEntityId : null}
+          onChange={(next) => {
+            if (next !== values.customerEntityId) {
+              resetAddressFormState(setValue)
+            }
+            setValue('customerEntityId', next)
+            loadAddresses(next).then((addrs) => {
+              const primary = addrs.find((addr) => addr.isPrimary)
+              if (primary) {
+                setValue('shippingAddressId', primary.id)
+              }
+            }).catch((err) => { console.error('sales.documents.autoSelectAddress', err) })
+            if (next) {
+              const match = customers.find((entry) => entry.id === next)
+              const possibleEmail =
+                typeof match?.primaryEmail === 'string' && match.primaryEmail.length
+                  ? match.primaryEmail
+                  : null
+              if (possibleEmail) {
+                setValue('customerEmail', possibleEmail)
+              } else {
+                fetchCustomerEmail(next, match?.kind)
+                  .then((email) => {
+                    if (email) setValue('customerEmail', email)
+                  })
+                  .catch(() => {})
+              }
+            }
+          }}
+          fetchItems={async (query) => {
+            const options = await loadCustomers(query)
+            return options.map<LookupSelectItem>((opt) => ({
+              id: opt.id,
+              title: opt.label,
+              subtitle: opt.subtitle ?? undefined,
+              icon:
+                opt.kind === 'person' ? (
+                  <UserRound className="h-5 w-5 text-muted-foreground" />
+                ) : (
+                  <Building2 className="h-5 w-5 text-muted-foreground" />
+                ),
+            }))
+          }}
+          actionSlot={
+            <CustomerQuickCreate
+              t={t}
+              onCreated={({ id, email, label, kind, subtitle }) => {
+                // Seed the search box with the new customer's display name so it renders immediately
+                customerQuerySetter.current?.(label)
+                setCustomers((prev) => {
+                  const exists = prev.some((entry) => entry.id === id)
+                  if (exists) return prev
+                  const next: CustomerOption = {
+                    id,
+                    label,
+                    subtitle: subtitle ?? undefined,
+                    kind,
+                    primaryEmail: email ?? null,
+                  }
+                  return [next, ...prev]
+                })
+                setValue('customerEntityId', id)
+                resetAddressFormState(setValue)
+                loadAddresses(id).then((addrs) => {
+                  const primary = addrs.find((addr) => addr.isPrimary)
+                  if (primary) {
+                    setValue('shippingAddressId', primary.id)
+                  }
+                }).catch((err) => { console.error('sales.documents.autoSelectAddress', err) })
+                if (email && !values.customerEmail) {
+                  setValue('customerEmail', email)
+                }
+              }}
+            />
+          }
+          onReady={({ setQuery }) => {
+            customerQuerySetter.current = setQuery
+          }}
+          searchPlaceholder={t('sales.documents.form.customer.placeholder', 'Search customers…')}
+          loadingLabel={t('sales.documents.form.customer.loading', 'Loading customers…')}
+          emptyLabel={t('sales.documents.form.customer.empty', 'No customers found.')}
+          selectedHintLabel={(id) => t('sales.documents.form.customer.selected', 'Selected customer: {{id}}', { id })}
+        />
+      </div>
+      <div className="space-y-2">
+        <EmailInput
+          value={emailValue}
+          onChange={(event) => setValue('customerEmail', event.target.value)}
+          placeholder={t('sales.documents.form.email.placeholder', 'Email used for the document')}
+          spellCheck={false}
+        />
+        {duplicate ? (
+          <div className="flex items-center justify-between rounded border bg-muted px-3 py-2 text-xs text-muted-foreground">
+            <span>
+              {t('customers.people.form.emailDuplicateNotice', undefined, { name: duplicate.displayName })}
+            </span>
+            <Button
+              size="sm"
+              variant="secondary"
+              className="px-4"
+              type="button"
+              disabled={values.customerEntityId === duplicate.id}
+              aria-disabled={values.customerEntityId === duplicate.id}
+              onClick={() => {
+                setValue('customerEntityId', duplicate.id)
+                resetAddressFormState(setValue)
+                loadAddresses(duplicate.id)
+              }}
+            >
+              {values.customerEntityId === duplicate.id
+                ? t('sales.documents.form.email.alreadySelected', 'Selected customer')
+                : t('sales.documents.form.email.selectCustomer', 'Select customer')}
+            </Button>
+          </div>
+        ) : null}
+        {!duplicate && checking ? (
+          <p className="text-xs text-muted-foreground">{t('customers.people.form.emailChecking')}</p>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
 export function SalesDocumentForm({ onCreated, isSubmitting = false, initialKind, inboxPreFill }: SalesDocumentFormProps) {
   const t = useT()
   const [customers, setCustomers] = React.useState<CustomerOption[]>([])
@@ -717,74 +1064,6 @@ export function SalesDocumentForm({ onCreated, isSubmitting = false, initialKind
     [],
   )
 
-  function DocumentNumberField({ value, setValue, values }: CrudCustomFieldRenderProps) {
-    const formValues = (values ?? {}) as Partial<SalesDocumentFormValues>
-    const kind: DocumentKind = formValues.documentKind === 'order' ? 'order' : 'quote'
-    const [loading, setLoading] = React.useState(false)
-    const [error, setError] = React.useState<string | null>(null)
-    const autoValueRef = React.useRef<string | null>(null)
-    const lastKindRef = React.useRef<DocumentKind | null>(null)
-
-    const requestNumber = React.useCallback(async () => {
-      setLoading(true)
-      setError(null)
-      try {
-        const call = await apiCall<{ number?: string; error?: string }>('/api/sales/document-numbers', {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ kind }),
-        })
-        const nextNumber = typeof call.result?.number === 'string' ? call.result.number : null
-        if (call.ok && nextNumber) {
-          autoValueRef.current = nextNumber
-          lastKindRef.current = kind
-          setValue(nextNumber)
-        } else {
-          setError(call.result?.error || t('sales.documents.form.errors.numberGenerate', 'Could not generate a document number.'))
-        }
-      } catch (err) {
-        console.error('sales.documents.generateNumber', err)
-        setError(t('sales.documents.form.errors.numberGenerate', 'Could not generate a document number.'))
-      } finally {
-        setLoading(false)
-      }
-    }, [kind, setValue, t])
-
-    React.useEffect(() => {
-      const current = typeof value === 'string' ? value.trim() : ''
-      if (!current.length && !lastKindRef.current) {
-        void requestNumber()
-      } else {
-        lastKindRef.current = kind
-      }
-    }, [kind, requestNumber, value])
-
-    return (
-      <div className="space-y-2">
-        <div className="flex w-full flex-col gap-2 md:flex-row md:items-center md:gap-3">
-          <Input
-            value={typeof value === 'string' ? value : ''}
-            onChange={(event) => setValue(event.target.value)}
-            disabled={loading}
-            spellCheck={false}
-            className="w-full md:flex-1"
-          />
-          <Button type="button" variant="outline" onClick={requestNumber} disabled={loading}>
-            {loading
-              ? t('sales.documents.form.numberLoading', 'Generating…')
-              : t('sales.documents.form.numberRefresh', 'Generate')}
-          </Button>
-        </div>
-        <p className="text-xs text-muted-foreground">
-          {kind === 'order'
-            ? t('sales.documents.form.numberHintOrder', 'Format applies to orders and uses the configured counter.')
-            : t('sales.documents.form.numberHintQuote', 'Format applies to quotes and uses the configured counter.')}
-        </p>
-        {error ? <p className="text-xs text-destructive">{error}</p> : null}
-      </div>
-    )
-  }
-
   const fields = React.useMemo<CrudField[]>(() => [
     {
       id: 'documentKind',
@@ -826,7 +1105,7 @@ export function SalesDocumentForm({ onCreated, isSubmitting = false, initialKind
       label: t('sales.documents.form.number', 'Document number'),
       type: 'custom',
       required: true,
-      component: DocumentNumberField,
+      component: (props) => <DocumentNumberField {...props} t={t} />,
     },
     {
       id: 'currencyCode',
@@ -967,130 +1246,7 @@ export function SalesDocumentForm({ onCreated, isSubmitting = false, initialKind
       id: 'billingAddressSection',
       label: '',
       type: 'custom',
-      component: function BillingAddressSectionField({ values, setFormValue }) {
-        const formValues = (values ?? {}) as Partial<SalesDocumentFormValues>
-        const updateValue = setFormValue ?? (() => {})
-        const useCustom = formValues.useCustomBilling === true
-        const selectedId = typeof formValues.billingAddressId === 'string' ? formValues.billingAddressId : ''
-        const draft = (formValues.billingAddressDraft ?? {}) as AddressDraft
-        const customerRequired = !formValues.customerEntityId
-        const sameAsShipping = formValues.sameAsShipping !== false
-        const shippingId = typeof formValues.shippingAddressId === 'string' ? formValues.shippingAddressId : null
-        const shippingDraft = (formValues.shippingAddressDraft ?? {}) as AddressDraft
-        const shippingDraftKey = JSON.stringify(shippingDraft)
-        const billingDraftKey = JSON.stringify(draft)
-        const useCustomShipping = formValues.useCustomShipping === true
-
-        React.useEffect(() => {
-          if (!sameAsShipping) return
-          if ((formValues.billingAddressId ?? null) !== shippingId) {
-            updateValue('billingAddressId', shippingId)
-          }
-          if (useCustomShipping !== (formValues.useCustomBilling === true)) {
-            updateValue('useCustomBilling', useCustomShipping)
-          }
-          if (useCustomShipping && shippingDraftKey !== billingDraftKey) {
-            updateValue('billingAddressDraft', shippingDraft)
-          }
-        }, [
-          billingDraftKey,
-          sameAsShipping,
-          updateValue,
-          shippingDraft,
-          shippingDraftKey,
-          shippingId,
-          useCustomShipping,
-          formValues.billingAddressId,
-          formValues.useCustomBilling,
-        ])
-
-        return (
-          <div className="space-y-3">
-            <div className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
-              <div>
-                <p className="text-base font-semibold">
-                  {t('sales.documents.form.billing.title', 'Billing address')}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {sameAsShipping
-                    ? t('sales.documents.form.address.sameAsShippingHint', 'Billing will mirror the shipping address. Uncheck to edit.')
-                    : t('sales.documents.form.billing.hint', 'Select an address or define a new one.')}
-                </p>
-              </div>
-              <SwitchField
-                label={t('sales.documents.form.address.sameAsShipping', 'Same as shipping')}
-                flip
-                checked={sameAsShipping}
-                onCheckedChange={(checked) => {
-                  updateValue('sameAsShipping', checked)
-                  if (checked) {
-                    updateValue('useCustomBilling', useCustomShipping)
-                    updateValue('billingAddressId', shippingId)
-                    updateValue('billingAddressDraft', shippingDraft)
-                  }
-                }}
-              />
-            </div>
-
-            {!sameAsShipping ? (
-              <>
-                {!useCustom ? (
-                  <Select
-                    value={selectedId || undefined}
-                    onValueChange={(value) => updateValue('billingAddressId', value || null)}
-                    disabled={addressesLoading || customerRequired}
-                  >
-                    <SelectTrigger>
-                      <SelectValue
-                        placeholder={
-                          addressesLoading
-                            ? t('sales.documents.form.address.loading', 'Loading addresses…')
-                            : t('sales.documents.form.address.placeholder', 'Select address')
-                        }
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {addressOptions.map((addr) => {
-                        const optionLabel = addr.summary ? `${addr.label} — ${addr.summary}` : addr.label
-                        return (
-                          <SelectItem key={addr.id} value={addr.id}>{optionLabel}</SelectItem>
-                        )
-                      })}
-                    </SelectContent>
-                  </Select>
-                ) : null}
-
-                <SwitchField
-                  label={t('sales.documents.form.shipping.custom', 'Define new address')}
-                  flip
-                  checked={useCustom}
-                  onCheckedChange={(checked) => updateValue('useCustomBilling', checked)}
-                  disabled={false}
-                />
-
-                {useCustom ? (
-                  <div className="space-y-3">
-                    <AddressEditor
-                      value={draft}
-                      format={addressFormat}
-                      t={t}
-                      onChange={(next) => updateValue('billingAddressDraft', next)}
-                      hidePrimaryToggle
-                    />
-                    <SwitchField
-                      containerClassName="col-span-2"
-                      label={t('sales.documents.form.address.saveToCustomer', 'Save this address to the customer')}
-                      flip
-                      checked={formValues.saveBillingAddress === true}
-                      onCheckedChange={(checked) => updateValue('saveBillingAddress', checked)}
-                    />
-                  </div>
-                ) : null}
-              </>
-            ) : null}
-          </div>
-        )
-      },
+      component: (props) => <BillingAddressSectionField {...props} t={t} addressesLoading={addressesLoading} addressOptions={addressOptions} addressFormat={addressFormat} />,
     },
     {
       id: 'comments',
@@ -1128,139 +1284,7 @@ export function SalesDocumentForm({ onCreated, isSubmitting = false, initialKind
       title: '',
       column: 1,
       fields: [],
-      component: function CustomerGroupComponent({ values, setValue }) {
-        const emailValue = typeof values.customerEmail === 'string' ? values.customerEmail : ''
-        const { duplicate, checking } = useEmailDuplicateCheck(emailValue, {
-          disabled: false,
-          debounceMs: 400,
-          matchMode: 'prefix',
-        })
-        return (
-          <div className="space-y-4">
-            <div className="space-y-3">
-              <LookupSelect
-                value={typeof values.customerEntityId === 'string' ? values.customerEntityId : null}
-                onChange={(next) => {
-                  if (next !== values.customerEntityId) {
-                    resetAddressFormState(setValue)
-                  }
-                  setValue('customerEntityId', next)
-                  loadAddresses(next).then((addrs) => {
-                    const primary = addrs.find((addr) => addr.isPrimary)
-                    if (primary) {
-                      setValue('shippingAddressId', primary.id)
-                    }
-                  }).catch((err) => { console.error('sales.documents.autoSelectAddress', err) })
-                  if (next) {
-                    const match = customers.find((entry) => entry.id === next)
-                    const possibleEmail =
-                      typeof match?.primaryEmail === 'string' && match.primaryEmail.length
-                        ? match.primaryEmail
-                        : null
-                    if (possibleEmail) {
-                      setValue('customerEmail', possibleEmail)
-                    } else {
-                      fetchCustomerEmail(next, match?.kind)
-                        .then((email) => {
-                          if (email) setValue('customerEmail', email)
-                        })
-                        .catch(() => {})
-                    }
-                  }
-                }}
-                fetchItems={async (query) => {
-                  const options = await loadCustomers(query)
-                  return options.map<LookupSelectItem>((opt) => ({
-                    id: opt.id,
-                    title: opt.label,
-                    subtitle: opt.subtitle ?? undefined,
-                    icon:
-                      opt.kind === 'person' ? (
-                        <UserRound className="h-5 w-5 text-muted-foreground" />
-                      ) : (
-                        <Building2 className="h-5 w-5 text-muted-foreground" />
-                      ),
-                  }))
-                }}
-                actionSlot={
-                  <CustomerQuickCreate
-                    t={t}
-                    onCreated={({ id, email, label, kind, subtitle }) => {
-                      // Seed the search box with the new customer's display name so it renders immediately
-                      customerQuerySetter.current?.(label)
-                      setCustomers((prev) => {
-                        const exists = prev.some((entry) => entry.id === id)
-                        if (exists) return prev
-                        const next: CustomerOption = {
-                          id,
-                          label,
-                          subtitle: subtitle ?? undefined,
-                          kind,
-                          primaryEmail: email ?? null,
-                        }
-                        return [next, ...prev]
-                      })
-                      setValue('customerEntityId', id)
-                      resetAddressFormState(setValue)
-                      loadAddresses(id).then((addrs) => {
-                        const primary = addrs.find((addr) => addr.isPrimary)
-                        if (primary) {
-                          setValue('shippingAddressId', primary.id)
-                        }
-                      }).catch((err) => { console.error('sales.documents.autoSelectAddress', err) })
-                      if (email && !values.customerEmail) {
-                        setValue('customerEmail', email)
-                      }
-                    }}
-                  />
-                }
-                onReady={({ setQuery }) => {
-                  customerQuerySetter.current = setQuery
-                }}
-                searchPlaceholder={t('sales.documents.form.customer.placeholder', 'Search customers…')}
-                loadingLabel={t('sales.documents.form.customer.loading', 'Loading customers…')}
-                emptyLabel={t('sales.documents.form.customer.empty', 'No customers found.')}
-                selectedHintLabel={(id) => t('sales.documents.form.customer.selected', 'Selected customer: {{id}}', { id })}
-              />
-            </div>
-            <div className="space-y-2">
-              <EmailInput
-                value={emailValue}
-                onChange={(event) => setValue('customerEmail', event.target.value)}
-                placeholder={t('sales.documents.form.email.placeholder', 'Email used for the document')}
-                spellCheck={false}
-              />
-              {duplicate ? (
-                <div className="flex items-center justify-between rounded border bg-muted px-3 py-2 text-xs text-muted-foreground">
-                  <span>
-                    {t('customers.people.form.emailDuplicateNotice', undefined, { name: duplicate.displayName })}
-                  </span>
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    className="px-4"
-                    type="button"
-                    disabled={values.customerEntityId === duplicate.id}
-                    aria-disabled={values.customerEntityId === duplicate.id}
-                    onClick={() => {
-                      setValue('customerEntityId', duplicate.id)
-                      resetAddressFormState(setValue)
-                      loadAddresses(duplicate.id)
-                    }}
-                  >
-                    {values.customerEntityId === duplicate.id
-                      ? t('sales.documents.form.email.alreadySelected', 'Selected customer')
-                      : t('sales.documents.form.email.selectCustomer', 'Select customer')}
-                  </Button>
-                </div>
-              ) : null}
-              {!duplicate && checking ? (
-                <p className="text-xs text-muted-foreground">{t('customers.people.form.emailChecking')}</p>
-              ) : null}
-            </div>
-          </div>
-        )
-      },
+      component: (ctx) => <CustomerGroupComponent {...ctx} t={t} customers={customers} setCustomers={setCustomers} customerQuerySetter={customerQuerySetter} loadAddresses={loadAddresses} loadCustomers={loadCustomers} fetchCustomerEmail={fetchCustomerEmail} resetAddressFormState={resetAddressFormState} />,
     },
     { id: 'channels-comments', title: '', column: 1, fields: ['channelId', 'comments'] },
     { id: 'currency', title: '', column: 2, fields: ['currencyCode'] },


### PR DESCRIPTION
## Summary

`SalesDocumentForm` defined three hook-using custom renderers (`DocumentNumberField`, `BillingAddressSectionField`, `CustomerGroupComponent`) inside the parent component and passed them to `CrudForm`. Because `CrudForm` invokes these as plain function calls and memo-compares them by component identity (`prev.field.component === next.field.component`), nesting them defeated rerender avoidance and ran their hooks inside CrudForm's render instead of their own component boundaries. This hoists the three renderers to module scope with explicit props, restoring stable identity and proper React component boundaries, with no behavior change.

Fixes #3173.

## Changes

- Hoisted `DocumentNumberField`, `BillingAddressSectionField`, and `CustomerGroupComponent` to module scope in `packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx`, threading their former closures (`t`, address state, customer state/loaders, refs) through explicit, fully-typed props (no `any`).
- The `fields`/`groups` config now renders them as JSX elements via thin wrappers (`component: (props) => <DocumentNumberField {...props} t={t} />`, etc.); `useMemo` dependency arrays are unchanged.
- Imported the existing `CrudFormGroupComponentProps` type from `@open-mercato/ui/backend/CrudForm`. `CrudForm.tsx` itself is unchanged (shared BC surface left intact).
- Left the 5 hook-free presentational renderers (documentKind toggle, currency, channel, shipping section, infoNote) inline as a narrow, documented exception — only hook-bearing renderers needed hoisting.
- Added `salesDocumentFormHoistedRenderers.test.tsx`: a structural guard (renderers must be module-scope, passed as stable element references) plus behavioral coverage of the document-number, billing-address, and customer-selection flows.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — behavior-preserving React refactor; no contract or spec surface affected.

## Testing

- `yarn workspace @open-mercato/core test salesDocumentFormHoistedRenderers` → 7 passed (4 structural, 3 behavioral)
- `yarn typecheck` → 21/21 packages, 0 errors
- `yarn build:packages` → 21/21
- `yarn test` → 22/22 packages (no regressions; includes existing `salesDocumentFormCurrency` test)
- `yarn i18n:check-sync` → all locales in sync
- `yarn build:app` → builds successfully

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (N/A — no strings, generators, or docs affected; `i18n:check-sync` passes.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required — package-internal React refactor with no new API/UI route; covered by the new jsdom render test, satisfying the issue's "tests or manual QA" acceptance criterion.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — single-module React refactor shipping with tests.)
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. (`needs-qa` — touches a sales-flow UI surface; behavior is unchanged and render-tested, so QA is a quick smoke of quote/order create — customer selection, billing address, document number.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens (moved code uses `text-destructive`/`text-muted-foreground`; none introduced)
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` (none introduced)
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) (N/A — form component, not a list page)
- [x] Loading state handled for async pages (N/A — no page-level async state changed; document-number field retains its own loading state)
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) (N/A — no icon-only buttons added)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements (unchanged; uses existing `Input`/`Button`/`Select`/`SwitchField`/`EmailInput`)

## Linked issues

Fixes #3173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
