### PR TITLE
fix: align global error fallback with DS tokens (#3160)

### DIFF
--- a/apps/mercato/src/app/__tests__/global-error.test.tsx
+++ b/apps/mercato/src/app/__tests__/global-error.test.tsx
@@ -79,6 +79,22 @@ describe('GlobalError component', () => {
     expect(reloadMock).not.toHaveBeenCalled()
   })
 
+  it('renders with design-system tokens and the shared Button primitive', () => {
+    setOnLine(true)
+    const reset = jest.fn()
+    const err = Object.assign(new Error('boom'), { name: 'TypeError' })
+    render(<GlobalError error={err} reset={reset} />)
+    const alert = screen.getByRole('alert')
+    const button = screen.getByRole('button', { name: /try again/i })
+
+    expect(alert).toHaveClass('bg-background', 'text-foreground')
+    expect(alert).not.toHaveAttribute('style')
+    expect(screen.getByRole('heading', { level: 1 })).not.toHaveAttribute('style')
+    expect(screen.getByText(/unexpected error occurred/i)).not.toHaveAttribute('style')
+    expect(button).toHaveAttribute('data-slot', 'button')
+    expect(button).not.toHaveAttribute('style')
+  })
+
   it('renders offline UI for ChunkLoadError even when navigator reports online', () => {
     setOnLine(true)
     const reset = jest.fn()

--- a/apps/mercato/src/app/global-error.tsx
+++ b/apps/mercato/src/app/global-error.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { Button } from '@open-mercato/ui/primitives/button'
 import { useEffect, useState } from 'react'
 import { reloadPage } from './global-error-reload'
 
@@ -53,6 +54,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
   }, [networkError])
 
   const showOfflineView = networkError || isOffline
+  // Next.js global-error renders outside normal app providers, so these are provider-independent fallback strings.
   const title = showOfflineView ? 'You appear to be offline' : 'Something went wrong'
   const description = showOfflineView
     ? 'Unable to connect. Please check your internet connection and try again. This page will reload automatically when your connection is restored.'
@@ -67,36 +69,20 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
   }
 
   return (
-    <html>
-      <body>
+    <html className="bg-background text-foreground">
+      <body className="bg-background text-foreground">
         <main
           role="alert"
           aria-live="assertive"
-          style={{
-            padding: '2rem',
-            fontFamily: 'system-ui, -apple-system, sans-serif',
-            maxWidth: '36rem',
-            margin: '4rem auto',
-          }}
+          className="flex min-h-screen items-start justify-center bg-background px-6 py-16 text-foreground"
         >
-          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{title}</h1>
-          <p style={{ marginBottom: '1.5rem', color: '#4b5563', lineHeight: 1.5 }}>{description}</p>
-          <button
-            type="button"
-            onClick={handleRetry}
-            style={{
-              padding: '0.5rem 1.25rem',
-              fontSize: '1rem',
-              fontWeight: 500,
-              background: '#111827',
-              color: '#ffffff',
-              border: 'none',
-              borderRadius: '0.375rem',
-              cursor: 'pointer',
-            }}
-          >
-            {buttonLabel}
-          </button>
+          <div className="w-full max-w-xl space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
+            <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+            <p className="text-sm leading-6 text-muted-foreground">{description}</p>
+            <Button type="button" onClick={handleRetry}>
+              {buttonLabel}
+            </Button>
+          </div>
         </main>
       </body>
     </html>

--- a/packages/create-app/template/src/app/__tests__/global-error.test.tsx
+++ b/packages/create-app/template/src/app/__tests__/global-error.test.tsx
@@ -79,6 +79,22 @@ describe('GlobalError component', () => {
     expect(reloadMock).not.toHaveBeenCalled()
   })
 
+  it('renders with design-system tokens and the shared Button primitive', () => {
+    setOnLine(true)
+    const reset = jest.fn()
+    const err = Object.assign(new Error('boom'), { name: 'TypeError' })
+    render(<GlobalError error={err} reset={reset} />)
+    const alert = screen.getByRole('alert')
+    const button = screen.getByRole('button', { name: /try again/i })
+
+    expect(alert).toHaveClass('bg-background', 'text-foreground')
+    expect(alert).not.toHaveAttribute('style')
+    expect(screen.getByRole('heading', { level: 1 })).not.toHaveAttribute('style')
+    expect(screen.getByText(/unexpected error occurred/i)).not.toHaveAttribute('style')
+    expect(button).toHaveAttribute('data-slot', 'button')
+    expect(button).not.toHaveAttribute('style')
+  })
+
   it('renders offline UI for ChunkLoadError even when navigator reports online', () => {
     setOnLine(true)
     const reset = jest.fn()

--- a/packages/create-app/template/src/app/global-error.tsx
+++ b/packages/create-app/template/src/app/global-error.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { Button } from '@open-mercato/ui/primitives/button'
 import { useEffect, useState } from 'react'
 import { reloadPage } from './global-error-reload'
 
@@ -53,6 +54,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
   }, [networkError])
 
   const showOfflineView = networkError || isOffline
+  // Next.js global-error renders outside normal app providers, so these are provider-independent fallback strings.
   const title = showOfflineView ? 'You appear to be offline' : 'Something went wrong'
   const description = showOfflineView
     ? 'Unable to connect. Please check your internet connection and try again. This page will reload automatically when your connection is restored.'
@@ -67,36 +69,20 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
   }
 
   return (
-    <html>
-      <body>
+    <html className="bg-background text-foreground">
+      <body className="bg-background text-foreground">
         <main
           role="alert"
           aria-live="assertive"
-          style={{
-            padding: '2rem',
-            fontFamily: 'system-ui, -apple-system, sans-serif',
-            maxWidth: '36rem',
-            margin: '4rem auto',
-          }}
+          className="flex min-h-screen items-start justify-center bg-background px-6 py-16 text-foreground"
         >
-          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{title}</h1>
-          <p style={{ marginBottom: '1.5rem', color: '#4b5563', lineHeight: 1.5 }}>{description}</p>
-          <button
-            type="button"
-            onClick={handleRetry}
-            style={{
-              padding: '0.5rem 1.25rem',
-              fontSize: '1rem',
-              fontWeight: 500,
-              background: '#111827',
-              color: '#ffffff',
-              border: 'none',
-              borderRadius: '0.375rem',
-              cursor: 'pointer',
-            }}
-          >
-            {buttonLabel}
-          </button>
+          <div className="w-full max-w-xl space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
+            <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+            <p className="text-sm leading-6 text-muted-foreground">{description}</p>
+            <Button type="button" onClick={handleRetry}>
+              {buttonLabel}
+            </Button>
+          </div>
         </main>
       </body>
     </html>


### PR DESCRIPTION
## Summary

Fix the global error fallback so it follows Open Mercato design-system rules in both the app shell and create-app template while preserving existing generic reset and offline reload behavior.

## Changes

- Replaced inline global-error layout, typography, color, and button styles with semantic DS token classes.
- Replaced the raw retry `<button>` with the shared `Button` primitive.
- Kept provider-independent fallback copy with a documented global-error boundary exception.
- Added mirrored regression tests for the app and create-app template copies.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- `yarn workspace @open-mercato/app test src/app/__tests__/global-error.test.tsx --runInBand` - pass
- Template global-error Jest test via temporary rootDir config - pass
- `yarn build:packages` - pass
- `yarn generate` - pass
- `yarn build:packages` - pass
- `yarn i18n:check-sync` - pass
- `yarn i18n:check-usage` - advisory failure on unrelated pre-existing missing keys
- `yarn lint` - blocked by known repo ESLint/tooling error: `scopeManager.addGlobals is not a function`
- `yarn typecheck` - pass
- `yarn test` - pass
- `yarn build:app` - pass

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). N/A - focused global error unit coverage is sufficient.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). N/A - minor bug fix.

### Design System Compliance

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) - use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) - use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop). N/A - not a list/data page.
- [x] Loading state handled for async pages. N/A - error boundary fallback.
- [x] `aria-label` on all icon-only buttons (`<IconButton>`). N/A - no icon-only buttons.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) - no custom replacements

## Linked issues

Fixes #3160
