### PR TITLE
perf(workflows): keep @xyflow/react inside the lazy graph/editor boundary (#3169)

### DIFF
--- a/packages/core/src/modules/workflows/__tests__/xyflow-import-boundary.test.ts
+++ b/packages/core/src/modules/workflows/__tests__/xyflow-import-boundary.test.ts
@@ -1,0 +1,70 @@
+/** @jest-environment node */
+
+import { describe, test, expect } from '@jest/globals'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Guards the lazy @xyflow/react boundary (#3169).
+ *
+ * React Flow (~12 MB) must only enter the module graph through the lazy
+ * `WorkflowGraphImpl` implementation (loaded via next/dynamic, ssr:false).
+ * Adjacent workflow pages, dialogs, and graph-data utilities must therefore
+ * import React Flow types with `import type` only, never pull runtime helpers
+ * (addEdge / applyNodeChanges / applyEdgeChanges) into their chunks.
+ */
+
+const moduleRoot = join(__dirname, '..')
+
+const read = (relativePath: string): string =>
+  readFileSync(join(moduleRoot, relativePath), 'utf8')
+
+// Extract whole import statements (this codebase omits semicolons, so anchor
+// each statement to a line-leading `import` and stop at its `from '...'`).
+const importStatements = (src: string): string[] =>
+  src.match(/^import\b[\s\S]*?from\s+['"][^'"]+['"]/gm) ?? []
+
+const xyflowValueImports = (src: string): string[] =>
+  importStatements(src).filter(
+    (statement) =>
+      /from\s+['"]@xyflow\/react['"]/.test(statement) &&
+      !/^import\s+type\b/.test(statement),
+  )
+
+// Files that only consume React Flow types or plain graph data — they must
+// never import React Flow runtime values.
+const typeOnlyConsumers = [
+  'components/WorkflowGraph.tsx',
+  'components/NodeEditDialog.tsx',
+  'components/EdgeEditDialog.tsx',
+  'components/NodeEditDialogCrudForm.tsx',
+  'components/EdgeEditDialogCrudForm.tsx',
+  'backend/instances/[id]/page.tsx',
+  'backend/definitions/visual-editor/page.tsx',
+  'lib/graph-utils.ts',
+]
+
+describe('@xyflow/react lazy boundary (#3169)', () => {
+  test.each(typeOnlyConsumers)(
+    '%s imports @xyflow/react with `import type` only',
+    (relativePath) => {
+      const valueImports = xyflowValueImports(read(relativePath))
+      expect(valueImports).toEqual([])
+    },
+  )
+
+  test('the visual editor page does not pull React Flow runtime reducers into its chunk', () => {
+    const src = read('backend/definitions/visual-editor/page.tsx')
+    const xyflowStatements = importStatements(src).filter((statement) =>
+      /from\s+['"]@xyflow\/react['"]/.test(statement),
+    )
+    const runtimeHelper = /\b(addEdge|applyNodeChanges|applyEdgeChanges)\b/
+    expect(xyflowStatements.some((statement) => runtimeHelper.test(statement))).toBe(false)
+  })
+
+  test('the lazy implementation remains the React Flow runtime boundary', () => {
+    // Sanity: WorkflowGraphImpl is the one place that may import runtime values.
+    const src = read('components/WorkflowGraphImpl.tsx')
+    expect(xyflowValueImports(src).length).toBeGreaterThan(0)
+  })
+})

--- a/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
@@ -6,10 +6,10 @@ import { NodeEditDialog } from '../../../components/NodeEditDialog'
 import { EdgeEditDialog } from '../../../components/EdgeEditDialog'
 import { NodeEditDialogCrudForm } from '../../../components/NodeEditDialogCrudForm'
 import { EdgeEditDialogCrudForm } from '../../../components/EdgeEditDialogCrudForm'
-import { Node, Edge, addEdge, Connection, applyNodeChanges, applyEdgeChanges, NodeChange, EdgeChange } from '@xyflow/react'
+import type { Node, Edge, Connection } from '@xyflow/react'
 import { useState, useCallback, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { graphToDefinition, definitionToGraph, validateWorkflowGraph, generateStepId, generateTransitionId, ValidationError } from '../../../lib/graph-utils'
+import { graphToDefinition, definitionToGraph, validateWorkflowGraph, generateStepId, generateTransitionId, appendWorkflowEdge, ValidationError } from '../../../lib/graph-utils'
 import { performDeleteEdgeFlow, performDeleteNodeFlow } from '../../../lib/visual-editor-delete-flow'
 import { workflowDefinitionDataSchema } from '../../../data/validators'
 import { Page } from '@open-mercato/ui/backend/Page'
@@ -169,16 +169,18 @@ export default function VisualEditorPage() {
     loadDefinition()
   }, [definitionId])
 
-  // Handle node changes from ReactFlow
-  const handleNodesChange = useCallback((changes: NodeChange[]) => {
+  // Handle node changes from ReactFlow. The lazy graph applies React Flow's
+  // change reducers internally (#3169) and hands back the resolved nodes, so
+  // this page never imports the @xyflow/react runtime.
+  const handleNodesChange = useCallback((nextNodes: Node[]) => {
     if (isCodeOnly) return
-    setNodes((nds) => applyNodeChanges(changes, nds))
+    setNodes(nextNodes)
   }, [isCodeOnly])
 
-  // Handle edge changes from ReactFlow
-  const handleEdgesChange = useCallback((changes: EdgeChange[]) => {
+  // Handle edge changes from ReactFlow (resolved edges from the lazy graph).
+  const handleEdgesChange = useCallback((nextEdges: Edge[]) => {
     if (isCodeOnly) return
-    setEdges((eds) => applyEdgeChanges(changes, eds))
+    setEdges(nextEdges)
   }, [isCodeOnly])
 
   // Handle adding new node from palette
@@ -285,7 +287,7 @@ export default function VisualEditorPage() {
       },
     }
 
-    setEdges((eds) => addEdge(newEdge, eds))
+    setEdges((eds) => appendWorkflowEdge(eds, newEdge))
   }, [])
 
   // Validate workflow

--- a/packages/core/src/modules/workflows/backend/instances/[id]/page.tsx
+++ b/packages/core/src/modules/workflows/backend/instances/[id]/page.tsx
@@ -18,7 +18,7 @@ import { WorkflowLegend } from '../../../components/WorkflowLegend'
 import { MobileInstanceOverview } from '../../../components/mobile/MobileInstanceOverview'
 import { useIsMobile } from '@open-mercato/ui/hooks/useIsMobile'
 import { definitionToGraph } from '../../../lib/graph-utils'
-import { Node } from '@xyflow/react'
+import type { Node } from '@xyflow/react'
 import { RecordNotFoundState, ErrorMessage } from '@open-mercato/ui/backend/detail'
 
 export default function WorkflowInstanceDetailPage({ params }: { params?: { id?: string } }) {

--- a/packages/core/src/modules/workflows/components/EdgeEditDialog.tsx
+++ b/packages/core/src/modules/workflows/components/EdgeEditDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import {Edge} from '@xyflow/react'
+import type {Edge} from '@xyflow/react'
 import {useEffect, useState} from 'react'
 import {
   Dialog,

--- a/packages/core/src/modules/workflows/components/EdgeEditDialogCrudForm.tsx
+++ b/packages/core/src/modules/workflows/components/EdgeEditDialogCrudForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Edge } from '@xyflow/react'
+import type { Edge } from '@xyflow/react'
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@open-mercato/ui/primitives/dialog'
 import { Badge } from '@open-mercato/ui/primitives/badge'

--- a/packages/core/src/modules/workflows/components/NodeEditDialog.tsx
+++ b/packages/core/src/modules/workflows/components/NodeEditDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import {Node} from '@xyflow/react'
+import type {Node} from '@xyflow/react'
 import {useEffect, useState} from 'react'
 import {Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle} from '@open-mercato/ui/primitives/dialog'
 import {Button} from '@open-mercato/ui/primitives/button'

--- a/packages/core/src/modules/workflows/components/NodeEditDialogCrudForm.tsx
+++ b/packages/core/src/modules/workflows/components/NodeEditDialogCrudForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Node } from '@xyflow/react'
+import type { Node } from '@xyflow/react'
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@open-mercato/ui/primitives/dialog'
 import { Badge } from '@open-mercato/ui/primitives/badge'

--- a/packages/core/src/modules/workflows/components/WorkflowGraph.tsx
+++ b/packages/core/src/modules/workflows/components/WorkflowGraph.tsx
@@ -8,8 +8,8 @@ import { Spinner } from '@open-mercato/ui/primitives/spinner'
 export interface WorkflowGraphProps {
   initialNodes?: Node[]
   initialEdges?: Edge[]
-  onNodesChange?: (changes: any[]) => void
-  onEdgesChange?: (changes: any[]) => void
+  onNodesChange?: (nodes: Node[]) => void
+  onEdgesChange?: (edges: Edge[]) => void
   onNodeClick?: (event: React.MouseEvent, node: Node) => void
   onEdgeClick?: (event: React.MouseEvent, edge: Edge) => void
   onConnect?: (connection: Connection) => void

--- a/packages/core/src/modules/workflows/components/WorkflowGraphImpl.tsx
+++ b/packages/core/src/modules/workflows/components/WorkflowGraphImpl.tsx
@@ -2,7 +2,7 @@
 
 import '@xyflow/react/dist/style.css'
 
-import { useCallback, useMemo, useEffect, useState } from 'react'
+import { useCallback, useMemo, useEffect, useRef, useState } from 'react'
 import {
   ReactFlow,
   Node,
@@ -15,7 +15,11 @@ import {
   useNodesState,
   useEdgesState,
   addEdge,
+  applyNodeChanges,
+  applyEdgeChanges,
   Connection,
+  NodeChange,
+  EdgeChange,
   ConnectionMode,
   MarkerType,
 } from '@xyflow/react'
@@ -30,8 +34,8 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 export interface WorkflowGraphImplProps {
   initialNodes?: Node[]
   initialEdges?: Edge[]
-  onNodesChange?: (changes: any[]) => void
-  onEdgesChange?: (changes: any[]) => void
+  onNodesChange?: (nodes: Node[]) => void
+  onEdgesChange?: (edges: Edge[]) => void
   onNodeClick?: (event: React.MouseEvent, node: Node) => void
   onEdgeClick?: (event: React.MouseEvent, edge: Edge) => void
   onConnect?: (connection: Connection) => void
@@ -53,8 +57,16 @@ export default function WorkflowGraphImpl({
   height = '600px',
 }: WorkflowGraphImplProps) {
   const t = useT()
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges)
+  const [nodes, setNodes] = useNodesState(initialNodes)
+  const [edges, setEdges] = useEdgesState(initialEdges)
+
+  // Track the latest committed graph so the change reducers can run inside the
+  // lazy boundary (#3169) and forward the already-applied arrays to the parent,
+  // keeping React Flow's runtime out of the editor page chunk.
+  const latestNodesRef = useRef(nodes)
+  latestNodesRef.current = nodes
+  const latestEdgesRef = useRef(edges)
+  latestEdgesRef.current = edges
 
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
@@ -105,23 +117,25 @@ export default function WorkflowGraphImpl({
   )
 
   const handleNodesChange = useCallback(
-    (changes: any) => {
-      onNodesChange(changes)
+    (changes: NodeChange[]) => {
+      const nextNodes = applyNodeChanges(changes, latestNodesRef.current)
+      setNodes(nextNodes)
       if (onNodesChangeProp) {
-        onNodesChangeProp(changes)
+        onNodesChangeProp(nextNodes)
       }
     },
-    [onNodesChange, onNodesChangeProp]
+    [setNodes, onNodesChangeProp]
   )
 
   const handleEdgesChange = useCallback(
-    (changes: any) => {
-      onEdgesChange(changes)
+    (changes: EdgeChange[]) => {
+      const nextEdges = applyEdgeChanges(changes, latestEdgesRef.current)
+      setEdges(nextEdges)
       if (onEdgesChangeProp) {
-        onEdgesChangeProp(changes)
+        onEdgesChangeProp(nextEdges)
       }
     },
-    [onEdgesChange, onEdgesChangeProp]
+    [setEdges, onEdgesChangeProp]
   )
 
   const nodeTypes = useMemo(

--- a/packages/core/src/modules/workflows/components/mobile/MobileVisualEditor.tsx
+++ b/packages/core/src/modules/workflows/components/mobile/MobileVisualEditor.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import type { Node, Edge, NodeChange, EdgeChange, Connection } from '@xyflow/react'
+import type { Node, Edge, Connection } from '@xyflow/react'
 import { Button } from '@open-mercato/ui/primitives/button'
 import {
   Dialog,
@@ -21,8 +21,8 @@ export interface MobileVisualEditorProps {
   isSaving: boolean
   nodes: Node[]
   edges: Edge[]
-  onNodesChange: (changes: NodeChange[]) => void
-  onEdgesChange: (changes: EdgeChange[]) => void
+  onNodesChange: (nodes: Node[]) => void
+  onEdgesChange: (edges: Edge[]) => void
   onNodeClick: (event: React.MouseEvent, node: Node) => void
   onEdgeClick: (event: React.MouseEvent, edge: Edge) => void
   onConnect: (connection: Connection) => void

--- a/packages/core/src/modules/workflows/lib/__tests__/graph-utils.appendWorkflowEdge.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/graph-utils.appendWorkflowEdge.test.ts
@@ -1,0 +1,40 @@
+/** @jest-environment node */
+
+import { describe, test, expect } from '@jest/globals'
+import type { Edge } from '@xyflow/react'
+import { appendWorkflowEdge } from '../graph-utils'
+
+const edge = (overrides: Partial<Edge> & Pick<Edge, 'id' | 'source' | 'target'>): Edge => ({
+  type: 'smoothstep',
+  ...overrides,
+})
+
+describe('appendWorkflowEdge (#3169 addEdge replacement)', () => {
+  test('appends a new edge as a new array', () => {
+    const existing = [edge({ id: 'e1', source: 'a', target: 'b' })]
+    const next = appendWorkflowEdge(existing, edge({ id: 'e2', source: 'b', target: 'c' }))
+    expect(next).toHaveLength(2)
+    expect(next).not.toBe(existing)
+    expect(next.map((e) => e.id)).toEqual(['e1', 'e2'])
+  })
+
+  test('drops a duplicate connection (same source/target) without mutating', () => {
+    const existing = [edge({ id: 'e1', source: 'a', target: 'b' })]
+    const next = appendWorkflowEdge(existing, edge({ id: 'e2', source: 'a', target: 'b' }))
+    expect(next).toBe(existing)
+    expect(next).toHaveLength(1)
+  })
+
+  test('treats differing handles as distinct connections', () => {
+    const existing = [edge({ id: 'e1', source: 'a', target: 'b', sourceHandle: 'out-1' })]
+    const next = appendWorkflowEdge(existing, edge({ id: 'e2', source: 'a', target: 'b', sourceHandle: 'out-2' }))
+    expect(next).toHaveLength(2)
+  })
+
+  test('treats empty-string and nullish handles as the same connection (matches addEdge)', () => {
+    const existing = [edge({ id: 'e1', source: 'a', target: 'b', sourceHandle: '' })]
+    const next = appendWorkflowEdge(existing, edge({ id: 'e2', source: 'a', target: 'b', sourceHandle: undefined }))
+    expect(next).toBe(existing)
+    expect(next).toHaveLength(1)
+  })
+})

--- a/packages/core/src/modules/workflows/lib/graph-utils.ts
+++ b/packages/core/src/modules/workflows/lib/graph-utils.ts
@@ -1,4 +1,4 @@
-import { Node, Edge } from '@xyflow/react'
+import type { Node, Edge } from '@xyflow/react'
 import type { WorkflowDefinition } from '../data/entities'
 
 /**
@@ -658,4 +658,24 @@ export function generateStepId(prefix: string = 'step'): string {
 export function generateTransitionId(fromStepId: string, toStepId: string): string {
   const id = `e_${fromStepId}_${toStepId}`
   return sanitizeId(id)
+}
+
+/**
+ * Append a new edge to the list, skipping duplicate connections.
+ *
+ * A plain-data replacement for React Flow's `addEdge` so the visual editor
+ * page does not pull the `@xyflow/react` runtime out of its lazy boundary
+ * (#3169). Mirrors `addEdge`'s dedup rule: an edge is dropped when one with
+ * the same source/target endpoints (and handles) already exists.
+ */
+export function appendWorkflowEdge(edges: Edge[], edge: Edge): Edge[] {
+  const isDuplicate = edges.some(
+    (existing) =>
+      existing.source === edge.source &&
+      existing.target === edge.target &&
+      // Match addEdge: empty-string and nullish handles are equivalent.
+      (existing.sourceHandle || null) === (edge.sourceHandle || null) &&
+      (existing.targetHandle || null) === (edge.targetHandle || null),
+  )
+  return isDuplicate ? edges : [...edges, edge]
 }


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The workflow editor declared a lazy `@xyflow/react` boundary (`WorkflowGraph` →
`next/dynamic(WorkflowGraphImpl, { ssr:false })`), but adjacent files weakened it:
five files imported React Flow *types* as value imports (which Turbopack/SWC can keep
as runtime imports), and the visual-editor page statically imported runtime helpers
(`addEdge`, `applyNodeChanges`, `applyEdgeChanges`), pulling the ~12 MB React Flow
runtime into the editor chunk outside the lazy boundary. This keeps React Flow's
runtime confined to `WorkflowGraphImpl`.

## Changes

- Convert type-only `@xyflow/react` imports (`Node`/`Edge`/`Connection`/`NodeChange`/`EdgeChange`)
  to `import type` in the node/edge dialogs, the instance view page, the visual-editor page,
  and `lib/graph-utils.ts`.
- Move React Flow's change reducers (`applyNodeChanges`/`applyEdgeChanges`) into the lazy
  `WorkflowGraphImpl`; it now applies changes internally and forwards the resolved
  `Node[]`/`Edge[]` to the parent. The visual-editor page no longer imports the React Flow runtime.
- Replace the page's `addEdge` call with a local `appendWorkflowEdge` data helper in
  `lib/graph-utils.ts` (same source/target/handle dedup semantics).
- Update `WorkflowGraph`/`MobileVisualEditor` prop types to the resolved-array contract.
- Add a source-text boundary guard test plus unit tests for `appendWorkflowEdge`.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — behavior-preserving perf/refactor from a React best-practices audit.

## Testing

- `packages/core` jest: `xyflow-import-boundary` (regression guard, red→green) + `graph-utils.appendWorkflowEdge` (new) + full `src/modules/workflows` suite → **558 passed**.
- `tsc --noEmit` (core) → clean (validates the prop-contract change across all consumers).
- `yarn workspace @open-mercato/core build` → success.
- `yarn i18n:check-sync` → all locales in sync.
- Live editor click-through not run; flagged `needs-qa` for manual verification of node drag / edge changes / connection creation in the visual editor (acceptance criterion #3) and the instance read-only view (#4).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no locale/generator/doc surface touched.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Not required: behavior-preserving refactor with no new API path or feature flow; covered by the source-guard + unit tests.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A, no spec.
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium`, inherited from the issue.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — single-module change with tests.)
- [x] QA routing set: `needs-qa` — modifies interactive editor wiring; a reviewer should exercise node drag / edge changes / connection creation.

### Design System Compliance
- [x] No hardcoded status colors — no styling changed (imports + handler wiring only).
- [x] No arbitrary text sizes — no styling changed.
- [x] Empty state handled for list/data pages — unchanged (pre-existing).
- [x] Loading state handled for async pages — unchanged (pre-existing).
- [x] `aria-label` on all icon-only buttons — unchanged (pre-existing).
- [x] Uses existing DS components — no custom replacements introduced.

## Linked issues

Fixes #3169
