### PR TITLE
fix(workflows): use functional state setters in editor/demo components (#3171)

### DIFF
--- a/packages/core/src/modules/workflows/components/EdgeEditDialog.tsx
+++ b/packages/core/src/modules/workflows/components/EdgeEditDialog.tsx
@@ -160,7 +160,7 @@ export function EdgeEditDialog({ edge, isOpen, onClose, onSave, onDelete }: Edge
         maxIntervalMs: 10000,
       },
     }
-    setActivities([...activities, newActivity])
+    setActivities(prev => [...prev, newActivity])
     // Auto-expand the new activity
     const newExpanded = new Set(expandedActivities)
     newExpanded.add(activities.length)
@@ -173,7 +173,7 @@ export function EdgeEditDialog({ edge, isOpen, onClose, onSave, onDelete }: Edge
       variant: 'destructive',
     })
     if (confirmed) {
-      setActivities(activities.filter((_, i) => i !== index))
+      setActivities(prev => prev.filter((_, i) => i !== index))
       // Remove from expanded set
       const newExpanded = new Set(expandedActivities)
       newExpanded.delete(index)
@@ -235,25 +235,25 @@ export function EdgeEditDialog({ edge, isOpen, onClose, onSave, onDelete }: Edge
 
     if (ruleSelectorMode === 'pre') {
       if (!preConditions.find(c => c.ruleId === ruleId)) {
-        setPreConditions([...preConditions, { ruleId, required: true }])
+        setPreConditions(prev => [...prev, { ruleId, required: true }])
       }
     } else {
       if (!postConditions.find(c => c.ruleId === ruleId)) {
-        setPostConditions([...postConditions, { ruleId, required: true }])
+        setPostConditions(prev => [...prev, { ruleId, required: true }])
       }
     }
     closeRuleSelector()
   }
 
   const removePreCondition = (index: number) => {
-    setPreConditions(preConditions.filter((_, i) => i !== index))
+    setPreConditions(prev => prev.filter((_, i) => i !== index))
     const newExpanded = new Set(expandedPreConditions)
     newExpanded.delete(index)
     setExpandedPreConditions(newExpanded)
   }
 
   const removePostCondition = (index: number) => {
-    setPostConditions(postConditions.filter((_, i) => i !== index))
+    setPostConditions(prev => prev.filter((_, i) => i !== index))
     const newExpanded = new Set(expandedPostConditions)
     newExpanded.delete(index)
     setExpandedPostConditions(newExpanded)

--- a/packages/core/src/modules/workflows/components/NodeEditDialog.tsx
+++ b/packages/core/src/modules/workflows/components/NodeEditDialog.tsx
@@ -287,7 +287,7 @@ export function NodeEditDialog({ node, isOpen, onClose, onSave, onDelete }: Node
       required: false,
       placeholder: '',
     }
-    setFormFields([...formFields, newField])
+    setFormFields(prev => [...prev, newField])
     // Auto-expand the new field
     const newExpanded = new Set(expandedFields)
     newExpanded.add(formFields.length)
@@ -300,7 +300,7 @@ export function NodeEditDialog({ node, isOpen, onClose, onSave, onDelete }: Node
       variant: 'destructive',
     })
     if (confirmed) {
-      setFormFields(formFields.filter((_, i) => i !== index))
+      setFormFields(prev => prev.filter((_, i) => i !== index))
       const newExpanded = new Set(expandedFields)
       newExpanded.delete(index)
       setExpandedFields(newExpanded)
@@ -1269,7 +1269,7 @@ export function NodeEditDialog({ node, isOpen, onClose, onSave, onDelete }: Node
                       <Button
                         type="button"
                         size="sm"
-                        onClick={() => setInputMappings([...inputMappings, { key: '', value: '' }])}
+                        onClick={() => setInputMappings(prev => [...prev, { key: '', value: '' }])}
                       >
                         <Plus className="size-3 mr-1" />
                         {t('workflows.form.addMapping')}
@@ -1316,7 +1316,7 @@ export function NodeEditDialog({ node, isOpen, onClose, onSave, onDelete }: Node
                               size="sm"
                               variant="ghost"
                               onClick={() => {
-                                setInputMappings(inputMappings.filter((_, i) => i !== index))
+                                setInputMappings(prev => prev.filter((_, i) => i !== index))
                               }}
                               className="mt-1"
                             >
@@ -1342,7 +1342,7 @@ export function NodeEditDialog({ node, isOpen, onClose, onSave, onDelete }: Node
                       <Button
                         type="button"
                         size="sm"
-                        onClick={() => setOutputMappings([...outputMappings, { key: '', value: '' }])}
+                        onClick={() => setOutputMappings(prev => [...prev, { key: '', value: '' }])}
                       >
                         <Plus className="size-3 mr-1" />
                         {t('workflows.form.addMapping')}
@@ -1389,7 +1389,7 @@ export function NodeEditDialog({ node, isOpen, onClose, onSave, onDelete }: Node
                               size="sm"
                               variant="ghost"
                               onClick={() => {
-                                setOutputMappings(outputMappings.filter((_, i) => i !== index))
+                                setOutputMappings(prev => prev.filter((_, i) => i !== index))
                               }}
                               className="mt-1"
                             >

--- a/packages/core/src/modules/workflows/components/__tests__/functionalStateSetters.test.tsx
+++ b/packages/core/src/modules/workflows/components/__tests__/functionalStateSetters.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression guard for #3171: array state in the workflow editor dialogs must be
+ * updated with functional setters (`setX(prev => ...)`) so that two updates landing
+ * in the same render batch both take effect. With a closed-over direct setter
+ * (`setX([...x, item])`) the second batched update overwrites the first and an add
+ * is silently lost.
+ *
+ * The two clicks are dispatched inside a single `act()` callback so React defers the
+ * flush and both handlers run against the same render closure — the exact "batched
+ * updates" condition described in the issue.
+ */
+import * as React from 'react'
+import { act, screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { EdgeEditDialog } from '../EdgeEditDialog'
+import { NodeEditDialog } from '../NodeEditDialog'
+
+// jsdom does not implement the pointer-capture / scrollIntoView APIs Radix uses.
+if (typeof window !== 'undefined') {
+  if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false
+  if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => undefined
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => undefined
+}
+
+function clickTwiceInOneBatch(button: HTMLElement) {
+  act(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+  })
+}
+
+describe('workflow editor dialogs — functional state setters (#3171)', () => {
+  it('EdgeEditDialog keeps both activities when add is invoked twice in one batch', () => {
+    renderWithProviders(
+      <EdgeEditDialog
+        edge={{ id: 'start_to_cart', data: {} } as any}
+        isOpen
+        onClose={jest.fn()}
+        onSave={jest.fn()}
+        onDelete={jest.fn()}
+      />,
+    )
+
+    const addActivity = screen.getByRole('button', { name: 'workflows.edgeEditor.addActivity' })
+    clickTwiceInOneBatch(addActivity)
+
+    // Each activity row renders one CALL_API type badge in its header.
+    expect(screen.getAllByText('CALL_API')).toHaveLength(2)
+  })
+
+  it('NodeEditDialog keeps both form fields when add is invoked twice in one batch', () => {
+    renderWithProviders(
+      <NodeEditDialog
+        node={{ id: 'task-1', type: 'userTask', data: {} } as any}
+        isOpen
+        onClose={jest.fn()}
+        onSave={jest.fn()}
+        onDelete={jest.fn()}
+      />,
+    )
+
+    const addField = screen.getByRole('button', { name: 'workflows.form.addField' })
+    clickTwiceInOneBatch(addField)
+
+    // Each new form-field row renders its label (workflows.form.newField) once in the header.
+    expect(screen.getAllByText('workflows.form.newField')).toHaveLength(2)
+  })
+})

--- a/packages/core/src/modules/workflows/frontend/checkout-demo/page.tsx
+++ b/packages/core/src/modules/workflows/frontend/checkout-demo/page.tsx
@@ -213,36 +213,37 @@ export default function CheckoutDemoPage() {
 
   // Cart management functions
   const addToCart = (product: Product) => {
-    const existing = cart.find(item => item.id === product.id)
-    if (existing) {
-      setCart(cart.map(item =>
-        item.id === product.id
-          ? { ...item, quantity: item.quantity + 1 }
-          : item
-      ))
-    } else {
-      setCart([...cart, {
+    setCart(prev => {
+      const existing = prev.find(item => item.id === product.id)
+      if (existing) {
+        return prev.map(item =>
+          item.id === product.id
+            ? { ...item, quantity: item.quantity + 1 }
+            : item
+        )
+      }
+      return [...prev, {
         id: product.id,
         name: product.title,
         // Use resolved pricing from catalog pricing service (in USD)
         price: product.pricing?.unit_price_gross || product.pricing?.unit_price_net || 99.99,
         quantity: 1,
-      }])
-    }
+      }]
+    })
   }
 
   const updateQuantity = (productId: string, quantity: number) => {
     if (quantity <= 0) {
-      setCart(cart.filter(item => item.id !== productId))
+      setCart(prev => prev.filter(item => item.id !== productId))
     } else {
-      setCart(cart.map(item =>
+      setCart(prev => prev.map(item =>
         item.id === productId ? { ...item, quantity } : item
       ))
     }
   }
 
   const removeFromCart = (productId: string) => {
-    setCart(cart.filter(item => item.id !== productId))
+    setCart(prev => prev.filter(item => item.id !== productId))
   }
 
   // Convert prices to selected currency (cart items are in USD by default)


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Several workflow editor/demo components updated array state from values closed over by the
current render instead of using functional state updaters. Under React update batching, two
updates derived from the same captured array can lose one another (the second overwrites the
first), making rapid add/remove interactions fragile. This replaces those stale-closure-prone
direct setters with functional setters (`setX(prev => ...)`), scoped exactly to the add/remove
cases the issue enumerates.

## Changes

- `workflows/components/EdgeEditDialog.tsx`: activity add/remove and pre/post-condition add/remove now use `setX(prev => ...)`.
- `workflows/components/NodeEditDialog.tsx`: form-field add/remove and input/output-mapping add/remove now use `setX(prev => ...)`.
- `workflows/frontend/checkout-demo/page.tsx`: `addToCart` collapsed into a single functional setter (the `existing` lookup now reads `prev`, so batched adds of the same product increment instead of duplicating/losing); `updateQuantity` and `removeFromCart` now use `setCart(prev => ...)`.
- Left direct setters in place where the next value comes from external/loaded data, form init, or a freshly computed local copy that intentionally replaces state (the issue's stated exclusion) — e.g. `setX(updated)` index-edit handlers.
- Added `workflows/components/__tests__/functionalStateSetters.test.tsx`: renders the real `EdgeEditDialog`/`NodeEditDialog` and dispatches two add-clicks inside one `act()` batch; asserts both adds survive. Fails on the pre-fix code, passes after.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — localized React state-correctness fix, no module/contract change.

## Testing

List the tests or commands you ran to validate the change.

- `yarn workspace @open-mercato/core test -- --testPathPattern functionalStateSetters` — 2/2 pass (red on unfixed code, green after fix; non-vacuousness verified by reverting a setter).
- `yarn workspace @open-mercato/core test -- --testPathPattern modules/workflows` — 30 suites / 547 tests pass.
- `yarn typecheck` — all packages pass.
- `yarn build:app` — compiled successfully.
- `yarn i18n:check-sync` — all locales in sync.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no user-facing strings, schema, or generated files changed.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required — the defect is React update-batching of in-component state; it is reproduced deterministically at the component-render level, which a Playwright flow cannot reliably trigger.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-low`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-low` — isolated UI state-update logic, no contract surface, behavior unchanged for normal interactions.)
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. (`needs-qa` — touches interactive workflow-editor dialogs and the checkout-demo cart; behavior is preserved for normal use and covered by deterministic render tests, so a reviewer may opt to `skip-qa`.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens. (N/A — no markup/styling changed; edits are to state-setter callbacks only.)
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`. (N/A — no styling changed.)
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop). (N/A — no list/data pages touched.)
- [x] Loading state handled for async pages. (N/A — no async loading changed.)
- [x] `aria-label` on all icon-only buttons (`<IconButton>`). (N/A — no buttons added/changed.)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements. (N/A — logic-only change.)

## Linked issues

Fixes #3171
