### PR TITLE
test(currencies): integration tests for guarded-mutation UI writes (follow-up to #3438)

### DIFF
--- a/.ai/runs/2026-06-24-currencies-guarded-mutation-integration-tests.md
+++ b/.ai/runs/2026-06-24-currencies-guarded-mutation-integration-tests.md
@@ -1,0 +1,78 @@
+# Execution Plan — currencies guarded-mutation integration tests
+
+## Overview
+
+Follow-up to **PR #3438** (`fix: route currencies non-CrudForm UI writes through guarded mutations`,
+fixes #3191), which routed the currencies / exchange-rates / fetch-config UI writes through
+`useGuardedMutation(...).runMutation(...)`. That PR shipped jsdom unit tests only. The
+`om-auto-verify-pr-ui` run on #3438 exercised every guarded write surface end-to-end with a
+**throwaway** Playwright spec and asked for a committed integration test to lock the behavior in
+(see the "🧪 Follow-up: add an integration test for this PR" comment on #3438).
+
+This run converts that manual UI-QA scenario into committed Playwright integration specs under
+`packages/core/src/modules/currencies/__integration__/`.
+
+### Goal
+
+Lock in (via committed integration tests) that the currencies UI writes route through the guard:
+the fetch-config provider toggle PUT succeeds and flashes "Provider enabled", and both the
+currency and exchange-rate row **Delete** actions route through the guard and surface the failure
+flash consistently (current behavior — a pre-existing body-vs-query `?id=` delete bug returns HTTP
+400, so the guard shows "Failed to delete …").
+
+### Scope
+
+- Add `TC-CUR-012.spec.ts` — currency + exchange-rate **Delete** route through the guard and surface
+  the failure flash; the fixture row survives (proves the guarded DELETE failed at the API, not silently).
+- Add `TC-CUR-013.spec.ts` — fetch-config provider **toggle on** routes a guarded PUT and flashes
+  "Provider enabled"; verified via API.
+
+### Non-goals
+
+- **Not** fixing the pre-existing currency/exchange-rate delete body-vs-query `?id=` bug
+  (`packages/shared/src/lib/crud/factory.ts:2771` defaults `idFrom: 'query'`, but the UI sends `id`
+  in the body). That is a separate corrective change with its own QA; this run only documents and
+  locks the current observable behavior, with a comment on how to flip the asserts once the bug is fixed.
+- No set-base happy-path test — already covered by `TC-CUR-004.spec.ts`.
+- No production code changes.
+
+### Affected paths
+
+- `packages/core/src/modules/currencies/__integration__/TC-CUR-012.spec.ts` (new)
+- `packages/core/src/modules/currencies/__integration__/TC-CUR-013.spec.ts` (new)
+
+### Source reference
+
+- PR #3438 + its `om-auto-verify-pr-ui` evidence + integration-test follow-up comment.
+- Conventions: `.ai/qa/AGENTS.md`, existing `TC-CUR-004.spec.ts` (UI row-action + flash pattern).
+
+### Risks (brief)
+
+- UI integration specs are inherently flaky (portalled menus, list re-renders). Mirror the proven
+  resilience patterns from `TC-CUR-004.spec.ts` (bounded clicks, retry loop, `test.setTimeout(60_000)`).
+- These specs require a live ephemeral app + Postgres to actually run. The sandbox cannot boot one,
+  so the deliverable is a correct, well-formed spec verified by typecheck/lint/build; runtime
+  execution happens in CI / the ephemeral QA env.
+- Asserting current (buggy) delete behavior could read as "locking a bug" — mitigated with an explicit
+  in-file comment pointing at the root cause and the flip-to-success instruction.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Guarded DELETE error-surfacing spec
+
+- [x] 1.1 Add `TC-CUR-012.spec.ts` covering currency + exchange-rate delete routing through the guard
+- [x] 1.2 Typecheck (specs type-clean; only env `#generated` TS2307 noise) + esbuild compile via `playwright --list`
+
+### Phase 2: Guarded fetch-config toggle spec
+
+- [x] 2.1 Add `TC-CUR-013.spec.ts` covering the fetch-config provider toggle guarded PUT
+- [x] 2.2 Typecheck (type-clean) + esbuild compile via `playwright --list`
+
+### Phase 3: Validation + PR
+
+- [x] 3.1 Validation: `playwright --list` compiles all 3 tests; `tsc -p packages/core` reports 0 errors in the new specs (199 pre-existing `#generated` TS2307 errors are env-only, no `yarn generate` in this fresh worktree). Full `yarn test`/`build:app` gate runs in CI — `yarn test` is unit-only and does not execute these `__integration__` Playwright specs (they run via `yarn test:integration` against an ephemeral env).
+- [ ] 3.2 Code-review + BC self-review
+- [ ] 3.3 Open PR against develop, normalize labels
+- [ ] 3.4 Run om-auto-review-pr and apply fixes

--- a/.ai/runs/2026-06-24-currencies-guarded-mutation-integration-tests.md
+++ b/.ai/runs/2026-06-24-currencies-guarded-mutation-integration-tests.md
@@ -73,6 +73,10 @@ flash consistently (current behavior — a pre-existing body-vs-query `?id=` del
 ### Phase 3: Validation + PR
 
 - [x] 3.1 Validation: `playwright --list` compiles all 3 tests; `tsc -p packages/core` reports 0 errors in the new specs (199 pre-existing `#generated` TS2307 errors are env-only, no `yarn generate` in this fresh worktree). Full `yarn test`/`build:app` gate runs in CI — `yarn test` is unit-only and does not execute these `__integration__` Playwright specs (they run via `yarn test:integration` against an ephemeral env).
-- [ ] 3.2 Code-review + BC self-review
-- [ ] 3.3 Open PR against develop, normalize labels
-- [ ] 3.4 Run om-auto-review-pr and apply fixes
+- [x] 3.2 Code-review + BC self-review — additive test-only files; no contract surface touched
+- [x] 3.3 Opened PR #3567 against develop; labels review, skip-qa, priority-low, risk-low
+- [x] 3.4 Independent adversarial review pass — 0 actional defects (all selectors/assertions/payloads verified against source); no fixes required
+
+## Changelog
+
+- 2026-06-24 — PR #3567 opened. Adversarial review returned clean (no actionable findings). Status: complete.

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-012.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-012.spec.ts
@@ -1,0 +1,204 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import {
+  createRandomCurrencyFixture,
+  deleteCurrenciesEntityIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+import { getTokenContext } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+/**
+ * TC-CUR-012: Currency & exchange-rate list Delete routes through the guarded mutation
+ * Covers: the DELETE write paths refactored in PR #3438 (fixes #3191) — the currencies
+ * (`backend/currencies/page.tsx`) and exchange-rates (`backend/exchange-rates/page.tsx`)
+ * row-action deletes now run through `useGuardedMutation(...).runMutation(...)`.
+ *
+ * This is the committed follow-up requested by the `om-auto-verify-pr-ui` run on #3438,
+ * which exercised these flows with a throwaway spec.
+ *
+ * Asserted behavior (current `develop`): both delete row-actions route through the guard
+ * and the failure is surfaced consistently as the page's error flash, while the row
+ * survives. The delete fails because of a *pre-existing* bug unrelated to #3438 — the UI
+ * sends the record `id` in the request body, but the CRUD factory's DELETE reads it from
+ * the `?id=` query (`packages/shared/src/lib/crud/factory.ts` defaults `del.idFrom: 'query'`),
+ * so the route returns HTTP 400 "ID is required". The point of this test is the guard
+ * routing + consistent error surfacing, not the delete succeeding.
+ *
+ * NOTE: once the body-vs-query `?id=` delete bug is fixed, flip these asserts to expect the
+ * success flash (`Currency deleted successfully` / `Exchange rate deleted successfully`) and
+ * the row's removal from the list.
+ */
+
+// The currencies/exchange-rates lists re-render their rows as data settles
+// (optimistic-lock headers, scope version), which can detach the portalled row
+// actions menu mid-click. Bound each click and retry across a few attempts so a
+// swallowed keypress or a detached element can't hang the run. Mirrors the
+// resilience pattern in TC-CUR-004 / TC-ADMIN-002.
+async function clickRowDelete(page: Page, openMenu: () => Promise<void>): Promise<void> {
+  const deleteItem = page.getByRole('menuitem').filter({ hasText: /^Delete$/ }).first();
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const alreadyOpen = await deleteItem.isVisible().catch(() => false);
+    if (!alreadyOpen) await openMenu();
+    const opened = await deleteItem
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!opened) continue;
+    if (await deleteItem.click({ timeout: 5_000 }).then(() => true).catch(() => false)) return;
+  }
+  throw new Error('Could not click the Delete menu item for the target row.');
+}
+
+function makeMenuOpener(row: Locator): () => Promise<void> {
+  const actionsButton = row.getByRole('button', { name: 'Open actions' });
+  return async () => {
+    await actionsButton.click({ timeout: 5_000 }).catch(async () => {
+      await actionsButton.focus();
+      await actionsButton.press('Enter');
+    });
+  };
+}
+
+test.describe('TC-CUR-012: Currency & exchange-rate Delete routes through the guarded mutation', () => {
+  test('currency list Delete routes through the guard and surfaces the failure flash', async ({ page, request }) => {
+    // Login + list navigation + portalled-menu retries do not fit the default 30s
+    // budget under parallel CI shard load; 60s matches the other UI specs (TC-CUR-004).
+    test.setTimeout(60_000);
+
+    let token: string | null = null;
+    let currencyId: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+
+      const currency = await createRandomCurrencyFixture(request, token, {
+        name: 'QA TC-CUR-012 Currency',
+      });
+      currencyId = currency.id;
+
+      await login(page, 'admin');
+      await page.goto('/backend/currencies');
+
+      // Match the code cell exactly — substring matching on the whole row collides
+      // when a random code appears inside a seeded currency name (see TC-CUR-004).
+      const row = page.getByRole('row').filter({
+        has: page.getByRole('cell', { name: currency.code, exact: true }),
+      });
+      await expect(row).toBeVisible({ timeout: 10_000 });
+
+      await clickRowDelete(page, makeMenuOpener(row));
+
+      const confirmButton = page.getByRole('button', { name: 'Confirm' });
+      await expect(confirmButton).toBeVisible({ timeout: 10_000 });
+      await confirmButton.click();
+
+      // The guarded DELETE fails (pre-existing ?id= bug) → guard surfaces the error flash.
+      await expect(page.getByText('Failed to delete currency').first()).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // The delete did not go through: the currency still exists via the API.
+      await expect
+        .poll(
+          async () => {
+            const response = await apiRequest(
+              request,
+              'GET',
+              `/api/currencies/currencies?code=${encodeURIComponent(currency.code)}&pageSize=10`,
+              { token: token as string },
+            );
+            const body = (await response.json()) as { items?: Array<{ id: string }> };
+            return body.items?.some((item) => item.id === currencyId) ?? false;
+          },
+          { timeout: 10_000 },
+        )
+        .toBe(true);
+    } finally {
+      // Best-effort teardown via the working query-param delete path.
+      await deleteCurrenciesEntityIfExists(
+        request,
+        token,
+        '/api/currencies/currencies',
+        currencyId,
+      ).catch(() => {});
+    }
+  });
+
+  test('exchange-rate list Delete routes through the guard and surfaces the failure flash', async ({ page, request }) => {
+    test.setTimeout(60_000);
+
+    let token: string | null = null;
+    let fromId: string | null = null;
+    let toId: string | null = null;
+    let rateId: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+      const { organizationId, tenantId } = getTokenContext(token);
+
+      const from = await createRandomCurrencyFixture(request, token, { name: 'QA TC-CUR-012 From' });
+      fromId = from.id;
+      const to = await createRandomCurrencyFixture(request, token, { name: 'QA TC-CUR-012 To' });
+      toId = to.id;
+
+      // A unique source so we can locate the row deterministically, and a far-future
+      // date so it sorts to the top of page 1 (the list defaults to date DESC) — neither
+      // the random pair nor the seeded rows can shadow it.
+      const source = `QA-TC-CUR-012-${from.code}${to.code}`;
+      const createResponse = await apiRequest(request, 'POST', '/api/currencies/exchange-rates', {
+        token,
+        data: {
+          organizationId,
+          tenantId,
+          fromCurrencyCode: from.code,
+          toCurrencyCode: to.code,
+          rate: '1.2345',
+          date: '2999-12-31T12:00:00.000Z',
+          source,
+        },
+      });
+      expect(createResponse.status(), 'exchange-rate fixture create').toBe(201);
+      rateId = ((await createResponse.json()) as { id?: string }).id ?? null;
+      expect(rateId).toBeTruthy();
+
+      await login(page, 'admin');
+      await page.goto('/backend/exchange-rates');
+
+      // The pair cell renders "FROM → TO"; identify the row by the unique source string.
+      const row = page.getByRole('row').filter({ hasText: source });
+      await expect(row).toBeVisible({ timeout: 10_000 });
+
+      await clickRowDelete(page, makeMenuOpener(row));
+
+      const confirmButton = page.getByRole('button', { name: 'Confirm' });
+      await expect(confirmButton).toBeVisible({ timeout: 10_000 });
+      await confirmButton.click();
+
+      // The guarded DELETE fails (pre-existing ?id= bug) → guard surfaces the error flash.
+      await expect(page.getByText('Failed to delete exchange rate').first()).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // The delete did not go through: the rate still exists via the API.
+      await expect
+        .poll(
+          async () => {
+            const response = await apiRequest(
+              request,
+              'GET',
+              `/api/currencies/exchange-rates?source=${encodeURIComponent(source)}&pageSize=10`,
+              { token: token as string },
+            );
+            const body = (await response.json()) as { items?: Array<{ id: string }> };
+            return body.items?.some((item) => item.id === rateId) ?? false;
+          },
+          { timeout: 10_000 },
+        )
+        .toBe(true);
+    } finally {
+      await deleteCurrenciesEntityIfExists(request, token, '/api/currencies/exchange-rates', rateId).catch(() => {});
+      await deleteCurrenciesEntityIfExists(request, token, '/api/currencies/currencies', fromId).catch(() => {});
+      await deleteCurrenciesEntityIfExists(request, token, '/api/currencies/currencies', toId).catch(() => {});
+    }
+  });
+});

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-013.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-013.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { createFetchConfigFixture } from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+
+/**
+ * TC-CUR-013: Currency-fetching provider toggle routes through the guarded mutation
+ * Covers: the fetch-config provider toggle (PUT) refactored in PR #3438 (fixes #3191) —
+ * `components/CurrencyFetchingConfig.tsx` `toggleEnabled` now runs through
+ * `useGuardedMutation(...).runMutation(...)`.
+ *
+ * Committed follow-up to the `om-auto-verify-pr-ui` run on #3438, which exercised this
+ * flow with a throwaway spec ("toggle a provider on → 'Provider enabled' flash").
+ *
+ * The toggle PUT carries the record id in the body (the fetch-configs route reads it from
+ * the body, unlike the `?id=` delete bug), so the happy path succeeds: the guarded PUT
+ * flips the switch on and the page flashes "Provider enabled".
+ */
+type FetchConfig = { id: string; provider: string; isEnabled: boolean };
+
+const NBP_PROVIDER = 'NBP';
+const NBP_HEADING = /National Bank of Poland/;
+
+async function readNbpConfig(
+  request: APIRequestContext,
+  token: string,
+): Promise<FetchConfig | null> {
+  const response = await apiRequest(request, 'GET', '/api/currencies/fetch-configs', { token });
+  const body = (await response.json()) as { configs?: FetchConfig[] };
+  return body.configs?.find((config) => config.provider === NBP_PROVIDER) ?? null;
+}
+
+test.describe('TC-CUR-013: Currency-fetching provider toggle routes through the guarded mutation', () => {
+  test('toggling a provider on flashes "Provider enabled" and persists via the guarded PUT', async ({ page, request }) => {
+    // Login + config-page initialization + a guarded PUT do not fit the default 30s
+    // budget under parallel CI shard load; 60s matches the other UI specs.
+    test.setTimeout(60_000);
+
+    let token: string | null = null;
+    let configId: string | null = null;
+    let createdByTest = false;
+    let originalEnabled = false;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+
+      // Deterministic precondition: an NBP fetch-config that exists and is disabled,
+      // so toggling it from the UI is unambiguously an "enable" → "Provider enabled".
+      const existing = await readNbpConfig(request, token);
+      if (existing) {
+        configId = existing.id;
+        originalEnabled = existing.isEnabled;
+        if (existing.isEnabled) {
+          await apiRequest(request, 'PUT', '/api/currencies/fetch-configs', {
+            token,
+            data: { id: existing.id, isEnabled: false },
+          });
+        }
+      } else {
+        configId = await createFetchConfigFixture(request, token, { provider: NBP_PROVIDER, isEnabled: false });
+        createdByTest = true;
+      }
+
+      await login(page, 'admin');
+      await page.goto('/backend/config/currency-fetching');
+
+      // Scope to the NBP provider card (`bg-card` is the DS card container) so we target
+      // only its switch, never the other provider's.
+      const nbpCard = page.locator('.bg-card').filter({
+        has: page.getByRole('heading', { name: NBP_HEADING }),
+      });
+      await expect(nbpCard).toHaveCount(1, { timeout: 15_000 });
+
+      const nbpSwitch = nbpCard.getByRole('switch');
+      await expect(nbpSwitch).toHaveAttribute('aria-checked', 'false', { timeout: 10_000 });
+
+      await nbpSwitch.click();
+
+      await expect(page.getByText('Provider enabled').first()).toBeVisible({ timeout: 10_000 });
+      await expect(nbpSwitch).toHaveAttribute('aria-checked', 'true', { timeout: 10_000 });
+
+      // The guarded PUT persisted: the provider is enabled via the API too.
+      await expect
+        .poll(
+          async () => {
+            const config = await readNbpConfig(request, token as string);
+            return config?.isEnabled ?? false;
+          },
+          { timeout: 10_000 },
+        )
+        .toBe(true);
+    } finally {
+      // Restore the provider to its original state so the run is repeatable.
+      if (token && configId) {
+        if (createdByTest) {
+          await deleteFetchConfig(request, token, configId).catch(() => {});
+        } else {
+          await apiRequest(request, 'PUT', '/api/currencies/fetch-configs', {
+            token,
+            data: { id: configId, isEnabled: originalEnabled },
+          }).catch(() => {});
+        }
+      }
+    }
+  });
+});
+
+// Best-effort cleanup for a config this test created. The fetch-configs route may not
+// expose DELETE; the swallowed error keeps teardown from masking a real failure.
+async function deleteFetchConfig(
+  request: APIRequestContext,
+  token: string,
+  id: string,
+): Promise<void> {
+  await apiRequest(request, 'DELETE', `/api/currencies/fetch-configs?id=${encodeURIComponent(id)}`, { token });
+}


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-24-currencies-guarded-mutation-integration-tests.md
Status: complete

## Goal
- Lock in, with committed Playwright integration tests, that the currencies UI writes refactored in **#3438** (fixes #3191) route through `useGuardedMutation`. Follow-up requested by the `om-auto-verify-pr-ui` run on #3438, which exercised these flows with a throwaway spec.

## What Changed
- **`TC-CUR-012.spec.ts`** (new) — the currencies and exchange-rates list **Delete** row-actions route through the guard and surface the failure flash consistently; the fixture row survives. Two `test()` blocks, one per page (each has its own `handleDelete`).
- **`TC-CUR-013.spec.ts`** (new) — the currency-fetching provider **toggle** routes a guarded PUT: toggling NBP on flashes "Provider enabled" and persists (verified via API).
- No production code changes.

### Why the deletes assert a *failure* flash (current `develop` behavior)
The currency/exchange-rate row delete sends the record `id` in the **request body**, but the CRUD factory's DELETE reads it from the `?id=` **query** (`packages/shared/src/lib/crud/factory.ts` defaults `del.idFrom: 'query'`), so the route returns **HTTP 400 "ID is required"**. This is a **pre-existing bug unrelated to #3438** (which only changed *how* the write is dispatched, not the payload shape). The test's purpose is the guard routing + consistent error surfacing. Each spec carries a `NOTE` explaining how to flip the asserts to the success path once that bug is fixed.

## Tests
- New integration specs only (run via `yarn test:integration` against an ephemeral env). `TC-CUR-012` (currency + exchange-rate guarded DELETE), `TC-CUR-013` (guarded fetch-config toggle).
- Resilience mirrors the proven `TC-CUR-004`/`TC-ADMIN-002` patterns (bounded portalled-menu clicks + retry, `test.setTimeout(60_000)`), with deterministic, self-contained API fixtures and best-effort teardown via the working `?id=` delete path.
- Validation in this fresh worktree: `playwright --list` compiles all 3 tests; `tsc -p packages/core` reports **0 errors in the new specs** (the 199 reported errors are all pre-existing `#generated/*` `TS2307` module-resolution failures — no `yarn generate` has run here — and none touch these files). The full `yarn test`/`build:app` gate runs in CI; note `yarn test` is unit-only and does not execute these `__integration__` Playwright specs.

## Backward Compatibility
- No contract surface changes. Test-only, additive files.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-24-currencies-guarded-mutation-integration-tests.md#progress).
