### PR TITLE
ci: dispatch package previews manually

### DIFF
--- a/.ai/skills/om-auto-publish-pr/SKILL.md
+++ b/.ai/skills/om-auto-publish-pr/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: om-auto-publish-pr
+description: Publish pkg.pr.new package previews for a same-repository Open Mercato PR by dispatching the Package Previews GitHub Actions workflow with gh. Use when a maintainer asks to publish, republish, or trigger a PR package preview. Does not publish npm snapshots.
+---
+
+# Auto Publish PR Preview
+
+Dispatch the `Package Previews` workflow for a PR. This publishes pkg.pr.new previews only; do not invoke `NPM Snapshot Preview` from this skill.
+
+## Arguments
+
+- `{pr_number}` (required) - Pull request number to publish previews for.
+- `--repo <owner/name>` (optional) - Defaults to the current repository.
+- `--ref <branch>` (optional) - Workflow definition ref. Default: `develop`.
+
+## Procedure
+
+1. Resolve inputs and confirm the PR exists:
+
+```bash
+REPO="${REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+PR_NUMBER="{pr_number}"
+WORKFLOW_REF="${WORKFLOW_REF:-develop}"
+
+gh pr view "$PR_NUMBER" --repo "$REPO" \
+  --json number,title,headRepositoryOwner,headRefName,headRefOid,isCrossRepository
+```
+
+2. If `isCrossRepository` is `true`, stop. The workflow rejects fork PRs because it runs publish-capable automation from a trusted workflow context.
+
+3. Dispatch the preview workflow:
+
+```bash
+gh workflow run package-previews.yml \
+  --repo "$REPO" \
+  --ref "$WORKFLOW_REF" \
+  -f "pr_number=$PR_NUMBER"
+```
+
+4. Find the newest run for the workflow and report it:
+
+```bash
+sleep 3
+gh run list \
+  --repo "$REPO" \
+  --workflow package-previews.yml \
+  --limit 5
+```
+
+5. Final response must include:
+
+- PR number and title.
+- The workflow ref used.
+- The dispatch command result.
+- The newest relevant run URL when available.
+
+## Guardrails
+
+- Do not commit, push, label, or merge anything.
+- Do not dispatch `npm-snapshot-preview.yml`; that is intentionally a separate manual path.
+- If the workflow is not found on `develop`, tell the user to pass `--ref <branch-with-workflow>` or wait until the workflow change is merged.

--- a/.ai/skills/tiers.json
+++ b/.ai/skills/tiers.json
@@ -43,6 +43,7 @@
         "om-followup-issue-from-pr",
         "om-sync-merged-pr-issues",
         "om-auto-update-changelog",
+        "om-auto-publish-pr",
         "om-auto-qa-scenarios",
         "om-auto-verify-pr-ui"
       ]

--- a/.ai/specs/2026-06-05-phased-integration-ci.md
+++ b/.ai/specs/2026-06-05-phased-integration-ci.md
@@ -19,7 +19,7 @@ The model:
 | `extended` | Non-fork PR with `extended-integration` label, or manual workflow input | Baseline plus tagged expensive suites: undo, broad CrudForm, optimistic-lock matrix, custom-field matrix, queue/realtime, long request suites | Only when requested or required by policy |
 | `full` | Push to `develop`/`main`, shared-path PRs, and every PR targeting `main` | All monorepo integration specs, sharded, with coverage | Yes for release PRs and protected branch pushes |
 | `standalone-sentinel` | Standalone-impact paths or `extended-integration` label on a non-fork PR | Minimal create-app installed-package smoke coverage | Required for standalone-impact PRs |
-| `standalone-full` | Develop snapshot/release pipeline, every release PR to `main`, and PRs explicitly labeled `publish-npm-snapshot` | Full standalone app integration against published/snapshot packages | Yes before release and opt-in npm snapshot previews |
+| `standalone-full` | Develop snapshot/release pipeline, every release PR to `main`, and PRs explicitly dispatched with `NPM Snapshot Preview` | Full standalone app integration against published/snapshot packages | Yes before release and opt-in npm snapshot previews |
 
 The critical safety rule: unknown paths, unknown metadata, fork restrictions, or manifest mismatches always fall back to current/full behavior. This spec extends the implemented CI performance work in [`.ai/specs/implemented/2026-04-10-ci-cd-performance.md`](implemented/2026-04-10-ci-cd-performance.md) and the label workflow in [`.ai/specs/implemented/2026-04-13-pr-label-workflow.md`](implemented/2026-04-13-pr-label-workflow.md).
 
@@ -156,7 +156,7 @@ Standalone coverage gets two lanes:
 | Lane | Trigger | Scope |
 |---|---|---|
 | `standalone-sentinel` | non-fork PR touching standalone-impact paths, or `extended-integration` label with standalone-impact paths | create-app scaffold/install/generate/initialize/login, one CRUD API, one backend UI load, queue helper path, enterprise-enabled module check |
-| `standalone-full` | develop snapshot pipeline, every release PR to `main`, and PRs explicitly labeled `publish-npm-snapshot` | current full standalone integration, ideally using published snapshot package versions |
+| `standalone-full` | develop snapshot pipeline, every release PR to `main`, and PRs explicitly dispatched with `NPM Snapshot Preview` | current full standalone integration, ideally using published snapshot package versions |
 
 Standalone-impact paths:
 

--- a/.ai/specs/2026-06-22-label-based-package-previews.md
+++ b/.ai/specs/2026-06-22-label-based-package-previews.md
@@ -1,4 +1,4 @@
-# Label-Based Package Previews
+# Explicit Package Previews
 
 **Date:** 2026-06-22
 **Status:** Approved
@@ -7,10 +7,10 @@
 
 ## TLDR
 
-PRs must no longer publish npm snapshot packages automatically. Maintainers can request package previews explicitly:
+PRs must no longer publish npm snapshot packages automatically. Maintainers can request package previews explicitly without creating skipped preview checks for unrelated labels or no-op comment-router checks for ordinary PR comments:
 
-- `publish-pkg-preview` publishes pkg.pr.new previews without publishing to npm.
-- `publish-npm-snapshot` runs the previous npm canary snapshot path, including standalone integration, only when the team wants to compare it against pkg.pr.new previews.
+- Manual `Package Previews` workflow dispatches, `gh workflow run`, or the `om-auto-publish-pr` skill publish pkg.pr.new previews without publishing to npm.
+- Manual `NPM Snapshot Preview` workflow dispatches run the previous npm canary snapshot path, including standalone integration, only when the team wants to compare it against pkg.pr.new previews.
 - Pushes to `develop` continue publishing the moving npm `develop` snapshot channel.
 
 ## Problem
@@ -21,31 +21,43 @@ The old PR snapshot workflow published real npm canary packages for every truste
 
 ### 1. pkg.pr.new Preview Workflow
 
-`.github/workflows/package-previews.yml` runs on `pull_request` `labeled` events and only proceeds when the added label is `publish-pkg-preview`.
+`.github/workflows/package-previews.yml` runs on `workflow_dispatch` with a required `pr_number` input.
 
 The workflow:
 
-1. checks out the PR code,
-2. installs with Yarn 4 from the committed lockfile,
-3. runs the package build sequence used by snapshot publishing (`build:packages`, `generate`, `build:packages`),
-4. runs `yarn pkg-pr-new publish --comment=update --no-template --yarn --packageManager=yarn` once for all public package directories.
+1. resolves the PR and rejects fork branches,
+2. checks out the PR head SHA,
+3. installs with Yarn 4 from the committed lockfile,
+4. runs the package build sequence used by snapshot publishing (`build:packages`, `generate`, `build:packages`),
+5. runs `yarn pkg-pr-new publish --comment=update --no-template --yarn --packageManager=yarn` once for all public package directories.
 
 `pkg-pr-new` is kept in root `devDependencies` so CI executes the locked CLI instead of `npx`, `dlx`, or another moving installer command.
 
 ### 2. npm Snapshot Preview Workflow
 
-`.github/workflows/npm-snapshot-preview.yml` preserves the old PR canary snapshot behavior behind the `publish-npm-snapshot` label.
+`.github/workflows/npm-snapshot-preview.yml` preserves the old PR canary snapshot behavior behind explicit `workflow_dispatch` with a required `pr_number` input.
 
 The workflow:
 
-1. runs only for same-repository PR branches because it requires `NPM_TOKEN`,
-2. publishes lockstep npm canary snapshots via `scripts/release-snapshot.sh`,
-3. comments the exact npm snapshot versions on the PR,
-4. runs standalone app integration against the exact published snapshot.
+1. resolves the PR and rejects fork branches because it requires `NPM_TOKEN`,
+2. checks out the PR head SHA,
+3. publishes lockstep npm canary snapshots via `scripts/release-snapshot.sh`,
+4. comments the exact npm snapshot versions on the PR,
+5. runs standalone app integration against the exact published snapshot.
 
 This path is intentionally separate from pkg.pr.new so maintainers can test whether npm canaries are still needed.
 
-### 3. develop Snapshot Workflow
+### 3. Trigger Decision: Dispatch Only
+
+The preview workflows intentionally do not use PR labels or issue-comment slash-command routers.
+
+- Label triggers (`pull_request` `labeled`) create workflow runs for every added PR label, then rely on job-level `if` filters. On label-heavy automation this shows many skipped preview checks.
+- Issue-comment routers create workflow runs for every PR comment before the router can inspect comment text. Normal review discussion would therefore create repeated no-op router checks.
+- Manual `workflow_dispatch`, `gh workflow run`, and `om-auto-publish-pr` create a run only when a maintainer explicitly asks for a package preview.
+
+This trades slash-command convenience for a clean PR Checks surface.
+
+### 4. develop Snapshot Workflow
 
 `.github/workflows/snapshot.yml` remains the trusted `develop` branch snapshot workflow. It no longer listens to PR events.
 
@@ -55,21 +67,23 @@ Pushes to `develop` still:
 - keep exact snapshot versions installable,
 - run standalone integration against the exact published snapshot.
 
-## Labels
+## Manual Dispatch
 
-| Label | Effect |
+| Dispatch path | Effect |
 | --- | --- |
-| `publish-pkg-preview` | Publish pkg.pr.new package previews for the current PR commit. |
-| `publish-npm-snapshot` | Publish the old npm canary snapshot preview and run standalone integration. |
+| manual `Package Previews` dispatch with `pr_number` | Publish pkg.pr.new package previews for the selected PR head. |
+| `gh workflow run package-previews.yml --ref develop -f pr_number=<PR>` | Publish pkg.pr.new package previews for the selected PR head. |
+| `om-auto-publish-pr <PR>` | Publish pkg.pr.new package previews for the selected PR head via GitHub CLI. |
+| manual `NPM Snapshot Preview` dispatch with `pr_number` | Publish the old npm canary snapshot preview and run standalone integration for the selected PR head. |
 
-Both labels are action triggers, not persistent pipeline states. To publish a fresh preview for a newer commit, remove and re-add the label.
+Dispatches are action triggers, not persistent pipeline states. To publish a fresh preview for a newer commit, re-run the workflow or skill with the same PR number.
 
 ## Compatibility
 
 - Stable `latest` releases remain unchanged.
 - The npm `develop` channel remains unchanged for pushes to `develop`.
 - PR preview publishing becomes opt-in.
-- Fork PRs can request pkg.pr.new previews, but npm snapshot previews are restricted to same-repository PR branches.
+- Both PR preview workflows are restricted to same-repository PR branches. This avoids checking out fork code in workflows that are dispatched from trusted workflow contexts and can publish artifacts or comment on PRs.
 
 ## Integration Coverage
 
@@ -78,6 +92,7 @@ Affected operational paths:
 - `.github/workflows/package-previews.yml`
 - `.github/workflows/npm-snapshot-preview.yml`
 - `.github/workflows/snapshot.yml`
+- `.ai/skills/om-auto-publish-pr/SKILL.md`
 - `package.json`
 - `yarn.lock`
 
@@ -96,6 +111,13 @@ Validation:
 - No local npm publish or pkg.pr.new publish should run during implementation.
 
 ## Changelog
+
+### 2026-06-24
+
+- Replaced label-triggered preview workflows with manual `workflow_dispatch` to avoid duplicate skipped checks from unrelated label events.
+- Rejected slash-command routers because ordinary PR comments would still create no-op router workflow runs in checks.
+- Added the `om-auto-publish-pr` skill as the preferred CLI-backed convenience path for pkg.pr.new previews.
+- Restricted both preview workflows to same-repository PR branches under the dispatch model.
 
 ### 2026-06-22
 

--- a/.ai/specs/implemented/2026-03-21-open-mercato-develop-snapshot-release.md
+++ b/.ai/specs/implemented/2026-03-21-open-mercato-develop-snapshot-release.md
@@ -6,7 +6,7 @@
 **Author:** Open Mercato Team
 **Related:** [2026-03-20-official-modules-platform-sync-playbook.md](./2026-03-20-official-modules-platform-sync-playbook.md), `.github/workflows/snapshot.yml`, `.github/workflows/release.yml`, `scripts/release-snapshot.sh`, `scripts/publish-packages.sh`
 
-> 2026-06-22 update: PR package previews are now specified separately in [../2026-06-22-label-based-package-previews.md](../2026-06-22-label-based-package-previews.md). This develop snapshot contract remains responsible for trusted pushes to `develop`; PR npm canary snapshots moved behind the `publish-npm-snapshot` label.
+> 2026-06-24 update: PR package previews are now specified separately in [../2026-06-22-label-based-package-previews.md](../2026-06-22-label-based-package-previews.md). This develop snapshot contract remains responsible for trusted pushes to `develop`; PR npm canary snapshots moved behind explicit manual `NPM Snapshot Preview` dispatches.
 
 ## TLDR
 

--- a/.ai/specs/implemented/2026-04-10-ci-cd-performance.md
+++ b/.ai/specs/implemented/2026-04-10-ci-cd-performance.md
@@ -4,7 +4,7 @@
 **Status:** Draft  
 **Scope:** All GitHub Actions workflows, Turborepo configuration, Docker build pipeline, integration test architecture
 
-> 2026-06-22 update: PR package preview publishing changed after this analysis. Normal PRs no longer publish npm snapshots automatically; pkg.pr.new previews use `publish-pkg-preview`, and the previous npm snapshot preview path moved to `publish-npm-snapshot`.
+> 2026-06-24 update: PR package preview publishing changed after this analysis. Normal PRs no longer publish npm snapshots automatically; pkg.pr.new previews use manual `Package Previews` dispatches, GitHub CLI, or the `om-auto-publish-pr` skill, and the previous npm snapshot preview path moved to manual `NPM Snapshot Preview` dispatches.
 
 ---
 

--- a/.github/CI-INTEGRATION-PHASES.md
+++ b/.github/CI-INTEGRATION-PHASES.md
@@ -22,7 +22,7 @@ Tracking issue: [#2588](https://github.com/open-mercato/open-mercato/issues/2588
 | `extended` | Non-fork PR with `extended-integration` label | Baseline plus tagged expensive regression suites such as undo, CrudForm matrix, optimistic-lock matrix, custom fields, queue/realtime, long request tests |
 | `full` | Pushes to `develop`/`main`, shared fail-closed paths, every PR targeting `main` | All monorepo integration specs, sharded, with coverage |
 | `standalone-sentinel` | Trusted PRs touching standalone-impact paths | Minimal installed-package/create-app smoke coverage |
-| `standalone-full` | Develop snapshot/release pipeline, release PRs to `main`, and PRs explicitly labeled `publish-npm-snapshot` | Full standalone app integration coverage |
+| `standalone-full` | Develop snapshot/release pipeline, release PRs to `main`, and PRs explicitly dispatched with `NPM Snapshot Preview` | Full standalone app integration coverage |
 
 ## Maintainer Label
 
@@ -48,16 +48,16 @@ Fork PRs run safe baseline checks only.
 
 They must not run privileged npm snapshot publishing or trusted standalone flows. If a fork-originated change needs release/full standalone evidence, a maintainer should replay it from a trusted branch before merge.
 
-## Package Preview Labels
+## Package Preview Dispatch
 
 Package publication previews are opt-in:
 
-| Label | Workflow | Effect |
+| Dispatch path | Workflow | Effect |
 |---|---|---|
-| `publish-pkg-preview` | `package-previews.yml` | Publishes pkg.pr.new previews for all public packages without publishing to npm |
-| `publish-npm-snapshot` | `npm-snapshot-preview.yml` | Publishes the legacy npm canary snapshot and runs standalone-full validation |
+| Manual workflow dispatch, `gh workflow run`, or `om-auto-publish-pr` | `package-previews.yml` | Publishes pkg.pr.new previews for all public packages without publishing to npm |
+| Manual workflow dispatch | `npm-snapshot-preview.yml` | Publishes the legacy npm canary snapshot and runs standalone-full validation |
 
-Both workflows run when the label is added. Remove and re-add the label to produce a fresh preview for a newer commit. `publish-npm-snapshot` is restricted to trusted same-repository PR branches because it requires npm credentials.
+Both preview workflows require a PR number and are restricted to trusted same-repository PR branches because they publish artifacts and use write-capable workflow credentials. Label triggers and comment slash-command routers are intentionally avoided: GitHub Actions creates workflow runs for every matching label/comment event before job-level filtering can happen, which clutters PR checks with skipped or no-op entries.
 
 ## Standalone-Impact Paths
 

--- a/.github/workflows/npm-snapshot-preview.yml
+++ b/.github/workflows/npm-snapshot-preview.yml
@@ -4,8 +4,12 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 on:
-  pull_request:
-    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to publish an npm snapshot preview for"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -15,12 +19,52 @@ permissions:
 # Serialize npm snapshot preview runs per PR. Cancelling mid-publish can leave
 # the registry with only part of the lockstep package set published.
 concurrency:
-  group: npm-snapshot-preview-${{ github.event.pull_request.number }}
+  group: npm-snapshot-preview-${{ github.event.inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
+  resolve-pr:
+    name: Resolve PR
+    runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      head_repo: ${{ steps.pr.outputs.head_repo }}
+      same_repo: ${{ steps.pr.outputs.same_repo }}
+    steps:
+      - name: Resolve pull request
+        id: pr
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed('pr_number must be a positive integer');
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const expectedRepo = `${context.repo.owner}/${context.repo.repo}`;
+            const sameRepo = pr.head.repo.full_name === expectedRepo;
+
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_repo', pr.head.repo.full_name);
+            core.setOutput('same_repo', String(sameRepo));
+
+            if (!sameRepo) {
+              core.setFailed('NPM snapshot previews are restricted to same-repository PR branches.');
+            }
+
   snapshot:
     name: Publish NPM Snapshot Preview
+    needs: resolve-pr
+    if: needs.resolve-pr.outputs.same_repo == 'true'
     permissions:
       contents: read
       issues: write
@@ -31,8 +75,6 @@ jobs:
       publish_tag: ${{ steps.channel.outputs.publish_tag }}
       packages_json: ${{ steps.release.outputs.packages_json }}
     runs-on: ubuntu-latest
-    # Requires npm credentials, so only trusted same-repository PR branches can run it.
-    if: github.event.label.name == 'publish-npm-snapshot' && github.event.pull_request.head.repo.full_name == github.repository
     env:
       YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -40,6 +82,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          ref: ${{ needs.resolve-pr.outputs.head_sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -64,7 +107,7 @@ jobs:
         id: channel
         run: |
           CONFIG=$(node scripts/lib/snapshot-release.mjs config \
-            --event-name "${{ github.event_name }}" \
+            --event-name "pull_request" \
             --ref-name "${{ github.ref_name }}")
 
           echo "channel=$(echo "$CONFIG" | jq -r '.channel')" >> $GITHUB_OUTPUT
@@ -122,8 +165,11 @@ jobs:
       - name: Comment on PR
         if: steps.release.outputs.package_count != '0'
         uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
         with:
           script: |
+            const issueNumber = Number(process.env.PR_NUMBER);
             const packages = ${{ steps.release.outputs.packages_json }};
             const marker = '<!-- npm-snapshot-preview-comment -->';
 
@@ -152,7 +198,7 @@ jobs:
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
             });
 
             const existing = comments.find(c => c.body.includes(marker));
@@ -168,7 +214,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 body: body
               });
             }
@@ -176,7 +222,9 @@ jobs:
   standalone-integration:
     name: Standalone App Integration Tests
     runs-on: ubuntu-latest
-    needs: snapshot
+    needs:
+      - resolve-pr
+      - snapshot
     if: needs.snapshot.outputs.snapshot_version != ''
     services:
       postgres:
@@ -196,6 +244,8 @@ jobs:
     steps:
       - name: Checkout monorepo
         uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve-pr.outputs.head_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/package-previews.yml
+++ b/.github/workflows/package-previews.yml
@@ -1,8 +1,12 @@
 name: Package Previews
 
 on:
-  pull_request:
-    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to publish package previews for"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -10,13 +14,52 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: package-previews-${{ github.event.pull_request.number }}
+  group: package-previews-${{ github.event.inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
+  resolve-pr:
+    name: Resolve PR
+    runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      head_repo: ${{ steps.pr.outputs.head_repo }}
+      same_repo: ${{ steps.pr.outputs.same_repo }}
+    steps:
+      - name: Resolve pull request
+        id: pr
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed('pr_number must be a positive integer');
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const expectedRepo = `${context.repo.owner}/${context.repo.repo}`;
+            const sameRepo = pr.head.repo.full_name === expectedRepo;
+
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_repo', pr.head.repo.full_name);
+            core.setOutput('same_repo', String(sameRepo));
+
+            if (!sameRepo) {
+              core.setFailed('Package previews are restricted to same-repository PR branches.');
+            }
+
   publish-previews:
-    if: github.event.label.name == 'publish-pkg-preview'
     name: Publish Package Previews
+    needs: resolve-pr
+    if: needs.resolve-pr.outputs.same_repo == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -26,6 +69,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve-pr.outputs.head_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,9 @@ This ensures design decisions are documented and the codebase remains well-under
 
 ### Package Previews
 
-PRs do not publish npm canary packages automatically. Maintainers can add `publish-pkg-preview` to publish pkg.pr.new package previews for the current PR commit. If a fresh preview is needed after more commits, remove and re-add the label.
+PRs do not publish npm canary packages automatically. Maintainers can publish pkg.pr.new package previews for a PR by dispatching the `Package Previews` workflow manually with the PR number — run it from the Actions tab, with `gh workflow run package-previews.yml --ref develop -f pr_number=<PR>`, or via the `om-auto-publish-pr` skill. To publish a fresh preview after more commits, re-run the dispatch with the same PR number.
 
-The legacy npm canary snapshot path is still available for comparison by adding `publish-npm-snapshot` on a trusted same-repository PR branch. That workflow publishes real npm canary packages and runs standalone app integration against the exact snapshot, so use it only when pkg.pr.new previews are not enough evidence.
+The legacy npm canary snapshot path is still available for comparison by dispatching the `NPM Snapshot Preview` workflow manually with the PR number on a trusted same-repository PR branch. That workflow publishes real npm canary packages and runs standalone app integration against the exact snapshot, so use it only when pkg.pr.new previews are not enough evidence. Both preview workflows are restricted to same-repository PR branches.
 
 ## Helpful Resources
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Architecture in two lines: Vault/KMS (or a derived-key fallback) issues per-tena
 - `latest` is the stable npm channel published from `main`.
 - `develop` is the moving prerelease channel published from pushes to `develop`.
 - Exact snapshot versions remain installable for debugging or rollback when you need to pin one specific build.
-- PR package previews are opt-in. Add `publish-pkg-preview` to a PR to publish pkg.pr.new previews without publishing to npm. Add `publish-npm-snapshot` only when you need the legacy npm canary snapshot and standalone validation path.
+- PR package previews are opt-in. Run the `Package Previews` workflow manually with the PR number, or use the `om-auto-publish-pr` skill / `gh workflow run`, to publish pkg.pr.new previews without publishing to npm. Run `NPM Snapshot Preview` manually only when you need the legacy npm canary snapshot and standalone validation path.
 
 Examples:
 

--- a/scripts/__tests__/preview-workflows.test.mjs
+++ b/scripts/__tests__/preview-workflows.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const packagePreviewWorkflowPath = path.resolve('.github/workflows/package-previews.yml')
+const npmSnapshotPreviewWorkflowPath = path.resolve('.github/workflows/npm-snapshot-preview.yml')
+const autoPublishSkillPath = path.resolve('.ai/skills/om-auto-publish-pr/SKILL.md')
+const skillTiersPath = path.resolve('.ai/skills/tiers.json')
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+function countOccurrences(text, fragment) {
+  return text.split(fragment).length - 1
+}
+
+test('package previews are explicit same-repository workflow dispatches', () => {
+  const workflow = readText(packagePreviewWorkflowPath)
+
+  assert.match(workflow, /workflow_dispatch:/)
+  assert.match(workflow, /pr_number:/)
+  assert.doesNotMatch(workflow, /^\s+pull_request:/m)
+  assert.doesNotMatch(workflow, /github\.event\.label\.name/)
+  assert.doesNotMatch(workflow, /publish-pkg-preview/)
+
+  assert.match(workflow, /PR_NUMBER: \$\{\{ github\.event\.inputs\.pr_number \}\}/)
+  assert.match(workflow, /const prNumber = Number\(process\.env\.PR_NUMBER\);/)
+  assert.match(workflow, /pull_number: prNumber/)
+  assert.match(workflow, /pr\.head\.repo\.full_name === expectedRepo/)
+  assert.match(workflow, /Package previews are restricted to same-repository PR branches\./)
+  assert.match(workflow, /if: needs\.resolve-pr\.outputs\.same_repo == 'true'/)
+  assert.match(workflow, /ref: \$\{\{ needs\.resolve-pr\.outputs\.head_sha \}\}/)
+  assert.match(workflow, /yarn pkg-pr-new publish --comment=update --no-template --yarn --packageManager=yarn/)
+})
+
+test('npm snapshot previews preserve PR canary behavior behind manual dispatch', () => {
+  const workflow = readText(npmSnapshotPreviewWorkflowPath)
+
+  assert.match(workflow, /workflow_dispatch:/)
+  assert.match(workflow, /pr_number:/)
+  assert.doesNotMatch(workflow, /^\s+pull_request:/m)
+  assert.doesNotMatch(workflow, /github\.event\.label\.name/)
+  assert.doesNotMatch(workflow, /publish-npm-snapshot/)
+
+  assert.match(workflow, /PR_NUMBER: \$\{\{ github\.event\.inputs\.pr_number \}\}/)
+  assert.match(workflow, /const prNumber = Number\(process\.env\.PR_NUMBER\);/)
+  assert.match(workflow, /pull_number: prNumber/)
+  assert.match(workflow, /pr\.head\.repo\.full_name === expectedRepo/)
+  assert.match(workflow, /NPM snapshot previews are restricted to same-repository PR branches\./)
+  assert.match(workflow, /--event-name "pull_request"/)
+  assert.equal(countOccurrences(workflow, 'ref: ${{ needs.resolve-pr.outputs.head_sha }}'), 2)
+  assert.match(workflow, /const issueNumber = Number\(process\.env\.PR_NUMBER\);/)
+  assert.doesNotMatch(workflow, /issue_number: context\.issue\.number/)
+})
+
+test('auto publish skill only dispatches pkg.pr.new previews and is tiered as automation', () => {
+  const skill = readText(autoPublishSkillPath)
+  const tiers = JSON.parse(readText(skillTiersPath))
+
+  assert.match(skill, /^name: om-auto-publish-pr$/m)
+  assert.match(skill, /gh workflow run package-previews\.yml/)
+  assert.match(skill, /-f "pr_number=\$PR_NUMBER"/)
+  assert.doesNotMatch(skill, /gh workflow run npm-snapshot-preview\.yml/)
+  assert.doesNotMatch(skill, /workflow run .*npm-snapshot/i)
+
+  assert.ok(
+    tiers.tiers.automation.skills.includes('om-auto-publish-pr'),
+    'om-auto-publish-pr should be installable through the automation tier',
+  )
+})


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Avoid duplicate skipped preview checks by moving PR package-preview workflows from label-triggered runs to explicit manual/CLI dispatch.

## Changes

- Convert `Package Previews` and `NPM Snapshot Preview` to `workflow_dispatch` with `pr_number`.
- Resolve and reject fork PR branches before checking out the PR head SHA.
- Add `om-auto-publish-pr` to dispatch pkg.pr.new previews via `gh workflow run`.
- Update README, CI docs, and specs with the dispatch-only decision and label/comment noise rationale.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
.ai/specs/2026-06-22-label-based-package-previews.md

## Testing

- `node -e "const fs=require('fs'); const YAML=require('yaml'); for (const f of ['.github/workflows/package-previews.yml','.github/workflows/npm-snapshot-preview.yml']) { YAML.parse(fs.readFileSync(f,'utf8')); console.log('parsed', f); }"`
- `node` frontmatter check for `.ai/skills/om-auto-publish-pr/SKILL.md`
- `bash scripts/validate-skills-tiers.sh`
- `git diff --check`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

None.