### PR TITLE
fix: mirror optimizePackageImports in standalone app template (#3168)

### DIFF
--- a/packages/create-app/src/lib/template-optimize-package-imports.test.ts
+++ b/packages/create-app/src/lib/template-optimize-package-imports.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+
+function extractOptimizePackageImports(source) {
+  const block = source.match(/optimizePackageImports:\s*\[([^\]]*)\]/)
+  if (!block) return null
+  return [...block[1].matchAll(/['"]([^'"]+)['"]/g)].map((entry) => entry[1])
+}
+
+function readConfigSource(relativeUrl) {
+  return fs.readFileSync(new URL(relativeUrl, import.meta.url), 'utf8')
+}
+
+test('standalone template next.config mirrors the main app optimizePackageImports list', () => {
+  const templateSource = readConfigSource('../../template/next.config.ts')
+  const mainAppSource = readConfigSource('../../../../apps/mercato/next.config.ts')
+
+  const templateImports = extractOptimizePackageImports(templateSource)
+  const mainAppImports = extractOptimizePackageImports(mainAppSource)
+
+  assert.ok(
+    mainAppImports && mainAppImports.length > 0,
+    'expected apps/mercato/next.config.ts to declare experimental.optimizePackageImports',
+  )
+  assert.ok(
+    templateImports,
+    'expected packages/create-app/template/next.config.ts to declare experimental.optimizePackageImports',
+  )
+  assert.deepEqual(
+    templateImports,
+    mainAppImports,
+    'standalone template optimizePackageImports drifted from the main app baseline',
+  )
+})
+
+test('standalone template optimizes lucide-react, recharts, and date-fns imports', () => {
+  const templateImports = extractOptimizePackageImports(
+    readConfigSource('../../template/next.config.ts'),
+  )
+
+  for (const pkg of ['lucide-react', 'recharts', 'date-fns']) {
+    assert.ok(
+      templateImports?.includes(pkg),
+      `expected standalone template to optimize ${pkg} imports`,
+    )
+  }
+})

--- a/packages/create-app/template/next.config.ts
+++ b/packages/create-app/template/next.config.ts
@@ -9,6 +9,13 @@ const nextConfig: NextConfig = {
   experimental: {
     serverMinification: false,
     turbopackMinify: false,
+    // Mirror apps/mercato: treat these barrel-heavy packages as having
+    // modularized exports so only the named exports actually used are
+    // evaluated. Keeps scaffolded apps on the same client-bundle baseline.
+    //   - lucide-react: icons used across the default backend components.
+    //   - recharts: pairs with the next/dynamic chart split in @open-mercato/ui.
+    //   - date-fns: already deep-imported; listed here as defense-in-depth.
+    optimizePackageImports: ['lucide-react', 'recharts', 'date-fns'],
     ...(isDevelopment
       ? {
           preloadEntriesOnStart: false,


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The standalone app template did not mirror the main app's package-import optimization. `apps/mercato/next.config.ts` enables `experimental.optimizePackageImports` for `lucide-react`, `recharts`, and `date-fns`, but `packages/create-app/template/next.config.ts` did not — so apps scaffolded from the template started with avoidable client-bundle overhead and drifted from the main app's known optimization baseline. This change adds the same `optimizePackageImports` list to the template config.

## Changes

- `packages/create-app/template/next.config.ts`: add `experimental.optimizePackageImports: ['lucide-react', 'recharts', 'date-fns']`, matching `apps/mercato/next.config.ts`, with an aligned explanatory comment.
- `packages/create-app/src/lib/template-optimize-package-imports.test.ts`: add a regression/drift-guard test asserting the template's `optimizePackageImports` list stays equal to the main app's and includes all three packages.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — single-line config mirror.


## Testing

List the tests or commands you ran to validate the change.

- `node --import tsx --test src/lib/template-optimize-package-imports.test.ts` — **red before** the fix (template did not declare `optimizePackageImports`), **green after** (2/2 pass).
- `node --import tsx --test src/**/*.test.ts` (full create-app suite) — **56/56 pass**.
- Confirmed `optimizePackageImports?: string[]` is a valid `NextConfig['experimental']` field in the Next 16 types and the value mirrors the already-building line in `apps/mercato/next.config.ts` (shape-compatible).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. <!-- N/A — config-only mirror; no docs/locale/generator output affected. -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- N/A — build-time bundling config has no API/UI runtime behavior to integration-test; covered by a unit-level config-parity guard instead. -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A — minor change, no spec. -->
- [x] Priority set: this PR carries exactly one `priority-*` label. <!-- priority-low (inherited from the issue). -->
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). <!-- risk-low (template config only; valid in the template's Next version). -->
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. <!-- skip-qa — build-config + test only, no customer-facing behavior change. -->

### Design System Compliance
- [x] No hardcoded status colors — use semantic tokens <!-- N/A — no UI. -->
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` <!-- N/A — no UI. -->
- [x] Empty state handled for list/data pages <!-- N/A — no UI. -->
- [x] Loading state handled for async pages <!-- N/A — no UI. -->
- [x] `aria-label` on all icon-only buttons <!-- N/A — no UI. -->
- [x] Uses existing DS components — no custom replacements <!-- N/A — no UI. -->

## Linked issues

Fixes #3168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
