### PR TITLE
fix(ci): stabilize ephemeral and standalone checks

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -329,6 +329,8 @@ jobs:
 
       - name: Build standalone app
         working-directory: /tmp/standalone-app
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
         run: yarn build
 
       - name: Start standalone app

--- a/packages/core/src/modules/staff/__integration__/TC-STAFF-020.spec.ts
+++ b/packages/core/src/modules/staff/__integration__/TC-STAFF-020.spec.ts
@@ -5,18 +5,20 @@ import { createTimeProjectFixture, assignEmployeeToProjectFixture, deleteStaffEn
 
 /**
  * TC-STAFF-020: My Timesheets Grid Loads
- * Verifies the monthly timesheet grid renders with project rows, day columns, and save button.
+ * Verifies the default weekly timesheet grid renders with project rows, day columns, and save button.
  * Self-contained: creates project + assigns employee in setup, cleans up in teardown.
  */
 test.describe('TC-STAFF-020: My Timesheets Grid Loads', () => {
-  test('should render the monthly timesheet grid with projects, day columns, and save button', async ({ page, request }) => {
+  test('should render the weekly timesheet grid with projects, day columns, and save button', async ({ page, request }) => {
     test.setTimeout(60_000)
 
     // Setup fixtures via API
+    const projectSuffix = Date.now()
+    const projectName = `QA Grid Project ${projectSuffix}`
     const adminToken = await getAuthToken(request, 'admin')
     const projectId = await createTimeProjectFixture(request, adminToken, {
-      name: `QA Grid Project ${Date.now()}`,
-      code: `QAG-${Date.now()}`,
+      name: projectName,
+      code: `QAG-${projectSuffix}`,
     })
 
     const employeeToken = await getAuthToken(request, 'employee')
@@ -26,22 +28,34 @@ test.describe('TC-STAFF-020: My Timesheets Grid Loads', () => {
     expect(employeeStaffMemberId.length > 0, 'Employee must have a staff member profile').toBeTruthy()
 
     await assignEmployeeToProjectFixture(request, adminToken, projectId, employeeStaffMemberId)
+    const showInGridRes = await apiRequest(request, 'PATCH', `/api/staff/timesheets/my-projects/${projectId}`, {
+      token: employeeToken,
+      data: { showInGrid: true },
+    })
+    expect(showInGridRes.ok(), `Failed to make project visible in grid: ${showInGridRes.status()}`).toBeTruthy()
 
     try {
       await login(page, 'employee')
       await page.goto('/backend/staff/timesheets')
 
       // Verify the grid table renders
-      await expect(page.getByRole('table')).toBeVisible({ timeout: 30_000 })
+      const table = page.getByRole('table')
+      await expect(table).toBeVisible({ timeout: 30_000 })
 
       // Verify project names appear as row headers
-      await expect(page.getByText('Project').first()).toBeVisible()
+      await expect(table.getByRole('columnheader', { name: /project/i })).toBeVisible()
+      await expect(table.getByText(projectName)).toBeVisible()
 
-      // Verify day columns exist (day numbers in the header)
-      await expect(page.getByText('1').first()).toBeVisible()
+      // Verify the current weekly view renders day columns. The old monthly
+      // assertion hard-coded day "1", which is not present in most weeks.
+      const monday = new Date()
+      const day = monday.getDay()
+      const diff = day === 0 ? -6 : 1 - day
+      monday.setDate(monday.getDate() + diff)
+      await expect(table.getByRole('columnheader', { name: new RegExp(`\\b${monday.getDate()}\\b`) })).toBeVisible()
 
       // Verify "Daily Total" footer row is present
-      await expect(page.getByText('Daily Total')).toBeVisible()
+      await expect(table.getByText('Daily Total')).toBeVisible()
 
       // Verify "Save Changes" button is present
       await expect(page.getByRole('button', { name: /save changes/i })).toBeVisible()

--- a/scripts/test-create-app-integration.ts
+++ b/scripts/test-create-app-integration.ts
@@ -17,6 +17,8 @@ const cyan = (value: string) => `\x1b[36m${value}\x1b[0m`
 const yellow = (value: string) => `\x1b[33m${value}\x1b[0m`
 const red = (value: string) => `\x1b[31m${value}\x1b[0m`
 
+const STANDALONE_BUILD_NODE_OPTIONS = '--max-old-space-size=8192'
+
 type EphemeralEnvState = {
   status?: string
   baseUrl?: string
@@ -47,6 +49,13 @@ function ensureEnterpriseDependency(appDir: string): void {
   dependencies['@open-mercato/enterprise'] = ROOT_VERSION
   packageJson.dependencies = dependencies
   writeJson(packageJsonPath, packageJson)
+}
+
+function withStandaloneBuildNodeOptions(value: string | undefined): string {
+  const normalized = value?.trim()
+  if (!normalized) return STANDALONE_BUILD_NODE_OPTIONS
+  if (/(?:^|\s)--max-old-space-size=\d+(?=\s|$)/.test(normalized)) return normalized
+  return `${normalized} ${STANDALONE_BUILD_NODE_OPTIONS}`
 }
 
 function writeStandaloneEnv(appDir: string): void {
@@ -196,6 +205,7 @@ async function main(): Promise<void> {
     CACHE_STRATEGY: 'memory',
     OM_INTEGRATION_APP_READY_TIMEOUT_SECONDS: '180',
     OM_TEST_APP_ROOT: appDir,
+    NODE_OPTIONS: withStandaloneBuildNodeOptions(process.env.NODE_OPTIONS),
     NODE_ENV: 'test',
   }
 


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Stabilizes the failing ephemeral and standalone CI checks.

The staff My Timesheets integration check now prepares the fixture project exactly as the UI expects and asserts the current weekly grid instead of hard-coding a monthly day column.

The standalone app snapshot job now builds generated apps with an explicit Node heap cap. The attached failure log shows `next build` completed compilation, then failed during Next's TypeScript phase with `Allocation failed - JavaScript heap out of memory`. The generated standalone app loads the full module surface plus enterprise modules, so the default Node heap is no longer enough on CI. This PR applies the same kind of build-time heap guard the monorepo app already uses.

## Changes

- Makes the fixture project visible in the employee's timesheet grid via the existing `my-projects` visibility endpoint.
- Updates TC-STAFF-020 wording and assertions to match the weekly default view.
- Scopes table assertions to the rendered table and the created fixture project.
- Sets `NODE_OPTIONS=--max-old-space-size=8192` for the snapshot workflow's standalone `yarn build` step.
- Propagates the same heap default through the local standalone integration runner, while preserving an existing `--max-old-space-size` value when one is already set.

## Why

- The staff integration failure was caused by stale test assumptions: the page default is weekly, and the fixture project must be opted into the employee's visible grid before the UI can render the expected row.
- The standalone failure was a CI resource issue, not an integration assertion failure. The Postgres messages in the log were service noise after the build failed; the actionable failure was the Node heap OOM during `next build`.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (CI/test-only fixes, no spec needed)

**Spec file path:**
N/A

## Testing

- `yarn turbo run typecheck --filter=@open-mercato/core`
- `npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/staff/__integration__/TC-STAFF-020.spec.ts --list`
- `yarn test:integration:ephemeral packages/core/src/modules/staff/__integration__/TC-STAFF-020.spec.ts --no-screenshots`
- `yarn workspace @open-mercato/core test src/modules/feature_toggles/api/__tests__/override-list-openapi-schema.test.ts`
- `yarn turbo run typecheck --filter=@open-mercato/core --filter=create-mercato-app`
- `yarn test:scripts`
- `ruby -e \"require 'yaml'; YAML.load_file('.github/workflows/snapshot.yml')\"`
- `git diff --check`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

N/A