### PR TITLE
fix(customers): regression-cover merged activities pagination order (P2 of #3386)

### DIFF
--- a/packages/core/src/modules/customers/api/activities/__tests__/merged-pagination.test.ts
+++ b/packages/core/src/modules/customers/api/activities/__tests__/merged-pagination.test.ts
@@ -83,6 +83,13 @@ describe('activities merged GET pagination', () => {
     mockEm.findAndCount.mockImplementation(async () => [[], 0])
     mockEm.find.mockImplementation(async () => [])
     mockEm.count.mockImplementation(async () => 0)
+
+    // clearAllMocks() resets call history but not implementations, so restore the
+    // jest.mock factory defaults here to keep tests isolated from each other.
+    jest.requireMock('../../../lib/interactionReadModel').hydrateCanonicalInteractions
+      .mockImplementation(async () => [])
+    jest.requireMock('../../../lib/interactionCompatibility').mapInteractionRecordToActivitySummary
+      .mockReset()
   })
 
   it('uses bounded DB-side paginated fetches for both sources in non-unified mode', async () => {
@@ -120,5 +127,138 @@ describe('activities merged GET pagination', () => {
       expect(entity).not.toBe(CustomerActivity)
       expect(entity).not.toBe(CustomerInteraction)
     }
+  })
+
+  // Merge-order regression coverage (P2 of #3386). The merged path sorts only on
+  // non-encrypted system timestamps, so the #3278 two-phase encrypted-sort does not
+  // apply; what matters here is that interleaving two DB-paginated sources stays
+  // globally ordered across the page boundary with no duplicate/dropped ids.
+  function legacyActivity(id: string, createdAtIso: string) {
+    const at = new Date(createdAtIso)
+    return {
+      id,
+      activityType: 'note',
+      subject: null,
+      body: null,
+      occurredAt: at,
+      createdAt: at,
+      appearanceIcon: null,
+      appearanceColor: null,
+      entity: 'entity-1',
+      authorUserId: null,
+      deal: null,
+    }
+  }
+
+  function canonicalInteraction(id: string, createdAtIso: string) {
+    return {
+      id,
+      interactionType: 'note',
+      deletedAt: null,
+      occurredAt: createdAtIso,
+      createdAt: createdAtIso,
+      customValues: null,
+    }
+  }
+
+  function wireMergedRows(
+    legacyRows: ReturnType<typeof legacyActivity>[],
+    canonicalRows: ReturnType<typeof canonicalInteraction>[],
+  ) {
+    mockEm.findAndCount.mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerActivity) return [legacyRows, legacyRows.length]
+      if (entity === CustomerInteraction) return [canonicalRows, canonicalRows.length]
+      return [[], 0]
+    })
+    mockEm.count.mockImplementation(async () => 0)
+
+    const { hydrateCanonicalInteractions } = jest.requireMock('../../../lib/interactionReadModel')
+    hydrateCanonicalInteractions.mockImplementation(
+      async ({ interactions }: { interactions: ReturnType<typeof canonicalInteraction>[] }) =>
+        interactions,
+    )
+
+    const { mapInteractionRecordToActivitySummary } = jest.requireMock(
+      '../../../lib/interactionCompatibility',
+    )
+    mapInteractionRecordToActivitySummary.mockImplementation(
+      (row: ReturnType<typeof canonicalInteraction>) => ({
+        id: row.id,
+        activityType: row.interactionType,
+        subject: null,
+        body: null,
+        occurredAt: row.occurredAt,
+        createdAt: row.createdAt,
+        entityId: 'entity-1',
+        authorUserId: null,
+        dealId: null,
+      }),
+    )
+  }
+
+  async function fetchIds(qs: string): Promise<string[]> {
+    const res = await GET(new Request(`http://localhost/api/customers/activities?${qs}`))
+    const body = (await res.json()) as { items: { id: string }[] }
+    return body.items.map((item) => item.id)
+  }
+
+  it('keeps the merged legacy+canonical stream globally ordered across the page boundary', async () => {
+    wireMergedRows(
+      [
+        legacyActivity('L1', '2026-01-01T00:00:00.000Z'),
+        legacyActivity('L3', '2026-01-03T00:00:00.000Z'),
+        legacyActivity('L5', '2026-01-05T00:00:00.000Z'),
+      ],
+      [
+        canonicalInteraction('C2', '2026-01-02T00:00:00.000Z'),
+        canonicalInteraction('C4', '2026-01-04T00:00:00.000Z'),
+        canonicalInteraction('C6', '2026-01-06T00:00:00.000Z'),
+      ],
+    )
+
+    const page1 = await fetchIds('page=1&pageSize=2&sortField=createdAt&sortDir=asc')
+    const page2 = await fetchIds('page=2&pageSize=2&sortField=createdAt&sortDir=asc')
+
+    expect(page1).toEqual(['L1', 'C2'])
+    expect(page2).toEqual(['L3', 'C4'])
+    // No id reappears across the boundary, and the concatenation stays sorted.
+    expect(new Set([...page1, ...page2]).size).toBe(4)
+    expect([...page1, ...page2]).toEqual(['L1', 'C2', 'L3', 'C4'])
+  })
+
+  it('reverses the merged order for descending sort', async () => {
+    wireMergedRows(
+      [
+        legacyActivity('L1', '2026-01-01T00:00:00.000Z'),
+        legacyActivity('L5', '2026-01-05T00:00:00.000Z'),
+      ],
+      [
+        canonicalInteraction('C4', '2026-01-04T00:00:00.000Z'),
+        canonicalInteraction('C6', '2026-01-06T00:00:00.000Z'),
+      ],
+    )
+
+    const ids = await fetchIds('page=1&pageSize=2&sortField=createdAt&sortDir=desc')
+    expect(ids).toEqual(['C6', 'L5'])
+  })
+
+  it('drops legacy items bridged into the canonical stream so they are not duplicated', async () => {
+    wireMergedRows(
+      [
+        legacyActivity('L1', '2026-01-01T00:00:00.000Z'),
+        legacyActivity('S1', '2026-01-02T12:00:00.000Z'),
+        legacyActivity('L5', '2026-01-05T00:00:00.000Z'),
+      ],
+      [
+        canonicalInteraction('C2', '2026-01-02T00:00:00.000Z'),
+        canonicalInteraction('S1', '2026-01-03T12:00:00.000Z'),
+        canonicalInteraction('C6', '2026-01-06T00:00:00.000Z'),
+      ],
+    )
+
+    const ids = await fetchIds('page=1&pageSize=50&sortField=createdAt&sortDir=asc')
+
+    expect(ids.filter((id) => id === 'S1')).toEqual(['S1'])
+    expect(ids).toEqual(['L1', 'C2', 'S1', 'L5', 'C6'])
   })
 })

--- a/packages/core/src/modules/customers/api/activities/route.ts
+++ b/packages/core/src/modules/customers/api/activities/route.ts
@@ -74,6 +74,12 @@ const ADAPTER_HEADERS = {
 // canonical bridge) read path. Keeps memory bounded on tenants with large
 // activity history; deep-pagination beyond this window is not supported here —
 // use /api/customers/interactions instead.
+//
+// Audited for the #3386 rollout (P2): this merged path sorts only on
+// non-encrypted system timestamps (createdAt/occurredAt, see
+// resolveActivitySortValue), so the #3278 two-phase *encrypted*-sort migration
+// is intentionally not applied here. Merge-order correctness across the page
+// boundary is covered by __tests__/merged-pagination.test.ts.
 const MERGED_ACTIVITY_FETCH_CAP = 2000
 
 type ActivityItem = {


### PR DESCRIPTION
## Summary

Phase 2 (P2) of #3386 — rolling the bounded encrypted-sort hardening out to custom list handlers. P2 is the deprecated `/api/customers/activities` endpoint, scoped in #3386 as a *review*. Audit finding: this path does **not** carry the #3278 hazard — the merged (legacy + canonical) read is already window-bounded by `MERGED_ACTIVITY_FETCH_CAP = 2000`, sorts only on non-encrypted system timestamps (`createdAt`/`occurredAt`), and its only `Promise.all` is two parallel queries (not an unbounded per-row decrypt). The route is also deprecated (sunset 2026-06-30) with a server-paginated successor (`/api/customers/interactions`).

So no behavior change is warranted; instead this PR closes the one real coverage gap —
existing tests asserted the bounded fetch shape but not merge-order correctness across the
page boundary.

## Changes

- `api/activities/__tests__/merged-pagination.test.ts`
  - Add merge-order regression cases on the non-unified merged path:
    - page-boundary global ordering (no duplicate/dropped ids),
    - sort-direction reversal,
    - bridge-id de-dup.
  - Restore mock-factory defaults in `beforeEach` for test isolation.

- `api/activities/route.ts`
  - Extend the existing `MERGED_ACTIVITY_FETCH_CAP` comment to record the audited invariant: non-encrypted sort → two-phase encrypted-sort migration intentionally N/A; deep pagination beyond the window unsupported — use `/api/customers/interactions`.
   - No logic change.

## Specification

- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed) — contained audit + test coverage, no contract
      surface change; mirrors #3278's precedent (scoped via plan mode, no committed spec).

**Spec file path:** N/A

## Testing

- `yarn workspace @open-mercato/core test -- activities`
  - 28/28 passed (7 suites; 3 new cases).

- `tsc --noEmit`
  - Clean for the changed files.
  - Remaining errors are pre-existing `#generated/*` resolution noise on a fresh checkout,
    unrelated to this change.

- No API/UI behavior change, so no `.ai/qa/tests/` integration spec added.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement.
- [ ] I updated documentation, locales, or generators if the change requires it. (N/A)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why not) — documented above: no API/UI surface change.
- [ ] I created or updated the spec in `.ai/specs/` (N/A).

## Linked issues

Part of #3386 (P2).

Related:
- #3278
- #2969