### PR TITLE
fix(ai_assistant): load @app module ai-tools in standalone MCP loader (#3524)

### DIFF
--- a/packages/ai-assistant/AGENTS.md
+++ b/packages/ai-assistant/AGENTS.md
@@ -1464,6 +1464,15 @@ Agents that need multi-step tool loops configure the `loop` block on `AiAgentDef
 
 ## Changelog
 
+### 2026-06-24 - MCP dev server loads ai-tools for @app local modules (#3524)
+
+**What changed** (`lib/generated-registry-loader.ts`):
+- `rewriteGeneratedAliasImports` now also rewrites the `../../src/...` relative imports the generator emits for `@app` local modules (e.g. `from "../../src/modules/<id>/ai-tools"`), resolving them against the generated file's directory (`<appRoot>/.mercato/generated`) to absolute `file://` URLs with the same `.ts`-suffix probe used for `@/` aliases. Previously only `@/` aliases were rewritten, so the `../../src/...` specifier passed through `esbuild.transform` (transpile-only) into the compiled `.mjs` and Node ESM threw `ERR_MODULE_NOT_FOUND` resolving the extensionless `.ts`-only target. Package-backed modules (`@open-mercato/*`) were never affected — their bare specifiers resolve through `node_modules` to compiled `.js`.
+
+**Files**: `lib/generated-registry-loader.ts`. Regression test: `lib/__tests__/generated-registry-loader.test.ts` (3 cases covering static import, dynamic `import()`, and `.ts`-suffix resolution for the `../../src/...` shape).
+
+**Backward compatibility**: Strictly additive — the `rewriteGeneratedAliasImports(source, appRoot)` signature is unchanged, and `@/` aliases, bare package imports, and sibling `./` imports keep their prior behavior. Only previously-broken `../../src/...` specifiers change (from unresolved to resolved).
+
 ### 2026-06-11 - Harden latent MCP server-config module (#2672)
 
 **What changed** (`lib/mcp-server-config.ts`, currently dead code — no callers):

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/generated-registry-loader.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/generated-registry-loader.test.ts
@@ -73,6 +73,53 @@ describe('rewriteGeneratedAliasImports', () => {
     ].join('\n')
     expect(rewriteGeneratedAliasImports(source, makeTempDir())).toBe(source)
   })
+
+  // Regression for issue #3524: the MCP dev server crashed with
+  //   "ERR_MODULE_NOT_FOUND: Cannot find module '.../src/modules/<id>/ai-tools'"
+  // because the generator emits `../../src/modules/<id>/ai-tools` relative
+  // imports for @app local modules, which the rewriter previously left intact.
+  // esbuild.transform keeps them verbatim, so Node ESM can't resolve the
+  // extensionless `.ts`-only specifier from the compiled `.mjs`.
+
+  it('rewrites a `../../src/...` @app relative import to an absolute file URL', () => {
+    const appRoot = makeTempDir()
+    const out = rewriteGeneratedAliasImports(
+      `import * as AI_TOOLS from "../../src/modules/media_campaigns/ai-tools"`,
+      appRoot,
+    )
+    const expectedUrl = pathToFileURL(
+      path.join(appRoot, 'src', 'modules', 'media_campaigns', 'ai-tools'),
+    ).href
+    expect(out).toBe(`import * as AI_TOOLS from ${safeJsLiteral(expectedUrl)}`)
+    expect(out).not.toContain('../../src/')
+  })
+
+  it('rewrites a dynamic `import("../../src/...")` @app call to an absolute file URL', () => {
+    const appRoot = makeTempDir()
+    const specifier = '"../../src/modules/media_campaigns/ai-tools"'
+    const source = `const load = () => import(${specifier})`
+    const out = rewriteGeneratedAliasImports(source, appRoot)
+    const expectedUrl = pathToFileURL(
+      path.join(appRoot, 'src', 'modules', 'media_campaigns', 'ai-tools'),
+    ).href
+    expect(out).toBe(source.replace(specifier, safeJsLiteral(expectedUrl)))
+    expect(out).not.toContain('../../src/')
+  })
+
+  it('appends `.ts` for a `../../src/...` @app import that exists only as TypeScript', () => {
+    const appRoot = makeTempDir()
+    const moduleDir = path.join(appRoot, 'src', 'modules', 'media_campaigns')
+    fs.mkdirSync(moduleDir, { recursive: true })
+    fs.writeFileSync(path.join(moduleDir, 'ai-tools.ts'), 'export const aiTools = []\n')
+
+    const out = rewriteGeneratedAliasImports(
+      `import * as AI_TOOLS from "../../src/modules/media_campaigns/ai-tools"`,
+      appRoot,
+    )
+
+    const expectedUrl = pathToFileURL(path.join(moduleDir, 'ai-tools.ts')).href
+    expect(out).toBe(`import * as AI_TOOLS from ${safeJsLiteral(expectedUrl)}`)
+  })
 })
 
 describe('escapeUnsafeJsStringChars', () => {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/generated-registry-loader.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/generated-registry-loader.ts
@@ -53,10 +53,12 @@ export function findGeneratedFile(fileName: string): string | null {
 }
 
 /**
- * Compile-and-import a generated registry file on the fly. Resolves the `@/`
- * alias to the app root, transpiles TS → ESM, and emits a sibling `.mjs` we can
- * `import()` from Node. Cached on mtime so repeat calls in the same process
- * don't recompile.
+ * Compile-and-import a generated registry file on the fly. Rewrites the entry
+ * specifiers Node can't resolve standalone (`@/...` aliases and the
+ * `../../src/...` relative imports the generator emits for `@app` local
+ * modules) to absolute file URLs, transpiles TS → ESM, and emits a sibling
+ * `.mjs` we can `import()` from Node. Cached on mtime so repeat calls in the
+ * same process don't recompile.
  *
  * Transpile-only (no bundling): the generated registries declare an array
  * literal whose entries are static `import("…")` arrow functions — we want
@@ -128,15 +130,31 @@ function toSafeJsStringLiteral(value: string): string {
 }
 
 /**
- * Rewrite `@/...` path-alias imports (both `from "@/x"` and dynamic
- * `import("@/x")`) in generated-registry source to absolute `file://` URLs
- * rooted at `appRoot`. The `@/` alias is a Next.js bundler convention; outside
- * the bundler Node treats `@/...` as a bare package specifier and throws
- * `ERR_MODULE_NOT_FOUND`. Exported for unit testing.
+ * Rewrite the two specifier shapes the generator emits for module entries in a
+ * generated registry to absolute `file://` URLs Node can resolve in a
+ * standalone process:
+ *
+ *   1. `@/...` path-alias imports (both `from "@/x"` and dynamic `import("@/x")`).
+ *      The `@/` alias is a Next.js bundler convention; outside the bundler Node
+ *      treats `@/...` as a bare package specifier and throws
+ *      `ERR_MODULE_NOT_FOUND`. Resolved against `appRoot`.
+ *   2. `../../src/...` relative imports the generator emits for `@app` local
+ *      modules (e.g. `from "../../src/modules/<id>/ai-tools"`). esbuild's
+ *      transform (transpile-only) leaves these untouched, so the compiled
+ *      `.mjs` keeps an extensionless relative specifier that resolves to a
+ *      `.ts` file with no compiled `.js`/`.mjs` sibling — Node ESM then throws
+ *      `ERR_MODULE_NOT_FOUND`. Resolved against the generated file's directory
+ *      (`<appRoot>/.mercato/generated`), the location the generator wrote them
+ *      relative to. Package-backed modules (`@open-mercato/*`) are unaffected —
+ *      their bare specifiers resolve through `node_modules` to compiled `.js`.
+ *
+ * Both shapes reuse the same `.ts`-suffix probe so a source-only TypeScript
+ * target is loaded directly (Node strips types). Other specifiers (bare
+ * packages, sibling `./` imports) are left untouched. Exported for unit testing.
  */
 export function rewriteGeneratedAliasImports(source: string, appRoot: string): string {
-  const resolveAlias = (relativePath: string): string => {
-    const target = path.join(appRoot, relativePath)
+  const generatedDir = path.join(appRoot, '.mercato', 'generated')
+  const toResolvedLiteral = (target: string): string => {
     const candidate = fs.existsSync(target)
       ? target
       : fs.existsSync(target + '.ts')
@@ -144,12 +162,22 @@ export function rewriteGeneratedAliasImports(source: string, appRoot: string): s
         : target
     return toSafeJsStringLiteral(pathToFileURL(candidate).href)
   }
+  const resolveAlias = (relativePath: string): string =>
+    toResolvedLiteral(path.join(appRoot, relativePath))
+  const resolveRelative = (specifier: string): string =>
+    toResolvedLiteral(path.resolve(generatedDir, specifier))
   return source
     .replace(/from\s+["']@\/([^"']+)["']/g, (_match, relativePath: string) => {
       return `from ${resolveAlias(relativePath)}`
     })
     .replace(/import\s*\(\s*["']@\/([^"']+)["']\s*\)/g, (_match, relativePath: string) => {
       return `import(${resolveAlias(relativePath)})`
+    })
+    .replace(/from\s+["']((?:\.\.\/)+src\/[^"']+)["']/g, (_match, specifier: string) => {
+      return `from ${resolveRelative(specifier)}`
+    })
+    .replace(/import\s*\(\s*["']((?:\.\.\/)+src\/[^"']+)["']\s*\)/g, (_match, specifier: string) => {
+      return `import(${resolveRelative(specifier)})`
     })
 }
 


### PR DESCRIPTION
Fixes #3524

## Problem
Running the MCP dev server (`yarn mercato ai_assistant:mcp:dev`) in a **standalone app** with a custom `@app` module that has an `ai-tools.ts` failed to load the module's tools:

```
[MCP Tools] Could not load ai-tools.generated.ts (module tools unavailable):
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/path/to/app/src/modules/<id>/ai-tools'
```

Package-backed modules (`@open-mercato/core`, …) were unaffected.

## Root Cause
The generator emits **relative** imports for `@app` modules in the generated registries:

```ts
// .mercato/generated/ai-tools.generated.ts
import * as AI_TOOLS_media_campaigns_883 from "../../src/modules/media_campaigns/ai-tools";
```

The standalone MCP loader (`lib/generated-registry-loader.ts`) compiles these files with `esbuild.transform` (transpile-only — bundling is deliberately avoided because it pulls Next.js/route-handler internals into the `.mjs` and breaks at runtime). `rewriteGeneratedAliasImports` only rewrote `@/`-prefixed imports, so the `../../src/...` relative specifier passed through unchanged into the compiled `.mjs`. Node ESM then could not resolve the extensionless relative import (only `ai-tools.ts` exists — no compiled `.js`/`.mjs` sibling), throwing `ERR_MODULE_NOT_FOUND`.

Package modules go through `node_modules`, where compiled `.js` files already exist, so they were never affected.

## What Changed
- `rewriteGeneratedAliasImports` (`packages/ai-assistant/src/modules/ai_assistant/lib/generated-registry-loader.ts`) now **also** rewrites the `../../src/...` relative imports the generator emits for `@app` local modules, resolving them against the generated file's directory (`<appRoot>/.mercato/generated`) to absolute `file://` URLs.
- Reuses the existing `.ts`-suffix probe (so a source-only TypeScript target is loaded directly — Node strips types on import) and the existing `toSafeJsStringLiteral` hardening that the `@/` path already uses.
- This is **Option B** from the issue. Option A (bundling) was rejected — the loader doc explicitly avoids bundling. Option C (changing the generator) would have far wider blast radius and still need a loader change for `@/* → src/*`.

## Tests
- 3 regression tests added to `lib/__tests__/generated-registry-loader.test.ts` covering the static import, the dynamic `import()`, and `.ts`-suffix resolution for the `../../src/...` shape. **Proven red before the fix, green after.**
- Full `@open-mercato/ai-assistant` suite green: **1322 tests / 95 suites pass**.

## Backward Compatibility
- Strictly additive. The `rewriteGeneratedAliasImports(source, appRoot)` signature is unchanged.
- `@/` aliases, bare package imports (`@open-mercato/*`), and sibling `./` imports keep their prior behavior — only previously-broken `../../src/...` specifiers change (from unresolved to resolved).
- No contract surface (types, signatures, import paths, event IDs, API routes, DB schema, DI keys, ACL features) is touched.

## Notes
- No DB access, no migrations, no i18n strings, no generated files changed.
