### PR TITLE
fix(sales): prevent ShipmentDialog infinite re-render loop when order has no address (#3529)

### DIFF
--- a/packages/core/src/modules/sales/components/documents/ShipmentDialog.tsx
+++ b/packages/core/src/modules/sales/components/documents/ShipmentDialog.tsx
@@ -255,6 +255,20 @@ const extractShipmentAddressSnapshot = (
   return normalizeAddressSnapshot(raw as Record<string, unknown>)
 }
 
+const addressOptionsSignature = (options: ShipmentAddressOption[]): string =>
+  options.map((option) => `${snapshotKey(option.snapshot) ?? ''}::${option.id}`).join('||')
+
+function useStableAddressOptions(options: ShipmentAddressOption[]): ShipmentAddressOption[] {
+  const signature = addressOptionsSignature(options)
+  const stableRef = React.useRef(options)
+  const signatureRef = React.useRef(signature)
+  if (signatureRef.current !== signature) {
+    signatureRef.current = signature
+    stableRef.current = options
+  }
+  return stableRef.current
+}
+
 export function ShipmentDialog({
   open,
   mode,
@@ -323,7 +337,7 @@ export function ShipmentDialog({
     [shipmentAddressSnapshot, t],
   )
 
-  const baseAddressOptions = React.useMemo(
+  const computedBaseAddressOptions = React.useMemo(
     () =>
       dedupeAddressOptions(
         [shippingAddressOption, shipmentAddressOption].filter(
@@ -332,6 +346,7 @@ export function ShipmentDialog({
       ),
     [shipmentAddressOption, shippingAddressOption],
   )
+  const baseAddressOptions = useStableAddressOptions(computedBaseAddressOptions)
 
   const preferredAddressId = React.useMemo(() => {
     const shipmentKey = snapshotKey(shipmentAddressSnapshot)
@@ -452,7 +467,10 @@ export function ShipmentDialog({
 
   const mergeAddressOptions = React.useCallback(
     (options: ShipmentAddressOption[]) =>
-      setAddressOptions((prev) => dedupeAddressOptions([...prev, ...options])),
+      setAddressOptions((prev) => {
+        const next = dedupeAddressOptions([...prev, ...options])
+        return next.length === prev.length ? prev : next
+      }),
     [],
   )
 

--- a/packages/core/src/modules/sales/components/documents/__tests__/ShipmentDialog.reRenderLoop.test.tsx
+++ b/packages/core/src/modules/sales/components/documents/__tests__/ShipmentDialog.reRenderLoop.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression test for issue #3529:
+ * Opening the "Add Shipment" dialog used to trigger an infinite React re-render
+ * loop ("Maximum update depth exceeded", originating from the bootstrap effect's
+ * `setFormResetKey`) whenever `baseAddressOptions` received a fresh array
+ * reference on every render. That happened when the parent passed a content-equal
+ * but new-reference `shippingAddressSnapshot` object (exactly what happens after a
+ * customer/address is added to the order), because the snapshot memos churned.
+ *
+ * The dialog must treat content-equal snapshots as referentially stable so the
+ * on-open bootstrap effect (which bumps `formResetKey` and remounts the form) does
+ * NOT re-fire on every render.
+ */
+import * as React from 'react'
+import { act, render } from '@testing-library/react'
+import { ShipmentDialog } from '../ShipmentDialog'
+
+jest.setTimeout(20000)
+
+let crudFormMountCount = 0
+
+const mockApiCall = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: any[]) => mockApiCall(...args),
+  withScopedApiRequestHeaders: async (_headers: any, fn: any) => fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  createCrud: jest.fn().mockResolvedValue({ ok: true }),
+  updateCrud: jest.fn().mockResolvedValue({ ok: true }),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/customFieldValues', () => ({
+  collectCustomFieldValues: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/serverErrors', () => ({
+  createCrudFormError: (message: string) => new Error(message),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('../optimisticLock', () => ({
+  handleSectionMutationError: jest.fn(),
+  rowOptimisticVersion: () => undefined,
+}))
+
+jest.mock('@open-mercato/core/modules/sales/lib/frontend/documentTotalsEvents', () => ({
+  emitSalesDocumentTotalsRefresh: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/hooks/useDialogKeyHandler', () => ({
+  useDialogKeyHandler: () => () => {},
+}))
+
+jest.mock('lucide-react', () => ({
+  MapPin: () => null,
+  Truck: () => null,
+}))
+
+jest.mock('@open-mercato/ui/primitives/dialog', () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <h3>{children}</h3>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}))
+
+jest.mock('@open-mercato/ui/primitives/textarea', () => ({
+  Textarea: (props: any) => <textarea {...props} />,
+}))
+
+jest.mock('@open-mercato/ui/primitives/label', () => ({
+  Label: ({ children, ...props }: any) => <label {...props}>{children}</label>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/switch', () => ({
+  Switch: ({ checked, onCheckedChange, ...props }: any) => (
+    <input
+      type="checkbox"
+      checked={!!checked}
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+      {...props}
+    />
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/inputs', () => ({
+  LookupSelect: ({ value, onChange }: any) => (
+    <select value={value ?? ''} onChange={(event) => onChange?.(event.target.value || null)}>
+      <option value="">Select</option>
+    </select>
+  ),
+}))
+
+// CrudForm receives `key={formResetKey}` from ShipmentDialog, so every time the
+// dialog bumps `formResetKey` (which happens inside the address-bootstrapping
+// effect) this mock unmounts and remounts, incrementing the counter. A stable
+// dialog must NOT remount the form when only the snapshot *reference* changes.
+// The tripwire converts a re-introduced infinite loop into a fast, clear failure
+// instead of an out-of-memory crash.
+jest.mock('@open-mercato/ui/backend/CrudForm', () => {
+  const ReactLib = require('react')
+  return {
+    CrudForm: ({ fields = [] }: any) => {
+      ReactLib.useEffect(() => {
+        crudFormMountCount += 1
+        if (crudFormMountCount > 50) {
+          throw new Error('[test] ShipmentDialog bootstrap effect re-render loop detected')
+        }
+      }, [])
+      return (
+        <form>
+          {fields.map((field: any) => (
+            <div key={field.id ?? field.name} data-testid={`crud-field-${field.id ?? field.name}`} />
+          ))}
+        </form>
+      )
+    },
+  }
+})
+
+// Stable translator reference (mirrors the production I18nProvider, whose `t` is
+// memoized on [locale, dict]) so the test isolates the snapshot-reference bug.
+const translate = (key: string, fallback?: unknown) =>
+  typeof fallback === 'string' ? fallback : key
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => translate,
+}))
+
+const baseLines = [
+  { id: 'line-1', title: 'Product A', lineNumber: 1, quantity: 2, thumbnail: null },
+]
+
+const computeAvailable = () => 5
+const noop = () => {}
+const noopAsync = async () => {}
+
+// Content-equal snapshot, but a brand-new object reference on every call —
+// simulating an unmemoized prop handed down by the order detail page.
+const makeSnapshot = () => ({
+  addressLine1: '1 Main Street',
+  city: 'Townsville',
+  postalCode: '12345',
+  country: 'US',
+})
+
+const renderDialog = () => (
+  <ShipmentDialog
+    open
+    mode="create"
+    shipment={null}
+    lines={baseLines}
+    orderId="order-1"
+    currencyCode="USD"
+    organizationId="org-1"
+    tenantId="tenant-1"
+    computeAvailable={computeAvailable}
+    shippingAddressSnapshot={makeSnapshot()}
+    onClose={noop}
+    onSaved={noopAsync}
+  />
+)
+
+describe('ShipmentDialog re-render stability (issue #3529)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    crudFormMountCount = 0
+    mockApiCall.mockResolvedValue({ ok: true, result: { items: [] } })
+  })
+
+  it('does not remount the form when the snapshot reference changes but content does not', async () => {
+    const { rerender } = render(renderDialog())
+
+    // Let the on-open async loaders (shipping methods, addresses, statuses) settle.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const baselineMounts = crudFormMountCount
+
+    // Simulate the parent re-rendering repeatedly, each time handing the dialog a
+    // brand-new snapshot object that is content-equal to the previous one.
+    for (let pass = 0; pass < 4; pass += 1) {
+      rerender(renderDialog())
+      await act(async () => {
+        await Promise.resolve()
+      })
+    }
+
+    // Before the fix, each content-equal rerender re-ran the bootstrap effect and
+    // bumped `formResetKey`, remounting the form once per pass. With stable
+    // `baseAddressOptions`, none of those rerenders should remount the form.
+    expect(crudFormMountCount).toBe(baselineMounts)
+  })
+})


### PR DESCRIPTION
Fixes #3529

## Problem
Opening the **Add Shipment** dialog on a sales order with no customer address (or a customer with no stored addresses) crashed the dialog with `Maximum update depth exceeded`, originating from `ShipmentDialog.tsx` (the `setFormResetKey` bootstrap effect). The dialog became unusable.

## Root Cause
Two effects in `ShipmentDialog` depended on the `baseAddressOptions` array **reference**:
- the on-open bootstrap effect (bumps `formResetKey`, resets + reloads addresses), and
- the address-merge effect (`mergeAddressOptions(baseAddressOptions)`).

`baseAddressOptions` is `useMemo`-derived, but its memo inputs (the normalized shipping/shipment **snapshot** values, ultimately driven by props) churn to new object references whenever the parent re-renders and hands the dialog a content-equal but new-reference `shippingAddressSnapshot` — exactly what happens right after a customer/address is added to the order. A new reference each render re-fired both effects → `setState` → re-render → new reference → infinite loop. `mergeAddressOptions` made it worse by always allocating a fresh array via `dedupeAddressOptions`, so even a no-op merge forced a re-render.

## What Changed
`packages/core/src/modules/sales/components/documents/ShipmentDialog.tsx`:
- Added a small `useStableAddressOptions` hook that keeps `baseAddressOptions` referentially stable across renders, keyed by a **content signature** (snapshot key + id). The effects now only re-run when the actual set of addresses changes, not on every reference churn.
- Made `mergeAddressOptions` idempotent: it returns the previous state (same reference) when no new option is added, so React bails out instead of re-rendering.

Both are minimal, internal-to-the-component changes — no props, exports, types, events, routes, or other contract surfaces changed.

## Tests
- New `ShipmentDialog.reRenderLoop.test.tsx` reproduces the bug: rendering the dialog and re-rendering the parent with content-equal but new-reference snapshots remounted the form on every pass (and, with an unstable translator, reproduced the literal `Maximum update depth exceeded` crash). The test asserts the bootstrap effect no longer re-fires (the form is not remounted). It **fails before the fix and passes after**, and includes a tripwire so a re-introduced loop fails fast instead of OOMing CI.
- Full sales module suite: 48 suites / 334 tests pass.
- `tsc --noEmit` (after `generate`): clean. `eslint`: no errors. `build:packages` + `generate`: clean.

## Backward Compatibility
No contract surface changes — the fix is internal to the `ShipmentDialog` component.