### PR TITLE
Fix auth and onboarding feedback tokens

### DIFF
--- a/packages/core/src/__tests__/auth-onboarding-feedback-ds-tokens.test.ts
+++ b/packages/core/src/__tests__/auth-onboarding-feedback-ds-tokens.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+const repoRoot = join(__dirname, '..', '..', '..', '..')
+
+const TARGET_FILES = [
+  'packages/core/src/modules/auth/frontend/login.tsx',
+  'packages/onboarding/src/modules/onboarding/frontend/onboarding/OnboardingPageClient.tsx',
+]
+
+const HARDCODED_STATUS_CLASS = /\b(?:border|bg|text)-(?:red|emerald)-\d{2,3}\b/g
+
+describe('auth and onboarding feedback states use DS status tokens (#3165)', () => {
+  it('does not use hardcoded red or emerald Tailwind classes in feedback surfaces', () => {
+    const violations: string[] = []
+
+    for (const file of TARGET_FILES) {
+      const fullPath = join(repoRoot, file)
+      const rel = relative(repoRoot, fullPath).split(sep).join('/')
+      const lines = readFileSync(fullPath, 'utf8').split('\n')
+
+      for (const [index, line] of lines.entries()) {
+        const matches = line.match(HARDCODED_STATUS_CLASS)
+        if (matches) {
+          violations.push(`${rel}:${index + 1} ${matches.join(', ')}`)
+        }
+      }
+    }
+
+    expect(violations).toEqual([])
+  })
+})

--- a/packages/core/src/modules/auth/frontend/login.tsx
+++ b/packages/core/src/modules/auth/frontend/login.tsx
@@ -383,15 +383,15 @@ export default function LoginPage() {
                 </div>
               ) : null}
               {showTenantInvalid ? (
-                <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-center text-xs text-red-700">
+                <div className="rounded-md border border-status-error-border bg-status-error-bg px-3 py-2 text-center text-xs text-status-error-text">
                   <div className="font-medium">{translate('auth.login.errors.tenantInvalid', 'Tenant not found. Clear the tenant selection and try again.')}</div>
-                  <Button type="button" variant="outline" size="sm" className="mt-2 border-red-300 text-red-700" onClick={handleClearTenant}>
+                  <Button type="button" variant="outline" size="sm" className="mt-2 border-status-error-border text-status-error-text hover:text-status-error-text" onClick={handleClearTenant}>
                     <X className="mr-2 size-4" aria-hidden="true" />
                     {translate('auth.login.tenantClear', 'Clear')}
                   </Button>
                 </div>
               ) : tenantId ? (
-                <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-center text-xs text-emerald-900">
+                <div className="rounded-md border border-status-success-border bg-status-success-bg px-3 py-2 text-center text-xs text-status-success-text">
                   <div className="font-medium">
                     {tenantLoading
                       ? translate('auth.login.tenantLoading', 'Loading tenant details...')
@@ -399,14 +399,14 @@ export default function LoginPage() {
                           tenant: tenantName || tenantId,
                         })}
                   </div>
-                  <Button type="button" variant="outline" size="sm" className="mt-2 border-emerald-300 text-emerald-900" onClick={handleClearTenant}>
+                  <Button type="button" variant="outline" size="sm" className="mt-2 border-status-success-border text-status-success-text hover:text-status-success-text" onClick={handleClearTenant}>
                     <X className="mr-2 size-4" aria-hidden="true" />
                     {translate('auth.login.tenantClear', 'Clear')}
                   </Button>
                 </div>
               ) : null}
               {error && !showTenantInvalid && (
-                <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-center text-sm text-red-700" role="alert" aria-live="polite">
+                <div className="rounded-md border border-status-error-border bg-status-error-bg px-3 py-2 text-center text-sm text-status-error-text" role="alert" aria-live="polite">
                   {error}
                 </div>
               )}

--- a/packages/onboarding/src/modules/onboarding/frontend/onboarding/OnboardingPageClient.tsx
+++ b/packages/onboarding/src/modules/onboarding/frontend/onboarding/OnboardingPageClient.tsx
@@ -16,6 +16,7 @@ import { Input } from '@open-mercato/ui/primitives/input'
 import { EmailInput } from '@open-mercato/ui/primitives/email-input'
 import { PasswordInput } from '@open-mercato/ui/primitives/password-input'
 import { Label } from '@open-mercato/ui/primitives/label'
+import { Alert, AlertDescription } from '@open-mercato/ui/primitives/alert'
 
 type SubmissionState = 'idle' | 'loading' | 'success'
 type FieldErrors = Partial<Record<
@@ -225,7 +226,7 @@ export default function OnboardingPageClient({ onboardingEnabled }: Props) {
         </CardHeader>
         <CardContent className={onboardingDisabled ? 'pb-10 opacity-45' : 'pb-10'}>
           {state === 'success' && emailSubmitted && (
-            <div className="mb-6 rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900" role="status" aria-live="polite">
+            <div className="mb-6 rounded-md border border-status-success-border bg-status-success-bg px-4 py-3 text-sm text-status-success-text" role="status" aria-live="polite">
               <strong className="block text-sm font-medium">
                 {translate('onboarding.form.successTitle', 'Check your inbox')}
               </strong>
@@ -235,9 +236,9 @@ export default function OnboardingPageClient({ onboardingEnabled }: Props) {
             </div>
           )}
           {state !== 'success' && (globalError || verifyStatusError) && (
-            <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert" aria-live="assertive">
-              {globalError || verifyStatusError}
-            </div>
+            <Alert status="error" style="lighter" showIcon={false} className="mb-4 text-sm" aria-live="assertive">
+              <AlertDescription>{globalError || verifyStatusError}</AlertDescription>
+            </Alert>
           )}
           <form className="grid gap-4" onSubmit={onSubmit} noValidate>
             <div className="grid gap-1">
@@ -249,10 +250,9 @@ export default function OnboardingPageClient({ onboardingEnabled }: Props) {
                 disabled={disabled}
                 aria-invalid={Boolean(fieldErrors.email)}
                 aria-describedby={fieldErrors.email ? 'email-error' : undefined}
-                className={fieldErrors.email ? 'border-red-500 aria-invalid:ring-destructive' : undefined}
               />
               {fieldErrors.email && (
-                <p id="email-error" className="text-xs text-red-600">{fieldErrors.email}</p>
+                <p id="email-error" className="text-xs text-status-error-text">{fieldErrors.email}</p>
               )}
             </div>
             <div className="grid gap-1 sm:grid-cols-2 sm:gap-4">
@@ -267,10 +267,9 @@ export default function OnboardingPageClient({ onboardingEnabled }: Props) {
                   autoComplete="given-name"
                   aria-invalid={Boolean(fieldErrors.firstName)}
                   aria-describedby={fieldErrors.firstName ? 'firstName-error' : undefined}
-                  className={fieldErrors.firstName ? 'border-red-500 aria-invalid:ring-destructive' : undefined}
                 />
                 {fieldErrors.firstName && (
-                  <p id="firstName-error" className="text-xs text-red-600">{fieldErrors.firstName}</p>
+                  <p id="firstName-error" className="text-xs text-status-error-text">{fieldErrors.firstName}</p>
                 )}
               </div>
               <div className="grid gap-1">
@@ -284,10 +283,9 @@ export default function OnboardingPageClient({ onboardingEnabled }: Props) {
                   autoComplete="family-name"
                   aria-invalid={Boolean(fieldErrors.lastName)}
                   aria-describedby={fieldErrors.lastName ? 'lastName-error' : undefined}
-                  className={fieldErrors.lastName ? 'border-red-500 aria-invalid:ring-destructive' : undefined}
                 />
                 {fieldErrors.lastName && (
-                  <p id="lastName-error" className="text-xs text-red-600">{fieldErrors.lastName}</p>
+                  <p id="lastName-error" className="text-xs text-status-error-text">{fieldErrors.lastName}</p>
                 )}
               </div>
             </div>
@@ -302,10 +300,9 @@ export default function OnboardingPageClient({ onboardingEnabled }: Props) {
                 autoComplete="organization"
                 aria-invalid={Boolean(fieldErrors.organizationName)}
                 aria-describedby={fieldErrors.organizationName ? 'organizationName-error' : undefined}
-                className={fieldErrors.organizationName ? 'border-red-500 aria-invalid:ring-destructive' : undefined}
               />
               {fieldErrors.organizationName && (
-                <p id="organizationName-error" className="text-xs text-red-600">{fieldErrors.organizationName}</p>
+                <p id="organizationName-error" className="text-xs text-status-error-text">{fieldErrors.organizationName}</p>
               )}
             </div>
             <div className="grid gap-1">
@@ -319,13 +316,12 @@ export default function OnboardingPageClient({ onboardingEnabled }: Props) {
                 minLength={passwordPolicy.minLength}
                 aria-invalid={Boolean(fieldErrors.password)}
                 aria-describedby={fieldErrors.password ? 'password-error' : undefined}
-                className={fieldErrors.password ? 'border-red-500 aria-invalid:ring-destructive' : undefined}
               />
               {passwordDescription ? (
                 <p className="text-xs text-muted-foreground">{passwordDescription}</p>
               ) : null}
               {fieldErrors.password && (
-                <p id="password-error" className="text-xs text-red-600">{fieldErrors.password}</p>
+                <p id="password-error" className="text-xs text-status-error-text">{fieldErrors.password}</p>
               )}
             </div>
             <div className="grid gap-1">
@@ -338,10 +334,9 @@ export default function OnboardingPageClient({ onboardingEnabled }: Props) {
                 autoComplete="new-password"
                 aria-invalid={Boolean(fieldErrors.confirmPassword)}
                 aria-describedby={fieldErrors.confirmPassword ? 'confirmPassword-error' : undefined}
-                className={fieldErrors.confirmPassword ? 'border-red-500 aria-invalid:ring-destructive' : undefined}
               />
               {fieldErrors.confirmPassword && (
-                <p id="confirmPassword-error" className="text-xs text-red-600">{fieldErrors.confirmPassword}</p>
+                <p id="confirmPassword-error" className="text-xs text-status-error-text">{fieldErrors.confirmPassword}</p>
               )}
             </div>
             <label className="flex items-start gap-3 text-sm text-muted-foreground">
@@ -371,7 +366,7 @@ export default function OnboardingPageClient({ onboardingEnabled }: Props) {
                   {translate('onboarding.form.privacyLink', 'Privacy Policy')}
                 </a>
                 {fieldErrors.termsAccepted && (
-                  <span className="mt-1 block text-xs text-red-600">{fieldErrors.termsAccepted}</span>
+                  <span className="mt-1 block text-xs text-status-error-text">{fieldErrors.termsAccepted}</span>
                 )}
               </span>
             </label>


### PR DESCRIPTION
## Summary

Fix hardcoded auth and onboarding feedback status colors by replacing red and emerald Tailwind classes with semantic design-system status tokens and existing DS error presentation.

## Changes

- Updated login tenant, error, and success feedback states to use semantic status tokens.
- Preserved the tenant Clear hover fix with semantic hover text tokens.
- Updated onboarding success, error, and field validation feedback to use DS tokens/components.
- Added a regression test that blocks hardcoded red/emerald status classes in the affected auth/onboarding files.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — small DS cleanup for #3165.

## Testing

- `yarn workspace @open-mercato/core test --runTestsByPath src/__tests__/auth-onboarding-feedback-ds-tokens.test.ts --runInBand`
- `yarn build:packages`
- `yarn generate`
- `yarn typecheck`
- `yarn i18n:check-sync`
- `yarn test`
- `yarn build:app --force`
- Targeted ESLint for changed files passed.
- Full `yarn lint` is blocked by unrelated pre-existing hook-order errors in `apps/mercato/src/components/OrganizationSwitcher.tsx`.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement.
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: `priority-low`.
- [x] Risk set: `risk-low`.
- [x] QA routing set: `needs-qa`.

### Design System Compliance

- [x] No hardcoded status colors.
- [x] No arbitrary text sizes.
- [x] Empty state handled or not applicable.
- [x] Loading state handled or not applicable.
- [x] `aria-label` on all icon-only buttons or not applicable.
- [x] Uses existing DS components/tokens.

## Linked issues

Fixes #3165
Related: #3129