### PR TITLE
fix(agent_orchestrator): stamp model on agent runs (follow-up to F8)

### DIFF
--- a/packages/enterprise/src/modules/agent_orchestrator/__tests__/opencode-runner.test.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/__tests__/opencode-runner.test.ts
@@ -252,6 +252,29 @@ describe('OpenCodeAgentRunner (integration, fake client)', () => {
     expect(deleteSessionApiKeyMock).toHaveBeenCalledTimes(1)
   })
 
+  it('stamps the declared model (alongside runtime) on runs.create so the cockpit can show/filter runs by model', async () => {
+    const entry = registerExampleFileAgent()
+    const { calls, commandBus, container } = makeHarness()
+    const sessionTokenRef = { value: '' }
+    const agentSentRef = { value: undefined as string | undefined }
+    const client = makeFakeClient({ outcome: validOutcome, sessionTokenRef, agentSentRef, container })
+
+    const runner = new OpenCodeAgentRunner({
+      container: container as never,
+      commandBus: commandBus as never,
+      openCodeClient: client,
+    })
+
+    await runner.run(entry, { dealId: 'deal-1' }, runCtx)
+
+    const createCall = calls.find((c) => c.id === 'agent_orchestrator.runs.create')!
+    // model comes from the registry entry's declared defaultModel (was always null before).
+    expect(createCall.input.model).toBe('claude-sonnet-4-6')
+    // runtime + externalRunId remain stamped (F8) — model is additive alongside them.
+    expect(createCall.input.runtime).toBe('opencode')
+    expect(createCall.input.externalRunId).toBe('ses_fake_1')
+  })
+
   it('fails the run when the agent never submits an outcome (idle without outcome, after the corrective nudge)', async () => {
     const entry = registerExampleFileAgent()
     const { calls, commandBus, container } = makeHarness()

--- a/packages/enterprise/src/modules/agent_orchestrator/commands/runs.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/commands/runs.ts
@@ -21,6 +21,8 @@ const createAgentRunSchema = z.object({
   runtime: z.string().min(1).nullable().optional(),
   /** Runtime-native run id; the other half of the ingestion idempotency key. */
   externalRunId: z.string().min(1).nullable().optional(),
+  /** Declared model id; stamped so the cockpit can show/filter runs by model. Null when the agent uses the tenant default. */
+  model: z.string().min(1).max(100).nullable().optional(),
 })
 export type CreateAgentRunInput = z.infer<typeof createAgentRunSchema>
 
@@ -52,6 +54,7 @@ const createAgentRunCommand: CommandHandler<CreateAgentRunInput, { runId: string
       parentRunId: input.parentRunId ?? null,
       runtime: input.runtime ?? null,
       externalRunId: input.externalRunId ?? null,
+      model: input.model ?? null,
     })
     em.persist(run)
     await em.flush()

--- a/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/agentRuntime.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/agentRuntime.ts
@@ -126,6 +126,7 @@ export class AgentRuntimeService {
       // stamped. The `(runtime, externalRunId)` unique index allows multiple
       // nulls, so leaving externalRunId null is correct here.
       runtime: 'in-process',
+      model: entry.defaultModel ?? null,
     })
 
     // Load the caller's effective ACL so the agent's read-only tools (e.g.

--- a/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/openCodeAgentRunner.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/openCodeAgentRunner.ts
@@ -125,6 +125,7 @@ export class OpenCodeAgentRunner {
       parentRunId: ctx.parentRunId ?? null,
       runtime: 'opencode',
       externalRunId: session.id,
+      model: entry.defaultModel ?? null,
     })
 
     // Mint a fresh per-run session token scoped to the caller (their roles,

--- a/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/persistence.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/persistence.ts
@@ -82,6 +82,8 @@ export async function createRun(
      */
     runtime?: string | null
     externalRunId?: string | null
+    /** Declared model id (e.g. `anthropic/claude-sonnet-4-5`); null when the agent uses the tenant default. */
+    model?: string | null
   },
 ): Promise<string> {
   const { result } = await commandBus.execute<typeof input, { runId: string }>(


### PR DESCRIPTION
## What
Stamp `agent_runs.model` on runner-created runs. Follow-up to **F8 (`3cc45a872`)**, which stamped `runtime` + `external_run_id` but left `model` NULL.

## Why
After F8 the Runs cockpit/API can show/filter by runtime, but `model` is still always NULL, so the per-run model is invisible. Surfaced while exercising the OpenCode file-defined runtime end-to-end (runs persisted with `model = NULL` even though the agent declares one).

## How
- `commands/runs.ts`: `runs.create` accepts + persists `model`.
- `lib/runtime/persistence.ts`: thread `model` through `createRun`.
- both runners pass the declared model (`entry.defaultModel`): OpenCode from the agent-file frontmatter, in-process from the agent's declared default (null when it relies on the tenant default).

No migration — the `model` column already exists. The new command field is optional/additive. Branched off the current branch tip (0 commits behind).

## Test
`__tests__/opencode-runner.test.ts` — new case asserts `runs.create` carries `model` (alongside F8's `runtime` / `externalRunId`).

```
yarn jest opencode-runner                       → Test Suites: 1 passed, Tests: 5 passed
yarn typecheck --filter=@open-mercato/enterprise → 1 successful
```

## Note
The in-process path records the *declared* model (`entry.defaultModel`), not the tenant-resolved model — fine for cockpit display; capturing the resolved model would need plumbing from the AI runtime and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
