### PR TITLE
fix(customers): localize CRM calendar date/time labels (#3482)

### DIFF
--- a/packages/core/src/modules/customers/__integration__/helpers/calendarFixtures.ts
+++ b/packages/core/src/modules/customers/__integration__/helpers/calendarFixtures.ts
@@ -1,6 +1,7 @@
 import { expect, type APIRequestContext, type Page } from '@playwright/test';
 import { apiRequest } from '@open-mercato/core/helpers/integration/api';
 import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import { formatDateRangeLabel } from '../../lib/calendar/format';
 
 /**
  * Shared fixtures + date helpers for the CRM Calendar integration specs
@@ -120,18 +121,19 @@ export function mondayWeekRange(anchor: Date): { from: Date; to: Date } {
   return { from, to };
 }
 
-const EN_MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-
-function pad2(value: number): string {
-  return String(value).padStart(2, '0');
-}
+/**
+ * Locale the calendar UI renders under during integration runs (the app default).
+ * Pinned so specs assert the exact `Intl.formatRange` output the toolbar produces.
+ */
+const TOOLBAR_LOCALE = 'en-US';
 
 /**
- * Mirrors `CalendarToolbar.formatRangeLabel` (date-fns `'MMM dd' – 'MMM dd, yyyy'`,
- * default English locale) so specs can assert the visible range label.
+ * Mirrors the visible toolbar range label by delegating to the same production
+ * `formatDateRangeLabel` (`Intl.DateTimeFormat(...).formatRange`) the toolbar uses,
+ * so the spec assertion can never drift from the component (e.g. `Jun 15 – 21, 2026`).
  */
 export function formatToolbarRangeLabel(from: Date, to: Date): string {
-  return `${EN_MONTHS_SHORT[from.getMonth()]} ${pad2(from.getDate())} – ${EN_MONTHS_SHORT[to.getMonth()]} ${pad2(to.getDate())}, ${to.getFullYear()}`;
+  return formatDateRangeLabel(TOOLBAR_LOCALE, from, to);
 }
 
 export function escapeRegExp(value: string): string {

--- a/packages/core/src/modules/customers/components/calendar/CalendarToolbar.tsx
+++ b/packages/core/src/modules/customers/components/calendar/CalendarToolbar.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import * as React from 'react'
-import { format } from 'date-fns/format'
 import { CalendarRange, ListFilter, Settings } from 'lucide-react'
 import { Badge } from '@open-mercato/ui/primitives/badge'
 import { Button } from '@open-mercato/ui/primitives/button'
@@ -18,7 +17,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@open-mercato/ui/primitives/select'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
+import { formatDateRangeLabel } from '../../lib/calendar/format'
 import type {
   CalendarFiltersValue,
   CalendarRangePreset,
@@ -32,10 +32,6 @@ const STATUS_OPTIONS = ['planned', 'done', 'canceled'] as const
 const ALL_OPTION = 'all'
 
 const EMPTY_FILTERS: CalendarFiltersValue = { types: [], status: null, ownerUserId: null }
-
-function formatRangeLabel(from: Date, to: Date): string {
-  return `${format(from, 'MMM dd')} – ${format(to, 'MMM dd, yyyy')}`
-}
 
 export function CalendarToolbar(props: CalendarToolbarProps) {
   const {
@@ -54,6 +50,7 @@ export function CalendarToolbar(props: CalendarToolbarProps) {
     onOpenSettings,
   } = props
   const t = useT()
+  const locale = useLocale()
   const [rangeOpen, setRangeOpen] = React.useState(false)
   const [filtersOpen, setFiltersOpen] = React.useState(false)
   const [pendingFilters, setPendingFilters] = React.useState<CalendarFiltersValue>(filters)
@@ -128,7 +125,7 @@ export function CalendarToolbar(props: CalendarToolbarProps) {
                 className="min-w-0 text-muted-foreground sm:-ml-px sm:rounded-l-none"
               >
                 <CalendarRange aria-hidden="true" />
-                <span className="truncate">{formatRangeLabel(range.from, range.to)}</span>
+                <span className="truncate">{formatDateRangeLabel(locale, range.from, range.to)}</span>
               </Button>
             </PopoverTrigger>
             <PopoverContent align="start" className="w-auto min-w-0 p-2">

--- a/packages/core/src/modules/customers/components/calendar/EventBlock.tsx
+++ b/packages/core/src/modules/customers/components/calendar/EventBlock.tsx
@@ -6,6 +6,7 @@ import { cn } from '@open-mercato/shared/lib/utils'
 import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import { Avatar, AvatarStack } from '@open-mercato/ui/primitives/avatar'
 import { Button } from '@open-mercato/ui/primitives/button'
+import { formatTimeRangeLabel } from '../../lib/calendar/format'
 import type { CalendarItem, CalendarPlatform } from './types'
 
 const SHOW_TIME_MIN_HEIGHT_PX = 44
@@ -63,12 +64,7 @@ export function resolveEventTone(item: CalendarItem, nowMs: number): EventTone {
 }
 
 export function formatTimeRange(locale: string, start: Date, end: Date): string {
-  const formatter = new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit' })
-  try {
-    return formatter.formatRange(start, end)
-  } catch {
-    return `${formatter.format(start)} - ${formatter.format(end)}`
-  }
+  return formatTimeRangeLabel(locale, start, end)
 }
 
 function participantLabel(participant: CalendarItem['participants'][number]): string {

--- a/packages/core/src/modules/customers/components/calendar/UpcomingCards.tsx
+++ b/packages/core/src/modules/customers/components/calendar/UpcomingCards.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react'
 import { differenceInCalendarDays } from 'date-fns/differenceInCalendarDays'
-import { format } from 'date-fns/format'
 import { AlertTriangle, ChevronDown, Clock } from 'lucide-react'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
@@ -13,12 +12,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@open-mercato/ui/primitives/popover'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
+import { formatDateLabel, formatTimeRangeLabel } from '../../lib/calendar/format'
 import type { CalendarItem, UpcomingCard, UpcomingCardsProps } from './types'
 
-function formatTimeRange(item: CalendarItem, allDayLabel: string): string {
+function formatTimeRange(locale: string, item: CalendarItem, allDayLabel: string): string {
   if (item.allDay) return allDayLabel
-  return `${format(item.start, 'h:mm a')} – ${format(item.end, 'h:mm a')}`
+  return formatTimeRangeLabel(locale, item.start, item.end)
 }
 
 function canJoin(item: CalendarItem): boolean {
@@ -37,6 +37,7 @@ function UpcomingCardStatus({
   onSeeConflict: UpcomingCardsProps['onSeeConflict']
 }) {
   const t = useT()
+  const locale = useLocale()
   const { item, kind, conflictCount } = card
 
   if (kind === 'today') {
@@ -91,7 +92,7 @@ function UpcomingCardStatus({
           {t('customers.calendar.cards.cancelled', 'Cancelled')}
         </span>
         <span className="shrink-0 text-xs text-muted-foreground">
-          {format(item.start, 'MMM dd, yyyy')}
+          {formatDateLabel(locale, item.start)}
         </span>
       </div>
     )
@@ -107,7 +108,7 @@ function UpcomingCardStatus({
           : t('customers.calendar.cards.daysLater', '{days} days later', { days: daysLater })}
       </span>
       <span className="shrink-0 text-xs text-muted-foreground">
-        {format(item.start, 'MMM dd, yyyy')}
+        {formatDateLabel(locale, item.start)}
       </span>
     </div>
   )
@@ -123,6 +124,7 @@ function UpcomingCardItem({
   onCancel,
 }: { card: UpcomingCard } & CardCallbacks) {
   const t = useT()
+  const locale = useLocale()
   const { item } = card
 
   return (
@@ -131,7 +133,7 @@ function UpcomingCardItem({
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <p className="truncate text-sm font-medium text-foreground">{item.title}</p>
           <p className="truncate text-xs text-muted-foreground">
-            {formatTimeRange(item, t('customers.calendar.cards.allDay', 'All day'))}
+            {formatTimeRange(locale, item, t('customers.calendar.cards.allDay', 'All day'))}
           </p>
         </div>
         <Popover>

--- a/packages/core/src/modules/customers/lib/calendar/__tests__/format.test.ts
+++ b/packages/core/src/modules/customers/lib/calendar/__tests__/format.test.ts
@@ -1,0 +1,59 @@
+import { formatDateLabel, formatDateRangeLabel, formatTimeRangeLabel } from '../format'
+
+const JUN_15 = new Date(2026, 5, 15)
+const JUN_21 = new Date(2026, 5, 21)
+const JUN_28 = new Date(2026, 5, 28)
+const AT_14 = new Date(2026, 5, 28, 14, 0)
+const AT_15 = new Date(2026, 5, 28, 15, 0)
+
+describe('formatDateRangeLabel', () => {
+  it('localizes the month name for Polish instead of falling back to English', () => {
+    const label = formatDateRangeLabel('pl', JUN_15, JUN_21)
+    expect(label).toContain('cze')
+    expect(label).toContain('2026')
+    expect(label).not.toMatch(/Jun/)
+  })
+
+  it('keeps English month names for the English locale', () => {
+    expect(formatDateRangeLabel('en', JUN_15, JUN_21)).toContain('Jun')
+  })
+
+  it('produces a different label per locale', () => {
+    expect(formatDateRangeLabel('pl', JUN_15, JUN_21)).not.toBe(
+      formatDateRangeLabel('en', JUN_15, JUN_21),
+    )
+  })
+})
+
+describe('formatDateLabel', () => {
+  it('localizes a single date for Polish', () => {
+    const label = formatDateLabel('pl', JUN_28)
+    expect(label).toContain('28')
+    expect(label).toContain('cze')
+    expect(label).toContain('2026')
+    expect(label).not.toMatch(/Jun/)
+  })
+
+  it('keeps English month names for the English locale', () => {
+    expect(formatDateLabel('en', JUN_28)).toContain('Jun')
+  })
+})
+
+describe('formatTimeRangeLabel', () => {
+  it('renders a 24h range for Polish without AM/PM markers', () => {
+    const label = formatTimeRangeLabel('pl', AT_14, AT_15)
+    expect(label).toContain('14:00')
+    expect(label).toContain('15:00')
+    expect(label).not.toMatch(/AM|PM/i)
+  })
+
+  it('uses the 12h clock for the English locale', () => {
+    expect(formatTimeRangeLabel('en', AT_14, AT_15)).toMatch(/PM/)
+  })
+
+  it('produces a different label per locale', () => {
+    expect(formatTimeRangeLabel('pl', AT_14, AT_15)).not.toBe(
+      formatTimeRangeLabel('en', AT_14, AT_15),
+    )
+  })
+})

--- a/packages/core/src/modules/customers/lib/calendar/format.ts
+++ b/packages/core/src/modules/customers/lib/calendar/format.ts
@@ -1,0 +1,25 @@
+const DATE_OPTIONS: Intl.DateTimeFormatOptions = { day: 'numeric', month: 'short', year: 'numeric' }
+
+const TIME_OPTIONS: Intl.DateTimeFormatOptions = { hour: 'numeric', minute: '2-digit' }
+
+export function formatDateLabel(locale: string, date: Date): string {
+  return new Intl.DateTimeFormat(locale, DATE_OPTIONS).format(date)
+}
+
+export function formatDateRangeLabel(locale: string, from: Date, to: Date): string {
+  const formatter = new Intl.DateTimeFormat(locale, DATE_OPTIONS)
+  try {
+    return formatter.formatRange(from, to)
+  } catch {
+    return `${formatter.format(from)} – ${formatter.format(to)}`
+  }
+}
+
+export function formatTimeRangeLabel(locale: string, start: Date, end: Date): string {
+  const formatter = new Intl.DateTimeFormat(locale, TIME_OPTIONS)
+  try {
+    return formatter.formatRange(start, end)
+  } catch {
+    return `${formatter.format(start)} – ${formatter.format(end)}`
+  }
+}


### PR DESCRIPTION
Fixes #3482

## Problem
In a non-English UI (tested in Polish), several CRM Calendar date/time strings rendered in **English**, breaking locale consistency with the surrounding Intl-localized grid:
- Toolbar date-range button (all views): `Jun 15 – Jun 21, 2026` instead of `15–21 cze 2026`.
- Upcoming card time: `2:00 PM – 3:00 PM` (English 12h) instead of 24h `14:00–15:00`.
- Upcoming card date: `Jun 28, 2026` instead of `28 cze 2026`.

## Root Cause
`CalendarToolbar.tsx` and `UpcomingCards.tsx` formatted dates/times with `date-fns` `format(...)` **without a locale option**, so they always render in English. The sibling grid components (`CalendarHeader`, `EventBlock`, `TimeGrid`, `EventPeekPopover`) already localize via `Intl.DateTimeFormat(locale, …)` driven by `useLocale()`, hence the mismatch.

## What Changed
- Added `packages/core/src/modules/customers/lib/calendar/format.ts` — a small React-free helper (`formatDateLabel`, `formatDateRangeLabel`, `formatTimeRangeLabel`) built on `Intl.DateTimeFormat` + `formatRange` (with a non-range fallback), matching the pattern the rest of the calendar module already uses.
- `CalendarToolbar.tsx` and `UpcomingCards.tsx` now read the active locale via `useLocale()` and render through the new helpers; the unused `date-fns/format` imports are dropped (`differenceInCalendarDays` is retained where still used).
- `EventBlock.formatTimeRange(locale, start, end)` now delegates to the shared `formatTimeRangeLabel` to remove duplicated logic. Its **export and signature are unchanged**, so `TimeGrid` (its only consumer) is unaffected.
- Out of scope by design: `AgendaList`/`MonthGrid` keep `date-fns` `format(date, 'yyyy-MM-dd')` — those are locale-independent grouping **keys**, not user-facing display, and must not be localized.

Note: for English, ranges now collapse the way `Intl` does (`Jun 15 – 21, 2026`, `2:00 – 3:00 PM`) — the idiomatic locale-aware output and exactly the collapsed form the issue specifies for Polish.

## Tests
- New unit suite `lib/calendar/__tests__/format.test.ts` (8 cases) asserts each helper localizes per-locale (`pl` vs `en`): Polish months (`cze`, not `Jun`), 24h time without AM/PM, and that each label differs between locales. Tests pass explicit locales so they are robust against the host machine locale.
- `yarn build:packages`, `yarn generate`, core `typecheck`, and `yarn build:app` all pass.
- Calendar lib suite: 12 suites / 148 tests pass (plus the 8 new). Customers module suite: 994/995 pass — the single failure (`DealsKpiStrip.test.tsx`) is a **pre-existing, environment-only** flake: that component uses `Intl.NumberFormat(undefined, …)` and the assertion expects `1K`, which only holds under an English host locale (passes under `LANG=en_US.UTF-8`); it is untouched by this change.

## Backward Compatibility
- No contract-surface changes. `EventBlock.formatTimeRange` keeps its public export and signature; the new `lib/calendar/format` exports are additive. No API routes, event IDs, types, DI keys, ACL features, DB schema, or i18n keys changed.
