### PR TITLE
fix(repo): enforce LF via .gitattributes to stop CRLF NODE_ENV corruption (#3470)

### DIFF
--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -360,6 +360,7 @@ function buildRegistryConfig(registryUrl: string): string {
 
 const FILE_RENAMES: Record<string, string> = {
   gitignore: '.gitignore',
+  gitattributes: '.gitattributes',
 }
 
 const SKIP_DIRS = new Set(['__tests__', '__integration__'])

--- a/packages/create-app/src/lib/template-gitattributes.test.ts
+++ b/packages/create-app/src/lib/template-gitattributes.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+
+const TEMPLATE_GITATTRIBUTES = new URL('../../template/gitattributes', import.meta.url)
+const CREATE_APP_INDEX = new URL('../index.ts', import.meta.url)
+const TEMPLATE_COMPOSE_FILES = [
+  new URL('../../template/docker-compose.fullapp.yml', import.meta.url),
+  new URL('../../template/docker-compose.fullapp.dev.yml', import.meta.url),
+]
+
+function hasGlobalLfRule(content: string): boolean {
+  return content
+    .split('\n')
+    .map((line) => line.trim())
+    .some((line) => /^\*\s+/.test(line) && /\btext=auto\b/.test(line) && /\beol=lf\b/.test(line))
+}
+
+test('standalone template ships a gitattributes that enforces LF globally', () => {
+  const content = fs.readFileSync(TEMPLATE_GITATTRIBUTES, 'utf8')
+  assert.ok(
+    hasGlobalLfRule(content),
+    'template/gitattributes must contain a global "* text=auto eol=lf" rule so scaffolded apps inherit the LF policy'
+  )
+})
+
+test('scaffolder renames template gitattributes to .gitattributes', () => {
+  const source = fs.readFileSync(CREATE_APP_INDEX, 'utf8')
+  assert.match(
+    source,
+    /gitattributes:\s*['"]\.gitattributes['"]/,
+    'FILE_RENAMES must map gitattributes -> .gitattributes so generated apps receive the LF policy'
+  )
+})
+
+test('template docker-compose files are stored with LF (no CR bytes)', () => {
+  for (const fileUrl of TEMPLATE_COMPOSE_FILES) {
+    const buffer = fs.readFileSync(fileUrl)
+    assert.ok(
+      !buffer.includes(0x0d),
+      `${fileUrl.pathname} contains a CR byte; it must be stored with LF endings`
+    )
+  }
+})

--- a/packages/create-app/template/gitattributes
+++ b/packages/create-app/template/gitattributes
@@ -1,7 +1,7 @@
 # Normalize all text files to LF on checkout for every platform so Windows
 # (CRLF) clones cannot corrupt files consumed by Docker, shell, and Next.js.
-# A CRLF in docker-compose turned NODE_ENV into "development\r", which disabled
-# Next.js dev optimizations and triggered an OOM compilation loop (see #3470).
+# A CRLF in docker-compose turns NODE_ENV into "development\r", which disables
+# Next.js dev optimizations and can trigger an OOM compilation loop.
 # text=auto leaves detected binary files (images, fonts, archives) untouched.
 * text=auto eol=lf
 

--- a/scripts/__tests__/gitattributes-lf-enforcement.test.mjs
+++ b/scripts/__tests__/gitattributes-lf-enforcement.test.mjs
@@ -1,0 +1,74 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+const COMPOSE_FILES = ['docker-compose.fullapp.dev.yml', 'docker-compose.fullapp.yml']
+
+const REPRESENTATIVE_TEXT_FILES = [
+  'docker-compose.fullapp.dev.yml',
+  'docker-compose.fullapp.yml',
+  'package.json',
+  '.gitattributes',
+]
+
+function git(args) {
+  return execFileSync('git', args, { cwd: ROOT, encoding: 'utf8' })
+}
+
+function resolveEol(relPath) {
+  const output = git(['check-attr', 'eol', '--', relPath]).trim()
+  const match = output.match(/eol:\s*(\S+)\s*$/)
+  return match ? match[1] : null
+}
+
+function hasGlobalLfRule(content) {
+  return content
+    .split('\n')
+    .map((line) => line.trim())
+    .some((line) => /^\*\s+/.test(line) && /\btext=auto\b/.test(line) && /\beol=lf\b/.test(line))
+}
+
+test('root .gitattributes enforces LF globally via "* text=auto eol=lf"', () => {
+  const content = fs.readFileSync(path.join(ROOT, '.gitattributes'), 'utf8')
+  assert.ok(
+    hasGlobalLfRule(content),
+    'Root .gitattributes must contain a global "* text=auto eol=lf" rule so Windows clones cannot inject CRLF'
+  )
+})
+
+test('git resolves eol=lf for docker-compose and representative text files', () => {
+  for (const file of REPRESENTATIVE_TEXT_FILES) {
+    assert.equal(
+      resolveEol(file),
+      'lf',
+      `Expected git to check out ${file} with LF endings — a CRLF here corrupts NODE_ENV and breaks Next.js`
+    )
+  }
+})
+
+test('docker-compose files are checked in with LF (no CR bytes)', () => {
+  for (const file of COMPOSE_FILES) {
+    const buffer = fs.readFileSync(path.join(ROOT, file))
+    assert.ok(!buffer.includes(0x0d), `${file} contains a CR byte; it must be committed with LF endings`)
+  }
+})
+
+test('text=auto leaves binary assets untouched (git detects them as -text)', () => {
+  const binaries = git(['ls-files', '*.png', '*.jpg', '*.ico', '*.woff2'])
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+  assert.ok(binaries.length > 0, 'expected at least one tracked binary asset to validate against the global LF rule')
+  const sample = binaries[0]
+  const output = git(['ls-files', '--eol', '--', sample]).trim()
+  assert.match(
+    output,
+    /[iw]\/-text/,
+    `Expected git to detect ${sample} as binary (-text) so the global "eol=lf" rule cannot corrupt it`
+  )
+})


### PR DESCRIPTION
Fixes #3470

## Problem
On Windows hosts (WSL/Docker) Git checks out the repo with `CRLF` by default. When `docker-compose.fullapp.dev.yml` injects `NODE_ENV: development`, the trailing carriage return makes the value `"development\r"` inside the container. Next.js rejects the non-standard `NODE_ENV`, disables dev cache / Turbopack optimizations, falls back to an unoptimized Webpack barrel compile, and spirals into an endless compilation loop with an OOM memory leak (>18GB RSS).

## Root Cause
The repository had no global line-ending policy in `.gitattributes` (only `*.sh text eol=lf`). `git check-attr eol` resolved to `unspecified` for `docker-compose.fullapp.dev.yml` and every other text file, so Windows clones were free to inject `CRLF` into files that are consumed verbatim by Docker, the shell, and Next.js.

## What Changed
- **`.gitattributes`**: added a global `* text=auto eol=lf` rule so every platform checks out text files with LF. `text=auto` leaves detected binary files (images, fonts, archives) untouched — verified that tracked binaries resolve to `-text` and `git add --renormalize` does not rewrite them.
- **`packages/create-app`**: shipped the same `gitattributes` rule in the standalone template and wired `gitattributes → .gitattributes` into `FILE_RENAMES` (same mechanism already used for `.gitignore`), so apps scaffolded with `create-mercato-app` on Windows are protected from the identical bug. `npm pack --dry-run` confirms the template file is published.

## Tests
- `scripts/__tests__/gitattributes-lf-enforcement.test.mjs` (runs in CI via `yarn test:scripts`): asserts the global LF rule exists, that `git check-attr eol` resolves to `lf` for the compose files + representative text files (this was `unspecified` before the fix), that the compose files carry no CR bytes, and that `text=auto` detects binaries as `-text` so the rule can't corrupt them.
- `packages/create-app/src/lib/template-gitattributes.test.ts` (runs in CI via the create-app `test` task): asserts the template ships the LF rule, that the scaffolder renames it to `.gitattributes`, and that the template compose files carry no CR bytes.
- Ran: root guard test (4/4 pass), create-app guard test (3/3 pass), `create-mercato-app` `typecheck` and `build` (both clean). The only pre-existing failures in `yarn test:scripts` are the unrelated `watch-packages` fs.watch-timing tests, which reproduce with this change stashed.

## Backward Compatibility
No contract surface changes. `.gitattributes` and the internal `FILE_RENAMES` map are not part of the 13 contract-surface categories; all changes are additive. Existing checkouts on this platform are already LF, so no files are rewritten by this PR.
