### PR TITLE
security(auth): enforce target-tenant scope on auth.users.create (#3549)

### DIFF
--- a/packages/core/src/modules/auth/commands/__tests__/users.create-tenant-scope.test.ts
+++ b/packages/core/src/modules/auth/commands/__tests__/users.create-tenant-scope.test.ts
@@ -1,0 +1,147 @@
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    auth: {
+      user: 'auth:user',
+      role: 'auth:role',
+    },
+    directory: {
+      organization: 'directory:organization',
+    },
+  },
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/commands/helpers')
+  return {
+    ...actual,
+    emitCrudSideEffects: jest.fn(async () => {}),
+    emitCrudUndoSideEffects: jest.fn(async () => {}),
+    setCustomFieldsIfAny: jest.fn(async () => {}),
+  }
+})
+
+const mockFindOneWithDecryption = jest.fn()
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+  findWithDecryption: jest.fn(async () => []),
+}))
+
+import '@open-mercato/core/modules/auth/commands/users'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import type { CommandHandler, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+
+const tenantA = '11111111-1111-4111-8111-111111111111'
+const tenantB = '22222222-2222-4222-8222-222222222222'
+const orgInTenantB = '55555555-5555-4555-8555-555555555555'
+const orgInTenantA = '66666666-6666-4666-8666-666666666666'
+const newUserId = '77777777-7777-4777-8777-777777777777'
+
+type CreateOrmEntity = jest.Mock<Promise<Record<string, unknown>>, [{ entity: unknown; data: Record<string, unknown> }]>
+
+function makeCtx(opts: { isSuperAdmin?: boolean; tenantId?: string | null; systemActor?: boolean } = {}): {
+  ctx: CommandRuntimeContext
+  createOrmEntity: CreateOrmEntity
+} {
+  const em: Record<string, unknown> = {
+    fork: () => em,
+    findOne: async () => null,
+    find: async () => [],
+    count: async () => 0,
+    nativeDelete: async () => 0,
+    flush: async () => {},
+    begin: async () => {},
+    commit: async () => {},
+    rollback: async () => {},
+  }
+  const createOrmEntity: CreateOrmEntity = jest.fn(async ({ data }) => ({ id: newUserId, ...data }))
+  const dataEngine = {
+    createOrmEntity,
+    markOrmEntityChange: jest.fn(),
+  }
+  const container = {
+    resolve: (token: string) => {
+      if (token === 'em') return em
+      if (token === 'dataEngine') return dataEngine
+      if (token === 'rbacService') return { invalidateUserCache: async () => {} }
+      if (token === 'cache') return null
+      throw new Error(`Unexpected dependency: ${token}`)
+    },
+  }
+  const ctx = {
+    container: container as never,
+    auth: { sub: 'actor-1', tenantId: opts.tenantId === undefined ? tenantA : opts.tenantId, orgId: null, isSuperAdmin: opts.isSuperAdmin ?? false } as never,
+    organizationScope: null,
+    selectedOrganizationId: null,
+    organizationIds: null,
+    request: undefined as never,
+    systemActor: opts.systemActor,
+  }
+  return { ctx, createOrmEntity }
+}
+
+function getHandler<T = unknown>(id: string): CommandHandler<Record<string, unknown>, T> {
+  const handler = commandRegistry.get<Record<string, unknown>, unknown>(id) as CommandHandler<Record<string, unknown>, T>
+  expect(handler).toBeDefined()
+  return handler
+}
+
+function mockOrganizationInTenant(tenantId: string): void {
+  // 1st decryption read = Organization lookup; 2nd = duplicate-email check.
+  mockFindOneWithDecryption
+    .mockResolvedValueOnce({ id: tenantId === tenantB ? orgInTenantB : orgInTenantA, tenant: { id: tenantId } })
+    .mockResolvedValueOnce(null)
+}
+
+const createInput = (organizationId: string) => ({
+  email: 'x@evil.com',
+  password: 'P@ssw0rd!23',
+  organizationId,
+})
+
+beforeEach(() => {
+  mockFindOneWithDecryption.mockReset()
+})
+
+describe('auth.users.create tenant scope', () => {
+  test('rejects a non-superadmin creating a user in an organization that belongs to another tenant', async () => {
+    mockOrganizationInTenant(tenantB)
+    const { ctx, createOrmEntity } = makeCtx({ tenantId: tenantA })
+    const handler = getHandler('auth.users.create')
+
+    await expect(handler.execute(createInput(orgInTenantB), ctx)).rejects.toMatchObject({ status: 404 })
+    expect(createOrmEntity).not.toHaveBeenCalled()
+  })
+
+  test('allows a non-superadmin creating a user in an organization within their own tenant', async () => {
+    mockOrganizationInTenant(tenantA)
+    const { ctx, createOrmEntity } = makeCtx({ tenantId: tenantA })
+    const handler = getHandler('auth.users.create')
+
+    await expect(handler.execute(createInput(orgInTenantA), ctx)).resolves.toBeTruthy()
+    expect(createOrmEntity).toHaveBeenCalledTimes(1)
+  })
+
+  test('allows a superadmin creating a user cross-tenant', async () => {
+    mockOrganizationInTenant(tenantB)
+    const { ctx, createOrmEntity } = makeCtx({ isSuperAdmin: true, tenantId: tenantA })
+    const handler = getHandler('auth.users.create')
+
+    await expect(handler.execute(createInput(orgInTenantB), ctx)).resolves.toBeTruthy()
+    expect(createOrmEntity).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not tenant-scope a system actor', async () => {
+    mockOrganizationInTenant(tenantB)
+    const { ctx, createOrmEntity } = makeCtx({ systemActor: true, tenantId: tenantA })
+    const handler = getHandler('auth.users.create')
+
+    await expect(handler.execute(createInput(orgInTenantB), ctx)).resolves.toBeTruthy()
+    expect(createOrmEntity).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/auth/commands/users.ts
+++ b/packages/core/src/modules/auth/commands/users.ts
@@ -205,6 +205,7 @@ const createUserCommand: CommandHandler<Record<string, unknown>, CreateUserResul
     )
     if (!organization) throw new CrudHttpError(400, { error: 'Organization not found' })
     const tenantId = organization.tenant?.id ? String(organization.tenant.id) : null
+    assertTargetTenantInScope(resolveActorTenantScope(ctx), tenantId, 'Organization not found')
 
     const emailHash = computeEmailHash(parsed.email)
     // Email is unique per-tenant, not globally (see Migration20260610120000:


### PR DESCRIPTION
## Summary

`auth.users.create` lets a tenant-scoped administrator create a user account inside another tenant. The command derives the target `tenantId` from the `organizationId` in the request body and never verifies that the resulting tenant is within the acting administrator's scope — unlike the sibling update and delete commands, which already enforce this via `assertTargetTenantInScope`.

This adds the same one-line guard to `createUserCommand`, so a non-super-admin can no longer target an organization outside their tenant. Super admins and system actors are unaffected (`resolveActorTenantScope(...) === null`).

Root cause: an omission from #2612, which wired the check into update/delete but not create.

## Changes

* `packages/core/src/modules/auth/commands/users.ts`: in `createUserCommand`, after the target `tenantId` is resolved from the organization, enforce:

  ```ts
  assertTargetTenantInScope(
    resolveActorTenantScope(ctx),
    tenantId,
    'Organization not found',
  )
  ```

  A non-super-admin targeting a foreign-tenant organization now gets a `404`.

* `packages/core/src/modules/auth/commands/__tests__/users.create-tenant-scope.test.ts`: new regression test (4 cases) covering the scope boundary.

## Specification

**Does a spec exist for this feature/module?**

* [ ] Yes
* [ ] No (created a new spec)
* [x] N/A (minor change, no spec needed)

**Spec file path:** N/A — single-line authorization fix mirroring the existing update/delete guard from #2612; no contract surface change.

## Testing

* `yarn workspace @open-mercato/core test -- users.create-tenant-scope`

  **4/4 pass:**

  * non-super-admin blocked creating a user cross-tenant (`404`, `createOrmEntity` not called)
  * non-super-admin allowed within their own tenant
  * super admin allowed cross-tenant
  * system actor not tenant-scoped

* Confirmed the test fails without the fix (reproduces #3549: the user is created with the foreign `tenantId`) and passes with it.

* Regression — neighbouring auth tenant-ownership suites:

  ```bash
  yarn workspace @open-mercato/core test -- tenant-ownership-defense users.tenant-scoped-email users.invite
  ```

  **27/27 pass**, no regressions.

## Checklist

* [x] This pull request targets `develop`.
* [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
* [x] I updated documentation, locales, or generators if the change requires it. — N/A (no user-facing strings, docs, or generated files affected)
* [x] I added or adjusted tests that cover the change.
* [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Covered by a command-level regression test that deterministically exercises the guard; happy to add an API-level integration test for `POST /api/auth/users` if preferred.

## Design System Compliance

N/A — backend-only change, no UI touched.

## Linked Issues

Fixes #3549.
