### PR TITLE
refactor: migrate remaining ErrorNotice call sites to Alert (#3166)

### DIFF
--- a/packages/checkout/src/modules/checkout/components/PayPage.tsx
+++ b/packages/checkout/src/modules/checkout/components/PayPage.tsx
@@ -16,7 +16,7 @@ import { useRegisteredComponent } from '@open-mercato/ui/backend/injection/useRe
 import { MarkdownContent } from '@open-mercato/ui/backend/markdown/MarkdownContent'
 import { apiCallOrThrow, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { mapCrudServerErrorToFormErrors } from '@open-mercato/ui/backend/utils/serverErrors'
-import { ErrorNotice } from '@open-mercato/ui/primitives/ErrorNotice'
+import { Alert, AlertDescription, AlertTitle } from '@open-mercato/ui/primitives/alert'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Card, CardContent } from '@open-mercato/ui/primitives/card'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@open-mercato/ui/primitives/dialog'
@@ -1967,15 +1967,15 @@ export function PayPage({
   if (loadError || !payload) {
     return (
       <div className="mx-auto max-w-3xl px-4 py-16">
-        <ErrorNotice
-          title={t('checkout.payPage.errors.loadTitle', 'Unable to load payment link')}
-          message={loadError ?? t('checkout.payPage.errors.loadMessage', "We couldn't load this payment page. Please try again.")}
-          action={(
+        <Alert variant="destructive">
+          <AlertTitle>{t('checkout.payPage.errors.loadTitle', 'Unable to load payment link')}</AlertTitle>
+          <AlertDescription>{loadError ?? t('checkout.payPage.errors.loadMessage', "We couldn't load this payment page. Please try again.")}</AlertDescription>
+          <div className="mt-2">
             <Button type="button" variant="outline" onClick={() => { void loadPayload() }}>
               {t('checkout.payPage.actions.retry', 'Retry')}
             </Button>
-          )}
-        />
+          </div>
+        </Alert>
       </div>
     )
   }

--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx
@@ -32,7 +32,7 @@ import { Button } from '@open-mercato/ui/primitives/button'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import { SearchInput } from '@open-mercato/ui/primitives/search-input'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
-import { ErrorNotice } from '@open-mercato/ui/primitives/ErrorNotice'
+import { Alert, AlertDescription, AlertTitle } from '@open-mercato/ui/primitives/alert'
 import { EmptyState } from '@open-mercato/ui/primitives/empty-state'
 import {
   Select,
@@ -2734,17 +2734,18 @@ export default function DealsKanbanPage(): React.ReactElement {
           </div>
         ) : firstError ? (
           <div className="max-w-xl">
-            <ErrorNotice
-              message={
-                firstError instanceof Error
+            <Alert variant="destructive">
+              <AlertTitle>{translateWithFallback(t, 'ui.errors.defaultTitle', 'Something went wrong')}</AlertTitle>
+              <AlertDescription>
+                {firstError instanceof Error
                   ? firstError.message
                   : translateWithFallback(
                       t,
                       'customers.deals.pipeline.loadError',
                       'Failed to load deals.',
-                    )
-              }
-            />
+                    )}
+              </AlertDescription>
+            </Alert>
           </div>
         ) : (
           <DndContext

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
@@ -9,7 +9,7 @@ import { invalidateCustomFieldDefs } from '@open-mercato/ui/backend/utils/custom
 import { upsertCustomEntitySchema, upsertCustomFieldDefSchema } from '@open-mercato/core/modules/entities/data/validators'
 import { z } from 'zod'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
-import { ErrorNotice } from '@open-mercato/ui/primitives/ErrorNotice'
+import { Alert, AlertDescription, AlertTitle } from '@open-mercato/ui/primitives/alert'
 import Link from 'next/link'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { loadGeneratedFieldRegistrations } from '@open-mercato/ui/backend/fields/registry'
@@ -522,7 +522,10 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
       <Page>
         <PageBody>
           <div className="p-6">
-            <ErrorNotice title="Invalid entity" message="The requested entity ID is missing or invalid." />
+            <Alert variant="destructive">
+              <AlertTitle>Invalid entity</AlertTitle>
+              <AlertDescription>The requested entity ID is missing or invalid.</AlertDescription>
+            </Alert>
           </div>
         </PageBody>
       </Page>

--- a/packages/core/src/modules/feature_toggles/components/FeatureToggleOverrideCard.tsx
+++ b/packages/core/src/modules/feature_toggles/components/FeatureToggleOverrideCard.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@open-mercato/ui/primitives/card'
-import { DataLoader, ErrorNotice } from "@open-mercato/ui";
+import { DataLoader } from "@open-mercato/ui";
+import { Alert, AlertDescription, AlertTitle } from "@open-mercato/ui/primitives/alert";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiCall, withScopedApiRequestHeaders } from "@open-mercato/ui/backend/utils/apiCall";
 import { buildOptimisticLockHeader } from "@open-mercato/ui/backend/utils/optimisticLock";
@@ -68,7 +69,10 @@ export function FeatureToggleOverrideCard({ toggleId }: { toggleId: string }) {
                     <CardTitle>{t('feature_toggles.override.title', 'Override')}</CardTitle>
                 </CardHeader>
                 <CardContent>
-                    <ErrorNotice message={error.message} />
+                    <Alert variant="destructive">
+                        <AlertTitle>{t('ui.errors.defaultTitle', 'Something went wrong')}</AlertTitle>
+                        <AlertDescription>{error.message}</AlertDescription>
+                    </Alert>
                 </CardContent>
             </Card>
         )

--- a/packages/ui/src/backend/custom-fields/FieldDefinitionsManager.tsx
+++ b/packages/ui/src/backend/custom-fields/FieldDefinitionsManager.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '../../primitives/button'
 import { Spinner } from '../../primitives/spinner'
-import { ErrorNotice } from '../../primitives/ErrorNotice'
+import { Alert, AlertDescription, AlertTitle } from '../../primitives/alert'
 import { flash } from '../FlashMessages'
 import { apiCall, readApiResultOrThrow } from '../utils/apiCall'
 import { raiseCrudError } from '../utils/serverErrors'
@@ -355,7 +355,10 @@ export const FieldDefinitionsManager = React.forwardRef<FieldDefinitionsManagerH
     return (
       <div className="flex flex-col gap-3 sm:gap-4">
         {statusError ? (
-          <ErrorNotice title={t('entities.customFields.errors.title', 'Something went wrong')} message={statusError} />
+          <Alert variant="destructive">
+            <AlertTitle>{t('entities.customFields.errors.title', 'Something went wrong')}</AlertTitle>
+            <AlertDescription>{statusError}</AlertDescription>
+          </Alert>
         ) : null}
         <div className="rounded-lg border bg-card p-3 sm:p-4 max-h-[70vh] overflow-y-auto">
           {content}

--- a/packages/ui/src/backend/dashboard/DashboardScreen.tsx
+++ b/packages/ui/src/backend/dashboard/DashboardScreen.tsx
@@ -4,7 +4,6 @@ import * as React from 'react'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
-import { ErrorNotice } from '@open-mercato/ui/primitives/ErrorNotice'
 import { Alert, AlertDescription, AlertTitle } from '@open-mercato/ui/primitives/alert'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { getDashboardWidgets, loadDashboardWidgetModule } from './widgetRegistry'
@@ -355,11 +354,11 @@ export function DashboardScreen() {
 
   if (error && layout.length === 0) {
     return (
-      <ErrorNotice
-        title={t('dashboard.unavailable')}
-        message={error}
-        action={<Button variant="outline" onClick={handleRefresh}>{t('dashboard.retry')}</Button>}
-      />
+      <Alert variant="destructive">
+        <AlertTitle>{t('dashboard.unavailable')}</AlertTitle>
+        <AlertDescription>{error}</AlertDescription>
+        <div className="mt-2"><Button variant="outline" onClick={handleRefresh}>{t('dashboard.retry')}</Button></div>
+      </Alert>
     )
   }
 
@@ -401,11 +400,11 @@ export function DashboardScreen() {
       </div>
 
       {error && layout.length > 0 && (
-        <ErrorNotice
-          title={t('dashboard.error.partial')}
-          message={error}
-          action={<Button variant="ghost" onClick={handleRefresh}>{t('dashboard.error.reload')}</Button>}
-        />
+        <Alert variant="destructive">
+          <AlertTitle>{t('dashboard.error.partial')}</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+          <div className="mt-2"><Button variant="ghost" onClick={handleRefresh}>{t('dashboard.error.reload')}</Button></div>
+        </Alert>
       )}
 
       <InjectionSpot spotId={dashboardBeforeSpotId} context={injectionContext} />

--- a/packages/ui/src/primitives/__tests__/no-deprecated-notice.test.ts
+++ b/packages/ui/src/primitives/__tests__/no-deprecated-notice.test.ts
@@ -70,3 +70,45 @@ describe('Deprecated <Notice> JSX guard', () => {
     expect(violations).toEqual([])
   })
 })
+
+describe('Deprecated <ErrorNotice> import guard', () => {
+  const ERROR_NOTICE_ALLOWED = new Set(
+    [
+      // The deprecated primitive itself is kept as a BC export.
+      'packages/ui/src/primitives/ErrorNotice.tsx',
+      // The package barrel re-exports it for backward compatibility.
+      'packages/ui/src/index.ts',
+    ].map((relative) => path.join(REPO_ROOT, relative)),
+  )
+
+  it('has no active ErrorNotice imports or usages outside the allow-list', () => {
+    const files: string[] = []
+    for (const dir of ['apps', 'packages']) {
+      const fullDir = path.join(REPO_ROOT, dir)
+      if (fs.existsSync(fullDir)) collectSourceFiles(fullDir, files)
+    }
+
+    const errorNoticeRegex = /\bErrorNotice\b/
+
+    const violations: Array<{ file: string; line: number; snippet: string }> = []
+    for (const file of files) {
+      if (ERROR_NOTICE_ALLOWED.has(file)) continue
+      if (/__tests__/.test(file)) continue
+      const contents = fs.readFileSync(file, 'utf8')
+      if (!errorNoticeRegex.test(contents)) continue
+
+      const lines = contents.split('\n')
+      lines.forEach((lineContent, index) => {
+        if (errorNoticeRegex.test(lineContent)) {
+          violations.push({
+            file: path.relative(REPO_ROOT, file),
+            line: index + 1,
+            snippet: lineContent.trim().slice(0, 160),
+          })
+        }
+      })
+    }
+
+    expect(violations).toEqual([])
+  })
+})


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Migrate the remaining six active `ErrorNotice` call sites to the current `Alert` feedback primitive. `ErrorNotice` is a deprecated wrapper that internally renders `<Alert variant="destructive"><AlertTitle/><AlertDescription/>{action}</Alert>`, so each replacement is a faithful 1:1 swap that preserves the exact rendered text, default title/message fallbacks, and action placement. The `ErrorNotice` primitive and its package-barrel re-export are kept as deprecated/BC exports. A regression guard is added so new code cannot reintroduce active `ErrorNotice` usage.

## Changes

- Replace `ErrorNotice` with the equivalent `Alert variant="destructive"` (+ `AlertTitle`/`AlertDescription`, action in `<div className="mt-2">`) in:
  - `packages/checkout/src/modules/checkout/components/PayPage.tsx` (payment-link load error)
  - `packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx` (deal-load error — preserves the default "Something went wrong" title)
  - `packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx` (invalid-entity guard)
  - `packages/core/src/modules/feature_toggles/components/FeatureToggleOverrideCard.tsx` (override-load error — preserves default title; barrel import split to keep `DataLoader`)
  - `packages/ui/src/backend/custom-fields/FieldDefinitionsManager.tsx` (status error)
  - `packages/ui/src/backend/dashboard/DashboardScreen.tsx` (two error states — reuses existing `Alert` import)
- Add an `ErrorNotice` import/usage guard to `packages/ui/src/primitives/__tests__/no-deprecated-notice.test.ts` (allow-list = the deprecated primitive `ErrorNotice.tsx` + its `packages/ui/src/index.ts` barrel re-export only).
- `packages/ui/src/primitives/ErrorNotice.tsx` and its barrel export are intentionally left in place as deprecated/BC exports.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — focused deprecation migration over a finite, enumerated call-site list (per issue #3166).


## Testing

List the tests or commands you ran to validate the change.

- Regression guard proven red→green (probe import → guard fails; migrated tree → green).
- `yarn build:packages` → ✅ 21/21
- `yarn generate` → ✅ ; `yarn build:packages` (rebuild with generated) → ✅ 21/21
- `yarn i18n:check-sync` → ✅ all locales (en/pl/es/de) in sync
- `yarn typecheck` → ✅ 21/21
- `yarn workspace @open-mercato/ui test` → ✅ 182 suites / 1558 tests (incl. new guard, `DashboardScreen`, `alert`, `ErrorNotice`)
- `yarn workspace @open-mercato/checkout test` → ✅ 14 suites / 69 tests
- core tests (`feature_toggles|entities|customers…deal`) → ✅ 66 suites / 394 tests
- `yarn build:app` → ✅
- `yarn lint` → pre-existing failures only in `apps/mercato/src/modules/example/` (unrelated; no changed file is under `apps/mercato`).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No new locale keys/docs/generators required — reuses existing `ui.errors.*` and per-module keys.)
- [x] I added or adjusted tests that cover the change. (Added the `ErrorNotice` regression guard.)
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Not required: render-identical deprecation swap with zero behavioral change; covered by the unit guard + existing `DashboardScreen` render test.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — no spec.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-low`, inherited from #3166.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). (`risk-low`, inherited from #3166 — mechanical, render-identical.)
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. (`skip-qa` — no behavioral/visual change; the `Alert` output is identical to the `ErrorNotice` it replaced.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) (N/A — no list/data page changed; the dashboard's `Alert variant="info"` empty state is untouched.)
- [x] Loading state handled for async pages (Unchanged — existing `Spinner` loading states untouched.)
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) (N/A — no icon-only buttons added/changed.)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements (This change migrates *to* the canonical `Alert` DS component.)

## Linked issues

Fixes #3166
