### PR TITLE
fix(customers): keep today's column in week view when weekends are hidden (#3483)

### DIFF
--- a/packages/core/src/modules/customers/components/calendar/TimeGrid.tsx
+++ b/packages/core/src/modules/customers/components/calendar/TimeGrid.tsx
@@ -172,6 +172,7 @@ export function TimeGrid({
   const scrollRef = React.useRef<HTMLDivElement | null>(null)
   const nowMs = Date.now()
   const today = startOfDay(new Date())
+  const todayMs = today.getTime()
   const anchorMs = anchor.getTime()
   const [selectedId, setSelectedId] = React.useState<string | null>(null)
   const [drag, setDrag] = React.useState<DragState | null>(null)
@@ -179,8 +180,8 @@ export function TimeGrid({
   const dayStarts = React.useMemo(() => {
     const rangeStart = getVisibleRange(days === 7 ? 'week' : 'day', new Date(anchorMs), 0).from
     const all = Array.from({ length: days }, (_, index) => addDays(rangeStart, index))
-    return days === 7 ? applyWeekendVisibility(all, showWeekends) : all
-  }, [days, anchorMs, showWeekends])
+    return days === 7 ? applyWeekendVisibility(all, showWeekends, new Date(todayMs)) : all
+  }, [days, anchorMs, showWeekends, todayMs])
 
   const dayColumns = React.useMemo(
     () => dayStarts.map((dayStart) => buildDayColumn(dayStart, items)),

--- a/packages/core/src/modules/customers/lib/calendar/__tests__/grid.test.ts
+++ b/packages/core/src/modules/customers/lib/calendar/__tests__/grid.test.ts
@@ -1,3 +1,4 @@
+import { isSameDay } from 'date-fns/isSameDay'
 import {
   applyWeekendVisibility,
   buildDragRange,
@@ -36,6 +37,42 @@ describe('applyWeekendVisibility', () => {
   it('falls back to the original days when every day is a weekend (day view)', () => {
     const weekendOnly = [new Date(2026, 5, 13), new Date(2026, 5, 14)]
     expect(applyWeekendVisibility(weekendOnly, false)).toEqual(weekendOnly)
+  })
+
+  it('keeps today even when it is a weekend and weekends are hidden (issue #3483)', () => {
+    const sunday = new Date(2026, 5, 14, 0, 0, 0, 0)
+    const visible = applyWeekendVisibility(weekDays(), false, sunday)
+    expect(visible).toHaveLength(6)
+    expect(visible.some((day) => isSameDay(day, sunday))).toBe(true)
+    // Saturday is still hidden — only today's weekend column is restored.
+    expect(visible.some((day) => isSameDay(day, new Date(2026, 5, 13)))).toBe(false)
+  })
+
+  it('matches today by calendar day, ignoring the time of day', () => {
+    const saturdayAfternoon = new Date(2026, 5, 13, 16, 30, 0, 0)
+    const visible = applyWeekendVisibility(weekDays(), false, saturdayAfternoon)
+    expect(visible).toHaveLength(6)
+    expect(visible.some((day) => isSameDay(day, new Date(2026, 5, 13)))).toBe(true)
+    expect(visible.some((day) => isSameDay(day, new Date(2026, 5, 14)))).toBe(false)
+  })
+
+  it('does not add a weekend column when today is a weekday', () => {
+    const wednesday = new Date(2026, 5, 10, 0, 0, 0, 0)
+    const visible = applyWeekendVisibility(weekDays(), false, wednesday)
+    expect(visible).toHaveLength(5)
+    expect(visible.every((day) => !isWeekendDay(day))).toBe(true)
+  })
+
+  it('does not add a weekend column when today is outside the visible week', () => {
+    const nextWeekSunday = new Date(2026, 5, 21, 0, 0, 0, 0)
+    const visible = applyWeekendVisibility(weekDays(), false, nextWeekSunday)
+    expect(visible).toHaveLength(5)
+    expect(visible.every((day) => !isWeekendDay(day))).toBe(true)
+  })
+
+  it('still shows the full week when weekends are enabled, ignoring the keep date', () => {
+    const sunday = new Date(2026, 5, 14, 0, 0, 0, 0)
+    expect(applyWeekendVisibility(weekDays(), true, sunday)).toHaveLength(7)
   })
 })
 

--- a/packages/core/src/modules/customers/lib/calendar/grid.ts
+++ b/packages/core/src/modules/customers/lib/calendar/grid.ts
@@ -1,3 +1,5 @@
+import { isSameDay } from 'date-fns/isSameDay'
+
 export const DRAG_SNAP_MINUTES = 15
 export const MIN_DRAG_DURATION_MINUTES = 30
 const MINUTES_PER_DAY = 24 * 60
@@ -7,9 +9,15 @@ export function isWeekendDay(date: Date): boolean {
   return weekday === 0 || weekday === 6
 }
 
-export function applyWeekendVisibility(days: Date[], showWeekends: boolean): Date[] {
+export function applyWeekendVisibility(
+  days: Date[],
+  showWeekends: boolean,
+  keepWeekendDate?: Date | null,
+): Date[] {
   if (showWeekends) return days
-  const workingDays = days.filter((day) => !isWeekendDay(day))
+  const workingDays = days.filter(
+    (day) => !isWeekendDay(day) || (keepWeekendDate != null && isSameDay(day, keepWeekendDate)),
+  )
   return workingDays.length > 0 ? workingDays : days
 }
 


### PR DESCRIPTION
Fixes #3483

## Problem
On the CRM Calendar (`/backend/calendar`), **"Show weekends"** is off by default. When today falls on a Saturday or Sunday, the default **Week** view filtered today's column out of the grid — so opening the calendar on a weekend showed an empty Mon–Fri week with no indication that today (and any weekend events on it) was hidden. The heading still read e.g. "21 cze 2026" (a Sunday) while no matching column existed.

## Root Cause
`applyWeekendVisibility(days, showWeekends)` (`packages/core/src/modules/customers/lib/calendar/grid.ts`) unconditionally dropped every Saturday/Sunday when weekends were hidden. The Week-view column computation in `TimeGrid.tsx` called it for the current week, so the "today" column disappeared whenever today was a weekend day.

## What Changed
- `applyWeekendVisibility` gains an optional third argument `keepWeekendDate`. When weekends are hidden, a weekend day is still kept if it matches that date (compared by calendar day, ignoring time-of-day). The signature change is **additive and backward-compatible** — the existing two-argument call behavior is unchanged.
- `TimeGrid.tsx` passes the current day (`today`, via a stable `todayMs` memo dependency) into the Week-view column computation, so today's column is always rendered even on a weekend. Other weekend columns stay hidden, and navigating to a *different* week is unaffected (today is not in that week's range).

This implements the issue's preferred remedy: *include today's column regardless of the weekend setting*.

## Tests
- Added regression unit tests in `lib/calendar/__tests__/grid.test.ts`:
  - keeps today when it is a weekend and weekends are hidden (only today's weekend column, not the whole weekend)
  - matches today by calendar day, ignoring time-of-day
  - does not add a weekend column when today is a weekday
  - does not add a weekend column when today is outside the visible week
  - still shows the full week when weekends are enabled
- `yarn workspace @open-mercato/core test -- lib/calendar`: 145 passed
- `yarn typecheck`: passed (21/21)
- `yarn build:packages`: passed
- Full core suite: 6476 passed; 1 pre-existing, unrelated failure in `DealsKpiStrip.test.tsx` caused by the local machine's Polish locale rendering compact numbers as "1 tys." instead of "1K" (environmental, not touched by this change).

## Backward Compatibility
- No contract surface changes. `applyWeekendVisibility` is an internal module helper (not a package-level export) and only gained an optional parameter; the single existing call site and all prior tests are unaffected.