### PR TITLE
fix(sales): seal gross>0 ⇒ net>0 invariant at sales line persistence (#3521)

### DIFF
--- a/packages/core/src/modules/sales/__integration__/TC-SALES-3521-return-net-gross.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-3521-return-net-gross.spec.ts
@@ -66,8 +66,8 @@ test.describe('TC-SALES-3521: order → return net/gross invariant', () => {
       expect(linesRes.ok(), `GET order-lines failed: ${linesRes.status()}`).toBeTruthy()
       const linesBody = (await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(linesRes)) ?? {}
       const line = (linesBody.items ?? []).find((item) => item.id === orderLineId) ?? {}
-      const lineNet = Number(line.totalNetAmount ?? 0)
-      const lineGross = Number(line.totalGrossAmount ?? 0)
+      const lineNet = Number(line.total_net_amount ?? line.totalNetAmount ?? 0)
+      const lineGross = Number(line.total_gross_amount ?? line.totalGrossAmount ?? 0)
       expect(lineGross).toBeGreaterThan(0)
       expect(lineNet).toBeGreaterThan(0)
 

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-3521-return-net-gross.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-3521-return-net-gross.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  canManageSalesOrders,
+  createOrderLineFixture,
+  createSalesOrderFixture,
+  deleteSalesEntityIfExists,
+} from '@open-mercato/core/helpers/integration/salesFixtures'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+/**
+ * TC-SALES-3521: order → return net/gross invariant (root cause of #3036)
+ * Source: issue #3521 (follow-up of #3036 / PR #3060)
+ *
+ * Reproduces the #3036 scenario through the real order → return flow: an order
+ * line must never be priced with net = 0 while gross > 0, and successive returns
+ * must reduce the order's net grand total in lockstep with gross. Before the
+ * root-cause fix, a line stored with `total_net_amount = 0` produced a zero net
+ * credit, freezing the net grand total on the second return while gross kept
+ * dropping.
+ *
+ * Self-contained: creates its own order + line, exercises two returns, and
+ * cleans up in `finally`. Self-skips on databases whose sales role ACLs were
+ * never synced (CI bootstraps a synced tenant, so it runs there).
+ */
+test.describe('TC-SALES-3521: order → return net/gross invariant', () => {
+  test('successive returns reduce the order net grand total in lockstep with gross', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    test.skip(!(await canManageSalesOrders(request, token)), 'sales.orders.manage not granted on this tenant')
+
+    const createdReturnIds: string[] = []
+    let orderId: string | null = null
+
+    const readOrderTotals = async (): Promise<{ net: number; gross: number }> => {
+      const res = await apiRequest(request, 'GET', `/api/sales/orders?id=${encodeURIComponent(orderId as string)}`, { token })
+      expect(res.ok(), `GET order failed: ${res.status()}`).toBeTruthy()
+      const body = (await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(res)) ?? {}
+      const order = body.items?.[0] ?? {}
+      return { net: Number(order.grandTotalNetAmount ?? 0), gross: Number(order.grandTotalGrossAmount ?? 0) }
+    }
+
+    const createReturn = async (orderLineId: string, quantity: number): Promise<void> => {
+      const res = await apiRequest(request, 'POST', '/api/sales/returns', {
+        token,
+        data: { orderId, lines: [{ orderLineId, quantity }] },
+      })
+      expect(res.ok(), `POST return failed: ${res.status()}`).toBeTruthy()
+      const body = (await readJsonSafe<Record<string, unknown>>(res)) ?? {}
+      const returnId = (body.id ?? body.returnId) as string | undefined
+      if (typeof returnId === 'string' && returnId.length) createdReturnIds.push(returnId)
+    }
+
+    try {
+      orderId = await createSalesOrderFixture(request, token, 'USD')
+      const orderLineId = await createOrderLineFixture(request, token, orderId, {
+        quantity: 2,
+        unitPriceNet: 100,
+        unitPriceGross: 110,
+        taxRate: 10,
+        name: `TC-SALES-3521 line ${Date.now()}`,
+      })
+
+      // Invariant at the source: the persisted line carries a positive net
+      // because gross is positive (never net = 0, gross > 0).
+      const linesRes = await apiRequest(request, 'GET', `/api/sales/order-lines?orderId=${encodeURIComponent(orderId)}`, { token })
+      expect(linesRes.ok(), `GET order-lines failed: ${linesRes.status()}`).toBeTruthy()
+      const linesBody = (await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(linesRes)) ?? {}
+      const line = (linesBody.items ?? []).find((item) => item.id === orderLineId) ?? {}
+      const lineNet = Number(line.totalNetAmount ?? 0)
+      const lineGross = Number(line.totalGrossAmount ?? 0)
+      expect(lineGross).toBeGreaterThan(0)
+      expect(lineNet).toBeGreaterThan(0)
+
+      const initial = await readOrderTotals()
+      expect(initial.net).toBeGreaterThan(0)
+      expect(initial.gross).toBeGreaterThan(0)
+
+      await createReturn(orderLineId, 1)
+      const afterFirst = await readOrderTotals()
+      // First return moves both net and gross down.
+      expect(afterFirst.gross).toBeLessThan(initial.gross)
+      expect(afterFirst.net).toBeLessThan(initial.net)
+
+      await createReturn(orderLineId, 1)
+      const afterSecond = await readOrderTotals()
+      // Second return must move net down again (it must NOT freeze) — this is #3036.
+      expect(afterSecond.gross).toBeLessThan(afterFirst.gross)
+      expect(afterSecond.net).toBeLessThan(afterFirst.net)
+    } finally {
+      for (const returnId of createdReturnIds) {
+        try {
+          await apiRequest(request, 'DELETE', '/api/sales/returns', { token, data: { id: returnId, orderId } })
+        } catch {
+          // best-effort cleanup
+        }
+      }
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+})

--- a/packages/core/src/modules/sales/commands/__tests__/lineNetGross.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/lineNetGross.test.ts
@@ -1,0 +1,136 @@
+/** @jest-environment node */
+
+/**
+ * Root-cause coverage for issue #3521 (and the #3036 symptom it sits behind).
+ *
+ * A sales line must never persist with `total_net_amount = 0` while
+ * `total_gross_amount > 0`: gross = net * (1 + taxRate) means net = 0 ⇒ gross =
+ * 0, so the skew is a data inconsistency, not a priced state. When it was stored
+ * anyway, the return-credit derivation in `commands/returns.ts`
+ * (`unitNet = totalNetAmount / quantity`) produced a zero net credit while the
+ * gross credit was correct, freezing the order net grand total on a second
+ * return.
+ *
+ * These tests pin the persistence-time invariant helpers and reproduce the
+ * #3036 mechanism end-to-end at the derivation level: the same formula the
+ * return command uses yields a frozen (zero) net credit on the raw broken line,
+ * but a correct net credit once the line is reconciled before persistence.
+ */
+
+import {
+  deriveLineNetFromGross,
+  reconcileLinePersistedTotals,
+} from '../shared'
+
+describe('deriveLineNetFromGross', () => {
+  it('derives net from gross and tax rate when net is zero', () => {
+    expect(deriveLineNetFromGross(0, 110, 10)).toBe(100)
+  })
+
+  it('accepts numeric-string inputs (the stored column shape)', () => {
+    expect(deriveLineNetFromGross('0', '110', '10')).toBe(100)
+  })
+
+  it('returns gross unchanged when the tax rate is zero', () => {
+    expect(deriveLineNetFromGross(0, 100, 0)).toBe(100)
+  })
+
+  it('treats a missing tax rate as zero', () => {
+    expect(deriveLineNetFromGross(0, 100, null)).toBe(100)
+    expect(deriveLineNetFromGross(0, 100, undefined)).toBe(100)
+  })
+
+  it('treats a missing/null net as zero and repairs it', () => {
+    expect(deriveLineNetFromGross(null, 121, 21)).toBe(100)
+    expect(deriveLineNetFromGross(undefined, 121, 21)).toBe(100)
+  })
+
+  it('treats a negative net as a violation and repairs it', () => {
+    expect(deriveLineNetFromGross(-5, 110, 10)).toBe(100)
+  })
+
+  it('leaves an already-positive net untouched', () => {
+    expect(deriveLineNetFromGross(50, 110, 10)).toBe(50)
+    expect(deriveLineNetFromGross('81.3008', '100', '23')).toBe(81.3008)
+  })
+
+  it('keeps a legitimately free line at zero (gross = 0 ⇒ net = 0)', () => {
+    expect(deriveLineNetFromGross(0, 0, 10)).toBe(0)
+  })
+
+  it('rounds the derived net to the 4-decimal column scale', () => {
+    // 100 / 1.23 = 81.30081300813... → 81.3008
+    expect(deriveLineNetFromGross(0, 100, 23)).toBe(81.3008)
+  })
+})
+
+describe('reconcileLinePersistedTotals', () => {
+  it('repairs a create payload that copied a zeroed net while gross is positive', () => {
+    const reconciled = reconcileLinePersistedTotals({
+      totalNetAmount: '0',
+      totalGrossAmount: '110',
+      taxRate: '10',
+      quantity: '1',
+      currencyCode: 'USD',
+    })
+    expect(reconciled.totalNetAmount).toBe('100')
+    // unrelated fields are preserved
+    expect(reconciled.totalGrossAmount).toBe('110')
+    expect(reconciled.currencyCode).toBe('USD')
+  })
+
+  it('is a no-op when the net total is already positive', () => {
+    const payload = { totalNetAmount: '100', totalGrossAmount: '110', taxRate: '10' }
+    expect(reconcileLinePersistedTotals(payload)).toBe(payload)
+  })
+
+  it('is a no-op for a free line (gross = 0)', () => {
+    const payload = { totalNetAmount: '0', totalGrossAmount: '0', taxRate: '0' }
+    expect(reconcileLinePersistedTotals(payload)).toBe(payload)
+  })
+})
+
+describe('#3036 return-credit mechanism', () => {
+  // Mirrors the per-unit credit derivation in commands/returns.ts:
+  //   const unitNet = lineQuantity > 0 ? toNumeric(line.totalNetAmount) / lineQuantity : unitPriceNet
+  //   const totalNet = -round(Math.max(unitNet, 0) * quantityReturned)
+  const round = (value: number) => Math.round((value + Number.EPSILON) * 100) / 100
+  const deriveReturnCredit = (
+    line: { totalNetAmount: string; totalGrossAmount: string; quantity: string; unitPriceNet: string; unitPriceGross: string },
+    quantityReturned: number,
+  ) => {
+    const lineQuantity = Math.max(Number(line.quantity), 0)
+    const unitNet = lineQuantity > 0 ? Number(line.totalNetAmount) / lineQuantity : Number(line.unitPriceNet)
+    const unitGross = lineQuantity > 0 ? Number(line.totalGrossAmount) / lineQuantity : Number(line.unitPriceGross)
+    return {
+      net: -round(Math.max(unitNet, 0) * quantityReturned),
+      gross: -round(Math.max(unitGross, 0) * quantityReturned),
+    }
+  }
+
+  const brokenLine = {
+    totalNetAmount: '0', // the inconsistent stored state
+    totalGrossAmount: '110',
+    quantity: '1',
+    unitPriceNet: '100',
+    unitPriceGross: '110',
+    taxRate: '10',
+  }
+
+  it('produces a frozen (zero) net credit when the order line stores net = 0 (the bug)', () => {
+    const credit = deriveReturnCredit(brokenLine, 1)
+    expect(credit.gross).toBe(-110)
+    // Net credit is zero even though gross moved — this is what froze the net total.
+    expect(Math.abs(credit.net)).toBe(0)
+  })
+
+  it('produces a correct net credit once the line is reconciled at persistence (the fix)', () => {
+    const reconciled = reconcileLinePersistedTotals(brokenLine)
+    expect(reconciled.totalNetAmount).toBe('100')
+
+    const credit = deriveReturnCredit({ ...brokenLine, totalNetAmount: reconciled.totalNetAmount as string }, 1)
+    expect(credit.gross).toBe(-110)
+    // Net now moves in lockstep with gross — the net grand total no longer freezes.
+    expect(credit.net).toBe(-100)
+  })
+})

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -96,6 +96,8 @@ import {
   ensureTenantScope,
   extractUndoPayload,
   toNumericString,
+  reconcileLinePersistedTotals,
+  deriveLineNetFromGross,
   enforceSalesDocumentOptimisticLock,
   SALES_RESOURCE_KIND_ORDER,
   SALES_RESOURCE_KIND_QUOTE,
@@ -2937,7 +2939,7 @@ function convertLineCalculationToEntityInput(
   index: number,
 ) {
   const line = lineResult.line;
-  return {
+  return reconcileLinePersistedTotals({
     lineNumber: line.lineNumber ?? index + 1,
     kind: line.kind ?? "product",
     statusEntryId: sourceLine.statusEntryId ?? null,
@@ -2984,7 +2986,7 @@ function convertLineCalculationToEntityInput(
     customFieldSetId: sourceLine.customFieldSetId ?? null,
     organizationId: document.organizationId,
     tenantId: document.tenantId,
-  };
+  });
 }
 
 function convertAdjustmentResultToEntityInput(
@@ -3941,7 +3943,9 @@ async function restoreQuoteGraph(
       discountPercent: line.discountPercent,
       taxRate: line.taxRate,
       taxAmount: line.taxAmount,
-      totalNetAmount: line.totalNetAmount,
+      totalNetAmount: toNumericString(
+        deriveLineNetFromGross(line.totalNetAmount, line.totalGrossAmount, line.taxRate),
+      ),
       totalGrossAmount: line.totalGrossAmount,
       configuration: line.configuration ? cloneJson(line.configuration) : null,
       promotionCode: line.promotionCode ?? null,
@@ -4269,7 +4273,9 @@ async function restoreOrderGraph(
       discountPercent: line.discountPercent,
       taxRate: line.taxRate,
       taxAmount: line.taxAmount,
-      totalNetAmount: line.totalNetAmount,
+      totalNetAmount: toNumericString(
+        deriveLineNetFromGross(line.totalNetAmount, line.totalGrossAmount, line.taxRate),
+      ),
       totalGrossAmount: line.totalGrossAmount,
       configuration: line.configuration ? cloneJson(line.configuration) : null,
       promotionCode: line.promotionCode ?? null,
@@ -6190,7 +6196,9 @@ const convertQuoteToOrderCommand: CommandHandler<
           discountPercent: line.discountPercent,
           taxRate: line.taxRate,
           taxAmount: line.taxAmount,
-          totalNetAmount: line.totalNetAmount,
+          totalNetAmount: toNumericString(
+            deriveLineNetFromGross(line.totalNetAmount, line.totalGrossAmount, line.taxRate),
+          ),
           totalGrossAmount: line.totalGrossAmount,
           configuration: line.configuration
             ? cloneJson(line.configuration)
@@ -8444,7 +8452,9 @@ const createInvoiceCommand: CommandHandler<
                   discountPercent: toNumericString(line.discountPercent ?? 0),
                   taxRate: toNumericString(line.taxRate ?? 0),
                   taxAmount: toNumericString(line.taxAmount ?? 0),
-                  totalNetAmount: toNumericString(line.totalNetAmount ?? 0),
+                  totalNetAmount: toNumericString(
+                    deriveLineNetFromGross(line.totalNetAmount ?? 0, line.totalGrossAmount ?? 0, line.taxRate ?? 0),
+                  ),
                   totalGrossAmount: toNumericString(line.totalGrossAmount ?? 0),
                   metadata: line.metadata ?? null,
                 }),
@@ -8796,7 +8806,9 @@ const deleteInvoiceCommand: CommandHandler<
         discountPercent: line.discountPercent,
         taxRate: line.taxRate,
         taxAmount: line.taxAmount,
-        totalNetAmount: line.totalNetAmount,
+        totalNetAmount: toNumericString(
+          deriveLineNetFromGross(line.totalNetAmount, line.totalGrossAmount, line.taxRate),
+        ),
         totalGrossAmount: line.totalGrossAmount,
         metadata: line.metadata,
       }));
@@ -8938,7 +8950,9 @@ const createCreditMemoCommand: CommandHandler<
                   unitPriceGross: toNumericString(line.unitPriceGross ?? 0),
                   taxRate: toNumericString(line.taxRate ?? 0),
                   taxAmount: toNumericString(line.taxAmount ?? 0),
-                  totalNetAmount: toNumericString(line.totalNetAmount ?? 0),
+                  totalNetAmount: toNumericString(
+                    deriveLineNetFromGross(line.totalNetAmount ?? 0, line.totalGrossAmount ?? 0, line.taxRate ?? 0),
+                  ),
                   totalGrossAmount: toNumericString(line.totalGrossAmount ?? 0),
                   metadata: line.metadata ?? null,
                 }),
@@ -9280,7 +9294,9 @@ const deleteCreditMemoCommand: CommandHandler<
         unitPriceGross: line.unitPriceGross,
         taxRate: line.taxRate,
         taxAmount: line.taxAmount,
-        totalNetAmount: line.totalNetAmount,
+        totalNetAmount: toNumericString(
+          deriveLineNetFromGross(line.totalNetAmount, line.totalGrossAmount, line.taxRate),
+        ),
         totalGrossAmount: line.totalGrossAmount,
         metadata: line.metadata,
       }));

--- a/packages/core/src/modules/sales/commands/shared.ts
+++ b/packages/core/src/modules/sales/commands/shared.ts
@@ -53,6 +53,74 @@ export function toNumericString(value: number | null | undefined): string | null
   return value.toString()
 }
 
+/** Numeric scale of the `total_net_amount` / `total_gross_amount` line columns. */
+const LINE_AMOUNT_SCALE = 4
+
+function parseLineAmount(value: number | string | null | undefined): number {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0
+  if (typeof value === 'string' && value.trim().length) {
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed)) return parsed
+  }
+  return 0
+}
+
+function roundLineAmount(value: number): number {
+  const factor = 10 ** LINE_AMOUNT_SCALE
+  return Math.round((value + Number.EPSILON) * factor) / factor
+}
+
+/**
+ * Derive a sales line's net total from its gross total and tax rate.
+ *
+ * `total_net_amount = 0` while `total_gross_amount > 0` is not a representable
+ * priced state: `gross = net * (1 + taxRate)`, so `net = 0 ⇒ gross = 0`. When a
+ * line carries a positive gross but a missing/zero net (legacy rows, optional
+ * pass-through inputs, or invoice/credit-memo copy of a zeroed order line), the
+ * net is reconstructed from gross and the line's tax rate. `taxRate` is a
+ * percentage (e.g. `23` ⇒ `0.23` fraction), matching the stored column and
+ * `taxCalculationService`. Returns the existing net unchanged when the
+ * invariant already holds. See issues #3521 / #3036.
+ */
+export function deriveLineNetFromGross(
+  net: number | string | null | undefined,
+  gross: number | string | null | undefined,
+  taxRate: number | string | null | undefined,
+): number {
+  const netValue = parseLineAmount(net)
+  const grossValue = parseLineAmount(gross)
+  if (grossValue > 0 && netValue <= 0) {
+    const rate = parseLineAmount(taxRate)
+    const fraction = rate > 0 ? rate / 100 : 0
+    return roundLineAmount(fraction > 0 ? grossValue / (1 + fraction) : grossValue)
+  }
+  return netValue
+}
+
+type LinePersistedTotals = {
+  totalNetAmount?: number | string | null
+  totalGrossAmount?: number | string | null
+  taxRate?: number | string | null
+}
+
+/**
+ * Enforce the `gross > 0 ⇒ net > 0` invariant on a line-entity create payload
+ * right before persistence. Returns the payload unchanged when the net total is
+ * already positive or gross is non-positive; otherwise fills the net total in
+ * from gross / taxRate via {@link deriveLineNetFromGross}. Applied at every
+ * sales line persistence site so the skew that froze return net totals (#3036)
+ * cannot be stored at the source. Idempotent and non-destructive: it only ever
+ * raises a zero/missing net to its derived value.
+ */
+export function reconcileLinePersistedTotals<T extends LinePersistedTotals>(payload: T): T {
+  const gross = parseLineAmount(payload.totalGrossAmount)
+  const net = parseLineAmount(payload.totalNetAmount)
+  if (gross <= 0 || net > 0) return payload
+  const derivedNet = toNumericString(deriveLineNetFromGross(net, gross, payload.taxRate))
+  if (derivedNet == null) return payload
+  return { ...payload, totalNetAmount: derivedNet } as T
+}
+
 export async function requireScopedEntity<T extends { id: string; deletedAt?: Date | null }>(
   em: EntityManager,
   entityClass: { new (): T },

--- a/packages/core/src/modules/sales/migrations/Migration20260624120000_backfill_line_net_from_gross.ts
+++ b/packages/core/src/modules/sales/migrations/Migration20260624120000_backfill_line_net_from_gross.ts
@@ -1,0 +1,48 @@
+import { Migration } from '@mikro-orm/migrations';
+
+/**
+ * Backfill sales line rows that violate the `gross > 0 ⇒ net > 0` invariant
+ * (issue #3521, root cause of #3036).
+ *
+ * `total_net_amount = 0` while `total_gross_amount > 0` is not a representable
+ * priced state (`gross = net * (1 + taxRate)`, so `net = 0 ⇒ gross = 0`). Such
+ * rows froze the order net grand total on a subsequent return and skewed any
+ * invoice / credit-memo line that copied the order line's net. The persistence
+ * paths are sealed at the source in `commands/documents.ts` via
+ * `reconcileLinePersistedTotals` / `deriveLineNetFromGross`; this migration
+ * repairs rows that were already stored in the inconsistent state (including the
+ * seeded demo order `SO-DEMO-2001` on tenants provisioned before the fix).
+ *
+ * The repaired net is reconstructed from the stored gross and tax rate exactly
+ * as the runtime helper does: `net = gross / (1 + taxRate/100)`, rounded to the
+ * column scale (4). When the tax rate is zero/null the net equals the gross.
+ *
+ * Forward-only: the original (corrupt) zero net carried no information to
+ * restore, so reverting is a no-op.
+ */
+export class Migration20260624120000_backfill_line_net_from_gross extends Migration {
+  override up(): void | Promise<void> {
+    for (const table of [
+      'sales_order_lines',
+      'sales_quote_lines',
+      'sales_invoice_lines',
+      'sales_credit_memo_lines',
+    ]) {
+      this.addSql(`
+        update "${table}"
+        set "total_net_amount" = round(
+          "total_gross_amount" / (1 + coalesce("tax_rate", 0) / 100),
+          4
+        )
+        where "total_gross_amount" > 0
+          and ("total_net_amount" is null or "total_net_amount" <= 0);
+      `);
+    }
+  }
+
+  override down(): void | Promise<void> {
+    // Forward-only data repair. The pre-migration zero/missing net carried no
+    // information to restore, and reintroducing the `net = 0, gross > 0` skew
+    // would re-open #3036. No-op.
+  }
+}


### PR DESCRIPTION
Fixes #3521

## Problem
A sales line could persist with `total_net_amount = 0` while `total_gross_amount > 0`. Since `gross = net * (1 + taxRate)` (so `net = 0 ⇒ gross = 0`), that is a data inconsistency, not a priced state. It:
- froze the order **net** grand total on a *second* return while gross kept dropping (the #3036 symptom that PR #3060 hardened at the return-credit layer), and
- leaked into invoice / credit-memo lines that copy the order line's `totalNetAmount`.

## Root Cause
`SalesOrderLine.totalNetAmount` defaults to `'0'` and is `.optional()` in the line validators. The normal create path computes net via `salesCalculationService`, but the **invoice / credit-memo copy paths** (`em.create(SalesInvoiceLine/SalesCreditMemoLine, …)`) and **undo-restore paths** propagated a zeroed net straight through, and **pre-existing rows** (e.g. seeded `SO-DEMO-2001` on older tenants) were already stored in the skewed state. The return-credit derivation (`unitNet = totalNetAmount / quantity`) then produced `amountNet = 0` while `amountGross` was correct.

## What Changed
- **`commands/shared.ts`** — added two pure, additive helpers:
  - `deriveLineNetFromGross(net, gross, taxRate)` — reconstructs `net = gross / (1 + taxRate/100)` (rounded to the column scale of 4, matching `taxCalculationService`) only when net is missing/zero while gross is positive; otherwise returns net unchanged.
  - `reconcileLinePersistedTotals(payload)` — idempotent, non-destructive guard applied to a line create payload right before persistence.
- **`commands/documents.ts`** — sealed the invariant at every sales line persistence site: the calc chokepoint `convertLineCalculationToEntityInput` (covers all forward order/quote line writes), the invoice & credit-memo **create** copy paths, and all order/quote/invoice/credit-memo **undo-restore** paths.
- **Migration `Migration20260624120000_backfill_line_net_from_gross`** — forward-only data repair of `sales_order_lines`, `sales_quote_lines`, `sales_invoice_lines`, `sales_credit_memo_lines` rows already stored with `net <= 0` while `gross > 0` (incl. seed `SO-DEMO-2001`). No schema change, so no snapshot change.

This is the root-cause seal complementary to PR #3060 (which hardened the return-credit derivation); with order lines never storing `net = 0, gross > 0`, the net grand total can no longer freeze.

## Tests
- **Unit** (`commands/__tests__/lineNetGross.test.ts`, 14 cases, all green) — `deriveLineNetFromGross` / `reconcileLinePersistedTotals` correctness (tax/no-tax/null/negative/free-line/rounding), plus a **#3036 mechanism reproduction**: the real return-credit formula yields a frozen (zero) net credit on the raw broken line and a correct net credit once the line is reconciled at persistence (fail-before / pass-after).
- **Integration** (`sales/__integration__/TC-SALES-3521-return-net-gross.spec.ts`) — real order → return × 2 flow asserting the persisted line satisfies the invariant and that successive returns reduce the order net grand total in lockstep with gross (no freeze). Self-contained (creates its own order/line, cleans up in `finally`), self-skips when sales ACLs are unsynced. Type-checked here; needs the ephemeral env to execute (see QA note below).

### Checks run
`build:packages` → `generate` → `build:packages` → `typecheck` (21/21) → `yarn workspace @open-mercato/core test` (6498 pass) → `build:app`, all green. The one failing core test (`customers/.../DealsKpiStrip.test.tsx`) is a pre-existing, locale-environmental compact-number-format assertion unrelated to this change (passes under `en_US`; the file is untouched by this PR).

## Security impact
Money/totals correctness fix. No auth, encryption, logging, or access-control surface touched. The backfill migration is a data-only repair scoped to the deployment database; it exposes no data and adds no new query surface.

## Backward Compatibility
No contract surface changes — two new additive exports in `commands/shared.ts`, no API response fields removed, no event IDs / DI keys / ACL / import paths altered, no schema change. `convertLineCalculationToEntityInput`'s return type is unchanged. Previously-corrupt `net = 0` values now resolve to their correct positive value (the intended fix).

## QA note
`needs-qa`: please exercise the order → return × 2 flow in the UI (or run the ephemeral integration suite — `TC-SALES-3521`) and confirm the **Grand Total (Net)** keeps dropping in step with **Grand Total (Gross)** on the second return. The Playwright `--list` could not run locally (the QA config triggers a global/web-server setup that hangs in this sandbox); the spec is type-checked and in `core`'s typecheck scope.
