### PR TITLE
fix(ui): disable native HTML5 validation on CrudForm so zod errors surface (#3485)

### DIFF
--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -3498,7 +3498,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
           className={embedded ? 'min-h-[1px]' : 'min-h-[400px]'}
         >
           {wrapFormBody(
-            <form id={formId} onSubmit={handleSubmit} className={`space-y-4 ${dialogFormPadding}`}>
+            <form id={formId} noValidate onSubmit={handleSubmit} className={`space-y-4 ${dialogFormPadding}`}>
             {resolvedInjectionSpotId ? (
               <InjectionSpot
                 spotId={resolvedInjectionSpotId}
@@ -3583,6 +3583,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
           <div>
           <form
             id={formId}
+            noValidate
             onSubmit={handleSubmit}
             className={`${embedded ? 'space-y-4' : 'rounded-lg border bg-card p-4 space-y-4'} ${dialogFormPadding}`}
           >

--- a/packages/ui/src/backend/__tests__/CrudForm.nativeValidation.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.nativeValidation.test.tsx
@@ -1,0 +1,61 @@
+/** @jest-environment jsdom */
+jest.setTimeout(15000)
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: () => {} }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}))
+jest.mock('remark-gfm', () => ({ __esModule: true, default: {} }))
+jest.mock('../injection/InjectionSpot', () => ({
+  __esModule: true,
+  InjectionSpot: () => null,
+  useInjectionWidgets: () => ({ widgets: [], loading: false, error: null }),
+  useInjectionSpotEvents: () => ({ triggerEvent: jest.fn() }),
+}))
+jest.mock('../injection/useInjectionDataWidgets', () => ({
+  __esModule: true,
+  useInjectionDataWidgets: () => ({ widgets: [], isLoading: false, error: null }),
+}))
+
+import * as React from 'react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { CrudForm, type CrudField } from '../CrudForm'
+
+describe('CrudForm native HTML5 validation (issue #3485)', () => {
+  it('marks the default single-card form as noValidate so native constraints cannot mask zod errors', () => {
+    const fields: CrudField[] = [
+      { id: 'canonicalUrl', label: 'Canonical URL', type: 'text' },
+    ]
+
+    const { container } = renderWithProviders(
+      <CrudForm title="Form" fields={fields} onSubmit={() => {}} />,
+      { dict: { 'ui.forms.actions.save': 'Save' } },
+    )
+
+    const form = container.querySelector('form') as HTMLFormElement | null
+    expect(form).not.toBeNull()
+    expect(form?.noValidate).toBe(true)
+  })
+
+  it('marks the grouped/two-column form as noValidate even when a child renders a native url input', () => {
+    const { container } = renderWithProviders(
+      <CrudForm
+        title="Form"
+        fields={[]}
+        groups={[
+          {
+            id: 'compliance',
+            component: () => <input type="url" defaultValue="not-a-valid-url" />,
+          },
+        ]}
+        onSubmit={() => {}}
+      />,
+      { dict: { 'ui.forms.actions.save': 'Save' } },
+    )
+
+    const form = container.querySelector('form') as HTMLFormElement | null
+    expect(form).not.toBeNull()
+    expect(form?.noValidate).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #3485

## Problem
On the catalog product form, the **Canonical URL** field is rendered as `<Input type="url">`. When the value isn't a valid URL, the browser's native HTML5 constraint validation intercepts the submit (focuses the field, shows an ephemeral native bubble) **before** the form's zod validation runs. The styled, translated `catalog.products.validation.canonicalUrlInvalid` message never shows, and other invalid compliance fields on the same submit (e.g. `maxOrderQty < minOrderQty`) don't get their inline error rendered until the URL is corrected.

## Root Cause
`CrudForm` drives validation **entirely through zod** (`handleSubmit` calls `e.preventDefault()`, runs its own required-field check + `schema.safeParse`, and renders inline errors). But its `<form>` elements did **not** set `noValidate`, so the browser's native constraint validation (`type="url"`, number `min`/`max`, etc.) fired first and short-circuited submit. This is systemic, not specific to one field: `CrudForm` itself renders native `type="number"` inputs and 40+ core files render native-validating inputs inside these forms — the canonical-URL field is just the reported trigger.

Fixing it at the field level (`type="url"` → `type="text"`) would patch one symptom and leave the same class of bug everywhere. The correct, minimal root-cause fix is to disable native validation on the form that already validates with zod.

## What Changed
- Added `noValidate` to **both** `CrudForm` `<form>` layouts (the default single-card layout and the grouped/two-column layout). Native browser validation no longer intercepts submit on any `CrudForm`-based create/edit page; zod runs and inline errors render consistently. Fixes the reported catalog product create **and** edit forms, plus the same class across every form.

No functional loss: required-field enforcement is done in JS (`field.required`), and there is no `checkValidity`/`reportValidity` reliance — only the native bubble that was masking zod errors is removed.

## Tests
- Added `packages/ui/src/backend/__tests__/CrudForm.nativeValidation.test.tsx` asserting both `CrudForm` layouts render a `noValidate` form (including the grouped layout with a child native `url` input that mirrors the issue). Verified it **fails before** the fix (`form.noValidate === false`) and **passes after**.
- `yarn workspace @open-mercato/ui test --testPathPatterns CrudForm` → all 15 suites / 80 tests pass (incl. the new one).
- `yarn workspace @open-mercato/ui build` → builds successfully.
- Typecheck (`tsc --noEmit`) on `@open-mercato/ui` → zero errors in touched files (the only 2 errors are the pre-existing fresh-worktree `#generated/*` shim resolution gotcha, unrelated to this change).
- Full `@open-mercato/ui` suite: 1540/1541 tests pass. The single failing test (`utils/format.test.ts` currency locale) and 7 `AiChat.*` suite load failures are pre-existing and environmental (locale + fresh-worktree module resolution), not caused by this change.
- Not run: full `yarn build:app` / root typecheck — they require `yarn generate` (CLI build) in this fresh worktree; a `noValidate` attribute on a form cannot affect generated code, DB, i18n, or the app build output.

## Backward Compatibility
- No contract-surface changes. `noValidate` is an additive HTML attribute on `CrudForm`'s internal `<form>`; no public prop/type/signature/import-path/event-ID/widget-spot/API/DB/DI/ACL changes. Behavior change is a strict UX improvement aligned with CrudForm's documented zod-first validation.