### PR TITLE
fix(cli): provision pgvector in ephemeral integration Postgres

### DIFF
--- a/.ai/runs/2026-06-24-ephemeral-pgvector-extension.md
+++ b/.ai/runs/2026-06-24-ephemeral-pgvector-extension.md
@@ -48,9 +48,9 @@ docker-compose stacks that already use a pgvector-enabled image.
 
 ### Phase 1: Provision pgvector in the ephemeral DB
 
-- [ ] 1.1 Add an env-overridable `resolveEphemeralPostgresImage()` helper defaulting to a pgvector-enabled image
-- [ ] 1.2 Add an initdb SQL constant that creates `vector` + `pgcrypto`, and wire both into the GenericContainer start
-- [ ] 1.3 Add unit tests for the image resolver (default + override) and the init SQL contents
+- [x] 1.1 Add an env-overridable `resolveEphemeralPostgresImage()` helper defaulting to a pgvector-enabled image — 4c0168e65
+- [x] 1.2 Add an initdb SQL constant that creates `vector` + `pgcrypto`, and wire both into the GenericContainer start — 4c0168e65
+- [x] 1.3 Add unit tests for the image resolver (default + override) and the init SQL contents — 4c0168e65
 
 ### Phase 2: Validation
 

--- a/.ai/runs/2026-06-24-ephemeral-pgvector-extension.md
+++ b/.ai/runs/2026-06-24-ephemeral-pgvector-extension.md
@@ -54,5 +54,5 @@ docker-compose stacks that already use a pgvector-enabled image.
 
 ### Phase 2: Validation
 
-- [ ] 2.1 Run targeted CLI unit tests + typecheck for changed package
-- [ ] 2.2 Full validation gate and self-review
+- [x] 2.1 Run targeted CLI unit tests + typecheck for changed package — typecheck 21/21, cli tests 987 pass
+- [x] 2.2 Full validation gate and self-review — build:packages + generate + typecheck + cli tests + eslint green; build:app/full-test scoped out (CLI test-runner-only change)

--- a/.ai/runs/2026-06-24-ephemeral-pgvector-extension.md
+++ b/.ai/runs/2026-06-24-ephemeral-pgvector-extension.md
@@ -1,0 +1,58 @@
+# Run: Ensure ephemeral integration environment provisions pgvector
+
+## Goal
+
+Make sure the ephemeral integration-test PostgreSQL provisioned by `startEphemeralEnvironment`
+ships and enables the `vector` (pgvector) extension, so vector-search code paths and any
+`CREATE EXTENSION vector` calls succeed under integration tests — matching the dev/prod
+docker-compose stacks that already use a pgvector-enabled image.
+
+## Context / Root Cause
+
+- Dev/prod and the dev container use `pgvector/pgvector:pg17-trixie` (see `docker-compose*.yml`,
+  `docker/postgres-init.sh`, `.devcontainer/docker-compose.yml`), which preinstalls pgvector and
+  creates the extension in the default DB and `template1`.
+- The ephemeral integration environment, however, starts a plain `postgres:16` Testcontainer
+  (`packages/cli/src/lib/testing/integration.ts:2948`). That image does **not** ship the pgvector
+  extension files, so `CREATE EXTENSION IF NOT EXISTS vector` (run by
+  `packages/search/src/vector/drivers/pgvector/index.ts`) fails with "could not open extension
+  control file …vector.control". The driver only special-cases the superuser error (`42501`),
+  not the missing-extension error, so vector indexing breaks in the ephemeral env.
+- Standalone apps reuse the same compiled CLI code path, so this single fix covers them too.
+
+## Scope
+
+- `packages/cli/src/lib/testing/integration.ts` — swap the ephemeral Postgres image to a
+  pgvector-enabled one (env-overridable) and eagerly create the `vector`/`pgcrypto` extensions
+  via an initdb script so the extension is guaranteed present, not merely available.
+- Unit test the new image/init resolver helpers.
+
+## Non-goals
+
+- Do not change dev/prod/devcontainer docker-compose files (already pgvector).
+- Do not change the pgvector driver's runtime extension-creation logic.
+- Do not bump the Postgres major version of the ephemeral DB (stay on pg16 to avoid behavioral
+  drift in the test suite); only add the pgvector layer.
+- Do not touch the reusable-environment path (caller supplies an external `DATABASE_URL`).
+
+## Risks
+
+- A pgvector image pull adds first-run latency in CI; mitigated by Docker layer caching and the
+  fact that the image is `postgres:16` + a small extension layer.
+- Image tag drift: pin to `pgvector/pgvector:pg16` and allow `OM_INTEGRATION_POSTGRES_IMAGE`
+  override for environments that mirror a different Postgres major.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Provision pgvector in the ephemeral DB
+
+- [ ] 1.1 Add an env-overridable `resolveEphemeralPostgresImage()` helper defaulting to a pgvector-enabled image
+- [ ] 1.2 Add an initdb SQL constant that creates `vector` + `pgcrypto`, and wire both into the GenericContainer start
+- [ ] 1.3 Add unit tests for the image resolver (default + override) and the init SQL contents
+
+### Phase 2: Validation
+
+- [ ] 2.1 Run targeted CLI unit tests + typecheck for changed package
+- [ ] 2.2 Full validation gate and self-review

--- a/packages/cli/src/lib/testing/__tests__/integration.test.ts
+++ b/packages/cli/src/lib/testing/__tests__/integration.test.ts
@@ -15,6 +15,8 @@ import {
   clearEphemeralEnvironmentState,
   resolveBuildCacheTtlSeconds,
   resolveAppReadyTimeoutMs,
+  resolveEphemeralPostgresImage,
+  ephemeralPostgresInitSql,
   shouldReuseBuildArtifacts,
   acquireEphemeralRuntimeLock,
   waitForApplicationReadiness,
@@ -401,6 +403,27 @@ describe('integration cache and options', () => {
     expect(resolveAppReadyTimeoutMs('integration')).toBe(90_000)
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('Invalid'))
     warn.mockRestore()
+  })
+
+  it('defaults the ephemeral Postgres image to a pgvector-enabled build', () => {
+    expect(resolveEphemeralPostgresImage({})).toBe('pgvector/pgvector:pg16')
+    expect(resolveEphemeralPostgresImage({ OM_INTEGRATION_POSTGRES_IMAGE: '   ' })).toBe(
+      'pgvector/pgvector:pg16',
+    )
+  })
+
+  it('honors an OM_INTEGRATION_POSTGRES_IMAGE override for the ephemeral Postgres image', () => {
+    expect(
+      resolveEphemeralPostgresImage({ OM_INTEGRATION_POSTGRES_IMAGE: 'pgvector/pgvector:pg17' }),
+    ).toBe('pgvector/pgvector:pg17')
+  })
+
+  it('creates the vector and pgcrypto extensions in the ephemeral init SQL', () => {
+    const sql = ephemeralPostgresInitSql()
+    expect(sql).toContain('CREATE EXTENSION IF NOT EXISTS vector')
+    expect(sql).toContain('CREATE EXTENSION IF NOT EXISTS pgcrypto')
+    // Extensions are also seeded into template1 so future databases inherit them.
+    expect(sql).toContain('\\connect template1')
   })
 
   it('reuses build artifacts only with matching source fingerprint and fresh cache state', async () => {

--- a/packages/cli/src/lib/testing/integration.ts
+++ b/packages/cli/src/lib/testing/integration.ts
@@ -157,6 +157,31 @@ const EPHEMERAL_ENV_LOCK_POLL_MS = 500
 const DEFAULT_BUILD_CACHE_TTL_SECONDS = 600
 const APP_READY_TIMEOUT_ENV_VAR = 'OM_INTEGRATION_APP_READY_TIMEOUT_SECONDS'
 const BUILD_CACHE_TTL_ENV_VAR = 'OM_INTEGRATION_BUILD_CACHE_TTL_SECONDS'
+const EPHEMERAL_POSTGRES_IMAGE_ENV_VAR = 'OM_INTEGRATION_POSTGRES_IMAGE'
+// Dev/prod and the dev container run pgvector-enabled Postgres (see docker-compose*.yml,
+// docker/postgres-init.sh, .devcontainer/docker-compose.yml). The ephemeral integration DB
+// MUST match so that `CREATE EXTENSION vector` (packages/search/src/vector/drivers/pgvector)
+// and any vector-search code path succeed. A plain `postgres:*` image lacks the extension
+// files. Stay on pg16 to avoid behavioral drift in the existing suite; only add pgvector.
+const DEFAULT_EPHEMERAL_POSTGRES_IMAGE = 'pgvector/pgvector:pg16'
+// Eagerly create the extensions the platform relies on so they are guaranteed present in the
+// fresh database, not merely available in the image. The ephemeral superuser can run these.
+// Mirrors docker/postgres-init.sh (default DB + template1 so any future DB inherits them).
+const EPHEMERAL_POSTGRES_INIT_SQL = `CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+\\connect template1
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+`
+
+export function resolveEphemeralPostgresImage(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env[EPHEMERAL_POSTGRES_IMAGE_ENV_VAR]?.trim()
+  return override && override.length > 0 ? override : DEFAULT_EPHEMERAL_POSTGRES_IMAGE
+}
+
+export function ephemeralPostgresInitSql(): string {
+  return EPHEMERAL_POSTGRES_INIT_SQL
+}
 const PLAYWRIGHT_ENV_UNAVAILABLE_PATTERNS: RegExp[] = [
   /net::ERR_CONNECTION_REFUSED/i,
   /Failed to connect to .* (localhost|127\.0\.0\.1)/i,
@@ -2945,12 +2970,21 @@ export async function startEphemeralEnvironment(options: EphemeralRuntimeOptions
     const databasePassword = 'secret'
 
     const { GenericContainer } = await import('testcontainers')
-    const databaseContainer = await new GenericContainer('postgres:16')
+    const databaseContainer = await new GenericContainer(resolveEphemeralPostgresImage())
       .withEnvironment({
         POSTGRES_DB: databaseName,
         POSTGRES_USER: databaseUser,
         POSTGRES_PASSWORD: databasePassword,
       })
+      // Guarantee the pgvector (and pgcrypto) extensions exist in the fresh database before the
+      // app boots, so vector-search code paths and `CREATE EXTENSION vector` succeed. The
+      // Postgres entrypoint runs *.sql files under /docker-entrypoint-initdb.d/ on first init.
+      .withCopyContentToContainer([
+        {
+          content: ephemeralPostgresInitSql(),
+          target: '/docker-entrypoint-initdb.d/00-open-mercato-extensions.sql',
+        },
+      ])
       .withExposedPorts(5432)
       .start()
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-24-ephemeral-pgvector-extension.md
Status: complete

## Goal
- Ensure the ephemeral integration-test PostgreSQL provisions the `vector` (pgvector) extension, so vector-search code paths and `CREATE EXTENSION vector` succeed under integration tests — matching dev/prod which already run a pgvector-enabled image.

## What Changed
- `packages/cli/src/lib/testing/integration.ts`: the ephemeral DB Testcontainer now uses `pgvector/pgvector:pg16` instead of plain `postgres:16` (the latter ships no pgvector extension files). Image is overridable via `OM_INTEGRATION_POSTGRES_IMAGE`.
- The container now mounts an initdb script (`/docker-entrypoint-initdb.d/00-open-mercato-extensions.sql`) that creates `vector` + `pgcrypto` in the database **and** `template1`, mirroring `docker/postgres-init.sh`, so the extensions are guaranteed present rather than merely available.
- Added exported helpers `resolveEphemeralPostgresImage()` and `ephemeralPostgresInitSql()` for testability.

## Root Cause
Dev/prod and the dev container use `pgvector/pgvector:pg17-trixie`, but the ephemeral integration environment started a plain `postgres:16` container. The pgvector driver (`packages/search/src/vector/drivers/pgvector/index.ts`) runs `CREATE EXTENSION IF NOT EXISTS vector`, which fails on a stock postgres image ("could not open extension control file …vector.control"). The driver only special-cases the superuser error (`42501`), not the missing-extension error, so vector indexing broke in the ephemeral env. Standalone apps reuse the same compiled CLI path, so this fix covers them too.

## Tests
- New unit tests in `packages/cli/src/lib/testing/__tests__/integration.test.ts`:
  - image resolver default (`pgvector/pgvector:pg16`) + blank-override fallback
  - `OM_INTEGRATION_POSTGRES_IMAGE` override honored
  - init SQL creates `vector` + `pgcrypto` and seeds `template1`
- `yarn typecheck` ✓ (21/21), `yarn build:packages` ✓, `yarn generate` ✓, CLI suite ✓ (987 passed), eslint ✓ on changed files.

## Backward Compatibility
- Additive only: two new exported helpers, one new env var (`OM_INTEGRATION_POSTGRES_IMAGE`). No signatures, API routes, event IDs, DI keys, ACL IDs, or DB schema changed. The image change affects the integration test runtime only; Postgres major stays at 16 to avoid behavioral drift.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-24-ephemeral-pgvector-extension.md#progress).
