### PR TITLE
test(feature_toggles): fix broken override-list test (em.count not mocked) — unblocks develop CI

### DIFF
--- a/packages/core/src/modules/feature_toggles/api/__tests__/override-list-openapi-schema.test.ts
+++ b/packages/core/src/modules/feature_toggles/api/__tests__/override-list-openapi-schema.test.ts
@@ -46,10 +46,12 @@ describe('feature toggle override list OpenAPI schema', () => {
   beforeEach(() => {
     em = {
       find: jest.fn(),
+      count: jest.fn(),
     } as unknown as EntityManager
   })
 
   it('documents the live response shape for both override and inherited rows', async () => {
+    (em.count as jest.Mock).mockResolvedValueOnce(2);
     (em.find as jest.Mock).mockResolvedValueOnce([overriddenToggle, inheritedToggle]);
     (em.find as jest.Mock).mockResolvedValueOnce([override])
 


### PR DESCRIPTION
## Problem

The `test` CI job is **red on develop** (and therefore on every open PR that merges develop, e.g. #3490). The failure:

```
TypeError: em.count is not a function
  at getOverrides (src/modules/feature_toggles/lib/queries.ts:72:33)
  at override-list-openapi-schema.test.ts:56:38
```

`getOverrides` was changed in #3242 (`perf(feature_toggles): paginate override list in the database`) to call `em.count(FeatureToggle, filters)` for DB-side pagination, but `override-list-openapi-schema.test.ts` stubs the `EntityManager` with only `find`. The missing `count` mock crashes the test.

## Fix

Add a `count` mock to the stubbed `EntityManager` that resolves the total item count (2), so the test exercises the real pagination path. Test-only change.

## Verification

```
yarn workspace @open-mercato/core test override-list-openapi-schema
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```

## Why this is a separate PR

Found while running auto-review on #3490 (a dependency bump). The failing `test` job is **not** caused by that PR — it is a pre-existing develop breakage inherited via the merge. Fixing it at the source unblocks develop CI and every open PR at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)