### PR TITLE
fix(staff): route timesheet timer writes through guards (carry-forward of #3398)

### DIFF
--- a/packages/core/src/modules/staff/lib/timesheets-ui/TimerBar.tsx
+++ b/packages/core/src/modules/staff/lib/timesheets-ui/TimerBar.tsx
@@ -7,6 +7,7 @@ import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { ProjectColorDot } from './ProjectColorDot'
 import { startTimerEntry } from './startTimer'
 import { resolveTimerActionError } from './timerErrors'
@@ -22,6 +23,17 @@ type TimerBarProps = {
   projects: ProjectOption[]
   staffMemberId: string | null
   onTimerStopped: () => void
+}
+
+const TIMER_MUTATION_CONTEXT_ID = 'staff-timesheets-timer-bar'
+
+type TimerMutationContext = {
+  formId: string
+  resourceKind: string
+  resourceId: string
+  staffMemberId: string | null
+  action: 'timer-create' | 'timer-start' | 'timer-stop'
+  retryLastMutation: () => Promise<boolean>
 }
 
 function formatElapsed(seconds: number): string {
@@ -41,6 +53,10 @@ function getToday(): string {
 
 export function TimerBar({ projects, staffMemberId, onTimerStopped }: TimerBarProps) {
   const t = useT()
+  const { runMutation, retryLastMutation } = useGuardedMutation<TimerMutationContext>({
+    contextId: TIMER_MUTATION_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
 
   const [activeEntryId, setActiveEntryId] = useState<string | null>(null)
   const [activeProjectId, setActiveProjectId] = useState<string | null>(null)
@@ -142,11 +158,23 @@ export function TimerBar({ projects, staffMemberId, onTimerStopped }: TimerBarPr
     setIsStarting(true)
     try {
       const today = getToday()
-      const { id: entryId } = await startTimerEntry({
+      const startPayload = {
         staffMemberId,
         timeProjectId: selectedProjectId,
         date: today,
         notes: description || null,
+      }
+      const { id: entryId } = await runMutation({
+        operation: () => startTimerEntry(startPayload),
+        context: {
+          formId: TIMER_MUTATION_CONTEXT_ID,
+          resourceKind: 'staff.timesheets.time_entry',
+          resourceId: staffMemberId,
+          staffMemberId,
+          action: 'timer-start',
+          retryLastMutation,
+        },
+        mutationPayload: startPayload,
       })
 
       setActiveEntryId(entryId)
@@ -167,10 +195,27 @@ export function TimerBar({ projects, staffMemberId, onTimerStopped }: TimerBarPr
 
     setIsStopping(true)
     try {
-      await apiCallOrThrow(
-        `/api/staff/timesheets/time-entries/${activeEntryId}/timer-stop`,
-        { method: 'POST' },
-      )
+      const stopPayload = {
+        id: activeEntryId,
+        action: 'timer-stop',
+        staffMemberId,
+      }
+      await runMutation({
+        operation: () =>
+          apiCallOrThrow(
+            `/api/staff/timesheets/time-entries/${activeEntryId}/timer-stop`,
+            { method: 'POST' },
+          ),
+        context: {
+          formId: TIMER_MUTATION_CONTEXT_ID,
+          resourceKind: 'staff.timesheets.time_entry',
+          resourceId: activeEntryId,
+          staffMemberId,
+          action: 'timer-stop',
+          retryLastMutation,
+        },
+        mutationPayload: stopPayload,
+      })
 
       setActiveEntryId(null)
       setActiveProjectId(null)

--- a/packages/core/src/modules/staff/lib/timesheets-ui/__tests__/TimerBar.guardedMutation.test.tsx
+++ b/packages/core/src/modules/staff/lib/timesheets-ui/__tests__/TimerBar.guardedMutation.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { TimerBar } from '../TimerBar'
+import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+
+const mockRunMutation = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+const mockRetryLastMutation = jest.fn(async () => true)
+const mockTranslate = (_key: string, fallback?: string) => fallback ?? ''
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: mockRunMutation,
+    retryLastMutation: mockRetryLastMutation,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+  apiCallOrThrow: jest.fn(),
+}))
+
+const mockApiCall = apiCall as jest.MockedFunction<typeof apiCall>
+const mockApiCallOrThrow = apiCallOrThrow as jest.MockedFunction<typeof apiCallOrThrow>
+
+const projects = [
+  { id: 'project-1', name: 'Build', code: 'BLD', color: null },
+]
+
+describe('TimerBar guarded mutations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRunMutation.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+    mockApiCall.mockResolvedValue({ ok: true, result: { items: [] } } as any)
+    mockApiCallOrThrow.mockResolvedValue({ result: { id: 'entry-1' } } as any)
+  })
+
+  it('routes the atomic timer start through guarded mutation context', async () => {
+    render(<TimerBar projects={projects} staffMemberId="staff-1" onTimerStopped={jest.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Project' }))
+    fireEvent.click(screen.getByRole('button', { name: /Build/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Start timer' }))
+
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalledTimes(1))
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({
+        resourceKind: 'staff.timesheets.time_entry',
+        resourceId: 'staff-1',
+        staffMemberId: 'staff-1',
+        action: 'timer-start',
+        retryLastMutation: mockRetryLastMutation,
+      }),
+      mutationPayload: expect.objectContaining({
+        staffMemberId: 'staff-1',
+        timeProjectId: 'project-1',
+      }),
+    }))
+    expect(mockApiCallOrThrow).toHaveBeenCalledWith(
+      '/api/staff/timesheets/time-entries/start-timer',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('routes timer stop through guarded mutation context', async () => {
+    mockApiCall.mockResolvedValue({
+      ok: true,
+      result: {
+        items: [{
+          id: 'entry-1',
+          time_project_id: 'project-1',
+          notes: 'Build task',
+          started_at: new Date().toISOString(),
+          ended_at: null,
+        }],
+      },
+    } as any)
+
+    render(<TimerBar projects={projects} staffMemberId="staff-1" onTimerStopped={jest.fn()} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Stop timer' }))
+
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalledTimes(1))
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({
+        resourceKind: 'staff.timesheets.time_entry',
+        resourceId: 'entry-1',
+        staffMemberId: 'staff-1',
+        retryLastMutation: mockRetryLastMutation,
+      }),
+      mutationPayload: {
+        id: 'entry-1',
+        action: 'timer-stop',
+        staffMemberId: 'staff-1',
+      },
+    }))
+  })
+})

--- a/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/__tests__/widget.client.guardedMutation.test.tsx
+++ b/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/__tests__/widget.client.guardedMutation.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import TimeReportingWidget from '../widget.client'
+import { apiCall, apiCallOrThrow, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+
+const mockRunMutation = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+const mockRetryLastMutation = jest.fn(async () => true)
+const mockOnSettingsChange = jest.fn()
+const mockTranslate = (_key: string, fallback?: string) => fallback ?? ''
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: mockRunMutation,
+    retryLastMutation: mockRetryLastMutation,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+  apiCallOrThrow: jest.fn(),
+  readApiResultOrThrow: jest.fn(),
+}))
+
+const mockApiCall = apiCall as jest.MockedFunction<typeof apiCall>
+const mockApiCallOrThrow = apiCallOrThrow as jest.MockedFunction<typeof apiCallOrThrow>
+const mockReadApiResultOrThrow = readApiResultOrThrow as jest.MockedFunction<typeof readApiResultOrThrow>
+
+function renderWidget() {
+  render(
+    <TimeReportingWidget
+      {...({
+        mode: 'view',
+        settings: {},
+        onSettingsChange: mockOnSettingsChange,
+      } as any)}
+    />,
+  )
+}
+
+function mockWidgetReads({ running }: { running: boolean }) {
+  mockReadApiResultOrThrow.mockImplementation(async (path: string) => {
+    if (path === '/api/staff/timesheets/my-projects?pageSize=100') {
+      return { items: [{ time_project_id: 'project-1' }] } as any
+    }
+    if (path === '/api/staff/timesheets/time-projects?ids=project-1&pageSize=100') {
+      return { items: [{ id: 'project-1', name: 'Build', code: 'BLD' }] } as any
+    }
+    if (path === '/api/staff/team-members/self') {
+      return { member: { id: 'staff-1' } } as any
+    }
+    if (path.startsWith('/api/staff/timesheets/time-entries?')) {
+      return {
+        items: running
+          ? [{
+            id: 'entry-1',
+            started_at: new Date().toISOString(),
+            ended_at: null,
+            time_project_id: 'project-1',
+          }]
+          : [],
+      } as any
+    }
+    return { items: [] } as any
+  })
+}
+
+describe('TimeReportingWidget guarded mutations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRunMutation.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+    mockApiCall.mockResolvedValue({ ok: true, result: { id: 'entry-1' } } as any)
+    mockApiCallOrThrow.mockResolvedValue({ result: { id: 'entry-1' } } as any)
+  })
+
+  it('routes the atomic timer start through guarded mutation context', async () => {
+    mockWidgetReads({ running: false })
+    renderWidget()
+
+    fireEvent.change(await screen.findByLabelText('Project'), { target: { value: 'project-1' } })
+    fireEvent.change(screen.getByLabelText('Task / Note'), { target: { value: 'Build task' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Start Timer' }))
+
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalledTimes(1))
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({
+        resourceKind: 'staff.timesheets.time_entry',
+        resourceId: 'staff-1',
+        staffMemberId: 'staff-1',
+        action: 'timer-start',
+        retryLastMutation: mockRetryLastMutation,
+      }),
+      mutationPayload: expect.objectContaining({
+        staffMemberId: 'staff-1',
+        timeProjectId: 'project-1',
+        notes: 'Build task',
+      }),
+    }))
+    expect(mockApiCallOrThrow).toHaveBeenCalledWith(
+      '/api/staff/timesheets/time-entries/start-timer',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('routes timer stop through guarded mutation context', async () => {
+    mockWidgetReads({ running: true })
+    renderWidget()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Stop Timer' }))
+
+    await waitFor(() => expect(mockRunMutation).toHaveBeenCalledTimes(1))
+    expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({
+        resourceKind: 'staff.timesheets.time_entry',
+        resourceId: 'entry-1',
+        staffMemberId: 'staff-1',
+        retryLastMutation: mockRetryLastMutation,
+      }),
+      mutationPayload: {
+        id: 'entry-1',
+        action: 'timer-stop',
+        staffMemberId: 'staff-1',
+      },
+    }))
+  })
+})

--- a/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/widget.client.tsx
+++ b/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/widget.client.tsx
@@ -6,6 +6,7 @@ import { apiCall, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/ap
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Input } from '@open-mercato/ui/primitives/input'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { startTimerEntry } from '../../../lib/timesheets-ui/startTimer'
 import { resolveTimerActionError } from '../../../lib/timesheets-ui/timerErrors'
 import { DEFAULT_SETTINGS, hydrateSettings, type TimeReportingSettings } from './config'
@@ -17,6 +18,17 @@ type TimerState = {
   running: boolean
   startedAt: string | null
   projectId: string | null
+}
+
+const TIMER_WIDGET_MUTATION_CONTEXT_ID = 'staff-timesheets-time-reporting-widget'
+
+type TimerWidgetMutationContext = {
+  formId: string
+  resourceKind: string
+  resourceId: string
+  staffMemberId: string
+  action: 'timer-create' | 'timer-start' | 'timer-stop'
+  retryLastMutation: () => Promise<boolean>
 }
 
 function formatElapsed(startedAt: string): string {
@@ -36,6 +48,10 @@ const TimeReportingWidget: React.FC<DashboardWidgetComponentProps<TimeReportingS
   onRefreshStateChange,
 }) => {
   const t = useT()
+  const { runMutation, retryLastMutation } = useGuardedMutation<TimerWidgetMutationContext>({
+    contextId: TIMER_WIDGET_MUTATION_CONTEXT_ID,
+    blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
+  })
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
 
   const [projects, setProjects] = React.useState<ProjectOption[]>([])
@@ -142,12 +158,26 @@ const TimeReportingWidget: React.FC<DashboardWidgetComponentProps<TimeReportingS
       const today = new Date().toISOString().slice(0, 10)
       // Single atomic create+start request (issue #3311): a partial failure can
       // no longer leave an orphaned, unstarted timer entry, and a rejected start
-      // now surfaces here instead of being silently ignored.
-      await startTimerEntry({
+      // now surfaces here instead of being silently ignored. The call is routed
+      // through the mutation guard (issue #3308) so global injection modules can
+      // run onBeforeSave/onAfterSave and surface conflicts consistently.
+      const startPayload = {
         staffMemberId,
         timeProjectId: selectedProjectId,
         date: today,
         notes: notes.trim() || null,
+      }
+      await runMutation({
+        operation: () => startTimerEntry(startPayload),
+        context: {
+          formId: TIMER_WIDGET_MUTATION_CONTEXT_ID,
+          resourceKind: 'staff.timesheets.time_entry',
+          resourceId: staffMemberId,
+          staffMemberId,
+          action: 'timer-start',
+          retryLastMutation,
+        },
+        mutationPayload: startPayload,
       })
 
       onSettingsChange({ ...hydrated, lastProjectId: selectedProjectId })
@@ -158,13 +188,30 @@ const TimeReportingWidget: React.FC<DashboardWidgetComponentProps<TimeReportingS
     } finally {
       setActionLoading(false)
     }
-  }, [selectedProjectId, staffMemberId, timer.running, notes, hydrated, onSettingsChange, loadState, t])
+  }, [selectedProjectId, staffMemberId, timer.running, notes, hydrated, onSettingsChange, loadState, runMutation, retryLastMutation, t])
 
   const handleStop = React.useCallback(async () => {
-    if (!timer.entryId) return
+    if (!timer.entryId || !staffMemberId) return
     setActionLoading(true)
     try {
-      await apiCall(`/api/staff/timesheets/time-entries/${timer.entryId}/timer-stop`, { method: 'POST' })
+      const stopPayload = {
+        id: timer.entryId,
+        action: 'timer-stop',
+        staffMemberId,
+      }
+      await runMutation({
+        operation: () =>
+          apiCall(`/api/staff/timesheets/time-entries/${timer.entryId}/timer-stop`, { method: 'POST' }),
+        context: {
+          formId: TIMER_WIDGET_MUTATION_CONTEXT_ID,
+          resourceKind: 'staff.timesheets.time_entry',
+          resourceId: timer.entryId,
+          staffMemberId,
+          action: 'timer-stop',
+          retryLastMutation,
+        },
+        mutationPayload: stopPayload,
+      })
       await loadState()
     } catch (err) {
       console.error('staff.timesheets.timeReporting.stop', err)
@@ -172,7 +219,7 @@ const TimeReportingWidget: React.FC<DashboardWidgetComponentProps<TimeReportingS
     } finally {
       setActionLoading(false)
     }
-  }, [timer.entryId, loadState, t])
+  }, [timer.entryId, staffMemberId, loadState, runMutation, retryLastMutation, t])
 
   if (mode === 'settings') {
     return (


### PR DESCRIPTION
Supersedes #3398

Credit: original implementation by @haxiorz (issue #3308). This follow-up PR carries that work forward with the `develop` merge conflict resolved, so it can merge without waiting on the fork branch.

## Why a replacement PR
#3398 is from a fork with "allow edits from maintainers" disabled, so the conflict against `develop` could not be resolved on the original branch.

## The conflict
#3398 (route timer writes through `useGuardedMutation`, #3308) collided with the atomic create+start refactor that landed on `develop` (#3311, `startTimerEntry()` → single `/start-timer` request).

## Resolution
Both intents are preserved: the timer start path now calls develop's atomic `startTimerEntry()` **routed through** `useGuardedMutation.runMutation` in both `TimerBar` and the time-reporting dashboard widget. The stop path stays guarded. This keeps the orphaned-entry race fix (#3311) **and** the mutation-guard contract (#3308).

## Included work
- Original changes from #3398 (guarded timesheet timer writes)
- Conflict resolution adopting the atomic `startTimerEntry()` helper under the guard
- Guarded-mutation tests updated to assert the atomic single-call flow

## Validation
- `yarn workspace @open-mercato/core build` — ✅
- staff timesheet UI tests (5 suites / 23 tests) — ✅
- `optimistic-lock-ui-coverage` guard — ✅

Re-reviewed after the conflict resolution; intended to be merge-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)