### PR TITLE
fix(agent-orchestrator): persist runtime/model/external_run_id on agent runs

### DIFF
--- a/packages/core/src/modules/agent_orchestrator/__tests__/opencode-runner.test.ts
+++ b/packages/core/src/modules/agent_orchestrator/__tests__/opencode-runner.test.ts
@@ -252,6 +252,32 @@ describe('OpenCodeAgentRunner (integration, fake client)', () => {
     expect(deleteSessionApiKeyMock).toHaveBeenCalledTimes(1)
   })
 
+  it('stamps runtime + model on runs.create and the OpenCode session id as externalRunId on runs.complete', async () => {
+    const entry = registerExampleFileAgent()
+    const { calls, commandBus, container } = makeHarness()
+    const sessionTokenRef = { value: '' }
+    const agentSentRef = { value: undefined as string | undefined }
+    const client = makeFakeClient({ outcome: validOutcome, sessionTokenRef, agentSentRef, container })
+
+    const runner = new OpenCodeAgentRunner({
+      container: container as never,
+      commandBus: commandBus as never,
+      openCodeClient: client,
+    })
+
+    await runner.run(entry, { dealId: 'deal-1' }, runCtx)
+
+    // runs.create carries the declared runtime + model so the cockpit can show
+    // and filter runs by runtime/model (the columns were previously always null).
+    const createCall = calls.find((c) => c.id === 'agent_orchestrator.runs.create')!
+    expect(createCall.input.runtime).toBe('opencode')
+    expect(createCall.input.model).toBe('claude-sonnet-4-6')
+
+    // runs.complete carries the OpenCode session id as the external correlation id.
+    const completeCall = calls.find((c) => c.id === 'agent_orchestrator.runs.complete')!
+    expect(completeCall.input.externalRunId).toBe('ses_fake_1')
+  })
+
   it('fails the run when the agent never submits an outcome (idle without outcome, after the corrective nudge)', async () => {
     const entry = registerExampleFileAgent()
     const { calls, commandBus, container } = makeHarness()

--- a/packages/core/src/modules/agent_orchestrator/commands/runs.ts
+++ b/packages/core/src/modules/agent_orchestrator/commands/runs.ts
@@ -12,6 +12,10 @@ const createAgentRunSchema = z.object({
   input: z.unknown(),
   /** Parent run id for a nested sub-agent run (Phase 4); null/absent for top-level runs. */
   parentRunId: z.string().uuid().nullable().optional(),
+  /** Declared agent runtime (`in-process` | `opencode`); stamped so the cockpit can show/filter runs by runtime. */
+  runtime: z.string().max(50).nullable().optional(),
+  /** Declared model id; null when the agent uses the tenant default. */
+  model: z.string().max(100).nullable().optional(),
 })
 export type CreateAgentRunInput = z.infer<typeof createAgentRunSchema>
 
@@ -20,6 +24,8 @@ const completeAgentRunSchema = z.object({
   status: z.enum(['ok', 'error']),
   output: z.unknown().optional(),
   resultKind: z.enum(['informative', 'actionable']).nullable().optional(),
+  /** External runtime correlation id (e.g. the OpenCode session id); only set when provided. */
+  externalRunId: z.string().max(255).nullable().optional(),
 })
 export type CompleteAgentRunInput = z.infer<typeof completeAgentRunSchema>
 
@@ -41,6 +47,8 @@ const createAgentRunCommand: CommandHandler<CreateAgentRunInput, { runId: string
       status: 'running' as AgentRunStatus,
       input: input.input,
       parentRunId: input.parentRunId ?? null,
+      runtime: input.runtime ?? null,
+      model: input.model ?? null,
     })
     em.persist(run)
     await em.flush()
@@ -66,6 +74,7 @@ const completeAgentRunCommand: CommandHandler<CompleteAgentRunInput, { runId: st
     run.status = input.status
     run.output = input.output ?? null
     run.resultKind = input.resultKind ?? null
+    if (input.externalRunId !== undefined) run.externalRunId = input.externalRunId
     run.updatedAt = new Date()
     await em.flush()
 

--- a/packages/core/src/modules/agent_orchestrator/lib/runtime/agentRuntime.ts
+++ b/packages/core/src/modules/agent_orchestrator/lib/runtime/agentRuntime.ts
@@ -95,6 +95,8 @@ export class AgentRuntimeService {
       agentId,
       input,
       parentRunId: ctx.parentRunId ?? null,
+      runtime: entry.runtime,
+      model: entry.defaultModel ?? null,
     })
 
     // Load the caller's effective ACL so the agent's read-only tools (e.g.

--- a/packages/core/src/modules/agent_orchestrator/lib/runtime/openCodeAgentRunner.ts
+++ b/packages/core/src/modules/agent_orchestrator/lib/runtime/openCodeAgentRunner.ts
@@ -117,6 +117,8 @@ export class OpenCodeAgentRunner {
       agentId,
       input,
       parentRunId: ctx.parentRunId ?? null,
+      runtime: entry.runtime,
+      model: entry.defaultModel ?? null,
     })
 
     // Mint a fresh per-run session token scoped to the caller (their roles,
@@ -186,6 +188,7 @@ export class OpenCodeAgentRunner {
         runId,
         output: result,
         resultKind: entry.resultKind,
+        externalRunId: session.id,
       })
 
       if (result.kind === 'actionable') {

--- a/packages/core/src/modules/agent_orchestrator/lib/runtime/persistence.ts
+++ b/packages/core/src/modules/agent_orchestrator/lib/runtime/persistence.ts
@@ -74,6 +74,10 @@ export async function createRun(
     input: unknown
     /** Nested sub-agent run trace (Phase 4); omit/null for top-level runs. */
     parentRunId?: string | null
+    /** Declared runtime of the agent (`in-process` | `opencode`); stamped on the run for the cockpit. */
+    runtime?: string | null
+    /** Declared model id (e.g. `anthropic/claude-sonnet-4-5`); null when the agent uses the tenant default. */
+    model?: string | null
   },
 ): Promise<string> {
   const { result } = await commandBus.execute<typeof input, { runId: string }>(
@@ -86,13 +90,31 @@ export async function createRun(
 export async function completeRun(
   commandBus: CommandBus,
   commandCtx: CommandRuntimeContext,
-  input: { runId: string; output: AgentResult; resultKind: 'informative' | 'actionable' },
+  input: {
+    runId: string
+    output: AgentResult
+    resultKind: 'informative' | 'actionable'
+    /** External runtime correlation id (e.g. the OpenCode session id); null for in-process runs. */
+    externalRunId?: string | null
+  },
 ): Promise<void> {
   await commandBus.execute<
-    { runId: string; status: 'ok'; output: AgentResult; resultKind: 'informative' | 'actionable' },
+    {
+      runId: string
+      status: 'ok'
+      output: AgentResult
+      resultKind: 'informative' | 'actionable'
+      externalRunId?: string | null
+    },
     { runId: string }
   >('agent_orchestrator.runs.complete', {
-    input: { runId: input.runId, status: 'ok', output: input.output, resultKind: input.resultKind },
+    input: {
+      runId: input.runId,
+      status: 'ok',
+      output: input.output,
+      resultKind: input.resultKind,
+      externalRunId: input.externalRunId ?? null,
+    },
     ctx: commandCtx,
   })
 }


### PR DESCRIPTION
## What
Populate `agent_runs.runtime`, `agent_runs.model`, and `agent_runs.external_run_id`, which were always `NULL`.

## Why
`AgentRun` declares these columns (and a `UNIQUE(runtime, external_run_id)` index), and the runs list API exposes `runtime`/`model` — but `createRun`/`completeRun` never set them. Result: the Runs cockpit/API can't show or filter by runtime/model, and the external-run dedup constraint is inert.

Surfaced while testing the **OpenCode file-defined runtime** end-to-end: every `agent_runs` row had `runtime = NULL`, even for `*_file` (OpenCode) agents. The "Open Code" badge in the agents registry is derived separately, so the gap was invisible there but real on the run rows.

## How
- `commands/runs.ts`: `runs.create` accepts + persists `runtime` and `model`; `runs.complete` accepts + persists `external_run_id` (optional, set only when provided).
- `lib/runtime/persistence.ts`: thread the new fields through `createRun` / `completeRun`.
- in-process + OpenCode runners stamp `runtime = entry.runtime` and `model = entry.defaultModel`; the OpenCode runner additionally sets `external_run_id = session.id`.

No migration — the columns already exist. The new command fields are optional and additive (backward-compatible); the in-process `(runtime, NULL)` rows are fine under the unique index (Postgres treats NULLs as distinct).

## Test
`__tests__/opencode-runner.test.ts` — new case asserts `runs.create` carries `runtime` + `model` and `runs.complete` carries the OpenCode session id as `externalRunId`.

```
yarn jest opencode-runner   → Test Suites: 1 passed, Tests: 5 passed
yarn typecheck --filter=@open-mercato/core → 1 successful
```

## Scope / notes
- Severity: low — observability/cockpit only; no impact on correctness, security, or the propose-only contract.
- Known follow-ups (out of scope): the in-process path records the *declared* model (`entry.defaultModel`), not the tenant-resolved model; and OpenCode sub-agent runs are still not recorded as nested `AgentRun`s with `parent_run_id` (pre-existing, documented in the module README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
