### PR TITLE
fix(record_locks): defer OSS optimistic-lock 409 to conflict bar, not merge dialog (#3504)

### DIFF
--- a/.ai/runs/2026-06-24-record-locks-defer-oss-409-to-conflict-bar.md
+++ b/.ai/runs/2026-06-24-record-locks-defer-oss-409-to-conflict-bar.md
@@ -62,9 +62,9 @@ blast radius, same behavior.
 
 ### Phase 1: Implement fix + tests
 
-- [ ] 1.1 Add `lib/optimisticLockFloor.ts` (`isOptimisticLockFloorConflict`, `classifyUnmatchedSaveError`)
-- [ ] 1.2 Gate the widget's no-payload-409 fallback-dialog branch via `classifyUnmatchedSaveError`
-- [ ] 1.3 Add `__tests__/optimisticLockFloor.test.ts` (predicate + classifier guard, incl. #3504 defer case)
+- [x] 1.1 Add `lib/optimisticLockFloor.ts` (`isOptimisticLockFloorConflict`, `classifyUnmatchedSaveError`) — ad5212870
+- [x] 1.2 Gate the widget's no-payload-409 fallback-dialog branch via `classifyUnmatchedSaveError` — ad5212870
+- [x] 1.3 Add `__tests__/optimisticLockFloor.test.ts` (predicate + classifier guard, incl. #3504 defer case) — ad5212870 (10 cases; record_locks suite 12/72 green)
 
 ### Phase 2: Validate + ship
 

--- a/.ai/runs/2026-06-24-record-locks-defer-oss-409-to-conflict-bar.md
+++ b/.ai/runs/2026-06-24-record-locks-defer-oss-409-to-conflict-bar.md
@@ -70,4 +70,7 @@ blast radius, same behavior.
 
 - [x] 2.1 Targeted validation (enterprise jest + typecheck on changed files) — record_locks 12/72, predicate suite 10/10
 - [x] 2.2 Full validation gate (build:packages, generate, i18n, typecheck 21/21, enterprise test 49/417, build:app) — all green
-- [ ] 2.3 Open PR, close #3550 with explanation + credit, normalize labels
+- [x] 2.3 Open PR, close #3550 with explanation + credit, normalize labels — PR #3569; #3550 closed; labels review/bug/enterprise/needs-qa/priority-medium/risk-medium
+
+## Changelog
+- PR #3569 opened against develop. Independent re-implementation of #3550's #3504 fix, authored in-house; #3550 closed with credit to @adeptofvoltron. Automated review (2 finders + verify) returned no actionable findings. Left in `review` (not self-routed to merge-queue) because the author is the maintainer — a human reviewer + QA should own the merge given the commercial-enterprise provenance.

--- a/.ai/runs/2026-06-24-record-locks-defer-oss-409-to-conflict-bar.md
+++ b/.ai/runs/2026-06-24-record-locks-defer-oss-409-to-conflict-bar.md
@@ -1,0 +1,73 @@
+# Execution plan — record_locks: defer OSS optimistic-lock 409 to conflict bar (#3504)
+
+## Context / Provenance
+
+This re-implements the fix for issue **#3504** ("with enterprise `record_locks` enabled, a
+concurrent-edit 409 on a standard `makeCrudRoute`/`CrudForm` screen renders TWO conflict
+surfaces — the OSS conflict bar AND the enterprise merge dialog — violating the single-surface
+invariant S3"). The problem and root cause were originally diagnosed and a fix proposed by
+external contributor **@adeptofvoltron** in PR #3550 (fork PR).
+
+Because `packages/enterprise` is the commercial enterprise package, the maintainer cannot accept
+an external fork contribution directly into it. This PR therefore lands an **independent
+implementation** of the same fix authored in-house, and **credits @adeptofvoltron** for the
+diagnosis and proposed solution. PR #3550 is closed in favor of this one.
+
+## Goal
+
+When the enterprise record-lock widget receives a save-time 409 that carries **no**
+`record_lock_conflict` payload but **is** an OSS optimistic-lock-floor conflict
+(`code: 'optimistic_lock_conflict'`), the widget must **stand down** and let the shared OSS
+conflict bar own the conflict — instead of opening a second, degraded merge dialog. Genuine
+`record_lock_conflict` 409s and non-optimistic-lock 409s keep their current behavior.
+
+## Scope
+
+- `packages/enterprise/src/modules/record_locks/` only.
+- New helper file `lib/optimisticLockFloor.ts` (pure, React-free, unit-testable).
+- One narrowed branch in `widgets/injection/record-locking/widget.client.tsx`.
+- New unit test `__tests__/optimisticLockFloor.test.ts`.
+
+## Non-goals
+
+- The degraded "Accept incoming" no-op (issue #3505) — already fixed and merged in #3551.
+- Any refactor of the rest of the `onCrudSaveError` listener (relevance gating, record-deleted
+  handling) beyond the single contested 409 branch.
+- No contract-surface, event-ID, ACL, DI, route, or DB change.
+
+## Independent-implementation note (differs from #3550)
+
+#3550 extracted the **whole** listener decision into a 5-value action enum
+(`decideCrudSaveErrorAction` → `record-deleted | open-fallback-dialog | apply-record-lock-payload
+| defer-to-oss-conflict-bar | ignore`) and rewired the widget to a `switch`. This implementation
+is intentionally narrower and structured differently: it leaves the listener's existing
+relevance/record-deleted control flow intact and extracts **only the contested no-payload-409
+decision** into `classifyUnmatchedSaveError` (3-value: `fallback-merge-dialog |
+defer-to-conflict-bar | ignore`) plus the predicate `isOptimisticLockFloorConflict`. Minimal
+blast radius, same behavior.
+
+## Risks
+
+- The widget's `onCrudSaveError` is React-internal; the pure helper is unit-tested but the
+  one-line wiring (calling the helper to gate the fallback branch) is verified by reading the
+  diff + the existing record_locks suite. Mitigated by keeping the wiring to a single, obvious
+  `if`.
+- `isOptimisticLockFloorConflict` reuses the canonical OSS detector `extractOptimisticLockConflict`
+  (status===409 + `optimistic_lock_conflict` code), so it cannot drift from the OSS bar's own
+  classification — the two surfaces decide off the same predicate.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Implement fix + tests
+
+- [ ] 1.1 Add `lib/optimisticLockFloor.ts` (`isOptimisticLockFloorConflict`, `classifyUnmatchedSaveError`)
+- [ ] 1.2 Gate the widget's no-payload-409 fallback-dialog branch via `classifyUnmatchedSaveError`
+- [ ] 1.3 Add `__tests__/optimisticLockFloor.test.ts` (predicate + classifier guard, incl. #3504 defer case)
+
+### Phase 2: Validate + ship
+
+- [ ] 2.1 Targeted validation (enterprise jest + typecheck/lint on changed files)
+- [ ] 2.2 Full validation gate (build:packages, generate, i18n, typecheck, test, build:app)
+- [ ] 2.3 Open PR, close #3550 with explanation + credit, normalize labels

--- a/.ai/runs/2026-06-24-record-locks-defer-oss-409-to-conflict-bar.md
+++ b/.ai/runs/2026-06-24-record-locks-defer-oss-409-to-conflict-bar.md
@@ -68,6 +68,6 @@ blast radius, same behavior.
 
 ### Phase 2: Validate + ship
 
-- [ ] 2.1 Targeted validation (enterprise jest + typecheck/lint on changed files)
-- [ ] 2.2 Full validation gate (build:packages, generate, i18n, typecheck, test, build:app)
+- [x] 2.1 Targeted validation (enterprise jest + typecheck on changed files) — record_locks 12/72, predicate suite 10/10
+- [x] 2.2 Full validation gate (build:packages, generate, i18n, typecheck 21/21, enterprise test 49/417, build:app) — all green
 - [ ] 2.3 Open PR, close #3550 with explanation + credit, normalize labels

--- a/packages/enterprise/src/modules/record_locks/__tests__/optimisticLockFloor.test.ts
+++ b/packages/enterprise/src/modules/record_locks/__tests__/optimisticLockFloor.test.ts
@@ -1,0 +1,104 @@
+import {
+  classifyUnmatchedSaveError,
+  isOptimisticLockFloorConflict,
+} from '../lib/optimisticLockFloor'
+import { OPTIMISTIC_LOCK_CONFLICT_CODE } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+
+/**
+ * Regression guard for issue #3504: on the standard makeCrudRoute / CrudForm save
+ * path a concurrent-edit 409 is an OSS optimistic-lock-floor conflict, already
+ * owned by the shared conflict bar. The record-lock widget must defer to that bar
+ * for these 409s rather than open a second, degraded merge dialog (single-surface
+ * invariant S3). Ownership is decided by `isOptimisticLockFloorConflict`, which must
+ * be true only for OSS optimistic-lock 409s and false for genuine record-lock
+ * conflicts and everything else.
+ */
+describe('isOptimisticLockFloorConflict', () => {
+  const optimisticLockBody = {
+    error: 'record_modified',
+    code: OPTIMISTIC_LOCK_CONFLICT_CODE,
+    currentUpdatedAt: '2026-06-24T10:00:01.000Z',
+    expectedUpdatedAt: '2026-06-24T10:00:00.000Z',
+  }
+
+  it('is true for an OSS optimistic-lock 409 with a nested body (CrudForm shape)', () => {
+    expect(isOptimisticLockFloorConflict({ status: 409, body: optimisticLockBody })).toBe(true)
+  })
+
+  it('is true for an OSS optimistic-lock 409 with fields attached directly to the error', () => {
+    expect(isOptimisticLockFloorConflict({ status: 409, ...optimisticLockBody })).toBe(true)
+  })
+
+  it('is false for a genuine record-lock conflict 409 (merge dialog owns it)', () => {
+    expect(
+      isOptimisticLockFloorConflict({
+        status: 409,
+        body: {
+          error: 'record_lock_conflict',
+          code: 'record_lock_conflict',
+          conflictId: 'a0000000-0000-4000-8000-000000000001',
+          resourceKind: 'catalog.product',
+          resourceId: 'b0000000-0000-4000-8000-000000000001',
+          resolutionOptions: ['accept_mine'],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('is false for a 409 carrying the code but missing the updated-at timestamps', () => {
+    expect(
+      isOptimisticLockFloorConflict({
+        status: 409,
+        body: { error: 'record_modified', code: OPTIMISTIC_LOCK_CONFLICT_CODE },
+      }),
+    ).toBe(false)
+  })
+
+  it('is false when the optimistic-lock code rides a non-409 status', () => {
+    expect(isOptimisticLockFloorConflict({ status: 422, body: optimisticLockBody })).toBe(false)
+  })
+
+  it('is false for nullish and non-object inputs', () => {
+    expect(isOptimisticLockFloorConflict(null)).toBe(false)
+    expect(isOptimisticLockFloorConflict(undefined)).toBe(false)
+    expect(isOptimisticLockFloorConflict('boom')).toBe(false)
+  })
+})
+
+/**
+ * Wiring guard for issue #3504: the predicate above proves classification, but the
+ * bug lived in which surface the widget's `onCrudSaveError` listener drives for a
+ * save error that produced no record_lock_conflict payload. That decision is
+ * extracted to `classifyUnmatchedSaveError`; these cases lock in that an OSS
+ * optimistic-lock 409 defers to the shared conflict bar (no merge dialog), while
+ * other 409s keep the fallback dialog and non-409s are ignored.
+ */
+describe('classifyUnmatchedSaveError', () => {
+  const optimisticLock409 = {
+    status: 409,
+    body: {
+      error: 'record_modified',
+      code: OPTIMISTIC_LOCK_CONFLICT_CODE,
+      currentUpdatedAt: '2026-06-24T10:00:01.000Z',
+      expectedUpdatedAt: '2026-06-24T10:00:00.000Z',
+    },
+  }
+
+  it('defers an OSS optimistic-lock 409 to the shared conflict bar (no merge dialog)', () => {
+    expect(classifyUnmatchedSaveError(optimisticLock409, 409)).toBe('defer-to-conflict-bar')
+  })
+
+  it('opens the fallback merge dialog for a 409 that is not an optimistic-lock conflict', () => {
+    expect(classifyUnmatchedSaveError({ status: 409, body: { error: 'conflict' } }, 409)).toBe(
+      'fallback-merge-dialog',
+    )
+  })
+
+  it('ignores a non-409 error (no conflict surface for this widget to drive)', () => {
+    expect(classifyUnmatchedSaveError({ status: 422 }, 422)).toBe('ignore')
+  })
+
+  it('ignores when the listener could not resolve an error status', () => {
+    expect(classifyUnmatchedSaveError(optimisticLock409, null)).toBe('ignore')
+  })
+})

--- a/packages/enterprise/src/modules/record_locks/lib/optimisticLockFloor.ts
+++ b/packages/enterprise/src/modules/record_locks/lib/optimisticLockFloor.ts
@@ -1,0 +1,51 @@
+import { extractOptimisticLockConflict } from '@open-mercato/ui/backend/utils/optimisticLock'
+
+/**
+ * True when `error` is an OSS optimistic-lock-floor conflict — an HTTP 409 whose
+ * body carries `code: 'optimistic_lock_conflict'`, the shape every standard
+ * `makeCrudRoute` route raises on a stale `CrudForm` save.
+ *
+ * Such a conflict is already surfaced by the shared OSS conflict bar
+ * (`surfaceRecordConflict` / `record-conflict-banner`). The enterprise record-lock
+ * widget consults this predicate so it can stand down for those 409s instead of
+ * opening a second, degraded merge dialog — preserving the single-conflict-surface
+ * invariant S3 (issue #3504). The merge dialog stays reserved for genuine
+ * `record_lock_conflict` 409s.
+ *
+ * Reusing the canonical OSS detector keeps this decision identical to the one the
+ * conflict bar makes, so the two surfaces can never disagree about ownership.
+ */
+export function isOptimisticLockFloorConflict(error: unknown): boolean {
+  return extractOptimisticLockConflict(error) !== null
+}
+
+/**
+ * What the record-lock widget should do with a save error that produced **no**
+ * `record_lock_conflict` payload (`extractRecordLockConflictPayload` returned null):
+ *
+ * - `defer-to-conflict-bar` — an OSS optimistic-lock-floor 409 the shared conflict
+ *   bar already owns; the widget must NOT open a merge dialog (#3504 / S3).
+ * - `fallback-merge-dialog` — a different 409; synthesize the fallback merge dialog
+ *   (prior behavior, unchanged).
+ * - `ignore` — not a 409; nothing for this widget to surface.
+ */
+export type UnmatchedSaveErrorOutcome =
+  | 'defer-to-conflict-bar'
+  | 'fallback-merge-dialog'
+  | 'ignore'
+
+/**
+ * Pure decision for the no-payload branch of the widget's `onCrudSaveError`
+ * listener. Extracted so the #3504 arbitration — deferring optimistic-lock-floor
+ * 409s to the shared conflict bar — is unit-testable without rendering the client
+ * widget. `status` is the value the listener already computed via its own
+ * `extractErrorStatus`, so the 409 gate stays consistent with the rest of the
+ * listener.
+ */
+export function classifyUnmatchedSaveError(
+  error: unknown,
+  status: number | null,
+): UnmatchedSaveErrorOutcome {
+  if (status !== 409) return 'ignore'
+  return isOptimisticLockFloorConflict(error) ? 'defer-to-conflict-bar' : 'fallback-merge-dialog'
+}

--- a/packages/enterprise/src/modules/record_locks/widgets/injection/record-locking/widget.client.tsx
+++ b/packages/enterprise/src/modules/record_locks/widgets/injection/record-locking/widget.client.tsx
@@ -32,6 +32,7 @@ import {
   type RecordLockUiView,
 } from '@open-mercato/enterprise/modules/record_locks/lib/clientLockStore'
 import { isUuid, resolveConflictId, runAcceptIncoming } from './conflictResolution'
+import { classifyUnmatchedSaveError } from '@open-mercato/enterprise/modules/record_locks/lib/optimisticLockFloor'
 
 type CrudInjectionContext = {
   formId?: string
@@ -1043,7 +1044,10 @@ export default function RecordLockingWidget({
           })
           return
         }
-        if (extractErrorStatus(detail.error) === 409) {
+        // Single-surface arbitration (issue #3504 / S3): an OSS optimistic-lock-floor
+        // 409 is already owned by the shared conflict bar, so defer to it instead of
+        // opening a second, degraded merge dialog. Other 409s keep the fallback dialog.
+        if (classifyUnmatchedSaveError(detail.error, extractErrorStatus(detail.error)) === 'fallback-merge-dialog') {
           applyConflictPayload(buildFallbackConflict(currentState))
         }
         return


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-24-record-locks-defer-oss-409-to-conflict-bar.md
Status: complete

Fixes #3504

## Goal
- With enterprise `record_locks` enabled, a concurrent-edit **409 on a standard `makeCrudRoute` / `CrudForm` screen** must surface **exactly one** conflict surface. It currently renders **two** — the OSS conflict bar (`record-conflict-banner`) **and** the enterprise merge dialog — violating the single-surface invariant (S3). While both are up, the dialog overlay intercepts pointer events and blocks the OSS bar's "Odśwież/Refresh", the only working recovery control.

## Provenance & credit (please read)
- This is an **independent re-implementation** of the fix originally diagnosed and proposed by **@adeptofvoltron** in PR #3550. Because `packages/enterprise` is the **commercial enterprise package**, the maintainer cannot merge an external fork contribution directly into it. The fix is therefore re-authored in-house here, with full credit to @adeptofvoltron for the root-cause analysis and the proposed solution.
- PR #3550 is being closed in favor of this PR. The sibling issue #3505 ("Accept incoming" no-op) was a separate fix already merged in #3551.

## Root Cause
The save-time 409 from the CRUD path is the **OSS** optimistic-lock shape (`code: 'optimistic_lock_conflict'`), not the enterprise `record_lock_conflict` shape. `extractRecordLockConflictPayload` returns `null` for it, so the widget's `onCrudSaveError` listener fell into its fallback branch and opened the **merge dialog on _any_ 409** — even though the OSS conflict bar already owns this conflict.

## What Changed
- New pure, React-free helper `packages/enterprise/src/modules/record_locks/lib/optimisticLockFloor.ts`:
  - `isOptimisticLockFloorConflict(error)` — reuses the canonical OSS detector `extractOptimisticLockConflict`, so the widget classifies **identically** to the conflict bar (the two surfaces can never disagree about ownership).
  - `classifyUnmatchedSaveError(error, status)` — decides the no-payload branch: `defer-to-conflict-bar` for optimistic-lock-floor 409s, `fallback-merge-dialog` for other 409s, `ignore` otherwise.
- `widget.client.tsx`: the no-payload-409 branch now gates the fallback merge dialog through `classifyUnmatchedSaveError`, so optimistic-lock-floor 409s **defer to the OSS bar** instead of opening a second, degraded surface. Genuine `record_lock_conflict` 409s and non-optimistic-lock 409s are unchanged.

> Implementation note: this intentionally differs from #3550's approach. #3550 extracted the **whole** listener into a 5-value action enum and rewired it to a `switch`; this version is narrower — it leaves the listener's relevance/record-deleted control flow intact and extracts only the contested decision. Minimal blast radius, same behavior.

## Tests
- New `__tests__/optimisticLockFloor.test.ts` (10 cases): `isOptimisticLockFloorConflict` true only for OSS optimistic-lock 409s (nested-body + flat shapes) and false for genuine record-lock conflicts, code-without-timestamps, non-409 status, and nullish/non-object inputs; `classifyUnmatchedSaveError` defers the optimistic-lock 409 (the #3504 invariant), opens the fallback for other 409s, ignores non-409s and unresolved status.
- `record_locks` suite: 12 suites / 72 tests pass. Full `@open-mercato/enterprise`: 49 suites / 417 tests pass.
- Full gate: `build:packages` ✓, `generate` ✓, `typecheck` ✓ (21/21), `i18n:check-sync` ✓, `build:app` ✓.

## Backward Compatibility
- No contract-surface changes. Net-additive: one new internal helper file and a narrowed internal `if`-condition. No event IDs, widget spot IDs, ACL IDs, DI keys, API routes, response fields, import paths, or DB schema touched.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-24-record-locks-defer-oss-409-to-conflict-bar.md#progress).
