### PR TITLE
test(auth): integration test for auth.users.create tenant scope (#3549)

### DIFF
--- a/.ai/runs/2026-06-24-auth-users-create-tenant-scope-integration.md
+++ b/.ai/runs/2026-06-24-auth-users-create-tenant-scope-integration.md
@@ -58,8 +58,8 @@ that verifies the create-user tenant-scope guard end-to-end via the public API.
 
 ### Phase 1: Author the integration spec
 
-- [ ] 1.1 Write TC-AUTH-052 spec covering the 3 act/assert cases + teardown
+- [x] 1.1 Write TC-AUTH-052 spec covering the 3 act/assert cases + teardown — 5854d80bb
 
 ### Phase 2: Validate
 
-- [ ] 2.1 Typecheck core package and lint the new spec
+- [x] 2.1 Typecheck core package and lint the new spec — esbuild transpile OK; tsc -p (ignoreDeprecations workaround for the worktree's TS 5.9.3 vs config's "6.0") exits 0; eslint clean (only the unrelated Next pages-dir plugin warning)

--- a/.ai/runs/2026-06-24-auth-users-create-tenant-scope-integration.md
+++ b/.ai/runs/2026-06-24-auth-users-create-tenant-scope-integration.md
@@ -1,0 +1,65 @@
+# Execution Plan — Integration test for `auth.users.create` tenant-scope guard
+
+## Overview
+
+Add the API-level integration test requested in the follow-up comment on PR #3555
+(<https://github.com/open-mercato/open-mercato/pull/3555#issuecomment-4790712986>).
+
+PR #3555 (merged) added a one-line authorization guard to `createUserCommand`
+(`assertTargetTenantInScope(resolveActorTenantScope(ctx), tenantId, 'Organization not found')`)
+so a tenant-scoped admin can no longer create a user inside another tenant. The PR shipped
+a unit test but no integration test. This run locks the cross-tenant boundary in via an
+API integration spec that exercises `POST /api/auth/users`.
+
+### External References
+
+- None. The driving artifact is a GitHub PR comment, not an external skill URL.
+
+## Goal
+
+Add `packages/core/src/modules/auth/__integration__/TC-AUTH-052-users-create-tenant-scope.spec.ts`
+that verifies the create-user tenant-scope guard end-to-end via the public API.
+
+## Scope
+
+- One new integration spec file. No production code changes.
+
+## Non-goals
+
+- No change to `createUserCommand` or any production code — the guard already exists and is merged.
+- No change to the existing unit test.
+- No new fixtures/helpers unless strictly necessary (reuse existing integration helpers).
+
+## Scenario (from the comment, derived from the manual run)
+
+1. **Setup** (API fixtures):
+   - `superadmin@acme.com` token (cross-tenant) + `admin@acme.com` token (non-superadmin, tenant A).
+   - Org A = the admin token's own `orgId` (an org in the actor's tenant A — deterministic).
+   - As superadmin: create tenant **B**; create **orgB** in tenant B.
+2. **Act / Assert**:
+   - admin `POST /api/auth/users` with **orgA** → **201** (same-tenant allowed).
+   - admin `POST /api/auth/users` with **orgB** → **404** `{"error":"Organization not found"}`;
+     assert **no** user row exists in tenant B for that email (superadmin list scoped to tenant B,
+     filtered by `organizationId=orgB`).
+   - superadmin `POST /api/auth/users` with **orgB** → **201** (cross-tenant allowed for superadmin).
+3. **Teardown**: delete users created in T1/T3, orgB, and tenant B via `deleteGeneralEntityIfExists`.
+   Self-contained, independent of seeded data.
+
+## Risks
+
+- Email-by-search is unreliable in the integration runner (search_tokens not synchronously
+  populated). Mitigation: assert non-existence by listing users filtered by `organizationId=orgB`
+  (decrypted `email` is returned in list items) rather than by `?search=<email>`.
+- `admin@acme.com` must carry `auth.users.create` — confirmed (`auth` setup grants `admin: ['auth.*']`).
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Author the integration spec
+
+- [ ] 1.1 Write TC-AUTH-052 spec covering the 3 act/assert cases + teardown
+
+### Phase 2: Validate
+
+- [ ] 2.1 Typecheck core package and lint the new spec

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-052-users-create-tenant-scope.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-052-users-create-tenant-scope.spec.ts
@@ -1,0 +1,176 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { randomInt } from 'node:crypto';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import {
+  deleteGeneralEntityIfExists,
+  expectId,
+  getTokenContext,
+  readJsonSafe,
+} from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createOrganizationFixture,
+  deleteOrganizationIfExists,
+  deleteUserIfExists,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+
+/**
+ * TC-AUTH-052 [P1]: `auth.users.create` enforces target-tenant scope (#3549, PR #3555).
+ *
+ * `POST /api/auth/users` derives the target tenant from the request body's `organizationId`.
+ * Before the fix a tenant-scoped administrator could pass an organization belonging to ANOTHER
+ * tenant and silently create a user there (#3549). The merged guard
+ * (`assertTargetTenantInScope(resolveActorTenantScope(ctx), tenantId, 'Organization not found')`)
+ * now returns 404 for non-super-admins targeting a foreign tenant, while super-admins remain
+ * unaffected.
+ *
+ * The PR shipped a command-level unit test; this locks the boundary in at the API layer so the
+ * isolation guard cannot silently regress. Covers: POST /api/auth/users (create command tenant
+ * scope) + GET /api/auth/users (superadmin tenant-scoped listing used to prove non-existence).
+ */
+type CreateResponse = { id?: string };
+type CreateError = { error?: string };
+type UserListItem = { id?: string; email?: string; organizationId?: string | null };
+type UserListResponse = { items?: UserListItem[] };
+
+const BASE_URL = process.env.BASE_URL?.trim() || null;
+
+function resolveUrl(path: string): string {
+  return BASE_URL ? `${BASE_URL}${path}` : path;
+}
+
+async function createTenant(request: APIRequestContext, token: string, name: string): Promise<string> {
+  const response = await apiRequest(request, 'POST', '/api/directory/tenants', { token, data: { name } });
+  expect(response.status(), 'POST /api/directory/tenants should return 201').toBe(201);
+  const body = await readJsonSafe<CreateResponse>(response);
+  return expectId(body?.id, 'Tenant create response should contain an id');
+}
+
+function createUser(request: APIRequestContext, token: string, organizationId: string, email: string) {
+  return apiRequest(request, 'POST', '/api/auth/users', {
+    token,
+    data: { email, password: 'StrongSecret123!', organizationId },
+  });
+}
+
+/**
+ * Lists users as a super-admin scoped to a specific tenant (via the topbar context cookie) and
+ * narrowed to one organization. Returns the decrypted emails so the test can assert presence /
+ * absence of a specific account inside tenant B without depending on the unreliable encrypted
+ * email search index.
+ */
+async function listOrganizationUserEmails(
+  request: APIRequestContext,
+  token: string,
+  tenantId: string,
+  organizationId: string,
+): Promise<string[]> {
+  const cookie = [
+    `om_selected_tenant=${encodeURIComponent(tenantId)}`,
+    `om_selected_org=${encodeURIComponent('__all__')}`,
+  ].join('; ');
+  const response = await request.fetch(
+    resolveUrl(`/api/auth/users?organizationId=${encodeURIComponent(organizationId)}&pageSize=100`),
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Cookie: cookie,
+      },
+    },
+  );
+  expect(response.status(), 'GET /api/auth/users (tenant-scoped) should return 200').toBe(200);
+  const body = (await readJsonSafe<UserListResponse>(response)) ?? {};
+  return (body.items ?? [])
+    .map((item) => (typeof item.email === 'string' ? item.email : null))
+    .filter((email): email is string => typeof email === 'string' && email.length > 0);
+}
+
+test.describe('TC-AUTH-052: create-user tenant scope (#3549)', () => {
+  test('blocks a tenant admin from creating a user in a foreign tenant but allows a superadmin', async ({ request }) => {
+    const superadminToken = await getAuthToken(request, 'superadmin');
+    const adminToken = await getAuthToken(request, 'admin');
+
+    // The admin's own org is, by definition, an organization inside the actor's tenant A.
+    const { organizationId: organizationA } = getTokenContext(adminToken);
+    expectId(organizationA, 'admin token should carry a home organization (tenant A org)');
+
+    const stamp = `${Date.now()}-${randomInt(1_000_000)}`;
+    const emailSameTenant = `qa-tc-auth-052-a-${stamp}@example.com`;
+    const emailForeignTenant = `qa-tc-auth-052-b-${stamp}@example.com`;
+
+    let tenantB: string | null = null;
+    let organizationB: string | null = null;
+    let sameTenantUserId: string | null = null;
+    let crossTenantUserId: string | null = null;
+
+    try {
+      // Setup: a separate tenant B with its own organization, created by the superadmin.
+      tenantB = await createTenant(request, superadminToken, `QA AUTH 052 Tenant B ${stamp}`);
+      organizationB = await createOrganizationFixture(request, superadminToken, {
+        name: `QA AUTH 052 Org B ${stamp}`,
+        tenantId: tenantB,
+      });
+
+      // T1: admin creates a user within their own tenant → allowed.
+      const sameTenantResponse = await createUser(request, adminToken, organizationA, emailSameTenant);
+      expect(sameTenantResponse.status(), 'admin create within own tenant should return 201').toBe(201);
+      sameTenantUserId = expectId(
+        (await readJsonSafe<CreateResponse>(sameTenantResponse))?.id,
+        'same-tenant user id',
+      );
+
+      // T2: admin targets tenant B's organization → blocked with 404 (guard treats it as not found).
+      const crossTenantBlocked = await createUser(request, adminToken, organizationB, emailForeignTenant);
+      expect(
+        crossTenantBlocked.status(),
+        'admin create targeting a foreign-tenant org should return 404',
+      ).toBe(404);
+      const blockedBody = await readJsonSafe<CreateError>(crossTenantBlocked);
+      expect(blockedBody?.error, 'blocked response should report Organization not found').toBe(
+        'Organization not found',
+      );
+
+      // ...and no user row leaked into tenant B for that email.
+      const tenantBEmailsAfterBlock = await listOrganizationUserEmails(
+        request,
+        superadminToken,
+        tenantB,
+        organizationB,
+      );
+      expect(
+        tenantBEmailsAfterBlock,
+        'blocked cross-tenant create must not have created a user in tenant B',
+      ).not.toContain(emailForeignTenant);
+
+      // T3: the same target is allowed for a superadmin (cross-tenant create is their privilege).
+      const crossTenantAllowed = await createUser(request, superadminToken, organizationB, emailForeignTenant);
+      expect(
+        crossTenantAllowed.status(),
+        'superadmin create targeting tenant B should return 201',
+      ).toBe(201);
+      crossTenantUserId = expectId(
+        (await readJsonSafe<CreateResponse>(crossTenantAllowed))?.id,
+        'cross-tenant user id',
+      );
+
+      // Sanity: the tenant-B listing surfaces the user once it legitimately exists, proving the
+      // negative assertion in T2 was meaningful (the list query does reach orgB users).
+      const tenantBEmailsAfterCreate = await listOrganizationUserEmails(
+        request,
+        superadminToken,
+        tenantB,
+        organizationB,
+      );
+      expect(
+        tenantBEmailsAfterCreate,
+        'superadmin-created user should be visible in the tenant B listing',
+      ).toContain(emailForeignTenant);
+    } finally {
+      await deleteUserIfExists(request, superadminToken, sameTenantUserId);
+      await deleteUserIfExists(request, superadminToken, crossTenantUserId);
+      await deleteOrganizationIfExists(request, superadminToken, organizationB);
+      await deleteGeneralEntityIfExists(request, superadminToken, '/api/directory/tenants', tenantB);
+    }
+  });
+});


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-24-auth-users-create-tenant-scope-integration.md
Status: complete

## Goal
- Add the API-level integration test requested in the follow-up comment on #3555 (which fixed #3549) so the `auth.users.create` cross-tenant boundary cannot silently regress.

## What Changed
- New spec `packages/core/src/modules/auth/__integration__/TC-AUTH-052-users-create-tenant-scope.spec.ts` exercising `POST /api/auth/users` across a real two-tenant setup:
  - tenant admin creates a user in their **own** tenant's org → **201**
  - tenant admin targets a **foreign-tenant** org → **404** `{"error":"Organization not found"}`, and a superadmin tenant-scoped list proves **no** user row leaked into tenant B
  - superadmin targets the same foreign org → **201** (cross-tenant create is their privilege)
  - a post-create re-list confirms the tenant-B listing surfaces the user once it legitimately exists, so the T2 negative assertion is meaningful (not a false pass)
- No production code changes — the guard already shipped in #3555.

## Tests
- Integration: `TC-AUTH-052` (self-contained — provisions tenant B + org B via API fixtures, deletes users/org/tenant in `finally`; independent of seeded data).
- Verification: esbuild transpile-check (mirrors how Playwright loads specs) passes; `tsc -p` over the spec + integration helpers exits 0 (the worktree resolved TS 5.9.3 while the repo tsconfig requests `ignoreDeprecations: "6.0"`, so a scoped override was used purely to run the type-checker); eslint clean apart from the repo's unrelated Next.js `no-html-link-for-pages` plugin warning.

## Backward Compatibility
- No contract surface changes (test-only addition).

## Progress
See [Progress section in the plan](.ai/runs/2026-06-24-auth-users-create-tenant-scope-integration.md#progress).
