### PR TITLE
fix(catalog): associate compliance field errors with inputs for a11y (#3486)

### DIFF
--- a/packages/core/src/modules/catalog/components/products/ProductComplianceSection.tsx
+++ b/packages/core/src/modules/catalog/components/products/ProductComplianceSection.tsx
@@ -29,9 +29,26 @@ type ProductComplianceSectionProps = {
   embedded?: boolean;
 };
 
-function FieldError({ message }: { message?: string }) {
+function fieldErrorId(inputId: string) {
+  return `${inputId}-error`;
+}
+
+function describedByError(
+  inputId: string,
+  message?: string,
+): { "aria-invalid"?: true; "aria-describedby"?: string } {
+  return message
+    ? { "aria-invalid": true, "aria-describedby": fieldErrorId(inputId) }
+    : {};
+}
+
+function FieldError({ id, message }: { id: string; message?: string }) {
   if (!message) return null;
-  return <p className="text-xs text-destructive">{message}</p>;
+  return (
+    <p id={id} className="text-xs text-destructive">
+      {message}
+    </p>
+  );
 }
 
 export function ProductComplianceSection({
@@ -85,8 +102,12 @@ export function ProductComplianceSection({
               onChange={(event) =>
                 setValue("countryOfOriginCode", event.target.value.toUpperCase())
               }
+              {...describedByError("catalog-product-compliance-country", errors.countryOfOriginCode)}
             />
-            <FieldError message={errors.countryOfOriginCode} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-country")}
+              message={errors.countryOfOriginCode}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-tax-classification">
@@ -96,8 +117,12 @@ export function ProductComplianceSection({
               id="catalog-product-compliance-tax-classification"
               value={values.taxClassificationCode ?? ""}
               onChange={(event) => setValue("taxClassificationCode", event.target.value)}
+              {...describedByError("catalog-product-compliance-tax-classification", errors.taxClassificationCode)}
             />
-            <FieldError message={errors.taxClassificationCode} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-tax-classification")}
+              message={errors.taxClassificationCode}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-pkwiu">
@@ -107,8 +132,12 @@ export function ProductComplianceSection({
               id="catalog-product-compliance-pkwiu"
               value={values.pkwiuCode ?? ""}
               onChange={(event) => setValue("pkwiuCode", event.target.value)}
+              {...describedByError("catalog-product-compliance-pkwiu", errors.pkwiuCode)}
             />
-            <FieldError message={errors.pkwiuCode} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-pkwiu")}
+              message={errors.pkwiuCode}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-cn">
@@ -118,8 +147,12 @@ export function ProductComplianceSection({
               id="catalog-product-compliance-cn"
               value={values.cnCode ?? ""}
               onChange={(event) => setValue("cnCode", event.target.value)}
+              {...describedByError("catalog-product-compliance-cn", errors.cnCode)}
             />
-            <FieldError message={errors.cnCode} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-cn")}
+              message={errors.cnCode}
+            />
           </div>
           <div className="space-y-2 md:col-span-2">
             <Label htmlFor="catalog-product-compliance-hs">
@@ -129,13 +162,24 @@ export function ProductComplianceSection({
               id="catalog-product-compliance-hs"
               value={values.hsCode ?? ""}
               onChange={(event) => setValue("hsCode", event.target.value)}
+              {...describedByError("catalog-product-compliance-hs", errors.hsCode)}
             />
-            <FieldError message={errors.hsCode} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-hs")}
+              message={errors.hsCode}
+            />
           </div>
         </div>
         <div className="space-y-2">
-          <Label>{t("catalog.products.compliance.fields.gtuCodes", "GTU codes (JPK_V7)")}</Label>
-          <div className="grid gap-2 sm:grid-cols-3 md:grid-cols-4">
+          <Label id="catalog-product-compliance-gtu-label">
+            {t("catalog.products.compliance.fields.gtuCodes", "GTU codes (JPK_V7)")}
+          </Label>
+          <div
+            role="group"
+            aria-labelledby="catalog-product-compliance-gtu-label"
+            className="grid gap-2 sm:grid-cols-3 md:grid-cols-4"
+            {...describedByError("catalog-product-compliance-gtu", errors.gtuCodes)}
+          >
             {CATALOG_GTU_CODES.map((code) => (
               <label
                 key={code}
@@ -151,7 +195,10 @@ export function ProductComplianceSection({
               </label>
             ))}
           </div>
-          <FieldError message={errors.gtuCodes} />
+          <FieldError
+            id={fieldErrorId("catalog-product-compliance-gtu")}
+            message={errors.gtuCodes}
+          />
         </div>
       </div>
 
@@ -179,8 +226,12 @@ export function ProductComplianceSection({
               max={120}
               value={values.ageMin ?? ""}
               onChange={(event) => setValue("ageMin", event.target.value)}
+              {...describedByError("catalog-product-compliance-age-min", errors.ageMin)}
             />
-            <FieldError message={errors.ageMin} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-age-min")}
+              message={errors.ageMin}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-excise-category">
@@ -192,7 +243,10 @@ export function ProductComplianceSection({
                 setValue("exciseCategory", value === NONE_OPTION ? null : value)
               }
             >
-              <SelectTrigger id="catalog-product-compliance-excise-category">
+              <SelectTrigger
+                id="catalog-product-compliance-excise-category"
+                {...describedByError("catalog-product-compliance-excise-category", errors.exciseCategory)}
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -206,7 +260,10 @@ export function ProductComplianceSection({
                 ))}
               </SelectContent>
             </Select>
-            <FieldError message={errors.exciseCategory} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-excise-category")}
+              message={errors.exciseCategory}
+            />
           </div>
         </div>
         <div className="grid gap-2 sm:grid-cols-2">
@@ -253,8 +310,12 @@ export function ProductComplianceSection({
               id="catalog-product-compliance-hazmat-class"
               value={values.hazmatClass ?? ""}
               onChange={(event) => setValue("hazmatClass", event.target.value)}
+              {...describedByError("catalog-product-compliance-hazmat-class", errors.hazmatClass)}
             />
-            <FieldError message={errors.hazmatClass} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-hazmat-class")}
+              message={errors.hazmatClass}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-un-number">
@@ -265,8 +326,12 @@ export function ProductComplianceSection({
               placeholder={t("catalog.products.compliance.placeholders.unNumber", "UN1234")}
               value={values.unNumber ?? ""}
               onChange={(event) => setValue("unNumber", event.target.value)}
+              {...describedByError("catalog-product-compliance-un-number", errors.unNumber)}
             />
-            <FieldError message={errors.unNumber} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-un-number")}
+              message={errors.unNumber}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-packing-group">
@@ -278,7 +343,10 @@ export function ProductComplianceSection({
                 setValue("hazmatPackingGroup", value === NONE_OPTION ? null : value)
               }
             >
-              <SelectTrigger id="catalog-product-compliance-packing-group">
+              <SelectTrigger
+                id="catalog-product-compliance-packing-group"
+                {...describedByError("catalog-product-compliance-packing-group", errors.hazmatPackingGroup)}
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -292,7 +360,10 @@ export function ProductComplianceSection({
                 ))}
               </SelectContent>
             </Select>
-            <FieldError message={errors.hazmatPackingGroup} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-packing-group")}
+              message={errors.hazmatPackingGroup}
+            />
           </div>
         </div>
       </div>
@@ -319,8 +390,12 @@ export function ProductComplianceSection({
               type="date"
               value={values.launchAt ?? ""}
               onChange={(event) => setValue("launchAt", event.target.value)}
+              {...describedByError("catalog-product-compliance-launch-at", errors.launchAt)}
             />
-            <FieldError message={errors.launchAt} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-launch-at")}
+              message={errors.launchAt}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-eol-at">
@@ -331,8 +406,12 @@ export function ProductComplianceSection({
               type="date"
               value={values.endOfLifeAt ?? ""}
               onChange={(event) => setValue("endOfLifeAt", event.target.value)}
+              {...describedByError("catalog-product-compliance-eol-at", errors.endOfLifeAt)}
             />
-            <FieldError message={errors.endOfLifeAt} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-eol-at")}
+              message={errors.endOfLifeAt}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-available-from">
@@ -343,8 +422,12 @@ export function ProductComplianceSection({
               type="date"
               value={values.availableFrom ?? ""}
               onChange={(event) => setValue("availableFrom", event.target.value)}
+              {...describedByError("catalog-product-compliance-available-from", errors.availableFrom)}
             />
-            <FieldError message={errors.availableFrom} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-available-from")}
+              message={errors.availableFrom}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-available-until">
@@ -355,8 +438,12 @@ export function ProductComplianceSection({
               type="date"
               value={values.availableUntil ?? ""}
               onChange={(event) => setValue("availableUntil", event.target.value)}
+              {...describedByError("catalog-product-compliance-available-until", errors.availableUntil)}
             />
-            <FieldError message={errors.availableUntil} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-available-until")}
+              message={errors.availableUntil}
+            />
           </div>
         </div>
         <label
@@ -395,8 +482,12 @@ export function ProductComplianceSection({
               min={1}
               value={values.minOrderQty ?? ""}
               onChange={(event) => setValue("minOrderQty", event.target.value)}
+              {...describedByError("catalog-product-compliance-min-qty", errors.minOrderQty)}
             />
-            <FieldError message={errors.minOrderQty} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-min-qty")}
+              message={errors.minOrderQty}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-max-qty">
@@ -408,8 +499,12 @@ export function ProductComplianceSection({
               min={1}
               value={values.maxOrderQty ?? ""}
               onChange={(event) => setValue("maxOrderQty", event.target.value)}
+              {...describedByError("catalog-product-compliance-max-qty", errors.maxOrderQty)}
             />
-            <FieldError message={errors.maxOrderQty} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-max-qty")}
+              message={errors.maxOrderQty}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-qty-increment">
@@ -421,8 +516,12 @@ export function ProductComplianceSection({
               min={1}
               value={values.orderQtyIncrement ?? ""}
               onChange={(event) => setValue("orderQtyIncrement", event.target.value)}
+              {...describedByError("catalog-product-compliance-qty-increment", errors.orderQtyIncrement)}
             />
-            <FieldError message={errors.orderQtyIncrement} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-qty-increment")}
+              message={errors.orderQtyIncrement}
+            />
           </div>
         </div>
         <label
@@ -460,8 +559,12 @@ export function ProductComplianceSection({
               maxLength={255}
               value={values.seoTitle ?? ""}
               onChange={(event) => setValue("seoTitle", event.target.value)}
+              {...describedByError("catalog-product-compliance-seo-title", errors.seoTitle)}
             />
-            <FieldError message={errors.seoTitle} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-seo-title")}
+              message={errors.seoTitle}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-seo-description">
@@ -473,8 +576,12 @@ export function ProductComplianceSection({
               maxLength={1000}
               value={values.seoDescription ?? ""}
               onChange={(event) => setValue("seoDescription", event.target.value)}
+              {...describedByError("catalog-product-compliance-seo-description", errors.seoDescription)}
             />
-            <FieldError message={errors.seoDescription} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-seo-description")}
+              message={errors.seoDescription}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="catalog-product-compliance-canonical-url">
@@ -487,8 +594,12 @@ export function ProductComplianceSection({
               placeholder="https://"
               value={values.canonicalUrl ?? ""}
               onChange={(event) => setValue("canonicalUrl", event.target.value)}
+              {...describedByError("catalog-product-compliance-canonical-url", errors.canonicalUrl)}
             />
-            <FieldError message={errors.canonicalUrl} />
+            <FieldError
+              id={fieldErrorId("catalog-product-compliance-canonical-url")}
+              message={errors.canonicalUrl}
+            />
           </div>
         </div>
       </div>

--- a/packages/core/src/modules/catalog/components/products/__tests__/ProductComplianceSection.test.tsx
+++ b/packages/core/src/modules/catalog/components/products/__tests__/ProductComplianceSection.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import { ProductComplianceSection } from '../ProductComplianceSection'
+import type { ProductFormValues } from '../productForm'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => {
+  const translate = (key: string, fallback?: string) => (fallback ?? key) as string
+  return { useT: () => translate }
+})
+
+jest.mock('@open-mercato/ui/primitives/label', () => ({
+  Label: ({ children, ...props }: any) => <label {...props}>{children}</label>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/checkbox', () => ({
+  Checkbox: ({ checked, onCheckedChange, ...props }: any) => (
+    <input
+      type="checkbox"
+      checked={Boolean(checked)}
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+      {...props}
+    />
+  ),
+}))
+
+jest.mock('@open-mercato/ui/primitives/input', () => ({
+  Input: ({ ...props }: any) => <input {...props} />,
+}))
+
+jest.mock('@open-mercato/ui/primitives/textarea', () => ({
+  Textarea: ({ showCount, wrapperClassName, ...props }: any) => <textarea {...props} />,
+}))
+
+jest.mock('@open-mercato/ui/primitives/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectTrigger: ({ children, ...props }: any) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectValue: () => <span />,
+}))
+
+function createDefaultValues(overrides?: Partial<ProductFormValues>): ProductFormValues {
+  return {
+    title: '',
+    subtitle: '',
+    handle: '',
+    sku: '',
+    productType: 'simple',
+    description: '',
+    useMarkdown: false,
+    taxRateId: null,
+    mediaDraftId: 'draft',
+    mediaItems: [],
+    defaultMediaId: null,
+    defaultMediaUrl: '',
+    hasVariants: false,
+    options: [],
+    variants: [],
+    metadata: {},
+    dimensions: null,
+    weight: null,
+    defaultUnit: null,
+    defaultSalesUnit: null,
+    defaultSalesUnitQuantity: '1',
+    uomRoundingScale: '4',
+    uomRoundingMode: 'half_up',
+    unitPriceEnabled: false,
+    unitPriceReferenceUnit: null,
+    unitPriceBaseQuantity: '',
+    unitConversions: [],
+    customFieldsetCode: null,
+    categoryIds: [],
+    channelIds: [],
+    tags: [],
+    optionSchemaId: null,
+    countryOfOriginCode: '',
+    pkwiuCode: '',
+    cnCode: '',
+    hsCode: '',
+    taxClassificationCode: '',
+    gtuCodes: [],
+    ageMin: '',
+    isExciseGood: false,
+    exciseCategory: null,
+    requiresPrescription: false,
+    hazmatClass: '',
+    unNumber: '',
+    hazmatPackingGroup: null,
+    containsLithiumBattery: false,
+    launchAt: '',
+    endOfLifeAt: '',
+    availableFrom: '',
+    availableUntil: '',
+    minOrderQty: '',
+    maxOrderQty: '',
+    orderQtyIncrement: '',
+    requiresShipping: true,
+    isQuoteOnly: false,
+    seoTitle: '',
+    seoDescription: '',
+    canonicalUrl: '',
+    ...overrides,
+  }
+}
+
+describe('ProductComplianceSection a11y error wiring', () => {
+  it('marks a text input invalid and links it to the error message when an error is present', () => {
+    const { container } = render(
+      <ProductComplianceSection
+        values={createDefaultValues()}
+        setValue={jest.fn()}
+        errors={{ unNumber: 'Invalid UN number' }}
+      />,
+    )
+
+    const input = container.querySelector('#catalog-product-compliance-un-number')
+    const error = container.querySelector('#catalog-product-compliance-un-number-error')
+
+    expect(input).not.toBeNull()
+    expect(error).not.toBeNull()
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+    expect(input).toHaveAttribute('aria-describedby', 'catalog-product-compliance-un-number-error')
+    expect(error).toHaveTextContent('Invalid UN number')
+  })
+
+  it('does not set aria-invalid or aria-describedby when a field has no error', () => {
+    const { container } = render(
+      <ProductComplianceSection
+        values={createDefaultValues()}
+        setValue={jest.fn()}
+        errors={{}}
+      />,
+    )
+
+    const input = container.querySelector('#catalog-product-compliance-un-number')
+
+    expect(input).not.toBeNull()
+    expect(input).not.toHaveAttribute('aria-invalid')
+    expect(input).not.toHaveAttribute('aria-describedby')
+    expect(container.querySelector('#catalog-product-compliance-un-number-error')).toBeNull()
+  })
+
+  it('wires the select trigger error state', () => {
+    const { container } = render(
+      <ProductComplianceSection
+        values={createDefaultValues()}
+        setValue={jest.fn()}
+        errors={{ hazmatPackingGroup: 'Required' }}
+      />,
+    )
+
+    const trigger = container.querySelector('#catalog-product-compliance-packing-group')
+    const error = container.querySelector('#catalog-product-compliance-packing-group-error')
+
+    expect(trigger).toHaveAttribute('aria-invalid', 'true')
+    expect(trigger).toHaveAttribute('aria-describedby', 'catalog-product-compliance-packing-group-error')
+    expect(error).toHaveTextContent('Required')
+  })
+
+  it('wires the textarea error state', () => {
+    const { container } = render(
+      <ProductComplianceSection
+        values={createDefaultValues()}
+        setValue={jest.fn()}
+        errors={{ seoDescription: 'Too long' }}
+      />,
+    )
+
+    const textarea = container.querySelector('#catalog-product-compliance-seo-description')
+    const error = container.querySelector('#catalog-product-compliance-seo-description-error')
+
+    expect(textarea).toHaveAttribute('aria-invalid', 'true')
+    expect(textarea).toHaveAttribute('aria-describedby', 'catalog-product-compliance-seo-description-error')
+    expect(error).toHaveTextContent('Too long')
+  })
+
+  it('exposes the GTU checkbox group as a labelled group and wires its error', () => {
+    const { container } = render(
+      <ProductComplianceSection
+        values={createDefaultValues()}
+        setValue={jest.fn()}
+        errors={{ gtuCodes: 'Pick at least one' }}
+      />,
+    )
+
+    const group = container.querySelector('[role="group"]')
+    const error = container.querySelector('#catalog-product-compliance-gtu-error')
+
+    expect(group).not.toBeNull()
+    expect(group).toHaveAttribute('aria-labelledby', 'catalog-product-compliance-gtu-label')
+    expect(group).toHaveAttribute('aria-invalid', 'true')
+    expect(group).toHaveAttribute('aria-describedby', 'catalog-product-compliance-gtu-error')
+    expect(error).toHaveTextContent('Pick at least one')
+  })
+})


### PR DESCRIPTION
Fixes #3486

## Problem
Inline validation errors in the catalog **product compliance** section rendered as a plain `<p class="text-xs text-destructive">` (the local `FieldError` helper) that was not linked to its input. The inputs never received `aria-invalid="true"` in the error state, and there was no `aria-describedby` pointing at the error text, so screen-reader users got the visual error but it was not announced in the field's context.

## Root Cause
`packages/core/src/modules/catalog/components/products/ProductComplianceSection.tsx` — `FieldError` rendered the message without an `id`, and the `Input`/`Textarea`/`SelectTrigger` controls never toggled `aria-invalid` / `aria-describedby`. The underlying DS primitives already support `aria-invalid` styling and forward these props; only the wiring in this section was missing.

## What Changed
- Added two small local helpers: `fieldErrorId(inputId)` (derives a stable `<input-id>-error` id) and `describedByError(inputId, message)` (returns `aria-invalid: true` + `aria-describedby` only when a message is present).
- `FieldError` now takes an `id` and renders it on the error `<p>`.
- Every compliance control (text `Input`s, number inputs, date inputs, the SEO `Textarea`, and both `SelectTrigger`s) now spreads `describedByError(...)` so it exposes `aria-invalid`/`aria-describedby` in the error state, paired with a `FieldError` carrying the matching id.
- The GTU checkbox group is now a labelled `role="group"` (`aria-labelledby` → the group label) that exposes `aria-invalid`/`aria-describedby` referencing its error message.

No behavior changes when there is no error: `aria-invalid`/`aria-describedby` stay absent, matching the previous DOM.

## Tests
- New jsdom unit test `ProductComplianceSection.test.tsx` asserting the aria wiring for a text input, the select trigger, the textarea, and the GTU group, plus the no-error case. Verified the 4 wiring assertions fail against the pre-fix component and pass after the fix.
- `yarn workspace @open-mercato/core test components/products` → 10 suites / 229 tests pass (incl. the new suite).
- Core `tsc --noEmit` clean (after `build:packages` → `generate` → `build:packages`).
- ESLint clean on the changed files.

## Backward Compatibility
No contract-surface changes. `FieldError` is a module-local helper (not exported); `ProductComplianceSection`'s exported props are unchanged. Purely additive a11y attributes on presentational markup.