### PR TITLE
fix(sales): surface server error reason when creating a return (#3527)

### DIFF
--- a/packages/core/src/modules/sales/components/documents/ReturnDialog.tsx
+++ b/packages/core/src/modules/sales/components/documents/ReturnDialog.tsx
@@ -11,6 +11,7 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { apiCallOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
+import { normalizeCrudServerError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { computeAvailableReturnQuantity } from '@open-mercato/core/modules/sales/lib/returnQuantity'
 import { handleSectionMutationError } from './optimisticLock'
@@ -136,7 +137,9 @@ export function ReturnDialog({ open, orderId, lines, documentUpdatedAt, onClose,
         onClose()
         return
       }
-      flash(t('sales.returns.errors.create', 'Failed to create return.'), 'error')
+      const normalized = normalizeCrudServerError(err)
+      const fallback = t('sales.returns.errors.create', 'Failed to create return.')
+      flash(normalized.message || fallback, 'error')
     } finally {
       setSaving(false)
     }

--- a/packages/core/src/modules/sales/components/documents/__tests__/ReturnDialog.test.tsx
+++ b/packages/core/src/modules/sales/components/documents/__tests__/ReturnDialog.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ReturnDialog } from '../ReturnDialog'
+
+const mockFlash = jest.fn()
+const mockApiCallOrThrow = jest.fn()
+const mockRunMutation = jest.fn()
+const mockHandleSectionMutationError = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: (...args: any[]) => mockFlash(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCallOrThrow: (...args: any[]) => mockApiCallOrThrow(...args),
+  withScopedApiRequestHeaders: (_headers: any, run: () => any) => run(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({ runMutation: (...args: any[]) => mockRunMutation(...args) }),
+}))
+
+jest.mock('../optimisticLock', () => ({
+  handleSectionMutationError: (...args: any[]) => mockHandleSectionMutationError(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/sales/lib/returnQuantity', () => ({
+  computeAvailableReturnQuantity: (line: any) => line.quantity - (line.returnedQuantity ?? 0),
+}))
+
+jest.mock('@open-mercato/ui/primitives/dialog', () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <h3>{children}</h3>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}))
+
+jest.mock('@open-mercato/ui/primitives/counter-input', () => ({
+  CounterInput: ({ id, value, onChange }: any) => (
+    <input
+      data-testid={id}
+      type="number"
+      value={value ?? ''}
+      onChange={(event) => {
+        const raw = event.target.value
+        onChange?.(raw === '' ? null : Number(raw))
+      }}
+    />
+  ),
+}))
+
+jest.mock('@open-mercato/ui/primitives/textarea', () => ({
+  Textarea: (props: any) => <textarea {...props} />,
+}))
+
+jest.mock('@open-mercato/ui/primitives/label', () => ({
+  Label: ({ children, ...props }: any) => <label {...props}>{children}</label>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, ...props }: any) => (
+    <button {...props} type={props.type || 'button'}>
+      {children}
+    </button>
+  ),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+}))
+
+const SERVER_MESSAGE =
+  'Cannot return more than the shipped quantity. Ship the items before recording a return.'
+const GENERIC_FALLBACK = 'Failed to create return.'
+
+const baseLines = [
+  { id: 'line-1', title: 'Widget', lineNumber: 1, quantity: 5, returnedQuantity: 0 },
+]
+
+function renderDialog() {
+  return render(
+    <ReturnDialog
+      open
+      orderId="order-1"
+      lines={baseLines}
+      documentUpdatedAt={null}
+      onClose={jest.fn()}
+      onSaved={jest.fn().mockResolvedValue(undefined)}
+    />,
+  )
+}
+
+function enterQuantityAndSubmit() {
+  fireEvent.change(screen.getByTestId('return-qty-line-1'), { target: { value: '3' } })
+  fireEvent.click(screen.getByRole('button', { name: /create return/i }))
+}
+
+describe('ReturnDialog error surfacing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockHandleSectionMutationError.mockReturnValue(false)
+    mockRunMutation.mockImplementation(async (config: any) => config.operation())
+  })
+
+  it('surfaces the server error reason instead of the generic fallback', async () => {
+    mockApiCallOrThrow.mockRejectedValue(
+      Object.assign(new Error(SERVER_MESSAGE), { error: SERVER_MESSAGE, status: 400 }),
+    )
+
+    renderDialog()
+    enterQuantityAndSubmit()
+
+    await waitFor(() => expect(mockFlash).toHaveBeenCalled())
+    expect(mockFlash).toHaveBeenCalledWith(SERVER_MESSAGE, 'error')
+    expect(mockFlash).not.toHaveBeenCalledWith(GENERIC_FALLBACK, 'error')
+  })
+
+  it('falls back to the generic message when the server provides no reason', async () => {
+    mockApiCallOrThrow.mockRejectedValue(new Error(''))
+
+    renderDialog()
+    enterQuantityAndSubmit()
+
+    await waitFor(() => expect(mockFlash).toHaveBeenCalled())
+    expect(mockFlash).toHaveBeenCalledWith(GENERIC_FALLBACK, 'error')
+  })
+
+  it('defers to the optimistic-lock handler without flashing a create error', async () => {
+    mockHandleSectionMutationError.mockReturnValue(true)
+    mockApiCallOrThrow.mockRejectedValue(
+      Object.assign(new Error('conflict'), { status: 409 }),
+    )
+
+    renderDialog()
+    enterQuantityAndSubmit()
+
+    await waitFor(() => expect(mockHandleSectionMutationError).toHaveBeenCalled())
+    expect(mockFlash).not.toHaveBeenCalledWith(SERVER_MESSAGE, 'error')
+    expect(mockFlash).not.toHaveBeenCalledWith(GENERIC_FALLBACK, 'error')
+  })
+})


### PR DESCRIPTION
Fixes #3527

## Problem
The **Create Return** dialog (`/backend/sales/orders/<order-id>` → Returns tab) always flashed the generic toast *"Failed to create return."* on an HTTP 400, hiding the server's actual reason (e.g. *"Cannot return more than the shipped quantity. Ship the items before recording a return."*). The real reason was only visible in DevTools → Network, leaving the user with no actionable feedback.

## Root Cause
`apiCallOrThrow` → `raiseCrudError` already parses the server body and puts the localized reason on the thrown error's `message`. But `ReturnDialog.tsx`'s `catch` block ignored the error entirely and unconditionally flashed the hardcoded `sales.returns.errors.create` fallback.

## What Changed
- `packages/core/src/modules/sales/components/documents/ReturnDialog.tsx`: in the `catch` block (after the optimistic-lock handler), extract the reason with `normalizeCrudServerError(err)` and flash `normalized.message || fallback`, so the server reason is shown and the generic message is used only when the server provides none.
- This mirrors the existing error-handling pattern in the sibling `ItemsSection.tsx` in the same folder. The optimistic-lock conflict path is unchanged.

## Tests
- New `ReturnDialog.test.tsx` (3 cases): surfaces the server reason instead of the fallback; falls back to the generic message when the server gives no reason; defers to the optimistic-lock handler without flashing a create error.
- Verified the regression test **fails** on the pre-fix code and **passes** after.
- `yarn jest src/modules/sales` — 329 passed; `optimistic-lock-ui-coverage` guard — passed; `@open-mercato/core` typecheck — passed.

## Backward Compatibility
No contract surface changes. Uses the already-exported `normalizeCrudServerError` helper; no API, type, event, route, or schema changes. No new user-facing strings (the existing `sales.returns.errors.create` key is retained as the fallback).