### PR TITLE
refactor(licensing): normalize module/package license metadata to MIT (#3475)

### DIFF
--- a/packages/ai-assistant/package.json
+++ b/packages/ai-assistant/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/ai-assistant",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "engines": {
     "node": ">=22.0.0"

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/cache",
   "version": "0.6.5",
+  "license": "MIT",
   "description": "Multi-strategy cache service with tag-based invalidation support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/channel-gmail/package.json
+++ b/packages/channel-gmail/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/channel-gmail",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/channel-imap/package.json
+++ b/packages/channel-imap/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/channel-imap",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/checkout/package.json
+++ b/packages/checkout/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/checkout",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/checkout/src/modules/checkout/index.ts
+++ b/packages/checkout/src/modules/checkout/index.ts
@@ -7,7 +7,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Pay links, checkout templates, public payment pages, and checkout transaction tracking.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   ejectable: true,
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/cli",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/content",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/core",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/core/src/__tests__/license-metadata-consistency.test.ts
+++ b/packages/core/src/__tests__/license-metadata-consistency.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import fg from 'fast-glob'
+
+/**
+ * License-metadata consistency guard (#3475).
+ *
+ * Open Mercato is open-core: the root LICENSE is MIT and every workspace
+ * package ships under it, EXCEPT `@open-mercato/enterprise`, the single
+ * commercial package (its own LICENSE.md + restricted publishConfig). The
+ * `ModuleInfo.license` / `IntegrationDefinition.license` strings are
+ * descriptive metadata only and are NOT the OSS-vs-proprietary boundary — the
+ * PACKAGE is.
+ *
+ * Those metadata strings had drifted: ~28 OSS module/integration manifests
+ * hardcoded `license: 'Proprietary'` (copy-paste legacy) even though their
+ * packages are MIT, which misled adopters into thinking core needed a
+ * commercial license. This guard pins the corrected invariant so the drift
+ * cannot silently return on new modules:
+ *
+ *   1. No metadata file OUTSIDE packages/enterprise/ may declare
+ *      `license: 'Proprietary'`.
+ *   2. The known commercial enterprise modules MUST keep declaring it, so an
+ *      accidental flip to MIT in the commercial package also fails here.
+ */
+
+const repoRoot = join(__dirname, '..', '..', '..', '..')
+
+const metadataFiles = fg.sync(
+  ['packages/*/src/modules/**/index.ts', 'packages/*/src/modules/**/integration.ts'],
+  {
+    cwd: repoRoot,
+    absolute: true,
+    ignore: ['**/node_modules/**', '**/dist/**', '**/__tests__/**', '**/__mocks__/**'],
+  },
+)
+
+const licenseOf = (file: string): string | null => {
+  const match = readFileSync(file, 'utf8').match(/license:\s*'([^']+)'/)
+  return match ? match[1] : null
+}
+
+const isEnterprise = (file: string): boolean =>
+  relative(repoRoot, file).split(sep).join('/').startsWith('packages/enterprise/')
+
+describe('license metadata consistency (#3475)', () => {
+  it('discovers module/integration metadata files', () => {
+    expect(metadataFiles.length).toBeGreaterThan(0)
+  })
+
+  it('no OSS-package metadata declares a proprietary license', () => {
+    const offenders = metadataFiles
+      .filter((file) => !isEnterprise(file))
+      .filter((file) => licenseOf(file) === 'Proprietary')
+      .map((file) => relative(repoRoot, file).split(sep).join('/'))
+
+    expect(offenders).toEqual([])
+  })
+
+  it('keeps the commercial enterprise modules marked proprietary', () => {
+    const enterpriseCommercial = [
+      'packages/enterprise/src/modules/record_locks/index.ts',
+      'packages/enterprise/src/modules/system_status_overlays/index.ts',
+    ]
+    for (const rel of enterpriseCommercial) {
+      expect(licenseOf(join(repoRoot, rel))).toBe('Proprietary')
+    }
+  })
+})

--- a/packages/core/src/modules/api_keys/index.ts
+++ b/packages/core/src/modules/api_keys/index.ts
@@ -6,7 +6,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Manage access tokens for external API access.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   requires: ['auth'],
 }
 

--- a/packages/core/src/modules/attachments/index.ts
+++ b/packages/core/src/modules/attachments/index.ts
@@ -6,6 +6,6 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'File attachments and media management.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }
 

--- a/packages/core/src/modules/audit_logs/index.ts
+++ b/packages/core/src/modules/audit_logs/index.ts
@@ -6,7 +6,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Tracks user actions and data accesses with undo support scaffolding.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }
 
 export { features } from './acl'

--- a/packages/core/src/modules/auth/index.ts
+++ b/packages/core/src/modules/auth/index.ts
@@ -8,7 +8,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'User accounts, sessions, roles and password resets.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }
 
 // Re-export features from module root acl.ts so generator can pick them up regardless of consumer imports

--- a/packages/core/src/modules/business_rules/index.ts
+++ b/packages/core/src/modules/business_rules/index.ts
@@ -6,7 +6,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Business Rules Engine for defining, managing, and executing business logic and automation rules.',
   author: 'Patryk Lewczuk',
-  license: 'Proprietary',
+  license: 'MIT',
 }
 
 // Export rule engine types and functions for programmatic usage

--- a/packages/core/src/modules/catalog/index.ts
+++ b/packages/core/src/modules/catalog/index.ts
@@ -7,7 +7,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Configurable catalog for products, variants, and pricing used by the sales module.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   ejectable: true,
 }
 

--- a/packages/core/src/modules/configs/index.ts
+++ b/packages/core/src/modules/configs/index.ts
@@ -6,6 +6,6 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Shared configuration storage and helpers for module settings.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }
 

--- a/packages/core/src/modules/currencies/index.ts
+++ b/packages/core/src/modules/currencies/index.ts
@@ -8,6 +8,6 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Currencies and Exchange rate management',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   ejectable: true,
 }

--- a/packages/core/src/modules/customer_accounts/index.ts
+++ b/packages/core/src/modules/customer_accounts/index.ts
@@ -6,7 +6,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Customer-facing authentication with two-tier identity model and full RBAC.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   ejectable: true,
 }
 

--- a/packages/core/src/modules/customers/index.ts
+++ b/packages/core/src/modules/customers/index.ts
@@ -7,7 +7,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Core CRM capabilities for people, companies, deals, and activities.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   ejectable: true,
 }
 

--- a/packages/core/src/modules/dashboards/index.ts
+++ b/packages/core/src/modules/dashboards/index.ts
@@ -6,7 +6,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Configurable admin dashboard with module-provided widgets.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }
 
 export { features } from './acl'

--- a/packages/core/src/modules/dictionaries/index.ts
+++ b/packages/core/src/modules/dictionaries/index.ts
@@ -7,7 +7,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Organization-scoped dictionaries for reusable enumerations and appearance presets.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }
 
 export { features } from './acl'

--- a/packages/core/src/modules/directory/index.ts
+++ b/packages/core/src/modules/directory/index.ts
@@ -8,5 +8,5 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Multi-tenant directory with tenants and organizations.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }

--- a/packages/core/src/modules/entities/index.ts
+++ b/packages/core/src/modules/entities/index.ts
@@ -6,7 +6,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'User-defined entities, custom fields, and dynamic records storage.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   // Ensure query/index layer is present for hybrid querying of custom entities
   requires: ['query_index'],
 }

--- a/packages/core/src/modules/feature_toggles/index.ts
+++ b/packages/core/src/modules/feature_toggles/index.ts
@@ -7,7 +7,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Global feature flags with tenant-level overrides.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }
 
 export { features } from './acl'

--- a/packages/core/src/modules/notifications/index.ts
+++ b/packages/core/src/modules/notifications/index.ts
@@ -6,7 +6,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'In-app notifications with module-extensible types and actions.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }
 
 export { features } from './acl'

--- a/packages/core/src/modules/perspectives/index.ts
+++ b/packages/core/src/modules/perspectives/index.ts
@@ -6,7 +6,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Shared persistence for DataTable perspectives (columns, filters, saved views).',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   ejectable: true,
 }
 

--- a/packages/core/src/modules/planner/index.ts
+++ b/packages/core/src/modules/planner/index.ts
@@ -7,7 +7,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Availability schedules, rulesets, and shared planning rules.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   ejectable: true,
 }
 

--- a/packages/core/src/modules/progress/index.ts
+++ b/packages/core/src/modules/progress/index.ts
@@ -6,6 +6,6 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Generic server-side progress tracking for long-running operations',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   ejectable: true,
 }

--- a/packages/core/src/modules/query_index/index.ts
+++ b/packages/core/src/modules/query_index/index.ts
@@ -6,6 +6,6 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Hybrid query layer with full-text and vector search capabilities.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }
 

--- a/packages/core/src/modules/resources/index.ts
+++ b/packages/core/src/modules/resources/index.ts
@@ -7,7 +7,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Assets and resources with scheduling policies.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   requires: ['planner'],
   ejectable: true,
 }

--- a/packages/core/src/modules/sales/index.ts
+++ b/packages/core/src/modules/sales/index.ts
@@ -9,7 +9,7 @@ export const metadata: ModuleInfo = {
   description:
     'Quoting, ordering, fulfillment, and billing capabilities built on modular pricing and tax pipelines.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   requires: ['catalog', 'customers', 'dictionaries'],
   ejectable: true,
 }

--- a/packages/core/src/modules/staff/index.ts
+++ b/packages/core/src/modules/staff/index.ts
@@ -7,7 +7,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Teams, roles, and employee rosters.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   requires: ['planner', 'resources'],
   ejectable: true,
 }

--- a/packages/core/src/modules/translations/index.ts
+++ b/packages/core/src/modules/translations/index.ts
@@ -7,5 +7,5 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'System-wide entity translation storage and locale overlay for CRUD responses.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }

--- a/packages/create-app/agentic/shared/ai/skills/om-integration-builder/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-integration-builder/SKILL.md
@@ -238,7 +238,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: '<what this integration does>',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
   ejectable: true,
 }
 export { features } from './acl'

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/enterprise",
   "version": "0.6.5",
+  "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/events",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/gateway-stripe/package.json
+++ b/packages/gateway-stripe/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/gateway-stripe",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/onboarding",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/onboarding/src/modules/onboarding/index.ts
+++ b/packages/onboarding/src/modules/onboarding/index.ts
@@ -6,7 +6,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Self-service tenant and organization onboarding flow.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }
 
 export { features } from './acl'

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/queue",
   "version": "0.6.5",
+  "license": "MIT",
   "description": "Multi-strategy job queue with local and BullMQ support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/scheduler",
   "version": "0.6.5",
+  "license": "MIT",
   "description": "Database-managed scheduled jobs with admin UI",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/search",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/shared",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/storage-s3/package.json
+++ b/packages/storage-s3/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/storage-s3",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/sync-akeneo/package.json
+++ b/packages/sync-akeneo/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/sync-akeneo",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/ui",
   "version": "0.6.5",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-mercato/webhooks",
   "version": "0.6.5",
+  "license": "MIT",
   "description": "Webhooks module for Open Mercato — Standard Webhooks compliant outbound/inbound delivery",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/webhooks/src/modules/webhooks/index.ts
+++ b/packages/webhooks/src/modules/webhooks/index.ts
@@ -6,7 +6,7 @@ export const metadata: ModuleInfo = {
   version: '0.1.0',
   description: 'Standard Webhooks compliant outbound webhook delivery for platform events.',
   author: 'Open Mercato Team',
-  license: 'Proprietary',
+  license: 'MIT',
 }
 
 export { features } from './acl'

--- a/packages/webhooks/src/modules/webhooks/integration.ts
+++ b/packages/webhooks/src/modules/webhooks/integration.ts
@@ -15,7 +15,7 @@ export const integration: IntegrationDefinition = {
   version: '1.0.0',
   author: 'Open Mercato Team',
   company: 'Open Mercato',
-  license: 'Proprietary',
+  license: 'MIT',
   tags: ['webhooks', 'automation', 'events', 'standard-webhooks'],
   detailPage: {
     widgetSpotId: webhookCustomDetailWidgetSpotId,


### PR DESCRIPTION
Fixes #3475

## Problem
Open Mercato is open-core — the root `LICENSE` is MIT and every workspace package ships under it, except `@open-mercato/enterprise` (commercial, own `LICENSE.md` + restricted `publishConfig`). But the `license` strings in module/integration metadata had drifted: ~28 OSS manifests hardcoded `license: 'Proprietary'` as copy-paste legacy, even though their packages are MIT. A prospective adopter evaluating production use of the core hit exactly this contradiction (MIT root LICENSE vs. `Proprietary` core modules).

## Root Cause
`ModuleInfo.license` / `IntegrationDefinition.license` are free-form, optional descriptive strings (`packages/shared/src/modules/registry.ts`, `.../integrations/types.ts`) — not the OSS↔proprietary boundary (the **package** is). With no guard asserting their value, the `Proprietary` label propagated across core modules and was never reconciled with the actual MIT license. Separately, `@open-mercato/enterprise/package.json` had **no** `license` field despite `private: false`, so the commercial package was published to npm with no license marker (implicitly inheriting root MIT).

## What Changed
- **Flip `Proprietary → MIT` in 28 OSS metadata files**: 24 `core` modules (`api_keys, attachments, audit_logs, auth, business_rules, catalog, configs, currencies, customer_accounts, customers, dashboards, dictionaries, directory, entities, feature_toggles, notifications, perspectives, planner, progress, query_index, resources, sales, staff, translations`), `checkout`, `onboarding`, `webhooks` (module + integration). Also fixed the `om-integration-builder` scaffold example so new integrations no longer copy `Proprietary`.
- **Left the two commercial enterprise modules** (`record_locks`, `system_status_overlays`) as `Proprietary`.
- **Added an explicit `license` to every publishable `package.json`**: `"MIT"` on 19 OSS packages that were missing it; `"SEE LICENSE IN LICENSE.md"` on `@open-mercato/enterprise` (fixes the reverse leak — marks the commercial package correctly on npm).
- **Added a guard test** (`packages/core/src/__tests__/license-metadata-consistency.test.ts`): dynamically scans all module/integration metadata and fails if any non-enterprise file declares `Proprietary`, or if the enterprise commercial modules stop declaring it. This is the missing check that let the drift happen — it now protects future modules too.

## Tests
- New guard test: 3 cases, verified to **fail** when drift is reintroduced (temporarily flipped `customers` back to `Proprietary` → red, listing the offender) and **pass** after restore.
- `packages/onboarding/src/__tests__/metadata.test.ts` (existing, asserts a non-empty license string): still green with `'MIT'`.
- `yarn build:packages` (21/21), `yarn generate`, `yarn typecheck` on all packages with `.ts` edits (`core`, `checkout`, `onboarding`, `webhooks`) — all pass.
- No user-facing strings or locale files changed → i18n checks N/A.

## Backward Compatibility
- No contract surface changed. `ModuleInfo.license` / `IntegrationDefinition.license` remain optional `string` (classified STABLE in `BACKWARD_COMPATIBILITY.md`); only their **values** changed, which is not a contract change.
- The `@open-mercato/enterprise` `package.json` license change is a **correction that tightens** licensing (the package was always commercial per its `LICENSE.md`; the absent field was the bug), not a loosening.
- Adding `"license"` to OSS `package.json` files is additive metadata.

## Out of scope (deliberately)
- SPDX file headers (high churn, would re-drift without dedicated CI enforcement; `LICENSE` + `package.json` already close the legal gap).
- Public footers rendering "All rights reserved"; missing root `RELEASE_NOTES.md`.
