### PR TITLE
docs(upgrade-notes): document versioned browser-storage envelopes (v0.6.6) (#3499)

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -22,6 +22,35 @@ most of the patterns listed below in a user's codebase.
 
 ---
 
+## 0.6.5 → 0.6.6 (unreleased)
+
+### Versioned browser-storage envelopes for shared UI preference slots (#3457)
+
+Several shared UI surfaces that persist client state to `localStorage` — DataTable perspective snapshots, the AppShell sidebar collapsed-groups set, the AI model picker selection, and the AI chat sessions cache — now write through a shared **versioned-envelope** helper (`packages/shared/src/lib/browser/versionedPreference.ts`) instead of bare JSON. On disk each of these slots now carries a `{ v, data }` shape with an explicit version discriminator, rather than the raw value it stored before.
+
+**No manual action is required for end users.** The `localStorage` **keys are unchanged**, and `readVersionedPreference(...)` migrates a pre-envelope (legacy bare) value forward automatically on the next write when a `legacyIsValid` guard is supplied (as it is for every slot migrated in #3457). Stored data that is version-mismatched or malformed is safely discarded back to the documented fallback instead of crashing or silently corrupting UI state, so a downgrade/upgrade across this boundary simply re-derives defaults at worst.
+
+**Action for module authors who read/write these persisted slots directly.** If your module reads or writes one of these shared `localStorage` keys (or adds its own structured preference slot), go through the helper rather than `safeLocalStorage`/raw `localStorage`:
+
+```ts
+import {
+  readVersionedPreference,
+  writeVersionedPreference,
+  // readVersionedIdSet / writeVersionedIdSet for the common "set of ids" shape
+} from '@open-mercato/shared/lib/browser/versionedPreference'
+
+// read: validate the envelope, discard stale/mismatched data, migrate a legacy bare value forward
+const value = readVersionedPreference(key, version, isValid, fallback, { legacyIsValid })
+// write: wraps as { v: version, data: value }
+writeVersionedPreference(key, version, value)
+```
+
+Follow the **versioning threshold** documented in [`packages/shared/AGENTS.md`](packages/shared/AGENTS.md) when deciding whether a slot needs an envelope: trivial scalar flags (a single boolean/number/string with no schema to evolve, e.g. `om:sidebarCollapsed`) MAY stay raw via `safeLocalStorage`; **structured values** (objects, records, arrays of objects whose shape can change incompatibly) MUST use a versioned envelope so a future shape change can migrate or discard old data. A slot that already carries its own inline `{ v, ... }` discriminator is already migratable and MUST NOT be re-wrapped — re-wrapping changes the on-disk format and discards existing user data.
+
+This is a refactor with no API, event-ID, DI, or DB-schema contract change. Related: #3457 (this change), and the sibling persisted-storage audit tracked in #3174 / #3393.
+
+---
+
 ## 0.6.3 → 0.6.4 (2026-06-08)
 
 ### Tenant-ownership & per-module ACL authorization hardening (#2612)


### PR DESCRIPTION
Fixes #3499

## Problem
- #3457 standardized several shared UI `localStorage` slots (DataTable perspective snapshots, AppShell sidebar groups, AI model picker, AI chat sessions cache) behind a versioned `{ v, data }` envelope helper. The maintainer asked to document this in the Upgrade Notes for the upcoming **v0.6.6** release; no entry existed yet.

## Root Cause
- Docs gap: the on-disk persisted shapes changed (envelope discriminator added) but `UPGRADE_NOTES.md` had no `0.6.5 → 0.6.6` section describing the migration semantics for downstream module authors.

## What Changed
- Added a `0.6.5 → 0.6.6 (unreleased)` section to `UPGRADE_NOTES.md`, placed at the top of the version log in the existing format.
- Documents that storage **keys are unchanged** and legacy bare values **migrate forward automatically** via `readVersionedPreference`'s `legacyIsValid` path — **no manual action for end users**.
- Calls out the downstream-actionable guidance for module authors who read/write these slots: use `readVersionedPreference`/`writeVersionedPreference` and follow the **versioning threshold** from `packages/shared/AGENTS.md`.
- Cross-links #3457 and the sibling audit #3174 / #3393.

## Tests
- None — documentation-only change to `UPGRADE_NOTES.md`; there is no executable surface to cover, and no test/markdownlint validates this file. Consistent with how #3457's own UPGRADE_NOTES additions shipped.
- Verified referenced paths (`packages/shared/src/lib/browser/versionedPreference.ts`, `packages/shared/AGENTS.md`) exist on `develop`.

## Backward Compatibility
- No contract surface changes (docs only).