### PR TITLE
fix(record_locks): Accept incoming resolves OSS-floor 409 instead of dead-ending (#3505)

### DIFF
--- a/packages/enterprise/src/modules/record_locks/__tests__/recordLockAcceptIncoming.test.ts
+++ b/packages/enterprise/src/modules/record_locks/__tests__/recordLockAcceptIncoming.test.ts
@@ -1,0 +1,133 @@
+import type { RecordLockUiConflict } from '@open-mercato/enterprise/modules/record_locks/lib/clientLockStore'
+import {
+  isUuid,
+  resolveConflictId,
+  runAcceptIncoming,
+  type AcceptIncomingFlow,
+} from '../widgets/injection/record-locking/conflictResolution'
+
+const RESOURCE_KIND = 'catalog.product'
+const RESOURCE_ID = 'b0000000-0000-4000-8000-000000000001'
+const REAL_CONFLICT_ID = 'a0000000-0000-4000-8000-000000000001'
+
+function degradedConflict(): RecordLockUiConflict {
+  return {
+    id: 'unresolved',
+    resourceKind: RESOURCE_KIND,
+    resourceId: RESOURCE_ID,
+    baseActionLogId: null,
+    incomingActionLogId: null,
+    allowIncomingOverride: false,
+    canOverrideIncoming: false,
+    resolutionOptions: [],
+    changes: [],
+  }
+}
+
+function recordLockConflict(): RecordLockUiConflict {
+  return {
+    ...degradedConflict(),
+    id: REAL_CONFLICT_ID,
+    allowIncomingOverride: true,
+    canOverrideIncoming: true,
+    resolutionOptions: ['accept_mine'],
+  }
+}
+
+function makeFlow(overrides: Partial<AcceptIncomingFlow> = {}): {
+  flow: AcceptIncomingFlow
+  calls: string[]
+  released: string[]
+} {
+  const calls: string[] = []
+  const released: string[] = []
+  const flow: AcceptIncomingFlow = {
+    conflict: degradedConflict(),
+    resourceKind: RESOURCE_KIND,
+    resourceId: RESOURCE_ID,
+    revalidateConflictId: async () => {
+      calls.push('revalidate')
+      return null
+    },
+    releaseIncoming: async (conflictId) => {
+      calls.push('release')
+      released.push(conflictId)
+    },
+    clearConflictState: () => {
+      calls.push('clear')
+    },
+    reload: () => {
+      calls.push('reload')
+    },
+    ...overrides,
+  }
+  return { flow, calls, released }
+}
+
+describe('isUuid / resolveConflictId', () => {
+  test('rejects the degraded fallback conflict id', () => {
+    expect(isUuid('unresolved')).toBe(false)
+    expect(resolveConflictId(degradedConflict())).toBeNull()
+  })
+
+  test('accepts a genuine record-lock conflict id', () => {
+    expect(isUuid(REAL_CONFLICT_ID)).toBe(true)
+    expect(resolveConflictId(recordLockConflict())).toBe(REAL_CONFLICT_ID)
+  })
+
+  test('treats null/undefined conflicts as unresolvable', () => {
+    expect(resolveConflictId(null)).toBeNull()
+    expect(resolveConflictId(undefined)).toBeNull()
+  })
+})
+
+describe('runAcceptIncoming', () => {
+  test('resolves a degraded OSS-floor 409 by reloading without a record-lock release (regression for #3505)', async () => {
+    const { flow, calls, released } = makeFlow()
+
+    const outcome = await runAcceptIncoming(flow)
+
+    expect(outcome).toBe('reloaded')
+    expect(released).toHaveLength(0)
+    expect(calls).toContain('clear')
+    expect(calls).toContain('reload')
+    // The action must never dead-end: state is cleared and the page reloads to load the incoming record.
+    expect(calls[calls.length - 1]).toBe('reload')
+  })
+
+  test('releases a genuine record-lock conflict before reloading', async () => {
+    const { flow, calls, released } = makeFlow({ conflict: recordLockConflict() })
+
+    const outcome = await runAcceptIncoming(flow)
+
+    expect(outcome).toBe('released')
+    expect(released).toEqual([REAL_CONFLICT_ID])
+    expect(calls).toEqual(['release', 'clear', 'reload'])
+  })
+
+  test('recovers a conflict id via revalidation when the local id is degraded', async () => {
+    const { flow, calls, released } = makeFlow({
+      revalidateConflictId: async () => {
+        calls.push('revalidate')
+        return REAL_CONFLICT_ID
+      },
+    })
+
+    const outcome = await runAcceptIncoming(flow)
+
+    expect(outcome).toBe('released')
+    expect(released).toEqual([REAL_CONFLICT_ID])
+    expect(calls).toEqual(['revalidate', 'release', 'clear', 'reload'])
+  })
+
+  test('skips entirely when there is no conflict or resource context', async () => {
+    const { flow, calls } = makeFlow({ conflict: null })
+    expect(await runAcceptIncoming(flow)).toBe('skipped')
+
+    const missingResource = makeFlow({ resourceId: null })
+    expect(await runAcceptIncoming(missingResource.flow)).toBe('skipped')
+
+    expect(calls).toHaveLength(0)
+    expect(missingResource.calls).toHaveLength(0)
+  })
+})

--- a/packages/enterprise/src/modules/record_locks/widgets/injection/record-locking/conflictResolution.ts
+++ b/packages/enterprise/src/modules/record_locks/widgets/injection/record-locking/conflictResolution.ts
@@ -1,0 +1,43 @@
+import type { RecordLockUiConflict } from '@open-mercato/enterprise/modules/record_locks/lib/clientLockStore'
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export function isUuid(value: string | null | undefined): value is string {
+  if (typeof value !== 'string') return false
+  const trimmed = value.trim()
+  if (!trimmed) return false
+  return UUID_PATTERN.test(trimmed)
+}
+
+export function resolveConflictId(
+  conflict: Pick<RecordLockUiConflict, 'id'> | null | undefined,
+): string | null {
+  const id = conflict?.id
+  return isUuid(id) ? id : null
+}
+
+export type AcceptIncomingOutcome = 'released' | 'reloaded' | 'skipped'
+
+export type AcceptIncomingFlow = {
+  conflict: RecordLockUiConflict | null | undefined
+  resourceKind: string | null | undefined
+  resourceId: string | null | undefined
+  revalidateConflictId: () => Promise<string | null>
+  releaseIncoming: (conflictId: string) => Promise<void>
+  clearConflictState: () => void
+  reload: () => void
+}
+
+export async function runAcceptIncoming(flow: AcceptIncomingFlow): Promise<AcceptIncomingOutcome> {
+  if (!flow.conflict || !flow.resourceKind || !flow.resourceId) return 'skipped'
+  let conflictId = resolveConflictId(flow.conflict)
+  if (!conflictId) {
+    conflictId = await flow.revalidateConflictId()
+  }
+  if (conflictId) {
+    await flow.releaseIncoming(conflictId)
+  }
+  flow.clearConflictState()
+  flow.reload()
+  return conflictId ? 'released' : 'reloaded'
+}

--- a/packages/enterprise/src/modules/record_locks/widgets/injection/record-locking/widget.client.tsx
+++ b/packages/enterprise/src/modules/record_locks/widgets/injection/record-locking/widget.client.tsx
@@ -31,6 +31,7 @@ import {
   type RecordLockUiConflict,
   type RecordLockUiView,
 } from '@open-mercato/enterprise/modules/record_locks/lib/clientLockStore'
+import { isUuid, resolveConflictId, runAcceptIncoming } from './conflictResolution'
 
 type CrudInjectionContext = {
   formId?: string
@@ -117,13 +118,6 @@ function readStringOrNull(value: unknown): string | null {
   if (typeof value !== 'string') return null
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : null
-}
-
-function isUuid(value: string | null | undefined): value is string {
-  if (typeof value !== 'string') return false
-  const trimmed = value.trim()
-  if (!trimmed) return false
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(trimmed)
 }
 
 function extractErrorStatus(error: unknown): number | null {
@@ -1107,42 +1101,41 @@ export default function RecordLockingWidget({
 
   const handleAcceptIncoming = React.useCallback(async () => {
     keepMineRetryVersionRef.current += 1
-    if (!state?.conflict || !state?.resourceKind || !state?.resourceId) return
-    let conflictId: string | undefined = isUuid(state.conflict.id) ? state.conflict.id : undefined
-    if (!conflictId) {
-      const validation = await validateBeforeSave({}, context)
-      conflictId = isUuid(validation.conflict?.id) ? validation.conflict.id : undefined
-      if (!conflictId) {
-        flash(
-          t(
-            'record_locks.conflict.refresh_required',
-            'Could not confirm conflict details. Save again to refresh conflict data.',
-          ),
-          'error',
-        )
-        return
-      }
-    }
-    await apiCallOrThrow('/api/record_locks/release', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        resourceKind: state.resourceKind,
-        resourceId: state.resourceId,
-        token: state.lock?.token ?? undefined,
-        reason: 'conflict_resolved',
-        conflictId,
-        resolution: 'accept_incoming',
-      }),
+    await runAcceptIncoming({
+      conflict: state?.conflict,
+      resourceKind: state?.resourceKind,
+      resourceId: state?.resourceId,
+      revalidateConflictId: async () => {
+        const validation = await validateBeforeSave({}, context)
+        return resolveConflictId(validation.conflict)
+      },
+      releaseIncoming: async (conflictId) => {
+        await apiCallOrThrow('/api/record_locks/release', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            resourceKind: state?.resourceKind,
+            resourceId: state?.resourceId,
+            token: state?.lock?.token ?? undefined,
+            reason: 'conflict_resolved',
+            conflictId,
+            resolution: 'accept_incoming',
+          }),
+        })
+      },
+      clearConflictState: () => {
+        setRecordLockFormState(formId, {
+          conflict: null,
+          pendingConflictId: null,
+          pendingResolution: 'normal',
+          pendingResolutionArmed: false,
+        })
+      },
+      reload: () => {
+        window.location.reload()
+      },
     })
-    setRecordLockFormState(formId, {
-      conflict: null,
-      pendingConflictId: null,
-      pendingResolution: 'normal',
-      pendingResolutionArmed: false,
-    })
-    window.location.reload()
-  }, [context, formId, state?.conflict, state?.lock?.token, state?.resourceId, state?.resourceKind, t])
+  }, [context, formId, state?.conflict, state?.lock?.token, state?.resourceId, state?.resourceKind])
 
   const handleKeepMine = React.useCallback(() => {
     if (!state?.conflict) return


### PR DESCRIPTION
Fixes #3505

## Problem
With enterprise `record_locks` enabled, a save-time 409 raised on a `CrudForm` / `makeCrudRoute` screen surfaced a **degraded** merge dialog whose primary action did nothing: clicking **"Accept incoming"** left the dialog open, the OSS conflict bar up, and the stale field value in place — no network call, no resolution.

## Root Cause
The CrudForm save-time 409 carries the **OSS optimistic-lock shape** (`{"code":"optimistic_lock_conflict", "currentUpdatedAt", "expectedUpdatedAt"}`) with no lock/conflict markers. `extractRecordLockConflictPayload` returns `null` for it, so `onCrudSaveError` builds a **fallback conflict** with `id: "unresolved"`, empty `changes`, and empty `resolutionOptions`.

`handleAcceptIncoming` then required a UUID `conflictId` to call `/api/record_locks/release` with `resolution: accept_incoming`. For an OSS-floor 409 there is **no record_locks conflict row** to resolve, so the id stays `"unresolved"`, re-validation also yields no UUID, and the handler dead-ended with an error flash + `return` — the conflict was never resolved.

## What Changed
- "Accept incoming" on a degraded conflict now means *discard my local edits and load the incoming record*: when no record_locks `conflictId` is resolvable, the handler **skips** the `release` call (there is no conflict row to resolve), clears conflict state, and reloads — which re-fetches the server (incoming) version and dismisses the dialog and OSS bar.
- Genuine record_locks conflicts (UUID id) are **unchanged**: they still `release` with `resolution=accept_incoming` before reloading.
- The flow was extracted into a small, dependency-light `conflictResolution.ts` helper (`isUuid`, `resolveConflictId`, `runAcceptIncoming`) so the behavior is unit-testable without rendering the client widget. The widget keeps its public surface (`validateBeforeSave`, default export) intact.

Scope note: this PR fixes the dialog's degraded/no-op action for #3505 specifically. The broader double-surface handshake tracked by #3504 is intentionally left untouched.

## Tests
- New `recordLockAcceptIncoming.test.ts` (7 cases): degraded OSS-floor 409 reloads **without** a release call (the regression), genuine UUID conflict releases then reloads, revalidation recovery, no-context skip, and predicate sanity for `isUuid`/`resolveConflictId`.
- Full `record_locks` unit suite green: 7 suites / 51 tests.
- Changed files typecheck clean (0 new errors vs baseline) and lint clean (0 errors).

## Backward Compatibility
- No contract-surface changes. No API response fields, event IDs, widget spot IDs, ACL IDs, DI names, routes, or DB schema touched. `conflictResolution.ts` is a new module-internal helper; `isUuid` moved into it but was never part of any public export.