### PR TITLE
perf(integrations): parallelize independent detail refresh requests (#3170)

### DIFF
--- a/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
@@ -47,6 +47,10 @@ import {
   resolveIntegrationDetailWidgetSpotId,
   resolveRequestedIntegrationDetailTab,
 } from '../detail-page-widgets'
+import {
+  refreshIntegrationDetailPanels,
+  refreshIntegrationRunActivityPanels,
+} from '../detail-page-refresh'
 import { isValidCredentialUrl } from '../../../lib/credentials-field-validation'
 
 type CredentialField = IntegrationCredentialField
@@ -531,8 +535,7 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
     spotId: detailWidgetSpotId,
   })
   const refreshDetail = React.useCallback(async () => {
-    await loadDetail({ showLoading: false })
-    await loadCredentials()
+    await refreshIntegrationDetailPanels({ loadDetail, loadCredentials })
   }, [loadCredentials, loadDetail])
   const refreshLogs = React.useCallback(async () => {
     await loadLogs()
@@ -549,13 +552,14 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
     }
     if (options?.showLoading) setIsRefreshingRunActivity(true)
     try {
-      const call = await apiCall<DataSyncRunDetail>(
-        `/api/data_sync/runs/${encodeURIComponent(runIdFromUrl)}`,
-        undefined,
-        { fallback: null },
-      )
-      await loadLogs()
-      await loadDetail({ showLoading: false })
+      const [call] = await Promise.all([
+        apiCall<DataSyncRunDetail>(
+          `/api/data_sync/runs/${encodeURIComponent(runIdFromUrl)}`,
+          undefined,
+          { fallback: null },
+        ),
+        refreshIntegrationRunActivityPanels({ loadLogs, loadDetail }),
+      ])
       if (call.ok && call.result) {
         setActiveRunDetail(call.result)
         setActiveRunRefreshedAt(new Date().toISOString())

--- a/packages/core/src/modules/integrations/backend/integrations/__tests__/detail-page-refresh.test.ts
+++ b/packages/core/src/modules/integrations/backend/integrations/__tests__/detail-page-refresh.test.ts
@@ -1,0 +1,51 @@
+/** @jest-environment node */
+
+import {
+  refreshIntegrationDetailPanels,
+  refreshIntegrationRunActivityPanels,
+} from '../detail-page-refresh'
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((res) => {
+    resolve = () => res()
+  })
+  return { promise, resolve }
+}
+
+describe('integration detail concurrent refresh helpers', () => {
+  it('starts detail and credential loads concurrently', async () => {
+    const detail = deferred()
+    const loadDetail = jest.fn((_options?: { showLoading?: boolean }) => detail.promise)
+    const loadCredentials = jest.fn(() => Promise.resolve())
+
+    const pending = refreshIntegrationDetailPanels({ loadDetail, loadCredentials })
+
+    // Both independent loads must already be in flight before detail resolves.
+    // A serial implementation only invokes loadCredentials after loadDetail
+    // settles, so this assertion fails for the serialized bug.
+    expect(loadDetail).toHaveBeenCalledTimes(1)
+    expect(loadDetail).toHaveBeenCalledWith({ showLoading: false })
+    expect(loadCredentials).toHaveBeenCalledTimes(1)
+
+    detail.resolve()
+    await pending
+  })
+
+  it('starts logs and detail reloads concurrently for run activity refresh', async () => {
+    const logs = deferred()
+    const loadLogs = jest.fn(() => logs.promise)
+    const loadDetail = jest.fn((_options?: { showLoading?: boolean }) => Promise.resolve())
+
+    const pending = refreshIntegrationRunActivityPanels({ loadLogs, loadDetail })
+
+    // loadLogs is held pending; a serial implementation would not start
+    // loadDetail until loadLogs resolves, so loadDetail would be uncalled here.
+    expect(loadLogs).toHaveBeenCalledTimes(1)
+    expect(loadDetail).toHaveBeenCalledTimes(1)
+    expect(loadDetail).toHaveBeenCalledWith({ showLoading: false })
+
+    logs.resolve()
+    await pending
+  })
+})

--- a/packages/core/src/modules/integrations/backend/integrations/detail-page-refresh.ts
+++ b/packages/core/src/modules/integrations/backend/integrations/detail-page-refresh.ts
@@ -1,0 +1,36 @@
+type ShowLoadingOption = { showLoading?: boolean }
+type IntegrationDetailLoader = (options?: ShowLoadingOption) => Promise<void>
+type IntegrationPanelLoader = () => Promise<void>
+
+/**
+ * Refresh the integration detail and credential panels concurrently.
+ *
+ * Detail and credentials are served by independent endpoints with no data
+ * dependency between them, so the two requests start together instead of
+ * waiting for the detail load to resolve before credentials begins.
+ */
+export async function refreshIntegrationDetailPanels(loaders: {
+  loadDetail: IntegrationDetailLoader
+  loadCredentials: IntegrationPanelLoader
+}): Promise<void> {
+  await Promise.all([
+    loaders.loadDetail({ showLoading: false }),
+    loaders.loadCredentials(),
+  ])
+}
+
+/**
+ * Refresh the run-activity panels (logs and detail) concurrently.
+ *
+ * loadLogs and loadDetail hit independent endpoints and neither consumes the
+ * other's result, so the two reloads start together.
+ */
+export async function refreshIntegrationRunActivityPanels(loaders: {
+  loadLogs: IntegrationPanelLoader
+  loadDetail: IntegrationDetailLoader
+}): Promise<void> {
+  await Promise.all([
+    loaders.loadLogs(),
+    loaders.loadDetail({ showLoading: false }),
+  ])
+}


### PR DESCRIPTION
## Summary

The integration detail page (`packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx`) awaited several independent API loaders sequentially. `refreshDetail` awaited `loadDetail` then `loadCredentials`, and the post-action `refreshRunActivity` awaited `loadLogs` then `loadDetail`. These endpoints have no data dependency, so the requests can start concurrently. This change starts the independent requests together, reducing latency on manual refresh and post-action reloads while keeping loading/error/success behavior identical.

## Changes

- Add `packages/core/src/modules/integrations/backend/integrations/detail-page-refresh.ts` with two concurrent-refresh helpers (`refreshIntegrationDetailPanels`, `refreshIntegrationRunActivityPanels`), following the existing sibling-helper pattern (`detail-page-widgets.ts`).
- `refreshDetail` now starts detail + credentials concurrently via `refreshIntegrationDetailPanels`.
- `refreshRunActivity` now starts the run-detail fetch, logs reload, and detail reload concurrently via `Promise.all`, preserving the run-detail result binding (`const [call]`).
- Left the three mount `useEffect`s untouched — they already fire concurrently and have independent dependency arrays (merging would over-fetch detail/credentials on log-level changes).
- Add `detail-page-refresh.test.ts` proving the loaders dispatch concurrently (fails on serialized code).

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — localized client-side performance refactor, no behavior change.

## Testing

List the tests or commands you ran to validate the change.

- `yarn workspace @open-mercato/core test detail-page-refresh` — new test, red on serial code → green after fix (2/2 pass)
- `yarn workspace @open-mercato/core test src/modules/integrations` — 8 suites, 45 tests pass
- `yarn typecheck` — 21/21 packages pass (core typechecked fresh)
- `yarn i18n:check-sync` — all locales in sync
- `yarn generate` — no registry churn
- `yarn build:app` — Next.js app builds successfully

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- author to confirm -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- none required: no docs/locale/generator-affecting change -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- Not required: client-side request-timing refactor with no API/behavior change; concurrency is covered directly by a unit test. -->
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A -->
- [x] Priority set: this PR carries exactly one `priority-*` label. <!-- priority-medium (inherited from issue) -->
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. <!-- risk-medium (inherited from issue); risk-low is also defensible — read-only control-flow change, no contract/schema/state change -->
- [x] QA routing set: `needs-qa` (matches the sibling parallelize PRs in the same audit series; integration detail page is customer-facing UI).

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI/markup change (control-flow only)
- [x] No arbitrary text sizes — N/A, no UI/markup change
- [x] Empty state handled — N/A, no UI/markup change
- [x] Loading state handled for async pages — unchanged; existing loading behavior preserved
- [x] `aria-label` on all icon-only buttons — N/A, no UI/markup change
- [x] Uses existing DS components — N/A, no UI/markup change

## Linked issues

Fixes #3170
