### PR TITLE
security(messages): restrict message action commandId to declared allowlist (#3488)

### DIFF
--- a/packages/core/src/modules/messages/api/[id]/actions/[actionId]/__tests__/route.test.ts
+++ b/packages/core/src/modules/messages/api/[id]/actions/[actionId]/__tests__/route.test.ts
@@ -81,4 +81,17 @@ describe('messages action execution route', () => {
       error: 'Actions have expired',
     })
   })
+
+  it('maps a disallowed action command to 403', async () => {
+    commandBus.execute.mockRejectedValueOnce(new Error('Action command is not allowed'))
+
+    const response = await POST(new Request('http://localhost', { method: 'POST' }), {
+      params: { id: 'message-1', actionId: 'acknowledge' },
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Action command is not allowed',
+    })
+  })
 })

--- a/packages/core/src/modules/messages/api/[id]/actions/[actionId]/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/actions/[actionId]/route.ts
@@ -101,6 +101,9 @@ export async function POST(
       if (error.message === 'Action not found') {
         return Response.json({ error: 'Action not found' }, { status: 404 })
       }
+      if (error.message === 'Action command is not allowed') {
+        return Response.json({ error: 'Action command is not allowed' }, { status: 403 })
+      }
       if (error.message === 'Action already taken') {
         const actionTaken = (error as Error & { actionTaken?: string }).actionTaken ?? null
         return Response.json({ error: 'Action already taken', actionTaken }, { status: 409 })

--- a/packages/core/src/modules/messages/commands/__tests__/actions.test.ts
+++ b/packages/core/src/modules/messages/commands/__tests__/actions.test.ts
@@ -1,8 +1,24 @@
 import '@open-mercato/core/modules/messages/commands/actions'
 import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
 import { Message, MessageObject, MessageRecipient } from '@open-mercato/core/modules/messages/data/entities'
+import { registerMessageTypes } from '@open-mercato/core/modules/messages/lib/message-types-registry'
 
 describe('messages.actions.execute command', () => {
+  beforeAll(() => {
+    // Opt `demo.approve` into the message-action allowlist so the concurrency
+    // test below exercises the claim path rather than being short-circuited by
+    // the confused-deputy guard.
+    registerMessageTypes([
+      {
+        type: 'demo.approval',
+        module: 'demo',
+        labelKey: 'demo.approval',
+        icon: 'bell',
+        defaultActions: [{ id: 'approve', label: 'Approve', commandId: 'demo.approve' }],
+      },
+    ])
+  })
+
   it('surfaces terminal action log entries for href actions', async () => {
     const command = commandRegistry.get('messages.actions.execute')
     expect(command).toBeTruthy()
@@ -203,5 +219,93 @@ describe('messages.actions.execute command', () => {
     expect(emFork.nativeUpdate).toHaveBeenCalledTimes(1)
     // ...and because the claim lost the race, the target command never executed.
     expect(nestedCommandBus.execute).not.toHaveBeenCalled()
+  })
+
+  it('refuses a composer-controlled commandId that no message type declares', async () => {
+    const command = commandRegistry.get('messages.actions.execute')
+    expect(command).toBeTruthy()
+
+    const message = {
+      id: '11111111-1111-4111-8111-111111111111',
+      type: 'default',
+      sourceEntityId: '22222222-2222-4222-8222-222222222222',
+      tenantId: '55555555-5555-4555-8555-555555555555',
+      organizationId: '66666666-6666-4666-8666-666666666666',
+      threadId: null,
+      parentMessageId: null,
+      sentAt: new Date('2026-03-01T12:00:00.000Z'),
+      deletedAt: null,
+      actionTaken: null,
+      actionData: {
+        actions: [
+          {
+            // Innocuous label, but the commandId targets an arbitrary registered
+            // command — the confused-deputy vector from issue #3488.
+            id: 'acknowledge',
+            label: 'Acknowledge',
+            commandId: 'auth.users.delete',
+            isTerminal: true,
+          },
+        ],
+      },
+    }
+
+    const emFork = {
+      findOne: jest.fn(async (entity: unknown) => {
+        if (entity === Message) return message
+        if (entity === MessageRecipient) {
+          return {
+            id: '33333333-3333-4333-8333-333333333333',
+            messageId: message.id,
+            recipientUserId: '44444444-4444-4444-8444-444444444444',
+            deletedAt: null,
+          }
+        }
+        return null
+      }),
+      find: jest.fn(async (entity: unknown) => {
+        if (entity === MessageObject) return []
+        return []
+      }),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+
+    const nestedCommandBus = {
+      execute: jest.fn(async () => ({ result: { ok: true }, logEntry: null })),
+    }
+
+    await expect(
+      command!.execute(
+        {
+          messageId: message.id,
+          actionId: 'acknowledge',
+          tenantId: '55555555-5555-4555-8555-555555555555',
+          organizationId: '66666666-6666-4666-8666-666666666666',
+          userId: '44444444-4444-4444-8444-444444444444',
+        },
+        {
+          container: {
+            resolve: (name: string) => {
+              if (name === 'em') return { fork: () => emFork }
+              if (name === 'commandBus') return nestedCommandBus
+              return null
+            },
+          } as never,
+          auth: {
+            sub: '44444444-4444-4444-8444-444444444444',
+            tenantId: '55555555-5555-4555-8555-555555555555',
+            orgId: '66666666-6666-4666-8666-666666666666',
+          } as never,
+          organizationScope: null,
+          selectedOrganizationId: '66666666-6666-4666-8666-666666666666',
+          organizationIds: ['66666666-6666-4666-8666-666666666666'],
+        },
+      ),
+    ).rejects.toThrow('Action command is not allowed')
+
+    // The disallowed command must never reach the bus, and no terminal claim
+    // should have been reserved (guard runs before the claim).
+    expect(nestedCommandBus.execute).not.toHaveBeenCalled()
+    expect(emFork.nativeUpdate).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/messages/commands/actions.ts
+++ b/packages/core/src/modules/messages/commands/actions.ts
@@ -7,6 +7,7 @@ import { Message, MessageObject, MessageRecipient } from '../data/entities'
 import { emitMessagesEvent } from '../events'
 import {
   findResolvedMessageActionById,
+  isMessageSafeCommandId,
   isTerminalMessageAction,
   resolveActionCommandInput,
   resolveActionHref,
@@ -227,6 +228,13 @@ const executeActionCommand: CommandHandler<
 
     if (!action) {
       throw new Error('Action not found')
+    }
+
+    // Confused-deputy guard: a composer-controlled action must not dispatch an
+    // arbitrary registered command with the recipient's auth. Only command ids
+    // declared by code-side message types / object types are dispatchable.
+    if (action.commandId && !isMessageSafeCommandId(action.commandId)) {
+      throw new Error('Action command is not allowed')
     }
 
     if (message.actionTaken) {

--- a/packages/core/src/modules/messages/lib/__tests__/actions.test.ts
+++ b/packages/core/src/modules/messages/lib/__tests__/actions.test.ts
@@ -1,9 +1,12 @@
 import {
+  getMessageSafeCommandIds,
+  isMessageSafeCommandId,
   isTerminalMessageAction,
   resolveActionCommandInput,
   resolveActionHref,
   type ResolvedMessageAction,
 } from '../actions'
+import { registerMessageTypes } from '../message-types-registry'
 import type { Message } from '../../data/entities'
 
 function createMessage(overrides: Partial<Message> = {}): Message {
@@ -181,5 +184,37 @@ describe('resolveActionHref', () => {
     const message = createMessage({ id: '../../evil?x=1#y' } as Partial<Message>)
     const resolved = resolveActionHref(action, message, resolutionContext)
     expect(resolved).toBe('/backend/search/..%2F..%2Fevil%3Fx%3D1%23y')
+  })
+})
+
+describe('message-safe command allowlist', () => {
+  it('includes command ids declared by registered message type default actions', () => {
+    registerMessageTypes([
+      {
+        type: 'test.confused-deputy',
+        module: 'test',
+        labelKey: 'test.confusedDeputy',
+        icon: 'bell',
+        defaultActions: [
+          { id: 'safe', label: 'Safe', commandId: 'test.safe_command' },
+        ],
+      },
+    ])
+
+    expect(getMessageSafeCommandIds().has('test.safe_command')).toBe(true)
+    expect(isMessageSafeCommandId('test.safe_command')).toBe(true)
+  })
+
+  it('rejects command ids that no message type or object type declares', () => {
+    expect(isMessageSafeCommandId('auth.users.delete')).toBe(false)
+    expect(isMessageSafeCommandId('any.unregistered.command')).toBe(false)
+  })
+
+  it('rejects empty, blank, and non-string command ids', () => {
+    expect(isMessageSafeCommandId('')).toBe(false)
+    expect(isMessageSafeCommandId('   ')).toBe(false)
+    expect(isMessageSafeCommandId(undefined)).toBe(false)
+    expect(isMessageSafeCommandId(null)).toBe(false)
+    expect(isMessageSafeCommandId(42)).toBe(false)
   })
 })

--- a/packages/core/src/modules/messages/lib/actions.ts
+++ b/packages/core/src/modules/messages/lib/actions.ts
@@ -1,8 +1,8 @@
 import { parseDecryptedFieldValue } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
 import { sanitizeRichTextHref } from '@open-mercato/shared/lib/html/sanitizeRichText'
 import type { Message, MessageAction, MessageActionData, MessageObject } from '../data/entities'
-import { getMessageObjectType } from './message-objects-registry'
-import { getMessageType } from './message-types-registry'
+import { getAllMessageObjectTypes, getMessageObjectType } from './message-objects-registry'
+import { getAllMessageTypes, getMessageType } from './message-types-registry'
 
 type MessageActionSource = 'message' | 'type_default' | 'object'
 
@@ -225,6 +225,34 @@ export function resolveActionHref(
   const context = buildTemplateContext(message, resolutionContext, action.objectRef)
   const resolved = resolveTemplateString(action.href, context, encodeURIComponent)
   return sanitizeRichTextHref(resolved)
+}
+
+function collectCommandId(target: Set<string>, commandId: unknown): void {
+  if (typeof commandId !== 'string') return
+  const trimmed = commandId.trim()
+  if (trimmed.length > 0) target.add(trimmed)
+}
+
+export function getMessageSafeCommandIds(): Set<string> {
+  const safeCommandIds = new Set<string>()
+  for (const messageType of getAllMessageTypes()) {
+    for (const action of messageType.defaultActions ?? []) {
+      collectCommandId(safeCommandIds, action.commandId)
+    }
+  }
+  for (const objectType of getAllMessageObjectTypes()) {
+    for (const action of objectType.actions ?? []) {
+      collectCommandId(safeCommandIds, action.commandId)
+    }
+  }
+  return safeCommandIds
+}
+
+export function isMessageSafeCommandId(commandId: unknown): boolean {
+  if (typeof commandId !== 'string') return false
+  const trimmed = commandId.trim()
+  if (trimmed.length === 0) return false
+  return getMessageSafeCommandIds().has(trimmed)
 }
 
 export function resolveActionCommandInput(


### PR DESCRIPTION
Fixes #3488

## Problem
A terminal message action's `commandId` was dispatched to the command bus using the **recipient's** auth context with no allowlist. A composer with `messages.compose` could label a button "Acknowledge" but point its `commandId` at any registered command; the recipient executes it (with their own privileges) on a single click — a confused-deputy / social-engineering vector.

## Root Cause
`messages.actions.execute` (`commands/actions.ts`) called `commandBus.execute(action.commandId, …)` directly. `action.commandId` originates from composer-controlled `actionData.actions[]` and was trusted at execution time — no check that it belonged to a set of message-safe commands.

## What Changed
- Added `getMessageSafeCommandIds()` / `isMessageSafeCommandId()` in `lib/actions.ts`. The allowlist is built from code-side declarations only: registered message types' `defaultActions[].commandId` and message object types' `actions[].commandId`. Composer-supplied actions can therefore only invoke commands a module has explicitly opted in.
- `messages.actions.execute` now rejects an action whose `commandId` is not allowlisted **before** reserving the terminal claim, so nothing is mutated and the action stays clean.
- Mapped the refusal to **HTTP 403** in the action route (previously an unmapped error would surface as 500).

Legitimate flows are unaffected: type-default and object-sourced actions draw their `commandId` from the registries, so they are inherently in the allowlist.

## Tests
- `lib/__tests__/actions.test.ts` — allowlist unit tests (declared command allowed; unregistered/empty/blank/non-string rejected).
- `commands/__tests__/actions.test.ts` — new regression test proving an arbitrary composer `commandId` (`auth.users.delete`) is refused, the command bus is never called, and no terminal claim is reserved. Verified it fails without the guard and passes with it. Allowlisted `demo.approve` for the existing concurrency test.
- `api/[id]/actions/[actionId]/__tests__/route.test.ts` — asserts the 403 mapping.
- Full `modules/messages` suite green (50 suites / 256 tests); `@open-mercato/core` typecheck and `i18n:check-sync` pass.

## Security impact
- **Authorization:** closes a confused-deputy hole in message action execution. Command dispatch from message buttons is now constrained to an explicit, code-declared allowlist instead of accepting any registered command id. This is **not** a privilege escalation (the command still runs as the recipient under their RBAC), but it removes the ability to trick a privileged recipient into running an unintended state-changing command.
- No new credentials, encryption, or logging surfaces touched. No raw `em.find`/`em.findOne` introduced.

## Backward Compatibility
- Additive exports in `lib/actions.ts`. The only behavior change is the intended security tightening: a message action `commandId` that no module declares is now refused (403). Any consumer relying on dispatching arbitrary undeclared command ids from message buttons was relying on the vulnerability itself.