### PR TITLE
fix(record_locks): defer OSS optimistic-lock 409 to conflict bar, not merge dialog (#3504)

### DIFF
--- a/packages/enterprise/src/modules/record_locks/__tests__/conflictSurface.test.ts
+++ b/packages/enterprise/src/modules/record_locks/__tests__/conflictSurface.test.ts
@@ -1,0 +1,79 @@
+import { isOssOptimisticLockConflict } from '../lib/conflictSurface'
+import { OPTIMISTIC_LOCK_CONFLICT_CODE } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+
+/**
+ * Regression guard for issue #3504: on the standard makeCrudRoute / CrudForm
+ * save path a concurrent-edit 409 is an OSS optimistic-lock conflict, already
+ * surfaced on the shared OSS conflict bar. The record-lock widget must NOT also
+ * open its merge dialog for that 409 (single-surface invariant S3). It decides
+ * via `isOssOptimisticLockConflict`, which must be true only for OSS
+ * optimistic-lock conflicts and false for genuine record-lock conflicts.
+ */
+describe('isOssOptimisticLockConflict', () => {
+  it('is true for an OSS optimistic-lock 409 with a nested body (CrudForm shape)', () => {
+    expect(
+      isOssOptimisticLockConflict({
+        status: 409,
+        body: {
+          error: 'record_modified',
+          code: OPTIMISTIC_LOCK_CONFLICT_CODE,
+          currentUpdatedAt: '2026-06-24T10:00:01.000Z',
+          expectedUpdatedAt: '2026-06-24T10:00:00.000Z',
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('is true for an OSS optimistic-lock 409 with fields attached directly to the error', () => {
+    expect(
+      isOssOptimisticLockConflict({
+        status: 409,
+        error: 'record_modified',
+        code: OPTIMISTIC_LOCK_CONFLICT_CODE,
+        currentUpdatedAt: '2026-06-24T10:00:01.000Z',
+        expectedUpdatedAt: '2026-06-24T10:00:00.000Z',
+      }),
+    ).toBe(true)
+  })
+
+  it('is false for a genuine record-lock conflict 409 (merge dialog owns it)', () => {
+    expect(
+      isOssOptimisticLockConflict({
+        status: 409,
+        body: {
+          error: 'record_lock_conflict',
+          code: 'record_lock_conflict',
+          conflictId: 'a0000000-0000-4000-8000-000000000001',
+          resourceKind: 'catalog.product',
+          resourceId: 'b0000000-0000-4000-8000-000000000001',
+          resolutionOptions: ['accept_mine'],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('is false for a 409 carrying lock markers but no optimistic-lock code', () => {
+    expect(
+      isOssOptimisticLockConflict({
+        status: 409,
+        body: {
+          conflict: { id: 'c0000000-0000-4000-8000-000000000001' },
+          resourceKind: 'customers.company',
+          resourceId: 'd0000000-0000-4000-8000-000000000001',
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('is false for non-409 errors and non-object inputs', () => {
+    expect(
+      isOssOptimisticLockConflict({
+        status: 422,
+        body: { error: 'validation_failed', code: OPTIMISTIC_LOCK_CONFLICT_CODE },
+      }),
+    ).toBe(false)
+    expect(isOssOptimisticLockConflict(null)).toBe(false)
+    expect(isOssOptimisticLockConflict(undefined)).toBe(false)
+    expect(isOssOptimisticLockConflict('boom')).toBe(false)
+  })
+})

--- a/packages/enterprise/src/modules/record_locks/__tests__/conflictSurface.test.ts
+++ b/packages/enterprise/src/modules/record_locks/__tests__/conflictSurface.test.ts
@@ -1,4 +1,8 @@
-import { isOssOptimisticLockConflict } from '../lib/conflictSurface'
+import {
+  decideCrudSaveErrorAction,
+  isOssOptimisticLockConflict,
+  type CrudSaveErrorDecisionInput,
+} from '../lib/conflictSurface'
 import { OPTIMISTIC_LOCK_CONFLICT_CODE } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
 
 /**
@@ -75,5 +79,121 @@ describe('isOssOptimisticLockConflict', () => {
     expect(isOssOptimisticLockConflict(null)).toBe(false)
     expect(isOssOptimisticLockConflict(undefined)).toBe(false)
     expect(isOssOptimisticLockConflict('boom')).toBe(false)
+  })
+})
+
+/**
+ * Wiring guard for issue #3504: the predicate test above proves classification,
+ * but the actual bug lived in the widget's `onCrudSaveError` listener — which
+ * surface it drives for a save error. That decision is extracted to
+ * `decideCrudSaveErrorAction`; these cases lock in that an OSS optimistic-lock
+ * 409 defers to the shared conflict bar (never opens the merge dialog), while
+ * genuine record-lock conflicts and other 409s keep their prior behavior.
+ */
+describe('decideCrudSaveErrorAction', () => {
+  const ossOptimisticLock409 = {
+    status: 409,
+    body: {
+      error: 'record_modified',
+      code: OPTIMISTIC_LOCK_CONFLICT_CODE,
+      currentUpdatedAt: '2026-06-24T10:00:01.000Z',
+      expectedUpdatedAt: '2026-06-24T10:00:00.000Z',
+    },
+  }
+
+  const baseInput: CrudSaveErrorDecisionInput = {
+    error: { status: 409 },
+    eventTargetsCurrentForm: true,
+    hasRecordLockPayload: false,
+    payloadResourceKind: null,
+    payloadResourceId: null,
+    currentResourceKind: 'catalog.product',
+    currentResourceId: 'b0000000-0000-4000-8000-000000000001',
+    isRecordDeleted: false,
+    errorStatus: 409,
+  }
+
+  it('defers an OSS optimistic-lock 409 to the shared conflict bar (does NOT open the merge dialog)', () => {
+    expect(
+      decideCrudSaveErrorAction({
+        ...baseInput,
+        error: ossOptimisticLock409,
+        errorStatus: 409,
+      }),
+    ).toBe('defer-to-oss-conflict-bar')
+  })
+
+  it('opens the fallback merge dialog for a 409 that is not an OSS optimistic-lock conflict', () => {
+    expect(
+      decideCrudSaveErrorAction({
+        ...baseInput,
+        error: { status: 409, body: { error: 'conflict' } },
+        errorStatus: 409,
+      }),
+    ).toBe('open-fallback-dialog')
+  })
+
+  it('applies the record-lock payload when one is present (merge dialog owns it)', () => {
+    expect(
+      decideCrudSaveErrorAction({
+        ...baseInput,
+        hasRecordLockPayload: true,
+        payloadResourceKind: 'catalog.product',
+        payloadResourceId: 'b0000000-0000-4000-8000-000000000001',
+      }),
+    ).toBe('apply-record-lock-payload')
+  })
+
+  it('reports record-deleted before considering any 409 surface', () => {
+    expect(
+      decideCrudSaveErrorAction({
+        ...baseInput,
+        isRecordDeleted: true,
+      }),
+    ).toBe('record-deleted')
+  })
+
+  it('ignores a non-409 error without a record-lock payload', () => {
+    expect(
+      decideCrudSaveErrorAction({
+        ...baseInput,
+        error: { status: 422 },
+        errorStatus: 422,
+      }),
+    ).toBe('ignore')
+  })
+
+  it('ignores when the current form has no record identity', () => {
+    expect(
+      decideCrudSaveErrorAction({
+        ...baseInput,
+        currentResourceKind: null,
+        currentResourceId: null,
+      }),
+    ).toBe('ignore')
+  })
+
+  it('ignores an event targeting a different form whose payload does not match this record', () => {
+    expect(
+      decideCrudSaveErrorAction({
+        ...baseInput,
+        eventTargetsCurrentForm: false,
+        hasRecordLockPayload: true,
+        payloadResourceKind: 'customers.company',
+        payloadResourceId: 'd0000000-0000-4000-8000-000000000002',
+      }),
+    ).toBe('ignore')
+  })
+
+  it('applies a cross-form record-lock payload that matches this record', () => {
+    expect(
+      decideCrudSaveErrorAction({
+        ...baseInput,
+        eventTargetsCurrentForm: false,
+        hasRecordLockPayload: true,
+        payloadResourceKind: 'catalog.product',
+        payloadResourceId: 'b0000000-0000-4000-8000-000000000001',
+      }),
+    ).toBe('apply-record-lock-payload')
   })
 })

--- a/packages/enterprise/src/modules/record_locks/lib/conflictSurface.ts
+++ b/packages/enterprise/src/modules/record_locks/lib/conflictSurface.ts
@@ -15,3 +15,69 @@ import { extractOptimisticLockConflict } from '@open-mercato/ui/backend/utils/op
 export function isOssOptimisticLockConflict(error: unknown): boolean {
   return extractOptimisticLockConflict(error) !== null
 }
+
+/**
+ * Surface the record-lock widget's `onCrudSaveError` listener should drive for a
+ * given save error:
+ * - `ignore` — not relevant to this widget instance (wrong form, no record
+ *   identity, or a non-conflict error).
+ * - `record-deleted` — the record was deleted underneath the editor.
+ * - `open-fallback-dialog` — open the merge dialog with a synthesized conflict.
+ * - `defer-to-oss-conflict-bar` — an OSS optimistic-lock 409 the shared conflict
+ *   bar already owns; the widget must NOT open a second surface (#3504 / S3).
+ * - `apply-record-lock-payload` — a genuine `record_lock_conflict` payload to render.
+ */
+export type CrudSaveErrorSurfaceAction =
+  | 'ignore'
+  | 'record-deleted'
+  | 'open-fallback-dialog'
+  | 'defer-to-oss-conflict-bar'
+  | 'apply-record-lock-payload'
+
+export type CrudSaveErrorDecisionInput = {
+  error: unknown
+  eventTargetsCurrentForm: boolean
+  hasRecordLockPayload: boolean
+  payloadResourceKind?: string | null
+  payloadResourceId?: string | null
+  currentResourceKind?: string | null
+  currentResourceId?: string | null
+  isRecordDeleted: boolean
+  errorStatus: number | null
+}
+
+/**
+ * Pure decision for the record-lock widget's `onCrudSaveError` listener. Extracted
+ * from `widget.client.tsx` so the surface-arbitration wiring is unit-testable
+ * without rendering the client component — in particular the #3504 invariant that
+ * an OSS optimistic-lock 409 defers to the shared conflict bar instead of opening
+ * a second, degraded merge dialog.
+ */
+export function decideCrudSaveErrorAction(
+  input: CrudSaveErrorDecisionInput,
+): CrudSaveErrorSurfaceAction {
+  const hasCurrentIdentity = Boolean(input.currentResourceKind) && Boolean(input.currentResourceId)
+
+  if (!input.eventTargetsCurrentForm) {
+    if (!input.hasRecordLockPayload || !hasCurrentIdentity) return 'ignore'
+    const payloadResourceKind = (input.payloadResourceKind ?? '').trim()
+    const payloadResourceId = (input.payloadResourceId ?? '').trim()
+    if (!payloadResourceKind || !payloadResourceId) return 'ignore'
+    if (payloadResourceKind !== input.currentResourceKind || payloadResourceId !== input.currentResourceId) {
+      return 'ignore'
+    }
+  }
+
+  if (!input.hasRecordLockPayload) {
+    if (!hasCurrentIdentity) return 'ignore'
+    if (input.isRecordDeleted) return 'record-deleted'
+    if (input.errorStatus === 409) {
+      return isOssOptimisticLockConflict(input.error)
+        ? 'defer-to-oss-conflict-bar'
+        : 'open-fallback-dialog'
+    }
+    return 'ignore'
+  }
+
+  return 'apply-record-lock-payload'
+}

--- a/packages/enterprise/src/modules/record_locks/lib/conflictSurface.ts
+++ b/packages/enterprise/src/modules/record_locks/lib/conflictSurface.ts
@@ -1,0 +1,17 @@
+import { extractOptimisticLockConflict } from '@open-mercato/ui/backend/utils/optimisticLock'
+
+/**
+ * True when `error` is an OSS optimistic-lock conflict (HTTP 409 with
+ * `code: 'optimistic_lock_conflict'`) — the conflict shape the shared OSS
+ * conflict bar (`surfaceRecordConflict`) already owns on the standard
+ * `makeCrudRoute` / `CrudForm` save path.
+ *
+ * The record-lock widget consults this before opening its fallback merge
+ * dialog: it must defer to the OSS bar for these 409s rather than render a
+ * second, degraded conflict surface, which would violate the single-surface
+ * invariant (issue #3504 / S3). The merge dialog stays reserved for genuine
+ * `record_lock_conflict` 409s.
+ */
+export function isOssOptimisticLockConflict(error: unknown): boolean {
+  return extractOptimisticLockConflict(error) !== null
+}

--- a/packages/enterprise/src/modules/record_locks/widgets/injection/record-locking/widget.client.tsx
+++ b/packages/enterprise/src/modules/record_locks/widgets/injection/record-locking/widget.client.tsx
@@ -31,7 +31,7 @@ import {
   type RecordLockUiConflict,
   type RecordLockUiView,
 } from '@open-mercato/enterprise/modules/record_locks/lib/clientLockStore'
-import { isOssOptimisticLockConflict } from '@open-mercato/enterprise/modules/record_locks/lib/conflictSurface'
+import { decideCrudSaveErrorAction } from '@open-mercato/enterprise/modules/record_locks/lib/conflictSurface'
 
 type CrudInjectionContext = {
   formId?: string
@@ -1025,19 +1025,28 @@ export default function RecordLockingWidget({
       const detail = (event as CustomEvent<CrudSaveErrorEventDetail>).detail
       if (!detail) return
       const eventContextId = detail.contextId ?? detail.formId
-      let payload = extractRecordLockConflictPayload(detail.error)
+      const payload = extractRecordLockConflictPayload(detail.error)
       const currentState = getRecordLockFormState(formId)
       const eventTargetsCurrentForm = !eventContextId || eventContextId === formId
-      if (!eventTargetsCurrentForm) {
-        if (!payload || !currentState?.resourceKind || !currentState?.resourceId) return
-        const payloadResourceKind = payload.conflict.resourceKind?.trim() ?? ''
-        const payloadResourceId = payload.conflict.resourceId?.trim() ?? ''
-        if (!payloadResourceKind || !payloadResourceId) return
-        if (payloadResourceKind !== currentState.resourceKind || payloadResourceId !== currentState.resourceId) return
-      }
-        if (!payload) {
-        if (!currentState?.resourceKind || !currentState?.resourceId) return
-        if (isRecordDeletedError(detail.error)) {
+
+      // Single-surface arbitration (issue #3504 / S3). Decision is extracted to a
+      // pure, unit-tested helper so the wiring — especially deferring OSS
+      // optimistic-lock 409s to the shared conflict bar instead of opening a
+      // second, degraded merge dialog — is covered without rendering the widget.
+      const action = decideCrudSaveErrorAction({
+        error: detail.error,
+        eventTargetsCurrentForm,
+        hasRecordLockPayload: payload !== null,
+        payloadResourceKind: payload?.conflict.resourceKind ?? null,
+        payloadResourceId: payload?.conflict.resourceId ?? null,
+        currentResourceKind: currentState?.resourceKind ?? null,
+        currentResourceId: currentState?.resourceId ?? null,
+        isRecordDeleted: isRecordDeletedError(detail.error),
+        errorStatus: extractErrorStatus(detail.error),
+      })
+
+      switch (action) {
+        case 'record-deleted':
           setIsConflictDialogOpen(true)
           setRecordLockFormState(formId, {
             recordDeleted: true,
@@ -1049,20 +1058,17 @@ export default function RecordLockingWidget({
             pendingResolutionArmed: false,
           })
           return
-        }
-        // Defer to the shared OSS conflict bar for optimistic-lock 409s: the
-        // merge dialog cannot resolve them and rendering both surfaces at once
-        // violates the single-surface invariant (issue #3504 / S3).
-        if (
-          extractErrorStatus(detail.error) === 409
-          && !isOssOptimisticLockConflict(detail.error)
-        ) {
-          applyConflictPayload(buildFallbackConflict(currentState))
-        }
-        return
+        case 'open-fallback-dialog':
+          if (currentState) applyConflictPayload(buildFallbackConflict(currentState))
+          return
+        case 'apply-record-lock-payload':
+          if (payload) applyConflictPayload(payload)
+          return
+        case 'defer-to-oss-conflict-bar':
+        case 'ignore':
+        default:
+          return
       }
-
-      applyConflictPayload(payload)
     }
 
     window.addEventListener(BACKEND_MUTATION_ERROR_EVENT, onCrudSaveError)

--- a/packages/enterprise/src/modules/record_locks/widgets/injection/record-locking/widget.client.tsx
+++ b/packages/enterprise/src/modules/record_locks/widgets/injection/record-locking/widget.client.tsx
@@ -31,6 +31,7 @@ import {
   type RecordLockUiConflict,
   type RecordLockUiView,
 } from '@open-mercato/enterprise/modules/record_locks/lib/clientLockStore'
+import { isOssOptimisticLockConflict } from '@open-mercato/enterprise/modules/record_locks/lib/conflictSurface'
 
 type CrudInjectionContext = {
   formId?: string
@@ -1049,7 +1050,13 @@ export default function RecordLockingWidget({
           })
           return
         }
-        if (extractErrorStatus(detail.error) === 409) {
+        // Defer to the shared OSS conflict bar for optimistic-lock 409s: the
+        // merge dialog cannot resolve them and rendering both surfaces at once
+        // violates the single-surface invariant (issue #3504 / S3).
+        if (
+          extractErrorStatus(detail.error) === 409
+          && !isOssOptimisticLockConflict(detail.error)
+        ) {
           applyConflictPayload(buildFallbackConflict(currentState))
         }
         return


### PR DESCRIPTION
Fixes #3504

## Problem
With enterprise `record_locks` enabled, a concurrent-edit **409 on a standard `makeCrudRoute` / `CrudForm` screen rendered TWO conflict surfaces at once** — the OSS conflict bar (`record-conflict-banner`) **and** the enterprise merge dialog (`record-lock-conflict-dialog`). This violates the single-conflict-surface invariant (S3, "never both, never swallowed"). While both were up, the dialog's modal overlay intercepted pointer events and blocked the OSS bar's "Odśwież/Refresh" — the only working recovery control. Reproduced on catalog product and CRM v2 company edit, role-independently and cross-user.

## Root Cause
The raw 409 from the CRUD path is the **OSS** shape (`code: 'optimistic_lock_conflict'`), not the enterprise `record_lock_conflict` shape. Two independent client paths then both fired:

- `surfaceRecordConflict` (CrudForm) detected the OSS conflict via `extractOptimisticLockConflict` and rendered the **OSS bar**.
- The record-lock widget's `onCrudSaveError` listener opened its **merge dialog on _any_ 409** for the mounted record (`buildFallbackConflict`), even though `extractRecordLockConflictPayload` returned `null` (i.e. it is NOT a record-lock conflict).

So the documented single-surface (S3) handshake held only for `record_lock_conflict`-coded 409s; on the OSS-floor 409 that `makeCrudRoute` actually returns, the listener's "fallback dialog on any 409" defeated it.

## What Changed
- Added `isOssOptimisticLockConflict(error)` (`packages/enterprise/src/modules/record_locks/lib/conflictSurface.ts`) — a pure, React-free predicate that reuses the canonical OSS detector `extractOptimisticLockConflict`.
- Gated the widget's fallback merge-dialog branch on it (`widget.client.tsx`): the widget now **defers to the OSS bar** for optimistic-lock 409s instead of opening a second, degraded surface. The merge dialog stays reserved for genuine `record_lock_conflict` 409s.

The error object the widget receives is the *same* object CrudForm passes to `extractOptimisticLockConflict`, so the widget defers exactly when the OSS bar will own the conflict — a robust, well-coupled handshake that restores the single-surface invariant on the broad CrudForm path.

> Out of scope (filed separately per the issue): the merge dialog being degraded / "Accept incoming" being a no-op on this path.

## Tests
- New unit guard `packages/enterprise/src/modules/record_locks/__tests__/conflictSurface.test.ts` — asserts `isOssOptimisticLockConflict` is true only for OSS optimistic-lock 409s (nested-body and flat shapes) and false for genuine record-lock conflicts, lock-marker 409s, non-409s and non-objects. This is the surface-arbitration guard the existing `optimistic-lock-ui-coverage` test could not catch (it asserts header-sending, not surface count).
- **Wiring guard (follow-up):** the predicate test alone could not catch a regression that dropped the defer branch in the widget. Extracted the `onCrudSaveError` surface decision into a pure `decideCrudSaveErrorAction` (`lib/conflictSurface.ts`, behavior-preserving) and added 8 cases asserting the actual listener wiring — including OSS optimistic-lock 409 → `defer-to-oss-conflict-bar` (merge dialog stays closed), genuine `record_lock_conflict` → apply, non-opt-lock 409 → fallback dialog, record-deleted, cross-form match/mismatch, and missing record identity.
- `yarn workspace @open-mercato/enterprise test` → 48 suites / 413 tests pass (incl. the new guards).
- `yarn build:packages` + `yarn generate` → OK; enterprise `tsc --noEmit` → clean.
- `eslint` on changed files → 0 errors.

## Backward Compatibility
No contract surface changes. Net-additive: one new internal helper file and a narrowed internal `if`-condition. No event IDs, widget spot IDs, ACL IDs, DI keys, API routes, response fields, import paths, or DB schema touched.

