### PR TITLE
fix(dev): stabilize all splash variants

### DIFF
--- a/packages/create-app/template/scripts/dev-splash.html
+++ b/packages/create-app/template/scripts/dev-splash.html
@@ -906,6 +906,7 @@
           modeDev: 'Standard dev flow',
           modeGreenfield: 'Greenfield dev flow',
           modeSetup: 'Project setup flow',
+          modeEphemeral: 'Ephemeral dev flow',
           codingButtonLabel: '🤖 Start coding with AI',
           codingNoTools: 'No supported coding tools were detected on this machine.',
           gitRepoHeading: 'GitHub repository',
@@ -943,6 +944,7 @@
           modeDev: 'Standardowy tryb dev',
           modeGreenfield: 'Tryb greenfield',
           modeSetup: 'Tryb konfiguracji projektu',
+          modeEphemeral: 'Tymczasowy tryb dev',
           codingButtonLabel: '🤖 Zacznij kodować z AI',
           codingNoTools: 'Na tej maszynie nie wykryto obsługiwanych narzędzi do kodowania.',
           gitRepoHeading: 'Repozytorium GitHub',
@@ -980,6 +982,7 @@
           modeDev: 'Flujo dev estándar',
           modeGreenfield: 'Flujo dev greenfield',
           modeSetup: 'Flujo de configuración del proyecto',
+          modeEphemeral: 'Flujo dev efímero',
           codingButtonLabel: '🤖 Empezar a programar con IA',
           codingNoTools: 'No se detectaron herramientas de programacion compatibles en esta maquina.',
           gitRepoHeading: 'Repositorio de GitHub',
@@ -1017,6 +1020,7 @@
           modeDev: 'Standard-Dev-Ablauf',
           modeGreenfield: 'Greenfield-Dev-Ablauf',
           modeSetup: 'Projekt-Setup-Ablauf',
+          modeEphemeral: 'Ephemerer Dev-Ablauf',
           codingButtonLabel: '🤖 Mit KI programmieren',
           codingNoTools: 'Auf diesem Rechner wurden keine unterstuetzten Coding-Tools erkannt.',
           gitRepoHeading: 'GitHub-Repository',
@@ -1630,15 +1634,18 @@
         }[char]))
       }
 
+      function getModeLabel(mode) {
+        if (mode === 'greenfield') return t('modeGreenfield')
+        if (mode === 'setup') return t('modeSetup')
+        if (mode === 'ephemeral') return t('modeEphemeral')
+        return t('modeDev')
+      }
+
       async function refresh() {
         try {
           const response = await fetch('/status', { cache: 'no-store' })
           const state = await response.json()
-          modeLine.textContent = state.mode === 'greenfield'
-            ? t('modeGreenfield')
-            : state.mode === 'setup'
-              ? t('modeSetup')
-              : t('modeDev')
+          modeLine.textContent = getModeLabel(state.mode)
           const rawPhase = state.phase || 'Preparing app runtime'
           const rawDetail = state.detail || 'Preparing app runtime'
           const rawProgressLabel = state.progressLabel || 'Preparing startup pipeline'

--- a/scripts/__tests__/dev-splash-html.test.mjs
+++ b/scripts/__tests__/dev-splash-html.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const here = import.meta.dirname
+const root = path.resolve(here, '..', '..')
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8')
+}
+
+test('dev splash html stays synced with create-app template copy', () => {
+  assert.equal(
+    read('scripts/dev-splash.html'),
+    read('packages/create-app/template/scripts/dev-splash.html'),
+  )
+})
+
+test('dev splash keeps stabilized stream layout and explicit locale picker', () => {
+  const source = read('scripts/dev-splash.html')
+
+  assert.match(source, /\.stream-shell\s*{[^}]*height:\s*100%;/s)
+  assert.match(source, /\.hero-body\s*{[^}]*align-content:\s*start;/s)
+  assert.match(source, /if \(overflowing\) {\s*activityList\.scrollTop = activityList\.scrollHeight\s*}/s)
+  assert.match(source, /<select class="locale-select" id="locale-select" aria-label="Language"><\/select>/)
+})
+
+test('dev splash recognizes greenfield, setup, and ephemeral mode labels', () => {
+  const source = read('scripts/dev-splash.html')
+
+  assert.match(source, /modeGreenfield:/)
+  assert.match(source, /modeSetup:/)
+  assert.match(source, /modeEphemeral:/)
+  assert.match(source, /if \(mode === 'greenfield'\) return t\('modeGreenfield'\)/)
+  assert.match(source, /if \(mode === 'setup'\) return t\('modeSetup'\)/)
+  assert.match(source, /if \(mode === 'ephemeral'\) return t\('modeEphemeral'\)/)
+})
+
+test('ephemeral dev runner publishes an explicit splash mode', () => {
+  const source = read('scripts/dev-ephemeral.ts')
+
+  assert.match(source, /const splashState = {\s*mode: 'ephemeral',/s)
+})

--- a/scripts/dev-ephemeral.ts
+++ b/scripts/dev-ephemeral.ts
@@ -128,7 +128,7 @@ const autoOpenSplash = !classic
 const splashChildStateFilePath = path.join(projectRootDirectory, '.mercato', 'dev-ephemeral-splash-child-state.json')
 const warmupReadyFilePath = path.join(projectRootDirectory, '.mercato', 'dev-ephemeral-warmup-ready.json')
 const splashState = {
-  mode: 'dev',
+  mode: 'ephemeral',
   phase: 'Ephemeral dev environment is starting...',
   detail: 'Preparing isolated PostgreSQL and app runtime',
   failed: false,

--- a/scripts/dev-splash.html
+++ b/scripts/dev-splash.html
@@ -906,6 +906,7 @@
           modeDev: 'Standard dev flow',
           modeGreenfield: 'Greenfield dev flow',
           modeSetup: 'Project setup flow',
+          modeEphemeral: 'Ephemeral dev flow',
           codingButtonLabel: '🤖 Start coding with AI',
           codingNoTools: 'No supported coding tools were detected on this machine.',
           gitRepoHeading: 'GitHub repository',
@@ -943,6 +944,7 @@
           modeDev: 'Standardowy tryb dev',
           modeGreenfield: 'Tryb greenfield',
           modeSetup: 'Tryb konfiguracji projektu',
+          modeEphemeral: 'Tymczasowy tryb dev',
           codingButtonLabel: '🤖 Zacznij kodować z AI',
           codingNoTools: 'Na tej maszynie nie wykryto obsługiwanych narzędzi do kodowania.',
           gitRepoHeading: 'Repozytorium GitHub',
@@ -980,6 +982,7 @@
           modeDev: 'Flujo dev estándar',
           modeGreenfield: 'Flujo dev greenfield',
           modeSetup: 'Flujo de configuración del proyecto',
+          modeEphemeral: 'Flujo dev efímero',
           codingButtonLabel: '🤖 Empezar a programar con IA',
           codingNoTools: 'No se detectaron herramientas de programacion compatibles en esta maquina.',
           gitRepoHeading: 'Repositorio de GitHub',
@@ -1017,6 +1020,7 @@
           modeDev: 'Standard-Dev-Ablauf',
           modeGreenfield: 'Greenfield-Dev-Ablauf',
           modeSetup: 'Projekt-Setup-Ablauf',
+          modeEphemeral: 'Ephemerer Dev-Ablauf',
           codingButtonLabel: '🤖 Mit KI programmieren',
           codingNoTools: 'Auf diesem Rechner wurden keine unterstuetzten Coding-Tools erkannt.',
           gitRepoHeading: 'GitHub-Repository',
@@ -1630,15 +1634,18 @@
         }[char]))
       }
 
+      function getModeLabel(mode) {
+        if (mode === 'greenfield') return t('modeGreenfield')
+        if (mode === 'setup') return t('modeSetup')
+        if (mode === 'ephemeral') return t('modeEphemeral')
+        return t('modeDev')
+      }
+
       async function refresh() {
         try {
           const response = await fetch('/status', { cache: 'no-store' })
           const state = await response.json()
-          modeLine.textContent = state.mode === 'greenfield'
-            ? t('modeGreenfield')
-            : state.mode === 'setup'
-              ? t('modeSetup')
-              : t('modeDev')
+          modeLine.textContent = getModeLabel(state.mode)
           const rawPhase = state.phase || 'Preparing app runtime'
           const rawDetail = state.detail || 'Preparing app runtime'
           const rawProgressLabel = state.progressLabel || 'Preparing startup pipeline'


### PR DESCRIPTION
## Summary

Applies the dev-splash UX stabilization follow-up from #3534 to the remaining splash variants by making ephemeral mode explicit and keeping the shared splash/template copies in lockstep.

## Changes

- Added explicit `ephemeral` mode labels to the shared dev splash renderer alongside `greenfield` and `setup`.
- Updated the ephemeral dev runner to publish `mode: 'ephemeral'` instead of falling through as standard dev.
- Added a regression test that guards dev-splash/template byte parity, stabilized stream layout, locale picker markup, and variant mode handling.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor dev splash UX fix, no spec needed)

**Spec file path:**
N/A

## Testing

- `node --test scripts/__tests__/dev-splash-html.test.mjs`
- `node --test scripts/__tests__/dev-splash-state.test.mjs scripts/__tests__/dev-ephemeral-shutdown.test.mjs scripts/__tests__/dev-cache-purge.test.mjs`
- `cmp -s scripts/dev-splash.html packages/create-app/template/scripts/dev-splash.html`
- `git diff --check -- scripts/dev-splash.html packages/create-app/template/scripts/dev-splash.html scripts/dev-ephemeral.ts scripts/__tests__/dev-splash-html.test.mjs`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3534
