### PR TITLE
fix: set safe QueryClient defaults (#2984)

### DIFF
--- a/packages/ui/src/theme/QueryProvider.tsx
+++ b/packages/ui/src/theme/QueryProvider.tsx
@@ -1,6 +1,7 @@
 "use client"
 import * as React from 'react'
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import { redirectToSessionRefresh, notifyForbiddenAccess, UnauthorizedError, ForbiddenError, apiFetch, setAuthRedirectConfig } from '../backend/utils/api'
 
 // Ensure global fetch calls also flow through apiFetch so 401 session-refresh
@@ -14,7 +15,37 @@ function ensureGlobalFetchInterception() {
   window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => apiFetch(input, init)) as any
 }
 
+export const DEFAULT_QUERY_STALE_TIME_MS = 30_000
+const QUERY_RETRY_LIMIT = 2
+
+function readErrorStatus(error: unknown): number | null {
+  const status = (error as { status?: unknown })?.status
+  if (typeof status === 'number') return status
+  const responseStatus = (error as { response?: { status?: unknown } })?.response?.status
+  return typeof responseStatus === 'number' ? responseStatus : null
+}
+
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+  const status = readErrorStatus(error)
+  if (status !== null && status >= 400 && status <= 404) return false
+  return failureCount < QUERY_RETRY_LIMIT
+}
+
+export function buildDefaultQueryOptions() {
+  const enableDefaultStaleTime = parseBooleanWithDefault(
+    process.env.NEXT_PUBLIC_OM_QUERY_DEFAULT_STALE_TIME_ENABLED,
+    false,
+  )
+  return {
+    retry: shouldRetryQuery,
+    ...(enableDefaultStaleTime ? { staleTime: DEFAULT_QUERY_STALE_TIME_MS } : {}),
+  }
+}
+
 const client = new QueryClient({
+  defaultOptions: {
+    queries: buildDefaultQueryOptions(),
+  },
   queryCache: new QueryCache({
     onError: (error) => {
       if (error instanceof UnauthorizedError) redirectToSessionRefresh()

--- a/packages/ui/src/theme/__tests__/QueryProvider.test.tsx
+++ b/packages/ui/src/theme/__tests__/QueryProvider.test.tsx
@@ -1,0 +1,37 @@
+import {
+  DEFAULT_QUERY_STALE_TIME_MS,
+  buildDefaultQueryOptions,
+  shouldRetryQuery,
+} from '../QueryProvider'
+import { UnauthorizedError } from '../../backend/utils/api'
+
+describe('QueryProvider defaults', () => {
+  const originalStaleTimeFlag = process.env.NEXT_PUBLIC_OM_QUERY_DEFAULT_STALE_TIME_ENABLED
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_OM_QUERY_DEFAULT_STALE_TIME_ENABLED = originalStaleTimeFlag
+  })
+
+  it('does not retry deterministic 4xx query failures', () => {
+    expect(shouldRetryQuery(0, new UnauthorizedError())).toBe(false)
+    expect(shouldRetryQuery(0, { status: 400 })).toBe(false)
+    expect(shouldRetryQuery(0, { status: 404 })).toBe(false)
+  })
+
+  it('keeps transient query failures retryable with a two-retry cap', () => {
+    expect(shouldRetryQuery(0, { status: 408 })).toBe(true)
+    expect(shouldRetryQuery(1, { status: 429 })).toBe(true)
+    expect(shouldRetryQuery(1, { status: 503 })).toBe(true)
+    expect(shouldRetryQuery(1, new Error('network'))).toBe(true)
+
+    expect(shouldRetryQuery(2, { status: 503 })).toBe(false)
+  })
+
+  it('gates the shared staleTime default behind the public env flag', () => {
+    process.env.NEXT_PUBLIC_OM_QUERY_DEFAULT_STALE_TIME_ENABLED = '0'
+    expect(buildDefaultQueryOptions().staleTime).toBeUndefined()
+
+    process.env.NEXT_PUBLIC_OM_QUERY_DEFAULT_STALE_TIME_ENABLED = '1'
+    expect(buildDefaultQueryOptions().staleTime).toBe(DEFAULT_QUERY_STALE_TIME_MS)
+  })
+})


### PR DESCRIPTION
## Summary

Set safe shared TanStack Query defaults in the app-wide `QueryProvider`: deterministic 400-404 query failures no longer retry, transient/status-less failures keep a two-retry cap, and a 30s default staleTime is available behind `NEXT_PUBLIC_OM_QUERY_DEFAULT_STALE_TIME_ENABLED` with default off.

## Changes

- Added shared query retry/default-options helpers to `packages/ui/src/theme/QueryProvider.tsx`.
- Wired `defaultOptions.queries` into the singleton `QueryClient`.
- Added focused regression tests for 4xx retry suppression, transient retry behavior, and env-gated staleTime.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — focused issue fix, no contract/schema/API surface changed.

## Testing

- `yarn workspace @open-mercato/ui test --runTestsByPath src/theme/__tests__/QueryProvider.test.tsx --runInBand` — passed
- `yarn workspace @open-mercato/ui test --runTestsByPath src/theme/__tests__/QueryProvider.test.tsx src/backend/utils/__tests__/api.test.ts --runInBand` — passed
- `yarn build:packages` — passed
- `yarn generate` — passed
- `yarn build:packages` — passed
- `yarn i18n:check-sync` — passed
- `yarn i18n:check-usage` — passed with existing advisory unused-key output
- `yarn typecheck` — passed
- `yarn test` — passed
- `yarn build:app` — passed
- `yarn lint` — blocked by unrelated existing errors in `apps/mercato/src/components/OrganizationSwitcher.tsx`
- `yarn exec eslint packages/ui/src/theme/QueryProvider.tsx packages/ui/src/theme/__tests__/QueryProvider.test.tsx` — passed with no errors

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
N/A — no visual UI component changes.

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #2984
