### PR TITLE
fix(customers): wrap decision-makers tooltip in TooltipProvider (#3525)

### DIFF
--- a/packages/core/src/modules/customers/components/detail/DecisionMakersFooter.tsx
+++ b/packages/core/src/modules/customers/components/detail/DecisionMakersFooter.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { Lightbulb, Send } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@open-mercato/ui/primitives/tooltip'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@open-mercato/ui/primitives/tooltip'
 
 interface DecisionMakersFooterProps {
   names: string[]
@@ -39,17 +39,19 @@ export function DecisionMakersFooter({ names, suggestion, onSendInvitation }: De
         </div>
       </div>
       {onSendInvitation && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="w-full shrink-0 sm:w-auto">
-              <Button type="button" size="sm" disabled className="pointer-events-none w-full sm:w-auto">
-                <Send className="mr-1.5 size-3.5" />
-                {t('customers.people.decisionMakers.sendInvitation', 'Send invitation')}
-              </Button>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>{t('customers.ai.comingSoon', 'Coming soon')}</TooltipContent>
-        </Tooltip>
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="w-full shrink-0 sm:w-auto">
+                <Button type="button" size="sm" disabled className="pointer-events-none w-full sm:w-auto">
+                  <Send className="mr-1.5 size-3.5" />
+                  {t('customers.people.decisionMakers.sendInvitation', 'Send invitation')}
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{t('customers.ai.comingSoon', 'Coming soon')}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       )}
     </div>
   )

--- a/packages/core/src/modules/customers/components/detail/__tests__/DecisionMakersFooter.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/DecisionMakersFooter.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { DecisionMakersFooter } from '../DecisionMakersFooter'
+
+// Regression for issue #3525: starring a Person in the Company detail view mounts
+// DecisionMakersFooter, whose "Send invitation" tooltip previously rendered a raw
+// <Tooltip> with no <TooltipProvider> ancestor. The backend shell provides no global
+// TooltipProvider, so the favourite action crashed the page with
+// "`Tooltip` must be used within `TooltipProvider`". renderWithProviders deliberately
+// omits a TooltipProvider, mirroring the backend shell, so a regression would throw here.
+
+describe('DecisionMakersFooter — tooltip provider regression (#3525)', () => {
+  it('renders the send-invitation tooltip without a surrounding TooltipProvider', () => {
+    expect(() =>
+      renderWithProviders(
+        <DecisionMakersFooter names={['Jan Kowalski']} onSendInvitation={() => {}} />,
+      ),
+    ).not.toThrow()
+
+    expect(screen.getByText('Send invitation')).toBeInTheDocument()
+    expect(screen.getByText('Decision Makers')).toBeInTheDocument()
+  })
+
+  it('returns nothing when there are no decision makers', () => {
+    const { container } = renderWithProviders(
+      <DecisionMakersFooter names={[]} onSendInvitation={() => {}} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})


### PR DESCRIPTION
Fixes #3525

## Problem
Clicking the favourite/star button on a Person in **Customers → Companies → (company) → People** crashed the page with a runtime error: `` `Tooltip` must be used within `TooltipProvider` `` (thrown at the `BackendCatchAll` page renderer). The crash happened **on the star click**, not on page load.

## Root Cause
`CompanyPeopleSection` always renders `<DecisionMakersFooter names={decisionMakerNames} … />`, but `DecisionMakersFooter` returns `null` while `names` is empty. Starring a person makes `decisionMakerNames` non-empty, so the footer mounts for the first time — and its disabled "Send invitation" button renders a **raw `<Tooltip>` with no `<TooltipProvider>` ancestor**.

The backend shell has no global `TooltipProvider` (the `DataTable` provides one only for its own subtree), so the first time that tooltip mounts — i.e. right after the favourite action — Radix throws and unmounts the page. This is why the crash was triggered by the click rather than the initial render.

## What Changed
- `packages/core/src/modules/customers/components/detail/DecisionMakersFooter.tsx`: wrapped the "Send invitation" tooltip in a local `<TooltipProvider delayDuration={300}>` (consistent with the sibling `AiActionChips` component in the same folder) and imported `TooltipProvider`. Behaviour is otherwise unchanged.

## Tests
- Added `__tests__/DecisionMakersFooter.test.tsx`: renders `DecisionMakersFooter` with a starred name **without** an ambient `TooltipProvider` (mirroring the backend shell, via `renderWithProviders`) and asserts it does not throw and renders the trigger. Verified this test **fails before** the fix with the exact issue error (`` `Tooltip` must be used within `TooltipProvider` ``) and **passes after**. Also covers the empty-`names` no-render case.
- `yarn workspace @open-mercato/core test "components/detail"` → 53 suites / 187 tests pass.
- `tsc --noEmit` for `@open-mercato/core` → clean. `yarn generate` + `yarn build:packages` → clean. `yarn i18n:check-sync` → in sync (no new strings; reused existing keys).

## Notes
- `NextStepCard.tsx` has the same raw-`<Tooltip>`-without-provider pattern, but it has **zero usages** in the codebase (dead code), so it is not in any crash path and is intentionally left out of scope.

## Backward Compatibility
- No contract surface changes. `DecisionMakersFooter` props are unchanged; only an existing `TooltipProvider` export was added to the import and used as a local wrapper.

## Security impact
- None. Pure client-side rendering fix; no auth, data access, or tenant scoping touched.